### PR TITLE
Fix docs relative links

### DIFF
--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -1,7 +1,7 @@
 # Usage
 
-- [Local tesnet](/usage/local): To quickly test and run Lodestar we recommend to start a local testnet.
-- [Connect to witti](usage/witti)
+- [Local tesnet](local): To quickly test and run Lodestar we recommend to start a local testnet.
+- [Connect to witti](witti)
 
 To run any other command or explore Lodestar options run the help command.
 


### PR DESCRIPTION
On Github pages the site is served in a subpath so absolute paths cannot be used