### PR TITLE
set minimum nodejs version to 12.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "root",
   "private": true,
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
Fixes #835 

I'm not sure what the actual minimum version is, but this resolves the issue with using node v10

with this change, attempting to install deps on node v10 results in this error message
```
lodestar on  master via ⬢ v10.18.1 
⇡0% ➜ yarn            
yarn install v1.22.4
[1/5] Validating package.json...
error root@: The engine "node" is incompatible with this module. Expected version ">=12.0.0". Got "10.18.1"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```