### PR TITLE
make block process in initial sync sequential

### DIFF
--- a/packages/lodestar/src/sync/initial.ts
+++ b/packages/lodestar/src/sync/initial.ts
@@ -85,9 +85,9 @@ export class InitialSync {
     const blocks = await this.rpc.getBeaconBlocks(
       peerInfo, latestFinalizedSlot, slotCountToSync, false
     );
-    blocks.forEach(async (block) => {
+    for(const block of blocks) {
       await this.chain.receiveBlock(block);
-    });
+    }
 
   }
   public async start(): Promise<void> {


### PR DESCRIPTION
- current initial sync run state transition parrallel with all received blocks