### PR TITLE
fix ethers wallet provider

### DIFF
--- a/packages/lodestar-cli/src/util/ethers.ts
+++ b/packages/lodestar-cli/src/util/ethers.ts
@@ -23,8 +23,7 @@ export async function getEthersSigner({
     const eth1Provider = rpcUrl
       ? new ethers.providers.JsonRpcProvider(rpcUrl)
       : ethers.getDefaultProvider();
-    const providerWallet = wallet.connect(eth1Provider);
-    return providerWallet;
+    return wallet.connect(eth1Provider);
   }
 
   if (rpcUrl) {

--- a/packages/lodestar-cli/src/util/ethers.ts
+++ b/packages/lodestar-cli/src/util/ethers.ts
@@ -23,8 +23,8 @@ export async function getEthersSigner({
     const eth1Provider = rpcUrl
       ? new ethers.providers.JsonRpcProvider(rpcUrl)
       : ethers.getDefaultProvider();
-    wallet.connect(eth1Provider);
-    return wallet;
+    const providerWallet = wallet.connect(eth1Provider);
+    return providerWallet;
   }
 
   if (rpcUrl) {


### PR DESCRIPTION
`.connect()` returns a new instance and does not modify the original wallet.