### PR TITLE
Block process stream

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,7 +2,7 @@ version: "2"         # required to adjust maintainability checks
 checks:
   argument-count:
     config:
-      threshold: 5
+      threshold: 6
   complex-logic:
     config:
       threshold: 7
@@ -17,7 +17,7 @@ checks:
       threshold: 20
   method-lines:
     config:
-      threshold: 25
+      threshold: 30
   nested-control-flow:
     config:
       threshold: 4
@@ -26,7 +26,7 @@ checks:
       threshold: 10
   similar-code:
     config:
-      threshold: 85
+      threshold: 95
   identical-code:
     config:
       threshold: 95

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -26,7 +26,7 @@ checks:
       threshold: 10
   similar-code:
     config:
-      threshold: 80
+      threshold: 85
   identical-code:
     config:
       threshold: 95

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -49,6 +49,8 @@
     "@chainsafe/lodestar-validator": "^0.5.0",
     "@chainsafe/ssz": "0.6.1",
     "@types/async": "^3.0.1",
+    "abort-controller": "^3.0.0",
+    "abortable-iterator": "^3.0.0",
     "assert": "^2.0.0",
     "deepmerge": "^3.2.0",
     "es6-promisify": "6.0.2",

--- a/packages/lodestar/src/chain/blocks/index.ts
+++ b/packages/lodestar/src/chain/blocks/index.ts
@@ -1,0 +1,1 @@
+export * from "./processor";

