### PR TITLE
Sync: use forkchoice latest() instead of head()

### DIFF
--- a/packages/lodestar/src/chain/blocks/post.ts
+++ b/packages/lodestar/src/chain/blocks/post.ts
@@ -39,7 +39,7 @@ export function postProcess(
         if (computeEpochAtSlot(config, preSlot) < currentEpoch) {
           eventBus.emit(
             "processedCheckpoint",
-            {epoch: currentEpoch, root: forkChoice.getCanonicalBlockSummaryAtSlot(preSlot).blockRoot},
+            {epoch: currentEpoch, root: block.message.parentRoot},
           );
           // newly justified epoch
           if (preJustifiedEpoch < postStateContext.state.currentJustifiedCheckpoint.epoch) {

--- a/packages/lodestar/src/chain/forkChoice/arrayDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/arrayDag/lmdGhost.ts
@@ -322,6 +322,13 @@ export class ArrayDagLMDGHOST extends (EventEmitter as { new(): ForkChoiceEventE
     this.synced = true;
   }
 
+  public latest(): BlockSummary {
+    if (!this.nodes || this.nodes.length === 0) {
+      return null;
+    }
+    return this.toBlockSummary(this.nodes[this.nodes.length - 1]);
+  }
+
   public head(): BlockSummary {
     if (!this.headNode()) {
       return null;

--- a/packages/lodestar/src/chain/forkChoice/interface.ts
+++ b/packages/lodestar/src/chain/forkChoice/interface.ts
@@ -19,6 +19,7 @@ export interface ILMDGHOST extends ForkChoiceEventEmitter {
   addBlock(info: BlockSummary): void;
   addAttestation(blockRoot: Uint8Array, attester: ValidatorIndex, weight: Gwei): void;
   head(): BlockSummary;
+  latest(): BlockSummary;
   headBlockSlot(): Slot;
   headBlockRoot(): Uint8Array;
   headStateRoot(): Uint8Array;

--- a/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
@@ -263,6 +263,10 @@ export class StatefulDagLMDGHOST extends (EventEmitter as { new(): ForkChoiceEve
    * Best justified checkpoint.
    */
   private bestJustifiedCheckpoint: Checkpoint;
+  /**
+   * The lastest block summary
+   */
+  private latestBlockSummary: BlockSummary;
   private synced: boolean;
   private clock: IBeaconClock;
 
@@ -364,6 +368,9 @@ export class StatefulDagLMDGHOST extends (EventEmitter as { new(): ForkChoiceEve
     if (shouldCheckBestTarget) {
       this.ensureCorrectBestTargets();
     }
+    if (!this.latestBlockSummary || this.latestBlockSummary.slot < slot) {
+      this.latestBlockSummary = node.toBlockSummary();
+    }
   }
 
   public getNode(blockRootBuf: Uint8Array): Node {
@@ -404,6 +411,10 @@ export class StatefulDagLMDGHOST extends (EventEmitter as { new(): ForkChoiceEve
     });
 
     this.synced = true;
+  }
+
+  public latest(): BlockSummary {
+    return this.latestBlockSummary;
   }
 
   public head(): BlockSummary {

--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -65,7 +65,7 @@ export class FastSync
     this.chain.on("processedCheckpoint", this.checkSyncCompleted);
     this.chain.on("processedBlock", this.checkSyncProgress);
     this.syncTriggerSource = pushable<ISlotRange>();
-    this.blockImportTarget = this.chain.forkChoice.headBlockSlot();
+    this.blockImportTarget = this.chain.forkChoice.latest().slot;
     this.targetCheckpoint = getCommonFinalizedCheckpoint(
       this.config,
       this.network.getPeers().map((peer) => this.reps.getFromPeerId(peer))

--- a/packages/lodestar/src/sync/regular/interface.ts
+++ b/packages/lodestar/src/sync/regular/interface.ts
@@ -4,7 +4,8 @@ import {EventEmitter} from "events";
 import StrictEventEmitter from "strict-event-emitter-types";
 
 export interface IRegularSyncEvents {
-  syncCompleted: () => void;
+  findingBestPeer: () => void;
+  foundBestPeer: () => void;
 }
 
 export type RegularSyncEventEmitter = StrictEventEmitter<EventEmitter, IRegularSyncEvents>;

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -221,7 +221,7 @@ export function getBestHead(peers: PeerId[], reps: IReputationStore): {slot: num
     return latestStatus? {slot: latestStatus.headSlot, root: latestStatus.headRoot} : {slot: 0, root: ZERO_HASH};
   }).reduce((head, peerStatus) => {
     return peerStatus.slot > head.slot? peerStatus : head;
-  });
+  }, {slot: 0, root: ZERO_HASH});
 }
 
 // should add peer score later

--- a/packages/lodestar/test/unit/chain/forkChoice/arrayDag.test.ts
+++ b/packages/lodestar/test/unit/chain/forkChoice/arrayDag.test.ts
@@ -452,11 +452,11 @@ describe("ArrayDagLMDGHOST", () => {
     });
   });
 
-  describe("getAncestor", () => {
+  describe("getAncestor and latest", () => {
     /**
      * genesis - a - b -c
      */
-    it("should return correct ancestor", () => {
+    it("should return correct ancestor and latest", () => {
       addBlock(lmd, GENESIS_SLOT, genesis, genesisState, Buffer.alloc(32), {root: genesis, epoch: GENESIS_EPOCH}, {root: genesis, epoch: GENESIS_EPOCH});
       const slotA = 1 * config.params.SLOTS_PER_EPOCH;
       addBlock(lmd, slotA, blockA, stateA, genesis, {root: genesis, epoch: GENESIS_EPOCH}, {root: genesis, epoch: GENESIS_EPOCH});
@@ -468,6 +468,14 @@ describe("ArrayDagLMDGHOST", () => {
       expect(Buffer.from(lmd.getAncestor(blockC, slotA + 1))).to.be.deep.equal(blockA);
       expect(Buffer.from(lmd.getAncestor(genesis, GENESIS_SLOT))).to.be.deep.equal(genesis);
       expect(lmd.getAncestor(genesis, GENESIS_SLOT - 1)).to.be.equal(null);
+      expect(lmd.latest()).to.be.deep.equal({
+        slot: slotC,
+        blockRoot: blockC,
+        parentRoot: blockB,
+        stateRoot: stateC,
+        justifiedCheckpoint: {root: genesis, epoch: GENESIS_EPOCH},
+        finalizedCheckpoint: {root: genesis, epoch: GENESIS_EPOCH}
+      });
     });
   });
 

--- a/packages/lodestar/test/unit/sync/initial/fast.test.ts
+++ b/packages/lodestar/test/unit/sync/initial/fast.test.ts
@@ -2,7 +2,7 @@ import {describe} from "mocha";
 import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
 import {FastSync} from "../../../../src/sync/initial/fast";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {BeaconChain, IBeaconChain, ILMDGHOST, StatefulDagLMDGHOST} from "../../../../src/chain";
+import {BeaconChain, IBeaconChain, ILMDGHOST, StatefulDagLMDGHOST, BlockSummary} from "../../../../src/chain";
 import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {INetwork, Libp2pNetwork} from "../../../../src/network";
 import {ReputationStore} from "../../../../src/sync/IReputation";
@@ -36,7 +36,7 @@ describe("fast sync", function () {
   });
 
   it("no peers with finalized epoch", async function () {
-    forkChoiceStub.headBlockSlot.returns(0);
+    forkChoiceStub.latest.returns({slot: 0} as BlockSummary);
     const sync = new FastSync(
       {blockPerChunk: 5, maxSlotImport: 10, minPeers: 0},
       {
@@ -58,7 +58,7 @@ describe("fast sync", function () {
   it("should sync till target and end", function (done) {
     const chainEventEmitter = new EventEmitter();
     const forkChoiceStub = sinon.createStubInstance(StatefulDagLMDGHOST);
-    forkChoiceStub.headBlockSlot.returns(0);
+    forkChoiceStub.latest.returns({slot: 0} as BlockSummary);
     // @ts-ignore
     chainEventEmitter.forkChoice = forkChoiceStub;
     const statsStub = sinon.createStubInstance(SyncStats);
@@ -98,7 +98,7 @@ describe("fast sync", function () {
   it("should continue syncing if there is new target", function (done) {
     const chainEventEmitter = new EventEmitter();
     const forkChoiceStub = sinon.createStubInstance(StatefulDagLMDGHOST);
-    forkChoiceStub.headBlockSlot.returns(0);
+    forkChoiceStub.latest.returns({slot: 0} as BlockSummary);
     // @ts-ignore
     chainEventEmitter.forkChoice = forkChoiceStub;
     const statsStub = sinon.createStubInstance(SyncStats);

--- a/packages/lodestar/test/unit/sync/utils/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/sync.test.ts
@@ -23,6 +23,7 @@ import {ReqResp} from "../../../../src/network/reqResp";
 import {generateEmptySignedBlock} from "../../../utils/block";
 import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import PeerId from "peer-id";
+import {ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
 
 describe("sync utils", function () {
 
@@ -223,33 +224,43 @@ describe("sync utils", function () {
 
   });
 
-  it("should get best head and best peer", async () => {
-    const peer1 = await PeerId.create();
-    const peer2 = await PeerId.create();
-    const peer3 = await PeerId.create();
-    const peers = [peer1, peer2, peer3];
-    const reps = new ReputationStore();
-    reps.add(peer1.toB58String());
-    reps.add(peer2.toB58String());
-    reps.add(peer3.toB58String());
-    reps.get(peer1.toB58String()).latestStatus = {
-      forkDigest: Buffer.alloc(0),
-      finalizedRoot: Buffer.alloc(0),
-      finalizedEpoch: 0,
-      headRoot: Buffer.alloc(32, 1),
-      headSlot: 1000
-    };
-    reps.get(peer2.toB58String()).latestStatus = {
-      forkDigest: Buffer.alloc(0),
-      finalizedRoot: Buffer.alloc(0),
-      finalizedEpoch: 0,
-      headRoot: Buffer.alloc(32, 2),
-      headSlot: 2000
-    };
+  describe("getBestHead and getBestPeer", () => {
+    it("should get best head and best peer", async () => {
+      const peer1 = await PeerId.create();
+      const peer2 = await PeerId.create();
+      const peer3 = await PeerId.create();
+      const peers = [peer1, peer2, peer3];
+      const reps = new ReputationStore();
+      reps.add(peer1.toB58String());
+      reps.add(peer2.toB58String());
+      reps.add(peer3.toB58String());
+      reps.get(peer1.toB58String()).latestStatus = {
+        forkDigest: Buffer.alloc(0),
+        finalizedRoot: Buffer.alloc(0),
+        finalizedEpoch: 0,
+        headRoot: Buffer.alloc(32, 1),
+        headSlot: 1000
+      };
+      reps.get(peer2.toB58String()).latestStatus = {
+        forkDigest: Buffer.alloc(0),
+        finalizedRoot: Buffer.alloc(0),
+        finalizedEpoch: 0,
+        headRoot: Buffer.alloc(32, 2),
+        headSlot: 2000
+      };
 
-    expect(getBestHead(peers, reps)).to.be.deep.equal({slot: 2000, root: Buffer.alloc(32, 2)});
-    expect(getBestPeer(config, peers, reps)).to.be.equal(peer2);
+      expect(getBestHead(peers, reps)).to.be.deep.equal({slot: 2000, root: Buffer.alloc(32, 2)});
+      expect(getBestPeer(config, peers, reps)).to.be.equal(peer2);
+    });
+
+    it("should handle no peer", () => {
+      const reps = new ReputationStore();
+      expect(getBestHead([], reps)).to.be.deep.equal({slot: 0, root: ZERO_HASH});
+      expect(getBestPeer(config, [], reps)).to.be.undefined;
+    });
   });
+
+
 
 });
 


### PR DESCRIPTION
+ part of #1234 
+ The current situation of Altona is head() is way behind latest() so Regular Sync can't proceed after start. So for Sync, we start from `latest()` (new) instead of `head()`
```
not received "processedCheckpoint" because all of the received blocks already exists, meaning our lastSlot is greater than headSlot and when we start Regular Sync, we always start from headSlot -> we receive existing blocks in our chain -> not passed packages/lodestar/src/chain/blocks/validate.ts -> processedBlock not emitted -> Regular Sync suspended.
```
+ Also only sync peer status if needed in Regular Sync to avoid abusing peers
+ Also quick fix #1236 as I saw it again
