### PR TITLE
Replace NodeJS's assert with a minimal implementation

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/block/blockHeader.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/blockHeader.ts
@@ -2,9 +2,9 @@
  * @module chain/stateTransition/block
  */
 
-import assert from "assert";
 import {BeaconBlock, BeaconState} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {assert} from "@chainsafe/lodestar-utils";
 
 import {getTemporaryBlockHeader, getBeaconProposerIndex} from "../util";
 

--- a/packages/lodestar-beacon-state-transition/src/block/operations/attestation.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/attestation.ts
@@ -2,10 +2,9 @@
  * @module chain/stateTransition/block
  */
 
-import assert from "assert";
-
 import {Attestation, BeaconState, PendingAttestation,} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {assert} from "@chainsafe/lodestar-utils";
 
 import {
   computeEpochAtSlot,

--- a/packages/lodestar-beacon-state-transition/src/block/operations/attesterSlashing.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/attesterSlashing.ts
@@ -2,13 +2,13 @@
  * @module chain/stateTransition/block
  */
 
-import assert from "assert";
 import {
   BeaconState,
   AttesterSlashing,
   ValidatorIndex,
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {assert} from "@chainsafe/lodestar-utils";
 
 import {
   getCurrentEpoch,

--- a/packages/lodestar-beacon-state-transition/src/block/operations/deposit.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/deposit.ts
@@ -2,13 +2,12 @@
  * @module chain/stateTransition/block
  */
 
-import assert from "assert";
 import {verify} from "@chainsafe/bls";
 import {BeaconState, Deposit, Validator} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {DEPOSIT_CONTRACT_TREE_DEPTH, DomainType, FAR_FUTURE_EPOCH,} from "../../constants";
 import {computeDomain, increaseBalance} from "../../util";
-import {bigIntMin, verifyMerkleBranch} from "@chainsafe/lodestar-utils";
+import {assert, bigIntMin, verifyMerkleBranch} from "@chainsafe/lodestar-utils";
 import {computeSigningRoot} from "../../util/signingRoot";
 
 /**

--- a/packages/lodestar-beacon-state-transition/src/block/operations/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/index.ts
@@ -1,4 +1,3 @@
-import assert from "assert";
 import {List} from "@chainsafe/ssz";
 import {
   Attestation,
@@ -10,6 +9,7 @@ import {
   SignedVoluntaryExit,
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {assert} from "@chainsafe/lodestar-utils";
 
 import {processProposerSlashing} from "./proposerSlashing";
 import {processAttesterSlashing} from "./attesterSlashing";
@@ -34,7 +34,7 @@ export function processOperations(
   verifySignatures = true,
 ): void {
   // Verify that outstanding deposits are processed up to the maximum number of deposits
-  assert.equal(body.deposits.length, Math.min(
+  assert(body.deposits.length === Math.min(
     config.params.MAX_DEPOSITS,
     state.eth1Data.depositCount - state.eth1DepositIndex));
   [{

--- a/packages/lodestar-beacon-state-transition/src/block/operations/proposerSlashing.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/proposerSlashing.ts
@@ -2,10 +2,9 @@
  * @module chain/stateTransition/block
  */
 
-import assert from "assert";
-
 import {BeaconState, ProposerSlashing,} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {assert} from "@chainsafe/lodestar-utils";
 
 import {slashValidator, isValidProposerSlashing} from "../../util";
 

--- a/packages/lodestar-beacon-state-transition/src/block/operations/voluntaryExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/voluntaryExit.ts
@@ -2,10 +2,9 @@
  * @module chain/stateTransition/block
  */
 
-import assert from "assert";
-
 import {BeaconState, SignedVoluntaryExit} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {assert} from "@chainsafe/lodestar-utils";
 
 
 import {initiateValidatorExit, isValidVoluntaryExit,} from "../../util";

--- a/packages/lodestar-beacon-state-transition/src/block/randao.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/randao.ts
@@ -2,13 +2,12 @@
  * @module chain/stateTransition/block
  */
 
-import assert from "assert";
 import xor from "buffer-xor";
 import {hash} from "@chainsafe/ssz";
 import {verify} from "@chainsafe/bls";
-
 import {BeaconBlockBody, BeaconState} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {assert} from "@chainsafe/lodestar-utils";
 
 import {DomainType} from "../constants";
 import {getBeaconProposerIndex, getCurrentEpoch, getDomain, getRandaoMix,} from "../util";

--- a/packages/lodestar-beacon-state-transition/src/epoch/util.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/util.ts
@@ -2,8 +2,6 @@
  * @module chain/stateTransition/epoch/util
  */
 
-import assert from "assert";
-
 import {
   BeaconState,
   Epoch,
@@ -12,6 +10,7 @@ import {
   ValidatorIndex,
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {assert} from "@chainsafe/lodestar-utils";
 
 import {
   getAttestingIndices,

--- a/packages/lodestar-beacon-state-transition/src/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/index.ts
@@ -2,10 +2,9 @@
  * @module chain/stateTransition
  */
 
-import assert from "assert";
-
 import {BeaconState, SignedBeaconBlock} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {assert} from "@chainsafe/lodestar-utils";
 
 import {verifyBlockSignature} from "./util/block";
 import {processBlock} from "./block";

--- a/packages/lodestar-beacon-state-transition/src/slot.ts
+++ b/packages/lodestar-beacon-state-transition/src/slot.ts
@@ -2,9 +2,9 @@
  * @module chain/stateTransition/slot
  */
 
-import assert from "assert";
 import {BeaconState, Slot} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {assert} from "@chainsafe/lodestar-utils";
 
 import {ZERO_HASH} from "./constants";
 

--- a/packages/lodestar-beacon-state-transition/src/util/blockRoot.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/blockRoot.ts
@@ -2,7 +2,6 @@
  * @module chain/stateTransition/util
  */
 
-import assert from "assert";
 import {
   BeaconBlock,
   BeaconBlockHeader,
@@ -14,6 +13,7 @@ import {
   SignedBeaconBlockHeader,
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {assert} from "@chainsafe/lodestar-utils";
 
 import {
   ZERO_HASH,

--- a/packages/lodestar-beacon-state-transition/src/util/duties.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/duties.ts
@@ -2,9 +2,9 @@
  * @module chain/stateTransition/util
  */
 
-import assert from "assert";
 import {BeaconState, CommitteeAssignment, Epoch, Slot, ValidatorIndex,} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {assert} from "@chainsafe/lodestar-utils";
 
 import {computeEpochAtSlot, computeStartSlotAtEpoch, getCurrentEpoch,} from "./epoch";
 import {getBeaconCommittee, getCommitteeCountAtSlot} from "./committee";

--- a/packages/lodestar-beacon-state-transition/src/util/proposer.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/proposer.ts
@@ -3,19 +3,17 @@
  */
 
 import {hash} from "@chainsafe/ssz";
-
 import {
   BeaconState,
   ValidatorIndex,
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {intToBytes,intDiv} from "@chainsafe/lodestar-utils";
+import {assert, intToBytes,intDiv} from "@chainsafe/lodestar-utils";
 
 import {getCurrentEpoch} from "./epoch";
 import {getSeed, computeShuffledIndex} from "./seed";
 import {DomainType} from "../constants";
 import {getActiveValidatorIndices} from ".";
-import assert from "assert";
 
 
 

--- a/packages/lodestar-beacon-state-transition/src/util/seed.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/seed.ts
@@ -2,7 +2,6 @@
  * @module chain/stateTransition/util
  */
 
-import assert from "assert";
 import {hash} from "@chainsafe/ssz";
 import {
   Epoch,
@@ -11,7 +10,7 @@ import {
   Bytes32,
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {bytesToBigInt, intToBytes,intDiv} from "@chainsafe/lodestar-utils";
+import {assert, bytesToBigInt, intToBytes,intDiv} from "@chainsafe/lodestar-utils";
 import {DomainType} from "../constants";
 
 

--- a/packages/lodestar-beacon-state-transition/src/util/shuffle.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/shuffle.ts
@@ -1,14 +1,13 @@
 /**
  * @module util/objects
  */
-import assert from "assert";
 import {hash} from "@chainsafe/ssz";
 import {
   ValidatorIndex,
   Bytes32,
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {bytesToBigInt} from "@chainsafe/lodestar-utils";
+import {assert, bytesToBigInt} from "@chainsafe/lodestar-utils";
 
 
 // ShuffleList shuffles a list, using the given seed for randomness. Mutates the input list.

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/deposit.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/deposit.test.ts
@@ -5,7 +5,7 @@ import {expect} from "chai";
 import {afterEach, beforeEach, describe, it} from "mocha";
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 import * as utils from "../../../../../src/util";
-import {bigIntMin, intToBytes} from "@chainsafe/lodestar-utils";
+import {bigIntMin, intToBytes, assert} from "@chainsafe/lodestar-utils";
 import {generateState} from "../../../../utils/state";
 import {generateDeposit} from "../../../../utils/deposit";
 import {generateValidator} from "../../../../utils/validator";
@@ -20,7 +20,8 @@ describe("process block - deposits", function () {
     mockery.registerMock("@chainsafe/lodestar-utils", {
       "verifyMerkleBranch": verifyMerkleBranchStub,
       "bigIntMin": bigIntMin,
-      "intToBytes": intToBytes
+      "intToBytes": intToBytes,
+      "assert": assert
     });
     mockery.registerMock("@chainsafe/bls", {
       verify: blsStub

--- a/packages/lodestar-utils/src/assert.ts
+++ b/packages/lodestar-utils/src/assert.ts
@@ -1,0 +1,14 @@
+/**
+ * Assert condition is truthy, otherwise throw AssertionError
+ * @param condition 
+ * @param message 
+ */
+export function assert(condition: boolean, message?: string): void {
+  if (!condition) {
+    throw new AssertionError(message || "Expect false == true");
+  }
+}
+
+export class AssertionError extends Error {
+  static code = "ERR_ASSERTION";
+}

--- a/packages/lodestar-utils/src/index.ts
+++ b/packages/lodestar-utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./assert";
 export * from "./math";
 export * from "./bytes";
 export * from "./yaml";

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -19,6 +19,7 @@ import {
   Slot
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {assert} from "@chainsafe/lodestar-utils";
 import {IBeaconDb} from "../../../db";
 import {IBeaconChain} from "../../../chain";
 import {IValidatorApi} from "./interface";
@@ -38,7 +39,6 @@ import {
 import {Signature, verify} from "@chainsafe/bls";
 import {DomainType, EMPTY_SIGNATURE} from "../../../constants";
 import {assembleAttesterDuty} from "../../../chain/factory/duties";
-import assert from "assert";
 import {assembleAttestation} from "../../../chain/factory/attestation";
 import {IBeaconSync} from "../../../sync";
 import {getCommitteeIndexSubnet} from "../../../network/gossip/utils";

--- a/packages/lodestar/src/chain/attestation.ts
+++ b/packages/lodestar/src/chain/attestation.ts
@@ -1,4 +1,3 @@
-import assert from "assert";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {
   Attestation,
@@ -16,6 +15,7 @@ import {
   getAttestingIndices
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
+import {assert} from "@chainsafe/lodestar-utils";
 
 import {ChainEventEmitter, IAttestationProcessor} from "./interface";
 import {ILMDGHOST} from ".";

--- a/packages/lodestar/src/chain/forkChoice/arrayDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/arrayDag/lmdGhost.ts
@@ -2,14 +2,13 @@
  * @module chain/forkChoice
  */
 
-import assert from "assert";
-
 import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {Gwei, Slot, ValidatorIndex, Number64, Checkpoint, Epoch, Root} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {computeSlotsSinceEpochStart,
   getCurrentSlot,
   computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {assert} from "@chainsafe/lodestar-utils";
 
 import {ILMDGHOST, BlockSummary, NO_NODE} from "../interface";
 
@@ -220,9 +219,8 @@ export class ArrayDagLMDGHOST implements ILMDGHOST {
       assert(node.slot > finalizedSlot,
         `Fork choice: node slot ${node.slot} should be bigger than finalized slot ${finalizedSlot}`);
       // Check block is a descendant of the finalized block at the checkpoint finalized slot
-      assert.equal(
-        this.getAncestor(blockRootHex, finalizedSlot),
-        this.finalized.node.blockRoot,
+      assert(
+        this.getAncestor(blockRootHex, finalizedSlot) === this.finalized.node.blockRoot,
         `Fork choice: Block slot ${node.slot} is not on the same chain, finalized slot=${finalizedSlot}`);
     }
 
@@ -325,7 +323,7 @@ export class ArrayDagLMDGHOST implements ILMDGHOST {
   }
 
   public headNode(): Node {
-    assert(this.justified);
+    assert(Boolean(this.justified));
     if (!this.synced) {
       this.syncChanges();
     }
@@ -343,7 +341,7 @@ export class ArrayDagLMDGHOST implements ILMDGHOST {
   }
 
   public headStateRoot(): Uint8Array {
-    assert(this.justified);
+    assert(Boolean(this.justified));
     if (!this.synced) {
       this.syncChanges();
     }

--- a/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
@@ -2,8 +2,6 @@
  * @module chain/forkChoice
  */
 
-import assert from "assert";
-
 import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {Checkpoint, Epoch, Gwei, Number64, Root, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
@@ -12,6 +10,7 @@ import {
   computeStartSlotAtEpoch,
   getCurrentSlot
 } from "@chainsafe/lodestar-beacon-state-transition";
+import {assert} from "@chainsafe/lodestar-utils";
 
 import {BlockSummary, ILMDGHOST} from "../interface";
 
@@ -327,9 +326,8 @@ export class StatefulDagLMDGHOST implements ILMDGHOST {
       assert(node.slot > finalizedSlot,
         `Fork choice: node slot ${node.slot} should be bigger than finalized slot ${finalizedSlot}`);
       // Check block is a descendant of the finalized block at the checkpoint finalized slot
-      assert.equal(
-        this.getAncestor(blockRootHex, finalizedSlot),
-        this.finalized.node.blockRoot,
+      assert(
+        this.getAncestor(blockRootHex, finalizedSlot) === this.finalized.node.blockRoot,
         `Fork choice: Block slot ${node.slot} is not on the same chain`);
     }
 
@@ -410,7 +408,7 @@ export class StatefulDagLMDGHOST implements ILMDGHOST {
     return this.headNode().toBlockSummary();
   }
   public headNode(): Node {
-    assert(this.justified);
+    assert(Boolean(this.justified));
     if (!this.synced) {
       this.syncChanges();
     }

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -1,8 +1,8 @@
-import assert from "assert";
 import Gossipsub, {IGossipMessage, Options, Registrar} from "libp2p-gossipsub";
 import {Type} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
+import {assert} from "@chainsafe/lodestar-utils";
 import {compress, uncompress} from "snappyjs";
 
 import {GossipMessageValidatorFn, GossipObject, IGossipMessageValidator, ILodestarGossipMessage} from "./interface";

--- a/packages/lodestar/src/network/gossip/utils.ts
+++ b/packages/lodestar/src/network/gossip/utils.ts
@@ -2,11 +2,11 @@
  * @module network/gossip
  */
 
-import assert from "assert";
 import {Attestation, ForkDigest} from "@chainsafe/lodestar-types";
 import {ATTESTATION_SUBNET_COUNT} from "../../constants";
 import {GossipEvent, AttestationSubnetRegExp, GossipTopicRegExp} from "./constants";
 import {CommitteeIndex} from "@chainsafe/lodestar-types/lib";
+import {assert} from "@chainsafe/lodestar-utils";
 import {IGossipMessage} from "libp2p-gossipsub";
 import {utils} from "libp2p-pubsub";
 import {ILodestarGossipMessage, IGossipEvents} from "./interface";


### PR DESCRIPTION
Note: In a few instances `assert.equal` were used instead of just `assert`. The main difference is that in case of error, the error would contain the expected and actual value. Should this behavior be respected in this PR?

Would it be in the scope of this PR to add assertion messages to all assert() calls?

Fixes https://github.com/ChainSafe/lodestar/issues/929