### PR TITLE
fix reorg issues

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -13,7 +13,7 @@
     "tests": "truffle test"
   },
   "scripts": {
-    "test": "mocha --recursive"
+    "test": "mocha --recursive tests"
   },
   "repository": {
     "type": "git",

--- a/core/tests/utils/test_bitfield.js
+++ b/core/tests/utils/test_bitfield.js
@@ -5,7 +5,7 @@ const {
 	getEmptyBitfield,
 	hasVoted,
 	setVoted,
-} = require('../../lodestar_chain/utils/bitfield');
+} = require('../../../core/utils/bitfield');
 
 const attestBitfield = [
 	[0, 0],


### PR DESCRIPTION
- specify the new name `tests/` for mocha (by default it is looking for `test/` 
- fix path for bitfield in bitfield test (previously looking for old directory `lodestar_chain`