### PR TITLE
Best effort load beacon config

### DIFF
--- a/packages/lodestar-cli/src/lodecli/cmds/beacon/config.ts
+++ b/packages/lodestar-cli/src/lodecli/cmds/beacon/config.ts
@@ -31,7 +31,11 @@ export async function writeBeaconConfig(filename: string, config: Partial<IBeaco
  * This needs to be a synchronous function because it will be run as part of the yargs 'build' step
  */
 export function readBeaconConfig(filename: string): Partial<IBeaconNodeOptions> {
-  return readFileSync(filename) as Partial<IBeaconNodeOptions>;
+  try {
+    return readFileSync(filename) as Partial<IBeaconNodeOptions>;
+  } catch(e) {
+    return {};
+  }
 }
 
 export async function initBeaconConfig(filename: string, args: IBeaconArgs): Promise<void> {


### PR DESCRIPTION
This lets us run `lodecli beacon run --help` without having run `lodecli beacon init`