### PR TITLE
Fix libp2p unit test fail and suspend in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,5 @@ jobs:
       run: $(yarn global bin)/lerna bootstrap
     - name: Check types
       run: $(yarn global bin)/lerna run check-types
-    - name: Lint
-      run: $(yarn global bin)/lerna run lint
     - name: Unit tests
       run: $(yarn global bin)/lerna run test:unit
-    - name: Coverage
-      run: $(yarn global bin)/lerna run coverage
-    - name: E2e tests
-      run: $(yarn global bin)/lerna run test:e2e
-    - name: Spec tests
-      run: $(yarn global bin)/lerna run test:spec-min

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,5 +14,13 @@ jobs:
       run: $(yarn global bin)/lerna bootstrap
     - name: Check types
       run: $(yarn global bin)/lerna run check-types
+    - name: Lint
+      run: $(yarn global bin)/lerna run lint
     - name: Unit tests
       run: $(yarn global bin)/lerna run test:unit
+    - name: Coverage
+      run: $(yarn global bin)/lerna run coverage
+    - name: E2e tests
+      run: $(yarn global bin)/lerna run test:e2e
+    - name: Spec tests
+      run: $(yarn global bin)/lerna run test:spec-min

--- a/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
+++ b/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
@@ -13,54 +13,51 @@ describe("[network] nodejs libp2p", () => {
     assert.equal(node.isStarted(), false);
   });
   it.only("can connect/disconnect to a peer", async function ()  {
-    this.timeout(5000 * 100);
-    for (let i = 0; i < 100; i++) {
-      // setup
-      const nodeA: NodejsNode = await createNode(multiaddr);
-      const nodeB: NodejsNode = await createNode(multiaddr);
-  
-      await Promise.all([
-        nodeA.start(),
-        nodeB.start(),
-      ]);
-  
-      // connect
-      await Promise.all(
-        [
-          new Promise((resolve, reject) => {
-            const t = setTimeout(reject, 1000, '!!! connect timed out');
-            nodeB.once("peer:connect", () => {
-              clearTimeout(t);
-              resolve();
-            });
-          }),
-          nodeA.dial(nodeB.peerInfo),
-        ]
-      );
-  
-      // test connection
-      // @ts-ignore
-      assert(nodeA.registrar.getConnection(nodeB.peerInfo));
-      // @ts-ignore
-      assert(nodeB.registrar.getConnection(nodeA.peerInfo));
-  
-      // disconnect
-      const p = new Promise(resolve => nodeB.once("peer:disconnect", resolve));
-      await new Promise(resolve => setTimeout(resolve, 100));
-      await nodeA.hangUp(nodeB.peerInfo);
-      await p;
-  
-      // test disconnection
-      // @ts-ignore
-      assert(!nodeA.registrar.getConnection(nodeB.peerInfo));
-      // @ts-ignore
-      assert(!nodeB.registrar.getConnection(nodeA.peerInfo));
-      // teardown
-      await Promise.all([
-        nodeA.stop(),
-        nodeB.stop()
-      ]);
-      console.log('@@@ finished connect/disconnect test ', i);
-    }
+    this.timeout(5000);
+    // setup
+    const nodeA: NodejsNode = await createNode(multiaddr);
+    const nodeB: NodejsNode = await createNode(multiaddr);
+
+    await Promise.all([
+      nodeA.start(),
+      nodeB.start(),
+    ]);
+
+    // connect
+    await Promise.all(
+      [
+        new Promise((resolve, reject) => {
+          const t = setTimeout(reject, 1000, '!!! connect timed out');
+          nodeB.once("peer:connect", () => {
+            clearTimeout(t);
+            resolve();
+          });
+        }),
+        nodeA.dial(nodeB.peerInfo),
+      ]
+    );
+
+    // test connection
+    // @ts-ignore
+    assert(nodeA.registrar.getConnection(nodeB.peerInfo));
+    // @ts-ignore
+    assert(nodeB.registrar.getConnection(nodeA.peerInfo));
+
+    // disconnect
+    const p = new Promise(resolve => nodeB.once("peer:disconnect", resolve));
+    await new Promise(resolve => setTimeout(resolve, 100));
+    await nodeA.hangUp(nodeB.peerInfo);
+    await p;
+
+    // test disconnection
+    // @ts-ignore
+    assert(!nodeA.registrar.getConnection(nodeB.peerInfo));
+    // @ts-ignore
+    assert(!nodeB.registrar.getConnection(nodeA.peerInfo));
+    // teardown
+    await Promise.all([
+      nodeA.stop(),
+      nodeB.stop()
+    ]);
   });
 });

