### PR TITLE
Ensure attestation slot and target epoch are coherent

### DIFF
--- a/packages/eth2.0-state-transition/src/block/operations/attestation.ts
+++ b/packages/eth2.0-state-transition/src/block/operations/attestation.ts
@@ -9,6 +9,7 @@ import {Attestation, BeaconState, PendingAttestation,} from "@chainsafe/eth2.0-t
 import {IBeaconConfig} from "@chainsafe/eth2.0-config";
 
 import {
+  computeEpochAtSlot,
   getBeaconProposerIndex,
   getBeaconCommittee,
   getCurrentEpoch,
@@ -29,6 +30,7 @@ export function processAttestation(
   const data = attestation.data;
   assert(data.index < getCommitteeCountAtSlot(config, state, data.slot));
   assert(data.target.epoch === previousEpoch || data.target.epoch === currentEpoch);
+  assert(data.target.epoch === computeEpochAtSlot(config, data.slot));
 
   const committee = getBeaconCommittee(config, state, data.slot, data.index);
   assert(


### PR DESCRIPTION
See ethereum/eth2.0-specs#1509

Our fork choice already has the additional check, so we only needed to update attestation processing in the state transition