### PR TITLE
Fix cli published files

### DIFF
--- a/packages/lodestar-cli/package.json
+++ b/packages/lodestar-cli/package.json
@@ -9,7 +9,10 @@
   },
   "homepage": "https://github.com/ChainSafe/lodestar#readme",
   "main": "lib/index.js",
-  "files": [],
+  "files": [
+    "lib",
+    "bin"
+  ],
   "scripts": {
     "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn run build:lib && yarn run build:types",

--- a/packages/lodestar-cli/package.json
+++ b/packages/lodestar-cli/package.json
@@ -10,9 +10,13 @@
   "homepage": "https://github.com/ChainSafe/lodestar#readme",
   "main": "lib/index.js",
   "files": [
-    "lib",
-    "bin"
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "lib/**/*.js.map"
   ],
+  "bin": {
+    "lodestar": "lib/index.js"
+  },
   "scripts": {
     "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
     "build": "yarn run build:lib && yarn run build:types",
@@ -68,9 +72,6 @@
     "rimraf": "^3.0.0",
     "uuidv4": "^6.1.1",
     "yargs": "^15.3.1"
-  },
-  "bin": {
-    "lodestar": "./bin/lodestar"
   },
   "devDependencies": {
     "@types/chai": "4.2.0",


### PR DESCRIPTION
from @dapplion 

The lodestar-cli package published in NPM seems to be empty
```bash
lion@lion-gram:~/Code/eth2.0/test/test-cli-npm$ tree node_modules/@chainsafe/lodestar-cli/
node_modules/@chainsafe/lodestar-cli/
├── bin
│   └── lodestar
├── lib
│   └── index.js
├── LICENSE
├── node_modules
├── package.json
└── README.md

3 directories, 5 files
```

Fixes #1145
This is the resulting directory after installing the latest version from NPM

---

This should fix this issue. to test, clone down, `lerna bootstrap`, `cd lodestar-cli`, `npm publish --dry-run`