### PR TITLE
Set strictNullChecks = true in easy packages

### DIFF
--- a/packages/lodestar-config/tsconfig.json
+++ b/packages/lodestar-config/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "typeRoots": [
       "../../node_modules/@types"
-    ]
+    ],
+    "strictNullChecks": true
   }
 }

--- a/packages/lodestar-params/tsconfig.json
+++ b/packages/lodestar-params/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "typeRoots": [
       "../../node_modules/@types"
-    ]
+    ],
+    "strictNullChecks": true
   }
 }

--- a/packages/lodestar-types/tsconfig.build.json
+++ b/packages/lodestar-types/tsconfig.build.json
@@ -7,7 +7,8 @@
     ],
     "outDir": "lib",
     /* Redirect output structure to the directory. */
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "strictNullChecks": true
     /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
   }
 }

--- a/packages/lodestar-types/tsconfig.json
+++ b/packages/lodestar-types/tsconfig.json
@@ -7,7 +7,8 @@
     ],
     "outDir": "lib",
     /* Redirect output structure to the directory. */
-    "rootDirs": ["./src","./test"]
+    "rootDirs": ["./src","./test"],
+    "strictNullChecks": true
     /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
   }
 }


### PR DESCRIPTION
Parallelizable effort to tackle https://github.com/ChainSafe/lodestar/issues/885. Sets `strictNullChecks = true` in a single package so eventually it can be set in the root tsconfig.