### PR TITLE
Detect Altona genesis state

### DIFF
--- a/packages/lodestar/src/chain/genesis/genesis.ts
+++ b/packages/lodestar/src/chain/genesis/genesis.ts
@@ -63,7 +63,7 @@ export class GenesisBuilder implements IGenesisBuilder {
       this.processDepositEvents(),
       this.assembleGenesisState()
     );
-    this.eth1.endEth1BlockAndDepositEventsSource();
+    await this.eth1.endEth1BlockAndDepositEventsSource();
     return state;
   }
 
@@ -72,6 +72,8 @@ export class GenesisBuilder implements IGenesisBuilder {
     return async (source) => {
       for await (const [deposits, block] of source) {
         applyDeposits(this.config, this.state, deposits, this.depositTree);
+        this.logger.verbose(`Found ${this.depositTree.length} deposits and ` +
+          `${this.state.validators.length} validators so far`);
         if (!block) {
           continue;
         }

--- a/packages/lodestar/src/chain/genesis/util.ts
+++ b/packages/lodestar/src/chain/genesis/util.ts
@@ -48,7 +48,7 @@ export function applyEth1BlockHash(config: IBeaconConfig, state: BeaconState, et
  * @param eth1Timestamp eth1 block timestamp
  */
 export function applyTimestamp(config: IBeaconConfig, state: BeaconState, eth1Timestamp: number): void {
-  state.genesisTime = eth1Timestamp + config.params.GENESIS_DELAY;
+  state.genesisTime = calculateStateTime(config, eth1Timestamp);
 }
 
 /**
@@ -73,10 +73,11 @@ export function applyDeposits(
       depositDataRootList.push(fullDepositDataRootList[index]);
     }
   }
+  const initDepositCount = depositDataRootList.length;
   const depositDatas: DepositData[] = fullDepositDataRootList? null : newDeposits.map((deposit) => deposit.data);
   newDeposits.forEach((deposit, index) => {
     if (fullDepositDataRootList) {
-      depositDataRootList.push(fullDepositDataRootList[index + depositDataRootList.length]);
+      depositDataRootList.push(fullDepositDataRootList[index + initDepositCount]);
       state.eth1Data.depositRoot = config.types.DepositDataRootList.hashTreeRoot(depositDataRootList);
     } else {
       const depositDataList = depositDatas.slice(0, index + 1);
@@ -103,6 +104,19 @@ export function applyDeposits(
   state.genesisValidatorsRoot = config.types.BeaconState.fields.validators.hashTreeRoot(state.validators);
 }
 
+/**
+ *
+ * This is used to either calculate genesis timestamp or estimate eth1 block forming genesis state.
+ */
+export function calculateStateTime(config: IBeaconConfig, eth1Timestamp: number): number {
+  return eth1Timestamp + config.params.GENESIS_DELAY;
+}
+
+/**
+ * Check if it's valid genesis state.
+ * @param config
+ * @param state
+ */
 export function isValidGenesisState(config: IBeaconConfig, state: BeaconState): boolean {
   if(state.genesisTime < config.params.MIN_GENESIS_TIME) {
     return false;

--- a/packages/lodestar/src/eth1/impl/util.ts
+++ b/packages/lodestar/src/eth1/impl/util.ts
@@ -2,19 +2,15 @@ import {IDepositEvent} from "../interface";
 
 /**
  * Return deposit events of blocks grouped/sorted by block number and deposit index
+ * Put [] as deposit events for blocks without events
  * @param depositEvents range deposit events
  */
-export function groupDepositEventsByBlock(rangeDepositEvents: IDepositEvent[]): Map<number, IDepositEvent[]> {
-  if (!rangeDepositEvents || rangeDepositEvents.length === 0) {
-    return new Map();
-  }
+export function groupDepositEventsByBlock(
+  rangeDepositEvents: IDepositEvent[], fromNumber: number, toNumber: number): Map<number, IDepositEvent[]> {
   rangeDepositEvents.sort((event1, event2) => event1.index - event2.index);
-  return rangeDepositEvents.reduce<Map<number, IDepositEvent[]>>((groupedEvents, event) => {
-    const blockNumber = event.blockNumber;
-    if (!groupedEvents.get(blockNumber)) {
-      groupedEvents.set(blockNumber, []);
-    }
-    groupedEvents.get(blockNumber).push(event);
-    return groupedEvents;
-  }, new Map());
+  const groupedEvents = new Map();
+  for (let blockNumber = fromNumber; blockNumber <= toNumber; blockNumber++) {
+    groupedEvents.set(blockNumber, rangeDepositEvents.filter((event) => event.blockNumber === blockNumber));
+  }
+  return groupedEvents;
 }

--- a/packages/lodestar/test/e2e/chain/genesis/genesis.test.ts
+++ b/packages/lodestar/test/e2e/chain/genesis/genesis.test.ts
@@ -1,0 +1,95 @@
+import {IEth1Notifier, EthersEth1Notifier} from "../../../../src/eth1";
+import {IEth1Options} from "../../../../src/eth1/options";
+import {BeaconDb, LevelDbController} from "../../../../src/db";
+import {ILogger, WinstonLogger, LogLevel} from "@chainsafe/lodestar-utils";
+import {ethers} from "ethers";
+import defaults from "../../../../src/eth1/dev/options";
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import * as fs from "fs";
+import {expect} from "chai";
+import {toHexString, fromHexString} from "@chainsafe/ssz";
+import sinon from "sinon";
+import {GenesisBuilder} from "../../../../src/chain/genesis/genesis";
+import {computeForkDigest} from "@chainsafe/lodestar-beacon-state-transition";
+import {sleep} from "../../../../src/util/sleep";
+
+describe("BeaconChain", function() {
+  this.timeout(10 * 60 * 1000);
+
+  let eth1Notifier: IEth1Notifier;
+  let provider: ethers.providers.JsonRpcProvider;
+  let builder: GenesisBuilder;
+  const opts: IEth1Options = {
+    ...defaults,
+    provider: {
+      url: "https://goerli.prylabs.net",
+      network: 5,
+    },
+    depositContract: {
+      ...defaults.depositContract,
+      deployedAt: 2917810,
+      address: "0x16e82D77882A663454Ef92806b7DeCa1D394810f",
+    }
+  };
+  let db: BeaconDb;
+  const dbPath = "./.tmpdb";
+  const logger: ILogger = new WinstonLogger();
+  logger.silent = false;
+  logger.level = LogLevel.info;
+  const altonaConfig = Object.assign({}, {params: config.params}, config);
+  altonaConfig.params = Object.assign({}, config.params, {
+    MIN_GENESIS_TIME: 1593433800,
+    MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 640,
+    GENESIS_DELAY: 172800,
+    GENESIS_FORK_VERSION: fromHexString("0x00000121")
+  });
+
+
+  const sandbox = sinon.createSandbox();
+
+  before(async () => {
+    await fs.promises.rmdir(dbPath, {recursive: true});
+    expect(altonaConfig.params.MIN_GENESIS_TIME).to.be.not.equal(config.params.MIN_GENESIS_TIME);
+    expect(altonaConfig.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT).to.be.not.equal(config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT);
+    db = new BeaconDb({
+      config: altonaConfig,
+      controller: new LevelDbController({name: dbPath}, {logger}),
+    });
+    provider = new ethers.providers.JsonRpcProvider(opts.provider.url, opts.provider.network);
+    await db.start();
+    eth1Notifier = new EthersEth1Notifier(
+      {...opts, providerInstance: provider},
+      {
+        config: altonaConfig,
+        db,
+        logger: logger.child({module: "eth1"}),
+      });
+  });
+
+
+  beforeEach(async function () {
+    builder = new GenesisBuilder(altonaConfig, {eth1: eth1Notifier, db, logger: logger.child({module: "genesis"})});
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  after(async () => {
+    await db.stop();
+    await fs.promises.rmdir(dbPath, {recursive: true});
+  });
+
+  it("should detect altona genesis state", async function() {
+    logger.profile("detect altona genesis state");
+    const headState = await builder.waitForGenesis();
+    // https://github.com/goerli/altona/tree/master/altona
+    expect(toHexString(altonaConfig.types.BeaconState.hashTreeRoot(headState))).to.be.equal("0x939d98077986a9f6eccae33614e2da1008a2f300f1aac36bc65ef710550eec4a");
+    expect(headState.genesisTime).to.be.equal(1593433805);
+    const forkDigest = computeForkDigest(altonaConfig, headState.fork.currentVersion, headState.genesisValidatorsRoot);
+    expect(toHexString(forkDigest)).to.be.equal("0xfdca39b0");
+    logger.profile("detect altona genesis state");
+    await eth1Notifier.stop();
+    await sleep(200);
+  });
+});

--- a/packages/lodestar/test/unit/chain/genesis/genesis.test.ts
+++ b/packages/lodestar/test/unit/chain/genesis/genesis.test.ts
@@ -1,4 +1,5 @@
-import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import * as fs from "fs";
 import sinon, {SinonStubbedInstance} from "sinon";
 import {EthersEth1Notifier, IDepositEvent, Eth1EventsBlock} from "../../../../src/eth1";
 import {ethers} from "ethers";
@@ -6,7 +7,7 @@ import pushable from "it-pushable";
 import {interopKeypair} from "@chainsafe/lodestar-validator/lib";
 import {PrivateKey, Keypair, initBLS} from "@chainsafe/bls";
 import {computeDomain, DomainType, computeSigningRoot} from "@chainsafe/lodestar-beacon-state-transition";
-import {DepositData, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {DepositData, ValidatorIndex, BLSPubkey} from "@chainsafe/lodestar-types";
 import {GenesisBuilder} from "../../../../src/chain/genesis/genesis";
 import {StubbedBeaconDb} from "../../../utils/stub";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
@@ -57,7 +58,9 @@ describe("genesis builder", function () {
     eth1Stub.getEth1BlockAndDepositEventsSource.resolves(eth1Source);
 
     const statePromise = genesisBuilder.waitForGenesis();
-    for (let i = 0; i < schlesiConfig.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT - 1; i++) {
+    // push 2 first events at the same time first
+    eth1Source.push({events: [events[0], events[1]]});
+    for (let i = 2; i < schlesiConfig.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT - 1; i++) {
       eth1Source.push({events: [events[i]]});
     }
     const lastEventIndex = schlesiConfig.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT - 1;

--- a/packages/lodestar/test/unit/eth1/impl/util.test.ts
+++ b/packages/lodestar/test/unit/eth1/impl/util.test.ts
@@ -3,30 +3,26 @@ import {groupDepositEventsByBlock} from "../../../../src/eth1/impl/util";
 import {IDepositEvent} from "../../../../src/eth1";
 
 describe("utils of eth1", function() {
-  it("should return empty array", () => {
-    expect(Array.from(groupDepositEventsByBlock(null).keys())).to.be.deep.equal([]);
-    expect(Array.from(groupDepositEventsByBlock([]).keys())).to.be.deep.equal([]);
-  });
-
   it("should return deposit events by block", () => {
     const depositData = {amount:BigInt(0), signature: Buffer.alloc(96), withdrawalCredentials: Buffer.alloc(32), pubkey: Buffer.alloc(48)};
     const depositEvents: IDepositEvent[] = [
-      {blockNumber: 1000, index: 0, ...depositData},
-      {blockNumber: 2000, index: 2, ...depositData},
-      {blockNumber: 2000, index: 1, ...depositData},
-      {blockNumber: 3000, index: 4, ...depositData},
-      {blockNumber: 3000, index: 3, ...depositData},
+      {blockNumber: 1, index: 0, ...depositData},
+      {blockNumber: 2, index: 2, ...depositData},
+      {blockNumber: 2, index: 1, ...depositData},
+      {blockNumber: 3, index: 4, ...depositData},
+      {blockNumber: 3, index: 3, ...depositData},
     ];
-    const blockEvents = groupDepositEventsByBlock(depositEvents);
-    expect(Array.from(blockEvents.keys())).to.be.deep.equals([1000, 2000, 3000]);
-    expect(blockEvents.get(1000).length).to.be.equal(1);
-    expect(blockEvents.get(1000)[0].index).to.be.equal(0);
-    expect(blockEvents.get(2000).length).to.be.equal(2);
-    expect(blockEvents.get(2000)[0].index).to.be.equal(1);
-    expect(blockEvents.get(2000)[1].index).to.be.equal(2);
-    expect(blockEvents.get(3000).length).to.be.equal(2);
-    expect(blockEvents.get(3000)[0].index).to.be.equal(3);
-    expect(blockEvents.get(3000)[1].index).to.be.equal(4);
-
+    const blockEvents = groupDepositEventsByBlock(depositEvents, 0, 4);
+    expect(Array.from(blockEvents.keys())).to.be.deep.equals([0, 1, 2, 3, 4]);
+    expect(blockEvents.get(0).length).to.be.equal(0);
+    expect(blockEvents.get(1).length).to.be.equal(1);
+    expect(blockEvents.get(1)[0].index).to.be.equal(0);
+    expect(blockEvents.get(2).length).to.be.equal(2);
+    expect(blockEvents.get(2)[0].index).to.be.equal(1);
+    expect(blockEvents.get(2)[1].index).to.be.equal(2);
+    expect(blockEvents.get(3).length).to.be.equal(2);
+    expect(blockEvents.get(3)[0].index).to.be.equal(3);
+    expect(blockEvents.get(3)[1].index).to.be.equal(4);
+    expect(blockEvents.get(4).length).to.be.equal(0);
   });
 });


### PR DESCRIPTION
+ Add `genesis.test.ts` to detect Altona genesis state, similar to what we did to Schlesi and compare found genesis state to https://github.com/goerli/altona/tree/master/altona
+ Need to save/process/push a block even it has no deposit event
+ Since Altona has a lot of invalid deposts, there are a lot of `getBlock` calls unnecessarily even it's way before genesis block. So I implement checkpoint strategy: if preGenesis only call `getBlock` if it's at checkpoint and set the next checkpoint based on `SECONDS_PER_ETH1_BLOCK` so the `getBlock` calls is likely reduced from `n` to `log2(n)`
+ SECONDS_PER_ETH1_BLOCK may not be the same to the reality but since we set checkpoint frequently at "`distance of current block to genesis/2`" , the "`delta`" is gradually smaller, it should be fine. Added unit tests to make sure.

## Tests
+ In CI we can find Altona genesis state in just 1 min but in my local environment, it can be up to 6 minutes depending on network situation
```
@chainsafe/lodestar: 2020-07-05 09:22:27  [ETH1]             info: Set checkpoint to 2947075 
@chainsafe/lodestar: 2020-07-05 09:22:27  [ETH1]             info: At block 2947075, probably 2 blocks to genesis time if there is enough validators 
@chainsafe/lodestar: 2020-07-05 09:22:27  [ETH1]             info: At block 2947076, probably 1 blocks to genesis time if there is enough validators 
@chainsafe/lodestar: 2020-07-05 09:22:27  [ETH1]             info: At block 2947077, probably 0 blocks to genesis time if there is enough validators 
@chainsafe/lodestar: 2020-07-05 09:22:33  [GENESIS]          info: Found genesis state at eth1 block 2947078 
@chainsafe/lodestar: 2020-07-05 09:22:33  [ETH1]             info: Unsubscribed eth1 blocks & depoosit events 
@chainsafe/lodestar: 2020-07-05 09:22:33  []                 info: detect altona genesis state - duration=59587ms
```