### PR TITLE
fix bug with db flag

### DIFF
--- a/src/cli/commands/beacon.ts
+++ b/src/cli/commands/beacon.ts
@@ -51,9 +51,18 @@ export class BeaconNodeCommand implements CliCommand {
       parsedConfig = getTomlConfig(options.configFile);
     }
 
+    let dbName: string;
+    if (options.db) {
+      dbName = options.db;
+    } else if (parsedConfig) {
+      dbName = parsedConfig.db.name;
+    } else {
+      dbName = defaults.db.name;
+    }
+
     let optionsMap: BeaconNodeCtx = {
       db: {
-        name: options.db || parsedConfig ? parsedConfig.db.name : defaults.db.name,
+        name: dbName,
       },
       eth1: {
         depositContract: {


### PR DESCRIPTION
This solves a bug found in #200 where the `--db` has strange behaviour and does not use the flag. This PR dumbs down the the logic into simple if/else statements.