### PR TITLE
Fix up CI

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,15 +1,12 @@
 BeaconChain:
 - packages/lodestar/**/*
 
-SSZ:
-- packages/ssz/**/*
-
 Validator:
-- packages/lodestar/validator/**/*
-
-BLS:
-- packages/bls/**/*
+- packages/lodestar-validator/**/*
 
 Benchmarks:
 - packages/benchmark-utils/**/*
 - packages/lodestar/test/benchmarks/**/*
+
+CI:
+- .github/**/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
         docker rmi $(docker image ls -aq)
         df -h
     - uses: actions/checkout@v1
-    - name: Install lerna
-      run: yarn global add lerna
     - name: Restore dependencies
       uses: actions/cache@master
       id: cache-deps
@@ -27,17 +25,17 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
     - name: Bootstrap
       if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: $(yarn global bin)/lerna bootstrap
+      run: node_modules/.bin/lerna bootstrap
     - name: Build
-      run: $(yarn global bin)/lerna run build
+      run: node_modules/.bin/lerna run build
       if: steps.cache-deps.outputs.cache-hit == 'true'
     - name: Lint
-      run: $(yarn global bin)/lerna run lint
+      run: node_modules/.bin/lerna run lint
     - name: Unit tests
-      run: $(yarn global bin)/lerna run test:unit
+      run: node_modules/.bin/lerna run test:unit
     - name: Coverage
-      run: $(yarn global bin)/lerna run coverage
+      run: node_modules/.bin/lerna run coverage
     - name: E2e tests
-      run: $(yarn global bin)/lerna run test:e2e
+      run: node_modules/.bin/lerna run test:e2e
     - name: Spec tests
-      run: $(yarn global bin)/lerna run test:spec-min
+      run: node_modules/.bin/lerna run test:spec-min

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,6 @@ jobs:
     - name: Build
       run: $(yarn global bin)/lerna run build
       if: steps.cache-deps.outputs.cache-hit == 'true'
-    - name: Check types
-      run: $(yarn global bin)/lerna run check-types
     - name: Lint
       run: $(yarn global bin)/lerna run lint
     - name: Unit tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,20 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install lerna
       run: yarn global add lerna
+    - name: Restore dependencies
+      uses: actions/cache@master
+      id: cache-deps
+      with:
+        path: |
+          node_modules
+          packages/*/node_modules
+        key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
     - name: Bootstrap
+      if: steps.cache-deps.outputs.cache-hit != 'true'
       run: $(yarn global bin)/lerna bootstrap
+    - name: Build
+      run: $(yarn global bin)/lerna run build
+      if: steps.cache-deps.outputs.cache-hit == 'true'
     - name: Check types
       run: $(yarn global bin)/lerna run check-types
     - name: Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
     - name: Bootstrap
       if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: node_modules/.bin/lerna bootstrap
+      run: yarn install --frozen-lockfile
     - name: Build
       run: node_modules/.bin/lerna run build
       if: steps.cache-deps.outputs.cache-hit == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,13 @@ jobs:
     name: Quick tests
     runs-on: ubuntu-latest
     steps:
+    - name: Free disk space
+      run: |
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+        df -h
     - uses: actions/checkout@v1
     - name: Install lerna
       run: yarn global add lerna

--- a/packages/lodestar-beacon-state-transition/package.json
+++ b/packages/lodestar-beacon-state-transition/package.json
@@ -19,7 +19,7 @@
     "lib/**/*.js.map"
   ],
   "scripts": {
-    "build": "yarn build:lib && yarn check-types && yarn build:types",
+    "build": "yarn build:lib && yarn build:types",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:release": "yarn clean && yarn build",

--- a/packages/lodestar-spec-test-util/package.json
+++ b/packages/lodestar-spec-test-util/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo && rm -f tsconfig.build.tsbuildinfo",
-    "build": "yarn build:lib && yarn check-types && yarn build:types",
+    "build": "yarn build:lib && yarn build:types",
     "build:release": "yarn clean && yarn build && yarn build:docs",
     "build:types": "tsc --incremental --declaration --project tsconfig.build.json --emitDeclarationOnly",
     "build:lib": "babel src -x .ts -d lib --source-maps",

--- a/packages/lodestar-types/package.json
+++ b/packages/lodestar-types/package.json
@@ -19,7 +19,7 @@
     "lib/**/*.js.map"
   ],
   "scripts": {
-    "build": "yarn build:lib && yarn check-types && yarn build:types",
+    "build": "yarn build:lib && yarn build:types",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:release": "yarn clean && yarn build",

--- a/packages/lodestar-validator/package.json
+++ b/packages/lodestar-validator/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo && rm -f tsconfig.build.tsbuildinfo",
-    "build": "yarn run build:lib && yarn check-types && yarn run build:types",
+    "build": "yarn run build:lib && yarn run build:types",
     "build:release": "yarn clean && yarn run build && yarn run build:docs",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "benchmark": "ts-node test/benchmarks",
-    "build": "yarn run build:lib && yarn run check-types && yarn run build:types",
+    "build": "yarn run build:lib && yarn run build:types",
     "build:docs": "typedoc --exclude src/index.ts --out docs src",
     "build:lib": "babel src -x .ts -d lib --source-maps",
     "build:release": "yarn clean && yarn run build && yarn run build:docs",


### PR DESCRIPTION
Merging directly into 0.11.x
1. free extra disk space (see https://github.community/t5/GitHub-Actions/BUG-Strange-quot-No-space-left-on-device-quot-IOExceptions-on/td-p/46101)
2. cache node_modules dependencies
3. remove check-types from build step
4. remove check-types from CI