### PR TITLE
Set strictNullChecks = true in lodestar-utils

### DIFF
--- a/packages/lodestar-utils/src/logger/winston.ts
+++ b/packages/lodestar-utils/src/logger/winston.ts
@@ -45,7 +45,7 @@ export class WinstonLogger implements ILogger {
       ],
       exitOnError: false
     });
-    this._level = options.level;
+    this._level = options.level || LogLevel.info;
     this._silent = false;
     if (typeof process !== "undefined" && typeof process.env !== "undefined") {
       this._silent = process.env.LODESTAR_SILENCE === "true";
@@ -85,7 +85,7 @@ export class WinstonLogger implements ILogger {
   }
 
   public stream(): Writable {
-    return null;
+    throw Error("Not implemented");
   }
 
   public set level(level: LogLevel) {
@@ -116,7 +116,7 @@ export class WinstonLogger implements ILogger {
     });
   }
 
-  private createLogEntry(level: LogLevel, message: string, context: Context|Error): void {
+  private createLogEntry(level: LogLevel, message: string, context?: Context|Error): void {
     if (this.silent || this.winston.levels[level] > this.winston.levels[this._level]) {
       return;
     }

--- a/packages/lodestar-utils/tsconfig.json
+++ b/packages/lodestar-utils/tsconfig.json
@@ -4,8 +4,9 @@
     "typeRoots": [
       "../../node_modules/@types"
     ],
-    "outDir": "lib"
+    "outDir": "lib",
     /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "strictNullChecks": true
   },
   "include": [
     "src",


### PR DESCRIPTION
Parallelizable effort to tackle https://github.com/ChainSafe/lodestar/issues/885. Sets `strictNullChecks = true` in a single package so eventually it can be set in the root tsconfig.