### PR TITLE
Update data structures and constants from latest beacon chain spec

### DIFF
--- a/beaconChain/constants/constants.ts
+++ b/beaconChain/constants/constants.ts
@@ -2,21 +2,46 @@
 // TODO Update TBD
 // TODO Explain what each constant does
 
-export default {
-  BASE_REWARD_QUOTIENT: 32768,
-  CYCLE_LENGTH: 64,
-  DEPOSIT_SIZE: 32,
-  GENESIS_TIME: "TBD",
-  GWEI_PER_ETH: 1000000000,
-  INITIAL_FORK_VERSION: 0,
-  LOGOUT_MESSAGE: "LOGOUT",
-  MAX_VALIDATOR_CHURN_QUOTIENT: 32,
-  MIN_COMMITTEE_SIZE: 128,
-  MIN_ONLINE_DEPOSIT_SIZE: 16,
-  MIN_VALIDATOR_SET_CHANGE_INTERVAL: 256,
-  RANDAO_SLOTS_PER_LAYER: 4096,
-  SHARD_COUNT: 1024,
-  SLOT_DURATION: 16,
-  SQRT_E_DROP_TIME: 65536,
-  WITHDRAWAL_PERIOD: 524288,
-};
+  // Misc
+export const SHARD_COUNT = 2**10; // 1024 shards
+export const TARGET_COMMITTEE_SIZE = 2**8; // 256 validators
+export const MIN_BALANCE = 2**4; // 16 ETH
+export const MAX_BALANCE_CHURN_QUOTIENT = 2**5; // 32
+export const GWEI_PER_ETH = 10**9; // 1B Gwei/ETH
+export const BEACON_CHAIN_SHARD_NUMBER = 2**64 - 1;
+export const BLS_WITHDRAWAL_PREFIX_BYTE = 0x0;
+export const MAX_CASPER_VOTES = 2**10; // 1024 votes
+
+// Deposit contract
+export const DEPOSIT_CONTRACT_ADDRESS = 'TBD';
+export const DEPOSIT_CONTRACT_TREE_DEPTH = 2**5; // 32
+export const MIN_DEPOSIT = 2**0; // 1 ETH
+export const MAX_DEPOSIT = 2**5; // 32 ETH
+
+// Initial values
+export const INITIAL_FORK_VERSION = 0;
+export const INITIAL_SLOT_NUMBER = 0;
+export const ZERO_HASH = new ArrayBuffer(32);
+
+// Time parameters
+export const SLOT_DURATION = 6; // 6 seconds
+export const MIN_ATTESTATION_INCLUSION_DELAY = 2**2; // 4 slots
+export const EPOCH_LENGTH = 2**6; // 64 slots
+export const MIN_VALIDATOR_REGISTRY_CHANGE_INTERVAL = 2**8; // 256 slots
+export const POW_RECEIPT_ROOT_VOTING_PERIOD = 2**10; // 1024 slots
+export const SHARD_PERSISTENT_COMMITTEE_CHANGE_POERIOD = 2**17; // 131,072 slots
+export const COLLECTIVE_PENALTY_CALCULATION_PERIOD = 2**20; // 1,048,576 slots
+export const ZERO_BALANCE_VALIDATOR_TTL = 2**22; // 4,194,304 slots
+
+// Reward and penalty quotients
+export const BASE_REWARD_QUOTIENT = 2**11; // 2048
+export const WHISTLEBLOWER_REWARD_QUOTIENT = 2**9; // 512
+export const INCLUDER_REWARD_QUOTIENT = 2**3; // 8
+export const INACTIVITY_PENALTY_QUOTIENT = 2**34; // 17,179,869,184
+
+// Max operations per block
+export const MAX_PROPOSER_SLASHINGS = 2**4; // 16
+export const MAX_CASPER_SLASHINGS = 2**4; // 16
+export const MAX_ATTESTATIONS = 2**7; // 128
+export const MAX_DEPOSITS = 2**4; // 16
+export const MAX_EXITS = 2**4; // 16

--- a/beaconChain/constants/constants.ts
+++ b/beaconChain/constants/constants.ts
@@ -9,7 +9,7 @@ export const MIN_BALANCE = 2 ** 4; // 16 ETH
 export const MAX_BALANCE_CHURN_QUOTIENT = 2 ** 5; // 32
 export const GWEI_PER_ETH = 10 ** 9; // 1B Gwei/ETH
 export const BEACON_CHAIN_SHARD_NUMBER = 2 ** 64 - 1;
