### PR TITLE
[DNM] Demo clearTimer is not called for single_response message

### DIFF
--- a/packages/lodestar/src/network/reqResp.ts
+++ b/packages/lodestar/src/network/reqResp.ts
@@ -282,7 +282,7 @@ export class ReqResp extends (EventEmitter as IReqEventEmitterClass) implements 
         (body !== null && body !== undefined) ? [body] : [null],
         eth2RequestEncode(config, logger, method, encoding),
         stream,
-        eth2ResponseTimer(),
+        eth2ResponseTimer(logger),
         eth2ResponseDecode(config, logger, method, encoding, requestId)
       );
     })();

--- a/packages/lodestar/src/network/util.ts
+++ b/packages/lodestar/src/network/util.ts
@@ -9,6 +9,7 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Method, MethodResponseType, Methods, RequestId, RESP_TIMEOUT, TTFB_TIMEOUT} from "../constants";
 import {source as abortSource} from "abortable-iterator";
 import AbortController from "abort-controller";
+import {ILogger} from "@chainsafe/lodestar-utils";
 
 // req/resp
 
@@ -61,7 +62,7 @@ export function isRequestSingleChunk(method: Method): boolean {
   return Methods[method].responseType === MethodResponseType.SingleResponse;
 }
 
-export function eth2ResponseTimer<T>(): (source: AsyncIterable<T>) => AsyncGenerator<T> {
+export function eth2ResponseTimer<T>(logger: ILogger): (source: AsyncIterable<T>) => AsyncGenerator<T> {
   const controller = new AbortController();
   let responseTimer = setTimeout(() => controller.abort(), TTFB_TIMEOUT);
   const renewTimer = (): void => {
@@ -69,6 +70,7 @@ export function eth2ResponseTimer<T>(): (source: AsyncIterable<T>) => AsyncGener
     responseTimer = setTimeout(() => controller.abort(), RESP_TIMEOUT);
   };
   const cancelTimer = (): void => {
+    logger.info("cancelTimer called");
     clearTimeout(responseTimer);
   };
   return (source) => {

--- a/packages/lodestar/test/unit/network/reqResp.test.ts
+++ b/packages/lodestar/test/unit/network/reqResp.test.ts
@@ -101,20 +101,17 @@ describe("[network] rpc", () => {
         rpcA.sendResponse(id, null, body as Status);
       }, 100);
     });
-    try {
-      const statusExpected: Status = {
-        forkDigest: Buffer.alloc(4),
-        finalizedRoot: Buffer.alloc(32),
-        finalizedEpoch: 0,
-        headRoot: Buffer.alloc(32),
-        headSlot: 0,
-      };
+    const statusExpected: Status = {
+      forkDigest: Buffer.alloc(4),
+      finalizedRoot: Buffer.alloc(32),
+      finalizedEpoch: 0,
+      headRoot: Buffer.alloc(32),
+      headSlot: 0,
+    };
 
-      const statusActual = await rpcB.status(nodeA.peerId, statusExpected);
-      assert.deepEqual(statusActual, statusExpected);
-    } catch (e) {
-      assert.fail("status not received");
-    }
+    const statusActual = await rpcB.status(nodeA.peerId, statusExpected);
+    assert.deepEqual(statusActual, statusExpected);
+    assert(loggerStub.info.calledWith("cancelTimer called"), "cancelTimer not called!!");
   });
 
   it("can handle multiple block requests from connected peers at the same time", async function () {
@@ -155,6 +152,7 @@ describe("[network] rpc", () => {
         }
         reqIndex ++;
       }
+      assert(loggerStub.info.calledWith("cancelTimer called"), "cancelTimer not called!!");
 
     } catch (e) {
       assert.fail(`Cannot receive response, error: ${e.message}`);


### PR DESCRIPTION
This is just to demo the `cancelTimer` issue with single response requests.
Whenever we break inside for loop of `eth2ResponseDecode`, pipe decides to finish everything and `cancelTimer` is not called after `for await`