### PR TITLE
Fix cli bin path

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "postinstall": "lerna run clean && lerna run build",
     "build": "lerna run build",
-    "cli": "node --trace-deprecation ./packages/lodestar-cli/bin/lodestar"
+    "cli": "node --trace-deprecation ./packages/lodestar-cli/lib"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.3",

--- a/packages/lodestar-cli/README.md
+++ b/packages/lodestar-cli/README.md
@@ -16,5 +16,5 @@ Command line tool for Lodestar
 
 We have an experimental new CLI called `lodestar` which currently provides a subset of the `lodestar` CLI functionality.
 
-`./bin/lodestar beacon init` - this will write a configuration and network identity to disk, by default `./.lodestar`
-`./bin/lodestar beacon run` - this will run a beacon node using a configuration from disk, by default `./.lodestar`
+`yarn cli beacon init` - this will write a configuration and network identity to disk, by default `./.lodestar`
+`yarn cli beacon run` - this will run a beacon node using a configuration from disk, by default `./.lodestar`

--- a/packages/lodestar-cli/bin/lodestar
+++ b/packages/lodestar-cli/bin/lodestar
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-require('../lib');

--- a/packages/lodestar-cli/package.json
+++ b/packages/lodestar-cli/package.json
@@ -60,7 +60,7 @@
     "yargs": "^15.3.1"
   },
   "bin": {
-    "lodestar": "./bin/lodestar"
+    "lodestar": "./lib/index.js"
   },
   "devDependencies": {
     "@types/chai": "4.2.0",

--- a/packages/lodestar-cli/src/index.ts
+++ b/packages/lodestar-cli/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import * as yargs from "yargs";
 
 import * as beaconCmd from "./cmds/beacon";

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -13,9 +13,6 @@
   },
   "version": "0.9.0",
   "main": "lib/index.js",
-  "bin": {
-    "lodestar": "./bin/lodestar"
-  },
   "files": [
     "lib/**/*.d.ts",
     "lib/**/*.js",

--- a/packages/lodestar/start-multi.sh
+++ b/packages/lodestar/start-multi.sh
@@ -41,9 +41,9 @@ START_TIME=$(date +%s)
 BASE_PORT=3060
 
 # The new-session needs to be created externally
-tmux new-session -d -s interop "./bin/lodestar interop -p minimal --db l0 -q $START_TIME,$TOTAL_VALIDATORS --multiaddrs /ip4/127.0.0.1/tcp/${BASE_PORT}0 -v ${VALIDATOR_ARRAY[0]} -r";
+tmux new-session -d -s interop "yarn cli interop -p minimal --db l0 -q $START_TIME,$TOTAL_VALIDATORS --multiaddrs /ip4/127.0.0.1/tcp/${BASE_PORT}0 -v ${VALIDATOR_ARRAY[0]} -r";
 for (( i=1; i<$nodes; i++ )) do
-    tmux split-window -v -t interop "./bin/lodestar interop -p minimal --db l$i -q $START_TIME,$TOTAL_VALIDATORS --multiaddrs /ip4/127.0.0.1/tcp/$BASE_PORT$i -v ${VALIDATOR_ARRAY[$i-1]},${VALIDATOR_ARRAY[$i]} -r"
+    tmux split-window -v -t interop "yarn cli interop -p minimal --db l$i -q $START_TIME,$TOTAL_VALIDATORS --multiaddrs /ip4/127.0.0.1/tcp/$BASE_PORT$i -v ${VALIDATOR_ARRAY[$i-1]},${VALIDATOR_ARRAY[$i]} -r"
 done
 
 # Change the layout

--- a/scripts/whiteblock_start.sh
+++ b/scripts/whiteblock_start.sh
@@ -79,7 +79,7 @@ done
 REAL_VALIDATOR_KEYS=/tmp/keys.yaml
 sed 's/0x/\"0x/g' $VALIDATOR_KEYS | sed 's/$/"/g' > $REAL_VALIDATOR_KEYS
 
-/lodestar/packages/lodestar/bin/lodestar \
+yarn cli \
  	interop \
 	-p minimal \
 	--db l1 \


### PR DESCRIPTION
Fixes https://github.com/ChainSafe/lodestar/issues/1145. (Potentially, haven't tested against this actual package)

Was there a specific reason to target package.json#bin to a different file than index.js?

**Edit**: Locally scripts and the root package.json point to that bin. I believe we can find a better setup, since require() statements will go unnoticed by our CI if anything changes