-export const BLS_WITHDRAWAL_PREFIX_BYTE = 0x0;
+export const BLS_WITHDRAWAL_PREFIX_BYTE = 0x00;
 export const MAX_CASPER_VOTES = 2 ** 10; // 1024 votes
 
 // Deposit contract

--- a/beaconChain/constants/constants.ts
+++ b/beaconChain/constants/constants.ts
@@ -3,20 +3,20 @@
 // TODO Explain what each constant does
 
   // Misc
-export const SHARD_COUNT = 2**10; // 1024 shards
-export const TARGET_COMMITTEE_SIZE = 2**8; // 256 validators
-export const MIN_BALANCE = 2**4; // 16 ETH
-export const MAX_BALANCE_CHURN_QUOTIENT = 2**5; // 32
-export const GWEI_PER_ETH = 10**9; // 1B Gwei/ETH
-export const BEACON_CHAIN_SHARD_NUMBER = 2**64 - 1;
+export const SHARD_COUNT = 2 ** 10; // 1024 shards
+export const TARGET_COMMITTEE_SIZE = 2 ** 8; // 256 validators
+export const MIN_BALANCE = 2 ** 4; // 16 ETH
+export const MAX_BALANCE_CHURN_QUOTIENT = 2 ** 5; // 32
+export const GWEI_PER_ETH = 10 ** 9; // 1B Gwei/ETH
+export const BEACON_CHAIN_SHARD_NUMBER = 2 ** 64 - 1;
 export const BLS_WITHDRAWAL_PREFIX_BYTE = 0x0;
-export const MAX_CASPER_VOTES = 2**10; // 1024 votes
+export const MAX_CASPER_VOTES = 2 ** 10; // 1024 votes
 
 // Deposit contract
-export const DEPOSIT_CONTRACT_ADDRESS = 'TBD';
-export const DEPOSIT_CONTRACT_TREE_DEPTH = 2**5; // 32
-export const MIN_DEPOSIT = 2**0; // 1 ETH
-export const MAX_DEPOSIT = 2**5; // 32 ETH
+export const DEPOSIT_CONTRACT_ADDRESS = "TBD";
+export const DEPOSIT_CONTRACT_TREE_DEPTH = 2 ** 5; // 32
+export const MIN_DEPOSIT = 2 ** 0; // 1 ETH
+export const MAX_DEPOSIT = 2 ** 5; // 32 ETH
 
 // Initial values
 export const INITIAL_FORK_VERSION = 0;
@@ -25,23 +25,23 @@ export const ZERO_HASH = new ArrayBuffer(32);
 
 // Time parameters
 export const SLOT_DURATION = 6; // 6 seconds
-export const MIN_ATTESTATION_INCLUSION_DELAY = 2**2; // 4 slots
-export const EPOCH_LENGTH = 2**6; // 64 slots
-export const MIN_VALIDATOR_REGISTRY_CHANGE_INTERVAL = 2**8; // 256 slots
-export const POW_RECEIPT_ROOT_VOTING_PERIOD = 2**10; // 1024 slots
-export const SHARD_PERSISTENT_COMMITTEE_CHANGE_POERIOD = 2**17; // 131,072 slots
-export const COLLECTIVE_PENALTY_CALCULATION_PERIOD = 2**20; // 1,048,576 slots
-export const ZERO_BALANCE_VALIDATOR_TTL = 2**22; // 4,194,304 slots
+export const MIN_ATTESTATION_INCLUSION_DELAY = 2 ** 2; // 4 slots
+export const EPOCH_LENGTH = 2 ** 6; // 64 slots
+export const MIN_VALIDATOR_REGISTRY_CHANGE_INTERVAL = 2 ** 8; // 256 slots
+export const POW_RECEIPT_ROOT_VOTING_PERIOD = 2 ** 10; // 1024 slots
+export const SHARD_PERSISTENT_COMMITTEE_CHANGE_POERIOD = 2 ** 17; // 131,072 slots
+export const COLLECTIVE_PENALTY_CALCULATION_PERIOD = 2 ** 20; // 1,048,576 slots
+export const ZERO_BALANCE_VALIDATOR_TTL = 2 ** 22; // 4,194,304 slots
 
 // Reward and penalty quotients
