### PR TITLE
Short lived committee assignments should not be added to ENR attnets

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/index.ts
@@ -6,6 +6,7 @@ import {processRewardsAndPenalties} from "./processRewardsAndPenalties";
 import {processRegistryUpdates} from "./processRegistryUpdates";
 import {processSlashings} from "./processSlashings";
 import {processFinalUpdates} from "./processFinalUpdates";
+import {processForkChanged} from "./processFork";
 
 export {
   processJustificationAndFinalization,
@@ -23,4 +24,5 @@ export function processEpoch(epochCtx: EpochContext, state: BeaconState): void {
   processRegistryUpdates(epochCtx, process, state);
   processSlashings(epochCtx, process, state);
   processFinalUpdates(epochCtx, process, state);
+  processForkChanged(epochCtx, process, state);
 }

--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/processFork.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/processFork.ts
@@ -1,0 +1,23 @@
+import {BeaconState} from "@chainsafe/lodestar-types";
+import {EpochContext} from "..";
+import {intToBytes} from "@chainsafe/lodestar-utils";
+import {IEpochProcess} from "../util";
+
+export function processForkChanged(
+  epochCtx: EpochContext,
+  process: IEpochProcess,
+  state: BeaconState): void {
+  const config = epochCtx.config;
+  const currentEpoch = process.currentEpoch;
+  const nextEpoch = currentEpoch + 1;
+  const currentForkVersion = state.fork.currentVersion;
+  const nextFork = config.params.ALL_FORKS && config.params.ALL_FORKS.find(
+    (fork) => config.types.Version.equals(currentForkVersion, intToBytes(fork.previousVersion, 4)));
+  if (nextFork && nextFork.epoch === nextEpoch) {
+    state.fork = {
+      previousVersion: state.fork.currentVersion,
+      currentVersion: intToBytes(nextFork.currentVersion, 4),
+      epoch: nextFork.epoch,
+    };
+  }
+}

--- a/packages/lodestar/src/chain/blocks/process.ts
+++ b/packages/lodestar/src/chain/blocks/process.ts
@@ -51,7 +51,7 @@ export function processBlock(
             const epoch = computeEpochAtSlot(config, newState.slot);
             const currentVersion = newState.fork.currentVersion;
             logger.important(`Fork version changed to ${currentVersion} at slot ${newState.slot} and epoch ${epoch}`);
-            eventBus.emit("forkDigestChanged");
+            eventBus.emit("forkVersion");
           }
         }
         pool.onProcessedBlock(job.signedBlock);

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -125,7 +125,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     this.forkChoice.start(state.genesisTime, this.clock);
     await this.blockProcessor.start();
     this._currentForkDigest =  computeForkDigest(this.config, state.fork.currentVersion, state.genesisValidatorsRoot);
-    this.on("forkDigestChanged", this.handleForkDigestChanged);
+    this.on("forkVersion", this.handleForkVersionChanged);
     await this.restoreHeadState(state);
   }
 
@@ -137,7 +137,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     }
 
     await this.blockProcessor.stop();
-    this.removeListener("forkDigestChanged", this.handleForkDigestChanged);
+    this.removeListener("forkVersion", this.handleForkVersionChanged);
   }
 
   public get currentForkDigest(): ForkDigest {
@@ -291,7 +291,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     this.logger.profile("restoreHeadState");
   }
 
