### PR TITLE
Add assertion messages

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/block/blockHeader.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/blockHeader.ts
@@ -14,17 +14,17 @@ export function processBlockHeader(
   block: BeaconBlock,
 ): void {
   // Verify that the slots match
-  assert(block.slot === state.slot);
+  assert.equal(block.slot, state.slot, "Slots do not match");
   // Verify that proposer index is the correct index
-  assert(block.proposerIndex === getBeaconProposerIndex(config, state));
+  assert.equal(block.proposerIndex, getBeaconProposerIndex(config, state), "Incorrect proposer index");
   // Verify that the parent matches
-  assert(config.types.Root.equals(
+  assert.true(config.types.Root.equals(
     block.parentRoot,
-    config.types.BeaconBlockHeader.hashTreeRoot(state.latestBlockHeader))
-  );
+    config.types.BeaconBlockHeader.hashTreeRoot(state.latestBlockHeader)
+  ), "Parent block roots do not match");
   // Save current block as the new latest block
   state.latestBlockHeader = getTemporaryBlockHeader(config, block);
 
   // Verify proposer is not slashed
-  assert(!state.validators[block.proposerIndex].slashed);
+  assert.true(!state.validators[block.proposerIndex].slashed, "Proposer must not be slashed");
 }

--- a/packages/lodestar-beacon-state-transition/src/block/operations/attestation.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/attestation.ts
@@ -26,15 +26,15 @@ export function processAttestation(
   const currentEpoch = getCurrentEpoch(config, state);
   const previousEpoch = getPreviousEpoch(config, state);
   const data = attestation.data;
-  assert.lt(data.index, getCommitteeCountAtSlot(config, state, data.slot), "attestation index out of bounds");
+  assert.lt(data.index, getCommitteeCountAtSlot(config, state, data.slot), "Attestation index out of bounds");
   assert.true(
     data.target.epoch === previousEpoch || data.target.epoch === currentEpoch,
-    `attestation is targeting too old epoch ${data.target.epoch}, current=${currentEpoch}`
+    `Attestation is targeting too old epoch ${data.target.epoch}, current=${currentEpoch}`
   );
-  assert.equal(data.target.epoch, computeEpochAtSlot(config, data.slot), "attestation is not targeting current epoch");
+  assert.equal(data.target.epoch, computeEpochAtSlot(config, data.slot), "Attestation is not targeting current epoch");
 
   const committee = getBeaconCommittee(config, state, data.slot, data.index);
-  assert.equal(attestation.aggregationBits.length, committee.length, "attestation invalid aggregationBits length");
+  assert.equal(attestation.aggregationBits.length, committee.length, "Attestation invalid aggregationBits length");
 
   // Cache pending attestation
   const pendingAttestation: PendingAttestation = {
@@ -47,13 +47,13 @@ export function processAttestation(
   if (data.target.epoch === currentEpoch) {
     assert.true(
       config.types.Checkpoint.equals(data.source, state.currentJustifiedCheckpoint),
-      "attestation invalid source"
+      "Attestation invalid source"
     );
     state.currentEpochAttestations.push(pendingAttestation);
   } else {
     assert.true(
       config.types.Checkpoint.equals(data.source, state.previousJustifiedCheckpoint),
-      "attestation invalid source"
+      "Attestation invalid source"
     );
     state.previousEpochAttestations.push(pendingAttestation);
   }
@@ -61,6 +61,6 @@ export function processAttestation(
   // Check signature
   assert.true(
     isValidIndexedAttestation(config, state, getIndexedAttestation(config, state, attestation), verifySignature),
-    "attestation invalid signature"
+    "Attestation invalid signature"
   );
 }

--- a/packages/lodestar-beacon-state-transition/src/block/operations/attesterSlashing.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/attesterSlashing.ts
@@ -45,5 +45,5 @@ export function processAttesterSlashing(
     }
   });
 
-  assert.true(slashedAny, "should slash any");
+  assert.true(slashedAny, "no slashable validators for attester slashing found");
 }

--- a/packages/lodestar-beacon-state-transition/src/block/operations/attesterSlashing.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/attesterSlashing.ts
@@ -27,7 +27,7 @@ export function processAttesterSlashing(
   verifySignatures = true,
 ): void {
   // Check that the attestations are conflicting
-  assert.true(isValidAttesterSlashing(config, state, attesterSlashing, verifySignatures), "invalid attester slashing");
+  assert.true(isValidAttesterSlashing(config, state, attesterSlashing, verifySignatures), "Invalid attester slashing");
 
   const attestation1 = attesterSlashing.attestation1;
   const attestation2 = attesterSlashing.attestation2;
@@ -45,5 +45,5 @@ export function processAttesterSlashing(
     }
   });
 