-export const BASE_REWARD_QUOTIENT = 2**11; // 2048
-export const WHISTLEBLOWER_REWARD_QUOTIENT = 2**9; // 512
-export const INCLUDER_REWARD_QUOTIENT = 2**3; // 8
-export const INACTIVITY_PENALTY_QUOTIENT = 2**34; // 17,179,869,184
+export const BASE_REWARD_QUOTIENT = 2 ** 11; // 2048
+export const WHISTLEBLOWER_REWARD_QUOTIENT = 2 ** 9; // 512
+export const INCLUDER_REWARD_QUOTIENT = 2 ** 3; // 8
+export const INACTIVITY_PENALTY_QUOTIENT = 2 ** 34; // 17,179,869,184
 
 // Max operations per block
-export const MAX_PROPOSER_SLASHINGS = 2**4; // 16
-export const MAX_CASPER_SLASHINGS = 2**4; // 16
-export const MAX_ATTESTATIONS = 2**7; // 128
-export const MAX_DEPOSITS = 2**4; // 16
-export const MAX_EXITS = 2**4; // 16
+export const MAX_PROPOSER_SLASHINGS = 2 ** 4; // 16
+export const MAX_CASPER_SLASHINGS = 2 ** 4; // 16
+export const MAX_ATTESTATIONS = 2 ** 7; // 128
+export const MAX_DEPOSITS = 2 ** 4; // 16
+export const MAX_EXITS = 2 ** 4; // 16

--- a/beaconChain/constants/enums.ts
+++ b/beaconChain/constants/enums.ts
@@ -3,34 +3,25 @@
 enum ValidatorStatusCodes {
   PENDING_ACTIVATION = 0,
   ACTIVE = 1,
-  PENDING_EXIT = 2,
-  PENDING_WITHDRAW = 3,
-  WITHDRAWN = 4,
-  PENALIZED = 127,
+  ACTIVE_PENDING_EXIT = 2,
+  EXITED_WITHOUT_PENALTY = 3,
+  EXITED_WITH_PENALTY = 4,
 }
 
