### PR TITLE
Separate out release buid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ LodestarValidatorDB/
 *.log
 data
 validators
+*.tsbuildinfo

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ jobs:
         - lerna run test:spec
 
 before_deploy:
-    - lerna run build:docs
+    - lerna run build:release
     - node scripts/collect-docs.js
 
 deploy:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sinon": "^7.2.7",
     "supertest": "^4.0.2",
     "ts-node": "^8.3.0",
-    "typedoc": "^0.14.2",
+    "typedoc": "^0.15.0",
     "typedoc-plugin-external-module-name": "^2.1.0",
     "typedoc-plugin-internal-external": "^2.0.2",
     "typedoc-plugin-markdown": "^2.0.6",

--- a/packages/benchmark-utils/package.json
+++ b/packages/benchmark-utils/package.json
@@ -15,9 +15,10 @@
     "lib"
   ],
   "scripts": {
-    "prebuild": "rm -rf lib",
+    "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn build:lib && yarn build:types",
-    "build:types": "tsc --declaration --emitDeclarationOnly",
+    "build:release": "yarn clean && yarn build && yarn build:docs",
+    "build:types": "tsc --declaration --incremental --emitDeclarationOnly",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --out docs src",
     "check-types": "tsc --noEmit --incremental",

--- a/packages/bls/package.json
+++ b/packages/bls/package.json
@@ -17,10 +17,11 @@
     "bls"
   ],
   "scripts": {
-    "prebuild": "rm -rf lib && rm -rf dist",
-    "build": "yarn build-lib && yarn build-web && yarn build-types",
+    "clean": "rm -rf lib && rm -rf dist && rm -f tsconfig.tsbuildinfo",
+    "build": "yarn build-lib && yarn build-types",
+    "build:release": "yarn clean && yarn build && yarn build-web",
     "build-lib": "babel src -x .ts -d lib",
-    "build-types": "tsc --declaration --outDir lib --emitDeclarationOnly",
+    "build-types": "tsc --declaration --incremental --outDir lib --emitDeclarationOnly",
     "build-web": "webpack --mode production --entry ./lib/web.js --output ./dist/bls.min.js",
     "check-types": "tsc --noEmit",
     "lint": "eslint --ext .ts src/",

--- a/packages/eth2.0-config/package.json
+++ b/packages/eth2.0-config/package.json
@@ -14,9 +14,10 @@
     "lib"
   ],
   "scripts": {
-    "prebuild": "rm -rf lib",
+    "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn build:lib && yarn build:types",
-    "build:types": "tsc --declaration --outDir lib --emitDeclarationOnly",
+    "build:release": "yarn clean &6 yarn build && yarn build-docs",
+    "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
     "check-types": "tsc --noEmit --incremental",

--- a/packages/eth2.0-config/package.json
+++ b/packages/eth2.0-config/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn build:lib && yarn build:types",
-    "build:release": "yarn clean &6 yarn build && yarn build-docs",
+    "build:release": "yarn run clean && yarn run build && yarn run build:docs",
     "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",

--- a/packages/eth2.0-params/package.json
+++ b/packages/eth2.0-params/package.json
@@ -14,10 +14,11 @@
     "lib"
   ],
   "scripts": {
-    "prebuild": "rm -rf lib",
+    "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn build:lib && yarn build:types",
+    "build:release": "yarn clean && yarn build && yarn build-docs",
     "build:lib": "babel src -x .ts -d lib --source-maps",
-    "build:types": "tsc --declaration --outDir lib --emitDeclarationOnly",
+    "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
     "check-types": "tsc --noEmit --incremental",
     "lint": "eslint --color --ext .ts src/",

--- a/packages/eth2.0-params/package.json
+++ b/packages/eth2.0-params/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn build:lib && yarn build:types",
-    "build:release": "yarn clean && yarn build && yarn build-docs",
+    "build:release": "yarn clean && yarn build",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",

--- a/packages/eth2.0-spec-test-util/package.json
+++ b/packages/eth2.0-spec-test-util/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn build:lib && yarn build:types",
-    "build:release": "yarn clean && yarn build && yarn build-docs",
+    "build:release": "yarn clean && yarn build && yarn build:docs",
     "build:types": "tsc --incremental --declaration --emitDeclarationOnly",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --out docs src",

--- a/packages/eth2.0-spec-test-util/package.json
+++ b/packages/eth2.0-spec-test-util/package.json
@@ -14,9 +14,10 @@
     "lib"
   ],
   "scripts": {
-    "prebuild": "rm -rf lib",
+    "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn build:lib && yarn build:types",
-    "build:types": "tsc --declaration --emitDeclarationOnly",
+    "build:release": "yarn clean && yarn build && yarn build-docs",
+    "build:types": "tsc --incremental --declaration --emitDeclarationOnly",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --out docs src",
     "check-types": "tsc --noEmit --incremental",

--- a/packages/eth2.0-types/package.json
+++ b/packages/eth2.0-types/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn build:lib && yarn build:types",
-    "build:release": "yarn clean && yarn build && yarn build-docs",
+    "build:release": "yarn clean && yarn build",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",

--- a/packages/eth2.0-types/package.json
+++ b/packages/eth2.0-types/package.json
@@ -14,10 +14,11 @@
     "lib"
   ],
   "scripts": {
-    "prebuild": "rm -rf lib",
-    "build": "yarn build:lib && yarn build:types && yarn build:docs",
+    "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
+    "build": "yarn build:lib && yarn build:types",
+    "build:release": "yarn clean && yarn build && yarn build-docs",
     "build:lib": "babel src -x .ts -d lib --source-maps",
-    "build:types": "tsc --declaration --outDir lib --emitDeclarationOnly",
+    "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
     "check-types": "tsc --noEmit --incremental",
     "lint": "eslint --color --ext .ts src/",

--- a/packages/eth2.0-utils/package.json
+++ b/packages/eth2.0-utils/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn build:lib && yarn build:types",
-    "build:release": "yarn clean && yarn build && yarn build-docs",
+    "build:release": "yarn clean && yarn build && yarn build:docs",
     "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",

--- a/packages/eth2.0-utils/package.json
+++ b/packages/eth2.0-utils/package.json
@@ -14,9 +14,10 @@
     "lib"
   ],
   "scripts": {
-    "prebuild": "rm -rf lib",
+    "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn build:lib && yarn build:types",
-    "build:types": "tsc --declaration --outDir lib --emitDeclarationOnly",
+    "build:release": "yarn clean && yarn build && yarn build-docs",
+    "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
     "check-types": "tsc --noEmit --incremental",

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn run build:lib && yarn run build:types",
-    "build:release": "yarn clean && yarn run build && && yarn run build:docs",
+    "build:release": "yarn clean && yarn run build && yarn run build:docs",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
     "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -14,11 +14,13 @@
     "lib"
   ],
   "scripts": {
-    "build": "yarn run build:lib && yarn run build:types && yarn run build:docs",
+    "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
+    "build": "yarn run build:lib && yarn run build:types",
+    "build:release": "yarn clean && yarn run build && && yarn run build:docs",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
-    "build:types": "tsc --declaration --outDir lib --emitDeclarationOnly",
-    "check-types": "tsc --noEmit",
+    "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
+    "check-types": "tsc --incremental --noEmit",
     "lint": "eslint --color --ext .ts src/",
     "lint:fix": "eslint --color --ext .ts src/ --fix",
     "pretest": "yarn run check-types",

--- a/packages/ssz-type-schema/package.json
+++ b/packages/ssz-type-schema/package.json
@@ -14,9 +14,10 @@
     "lib"
   ],
   "scripts": {
-    "prebuild": "rm -rf lib",
+    "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn build:lib && yarn build:types",
-    "build:types": "tsc --declaration --outDir lib --emitDeclarationOnly",
+    "build:release": "yarn clean && yarn run build && yarn run build:docs",
+    "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
     "check-types": "tsc --noEmit --incremental",

--- a/packages/ssz-type-schema/tsconfig.json
+++ b/packages/ssz-type-schema/tsconfig.json
@@ -1,14 +1,13 @@
 {
   "extends": "../../tsconfig",
-  "include": ["src"],
+  "include": ["./src"],
   "compilerOptions": {
     "typeRoots": [
       "../../node_modules/@types"
     ],
     "outDir": "lib",
     /* Redirect output structure to the directory. */
-    "rootDir": "./src",
-    "composite": true
+    "rootDir": "./src"
     /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
   }
 }

--- a/packages/ssz-type-schema/tsconfig.json
+++ b/packages/ssz-type-schema/tsconfig.json
@@ -7,7 +7,8 @@
     ],
     "outDir": "lib",
     /* Redirect output structure to the directory. */
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "composite": true
     /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-  },
