### PR TITLE
Update ssz dependency

### DIFF
--- a/packages/lodestar-beacon-state-transition/package.json
+++ b/packages/lodestar-beacon-state-transition/package.json
@@ -38,7 +38,7 @@
     "@chainsafe/bls": "2.0.0",
     "@chainsafe/lodestar-config": "^0.10.2",
     "@chainsafe/lodestar-utils": "^0.10.2",
-    "@chainsafe/ssz": "^0.6.10",
+    "@chainsafe/ssz": "^0.6.11",
     "bigint-buffer": "^1.1.5",
     "buffer-xor": "^2.0.2"
   },

--- a/packages/lodestar-cli/package.json
+++ b/packages/lodestar-cli/package.json
@@ -56,7 +56,7 @@
     "@chainsafe/lodestar-types": "^0.10.2",
     "@chainsafe/lodestar-utils": "^0.10.2",
     "@chainsafe/lodestar-validator": "^0.10.2",
-    "@chainsafe/ssz": "^0.6.10",
+    "@chainsafe/ssz": "^0.6.11",
     "@iarna/toml": "^2.2.3",
     "@types/lockfile": "^1.0.1",
     "bigint-buffer": "^1.1.5",

--- a/packages/lodestar-params/package.json
+++ b/packages/lodestar-params/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@types/js-yaml": "^3.12.2",
-    "@chainsafe/ssz": "^0.6.10",
+    "@chainsafe/ssz": "^0.6.11",
     "js-yaml": "^3.13.1"
   }
 }

--- a/packages/lodestar-spec-test-util/package.json
+++ b/packages/lodestar-spec-test-util/package.json
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "@chainsafe/lodestar-utils": "^0.10.2",
-    "@chainsafe/ssz": "^0.6.10",
+    "@chainsafe/ssz": "^0.6.11",
     "camelcase": "^5.3.1",
     "chai": "^4.2.0",
     "deepmerge": "^4.0.0",

