### PR TITLE
Abstract query stringify in the validator REST API

### DIFF
--- a/packages/lodestar-validator/src/util/httpClient.ts
+++ b/packages/lodestar-validator/src/util/httpClient.ts
@@ -7,6 +7,10 @@ export interface IHttpClientOptions {
   urlPrefix: string;
 }
 
+export interface IHttpQuery {
+  [key: string]: string | number | boolean | string[] | number[];
+}
+
 export class HttpClient {
   private client: AxiosInstance;
   private logger: ILogger;
@@ -18,7 +22,7 @@ export class HttpClient {
     this.logger = logger;
   }
 
-  public async get<T>(url: string, query?: querystring.ParsedUrlQueryInput): Promise<T> {
+  public async get<T>(url: string, query?: IHttpQuery): Promise<T> {
     try {
       if (query) url += "?" + querystring.stringify(query);
       const result: AxiosResponse<T> = await this.client.get<T>(url);
@@ -30,8 +34,9 @@ export class HttpClient {
     }
   }
 
-  public async post<T, T2>(url: string, data: T): Promise<T2> {
+  public async post<T, T2>(url: string, data: T, query?: IHttpQuery): Promise<T2> {
     try {
+      if (query) url += "?" + querystring.stringify(query);
       const result: AxiosResponse<T2> = await this.client.post(url, data);
       this.logger.verbose(`HttpClient POST url=${url} result=${JSON.stringify(result.data)}`);
       return result.data;

--- a/packages/lodestar-validator/src/util/httpClient.ts
+++ b/packages/lodestar-validator/src/util/httpClient.ts
@@ -1,5 +1,6 @@
 import Axios, {AxiosError, AxiosInstance, AxiosResponse} from "axios";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
+import querystring from "querystring";
 
 export interface IHttpClientOptions {
   // Add more options if needed
@@ -17,8 +18,9 @@ export class HttpClient {
     this.logger = logger;
   }
 
-  public async get<T>(url: string): Promise<T> {
+  public async get<T>(url: string, query?: querystring.ParsedUrlQueryInput): Promise<T> {
     try {
+      if (query) url += "?" + querystring.stringify(query);
       const result: AxiosResponse<T> = await this.client.get<T>(url);
       this.logger.verbose(`HttpClient GET url=${url} result=${JSON.stringify(result.data)}`);
       return result.data;

--- a/packages/lodestar-validator/test/unit/utils/httpClient.test.ts
+++ b/packages/lodestar-validator/test/unit/utils/httpClient.test.ts
@@ -30,6 +30,15 @@ describe("httpClient test", () => {
     assert.equal(user.name, "John Smith");
   });
 
+  it("should handle successful GET request with query correctly", async () => {
+    mock.onGet("/users?id=1").reply(
+      200, {id: 1, name: "John Smith"}
+    );
+    const user: IUser = await httpClient.get<IUser>("/users", {id: 1});
+    assert.equal(user.id, 1);
+    assert.equal(user.name, "John Smith");
+  });
+
   it("should handle successful POST request correctly", async () => {
     mock.onPost("/users", {name: "New comer"}).reply(200, "The user 'New comer' was saved successfully");
     const result: string = await httpClient.post<IUser, string>("/users", {name: "New comer"});


### PR DESCRIPTION
It should help with readability and maintainability. If the NodeJS `querystring` module is not appropriate for use I can substitute with a minimal implementation.