### PR TITLE
Replace infinite timeouts with a long timeout of 10 min

### DIFF
--- a/packages/lodestar-cli/test/unit/lodecli/init.test.ts
+++ b/packages/lodestar-cli/test/unit/lodecli/init.test.ts
@@ -6,7 +6,7 @@ import rimraf from "rimraf";
 import {beacon} from "../../../src/cmds/beacon";
 
 describe("beacon cli", function() {
-  this.timeout(0);
+  this.timeout("10 min");
 
   const tmpDir = ".tmp";
 

--- a/packages/lodestar-spec-test-util/src/single.ts
+++ b/packages/lodestar-spec-test-util/src/single.ts
@@ -74,7 +74,7 @@ export function describeDirectorySpecTest<TestCase, Result>(
   }
   describe(name, function () {
     if(options.timeout) {
-      this.timeout(options.timeout);
+      this.timeout(options.timeout || "10 min");
     }
 
     const testCases = readdirSync(testCaseDirectoryPath)

--- a/packages/lodestar/test/e2e/chain/factory/block/assembleBlock.test.ts
+++ b/packages/lodestar/test/e2e/chain/factory/block/assembleBlock.test.ts
@@ -26,7 +26,8 @@ import {ValidatorApi} from "../../../../../src/api/impl/validator";
 import {StubbedBeaconDb} from "../../../../utils/stub";
 
 describe("produce block", function () {
-  this.timeout(0);
+  this.timeout("10 min");
+
   const dbStub = new StubbedBeaconDb(sinon);
   const chainStub = sinon.createStubInstance(BeaconChain);
   chainStub.forkChoice = sinon.createStubInstance(StatefulDagLMDGHOST);

--- a/packages/lodestar/test/e2e/sync/sync.test.ts
+++ b/packages/lodestar/test/e2e/sync/sync.test.ts
@@ -8,7 +8,8 @@ import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 describe("syncing", function () {
 
   it("should sync from other BN", async function () {
-    this.timeout(0);
+    this.timeout("10 min");
+
     const bn = await getDevBeaconNode({SECONDS_PER_SLOT: 2, SLOTS_PER_EPOCH: 8}, {sync: {minPeers: 0}}, 8);
     const finalizationEventListener = waitForEvent<Checkpoint>(bn.chain, "finalizedCheckpoint", 240000);
     const validators = getDevValidators(bn, 8);


### PR DESCRIPTION
In case something goes wrong in the beacon nodes e2e, prevent exhausting the 6 hours timeout of Github Actions jobs. Mocha accepts any string parseable by https://www.npmjs.com/package/ms as timeout