-  assert.true(slashedAny, "no slashable validators for attester slashing found");
+  assert.true(slashedAny, "No slashable validators for attester slashing found");
 }

--- a/packages/lodestar-beacon-state-transition/src/block/operations/attesterSlashing.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/attesterSlashing.ts
@@ -27,7 +27,7 @@ export function processAttesterSlashing(
   verifySignatures = true,
 ): void {
   // Check that the attestations are conflicting
-  assert(isValidAttesterSlashing(config, state, attesterSlashing, verifySignatures));
+  assert.true(isValidAttesterSlashing(config, state, attesterSlashing, verifySignatures), "invalid attester slashing");
 
   const attestation1 = attesterSlashing.attestation1;
   const attestation2 = attesterSlashing.attestation2;
@@ -45,5 +45,5 @@ export function processAttesterSlashing(
     }
   });
 
-  assert(slashedAny);
+  assert.true(slashedAny, "should slash any");
 }

--- a/packages/lodestar-beacon-state-transition/src/block/operations/deposit.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/deposit.ts
@@ -25,7 +25,7 @@ export function processDeposit(
     DEPOSIT_CONTRACT_TREE_DEPTH + 1,
     state.eth1DepositIndex,
     state.eth1Data.depositRoot.valueOf() as Uint8Array,
-  ), "invalid deposit merkle branch");
+  ), "Invalid deposit merkle branch");
 
   // Deposits must be processed in order
   state.eth1DepositIndex += 1;

