### PR TITLE
Block endpoints in rest api

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,5 @@
-version: "2"         # required to adjust maintainability checks
+version: "2"  # required to adjust maintainability checks
+
 checks:
   argument-count:
     config:
@@ -30,3 +31,9 @@ checks:
   identical-code:
     config:
       threshold: 95
+exclude_patterns:
+  - "**/node_modules/"
+  - "**/dist"
+  - "**/test"
+  - "**/lib"
+  - "**/*.d.ts"

--- a/packages/lodestar-types/src/ssz/generators/api.ts
+++ b/packages/lodestar-types/src/ssz/generators/api.ts
@@ -1,6 +1,14 @@
 import {IBeaconSSZTypes} from "../interface";
 import {ContainerType} from "@chainsafe/ssz";
 
+export const SignedBeaconHeaderResponse = (ssz: IBeaconSSZTypes): ContainerType => new ContainerType({
+  fields: {
+    root: ssz.Root,
+    canonical: ssz.Boolean,
+    header: ssz.SignedBeaconBlockHeader
+  },
+});
+
 export const SubscribeToCommitteeSubnetPayload = (ssz: IBeaconSSZTypes): ContainerType => new ContainerType({
   fields: {
     slot: ssz.Slot,

--- a/packages/lodestar-types/src/ssz/interface.ts
+++ b/packages/lodestar-types/src/ssz/interface.ts
@@ -83,6 +83,7 @@ export interface IBeaconSSZTypes {
   BeaconBlocksByRangeRequest: ContainerType<t.BeaconBlocksByRangeRequest>;
   BeaconBlocksByRootRequest: ContainerType<t.BeaconBlocksByRootRequest>;
   //api
+  SignedBeaconHeaderResponse: ContainerType<t.SignedBeaconHeaderResponse>;
   SubscribeToCommitteeSubnetPayload: ContainerType<t.SubscribeToCommitteeSubnetPayload>;
   ForkResponse: ContainerType<t.ForkResponse>;
   ValidatorResponse: ContainerType<t.ValidatorResponse>;
@@ -158,6 +159,7 @@ export const typeNames: (keyof IBeaconSSZTypes)[] = [
   "BeaconBlocksByRangeRequest",
   "BeaconBlocksByRootRequest",
   //api
+  "SignedBeaconHeaderResponse",
   "SubscribeToCommitteeSubnetPayload",
   "ForkResponse",
   "SyncingStatus",

--- a/packages/lodestar-types/src/types/api.ts
+++ b/packages/lodestar-types/src/types/api.ts
@@ -1,6 +1,12 @@
 /* eslint-disable @typescript-eslint/interface-name-prefix */
 import {BLSPubkey, BLSSignature, CommitteeIndex, Gwei, Number64, Slot, Uint64, ValidatorIndex, Root} from "./primitive";
-import {Fork, Validator} from "./misc";
+import {Fork, SignedBeaconBlockHeader, Validator} from "./misc";
+
+export interface SignedBeaconHeaderResponse {
+  root: Root;
+  canonical: boolean;
+  header: SignedBeaconBlockHeader;
+}
 
 export interface SubscribeToCommitteeSubnetPayload {
   slot: Slot;

--- a/packages/lodestar/src/api/impl/beacon/beacon.ts
+++ b/packages/lodestar/src/api/impl/beacon/beacon.ts
@@ -11,8 +11,8 @@ import {
   Number64,
   SignedBeaconBlock,
   SyncingStatus,
-  ValidatorResponse,
-  Uint64
+  Uint64,
+  ValidatorResponse
 } from "@chainsafe/lodestar-types";
 import {IBeaconApi} from "./interface";
 import {IBeaconChain} from "../../../chain";
@@ -22,10 +22,12 @@ import {ApiNamespace} from "../../index";
 import EventIterator from "event-iterator";
 import {IBeaconDb} from "../../../db/api";
 import {IBeaconSync} from "../../../sync";
+import {BeaconBlockApi, IBeaconBlocksApi} from "./blocks";
 
 export class BeaconApi implements IBeaconApi {
 
   public namespace: ApiNamespace;
+  public blocks: IBeaconBlocksApi;
 
   private readonly config: IBeaconConfig;
   private readonly chain: IBeaconChain;
@@ -38,6 +40,7 @@ export class BeaconApi implements IBeaconApi {
     this.chain = modules.chain;
     this.db = modules.db;
     this.sync = modules.sync;
+    this.blocks = new BeaconBlockApi(opts, modules);
   }
 
   public async getClientVersion(): Promise<Bytes32> {
@@ -92,7 +95,7 @@ export class BeaconApi implements IBeaconApi {
   }
 
   public getBlockStream(): AsyncIterable<SignedBeaconBlock> {
-    return new EventIterator<SignedBeaconBlock>((push) => {
+    return new EventIterator<SignedBeaconBlock>(({push}) => {
       this.chain.on("processedBlock", (block) => {
         push(block);
       });

--- a/packages/lodestar/src/api/impl/beacon/beacon.ts
+++ b/packages/lodestar/src/api/impl/beacon/beacon.ts
@@ -95,7 +95,7 @@ export class BeaconApi implements IBeaconApi {
   }
 
   public getBlockStream(): AsyncIterable<SignedBeaconBlock> {
-    return new EventIterator<SignedBeaconBlock>(({push}) => {
+    return new EventIterator<SignedBeaconBlock>((push) => {
       this.chain.on("processedBlock", (block) => {
         push(block);
       });

--- a/packages/lodestar/src/api/impl/beacon/blocks/index.ts
+++ b/packages/lodestar/src/api/impl/beacon/blocks/index.ts
@@ -1,5 +1,5 @@
-import {IBeaconBlocksApi} from "./interface";
-import {Root, SignedBeaconHeaderResponse, Slot} from "@chainsafe/lodestar-types";
+import {BlockId, IBeaconBlocksApi} from "./interface";
+import {Root, SignedBeaconBlock, SignedBeaconHeaderResponse, Slot} from "@chainsafe/lodestar-types";
 import {IApiOptions} from "../../../options";
 import {IApiModules} from "../../../interface";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
@@ -57,13 +57,22 @@ export class BeaconBlockApi implements IBeaconBlocksApi {
     return result;
   }
 
-  public async getBlockHeader(blockId: string): Promise<SignedBeaconHeaderResponse | null> {
+  public async getBlockHeader(blockId: BlockId): Promise<SignedBeaconHeaderResponse | null> {
     const blockRoot = await resolveBlockId(this.config, this.chain.forkChoice, blockId);
     if(!blockRoot) {
       return null;
     }
     //TODO: handle when root points to finalized block
     return toBeaconHeaderResponse(this.config, await this.db.block.get(blockRoot.valueOf() as Uint8Array));
+  }
+
+  public async getBlock(blockId: BlockId): Promise<SignedBeaconBlock | null> {
+    const blockRoot = await resolveBlockId(this.config, this.chain.forkChoice, blockId);
+    if(!blockRoot) {
+      return null;
+    }
+    //TODO: handle when root points to finalized block
+    return await this.db.block.get(blockRoot.valueOf() as Uint8Array);
   }
 
 }

--- a/packages/lodestar/src/api/impl/beacon/blocks/index.ts
+++ b/packages/lodestar/src/api/impl/beacon/blocks/index.ts
@@ -1,0 +1,54 @@
+import {IBeaconBlocksApi} from "./interface";
+import {Root, SignedBeaconHeaderResponse, Slot} from "@chainsafe/lodestar-types";
+import {IApiOptions} from "../../../options";
+import {IApiModules} from "../../../interface";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IBeaconChain} from "../../../../chain";
+import {IBeaconDb} from "../../../../db/api";
+import {toBeaconHeaderResponse} from "./utils";
+
+export * from "./interface";
+
+export class BeaconBlockApi implements IBeaconBlocksApi {
+
+  private readonly config: IBeaconConfig;
+  private readonly chain: IBeaconChain;
+  private readonly db: IBeaconDb;
+
+  public constructor(opts: Partial<IApiOptions>, modules: IApiModules) {
+    this.config = modules.config;
+    this.chain = modules.chain;
+    this.db = modules.db;
+  }
+
+  public async getBlockHeaders(
+    filters: Partial<{ slot: Slot; parentRoot: Root }>
+  ): Promise<SignedBeaconHeaderResponse[]> {
+    const result: SignedBeaconHeaderResponse[] = [];
+    if(filters.parentRoot) {
+      //TODO: figure out how to filter and return blocks with given parent root
+      return result;
+    }
+    if(!filters.parentRoot && !filters.slot && filters.slot !== 0) {
+      filters.slot = this.chain.forkChoice.headBlockSlot();
+    }
+    if(filters.slot > this.chain.forkChoice.headBlockSlot()) {
+      return [];
+    }
+    const canonicalBlock = await this.chain.getBlockAtSlot(filters.slot);
+    const canonicalRoot = this.config.types.BeaconBlock.hashTreeRoot(canonicalBlock.message);
+    result.push(toBeaconHeaderResponse(this.config, canonicalBlock, true));
+
+    await Promise.all(
+      this.chain.forkChoice.getBlockSummariesAtSlot(filters.slot)
+        //remove canonical block
+        .filter((summary) => !this.config.types.Root.equals(summary.blockRoot, canonicalRoot))
+        .map(async (summary) => {
+          result.push(toBeaconHeaderResponse(this.config, await this.db.block.get(summary.blockRoot)));
+        })
+    );
+    return result;
+  }
+
+}
+

--- a/packages/lodestar/src/api/impl/beacon/blocks/index.ts
+++ b/packages/lodestar/src/api/impl/beacon/blocks/index.ts
@@ -5,7 +5,7 @@ import {IApiModules} from "../../../interface";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBeaconChain} from "../../../../chain";
 import {IBeaconDb} from "../../../../db/api";
-import {toBeaconHeaderResponse} from "./utils";
+import {resolveBlockId, toBeaconHeaderResponse} from "./utils";
 
 export * from "./interface";
 
@@ -55,6 +55,15 @@ export class BeaconBlockApi implements IBeaconBlocksApi {
         })
     );
     return result;
+  }
+
+  public async getBlockHeader(blockId: string): Promise<SignedBeaconHeaderResponse | null> {
+    const blockRoot = await resolveBlockId(this.config, this.chain.forkChoice, blockId);
+    if(!blockRoot) {
+      return null;
+    }
+    //TODO: handle when root points to finalized block
+    return toBeaconHeaderResponse(this.config, await this.db.block.get(blockRoot.valueOf() as Uint8Array));
   }
 
 }

--- a/packages/lodestar/src/api/impl/beacon/blocks/interface.ts
+++ b/packages/lodestar/src/api/impl/beacon/blocks/interface.ts
@@ -1,0 +1,5 @@
+import {Root, SignedBeaconHeaderResponse, Slot} from "@chainsafe/lodestar-types";
+
+export interface IBeaconBlocksApi {
+  getBlockHeaders(filters: Partial<{slot: Slot; parentRoot: Root}>): Promise<SignedBeaconHeaderResponse[]>;
+}

--- a/packages/lodestar/src/api/impl/beacon/blocks/interface.ts
+++ b/packages/lodestar/src/api/impl/beacon/blocks/interface.ts
@@ -2,4 +2,6 @@ import {Root, SignedBeaconHeaderResponse, Slot} from "@chainsafe/lodestar-types"
 
 export interface IBeaconBlocksApi {
   getBlockHeaders(filters: Partial<{slot: Slot; parentRoot: Root}>): Promise<SignedBeaconHeaderResponse[]>;
+
+  getBlockHeader(blockId: string): Promise<SignedBeaconHeaderResponse|null>;
 }

--- a/packages/lodestar/src/api/impl/beacon/blocks/interface.ts
+++ b/packages/lodestar/src/api/impl/beacon/blocks/interface.ts
@@ -1,7 +1,9 @@
-import {Root, SignedBeaconHeaderResponse, Slot} from "@chainsafe/lodestar-types";
+import {Root, SignedBeaconBlock, SignedBeaconHeaderResponse, Slot} from "@chainsafe/lodestar-types";
 
 export interface IBeaconBlocksApi {
   getBlockHeaders(filters: Partial<{slot: Slot; parentRoot: Root}>): Promise<SignedBeaconHeaderResponse[]>;
-
-  getBlockHeader(blockId: string): Promise<SignedBeaconHeaderResponse|null>;
+  getBlockHeader(blockId: BlockId): Promise<SignedBeaconHeaderResponse|null>;
+  getBlock(blockId: BlockId): Promise<SignedBeaconBlock|null>;
 }
+
+export type BlockId = string|"head"|"genesis"|"finalized";

--- a/packages/lodestar/src/api/impl/beacon/blocks/utils.ts
+++ b/packages/lodestar/src/api/impl/beacon/blocks/utils.ts
@@ -1,8 +1,11 @@
-import {SignedBeaconBlock, SignedBeaconHeaderResponse} from "@chainsafe/lodestar-types";
+import {Root, SignedBeaconBlock, SignedBeaconHeaderResponse} from "@chainsafe/lodestar-types";
 import {blockToHeader} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {ILMDGHOST} from "../../../../chain/forkChoice";
 
-export function toBeaconHeaderResponse(config: IBeaconConfig, block: SignedBeaconBlock, canonical= false): SignedBeaconHeaderResponse {
+export function toBeaconHeaderResponse(
+  config: IBeaconConfig, block: SignedBeaconBlock, canonical= false
+): SignedBeaconHeaderResponse {
   return {
     root: config.types.BeaconBlock.hashTreeRoot(block.message),
     canonical,
@@ -11,4 +14,35 @@ export function toBeaconHeaderResponse(config: IBeaconConfig, block: SignedBeaco
       signature: block.signature
     }
   };
+}
+
+// this will need async once we wan't to resolve archive slot
+export async function resolveBlockId(
+  config: IBeaconConfig, forkChoice: ILMDGHOST, blockId: string
+): Promise<Root|null> {
+  blockId = blockId.toLowerCase();
+  if(blockId === "head") {
+    return forkChoice.headBlockRoot();
+  }
+  if(blockId === "genesis") {
+    blockId = "0";
+  }
+  if(blockId === "finalized") {
+    return forkChoice.getFinalized().root;
+  }
+  if(blockId.startsWith("0x")) {
+    return config.types.Root.fromJson(blockId);
+  }
+  //block id must be slot
+  const slot = parseInt(blockId, 10);
+  if(isNaN(slot) && isNaN(slot - 0)) {
+    throw new Error("Invalid block id");
+  }
+  const blockSummary = forkChoice.getCanonicalBlockSummaryAtSlot(slot);
+  if(blockSummary) {
+    return blockSummary.blockRoot;
+  }
+  //todo: resolve archive slot -> root
+
+  return null;
 }

--- a/packages/lodestar/src/api/impl/beacon/blocks/utils.ts
+++ b/packages/lodestar/src/api/impl/beacon/blocks/utils.ts
@@ -1,0 +1,14 @@
+import {SignedBeaconBlock, SignedBeaconHeaderResponse} from "@chainsafe/lodestar-types";
+import {blockToHeader} from "@chainsafe/lodestar-beacon-state-transition";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+
+export function toBeaconHeaderResponse(config: IBeaconConfig, block: SignedBeaconBlock, canonical= false): SignedBeaconHeaderResponse {
+  return {
+    root: config.types.BeaconBlock.hashTreeRoot(block.message),
+    canonical,
+    header: {
+      message: blockToHeader(config, block.message),
+      signature: block.signature
+    }
+  };
+}

--- a/packages/lodestar/src/api/impl/beacon/blocks/utils.ts
+++ b/packages/lodestar/src/api/impl/beacon/blocks/utils.ts
@@ -2,6 +2,7 @@ import {Root, SignedBeaconBlock, SignedBeaconHeaderResponse} from "@chainsafe/lo
 import {blockToHeader} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILMDGHOST} from "../../../../chain/forkChoice";
+import {BlockId} from "./interface";
 
 export function toBeaconHeaderResponse(
   config: IBeaconConfig, block: SignedBeaconBlock, canonical= false
@@ -18,7 +19,7 @@ export function toBeaconHeaderResponse(
 
 // this will need async once we wan't to resolve archive slot
 export async function resolveBlockId(
-  config: IBeaconConfig, forkChoice: ILMDGHOST, blockId: string
+  config: IBeaconConfig, forkChoice: ILMDGHOST, blockId: BlockId
 ): Promise<Root|null> {
   blockId = blockId.toLowerCase();
   if(blockId === "head") {

--- a/packages/lodestar/src/api/impl/beacon/interface.ts
+++ b/packages/lodestar/src/api/impl/beacon/interface.ts
@@ -12,8 +12,11 @@ import {
   SyncingStatus,
   ValidatorResponse
 } from "@chainsafe/lodestar-types";
+import {IBeaconBlocksApi} from "./blocks";
 
 export interface IBeaconApi extends IApi {
+
+  blocks: IBeaconBlocksApi;
 
   /**
    * Requests that the BeaconNode identify information about its

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlock.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlock.ts
@@ -2,19 +2,19 @@ import {ApiController} from "../../types";
 import {DefaultQuery} from "fastify";
 import {FastifyError} from "fastify";
 
-export const getBlockHeader: ApiController<DefaultQuery, {blockId: string}> = {
+export const getBlock: ApiController<DefaultQuery, {blockId: string}> = {
 
-  url: "/v1/beacon/headers/:blockId",
+  url: "/v1/beacon/blocks/:blockId",
 
   handler: async function (req, resp) {
     try {
-      const data = await this.api.beacon.blocks.getBlockHeader(req.params.blockId);
+      const data = await this.api.beacon.blocks.getBlock(req.params.blockId);
       if(!data) {
         return resp.status(404).send();
       }
       return resp.status(200)
         .send({
-          data: this.config.types.SignedBeaconHeaderResponse.toJson(data, {case: "snake"})
+          data: this.config.types.SignedBeaconBlock.toJson(data, {case: "snake"})
         });
     } catch (e) {
       if(e.message === "Invalid block id") {

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockAttestations.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockAttestations.ts
@@ -1,0 +1,51 @@
+import {ApiController} from "../../types";
+import {DefaultQuery} from "fastify";
+import {FastifyError} from "fastify";
+
+export const getBlockAttestations: ApiController<DefaultQuery, {blockId: string}> = {
+
+  url: "/v1/beacon/blocks/:blockId/attestations",
+
+  handler: async function (req, resp) {
+    try {
+      const data = await this.api.beacon.blocks.getBlock(req.params.blockId);
+      if(!data) {
+        return resp.status(404).send();
+      }
+      return resp.status(200)
+        .send({
+          data: Array.from(data.message.body.attestations).map(attestations => {
+            this.config.types.Attestation.toJson(attestations, {case: "snake"});
+          })
+        });
+    } catch (e) {
+      if(e.message === "Invalid block id") {
+        //TODO: fix when unifying errors
+        throw {
+          statusCode: 400,
+          validation: [
+            {
+              dataPath: "block_id",
+              message: e.message
+            }
+          ]
+        } as FastifyError;
+      }
+      throw e;
+    }
+  },
+
+  opts: {
+    schema: {
+      params: {
+        type: "object",
+        required: ["blockId"],
+        properties: {
+          blockId: {
+            types: "string"
+          }
+        }
+      }
+    }
+  }
+};

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockHeader.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockHeader.ts
@@ -1,0 +1,49 @@
+import {ApiController} from "../../types";
+import {DefaultQuery} from "fastify";
+import {FastifyError} from "fastify";
+
+export const getBlockHeader: ApiController<DefaultQuery, {blockId: string}> = {
+
+  url: "/v1/beacon/block/headers/:blockId",
+
+  handler: async function (req, resp) {
+    try {
+      const data = await this.api.beacon.blocks.getBlockHeader(req.params.blockId);
+      if(!data) {
+        return resp.status(404).send();
+      }
+      return resp.status(200)
+        .send({
+          data: this.config.types.SignedBeaconHeaderResponse.toJson(data, {case: "snake"})
+        });
+    } catch (e) {
+      if(e.message === "Invalid block id") {
+        //TODO: fix when unifying errors
+        throw {
+          statusCode: 400,
+          validation: [
+            {
+              dataPath: "block_id",
+              message: e.message
+            }
+          ]
+        } as FastifyError;
+      }
+      throw e;
+    }
+  },
+
+  opts: {
+    schema: {
+      params: {
+        type: "object",
+        required: ["blockId"],
+        properties: {
+          blockId: {
+            types: "string"
+          }
+        }
+      }
+    }
+  }
+};

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockHeaders.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockHeaders.ts
@@ -3,7 +3,7 @@ import {ApiController} from "../../types";
 
 export const getBlockHeaders: ApiController<{slot?: string; parent_root?: string}> = {
 
-  url: "/v1/beacon/block/headers",
+  url: "/v1/beacon/headers",
 
   handler: async function (req, resp) {
     let slot: Slot|undefined;

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockHeaders.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockHeaders.ts
@@ -1,5 +1,5 @@
-import {ApiController} from "../types";
 import {Root, Slot} from "@chainsafe/lodestar-types";
+import {ApiController} from "../../types";
 
 export const getBlockHeaders: ApiController<{slot?: string; parent_root?: string}> = {
 

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockRoot.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockRoot.ts
@@ -1,0 +1,51 @@
+import {ApiController} from "../../types";
+import {DefaultQuery} from "fastify";
+import {FastifyError} from "fastify";
+
+export const getBlockRoot: ApiController<DefaultQuery, {blockId: string}> = {
+
+  url: "/v1/beacon/blocks/:blockId/root",
+
+  handler: async function (req, resp) {
+    try {
+      const data = await this.api.beacon.blocks.getBlock(req.params.blockId);
+      if(!data) {
+        return resp.status(404).send();
+      }
+      return resp.status(200)
+        .send({
+          data: {
+            root: this.config.types.Root.toJson(this.config.types.BeaconBlock.hashTreeRoot(data.message))
+          }
+        });
+    } catch (e) {
+      if(e.message === "Invalid block id") {
+        //TODO: fix when unifying errors
+        throw {
+          statusCode: 400,
+          validation: [
+            {
+              dataPath: "block_id",
+              message: e.message
+            }
+          ]
+        } as FastifyError;
+      }
+      throw e;
+    }
+  },
+
+  opts: {
+    schema: {
+      params: {
+        type: "object",
+        required: ["blockId"],
+        properties: {
+          blockId: {
+            types: "string"
+          }
+        }
+      }
+    }
+  }
+};

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/index.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/index.ts
@@ -1,2 +1,3 @@
 export * from "./getBlockHeaders";
 export * from "./getBlockHeader";
+export * from "./getBlock";

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/index.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/index.ts
@@ -2,3 +2,4 @@ export * from "./getBlockHeaders";
 export * from "./getBlockHeader";
 export * from "./getBlock";
 export * from "./getBlockRoot";
+export * from "./getBlockAttestations";

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/index.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/index.ts
@@ -1,3 +1,4 @@
 export * from "./getBlockHeaders";
 export * from "./getBlockHeader";
 export * from "./getBlock";
+export * from "./getBlockRoot";

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/index.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/index.ts
@@ -1,0 +1,2 @@
+export * from "./getBlockHeaders";
+export * from "./getBlockHeader";

--- a/packages/lodestar/src/api/rest/controllers/beacon/getBlockHeaders.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/getBlockHeaders.ts
@@ -1,0 +1,36 @@
+import {ApiController} from "../types";
+import {Root, Slot} from "@chainsafe/lodestar-types";
+
+export const getBlockHeaders: ApiController<{slot?: string; parent_root?: string}> = {
+  handler: async function (req, resp) {
+    let slot: Slot|undefined;
+    if(req.query.slot) {
+      slot = this.config.types.Slot.fromJson(req.query.slot);
+    }
+    let parentRoot: Root|undefined;
+    if(req.query.parent_root) {
+      parentRoot = this.config.types.Root.fromJson(req.query.parent_root);
+    }
+    const data = await this.api.beacon.blocks.getBlockHeaders({slot, parentRoot});
+    resp.status(200).send({
+      data: data.map((item) => this.config.types.SignedBeaconHeaderResponse.toJson(item, {case: "snake"}))
+    });
+  },
+  opts: {
+    schema: {
+      querystring: {
+        type: "object",
+        required: [],
+        properties: {
+          "slot": {
+            type: "number",
+            minimum: 0
+          },
+          "parentRoot": {
+            type: "string"
+          }
+        }
+      }
+    }
+  }
+};

--- a/packages/lodestar/src/api/rest/controllers/beacon/getBlockHeaders.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/getBlockHeaders.ts
@@ -2,6 +2,9 @@ import {ApiController} from "../types";
 import {Root, Slot} from "@chainsafe/lodestar-types";
 
 export const getBlockHeaders: ApiController<{slot?: string; parent_root?: string}> = {
+
+  url: "/v1/beacon/block/headers",
+
   handler: async function (req, resp) {
     let slot: Slot|undefined;
     if(req.query.slot) {
@@ -16,6 +19,7 @@ export const getBlockHeaders: ApiController<{slot?: string; parent_root?: string
       data: data.map((item) => this.config.types.SignedBeaconHeaderResponse.toJson(item, {case: "snake"}))
     });
   },
+
   opts: {
     schema: {
       querystring: {

--- a/packages/lodestar/src/api/rest/controllers/types.ts
+++ b/packages/lodestar/src/api/rest/controllers/types.ts
@@ -1,0 +1,13 @@
+import {DefaultBody, DefaultHeaders, DefaultParams, DefaultQuery, RequestHandler, RouteShorthandOptions} from "fastify";
+import {IncomingMessage, Server, ServerResponse} from "http";
+
+export type ApiHandler<Query = DefaultQuery, Params = DefaultParams, Body = DefaultBody, Headers = DefaultHeaders>
+    = RequestHandler<IncomingMessage, ServerResponse, Query, Params, Headers, Body>;
+
+// eslint-disable-next-line @typescript-eslint/interface-name-prefix
+export interface ApiController<
+  Query = DefaultQuery, Params = DefaultParams, Body = DefaultBody, Headers = DefaultHeaders
+> {
+  opts: RouteShorthandOptions<Server, IncomingMessage, ServerResponse, Query, Params, Headers, Body>;
+  handler: ApiHandler<Query, Params, Body, Headers>;
+}

--- a/packages/lodestar/src/api/rest/controllers/types.ts
+++ b/packages/lodestar/src/api/rest/controllers/types.ts
@@ -10,4 +10,5 @@ export interface ApiController<
 > {
   opts: RouteShorthandOptions<Server, IncomingMessage, ServerResponse, Query, Params, Headers, Body>;
   handler: ApiHandler<Query, Params, Body, Headers>;
+  url: string;
 }

--- a/packages/lodestar/src/api/rest/routes/beacon/index.ts
+++ b/packages/lodestar/src/api/rest/routes/beacon/index.ts
@@ -6,7 +6,13 @@ import {LodestarApiPlugin} from "../../interface";
 import {registerBlockStreamEndpoint} from "./blockStream";
 import {registerGetValidatorEndpoint} from "./validator";
 import {FastifyInstance} from "fastify";
-import {getBlock, getBlockHeader, getBlockHeaders, getBlockRoot} from "../../controllers/beacon/blocks";
+import {
+  getBlock,
+  getBlockAttestations,
+  getBlockHeader,
+  getBlockHeaders,
+  getBlockRoot
+} from "../../controllers/beacon/blocks";
 
 //old
 export const beacon: LodestarApiPlugin = (fastify, opts, done: Function): void => {
@@ -25,4 +31,5 @@ export function registerBeaconRoutes(server: FastifyInstance): void {
   server.get(getBlockHeader.url, getBlockHeader.opts, getBlockHeader.handler);
   server.get(getBlock.url, getBlock.opts, getBlock.handler);
   server.get(getBlockRoot.url, getBlockRoot.opts, getBlockRoot.handler);
+  server.get(getBlockAttestations.url, getBlockAttestations.opts, getBlockAttestations.handler);
 }

--- a/packages/lodestar/src/api/rest/routes/beacon/index.ts
+++ b/packages/lodestar/src/api/rest/routes/beacon/index.ts
@@ -5,7 +5,10 @@ import {registerSyncingEndpoint} from "./syncing";
 import {LodestarApiPlugin} from "../../interface";
 import {registerBlockStreamEndpoint} from "./blockStream";
 import {registerGetValidatorEndpoint} from "./validator";
+import {FastifyInstance} from "fastify";
+import {getBlockHeaders} from "../../controllers/beacon/getBlockHeaders";
 
+//old
 export const beacon: LodestarApiPlugin = (fastify, opts, done: Function): void => {
   registerVersionEndpoint(fastify, opts);
   registerGenesisTimeEndpoint(fastify, opts);
@@ -15,3 +18,8 @@ export const beacon: LodestarApiPlugin = (fastify, opts, done: Function): void =
   registerBlockStreamEndpoint(fastify, opts);
   done();
 };
+
+//new
+export function registerBeaconRoutes(server: FastifyInstance): void {
+  server.get("/v1/beacon/headers", getBlockHeaders.opts, getBlockHeaders.handler);
+}

--- a/packages/lodestar/src/api/rest/routes/beacon/index.ts
+++ b/packages/lodestar/src/api/rest/routes/beacon/index.ts
@@ -6,7 +6,7 @@ import {LodestarApiPlugin} from "../../interface";
 import {registerBlockStreamEndpoint} from "./blockStream";
 import {registerGetValidatorEndpoint} from "./validator";
 import {FastifyInstance} from "fastify";
-import {getBlockHeaders, getBlockHeader} from "../../controllers/beacon/blocks";
+import {getBlock, getBlockHeader, getBlockHeaders} from "../../controllers/beacon/blocks";
 
 //old
 export const beacon: LodestarApiPlugin = (fastify, opts, done: Function): void => {
@@ -23,4 +23,5 @@ export const beacon: LodestarApiPlugin = (fastify, opts, done: Function): void =
 export function registerBeaconRoutes(server: FastifyInstance): void {
   server.get(getBlockHeaders.url, getBlockHeaders.opts, getBlockHeaders.handler);
   server.get(getBlockHeader.url, getBlockHeader.opts, getBlockHeader.handler);
+  server.get(getBlock.url, getBlock.opts, getBlock.handler);
 }

--- a/packages/lodestar/src/api/rest/routes/beacon/index.ts
+++ b/packages/lodestar/src/api/rest/routes/beacon/index.ts
@@ -6,7 +6,7 @@ import {LodestarApiPlugin} from "../../interface";
 import {registerBlockStreamEndpoint} from "./blockStream";
 import {registerGetValidatorEndpoint} from "./validator";
 import {FastifyInstance} from "fastify";
-import {getBlock, getBlockHeader, getBlockHeaders} from "../../controllers/beacon/blocks";
+import {getBlock, getBlockHeader, getBlockHeaders, getBlockRoot} from "../../controllers/beacon/blocks";
 
 //old
 export const beacon: LodestarApiPlugin = (fastify, opts, done: Function): void => {
@@ -24,4 +24,5 @@ export function registerBeaconRoutes(server: FastifyInstance): void {
   server.get(getBlockHeaders.url, getBlockHeaders.opts, getBlockHeaders.handler);
   server.get(getBlockHeader.url, getBlockHeader.opts, getBlockHeader.handler);
   server.get(getBlock.url, getBlock.opts, getBlock.handler);
+  server.get(getBlockRoot.url, getBlockRoot.opts, getBlockRoot.handler);
 }

--- a/packages/lodestar/src/api/rest/routes/beacon/index.ts
+++ b/packages/lodestar/src/api/rest/routes/beacon/index.ts
@@ -21,5 +21,5 @@ export const beacon: LodestarApiPlugin = (fastify, opts, done: Function): void =
 
 //new
 export function registerBeaconRoutes(server: FastifyInstance): void {
-  server.get("/v1/beacon/headers", getBlockHeaders.opts, getBlockHeaders.handler);
+  server.get(getBlockHeaders.url, getBlockHeaders.opts, getBlockHeaders.handler);
 }

--- a/packages/lodestar/src/api/rest/routes/beacon/index.ts
+++ b/packages/lodestar/src/api/rest/routes/beacon/index.ts
@@ -6,7 +6,7 @@ import {LodestarApiPlugin} from "../../interface";
 import {registerBlockStreamEndpoint} from "./blockStream";
 import {registerGetValidatorEndpoint} from "./validator";
 import {FastifyInstance} from "fastify";
-import {getBlockHeaders} from "../../controllers/beacon/getBlockHeaders";
+import {getBlockHeaders, getBlockHeader} from "../../controllers/beacon/blocks";
 
 //old
 export const beacon: LodestarApiPlugin = (fastify, opts, done: Function): void => {
@@ -22,4 +22,5 @@ export const beacon: LodestarApiPlugin = (fastify, opts, done: Function): void =
 //new
 export function registerBeaconRoutes(server: FastifyInstance): void {
   server.get(getBlockHeaders.url, getBlockHeaders.opts, getBlockHeaders.handler);
+  server.get(getBlockHeader.url, getBlockHeader.opts, getBlockHeader.handler);
 }

--- a/packages/lodestar/src/api/rest/routes/index.ts
+++ b/packages/lodestar/src/api/rest/routes/index.ts
@@ -1,2 +1,9 @@
+import {FastifyInstance} from "fastify";
+import {registerBeaconRoutes} from "./beacon";
+
 export * from "./beacon";
 export * from "./validator";
+
+export function registerRoutes(server: FastifyInstance): void {
+  registerBeaconRoutes(server);
+}

--- a/packages/lodestar/src/chain/blocks/post.ts
+++ b/packages/lodestar/src/chain/blocks/post.ts
@@ -35,7 +35,7 @@ export function postProcess(
         if (computeEpochAtSlot(config, preSlot) < currentEpoch) {
           eventBus.emit(
             "processedCheckpoint",
-            {epoch: currentEpoch, root: forkChoice.getBlockSummaryAtSlot(preSlot).blockRoot},
+            {epoch: currentEpoch, root: forkChoice.getCanonicalBlockSummaryAtSlot(preSlot).blockRoot},
           );
           // newly justified epoch
           if (preJustifiedEpoch < postState.currentJustifiedCheckpoint.epoch) {

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -107,7 +107,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     if (finalizedCheckpoint.epoch > computeEpochAtSlot(this.config, slot)) {
       return this.db.blockArchive.get(slot);
     }
-    const summary = this.forkChoice.getBlockSummaryAtSlot(slot);
+    const summary = this.forkChoice.getCanonicalBlockSummaryAtSlot(slot);
     if (!summary) {
       return null;
     }

--- a/packages/lodestar/src/chain/forkChoice/arrayDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/arrayDag/lmdGhost.ts
@@ -3,18 +3,19 @@
  */
 
 import {fromHexString, toHexString} from "@chainsafe/ssz";
-import {Gwei, Slot, ValidatorIndex, Number64, Checkpoint, Epoch, Root} from "@chainsafe/lodestar-types";
+import {Checkpoint, Epoch, Gwei, Number64, Root, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {computeSlotsSinceEpochStart,
-  getCurrentSlot,
-  computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {
+  computeSlotsSinceEpochStart,
+  computeStartSlotAtEpoch,
+  getCurrentSlot
+} from "@chainsafe/lodestar-beacon-state-transition";
 import {assert} from "@chainsafe/lodestar-utils";
 
-import {ILMDGHOST, BlockSummary, NO_NODE} from "../interface";
+import {BlockSummary, HexCheckpoint, ILMDGHOST, NO_NODE, RootHex} from "../interface";
 
 import {NodeInfo} from "./interface";
-import {RootHex, HexCheckpoint} from "../interface";
-import {GENESIS_EPOCH, ZERO_HASH, GENESIS_SLOT} from "../../../constants";
+import {GENESIS_EPOCH, GENESIS_SLOT, ZERO_HASH} from "../../../constants";
 import {AttestationAggregator} from "../attestationAggregator";
 import {IBeaconClock} from "../../clock/interface";
 
@@ -349,9 +350,8 @@ export class ArrayDagLMDGHOST implements ILMDGHOST {
     return bestTarget.stateRoot.valueOf() as Uint8Array;
   }
 
-  public getBlockSummaryAtSlot(slot: Slot): BlockSummary | null {
-    const head = this.headNode();
-    let node = head;
+  public getCanonicalBlockSummaryAtSlot(slot: Slot): BlockSummary | null {
+    let node = this.headNode();
     if (!node) {
       return null;
     }
@@ -363,6 +363,12 @@ export class ArrayDagLMDGHOST implements ILMDGHOST {
       node = this.nodes[node.parent];
     }
     return this.toBlockSummary(node);
+  }
+
+  public getBlockSummariesAtSlot(slot: Slot): BlockSummary[] {
+    return this.nodes
+      .filter((node) => this.config.types.Slot.equals(node.slot, slot))
+      .map((node) => this.toBlockSummary(node));
   }
 
   public getBlockSummaryByBlockRoot(blockRoot: Uint8Array): BlockSummary | null {

--- a/packages/lodestar/src/chain/forkChoice/interface.ts
+++ b/packages/lodestar/src/chain/forkChoice/interface.ts
@@ -18,7 +18,8 @@ export interface ILMDGHOST {
   headStateRoot(): Uint8Array;
   getJustified(): Checkpoint;
   getFinalized(): Checkpoint;
-  getBlockSummaryAtSlot(slot: Slot): BlockSummary;
+  getBlockSummariesAtSlot(slot: Slot): BlockSummary[];
+  getCanonicalBlockSummaryAtSlot(slot: Slot): BlockSummary;
   getBlockSummaryByBlockRoot(blockRoot: Uint8Array): BlockSummary;
   hasBlock(blockRoot: Uint8Array): boolean;
 }

--- a/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
@@ -427,7 +427,7 @@ export class StatefulDagLMDGHOST implements ILMDGHOST {
     return this.head().slot;
   }
 
-  public getBlockSummaryAtSlot(slot: Slot): BlockSummary | null {
+  public getCanonicalBlockSummaryAtSlot(slot: Slot): BlockSummary | null {
     const head = this.headNode();
     let node = head;
     // navigate from the head node, up the chain until either the slot is found or the slot is passed
@@ -438,6 +438,12 @@ export class StatefulDagLMDGHOST implements ILMDGHOST {
       node = node.parent;
     }
     return node.toBlockSummary();
+  }
+
+  public getBlockSummariesAtSlot(slot: Slot): BlockSummary[] {
+    return Object.values(this.nodes)
+      .filter((node) => this.config.types.Slot.equals(slot, node.slot))
+      .map((node) => node.toBlockSummary());
   }
 
   public getBlockSummaryByBlockRoot(blockRoot: Uint8Array): BlockSummary | null {

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlock.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlock.test.ts
@@ -13,7 +13,7 @@ import {generateEmptySignedBlock} from "../../../../../utils/block";
 
 use(chaiAsPromised);
 
-describe("api - beacon - getBlockHeader", function () {
+describe("api - beacon - getBlock", function () {
 
   const sandbox = sinon.createSandbox();
 
@@ -45,26 +45,26 @@ describe("api - beacon - getBlockHeader", function () {
 
   it("block not found", async function () {
     resolveBlockIdStub.withArgs(config, sinon.match.any, "1").resolves(null);
-    const result = await blockApi.getBlockHeader("1");
+    const result = await blockApi.getBlock("1");
     expect(result).to.be.null;
   });
 
   it("invalid block id", async function () {
     resolveBlockIdStub.withArgs(config, sinon.match.any,"abc").throwsException();
-    await expect(blockApi.getBlockHeader("abc")).to.eventually.be.rejected;
+    await expect(blockApi.getBlock("abc")).to.eventually.be.rejected;
   });
 
   it("success for non finalized block", async function () {
     resolveBlockIdStub.withArgs(config, sinon.match.any,"head").resolves(Buffer.alloc(1));
     dbStub.block.get.withArgs(Buffer.alloc(1)).resolves(generateEmptySignedBlock());
-    const result = await blockApi.getBlockHeader("head");
+    const result = await blockApi.getBlock("head");
     expect(result).to.not.be.null;
-    expect(() => config.types.SignedBeaconHeaderResponse.assertValidValue(result)).to.not.throw();
+    expect(() => config.types.SignedBeaconBlock.assertValidValue(result)).to.not.throw();
   });
 
   it.skip("success for finalized block", async function () {
     resolveBlockIdStub.withArgs(config, sinon.match.any,"0").resolves(Buffer.alloc(1));
-    const result = await blockApi.getBlockHeader("0");
+    const result = await blockApi.getBlock("0");
     expect(result).to.not.be.null;
   });
 

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlockHeader.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlockHeader.test.ts
@@ -1,0 +1,71 @@
+import {BeaconBlockApi} from "../../../../../../src/api/impl/beacon/blocks";
+import * as blockUtils from "../../../../../../src/api/impl/beacon/blocks/utils";
+import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
+import {ArrayDagLMDGHOST, BeaconChain, IBeaconChain, ILMDGHOST} from "../../../../../../src/chain";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Libp2pNetwork} from "../../../../../../src/network";
+import {BeaconSync} from "../../../../../../src/sync";
+import {StubbedBeaconDb} from "../../../../../utils/stub";
+import {expect, use} from "chai";
+import chaiAsPromised from "chai-as-promised";
+import {generateEmptySignedBlock} from "../../../../../utils/block";
+
+use(chaiAsPromised);
+
+describe("api - beacon - getBlockHeaders", function () {
+
+  const sandbox = sinon.createSandbox();
+
+  let blockApi: BeaconBlockApi;
+  let chainStub: SinonStubbedInstance<IBeaconChain>;
+  let dbStub: StubbedBeaconDb;
+  let forkChoiceStub: SinonStubbedInstance<ILMDGHOST>;
+  let resolveBlockIdStub: SinonStub;
+
+  beforeEach(function () {
+    forkChoiceStub = sinon.createStubInstance(ArrayDagLMDGHOST);
+    chainStub = sinon.createStubInstance(BeaconChain);
+    chainStub.forkChoice = forkChoiceStub;
+    dbStub = new StubbedBeaconDb(sinon, config);
+    resolveBlockIdStub = sandbox.stub(blockUtils, "resolveBlockId");
+    blockApi = new BeaconBlockApi({}, {
+      chain: chainStub,
+      config,
+      db: dbStub,
+      logger: sinon.createStubInstance(WinstonLogger),
+      network: sinon.createStubInstance(Libp2pNetwork),
+      sync: sinon.createStubInstance(BeaconSync)
+    });
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("block not found", async function () {
+    resolveBlockIdStub.withArgs(config, sinon.match.any, "1").resolves(null);
+    const result = await blockApi.getBlockHeader("1");
+    expect(result).to.be.null;
+  });
+
+  it("invalid block id", async function () {
+    resolveBlockIdStub.withArgs(config, sinon.match.any,"abc").throwsException();
+    await expect(blockApi.getBlockHeader("abc")).to.eventually.be.rejected;
+  });
+
+  it("success for non finalized block", async function () {
+    resolveBlockIdStub.withArgs(config, sinon.match.any,"head").resolves(Buffer.alloc(1));
+    dbStub.block.get.withArgs(Buffer.alloc(1)).resolves(generateEmptySignedBlock());
+    const result = await blockApi.getBlockHeader("head");
+    expect(result).to.not.be.null;
+  });
+
+  it.skip("success for finalized block", async function () {
+    resolveBlockIdStub.withArgs(config, sinon.match.any,"0").resolves(Buffer.alloc(1));
+    const result = await blockApi.getBlockHeader("0");
+    expect(result).to.not.be.null;
+  });
+
+
+});

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlockHeaders.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlockHeaders.test.ts
@@ -1,0 +1,87 @@
+import {BeaconBlockApi} from "../../../../../../src/api/impl/beacon/blocks";
+import {SinonStubbedInstance} from "sinon";
+import {ArrayDagLMDGHOST, BeaconChain, BlockSummary, IBeaconChain, ILMDGHOST} from "../../../../../../src/chain";
+import {BeaconDb, IBeaconDb} from "../../../../../../src/db/api";
+import sinon from "sinon";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Libp2pNetwork} from "../../../../../../src/network";
+import {BeaconSync} from "../../../../../../src/sync";
+import {generateEmptyBlock, generateEmptyBlockSummary, generateEmptySignedBlock} from "../../../../../utils/block";
+import deepmerge from "deepmerge";
+import {StubbedBeaconDb} from "../../../../../utils/stub";
+import {expect} from "chai";
+
+describe("api - beacon - getBlockHeaders", function () {
+
+  let blockApi: BeaconBlockApi;
+  let chainStub: SinonStubbedInstance<IBeaconChain>;
+  let dbStub: StubbedBeaconDb;
+  let forkChoiceStub: SinonStubbedInstance<ILMDGHOST>;
+
+  beforeEach(function () {
+    forkChoiceStub = sinon.createStubInstance(ArrayDagLMDGHOST);
+    chainStub = sinon.createStubInstance(BeaconChain);
+    chainStub.forkChoice = forkChoiceStub;
+    dbStub = new StubbedBeaconDb(sinon, config);
+    blockApi = new BeaconBlockApi({}, {
+      chain: chainStub,
+      config,
+      db: dbStub,
+      logger: sinon.createStubInstance(WinstonLogger),
+      network: sinon.createStubInstance(Libp2pNetwork),
+      sync: sinon.createStubInstance(BeaconSync)
+    });
+  });
+
+  it("no filters", async function () {
+    forkChoiceStub.headBlockSlot.returns(1);
+    chainStub.getBlockAtSlot.withArgs(1).resolves(generateEmptySignedBlock());
+    forkChoiceStub.getBlockSummariesAtSlot.withArgs(1)
+      .returns([
+        generateEmptyBlockSummary(),
+        //canonical block summary
+        deepmerge<BlockSummary>(
+          generateEmptyBlockSummary(),
+          {blockRoot: config.types.BeaconBlock.hashTreeRoot(generateEmptyBlock())}
+        )
+      ]);
+    dbStub.block.get.resolves(deepmerge(generateEmptySignedBlock(), {message: {slot: 3}}));
+    dbStub.blockArchive.get.resolves(null);
+    const blockHeaders = await blockApi.getBlockHeaders({});
+    expect(blockHeaders).to.not.be.null;
+    expect(blockHeaders.length).to.be.equal(2);
+    expect(() => config.types.SignedBeaconHeaderResponse.assertValidValue(blockHeaders[0])).to.not.throw;
+    expect(() => config.types.SignedBeaconHeaderResponse.assertValidValue(blockHeaders[1])).to.not.throw;
+    expect(blockHeaders.filter((header) => header.canonical).length).to.be.equal(1);
+    expect(forkChoiceStub.headBlockSlot.calledOnce).to.be.true;
+    expect(chainStub.getBlockAtSlot.calledOnce).to.be.true;
+    expect(forkChoiceStub.getBlockSummariesAtSlot.calledOnce).to.be.true;
+    expect(dbStub.blockArchive.get.calledOnce).to.be.true;
+    expect(dbStub.block.get.calledOnce).to.be.true;
+  });
+
+  it("future slot", async function () {
+    forkChoiceStub.headBlockSlot.returns(1);
+    const blockHeaders = await blockApi.getBlockHeaders({slot: 2});
+    expect(blockHeaders.length).to.be.equal(0);
+  });
+
+  it("finalized slot", async function () {
+    forkChoiceStub.headBlockSlot.returns(2);
+    chainStub.getBlockAtSlot.withArgs(0).resolves(generateEmptySignedBlock());
+    forkChoiceStub.getBlockSummariesAtSlot.withArgs(0).returns([]);
+    const blockHeaders = await blockApi.getBlockHeaders({slot: 0});
+    expect(blockHeaders.length).to.be.equal(1);
+    expect(() => config.types.SignedBeaconHeaderResponse.assertValidValue(blockHeaders[0])).to.not.throw;
+    expect(blockHeaders[0].canonical).to.be.true;
+  });
+
+  it("skip slot", async function () {
+    forkChoiceStub.headBlockSlot.returns(2);
+    chainStub.getBlockAtSlot.withArgs(0).resolves(null);
+    const blockHeaders = await blockApi.getBlockHeaders({slot: 0});
+    expect(blockHeaders.length).to.be.equal(0);
+  });
+
+});

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlockHeaders.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlockHeaders.test.ts
@@ -1,8 +1,6 @@
 import {BeaconBlockApi} from "../../../../../../src/api/impl/beacon/blocks";
-import {SinonStubbedInstance} from "sinon";
+import sinon, {SinonStubbedInstance} from "sinon";
 import {ArrayDagLMDGHOST, BeaconChain, BlockSummary, IBeaconChain, ILMDGHOST} from "../../../../../../src/chain";
-import {BeaconDb, IBeaconDb} from "../../../../../../src/db/api";
-import sinon from "sinon";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {Libp2pNetwork} from "../../../../../../src/network";
@@ -57,7 +55,6 @@ describe("api - beacon - getBlockHeaders", function () {
     expect(forkChoiceStub.headBlockSlot.calledOnce).to.be.true;
     expect(chainStub.getBlockAtSlot.calledOnce).to.be.true;
     expect(forkChoiceStub.getBlockSummariesAtSlot.calledOnce).to.be.true;
-    expect(dbStub.blockArchive.get.calledOnce).to.be.true;
     expect(dbStub.block.get.calledOnce).to.be.true;
   });
 
@@ -84,4 +81,15 @@ describe("api - beacon - getBlockHeaders", function () {
     expect(blockHeaders.length).to.be.equal(0);
   });
 
+  it.skip("parent root filter", async function() {
+
+  });
+
+  it.skip("parent root - block not found", async function() {
+
+  });
+
+  it.skip("parent root + slot filter", async function() {
+
+  });
 });

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/utils.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/utils.test.ts
@@ -1,0 +1,72 @@
+import {SinonStubbedInstance} from "sinon";
+import {ArrayDagLMDGHOST, ILMDGHOST} from "../../../../../../src/chain/forkChoice";
+import sinon from "sinon";
+import {resolveBlockId} from "../../../../../../src/api/impl/beacon/blocks/utils";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {expect, use} from "chai";
+import {toHexString} from "@chainsafe/ssz";
+import {generateEmptyBlockSummary} from "../../../../../utils/block";
+import chaiAsPromised from "chai-as-promised";
+
+use(chaiAsPromised);
+
+describe("block api utils", function () {
+
+  describe("resolveBlockId", function () {
+
+    let forkChoiceStub: SinonStubbedInstance<ILMDGHOST>;
+
+    beforeEach(function () {
+      forkChoiceStub = sinon.createStubInstance(ArrayDagLMDGHOST);
+    });
+
+    it("should resolve head", async function () {
+      const expected = Buffer.alloc(32, 2);
+      forkChoiceStub.headBlockRoot.returns(expected);
+      const root = await resolveBlockId(config, forkChoiceStub, "head");
+      expect(root).to.be.equal(expected);
+    });
+
+    it.skip("should resolve genesis", async function () {
+      const expected = Buffer.alloc(32, 2);
+      const root = await resolveBlockId(config, forkChoiceStub, "genesis");
+      expect(root).to.be.equal(expected);
+    });
+
+    it("should resolve finalized", async function () {
+      const expected = Buffer.alloc(32, 2);
+      forkChoiceStub.getFinalized.returns({epoch: 0, root: expected});
+      const root = await resolveBlockId(config, forkChoiceStub, "finalized");
+      expect(root).to.be.equal(expected);
+    });
+
+    it("should resolve root", async function () {
+      const expected = Buffer.alloc(32, 2);
+      const root = await resolveBlockId(config, forkChoiceStub, toHexString(expected));
+      expect(root).to.be.deep.equal(expected);
+    });
+
+    it("should resolve non finalized slot", async function () {
+      const expected = Buffer.alloc(32, 2);
+      forkChoiceStub.getCanonicalBlockSummaryAtSlot.withArgs(2).returns({
+        ...generateEmptyBlockSummary(),
+        blockRoot: expected
+      });
+      const root = await resolveBlockId(config, forkChoiceStub, "2");
+      expect(root).to.be.deep.equal(expected);
+    });
+
+    it.skip("should resolve finalized slot", async function () {
+      const expected = Buffer.alloc(32, 2);
+      forkChoiceStub.getCanonicalBlockSummaryAtSlot.withArgs(2).returns(null);
+      const root = await resolveBlockId(config, forkChoiceStub, "2");
+      expect(root).to.be.deep.equal(expected);
+    });
+
+    it("should trow on invalid", async function () {
+      await expect(resolveBlockId(config, forkChoiceStub, "asbc")).to.eventually.be.rejected;
+    });
+
+  });
+
+});

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlock.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlock.test.ts
@@ -7,11 +7,10 @@ import {ApiNamespace} from "../../../../../../src/api";
 import {StubbedBeaconApi} from "../../../../../utils/stub/beaconApi";
 import supertest from "supertest";
 import {expect} from "chai";
-import {generateSignedBeaconHeaderResponse} from "../../../../../utils/api";
-import {toHexString} from "@chainsafe/ssz";
-import {getBlockHeader} from "../../../../../../src/api/rest/controllers/beacon/blocks";
+import {getBlock} from "../../../../../../src/api/rest/controllers/beacon/blocks";
+import {generateEmptySignedBlock} from "../../../../../utils/block";
 
-describe("rest - beacon - getBlockHeader", function () {
+describe("rest - beacon - getBlock", function () {
 
   let api: RestApi;
   let beaconApiStub: StubbedBeaconApi;
@@ -38,25 +37,25 @@ describe("rest - beacon - getBlockHeader", function () {
   });
 
   it("should succeed", async function () {
-    beaconApiStub.blocks.getBlockHeader.withArgs("head").resolves(generateSignedBeaconHeaderResponse());
+    beaconApiStub.blocks.getBlock.withArgs("head").resolves(generateEmptySignedBlock());
     const response = await supertest(api.server.server)
-      .get(getBlockHeader.url.replace(":blockId", "head"))
+      .get(getBlock.url.replace(":blockId", "head"))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
     expect(response.body.data).to.not.be.undefined;
   });
 
   it("should not found block header", async function () {
-    beaconApiStub.blocks.getBlockHeader.withArgs("4").resolves(null);
+    beaconApiStub.blocks.getBlock.withArgs("4").resolves(null);
     await supertest(api.server.server)
-      .get(getBlockHeader.url.replace(":blockId", "4"))
+      .get(getBlock.url.replace(":blockId", "4"))
       .expect(404);
   });
 
   it("should fail validation", async function () {
-    beaconApiStub.blocks.getBlockHeader.throws(new Error("Invalid block id"));
+    beaconApiStub.blocks.getBlock.throws(new Error("Invalid block id"));
     await supertest(api.server.server)
-      .get(getBlockHeader.url.replace(":blockId", "abc"))
+      .get(getBlock.url.replace(":blockId", "abc"))
       .expect(400)
       .expect("Content-Type", "application/json; charset=utf-8");
   });

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockAttestations.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockAttestations.test.ts
@@ -1,0 +1,75 @@
+import {RestApi} from "../../../../../../src/api/rest";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {ValidatorApi} from "../../../../../../src/api/impl/validator";
+import sinon from "sinon";
+import {ApiNamespace} from "../../../../../../src/api";
+import {StubbedBeaconApi} from "../../../../../utils/stub/beaconApi";
+import supertest from "supertest";
+import {expect} from "chai";
+import {getBlockAttestations} from "../../../../../../src/api/rest/controllers/beacon/blocks";
+import {generateSignedBlock} from "../../../../../utils/block";
+import {generateEmptyAttestation} from "../../../../../utils/attestation";
+
+describe("rest - beacon - getBlockAttestations", function () {
+
+  let api: RestApi;
+  let beaconApiStub: StubbedBeaconApi;
+
+  beforeEach(async function () {
+    beaconApiStub = new StubbedBeaconApi();
+    api = new RestApi({
+      api: [ApiNamespace.BEACON],
+      cors: "*",
+      enabled: true,
+      host: "127.0.0.1",
+      port: 0
+    }, {
+      config,
+      logger: sinon.createStubInstance(WinstonLogger),
+      validator: sinon.createStubInstance(ValidatorApi),
+      beacon: beaconApiStub
+    });
+    await api.start();
+  });
+
+  afterEach(async function() {
+    await api.stop();
+  });
+
+  it("should succeed", async function () {
+    beaconApiStub.blocks.getBlock.withArgs("head")
+      .resolves(generateSignedBlock({
+        message: {
+          body: {
+            attestations: [
+              generateEmptyAttestation(),
+              generateEmptyAttestation(),
+            ]
+          }
+        }
+      }));
+    const response = await supertest(api.server.server)
+      .get(getBlockAttestations.url.replace(":blockId", "head"))
+      .expect(200)
+      .expect("Content-Type", "application/json; charset=utf-8");
+    expect(response.body.data).to.not.be.undefined;
+    expect(response.body.data.length).to.equal(2);
+  });
+
+  it("should not found block", async function () {
+    beaconApiStub.blocks.getBlock.withArgs("4").resolves(null);
+    await supertest(api.server.server)
+      .get(getBlockAttestations.url.replace(":blockId", "4"))
+      .expect(404);
+  });
+
+  it("should fail validation", async function () {
+    beaconApiStub.blocks.getBlock.throws(new Error("Invalid block id"));
+    await supertest(api.server.server)
+      .get(getBlockAttestations.url.replace(":blockId", "abc"))
+      .expect(400)
+      .expect("Content-Type", "application/json; charset=utf-8");
+  });
+
+});

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockHeader.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockHeader.test.ts
@@ -1,0 +1,65 @@
+import {RestApi} from "../../../../../../src/api/rest";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {ValidatorApi} from "../../../../../../src/api/impl/validator";
+import sinon from "sinon";
+import {ApiNamespace} from "../../../../../../src/api";
+import {StubbedBeaconApi} from "../../../../../utils/stub/beaconApi";
+import supertest from "supertest";
+import {expect} from "chai";
+import {generateSignedBeaconHeaderResponse} from "../../../../../utils/api";
+import {toHexString} from "@chainsafe/ssz";
+import {getBlockHeader} from "../../../../../../src/api/rest/controllers/beacon/blocks";
+
+describe("rest - beacon - getBlockHeader", function () {
+
+  let api: RestApi;
+  let beaconApiStub: StubbedBeaconApi;
+
+  beforeEach(async function () {
+    beaconApiStub = new StubbedBeaconApi();
+    api = new RestApi({
+      api: [ApiNamespace.BEACON],
+      cors: "*",
+      enabled: true,
+      host: "127.0.0.1",
+      port: 0
+    }, {
+      config,
+      logger: sinon.createStubInstance(WinstonLogger),
+      validator: sinon.createStubInstance(ValidatorApi),
+      beacon: beaconApiStub
+    });
+    await api.start();
+  });
+
+  afterEach(async function() {
+    await api.stop();
+  });
+
+  it("should succeed", async function () {
+    beaconApiStub.blocks.getBlockHeader.withArgs("head").resolves(generateSignedBeaconHeaderResponse());
+    const response = await supertest(api.server.server)
+      .get(getBlockHeader.url.replace(":blockId", "head"))
+      .expect(200)
+      .expect("Content-Type", "application/json; charset=utf-8");
+    expect(response.body.data).to.not.be.undefined;
+  });
+
+  it("should not found block header", async function () {
+    beaconApiStub.blocks.getBlockHeader.withArgs("4").resolves(null);
+    await supertest(api.server.server)
+      .get(getBlockHeader.url.replace(":blockId", "4"))
+      .expect(404);
+  });
+
+  it("should fail validation", async function () {
+    beaconApiStub.blocks.getBlockHeader.throws(new Error("Invalid block id"));
+    await supertest(api.server.server)
+      .get(getBlockHeader.url.replace(":blockId", "abc"))
+      .query({"parent_root": toHexString(Buffer.alloc(32, 1))})
+      .expect(400)
+      .expect("Content-Type", "application/json; charset=utf-8");
+  });
+
+});

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockHeaders.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockHeaders.test.ts
@@ -6,10 +6,10 @@ import sinon from "sinon";
 import {ApiNamespace} from "../../../../../../src/api";
 import {StubbedBeaconApi} from "../../../../../utils/stub/beaconApi";
 import supertest from "supertest";
-import {getBlockHeaders} from "../../../../../../src/api/rest/controllers/beacon/getBlockHeaders";
 import {expect} from "chai";
 import {generateSignedBeaconHeaderResponse} from "../../../../../utils/api";
 import {toHexString} from "@chainsafe/ssz";
+import {getBlockHeaders} from "../../../../../../src/api/rest/controllers/beacon/blocks";
 
 describe("rest - beacon - getBlockHeaders", function () {
 

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockHeaders.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockHeaders.test.ts
@@ -1,0 +1,105 @@
+import {RestApi} from "../../../../../../src/api/rest";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {ValidatorApi} from "../../../../../../src/api/impl/validator";
+import sinon from "sinon";
+import {ApiNamespace} from "../../../../../../src/api";
+import {StubbedBeaconApi} from "../../../../../utils/stub/beaconApi";
+import supertest from "supertest";
+import {getBlockHeaders} from "../../../../../../src/api/rest/controllers/beacon/getBlockHeaders";
+import {expect} from "chai";
+import {generateSignedBeaconHeaderResponse} from "../../../../../utils/api";
+import {toHexString} from "@chainsafe/ssz";
+
+describe("rest - beacon - getBlockHeaders", function () {
+
+  let api: RestApi;
+  let beaconApiStub: StubbedBeaconApi;
+
+  beforeEach(async function () {
+    beaconApiStub = new StubbedBeaconApi();
+    api = new RestApi({
+      api: [ApiNamespace.BEACON],
+      cors: "*",
+      enabled: true,
+      host: "127.0.0.1",
+      port: 0
+    }, {
+      config,
+      logger: sinon.createStubInstance(WinstonLogger),
+      validator: sinon.createStubInstance(ValidatorApi),
+      beacon: beaconApiStub
+    });
+    await api.start();
+  });
+
+  afterEach(async function() {
+    await api.stop();
+  });
+
+  it("should fetch without filters", async function () {
+    beaconApiStub.blocks.getBlockHeaders.resolves([generateSignedBeaconHeaderResponse()]);
+    const response = await supertest(api.server.server)
+      .get(getBlockHeaders.url)
+      .expect(200)
+      .expect("Content-Type", "application/json; charset=utf-8");
+    expect(response.body.data.length).to.be.equal(1);
+  });
+
+  it("should parse slot param", async function () {
+    beaconApiStub.blocks.getBlockHeaders
+      .withArgs({slot: 1, parentRoot: undefined})
+      .resolves([generateSignedBeaconHeaderResponse()]);
+    const response = await supertest(api.server.server)
+      .get(getBlockHeaders.url)
+      .query({"slot": "1"})
+      .expect(200)
+      .expect("Content-Type", "application/json; charset=utf-8");
+    expect(response.body.data.length).to.be.equal(1);
+  });
+
+  it("should parse parentRoot param", async function () {
+    beaconApiStub.blocks.getBlockHeaders
+      .withArgs({slot: undefined, parentRoot: new Uint8Array(32).fill(1)})
+      .resolves([generateSignedBeaconHeaderResponse()]);
+    const response = await supertest(api.server.server)
+      .get(getBlockHeaders.url)
+      .query({"parent_root": toHexString(Buffer.alloc(32, 1))})
+      .expect(200)
+      .expect("Content-Type", "application/json; charset=utf-8");
+    expect(response.body.data.length).to.be.equal(1);
+  });
+
+  it("should throw validation error on invalid slot", async function () {
+    await supertest(api.server.server)
+      .get(getBlockHeaders.url)
+      .query({"slot": "abc"})
+      .expect(400)
+      .expect("Content-Type", "application/json; charset=utf-8");
+  });
+
+  it.skip("should throw validation error on invalid parentRoot - not hex", async function () {
+    await supertest(api.server.server)
+      .get(getBlockHeaders.url)
+      .query({"parentRoot": "0xb0e16cdb82ddf08b02aa3898d16a706997b11a69048c80525338d4a7b378d8eg"})
+      .expect(400)
+      .expect("Content-Type", "application/json; charset=utf-8");
+  });
+
+  it.skip("should throw validation error on invalid parentRoot - incorrect length", async function () {
+    await supertest(api.server.server)
+      .get(getBlockHeaders.url)
+      .query({"parentRoot": "0xb0e"})
+      .expect(400)
+      .expect("Content-Type", "application/json; charset=utf-8");
+  });
+
+  it.skip("should throw validation error on invalid parentRoot - missing 0x prefix", async function () {
+    await supertest(api.server.server)
+      .get(getBlockHeaders.url)
+      .query({"parentRoot": "b0e16cdb82ddf08b02aa3898d16a706997b11a69048c80525338d4a7b378d8eb"})
+      .expect(400)
+      .expect("Content-Type", "application/json; charset=utf-8");
+  });
+
+});

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockRoot.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockRoot.test.ts
@@ -1,0 +1,65 @@
+import {RestApi} from "../../../../../../src/api/rest";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {ValidatorApi} from "../../../../../../src/api/impl/validator";
+import sinon from "sinon";
+import {ApiNamespace} from "../../../../../../src/api";
+import {StubbedBeaconApi} from "../../../../../utils/stub/beaconApi";
+import supertest from "supertest";
+import {expect} from "chai";
+import {getBlockRoot} from "../../../../../../src/api/rest/controllers/beacon/blocks";
+import {generateEmptySignedBlock} from "../../../../../utils/block";
+import {toHexString} from "@chainsafe/ssz";
+
+describe("rest - beacon - getBlockRoot", function () {
+
+  let api: RestApi;
+  let beaconApiStub: StubbedBeaconApi;
+
+  beforeEach(async function () {
+    beaconApiStub = new StubbedBeaconApi();
+    api = new RestApi({
+      api: [ApiNamespace.BEACON],
+      cors: "*",
+      enabled: true,
+      host: "127.0.0.1",
+      port: 0
+    }, {
+      config,
+      logger: sinon.createStubInstance(WinstonLogger),
+      validator: sinon.createStubInstance(ValidatorApi),
+      beacon: beaconApiStub
+    });
+    await api.start();
+  });
+
+  afterEach(async function() {
+    await api.stop();
+  });
+
+  it("should succeed", async function () {
+    const block = generateEmptySignedBlock();
+    beaconApiStub.blocks.getBlock.withArgs("head").resolves(block);
+    const response = await supertest(api.server.server)
+      .get(getBlockRoot.url.replace(":blockId", "head"))
+      .expect(200)
+      .expect("Content-Type", "application/json; charset=utf-8");
+    expect(response.body.data.root).to.be.equal(toHexString(config.types.BeaconBlock.hashTreeRoot(block.message)));
+  });
+
+  it("should not found block header", async function () {
+    beaconApiStub.blocks.getBlock.withArgs("4").resolves(null);
+    await supertest(api.server.server)
+      .get(getBlockRoot.url.replace(":blockId", "4"))
+      .expect(404);
+  });
+
+  it("should fail validation", async function () {
+    beaconApiStub.blocks.getBlock.throws(new Error("Invalid block id"));
+    await supertest(api.server.server)
+      .get(getBlockRoot.url.replace(":blockId", "abc"))
+      .expect(400)
+      .expect("Content-Type", "application/json; charset=utf-8");
+  });
+
+});

--- a/packages/lodestar/test/unit/chain/blocks/post.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/post.test.ts
@@ -41,7 +41,7 @@ describe("post block process stream", function () {
     metricsStub.previousJustifiedEpoch = sinon.createStubInstance(Gauge) as unknown as Gauge;
     eventBusStub = sinon.createStubInstance(BeaconChain);
     attestationProcessorStub = sinon.createStubInstance(AttestationProcessor);
-    forkChoiceStub.getBlockSummaryAtSlot.returns({
+    forkChoiceStub.getCanonicalBlockSummaryAtSlot.returns({
       blockRoot: Buffer.alloc(32),
       stateRoot: Buffer.alloc(32),
       parentRoot: Buffer.alloc(32),

--- a/packages/lodestar/test/unit/chain/forkChoice/arrayDag.test.ts
+++ b/packages/lodestar/test/unit/chain/forkChoice/arrayDag.test.ts
@@ -3,18 +3,12 @@ import {assert, expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 import sinon, {SinonFakeTimers} from "sinon";
 import {Checkpoint, Slot} from "@chainsafe/lodestar-types";
-import {GENESIS_SLOT, GENESIS_EPOCH} from "../../../../src/constants";
+import {GENESIS_EPOCH, GENESIS_SLOT} from "../../../../src/constants";
 import {LocalClock} from "../../../../src/chain/clock/local/LocalClock";
 import {sleep} from "../../../../src/util/sleep";
 import {StubbedBeaconDb} from "../../../utils/stub";
-import {generateEmptySignedBlock} from "../../../utils/block";
-import {generateState} from "../../../utils/state";
 import {toHexString} from "@chainsafe/ssz";
-import {NO_NODE, BeaconChain} from "../../../../src/chain";
-import chainOpts from "../../../../src/chain/options";
-import {InteropEth1Notifier} from "../../../../src/eth1/impl/interop";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
-import {BeaconMetrics} from "../../../../src/metrics";
+import {NO_NODE} from "../../../../src/chain";
 import {ArrayDagLMDGHOST} from "../../../../src/chain/forkChoice/arrayDag/lmdGhost";
 
 describe("ArrayDagLMDGHOST", () => {

--- a/packages/lodestar/test/utils/api.ts
+++ b/packages/lodestar/test/utils/api.ts
@@ -1,0 +1,20 @@
+import {SignedBeaconHeaderResponse} from "@chainsafe/lodestar-types";
+import deepmerge from "deepmerge";
+import {blockToHeader} from "@chainsafe/lodestar-beacon-state-transition";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {generateEmptySignedBlock} from "./block";
+import {isPlainObject} from "@chainsafe/lodestar-utils";
+
+export function generateSignedBeaconHeaderResponse(
+  override: Partial<SignedBeaconHeaderResponse> = {}
+): SignedBeaconHeaderResponse {
+  const signedBlock = generateEmptySignedBlock();
+  return deepmerge({
+    canonical: true,
+    root: Buffer.alloc(32, 0),
+    header: {
+      message: blockToHeader(config, signedBlock.message),
+      signature: signedBlock.signature
+    }
+  }, override, {isMergeableObject: isPlainObject});
+}

--- a/packages/lodestar/test/utils/block.ts
+++ b/packages/lodestar/test/utils/block.ts
@@ -1,6 +1,9 @@
 import {BeaconBlock, SignedBeaconBlock} from "@chainsafe/lodestar-types";
 import {EMPTY_SIGNATURE, ZERO_HASH} from "../../src/constants";
 import {BlockSummary} from "../../src/chain";
+import deepmerge from "deepmerge";
+import {isPlainObject} from "@chainsafe/lodestar-utils";
+import {DeepPartial} from "./misc";
 
 
 export function generateEmptyBlock(): BeaconBlock {
@@ -31,6 +34,14 @@ export function generateEmptySignedBlock(): SignedBeaconBlock {
     message: generateEmptyBlock(),
     signature: EMPTY_SIGNATURE,
   };
+}
+
+export function generateSignedBlock(override: DeepPartial<SignedBeaconBlock> = {}): SignedBeaconBlock {
+  return deepmerge<SignedBeaconBlock, DeepPartial<SignedBeaconBlock>>(
+    generateEmptySignedBlock(),
+    override,
+    {isMergeableObject: isPlainObject}
+  );
 }
 
 export function generateEmptyBlockSummary(): BlockSummary {

--- a/packages/lodestar/test/utils/misc.ts
+++ b/packages/lodestar/test/utils/misc.ts
@@ -13,3 +13,5 @@ export function randBetween(min: number, max: number): number {
 export function randBetweenBigInt(min: number, max: number): bigint {
   return BigInt(randBetween(min, max));
 }
+
+export type DeepPartial<T> = T extends Function ? T : (T extends object ? { [P in keyof T]?: DeepPartial<T[P]>; } : T);

--- a/packages/lodestar/test/utils/stub/beaconApi.ts
+++ b/packages/lodestar/test/utils/stub/beaconApi.ts
@@ -1,0 +1,26 @@
+import {IBeaconApi} from "../../../src/api/impl/beacon";
+import Sinon, {SinonSandbox, SinonStubbedInstance} from "sinon";
+import {BeaconBlockApi, IBeaconBlocksApi} from "../../../src/api/impl/beacon/blocks";
+import {ApiNamespace} from "../../../src/api";
+
+export class StubbedBeaconApi implements SinonStubbedInstance<IBeaconApi> {
+  blocks: SinonStubbedInstance<IBeaconBlocksApi>;
+  getBlockStream: Sinon.SinonStubbedMember<IBeaconApi["getBlockStream"]>;
+  getClientVersion: Sinon.SinonStubbedMember<IBeaconApi["getClientVersion"]>;
+  getFork: Sinon.SinonStubbedMember<IBeaconApi["getFork"]>;
+  getGenesisTime: Sinon.SinonStubbedMember<IBeaconApi["getGenesisTime"]>;
+  getSyncingStatus: Sinon.SinonStubbedMember<IBeaconApi["getSyncingStatus"]>;
+  getValidator: Sinon.SinonStubbedMember<IBeaconApi["getValidator"]>;
+  namespace: ApiNamespace.BEACON;
+
+  constructor(sandbox: SinonSandbox = Sinon) {
+    this.blocks = sandbox.createStubInstance(BeaconBlockApi);
+    this.getBlockStream = sandbox.stub();
+    this.getClientVersion = sandbox.stub();
+    this.getFork = sandbox.stub();
+    this.getGenesisTime = sandbox.stub();
+    this.getSyncingStatus = sandbox.stub();
+    this.getValidator = sandbox.stub();
+  }
+
+}


### PR DESCRIPTION
resolves #1056 

There are some things lacking like:
- fetching finalized blocks - depends on #1070 
- searching blocks by parent root - depends on #1069 

I wish we migrate all endpoints to look like this
- controller defines route (easier to change)
- controller files are named after operationId in spec

Side note: Aparently we will return response much faster if we define fastify response schema, it's not really important for now but later on, we could generate that schemas from ssz