-  private async handleForkDigestChanged(): Promise<void> {
+  private async handleForkVersionChanged(): Promise<void> {
     this._currentForkDigest = await this.getCurrentForkDigest();
     this.emit("forkDigest", this._currentForkDigest);
   }

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -25,7 +25,7 @@ export interface IChainEvents {
   processedAttestation: (attestation: Attestation) => void;
   justifiedCheckpoint: (checkpoint: Checkpoint) => void;
   finalizedCheckpoint: (checkpoint: Checkpoint) => void;
-  forkDigestChanged: () => void;
+  forkVersion: () => void;
   forkDigest: (forkDigest: ForkDigest) => void;
 }
 

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -24,7 +24,6 @@ import {
   getDomain,
   computeEpochAtSlot,
   computeSigningRoot,
-  isUnaggregatedAttestation,
   computeSubnetForAttestation
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -62,7 +62,7 @@ export class Libp2pNetwork extends (EventEmitter as { new(): NetworkEventEmitter
         const discv5Discovery = this.libp2p._discovery.get("discv5") as Discv5Discovery;
         const enr = discv5Discovery && discv5Discovery.discv5 && discv5Discovery.discv5.enr || undefined;
         this.metadata = new MetadataController({enr}, {config, chain, logger});
-        this.gossip = (new Gossip(opts, this.metadata,
+        this.gossip = (new Gossip(opts,
           {config, libp2p, logger, validator, chain})) as unknown as IGossip;
         resolve();
       });

--- a/packages/lodestar/test/unit/chain/chain.test.ts
+++ b/packages/lodestar/test/unit/chain/chain.test.ts
@@ -63,7 +63,7 @@ describe("BeaconChain", function() {
     });
   });
 
-  describe("forkDigestChanged event", () => {
+  describe("forkVersion event", () => {
     it("should should receive forkDigest event", async () => {
       const spy = sinon.spy();
       const received = new Promise((resolve) => {
@@ -72,7 +72,7 @@ describe("BeaconChain", function() {
           resolve();
         });
       });
-      chain.emit("forkDigestChanged");
+      chain.emit("forkVersion");
       await received;
       expect(spy.callCount).to.be.equal(1);
     });

--- a/packages/lodestar/test/unit/network/gossip/gossip.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/gossip.test.ts
@@ -1,8 +1,5 @@
 import {Gossip} from "../../../../src/network/gossip/gossip";
 import {INetworkOptions} from "../../../../src/network/options";
-import {ENR} from "@chainsafe/discv5";
-import {createPeerId} from "../../../../src/network";
-import {MetadataController} from "../../../../src/network/metadata";
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 import sinon from "sinon";
 import {NodejsNode} from "../../../../src/network/nodejs";
@@ -22,7 +19,6 @@ import {BeaconState} from "@chainsafe/lodestar-types";
 
 describe("Network Gossip", function() {
   let gossip: Gossip;
-  let metadata: MetadataController;
   const sandbox = sinon.createSandbox();
   let pubsub: IGossipSub;
   let chain: IBeaconChain;
@@ -37,8 +33,6 @@ describe("Network Gossip", function() {
       connectTimeout: 0,
       disconnectTimeout: 0,
     };
-    const peerIdB = await createPeerId();
-    const enr = ENR.createFromPeerId(peerIdB);
     const libp2p = sandbox.createStubInstance(NodejsNode);
     const logger = new WinstonLogger();
     logger.silent = true;
@@ -51,9 +45,8 @@ describe("Network Gossip", function() {
       state,
       config
     });
-    metadata = new MetadataController({enr}, {config,  chain, logger});
     pubsub = new MockGossipSub();
-    gossip = new Gossip(networkOpts, metadata, {config, libp2p, logger, validator, chain, pubsub});
+    gossip = new Gossip(networkOpts, {config, libp2p, logger, validator, chain, pubsub});
     await gossip.start();
   });
 
@@ -170,32 +163,32 @@ describe("Network Gossip", function() {
     });
   });
 
-  describe("Metadata", async function() {
-    it("subscribeToAttestationSubnet", () => {
-      expect(Number(metadata.seqNumber.valueOf())).to.be.equal(0);
-      gossip.subscribeToAttestationSubnet(chain.currentForkDigest, 10);
-      expect(Number(metadata.seqNumber.valueOf())).to.be.equal(1);
-      // subscribe same subnet again, should not change seq number
-      gossip.subscribeToAttestationSubnet(chain.currentForkDigest, 10);
-      expect(Number(metadata.seqNumber.valueOf())).to.be.equal(1);
-      gossip.subscribeToAttestationSubnet(chain.currentForkDigest, 20);
-      expect(Number(metadata.seqNumber.valueOf())).to.be.equal(2);
-    });
+  // describe("Metadata", async function() {
+  //   it("subscribeToAttestationSubnet", () => {
+  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(0);
+  //     gossip.subscribeToAttestationSubnet(chain.currentForkDigest, 10);
+  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(1);
+  //     // subscribe same subnet again, should not change seq number
+  //     gossip.subscribeToAttestationSubnet(chain.currentForkDigest, 10);
+  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(1);
+  //     gossip.subscribeToAttestationSubnet(chain.currentForkDigest, 20);
+  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(2);
+  //   });
 
-    it("unsubscribeFromAttestationSubnet", () => {
-      expect(Number(metadata.seqNumber.valueOf())).to.be.equal(0);
-      gossip.subscribeToAttestationSubnet(chain.currentForkDigest, 10);
-      expect(Number(metadata.seqNumber.valueOf())).to.be.equal(1);
-      gossip.subscribeToAttestationSubnet(chain.currentForkDigest, 20);
-      expect(Number(metadata.seqNumber.valueOf())).to.be.equal(2);
-      gossip.unsubscribeFromAttestationSubnet(chain.currentForkDigest, 20);
-      expect(Number(metadata.seqNumber.valueOf())).to.be.equal(3);
-      // unsubscribe same subnet again
-      gossip.unsubscribeFromAttestationSubnet(chain.currentForkDigest, 20);
-      expect(Number(metadata.seqNumber.valueOf())).to.be.equal(3);
-      gossip.unsubscribeFromAttestationSubnet(chain.currentForkDigest, 10);
-      expect(Number(metadata.seqNumber.valueOf())).to.be.equal(4);
-    });
-  });
+  //   it("unsubscribeFromAttestationSubnet", () => {
+  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(0);
+  //     gossip.subscribeToAttestationSubnet(chain.currentForkDigest, 10);
+  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(1);
+  //     gossip.subscribeToAttestationSubnet(chain.currentForkDigest, 20);
+  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(2);
+  //     gossip.unsubscribeFromAttestationSubnet(chain.currentForkDigest, 20);
+  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(3);
+  //     // unsubscribe same subnet again
+  //     gossip.unsubscribeFromAttestationSubnet(chain.currentForkDigest, 20);
+  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(3);
+  //     gossip.unsubscribeFromAttestationSubnet(chain.currentForkDigest, 10);
+  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(4);
+  //   });
+  // });
 
 });

--- a/packages/lodestar/test/unit/network/gossip/gossip.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/gossip.test.ts
@@ -163,32 +163,4 @@ describe("Network Gossip", function() {
     });
   });
 
-  // describe("Metadata", async function() {
-  //   it("subscribeToAttestationSubnet", () => {
-  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(0);
-  //     gossip.subscribeToAttestationSubnet(chain.currentForkDigest, 10);
-  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(1);
-  //     // subscribe same subnet again, should not change seq number
-  //     gossip.subscribeToAttestationSubnet(chain.currentForkDigest, 10);
-  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(1);
-  //     gossip.subscribeToAttestationSubnet(chain.currentForkDigest, 20);
-  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(2);
-  //   });
-
-  //   it("unsubscribeFromAttestationSubnet", () => {
-  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(0);
-  //     gossip.subscribeToAttestationSubnet(chain.currentForkDigest, 10);
-  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(1);
-  //     gossip.subscribeToAttestationSubnet(chain.currentForkDigest, 20);
-  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(2);
-  //     gossip.unsubscribeFromAttestationSubnet(chain.currentForkDigest, 20);
-  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(3);
-  //     // unsubscribe same subnet again
-  //     gossip.unsubscribeFromAttestationSubnet(chain.currentForkDigest, 20);
-  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(3);
-  //     gossip.unsubscribeFromAttestationSubnet(chain.currentForkDigest, 10);
-  //     expect(Number(metadata.seqNumber.valueOf())).to.be.equal(4);
-  //   });
-  // });
-
 });

