### PR TITLE
Use bigint for all epoch and slot related types

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/block/randao.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/randao.ts
@@ -31,7 +31,7 @@ export function processRandao(
     body.randaoReveal.valueOf() as Uint8Array,
   ));
   // Mix it in
-  state.randaoMixes[currentEpoch % config.params.EPOCHS_PER_HISTORICAL_VECTOR] = xor(
+  state.randaoMixes[Number(currentEpoch % config.params.EPOCHS_PER_HISTORICAL_VECTOR)] = xor(
     Buffer.from(getRandaoMix(config, state, currentEpoch) as Uint8Array),
     Buffer.from(hash(body.randaoReveal.valueOf() as Uint8Array)),
   );

--- a/packages/lodestar-beacon-state-transition/src/constants/constants.ts
+++ b/packages/lodestar-beacon-state-transition/src/constants/constants.ts
@@ -3,9 +3,9 @@
  */
 
 export const DEPOSIT_CONTRACT_TREE_DEPTH = 2 ** 5; // 32
-export const GENESIS_SLOT = 0;
-export const GENESIS_EPOCH = 0;
-export const FAR_FUTURE_EPOCH = Infinity;
+export const GENESIS_SLOT = 0n;
+export const GENESIS_EPOCH = 0n;
+export const FAR_FUTURE_EPOCH = 2n**64n - 1n;
 export const ZERO_HASH = Buffer.alloc(32, 0);
 export const EMPTY_SIGNATURE = Buffer.alloc(96, 0);
 export const SECONDS_PER_DAY = 86400;

--- a/packages/lodestar-beacon-state-transition/src/epoch/balanceUpdates/attestation.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/balanceUpdates/attestation.ts
@@ -32,7 +32,7 @@ export function getAttestationDeltas(config: IBeaconConfig, state: BeaconState):
   const eligibleValidatorIndices = Array.from(state.validators)
     .reduce((indices: ValidatorIndex[], v, index) => {
       if (isActiveValidator(v, previousEpoch)
-        || (v.slashed && previousEpoch + 1 < v.withdrawableEpoch)) {
+        || (v.slashed && previousEpoch + 1n < v.withdrawableEpoch)) {
         indices.push(index);
       }
       return indices;

--- a/packages/lodestar-beacon-state-transition/src/epoch/finalUpdates.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/finalUpdates.ts
@@ -8,14 +8,14 @@ import {
   getCurrentEpoch,
   getRandaoMix
 } from "../util";
-import {bigIntMin, intDiv} from "@chainsafe/lodestar-utils";
+import {bigIntMin} from "@chainsafe/lodestar-utils";
 
 
 export function processFinalUpdates(config: IBeaconConfig, state: BeaconState): void {
   const currentEpoch = getCurrentEpoch(config, state);
-  const nextEpoch = currentEpoch + 1;
+  const nextEpoch = currentEpoch + 1n;
   // Reset eth1 data votes
-  if (nextEpoch % config.params.EPOCHS_PER_ETH1_VOTING_PERIOD === 0) {
+  if (nextEpoch % config.params.EPOCHS_PER_ETH1_VOTING_PERIOD === 0n) {
     state.eth1DataVotes = [];
   }
   // Update effective balances with hysteresis
@@ -34,12 +34,12 @@ export function processFinalUpdates(config: IBeaconConfig, state: BeaconState): 
     }
   });
   // Reset slashings
-  state.slashings[nextEpoch % config.params.EPOCHS_PER_SLASHINGS_VECTOR] = 0n;
+  state.slashings[Number(nextEpoch % config.params.EPOCHS_PER_SLASHINGS_VECTOR)] = 0n;
   // Set randao mix
-  state.randaoMixes[nextEpoch % config.params.EPOCHS_PER_HISTORICAL_VECTOR] =
+  state.randaoMixes[Number(nextEpoch % config.params.EPOCHS_PER_HISTORICAL_VECTOR)] =
     getRandaoMix(config, state, currentEpoch);
   // Set historical root accumulator
-  if (nextEpoch % intDiv(config.params.SLOTS_PER_HISTORICAL_ROOT, config.params.SLOTS_PER_EPOCH) === 0) {
+  if (nextEpoch % BigInt(config.params.SLOTS_PER_HISTORICAL_ROOT) / config.params.SLOTS_PER_EPOCH === 0n) {
     const historicalBatch: HistoricalBatch = {
       blockRoots: state.blockRoots,
       stateRoots: state.stateRoots,

--- a/packages/lodestar-beacon-state-transition/src/epoch/fork.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/fork.ts
@@ -5,7 +5,7 @@ import {intToBytes} from "@chainsafe/lodestar-utils";
 
 export function processForkChanged(config: IBeaconConfig, state: BeaconState): void {
   const currentEpoch = getCurrentEpoch(config, state);
-  const nextEpoch = currentEpoch + 1;
+  const nextEpoch = currentEpoch + 1n;
   const currentForkVersion = state.fork.currentVersion;
   const nextFork = config.params.ALL_FORKS && config.params.ALL_FORKS.find(
     (fork) => config.types.Version.equals(currentForkVersion, intToBytes(fork.previousVersion, 4)));

--- a/packages/lodestar-beacon-state-transition/src/epoch/justification.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/justification.ts
@@ -16,7 +16,7 @@ export function processJustificationAndFinalization(
   state: BeaconState
 ): void {
   const currentEpoch = getCurrentEpoch(config, state);
-  if(currentEpoch <= GENESIS_EPOCH + 1) {
+  if(currentEpoch <= GENESIS_EPOCH + 1n) {
     return;
   }
   const previousEpoch = getPreviousEpoch(config, state);
@@ -59,28 +59,28 @@ export function processJustificationAndFinalization(
   // The 2nd/3rd/4th most recent epochs are all justified, the 2nd using the 4th as source
   if (
     bits[1] && bits[2] && bits[3] &&
-    oldPreviousJustifiedCheckpoint.epoch + 3 === currentEpoch
+    oldPreviousJustifiedCheckpoint.epoch + 3n === currentEpoch
   ) {
     state.finalizedCheckpoint = oldPreviousJustifiedCheckpoint;
   }
   // The 2nd/3rd most recent epochs are both justified, the 2nd using the 3rd as source
   if (
     bits[1] && bits[2] &&
-    oldPreviousJustifiedCheckpoint.epoch + 2 === currentEpoch
+    oldPreviousJustifiedCheckpoint.epoch + 2n === currentEpoch
   ) {
     state.finalizedCheckpoint = oldPreviousJustifiedCheckpoint;
   }
   // The 1st/2nd/3rd most recent epochs are all justified, the 1st using the 3rd as source
   if (
     bits[0] && bits[1] && bits[2] &&
-    oldCurrentJustifiedCheckpoint.epoch + 2 === currentEpoch
+    oldCurrentJustifiedCheckpoint.epoch + 2n === currentEpoch
   ) {
     state.finalizedCheckpoint = oldCurrentJustifiedCheckpoint;
   }
   // The 1st/2nd most recent epochs are both justified, the 1st using the 2nd as source
   if (
     bits[0] && bits[1] &&
-    oldCurrentJustifiedCheckpoint.epoch + 1 === currentEpoch
+    oldCurrentJustifiedCheckpoint.epoch + 1n === currentEpoch
   ) {
     state.finalizedCheckpoint = oldCurrentJustifiedCheckpoint;
   }

--- a/packages/lodestar-beacon-state-transition/src/epoch/registryUpdates.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/registryUpdates.ts
@@ -22,7 +22,7 @@ export function processRegistryUpdates(config: IBeaconConfig, state: BeaconState
   const ejectionBalance = config.params.EJECTION_BALANCE;
   state.validators.forEach((validator, index) => {
     if (isEligibleForActivationQueue(config, validator)) {
-      validator.activationEligibilityEpoch = currentEpoch + 1;
+      validator.activationEligibilityEpoch = currentEpoch + 1n;
     }
     if (isActiveValidator(validator, currentEpoch) &&
       validator.effectiveBalance <= ejectionBalance) {
@@ -39,7 +39,7 @@ export function processRegistryUpdates(config: IBeaconConfig, state: BeaconState
     .map((val: Validator, index: number) => {
       return {val, index};
     })
-    .sort((a, b) => (a.val.activationEligibilityEpoch - b.val.activationEligibilityEpoch) || a.index - b.index)
+    .sort((a, b) => Number(a.val.activationEligibilityEpoch - b.val.activationEligibilityEpoch) || a.index - b.index)
     .map((obj) => obj.val);
   // Dequeued validators for activation up to churn limit
   activationQueue.slice(0, getValidatorChurnLimit(config, state)).forEach((validator) => {

--- a/packages/lodestar-beacon-state-transition/src/epoch/slashings.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/slashings.ts
@@ -5,7 +5,7 @@
 import {BeaconState} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {decreaseBalance, getCurrentEpoch, getTotalActiveBalance,} from "../util";
-import {bigIntMin, intDiv} from "@chainsafe/lodestar-utils";
+import {bigIntMin} from "@chainsafe/lodestar-utils";
 
 
 /**
@@ -22,7 +22,7 @@ export function processSlashings(config: IBeaconConfig, state: BeaconState): voi
   state.validators.forEach((validator, index) => {
     if (
       validator.slashed &&
-      (currentEpoch + intDiv(config.params.EPOCHS_PER_SLASHINGS_VECTOR, 2)) === validator.withdrawableEpoch
+      (currentEpoch + config.params.EPOCHS_PER_SLASHINGS_VECTOR / 2n) === validator.withdrawableEpoch
     ) {
       const penalty = validator.effectiveBalance / config.params.EFFECTIVE_BALANCE_INCREMENT *
         slashingMultiplier / totalBalance * config.params.EFFECTIVE_BALANCE_INCREMENT;

--- a/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
@@ -1,4 +1,5 @@
 import {BeaconState, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {bigIntArrayMax} from "@chainsafe/lodestar-utils";
 
 import {FAR_FUTURE_EPOCH} from "../../constants";
 import {computeActivationExitEpoch, getChurnLimit} from "../../util";
@@ -24,10 +25,10 @@ export function initiateValidatorExit(
   const validatorExitEpochs = Array.from(state.validators).map((v) => v.exitEpoch);
   const exitEpochs = validatorExitEpochs.filter((exitEpoch) => exitEpoch !== FAR_FUTURE_EPOCH);
   exitEpochs.push(computeActivationExitEpoch(config, currentEpoch));
-  let exitQueueEpoch = Math.max(...exitEpochs);
+  let exitQueueEpoch = bigIntArrayMax(...exitEpochs);
   const exitQueueChurn = validatorExitEpochs.filter((exitEpoch) => exitEpoch === exitQueueEpoch).length;
   if (exitQueueChurn >= getChurnLimit(config, epochCtx.currentShuffling.activeIndices.length)) {
-    exitQueueEpoch += 1;
+    exitQueueEpoch += 1n;
   }
 
   // set validator exit epoch and withdrawable epoch

--- a/packages/lodestar-beacon-state-transition/src/fast/block/processRandao.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/processRandao.ts
@@ -32,7 +32,7 @@ export function processRandao(
     }
   }
   // mix in RANDAO reveal
-  state.randaoMixes[epoch % config.params.EPOCHS_PER_HISTORICAL_VECTOR] = xor(
+  state.randaoMixes[Number(epoch % config.params.EPOCHS_PER_HISTORICAL_VECTOR)] = xor(
     Buffer.from(getRandaoMix(config, state, epoch) as Uint8Array),
     Buffer.from(hash(randaoReveal)),
   );

--- a/packages/lodestar-beacon-state-transition/src/fast/block/slashValidator.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/slashValidator.ts
@@ -1,4 +1,5 @@
 import {BeaconState, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {bigIntMax} from "@chainsafe/lodestar-utils";
 
 import {decreaseBalance, increaseBalance} from "../../util";
 import {EpochContext} from "../util";
@@ -21,8 +22,8 @@ export function slashValidator(
   initiateValidatorExit(epochCtx, state, slashedIndex);
   const validator = state.validators[slashedIndex];
   validator.slashed = true;
-  validator.withdrawableEpoch = Math.max(validator.withdrawableEpoch, epoch + EPOCHS_PER_SLASHINGS_VECTOR);
-  state.slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] += validator.effectiveBalance;
+  validator.withdrawableEpoch = bigIntMax(validator.withdrawableEpoch, epoch + EPOCHS_PER_SLASHINGS_VECTOR);
+  state.slashings[Number(epoch % EPOCHS_PER_SLASHINGS_VECTOR)] += validator.effectiveBalance;
   decreaseBalance(state, slashedIndex, validator.effectiveBalance / BigInt(MIN_SLASHING_PENALTY_QUOTIENT));
 
   // apply proposer and whistleblower rewards

--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/processFinalUpdates.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/processFinalUpdates.ts
@@ -1,5 +1,5 @@
 import {BeaconState} from "@chainsafe/lodestar-types";
-import {bigIntMin, intDiv} from "@chainsafe/lodestar-utils";
+import {bigIntMin} from "@chainsafe/lodestar-utils";
 
 import {getRandaoMix} from "../../util";
 import {EpochContext, IEpochProcess} from "../util";
@@ -11,7 +11,7 @@ export function processFinalUpdates(
 ): void {
   const config = epochCtx.config;
   const currentEpoch = process.currentEpoch;
-  const nextEpoch = currentEpoch + 1;
+  const nextEpoch = currentEpoch + 1n;
   const {
     EFFECTIVE_BALANCE_INCREMENT,
     EPOCHS_PER_ETH1_VOTING_PERIOD,
@@ -29,7 +29,7 @@ export function processFinalUpdates(
   const UPWARD_THRESHOLD = HYSTERESIS_INCREMENT * BigInt(HYSTERESIS_UPWARD_MULTIPLIER);
 
   // reset eth1 data votes
-  if (nextEpoch % EPOCHS_PER_ETH1_VOTING_PERIOD === 0) {
+  if (nextEpoch % EPOCHS_PER_ETH1_VOTING_PERIOD === 0n) {
     state.eth1DataVotes = [];
   }
 
@@ -49,13 +49,13 @@ export function processFinalUpdates(
   }
 
   // reset slashings
-  state.slashings[nextEpoch % EPOCHS_PER_SLASHINGS_VECTOR] = BigInt(0);
+  state.slashings[Number(nextEpoch % EPOCHS_PER_SLASHINGS_VECTOR)] = BigInt(0);
 
   // set randao mix
-  state.randaoMixes[nextEpoch  % EPOCHS_PER_HISTORICAL_VECTOR] = getRandaoMix(config, state, currentEpoch);
+  state.randaoMixes[Number(nextEpoch  % EPOCHS_PER_HISTORICAL_VECTOR)] = getRandaoMix(config, state, currentEpoch);
 
   // set historical root accumulator
-  if (nextEpoch % intDiv(SLOTS_PER_HISTORICAL_ROOT, SLOTS_PER_EPOCH) === 0) {
+  if (nextEpoch % SLOTS_PER_HISTORICAL_ROOT / SLOTS_PER_EPOCH === 0n) {
     state.historicalRoots.push(
       config.types.HistoricalBatch.hashTreeRoot({
         blockRoots: state.blockRoots,

--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/processJustificationAndFinalization.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/processJustificationAndFinalization.ts
@@ -14,7 +14,7 @@ export function processJustificationAndFinalization(
   const previousEpoch = process.prevEpoch;
   const currentEpoch = process.currentEpoch;
 
-  if (currentEpoch <= GENESIS_EPOCH + 1) {
+  if (currentEpoch <= GENESIS_EPOCH + 1n) {
     return;
   }
 
@@ -49,28 +49,28 @@ export function processJustificationAndFinalization(
   // The 2nd/3rd/4th most recent epochs are all justified, the 2nd using the 4th as source
   if (
     bits[1] && bits[2] && bits[3] &&
-    oldPreviousJustifiedCheckpoint.epoch + 3 === currentEpoch
+    oldPreviousJustifiedCheckpoint.epoch + 3n === currentEpoch
   ) {
     state.finalizedCheckpoint = oldPreviousJustifiedCheckpoint;
   }
   // The 2nd/3rd most recent epochs are both justified, the 2nd using the 3rd as source
   if (
     bits[1] && bits[2] &&
-    oldPreviousJustifiedCheckpoint.epoch + 2 === currentEpoch
+    oldPreviousJustifiedCheckpoint.epoch + 2n === currentEpoch
   ) {
     state.finalizedCheckpoint = oldPreviousJustifiedCheckpoint;
   }
   // The 1st/2nd/3rd most recent epochs are all justified, the 1st using the 3rd as source
   if (
     bits[0] && bits[1] && bits[2] &&
-    oldCurrentJustifiedCheckpoint.epoch + 2 === currentEpoch
+    oldCurrentJustifiedCheckpoint.epoch + 2n === currentEpoch
   ) {
     state.finalizedCheckpoint = oldCurrentJustifiedCheckpoint;
   }
   // The 1st/2nd most recent epochs are both justified, the 1st using the 2nd as source
   if (
     bits[0] && bits[1] &&
-    oldCurrentJustifiedCheckpoint.epoch + 1 === currentEpoch
+    oldCurrentJustifiedCheckpoint.epoch + 1n === currentEpoch
   ) {
     state.finalizedCheckpoint = oldCurrentJustifiedCheckpoint;
   }

--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/processRegistryUpdates.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/processRegistryUpdates.ts
@@ -24,13 +24,13 @@ export function processRegistryUpdates(
     endChurn += 1;
     if (endChurn >= process.churnLimit) {
       endChurn = 0;
-      exitEnd += 1;
+      exitEnd += 1n;
     }
   });
 
   // set new activation eligibilities
   process.indicesToSetActivationEligibility.forEach((index) => {
-    state.validators[index].activationEligibilityEpoch = epochCtx.currentShuffling.epoch + 1;
+    state.validators[index].activationEligibilityEpoch = epochCtx.currentShuffling.epoch + 1n;
   });
 
   const finalityEpoch = state.finalizedCheckpoint.epoch;

--- a/packages/lodestar-beacon-state-transition/src/fast/slot/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/slot/index.ts
@@ -19,12 +19,12 @@ export function processSlots(epochCtx: EpochContext, state: BeaconState, slot: S
   while (state.slot < slot) {
     processSlot(epochCtx, state);
     // process epoch on the start slot of the next epoch
-    if ((state.slot + 1) % epochCtx.config.params.SLOTS_PER_EPOCH === 0) {
+    if ((state.slot + 1n) % epochCtx.config.params.SLOTS_PER_EPOCH === 0n) {
       processEpoch(epochCtx, state);
-      state.slot += 1;
+      state.slot += 1n;
       epochCtx.rotateEpochs(state);
     } else {
-      state.slot += 1;
+      state.slot += 1n;
     }
   }
 }

--- a/packages/lodestar-beacon-state-transition/src/fast/slot/processSlot.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/slot/processSlot.ts
@@ -8,12 +8,12 @@ export function processSlot(epochCtx: EpochContext, state: BeaconState): void {
   const {SLOTS_PER_HISTORICAL_ROOT} = config.params;
   // cache state root
   const prevStateRoot = config.types.BeaconState.hashTreeRoot(state);
-  state.stateRoots[state.slot % SLOTS_PER_HISTORICAL_ROOT] = prevStateRoot;
+  state.stateRoots[Number(state.slot % SLOTS_PER_HISTORICAL_ROOT)] = prevStateRoot;
   // cache latest block header state root
   if (config.types.Root.equals(state.latestBlockHeader.stateRoot, new Uint8Array(32))) {
     state.latestBlockHeader.stateRoot = prevStateRoot;
   }
   // cache block root
-  state.blockRoots[state.slot % SLOTS_PER_HISTORICAL_ROOT] =
+  state.blockRoots[Number(state.slot % SLOTS_PER_HISTORICAL_ROOT)] =
     config.types.BeaconBlockHeader.hashTreeRoot(state.latestBlockHeader);
 }

--- a/packages/lodestar-beacon-state-transition/src/fast/util/attesterStatus.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/attesterStatus.ts
@@ -12,7 +12,7 @@ export const FLAG_ELIGIBLE_ATTESTER = 1 << 7;
 export interface IAttesterStatus {
   flags: number;
   proposerIndex: number; // -1 when not included by any proposer
-  inclusionDelay: number;
+  inclusionDelay: bigint;
   validator: IFlatValidator;
   active: boolean;
 }
@@ -21,7 +21,7 @@ export function createIAttesterStatus(v: IFlatValidator): IAttesterStatus {
   return {
     flags: 0,
     proposerIndex: -1,
-    inclusionDelay: 0,
+    inclusionDelay: 0n,
     validator: v,
     active: false,
   };

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
@@ -35,8 +35,8 @@ export class EpochContext {
   public loadState(state: BeaconState): void {
     this.syncPubkeys(state);
     const currentEpoch = computeEpochAtSlot(this.config, state.slot);
-    const previousEpoch = currentEpoch === GENESIS_EPOCH ? GENESIS_EPOCH : currentEpoch - 1;
-    const nextEpoch = currentEpoch + 1;
+    const previousEpoch = currentEpoch === GENESIS_EPOCH ? GENESIS_EPOCH : currentEpoch - 1n;
+    const nextEpoch = currentEpoch + 1n;
 
     // TODO use readonly iteration here
     const indicesBounded: [ValidatorIndex, Epoch, Epoch][] = Array.from(state.validators).map((v, i) => ([
@@ -89,7 +89,7 @@ export class EpochContext {
   public rotateEpochs(state: BeaconState): void {
     this.previousShuffling = this.currentShuffling;
     this.currentShuffling = this.nextShuffling;
-    const nextEpoch = this.currentShuffling.epoch + 1;
+    const nextEpoch = this.currentShuffling.epoch + 1n;
     // TODO use readonly iteration here
     const indicesBounded: [ValidatorIndex, Epoch, Epoch][] = Array.from(state.validators).map((v, i) => ([
       i, v.activationEpoch, v.exitEpoch,
@@ -115,7 +115,7 @@ export class EpochContext {
     if (epoch !== this.currentShuffling.epoch) {
       throw new Error("beacon proposer index out of range");
     }
-    return this.proposers[slot % this.config.params.SLOTS_PER_EPOCH];
+    return this.proposers[Number(slot % this.config.params.SLOTS_PER_EPOCH)];
   }
 
   private _resetProposers(state: BeaconState): void {
@@ -138,11 +138,11 @@ export class EpochContext {
     const epoch = computeEpochAtSlot(this.config, slot);
     const epochSlot = slot % this.config.params.SLOTS_PER_EPOCH;
     if (epoch === this.previousShuffling.epoch) {
-      return this.previousShuffling.committees[epochSlot];
+      return this.previousShuffling.committees[Number(epochSlot)];
     } else if (epoch === this.currentShuffling.epoch) {
-      return this.currentShuffling.committees[epochSlot];
+      return this.currentShuffling.committees[Number(epochSlot)];
     } else if (epoch === this.nextShuffling.epoch) {
-      return this.nextShuffling.committees[epochSlot];
+      return this.nextShuffling.committees[Number(epochSlot)];
     } else {
       throw new Error(`crosslink committee retrieval: out of range epoch: ${epoch}`);
     }

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochShuffling.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochShuffling.ts
@@ -33,7 +33,7 @@ export interface IEpochShuffling {
 }
 
 export function computeCommitteeCount(config: IBeaconConfig, activeValidatorCount: number): number {
-  const validatorsPerSlot = intDiv(activeValidatorCount, config.params.SLOTS_PER_EPOCH);
+  const validatorsPerSlot = intDiv(activeValidatorCount, Number(config.params.SLOTS_PER_EPOCH));
   let committeesPerSlot = intDiv(validatorsPerSlot, config.params.TARGET_COMMITTEE_SIZE);
   if (config.params.MAX_COMMITTEES_PER_SLOT < committeesPerSlot) {
     committeesPerSlot = config.params.MAX_COMMITTEES_PER_SLOT;
@@ -66,7 +66,7 @@ export function computeEpochShuffling(
   const activeValidatorCount = activeIndices.length;
   const committeesPerSlot = computeCommitteeCount(config, activeValidatorCount);
 
-  const committeeCount = committeesPerSlot * config.params.SLOTS_PER_EPOCH;
+  const committeeCount = committeesPerSlot * Number(config.params.SLOTS_PER_EPOCH);
 
   const sliceCommittee = (slot: number, committeeIndex: number): ValidatorIndex[] => {
     const index = (slot * committeesPerSlot) + committeeIndex;
@@ -78,7 +78,7 @@ export function computeEpochShuffling(
     return shuffling.slice(startOffset, endOffset);
   };
 
-  const committees = Array.from({length: config.params.SLOTS_PER_EPOCH}, (_, slot) => {
+  const committees = Array.from({length: Number(config.params.SLOTS_PER_EPOCH)}, (_, slot) => {
     return Array.from({length: committeesPerSlot}, (_, committeeIndex) => {
       return sliceCommittee(slot, committeeIndex);
     });

--- a/packages/lodestar-beacon-state-transition/src/slot.ts
+++ b/packages/lodestar-beacon-state-transition/src/slot.ts
@@ -20,7 +20,7 @@ export function processSlots(
   while (state.slot < slot){
     processSlot(config, state);
     // Process epoch on the first slot of the next epoch
-    if ((state.slot + 1) % config.params.SLOTS_PER_EPOCH === 0){
+    if ((state.slot + 1n) % config.params.SLOTS_PER_EPOCH === 0n){
       processEpoch(config, state);
     }
     state.slot++;
@@ -30,7 +30,7 @@ export function processSlots(
 function processSlot(config: IBeaconConfig, state: BeaconState): void {
   // Cache state root
   const previousStateRoot = config.types.BeaconState.hashTreeRoot(state);
-  state.stateRoots[state.slot % config.params.SLOTS_PER_HISTORICAL_ROOT] = previousStateRoot;
+  state.stateRoots[Number(state.slot % config.params.SLOTS_PER_HISTORICAL_ROOT)] = previousStateRoot;
 
   // Cache latest block header state root
   if (config.types.Root.equals(state.latestBlockHeader.stateRoot, ZERO_HASH)) {
@@ -39,5 +39,5 @@ function processSlot(config: IBeaconConfig, state: BeaconState): void {
 
   // Cache block root
   const previousBlockRoot = config.types.BeaconBlockHeader.hashTreeRoot(state.latestBlockHeader);
-  state.blockRoots[state.slot % config.params.SLOTS_PER_HISTORICAL_ROOT] = previousBlockRoot;
+  state.blockRoots[Number(state.slot % config.params.SLOTS_PER_HISTORICAL_ROOT)] = previousBlockRoot;
 }

--- a/packages/lodestar-beacon-state-transition/src/util/balance.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/balance.ts
@@ -8,9 +8,9 @@ import {
   ValidatorIndex,
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {bigIntMax} from "@chainsafe/lodestar-utils";
 import {getCurrentEpoch} from "./epoch";
 import {getActiveValidatorIndices} from "./validator";
-import {bigIntMax} from "@chainsafe/lodestar-utils";
 
 
 /**

--- a/packages/lodestar-beacon-state-transition/src/util/blockRoot.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/blockRoot.ts
@@ -27,7 +27,7 @@ import {computeStartSlotAtEpoch} from "./epoch";
 export function getBlockRootAtSlot(config: IBeaconConfig, state: BeaconState, slot: Slot): Root {
   assert(slot < state.slot);
   assert(state.slot <= slot + config.params.SLOTS_PER_HISTORICAL_ROOT);
-  return state.blockRoots[slot % config.params.SLOTS_PER_HISTORICAL_ROOT];
+  return state.blockRoots[Number(slot % config.params.SLOTS_PER_HISTORICAL_ROOT)];
 }
 
 /**

--- a/packages/lodestar-beacon-state-transition/src/util/committee.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/committee.ts
@@ -46,7 +46,10 @@ export function getCommitteeCountAtSlot(config: IBeaconConfig, state: BeaconStat
     1,
     Math.min(
       config.params.MAX_COMMITTEES_PER_SLOT,
-      intDiv(intDiv(activeValidatorIndices.length, config.params.SLOTS_PER_EPOCH), config.params.TARGET_COMMITTEE_SIZE),
+      intDiv(
+        intDiv(activeValidatorIndices.length, Number(config.params.SLOTS_PER_EPOCH)),
+        config.params.TARGET_COMMITTEE_SIZE
+      ),
     ),
   );
 }
@@ -66,7 +69,7 @@ export function getBeaconCommittee(
     config,
     getActiveValidatorIndices(state, epoch),
     getSeed(config, state, epoch, DomainType.BEACON_ATTESTER),
-    (slot % config.params.SLOTS_PER_EPOCH) * committeesPerSlot + index,
-    committeesPerSlot * config.params.SLOTS_PER_EPOCH
+    Number(slot % config.params.SLOTS_PER_EPOCH) * committeesPerSlot + index,
+    committeesPerSlot * Number(config.params.SLOTS_PER_EPOCH)
   );
 }

--- a/packages/lodestar-beacon-state-transition/src/util/duties.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/duties.ts
@@ -25,7 +25,7 @@ export function getCommitteeAssignment(
   validatorIndex: ValidatorIndex
 ): CommitteeAssignment {
 
-  const next2Epoch = getCurrentEpoch(config, state) + 2;
+  const next2Epoch = getCurrentEpoch(config, state) + 2n;
   assert(epoch <= next2Epoch);
 
   const epochStartSlot = computeStartSlotAtEpoch(config, epoch);

--- a/packages/lodestar-beacon-state-transition/src/util/epoch.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/epoch.ts
@@ -15,7 +15,7 @@ import {GENESIS_EPOCH} from "../constants";
  * Return the epoch number at the given slot.
  */
 export function computeEpochAtSlot(config: IBeaconConfig, slot: Slot): Epoch {
-  return Math.floor(slot / config.params.SLOTS_PER_EPOCH);
+  return slot / config.params.SLOTS_PER_EPOCH;
 }
 
 /**
@@ -29,7 +29,7 @@ export function computeStartSlotAtEpoch(config: IBeaconConfig, epoch: Epoch): Sl
  * Return the epoch at which an activation or exit triggered in ``epoch`` takes effect.
  */
 export function computeActivationExitEpoch(config: IBeaconConfig, epoch: Epoch): Epoch {
-  return epoch + 1 + config.params.MAX_SEED_LOOKAHEAD;
+  return epoch + 1n + config.params.MAX_SEED_LOOKAHEAD;
 }
 
 /**
@@ -47,5 +47,5 @@ export function getPreviousEpoch(config: IBeaconConfig, state: BeaconState): Epo
   if (currentEpoch === GENESIS_EPOCH) {
     return GENESIS_EPOCH;
   }
-  return currentEpoch - 1;
+  return currentEpoch - 1n;
 }

--- a/packages/lodestar-beacon-state-transition/src/util/seed.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/seed.ts
@@ -57,7 +57,7 @@ export function computeShuffledIndex(
  * Return the randao mix at a recent [[epoch]].
  */
 export function getRandaoMix(config: IBeaconConfig, state: BeaconState, epoch: Epoch): Bytes32 {
-  return state.randaoMixes[epoch % config.params.EPOCHS_PER_HISTORICAL_VECTOR];
+  return state.randaoMixes[Number(epoch % config.params.EPOCHS_PER_HISTORICAL_VECTOR)];
 }
 
 /**
@@ -67,7 +67,7 @@ export function getSeed(config: IBeaconConfig, state: BeaconState, epoch: Epoch,
   const mix = getRandaoMix(
     config,
     state,
-    epoch + config.params.EPOCHS_PER_HISTORICAL_VECTOR - config.params.MIN_SEED_LOOKAHEAD - 1
+    epoch + config.params.EPOCHS_PER_HISTORICAL_VECTOR - config.params.MIN_SEED_LOOKAHEAD - 1n
   );
 
   return hash(Buffer.concat([

--- a/packages/lodestar-beacon-state-transition/src/util/slot.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/slot.ts
@@ -13,9 +13,9 @@ export function getCurrentSlot(config: IBeaconConfig, genesisTime: Number64): Sl
   return GENESIS_SLOT + getSlotsSinceGenesis(config, genesisTime);
 }
 
-export function computeSlotsSinceEpochStart(config: IBeaconConfig, slot: Slot, epoch?: Epoch): number {
+export function computeSlotsSinceEpochStart(config: IBeaconConfig, slot: Slot, epoch?: Epoch): Slot {
   const computeEpoch = epoch ? epoch : computeEpochAtSlot(config, slot);
-  return Number(slot - computeStartSlotAtEpoch(config, computeEpoch));
+  return slot - computeStartSlotAtEpoch(config, computeEpoch);
 }
 
 export function computeTimeAtSlot(config: IBeaconConfig, slot: Slot, genesisTime: Number64): Number64 {

--- a/packages/lodestar-beacon-state-transition/src/util/slot.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/slot.ts
@@ -6,7 +6,7 @@ import {GENESIS_SLOT} from "../constants";
 
 export function getSlotsSinceGenesis(config: IBeaconConfig, genesisTime: Number64): Slot {
   const diffInSeconds = (Date.now() / 1000) - genesisTime;
-  return intDiv(diffInSeconds, config.params.SECONDS_PER_SLOT);
+  return BigInt(intDiv(diffInSeconds, config.params.SECONDS_PER_SLOT));
 }
 
 export function getCurrentSlot(config: IBeaconConfig, genesisTime: Number64): Slot {
@@ -15,9 +15,9 @@ export function getCurrentSlot(config: IBeaconConfig, genesisTime: Number64): Sl
 
 export function computeSlotsSinceEpochStart(config: IBeaconConfig, slot: Slot, epoch?: Epoch): number {
   const computeEpoch = epoch ? epoch : computeEpochAtSlot(config, slot);
-  return slot - computeStartSlotAtEpoch(config, computeEpoch);
+  return Number(slot - computeStartSlotAtEpoch(config, computeEpoch));
 }
 
 export function computeTimeAtSlot(config: IBeaconConfig, slot: Slot, genesisTime: Number64): Number64 {
-  return genesisTime + slot * config.params.SECONDS_PER_SLOT;
+  return genesisTime + Number(slot) * config.params.SECONDS_PER_SLOT;
 }

--- a/packages/lodestar-beacon-state-transition/test/unit/fast/block/isValidIndexedAttestation.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/fast/block/isValidIndexedAttestation.test.ts
@@ -9,7 +9,7 @@ import {EMPTY_SIGNATURE} from "../../../../src";
 describe("validate indexed attestation", () => {
   const epochCtx = new EpochContext(config);
   it("should return invalid indexed attestation - empty participants", () => {
-    const attestationData = generateAttestationData(0, 1);
+    const attestationData = generateAttestationData(0n, 1n);
 
     const indexedAttestation: IndexedAttestation = {
       attestingIndices: [],
@@ -20,7 +20,7 @@ describe("validate indexed attestation", () => {
   });
 
   it("should return invalid indexed attestation - indexes not sorted", () => {
-    const attestationData = generateAttestationData(0, 1);
+    const attestationData = generateAttestationData(0n, 1n);
 
     const indexedAttestation: IndexedAttestation = {
       attestingIndices: [1, 0],
@@ -31,7 +31,7 @@ describe("validate indexed attestation", () => {
   });
 
   it("should return valid indexed attestation", () => {
-    const attestationData = generateAttestationData(0, 1);
+    const attestationData = generateAttestationData(0n, 1n);
 
     const indexedAttestation: IndexedAttestation = {
       attestingIndices: [0, 1, 2, 3],

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/blockHeader.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/blockHeader.test.ts
@@ -25,9 +25,9 @@ describe("process block - block header", function () {
   });
 
   it("fail to process header - invalid slot", function () {
-    const state = generateState({slot: 5});
+    const state = generateState({slot: 5n});
     const block = generateEmptyBlock();
-    block.slot = 4;
+    block.slot = 4n;
     try {
       processBlockHeader(config, state, block);
       expect.fail();
@@ -36,9 +36,9 @@ describe("process block - block header", function () {
   });
 
   it("fail to process header - invalid parent header", function () {
-    const state = generateState({slot: 5});
+    const state = generateState({slot: 5n});
     const block = generateEmptyBlock();
-    block.slot = 5;
+    block.slot = 5n;
     block.parentRoot = Buffer.alloc(10, 1);
     try {
       processBlockHeader(config, state, block);
@@ -47,10 +47,10 @@ describe("process block - block header", function () {
   });
 
   it("fail to process header - proposerSlashed", function () {
-    const state = generateState({slot: 5});
-    state.validators.push(generateValidator({activation: 0, exit: 10, slashed: true}));
+    const state = generateState({slot: 5n});
+    state.validators.push(generateValidator({activation: 0n, exit: 10n, slashed: true}));
     const block = generateEmptyBlock();
-    block.slot = 5;
+    block.slot = 5n;
     block.parentRoot = config.types.BeaconBlockHeader.hashTreeRoot(state.latestBlockHeader);
     try {
       processBlockHeader(config, state, block);
@@ -60,10 +60,10 @@ describe("process block - block header", function () {
   });
 
   it("should process block", function () {
-    const state = generateState({slot: 5});
-    state.validators.push(generateValidator({activation: 0, exit: 10}));
+    const state = generateState({slot: 5n});
+    state.validators.push(generateValidator({activation: 0n, exit: 10n}));
     const block = generateEmptyBlock();
-    block.slot = 5;
+    block.slot = 5n;
     block.parentRoot = config.types.BeaconBlockHeader.hashTreeRoot(state.latestBlockHeader);
     getBeaconProposeIndexStub.returns(0);
     try {

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/eth1data.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/eth1data.test.ts
@@ -27,7 +27,7 @@ describe('process block - eth1data', function () {
       depositRoot: Buffer.alloc(32),
     };
     state.eth1DataVotes = new Array(
-      config.params.EPOCHS_PER_ETH1_VOTING_PERIOD * 2 * config.params.SLOTS_PER_EPOCH
+      config.params.EPOCHS_PER_ETH1_VOTING_PERIOD * 2n * config.params.SLOTS_PER_EPOCH
     ).fill(undefined).map(() => {
       return vote;
     });

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attestation.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attestation.test.ts
@@ -29,36 +29,36 @@ describe("process block - attestation", function () {
   });
 
   it("fail to process attestation - exceeds inclusion delay", function () {
-    const state = generateState({slot: config.params.MIN_ATTESTATION_INCLUSION_DELAY + 1});
+    const state = generateState({slot: config.params.MIN_ATTESTATION_INCLUSION_DELAY + 1n});
     const attestation = generateEmptyAttestation();
     expect(() => processAttestation(config, state, attestation)).to.throw;
   });
 
   it("fail to process attestation - future epoch", function () {
-    const state = generateState({slot: 0});
+    const state = generateState({slot: 0n});
     const attestation = generateEmptyAttestation();
     expect(() => processAttestation(config, state, attestation)).to.throw;
   });
 
   it("fail to process attestation - crosslink not zerohash", function () {
-    const state = generateState({slot: 0});
+    const state = generateState({slot: 0n});
     const attestation = generateEmptyAttestation();
     expect(() => processAttestation(config, state, attestation)).to.throw;
   });
 
   it("should process attestation - currentEpoch === data.targetEpoch", function () {
     const state = generateState({
-      slot: config.params.MIN_ATTESTATION_INCLUSION_DELAY + 1,
-      currentJustifiedCheckpoint: {epoch: 1, root: ZERO_HASH}
+      slot: config.params.MIN_ATTESTATION_INCLUSION_DELAY + 1n,
+      currentJustifiedCheckpoint: {epoch: 1n, root: ZERO_HASH}
     });
     currentEpochStub.returns(1);
     previousEpochStub.returns(0);
     validateIndexedAttestationStub.returns(true);
     getBeaconProposerIndexStub.returns(2);
     const attestation = generateEmptyAttestation();
-    attestation.data.slot = config.params.SLOTS_PER_EPOCH + 1;
-    attestation.data.target.epoch = 1;
-    attestation.data.source.epoch = 1;
+    attestation.data.slot = config.params.SLOTS_PER_EPOCH + 1n;
+    attestation.data.target.epoch = 1n;
+    attestation.data.source.epoch = 1n;
     attestation.data.source.root = state.currentJustifiedCheckpoint.root;
     getBeaconComitteeStub.returns(Array.from({length: attestation.aggregationBits.length}));
     expect(processAttestation(config, state, attestation)).to.not.throw;
@@ -68,16 +68,16 @@ describe("process block - attestation", function () {
 
   it("should process attestation - previousEpoch === data.targetEpoch", function () {
     const state = generateState({
-      slot: config.params.MIN_ATTESTATION_INCLUSION_DELAY + 1,
-      currentJustifiedCheckpoint: {epoch: 1, root: ZERO_HASH}
+      slot: config.params.MIN_ATTESTATION_INCLUSION_DELAY + 1n,
+      currentJustifiedCheckpoint: {epoch: 1n, root: ZERO_HASH}
     });
     currentEpochStub.returns(1);
     previousEpochStub.returns(0);
     validateIndexedAttestationStub.returns(true);
     getBeaconProposerIndexStub.returns(2);
     const attestation = generateEmptyAttestation();
-    attestation.data.target.epoch = 0;
-    attestation.data.source.epoch = 0;
+    attestation.data.target.epoch = 0n;
+    attestation.data.source.epoch = 0n;
     attestation.data.source.root = state.previousJustifiedCheckpoint.root;
     getBeaconComitteeStub.returns(Array.from({length: attestation.aggregationBits.length}));
     expect(processAttestation(config, state, attestation)).to.not.throw;

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attesterSlashing.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attesterSlashing.test.ts
@@ -53,8 +53,8 @@ describe("process block - attester slashings", function () {
   it("should fail to process slashings - data2 incorrect", function () {
     const state = generateState();
     const attesterSlashing = generateEmptyAttesterSlashing();
-    attesterSlashing.attestation1.data.source.epoch = 2;
-    attesterSlashing.attestation2.data.source.epoch = 3;
+    attesterSlashing.attestation1.data.source.epoch = 2n;
+    attesterSlashing.attestation2.data.source.epoch = 3n;
     isSlashableAttestationStub.returns(true);
     validateIndexedAttestationStub.withArgs(state, attesterSlashing.attestation1).returns(true);
     validateIndexedAttestationStub.withArgs(state, attesterSlashing.attestation2).returns(false);
@@ -70,8 +70,8 @@ describe("process block - attester slashings", function () {
   it("should fail to process slashings - nothing slashed", function () {
     const state = generateState();
     const attesterSlashing = generateEmptyAttesterSlashing();
-    attesterSlashing.attestation1.data.source.epoch = 2;
-    attesterSlashing.attestation2.data.source.epoch = 3;
+    attesterSlashing.attestation1.data.source.epoch = 2n;
+    attesterSlashing.attestation2.data.source.epoch = 3n;
     isSlashableAttestationStub.returns(true);
     validateIndexedAttestationStub.returns(true);
     try {

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/proposerSlashings.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/proposerSlashings.test.ts
@@ -26,8 +26,8 @@ describe("process block - proposer slashings", function () {
   it("should fail to process - different epoch", function () {
     const state = generateState({validators: [generateValidator()]});
     const proposerSlashing = generateEmptyProposerSlashing();
-    proposerSlashing.signedHeader1.message.slot = 1;
-    proposerSlashing.signedHeader2.message.slot = config.params.SLOTS_PER_EPOCH + 1;
+    proposerSlashing.signedHeader1.message.slot = 1n;
+    proposerSlashing.signedHeader2.message.slot = config.params.SLOTS_PER_EPOCH + 1n;
     try {
       processProposerSlashing(config, state, proposerSlashing);
       expect.fail();
@@ -38,7 +38,7 @@ describe("process block - proposer slashings", function () {
   it("should fail to process - same headers", function () {
     const state = generateState({validators: [generateValidator()]});
     const proposerSlashing = generateEmptyProposerSlashing();
-    proposerSlashing.signedHeader1.message.slot = 1;
+    proposerSlashing.signedHeader1.message.slot = 1n;
     proposerSlashing.signedHeader2.message.slot = proposerSlashing.signedHeader1.message.slot;
     try {
       processProposerSlashing(config, state, proposerSlashing);
@@ -50,8 +50,8 @@ describe("process block - proposer slashings", function () {
   it("should fail to process - same headers", function () {
     const state = generateState({validators: [generateValidator()]});
     const proposerSlashing = generateEmptyProposerSlashing();
-    proposerSlashing.signedHeader1.message.slot = 1;
-    proposerSlashing.signedHeader2.message.slot = 2;
+    proposerSlashing.signedHeader1.message.slot = 1n;
+    proposerSlashing.signedHeader2.message.slot = 2n;
     isSlashableValidatorStub.returns(false);
     try {
       processProposerSlashing(config, state, proposerSlashing);
@@ -65,8 +65,8 @@ describe("process block - proposer slashings", function () {
   it("should fail to process - invalid signature 1", function () {
     const state = generateState({validators: [generateValidator()]});
     const proposerSlashing = generateEmptyProposerSlashing();
-    proposerSlashing.signedHeader1.message.slot = 1;
-    proposerSlashing.signedHeader2.message.slot = 1;
+    proposerSlashing.signedHeader1.message.slot = 1n;
+    proposerSlashing.signedHeader2.message.slot = 1n;
     isSlashableValidatorStub.returns(true);
     try {
       processProposerSlashing(config, state, proposerSlashing, true);
@@ -80,9 +80,9 @@ describe("process block - proposer slashings", function () {
     const validator = generateValidator();
     const state = generateState({validators: [validator]});
     const proposerSlashing = generateEmptyProposerSlashing();
-    proposerSlashing.signedHeader1.message.slot = 1;
+    proposerSlashing.signedHeader1.message.slot = 1n;
     proposerSlashing.signedHeader1.signature = Buffer.alloc(96, 1);
-    proposerSlashing.signedHeader2.message.slot = 1;
+    proposerSlashing.signedHeader2.message.slot = 1n;
     proposerSlashing.signedHeader2.signature = Buffer.alloc(96, 2);
     isSlashableValidatorStub.returns(true);
     try {
@@ -97,8 +97,8 @@ describe("process block - proposer slashings", function () {
     const validator = generateValidator();
     const state = generateState({validators: [validator]});
     const proposerSlashing = generateEmptyProposerSlashing();
-    proposerSlashing.signedHeader1.message.slot = 1;
-    proposerSlashing.signedHeader2.message.slot = 1;
+    proposerSlashing.signedHeader1.message.slot = 1n;
+    proposerSlashing.signedHeader2.message.slot = 1n;
     isSlashableValidatorStub.returns(true);
     try {
       processProposerSlashing(config, state, proposerSlashing, false);

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/voluntaryExit.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/voluntaryExit.test.ts
@@ -43,7 +43,7 @@ describe("process block - voluntary exits", function () {
   it("should fail - already exited", function () {
     const state = generateState();
     const exit = generateEmptySignedVoluntaryExit();
-    state.validators.push(generateValidator({activation: 0, exit: 1}));
+    state.validators.push(generateValidator({activation: 0n, exit: 1n}));
     isActiveValidatorStub.returns(true);
     try {
       processVoluntaryExit(config, state, exit);
@@ -54,10 +54,10 @@ describe("process block - voluntary exits", function () {
   });
 
   it("should fail - not valid", function () {
-    const state = generateState({slot: 0});
+    const state = generateState({slot: 0n});
     const exit = generateEmptySignedVoluntaryExit();
-    exit.message.epoch = config.params.SLOTS_PER_EPOCH * 2;
-    state.validators.push(generateValidator({activation: 0, exit: FAR_FUTURE_EPOCH}));
+    exit.message.epoch = config.params.SLOTS_PER_EPOCH * 2n;
+    state.validators.push(generateValidator({activation: 0n, exit: FAR_FUTURE_EPOCH}));
     isActiveValidatorStub.returns(true);
     try {
       processVoluntaryExit(config, state, exit);
@@ -68,10 +68,10 @@ describe("process block - voluntary exits", function () {
   });
 
   it("should fail - validator not enough active", function () {
-    const state = generateState({slot: config.params.SLOTS_PER_EPOCH * 2});
+    const state = generateState({slot: config.params.SLOTS_PER_EPOCH * 2n});
     const exit = generateEmptySignedVoluntaryExit();
-    exit.message.epoch = 0;
-    state.validators.push(generateValidator({activation: 0, exit: FAR_FUTURE_EPOCH}));
+    exit.message.epoch = 0n;
+    state.validators.push(generateValidator({activation: 0n, exit: FAR_FUTURE_EPOCH}));
     isActiveValidatorStub.returns(true);
     try {
       processVoluntaryExit(config, state, exit);
@@ -82,10 +82,10 @@ describe("process block - voluntary exits", function () {
   });
 
   it("should fail - invalid signature", function () {
-    const state = generateState({slot: (config.params.PERSISTENT_COMMITTEE_PERIOD + 1) * config.params.SLOTS_PER_EPOCH});
+    const state = generateState({slot: (config.params.PERSISTENT_COMMITTEE_PERIOD + 1n) * config.params.SLOTS_PER_EPOCH});
     const exit = generateEmptySignedVoluntaryExit();
-    exit.message.epoch = 0;
-    state.validators.push(generateValidator({activation: 0, exit: FAR_FUTURE_EPOCH}));
+    exit.message.epoch = 0n;
+    state.validators.push(generateValidator({activation: 0n, exit: FAR_FUTURE_EPOCH}));
     isActiveValidatorStub.returns(true);
     try {
       processVoluntaryExit(config, state, exit);
@@ -96,10 +96,10 @@ describe("process block - voluntary exits", function () {
   });
 
   it("should process exit", function () {
-    const validator = generateValidator({activation: 1, exit: FAR_FUTURE_EPOCH});
-    const state = generateState({slot: (config.params.PERSISTENT_COMMITTEE_PERIOD + 1) * config.params.SLOTS_PER_EPOCH});
+    const validator = generateValidator({activation: 1n, exit: FAR_FUTURE_EPOCH});
+    const state = generateState({slot: (config.params.PERSISTENT_COMMITTEE_PERIOD + 1n) * config.params.SLOTS_PER_EPOCH});
     const exit = generateEmptySignedVoluntaryExit();
-    exit.message.epoch = 0;
+    exit.message.epoch = 0n;
     state.validators.push(validator);
     isActiveValidatorStub.returns(true);
     try {

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/randao.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/randao.test.ts
@@ -43,7 +43,9 @@ describe("process block - randao", function () {
     try {
       processRandao(config, state, block.body, false);
       expect(getBeaconProposerStub.calledOnce).to.be.true;
-      expect(state.randaoMixes[getCurrentEpoch(config, state) % config.params.EPOCHS_PER_HISTORICAL_VECTOR]).to.not.be.null;
+      expect(state.randaoMixes[
+        Number(getCurrentEpoch(config, state) % config.params.EPOCHS_PER_HISTORICAL_VECTOR)
+      ]).to.not.be.null;
     } catch (e) {
       expect.fail(e.stack);
     }

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/finalUpdates.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/finalUpdates.test.ts
@@ -26,7 +26,7 @@ describe('process epoch - final updates', function () {
 
   it('should make required final updates', function () {
     const state = generateState();
-    state.slot = config.params.EPOCHS_PER_ETH1_VOTING_PERIOD - 1;
+    state.slot = config.params.EPOCHS_PER_ETH1_VOTING_PERIOD - 1n;
     state.validators.push(generateValidator());
     state.balances.push(0xffffffffffn);
 

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/fork.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/fork.test.ts
@@ -12,7 +12,7 @@ describe("processForkChanged", () => {
     state = generateState();
     state.fork = {
       currentVersion: Buffer.from([1, 0, 0, 0]),
-      epoch: 100,
+      epoch: 100n,
       previousVersion: Buffer.alloc(4),
     };
   });
@@ -33,7 +33,7 @@ describe("processForkChanged", () => {
       {
         previousVersion: bytesToInt(Buffer.from([1, 0, 0, 0])),
         currentVersion: bytesToInt(Buffer.from([2, 0, 0, 0])),
-        epoch: 200,
+        epoch: 200n,
       },
     ];
     const preFork = state.fork;
@@ -46,11 +46,11 @@ describe("processForkChanged", () => {
       {
         previousVersion: bytesToInt(Buffer.from([1, 0, 0, 0])),
         currentVersion: bytesToInt(Buffer.from([2, 0, 0, 0])),
-        epoch: 200,
+        epoch: 200n,
       },
     ];
     const preFork = state.fork;
-    state.slot = 200 * config.params.SLOTS_PER_EPOCH - 1;
+    state.slot = 200n * config.params.SLOTS_PER_EPOCH - 1n;
     processForkChanged(config, state);
     expect(config.types.Fork.equals(preFork, state.fork)).to.be.false;
     expect(config.types.Version.equals(preFork.currentVersion, state.fork.previousVersion));

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/justification.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/justification.test.ts
@@ -2,6 +2,7 @@ import sinon from "sinon";
 import {expect} from "chai";
 
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import {Epoch} from "@chainsafe/lodestar-types";
 import * as utils1 from "../../../../src/util";
 import * as utils2 from "../../../../src/epoch/util";
 import {generateState} from "../../../utils/state";
@@ -35,8 +36,8 @@ describe('process epoch - justification and finalization', function () {
 
   it('should make required justification and finalization', function () {
     const state = generateState();
-    let previousJustifiedEpoch;
-    let currentJustifiedEpoch;
+    let previousJustifiedEpoch: Epoch;
+    let currentJustifiedEpoch: Epoch;
     getTotalActiveBalanceStub.returns(10n);
     getAttestingBalanceStub.returns(10n);
     state.justificationBits = Array.from({length: 64}, () => false);
@@ -46,7 +47,7 @@ describe('process epoch - justification and finalization', function () {
     expect(getCurrentEpochStub.calledOnceWith(config, state)).to.be.true;
 
     // hit 1st if condition of finalization
-    state.previousJustifiedCheckpoint.epoch = previousJustifiedEpoch = 0;
+    state.previousJustifiedCheckpoint.epoch = previousJustifiedEpoch = 0n;
     getBlockRootStub.returns(Buffer.alloc(32));
     getCurrentEpochStub.returns(3);
     getPreviousEpochStub.returns(1);
@@ -55,20 +56,20 @@ describe('process epoch - justification and finalization', function () {
 
     // hit 2nd if condition of finalization
     getCurrentEpochStub.returns(2);
-    state.previousJustifiedCheckpoint.epoch = previousJustifiedEpoch = 0;
+    state.previousJustifiedCheckpoint.epoch = previousJustifiedEpoch = 0n;
     processJustificationAndFinalization(config, state);
     expect(state.finalizedCheckpoint.epoch).to.be.equal(previousJustifiedEpoch);
 
     // hit 3rd if condition of finalization
-    state.currentJustifiedCheckpoint.epoch = currentJustifiedEpoch = 0;
+    state.currentJustifiedCheckpoint.epoch = currentJustifiedEpoch = 0n;
     getCurrentEpochStub.returns(2);
     processJustificationAndFinalization(config, state);
     expect(state.finalizedCheckpoint.epoch).to.be.equal(currentJustifiedEpoch);
 
     // hit 4th if condition of finalization
     getCurrentEpochStub.returns(2);
-    state.previousJustifiedCheckpoint.epoch = 1;
-    state.currentJustifiedCheckpoint.epoch = currentJustifiedEpoch = 1;
+    state.previousJustifiedCheckpoint.epoch = 1n;
+    state.currentJustifiedCheckpoint.epoch = currentJustifiedEpoch = 1n;
     processJustificationAndFinalization(config, state);
     expect(state.finalizedCheckpoint.epoch).to.be.equal(currentJustifiedEpoch);
 

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/registryUpdates.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/registryUpdates.test.ts
@@ -33,7 +33,7 @@ describe('process epoch - slashings', function () {
     const validatorEligble = generateValidator();
     validatorEligble.effectiveBalance = BigInt(config.params.MAX_EFFECTIVE_BALANCE);
 
-    const validatorToExit = generateValidator({activation: 1});
+    const validatorToExit = generateValidator({activation: 1n});
     validatorToExit.effectiveBalance = 1n;
     isActiveValidatorStub.withArgs(sinon.match.any, sinon.match.any).returns(true);
     const state = generateState({validators: [validatorEligble, validatorToExit]});

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/slashing.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/slashing.test.ts
@@ -6,7 +6,6 @@ import {FAR_FUTURE_EPOCH} from "../../../../src/constants";
 import {processSlashings} from "../../../../src/epoch/slashings";
 import {generateState} from "../../../utils/state";
 import {generateValidator} from "../../../utils/validator";
-import {intDiv} from "@chainsafe/lodestar-utils";
 
 describe('process epoch - slashings', function () {
 
@@ -31,11 +30,11 @@ describe('process epoch - slashings', function () {
   it('should decrease validator balances with penalty', function () {
     getCurrentEpochStub.returns(1);
     getTotalBalanceStub.returns(2n);
-    const validator1 = generateValidator({activation: 0, exit: FAR_FUTURE_EPOCH, slashed: false});
-    const validator2 = generateValidator({activation: 0, exit: FAR_FUTURE_EPOCH, slashed: true});
+    const validator1 = generateValidator({activation: 0n, exit: FAR_FUTURE_EPOCH, slashed: false});
+    const validator2 = generateValidator({activation: 0n, exit: FAR_FUTURE_EPOCH, slashed: true});
     validator2.withdrawableEpoch = config.params.EPOCHS_PER_SLASHINGS_VECTOR;
-    const validator3 = generateValidator({activation: 0, exit: FAR_FUTURE_EPOCH, slashed: true});
-    validator3.withdrawableEpoch = intDiv(config.params.EPOCHS_PER_SLASHINGS_VECTOR, 2) + 1;
+    const validator3 = generateValidator({activation: 0n, exit: FAR_FUTURE_EPOCH, slashed: true});
+    validator3.withdrawableEpoch = config.params.EPOCHS_PER_SLASHINGS_VECTOR / 2n + 1n;
     const state = generateState({
       validators: [
         validator1,

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/util/epoch.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/util/epoch.test.ts
@@ -16,14 +16,14 @@ import {generateState} from "../../../utils/state";
 
 describe("computeEpochAtSlot", () => {
   const pairs = [
-    {test: 0, expected: 0},
-    {test: 1, expected: 0},
-    {test: 10, expected: 0},
-    {test: 100, expected: 3},
-    {test: 1000, expected: 31},
-    {test: 10000, expected: 312},
-    {test: 100000, expected: 3125},
-    {test: 1000000, expected: 31250},
+    {test: 0n, expected: 0n},
+    {test: 1n, expected: 0n},
+    {test: 10n, expected: 0n},
+    {test: 100n, expected: 3n},
+    {test: 1000n, expected: 31n},
+    {test: 10000n, expected: 312n},
+    {test: 100000n, expected: 3125n},
+    {test: 1000000n, expected: 31250n},
   ];
   for (const pair of pairs) {
     it(`Slot ${pair.test} should map to epoch ${pair.expected}`, () => {
@@ -35,14 +35,14 @@ describe("computeEpochAtSlot", () => {
 
 describe("computeStartSlotAtEpoch", () => {
   const pairs = [
-    {test: 0, expected: 0},
-    {test: 1, expected: 32},
-    {test: 10, expected: 320},
-    {test: 100, expected: 3200},
-    {test: 1000, expected: 32000},
-    {test: 10000, expected: 320000},
-    {test: 100000, expected: 3200000},
-    {test: 1000000, expected: 32000000},
+    {test: 0n, expected: 0n},
+    {test: 1n, expected: 32n},
+    {test: 10n, expected: 320n},
+    {test: 100n, expected: 3200n},
+    {test: 1000n, expected: 32000n},
+    {test: 10000n, expected: 320000n},
+    {test: 100000n, expected: 3200000n},
+    {test: 1000000n, expected: 32000000n},
   ];
   for (const pair of pairs) {
     it(`Epoch ${pair.test} should map to slot ${pair.expected}`, () => {
@@ -55,15 +55,15 @@ describe("computeStartSlotAtEpoch", () => {
 describe("getPreviousEpoch", () => {
 
   it("epoch should return previous epoch", () => {
-    const state: BeaconState = generateState({slot: 512});
-    const expected: Epoch = 15;
+    const state: BeaconState = generateState({slot: 512n});
+    const expected: Epoch = 15n;
     const result = getPreviousEpoch(config, state);
     assert.equal(result, expected);
   });
 
   it("epoch should return previous epoch", () => {
-    const state: BeaconState = generateState({slot: 256});
-    const expected: Epoch = 7;
+    const state: BeaconState = generateState({slot: 256n});
+    const expected: Epoch = 7n;
     const result = getPreviousEpoch(config, state);
     assert.equal(result, expected);
   });
@@ -78,8 +78,8 @@ describe("getPreviousEpoch", () => {
 
 describe("computeActivationExitEpoch", () => {
   it("epoch is always equal to the epoch after the exit delay", () => {
-    for (let e: Epoch = 0; e < 1000; e++) {
-      assert.equal(computeActivationExitEpoch(config, e), e + 1 + config.params.MAX_SEED_LOOKAHEAD);
+    for (let e: Epoch = 0n; e < 1000n; e++) {
+      assert.equal(computeActivationExitEpoch(config, e), e + 1n + config.params.MAX_SEED_LOOKAHEAD);
     }
   });
 });

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/util/misc.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/util/misc.test.ts
@@ -21,24 +21,24 @@ import { generateState } from "../../../utils/state";
 describe("getDomain", () => {
   const state = generateState();
   const fork: Fork = {
-    epoch: 12,
+    epoch: 12n,
     previousVersion: Buffer.from([4, 0, 0, 0]),
     currentVersion: Buffer.from([5, 0, 0, 0]),
   };
   state.fork = fork;
 
   it("epoch before fork epoch should result in domain === previous fork version * 2**32 + domain type", () => {
-    const result = getDomain(config, state, 4, 8);
+    const result = getDomain(config, state, 4, 8n);
     assert.equal(Buffer.from(result).toString('hex'), '04000000d6e497b816c27a31acd5d9f3ed670639fef7842fee51f044dfbfb631');
   });
 
   it("epoch before fork epoch should result in domain === previous fork version * 2**32 + domain type", () => {
-    const result = getDomain(config, state, 5, 13);
+    const result = getDomain(config, state, 5, 13n);
     assert.equal(Buffer.from(result).toString('hex'), '05000000c8b9e6acb00f5b32f776f5466510630a94829c965d35074e9d162016');
   });
 
   it("epoch before fork epoch should result in domain === previous fork version * 2**32 + domain type", () => {
-    const result = getDomain(config, state, 5, 12);
+    const result = getDomain(config, state, 5, 12n);
     assert.equal(Buffer.from(result).toString('hex'), '05000000c8b9e6acb00f5b32f776f5466510630a94829c965d35074e9d162016');
   });
 });
@@ -46,8 +46,8 @@ describe("getDomain", () => {
 describe("getBlockRoot", () => {
   it("should return first block root for genesis slot", () => {
     const state = generateState({
-      slot:  GENESIS_SLOT + 1,
-      blockRoots: Array.from({ length: config.params.SLOTS_PER_HISTORICAL_ROOT }, () => Buffer.from([0xAB])),
+      slot:  GENESIS_SLOT + 1n,
+      blockRoots: Array.from({ length: Number(config.params.SLOTS_PER_HISTORICAL_ROOT) }, () => Buffer.from([0xAB])),
     });
     const res = Buffer.from(getBlockRoot(config, state, GENESIS_SLOT) as Uint8Array);
     assert(toBigIntLE(res) === 0xABn,
@@ -58,7 +58,7 @@ describe("getBlockRoot", () => {
     assert.throws(() => getBlockRoot(config, state, GENESIS_SLOT), "");
   });
   it("should fail if slot is not within SLOTS_PER_HISTORICAL_ROOT of current slot", () => {
-    const state = generateState({ slot: GENESIS_SLOT + config.params.SLOTS_PER_HISTORICAL_ROOT + 1 });
+    const state = generateState({ slot: GENESIS_SLOT + config.params.SLOTS_PER_HISTORICAL_ROOT + 1n });
     assert.throws(() => getBlockRoot(config, state, GENESIS_SLOT), "");
   });
 });

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/util/seed.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/util/seed.test.ts
@@ -26,10 +26,10 @@ describe("getRandaoMix", () => {
   it("should return second randao mix for GENESIS_EPOCH + 1", () => {
     // Empty state in 2nd epoch
     const state = generateState({
-      slot: GENESIS_SLOT + config.params.SLOTS_PER_EPOCH * 2,
+      slot: GENESIS_SLOT + config.params.SLOTS_PER_EPOCH * 2n,
       randaoMixes: [Buffer.from([0xAB]), Buffer.from([0xCD]), Buffer.from([0xEF])]
     });
-    const res = getRandaoMix(config, state, GENESIS_EPOCH + 1);
+    const res = getRandaoMix(config, state, GENESIS_EPOCH + 1n);
     assert(Buffer.from(res as Uint8Array).equals(Uint8Array.from([0xCD])));
   });
 });

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/util/slashing.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/util/slashing.test.ts
@@ -9,18 +9,18 @@ import {generateAttestationData} from "../../../utils/attestation";
 
 describe("isSlashableAttestationData", () => {
   it("Attestation data with the same target epoch should return true", () => {
-    const epoch1: Epoch = randBetween(1, 1000);
-    const epoch2: Epoch = epoch1 + 1;
+    const epoch1: Epoch = BigInt(randBetween(1, 1000));
+    const epoch2: Epoch = epoch1 + 1n;
     const a1 = generateAttestationData(epoch1, epoch2);
-    const a2 = generateAttestationData(epoch1-1, epoch2);
+    const a2 = generateAttestationData(epoch1-1n, epoch2);
     assert.isTrue(isSlashableAttestationData(config, a1, a2));
   });
 
   it("Attestation data with disjoint source/target epochs should return false", () => {
-    const epoch1: Epoch = randBetween(1, 1000);
-    const epoch2 = epoch1 + 1;
-    const epoch3 = epoch2 + 1;
-    const epoch4 = epoch3 + 1;
+    const epoch1: Epoch = BigInt(randBetween(1, 1000));
+    const epoch2 = epoch1 + 1n;
+    const epoch3 = epoch2 + 1n;
+    const epoch4 = epoch3 + 1n;
     const a1 = generateAttestationData(epoch1, epoch2);
     const a2 = generateAttestationData(epoch3, epoch4);
     assert.isFalse(isSlashableAttestationData(config, a1, a2));
@@ -28,11 +28,11 @@ describe("isSlashableAttestationData", () => {
 
   it("Should return false if the second attestation does not have a greater source epoch", () => {
     // Both attestations have the same source epoch.
-    const sourceEpoch1: Epoch = randBetween(1, 1000);
+    const sourceEpoch1: Epoch = BigInt(randBetween(1, 1000));
     let sourceEpoch2: Epoch = sourceEpoch1;
 
-    const targetEpoch1: Epoch = randBetween(1, 1000);
-    const targetEpoch2: Epoch = targetEpoch1 - 1;
+    const targetEpoch1: Epoch = BigInt(randBetween(1, 1000));
+    const targetEpoch2: Epoch = targetEpoch1 - 1n;
 
     const a1 = generateAttestationData(sourceEpoch1, targetEpoch1);
     let a2 = generateAttestationData(sourceEpoch2, targetEpoch2);
@@ -40,22 +40,22 @@ describe("isSlashableAttestationData", () => {
     assert.isFalse(isSlashableAttestationData(config, a1, a2));
 
     // Second attestation has a smaller source epoch.
-    sourceEpoch2 = sourceEpoch1 - 1;
+    sourceEpoch2 = sourceEpoch1 - 1n;
     a2 = generateAttestationData(sourceEpoch2, targetEpoch2);
     assert.isFalse(isSlashableAttestationData(config, a1, a2));
   });
 
   it("Should return false if the second attestation does not have a smaller target epoch", () => {
     // Both attestations have the same target epoch.
-    const sourceEpoch1: Epoch = randBetween(1, 1000);
-    const sourceEpoch2: Epoch = sourceEpoch1 + 1;
+    const sourceEpoch1: Epoch = BigInt(randBetween(1, 1000));
+    const sourceEpoch2: Epoch = sourceEpoch1 + 1n;
 
-    const targetEpoch: Epoch = randBetween(2, 1000);
+    const targetEpoch: Epoch = BigInt(randBetween(2, 1000));
 
     // Last slot in the epoch.
-    let targetSlot1: Slot = targetEpoch * config.params.SLOTS_PER_EPOCH - 1;
+    let targetSlot1: Slot = targetEpoch * config.params.SLOTS_PER_EPOCH - 1n;
     // First slot in the epoch
-    let targetSlot2: Slot = (targetEpoch - 1) * config.params.SLOTS_PER_EPOCH;
+    let targetSlot2: Slot = (targetEpoch - 1n) * config.params.SLOTS_PER_EPOCH;
 
     let a1 = generateAttestationData(targetSlot1, sourceEpoch1);
     let a2 = generateAttestationData(targetSlot2, sourceEpoch2);
@@ -64,7 +64,7 @@ describe("isSlashableAttestationData", () => {
 
     // Second attestation has a greater target epoch.
     targetSlot1 = targetEpoch * config.params.SLOTS_PER_EPOCH;
-    targetSlot2 = (targetEpoch + 1) * config.params.SLOTS_PER_EPOCH;
+    targetSlot2 = (targetEpoch + 1n) * config.params.SLOTS_PER_EPOCH;
     a1 = generateAttestationData(targetSlot1, sourceEpoch1);
     a2 = generateAttestationData(targetSlot2, sourceEpoch2);
     assert.isFalse(isSlashableAttestationData(config, a1, a2));

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/util/slot.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/util/slot.test.ts
@@ -6,10 +6,10 @@ import {Slot} from "@chainsafe/lodestar-types";
 
 describe("computeSlotsSinceEpochStart", () => {
   const pairs = [
-    {test: 0, expected: 0},
-    {test: 5, expected: 5},
-    {test: 40, expected: 8},
-    {test: 50, expected: 18},
+    {test: 0n, expected: 0n},
+    {test: 5n, expected: 5n},
+    {test: 40n, expected: 8n},
+    {test: 50n, expected: 18n},
   ];
 
   for (const pair of pairs) {
@@ -20,8 +20,8 @@ describe("computeSlotsSinceEpochStart", () => {
   }
 
   it("should compute slot correctly since a specified epoch", () => {
-    const epoch = 1;
-    const slot = 70;
+    const epoch = 1n;
+    const slot = 70n;
     const result = computeSlotsSinceEpochStart(config, slot, epoch);
     // 70 - NUM_SLOT_PER_EPOCH
     assert.equal(result, 38);

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/util/validator.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/util/validator.test.ts
@@ -11,16 +11,17 @@ import {
 import {randBetween} from "../../../utils/misc";
 import {generateValidator} from "../../../utils/validator";
 import {generateState} from "../../../utils/state";
+import {FAR_FUTURE_EPOCH} from "../../../src/constants";
 
 
 describe("getActiveValidatorIndices", () => {
   it("empty list of validators should return no indices (empty list)", () => {
-    assert.deepEqual(getActiveValidatorIndices(generateState(), randBetween(0, 4)), []);
+    assert.deepEqual(getActiveValidatorIndices(generateState(), BigInt(randBetween(0, 4))), []);
   });
   it("list of cloned validators should return all or none", () => {
     const state = generateState();
-    const activationEpoch = 1;
-    const exitEpoch = 10;
+    const activationEpoch = 1n;
+    const exitEpoch = 10n;
     state.validators = Array.from({length: 10},
       () => generateValidator({activation: activationEpoch, exit: exitEpoch }));
     const allActiveIndices = Array.from(state.validators).map((_, i) => i);
@@ -32,38 +33,38 @@ describe("getActiveValidatorIndices", () => {
 
 describe("isActiveValidator", () => {
   it("should be active", () => {
-    const v: Validator = generateValidator({activation: 0, exit: 100});
-    const result: boolean = isActiveValidator(v, 0);
+    const v: Validator = generateValidator({activation: 0n, exit: 100n});
+    const result: boolean = isActiveValidator(v, 0n);
     assert.isTrue(result);
   });
 
   it("should be active", () => {
-    const v: Validator = generateValidator({activation: 10, exit: 101});
-    const result: boolean = isActiveValidator(v, 100);
+    const v: Validator = generateValidator({activation: 10n, exit: 101n});
+    const result: boolean = isActiveValidator(v, 100n);
     assert.isTrue(result);
   });
 
   it("should be active", () => {
-    const v: Validator = generateValidator({activation: 100, exit: 1000 });
-    const result: boolean = isActiveValidator(v, 100);
+    const v: Validator = generateValidator({activation: 100n, exit: 1000n });
+    const result: boolean = isActiveValidator(v, 100n);
     assert.isTrue(result);
   });
 
   it("should not be active", () => {
-    const v: Validator = generateValidator({activation: 1});
-    const result: boolean = isActiveValidator(v, 0);
+    const v: Validator = generateValidator({activation: 1n});
+    const result: boolean = isActiveValidator(v, 0n);
     assert.isFalse(result);
   });
 
   it("should not be active", () => {
-    const v: Validator = generateValidator({activation: 100 });
-    const result: boolean = isActiveValidator(v, 5);
+    const v: Validator = generateValidator({activation: 100n });
+    const result: boolean = isActiveValidator(v, 5n);
     assert.isFalse(result);
   });
 
   it("should not be active", () => {
-    const v: Validator = generateValidator({activation: 1, exit: 5 });
-    const result: boolean = isActiveValidator(v, 100);
+    const v: Validator = generateValidator({activation: 1n, exit: 5n });
+    const result: boolean = isActiveValidator(v, 100n);
     assert.isFalse(result);
   });
 });
@@ -71,29 +72,29 @@ describe("isActiveValidator", () => {
 describe("isSlashableValidator", () => {
   it("should check validator.slashed", () => {
     const validator = generateValidator();
-    validator.activationEpoch = 0;
-    validator.withdrawableEpoch = Infinity;
+    validator.activationEpoch = 0n;
+    validator.withdrawableEpoch = FAR_FUTURE_EPOCH;
     validator.slashed = false;
-    assert(isSlashableValidator(validator, 0),
+    assert(isSlashableValidator(validator, 0n),
       "unslashed validator should be slashable");
     validator.slashed = true;
-    assert(!isSlashableValidator(validator, 0),
+    assert(!isSlashableValidator(validator, 0n),
       "slashed validator should not be slashable");
   });
   it("should check validator.activationEpoch", () => {
     const validator = generateValidator();
-    validator.activationEpoch = 10;
-    validator.withdrawableEpoch = Infinity;
-    assert(!isSlashableValidator(validator, validator.activationEpoch - 1),
+    validator.activationEpoch = 10n;
+    validator.withdrawableEpoch = FAR_FUTURE_EPOCH;
+    assert(!isSlashableValidator(validator, validator.activationEpoch - 1n),
       "unactivated validator should not be slashable");
     assert(isSlashableValidator(validator, validator.activationEpoch),
       "activated validator should be slashable");
   });
   it("should check validator.withdrawableEpoch", () => {
     const validator = generateValidator();
-    validator.activationEpoch = 0;
-    validator.withdrawableEpoch = 10;
-    assert(isSlashableValidator(validator, validator.withdrawableEpoch - 1),
+    validator.activationEpoch = 0n;
+    validator.withdrawableEpoch = 10n;
+    assert(isSlashableValidator(validator, validator.withdrawableEpoch - 1n),
       "nonwithdrawable validator should be slashable");
     assert(!isSlashableValidator(validator, validator.withdrawableEpoch),
       "withdrawable validator should not be slashable");

--- a/packages/lodestar-beacon-state-transition/test/utils/attestation.ts
+++ b/packages/lodestar-beacon-state-transition/test/utils/attestation.ts
@@ -13,7 +13,7 @@ import {
 
 export function generateAttestationData(sourceEpoch: Epoch, targetEpoch: Epoch): AttestationData {
   return {
-    slot: 0,
+    slot: 0n,
     index: 0,
     beaconBlockRoot: Buffer.alloc(32),
     source: {
@@ -31,15 +31,15 @@ export function generateEmptyAttestation(): Attestation {
   return {
     aggregationBits: Array.from({length: 64}, () => false),
     data: {
-      slot: 1,
+      slot: 1n,
       index: 0,
       beaconBlockRoot: Buffer.alloc(32),
       source: {
-        epoch: 0,
+        epoch: 0n,
         root: Buffer.alloc(32),
       },
       target: {
-        epoch: 0,
+        epoch: 0n,
         root: Buffer.alloc(32),
       },
     },

--- a/packages/lodestar-beacon-state-transition/test/utils/validator.ts
+++ b/packages/lodestar-beacon-state-transition/test/utils/validator.ts
@@ -1,9 +1,9 @@
-import {Validator} from "@chainsafe/lodestar-types";
+import {Validator, Slot} from "@chainsafe/lodestar-types";
 import {FAR_FUTURE_EPOCH} from "../../src/constants";
 
 export interface ValidatorGeneratorOpts {
-  activation?: number;
-  exit?: number;
+  activation?: Slot;
+  exit?: Slot;
   slashed?: boolean;
   balance?: bigint;
 }
@@ -17,14 +17,14 @@ export interface ValidatorGeneratorOpts {
  */
 export function generateValidator(opts: ValidatorGeneratorOpts = {}): Validator {
   const randNum = () =>  Math.floor(Math.random() * Math.floor(4));
-  const activationEpoch = (opts.activation || opts.activation === 0) ? opts.activation : FAR_FUTURE_EPOCH;
+  const activationEpoch = (opts.activation || opts.activation === 0n) ? opts.activation : FAR_FUTURE_EPOCH;
   return {
     pubkey: Buffer.alloc(48),
     withdrawalCredentials: Buffer.alloc(32),
     activationEpoch,
     activationEligibilityEpoch: activationEpoch,
-    exitEpoch: opts.exit || randNum(),
-    withdrawableEpoch: randNum(),
+    exitEpoch: opts.exit || BigInt(randNum()),
+    withdrawableEpoch: BigInt(randNum()),
     slashed: opts.slashed || false,
     effectiveBalance: opts.balance || 0n
   };

--- a/packages/lodestar-params/src/interface.ts
+++ b/packages/lodestar-params/src/interface.ts
@@ -38,21 +38,21 @@ export interface IBeaconParams {
   // Time parameters
   MIN_GENESIS_DELAY: number;
   SECONDS_PER_SLOT: number;
-  MIN_ATTESTATION_INCLUSION_DELAY: number;
-  SLOTS_PER_EPOCH: number;
-  MIN_SEED_LOOKAHEAD: number;
-  MAX_SEED_LOOKAHEAD: number;
-  EPOCHS_PER_ETH1_VOTING_PERIOD: number;
+  MIN_ATTESTATION_INCLUSION_DELAY: bigint;
+  SLOTS_PER_EPOCH: bigint;
+  MIN_SEED_LOOKAHEAD: bigint;
+  MAX_SEED_LOOKAHEAD: bigint;
+  EPOCHS_PER_ETH1_VOTING_PERIOD: bigint;
   ETH1_FOLLOW_DISTANCE: number;
-  SLOTS_PER_HISTORICAL_ROOT: number;
-  MIN_VALIDATOR_WITHDRAWABILITY_DELAY: number;
-  PERSISTENT_COMMITTEE_PERIOD: number;
+  SLOTS_PER_HISTORICAL_ROOT: bigint;
+  MIN_VALIDATOR_WITHDRAWABILITY_DELAY: bigint;
+  PERSISTENT_COMMITTEE_PERIOD: bigint;
 
-  MIN_EPOCHS_TO_INACTIVITY_PENALTY: number;
+  MIN_EPOCHS_TO_INACTIVITY_PENALTY: bigint;
 
   // State list lengths
-  EPOCHS_PER_HISTORICAL_VECTOR: number;
-  EPOCHS_PER_SLASHINGS_VECTOR: number;
+  EPOCHS_PER_HISTORICAL_VECTOR: bigint;
+  EPOCHS_PER_SLASHINGS_VECTOR: bigint;
   HISTORICAL_ROOTS_LIMIT: number;
   VALIDATOR_REGISTRY_LIMIT: number;
 
@@ -81,6 +81,6 @@ interface IFork {
   // 4 bytes
   currentVersion: number;
   // Fork epoch number
-  epoch: number;
+  epoch: bigint;
 }
 

--- a/packages/lodestar-types/src/ssz/generators/misc.ts
+++ b/packages/lodestar-types/src/ssz/generators/misc.ts
@@ -97,12 +97,12 @@ export const Eth1Data = (ssz: IBeaconSSZTypes): ContainerType => new ContainerTy
 
 export const HistoricalBlockRoots = (ssz: IBeaconSSZTypes, params: IBeaconParams): VectorType => new VectorType({
   elementType: new RootType({expandedType: () => ssz.BeaconBlock}),
-  length: params.SLOTS_PER_HISTORICAL_ROOT,
+  length: Number(params.SLOTS_PER_HISTORICAL_ROOT),
 });
 
 export const HistoricalStateRoots = (ssz: IBeaconSSZTypes, params: IBeaconParams): VectorType => new VectorType({
   elementType: new RootType({expandedType: () => ssz.BeaconState}),
-  length: params.SLOTS_PER_HISTORICAL_ROOT,
+  length:  Number(params.SLOTS_PER_HISTORICAL_ROOT),
 });
 
 export const HistoricalBatch = (ssz: IBeaconSSZTypes): ContainerType => new ContainerType({

--- a/packages/lodestar-types/src/ssz/generators/state.ts
+++ b/packages/lodestar-types/src/ssz/generators/state.ts
@@ -10,7 +10,7 @@ import {IBeaconSSZTypes} from "../interface";
 
 export const EpochAttestations = (ssz: IBeaconSSZTypes, params: IBeaconParams): ListType => new ListType({
   elementType: ssz.PendingAttestation,
-  limit: params.MAX_ATTESTATIONS * params.SLOTS_PER_EPOCH,
+  limit: params.MAX_ATTESTATIONS * Number(params.SLOTS_PER_EPOCH),
 });
 
 export const BeaconState = (ssz: IBeaconSSZTypes, params: IBeaconParams): ContainerType => new ContainerType({
@@ -34,7 +34,7 @@ export const BeaconState = (ssz: IBeaconSSZTypes, params: IBeaconParams): Contai
     eth1Data: ssz.Eth1Data,
     eth1DataVotes: new ListType({
       elementType: ssz.Eth1Data,
-      limit: params.EPOCHS_PER_ETH1_VOTING_PERIOD * params.SLOTS_PER_EPOCH,
+      limit: Number(params.EPOCHS_PER_ETH1_VOTING_PERIOD * params.SLOTS_PER_EPOCH),
     }),
     eth1DepositIndex: ssz.Number64,
     // Registry
@@ -48,12 +48,12 @@ export const BeaconState = (ssz: IBeaconSSZTypes, params: IBeaconParams): Contai
     }),
     randaoMixes: new VectorType({
       elementType: ssz.Bytes32,
-      length: params.EPOCHS_PER_HISTORICAL_VECTOR,
+      length: Number(params.EPOCHS_PER_HISTORICAL_VECTOR),
     }),
     // Slashings
     slashings: new VectorType({
       elementType: ssz.Gwei,
-      length: params.EPOCHS_PER_SLASHINGS_VECTOR,
+      length: Number(params.EPOCHS_PER_SLASHINGS_VECTOR),
     }),
     // Attestations
     previousEpochAttestations: ssz.EpochAttestations,

--- a/packages/lodestar-types/src/ssz/interface.ts
+++ b/packages/lodestar-types/src/ssz/interface.ts
@@ -20,8 +20,8 @@ export interface IBeaconSSZTypes {
   Uint64: BigIntUintType;
   Uint128: BigIntUintType;
   Uint256: BigIntUintType;
-  Slot: NumberUintType;
-  Epoch: NumberUintType;
+  Slot: BigIntUintType;
+  Epoch: BigIntUintType;
   CommitteeIndex: NumberUintType;
   ValidatorIndex: NumberUintType;
   Gwei: BigIntUintType;

--- a/packages/lodestar-types/src/types/primitive.ts
+++ b/packages/lodestar-types/src/types/primitive.ts
@@ -24,8 +24,8 @@ export type Uint256 = bigint;
 
 // Custom types, defined for type hinting and readability
 
-export type Slot = Number64;
-export type Epoch = Number64;
+export type Slot = Uint64;
+export type Epoch = Uint64;
 export type CommitteeIndex = Number64;
 export type ValidatorIndex = Number64;
 export type Gwei = Uint64;

--- a/packages/lodestar-utils/src/math.ts
+++ b/packages/lodestar-utils/src/math.ts
@@ -18,6 +18,13 @@ export function bigIntMax(a: bigint, b: bigint): bigint {
 }
 
 /**
+ * Return the min number between many big numbers.
+ */
+export function bigIntArrayMin(...bigints: bigint[]): bigint {
+  return bigints.reduce(bigIntMin, bigints[0]);
+}
+
+/**
  * Return the max number between many big numbers.
  */
 export function bigIntArrayMax(...bigints: bigint[]): bigint {

--- a/packages/lodestar-utils/src/math.ts
+++ b/packages/lodestar-utils/src/math.ts
@@ -17,6 +17,13 @@ export function bigIntMax(a: bigint, b: bigint): bigint {
   return a > b ? a : b;
 }
 
+/**
+ * Return the max number between many big numbers.
+ */
+export function bigIntArrayMax(...bigints: bigint[]): bigint {
+  return bigints.reduce(bigIntMax, bigints[0]);
+}
+
 export function intDiv(dividend: number, divisor: number): number {
   return Math.floor(dividend / divisor);
 }

--- a/packages/lodestar-utils/test/unit/math.test.ts
+++ b/packages/lodestar-utils/test/unit/math.test.ts
@@ -1,5 +1,5 @@
 import {assert} from "chai";
-import {bigIntMin, bigIntMax, bigIntArrayMax, intDiv, intSqrt, bigIntSqrt} from "../../src";
+import {bigIntMin, bigIntMax, bigIntArrayMin, bigIntArrayMax, intDiv, intSqrt, bigIntSqrt} from "../../src";
 
 
 describe("util/maths", function() {
@@ -31,6 +31,23 @@ describe("util/maths", function() {
       const b = 3n;
       const result = bigIntMax(a, b);
       assert.equal(result, b, "Should have returned b!");
+    });
+  });
+  
+  describe("bigIntArrayMin", () => {
+    it("if a is lt should return a", () => {
+      const a = 1n;
+      const b = 2n;
+      const c = 3n;
+      const result = bigIntArrayMin(a, b, c);
+      assert.equal(result, a, "Should have returned a!");
+    });
+    it("if c is lt should return c", () => {
+      const a = 3n;
+      const b = 2n;
+      const c = 1n;
+      const result = bigIntArrayMin(a, b, c);
+      assert.equal(result, c, "Should have returned c!");
     });
   });
 

--- a/packages/lodestar-utils/test/unit/math.test.ts
+++ b/packages/lodestar-utils/test/unit/math.test.ts
@@ -1,5 +1,5 @@
 import {assert} from "chai";
-import {bigIntMin, bigIntMax, intDiv, intSqrt, bigIntSqrt} from "../../src";
+import {bigIntMin, bigIntMax, bigIntArrayMax, intDiv, intSqrt, bigIntSqrt} from "../../src";
 
 
 describe("util/maths", function() {
@@ -31,6 +31,23 @@ describe("util/maths", function() {
       const b = 3n;
       const result = bigIntMax(a, b);
       assert.equal(result, b, "Should have returned b!");
+    });
+  });
+
+  describe("bigIntArrayMax", () => {
+    it("if a is gt should return a", () => {
+      const a = 3n;
+      const b = 2n;
+      const c = 1n;
+      const result = bigIntArrayMax(a, b, c);
+      assert.equal(result, a, "Should have returned a!");
+    });
+    it("if c is gt should return c", () => {
+      const a = 1n;
+      const b = 2n;
+      const c = 3n;
+      const result = bigIntArrayMax(a, b, c);
+      assert.equal(result, c, "Should have returned c!");
     });
   });
 

--- a/packages/lodestar-validator/src/api/abstract.ts
+++ b/packages/lodestar-validator/src/api/abstract.ts
@@ -14,8 +14,8 @@ export abstract class AbstractApiClient
 
   protected config: IBeaconConfig;
 
-  private currentSlot: Slot = 0;
-  private currentEpoch: Epoch = 0;
+  private currentSlot: Slot = 0n;
+  private currentEpoch: Epoch = 0n;
   private newSlotCallbacks: INewSlotCallback[] = [];
   private newEpochCallbacks: INewEpochCallback[] = [];
   private running = false;

--- a/packages/lodestar-validator/src/api/impl/rest/validator/validator.ts
+++ b/packages/lodestar-validator/src/api/impl/rest/validator/validator.ts
@@ -65,8 +65,8 @@ export class RestValidatorApi implements IValidatorApi {
 
   public async produceAttestation(
     validatorPubKey: BLSPubkey,
+    committeeIndex: CommitteeIndex,
     slot: Slot,
-    committeeIndex: CommitteeIndex
   ): Promise<Attestation> {
     const url = "/attestation"
         +`?slot=${slot}&committee_index=${committeeIndex}&validator_pubkey=${toHexString(validatorPubKey)}`;

--- a/packages/lodestar-validator/src/services/attestation.ts
+++ b/packages/lodestar-validator/src/services/attestation.ts
@@ -63,11 +63,11 @@ export class AttestationService {
   public start = async (): Promise<void> => {
     const slot = this.provider.getCurrentSlot();
     //trigger getting duties for current epoch
-    this.onNewEpoch(computeEpochAtSlot(this.config, slot) - 1);
+    this.onNewEpoch(computeEpochAtSlot(this.config, slot) - 1n);
   };
 
   public onNewEpoch = async (epoch: Epoch): Promise<void> => {
-    const attesterDuties = await this.provider.validator.getAttesterDuties(epoch + 1, [this.publicKey]);
+    const attesterDuties = await this.provider.validator.getAttesterDuties(epoch + 1n, [this.publicKey]);
     if (
       attesterDuties && attesterDuties.length === 1 &&
             this.config.types.BLSPubkey.equals(attesterDuties[0].validatorPubkey, this.publicKey)
@@ -235,7 +235,7 @@ export class AttestationService {
 
   private async isConflictingAttestation(other: AttestationData): Promise<boolean> {
     const potentialAttestationConflicts =
-            await this.db.getAttestations(this.publicKey, {gt: other.target.epoch - 1});
+            await this.db.getAttestations(this.publicKey, {gt: other.target.epoch - 1n});
     return potentialAttestationConflicts.some((attestation => {
       return isSlashableAttestationData(this.config, attestation.data, other);
     }));
@@ -248,7 +248,7 @@ export class AttestationService {
     const unusedAttestations =
             await this.db.getAttestations(
               this.publicKey,
-              {gt: 0, lt: attestation.data.target.epoch}
+              {gt: 0n, lt: attestation.data.target.epoch}
             );
     await this.db.deleteAttestations(this.publicKey, unusedAttestations);
   }

--- a/packages/lodestar/src/api/impl/beacon/beacon.ts
+++ b/packages/lodestar/src/api/impl/beacon/beacon.ts
@@ -68,7 +68,7 @@ export class BeaconApi implements IBeaconApi {
     const fork = state? state.fork : {
       previousVersion: Buffer.alloc(4),
       currentVersion: Buffer.alloc(4),
-      epoch: 0
+      epoch: 0n
     };
     return {
       fork,

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -115,7 +115,7 @@ export class ValidatorApi implements IValidatorApi {
 
   public async getProposerDuties(epoch: Epoch): Promise<ProposerDuty[]> {
     const state = await this.chain.getHeadState();
-    assert(epoch >= 0 && epoch <= computeEpochAtSlot(this.config, state.slot) + 2);
+    assert(epoch >= 0 && epoch <= computeEpochAtSlot(this.config, state.slot) + 2n);
     const startSlot = computeStartSlotAtEpoch(this.config, epoch);
     if(state.slot < startSlot) {
       processSlots(this.config, state, startSlot);
@@ -129,7 +129,7 @@ export class ValidatorApi implements IValidatorApi {
     return duties;
   }
 
-  public async getAttesterDuties(epoch: number, validatorPubKeys: BLSPubkey[]): Promise<AttesterDuty[]> {
+  public async getAttesterDuties(epoch: Epoch, validatorPubKeys: BLSPubkey[]): Promise<AttesterDuty[]> {
     const state = await this.chain.getHeadState();
 
     const validatorIndexes = await Promise.all(validatorPubKeys.map(async publicKey => {
@@ -155,7 +155,7 @@ export class ValidatorApi implements IValidatorApi {
     ]);
   }
 
-  public async getWireAttestations(epoch: number, committeeIndex: number): Promise<Attestation[]> {
+  public async getWireAttestations(epoch: Epoch, committeeIndex: number): Promise<Attestation[]> {
     return await this.db.attestation.getCommiteeAttestations(epoch, committeeIndex);
   }
 

--- a/packages/lodestar/src/api/rest/routes/validator/duties/attester.ts
+++ b/packages/lodestar/src/api/rest/routes/validator/duties/attester.ts
@@ -47,7 +47,7 @@ export const registerAttesterDutiesEndpoint: LodestarRestApiEndpoint = (fastify,
     opts,
     async (request, reply) => {
       const responseValue = await api.validator.getAttesterDuties(
-        request.params.epoch,
+        BigInt(request.params.epoch),
         request.query.validator_pubkeys.map((pubKeyHex) => fromHexString(pubKeyHex))
       );
       reply

--- a/packages/lodestar/src/api/rest/routes/validator/duties/proposer.ts
+++ b/packages/lodestar/src/api/rest/routes/validator/duties/proposer.ts
@@ -27,7 +27,7 @@ export const registerProposerDutiesEndpoint: LodestarRestApiEndpoint = (fastify,
     "/duties/:epoch/proposer",
     opts,
     async (request, reply) => {
-      const responseValue = await api.validator.getProposerDuties(request.params.epoch);
+      const responseValue = await api.validator.getProposerDuties(BigInt(request.params.epoch));
       const response = responseValue.map(duty => config.types.ProposerDuty.toJson(duty));
       reply
         .code(200)

--- a/packages/lodestar/src/api/rest/routes/validator/getWireAttestations.ts
+++ b/packages/lodestar/src/api/rest/routes/validator/getWireAttestations.ts
@@ -34,7 +34,7 @@ export const registerGetWireAttestationEndpoint: LodestarRestApiEndpoint = (fast
     opts,
     async (request, reply) => {
       const responseValue = await api.validator.getWireAttestations(
-        request.query.epoch,
+        BigInt(request.query.epoch),
         request.query.committee_index
       );
       reply

--- a/packages/lodestar/src/api/rest/routes/validator/produceAttestation.ts
+++ b/packages/lodestar/src/api/rest/routes/validator/produceAttestation.ts
@@ -42,7 +42,7 @@ export const registerAttestationProductionEndpoint: LodestarRestApiEndpoint = (f
       const responseValue = await api.validator.produceAttestation(
         fromHexString(request.query.validator_pubkey),
         request.query.attestation_committee_index,
-        request.query.slot
+        BigInt(request.query.slot)
       );
       reply
         .code(200)

--- a/packages/lodestar/src/api/rest/routes/validator/produceBlock.ts
+++ b/packages/lodestar/src/api/rest/routes/validator/produceBlock.ts
@@ -39,7 +39,7 @@ export const registerBlockProductionEndpoint: LodestarRestApiEndpoint = (fastify
     opts,
     async (request, reply) => {
       const block = await api.validator.produceBlock(
-        request.query.slot,
+        BigInt(request.query.slot),
         fromHex(request.query.proposer_pubkey),
         fromHex(request.query.randao_reveal)
       );

--- a/packages/lodestar/src/api/rest/routes/validator/subscribeToCommitteeSubnet.ts
+++ b/packages/lodestar/src/api/rest/routes/validator/subscribeToCommitteeSubnet.ts
@@ -37,7 +37,7 @@ export const registerSubscribeToCommitteeSubnet: LodestarRestApiEndpoint = (fast
     opts,
     async (request, reply) => {
       await api.validator.subscribeCommitteeSubnet(
-        Number(request.body.slot),
+        BigInt(request.body.slot),
         fromHexString(request.body.slot_signature),
         Number(request.body.attestation_committee_index),
         fromHexString(request.body.aggregator_pubkey)

--- a/packages/lodestar/src/chain/attestation.ts
+++ b/packages/lodestar/src/chain/attestation.ts
@@ -109,9 +109,9 @@ export class AttestationProcessor implements IAttestationProcessor {
       }
     } else {
       // should be genesis state
-      checkpointState = await this.db.stateArchive.get(0);
+      checkpointState = await this.db.stateArchive.get(0n);
     }
-    const previousEpoch = currentEpoch > GENESIS_EPOCH ? currentEpoch - 1 : GENESIS_EPOCH;
+    const previousEpoch = currentEpoch > GENESIS_EPOCH ? currentEpoch - 1n : GENESIS_EPOCH;
     const target = attestation.data.target;
     assert([previousEpoch, currentEpoch].includes(target.epoch),
       `attestation is targeting too old epoch ${target.epoch}, current=${currentEpoch}`

--- a/packages/lodestar/src/chain/blocks/pool.ts
+++ b/packages/lodestar/src/chain/blocks/pool.ts
@@ -32,7 +32,7 @@ export class BlockPool {
     } else {
       this.pool.set(key, [job]);
       //this prevents backward syncing
-      if(job.signedBlock.message.slot <= this.forkChoice.headBlockSlot() + 5) {
+      if(job.signedBlock.message.slot <= this.forkChoice.headBlockSlot() + 5n) {
         this.eventBus.emit("unknownBlockRoot", job.signedBlock.message.parentRoot);
       }
     }
@@ -44,7 +44,7 @@ export class BlockPool {
     if(jobs) {
       this.pool.delete(key);
       jobs
-        .sort((a, b) => a.signedBlock.message.slot - b.signedBlock.message.slot)
+        .sort((a, b) => Number(a.signedBlock.message.slot - b.signedBlock.message.slot))
         .forEach((job) => {
           this.blockProcessorSource.push(job);
         });

--- a/packages/lodestar/src/chain/blocks/post.ts
+++ b/packages/lodestar/src/chain/blocks/post.ts
@@ -26,7 +26,7 @@ export function postProcess(
         if(!finalized) {
           await attestationProcessor.receiveBlock(block);
         }
-        metrics.currentSlot.set(block.message.slot);
+        metrics.currentSlot.set(Number(block.message.slot));
         eventBus.emit("processedBlock", block);
         const preSlot = preState.slot;
         const preFinalizedEpoch = preState.finalizedCheckpoint.epoch;
@@ -62,8 +62,8 @@ function newJustifiedEpoch(
   state: BeaconState
 ): void {
   logger.important(`Epoch ${state.currentJustifiedCheckpoint.epoch} is justified!`);
-  metrics.previousJustifiedEpoch.set(state.previousJustifiedCheckpoint.epoch);
-  metrics.currentJustifiedEpoch.set(state.currentJustifiedCheckpoint.epoch);
+  metrics.previousJustifiedEpoch.set(Number(state.previousJustifiedCheckpoint.epoch));
+  metrics.currentJustifiedEpoch.set(Number(state.currentJustifiedCheckpoint.epoch));
   eventBus.emit("justifiedCheckpoint", state.currentJustifiedCheckpoint);
 }
 
@@ -74,6 +74,6 @@ function newFinalizedEpoch(
   state: BeaconState
 ): void {
   logger.important(`Epoch ${state.finalizedCheckpoint.epoch} is finalized!`);
-  metrics.currentFinalizedEpoch.set(state.finalizedCheckpoint.epoch);
+  metrics.currentFinalizedEpoch.set(Number(state.finalizedCheckpoint.epoch));
   eventBus.emit("finalizedCheckpoint", state.finalizedCheckpoint);
 }

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -21,7 +21,7 @@ import {computeEpochAtSlot, computeForkDigest, EpochContext} from "@chainsafe/lo
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {intToBytes} from "@chainsafe/lodestar-utils";
 
-import {EMPTY_SIGNATURE, GENESIS_SLOT} from "../constants";
+import {EMPTY_SIGNATURE, GENESIS_SLOT, FAR_FUTURE_EPOCH} from "../constants";
 import {IBeaconDb} from "../db";
 import {IEth1Notifier} from "../eth1";
 import {IBeaconMetrics} from "../metrics";
@@ -201,7 +201,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     return {
       forkDigest: this.currentForkDigest,
       nextForkVersion: nextVersion? intToBytes(nextVersion.currentVersion, 4) : MAX_VERSION,
-      nextForkEpoch: nextVersion? nextVersion.epoch : Number.MAX_SAFE_INTEGER,
+      nextForkEpoch: nextVersion? nextVersion.epoch : FAR_FUTURE_EPOCH,
     };
   }
 
@@ -318,10 +318,10 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
       });
     }
     // set metrics based on beacon state
-    this.metrics.currentSlot.set(state.slot);
-    this.metrics.previousJustifiedEpoch.set(state.previousJustifiedCheckpoint.epoch);
-    this.metrics.currentJustifiedEpoch.set(state.currentJustifiedCheckpoint.epoch);
-    this.metrics.currentFinalizedEpoch.set(state.finalizedCheckpoint.epoch);
+    this.metrics.currentSlot.set(Number(state.slot));
+    this.metrics.previousJustifiedEpoch.set(Number(state.previousJustifiedCheckpoint.epoch));
+    this.metrics.currentJustifiedEpoch.set(Number(state.currentJustifiedCheckpoint.epoch));
+    this.metrics.currentFinalizedEpoch.set(Number(state.finalizedCheckpoint.epoch));
     return state;
   }
 

--- a/packages/lodestar/src/chain/clock/local/LocalClock.ts
+++ b/packages/lodestar/src/chain/clock/local/LocalClock.ts
@@ -1,5 +1,6 @@
 import {IBeaconClock, NewEpochCallback, NewSlotCallback} from "../interface";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {Slot} from "@chainsafe/lodestar-types";
 import {computeEpochAtSlot, getCurrentSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {EventEmitter} from "events";
 
@@ -7,7 +8,7 @@ export class LocalClock extends EventEmitter implements IBeaconClock {
 
   private readonly config: IBeaconConfig;
   private readonly genesisTime: number;
-  private currentSlot: number;
+  private currentSlot: Slot;
   private isRunning: boolean;
   private timeoutId: NodeJS.Timeout;
 
@@ -32,7 +33,7 @@ export class LocalClock extends EventEmitter implements IBeaconClock {
     clearTimeout(this.timeoutId);
   }
 
-  public getCurrentSlot(): number {
+  public getCurrentSlot(): Slot {
     return this.currentSlot;
   }
 

--- a/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
@@ -472,14 +472,14 @@ export class StatefulDagLMDGHOST implements ILMDGHOST {
 
   public getJustified(): Checkpoint {
     if (!this.justified) {
-      return {epoch: 0, root: ZERO_HASH};
+      return {epoch: 0n, root: ZERO_HASH};
     }
     return this.head().justifiedCheckpoint;
   }
 
   public getFinalized(): Checkpoint {
     if (!this.finalized) {
-      return {epoch: 0, root: ZERO_HASH};
+      return {epoch: 0n, root: ZERO_HASH};
     }
     return this.head().finalizedCheckpoint;
   }

--- a/packages/lodestar/src/chain/genesis/genesis.ts
+++ b/packages/lodestar/src/chain/genesis/genesis.ts
@@ -98,7 +98,8 @@ export function getGenesisBeaconState(
   latestBlockHeader: BeaconBlockHeader
 ): BeaconState {
   // Seed RANDAO with Eth1 entropy
-  const randaoMixes = Array<Bytes32>(config.params.EPOCHS_PER_HISTORICAL_VECTOR).fill(genesisEth1Data.blockHash);
+  const randaoMixes = Array<Bytes32>(Number(config.params.EPOCHS_PER_HISTORICAL_VECTOR))
+    .fill(genesisEth1Data.blockHash);
 
   const state: BeaconState = config.types.BeaconState.tree.defaultValue();
   // MISC

--- a/packages/lodestar/src/constants/constants.ts
+++ b/packages/lodestar/src/constants/constants.ts
@@ -3,10 +3,10 @@
  */
 
 export const DEPOSIT_CONTRACT_TREE_DEPTH = 2 ** 5; // 32
-export const GENESIS_SLOT = 0;
-export const GENESIS_EPOCH = 0;
+export const GENESIS_SLOT = 0n;
+export const GENESIS_EPOCH = 0n;
 export const GENESIS_START_SHARD = 0;
-export const FAR_FUTURE_EPOCH = Infinity;
+export const FAR_FUTURE_EPOCH = 2n**64n - 1n;
 export const ZERO_HASH = Buffer.alloc(32, 0);
 export const EMPTY_SIGNATURE = Buffer.alloc(96, 0);
 

--- a/packages/lodestar/src/constants/network.ts
+++ b/packages/lodestar/src/constants/network.ts
@@ -3,7 +3,7 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
 export const ATTESTATION_SUBNET_COUNT = 64;
-export const ATTESTATION_PROPAGATION_SLOT_RANGE = 23;
+export const ATTESTATION_PROPAGATION_SLOT_RANGE = 23n;
 export const MAXIMUM_GOSSIP_CLOCK_DISPARITY = 500;
 // req/resp
 

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -36,7 +36,7 @@ export class LodestarGossipsub extends Gossipsub {
     this.config = config;
     this.validator = validator;
     // This can be epoch/daily/hourly ...
-    this.timeToLive = this.config.params.SLOTS_PER_EPOCH * this.config.params.SECONDS_PER_SLOT * 1000;
+    this.timeToLive = Number(this.config.params.SLOTS_PER_EPOCH) * this.config.params.SECONDS_PER_SLOT * 1000;
     this.logger = logger;
   }
 

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -64,8 +64,8 @@ export class GossipMessageValidator implements IGossipMessageValidator {
     }
     // block is not in the future
     const milliSecPerSlot = this.config.params.SECONDS_PER_SLOT * 1000;
-    if (signedBlock.message.slot * milliSecPerSlot >
-      getCurrentSlot(this.config, state.genesisTime) * milliSecPerSlot + MAXIMUM_GOSSIP_CLOCK_DISPARITY) {
+    if (Number(signedBlock.message.slot) * milliSecPerSlot >
+      Number(getCurrentSlot(this.config, state.genesisTime)) * milliSecPerSlot + MAXIMUM_GOSSIP_CLOCK_DISPARITY) {
       return false;
     }
 
@@ -148,9 +148,9 @@ export class GossipMessageValidator implements IGossipMessageValidator {
 
     const currentSlot = getCurrentSlot(this.config, state.genesisTime);
     const milliSecPerSlot = this.config.params.SECONDS_PER_SLOT * 1000;
-    const currentSlotTime = currentSlot * milliSecPerSlot;
-    if (!((slot + ATTESTATION_PROPAGATION_SLOT_RANGE) * milliSecPerSlot + MAXIMUM_GOSSIP_CLOCK_DISPARITY
-      >= currentSlotTime && currentSlotTime >= slot * milliSecPerSlot - MAXIMUM_GOSSIP_CLOCK_DISPARITY)) {
+    const currentSlotTime = Number(currentSlot) * milliSecPerSlot;
+    if (!(Number(slot + ATTESTATION_PROPAGATION_SLOT_RANGE) * milliSecPerSlot + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+      >= currentSlotTime && currentSlotTime >= Number(slot) * milliSecPerSlot - MAXIMUM_GOSSIP_CLOCK_DISPARITY)) {
       return false;
     }
 

--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -38,7 +38,7 @@ export class FastSync
   /**
    * Target slot for block import, we won't download blocks past that point.
    */
-  private blockImportTarget: Slot = 0;
+  private blockImportTarget: Slot = 0n;
 
   /**
    * Trigger for block import
@@ -116,10 +116,10 @@ export class FastSync
     const lastTarget = fromSlot || this.blockImportTarget;
     const newTarget = this.getNewBlockImportTarget(this.blockImportTarget);
     this.logger.info(
-      `Fetching blocks for ${lastTarget + 1}...${newTarget} slot range`
+      `Fetching blocks for ${lastTarget + 1n}...${newTarget} slot range`
     );
     this.syncTriggerSource.push(
-      {start: lastTarget + 1, end: newTarget}
+      {start: lastTarget + 1n, end: newTarget}
     );
     this.updateBlockImportTarget(newTarget);
   };

--- a/packages/lodestar/src/sync/options.ts
+++ b/packages/lodestar/src/sync/options.ts
@@ -4,7 +4,7 @@ export interface ISyncOptions {
    * max slots to import before waiting for
    * chain to process them
    */
-  maxSlotImport: number;
+  maxSlotImport: bigint;
   minPeers: number;
 }
 
@@ -12,7 +12,7 @@ export interface ISyncOptions {
 const config: ISyncOptions = {
   minPeers: 2,
   //2 epochs
-  maxSlotImport: 64,
+  maxSlotImport: 64n,
   blockPerChunk: 20
 };
 

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -67,7 +67,7 @@ export class NaiveRegularSync implements IRegularSync {
   private async getNewTarget(): Promise<Slot> {
     return getHighestCommonSlot(
       (await this.getSyncPeers(
-        0
+        0n
       )).map((peer) => this.reps.getFromPeerInfo(peer))
     );
   }
@@ -75,8 +75,8 @@ export class NaiveRegularSync implements IRegularSync {
   private setTarget = async (newTarget?: Slot, triggerSync = true): Promise<void> => {
     newTarget = newTarget || await this.getNewTarget();
     if(triggerSync && newTarget > this.currentTarget) {
-      this.logger.info(`Requesting blocks from slot ${this.currentTarget + 1} to slot ${newTarget}`);
-      this.targetSlotRangeSource.push({start: this.currentTarget + 1, end: newTarget});
+      this.logger.info(`Requesting blocks from slot ${this.currentTarget + 1n} to slot ${newTarget}`);
+      this.targetSlotRangeSource.push({start: this.currentTarget + 1n, end: newTarget});
     }
     this.currentTarget = newTarget;
   };

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -178,7 +178,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
     try {
       const archiveBlocksStream = this.db.blockArchive.valuesStream({
         gte: request.startSlot,
-        lt: request.startSlot + request.count * request.step,
+        lt: request.startSlot + BigInt(request.count) * BigInt(request.step),
         step: request.step,
       });
       const responseStream = this.injectRecentBlocks(archiveBlocksStream, this.chain, request);
@@ -236,19 +236,19 @@ export class BeaconReqRespHandler implements IReqRespHandler {
     chain: IBeaconChain,
     request: BeaconBlocksByRangeRequest
   ): AsyncGenerator<SignedBeaconBlock> {
-    let slot = -1;
+    let slot = -1n;
     for await(const archiveBlock of archiveStream) {
       yield archiveBlock;
       slot = archiveBlock.message.slot;
     }
-    slot = (slot === -1)? request.startSlot : slot + request.step;
-    const upperSlot = request.startSlot + request.count * request.step;
+    slot = (slot === -1n)? request.startSlot : slot + BigInt(request.step);
+    const upperSlot = request.startSlot + BigInt(request.count) * BigInt(request.step);
     while (slot < upperSlot) {
       const block = await chain.getBlockAtSlot(slot);
       if(block) {
         yield block;
       }
-      slot += request.step;
+      slot += BigInt(request.step);
     }
   };
 }

--- a/packages/lodestar/src/sync/stats/stats.ts
+++ b/packages/lodestar/src/sync/stats/stats.ts
@@ -30,7 +30,7 @@ export class SyncStats implements ISyncStats {
     }
     const slotsToSync = targetSlot - headSlot;
     if(slotsToSync > 0) {
-      return Math.round(slotsToSync / rate);
+      return Math.round(Number(slotsToSync) / rate);
     }
     return 0;
   }

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -36,7 +36,7 @@ export class BeaconSync implements IBeaconSync {
   private gossip: IGossipHandler;
   private attestationCollector: AttestationCollector;
 
-  private startingBlock: Slot = 0;
+  private startingBlock: Slot = 0n;
 
   constructor(opts: ISyncOptions, modules: ISyncModules) {
     this.opts = opts;
@@ -86,7 +86,7 @@ export class BeaconSync implements IBeaconSync {
     if(this.isSynced()) {
       return null;
     }
-    let target: Slot = 0;
+    let target: Slot = 0n;
     if(this.mode === SyncMode.INITIAL_SYNCING) {
       target = await this.initialSync.getHighestBlock();
     } else {

--- a/packages/lodestar/src/sync/utils/blocks.ts
+++ b/packages/lodestar/src/sync/utils/blocks.ts
@@ -13,13 +13,13 @@ import {sleep} from "../../util/sleep";
  * @param currentSlot
  * @param targetSlot
  */
-export function chunkify(blocksPerChunk: number, currentSlot: Slot, targetSlot: Slot): ISlotRange[] {
+export function chunkify(blocksPerChunk: bigint, currentSlot: Slot, targetSlot: Slot): ISlotRange[] {
   if(blocksPerChunk < 5) {
-    blocksPerChunk = 5;
+    blocksPerChunk = 5n;
   }
   const chunks: ISlotRange[] = [];
   //currentSlot is our state slot so we need block from next slot
-  for(let i = currentSlot; i < targetSlot; i  = i + blocksPerChunk + 1) {
+  for(let i = currentSlot; i < targetSlot; i  = i + blocksPerChunk + 1n) {
     if(i + blocksPerChunk > targetSlot) {
       chunks.push({
         start: i,
@@ -45,7 +45,7 @@ export async function getBlockRangeFromPeer(
     {
       startSlot: chunk.start,
       step: 1,
-      count: chunk.end - chunk.start + 1
+      count: Number(chunk.end - chunk.start) + 1
     }
   ) as SignedBeaconBlock[];
 }
@@ -55,11 +55,11 @@ export async function getBlockRange(
   rpc: IReqResp,
   peers: PeerInfo[],
   range: ISlotRange,
-  blocksPerChunk?: number,
+  blocksPerChunk?: bigint,
   maxRetry = 6
 ): Promise<SignedBeaconBlock[]> {
   const totalBlocks = range.end - range.start;
-  blocksPerChunk = blocksPerChunk || Math.ceil(totalBlocks/peers.length);
+  blocksPerChunk = blocksPerChunk || totalBlocks / BigInt(peers.length);
   if(blocksPerChunk < 5) {
     blocksPerChunk = totalBlocks;
   }
@@ -95,7 +95,7 @@ export async function getBlockRange(
 }
 
 export function sortBlocks(blocks: SignedBeaconBlock[]): SignedBeaconBlock[] {
-  return blocks.sort((b1, b2) => b1.message.slot - b2.message.slot);
+  return blocks.sort((b1, b2) => Number(b1.message.slot - b2.message.slot));
 }
 
 

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -24,7 +24,7 @@ export function getHighestCommonSlot(peers: IReputation[]): Slot {
       .sort((a, b) => b[1] - a[1]);
     return best[0][0];
   } else {
-    return 0;
+    return 0n;
   }
 }
 
@@ -67,7 +67,7 @@ export function targetSlotToBlockChunks(
     return (async function*() {
       for await (const targetSlot of source) {
         await getInitialSyncPeers(targetSlot);
-        yield* chunkify(config.params.SLOTS_PER_EPOCH, (await chain.getHeadState()).slot + 1, targetSlot);
+        yield* chunkify(config.params.SLOTS_PER_EPOCH, (await chain.getHeadState()).slot + 1n, targetSlot);
       }
     })();
   };

--- a/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
@@ -6,6 +6,7 @@ import {ITask} from "../interface";
 import {IBeaconDb} from "../../db/api";
 import {Checkpoint} from "@chainsafe/lodestar-types";
 import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {bigIntArrayMax, bigIntArrayMin} from "@chainsafe/lodestar-utils";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from  "@chainsafe/lodestar-utils/lib/logger";
 
@@ -37,8 +38,8 @@ export class ArchiveBlocksTask implements ITask {
       (block) =>
         computeEpochAtSlot(this.config, block.message.slot) < this.finalizedCheckpoint.epoch
     );
-    const fromSlot = blocks.length > 0? Math.min(...blocks.map(block => block.message.slot)) : undefined;
-    const toSlot = blocks.length > 0? Math.max(...blocks.map(block => block.message.slot)) : undefined;
+    const fromSlot = blocks.length > 0? bigIntArrayMin(...blocks.map(block => block.message.slot)) : undefined;
+    const toSlot = blocks.length > 0? bigIntArrayMax(...blocks.map(block => block.message.slot)) : undefined;
     this.logger.info(`Started archiving ${blocks.length} blocks from slot ${fromSlot} to ${toSlot}`
         +`(finalized epoch #${this.finalizedCheckpoint.epoch})...`
     );

--- a/packages/lodestar/src/tasks/tasks/archiveStates.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveStates.ts
@@ -41,7 +41,7 @@ export class ArchiveStatesTask implements ITask {
     // store the state of finalized checkpoint
     const finalizedState = (await this.db.stateCache.values())
       .filter((state) => computeEpochAtSlot(this.config, state.slot) === this.finalizedCheckpoint.epoch)
-      .sort((a, b) => a.slot - b.slot)[0];
+      .sort((a, b) => Number(a.slot - b.slot))[0];
     await this.db.stateArchive.add(finalizedState);
     // delete states before the finalized state
     await this.db.stateCache.batchDelete(

--- a/packages/lodestar/src/tasks/tasks/interopSubnetsJoiningTask.ts
+++ b/packages/lodestar/src/tasks/tasks/interopSubnetsJoiningTask.ts
@@ -81,7 +81,7 @@ export class InteropSubnetsJoiningTask implements ITask {
     this.timers.push(setTimeout(
       this.handleChangeSubnets,
       subscriptionLifetime
-            * this.config.params.SLOTS_PER_EPOCH
+            * Number(this.config.params.SLOTS_PER_EPOCH)
             * this.config.params.SECONDS_PER_SLOT
             * 1000,
       forkDigest,


### PR DESCRIPTION
Uses javascript native `bigint` type to represent Epoch and Slot types. Motivated to fix the issues outlined in https://github.com/ChainSafe/lodestar/issues/970
> One wrinkle to that assumption, FAR_FUTURE_EPOCH.We get around that by representing it as infinity.
We've also had pain running ssz spec tests and fuzz tests that exercise the higher bits of epoch and slot.

No big structural changes are required. The least appealing is having to cast to Number to index arrays
```js
this.proposers[Number(slot % this.config.params.SLOTS_PER_EPOCH)]
```
Native `Map`s support indexing with BigInt, but I don't know if it's appropriate for the requirements of this codebase. I would appreciate your feedback.

Fixes https://github.com/ChainSafe/lodestar/issues/970