### PR TITLE
Change default metrics server port

### DIFF
--- a/packages/lodestar-cli/src/cmds/beacon/cmds/run/options/metrics.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/cmds/run/options/metrics.ts
@@ -41,6 +41,6 @@ export const metricsServerPort: Options = {
     "metrics.serverPort",
   ],
   type: "number",
-  default: 5000,
+  default: 8008,
   group: "metrics",
 };

--- a/packages/lodestar-cli/src/cmds/beacon/testnets/altona.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/testnets/altona.ts
@@ -49,7 +49,7 @@ export const altonaConfig = {
   },
   "metrics": {
     "enabled": true,
-    "serverPort": 5000
+    "serverPort": 8008
   },
   "network": {
     "discv5": {

--- a/packages/lodestar-cli/src/cmds/dev/options/metrics.ts
+++ b/packages/lodestar-cli/src/cmds/dev/options/metrics.ts
@@ -14,7 +14,7 @@ export const metricsServerPort: Options = {
     "metrics.serverPort",
   ],
   type: "number",
-  default: 5000,
+  default: 8008,
   group: "metrics",
 };
 

--- a/packages/lodestar/src/metrics/options.ts
+++ b/packages/lodestar/src/metrics/options.ts
@@ -14,7 +14,7 @@ const config: IMetricsOptions = {
   enabled: false,
   timeout: 5000,
   pushGateway: false,
-  serverPort: 5000,
+  serverPort: 8008,
 };
 
 export default config;

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -3,4 +3,4 @@ scrape_configs:
   scrape_interval: 5s
   metrics_path: /metrics
   static_configs:
-      - targets: ['127.0.0.1:5000']
+      - targets: ['127.0.0.1:8008']


### PR DESCRIPTION
According to https://github.com/ethereum/eth2.0-metrics/blob/master/metrics.md#prometheus-metrics-collection
> By default, the Prometheus collection endpoint SHOULD be served from 0.0.0.0:8008

Update the default port from 5000 to 8008