### PR TITLE
Add prometheus metrics gathering

### DIFF
--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -77,6 +77,8 @@
     "peer-info": "^0.15.1",
     "pouchdb-adapter-memory": "^7.0.0",
     "pouchdb-core": "^7.0.0",
+    "prom-client": "^11.5.3",
+    "prometheus-gc-stats": "^0.6.2",
     "promisify-es6": "^1.0.3",
     "pull-abortable": "^4.1.1",
     "pull-pushable": "^2.2.0",

--- a/packages/lodestar/src/metrics/beacon.ts
+++ b/packages/lodestar/src/metrics/beacon.ts
@@ -1,0 +1,103 @@
+/**
+ * @module metrics
+ */
+import {Gauge, Counter} from "prom-client";
+
+import {IBeaconMetrics} from "./interface";
+import {IMetricsOptions} from "./options";
+import {Metrics} from "./metrics";
+
+
+export class BeaconMetrics extends Metrics implements IBeaconMetrics {
+  public peers: Gauge;
+  public currentSlot: Gauge;
+  public previousJustifiedEpoch: Gauge;
+  public currentJustifiedEpoch: Gauge;
+  public currentFinalizedEpoch: Gauge;
+  public previousEpochLiveValidators: Gauge;
+  public currentEpochLiveValidators: Gauge;
+  public reorgEventsTotal: Counter;
+  public pendingDeposits: Gauge;
+  public pendingExits: Gauge;
+  public totalDeposits: Gauge;
+  public previousEpochStaleBlocks: Gauge;
+  public propagatedAttestations: Gauge;
+
+  public constructor(opts: IMetricsOptions) {
+    super(opts);
+    const registers = [this.registry];
+    this.peers = new Gauge({
+      name: "beaconchain_peers",
+      help: "number of connected peers",
+      registers,
+    });
+    this.currentSlot = new Gauge({
+      name: "beaconchain_current_slot",
+      help: "latest slot",
+      registers,
+    });
+    this.previousJustifiedEpoch = new Gauge({
+      name: "beaconchain_current_prev_justified_epoch",
+      help: "previous justified epoch",
+      registers,
+    });
+    this.currentJustifiedEpoch = new Gauge({
+      name: "beaconchain_current_justified_epoch",
+      help: "current justified epoch",
+      registers,
+    });
+    this.currentFinalizedEpoch = new Gauge({
+      name: "beaconchain_current_finalized_epoch",
+      help: "current finalized epoch",
+      registers,
+    });
+    this.previousEpochLiveValidators = new Gauge({
+      name: "beaconchain_previous_epoch_live_validators",
+      help: "number of active validators in previous epoch",
+      registers,
+    });
+    this.currentEpochLiveValidators = new Gauge({
+      name: "beaconchain_current_epoch_live_validators",
+      help: "number of active validators in current epoch",
+      registers,
+    });
+    this.reorgEventsTotal = new Counter({
+      name: "beaconchain_reorg_events_total",
+      help: "number of chain reorganizations",
+      registers,
+    });
+    this.pendingDeposits = new Gauge({
+      name: "beaconchain_pending_deposits",
+      help: "number of pending deposits",
+      registers,
+    });
+    this.pendingExits = new Gauge({
+      name: "beaconchain_pending_exits",
+      help: "number of pending voluntary exits",
+      registers,
+    });
+    this.totalDeposits = new Gauge({
+      name: "beaconchain_total_deposits",
+      help: "number of total deposits",
+      registers,
+    });
+    this.previousEpochStaleBlocks = new Gauge({
+      name: "beaconchain_previous_epoch_stale_blocks",
+      help: "number of blocks not included into the chain in previous epoch",
+      registers,
+    });
+    this.propagatedAttestations = new Gauge({
+      name: "beaconchain_propagated_attestations",
+      help: "number of distinct attestations received",
+      registers,
+    });
+  }
+
+  public async start(): Promise<void> {
+    await super.start();
+  }
+
+  public async stop(): Promise<void> {
+    await super.stop();
+  }
+}

--- a/packages/lodestar/src/metrics/index.ts
+++ b/packages/lodestar/src/metrics/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @module metrics
+ */
+export * from "./interface";
+export * from "./metrics";
+export * from "./beacon";
+export * from "./server";

