### PR TITLE
Fix bls-wasm exception handling

### DIFF
--- a/packages/bls/package.json
+++ b/packages/bls/package.json
@@ -39,8 +39,7 @@
     "@chainsafe/bls-keygen": "^0.0.2",
     "@chainsafe/eth2-bls-wasm": "^0.2.0",
     "@chainsafe/eth2.0-types": "^0.2.0",
-    "assert": "^1.4.1",
-    "bls-wasm": "^0.2.7"
+    "assert": "^1.4.1"
   },
   "devDependencies": {
     "@chainsafe/benchmark-utils": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,10 +2907,6 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bls-wasm@^0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/bls-wasm/-/bls-wasm-0.2.7.tgz#7bd75276649b90cc8dade959711c7d71d3ae83ba"
-
 bluebird@^2.9.34:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"


### PR DESCRIPTION
This will stop bls from messing with exceptions and stacktraces.
Also removes extra dep