### PR TITLE
Fix status request head root computation

### DIFF
--- a/packages/lodestar/test/e2e/sync/reqResp.test.ts
+++ b/packages/lodestar/test/e2e/sync/reqResp.test.ts
@@ -140,7 +140,7 @@ describe("[sync] rpc", function () {
     await new Promise((resolve, reject) => {
       // if there is goodbye request from B
       netA.reqResp.once("request", reject);
-      setTimeout(resolve, 200);
+      setTimeout(resolve, 1000);
     });
     expect(repsA.get(netB.peerInfo.id.toB58String()).latestStatus).to.not.equal(null);
     expect(repsB.get(netA.peerInfo.id.toB58String()).latestStatus).to.not.equal(null);

--- a/packages/lodestar/test/e2e/sync/reqResp.test.ts
+++ b/packages/lodestar/test/e2e/sync/reqResp.test.ts
@@ -140,7 +140,7 @@ describe("[sync] rpc", function () {
     await new Promise((resolve, reject) => {
       // if there is goodbye request from B
       netA.reqResp.once("request", reject);
-      setTimeout(resolve, 1000);
+      setTimeout(resolve, 2000);
     });
     expect(repsA.get(netB.peerInfo.id.toB58String()).latestStatus).to.not.equal(null);
     expect(repsB.get(netA.peerInfo.id.toB58String()).latestStatus).to.not.equal(null);


### PR DESCRIPTION
See discord chat:

> 
> Found a likely cause of the status request being weird, don't have a good setup yet to trigger it from lodestar, but chances are this is it
> 
> headRoot: this.config.types.BeaconBlockHeader.hashTreeRoot(state.latestBlockHeader),
> 
> 
> This is half-wrong. The hash-tree-root of the latest block header only equals the head-block root if the state-root in the latest-block-header is updated
> Normally this happens as the first thing in the next slot, since the state root is a result of processing the block that is represented by latest-block-header
> This is in reqResp.ts
>
> Logged the root with a dirty console log. And yes, the root was incorrect, and after my fix, it correctly sends 0xc9cbcb8ceb9b5f71216f5137282bf6a1e3b50f64e42d6c7fb347abe07eb0db82 in its Status request

As reference, see parent root for block at slot 1 in the explorer: https://schlesi.beaconcha.in/block/78339bf5938b8ea805799488d0f474af2fa5839025965ca63295cb55e2e8b84a