### PR TITLE
Move spec test cases from git submodule to npm dep

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "spec-test-cases-module"]
-	path = packages/spec-test-cases
-	url = https://github.com/ChainSafe/eth2.0-spec-tests.git
-	branch = v0.8.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,41 +16,31 @@ jobs:
     - stage: Lint and Check types
       name: Check types
       script: lerna run check-types && lerna run lint
-      git:
-        submodules: false
 
     - stage: Tests
       name: Unit
       script: lerna run test:unit && lerna run coverage
-      git:
-        submodules: false
     -
       name: e2e
       script: lerna run test:e2e
-      git:
-        submodules: false
     -
       name: spec-minimal
       if: branch != master || type = pull_request
       script:
-        - git submodule foreach git lfs pull
         - lerna run test:spec-min
       cache:
         directories:
           - node_modules
           - packages/lodestar/node_modules
-          - .git/modules/spec-test-cases-module/lfs
     -
       name: spec-full
       if: branch = master AND type != pull_request
       script:
-        - git submodule foreach git lfs pull
         - lerna run test:spec
       cache:
         directories:
           - node_modules
           - packages/lodestar/node_modules
-          - .git/modules/spec-test-cases-module/lfs
 
 before_deploy:
     - lerna run build:docs

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "typedoc-plugin-markdown": "^2.0.6",
     "typescript": "^3.5.1",
     "webpack": "^4.39.1"
+  },
+  "optionalDependencies": {
+    "@chainsafe/eth2-spec-tests": "0.8.3"
   }
 }

--- a/packages/bls/package.json
+++ b/packages/bls/package.json
@@ -27,7 +27,7 @@
     "lint:fix": "eslint --ext .ts src/ --fix",
     "pretest": "yarn check-types",
     "prepublishOnly": "yarn build",
-    "test:unit": "nyc --cache-dir .nyc_output/.cache -r lcov -e .ts mocha --colors -r ./.babel-register 'test/unit/**/*.test.ts' && nyc report",
+    "test:unit": "nyc --cache-dir .nyc_output/.cache -r lcov -e .ts mocha --colors -r ts-node/register 'test/unit/**/*.test.ts' && nyc report",
     "test:spec": "mocha --colors -r ts-node/register 'test/spec/**/*.test.ts'",
     "test:spec-min": "yarn run test:spec",
     "test": "yarn test:unit && yarn test:spec",

--- a/packages/bls/test/spec/aggregate_pubkeys.test.ts
+++ b/packages/bls/test/spec/aggregate_pubkeys.test.ts
@@ -2,21 +2,24 @@ import bls from "../../src";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import path from "path";
 
