### PR TITLE
[WIP] Create index for validator array so that it's faster to find by public key

### DIFF
--- a/packages/eth2.0-types/src/types/validator.ts
+++ b/packages/eth2.0-types/src/types/validator.ts
@@ -4,6 +4,7 @@
  */
 
 import {BLSPubkey, Shard, Slot, uint64, number64} from "./primitive";
+import {Validator} from "./misc";
 
 export interface ValidatorDuty {
   // The validator's public key, uniquely identifying them
@@ -26,3 +27,61 @@ export interface SyncingStatus {
   // The estimated highest block, or current target block number
   highestBlock: uint64;
 }
+
+export interface Registry<T, T1> extends Array<T> {
+  // find index in array from a field
+  findIndexByRegistry?: (field: T1) => number;
+}
+// T: the type to index
+// T1: the type of field to index
+interface InternalRegistry<T, T1> extends Registry<T, T1> {
+  registry?: Map<T1, number>;
+}
+
+export function getRegistry<T, T1>(items: T[], getField: (item: T) => T1): Registry<T, T1> {
+  const internalRegistry: InternalRegistry<T, T1> = items;
+  // index for the first time
+  const tmp = new Map<T1, number>();
+  internalRegistry.forEach((value: T, index: number) => tmp.set(getField(value), index));
+  internalRegistry.registry = tmp;
+  internalRegistry.findIndexByRegistry = (field: T1) => internalRegistry.registry.get(field);
+
+  // on the fly index
+  const handler: ProxyHandler<InternalRegistry<T, T1>> = {
+    get: (target: InternalRegistry<T, T1>, p: PropertyKey) => {
+      if (p.toString() === "registry") {
+        throw new Error("Cannot access registry property directly");
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const obj = target as any;
+      return obj[p.toString()];
+    },
+    set: (target: InternalRegistry<T, T1>, p: PropertyKey, receiver) => {
+      if(Number(p.toString()) || p.toString() === "0") {
+        const oldValue = target[Number(p)];
+        // make sure we haven't just update the old value
+        // like in the case of splice method
+        if (oldValue && target.registry.get(getField(oldValue)) == Number(p)) {
+          target.registry.delete(getField(oldValue));
+        }
+        target.registry.set(getField(receiver), Number(p));
+        target[Number(p)] = receiver;
+        return true;
+      } else if (p.toString() === "length") {
+        target["length"] = receiver; 
+        return true;
+      }
+      return false;
+    }
+  };
+
+  return new Proxy<InternalRegistry<T, T1>>(internalRegistry, handler);
+}
+
+// Map uses === to compare key so to search for public key so we should base on hex, not BLSPublickey
+export type ValidatorRegistry = Registry<Validator, string>;
+
+export const getValidatorRegistry = (validators: Validator[]): ValidatorRegistry => {
+  const getPublicKey = (validator: Validator): string => validator.pubkey.toString("hex");
+  return getRegistry(validators, getPublicKey);
+};

--- a/packages/eth2.0-types/test/unit/validator.test.ts
+++ b/packages/eth2.0-types/test/unit/validator.test.ts
@@ -29,6 +29,11 @@ describe("ValidatorRegistry", () => {
     for (let i = 0; i < TOTAL_ITEM; i++) {
       expect(validatorRegistry[i].effectiveBalance.toNumber()).to.be.equal(i);
     }
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[3])).to.be.equal(3);
+    const newItem: BN = new BN(2019);
+    validatorRegistry[3] = {effectiveBalance: newItem};
+    expect(validatorRegistry.findIndexByRegistry(newItem)).to.be.equal(3);
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[3])).to.be.undefined;
   });
 
   it("should work well with forEach method", () => {

--- a/packages/eth2.0-types/test/unit/validator.test.ts
+++ b/packages/eth2.0-types/test/unit/validator.test.ts
@@ -1,0 +1,95 @@
+import {describe, it} from "mocha";
+import {Validator} from "../../src/types/misc";
+import {getRegistry, Registry} from "../../src/types/validator";
+import BN from "bn.js";
+import {expect} from "chai";
+import { Gwei } from "../../src/types/primitive";
+
+describe("ValidatorRegistry", () => {
+  let validators: Partial<Validator>[] = [];
+  let validatorRegistry: Registry<Partial<Validator>, Gwei>;
+  const EFFECTIVE_BALANCES: BN[] = [];
+  const TOTAL_ITEM = 6;
+
+  before(() => {
+    for (let i = 0; i < TOTAL_ITEM; i++) {
+      EFFECTIVE_BALANCES.push(new BN(i));
+    }
+  });
+
+  beforeEach(() => {
+    validators = [];
+    for (let i = 0; i < TOTAL_ITEM; i++) {
+      validators.push({effectiveBalance: EFFECTIVE_BALANCES[i]});
+    }
+    validatorRegistry = getRegistry<Partial<Validator>, Gwei>(validators, (val: Partial<Validator>) => val.effectiveBalance);
+  });
+
+  it("should work well with index operator", () => {
+    for (let i = 0; i < TOTAL_ITEM; i++) {
+      expect(validatorRegistry[i].effectiveBalance.toNumber()).to.be.equal(i);
+    }
+  });
+
+  it("should work well with forEach method", () => {
+    validatorRegistry.forEach((value: Partial<Validator>, index: number) => {
+      expect(value.effectiveBalance.toNumber()).to.be.equal(index);
+    })
+  });
+
+  it("should return correct index from registry", () => {
+    for (let i = 0; i < TOTAL_ITEM; i++) {
+      expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[i])).to.be.equal(i);
+    }
+  });
+
+  it("should work well after push", () => {
+    const newItem: BN = new BN(2019);
+    const count = validatorRegistry.length;
+    validatorRegistry.push({effectiveBalance: newItem});
+    expect(validatorRegistry.findIndexByRegistry(newItem)).to.be.equal(count);
+  });
+
+  it("should work well after splice", () => {
+    const newItem: BN = new BN(2019);
+    // delete 1, 2, 3 and insert 1 new
+    validatorRegistry.splice(1, 3, {effectiveBalance: newItem});
+    expect(validatorRegistry.findIndexByRegistry(newItem)).to.be.equal(1);
+    // should not find deleted item anymore
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[1])).to.be.undefined;
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[2])).to.be.undefined;
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[3])).to.be.undefined;
+    // old index is 4, new index is 3
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[4])).to.be.equal(2);
+  });
+
+  it("should work well after reverse method", () => {
+    validatorRegistry.reverse();
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[0])).to.be.equal(5);
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[1])).to.be.equal(4);
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[2])).to.be.equal(3);
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[3])).to.be.equal(2);
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[4])).to.be.equal(1);
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[5])).to.be.equal(0);
+  });
+
+  it("should work well after shift method", () => {
+    validatorRegistry.shift();
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[0])).to.be.undefined;
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[1])).to.be.equal(0);
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[2])).to.be.equal(1);
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[3])).to.be.equal(2);
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[4])).to.be.equal(3);
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[5])).to.be.equal(4);
+  });
+
+  it("should work well after sort", () => {
+    validatorRegistry.sort((val1, val2: Partial<Validator>) => val2.effectiveBalance.toNumber() - val1.effectiveBalance.toNumber());
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[0])).to.be.equal(5);
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[1])).to.be.equal(4);
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[2])).to.be.equal(3);
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[3])).to.be.equal(2);
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[4])).to.be.equal(1);
+    expect(validatorRegistry.findIndexByRegistry(EFFECTIVE_BALANCES[5])).to.be.equal(0);
+  });
+});


### PR DESCRIPTION
## Goal
+ Close #486 
## Solution
+ Enhance Array interface with newly created `findIndexByRegistry ` method, call the new interface ValidatorRegistry
+ Have a new Proxy sitting before the enhanced array and index every `set` method
+ Implement `findIndexByRegistry ` by getting from the index which is implemented by a map
## Unit tests:
```
ValidatorRegistry
    ✓ should work well with index operator
    ✓ should work well with forEach method
    ✓ should return correct index from registry
    ✓ should work well after push
    ✓ should work well after splice
    ✓ should work well after reverse method
    ✓ should work well after shift method
    ✓ should work well after sort
```