### PR TITLE
Remove generic yargs alias that collided with global opts

### DIFF
--- a/packages/lodestar-cli/src/cmds/dev/options/dev.ts
+++ b/packages/lodestar-cli/src/cmds/dev/options/dev.ts
@@ -3,7 +3,6 @@ import {Options} from "yargs";
 export const genesisValidatorsCount: Options = {
   alias: [
     "dev.genesisValidators",
-    "c"
   ],
   description: "If present it will create genesis with interop validators and start chain.",
   type: "number",
@@ -14,7 +13,6 @@ export const genesisValidatorsCount: Options = {
 export const startValidators: Options = {
   alias: [
     "dev.startValidators",
-    "v"
   ],
   description: "Start interop validators in given range",
   default: "0:8",
@@ -26,7 +24,6 @@ export const startValidators: Options = {
 export const resetChainDir: Options = {
   alias: [
     "dev.reset",
-    "r"
   ],
   description: "To delete chain and validator directories",
   type: "boolean",


### PR DESCRIPTION
A `dev` cmd option ` "dev.startValidators"` had the alias `"v"` which collided with the recently introduced alias for `--version`, `-v`. For some reason, Yargs then mapped `dev` to the alias `v` and showed package version.

This PR removes the generic aliases of those `dev` options. If they are necessary and widely used I can remove the `-v` alias for `--version` which also solves the problem.