--- a/packages/lodestar/test/unit/tasks/interopSubnetsJoiningTask.test.ts
+++ b/packages/lodestar/test/unit/tasks/interopSubnetsJoiningTask.test.ts
@@ -105,7 +105,7 @@ describe("interopSubnetsJoiningTask", () => {
       * config.params.SLOTS_PER_EPOCH
       * config.params.SECONDS_PER_SLOT
       * 1000);
-    // 1 run right after start, 1 run in scheduleNextForkSubscription
+    // at least 1 run right after start, 1 run in scheduleNextForkSubscription
     expect(gossipStub.subscribeToAttestationSubnet.callCount).to.be.gte(2 * config.params.RANDOM_SUBNETS_PER_VALIDATOR);
     // subscribe to next fork digest subnet
     expect(spy.args[spy.args.length - 1][0]).to.be.deep.equal(nextForkDigest);


### PR DESCRIPTION
## Goals
+ resolves #959 
+ process hard fork in fast state transition
+ Address this snippet in the spec
```
Note: When preparing for a hard fork, a validator must select and subscribe to random subnets of the future fork versioning at least EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION epochs in advance of the fork. These new subnets for the fork are maintained in addition to those for the current fork until the fork occurs. After the fork occurs, let the subnets from the previous fork reach the end of life with no replacements.
```