### PR TITLE
Tweak ssz clone and equals

### DIFF
--- a/packages/ssz/src/core/clone.ts
+++ b/packages/ssz/src/core/clone.ts
@@ -79,10 +79,10 @@ function _clone(type: FullSSZType, value: any): any {
       return (value as Buffer).slice();
     case Type.list:
     case Type.vector:
-      return value.map((element: any) => clone(type.elementType, element));
+      return value.map((element: any) => _clone(type.elementType, element));
     case Type.container:
       type.fields.forEach(([fieldName, fieldType]) => {
-        obj[fieldName] = clone(fieldType, value[fieldName]);
+        obj[fieldName] = _clone(fieldType, value[fieldName]);
       });
       return obj;
   }

--- a/packages/ssz/src/core/equals.ts
+++ b/packages/ssz/src/core/equals.ts
@@ -76,10 +76,10 @@ function _equals(type: FullSSZType, value1: any, value2: any): boolean {
       return value1.equals(value2);
     case Type.list:
       return value1.length === value2.length &&
-        value1.every((element1: any, i: number) => equals(type.elementType, element1, value2[i]));
+        value1.every((element1: any, i: number) => _equals(type.elementType, element1, value2[i]));
     case Type.vector:
-      return value1.every((element1: any, i: number) => equals(type.elementType, element1, value2[i]));
+      return value1.every((element1: any, i: number) => _equals(type.elementType, element1, value2[i]));
     case Type.container:
-      return type.fields.every(([fieldName, fieldType]) => equals(fieldType, value1[fieldName], value2[fieldName]));
+      return type.fields.every(([fieldName, fieldType]) => _equals(fieldType, value1[fieldName], value2[fieldName]));
   }
 }


### PR DESCRIPTION
Use the lower level _clone and _equals instead of clone and equals in the recursive sections