### PR TITLE
Make db controller naming consistent

### DIFF
--- a/src/db/api/abstract.ts
+++ b/src/db/api/abstract.ts
@@ -1,8 +1,8 @@
-import {IDatabaseController} from "../persistance";
+import {IDatabaseController} from "../controller";
 import {Service} from "../../node";
 
 export interface DatabaseApiOptions {
-  persistance: IDatabaseController;
+  controller: IDatabaseController;
 }
 
 export abstract class DatabaseService implements Service{
@@ -10,7 +10,7 @@ export abstract class DatabaseService implements Service{
   protected db: IDatabaseController;
 
   protected constructor(opts: DatabaseApiOptions) {
-    this.db = opts.persistance;
+    this.db = opts.controller;
   }
 
   public async start(): Promise<void> {

--- a/src/db/controller/impl/level.ts
+++ b/src/db/controller/impl/level.ts
@@ -1,5 +1,5 @@
 /**
- * @module db/persistance/impl
+ * @module db/controller/impl
  */
 
 import {LevelUp} from "levelup";
@@ -17,7 +17,7 @@ export interface LevelDBOptions extends DBOptions {
 /**
  * The LevelDB implementation of DB
  */
-export class LevelDbPersistance extends EventEmitter implements IDatabaseController {
+export class LevelDbController extends EventEmitter implements IDatabaseController {
 
   private db: LevelUp;
 

--- a/src/db/controller/impl/pouch.ts
+++ b/src/db/controller/impl/pouch.ts
@@ -1,5 +1,5 @@
 /**
- * @module db/persistance/impl
+ * @module db/controller/impl
  */
 
 import PouchDB from "pouchdb-core";
@@ -11,7 +11,7 @@ PouchDB.plugin(MemoryAdapter);
 
 const BASE_REVISION = "1";
 
-export class PouchDbPersistance extends EventEmitter implements IDatabaseController {
+export class PouchDbController extends EventEmitter implements IDatabaseController {
 
   private db: PouchDB.Database;
 

--- a/src/db/controller/index.ts
+++ b/src/db/controller/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @module db/controller
+ */
+
+export {IDatabaseController, DBOptions, SearchOptions} from "./interface";
+export {LevelDbController} from "./impl/level";
+export {PouchDbController} from "./impl/pouch";

--- a/src/db/controller/interface.ts
+++ b/src/db/controller/interface.ts
@@ -1,5 +1,5 @@
 /**
- * @module db/persistance
+ * @module db/controller
  */
 
 import {EventEmitter} from "events";

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -3,10 +3,10 @@
  */
 
 export {
-  LevelDbPersistance,
-  PouchDbPersistance,
+  LevelDbController,
+  PouchDbController,
   IDatabaseController,
   SearchOptions,
   DBOptions
-} from "./persistance";
+} from "./controller";
 export {BeaconDB, IBeaconDb, ValidatorDB, IValidatorDB} from "./api";

--- a/src/db/persistance/index.ts
+++ b/src/db/persistance/index.ts
@@ -1,7 +1,0 @@
-/**
- * @module db/persistance
- */
-
-export {IDatabaseController, DBOptions, SearchOptions} from "./interface";
-export {LevelDbPersistance} from "./impl/level";
-export {PouchDbPersistance} from "./impl/pouch";

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -3,7 +3,7 @@
  */
 
 import deepmerge from "deepmerge";
-import {BeaconDB, LevelDbPersistance} from "../db";
+import {BeaconDB, LevelDbController} from "../db";
 import {EthersEth1Notifier, EthersEth1Options} from "../eth1";
 import {Libp2pNetwork, NetworkOptions, NodejsNode} from "../network";
 
@@ -66,7 +66,7 @@ class BeaconNode {
     );
 
     this.db = new BeaconDB({
-      persistance: new LevelDbPersistance(
+      controller: new LevelDbController(
         this.conf.db
       )
     });

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -19,8 +19,7 @@ import {Epoch, Slot, ValidatorIndex} from "../types";
 import {GenesisInfo, ValidatorCtx} from "./types";
 import {RpcClient, RpcClientOverWs} from "./rpc";
 import {AttestationService} from "./services/attestation";
-import {ValidatorDB, IValidatorDB} from "../db";
-import {LevelDbPersistance} from "../db/persistance";
+import {ValidatorDB, IValidatorDB, LevelDbController} from "../db";
 
 /**
  * Main class for the Validator client.
@@ -41,7 +40,7 @@ class Validator {
     this.logger = logger;
     this.isActive = false;
     this.db = ctx.db ? ctx.db : new ValidatorDB({
-      persistance: new LevelDbPersistance({
+      controller: new LevelDbController({
         name: 'LodestarValidatorDB'
       })
     });

--- a/test/e2e/eth1/deploy.test.ts
+++ b/test/e2e/eth1/deploy.test.ts
@@ -7,7 +7,7 @@ import defaults from "../../../src/eth1/dev/defaults";
 import {PrivateEth1Network} from "../../../src/eth1/dev";
 import logger from "../../../src/logger/winston";
 import {BeaconDB} from "../../../src/db/api";
-import {PouchDbPersistance} from "../../../src/db";
+import {PouchDbController} from "../../../src/db";
 
 describe("Eth1Notifier - using deployed contract", () => {
 
@@ -16,7 +16,7 @@ describe("Eth1Notifier - using deployed contract", () => {
   let depositContractAddress;
   let provider;
   const db = new BeaconDB({
-    persistance: new PouchDbPersistance(
+    controller: new PouchDbController(
       {name: 'testDb'}
     )
   });

--- a/test/unit/db/api/beacon.test.ts
+++ b/test/unit/db/api/beacon.test.ts
@@ -3,7 +3,7 @@ import sinon from "sinon";
 import * as dbKeys from "../../../../src/db/schema";
 import {Bucket, Key} from "../../../../src/db/schema";
 import {BeaconDB} from "../../../../src/db/api";
-import {LevelDbPersistance} from "../../../../src/db/persistance";
+import {LevelDbController} from "../../../../src/db/controller";
 import {
   Attestation,
   AttesterSlashing,
@@ -36,9 +36,9 @@ describe('beacon db api', function() {
 
   beforeEach(() => {
     encodeKeyStub = sandbox.stub(dbKeys, 'encodeKey');
-    dbStub = sandbox.createStubInstance(LevelDbPersistance);
+    dbStub = sandbox.createStubInstance(LevelDbController);
     beaconDB = new BeaconDB({
-      persistance: dbStub
+      controller: dbStub
     });
   });
 

--- a/test/unit/db/api/validator.test.ts
+++ b/test/unit/db/api/validator.test.ts
@@ -2,7 +2,7 @@ import sinon from "sinon";
 
 import * as dbKeys from "../../../../src/db/schema";
 import {Bucket} from "../../../../src/db/schema";
-import {LevelDbPersistance} from "../../../../src/db/persistance";
+import {LevelDbController} from "../../../../src/db/controller";
 import {Attestation, BeaconBlock} from "../../../../src/types";
 import chai, {expect} from "chai";
 import {serialize} from "@chainsafe/ssz";
@@ -22,9 +22,9 @@ describe('beacon db api', function () {
 
   beforeEach(() => {
     encodeKeyStub = sandbox.stub(dbKeys, 'encodeKey');
-    dbStub = sandbox.createStubInstance(LevelDbPersistance);
+    dbStub = sandbox.createStubInstance(LevelDbController);
     validatorDB = new ValidatorDB({
-      persistance: dbStub
+      controller: dbStub
     });
   });
 

--- a/test/unit/db/controller/level.test.ts
+++ b/test/unit/db/controller/level.test.ts
@@ -1,18 +1,18 @@
 import {assert, expect} from "chai";
 import level from "level";
 import leveldown from "leveldown";
-import {LevelDbPersistance} from "../../../../src/db/persistance";
+import {LevelDbController} from "../../../../src/db/controller";
 import logger from "../../../../src/logger";
 import promisify from "promisify-es6";
 
-describe("LevelDB persistance", () => {
+describe("LevelDB controller", () => {
   const dbLocation = "./.__testdb";
   const testDb = level(
     dbLocation, {
       keyEncoding: 'binary',
       valueEncoding: 'binary',
     });
-  const db = new LevelDbPersistance({db: testDb});
+  const db = new LevelDbController({db: testDb});
 
   before(async () => {
     logger.silent(true);

--- a/test/unit/db/controller/pouch.test.ts
+++ b/test/unit/db/controller/pouch.test.ts
@@ -1,9 +1,9 @@
 import {assert, expect} from "chai";
-import {PouchDbPersistance} from "../../../../src/db/persistance";
+import {PouchDbController} from "../../../../src/db/controller";
 import logger from "../../../../src/logger";
 
-describe("PouchDB persistance", () => {
-  const db = new PouchDbPersistance({name: 'testDb'});
+describe("PouchDB controller", () => {
+  const db = new PouchDbController({name: 'testDb'});
 
   before(async () => {
     logger.silent(true);


### PR DESCRIPTION
Just a naming thing, no changed functionality.
This aligns the db controller interface/implementation/file names.