### PR TITLE
Add ProgressiveMerkleTree implementation

### DIFF
--- a/src/chain/stateTransition/block/deposits.ts
+++ b/src/chain/stateTransition/block/deposits.ts
@@ -25,13 +25,13 @@ import {
 
 import {hash} from "../../../util/crypto";
 import {bnMin} from "../../../util/math";
+import {verifyMerkleBranch} from "../../../util/merkleTree";
 
 import bls from "@chainsafe/bls-js";
 
 import {
   getDomain,
   increaseBalance,
-  verifyMerkleBranch,
 } from "../util";
 
 

--- a/src/chain/stateTransition/util/misc.ts
+++ b/src/chain/stateTransition/util/misc.ts
@@ -84,22 +84,6 @@ export function getBeaconProposerIndex(state: BeaconState): ValidatorIndex {
 }
 
 /**
- * Verify that the given ``leaf`` is on the merkle branch ``proof``
- * starting with the given ``root``.
- */
-export function verifyMerkleBranch(leaf: bytes32, proof: bytes32[], depth: number, index: number, root: bytes32): boolean {
-  let value = leaf;
-  for (let i = 0; i < depth; i++) {
-    if (intDiv(index, 2**i) % 2) {
-      value = hash(Buffer.concat([proof[i], value]));
-    } else {
-      value = hash(Buffer.concat([value, proof[i]]));
-    }
-  }
-  return value.equals(root);
-}
-
-/**
  * Return the signature domain (fork version concatenated with domain type) of a message.
  */
 export function getDomain(state: BeaconState, domainType: number, messageEpoch: Epoch | null = null): BLSDomain {

--- a/src/util/merkleTree.ts
+++ b/src/util/merkleTree.ts
@@ -1,0 +1,150 @@
+/**
+ * @module util/merkleTree
+ */
+
+import assert from "assert";
+import {bytes32} from "../types";
+import {hash} from "../util/crypto";
+import {intDiv} from "../util/math";
+
+interface IProgressiveMerkleTree {
+  /**
+   * The number of items in the tree
+   */
+  count(): number;
+  depth(): number;
+  /**
+   * Add a new item into the tree
+   *
+   * Return a proof to verify the item is in the tree
+   * @returns proof
+   */
+  push(item: bytes32): bytes32[];
+  /**
+   * The merkle root of the tree
+   */
+  root(): bytes32;
+}
+
+export class ProgressiveMerkleTree implements IProgressiveMerkleTree {
+  private _depth: number;
+  private _count: number;
+  private _branch: bytes32[];
+  private _zerohashes: bytes32[];
+
+  public constructor(depth: number) {
+    assert(depth <= 52, "tree depth must be less than 53");
+    this._depth = depth;
+    this._count = 0;
+    this._branch = Array.from({length: depth}, () => Buffer.alloc(32));
+    this._zerohashes = Array.from({length: depth}, () => Buffer.alloc(32));
+    for (let i = 0; i < depth - 1; i++) {
+      this._zerohashes[i + 1] = this._branch[i + 1] =
+        hash(Buffer.concat([
+          this._zerohashes[i],
+          this._zerohashes[i],
+        ]));
+    }
+  }
+
+  public count(): number {
+    return this._count;
+  }
+
+  public depth(): number {
+    return this._depth;
+  }
+
+  public push(item: bytes32): bytes32[] {
+    const depth = this._depth;
+    const proof = this._proof();
+    this._count++;
+    let i = 0;
+    let powerOfTwo = 2;
+    for (let j = 0; j < depth; j++) {
+      if (this._count % powerOfTwo !== 0) {
+        break;
+      }
+      i++;
+      powerOfTwo *= 2;
+    }
+
+    let value = item;
+    for (let j = 0; j < depth; j++) {
+      if (j < i) {
+        value = hash(Buffer.concat([
+          this._branch[j],
+          value,
+        ]));
+      } else {
+        break;
+      }
+    }
+    this._branch[i] = value;
+    return proof;
+  }
+
+  public clone(): ProgressiveMerkleTree {
+    const cloned: ProgressiveMerkleTree = Object.create(ProgressiveMerkleTree.prototype);
+    cloned._depth = this._depth;
+    cloned._count = this._count;
+    cloned._branch = this._branch.slice();
+    cloned._zerohashes = this._zerohashes;
+    return cloned;
+  }
+
+  public root(): bytes32 {
+    let root = Buffer.alloc(32);
+    let size = this._count;
+    for (let i = 0; i < this._depth; i++) {
+      if (size % 2 === 1) {
+        root = hash(Buffer.concat([
+          this._branch[i],
+          root,
+        ]));
+      } else {
+        root = hash(Buffer.concat([
+          root,
+          this._zerohashes[i],
+        ]));
+      }
+      size = intDiv(size, 2);
+    }
+    return root;
+  }
+
+  private _proof(): bytes32[] {
+    let size = this._count;
+    let proof = this._branch.slice();
+    for (let i = 0; i < this._depth; i++) {
+      if (size % 2 === 0) {
+        proof[i] = this._zerohashes[i];
+      }
+      size = intDiv(size, 2);
+    }
+    return proof;
+  }
+
+}
+
+/**
+ * Verify that the given ``leaf`` is on the merkle branch ``proof``
+ * starting with the given ``root``.
+ */
+export function verifyMerkleBranch(
+  leaf: bytes32,
+  proof: bytes32[],
+  depth: number,
+  index: number,
+  root: bytes32,
+): boolean {
+  let value = leaf;
+  for (let i = 0; i < depth; i++) {
+    if (intDiv(index, 2**i) % 2) {
+      value = hash(Buffer.concat([proof[i], value]));
+    } else {
+      value = hash(Buffer.concat([value, proof[i]]));
+    }
+  }
+  return value.equals(root);
+}

--- a/test/unit/chain/stateTransition/util/misc.test.ts
+++ b/test/unit/chain/stateTransition/util/misc.test.ts
@@ -11,7 +11,6 @@ import {
   getBeaconProposerIndex,
   getBlockRootAtSlot,
   getBlockRoot,
-  verifyMerkleBranch,
   getDomain,
   getChurnLimit,
 } from "../../../../../src/chain/stateTransition/util/misc";

--- a/test/unit/util/merkleTree.test.ts
+++ b/test/unit/util/merkleTree.test.ts
@@ -1,0 +1,47 @@
+import { assert } from "chai";
+
+import {
+  ProgressiveMerkleTree,
+  verifyMerkleBranch,
+} from "../../../src/util/merkleTree";
+
+
+describe('util/merkleTree', function() {
+  describe('ProgressiveMerkleTree', function() {
+    it("can add items", () => {
+      const t = new ProgressiveMerkleTree(4);
+      let count = 0;
+      assert.equal(t.count(), count, `Should have ${count} items`);
+      const buf = Buffer.alloc(32);
+      for (let i = 1; i < 10; i++) {
+        buf[0] = i;
+        t.push(buf);
+        count++;
+        assert.equal(t.count(), count, `Should have ${count} items`);
+      }
+    });
+    it("returns valid proofs", () => {
+      const depth = 4;
+      const t = new ProgressiveMerkleTree(depth);
+      for (let i = 0; i < 10; i++) {
+        let buf = Buffer.alloc(32);
+        buf[0] = 10;
+        const proof = t.push(buf);
+        assert(verifyMerkleBranch(buf, proof, depth, t.count() - 1, t.root()));
+      }
+    });
+    it("clones of a tree do not effect the original", () => {
+      const depth = 4;
+      const t = new ProgressiveMerkleTree(depth);
+      const clone = t.clone();
+      for (let i = 0; i < 10; i++) {
+        let buf = Buffer.alloc(32);
+        buf[0] = 10;
+        t.push(buf);
+      }
+      assert(clone.count() === 0);
+      assert(t.count() === 10);
+      assert(!clone.root().equals(t.root()));
+    });
+  });
+});


### PR DESCRIPTION
- Move `verifyMerkleBranch` to `src/util/merkleTree.ts`
- Add `ProgressiveMerkleTree` implementation
  - follows the logic of the deposit contract
  - the tree only stores the latest non-default branch in the merkle tree (we take advantage of the fact that most of the tree is successive hashes of zeroed data)
  - this tree is append-only,  `push`ing a new item into the tree returns a `proof` (`bytes32[]`)
  - the `proof`, along with the `root`, `index`, and inserted `item` can be verified w/ `verifyMerkleBranch`
  - the tree can return the `count` of items in the tree (used to get the `index` of an item to-be-inserted or a just-inserted item) and the `root` of the tree
  - `clone` a tree to create a duplicate tree