### PR TITLE
Build genesis state incrementally

### DIFF
--- a/packages/lodestar/src/chain/genesis/genesis.ts
+++ b/packages/lodestar/src/chain/genesis/genesis.ts
@@ -4,37 +4,29 @@
 
 import {TreeBacked, List, fromHexString} from "@chainsafe/ssz";
 import {
-  BeaconBlock,
-  BeaconBlockBody,
-  BeaconBlockHeader,
   BeaconState,
   Deposit,
-  Eth1Data,
   Number64,
   Bytes32,
-  Fork,
-  SignedBeaconBlock,
   Root,
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
 import {
-  EMPTY_SIGNATURE,
-  GENESIS_SLOT,
-  ZERO_HASH,
-} from "../../constants";
-import {
-  computeEpochAtSlot,
-  getActiveValidatorIndices,
   getTemporaryBlockHeader,
-  processDeposit,
 } from "@chainsafe/lodestar-beacon-state-transition";
-import {bigIntMin, ILogger} from "@chainsafe/lodestar-utils";
+import {ILogger} from "@chainsafe/lodestar-utils";
 import {IBeaconDb} from "../../db";
-import {IEth1Notifier, IDepositEvent} from "../../eth1";
+import {IEth1Notifier, Eth1Block, Eth1EventsBlock} from "../../eth1";
 import pipe from "it-pipe";
-import {ethers} from "ethers";
 import {IGenesisBuilder, IGenesisBuilderModules} from "./interface";
+import {
+  getGenesisBeaconState,
+  getEmptyBlock,
+  applyDeposits,
+  applyTimestamp,
+  applyEth1BlockHash,
+  isValidGenesisState} from "./util";
 
 export class GenesisBuilder implements IGenesisBuilder {
   private readonly config: IBeaconConfig;
@@ -43,7 +35,6 @@ export class GenesisBuilder implements IGenesisBuilder {
   private readonly logger: ILogger;
   private state: TreeBacked<BeaconState>;
   private depositTree: TreeBacked<List<Root>>;
-  private deposits: Deposit[];
 
   constructor(config: IBeaconConfig, {eth1, db, logger}: IGenesisBuilderModules) {
     this.state = getGenesisBeaconState(
@@ -59,56 +50,71 @@ export class GenesisBuilder implements IGenesisBuilder {
     this.eth1 = eth1;
     this.db = db;
     this.logger = logger;
-    this.deposits = [];
   }
 
   /**
    * Get eth1 deposit events and blocks and apply to this.state until we found genesis.
    */
-  public waitForGenesis = async (): Promise<TreeBacked<BeaconState>> => {
+  public async waitForGenesis(): Promise<TreeBacked<BeaconState>> {
     await this.initialize();
-    const eth1DataStream = await this.eth1.startProcessEth1Blocks(true);
-    return await pipe(eth1DataStream,
-      async (source: AsyncIterable<[IDepositEvent[], ethers.providers.Block]>) => {
-        for await (const data of source) {
-          const depositEvents = data[0];
-          const deposits = depositEvents.map((depositEvent) => {
-            this.depositTree.push(this.config.types.DepositData.hashTreeRoot(depositEvent));
+    const eth1DataStream = await this.eth1.getEth1BlockAndDepositEventsSource();
+    const state = await pipe(
+      eth1DataStream,
+      this.processDepositEvents(),
+      this.assembleGenesisState()
+    );
+    this.eth1.endEth1BlockAndDepositEventsSource();
+    return state;
+  }
+
+  private assembleGenesisState():
+  (source: AsyncIterable<[Deposit[], Eth1Block]>) => Promise<TreeBacked<BeaconState>> {
+    return async (source) => {
+      for await (const [deposits, block] of source) {
+        applyDeposits(this.config, this.state, deposits, this.depositTree);
+        if (!block) {
+          continue;
+        }
+        applyTimestamp(this.config, this.state, block.timestamp);
+        applyEth1BlockHash(this.config, this.state, fromHexString(block.hash));
+        const isValid = isValidGenesisState(this.config, this.state);
+        if (isValid) {
+          this.logger.info(`Found genesis state at eth1 block ${block.number}`);
+          return this.state;
+        }
+      }
+    };
+  }
+
+  private processDepositEvents():
+  (source: AsyncIterable<Eth1EventsBlock>) => AsyncGenerator<[Deposit[], Eth1Block]> {
+    return ((source) => {
+      const {depositTree, config} = this;
+      return async function * () {
+        for await (const {events, block} of source) {
+          const newDeposits: Deposit[] = events.map((depositEvent) => {
+            depositTree.push(config.types.DepositData.hashTreeRoot(depositEvent));
             return {
-              proof: this.depositTree.tree().getSingleProof(this.depositTree.gindexOfProperty(depositEvent.index)),
+              proof: depositTree.tree().getSingleProof(depositTree.gindexOfProperty(depositEvent.index)),
               data: depositEvent,
             };
           });
-          this.deposits.push(...deposits);
-          applyDeposits(this.config, this.state, this.deposits, this.depositTree);
-          const block = data[1];
-          if (!block) {
-            continue;
-          }
-          applyTimestamp(this.config, this.state, block.timestamp);
-          applyEth1BlockHash(this.config, this.state, fromHexString(block.hash));
-          const isValid = isValidGenesisState(this.config, this.state);
-          if (isValid) {
-            this.logger.info(`Found genesis state at eth1 block ${block.number}`);
-            this.eth1.unsubscribeEth1Blocks();
-            return this.state;
-          }
+          yield [newDeposits, block] as [Deposit[], Eth1Block];
         }
-      }
-    );
-  };
+      }();
+    });
+  }
 
   private async initialize(): Promise<void> {
     const depositDatas = await this.db.depositData.values() || [];
     const depositDataRoots = await this.db.depositDataRoot.values() || [];
-    const deposits = depositDatas.map((event, index) => {
+    depositDatas.map((event, index) => {
       this.depositTree.push(depositDataRoots[index]);
       return {
         proof: this.depositTree.tree().getSingleProof(this.depositTree.gindexOfProperty(index)),
         data: event,
       };
     });
-    this.deposits.push(...deposits);
   }
 
 }
@@ -146,157 +152,4 @@ export function initializeBeaconStateFromEth1(
   return state as TreeBacked<BeaconState>;
 }
 
-/**
- * Apply eth1 block hash to state.
- * @param config IBeaconConfig
- * @param state BeaconState
- * @param eth1BlockHash eth1 block hash
- */
-function applyEth1BlockHash(config: IBeaconConfig, state: BeaconState, eth1BlockHash: Bytes32): void {
-  state.eth1Data.blockHash = eth1BlockHash;
-  state.randaoMixes = Array<Bytes32>(config.params.EPOCHS_PER_HISTORICAL_VECTOR).fill(eth1BlockHash);
-}
 
-/**
- * Apply eth1 block timestamp to state.
- * @param config IBeaconState
- * @param state BeaconState
- * @param eth1Timestamp eth1 block timestamp
- */
-function applyTimestamp(config: IBeaconConfig, state: BeaconState, eth1Timestamp: number): void {
-  state.genesisTime =
-    eth1Timestamp - eth1Timestamp % config.params.MIN_GENESIS_DELAY + 2 * config.params.MIN_GENESIS_DELAY;
-}
-
-/**
- * Apply deposits to state.
- * @param config IBeaconConfig
- * @param state BeaconState
- * @param deposits full list of deposits
- */
-function applyDeposits(
-  config: IBeaconConfig,
-  state: BeaconState,
-  deposits: Deposit[],
-  fullDepositDataRootList?: TreeBacked<List<Root>>
-): void {
-  state.eth1Data.depositCount = deposits.length;
-  const leaves = deposits.map((deposit) => deposit.data);
-  const depositDataRootList: Root[] = [];
-  deposits.forEach((deposit, index) => {
-    if (fullDepositDataRootList) {
-      depositDataRootList.push(fullDepositDataRootList[index]);
-    }
-    if (index >= state.eth1DepositIndex) {
-      if (fullDepositDataRootList) {
-        state.eth1Data.depositRoot = config.types.DepositDataRootList.hashTreeRoot(depositDataRootList);
-      } else {
-        const depositDataList = leaves.slice(0, index + 1);
-        state.eth1Data.depositRoot = config.types.DepositDataRootList.hashTreeRoot(
-          depositDataList.map((d) => config.types.DepositData.hashTreeRoot(d))
-        );
-      }
-      processDeposit(config, state, deposit);
-    }
-  });
-
-  // Process activations
-  state.validators.forEach((validator, index) => {
-    const balance = state.balances[index];
-    validator.effectiveBalance = bigIntMin(
-      balance - (balance % config.params.EFFECTIVE_BALANCE_INCREMENT),
-      config.params.MAX_EFFECTIVE_BALANCE
-    );
-    if(validator.effectiveBalance === config.params.MAX_EFFECTIVE_BALANCE) {
-      validator.activationEligibilityEpoch = computeEpochAtSlot(config, GENESIS_SLOT);
-      validator.activationEpoch = computeEpochAtSlot(config, GENESIS_SLOT);
-    }
-  });
-
-  // Set genesis validators root for domain separation and chain versioning
-  state.genesisValidatorsRoot = config.types.BeaconState.fields.validators.hashTreeRoot(state.validators);
-
-}
-
-export function isValidGenesisState(config: IBeaconConfig, state: BeaconState): boolean {
-  if(state.genesisTime < config.params.MIN_GENESIS_TIME) {
-    return false;
-  }
-  return getActiveValidatorIndices(state, computeEpochAtSlot(config, GENESIS_SLOT)).length
-      >=
-      config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT;
-
-}
-
-/**
- * Generate the initial beacon chain state.
- */
-function getGenesisBeaconState(
-  config: IBeaconConfig,
-  genesisEth1Data: Eth1Data,
-  latestBlockHeader: BeaconBlockHeader
-): TreeBacked<BeaconState> {
-  // Seed RANDAO with Eth1 entropy
-  const randaoMixes = Array<Bytes32>(config.params.EPOCHS_PER_HISTORICAL_VECTOR).fill(genesisEth1Data.blockHash);
-
-  const state: BeaconState = config.types.BeaconState.tree.defaultValue();
-  // MISC
-  state.slot = GENESIS_SLOT;
-  state.fork = {
-    previousVersion: config.params.GENESIS_FORK_VERSION,
-    currentVersion: config.params.GENESIS_FORK_VERSION,
-    epoch: computeEpochAtSlot(config, GENESIS_SLOT),
-  } as Fork;
-
-  // Validator registry
-
-  // Randomness and committees
-  state.latestBlockHeader = latestBlockHeader;
-
-  // Ethereum 1.0 chain data
-  state.eth1Data = genesisEth1Data;
-  state.randaoMixes = randaoMixes;
-
-  return state as TreeBacked<BeaconState>;
-}
-
-export function getEmptyBlockBody(): BeaconBlockBody {
-  return {
-    randaoReveal: EMPTY_SIGNATURE,
-    eth1Data: {
-      depositRoot: ZERO_HASH,
-      depositCount: 0,
-      blockHash: ZERO_HASH,
-    },
-    graffiti: ZERO_HASH,
-    proposerSlashings: [],
-    attesterSlashings: [],
-    attestations: [],
-    deposits: [],
-    voluntaryExits: [],
-  };
-}
-
-/**
- * Get an empty [[BeaconBlock]].
- */
-export function getEmptySignedBlock(): SignedBeaconBlock {
-  const block = getEmptyBlock();
-  return {
-    message: block,
-    signature: Buffer.alloc(96),
-  };
-}
-
-/**
- * Get an empty [[BeaconBlock]].
- */
-export function getEmptyBlock(): BeaconBlock {
-  return {
-    slot: GENESIS_SLOT,
-    proposerIndex: 0,
-    parentRoot: ZERO_HASH,
-    stateRoot: ZERO_HASH,
-    body: getEmptyBlockBody(),
-  };
-}

--- a/packages/lodestar/src/chain/genesis/genesis.ts
+++ b/packages/lodestar/src/chain/genesis/genesis.ts
@@ -133,11 +133,7 @@ export function initializeBeaconStateFromEth1(
   deposits: Deposit[]): TreeBacked<BeaconState> {
   const state = getGenesisBeaconState(
     config,
-    {
-      depositCount: deposits.length,
-      depositRoot: new Uint8Array(32),
-      blockHash: eth1BlockHash
-    },
+    config.types.Eth1Data.defaultValue(),
     getTemporaryBlockHeader(
       config,
       getEmptyBlock()
@@ -145,6 +141,7 @@ export function initializeBeaconStateFromEth1(
   );
 
   applyTimestamp(config, state, eth1Timestamp);
+  applyEth1BlockHash(config, state, eth1BlockHash);
 
   // Process deposits
   applyDeposits(config, state, deposits);

--- a/packages/lodestar/src/chain/genesis/genesis.ts
+++ b/packages/lodestar/src/chain/genesis/genesis.ts
@@ -2,7 +2,7 @@
  * @module chain/genesis
  */
 
-import {TreeBacked} from "@chainsafe/ssz";
+import {TreeBacked, List, fromHexString} from "@chainsafe/ssz";
 import {
   BeaconBlock,
   BeaconBlockBody,
@@ -14,6 +14,7 @@ import {
   Bytes32,
   Fork,
   SignedBeaconBlock,
+  Root,
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
@@ -28,8 +29,97 @@ import {
   getTemporaryBlockHeader,
   processDeposit,
 } from "@chainsafe/lodestar-beacon-state-transition";
-import {bigIntMin} from "@chainsafe/lodestar-utils";
+import {bigIntMin, ILogger} from "@chainsafe/lodestar-utils";
+import {IBeaconDb} from "../../db";
+import {IEth1Notifier, IDepositEvent} from "../../eth1";
+import pipe from "it-pipe";
+import {ethers} from "ethers";
+import {IGenesisBuilder, IGenesisBuilderModules} from "./interface";
 
+export class GenesisBuilder implements IGenesisBuilder {
+  private readonly config: IBeaconConfig;
+  private readonly db: IBeaconDb;
+  private readonly eth1: IEth1Notifier;
+  private readonly logger: ILogger;
+  private state: TreeBacked<BeaconState>;
+  private depositTree: TreeBacked<List<Root>>;
+  private deposits: Deposit[];
+
+  constructor(config: IBeaconConfig, {eth1, db, logger}: IGenesisBuilderModules) {
+    this.state = getGenesisBeaconState(
+      config,
+      config.types.Eth1Data.defaultValue(),
+      getTemporaryBlockHeader(
+        config,
+        getEmptyBlock()
+      )
+    );
+    this.depositTree = config.types.DepositDataRootList.tree.defaultValue();
+    this.config = config;
+    this.eth1 = eth1;
+    this.db = db;
+    this.logger = logger;
+    this.deposits = [];
+  }
+
+  /**
+   * Get eth1 deposit events and blocks and apply to this.state until we found genesis.
+   */
+  public waitForGenesis = async (): Promise<TreeBacked<BeaconState>> => {
+    await this.initialize();
+    const eth1DataStream = await this.eth1.startProcessEth1Blocks(true);
+    return await pipe(eth1DataStream,
+      async (source: AsyncIterable<[IDepositEvent[], ethers.providers.Block]>) => {
+        for await (const data of source) {
+          const depositEvents = data[0];
+          const deposits = depositEvents.map((depositEvent) => {
+            this.depositTree.push(this.config.types.DepositData.hashTreeRoot(depositEvent));
+            return {
+              proof: this.depositTree.tree().getSingleProof(this.depositTree.gindexOfProperty(depositEvent.index)),
+              data: depositEvent,
+            };
+          });
+          this.deposits.push(...deposits);
+          applyDeposits(this.config, this.state, this.deposits, this.depositTree);
+          const block = data[1];
+          if (!block) {
+            continue;
+          }
+          applyTimestamp(this.config, this.state, block.timestamp);
+          applyEth1BlockHash(this.config, this.state, fromHexString(block.hash));
+          const isValid = isValidGenesisState(this.config, this.state);
+          if (isValid) {
+            this.logger.info(`Found genesis state at eth1 block ${block.number}`);
+            this.eth1.unsubscribeEth1Blocks();
+            return this.state;
+          }
+        }
+      }
+    );
+  };
+
+  private async initialize(): Promise<void> {
+    const depositDatas = await this.db.depositData.values() || [];
+    const depositDataRoots = await this.db.depositDataRoot.values() || [];
+    const deposits = depositDatas.map((event, index) => {
+      this.depositTree.push(depositDataRoots[index]);
+      return {
+        proof: this.depositTree.tree().getSingleProof(this.depositTree.gindexOfProperty(index)),
+        data: event,
+      };
+    });
+    this.deposits.push(...deposits);
+  }
+
+}
+
+/**
+ * Mainly used for spec test.
+ * @param config
+ * @param eth1BlockHash
+ * @param eth1Timestamp
+ * @param deposits
+ */
 export function initializeBeaconStateFromEth1(
   config: IBeaconConfig,
   eth1BlockHash: Bytes32,
@@ -37,7 +127,6 @@ export function initializeBeaconStateFromEth1(
   deposits: Deposit[]): TreeBacked<BeaconState> {
   const state = getGenesisBeaconState(
     config,
-    eth1Timestamp - eth1Timestamp % config.params.MIN_GENESIS_DELAY + 2 * config.params.MIN_GENESIS_DELAY,
     {
       depositCount: deposits.length,
       depositRoot: new Uint8Array(32),
@@ -49,14 +138,66 @@ export function initializeBeaconStateFromEth1(
     )
   );
 
+  applyTimestamp(config, state, eth1Timestamp);
+
   // Process deposits
+  applyDeposits(config, state, deposits);
+
+  return state as TreeBacked<BeaconState>;
+}
+
+/**
+ * Apply eth1 block hash to state.
+ * @param config IBeaconConfig
+ * @param state BeaconState
+ * @param eth1BlockHash eth1 block hash
+ */
+function applyEth1BlockHash(config: IBeaconConfig, state: BeaconState, eth1BlockHash: Bytes32): void {
+  state.eth1Data.blockHash = eth1BlockHash;
+  state.randaoMixes = Array<Bytes32>(config.params.EPOCHS_PER_HISTORICAL_VECTOR).fill(eth1BlockHash);
+}
+
+/**
+ * Apply eth1 block timestamp to state.
+ * @param config IBeaconState
+ * @param state BeaconState
+ * @param eth1Timestamp eth1 block timestamp
+ */
+function applyTimestamp(config: IBeaconConfig, state: BeaconState, eth1Timestamp: number): void {
+  state.genesisTime =
+    eth1Timestamp - eth1Timestamp % config.params.MIN_GENESIS_DELAY + 2 * config.params.MIN_GENESIS_DELAY;
+}
+
+/**
+ * Apply deposits to state.
+ * @param config IBeaconConfig
+ * @param state BeaconState
+ * @param deposits full list of deposits
+ */
+function applyDeposits(
+  config: IBeaconConfig,
+  state: BeaconState,
+  deposits: Deposit[],
+  fullDepositDataRootList?: TreeBacked<List<Root>>
+): void {
+  state.eth1Data.depositCount = deposits.length;
   const leaves = deposits.map((deposit) => deposit.data);
+  const depositDataRootList: Root[] = [];
   deposits.forEach((deposit, index) => {
-    const depositDataList = leaves.slice(0, index + 1);
-    state.eth1Data.depositRoot = config.types.DepositDataRootList.hashTreeRoot(
-      depositDataList.map((d) => config.types.DepositData.hashTreeRoot(d))
-    );
-    processDeposit(config, state, deposit);
+    if (fullDepositDataRootList) {
+      depositDataRootList.push(fullDepositDataRootList[index]);
+    }
+    if (index >= state.eth1DepositIndex) {
+      if (fullDepositDataRootList) {
+        state.eth1Data.depositRoot = config.types.DepositDataRootList.hashTreeRoot(depositDataRootList);
+      } else {
+        const depositDataList = leaves.slice(0, index + 1);
+        state.eth1Data.depositRoot = config.types.DepositDataRootList.hashTreeRoot(
+          depositDataList.map((d) => config.types.DepositData.hashTreeRoot(d))
+        );
+      }
+      processDeposit(config, state, deposit);
+    }
   });
 
   // Process activations
@@ -75,7 +216,6 @@ export function initializeBeaconStateFromEth1(
   // Set genesis validators root for domain separation and chain versioning
   state.genesisValidatorsRoot = config.types.BeaconState.fields.validators.hashTreeRoot(state.validators);
 
-  return state as TreeBacked<BeaconState>;
 }
 
 export function isValidGenesisState(config: IBeaconConfig, state: BeaconState): boolean {
@@ -91,19 +231,17 @@ export function isValidGenesisState(config: IBeaconConfig, state: BeaconState): 
 /**
  * Generate the initial beacon chain state.
  */
-export function getGenesisBeaconState(
+function getGenesisBeaconState(
   config: IBeaconConfig,
-  genesisTime: Number64,
   genesisEth1Data: Eth1Data,
   latestBlockHeader: BeaconBlockHeader
-): BeaconState {
+): TreeBacked<BeaconState> {
   // Seed RANDAO with Eth1 entropy
   const randaoMixes = Array<Bytes32>(config.params.EPOCHS_PER_HISTORICAL_VECTOR).fill(genesisEth1Data.blockHash);
 
   const state: BeaconState = config.types.BeaconState.tree.defaultValue();
   // MISC
   state.slot = GENESIS_SLOT;
-  state.genesisTime = genesisTime;
   state.fork = {
     previousVersion: config.params.GENESIS_FORK_VERSION,
     currentVersion: config.params.GENESIS_FORK_VERSION,
@@ -119,7 +257,7 @@ export function getGenesisBeaconState(
   state.eth1Data = genesisEth1Data;
   state.randaoMixes = randaoMixes;
 
-  return state;
+  return state as TreeBacked<BeaconState>;
 }
 
 export function getEmptyBlockBody(): BeaconBlockBody {

--- a/packages/lodestar/src/chain/genesis/interface.ts
+++ b/packages/lodestar/src/chain/genesis/interface.ts
@@ -1,0 +1,15 @@
+import {IBeaconDb} from "../../db";
+import {IEth1Notifier} from "../../eth1";
+import {ILogger} from "@chainsafe/lodestar-utils";
+import {TreeBacked} from "@chainsafe/ssz";
+import {BeaconState} from "@chainsafe/lodestar-types";
+
+export interface IGenesisBuilderModules {
+  db: IBeaconDb;
+  eth1: IEth1Notifier;
+  logger: ILogger;
+}
+
+export interface IGenesisBuilder {
+  waitForGenesis: () => Promise<TreeBacked<BeaconState>>;
+}

--- a/packages/lodestar/src/chain/genesis/util.ts
+++ b/packages/lodestar/src/chain/genesis/util.ts
@@ -1,0 +1,190 @@
+/**
+ * @module chain/genesis
+ */
+
+import {TreeBacked, List} from "@chainsafe/ssz";
+import {
+  BeaconBlock,
+  BeaconBlockBody,
+  BeaconBlockHeader,
+  BeaconState,
+  Deposit,
+  Eth1Data,
+  Bytes32,
+  Fork,
+  SignedBeaconBlock,
+  Root,
+  DepositData,
+} from "@chainsafe/lodestar-types";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+
+import {
+  EMPTY_SIGNATURE,
+  GENESIS_SLOT,
+  ZERO_HASH,
+} from "../../constants";
+import {
+  computeEpochAtSlot,
+  getActiveValidatorIndices,
+  processDeposit,
+} from "@chainsafe/lodestar-beacon-state-transition";
+import {bigIntMin} from "@chainsafe/lodestar-utils";
+
+/**
+ * Apply eth1 block hash to state.
+ * @param config IBeaconConfig
+ * @param state BeaconState
+ * @param eth1BlockHash eth1 block hash
+ */
+export function applyEth1BlockHash(config: IBeaconConfig, state: BeaconState, eth1BlockHash: Bytes32): void {
+  state.eth1Data.blockHash = eth1BlockHash;
+  state.randaoMixes = Array<Bytes32>(config.params.EPOCHS_PER_HISTORICAL_VECTOR).fill(eth1BlockHash);
+}
+
+/**
+ * Apply eth1 block timestamp to state.
+ * @param config IBeaconState
+ * @param state BeaconState
+ * @param eth1Timestamp eth1 block timestamp
+ */
+export function applyTimestamp(config: IBeaconConfig, state: BeaconState, eth1Timestamp: number): void {
+  state.genesisTime =
+    eth1Timestamp - eth1Timestamp % config.params.MIN_GENESIS_DELAY + 2 * config.params.MIN_GENESIS_DELAY;
+}
+
+/**
+ * Apply deposits to state.
+ * For spec test, fullDepositDataRootList is undefined.
+ * For genesis builder, fullDepositDataRootList is full list of deposit data root from index 0.
+ * @param config IBeaconConfig
+ * @param state BeaconState
+ * @param newDeposits new deposits
+ * @param fullDepositDataRootList full list of deposit data root from index 0
+ */
+export function applyDeposits(
+  config: IBeaconConfig,
+  state: BeaconState,
+  newDeposits: Deposit[],
+  fullDepositDataRootList?: TreeBacked<List<Root>>
+): void {
+  let depositDatas: DepositData[];
+  const depositDataRootList: Root[] = [];
+  if (fullDepositDataRootList) {
+    for (let index = 0; index < state.eth1Data.depositCount; index++) {
+      depositDataRootList.push(fullDepositDataRootList[index]);
+    }
+  } else {
+    depositDatas = newDeposits.map((deposit) => deposit.data);
+  }
+  newDeposits.forEach((deposit, index) => {
+    if (fullDepositDataRootList) {
+      depositDataRootList.push(fullDepositDataRootList[index + depositDataRootList.length]);
+      state.eth1Data.depositRoot = config.types.DepositDataRootList.hashTreeRoot(depositDataRootList);
+    } else {
+      const depositDataList = depositDatas.slice(0, index + 1);
+      state.eth1Data.depositRoot = config.types.DepositDataRootList.hashTreeRoot(
+        depositDataList.map((d) => config.types.DepositData.hashTreeRoot(d))
+      );
+    }
+    state.eth1Data.depositCount += 1;
+    processDeposit(config, state, deposit);
+  });
+
+  // Process activations
+  state.validators.forEach((validator, index) => {
+    const balance = state.balances[index];
+    validator.effectiveBalance = bigIntMin(
+      balance - (balance % config.params.EFFECTIVE_BALANCE_INCREMENT),
+      config.params.MAX_EFFECTIVE_BALANCE
+    );
+    if(validator.effectiveBalance === config.params.MAX_EFFECTIVE_BALANCE) {
+      validator.activationEligibilityEpoch = computeEpochAtSlot(config, GENESIS_SLOT);
+      validator.activationEpoch = computeEpochAtSlot(config, GENESIS_SLOT);
+    }
+  });
+
+  // Set genesis validators root for domain separation and chain versioning
+  state.genesisValidatorsRoot = config.types.BeaconState.fields.validators.hashTreeRoot(state.validators);
+}
+
+export function isValidGenesisState(config: IBeaconConfig, state: BeaconState): boolean {
+  if(state.genesisTime < config.params.MIN_GENESIS_TIME) {
+    return false;
+  }
+  return getActiveValidatorIndices(state, computeEpochAtSlot(config, GENESIS_SLOT)).length
+      >=
+      config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT;
+}
+
+/**
+ * Generate the initial beacon chain state.
+ */
+export function getGenesisBeaconState(
+  config: IBeaconConfig,
+  genesisEth1Data: Eth1Data,
+  latestBlockHeader: BeaconBlockHeader
+): TreeBacked<BeaconState> {
+  // Seed RANDAO with Eth1 entropy
+  const randaoMixes = Array<Bytes32>(config.params.EPOCHS_PER_HISTORICAL_VECTOR).fill(genesisEth1Data.blockHash);
+
+  const state: BeaconState = config.types.BeaconState.tree.defaultValue();
+  // MISC
+  state.slot = GENESIS_SLOT;
+  state.fork = {
+    previousVersion: config.params.GENESIS_FORK_VERSION,
+    currentVersion: config.params.GENESIS_FORK_VERSION,
+    epoch: computeEpochAtSlot(config, GENESIS_SLOT),
+  } as Fork;
+
+  // Validator registry
+
+  // Randomness and committees
+  state.latestBlockHeader = latestBlockHeader;
+
+  // Ethereum 1.0 chain data
+  state.eth1Data = genesisEth1Data;
+  state.randaoMixes = randaoMixes;
+
+  return state as TreeBacked<BeaconState>;
+}
+
+export function getEmptyBlockBody(): BeaconBlockBody {
+  return {
+    randaoReveal: EMPTY_SIGNATURE,
+    eth1Data: {
+      depositRoot: ZERO_HASH,
+      depositCount: 0,
+      blockHash: ZERO_HASH,
+    },
+    graffiti: ZERO_HASH,
+    proposerSlashings: [],
+    attesterSlashings: [],
+    attestations: [],
+    deposits: [],
+    voluntaryExits: [],
+  };
+}
+
+/**
+ * Get an empty [[BeaconBlock]].
+ */
+export function getEmptySignedBlock(): SignedBeaconBlock {
+  const block = getEmptyBlock();
+  return {
+    message: block,
+    signature: Buffer.alloc(96),
+  };
+}
+
+/**
+ * Get an empty [[BeaconBlock]].
+ */
+export function getEmptyBlock(): BeaconBlock {
+  return {
+    slot: GENESIS_SLOT,
+    proposerIndex: 0,
+    parentRoot: ZERO_HASH,
+    stateRoot: ZERO_HASH,
+    body: getEmptyBlockBody(),
+  };
+}

--- a/packages/lodestar/src/chain/genesis/util.ts
+++ b/packages/lodestar/src/chain/genesis/util.ts
@@ -67,15 +67,14 @@ export function applyDeposits(
   newDeposits: Deposit[],
   fullDepositDataRootList?: TreeBacked<List<Root>>
 ): void {
-  let depositDatas: DepositData[];
+
   const depositDataRootList: Root[] = [];
   if (fullDepositDataRootList) {
     for (let index = 0; index < state.eth1Data.depositCount; index++) {
       depositDataRootList.push(fullDepositDataRootList[index]);
     }
-  } else {
-    depositDatas = newDeposits.map((deposit) => deposit.data);
   }
+  const depositDatas: DepositData[] = fullDepositDataRootList? null : newDeposits.map((deposit) => deposit.data);
   newDeposits.forEach((deposit, index) => {
     if (fullDepositDataRootList) {
       depositDataRootList.push(fullDepositDataRootList[index + depositDataRootList.length]);
@@ -93,10 +92,8 @@ export function applyDeposits(
   // Process activations
   state.validators.forEach((validator, index) => {
     const balance = state.balances[index];
-    validator.effectiveBalance = bigIntMin(
-      balance - (balance % config.params.EFFECTIVE_BALANCE_INCREMENT),
-      config.params.MAX_EFFECTIVE_BALANCE
-    );
+    validator.effectiveBalance = bigIntMin(balance - (balance % config.params.EFFECTIVE_BALANCE_INCREMENT),
+      config.params.MAX_EFFECTIVE_BALANCE);
     if(validator.effectiveBalance === config.params.MAX_EFFECTIVE_BALANCE) {
       validator.activationEligibilityEpoch = computeEpochAtSlot(config, GENESIS_SLOT);
       validator.activationEpoch = computeEpochAtSlot(config, GENESIS_SLOT);

--- a/packages/lodestar/src/eth1/impl/ethers.ts
+++ b/packages/lodestar/src/eth1/impl/ethers.ts
@@ -2,7 +2,6 @@
  * @module eth1
  */
 
-import {EventEmitter} from "events";
 import {Contract, ethers} from "ethers";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
@@ -12,8 +11,9 @@ import {isValidAddress} from "../../util/address";
 import {IBeaconDb} from "../../db";
 import {RetryProvider} from "./retryProvider";
 import {IEth1Options} from "../options";
-import {Eth1EventEmitter, IEth1Notifier, IDepositEvent} from "../interface";
+import {IEth1Notifier, IDepositEvent} from "../interface";
 import {groupDepositEventsByBlock} from "./util";
+import pushable, {Pushable} from "it-pushable";
 
 export interface IEthersEth1Options extends IEth1Options {
   contract?: Contract;
@@ -33,7 +33,7 @@ const ETH1_BLOCK_RETRY = 3;
  * It proceses eth1 blocks, starting from block number `depositContract.deployedAt`, maintaining a follow distance.
  * It stores deposit events and eth1 data in a IBeaconDb resumes processing from the last stored eth1 data
  */
-export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitter }) implements IEth1Notifier {
+export class EthersEth1Notifier implements IEth1Notifier {
 
   private opts: IEthersEth1Options;
 
@@ -44,11 +44,11 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
   private db: IBeaconDb;
   private logger: ILogger;
 
-  private started: boolean;
+  private startedProcessEth1: boolean;
   private lastProcessedEth1BlockNumber: number;
+  private eth1Source: Pushable<[IDepositEvent[], ethers.providers.Block]>;
 
   public constructor(opts: IEthersEth1Options, {config, db, logger}: IEthersEth1Modules) {
-    super();
     this.opts = opts;
     this.config = config;
     this.db = db;
@@ -70,11 +70,10 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
       this.logger.verbose("Eth1 notifier is disabled" );
       return;
     }
-    if (this.started) {
+    if (this.startedProcessEth1) {
       this.logger.verbose("Eth1 notifier already started" );
       return;
     }
-    this.started = true;
     if(!this.contract) {
       await this.initContract();
     }
@@ -86,24 +85,49 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
     this.logger.verbose(
       `Last processed block number: ${this.lastProcessedEth1BlockNumber}`
     );
-    const headBlockNumber = await this.provider.getBlockNumber();
-    // process historical unprocessed blocks up to curent head
-    // then start listening for incoming blocks
-    this.processBlocks(headBlockNumber - this.config.params.ETH1_FOLLOW_DISTANCE).then(() => {
-      if(this.started) {
-        this.provider.on("block", this.onNewEth1Block.bind(this));
-      }
-    });
+
   }
 
   public async stop(): Promise<void> {
-    if (!this.started) {
-      this.logger.verbose("Eth1 notifier already stopped");
+    this.provider.removeAllListeners("block");
+    // stop processing eth1
+    this.startedProcessEth1 = false;
+    this.logger.verbose("Eth1 notifier stopped");
+  }
+
+  /**
+   * This is triggered when building genesis or after chain gets started.
+   * @param subscribe true for genesis builder
+   * @returns a pushable for genesis builder, null otherwise.
+   */
+  public async startProcessEth1Blocks(subscribe = false): Promise<Pushable<[IDepositEvent[], ethers.providers.Block]>> {
+    if (this.startedProcessEth1) {
+      this.logger.info("Started processing eth1 blocks already");
       return;
     }
-    this.provider.removeAllListeners("block");
-    this.started = false;
-    this.logger.verbose("Eth1 notifier stopped");
+    const headBlockNumber = await this.provider.getBlockNumber();
+    // process historical unprocessed blocks up to curent head
+    // then start listening for incoming blocks
+    if (subscribe) {
+      this.eth1Source = pushable<[IDepositEvent[], ethers.providers.Block]>();
+    }
+    this.processBlocks(headBlockNumber - this.config.params.ETH1_FOLLOW_DISTANCE).then(() => {
+      if(this.startedProcessEth1) {
+        this.provider.on("block", this.onNewEth1Block.bind(this));
+      }
+    });
+    this.startedProcessEth1 = true;
+    return this.eth1Source;
+  }
+
+  /**
+   * Unsubscribe to eth1 events + blocks
+   */
+  public unsubscribeEth1Blocks(): void {
+    if (this.eth1Source) {
+      this.eth1Source.end();
+      this.eth1Source = null;
+    }
   }
 
   public async getLastProcessedBlockTag(): Promise<string | number> {
@@ -128,7 +152,7 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
    */
   public async processBlocks(toNumber: number): Promise<void> {
     let rangeBlockNumber = this.lastProcessedEth1BlockNumber;
-    while (rangeBlockNumber < toNumber && this.started) {
+    while (rangeBlockNumber < toNumber && this.startedProcessEth1) {
       const blockNumber = Math.min(this.lastProcessedEth1BlockNumber + 100, toNumber);
       let rangeDepositEvents;
       try {
@@ -161,7 +185,7 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
    * Returns true if processing was successful
    */
   public async processDepositEvents(blockNumber: number, blockDepositEvents: IDepositEvent[]): Promise<boolean> {
-    if (!this.started) {
+    if (!this.startedProcessEth1) {
       this.logger.verbose("Eth1 notifier must be started to process a block");
       return false;
     }
@@ -181,7 +205,15 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
     ]);
     const depositCount = blockDepositEvents[blockDepositEvents.length - 1].index + 1;
     if (depositCount >= this.config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT) {
-      return await this.processEth1Data(blockNumber, blockDepositEvents);
+      const block = await this.getBlock(blockNumber);
+      if (!block) {
+        this.logger.verbose(`eth1 block ${blockNumber} not found`);
+        return false;
+      }
+      this.eth1Source && this.eth1Source.push([blockDepositEvents, block]);
+      return await this.processEth1Data(block, blockDepositEvents);
+    } else {
+      this.eth1Source && this.eth1Source.push([blockDepositEvents, null]);
     }
     return true;
   }
@@ -192,14 +224,12 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
    * @param blockDepositEvents
    * @returns true if success
    */
-  public async processEth1Data(blockNumber: number, blockDepositEvents: IDepositEvent[]): Promise<boolean> {
-    this.logger.verbose(`Processing proposing data of eth1 block ${blockNumber}`);
-    const block = await this.getBlock(blockNumber);
-
-    if (!block) {
-      this.logger.verbose(`eth1 block ${blockNumber} not found`);
+  public async processEth1Data(block: ethers.providers.Block, blockDepositEvents: IDepositEvent[]): Promise<boolean> {
+    if (!this.startedProcessEth1) {
+      this.logger.verbose("Eth1 notifier must be started to process a block");
       return false;
     }
+    this.logger.verbose(`Processing proposing data of eth1 block ${block.number}`);
     const depositTree = await this.db.depositDataRoot.getTreeBacked(blockDepositEvents[0].index - 1);
     const depositCount = blockDepositEvents[blockDepositEvents.length - 1].index + 1;
     const eth1Data = {
@@ -209,12 +239,7 @@ export class EthersEth1Notifier extends (EventEmitter as { new(): Eth1EventEmitt
     };
     // eth1 data
     await this.db.eth1Data.put(block.timestamp, eth1Data);
-    this.lastProcessedEth1BlockNumber = blockNumber;
-    // emit events
-    blockDepositEvents.forEach((depositEvent) => {
-      this.emit("deposit", depositEvent.index, depositEvent);
-    });
-    this.emit("eth1Data", block.timestamp, eth1Data, blockNumber);
+    this.lastProcessedEth1BlockNumber = block.number;
     return true;
   }
 

--- a/packages/lodestar/src/eth1/impl/interop.ts
+++ b/packages/lodestar/src/eth1/impl/interop.ts
@@ -19,7 +19,7 @@ export class InteropEth1Notifier extends EventEmitter implements IEth1Notifier {
   Promise<Pushable<[IDepositEvent[], ethers.providers.Block]>> {
     return null;
   }
-  public unsubscribeEth1Blocks(): void {}
+  public async unsubscribeEth1Blocks(): Promise<void> {}
 
   public async getDepositRoot(): Promise<Uint8Array> {
     return Buffer.alloc(32);

--- a/packages/lodestar/src/eth1/impl/interop.ts
+++ b/packages/lodestar/src/eth1/impl/interop.ts
@@ -2,11 +2,10 @@
 import {EventEmitter} from "events";
 import {ethers} from "ethers";
 
-import {hash} from "@chainsafe/ssz";
-import {Eth1Data, DepositData} from "@chainsafe/lodestar-types";
-import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {Eth1Data} from "@chainsafe/lodestar-types";
 
 import {IEth1Notifier, IDepositEvent} from "../interface";
+import {Pushable} from "it-pushable";
 
 export class InteropEth1Notifier extends EventEmitter implements IEth1Notifier {
   public constructor() {
@@ -15,6 +14,12 @@ export class InteropEth1Notifier extends EventEmitter implements IEth1Notifier {
 
   public async start(): Promise<void> {}
   public async stop(): Promise<void> {}
+
+  public async startProcessEth1Blocks(subscribe?: boolean):
+  Promise<Pushable<[IDepositEvent[], ethers.providers.Block]>> {
+    return null;
+  }
+  public unsubscribeEth1Blocks(): void {}
 
   public async getDepositRoot(): Promise<Uint8Array> {
     return Buffer.alloc(32);

--- a/packages/lodestar/src/eth1/impl/interop.ts
+++ b/packages/lodestar/src/eth1/impl/interop.ts
@@ -4,7 +4,7 @@ import {ethers} from "ethers";
 
 import {Eth1Data} from "@chainsafe/lodestar-types";
 
-import {IEth1Notifier, IDepositEvent} from "../interface";
+import {IEth1Notifier, IDepositEvent, Eth1EventsBlock} from "../interface";
 import {Pushable} from "it-pushable";
 
 export class InteropEth1Notifier extends EventEmitter implements IEth1Notifier {
@@ -15,11 +15,10 @@ export class InteropEth1Notifier extends EventEmitter implements IEth1Notifier {
   public async start(): Promise<void> {}
   public async stop(): Promise<void> {}
 
-  public async startProcessEth1Blocks(subscribe?: boolean):
-  Promise<Pushable<[IDepositEvent[], ethers.providers.Block]>> {
+  public async getEth1BlockAndDepositEventsSource(): Promise<Pushable<Eth1EventsBlock>> {
     return null;
   }
-  public async unsubscribeEth1Blocks(): Promise<void> {}
+  public async endEth1BlockAndDepositEventsSource(): Promise<void> {}
 
   public async getDepositRoot(): Promise<Uint8Array> {
     return Buffer.alloc(32);

--- a/packages/lodestar/src/eth1/interface.ts
+++ b/packages/lodestar/src/eth1/interface.ts
@@ -23,14 +23,14 @@ export interface IDepositEvent extends DepositData {
 export interface IEth1Notifier {
   start(): Promise<void>;
   stop(): Promise<void>;
-  startProcessEth1Blocks(subscribe?: boolean): Promise<Pushable<[IDepositEvent[], ethers.providers.Block]>>;
-  unsubscribeEth1Blocks(): Promise<void>;
+  getEth1BlockAndDepositEventsSource(): Promise<Pushable<Eth1EventsBlock>>;
+  endEth1BlockAndDepositEventsSource(): Promise<void>;
 
   /**
    * Returns block by block hash or number
    * @param blockTag
    */
-  getBlock(blockTag: string | number): Promise<ethers.providers.Block>;
+  getBlock(blockTag: string | number): Promise<Eth1Block>;
 
   /**
    * Return deposit events at a block
@@ -44,4 +44,17 @@ export interface IEth1Notifier {
 export interface Eth1BlockRange {
   fromNumber: number;
   toNumber: number;
+}
+
+/**
+ * Eth1 block.
+ */
+export type Eth1Block = ethers.providers.Block;
+
+/**
+ * Eth1 Deposit Events and Block.
+ */
+export interface Eth1EventsBlock {
+  events: IDepositEvent[];
+  block?: Eth1Block;
 }

--- a/packages/lodestar/src/eth1/interface.ts
+++ b/packages/lodestar/src/eth1/interface.ts
@@ -24,7 +24,7 @@ export interface IEth1Notifier {
   start(): Promise<void>;
   stop(): Promise<void>;
   startProcessEth1Blocks(subscribe?: boolean): Promise<Pushable<[IDepositEvent[], ethers.providers.Block]>>;
-  unsubscribeEth1Blocks(): void;
+  unsubscribeEth1Blocks(): Promise<void>;
 
   /**
    * Returns block by block hash or number

--- a/packages/lodestar/src/eth1/interface.ts
+++ b/packages/lodestar/src/eth1/interface.ts
@@ -4,11 +4,10 @@
  * @module eth1
  */
 
-import {EventEmitter} from "events";
 
-import {Eth1Data, Number64, DepositData} from "@chainsafe/lodestar-types";
+import {DepositData} from "@chainsafe/lodestar-types";
 import {ethers} from "ethers";
-import StrictEventEmitter from "strict-event-emitter-types";
+import {Pushable} from "it-pushable";
 
 export type IEthersAbi = Array<string | ethers.utils.EventFragment | ethers.utils.ParamType>;
 
@@ -17,19 +16,15 @@ export interface IDepositEvent extends DepositData {
   index: number;
 }
 
-export interface IEth1Events {
-  deposit: (index: Number64, depositData: DepositData) => void;
-  eth1Data: (timestamp: number, eth1Data: Eth1Data, blockNumber: number) => void;
-}
-
-export type Eth1EventEmitter = StrictEventEmitter<EventEmitter, IEth1Events>;
 
 /**
  * The IEth1Notifier service watches the Eth1 chain for IEth1Events
  */
-export interface IEth1Notifier extends Eth1EventEmitter {
+export interface IEth1Notifier {
   start(): Promise<void>;
   stop(): Promise<void>;
+  startProcessEth1Blocks(subscribe?: boolean): Promise<Pushable<[IDepositEvent[], ethers.providers.Block]>>;
+  unsubscribeEth1Blocks(): void;
 
   /**
    * Returns block by block hash or number

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -145,7 +145,7 @@ export class BeaconNode {
     await this.metrics.start();
     await this.metricsServer.start();
     await this.db.start();
-    await this.eth1.start();
+    // eth1 is started in chain
     await this.chain.start();
     await this.network.start();
     this.sync.start();

--- a/packages/lodestar/test/e2e/chain/chain.test.ts
+++ b/packages/lodestar/test/e2e/chain/chain.test.ts
@@ -72,8 +72,8 @@ describe("BeaconChain", function() {
   });
 
   after(async () => {
-    await db.stop();
     await eth1Notifier.stop();
+    await db.stop();
     await fs.promises.rmdir(dbPath, {recursive: true});
   });
 

--- a/packages/lodestar/test/e2e/eth1/deploy.test.ts
+++ b/packages/lodestar/test/e2e/eth1/deploy.test.ts
@@ -1,15 +1,15 @@
-import * as fs from "fs";
 import {expect} from "chai";
 import {ethers} from "ethers";
 import sinon from "sinon";
 import {afterEach, beforeEach, describe, it} from "mocha";
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
-import {EthersEth1Notifier, IEth1Notifier} from "../../../src/eth1";
+import {EthersEth1Notifier, IEth1Notifier, IDepositEvent} from "../../../src/eth1";
 import defaults from "../../../src/eth1/dev/options";
 import {ILogger, LogLevel, WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {BeaconDb, LevelDbController} from "../../../src/db";
 import {IEth1Options} from "../../../src/eth1/options";
 import rimraf from "rimraf";
+import pipe from "it-pipe";
 
 describe("Eth1Notifier - using goerli known deployed contract", () => {
 
@@ -55,6 +55,7 @@ describe("Eth1Notifier - using goerli known deployed contract", () => {
         logger,
       });
     await db.start();
+    await eth1Notifier.start();
   });
 
   afterEach(async () => {
@@ -69,14 +70,7 @@ describe("Eth1Notifier - using goerli known deployed contract", () => {
     // process 2 blocks, should be 1 deposit
     const targetBlockNumber = opts.depositContract.deployedAt + 1;
     provider.getBlockNumber = sinon.stub().resolves(targetBlockNumber);
-    const blockPromise = new Promise(resolve => eth1Notifier.on("eth1Data", (_, __, blockNumber) => {
-      if(blockNumber === targetBlockNumber) {
-        eth1Notifier.removeAllListeners("eth1Data");
-        resolve();
-      }
-    }));
-    await eth1Notifier.start();
-    await blockPromise;
+    await waitForEth1Block(targetBlockNumber);
     const tree = await db.depositDataRoot.getTreeBacked(0);
     expect(tree.length).to.be.equal(1);
   });
@@ -87,32 +81,30 @@ describe("Eth1Notifier - using goerli known deployed contract", () => {
     // there should be one deposit to process
     const target1BlockNumber = opts.depositContract.deployedAt + 3;
     provider.getBlockNumber = sinon.stub().resolves(target1BlockNumber);
-    const blockPromise1 = new Promise(resolve => eth1Notifier.on("eth1Data", (_, __, blockNumber) => {
-      // 1 event at deployedAt + 1
-      if(blockNumber === opts.depositContract.deployedAt + 1) {
-        eth1Notifier.removeAllListeners("eth1Data");
-        resolve();
-      }
-    }));
-    await eth1Notifier.start();
-    await blockPromise1;
+    await waitForEth1Block(opts.depositContract.deployedAt + 1);
     await eth1Notifier.stop();
     const tree = await db.depositDataRoot.getTreeBacked(0);
     expect(tree.length).to.be.equal(1);
     const target2BlockNumber = opts.depositContract.deployedAt + 10;
     // process 7 more blocks, it should start from where it left off
     provider.getBlockNumber = sinon.stub().resolves(target2BlockNumber);
-    const blockPromise2 = new Promise(resolve => eth1Notifier.on("eth1Data", (_, __, blockNumber) => {
-      // 1 more event at deployedAt + 9
-      if(blockNumber === opts.depositContract.deployedAt + 9) {
-        eth1Notifier.removeAllListeners("eth1Data");
-        resolve();
-      }
-    }));
     await eth1Notifier.start();
-    await blockPromise2;
+    // await blockPromise2;
+    await waitForEth1Block(opts.depositContract.deployedAt + 9);
     const tree2 = await db.depositDataRoot.getTreeBacked(1);
     expect(tree2.length).to.be.equal(2);
   });
+
+  async function waitForEth1Block(targetBlockNumber: number): Promise<void> {
+    const eth1DataStream = await eth1Notifier.startProcessEth1Blocks(true);
+    await pipe(eth1DataStream, async function(source: AsyncIterable<[IDepositEvent[], ethers.providers.Block]>) {
+      for await (const data of source) {
+        if (data[1] && data[1].number === targetBlockNumber) {
+          return;
+        }
+      }
+    });
+    eth1Notifier.unsubscribeEth1Blocks();
+  }
 
 });

--- a/packages/lodestar/test/unit/chain/genesis/genesis.test.ts
+++ b/packages/lodestar/test/unit/chain/genesis/genesis.test.ts
@@ -1,0 +1,87 @@
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import sinon, {SinonStubbedInstance} from "sinon";
+import {EthersEth1Notifier, IDepositEvent} from "../../../../src/eth1";
+import {ethers} from "ethers";
+import pushable from "it-pushable";
+import {interopKeypair} from "@chainsafe/lodestar-validator/lib";
+import {PrivateKey, Keypair, initBLS} from "@chainsafe/bls";
+import {computeDomain, DomainType, computeSigningRoot} from "@chainsafe/lodestar-beacon-state-transition";
+import {DepositData, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {GenesisBuilder} from "../../../../src/chain/genesis/genesis";
+import {StubbedBeaconDb} from "../../../utils/stub";
+import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {expect} from "chai";
+import {toHexString} from "@chainsafe/ssz";
+
+describe("genesis builder", function () {
+  const schlesiConfig = Object.assign({}, {params: config.params}, config);
+  schlesiConfig.params = Object.assign({}, config.params, {MIN_GENESIS_TIME: 1587755000, MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 4, MIN_GENESIS_DELAY: 3600});
+  const sandbox = sinon.createSandbox();
+  let genesisBuilder: GenesisBuilder;
+  let eth1Stub: SinonStubbedInstance<EthersEth1Notifier>;
+  let dbStub: StubbedBeaconDb, loggerStub: any;
+  const events: IDepositEvent[] = [];
+  const keypairs: Keypair[] = [];
+
+  before(async function f() {
+    try {
+      await initBLS();
+    } catch (e) {
+      console.log(e);
+    }
+  });
+
+  beforeEach(() => {
+    for (let i = 0; i < schlesiConfig.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT; i++) {
+      keypairs.push(new Keypair(PrivateKey.fromBytes(interopKeypair(i).privkey)));
+      const event = {...generateDeposit(i), index: i, blockNumber: i};
+      events.push(event);
+    }
+
+    eth1Stub = sandbox.createStubInstance(EthersEth1Notifier);
+    dbStub = new StubbedBeaconDb(sandbox);
+    loggerStub = sandbox.createStubInstance(WinstonLogger);
+    genesisBuilder = new GenesisBuilder(schlesiConfig, {
+      eth1: eth1Stub,
+      db: dbStub,
+      logger: loggerStub,
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should build genesis state", async () => {
+    const eth1Source = pushable<[IDepositEvent[], ethers.providers.Block]>();
+    eth1Stub.startProcessEth1Blocks.resolves(eth1Source);
+
+    const statePromise = genesisBuilder.waitForGenesis();
+    for (let i = 0; i < schlesiConfig.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT - 1; i++) {
+      eth1Source.push([[events[i]], null]);
+    }
+    const lastEventIndex = schlesiConfig.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT - 1;
+    const block = {
+      number: lastEventIndex,
+      timestamp: Math.floor(Date.now()/1000),
+      hash: "0x54b9f905f15634d966690bd362381cfd7a28362d683f8d1616aa478b575152f8"
+    } as ethers.providers.Block;
+    eth1Source.push([[events[lastEventIndex]], block]);
+    const state = await statePromise;
+    expect(state.validators.length).to.be.equal(4);
+
+    expect(toHexString(state.eth1Data.blockHash)).to.be.equal("0x54b9f905f15634d966690bd362381cfd7a28362d683f8d1616aa478b575152f8");
+  });
+
+  function generateDeposit(index: ValidatorIndex): DepositData {
+    const domain = computeDomain(config, DomainType.DEPOSIT);
+    const depositMessage = {
+      pubkey: keypairs[index].publicKey.toBytesCompressed(),
+      withdrawalCredentials: Buffer.alloc(32, index),
+      amount: BigInt(32 * 1000000000000000000),
+    };
+    const signingRoot = computeSigningRoot(config, config.types.DepositMessage, depositMessage, domain);
+    const signature = keypairs[index].privateKey.signMessage(signingRoot);
+    return {...depositMessage, signature: signature.toBytesCompressed()};
+  }
+});

--- a/packages/lodestar/test/unit/eth1/impl/ethers.test.ts
+++ b/packages/lodestar/test/unit/eth1/impl/ethers.test.ts
@@ -65,6 +65,46 @@ describe("Eth1Notifier", () => {
     await eth1.stop();
   });
 
+  it("should start eth1 to build genesis even it's disabled", async () => {
+    eth1 = new EthersEth1Notifier({
+      ...defaults,
+      enabled: false,
+      contract: contract as any,
+      providerInstance: provider as any,
+    },
+    {
+      config,
+      db,
+      logger,
+    });
+    await eth1.start();
+    expect(provider.getBlock.called).to.be.false;
+    // cannot start if subscribe=false
+    let eth1Source = await eth1.startProcessEth1Blocks(false);
+    expect(provider.getBlock.called).to.be.false;
+    expect(eth1Source).to.be.undefined;
+    // should start if subscribe=true
+    const lastProcessedEth1Data = {
+      blockHash: Buffer.alloc(32, 1),
+      depositRoot: Buffer.alloc(32, 2),
+      depositCount: 5,
+    };
+    const lastProcessedBlock = {
+      number: 5000000,
+    } as ethers.providers.Block;
+    const currentBlockNumber = lastProcessedBlock.number;
+    db.eth1Data.lastValue.resolves(lastProcessedEth1Data);
+    provider.getBlock.withArgs(toHexString(lastProcessedEth1Data.blockHash)).resolves(lastProcessedBlock);
+    provider.getBlockNumber.resolves(currentBlockNumber);
+    eth1Source = await eth1.startProcessEth1Blocks(true);
+    expect(eth1Source).not.to.be.undefined;
+    expect(provider.getBlock.withArgs(toHexString(lastProcessedEth1Data.blockHash)).calledOnce).to.be.true;
+
+    await eth1.unsubscribeEth1Blocks();
+    // make sure stop() is called
+    expect(provider.removeAllListeners.calledOnce).to.be.true;
+  });
+
   it("should fail to start because there isn't contract at given address", async function (): Promise<void> {
     eth1 = new EthersEth1Notifier({
       ...defaults,

--- a/packages/spec-test-runner/test/spec/genesis/validity/genesis_validity_minimal.test.ts
+++ b/packages/spec-test-runner/test/spec/genesis/validity/genesis_validity_minimal.test.ts
@@ -4,7 +4,7 @@ import {join} from "path";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import {BeaconState} from "@chainsafe/lodestar-types";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util/lib/single";
-import {isValidGenesisState} from "@chainsafe/lodestar/lib/chain/genesis/genesis";
+import {isValidGenesisState} from "@chainsafe/lodestar/lib/chain/genesis/util";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
 
 interface IGenesisValidityTestCase {


### PR DESCRIPTION
resolves #883 

+ Build genesis state incrementally using newly created GenesisBuilder, it should be a good preparation for mainnet with `MIN_GENESIS_ACTIVE_VALIDATOR_COUNT > 16000`
+ Start processing eth1 blocks/events from either genesis builder or chain
+ Process eth1 blocks/events one by one using pipe instead of event

This doesn't address the following issues/concerns (should have a separate issue for it)
+ ethers.ts should be stateless, no db should be involved there. Create a separate service to manage that.
+ No need to store proposing data during initial sync