### PR TITLE
Round up chunk count for list of basic objects

### DIFF
--- a/packages/ssz/src/hashTreeRoot.ts
+++ b/packages/ssz/src/hashTreeRoot.ts
@@ -127,13 +127,13 @@ export function _hashTreeRoot(value: SerializableValue, type: FullSSZType): Buff
       );
     case Type.byteList:
       const sizeOfByte = 1;
-      const chunkCount = Math.floor(type.maxLength * sizeOfByte + 31 / BYTES_PER_CHUNK);
+      const chunkCount = Math.floor((type.maxLength * sizeOfByte + 31) / BYTES_PER_CHUNK);
       return mixInLength(
         merkleize(pack([value], type), chunkCount), (value as Bytes).length);
     case Type.list:
       value = value as SerializableArray;
       if (isBasicType(type.elementType)) {
-        const chunkCount = Math.floor(type.maxLength * fixedSize(type.elementType) + 31 / BYTES_PER_CHUNK);
+        const chunkCount = Math.floor((type.maxLength * fixedSize(type.elementType) + 31) / BYTES_PER_CHUNK);
         return mixInLength(
           merkleize(pack(value, (type as ListType).elementType), chunkCount), value.length);
       } else {

--- a/packages/ssz/src/hashTreeRoot.ts
+++ b/packages/ssz/src/hashTreeRoot.ts
@@ -132,26 +132,22 @@ export function _hashTreeRoot(value: SerializableValue, type: FullSSZType): Buff
         merkleize(pack([value], type), chunkCount), (value as Bytes).length);
     case Type.list:
       value = value as SerializableArray;
