### PR TITLE
@chainsafe/ssz version bump

### DIFF
--- a/packages/lodestar-beacon-state-transition/package.json
+++ b/packages/lodestar-beacon-state-transition/package.json
@@ -36,7 +36,7 @@
     "@chainsafe/bls": "1.0.0",
     "@chainsafe/lodestar-config": "^0.8.0",
     "@chainsafe/lodestar-utils": "^0.8.0",
-    "@chainsafe/ssz": "^0.6.4",
+    "@chainsafe/ssz": "^0.6.5",
     "bigint-buffer": "^1.1.5",
     "buffer-xor": "^2.0.2"
   },

--- a/packages/lodestar-cli/package.json
+++ b/packages/lodestar-cli/package.json
@@ -46,7 +46,7 @@
     "@chainsafe/lodestar-types": "^0.8.0",
     "@chainsafe/lodestar-utils": "^0.8.0",
     "@chainsafe/lodestar-validator": "^0.8.0",
-    "@chainsafe/ssz": "^0.6.4",
+    "@chainsafe/ssz": "^0.6.5",
     "@iarna/toml": "^2.2.3",
     "bigint-buffer": "^1.1.5",
     "commander": "^2.19.0",

--- a/packages/lodestar-spec-test-util/package.json
+++ b/packages/lodestar-spec-test-util/package.json
@@ -41,7 +41,7 @@
   ],
   "dependencies": {
     "@chainsafe/lodestar-utils": "^0.8.0",
-    "@chainsafe/ssz": "^0.6.4",
+    "@chainsafe/ssz": "^0.6.5",
     "camelcase": "^5.3.1",
     "chai": "^4.2.0",
     "deepmerge": "^4.0.0",

--- a/packages/lodestar-types/package.json
+++ b/packages/lodestar-types/package.json
@@ -34,7 +34,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/lodestar-params": "^0.8.0",
-    "@chainsafe/ssz": "^0.6.4"
+    "@chainsafe/ssz": "^0.6.5"
   },
   "devDependencies": {
     "@types/chai": "4.2.0",

--- a/packages/lodestar-utils/package.json
+++ b/packages/lodestar-utils/package.json
@@ -34,7 +34,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/ssz": "^0.6.4",
+    "@chainsafe/ssz": "^0.6.5",
     "bigint-buffer": "^1.1.5",
     "camelcase": "^5.3.1",
     "chalk": "^2.4.2",

--- a/packages/lodestar-validator/package.json
+++ b/packages/lodestar-validator/package.json
@@ -46,7 +46,7 @@
     "@chainsafe/lodestar-config": "^0.8.0",
     "@chainsafe/lodestar-types": "^0.8.0",
     "@chainsafe/lodestar-utils": "^0.8.0",
-    "@chainsafe/ssz": "^0.6.4",
+    "@chainsafe/ssz": "^0.6.5",
     "axios": "^0.19.0",
     "axios-mock-adapter": "^1.17.0",
     "eventsource": "^1.0.7",

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -48,7 +48,7 @@
     "@chainsafe/lodestar-utils": "^0.8.0",
     "@chainsafe/lodestar-validator": "^0.8.0",
     "@chainsafe/snappy-stream": "3.0.4",
-    "@chainsafe/ssz": "0.6.4",
+    "@chainsafe/ssz": "0.6.5",
     "@types/async": "^3.0.1",
     "abort-controller": "^3.0.0",
     "abortable-iterator": "^3.0.0",

--- a/packages/spec-test-runner/package.json
+++ b/packages/spec-test-runner/package.json
@@ -40,7 +40,7 @@
     "@chainsafe/lodestar-types": "^0.8.0",
     "@chainsafe/lodestar-utils": "^0.8.0",
     "@chainsafe/lodestar-validator": "^0.8.0",
-    "@chainsafe/ssz": "0.6.4",
+    "@chainsafe/ssz": "0.6.5",
     "@types/chai": "4.2.0",
     "@types/chai-as-promised": "^7.1.1",
     "@types/mocha": "^5.2.7",


### PR DESCRIPTION
bumping @chainsafe/ssz from 0.6.4 to 0.6.5