### PR TITLE
Fix account validator deposit command

### DIFF
--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/deposit.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/deposit.ts
@@ -1,4 +1,7 @@
 import {CommandBuilder} from "yargs";
+import {BigNumber} from "ethers";
+import {toHexString} from "@chainsafe/ssz";
+
 import {ValidatorDirManager} from "../../../../validatorDir";
 import {getAccountPaths} from "../../paths";
 import {getBeaconConfig, getEthersSigner, YargsError} from "../../../../util";
@@ -68,7 +71,7 @@ export async function handler(options: IAccountValidatorDepositOptions): Promise
 
   if (!config.params.DEPOSIT_CONTRACT_ADDRESS)
     throw new YargsError("deposit_contract not in configuration");
-  const depositContractAddress = String(config.params.DEPOSIT_CONTRACT_ADDRESS);
+  const depositContractAddress = toHexString(config.params.DEPOSIT_CONTRACT_ADDRESS);
 
   // Load validators to deposit
   // depositData is already generated when building / creating the validator dir
@@ -79,7 +82,7 @@ export async function handler(options: IAccountValidatorDepositOptions): Promise
 
   const validatorDirsToSubmit = validatorDirs
     // txHash file is used as a flag of deposit submission
-    .filter(validatorDir => validatorDir.eth1DepositTxHashExists());
+    .filter(validatorDir => !validatorDir.eth1DepositTxHashExists());
   
   if (validatorDirsToSubmit.length === 0)
     throw new YargsError("No validators to deposit");
@@ -93,8 +96,9 @@ export async function handler(options: IAccountValidatorDepositOptions): Promise
     const tx = await eth1Signer.sendTransaction({
       to: depositContractAddress,
       gasLimit: DEPOSIT_GAS_LIMIT,
-      value: (depositData.amount * BigInt(1e9)).toString(),
-      data: rlp
+      value: BigNumber.from(depositData.amount * BigInt(1e9)),
+      data: rlp,
+      chainId: config.params.DEPOSIT_CHAIN_ID
     });
     if (!tx.hash) throw Error("No transaction hash");
     validatorDir.saveEth1DepositTxHash(tx.hash);


### PR DESCRIPTION
Fix a few minor bugs, clear the way for using the account validator deposit command

- convert `DEPOSIT_CONTRACT_ADDRESS` to hex string instead of comma-separated string
- reverse the filter of `validatorDir.eth1DepositTxHashExists`. If it exists, a tx has already been made, so ignore that validator
- parse the transaction amount to a `BigNumber`. Seems ethers does not like string here.
- add `DEPOSIT_CHAIN_ID` to the transaction submission. disallows txs to be replayed on other chains
- Fix deposit data decoding (was an error in decoding the `amount`), simplify by using `DepositData.fromJson`
- Fix deposit data root equality check