### PR TITLE
Regular sync: retry requests to out-of-sync peer with best peer

### DIFF
--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -131,6 +131,7 @@ export class NaiveRegularSync implements IRegularSync {
     const reqResp = this.network.reqResp;
     const getSyncPeers = this.getSyncPeers;
     const setTarget = this.setTarget;
+    const doneFirstSync = this.doneFirstSync;
     await pipe(
       this.targetSlotRangeSource,
       (source) => {
@@ -145,7 +146,9 @@ export class NaiveRegularSync implements IRegularSync {
               await setTarget(lastFetchedSlot, false);
             } else {
               // some peers maybe not up to date, retry the range again next time
-              await setTarget(range.start - 1, false);
+              // first sync: force it runs again
+              // after first sync: onNextSlot will trigger
+              await setTarget(range.start - 1, !doneFirstSync);
             }
           }
         })();

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -12,7 +12,7 @@ import {IReputationStore} from "../../IReputation";
 import {SignedBeaconBlock, Slot, Root} from "@chainsafe/lodestar-types";
 import pushable, {Pushable} from "it-pushable";
 import pipe from "it-pipe";
-import {fetchBlockChunks, processSyncBlocks} from "../../utils";
+import {processSyncBlocks, fetchBlockInterleave} from "../../utils";
 import {ISlotRange} from "../../interface";
 import {getCurrentSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {GossipEvent} from "../../../network/gossip/constants";
@@ -138,7 +138,7 @@ export class NaiveRegularSync implements IRegularSync {
           for await (const range of abortSource(source, controller.signal, {returnOnAbort: true})) {
             const lastFetchedSlot = await pipe(
               [range],
-              fetchBlockChunks(logger, chain, reqResp, getSyncPeers),
+              fetchBlockInterleave(logger, reqResp, getSyncPeers),
               processSyncBlocks(config, chain, logger, false)
             );
             if(lastFetchedSlot) {

--- a/packages/lodestar/src/sync/utils/blocks.ts
+++ b/packages/lodestar/src/sync/utils/blocks.ts
@@ -39,14 +39,15 @@ export function chunkify(blocksPerChunk: number, currentSlot: Slot, targetSlot: 
 export async function getBlockRangeFromPeer(
   rpc: IReqResp,
   peer: PeerId,
-  chunk: ISlotRange
+  chunk: ISlotRange,
+  step = 1
 ): Promise<SignedBeaconBlock[]|null> {
   return await rpc.beaconBlocksByRange(
     peer,
     {
       startSlot: chunk.start,
-      step: 1,
-      count: chunk.end - chunk.start + 1
+      step,
+      count: Math.floor((chunk.end - chunk.start) / step) + 1
     }
   ) as SignedBeaconBlock[];
 }
@@ -95,6 +96,58 @@ export async function getBlockRange(
   return sortBlocks(blocks);
 }
 
+export async function getBlockRangeInterleave(
+  logger: ILogger, rpc: IReqResp, peers: PeerId[], range: ISlotRange,
+): Promise<SignedBeaconBlock[]> {
+  // TODO: order peers by peer score?
+  const totalBlocks = range.end - range.start + 1;
+  const minBlockPerRequest = 3;
+  const numPeer = Math.min(peers.length, Math.floor(totalBlocks / minBlockPerRequest));
+  const peerBalancer = new RoundRobinArray(peers);
+  // Round 0
+  const round0Promises = [];
+  const selectedPeers = [];
+  const interleaveRanges: ISlotRange[] = [];
+  for (let i = 0; i < numPeer; i++) {
+    const peer = peerBalancer.next();
+    const interleaveRange = {start: range.start + i, end: range.end};
+    // step = numPeer
+    round0Promises.push(getBlockRangeFromPeer(rpc, peer, interleaveRange, numPeer));
+    selectedPeers.push(peer);
+    interleaveRanges.push(interleaveRange);
+  }
+  const round0BlocksByRequest = await Promise.all(round0Promises);
+  const retryRanges: ISlotRange[] = [];
+  round0BlocksByRequest.forEach((blocks, index) => {
+    const oldRange = interleaveRanges[index];
+    if (shouldRetryRange(oldRange, blocks, numPeer)) {
+      const range = {
+        start: (!blocks || blocks.length === 0)?
+          oldRange.start : Math.max(...blocks.map(block => block.message.slot)) + numPeer,
+        end: oldRange.end};
+      retryRanges.push(range);
+      logger.verbose(`Retry range ${JSON.stringify(oldRange)} by ${JSON.stringify(range)} ` +
+        `num block=${blocks && blocks.length}, num peer(step)=${numPeer}`);
+    }
+  });
+  const round0Blocks = toBlocks(round0BlocksByRequest);
+  if (retryRanges.length === 0 || selectedPeers.length === 1) return sortBlocks(round0Blocks);
+  if (round0Blocks.length === 0) {
+    // next call will shuffle peers hopefully
+    logger.warn(`All beacon_block_by_range requests return null or no block for range ${JSON.stringify(range)}`);
+    return [];
+  }
+  // Round 1: fallback
+  const lastSlot = Math.max(...round0Blocks.map(block => block.message.slot));
+  const bestPeerIndex = round0BlocksByRequest.findIndex(
+    (value) => value && value.length > 0 && value[value.length - 1].message.slot === lastSlot);
+  const bestPeer = selectedPeers[bestPeerIndex];
+  const round1BlocksByRequest =
+    await Promise.all(retryRanges.map((range) => getBlockRangeFromPeer(rpc, bestPeer, range, numPeer)));
+  const round1Blocks = toBlocks(round1BlocksByRequest);
+  return sortBlocks([...round0Blocks, ...round1Blocks]);
+}
+
 export function sortBlocks(blocks: SignedBeaconBlock[]): SignedBeaconBlock[] {
   return blocks.sort((b1, b2) => b1.message.slot - b2.message.slot);
 }
@@ -113,4 +166,22 @@ export function isValidChainOfBlocks(
     parentRoot = config.types.BeaconBlock.hashTreeRoot(signedBlock.message);
   }
   return true;
+}
+
+export function shouldRetryRange(range: ISlotRange, blocks: SignedBeaconBlock[], step: number): boolean {
+  let slot = range.start;
+  while (slot + step < range.end) {
+    slot += step;
+  }
+  if (!blocks || blocks.length === 0 ||
+    Math.max(...blocks.map(block => block.message.slot)) < slot) {
+    return true;
+  }
+  return false;
+}
+
+export function toBlocks(blocksByRequest: SignedBeaconBlock[][]): SignedBeaconBlock[] {
+  return blocksByRequest.reduce((allBlocks, blocks) => {
+    return allBlocks.concat(blocks? blocks : []);
+  }, []);
 }

--- a/packages/lodestar/src/sync/utils/blocks.ts
+++ b/packages/lodestar/src/sync/utils/blocks.ts
@@ -131,7 +131,7 @@ export async function getBlockRangeInterleave(
     }
   });
   const round0Blocks = toBlocks(round0BlocksByRequest);
-  if (retryRanges.length === 0 || selectedPeers.length === 1) return sortBlocks(round0Blocks);
+  if (retryRanges.length === 0 || numPeer === 1) return sortBlocks(round0Blocks);
   if (round0Blocks.length === 0) {
     // next call will shuffle peers hopefully
     logger.warn(`All beacon_block_by_range requests return null or no block for range ${JSON.stringify(range)}`);
@@ -169,6 +169,9 @@ export function isValidChainOfBlocks(
 }
 
 export function shouldRetryRange(range: ISlotRange, blocks: SignedBeaconBlock[], step: number): boolean {
+  if (step === 1) {
+    return false;
+  }
   let slot = range.start;
   while (slot + step < range.end) {
     slot += step;

--- a/packages/lodestar/test/unit/sync/utils/block.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/block.test.ts
@@ -197,7 +197,14 @@ describe("sync - block utils", function () {
   });
 
   describe("shouldRetryRange", function () {
-    it("should return false", () => {
+    it("should return false - step=1", () => {
+      const step = 1;
+      const range: ISlotRange = {start: 3, end: 10};
+      // even latest slot is not expected, don't want to retry because there is 1 peer only
+      const blocks = [generateSignedBlock({message: {slot: 3}})];
+      expect(shouldRetryRange(range, blocks, step)).to.be.false;
+    });
+    it("should return false - end slot is expected", () => {
       const step = 3;
       const range: ISlotRange = {start: 3, end: 10};
       const blocks = [generateSignedBlock({message: {slot: 9}})];


### PR DESCRIPTION
resolves #1234 

```
Given 3 peers, we can query by interleaving way, assuming we want to get block 10 to 20 for regular sync:
Round 0

Peer 0: start_slot=10, step=3 => return 10,13,16,19
Peer 1: start_slot=11, step=3 => return 11,14 - this peer is out-of-sync because expected latest slot=20
Peer 2: start_slot=12, step=3 => return null - error querying this peer - timeout for example
=> bestPeer=peer has max(lastSlot)=peer 0
Round 1 - fallback

Query bestPeer with start_slot=17, step=3
Query bestPeer with start_slot=12, step=3
```

Tested successfully a couple of times. Cannot test the latest version after I rebase to master because I got a some recent issues with "initial sync".