### PR TITLE
Regular sync: find best peer at startup and use it

### DIFF
--- a/packages/lodestar/src/network/reqResp.ts
+++ b/packages/lodestar/src/network/reqResp.ts
@@ -294,6 +294,7 @@ export class ReqResp extends (EventEmitter as IReqEventEmitterClass) implements 
       logger.verbose(`sending ${method} request to ${peerId.toB58String()}`, {requestId, encoding});
       const {stream} = await dialProtocol(libp2p, peerId, protocol, TTFB_TIMEOUT) as {stream: Stream};
       logger.verbose(`got stream to ${peerId.toB58String()}`, {requestId, encoding});
+
       const controller = new AbortController();
       yield* pipe(
         (body !== null && body !== undefined) ? [body] : [null],

--- a/packages/lodestar/src/sync/regular/interface.ts
+++ b/packages/lodestar/src/sync/regular/interface.ts
@@ -1,7 +1,15 @@
 import {IService} from "../../node";
 import {ISyncModule, ISyncModules} from "../index";
+import {EventEmitter} from "events";
+import StrictEventEmitter from "strict-event-emitter-types";
 
-export type IRegularSync = IService & ISyncModule;
+export interface IRegularSyncEvents {
+  syncCompleted: () => void;
+}
+
+export type RegularSyncEventEmitter = StrictEventEmitter<EventEmitter, IRegularSyncEvents>;
+
+export type IRegularSync = IService & ISyncModule & RegularSyncEventEmitter;
 
 export type IRegularSyncModules =
     Pick<ISyncModules, "config"|"chain"|"network"|"logger"|"reputationStore">;

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -191,9 +191,9 @@ export class NaiveRegularSync implements IRegularSync {
       isAborted = true;
     });
     while (!this.bestPeer && !isAborted) {
-      const peers = this.network.getPeers();
       const previousSlot = getCurrentSlot(this.config, state.genesisTime) - 1;
       await syncPeersStatus(this.reps, this.network, status);
+      const peers = this.network.getPeers();
       const maxHeadSlot = Math.max(...peers.map(
         (peerId) => this.reps.get(peerId.toB58String()).latestStatus?.headSlot || 0));
       this.bestPeer = peers.find(peerId => {
@@ -204,7 +204,8 @@ export class NaiveRegularSync implements IRegularSync {
       if (this.bestPeer) {
         this.logger.verbose(`Regular Sync: Found best peer ${this.bestPeer.toB58String()}`);
       } else {
-        this.logger.verbose(`Regular Sync: Not found peer with headSlot >= ${previousSlot} num peers=${peers.length}`);
+        this.logger.verbose(`Regular Sync: Not found peer with headSlot >= ${previousSlot} num peers=${peers.length}` +
+          ` maxHeadSlot=${maxHeadSlot}`);
       }
     }
   };

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -90,7 +90,8 @@ export class NaiveRegularSync implements IRegularSync {
   private async getNewTarget(): Promise<Slot> {
     const state = await this.chain.getHeadState();
     const currentSlot = getCurrentSlot(this.config, state.genesisTime);
-    return Math.min((this.currentTarget + this.opts.blockPerChunk), currentSlot);
+    // due to exclusive endSlot in chunkify, we want `currentSlot + 1`
+    return Math.min((this.currentTarget + this.opts.blockPerChunk), currentSlot + 1);
   }
 
   private setTarget = async (newTarget?: Slot, triggerSync = true): Promise<void> => {

--- a/packages/lodestar/src/sync/regular/options.ts
+++ b/packages/lodestar/src/sync/regular/options.ts
@@ -4,5 +4,5 @@ export interface IRegularSyncOptions {
 }
 
 export const defaultOptions: IRegularSyncOptions = {
-  blockPerChunk: 5
+  blockPerChunk: 64
 };

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -24,7 +24,7 @@ import {IReputationStore} from "../IReputation";
 import {computeStartSlotAtEpoch, getBlockRoot, GENESIS_SLOT} from "@chainsafe/lodestar-beacon-state-transition";
 import {toHexString} from "@chainsafe/ssz";
 import {RpcError} from "../../network/error";
-import {createStatus} from "../utils/sync";
+import {createStatus, syncPeersStatus} from "../utils/sync";
 
 export interface IReqRespHandlerModules {
   config: IBeaconConfig;
@@ -66,10 +66,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
     this.network.reqResp.on("request", this.onRequest);
     this.network.on("peer:connect", this.handshake);
     const myStatus = await createStatus(this.chain);
-    await Promise.all(
-      this.network.getPeers().map((peerId) =>
-        this.network.reqResp.status(peerId, myStatus)));
-
+    await syncPeersStatus(this.reps, this.network, myStatus);
   }
 
   public async stop(): Promise<void> {

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -133,7 +133,7 @@ export class BeaconSync implements IBeaconSync {
     this.mode = SyncMode.REGULAR_SYNCING;
     await this.initialSync.stop();
     this.startSyncTimer(this.config.params.SECONDS_PER_SLOT * 1000);
-    this.regularSync.on("syncCompleted", this.stopSyncTimer);
+    this.regularSync.on("syncCompleted", this.stopSyncTimer.bind(this));
     await this.gossip.start();
     await this.regularSync.start();
   }

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -134,10 +134,8 @@ export class BeaconSync implements IBeaconSync {
     await this.initialSync.stop();
     this.startSyncTimer(this.config.params.SECONDS_PER_SLOT * 1000);
     this.regularSync.on("syncCompleted", this.stopSyncTimer);
-    await Promise.all([
-      this.gossip.start(),
-      this.regularSync.start(),
-    ]);
+    await this.gossip.start();
+    await this.regularSync.start();
   }
 
   private startSyncTimer(interval: number): void {

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -210,7 +210,7 @@ export function createStatus(chain: IBeaconChain): Status {
 }
 
 export async function syncPeersStatus(reps: IReputationStore, network: INetwork, status: Status): Promise<void> {
-  await Promise.all(network.getPeers().map(peerId => async () => {
+  await Promise.all(network.getPeers().map(async (peerId) => {
     reps.get(peerId.toB58String()).latestStatus = await network.reqResp.status(peerId, status);
   }));
 }

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -10,6 +10,7 @@ import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {toHexString} from "@chainsafe/ssz";
 import {blockToHeader} from "@chainsafe/lodestar-beacon-state-transition";
 import {sleep} from "../../util/sleep";
+import {GENESIS_EPOCH, ZERO_HASH} from "../../constants";
 
 export function getHighestCommonSlot(peers: IReputation[]): Slot {
   const slotStatuses = peers.reduce<Map<Slot, number>>((current, peer) => {
@@ -194,5 +195,17 @@ export function processSyncBlocks(
       }
     }
     return lastProcessedSlot;
+  };
+}
+
+
+export function createStatus(chain: IBeaconChain): Status {
+  const head = chain.forkChoice.head();
+  return {
+    forkDigest: chain.currentForkDigest,
+    finalizedRoot: head.finalizedCheckpoint.epoch === GENESIS_EPOCH ? ZERO_HASH : head.finalizedCheckpoint.root,
+    finalizedEpoch: head.finalizedCheckpoint.epoch,
+    headRoot: head.blockRoot,
+    headSlot: head.slot,
   };
 }

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -214,3 +214,17 @@ export async function syncPeersStatus(reps: IReputationStore, network: INetwork,
     reps.get(peerId.toB58String()).latestStatus = await network.reqResp.status(peerId, status);
   }));
 }
+
+export function getBestHead(peers: PeerId[], reps: IReputationStore): number {
+  return Math.max(...peers.map(
+    (peerId) => reps.get(peerId.toB58String()).latestStatus?.headSlot || 0));
+}
+
+// should add peer score later
+export function getBestPeer(peers: PeerId[], reps: IReputationStore): PeerId {
+  const bestHead = getBestHead(peers, reps);
+  return peers.find(peerId => {
+    const headSlot = reps.get(peerId.toB58String()).latestStatus?.headSlot;
+    return headSlot === bestHead;
+  });
+}

--- a/packages/lodestar/test/unit/sync/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/sync.test.ts
@@ -1,4 +1,4 @@
-import sinon, {SinonStubbedInstance} from "sinon";
+import sinon, {SinonStubbedInstance, SinonFakeTimers} from "sinon";
 import {BeaconChain, IBeaconChain} from "../../../src/chain";
 import {BeaconReqRespHandler, IReqRespHandler} from "../../../src/sync/reqResp";
 import {AttestationCollector} from "../../../src/sync/utils";
@@ -26,6 +26,7 @@ describe("sync", function () {
   let loggerStub: SinonStubbedInstance<ILogger>;
   let regularSyncStub: SinonStubbedInstance<IRegularSync>;
   let initialSyncStub: SinonStubbedInstance<InitialSync>;
+  let clock: SinonFakeTimers;
 
   const getSync = (opts: ISyncOptions): IBeaconSync => {
     return new BeaconSync(
@@ -54,6 +55,11 @@ describe("sync", function () {
     loggerStub = sinon.createStubInstance(WinstonLogger);
     regularSyncStub = sinon.createStubInstance(NaiveRegularSync);
     initialSyncStub = sinon.createStubInstance(FastSync);
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
   });
 
   it("is synced should be true", async function () {

--- a/packages/lodestar/test/unit/sync/utils/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/sync.test.ts
@@ -1,5 +1,5 @@
 import {describe} from "mocha";
-import {IReputation} from "../../../../src/sync/IReputation";
+import {IReputation, ReputationStore} from "../../../../src/sync/IReputation";
 import {Checkpoint, Status} from "@chainsafe/lodestar-types";
 import {
   fetchBlockChunks,
@@ -7,6 +7,8 @@ import {
   getHighestCommonSlot,
   getStatusFinalizedCheckpoint,
   processSyncBlocks,
+  getBestHead,
+  getBestPeer,
 } from "../../../../src/sync/utils";
 import {expect} from "chai";
 import deepmerge from "deepmerge";
@@ -20,6 +22,7 @@ import {collect} from "../../chain/blocks/utils";
 import {ReqResp} from "../../../../src/network/reqResp";
 import {generateEmptySignedBlock} from "../../../utils/block";
 import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
+import PeerId from "peer-id";
 
 describe("sync utils", function () {
 
@@ -218,6 +221,34 @@ describe("sync utils", function () {
       expect(chainStub.receiveBlock.calledTwice).to.be.true;
     });
 
+  });
+
+  it("should get best head and best peer", async () => {
+    const peer1 = await PeerId.create();
+    const peer2 = await PeerId.create();
+    const peer3 = await PeerId.create();
+    const peers = [peer1, peer2, peer3];
+    const reps = new ReputationStore();
+    reps.add(peer1.toB58String());
+    reps.add(peer2.toB58String());
+    reps.add(peer3.toB58String());
+    reps.get(peer1.toB58String()).latestStatus = {
+      forkDigest: Buffer.alloc(0),
+      finalizedRoot: Buffer.alloc(0),
+      finalizedEpoch: 0,
+      headRoot: Buffer.alloc(0),
+      headSlot: 1000
+    };
+    reps.get(peer2.toB58String()).latestStatus = {
+      forkDigest: Buffer.alloc(0),
+      finalizedRoot: Buffer.alloc(0),
+      finalizedEpoch: 0,
+      headRoot: Buffer.alloc(0),
+      headSlot: 2000
+    };
+
+    expect(getBestHead(peers, reps)).to.be.equal(2000);
+    expect(getBestPeer(peers, reps)).to.be.equal(peer2);
   });
 
 });

--- a/packages/lodestar/test/unit/sync/utils/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/sync.test.ts
@@ -236,19 +236,19 @@ describe("sync utils", function () {
       forkDigest: Buffer.alloc(0),
       finalizedRoot: Buffer.alloc(0),
       finalizedEpoch: 0,
-      headRoot: Buffer.alloc(0),
+      headRoot: Buffer.alloc(32, 1),
       headSlot: 1000
     };
     reps.get(peer2.toB58String()).latestStatus = {
       forkDigest: Buffer.alloc(0),
       finalizedRoot: Buffer.alloc(0),
       finalizedEpoch: 0,
-      headRoot: Buffer.alloc(0),
+      headRoot: Buffer.alloc(32, 2),
       headSlot: 2000
     };
 
-    expect(getBestHead(peers, reps)).to.be.equal(2000);
-    expect(getBestPeer(peers, reps)).to.be.equal(peer2);
+    expect(getBestHead(peers, reps)).to.be.deep.equal({slot: 2000, root: Buffer.alloc(32, 2)});
+    expect(getBestPeer(config, peers, reps)).to.be.equal(peer2);
   });
 
 });


### PR DESCRIPTION
+ resolves #1234 
+ remove `onNewSlot` as it may cause missing blocks and we can process chain up to head()

At regular sync, if we query blocks from multiple peers we may get blocks from different forkchoice branch so we'll *not* be able to sync to head in that case.
This PR helps find best peer at Regular Sync start time and use it as the only peer.

![image](https://user-images.githubusercontent.com/10568965/88903579-21066180-d27e-11ea-9447-8185132ea4bb.png)
