### PR TITLE
Avoid using db.stateCache.values()

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -232,7 +232,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
 
   public async waitForBlockProcessed(blockRoot: Uint8Array): Promise<void> {
     await new Promise((resolve) => {
-      this.once("processedBlock", (signedBlock) => {
+      this.on("processedBlock", (signedBlock) => {
         const root = this.config.types.BeaconBlock.hashTreeRoot(signedBlock.message);
         if (this.config.types.Root.equals(root, blockRoot)) {
           resolve();

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -231,14 +231,17 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
   }
 
   public async waitForBlockProcessed(blockRoot: Uint8Array): Promise<void> {
+    let listener: (signedBlock: SignedBeaconBlock) => void;
     await new Promise((resolve) => {
-      this.on("processedBlock", (signedBlock) => {
+      listener = (signedBlock) => {
         const root = this.config.types.BeaconBlock.hashTreeRoot(signedBlock.message);
         if (this.config.types.Root.equals(root, blockRoot)) {
           resolve();
         }
-      });
+      };
+      this.on("processedBlock", listener);
     });
+    this.removeListener("processedBlock", listener);
   }
 
   /**

--- a/packages/lodestar/src/chain/forkChoice/interface.ts
+++ b/packages/lodestar/src/chain/forkChoice/interface.ts
@@ -2,12 +2,18 @@
 /**
  * @module chain/forkChoice
  */
-
+import {EventEmitter} from "events";
+import StrictEventEmitter from "strict-event-emitter-types";
 import {Checkpoint, Gwei, Slot, ValidatorIndex, Epoch} from "@chainsafe/lodestar-types";
 import {IBeaconClock} from "../clock/interface";
 
+export interface IForkChoiceEvents {
+  prune: (finalized: BlockSummary, pruned: BlockSummary[]) => void;
+}
 
-export interface ILMDGHOST {
+export type ForkChoiceEventEmitter = StrictEventEmitter<EventEmitter, IForkChoiceEvents>;
+
+export interface ILMDGHOST extends ForkChoiceEventEmitter {
   start(genesisTime: number, clock: IBeaconClock): Promise<void>;
   stop(): Promise<void>;
   addBlock(info: BlockSummary): void;

--- a/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
@@ -12,13 +12,14 @@ import {
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {assert} from "@chainsafe/lodestar-utils";
 
-import {BlockSummary, ILMDGHOST} from "../interface";
+import {BlockSummary, ILMDGHOST, ForkChoiceEventEmitter} from "../interface";
 
 import {NodeInfo} from "./interface";
 import {HexCheckpoint, RootHex} from "../interface";
 import {GENESIS_EPOCH, ZERO_HASH} from "../../../constants";
 import {AttestationAggregator} from "../attestationAggregator";
 import {IBeaconClock} from "../../clock/interface";
+import {EventEmitter} from "events";
 
 /**
  * A block root with additional metadata required to form a DAG
@@ -236,7 +237,7 @@ export class Node {
  *
  * See https://github.com/protolambda/lmd-ghost#state-ful-dag
  */
-export class StatefulDagLMDGHOST implements ILMDGHOST {
+export class StatefulDagLMDGHOST extends (EventEmitter as { new(): ForkChoiceEventEmitter }) implements ILMDGHOST {
   private readonly config: IBeaconConfig;
   private genesisTime: Number64;
 
@@ -267,6 +268,7 @@ export class StatefulDagLMDGHOST implements ILMDGHOST {
   private clock: IBeaconClock;
 
   public constructor(config: IBeaconConfig) {
+    super();
     this.aggregator =
       new AttestationAggregator((hex: string) => this.nodes[hex] ? this.nodes[hex].slot : null);
     this.nodes = {};

--- a/packages/lodestar/src/db/api/beacon/beacon.ts
+++ b/packages/lodestar/src/db/api/beacon/beacon.ts
@@ -43,7 +43,7 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
     super(opts);
     this.badBlock = new BadBlockRepository(this.config, this.db);
     this.block = new BlockRepository(this.config, this.db);
-    this.stateCache = new StateContextCache();
+    this.stateCache = new StateContextCache(this.config);
     this.blockArchive = new BlockArchiveRepository(this.config, this.db);
     this.stateArchive = new StateArchiveRepository(this.config, this.db);
     this.attestation = new AttestationRepository(this.config, this.db);

--- a/packages/lodestar/src/db/api/beacon/beacon.ts
+++ b/packages/lodestar/src/db/api/beacon/beacon.ts
@@ -43,7 +43,7 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
     super(opts);
     this.badBlock = new BadBlockRepository(this.config, this.db);
     this.block = new BlockRepository(this.config, this.db);
-    this.stateCache = new StateContextCache(this.config);
+    this.stateCache = new StateContextCache();
     this.blockArchive = new BlockArchiveRepository(this.config, this.db);
     this.stateArchive = new StateArchiveRepository(this.config, this.db);
     this.attestation = new AttestationRepository(this.config, this.db);

--- a/packages/lodestar/src/db/api/beacon/stateContextCache.ts
+++ b/packages/lodestar/src/db/api/beacon/stateContextCache.ts
@@ -1,6 +1,6 @@
 import {ByteVector, toHexString, TreeBacked} from "@chainsafe/ssz";
-import {BeaconState, Epoch, Slot} from "@chainsafe/lodestar-types";
-import {EpochContext, computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconState} from "@chainsafe/lodestar-types";
+import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
 export interface ITreeStateContext {
@@ -53,20 +53,6 @@ export class StateContextCache {
   // public async values(): Promise<ITreeStateContext[]> {
   //   return Object.values(this.cache).map(item => this.clone(item));
   // }
-
-  public async firstStateOfEpoch(epoch: Epoch): Promise<ITreeStateContext | null> {
-    const items = Object.values(this.cache).filter(item => computeEpochAtSlot(this.config, item.state.slot) === epoch);
-    if (!items || items.length === 0) {
-      return null;
-    }
-    return this.clone(items.sort((a, b) => a.state.slot - b.state.slot)[0]);
-  }
-
-  public prune(slot: Slot): void {
-    const rootsToDelete =
-      Object.values(this.cache).filter(item => item.state.slot < slot).map(item => item.state.hashTreeRoot());
-    this.batchDelete(rootsToDelete);
-  }
 
   private clone(item: ITreeStateContext): ITreeStateContext {
     return {

--- a/packages/lodestar/src/db/api/beacon/stateContextCache.ts
+++ b/packages/lodestar/src/db/api/beacon/stateContextCache.ts
@@ -1,7 +1,6 @@
 import {ByteVector, toHexString, TreeBacked} from "@chainsafe/ssz";
 import {BeaconState} from "@chainsafe/lodestar-types";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
-import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
 export interface ITreeStateContext {
   state: TreeBacked<BeaconState>;
@@ -14,11 +13,8 @@ export interface ITreeStateContext {
  * Similar API to Repository
  */
 export class StateContextCache {
-  private config: IBeaconConfig;
-
   private cache: Record<string, ITreeStateContext>;
-  constructor(config: IBeaconConfig) {
-    this.config = config;
+  constructor() {
     this.cache = {};
   }
 
@@ -50,9 +46,9 @@ export class StateContextCache {
    * Should only use this with care as this is expensive.
    * @param epoch
    */
-  // public async values(): Promise<ITreeStateContext[]> {
-  //   return Object.values(this.cache).map(item => this.clone(item));
-  // }
+  public async valuesUnsafe(): Promise<ITreeStateContext[]> {
+    return Object.values(this.cache).map(item => this.clone(item));
+  }
 
   private clone(item: ITreeStateContext): ITreeStateContext {
     return {

--- a/packages/lodestar/src/tasks/index.ts
+++ b/packages/lodestar/src/tasks/index.ts
@@ -5,8 +5,7 @@
 import {IService} from "../node";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBeaconDb} from "../db/api";
-import {IBeaconChain} from "../chain";
-import {Checkpoint} from "@chainsafe/lodestar-types";
+import {IBeaconChain, BlockSummary} from "../chain";
 import {ArchiveBlocksTask} from "./tasks/archiveBlocks";
 import {ArchiveStatesTask} from "./tasks/archiveStates";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
@@ -49,7 +48,7 @@ export class TasksService implements IService {
   }
 
   public async start(): Promise<void> {
-    this.chain.on("finalizedCheckpoint", this.handleFinalizedCheckpointChores);
+    this.chain.forkChoice.on("prune", this.handleFinalizedCheckpointChores);
     await this.interopSubnetsTask.start();
   }
 
@@ -58,9 +57,9 @@ export class TasksService implements IService {
     await this.interopSubnetsTask.stop();
   }
 
-  private handleFinalizedCheckpointChores = async (finalizedCheckpoint: Checkpoint): Promise<void> => {
-    new ArchiveBlocksTask(this.config, {db: this.db, logger: this.logger}, finalizedCheckpoint).run();
-    new ArchiveStatesTask(this.config, {db: this.db, logger: this.logger}, finalizedCheckpoint).run();
+  private handleFinalizedCheckpointChores = async (finalized: BlockSummary, pruned: BlockSummary[]): Promise<void> => {
+    new ArchiveBlocksTask(this.config, {db: this.db, logger: this.logger}, finalized, pruned).run();
+    new ArchiveStatesTask(this.config, {db: this.db, logger: this.logger}, finalized, pruned).run();
   };
 
 }

--- a/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
@@ -43,17 +43,13 @@ export class ArchiveBlocksTask implements ITask {
   public async run(): Promise<void> {
     this.logger.profile("Archieve Blocks");
     const allBlocks = await this.db.block.values();
-    const finalizedBlock = allBlocks.find(block => {
-      const blockRoot = this.config.types.BeaconBlock.hashTreeRoot(block.message);
-      return this.config.types.Root.equals(blockRoot, this.finalized.blockRoot);
-    });
     const blocks = allBlocks.filter(
-      (block) =>
-        block.message.slot <= finalizedBlock.message.slot
+      (block) => block.message.slot <= this.finalized.slot
     );
     const blocksByRoot = new Map<string, SignedBeaconBlock>();
     blocks.forEach((block) =>
       blocksByRoot.set(toHexString(this.config.types.BeaconBlock.hashTreeRoot(block.message)), block));
+    const finalizedBlock = blocksByRoot.get(toHexString(this.finalized.blockRoot));
     const archivedBlocks = [finalizedBlock];
     let lastBlock = finalizedBlock;
     while (lastBlock) {

--- a/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
@@ -41,7 +41,7 @@ export class ArchiveBlocksTask implements ITask {
    * Only archive blocks on the same chain to the finalized checkpoint.
    */
   public async run(): Promise<void> {
-    this.logger.profile("Archieve Blocks");
+    this.logger.profile("Archive Blocks");
     const allBlocks = await this.db.block.values();
     const blocks = allBlocks.filter(
       (block) => block.message.slot <= this.finalized.slot
@@ -69,7 +69,7 @@ export class ArchiveBlocksTask implements ITask {
       this.db.blockArchive.batchAdd(archivedBlocks),
       this.db.block.batchRemove(blocks)
     ]);
-    this.logger.profile("Archieve Blocks");
+    this.logger.profile("Archive Blocks");
     this.logger.info(`Archiving of ${archivedBlocks.length} finalized blocks from slot ${fromSlot} to ${toSlot}`
         + ` completed (finalized epoch #${epoch})`);
   }

--- a/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
@@ -4,10 +4,12 @@
 
 import {ITask} from "../interface";
 import {IBeaconDb} from "../../db/api";
-import {Checkpoint, SignedBeaconBlock} from "@chainsafe/lodestar-types";
+import {SignedBeaconBlock} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {toHexString} from "@chainsafe/ssz";
+import {BlockSummary} from "../../chain";
+import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 
 export interface IArchiveBlockModules {
   db: IBeaconDb;
@@ -23,23 +25,27 @@ export class ArchiveBlocksTask implements ITask {
   private readonly logger: ILogger;
   private readonly config: IBeaconConfig;
 
-  private finalizedCheckpoint: Checkpoint;
+  private finalized: BlockSummary;
+  private pruned: BlockSummary[];
 
-  public constructor(config: IBeaconConfig, modules: IArchiveBlockModules, finalizedCheckpoint: Checkpoint) {
+  public constructor(
+    config: IBeaconConfig, modules: IArchiveBlockModules, finalized: BlockSummary, pruned: BlockSummary[]) {
     this.db = modules.db;
     this.logger = modules.logger;
     this.config = config;
-    this.finalizedCheckpoint = finalizedCheckpoint;
+    this.finalized = finalized;
+    this.pruned = pruned;
   }
 
   /**
    * Only archive blocks on the same chain to the finalized checkpoint.
    */
   public async run(): Promise<void> {
+    this.logger.profile("Archieve Blocks");
     const allBlocks = await this.db.block.values();
     const finalizedBlock = allBlocks.find(block => {
       const blockRoot = this.config.types.BeaconBlock.hashTreeRoot(block.message);
-      return this.config.types.Root.equals(blockRoot, this.finalizedCheckpoint.root);
+      return this.config.types.Root.equals(blockRoot, this.finalized.blockRoot);
     });
     const blocks = allBlocks.filter(
       (block) =>
@@ -58,14 +64,17 @@ export class ArchiveBlocksTask implements ITask {
     }
     const fromSlot = (archivedBlocks.length > 0)? archivedBlocks[archivedBlocks.length - 1].message.slot : undefined;
     const toSlot = (archivedBlocks.length > 0)? archivedBlocks[0].message.slot : undefined;
+    const epoch = computeEpochAtSlot(this.config, this.finalized.slot);
+
     this.logger.info(`Started archiving ${archivedBlocks.length} blocks from slot ${fromSlot} to ${toSlot}`
-        +`(finalized epoch #${this.finalizedCheckpoint.epoch})...`
+        +`(finalized epoch #${epoch})...`
     );
     await Promise.all([
       this.db.blockArchive.batchAdd(archivedBlocks),
       this.db.block.batchRemove(blocks)
     ]);
+    this.logger.profile("Archieve Blocks");
     this.logger.info(`Archiving of ${archivedBlocks.length} finalized blocks from slot ${fromSlot} to ${toSlot}`
-        + ` completed (finalized epoch #${this.finalizedCheckpoint.epoch})`);
+        + ` completed (finalized epoch #${epoch})`);
   }
 }

--- a/packages/lodestar/src/tasks/tasks/archiveStates.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveStates.ts
@@ -42,7 +42,7 @@ export class ArchiveStatesTask implements ITask {
     this.logger.info(
       `Started archiving states (finalized epoch #${epoch})...`
     );
-    this.logger.profile("Archieve States");
+    this.logger.profile("Archive States");
     // store the state of finalized checkpoint
     const finalizedState = (await this.db.stateCache.get(this.finalized.stateRoot)).state;
     await this.db.stateArchive.add(finalizedState);
@@ -51,6 +51,6 @@ export class ArchiveStatesTask implements ITask {
     this.db.stateCache.batchDelete(prunedStates);
     this.logger.info(
       `Archiving of finalized states completed (finalized epoch #${epoch})`);
-    this.logger.profile("Archieve States");
+    this.logger.profile("Archive States");
   }
 }

--- a/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
+++ b/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
@@ -50,9 +50,14 @@ describe("block archiver task", function () {
         db: dbStub,
         logger: loggerStub
       }, {
-        epoch: 3,
-        root: config.types.BeaconBlock.hashTreeRoot(finalizedBlock.message)
-      }
+        slot: 3,
+        blockRoot: config.types.BeaconBlock.hashTreeRoot(finalizedBlock.message),
+        parentRoot: finalizedBlock.message.parentRoot as Uint8Array,
+        stateRoot: finalizedBlock.message.stateRoot as Uint8Array,
+        justifiedCheckpoint: {epoch: 0, root: Buffer.alloc(32)},
+        finalizedCheckpoint: {epoch: 0, root: Buffer.alloc(32)}
+      },
+      []
     );
     dbStub.block.values.resolves([
       blockA, blockB, blockC, blockD, finalizedBlock, blockE

--- a/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
+++ b/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
@@ -50,7 +50,7 @@ describe("block archiver task", function () {
         db: dbStub,
         logger: loggerStub
       }, {
-        slot: 3,
+        slot: finalizedBlock.message.slot,
         blockRoot: config.types.BeaconBlock.hashTreeRoot(finalizedBlock.message),
         parentRoot: finalizedBlock.message.parentRoot as Uint8Array,
         stateRoot: finalizedBlock.message.stateRoot as Uint8Array,


### PR DESCRIPTION
resolves #1118 

+ We know that using `db.stateCache.values()` is expensive so just comment out that for now. The processing time is reduce from ~2500ms to ~200ms in my environment.