### PR TITLE
Parse yargs option types from the default config values

### DIFF
--- a/packages/lodestar-cli/src/lodecli/cmds/beacon/cmds/run/options/params.ts
+++ b/packages/lodestar-cli/src/lodecli/cmds/beacon/cmds/run/options/params.ts
@@ -9,7 +9,17 @@ Object.keys(params).forEach((key) => {
       `chain.params.${key}`,
     ],
     hidden: true,
+    type: yargsOptionType(params[key as keyof typeof params])
   };
 });
+
+
+function yargsOptionType(value: unknown): Options["type"] {
+  if (typeof value === "string" || Buffer.isBuffer(value)) return "string";
+  if (typeof value === "boolean") return "boolean";
+  if (typeof value === "number") return "number";
+  if (Array.isArray(value)) return "array";
+  else return undefined;
+}
 
 export const paramsOptions = options;


### PR DESCRIPTION
Implements the quick fix outlined by https://github.com/ChainSafe/lodestar/issues/977

Fixes https://github.com/ChainSafe/lodestar/issues/977