### PR TITLE
Don't Return Unwanted Slot 0 on BeaconBlocksByRange Call

### DIFF
--- a/packages/lodestar/src/db/api/beacon/repositories/blockArchive.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/blockArchive.ts
@@ -1,9 +1,9 @@
-import { BeaconBlock } from "@chainsafe/eth2.0-types";
-import { IBeaconConfig } from "@chainsafe/eth2.0-config";
-import { BulkRepository } from "../repository";
-import { IDatabaseController } from "../../../controller";
-import { Bucket, encodeKey } from "../../../schema";
-import { serialize, deserialize } from "@chainsafe/ssz";
+import {BeaconBlock} from "@chainsafe/eth2.0-types";
+import {IBeaconConfig} from "@chainsafe/eth2.0-config";
+import {BulkRepository} from "../repository";
+import {IDatabaseController} from "../../../controller";
+import {Bucket, encodeKey} from "../../../schema";
+import {serialize, deserialize} from "@chainsafe/ssz";
 
 /**
  * Stores finalized blocks. Block slot is identifier.

--- a/packages/lodestar/src/db/api/beacon/repositories/blockArchive.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/blockArchive.ts
@@ -1,9 +1,9 @@
-import {BeaconBlock} from "@chainsafe/eth2.0-types";
-import {IBeaconConfig} from "@chainsafe/eth2.0-config";
-import {BulkRepository} from "../repository";
-import {IDatabaseController} from "../../../controller";
-import {Bucket, encodeKey} from "../../../schema";
-import {serialize, deserialize} from "@chainsafe/ssz";
+import { BeaconBlock } from "@chainsafe/eth2.0-types";
+import { IBeaconConfig } from "@chainsafe/eth2.0-config";
+import { BulkRepository } from "../repository";
+import { IDatabaseController } from "../../../controller";
+import { Bucket, encodeKey } from "../../../schema";
+import { serialize, deserialize } from "@chainsafe/ssz";
 
 /**
  * Stores finalized blocks. Block slot is identifier.
@@ -45,7 +45,7 @@ export class BlockArchiveRepository extends BulkRepository<BeaconBlock> {
       .map((datum) => deserialize(this.type, datum))
       .filter(block => {
         if (step !== null && typeof safeLowerLimit === "number") {
-          return (block.slot - safeLowerLimit) % step === 0;
+          return block.slot >= safeLowerLimit && (block.slot - safeLowerLimit) % step === 0;
         } else {
           return true;
         }


### PR DESCRIPTION
Fixes #602. It appears that unwanted blocks with slot 0 are returned whenever BeaconBlocksByRange's `step` and `lowerLimit` arguments are equal, since `(0 - lowerLimit) % step === 0` is true whenever the two are equal.

Ensuring that some `slot` is greater than or equal to the `lowerLimit` should fix this.