### PR TITLE
Put eth2ResponseDecode warn message at correct place

### DIFF
--- a/packages/lodestar/src/network/encoders/response.ts
+++ b/packages/lodestar/src/network/encoders/response.ts
@@ -75,6 +75,8 @@ export function eth2ResponseDecode(
           } catch (e) {
             logger.warn(`Failed to get error message from other node, method ${method}, error ${e.message}`);
           }
+          logger.warn(`eth2ResponseDecode: Received err status '${status}' with message ` +
+          `'${errorMessage}' for method ${method} and request ${requestId}`);
           break;
         }
         if(sszLength === null) {
@@ -124,10 +126,6 @@ export function eth2ResponseDecode(
             }
           }
         }
-      }
-      if(status !== RpcResponseStatus.SUCCESS) {
-        logger.warn(`eth2ResponseDecode: Received err status '${status}' with message ` +
-          `'${errorMessage}' for method ${method}`);
       }
       if (buffer.length > 0) {
         throw new Error(`There is remaining data not deserialized for method ${method}`);


### PR DESCRIPTION
This is to avoid the below message happening for every success beacon_block_by_range response
```
warn: eth2ResponseDecode: Received err status 'null' with message 'null' for method beacon_blocks_by_range
```