### PR TITLE
Fix number key database serialization

### DIFF
--- a/packages/lodestar-cli/src/commands/dev/command.ts
+++ b/packages/lodestar-cli/src/commands/dev/command.ts
@@ -96,7 +96,7 @@ export class DevCommand implements ICliCommand {
       {discv5: {enr: ENR.createFromPeerId(peerId), bindAddr: "/ip4/127.0.0.1/udp/0"}},
       {isMergeableObject: isPlainObject}
     );
-    const libp2p = await createNodeJsLibp2p(peerId, conf.network, true);
+    const libp2p = await createNodeJsLibp2p(peerId, conf.network, false);
 
     const config = options.preset === "minimal" ? minimalConfig : mainnetConfig;
     const depositDataRootList = config.types.DepositDataRootList.tree.defaultValue();

--- a/packages/lodestar-cli/src/commands/dev/command.ts
+++ b/packages/lodestar-cli/src/commands/dev/command.ts
@@ -96,7 +96,7 @@ export class DevCommand implements ICliCommand {
       {discv5: {enr: ENR.createFromPeerId(peerId), bindAddr: "/ip4/127.0.0.1/udp/0"}},
       {isMergeableObject: isPlainObject}
     );
-    const libp2p = await createNodeJsLibp2p(peerId, conf.network, false);
+    const libp2p = await createNodeJsLibp2p(peerId, conf.network, true);
 
     const config = options.preset === "minimal" ? minimalConfig : mainnetConfig;
     const depositDataRootList = config.types.DepositDataRootList.tree.defaultValue();

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -55,7 +55,7 @@
     "bl": "^4.0.2",
     "deepmerge": "^3.2.0",
     "es6-promisify": "6.0.2",
-    "ethers": "^4.0.40",
+    "ethers": "^4.0.47",
     "event-iterator": "^1.2.0",
     "fastify": "2.13.0",
     "fastify-cors": "^2.1.3",
@@ -112,6 +112,7 @@
     "eventsource": "^1.0.7",
     "libp2p-ts": "https://github.com/ChainSafe/libp2p-ts.git",
     "mocha": "^6.2.2",
+    "rimraf": "^3.0.2",
     "supertest": "^4.0.2",
     "webpack": "^4.39.1"
   },

--- a/packages/lodestar/src/db/api/beacon/repositories/depositDataRoot.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/depositDataRoot.ts
@@ -1,11 +1,9 @@
 import {List, TreeBacked} from "@chainsafe/ssz";
 import {Root} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {bytesToInt} from "@chainsafe/lodestar-utils";
-
 import {Repository} from "./abstract";
 import {IDatabaseController, IKeyValue} from "../../../controller";
