### PR TITLE
Use fastStateTransition when producing block

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -59,7 +59,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
   public chainId: Uint16;
   public networkId: Uint64;
   public clock: IBeaconClock;
-  public epochCtx: EpochContext;
+  private epochCtx: EpochContext;
   private readonly config: IBeaconConfig;
   private readonly db: IBeaconDb;
   private readonly eth1: IEth1Notifier;
@@ -108,6 +108,10 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
       return null;
     }
     return this.db.block.get(summary.blockRoot);
+  }
+
+  public getEpochContext(): EpochContext {
+    return this.epochCtx.copy();
   }
 
   public async getFinalizedCheckpoint(): Promise<Checkpoint> {

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -41,7 +41,7 @@ export async function assembleBlock(
 
 function computeNewStateRoot(config: IBeaconConfig, state: BeaconState, block: BeaconBlock, chain: IBeaconChain): Root {
   // state is cloned from the cache already
-  const epochContext = chain.epochCtx.copy();
+  const epochContext = chain.getEpochContext();
   const signedBlock = {
     message: block,
     signature: EMPTY_SIGNATURE,

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -41,7 +41,6 @@ export interface IBeaconChain extends ChainEventEmitter {
   chainId: Uint16;
   networkId: Uint64;
   currentForkDigest: ForkDigest;
-  epochCtx: EpochContext;
   /**
    * Start beacon chain processing
    */
@@ -62,6 +61,8 @@ export interface IBeaconChain extends ChainEventEmitter {
   getHeadBlock(): Promise<SignedBeaconBlock|null>;
 
   getFinalizedCheckpoint(): Promise<Checkpoint>;
+
+  getEpochContext(): EpochContext;
 
   getBlockAtSlot(slot: Slot): Promise<SignedBeaconBlock|null>;
 

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -24,7 +24,6 @@ import {
   getDomain,
   computeEpochAtSlot,
   computeSigningRoot,
-  isUnaggregatedAttestation,
   computeSubnetForAttestation
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
@@ -90,7 +89,7 @@ export class GossipMessageValidator implements IGossipMessageValidator {
       return false;
     }
 
-    const supposedProposerIndex = this.chain.epochCtx.getBeaconProposer(signedBlock.message.slot);
+    const supposedProposerIndex = this.chain.getEpochContext().getBeaconProposer(signedBlock.message.slot);
     if (supposedProposerIndex !== signedBlock.message.proposerIndex) {
       return false;
     }
@@ -178,7 +177,7 @@ export class GossipMessageValidator implements IGossipMessageValidator {
       return false;
     }
 
-    const committee = this.chain.epochCtx.getBeaconCommittee(attestationData.slot, attestationData.index);
+    const committee = this.chain.getEpochContext().getBeaconCommittee(attestationData.slot, attestationData.index);
     if (!committee.includes(aggregatorIndex)) {
       return false;
     }

--- a/packages/lodestar/test/e2e/chain/factory/block/assembleBlock.test.ts
+++ b/packages/lodestar/test/e2e/chain/factory/block/assembleBlock.test.ts
@@ -54,8 +54,9 @@ describe("produce block", function () {
     depositDataRootList.push(config.types.DepositData.hashTreeRoot(generateDeposit().data));
     chainStub.getHeadState.resolves(config.types.BeaconState.clone(state));
     chainStub.getHeadBlock.resolves(parentBlock);
-    chainStub.epochCtx = new EpochContext(config);
-    chainStub.epochCtx.loadState(state);
+    const epochCtx = new EpochContext(config);
+    epochCtx.loadState(state);
+    chainStub.getEpochContext.returns(epochCtx);
     dbStub.depositDataRoot.getTreeBacked.resolves(depositDataRootList);
     dbStub.proposerSlashing.values.resolves([]);
     dbStub.aggregateAndProof.getBlockAttestations.resolves([]);
@@ -74,7 +75,7 @@ describe("produce block", function () {
       return await assembleBlock(config, chainStub, dbStub, slot, validatorIndex, randao);
     });
     const block = await blockProposingService.createAndPublishBlock(1, state.fork, ZERO_HASH);
-    expect(() => fastStateTransition(chainStub.epochCtx, state, block, false)).to.not.throw();
+    expect(() => fastStateTransition(chainStub.getEpochContext(), state, block, false)).to.not.throw();
   });
 
   function getBlockProposingService(keypair: Keypair): BlockProposingService {

--- a/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
@@ -3,13 +3,14 @@ import {expect} from "chai";
 
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 import * as blockBodyAssembly from "../../../../../src/chain/factory/block/body";
-import * as blockTransitions from "@chainsafe/lodestar-beacon-state-transition";
+import * as blockTransitions from "@chainsafe/lodestar-beacon-state-transition/lib/fast";
 import {assembleBlock} from "../../../../../src/chain/factory/block";
 import {generateState} from "../../../../utils/state";
 import {StatefulDagLMDGHOST} from "../../../../../../lodestar/src/chain/forkChoice";
 import {BeaconChain} from "../../../../../src/chain";
 import {generateEmptyBlock, generateEmptySignedBlock} from "../../../../utils/block";
 import {StubbedBeaconDb, StubbedChain} from "../../../../utils/stub";
+import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 
 describe("block assembly", function () {
 
@@ -19,7 +20,7 @@ describe("block assembly", function () {
 
   beforeEach(() => {
     assembleBodyStub = sandbox.stub(blockBodyAssembly, "assembleBody");
-    stateTransitionStub = sandbox.stub(blockTransitions, "stateTransition");
+    stateTransitionStub = sandbox.stub(blockTransitions, "fastStateTransition");
 
 
     forkChoiceStub = sandbox.createStubInstance(StatefulDagLMDGHOST);
@@ -34,9 +35,9 @@ describe("block assembly", function () {
   });
 
   it("should assemble block", async function () {
-    const head = chainStub.forkChoice.headBlockRoot();
     chainStub.getHeadBlock.resolves(generateEmptySignedBlock());
-    chainStub.getHeadState.resolves(generateState({slot: 1}) as any);
+    chainStub.getHeadState.resolves(generateState({slot: 1}));
+    chainStub.epochCtx = new EpochContext(config);
     beaconDB.depositDataRoot.getTreeBacked.resolves(config.types.DepositDataRootList.tree.defaultValue());
     assembleBodyStub.resolves(generateEmptyBlock().body);
     stateTransitionStub.returns(generateState());

--- a/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
@@ -37,7 +37,7 @@ describe("block assembly", function () {
   it("should assemble block", async function () {
     chainStub.getHeadBlock.resolves(generateEmptySignedBlock());
     chainStub.getHeadState.resolves(generateState({slot: 1}));
-    chainStub.epochCtx = new EpochContext(config);
+    chainStub.getEpochContext.returns(new EpochContext(config));
     beaconDB.depositDataRoot.getTreeBacked.resolves(config.types.DepositDataRootList.tree.defaultValue());
     assembleBodyStub.resolves(generateEmptyBlock().body);
     stateTransitionStub.returns(generateState());

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -22,7 +22,6 @@ export class MockBeaconChain extends EventEmitter implements IBeaconChain {
   public clock: IBeaconClock;
   public epochCtx: EpochContext;
 
-
   private state: BeaconState|null;
   private config: IBeaconConfig;
 

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -20,8 +20,8 @@ export class MockBeaconChain extends EventEmitter implements IBeaconChain {
   public chainId: Uint16;
   public networkId: Uint64;
   public clock: IBeaconClock;
-  public epochCtx: EpochContext;
 
+  private epochCtx: EpochContext;
   private state: BeaconState|null;
   private config: IBeaconConfig;
 
@@ -45,6 +45,10 @@ export class MockBeaconChain extends EventEmitter implements IBeaconChain {
     const block = generateEmptySignedBlock();
     block.message.slot = slot;
     return block;
+  }
+
+  public getEpochContext(): EpochContext {
+    return this.epochCtx.copy();
   }
 
   public async getFinalizedCheckpoint(): Promise<Checkpoint> {


### PR DESCRIPTION
## Goal
+ resolves #957 
+ Don't need to modify `is_candidate_block` because we query from db instead of having that function
+ Write `compute_new_state_root` to easier maintain the spec, use fastStateTransition
+ Don't need to modify `get_block_signature` because we get signing root from block when calculating signature already in our validator