### PR TITLE
API: add /node/head endpoint, tweak /node/version endpoint

### DIFF
--- a/packages/lodestar-types/src/ssz/generators/api.ts
+++ b/packages/lodestar-types/src/ssz/generators/api.ts
@@ -59,3 +59,13 @@ export const ValidatorResponse = (ssz: IBeaconSSZTypes): ContainerType => new Co
   },
 });
 
+export const HeadResponse = (ssz: IBeaconSSZTypes): ContainerType => new ContainerType({
+  fields: {
+    headSlot: ssz.Slot,
+    headBlockRoot: ssz.Root,
+    finalizedSlot: ssz.Slot,
+    finalizedBlockRoot: ssz.Root,
+    justifiedSlot: ssz.Slot,
+    justifiedBlockRoot: ssz.Root
+  },
+});

--- a/packages/lodestar-types/src/ssz/interface.ts
+++ b/packages/lodestar-types/src/ssz/interface.ts
@@ -168,5 +168,6 @@ export const typeNames: (keyof IBeaconSSZTypes)[] = [
   "SyncingStatus",
   "AttesterDuty",
   "ProposerDuty",
-  "ValidatorResponse"
+  "ValidatorResponse",
+  "HeadResponse",
 ];

--- a/packages/lodestar-types/src/ssz/interface.ts
+++ b/packages/lodestar-types/src/ssz/interface.ts
@@ -88,6 +88,7 @@ export interface IBeaconSSZTypes {
   SubscribeToCommitteeSubnetPayload: ContainerType<t.SubscribeToCommitteeSubnetPayload>;
   ForkResponse: ContainerType<t.ForkResponse>;
   ValidatorResponse: ContainerType<t.ValidatorResponse>;
+  HeadResponse: ContainerType<t.HeadResponse>;
 }
 
 export const typeNames: (keyof IBeaconSSZTypes)[] = [

--- a/packages/lodestar-types/src/types/api.ts
+++ b/packages/lodestar-types/src/types/api.ts
@@ -53,3 +53,12 @@ export interface ValidatorResponse {
   balance: Gwei;
   validator: Validator;
 }
+
+export interface HeadResponse {
+  headSlot: Slot;
+  headBlockRoot: Root;
+  finalizedSlot: Slot;
+  finalizedBlockRoot: Root;
+  justifiedSlot: Slot;
+  justifiedBlockRoot: Root;
+}

--- a/packages/lodestar/src/api/impl/beacon/beacon.ts
+++ b/packages/lodestar/src/api/impl/beacon/beacon.ts
@@ -11,7 +11,8 @@ import {
   SignedBeaconBlock,
   SyncingStatus,
   Uint64,
-  ValidatorResponse
+  ValidatorResponse,
+  HeadResponse,
 } from "@chainsafe/lodestar-types";
 import {IBeaconApi} from "./interface";
 import {IBeaconChain} from "../../../chain";
@@ -100,5 +101,9 @@ export class BeaconApi implements IBeaconApi {
         this.chain.off("processedBlock", push);
       };
     });
+  }
+
+  public async getHead(): Promise<HeadResponse> {
+    return this.chain.getHead();
   }
 }

