### PR TITLE
RPC module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1459,6 +1459,11 @@
       "dev": true,
       "optional": true
     },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -5628,6 +5633,23 @@
               "requires": {
                 "bn.js": "^4.11.8",
                 "ethereumjs-util": "^6.0.0"
+              },
+              "dependencies": {
+                "ethereumjs-util": {
+                  "version": "6.1.0",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+                  "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+                  "dev": true,
+                  "requires": {
+                    "bn.js": "^4.11.0",
+                    "create-hash": "^1.1.2",
+                    "ethjs-util": "0.1.6",
+                    "keccak": "^1.0.2",
+                    "rlp": "^2.0.0",
+                    "safe-buffer": "^5.1.1",
+                    "secp256k1": "^3.0.1"
+                  }
+                }
               }
             },
             "ethereumjs-block": {
@@ -9699,6 +9721,23 @@
               "requires": {
                 "bn.js": "^4.11.8",
                 "ethereumjs-util": "^6.0.0"
+              },
+              "dependencies": {
+                "ethereumjs-util": {
+                  "version": "6.1.0",
+                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+                  "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+                  "dev": true,
+                  "requires": {
+                    "bn.js": "^4.11.0",
+                    "create-hash": "^1.1.2",
+                    "ethjs-util": "0.1.6",
+                    "keccak": "^1.0.2",
+                    "rlp": "^2.0.0",
+                    "safe-buffer": "^5.1.1",
+                    "secp256k1": "^3.0.1"
+                  }
+                }
               }
             },
             "ethereumjs-block": {
@@ -11286,6 +11325,11 @@
       "requires": {
         "semver": "^5.3.0"
       }
+    },
+    "noice-json-rpc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/noice-json-rpc/-/noice-json-rpc-1.2.0.tgz",
+      "integrity": "sha512-Wm+otW+drKzdqlSPoSwj34tUEq/Xj1gX6Cr2avrykvTW4IY7d3ngLmP+PErALzS0s9nYRokXvYDM54sbFvLlDA=="
     },
     "noop-logger": {
       "version": "0.1.1",
@@ -13355,6 +13399,14 @@
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
+      }
+    },
+    "ws": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+      "requires": {
+        "async-limiter": "~1.0.0"
       }
     },
     "xmlhttprequest": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "deepmerge": "^3.2.0",
     "ethers": "^4.0.27",
     "level": "^4.0.0",
-    "promisify-es6": "^1.0.3"
+    "noice-json-rpc": "^1.2.0",
+    "promisify-es6": "^1.0.3",
+    "ws": "^6.2.1"
   },
   "bin": {
     "lodestar": "./bin/lodestar",

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -5,7 +5,7 @@ import {BeaconChain} from "../chain";
 import {LevelDB} from "../db";
 import {Eth1Notifier} from "../eth1";
 import {P2PNetwork} from "../p2p";
-import {BeaconRPC} from "../rpc";
+import {BeaconAPI, JSONRPC, WSServer} from "../rpc";
 import {Sync} from "../sync";
 import {OpPool} from "../opPool";
 
@@ -54,7 +54,14 @@ class BeaconNode {
       db: this.db,
       chain: this.chain,
     });
