### PR TITLE
Add autogenerated doc pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,16 @@ language: node_js
 node_js:
   - "lts/*"
 cache: yarn
-before_script:
-  - yarn install
 script:
   - yarn run lint
   - yarn test
   - yarn run coverage
+  - yarn build:docs
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GH_PAGES_TOKEN
+  keep_history: true
+  local_dir: docs
+  on:
+    branch: master

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "build": "babel src -x .ts -d lib --source-maps",
+    "build:docs": "typedoc --exclude src/index.ts --out docs src",
     "check-types": "tsc --noEmit",
     "lint": "eslint --ext .ts src/",
     "lint-fix": "eslint --ext .ts src/ --fix",
@@ -81,6 +82,7 @@
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-typescript": "^7.3.3",
     "@babel/register": "^7.0.0",
+    "@polkadot/ts": "^0.1.56",
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^5.2.5",
@@ -88,7 +90,6 @@
     "@types/sinon": "^7.0.11",
     "@typescript-eslint/eslint-plugin": "^1.3.0",
     "@typescript-eslint/parser": "^1.3.0",
-    "@polkadot/ts": "^0.1.56",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "codecov": "^3.1.0",
@@ -98,6 +99,10 @@
     "sinon": "^7.2.7",
     "supertest": "^4.0.2",
     "ts-node": "^7.0.1",
+    "typedoc": "^0.14.2",
+    "typedoc-plugin-external-module-name": "^2.1.0",
+    "typedoc-plugin-internal-external": "^2.0.2",
+    "typedoc-plugin-markdown": "^1.2.0",
     "typescript": "^3.2.1"
   }
 }

--- a/src/chain/forkChoice/index.ts
+++ b/src/chain/forkChoice/index.ts
@@ -1,2 +1,6 @@
+/**
+ * @module chain/forkChoice
+ */
+
 export * from "./interface";
 export * from "./statefulDag";

