### PR TITLE
Fix compilation errors

### DIFF
--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -59,7 +59,8 @@ export class Libp2pNetwork extends (EventEmitter as { new(): NetworkEventEmitter
         this.peerInfo = libp2p.peerInfo;
         this.libp2p = libp2p;
         this.reqResp = new ReqResp(opts, {config, libp2p, logger});
-        const enr = (this.libp2p._discovery.get("discv5") as Discv5Discovery)?.discv5?.enr || undefined;
+        const discv5Discovery = this.libp2p._discovery.get("discv5") as Discv5Discovery;
+        const enr = discv5Discovery && discv5Discovery.discv5 && discv5Discovery.discv5.enr || undefined;
         this.metadata = new MetadataController({enr}, {config, chain, logger});
         this.gossip = (new Gossip(opts, this.metadata,
           {config, libp2p, logger, validator, chain})) as unknown as IGossip;

--- a/packages/lodestar/test/unit/network/encoders/snappy-frames/uncompress.test.ts
+++ b/packages/lodestar/test/unit/network/encoders/snappy-frames/uncompress.test.ts
@@ -1,4 +1,4 @@
-import {createCompressStream} from "snappy-stream";
+import {createCompressStream} from "@chainsafe/snappy-stream";
 import {SnappyFramesUncompress} from "../../../../../src/network/encoders/snappy-frames/uncompress";
 import {expect} from "chai";
 
@@ -6,11 +6,11 @@ describe("snappy frames uncompress", function () {
 
   it("should work with short input", function (done) {
     const compressStream = createCompressStream();
-    
+
     const decompress = new SnappyFramesUncompress();
-    
+
     const testData = "Small test data";
-    
+
     compressStream.on("data", function (data) {
       const result = decompress.uncompress(data);
       if(result) {
@@ -18,7 +18,7 @@ describe("snappy frames uncompress", function () {
         done();
       }
     });
-    
+
     compressStream.write(testData);
   });
 
@@ -53,5 +53,5 @@ describe("snappy frames uncompress", function () {
 
     expect(decompress.uncompress(Buffer.alloc(3, 1))).to.be.null;
   });
-    
+
 });


### PR DESCRIPTION
## Goal
+ We have some compilation errors in test but CI did not fail
## Question
+ If we bring back https://github.com/ChainSafe/lodestar/pull/664/files#diff-4ab3bf1feca40a36f6c4967139b0fe10R27 , we'll see tests' compilation errors during `build` process. Do we want to do that?