### PR TITLE
Fix reqResp logging, simplify logger context type

### DIFF
--- a/packages/lodestar-utils/src/logger/format.ts
+++ b/packages/lodestar-utils/src/logger/format.ts
@@ -1,6 +1,5 @@
 import {format} from "winston";
 import {Context} from "./interface";
-import {toHex} from "../bytes";
 
 export const defaultLogFormat = format.combine(
   format.colorize(),

--- a/packages/lodestar-utils/src/logger/format.ts
+++ b/packages/lodestar-utils/src/logger/format.ts
@@ -27,13 +27,11 @@ export function serializeContext(context?: Context|Error): string {
     return "Error: " + context.message + "\n" + context.stack;
   }
   if (typeof context === "string") return context;
+  if (
+    typeof context === "number" || typeof context === "boolean" || Array.isArray(context)
+  ) return JSON.stringify(context);
   return Object.keys(context).map((key) => {
-    let value = "";
-    if(Array.isArray(context[key]) || context[key] instanceof Uint8Array) {
-      value = toHex(context[key] as Uint8Array);
-    } else {
-      value = context[key].toString();
-    }
+    const value = typeof context[key] === "string" ? context[key] : JSON.stringify(context[key]);
     return `${key}=${value}`;
   }).join(", ");
 }

--- a/packages/lodestar-utils/src/logger/interface.ts
+++ b/packages/lodestar-utils/src/logger/interface.ts
@@ -2,7 +2,7 @@
  * @module logger
  */
 
-import {ArrayLike} from "@chainsafe/ssz";
+import {ArrayLike, Json} from "@chainsafe/ssz";
 import {Writable} from "stream";
 
 export enum LogLevel {
@@ -34,7 +34,7 @@ export interface ILoggerOptions {
   module?: string;
 }
 
-export type Context = {[k: string]: string|number|BigInt|ArrayLike<number>};
+export type Context = Json;
 
 export interface ILogger {
   level: LogLevel;

--- a/packages/lodestar-utils/src/logger/interface.ts
+++ b/packages/lodestar-utils/src/logger/interface.ts
@@ -2,7 +2,7 @@
  * @module logger
  */
 
-import {ArrayLike, Json} from "@chainsafe/ssz";
+import {Json} from "@chainsafe/ssz";
 import {Writable} from "stream";
 
 export enum LogLevel {

--- a/packages/lodestar-utils/test/unit/logger/format.test.ts
+++ b/packages/lodestar-utils/test/unit/logger/format.test.ts
@@ -1,21 +1,25 @@
 import {serializeContext} from "../../../src/logger";
 import {expect} from "chai";
-import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 
 describe("log format", function () {
 
   describe("serialize context", function () {
     it("should serialize context", function () {
       const serialized = serializeContext({
-        array: config.types.Uint64.hashTreeRoot(10n),
-        buffer: Buffer.alloc(2, 0),
+        object: {
+          foo: "bar",
+          baz: 1,
+        },
+        array: ["a", "small", "array"],
         string: "test",
-        bigint: 10n
+        number: 3,
+        bool: true,
       });
       expect(serialized)
         .to.equal(
-          "array=0x0a00000000000000000000000000000000000000000000000000000000000000,"
-          +" buffer=0x0000, string=test, bigint=10"
+          "object={\"foo\":\"bar\",\"baz\":1},"
+          +" array=[\"a\",\"small\",\"array\"],"
+          +" string=test, number=3, bool=true"
         );
     });
 

--- a/packages/lodestar/src/chain/blocks/process.ts
+++ b/packages/lodestar/src/chain/blocks/process.ts
@@ -52,9 +52,11 @@ export function processBlock(
 
         const newChainHeadRoot = updateForkChoice(config, forkChoice, job.signedBlock, newState);
         if(config.types.Root.equals(newChainHeadRoot, blockRoot)) {
-          logger.info("Processed new chain head",
-            {newChainHeadRoot, slot: newState.slot, epoch: computeEpochAtSlot(config, newState.slot)}
-          );
+          logger.info("Processed new chain head", {
+            newChainHeadRoot: toHexString(newChainHeadRoot),
+            slot: newState.slot,
+            epoch: computeEpochAtSlot(config, newState.slot)
+          });
           if(!config.types.Fork.equals(preStateContext.state.fork, newState.fork)) {
             const epoch = computeEpochAtSlot(config, newState.slot);
             const currentVersion = newState.fork.currentVersion;

--- a/packages/lodestar/src/constants/network.ts
+++ b/packages/lodestar/src/constants/network.ts
@@ -18,6 +18,15 @@ export enum Method {
   BeaconBlocksByRoot = "beacon_blocks_by_root",
 }
 
+export enum MethodRequestType {
+  "status" = "Status",
+  "goodbye" = "Goodbye",
+  "ping" = "Ping",
+  "metadata" = "Metadata",
+  "beacon_blocks_by_range" = "BeaconBlocksByRangeRequest",
+  "beacon_blocks_by_root" = "BeaconBlocksByRootRequest",
+}
+
 export enum MethodResponseType {
   SingleResponse = "SingleResponse",
   NoResponse = "NoResponse",


### PR DESCRIPTION
Using JSON.stringify on ssz types occasionally blows up when the input is/has BigInt. This was happening to coerce a request body into a log entry.

Adds a reverse mapping for Method => Req SSZ type, uses that to toJson request body.
Simplifies logger `Context` type to `Json`.