### PR TITLE
Process deposit event logs in bulk

### DIFF
--- a/packages/lodestar/src/db/api/beacon/repositories/depositDataRoot.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/depositDataRoot.ts
@@ -51,12 +51,13 @@ export class DepositDataRootRepository extends Repository<number, Root> {
       await this.initTree();
     }
     const tree = this.depositRootTree.clone();
-    const maxIndex = tree.length - 1;
+    let maxIndex = tree.length - 1;
     if (depositIndex > maxIndex) {
       throw new Error(`Cannot get tree for unseen deposits: requested ${depositIndex}, last seen ${maxIndex}`);
     }
     while (maxIndex > depositIndex) {
       tree.pop();
+      maxIndex = tree.length - 1;
     }
     return tree;
   }

--- a/packages/lodestar/src/eth1/impl/ethers.ts
+++ b/packages/lodestar/src/eth1/impl/ethers.ts
@@ -90,7 +90,7 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
     const headBlockNumber = await this.provider.getBlockNumber();
     // process historical unprocessed blocks up to curent head
     // then start listening for incoming blocks
-    this.processBlocks(headBlockNumber).then(() => {
+    this.processBlocks(headBlockNumber - this.config.params.ETH1_FOLLOW_DISTANCE).then(() => {
       if(this.started) {
         this.provider.on("block", this.onNewEth1Block.bind(this));
       }

--- a/packages/lodestar/src/eth1/impl/util.ts
+++ b/packages/lodestar/src/eth1/impl/util.ts
@@ -1,0 +1,21 @@
+import {IDepositEvent} from "../interface";
+
+/**
+ * Return deposit events of blocks.
+ * @param depositEvents range deposit events
+ */
+export function getDepositEventsByBlock(rangeDepositEvents: IDepositEvent[]): [number, IDepositEvent[]][] {
+  if (!rangeDepositEvents || rangeDepositEvents.length === 0) {
+    return [];
+  }
+  const firstBlockNumber = rangeDepositEvents[0].blockNumber;
+  const lastBlockNumber = rangeDepositEvents[rangeDepositEvents.length - 1].blockNumber;
+  const result: [number, IDepositEvent[]][] = [];
+  for (let blockNumber = firstBlockNumber; blockNumber <= lastBlockNumber; blockNumber ++) {
+    const blockDepositEvents = rangeDepositEvents.filter(event => event.blockNumber === blockNumber);
+    if (blockDepositEvents.length > 0) {
+      result.push([blockNumber, blockDepositEvents]);
+    }
+  }
+  return result;
+}

--- a/packages/lodestar/src/eth1/impl/util.ts
+++ b/packages/lodestar/src/eth1/impl/util.ts
@@ -1,10 +1,10 @@
 import {IDepositEvent} from "../interface";
 
 /**
- * Return deposit events of blocks.
+ * Return deposit events of blocks sorted by block number and deposit index
  * @param depositEvents range deposit events
  */
-export function getDepositEventsByBlock(rangeDepositEvents: IDepositEvent[]): [number, IDepositEvent[]][] {
+export function groupDepositEventsByBlock(rangeDepositEvents: IDepositEvent[]): [number, IDepositEvent[]][] {
   if (!rangeDepositEvents || rangeDepositEvents.length === 0) {
     return [];
   }
@@ -14,7 +14,7 @@ export function getDepositEventsByBlock(rangeDepositEvents: IDepositEvent[]): [n
   for (let blockNumber = firstBlockNumber; blockNumber <= lastBlockNumber; blockNumber ++) {
     const blockDepositEvents = rangeDepositEvents.filter(event => event.blockNumber === blockNumber);
     if (blockDepositEvents.length > 0) {
-      result.push([blockNumber, blockDepositEvents]);
+      result.push([blockNumber, blockDepositEvents.sort((event1, event2) => event1.index - event2.index)]);
     }
   }
   return result;

--- a/packages/lodestar/src/eth1/impl/util.ts
+++ b/packages/lodestar/src/eth1/impl/util.ts
@@ -9,12 +9,12 @@ export function groupDepositEventsByBlock(rangeDepositEvents: IDepositEvent[]): 
     return new Map();
   }
   rangeDepositEvents.sort((event1, event2) => event1.index - event2.index);
-  return rangeDepositEvents.reduce<Map<number, IDepositEvent[]>>((previousValue, currentValue) => {
-    const blockNumber = currentValue.blockNumber;
-    if (!previousValue.get(blockNumber)) {
-      previousValue.set(blockNumber, []);
+  return rangeDepositEvents.reduce<Map<number, IDepositEvent[]>>((groupedEvents, event) => {
+    const blockNumber = event.blockNumber;
+    if (!groupedEvents.get(blockNumber)) {
+      groupedEvents.set(blockNumber, []);
     }
-    previousValue.get(blockNumber).push(currentValue);
-    return previousValue;
+    groupedEvents.get(blockNumber).push(event);
+    return groupedEvents;
   }, new Map());
 }

--- a/packages/lodestar/src/eth1/impl/util.ts
+++ b/packages/lodestar/src/eth1/impl/util.ts
@@ -1,21 +1,20 @@
 import {IDepositEvent} from "../interface";
 
 /**
- * Return deposit events of blocks sorted by block number and deposit index
+ * Return deposit events of blocks grouped/sorted by block number and deposit index
  * @param depositEvents range deposit events
  */
-export function groupDepositEventsByBlock(rangeDepositEvents: IDepositEvent[]): [number, IDepositEvent[]][] {
+export function groupDepositEventsByBlock(rangeDepositEvents: IDepositEvent[]): Map<number, IDepositEvent[]> {
   if (!rangeDepositEvents || rangeDepositEvents.length === 0) {
-    return [];
+    return new Map();
   }
-  const firstBlockNumber = rangeDepositEvents[0].blockNumber;
-  const lastBlockNumber = rangeDepositEvents[rangeDepositEvents.length - 1].blockNumber;
-  const result: [number, IDepositEvent[]][] = [];
-  for (let blockNumber = firstBlockNumber; blockNumber <= lastBlockNumber; blockNumber ++) {
-    const blockDepositEvents = rangeDepositEvents.filter(event => event.blockNumber === blockNumber);
-    if (blockDepositEvents.length > 0) {
-      result.push([blockNumber, blockDepositEvents.sort((event1, event2) => event1.index - event2.index)]);
+  rangeDepositEvents.sort((event1, event2) => event1.index - event2.index);
+  return rangeDepositEvents.reduce<Map<number, IDepositEvent[]>>((previousValue, currentValue) => {
+    const blockNumber = currentValue.blockNumber;
+    if (!previousValue.get(blockNumber)) {
+      previousValue.set(blockNumber, []);
     }
-  }
-  return result;
+    previousValue.get(blockNumber).push(currentValue);
+    return previousValue;
+  }, new Map());
 }

--- a/packages/lodestar/src/eth1/interface.ts
+++ b/packages/lodestar/src/eth1/interface.ts
@@ -11,6 +11,7 @@ import {Block} from "ethers/providers";
 import StrictEventEmitter from "strict-event-emitter-types";
 
 export interface IDepositEvent extends DepositData {
+  blockNumber: number;
   index: number;
 }
 

--- a/packages/lodestar/test/e2e/chain/chain.test.ts
+++ b/packages/lodestar/test/e2e/chain/chain.test.ts
@@ -1,0 +1,99 @@
+import {IEth1Notifier, EthersEth1Notifier} from "../../../src/eth1";
+import {IEth1Options} from "../../../src/eth1/options";
+import {BeaconDb, LevelDbController} from "../../../src/db";
+import {ILogger, WinstonLogger, LogLevel} from "@chainsafe/lodestar-utils";
+import {ethers} from "ethers";
+import defaults from "../../../src/eth1/dev/options";
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import * as fs from "fs";
+import {BeaconChain} from "../../../src/chain";
+import chainOpts from "../../../src/chain/options";
+import {BeaconMetrics} from "../../../src/metrics";
+import {expect} from "chai";
+import {toHexString} from "@chainsafe/ssz";
+import sinon from "sinon";
+
+describe("BeaconChain", function() {
+  this.timeout(100000);
+
+  let eth1Notifier: IEth1Notifier;
+  let chain: BeaconChain;
+  let provider: ethers.providers.JsonRpcProvider;
+  let metrics: any;
+  const opts: IEth1Options = {
+    ...defaults,
+    provider: {
+      url: "https://goerli.prylabs.net",
+      network: 5,
+    },
+    depositContract: {
+      ...defaults.depositContract,
+      deployedAt: 2596126,
+      address: "0xA15554BF93a052669B511ae29EA21f3581677ac5",
+    }
+  };
+  let db: BeaconDb;
+  const dbPath = "./.tmpdb";
+  const logger: ILogger = new WinstonLogger();
+  logger.silent = true;
+  logger.level = LogLevel.verbose;
+  const schlesiConfig = Object.assign({}, {params: config.params}, config);
+  schlesiConfig.params = Object.assign({}, config.params, {MIN_GENESIS_TIME: 1587755000, MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 4, MIN_GENESIS_DELAY: 3600});
+  const sandbox = sinon.createSandbox();
+
+  before(async () => {
+    await fs.promises.rmdir(dbPath, {recursive: true});
+    expect(schlesiConfig.params.MIN_GENESIS_TIME).to.be.not.equal(config.params.MIN_GENESIS_TIME);
+    expect(schlesiConfig.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT).to.be.not.equal(config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT);
+    db = new BeaconDb({
+      config: schlesiConfig,
+      controller: new LevelDbController({name: dbPath}, {logger}),
+    });
+    provider = new ethers.providers.JsonRpcProvider(opts.provider.url, opts.provider.network);
+    await db.start();
+    eth1Notifier = new EthersEth1Notifier(
+      {...opts, providerInstance: provider},
+      {
+        config: schlesiConfig,
+        db,
+        logger,
+      });
+    await eth1Notifier.start();
+  });
+
+
+  beforeEach(async function () {
+    metrics = new BeaconMetrics({enabled: false} as any, {logger});
+    chain = new BeaconChain(chainOpts, {config: schlesiConfig, db, eth1: eth1Notifier, logger, metrics});
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  after(async () => {
+    await db.stop();
+    await eth1Notifier.stop();
+    await fs.promises.rmdir(dbPath, {recursive: true});
+  });
+
+  it("should detect schlesi genesis state", async function() {
+    await eth1Notifier.start();
+    const start = Date.now();
+    await chain.start();
+    const headState = await chain.getHeadState();
+    const eth1Data = headState.eth1Data;
+    // https://schlesi.beaconcha.in/block/1
+    expect(toHexString(eth1Data.blockHash)).to.be.equal("0x54b9f905f15634d966690bd362381cfd7a28362d683f8d1616aa478b575152f8");
+    expect(toHexString(eth1Data.depositRoot)).to.be.equal("0x24dccd5595a434f57680128048c69548919b067b1285693d06881f6101325d1d");
+    expect(eth1Data.depositCount).to.be.equal(4);
+    const headBlock = await chain.getHeadBlock();
+    expect(toHexString(schlesiConfig.types.BeaconBlock.hashTreeRoot(headBlock.message))).to.be.equal("0xc9cbcb8ceb9b5f71216f5137282bf6a1e3b50f64e42d6c7fb347abe07eb0db82");
+    // schlesi fork digest: https://github.com/goerli/schlesi
+    const forkDigest = await chain.currentForkDigest;
+    expect(toHexString(forkDigest)).to.be.equal("0x9925efd6");
+    logger.info(`chain is started successfully. Genesis state found in ${Math.floor(Date.now() - start) / 1000} seconds`);
+    await chain.stop();
+    logger.info("chain stopped");
+  });
+});

--- a/packages/lodestar/test/unit/eth1/impl/util.test.ts
+++ b/packages/lodestar/test/unit/eth1/impl/util.test.ts
@@ -1,0 +1,29 @@
+import {expect} from "chai";
+import {getDepositEventsByBlock} from "../../../../src/eth1/impl/util";
+import {IDepositEvent} from "../../../eth1";
+
+describe("utils of eth1", function() {
+  it("should return empty array", () => {
+    expect(getDepositEventsByBlock(null)).to.be.deep.equal([]);
+    expect(getDepositEventsByBlock([])).to.be.deep.equal([]);
+  });
+
+  it("should return deposit events by block", () => {
+    const depositData = {amount: 0n, signature: Buffer.alloc(96), withdrawalCredentials: Buffer.alloc(32), pubkey: Buffer.alloc(48)};
+    const depositEvents: IDepositEvent[] = [
+      {blockNumber: 1000, index: 0, ...depositData},
+      {blockNumber: 2000, index: 1, ...depositData},
+      {blockNumber: 2000, index: 2, ...depositData},
+      {blockNumber: 3000, index: 3, ...depositData},
+      {blockNumber: 3000, index: 4, ...depositData},
+    ];
+    const blockEvents = getDepositEventsByBlock(depositEvents);
+    expect(blockEvents.length).to.be.equal(3);
+    expect(blockEvents[0][0]).to.be.equal(1000);
+    expect(blockEvents[0][1].length).to.be.equal(1);
+    expect(blockEvents[1][0]).to.be.equal(2000);
+    expect(blockEvents[1][1].length).to.be.equal(2);
+    expect(blockEvents[2][0]).to.be.equal(3000);
+    expect(blockEvents[2][1].length).to.be.equal(2);
+  });
+});

--- a/packages/lodestar/test/unit/eth1/impl/util.test.ts
+++ b/packages/lodestar/test/unit/eth1/impl/util.test.ts
@@ -1,29 +1,33 @@
 import {expect} from "chai";
-import {getDepositEventsByBlock} from "../../../../src/eth1/impl/util";
-import {IDepositEvent} from "../../../eth1";
+import {groupDepositEventsByBlock} from "../../../../src/eth1/impl/util";
+import {IDepositEvent} from "../../../../src/eth1";
 
 describe("utils of eth1", function() {
   it("should return empty array", () => {
-    expect(getDepositEventsByBlock(null)).to.be.deep.equal([]);
-    expect(getDepositEventsByBlock([])).to.be.deep.equal([]);
+    expect(groupDepositEventsByBlock(null)).to.be.deep.equal([]);
+    expect(groupDepositEventsByBlock([])).to.be.deep.equal([]);
   });
 
   it("should return deposit events by block", () => {
     const depositData = {amount: 0n, signature: Buffer.alloc(96), withdrawalCredentials: Buffer.alloc(32), pubkey: Buffer.alloc(48)};
     const depositEvents: IDepositEvent[] = [
       {blockNumber: 1000, index: 0, ...depositData},
-      {blockNumber: 2000, index: 1, ...depositData},
       {blockNumber: 2000, index: 2, ...depositData},
-      {blockNumber: 3000, index: 3, ...depositData},
+      {blockNumber: 2000, index: 1, ...depositData},
       {blockNumber: 3000, index: 4, ...depositData},
+      {blockNumber: 3000, index: 3, ...depositData},
     ];
-    const blockEvents = getDepositEventsByBlock(depositEvents);
+    const blockEvents = groupDepositEventsByBlock(depositEvents);
     expect(blockEvents.length).to.be.equal(3);
     expect(blockEvents[0][0]).to.be.equal(1000);
     expect(blockEvents[0][1].length).to.be.equal(1);
     expect(blockEvents[1][0]).to.be.equal(2000);
     expect(blockEvents[1][1].length).to.be.equal(2);
+    // make sure events are sorted
+    expect(blockEvents[1][1][0].index).to.be.lt(blockEvents[1][1][1].index);
     expect(blockEvents[2][0]).to.be.equal(3000);
     expect(blockEvents[2][1].length).to.be.equal(2);
+    // make sure events are sorted
+    expect(blockEvents[2][1][0].index).to.be.lt(blockEvents[2][1][1].index);
   });
 });

--- a/packages/lodestar/test/unit/eth1/impl/util.test.ts
+++ b/packages/lodestar/test/unit/eth1/impl/util.test.ts
@@ -4,8 +4,8 @@ import {IDepositEvent} from "../../../../src/eth1";
 
 describe("utils of eth1", function() {
   it("should return empty array", () => {
-    expect(groupDepositEventsByBlock(null)).to.be.deep.equal([]);
-    expect(groupDepositEventsByBlock([])).to.be.deep.equal([]);
+    expect(Array.from(groupDepositEventsByBlock(null).keys())).to.be.deep.equal([]);
+    expect(Array.from(groupDepositEventsByBlock([]).keys())).to.be.deep.equal([]);
   });
 
   it("should return deposit events by block", () => {
@@ -18,16 +18,15 @@ describe("utils of eth1", function() {
       {blockNumber: 3000, index: 3, ...depositData},
     ];
     const blockEvents = groupDepositEventsByBlock(depositEvents);
-    expect(blockEvents.length).to.be.equal(3);
-    expect(blockEvents[0][0]).to.be.equal(1000);
-    expect(blockEvents[0][1].length).to.be.equal(1);
-    expect(blockEvents[1][0]).to.be.equal(2000);
-    expect(blockEvents[1][1].length).to.be.equal(2);
-    // make sure events are sorted
-    expect(blockEvents[1][1][0].index).to.be.lt(blockEvents[1][1][1].index);
-    expect(blockEvents[2][0]).to.be.equal(3000);
-    expect(blockEvents[2][1].length).to.be.equal(2);
-    // make sure events are sorted
-    expect(blockEvents[2][1][0].index).to.be.lt(blockEvents[2][1][1].index);
+    expect(Array.from(blockEvents.keys())).to.be.deep.equals([1000, 2000, 3000]);
+    expect(blockEvents.get(1000).length).to.be.equal(1);
+    expect(blockEvents.get(1000)[0].index).to.be.equal(0);
+    expect(blockEvents.get(2000).length).to.be.equal(2);
+    expect(blockEvents.get(2000)[0].index).to.be.equal(1);
+    expect(blockEvents.get(2000)[1].index).to.be.equal(2);
+    expect(blockEvents.get(3000).length).to.be.equal(2);
+    expect(blockEvents.get(3000)[0].index).to.be.equal(3);
+    expect(blockEvents.get(3000)[1].index).to.be.equal(4);
+
   });
 });


### PR DESCRIPTION
## Goal
+ resolves #889  with minimal change
+ instead of doing `processBlock(blockNumber)` we get deposit events of block range and do `processBlock(blockNumber, blockDepositEvents)` and only process blocks that have deposit events