--- a/packages/lodestar/src/metrics/interface.ts
+++ b/packages/lodestar/src/metrics/interface.ts
@@ -1,0 +1,27 @@
+/**
+ * @module metrics
+ */
+import {Registry, Gauge, Counter} from "prom-client";
+
+export interface IMetrics {
+  registry: Registry;
+}
+
+export interface IBeaconMetrics extends IMetrics {
+  peers: Gauge;
+  currentSlot: Gauge;
+  previousJustifiedEpoch: Gauge;
+  currentJustifiedEpoch: Gauge;
+  currentFinalizedEpoch: Gauge;
+  previousEpochLiveValidators: Gauge;
+  currentEpochLiveValidators: Gauge;
+  reorgEventsTotal: Counter;
+  pendingDeposits: Gauge;
+  pendingExits: Gauge;
+  totalDeposits: Gauge;
+  previousEpochStaleBlocks: Gauge;
+  propagatedAttestations: Gauge;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface IMetricsServer {}

--- a/packages/lodestar/src/metrics/metrics.ts
+++ b/packages/lodestar/src/metrics/metrics.ts
@@ -1,0 +1,31 @@
+/**
+ * @module metrics
+ */
+import {collectDefaultMetrics, Registry} from "prom-client";
+
+import {IMetrics} from "./interface";
+import {IMetricsOptions} from "./options";
+
+
+export class Metrics implements IMetrics {
+  public registry: Registry;
+
+  private defaultInterval;
+  private opts: IMetricsOptions;
+
+  public constructor(opts: IMetricsOptions) {
+    this.opts = opts;
+    this.registry = new Registry();
+  }
+
+  public async start(): Promise<void> {
+    this.defaultInterval = collectDefaultMetrics({
+      register: this.registry,
+      timeout: this.opts.timeout,
+    });
+  }
+
+  public async stop(): Promise<void> {
+    clearInterval(this.defaultInterval);
+  }
+}

--- a/packages/lodestar/src/metrics/options.ts
+++ b/packages/lodestar/src/metrics/options.ts
@@ -1,0 +1,21 @@
+/**
+ * @module metrics
+ */
+import {IConfigurationModule} from "../util/config";
+
+export interface IMetricsOptions {
+  enabled: boolean;
+  timeout: number;
+  pushGateway: boolean;
+  serverPort?: number;
+  gatewayUrl?: string;
+}
+
+const config: IMetricsOptions = {
+  enabled: true,
+  timeout: 5000,
+  pushGateway: false,
+  serverPort: 5000,
+};
+
+export default config;

--- a/packages/lodestar/src/metrics/server/http.ts
+++ b/packages/lodestar/src/metrics/server/http.ts
@@ -19,11 +19,11 @@ export class HttpMetricsServer implements IMetricsServer {
   }
   private onRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
     if (req.method === "GET" && url.parse(req.url, true).pathname === "/metrics") {
-      res
-        .writeHead(200, {"content-type": this.metrics.registry.contentType})
-        .end(this.metrics.registry.metrics());
+      res.writeHead(200, {"content-type": this.metrics.registry.contentType});
+      res.end(this.metrics.registry.metrics());
     } else {
-      res.writeHead(404).end();
+      res.writeHead(404);
+      res.end();
     }
   }
   public async start(): Promise<void> {

--- a/packages/lodestar/src/metrics/server/http.ts
+++ b/packages/lodestar/src/metrics/server/http.ts
@@ -1,0 +1,35 @@
+/**
+ * @module metrics/server
+ */
+import http from "http";
+import url from "url";
+import promisify from "promisify-es6";
+
+import {IMetrics, IMetricsServer} from "../interface";
+import {IMetricsOptions} from "../options";
+
+export class HttpMetricsServer implements IMetricsServer {
+  private opts: IMetricsOptions;
+  private metrics: IMetrics;
+  private http: http.Server;
+  public constructor(opts: IMetricsOptions, {metrics}: {metrics: IMetrics}) {
+    this.opts = opts;
+    this.metrics = metrics;
+    this.http = http.createServer(this.onRequest.bind(this));
+  }
+  private onRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
+    if (req.method === "GET" && url.parse(req.url, true).pathname === "/metrics") {
+      res
+        .writeHead(200, {"content-type": this.metrics.registry.contentType})
+        .end(this.metrics.registry.metrics());
+    } else {
+      res.writeHead(404).end();
+    }
+  }
+  public async start(): Promise<void> {
+    await promisify(this.http.listen.bind(this.http))(this.opts.serverPort);
+  }
+  public async stop(): Promise<void> {
+    await promisify(this.http.close.bind(this.http))();
+  }
+}

