### PR TITLE
[Benchmarks] Refactored

### DIFF
--- a/packages/lodestar/test/benchmarks/examples/random.ts
+++ b/packages/lodestar/test/benchmarks/examples/random.ts
@@ -4,14 +4,18 @@ import { writeReport } from "../utils";
 // Initiate the benchmark suite
 const suite = new Benchmark.Suite;
 
-const bench = (dir: string) => {
+export interface BenchSuite {
+  suite: Benchmark.Suite;
+  file: string;
+}
+
+export const bench = (dir: string): BenchSuite => {
 
   // Set the function test
   const FUNCTION_NAME = "example"; // PLEASE FILL THIS OUT
-  const FILE_TO_WRITE = dir + FUNCTION_NAME + ".txt";
 
   // Add tests
-  suite
+  const tests = suite
   .add('RegExp#test', () => {
     /o/.test('Hello World!');
   })
@@ -22,16 +26,8 @@ const bench = (dir: string) => {
     'Helldd World!'.indexOf('o') > -1;
   })
 
-  // EVERYTHING BELOW IS COOKIE CUTTER
-  // add listeners
-  .on('cycle', (event) => {
-    writeReport(FILE_TO_WRITE, String(event.target));
-  })
-  // Scoping issue requires function decleration
-  .on('complete', function() {
-    const msg: string = 'Fastest is ' + this.filter('fastest').map('name');
-    writeReport(FILE_TO_WRITE, msg);
-  })
-  // run async
-  .run({ 'async': true });
+  return {
+    suite: tests,
+    file: dir + FUNCTION_NAME + ".txt"
+  }
 }

--- a/packages/lodestar/test/benchmarks/index.ts
+++ b/packages/lodestar/test/benchmarks/index.ts
@@ -1,12 +1,14 @@
-import {createReportDir} from "./utils"
+import Benchmark from "benchmark";
+import {createReportDir, writeReport, runSuite} from "./utils"
 
 // Import benchmarks
 import * as benchmarks from "./imports";
+import { BenchSuite } from "./examples";
 
 // Create file
 const directory: string = createReportDir();
 
 // Run benchmarks
 for (let bench in benchmarks) {
-    benchmarks[bench](directory);
+    runSuite(benchmarks[bench](directory));
 }

--- a/packages/lodestar/test/benchmarks/utils/index.ts
+++ b/packages/lodestar/test/benchmarks/utils/index.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import { BENCH_DIR } from "../constant";
+import { BenchSuite } from "../examples";
 
 export const createReportDir = (): string => {
     const curDate: string = new Date().toISOString();
@@ -21,4 +22,19 @@ export const writeReport = (file: string, data: string) => {
     fs.appendFile(file, `\r\n${data}`, 'ascii', (err) => {
         if (err) throw err;
     })
+}
+
+export const runSuite = (bench: BenchSuite) => {
+    bench.suite
+    // add listeners
+    .on('cycle', (event) => {
+        writeReport(bench.file, String(event.target));
+    })
+    // Scoping issue requires function decleration
+    .on('complete', function() {
+        const msg: string = 'Fastest is ' + this.filter('fastest').map('name');
+        writeReport(bench.file, msg);
+    })
+    // run async
+    .run({ 'async': true });
 }


### PR DESCRIPTION
This removes the event listeners from the benchmarks themselves. Although its still very ugly now you write something like: 

```
export const bench = (dir: string): BenchSuite => {

  // Set the function test
  const FUNCTION_NAME = "example"; // PLEASE FILL THIS OUT

  // Add tests
  const tests = suite
  .add('RegExp#test', () => {
    /o/.test('Hello World!');
  })
  .add('String#indexOf', () => {
    'Hello World!'.indexOf('o') > -1;
  })
  .add('String#indexOf', () => {
    'Helldd World!'.indexOf('o') > -1;
  })

  return {
    suite: tests,
    file: dir + FUNCTION_NAME + ".txt"
  }
}
```

Future refactor would be to produce something a bit simpler, perhaps abstracting benchmark.js entirely, allowing you to write something like this:
```
export const tests = [
  {
    name: "SHA256-js",
    fn: () => {...<this is the test>...}
  } ,
  {
    name: "SHA256-js",
    fn: () => {...<this is the test>...}
  } 
]
```

Ultimately I'm open to any suggestion on how to make writing the benchmarks easier. if we abstract it far enough we could seperate this into its own package ... lawl