### PR TITLE
Fix e2e tests

### DIFF
--- a/packages/lodestar-validator/src/services/attestation.ts
+++ b/packages/lodestar-validator/src/services/attestation.ts
@@ -25,7 +25,7 @@ import {toHexString} from "@chainsafe/ssz";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {
   computeEpochAtSlot,
-  computeSigningRoot,
+  computeSigningRoot, computeStartSlotAtEpoch,
   DomainType,
   getDomain,
   isSlashableAttestationData,
@@ -33,6 +33,7 @@ import {
 
 import {IAttesterDuty} from "../types";
 import {isValidatorAggregator} from "../util/aggregator";
+import {GENESIS_EPOCH} from "@chainsafe/lodestar/lib/constants";
 
 export class AttestationService {
 
@@ -99,6 +100,9 @@ export class AttestationService {
           this.logger.error("Failed to subscribe to committee subnet", e);
         }
       }
+    }
+    if(epoch != GENESIS_EPOCH) {
+      await this.onNewSlot(computeStartSlotAtEpoch(this.config, epoch));
     }
   };
 

--- a/packages/lodestar-validator/src/services/attestation.ts
+++ b/packages/lodestar-validator/src/services/attestation.ts
@@ -2,19 +2,20 @@
  * @module validator/attestation
  */
 import {
+  AggregateAndProof,
   Attestation,
   AttestationData,
+  AttesterDuty,
   BeaconState,
   BLSPubkey,
   BLSSignature,
   CommitteeIndex,
   Epoch,
   Fork,
-  Slot,
   Root,
+  SignedAggregateAndProof,
   SignedBeaconBlock,
-  AggregateAndProof,
-  SignedAggregateAndProof, AttesterDuty
+  Slot
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import EventSource from "eventsource";
@@ -25,7 +26,8 @@ import {toHexString} from "@chainsafe/ssz";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {
   computeEpochAtSlot,
-  computeSigningRoot, computeStartSlotAtEpoch,
+  computeSigningRoot,
+  computeStartSlotAtEpoch,
   DomainType,
   getDomain,
   isSlashableAttestationData,
@@ -33,7 +35,6 @@ import {
 
 import {IAttesterDuty} from "../types";
 import {isValidatorAggregator} from "../util/aggregator";
-import {GENESIS_EPOCH} from "@chainsafe/lodestar/lib/constants";
 
 export class AttestationService {
 
@@ -101,7 +102,7 @@ export class AttestationService {
         }
       }
     }
-    if(epoch != GENESIS_EPOCH) {
+    if(epoch != 0) {
       await this.onNewSlot(computeStartSlotAtEpoch(this.config, epoch));
     }
   };

--- a/packages/lodestar-validator/src/services/block.ts
+++ b/packages/lodestar-validator/src/services/block.ts
@@ -78,8 +78,8 @@ export default class BlockProposingService {
     if(this.nextProposalSlots.includes(slot)) {
       const {fork, genesisValidatorsRoot} = await this.provider.beacon.getFork();
       await this.createAndPublishBlock(slot, fork, genesisValidatorsRoot);
-      this.nextProposalSlots = this.nextProposalSlots.filter(s => s != slot);
     }
+    this.nextProposalSlots = this.nextProposalSlots.filter(s => s > slot);
   };
 
   /**

--- a/packages/lodestar-validator/src/services/block.ts
+++ b/packages/lodestar-validator/src/services/block.ts
@@ -67,15 +67,18 @@ export default class BlockProposingService {
     if(!proposerDuties) {
       return;
     }
-    this.nextProposalSlots = proposerDuties.filter((proposerDuty) => {
-      return this.config.types.BLSPubkey.equals(proposerDuty.proposerPubkey, this.publicKey);
-    }).map((duty) => duty.slot);
+    this.nextProposalSlots = this.nextProposalSlots.concat(
+      proposerDuties.filter((proposerDuty) => {
+        return this.config.types.BLSPubkey.equals(proposerDuty.proposerPubkey, this.publicKey);
+      }).map((duty) => duty.slot)
+    );
   };
 
   public onNewSlot = async(slot: Slot): Promise<void> => {
     if(this.nextProposalSlots.includes(slot)) {
       const {fork, genesisValidatorsRoot} = await this.provider.beacon.getFork();
       await this.createAndPublishBlock(slot, fork, genesisValidatorsRoot);
+      this.nextProposalSlots = this.nextProposalSlots.filter(s => s != slot);
     }
   };
 

--- a/packages/lodestar-validator/src/services/block.ts
+++ b/packages/lodestar-validator/src/services/block.ts
@@ -7,10 +7,10 @@ import {
   BLSPubkey,
   Epoch,
   Fork,
-  Slot,
-  SignedBeaconBlock,
+  ProposerDuty,
   Root,
-  ProposerDuty
+  SignedBeaconBlock,
+  Slot
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Keypair, PrivateKey} from "@chainsafe/bls";
@@ -18,13 +18,13 @@ import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {toHexString} from "@chainsafe/ssz";
 import {
   computeEpochAtSlot,
-  computeSigningRoot, computeStartSlotAtEpoch,
+  computeSigningRoot,
+  computeStartSlotAtEpoch,
   DomainType,
   getDomain
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {IValidatorDB} from "../";
 import {IApiClient} from "../api";
-import {GENESIS_EPOCH} from "@chainsafe/lodestar/lib/constants";
 
 export default class BlockProposingService {
 
@@ -74,7 +74,7 @@ export default class BlockProposingService {
       }).map((duty) => duty.slot)
     );
     //because on new slot will execute before duties are fetched
-    if(epoch != GENESIS_EPOCH) {
+    if(epoch != 0) {
       await this.onNewSlot(computeStartSlotAtEpoch(this.config, epoch));
     }
   };

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -129,7 +129,7 @@ export class ValidatorApi implements IValidatorApi {
     }
     const duties: ProposerDuty[] = [];
 
-    for(let slot = startSlot; slot < startSlot + this.config.params.SLOTS_PER_EPOCH; slot ++) {
+    for(let slot = startSlot; slot < startSlot + this.config.params.SLOTS_PER_EPOCH; slot++) {
       const blockProposerIndex = getBeaconProposerIndex(this.config, {...state, slot});
       duties.push({slot, proposerPubkey: state.validators[blockProposerIndex].pubkey});
     }

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -110,7 +110,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
   }
 
   public getEpochContext(): EpochContext {
-    return this.epochCtx;
+    return this.epochCtx.copy();
   }
 
   public async getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<SignedBeaconBlock[]|null> {

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -43,7 +43,7 @@ export async function assembleBlock(
 
 function computeNewStateRoot(config: IBeaconConfig, state: BeaconState, block: BeaconBlock, chain: IBeaconChain): Root {
   // state is cloned from the cache already
-  const epochContext = chain.getEpochContext().copy();
+  const epochContext = chain.getEpochContext();
   const signedBlock = {
     message: block,
     signature: EMPTY_SIGNATURE,

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -43,7 +43,7 @@ export async function assembleBlock(
 
 function computeNewStateRoot(config: IBeaconConfig, state: BeaconState, block: BeaconBlock, chain: IBeaconChain): Root {
   // state is cloned from the cache already
-  const epochContext = chain.getEpochContext();
+  const epochContext = chain.getEpochContext().copy();
   const signedBlock = {
     message: block,
     signature: EMPTY_SIGNATURE,

--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -13,7 +13,6 @@ import {Checkpoint, SignedBeaconBlock, Slot} from "@chainsafe/lodestar-types";
 import pushable, {Pushable} from "it-pushable";
 import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import pipe from "it-pipe";
-import {toHexString} from "@chainsafe/ssz";
 import {ISlotRange} from "../../interface";
 import {fetchBlockChunks, getCommonFinalizedCheckpoint, processSyncBlocks} from "../../utils";
 import {GENESIS_EPOCH} from "../../../constants";

--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -177,11 +177,13 @@ export class FastSync
         +`, estimateTillComplete=${Math.round((estimate/3600) * 10)/10} hours`
     );
     if(processedCheckpoint.epoch === this.targetCheckpoint.epoch) {
-      if(!this.config.types.Root.equals(processedCheckpoint.root, this.targetCheckpoint.root)) {
-        this.logger.error("Different finalized root. Something fishy is going on: "
-        + `expected ${toHexString(this.targetCheckpoint.root)}, actual ${toHexString(processedCheckpoint.root)}`);
-        throw new Error("Should delete chain and start again. Invalid blocks synced");
-      }
+      //this doesn't work because finalized checkpoint root is first slot of that epoch as per ffg,
+      // while our processed checkpoint has root of last slot of that epoch
+      // if(!this.config.types.Root.equals(processedCheckpoint.root, this.targetCheckpoint.root)) {
+      //   this.logger.error("Different finalized root. Something fishy is going on: "
+      //   + `expected ${toHexString(this.targetCheckpoint.root)}, actual ${toHexString(processedCheckpoint.root)}`);
+      //   throw new Error("Should delete chain and start again. Invalid blocks synced");
+      // }
       const newTarget = getCommonFinalizedCheckpoint(
         this.config,
         this.network.getPeers().map((peer) => this.reps.getFromPeerInfo(peer))

--- a/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
@@ -5,9 +5,8 @@
 import {ITask} from "../interface";
 import {IBeaconDb} from "../../db/api";
 import {Checkpoint, SignedBeaconBlock} from "@chainsafe/lodestar-types";
-import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {ILogger} from  "@chainsafe/lodestar-utils/lib/logger";
+import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {toHexString} from "@chainsafe/ssz";
 
 export interface IArchiveBlockModules {

--- a/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
@@ -44,12 +44,12 @@ export class ArchiveBlocksTask implements ITask {
     });
     const blocks = allBlocks.filter(
       (block) =>
-        computeEpochAtSlot(this.config, block.message.slot) < this.finalizedCheckpoint.epoch
+        block.message.slot <= finalizedBlock.message.slot
     );
     const blocksByRoot = new Map<string, SignedBeaconBlock>();
     blocks.forEach((block) =>
       blocksByRoot.set(toHexString(this.config.types.BeaconBlock.hashTreeRoot(block.message)), block));
-    const archivedBlocks = [];
+    const archivedBlocks = [finalizedBlock];
     let lastBlock = finalizedBlock;
     while (lastBlock) {
       lastBlock = blocksByRoot.get(toHexString(lastBlock.message.parentRoot));

--- a/packages/lodestar/test/unit/api/impl/validator/duties/proposer.test.ts
+++ b/packages/lodestar/test/unit/api/impl/validator/duties/proposer.test.ts
@@ -1,6 +1,5 @@
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import sinon, {SinonStubbedInstance} from "sinon";
-import {BlockRepository} from "../../../../../../src/db/api/beacon/repositories";
 import {generateState} from "../../../../../utils/state";
 import {generateValidators} from "../../../../../utils/validator";
 import {expect} from "chai";
@@ -15,7 +14,7 @@ describe("get proposers api impl", function () {
   const sandbox = sinon.createSandbox();
 
   let dbStub: StubbedBeaconDb, chainStub: SinonStubbedInstance<IBeaconChain>;
-  
+
   let api: IValidatorApi;
 
   beforeEach(function () {

--- a/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
+++ b/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
@@ -65,9 +65,9 @@ describe("block archiver task", function () {
     await archiverTask.run();
 
     expect(dbStub.blockArchive.batchAdd.calledOnce).to.be.true;
-    expect(blockArchieveSpy.args[0][0]).to.be.deep.equal([blockD, blockB, blockA]);
+    expect(blockArchieveSpy.args[0][0]).to.be.deep.equal([finalizedBlock, blockD, blockB, blockA]);
     expect(dbStub.block.batchRemove.calledOnce).to.be.true;
-    expect(blockSpy.args[0][0]).to.be.deep.equal([blockA, blockB, blockC, blockD]);
+    expect(blockSpy.args[0][0]).to.be.deep.equal([blockA, blockB, blockC, blockD, finalizedBlock]);
   });
 
 });

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -48,7 +48,7 @@ export class MockBeaconChain extends EventEmitter implements IBeaconChain {
   }
 
   public getEpochContext(): EpochContext {
-    return this.epochCtx;
+    return this.epochCtx.copy();
   }
 
   public async getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<SignedBeaconBlock[]|null> {


### PR DESCRIPTION
- fix validators skipping first slot in epoch
- fix archiving  task not storing finalized block so it's not returned in block by range
- add removal of past proposer duties
- fix block proposing modifying context

There are other bugs identified:
- something is wrong in block gossip validation, a lot of blocks are failing with block proposer index out of range (could be bad context or state)
- when checking if synced proper chain we would compare peer finalized root with processed checkpoint root but they are returning blocks for diffferent slot (processed checkpoint has root for last slot in epoch while finalized has first slot in epoch)