### PR TITLE
Dont use epochContext inside gossip validator

### DIFF
--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -24,7 +24,8 @@ import {
   getDomain,
   computeEpochAtSlot,
   computeSigningRoot,
-  computeSubnetForAttestation
+  computeSubnetForAttestation,
+  getBeaconProposerIndex
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ATTESTATION_PROPAGATION_SLOT_RANGE, DomainType, MAXIMUM_GOSSIP_CLOCK_DISPARITY} from "../../constants";
@@ -89,7 +90,7 @@ export class GossipMessageValidator implements IGossipMessageValidator {
       return false;
     }
 
-    const supposedProposerIndex = this.chain.getEpochContext().getBeaconProposer(signedBlock.message.slot);
+    const supposedProposerIndex = getBeaconProposerIndex(this.config, state);
     if (supposedProposerIndex !== signedBlock.message.proposerIndex) {
       return false;
     }
@@ -163,7 +164,8 @@ export class GossipMessageValidator implements IGossipMessageValidator {
       return false;
     }
 
-    if (getAttestingIndices(this.config, state, attestationData, aggregate.aggregationBits).length < 1) {
+    const attestorIndices = getAttestingIndices(this.config, state, attestationData, aggregate.aggregationBits);
+    if (attestorIndices.length < 1) {
       return false;
     }
 
@@ -177,8 +179,7 @@ export class GossipMessageValidator implements IGossipMessageValidator {
       return false;
     }
 
-    const committee = this.chain.getEpochContext().getBeaconCommittee(attestationData.slot, attestationData.index);
-    if (!committee.includes(aggregatorIndex)) {
+    if (!attestorIndices.includes(aggregatorIndex)) {
       return false;
     }
 


### PR DESCRIPTION
Sometimes I got this error in e2e
```
error: Cannot validate message from 16Uiu2HAmRN1W6A8o1Yb7DdFA8UneV7XXy8pd5GiDjweEsvexY8Pt, topic /eth2/31681ad1/beacon_block/ssz_snappy, error: Error: beacon proposer index out of range
```
This is because `EpochContext.getBeaconProposer()` is only designed to get proposers for slots of current epoch.

Similarly, we should not use `EpochContext.getBeaconCommittee()` because it only caches committes for previous epoch, current epoch or next epoch. I sometimes see the error `crosslink committee retrieval: out of range epoch` in my e2e too