### PR TITLE
Remove unnecessary try / catch on mkdir recursive

### DIFF
--- a/packages/lodestar-cli/src/util/file.ts
+++ b/packages/lodestar-cli/src/util/file.ts
@@ -6,12 +6,8 @@ import {Json} from "@chainsafe/ssz";
 /**
  * Maybe create a directory
  */
-export async function mkdir(filename: string): Promise<void> {
-  try {
-    await fs.promises.readdir(filename);
-  } catch (e) {
-    await fs.promises.mkdir(filename, {recursive: true});
-  }
+export async function mkdir(dirname: string): Promise<void> {
+  await fs.promises.mkdir(dirname, {recursive: true});
 }
 
 export enum FileFormat {


### PR DESCRIPTION
You can call fs.mkdir with recursive = true on the same directory multiple times. Is there any specific version why the try / catch was added in the first place?