### PR TITLE
Collect packages documentation for deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 lib
+docs
 .nyc_output/
 coverage/**
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,13 +53,15 @@ jobs:
           - packages/lodestar/node_modules
           - .git/modules/spect-test-cases/lfs
 
-before_deploy: lerna run --scope @chainsafe/lodestar build:docs
+before_deploy:
+    - lerna run build:docs
+    - node scripts/collect-docs.js
 
 deploy:
   provider: pages
   skip_cleanup: true
   github_token: $GH_PAGES_TOKEN
   keep_history: true
-  local_dir: packages/lodestar/docs
+  local_dir: docs
   on:
     branch: master

--- a/scripts/collect-docs.js
+++ b/scripts/collect-docs.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+// Move all documentation to project root
+
+const fs = require("fs");
+const path = require("path");
+
+const rootDir = path.join(__dirname, "..");
+
+const pkgsDir = path.join(rootDir, "packages");
+const docsDir = path.join(rootDir, "docs");
+
+if (fs.existsSync(docsDir)) {
+  fs.rmdirSync(docsDir);
+}
+fs.mkdirSync(docsDir);
+
+for (const pkg of fs.readdirSync(pkgsDir)) {
+  const oldPath = path.join(pkgsDir, pkg, "docs");
+  const newPath = path.join(docsDir, pkg);
+  if (fs.existsSync(oldPath)) {
+    fs.renameSync(oldPath, newPath);
+  }
+}


### PR DESCRIPTION
Add small script to move each `packages/${name}/docs` to `docs/${name}`
Edit the travis deployment to `build:docs` for each package, then collect docs, so we can serve all packages documentation pages

resolves #370 