### PR TITLE
Readonly interface for EpochContext

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochShuffling.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochShuffling.ts
@@ -5,6 +5,14 @@ import {intDiv} from "@chainsafe/lodestar-utils";
 import {getSeed, unshuffleList} from "../../util";
 import {DomainType} from "../../constants";
 
+/**
+ * Readonly interface for IEpochShuffling.
+ */
+export interface IReadonlyEpochShuffling {
+  readonly epoch: Epoch;
+  readonly committees: Readonly<ValidatorIndex[][][]>;
+}
+
 export interface IEpochShuffling {
   /**
    * Epoch being shuffled

--- a/packages/lodestar-beacon-state-transition/src/fast/util/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/index.ts
@@ -4,3 +4,4 @@ export * from "./epochProcess";
 export * from "./epochShuffling";
 export * from "./epochStakeSummary";
 export * from "./flatValidator";
+export * from "./interface";

--- a/packages/lodestar-beacon-state-transition/src/fast/util/interface.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/interface.ts
@@ -1,0 +1,15 @@
+/* eslint-disable @typescript-eslint/interface-name-prefix */
+import {IReadonlyEpochShuffling} from ".";
+import {ValidatorIndex, Slot} from "@chainsafe/lodestar-types";
+import {ByteVector} from "@chainsafe/ssz";
+
+/**
+ * Readonly interface for EpochContext.
+ */
+export interface ReadonlyEpochContext {
+  readonly pubkey2index: ReadonlyMap<ByteVector, ValidatorIndex>;
+  readonly index2pubkey: Readonly<Uint8Array[]>;
+  readonly currentShuffling?: IReadonlyEpochShuffling;
+  readonly previousShuffling?: IReadonlyEpochShuffling;
+  getBeaconProposer: (slot: Slot) => ValidatorIndex;
+}

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -18,6 +18,7 @@ import {
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {computeEpochAtSlot, computeForkDigest, EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
+import {ReadonlyEpochContext} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {intToBytes} from "@chainsafe/lodestar-utils";
 
@@ -97,8 +98,8 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     return this.db.block.get(this.forkChoice.headBlockRoot());
   }
 
-  public getEpochContext(): EpochContext {
-    return this.epochCtx.copy();
+  public getEpochContext(): ReadonlyEpochContext {
+    return this.epochCtx;
   }
 
   public async getBlockAtSlot(slot: Slot): Promise<SignedBeaconBlock|null> {

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -16,7 +16,7 @@ import {
 
 import {ILMDGHOST} from "./forkChoice";
 import {IBeaconClock} from "./clock/interface";
-import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
+import {ReadonlyEpochContext} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
 export interface IChainEvents {
   unknownBlockRoot: (root: Root) => void;
@@ -62,7 +62,7 @@ export interface IBeaconChain extends ChainEventEmitter {
 
   getFinalizedCheckpoint(): Promise<Checkpoint>;
 
-  getEpochContext(): EpochContext;
+  getEpochContext(): ReadonlyEpochContext;
 
   getBlockAtSlot(slot: Slot): Promise<SignedBeaconBlock|null>;
 

--- a/packages/lodestar/test/unit/api/impl/beacon/validator.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/validator.test.ts
@@ -27,22 +27,21 @@ describe("get validator details api", function () {
   });
 
   it("should get validator details", async function () {
+    const state = generateState({
+      validators: [
+        generateValidator({
+          pubkey: Buffer.alloc(48, 1)
+        }),
+        generateValidator({
+          pubkey: Buffer.alloc(48, 2),
+          slashed: true
+        })
+      ]
+    });
     const epochCtx = new EpochContext(config);
+    epochCtx.syncPubkeys(state);
     chainStub.getEpochContext.returns(epochCtx);
-    epochCtx.pubkey2index.set(Buffer.alloc(48, 2), 1);
-    chainStub.getHeadState.resolves(
-      generateState({
-        validators: [
-          generateValidator({
-            pubkey: Buffer.alloc(48, 1)
-          }),
-          generateValidator({
-            pubkey: Buffer.alloc(48, 2),
-            slashed: true
-          })
-        ]
-      })
-    );
+    chainStub.getHeadState.resolves(state);
     const result = await api.getValidator(Buffer.alloc(48, 2));
     expect(result.validator.slashed).to.be.true;
     expect(result.index).to.be.equal(1);

--- a/packages/lodestar/test/unit/api/impl/validator/produceAggregateAndProof.test.ts
+++ b/packages/lodestar/test/unit/api/impl/validator/produceAggregateAndProof.test.ts
@@ -8,6 +8,8 @@ import {Attestation} from "@chainsafe/lodestar-types";
 import {computeDomain, computeSigningRoot, DomainType, EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {expect} from "chai";
 import {IBeaconChain, BeaconChain} from "../../../../../src/chain";
+import {generateState} from "../../../../utils/state";
+import {generateValidator} from "../../../../utils/validator";
 
 
 describe("produce aggregate and proof api implementation", function () {
@@ -35,9 +37,16 @@ describe("produce aggregate and proof api implementation", function () {
       getCommitteeAttestation(generateEmptyAttestation(), PrivateKey.fromInt(1), 1),
       getCommitteeAttestation(generateEmptyAttestation(), PrivateKey.fromInt(2), 2)
     ]);
+    const state = generateState({
+      validators: [
+        generateValidator({
+          pubkey: Buffer.alloc(48, 0)
+        }),
+      ]
+    });
     const epochCtx = new EpochContext(config);
+    epochCtx.syncPubkeys(state);
     chainStub.getEpochContext.returns(epochCtx);
-    epochCtx.pubkey2index.set(Buffer.alloc(48), 0);
 
     const result = await api.produceAggregateAndProof(generateEmptyAttestation().data, Buffer.alloc(48));
     expect(result.aggregate.signature).to.not.be.null;

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -4,6 +4,7 @@ import {Number64, Uint16, Uint64, ForkDigest, ENRForkID, Checkpoint, Slot, Signe
 import {IBeaconChain, ILMDGHOST} from "../../../../src/chain";
 import {IBeaconClock} from "../../../../src/chain/clock/interface";
 import {computeForkDigest, EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
+import {ReadonlyEpochContext} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {generateEmptySignedBlock} from "../../block";
 
@@ -41,7 +42,7 @@ export class MockBeaconChain extends EventEmitter implements IBeaconChain {
     return this.state;
   }
 
-  public getEpochContext(): EpochContext {
+  public getEpochContext(): ReadonlyEpochContext {
     return this.epochCtx;
   }
 


### PR DESCRIPTION
Part of #1027 
+ Create readonly interfaces for EpochContext
+ chain.getEpochContext() should return that readonly interface instead of a copy