### PR TITLE
Fix nyc config

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,0 +1,13 @@
+{
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "**/*mock*",
+    "**/stubs/*"
+  ],
+  "extensions": [
+    ".ts"
+  ],
+  "all": true
+}

--- a/nyc.json
+++ b/nyc.json
@@ -1,9 +1,0 @@
-{
-  "include": [
-    "src/**/*.ts",
-  ],
-  "extensions": [
-    ".ts"
-  ],
-  "all": true
-}

--- a/src/p2p/defaults.ts
+++ b/src/p2p/defaults.ts
@@ -1,4 +1,4 @@
-import {PeerBook} from "peer-book";
+import PeerBook from "peer-book";
 
 export default {
   maxPeers: 25,


### PR DESCRIPTION
As per docs, nyc.json isn't detected because of name. Also modified config to exclude tests, mocks and stubs from coverage