### PR TITLE
Update labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,12 +1,34 @@
-BeaconChain:
-- packages/lodestar/**/*
+StateTransition:
+  - packages/lodestar-beacon-state-transition/**/*
+  - packages/spec-test-runner/**/*
+  - packages/lodestar-spec-test-util/**/*
+
+CLI:
+  - packages/lodestar-cli/**/*
+
+Types:
+  - packages/lodestar-types/**/*
+
+Config:
+  - packages/lodestar-config/**/*
+  - packages/lodestar-params/**/*
 
 Validator:
-- packages/lodestar-validator/**/*
+  - packages/lodestar-validator/**/*
+
+Api:
+  - packages/lodestar/src/api/**/*
+
+Network:
+  - packages/lodestar/src/network/**/*
+  - packages/lodestar/src/sync/**/*
+
+Eth1:
+  - packages/lodestar/src/eth1/**/*
 
 Benchmarks:
-- packages/benchmark-utils/**/*
-- packages/lodestar/test/benchmarks/**/*
+  - packages/benchmark-utils/**/*
+  - packages/lodestar/test/benchmarks/**/*
 
 CI:
-- .github/**/*
+  - .github/**/*

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -3,10 +3,9 @@ on: [pull_request]
 
 jobs:
   label:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/labeler@v2
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/labeler@v2
+        if: github.repository == 'ChainSafe/lodestar'
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Implements https://github.com/ChainSafe/lodestar/issues/1017. Fixes https://github.com/ChainSafe/lodestar/issues/1017

**Note**: Disabled Labeler action for forks. Forks do not have write permissions thus cannot label (see https://github.com/actions/labeler/issues/12). Also https://github.com/ethereum/ethereum-org-website/pull/345/files as a reference solution