### PR TITLE
better nyc exclude

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -5,8 +5,10 @@
   ],
   "exclude": [
     "**/*.d.ts",
-    "coverage/**",
-    "test/**",
+    "**/*.js",
+    "**/lib/**",
+    "**/coverage/**",
+    "**/test/**",
     "**/node_modules/**"
   ],
   "all": "true",


### PR DESCRIPTION
From issues and from my local testing it seems nyc report is sometimes failing because it tries to include files from directories that are suppose to be excluded