### PR TITLE
Allow empty network rpc requests

### DIFF
--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -162,7 +162,7 @@ describe("[network] network", function () {
       netB.reqResp.sendResponse(requestId, null, netB.metadata.seqNumber);
     });
     const seqNumber = await netA.reqResp.ping(netB.peerInfo, netA.metadata.seqNumber);
-    expect(seqNumber).to.equal(netB.metadata.seqNumber);
+    expect(seqNumber.toString()).to.equal(netB.metadata.seqNumber.toString());
   });
   it("should send/receive metadata messages", async function () {
     const connected = Promise.all([

--- a/packages/lodestar/test/unit/network/encoders/request.test.ts
+++ b/packages/lodestar/test/unit/network/encoders/request.test.ts
@@ -9,33 +9,33 @@ import {expect} from "chai";
 import {createStatus} from "./utils";
 
 describe("request encoders", function () {
-    
+
   let loggerStub: SinonStubbedInstance<ILogger>;
-    
+
   beforeEach(function () {
     loggerStub = sinon.createStubInstance(WinstonLogger);
   });
 
   it("should work - basic request - ssz", async function () {
     const requests = await pipe(
-      [1n],
+      [0n],
       eth2RequestEncode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ),
       eth2RequestDecode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ),
       collect
     );
     expect(requests.length).to.be.equal(1);
-    expect(config.types.Uint64.equals(requests[0], 1n)).to.be.true;
+    expect(config.types.Uint64.equals(requests[0], 0n)).to.be.true;
   });
 
   it("should work - basic request - ssz_snappy", async function () {
     const requests = await pipe(
-      [1n],
+      [0n],
       eth2RequestEncode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ_SNAPPY),
       eth2RequestDecode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ_SNAPPY),
       collect
     );
     expect(requests.length).to.be.equal(1);
-    expect(config.types.Uint64.equals(requests[0], 1n)).to.be.true;
+    expect(config.types.Uint64.equals(requests[0], 0n)).to.be.true;
   });
 
   it("should work - container request - ssz", async function () {
@@ -87,23 +87,21 @@ describe("request encoders", function () {
   it("should work - no request body - ssz", async function () {
     const requests = await pipe(
       [],
-      eth2RequestEncode(config, loggerStub, Method.Metadata, ReqRespEncoding.SSZ),
       eth2RequestDecode(config, loggerStub, Method.Metadata, ReqRespEncoding.SSZ),
       collect
     );
-    expect(requests.length).to.be.equal(0);
+    expect(requests.length).to.be.equal(1);
   });
 
   it("should work - no request body - ssz_snappy", async function () {
     const requests = await pipe(
       [],
-      eth2RequestEncode(config, loggerStub, Method.Metadata, ReqRespEncoding.SSZ_SNAPPY),
       eth2RequestDecode(config, loggerStub, Method.Metadata, ReqRespEncoding.SSZ_SNAPPY),
       collect
     );
-    expect(requests.length).to.be.equal(0);
+    expect(requests.length).to.be.equal(1);
   });
-  
+
   it("should warn user if failed to decode request", async function () {
     await pipe(
       [1n],
@@ -132,5 +130,5 @@ describe("request encoders", function () {
     );
     expect(loggerStub.warn.calledOnce).to.be.true;
   });
-    
+
 });


### PR DESCRIPTION
- metadata method has no request body, this allows for methods like that

resolves #973 