### PR TITLE
Add ENRForkID to ENR eth2

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/epoch/fork.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/fork.ts
@@ -1,0 +1,19 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {BeaconState} from "@chainsafe/lodestar-types";
+import {getCurrentEpoch} from "..";
+import {intToBytes} from "@chainsafe/lodestar-utils";
+
+export function processForkChanged(config: IBeaconConfig, state: BeaconState): void {
+  const currentEpoch = getCurrentEpoch(config, state);
+  const nextEpoch = currentEpoch + 1;
+  const currentForkVersion = state.fork.currentVersion;
+  const nextFork = config.params.ALL_FORKS && config.params.ALL_FORKS.find(
+    (fork) => config.types.Version.equals(currentForkVersion, intToBytes(fork.previousVersion, 4)));
+  if (nextFork && nextFork.epoch === nextEpoch) {
+    state.fork = {
+      previousVersion: state.fork.currentVersion,
+      currentVersion: intToBytes(nextFork.currentVersion, 4),
+      epoch: nextFork.epoch,
+    };
+  }
+}

--- a/packages/lodestar-beacon-state-transition/src/epoch/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/index.ts
@@ -10,6 +10,7 @@ import {processFinalUpdates} from "./finalUpdates";
 import {processJustificationAndFinalization} from "./justification";
 import {processRegistryUpdates} from "./registryUpdates";
 import {processSlashings} from "./slashings";
+import {processForkChanged} from "./fork";
 
 export * from "./balanceUpdates";
 export * from "./finalUpdates";
@@ -40,6 +41,9 @@ export function processEpoch(config: IBeaconConfig, state: BeaconState): BeaconS
 
   // Final Updates
   processFinalUpdates(config, state);
+
+  // check and process planned hard fork
+  processForkChanged(config, state);
 
   // TODO Later Phase
   // afterProcessFinalUpdates

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/fork.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/fork.test.ts
@@ -1,0 +1,59 @@
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import {BeaconState} from "@chainsafe/lodestar-types";
+import {generateState} from "../../../utils/state";
+import {processForkChanged} from "../../../../src/epoch/fork";
+import {expect} from "chai";
+import {bytesToInt} from "@chainsafe/lodestar-utils";
+
+describe("processForkChanged", () => {
+  let state: BeaconState;
+
+  beforeEach(() => {
+    state = generateState();
+    state.fork = {
+      currentVersion: Buffer.from([1, 0, 0, 0]),
+      epoch: 100,
+      previousVersion: Buffer.alloc(4),
+    };
+  });
+
+  afterEach(() => {
+    config.params.ALL_FORKS = undefined;
+  });
+
+  it("should not update fork if no matched next fork", () => {
+    config.params.ALL_FORKS = undefined;
+    const preFork = state.fork;
+    processForkChanged(config, state);
+    expect(config.types.Fork.equals(preFork, state.fork)).to.be.true;
+  });
+
+  it("should not update fork if found matched next fork but epoch not matched", () => {
+    config.params.ALL_FORKS = [
+      {
+        previousVersion: bytesToInt(Buffer.from([1, 0, 0, 0])),
+        currentVersion: bytesToInt(Buffer.from([2, 0, 0, 0])),
+        epoch: 200,
+      },
+    ];
+    const preFork = state.fork;
+    processForkChanged(config, state);
+    expect(config.types.Fork.equals(preFork, state.fork)).to.be.true;
+  });
+
+  it("should update fork if found matched next fork and matched epoch", () => {
+    config.params.ALL_FORKS = [
+      {
+        previousVersion: bytesToInt(Buffer.from([1, 0, 0, 0])),
+        currentVersion: bytesToInt(Buffer.from([2, 0, 0, 0])),
+        epoch: 200,
+      },
+    ];
+    const preFork = state.fork;
+    state.slot = 200 * config.params.SLOTS_PER_EPOCH - 1;
+    processForkChanged(config, state);
+    expect(config.types.Fork.equals(preFork, state.fork)).to.be.false;
+    expect(config.types.Version.equals(preFork.currentVersion, state.fork.previousVersion));
+    expect(state.fork.epoch).to.be.equal(200);
+  });
+});

--- a/packages/lodestar-params/src/interface.ts
+++ b/packages/lodestar-params/src/interface.ts
@@ -70,4 +70,17 @@ export interface IBeaconParams {
   MAX_ATTESTATIONS: number;
   MAX_DEPOSITS: number;
   MAX_VOLUNTARY_EXITS: number;
+
+  // Old and future forks
+  ALL_FORKS: IFork[];
 }