--- a/packages/lodestar/src/api/impl/beacon/beacon.ts
+++ b/packages/lodestar/src/api/impl/beacon/beacon.ts
@@ -3,6 +3,7 @@
  */
 
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import PeerId from "peer-id";
 import {
   BLSPubkey,
   Bytes32,
@@ -21,6 +22,7 @@ import {IApiModules} from "../../interface";
 import {ApiNamespace} from "../../index";
 import {IBeaconDb} from "../../../db/api";
 import {IBeaconSync} from "../../../sync";
+import {INetwork} from "../../../network";
 import {BeaconBlockApi, IBeaconBlocksApi} from "./blocks";
 import {LodestarEventIterator} from "../../../util/events";
 
@@ -33,6 +35,7 @@ export class BeaconApi implements IBeaconApi {
   private readonly chain: IBeaconChain;
   private readonly db: IBeaconDb;
   private readonly sync: IBeaconSync;
+  private readonly network: INetwork;
 
   public constructor(opts: Partial<IApiOptions>, modules: IApiModules) {
     this.namespace = ApiNamespace.BEACON;
@@ -40,6 +43,7 @@ export class BeaconApi implements IBeaconApi {
     this.chain = modules.chain;
     this.db = modules.db;
     this.sync = modules.sync;
+    this.network = modules.network;
     this.blocks = new BeaconBlockApi(opts, modules);
   }
 
@@ -105,5 +109,9 @@ export class BeaconApi implements IBeaconApi {
 
   public async getHead(): Promise<HeadResponse> {
     return this.chain.getHead();
+  }
+
+  public async getPeers(): Promise<PeerId[]> {
+    return this.network.getPeers();
   }
 }

--- a/packages/lodestar/src/api/impl/beacon/beacon.ts
+++ b/packages/lodestar/src/api/impl/beacon/beacon.ts
@@ -44,7 +44,7 @@ export class BeaconApi implements IBeaconApi {
   }
 
   public async getClientVersion(): Promise<Bytes32> {
-    return Buffer.from(`lodestar-${process.env.npm_package_version}`, "utf-8");
+    return Buffer.from(`Lodestar/${process.env.npm_package_version || "dev"}`, "utf-8");
   }
 
 

--- a/packages/lodestar/src/api/impl/beacon/interface.ts
+++ b/packages/lodestar/src/api/impl/beacon/interface.ts
@@ -15,6 +15,7 @@ import {
 } from "@chainsafe/lodestar-types";
 import {LodestarEventIterator} from "../../../util/events";
 import {IBeaconBlocksApi} from "./blocks";
+import PeerId from "peer-id";
 
 export interface IBeaconApi extends IApi {
 
@@ -58,4 +59,9 @@ export interface IBeaconApi extends IApi {
    * Requests the current fork-choice head, including finalization and justification data.
    */
   getHead(): Promise<HeadResponse>;
+
+  /**
+   * Requests list of currently connected peers.
+   */
+  getPeers(): Promise<PeerId[]>;
 }

--- a/packages/lodestar/src/api/impl/beacon/interface.ts
+++ b/packages/lodestar/src/api/impl/beacon/interface.ts
@@ -10,7 +10,8 @@ import {
   Number64,
   SignedBeaconBlock,
   SyncingStatus,
-  ValidatorResponse
+  ValidatorResponse,
+  HeadResponse
 } from "@chainsafe/lodestar-types";
 import {LodestarEventIterator} from "../../../util/events";
 import {IBeaconBlocksApi} from "./blocks";
@@ -52,4 +53,9 @@ export interface IBeaconApi extends IApi {
   getSyncingStatus(): Promise<boolean | SyncingStatus>;
 
   getBlockStream(): LodestarEventIterator<SignedBeaconBlock>;
+
+  /**
+   * Requests the current fork-choice head, including finalization and justification data.
+   */
+  getHead(): Promise<HeadResponse>;
 }

--- a/packages/lodestar/src/api/rest/routes/beacon/head.ts
+++ b/packages/lodestar/src/api/rest/routes/beacon/head.ts
@@ -1,0 +1,19 @@
+import * as fastify from "fastify";
+import {LodestarRestApiEndpoint} from "../../interface";
+import {Json} from "@chainsafe/ssz";
+
+export const registerHeadEndpoint: LodestarRestApiEndpoint = (server, {api, config}): void => {
+  server.get<fastify.DefaultQuery, {}, unknown>(
+    "/head",
+    {},
+    async (request, reply) => {
+      const responseValue = await api.beacon.getHead();
+      const response: Json = config.types.HeadResponse.toJson(responseValue);
+      reply
+        .code(200)
+        .type("application/json")
+        .send(
+          response
+        );
+    });
+};

--- a/packages/lodestar/src/api/rest/routes/beacon/head.ts
+++ b/packages/lodestar/src/api/rest/routes/beacon/head.ts
@@ -1,6 +1,5 @@
 import * as fastify from "fastify";
 import {LodestarRestApiEndpoint} from "../../interface";
-import {Json} from "@chainsafe/ssz";
 
 export const registerHeadEndpoint: LodestarRestApiEndpoint = (server, {api, config}): void => {
   server.get<fastify.DefaultQuery, {}, unknown>(
@@ -8,12 +7,11 @@ export const registerHeadEndpoint: LodestarRestApiEndpoint = (server, {api, conf
     {},
     async (request, reply) => {
       const responseValue = await api.beacon.getHead();
-      const response: Json = config.types.HeadResponse.toJson(responseValue);
       reply
         .code(200)
         .type("application/json")
         .send(
-          response
+          config.types.HeadResponse.toJson(responseValue, {case: "snake"})
         );
     });
 };

--- a/packages/lodestar/src/api/rest/routes/beacon/index.ts
+++ b/packages/lodestar/src/api/rest/routes/beacon/index.ts
@@ -5,6 +5,7 @@ import {registerSyncingEndpoint} from "./syncing";
 import {LodestarApiPlugin} from "../../interface";
 import {registerBlockStreamEndpoint} from "./blockStream";
 import {registerGetValidatorEndpoint} from "./validator";
+import {registerHeadEndpoint} from "./head";
 import {FastifyInstance} from "fastify";
 import {
   getBlock,
@@ -13,7 +14,6 @@ import {
   getBlockHeaders,
   getBlockRoot
 } from "../../controllers/beacon/blocks";
-import {registerHeadEndpoint} from "./head";
 
 //old
 export const beacon: LodestarApiPlugin = (fastify, opts, done: Function): void => {

--- a/packages/lodestar/src/api/rest/routes/beacon/index.ts
+++ b/packages/lodestar/src/api/rest/routes/beacon/index.ts
@@ -6,6 +6,7 @@ import {LodestarApiPlugin} from "../../interface";
 import {registerBlockStreamEndpoint} from "./blockStream";
 import {registerGetValidatorEndpoint} from "./validator";
 import {registerHeadEndpoint} from "./head";
+import {registerPeersEndpoint} from "./peers";
 import {FastifyInstance} from "fastify";
 import {
   getBlock,
@@ -24,6 +25,7 @@ export const beacon: LodestarApiPlugin = (fastify, opts, done: Function): void =
   registerGetValidatorEndpoint(fastify, opts);
   registerBlockStreamEndpoint(fastify, opts);
   registerHeadEndpoint(fastify, opts);
+  registerPeersEndpoint(fastify, opts);
   done();
 };
 

--- a/packages/lodestar/src/api/rest/routes/beacon/index.ts
+++ b/packages/lodestar/src/api/rest/routes/beacon/index.ts
@@ -13,6 +13,7 @@ import {
   getBlockHeaders,
   getBlockRoot
 } from "../../controllers/beacon/blocks";
+import {registerHeadEndpoint} from "./head";
 
 //old
 export const beacon: LodestarApiPlugin = (fastify, opts, done: Function): void => {
@@ -22,6 +23,7 @@ export const beacon: LodestarApiPlugin = (fastify, opts, done: Function): void =
   registerSyncingEndpoint(fastify, opts);
   registerGetValidatorEndpoint(fastify, opts);
   registerBlockStreamEndpoint(fastify, opts);
+  registerHeadEndpoint(fastify, opts);
   done();
 };
 

--- a/packages/lodestar/src/api/rest/routes/beacon/peers.ts
+++ b/packages/lodestar/src/api/rest/routes/beacon/peers.ts
@@ -1,0 +1,15 @@
+import * as fastify from "fastify";
+import {LodestarRestApiEndpoint} from "../../interface";
+
+export const registerPeersEndpoint: LodestarRestApiEndpoint = (server, {api}): void => {
+  server.get<fastify.DefaultQuery, {}, unknown>(
+    "/peers",
+    {},
+    async (request, reply) => {
+      const responseValue = await api.beacon.getPeers();
+      reply
+        .code(200)
+        .type("application/json")
+        .send(responseValue.map((id) => id.toString()));
+    });
+};

--- a/packages/lodestar/src/api/rest/routes/beacon/peers.ts
+++ b/packages/lodestar/src/api/rest/routes/beacon/peers.ts
@@ -10,6 +10,6 @@ export const registerPeersEndpoint: LodestarRestApiEndpoint = (server, {api}): v
       reply
         .code(200)
         .type("application/json")
-        .send(responseValue.map((id) => id.toString()));
+        .send(responseValue.map((id) => id.toB58String()));
     });
 };

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -10,13 +10,19 @@ import {
   Checkpoint,
   ENRForkID,
   ForkDigest,
+  HeadResponse,
   SignedBeaconBlock,
   Slot,
   Uint16,
   Uint64,
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {computeEpochAtSlot, computeForkDigest, EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
+import {
+  computeEpochAtSlot,
+  computeForkDigest,
+  computeStartSlotAtEpoch,
+  EpochContext
+} from "@chainsafe/lodestar-beacon-state-transition";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {intToBytes} from "@chainsafe/lodestar-utils";
 
@@ -132,6 +138,18 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
 
   public async getFinalizedCheckpoint(): Promise<Checkpoint> {
     return this.forkChoice.getFinalized();
+  }
+
+  public async getHead(): Promise<HeadResponse> {
+    const head = this.forkChoice.head();
+    return {
+      headSlot: head.slot,
+      headBlockRoot: head.blockRoot,
+      finalizedSlot: computeStartSlotAtEpoch(this.config, head.finalizedCheckpoint.epoch),
+      finalizedBlockRoot: head.finalizedCheckpoint.root,
+      justifiedSlot: computeStartSlotAtEpoch(this.config, head.justifiedCheckpoint.epoch),
+      justifiedBlockRoot: head.justifiedCheckpoint.root,
+    };
   }
 
   public async start(): Promise<void> {

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -6,7 +6,7 @@ import {
   BeaconState,
   Checkpoint,
   ENRForkID,
-  ForkDigest,
+  ForkDigest, HeadResponse,
   Root,
   SignedBeaconBlock,
   Slot,
@@ -65,6 +65,8 @@ export interface IBeaconChain extends ChainEventEmitter {
   getHeadBlock(): Promise<SignedBeaconBlock|null>;
 
   getFinalizedCheckpoint(): Promise<Checkpoint>;
+
+  getHead(): Promise<HeadResponse>;
 
   getBlockAtSlot(slot: Slot): Promise<SignedBeaconBlock|null>;
 

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -14,11 +14,12 @@ import {
 import {IBeaconChain, ILMDGHOST} from "../../../../src/chain";
 import {IBeaconClock} from "../../../../src/chain/clock/interface";
 import {ZERO_HASH} from "../../../../src/constants";
-import {computeForkDigest, computeStartSlotAtEpoch, EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
+import {computeForkDigest, EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {generateEmptySignedBlock} from "../../block";
 import {ITreeStateContext} from "../../../../src/db/api/beacon/stateContextCache";
 import {TreeBacked} from "@chainsafe/ssz";
+import PeerId from "peer-id";
 
 export interface IMockChainParams {
   genesisTime: Number64;
@@ -106,6 +107,10 @@ export class MockBeaconChain extends EventEmitter implements IBeaconChain {
       nextForkEpoch: 100,
       nextForkVersion: Buffer.alloc(4),
     };
+  }
+
+  public async getPeers(): Promise<PeerId[]> {
+    return [];
   }
 
   receiveAttestation(): Promise<void> {

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -4,7 +4,7 @@ import {
   BeaconState,
   Checkpoint,
   ENRForkID,
-  ForkDigest,
+  ForkDigest, HeadResponse,
   Number64,
   SignedBeaconBlock,
   Slot,
@@ -13,7 +13,8 @@ import {
 } from "@chainsafe/lodestar-types";
 import {IBeaconChain, ILMDGHOST} from "../../../../src/chain";
 import {IBeaconClock} from "../../../../src/chain/clock/interface";
-import {computeForkDigest, EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
+import {ZERO_HASH} from "../../../../src/constants";
+import {computeForkDigest, computeStartSlotAtEpoch, EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {generateEmptySignedBlock} from "../../block";
 import {ITreeStateContext} from "../../../../src/db/api/beacon/stateContextCache";
@@ -78,6 +79,17 @@ export class MockBeaconChain extends EventEmitter implements IBeaconChain {
 
   public async getFinalizedCheckpoint(): Promise<Checkpoint> {
     return this.state.finalizedCheckpoint;
+  }
+
+  public async getHead(): Promise<HeadResponse> {
+    return {
+      headSlot: 0,
+      headBlockRoot: ZERO_HASH,
+      finalizedSlot: 0,
+      finalizedBlockRoot: ZERO_HASH,
+      justifiedSlot: 0,
+      justifiedBlockRoot: ZERO_HASH,
+    };
   }
 
   public get currentForkDigest(): ForkDigest {

--- a/packages/lodestar/test/utils/stub/beaconApi.ts
+++ b/packages/lodestar/test/utils/stub/beaconApi.ts
@@ -11,6 +11,7 @@ export class StubbedBeaconApi implements SinonStubbedInstance<IBeaconApi> {
   getGenesisTime: Sinon.SinonStubbedMember<IBeaconApi["getGenesisTime"]>;
   getSyncingStatus: Sinon.SinonStubbedMember<IBeaconApi["getSyncingStatus"]>;
   getValidator: Sinon.SinonStubbedMember<IBeaconApi["getValidator"]>;
+  getHead: Sinon.SinonStubbedMember<IBeaconApi["getHead"]>;
   namespace: ApiNamespace.BEACON;
 
   constructor(sandbox: SinonSandbox = Sinon) {
@@ -21,6 +22,7 @@ export class StubbedBeaconApi implements SinonStubbedInstance<IBeaconApi> {
     this.getGenesisTime = sandbox.stub();
     this.getSyncingStatus = sandbox.stub();
     this.getValidator = sandbox.stub();
+    this.getHead = sandbox.stub();
   }
 
 }

--- a/packages/lodestar/test/utils/stub/beaconApi.ts
+++ b/packages/lodestar/test/utils/stub/beaconApi.ts
@@ -12,6 +12,8 @@ export class StubbedBeaconApi implements SinonStubbedInstance<IBeaconApi> {
   getSyncingStatus: Sinon.SinonStubbedMember<IBeaconApi["getSyncingStatus"]>;
   getValidator: Sinon.SinonStubbedMember<IBeaconApi["getValidator"]>;
   getHead: Sinon.SinonStubbedMember<IBeaconApi["getHead"]>;
+  getPeers: Sinon.SinonStubbedMember<IBeaconApi["getPeers"]>;
+
   namespace: ApiNamespace.BEACON;
 
   constructor(sandbox: SinonSandbox = Sinon) {


### PR DESCRIPTION
Working on Eth2stats support, and for this I need a few APIs.
- genesis time is already there
- version is there, but had an "undefined" in it. Defaulting the extra info to "dev" now
- head (or sometimes called chainhead) endpoint. Not standard yet, but this matches Lighthouse and Teku closely, so it's easy to adapt in eth2stats, and we'll very likely see something like this in the final API standard anyway.
- Looking at implementing a peers endpoint now. Think I'll add it to `/node` for now, and you can wait for the api standard to extend and move it to `/network`