--- a/src/chain/forkChoice/interface.ts
+++ b/src/chain/forkChoice/interface.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/forkChoice
+ */
+
 import {
   bytes32,
   Gwei,

--- a/src/chain/forkChoice/statefulDag/attestationAggregator.ts
+++ b/src/chain/forkChoice/statefulDag/attestationAggregator.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/forkChoice
+ */
+
 import BN from "bn.js";
 
 import {Gwei, Slot, ValidatorIndex} from "../../../types";
@@ -5,6 +9,7 @@ import {Gwei, Slot, ValidatorIndex} from "../../../types";
 
 /**
  * Root is a block root as a hex string
+ *
  * Used here for light weight and easy comparison
  */
 export type Root = string;
@@ -99,6 +104,7 @@ export class AttestationAggregator {
 
   /**
    * Remove all unused aggregations
+   *
    * Note: latestAttestations is currently never pruned
    */
   public prune(): void {

--- a/src/chain/forkChoice/statefulDag/index.ts
+++ b/src/chain/forkChoice/statefulDag/index.ts
@@ -1,2 +1,6 @@
+/**
+ * @module chain/forkChoice
+ */
+
 export * from "./lmdGhost";
 export * from "./attestationAggregator";

--- a/src/chain/forkChoice/statefulDag/lmdGhost.ts
+++ b/src/chain/forkChoice/statefulDag/lmdGhost.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/forkChoice
+ */
+
 import assert from "assert";
 import BN from "bn.js";
 
@@ -147,6 +151,7 @@ class Node {
 /**
  * Calculate best block using
  * Latest Message-Driven Greedy Heaviest Observed SubTree
+ *
  * See https://github.com/protolambda/lmd-ghost#state-ful-dag
  */
 export class StatefulDagLMDGHOST implements LMDGHOST {

--- a/src/chain/genesis.ts
+++ b/src/chain/genesis.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/genesis
+ */
+
 import BN from "bn.js";
 import {hashTreeRoot} from "@chainsafe/ssz";
 
@@ -22,8 +26,7 @@ import {processDeposit} from "./stateTransition/block/deposits";
 
 
 /**
- * Get an empty ``BeaconBlock``.
- * @returns {BeaconBlock}
+ * Get an empty [[BeaconBlock]].
  */
 export function getEmptyBlock(): BeaconBlock {
   return {
@@ -50,10 +53,6 @@ export function getEmptyBlock(): BeaconBlock {
 
 /**
  * Generate the initial beacon chain state.
- * @param {Deposit[]} initialValidatorDeposits
- * @param {number64} genesisTime
- * @param {Eth1Data} latestEth1Data
- * @returns {BeaconState}
  */
 export function getGenesisBeaconState(
   genesisValidatorDeposits: Deposit[],

--- a/src/chain/index.ts
+++ b/src/chain/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain
+ */
+
 import assert from "assert";
 import {EventEmitter} from "events";
 import {hashTreeRoot} from "@chainsafe/ssz";

--- a/src/chain/stateTransition/block/attestations.ts
+++ b/src/chain/stateTransition/block/attestations.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/block
+ */
+
 import assert from "assert";
 import {hashTreeRoot} from "@chainsafe/ssz";
 

--- a/src/chain/stateTransition/block/attesterSlashings.ts
+++ b/src/chain/stateTransition/block/attesterSlashings.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/block
+ */
+
 import assert from "assert";
 
 import {serialize} from "@chainsafe/ssz";
@@ -26,8 +30,6 @@ import {
 /**
  * Process ``AttesterSlashing`` operation.
  * Note that this function mutates ``state``.
- * @param {BeaconState} state
- * @param {AttesterSlashing} attesterSlashing
  */
 export function processAttesterSlashing(state: BeaconState, attesterSlashing: AttesterSlashing): void {
   const attestation1 = attesterSlashing.attestation1;

--- a/src/chain/stateTransition/block/blockHeader.ts
+++ b/src/chain/stateTransition/block/blockHeader.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/block
+ */
+
 import assert from "assert";
 
 import {signingRoot} from "@chainsafe/ssz";

--- a/src/chain/stateTransition/block/deposits.ts
+++ b/src/chain/stateTransition/block/deposits.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/block
+ */
+
 import assert from "assert";
 import {serialize, signingRoot} from "@chainsafe/ssz";
 
@@ -30,8 +34,6 @@ import {
 
 /**
  * Process an Eth1 deposit, registering a validator or increasing its balance.
- * @param {BeaconState} state
- * @param {Deposit} deposit
  */
 export function processDeposit(state: BeaconState, deposit: Deposit): void {
   // Verify the Merkle branch

--- a/src/chain/stateTransition/block/eth1Data.ts
+++ b/src/chain/stateTransition/block/eth1Data.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/block
+ */
+
 import {serialize} from "@chainsafe/ssz";
 
 import {

--- a/src/chain/stateTransition/block/index.ts
+++ b/src/chain/stateTransition/block/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/block
+ */
+
 import {
   BeaconBlock,
   BeaconState,

--- a/src/chain/stateTransition/block/proposerSlashings.ts
+++ b/src/chain/stateTransition/block/proposerSlashings.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/block
+ */
+
 import assert from "assert";
 
 import {serialize, signingRoot} from "@chainsafe/ssz";

--- a/src/chain/stateTransition/block/randao.ts
+++ b/src/chain/stateTransition/block/randao.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/block
+ */
+
 import assert from "assert";
 import xor from "buffer-xor";
 import {hashTreeRoot} from "@chainsafe/ssz";

--- a/src/chain/stateTransition/block/rootVerification.ts
+++ b/src/chain/stateTransition/block/rootVerification.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/block
+ */
+
 import assert from "assert";
 import {hashTreeRoot} from "@chainsafe/ssz";
 

--- a/src/chain/stateTransition/block/transfers.ts
+++ b/src/chain/stateTransition/block/transfers.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/block
+ */
+
 import assert from "assert";
 import BN from "bn.js";
 import {signingRoot} from "@chainsafe/ssz";
@@ -32,9 +36,8 @@ import {
 
 /**
  * Process ``Transfer`` operation.
+ *
  * Note that this function mutates ``state``.
- * @param {BeaconState} state
- * @param {Transfer} transfer
  */
 export function processTransfer(state: BeaconState, transfer: Transfer): void {
   // Verify the amount and fee aren't individually too big (for anti-overflow purposes)

--- a/src/chain/stateTransition/block/voluntaryExits.ts
+++ b/src/chain/stateTransition/block/voluntaryExits.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/block
+ */
+
 import assert from "assert";
 import {signingRoot} from "@chainsafe/ssz";
 
@@ -26,9 +30,8 @@ import {
 
 /**
  * Process ``VoluntaryExit`` operation.
+ *
  * Note that this function mutates ``state``.
- * @param {BeaconState} state
- * @param {VoluntaryExit} exit
  */
 export function processVoluntaryExit(state: BeaconState, exit: VoluntaryExit): void {
   const validator = state.validatorRegistry[exit.validatorIndex];

--- a/src/chain/stateTransition/epoch/balanceUpdates/attestation.ts
+++ b/src/chain/stateTransition/epoch/balanceUpdates/attestation.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/epoch
+ */
+
 import BN from "bn.js";
 
 import {BeaconState, Gwei} from "../../../../types";

--- a/src/chain/stateTransition/epoch/balanceUpdates/baseReward.ts
+++ b/src/chain/stateTransition/epoch/balanceUpdates/baseReward.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/epoch
+ */
+
 import BN from "bn.js";
 
 import {BeaconState, Gwei, ValidatorIndex} from "../../../../types";

--- a/src/chain/stateTransition/epoch/balanceUpdates/crosslink.ts
+++ b/src/chain/stateTransition/epoch/balanceUpdates/crosslink.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/epoch
+ */
+
 import BN from "bn.js";
 
 import {BeaconState, Gwei} from "../../../../types";

--- a/src/chain/stateTransition/epoch/balanceUpdates/index.ts
+++ b/src/chain/stateTransition/epoch/balanceUpdates/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/epoch
+ */
+
 import {BeaconState} from "../../../../types";
 import {GENESIS_EPOCH} from "../../../../constants";
 import {getCurrentEpoch, increaseBalance, decreaseBalance} from "../../util";

--- a/src/chain/stateTransition/epoch/crosslinks.ts
+++ b/src/chain/stateTransition/epoch/crosslinks.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/epoch
+ */
+
 import {BeaconState} from "../../../types";
 import {
   getCrosslinkCommitteesAtSlot,

--- a/src/chain/stateTransition/epoch/finalUpdates.ts
+++ b/src/chain/stateTransition/epoch/finalUpdates.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/epoch
+ */
+
 import BN from "bn.js";
 import {hashTreeRoot} from "@chainsafe/ssz";
 

--- a/src/chain/stateTransition/epoch/index.ts
+++ b/src/chain/stateTransition/epoch/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/epoch
+ */
+
 import assert from "assert";
 
 import {BeaconState} from "../../../types";

--- a/src/chain/stateTransition/epoch/justification.ts
+++ b/src/chain/stateTransition/epoch/justification.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/epoch
+ */
+
 import BN from "bn.js";
 
 import {BeaconState} from "../../../types";

--- a/src/chain/stateTransition/epoch/registryUpdates.ts
+++ b/src/chain/stateTransition/epoch/registryUpdates.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/epoch
+ */
+
 import {BeaconState} from "../../../types";
 import {FAR_FUTURE_EPOCH, MAX_EFFECTIVE_BALANCE, EJECTION_BALANCE} from "../../../constants";
 

--- a/src/chain/stateTransition/epoch/slashings.ts
+++ b/src/chain/stateTransition/epoch/slashings.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/epoch
+ */
+
 import {BeaconState} from "../../../types";
 
 import {
@@ -14,8 +18,8 @@ import {
 
 /**
  * Process the slashings.
+ *
  * Note that this function mutates ``state``.
- * @param {BeaconState} state
  */
 export function processSlashings(state: BeaconState): void {
   const currentEpoch = getCurrentEpoch(state);

--- a/src/chain/stateTransition/epoch/util.ts
+++ b/src/chain/stateTransition/epoch/util.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/epoch/util
+ */
+
 import assert from "assert";
 import {deserialize, serialize, hashTreeRoot} from "@chainsafe/ssz";
 

--- a/src/chain/stateTransition/index.ts
+++ b/src/chain/stateTransition/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition
+ */
+
 import {
   BeaconBlock,
   BeaconState,

--- a/src/chain/stateTransition/slot.ts
+++ b/src/chain/stateTransition/slot.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/slot
+ */
+
 import {hashTreeRoot, signingRoot} from "@chainsafe/ssz";
 
 import {

--- a/src/chain/stateTransition/util/attestation.ts
+++ b/src/chain/stateTransition/util/attestation.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/util
+ */
+
 import {hashTreeRoot} from "@chainsafe/ssz";
 import assert from "assert";
 
@@ -30,10 +34,6 @@ import {getDomain} from "./misc";
 
 /**
  * Return the sorted attesting indices corresponding to ``attestation_data`` and ``bitfield``.
- * @param {BeaconState} state
- * @param {AttestationData} attestationData
- * @param {bytes} bitfield
- * @returns {ValidatorIndex[]}
  */
 export function getAttestingIndices(state: BeaconState, attestationData: AttestationData, bitfield: bytes): ValidatorIndex[] {
   const crosslinkCommittees = getCrosslinkCommitteesAtSlot(state, attestationData.slot);
@@ -50,9 +50,6 @@ export function getAttestingIndices(state: BeaconState, attestationData: Attesta
 
 /**
  * Returns the ith bit in bitfield
- * @param {bytes} bitfield
- * @param {number} i
- * @returns {number}
  */
 export function getBitfieldBit(bitfield: bytes, i: number): number {
   const bit = i % 8;
@@ -62,9 +59,6 @@ export function getBitfieldBit(bitfield: bytes, i: number): number {
 
 /**
  * Verify ``bitfield`` against the ``committee_size``.
- * @param {bytes} bitfield
- * @param {number} committeeSize
- * @returns {boolean}
  */
 export function verifyBitfield(bitfield: bytes, committeeSize: number): boolean {
   if (bitfield.length !== intDiv(committeeSize + 7, 8)) {
@@ -82,9 +76,6 @@ export function verifyBitfield(bitfield: bytes, committeeSize: number): boolean 
 
 /**
  * Convert ``attestation`` to (almost) indexed-verifiable form.
- * @param {BeaconState} state
- * @param {Attestation} attestation
- * @returns {IndexedAttestation}
  */
 export function convertToIndexed(state: BeaconState, attestation: Attestation): IndexedAttestation {
   const attestingIndices = getAttestingIndices(state, attestation.data, attestation.aggregationBitfield);
@@ -101,9 +92,6 @@ export function convertToIndexed(state: BeaconState, attestation: Attestation): 
 
 /**
  * Verify validity of ``indexed_attestation`` fields.
- * @param {BeaconState} state
- * @param {IndexedAttestation} indexedAttestation
- * @returns {bool}
  */
 export function verifyIndexedAttestation(state: BeaconState, indexedAttestation: IndexedAttestation): bool {
   const custodyBit0Indices = indexedAttestation.custodyBit0Indices;

--- a/src/chain/stateTransition/util/balance.ts
+++ b/src/chain/stateTransition/util/balance.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/util
+ */
+
 import BN from "bn.js";
 
 import {
@@ -9,9 +13,6 @@ import {
 
 /**
  * Increase the balance for a validator with the given ``index`` by ``delta``.
- * @param {BeaconState} state
- * @param {ValidatorIndex} index
- * @param {Gwei} delta
  */
 export function increaseBalance(state: BeaconState, index: ValidatorIndex, delta: Gwei): void {
   state.balances[index] = state.balances[index].add(delta);
@@ -19,10 +20,8 @@ export function increaseBalance(state: BeaconState, index: ValidatorIndex, delta
 
 /**
  * Decrease the balance for a validator with the given ``index`` by ``delta``.
+ *
  * Set to ``0`` when underflow.
- * @param {BeaconState} state
- * @param {ValidatorIndex} index
- * @param {Gwei} delta
  */
 export function decreaseBalance(state: BeaconState, index: ValidatorIndex, delta: Gwei): void {
   const currentBalance = state.balances[index];
@@ -33,9 +32,6 @@ export function decreaseBalance(state: BeaconState, index: ValidatorIndex, delta
 
 /**
  * Return the combined effective balance of an array of validators.
- * @param {BeaconState} state
- * @param {ValidatorIndex[]} validators
- * @returns {Gwei}
  */
 export function getTotalBalance(state: BeaconState, indices: ValidatorIndex[]): Gwei {
   return indices.reduce((total: Gwei, index: ValidatorIndex): Gwei =>

--- a/src/chain/stateTransition/util/crosslinkCommittee.ts
+++ b/src/chain/stateTransition/util/crosslinkCommittee.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/util
+ */
+
 import assert from "assert";
 
 import {
@@ -37,11 +41,8 @@ import {generateSeed} from "./seed";
  *
  * Utilizes 'swap or not' shuffling found in
  * https://link.springer.com/content/pdf/10.1007%2F978-3-642-32009-5_1.pdf
+ *
  * See the 'generalized domain' algorithm on page 3.
- * @param {number} index
- * @param {number} listSize
- * @param {seed} bytes32
- * @returns {number}
  */
 export function getPermutedIndex(index: number, listSize: number, seed: bytes32): number {
   let permuted = index;
@@ -69,10 +70,6 @@ export function getPermutedIndex(index: number, listSize: number, seed: bytes32)
 /**
  * Returns a value such that for a list L, chunk count k and index i,
  * split(L, k)[i] == L[get_split_offset(len(L), k, i): get_split_offset(len(L), k, i+1)]
- * @param {number} listSize
- * @param {number} chunks
- * @param {number} index
- * @returns {number}
  */
 export function getSplitOffset(listSize: number, chunks: number, index: number): number {
   return intDiv(listSize * index, chunks);
@@ -80,9 +77,6 @@ export function getSplitOffset(listSize: number, chunks: number, index: number):
 
 /**
  * Return the number of committees in one epoch.
- * @param {BeaconState} state
- * @param {Epoch} epoch
- * @returns {number}
  */
 export function getEpochCommitteeCount(state: BeaconState, epoch: Epoch): number {
   const activeValidatorIndices = getActiveValidatorIndices(state, epoch);
@@ -97,9 +91,6 @@ export function getEpochCommitteeCount(state: BeaconState, epoch: Epoch): number
 
 /**
  * Return the number of shards to increment ``state.latest_start_shard`` during ``epoch``.
- * @param {BeaconState} state
- * @param {Epoch} epoch
- * @returns {number}
  */
 export function getShardDelta(state: BeaconState, epoch: Epoch): number {
   return Math.min(
@@ -111,11 +102,6 @@ export function getShardDelta(state: BeaconState, epoch: Epoch): number {
 /**
  * Return the ``index``'th shuffled committee out of a total ``total_committees``
  * using ``validator_indices`` and ``seed``.
- * @param {ValidatorIndex[]} validatorIndices
- * @param {bytes32} seed
- * @param {number} index
- * @param {number} totalCommittees
- * @returns {ValidatorIndex[]}
  */
 export function computeCommittee(validatorIndices: ValidatorIndex[], seed: bytes32, index: number, totalCommittees: number): ValidatorIndex[] {
   const startOffset = getSplitOffset(validatorIndices.length, totalCommittees, index);
@@ -127,10 +113,6 @@ export function computeCommittee(validatorIndices: ValidatorIndex[], seed: bytes
 
 /**
  * Return the list of (committee, shard) acting as a tuple for the slot.
- * @param {BeaconState} state
- * @param {Slot} slot
- * @param {boolean} registryChange
- * @returns {[]}
  */
 export function getCrosslinkCommitteesAtSlot(state: BeaconState, slot: Slot): [ValidatorIndex[], Shard][] {
   const epoch = slotToEpoch(slot);

--- a/src/chain/stateTransition/util/epoch.ts
+++ b/src/chain/stateTransition/util/epoch.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/util
+ */
+
 import {
   ACTIVATION_EXIT_DELAY,
   GENESIS_EPOCH,
@@ -12,8 +16,6 @@ import {
 
 /**
  * Return the epoch number of the given slot.
- * @param {Slot} slot
- * @returns {Epoch}
  */
 export function slotToEpoch(slot: Slot): Epoch {
   return Math.floor(slot / SLOTS_PER_EPOCH);
@@ -21,8 +23,6 @@ export function slotToEpoch(slot: Slot): Epoch {
 
 /**
  * Return the previous epoch of the given state.
- * @param {BeaconState} state
- * @returns {Epoch}
  */
 export function getPreviousEpoch(state: BeaconState): Epoch {
   const currentEpoch = getCurrentEpoch(state);
@@ -34,8 +34,6 @@ export function getPreviousEpoch(state: BeaconState): Epoch {
 
 /**
  * Return the current epoch of the given state.
- * @param {BeaconState} state
- * @returns {Epoch}
  */
 export function getCurrentEpoch(state: BeaconState): Epoch {
   return slotToEpoch(state.slot);
@@ -43,8 +41,6 @@ export function getCurrentEpoch(state: BeaconState): Epoch {
 
 /**
  * Return the starting slot of the given epoch.
- * @param {Epoch} epoch
- * @returns {Slot}
  */
 export function getEpochStartSlot(epoch: Epoch): Slot {
   return epoch * SLOTS_PER_EPOCH;
@@ -52,8 +48,6 @@ export function getEpochStartSlot(epoch: Epoch): Slot {
 
 /**
  * Return the epoch at which an activation or exit triggered in ``epoch`` takes effect.
- * @param {Epoch} epoch
- * @returns {Epoch}
  */
 export function getDelayedActivationExitEpoch(epoch: Epoch): Epoch {
   return epoch + 1 + ACTIVATION_EXIT_DELAY;

--- a/src/chain/stateTransition/util/index.ts
+++ b/src/chain/stateTransition/util/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/util
+ */
+
 export * from "./epoch";
 export * from "./validator";
 export * from "./validatorStatus";

--- a/src/chain/stateTransition/util/misc.ts
+++ b/src/chain/stateTransition/util/misc.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/util
+ */
+
 import assert from "assert";
 
 import {
@@ -38,9 +42,6 @@ import {hashTreeRoot} from "@chainsafe/ssz";
 
 /**
  * Return the block root at a recent ``slot``.
- * @param {BeaconState} state
- * @param {Slot} slot
- * @returns {bytes32}
  */
 export function getBlockRootAtSlot(state: BeaconState, slot: Slot): bytes32 {
   assert(slot < state.slot);
@@ -50,9 +51,6 @@ export function getBlockRootAtSlot(state: BeaconState, slot: Slot): bytes32 {
 
 /**
  * Return the block root at a recent ``epoch``.
- * @param {BeaconState} state
- * @param {Epoch} epoch
- * @returns {bytes32}
  */
 export function getBlockRoot(state: BeaconState, epoch: Epoch): bytes32 {
   return getBlockRootAtSlot(state, getEpochStartSlot(epoch));
@@ -60,9 +58,6 @@ export function getBlockRoot(state: BeaconState, epoch: Epoch): bytes32 {
 
 /**
  * Return the state root at a recent ``slot``.
- * @param {BeaconState} state
- * @param {Slot} slot
- * @returns {bytes32}
  */
 export function getStateRoot(state: BeaconState, slot: Slot): bytes32 {
   assert(slot < state.slot);
@@ -72,8 +67,6 @@ export function getStateRoot(state: BeaconState, slot: Slot): bytes32 {
 
 /**
  * Return the beacon proposer index at ``state.slot``.
- * @param {BeaconState} state
- * @returns {ValidatorIndex}
  */
 export function getBeaconProposerIndex(state: BeaconState): ValidatorIndex {
   const currentEpoch = getCurrentEpoch(state);
@@ -96,12 +89,6 @@ export function getBeaconProposerIndex(state: BeaconState): ValidatorIndex {
 /**
  * Verify that the given ``leaf`` is on the merkle branch ``proof``
  * starting with the given ``root``.
- * @param {bytes32} leaf
- * @param {bytes32[]} proof
- * @param {number} depth
- * @param {number} index
- * @param {bytes32} root
- * @returns {bool}
  */
 export function verifyMerkleBranch(leaf: bytes32, proof: bytes32[], depth: number, index: number, root: bytes32): boolean {
   let value = leaf;
@@ -117,10 +104,6 @@ export function verifyMerkleBranch(leaf: bytes32, proof: bytes32[], depth: numbe
 
 /**
  * Return the signature domain (fork version concatenated with domain type) of a message.
- * @param {Fork} fork
- * @param {Epoch} epoch
- * @param {number} domainType
- * @returns {bytes8}
  */
 export function getDomain(state: BeaconState, domainType: number, messageEpoch: Epoch | null = null): bytes8 {
   const epoch = messageEpoch || getCurrentEpoch(state);
@@ -131,8 +114,7 @@ export function getDomain(state: BeaconState, domainType: number, messageEpoch: 
 }
 
 /**
- * @param {BeaconState} state
- * @returns {number}
+ * Return the churn limit based on the active validator count.
  */
 export function getChurnLimit(state: BeaconState): number {
   return Math.max(
@@ -143,8 +125,6 @@ export function getChurnLimit(state: BeaconState): number {
 
 /**                       
  * Return the block header corresponding to a block with ``state_root`` set to ``ZERO_HASH``.
- * @param {BeaconBlock} block
- * @returns {BeaconBlockHeader} 
  */                                                                                      
 export function getTemporaryBlockHeader(block: BeaconBlock): BeaconBlockHeader {
   return {

--- a/src/chain/stateTransition/util/seed.ts
+++ b/src/chain/stateTransition/util/seed.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/util
+ */
+
 import assert from "assert";
 
 import {
@@ -21,9 +25,6 @@ import {getCurrentEpoch} from "./epoch";
 
 /**
  * Return the randao mix at a recent epoch.
- * @param {BeaconState} state
- * @param {Epoch} epoch
- * @returns {bytes32}
  */
 export function getRandaoMix(state: BeaconState, epoch: Epoch): bytes32 {
   const currentEpoch = getCurrentEpoch(state);
@@ -36,9 +37,6 @@ export function getRandaoMix(state: BeaconState, epoch: Epoch): bytes32 {
 
 /**
  * Return the index root at a recent epoch.
- * @param {BeaconState} state
- * @param {Epoch} epoch
- * @returns {bytes32}
  */
 export function getActiveIndexRoot(state: BeaconState, epoch: Epoch): bytes32 {
   const currentEpoch = getCurrentEpoch(state);
@@ -51,9 +49,6 @@ export function getActiveIndexRoot(state: BeaconState, epoch: Epoch): bytes32 {
 
 /**
  * Generate a seed for the given epoch.
- * @param {BeaconState} state
- * @param {Epoch} epoch
- * @returns {bytes32}
  */
 export function generateSeed(state: BeaconState, epoch: Epoch): bytes32 {
   return hash(Buffer.concat([

--- a/src/chain/stateTransition/util/slashing.ts
+++ b/src/chain/stateTransition/util/slashing.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/util
+ */
+
 import {
   AttestationData,
   Epoch,
@@ -7,10 +11,7 @@ import {slotToEpoch} from "./epoch";
 
 
 /**
- * Check if attestationData1 and attestationData2 have the same target.
- * @param {AttestationData} attestationData1
- * @param {AttestationData} attestationData2
- * @returns {boolean}
+ * Check if ``attestationData1`` and ``attestationData2`` have the same target.
  */
 export function isDoubleVote(attestationData1: AttestationData, attestationData2: AttestationData): boolean {
   const targetEpoch1: Epoch = slotToEpoch(attestationData1.slot);
@@ -19,10 +20,7 @@ export function isDoubleVote(attestationData1: AttestationData, attestationData2
 }
 
 /**
- * Check if attestationData1 surrounds attestationData2
- * @param {AttestationData} attestationData1
- * @param {AttestationData} attestationData2
- * @returns {boolean}
+ * Check if ``attestationData1`` surrounds ``attestationData2``
  */
 export function isSurroundVote(attestationData1: AttestationData, attestationData2: AttestationData): boolean {
   const sourceEpoch1: Epoch  = attestationData1.sourceEpoch;

--- a/src/chain/stateTransition/util/validator.ts
+++ b/src/chain/stateTransition/util/validator.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/util
+ */
+
 import assert from "assert";
 import {
   BeaconState,
@@ -13,9 +17,6 @@ import {SLOTS_PER_EPOCH} from "../../../constants";
 
 /**
  * Check if validator is active
- * @param {Validator} validator
- * @param {Epoch} epoch
- * @returns {boolean}
  */
 export function isActiveValidator(validator: Validator, epoch: Epoch): boolean {
   return validator.activationEpoch <= epoch && epoch < validator.exitEpoch;
@@ -23,9 +24,6 @@ export function isActiveValidator(validator: Validator, epoch: Epoch): boolean {
 
 /**
  * Check if validator is slashable
- * @param {Validator} validator
- * @param {Epoch} epoch
- * @returns {boolean}
  */
 export function isSlashableValidator(validator: Validator, epoch: Epoch): boolean {
   return (
@@ -37,9 +35,6 @@ export function isSlashableValidator(validator: Validator, epoch: Epoch): boolea
 
 /**
  * Get indices of active validators from validators.
- * @param {BeaconState} state
- * @param {Epoch} epoch
- * @returns {ValidatorIndex[]}
  */
 export function getActiveValidatorIndices(state: BeaconState, epoch: Epoch): ValidatorIndex[] {
   return state.validatorRegistry.reduce((indices, validator, index) => {
@@ -57,11 +52,6 @@ export function getActiveValidatorIndices(state: BeaconState, epoch: Epoch): Val
  * ``assignment[1]`` is the shard to which the committee is assigned
  * ``assignment[2]`` is the slot at which the committee is assigned
  * a beacon block at the assigned slot.
- * @param {BeaconState} state
- * @param {Epoch} epoch
- * @param {ValidatorIndex} validatorIndex
- * @param {boolean} registryChange
- * @returns {{validators: ValidatorIndex[]; shard: Shard; slot: number; isProposer: boolean}}
  */
 export function getCommitteeAssignment(
   state: BeaconState,
@@ -89,10 +79,6 @@ export function getCommitteeAssignment(
 
 /**
  * Checks if a validator is supposed to propose a block
- * @param {BeaconState} state
- * @param {Slot} slot
- * @param {ValidatorIndex} validatorIndex
- * @returns {Boolean}
  */
 export function isProposerAtSlot(
   state: BeaconState,

--- a/src/chain/stateTransition/util/validatorStatus.ts
+++ b/src/chain/stateTransition/util/validatorStatus.ts
@@ -1,3 +1,7 @@
+/**
+ * @module chain/stateTransition/util
+ */
+
 import {
   BeaconState,
   Epoch,
@@ -31,9 +35,8 @@ import {
 
 /**
  * Initiate exit for the validator with the given index.
+ *
  * Note: that this function mutates state.
- * @param {BeaconState} state
- * @param {ValidatorIndex} index
  */
 export function initiateValidatorExit(state: BeaconState, index: ValidatorIndex): void {
   const validator = state.validatorRegistry[index];
@@ -63,10 +66,8 @@ export function initiateValidatorExit(state: BeaconState, index: ValidatorIndex)
 
 /**
  * Slash the validator with index ``slashedIndex``.
+ * 
  * Note that this function mutates ``state``.
- * @param {BeaconState} state
- * @param {ValidatorIndex} shashedIndex
- * @param {ValidatorIndex} whistleblowerIndex
  */
 export function slashValidator(state: BeaconState, slashedIndex: ValidatorIndex, whistleblowerIndex: ValidatorIndex | null = null): void {
   const currentEpoch = getCurrentEpoch(state);

--- a/src/cli/commands/beacon.ts
+++ b/src/cli/commands/beacon.ts
@@ -1,3 +1,7 @@
+/**
+ * @module cli/commands
+ */
+
 import {CliCommand} from "./interface";
 import * as commander from "commander";
 import logger from "../../logger";

--- a/src/cli/commands/deposit.ts
+++ b/src/cli/commands/deposit.ts
@@ -1,3 +1,7 @@
+/**
+ * @module cli/commands
+ */
+
 import {CliCommand} from "./interface";
 import * as commander from "commander";
 import defaults from "../../eth1/defaults";

--- a/src/cli/commands/eth1-private-network.ts
+++ b/src/cli/commands/eth1-private-network.ts
@@ -1,3 +1,7 @@
+/**
+ * @module cli/commands
+ */
+
 import {CliCommand} from "./interface";
 import {PrivateEth1Network} from "../../eth1/dev";
 import * as commander from "commander";

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module cli/commands
+ */
+
 export * from "./deposit";
 export * from "./eth1-private-network";
 

--- a/src/cli/commands/interface.ts
+++ b/src/cli/commands/interface.ts
@@ -1,3 +1,7 @@
+/**
+ * @module cli/commands
+ */
+
 import {CommanderStatic} from "commander";
 
 export interface CliCommand {

--- a/src/cli/error.ts
+++ b/src/cli/error.ts
@@ -1,3 +1,7 @@
+/**
+ * @module cli
+ */
+
 export class CliError extends Error {
 
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module cli
+ */
+
 // NOTE :: All commands are stubbed as examples
 // Useful repo https://github.com/tsantef/commander-starter
 import program from "commander";

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,3 +1,7 @@
+/**
+ * @module constants
+ */
+
 // Misc
 export const SHARD_COUNT = 2 ** 10; // 1024 shards
 export const TARGET_COMMITTEE_SIZE = 2 ** 7; // 128 validators

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,5 @@
+/**
+ * @module constants
+ */
+
 export * from "./constants";

--- a/src/db/impl/abstract.ts
+++ b/src/db/impl/abstract.ts
@@ -1,3 +1,7 @@
+/**
+ * @module db
+ */
+
 import {EventEmitter} from "events";
 import {DB} from "../interface";
 import {

--- a/src/db/impl/level.ts
+++ b/src/db/impl/level.ts
@@ -1,3 +1,7 @@
+/**
+ * @module db
+ */
+
 import level from "level";
 import {LevelUp} from "levelup";
 

--- a/src/db/impl/pouch.ts
+++ b/src/db/impl/pouch.ts
@@ -1,3 +1,7 @@
+/**
+ * @module db
+ */
+
 import {DBOptions} from "../interface";
 
 import PouchDB from "pouchdb-core";

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module db
+ */
+
 export {DB, DBOptions} from "./interface";
 export {LevelDB, LevelDBOptions} from "./impl/level";
 export {PouchDb} from "./impl/pouch";

--- a/src/db/interface.ts
+++ b/src/db/interface.ts
@@ -1,3 +1,7 @@
+/**
+ * @module db
+ */
+
 import {EventEmitter} from "events";
 
 import {
@@ -26,7 +30,6 @@ export interface DB extends EventEmitter {
 
   /**
    * Adds deposit to database
-   * @param deposit
    */
   setGenesisDeposit(deposit: Deposit): Promise<void>;
 
@@ -44,46 +47,36 @@ export interface DB extends EventEmitter {
 
   /**
    * Get the beacon chain state
-   * @returns {Promise<BeaconState>}
    */
   getState(): Promise<BeaconState>;
 
   /**
    * Set the beacon chain state
-   * @param {BeaconState} state
-   * @returns {Promise<void>}
    */
   setState(state: BeaconState): Promise<void>;
 
   /**
    * Get the last finalized state
-   * @returns {Promise<BeaconState>}
    */
   getFinalizedState(): Promise<BeaconState>;
 
   /**
    * Set the last justified state
-   * @param {BeaconState} state
-   * @returns {Promise<void>}
    */
   setJustifiedState(state: BeaconState): Promise<void>;
 
   /**
    * Get the last justified state
-   * @returns {Promise<BeaconState>}
    */
   getJustifiedState(): Promise<BeaconState>;
 
   /**
    * Set the last finalized state
-   * @param {BeaconState} state
-   * @returns {Promise<void>}
    */
   setFinalizedState(state: BeaconState): Promise<void>;
 
   /**
    * Get a block by block hash
-   * @returns {Promise<BeaconBlock>}
    */
   getBlock(blockRoot: bytes32): Promise<BeaconBlock>;
 
@@ -91,160 +84,121 @@ export interface DB extends EventEmitter {
 
   /**
    * Get a block by slot
-   * @returns {Promise<BeaconBlock>}
    */
   getBlockBySlot(slot: Slot): Promise<BeaconBlock>;
 
   /**
    * Put a block into the db
-   * @param {BeaconBlock} block
-   * @returns {Promise<void>}
    */
   setBlock(block: BeaconBlock): Promise<void>;
 
   /**
    * Get the latest finalized block
-   * @returns {Promise<BeaconBlock>}
    */
   getFinalizedBlock(): Promise<BeaconBlock>;
 
   /**
    * Set the latest finalized block
-   * @param {BeaconBlock} block
-   * @returns {Promise<void>}
    */
   setFinalizedBlock(block: BeaconBlock): Promise<void>;
 
   /**
    * Get the latest justified block
-   * @returns {Promise<BeaconBlock>}
    */
   getJustifiedBlock(): Promise<BeaconBlock>;
 
   /**
    * Set the latest justified block
-   * @param {BeaconBlock} block
-   * @returns {Promise<void>}
    */
   setJustifiedBlock(block: BeaconBlock): Promise<void>;
 
   /**
    * Get the head of the chain
-   * @returns {Promise<BeaconBlock>}
    */
   getChainHead(): Promise<BeaconBlock>;
 
   /**
    * Get the root of the head of the chain
-   * @returns {Promise<bytes32>}
    */
   getChainHeadRoot(): Promise<bytes32>;
 
   /**
    * Set the head of the chain
-   * @param {BeaconState} state
-   * @param {BeaconBlock} block
-   * @returns {Promise<void>}
    */
   setChainHead(state: BeaconState, block: BeaconBlock): Promise<void>;
 
   /**
    * Fetch all attestations
-   * @returns {Promise<Attestation[]>}
    */
   getAttestations(): Promise<Attestation[]>;
 
   /**
    * Put an attestation into the db
-   * @param {Attestation} attestation
-   * @returns {Promise<void>}
    */
   setAttestation(attestation: Attestation): Promise<void>;
 
   /**
    * Delete attestations from the db
-   * @param {Attestation[]} attestations
-   * @returns {Promise<void>}
    */
   deleteAttestations(attestations: Attestation[]): Promise<void>;
 
   /**
    * Fetch all voluntary exits
-   * @returns {Promise<VoluntaryExit[]>}
    */
   getVoluntaryExits(): Promise<VoluntaryExit[]>;
 
   /**
    * Put a voluntary exit into the db
-   * @param {VoluntaryExit} exit
-   * @returns {Promise<void>}
    */
   setVoluntaryExit(exit: VoluntaryExit): Promise<void>;
 
   /**
    * Delete voluntary exits from the db
-   * @param {VoluntaryExit[]} exits
-   * @returns {Promise<void>}
    */
   deleteVoluntaryExits(exits: VoluntaryExit[]): Promise<void>;
 
   /**
    * Fetch all transfers
-   * @returns {Promise<Transfer[]>}
    */
   getTransfers(): Promise<Transfer[]>;
 
   /**
    * Put a transfer into the db
-   * @param {Transfer} transfer
-   * @returns {Promise<void>}
    */
   setTransfer(transfer: Transfer): Promise<void>;
 
   /**
    * Delete transfers from the db
-   * @param {Transfer[]} transfers
-   * @returns {Promise<void>}
    */
   deleteTransfers(transfers: Transfer[]): Promise<void>;
 
   /**
    * Fetch all proposer slashings
-   * @returns {Promise<ProposerSlashing[]>}
    */
   getProposerSlashings(): Promise<ProposerSlashing[]>;
 
   /**
    * Put a proposer slashing into the db
-   * @param {ProposerSlashing} proposerSlashing
-   * @returns {Promise<void>}
    */
   setProposerSlashing(proposerSlashing: ProposerSlashing): Promise<void>;
 
   /**
    * Delete attestations from the db
-   * @param {ProposerSlashing[]} proposerSlashings
-   * @returns {Promise<void>}
    */
   deleteProposerSlashings(proposerSlashings: ProposerSlashing[]): Promise<void>;
 
   /**
    * Fetch all attester slashings
-   * @returns {Promise<AttesterSlashing[]>}
    */
   getAttesterSlashings(): Promise<AttesterSlashing[]>;
 
   /**
    * Put an attester slashing into the db
-   * @param {AttesterSlashing} attesterSlashing
-   * @returns {Promise<void>}
    */
   setAttesterSlashing(attesterSlashing: AttesterSlashing): Promise<void>;
 
   /**
    * Delete attester slashings from the db
-   * @param {AttesterSlashing[]} attesterSlashings
-   * @returns {Promise<void>}
    */
   deleteAttesterSlashings(attesterSlashings: AttesterSlashing[]): Promise<void>;
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,3 +1,7 @@
+/**
+ * @module db/schema
+ */
+
 import BN from "bn.js";
 
 // Buckets are separate database namespaces

--- a/src/eth1/defaults.ts
+++ b/src/eth1/defaults.ts
@@ -1,3 +1,7 @@
+/**
+ * @module eth1
+ */
+
 import {ethers} from "ethers";
 import {DEPOSIT_CONTRACT_ADDRESS} from "../constants";
 

--- a/src/eth1/dev/defaults.ts
+++ b/src/eth1/dev/defaults.ts
@@ -1,3 +1,7 @@
+/**
+ * @module eth1/dev
+ */
+
 export const networkOpts =  {
   port: 8545,
   networkId: 200,

--- a/src/eth1/dev/index.ts
+++ b/src/eth1/dev/index.ts
@@ -1,1 +1,5 @@
+/**
+ * @module eth1/dev
+ */
+
 export * from "./network";

--- a/src/eth1/dev/network.ts
+++ b/src/eth1/dev/network.ts
@@ -1,3 +1,7 @@
+/**
+ * @module eth1/dev
+ */
+
 import ganache from "ganache-core";
 import {promisify} from "util";
 import logger from "../../logger";

--- a/src/eth1/impl/ethers.ts
+++ b/src/eth1/impl/ethers.ts
@@ -1,3 +1,7 @@
+/**
+ * @module eth1
+ */
+
 import BN from "bn.js";
 import {EventEmitter} from "events";
 import {Contract, ethers} from "ethers";

--- a/src/eth1/index.ts
+++ b/src/eth1/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module eth1
+ */
+
 export {Eth1Notifier, Eth1Options} from "./interface";
 export {EthersEth1Notifier, EthersEth1Options} from "./impl/ethers";
 export {Eth1Wallet} from "./wallet";

--- a/src/eth1/interface.ts
+++ b/src/eth1/interface.ts
@@ -1,3 +1,7 @@
+/**
+ * @module eth1
+ */
+
 import {EventEmitter} from "events";
 
 import {bytes32, Deposit, number64} from "../types";

--- a/src/eth1/wallet.ts
+++ b/src/eth1/wallet.ts
@@ -1,3 +1,7 @@
+/**
+ * @module eth1
+ */
+
 import defaults from "./defaults";
 import {ContractTransaction, ethers, Wallet} from "ethers";
 import {Provider} from "ethers/providers";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,5 @@
+/**
+ * @private
+ */
+
 import "./cli";

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module logger
+ */
+
 import logger from "./winston";
 export * from "./winston";
 export {LogLevel, AbstractLogger} from "./interface";

--- a/src/logger/interface.ts
+++ b/src/logger/interface.ts
@@ -1,3 +1,7 @@
+/**
+ * @module logger
+ */
+
 export enum LogLevel {
   DEBUG = 'debug',
   INFO = 'info',

--- a/src/logger/winston.ts
+++ b/src/logger/winston.ts
@@ -1,3 +1,7 @@
+/**
+ * @module logger
+ */
+
 import {AbstractLogger, LogLevel} from "./interface";
 import {createLogger, Logger, transports, format} from 'winston';
 

--- a/src/node/defaults.ts
+++ b/src/node/defaults.ts
@@ -1,3 +1,7 @@
+/**
+ * @module node
+ */
+
 import eth1Defaults from "../eth1/defaults";
 import p2pDefaults from "../p2p/defaults";
 

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module node
+ */
+
 import deepmerge from "deepmerge";
 import {LevelDB} from "../db";
 import {Eth1Options, EthersEth1Notifier} from "../eth1";

--- a/src/opPool/index.ts
+++ b/src/opPool/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module opPool
+ */
+
 import {EventEmitter} from "events";
 
 import {Attestation, VoluntaryExit, Transfer, ProposerSlashing, AttesterSlashing, BeaconBlock, Slot} from "../types";

--- a/src/p2p/defaults.ts
+++ b/src/p2p/defaults.ts
@@ -1,3 +1,7 @@
+/**
+ * @module p2p
+ */
+
 import PeerBook from "peer-book";
 
 export default {

--- a/src/p2p/index.ts
+++ b/src/p2p/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module p2p
+ */
+
 import {EventEmitter} from "events";
 import {Service} from "../node";
 import {LodestarNode} from "./node";

--- a/src/p2p/node.ts
+++ b/src/p2p/node.ts
@@ -1,3 +1,7 @@
+/**
+ * @module p2p
+ */
+
 import LibP2p from "libp2p";
 import {TCP} from "libp2p-tcp";
 import {Mplex} from "libp2p-mplex";

--- a/src/rpc/api/beacon/beacon.ts
+++ b/src/rpc/api/beacon/beacon.ts
@@ -1,3 +1,7 @@
+/**
+ * @module rpc/api
+ */
+
 import {IBeaconApi} from "./interface";
 import {BeaconBlock, BeaconState, bytes32, Fork, number64, SyncingStatus} from "../../../types";
 import {BeaconChain} from "../../../chain";

--- a/src/rpc/api/beacon/index.ts
+++ b/src/rpc/api/beacon/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module rpc/api
+ */
+
 import {BeaconApi} from "./beacon";
 import {IBeaconApi} from "./interface";
 

--- a/src/rpc/api/beacon/interface.ts
+++ b/src/rpc/api/beacon/interface.ts
@@ -1,3 +1,7 @@
+/**
+ * @module rpc/api
+ */
+
 import {IApi} from "../interface";
 import {BeaconBlock, BeaconState, bytes32, Fork, number64, SyncingStatus} from "../../../types";
 
@@ -6,21 +10,20 @@ export interface IBeaconApi extends IApi{
   /**
    * Requests that the BeaconNode identify information about its
    * implementation in a format similar to a HTTP User-Agent field.
-   * @returns {Promise<bytes32>} An ASCII-encoded hex string which
+   * @returns An ASCII-encoded hex string which
    * uniquely defines the implementation of the BeaconNode and its current software version.
    */
   getClientVersion(): Promise<bytes32>;
 
   /**
    * Requests the BeaconNode to provide which fork version it is currently on.
-   * @returns {Promise<{fork: Fork; chainId: uint64}>}
    */
   getFork(): Promise<Fork>;
 
   /**
    * Requests the genesis_time parameter from the BeaconNode,
    * which should be consistent across all BeaconNodes that follow the same beacon chain.
-   * @returns {Promise<uint64>} The genesis_time,
+   * @returns The genesis_time,
    * which is a fairly static configuration option for the BeaconNode.
    */
   getGenesisTime(): Promise<number64>;
@@ -29,7 +32,7 @@ export interface IBeaconApi extends IApi{
    * Requests the BeaconNode to describe if it's currently syncing or not,
    * and if it is, what block it is up to.
    * This is modelled after the Eth1.0 JSON-RPC eth_syncing call.
-   * @returns {Promise<boolean | SyncingStatus>} Either false if the node is not syncing,
+   * @returns Either false if the node is not syncing,
    * or a SyncingStatus object if it is.
    */
   getSyncingStatus(): Promise<boolean | SyncingStatus>;

--- a/src/rpc/api/index.ts
+++ b/src/rpc/api/index.ts
@@ -1,2 +1,6 @@
+/**
+ * @module rpc/api
+ */
+
 export * from "./validator";
 export * from "./beacon";

--- a/src/rpc/api/interface.ts
+++ b/src/rpc/api/interface.ts
@@ -1,3 +1,7 @@
+/**
+ * @module rpc/api
+ */
+
 export interface IApi {
   /**
    * Name space for API commands

--- a/src/rpc/api/validator/index.ts
+++ b/src/rpc/api/validator/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module rpc/api
+ */
+
 import {ValidatorApi} from "./validator";
 import {IValidatorApi} from "./interface";
 

--- a/src/rpc/api/validator/interface.ts
+++ b/src/rpc/api/validator/interface.ts
@@ -1,6 +1,7 @@
 /**
- * The API interface defines the calls that can be made from a Validator
+ * @module rpc/api
  */
+
 import {
   Attestation,
   AttestationData,
@@ -20,57 +21,45 @@ import {
 import {IApi} from "../interface";
 import {CommitteeAssignment} from "../../../validator/types";
 
+/**
+ * The API interface defines the calls that can be made from a Validator
+ */
 export interface IValidatorApi extends IApi {
 
   /**
    * Requests the BeaconNode to provide a set of “duties”, which are actions that should be performed by ValidatorClients. This API call should be polled at every slot, to ensure that any chain reorganisations are catered for, and to ensure that the currently connected BeaconNode is properly synchronised.
-   * @param {bytes48[]} validatorPubkey
-   * @returns {Promise<{currentVersion: bytes4; validatorDuty: ValidatorDuty}>} A list of unique validator public keys, where each item is a 0x encoded hex string.
+   * @returns A list of unique validator public keys, where each item is a 0x encoded hex string.
    */
   getDuties(validatorPubkey: bytes48): Promise<{currentVersion: Fork; validatorDuty: ValidatorDuty}>;
 
   /**
    * Requests to check if a validator should propose for a given slot.
-   * @param {bytes48} validatorPubkey
-   * @param {Slot} slot
-   * @returns {Promise<{slot: Slot, proposer: boolean}}
    */
   isProposer(index: ValidatorIndex, slot: Slot): Promise<boolean>;
 
   /**
    * Requests a validators committeeAssignment, can be used for past, current and one epoch in the future
-   * @param {ValidatorIndex} index
-   * @param {Epoch} epoch
    */
   getCommitteeAssignment(index: ValidatorIndex, epoch: Epoch): Promise<CommitteeAssignment>;
 
   /**
    * Requests a BeaconNode to produce a valid block, which can then be signed by a ValidatorClient.
-   * @param {Slot} slot
-   * @param {bytes} randaoReveal
-   * @returns {Promise<BeaconBlock>} A proposed BeaconBlock object, but with the signature field left blank.
+   * @returns A proposed BeaconBlock object, but with the signature field left blank.
    */
   produceBlock(slot: Slot, randaoReveal: bytes): Promise<BeaconBlock>;
 
   /**
    * Requests that the BeaconNode produce an IndexedAttestation, with a blank signature field, which the ValidatorClient will then sign.
-   * @param {Slot} slot
-   * @param {Shard} shard
-   * @returns {Promise<Attestation>}
    */
   produceAttestation(slot: Slot, shard: Shard): Promise<AttestationData>;
 
   /**
    * Instructs the BeaconNode to publish a newly signed beacon block to the beacon network, to be included in the beacon chain.
-   * @param {BeaconBlock} beaconBlock
-   * @returns {Promise<void>}
    */
   publishBlock(beaconBlock: BeaconBlock): Promise<void>;
 
   /**
    * Instructs the BeaconNode to publish a newly signed IndexedAttestation object, to be incorporated into the beacon chain.
-   * @param {Attestation} attestation
-   * @returns {Promise<void>}
    */
   publishAttestation(attestation: Attestation): Promise<void>;
 }

--- a/src/rpc/api/validator/validator.ts
+++ b/src/rpc/api/validator/validator.ts
@@ -1,3 +1,7 @@
+/**
+ * @module rpc/api
+ */
+
 import {
   Attestation,
   AttestationData,

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module rpc
+ */
+
 export * from "./api";
 export * from "./transport";
 export * from "./protocol";

--- a/src/rpc/protocol/index.ts
+++ b/src/rpc/protocol/index.ts
@@ -1,1 +1,5 @@
+/**
+ * @module rpc/protocol
+ */
+
 export * from "./jsonRpc";

--- a/src/rpc/protocol/jsonRpc.ts
+++ b/src/rpc/protocol/jsonRpc.ts
@@ -1,3 +1,7 @@
+/**
+ * @module rpc/protocol
+ */
+
 import * as jsonRpc from "noice-json-rpc";
 
 import {IApi} from "../api/interface";

--- a/src/rpc/transport/http.ts
+++ b/src/rpc/transport/http.ts
@@ -1,3 +1,7 @@
+/**
+ * @module rpc/transport
+ */
+
 import {LikeSocketServer} from "../protocol";
 import {LikeSocket} from "noice-json-rpc";
 import http from "http";

--- a/src/rpc/transport/index.ts
+++ b/src/rpc/transport/index.ts
@@ -1,2 +1,6 @@
+/**
+ * @module rpc/transport
+ */
+
 export * from "./ws";
 export * from "./http";

--- a/src/rpc/transport/ws.ts
+++ b/src/rpc/transport/ws.ts
@@ -1,3 +1,7 @@
+/**
+ * @module rpc/transport
+ */
+
 import * as http from "http";
 import promisify from "promisify-es6";
 import WebSocket from "ws";

--- a/src/stubs/bls.ts
+++ b/src/stubs/bls.ts
@@ -1,3 +1,7 @@
+/**
+ * @module stubs
+ */
+
 import {
   bool,
   bytes8,

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module sync
+ */
+
 import {EventEmitter} from "events";
 
 /**

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -1,3 +1,7 @@
+/**
+ * @module types
+ */
+
 // Each type exported here contains both a compile-time type (a typescript interface) and a run-time ssz type (a javascript variable)
 // For more information, see ./index.ts
 import {SimpleContainerType} from "@chainsafe/ssz";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module types
+ */
+
 /*
 Each type exported here contains both a compile-time type (a typescript
 interface) and a run-time ssz type (a javascript variable)

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -1,3 +1,7 @@
+/**
+ * @module types
+ */
+
 // Each type exported here contains both a compile-time type (a typescript interface) and a run-time ssz type (a javascript variable)
 // For more information, see ./index.ts
 import {SimpleContainerType} from "@chainsafe/ssz";

--- a/src/types/operations.ts
+++ b/src/types/operations.ts
@@ -1,3 +1,7 @@
+/**
+ * @module types
+ */
+
 // Each type exported here contains both a compile-time type (a typescript interface) and a run-time type (a javascript variable)
 // For more information, see ./index.ts
 import {SimpleContainerType} from "@chainsafe/ssz";

--- a/src/types/primitive.ts
+++ b/src/types/primitive.ts
@@ -1,3 +1,7 @@
+/**
+ * @module types
+ */
+
 // Each type exported here contains both a compile-time type (a typescript interface) and a run-time ssz type (a javascript variable)
 // For more information, see ./index.ts
 import BN from "bn.js";

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -1,3 +1,7 @@
+/**
+ * @module types
+ */
+
 // Each type exported here contains both a compile-time type (a typescript interface) and a run-time ssz type (a javascript variable)
 // For more information, see ./index.ts
 import {SimpleContainerType} from "@chainsafe/ssz";

--- a/src/types/validator.ts
+++ b/src/types/validator.ts
@@ -1,3 +1,7 @@
+/**
+ * @module types
+ */
+
 import {bytes48, Shard, Slot, uint64} from "./primitive";
 import {SimpleContainerType} from "@chainsafe/ssz";
 

--- a/src/util/address.ts
+++ b/src/util/address.ts
@@ -1,3 +1,7 @@
+/**
+ * @module util/address
+ */
+
 export function isValidAddress(address: string) {
   return !!address && address.startsWith('0x') && address.length === 42;
 

--- a/src/util/bytes.ts
+++ b/src/util/bytes.ts
@@ -1,12 +1,13 @@
+/**
+ * @module util/bytes
+ */
+
 import BN from "bn.js";
 
 import {bytes} from "../types";
 
 /**
  * Return a byte array from a number or BN
- * @param {BN | number} value
- * @param {number} length
- * @returns {bytes}
  */
 export function intToBytes(value: BN | number, length: number): bytes {
   if (BN.isBN(value)) { // value is BN

--- a/src/util/crypto.ts
+++ b/src/util/crypto.ts
@@ -1,3 +1,7 @@
+/**
+ * @module util/crypto
+ */
+
 import {keccakAsU8a} from "@polkadot/util-crypto";
 
 import {

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -1,10 +1,11 @@
+/**
+ * @module util/math
+ */
+
 import BN from "bn.js";
 
 /**
  * Return the min number between two big numbers.
- * @param {BN} a
- * @param {BN} b
- * @returns {BN}
  */
 export function bnMin(a: BN, b: BN): BN {
   return a.lt(b) ? a : b;
@@ -12,9 +13,6 @@ export function bnMin(a: BN, b: BN): BN {
 
 /**
  * Return the max number between two big numbers.
- * @param {BN} a
- * @param {BN} b
- * @returns {BN}
  */
 export function bnMax(a: BN, b: BN): BN {
   return a.gt(b) ? a : b;
@@ -26,9 +24,6 @@ export function intDiv(dividend: number, divisor: number): number {
 
 /**
  * Calculate the largest integer k such that k**2 <= n.
- * Used in reward/penalty calculations
- * @param {number} n
- * @returns {number}
  */
 export function intSqrt(n: number): number {
   let x = n;

--- a/src/util/objects.ts
+++ b/src/util/objects.ts
@@ -1,3 +1,7 @@
+/**
+ * @module util/objects
+ */
+
 function isObjectObject(val: any): boolean {
   return val != null && typeof val === 'object' && Array.isArray(val) === false;
 }

--- a/src/validator/attestation.ts
+++ b/src/validator/attestation.ts
@@ -1,0 +1,4 @@
+/**
+ * @module validator
+ */
+

--- a/src/validator/block.ts
+++ b/src/validator/block.ts
@@ -1,3 +1,7 @@
+/**
+ * @module validator
+ */
+
 import ssz from "@chainsafe/ssz";
 
 import {ValidatorIndex, BeaconBlock, BeaconState, bytes48} from "../types";
@@ -20,7 +24,6 @@ export default class BlockProcessingService {
 
   /**
    * IFF a validator is selected construct a block to propose.
-   * @returns {Promise<void>}
    */
   public async buildBlock(): Promise<BeaconBlock> {
     let block: BeaconBlock = getEmptyBlock();

--- a/src/validator/constants.ts
+++ b/src/validator/constants.ts
@@ -1,1 +1,5 @@
+/**
+ * @module validator
+ */
+
 export const KEYSTORE_DIR = "./keystores";

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module validator
+ */
+
 import Validator from "./validator";
 
 export default Validator;

--- a/src/validator/stubs/helpers.ts
+++ b/src/validator/stubs/helpers.ts
@@ -1,3 +1,7 @@
+/**
+ * @module validator/stubs
+ */
+
 // This file makes some naive assumptions surrounding the way RPC like calls will be made in ETH2.0
 // Subject to change with future developments with Hobbits and wire protocol
 import {ValidatorIndex, Slot, Epoch, BeaconBlock, BeaconState, bytes48} from "../../types/index";

--- a/src/validator/stubs/rpc.ts
+++ b/src/validator/stubs/rpc.ts
@@ -1,3 +1,7 @@
+/**
+ * @module validator/stubs
+ */
+
 import {
   BeaconBlock, BeaconState, bytes48, Epoch, Shard, Slot,
   ValidatorIndex

--- a/src/validator/types.ts
+++ b/src/validator/types.ts
@@ -1,3 +1,7 @@
+/**
+ * @module validator
+ */
+
 import {bytes48, Slot, Shard, ValidatorIndex} from "../types";
 
 export interface ValidatorCtx {

--- a/src/validator/utils/wallet.ts
+++ b/src/validator/utils/wallet.ts
@@ -1,3 +1,7 @@
+/**
+ * @module validator
+ */
+
 import ethers from "ethers";
 
 export function unlockWallet(keystorePath: string, keystorePassword: string, type: string): Promise<ethers.Wallet> {

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -1,3 +1,7 @@
+/**
+ * @module validator
+ */
+
 // This file makes some naive assumptions surrounding the way RPC like calls will be made in ETH2.0
 /**
  * 1. Setup any necessary connections (RPC,...)
@@ -28,9 +32,6 @@ class Validator {
   private genesisInfo: GenesisInfo;
   public isActive: boolean;
 
-  /**
-   * @param {ValidatorCtx} ctx
-   */
   public constructor(ctx: ValidatorCtx) {
     this.ctx = ctx;
     this.logger = logger;
@@ -52,7 +53,6 @@ class Validator {
 	  
   /**
    * Main method that starts a client.
-   * @returns {Promise<void>}
    */
   public async setup(): Promise<void> {
     this.logger.info("Setting up validator client...");
@@ -77,7 +77,6 @@ class Validator {
 
   /**
    * Recursively checks for the chain start log event from the ETH1.x deposit contract
-   * @returns {Promise<boolean>}
    */
   private async isChainLive(): Promise<boolean> {
     this.logger.info("Checking if chain has started...");
@@ -91,7 +90,6 @@ class Validator {
 
   /**
    * Checks to see if the validator has been processed on the beacon chain.
-   * @returns {Promise<ValidatorIndex>}
    */
   private async getValidatorIndex(): Promise<ValidatorIndex> {
     this.logger.info("Checking if validator has been processed...");
@@ -105,7 +103,6 @@ class Validator {
 
   /**
    * Setups the necessary services.
-   * @returns {Promise<void>}
    */
   private async setupServices(): Promise<void> {
     this.blockService = new BlockProcessingService(this.validatorIndex, this.provider, this.ctx.privateKey);

--- a/yarn.lock
+++ b/yarn.lock
@@ -641,14 +641,12 @@
 "@nodeutils/defaults-deep@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@nodeutils/defaults-deep/-/defaults-deep-1.1.0.tgz#bb1124dc8d7ce0bc5da1d668ace58149258ef20b"
-  integrity sha1-uxEk3I184LxdodZorOWBSSWO8gs=
   dependencies:
     lodash "^4.15.0"
 
 "@polkadot/ts@^0.1.56":
   version "0.1.56"
   resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.56.tgz#ffd6e9c95704a7fb90b918193b9dc5c440114b27"
-  integrity sha512-wnt4zXxZXyz6WaubTO/I+nUElwV2DogFzdl6CrKfVn2PTWp8uHN06W9s40FH57ORtmQfDr9rLRP8Nq+oIyElbg==
 
 "@polkadot/util-crypto@^0.33.27":
   version "0.33.36"
@@ -744,6 +742,30 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
 
+"@types/fs-extra@^5.0.3":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.0.5.tgz#080d90a792f3fa2c5559eb44bd8ef840aae9104b"
+  dependencies:
+    "@types/node" "*"
+
+"@types/glob@*":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
+  dependencies:
+    "@types/events" "*"
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
+"@types/handlebars@^4.0.38":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.1.0.tgz#3fcce9bf88f85fe73dc932240ab3fb682c624850"
+  dependencies:
+    handlebars "*"
+
+"@types/highlight.js@^9.12.3":
+  version "9.12.3"
+  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.3.tgz#b672cfaac25cbbc634a0fd92c515f66faa18dbca"
+
 "@types/ip-regex@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/ip-regex/-/ip-regex-3.0.0.tgz#f06748a44dd47810bb24555958b4b410cfe5abab"
@@ -756,6 +778,18 @@
     "@types/events" "*"
     "@types/node" "*"
 
+"@types/lodash@^4.14.110":
+  version "4.14.123"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.123.tgz#39be5d211478c8dd3bdae98ee75bb7efe4abfe4d"
+
+"@types/marked@^0.4.0":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.4.2.tgz#64a89e53ea37f61cc0f3ee1732c555c2dbf6452f"
+
+"@types/minimatch@*", "@types/minimatch@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
+
 "@types/mocha@^5.2.5":
   version "5.2.6"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.6.tgz#b8622d50557dd155e9f2f634b7d68fd38de5e94b"
@@ -767,6 +801,13 @@
 "@types/node@^10.12.17", "@types/node@^10.3.2":
   version "10.14.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.5.tgz#27733a949f5d9972d87109297cffb62207ace70f"
+
+"@types/shelljs@^0.8.0":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.5.tgz#1e507b2f6d1f893269bd3e851ec24419ef9beeea"
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
 
 "@types/sinon@^7.0.11":
   version "7.0.11"
@@ -802,6 +843,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
+abab@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -809,7 +854,6 @@ abbrev@1:
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
-  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
   dependencies:
     event-target-shim "^5.0.0"
 
@@ -846,7 +890,6 @@ abstract-leveldown@~2.6.0:
 accept@2.x.x:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/accept/-/accept-2.1.4.tgz#887af54ceee5c7f4430461971ec400c61d09acbb"
-  integrity sha1-iHr1TO7lx/RDBGGXHsQAxh0JrLs=
   dependencies:
     boom "5.x.x"
     hoek "4.x.x"
@@ -854,7 +897,6 @@ accept@2.x.x:
 accepts@~1.3.4:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
-  integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
   dependencies:
     mime-types "~2.1.24"
     negotiator "0.6.2"
@@ -866,11 +908,26 @@ accepts@~1.3.5:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
+acorn-globals@^4.1.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.2.tgz#4e2c2313a597fd589720395f6354b41cd5ec8006"
+  dependencies:
+    acorn "^6.0.1"
+    acorn-walk "^6.0.1"
+
 acorn-jsx@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
 
-acorn@^6.0.7:
+acorn-walk@^6.0.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
+
+acorn@^5.5.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
+
+acorn@^6.0.1, acorn@^6.0.7:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
 
@@ -885,7 +942,6 @@ aes-js@^3.1.1:
 after@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
-  integrity sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
 
 agent-base@^4.1.0:
   version "4.2.1"
@@ -905,7 +961,6 @@ ajv@^6.5.5, ajv@^6.9.1:
 ammo@2.x.x:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/ammo/-/ammo-2.0.4.tgz#bf80aab211698ea78f63ef5e7f113dd5d9e8917f"
-  integrity sha1-v4CqshFpjqePY+9efxE91dnokX8=
   dependencies:
     boom "5.x.x"
     hoek "4.x.x"
@@ -994,6 +1049,10 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
 
+array-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -1009,7 +1068,6 @@ array-unique@^0.3.2:
 arraybuffer.slice@~0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
-  integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
 arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
@@ -1018,7 +1076,6 @@ arrify@^1.0.0, arrify@^1.0.1:
 asmcrypto.js@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/asmcrypto.js/-/asmcrypto.js-2.3.2.tgz#b9f84bd0a1fb82f21f8c29cc284a707ad17bba2e"
-  integrity sha512-3FgFARf7RupsZETQ1nHnhLUUvpcttcCq1iZCaVAbJZbCZ5VNRrNyvpDyHTOb0KC3llFcsyOT/a99NZcCbeiEsA==
 
 asn1.js@^4.0.0:
   version "4.10.1"
@@ -1031,7 +1088,6 @@ asn1.js@^4.0.0:
 asn1.js@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.0.1.tgz#7668b56416953f0ce3421adbb3893ace59c96f59"
-  integrity sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==
   dependencies:
     bn.js "^4.0.0"
     inherits "^2.0.1"
@@ -1118,7 +1174,6 @@ aws4@^1.8.0:
 b64@3.x.x:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/b64/-/b64-3.0.3.tgz#36afeee0d9345f046387ce6de8a6702afe5bb56e"
-  integrity sha512-Pbeh0i6OLubPJdIdCepn8ZQHwN2MWznZHbHABSTEfQ706ie+yuxNSaPdqX1xRatT6WanaS1EazMiSg0NUW2XxQ==
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -1588,7 +1643,6 @@ babylon@^6.18.0:
 backo2@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
-  integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
 
 backoff@^2.5.0:
   version "2.5.0"
@@ -1603,7 +1657,6 @@ balanced-match@^1.0.0:
 base-x@3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.4.tgz#94c1788736da065edb1d68808869e357c977fa77"
-  integrity sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==
   dependencies:
     safe-buffer "^5.0.1"
 
@@ -1616,12 +1669,10 @@ base-x@^3.0.2:
 base32.js@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/base32.js/-/base32.js-0.1.0.tgz#b582dec693c2f11e893cf064ee6ac5b6131a2202"
-  integrity sha1-tYLexpPC8R6JPPBk7mrFthMaIgI=
 
 base64-arraybuffer@0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
-  integrity sha1-c5JncZI7Whl0etZmqlzUv5xunOg=
 
 base64-js@^1.0.2:
   version "1.3.0"
@@ -1630,7 +1681,6 @@ base64-js@^1.0.2:
 base64id@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-1.0.0.tgz#47688cb99bb6804f0e06d3e763b1c32e57d8e6b6"
-  integrity sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=
 
 base@^0.11.1:
   version "0.11.2"
@@ -1653,7 +1703,6 @@ bcrypt-pbkdf@^1.0.0:
 better-assert@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/better-assert/-/better-assert-1.0.2.tgz#40866b9e1b9e0b55b481894311e68faffaebc522"
-  integrity sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=
   dependencies:
     callsite "1.0.0"
 
@@ -1664,7 +1713,6 @@ bignumber.js@^7.2.1:
 bignumber.js@^8.0.2:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.1.1.tgz#4b072ae5aea9c20f6730e4e5d529df1271c4d885"
-  integrity sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==
 
 binary-extensions@^1.0.0:
   version "1.13.1"
@@ -1687,7 +1735,6 @@ bindings@~1.3.0:
 bintrees@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
-  integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
 
 bip39@2.5.0:
   version "2.5.0"
@@ -1729,7 +1776,6 @@ blakejs@^1.1.0:
 blob@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
-  integrity sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
 
 block-stream@*:
   version "0.0.9"
@@ -1771,14 +1817,12 @@ body-parser@1.18.3, body-parser@^1.16.0:
 boom@5.x.x:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
-  integrity sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==
   dependencies:
     hoek "4.x.x"
 
 bourne@1.x.x:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/bourne/-/bourne-1.1.2.tgz#e290b5bd7166635632eaf8ef12b006b2d4a75b83"
-  integrity sha512-b2dgVkTZhkQirNMohgC00rWfpVqEi9y5tKM1k3JvoNx05ODtfQoPPd4js9CYFQoY0IM8LAmnJulEuWv74zjUOg==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1805,6 +1849,10 @@ braces@^2.3.1, braces@^2.3.2:
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+
+browser-process-hrtime@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"
 
 browser-stdout@1.3.1:
   version "1.3.1"
@@ -1927,12 +1975,10 @@ buffer-from@^1.0.0, buffer-from@^1.1.0:
 buffer-indexof@~0.0.0:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-0.0.2.tgz#ed0f36b7ae166a66a7cd174c0467ae8dedf008f5"
-  integrity sha1-7Q82t64WamanzRdMBGeuje3wCPU=
 
 buffer-split@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-split/-/buffer-split-1.0.0.tgz#4427dbff53731b61d7a71aba47f503396613784a"
-  integrity sha1-RCfb/1NzG2HXpxq6R/UDOWYTeEo=
   dependencies:
     buffer-indexof "~0.0.0"
 
@@ -2007,7 +2053,6 @@ caching-transform@^3.0.1:
 call@4.x.x:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/call/-/call-4.0.2.tgz#df76f5f51ee8dd48b856ac8400f7e69e6d7399c4"
-  integrity sha1-33b19R7o3Ui4VqyEAPfmnm1zmcQ=
   dependencies:
     boom "5.x.x"
     hoek "4.x.x"
@@ -2015,7 +2060,6 @@ call@4.x.x:
 callsite@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
-  integrity sha1-KAOY5dZkvXQDi28JBRU+borxvCA=
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -2036,14 +2080,12 @@ caseless@~0.12.0:
 catbox-memory@2.x.x:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/catbox-memory/-/catbox-memory-2.0.4.tgz#433e255902caf54233d1286429c8f4df14e822d5"
-  integrity sha1-Qz4lWQLK9UIz0ShkKcj03xToItU=
   dependencies:
     hoek "4.x.x"
 
 catbox@7.x.x:
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/catbox/-/catbox-7.1.5.tgz#c56f7e8e9555d27c0dc038a96ef73e57d186bb1f"
-  integrity sha512-4fui5lELzqZ+9cnaAP/BcqXTH6LvWLBRtFhJ0I4FfgfXiSaZcf6k9m9dqOyChiTxNYtvLk7ZMYSf7ahMq3bf5A==
   dependencies:
     boom "5.x.x"
     hoek "4.x.x"
@@ -2058,7 +2100,6 @@ chai-as-promised@^7.1.1:
 chai-checkmark@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chai-checkmark/-/chai-checkmark-1.0.1.tgz#9fbb3c9ad9101f097ef288328d30f4227d74fffb"
-  integrity sha1-n7s8mtkQHwl+8ogyjTD0In10//s=
 
 chai@^4.2.0:
   version "4.2.0"
@@ -2128,12 +2169,10 @@ chownr@^1.0.1, chownr@^1.1.1:
 chunky@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/chunky/-/chunky-0.0.0.tgz#1e7580a23c083897d2ad662459e7efd8465f608a"
-  integrity sha1-HnWAojwIOJfSrWYkWefv2EZfYIo=
 
 cids@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/cids/-/cids-0.6.0.tgz#0de7056a5246a7c7ebf3134eb4d83b3b8b841a06"
-  integrity sha512-34wuIeiBZOuvBwUuYR4XooVuXUQI2PYU9VmgM2eB3xkSmQYRlv2kh/dIbmGiLY2GuONlGR3lLtYdVkx1G9yXUg==
   dependencies:
     class-is "^1.1.0"
     multibase "~0.6.0"
@@ -2150,7 +2189,6 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
 class-is@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/class-is/-/class-is-1.1.0.tgz#9d3c0fba0440d211d843cec3dedfa48055005825"
-  integrity sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -2285,12 +2323,10 @@ commondir@^1.0.1:
 component-bind@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
-  integrity sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=
 
 component-emitter@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
-  integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
 
 component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.3.0"
@@ -2299,7 +2335,6 @@ component-emitter@^1.2.0, component-emitter@^1.2.1:
 component-inherit@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
-  integrity sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -2329,7 +2364,6 @@ content-type@~1.0.4:
 content@3.x.x:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/content/-/content-3.0.7.tgz#0cbb88e82702d35ccf59800b8add609bb5c1dfc2"
-  integrity sha512-LXtnSnvE+Z1Cjpa3P9gh9kb396qV4MqpfwKy777BOSF8n6nw2vAi03tHNl0/XRqZUyzVzY/+nMXOZVnEapWzdg==
   dependencies:
     boom "5.x.x"
 
@@ -2442,7 +2476,6 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
 cryptiles@3.x.x:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.4.tgz#769a68c95612b56faadfcebf57ac86479cbe8322"
-  integrity sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==
   dependencies:
     boom "5.x.x"
 
@@ -2462,6 +2495,16 @@ crypto-browserify@3.12.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.6.tgz#f85206cee04efa841f3c5982a74ba96ab20d65ad"
+
+cssstyle@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.2.2.tgz#427ea4d585b18624f6fdbf9de7a2a1a3ba713077"
+  dependencies:
+    cssom "0.3.x"
+
 cuint@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
@@ -2471,6 +2514,14 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+data-urls@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
+  dependencies:
+    abab "^2.0.0"
+    whatwg-mimetype "^2.2.0"
+    whatwg-url "^7.0.0"
 
 deasync@^0.1.14:
   version "0.1.14"
@@ -2698,6 +2749,12 @@ dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
 
+domexception@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
+  dependencies:
+    webidl-conversions "^4.0.2"
+
 double-ended-queue@2.1.0-0:
   version "2.1.0-0"
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
@@ -2789,7 +2846,6 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
 engine.io-client@~3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.3.2.tgz#04e068798d75beda14375a264bb3d742d7bc33aa"
-  integrity sha512-y0CPINnhMvPuwtqXfsGuWE8BB66+B6wTtCofQDRecMQPYX3MYUZXFNKDhdrSe3EVjgOu4V3rxdeqN/Tr91IgbQ==
   dependencies:
     component-emitter "1.2.1"
     component-inherit "0.0.3"
@@ -2806,7 +2862,6 @@ engine.io-client@~3.3.1:
 engine.io-parser@~2.1.0, engine.io-parser@~2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-2.1.3.tgz#757ab970fbf2dfb32c7b74b033216d5739ef79a6"
-  integrity sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==
   dependencies:
     after "0.8.2"
     arraybuffer.slice "~0.0.7"
@@ -2817,7 +2872,6 @@ engine.io-parser@~2.1.0, engine.io-parser@~2.1.1:
 engine.io@~3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-3.3.2.tgz#18cbc8b6f36e9461c5c0f81df2b830de16058a59"
-  integrity sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==
   dependencies:
     accepts "~1.3.4"
     base64id "1.0.0"
@@ -2833,14 +2887,12 @@ env-variable@0.0.x:
 epimetheus@^1.0.92:
   version "1.0.92"
   resolved "https://registry.yarnpkg.com/epimetheus/-/epimetheus-1.0.92.tgz#c4f354341f8ab692f62c3392108b356e1282d191"
-  integrity sha512-rZqoUT63Xu3z5wPpTFPWkrIileJ9deOx/k/0ZPTiMSKBtPmJ9RzNrlo/M2UWvky7h8clrgc/s2uciq2mfruKrA==
   dependencies:
     prom-client "^10.0.0"
 
 err-code@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
-  integrity sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=
 
 errno@~0.1.1:
   version "0.1.7"
@@ -2898,6 +2950,17 @@ escape-html@~1.0.3:
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+escodegen@^1.9.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.1.tgz#c485ff8d6b4cdb89e27f4a856e91f118401ca510"
+  dependencies:
+    esprima "^3.1.3"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
 
 eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"
@@ -2963,6 +3026,10 @@ espree@^5.0.1:
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
 
+esprima@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
@@ -2979,7 +3046,7 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -3257,7 +3324,6 @@ ethjs-util@0.1.6, ethjs-util@^0.1.3:
 event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
-  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 eventemitter3@1.1.1:
   version "1.1.1"
@@ -3565,6 +3631,14 @@ fs-extra@^2.0.0, fs-extra@^2.1.2:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
 
+fs-extra@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -3598,14 +3672,12 @@ fsevents@^1.2.7:
 fsm-event@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fsm-event/-/fsm-event-2.1.0.tgz#d385716ed38f9c92feab2ba601e2aac6c0ba5a92"
-  integrity sha1-04VxbtOPnJL+qyumAeKqxsC6WpI=
   dependencies:
     fsm "^1.0.2"
 
 fsm@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/fsm/-/fsm-1.0.2.tgz#e2eb9b29747e806bbb90f8d5453e2f9d7bd23783"
-  integrity sha1-4uubKXR+gGu7kPjVRT4vnXvSN4M=
   dependencies:
     split "~0.3.0"
 
@@ -3676,7 +3748,6 @@ gauge@~2.7.3:
 get-browser-rtc@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-browser-rtc/-/get-browser-rtc-1.0.2.tgz#bbcd40c8451a7ed4ef5c373b8169a409dd1d11d9"
-  integrity sha1-u81AyEUaftTvXDc7gWmkCd0dEdk=
 
 get-caller-file@^1.0.1:
   version "1.0.3"
@@ -3792,7 +3863,7 @@ growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
 
-handlebars@^4.1.0:
+handlebars@*, handlebars@^4.0.6, handlebars@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
   dependencies:
@@ -3805,7 +3876,6 @@ handlebars@^4.1.0:
 hapi@^16.6.2:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/hapi/-/hapi-16.7.0.tgz#3bb39517971df81e8198ec04751455e8b6cb0871"
-  integrity sha512-UeMX1LMWmHEIgMlwZGK/3lhI7X0VRvOioVply0Y9qF+/O5woGdQzNB8ZmDnLOBjnB6bdWWHyo5DEamuCsE1vmg==
   dependencies:
     accept "2.x.x"
     ammo "2.x.x"
@@ -3847,14 +3917,12 @@ has-ansi@^2.0.0:
 has-binary2@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has-binary2/-/has-binary2-1.0.3.tgz#7776ac627f3ea77250cfc332dab7ddf5e4f5d11d"
-  integrity sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==
   dependencies:
     isarray "2.0.1"
 
 has-cors@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
-  integrity sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -3941,7 +4009,6 @@ hasha@^3.0.0:
 hashlru@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/hashlru/-/hashlru-2.3.0.tgz#5dc15928b3f6961a2056416bb3a4910216fdfb51"
-  integrity sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==
 
 hdkey@^1.0.0:
   version "1.1.1"
@@ -3962,11 +4029,14 @@ heap@0.2.6, heap@~0.2.6:
 heavy@4.x.x:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/heavy/-/heavy-4.0.4.tgz#36c91336c00ccfe852caa4d153086335cd2f00e9"
-  integrity sha1-NskTNsAMz+hSyqTRUwhjNc0vAOk=
   dependencies:
     boom "5.x.x"
     hoek "4.x.x"
     joi "10.x.x"
+
+highlight.js@^9.13.1:
+  version "9.15.6"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.15.6.tgz#72d4d8d779ec066af9a17cb14360c3def0aa57c4"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -3979,12 +4049,10 @@ hmac-drbg@^1.0.0:
 hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
-  integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
 
 hoek@6.x.x:
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-6.1.3.tgz#73b7d33952e01fe27a38b0457294b79dd8da242c"
-  integrity sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3996,6 +4064,12 @@ home-or-tmp@^2.0.0:
 hosted-git-info@^2.1.4:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
+
+html-encoding-sniffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
+  dependencies:
+    whatwg-encoding "^1.0.1"
 
 http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
   version "1.6.3"
@@ -4031,7 +4105,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
@@ -4073,12 +4147,10 @@ imurmurhash@^0.1.4:
 indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
-  integrity sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
 
 inert@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/inert/-/inert-4.2.1.tgz#da743c478a18a8378032f80ada128a28cd2bba93"
-  integrity sha512-qmbbZYPSzU/eOUOStPQvSjrU9IR1Q3uDtsEsVwnBQeZG43xu7Nrj6yuUrX3ice/03rv5dj/KiKB+NGCbiqH+aQ==
   dependencies:
     ammo "2.x.x"
     boom "5.x.x"
@@ -4127,14 +4199,12 @@ inquirer@^6.2.2:
 interface-connection@~0.3.2, interface-connection@~0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/interface-connection/-/interface-connection-0.3.3.tgz#d82dd81efee5f2d40d7cb0fd75e6e858f92fa199"
-  integrity sha512-OV9Rj7AhUlssWJTO6nOazJdPFGqWDOVZ3j5aM+i0RPKyTzR87vJ949VqhMyKkCIR0GBAaNqfB7F4YA70a/QWiw==
   dependencies:
     pull-defer "~0.2.3"
 
 interface-datastore@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/interface-datastore/-/interface-datastore-0.6.0.tgz#d167c6229c708c48d1ef9b1819ff68efeb82ac72"
-  integrity sha512-aDbjWsEdTHd2Yc2A8QOeAEWMwlWDwumVX24bE0/AE7XxfDveWuDUKP7HQito0u1c80FZmR+y/Op14um+cG0CSw==
   dependencies:
     async "^2.6.1"
     class-is "^1.1.0"
@@ -4142,6 +4212,10 @@ interface-datastore@~0.6.0:
     pull-defer "~0.2.3"
     pull-stream "^3.6.9"
     uuid "^3.2.2"
+
+interpret@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
 
 invariant@^2.2.2:
   version "2.2.4"
@@ -4156,7 +4230,6 @@ invert-kv@^2.0.0:
 ip-address@^5.8.9:
   version "5.9.0"
   resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-5.9.0.tgz#e501b3a0da9e31d9a14ef7ccdc05c5552c465954"
-  integrity sha512-+4yKpEyent8IpjuDQVkIpzIDbxSlCHTPdmaXCRLH0ttt3YsrbNxuZJ6h+1wLPx10T7gWsLN7M6BXIHV2vZNOGw==
   dependencies:
     jsbn "1.1.0"
     lodash.find "^4.6.0"
@@ -4169,7 +4242,6 @@ ip-address@^5.8.9:
 ip-regex@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
-  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
 ip-regex@^3.0.0:
   version "3.0.0"
@@ -4178,7 +4250,6 @@ ip-regex@^3.0.0:
 ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
-  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
 ipaddr.js@1.9.0:
   version "1.9.0"
@@ -4187,7 +4258,6 @@ ipaddr.js@1.9.0:
 iron@4.x.x:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/iron/-/iron-4.0.5.tgz#4f042cceb8b9738f346b59aa734c83a89bc31428"
-  integrity sha1-TwQszri5c480a1mqc0yDqJvDFCg=
   dependencies:
     boom "5.x.x"
     cryptiles "3.x.x"
@@ -4316,7 +4386,6 @@ is-hex-prefixed@1.0.0:
 is-ip@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-2.0.0.tgz#68eea07e8a0a0a94c2d080dd674c731ab2a461ab"
-  integrity sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=
   dependencies:
     ip-regex "^2.0.0"
 
@@ -4351,7 +4420,6 @@ is-promise@^2.1.0:
 is-promise@~1, is-promise@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-1.0.1.tgz#31573761c057e33c2e91aab9e96da08cefbe76e5"
-  integrity sha1-MVc3YcBX4zwukaq56W2gjO++duU=
 
 is-regex@^1.0.4:
   version "1.0.4"
@@ -4392,17 +4460,14 @@ isarray@1.0.0, isarray@~1.0.0:
 isarray@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
-  integrity sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=
 
 isemail@2.x.x:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isemail/-/isemail-2.2.1.tgz#0353d3d9a62951080c262c2aa0a42b8ea8e9e2a6"
-  integrity sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=
 
 isemail@3.x.x:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.2.0.tgz#59310a021931a9fb06bbb51e155ce0b3f236832c"
-  integrity sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==
   dependencies:
     punycode "2.x.x"
 
@@ -4413,12 +4478,10 @@ isexe@^2.0.0:
 iso-random-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/iso-random-stream/-/iso-random-stream-1.1.0.tgz#c1dc1bb43dd8da6524df9cbc6253b010806585c8"
-  integrity sha512-ywSWt0KrWcsaK0jVoVJIR30rLyjg9Rw3k2Sm/qp+3tdtSV0SNH7L7KilKnENcENOSoJxDFvpt2idvuMMQohdCQ==
 
 iso-url@^0.4.4:
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/iso-url/-/iso-url-0.4.6.tgz#45005c4af4984cad4f8753da411b41b74cf0a8a6"
-  integrity sha512-YQO7+aIe6l1aSJUKOx+Vrv08DlhZeLFIVfehG2L29KLSEb9RszqPXilxJRVpp57px36BddKR5ZsebacO5qG0tg==
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -4490,17 +4553,14 @@ isurl@^1.0.0-alpha5:
 items@2.x.x:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/items/-/items-2.1.2.tgz#0849354595805d586dac98e7e6e85556ea838558"
-  integrity sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg==
 
 joi-browser@^13.4.0:
   version "13.4.0"
   resolved "https://registry.yarnpkg.com/joi-browser/-/joi-browser-13.4.0.tgz#b72ba61b610e3f58e51b563a14e0f5225cfb6896"
-  integrity sha512-TfzJd2JaJ/lg/gU+q5j9rLAjnfUNF9DUmXTP9w+GfmG79LjFOXFeM7hIFuXCBcZCivUDFwd9l1btTV9rhHumtQ==
 
 joi@10.x.x:
   version "10.6.0"
   resolved "https://registry.yarnpkg.com/joi/-/joi-10.6.0.tgz#52587f02d52b8b75cdb0c74f0b164a191a0e1fc2"
-  integrity sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==
   dependencies:
     hoek "4.x.x"
     isemail "2.x.x"
@@ -4510,7 +4570,6 @@ joi@10.x.x:
 joi@11.x.x:
   version "11.4.0"
   resolved "https://registry.yarnpkg.com/joi/-/joi-11.4.0.tgz#f674897537b625e9ac3d0b7e1604c828ad913ccb"
-  integrity sha512-O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==
   dependencies:
     hoek "4.x.x"
     isemail "3.x.x"
@@ -4519,7 +4578,6 @@ joi@11.x.x:
 joi@12.x.x:
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/joi/-/joi-12.0.0.tgz#46f55e68f4d9628f01bbb695902c8b307ad8d33a"
-  integrity sha512-z0FNlV4NGgjQN1fdtHYXf5kmgludM65fG/JlXzU6+rwkt9U5UWuXVYnXa2FpK0u6+qBuCmrm5byPNuiiddAHvQ==
   dependencies:
     hoek "4.x.x"
     isemail "3.x.x"
@@ -4528,7 +4586,6 @@ joi@12.x.x:
 joi@^14.0.6:
   version "14.3.1"
   resolved "https://registry.yarnpkg.com/joi/-/joi-14.3.1.tgz#164a262ec0b855466e0c35eea2a885ae8b6c703c"
-  integrity sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==
   dependencies:
     hoek "6.x.x"
     isemail "3.x.x"
@@ -4572,11 +4629,41 @@ js-yaml@^3.12.0, js-yaml@^3.13.0:
 jsbn@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
-  integrity sha1-sBMHyym2GKHtJux56RH4A8TaAEA=
 
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
+jsdom@^11.9.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
+  dependencies:
+    abab "^2.0.0"
+    acorn "^5.5.3"
+    acorn-globals "^4.1.0"
+    array-equal "^1.0.0"
+    cssom ">= 0.3.2 < 0.4.0"
+    cssstyle "^1.0.0"
+    data-urls "^1.0.0"
+    domexception "^1.0.1"
+    escodegen "^1.9.1"
+    html-encoding-sniffer "^1.0.2"
+    left-pad "^1.3.0"
+    nwsapi "^2.0.7"
+    parse5 "4.0.0"
+    pn "^1.1.0"
+    request "^2.87.0"
+    request-promise-native "^1.0.5"
+    sax "^1.2.4"
+    symbol-tree "^3.2.2"
+    tough-cookie "^2.3.4"
+    w3c-hr-time "^1.0.1"
+    webidl-conversions "^4.0.2"
+    whatwg-encoding "^1.0.3"
+    whatwg-mimetype "^2.1.0"
+    whatwg-url "^6.4.1"
+    ws "^5.2.0"
+    xml-name-validator "^3.0.0"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -4653,6 +4740,12 @@ jsonfile@^2.1.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -4673,7 +4766,6 @@ just-extend@^4.0.2:
 k-bucket@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/k-bucket/-/k-bucket-5.0.0.tgz#ef7a401fcd4c37cd31dceaa6ae4440ca91055e01"
-  integrity sha512-r/q+wV/Kde62/tk+rqyttEJn6h0jR7x+incdMVSYTqK73zVxVrzJa70kJL49cIKen8XjIgUZKSvk8ktnrQbK4w==
   dependencies:
     randombytes "^2.0.3"
 
@@ -4696,7 +4788,6 @@ keccakjs@^0.2.0, keccakjs@^0.2.1:
 keypair@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/keypair/-/keypair-1.0.1.tgz#7603719270afb6564ed38a22087a06fc9aa4ea1b"
-  integrity sha1-dgNxknCvtlZO04oiCHoG/Jqk6hs=
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -4727,7 +4818,6 @@ kuler@1.0.x:
 latency-monitor@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/latency-monitor/-/latency-monitor-0.2.1.tgz#4043d5f23de86e2bfcef6ced4a3b5b922e1dd7ed"
-  integrity sha1-QEPV8j3obiv872ztSjtbki4d1+0=
   dependencies:
     debug "^2.6.0"
     lodash "^4.17.4"
@@ -4741,12 +4831,10 @@ lcid@^2.0.0:
 left-pad@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
-  integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
 
 length-prefixed-stream@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/length-prefixed-stream/-/length-prefixed-stream-1.6.0.tgz#6aeeecf38a337172ea0472250e90f5e15b8b2334"
-  integrity sha512-gsJvrb5giDqil/ScQ7fEoplsI2Ch4DwnvnfTW2EGl9KBW6Ekzn8JSNESObqNAeZD8HkSjEMvc5XjhuB66fsSZQ==
   dependencies:
     buffer-alloc-unsafe "^1.0.0"
     readable-stream "^2.0.0"
@@ -4755,7 +4843,6 @@ length-prefixed-stream@^1.6.0:
 length-prefixed-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/length-prefixed-stream/-/length-prefixed-stream-2.0.0.tgz#16e603c97aefb46f43ae4b5d22f1734ecd14ffce"
-  integrity sha512-dvjTuWTKWe0oEznQcG6a9osfiYknCs7DEFJMP88n9Y581IFhYh1sZIgAFcuDOojKB0G7ftPreKhh4D0kh/VPjQ==
   dependencies:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
@@ -4905,7 +4992,6 @@ levn@^0.3.0, levn@~0.3.0:
 libp2p-bootstrap@^0.9.7:
   version "0.9.7"
   resolved "https://registry.yarnpkg.com/libp2p-bootstrap/-/libp2p-bootstrap-0.9.7.tgz#eabedab24775a6175f07ce035b716e8114d84a76"
-  integrity sha512-GuuYoTh0UBBlph0WuuiewtDZqfYsXmhSdX+JLMzGY6uMuK5aLr7gCa++2zVyBoOIgn0yTq2F6n4vKaWoK9Hi0w==
   dependencies:
     async "^2.6.1"
     debug "^4.1.1"
@@ -4917,7 +5003,6 @@ libp2p-bootstrap@^0.9.7:
 libp2p-circuit@~0.3.4:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/libp2p-circuit/-/libp2p-circuit-0.3.6.tgz#cab020526dba73dcde3a95c0d9334be0058368ab"
-  integrity sha512-aeLAyQKIvWOxD5AWJ5M6z9XNUWerfBmUNQEEOoGDVW91PW95BrxqtOmaCXOXiMct7qpT4gz2RtAPES55dDwbIQ==
   dependencies:
     async "^2.6.2"
     debug "^4.1.1"
@@ -4936,7 +5021,6 @@ libp2p-circuit@~0.3.4:
 libp2p-connection-manager@~0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/libp2p-connection-manager/-/libp2p-connection-manager-0.0.2.tgz#ea3db3efce8b7bb3c55af9002b8edbf65244fb1e"
-  integrity sha512-G/OzMfxQe0lHx7ujibPqpFLCeMN9I5vNH0+Rs9zat6+uIT51Saupx95lyoyh5J8nh93ui2cNH7PQnwJMZVKa1A==
   dependencies:
     debug "^3.1.0"
     latency-monitor "^0.2.1"
@@ -4944,7 +5028,6 @@ libp2p-connection-manager@~0.0.2:
 libp2p-crypto-secp256k1@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.3.0.tgz#47ce694fa3c9f2a8b61b11e66d29f1b101d9e985"
-  integrity sha512-+rF3S5p2pzS4JLDwVE6gLWZeaKkpl4NkYwG+0knV6ot29UcRSb73OyCWl07r1h5+g9E3KZC3wpsu+RIK5w8zQA==
   dependencies:
     async "^2.6.1"
     bs58 "^4.0.1"
@@ -4956,7 +5039,6 @@ libp2p-crypto-secp256k1@~0.3.0:
 libp2p-crypto@~0.16.0, libp2p-crypto@~0.16.1:
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/libp2p-crypto/-/libp2p-crypto-0.16.1.tgz#40aa07e95a0a7fe6887ea3868625e74c81c34d75"
-  integrity sha512-+fxqy+cDjwOKK4KTj44WQmjPE5ep2eR5uAIQWHl/+RKvRSor3+RAY53VWkAecgAEvjX2AswxBsoCIJK1Qk5aIQ==
   dependencies:
     asmcrypto.js "^2.3.2"
     asn1.js "^5.0.1"
@@ -4978,7 +5060,6 @@ libp2p-crypto@~0.16.0, libp2p-crypto@~0.16.1:
 libp2p-floodsub@^0.15.8, libp2p-floodsub@~0.15.1:
   version "0.15.8"
   resolved "https://registry.yarnpkg.com/libp2p-floodsub/-/libp2p-floodsub-0.15.8.tgz#ecfd94162825ed7b5431ccbe672f5bf58f7efab2"
-  integrity sha512-tsRTRRz9vg3iPqhSgkn4gotX635Hp/VMxPd4VQZlRvO8pZsfZwd61Qn9Vx8bES881RhRX0YpGM4Sa0izInHEWA==
   dependencies:
     async "^2.6.1"
     bs58 "^4.0.1"
@@ -4995,7 +5076,6 @@ libp2p-floodsub@^0.15.8, libp2p-floodsub@~0.15.1:
 libp2p-identify@~0.7.5:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/libp2p-identify/-/libp2p-identify-0.7.6.tgz#b17fad2ec0df76d6ca6b5b0a7e58b04620b8dbe9"
-  integrity sha512-QleYqI6f8ah6G6sQU9uaIa9FVOtyp6LtiqopfjrmAIO5Oz22Zw+dpT7FcEXvYP7kL036Es2vzZm0js0pOWw1MA==
   dependencies:
     multiaddr "^6.0.4"
     peer-id "~0.12.2"
@@ -5007,7 +5087,6 @@ libp2p-identify@~0.7.5:
 libp2p-kad-dht@^0.14.12:
   version "0.14.13"
   resolved "https://registry.yarnpkg.com/libp2p-kad-dht/-/libp2p-kad-dht-0.14.13.tgz#0acd38afa2211331850e14799786579f1c4525af"
-  integrity sha512-mbR9m31m9/Ru1baraguDVEhGEt+OFy8kHGZVaULbTzLJNB53C05IW6NzzgC/v5d05fFFwnqDA9b1FYhGjr2gow==
   dependencies:
     abort-controller "^3.0.0"
     async "^2.6.2"
@@ -5037,7 +5116,6 @@ libp2p-kad-dht@^0.14.12:
 libp2p-mplex@^0.8.5:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/libp2p-mplex/-/libp2p-mplex-0.8.5.tgz#a81a10f009c3cccd97f66da11c5f950a6ca37de7"
-  integrity sha512-L/1xbk8Mux2vroxfH2nfLrqyHfMdl4ScnIXhmQm19tlHZokcg/sadI5XmjdsBqMq3nP/q8wgNjIuX9IX6m1C6w==
   dependencies:
     async "^2.6.2"
     chunky "0.0.0"
@@ -5055,7 +5133,6 @@ libp2p-mplex@^0.8.5:
 libp2p-ping@~0.8.3:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/libp2p-ping/-/libp2p-ping-0.8.5.tgz#e7fb9fb32d9ff0d6b51be52caef4395ce1a17613"
-  integrity sha512-BzCN3+jp1SvJQZlXq2G3TMkyK5UOOf3JO+CZMnaUEHYlRgQf2zShYta5XU2IGx0EJA/23iCdCL+LjBP/DOvbkQ==
   dependencies:
     libp2p-crypto "~0.16.0"
     pull-handshake "^1.1.4"
@@ -5064,7 +5141,6 @@ libp2p-ping@~0.8.3:
 libp2p-pubsub@~0.0.1:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/libp2p-pubsub/-/libp2p-pubsub-0.0.4.tgz#8c4b53b32b2e2cd6838e9e4dfc48e2ba010bfcb8"
-  integrity sha512-j6cup6pQ1060Qhn8Lw2wzoGISyvQgvsFNiGngn5Yld8LaHKgP2T6wgJMEe0e69uEa3yqCWxe+QWFO5RcA1AJDw==
   dependencies:
     async "^2.6.2"
     bs58 "^4.0.1"
@@ -5081,7 +5157,6 @@ libp2p-pubsub@~0.0.1:
 libp2p-record@~0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/libp2p-record/-/libp2p-record-0.6.2.tgz#712a2be9e1d97df8a62c8a240201c41372ddd543"
-  integrity sha512-b+RQc4l6AzYtQq0kAyDYV2Eth1DDsB2TQoQfvQtyJy/iVeKz8Q1RZxLTo7lhwS78LMwcVCGrdlx5H5luONjhjg==
   dependencies:
     async "^2.6.2"
     buffer-split "^1.0.0"
@@ -5094,7 +5169,6 @@ libp2p-record@~0.6.2:
 libp2p-switch@~0.41.3:
   version "0.41.7"
   resolved "https://registry.yarnpkg.com/libp2p-switch/-/libp2p-switch-0.41.7.tgz#d168aa4c71f475626bf4e1399b8d47632757de21"
-  integrity sha512-56T9JlHydFkX91TzPP+YDqbI8W3JuLQTiKdtbg74P5lbse0VOaPzgDaDdSfXq9qGtlBHl9sG116Kz3U8GrCcvA==
   dependencies:
     async "^2.6.2"
     bignumber.js "^8.0.2"
@@ -5118,7 +5192,6 @@ libp2p-switch@~0.41.3:
 libp2p-tcp@^0.13.0:
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/libp2p-tcp/-/libp2p-tcp-0.13.0.tgz#597f0f837890ca07b062b75593a4d58b755122b2"
-  integrity sha512-bsmfxi+uVegK61x9UxBEgWtvujPl+zwzuVEyaVRs2IxHu6OE5MGKnj7AflzlK4e3w2HZn8nm4qwMV5m+fhqK1g==
   dependencies:
     class-is "^1.1.0"
     debug "^3.1.0"
@@ -5134,7 +5207,6 @@ libp2p-tcp@^0.13.0:
 libp2p-webrtc-star@^0.15.8:
   version "0.15.8"
   resolved "https://registry.yarnpkg.com/libp2p-webrtc-star/-/libp2p-webrtc-star-0.15.8.tgz#ffcba2cc42b427a8f2af711ba3c35ac365d6d4ab"
-  integrity sha512-ONfDf0DCamO++xZRJsPA2SSlrutO+UxC80t56acShg6ViZItiY3Y1WaMO+87jVW2711x230NlmOVoQ/gHfJmVw==
   dependencies:
     async "^2.6.1"
     class-is "^1.1.0"
@@ -5159,7 +5231,6 @@ libp2p-webrtc-star@^0.15.8:
 libp2p-websockets@~0.12.0:
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/libp2p-websockets/-/libp2p-websockets-0.12.2.tgz#eecf25564cbe6b0e9017bb411c2a8abec8c9f29b"
-  integrity sha512-K/Jg/fWFfP5NyiLx01EJcoAcYQO00RSHpZfPQDR3May6ABvOseAjq45SrUDdDCW5mCS0502Vz1VjRrZdOXw8zQ==
   dependencies:
     class-is "^1.1.0"
     debug "^4.1.1"
@@ -5171,7 +5242,6 @@ libp2p-websockets@~0.12.0:
 libp2p@^0.24.4:
   version "0.24.4"
   resolved "https://registry.yarnpkg.com/libp2p/-/libp2p-0.24.4.tgz#aca6fa665349f118e845eafd13ca804a53355c9a"
-  integrity sha512-Od6we8H6P/sm3tuJCYFiP/PJ+O6ZNaNw0q5DuNw6obMHgKm/XSsJcDYzgfrPs1P9ASpAMTXAe0cYtjHRoQ9yPQ==
   dependencies:
     async "^2.6.1"
     debug "^4.1.0"
@@ -5209,12 +5279,10 @@ locate-path@^3.0.0:
 lodash.filter@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
-  integrity sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=
 
 lodash.find@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
-  integrity sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=
 
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
@@ -5223,42 +5291,38 @@ lodash.flattendeep@^4.4.0:
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
-  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
 
 lodash.isfunction@^3.0.9:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
-  integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
 
 lodash.map@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
-  integrity sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=
 
 lodash.max@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.max/-/lodash.max-4.0.1.tgz#8735566c618b35a9f760520b487ae79658af136a"
-  integrity sha1-hzVWbGGLNan3YFILSHrnllivE2o=
 
 lodash.merge@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
-  integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
 
 lodash.padstart@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.padstart/-/lodash.padstart-4.6.1.tgz#d2e3eebff0d9d39ad50f5cbd1b52a7bce6bb611b"
-  integrity sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=
 
 lodash.repeat@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/lodash.repeat/-/lodash.repeat-4.1.0.tgz#fc7de8131d8c8ac07e4b49f74ffe829d1f2bec44"
-  integrity sha1-/H3oEx2MisB+S0n3T/6CnR8r7EQ=
+
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
 lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
-  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
 lodash.unescape@4.0.1:
   version "4.0.1"
@@ -5267,7 +5331,6 @@ lodash.unescape@4.0.1:
 lodash@4.17.11, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 logform@^2.1.1:
   version "2.1.2"
@@ -5308,7 +5371,6 @@ lowercase-keys@^1.0.0:
 lru-cache@4.1.x, lru-cache@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
-  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
@@ -5330,7 +5392,6 @@ ltgt@~2.1.1, ltgt@~2.1.3:
 mafmt@^6.0.2, mafmt@^6.0.4, mafmt@^6.0.6:
   version "6.0.7"
   resolved "https://registry.yarnpkg.com/mafmt/-/mafmt-6.0.7.tgz#80312e08bfba0f89e2daa403525f33e07d9b97fa"
-  integrity sha512-2OG/EGAJZmpZBl7YRT1hD83sZa2gKsUEdegRuURreIOe7B4VeHU1rYYmhgk7BkLzknGL3xGYsDx3bbSgEEzE7g==
   dependencies:
     multiaddr "^6.0.4"
 
@@ -5366,6 +5427,10 @@ map-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   dependencies:
     object-visit "^1.0.0"
+
+marked@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.4.0.tgz#9ad2c2a7a1791f10a852e0112f77b571dce10c66"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -5415,7 +5480,6 @@ merge-descriptors@1.0.1:
 merge-options@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-1.0.1.tgz#2a64b24457becd4e4dc608283247e94ce589aa32"
-  integrity sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==
   dependencies:
     is-plain-obj "^1.1"
 
@@ -5513,7 +5577,6 @@ mimic-response@^1.0.0:
 mimos@3.x.x:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/mimos/-/mimos-3.0.3.tgz#b9109072ad378c2b72f6a0101c43ddfb2b36641f"
-  integrity sha1-uRCQcq03jCty9qAQHEPd+ys2ZB8=
   dependencies:
     hoek "4.x.x"
     mime-db "1.x.x"
@@ -5532,7 +5595,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-minimatch@3.0.4, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -5613,7 +5676,6 @@ mout@^0.11.0:
 moving-average@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/moving-average/-/moving-average-1.0.0.tgz#b1247ba8dd2d7927c619f1eac8036cf933d65adc"
-  integrity sha512-97cgMz0U2zciiDp4xRl/n+MYgrm9l7UiYbtsBLPr0rhw6KH3m4LyK2w4d96V6+UwKo+ph7KtQSoL2qgnqZVgvA==
 
 ms@2.0.0:
   version "2.0.0"
@@ -5626,14 +5688,12 @@ ms@^2.1.1:
 multiaddr-to-uri@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/multiaddr-to-uri/-/multiaddr-to-uri-4.0.1.tgz#3b89d2a460a96602a16f3bfe296ee771ecb2558b"
-  integrity sha512-RVHKm5NXcMWMIhrwF4B4Q34JtMXt1/2wgnDTnKRE+AGAiXfqFika0bIfCsAtLp+gZJOWeDLeT1vR6P0gGyVAtg==
   dependencies:
     multiaddr "^6.0.3"
 
 multiaddr@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/multiaddr/-/multiaddr-5.0.2.tgz#bffc4ebf0ef208ce40eab8cd6f146296b61aa0e3"
-  integrity sha512-dXz1chaUHV6L6okujDLS7uRA6NmCbitpikOJA0vMMnrwVyai5kC3ot2CSLrSfj3B8XIgNzpe/j5auSYrnbGGzA==
   dependencies:
     bs58 "^4.0.1"
     class-is "^1.1.0"
@@ -5647,7 +5707,6 @@ multiaddr@^5.0.0:
 multiaddr@^6.0.2, multiaddr@^6.0.3, multiaddr@^6.0.4:
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/multiaddr/-/multiaddr-6.0.6.tgz#99296d219d4f21b6520c7eaf43fd3ef9306d7a63"
-  integrity sha512-nR4s91mi7IKed1jrqUj/4OhZ1VKdAjUG79IuVB5PS6b+qxOZLKPW8nsskHhrfGn4o1Rn1NJWl7znidF/NVQpEA==
   dependencies:
     bs58 "^4.0.1"
     class-is "^1.1.0"
@@ -5658,21 +5717,18 @@ multiaddr@^6.0.2, multiaddr@^6.0.3, multiaddr@^6.0.4:
 multibase@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/multibase/-/multibase-0.6.0.tgz#0216e350614c7456da5e8e5b20d3fcd4c9104f56"
-  integrity sha512-R9bNLQhbD7MsitPm1NeY7w9sDgu6d7cuj25snAWH7k5PSNPSwIQQBpcpj8jx1W96dLbdigZqmUWOdQRMnAmgjA==
   dependencies:
     base-x "3.0.4"
 
 multicodec@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/multicodec/-/multicodec-0.5.1.tgz#fa4d6fbb99abdf3cec0f207a022ce20ad3813fd5"
-  integrity sha512-Q5glyZLdXVbbBxvRYHLQHpu8ydVf1422Z+v9fU47v2JCkiue7n+JcFS7uRv0cQW8hbVtgdtIDgYWPWaIKEXuXA==
   dependencies:
     varint "^5.0.0"
 
 multihashes@~0.4.13, multihashes@~0.4.14:
   version "0.4.14"
   resolved "https://registry.yarnpkg.com/multihashes/-/multihashes-0.4.14.tgz#774db9a161f81a8a27dc60788f91248e020f5244"
-  integrity sha512-V/g/EIN6nALXfS/xHUAgtfPP3mn3sPIF/i9beuGKf25QXS2QZYCpeVJbDPEannkz32B2fihzCe2D/KMrbcmefg==
   dependencies:
     bs58 "^4.0.1"
     varint "^5.0.0"
@@ -5680,7 +5736,6 @@ multihashes@~0.4.13, multihashes@~0.4.14:
 multihashing-async@~0.5.1, multihashing-async@~0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/multihashing-async/-/multihashing-async-0.5.2.tgz#4af40e0dde2f1dbb12a7c6b265181437ac26b9de"
-  integrity sha512-mmyG6M/FKxrpBh9xQDUvuJ7BbqT93ZeEeH5X6LeMYKoYshYLr9BDdCsvDtZvn+Egf+/Xi+aOznrWL4vp3s+p0Q==
   dependencies:
     blakejs "^1.1.0"
     js-sha3 "~0.8.0"
@@ -5691,7 +5746,6 @@ multihashing-async@~0.5.1, multihashing-async@~0.5.2:
 multistream-select@~0.14.4:
   version "0.14.4"
   resolved "https://registry.yarnpkg.com/multistream-select/-/multistream-select-0.14.4.tgz#76d67e72decb0e8f5f47563ab65fb096a3dfc442"
-  integrity sha512-pWC3AOtcJXXUtN+GpY66enRN0Qrw51mFuzhxs9TjVcjSllpA3bGYkwBlORUHiVjSTxBGZy7mR4VbsBDGrhQV3g==
   dependencies:
     async "^2.6.0"
     debug "^4.1.0"
@@ -5706,7 +5760,6 @@ multistream-select@~0.14.4:
 murmurhash3js@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/murmurhash3js/-/murmurhash3js-3.0.1.tgz#3e983e5b47c2a06f43a713174e7e435ca044b998"
-  integrity sha1-Ppg+W0fCoG9DpxMXTn5DXKBEuZg=
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -5775,7 +5828,6 @@ negotiator@0.6.1:
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
-  integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
 neo-async@^2.6.0:
   version "2.6.0"
@@ -5788,7 +5840,6 @@ nice-try@^1.0.4:
 nigel@2.x.x:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/nigel/-/nigel-2.0.2.tgz#93a1866fb0c52d87390aa75e2b161f4b5c75e5b1"
-  integrity sha1-k6GGb7DFLYc5CqdeKxYfS1x15bE=
   dependencies:
     hoek "4.x.x"
     vise "2.x.x"
@@ -5831,7 +5882,6 @@ node-fetch@~1.7.1:
 node-forge@~0.7.6:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
-  integrity sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==
 
 node-modules-regexp@^1.0.0:
   version "1.0.0"
@@ -5861,7 +5911,6 @@ node-releases@^1.1.14:
 nodeify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/nodeify/-/nodeify-1.0.1.tgz#64ab69a7bdbaf03ce107b4f0335c87c0b9e91b1d"
-  integrity sha1-ZKtpp7268DzhB7TwM1yHwLnpGx0=
   dependencies:
     is-promise "~1.0.0"
     promise "~1.3.0"
@@ -5937,6 +5986,10 @@ number-to-bn@1.7.0:
     bn.js "4.11.6"
     strip-hex-prefix "1.0.0"
 
+nwsapi@^2.0.7:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.1.4.tgz#e006a878db23636f8e8a67d33ca0e4edf61a842f"
+
 nyc@^13.3.0:
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/nyc/-/nyc-13.3.0.tgz#da4dbe91a9c8b9ead3f4f3344c76f353e3c78c75"
@@ -5973,7 +6026,6 @@ oauth-sign@~0.9.0:
 object-assign@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-2.1.1.tgz#43c36e5d569ff8e4816c4efa8be02d26967c18aa"
-  integrity sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=
 
 object-assign@^4, object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
@@ -5982,7 +6034,6 @@ object-assign@^4, object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1
 object-component@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
-  integrity sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=
 
 object-copy@^0.1.0:
   version "0.1.0"
@@ -6058,11 +6109,10 @@ optimist@^0.6.1:
 optimist@~0.3.5:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.3.7.tgz#c90941ad59e4273328923074d2cf2e7cbc6ec0d9"
-  integrity sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=
   dependencies:
     wordwrap "~0.0.2"
 
-optionator@^0.8.2:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -6076,7 +6126,6 @@ optionator@^0.8.2:
 options@>=0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/options/-/options-0.0.6.tgz#ec22d312806bb53e731773e7cdaefcf1c643128f"
-  integrity sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=
 
 os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
@@ -6187,17 +6236,19 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parse5@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
+
 parseqs@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.5.tgz#d5208a3738e46766e291ba2ea173684921a8b89d"
-  integrity sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=
   dependencies:
     better-assert "~1.0.0"
 
 parseuri@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/parseuri/-/parseuri-0.0.5.tgz#80204a50d4dbb779bfdc6ebe2778d90e4bce320a"
-  integrity sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=
   dependencies:
     better-assert "~1.0.0"
 
@@ -6266,7 +6317,6 @@ pbkdf2@^3.0.3, pbkdf2@^3.0.9:
 peer-book@^0.9.1, peer-book@~0.9.0:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/peer-book/-/peer-book-0.9.1.tgz#42dffd7b1faf263bd6abe2907a26f7411f4dbf34"
-  integrity sha512-Bnhsrruilysw5nFU0V2hcTmLnT2cRfc6mud62aaG1dkh9J8IkQ83IclcC2ziVPnEi8AFX8SQ1sSG7Qe0JTwIBA==
   dependencies:
     bs58 "^4.0.1"
     peer-id "~0.12.2"
@@ -6275,7 +6325,6 @@ peer-book@^0.9.1, peer-book@~0.9.0:
 peer-id@^0.12.2, peer-id@~0.12.0, peer-id@~0.12.2:
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/peer-id/-/peer-id-0.12.2.tgz#0d1b876ebf21a528be9948c9cb7d30266342b2fd"
-  integrity sha512-pked3yPLcOcprH21OnYbJAzk9OgI/TDEqjJ0IfRJSVB/61ZyqU5VKO7cw7hul+YD8nTD79wM79xFRWN3f6otNg==
   dependencies:
     async "^2.6.1"
     class-is "^1.1.0"
@@ -6285,7 +6334,6 @@ peer-id@^0.12.2, peer-id@~0.12.0, peer-id@~0.12.2:
 peer-info@^0.15.1, peer-info@~0.15.0, peer-info@~0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/peer-info/-/peer-info-0.15.1.tgz#21254a7c516d0dd046b150120b9aaf1b9ad02146"
-  integrity sha512-Y91Q2tZRC0CpSTPd1UebhGqniOrOAk/aj60uYUcWJXCoLTAnGu+4LJGoiay8ayudS6ice7l3SKhgL/cS62QacA==
   dependencies:
     mafmt "^6.0.2"
     multiaddr "^6.0.3"
@@ -6295,7 +6343,6 @@ peer-info@^0.15.1, peer-info@~0.15.0, peer-info@~0.15.1:
 pem-jwk@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pem-jwk/-/pem-jwk-2.0.0.tgz#1c5bb264612fc391340907f5c1de60c06d22f085"
-  integrity sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==
   dependencies:
     asn1.js "^5.0.1"
 
@@ -6310,7 +6357,6 @@ performance-now@^2.1.0:
 pez@2.x.x:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/pez/-/pez-2.1.5.tgz#5ec2cc62500cc3eb4236d4a414cf5a17b5eb5007"
-  integrity sha1-XsLMYlAMw+tCNtSkFM9aF7XrUAc=
   dependencies:
     b64 "3.x.x"
     boom "5.x.x"
@@ -6352,10 +6398,13 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
+pn@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
+
 podium@1.x.x:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/podium/-/podium-1.3.0.tgz#3c490f54d16f10f5260cbe98641f1cb733a8851c"
-  integrity sha512-ZIujqk1pv8bRZNVxwwwq0BhXilZ2udycQT3Kp8ah3f3TcTmVg7ILJsv/oLf47gRa2qeiP584lNq+pfvS9U3aow==
   dependencies:
     hoek "4.x.x"
     items "2.x.x"
@@ -6524,7 +6573,6 @@ prepend-http@^1.0.1:
 priorityqueue@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/priorityqueue/-/priorityqueue-0.2.1.tgz#f57e623f20237f30c142d4cb45fafed9e7d51403"
-  integrity sha512-Dr6ZkRFGZHoAri6iNp5KvspOrFPfhxJ5AExXqLy5ChgdwALd3nC+q5/QG+gmjmf9W63joDXc+Zp0h05Ug/RtYg==
 
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"
@@ -6545,7 +6593,6 @@ progress@^2.0.0:
 prom-client@^10.0.0:
   version "10.2.3"
   resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-10.2.3.tgz#a51bf21c239c954a6c5be4b1361fdd380218bb41"
-  integrity sha512-Xboq5+TdUwuQtSSDRZRNnb5NprINlgQN999VqUjZxnLKydUNLeIPx6Eiahg6oJua3XBg2TGnh5Cth1s4I6+r7g==
   dependencies:
     tdigest "^0.1.1"
 
@@ -6559,7 +6606,6 @@ promise-to-callback@^1.0.0:
 promise@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/promise/-/promise-1.3.0.tgz#e5cc9a4c8278e4664ffedc01c7da84842b040175"
-  integrity sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=
   dependencies:
     is-promise "~1"
 
@@ -6570,12 +6616,10 @@ promisify-es6@^1.0.3:
 protocol-buffers-schema@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz#00434f608b4e8df54c59e070efeefc37fb4bb859"
-  integrity sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w==
 
 protons@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/protons/-/protons-1.0.1.tgz#1c107144c07fc2d1cb8b6cb76451e6a938237676"
-  integrity sha512-+0ZKnfVs+4c43tbAQ5j0Mck8wPcLnlxUYzKQoB4iDW4ocdXGnN4P+0dDbgX1FTpoY9+7P2Tn2scJyHHqj+S/lQ==
   dependencies:
     protocol-buffers-schema "^3.3.1"
     safe-buffer "^5.1.1"
@@ -6619,7 +6663,6 @@ pull-cat@^1.1.9:
 pull-catch@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/pull-catch/-/pull-catch-1.0.1.tgz#61be4d3d4184436a89994bec975f1ff4aea854cb"
-  integrity sha512-wrKbmEYySNETxOYXDTCJ8L/rcAFMayOifne2a+X9C0wSm6ttIWHHXwMYQh6k8iDRvtMM8itYkBlP4leKBJTiKA==
 
 pull-defer@^0.2.2, pull-defer@~0.2.3:
   version "0.2.3"
@@ -6628,7 +6671,6 @@ pull-defer@^0.2.2, pull-defer@~0.2.3:
 pull-handshake@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/pull-handshake/-/pull-handshake-1.1.4.tgz#6000a0fd018884cdfd737254f8cc60ab2a637791"
-  integrity sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=
   dependencies:
     pull-cat "^1.1.9"
     pull-pair "~1.1.0"
@@ -6638,7 +6680,6 @@ pull-handshake@^1.1.4:
 pull-length-prefixed@^1.3.1, pull-length-prefixed@^1.3.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/pull-length-prefixed/-/pull-length-prefixed-1.3.3.tgz#aa01aea117ef8be45ff6b0534e636827fa63b554"
-  integrity sha512-tAvRbeHMrA3pqZVth8A0VAYeTG9+mpBpyzFPTwH65Jf6K5GYB3WFkvLSP/rgXFy+tJ+vqf6tol7gme13r0Z10g==
   dependencies:
     pull-pushable "^2.2.0"
     pull-reader "^1.3.1"
@@ -6667,7 +6708,6 @@ pull-live@^1.0.1:
 pull-pair@^1.1.0, pull-pair@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pull-pair/-/pull-pair-1.1.0.tgz#7ee427263fdf4da825397ac0a05e1ab4b74bd76d"
-  integrity sha1-fuQnJj/fTaglOXrAoF4atLdL120=
 
 pull-pushable@^2.0.0, pull-pushable@^2.2.0:
   version "2.2.0"
@@ -6676,12 +6716,10 @@ pull-pushable@^2.0.0, pull-pushable@^2.2.0:
 pull-reader@^1.2.3, pull-reader@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/pull-reader/-/pull-reader-1.3.1.tgz#03a253e37efce111223ea2dc1dec847be1940be6"
-  integrity sha512-CBkejkE5nX50SiSEzu0Qoz4POTJMS/mw8G6aj3h3M/RJoKgggLxyF0IyTZ0mmpXFlXRcLmLmIEW4xeYn7AeDYw==
 
 pull-stream-to-stream@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/pull-stream-to-stream/-/pull-stream-to-stream-1.3.4.tgz#3f81d8216bd18d2bfd1a198190471180e2738399"
-  integrity sha1-P4HYIWvRjSv9GhmBkEcRgOJzg5k=
 
 pull-stream@^3.2.3, pull-stream@^3.4.0, pull-stream@^3.6.8:
   version "3.6.9"
@@ -6690,7 +6728,6 @@ pull-stream@^3.2.3, pull-stream@^3.4.0, pull-stream@^3.6.8:
 pull-stream@^3.6.7, pull-stream@^3.6.9:
   version "3.6.10"
   resolved "https://registry.yarnpkg.com/pull-stream/-/pull-stream-3.6.10.tgz#602fffec56ab000a5d93c6099d64976c6d5805f4"
-  integrity sha512-wRbdq8mDLYO4n8HoNI9rqPqb3Y6FWofr9ZlKnSYMT3P0iBr8qUoBNDm4ubOpef+oIpEcvjlmKNhiS42hgqEASw==
 
 pull-window@^2.1.4:
   version "2.1.4"
@@ -6861,6 +6898,12 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
+
 regenerate-unicode-properties@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.2.tgz#7b38faa296252376d363558cfbda90c9ce709662"
@@ -6950,7 +6993,6 @@ regjsparser@^0.6.0:
 relative-url@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/relative-url/-/relative-url-1.0.2.tgz#d21c52a72d6061018bcee9f9c9fc106bf7d65287"
-  integrity sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc=
 
 release-zalgo@^1.0.0:
   version "1.0.0"
@@ -6976,7 +7018,21 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.79.0, request@^2.85.0:
+request-promise-core@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.2.tgz#339f6aababcafdb31c799ff158700336301d3346"
+  dependencies:
+    lodash "^4.17.11"
+
+request-promise-native@^1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.7.tgz#a49868a624bdea5069f1251d0a836e0d89aa2c59"
+  dependencies:
+    request-promise-core "1.1.2"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
+
+request@^2.79.0, request@^2.85.0, request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   dependencies:
@@ -7025,7 +7081,7 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
-resolve@^1.10.0, resolve@^1.3.2, resolve@^1.8.1, resolve@~1.10.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.8.1, resolve@~1.10.0:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
   dependencies:
@@ -7051,7 +7107,6 @@ ret@~0.1.10:
 retimer@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/retimer/-/retimer-2.0.0.tgz#e8bd68c5e5a8ec2f49ccb5c636db84c04063bbca"
-  integrity sha512-KLXY85WkEq2V2bKex/LOO1ViXVn2KGYe4PYysAdYdjmraYIUsVkXu8O4am+8+5UbaaGl1qho4aqAAPHNQ4GSbg==
 
 rimraf@2, rimraf@2.6.3, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.6.3"
@@ -7082,7 +7137,6 @@ rlp@^2.0.0:
 rsa-pem-to-jwk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/rsa-pem-to-jwk/-/rsa-pem-to-jwk-1.1.3.tgz#245e76bdb7e7234cfee7ca032d31b54c38fab98e"
-  integrity sha1-JF52vbfnI0z+58oDLTG1TDj6uY4=
   dependencies:
     object-assign "^2.0.0"
     rsa-unpack "0.0.6"
@@ -7090,7 +7144,6 @@ rsa-pem-to-jwk@^1.1.3:
 rsa-unpack@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/rsa-unpack/-/rsa-unpack-0.0.6.tgz#f50ebd56a628378e631f297161026ce9ab4eddba"
-  integrity sha1-9Q69VqYoN45jHylxYQJs6atO3bo=
   dependencies:
     optimist "~0.3.5"
 
@@ -7305,10 +7358,17 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
+shelljs@^0.8.2:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 shot@3.x.x:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/shot/-/shot-3.4.2.tgz#1e5c3f6f2b26649adc42f7eb350214a5a0291d67"
-  integrity sha1-Hlw/bysmZJrcQvfrNQIUpaApHWc=
   dependencies:
     hoek "4.x.x"
     joi "10.x.x"
@@ -7320,7 +7380,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
 signed-varint@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/signed-varint/-/signed-varint-2.0.1.tgz#50a9989da7c98c2c61dad119bc97470ef8528129"
-  integrity sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=
   dependencies:
     varint "~5.0.0"
 
@@ -7339,7 +7398,6 @@ simple-get@^2.7.0:
 simple-peer@^9.1.2:
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/simple-peer/-/simple-peer-9.3.0.tgz#85ecb126b23d8730f3904f199db65e84141e0f4e"
-  integrity sha512-5dLDfrRomrS2LuZUuH2aO7yTGtHFEl5Eb+8ZzqM0KC0lHcYUyJudUomP9ZY/lPUKBx2broL/Eee9bQ53yycEgQ==
   dependencies:
     debug "^4.0.1"
     get-browser-rtc "^1.0.0"
@@ -7411,12 +7469,10 @@ snapdragon@^0.8.1:
 socket.io-adapter@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz#2a805e8a14d6372124dd9159ad4502f8cb07f06b"
-  integrity sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs=
 
 socket.io-client@2.2.0, socket.io-client@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.2.0.tgz#84e73ee3c43d5020ccc1a258faeeb9aec2723af7"
-  integrity sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==
   dependencies:
     backo2 "1.0.2"
     base64-arraybuffer "0.1.5"
@@ -7436,7 +7492,6 @@ socket.io-client@2.2.0, socket.io-client@^2.1.1:
 socket.io-parser@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.0.tgz#2b52a96a509fdf31440ba40fed6094c7d4f1262f"
-  integrity sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==
   dependencies:
     component-emitter "1.2.1"
     debug "~3.1.0"
@@ -7445,7 +7500,6 @@ socket.io-parser@~3.3.0:
 socket.io@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-2.2.0.tgz#f0f633161ef6712c972b307598ecd08c9b1b4d5b"
-  integrity sha512-wxXrIuZ8AILcn+f1B4ez4hJTPG24iNgxBBDaJfT6MsyOhVYiTXWexGoPkd87ktJG8kQEcL/NBvRi64+9k4Kc0w==
   dependencies:
     debug "~4.1.0"
     engine.io "~3.3.1"
@@ -7457,7 +7511,6 @@ socket.io@^2.1.1:
 somever@1.x.x:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/somever/-/somever-1.0.1.tgz#28a5c7de0d55f781af52fbce9960db1b84ce206e"
-  integrity sha512-PCDMBcega4n7wuBUKmkiXidF3cOwtHHGg2qJYl0Rkw7StZqORoCgqce7HUuWNta/NAiQhwLDezNnTANxEWPCGA==
   dependencies:
     hoek "4.x.x"
 
@@ -7549,14 +7602,12 @@ split-string@^3.0.1, split-string@^3.0.2:
 split@~0.3.0:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
-  integrity sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=
   dependencies:
     through "2"
 
 sprintf-js@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
-  integrity sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -7583,7 +7634,6 @@ stack-trace@0.0.x:
 statehood@5.x.x:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/statehood/-/statehood-5.0.4.tgz#bb5c343c357e3b6a18260c36cde4a282563ca558"
-  integrity sha512-6/feFLqqHylvA/dHwJA0DgXvbEcKgbhRUeljsuu6+cIr8PO88nax7Wc+celZlPTncqT2arsxXL8P329Q1yfe9Q==
   dependencies:
     boom "5.x.x"
     bourne "1.x.x"
@@ -7607,6 +7657,10 @@ static-extend@^0.1.1:
 statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
+
+stealthy-require@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
 stream-to-pull-stream@^1.7.1, stream-to-pull-stream@^1.7.2:
   version "1.7.3"
@@ -7720,7 +7774,6 @@ sublevel-pouchdb@7.0.0:
 subtext@5.x.x:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/subtext/-/subtext-5.0.1.tgz#3ba39c93260e2e2ee1eddcde371be9d5fbe88861"
-  integrity sha512-zH/jaUKJ/bkrTpEe3zuTFIRnqAwv5xcGpXA2JaxEc30KRAT4k78jZnRqM45snjBSZAuvpI8chRUh1VZprcUVfw==
   dependencies:
     boom "5.x.x"
     bourne "1.x.x"
@@ -7790,6 +7843,10 @@ swarm-js@0.1.37:
     setimmediate "^1.0.5"
     tar.gz "^1.0.5"
     xhr-request-promise "^0.1.2"
+
+symbol-tree@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
 table@^5.2.3:
   version "5.2.3"
@@ -7872,7 +7929,6 @@ tar@^4:
 tdigest@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
-  integrity sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=
   dependencies:
     bintrees "1.0.1"
 
@@ -7934,7 +7990,6 @@ through@2, through@^2.3.6, through@^2.3.8, through@~2.3.4, through@~2.3.8:
 time-cache@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/time-cache/-/time-cache-0.3.0.tgz#ed0dfcf0fda45cdc95fbd601fda830ebf1bd5d8b"
-  integrity sha1-7Q388P2kXNyV+9YB/agw6/G9XYs=
   dependencies:
     lodash.throttle "^4.1.1"
 
@@ -7951,7 +8006,6 @@ tmp@0.0.33, tmp@^0.0.33:
 to-array@0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
-  integrity sha1-F+bBH3PdTz10zaek/zI46a2b+JA=
 
 to-buffer@^1.1.1:
   version "1.1.1"
@@ -7990,18 +8044,16 @@ to-regex@^3.0.1, to-regex@^3.0.2:
 topo@2.x.x:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/topo/-/topo-2.0.2.tgz#cd5615752539057c0dc0491a621c3bc6fbe1d182"
-  integrity sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=
   dependencies:
     hoek "4.x.x"
 
 topo@3.x.x:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/topo/-/topo-3.0.3.tgz#d5a67fb2e69307ebeeb08402ec2a2a6f5f7ad95c"
-  integrity sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==
   dependencies:
     hoek "6.x.x"
 
-tough-cookie@^2.3.1:
+tough-cookie@^2.3.1, tough-cookie@^2.3.3, tough-cookie@^2.3.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   dependencies:
@@ -8014,6 +8066,12 @@ tough-cookie@~2.4.3:
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
+
+tr46@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  dependencies:
+    punycode "^2.1.0"
 
 trim-right@^1.0.1:
   version "1.0.1"
@@ -8052,6 +8110,12 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+turndown@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/turndown/-/turndown-5.0.3.tgz#a1350b66155d7891f10e451432170b0f7cd7449a"
+  dependencies:
+    jsdom "^11.9.0"
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
@@ -8087,6 +8151,50 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typedoc-default-themes@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
+
+typedoc-plugin-external-module-name@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-external-module-name/-/typedoc-plugin-external-module-name-2.1.0.tgz#25f108e99673ad34f3424719c10c299ee50e92f0"
+
+typedoc-plugin-internal-external@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-internal-external/-/typedoc-plugin-internal-external-2.0.2.tgz#6ced269be25e1b23559443c2ce6a5483860d53c3"
+
+typedoc-plugin-markdown@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-1.2.0.tgz#8bc551656be42d2dfa7879675dfa29470c170190"
+  dependencies:
+    turndown "^5.0.3"
+
+typedoc@^0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.14.2.tgz#769f457f4f9e4bdb8b5f3b177c86b6a31d8c3dc3"
+  dependencies:
+    "@types/fs-extra" "^5.0.3"
+    "@types/handlebars" "^4.0.38"
+    "@types/highlight.js" "^9.12.3"
+    "@types/lodash" "^4.14.110"
+    "@types/marked" "^0.4.0"
+    "@types/minimatch" "3.0.3"
+    "@types/shelljs" "^0.8.0"
+    fs-extra "^7.0.0"
+    handlebars "^4.0.6"
+    highlight.js "^9.13.1"
+    lodash "^4.17.10"
+    marked "^0.4.0"
+    minimatch "^3.0.0"
+    progress "^2.0.0"
+    shelljs "^0.8.2"
+    typedoc-default-themes "^0.5.0"
+    typescript "3.2.x"
+
+typescript@3.2.x:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
+
 typescript@^3.2.1:
   version "3.4.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
@@ -8115,7 +8223,6 @@ uglify-js@^3.1.4:
 ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
-  integrity sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=
 
 ultron@~1.1.0:
   version "1.1.1"
@@ -8163,7 +8270,10 @@ union-value@^1.0.0:
 unique-by@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unique-by/-/unique-by-1.0.0.tgz#5220c86ba7bc572fb713ad74651470cb644212bd"
-  integrity sha1-UiDIa6e8Vy+3E610ZRRwy2RCEr0=
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
 
 unorm@^1.3.3:
   version "1.5.0"
@@ -8215,7 +8325,6 @@ urlgrey@^0.4.4:
 ursa-optional@~0.9.10:
   version "0.9.10"
   resolved "https://registry.yarnpkg.com/ursa-optional/-/ursa-optional-0.9.10.tgz#f2eabfe0b6001dbf07a78740cd0a6e5ba6eb2554"
-  integrity sha512-RvEbhnxlggX4MXon7KQulTFiJQtLJZpSb9ZSa7ZTkOW0AzqiVTaLjI4vxaSzJBDH9dwZ3ltZadFiBaZslp6haA==
   dependencies:
     bindings "^1.3.0"
     nan "^2.11.1"
@@ -8268,7 +8377,6 @@ validate-npm-package-license@^3.0.1:
 varint@^5.0.0, varint@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/varint/-/varint-5.0.0.tgz#d826b89f7490732fabc0c0ed693ed475dcb29ebf"
-  integrity sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8=
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"
@@ -8285,13 +8393,18 @@ verror@1.10.0:
 vise@2.x.x:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/vise/-/vise-2.0.2.tgz#6b08e8fb4cb76e3a50cd6dd0ec37338e811a0d39"
-  integrity sha1-awjo+0y3bjpQzW3Q7DczjoEaDTk=
   dependencies:
     hoek "4.x.x"
 
 vuvuzela@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/vuvuzela/-/vuvuzela-1.0.3.tgz#3be145e58271c73ca55279dd851f12a682114b0b"
+
+w3c-hr-time@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
+  dependencies:
+    browser-process-hrtime "^0.1.2"
 
 web3-bzz@1.0.0-beta.35:
   version "1.0.0-beta.35"
@@ -8513,6 +8626,10 @@ web3@1.0.0-beta.35:
     web3-shh "1.0.0-beta.35"
     web3-utils "1.0.0-beta.35"
 
+webidl-conversions@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+
 "webrtcsupport@github:ipfs/webrtcsupport":
   version "2.2.0"
   resolved "https://codeload.github.com/ipfs/webrtcsupport/tar.gz/0669f576582c53a3a42aa5ac014fcc5966809615"
@@ -8535,9 +8652,35 @@ websocket@1.0.26:
     typedarray-to-buffer "^3.1.2"
     yaeti "^0.0.6"
 
+whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
+  dependencies:
+    iconv-lite "0.4.24"
+
 whatwg-fetch@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
+
+whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
+
+whatwg-url@^6.4.1:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
+
+whatwg-url@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 which-module@^2.0.0:
   version "2.0.0"
@@ -8602,7 +8745,6 @@ wrappy@1:
 wreck@12.x.x:
   version "12.5.1"
   resolved "https://registry.yarnpkg.com/wreck/-/wreck-12.5.1.tgz#cd2ffce167449e1f0242ed9cf80552e20fb6902a"
-  integrity sha512-l5DUGrc+yDyIflpty1x9XuMj1ehVjC/dTbF3/BasOO77xk0EdEa4M/DuOY8W88MQDAD0fEDqyjc8bkIMHd2E9A==
   dependencies:
     boom "5.x.x"
     hoek "4.x.x"
@@ -8624,7 +8766,6 @@ write@1.0.3:
 ws@^1.1.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.5.tgz#cbd9e6e75e09fc5d2c90015f21f0c40875e0dd51"
-  integrity sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"
@@ -8637,7 +8778,7 @@ ws@^3.0.0:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
-ws@^5.1.1:
+ws@^5.1.1, ws@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
   dependencies:
@@ -8652,7 +8793,6 @@ ws@^6.2.1:
 ws@~6.1.0:
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.4.tgz#5b5c8800afab925e94ccb29d153c8d02c1776ef9"
-  integrity sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==
   dependencies:
     async-limiter "~1.0.0"
 
@@ -8689,10 +8829,13 @@ xhr@^2.0.4, xhr@^2.2.0, xhr@^2.3.3:
     parse-headers "^2.0.0"
     xtend "^4.0.0"
 
+xml-name-validator@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+
 xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
-  integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
 
 xmlhttprequest@1.8.0:
   version "1.8.0"
@@ -8701,7 +8844,6 @@ xmlhttprequest@1.8.0:
 xor-distance@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/xor-distance/-/xor-distance-2.0.0.tgz#cad3920d3a1e3d73eeedc61a554e51972dae0798"
-  integrity sha512-AsAqZfPAuWx7qB/0kyRDUEvoU3QKsHWzHU9smFlkaiprEpGfJ/NBbLze2Uq0rdkxCxkNM9uOLvz/KoNBCbZiLQ==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
@@ -8769,7 +8911,6 @@ yauzl@^2.4.2:
 yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
-  integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
 
 yn@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Adds a `yarn build:docs` script to run `typedoc` against our code
and a travis deployment step to sync the docs to the lodestar gh pages.

You can see what it will look like by running
`yarn build:docs && cd docs && python -m SimpleHTTPServer`
and going to `localhost:8000` in the browser.

Most of the changes in this PR are either
- adding `@module` to group the code for the docs
- removing extraneous jsdoc @param/@returns (though any param/return description was retained)