### PR TITLE
Add optional generic typescript type to ssz types

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "typedoc-plugin-external-module-name": "^2.1.0",
     "typedoc-plugin-internal-external": "^2.0.2",
     "typedoc-plugin-markdown": "^2.0.6",
-    "typescript": "^3.5.1",
+    "typescript": "^3.7.2",
     "webpack": "^4.39.1"
   },
   "optionalDependencies": {

--- a/packages/eth2.0-types/src/ssz/interface.ts
+++ b/packages/eth2.0-types/src/ssz/interface.ts
@@ -1,63 +1,64 @@
 import {AnyContainerType, AnySSZType} from "@chainsafe/ssz-type-schema";
+import * as t from "../types";
 
 export interface IBeaconSSZTypes {
   // primitive
-  bool: AnySSZType;
-  bytes4: AnySSZType;
-  bytes8: AnySSZType;
-  bytes32: AnySSZType;
-  bytes48: AnySSZType;
-  bytes96: AnySSZType;
-  uint8: AnySSZType;
-  uint16: AnySSZType;
-  uint24: AnySSZType;
-  number64: AnySSZType;
-  uint64: AnySSZType;
-  uint256: AnySSZType;
-  Slot: AnySSZType;
-  Epoch: AnySSZType;
-  Shard: AnySSZType;
-  ValidatorIndex: AnySSZType;
-  Gwei: AnySSZType;
-  Hash: AnySSZType;
-  Version: AnySSZType;
-  BLSPubkey: AnySSZType;
-  BLSSignature: AnySSZType;
+  bool: AnySSZType<t.bool>;
+  bytes4: AnySSZType<t.bytes4>;
+  bytes8: AnySSZType<t.bytes8>;
+  bytes32: AnySSZType<t.bytes32>;
+  bytes48: AnySSZType<t.bytes48>;
+  bytes96: AnySSZType<t.bytes96>;
+  uint8: AnySSZType<t.uint8>;
+  uint16: AnySSZType<t.uint16>;
+  uint24: AnySSZType<t.uint24>;
+  number64: AnySSZType<t.number64>;
+  uint64: AnySSZType<t.uint64>;
+  uint256: AnySSZType<t.uint256>;
+  Slot: AnySSZType<t.Slot>;
+  Epoch: AnySSZType<t.Epoch>;
+  Shard: AnySSZType<t.Shard>;
+  ValidatorIndex: AnySSZType<t.ValidatorIndex>;
+  Gwei: AnySSZType<t.Gwei>;
+  Hash: AnySSZType<t.Hash>;
+  Version: AnySSZType<t.Version>;
+  BLSPubkey: AnySSZType<t.BLSPubkey>;
+  BLSSignature: AnySSZType<t.BLSSignature>;
   // misc
-  Fork: AnyContainerType;
-  Checkpoint: AnyContainerType;
-  Validator: AnyContainerType;
-  Crosslink: AnyContainerType;
-  AttestationData: AnyContainerType;
-  AttestationDataAndCustodyBit: AnyContainerType;
-  IndexedAttestation: AnyContainerType;
-  PendingAttestation: AnyContainerType;
-  Eth1Data: AnyContainerType;
-  HistoricalBatch: AnyContainerType;
-  DepositData: AnyContainerType;
-  CompactCommittee: AnyContainerType;
-  BeaconBlockHeader: AnyContainerType;
-  FFGData: AnyContainerType;
-  MerkleTree: AnyContainerType;
+  Fork: AnyContainerType<t.Fork>;
+  Checkpoint: AnyContainerType<t.Checkpoint>;
+  Validator: AnyContainerType<t.Validator>;
+  Crosslink: AnyContainerType<t.Crosslink>;
+  AttestationData: AnyContainerType<t.AttestationData>;
+  AttestationDataAndCustodyBit: AnyContainerType<t.AttestationDataAndCustodyBit>;
+  IndexedAttestation: AnyContainerType<t.IndexedAttestation>;
+  PendingAttestation: AnyContainerType<t.PendingAttestation>;
+  Eth1Data: AnyContainerType<t.Eth1Data>;
+  HistoricalBatch: AnyContainerType<t.HistoricalBatch>;
+  DepositData: AnyContainerType<t.DepositData>;
+  CompactCommittee: AnyContainerType<t.CompactCommittee>;
+  BeaconBlockHeader: AnyContainerType<t.BeaconBlockHeader>;
+  FFGData: AnyContainerType<t.FFGData>;
+  MerkleTree: AnyContainerType<t.MerkleTree>;
   // operations
-  ProposerSlashing: AnyContainerType;
-  AttesterSlashing: AnyContainerType;
-  Attestation: AnyContainerType;
-  Deposit: AnyContainerType;
-  VoluntaryExit: AnyContainerType;
-  Transfer: AnyContainerType;
+  ProposerSlashing: AnyContainerType<t.ProposerSlashing>;
+  AttesterSlashing: AnyContainerType<t.AttesterSlashing>;
+  Attestation: AnyContainerType<t.Attestation>;
+  Deposit: AnyContainerType<t.Deposit>;
+  VoluntaryExit: AnyContainerType<t.VoluntaryExit>;
+  Transfer: AnyContainerType<t.Transfer>;
   // block
-  BeaconBlockBody: AnyContainerType;
-  BeaconBlock: AnyContainerType;
+  BeaconBlockBody: AnyContainerType<t.BeaconBlockBody>;
+  BeaconBlock: AnyContainerType<t.BeaconBlock>;
   // state
-  BeaconState: AnyContainerType;
+  BeaconState: AnyContainerType<t.BeaconState>;
   // wire
-  Hello: AnyContainerType;
-  Goodbye: AnyContainerType;
-  BeaconBlocksByRangeRequest: AnyContainerType;
-  BeaconBlocksByRangeResponse: AnyContainerType;
-  BeaconBlocksByRootRequest: AnyContainerType;
-  BeaconBlocksByRootResponse: AnyContainerType;
+  Hello: AnyContainerType<t.Hello>;
+  Goodbye: AnyContainerType<t.Goodbye>;
+  BeaconBlocksByRangeRequest: AnyContainerType<t.BeaconBlocksByRangeRequest>;
+  BeaconBlocksByRangeResponse: AnyContainerType<t.BeaconBlocksByRangeResponse>;
+  BeaconBlocksByRootRequest: AnyContainerType<t.BeaconBlocksByRootRequest>;
+  BeaconBlocksByRootResponse: AnyContainerType<t.BeaconBlocksByRootResponse>;
 }
 
 export const typeNames: (keyof IBeaconSSZTypes)[] = [

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -71,7 +71,7 @@
     "commander": "^2.19.0",
     "deepmerge": "^3.2.0",
     "es6-promisify": "6.0.2",
-    "ethers": "^4.0.27",
+    "ethers": "^4.0.40",
     "fastify": "^2.7.1",
     "fastify-cors": "^2.1.3",
     "fastpriorityqueue": "^0.6.3",

--- a/packages/lodestar/src/db/api/beacon/repositories/chain.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/chain.ts
@@ -79,7 +79,7 @@ export class ChainRepository {
       if(!heightBuf) {
         throw new Error("Missing chain height");
       }
-      return deserialize(heightBuf, this.config.types.Slot) as Slot;
+      return deserialize(heightBuf, this.config.types.Slot);
     } catch (e) {
       return null;
     }

--- a/packages/lodestar/src/eth1/impl/ethers.ts
+++ b/packages/lodestar/src/eth1/impl/ethers.ts
@@ -6,7 +6,7 @@ import {EventEmitter} from "events";
 import {Contract, ethers} from "ethers";
 import {Block, Log} from "ethers/providers";
 import {deserialize} from "@chainsafe/ssz";
-import {BeaconState, Deposit, Epoch, Eth1Data, Gwei, Hash, number64} from "@chainsafe/eth2.0-types";
+import {BeaconState, Deposit, Epoch, Eth1Data, Hash, number64} from "@chainsafe/eth2.0-types";
 import {IBeaconConfig} from "@chainsafe/eth2.0-config";
 import {Eth1EventEmitter, IEth1Notifier} from "../interface";
 import {isValidAddress} from "../../util/address";
@@ -84,7 +84,7 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
     merkleTreeIndex: string
   ): Promise<void> {
     try {
-      const index = deserialize(Buffer.from(merkleTreeIndex.substr(2), "hex"), this.config.types.number64) as number64;
+      const index = deserialize(Buffer.from(merkleTreeIndex.substr(2), "hex"), this.config.types.number64);
       const deposit = this.createDeposit(
         pubkey,
         withdrawalCredentials,
@@ -224,7 +224,7 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
       data: {
         pubkey: Buffer.from(pubkey.slice(2), "hex"),
         withdrawalCredentials: Buffer.from(withdrawalCredentials.slice(2), "hex"),
-        amount: deserialize(Buffer.from(amount.slice(2), "hex"), this.config.types.Gwei) as Gwei,
+        amount: deserialize(Buffer.from(amount.slice(2), "hex"), this.config.types.Gwei),
         signature: Buffer.from(signature.slice(2), "hex"),
       },
     };

--- a/packages/lodestar/src/util/serialization.ts
+++ b/packages/lodestar/src/util/serialization.ts
@@ -12,7 +12,7 @@ export class MerkleTreeSerialization implements IMerkleTreeSerialization {
   }
 
   public deserializeTree(tree: Buffer): MerkleTree {
-    return deserialize(tree, this.config.types.MerkleTree) as MerkleTree;
+    return deserialize(tree, this.config.types.MerkleTree);
   }
 
   public serializeLength(length: number): Buffer {

--- a/packages/ssz-type-schema/src/types.ts
+++ b/packages/ssz-type-schema/src/types.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/interface-name-prefix */
+/* eslint-disable @typescript-eslint/interface-name-prefix, @typescript-eslint/no-explicit-any */
 
 // Serializable values
 
@@ -17,19 +17,19 @@ export type SerializableValue = Uint | Bool | Bits | Bytes | SerializableArray |
 // Simple types
 // These types are supplied to provide a convenient interface with which to specify types
 
-export type SimplePrimitiveType = string;
+export type SimplePrimitiveType<T=any> = string;
 
-export interface SimpleListType {
+export interface SimpleListType<T=any> {
   elementType: AnySSZType;
   maxLength: number;
 }
 
-export interface SimpleVectorType {
+export interface SimpleVectorType<T=any> {
   elementType: AnySSZType;
   length: number;
 }
 
-export interface SimpleContainerType {
+export interface SimpleContainerType<T=any> {
   fields: [string, AnySSZType][];
 }
 
@@ -39,7 +39,8 @@ export interface SimpleContainerType {
  * In most cases, types are specified by users in simple form.
  * They will be parsed to a [[FullSSZType]] before any processing.
  */
-export type SimpleSSZType = SimplePrimitiveType | SimpleListType | SimpleVectorType | SimpleContainerType;
+export type SimpleSSZType<T=any> =
+  SimplePrimitiveType<T> | SimpleListType<T> | SimpleVectorType<T> | SimpleContainerType<T>;
 
 // Full types
 // These types are used internally
@@ -56,55 +57,55 @@ export enum Type {
   container,
 }
 
-export interface UintType {
+export interface UintType<T=any> {
   type: Type.uint;
   byteLength: number;
   useNumber: boolean;
 }
 
-export interface BoolType {
+export interface BoolType<T=any> {
   type: Type.bool;
 }
 
-export interface BitListType {
+export interface BitListType<T=any> {
   type: Type.bitList;
   maxLength: number;
 }
 
-export interface BitVectorType {
+export interface BitVectorType<T=any> {
   type: Type.bitVector;
   length: number;
 }
 
-export type BitsType = BitListType | BitVectorType;
+export type BitsType<T=any> = BitListType<T> | BitVectorType<T>;
 
-export interface ByteListType {
+export interface ByteListType<T=any> {
   type: Type.byteList;
   maxLength: number;
 }
 
-export interface ByteVectorType {
+export interface ByteVectorType<T=any> {
   type: Type.byteVector;
   length: number;
 }
 
-export type BytesType = ByteListType | ByteVectorType;
+export type BytesType<T=any> = ByteListType<T> | ByteVectorType<T>;
 
-export interface ListType {
+export interface ListType<T=any> {
   type: Type.list;
   elementType: FullSSZType;
   maxLength: number;
 }
 
-export interface VectorType {
+export interface VectorType<T=any> {
   type: Type.vector;
   elementType: FullSSZType;
   length: number;
 }
 
-export type ArrayType = ListType | VectorType;
+export type ArrayType<T=any> = ListType<T> | VectorType<T>;
 
-export interface ContainerType {
+export interface ContainerType<T=any> {
   type: Type.container;
   fields: [string, FullSSZType][];
 }
@@ -114,10 +115,11 @@ export interface ContainerType {
  *
  * Full types are used internally.
  */
-export type FullSSZType = UintType | BoolType | BitsType | BytesType | ArrayType | ContainerType;
+export type FullSSZType<T=any> =
+  UintType<T> | BoolType<T> | BitsType<T> | BytesType<T> | ArrayType<T> | ContainerType<T>;
 
 // simple + full types
 
-export type AnyContainerType = ContainerType | SimpleContainerType;
+export type AnyContainerType<T=any> = ContainerType<T> | SimpleContainerType<T>;
 
-export type AnySSZType = FullSSZType | SimpleSSZType;
+export type AnySSZType<T=any> = FullSSZType<T> | SimpleSSZType<T>;

--- a/packages/ssz/src/core/deserialize.ts
+++ b/packages/ssz/src/core/deserialize.ts
@@ -108,12 +108,12 @@ import {toBigIntLE} from "bigint-buffer";
  * const obj: myData = deserialize(data, myDataType);
  * ```
   */
-export function deserialize(data: Buffer, type: AnySSZType): any {
+export function deserialize<T>(data: Buffer, type: AnySSZType<T>): T {
   const _type = parseType(type);
   if (!isVariableSizeType(_type)) {
     assert(fixedSize(_type) === data.length, "Incorrect data length");
   }
-  return _deserialize(data, _type, 0, data.length);
+  return _deserialize(data, _type, 0, data.length) as unknown as T;
 
 }
 

--- a/packages/ssz/test/unit/deserialize.test.ts
+++ b/packages/ssz/test/unit/deserialize.test.ts
@@ -1,12 +1,12 @@
 import {assert} from "chai";
 
 import {describe, it} from "mocha";
-import {SerializableValue,} from "@chainsafe/ssz-type-schema";
+import {AnySSZType, SerializableValue} from "@chainsafe/ssz-type-schema";
 
 import {ArrayObject, OuterObject, SimpleObject,} from "./objects";
 
 import {stringifyType} from "./utils";
-import {deserialize} from "../../src";
+import {serialize, deserialize} from "../../src";
 
 describe("deserialize", () => {
 
@@ -98,4 +98,27 @@ describe("deserialize", () => {
       assert.throws(() => deserialize(Buffer.from(value, "hex"), type));
     });
   }
+});
+
+interface ITestType {
+  foo: number;
+  bar: boolean;
+}
+
+describe("type inference", () => {
+  it("should detect the return type", () => {
+    const testType: AnySSZType<ITestType> = {
+      fields: [
+        ["foo", "uint8"],
+        ["bar", "bool"],
+      ],
+    };
+    const input: ITestType = {
+      foo: 1,
+      bar: true,
+    };
+    const bytes = serialize(input, testType);
+    const output = deserialize(bytes, testType);
+    assert(output.bar == true);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1654,10 +1654,6 @@
   version "12.6.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"
 
-"@types/node@^10.3.2":
-  version "10.14.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.13.tgz#ac786d623860adf39a3f51d629480aacd6a6eec7"
-
 "@types/node@^12.7.2":
   version "12.7.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.2.tgz#c4e63af5e8823ce9cc3f0b34f7b998c2171f0c44"
@@ -4272,14 +4268,18 @@ electron-to-chromium@^1.3.191, electron-to-chromium@^1.3.47:
   version "1.3.200"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.200.tgz#78fb858b466269e8eb46d31a52562f00c865127f"
 
-elliptic@6.3.3:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.3.3.tgz#5482d9646d54bcb89fd7d994fc9e2e9568876e3f"
+elliptic@6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
+  integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
     hash.js "^1.0.0"
+    hmac-drbg "^1.0.0"
     inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.0"
 
 elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.4.1:
   version "6.5.0"
@@ -4868,14 +4868,14 @@ ethereumjs-wallet@0.6.3:
     utf8 "^3.0.0"
     uuid "^3.3.2"
 
-ethers@^4.0.27:
-  version "4.0.33"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.33.tgz#f7b88d2419d731a39aefc37843a3f293e396f918"
+ethers@^4.0.40:
+  version "4.0.40"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.40.tgz#6e1963d10b5d336a13cd81b519c230cc17624653"
+  integrity sha512-MC9BtV7Hpq4dgFONEfanx9aU9GhhoWU270F+/wegHZXA7FR+2KXFdt36YIQYLmVY5ykUWswDxd+f9EVkIa7JOA==
   dependencies:
-    "@types/node" "^10.3.2"
     aes-js "3.0.0"
     bn.js "^4.4.0"
-    elliptic "6.3.3"
+    elliptic "6.5.2"
     hash.js "1.1.3"
     js-sha3 "0.5.7"
     scrypt-js "2.0.4"
@@ -11060,7 +11060,7 @@ typedoc@^0.15.0:
     typedoc-default-themes "^0.6.0"
     typescript "3.5.x"
 
-typescript@3.5.x, typescript@^3.5.1, typescript@^3.5.3:
+typescript@3.5.x, typescript@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
@@ -11069,6 +11069,11 @@ typescript@^3.2.1:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
   integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+
+typescript@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
- Adds an optional generic type to ssz types (eg: `FullSSZType<T>`).
Defaults to `any`, so filling in the generic is not required and nothing changes if someone's ssz types don't fill in the generic.

- `ssz.deserialize` now uses this type as its return type.
eg:
```typescript
interface Foo {
  bar: number;
}
const fooType: AnySSZType<Foo> = {
  fields: [["bar", "uint8"]],
}
const deserialized = deserialize(data, fooType);
// ^ typescript now knows that `deserialized` is a `Foo`
deserialized.bar // <- IDE will be able to tab-complete this
```

- eth2.0-types `IBeaconSSZTypes` have been updated to include the typescript types of each ssz type
eg:
```typescript
interface IBeaconSSZTypes {
  ...
  BeaconState: AnySSZType<BeaconState>;
  ...
}
```

- In lodestar, we no longer do `deserialize(...) as Type` since we're always deserializing one of the known `IBeaconSSZTypes`