### PR TITLE
Dont use EpochContext to calculate state root

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -35,6 +35,7 @@ import {LocalClock} from "./clock/local/LocalClock";
 import {BlockProcessor} from "./blocks";
 import {sortBlocks} from "../sync/utils";
 import {getEmptyBlock} from "./genesis/util";
+import {ReadonlyEpochContext} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
 export interface IBeaconChainModules {
   config: IBeaconConfig;
@@ -109,7 +110,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     return this.db.block.get(summary.blockRoot);
   }
 
-  public getEpochContext(): EpochContext {
+  public getEpochContext(): ReadonlyEpochContext {
     return this.epochCtx.copy();
   }
 

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -8,7 +8,7 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
 import {IBeaconDb} from "../../../db/api";
 import {assembleBody} from "./body";
-import {blockToHeader, fastStateTransition} from "@chainsafe/lodestar-beacon-state-transition";
+import {blockToHeader, stateTransition} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconChain} from "../../interface";
 import {EMPTY_SIGNATURE, ZERO_HASH} from "../../../constants";
 
@@ -36,18 +36,17 @@ export async function assembleBlock(
   };
 
 
-  block.stateRoot = computeNewStateRoot(config, currentState, block, chain);
+  block.stateRoot = computeNewStateRoot(config, currentState, block);
 
   return block;
 }
 
-function computeNewStateRoot(config: IBeaconConfig, state: BeaconState, block: BeaconBlock, chain: IBeaconChain): Root {
+function computeNewStateRoot(config: IBeaconConfig, state: BeaconState, block: BeaconBlock): Root {
   // state is cloned from the cache already
-  const epochContext = chain.getEpochContext();
   const signedBlock = {
     message: block,
     signature: EMPTY_SIGNATURE,
   };
-  const newState = fastStateTransition(epochContext, state, signedBlock, false, false, true);
+  const newState = stateTransition(config, state, signedBlock, false, false, true);
   return config.types.BeaconState.hashTreeRoot(newState);
 }

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -16,7 +16,7 @@ import {
 
 import {ILMDGHOST} from "./forkChoice";
 import {IBeaconClock} from "./clock/interface";
-import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
+import {ReadonlyEpochContext} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
 export interface IChainEvents {
   unknownBlockRoot: (root: Root) => void;
@@ -62,7 +62,7 @@ export interface IBeaconChain extends ChainEventEmitter {
 
   getFinalizedCheckpoint(): Promise<Checkpoint>;
 
-  getEpochContext(): EpochContext;
+  getEpochContext(): ReadonlyEpochContext;
 
   getBlockAtSlot(slot: Slot): Promise<SignedBeaconBlock|null>;
 

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -6,6 +6,7 @@ import {IBeaconClock} from "../../../../src/chain/clock/interface";
 import {computeForkDigest, EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {generateEmptySignedBlock} from "../../block";
+import {ReadonlyEpochContext} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
 export interface IMockChainParams {
   genesisTime: Number64;
@@ -47,7 +48,7 @@ export class MockBeaconChain extends EventEmitter implements IBeaconChain {
     return block;
   }
 
-  public getEpochContext(): EpochContext {
+  public getEpochContext(): ReadonlyEpochContext {
     return this.epochCtx.copy();
   }
 


### PR DESCRIPTION
In my environment, this error happens once per every 10 times when we produce a block: `Cannot get block root for slot in the future`

This is inside `packages/lodestar/src/chain/factory/block/index.ts` where we calculate state root, and `computeNewStateRoot` really depends on the correctness of EpochContext which changes very quickly, this is an uncertainty.

As we're not sure the correctness of EpochContext here, I propose we switch back to the legacy way of calculating state root. This doesnt happen very frequently at runtime so I think we don't have to worry about the performance here.