### PR TITLE
Add early --testnet medalla support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,9 @@ docs/assets
 genesis.ssz
 witti.json
 altona.json
+medalla.json
 .altona
+.medalla
 
 # Wallet CLI artifacts
 .pass

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,13 @@
 
 **Lodestar is a Typescript implementation** of the official [Ethereum 2.0 specification](https://github.com/ethereum/eth2.0-specs) which is the product of an ongoing collective research and development effort by various teams.
 
+<!-- prettier-ignore-start -->
+!!! important
+    You can already join the [**Medalla testnet**](usage/medalla) running a Lodestar node!
+<!-- prettier-ignore-end -->
+
 - Follow the [installation guide](installation) to install Lodestar.
+- Run a node in the [Medalla testnet](usage/medalla).
 - Utilize the whole stack by [starting a local testnet](usage).
 - View the [typedoc code docs](packages).
 - Prospective contributors can read the [contributing section](contributing) to understand how we develop and test on Lodestar.

--- a/docs/usage/medalla.md
+++ b/docs/usage/medalla.md
@@ -45,7 +45,7 @@ After finding some peers the chain should start processing blocks up to the curr
     If your node is stuck with `Current peerCount=0` review your network configuration to make sure your ports are open.
 <!-- prettier-ignore-end -->
 
-A young testnet (such as Altona) should take a few hours to sync. If you see multiple or consistent errors in the logs, please open a [Github issue](https://github.com/ChainSafe/lodestar/issues/new) or reach out to us in [Discord](https://discord.gg/yjyvFRP). Just by reporting anomalities you are helping accelerate the progress of Eth2.0, thanks for contributing!
+A young testnet (such as Medalla) should take a few hours to sync. If you see multiple or consistent errors in the logs, please open a [Github issue](https://github.com/ChainSafe/lodestar/issues/new) or reach out to us in [Discord](https://discord.gg/yjyvFRP). Just by reporting anomalities you are helping accelerate the progress of Eth2.0, thanks for contributing!
 
 The `--testnet medalla` flag automatically sets the following configuration options. You may overwrite them with flags if necessary:
 

--- a/docs/usage/medalla.md
+++ b/docs/usage/medalla.md
@@ -1,0 +1,62 @@
+# Connect to Medalla testnet
+
+Running a Lodestar node on the [Medalla](https://github.com/goerli/medalla) multi-client testnet only requires basic familiarity with the terminal.
+
+Make sure lodestar is installed in your local environment. The following command should return a non error message. If it fails, go the [install guide](/install).
+
+```
+yarn run cli --help
+```
+
+## Run a beacon node
+
+To start a Lodestar beacon run the command:
+
+```bash
+yarn run cli beacon run --testnet medalla
+```
+
+<!-- prettier-ignore-start -->
+!!! info
+    Until genesis, the node will stay idle waiting for all genesis conditions to pass.
+<!-- prettier-ignore-end -->
+
+Immediatelly you should see confirmation that the different modules have started
+
+```bash
+2020-06-21 17:34:24  [CHAIN]            info: Initializing beacon chain with state root 0x773c694b47504d789dc768d2356f691866b47833d0d85e02511d7cd339925b17 and genesis block root 0x19aa2deaa02cac9774eb8948a8ead1ebe851ba9590878a10cd5767092e16ba12
+2020-06-21 17:34:25  [CHAIN]            info: Beacon chain initialized
+2020-06-21 17:34:25  [NODE]             info: Starting eth2 beacon node - LODESTAR!
+2020-06-21 17:34:25  [METRICS]          info: Starting metrics HTTP server on port 5000
+2020-06-21 17:34:25  [DB]               info: Connected to LevelDB database at .medalla/beacon/chain-db
+2020-06-21 17:34:26  [CHAIN]            info: Chain started, waiting blocks and attestations
+```
+
+After finding some peers the chain should start processing blocks up to the current head
+
+```
+2020-06-21 17:35:31  [CHAIN]            info: Processed new chain head newChainHeadRoot=0x993d99d17c176263f246c96a232bd96d847543d7c90cc60ddc559edcab99b2e6, slot=111, epoch=3
+2020-06-21 17:35:31  [CHAIN]            info: Processed new chain head newChainHeadRoot=0xcc1eb4c83cb0d9a9f7ed0045d2cd6257aadd226420baabd3d672be35605fe470, slot=112, epoch=3
+2020-06-21 17:35:31  [CHAIN]            info: Processed new chain head newChainHeadRoot=0xb5c7b08a369c0943292a91e733f3feed184bc3c0b49d04878bc86e0705c15fe8, slot=113, epoch=3
+```
+
+<!-- prettier-ignore-start -->
+!!! info
+    If your node is stuck with `Current peerCount=0` review your network configuration to make sure your ports are open.
+<!-- prettier-ignore-end -->
+
+A young testnet (such as Altona) should take a few hours to sync. If you see multiple or consistent errors in the logs, please open a [Github issue](https://github.com/ChainSafe/lodestar/issues/new) or reach out to us in [Discord](https://discord.gg/yjyvFRP). Just by reporting anomalities you are helping accelerate the progress of Eth2.0, thanks for contributing!
+
+The `--testnet medalla` flag automatically sets the following configuration options. You may overwrite them with flags if necessary:
+
+- Use a genesis state file from `eth2-clients/eth2-testnets` since Eth1 genesis state processing is slow.
+- Set `eth1.enabled` to false.
+- Set the root directory to `.medalla`.
+
+## Run a validator
+
+_TBD_
+
+## Submit your deposit to Goerli
+
+_TBD_

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,9 +43,9 @@ nav:
   - Getting started: index.md
   - Installation: installation.md
   - Usage:
-      - Local testnet: usage/local.md
-      - Altona testnet: usage/altona.md
       - Medalla testnet: usage/medalla.md
+      - Altona testnet: usage/altona.md
+      - Local testnet: usage/local.md
       - Key management: usage/key-management.md
       - Prometheus & Grafana Setup: usage/prometheus-grafana.md
   - Packages: packages.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
   - Usage:
       - Local testnet: usage/local.md
       - Altona testnet: usage/altona.md
+      - Medalla testnet: usage/medalla.md
       - Key management: usage/key-management.md
       - Prometheus & Grafana Setup: usage/prometheus-grafana.md
   - Packages: packages.md

--- a/packages/lodestar-cli/src/cmds/beacon/cmds/init/init.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/cmds/init/init.ts
@@ -5,7 +5,7 @@ import {IBeaconOptions} from "../../options";
 import {mkdir} from "../../../../util";
 import {initPeerId, initEnr, readPeerId} from "../../../../network";
 import {initBeaconConfig} from "../../config";
-import {getTestnetConfig, downloadGenesisFile, fetchBootnodes} from "../../testnets";
+import {getTestnetConfig, getGenesisFileUrl, downloadGenesisFile, fetchBootnodes} from "../../testnets";
 import {getBeaconPaths} from "../../paths";
 
 /**
@@ -29,8 +29,13 @@ export async function initHandler(options: IBeaconOptions): Promise<void> {
     }
     // Mutate options so options propagate upstream to the run call
     Object.assign(options, deepmerge(options, testnetConfig));
-    options.genesisStateFile = path.join(beaconPaths.beaconDir, "genesis.ssz");
-    await downloadGenesisFile(options.testnet, options.genesisStateFile);
+    const genesisFileUrl = getGenesisFileUrl(options.testnet);
+    if (genesisFileUrl) {
+      const genesisStateFile = path.join(beaconPaths.beaconDir, "genesis.ssz");
+      await downloadGenesisFile(options.genesisStateFile, genesisFileUrl);
+      options.genesisStateFile = genesisStateFile;
+      options.eth1.enabled = false;
+    }
   }
 
   // initialize beacon directory + rootDir

--- a/packages/lodestar-cli/src/cmds/beacon/config.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/config.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import _yargs from "yargs/yargs";
 import deepmerge from "deepmerge";
 import {Json} from "@chainsafe/ssz";
-import {IBeaconNodeOptions} from "@chainsafe/lodestar/lib/node/options";
+import {IBeaconNodeOptions} from "../../options";
 import defaultOptions from "@chainsafe/lodestar/lib/node/options";
 import {readFileSync, writeFile, getSubObject, setSubObject} from "../../util";
 import {IBeaconOptions, beaconOptions} from "./options";
@@ -53,7 +53,7 @@ export function mergeConfigOptions(options: IBeaconOptions): IBeaconOptions {
 
   return deepmerge(
     deepmerge(
-      defaultOptions as IBeaconOptions,
+      defaultOptions as Partial<IBeaconOptions>,
       optionsFromFile
     ),
     options

--- a/packages/lodestar-cli/src/cmds/beacon/options.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/options.ts
@@ -36,7 +36,7 @@ export const beaconOptions: {[k: string]: Options} = {
   testnet: {
     description: "Use a testnet configuration and genesis file",
     type: "string",
-    choices: ["altona"] as TestnetName[],
+    choices: ["altona", "medalla"] as TestnetName[],
   },
 
   // Beacon paths

--- a/packages/lodestar-cli/src/cmds/beacon/testnets/altona.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/testnets/altona.ts
@@ -11,7 +11,6 @@ export const altonaConfig: IBeaconNodeOptionsPartial = {
     },
   },
   eth1: {
-    enabled: false,
     provider: {
       url: "http://goerli.prylabs.net",
     },

--- a/packages/lodestar-cli/src/cmds/beacon/testnets/altona.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/testnets/altona.ts
@@ -18,7 +18,6 @@ export const altonaConfig: IBeaconNodeOptionsPartial = {
       deployedAt: 2917810,
     },
   },
-  genesisStateFile: ".altona/beacon/genesis.ssz",
   metrics: {
     enabled: true,
     serverPort: 8008,
@@ -47,11 +46,11 @@ export const altonaConfig: IBeaconNodeOptionsPartial = {
       ],
     },
     maxPeers: 25,
-    bootMultiaddrs: [
+    bootnodes: [
       "/ip4/51.15.97.240/tcp/9000/p2p/16Uiu2HAkwVT363kpFmupwJBH5tkhnaNZPQSY7zANnPGB63ikD1Wp",
       "/ip4/51.15.70.7/tcp/9000/p2p/16Uiu2HAmHV1UA1SBnNK7Ztp8ACQ8DzHwNnR49VDEPBavCU33PtVE",
     ],
-    localMultiaddrs: ["/ip4/0.0.0.0/tcp/30607"],
+    multiaddrs: ["/ip4/0.0.0.0/tcp/30607"],
   },
   params: {
     MIN_GENESIS_TIME: 1593433800,

--- a/packages/lodestar-cli/src/cmds/beacon/testnets/altona.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/testnets/altona.ts
@@ -1,50 +1,36 @@
+import {IBeaconNodeOptionsPartial} from "../../../options";
+
 /* eslint-disable max-len */
 
 // Use a Typescript file instead of JSON so it's automatically included in the built files
 
-export const altonaConfig = {
-  "api": {
-    "enabled": true,
-    "namespaces": ["beacon", "validator"],
-    "host": "127.0.0.1",
-    "port": 9596,
-    "cors": {
-      "origin": "*"
-    }
-  },
-  "eth1": {
-    "enabled": false,
-    "provider": {
-      "url": "http://goerli.prylabs.net"
+export const altonaConfig: IBeaconNodeOptionsPartial = {
+  api: {
+    rest: {
+      enabled: true,
     },
-    "depositContract": {
-      "deployedAt": 2917810
-    }
   },
-  "genesisStateFile": ".altona/beacon/genesis.ssz",
-  "logger": {
-    "chain": {
-      "level": "info"
+  eth1: {
+    enabled: false,
+    provider: {
+      url: "http://goerli.prylabs.net",
     },
-    "network": {
-      "level": "info"
+    depositContract: {
+      deployedAt: 2917810,
     },
-    "eth1": {
-      "level": "info"
-    },
-    "sync": {
-      "level": "info"
-    }
   },
-  "metrics": {
-    "enabled": true,
-    "serverPort": 8008
+  genesisStateFile: ".altona/beacon/genesis.ssz",
+  metrics: {
+    enabled: true,
+    serverPort: 8008,
   },
-  "network": {
-    "discv5": {
-      "enabled": true,
-      "bindAddr": "/ip4/0.0.0.0/udp/9000",
-      "bootEnrs": [
+  network: {
+    discv5: {
+      // TODO: Add `network.discv5.enabled` to the `IDiscv5DiscoveryInputOptions` type
+      // @ts-ignore
+      enabled: true,
+      bindAddr: "/ip4/0.0.0.0/udp/9000",
+      bootEnrs: [
         "enr:-LK4QFtV7Pz4reD5a7cpfi1z6yPrZ2I9eMMU5mGQpFXLnLoKZW8TXvVubShzLLpsEj6aayvVO1vFx-MApijD3HLPhlECh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD6etXjAAABIf__________gmlkgnY0gmlwhDMPYfCJc2VjcDI1NmsxoQIerw_qBc9apYfZqo2awiwS930_vvmGnW2psuHsTzrJ8YN0Y3CCIyiDdWRwgiMo",
         "enr:-LK4QPVkFd_MKzdW0219doTZryq40tTe8rwWYO75KDmeZM78fBskGsfCuAww9t8y3u0Q0FlhXOhjE1CWpx3SGbUaU80Ch2F0dG5ldHOIAAAAAAAAAACEZXRoMpD6etXjAAABIf__________gmlkgnY0gmlwhDMPRgeJc2VjcDI1NmsxoQNHu-QfNgzl8VxbMiPgv6wgAljojnqAOrN18tzJMuN8oYN0Y3CCIyiDdWRwgiMo",
         "enr:-LK4QHe52XPPrcv6-MvcmN5GqDe_sgCwo24n_2hedlfwD_oxNt7cXL3tXJ7h9aYv6CTS1C_H2G2_dkeqm_LBO9nrpiYBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD9yjmwAAABIf__________gmlkgnY0gmlwhANzD9uJc2VjcDI1NmsxoQJX7zMnRU3szfGfS8MAIfPaQKOBpu3sBVTXf4Qq0b_m-4N0Y3CCIyiDdWRwgiMo",
@@ -58,22 +44,22 @@ export const altonaConfig = {
         "enr:-LK4QHdys8TViG_QtAVjTKaP92xlbD7eP_kdqQDGEOSTYh2sW_uN41AyS_cBWP1nM-Gi_cXYQ5_rjx-Qgn3dCDydi8MBh2F0dG5ldHOI__________-EZXRoMpD9yjmwAAABIf__________gmlkgnY0gmlwhDZdpaaJc2VjcDI1NmsxoQNX8JXYTfTkL1rZ9-4Dd9De-C9W7bwUlmwOEhSIa8jZ0YN0Y3CCI4yDdWRwgiOM---",
         "enr:-LK4QPM8lQwCtEFVqBnqHs6p_OE2WkDtcDh5gLriXMMSy-wnd8058swVyiUgANqFgbPdV6Pm5_LyeAIT6gKLBW70ia4Bh2F0dG5ldHOI__________-EZXRoMpD9yjmwAAABIf__________gmlkgnY0gmlwhBLCKTOJc2VjcDI1NmsxoQMQfjhh_GwSLRpPKweO79mo_n3sPaK75E11DbrM-8OaY4N0Y3CCI4yDdWRwgiOM---",
         "enr:-LK4QKFLQRdyIaxd8_eT0nD35ZU2JrRc6IcO347uURaVaZ7UbU3ts_jAaEt2krT5DyI9IQt5JECOTO7IpSPCZgeySwMBh2F0dG5ldHOI__________-EZXRoMpD9yjmwAAABIf__________gmlkgnY0gmlwhDZdfJeJc2VjcDI1NmsxoQNnAwjMpA-1zWgd4ogGmRqsM1x7y7EQGDw_XxRpoo7KFIN0Y3CCI4yDdWRwgiOM---",
-        "enr:-LK4QOCodKmp5bsgQyl1nciqX7FGpsZdu0Mj1qFFpmw5BEdSOQ1xEwFlOuSkOVC4vHvbMNV5MPLkPvzw7xC42BvlMnEBh2F0dG5ldHOI__________-EZXRoMpD9yjmwAAABIf__________gmlkgnY0gmlwhBLEHx6Jc2VjcDI1NmsxoQLjYA6hPlO-7bzqsnT_NJRC0vjGTSQwyhlSqSVCdB0UcYN0Y3CCI4yDdWRwgiOM---"
-      ]
+        "enr:-LK4QOCodKmp5bsgQyl1nciqX7FGpsZdu0Mj1qFFpmw5BEdSOQ1xEwFlOuSkOVC4vHvbMNV5MPLkPvzw7xC42BvlMnEBh2F0dG5ldHOI__________-EZXRoMpD9yjmwAAABIf__________gmlkgnY0gmlwhBLEHx6Jc2VjcDI1NmsxoQLjYA6hPlO-7bzqsnT_NJRC0vjGTSQwyhlSqSVCdB0UcYN0Y3CCI4yDdWRwgiOM---",
+      ],
     },
-    "maxPeers": 25,
-    "bootMultiaddrs": [
+    maxPeers: 25,
+    bootMultiaddrs: [
       "/ip4/51.15.97.240/tcp/9000/p2p/16Uiu2HAkwVT363kpFmupwJBH5tkhnaNZPQSY7zANnPGB63ikD1Wp",
-      "/ip4/51.15.70.7/tcp/9000/p2p/16Uiu2HAmHV1UA1SBnNK7Ztp8ACQ8DzHwNnR49VDEPBavCU33PtVE"
+      "/ip4/51.15.70.7/tcp/9000/p2p/16Uiu2HAmHV1UA1SBnNK7Ztp8ACQ8DzHwNnR49VDEPBavCU33PtVE",
     ],
-    "localMultiaddrs": ["/ip4/0.0.0.0/tcp/30607"]
+    localMultiaddrs: ["/ip4/0.0.0.0/tcp/30607"],
   },
-  "params": {
-    "MIN_GENESIS_TIME": 1593433800,
-    "MIN_GENESIS_ACTIVE_VALIDATOR_COUNT": 640,
-    "GENESIS_DELAY": 172800,
-    "GENESIS_FORK_VERSION": "0x00000121",
-    "DEPOSIT_NETWORK_ID": 5,
-    "DEPOSIT_CONTRACT_ADDRESS": "0x16e82D77882A663454Ef92806b7DeCa1D394810f"
-  }
+  params: {
+    MIN_GENESIS_TIME: 1593433800,
+    MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 640,
+    GENESIS_DELAY: 172800,
+    GENESIS_FORK_VERSION: "0x00000121",
+    DEPOSIT_NETWORK_ID: 5,
+    DEPOSIT_CONTRACT_ADDRESS: "0x16e82D77882A663454Ef92806b7DeCa1D394810f",
+  },
 };

--- a/packages/lodestar-cli/src/cmds/beacon/testnets/index.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/testnets/index.ts
@@ -3,16 +3,15 @@ import path from "path";
 import stream from "stream";
 import {promisify} from "util";
 import got from "got";
-import {IBeaconNodeOptions} from "@chainsafe/lodestar/lib/node/options";
+import {IBeaconNodeOptionsPartial} from "../../../options";
 import {altonaConfig} from "./altona";
 
 export type TestnetName = "altona";
 
-export function getTestnetConfig(testnet: TestnetName): Partial<IBeaconNodeOptions> {
+export function getTestnetConfig(testnet: TestnetName): IBeaconNodeOptionsPartial {
   switch (testnet) {
     case "altona":
-      // Casting type since IBeaconNodeOptions doesn't match this config
-      return altonaConfig as unknown as Partial<IBeaconNodeOptions>;
+      return altonaConfig;
     default:
       throw Error(`Testnet not supported: ${testnet}`);
   }

--- a/packages/lodestar-cli/src/cmds/beacon/testnets/index.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/testnets/index.ts
@@ -20,7 +20,10 @@ export function getTestnetConfig(testnet: TestnetName): IBeaconNodeOptionsPartia
   }
 }
 
-function getGenesisFileUrl(testnet: TestnetName): string {
+/**
+ * Get genesisStateFile URL to download. Returns null if not available
+ */
+export function getGenesisFileUrl(testnet: TestnetName): string | null {
   switch (testnet) {
     case "altona":
       // eslint-disable-next-line max-len
@@ -45,19 +48,13 @@ function getBootnodesFileUrl(testnet: TestnetName): string {
 
 /**
  * Downloads a genesis file per testnet if it does not exist
- * @param options
  */
-export async function downloadGenesisFile(
-  testnet: TestnetName,
-  genesisFilePath: string
-): Promise<void> {
-  const genesisFileUrl = getGenesisFileUrl(testnet);
-
-  if (!fs.existsSync(genesisFilePath)) {
-    fs.mkdirSync(path.parse(genesisFilePath).dir, {recursive: true});
+export async function downloadGenesisFile(filepath: string, url: string): Promise<void> {
+  if (!fs.existsSync(filepath)) {
+    fs.mkdirSync(path.parse(filepath).dir, {recursive: true});
     await promisify(stream.pipeline)(
-      got.stream(genesisFileUrl),
-      fs.createWriteStream(genesisFilePath)
+      got.stream(url),
+      fs.createWriteStream(filepath)
     );
   }
 }

--- a/packages/lodestar-cli/src/cmds/beacon/testnets/index.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/testnets/index.ts
@@ -5,13 +5,16 @@ import {promisify} from "util";
 import got from "got";
 import {IBeaconNodeOptionsPartial} from "../../../options";
 import {altonaConfig} from "./altona";
+import {medallaConfig} from "./medalla";
 
-export type TestnetName = "altona";
+export type TestnetName = "altona" | "medalla";
 
 export function getTestnetConfig(testnet: TestnetName): IBeaconNodeOptionsPartial {
   switch (testnet) {
     case "altona":
       return altonaConfig;
+    case "medalla":
+      return medallaConfig;
     default:
       throw Error(`Testnet not supported: ${testnet}`);
   }
@@ -22,6 +25,8 @@ function getGenesisFileUrl(testnet: TestnetName): string {
     case "altona":
       // eslint-disable-next-line max-len
       return "https://github.com/eth2-clients/eth2-testnets/raw/b84d27cc8f161cc6289c91acce6dae9c35096845/shared/altona/genesis.ssz";
+    case "medalla":
+      return null;
     default:
       throw Error(`Testnet not supported: ${testnet}`);
   }
@@ -31,6 +36,8 @@ function getBootnodesFileUrl(testnet: TestnetName): string {
   switch (testnet) {
     case "altona":
       return "https://github.com/eth2-clients/eth2-testnets/raw/master/shared/altona/bootstrap_nodes.txt";
+    case "medalla":
+      return "https://github.com/goerli/medalla/raw/master/medalla/bootnodes.txt";
     default:
       throw Error(`Testnet not supported: ${testnet}`);
   }
@@ -63,5 +70,9 @@ export async function downloadGenesisFile(
 export async function fetchBootnodes(testnet: TestnetName): Promise<string[]> {
   const bootnodesFileUrl = getBootnodesFileUrl(testnet);
   const bootnodesFile = await got.get(bootnodesFileUrl).text();
-  return bootnodesFile.trim().split(/\r?\n/).filter(enr => enr.trim());
+  return bootnodesFile
+    .trim()
+    .split(/\r?\n/)
+    // File may contain a row with '### Ethereum Node Records'
+    .filter(enr => enr.trim() && enr.startsWith("enr:"));
 }

--- a/packages/lodestar-cli/src/cmds/beacon/testnets/medalla.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/testnets/medalla.ts
@@ -35,8 +35,8 @@ export const medallaConfig: IBeaconNodeOptionsPartial = {
       ],
     },
     maxPeers: 25,
-    bootMultiaddrs: [],
-    localMultiaddrs: ["/ip4/0.0.0.0/tcp/30607"],
+    bootnodes: [],
+    multiaddrs: ["/ip4/0.0.0.0/tcp/30607"],
   },
   params: {
     MIN_GENESIS_TIME: 1596546000,

--- a/packages/lodestar-cli/src/cmds/beacon/testnets/medalla.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/testnets/medalla.ts
@@ -11,7 +11,6 @@ export const medallaConfig: IBeaconNodeOptionsPartial = {
     },
   },
   eth1: {
-    enabled: false,
     provider: {
       url: "http://goerli.prylabs.net",
     },
@@ -19,7 +18,6 @@ export const medallaConfig: IBeaconNodeOptionsPartial = {
       deployedAt: 3085928,
     },
   },
-  genesisStateFile: ".medalla/beacon/genesis.ssz",
   metrics: {
     enabled: true,
     serverPort: 8008,

--- a/packages/lodestar-cli/src/cmds/beacon/testnets/medalla.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/testnets/medalla.ts
@@ -1,0 +1,51 @@
+import {IBeaconNodeOptionsPartial} from "../../../options";
+
+/* eslint-disable max-len */
+
+// Use a Typescript file instead of JSON so it's automatically included in the built files
+
+export const medallaConfig: IBeaconNodeOptionsPartial = {
+  api: {
+    rest: {
+      enabled: true,
+    },
+  },
+  eth1: {
+    enabled: false,
+    provider: {
+      url: "http://goerli.prylabs.net",
+    },
+    depositContract: {
+      deployedAt: 3085928,
+    },
+  },
+  genesisStateFile: ".medalla/beacon/genesis.ssz",
+  metrics: {
+    enabled: true,
+    serverPort: 8008,
+  },
+  network: {
+    discv5: {
+      // TODO: Add `network.discv5.enabled` to the `IDiscv5DiscoveryInputOptions` type
+      // @ts-ignore
+      enabled: true,
+      bindAddr: "/ip4/0.0.0.0/udp/9000",
+      bootEnrs: [
+        "enr:-LK4QKWk9yZo258PQouLshTOEEGWVHH7GhKwpYmB5tmKE4eHeSfman0PZvM2Rpp54RWgoOagAsOfKoXgZSbiCYzERWABh2F0dG5ldHOIAAAAAAAAAACEZXRoMpAAAAAAAAAAAAAAAAAAAAAAgmlkgnY0gmlwhDQlA5CJc2VjcDI1NmsxoQOYiWqrQtQksTEtS3qY6idxJE5wkm0t9wKqpzv2gCR21oN0Y3CCIyiDdWRwgiMo",
+        "enr:-LK4QEnIS-PIxxLCadJdnp83VXuJqgKvC9ZTIWaJpWqdKlUFCiup2sHxWihF9EYGlMrQLs0mq_2IyarhNq38eoaOHUoBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpAAAAAAAAAAAAAAAAAAAAAAgmlkgnY0gmlwhA37LMaJc2VjcDI1NmsxoQJ7k0mKtTd_kdEq251flOjD1HKpqgMmIETDoD-Msy_O-4N0Y3CCIyiDdWRwgiMo",
+        "enr:-KG4QIOJRu0BBlcXJcn3lI34Ub1aBLYipbnDaxBnr2uf2q6nE1TWnKY5OAajg3eG6mHheQSfRhXLuy-a8V5rqXKSoUEChGV0aDKQGK5MywAAAAH__________4JpZIJ2NIJpcIQKAAFhiXNlY3AyNTZrMaEDESplmV9c2k73v0DjxVXJ6__2bWyP-tK28_80lf7dUhqDdGNwgiMog3VkcIIjKA"
+      ],
+    },
+    maxPeers: 25,
+    bootMultiaddrs: [],
+    localMultiaddrs: ["/ip4/0.0.0.0/tcp/30607"],
+  },
+  params: {
+    MIN_GENESIS_TIME: 1596546000,
+    MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 16384,
+    GENESIS_DELAY: 172800,
+    GENESIS_FORK_VERSION: "0x00000001",
+    DEPOSIT_NETWORK_ID: 5,
+    DEPOSIT_CONTRACT_ADDRESS: "0x07b39F4fDE4A38bACe212b546dAc87C58DfE3fDC",
+  },
+};

--- a/packages/lodestar-cli/src/options/beaconNodeOptions/index.ts
+++ b/packages/lodestar-cli/src/options/beaconNodeOptions/index.ts
@@ -5,8 +5,16 @@ import {loggerOptions} from "./logger";
 import {metricsOptions} from "./metrics";
 import {networkOptions} from "./network";
 
+type RecursivePartial<T> = {
+  [P in keyof T]?:
+  T[P] extends (infer U)[] ? RecursivePartial<U>[] :
+    T[P] extends object ? RecursivePartial<T[P]> :
+      T[P];
+};
+
 // Re-export for convenience
-export type IBeaconNodeOptions = Partial<_IBeaconNodeOptions>;
+export type IBeaconNodeOptions = _IBeaconNodeOptions;
+export type IBeaconNodeOptionsPartial = RecursivePartial<_IBeaconNodeOptions>;
 
 export const beaconNodeOptions = {
   ...apiOptions,


### PR DESCRIPTION
Adds the option `--testnet medalla` to the CLI. It required some changes aside from adding its particular spec params:

- Type testnet config object. I've removed values that are the same as current defaults. Also, `api.rest.enabled` had an incorrect json path.
- Make `genesisStateFile` and `eth1.enabled` optional to the genesis state file URL existing. It currently doesn't for Medalla, so eth1 will be enabled.

Other goodies

- Call to action in docs home

![Screenshot from 2020-07-31 18-57-43](https://user-images.githubusercontent.com/35266934/89059335-4b7d1b00-d361-11ea-8429-747952acb07c.png)