--- a/packages/lodestar/src/metrics/server/index.ts
+++ b/packages/lodestar/src/metrics/server/index.ts
@@ -1,0 +1,5 @@
+/**
+ * @module metrics/server
+ */
+export * from "./http";
+export * from "./push";

--- a/packages/lodestar/src/metrics/server/push.ts
+++ b/packages/lodestar/src/metrics/server/push.ts
@@ -1,0 +1,23 @@
+/**
+ * @module metrics/server
+ */
+import {Pushgateway} from "prom-client";
+
+import {IMetrics, IMetricsServer} from "../interface";
+import {IMetricsOptions} from "../options";
+
+export class PushMetricsServer implements IMetricsServer {
+  private metrics: IMetrics;
+  private opts: IMetricsOptions;
+  private gateway: Pushgateway;
+  public constructor(opts: IMetricsOptions, {metrics}: {metrics: IMetrics}) {
+    this.opts = opts;
+    this.metrics = metrics;
+  }
+  public async start(): Promise<void> {
+    this.gateway = new Pushgateway(this.opts.gatewayUrl, {}, this.metrics.registry);
+  }
+  public async stop(): Promise<void> {
+    this.gateway = null;
+  }
+}

--- a/packages/lodestar/src/network/libp2p/network.ts
+++ b/packages/lodestar/src/network/libp2p/network.ts
@@ -17,8 +17,16 @@ import {
 import {shardAttestationTopic, shardSubnetAttestationTopic} from "../util";
 import {NetworkRpc} from "./rpc";
 import {ILogger} from "../../logger";
+import {IBeaconMetrics} from "../../metrics";
 import {INetworkOptions} from "../options";
 import {INetwork, NetworkEventEmitter} from "../interface";
+
+interface Libp2pModules {
+  config: IBeaconConfig;
+  libp2p: any;
+  logger: ILogger;
+  metrics: IBeaconMetrics;
+}
 
 
 export class Libp2pNetwork extends (EventEmitter as { new(): NetworkEventEmitter }) implements INetwork {
@@ -30,12 +38,14 @@ export class Libp2pNetwork extends (EventEmitter as { new(): NetworkEventEmitter
   private rpc: NetworkRpc;
   private inited: Promise<void>;
   private logger: ILogger;
+  private metrics: IBeaconMetrics;
 
-  public constructor(opts: INetworkOptions, {config, libp2p,logger}: {config: IBeaconConfig; libp2p: any; logger: ILogger}) {
+  public constructor(opts: INetworkOptions, {config, libp2p, logger, metrics}: Libp2pModules) {
     super();
     this.opts = opts;
     this.config = config;
     this.logger = logger;
+    this.metrics = metrics;
     // `libp2p` can be a promise as well as a libp2p object
     this.inited = new Promise((resolve) => {
       Promise.resolve(libp2p).then((libp2p) => {
@@ -129,9 +139,11 @@ export class Libp2pNetwork extends (EventEmitter as { new(): NetworkEventEmitter
     this.emit("request", peerInfo, method, id, body);
   };
   private emitPeerConnect = (peerInfo: PeerInfo): void => {
+    this.metrics.peers.inc();
     this.emit("peer:connect", peerInfo);
   };
   private emitPeerDisconnect = (peerInfo: PeerInfo): void => {
+    this.metrics.peers.dec();
     this.emit("peer:disconnect", peerInfo);
   };
 

--- a/packages/lodestar/src/node/options.ts
+++ b/packages/lodestar/src/node/options.ts
@@ -9,6 +9,7 @@ import defaultEth1Options, {Eth1Options, IEth1Options} from "../eth1/options";
 import defaultNetworkOptions, {INetworkOptions, NetworkOptions} from "../network/options";
 import defaultOpPoolOptions, {IOpPoolOptions, OpPoolOptions} from "../opPool/options";
 import defaultSyncOptions, {ISyncOptions, SyncOptions} from "../sync/options";
+import defaultMetricsOptions, {IMetricsOptions} from "../metrics/options";
 import {IValidatorOptions, ValidatorOptions} from "../validator/options";
 import {IConfigurationModule} from "../util/config";
 
@@ -20,6 +21,7 @@ export interface IBeaconNodeOptions {
   network: INetworkOptions;
   opPool: IOpPoolOptions;
   sync: ISyncOptions;
+  metrics: IMetricsOptions;
   validator?: IValidatorOptions;
 }
 
@@ -45,6 +47,7 @@ const config: IBeaconNodeOptions = {
   network: defaultNetworkOptions,
   opPool: defaultOpPoolOptions,
   sync: defaultSyncOptions,
+  metrics: defaultMetricsOptions,
 };
 
 export default config;

--- a/packages/lodestar/test/e2e/network/libp2p/network.test.ts
+++ b/packages/lodestar/test/e2e/network/libp2p/network.test.ts
@@ -9,6 +9,7 @@ import {generateEmptyAttestation} from "../../../utils/attestation";
 import {shardAttestationTopic} from "../../../../src/network/util";
 import {ILogger, WinstonLogger} from "../../../../src/logger";
 import {INetworkOptions} from "../../../../src/network/options";
+import {BeaconMetrics} from "../../../../src/metrics";
 
 const multiaddr = "/ip4/127.0.0.1/tcp/0";
 const opts: INetworkOptions = {
@@ -24,10 +25,11 @@ describe("[network] network", () => {
 
   let netA: Libp2pNetwork, netB: Libp2pNetwork;
   const logger: ILogger = new WinstonLogger();
+  const metrics = new BeaconMetrics({enabled: true, timeout: 5000, pushGateway: false});
 
   beforeEach(async () => {
-    netA = new Libp2pNetwork(opts, {config, libp2p: createNode(multiaddr), logger: logger});
-    netB = new Libp2pNetwork(opts, {config, libp2p: createNode(multiaddr), logger: logger});
+    netA = new Libp2pNetwork(opts, {config, libp2p: createNode(multiaddr), logger: logger, metrics});
+    netB = new Libp2pNetwork(opts, {config, libp2p: createNode(multiaddr), logger: logger, metrics});
     await Promise.all([
       netA.start(),
       netB.start(),

--- a/packages/lodestar/test/e2e/sync/rpc.test.ts
+++ b/packages/lodestar/test/e2e/sync/rpc.test.ts
@@ -13,6 +13,7 @@ import {MockBeaconChain} from "../../utils/mocks/chain/chain";
 import {createNode} from "../../unit/network/libp2p/util";
 import {WinstonLogger} from "../../../src/logger";
 import {INetworkOptions} from "../../../src/network/options";
+import {BeaconMetrics} from "../../../src/metrics";
 
 const multiaddr = "/ip4/127.0.0.1/tcp/0";
 const opts: INetworkOptions = {
@@ -27,12 +28,13 @@ const opts: INetworkOptions = {
 describe("[sync] rpc", () => {
   const sandbox = sinon.createSandbox();
   let logger = new WinstonLogger();
+  const metrics = new BeaconMetrics({enabled: false, timeout: 5000, pushGateway: false});
 
   let rpcA: SyncRpc, netA: Libp2pNetwork, repsA: ReputationStore;
   let rpcB: SyncRpc, netB: Libp2pNetwork, repsB: ReputationStore;
   beforeEach(async () => {
-    netA = new Libp2pNetwork(opts, {config, libp2p: createNode(multiaddr), logger: logger});
-    netB = new Libp2pNetwork(opts, {config, libp2p: createNode(multiaddr), logger: logger});
+    netA = new Libp2pNetwork(opts, {config, libp2p: createNode(multiaddr), logger: logger, metrics});
+    netB = new Libp2pNetwork(opts, {config, libp2p: createNode(multiaddr), logger: logger, metrics});
     await Promise.all([
       netA.start(),
       netB.start(),

--- a/packages/lodestar/test/unit/metrics/beacon.test.ts
+++ b/packages/lodestar/test/unit/metrics/beacon.test.ts
@@ -1,0 +1,19 @@
+import {expect} from "chai";
+import {BeaconMetrics} from "../../../src/metrics";
+
+describe("BeaconMetrics", () => {
+  it("updated metrics should be reflected in the registry", async () => {
+    const m = new BeaconMetrics({enabled: true, timeout: 5000, pushGateway: false, serverPort: 5000});
+    await m.start();
+    // basic assumptions
+    expect(m.registry.getMetricsAsArray().length).to.be.gt(0);
+    expect(m.registry.metrics()).to.not.equal('');
+    // check updating beacon-specific metrics
+    expect(m.registry.getSingleMetricAsString("beaconchain_peers").match(/beaconchain_peers 0/)).to.not.be.null;
+    m.peers.set(1);
+    expect(m.registry.getSingleMetricAsString("beaconchain_peers").match(/beaconchain_peers 1/)).to.not.be.null;
+    m.peers.set(20);
+    expect(m.registry.getSingleMetricAsString("beaconchain_peers").match(/beaconchain_peers 20/)).to.not.be.null;
+    await m.stop();
+  });
+});

--- a/packages/lodestar/test/unit/metrics/metrics.test.ts
+++ b/packages/lodestar/test/unit/metrics/metrics.test.ts
@@ -1,0 +1,12 @@
+import {expect} from "chai";
+import {Metrics} from "../../../src/metrics";
+
+describe("Metrics", () => {
+  it("should get default metrics from registry", async () => {
+    const m = new Metrics({enabled: true, timeout: 5000, serverPort: 5000, pushGateway: false});
+    await m.start();
+    expect(m.registry.getMetricsAsArray().length).to.be.gt(0);
+    expect(m.registry.metrics()).to.not.equal('');
+    await m.stop();
+  });
+});

--- a/packages/lodestar/test/unit/metrics/server/http.test.ts
+++ b/packages/lodestar/test/unit/metrics/server/http.test.ts
@@ -1,0 +1,17 @@
+import request from "supertest";
+import {Metrics, HttpMetricsServer} from "../../../../src/metrics";
+
+describe("HttpMetricsServer", () => {
+  it("should serve metrics on /metrics", async () => {
+    const options = {enabled: true, timeout: 5000, serverPort: 5000, pushGateway: false};
+    let metrics = new Metrics(options);
+    let server = new HttpMetricsServer(options, {metrics});
+    await metrics.start();
+    await server.start();
+    await request('localhost:5000')
+      .get('/metrics')
+      .expect(200);
+    await server.stop();
+    await metrics.stop();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5537,6 +5537,13 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+gc-stats@^1.2.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/gc-stats/-/gc-stats-1.4.0.tgz#66cd194c5a8eae1138407300bc6cb42c2f6f3cd6"
+  dependencies:
+    nan "^2.13.2"
+    node-pre-gyp "^0.13.0"
+
 genfun@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/genfun/-/genfun-5.0.0.tgz#9dd9710a06900a5c4a5bf57aca5da4e52fe76537"
@@ -8228,6 +8235,21 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
+node-pre-gyp@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz#df9ab7b68dd6498137717838e4f92a33fc9daa42"
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
+
 node-releases@^1.1.25:
   version "1.1.26"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.26.tgz#f30563edc5c7dc20cf524cc8652ffa7be0762937"
@@ -8541,6 +8563,10 @@ optimist@~0.3.5:
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.3.7.tgz#c90941ad59e4273328923074d2cf2e7cbc6ec0d9"
   dependencies:
     wordwrap "~0.0.2"
+
+optional@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/optional/-/optional-0.1.4.tgz#cdb1a9bedc737d2025f690ceeb50e049444fd5b3"
 
 optionator@^0.8.2:
   version "0.8.2"
@@ -9115,6 +9141,20 @@ prom-client@^10.0.0:
   resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-10.2.3.tgz#a51bf21c239c954a6c5be4b1361fdd380218bb41"
   dependencies:
     tdigest "^0.1.1"
+
+prom-client@^11.5.3:
+  version "11.5.3"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-11.5.3.tgz#5fedfce1083bac6c2b223738e966d0e1643756f8"
+  dependencies:
+    tdigest "^0.1.1"
+
+prometheus-gc-stats@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/prometheus-gc-stats/-/prometheus-gc-stats-0.6.2.tgz#6ccae3a5ad74063d429849ec65febdcc95a7df52"
+  dependencies:
+    optional "^0.1.3"
+  optionalDependencies:
+    gc-stats "^1.2.1"
 
 promise-inflight@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- Adds metrics and metricsServer modules
- Metrics is injected as a dependency to various other modules
  - used to update the metrics (eg: `metrics.peers.inc()`)
  - subclassed for the beacon node, could be subclassed for validator / light client / etc
- MetricsServer serves metrics data
  - it's separate to allow for alternative implementations (eg: pushgateway for the browser)
  - the http metrics server serves data as expected for prometheus
  - also included a pushgateway implementation (not currently used)

resolves #252 