### PR TITLE
bugfix level db encoding

### DIFF
--- a/src/db/impl/level.ts
+++ b/src/db/impl/level.ts
@@ -17,7 +17,12 @@ export class LevelDB extends AbstractDB implements DB {
 
   public constructor(opts: LevelDBOptions) {
     super();
-    this.db = opts.db || level(opts.name || 'beaconchain');
+    this.db =
+            opts.db
+            || level(opts.name || 'beaconchain', {
+              keyEncoding: 'binary',
+              valueEncoding: 'binary',
+            });
   }
 
   public async start(): Promise<void> {

--- a/src/db/impl/level.ts
+++ b/src/db/impl/level.ts
@@ -18,11 +18,12 @@ export class LevelDB extends AbstractDB implements DB {
   public constructor(opts: LevelDBOptions) {
     super();
     this.db =
-            opts.db
-            || level(opts.name || 'beaconchain', {
-              keyEncoding: 'binary',
-              valueEncoding: 'binary',
-            });
+      opts.db
+      ||
+      level(
+        opts.name || 'beaconchain',
+        {keyEncoding: 'binary', valueEncoding: 'binary'}
+      );
   }
 
   public async start(): Promise<void> {

--- a/tests/db/level.test.ts
+++ b/tests/db/level.test.ts
@@ -1,59 +1,54 @@
-import { assert } from "chai";
+import {assert} from "chai";
 import BN from "bn.js";
 import leveldown from "leveldown";
 import promisify from "promisify-es6";
-import {
-  serialize,
-  hashTreeRoot,
-} from "@chainsafe/ssz";
+import {hashTreeRoot, serialize,} from "@chainsafe/ssz";
 
-import {
-  BeaconBlock,
-  BeaconState,
-  Attestation,
-} from "../../src/types";
+import {BeaconBlock, BeaconState,} from "../../src/types";
 
 import {LevelDB} from "../../src/db";
 
-import { generateState } from "../utils/state";
-import { generateEmptyBlock } from "../utils/block";
-import { generateEmptyAttestation } from "../utils/attestation";
+import {generateState} from "../utils/state";
+import {generateEmptyBlock} from "../utils/block";
+import {generateEmptyAttestation} from "../utils/attestation";
 import {generateEmptyVoluntaryExit} from "../utils/voluntaryExits";
 import level from "level";
 
 describe("LevelDB", () => {
   const dbLocation = "./.__testdb";
-  const testDb = level(dbLocation, {
+  const testDb = level(
+    dbLocation, {
       keyEncoding: 'binary',
       valueEncoding: 'binary',
-  });
+    });
   const db = new LevelDB({db: testDb});
   before(async () => {
     await db.start();
-  })
+  });
   after(async () => {
     await db.stop();
-    await promisify(leveldown.destroy)(dbLocation, function() {})
-  })
+    await promisify(leveldown.destroy)(dbLocation, function () {
+    })
+  });
   it("should correctly get and set the state", async () => {
     const testState = generateState();
     await db.setState(testState);
     const actualState = await db.getState();
     assert.deepEqual(serialize(actualState, BeaconState), serialize(testState, BeaconState));
-  })
+  });
   it("should correctly get and set the finalized state", async () => {
     const testState = generateState();
     await db.setFinalizedState(testState);
     const actualState = await db.getFinalizedState();
     assert.deepEqual(serialize(actualState, BeaconState), serialize(testState, BeaconState));
-  })
+  });
   it("should correctly get and set a block", async () => {
     const testBlock = generateEmptyBlock();
     const testBlockRoot = hashTreeRoot(testBlock, BeaconBlock);
     await db.setBlock(testBlock);
     const actualBlock = await db.getBlock(testBlockRoot);
     assert.deepEqual(serialize(actualBlock, BeaconBlock), serialize(testBlock, BeaconBlock));
-  })
+  });
   it("should correctly set the chain head", async () => {
     const testState = generateState();
     const testBlock = generateEmptyBlock();
@@ -64,13 +59,13 @@ describe("LevelDB", () => {
     await db.setChainHead(testState, testBlock);
     const actualBlock = await db.getBlockBySlot(slot);
     assert.deepEqual(serialize(actualBlock, BeaconBlock), serialize(testBlock, BeaconBlock));
-  })
+  });
   it("should correctly set, get, delete attestations", async () => {
     const testAttestations = Array.from({length: 64}, (_, i) => {
       const a = generateEmptyAttestation();
       a.aggregationBitfield = Buffer.from(i.toString());
       return a;
-    })
+    });
     for (const a of testAttestations) {
       await db.setAttestation(a);
     }
@@ -79,21 +74,21 @@ describe("LevelDB", () => {
     await db.deleteAttestations(testAttestations);
     const noAttestations = await db.getAttestations();
     assert.equal(noAttestations.length, 0);
-  })
+  });
 
   it("should correctly set, get, delete voluntary exits", async () => {
-      const testVoluntaryExits = Array.from({length: 10}, (_, i) => {
-          const a = generateEmptyVoluntaryExit();
-          a.epoch = new BN(i);
-          return a;
-      });
-      for (const a of testVoluntaryExits) {
-          await db.setVoluntaryExit(a);
-      }
-      const actualVoluntaryExits = await db.getVoluntaryExits();
-      assert.equal(actualVoluntaryExits.length, testVoluntaryExits.length);
-      await db.deleteVoluntaryExits(actualVoluntaryExits);
-      const noVoluntaryExits = await db.getVoluntaryExits();
-      assert.equal(noVoluntaryExits.length, 0);
+    const testVoluntaryExits = Array.from({length: 10}, (_, i) => {
+      const a = generateEmptyVoluntaryExit();
+      a.epoch = new BN(i);
+      return a;
+    });
+    for (const a of testVoluntaryExits) {
+      await db.setVoluntaryExit(a);
+    }
+    const actualVoluntaryExits = await db.getVoluntaryExits();
+    assert.equal(actualVoluntaryExits.length, testVoluntaryExits.length);
+    await db.deleteVoluntaryExits(actualVoluntaryExits);
+    const noVoluntaryExits = await db.getVoluntaryExits();
+    assert.equal(noVoluntaryExits.length, 0);
   })
 });

--- a/tests/db/level.test.ts
+++ b/tests/db/level.test.ts
@@ -1,7 +1,6 @@
 import { assert } from "chai";
 import BN from "bn.js";
 import leveldown from "leveldown";
-import levelup from "levelup";
 import promisify from "promisify-es6";
 import {
   serialize,
@@ -20,10 +19,14 @@ import { generateState } from "../utils/state";
 import { generateEmptyBlock } from "../utils/block";
 import { generateEmptyAttestation } from "../utils/attestation";
 import {generateEmptyVoluntaryExit} from "../utils/voluntaryExits";
+import level from "level";
 
 describe("LevelDB", () => {
   const dbLocation = "./.__testdb";
-  const testDb = levelup(leveldown(dbLocation));
+  const testDb = level(dbLocation, {
+      keyEncoding: 'binary',
+      valueEncoding: 'binary',
+  });
   const db = new LevelDB({db: testDb});
   before(async () => {
     await db.start();


### PR DESCRIPTION
Currently tests are passing because llevel db instance is created manually without key or value encoding. But when using level db created in constructor with level wrapper, default encoding is `utf-8` so db methods are always returning string and not buffer.