### PR TITLE
Validate passphraseFile before wallet create

### DIFF
--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/create.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/create.ts
@@ -1,10 +1,9 @@
-import fs from "fs";
 import {CommandBuilder} from "yargs";
 import {initBLS} from "@chainsafe/bls";
 import {getAccountPaths} from "../../paths";
 import {WalletManager} from "../../../../wallet";
 import {ValidatorDirBuilder} from "../../../../validatorDir";
-import {stripOffNewlines, getBeaconConfig, YargsError} from "../../../../util";
+import {getBeaconConfig, YargsError, readPassphraseFile} from "../../../../util";
 import {IAccountValidatorOptions} from "./options";
 
 export const command = "create";
@@ -83,7 +82,7 @@ export async function handler(options: IValidatorCreateOptions): Promise<void> {
   const n = count || atMost - wallet.nextaccount;
   if (n <= 0) throw new YargsError("No validators to create");
 
-  const walletPassword = stripOffNewlines(fs.readFileSync(passphraseFile, "utf8"));
+  const walletPassword = readPassphraseFile(passphraseFile);
 
   for (let i = 0; i < n; i++) {
     const passwords = wallet.randomPasswords();

--- a/packages/lodestar-cli/src/cmds/account/cmds/wallet/create.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/wallet/create.ts
@@ -66,14 +66,6 @@ export async function handler(options: IWalletCreateOptions): Promise<void> {
     writeFile600Perm(passphraseFile, randomPassword());
   }
   const password = readPassphraseFile(passphraseFile);
-  // Validate the passphraseFile contents to prevent the user to create a wallet with a password
-  // that is the contents a random unintended file
-  try {
-    if (password.includes("\n")) throw Error("contains multiple lines");
-    if (password.length > 512) throw Error("is really long");
-  } catch (e) {
-    throw new YargsError(`passphraseFile ${passphraseFile} ${e.message}. Is this a well-formated passphraseFile?`);
-  }
 
   const walletManager = new WalletManager(accountPaths);
   const wallet = walletManager.createWallet(name, type, mnemonic, password);

--- a/packages/lodestar-cli/src/cmds/account/cmds/wallet/create.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/wallet/create.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import {CommandBuilder} from "yargs";
 import * as bip39 from "bip39";
-import {randomPassword, writeFile600Perm,YargsError} from "../../../../util";
+import {randomPassword, writeFile600Perm,YargsError, readPassphraseFile} from "../../../../util";
 import {WalletManager} from "../../../../wallet";
 import {getAccountPaths} from "../../paths";
 import {IAccountWalletOptions} from "./options";
@@ -59,14 +59,21 @@ export async function handler(options: IWalletCreateOptions): Promise<void> {
   // Create a new random mnemonic.
   const mnemonic = bip39.generateMnemonic();
 
-  // Create a random password if the file does not exist.
+  if (path.parse(passphraseFile).ext !== ".pass") {
+    throw new YargsError("passphraseFile must end with .pass, make sure to not provide the actual password");
+  }
   if (!fs.existsSync(passphraseFile)) {
-    if (path.parse(passphraseFile).ext !== ".pass") {
-      throw new YargsError("passphraseFile must end with .pass, make sure to not provide the actual password");
-    }
     writeFile600Perm(passphraseFile, randomPassword());
   }
-  const password = fs.readFileSync(passphraseFile, "utf8");
+  const password = readPassphraseFile(passphraseFile);
+  // Validate the passphraseFile contents to prevent the user to create a wallet with a password
+  // that is the contents a random unintended file
+  try {
+    if (password.includes("\n")) throw Error("contains multiple lines");
+    if (password.length > 512) throw Error("is really long");
+  } catch (e) {
+    throw new YargsError(`passphraseFile ${passphraseFile} ${e.message}. Is this a well-formated passphraseFile?`);
+  }
 
   const walletManager = new WalletManager(accountPaths);
   const wallet = walletManager.createWallet(name, type, mnemonic, password);

--- a/packages/lodestar-cli/src/util/fs.ts
+++ b/packages/lodestar-cli/src/util/fs.ts
@@ -24,5 +24,17 @@ export function ensureDirExists(dirPath: string): void {
  */
 export function readPassphraseFile(passphraseFile: string): string {
   const data = fs.readFileSync(passphraseFile, "utf8");
-  return stripOffNewlines(data);
+  const passphrase = stripOffNewlines(data);
+
+  // Validate the passphraseFile contents to prevent the user to create a wallet with a password
+  // that is the contents a random unintended file
+  try {
+    if (passphrase.includes("\n")) throw Error("contains multiple lines");
+    // 512 is an arbitrary high number that should be longer than any actual passphrase
+    if (passphrase.length > 512) throw Error("is really long");
+  } catch (e) {
+    throw new Error(`passphraseFile ${passphraseFile} ${e.message}. Is this a well-formated passphraseFile?`);
+  }
+
+  return passphrase;
 }

--- a/packages/lodestar-cli/src/util/fs.ts
+++ b/packages/lodestar-cli/src/util/fs.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import {stripOffNewlines} from "./stripOffNewlines";
 
 /**
  * Create a file with `600 (-rw-------)` permissions
@@ -15,4 +16,13 @@ export function writeFile600Perm(filepath: string, data: string): void {
  */
 export function ensureDirExists(dirPath: string): void {
   if (!fs.existsSync(dirPath)) fs.mkdirSync(dirPath, {recursive: true});
+}
+
+/**
+ * Utility to read file as UTF8 and strip any trailing new lines
+ * All passphrase files must be read with this function
+ */
+export function readPassphraseFile(passphraseFile: string): string {
+  const data = fs.readFileSync(passphraseFile, "utf8");
+  return stripOffNewlines(data);
 }


### PR DESCRIPTION
Fixes https://github.com/ChainSafe/lodestar/issues/1174.

In CLI cmd `account wallet create` validates that the passphraseFile has `.pass` extension even if it exists. It also validates that its contents:
- Do not have multilines
- Do not have length > 512 chars

This prevents the scenario brought up by https://github.com/ChainSafe/lodestar/issues/1174 where the user might typo the passphraseFile path and create a wallet with the contents of some random file.