-enum SpecialRecordTypes {
-  LOGOUT = 0,
-  CASPER_SLASHING = 1,
-  PROPOSER_SLASHING = 2,
-  DEPOSIT_PROOF = 3,
-}
-
-enum ValidatorSetDeltaFlags {
-  ENTRY = 0,
+enum ValidatorRegistryDeltaFlags {
+  ACTIVATION = 0,
   EXIT = 1,
 }
 
-enum BLSDomains {
+enum SignatureDomains {
   DOMAIN_DEPOSIT = 0,
   DOMAIN_ATTESTATION = 1,
   DOMAIN_PROPOSAL = 2,
-  DOMAIN_LOGOUT = 3,
+  DOMAIN_EXIT = 3,
 }
 
 export {
-  BLSDomains,
-  SpecialRecordTypes,
-  ValidatorSetDeltaFlags,
+  SignatureDomains,
+  ValidatorRegistryDeltaFlags,
   ValidatorStatusCodes,
 };

--- a/beaconChain/helpers/stateTransitionHelpers.ts
+++ b/beaconChain/helpers/stateTransitionHelpers.ts
@@ -1,8 +1,8 @@
 // Helper functions related to state transition functions
-import constants from "../constants/constants";
+import {EPOCH_LENGTH, MAX_DEPOSIT} from "../constants/constants";
 import { ValidatorStatusCodes } from "../constants/enums";
-import {AttestationSignedData, BeaconBlock} from "../interfaces/blocks";
-import {BeaconState, ShardAndCommittee, ValidatorRecord} from "../interfaces/state";
+import {AttestationData, BeaconBlock} from "../interfaces/blocks";
+import {BeaconState, ShardCommittee, ValidatorRecord} from "../interfaces/state";
 
 type int = number;
 type bytes = number;
@@ -97,28 +97,23 @@ export function clamp(minval: int, maxval: int, x: int): int {
  * @param {int} slot
  * @returns {ShardAndCommittee[] | Error}
  */
-function getShardsAndCommitteesForSlot(state: BeaconState, slot: int): ShardAndCommittee[] {
-  const earliestSlotInArray: int = state.lastStateRecalculationSlot - constants.CYCLE_LENGTH;
-  // TODO Figure out why this is an error
-  // TODO fix error with `<`
-  // if (earliestSlotInArray <= slot < earliestSlotInArray + constants.CYCLE_LENGTH * 2) throw new Error();
-  return state.shardAndCommitteeForSlots[slot - earliestSlotInArray];
+function getShardCommitteesAtSlot(state: BeaconState, slot: int): ShardCommittee[] {
+  const earliestSlotInArray: int = state.slot - (state.slot % EPOCH_LENGTH) - EPOCH_LENGTH;
+  if (earliestSlotInArray <= slot && slot < earliestSlotInArray + EPOCH_LENGTH * 2) throw new Error();
+  return state.shardCommitteesAtSlots[slot - earliestSlotInArray];
 }
 
 /**
  * Retrieves hash for a given beacon block.
  * It should always return the block hash in the beacon chain slot for `slot`.
  * @param {BeaconState} state
- * @param {BeaconBlock} currentBlock
  * @param {int} slot
  * @returns {hash32}
  */
-function getBlockHash(state: BeaconState, currentBlock: BeaconBlock, slot: int): hash32 {
-  const earliestSlotInArray = currentBlock.slot - state.recentBlockHashes.length;
-  // TODO Figure out why this is an error
-  // TODO fix error with `<`
-// if (earliestSlotInArray <= slot < currentBlock.slot) throw new Error();
-  return state.recentBlockHashes[slot - earliestSlotInArray];
+function getBlockHash(state: BeaconState, slot: int): hash32 {
+  const earliestSlotInArray = state.slot - state.latestBlockHashes.length;
+  if (earliestSlotInArray <= slot && slot < state.slot) throw new Error();
+  return state.latestBlockHashes[slot - earliestSlotInArray];
 }
 
 /**
@@ -128,15 +123,15 @@ function getBlockHash(state: BeaconState, currentBlock: BeaconBlock, slot: int):
  * @returns {int}
  */
 function getBeaconProposerIndex(state: BeaconState, slot: int): int {
-  const firstCommittee = getShardsAndCommitteesForSlot(state, slot)[0].committee;
+  const firstCommittee = getShardCommitteesAtSlot(state, slot)[0].committee;
   return firstCommittee[slot % firstCommittee.length];
 }
 
 // TODO finish
-function getAttestationParticipants(state: BeaconState, attestationData: AttestationSignedData, participationBitfield: bytes): int[] {
-  const sncsForSlot: ShardAndCommittee[] = getShardsAndCommitteesForSlot(state, attestationData.slot);
-  const snc: ShardAndCommittee = sncsForSlot.filter((x: ShardAndCommittee) => {
-    if (x.shard === attestationData.shard) { return x; }
+function getAttestationParticipants(state: BeaconState, attestationData: AttestationData, participationBitfield: bytes): int[] {
+  const shardCommittees: ShardCommittee[] = getShardCommitteesAtSlot(state, attestationData.slot);
+  const shardCommittee: ShardCommittee = shardCommittees.filter((x: ShardCommittee) => {
+    return x.shard === attestationData.shard;
   })[0];
 
   // TODO Figure out why this is an error
@@ -144,11 +139,9 @@ function getAttestationParticipants(state: BeaconState, attestationData: Attesta
   // TODO what is ceil_div8()
   // assert len(participation_bitfield) == ceil_div8(len(snc.committee))
 
-  const participants: int[] = snc.committee.filter((validator: uint24, index: int) => {
+  const participants: int[] = shardCommittee.committee.filter((validator: uint24, index: int) => {
     const bit: int = (participationBitfield[Math.floor(index / 8)] >> (7 - (index % 8))) % 2;
-    if (bit === 1) {
-      return index;
-    }
+    return bit === 1;
   });
   return participants;
 }
@@ -161,7 +154,7 @@ function getAttestationParticipants(state: BeaconState, attestationData: Attesta
  */
 // TODO Math.min requires int, validator.record is a uint64
 function getEffectiveBalance(validator: ValidatorRecord): int {
-  return Math.min(validator.balance, constants.DEPOSIT_SIZE);
+  return Math.min(validator.balance, MAX_DEPOSIT);
 }
 
 // TODO figure out what bytes1() does in python
@@ -187,4 +180,3 @@ export function intSqrt(n: int): int {
   }
   return x;
 }
-

--- a/beaconChain/helpers/stateTransitionHelpers.ts
+++ b/beaconChain/helpers/stateTransitionHelpers.ts
@@ -99,7 +99,9 @@ export function clamp(minval: int, maxval: int, x: int): int {
  */
 function getShardCommitteesAtSlot(state: BeaconState, slot: int): ShardCommittee[] {
   const earliestSlotInArray: int = state.slot - (state.slot % EPOCH_LENGTH) - EPOCH_LENGTH;
-  if (earliestSlotInArray <= slot && slot < earliestSlotInArray + EPOCH_LENGTH * 2) throw new Error();
+  if (earliestSlotInArray <= slot && slot < earliestSlotInArray + EPOCH_LENGTH * 2) {
+    throw new Error();
+  }
   return state.shardCommitteesAtSlots[slot - earliestSlotInArray];
 }
 
@@ -112,7 +114,9 @@ function getShardCommitteesAtSlot(state: BeaconState, slot: int): ShardCommittee
  */
 function getBlockHash(state: BeaconState, slot: int): hash32 {
   const earliestSlotInArray = state.slot - state.latestBlockHashes.length;
-  if (earliestSlotInArray <= slot && slot < state.slot) throw new Error();
+  if (earliestSlotInArray <= slot && slot < state.slot) {
+    throw new Error();
+  }
   return state.latestBlockHashes[slot - earliestSlotInArray];
 }
 

--- a/beaconChain/interfaces/blocks.ts
+++ b/beaconChain/interfaces/blocks.ts
@@ -3,82 +3,146 @@
 // These interfaces relate to the data structures for beacon chain blocks
 
 type bytes = number;
+type uint24 = number;
 type uint64 = number;
 type uint384 = number;
 type hash32 = number;
 
+// Beacon chain operations
+
+export interface ProposerSlashing {
+  // Proposer index
+  proposerIndex: uint24;
+  // First proposal data
+  proposalData1: ProposalSignedData;
+  // First proposal signature
+  proposalSignature1: uint384[];
+  // Second proposal data
+  proposalData2: ProposalSignedData;
+  // Second proposal signature
+  proposalSignature2: uint384[];
+}
+
+export interface CasperSlashing {
+  // First batch of votes
+  votes1: SlashableVoteData;
+  // Second batch of votes
+  votes2: SlashableVoteData;
+}
+
+export interface SlashableVoteData {
+  // Proof-of-custody indices (0 bits)
+  aggregateSignaturePoc0Indices: uint24[];
+  // Proof-of-custody indices (1 bits)
+  aggregateSignaturePoc1Indices: uint24[];
+  // Attestation data
+  data: AttestationData;
+  // Aggregate signature
+  aggregateSignature: uint384[];
+}
+
+export interface Attestation {
+  // Attestation data
+  data: AttestationData;
+  // Attester participation bitfield
+  participationBitfield: bytes;
+  // Proof of custody bitfield
+  custodyBitfield: bytes;
+  // BLS aggregate signature
+  aggregateSignature: uint384[];
+}
+
+export interface AttestationData {
+  // Slot number
+  slot: uint64;
+  // Shard number
+  shard: uint64;
+  // Hash of the signed beacon block
+  beaconBlockHash: hash32;
+  // Hash of the ancestor at the epoch boundary
+  epochBoundaryHash: hash32;
+  // Shard block hash being attested to
+  shardBlockHash: hash32;
+  // Last crosslink hash
+  latestCrosslinkHash: hash32;
+  // Slot of the last justified beacon block
+  justifiedSlot: uint64;
+  // Hash of the last justified beacon block
+  justifiedBlockHash: hash32;
+}
+
+export interface Deposit {
+  // Receipt Merkle branch
+  merkleBranch: hash32[];
+  // Merkle tree index
+  merkleTreeIndex: uint64;
+  // Deposit data
+  depositData: DepositData;
+}
+
+export interface DepositData {
+  // Deposit parameters
+  depositParameters: DepositParameters;
+  // Value in Gwei
+  value: uint64;
+  // Timestamp from deposit contract
+  timestamp: uint64;
+}
+
+export interface DepositParameters {
+  // BLS pubkey
+  pubkey: uint384;
+  // BLS proof of possession (a BLS signature)
+  proofOfPossession: uint384[];
+  // Withdrawal credentials
+  withdrawalCredentials: hash32;
+  // Initial RANDAO commitment
+  randaoCommitment: hash32;
+}
+
+export interface Exit {
+  // Minimum slot for processing exit
+  slot: uint64;
+  // Index of the exiting validator
+  validator_index: uint64;
+  // Validator signature
+  signature: uint384[];
+}
+
+// Beacon chain blocks
+
 export interface BeaconBlock {
   // Slot number
   slot: uint64;
-  // Proposer RANDAO reveal
-  randaoReveal: hash32;
-  // Recent PoW receipt root
-  candidatePowReceiptRoot: hash32;
   // Skip list of previous beacon block hashes
   // i'th item is the most recent ancestor whose slot is a multiple of 2**i for i = 0, ..., 31
   ancestorHashes: hash32[];
   // State root
   stateRoot: hash32;
-  // Attestations
-  attestations: AttestationRecord[];
-  // Specials (e.g. logouts, penalties)
-  specials: SpecialRecord[];
+  // Proposer RANDAO reveal
+  randaoReveal: hash32;
+  // Recent PoW receipt root
+  candidatePowReceiptRoot: hash32;
   // Proposer signature
-  proposerSignature: uint384[];
+  signature: uint384[];
+
+  // Body
+  body: BeaconBlockBody;
 }
 
-export interface AttestationRecord {
-  // Slot number
-  slot: uint64;
-  // Shard number
-  shard: uint64;
-  // Beacon block hashes not part of the current chain, oldest to newest
-  obliqueParentHashes: hash32[];
-  // Shard block hash being attested to
-  shardBlockHash: hash32;
-  // Last crosslink hash
-  lastCrosslinkHash: hash32;
-  // Root of data between last hash and this one
-  shardBlockCombinedDataRoot: hash32;
-  // Attester participation bitfield (1 bit per attester)
-  attesterBitfield: bytes;
-  // Slot of last justified beacon block
-  justifiedSlot: uint64;
-  // Hash of last justified beacon block
-  justifiedBlockHash: hash32;
-  // BLS aggregate signature
-  aggregateSig: uint384[];
+export interface BeaconBlockBody {
+  attestations: Attestation[];
+  proposerSlashings: ProposerSlashing[];
+  casperSlashings: CasperSlashing[];
+  deposits: Deposit[];
+  exits: Exit[];
 }
 
 export interface ProposalSignedData {
   // Slot number
   slot: uint64;
-  // Shard number (or `2**64 - 1` for beacon chain)
+  // Shard number (`BEACON_CHAIN_SHARD_NUMBER` for beacon chain)
   shard: uint64;
   // Block hash
   blockHash: hash32;
-}
-
-export interface AttestationSignedData {
-  // Slot number
-  slot: uint64;
-  // Shard number
-  shard: uint64;
-  // CYCLE_LENGTH parent hashes
-  parentHashes: hash32[];
-  // Shard block hash
-  shardBlockHash: hash32;
-  // Last crosslink hash
-  lastCrosslinkHash: hash32;
-  // Root of data between last hash and this one
-  shardBlockCombinedDataRoot: hash32;
-  // Slot of last justified beacon block referenced in the attestation
-  justifiedSlot: uint64;
-}
-
-export interface SpecialRecord {
-  // Kind
-  kind: uint64;
-  // Data
-  data: bytes;
 }

--- a/beaconChain/tests/helpers/stateTransitionHelpers.test.ts
+++ b/beaconChain/tests/helpers/stateTransitionHelpers.test.ts
@@ -132,7 +132,7 @@ describe("getActiveValidatorIndices", () => {
   const randNum = () =>  Math.floor(Math.random() * Math.floor(4));
   const genValidatorRecord = () => ({
     balance: randNum(),
-    exit_seq: randNum(),
+    exitCount: randNum(),
     lastStatusChangeSlot: randNum(),
     pubkey: randNum(),
     randaoCommitment: randNum(),


### PR DESCRIPTION
A bunch of the data structures and constants have changed in the [beacon chain spec](https://github.com/ethereum/eth2.0-specs/blob/master/specs/core/0_beacon-chain.md).

This brings the code up to the latest spec in regards to the data structures and constants. Where possible, a variable's name and order is identical to the camel-case-ified name and order of the variables in the spec. 

This also minimally fixes existing helper functions and test functions.