### PR TITLE
Remove --incremental from build:types

### DIFF
--- a/packages/benchmark-utils/package.json
+++ b/packages/benchmark-utils/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn build:lib && yarn build:types",
     "build:release": "yarn clean && yarn build && yarn build:docs",
-    "build:types": "tsc --declaration --incremental --emitDeclarationOnly",
+    "build:types": "tsc --declaration --emitDeclarationOnly",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --out docs src",
     "check-types": "tsc --noEmit --incremental",

--- a/packages/bls/package.json
+++ b/packages/bls/package.json
@@ -21,7 +21,7 @@
     "build": "yarn build-lib && yarn build-types",
     "build:release": "yarn clean && yarn build && yarn build-web",
     "build-lib": "babel src -x .ts -d lib",
-    "build-types": "tsc --declaration --incremental --outDir lib --emitDeclarationOnly",
+    "build-types": "tsc --declaration --outDir lib --emitDeclarationOnly",
     "build-web": "webpack --mode production --entry ./lib/web.js --output ./dist/bls.min.js",
     "check-types": "tsc --noEmit",
     "lint": "eslint --ext .ts src/",

--- a/packages/eth2.0-config/package.json
+++ b/packages/eth2.0-config/package.json
@@ -17,7 +17,7 @@
     "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn build:lib && yarn build:types",
     "build:release": "yarn run clean && yarn run build && yarn run build:docs",
-    "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
+    "build:types": "tsc --declaration --outDir lib --emitDeclarationOnly",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
     "check-types": "tsc --noEmit --incremental",

--- a/packages/eth2.0-params/package.json
+++ b/packages/eth2.0-params/package.json
@@ -18,7 +18,7 @@
     "build": "yarn build:lib && yarn build:types",
     "build:release": "yarn clean && yarn build",
     "build:lib": "babel src -x .ts -d lib --source-maps",
-    "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
+    "build:types": "tsc --declaration --outDir lib --emitDeclarationOnly",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
     "check-types": "tsc --noEmit --incremental",
     "lint": "eslint --color --ext .ts src/",

--- a/packages/eth2.0-spec-test-util/package.json
+++ b/packages/eth2.0-spec-test-util/package.json
@@ -17,7 +17,7 @@
     "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn build:lib && yarn build:types",
     "build:release": "yarn clean && yarn build && yarn build:docs",
-    "build:types": "tsc --incremental --declaration --emitDeclarationOnly",
+    "build:types": "tsc --declaration --emitDeclarationOnly",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --out docs src",
     "check-types": "tsc --noEmit --incremental",

--- a/packages/eth2.0-state-transition/package.json
+++ b/packages/eth2.0-state-transition/package.json
@@ -18,7 +18,7 @@
     "build": "yarn build:lib && yarn build:types",
     "build:release": "yarn clean && yarn build",
     "build:lib": "babel src -x .ts -d lib --source-maps",
-    "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
+    "build:types": "tsc --declaration --outDir lib --emitDeclarationOnly",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
     "check-types": "tsc --noEmit --incremental",
     "lint": "eslint --color --ext .ts src/",

--- a/packages/eth2.0-types/package.json
+++ b/packages/eth2.0-types/package.json
@@ -18,7 +18,7 @@
     "build": "yarn build:lib && yarn build:types",
     "build:release": "yarn clean && yarn build",
     "build:lib": "babel src -x .ts -d lib --source-maps",
-    "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
+    "build:types": "tsc --declaration --outDir lib --emitDeclarationOnly",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
     "check-types": "tsc --noEmit --incremental",
     "lint": "eslint --color --ext .ts src/",

--- a/packages/eth2.0-utils/package.json
+++ b/packages/eth2.0-utils/package.json
@@ -17,7 +17,7 @@
     "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn build:lib && yarn build:types",
     "build:release": "yarn clean && yarn build && yarn build:docs",
-    "build:types": "tsc --incremental --project tsconfig.build.json --declaration --outDir lib --emitDeclarationOnly",
+    "build:types": "tsc --project tsconfig.build.json --declaration --outDir lib --emitDeclarationOnly",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
     "check-types": "tsc --noEmit --incremental",

--- a/packages/lodestar-validator/package.json
+++ b/packages/lodestar-validator/package.json
@@ -18,7 +18,7 @@
     "build:release": "yarn clean && yarn run build && yarn run build:docs",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
-    "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
+    "build:types": "tsc --declaration --outDir lib --emitDeclarationOnly",
     "check-types": "tsc --incremental --noEmit",
     "lint": "eslint --color --ext .ts src/",
     "lint:fix": "eslint --color --ext .ts src/ --fix",

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -19,7 +19,7 @@
     "build:release": "yarn clean && yarn run build && yarn run build:docs",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
-    "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
+    "build:types": "tsc --declaration --outDir lib --emitDeclarationOnly",
     "check-types": "tsc --incremental --noEmit",
     "lint": "eslint --color --ext .ts src/",
     "lint:fix": "eslint --color --ext .ts src/ --fix",

--- a/packages/ssz-type-schema/package.json
+++ b/packages/ssz-type-schema/package.json
@@ -17,7 +17,7 @@
     "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn build:lib && yarn build:types",
     "build:release": "yarn clean && yarn run build && yarn run build:docs",
-    "build:types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
+    "build:types": "tsc --declaration --outDir lib --emitDeclarationOnly",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
     "check-types": "tsc --noEmit --incremental",

--- a/packages/ssz/package.json
+++ b/packages/ssz/package.json
@@ -13,7 +13,7 @@
     "build:release": "yarn clean && yarn run build && yarn build-web && yarn run build:docs",
     "build:docs": "typedoc --exclude src/index.ts,src/web.ts --out docs src",
     "build-lib": "babel src -x .ts -d lib --source-maps",
-    "build-types": "tsc --incremental --declaration --outDir lib --emitDeclarationOnly",
+    "build-types": "tsc --declaration --outDir lib --emitDeclarationOnly",
     "build-web": "webpack --mode production --entry ./lib/web.js --output ./dist/ssz.min.js",
     "check-types": "tsc --incremental --noEmit",
     "lint": "eslint --color --ext .ts src/ test/",


### PR DESCRIPTION
Using the --incremental flag, typescript will add a buildinfo file in the published package.
We don't want to be publishing this file, since its useless and potentially a security concern (leaks personal information of the publisher).