### PR TITLE
Add readonly iteration to state transition

### DIFF
--- a/packages/lodestar-beacon-state-transition/package.json
+++ b/packages/lodestar-beacon-state-transition/package.json
@@ -38,7 +38,7 @@
     "@chainsafe/bls": "2.0.0",
     "@chainsafe/lodestar-config": "^0.10.2",
     "@chainsafe/lodestar-utils": "^0.10.2",
-    "@chainsafe/ssz": "^0.6.9",
+    "@chainsafe/ssz": "^0.6.10",
     "bigint-buffer": "^1.1.5",
     "buffer-xor": "^2.0.2"
   },

--- a/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
@@ -1,3 +1,4 @@
+import {readOnlyMap} from "@chainsafe/ssz";
 import {BeaconState, ValidatorIndex} from "@chainsafe/lodestar-types";
 
 import {FAR_FUTURE_EPOCH} from "../../constants";
@@ -20,8 +21,7 @@ export function initiateValidatorExit(
   const currentEpoch = epochCtx.currentShuffling.epoch;
 
   // compute exit queue epoch
-  // TODO fast read-only iteration
-  const validatorExitEpochs = Array.from(state.validators).map((v) => v.exitEpoch);
+  const validatorExitEpochs = readOnlyMap(state.validators, (v) => v.exitEpoch);
   const exitEpochs = validatorExitEpochs.filter((exitEpoch) => exitEpoch !== FAR_FUTURE_EPOCH);
   exitEpochs.push(computeActivationExitEpoch(config, currentEpoch));
   let exitQueueEpoch = Math.max(...exitEpochs);

--- a/packages/lodestar-beacon-state-transition/src/fast/block/processEth1Data.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/processEth1Data.ts
@@ -22,8 +22,8 @@ export function processEth1Data(
   if (Eth1Data.equals(state.eth1Data, newEth1Data)) {
     return; // Nothing to do if the state already has this as eth1data (happens a lot after majority vote is in)
   }
-  // TODO fast read-only iteration
-  const sameVotesCount = readOnlyMap(state.eth1DataVotes, (v) => v).filter((e) => Eth1Data.equals(e, newEth1Data)).length;
+  const sameVotesCount = readOnlyMap(state.eth1DataVotes, (v) => v)
+    .filter((e) => Eth1Data.equals(e, newEth1Data)).length;
   if (sameVotesCount * 2 > SLOTS_PER_ETH1_VOTING_PERIOD) {
     state.eth1Data = newEth1Data;
   }

--- a/packages/lodestar-beacon-state-transition/src/fast/block/processEth1Data.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/processEth1Data.ts
@@ -1,3 +1,4 @@
+import {readOnlyMap} from "@chainsafe/ssz";
 import {BeaconBlockBody, BeaconState} from "@chainsafe/lodestar-types";
 
 import {EpochContext} from "../util";
@@ -22,7 +23,7 @@ export function processEth1Data(
     return; // Nothing to do if the state already has this as eth1data (happens a lot after majority vote is in)
   }
   // TODO fast read-only iteration
-  const sameVotesCount = Array.from(state.eth1DataVotes).filter((e) => Eth1Data.equals(e, newEth1Data)).length;
+  const sameVotesCount = readOnlyMap(state.eth1DataVotes, (v) => v).filter((e) => Eth1Data.equals(e, newEth1Data)).length;
   if (sameVotesCount * 2 > SLOTS_PER_ETH1_VOTING_PERIOD) {
     state.eth1Data = newEth1Data;
   }

--- a/packages/lodestar-beacon-state-transition/src/fast/block/processOperations.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/processOperations.ts
@@ -1,3 +1,4 @@
+import {List, readOnlyForEach} from "@chainsafe/ssz";
 import {
   Attestation,
   AttesterSlashing,
@@ -14,7 +15,6 @@ import {processAttesterSlashing} from "./processAttesterSlashing";
 import {processAttestation} from "./processAttestation";
 import {processDeposit} from "./processDeposit";
 import {processVoluntaryExit} from "./processVoluntaryExit";
-import {List} from "@chainsafe/ssz";
 
 type Operation = ProposerSlashing | AttesterSlashing | Attestation | Deposit | VoluntaryExit;
 type OperationFunction = (epochCtx: EpochContext, state: BeaconState, op: Operation, verify: boolean) => void;
@@ -44,7 +44,7 @@ export function processOperations(
     [body.deposits, processDeposit],
     [body.voluntaryExits, processVoluntaryExit],
   ] as [List<Operation>, OperationFunction][]).forEach(([operations, processOp]) => {
-    Array.from(operations).forEach((op) => {
+    readOnlyForEach(operations, (op) => {
       processOp(epochCtx, state, op, verifySignatures);
     });
   });

--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/processFinalUpdates.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/processFinalUpdates.ts
@@ -3,6 +3,7 @@ import {bigIntMin, intDiv} from "@chainsafe/lodestar-utils";
 
 import {getRandaoMix} from "../../util";
 import {EpochContext, IEpochProcess} from "../util";
+import {readOnlyMap} from "@chainsafe/ssz";
 
 export function processFinalUpdates(
   epochCtx: EpochContext,
@@ -34,8 +35,7 @@ export function processFinalUpdates(
   }
 
   // update effective balances with hysteresis
-  // TODO fast read-only iteration
-  const balances = Array.from(state.balances);
+  const balances = readOnlyMap(state.balances, (balance) => balance);
   for (let i = 0; i < process.statuses.length; i++) {
     const status = process.statuses[i];
     const balance = balances[i];

--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/processRewardsAndPenalties.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/processRewardsAndPenalties.ts
@@ -1,4 +1,5 @@
 import {BeaconState} from "@chainsafe/lodestar-types";
+import {readOnlyMap} from "@chainsafe/ssz";
 
 import {GENESIS_EPOCH} from "../../constants";
 import {EpochContext, IEpochProcess} from "../util";
@@ -14,8 +15,7 @@ export function processRewardsAndPenalties(
     return;
   }
   const [rewards, penalties] = getAttestationDeltas(epochCtx, process, state);
-  // TODO fast read-only iteration
-  const newBalances = Array.from(state.balances);
+  const newBalances = readOnlyMap(state.balances, (balance) => balance);
 
   rewards.forEach((reward, i) => {
     newBalances[i] += reward;

--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/processSlashings.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/processSlashings.ts
@@ -1,3 +1,4 @@
+import {readOnlyMap} from "@chainsafe/ssz";
 import {BeaconState} from "@chainsafe/lodestar-types";
 import {bigIntMin} from "@chainsafe/lodestar-utils";
 
@@ -11,8 +12,7 @@ export function processSlashings(
   state: BeaconState
 ): void {
   const totalBalance = process.totalActiveStake;
-  // TODO fast read-only iteration
-  const totalSlashings = Array.from(state.slashings).reduce((a, b) => a + b, BigInt(0));
+  const totalSlashings = readOnlyMap(state.slashings, (s) => s).reduce((a, b) => a + b, BigInt(0));
   const slashingsScale = bigIntMin(totalSlashings * BigInt(3), totalBalance);
   const increment = BigInt(epochCtx.config.params.EFFECTIVE_BALANCE_INCREMENT);
   process.indicesToSlash.forEach((index) => {

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
@@ -1,4 +1,4 @@
-import {ByteVector, hash, toHexString} from "@chainsafe/ssz";
+import {ByteVector, hash, toHexString, readOnlyMap} from "@chainsafe/ssz";
 import {BeaconState, CommitteeIndex, Epoch, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {intToBytes} from "@chainsafe/lodestar-utils";
@@ -43,8 +43,7 @@ export class EpochContext {
     const previousEpoch = currentEpoch === GENESIS_EPOCH ? GENESIS_EPOCH : currentEpoch - 1;
     const nextEpoch = currentEpoch + 1;
 
-    // TODO use readonly iteration here
-    const indicesBounded: [ValidatorIndex, Epoch, Epoch][] = Array.from(state.validators).map((v, i) => ([
+    const indicesBounded: [ValidatorIndex, Epoch, Epoch][] = readOnlyMap(state.validators, (v, i) => ([
       i, v.activationEpoch, v.exitEpoch,
     ]));
 
@@ -94,8 +93,7 @@ export class EpochContext {
     this.previousShuffling = this.currentShuffling;
     this.currentShuffling = this.nextShuffling;
     const nextEpoch = this.currentShuffling.epoch + 1;
-    // TODO use readonly iteration here
-    const indicesBounded: [ValidatorIndex, Epoch, Epoch][] = Array.from(state.validators).map((v, i) => ([
+    const indicesBounded: [ValidatorIndex, Epoch, Epoch][] = readOnlyMap(state.validators, (v, i) => ([
       i, v.activationEpoch, v.exitEpoch,
     ]));
     this.nextShuffling = computeEpochShuffling(this.config, state, indicesBounded, nextEpoch);

--- a/packages/lodestar-cli/package.json
+++ b/packages/lodestar-cli/package.json
@@ -56,7 +56,7 @@
     "@chainsafe/lodestar-types": "^0.10.2",
     "@chainsafe/lodestar-utils": "^0.10.2",
     "@chainsafe/lodestar-validator": "^0.10.2",
-    "@chainsafe/ssz": "^0.6.9",
+    "@chainsafe/ssz": "^0.6.10",
     "@iarna/toml": "^2.2.3",
     "@types/lockfile": "^1.0.1",
     "bigint-buffer": "^1.1.5",

--- a/packages/lodestar-params/package.json
+++ b/packages/lodestar-params/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@types/js-yaml": "^3.12.2",
-    "@chainsafe/ssz": "^0.6.9",
+    "@chainsafe/ssz": "^0.6.10",
     "js-yaml": "^3.13.1"
   }
 }

--- a/packages/lodestar-spec-test-util/package.json
+++ b/packages/lodestar-spec-test-util/package.json
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "@chainsafe/lodestar-utils": "^0.10.2",
-    "@chainsafe/ssz": "^0.6.9",
+    "@chainsafe/ssz": "^0.6.10",
     "camelcase": "^5.3.1",
     "chai": "^4.2.0",
     "deepmerge": "^4.0.0",

--- a/packages/lodestar-types/package.json
+++ b/packages/lodestar-types/package.json
@@ -36,7 +36,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/lodestar-params": "^0.10.2",
-    "@chainsafe/ssz": "^0.6.9"
+    "@chainsafe/ssz": "^0.6.10"
   },
   "devDependencies": {
     "@types/chai": "4.2.0",

--- a/packages/lodestar-utils/package.json
+++ b/packages/lodestar-utils/package.json
@@ -36,7 +36,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/ssz": "^0.6.9",
+    "@chainsafe/ssz": "^0.6.10",
     "bigint-buffer": "^1.1.5",
     "camelcase": "^5.3.1",
     "chalk": "^2.4.2",

--- a/packages/lodestar-validator/package.json
+++ b/packages/lodestar-validator/package.json
@@ -48,7 +48,7 @@
     "@chainsafe/lodestar-config": "^0.10.2",
     "@chainsafe/lodestar-types": "^0.10.2",
     "@chainsafe/lodestar-utils": "^0.10.2",
-    "@chainsafe/ssz": "^0.6.9",
+    "@chainsafe/ssz": "^0.6.10",
     "axios": "^0.19.0",
     "axios-mock-adapter": "^1.17.0",
     "bigint-buffer": "^1.1.5",

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -50,7 +50,7 @@
     "@chainsafe/lodestar-utils": "^0.10.2",
     "@chainsafe/lodestar-validator": "^0.10.2",
     "@chainsafe/snappy-stream": "3.0.4",
-    "@chainsafe/ssz": "^0.6.9",
+    "@chainsafe/ssz": "^0.6.10",
     "@types/async": "^3.0.1",
     "abort-controller": "^3.0.0",
     "abortable-iterator": "^3.0.0",

--- a/packages/spec-test-runner/package.json
+++ b/packages/spec-test-runner/package.json
@@ -40,7 +40,7 @@
     "@chainsafe/lodestar-types": "^0.10.2",
     "@chainsafe/lodestar-utils": "^0.10.2",
     "@chainsafe/lodestar-validator": "^0.10.2",
-    "@chainsafe/ssz": "^0.6.9",
+    "@chainsafe/ssz": "^0.6.10",
     "@types/chai": "4.2.0",
     "@types/chai-as-promised": "^7.1.1",
     "@types/mocha": "^5.2.7",

--- a/packages/spec-test-runner/test/spec/ssz/util/testCases.ts
+++ b/packages/spec-test-runner/test/spec/ssz/util/testCases.ts
@@ -77,6 +77,12 @@ export function testStatic(type: keyof IBeaconSSZTypes): void {
           }
           // @ts-ignore
           const structural = Type.deserialize(testCase.serialized_raw)
+          // @ts-ignore
+          const tree = Type.tree.deserialize(testCase.serialized_raw)
+          expect(
+            tree.serialize(),
+            "tree serialization != structural serialization"
+          ).to.deep.equal(Type.serialize(structural))
           expect(expected.serialized.equals(Type.serialize(structural)))
           expect(expected.root.equals(Type.hashTreeRoot(structural)))
           expect(expected.serialized.equals(actual.serialized), "incorrect serialize").to.be.true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,10 +921,10 @@
   resolved "https://registry.yarnpkg.com/@chainsafe/eth2-spec-tests/-/eth2-spec-tests-0.12.1.tgz#8d172ebc40a4269e071bb20f607b3a5f4a557bc9"
   integrity sha512-M4XsIuNU/LG4FdExZRxgotcj2ePX2uMtfcTI736HZBYBioyilSh2/dk6NekwQcd7qP/eRlIZ2CrWYwneY0cM/A==
 
-"@chainsafe/persistent-merkle-tree@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.1.3.tgz#95d16f5faefc4d75f2861859ec5474f34767a4f7"
-  integrity sha512-ZFu7Zoxjt1A9W5whMVlwWJ+dGMF6+iL99lI9g7kIaG1JbI37M0F4TszO5Fe758e6/XJdGl5SFLi+923JYVB/ow==
+"@chainsafe/persistent-merkle-tree@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.2.0.tgz#2b00ea7e18ec9440af54082abe8a596c7ec1135d"
+  integrity sha512-gOxAuUx0FAH0lZm4jDzUJOiFoIpug+SLnd1cumz1i/EdZlmcFIN0YEdqPq+HhN/4/qWhnJs52bY8pum82KMMaA==
   dependencies:
     "@chainsafe/as-sha256" "^0.2.0"
 
@@ -940,13 +940,13 @@
     fast-crc32c "^1.0.1"
     snappy "^6.0.1"
 
-"@chainsafe/ssz@^0.6.9":
-  version "0.6.9"
-  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.6.9.tgz#eea26e5eb93dad498b80289aa0b5b54e9e2f2c76"
-  integrity sha512-w8QqLfnT3GatW38wkV9zqILrrc6FLzF/Typ4fVT79aq6AwZjiPgllNC8gVRWWHsoohKqHjzX0mhRxdhGbscrAQ==
+"@chainsafe/ssz@^0.6.10":
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.6.10.tgz#2fe7bf17c4d8c644ae61b8d3b1a9c88cd009ab90"
+  integrity sha512-4tn7uxNg2g2uFMHhtq3ErGgZ8HKl7on0BgpTfePeOXB3+tBxk5z84BvhWP8cg5G5bawrQODKyJimRUWnSFJamw==
   dependencies:
     "@chainsafe/as-sha256" "^0.2.0"
-    "@chainsafe/persistent-merkle-tree" "^0.1.3"
+    "@chainsafe/persistent-merkle-tree" "^0.2.0"
     case "^1.6.3"
 
 "@ethersproject/abi@^5.0.0":


### PR DESCRIPTION
Depends on chainsafe/ssz#54 and subsequent release

Updates fast state transition to use `readOnlyForEach` and `readOnlyMap` where possible.
These functions more optimally navigate the tree backings, resulting in faster state transtion.