### PR TITLE
Set strictNullChecks true in lodestar-params

### DIFF
--- a/packages/lodestar-params/tsconfig.json
+++ b/packages/lodestar-params/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "typeRoots": [
       "../../node_modules/@types"
-    ]
+    ],
+    "strictNullChecks": true
   }
 }


### PR DESCRIPTION
Parallelizable effort to tackle https://github.com/ChainSafe/lodestar/issues/885. Sets `strictNullChecks = true` in a single package so eventually it can be set in the root tsconfig.