### PR TITLE
Update db interface

### DIFF
--- a/src/chain/factory/block/index.ts
+++ b/src/chain/factory/block/index.ts
@@ -17,11 +17,11 @@ export async function assembleBlock(
   slot: Slot,
   randao: bytes96
 ): Promise<BeaconBlock> {
-  const [parentBlock, currentState, merkleTree] = await Promise.all([
+  const [parentBlock, currentState] = await Promise.all([
     db.getChainHead(),
-    db.getState(),
-    db.getMerkleTree()
+    db.getLatestState(),
   ]);
+  const merkleTree = await db.getMerkleTree(currentState.depositIndex);
   const parentHeader: BeaconBlockHeader = {
     stateRoot: parentBlock.stateRoot,
     signature: parentBlock.signature,

--- a/src/db/api/abstract.ts
+++ b/src/db/api/abstract.ts
@@ -8,11 +8,9 @@ export interface DatabaseApiOptions {
 export abstract class DatabaseService implements Service{
 
   protected db: IDatabaseController;
-  protected cache: Record<any, any>;
 
   protected constructor(opts: DatabaseApiOptions) {
     this.db = opts.controller;
-    this.cache = {};
   }
 
   public async start(): Promise<void> {

--- a/src/db/api/abstract.ts
+++ b/src/db/api/abstract.ts
@@ -8,9 +8,11 @@ export interface DatabaseApiOptions {
 export abstract class DatabaseService implements Service{
 
   protected db: IDatabaseController;
+  protected cache: Record<any, any>;
 
   protected constructor(opts: DatabaseApiOptions) {
     this.db = opts.controller;
+    this.cache = {};
   }
 
   public async start(): Promise<void> {

--- a/src/db/api/beacon/interface.ts
+++ b/src/db/api/beacon/interface.ts
@@ -40,108 +40,118 @@ export interface IBeaconDb {
    */
   deleteDeposits(): Promise<void>;
 
-  setMerkleTree(merkleTree: IProgressiveMerkleTree): Promise<void>;
+  setMerkleTree(index: number, merkleTree: IProgressiveMerkleTree): Promise<void>;
 
-  getMerkleTree(): Promise<IProgressiveMerkleTree>;
-
-  /**
-   * Get the beacon chain state
-   */
-  getState(): Promise<BeaconState>;
+  getMerkleTree(index: number): Promise<IProgressiveMerkleTree | null>;
 
   /**
-   * Set the beacon chain state
+   * Get a beacon chain state by hash
    */
-  setState(state: BeaconState): Promise<void>;
+  getState(root: bytes32): Promise<BeaconState | null>;
+
+  /**
+   * Set a beacon chain state
+   */
+  setState(root: bytes32, state: BeaconState): Promise<void>;
+
+  /**
+   * Get the latest beacon chain state
+   */
+  getLatestState(): Promise<BeaconState | null>;
+
+  /**
+   * Set the latest beacon chain state
+   */
+  setLatestStateRoot(root: bytes32, state?: BeaconState): Promise<void>;
+
+  /**
+   * Get the last finalized state
+   */
+  getFinalizedState(): Promise<BeaconState | null>;
+
+  /**
+   * Set the last finalized state
+   */
+  setFinalizedStateRoot(root: bytes32, state?: BeaconState): Promise<void>;
+
+  /**
+   * Get the last justified state
+   */
+  getJustifiedState(): Promise<BeaconState | null>;
+
+  /**
+   * Set the last justified state
+   */
+  setJustifiedStateRoot(root: bytes32, state?: BeaconState): Promise<void>;
 
   /**
    * Returns validator index coresponding to validator
    * public key in registry,
    * @param publicKey
    */
-  getValidatorIndex(publicKey: BLSPubkey): Promise<ValidatorIndex>;
-
-  /**
-   * Get the last finalized state
-   */
-  getFinalizedState(): Promise<BeaconState>;
-
-  /**
-   * Set the last justified state
-   */
-  setJustifiedState(state: BeaconState): Promise<void>;
-
-  /**
-   * Get the last justified state
-   */
-  getJustifiedState(): Promise<BeaconState>;
-
-  /**
-   * Set the last finalized state
-   */
-  setFinalizedState(state: BeaconState): Promise<void>;
+  getValidatorIndex(publicKey: BLSPubkey): Promise<ValidatorIndex | null>;
 
   /**
    * Get a block by block hash
    */
-  getBlock(blockRoot: bytes32): Promise<BeaconBlock>;
+  getBlock(blockRoot: bytes32): Promise<BeaconBlock | null>;
 
   hasBlock(blockHash: bytes32): Promise<boolean>;
 
   /**
    * Get a block root by slot
    */
-  getBlockRoot(slot: Slot): Promise<bytes32>;
+  getBlockRoot(slot: Slot): Promise<bytes32 | null>;
 
   /**
    * Get a block by slot
    */
-  getBlockBySlot(slot: Slot): Promise<BeaconBlock>;
+  getBlockBySlot(slot: Slot): Promise<BeaconBlock | null>;
 
   /**
    * Put a block into the db
    */
-  setBlock(block: BeaconBlock): Promise<void>;
+  setBlock(root: bytes32, block: BeaconBlock): Promise<void>;
 
   /**
    * Get the latest finalized block
    */
-  getFinalizedBlock(): Promise<BeaconBlock>;
+  getFinalizedBlock(): Promise<BeaconBlock | null>;
 
   /**
    * Set the latest finalized block
    */
-  setFinalizedBlock(block: BeaconBlock): Promise<void>;
+  setFinalizedBlockRoot(root: bytes32, block?: BeaconBlock): Promise<void>;
 
   /**
    * Get the latest justified block
    */
-  getJustifiedBlock(): Promise<BeaconBlock>;
+  getJustifiedBlock(): Promise<BeaconBlock | null>;
 
   /**
    * Set the latest justified block
    */
-  setJustifiedBlock(block: BeaconBlock): Promise<void>;
+  setJustifiedBlockRoot(root: bytes32, block?: BeaconBlock): Promise<void>;
 
   /**
    * Get the slot of the head of the chain
    */
-  getChainHeadSlot(): Promise<Slot>;
+  getChainHeadSlot(): Promise<Slot | null>;
 
   /**
    * Get the root of the head of the chain
    */
-  getChainHeadRoot(): Promise<bytes32>;
+  getChainHeadRoot(): Promise<bytes32 | null>;
 
   /**
    * Get the head of the chain
    */
-  getChainHead(): Promise<BeaconBlock>;
+  getChainHead(): Promise<BeaconBlock | null>;
 
   /**
    * Set the head of the chain
    */
-  setChainHead(state: BeaconState, block: BeaconBlock): Promise<void>;
+  setChainHeadRoots(blockRoot: bytes32, stateRoot: bytes32, block?: BeaconBlock, state?: BeaconState): Promise<void>;
 
   /**
    * Fetch all attestations
@@ -151,7 +161,7 @@ export interface IBeaconDb {
   /**
    * Fetch an attestation by hash
    */
-  getAttestation(attestationRoot: bytes32): Promise<Attestation>;
+  getAttestation(attestationRoot: bytes32): Promise<Attestation | null>;
 
 
   hasAttestation(attestationRoot: bytes32): Promise<boolean>;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -6,29 +6,34 @@ import BN from "bn.js";
 
 // Buckets are separate database namespaces
 export enum Bucket {
-  attestation,
-  block,
-  mainChain,
-  chainInfo,
+  // beacon chain
+  state, // hash -> BeaconState
+  attestation, // hash -> Attestation
+  block, // hash -> BeaconBlock
+  mainChain, // slot -> blockHash
+  chainInfo, // Key -> number64 | stateHash | blockHash
   validator,
-  genesisDeposit,
-  exit,
-  transfer,
-  proposerSlashing,
-  attesterSlashing,
+  genesisDeposit, // index -> Deposit
+  exit, // hash -> VoluntaryExit
+  transfer, // hash -> Transfer
+  proposerSlashing, // hash -> ProposerSlashing
+  attesterSlashing, // hash -> AttesterSlashing
+  merkleTree,
+  // validator
   lastProposedBlock,
   proposedAttestations,
-  merkleTree
 }
 
-export const Key = {
-  chainHeight: Buffer.from('chainHeight'),
-  state: Buffer.from('state'),
-  finalizedState: Buffer.from('finalizedState'),
-  justifiedState: Buffer.from('justifiedState'),
-  finalizedBlock: Buffer.from('finalizedBlock'),
-  justifiedBlock: Buffer.from('justifiedBlock'),
-  progressiveMerkleTree: Buffer.from('progressiveMerkleTree'),
+export enum Key {
+  chainHeight,
+
+  latestState,
+  finalizedState,
+  justifiedState,
+
+  finalizedBlock,
+  justifiedBlock,
+  progressiveMerkleTree,
 };
 
 /**

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -18,7 +18,7 @@ export enum Bucket {
   transfer, // hash -> Transfer
   proposerSlashing, // hash -> ProposerSlashing
   attesterSlashing, // hash -> AttesterSlashing
-  merkleTree,
+  merkleTree, // depositIndex -> MerkleTree
   // validator
   lastProposedBlock,
   proposedAttestations,

--- a/src/rpc/api/beacon/beacon.ts
+++ b/src/rpc/api/beacon/beacon.ts
@@ -26,7 +26,7 @@ export class BeaconApi implements IBeaconApi {
   }
 
   public async getFork(): Promise<Fork> {
-    const state: BeaconState = await this.db.getState();
+    const state: BeaconState = await this.db.getLatestState();
     return state.fork;
   }
 
@@ -41,7 +41,7 @@ export class BeaconApi implements IBeaconApi {
   }
 
   public async getBeaconState(): Promise<BeaconState> {
-    return await this.db.getState();
+    return await this.db.getLatestState();
   }
 
   public async getChainHead(): Promise<BeaconBlock> {

--- a/src/rpc/api/validator/validator.ts
+++ b/src/rpc/api/validator/validator.ts
@@ -51,12 +51,12 @@ export class ValidatorApi implements IValidatorApi {
   }
 
   public async isProposer(index: ValidatorIndex, slot: Slot): Promise<boolean> {
-    const state: BeaconState = await this.db.getState();
+    const state: BeaconState = await this.db.getLatestState();
     return isProposerAtSlot(state, slot, index);
   }
 
   public async getDuties(validatorPublicKeys: Buffer[]): Promise<ValidatorDuty[]> {
-    const state = await this.db.getState();
+    const state = await this.db.getLatestState();
 
     const validatorIndexes = await Promise.all(validatorPublicKeys.map(async publicKey => {
       return  await this.db.getValidatorIndex(publicKey);
@@ -75,13 +75,13 @@ export class ValidatorApi implements IValidatorApi {
   public async getCommitteeAssignment(
     index: ValidatorIndex,
     epoch: Epoch): Promise<CommitteeAssignment> {
-    const state: BeaconState = await this.db.getState();
+    const state: BeaconState = await this.db.getLatestState();
     return getCommitteeAssignment(state, epoch, index);
   }
 
   public async produceAttestation(slot: Slot, shard: Shard): Promise<IndexedAttestation> {
     const [headState, headBlock] = await Promise.all([
-      this.db.getState(),
+      this.db.getLatestState(),
       this.db.getBlock(this.chain.forkChoice.head())
     ]);
     return await assembleAttestation(this.db, headState, headBlock, shard, slot);

--- a/src/sync/regular.ts
+++ b/src/sync/regular.ts
@@ -45,7 +45,7 @@ export class RegularSync {
       return;
     }
     // skip attestation if its too old
-    const state = await this.db.getState();
+    const state = await this.db.getLatestState();
     if (attestation.data.targetEpoch < slotToEpoch(state.finalizedEpoch)) {
       return;
     }

--- a/src/sync/rpc.ts
+++ b/src/sync/rpc.ts
@@ -5,6 +5,8 @@
 import assert from "assert";
 import BN from "bn.js";
 import {hashTreeRoot} from "@chainsafe/ssz";
+import PeerInfo from "peer-info";
+
 import {
   bytes32, Slot, number64,
   BeaconBlockHeader, BeaconBlockBody,
@@ -67,7 +69,7 @@ export class SyncRpc {
       bestSlot = await this.db.getChainHeadSlot();
       const [bRoot, state] = await Promise.all([
         this.db.getBlockRoot(bestSlot),
-        this.db.getState(),
+        this.db.getLatestState(),
       ]);
       bestRoot = bRoot;
       latestFinalizedEpoch = state.finalizedEpoch;

--- a/test/unit/chain/factory/block/blockAssembly.test.ts
+++ b/test/unit/chain/factory/block/blockAssembly.test.ts
@@ -28,7 +28,7 @@ describe('block assembly', function () {
   });
 
   it('should assemble block', async function() {
-    beaconDB.getState.resolves(generateState({slot: 1}));
+    beaconDB.getLatestState.resolves(generateState({slot: 1}));
     beaconDB.getChainHead.resolves(generateEmptyBlock());
     assembleBodyStub.resolves(generateEmptyBlock().body);
     try {
@@ -37,7 +37,7 @@ describe('block assembly', function () {
       expect(result.slot).to.equal(1);
       expect(result.stateRoot).to.not.be.null;
       expect(result.parentRoot).to.not.be.null;
-      expect(beaconDB.getState.calledOnce).to.be.true;
+      expect(beaconDB.getLatestState.calledOnce).to.be.true;
       expect(beaconDB.getChainHead.calledOnce).to.be.true;
       expect(assembleBodyStub.calledOnce).to.be.true;
       expect(processBlockStub.withArgs(sinon.match.any, sinon.match.any).calledOnce).to.be.true;

--- a/test/unit/db/api/beacon.test.ts
+++ b/test/unit/db/api/beacon.test.ts
@@ -32,6 +32,8 @@ chai.use(chaiAsPromised);
 describe('beacon db api', function() {
 
   const sandbox = sinon.createSandbox();
+  const objKey = Buffer.alloc(32, 10);
+  const objRoot = Buffer.alloc(32, 11);
 
   let encodeKeyStub, dbStub, beaconDB;
 
@@ -47,82 +49,91 @@ describe('beacon db api', function() {
     sandbox.restore();
   });
 
-  it('get state', async function() {
-    encodeKeyStub.withArgs(Bucket.chainInfo, Key.state).returns('stateKey');
-    dbStub.get.withArgs('stateKey').resolves(serialize(generateState(), BeaconState));
-    const result = await beaconDB.getState();
-    expect(encodeKeyStub.withArgs(Bucket.chainInfo, Key.state).calledOnce).to.be.true;
-    expect(dbStub.get.withArgs('stateKey').calledOnce).to.be.true;
+  it('get latest state', async function() {
+    encodeKeyStub.withArgs(Bucket.chainInfo, Key.latestState).returns(objKey);
+    encodeKeyStub.withArgs(Bucket.state, objRoot).returns(objRoot);
+    dbStub.get.withArgs(objKey).resolves(objRoot);
+    dbStub.get.withArgs(objRoot).resolves(serialize(generateState(), BeaconState));
+    const result = await beaconDB.getLatestState();
+    expect(encodeKeyStub.withArgs(Bucket.chainInfo, Key.latestState).calledOnce).to.be.true;
+    expect(dbStub.get.withArgs(objKey).calledOnce).to.be.true;
+    expect(dbStub.get.withArgs(objRoot).calledOnce).to.be.true;
     expect(result.slot)
       .to.be.equal(generateState().slot);
   });
 
-  it('set state', async function() {
-    encodeKeyStub.withArgs(Bucket.chainInfo, Key.state).returns('stateKey');
-    await beaconDB.setState(generateState());
-    expect(encodeKeyStub.withArgs(Bucket.chainInfo, Key.state).calledOnce).to.be.true;
-    expect(dbStub.put.withArgs('stateKey', sinon.match.any).calledOnce).to.be.true;
+  it('set latest state root', async function() {
+    encodeKeyStub.withArgs(Bucket.chainInfo, Key.latestState).returns(objKey);
+    await beaconDB.setLatestStateRoot(objKey, generateState());
+    expect(encodeKeyStub.withArgs(Bucket.chainInfo, Key.latestState).calledOnce).to.be.true;
+    expect(dbStub.put.withArgs(objKey, sinon.match.any).calledOnce).to.be.true;
   });
 
   it('get finalized state', async function() {
-    encodeKeyStub.withArgs(Bucket.chainInfo, Key.finalizedState).returns('stateKey');
-    dbStub.get.withArgs('stateKey').resolves(serialize(generateState(), BeaconState));
+    encodeKeyStub.withArgs(Bucket.chainInfo, Key.finalizedState).returns(objKey);
+    encodeKeyStub.withArgs(Bucket.state, objRoot).returns(objRoot);
+    dbStub.get.withArgs(objKey).resolves(objRoot);
+    dbStub.get.withArgs(objRoot).resolves(serialize(generateState(), BeaconState));
     const result = await beaconDB.getFinalizedState();
     expect(encodeKeyStub.withArgs(Bucket.chainInfo, Key.finalizedState).calledOnce).to.be.true;
-    expect(dbStub.get.withArgs('stateKey').calledOnce).to.be.true;
+    expect(dbStub.get.withArgs(objKey).calledOnce).to.be.true;
+    expect(dbStub.get.withArgs(objRoot).calledOnce).to.be.true;
     expect(result.slot)
       .to.be.equal(generateState().slot);
   });
 
   it('set finalized state', async function() {
-    encodeKeyStub.withArgs(Bucket.chainInfo, Key.finalizedState).returns('stateKey');
-    await beaconDB.setFinalizedState(generateState());
+    encodeKeyStub.withArgs(Bucket.chainInfo, Key.finalizedState).returns(objKey);
+    await beaconDB.setFinalizedStateRoot(objKey, generateState());
     expect(encodeKeyStub.withArgs(Bucket.chainInfo, Key.finalizedState).calledOnce).to.be.true;
-    expect(dbStub.put.withArgs('stateKey', sinon.match.any).calledOnce).to.be.true;
+    expect(dbStub.put.withArgs(objKey, sinon.match.any).calledOnce).to.be.true;
   });
 
   it('get justified state', async function() {
-    encodeKeyStub.withArgs(Bucket.chainInfo, Key.justifiedState).returns('stateKey');
-    dbStub.get.withArgs('stateKey').resolves(serialize(generateState(), BeaconState));
+    encodeKeyStub.withArgs(Bucket.chainInfo, Key.justifiedState).returns(objKey);
+    encodeKeyStub.withArgs(Bucket.state, objRoot).returns(objRoot);
+    dbStub.get.withArgs(objKey).resolves(objRoot);
+    dbStub.get.withArgs(objRoot).resolves(serialize(generateState(), BeaconState));
     const result = await beaconDB.getJustifiedState();
     expect(encodeKeyStub.withArgs(Bucket.chainInfo, Key.justifiedState).calledOnce).to.be.true;
-    expect(dbStub.get.withArgs('stateKey').calledOnce).to.be.true;
+    expect(dbStub.get.withArgs(objKey).calledOnce).to.be.true;
+    expect(dbStub.get.withArgs(objRoot).calledOnce).to.be.true;
     expect(result.slot)
       .to.be.equal(generateState().slot);
   });
 
   it('set justified state', async function() {
-    encodeKeyStub.withArgs(Bucket.chainInfo, Key.justifiedState).returns('stateKey');
-    await beaconDB.setJustifiedState(generateState());
+    encodeKeyStub.withArgs(Bucket.chainInfo, Key.justifiedState).returns(objKey);
+    await beaconDB.setJustifiedStateRoot(objKey, generateState());
     expect(encodeKeyStub.withArgs(Bucket.chainInfo, Key.justifiedState).calledOnce).to.be.true;
-    expect(dbStub.put.withArgs('stateKey', sinon.match.any).calledOnce).to.be.true;
+    expect(dbStub.put.withArgs(objKey, sinon.match.any).calledOnce).to.be.true;
   });
 
   it('get block', async function() {
-    encodeKeyStub.withArgs(Bucket.block, sinon.match.any).returns('blockId');
-    dbStub.get.withArgs('blockId').resolves(serialize(generateEmptyBlock(), BeaconBlock));
+    encodeKeyStub.withArgs(Bucket.block, sinon.match.any).returns(objRoot);
+    dbStub.get.withArgs(objRoot).resolves(serialize(generateEmptyBlock(), BeaconBlock));
     const result = await beaconDB.getBlock('blockHash');
     expect(encodeKeyStub.withArgs(Bucket.block, sinon.match.any).calledOnce).to.be.true;
-    expect(dbStub.get.withArgs('blockId').calledOnce).to.be.true;
+    expect(dbStub.get.withArgs(objRoot).calledOnce).to.be.true;
     expect(serialize(result, BeaconBlock).toString('hex'))
       .to.be.equal(serialize(generateEmptyBlock(), BeaconBlock).toString('hex'));
   });
 
   it('has block - false', async function() {
-    encodeKeyStub.withArgs(Bucket.block, sinon.match.any).returns('blockId');
-    dbStub.get.withArgs('blockId').resolves(null);
+    encodeKeyStub.withArgs(Bucket.block, sinon.match.any).returns(objRoot);
+    dbStub.get.withArgs(objRoot).resolves(null);
     const result = await beaconDB.hasBlock('blockHash');
     expect(encodeKeyStub.withArgs(Bucket.block, sinon.match.any).calledOnce).to.be.true;
-    expect(dbStub.get.withArgs('blockId').calledOnce).to.be.true;
+    expect(dbStub.get.withArgs(objRoot).calledOnce).to.be.true;
     expect(result).to.be.false;
   });
 
   it('has block - true', async function() {
-    encodeKeyStub.withArgs(Bucket.block, sinon.match.any).returns('blockId');
-    dbStub.get.withArgs('blockId').resolves(serialize(generateEmptyBlock(), BeaconBlock));
+    encodeKeyStub.withArgs(Bucket.block, sinon.match.any).returns(objRoot);
+    dbStub.get.withArgs(objRoot).resolves(serialize(generateEmptyBlock(), BeaconBlock));
     const result = await beaconDB.hasBlock('blockHash');
     expect(encodeKeyStub.withArgs(Bucket.block, sinon.match.any).calledOnce).to.be.true;
-    expect(dbStub.get.withArgs('blockId').calledOnce).to.be.true;
+    expect(dbStub.get.withArgs(objRoot).calledOnce).to.be.true;
     expect(result).to.be.true;
   });
 
@@ -143,7 +154,7 @@ describe('beacon db api', function() {
     encodeKeyStub
       .withArgs(Bucket.block, sinon.match.any)
       .returns('blockId');
-    await beaconDB.setBlock(generateEmptyBlock());
+    await beaconDB.setBlock(objRoot, generateEmptyBlock());
     expect(
       encodeKeyStub
         .withArgs(
@@ -154,11 +165,11 @@ describe('beacon db api', function() {
     expect(dbStub.put.withArgs('blockId', sinon.match.any).calledOnce).to.be.true;
   });
 
-  it('set finalized block', async function() {
+  it('set finalized block root', async function() {
     encodeKeyStub
       .withArgs(Bucket.chainInfo, Key.finalizedBlock)
       .returns('blockId');
-    await beaconDB.setFinalizedBlock(generateEmptyBlock());
+    await beaconDB.setFinalizedBlockRoot(objRoot, generateEmptyBlock());
     expect(
       encodeKeyStub
         .withArgs(Bucket.chainInfo, Key.finalizedBlock).calledOnce
@@ -167,20 +178,23 @@ describe('beacon db api', function() {
   });
 
   it('get finalized block', async function() {
-    encodeKeyStub.withArgs(Bucket.chainInfo, Key.finalizedBlock).returns('blockId');
-    dbStub.get.withArgs('blockId').resolves(serialize(generateEmptyBlock(), BeaconBlock));
-    const result = await beaconDB.getFinalizedBlock('blockHash');
+    encodeKeyStub.withArgs(Bucket.chainInfo, Key.finalizedBlock).returns(objKey);
+    encodeKeyStub.withArgs(Bucket.block, objRoot).returns(objRoot);
+    dbStub.get.withArgs(objKey).resolves(objRoot);
+    dbStub.get.withArgs(objRoot).resolves(serialize(generateEmptyBlock(), BeaconBlock));
+    const result = await beaconDB.getFinalizedBlock();
     expect(encodeKeyStub.withArgs(Bucket.chainInfo, Key.finalizedBlock).calledOnce).to.be.true;
-    expect(dbStub.get.withArgs('blockId').calledOnce).to.be.true;
+    expect(dbStub.get.withArgs(objKey).calledOnce).to.be.true;
+    expect(dbStub.get.withArgs(objRoot).calledOnce).to.be.true;
     expect(serialize(result, BeaconBlock).toString('hex'))
       .to.be.equal(serialize(generateEmptyBlock(), BeaconBlock).toString('hex'));
   });
 
-  it('set justified block', async function() {
+  it('set justified block root', async function() {
     encodeKeyStub
       .withArgs(Bucket.chainInfo, Key.justifiedBlock)
       .returns('blockId');
-    await beaconDB.setJustifiedBlock(generateEmptyBlock());
+    await beaconDB.setJustifiedBlockRoot(objRoot, generateEmptyBlock());
     expect(
       encodeKeyStub
         .withArgs(Bucket.chainInfo, Key.justifiedBlock).calledOnce
@@ -189,11 +203,14 @@ describe('beacon db api', function() {
   });
 
   it('get justified block', async function() {
-    encodeKeyStub.withArgs(Bucket.chainInfo, Key.justifiedBlock).returns('blockId');
-    dbStub.get.withArgs('blockId').resolves(serialize(generateEmptyBlock(), BeaconBlock));
-    const result = await beaconDB.getJustifiedBlock('blockHash');
+    encodeKeyStub.withArgs(Bucket.chainInfo, Key.justifiedBlock).returns(objKey);
+    encodeKeyStub.withArgs(Bucket.block, objRoot).returns(objRoot);
+    dbStub.get.withArgs(objKey).resolves(objRoot);
+    dbStub.get.withArgs(objRoot).resolves(serialize(generateEmptyBlock(), BeaconBlock));
+    const result = await beaconDB.getJustifiedBlock();
     expect(encodeKeyStub.withArgs(Bucket.chainInfo, Key.justifiedBlock).calledOnce).to.be.true;
-    expect(dbStub.get.withArgs('blockId').calledOnce).to.be.true;
+    expect(dbStub.get.withArgs(objKey).calledOnce).to.be.true;
+    expect(dbStub.get.withArgs(objRoot).calledOnce).to.be.true;
     expect(serialize(result, BeaconBlock).toString('hex'))
       .to.be.equal(serialize(generateEmptyBlock(), BeaconBlock).toString('hex'));
   });
@@ -213,19 +230,22 @@ describe('beacon db api', function() {
   it('set chain head', async function() {
     encodeKeyStub.withArgs(Bucket.chainInfo, Key.chainHeight).returns('chainHeightKey');
     beaconDB.getBlock = sandbox.stub().resolves(generateEmptyBlock());
-    await beaconDB.setChainHead(generateState(), generateEmptyBlock());
-    expect(beaconDB.getBlock.calledOnce).to.be.true;
+    const block = generateEmptyBlock();
+    block.stateRoot = objRoot;
+    await beaconDB.setChainHeadRoots(objRoot, objRoot, block, generateState());
     expect(encodeKeyStub.withArgs(Bucket.mainChain, 0).calledOnce).to.be.true;
     expect(encodeKeyStub.withArgs(Bucket.chainInfo, Key.chainHeight).calledOnce).to.be.true;
-    expect(encodeKeyStub.withArgs(Bucket.chainInfo, Key.state).calledOnce).to.be.true;
+    expect(encodeKeyStub.withArgs(Bucket.chainInfo, Key.latestState).calledOnce).to.be.true;
     expect(dbStub.batchPut.withArgs(sinon.match.array).calledOnce).to.be.true;
   });
 
   it('fail to set chain head (block missing)', async function() {
     encodeKeyStub.withArgs(Bucket.chainInfo, Key.chainHeight).returns('chainHeightKey');
     beaconDB.getBlock = sandbox.stub().resolves(null);
-    await expect(beaconDB.setChainHead(generateState(), generateEmptyBlock()))
-      .to.be.rejectedWith("block should be saved already");
+    const block = generateEmptyBlock();
+    block.stateRoot = objRoot;
+    await expect(beaconDB.setChainHeadRoots(objRoot, objRoot, null, generateState()))
+      .to.be.rejectedWith("unknown block root");
   });
 
   it('test get attestation', async function() {
@@ -492,16 +512,18 @@ describe('beacon db api', function() {
   it('store merkle tree', async function() {
     encodeKeyStub.returns('merkleTreeKey');
     dbStub.put.resolves();
-    await beaconDB.setMerkleTree(ProgressiveMerkleTree.empty(5));
-    expect(encodeKeyStub.calledOnceWith(Bucket.merkleTree, Key.progressiveMerkleTree)).to.be.true;
+    const index = 1;
+    await beaconDB.setMerkleTree(index, ProgressiveMerkleTree.empty(5));
+    expect(encodeKeyStub.calledOnceWith(Bucket.merkleTree, index)).to.be.true;
     expect(dbStub.put.calledOnceWith('merkleTreeKey', sinon.match.any)).to.be.true;
   });
 
   it('get merkle tree', async function() {
     encodeKeyStub.returns('merkleTreeKey');
     dbStub.get.resolves(ProgressiveMerkleTree.empty(5).serialize());
-    const tree = await beaconDB.getMerkleTree();
-    expect(encodeKeyStub.calledOnceWith(Bucket.merkleTree, Key.progressiveMerkleTree)).to.be.true;
+    const index = 1;
+    const tree = await beaconDB.getMerkleTree(index);
+    expect(encodeKeyStub.calledOnceWith(Bucket.merkleTree, index)).to.be.true;
     expect(dbStub.get.calledOnceWith('merkleTreeKey')).to.be.true;
     expect(tree).to.not.be.null;
   });
@@ -509,8 +531,9 @@ describe('beacon db api', function() {
   it('get merkle not found', async function() {
     encodeKeyStub.returns('merkleTreeKey');
     dbStub.get.resolves(null);
-    const tree = await beaconDB.getMerkleTree();
-    expect(encodeKeyStub.calledOnceWith(Bucket.merkleTree, Key.progressiveMerkleTree)).to.be.true;
+    const index = 1;
+    const tree = await beaconDB.getMerkleTree(index);
+    expect(encodeKeyStub.calledOnceWith(Bucket.merkleTree, index)).to.be.true;
     expect(dbStub.get.calledOnceWith('merkleTreeKey')).to.be.true;
     expect(tree).to.be.null;
   });

--- a/test/unit/rpc/api/beacon/beacon.test.ts
+++ b/test/unit/rpc/api/beacon/beacon.test.ts
@@ -34,9 +34,9 @@ describe('beacon rpc api', function () {
         currentVersion: Buffer.from("2")
       }
     });
-    dbStub.getState.resolves(state);
+    dbStub.getLatestState.resolves(state);
     const fork = await beaconApi.getFork();
-    expect(dbStub.getState.calledOnce).to.be.true;
+    expect(dbStub.getLatestState.calledOnce).to.be.true;
     expect(fork).to.be.deep.equal(state.fork);
   });
 
@@ -53,9 +53,9 @@ describe('beacon rpc api', function () {
 
   it('should return state', async function() {
     const state = generateState();
-    dbStub.getState.resolves(state);
+    dbStub.getLatestState.resolves(state);
     const result = await beaconApi.getBeaconState();
-    expect(dbStub.getState.calledOnce).to.be.true;
+    expect(dbStub.getLatestState.calledOnce).to.be.true;
     expect(result).to.be.deep.equal(state);
   });
 

--- a/test/unit/rpc/api/validator/validator.test.ts
+++ b/test/unit/rpc/api/validator/validator.test.ts
@@ -49,7 +49,7 @@ describe('validator rpc api', function () {
   it('is proposer', async function() {
     const isProposerStub = sandbox.stub(stateTransitionUtils, 'isProposerAtSlot');
     const state = generateState();
-    dbStub.getState.resolves(state);
+    dbStub.getLatestState.resolves(state);
     isProposerStub.returns(true);
     const result = await validatorApi.isProposer(1, 2);
     expect(result).to.be.true;
@@ -63,7 +63,7 @@ describe('validator rpc api', function () {
   it('get duties', async function() {
     const publicKey = Buffer.alloc(48, 1);
     const state = generateState();
-    dbStub.getState.resolves(state);
+    dbStub.getLatestState.resolves(state);
     dbStub.getValidatorIndex.resolves(5);
     const getProposerStub = sandbox.stub(stateTransitionUtils, 'getBeaconProposerIndex');
     getProposerStub.returns(4);
@@ -73,7 +73,7 @@ describe('validator rpc api', function () {
     expect(duties.length).to.be.equal(1);
     expect(duties[0].committeeIndex).to.be.null;
     expect(duties[0].blockProductionSlot).to.be.null;
-    expect(dbStub.getState.calledOnce).to.be.true;
+    expect(dbStub.getLatestState.calledOnce).to.be.true;
     expect(dbStub.getValidatorIndex.withArgs(publicKey).calledOnce).to.be.true;
     expect(getProposerStub.withArgs(state).calledOnce).to.be.true;
     expect(assembleValidatorDutyStub.calledOnceWith(publicKey, 5, state, 4)).to.be.true;
@@ -81,23 +81,23 @@ describe('validator rpc api', function () {
 
   it('get committee assignment', async function() {
     const state = generateState();
-    dbStub.getState.resolves(state);
+    dbStub.getLatestState.resolves(state);
     const commiteeAssignmentStub = sandbox.stub(stateTransitionUtils, 'getCommitteeAssignment');
     commiteeAssignmentStub.returns(null);
     const result = await validatorApi.getCommitteeAssignment(1, 2);
     expect(result).to.be.null;
-    expect(dbStub.getState.calledOnce).to.be.true;
+    expect(dbStub.getLatestState.calledOnce).to.be.true;
     expect(commiteeAssignmentStub.withArgs(state, 2, 1));
   });
 
   it('produceAttestation - missing slots', async function() {
     const state = generateState({slot: 1});
-    dbStub.getState.resolves(state);
+    dbStub.getLatestState.resolves(state);
     const block = generateEmptyBlock();
     dbStub.getBlock.resolves(block);
     const result = await validatorApi.produceAttestation(4, 2);
     expect(result).to.not.be.null;
-    expect(dbStub.getState.calledOnce).to.be.true;
+    expect(dbStub.getLatestState.calledOnce).to.be.true;
     expect(dbStub.getBlock.calledTwice).to.be.true;
   });
 


### PR DESCRIPTION
Resolves #256 
Partially resolves #273 - updates FFG checkpoints after state transition runs

- all get by root/key and derived db methods return `T | null`
- get/setState now mirrors get/setBlock (getLatestState now gets the latest state)
- justified/finalized blocks/states are now stored by root
- merkle trees are now stored by index