-interface AggregatePubKeysTestCase {
+interface IAggregatePubKeysTestCase {
   data: {
     input: string[];
     output: string;
   };
 }
 
-describeDirectorySpecTest<AggregatePubKeysTestCase, string>(
+describeDirectorySpecTest<IAggregatePubKeysTestCase, string>(
   "aggregate pubkeys",
-  path.join(__dirname, "../../../spec-test-cases/tests/general/phase0/bls/aggregate_pubkeys/small"),
+  path.join(
+    __dirname,
+    "../../../../node_modules/@chainsafe/eth2-spec-tests/tests/general/phase0/bls/aggregate_pubkeys/small"
+  ),
   (testCase => {
     const result =  bls.aggregatePubkeys(testCase.data.input.map(pubKey => {
       return Buffer.from(pubKey.replace("0x", ""), "hex");
     }));
-    return `0x${result.toString('hex')}`;
+    return `0x${result.toString("hex")}`;
   }),
   {
     inputTypes: {

--- a/packages/bls/test/spec/aggregate_sigs.test.ts
+++ b/packages/bls/test/spec/aggregate_sigs.test.ts
@@ -11,12 +11,15 @@ interface AggregateSigsTestCase {
 
 describeDirectorySpecTest<AggregateSigsTestCase, string>(
   "aggregate sigs",
-  path.join(__dirname, "../../../spec-test-cases/tests/general/phase0/bls/aggregate_sigs/small"),
+  path.join(
+    __dirname,
+    "../../../../node_modules/@chainsafe/eth2-spec-tests/tests/general/phase0/bls/aggregate_sigs/small"
+  ),
   (testCase => {
     const result =  bls.aggregateSignatures(testCase.data.input.map(pubKey => {
       return Buffer.from(pubKey.replace("0x", ""), "hex");
     }));
-    return `0x${result.toString('hex')}`;
+    return `0x${result.toString("hex")}`;
   }),
   {
     inputTypes: {

--- a/packages/bls/test/spec/msg_hash_compressed.test.ts
+++ b/packages/bls/test/spec/msg_hash_compressed.test.ts
@@ -3,7 +3,7 @@ import {padLeft} from "../../src/helpers/utils";
 import {G2point} from "../../src/helpers/g2point";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 
-interface MsgHHashCOmpressed {
+interface IMsgHHashCOmpressed {
   data: {
     input: {
       message: string;
@@ -13,23 +13,26 @@ interface MsgHHashCOmpressed {
   };
 }
 
-describeDirectorySpecTest<MsgHHashCOmpressed, string>(
+describeDirectorySpecTest<IMsgHHashCOmpressed, string>(
   "msg_hash_compressed",
-  path.join(__dirname, "../../../spec-test-cases/tests/general/phase0/bls/msg_hash_compressed/small"),
+  path.join(
+    __dirname,
+    "../../../../node_modules/@chainsafe/eth2-spec-tests/tests/general/phase0/bls/msg_hash_compressed/small"
+  ),
   (testCase => {
-    const domain = padLeft(Buffer.from(testCase.data.input.domain.replace('0x', ''), 'hex'), 8);
-    const input = Buffer.from(testCase.data.input.message.replace('0x', ''), "hex");
+    const domain = padLeft(Buffer.from(testCase.data.input.domain.replace("0x", ""), "hex"), 8);
+    const input = Buffer.from(testCase.data.input.message.replace("0x", ""), "hex");
     const result = G2point.hashToG2(input, domain);
-    return `0x${result.toBytesCompressed().toString('hex')}`;
+    return `0x${result.toBytesCompressed().toString("hex")}`;
   }),
   {
     inputTypes: {
       data: InputType.YAML,
     },
     getExpected: (testCase => {
-      const xReExpected = padLeft(Buffer.from(testCase.data.output[0].replace('0x', ''), 'hex'), 48);
-      const xImExpected = padLeft(Buffer.from(testCase.data.output[1].replace('0x', ''), 'hex'), 48);
-      return '0x' + Buffer.concat([xReExpected, xImExpected]).toString('hex');
+      const xReExpected = padLeft(Buffer.from(testCase.data.output[0].replace("0x", ""), "hex"), 48);
+      const xImExpected = padLeft(Buffer.from(testCase.data.output[1].replace("0x", ""), "hex"), 48);
+      return "0x" + Buffer.concat([xReExpected, xImExpected]).toString("hex");
     })
   }
 );

--- a/packages/bls/test/spec/msg_hash_uncompressed.test.ts
+++ b/packages/bls/test/spec/msg_hash_uncompressed.test.ts
@@ -3,7 +3,7 @@ import {padLeft} from "../../src/helpers/utils";
 import {G2point} from "../../src/helpers/g2point";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 
-interface MsgHHashUnCompressed {
+interface IMsgHHashUnCompressed {
   data: {
     input: {
       message: string;
@@ -13,28 +13,31 @@ interface MsgHHashUnCompressed {
   };
 }
 
-describeDirectorySpecTest<MsgHHashUnCompressed, string>(
+describeDirectorySpecTest<IMsgHHashUnCompressed, string>(
   "msg_hash_uncompressed",
-  path.join(__dirname, "../../../spec-test-cases/tests/general/phase0/bls/msg_hash_uncompressed/small"),
+  path.join(
+    __dirname,
+    "../../../../node_modules/@chainsafe/eth2-spec-tests/tests/general/phase0/bls/msg_hash_uncompressed/small"
+  ),
   (testCase => {
-    const domain = padLeft(Buffer.from(testCase.data.input.domain.replace('0x', ''), 'hex'), 8);
+    const domain = padLeft(Buffer.from(testCase.data.input.domain.replace("0x", ""), "hex"), 8);
     const input = Buffer.from(testCase.data.input.message.replace("0x", ""), "hex");
     const result = G2point.hashToG2(input, domain);
-    return `0x${result.toBytesCompressed().toString('hex')}`;
+    return `0x${result.toBytesCompressed().toString("hex")}`;
   }),
   {
     inputTypes: {
       data: InputType.YAML,
     },
     getExpected: (testCase => {
-      return '0x' + G2point.fromUncompressedInput(
-        Buffer.from(testCase.data.output[0][0].replace('0x', ''), 'hex'),
-        Buffer.from(testCase.data.output[0][1].replace('0x', ''), 'hex'),
-        Buffer.from(testCase.data.output[1][0].replace('0x', ''), 'hex'),
-        Buffer.from(testCase.data.output[1][1].replace('0x', ''), 'hex'),
-        Buffer.from(testCase.data.output[2][0].replace('0x', ''), 'hex'),
-        Buffer.from(testCase.data.output[2][1].replace('0x', ''), 'hex'),
-      ).toBytesCompressed().toString('hex');
+      return "0x" + G2point.fromUncompressedInput(
+        Buffer.from(testCase.data.output[0][0].replace("0x", ""), "hex"),
+        Buffer.from(testCase.data.output[0][1].replace("0x", ""), "hex"),
+        Buffer.from(testCase.data.output[1][0].replace("0x", ""), "hex"),
+        Buffer.from(testCase.data.output[1][1].replace("0x", ""), "hex"),
+        Buffer.from(testCase.data.output[2][0].replace("0x", ""), "hex"),
+        Buffer.from(testCase.data.output[2][1].replace("0x", ""), "hex"),
+      ).toBytesCompressed().toString("hex");
     })
   }
 );

--- a/packages/bls/test/spec/priv_to_public.test.ts
+++ b/packages/bls/test/spec/priv_to_public.test.ts
@@ -2,24 +2,27 @@ import bls from "../../src";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import path from "path";
 
-interface PrivToPubTestCase {
-    data: {
-        input: string;
-        output: string;
-    };
+interface IPrivToPubTestCase {
+  data: {
+    input: string;
+    output: string;
+  };
 }
 
-describeDirectorySpecTest<PrivToPubTestCase, string>(
-    "priv_to_pub",
-    path.join(__dirname, "../../../spec-test-cases/tests/general/phase0/bls/priv_to_pub/small"),
-    (testCase => {
-        const result =  bls.generatePublicKey(Buffer.from(testCase.data.input.replace('0x', ''), 'hex'));
-        return `0x${result.toString('hex')}`;
-    }),
-    {
-        inputTypes: {
-            data: InputType.YAML,
-        },
-        getExpected: (testCase => testCase.data.output)
-    }
+describeDirectorySpecTest<IPrivToPubTestCase, string>(
+  "priv_to_pub",
+  path.join(
+    __dirname,
+    "../../../../node_modules/@chainsafe/eth2-spec-tests/tests/general/phase0/bls/priv_to_pub/small"
+  ),
+  (testCase => {
+    const result =  bls.generatePublicKey(Buffer.from(testCase.data.input.replace("0x", ""), "hex"));
+    return `0x${result.toString("hex")}`;
+  }),
+  {
+    inputTypes: {
+      data: InputType.YAML,
+    },
+    getExpected: (testCase => testCase.data.output)
+  }
 );

--- a/packages/bls/test/spec/sign_message.test.ts
+++ b/packages/bls/test/spec/sign_message.test.ts
@@ -3,7 +3,7 @@ import bls from "../../src";
 import {padLeft} from "../../src/helpers/utils";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 
-interface SignMessageTestCase {
+interface ISignMessageTestCase {
   data: {
     input: {
       privkey: string;
@@ -14,14 +14,17 @@ interface SignMessageTestCase {
   };
 }
 
-describeDirectorySpecTest<SignMessageTestCase, string>(
+describeDirectorySpecTest<ISignMessageTestCase, string>(
   "priv_to_pub",
-  path.join(__dirname, "../../../spec-test-cases/tests/general/phase0/bls/sign_msg/small"),
+  path.join(
+    __dirname,
+    "../../../../node_modules/@chainsafe/eth2-spec-tests/tests/general/phase0/bls/sign_msg/small"
+  ),
   (testCase => {
     const signature =  bls.sign(
       Buffer.from(testCase.data.input.privkey.replace("0x", ""), "hex"),
       Buffer.from(testCase.data.input.message.replace("0x", ""), "hex"),
-      padLeft(Buffer.from(testCase.data.input.domain.replace('0x', ''), 'hex'), 8)
+      padLeft(Buffer.from(testCase.data.input.domain.replace("0x", ""), "hex"), 8)
     );
     return `0x${signature.toString("hex")}`;
   }),

--- a/packages/lodestar/README.md
+++ b/packages/lodestar/README.md
@@ -34,6 +34,11 @@ Open resulting html file in favorite browser.
 2. `lerna run build`
 3. `packages/lodestar/./bin/lodestar --help`
 
+Note:
+
+Spec test cases are optional dependency which can be skipped by adding `--ignore-optional` when installing dependencies.
+You can always download spec test cases by running `yarn install --force`.
+
 ### Starting private eth1 chain
 
 `./bin/lodestar eth1:dev -m "vast thought differ pull jewel broom cook wrist tribe word before omit"`

--- a/packages/lodestar/test/spec/epoch_processing/crosslinks/crosslinks_mainnet.test.ts
+++ b/packages/lodestar/test/spec/epoch_processing/crosslinks/crosslinks_mainnet.test.ts
@@ -6,10 +6,11 @@ import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-
 import {equals} from "@chainsafe/ssz";
 import {expect} from "chai";
 import {StateTestCase} from "../../../utils/specTestTypes/stateTestCase";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<StateTestCase, BeaconState>(
   "epoch_croslinks mainnet",
-  join(__dirname, "../../../../../spec-test-cases/tests/mainnet/phase0/epoch_processing/crosslinks/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "tests/mainnet/phase0/epoch_processing/crosslinks/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processCrosslinks(config, state);

--- a/packages/lodestar/test/spec/epoch_processing/crosslinks/crosslinks_minimal.test.ts
+++ b/packages/lodestar/test/spec/epoch_processing/crosslinks/crosslinks_minimal.test.ts
@@ -7,10 +7,11 @@ import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-
 import {equals} from "@chainsafe/ssz";
 import {expect} from "chai";
 import {StateTestCase} from "../../../utils/specTestTypes/stateTestCase";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<StateTestCase, BeaconState>(
   "epoch_croslinks minimal",
-  join(__dirname, "../../../../../spec-test-cases/tests/minimal/phase0/epoch_processing/crosslinks/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/epoch_processing/crosslinks/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processCrosslinks(config, state);

--- a/packages/lodestar/test/spec/epoch_processing/finalUpdates/final_updates_mainnet.test.ts
+++ b/packages/lodestar/test/spec/epoch_processing/finalUpdates/final_updates_mainnet.test.ts
@@ -7,10 +7,11 @@ import {processFinalUpdates} from "../../../../src/chain/stateTransition/epoch/f
 import {BeaconState} from "@chainsafe/eth2.0-types";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {StateTestCase} from "../../../utils/specTestTypes/stateTestCase";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<StateTestCase, BeaconState>(
   "epoch final updates mainnet",
-  join(__dirname, "../../../../../spec-test-cases/tests/mainnet/phase0/epoch_processing/final_updates/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "tests/mainnet/phase0/epoch_processing/final_updates/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processFinalUpdates(config, state);

--- a/packages/lodestar/test/spec/epoch_processing/finalUpdates/final_updates_minimal.test.ts
+++ b/packages/lodestar/test/spec/epoch_processing/finalUpdates/final_updates_minimal.test.ts
@@ -7,10 +7,11 @@ import {processFinalUpdates} from "../../../../src/chain/stateTransition/epoch/f
 import {BeaconState} from "@chainsafe/eth2.0-types";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {StateTestCase} from "../../../utils/specTestTypes/stateTestCase";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<StateTestCase, BeaconState>(
   "epoch final updates minimal",
-  join(__dirname, "../../../../../spec-test-cases/tests/minimal/phase0/epoch_processing/final_updates/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "tests/minimal/phase0/epoch_processing/final_updates/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processFinalUpdates(config, state);

--- a/packages/lodestar/test/spec/epoch_processing/justification/justification_and_finalization_mainnet.test.ts
+++ b/packages/lodestar/test/spec/epoch_processing/justification/justification_and_finalization_mainnet.test.ts
@@ -7,10 +7,11 @@ import {processJustificationAndFinalization} from "../../../../src/chain/stateTr
 import {BeaconState} from "@chainsafe/eth2.0-types";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {StateTestCase} from "../../../utils/specTestTypes/stateTestCase";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<StateTestCase, BeaconState>(
   "epoch justification and finalization mainnet",
-  join(__dirname, "../../../../../spec-test-cases/tests/mainnet/phase0/epoch_processing/justification_and_finalization/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "tests/mainnet/phase0/epoch_processing/justification_and_finalization/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processJustificationAndFinalization(config, state);

--- a/packages/lodestar/test/spec/epoch_processing/justification/justification_and_finalization_minimal.test.ts
+++ b/packages/lodestar/test/spec/epoch_processing/justification/justification_and_finalization_minimal.test.ts
@@ -7,10 +7,11 @@ import {processJustificationAndFinalization} from "../../../../src/chain/stateTr
 import {BeaconState} from "@chainsafe/eth2.0-types";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {StateTestCase} from "../../../utils/specTestTypes/stateTestCase";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<StateTestCase, BeaconState>(
   "epoch justification and finalization minimal",
-  join(__dirname, "../../../../../spec-test-cases/tests/minimal/phase0/epoch_processing/justification_and_finalization/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/epoch_processing/justification_and_finalization/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processJustificationAndFinalization(config, state);

--- a/packages/lodestar/test/spec/epoch_processing/registryUpdates/registry_updates_mainnet.test.ts
+++ b/packages/lodestar/test/spec/epoch_processing/registryUpdates/registry_updates_mainnet.test.ts
@@ -7,10 +7,11 @@ import {BeaconState} from "@chainsafe/eth2.0-types";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {StateTestCase} from "../../../utils/specTestTypes/stateTestCase";
 import {processRegistryUpdates} from "../../../../src/chain/stateTransition/epoch/registryUpdates";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<StateTestCase, BeaconState>(
   "epoch registry updates mainnet",
-  join(__dirname, "../../../../../spec-test-cases/tests/mainnet/phase0/epoch_processing/registry_updates/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/epoch_processing/registry_updates/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processRegistryUpdates(config, state);

--- a/packages/lodestar/test/spec/epoch_processing/registryUpdates/registry_updates_minimal.test.ts
+++ b/packages/lodestar/test/spec/epoch_processing/registryUpdates/registry_updates_minimal.test.ts
@@ -7,10 +7,11 @@ import {processRegistryUpdates} from "../../../../src/chain/stateTransition/epoc
 import {BeaconState} from "@chainsafe/eth2.0-types";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {StateTestCase} from "../../../utils/specTestTypes/stateTestCase";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<StateTestCase, BeaconState>(
   "epoch registry updates minimal",
-  join(__dirname, "../../../../../spec-test-cases/tests/minimal/phase0/epoch_processing/registry_updates/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "tests/minimal/phase0/epoch_processing/registry_updates/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processRegistryUpdates(config, state);

--- a/packages/lodestar/test/spec/epoch_processing/slashings/slashings_mainnet.test.ts
+++ b/packages/lodestar/test/spec/epoch_processing/slashings/slashings_mainnet.test.ts
@@ -7,10 +7,11 @@ import {BeaconState} from "@chainsafe/eth2.0-types";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {StateTestCase} from "../../../utils/specTestTypes/stateTestCase";
 import {processSlashings} from "../../../../src/chain/stateTransition/epoch/slashings";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<StateTestCase, BeaconState>(
   "epoch slashings mainnet",
-  join(__dirname, "../../../../../spec-test-cases/tests/mainnet/phase0/epoch_processing/slashings/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/epoch_processing/slashings/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processSlashings(config, state);

--- a/packages/lodestar/test/spec/epoch_processing/slashings/slashings_minimal.test.ts
+++ b/packages/lodestar/test/spec/epoch_processing/slashings/slashings_minimal.test.ts
@@ -7,10 +7,11 @@ import {processSlashings} from "../../../../src/chain/stateTransition/epoch/slas
 import {BeaconState} from "@chainsafe/eth2.0-types";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {StateTestCase} from "../../../utils/specTestTypes/stateTestCase";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<StateTestCase, BeaconState>(
   "epoch slashings minimal",
-  join(__dirname, "../../../../../spec-test-cases/tests/minimal/phase0/epoch_processing/slashings/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/epoch_processing/slashings/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processSlashings(config, state);

--- a/packages/lodestar/test/spec/genesis/initialization/genesis_initialization_minimal.test.ts
+++ b/packages/lodestar/test/spec/genesis/initialization/genesis_initialization_minimal.test.ts
@@ -9,6 +9,7 @@ import {BeaconState, Deposit, Hash, number64, uint64} from "@chainsafe/eth2.0-ty
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {initializeBeaconStateFromEth1} from "../../../../src/chain/genesis/genesis";
 import {IBeaconConfig} from "@chainsafe/eth2.0-config";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 interface GenesisInitSpecTest {
   eth1_block_hash: Hash;
@@ -22,7 +23,7 @@ interface GenesisInitSpecTest {
 
 describeDirectorySpecTest<GenesisInitSpecTest, BeaconState>(
   "genesis initialization",
-  join(__dirname, "../../../../../spec-test-cases/tests/minimal/phase0/genesis/initialization/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/genesis/initialization/pyspec_tests"),
   (testcase) => {
     const deposits: Deposit[] = [];
     for(let i= 0; i < testcase.meta.depositsCount.toNumber(); i++) {

--- a/packages/lodestar/test/spec/genesis/validity/genesis_validity_minimal.test.ts
+++ b/packages/lodestar/test/spec/genesis/validity/genesis_validity_minimal.test.ts
@@ -8,6 +8,7 @@ import {GenesisValidityCase} from "../../../utils/specTestTypes/genesis";
 import {BeaconState} from "@chainsafe/eth2.0-types";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {equals} from "@chainsafe/ssz";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 interface GenesisValidityTestCase {
   is_valid: boolean;
@@ -16,7 +17,7 @@ interface GenesisValidityTestCase {
 
 describeDirectorySpecTest<GenesisValidityTestCase, boolean>(
   "genesis initialization",
-  join(__dirname, "../../../../../spec-test-cases/tests/minimal/phase0/genesis/validity/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "tests/minimal/phase0/genesis/validity/pyspec_tests"),
   (testcase) => {
     return isValidGenesisState(config, testcase.genesis);
   },

--- a/packages/lodestar/test/spec/operations/attestations/attestations_mainnet.test.ts
+++ b/packages/lodestar/test/spec/operations/attestations/attestations_mainnet.test.ts
@@ -6,10 +6,11 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/mainnet";
 import {processAttestation} from "../../../../src/chain/stateTransition/block/operations";
 import {describeDirectorySpecTest} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {ProcessAttestationTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<ProcessAttestationTestCase, BeaconState>(
   "process attestation mainnet",
-  join(__dirname, "../../../../../spec-test-cases/tests/mainnet/phase0/operations/attestation/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/operations/attestation/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processAttestation(config, state, testcase.attestation);

--- a/packages/lodestar/test/spec/operations/attestations/attestations_minimal.test.ts
+++ b/packages/lodestar/test/spec/operations/attestations/attestations_minimal.test.ts
@@ -8,10 +8,11 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {processAttestation} from "../../../../src/chain/stateTransition/block/operations";
 import {describeDirectorySpecTest} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {ProcessAttestationTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<ProcessAttestationTestCase, BeaconState>(
   "process attestation minimal",
-  join(__dirname, "../../../../../spec-test-cases/tests/minimal/phase0/operations/attestation/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/operations/attestation/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processAttestation(config, state, testcase.attestation);

--- a/packages/lodestar/test/spec/operations/attesterSlashing/attester_slashing_mainnet.test.ts
+++ b/packages/lodestar/test/spec/operations/attesterSlashing/attester_slashing_mainnet.test.ts
@@ -1,22 +1,16 @@
 import {join} from "path";
-import {describeMultiSpec} from "@chainsafe/eth2.0-spec-test-util";
 import {expect} from "chai";
-import sinon from "sinon";
-// @ts-ignore
-import {restore, rewire} from "@chainsafe/bls";
 import {equals} from "@chainsafe/ssz";
-
 import {BeaconState} from "@chainsafe/eth2.0-types";
 import {config} from "@chainsafe/eth2.0-config/lib/presets/mainnet";
 import {processAttesterSlashing} from "../../../../src/chain/stateTransition/block/operations";
-import {expandYamlValue} from "../../../utils/expandYamlValue";
-import {AttesterSlashingCase} from "../../../utils/specTestTypes/beaconStateComparison";
 import {describeDirectorySpecTest} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {ProcessAttesterSlashingTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<ProcessAttesterSlashingTestCase, BeaconState>(
   "process attester slashing mainnet",
-  join(__dirname, "../../../../../spec-test-cases/tests/mainnet/phase0/operations/attester_slashing/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/operations/attester_slashing/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processAttesterSlashing(config, state, testcase.attester_slashing);

--- a/packages/lodestar/test/spec/operations/attesterSlashing/attester_slashing_minimal.test.ts
+++ b/packages/lodestar/test/spec/operations/attesterSlashing/attester_slashing_minimal.test.ts
@@ -6,10 +6,11 @@ import {processAttesterSlashing} from "../../../../src/chain/stateTransition/blo
 import {BeaconState} from "@chainsafe/eth2.0-types";
 import {describeDirectorySpecTest} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {ProcessAttesterSlashingTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<ProcessAttesterSlashingTestCase, BeaconState>(
   "process attester slashing minimal",
-  join(__dirname, "../../../../../spec-test-cases/tests/minimal/phase0/operations/attester_slashing/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/operations/attester_slashing/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processAttesterSlashing(config, state, testcase.attester_slashing);

--- a/packages/lodestar/test/spec/operations/blockHeader/block_header_mainnet.test.ts
+++ b/packages/lodestar/test/spec/operations/blockHeader/block_header_mainnet.test.ts
@@ -1,22 +1,18 @@
 import {join} from "path";
-import {describeMultiSpec} from "@chainsafe/eth2.0-spec-test-util";
 import {expect} from "chai";
 // @ts-ignore
-import {restore, rewire} from "@chainsafe/bls";
-import sinon from "sinon";
 import {equals} from "@chainsafe/ssz";
 
 import {BeaconState} from "@chainsafe/eth2.0-types";
 import {config} from "@chainsafe/eth2.0-config/lib/presets/mainnet";
 import {processBlockHeader} from "../../../../src/chain/stateTransition/block/blockHeader";
-import {expandYamlValue} from "../../../utils/expandYamlValue";
-import {BlockHeaderCase} from "../../../utils/specTestTypes/beaconStateComparison";
 import {describeDirectorySpecTest} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {ProcessBlockHeader} from "./type";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<ProcessBlockHeader, BeaconState>(
   "process block header mainnet",
-  join(__dirname, "../../../../../spec-test-cases/tests/mainnet/phase0/operations/block_header/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/operations/block_header/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processBlockHeader(config, state, testcase.block);

--- a/packages/lodestar/test/spec/operations/blockHeader/block_header_minimal.test.ts
+++ b/packages/lodestar/test/spec/operations/blockHeader/block_header_minimal.test.ts
@@ -7,10 +7,11 @@ import {BeaconState} from "@chainsafe/eth2.0-types";
 import {describeDirectorySpecTest} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {ProcessBlockHeader} from "./type";
 import {processBlockHeader} from "../../../../src/chain/stateTransition/block/blockHeader";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<ProcessBlockHeader, BeaconState>(
   "process block header minimal",
-  join(__dirname, "../../../../../spec-test-cases/tests/minimal/phase0/operations/block_header/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/operations/block_header/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processBlockHeader(config, state, testcase.block);

--- a/packages/lodestar/test/spec/operations/deposit/deposit_mainnet.test.ts
+++ b/packages/lodestar/test/spec/operations/deposit/deposit_mainnet.test.ts
@@ -6,10 +6,11 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/mainnet";
 import {processDeposit} from "../../../../src/chain/stateTransition/block/operations";
 import {describeDirectorySpecTest} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {ProcessDepositTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<ProcessDepositTestCase, BeaconState>(
   "process deposit mainnet",
-  join(__dirname, "../../../../../spec-test-cases/tests/mainnet/phase0/operations/deposit/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/operations/deposit/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processDeposit(config, state, testcase.deposit);

--- a/packages/lodestar/test/spec/operations/deposit/deposit_minimal.test.ts
+++ b/packages/lodestar/test/spec/operations/deposit/deposit_minimal.test.ts
@@ -6,10 +6,11 @@ import {processDeposit} from "../../../../src/chain/stateTransition/block/operat
 import {BeaconState} from "@chainsafe/eth2.0-types";
 import {describeDirectorySpecTest} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {ProcessDepositTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<ProcessDepositTestCase, BeaconState>(
   "process deposit minimal",
-  join(__dirname, "../../../../../spec-test-cases/tests/minimal/phase0/operations/deposit/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/operations/deposit/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processDeposit(config, state, testcase.deposit);

--- a/packages/lodestar/test/spec/operations/proposerSlashing/proposer_slashing_mainnet.test.ts
+++ b/packages/lodestar/test/spec/operations/proposerSlashing/proposer_slashing_mainnet.test.ts
@@ -6,10 +6,11 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/mainnet";
 import {processProposerSlashing} from "../../../../src/chain/stateTransition/block/operations";
 import {describeDirectorySpecTest} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {ProcessProposerSlashingTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<ProcessProposerSlashingTestCase, BeaconState>(
   "process proposer slashing mainnet",
-  join(__dirname, "../../../../../spec-test-cases/tests/mainnet/phase0/operations/proposer_slashing/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/operations/proposer_slashing/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processProposerSlashing(config, state, testcase.proposer_slashing);

--- a/packages/lodestar/test/spec/operations/proposerSlashing/proposer_slashing_minimal.test.ts
+++ b/packages/lodestar/test/spec/operations/proposerSlashing/proposer_slashing_minimal.test.ts
@@ -6,10 +6,11 @@ import {processProposerSlashing} from "../../../../src/chain/stateTransition/blo
 import {BeaconState} from "@chainsafe/eth2.0-types";
 import {describeDirectorySpecTest} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {ProcessProposerSlashingTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<ProcessProposerSlashingTestCase, BeaconState>(
   "process proposer slashing minimal",
-  join(__dirname, "../../../../../spec-test-cases/tests/minimal/phase0/operations/proposer_slashing/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/operations/proposer_slashing/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processProposerSlashing(config, state, testcase.proposer_slashing);

--- a/packages/lodestar/test/spec/operations/transfer/transfer_minimal.test.ts
+++ b/packages/lodestar/test/spec/operations/transfer/transfer_minimal.test.ts
@@ -8,10 +8,11 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {processTransfer} from "../../../../src/chain/stateTransition/block/operations";
 import {describeDirectorySpecTest} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {ProcessTransferTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<ProcessTransferTestCase, BeaconState>(
   "process transfer minimal",
-  join(__dirname, "../../../../../spec-test-cases/tests/minimal/phase0/operations/transfer/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/operations/transfer/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processTransfer(config, state, testcase.transfer);

--- a/packages/lodestar/test/spec/operations/voluntaryExit/voluntary_exit_mainnet.test.ts
+++ b/packages/lodestar/test/spec/operations/voluntaryExit/voluntary_exit_mainnet.test.ts
@@ -8,10 +8,11 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/mainnet";
 import {processVoluntaryExit} from "../../../../src/chain/stateTransition/block/operations";
 import {describeDirectorySpecTest} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {ProcessVoluntaryExitTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<ProcessVoluntaryExitTestCase, BeaconState>(
   "process voluntary exit mainnet",
-  join(__dirname, "../../../../../spec-test-cases/tests/mainnet/phase0/operations/voluntary_exit/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/operations/voluntary_exit/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processVoluntaryExit(config, state, testcase.voluntary_exit);

--- a/packages/lodestar/test/spec/operations/voluntaryExit/voluntary_exit_minimal.test.ts
+++ b/packages/lodestar/test/spec/operations/voluntaryExit/voluntary_exit_minimal.test.ts
@@ -6,10 +6,11 @@ import {processVoluntaryExit} from "../../../../src/chain/stateTransition/block/
 import {BeaconState} from "@chainsafe/eth2.0-types";
 import {describeDirectorySpecTest} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {ProcessVoluntaryExitTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<ProcessVoluntaryExitTestCase, BeaconState>(
   "process voluntary exit minimal",
-  join(__dirname, "../../../../../spec-test-cases/tests/minimal/phase0/operations/voluntary_exit/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/operations/voluntary_exit/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processVoluntaryExit(config, state, testcase.voluntary_exit);

--- a/packages/lodestar/test/spec/sanity/blocks/sanity_blocks_mainnet.test.ts
+++ b/packages/lodestar/test/spec/sanity/blocks/sanity_blocks_mainnet.test.ts
@@ -9,10 +9,11 @@ import {stateTransition} from "../../../../src/chain/stateTransition";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {BlockSanityTestCase} from "./type";
 import {IBeaconConfig} from "@chainsafe/eth2.0-config";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<BlockSanityTestCase, BeaconState>(
   "block sanity minimal",
-  join(__dirname, "../../../../../spec-test-cases/tests/mainnet/phase0/sanity/blocks/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/sanity/blocks/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     for(let i = 0; i < testcase.meta.blocksCount.toNumber(); i++) {

--- a/packages/lodestar/test/spec/sanity/blocks/sanity_blocks_minimal.test.ts
+++ b/packages/lodestar/test/spec/sanity/blocks/sanity_blocks_minimal.test.ts
@@ -7,10 +7,11 @@ import {stateTransition} from "../../../../src/chain/stateTransition";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {IBeaconConfig} from "@chainsafe/eth2.0-config";
 import {BlockSanityTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<BlockSanityTestCase, BeaconState>(
   "block sanity minimal",
-  join(__dirname, "../../../../../spec-test-cases/tests/minimal/phase0/sanity/blocks/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/sanity/blocks/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     for(let i = 0; i < testcase.meta.blocksCount.toNumber(); i++) {

--- a/packages/lodestar/test/spec/sanity/slots/sanity_slots_mainnet.test.ts
+++ b/packages/lodestar/test/spec/sanity/slots/sanity_slots_mainnet.test.ts
@@ -6,10 +6,11 @@ import {BeaconState} from "@chainsafe/eth2.0-types";
 import {processSlots} from "../../../../src/chain/stateTransition";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {ProcessSlotsTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<ProcessSlotsTestCase, BeaconState>(
   "slot sanity mainnet",
-  join(__dirname, "../../../../../spec-test-cases/tests/mainnet/phase0/sanity/slots/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/sanity/slots/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processSlots(config, state, state.slot + testcase.slots.toNumber());

--- a/packages/lodestar/test/spec/sanity/slots/sanity_slots_minimal.test.ts
+++ b/packages/lodestar/test/spec/sanity/slots/sanity_slots_minimal.test.ts
@@ -6,10 +6,11 @@ import {BeaconState} from "@chainsafe/eth2.0-types";
 import {processSlots} from "../../../../src/chain/stateTransition";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {ProcessSlotsTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<ProcessSlotsTestCase, BeaconState>(
   "slot sanity minimal",
-  join(__dirname, "../../../../../spec-test-cases/tests/minimal/phase0/sanity/slots/pyspec_tests"),
+  join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/sanity/slots/pyspec_tests"),
   (testcase) => {
     const state = testcase.pre;
     processSlots(config, state, state.slot + testcase.slots.toNumber());

--- a/packages/lodestar/test/spec/shufling/shuffling_mainnet.test.ts
+++ b/packages/lodestar/test/spec/shufling/shuffling_mainnet.test.ts
@@ -3,10 +3,11 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/mainnet";
 import {computeShuffledIndex} from "../../../src/chain/stateTransition/util";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {ShufflingTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
 
 describeDirectorySpecTest<ShufflingTestCase, number[]>(
   "shuffling mainnet",
-  join(__dirname, "../../../../spec-test-cases/tests/mainnet/phase0/shuffling/core/shuffle"),
+  join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/shuffling/core/shuffle"),
   (testcase) => {
     const output = [];
     const seed = Buffer.from(testcase.mapping.seed.replace("0x", ""),"hex");

--- a/packages/lodestar/test/spec/shufling/shuffling_minimal.test.ts
+++ b/packages/lodestar/test/spec/shufling/shuffling_minimal.test.ts
@@ -3,10 +3,11 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/eth2.0-spec-test-util/lib/single";
 import {computeShuffledIndex} from "../../../src/chain/stateTransition/util";
 import {ShufflingTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
 
 describeDirectorySpecTest<ShufflingTestCase, number[]>(
   "shuffling minimal",
-  join(__dirname, "../../../../spec-test-cases/tests/minimal/phase0/shuffling/core/shuffle"),
+  join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/shuffling/core/shuffle"),
   (testcase) => {
     const output = [];
     const seed = Buffer.from(testcase.mapping.seed.replace("0x", ""),"hex");

--- a/packages/lodestar/test/utils/specTestCases.ts
+++ b/packages/lodestar/test/utils/specTestCases.ts
@@ -1,0 +1,3 @@
+import {join} from "path";
+
+export const SPEC_TEST_LOCATION = join(__dirname, "../../../../node_modules/@chainsafe/eth2-spec-tests");

--- a/packages/ssz/test/spec/minimal/static/attestation.test.ts
+++ b/packages/ssz/test/spec/minimal/static/attestation.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {expect} from "chai";
 import {IBaseSSZStaticTestCase} from "../../type";
 import {hashTreeRoot, serialize, signingRoot} from "../../../../src";
+import {TEST_CASE_LOCATION} from "../../../util/testCases";
 
 interface IResult {
   root: Hash;
@@ -16,8 +17,11 @@ interface IResult {
 
   describeDirectorySpecTest<IBaseSSZStaticTestCase<Attestation>, IResult>(
     `attestation ${caseName} minimal`,
-    join(__dirname, `../../../../../spec-test-cases/tests/minimal/phase0/ssz_static/Attestation/${caseName}`),
-    (testcase) => {
+    join(
+      __dirname,
+      `${TEST_CASE_LOCATION}/tests/minimal/phase0/ssz_static/Attestation/${caseName}`
+    ),
+    (testcase: IBaseSSZStaticTestCase<Attestation>) => {
       const serialized = serialize(testcase.serialized, config.types.Attestation);
       const root = hashTreeRoot(testcase.serialized, config.types.Attestation);
       const signing = signingRoot(testcase.serialized, config.types.Attestation);

--- a/packages/ssz/test/spec/minimal/static/attestationData.test.ts
+++ b/packages/ssz/test/spec/minimal/static/attestationData.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {expect} from "chai";
 import {IBaseSSZStaticTestCase} from "../../type";
 import {hashTreeRoot, serialize} from "../../../../src";
+import {TEST_CASE_LOCATION} from "../../../util/testCases";
 
 interface IResult {
   root: Hash;
@@ -15,7 +16,10 @@ interface IResult {
 
   describeDirectorySpecTest<IBaseSSZStaticTestCase<AttestationData>, IResult>(
     `attestation data ${caseName} minimal`,
-    join(__dirname, `../../../../../spec-test-cases/tests/minimal/phase0/ssz_static/AttestationData/${caseName}`),
+    join(
+      __dirname,
+      `${TEST_CASE_LOCATION}/tests/minimal/phase0/ssz_static/AttestationData/${caseName}`
+    ),
     (testcase) => {
       const serialized = serialize(testcase.serialized, config.types.AttestationData);
       const root = hashTreeRoot(testcase.serialized, config.types.AttestationData);

--- a/packages/ssz/test/spec/minimal/static/attestationDataAndCustodyBit.test.ts
+++ b/packages/ssz/test/spec/minimal/static/attestationDataAndCustodyBit.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {expect} from "chai";
 import {IBaseSSZStaticTestCase} from "../../type";
 import {hashTreeRoot, serialize} from "../../../../src";
+import {TEST_CASE_LOCATION} from "../../../util/testCases";
 
 interface IResult {
   root: Hash;
@@ -17,7 +18,7 @@ interface IResult {
     `attestation data and custody bit ${caseName} minimal`,
     join(
       __dirname,
-      `../../../../../spec-test-cases/tests/minimal/phase0/ssz_static/AttestationDataAndCustodyBit/${caseName}`
+      `${TEST_CASE_LOCATION}/tests/minimal/phase0/ssz_static/AttestationDataAndCustodyBit/${caseName}`
     ),
     (testcase) => {
       const serialized = serialize(testcase.serialized, config.types.AttestationDataAndCustodyBit);

--- a/packages/ssz/test/spec/minimal/static/attesterSlashing.test.ts
+++ b/packages/ssz/test/spec/minimal/static/attesterSlashing.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {expect} from "chai";
 import {IBaseSSZStaticTestCase} from "../../type";
 import {hashTreeRoot, serialize} from "../../../../src";
+import {TEST_CASE_LOCATION} from "../../../util/testCases";
 
 interface IResult {
   root: Hash;
@@ -15,7 +16,10 @@ interface IResult {
 
   describeDirectorySpecTest<IBaseSSZStaticTestCase<AttesterSlashing>, IResult>(
     `attester slashing ${caseName} minimal`,
-    join(__dirname, `../../../../../spec-test-cases/tests/minimal/phase0/ssz_static/AttesterSlashing/${caseName}`),
+    join(
+      __dirname,
+      `${TEST_CASE_LOCATION}/tests/minimal/phase0/ssz_static/AttesterSlashing/${caseName}`
+    ),
     (testcase) => {
       const serialized = serialize(testcase.serialized, config.types.AttesterSlashing);
       const root = hashTreeRoot(testcase.serialized, config.types.AttesterSlashing);

--- a/packages/ssz/test/spec/minimal/static/beaconBlock.test.ts
+++ b/packages/ssz/test/spec/minimal/static/beaconBlock.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {expect} from "chai";
 import {IBaseSSZStaticTestCase} from "../../type";
 import {hashTreeRoot, serialize, signingRoot} from "../../../../src";
+import {TEST_CASE_LOCATION} from "../../../util/testCases";
 
 interface IResult {
   root: Hash;
@@ -16,7 +17,9 @@ interface IResult {
 
   describeDirectorySpecTest<IBaseSSZStaticTestCase<BeaconBlock>, IResult>(
     `beacon block ${caseName} minimal`,
-    join(__dirname, `../../../../../spec-test-cases/tests/minimal/phase0/ssz_static/BeaconBlock/${caseName}`),
+    join(
+      __dirname,
+      `${TEST_CASE_LOCATION}/tests/minimal/phase0/ssz_static/BeaconBlock/${caseName}`),
     (testcase) => {
       const serialized = serialize(testcase.serialized, config.types.BeaconBlock);
       const root = hashTreeRoot(testcase.serialized, config.types.BeaconBlock);

--- a/packages/ssz/test/spec/minimal/static/beaconBlockBody.test.ts
+++ b/packages/ssz/test/spec/minimal/static/beaconBlockBody.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {expect} from "chai";
 import {IBaseSSZStaticTestCase} from "../../type";
 import {hashTreeRoot, serialize} from "../../../../src";
+import {TEST_CASE_LOCATION} from "../../../util/testCases";
 
 interface IResult {
   root: Hash;
@@ -15,7 +16,9 @@ interface IResult {
 
   describeDirectorySpecTest<IBaseSSZStaticTestCase<BeaconBlockBody>, IResult>(
     `beacon block body ${caseName} minimal`,
-    join(__dirname, `../../../../../spec-test-cases/tests/minimal/phase0/ssz_static/BeaconBlockBody/${caseName}`),
+    join(
+      __dirname,
+      `${TEST_CASE_LOCATION}/tests/minimal/phase0/ssz_static/BeaconBlockBody/${caseName}`),
     (testcase) => {
       const serialized = serialize(testcase.serialized, config.types.BeaconBlockBody);
       const root = hashTreeRoot(testcase.serialized, config.types.BeaconBlockBody);

--- a/packages/ssz/test/spec/minimal/static/beaconBlockHeader.test.ts
+++ b/packages/ssz/test/spec/minimal/static/beaconBlockHeader.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {expect} from "chai";
 import {IBaseSSZStaticTestCase} from "../../type";
 import {hashTreeRoot, serialize} from "../../../../src";
+import {TEST_CASE_LOCATION} from "../../../util/testCases";
 
 interface IResult {
   root: Hash;
@@ -15,7 +16,7 @@ interface IResult {
 
   describeDirectorySpecTest<IBaseSSZStaticTestCase<BeaconBlockHeader>, IResult>(
     `beacon block header ${caseName} minimal`,
-    join(__dirname, `../../../../../spec-test-cases/tests/minimal/phase0/ssz_static/BeaconBlockHeader/${caseName}`),
+    join(__dirname, `${TEST_CASE_LOCATION}/tests/minimal/phase0/ssz_static/BeaconBlockHeader/${caseName}`),
     (testcase) => {
       const serialized = serialize(testcase.serialized, config.types.BeaconBlockHeader);
       const root = hashTreeRoot(testcase.serialized, config.types.BeaconBlockHeader);

--- a/packages/ssz/test/spec/minimal/static/beaconState.test.ts
+++ b/packages/ssz/test/spec/minimal/static/beaconState.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {expect} from "chai";
 import {IBaseSSZStaticTestCase} from "../../type";
 import {hashTreeRoot, serialize} from "../../../../src";
+import {TEST_CASE_LOCATION} from "../../../util/testCases";
 
 interface IResult {
   root: Hash;
@@ -15,7 +16,7 @@ interface IResult {
 
   describeDirectorySpecTest<IBaseSSZStaticTestCase<BeaconState>, IResult>(
     `beacon state ${caseName} minimal`,
-    join(__dirname, `../../../../../spec-test-cases/tests/minimal/phase0/ssz_static/BeaconState/${caseName}`),
+    join(__dirname, `${TEST_CASE_LOCATION}/tests/minimal/phase0/ssz_static/BeaconState/${caseName}`),
     (testcase) => {
       const serialized = serialize(testcase.serialized, config.types.BeaconState);
       const root = hashTreeRoot(testcase.serialized, config.types.BeaconState);

--- a/packages/ssz/test/spec/minimal/static/checkpoint.test.ts
+++ b/packages/ssz/test/spec/minimal/static/checkpoint.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {expect} from "chai";
 import {IBaseSSZStaticTestCase} from "../../type";
 import {hashTreeRoot, serialize} from "../../../../src";
+import {TEST_CASE_LOCATION} from "../../../util/testCases";
 
 interface IResult {
   root: Hash;
@@ -15,7 +16,7 @@ interface IResult {
 
   describeDirectorySpecTest<IBaseSSZStaticTestCase<Checkpoint>, IResult>(
     `checkpoint ${caseName} minimal`,
-    join(__dirname, `../../../../../spec-test-cases/tests/minimal/phase0/ssz_static/Checkpoint/${caseName}`),
+    join(__dirname, `${TEST_CASE_LOCATION}/tests/minimal/phase0/ssz_static/Checkpoint/${caseName}`),
     (testcase) => {
       const serialized = serialize(testcase.serialized, config.types.Checkpoint);
       const root = hashTreeRoot(testcase.serialized, config.types.Checkpoint);

--- a/packages/ssz/test/spec/minimal/static/compactCommittee.test.ts
+++ b/packages/ssz/test/spec/minimal/static/compactCommittee.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {expect} from "chai";
 import {IBaseSSZStaticTestCase} from "../../type";
 import {hashTreeRoot, serialize} from "../../../../src";
+import {TEST_CASE_LOCATION} from "../../../util/testCases";
 
 interface IResult {
   root: Hash;
@@ -15,7 +16,7 @@ interface IResult {
 
   describeDirectorySpecTest<IBaseSSZStaticTestCase<CompactCommittee>, IResult>(
     `compact committee ${caseName} minimal`,
-    join(__dirname, `../../../../../spec-test-cases/tests/minimal/phase0/ssz_static/CompactCommittee/${caseName}`),
+    join(__dirname, `${TEST_CASE_LOCATION}/tests/minimal/phase0/ssz_static/CompactCommittee/${caseName}`),
     (testcase) => {
       const serialized = serialize(testcase.serialized, config.types.CompactCommittee);
       const root = hashTreeRoot(testcase.serialized, config.types.CompactCommittee);

--- a/packages/ssz/test/spec/minimal/static/crosslink.test.ts
+++ b/packages/ssz/test/spec/minimal/static/crosslink.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {expect} from "chai";
 import {IBaseSSZStaticTestCase} from "../../type";
 import {hashTreeRoot, serialize} from "../../../../src";
+import {TEST_CASE_LOCATION} from "../../../util/testCases";
 
 interface IResult {
   root: Hash;
@@ -15,7 +16,7 @@ interface IResult {
 
   describeDirectorySpecTest<IBaseSSZStaticTestCase<CompactCommittee>, IResult>(
     `crosslink ${caseName} minimal`,
-    join(__dirname, `../../../../../spec-test-cases/tests/minimal/phase0/ssz_static/Crosslink/${caseName}`),
+    join(__dirname, `${TEST_CASE_LOCATION}/tests/minimal/phase0/ssz_static/Crosslink/${caseName}`),
     (testcase) => {
       const serialized = serialize(testcase.serialized, config.types.Crosslink);
       const root = hashTreeRoot(testcase.serialized, config.types.Crosslink);

--- a/packages/ssz/test/spec/minimal/static/deposit.test.ts
+++ b/packages/ssz/test/spec/minimal/static/deposit.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {expect} from "chai";
 import {IBaseSSZStaticTestCase} from "../../type";
 import {hashTreeRoot, serialize} from "../../../../src";
+import {TEST_CASE_LOCATION} from "../../../util/testCases";
 
 interface IResult {
   root: Hash;
@@ -15,7 +16,7 @@ interface IResult {
 
   describeDirectorySpecTest<IBaseSSZStaticTestCase<Deposit>, IResult>(
     `deposit ${caseName} minimal`,
-    join(__dirname, `../../../../../spec-test-cases/tests/minimal/phase0/ssz_static/Deposit/${caseName}`),
+    join(__dirname, `${TEST_CASE_LOCATION}/tests/minimal/phase0/ssz_static/Deposit/${caseName}`),
     (testcase) => {
       const serialized = serialize(testcase.serialized, config.types.Deposit);
       const root = hashTreeRoot(testcase.serialized, config.types.Deposit);

--- a/packages/ssz/test/spec/minimal/static/depositData.test.ts
+++ b/packages/ssz/test/spec/minimal/static/depositData.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {expect} from "chai";
 import {IBaseSSZStaticTestCase} from "../../type";
 import {hashTreeRoot, serialize, signingRoot} from "../../../../src";
+import {TEST_CASE_LOCATION} from "../../../util/testCases";
 
 interface IResult {
   root: Hash;
@@ -16,7 +17,7 @@ interface IResult {
 
   describeDirectorySpecTest<IBaseSSZStaticTestCase<DepositData>, IResult>(
     `deposit data ${caseName} minimal`,
-    join(__dirname, `../../../../../spec-test-cases/tests/minimal/phase0/ssz_static/DepositData/${caseName}`),
+    join(__dirname, `${TEST_CASE_LOCATION}/tests/minimal/phase0/ssz_static/DepositData/${caseName}`),
     (testcase) => {
       const serialized = serialize(testcase.serialized, config.types.DepositData);
       const root = hashTreeRoot(testcase.serialized, config.types.DepositData);

--- a/packages/ssz/test/spec/minimal/static/eth1Data.test.ts
+++ b/packages/ssz/test/spec/minimal/static/eth1Data.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {expect} from "chai";
 import {IBaseSSZStaticTestCase} from "../../type";
 import {hashTreeRoot, serialize} from "../../../../src";
+import {TEST_CASE_LOCATION} from "../../../util/testCases";
 
 interface IResult {
   root: Hash;
@@ -15,7 +16,7 @@ interface IResult {
 
   describeDirectorySpecTest<IBaseSSZStaticTestCase<Eth1Data>, IResult>(
     `eth1 data ${caseName} minimal`,
-    join(__dirname, `../../../../../spec-test-cases/tests/minimal/phase0/ssz_static/Eth1Data/${caseName}`),
+    join(__dirname, `${TEST_CASE_LOCATION}/tests/minimal/phase0/ssz_static/Eth1Data/${caseName}`),
     (testcase) => {
       const serialized = serialize(testcase.serialized, config.types.Eth1Data);
       const root = hashTreeRoot(testcase.serialized, config.types.Eth1Data);

--- a/packages/ssz/test/spec/minimal/static/fork.test.ts
+++ b/packages/ssz/test/spec/minimal/static/fork.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {expect} from "chai";
 import {IBaseSSZStaticTestCase} from "../../type";
 import {hashTreeRoot, serialize} from "../../../../src";
+import {TEST_CASE_LOCATION} from "../../../util/testCases";
 
 interface IResult {
   root: Hash;
@@ -15,7 +16,7 @@ interface IResult {
 
   describeDirectorySpecTest<IBaseSSZStaticTestCase<Fork>, IResult>(
     `fork ${caseName} minimal`,
-    join(__dirname, `../../../../../spec-test-cases/tests/minimal/phase0/ssz_static/Fork/${caseName}`),
+    join(__dirname, `${TEST_CASE_LOCATION}/tests/minimal/phase0/ssz_static/Fork/${caseName}`),
     (testcase) => {
       const serialized = serialize(testcase.serialized, config.types.Fork);
       const root = hashTreeRoot(testcase.serialized, config.types.Fork);

--- a/packages/ssz/test/util/testCases.ts
+++ b/packages/ssz/test/util/testCases.ts
@@ -1,0 +1,1 @@
+export const TEST_CASE_LOCATION = "../../../../../../node_modules/@chainsafe/eth2-spec-tests";

--- a/yarn.lock
+++ b/yarn.lock
@@ -664,6 +664,11 @@
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@chainsafe/bit-utils/-/bit-utils-0.1.3.tgz#d29a69c161526fda8bf0880da3d62a4a7100e169"
 
+"@chainsafe/eth2-spec-tests@0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@chainsafe/eth2-spec-tests/-/eth2-spec-tests-0.8.3.tgz#5d165305bc3616fbc8b9c508d94f7a096950ccee"
+  integrity sha512-3r2u9NNHAVVlLZuWzQzU3jndu8mNjh2RAiyNoTySthVdnWqQOHmgOsyPz8iy/atH9RiUj57gguEhEwcA4tkr/Q==
+
 "@chainsafe/milagro-crypto-js@0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@chainsafe/milagro-crypto-js/-/milagro-crypto-js-0.1.3.tgz#0813b5991f53e9573174637ce9ec96576218a09b"


### PR DESCRIPTION
- removed spec test cases submodule
- add spec test cases as optional npm dependency
- converted all spec tests to use files from npm dependency

resolves #471 