### PR TITLE
Avoid deep copy pubkey2index map in EpochContext.copy()

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/fast/util/pubkeyIndexMap.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/pubkeyIndexMap.ts
@@ -1,0 +1,25 @@
+import {ByteVector, toHexString} from "@chainsafe/ssz";
+import {ValidatorIndex} from "@chainsafe/lodestar-types";
+
+export class PubkeyIndexMap extends Map<ByteVector, ValidatorIndex> implements IPubkeyIndexGetter {
+  get(key: ByteVector): ValidatorIndex | undefined {
+    return super.get(toHexString(key) as unknown as ByteVector);
+  }
+  set(key: ByteVector, value: ValidatorIndex): this {
+    return super.set(toHexString(key) as unknown as ByteVector, value);
+  }
+}
+
+export interface IPubkeyIndexGetter {
+  get(key: ByteVector): ValidatorIndex | undefined;
+}
+
+export const pubkey2indexProxyHandler = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get: (target: PubkeyIndexMap, p: string | number | symbol): any => {
+    if (p !== "get") {
+      throw new Error(`Illegal access '${p.toString()}' from pubkey2index`);
+    }
+    return target.get.bind(target);
+  }
+};

--- a/packages/lodestar-beacon-state-transition/test/unit/fast/util/epochContext.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/fast/util/epochContext.test.ts
@@ -1,0 +1,40 @@
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import {expect, assert} from "chai";
+
+import {generateState} from "../../../utils/state";
+import {generateValidator} from "../../../utils/validator";
+import {EpochContext} from "../../../../src/fast/util/epochContext";
+
+describe("EpochContext", () => {
+  describe("pubkey2index map", () => {
+    it("should share same pubkey map after copy", () => {
+      const validator0 = generateValidator();
+      validator0.pubkey = Buffer.alloc(48, 1);
+      const state0 = generateState({validators: [validator0]});
+      const epochCtx = new EpochContext(config);
+      epochCtx.syncPubkeys(state0);
+      const copiedEpochCtx = epochCtx.copy();
+      expect(epochCtx.pubkey2index.get(validator0.pubkey)).to.be.equal(0);
+      expect(copiedEpochCtx.pubkey2index.get(validator0.pubkey)).to.be.equal(0);
+      const validator1 = generateValidator();
+      validator1.pubkey = Buffer.alloc(48, 2);
+      const state1 = generateState({validators: [validator0, validator1]});
+      epochCtx.syncPubkeys(state1);
+      expect(epochCtx.pubkey2index.get(validator1.pubkey)).to.be.equal(1);
+      // this works even we didn't call copy() again
+      expect(copiedEpochCtx.pubkey2index.get(validator1.pubkey)).to.be.equal(1);
+    });
+
+    it("should not be able to mutate pubkey map from outside", () => {
+      try {
+        const epochCtx = new EpochContext(config);
+        epochCtx.syncPubkeys(generateState());
+        // @ts-ignore
+        epochCtx.pubkey2index.set(Buffer.alloc(48), 0);
+        assert.fail("Expect error here");
+      } catch (e) {
+        expect(e.message).to.be.equal("Illegal access 'set' from pubkey2index");
+      }
+    });
+  });
+});

--- a/packages/lodestar/test/unit/api/impl/beacon/validator.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/validator.test.ts
@@ -27,22 +27,21 @@ describe("get validator details api", function () {
   });
 
   it("should get validator details", async function () {
+    const state = generateState({
+      validators: [
+        generateValidator({
+          pubkey: Buffer.alloc(48, 1)
+        }),
+        generateValidator({
+          pubkey: Buffer.alloc(48, 2),
+          slashed: true
+        })
+      ]
+    });
     const epochCtx = new EpochContext(config);
+    epochCtx.syncPubkeys(state);
     chainStub.getEpochContext.returns(epochCtx);
-    epochCtx.pubkey2index.set(Buffer.alloc(48, 2), 1);
-    chainStub.getHeadState.resolves(
-      generateState({
-        validators: [
-          generateValidator({
-            pubkey: Buffer.alloc(48, 1)
-          }),
-          generateValidator({
-            pubkey: Buffer.alloc(48, 2),
-            slashed: true
-          })
-        ]
-      })
-    );
+    chainStub.getHeadState.resolves(state);
     const result = await api.getValidator(Buffer.alloc(48, 2));
     expect(result.validator.slashed).to.be.true;
     expect(result.index).to.be.equal(1);

--- a/packages/lodestar/test/unit/api/impl/validator/produceAggregateAndProof.test.ts
+++ b/packages/lodestar/test/unit/api/impl/validator/produceAggregateAndProof.test.ts
@@ -8,6 +8,8 @@ import {Attestation} from "@chainsafe/lodestar-types";
 import {computeDomain, computeSigningRoot, DomainType, EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {expect} from "chai";
 import {IBeaconChain, BeaconChain} from "../../../../../src/chain";
+import {generateState} from "../../../../utils/state";
+import {generateValidator} from "../../../../utils/validator";
 
 
 describe("produce aggregate and proof api implementation", function () {
@@ -35,9 +37,16 @@ describe("produce aggregate and proof api implementation", function () {
       getCommitteeAttestation(generateEmptyAttestation(), PrivateKey.fromInt(1), 1),
       getCommitteeAttestation(generateEmptyAttestation(), PrivateKey.fromInt(2), 2)
     ]);
+    const state = generateState({
+      validators: [
+        generateValidator({
+          pubkey: Buffer.alloc(48, 0)
+        })
+      ]
+    });
     const epochCtx = new EpochContext(config);
+    epochCtx.syncPubkeys(state);
     chainStub.getEpochContext.returns(epochCtx);
-    epochCtx.pubkey2index.set(Buffer.alloc(48), 0);
 
     const result = await api.produceAggregateAndProof(generateEmptyAttestation().data, Buffer.alloc(48));
     expect(result.aggregate.signature).to.not.be.null;


### PR DESCRIPTION
resolves #1027  with Proxy approach:
+ Share the same pubkey2Index map in EpochContext.copy()
+ pubkey2Index is now a getter method returning pubkey2index map proxy with `get` method only