### PR TITLE
Use fake timer for fork choice test

### DIFF
--- a/packages/lodestar/test/unit/chain/forkChoice/statefulDag.test.ts
+++ b/packages/lodestar/test/unit/chain/forkChoice/statefulDag.test.ts
@@ -2,6 +2,7 @@ import {assert} from "chai";
 
 import {StatefulDagLMDGHOST} from "../../../../src/chain/forkChoice/statefulDag/lmdGhost";
 import {config} from "@chainsafe/eth2.0-config/lib/presets/mainnet";
+import sinon from "sinon";
 
 describe("StatefulDagLMDGHOST", () => {
   const genesis = Buffer.from("genesis");
@@ -13,6 +14,15 @@ describe("StatefulDagLMDGHOST", () => {
   const f = Buffer.from("f");
   const g = Buffer.from("g");
   const h = Buffer.from("h");
+
+  beforeEach(() => {
+    this.clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    this.clock.restore();
+  });
+
   it("should accept blocks to create a DAG", () => {
     /*
      *           c -- f


### PR DESCRIPTION
## Issue
+ Cannot finish unit test in github action
## Cause
+ During code merge from master to 0.9.x, we missed `--exit` flag in package.json
+ Actually it should be better to use sinon fake timer