### PR TITLE
convert effective_balance_increment to BN

### DIFF
--- a/src/chain/stateTransition/block/deposits.ts
+++ b/src/chain/stateTransition/block/deposits.ts
@@ -77,7 +77,7 @@ export function processDeposit(state: BeaconState, deposit: Deposit): void {
       withdrawableEpoch: FAR_FUTURE_EPOCH,
       slashed: false,
       effectiveBalance: bnMin(
-        amount.subn(amount.modn(EFFECTIVE_BALANCE_INCREMENT)),
+        amount.sub(amount.mod(EFFECTIVE_BALANCE_INCREMENT)),
         new BN(MAX_EFFECTIVE_BALANCE)),
     };
     state.validatorRegistry.push(validator);

--- a/src/chain/stateTransition/epoch/finalUpdates.ts
+++ b/src/chain/stateTransition/epoch/finalUpdates.ts
@@ -33,10 +33,11 @@ export function processFinalUpdates(state: BeaconState): void {
   // Update effective balances with hysteresis
   state.validatorRegistry.forEach((validator, index) => {
     const balance = state.balances[index];
-    const HALF_INCREMENT = intDiv(EFFECTIVE_BALANCE_INCREMENT, 2);
+    // TODO probably unsafe
+    const HALF_INCREMENT = EFFECTIVE_BALANCE_INCREMENT.divn(2).toNumber();
     if (balance.lt(validator.effectiveBalance) || validator.effectiveBalance.addn(3 * HALF_INCREMENT).lt(balance)) {
       validator.effectiveBalance = bnMin(
-        balance.subn(balance.modn(EFFECTIVE_BALANCE_INCREMENT)),
+        balance.sub(balance.mod(EFFECTIVE_BALANCE_INCREMENT)),
         new BN(MAX_EFFECTIVE_BALANCE));
     }
   });

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,3 +1,4 @@
+import BN from "bn.js";
 /**
  * @module constants
  */
@@ -19,7 +20,7 @@ export const DEPOSIT_CONTRACT_TREE_DEPTH = 2 ** 5; // 32
 export const MIN_DEPOSIT_AMOUNT = 2 ** 0 * 1e9; // 1,000,000,000 Gwei
 export const MAX_EFFECTIVE_BALANCE = 2 ** 5 * 1e9; // 32,000,000,000 Gwei
 export const EJECTION_BALANCE = 2 ** 4 * 1e9; // 16,000,000,000 Gwei
-export const EFFECTIVE_BALANCE_INCREMENT = 2 ** 0 * 1e9; // 1,000,000,000 Gwei
+export const EFFECTIVE_BALANCE_INCREMENT = new BN(2 ** 0 * 1e9); // 1,000,000,000 Gwei
 
 // Initial values
 export const GENESIS_SLOT = 0;


### PR DESCRIPTION
This addresses an issue found in #200 where modding effective_balance_increment causes the resultant to be a number, rather than a BN, which causes a assertion failure from within the BN.js library