### PR TITLE
Process eth1 blocks in bulk

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -9,7 +9,6 @@ import {
   BeaconState,
   Checkpoint,
   ENRForkID,
-  Eth1Data,
   ForkDigest,
   SignedBeaconBlock,
   Uint16,
@@ -25,7 +24,7 @@ import {EMPTY_SIGNATURE, GENESIS_SLOT} from "../constants";
 import {IBeaconDb} from "../db";
 import {IEth1Notifier} from "../eth1";
 import {IBeaconMetrics} from "../metrics";
-import {getEmptyBlock, initializeBeaconStateFromEth1, isValidGenesisState} from "./genesis/genesis";
+import {getEmptyBlock, GenesisBuilder} from "./genesis/genesis";
 import {ILMDGHOST, ArrayDagLMDGHOST} from "./forkChoice";
 
 import {ChainEventEmitter, IAttestationProcessor, IBeaconChain} from "./interface";
@@ -306,16 +305,10 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     let state: TreeBacked<BeaconState> = await this.db.stateArchive.lastValue();
     if (!state) {
       this.logger.info("Chain not started, listening for genesis block");
-      state = await new Promise((resolve) => {
-        const genesisListener = async (timestamp: number, eth1Data: Eth1Data): Promise<void> => {
-          const state = await this.checkGenesis(timestamp, eth1Data);
-          if (state) {
-            this.eth1.removeListener("eth1Data", genesisListener);
-            resolve(state);
-          }
-        };
-        this.eth1.on("eth1Data", genesisListener);
-      });
+      const builder = new GenesisBuilder(this.config, {eth1: this.eth1, db: this.db, logger: this.logger});
+      state = await builder.genesis();
+      await this.initializeBeaconChain(state);
+      this.logger.info(`Genesis state is ready with ${state.validators.length} validators`);
     }
     // set metrics based on beacon state
     this.metrics.currentSlot.set(state.slot);
@@ -324,41 +317,4 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     this.metrics.currentFinalizedEpoch.set(state.finalizedCheckpoint.epoch);
     return state;
   }
-
-  /**
-   * Create a candidate BeaconState from the deposits at a certain time and eth1 state
-   *
-   * Returns the BeaconState if it is valid else null
-   */
-  private checkGenesis = async (timestamp: number, eth1Data: Eth1Data): Promise<TreeBacked<BeaconState> | null> => {
-    const blockHashHex = toHexString(eth1Data.blockHash);
-    this.logger.info(`Checking if block ${blockHashHex} will form valid genesis state`);
-    const depositDatas = await this.db.depositData.values({lt: eth1Data.depositCount});
-    const depositDataRoots = await this.db.depositDataRoot.values({lt: eth1Data.depositCount});
-    this.logger.info(`Found ${depositDatas.length} deposits`);
-    const depositDataRootList = this.config.types.DepositDataRootList.tree.defaultValue();
-    const tree = depositDataRootList.tree();
-
-    const genesisState = initializeBeaconStateFromEth1(
-      this.config,
-      eth1Data.blockHash,
-      timestamp,
-      depositDatas.map((data, index) => {
-        depositDataRootList.push(depositDataRoots[index]);
-        return {
-          proof: tree.getSingleProof(depositDataRootList.gindexOfProperty(index)),
-          data,
-        };
-      })
-    );
-    if (!isValidGenesisState(this.config, genesisState)) {
-      this.logger.info(`Eth1 block ${blockHashHex} is NOT forming valid genesis state`);
-      return null;
-    }
-    this.logger.info(`Initializing beacon chain with eth1 block ${blockHashHex}`);
-    await this.initializeBeaconChain(genesisState as TreeBacked<BeaconState>);
-    this.logger.info(`Genesis state is ready with ${genesisState.validators.length} validators`);
-    return genesisState;
-  };
-
 }

--- a/packages/lodestar/src/chain/genesis/genesis.ts
+++ b/packages/lodestar/src/chain/genesis/genesis.ts
@@ -2,7 +2,6 @@
  * @module chain/genesis
  */
 