--- a/packages/lodestar/src/chain/blocks/pool.ts
+++ b/packages/lodestar/src/chain/blocks/pool.ts
@@ -29,12 +29,14 @@ export class BlockPool {
   public onProcessedBlock(block: SignedBeaconBlock): void {
     const key = toHexString(this.config.types.BeaconBlock.hashTreeRoot(block.message));
     const jobs = this.pool.get(key);
-    this.pool.delete(key);
-    jobs
-      .sort((a, b) => a.signedBlock.message.slot - b.signedBlock.message.slot)
-      .forEach((job) => {
-        this.blockProcessorSource.push(job);
-      });
+    if(jobs) {
+      this.pool.delete(key);
+      jobs
+        .sort((a, b) => a.signedBlock.message.slot - b.signedBlock.message.slot)
+        .forEach((job) => {
+          this.blockProcessorSource.push(job);
+        }); 
+    }
   }
 
   private getKey(block: SignedBeaconBlock): string {

--- a/packages/lodestar/src/chain/blocks/pool.ts
+++ b/packages/lodestar/src/chain/blocks/pool.ts
@@ -3,6 +3,7 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {SignedBeaconBlock} from "@chainsafe/lodestar-types";
 import {toHexString} from "@chainsafe/ssz";
 import {Pushable} from "it-pushable";
+import {ChainEventEmitter} from "../interface";
 
 export class BlockPool {
 
@@ -10,10 +11,12 @@ export class BlockPool {
 
   private readonly config: IBeaconConfig;
   private readonly blockProcessorSource: Pushable<IBlockProcessJob>;
+  private readonly eventBus: ChainEventEmitter;
 
-  constructor(config: IBeaconConfig, blockProcessorSource: Pushable<IBlockProcessJob>) {
+  constructor(config: IBeaconConfig, blockProcessorSource: Pushable<IBlockProcessJob>, eventBus: ChainEventEmitter) {
     this.config = config;
     this.blockProcessorSource = blockProcessorSource;
+    this.eventBus = eventBus;
   }
 
   public addPendingBlock(job: IBlockProcessJob): void {
@@ -22,7 +25,7 @@ export class BlockPool {
       this.pool.get(key).push(job);
     } else {
       this.pool.set(key, [job]);
-      //TODO: emit unknown block root event
+      this.eventBus.emit("unknownBlockRoot", job.signedBlock.message.parentRoot);
     }
   }
 

--- a/packages/lodestar/src/chain/blocks/pool.ts
+++ b/packages/lodestar/src/chain/blocks/pool.ts
@@ -1,0 +1,43 @@
+import {IBlockProcessJob} from "../chain";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {SignedBeaconBlock} from "@chainsafe/lodestar-types";
+import {toHexString} from "@chainsafe/ssz";
+import {Pushable} from "it-pushable";
+
+export class BlockPool {
+
+  private pool = new Map<string, IBlockProcessJob[]>();
+
+  private readonly config: IBeaconConfig;
+  private readonly blockProcessorSource: Pushable<IBlockProcessJob>;
+
+  constructor(config: IBeaconConfig, blockProcessorSource: Pushable<IBlockProcessJob>) {
+    this.config = config;
+    this.blockProcessorSource = blockProcessorSource;
+  }
+
+  public addPendingBlock(job: IBlockProcessJob): void {
+    const key = this.getKey(job.signedBlock);
+    if(this.pool.has(key)) {
+      this.pool.get(key).push(job);
+    } else {
+      this.pool.set(key, [job]);
+      //TODO: emit unknown block root event
+    }
+  }
+
+  public onProcessedBlock(block: SignedBeaconBlock): void {
+    const key = toHexString(this.config.types.BeaconBlock.hashTreeRoot(block.message));
+    const jobs = this.pool.get(key);
+    this.pool.delete(key);
+    jobs
+      .sort((a, b) => a.signedBlock.message.slot - b.signedBlock.message.slot)
+      .forEach((job) => {
+        this.blockProcessorSource.push(job);
+      });
+  }
+
+  private getKey(block: SignedBeaconBlock): string {
+    return toHexString(block.message.parentRoot);
+  }
+}

--- a/packages/lodestar/src/chain/blocks/post.ts
+++ b/packages/lodestar/src/chain/blocks/post.ts
@@ -6,8 +6,6 @@ import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {IBeaconMetrics} from "../../metrics";
 import {ChainEventEmitter} from "../interface";
 import {Epoch} from "@chainsafe/lodestar-types/lib";
-import {promisify} from "es6-promisify";
-import Promise = promisify.Promise;
 
 export function postProcess(
   config: IBeaconConfig, db: IBeaconDb, logger: ILogger, metrics: IBeaconMetrics, eventBus: ChainEventEmitter
@@ -47,7 +45,7 @@ async function setJustified(
   if (preJustifiedEpoch < postState.currentJustifiedCheckpoint.epoch) {
     const justifiedBlockRoot = postState.currentJustifiedCheckpoint.root;
     const justifiedBlock = await db.block.get(justifiedBlockRoot.valueOf() as Uint8Array);
-    logger.important(`Epoch ${computeEpochAtSlot(config, justifiedBlock.message.slot)} is justified!`);
+    logger.important(`Epoch ${postState.currentJustifiedCheckpoint.epoch} is justified!`);
     await Promise.all([
       db.chain.setJustifiedStateRoot(justifiedBlock.message.stateRoot.valueOf() as Uint8Array),
       db.chain.setJustifiedBlockRoot(justifiedBlockRoot.valueOf() as Uint8Array),
@@ -64,7 +62,7 @@ async function setFinalized(
   if (preFinalizedEpoch < postState.finalizedCheckpoint.epoch) {
     const finalizedBlockRoot = postState.finalizedCheckpoint.root;
     const finalizedBlock = await db.block.get(finalizedBlockRoot.valueOf() as Uint8Array);
-    logger.important(`Epoch ${computeEpochAtSlot(config, finalizedBlock.message.slot)} is finalized!`);
+    logger.important(`Epoch ${postState.finalizedCheckpoint.epoch} is finalized!`);
     await Promise.all([
       db.chain.setFinalizedStateRoot(finalizedBlock.message.stateRoot.valueOf() as Uint8Array),
       db.chain.setFinalizedBlockRoot(finalizedBlockRoot.valueOf() as Uint8Array),

--- a/packages/lodestar/src/chain/blocks/post.ts
+++ b/packages/lodestar/src/chain/blocks/post.ts
@@ -10,7 +10,7 @@ export function postProcess(
   config: IBeaconConfig, db: IBeaconDb, logger: ILogger, metrics: IBeaconMetrics, eventBus: ChainEventEmitter
 ): (source: AsyncIterable<{preState: BeaconState; postState: BeaconState; block: SignedBeaconBlock}>) => void {
   return (source) => {
-    (async function*() {
+    (async function() {
       for await(const item of source) {
         metrics.currentSlot.set(item.block.message.slot);
         const preSlot = item.preState.slot;

--- a/packages/lodestar/src/chain/blocks/post.ts
+++ b/packages/lodestar/src/chain/blocks/post.ts
@@ -5,6 +5,9 @@ import {IBeaconDb} from "../../db/api";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {IBeaconMetrics} from "../../metrics";
 import {ChainEventEmitter} from "../interface";
+import {Epoch} from "@chainsafe/lodestar-types/lib";
+import {promisify} from "es6-promisify";
+import Promise = promisify.Promise;
 
 export function postProcess(
   config: IBeaconConfig, db: IBeaconDb, logger: ILogger, metrics: IBeaconMetrics, eventBus: ChainEventEmitter
@@ -20,29 +23,10 @@ export function postProcess(
         if (computeEpochAtSlot(config, preSlot) < currentEpoch) {
           const blockRoot = config.types.BeaconBlock.hashTreeRoot(item.block.message);
           eventBus.emit("processedCheckpoint", {epoch: currentEpoch, root: blockRoot});
-          // Update FFG Checkpoints
-          // Newly justified epoch
-          if (preJustifiedEpoch < item.postState.currentJustifiedCheckpoint.epoch) {
-            const justifiedBlockRoot = item.postState.currentJustifiedCheckpoint.root;
-            const justifiedBlock = await db.block.get(justifiedBlockRoot.valueOf() as Uint8Array);
-            logger.important(`Epoch ${computeEpochAtSlot(config, justifiedBlock.message.slot)} is justified!`);
-            await Promise.all([
-              db.chain.setJustifiedStateRoot(justifiedBlock.message.stateRoot.valueOf() as Uint8Array),
-              db.chain.setJustifiedBlockRoot(justifiedBlockRoot.valueOf() as Uint8Array),
-            ]);
-            eventBus.emit("justifiedCheckpoint", item.postState.currentJustifiedCheckpoint);
-          }
-          // Newly finalized epoch
-          if (preFinalizedEpoch < item.postState.finalizedCheckpoint.epoch) {
-            const finalizedBlockRoot = item.postState.finalizedCheckpoint.root;
-            const finalizedBlock = await db.block.get(finalizedBlockRoot.valueOf() as Uint8Array);
-            logger.important(`Epoch ${computeEpochAtSlot(config, finalizedBlock.message.slot)} is finalized!`);
-            await Promise.all([
-              db.chain.setFinalizedStateRoot(finalizedBlock.message.stateRoot.valueOf() as Uint8Array),
-              db.chain.setFinalizedBlockRoot(finalizedBlockRoot.valueOf() as Uint8Array),
-            ]);
-            eventBus.emit("finalizedCheckpoint", item.postState.finalizedCheckpoint);
-          }
+
+          await setJustified(config, db, eventBus, logger, item.postState, preJustifiedEpoch);
+          await setFinalized(config, db, eventBus, logger, item.postState, preFinalizedEpoch);
+
           metrics.previousJustifiedEpoch.set(item.postState.previousJustifiedCheckpoint.epoch);
           metrics.currentJustifiedEpoch.set(item.postState.currentJustifiedCheckpoint.epoch);
           metrics.currentFinalizedEpoch.set(item.postState.finalizedCheckpoint.epoch);
@@ -53,4 +37,38 @@ export function postProcess(
       }
     })();
   };
+}
+
+async function setJustified(
+  config: IBeaconConfig, db: IBeaconDb, eventBus: ChainEventEmitter, logger: ILogger,
+  postState: BeaconState, preJustifiedEpoch: Epoch
+): Promise<void> {
+  // Newly justified epoch
+  if (preJustifiedEpoch < postState.currentJustifiedCheckpoint.epoch) {
+    const justifiedBlockRoot = postState.currentJustifiedCheckpoint.root;
+    const justifiedBlock = await db.block.get(justifiedBlockRoot.valueOf() as Uint8Array);
+    logger.important(`Epoch ${computeEpochAtSlot(config, justifiedBlock.message.slot)} is justified!`);
+    await Promise.all([
+      db.chain.setJustifiedStateRoot(justifiedBlock.message.stateRoot.valueOf() as Uint8Array),
+      db.chain.setJustifiedBlockRoot(justifiedBlockRoot.valueOf() as Uint8Array),
+    ]);
+    eventBus.emit("justifiedCheckpoint", postState.currentJustifiedCheckpoint);
+  }
+}
+
+async function setFinalized(
+  config: IBeaconConfig, db: IBeaconDb, eventBus: ChainEventEmitter, logger: ILogger,
+  postState: BeaconState, preFinalizedEpoch: Epoch
+): Promise<void> {
+  // Newly finalized epoch
+  if (preFinalizedEpoch < postState.finalizedCheckpoint.epoch) {
+    const finalizedBlockRoot = postState.finalizedCheckpoint.root;
+    const finalizedBlock = await db.block.get(finalizedBlockRoot.valueOf() as Uint8Array);
+    logger.important(`Epoch ${computeEpochAtSlot(config, finalizedBlock.message.slot)} is finalized!`);
+    await Promise.all([
+      db.chain.setFinalizedStateRoot(finalizedBlock.message.stateRoot.valueOf() as Uint8Array),
+      db.chain.setFinalizedBlockRoot(finalizedBlockRoot.valueOf() as Uint8Array),
+    ]);
+    eventBus.emit("finalizedCheckpoint", postState.finalizedCheckpoint);
+  }
 }

--- a/packages/lodestar/src/chain/blocks/post.ts
+++ b/packages/lodestar/src/chain/blocks/post.ts
@@ -1,0 +1,56 @@
+import {computeEpochAtSlot, isActiveValidator} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconState, SignedBeaconBlock, Validator} from "@chainsafe/lodestar-types";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IBeaconDb} from "../../db/api";
+import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
+import {IBeaconMetrics} from "../../metrics";
+import {ChainEventEmitter} from "../interface";
+
+export function postProcess(
+  config: IBeaconConfig, db: IBeaconDb, logger: ILogger, metrics: IBeaconMetrics, eventBus: ChainEventEmitter
+): (source: AsyncIterable<{preState: BeaconState; postState: BeaconState; block: SignedBeaconBlock}>) => void {
+  return (source) => {
+    (async function*() {
+      for await(const item of source) {
+        metrics.currentSlot.set(item.block.message.slot);
+        const preSlot = item.preState.slot;
+        const preFinalizedEpoch = item.preState.finalizedCheckpoint.epoch;
+        const preJustifiedEpoch = item.preState.currentJustifiedCheckpoint.epoch;
+        const currentEpoch = computeEpochAtSlot(config, item.postState.slot);
+        if (computeEpochAtSlot(config, preSlot) < currentEpoch) {
+          const blockRoot = config.types.BeaconBlock.hashTreeRoot(item.block.message);
+          eventBus.emit("processedCheckpoint", {epoch: currentEpoch, root: blockRoot});
+          // Update FFG Checkpoints
+          // Newly justified epoch
+          if (preJustifiedEpoch < item.postState.currentJustifiedCheckpoint.epoch) {
+            const justifiedBlockRoot = item.postState.currentJustifiedCheckpoint.root;
+            const justifiedBlock = await db.block.get(justifiedBlockRoot.valueOf() as Uint8Array);
+            logger.important(`Epoch ${computeEpochAtSlot(config, justifiedBlock.message.slot)} is justified!`);
+            await Promise.all([
+              db.chain.setJustifiedStateRoot(justifiedBlock.message.stateRoot.valueOf() as Uint8Array),
+              db.chain.setJustifiedBlockRoot(justifiedBlockRoot.valueOf() as Uint8Array),
+            ]);
+            eventBus.emit("justifiedCheckpoint", item.postState.currentJustifiedCheckpoint);
+          }
+          // Newly finalized epoch
+          if (preFinalizedEpoch < item.postState.finalizedCheckpoint.epoch) {
+            const finalizedBlockRoot = item.postState.finalizedCheckpoint.root;
+            const finalizedBlock = await db.block.get(finalizedBlockRoot.valueOf() as Uint8Array);
+            logger.important(`Epoch ${computeEpochAtSlot(config, finalizedBlock.message.slot)} is finalized!`);
+            await Promise.all([
+              db.chain.setFinalizedStateRoot(finalizedBlock.message.stateRoot.valueOf() as Uint8Array),
+              db.chain.setFinalizedBlockRoot(finalizedBlockRoot.valueOf() as Uint8Array),
+            ]);
+            eventBus.emit("finalizedCheckpoint", item.postState.finalizedCheckpoint);
+          }
+          metrics.previousJustifiedEpoch.set(item.postState.previousJustifiedCheckpoint.epoch);
+          metrics.currentJustifiedEpoch.set(item.postState.currentJustifiedCheckpoint.epoch);
+          metrics.currentFinalizedEpoch.set(item.postState.finalizedCheckpoint.epoch);
+          metrics.currentEpochLiveValidators.set(
+            Array.from(item.postState.validators).filter((v: Validator) => isActiveValidator(v, currentEpoch)).length
+          );
+        }
+      }
+    })();
+  };
+}

--- a/packages/lodestar/src/chain/blocks/process.ts
+++ b/packages/lodestar/src/chain/blocks/process.ts
@@ -1,0 +1,113 @@
+import {IBlockProcessJob} from "../chain";
+import {BeaconState, Root, SignedBeaconBlock} from "@chainsafe/lodestar-types";
+import {stateTransition} from "@chainsafe/lodestar-beacon-state-transition";
+import {toHexString} from "@chainsafe/ssz";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IBeaconDb} from "../../db/api";
+import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
+import {ILMDGHOST} from "../forkChoice";
+import {BlockPool} from "./pool";
+
+export function processBlock(
+  config: IBeaconConfig, db: IBeaconDb, logger: ILogger, forkChoice: ILMDGHOST, pool: BlockPool
+): (source: AsyncIterable<IBlockProcessJob>) => AsyncGenerator<{block: SignedBeaconBlock; postState: BeaconState}> {
+  return (source) => {
+    return (async function*() {
+      for await(const job of source) {
+        const blockRoot = config.types.BeaconBlock.hashTreeRoot(job.signedBlock.message);
+        const preState = await getPreState(config, db, pool, logger, job);
+        if(!preState) {
+          logger.error(`Missing prestate for block ${toHexString(blockRoot)}`);
+          continue;
+        }
+        // Run the state transition
+        let newState: BeaconState;
+        const trusted = job.trusted;
+        try {
+          // if block is trusted don't verify state roots, proposer or signature
+          newState = stateTransition(config, preState, job.signedBlock, !trusted, !trusted, !trusted);
+        } catch (e) {
+          // store block root in db and terminate
+          await db.block.storeBadBlock(blockRoot);
+          logger.warn(`Found bad block, block root: ${toHexString(blockRoot)} ` + e.message);
+          return;
+        }
+        // On successful transition, update system state
+        await Promise.all([
+          db.state.set(job.signedBlock.message.stateRoot.valueOf() as Uint8Array, newState),
+          db.block.set(blockRoot, job.signedBlock),
+        ]);
+        const newChainHeadRoot = await updateForkChoice(config, db, forkChoice, job.signedBlock, newState);
+        if(newChainHeadRoot) {
+          logger.important(`Fork choice changed head to 0x${toHexString(newChainHeadRoot)}`);
+          await updateDepositMerkleTree(config, db, newState);
+        }
+        pool.onProcessedBlock(job.signedBlock);
+        yield {preState, postState: newState, block: job.signedBlock};
+      }
+    })();
+  };
+
+}
+
+export async function getPreState(
+  config: IBeaconConfig, db: IBeaconDb, pool: BlockPool, logger: ILogger, job: IBlockProcessJob
+): Promise<BeaconState|null> {
+  const parentBlock = await db.block.get(job.signedBlock.message.parentRoot.valueOf() as Uint8Array);
+  if (!parentBlock) {
+    const blockRoot = config.types.BeaconBlock.hashTreeRoot(job.signedBlock.message);
+    logger.warn(`Block(${toHexString(blockRoot)}) at slot ${job.signedBlock.message.slot}`
+            + ` is missing parent block (${toHexString(job.signedBlock.message.parentRoot)}).`
+    );
+    pool.addPendingBlock(job);
+    return null;
+  }
+  return await db.state.get(parentBlock.message.stateRoot as Uint8Array);
+}
+
+/**
+ * Returns new chainhead or null
+ * @param config
+ * @param db
+ * @param forkChoice
+ * @param block
+ * @param newState
+ */
+export async function updateForkChoice(
+  config: IBeaconConfig, db: IBeaconDb, forkChoice: ILMDGHOST, block: SignedBeaconBlock, newState: BeaconState
+): Promise<Root|null> {
+  forkChoice.addBlock({
+    slot: block.message.slot,
+    blockRootBuf: config.types.BeaconBlock.hashTreeRoot(block.message),
+    stateRootBuf: block.message.stateRoot.valueOf() as Uint8Array,
+    parentRootBuf: block.message.parentRoot.valueOf() as Uint8Array,
+    justifiedCheckpoint: newState.currentJustifiedCheckpoint,
+    finalizedCheckpoint: newState.finalizedCheckpoint
+  });
+  const currentRoot = await db.chain.getChainHeadRoot();
+  const headRoot = forkChoice.head();
+  if (currentRoot && !config.types.Root.equals(currentRoot, headRoot)) {
+    const signedBlock = await db.block.get(headRoot);
+    await db.updateChainHead(headRoot, signedBlock.message.stateRoot.valueOf() as Uint8Array);
+    return headRoot;
+  } else {
+    return null;
+  }
+}
+
+export async function updateDepositMerkleTree(
+  config: IBeaconConfig, db: IBeaconDb, newState: BeaconState
+): Promise<void> {
+  const upperIndex = newState.eth1DepositIndex + Math.min(
+    config.params.MAX_DEPOSITS,
+    newState.eth1Data.depositCount - newState.eth1DepositIndex
+  );
+  const [depositDatas, depositDataRootList] = await Promise.all([
+    db.depositData.getAllBetween(newState.eth1DepositIndex, upperIndex),
+    db.depositDataRootList.get(newState.eth1DepositIndex),
+  ]);
+
+  depositDataRootList.push(...depositDatas.map(config.types.DepositData.hashTreeRoot));
+  //TODO: remove deposits with index <= newState.depositIndex
+  await db.depositDataRootList.set(newState.eth1DepositIndex, depositDataRootList);
+}

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -44,7 +44,7 @@ export class BlockProcessor implements IService {
     this.forkChoice = forkChoice;
     this.metrics = metrics;
     this.eventBus = eventBus;
-    this.pendingBlocks = new BlockPool(config, this.blockProcessingSource);
+    this.pendingBlocks = new BlockPool(config, this.blockProcessingSource, this.eventBus);
   }
 
   public async start(): Promise<void> {

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -1,0 +1,74 @@
+import pushable from "it-pushable";
+import {SignedBeaconBlock} from "@chainsafe/lodestar-types";
+import pipe from "it-pipe";
+import abortable from "abortable-iterator";
+import {AbortController} from "abort-controller";
+import {validateBlock} from "./validate";
+import {processBlock} from "./process";
+import {BlockPool} from "./pool";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {postProcess} from "./post";
+import {IService} from "../../node";
+import {IBlockProcessJob} from "../chain";
+import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
+import {IBeaconDb} from "../../db/api";
+import {ILMDGHOST} from "../forkChoice";
+import {IBeaconMetrics} from "../../metrics";
+import {ChainEventEmitter} from "../interface";
+
+export class BlockProcessor implements IService {
+
+  private readonly config: IBeaconConfig;
+  private readonly logger: ILogger;
+  private readonly db: IBeaconDb;
+  private readonly forkChoice: ILMDGHOST;
+  private readonly metrics: IBeaconMetrics;
+  private readonly eventBus: ChainEventEmitter;
+
+  /**
+     * map where key is required parent block root and value are blocks that require that parent block
+     */
+  private pendingBlocks: BlockPool;
+
+  private blockProcessingSource = pushable<IBlockProcessJob>();
+
+  private controller: AbortController = new AbortController();
+
+  constructor(
+    config: IBeaconConfig, logger: ILogger, db: IBeaconDb,
+    forkChoice: ILMDGHOST, metrics: IBeaconMetrics, eventBus: ChainEventEmitter
+  ) {
+    this.config = config;
+    this.logger = logger;
+    this.db = db;
+    this.forkChoice = forkChoice;
+    this.metrics = metrics;
+    this.eventBus = eventBus;
+    this.pendingBlocks = new BlockPool(config, this.blockProcessingSource);
+  }
+
+  public async start(): Promise<void> {
+    const abortSignal = this.controller.signal;
+    pipe(
+      //source of blocks
+      this.blockProcessingSource,
+      //middleware to allow to stop block processing
+      function (source: AsyncIterable<IBlockProcessJob>) {
+        //use onAbort to collect and save pending blocks
+        return abortable(source, abortSignal, {returnOnAbort: true});
+      },
+      validateBlock(this.config, this.logger, this.db, this.forkChoice),
+      processBlock(this.config, this.db, this.logger, this.forkChoice, this.pendingBlocks),
+      postProcess(this.config, this.db, this.logger, this.metrics, this.eventBus)
+    );
+  }
+
+  public async stop(): Promise<void> {
+    this.controller.abort();
+  }
+
+  public receiveBlock(block: SignedBeaconBlock, trusted = false): void {
+    this.blockProcessingSource.push({signedBlock: block, trusted});
+  }
+
+}

--- a/packages/lodestar/src/chain/blocks/validate.ts
+++ b/packages/lodestar/src/chain/blocks/validate.ts
@@ -13,7 +13,7 @@ export function validateBlock(
     return (async function*() {
       for await(const job of source) {
         const blockHash = config.types.BeaconBlock.hashTreeRoot(job.signedBlock.message);
-        const currentSlot = db.chain.getChainHeadSlot();
+        const currentSlot = (await db.block.get(forkChoice.head())).message.slot;
         logger.info(
           `Received block with hash ${toHexString(blockHash)}` +
                     `at slot ${job.signedBlock.message.slot}. Current state slot ${currentSlot}`

--- a/packages/lodestar/src/chain/blocks/validate.ts
+++ b/packages/lodestar/src/chain/blocks/validate.ts
@@ -1,6 +1,6 @@
 import {IBlockProcessJob} from "../chain";
 import {toHexString} from "@chainsafe/ssz";
-import {computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {IBeaconDb} from "../../db/api";
@@ -13,23 +13,23 @@ export function validateBlock(
     return (async function*() {
       for await(const job of source) {
         const blockHash = config.types.BeaconBlock.hashTreeRoot(job.signedBlock.message);
-        const currentSlot = (await db.block.get(forkChoice.head())).message.slot;
-        logger.info(
-          `Received block with hash ${toHexString(blockHash)}` +
-                    `at slot ${job.signedBlock.message.slot}. Current state slot ${currentSlot}`
-        );
         if (await db.block.has(blockHash)) {
-          logger.warn(`Block ${toHexString(blockHash)} existed already, no need to process it.`);
+          logger.warn(`Block ${toHexString(blockHash)} was already processed, skipping...`);
           continue;
         }
         const finalizedCheckpoint = forkChoice.getFinalized();
-        if (job.signedBlock.message.slot <= computeStartSlotAtEpoch(config, finalizedCheckpoint.epoch)) {
+        if (computeEpochAtSlot(config, job.signedBlock.message.slot) <= finalizedCheckpoint.epoch) {
           logger.warn(
-            `Block ${toHexString(blockHash)} is not after ` +
-                        `finalized checkpoint ${toHexString(finalizedCheckpoint.root)}.`
+            `Block ${toHexString(blockHash)} with slot ${job.signedBlock.message.slot} is not after ` +
+                        `finalized epoch (${finalizedCheckpoint.epoch}).`
           );
           continue;
         }
+        const currentSlot = (await db.block.get(forkChoice.head())).message.slot;
+        logger.info(
+            `Received block with hash ${toHexString(blockHash)}` +
+            `at slot ${job.signedBlock.message.slot}. Current state slot ${currentSlot}`
+        );
         yield job;
       }
     })();

--- a/packages/lodestar/src/chain/blocks/validate.ts
+++ b/packages/lodestar/src/chain/blocks/validate.ts
@@ -1,0 +1,40 @@
+import {IBlockProcessJob} from "../chain";
+import {toHexString} from "@chainsafe/ssz";
+import {computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
+import {IBeaconDb} from "../../db/api";
+import {ILMDGHOST} from "../forkChoice";
+
+export function validateBlock(
+  config: IBeaconConfig, logger: ILogger, db: IBeaconDb, forkChoice: ILMDGHOST
+): (source: AsyncIterable<IBlockProcessJob>) => AsyncGenerator<IBlockProcessJob> {
+  return (source) => {
+    return (async function*() {
+      for await(const job of source) {
+        const blockHash = config.types.BeaconBlock.hashTreeRoot(job.signedBlock.message);
+        const hexBlockHash = toHexString(blockHash);
+        const currentSlot = db.chain.getChainHeadSlot();
+        logger.info(
+          `Received block with hash ${hexBlockHash}` +
+                    `at slot ${job.signedBlock.message.slot}. Current state slot ${currentSlot}`
+        );
+
+        if (await db.block.has(blockHash)) {
+          logger.warn(`Block ${hexBlockHash} existed already, no need to process it.`);
+          continue;
+        }
+
+        const finalizedCheckpoint = forkChoice.getFinalized();
+        if (job.signedBlock.message.slot <= computeStartSlotAtEpoch(config, finalizedCheckpoint.epoch)) {
+          logger.warn(
+            `Block ${hexBlockHash} is not after ` +
+                        `finalized checkpoint ${toHexString(finalizedCheckpoint.root)}.`
+          );
+          continue;
+        }
+        yield job;
+      }
+    })();
+  };
+}

--- a/packages/lodestar/src/chain/blocks/validate.ts
+++ b/packages/lodestar/src/chain/blocks/validate.ts
@@ -13,22 +13,19 @@ export function validateBlock(
     return (async function*() {
       for await(const job of source) {
         const blockHash = config.types.BeaconBlock.hashTreeRoot(job.signedBlock.message);
-        const hexBlockHash = toHexString(blockHash);
         const currentSlot = db.chain.getChainHeadSlot();
         logger.info(
-          `Received block with hash ${hexBlockHash}` +
+          `Received block with hash ${toHexString(blockHash)}` +
                     `at slot ${job.signedBlock.message.slot}. Current state slot ${currentSlot}`
         );
-
         if (await db.block.has(blockHash)) {
-          logger.warn(`Block ${hexBlockHash} existed already, no need to process it.`);
+          logger.warn(`Block ${toHexString(blockHash)} existed already, no need to process it.`);
           continue;
         }
-
         const finalizedCheckpoint = forkChoice.getFinalized();
         if (job.signedBlock.message.slot <= computeStartSlotAtEpoch(config, finalizedCheckpoint.epoch)) {
           logger.warn(
-            `Block ${hexBlockHash} is not after ` +
+            `Block ${toHexString(blockHash)} is not after ` +
                         `finalized checkpoint ${toHexString(finalizedCheckpoint.root)}.`
           );
           continue;

--- a/packages/lodestar/src/chain/blocks/validate.ts
+++ b/packages/lodestar/src/chain/blocks/validate.ts
@@ -1,6 +1,6 @@
 import {IBlockProcessJob} from "../chain";
 import {toHexString} from "@chainsafe/ssz";
-import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {IBeaconDb} from "../../db/api";
@@ -27,7 +27,7 @@ export function validateBlock(
         }
         const currentSlot = (await db.block.get(forkChoice.head())).message.slot;
         logger.info(
-            `Received block with hash ${toHexString(blockHash)}` +
+          `Received block with hash ${toHexString(blockHash)}` +
             `at slot ${job.signedBlock.message.slot}. Current state slot ${currentSlot}`
         );
         yield job;

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -82,7 +82,8 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
   }
 
   public isInitialized(): boolean {
-    throw new Error("Method not implemented.");
+    //TODO: implement
+    return true;
   }
 
   public async start(): Promise<void> {

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -41,9 +41,9 @@ export interface IBlockProcessJob {
 export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) implements IBeaconChain {
 
   public readonly chain: string;
-  public readonly forkChoice: ILMDGHOST;
-  public readonly chainId: Uint16;
-  public readonly networkId: Uint64;
+  public forkChoice: ILMDGHOST;
+  public chainId: Uint16;
+  public networkId: Uint64;
   public clock: IBeaconClock;
 
   private readonly config: IBeaconConfig;
@@ -71,6 +71,14 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     this.networkId = 0n; // TODO make this real
     this.blockProcessor = new BlockProcessor(config, logger, db, this.forkChoice, metrics, this);
     this.attestationProcessor = new AttestationProcessor(this, this.forkChoice, {config, db, logger});
+  }
+
+  public async getHeadState(): Promise<BeaconState|null> {
+    return this.db.state.get(this.forkChoice.headStateRoot());
+  }
+
+  public async getHeadBlock(): Promise<SignedBeaconBlock|null> {
+    return this.db.block.get(this.forkChoice.head());
   }
 
   public isInitialized(): boolean {

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -2,10 +2,9 @@
  * @module chain
  */
 
-import assert from "assert";
 import {EventEmitter} from "events";
 import {fromHexString, List, toHexString, TreeBacked} from "@chainsafe/ssz";
-import {Attestation, BeaconState, Root, SignedBeaconBlock, Uint16, Uint64, Validator,} from "@chainsafe/lodestar-types";
+import {Attestation, BeaconState, Root, SignedBeaconBlock, Uint16, Uint64,} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {EMPTY_SIGNATURE, GENESIS_SLOT} from "../constants";
 import {IBeaconDb} from "../db";
@@ -13,24 +12,17 @@ import {IEth1Notifier} from "../eth1";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {IBeaconMetrics} from "../metrics";
 import {getEmptyBlock, initializeBeaconStateFromEth1, isValidGenesisState} from "./genesis/genesis";
-import {
-  computeEpochAtSlot,
-  computeStartSlotAtEpoch,
-  getCurrentSlot,
-  isActiveValidator,
-  stateTransition
-} from "@chainsafe/lodestar-beacon-state-transition";
+import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {ILMDGHOST, StatefulDagLMDGHOST} from "./forkChoice";
 
 import {ChainEventEmitter, IAttestationProcessor, IBeaconChain} from "./interface";
 import {IChainOptions} from "./options";
 import {OpPool} from "../opPool";
 import {Block} from "ethers/providers";
-import FastPriorityQueue from "fastpriorityqueue";
 import {AttestationProcessor} from "./attestation";
-import {sleep} from "../util/sleep";
 import {IBeaconClock} from "./clock/interface";
 import {LocalClock} from "./clock/local/LocalClock";
+import {BlockProcessor} from "./blocks";
 
 export interface IBeaconChainModules {
   config: IBeaconConfig;
@@ -48,23 +40,21 @@ export interface IBlockProcessJob {
 
 export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) implements IBeaconChain {
 
-  public chain: string;
-  public _latestState: BeaconState = null;
-  public forkChoice: ILMDGHOST;
-  public chainId: Uint16;
-  public networkId: Uint64;
+  public readonly chain: string;
+  public readonly forkChoice: ILMDGHOST;
+  public readonly chainId: Uint16;
+  public readonly networkId: Uint64;
   public clock: IBeaconClock;
 
   private readonly config: IBeaconConfig;
-  private db: IBeaconDb;
-  private opPool: OpPool;
-  private eth1: IEth1Notifier;
-  private logger: ILogger;
-  private metrics: IBeaconMetrics;
-  private opts: IChainOptions;
-  private blockProcessingQueue: FastPriorityQueue<IBlockProcessJob>; //sort by slot number
+  private readonly db: IBeaconDb;
+  private readonly opPool: OpPool;
+  private readonly eth1: IEth1Notifier;
+  private readonly logger: ILogger;
+  private readonly metrics: IBeaconMetrics;
+  private readonly opts: IChainOptions;
+  private blockProcessor: BlockProcessor;
   private attestationProcessor: IAttestationProcessor;
-  private isPollingBlocks = false;
 
   public constructor(opts: IChainOptions, {config, db, eth1, opPool, logger, metrics}: IBeaconChainModules) {
     super();
@@ -79,15 +69,16 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     this.forkChoice = new StatefulDagLMDGHOST(config);
     this.chainId = 0; // TODO make this real
     this.networkId = 0n; // TODO make this real
-    this.blockProcessingQueue = new FastPriorityQueue((a: IBlockProcessJob, b: IBlockProcessJob) => {
-      return a.signedBlock.message.slot < b.signedBlock.message.slot;
-    });
+    this.blockProcessor = new BlockProcessor(config, logger, db, this.forkChoice, metrics, this);
     this.attestationProcessor = new AttestationProcessor(this, this.forkChoice, {config, db, logger});
   }
 
+  public isInitialized(): boolean {
+    throw new Error("Method not implemented.");
+  }
+
   public async start(): Promise<void> {
-    this.logger.verbose("asokdoasjdiajsdijas");
-    const state = this.latestState || await this.db.state.getLatest();
+    const state = await this.db.state.getLatest();
     this.forkChoice.start(state.genesisTime);
     // if state doesn't exist in the db, the chain maybe hasn't started
     if (!state) {
@@ -95,71 +86,25 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
       this.logger.info("Chain not started, listening for genesis block");
       this.eth1.on("block", this.checkGenesis);
     }
-    this.latestState = state;
     this.logger.info("Chain started, waiting blocks and attestations");
-    this.clock = new LocalClock(this.config, this.latestState.genesisTime);
+    this.clock = new LocalClock(this.config, state.genesisTime);
     await this.clock.start();
-    this.isPollingBlocks = true;
-    this.pollBlock();
+    await this.blockProcessor.start();
   }
 
   public async stop(): Promise<void> {
     await this.forkChoice.stop();
     await this.clock.stop();
+    await this.blockProcessor.stop();
     this.eth1.removeListener("block", this.checkGenesis);
-    this.isPollingBlocks = false;
-    this.logger.warn(`Discarding ${this.blockProcessingQueue.size} blocks from queue...`);
-  }
-
-  public get latestState(): BeaconState {
-    return this.config.types.BeaconState.clone(this._latestState);
-  }
-
-  public set latestState(state: BeaconState) {
-    this._latestState = state;
-  }
-
-  public isInitialized(): boolean {
-    return !!this.latestState;
   }
 
   public async receiveAttestation(attestation: Attestation): Promise<void> {
     return this.attestationProcessor.receiveAttestation(attestation);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public async receiveBlock(signedBlock: SignedBeaconBlock, trusted = false): Promise<void> {
-    const blockHash = this.config.types.BeaconBlock.hashTreeRoot(signedBlock.message);
-    const hexBlockHash = toHexString(blockHash);
-    this.logger.info(
-      `Received block with hash ${hexBlockHash}` +
-      `at slot ${signedBlock.message.slot}. Current state slot ${this.latestState.slot}`
-    );
-
-    if (await this.db.block.has(blockHash)) {
-      this.logger.warn(`Block ${hexBlockHash} existed already, no need to process it.`);
-      return;
-    }
-    const finalizedCheckpoint = this.forkChoice.getFinalized();
-    if (signedBlock.message.slot <= computeStartSlotAtEpoch(this.config, finalizedCheckpoint.epoch)) {
-      this.logger.warn(
-        `Block ${hexBlockHash} is not after ` +
-        `finalized checkpoint ${toHexString(finalizedCheckpoint.root)}.`
-      );
-      return;
-    }
-
-    this.blockProcessingQueue.add({signedBlock, trusted});
-  }
-
-  public async applyForkChoiceRule(): Promise<void> {
-    const currentRoot = await this.db.chain.getChainHeadRoot();
-    const headRoot = this.forkChoice.head();
-    if (currentRoot && !this.config.types.Root.equals(currentRoot, headRoot)) {
-      const signedBlock = await this.db.block.get(headRoot);
-      await this.db.updateChainHead(headRoot, signedBlock.message.stateRoot.valueOf() as Uint8Array);
-      this.logger.info(`Fork choice changed head to 0x${toHexString(headRoot)}`);
-    }
+    this.blockProcessor.receiveBlock(signedBlock, trusted);
   }
 
   public async initializeBeaconChain(
@@ -173,7 +118,6 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     this.logger.info(`Initializing beacon chain with state root ${toHexString(stateRoot)}`
             + ` and genesis block root ${toHexString(blockRoot)}`
     );
-    this.latestState = genesisState;
     // Determine whether a genesis state already in
     // the database matches what we were provided
     const storedGenesisBlock = await this.db.block.getBlockBySlot(GENESIS_SLOT);
@@ -203,151 +147,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     });
     this.logger.info("Beacon chain initialized");
   }
-
-  public async isValidBlock(state: BeaconState, signedBlock: SignedBeaconBlock): Promise<boolean> {
-    // The parent block with root block.previous_block_root has been processed and accepted.
-    // const hasParent = await this.db.block.has(block.parentRoot);
-    // if (!hasParent) {
-    //   return false;
-    // }
-    // An Ethereum 1.0 block pointed to by the state.
-    // latest_eth1_data.block_hash has been processed and accepted.
-    // TODO: implement
-
-    return getCurrentSlot(this.config, state.genesisTime) >= signedBlock.message.slot;
-  }
-
-  private processBlock = async (job: IBlockProcessJob, blockHash: Root): Promise<void> => {
-    const parentBlock = await this.db.block.get(job.signedBlock.message.parentRoot.valueOf() as Uint8Array);
-    if (!parentBlock) {
-      this.logger.warn(`Block(${toHexString(blockHash)}) at slot ${job.signedBlock.message.slot} `
-          + ` is missing parent block (${toHexString(job.signedBlock.message.parentRoot)}).`
-      );
-      this.emit("unknownBlockRoot", job.signedBlock.message.parentRoot.valueOf() as Uint8Array);
-      setTimeout((queue) => queue.add(job), 1000, this.blockProcessingQueue);
-      return;
-    }
-    const pre = await this.db.state.get(parentBlock.message.stateRoot.valueOf() as Uint8Array);
-    const isValidBlock = await this.isValidBlock(pre, job.signedBlock);
-    assert(isValidBlock);
-    const hexBlockHash = toHexString(blockHash);
-    this.logger.info(`${hexBlockHash} is valid, running state transition...`);
-
-    // process current slot
-    const post = await this.runStateTransition(job.signedBlock, pre);
-
-    this.logger.info(
-      `Slot ${job.signedBlock.message.slot} Block ${hexBlockHash} ` +
-      `State ${toHexString(this.config.types.BeaconState.hashTreeRoot(post))} passed state transition`
-    );
-    await this.opPool.processBlockOperations(job.signedBlock);
-    job.signedBlock.message.body.attestations.forEach((attestation: Attestation) => {
-      this.receiveAttestation(attestation);
-    });
-    await this.attestationProcessor.receiveBlock(job.signedBlock);
-
-    this.metrics.currentSlot.inc(1);
-
-    // forward processed block for additional processing
-    this.emit("processedBlock", job.signedBlock);
-  };
-
-  /**
-   *
-   * @param signedBlock
-   * @param state
-   * @param trusted if state transition should trust that block is valid
-   */
-  private async runStateTransition(
-    signedBlock: SignedBeaconBlock,
-    state: BeaconState,
-    trusted = false
-  ): Promise<BeaconState | null> {
-    const preSlot = state.slot;
-    const preFinalizedEpoch = state.finalizedCheckpoint.epoch;
-    const preJustifiedEpoch = state.currentJustifiedCheckpoint.epoch;
-    // Run the state transition
-    let newState: BeaconState;
-    const blockRoot = this.config.types.BeaconBlock.hashTreeRoot(signedBlock.message);
-    try {
-      // if block is trusted don't verify state roots, proposer or signature
-      newState = stateTransition(this.config, state, signedBlock, !trusted, !trusted, !trusted);
-    } catch (e) {
-      // store block root in db and terminate
-      await this.db.block.storeBadBlock(blockRoot);
-      this.logger.warn(`Found bad block, block root: ${toHexString(blockRoot)} ` + e.message);
-      return;
-    }
-    this.latestState = newState;
-    // On successful transition, update system state
-    await Promise.all([
-      this.db.state.set(signedBlock.message.stateRoot.valueOf() as Uint8Array, newState),
-      this.db.block.set(blockRoot, signedBlock),
-    ]);
-    this.forkChoice.addBlock({
-      slot: signedBlock.message.slot,
-      blockRootBuf: blockRoot,
-      stateRootBuf: signedBlock.message.stateRoot.valueOf() as Uint8Array,
-      parentRootBuf: signedBlock.message.parentRoot.valueOf() as Uint8Array,
-      justifiedCheckpoint: newState.currentJustifiedCheckpoint,
-      finalizedCheckpoint: newState.finalizedCheckpoint
-    });
-    await this.applyForkChoiceRule();
-    await this.updateDepositMerkleTree(newState);
-    // update metrics
-    this.metrics.currentSlot.set(signedBlock.message.slot);
-
-    // Post-epoch processing
-    const currentEpoch = computeEpochAtSlot(this.config, newState.slot);
-    if (computeEpochAtSlot(this.config, preSlot) < currentEpoch) {
-      this.emit("processedCheckpoint", {epoch: currentEpoch, root: blockRoot});
-      // Update FFG Checkpoints
-      // Newly justified epoch
-      if (preJustifiedEpoch < newState.currentJustifiedCheckpoint.epoch) {
-        const justifiedBlockRoot = newState.currentJustifiedCheckpoint.root;
-        const justifiedBlock = await this.db.block.get(justifiedBlockRoot.valueOf() as Uint8Array);
-        this.logger.important(`Epoch ${computeEpochAtSlot(this.config, justifiedBlock.message.slot)} is justified!`);
-        await Promise.all([
-          this.db.chain.setJustifiedStateRoot(justifiedBlock.message.stateRoot.valueOf() as Uint8Array),
-          this.db.chain.setJustifiedBlockRoot(justifiedBlockRoot.valueOf() as Uint8Array),
-        ]);
-        this.emit("justifiedCheckpoint", newState.currentJustifiedCheckpoint);
-      }
-      // Newly finalized epoch
-      if (preFinalizedEpoch < newState.finalizedCheckpoint.epoch) {
-        const finalizedBlockRoot = newState.finalizedCheckpoint.root;
-        const finalizedBlock = await this.db.block.get(finalizedBlockRoot.valueOf() as Uint8Array);
-        this.logger.important(`Epoch ${computeEpochAtSlot(this.config, finalizedBlock.message.slot)} is finalized!`);
-        await Promise.all([
-          this.db.chain.setFinalizedStateRoot(finalizedBlock.message.stateRoot.valueOf() as Uint8Array),
-          this.db.chain.setFinalizedBlockRoot(finalizedBlockRoot.valueOf() as Uint8Array),
-        ]);
-        this.emit("finalizedCheckpoint", newState.finalizedCheckpoint);
-      }
-      this.metrics.previousJustifiedEpoch.set(newState.previousJustifiedCheckpoint.epoch);
-      this.metrics.currentJustifiedEpoch.set(newState.currentJustifiedCheckpoint.epoch);
-      this.metrics.currentFinalizedEpoch.set(newState.finalizedCheckpoint.epoch);
-      this.metrics.currentEpochLiveValidators.set(
-        Array.from(newState.validators).filter((v: Validator) => isActiveValidator(v, currentEpoch)).length
-      );
-    }
-    return newState;
-  }
-
-  private async updateDepositMerkleTree(newState: BeaconState): Promise<void> {
-    const upperIndex = newState.eth1DepositIndex + Math.min(
-      this.config.params.MAX_DEPOSITS,
-      newState.eth1Data.depositCount - newState.eth1DepositIndex
-    );
-    const [depositDatas, depositDataRootList] = await Promise.all([
-      this.db.depositData.getAllBetween(newState.eth1DepositIndex, upperIndex),
-      this.db.depositDataRootList.get(newState.eth1DepositIndex),
-    ]);
-
-    depositDataRootList.push(...depositDatas.map(this.config.types.DepositData.hashTreeRoot));
-    //TODO: remove deposits with index <= newState.depositIndex
-    await this.db.depositDataRootList.set(newState.eth1DepositIndex, depositDataRootList);
-  }
+  
 
   private checkGenesis = async (eth1Block: Block): Promise<void> => {
     this.logger.info(`Checking if block ${eth1Block.hash} will form valid genesis state`);
@@ -375,38 +175,4 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     await this.initializeBeaconChain(genesisState, depositDataRootList);
   };
 
-  /**
-     * To prevent queue process stalling (if it receives multiple blocks at same time),
-     * this introduces continuous queue processing. If there is block ready it will be processed sequentially
-     * and if next block is missing or errors, it will stall for 500ms.
-     */
-  private pollBlock = async (): Promise<void> => {
-    if (!this.isPollingBlocks) {
-      return;
-    }
-    const nextBlockInQueue = this.blockProcessingQueue.poll();
-    if (!nextBlockInQueue) {
-      setTimeout(this.pollBlock, 1000);
-      return;
-    }
-    try {
-      const latestBlock = await this.db.block.getChainHead();
-      if (this.config.types.Root.equals(
-        nextBlockInQueue.signedBlock.message.parentRoot,
-        this.config.types.BeaconBlock.hashTreeRoot(latestBlock.message)
-      )) {
-        await this.processBlock(
-          nextBlockInQueue,
-          this.config.types.BeaconBlock.hashTreeRoot(nextBlockInQueue.signedBlock.message)
-        );
-      } else {
-        this.blockProcessingQueue.add(nextBlockInQueue);
-        await sleep(500);
-      }
-    } catch (e) {
-      this.logger.error(e.message);
-      await sleep(500);
-    }
-    this.pollBlock();
-  };
 }

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -31,7 +31,6 @@ export type ChainEventEmitter = StrictEventEmitter<EventEmitter, IChainEvents>;
  * and applying the fork choice rule to update the chain head
  */
 export interface IBeaconChain extends ChainEventEmitter {
-  latestState: BeaconState|null;
   forkChoice: ILMDGHOST;
   clock: IBeaconClock;
   chainId: Uint16;
@@ -55,16 +54,6 @@ export interface IBeaconChain extends ChainEventEmitter {
    * Pre-process and run the per slot state transition function
    */
   receiveBlock(signedBlock: SignedBeaconBlock, trusted?: boolean): Promise<void>;
-
-  /**
-   * Update the chain head using LMD GHOST
-   */
-  applyForkChoiceRule(): Promise<void>;
-
-  /**
-   * Ensure that the block is compliant with block processing validity conditions
-   */
-  isValidBlock(state: BeaconState, signedBlock: SignedBeaconBlock): Promise<boolean>;
 
   /**
    * Used for starting beacon chain with fake genesis state (dev, test, interop).

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -45,6 +45,10 @@ export interface IBeaconChain extends ChainEventEmitter {
    */
   stop(): Promise<void>;
 
+  getHeadState(): Promise<BeaconState|null>;
+
+  getHeadBlock(): Promise<SignedBeaconBlock|null>;
+
   /**
    * Add attestation to the fork-choice rule
    */

--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -10,7 +10,7 @@ import {ISyncOptions} from "../../options";
 import {IInitialSyncModules, InitialSync, InitialSyncEventEmitter} from "../interface";
 import {EventEmitter} from "events";
 import {getInitalSyncTargetEpoch, isValidChainOfBlocks, isValidFinalizedCheckPoint} from "../../utils/sync";
-import {BeaconState, Checkpoint} from "@chainsafe/lodestar-types";
+import {Checkpoint} from "@chainsafe/lodestar-types";
 import {computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {getBlockRange} from "../../utils/blocks";
 
@@ -49,7 +49,7 @@ export class FastSync
       return;
     }
 
-    const chainCheckPoint = this.chain.latestState.currentJustifiedCheckpoint;
+    const chainCheckPoint = (await this.chain.getHeadState()).currentJustifiedCheckpoint;
     //listen on finalization events
     this.chain.on("processedCheckpoint", this.sync);
     //start syncing from current chain checkpoint
@@ -74,7 +74,7 @@ export class FastSync
       this.logger.error("Wrong chain synced, should clean and start over");
     } else {
       this.logger.debug(`Fast syncing to target ${targetEpoch}`);
-      const latestState = this.chain.latestState as BeaconState;
+      const latestState = await this.chain.getHeadState();
       const blocks = await getBlockRange(
         this.network.reqResp,
         this.reps,

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -99,7 +99,7 @@ export class NaiveRegularSync implements IRegularSync {
      * @return false if it's already synced up, true if submitted blocks for chain processing
      */
   private async syncUp(): Promise<boolean> {
-    const latestState = this.chain.latestState;
+    const latestState = await this.chain.getHeadState();
     const currentSlot = latestState.slot;
     const highestCommonSlot = getHighestCommonSlot(
       Array.from(this.peers).map((peer) => this.reps.getFromPeerInfo(peer))

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -202,7 +202,7 @@ export class SyncReqResp implements ISyncReqResp {
       finalizedRoot = state.finalizedCheckpoint.root;
     }
     return {
-      headForkVersion: this.chain.latestState.fork.currentVersion,
+      headForkVersion: (await this.chain.getHeadState()).fork.currentVersion,
       finalizedRoot,
       finalizedEpoch,
       headRoot,

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -66,16 +66,13 @@ export function isValidFinalizedCheckPoint(peers: IReputation[], finalizedCheckp
   return peerCount >= (validPeers.length / 2);
 }
 
-export function isValidPeerForInitSync(config: IBeaconConfig, myState: BeaconState, peerStatus: Status): boolean {
+export function isValidPeerForInitSync(config: IBeaconConfig, myState: BeaconState|null, peerStatus: Status): boolean {
   if (!peerStatus) {
     return false;
   }
   // TODO: compare fork_digest in the latest spec?
+  return !(myState && peerStatus.finalizedEpoch < myState.finalizedCheckpoint.epoch);
 
-  if (peerStatus.finalizedEpoch < myState.finalizedCheckpoint.epoch) {
-    return false;
-  }
-  return true;
 }
 
 export interface ISlotRange {

--- a/packages/lodestar/test/e2e/chain/factory/block/assembleBlock.test.ts
+++ b/packages/lodestar/test/e2e/chain/factory/block/assembleBlock.test.ts
@@ -9,7 +9,11 @@ import {generateState} from "../../../../utils/state";
 import {assembleBlock} from "../../../../../src/chain/factory/block";
 import {OpPool} from "../../../../../src/opPool";
 import {EthersEth1Notifier} from "../../../../../src/eth1";
-import {getBeaconProposerIndex, stateTransition, signedBlockToSignedHeader} from "@chainsafe/lodestar-beacon-state-transition";
+import {
+  getBeaconProposerIndex,
+  signedBlockToSignedHeader,
+  stateTransition
+} from "@chainsafe/lodestar-beacon-state-transition";
 import {generateValidator} from "../../../../utils/validator";
 import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {generateDeposit} from "../../../../utils/deposit";

--- a/packages/lodestar/test/e2e/sync/reqResp.test.ts
+++ b/packages/lodestar/test/e2e/sync/reqResp.test.ts
@@ -14,7 +14,9 @@ import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {INetworkOptions} from "../../../src/network/options";
 import {BeaconMetrics} from "../../../src/metrics";
 import {generateState} from "../../utils/state";
-import {BlockRepository, ChainRepository, StateRepository, BlockArchiveRepository} from "../../../src/db/api/beacon/repositories";
+import {
+  BlockRepository, ChainRepository, StateRepository, BlockArchiveRepository
+} from "../../../src/db/api/beacon/repositories";
 import {IGossipMessageValidator} from "../../../src/network/gossip/interface";
 import {generateEmptySignedBlock} from "../../utils/block";
 import {BeaconBlocksByRootRequest, BeaconBlocksByRangeRequest} from "@chainsafe/lodestar-types";
@@ -59,12 +61,13 @@ describe("[sync] rpc", function () {
       netB.start(),
     ]);
     repsA = new ReputationStore();
+    const state = generateState();
     const chain = new MockBeaconChain({
       genesisTime: 0,
       chainId: 0,
       networkId: 0n,
+      state
     });
-    const state = generateState();
     
     state.finalizedCheckpoint = {
       epoch: 0,
@@ -92,7 +95,6 @@ describe("[sync] rpc", function () {
       yield block;
       yield block2;
     }());
-    chain.latestState = state;
     rpcA = new SyncReqResp({}, {
       config,
       db,

--- a/packages/lodestar/test/unit/api/impl/validator/duties/proposer.test.ts
+++ b/packages/lodestar/test/unit/api/impl/validator/duties/proposer.test.ts
@@ -1,11 +1,11 @@
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import sinon from "sinon";
+import sinon, {SinonStubbedInstance} from "sinon";
 import {BlockRepository, StateRepository} from "../../../../../../src/db/api/beacon/repositories";
 import {generateState} from "../../../../../utils/state";
 import {generateValidators} from "../../../../../utils/validator";
 import {expect} from "chai";
 import {FAR_FUTURE_EPOCH} from "../../../../../../src/constants";
-import {BeaconChain, StatefulDagLMDGHOST} from "../../../../../../src/chain";
+import {BeaconChain, IBeaconChain} from "../../../../../../src/chain";
 import {IValidatorApi, ValidatorApi} from "../../../../../../src/api/impl/validator";
 
 
@@ -13,7 +13,7 @@ describe("get proposers api impl", function () {
 
   const sandbox = sinon.createSandbox();
 
-  let dbStub: any, chainStub: any;
+  let dbStub: any, chainStub: SinonStubbedInstance<IBeaconChain>;
   
   let api: IValidatorApi;
 
@@ -23,7 +23,6 @@ describe("get proposers api impl", function () {
       block: sandbox.createStubInstance(BlockRepository),
     };
     chainStub = sandbox.createStubInstance(BeaconChain);
-    chainStub.forkChoice = sandbox.createStubInstance(StatefulDagLMDGHOST);
     // @ts-ignore
     api = new ValidatorApi({}, {db: dbStub, chain: chainStub, config});
   });
@@ -34,7 +33,7 @@ describe("get proposers api impl", function () {
 
   it("should get proposers", async function () {
     dbStub.block.get.resolves({message: {stateRoot: Buffer.alloc(32)}});
-    dbStub.state.get.resolves(
+    chainStub.getHeadState.resolves(
       generateState(
         {
           slot: 0,
@@ -51,8 +50,7 @@ describe("get proposers api impl", function () {
   });
 
   it("should get future proposers", async function () {
-    dbStub.block.get.resolves({message: {stateRoot: Buffer.alloc(32)}});
-    dbStub.state.get.resolves(
+    chainStub.getHeadState.resolves(
       generateState(
         {
           slot: config.params.SLOTS_PER_EPOCH - 3,

--- a/packages/lodestar/test/unit/chain/blocks/pool.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/pool.test.ts
@@ -1,0 +1,99 @@
+import {SinonStubbedInstance} from "sinon";
+import {BeaconChain, ChainEventEmitter, IBlockProcessJob} from "../../../../src/chain";
+import pushable, {Pushable} from "it-pushable";
+import {BlockPool} from "../../../../src/chain/blocks/pool";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import sinon from "sinon";
+import { expect } from "chai";
+
+describe("block pool", function () {
+
+    let eventBusStub: SinonStubbedInstance<ChainEventEmitter>;
+    let sourceStub: SinonStubbedInstance<Pushable<IBlockProcessJob>>&AsyncIterable<IBlockProcessJob>;
+
+    beforeEach(function () {
+        eventBusStub = sinon.createStubInstance(BeaconChain);
+        sourceStub = {
+            ...pushable<IBlockProcessJob>(),
+            push: sinon.stub(),
+            end: sinon.stub()
+        }
+    });
+
+    it("should add pending blocks", function () {
+        const pool = new BlockPool(config, sourceStub, eventBusStub);
+        pool.addPendingBlock({
+            signedBlock: config.types.SignedBeaconBlock.defaultValue(),
+            trusted: false
+        });
+        const differentParentRoot = config.types.SignedBeaconBlock.defaultValue();
+        differentParentRoot.message.parentRoot = Buffer.alloc(32, 1);
+        pool.addPendingBlock({
+            signedBlock: differentParentRoot,
+            trusted: false
+        });
+        pool.addPendingBlock({
+            signedBlock: config.types.SignedBeaconBlock.defaultValue(),
+            trusted: false
+        });
+
+        expect(
+            // @ts-ignore
+            eventBusStub.emit.withArgs("unknownBlockRoot", config.types.SignedBeaconBlock.defaultValue().message.parentRoot).callCount
+        ).to.be.equal(1);
+        expect(
+            // @ts-ignore
+            eventBusStub.emit.withArgs("unknownBlockRoot", differentParentRoot.message.parentRoot).callCount
+        ).to.be.equal(1);
+    });
+
+    it("should remove block when parent found", function () {
+        const pool = new BlockPool(config, sourceStub, eventBusStub);
+        const requiredBlock = config.types.SignedBeaconBlock.defaultValue();
+        const pendingBlock = config.types.SignedBeaconBlock.defaultValue();
+        pendingBlock.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(requiredBlock.message);
+        pool.addPendingBlock({
+            signedBlock: pendingBlock,
+            trusted: false
+        });
+
+        pool.onProcessedBlock(requiredBlock);
+        pool.addPendingBlock({
+            signedBlock: pendingBlock,
+            trusted: false
+        });
+        expect(sourceStub.push.calledOnce).to.be.true;
+        expect(eventBusStub.emit.calledTwice).to.be.true;
+    });
+
+    it("should sort pending blocks", function () {
+        const pool = new BlockPool(config, sourceStub, eventBusStub);
+        const requiredBlock = config.types.SignedBeaconBlock.defaultValue();
+        const pendingBlock = config.types.SignedBeaconBlock.defaultValue();
+        pendingBlock.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(requiredBlock.message);
+        pendingBlock.message.slot = 3;
+        const pendingBlock2 = config.types.SignedBeaconBlock.clone(pendingBlock);
+        pendingBlock2.message.slot = 2;
+        pool.addPendingBlock({
+            signedBlock: pendingBlock,
+            trusted: false
+        });
+        pool.addPendingBlock({
+            signedBlock: pendingBlock2,
+            trusted: false
+        });
+        pool.onProcessedBlock(requiredBlock);
+
+        expect(sourceStub.push.calledTwice).to.be.true;
+        expect(sourceStub.push.firstCall.calledWith({signedBlock: pendingBlock2, trusted: false})).to.be.true;
+        expect(sourceStub.push.secondCall.calledWith({signedBlock: pendingBlock, trusted: false})).to.be.true;
+    });
+
+    it("should proceed without pending blocks", function () {
+        const pool = new BlockPool(config, sourceStub, eventBusStub);
+
+        pool.onProcessedBlock(config.types.SignedBeaconBlock.defaultValue());
+        expect(sourceStub.push.notCalled).to.be.true;
+        expect(eventBusStub.emit.notCalled).to.be.true;
+    })
+});

--- a/packages/lodestar/test/unit/chain/blocks/post.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/post.test.ts
@@ -1,0 +1,106 @@
+import pipe from "it-pipe";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import sinon, {SinonStubbedInstance} from "sinon";
+import {BlockRepository, ChainRepository} from "../../../../src/db/api/beacon/repositories";
+import {BeaconDb} from "../../../../src/db/api";
+import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
+import {expect} from "chai";
+import {BeaconChain, ChainEventEmitter} from "../../../../src/chain";
+import {generateState} from "../../../utils/state";
+import {postProcess} from "../../../../src/chain/blocks/post";
+import {BeaconMetrics, IBeaconMetrics} from "../../../../src/metrics";
+import {Gauge} from "prom-client";
+
+describe("post block process stream", function () {
+
+    let blockDbStub: SinonStubbedInstance<BlockRepository>;
+    let chainDbStub: SinonStubbedInstance<ChainRepository>;
+    let dbStub: SinonStubbedInstance<BeaconDb>;
+    let metricsStub: SinonStubbedInstance<IBeaconMetrics>;
+    let slotMetricsStub: SinonStubbedInstance<Gauge>;
+    let currentEpochLiveValidatorsMetricsStub: SinonStubbedInstance<Gauge>;
+    let eventBusStub: SinonStubbedInstance<ChainEventEmitter>;
+
+    beforeEach(function () {
+        dbStub = sinon.createStubInstance(BeaconDb);
+        blockDbStub = sinon.createStubInstance(BlockRepository);
+        chainDbStub = sinon.createStubInstance(ChainRepository);
+        dbStub.block = blockDbStub as unknown as BlockRepository;
+        dbStub.chain = chainDbStub as unknown as ChainRepository;
+        slotMetricsStub = sinon.createStubInstance(Gauge);
+        currentEpochLiveValidatorsMetricsStub = sinon.createStubInstance(Gauge);
+        metricsStub = sinon.createStubInstance(BeaconMetrics);
+        metricsStub.currentSlot = slotMetricsStub as unknown as Gauge;
+        metricsStub.currentEpochLiveValidators = currentEpochLiveValidatorsMetricsStub as unknown as Gauge;
+        metricsStub.currentFinalizedEpoch = sinon.createStubInstance(Gauge) as unknown as Gauge;
+        metricsStub.currentJustifiedEpoch = sinon.createStubInstance(Gauge) as unknown as Gauge;
+        metricsStub.previousJustifiedEpoch = sinon.createStubInstance(Gauge) as unknown as Gauge;
+        eventBusStub = sinon.createStubInstance(BeaconChain);
+    });
+
+    it("no epoch transition", async function () {
+        const preState = generateState();
+        const postState = generateState();
+        const block = config.types.SignedBeaconBlock.defaultValue();
+        const item = {
+            preState,
+            postState,
+            block
+        };
+        await pipe(
+            [item],
+            postProcess(config, dbStub, sinon.createStubInstance(WinstonLogger), metricsStub, eventBusStub),
+        );
+        expect(slotMetricsStub.set.withArgs(0).calledOnce).to.be.true;
+    });
+
+    it("epoch transition", async function () {
+        const preState = generateState();
+        const postState = generateState({slot: config.params.SLOTS_PER_EPOCH});
+        const block = config.types.SignedBeaconBlock.defaultValue();
+        const item = {
+            preState,
+            postState,
+            block
+        };
+        await pipe(
+            [item],
+            postProcess(config, dbStub, sinon.createStubInstance(WinstonLogger), metricsStub, eventBusStub),
+        );
+        expect(slotMetricsStub.set.withArgs(0).calledOnce).to.be.true;
+        // @ts-ignore
+        expect(eventBusStub.emit.withArgs("processedCheckpoint").calledOnce).to.be.true;
+        expect(chainDbStub.setFinalizedBlockRoot.notCalled).to.be.true;
+        expect(chainDbStub.setJustifiedBlockRoot.notCalled).to.be.true;
+        expect(chainDbStub.setFinalizedStateRoot.notCalled).to.be.true;
+        expect(chainDbStub.setJustifiedStateRoot.notCalled).to.be.true;
+    });
+
+    it("epoch transition - justified and finalized", async function () {
+        const preState = generateState();
+        const postState = generateState({
+            slot: config.params.SLOTS_PER_EPOCH,
+            currentJustifiedCheckpoint: {epoch: 1, root: Buffer.alloc(1)},
+            finalizedCheckpoint: {epoch: 1, root: Buffer.alloc(1)}
+        });
+        const block = config.types.SignedBeaconBlock.defaultValue();
+        const item = {
+            preState,
+            postState,
+            block
+        };
+        blockDbStub.get.resolves(block);
+        await pipe(
+            [item],
+            postProcess(config, dbStub, sinon.createStubInstance(WinstonLogger), metricsStub, eventBusStub),
+        );
+        expect(slotMetricsStub.set.withArgs(0).calledOnce).to.be.true;
+        // @ts-ignore
+        expect(eventBusStub.emit.withArgs("processedCheckpoint").calledOnce).to.be.true;
+        expect(chainDbStub.setFinalizedBlockRoot.calledOnce).to.be.true;
+        expect(chainDbStub.setJustifiedBlockRoot.calledOnce).to.be.true;
+        expect(chainDbStub.setFinalizedStateRoot.calledOnce).to.be.true;
+        expect(chainDbStub.setJustifiedStateRoot.calledOnce).to.be.true;
+    });
+
+});

--- a/packages/lodestar/test/unit/chain/blocks/process.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/process.test.ts
@@ -1,0 +1,159 @@
+import pipe from "it-pipe";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
+import {
+    BlockRepository,
+    ChainRepository,
+    DepositDataRepository,
+    StateRepository,
+    DepositDataRootListRepository
+} from "../../../../src/db/api/beacon/repositories";
+import {BeaconDb} from "../../../../src/db/api";
+import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
+import {ILMDGHOST, StatefulDagLMDGHOST} from "../../../../src/chain/forkChoice";
+import {collect} from "./utils";
+import {expect} from "chai";
+import {IBlockProcessJob} from "../../../../src/chain";
+import {BlockPool} from "../../../../src/chain/blocks/pool";
+import {processBlock} from "../../../../src/chain/blocks/process";
+import * as stateTransitionUtils from "@chainsafe/lodestar-beacon-state-transition";
+import {generateState} from "../../../utils/state";
+import {List, TreeBacked} from "@chainsafe/ssz";
+import {Root} from "@chainsafe/lodestar-types";
+
+describe("block process stream", function () {
+
+    let blockDbStub: SinonStubbedInstance<BlockRepository>;
+    let stateDbStub: SinonStubbedInstance<StateRepository>;
+    let chainDbStub: SinonStubbedInstance<ChainRepository>;
+    let depositDataDbStub: SinonStubbedInstance<DepositDataRepository>;
+    let depositDataRootListDbStub: SinonStubbedInstance<DepositDataRootListRepository>;
+    let dbStub: SinonStubbedInstance<BeaconDb>;
+    let forkChoiceStub: SinonStubbedInstance<ILMDGHOST>;
+    let blockPoolStub: SinonStubbedInstance<BlockPool>;
+    let stateTransitionStub: SinonStub;
+
+    const sandbox = sinon.createSandbox();
+
+    beforeEach(function () {
+        dbStub = sinon.createStubInstance(BeaconDb);
+        blockDbStub = sinon.createStubInstance(BlockRepository);
+        stateDbStub = sinon.createStubInstance(StateRepository);
+        chainDbStub = sinon.createStubInstance(ChainRepository);
+        depositDataRootListDbStub = sinon.createStubInstance(DepositDataRootListRepository);
+        depositDataDbStub = sinon.createStubInstance(DepositDataRepository);
+        dbStub.block = blockDbStub as unknown as BlockRepository;
+        dbStub.state = stateDbStub as unknown as StateRepository;
+        dbStub.chain = chainDbStub as unknown as ChainRepository;
+        dbStub.depositData = depositDataDbStub as unknown as DepositDataRepository;
+        dbStub.depositDataRootList = depositDataRootListDbStub as unknown as DepositDataRootListRepository;
+        blockPoolStub = sinon.createStubInstance(BlockPool);
+        forkChoiceStub = sinon.createStubInstance(StatefulDagLMDGHOST);
+        stateTransitionStub = sandbox.stub(stateTransitionUtils, "stateTransition")
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it("missing parent block", async function () {
+        const receivedJob: IBlockProcessJob = {
+          signedBlock: config.types.SignedBeaconBlock.defaultValue(),
+          trusted: false
+        };
+        blockDbStub.get.withArgs(receivedJob.signedBlock.message.parentRoot.valueOf() as Uint8Array).resolves(null);
+        const result = await pipe(
+            [receivedJob],
+            processBlock(config, dbStub, sinon.createStubInstance(WinstonLogger), forkChoiceStub, blockPoolStub as unknown as BlockPool),
+            collect
+        );
+        expect(result).to.have.length(0);
+        expect(blockPoolStub.addPendingBlock.calledOnce).to.be.true;
+    });
+
+    it("missing parent state", async function () {
+        const receivedJob: IBlockProcessJob = {
+          signedBlock: config.types.SignedBeaconBlock.defaultValue(),
+          trusted: false
+        };
+        const parentBlock = config.types.SignedBeaconBlock.defaultValue();
+        blockDbStub.get.withArgs(receivedJob.signedBlock.message.parentRoot.valueOf() as Uint8Array).resolves(parentBlock);
+        stateDbStub.get.resolves(null);
+        const result = await pipe(
+            [receivedJob],
+            processBlock(config, dbStub, sinon.createStubInstance(WinstonLogger), forkChoiceStub, blockPoolStub as unknown as BlockPool),
+            collect
+        );
+        expect(result).to.have.length(0);
+    });
+
+    it("failed state transition", async function () {
+        const receivedJob: IBlockProcessJob = {
+          signedBlock: config.types.SignedBeaconBlock.defaultValue(),
+          trusted: false
+        };
+        const parentBlock = config.types.SignedBeaconBlock.defaultValue();
+        blockDbStub.get.withArgs(receivedJob.signedBlock.message.parentRoot.valueOf() as Uint8Array).resolves(parentBlock);
+        stateDbStub.get.resolves(generateState());
+        stateTransitionStub.throws();
+        const result = await pipe(
+            [receivedJob],
+            processBlock(config, dbStub, sinon.createStubInstance(WinstonLogger), forkChoiceStub, blockPoolStub as unknown as BlockPool),
+            collect
+        );
+        expect(result).to.have.length(0);
+        expect(blockDbStub.storeBadBlock.calledOnce).to.be.true;
+    });
+
+    it("successful block process - not new chain head", async function () {
+        const receivedJob: IBlockProcessJob = {
+          signedBlock: config.types.SignedBeaconBlock.defaultValue(),
+          trusted: false
+        };
+        const parentBlock = config.types.SignedBeaconBlock.defaultValue();
+        blockDbStub.get.withArgs(receivedJob.signedBlock.message.parentRoot.valueOf() as Uint8Array).resolves(parentBlock);
+        stateDbStub.get.resolves(generateState());
+        stateTransitionStub.resolves(generateState());
+        chainDbStub.getChainHeadRoot.resolves(Buffer.alloc(32, 1));
+        forkChoiceStub.head.returns(Buffer.alloc(32, 1));
+        const result = await pipe(
+            [receivedJob],
+            processBlock(config, dbStub, sinon.createStubInstance(WinstonLogger), forkChoiceStub, blockPoolStub as unknown as BlockPool),
+            collect
+        );
+        expect(result).to.have.length(1);
+        expect(blockDbStub.storeBadBlock.notCalled).to.be.true;
+        expect(blockDbStub.set.calledOnce).to.be.true;
+        expect(stateDbStub.set.calledOnce).to.be.true;
+        expect(dbStub.updateChainHead.notCalled).to.be.true;
+        expect(blockPoolStub.onProcessedBlock.calledOnce).to.be.true;
+    });
+
+    it("successful block process - new chain head", async function () {
+        const receivedJob: IBlockProcessJob = {
+          signedBlock: config.types.SignedBeaconBlock.defaultValue(),
+          trusted: false
+        };
+        const parentBlock = config.types.SignedBeaconBlock.defaultValue();
+        blockDbStub.get.withArgs(receivedJob.signedBlock.message.parentRoot.valueOf() as Uint8Array).resolves(parentBlock);
+        stateDbStub.get.resolves(generateState());
+        stateTransitionStub.resolves(generateState());
+        chainDbStub.getChainHeadRoot.resolves(Buffer.alloc(32, 1));
+        forkChoiceStub.head.returns(Buffer.alloc(32, 2));
+        depositDataDbStub.getAllBetween.resolves([]);
+        depositDataRootListDbStub.get.resolves(config.types.DepositDataRootList.defaultValue().valueOf() as TreeBacked<List<Root>>);
+        blockDbStub.get.resolves(receivedJob.signedBlock);
+        const result = await pipe(
+            [receivedJob],
+            processBlock(config, dbStub, sinon.createStubInstance(WinstonLogger), forkChoiceStub, blockPoolStub as unknown as BlockPool),
+            collect
+        );
+        expect(result).to.have.length(1);
+        expect(blockDbStub.storeBadBlock.notCalled).to.be.true;
+        expect(blockDbStub.set.calledOnce).to.be.true;
+        expect(stateDbStub.set.calledOnce).to.be.true;
+        expect(dbStub.updateChainHead.calledOnce).to.be.true;
+        expect(depositDataRootListDbStub.set.calledOnce).to.be.true;
+        expect(blockPoolStub.onProcessedBlock.calledOnce).to.be.true;
+    });
+});

--- a/packages/lodestar/test/unit/chain/blocks/utils.ts
+++ b/packages/lodestar/test/unit/chain/blocks/utils.ts
@@ -1,0 +1,7 @@
+export async function collect (source: AsyncIterable<unknown>): Promise<unknown[]> {
+    const vals: unknown[] = [];
+    for await (const val of source) {
+        vals.push(val);
+    }
+    return vals;
+}

--- a/packages/lodestar/test/unit/chain/blocks/validate.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/validate.test.ts
@@ -1,0 +1,65 @@
+import pipe from "it-pipe";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {SinonStubbedInstance} from "sinon";
+import {BlockRepository} from "../../../../src/db/api/beacon/repositories";
+import {BeaconDb} from "../../../../src/db/api";
+import sinon from "sinon";
+import {validateBlock} from "../../../../src/chain/blocks/validate";
+import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
+import {ILMDGHOST, StatefulDagLMDGHOST} from "../../../../src/chain/forkChoice";
+import {collect} from "./utils";
+import { expect } from "chai";
+
+describe("block validate process", function () {
+
+    let blockDbStub: SinonStubbedInstance<BlockRepository>;
+    let dbStub: SinonStubbedInstance<BeaconDb>;
+    let forkChoiceStub: SinonStubbedInstance<ILMDGHOST>;
+
+    beforeEach(function () {
+        dbStub = sinon.createStubInstance(BeaconDb);
+        blockDbStub = sinon.createStubInstance(BlockRepository);
+        dbStub.block = blockDbStub as unknown as BlockRepository;
+        forkChoiceStub = sinon.createStubInstance(StatefulDagLMDGHOST);
+    });
+
+    it("should filter processed blocks", async function () {
+        const receivedBlock = config.types.SignedBeaconBlock.defaultValue();
+        blockDbStub.has.withArgs(config.types.BeaconBlock.hashTreeRoot(receivedBlock.message)).resolves(true);
+        const result = await pipe(
+            [{signedBlock: receivedBlock, trusted: false}],
+            validateBlock(config, sinon.createStubInstance(WinstonLogger), dbStub, forkChoiceStub),
+            collect
+        );
+        expect(result).to.have.length(0);
+    });
+
+    it("should filter finalized blocks", async function () {
+        const receivedBlock = config.types.SignedBeaconBlock.defaultValue();
+        receivedBlock.message.slot = 0;
+        blockDbStub.has.withArgs(config.types.BeaconBlock.hashTreeRoot(receivedBlock.message)).resolves(false);
+        forkChoiceStub.getFinalized.returns({epoch: 0, root: Buffer.alloc(0)});
+        const result = await pipe(
+            [{signedBlock: receivedBlock, trusted: false}],
+            validateBlock(config, sinon.createStubInstance(WinstonLogger), dbStub, forkChoiceStub),
+            collect
+        );
+        expect(result).to.have.length(0);
+    });
+
+    it("should allow valid blocks", async function () {
+        const receivedBlock = config.types.SignedBeaconBlock.defaultValue();
+        receivedBlock.message.slot = config.params.SLOTS_PER_EPOCH;
+        blockDbStub.has.withArgs(config.types.BeaconBlock.hashTreeRoot(receivedBlock.message)).resolves(false);
+        forkChoiceStub.getFinalized.returns({epoch: 0, root: Buffer.alloc(0)});
+        forkChoiceStub.head.returns(Buffer.alloc(0));
+        blockDbStub.get.resolves(config.types.SignedBeaconBlock.defaultValue());
+        const result = await pipe(
+            [{signedBlock: receivedBlock, trusted: false}],
+            validateBlock(config, sinon.createStubInstance(WinstonLogger), dbStub, forkChoiceStub),
+            collect
+        );
+        expect(result).to.have.length(1);
+    });
+
+});

--- a/packages/lodestar/test/unit/chain/blocks/validate.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/validate.test.ts
@@ -10,7 +10,7 @@ import {ILMDGHOST, StatefulDagLMDGHOST} from "../../../../src/chain/forkChoice";
 import {collect} from "./utils";
 import { expect } from "chai";
 
-describe("block validate process", function () {
+describe("block validate stream", function () {
 
     let blockDbStub: SinonStubbedInstance<BlockRepository>;
     let dbStub: SinonStubbedInstance<BeaconDb>;

--- a/packages/lodestar/test/unit/sync/initial/fast.test.ts
+++ b/packages/lodestar/test/unit/sync/initial/fast.test.ts
@@ -10,7 +10,6 @@ import {ISyncOptions} from "../../../../src/sync/options";
 import {expect} from "chai";
 import * as syncUtils from "../../../../src/sync/utils/sync";
 import * as blockSyncUtils from "../../../../src/sync/utils/blocks";
-// @ts-ignore
 import PeerInfo from "peer-info";
 import {generateState} from "../../../utils/state";
 import {generateEmptyBlock} from "../../../utils/block";
@@ -85,8 +84,8 @@ describe("fast sync", function () {
     const chainCheckPoint = {root: Buffer.alloc(32, 1), epoch: 3};
     // @ts-ignore
     modules.reps.getFromPeerInfo.returns({latestStatus: {finalizedEpoch: 3, finalizedRoot: chainCheckPoint.root}});
-    sinon.stub(modules.chain, "latestState")
-      .get(() => generateState({currentJustifiedCheckpoint: chainCheckPoint}));
+    // @ts-ignore
+    modules.chain.getHeadState.resolves(generateState({currentJustifiedCheckpoint: chainCheckPoint}))
     getTargetEpochStub.returns(3);
     const eventSpy = sinon.spy();
     sync.once("sync:completed", eventSpy);
@@ -111,8 +110,8 @@ describe("fast sync", function () {
     const chainCheckPoint = {root: Buffer.alloc(32, 1), epoch: 4};
     // @ts-ignore
     modules.reps.getFromPeerInfo.returns({latestStatus: {finalizedEpoch: 3, finalizedRoot: chainCheckPoint.root}});
-    sinon.stub(modules.chain, "latestState")
-      .get(() => generateState({currentJustifiedCheckpoint: chainCheckPoint}));
+    // @ts-ignore
+    modules.chain.getHeadState.resolves(generateState({currentJustifiedCheckpoint: chainCheckPoint}));
     getTargetEpochStub.returns(3);
     const eventSpy = sinon.spy();
     sync.once("sync:completed", eventSpy);
@@ -134,8 +133,8 @@ describe("fast sync", function () {
     // @ts-ignore
     modules.chain.isInitialized.returns(true);
     const chainCheckPoint = {root: Buffer.alloc(32, 1), epoch: 4};
-    sinon.stub(modules.chain, "latestState")
-      .get(() => generateState({currentJustifiedCheckpoint: chainCheckPoint}));
+    // @ts-ignore
+    modules.chain.getHeadState.resolves(generateState({currentJustifiedCheckpoint: chainCheckPoint}));
     // @ts-ignore
     modules.reps.getFromPeerInfo.returns({latestStatus: {finalizedEpoch: 3, finalizedRoot: chainCheckPoint.root}});
     // @ts-ignore
@@ -161,8 +160,8 @@ describe("fast sync", function () {
     // @ts-ignore
     modules.chain.isInitialized.returns(true);
     const chainCheckPoint = {root: Buffer.alloc(32, 1), epoch: 4};
-    sinon.stub(modules.chain, "latestState")
-      .get(() => generateState({currentJustifiedCheckpoint: chainCheckPoint}));
+    // @ts-ignore
+    modules.chain.getHeadState.resolves(generateState({currentJustifiedCheckpoint: chainCheckPoint}));
     // @ts-ignore
     modules.reps.getFromPeerInfo.returns({} as unknown as IReputation);
     getTargetEpochStub.returns(5);

--- a/packages/lodestar/test/unit/sync/reqRes.test.ts
+++ b/packages/lodestar/test/unit/sync/reqRes.test.ts
@@ -39,7 +39,7 @@ describe("sync req resp", function () {
 
   beforeEach(() => {
     chainStub = sandbox.createStubInstance(BeaconChain);
-    chainStub["latestState"] = generateState();
+    chainStub.getHeadState.resolves(generateState());
     // @ts-ignore
     chainStub.config = config;
     reqRespStub = sandbox.createStubInstance(ReqResp);
@@ -72,7 +72,6 @@ describe("sync req resp", function () {
 
 
   it("should able to create Status - genesis time", async function () {
-    // chainStub.genesisTime = 0;
     chainStub.networkId = 1n;
     chainStub.chainId = 1;
 

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -1,47 +1,64 @@
 import {EventEmitter} from "events";
 
-import {
-  Attestation,
-  BeaconState,
-  Slot,
-  Number64,
-  Uint16,
-  Uint64,
-  SignedBeaconBlock,
-  Root
-} from "@chainsafe/lodestar-types";
+import {Number64, Uint16, Uint64} from "@chainsafe/lodestar-types";
 import {IBeaconChain, ILMDGHOST} from "../../../../src/chain";
-import {generateState} from "../../state";
-import {List, TreeBacked} from "@chainsafe/ssz";
+import {ITreeBacked, List, TreeBackedify} from "@chainsafe/ssz";
 import {IBeaconClock} from "../../../../src/chain/clock/interface";
+import {BeaconState} from "@chainsafe/lodestar-types";
+
+export interface IMockChainParams {
+  genesisTime: Number64;
+  chainId: Uint16;
+  networkId: Uint64;
+  state: BeaconState;
+}
 
 export class MockBeaconChain extends EventEmitter implements IBeaconChain {
-  public latestState: BeaconState;
   public forkChoice: ILMDGHOST;
   public chainId: Uint16;
   public networkId: Uint64;
   public clock: IBeaconClock;
 
-  public constructor({genesisTime, chainId, networkId}: {genesisTime: Number64; chainId: Uint16; networkId: Uint64}) {
+  private initialized: boolean;
+  private state: BeaconState|null;
+
+  public constructor({genesisTime, chainId, networkId, state}: Partial<IMockChainParams>) {
     super();
-    this.latestState = generateState({genesisTime});
-    this.chainId = chainId;
-    this.networkId = networkId;
+    this.initialized = genesisTime > 0;
+    this.chainId = chainId || 0;
+    this.networkId = networkId || 0n;
+    this.state = state; 
   }
 
-  public async start(): Promise<void> {}
-  public async stop(): Promise<void> {}
-  public async receiveAttestation(attestation: Attestation): Promise<void> {}
-  public async receiveBlock(signedBlock: SignedBeaconBlock): Promise<void> {}
-  public async applyForkChoiceRule(): Promise<void> {}
-  public async isValidBlock(state: BeaconState, block: SignedBeaconBlock): Promise<boolean> {
-    return true;
+  getHeadBlock(): Promise<| null> {
+    return undefined;
   }
-  public async advanceState(slot?: Slot): Promise<void>{}
-  initializeBeaconChain(genesisState: BeaconState, depositDataRootList: TreeBacked<List<Root>>): Promise<void> {
-    throw new Error("Method not implemented.");
+
+  public async getHeadState(): Promise<BeaconState| null> {
+    return this.state;
   }
+
+  public async initializeBeaconChain(): Promise<void> {
+    return undefined;
+  }
+
   isInitialized(): boolean {
-    return !!this.latestState;
+    return !!this.initialized;
+  }
+
+  receiveAttestation(): Promise<void> {
+    return undefined;
+  }
+
+  receiveBlock(): Promise<void> {
+    return undefined;
+  }
+
+  start(): Promise<void> {
+    return undefined;
+  }
+
+  stop(): Promise<void> {
+    return undefined;
   }
 }


### PR DESCRIPTION
I would like some feedback on this block processing stream proposal before I start writing tests and modifying rest of codebase
Block lifecycle is:
network/api -> chain -> blockProcessStream - > validate -> process -> postProcess
                                                                                          \
                                                                                             -> blockPool-> blockProcessStream
After we process block, we will notify block pool which will put blocks waiting for that parent back on process stream.

Pros:
- very much testable code so we can cover a lot of scenarios with unit tests
- clean modular code
- parallel validate/process/post processes

Cons:
- it seems like during sync every block except first will end up in block pool before being process
   - it because there is a great chance most block will go trough validate before block process starts
   - naive idea to mitigate it is to combine validate and process function into one but we will end up with huge function again and we wouldn't be able to discard some blocks while waiting for process operations

resolves #694 
resolves #481 