### PR TITLE
Remove event listeners

### DIFF
--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -57,7 +57,7 @@
     "deepmerge": "^3.2.0",
     "es6-promisify": "6.0.2",
     "ethers": "^5.0.2",
-    "event-iterator": "^1.2.0",
+    "event-iterator": "^2.0.0",
     "fastify": "2.13.0",
     "fastify-cors": "^2.1.3",
     "fastify-sse-v2": "^1.0.3",

--- a/packages/lodestar/src/api/impl/beacon/beacon.ts
+++ b/packages/lodestar/src/api/impl/beacon/beacon.ts
@@ -92,7 +92,7 @@ export class BeaconApi implements IBeaconApi {
   }
 
   public getBlockStream(): AsyncIterable<SignedBeaconBlock> {
-    return new EventIterator<SignedBeaconBlock>((push) => {
+    return new EventIterator<SignedBeaconBlock>(({push}) => {
       this.chain.on("processedBlock", push);
       return () => this.chain.off("processedBlock", push);
     });

--- a/packages/lodestar/src/api/impl/beacon/beacon.ts
+++ b/packages/lodestar/src/api/impl/beacon/beacon.ts
@@ -93,9 +93,8 @@ export class BeaconApi implements IBeaconApi {
 
   public getBlockStream(): AsyncIterable<SignedBeaconBlock> {
     return new EventIterator<SignedBeaconBlock>((push) => {
-      this.chain.on("processedBlock", (block) => {
-        push(block);
-      });
+      this.chain.on("processedBlock", push);
+      return () => this.chain.off("processedBlock", push);
     });
   }
 }

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -210,7 +210,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
 
   public async waitForBlockProcessed(blockRoot: Uint8Array): Promise<void> {
     await new Promise((resolve) => {
-      this.on("processedBlock", (signedBlock) => {
+      this.once("processedBlock", (signedBlock) => {
         const root = this.config.types.BeaconBlock.hashTreeRoot(signedBlock.message);
         if (this.config.types.Root.equals(root, blockRoot)) {
           resolve();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6640,10 +6640,10 @@ ethjs-util@0.1.6, ethjs-util@^0.1.3:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
-event-iterator@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/event-iterator/-/event-iterator-1.2.0.tgz#2e71dc6ca56f1cf8ebcb2b9be7fdfd10acabbb76"
-  integrity sha512-Daq7YUl0Mv1i4QEgzGQlz0jrx7hUFNyLGbiF+Ap7NCMCjDLCCnolyj6s0TAc6HmrBziO5rNVHsPwGMp7KdRPvw==
+event-iterator@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/event-iterator/-/event-iterator-2.0.0.tgz#10f06740cc1e9fd6bc575f334c2bc1ae9d2dbf62"
+  integrity sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ==
 
 event-target-shim@^5.0.0:
   version "5.0.1"


### PR DESCRIPTION
- Unsubscribe from processedBlock on EventIterator remove. Fixes https://github.com/ChainSafe/lodestar/issues/1029
- Remove processedBlock listener on first event in waitForBlockProcessed