### PR TITLE
Fix build and add linter rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
     "no-caller": "error",
     "no-bitwise": "off",
     "@typescript-eslint/indent": ["error", 2],
+    "@typescript-eslint/no-require-imports": "error",
     "no-conditional-assignment": true,
     "no-consecutive-blank-lines": false,
     "object-literal-sort-keys": false,

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
-
+lib
 .nyc_output/
 coverage/**
 .DS_Store

--- a/src/chain/index.ts
+++ b/src/chain/index.ts
@@ -1,4 +1,4 @@
-import assert = require("assert");
+import assert from "assert";
 import BN from "bn.js";
 import {EventEmitter} from "events";
 import { treeHash } from "@chainsafesystems/ssz";

--- a/src/chain/stateTransition/epoch/balanceUpdates/index.ts
+++ b/src/chain/stateTransition/epoch/balanceUpdates/index.ts
@@ -1,4 +1,4 @@
-import BN = require("bn.js");
+import BN  from "bn.js";
 import {processAttestationInclusion} from "./attestation";
 import {BeaconState, Epoch, PendingAttestation, ValidatorIndex} from "../../../../types";
 import {processJustificationAndFinalization} from "./justification";

--- a/src/chain/stateTransition/epoch/balanceUpdates/justification.ts
+++ b/src/chain/stateTransition/epoch/balanceUpdates/justification.ts
@@ -1,7 +1,7 @@
 import {getActiveValidatorIndices, isActiveValidator} from "../../../helpers/stateTransitionHelpers";
 import {MIN_ATTESTATION_INCLUSION_DELAY} from "../../../../constants";
 import {BeaconState, Epoch} from "../../../../types";
-import BN = require("bn.js");
+import BN from "bn.js";
 import {inclusionDistance} from "../helpers";
 
 export function processJustificationAndFinalization(

--- a/src/chain/stateTransition/epoch/crosslinks.ts
+++ b/src/chain/stateTransition/epoch/crosslinks.ts
@@ -3,7 +3,7 @@ import {
   getCrosslinkCommitteesAtSlot, getEpochStartSlot, getTotalBalance,
   slotToEpoch
 } from "../../helpers/stateTransitionHelpers";
-import BN = require("bn.js");
+import BN from "bn.js";
 import {winningRoot} from "./helpers";
 
 export function processCrosslinks(

--- a/src/chain/stateTransition/epoch/variables.ts
+++ b/src/chain/stateTransition/epoch/variables.ts
@@ -1,4 +1,4 @@
-import BN = require("bn.js");
+import BN from "bn.js";
 import {
   getActiveValidatorIndices, getAttestationParticipants,
   getBlockRoot, getCrosslinkCommitteesAtSlot, getCurrentEpoch, getEpochStartSlot, getPreviousEpoch, getTotalBalance,

--- a/src/eth1/fake.ts
+++ b/src/eth1/fake.ts
@@ -1,4 +1,4 @@
-import BN = require("bn.js");
+import BN from "bn.js";
 import { Deposit, DepositData, DepositInput, Eth1Data, int } from "../types";
 
 interface DummyChainStart {

--- a/src/helpers/math.ts
+++ b/src/helpers/math.ts
@@ -1,4 +1,4 @@
-import BN = require("bn.js");
+import BN from "bn.js";
 
 /**
  * Return the min number between two big numbers.

--- a/validator/helpers.ts
+++ b/validator/helpers.ts
@@ -1,7 +1,8 @@
 import assert from "assert";
+import BN from "bn.js";
+
 import {BeaconState, Epoch, ValidatorIndex, Shard} from "../src/types";
 import {getPreviousEpoch, getCurrentEpoch, getEpochStartSlot, getCrosslinkCommitteesAtSlot, getBeaconProposerIndex} from "../src/chain/helpers/stateTransitionHelpers";
-import BN = require("bn.js");
 import {SLOTS_PER_EPOCH} from "../src/constants";
 
 /**

--- a/validator/stubs.ts
+++ b/validator/stubs.ts
@@ -1,6 +1,6 @@
 // This file makes some naive assumptions surrounding the way RPC like calls will be made in ETH2.0
 // Subject to change with future developments with Hobbits and wire protocol
-import BN = require("bn.js");
+import BN from "bn.js";
 import blgr from "blgr";
 import {ValidatorIndex, Slot, BeaconBlock, BeaconState} from "../src/types";
 


### PR DESCRIPTION
There were a few cases where we had the `import x = require(y)` pattern.
This seems to break our build (`npm run build`), so this PR updates our linter rules to catch this sort of thing proactively.
Also fixed all occurrences.

This issue was found during #146

We could think about adding a build step or docker image build step to our CI pipeline.