### PR TITLE
Add bootEnrs cli option

### DIFF
--- a/packages/lodestar-cli/src/lodecli/cmds/beacon/cmds/run/options/network.ts
+++ b/packages/lodestar-cli/src/lodecli/cmds/beacon/cmds/run/options/network.ts
@@ -18,6 +18,17 @@ export const discv5BindAddr: Options = {
   group: "network",
 };
 
+export const discv5BootEnrs: Options = {
+  alias: [
+    "network.discv5.bootEnrs",
+  ],
+  type: "array",
+  default: [],
+  group: "network",
+};
+
+
+
 export const networkMaxPeers: Options = {
   alias: [
     "network.maxPeers",

--- a/packages/lodestar-cli/src/lodecli/cmds/beacon/cmds/run/run.ts
+++ b/packages/lodestar-cli/src/lodecli/cmds/beacon/cmds/run/run.ts
@@ -14,6 +14,7 @@ import {WinstonLogger} from "@chainsafe/lodestar-utils";
 
 import {readPeerId, readEnr, writeEnr} from "../../../../network";
 import {IBeaconArgs} from "../../options";
+import {ENR} from "@chainsafe/discv5";
 
 /**
  * Run a beacon node
@@ -24,7 +25,12 @@ export async function run(options: Arguments<IBeaconArgs & Partial<IBeaconNodeOp
   options = deepmerge(defaultOptions, options) as Arguments<IBeaconArgs & Partial<IBeaconNodeOptions>>;
 
   const peerId = await readPeerId(options.network.peerIdFile);
+  // read local enr from disk
   options.network.discv5.enr = await readEnr(options.network.enrFile);
+  // read bootstrap enrs from configuration
+  options.network.discv5.bootEnrs = options.network.discv5.bootEnrs
+    ? options.network.discv5.bootEnrs.map(e => ENR.decodeTxt(e as unknown as string))
+    : [];
 
   const config = createIBeaconConfig({
     ...(options.chain.name === "mainnet" ? mainnetParams : minimalParams),

--- a/packages/lodestar/src/network/nodejs/bundle.ts
+++ b/packages/lodestar/src/network/nodejs/bundle.ts
@@ -53,6 +53,7 @@ export class NodejsNode extends LibP2p {
             peerInfo: options.peerInfo
           },
           bootstrap: {
+            enabled: !!(options.bootnodes && options.bootnodes.length),
             interval: 2000,
             list: (options.bootnodes || []) as string[],
           },


### PR DESCRIPTION
Ideally, the discv5 engine would accept the bootEnrs as strings directly
until then, we can parse here