### PR TITLE
Make labeler actually skip forks

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -4,8 +4,8 @@ on: [pull_request]
 jobs:
   label:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/labeler@v2
-        if: github.repository == 'ChainSafe/lodestar'
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
The previous conditional statement didn't work because `github.repository` is the target branch repo, not the fork's.

