### PR TITLE
Join validator API client base url safely

### DIFF
--- a/packages/lodestar-validator/src/api/impl/rest/beacon/beacon.ts
+++ b/packages/lodestar-validator/src/api/impl/rest/beacon/beacon.ts
@@ -11,7 +11,7 @@ import {
   ValidatorResponse
 } from "@chainsafe/lodestar-types";
 import {IBeaconApi} from "../../../interface/beacon";
-import {HttpClient} from "../../../../util";
+import {HttpClient, urlJoin} from "../../../../util";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Json, toHexString} from "@chainsafe/ssz";
@@ -25,7 +25,7 @@ export class RestBeaconApi implements IBeaconApi {
   private readonly config: IBeaconConfig;
 
   public constructor(config: IBeaconConfig, restUrl: string, logger: ILogger) {
-    this.client = new HttpClient({urlPrefix: `${restUrl}/node`}, {logger});
+    this.client = new HttpClient({urlPrefix: urlJoin(restUrl, "node")}, {logger});
     this.logger = logger;
     this.config = config;
   }

--- a/packages/lodestar-validator/src/api/impl/rest/validator/validator.ts
+++ b/packages/lodestar-validator/src/api/impl/rest/validator/validator.ts
@@ -15,7 +15,7 @@ import {
   SignedAggregateAndProof,
 } from "@chainsafe/lodestar-types";
 import {IValidatorApi} from "../../../interface/validators";
-import {HttpClient} from "../../../../util";
+import {HttpClient, urlJoin} from "../../../../util";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Json, toHexString} from "@chainsafe/ssz";
@@ -27,7 +27,7 @@ export class RestValidatorApi implements IValidatorApi {
   private readonly config: IBeaconConfig;
 
   public constructor(config: IBeaconConfig, restUrl: string, logger: ILogger) {
-    this.client = new HttpClient({urlPrefix: `${restUrl}/validator`}, {logger});
+    this.client = new HttpClient({urlPrefix: urlJoin(restUrl, "validator")}, {logger});
     this.config = config;
   }
 

--- a/packages/lodestar-validator/src/util/httpClient.ts
+++ b/packages/lodestar-validator/src/util/httpClient.ts
@@ -51,6 +51,9 @@ const handleError = (error: AxiosError): AxiosError => {
   if (error.response) {
     if(error.response.status === 404) {
       error.message = "Endpoint not found";
+      if (error.request && error.request.path) {
+        error.message += `: ${error.request.path}`;
+      }
     } else {
       error.message = error.response.data.message || "Request failed with response status " + error.response.status;
     }

--- a/packages/lodestar-validator/src/util/index.ts
+++ b/packages/lodestar-validator/src/util/index.ts
@@ -1,2 +1,3 @@
 export * from "./httpClient";
 export * from "./misc";
+export * from "./url";

--- a/packages/lodestar-validator/src/util/url.ts
+++ b/packages/lodestar-validator/src/util/url.ts
@@ -1,0 +1,16 @@
+/**
+ * Joins multiple url parts safely
+ * - Does not break the protocol double slash //
+ * - Cleans double slashes at any point
+ * @param args ("http://localhost/", "/node/", "/genesis_time")
+ * @return "http://localhost/node/genesis_time"
+ */
+export function urlJoin(...args: string[]): string {
+  return (
+    args
+      .join("/")
+      .replace(/([^:]\/)\/+/g, "$1")
+      // Remove duplicate slashes in the front
+      .replace(/^(\/)+/, "/")
+  );
+}


### PR DESCRIPTION
Concatening the `restUrl` with `/node` resulted in http://127.0.0.1:9596//node/genesis_time which fastify does not recognizes as a valid route, returning 404 and breaking the validator. A small urlJoin util makes sure there are no double `/` when concatening url parts