### PR TITLE
Fix req/resp TTFB timeout

### DIFF
--- a/packages/lodestar/src/network/util.ts
+++ b/packages/lodestar/src/network/util.ts
@@ -61,23 +61,27 @@ export function isRequestSingleChunk(method: Method): boolean {
   return Methods[method].responseType === MethodResponseType.SingleResponse;
 }
 
-export function eth2ResponseTimer<T>(): (source: AsyncIterable<T>) => AsyncGenerator<T> {
-  return (source) => {
-    return (async function*() {
-      const controller = new AbortController();
-      let responseTimer = setTimeout(() => controller.abort(), TTFB_TIMEOUT);
-      const renewTimer = (): void => {
-        clearTimeout(responseTimer);
-        responseTimer = setTimeout(() => controller.abort(), RESP_TIMEOUT);
-      };
-      const cancelTimer = (): void => {
-        clearTimeout(responseTimer);
-      };
-      for await(const item of abortSource(source, controller.signal, {abortMessage: "response timeout"})) {
-        renewTimer();
-        yield item;
-      }
-      cancelTimer();
-    })();
+export function initResponseTimer<T>(): (() => ((source: AsyncIterable<T>) => AsyncGenerator<T>)) {
+  const controller = new AbortController();
+  let responseTimer = setTimeout(() => controller.abort(), TTFB_TIMEOUT);
+  const renewTimer = (): void => {
+    clearTimeout(responseTimer);
+    responseTimer = setTimeout(() => controller.abort(), RESP_TIMEOUT);
   };
+  const cancelTimer = (): void => {
+    clearTimeout(responseTimer);
+  };
+  const checkTimeout = (): ((source: AsyncIterable<T>) => AsyncGenerator<T>) => {
+    return (source) => {
+      return (async function*() {
+        const abortOpt = {abortMessage: "response timeout"};
+        for await(const item of abortSource(source, controller.signal, abortOpt)) {
+          renewTimer();
+          yield item;
+        }
+        cancelTimer();
+      })();
+    };
+  };
+  return checkTimeout;
 }


### PR DESCRIPTION
resolves #1128 

+ One timeouted response logged after 1h. We should handle TTFB_TIMEOUT in `sendRequestStream` instead of `sendRequest`
+ In `getBlockRange`, we keep sending to a disconnected peer, it's also the peer id of a timeout response earlier so I handled bad peer inside that