### PR TITLE
Include non-null values in config which are either not hidden or not default

### DIFF
--- a/packages/lodestar-cli/src/lodecli/cmds/beacon/config.ts
+++ b/packages/lodestar-cli/src/lodecli/cmds/beacon/config.ts
@@ -14,10 +14,11 @@ export function createBeaconConfig(args: IBeaconArgs): Partial<IBeaconNodeOption
   // don't create hidden options
   const config: Partial<IBeaconNodeOptions> = {};
   for (const [alias, option] of Object.entries(beaconRunOptions)) {
-    if (!option.hidden && option.default !== undefined) {
-      // handle duck typed access to a subobject
-      const preferredNameArr = alias.split(".");
-      setSubObject(config, preferredNameArr, getSubObject(cliDefaults, preferredNameArr));
+    // handle duck typed access to a subobject
+    const preferredNameArr = alias.split(".");
+    const value = getSubObject(cliDefaults, preferredNameArr);
+    if (value !== undefined && (value !== option.default || !option.hidden)) {
+      setSubObject(config, preferredNameArr, value);
     }
   }
   return config;


### PR DESCRIPTION
Allows us to set `chain.genesisStateFile` and others via `lodecli beacon init`