### PR TITLE
Logger should not iterate over a string context

### DIFF
--- a/packages/lodestar-utils/src/logger/format.ts
+++ b/packages/lodestar-utils/src/logger/format.ts
@@ -26,6 +26,7 @@ export function serializeContext(context?: Context|Error): string {
   if(context instanceof Error) {
     return context.stack;
   }
+  if (typeof context === "string") return context;
   return Object.keys(context).map((key) => {
     let value = "";
     if(Array.isArray(context[key]) || context[key] instanceof Uint8Array) {

--- a/packages/lodestar-utils/test/unit/logger/format.test.ts
+++ b/packages/lodestar-utils/test/unit/logger/format.test.ts
@@ -18,6 +18,12 @@ describe("log format", function () {
           +" buffer=0x0000, string=test, bigint=10"
         );
     });
+
+    it("should serialize string context", function () {
+      const context = "Error as a string" as any;
+      const serialized = serializeContext(context);
+      expect(serialized).to.equal(context);
+    });
   });
 
 });


### PR DESCRIPTION
The `serializeContext()` function in `lodestar-utils/src/logger/format.ts` iterates over strings. While running the validator there was a network error that produced this output

```
0=N, 1=o, 2= , 3=r, 4=e, 5=s, 6=p, 7=o, 8=n, 9=s, 10=e, 11= , 12=r, 13=e, 14=t, 15=u, 16=r, 17=n, 18=e, 19=d, 20= , 21=f, 22=o, 23=r, 24= , 25=m, 26=e, 27=t, 28=h, 29=o, 30=d, 31= , 32=g, 33=o, 34=o, 35=d, 36=b, 37=y, 38=e, 39=., 40= , 41=r, 42=e, 43=q, 44=u, 45=e, 46=s, 47=t, 48==, 49=f, 50=6, 51=e, 52=9, 53=b, 54=4, 55=3, 56=e, 57=a, 58=8, 59=0, 60=1, 61=2, 62=a, 63=0, 64=1
```

Since it's not possible to be 100% sure that all errors that are thrown will be of an instance of Error, this PR checks the context type and returns early if it's of type string.