--- a/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
+++ b/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
@@ -27,7 +27,7 @@ describe("[network] nodejs libp2p", () => {
     await Promise.all(
       [
         new Promise((resolve, reject) => {
-          const t = setTimeout(reject, 1000, '!!! connect timed out');
+          const t = setTimeout(reject, 1000, 'connection timed out');
           nodeB.once("peer:connect", () => {
             clearTimeout(t);
             resolve();

--- a/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
+++ b/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
@@ -13,7 +13,7 @@ describe("[network] nodejs libp2p", () => {
     assert.equal(node.isStarted(), false);
   });
   it.only("can connect/disconnect to a peer", async function ()  {
-    this.timeout(5000 * 100 * 2);
+    this.timeout(5000 * 100);
     for (let i = 0; i < 100; i++) {
       // setup
       const nodeA: NodejsNode = await createNode(multiaddr);
@@ -25,14 +25,26 @@ describe("[network] nodejs libp2p", () => {
       ]);
   
       // connect
-      await nodeA.dial(nodeB.peerInfo);
-      await new Promise((resolve, reject) => {
-        const t = setTimeout(reject, 1000 * 2, '!!! connect timed out');
-        nodeB.once("peer:connect", () => {
-          clearTimeout(t);
-          resolve();
-        });
-      });
+      await Promise.all(
+        [
+          new Promise((resolve, reject) => {
+            const t = setTimeout(reject, 1000, '!!! connect timed out');
+            nodeB.once("peer:connect", () => {
+              clearTimeout(t);
+              resolve();
+            });
+          }),
+          nodeA.dial(nodeB.peerInfo),
+        ]
+      );
+      // await nodeA.dial(nodeB.peerInfo);
+      // await new Promise((resolve, reject) => {
+      //   const t = setTimeout(reject, 1000 * 2, '!!! connect timed out');
+      //   nodeB.once("peer:connect", () => {
+      //     clearTimeout(t);
+      //     resolve();
+      //   });
+      // });
   
   
       // test connection

--- a/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
+++ b/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
@@ -13,7 +13,7 @@ describe("[network] nodejs libp2p", () => {
     assert.equal(node.isStarted(), false);
   });
   it("can connect/disconnect to a peer", async function ()  {
-    this.timeout(5000)
+    this.timeout(5000);
     // setup
     const nodeA: NodejsNode = await createNode(multiaddr);
     const nodeB: NodejsNode = await createNode(multiaddr);
@@ -44,7 +44,7 @@ describe("[network] nodejs libp2p", () => {
     const p = new Promise(resolve => nodeB.once("peer:disconnect", resolve));
     await new Promise(resolve => setTimeout(resolve, 100));
     await nodeA.hangUp(nodeB.peerInfo);
-    await p
+    await p;
 
     // test disconnection
     // @ts-ignore

--- a/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
+++ b/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
@@ -37,15 +37,6 @@ describe("[network] nodejs libp2p", () => {
           nodeA.dial(nodeB.peerInfo),
         ]
       );
-      // await nodeA.dial(nodeB.peerInfo);
-      // await new Promise((resolve, reject) => {
-      //   const t = setTimeout(reject, 1000 * 2, '!!! connect timed out');
-      //   nodeB.once("peer:connect", () => {
-      //     clearTimeout(t);
-      //     resolve();
-      //   });
-      // });
-  
   
       // test connection
       // @ts-ignore

--- a/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
+++ b/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
@@ -13,7 +13,7 @@ describe("[network] nodejs libp2p", () => {
     assert.equal(node.isStarted(), false);
   });
   it.only("can connect/disconnect to a peer", async function ()  {
-    this.timeout(5000 * 100);
+    this.timeout(5000 * 100 * 2);
     for (let i = 0; i < 100; i++) {
       // setup
       const nodeA: NodejsNode = await createNode(multiaddr);
@@ -27,7 +27,7 @@ describe("[network] nodejs libp2p", () => {
       // connect
       await nodeA.dial(nodeB.peerInfo);
       await new Promise((resolve, reject) => {
-        const t = setTimeout(reject, 1000);
+        const t = setTimeout(reject, 1000 * 2, '!!! connect timed out');
         nodeB.once("peer:connect", () => {
           clearTimeout(t);
           resolve();

--- a/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
+++ b/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
@@ -12,7 +12,7 @@ describe("[network] nodejs libp2p", () => {
     await node.stop();
     assert.equal(node.isStarted(), false);
   });
-  it.only("can connect/disconnect to a peer", async function ()  {
+  it("can connect/disconnect to a peer", async function ()  {
     this.timeout(5000);
     // setup
     const nodeA: NodejsNode = await createNode(multiaddr);

--- a/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
+++ b/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
@@ -12,49 +12,52 @@ describe("[network] nodejs libp2p", () => {
     await node.stop();
     assert.equal(node.isStarted(), false);
   });
-  it("can connect/disconnect to a peer", async function ()  {
-    this.timeout(5000);
-    // setup
-    const nodeA: NodejsNode = await createNode(multiaddr);
-    const nodeB: NodejsNode = await createNode(multiaddr);
-
-    await Promise.all([
-      nodeA.start(),
-      nodeB.start(),
-    ]);
-
-    // connect
-    await nodeA.dial(nodeB.peerInfo);
-    await new Promise((resolve, reject) => {
-      const t = setTimeout(reject, 1000);
-      nodeB.once("peer:connect", () => {
-        clearTimeout(t);
-        resolve();
+  it.only("can connect/disconnect to a peer", async function ()  {
+    this.timeout(5000 * 100);
+    for (let i = 0; i < 100; i++) {
+      // setup
+      const nodeA: NodejsNode = await createNode(multiaddr);
+      const nodeB: NodejsNode = await createNode(multiaddr);
+  
+      await Promise.all([
+        nodeA.start(),
+        nodeB.start(),
+      ]);
+  
+      // connect
+      await nodeA.dial(nodeB.peerInfo);
+      await new Promise((resolve, reject) => {
+        const t = setTimeout(reject, 1000);
+        nodeB.once("peer:connect", () => {
+          clearTimeout(t);
+          resolve();
+        });
       });
-    });
-
-
-    // test connection
-    // @ts-ignore
-    assert(nodeA.registrar.getConnection(nodeB.peerInfo));
-    // @ts-ignore
-    assert(nodeB.registrar.getConnection(nodeA.peerInfo));
-
-    // disconnect
-    const p = new Promise(resolve => nodeB.once("peer:disconnect", resolve));
-    await new Promise(resolve => setTimeout(resolve, 100));
-    await nodeA.hangUp(nodeB.peerInfo);
-    await p;
-
-    // test disconnection
-    // @ts-ignore
-    assert(!nodeA.registrar.getConnection(nodeB.peerInfo));
-    // @ts-ignore
-    assert(!nodeB.registrar.getConnection(nodeA.peerInfo));
-    // teardown
-    await Promise.all([
-      nodeA.stop(),
-      nodeB.stop()
-    ]);
+  
+  
+      // test connection
+      // @ts-ignore
+      assert(nodeA.registrar.getConnection(nodeB.peerInfo));
+      // @ts-ignore
+      assert(nodeB.registrar.getConnection(nodeA.peerInfo));
+  
+      // disconnect
+      const p = new Promise(resolve => nodeB.once("peer:disconnect", resolve));
+      await new Promise(resolve => setTimeout(resolve, 100));
+      await nodeA.hangUp(nodeB.peerInfo);
+      await p;
+  
+      // test disconnection
+      // @ts-ignore
+      assert(!nodeA.registrar.getConnection(nodeB.peerInfo));
+      // @ts-ignore
+      assert(!nodeB.registrar.getConnection(nodeA.peerInfo));
+      // teardown
+      await Promise.all([
+        nodeA.stop(),
+        nodeB.stop()
+      ]);
+      console.log('@@@ finished connect/disconnect test ', i);
+    }
   });
 });


### PR DESCRIPTION
In CI environment, sometimes the libp2p unit test failed and unit test get suspended.
## Root Cause
+ It's too late to wait for `peer:connect`
## Fix
+ Use `Promise.all`