### PR TITLE
Fix e2e tests from libp2p refactor

### DIFF
--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -57,10 +57,14 @@ export class Libp2pNetwork extends (EventEmitter as { new(): NetworkEventEmitter
   }
 
   public getPeers(): PeerInfo[] {
-    return this.libp2p.peerBook.getAllArray();
+    return this.libp2p.peerBook.getAllArray().filter((peerInfo) => peerInfo.isConnected());
   }
   public hasPeer(peerInfo: PeerInfo): boolean {
-    return this.libp2p.peerBook.has(peerInfo);
+    const peer = this.libp2p.peerBook.get(peerInfo);
+    if (!peer) {
+      return false;
+    }
+    return Boolean(peer.isConnected());
   }
   public async connect(peerInfo: PeerInfo): Promise<void> {
     await promisify(this.libp2p.dial.bind(this.libp2p))(peerInfo);

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -89,7 +89,11 @@ export class SyncReqResp implements ISyncReqResp {
       !this.reps.get(peerInfo.id.toB58String()).latestHello
     ) {
       const request = await this.createHello();
-      await this.network.reqResp.hello(peerInfo, request).catch((e) => {});
+      try {
+        const response = await this.network.reqResp.hello(peerInfo, request);
+        this.reps.get(peerInfo.id.toB58String()).latestHello = request;
+      } catch (e) {
+      }
     }
   }
 
@@ -127,7 +131,7 @@ export class SyncReqResp implements ISyncReqResp {
   }
 
   public async onGoodbye(peerInfo: PeerInfo, id: RequestId, request: Goodbye): Promise<void> {
-    this.network.disconnect(peerInfo);
+    await this.network.disconnect(peerInfo);
   }
 
   public async onBeaconBlocks(id: RequestId, request: BeaconBlocksRequest): Promise<void> {

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -1,15 +1,15 @@
 import {expect} from "chai";
 
 import {config} from "@chainsafe/eth2.0-config/lib/presets/mainnet";
-import {Libp2pNetwork} from "../../../../src/network";
-import {BLOCK_TOPIC, ATTESTATION_TOPIC} from "../../../../src/constants";
-import {getEmptyBlock} from "../../../../src/chain/genesis/genesis";
-import {createNode} from "../../../unit/network/libp2p/util";
-import {generateEmptyAttestation} from "../../../utils/attestation";
-import {shardAttestationTopic} from "../../../../src/network/util";
-import {ILogger, WinstonLogger} from "../../../../src/logger";
-import {INetworkOptions} from "../../../../src/network/options";
-import {BeaconMetrics} from "../../../../src/metrics";
+import {Libp2pNetwork} from "../../../src/network";
+import {BLOCK_TOPIC, ATTESTATION_TOPIC} from "../../../src/constants";
+import {getEmptyBlock} from "../../../src/chain/genesis/genesis";
+import {createNode} from "../../unit/network/util";
+import {generateEmptyAttestation} from "../../utils/attestation";
+import {shardAttestationTopic} from "../../../src/network/util";
+import {ILogger, WinstonLogger} from "../../../src/logger";
+import {INetworkOptions} from "../../../src/network/options";
+import {BeaconMetrics} from "../../../src/metrics";
 
 const multiaddr = "/ip4/127.0.0.1/tcp/0";
 const opts: INetworkOptions = {
@@ -42,20 +42,22 @@ describe("[network] network", () => {
     ]);
   });
   it("should create a peer on connect", async function () {
-    await netA.connect(netB.peerInfo);
-    await Promise.all([
+    const connected = Promise.all([
       new Promise((resolve) => netA.on("peer:connect", resolve)),
       new Promise((resolve) => netB.on("peer:connect", resolve)),
     ]);
+    await netA.connect(netB.peerInfo);
+    await connected;
     expect(netA.getPeers().length).to.equal(1);
     expect(netB.getPeers().length).to.equal(1);
   });
   it("should delete a peer on disconnect", async function () {
-    await netA.connect(netB.peerInfo);
-    await Promise.all([
+    const connected = Promise.all([
       new Promise((resolve) => netA.on("peer:connect", resolve)),
       new Promise((resolve) => netB.on("peer:connect", resolve)),
     ]);
+    await netA.connect(netB.peerInfo);
+    await connected;
     const disconnection = Promise.all([
       new Promise((resolve) => netA.on("peer:disconnect", resolve)),
       new Promise((resolve) => netB.on("peer:disconnect", resolve)),
@@ -66,53 +68,56 @@ describe("[network] network", () => {
     expect(netB.getPeers().length).to.equal(0);
   });
   it("should receive blocks on subscription", async function () {
-    netA.subscribeToBlocks();
-    await netA.connect(netB.peerInfo);
-    await Promise.all([
+    netA.gossip.subscribeToBlocks();
+    const connected = Promise.all([
       new Promise((resolve) => netA.on("peer:connect", resolve)),
       new Promise((resolve) => netB.on("peer:connect", resolve)),
     ]);
+    await netA.connect(netB.peerInfo);
+    await connected;
     const received = new Promise((resolve, reject) => {
       setTimeout(reject, 4000);
-      netA.on(BLOCK_TOPIC, resolve);
+      netA.gossip.on(BLOCK_TOPIC, resolve);
     });
-    await new Promise((resolve) => netB.once("gossipsub:heartbeat", resolve));
-    netB.publishBlock(getEmptyBlock());
+    await new Promise((resolve) => netB.gossip.once("gossipsub:heartbeat", resolve));
+    netB.gossip.publishBlock(getEmptyBlock());
     await received;
   });
   it("should receive attestations on subscription", async function () {
-    netA.subscribeToAttestations();
-    await netA.connect(netB.peerInfo);
-    await Promise.all([
+    netA.gossip.subscribeToAttestations();
+    const connected = Promise.all([
       new Promise((resolve) => netA.on("peer:connect", resolve)),
       new Promise((resolve) => netB.on("peer:connect", resolve)),
     ]);
+    await netA.connect(netB.peerInfo);
+    await connected;
     const received = new Promise((resolve, reject) => {
       setTimeout(reject, 4000);
-      netA.on(ATTESTATION_TOPIC, resolve);
+      netA.gossip.on(ATTESTATION_TOPIC, resolve);
     });
-    await new Promise((resolve) => netB.once("gossipsub:heartbeat", resolve));
-    netB.publishAttestation(generateEmptyAttestation());
+    await new Promise((resolve) => netB.gossip.once("gossipsub:heartbeat", resolve));
+    netB.gossip.publishAttestation(generateEmptyAttestation());
     await received;
   });
   it("should receive shard attestations on subscription", async function () {
     const shard = 10;
-    netA.subscribeToShardAttestations(shard);
+    netA.gossip.subscribeToShardAttestations(shard);
     const topic = shardAttestationTopic(shard);
-    await netA.connect(netB.peerInfo);
-    await Promise.all([
+    const connected = Promise.all([
       new Promise((resolve) => netA.on("peer:connect", resolve)),
       new Promise((resolve) => netB.on("peer:connect", resolve)),
     ]);
+    await netA.connect(netB.peerInfo);
+    await connected;
     const received = new Promise((resolve, reject) => {
       setTimeout(reject, 4000);
       // @ts-ignore
-      netA.on(topic, resolve);
+      netA.gossip.on(topic, resolve);
     });
-    await new Promise((resolve) => netB.once("gossipsub:heartbeat", resolve));
+    await new Promise((resolve) => netB.gossip.once("gossipsub:heartbeat", resolve));
     const attestation = generateEmptyAttestation();
     attestation.data.crosslink.shard = shard;
-    netB.publishShardAttestation(attestation);
+    netB.gossip.publishShardAttestation(attestation);
     await received;
   });
 });


### PR DESCRIPTION
The e2e tests were broken from #425 

This cleans up tests and updates the network implementation to a more working state.
- properly destroy timers for requests/responses
- handle the request-only goodbye method (properly destroying timers)
- fix `network.getPeers` and `network.hasPeer`