### PR TITLE
Syncing WIP

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -186,7 +186,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     try {
       processSlots(this.config, state, targetSlot);
     } catch (e) {
-      this.logger.warn(`Failed to advance slot mannually because ${e.message}`);
+      this.logger.warn(`Failed to advance slot manually because ${e.message}`);
     }
     this.latestState = state;
     await this.db.state.setUnderRoot(state);

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -166,12 +166,13 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     }
 
     await this.processBlock(block, blockHash);
-    const nextBlockInQueue = this.blockProcessingQueue.peek();
+    let nextBlockInQueue = this.blockProcessingQueue.peek();
     while (nextBlockInQueue) {
       const latestBlock = await this.db.block.getChainHead();
       if (nextBlockInQueue.parentRoot.equals(signingRoot(latestBlock, this.config.types.BeaconBlock))) {
         await this.processBlock(nextBlockInQueue, signingRoot(nextBlockInQueue, this.config.types.BeaconBlock));
         this.blockProcessingQueue.poll();
+        nextBlockInQueue = this.blockProcessingQueue.peek();
       } else{
         return;
       }

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -42,8 +42,10 @@ export async function assembleBlock(
     body: await assembleBody(config, opPool, eth1, merkleTree, currentState, randao),
   };
 
-  stateTransition(config, currentState, block, false, false);
+  block.stateRoot = hashTreeRoot(
+    stateTransition(config, currentState, block, false, false),
+    config.types.BeaconState
+  );
 
-  block.stateRoot = hashTreeRoot(currentState, config.types.BeaconState);
   return block;
 }

--- a/packages/lodestar/src/cli/commands/interop.ts
+++ b/packages/lodestar/src/cli/commands/interop.ts
@@ -132,7 +132,7 @@ export class InteropCommand implements ICliCommand {
         config,
         computeEpochOfSlot(config, getCurrentSlot(config, state.genesisTime))
       );
-      await this.node.chain.advanceState(targetSlot);
+      // await this.node.chain.advanceState(targetSlot);
     } else {
       throw new Error("Missing --quickstart flag");
     }

--- a/packages/lodestar/src/cli/commands/interop.ts
+++ b/packages/lodestar/src/cli/commands/interop.ts
@@ -63,6 +63,7 @@ export class InteropCommand implements ICliCommand {
       .option("--peer-id-file [peerIdFile]","peer id json file")
       .option("--peer-id [peerId]","peer id hex string")
       .option("--validators-from-yaml-key-file [validatorsYamlFile]", "validator keys")
+      .option("-a, --advanceState", "Advance the state on older genesis time. NOT SAFE FOR PRODUCTION")
       .action(async (options) => {
         // library is not awaiting this method so don't allow error propagation
         // (unhandled promise rejections)
@@ -128,11 +129,13 @@ export class InteropCommand implements ICliCommand {
       const tree = ProgressiveMerkleTree.empty(DEPOSIT_CONTRACT_TREE_DEPTH, new MerkleTreeSerialization(config));
       const state = quickStartOptionToState(config, tree, options.quickStart);
       await this.node.chain.initializeBeaconChain(state, tree);
-      const targetSlot = computeStartSlotOfEpoch(
-        config,
-        computeEpochOfSlot(config, getCurrentSlot(config, state.genesisTime))
-      );
-      // await this.node.chain.advanceState(targetSlot);
+      if (options.advanceState){
+        const targetSlot = computeStartSlotOfEpoch(
+            config,
+            computeEpochOfSlot(config, getCurrentSlot(config, state.genesisTime))
+        );
+        await this.node.chain.advanceState(targetSlot);
+      }
     } else {
       throw new Error("Missing --quickstart flag");
     }

--- a/packages/lodestar/src/db/api/beacon/repositories/merkleTree.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/merkleTree.ts
@@ -4,7 +4,7 @@ import {IBeaconConfig} from "@chainsafe/eth2.0-config";
 import {BulkRepository} from "../repository";
 import {IDatabaseController} from "../../../controller";
 import {Bucket} from "../../../schema";
-import {DEPOSIT_CONTRACT_TREE_DEPTH} from "@chainsafe/eth2.0-params/src/presets/mainnet";
+import {DEPOSIT_CONTRACT_TREE_DEPTH} from "../../../../constants";
 import {IProgressiveMerkleTree, ProgressiveMerkleTree} from "@chainsafe/eth2.0-utils";
 import {MerkleTreeSerialization} from "../../../../util/serialization";
 

--- a/packages/lodestar/src/sync/index.ts
+++ b/packages/lodestar/src/sync/index.ts
@@ -81,7 +81,7 @@ export class Sync extends EventEmitter {
   };
 
   public async start(): Promise<void> {
-    //await new Promise((resolve) => this.network.once("peer:connect", resolve));
+    await new Promise((resolve) => this.network.once("peer:connect", resolve));
     await this.reqResp.start();
     if (!await this.isSynced()) {
       this.logger.info("Chain not synced, running initial sync...");


### PR DESCRIPTION
This pull request is currently a WIP as there are still things that do not work the way they should. Currently initial syncing and regular sync "work". But "work" here is used very loosely. 
It "works" because it syncs. But it does so very inefficiently because the block processing queue and syncing is flawed as @mpetrunic described in standup. 
What happens is that if before the block processing queue finishes processing the blocks in the queue and a new block is received through gossip, we will ask for all the blocks in range (most recently processed, newly gossiped block) even if we already have them. 