### PR TITLE
Deposit events history

### DIFF
--- a/src/eth1/impl/ethers.ts
+++ b/src/eth1/impl/ethers.ts
@@ -56,8 +56,7 @@ export class EthersEth1Notifier extends EventEmitter implements Eth1Notifier {
       this.provider.on('block', this.processBlockHeadUpdate.bind(this));
     } else {
       const pastDeposits = await this.getContractDeposits(
-        this.opts.depositContract.deployedAt,
-        null
+        this.opts.depositContract.deployedAt
       );
       await Promise.all(pastDeposits.map((pastDeposit) => {
         return this.db.setGenesisDeposit(pastDeposit);

--- a/src/eth1/index.ts
+++ b/src/eth1/index.ts
@@ -1,4 +1,3 @@
 export {Eth1Notifier, Eth1Options} from "./interface";
-export {MockEth1Notifier, MockEth1Options} from "./impl/mock";
 export {EthersEth1Notifier, EthersEth1Options} from "./impl/ethers";
 export {Eth1Wallet} from "./wallet";

--- a/src/eth1/interface.ts
+++ b/src/eth1/interface.ts
@@ -1,6 +1,6 @@
 import {EventEmitter} from "events";
 
-import {bytes32, DepositData, Deposit, Eth1Data} from "../types";
+import {bytes32, Deposit, number64} from "../types";
 
 export interface Eth1Options {
   depositContract: {
@@ -35,10 +35,21 @@ export interface Eth1Notifier extends EventEmitter {
   /**
    * Process a Eth2genesis log which has been received from the Eth 1.0 chain
    */
-  processEth2GenesisLog(depositRootHex: string, depositCountHex: string, timeHex: string, event: object): Promise<void>;
+  processEth2GenesisLog(
+    depositRootHex: string, depositCountHex: string, timeHex: string, event: object
+  ): Promise<void>;
 
   /**
-   * Return an array of deposits to process at genesis
+   * Obtains Deposit logs between given range of blocks
+   * @param fromBlock either block hash or block number
+   * @param toBlock optional, if not submitted it will assume latest
+   */
+  getContractDeposits(
+    fromBlock: string | number64, toBlock?: string | number64
+  ): Promise<Deposit[]>;
+
+  /**
+   * Return an array of deposits to process at genesis event
    */
   genesisDeposits(): Promise<Deposit[]>;
 

--- a/src/eth1/interface.ts
+++ b/src/eth1/interface.ts
@@ -14,6 +14,11 @@ export interface Eth1Options {
  * The Eth1Notifier service watches the Eth1.0 chain for relevant events
  */
 export interface Eth1Notifier extends EventEmitter {
+  /**
+   * If there isn't Eth2Genesis events in past logs, it should fetch
+   * all the deposit logs from block at which contract is deployed.
+   * If there is Eth2Genesis event in logs it should just listen for new eth1 blocks.
+   */
   start(): Promise<void>;
   stop(): Promise<void>;
 

--- a/test/e2e/cli/commands/deposit.test.ts
+++ b/test/e2e/cli/commands/deposit.test.ts
@@ -39,7 +39,7 @@ describe('[CLI] deposit', function() {
   });
 
   it('Should make a deposit for 10 accounts derived from mnemonic', async function() {
-    this.timeout(4000);
+    this.timeout(0);
     const contractAddress = await eth1Network.deployDepositContract();
     const command = new DepositCommand();
     await expect(

--- a/test/e2e/eth1/deploy.test.ts
+++ b/test/e2e/eth1/deploy.test.ts
@@ -74,7 +74,6 @@ describe("Eth1Notifier - using deployed contract", () => {
             )
         )
     );
-    await eth1Notifier.genesisDeposits('latest');
     assert(cb.called, "eth2genesis event did not fire");
   });
 

--- a/test/unit/eth1/ethers.test.ts
+++ b/test/unit/eth1/ethers.test.ts
@@ -48,6 +48,15 @@ describe("Eth1Notifier", () => {
     "should start notifier",
     async function (): Promise<void> {
       const contract = sinon.createStubInstance(Contract);
+      // @ts-ignore
+      contract.interface = {
+        events: {
+          Eth2Genesis: {
+            //random hash
+            topic: '0x6be15e8568869b1e100750dd5079151b32637268ec08d199b318b793181b8a7d'
+          }
+        }
+      };
       const notifier = new EthersEth1Notifier({
         depositContract: defaults.depositContract,
         provider,

--- a/test/utils/mockEth1Notifier.ts
+++ b/test/utils/mockEth1Notifier.ts
@@ -1,8 +1,8 @@
 import {EventEmitter} from "events";
 
-import {bytes32, Deposit} from "../../types";
+import {bytes32, Deposit} from "../../src/types";
 
-import {Eth1Notifier, Eth1Options} from "../interface";
+import {Eth1Notifier, Eth1Options} from "../../src/eth1/interface";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface MockEth1Options extends Eth1Options {
@@ -42,5 +42,9 @@ export class MockEth1Notifier extends EventEmitter implements Eth1Notifier {
 
   public async depositRoot(): Promise<bytes32> {
     return Buffer.alloc(32);
+  }
+
+  public async getContractDeposits(fromBlock: string | number, toBlock?: string | number): Promise<Deposit[]> {
+    return [];
   }
 }


### PR DESCRIPTION
The logic is:
- if Eth2Genesis event occured
   - just subscribe to block updates (deposit events will be extracted in processBlock method I think)
- If there is no Eth2Genesis event
   - fetch all deposit events since contract deployed and store in database
   - subscribe to blocks, Deposit and Eth2Genesis events


Should resolve #163 