### PR TITLE
Gossip Extended Validator

### DIFF
--- a/packages/lodestar/src/network/gossip/constants.ts
+++ b/packages/lodestar/src/network/gossip/constants.ts
@@ -22,3 +22,9 @@ export const GossipTopicRegExp = new RegExp("^(/eth2/)([a-f0-9]{8})/(\\w+)(/[a-z
 export function getCommitteeSubnetEvent(index: CommitteeIndex): string {
   return GossipEvent.ATTESTATION_SUBNET.replace("{subnet}", String(index % ATTESTATION_SUBNET_COUNT));
 }
+
+export const enum ExtendedValidatorResult {
+  accept = "accept",
+  reject = "reject",
+  ignore = "ignore"
+}

--- a/packages/lodestar/src/network/gossip/interface.ts
+++ b/packages/lodestar/src/network/gossip/interface.ts
@@ -2,7 +2,7 @@
  * @module network/gossip
  */
 
-import {GossipEvent} from "./constants";
+import {GossipEvent, ExtendedValidatorResult} from "./constants";
 import {
   Attestation,
   AttesterSlashing,
@@ -80,18 +80,18 @@ export interface IGossip extends IService, GossipEventEmitter {
 }
 
 export interface IGossipMessageValidator {
-  isValidIncomingBlock(signedBlock: SignedBeaconBlock): Promise<boolean>;
-  isValidIncomingCommitteeAttestation(attestation: Attestation, subnet: number): Promise<boolean>;
-  isValidIncomingAggregateAndProof(signedAggregateAndProof: SignedAggregateAndProof): Promise<boolean>;
-  isValidIncomingVoluntaryExit(voluntaryExit: SignedVoluntaryExit): Promise<boolean>;
-  isValidIncomingProposerSlashing(proposerSlashing: ProposerSlashing): Promise<boolean>;
-  isValidIncomingAttesterSlashing(attesterSlashing: AttesterSlashing): Promise<boolean>;
+  isValidIncomingBlock(signedBlock: SignedBeaconBlock): Promise<ExtendedValidatorResult>;
+  isValidIncomingCommitteeAttestation(attestation: Attestation, subnet: number): Promise<ExtendedValidatorResult>;
+  isValidIncomingAggregateAndProof(signedAggregateAndProof: SignedAggregateAndProof): Promise<ExtendedValidatorResult>;
+  isValidIncomingVoluntaryExit(voluntaryExit: SignedVoluntaryExit): Promise<ExtendedValidatorResult>;
+  isValidIncomingProposerSlashing(proposerSlashing: ProposerSlashing): Promise<ExtendedValidatorResult>;
+  isValidIncomingAttesterSlashing(attesterSlashing: AttesterSlashing): Promise<ExtendedValidatorResult>;
 }
 
 export type GossipObject = SignedBeaconBlock | Attestation | SignedAggregateAndProof |
 SignedVoluntaryExit | ProposerSlashing | AttesterSlashing;
 
-export type GossipMessageValidatorFn = (message: GossipObject, subnet?: number) => Promise<boolean>;
+export type GossipMessageValidatorFn = (message: GossipObject, subnet?: number) => Promise<ExtendedValidatorResult>;
 
 export interface ILodestarGossipMessage extends Message{
   messageId: string;

--- a/packages/lodestar/src/util/validation/attestation.ts
+++ b/packages/lodestar/src/util/validation/attestation.ts
@@ -36,7 +36,7 @@ export function isUnaggregatedAttestation(
 
 export async function isAttestingToValidBlock(db: IBeaconDb, attestation: Attestation): Promise<boolean> {
   const blockRoot = attestation.data.beaconBlockRoot.valueOf() as Uint8Array;
-  return await db.block.has(blockRoot);
+  return (await db.block.has(blockRoot)) && (!await db.badBlock.has(blockRoot));
 }
 
 export async function hasValidatorAttestedForThatTargetEpoch(

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -20,6 +20,7 @@ import {Discv5Discovery, ENR} from "@chainsafe/discv5";
 import {createNode} from "../../utils/network";
 import {ReputationStore} from "../../../src/sync/IReputation";
 import {getAttestationSubnetEvent} from "../../../src/network/gossip/utils";
+import {ExtendedValidatorResult} from "../../../src/network/gossip/constants";
 
 const multiaddr = "/ip4/127.0.0.1/tcp/0";
 
@@ -145,7 +146,7 @@ describe("[network] network", function () {
     await netA.connect(netB.peerId, netB.multiaddrs);
     await connected;
     await new Promise((resolve) => netB.gossip.once("gossipsub:heartbeat", resolve));
-    validator.isValidIncomingBlock.resolves(true);
+    validator.isValidIncomingBlock.resolves(ExtendedValidatorResult.accept);
     const block = generateEmptySignedBlock();
     block.message.slot = 2020;
     for (let i = 0; i < 5; i++) {
@@ -197,7 +198,7 @@ describe("[network] network", function () {
       });
     });
     await new Promise((resolve) => netB.gossip.once("gossipsub:heartbeat", resolve));
-    validator.isValidIncomingBlock.resolves(true);
+    validator.isValidIncomingBlock.resolves(ExtendedValidatorResult.accept);
     const block = generateEmptySignedBlock();
     block.message.slot = 2020;
     netB.gossip.publishBlock(block);
@@ -217,7 +218,7 @@ describe("[network] network", function () {
       netA.gossip.subscribeToAggregateAndProof(forkDigest, resolve);
     });
     await new Promise((resolve) => netB.gossip.once("gossipsub:heartbeat", resolve));
-    validator.isValidIncomingAggregateAndProof.resolves(true);
+    validator.isValidIncomingAggregateAndProof.resolves(ExtendedValidatorResult.accept);
     await netB.gossip.publishAggregatedAttestation(generateEmptySignedAggregateAndProof());
     await received;
   });
@@ -238,7 +239,7 @@ describe("[network] network", function () {
     await new Promise((resolve) => netB.gossip.once("gossipsub:heartbeat", resolve));
     const attestation = generateEmptyAttestation();
     attestation.data.index = 0;
-    validator.isValidIncomingCommitteeAttestation.resolves(true);
+    validator.isValidIncomingCommitteeAttestation.resolves(ExtendedValidatorResult.accept);
     await netB.gossip.publishCommiteeAttestation(attestation);
     await received;
     expect(netA.gossip.listenerCount(getAttestationSubnetEvent(0))).to.be.equal(1);

--- a/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
@@ -3,7 +3,7 @@ import {generateEmptySignedBlock} from "../../../utils/block";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import {Message} from "libp2p-gossipsub/src/message";
 import {getGossipTopic} from "../../../../src/network/gossip/utils";
-import {GossipEvent} from "../../../../src/network/gossip/constants";
+import {GossipEvent, ExtendedValidatorResult} from "../../../../src/network/gossip/constants";
 import {IGossipMessageValidator} from "../../../../src/network/gossip/interface";
 import sinon from "sinon";
 import {LodestarGossipsub} from "../../../../src/network/gossip/gossipsub";
@@ -45,22 +45,22 @@ describe("gossipsub", function() {
 
 
   it("should return false because of failed validation", async () => {
-    validator.isValidIncomingBlock = (): Promise<boolean> => Promise.resolve(false);
-    const result = await gossipSub.validate(message);
+    validator.isValidIncomingBlock = (): Promise<ExtendedValidatorResult> => Promise.resolve(ExtendedValidatorResult.reject);
+    const result = await gossipSub.validate(message, undefined);
     expect(result).to.be.false;
   });
 
   it("should return true if pass validator function", async () => {
-    validator.isValidIncomingBlock = (): Promise<boolean> => Promise.resolve(true);
-    const result = await gossipSub.validate(message);
+    validator.isValidIncomingBlock = (): Promise<ExtendedValidatorResult> => Promise.resolve(ExtendedValidatorResult.accept);
+    const result = await gossipSub.validate(message, undefined);
     expect(result).to.be.true;
   });
 
   it("should return false because of duplicate", async () => {
-    validator.isValidIncomingBlock = (): Promise<boolean> => Promise.resolve(true);
-    const result = await gossipSub.validate(message);
+    validator.isValidIncomingBlock = (): Promise<ExtendedValidatorResult> => Promise.resolve(ExtendedValidatorResult.accept);
+    const result = await gossipSub.validate(message, undefined);
     expect(result).to.be.true;
     // receive again => duplicate
-    expect(await gossipSub.validate(message)).to.be.false;
+    expect(await gossipSub.validate(message, undefined)).to.be.false;
   });
 });


### PR DESCRIPTION
Part of #961 
+ Support Extended Validator in the current version of gossip. Once Gossip 1.1 is in, we just need to have a small change to remove `_processTopicValidatorResult`
+ Remove the check for parentRoot in `isValidIncomingBlock` as it's not part of the spec. If a block comes far away in the future, we have a check for it already.