+  }
 }

--- a/packages/ssz/package.json
+++ b/packages/ssz/package.json
@@ -8,13 +8,14 @@
     "lib"
   ],
   "scripts": {
-    "prebuild": "rm -rf lib && rm -rf dist",
-    "build": "yarn build-lib && yarn build-web && yarn build-types",
+    "clean": "rm -rf lib && rm -rf dist && rm -f tsconfig.tsbuildinfo",
+    "build": "yarn build-lib && yarn build-types",
+    "build:release": "yarn clean && yarn run build && yarn build-web && yarn run build:docs",
     "build:docs": "typedoc --exclude src/index.ts,src/web.ts --out docs src",
     "build-lib": "babel src -x .ts -d lib --source-maps",
-    "build-types": "tsc --declaration --outDir lib --emitDeclarationOnly",
+    "build-types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
     "build-web": "webpack --mode production --entry ./lib/web.js --output ./dist/ssz.min.js",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --incremental --noEmit",
     "lint": "eslint --color --ext .ts src/ test/",
     "lint:fix": "eslint --color --fix --ext .ts src/ test/",
     "pretest": "yarn check-types",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1869,29 +1869,13 @@
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.28.tgz#c054e8af4d9dd75db4e63abc76f885168714d4b3"
 
-"@types/fs-extra@^5.0.3":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.1.0.tgz#2a325ef97901504a3828718c390d34b8426a10a1"
-  dependencies:
-    "@types/node" "*"
-
-"@types/glob@*", "@types/glob@^7.1.1":
+"@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
   dependencies:
     "@types/events" "*"
     "@types/minimatch" "*"
     "@types/node" "*"
-
-"@types/handlebars@^4.0.38":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.1.0.tgz#3fcce9bf88f85fe73dc932240ab3fb682c624850"
-  dependencies:
-    handlebars "*"
-
-"@types/highlight.js@^9.12.3":
-  version "9.12.3"
-  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.3.tgz#b672cfaac25cbbc634a0fd92c515f66faa18dbca"
 
 "@types/js-yaml@^3.12.1":
   version "3.12.1"
@@ -1908,14 +1892,6 @@
   dependencies:
     "@types/abstract-leveldown" "*"
     "@types/node" "*"
-
-"@types/lodash@^4.14.110":
-  version "4.14.136"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.136.tgz#413e85089046b865d960c9ff1d400e04c31ab60f"
-
-"@types/marked@^0.4.0":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.4.2.tgz#64a89e53ea37f61cc0f3ee1732c555c2dbf6452f"
 
 "@types/minimatch@*", "@types/minimatch@3.0.3":
   version "3.0.3"
@@ -1959,13 +1935,6 @@
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/@types/secp256k1/-/secp256k1-3.5.0.tgz#0f3baf16b07488c6da2633a63b4160bcf8d0fd5b"
   dependencies:
-    "@types/node" "*"
-
-"@types/shelljs@^0.8.0":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.5.tgz#1e507b2f6d1f893269bd3e851ec24419ef9beeea"
-  dependencies:
-    "@types/glob" "*"
     "@types/node" "*"
 
 "@types/sinon@^7.0.11":
@@ -3110,6 +3079,13 @@ babelify@^7.3.0:
 babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
+
+backbone@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.4.0.tgz#54db4de9df7c3811c3f032f34749a4cd27f3bd12"
+  integrity sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==
+  dependencies:
+    underscore ">=1.8.3"
 
 backo2@1.0.2:
   version "1.0.2"
@@ -5702,14 +5678,6 @@ fs-extra@^2.0.0, fs-extra@^2.1.2:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
 
-fs-extra@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -6078,7 +6046,7 @@ growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
 
-handlebars@*, handlebars@^4.0.6, handlebars@^4.1.0, handlebars@^4.1.2:
+handlebars@^4.1.0, handlebars@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
   dependencies:
@@ -6221,9 +6189,10 @@ hi-base32@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/hi-base32/-/hi-base32-0.5.0.tgz#61329f76a31f31008533f1c36f2473e259d64571"
 
-highlight.js@^9.13.1:
-  version "9.15.8"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.15.8.tgz#f344fda123f36f1a65490e932cf90569e4999971"
+highlight.js@^9.15.8:
+  version "9.15.10"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.15.10.tgz#7b18ed75c90348c045eef9ed08ca1319a2219ad2"
+  integrity sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -6841,6 +6810,11 @@ isurl@^1.0.0-alpha5:
   dependencies:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
+
+jquery@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-levenshtein@^1.1.3:
   version "1.1.6"
@@ -7868,6 +7842,11 @@ ltgt@~2.1.1, ltgt@~2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.1.3.tgz#10851a06d9964b971178441c23c9e52698eece34"
 
+lunr@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.6.tgz#f278beee7ffd56ad86e6e478ce02ab2b98c78dd5"
+  integrity sha512-swStvEyDqQ85MGpABCMBclZcLI/pBIlu8FFDtmX197+oEgKloJ67QnB+Tidh0340HmLMs39c4GrkPY3cmkXp6Q==
+
 macos-release@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
@@ -7944,9 +7923,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.4.0.tgz#9ad2c2a7a1791f10a852e0112f77b571dce10c66"
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
+  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -9555,7 +9535,7 @@ process@~0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
 
-progress@^2.0.0:
+progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
 
@@ -10564,9 +10544,10 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shelljs@^0.8.2:
+shelljs@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
+  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
@@ -11541,9 +11522,15 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typedoc-default-themes@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
+typedoc-default-themes@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.6.0.tgz#7e73bf54dd9e11550dd0fb576d5176b758f8f8b5"
+  integrity sha512-MdTROOojxod78CEv22rIA69o7crMPLnVZPefuDLt/WepXqJwgiSu8Xxq+H36x0Jj3YGc7lOglI2vPJ2GhoOybw==
+  dependencies:
+    backbone "^1.4.0"
+    jquery "^3.4.1"
+    lunr "^2.3.6"
+    underscore "^1.9.1"
 
 typedoc-plugin-external-module-name@^2.1.0:
   version "2.1.0"
@@ -11557,41 +11544,32 @@ typedoc-plugin-markdown@^2.0.6:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-2.0.11.tgz#47d8aecd1667f9d083b0a3ebbff0918512808bd3"
 
-typedoc@^0.14.2:
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.14.2.tgz#769f457f4f9e4bdb8b5f3b177c86b6a31d8c3dc3"
+typedoc@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.15.0.tgz#21eaf4db41cf2797bad027a74f2a75cd08ae0c2d"
+  integrity sha512-NOtfq5Tis4EFt+J2ozhVq9RCeUnfEYMFKoU6nCXCXUULJz1UQynOM+yH3TkfZCPLzigbqB0tQYGVlktUWweKlw==
   dependencies:
-    "@types/fs-extra" "^5.0.3"
-    "@types/handlebars" "^4.0.38"
-    "@types/highlight.js" "^9.12.3"
-    "@types/lodash" "^4.14.110"
-    "@types/marked" "^0.4.0"
     "@types/minimatch" "3.0.3"
-    "@types/shelljs" "^0.8.0"
-    fs-extra "^7.0.0"
-    handlebars "^4.0.6"
-    highlight.js "^9.13.1"
-    lodash "^4.17.10"
-    marked "^0.4.0"
+    fs-extra "^8.1.0"
+    handlebars "^4.1.2"
+    highlight.js "^9.15.8"
+    lodash "^4.17.15"
+    marked "^0.7.0"
     minimatch "^3.0.0"
-    progress "^2.0.0"
-    shelljs "^0.8.2"
-    typedoc-default-themes "^0.5.0"
-    typescript "3.2.x"
+    progress "^2.0.3"
+    shelljs "^0.8.3"
+    typedoc-default-themes "^0.6.0"
+    typescript "3.5.x"
 
-typescript@3.2.x:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
-  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
+typescript@3.5.x, typescript@^3.5.1, typescript@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 typescript@^3.2.1:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
   integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
-
-typescript@^3.5.1, typescript@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"
@@ -11640,6 +11618,11 @@ unbzip2-stream@^1.0.9:
 underscore@1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+
+underscore@>=1.8.3, underscore@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
+  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2500,9 +2500,9 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
-"assemblyscript@git+https://github.com/AssemblyScript/assemblyscript.git#5b510571f6ebfc5530d85412005059e4cf961a97":
+"assemblyscript@https://github.com/AssemblyScript/assemblyscript.git#5b510571f6ebfc5530d85412005059e4cf961a97":
   version "0.7.0"
-  resolved "git+https://github.com/AssemblyScript/assemblyscript.git#5b510571f6ebfc5530d85412005059e4cf961a97"
+  resolved "https://github.com/AssemblyScript/assemblyscript.git#5b510571f6ebfc5530d85412005059e4cf961a97"
   dependencies:
     "@protobufjs/utf8" "^1.1.0"
     binaryen "89.0.0-nightly.20190914"


### PR DESCRIPTION
- faster build time (~20s)
- updated typedoc to latest version (typescript 3.5.3)
- introduced `lerna run clean` command

resolves #468 