### PR TITLE
Changes to utilize new gindex code

### DIFF
--- a/packages/ssz/src/backings/tree/abstract.ts
+++ b/packages/ssz/src/backings/tree/abstract.ts
@@ -1,4 +1,4 @@
-import {Node, TreeBacking, Gindex, toGindex, LeafNode, getDepth} from "@chainsafe/merkle-tree";
+import {Node, TreeBacking, Gindex, toGindex, LeafNode, countToDepth} from "@chainsafe/merkle-tree";
 
 import {CompositeType} from "../../types";
 import { isBackedValue, BackingType } from "..";
@@ -94,7 +94,7 @@ export class TreeHandler<T extends object> implements ProxyHandler<T> {
     return this._type.structural.serializeTo(this.createBackedValue(target), output, offset);
   }
   depth(): number {
-    return getDepth(BigInt(this._type.chunkCount()));
+    return countToDepth(BigInt(this._type.chunkCount()));
   }
   gindexOfChunk(target: TreeBacking, index: number): Gindex {
     return toGindex(BigInt(index), this.depth());

--- a/packages/ssz/src/backings/tree/array.ts
+++ b/packages/ssz/src/backings/tree/array.ts
@@ -1,4 +1,4 @@
-import {Node, BranchNode, zeroNode, getDepth, TreeBacking, LeafNode} from "@chainsafe/merkle-tree";
+import {Node, BranchNode, zeroNode, TreeBacking, LeafNode} from "@chainsafe/merkle-tree";
 
 import {BasicArrayType, CompositeArrayType} from "../../types";
 import {TreeHandler, PropOfCompositeTreeBackedValue, TreeBackedValue} from "./abstract";

--- a/packages/ssz/src/backings/tree/container.ts
+++ b/packages/ssz/src/backings/tree/container.ts
@@ -10,12 +10,12 @@ export class ContainerTreeHandler<T extends object> extends TreeHandler<T> {
     return subtreeFillToContents(
       this._type.fields.map(([_, fieldType]) => {
         if (fieldType.isBasic()) {
-          return zeroNode(BigInt(0));
+          return zeroNode(0);
         } else {
           return fieldType.tree.defaultNode();
         }
       }),
-      BigInt(this.depth()),
+      this.depth(),
     );
   }
   createValue(value: any): TreeBackedValue<T> {

--- a/packages/ssz/src/backings/tree/list.ts
+++ b/packages/ssz/src/backings/tree/list.ts
@@ -8,7 +8,7 @@ export class BasicListTreeHandler<T extends ArrayLike<any>> extends BasicArrayTr
   _defaultNode: Node;
   defaultNode(): Node {
     if (!this._defaultNode) {
-      this._defaultNode = new BranchNode(zeroNode(BigInt(super.depth())), zeroNode(BigInt(0)));
+      this._defaultNode = new BranchNode(zeroNode(super.depth()), zeroNode(0));
     }
     return this._defaultNode;
   }
@@ -66,7 +66,7 @@ export class CompositeListTreeHandler<T extends ArrayLike<any>> extends Composit
   _defaultNode: Node;
   defaultNode(): Node {
     if (!this._defaultNode) {
-      this._defaultNode = new BranchNode(zeroNode(BigInt(super.depth())), zeroNode(BigInt(0)));
+      this._defaultNode = new BranchNode(zeroNode(super.depth()), zeroNode(0));
     }
     return this._defaultNode;
   }
@@ -112,7 +112,7 @@ export class CompositeListTreeHandler<T extends ArrayLike<any>> extends Composit
   pop(target: TreeBacking): T[number] {
     const length = this.getLength(target);
     const value = this.get(target, length - 1);
-    super.set(target, length - 1, new TreeBacking(zeroNode(BigInt(0))));
+    super.set(target, length - 1, new TreeBacking(zeroNode(0)));
     this.setLength(target, length - 1);
     return value;
   }

--- a/packages/ssz/src/backings/tree/vector.ts
+++ b/packages/ssz/src/backings/tree/vector.ts
@@ -2,7 +2,6 @@ import {Node, TreeBacking, subtreeFillToLength, zeroNode} from "@chainsafe/merkl
 
 import {BasicVectorType, CompositeVectorType} from "../../types";
 import {BasicArrayTreeHandler, CompositeArrayTreeHandler} from "./array";
-import {TreeBackedValue} from "./abstract";
 
 export class BasicVectorTreeHandler<T extends ArrayLike<any>> extends BasicArrayTreeHandler<T> {
   _type: BasicVectorType<T>;
@@ -10,9 +9,9 @@ export class BasicVectorTreeHandler<T extends ArrayLike<any>> extends BasicArray
   defaultNode(): Node {
     if (!this._defaultNode) {
       this._defaultNode = subtreeFillToLength(
-        zeroNode(BigInt(0)),
-        BigInt(this.depth()),
-        BigInt(this._type.chunkCount())
+        zeroNode(0),
+        this.depth(),
+        this._type.chunkCount()
       );
     }
     return this._defaultNode;
@@ -28,8 +27,8 @@ export class CompositeVectorTreeHandler<T extends ArrayLike<any>> extends Compos
     if (!this._defaultNode) {
       this._defaultNode = subtreeFillToLength(
         this._type.elementType.tree.defaultNode(),
-        BigInt(this.depth()),
-        BigInt(this._type.length)
+        this.depth(),
+        this._type.length
       );
     }
     return this._defaultNode;


### PR DESCRIPTION
Changed merkle-tree api slightly, to use regular numbers where allowable (like depth). Also see PR in merkle-tree library repo.