### PR TITLE
update .gitignore to ignore altona testnet artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ docs/assets
 .witti
 genesis.ssz
 witti.json
+altona.json
+.altona
 
 # Wallet CLI artifacts
 .pass


### PR DESCRIPTION
update .gitignore to ignore altona testnet artifacts (the .altona folder and altona.json, since these are commonly used names)