### PR TITLE
Fix undefined option in lodestar dev --help

### DIFF
--- a/packages/lodestar-cli/src/cmds/beacon/cmds/run/options/chain.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/cmds/run/options/chain.ts
@@ -9,6 +9,7 @@ export const chainPreset: Options = {
   type: "string",
   choices: ["mainnet", "minimal"],
   default: "mainnet",
+  group: "chain"
 };
 
 export const chainGenesisStateFile: Options = {
@@ -18,4 +19,5 @@ export const chainGenesisStateFile: Options = {
   description: "Genesis state in ssz-encoded format",
   type: "string",
   normalize: true,
+  group: "chain"
 };

--- a/packages/lodestar-cli/src/cmds/dev/options/chain.ts
+++ b/packages/lodestar-cli/src/cmds/dev/options/chain.ts
@@ -1,6 +1,15 @@
 import {Options} from "yargs";
 
-export {chainGenesisStateFile} from "../../beacon/cmds/run/options/chain";
+// if we import from somewhere it'll print out "undefined" help
+export const chainGenesisStateFile: Options = {
+  alias: [
+    "chain.genesisStateFile",
+  ],
+  description: "Genesis state in ssz-encoded format",
+  type: "string",
+  normalize: true,
+  group: "chain"
+};
 
 export const chainPreset: Options = {
   alias: [
@@ -11,6 +20,7 @@ export const chainPreset: Options = {
   type: "string",
   choices: ["mainnet", "minimal"],
   default: "minimal",
+  group: "chain"
 };
 
 export interface IChainArgs {


### PR DESCRIPTION
resolves #1148 

`./bin/lodestar dev --help` now prints:
```
chain
  --chain.genesisStateFile      Genesis state in ssz-encoded format                                                       [string]
  --chain.preset, --chain.name  Specifies the default eth2 spec type [string] [choices: "mainnet", "minimal"] [default: "minimal"]

```