### PR TITLE
Review account docs comments

### DIFF
--- a/docs/usage/key-management.md
+++ b/docs/usage/key-management.md
@@ -11,7 +11,7 @@ The 12-word string is randomly generated during wallet creation and printed out 
 To create a wallet, use the following command:
 
 ```
-lodestar account wallet create --name primary --passphrase-file primary.pass
+lodestar account wallet create --name primary --passphraseFile primary.pass --rootDir .lodestar
 ```
 
 This command will:
@@ -35,16 +35,16 @@ Validators are represented by a BLS keypair. It is recommended to generate valid
 To create a new validator use the following command:
 
 ```
-lodestar account validator create --name primary --passphrase-file primary.pass
+lodestar account validator create --name primary --passphraseFile primary.pass --rootDir .lodestar
 ```
 
 This command will:
 
 - Derive a new BLS keypair from the wallet `primary`.
-- Create a new directory in `./.lodestar/keystores` containing:
+- Create a new directory in `.lodestar/keystores` containing:
   - An encrypted Keystore with the validator voting keypair.
   - An eth1_deposit_data.rlp file with the precomputed Eth1 deposit transaction data ready to be submitted to the deposit contract.
-- Store the validator voting Keystore password in `./.lodestar/secrets`.
+- Store the validator voting Keystore password in `.lodestar/secrets`.
 - Print the validator public key to the terminal
 
 <!-- prettier-ignore-start -->
@@ -63,10 +63,10 @@ To submit the deposit transaction for a validator, use the following command wit
   - `--rpcUrl` alone to connect to the node's JSON RPC API if it's already unlocked.
 
 ```
-lodestar account validator deposit --validator 0x88f920bb56d76c68e0d983e9772e67d2ba4afadd5eb162a51f7fc62212c138e5611d99f98f834fce43f310295ca35eca
+lodestar account validator deposit --validator 0x88f920bb56d76c68e0d983e9772e67d2ba4afadd5eb162a51f7fc62212c138e5611d99f98f834fce43f310295ca35eca --rootDir .lodestar
 ```
 
-The resulting transaction hash will be print to the terminal and also stored in the validator's dir. 
+The resulting transaction hash will be print to the terminal and also stored in the validator's dir.
 
 <!-- prettier-ignore-start -->
 !!! info

--- a/docs/usage/key-management.md
+++ b/docs/usage/key-management.md
@@ -14,7 +14,10 @@ To create a wallet, use the following command:
 lodestar account wallet create --name primary --passphrase-file primary.pass
 ```
 
-A random strong password will be generated and stored in `primary.pass`.
+This command will:
+
+- Create a hierarchical deterministic wallet identified with the name `primary`. This name can be arbitrary and is only used to reference the wallet in subsequent commands.
+- Generate a random strong password and stored in `primary.pass`.
 
 <!-- prettier-ignore-start -->
 !!! info

--- a/docs/usage/key-management.md
+++ b/docs/usage/key-management.md
@@ -41,10 +41,10 @@ lodestar account validator create --name primary --passphrase-file primary.pass
 This command will:
 
 - Derive a new BLS keypair from the wallet `primary`.
-- Create a new directory in `./lodestar/keystores` containing:
+- Create a new directory in `./.lodestar/keystores` containing:
   - An encrypted Keystore with the validator voting keypair.
   - An eth1_deposit_data.rlp file with the precomputed Eth1 deposit transaction data ready to be submitted to the deposit contract.
-- Store the validator voting Keystore password in `./lodestar/secrets`.
+- Store the validator voting Keystore password in `./.lodestar/secrets`.
 - Print the validator public key to the terminal
 
 <!-- prettier-ignore-start -->

--- a/docs/usage/key-management.md
+++ b/docs/usage/key-management.md
@@ -38,7 +38,7 @@ lodestar account validator create --name primary --passphrase-file primary.pass
 This command will:
 
 - Derive a new BLS keypair from the wallet `primary`.
-- Create a new directory in `$rootDir/validators` containing:
+- Create a new directory in `$rootDir/keystores` containing:
   - An encrypted Keystore with the validator voting keypair.
   - An eth1_deposit_data.rlp file with the precomputed Eth1 deposit transaction data ready to be submitted to the deposit contract.
 - Store the validator voting Keystore password in `$rootDir/secrets`.

--- a/docs/usage/key-management.md
+++ b/docs/usage/key-management.md
@@ -38,10 +38,10 @@ lodestar account validator create --name primary --passphrase-file primary.pass
 This command will:
 
 - Derive a new BLS keypair from the wallet `primary`.
-- Create a new directory in `$rootDir/keystores` containing:
+- Create a new directory in `./lodestar/keystores` containing:
   - An encrypted Keystore with the validator voting keypair.
   - An eth1_deposit_data.rlp file with the precomputed Eth1 deposit transaction data ready to be submitted to the deposit contract.
-- Store the validator voting Keystore password in `$rootDir/secrets`.
+- Store the validator voting Keystore password in `./lodestar/secrets`.
 - Print the validator public key to the terminal
 
 <!-- prettier-ignore-start -->

--- a/packages/lodestar-cli/.gitignore
+++ b/packages/lodestar-cli/.gitignore
@@ -16,6 +16,7 @@ package-lock.json
 LodestarValidatorDB/
 benchmark-reports/
 validators/
+keystores/
 .lodestar
 
 # Wallet CLI artifacts

--- a/packages/lodestar/.gitignore
+++ b/packages/lodestar/.gitignore
@@ -16,3 +16,4 @@ package-lock.json
 LodestarValidatorDB/
 benchmark-reports/
 validators/
+keystores/


### PR DESCRIPTION
Fixes https://github.com/ChainSafe/lodestar/issues/1229

- Fix account docs directory name holding validator keystores
- Don't use $rootDir in docs, but its default value
- Clarify the role of --name option in 'lodestar account wallet create'