### PR TITLE
SSZ types for p2p spec

### DIFF
--- a/packages/lodestar-types/src/ssz/constants.ts
+++ b/packages/lodestar-types/src/ssz/constants.ts
@@ -1,3 +1,5 @@
 export const DEPOSIT_CONTRACT_TREE_DEPTH = 2 ** 5; // 32
 export const JUSTIFICATION_BITS_LENGTH = 4;
 export const ATTESTATION_SUBNET_COUNT = 64;
+export const MAX_REQUEST_BLOCKS = 2 ** 10; // 1024
+export const P2P_ERROR_MESSAGE_MAX_LENGTH = 256;

--- a/packages/lodestar-types/src/ssz/generators/wire.ts
+++ b/packages/lodestar-types/src/ssz/generators/wire.ts
@@ -5,6 +5,7 @@
 import {ContainerType, BigIntUintType, ListType} from "@chainsafe/ssz";
 
 import {IBeaconSSZTypes} from "../interface";
+import {MAX_REQUEST_BLOCKS, P2P_ERROR_MESSAGE_MAX_LENGTH} from "..";
 
 export const Status = (ssz: IBeaconSSZTypes): ContainerType => new ContainerType({
   fields: {
@@ -37,5 +38,10 @@ export const BeaconBlocksByRangeRequest = (ssz: IBeaconSSZTypes): ContainerType 
 
 export const BeaconBlocksByRootRequest = (ssz: IBeaconSSZTypes): ListType => new ListType({
   elementType: ssz.Root,
-  limit: 32000,
+  limit: MAX_REQUEST_BLOCKS,
+});
+
+export const P2pErrorMessage = (ssz: IBeaconSSZTypes): ListType => new ListType({
+  elementType: ssz.Uint8,
+  limit: P2P_ERROR_MESSAGE_MAX_LENGTH,
 });

--- a/packages/lodestar-types/src/ssz/interface.ts
+++ b/packages/lodestar-types/src/ssz/interface.ts
@@ -82,6 +82,7 @@ export interface IBeaconSSZTypes {
   Metadata: ContainerType<t.Metadata>;
   BeaconBlocksByRangeRequest: ContainerType<t.BeaconBlocksByRangeRequest>;
   BeaconBlocksByRootRequest: ContainerType<t.BeaconBlocksByRootRequest>;
+  P2pErrorMessage: ListType<t.P2pErrorMessage>;
   //api
   SubscribeToCommitteeSubnetPayload: ContainerType<t.SubscribeToCommitteeSubnetPayload>;
   ForkResponse: ContainerType<t.ForkResponse>;
@@ -157,6 +158,7 @@ export const typeNames: (keyof IBeaconSSZTypes)[] = [
   "Metadata",
   "BeaconBlocksByRangeRequest",
   "BeaconBlocksByRootRequest",
+  "P2pErrorMessage",
   //api
   "SubscribeToCommitteeSubnetPayload",
   "ForkResponse",

--- a/packages/lodestar-types/src/types/wire.ts
+++ b/packages/lodestar-types/src/types/wire.ts
@@ -2,7 +2,7 @@
 import {List} from "@chainsafe/ssz";
 
 import {
-  Slot, Epoch, Root, Number64, Uint64, ForkDigest,
+  Slot, Epoch, Root, Number64, Uint64, ForkDigest, Uint8
 } from "./primitive";
 import {SignedBeaconBlock} from "./block";
 import {AttestationSubnets} from "./misc";
@@ -21,7 +21,8 @@ export type ResponseBody =
   Goodbye |
   Ping |
   Metadata |
-  SignedBeaconBlock;
+  SignedBeaconBlock |
+  P2pErrorMessage;
 
 export interface Status {
   forkDigest: ForkDigest;
@@ -47,3 +48,5 @@ export interface BeaconBlocksByRangeRequest {
 }
 
 export type BeaconBlocksByRootRequest = List<Root>;
+
+export type P2pErrorMessage = List<Uint8>;

--- a/packages/lodestar/src/network/encoders/interface.ts
+++ b/packages/lodestar/src/network/encoders/interface.ts
@@ -11,8 +11,7 @@ export interface IResponseChunk {
 
   status: RpcResponseStatus;
 
-  //missing body if status !== 0
-  body?: ResponseBody;
+  body: ResponseBody;
 
 }
 

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -11,6 +11,7 @@ import {
   RequestBody,
   SignedBeaconBlock,
   Status,
+  MAX_REQUEST_BLOCKS,
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {GENESIS_EPOCH, Method, RequestId} from "../../constants";
@@ -176,6 +177,11 @@ export class BeaconReqRespHandler implements IReqRespHandler {
     request: BeaconBlocksByRangeRequest
   ): Promise<void> {
     try {
+      if (request.count > MAX_REQUEST_BLOCKS) {
+        this.logger.warn(`Request id ${id} asked for ${request.count} blocks, ` +
+          `just return ${MAX_REQUEST_BLOCKS} maximum`);
+        request.count = MAX_REQUEST_BLOCKS;
+      }
       const archiveBlocksStream = this.db.blockArchive.valuesStream({
         gte: request.startSlot,
         lt: request.startSlot + request.count * request.step,


### PR DESCRIPTION
resolves #997 

+ If p2p response an error, we want to return error message along with status code
+ New P2pErrorMessage ssz type for p2p error
+ `MAX_REQUEST_BLOCKS` for beacon_block_by_range is enforced by validating the request
+ `MAX_REQUEST_BLOCKS` for beacon_block_by_root is enforced by ssz max size validation