-    this.rpc = new BeaconRPC(this.conf.rpc);
+    this.rpc = new JSONRPC(this.conf.rpc, {
+      transport: new WSServer(this.conf.rpc), 
+      api: new BeaconAPI(this.conf.rpc, {
+        chain: this.chain,
+        db: this.db,
+        opPool: this.opPool,
+      }),
+    });
   }
 
   public async start() {

--- a/src/rpc/api/api.ts
+++ b/src/rpc/api/api.ts
@@ -1,0 +1,52 @@
+import { Attestation, AttestationData, BeaconBlock, bytes32, Deposit, Shard, Slot, Eth1Data } from "../../types";
+import { DB } from "../../db";
+import { BeaconChain } from "../../chain";
+import { OpPool } from "../../opPool";
+
+import {API} from "./interface"; 
+
+export class BeaconAPI implements API {
+  private chain: BeaconChain;
+  private db: DB;
+  private opPool: OpPool;
+
+  public constructor(opts, {chain, db, opPool}) {
+    this.chain = chain;
+    this.db = db;
+    this.opPool = opPool;
+  }
+
+  public async getChainHead(): Promise<BeaconBlock> {
+    return await this.db.getChainHead();
+  }
+
+  public async getPendingAttestations(): Promise<Attestation[]> {
+    return this.opPool.getAttestations();
+  }
+
+  public async getPendingDeposits(): Promise<Deposit[]> {
+    return [];
+  }
+
+  public async getEth1Data(): Promise<Eth1Data> {
+    // eslint-disable-next-line @typescript-eslint/no-object-literal-type-assertion
+    return {} as Eth1Data;
+  }
+
+  public async computeStateRoot(block: BeaconBlock): Promise<bytes32> {
+    return Buffer.alloc(32);
+  }
+
+  public async getAttestationData(slot: Slot, shard: Shard): Promise<AttestationData> {
+    // eslint-disable-next-line @typescript-eslint/no-object-literal-type-assertion
+    return {} as AttestationData;
+  }
+
+  public async putAttestation(attestation: Attestation): Promise<void> {
+    await this.opPool.receiveAttestation(attestation);
+  }
+
+  public async putBlock(block: BeaconBlock): Promise<void> {
+    await this.chain.receiveBlock(block);
+  }
+}

--- a/src/rpc/api/index.ts
+++ b/src/rpc/api/index.ts
@@ -1,0 +1,3 @@
+export * from "./interface";
+export * from "./mock";
+export * from "./api";

--- a/src/rpc/api/interface.ts
+++ b/src/rpc/api/interface.ts
@@ -1,0 +1,46 @@
+import { Attestation, AttestationData, BeaconBlock, bytes32, Deposit, Shard, Slot, Eth1Data } from "../../types";
+
+/**
+ * The API interface defines the calls that can be made externally
+ */
+export interface API {
+  /**
+   * Return the current chain head
+   */
+  getChainHead(): Promise<BeaconBlock>;
+
+  /**
+   * Return a list of attestations ready for inclusion in the next block
+   */
+  getPendingAttestations(): Promise<Attestation[]>;
+
+  /**
+   * Return a list of deposits ready for inclusion in the next block
+   */
+  getPendingDeposits(): Promise<Deposit[]>;
+
+  /**
+   * Return the Eth1Data to be included in the next block
+   */
+  getEth1Data(): Promise<Eth1Data>;
+
+  /**
+   * Return the state root after the block has been run through the state transition
+   */
+  computeStateRoot(block: BeaconBlock): Promise<bytes32>;
+
+  /**
+   * Return the attestation data for a slot and shard based on the current head
+   */
+  getAttestationData(slot: Slot, shard: Shard): Promise<AttestationData>;
+
+  /**
+   * Submit an attestation for processing
+   */
+  putAttestation(attestation: Attestation): Promise<void>;
+
+  /**
+   * Submit a block for processing
+   */
+  putBlock(block: BeaconBlock): Promise<void>;
+}

--- a/src/rpc/api/mock.ts
+++ b/src/rpc/api/mock.ts
@@ -1,0 +1,55 @@
+import { Attestation, AttestationData, BeaconBlock, bytes32, Deposit, Shard, Slot, Eth1Data } from "../../types";
+
+import { getEmptyBlock } from "../../chain/helpers/genesis";
+
+import {API} from "./interface";
+
+export interface MockAPIOpts {
+  head?: BeaconBlock;
+  pendingAttestations?: Attestation[];
+  getPendingDeposits?: Deposit[];
+  Eth1Data?: Eth1Data;
+  attestationData?: AttestationData;
+}
+
+export class MockAPI implements API {
+  private head;
+  private attestations;
+  public constructor(opts?: MockAPIOpts) {
+    this.attestations = opts && opts.pendingAttestations || [];
+    this.head = opts && opts.head || getEmptyBlock();
+  }
+  public async getChainHead(): Promise<BeaconBlock> {
+    return this.head;
+  }
+
+  public async getPendingAttestations(): Promise<Attestation[]> {
+    return this.attestations;
+  }
+
+  public async getPendingDeposits(): Promise<Deposit[]> {
+    return [];
+  }
+
+  public async getEth1Data(): Promise<Eth1Data> {
+    // eslint-disable-next-line @typescript-eslint/no-object-literal-type-assertion
+    return {} as Eth1Data;
+  }
+
+  public async computeStateRoot(block: BeaconBlock): Promise<bytes32> {
+    return Buffer.alloc(32);
+  }
+
+  public async getAttestationData(slot: Slot, shard: Shard): Promise<AttestationData> {
+    // eslint-disable-next-line @typescript-eslint/no-object-literal-type-assertion
+    return {} as AttestationData;
+  }
+
+  public async putAttestation(attestation: Attestation): Promise<void> {
+    this.attestations.push(attestation);
+  }
+
+  public async putBlock(block: BeaconBlock): Promise<void> {
+    this.head = block;
+  }
+}

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -1,8 +1,3 @@
-/**
- * The BeaconRPC service manages incoming/outgoing RPC requests
- */
-export class BeaconRPC {
-  public constructor(opts) {}
-  public async start() {}
-  public async stop() {}
-}
+export * from "./api";
+export * from "./transport";
+export * from "./protocol";

--- a/src/rpc/protocol/index.ts
+++ b/src/rpc/protocol/index.ts
@@ -1,0 +1,1 @@
+export * from "./jsonRpc";

--- a/src/rpc/protocol/jsonRpc.ts
+++ b/src/rpc/protocol/jsonRpc.ts
@@ -1,0 +1,44 @@
+import http from "http";
+import * as jsonRpc from "noice-json-rpc";
+import Websocket from "ws";
+import promisify from "promisify-es6";
+
+
+import {API} from "../api/interface";
+
+export interface LikeSocketServer extends jsonRpc.LikeSocketServer {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}
+
+/**
+ * JSON-RPC over some transport
+ *
+ * 
+ */
+export class JSONRPC {
+  private rpcServer: jsonRpc.Server;
+  private transport: LikeSocketServer;
+  private jsonRpcApi;
+  private opts;
+  public constructor(opts, {transport, api}: {transport: LikeSocketServer; api: API}) {
+    this.transport = transport;
+    // attach the json-rpc server to underlying transport
+    this.rpcServer = new jsonRpc.Server(this.transport);
+    this.jsonRpcApi = this.rpcServer.api();
+    // collect the api methods into an enumerable object for rpc exposure
+    const methods = {}
+    for (let name of Object.getOwnPropertyNames(Object.getPrototypeOf(api))) {
+      if (name !== 'constructor' && typeof api[name] === 'function') {
+        methods[name] = api[name].bind(api)
+      }
+    }
+    this.jsonRpcApi.BeaconChain.expose(methods);
+  }
+  public async start(): Promise<void> {
+    await this.transport.start();
+  }
+  public async stop(): Promise<void> {
+    await this.transport.stop();
+  }
+}

--- a/src/rpc/transport/index.ts
+++ b/src/rpc/transport/index.ts
@@ -1,0 +1,1 @@
+export * from "./ws";

--- a/src/rpc/transport/ws.ts
+++ b/src/rpc/transport/ws.ts
@@ -1,0 +1,27 @@
+import * as http from "http";
+import promisify from "promisify-es6";
+import WebSocket from "ws";
+
+export interface WSServerOpts {
+  port: number;
+}
+
+export class WSServer {
+  private ws: WebSocket.Server;
+  private httpServer: http.Server;
+  private opts: WSServerOpts;
+  public on: any;
+  public constructor(opts) {
+    this.opts = opts;
+    this.httpServer = http.createServer();
+    this.ws = new WebSocket.Server({server: this.httpServer});
+    this.on = this.ws.on.bind(this.ws);
+  }
+  public async start(): Promise<void> {
+    await promisify(this.httpServer.listen.bind(this.httpServer))(this.opts.port);
+  }
+  public async stop(): Promise<void> {
+    await promisify(this.ws.close.bind(this.ws))();
+    await promisify(this.httpServer.close.bind(this.httpServer))();
+  }
+}

--- a/tests/rpc/api.test.ts
+++ b/tests/rpc/api.test.ts
@@ -1,0 +1,36 @@
+import { assert } from "chai";
+
+import {
+  BeaconBlock,
+  BeaconState,
+  Attestation,
+} from "../../src/types";
+
+import {BeaconChain} from "../../src/chain";
+import {OpPool} from "../../src/opPool";
+import {LevelDB} from "../../src/db";
+import {BeaconAPI} from "../../src/rpc"; 
+
+import { generateEmptyBlock } from "../utils/block";
+import { generateEmptyAttestation } from "../utils/attestation";
+
+describe("RPC API", () => {
+  /*
+  it("should get the chain head", async () => {
+  })
+  it("should get pending attestations", async () => {
+  })
+  it("should get pending deposits", async () => {
+  })
+  it("should get eth1 data", async () => {
+  })
+  it("should compute the state root", async () => {
+  })
+  it("should get attestation data", async () => {
+  })
+  it("should accept an attestation submission", async () => {
+  })
+  it("should accept a block submission", async () => {
+  })
+  */
+});

--- a/tests/rpc/jsonRpc.test.ts
+++ b/tests/rpc/jsonRpc.test.ts
@@ -1,0 +1,76 @@
+import { assert } from "chai";
+import BN from "bn.js";
+import promisify from "promisify-es6";
+import * as jsonRpc from "noice-json-rpc";
+import Websocket from "ws";
+import {
+  serialize,
+  treeHash,
+} from "@chainsafesystems/ssz";
+
+import {
+  BeaconBlock,
+  BeaconState,
+  Attestation,
+} from "../../src/types";
+
+import {MockAPI, JSONRPC, API, WSServer} from "../../src/rpc"; 
+
+import { generateState } from "../utils/state";
+import { generateEmptyBlock } from "../utils/block";
+import { generateEmptyAttestation } from "../utils/attestation";
+
+describe("RPC JSONRPC", () => {
+  const rpc = new JSONRPC({}, {transport: new WSServer({port: 32420}), api: new MockAPI()}); 
+  let client;
+  let ws;
+  let clientApi: {BeaconChain: API};
+  before(async () => {
+    await rpc.start();
+    ws = new Websocket("ws://localhost:32420");
+    client = new jsonRpc.Client(ws);
+    clientApi = client.api();
+  })
+  after(async () => {
+    await rpc.stop();
+  })
+  it("should get the chain head", async () => {
+    const head = await clientApi.BeaconChain.getChainHead();
+    assert.ok(head);
+  })
+  it("should get pending attestations", async () => {
+    const attestations = await clientApi.BeaconChain.getPendingAttestations();
+    assert.ok(attestations);
+  })
+  it("should get pending deposits", async () => {
+    const deposits = await clientApi.BeaconChain.getPendingDeposits();
+    assert.ok(deposits);
+  })
+  it("should get eth1 data", async () => {
+    const eth1Data = await clientApi.BeaconChain.getEth1Data();
+    assert.ok(eth1Data);
+  })
+  it("should compute the state root", async () => {
+    const root = await clientApi.BeaconChain.computeStateRoot(generateEmptyBlock());
+    assert.ok(root);
+  })
+  it("should get attestation data", async () => {
+    const data = await clientApi.BeaconChain.getAttestationData(new BN(0), new BN(0));
+    assert.ok(data);
+  })
+  it("should accept an attestation submission", async () => {
+    await clientApi.BeaconChain.putAttestation(generateEmptyAttestation());
+    assert.ok(true);
+  })
+  it("should accept a block submission", async () => {
+    await clientApi.BeaconChain.putBlock(generateEmptyBlock());
+    assert.ok(true);
+  })
+  it("should fail for unknown methods", async () => {
+    try {
+      await (clientApi.BeaconChain as any).foo();
+      assert.fail('Unknown/undefined method should fail');
+    } catch (e) {}
+  })
+  
+});


### PR DESCRIPTION
RPC module, some methods stubbed out (probably incomplete too).

The module is split into three submodules for extensibility:
- api - this is where the actual beacon-chain logic goes. So far, we've added an interface, the standard api, and a mock api (for testing)
- protocol - this is currently where the JSON-RPC-specific logic lives. The JSONRPC class is agnostic to the underlying server, so we can use it for json-rpc over tcp, http, ws, node MessageChannel, etc.
- transport - this is where logic specific to a certain transport goes. Currently only a websocket transport exists.

This should include every endpoint a validator needs for block proposal and attesting.
