### PR TITLE
bugfix: justification based on unslashed target-attesting balance

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/processJustificationAndFinalization.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/processJustificationAndFinalization.ts
@@ -29,14 +29,14 @@ export function processJustificationAndFinalization(
   }
   bits[0] = false;
 
-  if (process.prevEpochTargetStake * BigInt(3) >= process.totalActiveStake * BigInt(2)) {
+  if (process.prevEpochUnslashedStake.targetStake * BigInt(3) >= process.totalActiveStake * BigInt(2)) {
     state.currentJustifiedCheckpoint = {
       epoch: previousEpoch,
       root: getBlockRoot(config, state, previousEpoch),
     };
     bits[1] = true;
   }
-  if (process.currEpochTargetStake * BigInt(3) >= process.totalActiveStake * BigInt(2)) {
+  if (process.currEpochUnslashedTargetStake * BigInt(3) >= process.totalActiveStake * BigInt(2)) {
     state.currentJustifiedCheckpoint = {
       epoch: currentEpoch,
       root: getBlockRoot(config, state, currentEpoch),


### PR DESCRIPTION
The spec justification rules read as:
```python
    matching_target_attestations = get_matching_target_attestations(state, previous_epoch)  # Previous epoch
    if get_attesting_balance(state, matching_target_attestations) * 3 >= get_total_active_balance(state) * 2:
```
`get_attesting_balance` does something special: it filters out slashed validators, and floors it to a minimum of 1 effective balance increment.
```python
def get_total_balance(state: BeaconState, indices: Set[ValidatorIndex]) -> Gwei:
    """
    Return the combined effective balance of the ``indices``.
    ``EFFECTIVE_BALANCE_INCREMENT`` Gwei minimum to avoid divisions by zero.
    Math safe up to ~10B ETH, afterwhich this overflows uint64.
    """
    return Gwei(max(EFFECTIVE_BALANCE_INCREMENT, sum([state.validators[index].effective_balance for index in indices])))

def get_attesting_balance(state: BeaconState, attestations: Sequence[PendingAttestation]) -> Gwei:
    """
    Return the combined effective balance of the set of unslashed validators participating in ``attestations``.
    Note: ``get_total_balance`` returns ``EFFECTIVE_BALANCE_INCREMENT`` Gwei minimum to avoid divisions by zero.
    """
    return get_total_balance(state, get_unslashed_attesting_indices(state, attestations))
```

This was missed in the optimized `eth2fastspec` variant (fixed it in v0.0.5), and got into Lodestar.

In Altona testnet this caused the code to make an incorrect justification in the transition of skip slots from 71933 to 71938.

I will review the edge case further, and try to introduce testing in the spec-tests for this. For now, this fix can be used to sync continue to sync Altona, Lodestar almost made the head already :+1: 


 with minimum of 1 increment