### PR TITLE
Start MetadataController with an enr

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -51,7 +51,6 @@ export interface IBlockProcessJob {
   reprocess: boolean;
 }
 
-const MAX_VERSION = Buffer.from([255, 255, 255, 255]);
 export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) implements IBeaconChain {
 
   public readonly chain: string;
@@ -204,7 +203,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
       fork => this.config.types.Version.equals(currentVersion, intToBytes(fork.previousVersion, 4)));
     return {
       forkDigest: this.currentForkDigest,
-      nextForkVersion: nextVersion? intToBytes(nextVersion.currentVersion, 4) : MAX_VERSION,
+      nextForkVersion: nextVersion? intToBytes(nextVersion.currentVersion, 4) : currentVersion.valueOf() as Uint8Array,
       nextForkEpoch: nextVersion? nextVersion.epoch : Number.MAX_SAFE_INTEGER,
     };
   }

--- a/packages/lodestar/src/network/metadata/metadata.ts
+++ b/packages/lodestar/src/network/metadata/metadata.ts
@@ -6,7 +6,6 @@ import {IBeaconChain} from "../../chain";
 import {ILogger} from "@chainsafe/lodestar-utils";
 
 export interface IMetadataOpts {
-  enr?: ENR;
   metadata?: Metadata;
 }
 
@@ -17,22 +16,21 @@ export interface IMetadataModules {
 }
 
 export class MetadataController {
-  public enr?: ENR;
-
+  private enr?: ENR;
   private config: IBeaconConfig;
   private chain: IBeaconChain;
   private _metadata: Metadata;
   private logger: ILogger;
 
   constructor(opts: IMetadataOpts, modules: IMetadataModules) {
-    this.enr = opts.enr;
     this.config = modules.config;
     this.chain = modules.chain;
     this.logger = modules.logger;
     this._metadata = opts.metadata || this.config.types.Metadata.defaultValue();
   }
 
-  public async start(): Promise<void> {
+  public async start(enr: ENR): Promise<void> {
+    this.enr = enr;
     if (this.enr) {
       this.enr.set("attnets", Buffer.from(this.config.types.AttestationSubnets.serialize(this._metadata.attnets)));
       this.enr.set("eth2", Buffer.from(this.config.types.ENRForkID.serialize(await this.chain.getENRForkID())));

--- a/packages/lodestar/test/unit/network/gossip/gossip.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/gossip.test.ts
@@ -37,8 +37,6 @@ describe("Network Gossip", function() {
       connectTimeout: 0,
       disconnectTimeout: 0,
     };
-    const peerIdB = await createPeerId();
-    const enr = ENR.createFromPeerId(peerIdB);
     const libp2p = sandbox.createStubInstance(NodejsNode);
     const logger = new WinstonLogger();
     logger.silent = true;
@@ -51,7 +49,7 @@ describe("Network Gossip", function() {
       state,
       config
     });
-    metadata = new MetadataController({enr}, {config,  chain, logger});
+    metadata = new MetadataController({}, {config,  chain, logger});
     pubsub = new MockGossipSub();
     gossip = new Gossip(networkOpts, metadata, {config, libp2p, logger, validator, chain, pubsub});
     await gossip.start();

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -64,7 +64,11 @@ export class MockBeaconChain extends EventEmitter implements IBeaconChain {
   }
 
   public async getENRForkID(): Promise<ENRForkID> {
-    return undefined;
+    return {
+      forkDigest: Buffer.alloc(4),
+      nextForkEpoch: 100,
+      nextForkVersion: Buffer.alloc(4),
+    };
   }
 
   receiveAttestation(): Promise<void> {


### PR DESCRIPTION
fixes #989 
## Cause
+ ENR is not available at the time of creating instance (constructor)
+ It's only available after libp2 started so make it `start(enr)`