### PR TITLE
Add fastify hook to convert querystring keys to camelcase

### DIFF
--- a/packages/lodestar/src/api/rest/index.ts
+++ b/packages/lodestar/src/api/rest/index.ts
@@ -2,6 +2,7 @@ import * as fastify from "fastify";
 import {FastifyInstance} from "fastify";
 import fastifyCors from "fastify-cors";
 import {IService} from "../../node";
+import {camelcase} from "../../util/camelcase"
 import {IRestApiOptions} from "./options";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import * as routes from "./routes";
@@ -70,6 +71,16 @@ export class RestApi implements IService {
       // applySyncingMiddleware(server, "/validator/*", modules);
       server.register(routes.validator, {prefix: "/validator", api, config: modules.config});
     }
+
+    // Make querystring keys also available in camelCase
+    server.addHook("preValidation", (request, reply, done) => {
+      if (typeof request.query === "object") {
+        for (const key in request.query) {
+          request.query[camelcase(key)] = request.query[key];
+        }
+      }
+      done();
+    });
 
     return server;
   }

--- a/packages/lodestar/src/api/rest/routes/validator/duties/attester.ts
+++ b/packages/lodestar/src/api/rest/routes/validator/duties/attester.ts
@@ -8,8 +8,7 @@ interface IParams extends DefaultParams {
 }
 
 interface IQuery extends DefaultQuery {
-  // eslint-disable-next-line camelcase
-  validator_pubkeys: string[];
+  validatorPubkeys: string[];
 }
 
 