-import {TreeBacked} from "@chainsafe/ssz";
 import {
   BeaconBlock,
   BeaconBlockBody,
@@ -14,6 +13,7 @@ import {
   Bytes32,
   Fork,
   SignedBeaconBlock,
+  Root,
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
@@ -28,8 +28,160 @@ import {
   getTemporaryBlockHeader,
   processDeposit,
 } from "@chainsafe/lodestar-beacon-state-transition";
-import {bigIntMin} from "@chainsafe/lodestar-utils";
+import {bigIntMin, ILogger} from "@chainsafe/lodestar-utils";
+import {TreeBacked, List, fromHexString} from "@chainsafe/ssz";
+import {IBeaconDb} from "../../db";
+import {IEth1Notifier, IDepositEvent} from "../../eth1";
+import pipe from "it-pipe";
 
+export interface IGenesisBuilderModules {
+  db: IBeaconDb;
+  eth1: IEth1Notifier;
+  logger: ILogger;
+}
+
+export class GenesisBuilder {
+  private state: TreeBacked<BeaconState>;
+  private depositTree: TreeBacked<List<Root>>;
+  private readonly config: IBeaconConfig;
+  private readonly db: IBeaconDb;
+  private readonly eth1: IEth1Notifier;
+  private readonly logger: ILogger;
+
+  private deposits: Deposit[];
+
+  constructor(config: IBeaconConfig, {eth1, db, logger}: IGenesisBuilderModules) {
+    this.state = getGenesisBeaconState(
+      config,
+      config.types.Eth1Data.defaultValue(),
+      getTemporaryBlockHeader(
+        config,
+        getEmptyBlock()
+      )
+    );
+    this.depositTree = config.types.DepositDataRootList.tree.defaultValue();
+    this.config = config;
+    this.eth1 = eth1;
+    this.db = db;
+    this.logger = logger;
+    this.deposits = [];
+  }
+
+
+  /**
+   * This processes an eth1 block and check if it can form genesis state of eth1.
+   */
+  public isFormingValidGenesisState = async (events: IDepositEvent[]): Promise<boolean> => {
+    const block = await this.eth1.getBlock(events[0].blockNumber);
+    applyTimestamp(this.config, this.state, block.timestamp);
+    applyEth1BlockHash(this.state, fromHexString(block.hash));
+    const isValid = isValidGenesisState(this.config, this.state);
+    this.logger.verbose(`genesis: Process block ${block.number}, valid genesis state=${isValid}`);
+    if (isValid) {
+      const eth1Data = {
+        blockHash: fromHexString(block.hash),
+        depositRoot: this.depositTree.tree().root,
+        depositCount: events[events.length - 1].index + 1,
+      };
+      await this.db.eth1Data.put(block.timestamp, eth1Data);
+    }
+    return isValid;
+  };
+
+  public processDepositEvents(): ((source: AsyncIterable<IDepositEvent[]>) => AsyncIterable<IDepositEvent[]>) {
+    const {logger, doProcessDepositEvents, config} = this;
+    return ((source: AsyncIterable<IDepositEvent[]>): AsyncIterable<IDepositEvent[]> => {
+      return async function* () {
+        for await (const depositEvents of source) {
+          const lastBlockNumber = depositEvents[depositEvents.length - 1].blockNumber;
+          const firstBlockNumber = depositEvents[0].blockNumber;
+          for (let blockNumber = firstBlockNumber; blockNumber <= lastBlockNumber; blockNumber++) {
+            const blockDepositEvents = depositEvents.filter(event => event.blockNumber === blockNumber);
+            if (blockDepositEvents.length > 0) {
+              await doProcessDepositEvents(blockDepositEvents);
+              const depositCount = blockDepositEvents[blockDepositEvents.length - 1].index + 1;
+              logger.info(`genesis: Found ${blockDepositEvents.length} deposit events for block ${blockNumber}, ` +
+                `depositCount=${depositCount}`);
+              if (depositCount >= config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT) {
+                yield blockDepositEvents;
+              }
+            }
+          }
+        }
+      }();
+    });
+  }
+
+  public genesis = async (): Promise<TreeBacked<BeaconState>> => {
+    await this.initialize();
+    const eth1DataStream = await this.eth1.getDepositEventsByBlock(true, undefined);
+    const {isFormingValidGenesisState: processSingleBlock, state} = this;
+    const foundGenesis = this.eth1.foundGenesis.bind(this.eth1);
+    return await pipe(eth1DataStream,
+      this.processDepositEvents(),
+      async function(source: AsyncIterable<IDepositEvent[]>) {
+        for await (const depositEvents of source) {
+          const isValidGenesis = await processSingleBlock(depositEvents);
+          if (isValidGenesis) {
+            await foundGenesis();
+            return state;
+          }
+        }
+      });
+  };
+
+  /**
+   * This processes deposit events of a single eth1 block.
+   */
+  private doProcessDepositEvents = async (depositEvents: IDepositEvent[]): Promise<void> => {
+    const depositDataRoots = new Map<number, Root>();
+    depositEvents.forEach(
+      event => depositDataRoots.set(event.index, this.config.types.DepositData.hashTreeRoot(event)));
+    await Promise.all([
+      // op pool depositData
+      this.db.depositData.batchPut(depositEvents.map((depositEvent) => ({
+        key: depositEvent.index,
+        value: depositEvent,
+      }))),
+      // deposit data roots
+      this.db.depositDataRoot.batchPut(depositEvents.map((depositEvent) => ({
+        key: depositEvent.index,
+        value: depositDataRoots.get(depositEvent.index),
+      }))),
+      this.db.setLastProcessedEth1BlockNumber(depositEvents[0].blockNumber),
+    ]);
+    const deposits = depositEvents.map((depositEvent) => {
+      this.depositTree.push(depositDataRoots.get(depositEvent.index));
+      return {
+        proof: this.depositTree.tree().getSingleProof(this.depositTree.gindexOfProperty(depositEvent.index)),
+        data: depositEvent,
+      };
+    });
+    this.deposits.push(...deposits);
+    applyDeposits(this.config, this.state, this.deposits, this.depositTree);
+  };
+
+  private async initialize(): Promise<void> {
+    const depositDatas = await this.db.depositData.values();
+    const depositDataRoots = await this.db.depositDataRoot.values();
+    const deposits = depositDatas.map((event, index) => {
+      this.depositTree.push(depositDataRoots[index]);
+      return {
+        proof: this.depositTree.tree().getSingleProof(this.depositTree.gindexOfProperty(index)),
+        data: event,
+      };
+    });
+    this.deposits.push(...deposits);
+  }
+}
+
+/**
+ * Mainly used for spec test.
+ * @param config
+ * @param eth1BlockHash
+ * @param eth1Timestamp
+ * @param deposits
+ */
 export function initializeBeaconStateFromEth1(
   config: IBeaconConfig,
   eth1BlockHash: Bytes32,
@@ -37,7 +189,6 @@ export function initializeBeaconStateFromEth1(
   deposits: Deposit[]): TreeBacked<BeaconState> {
   const state = getGenesisBeaconState(
     config,
-    eth1Timestamp - eth1Timestamp % config.params.MIN_GENESIS_DELAY + 2 * config.params.MIN_GENESIS_DELAY,
     {
       depositCount: deposits.length,
       depositRoot: new Uint8Array(32),
@@ -49,14 +200,53 @@ export function initializeBeaconStateFromEth1(
     )
   );
 
+  applyTimestamp(config, state, eth1Timestamp);
+
   // Process deposits
+  applyDeposits(config, state, deposits);
+
+  return state as TreeBacked<BeaconState>;
+}
+
+function applyEth1BlockHash(state: BeaconState, eth1BlockHash: Bytes32): void {
+  state.eth1Data.blockHash = eth1BlockHash;
+}
+
+function applyTimestamp(config: IBeaconConfig, state: BeaconState, eth1Timestamp: number): void {
+  state.genesisTime =
+    eth1Timestamp - eth1Timestamp % config.params.MIN_GENESIS_DELAY + 2 * config.params.MIN_GENESIS_DELAY;
+}
+
+/**
+ * Apply deposits for a state.
+ * @param config IBeaconConfig
+ * @param state BeaconState
+ * @param deposits full list of deposits
+ */
+function applyDeposits(
+  config: IBeaconConfig,
+  state: BeaconState,
+  deposits: Deposit[],
+  fullDepositDataRootList?: TreeBacked<List<Root>>
+): void {
+  state.eth1Data.depositCount = deposits.length;
   const leaves = deposits.map((deposit) => deposit.data);
+  const depositDataRootList: Root[] = [];
   deposits.forEach((deposit, index) => {
-    const depositDataList = leaves.slice(0, index + 1);
-    state.eth1Data.depositRoot = config.types.DepositDataRootList.hashTreeRoot(
-      depositDataList.map((d) => config.types.DepositData.hashTreeRoot(d))
-    );
-    processDeposit(config, state, deposit);
+    if (fullDepositDataRootList) {
+      depositDataRootList.push(fullDepositDataRootList[index]);
+    }
+    if (index >= state.eth1DepositIndex) {
+      if (fullDepositDataRootList) {
+        state.eth1Data.depositRoot = config.types.DepositDataRootList.hashTreeRoot(depositDataRootList);
+      } else {
+        const depositDataList = leaves.slice(0, index + 1);
+        state.eth1Data.depositRoot = config.types.DepositDataRootList.hashTreeRoot(
+          depositDataList.map((d) => config.types.DepositData.hashTreeRoot(d))
+        );
+      }
+      processDeposit(config, state, deposit);
+    }
   });
 
   // Process activations
@@ -75,7 +265,6 @@ export function initializeBeaconStateFromEth1(
   // Set genesis validators root for domain separation and chain versioning
   state.genesisValidatorsRoot = config.types.BeaconState.fields.validators.hashTreeRoot(state.validators);
 
-  return state as TreeBacked<BeaconState>;
 }
 
 export function isValidGenesisState(config: IBeaconConfig, state: BeaconState): boolean {
@@ -91,19 +280,17 @@ export function isValidGenesisState(config: IBeaconConfig, state: BeaconState): 
 /**
  * Generate the initial beacon chain state.
  */
-export function getGenesisBeaconState(
+function getGenesisBeaconState(
   config: IBeaconConfig,
-  genesisTime: Number64,
   genesisEth1Data: Eth1Data,
   latestBlockHeader: BeaconBlockHeader
-): BeaconState {
+): TreeBacked<BeaconState> {
   // Seed RANDAO with Eth1 entropy
   const randaoMixes = Array<Bytes32>(config.params.EPOCHS_PER_HISTORICAL_VECTOR).fill(genesisEth1Data.blockHash);
 
   const state: BeaconState = config.types.BeaconState.tree.defaultValue();
   // MISC
   state.slot = GENESIS_SLOT;
-  state.genesisTime = genesisTime;
   state.fork = {
     previousVersion: config.params.GENESIS_FORK_VERSION,
     currentVersion: config.params.GENESIS_FORK_VERSION,
@@ -119,7 +306,7 @@ export function getGenesisBeaconState(
   state.eth1Data = genesisEth1Data;
   state.randaoMixes = randaoMixes;
 
-  return state;
+  return state as TreeBacked<BeaconState>;
 }
 
 export function getEmptyBlockBody(): BeaconBlockBody {

--- a/packages/lodestar/src/chain/genesis/genesis.ts
+++ b/packages/lodestar/src/chain/genesis/genesis.ts
@@ -114,7 +114,7 @@ export class GenesisBuilder {
 
   public genesis = async (): Promise<TreeBacked<BeaconState>> => {
     await this.initialize();
-    const eth1DataStream = await this.eth1.getDepositEventsByBlock(true, undefined);
+    const eth1DataStream = await this.eth1.getDepositEventsFromBlock(true, undefined);
     const {isFormingValidGenesisState: processSingleBlock, state} = this;
     const foundGenesis = this.eth1.foundGenesis.bind(this.eth1);
     return await pipe(eth1DataStream,
@@ -130,9 +130,6 @@ export class GenesisBuilder {
       });
   };
 
-  /**
-   * This processes deposit events of a single eth1 block.
-   */
   private doProcessDepositEvents = async (depositEvents: IDepositEvent[]): Promise<void> => {
     const depositDataRoots = new Map<number, Root>();
     depositEvents.forEach(

--- a/packages/lodestar/src/db/api/beacon/beacon.ts
+++ b/packages/lodestar/src/db/api/beacon/beacon.ts
@@ -82,7 +82,6 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
     this.stateCache.clear();
   }
 
-  // TODO: small e2e to make sure it works
   public async getLastProcessedEth1BlockNumber(): Promise<number> {
     const data = await this.db.get(
       encodeKey(Bucket.chainInfo, "lastProcessedBlockNumber")

--- a/packages/lodestar/src/db/api/beacon/beacon.ts
+++ b/packages/lodestar/src/db/api/beacon/beacon.ts
@@ -20,6 +20,8 @@ import {
   VoluntaryExitRepository
 } from "./repositories";
 import {StateCache} from "./stateCache";
+import {encodeKey, Bucket} from "../schema";
+import {bytesToInt, intToBytes} from "@chainsafe/lodestar-utils";
 
 export class BeaconDb extends DatabaseService implements IBeaconDb {
 
@@ -78,5 +80,21 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
   public async stop(): Promise<void> {
     await super.stop();
     this.stateCache.clear();
+  }
+
+  // TODO: small e2e to make sure it works
+  public async getLastProcessedEth1BlockNumber(): Promise<number> {
+    const data = await this.db.get(
+      encodeKey(Bucket.chainInfo, "lastProcessedBlockNumber")
+    );
+    if(!data) {
+      return undefined;
+    }
+    return bytesToInt(data);
+  }
+
+  public async setLastProcessedEth1BlockNumber(eth1BlockNumber: number): Promise<void> {
+    const data = intToBytes(eth1BlockNumber, 32);
+    return this.db.put(encodeKey(Bucket.chainInfo, "lastProcessedBlockNumber"), data);
   }
 }

--- a/packages/lodestar/src/db/api/beacon/interface.ts
+++ b/packages/lodestar/src/db/api/beacon/interface.ts
@@ -67,4 +67,8 @@ export interface IBeaconDb {
   getValidatorIndex(publicKey: BLSPubkey): Promise<ValidatorIndex | null>;
 
   processBlockOperations(signedBlock: SignedBeaconBlock): Promise<void>;
+
+  getLastProcessedEth1BlockNumber(): Promise<number>;
+
+  setLastProcessedEth1BlockNumber(eth1BlockNumber: number): Promise<void>;
 }

--- a/packages/lodestar/src/db/api/beacon/repositories/depositDataRoot.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/depositDataRoot.ts
@@ -51,12 +51,13 @@ export class DepositDataRootRepository extends Repository<number, Root> {
       await this.initTree();
     }
     const tree = this.depositRootTree.clone();
-    const maxIndex = tree.length - 1;
+    let maxIndex = tree.length - 1;
     if (depositIndex > maxIndex) {
       throw new Error(`Cannot get tree for unseen deposits: requested ${depositIndex}, last seen ${maxIndex}`);
     }
     while (maxIndex > depositIndex) {
       tree.pop();
+      maxIndex = tree.length - 1;
     }
     return tree;
   }

--- a/packages/lodestar/src/eth1/impl/ethers.ts
+++ b/packages/lodestar/src/eth1/impl/ethers.ts
@@ -5,16 +5,16 @@
 import {EventEmitter} from "events";
 import {Contract, ethers} from "ethers";
 import {Block} from "ethers/providers";
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from  "@chainsafe/lodestar-utils/lib/logger";
-
 import {isValidAddress} from "../../util/address";
-import {sleep} from "../../util/sleep";
-import {IBeaconDb} from "../../db";
 import {RetryProvider} from "./retryProvider";
 import {IEth1Options} from "../options";
 import {Eth1EventEmitter, IEth1Notifier, IDepositEvent} from "../interface";
+import pushable, {Pushable} from "it-pushable";
+import pipe from "it-pipe";
+import {sleep} from "../../util/sleep";
 
 export interface IEthersEth1Options extends IEth1Options {
   contract?: Contract;
@@ -22,7 +22,6 @@ export interface IEthersEth1Options extends IEth1Options {
 
 export interface IEthersEth1Modules {
   config: IBeaconConfig;
-  db: IBeaconDb;
   logger: ILogger;
 }
 
@@ -42,19 +41,18 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
   private contract: ethers.Contract;
 
   private config: IBeaconConfig;
-  private db: IBeaconDb;
   private logger: ILogger;
 
   private started: boolean;
-  private processingBlock: boolean;
   private lastProcessedEth1BlockNumber: number;
-  private lastProcessedDepositIndex: number;
+  private eth1DataSource: Pushable<IDepositEvent[]>;
+  private targetBlockSource: Pushable<number>;
+  private processingBlock: boolean;
 
-  public constructor(opts: IEthersEth1Options, {config, db, logger}: IEthersEth1Modules) {
+  public constructor(opts: IEthersEth1Options, {config, logger}: IEthersEth1Modules) {
     super();
     this.opts = opts;
     this.config = config;
-    this.db = db;
     this.logger = logger;
     if(this.opts.providerInstance) {
       this.provider = this.opts.providerInstance;
@@ -78,27 +76,48 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
       return;
     }
     this.started = true;
-    if(!this.contract) {
-      await this.initContract();
+    await this.initialize();
+  }
+
+  /**
+   * Main methods to be called either to build genesis state or to save data to propose block later.
+   * @param isScanEth1ForGenesis
+   * @param fromBlock
+   */
+  public async getDepositEventsByBlock(
+    isScanEth1ForGenesis: boolean, fromBlock?: number): Promise<Pushable<IDepositEvent[]>> {
+    if (!isScanEth1ForGenesis && !this.opts.enabled) {
+      this.logger.warn(`eth1 is disabled so can't get deposit event, fromBlock=${fromBlock}`);
+      return null;
     }
-    const lastProcessedBlockTag = await this.getLastProcessedBlockTag();
-    this.lastProcessedEth1BlockNumber = (await this.getBlock(lastProcessedBlockTag)).number;
-    this.lastProcessedDepositIndex = await this.getLastProcessedDepositIndex();
-    this.logger.info(
-      `Started listening to eth1 provider ${this.opts.provider.url} on chain ${this.opts.provider.network}`
-    );
-    this.logger.verbose(
-      `Last processed block number: ${this.lastProcessedEth1BlockNumber}, ` +
-      `last processed deposit index: ${this.lastProcessedDepositIndex}`
-    );
-    const headBlockNumber = await this.provider.getBlockNumber();
-    // process historical unprocessed blocks up to curent head
-    // then start listening for incoming blocks
-    this.processBlocks(headBlockNumber).then(() => {
-      if(this.started) {
-        this.provider.on("block", this.onNewEth1Block.bind(this));
-      }
-    });
+    // if we try to form deposit, allow to scan deposit events even eth1 is disabled
+    if (!this.opts.enabled) {
+      await this.initialize();
+    }
+    this.lastProcessedEth1BlockNumber = fromBlock || this.opts.depositContract.deployedAt - 1;
+    this.logger.info("eth1: Get deposit events by block from block " + this.lastProcessedEth1BlockNumber);
+    this.eth1DataSource = pushable<IDepositEvent[]>();
+    this.targetBlockSource = pushable<number>();
+    // should not wait
+    this.doGetDepositEventsByBlock();
+    return this.eth1DataSource;
+  }
+
+  /**
+   * Called by genesis builder to inform that we found genesis state.
+   * Should stop pushing deposit events to genesis builder.
+   */
+  public async foundGenesis(): Promise<void> {
+    this.eth1DataSource.end();
+    this.eth1DataSource = undefined;
+    this.targetBlockSource.end();
+    this.targetBlockSource = undefined;
+    // we'll start listening for new block after chain starts
+    this.provider.removeAllListeners("block");
+    while (this.processingBlock) {
+      await sleep(5);
+    }
+    this.logger.info("eth1 foundGenesis: stopped scanning eth1 data");
   }
 
   public async stop(): Promise<void> {
@@ -106,110 +125,38 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
       this.logger.verbose("Eth1 notifier already stopped");
       return;
     }
+    if (this.eth1DataSource) {
+      this.eth1DataSource.end();
+      this.eth1DataSource = undefined;
+    }
+    if (this.targetBlockSource) {
+      this.targetBlockSource.end();
+      this.targetBlockSource = undefined;
+    }
     this.provider.removeAllListeners("block");
     this.started = false;
     while (this.processingBlock) {
       await sleep(5);
     }
-  }
-
-  public async getLastProcessedBlockTag(): Promise<string | number> {
-    const lastEth1Data = await this.db.eth1Data.lastValue();
-    return lastEth1Data ? toHexString(lastEth1Data.blockHash) : this.opts.depositContract.deployedAt;
-  }
-  public async getLastProcessedDepositIndex(): Promise<number> {
-    const lastStoredIndex = await this.db.depositDataRoot.lastKey();
-    return lastStoredIndex === null ? -1 : lastStoredIndex;
+    this.logger.info("eth1: stopped scanning eth1 data");
   }
 
   public async onNewEth1Block(blockNumber: number): Promise<void> {
     const followBlockNumber = blockNumber - this.config.params.ETH1_FOLLOW_DISTANCE;
-    if (followBlockNumber > 0 && followBlockNumber > this.lastProcessedEth1BlockNumber) {
-      await this.processBlocks(followBlockNumber);
+    if (followBlockNumber > 0) {
+      this.targetBlockSource.push(followBlockNumber);
     }
   }
 
-  public async processBlocks(toNumber: number): Promise<void> {
-    let blockNumber = this.lastProcessedEth1BlockNumber + 1;
-    while (blockNumber <= toNumber && await this.processBlock(blockNumber)) {
-      blockNumber++;
-    }
-  }
-
-  /**
-   * Process an eth1 block for DepositEvents and Eth1Data
-   *
-   * Must process blocks in order with no gaps
-   *
-   * Returns true if processing was successful
-   */
-  public async processBlock(blockNumber: number): Promise<boolean> {
-    if (!this.started) {
-      this.logger.verbose("Eth1 notifier must be started to process a block");
-      return false;
-    }
-    this.processingBlock = true;
-    this.logger.verbose(`Processing eth1 block ${blockNumber}`);
-    if (blockNumber !== this.lastProcessedEth1BlockNumber + 1) {
-      this.logger.verbose(
-        `eth1 block out of order. expected: ${this.lastProcessedEth1BlockNumber + 1} actual: ${blockNumber}`
-      );
-      this.processingBlock = false;
-      return false;
-    }
-    const block = await this.getBlock(blockNumber);
-    if (!block) {
-      this.logger.verbose(`eth1 block ${blockNumber} not found`);
-      this.processingBlock = false;
-      return false;
-    }
-    // get results
-    const depositEvents  = await this.getDepositEvents(blockNumber);
-    if (depositEvents.length) {
-      this.lastProcessedDepositIndex = depositEvents[depositEvents.length - 1].index;
-      this.logger.verbose(
-        `${depositEvents.length} deposits found, latest depositIndex: ${this.lastProcessedDepositIndex}`
-      );
-    }
-    // update state
-    await Promise.all([
-      // op pool depositData
-      this.db.depositData.batchPut(depositEvents.map((depositEvent) => ({
-        key: depositEvent.index,
-        value: depositEvent,
-      }))),
-      // deposit data roots
-      this.db.depositDataRoot.batchPut(depositEvents.map((depositEvent) => ({
-        key: depositEvent.index,
-        value: this.config.types.DepositData.hashTreeRoot(depositEvent),
-      }))),
-    ]);
-    const depositTree = await this.db.depositDataRoot.getTreeBacked(this.lastProcessedDepositIndex);
-    const eth1Data = {
-      blockHash: fromHexString(block.hash),
-      depositRoot: depositTree.tree().root,
-      depositCount: this.lastProcessedDepositIndex + 1,
-    };
-    // eth1 data
-    await this.db.eth1Data.put(block.timestamp, eth1Data);
-    this.lastProcessedEth1BlockNumber++;
-    // emit events
-    depositEvents.forEach((depositEvent) => {
-      this.emit("deposit", depositEvent.index, depositEvent);
-    });
-    this.emit("eth1Data", block.timestamp, eth1Data, blockNumber);
-    this.processingBlock = false;
-    return true;
-  }
-
-  public async getDepositEvents(blockTag: string | number): Promise<IDepositEvent[]> {
+  public async getDepositEvents(fromBlockTag: string | number, toBlockTag?: string | number): Promise<IDepositEvent[]> {
     return (await this.provider.getLogs({
-      fromBlock: blockTag,
-      toBlock: blockTag,
+      fromBlock: fromBlockTag,
+      toBlock: toBlockTag,
       address: this.contract.address,
       topics: [this.contract.interface.events.DepositEvent.topic],
     })).map((log) => {
-      return this.parseDepositEvent(this.contract.interface.parseLog(log).values);
+      const blockNumber = log.blockNumber;
+      return this.parseDepositEvent(this.contract.interface.parseLog(log).values, blockNumber);
     });
   }
 
@@ -217,7 +164,7 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
     try {
       return this.provider.getBlock(blockTag, false);
     } catch (e) {
-      this.logger.warn("Failed to get eth1 block " + blockTag + ". Error: " + e.message);
+      this.logger.warn("eth1: Failed to get eth1 block " + blockTag + ". Error: " + e.message);
       return null;
     }
   }
@@ -226,13 +173,118 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
     const address = this.opts.depositContract.address;
     const abi = this.opts.depositContract.abi;
     if (!(await this.contractExists(address))) {
-      throw new Error(`There is no deposit contract at given address: ${address}`);
+      throw new Error(`eth1: There is no deposit contract at given address: ${address}`);
     }
     try {
       this.contract = new ethers.Contract(address, abi, this.provider);
     } catch (e) {
-      throw new Error("Eth1 deposit contract not found! Probably wrong eth1 rpc url");
+      throw new Error("eth1 deposit contract not found! Probably wrong eth1 rpc url");
     }
+  }
+
+  /**
+   * This can be scanned for genesis, or scan until stop for proposing block.
+   */
+  private async doGetDepositEventsByBlock(): Promise<void> {
+    const followBlockNumber = await this.provider.getBlockNumber() - this.config.params.ETH1_FOLLOW_DISTANCE;
+    this.logger.info(
+      `eth1: Start scanning Eth1Data last block =${this.lastProcessedEth1BlockNumber}` +
+      ` followBlockNumber=${followBlockNumber}`
+    );
+    await this.process(followBlockNumber);
+    if (this.lastProcessedEth1BlockNumber === followBlockNumber) {
+      // the previous pipe is done, need to start a new one
+      this.process(undefined);
+      this.provider.on("block", this.onNewEth1Block.bind(this));
+    }
+  }
+
+
+  /**
+   * Scan deposit events per every n (100 currently) blocks until inBlockNumber
+   * If undefined inBlockNumber then this is a reusable pipe, process whenever we push to targetBlockSource.
+   * If inBlockNumber exists, we close pipe after use.
+   * @param inBlockNumber
+   */
+  private async process(inBlockNumber?: number): Promise<void> {
+    if (inBlockNumber) {
+      this.targetBlockSource.push(inBlockNumber);
+    }
+    pipe(this.targetBlockSource,
+      async (source) => {
+        for await(const targetBlockNumber of source) {
+          if (targetBlockNumber <= this.lastProcessedEth1BlockNumber) {
+            continue;
+          }
+          const blockNumber = Math.min(this.lastProcessedEth1BlockNumber + 100, targetBlockNumber);
+          await this.getAndProcessDepositEvents(this.lastProcessedEth1BlockNumber + 1, blockNumber);
+          if (!this.eth1DataSource || !this.targetBlockSource) {
+            return;
+          }
+          if (this.lastProcessedEth1BlockNumber < targetBlockNumber) {
+            this.targetBlockSource.push(targetBlockNumber);
+          } else if (inBlockNumber) {
+            // finish this pipe if this is a catchup until followup block
+            return;
+          }
+          // keep this pipe open until we receive new eth1 block
+        }
+      }
+    );
+  }
+
+  /**
+   * Process blocks in bulk.
+   * Must process blocks in order with no gaps.
+   * @param fromBlockNbr
+   * @param toBlockNbr
+   */
+  private async getAndProcessDepositEvents(fromBlockNbr: number, toBlockNbr: number): Promise<void> {
+    if (toBlockNbr < fromBlockNbr) {
+      return;
+    }
+    this.logger.verbose(`eth1: getting events from block ${fromBlockNbr} to ${toBlockNbr}`);
+    try {
+      this.processingBlock = true;
+      const depositEvents  = await this.getDepositEvents(fromBlockNbr, toBlockNbr);
+      this.logger.info(`eth1: Found ${depositEvents.length} deposit events from block ` +
+        `${fromBlockNbr} to ${toBlockNbr}`);
+      this.processingBlock = false;
+      if (!this.eth1DataSource) {
+        return;
+      }
+      if (depositEvents.length === 0) {
+        this.lastProcessedEth1BlockNumber = toBlockNbr;
+        this.logger.verbose("eth1: Set lastProcessedEth1BlockNumber to " + this.lastProcessedEth1BlockNumber);
+        return;
+      }
+      // const lastBlockNumber = depositEvents[depositEvents.length - 1].blockNumber;
+      // const firstBlockNumber = depositEvents[0].blockNumber;
+      // for (let blockNumber = firstBlockNumber; blockNumber <= lastBlockNumber; blockNumber++) {
+      //   const blockDepositEvents = depositEvents.filter(event => event.blockNumber === blockNumber);
+      //   if (blockDepositEvents.length > 0) {
+      //     this.logger.info(`eth1: Found ${blockDepositEvents.length} deposit events for block ${blockNumber}`);
+      //     this.eth1DataSource.push(blockDepositEvents);
+      //   }
+      // }
+      // consumers should group by block whenever it needs to
+      this.eth1DataSource.push(depositEvents);
+      this.lastProcessedEth1BlockNumber = toBlockNbr;
+    } catch (ex) {
+      this.logger.error(
+        `eth1: Failed to process deposit events last eth1 block is ${this.lastProcessedEth1BlockNumber}` +
+        `, err=${ex.message}`
+      );
+    }
+  }
+
+  private async initialize(): Promise<void> {
+    if(!this.contract) {
+      await this.initContract();
+    }
+    this.logger.info(
+      `eth1: Started listening to eth1 provider ${this.opts.provider.url} on chain ${this.opts.provider.network}`
+    );
   }
 
   private async contractExists(address: string): Promise<boolean> {
@@ -240,12 +292,14 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
     const code = await this.provider.getCode(address);
     return !(!code || code === "0x");
   }
+
   /**
    * Parse DepositEvent log
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private parseDepositEvent(log: any): IDepositEvent {
+  private parseDepositEvent(log: any, blockNumber: number): IDepositEvent {
     return {
+      blockNumber,
       index: this.config.types.Number64.deserialize(fromHexString(log.index)),
       pubkey: fromHexString(log.pubkey),
       withdrawalCredentials: fromHexString(log.withdrawal_credentials),

--- a/packages/lodestar/src/eth1/impl/ethers.ts
+++ b/packages/lodestar/src/eth1/impl/ethers.ts
@@ -90,7 +90,7 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
       this.logger.warn(`eth1 is disabled so can't get deposit event, fromBlock=${fromBlock}`);
       return null;
     }
-    // if we try to form deposit, allow to scan deposit events even eth1 is disabled
+    // if we try to form genesis, allow to scan deposit events even eth1 is disabled
     if (!this.opts.enabled) {
       await this.initialize();
     }
@@ -99,7 +99,7 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
     this.eth1DataSource = pushable<IDepositEvent[]>();
     this.targetBlockSource = pushable<number>();
     // should not wait
-    this.doGetDepositEventsByBlock();
+    this.doGetDepositEventsFromLastProcessedBlock();
     return this.eth1DataSource;
   }
 
@@ -182,7 +182,7 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
     }
   }
 
-  private async doGetDepositEventsByBlock(): Promise<void> {
+  private async doGetDepositEventsFromLastProcessedBlock(): Promise<void> {
     const followBlockNumber = await this.provider.getBlockNumber() - this.config.params.ETH1_FOLLOW_DISTANCE;
     this.logger.info(
       `eth1: Start scanning Eth1Data last block =${this.lastProcessedEth1BlockNumber}` +

--- a/packages/lodestar/src/eth1/impl/ethers.ts
+++ b/packages/lodestar/src/eth1/impl/ethers.ts
@@ -263,6 +263,7 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
         `eth1: Failed to process deposit events last eth1 block is ${this.lastProcessedEth1BlockNumber}` +
         `, err=${ex.message}`
       );
+      this.processingBlock = false;
     }
   }
 

--- a/packages/lodestar/src/eth1/impl/ethers.ts
+++ b/packages/lodestar/src/eth1/impl/ethers.ts
@@ -80,11 +80,11 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
   }
 
   /**
-   * Main methods to be called either to build genesis state or to save data to propose block later.
+   * Main methods to be called either to build genesis state or to save data to propose blocks later.
    * @param isScanEth1ForGenesis
    * @param fromBlock
    */
-  public async getDepositEventsByBlock(
+  public async getDepositEventsFromBlock(
     isScanEth1ForGenesis: boolean, fromBlock?: number): Promise<Pushable<IDepositEvent[]>> {
     if (!isScanEth1ForGenesis && !this.opts.enabled) {
       this.logger.warn(`eth1 is disabled so can't get deposit event, fromBlock=${fromBlock}`);
@@ -182,9 +182,6 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
     }
   }
 
-  /**
-   * This can be scanned for genesis, or scan until stop for proposing block.
-   */
   private async doGetDepositEventsByBlock(): Promise<void> {
     const followBlockNumber = await this.provider.getBlockNumber() - this.config.params.ETH1_FOLLOW_DISTANCE;
     this.logger.info(
@@ -258,15 +255,6 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
         this.logger.verbose("eth1: Set lastProcessedEth1BlockNumber to " + this.lastProcessedEth1BlockNumber);
         return;
       }
-      // const lastBlockNumber = depositEvents[depositEvents.length - 1].blockNumber;
-      // const firstBlockNumber = depositEvents[0].blockNumber;
-      // for (let blockNumber = firstBlockNumber; blockNumber <= lastBlockNumber; blockNumber++) {
-      //   const blockDepositEvents = depositEvents.filter(event => event.blockNumber === blockNumber);
-      //   if (blockDepositEvents.length > 0) {
-      //     this.logger.info(`eth1: Found ${blockDepositEvents.length} deposit events for block ${blockNumber}`);
-      //     this.eth1DataSource.push(blockDepositEvents);
-      //   }
-      // }
       // consumers should group by block whenever it needs to
       this.eth1DataSource.push(depositEvents);
       this.lastProcessedEth1BlockNumber = toBlockNbr;

--- a/packages/lodestar/src/eth1/impl/interop.ts
+++ b/packages/lodestar/src/eth1/impl/interop.ts
@@ -14,7 +14,7 @@ export class InteropEth1Notifier extends EventEmitter implements IEth1Notifier {
 
   public async start(): Promise<void> {}
   public async stop(): Promise<void> {}
-  public async getDepositEventsByBlock(): Promise<Pushable<IDepositEvent[]>> {
+  public async getDepositEventsFromBlock(): Promise<Pushable<IDepositEvent[]>> {
     return null;
   }
   public async foundGenesis(): Promise<void> {}

--- a/packages/lodestar/src/eth1/impl/interop.ts
+++ b/packages/lodestar/src/eth1/impl/interop.ts
@@ -2,11 +2,10 @@
 import {EventEmitter} from "events";
 import {Block} from "ethers/providers";
 
-import {hash} from "@chainsafe/ssz";
-import {Eth1Data, DepositData} from "@chainsafe/lodestar-types";
-import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {Eth1Data} from "@chainsafe/lodestar-types";
 
 import {IEth1Notifier, IDepositEvent} from "../interface";
+import {Pushable} from "it-pushable";
 
 export class InteropEth1Notifier extends EventEmitter implements IEth1Notifier {
   public constructor() {
@@ -15,6 +14,10 @@ export class InteropEth1Notifier extends EventEmitter implements IEth1Notifier {
 
   public async start(): Promise<void> {}
   public async stop(): Promise<void> {}
+  public async getDepositEventsByBlock(): Promise<Pushable<IDepositEvent[]>> {
+    return null;
+  }
+  public async foundGenesis(): Promise<void> {}
 
   public async getDepositRoot(): Promise<Uint8Array> {
     return Buffer.alloc(32);

--- a/packages/lodestar/src/eth1/interface.ts
+++ b/packages/lodestar/src/eth1/interface.ts
@@ -28,7 +28,7 @@ export type Eth1EventEmitter = StrictEventEmitter<EventEmitter, IEth1Events>;
 export interface IEth1Notifier extends Eth1EventEmitter {
   start(): Promise<void>;
   stop(): Promise<void>;
-  getDepositEventsByBlock(isScanEth1ForGenesis: boolean, fromBlock?: number): Promise<Pushable<IDepositEvent[]>>;
+  getDepositEventsFromBlock(isScanEth1ForGenesis: boolean, fromBlock?: number): Promise<Pushable<IDepositEvent[]>>;
   foundGenesis(): Promise<void>;
   /**
    * Returns block by block hash or number

--- a/packages/lodestar/src/eth1/interface.ts
+++ b/packages/lodestar/src/eth1/interface.ts
@@ -6,17 +6,18 @@
 
 import {EventEmitter} from "events";
 
-import {Eth1Data, Number64, DepositData} from "@chainsafe/lodestar-types";
+import {Number64, DepositData} from "@chainsafe/lodestar-types";
 import {Block} from "ethers/providers";
 import StrictEventEmitter from "strict-event-emitter-types";
+import {Pushable} from "it-pushable";
 
 export interface IDepositEvent extends DepositData {
   index: number;
+  blockNumber: number;
 }
 
 export interface IEth1Events {
   deposit: (index: Number64, depositData: DepositData) => void;
-  eth1Data: (timestamp: number, eth1Data: Eth1Data, blockNumber: number) => void;
 }
 
 export type Eth1EventEmitter = StrictEventEmitter<EventEmitter, IEth1Events>;
@@ -27,7 +28,8 @@ export type Eth1EventEmitter = StrictEventEmitter<EventEmitter, IEth1Events>;
 export interface IEth1Notifier extends Eth1EventEmitter {
   start(): Promise<void>;
   stop(): Promise<void>;
-
+  getDepositEventsByBlock(isScanEth1ForGenesis: boolean, fromBlock?: number): Promise<Pushable<IDepositEvent[]>>;
+  foundGenesis(): Promise<void>;
   /**
    * Returns block by block hash or number
    * @param blockTag

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -81,7 +81,6 @@ export class BeaconNode {
     });
     this.eth1 = eth1 || new EthersEth1Notifier(this.conf.eth1, {
       config,
-      db: this.db,
       logger: logger.child(this.conf.logger.eth1),
     });
     this.chain = new BeaconChain(this.conf.chain, {
@@ -110,6 +109,7 @@ export class BeaconNode {
       config,
       db: this.db,
       chain: this.chain,
+      eth1: this.eth1,
       network: this.network,
       reputationStore: this.reps,
       logger: logger.child(this.conf.logger.sync),
@@ -132,7 +132,8 @@ export class BeaconNode {
         chain: this.chain,
         sync: this.sync,
         network: this.network,
-        logger: this.logger.child(this.conf.logger.chores)
+        logger: this.logger.child(this.conf.logger.chores),
+        eth1: this.eth1,
       }
     );
   }

--- a/packages/lodestar/src/sync/interface.ts
+++ b/packages/lodestar/src/sync/interface.ts
@@ -3,6 +3,7 @@ import {INetwork} from "../network";
 import {IReputationStore} from "./IReputation";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {CommitteeIndex, Slot, SyncingStatus} from "@chainsafe/lodestar-types";
+import StrictEventEmitter from "strict-event-emitter-types";
 import {InitialSync} from "./initial";
 import {IRegularSync} from "./regular";
 import {IGossipHandler} from "./gossip";
@@ -11,12 +12,20 @@ import {IBeaconChain} from "../chain";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBeaconDb} from "../db/api";
 import {AttestationCollector} from "./utils";
+import {IEth1Notifier} from "../eth1";
+import {EventEmitter} from "events";
 
-export interface IBeaconSync extends IService {
+export interface IBeaconSync extends IService, SyncEventEmitter {
   getSyncStatus(): Promise<SyncingStatus|null>;
   isSynced(): boolean;
   collectAttestations(slot: Slot, committeeIndex: CommitteeIndex): void;
 }
+
+export interface ISyncEvents {
+  "initialsync:completed": () => void;
+}
+
+export type SyncEventEmitter = StrictEventEmitter<EventEmitter, ISyncEvents>;
 
 export interface ISyncModule {
   getHighestBlock(): Slot;
@@ -34,6 +43,7 @@ export interface ISyncModules {
   reputationStore: IReputationStore;
   logger: ILogger;
   chain: IBeaconChain;
+  eth1: IEth1Notifier;
   initialSync?: InitialSync;
   regularSync?: IRegularSync;
   reqRespHandler?: IReqRespHandler;

--- a/packages/lodestar/src/tasks/tasks/watchEth1ForProposingTask.ts
+++ b/packages/lodestar/src/tasks/tasks/watchEth1ForProposingTask.ts
@@ -1,0 +1,166 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {ILogger} from "@chainsafe/lodestar-utils";
+import {IBeaconDb} from "../../db";
+import {IEth1Notifier, IDepositEvent} from "../../eth1";
+import {toHexString, fromHexString} from "@chainsafe/ssz";
+import pipe from "it-pipe";
+import abortable from "abortable-iterator";
+import {AbortController} from "abort-controller";
+import {IBeaconSync} from "../../sync";
+import {Eth1Data} from "@chainsafe/lodestar-types";
+
+export interface IWatchEth1ForProposingModules {
+  logger: ILogger;
+  db: IBeaconDb;
+  eth1: IEth1Notifier;
+  sync: IBeaconSync;
+}
+export class WatchEth1ForProposingTask {
+  private readonly config: IBeaconConfig;
+  private readonly logger: ILogger;
+  private readonly db: IBeaconDb;
+  private readonly eth1: IEth1Notifier;
+  private readonly sync: IBeaconSync;
+  private controller: AbortController = new AbortController();
+  private isInitSyncing: boolean;
+
+  public constructor(config: IBeaconConfig, modules: IWatchEth1ForProposingModules) {
+    this.config = config;
+    this.db = modules.db;
+    this.logger = modules.logger;
+    this.eth1 = modules.eth1;
+    this.sync = modules.sync;
+    this.isInitSyncing = true;
+  }
+  public async start(): Promise<void> {
+    this.sync.on("initialsync:completed", this.finishInitSync);
+    const startEth1BlockNumber = await this.db.getLastProcessedEth1BlockNumber();
+    const eth1DataStream = await this.eth1.getDepositEventsByBlock(false, startEth1BlockNumber);
+    if (!eth1DataStream) {
+      this.logger
+        .warn(`watchEth1: No need to run WatchEth1ForProposingTask task startEth1BlockNumber=${startEth1BlockNumber}`);
+      return;
+    }
+    const abortSignal = this.controller.signal;
+    pipe(eth1DataStream,
+      //middleware to allow to stop pipe
+      function (source: AsyncIterable<IDepositEvent[]>) {
+        return abortable(source, abortSignal, {returnOnAbort: true});
+      },
+      this.storeDepositDataRoots(),
+      this.transformToProposingData(),
+      this.storeProposingData(),
+    );
+  }
+
+  public async stop(): Promise<void> {
+    this.sync.removeListener("initialsync:completed", this.finishInitSync);
+    this.controller.abort();
+  }
+
+  public finishInitSync(): void {
+    this.isInitSyncing = false;
+  }
+
+  public async newFinalizedCheckpoint(): Promise<void> {
+    const lastFinalizedState = await this.db.stateArchive.lastValue();
+    const eth1BlockHash = toHexString(lastFinalizedState.eth1Data.blockHash);
+    const depositCount = lastFinalizedState.eth1Data.depositCount;
+    const eth1Timestamp = (await this.eth1.getBlock(eth1BlockHash)).number;
+    await Promise.all([
+      this.db.eth1Data.deleteOld(eth1Timestamp),
+      this.db.depositData.deleteOld(depositCount)
+    ]);
+    this.logger.info(`watchEth1: Deleted old eth1Data and deposit up to eth1 block ${eth1BlockHash} ` +
+    `timestamp=${eth1Timestamp}`);
+  }
+
+  /**
+   * Store last processed eth1 block number and deposit data roots.
+   */
+  private storeDepositDataRoots(): ((source: AsyncIterable<IDepositEvent[]>) => AsyncIterable<IDepositEvent[]>) {
+    const {db, config, logger} = this;
+    const getIsInitSync = this.getIsInitSync.bind(this);
+    return (source: AsyncIterable<IDepositEvent[]>): AsyncIterable<IDepositEvent[]> => {
+      return async function* () {
+        for await (const depositEvents of source) {
+          if (getIsInitSync()) {
+            await Promise.all([
+              db.setLastProcessedEth1BlockNumber(depositEvents[depositEvents.length - 1].blockNumber),
+              db.depositDataRoot.batchPut(depositEvents.map((depositEvent) => ({
+                key: depositEvent.index,
+                value: config.types.DepositData.hashTreeRoot(depositEvent),
+              }))),
+            ]);
+          } else {
+            await db.depositDataRoot.batchPut(depositEvents.map((depositEvent) => ({
+              key: depositEvent.index,
+              value: config.types.DepositData.hashTreeRoot(depositEvent),
+            })));
+            // next transform should save last processed eth1 block number
+            const lastBlockNumber = depositEvents[depositEvents.length - 1].blockNumber;
+            const firstBlockNumber = depositEvents[0].blockNumber;
+            for (let blockNumber = firstBlockNumber; blockNumber <= lastBlockNumber; blockNumber++) {
+              const blockDepositEvents = depositEvents.filter(event => event.blockNumber === blockNumber);
+              if (blockDepositEvents.length > 0) {
+                logger.info(`watchEth1: Found ${blockDepositEvents.length} deposit events for block ${blockNumber}`);
+                yield blockDepositEvents;
+              }
+            }
+          }
+        }// end for
+      }();
+    };
+  }
+
+  /**
+   * Transform to [block number, timestamp, eth1 data, deposit events of block]
+   */
+  private transformToProposingData():
+  ((source: AsyncIterable<IDepositEvent[]>) => AsyncIterable<[number, number, Eth1Data, IDepositEvent[]]>) {
+    const {eth1, db} = this;
+    return (source: AsyncIterable<IDepositEvent[]>): AsyncIterable<[number, number, Eth1Data, IDepositEvent[]]> => {
+      return async function* () {
+        for await (const depositEvents of source) {
+          const blockNumber = depositEvents[0].blockNumber;
+          const block = await eth1.getBlock(depositEvents[0].blockNumber);
+          const depositCount = depositEvents[depositEvents.length - 1].index + 1;
+          const depositTree = await db.depositDataRoot.getTreeBacked(depositCount - 1);
+          const eth1Data: Eth1Data = {
+            blockHash: fromHexString(block.hash),
+            depositRoot: depositTree.tree().root,
+            depositCount,
+          };
+          const result: [number, number, Eth1Data, IDepositEvent[]] =
+            [blockNumber, block.timestamp, eth1Data, depositEvents];
+          yield result;
+        }
+      }();
+    };
+  }
+
+  /**
+   * Store eth1 data and deposit data.
+   * Deposit events from source are grouped by block already.
+   * Input stream is of type [block number, timestamp, eth1data, deposit events of block]
+   */
+  private storeProposingData():
+  ((source: AsyncIterable<[number, number, Eth1Data, IDepositEvent[]]>) => Promise<void>) {
+    return (async (source: AsyncIterable<[number, number, Eth1Data, IDepositEvent[]]>): Promise<void> => {
+      for await (const data of source) {
+        await Promise.all([
+          this.db.setLastProcessedEth1BlockNumber(data[0]),
+          this.db.eth1Data.put(data[1], data[2]),
+          this.db.depositData.batchPut(data[3].map((depositEvent) => ({
+            key: depositEvent.index,
+            value: depositEvent,
+          })))
+        ]);
+      }// end for
+    });
+  }
+
+  private getIsInitSync(): boolean {
+    return this.isInitSyncing;
+  }
+}

--- a/packages/lodestar/src/tasks/tasks/watchEth1ForProposingTask.ts
+++ b/packages/lodestar/src/tasks/tasks/watchEth1ForProposingTask.ts
@@ -35,7 +35,7 @@ export class WatchEth1ForProposingTask {
   public async start(): Promise<void> {
     this.sync.on("initialsync:completed", this.finishInitSync);
     const startEth1BlockNumber = await this.db.getLastProcessedEth1BlockNumber();
-    const eth1DataStream = await this.eth1.getDepositEventsByBlock(false, startEth1BlockNumber);
+    const eth1DataStream = await this.eth1.getDepositEventsFromBlock(false, startEth1BlockNumber);
     if (!eth1DataStream) {
       this.logger
         .warn(`watchEth1: No need to run WatchEth1ForProposingTask task startEth1BlockNumber=${startEth1BlockNumber}`);

--- a/packages/lodestar/test/e2e/chain/chain.test.ts
+++ b/packages/lodestar/test/e2e/chain/chain.test.ts
@@ -16,7 +16,7 @@ import {BeaconSync} from "../../../src/sync";
 import sinon from "sinon";
 import {sleep} from "../../../src/util/sleep";
 
-describe("genesis state", () => {
+describe("BeaconChain", () => {
 
   let eth1Notifier: IEth1Notifier;
   let chain: BeaconChain;
@@ -103,7 +103,7 @@ describe("genesis state", () => {
   /**
    * this test has to start immediately after the above test.
    */
-  it("should start WatchEth1ForProposingTask successfully", async function() {
+  it("should start WatchEth1ForProposingTask and store proposing data successfully", async function() {
     this.timeout(100000);
     const lastProcessedEth1Block = await db.getLastProcessedEth1BlockNumber();
     logger.info(`At genesis, lastProcessedEth1Block=${lastProcessedEth1Block}`);

--- a/packages/lodestar/test/e2e/chain/chain.test.ts
+++ b/packages/lodestar/test/e2e/chain/chain.test.ts
@@ -41,7 +41,7 @@ describe("BeaconChain", () => {
   logger.silent = true;
   // logger.level = LogLevel.verbose;
   const schlesiConfig = Object.assign({}, {params: config.params}, config);
-  schlesiConfig.params = Object.assign({}, config.params, {MIN_GENESIS_TIME: 1587755000, MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 4});
+  schlesiConfig.params = Object.assign({}, config.params, {MIN_GENESIS_TIME: 1587755000, MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 4, MIN_GENESIS_DELAY: 3600});
   const sandbox = sinon.createSandbox();
 
   before(async () => {
@@ -92,8 +92,10 @@ describe("BeaconChain", () => {
     expect(toHexString(eth1Data.blockHash)).to.be.equal("0x54b9f905f15634d966690bd362381cfd7a28362d683f8d1616aa478b575152f8");
     expect(toHexString(eth1Data.depositRoot)).to.be.equal("0x24dccd5595a434f57680128048c69548919b067b1285693d06881f6101325d1d");
     expect(eth1Data.depositCount).to.be.equal(4);
-    const forkDigest = await chain.currentForkDigest;
+    const headBlock = await chain.getHeadBlock();
+    expect(toHexString(schlesiConfig.types.BeaconBlock.hashTreeRoot(headBlock.message))).to.be.equal("0xc9cbcb8ceb9b5f71216f5137282bf6a1e3b50f64e42d6c7fb347abe07eb0db82");
     // schlesi fork digest: https://github.com/goerli/schlesi
+    const forkDigest = await chain.currentForkDigest;
     expect(toHexString(forkDigest)).to.be.equal("0x9925efd6");
     logger.info(`chain is started successfully. Genesis state found in ${Math.floor(Date.now() - start) / 1000} seconds`);
     await chain.stop();

--- a/packages/lodestar/test/e2e/chain/chain.test.ts
+++ b/packages/lodestar/test/e2e/chain/chain.test.ts
@@ -1,0 +1,151 @@
+import {IEth1Notifier, EthersEth1Notifier} from "../../../src/eth1";
+import {IEth1Options} from "../../../src/eth1/options";
+import {BeaconDb, LevelDbController} from "../../../src/db";
+import {ILogger, WinstonLogger, LogLevel} from "@chainsafe/lodestar-utils";
+import {ethers} from "ethers";
+import defaults from "../../../src/eth1/dev/options";
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import * as fs from "fs";
+import {BeaconChain} from "../../../src/chain";
+import chainOpts from "../../../src/chain/options";
+import {BeaconMetrics} from "../../../src/metrics";
+import {expect, assert} from "chai";
+import {toHexString} from "@chainsafe/ssz";
+import {WatchEth1ForProposingTask} from "../../../src/tasks/tasks/watchEth1ForProposingTask";
+import {BeaconSync} from "../../../src/sync";
+import sinon from "sinon";
+import {sleep} from "../../../src/util/sleep";
+
+describe("genesis state", () => {
+
+  let eth1Notifier: IEth1Notifier;
+  let chain: BeaconChain;
+  let provider: ethers.providers.JsonRpcProvider;
+  let metrics: any;
+  let sync: any;
+  const opts: IEth1Options = {
+    ...defaults,
+    provider: {
+      url: "https://goerli.prylabs.net",
+      network: 5,
+    },
+    depositContract: {
+      ...defaults.depositContract,
+      deployedAt: 2596126,
+      address: "0xA15554BF93a052669B511ae29EA21f3581677ac5",
+    }
+  };
+  let db: BeaconDb;
+  const dbPath = "./.tmpdb";
+  const logger: ILogger = new WinstonLogger();
+  logger.silent = true;
+  // logger.level = LogLevel.verbose;
+  const schlesiConfig = Object.assign({}, {params: config.params}, config);
+  schlesiConfig.params = Object.assign({}, config.params, {MIN_GENESIS_TIME: 1587755000, MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 4});
+  const sandbox = sinon.createSandbox();
+
+  before(async () => {
+    await fs.promises.rmdir(dbPath, {recursive: true});
+    expect(schlesiConfig.params.MIN_GENESIS_TIME).to.be.not.equal(config.params.MIN_GENESIS_TIME);
+    expect(schlesiConfig.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT).to.be.not.equal(config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT);
+    db = new BeaconDb({
+      config: schlesiConfig,
+      controller: new LevelDbController({name: dbPath}, {logger}),
+    });
+    provider = new ethers.providers.JsonRpcProvider(opts.provider.url, opts.provider.network);
+    await db.start();
+    eth1Notifier = new EthersEth1Notifier(
+      {...opts, providerInstance: provider},
+      {
+        config: schlesiConfig,
+        logger,
+      });
+    await eth1Notifier.start();
+  });
+
+
+  beforeEach(async function () {
+    sync = sandbox.createStubInstance(BeaconSync);
+
+    metrics = new BeaconMetrics({enabled: false} as any, {logger});
+    chain = new BeaconChain(chainOpts, {config: schlesiConfig, db, eth1: eth1Notifier, logger, metrics});
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  after(async () => {
+    await db.stop();
+    await eth1Notifier.stop();
+    await fs.promises.rmdir(dbPath, {recursive: true});
+  });
+
+  it("should detect schlesi genesis state", async function() {
+    this.timeout(20000);
+    await eth1Notifier.start();
+    const start = Date.now();
+    await chain.start();
+    const headState = await chain.getHeadState();
+    const eth1Data = headState.eth1Data;
+    // https://schlesi.beaconcha.in/block/1
+    expect(toHexString(eth1Data.blockHash)).to.be.equal("0x54b9f905f15634d966690bd362381cfd7a28362d683f8d1616aa478b575152f8");
+    expect(toHexString(eth1Data.depositRoot)).to.be.equal("0x24dccd5595a434f57680128048c69548919b067b1285693d06881f6101325d1d");
+    expect(eth1Data.depositCount).to.be.equal(4);
+    const forkDigest = await chain.currentForkDigest;
+    // schlesi fork digest: https://github.com/goerli/schlesi
+    expect(toHexString(forkDigest)).to.be.equal("0x9925efd6");
+    logger.info(`chain is started successfully. Genesis state found in ${Math.floor(Date.now() - start) / 1000} seconds`);
+    await chain.stop();
+    logger.info("chain stopped");
+  });
+
+  /**
+   * this test has to start immediately after the above test.
+   */
+  it("should start WatchEth1ForProposingTask successfully", async function() {
+    this.timeout(100000);
+    const lastProcessedEth1Block = await db.getLastProcessedEth1BlockNumber();
+    logger.info(`At genesis, lastProcessedEth1Block=${lastProcessedEth1Block}`);
+    // eth1 block at genesis
+    expect(lastProcessedEth1Block).to.be.equal(2596296);
+    const watchEth1Task = new WatchEth1ForProposingTask(schlesiConfig, {
+      db,
+      eth1: eth1Notifier,
+      logger,
+      sync
+    });
+    watchEth1Task.finishInitSync();
+    await watchEth1Task.start();
+    try {
+      // wait for proposing data
+      let eth1DataCount = (await db.eth1Data.values()).length;
+      // from genesis
+      expect(eth1DataCount).to.be.equal(1);
+      await new Promise((resolve, reject) => {
+        const rejectTimer = setTimeout(reject, 10000);
+        (
+          async () => {
+            while (eth1DataCount < 2) {
+              eth1DataCount = (await db.eth1Data.values()).length;
+              sleep(500);
+            }
+            clearTimeout(rejectTimer);
+            resolve();
+          }
+        )();
+      });
+      logger.info(`Found ${eth1DataCount} eth1Data`);
+      const depositDatas = await db.depositData.values();
+      expect(depositDatas.length).to.be.greaterThan(0);
+      logger.info(`Found ${depositDatas.length} depositData`);
+    } catch (err) {
+      assert(false, "Failed with error " + err);
+    } finally {
+      await watchEth1Task.stop();
+      // wait for any database operation
+      await sleep(1000);
+      logger.info("WatchEth1ForProposingTask stopped");
+    }
+  });
+});

--- a/packages/lodestar/test/e2e/eth1/deploy.test.ts
+++ b/packages/lodestar/test/e2e/eth1/deploy.test.ts
@@ -1,15 +1,12 @@
-import * as fs from "fs";
-import {expect} from "chai";
 import {ethers} from "ethers";
 import sinon from "sinon";
 import {afterEach, beforeEach, describe, it} from "mocha";
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
-import {EthersEth1Notifier, IEth1Notifier} from "../../../src/eth1";
+import {EthersEth1Notifier, IEth1Notifier, IDepositEvent} from "../../../src/eth1";
 import defaults from "../../../src/eth1/dev/options";
 import {ILogger, LogLevel, WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
-import {BeaconDb, LevelDbController} from "../../../src/db";
 import {IEth1Options} from "../../../src/eth1/options";
-import rimraf from "rimraf";
+import pipe from "it-pipe";
 
 describe("Eth1Notifier - using goerli known deployed contract", () => {
 
@@ -19,6 +16,7 @@ describe("Eth1Notifier - using goerli known deployed contract", () => {
   // start 1 block before first deposit
   const opts: IEth1Options = {
     ...defaults,
+    enabled: false,
     provider: {
       url: "https://goerli.prylabs.net",
       network: 5,
@@ -29,84 +27,53 @@ describe("Eth1Notifier - using goerli known deployed contract", () => {
       address: "0x5cA1e00004366Ac85f492887AAab12d0e6418876",
     }
   };
-  let db: BeaconDb;
-  const dbPath = "./.tmpdb";
   const logger: ILogger = new WinstonLogger();
 
+  // chain can't receive eth1Data that's not qualified genesis condition so we need this test config
+  const testConfig = Object.assign({}, {params: config.params}, config);
+  // 1586833385 is timestamp of the contract's block
+  testConfig.params = Object.assign({}, config.params,
+    {MIN_GENESIS_TIME: 1586833385, MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 1, ETH1_FOLLOW_DISTANCE: 0});
+
   beforeEach(async function () {
+
     this.timeout(0);
-    rimraf.sync(dbPath);
     logger.silent = true;
     logger.level = LogLevel.verbose;
-    db = new BeaconDb({
-      config,
-      controller: new LevelDbController({name: dbPath}, {logger}),
-    });
     provider = new ethers.providers.JsonRpcProvider(opts.provider.url, opts.provider.network);
     eth1Notifier = new EthersEth1Notifier(
       {...opts, providerInstance: provider},
       {
-        config,
-        db,
+        config: testConfig,
         logger,
       });
-    await db.start();
   });
 
   afterEach(async () => {
     await eth1Notifier.stop();
-    await db.stop();
-    rimraf.sync(dbPath);
     logger.silent = false;
   });
 
-  it("should process blocks", async function () {
+  it("should process deposit events in batch", async function () {
     this.timeout(0);
     // process 2 blocks, should be 1 deposit
-    const targetBlockNumber = opts.depositContract.deployedAt + 2;
+    const targetBlockNumber = opts.depositContract.deployedAt + 10;
     provider.getBlockNumber = sinon.stub().resolves(targetBlockNumber);
-    const blockPromise = new Promise(resolve => eth1Notifier.on("eth1Data", (_, __, blockNumber) => {
-      if(blockNumber === targetBlockNumber) {
-        eth1Notifier.removeAllListeners("eth1Data");
-        resolve();
-      }
-    }));
     await eth1Notifier.start();
-    await blockPromise;
-    const tree = await db.depositDataRoot.getTreeBacked(0);
-    expect(tree.length).to.be.equal(1);
+    const eth1DataStream = await eth1Notifier.getDepositEventsByBlock(true);
+
+    await pipe(eth1DataStream, async function(source: AsyncIterable<IDepositEvent[]>) {
+      for await (const events of source) {
+        // there is 1 deposit at opts.depositContract.deployedAt + 1 and 1 more at deployedAt + 9
+        const blockNumbers = events.map(event => event.blockNumber);
+        if (blockNumbers.includes(opts.depositContract.deployedAt + 1) &&
+          blockNumbers.includes(opts.depositContract.deployedAt + 9)) {
+          return;
+        }
+      }
+    });
+    await eth1Notifier.foundGenesis();
   });
 
-  it("should resume processing blocks after restart", async function () {
-    this.timeout(0);
-    // process 3 blocks, starting from depositContract.deployedAt
-    // there should be one deposit to process
-    const target1BlockNumber = opts.depositContract.deployedAt + 3;
-    provider.getBlockNumber = sinon.stub().resolves(target1BlockNumber);
-    const blockPromise1 = new Promise(resolve => eth1Notifier.on("eth1Data", (_, __, blockNumber) => {
-      if(blockNumber === target1BlockNumber) {
-        eth1Notifier.removeAllListeners("eth1Data");
-        resolve();
-      }
-    }));
-    await eth1Notifier.start();
-    await blockPromise1;
-    await eth1Notifier.stop();
-    const tree = await db.depositDataRoot.getTreeBacked(0);
-    expect(tree.length).to.be.equal(1);
-    const target2BlockNumber = opts.depositContract.deployedAt + 10;
-    // process 7 more blocks, it should start from where it left off
-    provider.getBlockNumber = sinon.stub().resolves(target2BlockNumber);
-    const blockPromise2 = new Promise(resolve => eth1Notifier.on("eth1Data", (_, __, blockNumber) => {
-      if(blockNumber === target2BlockNumber) {
-        eth1Notifier.removeAllListeners("eth1Data");
-        resolve();
-      }
-    }));
-    await eth1Notifier.start();
-    await blockPromise2;
-    const tree2 = await db.depositDataRoot.getTreeBacked(1);
-    expect(tree2.length).to.be.equal(2);
-  });
 
 });

--- a/packages/lodestar/test/e2e/eth1/deploy.test.ts
+++ b/packages/lodestar/test/e2e/eth1/deploy.test.ts
@@ -60,7 +60,7 @@ describe("Eth1Notifier - using goerli known deployed contract", () => {
     const targetBlockNumber = opts.depositContract.deployedAt + 10;
     provider.getBlockNumber = sinon.stub().resolves(targetBlockNumber);
     await eth1Notifier.start();
-    const eth1DataStream = await eth1Notifier.getDepositEventsByBlock(true);
+    const eth1DataStream = await eth1Notifier.getDepositEventsFromBlock(true);
 
     await pipe(eth1DataStream, async function(source: AsyncIterable<IDepositEvent[]>) {
       for await (const events of source) {

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -244,7 +244,8 @@ describe("[network] network", function () {
     netA.gossip.unsubscribeFromAttestationSubnet(forkDigest, "0", callback);
     expect(netA.gossip.listenerCount(getAttestationSubnetEvent(0))).to.be.equal(0);
   });
-  it("should connect to new peer by subnet", async function() {
+  // TODO: bring this back
+  it.skip("should connect to new peer by subnet", async function() {
     const subnet = 10;
     netB.metadata.attnets[subnet] = true;
     const connected = Promise.all([

--- a/packages/lodestar/test/unit/eth1/impl/ethers.test.ts
+++ b/packages/lodestar/test/unit/eth1/impl/ethers.test.ts
@@ -11,7 +11,6 @@ import {ILogger, WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 
 import {EthersEth1Notifier} from "../../../../src/eth1";
 import defaults from "../../../../src/eth1/dev/options";
-import {StubbedBeaconDb} from "../../../utils/stub";
 
 chai.use(chaiAsPromised);
 
@@ -20,14 +19,12 @@ describe("Eth1Notifier", () => {
   const logger: ILogger = new WinstonLogger();
   let contract: SinonStubbedInstance<ethers.Contract>;
   let provider: SinonStubbedInstance<JsonRpcProvider>;
-  let db: StubbedBeaconDb;
   let eth1: EthersEth1Notifier;
 
   beforeEach(async function (): Promise<void> {
     logger.silent = true;
     contract = sandbox.createStubInstance(Contract) as any;
     provider = sandbox.createStubInstance(JsonRpcProvider) as any;
-    db = new StubbedBeaconDb(sandbox);
     eth1 = new EthersEth1Notifier({
       ...defaults,
       contract: contract as any,
@@ -35,7 +32,6 @@ describe("Eth1Notifier", () => {
     },
     {
       config,
-      db,
       logger,
     });
   });
@@ -55,14 +51,12 @@ describe("Eth1Notifier", () => {
       number: 5000000,
     } as Block;
     const currentBlockNumber = lastProcessedBlock.number;
-    db.eth1Data.lastValue.resolves(lastProcessedEth1Data);
 
 
     provider.getBlock.withArgs(toHexString(lastProcessedEth1Data.blockHash)).resolves(lastProcessedBlock);
     provider.getBlockNumber.resolves(currentBlockNumber);
 
     await eth1.start();
-    expect(provider.getBlock.withArgs(toHexString(lastProcessedEth1Data.blockHash), false).calledOnce).to.be.true;
     await eth1.stop();
   });
 
@@ -72,7 +66,6 @@ describe("Eth1Notifier", () => {
       providerInstance: provider as any,
     }, {
       config,
-      db,
       logger,
     });
     await expect(

--- a/packages/lodestar/test/unit/sync/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/sync.test.ts
@@ -15,6 +15,7 @@ import {ReputationStore} from "../../../src/sync/IReputation";
 import {generateEmptySignedBlock} from "../../utils/block";
 import {ISyncOptions} from "../../../src/sync/options";
 import {IBeaconSync} from "../../../lib/sync";
+import {InteropEth1Notifier} from "../../../src/eth1/impl/interop";
 
 describe("sync", function () {
 
@@ -32,6 +33,7 @@ describe("sync", function () {
       opts,
       {
         chain: chainStub,
+        eth1: new InteropEth1Notifier(),
         config,
         db: sinon.createStubInstance(BeaconDb),
         regularSync: regularSyncStub,


### PR DESCRIPTION
## Goal
+ resolves #889 
+ eth1 pushes Eth1Data to chain only when needed so it mitigates the issue in #883 
## Approach
+ ethers is now stateless, no db getting involved there
+ Store lastProcessedEth1Block in db
+ New GenesisBuilder and WatchEth1ForProposingTask class to use ethers
+ ethers has 1 main interface `getDepositEventsFromBlock`, this is called by GenesisBuilder to build genesis state and by WatchEth1ForProposingTask for proposing data
+ At init sync time, only store deposit roots of events and last processed eth1 block because we don't need proposing data. After that time we store proposing data like Eth1Data, block number, timestamp
+ Genesis builder stores deposit roots and Eth1Data itself and save lastProcessedEth1Block so WatchEth1ForProposingTask just continue from there
+ Whenever there is a new finalized checkpoint, delete old deposit data and Eth1Data
## Test
+ I can detect schlesi genesis state in around 7s with 4 deposits, hope it does not break anything
![image](https://user-images.githubusercontent.com/10568965/81493966-0e0f7100-92cf-11ea-84c9-7d2874e3957d.png)

## TODOs
+ [x] Rebase against master once it's ready, fix tests
