### PR TITLE
Archive blocks faster

### DIFF
--- a/packages/lodestar/src/db/api/beacon/repositories/abstract.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/abstract.ts
@@ -137,7 +137,7 @@ export abstract class Repository<I extends Id, T> {
     const data = await this.db.entries(this.dbFilterOptions(opts));
     return (data || []).map((data) => ({
       key: this.decodeKey(data.key),
-      value: this.decodeValue(data.key),
+      value: this.decodeValue(data.value),
     }));
   }
   public entriesStream(opts?: IFilterOptions<I>): AsyncIterable<IKeyValue<I, T>> {

--- a/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
+++ b/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
@@ -59,20 +59,31 @@ describe("block archiver task", function () {
       },
       []
     );
-    dbStub.block.values.resolves([
-      blockA, blockB, blockC, blockD, finalizedBlock, blockE
+    dbStub.block.entries.resolves([
+      {key: config.types.BeaconBlock.hashTreeRoot(blockA.message), value: blockA},
+      {key: config.types.BeaconBlock.hashTreeRoot(blockB.message), value: blockB},
+      {key: config.types.BeaconBlock.hashTreeRoot(blockC.message), value: blockC},
+      {key: config.types.BeaconBlock.hashTreeRoot(blockD.message), value: blockD},
+      {key: config.types.BeaconBlock.hashTreeRoot(finalizedBlock.message), value: finalizedBlock},
+      {key: config.types.BeaconBlock.hashTreeRoot(blockE.message), value: blockE},
     ]);
-    const blockArchieveSpy = sinon.spy();
-    dbStub.blockArchive.batchAdd.callsFake(blockArchieveSpy);
+    const blockArchiveSpy = sinon.spy();
+    dbStub.blockArchive.batchAdd.callsFake(blockArchiveSpy);
     const blockSpy = sinon.spy();
-    dbStub.block.batchRemove.callsFake(blockSpy);
+    dbStub.block.batchDelete.callsFake(blockSpy);
 
     await archiverTask.run();
 
     expect(dbStub.blockArchive.batchAdd.calledOnce).to.be.true;
-    expect(blockArchieveSpy.args[0][0]).to.be.deep.equal([finalizedBlock, blockD, blockB, blockA]);
-    expect(dbStub.block.batchRemove.calledOnce).to.be.true;
-    expect(blockSpy.args[0][0]).to.be.deep.equal([blockA, blockB, blockC, blockD, finalizedBlock]);
+    expect(blockArchiveSpy.args[0][0]).to.be.deep.equal([finalizedBlock, blockD, blockB, blockA]);
+    expect(dbStub.block.batchDelete.calledOnce).to.be.true;
+    expect(blockSpy.args[0][0]).to.be.deep.equal([
+      config.types.BeaconBlock.hashTreeRoot(blockA.message),
+      config.types.BeaconBlock.hashTreeRoot(blockB.message),
+      config.types.BeaconBlock.hashTreeRoot(blockC.message),
+      config.types.BeaconBlock.hashTreeRoot(blockD.message),
+      config.types.BeaconBlock.hashTreeRoot(finalizedBlock.message),
+    ]);
   });
 
 });


### PR DESCRIPTION
Use the precomputed roots from `db.block` (using `db.block.entries` instead of `db.block.values`) instead of re-hashTreeRooting blocks as part of the archive task.