### PR TITLE
make state transition pure

### DIFF
--- a/packages/lodestar/src/chain/stateTransition/index.ts
+++ b/packages/lodestar/src/chain/stateTransition/index.ts
@@ -3,7 +3,7 @@
  */
 
 import assert from "assert";
-import {hashTreeRoot} from "@chainsafe/ssz";
+import {hashTreeRoot, clone} from "@chainsafe/ssz";
 
 import {BeaconBlock, BeaconState,} from "@chainsafe/eth2.0-types";
 import {IBeaconConfig} from "@chainsafe/eth2.0-config";
@@ -28,15 +28,17 @@ export function stateTransition(
   validateStateRoot = false,
   verifySignatures = true
 ): BeaconState {
+  // Clone state because process slots and block are not pure
+  const postState = clone(state, config.types.BeaconState);
   // Process slots (including those with no blocks) since block
-  processSlots(config, state, block.slot);
+  processSlots(config, postState, block.slot);
   // Process block
-  processBlock(config, state, block, verifySignatures);
+  processBlock(config, postState, block, verifySignatures);
   // Validate state root (`validate_state_root == True` in production)
   if (validateStateRoot){
-    assert(block.stateRoot.equals(hashTreeRoot(state, config.types.BeaconState)));
+    assert(block.stateRoot.equals(hashTreeRoot(postState, config.types.BeaconState)));
   }
 
   // Return post-state
-  return state;
+  return postState;
 }

--- a/packages/lodestar/test/spec/sanity/blocks/sanity_blocks_mainnet.test.ts
+++ b/packages/lodestar/test/spec/sanity/blocks/sanity_blocks_mainnet.test.ts
@@ -12,12 +12,12 @@ import {IBeaconConfig} from "@chainsafe/eth2.0-config";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 describeDirectorySpecTest<BlockSanityTestCase, BeaconState>(
-  "block sanity minimal",
+  "block sanity mainnet",
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/sanity/blocks/pyspec_tests"),
   (testcase) => {
-    const state = testcase.pre;
+    let state = testcase.pre;
     for(let i = 0; i < testcase.meta.blocksCount.toNumber(); i++) {
-      stateTransition(config, state, testcase[`blocks_${i}`] as BeaconBlock, true, true);
+      state = stateTransition(config, state, testcase[`blocks_${i}`] as BeaconBlock, true, true);
     }
     return state;
   },

--- a/packages/lodestar/test/spec/sanity/blocks/sanity_blocks_minimal.test.ts
+++ b/packages/lodestar/test/spec/sanity/blocks/sanity_blocks_minimal.test.ts
@@ -1,6 +1,6 @@
 import {join} from "path";
 import {expect} from "chai";
-import {equals} from "@chainsafe/ssz";
+import {equals, clone} from "@chainsafe/ssz";
 import {BeaconBlock, BeaconState} from "@chainsafe/eth2.0-types";
 import {config} from "@chainsafe/eth2.0-config/lib/presets/minimal";
 import {stateTransition} from "../../../../src/chain/stateTransition";
@@ -13,9 +13,9 @@ describeDirectorySpecTest<BlockSanityTestCase, BeaconState>(
   "block sanity minimal",
   join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/sanity/blocks/pyspec_tests"),
   (testcase) => {
-    const state = testcase.pre;
+    let state = testcase.pre;
     for(let i = 0; i < testcase.meta.blocksCount.toNumber(); i++) {
-      stateTransition(config, state, testcase[`blocks_${i}`] as BeaconBlock, true, true);
+      state = stateTransition(config, state, testcase[`blocks_${i}`] as BeaconBlock, true, true);
     }
     return state;
   },


### PR DESCRIPTION
This makes the state transition function not mutate the state parameter. The motivation behind this is to be able to try out making state transitions run in a `worker_thread` which is easier if the function is pure. 