### PR TITLE
Handle dialProtocol timeout

### DIFF
--- a/packages/lodestar/src/network/reqResp.ts
+++ b/packages/lodestar/src/network/reqResp.ts
@@ -293,6 +293,7 @@ export class ReqResp extends (EventEmitter as IReqEventEmitterClass) implements 
       const protocol = createRpcProtocol(method, encoding);
       logger.verbose(`sending ${method} request to ${peerId.toB58String()}`, {requestId, encoding});
       const {stream} = await dialProtocol(libp2p, peerId, protocol, TTFB_TIMEOUT) as {stream: Stream};
+      logger.verbose(`got stream to ${peerId.toB58String()}`, {requestId, encoding});
       const controller = new AbortController();
       yield* pipe(
         (body !== null && body !== undefined) ? [body] : [null],

--- a/packages/lodestar/src/network/util.ts
+++ b/packages/lodestar/src/network/util.ts
@@ -130,7 +130,10 @@ export async function dialProtocol(
   timeout: number
 ): ReturnType<LibP2p["dialProtocol"]> {
   const abortController = new AbortController();
-  const timer = setTimeout(() => abortController.abort(), timeout);
+  const timer = setTimeout(() => {
+    abortController.abort();
+    throw new Error("Failed to dial");
+  }, timeout);
   const result = await libp2p.dialProtocol(peerId, protocol, {signal: abortController.signal} as object);
   clearTimeout(timer);
   return result;

--- a/packages/lodestar/test/unit/network/reqResp.test.ts
+++ b/packages/lodestar/test/unit/network/reqResp.test.ts
@@ -217,9 +217,6 @@ describe("[network] rpc", () => {
     const libP2pMock = await createNode(multiaddr);
     libP2pMock.dialProtocol = async (_, __, {signal}: {signal: AbortSignal} ) => {
       timer.tick(TTFB_TIMEOUT);
-      if(signal.aborted) {
-        throw new Error("Failed to dial");
-      }
       return {stream: {} as unknown as Stream, protocol: ""};
     };
     const rpcC = new ReqResp(


### PR DESCRIPTION
resolves #1268 

+ we can't rely on `libp2p.dialProtocol()` to throw Error for us in case of timeout so let's do it ourself.