@@ -27,9 +26,9 @@ const opts: fastify.RouteShorthandOptions<Server, IncomingMessage, ServerRespons
     },
     querystring: {
       type: "object",
-      required: ["validator_pubkeys"],
+      required: ["validatorPubkeys"],
       properties: {
-        "validator_pubkeys": {
+        validatorPubkeys: {
           type: "array",
           maxItems: 5,
           items: {
@@ -48,7 +47,7 @@ export const registerAttesterDutiesEndpoint: LodestarRestApiEndpoint = (fastify,
     async (request, reply) => {
       const responseValue = await api.validator.getAttesterDuties(
         request.params.epoch,
-        request.query.validator_pubkeys.map((pubKeyHex) => fromHexString(pubKeyHex))
+        request.query.validatorPubkeys.map((pubKeyHex) => fromHexString(pubKeyHex))
       );
       reply
         .code(200)

--- a/packages/lodestar/src/api/rest/routes/validator/getWireAttestations.ts
+++ b/packages/lodestar/src/api/rest/routes/validator/getWireAttestations.ts
@@ -4,8 +4,7 @@ import {LodestarRestApiEndpoint} from "../../interface";
 
 interface IQuery extends DefaultQuery {
   epoch: number;
-  // eslint-disable-next-line camelcase
-  committee_index: number;
+  committeeIndex: number;
 }
 
 
@@ -13,13 +12,13 @@ const opts: fastify.RouteShorthandOptions<Server, IncomingMessage, ServerRespons
   schema: {
     querystring: {
       type: "object",
-      required: ["epoch", "committee_index"],
+      required: ["epoch", "committeeIndex"],
       properties: {
         epoch: {
           type: "integer",
           minimum: 0
         },
-        "committee_index": {
+        committeeIndex: {
           type: "integer",
           minimum: 0
         }
@@ -35,7 +34,7 @@ export const registerGetWireAttestationEndpoint: LodestarRestApiEndpoint = (fast
     async (request, reply) => {
       const responseValue = await api.validator.getWireAttestations(
         request.query.epoch,
-        request.query.committee_index
+        request.query.committeeIndex
       );
       reply
         .code(200)

--- a/packages/lodestar/src/api/rest/routes/validator/produceAggregatedAttestation.ts
+++ b/packages/lodestar/src/api/rest/routes/validator/produceAggregatedAttestation.ts
@@ -4,9 +4,8 @@ import {LodestarRestApiEndpoint} from "../../interface";
 import {fromHex} from "@chainsafe/lodestar-utils";
 
 interface IQuery extends DefaultQuery {
-  // eslint-disable-next-line camelcase
-  attestation_data: string;
-  aggregator_pubkey: string;
+  attestationData: string;
+  aggregatorPubkey: string;
 }
 
 
@@ -14,12 +13,12 @@ const opts: fastify.RouteShorthandOptions<Server, IncomingMessage, ServerRespons
   schema: {
     querystring: {
       type: "object",
-      required: ["attestation_data", "aggregator_pubkey"],
+      required: ["attestationData", "aggregatorPubkey"],
       properties: {
-        "attestation_data": {
+        attestationData: {
           type: "string"
         },
-        "aggregator_pubkey": {
+        aggregatorPubkey: {
           type: "string"
         }
       }
@@ -32,10 +31,10 @@ export const registerAggregateAndProofProductionEndpoint: LodestarRestApiEndpoin
     "/aggregate_and_proof",
     opts,
     async (request, reply) => {
-      const serialized = fromHex(request.query.attestation_data);
+      const serialized = fromHex(request.query.attestationData);
       const aggregate = await api.validator.produceAggregateAndProof(
         config.types.AttestationData.deserialize(serialized),
-        config.types.BLSPubkey.fromJson(request.query.aggregator_pubkey, {case: "snake"})
+        config.types.BLSPubkey.fromJson(request.query.aggregatorPubkey, {case: "snake"})
       );
       reply
         .code(200)

--- a/packages/lodestar/src/api/rest/routes/validator/produceAttestation.ts
+++ b/packages/lodestar/src/api/rest/routes/validator/produceAttestation.ts
@@ -5,10 +5,9 @@ import {fromHexString} from "@chainsafe/ssz";
 import {LodestarRestApiEndpoint} from "../../interface";
 
 interface IQuery extends DefaultQuery {
-  validator_pubkey: string;
-  poc_bit: number;
+  validatorPubkey: string;
   slot: number;
-  attestation_committee_index: number;
+  attestationCommitteeIndex: number;
 }
 
 
@@ -16,12 +15,12 @@ const opts: fastify.RouteShorthandOptions<Server, IncomingMessage, ServerRespons
   schema: {
     querystring: {
       type: "object",
-      required: ["validator_pubkey", "slot", "attestation_committee_index"],
+      required: ["validatorPubkey", "slot", "attestationCommitteeIndex"],
       properties: {
-        "validator_pubkey": {
+        validatorPubkey: {
           type: "string"
         },
-        "attestation_committee_index": {
+        attestationCommitteeIndex: {
           type: "integer",
           minimum: 0
         },
@@ -40,8 +39,8 @@ export const registerAttestationProductionEndpoint: LodestarRestApiEndpoint = (f
     opts,
     async (request, reply) => {
       const responseValue = await api.validator.produceAttestation(
-        fromHexString(request.query.validator_pubkey),
-        request.query.attestation_committee_index,
+        fromHexString(request.query.validatorPubkey),
+        request.query.attestationCommitteeIndex,
         request.query.slot
       );
       reply

--- a/packages/lodestar/src/api/rest/routes/validator/produceBlock.ts
+++ b/packages/lodestar/src/api/rest/routes/validator/produceBlock.ts
@@ -5,10 +5,8 @@ import {fromHex} from "@chainsafe/lodestar-utils";
 
 interface IQuery extends DefaultQuery {
   slot: number;
-  // eslint-disable-next-line camelcase
-  proposer_pubkey: string;
-  // eslint-disable-next-line camelcase
-  randao_reveal: string;
+  proposerPubkey: string;
+  randaoReveal: string;
 }
 
 
@@ -16,16 +14,16 @@ const opts: fastify.RouteShorthandOptions<Server, IncomingMessage, ServerRespons
   schema: {
     querystring: {
       type: "object",
-      required: ["slot", "proposer_pubkey", "randao_reveal"],
+      required: ["slot", "proposerPubkey", "randaoReveal"],
       properties: {
         slot: {
           type: "integer",
           minimum: 0
         },
-        "proposer_pubkey": {
+        proposerPubkey: {
           type: "string",
         },
-        "randao_reveal": {
+        randaoReveal: {
           type: "string"
         }
       }
@@ -40,8 +38,8 @@ export const registerBlockProductionEndpoint: LodestarRestApiEndpoint = (fastify
     async (request, reply) => {
       const block = await api.validator.produceBlock(
         request.query.slot,
-        fromHex(request.query.proposer_pubkey),
-        fromHex(request.query.randao_reveal)
+        fromHex(request.query.proposerPubkey),
+        fromHex(request.query.randaoReveal)
       );
       reply
         .code(200)

--- a/packages/lodestar/src/api/rest/routes/validator/subscribeToCommitteeSubnet.ts
+++ b/packages/lodestar/src/api/rest/routes/validator/subscribeToCommitteeSubnet.ts
@@ -7,17 +7,17 @@ const opts: fastify.RouteShorthandOptions = {
   schema: {
     body: {
       type: "object",
-      requiredKeys: ["committee_index", "slot", "slot_signature", "aggregator_pubkey"],
-      "attestation_committee_index": {
+      requiredKeys: ["attestationCommitteeIndex", "slot", "slotSignature", "aggregatorPubkey"],
+      attestationCommitteeIndex: {
         type: "string"
       },
-      "slot": {
+      slot: {
         type: "string"
       },
-      "slot_signature": {
+      slotSignature: {
         type: "string"
       },
-      "aggregator_pubkey": {
+      aggregatorPubkey: {
         type: "string"
       },
     },
@@ -25,10 +25,10 @@ const opts: fastify.RouteShorthandOptions = {
 };
 
 interface IBody extends DefaultBody {
-  attestation_committee_index: string;
+  attestationCommitteeIndex: string;
   slot: string;
-  slot_signature: string;
-  aggregator_pubkey: string;
+  slotSignature: string;
+  aggregatorPubkey: string;
 }
 
 export const registerSubscribeToCommitteeSubnet: LodestarRestApiEndpoint = (fastify, {api}): void => {
@@ -38,9 +38,9 @@ export const registerSubscribeToCommitteeSubnet: LodestarRestApiEndpoint = (fast
     async (request, reply) => {
       await api.validator.subscribeCommitteeSubnet(
         Number(request.body.slot),
-        fromHexString(request.body.slot_signature),
-        Number(request.body.attestation_committee_index),
-        fromHexString(request.body.aggregator_pubkey)
+        fromHexString(request.body.slotSignature),
+        Number(request.body.attestationCommitteeIndex),
+        fromHexString(request.body.aggregatorPubkey)
       );
       reply
         .code(200)

--- a/packages/lodestar/src/util/camelcase.ts
+++ b/packages/lodestar/src/util/camelcase.ts
@@ -1,0 +1,12 @@
+/**
+ * Converts non-camelcase to camelcase
+ * "one_two" => "oneTwo"
+ * @param str 
+ */
+export function camelcase(str: string): string {
+  return str
+    .replace(/^[_.\- ]+/, "")
+    .toLocaleLowerCase()
+    .replace(/[_.\- ]+([\p{Alpha}\p{N}_]|$)/gu, (_, p1) => p1.toLocaleUpperCase())
+    .replace(/\d+([\p{Alpha}\p{N}_]|$)/gu, m => m.toLocaleUpperCase());
+}

--- a/packages/lodestar/test/unit/util/camelcase.test.ts
+++ b/packages/lodestar/test/unit/util/camelcase.test.ts
@@ -1,0 +1,19 @@
+import {expect} from "chai";
+
+import {camelcase} from "../../../src/util/camelcase";
+
+
+describe("camelcase", () => {
+
+  const cases: {[from: string]: string} = {
+    "one": "one",
+    "one_two": "oneTwo",
+    "one_two_three": "oneTwoThree",
+  };
+
+  for (const from in cases) {
+    it(`should convert ${from} to camelCase`, () => {
+      expect(camelcase(from)).to.equal(cases[from]);
+    });
+  }
+});


### PR DESCRIPTION
Adds a step in the [fastify lifecycle](https://www.fastify.io/docs/latest/Lifecycle/) to mutate the query object before hitting the schema validation. The hook adds a cameCase version of each keys in the query string object.

Fixes https://github.com/ChainSafe/lodestar/issues/1021

Personally I will stick to snake case query string params if that is what the spec is using for clarity. Now there is a non-obvious step that might be problematic in the future.