### PR TITLE
Fix attestation  processing bug where we would use wrong state

### DIFF
--- a/packages/lodestar/src/chain/attestation.ts
+++ b/packages/lodestar/src/chain/attestation.ts
@@ -1,12 +1,5 @@
 import {fromHexString, toHexString} from "@chainsafe/ssz";
-import {
-  Attestation,
-  AttestationRootHex,
-  BlockRootHex,
-  Root,
-  SignedBeaconBlock,
-  Slot
-} from "@chainsafe/lodestar-types";
+import {Attestation, AttestationRootHex, BlockRootHex, Root, SignedBeaconBlock, Slot} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {
   computeEpochAtSlot,
@@ -20,7 +13,6 @@ import {ChainEventEmitter, IAttestationProcessor} from "./interface";
 import {ILMDGHOST} from ".";
 import {IBeaconDb} from "../db";
 import {GENESIS_EPOCH} from "../constants";
-import {ITreeStateContext} from "../db/api/beacon/stateContextCache";
 
 export class AttestationProcessor implements IAttestationProcessor {
   private readonly config: IBeaconConfig;

--- a/packages/lodestar/src/chain/attestation.ts
+++ b/packages/lodestar/src/chain/attestation.ts
@@ -71,6 +71,7 @@ export class AttestationProcessor implements IAttestationProcessor {
     try {
       await this.processAttestation(attestation, attestationHash);
     } catch (e) {
+      console.log(e);
       this.logger.warn("Failed to process attestation. Reason: " + e.message);
     }
   }
@@ -97,14 +98,10 @@ export class AttestationProcessor implements IAttestationProcessor {
     const justifiedCheckpoint = this.forkChoice.getJustified();
     const currentSlot = this.forkChoice.headBlockSlot();
     const currentEpoch = computeEpochAtSlot(this.config, currentSlot);
-    let stateCtx: ITreeStateContext;
     const justifiedBlock = this.forkChoice.getBlockSummaryByBlockRoot(
       justifiedCheckpoint.root.valueOf() as Uint8Array
     );
-    if (justifiedBlock) {
-      stateCtx = await this.db.stateCache.get(justifiedBlock.stateRoot);
-    }
-    if (!justifiedBlock || !stateCtx) {
+    if (!justifiedBlock) {
       // should not happen
       throw new Error(`Cannot find justified node of forkchoice, blockHash=${toHexString(justifiedCheckpoint.root)}`);
     }
@@ -127,7 +124,11 @@ export class AttestationProcessor implements IAttestationProcessor {
     assert.true(
       ancestor && this.config.types.Root.equals(target.root, ancestor),
       "FFG and LMD vote must be consistent with each other");
-
+    const stateCtx = await this.db.stateCache.get(block.stateRoot);
+    assert.true(
+      !!stateCtx,
+      `Missing state context for attestation block with stateRoot ${toHexString(block.stateRoot)}`
+    );
     const validators = getAttestingIndicesFromCommittee(
       stateCtx.epochCtx.getBeaconCommittee(attestation.data.slot, attestation.data.index),
       attestation.aggregationBits


### PR DESCRIPTION
Seems like I'm on a bug hunt today.

Fixed:
`warn: Failed to process attestation. Reason: crosslink committee retrieval: out of range epoch: 2`

This will speed up e2e tests as we would reach finalization sooner.