### PR TITLE
Unstub validator rpc

### DIFF
--- a/src/validator/rpc/interface.ts
+++ b/src/validator/rpc/interface.ts
@@ -13,7 +13,7 @@ export interface RpcClient {
   connect(): Promise<void>;
 
   /**
-   * Initiates connection to rpc server.
+   * Destroys connection to rpc server.
    */
   disconnect(): Promise<void>;
 

--- a/src/validator/rpc/interface.ts
+++ b/src/validator/rpc/interface.ts
@@ -1,0 +1,44 @@
+import {BeaconAPI} from "../../rpc/api";
+import {AttestationData, BeaconState, Slot} from "../../types";
+
+export interface RpcClient {
+
+  beacon: BeaconAPI;
+
+  //validator: ValidatorAPI
+
+  /**
+   * Initiates connection to rpc server.
+   */
+  connect(): Promise<void>;
+
+  /**
+   * Initiates connection to rpc server.
+   */
+  disconnect(): Promise<void>;
+
+  /**
+   * Invokes callback on new slot.
+   * Depending on implementation it will poll for new slot or getting notified(Websockets)
+   * @param cb
+   */
+  onNewSlot(cb: (slot: Slot) => void);
+
+
+  /**
+   * Invokes callback on new head block.
+   * Depending on implementation it will poll for new head block or getting notified(Websockets)
+   * @param cb
+   */
+  onNewBeaconState(cb: (state: BeaconState) => void);
+
+  /**
+   * Invokes callback on new attestation data.
+   * Depending on implementation it will poll for attestation data or getting notified(Websockets)
+   * @param cb
+   */
+  onNewAttestation(cb: (attestation: AttestationData) => void);
+
+
+
+}


### PR DESCRIPTION
I started unstubbing validator rpc calls.
I'm not really sure how much of that will end up in beacon/validator api in beacon node so I've put abstract class that implements all those data processing functions that validator require.

I would leave them for now like this until rpc endpoints are defined and then we can either move this logic from `AbstractClient` to beacon node. If they are going to stay in validator it should probably be extracted to some class with more sane name.

I would like if you could check if I implemented those things correctly before I start writing tests.