### PR TITLE
Rename public logs and variables, adjust tests accordingly

### DIFF
--- a/solidity/test/ValidatorRegistration-test.js
+++ b/solidity/test/ValidatorRegistration-test.js
@@ -74,15 +74,15 @@ contract('ValidatorRegistration', accounts => {
     })
   })
 
-  it('properly emits Eth1Deposit event', async () => {
+  it('properly emits Deposit event', async () => {
     const depositTxion = this.contract.deposit.bind(this.contract, DEPOSIT_DATA, {
       from: this.depositAddress,
       value: DEPOSIT_AMOUNT
     })
-    await inTransaction(depositTxion, 'Eth1Deposit')
+    await inTransaction(depositTxion, 'Deposit')
   })
 
-  it('properly emits ChainStart event', async () => {
+  it('properly emits Eth2Genesis event', async () => {
     let i
     for (i = 0; i < 7; i++) {
       await this.contract.deposit(DEPOSIT_DATA, {
@@ -94,6 +94,6 @@ contract('ValidatorRegistration', accounts => {
       from: accounts[i + 1],
       value: DEPOSIT_AMOUNT
     })
-    await inTransaction(depositTxion, 'ChainStart')
+    await inTransaction(depositTxion, 'Eth2Genesis')
   })
 });


### PR DESCRIPTION
This PR aims to rename some logs and variables in the Validator Registration contract in order to more closely align with spec.

- ~ChainStart~ Eth2Genesis
- ~Eth1Deposit~ Deposit
- ~MIN_TOPUP_SIZE~ MIN_DEPOSIT_AMOUNT
- ~DEPOSIT_SIZE~ MAX_DEPOSIT_AMOUNT