### PR TITLE
once/on patch, eth1vote optimization, pubkey cache change, attestation optimizations

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/fast/block/isValidIndexedAttestation.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/isValidIndexedAttestation.ts
@@ -20,11 +20,17 @@ export function isValidIndexedAttestation(
   if (!(indices.length > 0 && indices.length <= MAX_VALIDATORS_PER_COMMITTEE)) {
     return false;
   }
-  // verify indices are sorted and unique
-  if (!config.types.CommitteeIndices.equals(
-    indices,
-    [...(new Set(indices)).values()].sort((a, b) => a - b))
-  ) {
+  // verify indices are sorted and unique.
+  // Just check if they are monotonically increasing,
+  // instead of creating a set and sorting it. Should be (O(n)) instead of O(n log(n))
+  let prev = -1;
+  for (const index of indices) {
+    if (index <= prev)
+      return false;
+    prev = index;
+  }
+  // check if indices are out of bounds, by checking the highest index (since it is sorted)
+  if (indices[indices.length-1] >= state.validators.length) {
     return false;
   }
   // verify aggregate signature

--- a/packages/lodestar-beacon-state-transition/src/fast/block/processAttestation.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/processAttestation.ts
@@ -3,6 +3,7 @@ import {Attestation, BeaconState, IndexedAttestation} from "@chainsafe/lodestar-
 import {computeEpochAtSlot} from "../../util";
 import {EpochContext} from "../util";
 import {isValidIndexedAttestation} from "./isValidIndexedAttestation";
+import {ValidatorIndex} from "@chainsafe/lodestar-types/lib/types/primitive";
 
 
 export function processAttestation(
@@ -84,15 +85,17 @@ export function processAttestation(
   const getIndexedAttestation = (attestation: Attestation): IndexedAttestation => {
     const bits = Array.from(attestation.aggregationBits);
     const committee = epochCtx.getBeaconCommittee(data.slot, data.index);
-    const attestingIndices = new Set<number>();
+    // No need for a Set, the indices in the committee are already unique.
+    const attestingIndices: ValidatorIndex[] = [];
     committee.forEach((index, i) => {
       if (bits[i]) {
-        attestingIndices.add(index);
+        attestingIndices.push(index);
       }
     });
-
+    // sort in-place
+    attestingIndices.sort((a, b) => a - b);
     return {
-      attestingIndices: [...attestingIndices.values()].sort((a, b) => a - b),
+      attestingIndices: attestingIndices,
       data: data,
       signature: attestation.signature,
     };

--- a/packages/lodestar-beacon-state-transition/src/fast/block/processDeposit.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/processDeposit.ts
@@ -30,7 +30,8 @@ export function processDeposit(
 
   const pubkey = deposit.data.pubkey;
   const amount = deposit.data.amount;
-  if (!Number.isSafeInteger(epochCtx.pubkey2index.get(pubkey))) {
+  const cachedIndex = epochCtx.pubkey2index.get(pubkey);
+  if (!Number.isSafeInteger(cachedIndex) || cachedIndex >= state.validators.length) {
     // verify the deposit signature (proof of posession) which is not checked by the deposit contract
     const depositMessage = {
       pubkey: deposit.data.pubkey,
@@ -62,8 +63,7 @@ export function processDeposit(
     state.balances.push(amount);
   } else {
     // increase balance by deposit amount
-    const index = epochCtx.pubkey2index.get(pubkey);
-    increaseBalance(state, index, amount);
+    increaseBalance(state, cachedIndex, amount);
   }
   // now that there is a new validator, update the epoch context with the new pubkey
   epochCtx.syncPubkeys(state);

--- a/packages/lodestar-beacon-state-transition/src/fast/block/processEth1Data.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/processEth1Data.ts
@@ -12,12 +12,19 @@ export function processEth1Data(
   const {EPOCHS_PER_ETH1_VOTING_PERIOD, SLOTS_PER_EPOCH} = epochCtx.config.params;
   const SLOTS_PER_ETH1_VOTING_PERIOD = EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH;
   const newEth1Data = body.eth1Data;
-  state.eth1DataVotes.push(newEth1Data);
-  if (Eth1Data.equals(state.eth1Data, newEth1Data)) {
+  // Convert to tree-backed, this is what it looks like in the state,
+  // and hash-tree-root caching speeds things up a lot during the vote counting.
+  const newEth1DataCached = Eth1Data.tree.asTreeBacked(Eth1Data.tree.fromStructural(newEth1Data));
+  // Count it as vote
+  state.eth1DataVotes.push(newEth1DataCached);
+  // If there are not more than 50% votes, then we do not have to count to find a winner.
+  if (state.eth1DataVotes.length * 2 <= SLOTS_PER_ETH1_VOTING_PERIOD) {
+    return;
+  }
+  if (Eth1Data.equals(state.eth1Data, newEth1DataCached)) {
     return; // Nothing to do if the state already has this as eth1data (happens a lot after majority vote is in)
   }
   // TODO fast read-only iteration
-  const newEth1DataCached = Eth1Data.tree.asTreeBacked(Eth1Data.tree.fromStructural(newEth1Data));
   const sameVotesCount = Array.from(state.eth1DataVotes).filter((e) => Eth1Data.equals(e, newEth1DataCached)).length;
   if (sameVotesCount * 2 > SLOTS_PER_ETH1_VOTING_PERIOD) {
     state.eth1Data = newEth1Data;

--- a/packages/lodestar-beacon-state-transition/src/fast/block/processEth1Data.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/processEth1Data.ts
@@ -17,7 +17,8 @@ export function processEth1Data(
     return; // Nothing to do if the state already has this as eth1data (happens a lot after majority vote is in)
   }
   // TODO fast read-only iteration
-  const sameVotesCount = Array.from(state.eth1DataVotes).filter((e) => Eth1Data.equals(e, newEth1Data)).length;
+  const newEth1DataCached = Eth1Data.tree.asTreeBacked(Eth1Data.tree.fromStructural(newEth1Data));
+  const sameVotesCount = Array.from(state.eth1DataVotes).filter((e) => Eth1Data.equals(e, newEth1DataCached)).length;
   if (sameVotesCount * 2 > SLOTS_PER_ETH1_VOTING_PERIOD) {
     state.eth1Data = newEth1Data;
   }

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -232,7 +232,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
 
   public async waitForBlockProcessed(blockRoot: Uint8Array): Promise<void> {
     await new Promise((resolve) => {
-      this.once("processedBlock", (signedBlock) => {
+      this.on("processedBlock", (signedBlock) => {
         const root = this.config.types.BeaconBlock.hashTreeRoot(signedBlock.message);
         if (this.config.types.Root.equals(root, blockRoot)) {
           resolve();


### PR DESCRIPTION
Collection of Altona optimizations/hotfixes

- once/on patch (not mine)
- eth1vote optimization
  - previously it hashed the eth1 data of the block over and over again, for each comparison. Super slow. Conver to tree backed, to cache hash-tree-root, and have much faster counting
- pubkey cache hack, index bound safety
  - the pubkeys don't change for eth1 data, unless a bad majority vote is made by an attacker and accepted by the local node.
  - added some safety checks, we don't want not-yet-existing pubkeys of a different beacon fork (but the same eth1 chain) to mess up the transition logic
     - optimized indices check in the attestation processing too

Edit, more optimization:
- convert the block to a tree-backed block. The amount of times the block is merkleized, its parts are merkleized, and how large parts end up in the state (attestation bitfields), hash-tee-root caching is too important.
- Optimize get-indexed-attestation. Don't unnecessarily copy. Don't use a Set when it's unique anyway. In-place sort the (small-ish) list of participants.
- Cut off eth1 vote logic when half of the period is not reached yet. No majority vote can exist before then, thus no state change anyway.
