### PR TITLE
bump bls-wasm version

### DIFF
--- a/packages/bls/package.json
+++ b/packages/bls/package.json
@@ -38,7 +38,7 @@
     "benchmark": "node -r ./.babel-register test/benchmarks"
   },
   "dependencies": {
-    "@chainsafe/eth2-bls-wasm": "^0.1.0",
+    "@chainsafe/eth2-bls-wasm": "^0.2.0",
     "@chainsafe/eth2.0-types": "^0.1.0",
     "assert": "^1.4.1",
     "bls-wasm": "^0.2.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -690,10 +690,12 @@
     js-sha256 "^0.9.0"
     secure-random "^1.1.1"
 
-"@chainsafe/eth2-bls-wasm@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/eth2-bls-wasm/-/eth2-bls-wasm-0.1.0.tgz#d76e42b2c5c77fdfdc67043717ac33cff4134288"
-  integrity sha512-aqp3GcJd9S3BU5hE+HiAX26CZ91SPWcupecX65N60S1xZykaEDcg8DvUgKNsPFYytpAhmXU/xn9pe866sMgOvQ==
+"@chainsafe/eth2-bls-wasm@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/eth2-bls-wasm/-/eth2-bls-wasm-0.2.0.tgz#8dab34ab223fe5b29133f3d4ee01b09e97dba978"
+  integrity sha512-d0dz96FSaRHQm7S7iW7vWpLvlhvRC6ps8iv1LUc5AxiT96u7cQMvA/u+dggMRBxwqwyT2WwsL8tt8/uW/Cqujw==
+  dependencies:
+    buffer "^5.4.3"
 
 "@chainsafe/eth2-spec-tests@0.8.3":
   version "0.8.3"
@@ -3185,6 +3187,14 @@ buffer@^4.3.0:
 buffer@^5.0.5, buffer@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
+buffer@^5.4.3:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.4.3.tgz#3fbc9c69eb713d323e3fc1a895eee0710c072115"
+  integrity sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"


### PR DESCRIPTION
- enables browser usage without the need for mannually copy wasm blob from library into "public" directory