### PR TITLE
Fix genesis checkpoint root in status msg

### DIFF
--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -14,7 +14,7 @@ import {
   MAX_REQUEST_BLOCKS,
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {GENESIS_EPOCH, Method, RequestId, RpcResponseStatus} from "../../constants";
+import {GENESIS_EPOCH, Method, RequestId, RpcResponseStatus, ZERO_HASH} from "../../constants";
 import {IBeaconDb} from "../../db";
 import {IBeaconChain} from "../../chain";
 import {INetwork} from "../../network";
@@ -234,7 +234,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
     const head = this.chain.forkChoice.head();
     return {
       forkDigest: this.chain.currentForkDigest,
-      finalizedRoot: head.finalizedCheckpoint.root,
+      finalizedRoot: head.finalizedCheckpoint.epoch === GENESIS_EPOCH ? ZERO_HASH : head.finalizedCheckpoint.root,
       finalizedEpoch: head.finalizedCheckpoint.epoch,
       headRoot: head.blockRoot,
       headSlot: head.slot,


### PR DESCRIPTION
Resolves https://github.com/chainsafe/lodestar/issues/998

If the finalized checkpoint is the genesis checkpoint, the status message should return all-zeros for the finalized checkpoint root.

#998 is _actually_ substantive, because we never had this special-cased logic for genesis.