### PR TITLE
Fork choice: make sure head() have correct justified/finalized epoch like the store

### DIFF
--- a/packages/lodestar/src/chain/forkChoice/statefulDag/attestationAggregator.ts
+++ b/packages/lodestar/src/chain/forkChoice/statefulDag/attestationAggregator.ts
@@ -3,33 +3,9 @@
  * @module chain/forkChoice
  */
 
-import {Gwei, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {RootHex, AggregatedAttestation, ForkChoiceAttestation} from "./interface";
 
-
-/**
- * Root is a block root as a hex string
- *
- * Used here for light weight and easy comparison
- */
-export type RootHex = string;
-
-/**
- * Minimal representation of attsetation for the purposes of fork choice
- */
-export interface ForkChoiceAttestation {
-  target: RootHex;
-  attester: ValidatorIndex;
-  weight: Gwei;
-}
-
-/**
- * Attestation aggregated across participants
- */
-export interface AggregatedAttestation {
-  target: RootHex;
-  weight: Gwei;
-  prevWeight: Gwei;
-}
 
 /**
  * Keep track of the latest attestations per validator

--- a/packages/lodestar/src/chain/forkChoice/statefulDag/interface.ts
+++ b/packages/lodestar/src/chain/forkChoice/statefulDag/interface.ts
@@ -1,0 +1,48 @@
+/* eslint-disable @typescript-eslint/interface-name-prefix */
+import {Slot, Epoch, ValidatorIndex, Gwei} from "@chainsafe/lodestar-types";
+import {Node} from "./lmdGhost";
+
+/**
+ * Interface to initialize a Node.
+ */
+export interface NodeInfo {
+  slot: Slot;
+  blockRoot: RootHex;
+  parent: Node;
+  justifiedCheckpoint: HexCheckpoint;
+  finalizedCheckpoint: HexCheckpoint;
+}
+
+/**
+ * Root is a block root as a hex string
+ *
+ * Used here for light weight and easy comparison
+ */
+export type RootHex = string;
+
+/**
+ * Minimal representation of attsetation for the purposes of fork choice
+ */
+export interface ForkChoiceAttestation {
+  target: RootHex;
+  attester: ValidatorIndex;
+  weight: Gwei;
+}
+
+/**
+ * Attestation aggregated across participants
+ */
+export interface AggregatedAttestation {
+  target: RootHex;
+  weight: Gwei;
+  prevWeight: Gwei;
+}
+
+/**
+ * Same to Checkpoint but with root as hex string
+ * this helps checkpoint's check inside node without a config
+ */
+export interface HexCheckpoint {
+  rootHex: RootHex;
+  epoch: Epoch;
+}

--- a/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
@@ -14,6 +14,7 @@ import {ILMDGHOST} from "../interface";
 import {AttestationAggregator} from "./attestationAggregator";
 import {sleep} from "../../../util/sleep";
 import {RootHex, NodeInfo, HexCheckpoint} from "./interface";
+import {GENESIS_EPOCH} from "../../../constants";
 
 
 /**
@@ -405,15 +406,27 @@ export class StatefulDagLMDGHOST implements ILMDGHOST {
     return {root: fromHexString(this.finalized.node.blockRoot), epoch: this.finalized.epoch};
   }
 
+  /**
+   * Don't want to check the initial justified/finalized checkpoint for the 1st epoch
+   * because initial state does not have checkpoints in database.
+   * First addBlock (for genesis block) call has checkpoints but from the 2nd call in the
+   * first epoch it has ZERO finalized/justified checkpoints.
+   */
   private getJustifiedCheckpoint(): HexCheckpoint {
-    if (!this.justified) {
+    if (this.finalized.epoch === GENESIS_EPOCH) {
       return null;
     }
     return {rootHex: this.justified.node.blockRoot, epoch: this.justified.epoch};
   }
 
+  /**
+   * Don't want to check the initial justified/finalized checkpoint for the 1st epoch
+   * because initial state does not have checkpoints in database.
+   * First addBlock (for genesis block) call has checkpoints but from the 2nd call in the
+   * first epoch it has ZERO finalized/justified checkpoints.
+   */
   private getFinalizedCheckpoint(): HexCheckpoint {
-    if (!this.finalized) {
+    if (this.finalized.epoch === GENESIS_EPOCH) {
       return null;
     }
     return {rootHex: this.finalized.node.blockRoot, epoch: this.finalized.epoch};

--- a/packages/lodestar/test/unit/chain/forkChoice/attestationAggregator.test.ts
+++ b/packages/lodestar/test/unit/chain/forkChoice/attestationAggregator.test.ts
@@ -2,7 +2,6 @@ import {assert} from "chai";
 
 import {
   AttestationAggregator,
-  ForkChoiceAttestation,
 } from "../../../../src/chain/forkChoice/statefulDag/attestationAggregator";
 
 

--- a/packages/lodestar/test/unit/chain/forkChoice/statefulDag.test.ts
+++ b/packages/lodestar/test/unit/chain/forkChoice/statefulDag.test.ts
@@ -14,6 +14,7 @@ describe("StatefulDagLMDGHOST", () => {
   const f = Buffer.from("f");
   const g = Buffer.from("g");
   const h = Buffer.from("h");
+  const i = Buffer.from("i");
   let clock: SinonFakeTimers;
 
   beforeEach(() => {
@@ -35,12 +36,12 @@ describe("StatefulDagLMDGHOST", () => {
      *           e
      */
     const lmd = new StatefulDagLMDGHOST(config);
-    lmd.addBlock(1, a, genesis, { root: a, epoch: 0 }, { root: a, epoch: 0 });
-    lmd.addBlock(2, b, a);
-    lmd.addBlock(3, c, b);
-    lmd.addBlock(3, d, b);
-    lmd.addBlock(3, e, b);
-    lmd.addBlock(4, f, c);
+    lmd.addBlock(1, a, genesis, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(2, b, a, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(3, c, b, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(3, d, b, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(3, e, b, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(4, f, c, {root: a, epoch: 0}, {root: a, epoch: 0});
     const head = lmd.head();
     assert.deepEqual(head, f);
   });
@@ -56,12 +57,12 @@ describe("StatefulDagLMDGHOST", () => {
      */
     const lmd = new StatefulDagLMDGHOST(config);
     let head: Uint8Array;
-    lmd.addBlock(1, a, genesis, { root: a, epoch: 0 }, { root: a, epoch: 0 });
-    lmd.addBlock(2, b, a);
-    lmd.addBlock(3, c, b);
-    lmd.addBlock(3, d, b);
-    lmd.addBlock(3, e, b);
-    lmd.addBlock(4, f, c);
+    lmd.addBlock(1, a, genesis, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(2, b, a, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(3, c, b, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(3, d, b, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(3, e, b, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(4, f, c, {root: a, epoch: 0}, {root: a, epoch: 0});
     // add vote to e
     lmd.addAttestation(e, 1, 3n);
     head = lmd.head();
@@ -75,7 +76,7 @@ describe("StatefulDagLMDGHOST", () => {
     head = lmd.head();
     assert.deepEqual(head, d, "head should be d");
     // add g block
-    lmd.addBlock(4, g, d);
+    lmd.addBlock(4, g, d, {root: a, epoch: 0}, {root: a, epoch: 0});
     head = lmd.head();
     assert.deepEqual(head, g, "head should be g");
     // add vote to c
@@ -103,13 +104,13 @@ describe("StatefulDagLMDGHOST", () => {
      */
     const lmd = new StatefulDagLMDGHOST(config);
     let head: Uint8Array;
-    lmd.addBlock(1, a, genesis, { root: a, epoch: 0 }, { root: a, epoch: 0 });
-    lmd.addBlock(2, b, a);
-    lmd.addBlock(3, c, b);
-    lmd.addBlock(4, d, c);
-    lmd.addBlock(5, e, d);
-    lmd.addBlock(2, f, a);
-    lmd.addBlock(3, g, f);
+    lmd.addBlock(1, a, genesis, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(2, b, a, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(3, c, b, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(4, d, c, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(5, e, d, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(2, f, a, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(3, g, f, {root: a, epoch: 0}, {root: a, epoch: 0});
     lmd.addAttestation(e, 1, 3n);
     head = lmd.head();
     assert.deepEqual(head, e, "head should be e");
@@ -135,13 +136,13 @@ describe("StatefulDagLMDGHOST", () => {
      */
     const lmd = new StatefulDagLMDGHOST(config);
     let head: Uint8Array;
-    lmd.addBlock(1, a, genesis, { root: a, epoch: 0 }, { root: a, epoch: 0 });
-    lmd.addBlock(2, b, a);
-    lmd.addBlock(3, c, a);
-    lmd.addBlock(4, d, b);
-    lmd.addBlock(5, e, b);
-    lmd.addBlock(2, f, c);
-    lmd.addBlock(3, g, c);
+    lmd.addBlock(1, a, genesis, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(2, b, a, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(3, c, a, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(4, d, b, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(5, e, b, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(2, f, c, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(3, g, c, {root: a, epoch: 0}, {root: a, epoch: 0});
     lmd.addAttestation(e, 1, 3n);
     head = lmd.head();
     assert.deepEqual(head, e, "head should be e");
@@ -152,16 +153,15 @@ describe("StatefulDagLMDGHOST", () => {
 
   it("should update justified block initially", () => {
     const lmd = new StatefulDagLMDGHOST(config);
-    lmd.addBlock(1, a, genesis);
-    assert(lmd.shouldUpdateJustifiedCheckpoint(a) === true, "should return true")
+    assert(lmd.shouldUpdateJustifiedCheckpoint(a) === true, "should return true");
   });
 
   it("should update justified block within SAFE_SLOTS_TO_UPDATE_JUSTIFIED", () => {
     const genesisTime = Math.floor(Date.now() / 1000) - (config.params.SAFE_SLOTS_TO_UPDATE_JUSTIFIED - 1) * config.params.SECONDS_PER_SLOT;
     const lmd = new StatefulDagLMDGHOST(config);
     lmd.start(genesisTime);
-    lmd.addBlock(1, a, genesis);
-    lmd.addBlock(2, b, a);
+    lmd.addBlock(1, a, genesis, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(2, b, a, {root: a, epoch: 0}, {root: a, epoch: 0});
     assert(lmd.shouldUpdateJustifiedCheckpoint(b) === true, "should return true");
   });
 
@@ -170,9 +170,9 @@ describe("StatefulDagLMDGHOST", () => {
    */
   it("should not update justified block after SAFE_SLOTS_TO_UPDATE_JUSTIFIED - 1", () => {
     const lmd = new StatefulDagLMDGHOST(config);
-    lmd.addBlock(1, a, genesis);
-    lmd.addBlock(2, b, a, { root: b, epoch: 0 });
-    const genesisTime = Math.floor(Date.now() / 1000) - (config.params.SAFE_SLOTS_TO_UPDATE_JUSTIFIED + 2) * config.params.SECONDS_PER_SLOT;
+    lmd.addBlock(1, a, genesis, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(2, b, a, {root: b, epoch: 0}, {root: b, epoch: 0});
+    const genesisTime = Math.floor(Date.now()/1000) - (config.params.SAFE_SLOTS_TO_UPDATE_JUSTIFIED + 2) * config.params.SECONDS_PER_SLOT;
     lmd.start(genesisTime);
     // a slot is smaller than justified block slot (b)
     assert(lmd.shouldUpdateJustifiedCheckpoint(a) === false, "should return false");
@@ -191,12 +191,124 @@ describe("StatefulDagLMDGHOST", () => {
    */
   it("should not update justified block after SAFE_SLOTS_TO_UPDATE_JUSTIFIED - 2", () => {
     const lmd = new StatefulDagLMDGHOST(config);
-    lmd.addBlock(1, a, genesis);
-    lmd.addBlock(2, b, a, { root: b, epoch: 0 });
-    lmd.addBlock(3, c, a);
-    const genesisTime = Math.floor(Date.now() / 1000) - (config.params.SAFE_SLOTS_TO_UPDATE_JUSTIFIED + 2) * config.params.SECONDS_PER_SLOT;
+    lmd.addBlock(1, a, genesis, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(2, b, a, {root: b, epoch: 1}, {root: b, epoch: 1});
+    lmd.addBlock(3, c, a, {root: b, epoch: 1}, {root: b, epoch: 1});
+    const genesisTime = Math.floor(Date.now()/1000) - (config.params.SAFE_SLOTS_TO_UPDATE_JUSTIFIED + 2) * config.params.SECONDS_PER_SLOT;
     lmd.start(genesisTime);
     // c is a conflicted justified block.
     assert(lmd.shouldUpdateJustifiedCheckpoint(c) === false, "should return false");
+  });
+
+  /**
+   *                g
+   *               /
+   *              d -- e -- h
+   *             /
+   *            /
+   * a -- b -- c
+   *            \
+   *             \
+   *              f
+   */
+  it("should switch best target - bad best target has no sibling", () => {
+    const lmd = new StatefulDagLMDGHOST(config);
+    lmd.addBlock(1, a, genesis, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(2, b, a, {root: b, epoch: 1}, {root: a, epoch: 0});
+    lmd.addBlock(3, c, b, {root: b, epoch: 1}, {root: a, epoch: 0});
+    lmd.addBlock(4, d, c, {root: b, epoch: 1}, {root: a, epoch: 0});
+    lmd.addBlock(5, e, d, {root: b, epoch: 1}, {root: a, epoch: 0});
+    // add vote for d
+    lmd.addAttestation(d, 1, 3n);
+    assert(lmd.getNode(d).bestTarget === lmd.getNode(e), "e should be best target of d");
+    assert(lmd.getNode(c).bestTarget === lmd.getNode(e), "e should be best target of c too");
+    assert(lmd.getNode(b).bestTarget === lmd.getNode(e), "e should be best target of b too");
+    assert(lmd.getNode(d).bestChild === lmd.getNode(e), "e should be best child of d");
+    assert.deepEqual(lmd.head(), e);
+
+    // f set new justified/finalized check point
+    lmd.addBlock(6, f, c, {root: c, epoch: 2}, {root: b, epoch: 1});
+    assert(lmd.getNode(d).bestChild === null, "e is not best target so d has no best child");
+    // so e is not best target anymore although d has more votes
+    assert.deepEqual(lmd.head(), f, "f should be the only possible head since it has no conflict justified/finalized epoch");
+
+    // add g as head candidate with good justified/finalized
+    lmd.addBlock(7, g, d, {root: c, epoch: 2}, {root: b, epoch: 1});
+    assert(lmd.getNode(d).bestChild === lmd.getNode(g), "g should be best child of d");
+    assert.deepEqual(lmd.head(), g, "g should be the head because d has more votes anyway");
+
+    // add h as as head candidate with good justified/finalized
+    lmd.addBlock(8, h, e, {root: c, epoch: 2}, {root: b, epoch: 1});
+    // make e has more votes than g
+    lmd.addAttestation(e, 2, 3n);
+    // e branch is used to be not eligible for bestTarget but now it's good thanks for h
+    assert.deepEqual(lmd.head(), h, "h should be the head because e has more votes");
+  });
+
+  /**
+   *                f (bad)
+   *               /  (bad)
+   *              d -- e -- h
+   *             /
+   *            /
+   * a -- b -- c
+   *            \
+   *             \
+   *              g (conflict epochs)
+   */
+  it("should switch best target - bad best target has bad sibling too", () => {
+    const lmd = new StatefulDagLMDGHOST(config);
+    lmd.addBlock(1, a, genesis, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(2, b, a, {root: b, epoch: 1}, {root: a, epoch: 0});
+    lmd.addBlock(3, c, b, {root: b, epoch: 1}, {root: a, epoch: 0});
+    lmd.addBlock(4, d, c, {root: b, epoch: 1}, {root: a, epoch: 0});
+    lmd.addBlock(5, e, d, {root: b, epoch: 1}, {root: a, epoch: 0});
+    lmd.addBlock(6, f, d, {root: b, epoch: 1}, {root: a, epoch: 0});
+    // add vote for e
+    lmd.addAttestation(e, 1, 3n);
+    assert.deepEqual(lmd.head(), e, "e should be the head initially");
+
+    // g is added with conflict epochs
+    lmd.addBlock(7, g, c, {root: c, epoch: 2}, {root: b, epoch: 1});
+    assert.deepEqual(lmd.head(), g, "g should be the head because it has correct epochs");
+
+    // h is added with good epochs
+    lmd.addBlock(8, h, e, {root: c, epoch: 2}, {root: b, epoch: 1});
+    // since we voted for e already, h should be the new head
+    assert.deepEqual(lmd.head(), h, "h should be the head because e was voted");
+  });
+
+  /**
+   *                f (bad)
+   *               /
+   *              d -- e -- i (bad)
+   *             /
+   *            /
+   * a -- b -- c -- g (bad)
+   *            \
+   *             h (conflict epochs)
+   */
+  it("should switch best target - all best targets have conflict epochs", () => {
+    const lmd = new StatefulDagLMDGHOST(config);
+    lmd.addBlock(1, a, genesis, {root: a, epoch: 0}, {root: a, epoch: 0});
+    lmd.addBlock(2, b, a, {root: b, epoch: 1}, {root: a, epoch: 0});
+    lmd.addBlock(3, c, b, {root: b, epoch: 1}, {root: a, epoch: 0});
+    lmd.addBlock(4, d, c, {root: b, epoch: 1}, {root: a, epoch: 0});
+    lmd.addBlock(5, e, d, {root: b, epoch: 1}, {root: a, epoch: 0});
+    lmd.addBlock(6, f, d, {root: b, epoch: 1}, {root: a, epoch: 0});
+    lmd.addBlock(7, g, c, {root: b, epoch: 1}, {root: a, epoch: 0});
+    // add vote for g
+    lmd.addAttestation(g, 1, 3n);
+    assert.deepEqual(lmd.head(), g, "g should be the head initially");
+
+    // h is added with conflict epochs
+    lmd.addBlock(8, h, c, {root: c, epoch: 2}, {root: b, epoch: 1});
+    assert.deepEqual(lmd.head(), h, "h should be the head because it has correct epochs");
+
+    // i is added with correct new epoch
+    lmd.addBlock(9, i, e, {root: c, epoch: 2}, {root: b, epoch: 1});
+    // add vote for e
+    lmd.addAttestation(e, 2, 6n);
+    assert.deepEqual(lmd.head(), i, "i should be the head");
   });
 });


### PR DESCRIPTION
## Goal
+ Close #637 
## Approach
+ Maintain justified & finalized epochs in our "store"
+ Maintain justified & finalized epochs in our node
+ Change weighing system taking justified & finalized epochs of best target into account
+ When adding block, if it causes any best targets to be epoch conflict, we do "soft unlink" by setting `bestChild=null`, this causes those best targets unreachable from the justified root
+ When adding block, relink if those best target's epochs now correct (and previously it's not)