### PR TITLE
Fix cmd account validator create - no validator bug

### DIFF
--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/create.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/create.ts
@@ -82,6 +82,7 @@ export async function handler(options: IValidatorCreateOptions): Promise<void> {
   const n = typeof count === "number" ? count
     : typeof atMost === "number" ? atMost - wallet.nextaccount
       : 1;
+  if (isNaN(n)) throw new Error(`Error computing validatorCount: ${n}`);
   if (n <= 0) throw new YargsError("No validators to create");
 
   const walletPassword = readPassphraseFile(passphraseFile);

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/create.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/create.ts
@@ -79,7 +79,9 @@ export async function handler(options: IValidatorCreateOptions): Promise<void> {
   const validatorDirBuilder = new ValidatorDirBuilder(accountPaths);
   const walletManager = new WalletManager(accountPaths);
   const wallet = walletManager.openByName(name);
-  const n = count || atMost - wallet.nextaccount;
+  const n = typeof count === "number" ? count
+    : typeof atMost === "number" ? atMost - wallet.nextaccount
+      : 1;
   if (n <= 0) throw new YargsError("No validators to create");
 
   const walletPassword = readPassphraseFile(passphraseFile);

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/create.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/create.ts
@@ -96,6 +96,6 @@ export async function handler(options: IValidatorCreateOptions): Promise<void> {
     walletManager.writeWallet(wallet);
 
     // eslint-disable-next-line no-console
-    console.log(`${i}/${count}\t${keystores.signing.pubkey}`);
+    console.log(`${i}/${n}\t${keystores.signing.pubkey}`);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/ChainSafe/lodestar/issues/1254.

FIxes a bug where if no --count or --atMost option was specified, validatorCount became `NaN` and no validator was created while not failing