+
+interface IFork {
+  // 4 bytes
+  previousVersion: number;
+  // 4 bytes
+  currentVersion: number;
+  // Fork epoch number
+  epoch: number;
+}
+

--- a/packages/lodestar-types/src/ssz/generators/misc.ts
+++ b/packages/lodestar-types/src/ssz/generators/misc.ts
@@ -23,6 +23,14 @@ export const ForkData = (ssz: IBeaconSSZTypes): ContainerType => new ContainerTy
   },
 });
 
+export const ENRForkID = (ssz: IBeaconSSZTypes): ContainerType => new ContainerType({
+  fields: {
+    forkDigest: ssz.ForkDigest,
+    nextForkVersion: ssz.Version,
+    nextForkEpoch: ssz.Epoch,
+  },
+});
+
 export const Checkpoint = (ssz: IBeaconSSZTypes): ContainerType => new ContainerType({
   fields: {
     epoch: ssz.Epoch,

--- a/packages/lodestar-types/src/ssz/interface.ts
+++ b/packages/lodestar-types/src/ssz/interface.ts
@@ -34,6 +34,7 @@ export interface IBeaconSSZTypes {
   // misc
   Fork: ContainerType<t.Fork>;
   ForkData: ContainerType<t.ForkData>;
+  ENRForkID: ContainerType<t.ENRForkID>;
   Checkpoint: ContainerType<t.Checkpoint>;
   Validator: ContainerType<t.Validator>;
   AttestationData: ContainerType<t.AttestationData>;
@@ -110,6 +111,7 @@ export const typeNames: (keyof IBeaconSSZTypes)[] = [
   // misc
   "Fork",
   "ForkData",
+  "ENRForkID",
   "Checkpoint",
   "Validator",
   "AttestationData",

--- a/packages/lodestar-types/src/types/misc.ts
+++ b/packages/lodestar-types/src/types/misc.ts
@@ -18,6 +18,7 @@ import {
   CommitteeIndex,
   Bytes32,
   Domain,
+  ForkDigest,
 } from "./primitive";
 
 export interface Fork {
@@ -34,6 +35,15 @@ export interface ForkData {
   currentVersion: Version;
   // root of genesis validator list
   genesisValidatorsRoot: Root;
+}
+
+export interface ENRForkID {
+  // Current fork digest
+  forkDigest: ForkDigest;
+  // next planned fork versin
+  nextForkVersion: Version;
+  // next fork epoch
+  nextForkEpoch: Epoch;
 }
 
 export interface Checkpoint {

--- a/packages/lodestar-utils/test/unit/bytes.test.ts
+++ b/packages/lodestar-utils/test/unit/bytes.test.ts
@@ -2,10 +2,11 @@ import {assert, expect} from "chai";
 import {describe, it} from "mocha";
 import {intToBytes, bytesToInt} from "../../src";
 
-describe("intToBytes", () => {                                    
+describe("intToBytes", () => {
   const zeroedArray = (length: number): number[] => Array.from({length}, () => 0);
   const testCases: { input: [bigint | number, number]; output: Buffer }[] = [
-    {input: [255, 1], output: Buffer.from([255])},                                        
+    {input: [255, 1], output: Buffer.from([255])},
+    {input: [1, 4], output: Buffer.from([1, 0, 0, 0])},
     {input: [255n, 1], output: Buffer.from([255])},
     {input: [65535, 2], output: Buffer.from([255, 255])},
     {input: [65535n, 2], output: Buffer.from([255, 255])},
@@ -31,7 +32,7 @@ describe("intToBytes", () => {
   }
 });
 
-describe.only("bytesToInt", () => {
+describe("bytesToInt", () => {
   const testCases: { input: Buffer; output: number}[] = [
     {input: Buffer.from([3]), output: 3},
     {input: Buffer.from([20, 0]), output: 20},

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -64,7 +64,7 @@ export class BlockProcessor implements IService {
         return abortable(source, abortSignal, {returnOnAbort: true});
       },
       validateBlock(this.config, this.logger, this.db, this.forkChoice),
-      processBlock(this.config, this.db, this.logger, this.forkChoice, this.pendingBlocks),
+      processBlock(this.config, this.db, this.logger, this.forkChoice, this.pendingBlocks, this.eventBus),
       postProcess(
         this.config,
         this.db,

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -10,6 +10,7 @@ import {
   Uint16,
   Uint64,
   ForkDigest,
+  ENRForkID,
 } from "@chainsafe/lodestar-types";
 
 import {ILMDGHOST} from "./forkChoice";
@@ -23,6 +24,8 @@ export interface IChainEvents {
   processedAttestation: (attestation: Attestation) => void;
   justifiedCheckpoint: (checkpoint: Checkpoint) => void;
   finalizedCheckpoint: (checkpoint: Checkpoint) => void;
+  forkDigestChanged: () => void;
+  forkDigest: (forkDigest: ForkDigest) => void;
 }
 
 export type ChainEventEmitter = StrictEventEmitter<EventEmitter, IChainEvents>;
@@ -46,6 +49,11 @@ export interface IBeaconChain extends ChainEventEmitter {
    * Stop beacon chain processing
    */
   stop(): Promise<void>;
+
+  /**
+   * Return ENRForkID.
+   */
+  getENRForkID(): Promise<ENRForkID>;
 
   getHeadState(): Promise<BeaconState|null>;
 

--- a/packages/lodestar/src/network/metadata/metadata.ts
+++ b/packages/lodestar/src/network/metadata/metadata.ts
@@ -1,7 +1,8 @@
 import {BitVector} from "@chainsafe/ssz";
 import {ENR} from "@chainsafe/discv5";
-import {Metadata} from "@chainsafe/lodestar-types";
+import {Metadata, ForkDigest} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IBeaconChain} from "../../chain";
 
 export interface IMetadataOpts {
   enr?: ENR;
@@ -10,21 +11,33 @@ export interface IMetadataOpts {
 
 export interface IMetadataModules {
   config: IBeaconConfig;
+  chain: IBeaconChain;
 }
 
 export class MetadataController {
   public enr?: ENR;
 
   private config: IBeaconConfig;
+  private chain: IBeaconChain;
   private _metadata: Metadata;
 
   constructor(opts: IMetadataOpts, modules: IMetadataModules) {
     this.enr = opts.enr;
     this.config = modules.config;
+    this.chain = modules.chain;
     this._metadata = opts.metadata || this.config.types.Metadata.defaultValue();
+  }
+
+  public async start(): Promise<void> {
     if (this.enr) {
       this.enr.set("attnets", Buffer.from(this.config.types.AttestationSubnets.serialize(this._metadata.attnets)));
+      this.enr.set("eth2", Buffer.from(this.config.types.ENRForkID.serialize(await this.chain.getENRForkID())));
     }
+    this.chain.on("forkDigest", this.handleForkDigest);
+  }
+
+  public async stop(): Promise<void> {
+    this.chain.removeListener("forkDigest", this.handleForkDigest);
   }
 
   get seqNumber(): bigint {
@@ -45,5 +58,12 @@ export class MetadataController {
 
   get metadata(): Metadata {
     return this._metadata;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  private async handleForkDigest(forkDigest: ForkDigest): Promise<void> {
+    if (this.enr) {
+      this.enr.set("eth2", Buffer.from(this.config.types.ENRForkID.serialize(await this.chain.getENRForkID())));
+    }
   }
 }

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -60,7 +60,7 @@ export class Libp2pNetwork extends (EventEmitter as { new(): NetworkEventEmitter
         this.libp2p = libp2p;
         this.reqResp = new ReqResp(opts, {config, libp2p, logger});
         const enr = opts.discv5 && opts.discv5.enr || undefined;
-        this.metadata = new MetadataController({enr}, {config});
+        this.metadata = new MetadataController({enr}, {config, chain});
         this.gossip = (new Gossip(opts, this.metadata,
           {config, libp2p, logger, validator, chain})) as unknown as IGossip;
         resolve();
@@ -73,6 +73,7 @@ export class Libp2pNetwork extends (EventEmitter as { new(): NetworkEventEmitter
     await this.libp2p.start();
     await this.reqResp.start();
     await this.gossip.start();
+    await this.metadata.start();
     this.libp2p.on("peer:connect", this.emitPeerConnect);
     this.libp2p.on("peer:disconnect", this.emitPeerDisconnect);
     const multiaddresses = this.libp2p.peerInfo.multiaddrs.toArray().map((m) => m.toString()).join(",");
@@ -80,6 +81,7 @@ export class Libp2pNetwork extends (EventEmitter as { new(): NetworkEventEmitter
   }
 
   public async stop(): Promise<void> {
+    await this.metadata.stop();
     await this.gossip.stop();
     await this.reqResp.stop();
     await this.libp2p.stop();

--- a/packages/lodestar/test/unit/chain/chain.test.ts
+++ b/packages/lodestar/test/unit/chain/chain.test.ts
@@ -1,0 +1,85 @@
+import chainOpts from "../../../src/chain/options";
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import sinon from "sinon";
+import {expect} from "chai";
+import {StateRepository, BlockRepository} from "../../../src/db/api/beacon/repositories";
+import {IEth1Notifier} from "../../../src/eth1";
+import {InteropEth1Notifier} from "../../../src/eth1/impl/interop";
+import {OpPool} from "../../../src/opPool";
+import {WinstonLogger, bytesToInt} from "@chainsafe/lodestar-utils";
+import {BeaconMetrics} from "../../../src/metrics";
+import {IBeaconChain, BeaconChain, StatefulDagLMDGHOST} from "../../../src/chain";
+import {generateState} from "../../utils/state";
+
+describe("BeaconChain", function() {
+  const sandbox = sinon.createSandbox();
+  let dbStub: any, eth1: IEth1Notifier, opPool: any, metrics: any, forkChoice: any;
+  const logger = new WinstonLogger();
+  let chain: IBeaconChain;
+
+  beforeEach(async () => {
+    dbStub = {
+      state: sandbox.createStubInstance(StateRepository),
+      block: sandbox.createStubInstance(BlockRepository),
+    };
+    eth1 = new InteropEth1Notifier();
+    opPool = sandbox.createStubInstance(OpPool);
+    metrics = sandbox.createStubInstance(BeaconMetrics);
+    forkChoice = sandbox.createStubInstance(StatefulDagLMDGHOST);
+    const state = generateState();
+    dbStub.state.get.resolves(state);
+    dbStub.state.getLatest.resolves(state);
+    chain = new BeaconChain(chainOpts, {config, db: dbStub, eth1, opPool, logger, metrics, forkChoice});
+    await chain.start();
+  });
+
+  afterEach(async () => {
+    await chain.stop();
+    sandbox.restore();
+  });
+
+  describe("getENRForkID", () => {
+    it("should get enr fork id if not found next fork", async () => {
+      forkChoice.headStateRoot.returns(Buffer.alloc(0));
+      const enrForkID = await chain.getENRForkID();
+      expect(config.types.Version.equals(enrForkID.nextForkVersion, Buffer.from([255, 255, 255, 255])));
+      expect(enrForkID.nextForkEpoch === Number.MAX_SAFE_INTEGER);
+      // it's possible to serialize enr fork id
+      config.types.ENRForkID.hashTreeRoot(enrForkID);
+    });
+
+    it("should get enr fork id if found next fork", async () => {
+      config.params.ALL_FORKS = [
+        {
+          currentVersion: 2,
+          epoch: 100,
+          previousVersion: bytesToInt(config.params.GENESIS_FORK_VERSION)
+        }
+      ];
+      forkChoice.headStateRoot.returns(Buffer.alloc(0));
+      const enrForkID = await chain.getENRForkID();
+      expect(config.types.Version.equals(enrForkID.nextForkVersion, Buffer.from([2, 0, 0, 0])));
+      expect(enrForkID.nextForkEpoch === 100);
+      // it's possible to serialize enr fork id
+      config.types.ENRForkID.hashTreeRoot(enrForkID);
+      config.params.ALL_FORKS = undefined;
+    });
+  });
+
+  describe("forkDigestChanged event", () => {
+    it("should should receive forkDigest event", async () => {
+      const spy = sinon.spy();
+      const received = new Promise((resolve) => {
+        chain.on("forkDigest", () => {
+          spy();
+          resolve();
+        });
+      });
+      chain.emit("forkDigestChanged");
+      await received;
+      expect(spy.callCount).to.be.equal(1);
+    });
+  });
+
+
+});

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -1,6 +1,6 @@
 import {EventEmitter} from "events";
 
-import {Number64, Uint16, Uint64, ForkDigest} from "@chainsafe/lodestar-types";
+import {Number64, Uint16, Uint64, ForkDigest, ENRForkID} from "@chainsafe/lodestar-types";
 import {IBeaconChain, ILMDGHOST} from "../../../../src/chain";
 import {IBeaconClock} from "../../../../src/chain/clock/interface";
 import {BeaconState} from "@chainsafe/lodestar-types";
@@ -47,6 +47,10 @@ export class MockBeaconChain extends EventEmitter implements IBeaconChain {
   }
 
   public async initializeBeaconChain(): Promise<void> {
+    return undefined;
+  }
+
+  public async getENRForkID(): Promise<ENRForkID> {
     return undefined;
   }
 


### PR DESCRIPTION
## Goal
+ resolves #750 
+ provide a way to configure planned hard forks
## TODOs work for discv 5:
+ Clients SHOULD connect to peers with fork_digest, next_fork_version, and next_fork_epoch that match local values.
+ Clients MAY connect to peers with the same fork_digest but a different next_fork_version/next_fork_epoch. Unless ENRForkID is manually updated to matching prior to the earlier next_fork_epoch of the two clients, these connecting clients will be unable to successfully interact starting at the earlier next_fork_epoch