-import {Bucket} from "../../schema";
+import {Bucket, decodeNumberKey} from "../../schema";
 
 export class DepositDataRootRepository extends Repository<number, Root> {
 
@@ -19,7 +17,7 @@ export class DepositDataRootRepository extends Repository<number, Root> {
   }
 
   public decodeKey(data: Buffer): number {
-    return bytesToInt(super.decodeKey(data) as unknown as Uint8Array, "be");
+    return decodeNumberKey(super.decodeKey(data) as unknown as Uint8Array);
   }
 
   // depositDataRoots stored by depositData index

--- a/packages/lodestar/src/db/api/beacon/repositories/eth1Data.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/eth1Data.ts
@@ -3,7 +3,7 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {bytesToInt} from "@chainsafe/lodestar-utils";
 
 import {IDatabaseController} from "../../../controller";
-import {Bucket} from "../../schema";
+import {Bucket, decodeNumberKey} from "../../schema";
 import {Repository} from "./abstract";
 
 export class Eth1DataRepository extends Repository<number, Eth1Data> {
@@ -16,7 +16,7 @@ export class Eth1DataRepository extends Repository<number, Eth1Data> {
   }
 
   public decodeKey(data: Buffer): number {
-    return bytesToInt(super.decodeKey(data) as unknown as Uint8Array, "be");
+    return decodeNumberKey(super.decodeKey(data) as unknown as Uint8Array);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/lodestar/src/db/api/beacon/repositories/eth1Data.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/eth1Data.ts
@@ -1,6 +1,5 @@
 import {Eth1Data} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {bytesToInt} from "@chainsafe/lodestar-utils";
 
 import {IDatabaseController} from "../../../controller";
 import {Bucket, decodeNumberKey} from "../../schema";

--- a/packages/lodestar/src/db/api/schema.ts
+++ b/packages/lodestar/src/db/api/schema.ts
@@ -58,8 +58,9 @@ export function encodeKey(
     buf = Buffer.alloc(key.length + 1);
     buf.write(key, 1);
   } else if (typeof key === "number" || typeof key === "bigint") {
-    buf = Buffer.alloc(9);
-    intToBytes(BigInt(key), 8, "be").copy(buf, 1);
+    const idBuf = Buffer.from(key.toString(10), "ascii");
+    buf = Buffer.alloc(idBuf.length + 1);
+    idBuf.copy(buf, 1);
   } else {
     buf = Buffer.alloc(key.length + 1);
     buf.set(key, 1);

--- a/packages/lodestar/src/db/api/schema.ts
+++ b/packages/lodestar/src/db/api/schema.ts
@@ -1,7 +1,6 @@
 /**
  * @module db/schema
  */
-import {intToBytes} from "@chainsafe/lodestar-utils";
 
 // Buckets are separate database namespaces
 export enum Bucket {

--- a/packages/lodestar/src/db/api/schema.ts
+++ b/packages/lodestar/src/db/api/schema.ts
@@ -57,7 +57,7 @@ export function encodeKey(
     buf = Buffer.alloc(key.length + 1);
     buf.write(key, 1);
   } else if (typeof key === "number" || typeof key === "bigint") {
-    const idBuf = Buffer.from(key.toString(10), "ascii");
+    const idBuf = Buffer.from(key.toString(10), "utf-8");
     buf = Buffer.alloc(idBuf.length + 1);
     idBuf.copy(buf, 1);
   } else {
@@ -66,4 +66,8 @@ export function encodeKey(
   }
   buf.writeUInt8(bucket, 0);
   return buf;
+}
+
+export function decodeNumberKey(key: Uint8Array): number {
+  return Number(Buffer.from(key).toString("utf-8"));
 }

--- a/packages/lodestar/src/eth1/impl/ethers.ts
+++ b/packages/lodestar/src/eth1/impl/ethers.ts
@@ -193,7 +193,7 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
     depositEvents.forEach((depositEvent) => {
       this.emit("deposit", depositEvent.index, depositEvent);
     });
-    this.emit("eth1Data", block.timestamp, eth1Data);
+    this.emit("eth1Data", block.timestamp, eth1Data, blockNumber);
     this.processingBlock = false;
     return true;
   }

--- a/packages/lodestar/src/eth1/impl/ethers.ts
+++ b/packages/lodestar/src/eth1/impl/ethers.ts
@@ -129,7 +129,7 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
     let blockNumber = this.lastProcessedEth1BlockNumber + 1;
     while (blockNumber <= toNumber && await this.processBlock(blockNumber)) {
       blockNumber++;
-    };
+    }
   }
 
   /**

--- a/packages/lodestar/src/eth1/impl/ethers.ts
+++ b/packages/lodestar/src/eth1/impl/ethers.ts
@@ -129,7 +129,7 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
     let blockNumber = this.lastProcessedEth1BlockNumber + 1;
     while (blockNumber <= toNumber && await this.processBlock(blockNumber)) {
       blockNumber++;
-    }
+    };
   }
 
   /**

--- a/packages/lodestar/src/eth1/impl/ethers.ts
+++ b/packages/lodestar/src/eth1/impl/ethers.ts
@@ -7,14 +7,14 @@ import {Contract, ethers} from "ethers";
 import {Block} from "ethers/providers";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {ILogger} from  "@chainsafe/lodestar-utils/lib/logger";
+import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 
 import {isValidAddress} from "../../util/address";
 import {sleep} from "../../util/sleep";
 import {IBeaconDb} from "../../db";
 import {RetryProvider} from "./retryProvider";
 import {IEth1Options} from "../options";
-import {Eth1EventEmitter, IEth1Notifier, IDepositEvent} from "../interface";
+import {Eth1EventEmitter, IDepositEvent, IEth1Notifier} from "../interface";
 
 export interface IEthersEth1Options extends IEth1Options {
   contract?: Contract;
@@ -129,7 +129,7 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
     let blockNumber = this.lastProcessedEth1BlockNumber + 1;
     while (blockNumber <= toNumber && await this.processBlock(blockNumber)) {
       blockNumber++;
-    };
+    }
   }
 
   /**

--- a/packages/lodestar/src/eth1/interface.ts
+++ b/packages/lodestar/src/eth1/interface.ts
@@ -16,7 +16,7 @@ export interface IDepositEvent extends DepositData {
 
 export interface IEth1Events {
   deposit: (index: Number64, depositData: DepositData) => void;
-  eth1Data: (timestamp: number, eth1Data: Eth1Data) => void;
+  eth1Data: (timestamp: number, eth1Data: Eth1Data, blockNumber: number) => void;
 }
 
 export type Eth1EventEmitter = StrictEventEmitter<EventEmitter, IEth1Events>;

--- a/packages/lodestar/test/e2e/db/blockArchive.test.ts
+++ b/packages/lodestar/test/e2e/db/blockArchive.test.ts
@@ -1,0 +1,56 @@
+import {LevelDbController} from "../../../src/db/controller";
+import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import sinon from "sinon";
+// @ts-ignore
+import leveldown from "leveldown";
+import {promisify} from "es6-promisify";
+import {BlockArchiveRepository} from "../../../src/db/api/beacon/repositories";
+import {config} from "@chainsafe/lodestar-config/src/presets/minimal";
+import {SignedBeaconBlock, Slot} from "@chainsafe/lodestar-types";
+import {generateEmptySignedBlock} from "../../utils/block";
+import {mkdirSync} from "fs";
+import {expect} from "chai";
+
+describe("block archive", function () {
+
+  const dbLocation = "./.__testdb";
+
+  let dbController: LevelDbController, blockArchive: BlockArchiveRepository;
+
+  beforeEach(async function () {
+    dbController = new LevelDbController(
+      {name: dbLocation},
+      {logger: sinon.createStubInstance(WinstonLogger)}
+    );
+    blockArchive = new BlockArchiveRepository(config, dbController);
+    mkdirSync(dbLocation, {recursive: true});
+    await dbController.start();
+    await Promise.all(generateBlocks().map((block) => {
+      return blockArchive.put(block.message.slot, block);
+    }));
+  });
+
+  afterEach(async function () {
+    await dbController.stop();
+    await promisify<void, string>(leveldown.destroy)(dbLocation);
+  });
+
+  it("should search for block range", async function () {
+    const filteredBlocks = await blockArchive.values({
+      gte: 2,
+      lt: 4
+    });
+    expect(filteredBlocks.length).to.be.equal(2);
+    expect(filteredBlocks[0].message.slot).to.be.equal(2);
+    expect(filteredBlocks[1].message.slot).to.be.equal(3);
+  });
+
+  function generateBlocks(): SignedBeaconBlock[] {
+    return Array.from({length: 5}, (value: null, slot: Slot) => {
+      const block = generateEmptySignedBlock();
+      block.message.slot = slot;
+      return block;
+    });
+  }
+
+});

--- a/packages/lodestar/test/e2e/eth1/deploy.test.ts
+++ b/packages/lodestar/test/e2e/eth1/deploy.test.ts
@@ -35,7 +35,7 @@ describe("Eth1Notifier - using goerli known deployed contract", () => {
   beforeEach(async function () {
     this.timeout(0);
     rimraf.sync(dbPath);
-    logger.silent = false;
+    logger.silent = true;
     logger.level = LogLevel.verbose;
     db = new BeaconDb({
       config,

--- a/packages/lodestar/test/e2e/eth1/deploy.test.ts
+++ b/packages/lodestar/test/e2e/eth1/deploy.test.ts
@@ -1,14 +1,14 @@
-import * as fs from "fs";
 import {expect} from "chai";
 import {ethers} from "ethers";
 import sinon from "sinon";
-import {describe, it, beforeEach, afterEach} from "mocha";
+import {afterEach, beforeEach, describe, it} from "mocha";
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 import {EthersEth1Notifier, IEth1Notifier} from "../../../src/eth1";
 import defaults from "../../../src/eth1/dev/options";
-import {ILogger, WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
+import {ILogger, LogLevel, WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {BeaconDb, LevelDbController} from "../../../src/db";
 import {IEth1Options} from "../../../src/eth1/options";
+import rimraf from "rimraf";
 
 describe("Eth1Notifier - using goerli known deployed contract", () => {
 
@@ -34,7 +34,9 @@ describe("Eth1Notifier - using goerli known deployed contract", () => {
 
   beforeEach(async function () {
     this.timeout(0);
+    rimraf.sync(dbPath);
     logger.silent = true;
+    logger.level = LogLevel.verbose;
     db = new BeaconDb({
       config,
       controller: new LevelDbController({name: dbPath}, {logger}),
@@ -53,7 +55,7 @@ describe("Eth1Notifier - using goerli known deployed contract", () => {
   afterEach(async () => {
     await eth1Notifier.stop();
     await db.stop();
-    await fs.promises.rmdir(dbPath, {recursive: true});
+    rimraf.sync(dbPath);
     logger.silent = false;
   });
 

--- a/packages/lodestar/test/unit/db/controller/level.test.ts
+++ b/packages/lodestar/test/unit/db/controller/level.test.ts
@@ -1,6 +1,4 @@
-import {assert, expect} from "chai";
-// @ts-ignore
-import level from "level";
+import {expect} from "chai";
 // @ts-ignore
 import leveldown from "leveldown";
 import {LevelDbController} from "../../../../src/db/controller";

--- a/packages/lodestar/test/unit/db/schema.test.ts
+++ b/packages/lodestar/test/unit/db/schema.test.ts
@@ -20,7 +20,7 @@ describe("encodeKey", () => {
       } else if (typeof key === "string") {
         expected = Buffer.concat([Buffer.from([bucket]), Buffer.from(key)]);
       } else if (typeof key === "number" || typeof key === "bigint") {
-        expected = Buffer.concat([Buffer.from([bucket]), intToBytes(BigInt(key), 8, "be")]);
+        expected = Buffer.concat([Buffer.from([bucket]), Buffer.from(key.toString(10), "ascii")]);
       }
       const actual = encodeKey(bucket, key);
       assert.deepEqual(actual, expected);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6253,6 +6253,21 @@ ethers@^4.0.40:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
+ethers@^4.0.47:
+  version "4.0.47"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.47.tgz#91b9cd80473b1136dd547095ff9171bd1fc68c85"
+  integrity sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==
+  dependencies:
+    aes-js "3.0.0"
+    bn.js "^4.4.0"
+    elliptic "6.5.2"
+    hash.js "1.1.3"
+    js-sha3 "0.5.7"
+    scrypt-js "2.0.4"
+    setimmediate "1.0.4"
+    uuid "2.0.1"
+    xmlhttprequest "1.8.0"
+
 ethjs-unit@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-unit/-/ethjs-unit-0.1.6.tgz#c665921e476e87bce2a9d588a6fe0405b2c41699"
@@ -12391,7 +12406,7 @@ rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
Leveldb is sorting keys lexicographic so it seems best way to keep order with number keys is to serialize them as utf8 string.