### PR TITLE
Fix ci mainnet spec tests

### DIFF
--- a/.github/workflows/spec-test.yml
+++ b/.github/workflows/spec-test.yml
@@ -32,4 +32,4 @@ jobs:
       run: node_modules/.bin/lerna run build
       if: steps.cache-deps.outputs.cache-hit == 'true'
     - name: Spec tests
-      run: $(yarn global bin)/lerna run test:spec-main
+      run: node_modules/.bin/lerna run test:spec-main


### PR DESCRIPTION
Whoops, left in reference to the globally installed lerna.
Fix of https://github.com/ChainSafe/lodestar/pull/821