### PR TITLE
Fix db key sorting, eth1 retry provider

### DIFF
--- a/packages/lodestar-utils/src/bytes.ts
+++ b/packages/lodestar-utils/src/bytes.ts
@@ -1,37 +1,40 @@
-import {toBufferLE, toBigIntLE} from "bigint-buffer";
+import {
+  toBufferLE, toBigIntLE,
+  toBufferBE, toBigIntBE,
+} from "bigint-buffer";
+
+type Endianness = "le" | "be";
+
 /**
  * Return a byte array from a number or BigInt
  */
-export function intToBytes(value: bigint | number, length: number): Buffer {
-  if (typeof  value === "number" && length <= 6) { // value is a number and length is at most 6 bytes
-    const b = Buffer.alloc(length);
-    b.writeUIntLE(value, 0, length);
-    return b;
-  } else { // value is number and is too large, or a BigInt
-    value = BigInt(value);
-    return toBufferLE(value, length);
-  }
+export function intToBytes(value: bigint | number, length: number, endianness: Endianness = "le"): Buffer {
+  return bigIntToBytes(BigInt(value), length, endianness);
 }
 
 /**
  * Convert byte array in LE to integer.
  */
-export function bytesToInt(value: Uint8Array): number {
-  const length = value.length;
-  let result = 0;
-  for (let i = 0; i < length; i++) {
-    result += value[i] * 2 ** (8 * i);
+export function bytesToInt(value: Uint8Array, endianness: Endianness = "le"): number {
+  return Number(bytesToBigInt(value, endianness));
+}
+
+export function bigIntToBytes(value: bigint, length: number, endianness: Endianness = "le"): Buffer {
+  if (endianness === "le") {
+    return toBufferLE(value, length);
+  } else if (endianness === "be") {
+    return toBufferBE(value, length);
   }
-  return result;
+  throw new Error("endianness must be either 'le' or 'be'");
 }
 
-export function bytesToBigInt(value: Uint8Array): bigint {
-  return toBigIntLE(value as Buffer);
-}
-
-export function bigIntToBytes(value: bigint, length: number): Uint8Array {
-  const b = toBufferLE(value, length);
-  return new Uint8Array(b.buffer, b.byteOffset, length);
+export function bytesToBigInt(value: Uint8Array, endianness: Endianness = "le"): bigint {
+  if (endianness === "le") {
+    return toBigIntLE(value as Buffer);
+  } else if (endianness === "be") {
+    return toBigIntBE(value as Buffer);
+  }
+  throw new Error("endianness must be either 'le' or 'be'");
 }
 
 

--- a/packages/lodestar/src/db/api/beacon/repositories/depositDataRoot.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/depositDataRoot.ts
@@ -1,6 +1,7 @@
 import {List, TreeBacked} from "@chainsafe/ssz";
 import {Root} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {bytesToInt} from "@chainsafe/lodestar-utils";
 
 import {Repository} from "./abstract";
 import {IDatabaseController, IKeyValue} from "../../../controller";
@@ -18,7 +19,7 @@ export class DepositDataRootRepository extends Repository<number, Root> {
   }
 
   public decodeKey(data: Buffer): number {
-    return this.config.types.Number64.deserialize(super.decodeKey(data) as unknown as Uint8Array);
+    return bytesToInt(super.decodeKey(data) as unknown as Uint8Array, "be");
   }
 
   // depositDataRoots stored by depositData index

--- a/packages/lodestar/src/db/api/beacon/repositories/eth1Data.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/eth1Data.ts
@@ -1,5 +1,6 @@
 import {Eth1Data} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {bytesToInt} from "@chainsafe/lodestar-utils";
 
 import {IDatabaseController} from "../../../controller";
 import {Bucket} from "../../schema";
@@ -12,6 +13,10 @@ export class Eth1DataRepository extends Repository<number, Eth1Data> {
     db: IDatabaseController<Buffer, Buffer>,
   ) {
     super(config, db, Bucket.eth1Data, config.types.Eth1Data);
+  }
+
+  public decodeKey(data: Buffer): number {
+    return bytesToInt(super.decodeKey(data) as unknown as Uint8Array, "be");
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/lodestar/src/db/api/schema.ts
+++ b/packages/lodestar/src/db/api/schema.ts
@@ -59,7 +59,7 @@ export function encodeKey(
     buf.write(key, 1);
   } else if (typeof key === "number" || typeof key === "bigint") {
     buf = Buffer.alloc(9);
-    intToBytes(BigInt(key), 8).copy(buf, 1);
+    intToBytes(BigInt(key), 8, "be").copy(buf, 1);
   } else {
     buf = Buffer.alloc(key.length + 1);
     buf.set(key, 1);

--- a/packages/lodestar/src/eth1/impl/retryProvider.ts
+++ b/packages/lodestar/src/eth1/impl/retryProvider.ts
@@ -27,7 +27,7 @@ export class RetryProvider extends JsonRpcProvider {
         },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (error: any) => {
-          if (error.statusCode !== 429 || attempts >= this.attempts) {
+          if (attempts >= this.attempts) {
             return Promise.reject(error);
           } else {
             return Promise.resolve(undefined);

--- a/packages/lodestar/test/unit/db/schema.test.ts
+++ b/packages/lodestar/test/unit/db/schema.test.ts
@@ -20,7 +20,7 @@ describe("encodeKey", () => {
       } else if (typeof key === "string") {
         expected = Buffer.concat([Buffer.from([bucket]), Buffer.from(key)]);
       } else if (typeof key === "number" || typeof key === "bigint") {
-        expected = Buffer.concat([Buffer.from([bucket]), intToBytes(BigInt(key), 8)]);
+        expected = Buffer.concat([Buffer.from([bucket]), intToBytes(BigInt(key), 8, "be")]);
       }
       const actual = encodeKey(bucket, key);
       assert.deepEqual(actual, expected);


### PR DESCRIPTION
- Store integer keys in big-endian format to db. This allows us to use leveldb's sorting properly.
- Make eth1 retry provider more robust (retry on any error)