### PR TITLE
Add basic beacon option to log to file

### DIFF
--- a/packages/lodestar-cli/src/cmds/beacon/cmds/init/index.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/cmds/init/index.ts
@@ -1,8 +1,9 @@
 import {CommandModule} from "yargs";
 import {IBeaconOptions} from "../../options";
 import {initHandler} from "./init";
+import {IGlobalArgs} from "../../../../options";
 
-export const init: CommandModule<IBeaconOptions, IBeaconOptions> = {
+export const init: CommandModule<IGlobalArgs, IBeaconOptions> = {
   command: "init",
   describe: "Initialize lodestar beacon node",
   handler: initHandler

--- a/packages/lodestar-cli/src/cmds/beacon/cmds/run/run.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/cmds/run/run.ts
@@ -3,7 +3,7 @@ import process from "process";
 import {initBLS} from "@chainsafe/bls";
 import {BeaconNode} from "@chainsafe/lodestar/lib/node";
 import {createNodeJsLibp2p} from "@chainsafe/lodestar/lib/network/nodejs";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {fileTransport, WinstonLogger} from "@chainsafe/lodestar-utils";
 import {IBeaconOptions} from "../../options";
 import {readPeerId, readEnr, writeEnr} from "../../../../network";
 import {ENR} from "@chainsafe/discv5";
@@ -11,6 +11,8 @@ import {initHandler as initBeacon} from "../init/init";
 import {getBeaconPaths} from "../../paths";
 import {mergeConfigOptions} from "../../config";
 import {getBeaconConfig} from "../../../../util";
+import {consoleTransport} from "@chainsafe/lodestar-utils";
+import path from "path";
 
 /**
  * Run a beacon node
@@ -34,7 +36,13 @@ export async function runHandler(options: IBeaconOptions): Promise<void> {
 
   const config = getBeaconConfig(options.preset, options.params);
   const libp2p = await createNodeJsLibp2p(peerId, options.network);
-  const logger = new WinstonLogger();
+  const loggerTransports = [
+    consoleTransport
+  ];
+  if(options.logFile) {
+    loggerTransports.push(fileTransport(path.join(options.rootDir, options.logFile)));
+  }
+  const logger = new WinstonLogger({}, loggerTransports);
 
   const node = new BeaconNode(options, {config, libp2p, logger});
 

--- a/packages/lodestar-cli/src/cmds/beacon/index.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/index.ts
@@ -9,8 +9,11 @@ export const beacon: CommandModule<IGlobalArgs, IBeaconOptions> = {
   describe: "Beacon node",
   builder: (yargs) => yargs
     .options(beaconOptions)
-    .command(init as CommandModule<IGlobalArgs, IBeaconOptions>)
-    .command(run as CommandModule<IGlobalArgs, IBeaconOptions>),
+  //seems like we need to define all beaconOptions in IGlobalArgs
+  // @ts-ignore
+    .command(init)
+    .command(run),
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  handler: () => {}
+  handler: () => {
+  }
 };

--- a/packages/lodestar-cli/src/cmds/beacon/options.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/options.ts
@@ -1,7 +1,6 @@
 import {Options} from "yargs";
 import {IGlobalArgs} from "../../options";
-import {beaconNodeOptions, IBeaconNodeOptions} from "../../options/beaconNodeOptions";
-import {paramsOptions, IParamsOptions} from "../../options/paramsOptions";
+import {paramsOptions, IParamsOptions, beaconNodeOptions, IBeaconNodeOptions} from "../../options";
 import {defaultBeaconPaths, IBeaconPaths} from "./paths";
 import {TestnetName} from "./testnets";
 
@@ -14,9 +13,10 @@ export type IBeaconOptions =
     templateConfigFile?: string;
     genesisStateFile?: string;
     testnet?: TestnetName;
+    logFile?: string;
   };
 
-export const beaconOptions = {
+export const beaconOptions: {[k: string]: Options} = {
   ...beaconNodeOptions,
   ...paramsOptions,
 
@@ -25,19 +25,19 @@ export const beaconOptions = {
     description: "Template configuration used to initialize beacon node",
     type: "string",
     default: null,
-  } as Options,
+  },
 
   genesisStateFile: {
     description: "Genesis state in ssz-encoded format",
     type: "string",
     normalize: true,
-  } as Options,
+  },
 
   testnet: {
     description: "Use a testnet configuration and genesis file",
     type: "string",
     choices: ["altona"] as TestnetName[],
-  } as Options,
+  },
 
   // Beacon paths
 
@@ -46,7 +46,7 @@ export const beaconOptions = {
     defaultDescription: defaultBeaconPaths.beaconDir,
     hidden: true,
     type: "string",
-  } as Options,
+  },
 
   dbDir: {
     alias: ["db.dir", "db.name"],
@@ -55,7 +55,7 @@ export const beaconOptions = {
     hidden: true,
     normalize: true,
     type: "string",
-  } as Options,
+  },
 
   configFile: {
     alias: ["config"],
@@ -63,7 +63,7 @@ export const beaconOptions = {
     defaultDescription: defaultBeaconPaths.configFile,
     type: "string",
     normalize: true,
-  } as Options,
+  },
 
   peerIdFile: {
     hidden: true,
@@ -71,7 +71,7 @@ export const beaconOptions = {
     defaultDescription: defaultBeaconPaths.peerIdFile,
     normalize: true,
     type: "string",
-  } as Options,
+  },
 
   enrFile: {
     hidden: true,
@@ -79,5 +79,11 @@ export const beaconOptions = {
     defaultDescription: defaultBeaconPaths.enrFile,
     normalize: true,
     type: "string",
-  } as Options
+  },
+
+  logFile: {
+    alias: ["log.file"],
+    type: "string",
+    normalize: true,
+  }
 };

--- a/packages/lodestar-utils/src/logger/winston.ts
+++ b/packages/lodestar-utils/src/logger/winston.ts
@@ -9,12 +9,26 @@ import {defaultLogFormat} from "./format";
 import TransportStream from "winston-transport";
 import {Writable} from "stream";
 
+export const consoleTransport: TransportStream = new winstonTransports.Console({
+  debugStdout: true,
+  level: "silly",
+  handleExceptions: true
+});
+
+export const fileTransport = (filename: string): TransportStream => {
+  return new winstonTransports.File({
+    level: "silly",
+    filename,
+    handleExceptions: true,
+  });
+};
+
 export class WinstonLogger implements ILogger {
   private winston: Logger;
   private _level: LogLevel;
   private _silent: boolean;
 
-  public constructor(options?: Partial<ILoggerOptions>, transports?: TransportStream) {
+  public constructor(options?: Partial<ILoggerOptions>, transports?: TransportStream[]) {
     options = {
       level: defaultLogLevel,
       module: "",
@@ -27,11 +41,7 @@ export class WinstonLogger implements ILogger {
       },
       format: defaultLogFormat,
       transports: transports || [
-        new winstonTransports.Console({
-          debugStdout: true,
-          level: "silly",
-          handleExceptions: true
-        })
+        consoleTransport
       ],
       exitOnError: false
     });


### PR DESCRIPTION
Later on we should probably introduce log rotatio but for current status it will suffice to just log everything to file so we can attach log file to issue and debug later on.