--- a/packages/lodestar-types/package.json
+++ b/packages/lodestar-types/package.json
@@ -36,7 +36,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/lodestar-params": "^0.10.2",
-    "@chainsafe/ssz": "^0.6.10"
+    "@chainsafe/ssz": "^0.6.11"
   },
   "devDependencies": {
     "@types/chai": "4.2.0",

--- a/packages/lodestar-utils/package.json
+++ b/packages/lodestar-utils/package.json
@@ -36,7 +36,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/ssz": "^0.6.10",
+    "@chainsafe/ssz": "^0.6.11",
     "bigint-buffer": "^1.1.5",
     "camelcase": "^5.3.1",
     "chalk": "^2.4.2",

--- a/packages/lodestar-validator/package.json
+++ b/packages/lodestar-validator/package.json
@@ -48,7 +48,7 @@
     "@chainsafe/lodestar-config": "^0.10.2",
     "@chainsafe/lodestar-types": "^0.10.2",
     "@chainsafe/lodestar-utils": "^0.10.2",
-    "@chainsafe/ssz": "^0.6.10",
+    "@chainsafe/ssz": "^0.6.11",
     "axios": "^0.19.0",
     "axios-mock-adapter": "^1.17.0",
     "bigint-buffer": "^1.1.5",

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -50,7 +50,7 @@
     "@chainsafe/lodestar-utils": "^0.10.2",
     "@chainsafe/lodestar-validator": "^0.10.2",
     "@chainsafe/snappy-stream": "3.0.4",
-    "@chainsafe/ssz": "^0.6.10",
+    "@chainsafe/ssz": "^0.6.11",
     "@types/async": "^3.0.1",
     "abort-controller": "^3.0.0",
     "abortable-iterator": "^3.0.0",

--- a/packages/spec-test-runner/package.json
+++ b/packages/spec-test-runner/package.json
@@ -40,7 +40,7 @@
     "@chainsafe/lodestar-types": "^0.10.2",
     "@chainsafe/lodestar-utils": "^0.10.2",
     "@chainsafe/lodestar-validator": "^0.10.2",
-    "@chainsafe/ssz": "^0.6.10",
+    "@chainsafe/ssz": "^0.6.11",
     "@types/chai": "4.2.0",
     "@types/chai-as-promised": "^7.1.1",
     "@types/mocha": "^5.2.7",

--- a/packages/spec-test-runner/test/spec/ssz/util/testCases.ts
+++ b/packages/spec-test-runner/test/spec/ssz/util/testCases.ts
@@ -79,10 +79,13 @@ export function testStatic(type: keyof IBeaconSSZTypes): void {
           const structural = Type.deserialize(testCase.serialized_raw)
           // @ts-ignore
           const tree = Type.tree.deserialize(testCase.serialized_raw)
+          // @ts-ignore
+          const treeFromStructural = Type.tree.createValue(structural)
           expect(
             tree.serialize(),
             "tree serialization != structural serialization"
           ).to.deep.equal(Type.serialize(structural))
+          expect(Type.equals(tree, treeFromStructural), "tree != treeFromStructural")
           expect(expected.serialized.equals(Type.serialize(structural)))
           expect(expected.root.equals(Type.hashTreeRoot(structural)))
           expect(expected.serialized.equals(actual.serialized), "incorrect serialize").to.be.true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,10 +921,10 @@
   resolved "https://registry.yarnpkg.com/@chainsafe/eth2-spec-tests/-/eth2-spec-tests-0.12.1.tgz#8d172ebc40a4269e071bb20f607b3a5f4a557bc9"
   integrity sha512-M4XsIuNU/LG4FdExZRxgotcj2ePX2uMtfcTI736HZBYBioyilSh2/dk6NekwQcd7qP/eRlIZ2CrWYwneY0cM/A==
 
-"@chainsafe/persistent-merkle-tree@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.2.0.tgz#2b00ea7e18ec9440af54082abe8a596c7ec1135d"
-  integrity sha512-gOxAuUx0FAH0lZm4jDzUJOiFoIpug+SLnd1cumz1i/EdZlmcFIN0YEdqPq+HhN/4/qWhnJs52bY8pum82KMMaA==
+"@chainsafe/persistent-merkle-tree@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.2.1.tgz#38eb5fd5772fd256e94639d0621fa606addebab1"
+  integrity sha512-07Hi5QiogeTuwNiZXxg7PQnwNyEqV3ArfITpEloGJ8JVOHxQ2Tha1fo4oNBF54628vTDMcDpMVFGrfnIMsQnxg==
   dependencies:
     "@chainsafe/as-sha256" "^0.2.0"
 
@@ -940,13 +940,13 @@
     fast-crc32c "^1.0.1"
     snappy "^6.0.1"
 
-"@chainsafe/ssz@^0.6.10":
-  version "0.6.10"
-  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.6.10.tgz#2fe7bf17c4d8c644ae61b8d3b1a9c88cd009ab90"
-  integrity sha512-4tn7uxNg2g2uFMHhtq3ErGgZ8HKl7on0BgpTfePeOXB3+tBxk5z84BvhWP8cg5G5bawrQODKyJimRUWnSFJamw==
+"@chainsafe/ssz@^0.6.11":
+  version "0.6.11"
+  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.6.11.tgz#076c2aa72dce646ab8ceef8ef8f57f476e6120fa"
+  integrity sha512-g/EbsgnKh2H/DKmHmH606QcMhejwyGYTpuM5uJLPHOfNmY0joa9eYtgwOj1CKgXsurZZ1bhU9/BfpXIVqusC3g==
   dependencies:
     "@chainsafe/as-sha256" "^0.2.0"
-    "@chainsafe/persistent-merkle-tree" "^0.2.0"
+    "@chainsafe/persistent-merkle-tree" "^0.2.1"
     case "^1.6.3"
 
 "@ethersproject/abi@^5.0.0":


### PR DESCRIPTION
- Update ssz to 0.6.11 - faster structural => tree
- Add a structural => tree check in ssz spec tests