### PR TITLE
Fix lodestar-cli test script

### DIFF
--- a/packages/lodestar-cli/package.json
+++ b/packages/lodestar-cli/package.json
@@ -24,7 +24,7 @@
     "pretest": "yarn run check-types",
     "test:unit": "TS_NODE_PROJECT=tsconfig.test.json nyc --cache-dir .nyc_output/.cache -e .ts mocha --file ./test/setup.ts --colors -r ts-node/register 'test/unit/**/*.test.ts'",
     "test:e2e": "TS_NODE_PROJECT=tsconfig.test.json mocha --file ./test/setup.ts --colors --timeout 5000 -r ts-node/register 'test/e2e/**/*.test.ts'",
-    "test": "yarn test:unit && yarn test:spec && yarn test:e2e",
+    "test": "yarn test:unit && yarn test:e2e",
     "coverage": "codecov -F lodestar",
     "benchmark": "ts-node test/benchmarks"
   },


### PR DESCRIPTION
Resolves #780
The `test` script referenced the old `test:spec` script.