### PR TITLE
De-isolate Isolated Unit Test

### DIFF
--- a/packages/lodestar/test/unit/chain/attestation.test.ts
+++ b/packages/lodestar/test/unit/chain/attestation.test.ts
@@ -99,7 +99,7 @@ describe("AttestationProcessor", function () {
     }
   });
 
-  it.only("processAttestation - should call forkChoice", async () => {
+  it("processAttestation - should call forkChoice", async () => {
     const attestation = generateEmptyAttestation();
     const attestationHash = hashTreeRoot(config.types.Attestation, attestation);
     const block = generateEmptySignedBlock();


### PR DESCRIPTION
An `it.only` block was accidentally merged into master. This changes it back to `it` so all Lodestar unit tests can be ran.