-      let listHash: Buffer;
       if (isBasicType(type.elementType)) {
         const chunkCount = Math.floor(type.maxLength * fixedSize(type.elementType) + 31 / BYTES_PER_CHUNK);
-        listHash = mixInLength(
+        return mixInLength(
           merkleize(pack(value, (type as ListType).elementType), chunkCount), value.length);
       } else {
-        listHash = mixInLength(
+        return mixInLength(
           merkleize(value.map((v,i) => hashTreeRoot(v, (type as ListType).elementType)), type.maxLength),
           value.length);
       }
-      return listHash;
     case Type.vector:
       value = value as SerializableArray;
-      let vectorHash: Buffer;
       if (isBasicType(type.elementType)) {
-        vectorHash = merkleize(pack(value, (type as VectorType).elementType));
+        return merkleize(pack(value, (type as VectorType).elementType));
       } else {
-        vectorHash = merkleize(value.map((v) => hashTreeRoot(v, (type as VectorType).elementType)));
+        return merkleize(value.map((v) => hashTreeRoot(v, (type as VectorType).elementType)));
       }
-      return vectorHash;
     case Type.container:
       type = type as ContainerType;
       return merkleize(type.fields

--- a/packages/ssz/src/hashTreeRoot.ts
+++ b/packages/ssz/src/hashTreeRoot.ts
@@ -126,15 +126,16 @@ export function _hashTreeRoot(value: SerializableValue, type: FullSSZType): Buff
         (value as BitList).bitLength
       );
     case Type.byteList:
+      const sizeOfByte = 1;
+      const chunkCount = Math.floor(type.maxLength * sizeOfByte + 31 / BYTES_PER_CHUNK);
       return mixInLength(
-        merkleize(pack([value], type), type.maxLength * 8 / BYTES_PER_CHUNK),
-        (value as Bytes).length);
+        merkleize(pack([value], type), chunkCount), (value as Bytes).length);
     case Type.list:
       value = value as SerializableArray;
       if (isBasicType(type.elementType)) {
+        const chunkCount = Math.floor(type.maxLength * fixedSize(type.elementType) + 31 / BYTES_PER_CHUNK);
         return mixInLength(
-          merkleize(pack(value, (type as ListType).elementType), type.maxLength * fixedSize(type.elementType) / BYTES_PER_CHUNK),
-          value.length);
+          merkleize(pack(value, (type as ListType).elementType), chunkCount), value.length);
       } else {
         return mixInLength(
           merkleize(value.map((v,i) => hashTreeRoot(v, (type as ListType).elementType)), type.maxLength),

--- a/packages/ssz/src/hashTreeRoot.ts
+++ b/packages/ssz/src/hashTreeRoot.ts
@@ -132,22 +132,26 @@ export function _hashTreeRoot(value: SerializableValue, type: FullSSZType): Buff
         merkleize(pack([value], type), chunkCount), (value as Bytes).length);
     case Type.list:
       value = value as SerializableArray;
+      let listHash: Buffer;
       if (isBasicType(type.elementType)) {
         const chunkCount = Math.floor(type.maxLength * fixedSize(type.elementType) + 31 / BYTES_PER_CHUNK);
-        return mixInLength(
+        listHash = mixInLength(
           merkleize(pack(value, (type as ListType).elementType), chunkCount), value.length);
       } else {
-        return mixInLength(
+        listHash = mixInLength(
           merkleize(value.map((v,i) => hashTreeRoot(v, (type as ListType).elementType)), type.maxLength),
           value.length);
       }
+      return listHash;
     case Type.vector:
       value = value as SerializableArray;
+      let vectorHash: Buffer;
       if (isBasicType(type.elementType)) {
-        return merkleize(pack(value, (type as VectorType).elementType));
+        vectorHash = merkleize(pack(value, (type as VectorType).elementType));
       } else {
-        return merkleize(value.map((v) => hashTreeRoot(v, (type as VectorType).elementType)));
+        vectorHash = merkleize(value.map((v) => hashTreeRoot(v, (type as VectorType).elementType)));
       }
+      return vectorHash;
     case Type.container:
       type = type as ContainerType;
       return merkleize(type.fields

--- a/packages/ssz/src/util/hash.ts
+++ b/packages/ssz/src/util/hash.ts
@@ -55,7 +55,7 @@ function bitLength (n: number): number {
 
 /** @ignore */
 function nextPowerOf2 (n: number): number {
-  return n === 0 ? 1 : Math.pow(2, bitLength(n - 1));
+  return n <= 0 ? 1 : Math.pow(2, bitLength(n - 1));
 }
 
 /** @ignore */

--- a/packages/ssz/test/unit/hashTreeRoot.test.ts
+++ b/packages/ssz/test/unit/hashTreeRoot.test.ts
@@ -7,6 +7,8 @@ import {
   SerializableValue,
   Type,
 } from "../../src";
+import { AnySSZType } from "../../src/types";
+
 
 import {
   ArrayObject,
@@ -64,6 +66,43 @@ describe("hashTreeRoot", () => {
       assert(actual);
     });
   }
+
+  it("should be able to hash inner object as list of basic object", () => {
+    const accountBalances = {
+      balances: []
+    };
+    const count = 2;
+    for (let i = 0; i < count; i++) {
+      accountBalances.balances.push(new BN("32000000000"));
+    }
+    const accountBalancesType: AnySSZType = {
+      fields: [["balances", { elementType: "uint64", maxLength: count }]]
+    };
+    const hash = hashTreeRoot(accountBalances, accountBalancesType).toString("hex");
+    assert(hash);
+  });
+
+  it("should have the same result to Prysmatic ssz unit test", () => {
+    const previousVersionBuf = Buffer.from("9f41bd5b", "hex");
+    const previousVersion = Uint8Array.from(previousVersionBuf);
+    const curVersionBuf = Buffer.from("cbb0f1d7", "hex");
+    const curVersion = Uint8Array.from(curVersionBuf);
+    const fork = {
+      previousVersion,
+      curVersion,
+      epoch: new BN("11971467576204192310")
+    };
+    const forkType: AnySSZType = {
+      fields: [
+        ["previousVersion", { elementType: "byte", length: 4 }],
+        ["curVersion", { elementType: "byte", length: 4 }],
+        ["epoch", "uint64"]
+      ]
+    };
+    const finalHash = hashTreeRoot(fork, forkType).toString("hex");
+    const want = "3ad1264c33bc66b43a49b1258b88f34b8dbfa1649f17e6df550f589650d34992";
+    assert.strictEqual(finalHash, want, "finalHash does not match");
+  });
 
   const failCases: {
     value: SerializableValue;

--- a/packages/ssz/test/unit/hashTreeRoot.test.ts
+++ b/packages/ssz/test/unit/hashTreeRoot.test.ts
@@ -67,6 +67,22 @@ describe("hashTreeRoot", () => {
     });
   }
 
+  it("should hash active validation indexes correctly as in final_updates_minimal.yalm", () => {
+    const validatorIndexes = [];
+    for (let i = 0; i < 64; i++) {
+      validatorIndexes.push(i);
+    }
+    const type: AnySSZType = {
+      elementType: {type:0, byteLength:8, useNumber:true},
+      // VALIDATOR_REGISTRY_LIMIT
+      maxLength: 1099511627776
+    }
+    // This is the logic to calculate activeIndexRoots in processFinalUpdates
+    const hash = hashTreeRoot(validatorIndexes, type).toString("hex");
+    const want = "ba1031ba1a5daab0d49597cfa8664ce2b4c9b4db6ca69fbef51e0a9a325a3b63";
+    assert.strictEqual(hash, want, "hash does not match");
+  });
+
   it("should be able to hash inner object as list of basic object", () => {
     const accountBalances = {
       balances: []


### PR DESCRIPTION
## Goal
+ Close #397 
## Root cause
+ bitLength() function runs forever if input parameter is <0
+ Chunk count is not correct for list of basic objects according to the spec