### PR TITLE
0.9.2: Minor refactor of AggregateAndProof

### DIFF
--- a/packages/eth2.0-params/src/presets/mainnet.ts
+++ b/packages/eth2.0-params/src/presets/mainnet.ts
@@ -10,7 +10,7 @@ export const MIN_PER_EPOCH_CHURN_LIMIT = 2 ** 2; // 4
 export const CHURN_LIMIT_QUOTIENT = 2 ** 16; // 65536
 export const BASE_REWARDS_PER_EPOCH = 4;
 export const SHUFFLE_ROUND_COUNT = 90;
-export const MIN_GENESIS_ACTIVE_VALIDATOR_COUNT = 2 ** 16;
+export const MIN_GENESIS_ACTIVE_VALIDATOR_COUNT = 2 ** 14;
 export const MIN_GENESIS_TIME = 1578009600;
 
 // Deposit contract

--- a/packages/eth2.0-types/src/ssz/generators/validator.ts
+++ b/packages/eth2.0-types/src/ssz/generators/validator.ts
@@ -36,8 +36,8 @@ export const SyncingStatus = (ssz: IBeaconSSZTypes): SimpleContainerType => ({
 
 export const AggregateAndProof = (ssz: IBeaconSSZTypes): SimpleContainerType => ({
   fields: [
-    ["index", ssz.ValidatorIndex],
-    ["selectionProof", ssz.BLSSignature],
+    ["aggregatorIndex", ssz.ValidatorIndex],
     ["aggregate", ssz.Attestation],
+    ["selectionProof", ssz.BLSSignature],
   ],
 });

--- a/packages/eth2.0-types/src/types/validator.ts
+++ b/packages/eth2.0-types/src/types/validator.ts
@@ -34,7 +34,7 @@ export interface CommitteeAssignment {
 }
 
 export interface AggregateAndProof {
-  index: ValidatorIndex;
-  selectionProof: BLSSignature;
+  aggregatorIndex: ValidatorIndex;
   aggregate: Attestation;
+  selectionProof: BLSSignature;
 }

--- a/packages/lodestar/src/network/gossip/handlers/aggregateAndProof.ts
+++ b/packages/lodestar/src/network/gossip/handlers/aggregateAndProof.ts
@@ -16,7 +16,7 @@ export function getIncomingAggregateAndProofHandler(validator: IGossipMessageVal
     try {
       const aggregateAndProof = deserializeGossipMessage<AggregateAndProof>(msg, this.config.types.AggregateAndProof);
       this.logger.verbose(
-        `Received AggregateAndProof from validator #${aggregateAndProof.index}`+
+        `Received AggregateAndProof from validator #${aggregateAndProof.aggregatorIndex}`+
           ` for target ${toHex(aggregateAndProof.aggregate.data.target.root)}`
       );
       if (await validator.isValidIncomingAggregateAndProof(aggregateAndProof)) {
@@ -40,7 +40,7 @@ export async function publishAggregatedAttestation(this: Gossip, aggregateAndPro
     )
   ]);
   this.logger.verbose(
-    `Publishing AggregateAndProof for validator #${aggregateAndProof.index}`
+    `Publishing AggregateAndProof for validator #${aggregateAndProof.aggregatorIndex}`
         + ` for target ${toHex(aggregateAndProof.aggregate.data.target.root)}`
   );
 }

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -102,13 +102,13 @@ export class GossipMessageValidator implements IGossipMessageValidator {
     }
     const attestorIndices = getAttestingIndices(this.config, state,
       aggregationAndProof.aggregate.data, aggregationAndProof.aggregate.aggregationBits);
-    if (!attestorIndices.includes(aggregationAndProof.index)) {
+    if (!attestorIndices.includes(aggregationAndProof.aggregatorIndex)) {
       return false;
     }
-    if (!isAggregator(this.config, state, slot, aggregationAndProof.index, aggregationAndProof.selectionProof)) {
+    if (!isAggregator(this.config, state, slot, aggregationAndProof.aggregatorIndex, aggregationAndProof.selectionProof)) {
       return false;
     }
-    const validatorPubKey = state.validators[aggregationAndProof.index].pubkey;
+    const validatorPubKey = state.validators[aggregationAndProof.aggregatorIndex].pubkey;
     const domain = getDomain(this.config, state, DomainType.BEACON_ATTESTER, computeEpochAtSlot(this.config, slot));
     if (!verify(validatorPubKey,
       hashTreeRoot(this.config.types.Slot, slot),

--- a/packages/lodestar/test/unit/network/gossip/handlers/aggregateAndProof.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/handlers/aggregateAndProof.test.ts
@@ -31,7 +31,7 @@ describe("gossip handlers - aggregate and proof", function () {
 
   it("handle valid message", async function () {
     const aggregate: AggregateAndProof = {
-      index: 0,
+      aggregatorIndex: 0,
       selectionProof: Buffer.alloc(0),
       aggregate: generateEmptyAttestation()
     };

--- a/packages/lodestar/test/utils/attestation.ts
+++ b/packages/lodestar/test/utils/attestation.ts
@@ -54,7 +54,7 @@ export function generateEmptyAttestation(): Attestation {
 export function generateEmptyAggregateAndProof(): AggregateAndProof {
   const attestation = generateEmptyAttestation();
   return {
-    index: 0,
+    aggregatorIndex: 0,
     selectionProof: Buffer.alloc(96),
     aggregate: attestation,
   }


### PR DESCRIPTION
## Goal
+ Part of #589 
+ Minor refactor of AggregateAndProof: reorder field, change `index` to `aggregatorIndex`
+ Minor mainnet configuration changed regarding `MIN_GENESIS_ACTIVE_VALIDATOR_COUNT`