--- a/packages/lodestar-beacon-state-transition/src/block/operations/deposit.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/deposit.ts
@@ -19,13 +19,13 @@ export function processDeposit(
   deposit: Deposit
 ): void {
   // Verify the Merkle branch
-  assert(verifyMerkleBranch(
+  assert.true(verifyMerkleBranch(
     config.types.DepositData.hashTreeRoot(deposit.data),
     Array.from(deposit.proof).map((p) => p.valueOf() as Uint8Array),
     DEPOSIT_CONTRACT_TREE_DEPTH + 1,
     state.eth1DepositIndex,
     state.eth1Data.depositRoot.valueOf() as Uint8Array,
-  ));
+  ), "invalid deposit merkle branch");
 
   // Deposits must be processed in order
   state.eth1DepositIndex += 1;

--- a/packages/lodestar-beacon-state-transition/src/block/operations/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/index.ts
@@ -34,9 +34,13 @@ export function processOperations(
   verifySignatures = true,
 ): void {
   // Verify that outstanding deposits are processed up to the maximum number of deposits
-  assert(body.deposits.length === Math.min(
-    config.params.MAX_DEPOSITS,
-    state.eth1Data.depositCount - state.eth1DepositIndex));
+  assert.true(
+    body.deposits.length === Math.min(
+      config.params.MAX_DEPOSITS,
+      state.eth1Data.depositCount - state.eth1DepositIndex),
+    "outstanding deposits are not processed"
+  );
+
   [{
     operations: body.proposerSlashings,
     maxOperations: config.params.MAX_PROPOSER_SLASHINGS,
@@ -74,7 +78,7 @@ export function processOperations(
     func: (config: IBeaconConfig, state: BeaconState, operation: any, verifySignatures: boolean) => void;
     verifySignatures: boolean;
   }) => {
-    assert(operations.length <= maxOperations);
+    assert.lte(operations.length, maxOperations, "too many operations");
     operations.forEach((operation) => {
       func(config, state, operation, verifySignatures);
     });

--- a/packages/lodestar-beacon-state-transition/src/block/operations/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/index.ts
@@ -38,7 +38,7 @@ export function processOperations(
     body.deposits.length === Math.min(
       config.params.MAX_DEPOSITS,
       state.eth1Data.depositCount - state.eth1DepositIndex),
-    "outstanding deposits are not processed"
+    "Outstanding deposits are not processed"
   );
 
   [{
@@ -78,7 +78,7 @@ export function processOperations(
     func: (config: IBeaconConfig, state: BeaconState, operation: any, verifySignatures: boolean) => void;
     verifySignatures: boolean;
   }) => {
-    assert.lte(operations.length, maxOperations, "too many operations");
+    assert.lte(operations.length, maxOperations, "Too many operations");
     operations.forEach((operation) => {
       func(config, state, operation, verifySignatures);
     });

--- a/packages/lodestar-beacon-state-transition/src/block/operations/proposerSlashing.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/proposerSlashing.ts
@@ -14,6 +14,6 @@ export function processProposerSlashing(
   proposerSlashing: ProposerSlashing,
   verifySignatures = true,
 ): void {
-  assert(isValidProposerSlashing(config, state, proposerSlashing, verifySignatures));
+  assert.true(isValidProposerSlashing(config, state, proposerSlashing, verifySignatures), "invalid proposer slashing");
   slashValidator(config, state, proposerSlashing.signedHeader1.message.proposerIndex);
 }

--- a/packages/lodestar-beacon-state-transition/src/block/operations/proposerSlashing.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/proposerSlashing.ts
@@ -14,6 +14,6 @@ export function processProposerSlashing(
   proposerSlashing: ProposerSlashing,
   verifySignatures = true,
 ): void {
-  assert.true(isValidProposerSlashing(config, state, proposerSlashing, verifySignatures), "invalid proposer slashing");
+  assert.true(isValidProposerSlashing(config, state, proposerSlashing, verifySignatures), "Invalid proposer slashing");
   slashValidator(config, state, proposerSlashing.signedHeader1.message.proposerIndex);
 }

--- a/packages/lodestar-beacon-state-transition/src/block/operations/voluntaryExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/voluntaryExit.ts
@@ -19,7 +19,7 @@ export function processVoluntaryExit(
   signedExit: SignedVoluntaryExit,
   verifySignature = true
 ): void {
-  assert(isValidVoluntaryExit(config, state, signedExit, verifySignature));
+  assert.true(isValidVoluntaryExit(config, state, signedExit, verifySignature), "invalid voluntary exit");
   // Initiate exit
   initiateValidatorExit(config, state, signedExit.message.validatorIndex);
 }

--- a/packages/lodestar-beacon-state-transition/src/block/operations/voluntaryExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/operations/voluntaryExit.ts
@@ -19,7 +19,7 @@ export function processVoluntaryExit(
   signedExit: SignedVoluntaryExit,
   verifySignature = true
 ): void {
-  assert.true(isValidVoluntaryExit(config, state, signedExit, verifySignature), "invalid voluntary exit");
+  assert.true(isValidVoluntaryExit(config, state, signedExit, verifySignature), "Invalid voluntary exit");
   // Initiate exit
   initiateValidatorExit(config, state, signedExit.message.validatorIndex);
 }

--- a/packages/lodestar-beacon-state-transition/src/block/randao.ts
+++ b/packages/lodestar-beacon-state-transition/src/block/randao.ts
@@ -24,11 +24,11 @@ export function processRandao(
   const domain = getDomain(config, state, DomainType.RANDAO);
   const signingRoot = computeSigningRoot(config, config.types.Epoch, currentEpoch, domain);
   // Verify RANDAO reveal
-  assert(!verifySignature || verify(
+  assert.true(!verifySignature || verify(
     proposer.pubkey.valueOf() as Uint8Array,
     signingRoot,
     body.randaoReveal.valueOf() as Uint8Array,
-  ));
+  ), "Invalid RANDAO reveal");
   // Mix it in
   state.randaoMixes[currentEpoch % config.params.EPOCHS_PER_HISTORICAL_VECTOR] = xor(
     Buffer.from(getRandaoMix(config, state, currentEpoch) as Uint8Array),

--- a/packages/lodestar-beacon-state-transition/src/epoch/util.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/util.ts
@@ -28,7 +28,10 @@ export function getMatchingSourceAttestations(
   epoch: Epoch
 ): PendingAttestation[] {
   const currentEpoch = getCurrentEpoch(config, state);
-  assert(epoch === currentEpoch || epoch === getPreviousEpoch(config, state));
+  assert.true(
+    epoch === currentEpoch || epoch === getPreviousEpoch(config, state), 
+    `too old epoch ${epoch}, current=${currentEpoch}`
+  );
   return Array.from(
     epoch === currentEpoch
       ? state.currentEpochAttestations

--- a/packages/lodestar-beacon-state-transition/src/epoch/util.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/util.ts
@@ -30,7 +30,7 @@ export function getMatchingSourceAttestations(
   const currentEpoch = getCurrentEpoch(config, state);
   assert.true(
     epoch === currentEpoch || epoch === getPreviousEpoch(config, state), 
-    `too old epoch ${epoch}, current=${currentEpoch}`
+    `Too old epoch ${epoch}, current=${currentEpoch}`
   );
   return Array.from(
     epoch === currentEpoch

--- a/packages/lodestar-beacon-state-transition/src/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/index.ts
@@ -47,10 +47,10 @@ export function stateTransition(
   processBlock(config, postState, signedBlock.message, verifySignatures);
   // Validate state root (`validate_state_root == True` in production)
   if (validateStateRoot){
-    assert(config.types.Root.equals(
+    assert.true(config.types.Root.equals(
       signedBlock.message.stateRoot,
       config.types.BeaconState.hashTreeRoot(postState)
-    ));
+    ), "State root is not valid");
   }
 
   // Return post-state

--- a/packages/lodestar-beacon-state-transition/src/slot.ts
+++ b/packages/lodestar-beacon-state-transition/src/slot.ts
@@ -15,7 +15,7 @@ export function processSlots(
   state: BeaconState,
   slot: Slot,
 ): void{
-  assert(state.slot <= slot);
+  assert.lte(state.slot, slot, `Too old epoch ${slot}, current=${state.slot}`);
 
   while (state.slot < slot){
     processSlot(config, state);

--- a/packages/lodestar-beacon-state-transition/src/util/blockRoot.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/blockRoot.ts
@@ -25,8 +25,12 @@ import {computeStartSlotAtEpoch} from "./epoch";
  * Return the block root at a recent [[slot]].
  */
 export function getBlockRootAtSlot(config: IBeaconConfig, state: BeaconState, slot: Slot): Root {
-  assert.lt(slot, state.slot, "cannot get future epochs");
-  assert.lte(state.slot, slot + config.params.SLOTS_PER_HISTORICAL_ROOT);
+  assert.lt(slot, state.slot, "cannot get block root for slot in the future");
+  assert.lte(
+    state.slot,
+    slot + config.params.SLOTS_PER_HISTORICAL_ROOT,
+    `cannot get block root from slot more than ${config.params.SLOTS_PER_HISTORICAL_ROOT} in the past`
+  );
   return state.blockRoots[slot % config.params.SLOTS_PER_HISTORICAL_ROOT];
 }
 

--- a/packages/lodestar-beacon-state-transition/src/util/blockRoot.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/blockRoot.ts
@@ -25,8 +25,8 @@ import {computeStartSlotAtEpoch} from "./epoch";
  * Return the block root at a recent [[slot]].
  */
 export function getBlockRootAtSlot(config: IBeaconConfig, state: BeaconState, slot: Slot): Root {
-  assert(slot < state.slot);
-  assert(state.slot <= slot + config.params.SLOTS_PER_HISTORICAL_ROOT);
+  assert.lt(slot, state.slot, "cannot get future epochs");
+  assert.lte(state.slot, slot + config.params.SLOTS_PER_HISTORICAL_ROOT);
   return state.blockRoots[slot % config.params.SLOTS_PER_HISTORICAL_ROOT];
 }
 

--- a/packages/lodestar-beacon-state-transition/src/util/blockRoot.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/blockRoot.ts
@@ -25,11 +25,11 @@ import {computeStartSlotAtEpoch} from "./epoch";
  * Return the block root at a recent [[slot]].
  */
 export function getBlockRootAtSlot(config: IBeaconConfig, state: BeaconState, slot: Slot): Root {
-  assert.lt(slot, state.slot, "cannot get block root for slot in the future");
+  assert.lt(slot, state.slot, "Cannot get block root for slot in the future");
   assert.lte(
     state.slot,
     slot + config.params.SLOTS_PER_HISTORICAL_ROOT,
-    `cannot get block root from slot more than ${config.params.SLOTS_PER_HISTORICAL_ROOT} in the past`
+    `Cannot get block root from slot more than ${config.params.SLOTS_PER_HISTORICAL_ROOT} in the past`
   );
   return state.blockRoots[slot % config.params.SLOTS_PER_HISTORICAL_ROOT];
 }

--- a/packages/lodestar-beacon-state-transition/src/util/duties.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/duties.ts
@@ -26,7 +26,7 @@ export function getCommitteeAssignment(
 ): CommitteeAssignment {
 
   const next2Epoch = getCurrentEpoch(config, state) + 2;
-  assert.lte(epoch, next2Epoch, "cannot get committee assignment for epoch more than two ahead");
+  assert.lte(epoch, next2Epoch, "Cannot get committee assignment for epoch more than two ahead");
 
   const epochStartSlot = computeStartSlotAtEpoch(config, epoch);
   for (let slot = epochStartSlot; slot < epochStartSlot + config.params.SLOTS_PER_EPOCH; slot++) {
@@ -57,7 +57,7 @@ export function isProposerAtSlot(
 
   state = {...state, slot};
   const currentEpoch = getCurrentEpoch(config, state);
-  assert.equal(computeEpochAtSlot(config, slot), currentEpoch, "must request for current epoch");
+  assert.equal(computeEpochAtSlot(config, slot), currentEpoch, "Must request for current epoch");
 
   return getBeaconProposerIndex(config, state) === validatorIndex;
 }

--- a/packages/lodestar-beacon-state-transition/src/util/duties.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/duties.ts
@@ -26,7 +26,7 @@ export function getCommitteeAssignment(
 ): CommitteeAssignment {
 
   const next2Epoch = getCurrentEpoch(config, state) + 2;
-  assert(epoch <= next2Epoch);
+  assert.lte(epoch, next2Epoch, "too future epoch");
 
   const epochStartSlot = computeStartSlotAtEpoch(config, epoch);
   for (let slot = epochStartSlot; slot < epochStartSlot + config.params.SLOTS_PER_EPOCH; slot++) {
@@ -57,7 +57,7 @@ export function isProposerAtSlot(
 
   state = {...state, slot};
   const currentEpoch = getCurrentEpoch(config, state);
-  assert(computeEpochAtSlot(config, slot) === currentEpoch);
+  assert.equal(computeEpochAtSlot(config, slot), currentEpoch, "must request for current epoch");
 
   return getBeaconProposerIndex(config, state) === validatorIndex;
 }

--- a/packages/lodestar-beacon-state-transition/src/util/duties.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/duties.ts
@@ -26,7 +26,7 @@ export function getCommitteeAssignment(
 ): CommitteeAssignment {
 
   const next2Epoch = getCurrentEpoch(config, state) + 2;
-  assert.lte(epoch, next2Epoch, "too future epoch");
+  assert.lte(epoch, next2Epoch, "cannot get committee assignment for epoch more than two ahead");
 
   const epochStartSlot = computeStartSlotAtEpoch(config, epoch);
   for (let slot = epochStartSlot; slot < epochStartSlot + config.params.SLOTS_PER_EPOCH; slot++) {

--- a/packages/lodestar-beacon-state-transition/src/util/proposer.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/proposer.ts
@@ -40,7 +40,7 @@ export function computeProposerIndex(
   indices: ValidatorIndex[], 
   seed: Uint8Array
 ): ValidatorIndex {
-  assert.gt(indices.length, 0, "validator indices must not be empty");
+  assert.gt(indices.length, 0, "Validator indices must not be empty");
   const MAX_RANDOM_BYTE = BigInt(2**8 - 1);
   let i = 0;
   /* eslint-disable-next-line no-constant-condition */

--- a/packages/lodestar-beacon-state-transition/src/util/proposer.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/proposer.ts
@@ -40,7 +40,7 @@ export function computeProposerIndex(
   indices: ValidatorIndex[], 
   seed: Uint8Array
 ): ValidatorIndex {
-  assert(indices.length > 0);
+  assert.gt(indices.length, 0, "validator indices must not be empty");
   const MAX_RANDOM_BYTE = BigInt(2**8 - 1);
   let i = 0;
   /* eslint-disable-next-line no-constant-condition */

--- a/packages/lodestar-beacon-state-transition/src/util/seed.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/seed.ts
@@ -30,8 +30,8 @@ export function computeShuffledIndex(
   seed: Bytes32
 ): number {
   let permuted = index;
-  assert(index < indexCount);
-  assert(indexCount <= 2 ** 40);
+  assert.lt(index, indexCount, "indexCount must be less than index");
+  assert.lte(indexCount, 2 ** 40, "indexCount too big");
   const _seed = seed.valueOf() as Uint8Array;
   for (let i = 0; i < config.params.SHUFFLE_ROUND_COUNT; i++) {
     const pivot = Number(bytesToBigInt(

--- a/packages/lodestar-beacon-state-transition/src/util/shuffle.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/shuffle.ts
@@ -84,7 +84,7 @@ function innerShuffleList(config: IBeaconConfig, input: ValidatorIndex[], seed: 
   // as we do a lot of bit math on it, which cannot be done as fast on more bits.
   const listSize = input.length >>> 0;
   // check if list size fits in uint32
-  assert(listSize == input.length);
+  assert.equal(listSize, input.length, "list size do not fit uint32");
 
   const buf = Buffer.alloc(_SHUFFLE_H_TOTAL_SIZE);
   let r = 0;

--- a/packages/lodestar-beacon-state-transition/src/util/shuffle.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/shuffle.ts
@@ -84,7 +84,7 @@ function innerShuffleList(config: IBeaconConfig, input: ValidatorIndex[], seed: 
   // as we do a lot of bit math on it, which cannot be done as fast on more bits.
   const listSize = input.length >>> 0;
   // check if list size fits in uint32
-  assert.equal(listSize, input.length, "list size do not fit uint32");
+  assert.equal(listSize, input.length, "input length does not fit uint32");
 
   const buf = Buffer.alloc(_SHUFFLE_H_TOTAL_SIZE);
   let r = 0;

--- a/packages/lodestar-utils/src/assert.ts
+++ b/packages/lodestar-utils/src/assert.ts
@@ -1,13 +1,73 @@
-/**
- * Assert condition is truthy, otherwise throw AssertionError
- * @param condition 
- * @param message 
- */
-export function assert(condition: boolean, message?: string): void {
-  if (!condition) {
-    throw new AssertionError(message || "Expect false == true");
+export const assert = {
+  /**
+   * Assert condition is true, otherwise throw AssertionError
+   */
+  true(condition: boolean, message?: string): void {
+    if (!condition) {
+      throw new AssertionError(message || "Expect condition to be true");
+    }
+  },
+
+  /**
+   * Assert strict equality
+   * ```js
+   * actual === expected
+   * ```
+   */
+  equal<T>(actual: T, expected: T, message?: string): void {
+    if (!(actual === expected)) {
+      throw new AssertionError(`${message || "Expected values to be equal"}: ${actual} === ${expected}`);
+    }
+  },
+
+  /**
+   * Assert less than or equal
+   * ```js
+   * left <= right
+   * ```
+   */
+  lte(left: number, right: number, message?: string): void {
+    if (!(left <= right)) {
+      throw new AssertionError(`${message || "Expected value to be lte"}: ${left} <= ${right}`);
+    }
+  },
+
+  /**
+   * Assert less than
+   * ```js
+   * left < right
+   * ```
+   */
+  lt(left: number, right: number, message?: string): void {
+    if (!(left < right)) {
+      throw new AssertionError(`${message || "Expected value to be lt"}: ${left} < ${right}`);
+    }
+  },
+
+  /**
+   * Assert greater than or equal
+   * ```js
+   * left >= right
+   * ```
+   */
+  gte(left: number, right: number, message?: string): void {
+    if (!(left >= right)) {
+      throw new AssertionError(`${message || "Expected value to be gte"}: ${left} >= ${right}`);
+    }
+  },
+
+  /**
+   * Assert greater than
+   * ```js
+   * left > right
+   * ```
+   */
+  gt(left: number, right: number, message?: string): void {
+    if (!(left > right)) {
+      throw new AssertionError(`${message || "Expected value to be gt"}: ${left} > ${right}`);
+    }
   }
-}
+};
 
 export class AssertionError extends Error {
   static code = "ERR_ASSERTION";

--- a/packages/lodestar-utils/test/unit/assert.test.ts
+++ b/packages/lodestar-utils/test/unit/assert.test.ts
@@ -1,0 +1,63 @@
+import {expect} from "chai";
+import {describe, it} from "mocha";
+import {assert} from "../../src";
+
+describe("assert", () => {
+  describe("true", () => {
+    it("Should not throw with true", () => {
+      expect(() => assert.true(true)).to.not.throw();
+    });
+    it("Should throw with false", () => {
+      expect(() => assert.true(false, "something must be valid"))
+        .to.throw("something must be valid");
+    });
+  });
+
+  describe("equal with custom message", () => {
+    it("Should not throw with equal values", () => {
+      expect(() => assert.equal(1, 1)).to.not.throw();
+    });
+    it("Should throw with different values", () => {
+      expect(() => assert.equal(1, 2, "something must be equal"))
+        .to.throw("something must be equal: 1 === 2");
+    });
+  });
+
+  const cases: {
+    op: keyof Omit<typeof assert, "true">;
+    args: [number, number];
+    ok: boolean;
+  }[] = [
+    {op: "equal", args: [0, 1], ok: false},
+    {op: "equal", args: [1, 1], ok: true},
+    {op: "equal", args: [2, 1], ok: false},
+
+    {op: "lte", args: [0, 1], ok: true},
+    {op: "lte", args: [1, 1], ok: true},
+    {op: "lte", args: [2, 1], ok: false},
+
+    {op: "lt", args: [0, 1], ok: true},
+    {op: "lt", args: [1, 1], ok: false},
+    {op: "lt", args: [2, 1], ok: false},
+
+    {op: "gte", args: [0, 1], ok: false},
+    {op: "gte", args: [1, 1], ok: true},
+    {op: "gte", args: [2, 1], ok: true},
+
+    {op: "gt", args: [0, 1], ok: false},
+    {op: "gt", args: [1, 1], ok: false},
+    {op: "gt", args: [2, 1], ok: true},
+  ];
+
+  describe("math ops", () => {
+    for (const {op, args, ok} of cases) {
+      it(`assert ${args[0]} ${op} ${args[1]} = ${ok}`, () => {
+        if (ok) {
+          expect(() => assert[op](...args)).to.not.throw();
+        } else {
+          expect(() => assert[op](...args)).to.throw();
+        }
+      });
+    }
+  });
+});

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -116,7 +116,7 @@ export class ValidatorApi implements IValidatorApi {
   public async getProposerDuties(epoch: Epoch): Promise<ProposerDuty[]> {
     const state = await this.chain.getHeadState();
     assert.gte(epoch, 0, "Epoch must be positive");
-    assert.lte(epoch, computeEpochAtSlot(this.config, state.slot) + 2, "Epoch too future");
+    assert.lte(epoch, computeEpochAtSlot(this.config, state.slot) + 2, "Cannot get duties for epoch more than two ahead");
     const startSlot = computeStartSlotAtEpoch(this.config, epoch);
     if(state.slot < startSlot) {
       processSlots(this.config, state, startSlot);

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -115,7 +115,8 @@ export class ValidatorApi implements IValidatorApi {
 
   public async getProposerDuties(epoch: Epoch): Promise<ProposerDuty[]> {
     const state = await this.chain.getHeadState();
-    assert(epoch >= 0 && epoch <= computeEpochAtSlot(this.config, state.slot) + 2);
+    assert.gte(epoch, 0, "Epoch must be positive");
+    assert.lte(epoch, computeEpochAtSlot(this.config, state.slot) + 2, "Epoch too future");
     const startSlot = computeStartSlotAtEpoch(this.config, epoch);
     if(state.slot < startSlot) {
       processSlots(this.config, state, startSlot);

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -116,7 +116,11 @@ export class ValidatorApi implements IValidatorApi {
   public async getProposerDuties(epoch: Epoch): Promise<ProposerDuty[]> {
     const state = await this.chain.getHeadState();
     assert.gte(epoch, 0, "Epoch must be positive");
-    assert.lte(epoch, computeEpochAtSlot(this.config, state.slot) + 2, "Cannot get duties for epoch more than two ahead");
+    assert.lte(
+      epoch,
+      computeEpochAtSlot(this.config, state.slot) + 2,
+      "Cannot get duties for epoch more than two ahead"
+    );
     const startSlot = computeStartSlotAtEpoch(this.config, epoch);
     if(state.slot < startSlot) {
       processSlots(this.config, state, startSlot);

--- a/packages/lodestar/src/chain/attestation.ts
+++ b/packages/lodestar/src/chain/attestation.ts
@@ -113,20 +113,20 @@ export class AttestationProcessor implements IAttestationProcessor {
     }
     const previousEpoch = currentEpoch > GENESIS_EPOCH ? currentEpoch - 1 : GENESIS_EPOCH;
     const target = attestation.data.target;
-    assert([previousEpoch, currentEpoch].includes(target.epoch),
+    assert.true([previousEpoch, currentEpoch].includes(target.epoch),
       `attestation is targeting too old epoch ${target.epoch}, current=${currentEpoch}`
     );
-    assert(
-      target.epoch === computeEpochAtSlot(this.config, attestation.data.slot),
+    assert.equal(
+      target.epoch, computeEpochAtSlot(this.config, attestation.data.slot),
       "attestation is not targeting current epoch"
     );
-    assert(
-      currentSlot >= computeStartSlotAtEpoch(this.config, target.epoch)
-      , "Current slot less than this target epoch's start slot"
+    assert.gte(
+      currentSlot, computeStartSlotAtEpoch(this.config, target.epoch),
+      "Current slot less than this target epoch's start slot"
     );
     const block = this.forkChoice.getBlockSummaryByBlockRoot(attestation.data.beaconBlockRoot.valueOf() as Uint8Array);
-    assert(!!block, `The block of attestation data ${toHexString(attestation.data.beaconBlockRoot)} does not exist`);
-    assert(block.slot <= attestation.data.slot, "Attestation is for past block");
+    assert.true(!!block, `Block of attestation data ${toHexString(attestation.data.beaconBlockRoot)} does not exist`);
+    assert.lte(block.slot, attestation.data.slot, "Attestation is for past block");
 
     const validators = getAttestingIndices(
       this.config, checkpointState, attestation.data, attestation.aggregationBits);

--- a/packages/lodestar/src/chain/forkChoice/arrayDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/arrayDag/lmdGhost.ts
@@ -97,7 +97,7 @@ export class Node {
   }
 
   public shiftIndex(n: number): void {
-    assert(n >= 0, "invalid value to shift index: " + n);
+    assert.gte(n, 0, "Shift index must be positive");
     if (this.hasBestChild()) {
       this.bestChild = this.bestChild - n;
     }
@@ -216,12 +216,13 @@ export class ArrayDagLMDGHOST implements ILMDGHOST {
     // Check that block is later than the finalized epoch slot (optimization to reduce calls to get_ancestor)
     if (this.finalized && this.finalized.node) {
       const finalizedSlot = computeStartSlotAtEpoch(this.config, this.finalized.epoch);
-      assert(node.slot > finalizedSlot,
-        `Fork choice: node slot ${node.slot} should be bigger than finalized slot ${finalizedSlot}`);
+      assert.gt(node.slot, finalizedSlot, "Fork choice: node slot should be bigger than finalized slot");
       // Check block is a descendant of the finalized block at the checkpoint finalized slot
-      assert(
-        this.getAncestor(blockRootHex, finalizedSlot) === this.finalized.node.blockRoot,
-        `Fork choice: Block slot ${node.slot} is not on the same chain, finalized slot=${finalizedSlot}`);
+      assert.equal(
+        this.getAncestor(blockRootHex, finalizedSlot), 
+        this.finalized.node.blockRoot,
+        `Fork choice: Block slot ${node.slot} is not on the same chain, finalized slot=${finalizedSlot}`
+      );
     }
 
     let shouldCheckBestTarget = false;
@@ -323,7 +324,7 @@ export class ArrayDagLMDGHOST implements ILMDGHOST {
   }
 
   public headNode(): Node {
-    assert(Boolean(this.justified));
+    assert.true(Boolean(this.justified), "Justified checkpoint does not exist");
     if (!this.synced) {
       this.syncChanges();
     }
@@ -341,7 +342,7 @@ export class ArrayDagLMDGHOST implements ILMDGHOST {
   }
 
   public headStateRoot(): Uint8Array {
-    assert(Boolean(this.justified));
+    assert.true(Boolean(this.justified), "Justified checkpoint does not exist");
     if (!this.synced) {
       this.syncChanges();
     }

--- a/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
@@ -323,12 +323,13 @@ export class StatefulDagLMDGHOST implements ILMDGHOST {
     // Check that block is later than the finalized epoch slot (optimization to reduce calls to get_ancestor)
     if (this.finalized) {
       const finalizedSlot = computeStartSlotAtEpoch(this.config, this.finalized.epoch);
-      assert(node.slot > finalizedSlot,
-        `Fork choice: node slot ${node.slot} should be bigger than finalized slot ${finalizedSlot}`);
+      assert.gt(node.slot, finalizedSlot, "Fork choice: node slot should be bigger than finalized slot");
       // Check block is a descendant of the finalized block at the checkpoint finalized slot
-      assert(
-        this.getAncestor(blockRootHex, finalizedSlot) === this.finalized.node.blockRoot,
-        `Fork choice: Block slot ${node.slot} is not on the same chain`);
+      assert.equal(
+        this.getAncestor(blockRootHex, finalizedSlot),
+        this.finalized.node.blockRoot,
+        `Fork choice: Block slot ${node.slot} is not on the same chain`
+      );
     }
 
     let shouldCheckBestTarget = false;
@@ -408,7 +409,7 @@ export class StatefulDagLMDGHOST implements ILMDGHOST {
     return this.headNode().toBlockSummary();
   }
   public headNode(): Node {
-    assert(Boolean(this.justified));
+    assert.true(Boolean(this.justified), "Justified checkpoint does not exist");
     if (!this.synced) {
       this.syncChanges();
     }

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -64,8 +64,9 @@ export class LodestarGossipsub extends Gossipsub {
 
   public async validate(rawMessage: IGossipMessage): Promise<boolean> {
     const message: ILodestarGossipMessage = normalizeInRpcMessage(rawMessage);
-    assert(message.topicIDs && message.topicIDs.length === 1, `Invalid topicIDs: ${message.topicIDs}`);
-    assert(message.data.length <= GOSSIP_MAX_SIZE, `Message exceeds size limit of ${GOSSIP_MAX_SIZE} bytes`);
+    assert.true(Boolean(message.topicIDs), "topicIds is not defined");
+    assert.equal(message.topicIDs.length, 1, "topicIds array must contain one item");
+    assert.lte(message.data.length, GOSSIP_MAX_SIZE, "Message exceeds byte size limit");
     const topic = message.topicIDs[0];
     // avoid duplicate
     if (this.transformedObjects.get(message.messageId)) {

--- a/packages/lodestar/src/network/gossip/utils.ts
+++ b/packages/lodestar/src/network/gossip/utils.ts
@@ -72,7 +72,7 @@ export function isAttestationSubnetTopic(topic: string): boolean {
 }
 
 export function getSubnetFromAttestationSubnetTopic(topic: string): number {
-  assert(isAttestationSubnetTopic(topic), "should be an attestation topic");
+  assert.true(isAttestationSubnetTopic(topic), "should be an attestation topic");
   const groups = topic.match(AttestationSubnetRegExp);
   const subnetStr = groups[4];
   return parseInt(subnetStr);

--- a/packages/lodestar/src/network/gossip/utils.ts
+++ b/packages/lodestar/src/network/gossip/utils.ts
@@ -72,7 +72,7 @@ export function isAttestationSubnetTopic(topic: string): boolean {
 }
 
 export function getSubnetFromAttestationSubnetTopic(topic: string): number {
-  assert.true(isAttestationSubnetTopic(topic), "should be an attestation topic");
+  assert.true(isAttestationSubnetTopic(topic), "Should be an attestation topic");
   const groups = topic.match(AttestationSubnetRegExp);
   const subnetStr = groups[4];
   return parseInt(subnetStr);


### PR DESCRIPTION
Add meaningful assert messages to all `assert()` statements.

Extends the assert util to include comparator methods (`equal`, `lte`, `lt`, `gte`, `gt`) so the error message contains the asserted values.

Assert errors currently printing 
```
AssertionError: Expect false == true
```

will print
```
AssertionError: Current slot less than this target epoch's start slot: 351 >= 354
```