### PR TITLE
Update Dockerfile to cache efficiently with a monorepo structure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,18 +1,28 @@
-supporting-docs
 .github
-assets
 .idea
-.tmp
 .git
 Dockerfile
 *.log
 **/*.log
-node_modules
 **/.nyc_output
 **/coverage
-**/node_modules
 **/test
+
+# Dependencies
+node_modules
+**/node_modules
+
+# Build artifacts
 **/lib
-**/.tmp
 **/dist
+
+# Docs
+supporting-docs
+docs
+audits
+assets
+
+# Data
 **/*-db
+.tmp
+**/.tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,26 @@ RUN apk update && apk add --no-cache git g++ make python && rm -rf /var/cache/ap
 WORKDIR /usr/app
 
 # Install node dependencies - done in a separate step so Docker can cache it.
+COPY package.json yarn.lock lerna.json ./
+# Use --ignore-scripts to trigger the build latter
+RUN yarn --frozen-lockfile --non-interactive --ignore-scripts
+
+COPY packages/benchmark-utils/package.json packages/benchmark-utils/
+COPY packages/lodestar/package.json packages/lodestar/
+COPY packages/lodestar-beacon-state-transition/package.json packages/lodestar-beacon-state-transition/
+COPY packages/lodestar-cli/package.json packages/lodestar-cli/
+COPY packages/lodestar-config/package.json packages/lodestar-config/
+COPY packages/lodestar-params/package.json packages/lodestar-params/
+COPY packages/lodestar-spec-test-util/package.json packages/lodestar-spec-test-util/
+COPY packages/lodestar-types/package.json packages/lodestar-types/
+COPY packages/lodestar-utils/package.json packages/lodestar-utils/
+COPY packages/lodestar-validator/package.json packages/lodestar-validator/
+COPY packages/spec-test-runner/package.json packages/spec-test-runner/
+
+RUN ./node_modules/.bin/lerna bootstrap -- --frozen-lockfile --non-interactive --ignore-scripts
+
 COPY . .
 
-RUN yarn install --force --network-timeout 1000000 --non-interactive --ignore-optional --frozen-lockfile && yarn cache clean
+RUN yarn build
 
-WORKDIR /usr/app/packages/lodestar-cli/bin
-
-ENTRYPOINT ["node", "lodestar"]
+ENTRYPOINT ["node", "./packages/lodestar-cli/bin/lodestar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,9 @@
-version: '2'
+version: "3.4"
 services:
+    lodestar:
+        build: .
+        volumes:
+            - ./:/root/lodestar
     prometheus:
         image: prom/prometheus:v2.9.2
         depends_on:
@@ -8,12 +12,3 @@ services:
             - ./prometheus.yml:/etc/prometheus/prometheus.yml
         ports:
             - '9090:9090'
-    lodestar:
-        build:
-            context: .
-            dockerfile: docker/Dockerfile
-        volumes:
-            - ./:/root/lodestar
-            - node_modules:/root/lodestar/node_modules
-volumes:
-  node_modules:

--- a/scripts/writeDockerfile.js
+++ b/scripts/writeDockerfile.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const path = require("path");
+
+// Use this script to write the pre-build step in the Dockerfile
+
+const packagesDir = "packages";
+
+console.log(fs.readdirSync(packagesDir)
+  .map(pkg =>
+    `COPY ${path.join(packagesDir, pkg, "package.json")} ${path.join(packagesDir, pkg)}/`
+  ).join("\n")
+);


### PR DESCRIPTION
Opening this as draft since the build fails in the docker context but not outside of it. For some reason the package linking does not work properly and errors with (see below). Have you encountered this issue before?

```
@chainsafe/lodestar-config: $ tsc --incremental --declaration --outDir lib --emitDeclarationOnly
@chainsafe/lodestar-config: src/index.ts:2:37 - error TS7016: Could not find a declaration file for module '@chainsafe/lodestar-types'. '/usr/app/packages/lodestar-types/lib/index.js' implicitly has an 'any' type.
@chainsafe/lodestar-config:   Try `npm install @types/chainsafe__lodestar-types` if it exists or add a new declaration (.d.ts) file containing `declare module '@chainsafe/lodestar-types';`
@chainsafe/lodestar-config: 2 import {createIBeaconSSZTypes} from "@chainsafe/lodestar-types";
@chainsafe/lodestar-config:                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@chainsafe/lodestar-config: src/interface.ts:2:31 - error TS7016: Could not find a declaration file for module '@chainsafe/lodestar-types'. '/usr/app/packages/lodestar-types/lib/index.js' implicitly has an 'any' type.
@chainsafe/lodestar-config:   Try `npm install @types/chainsafe__lodestar-types` if it exists or add a new declaration (.d.ts) file containing `declare module '@chainsafe/lodestar-types';`
@chainsafe/lodestar-config: 2 import {IBeaconSSZTypes} from "@chainsafe/lodestar-types";
@chainsafe/lodestar-config:                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@chainsafe/lodestar-config: src/presets/mainnet.ts:2:21 - error TS7016: Could not find a declaration file for module '@chainsafe/lodestar-types/lib/ssz/presets/mainnet'. '/usr/app/packages/lodestar-types/lib/ssz/presets/mainnet.js' implicitly has an 'any' type.
@chainsafe/lodestar-config:   Try `npm install @types/chainsafe__lodestar-types` if it exists or add a new declaration (.d.ts) file containing `declare module '@chainsafe/lodestar-types/lib/ssz/presets/mainnet';`
@chainsafe/lodestar-config: 2 import {types} from "@chainsafe/lodestar-types/lib/ssz/presets/mainnet";
@chainsafe/lodestar-config:                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@chainsafe/lodestar-config: src/presets/minimal.ts:2:21 - error TS7016: Could not find a declaration file for module '@chainsafe/lodestar-types/lib/ssz/presets/minimal'. '/usr/app/packages/lodestar-types/lib/ssz/presets/minimal.js' implicitly has an 'any' type.
@chainsafe/lodestar-config:   Try `npm install @types/chainsafe__lodestar-types` if it exists or add a new declaration (.d.ts) file containing `declare module '@chainsafe/lodestar-types/lib/ssz/presets/minimal';`
@chainsafe/lodestar-config: 2 import {types} from "@chainsafe/lodestar-types/lib/ssz/presets/minimal";
@chainsafe/lodestar-config:                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@chainsafe/lodestar-config: Found 4 errors.
@chainsafe/lodestar-config: error Command failed with exit code 2.
@chainsafe/lodestar-config: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
@chainsafe/lodestar-config: error Command failed with exit code 2.
@chainsafe/lodestar-config: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
lerna ERR! yarn run build exited 2 in '@chainsafe/lodestar-config'
error Command failed with exit code 2.

```