### PR TITLE
Added ETH2.0 Spec badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,11 @@ There is a lot of work being done that are core infrastructural pieces for Eth2.
 [![](https://badges.gitter.im/chainsafe/lodestar.svg)](https://gitter.im/chainsafe/lodestar?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![codecov](https://codecov.io/gh/ChainSafe/lodestar/branch/master/graph/badge.svg)](https://codecov.io/gh/ChainSafe/lodestar)
 [![Maintainability](https://api.codeclimate.com/v1/badges/678099476c401e1af503/maintainability)](https://codeclimate.com/github/ChainSafe/lodestar/maintainability)
+![ETH2.0_Spec_Version 0.3.0](https://img.shields.io/badge/ETH2.0_Spec_Version-0.3.0-2e86c1.svg)
 
 # Overview
 The goal of this repository is to provide an implementation of the beacon chain. As even the Ethereum Core dev team don't know how the finalized beacon chain
 will be implemented, this is our contribution to the effort to transitioning Ethereum from a PoW blockchain to a PoS blockchain.
-
-
-We are currently targeting version 0.3.0: Let There Be Liquidity release of the specification. As such, this is currently a work in progress and you can ask questions and contribute in our [gitter](https://gitter.im/chainsafe/lodestar-chain).
 
 ## What you need
 You will need to go over the [specification](https://github.com/ethereum/eth2.0-specs). You will also need to have a [basic understanding of sharding](https://github.com/ethereum/wiki/wiki/Sharding-FAQs). Note that that the specification is an ongoing document and will get outdated. The reference implementation by the Ethereum development team is written in Python and can be found [here](https://github.com/ethereum/beacon_chain).


### PR DESCRIPTION
Added a ETH2.0 Spec version badge in order to make it easy for everyone to know which version of the spec is currently implemented in this repo.