### PR TITLE
Remove the correct event handler in tasks stop

### DIFF
--- a/packages/lodestar/src/tasks/index.ts
+++ b/packages/lodestar/src/tasks/index.ts
@@ -53,7 +53,7 @@ export class TasksService implements IService {
   }
 
   public async stop(): Promise<void> {
-    this.chain.removeListener("finalizedCheckpoint", this.handleFinalizedCheckpointChores);
+    this.chain.forkChoice.removeListener("prune", this.handleFinalizedCheckpointChores);
     await this.interopSubnetsTask.stop();
   }
 


### PR DESCRIPTION
See the `start` method, the `stop` should remove the same event handler from the same event.