### PR TITLE
Make lodestar a 'private' package

### DIFF
--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@chainsafe/lodestar",
+  "private": true,
   "version": "0.1.0",
   "description": "A Typescript implementation of the beacon chain and validator client",
   "author": "ChainSafe Systems",


### PR DESCRIPTION
Preparation for being able to run `lerna publish` to publish our packages.
From the docs:
> Lerna will never publish packages which are marked as private ("private": true in the package.json).

This is what we currently want for the `lodestar` package, since its still a work in progress.
The other packages should all be published though. :rocket: 