### PR TITLE
Fix testnet params generation in init

### DIFF
--- a/packages/lodestar-cli/src/cmds/beacon/options.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/options.ts
@@ -1,6 +1,6 @@
 import {Options} from "yargs";
 import {IGlobalArgs} from "../../options";
-import {beaconNodeOptions, IBeaconNodeOptions} from "../../options";
+import {beaconNodeOptions, paramsOptions, IBeaconNodeOptions} from "../../options";
 import {defaultBeaconPaths, IBeaconPaths} from "./paths";
 
 export type IBeaconOptions =
@@ -14,6 +14,7 @@ export type IBeaconOptions =
 
 export const beaconOptions: {[k: string]: Options} = {
   ...beaconNodeOptions,
+  ...paramsOptions,
 
   genesisStateFile: {
     description: "Genesis state in ssz-encoded format",

--- a/packages/lodestar-cli/src/cmds/init/init.ts
+++ b/packages/lodestar-cli/src/cmds/init/init.ts
@@ -6,7 +6,7 @@ import {initBeaconConfig} from "../../config/beacon";
 import {mkdir, getBeaconConfig} from "../../util";
 import {initPeerId, initEnr, readPeerId} from "../../network";
 import {getTestnetConfig, getGenesisFileUrl, downloadFile, fetchBootnodes, getTestnetParamsUrl} from "../../testnets";
-import {writeParamsConfig, appendTestnetParamsConfig} from "../../config/params";
+import {writeParamsConfig} from "../../config/params";
 import {getBeaconPaths} from "../beacon/paths";
 
 /**
@@ -42,7 +42,6 @@ export async function initHandler(options: IInitOptions): Promise<void> {
     const paramsUrl = getTestnetParamsUrl(options.testnet);
     if (paramsUrl) {
       await downloadFile(options.paramsFile, paramsUrl);
-      await appendTestnetParamsConfig(options.paramsFile);
     }
   }
 

--- a/packages/lodestar-cli/src/config/params.ts
+++ b/packages/lodestar-cli/src/config/params.ts
@@ -38,13 +38,3 @@ export async function getMergedIBeaconConfig(
     ...options,
   });
 }
-
-/**
- * Adds required params not found in the downloaded config
- */
-export async function appendTestnetParamsConfig(filename: string): Promise<void> {
-  const params = await readParamsConfig(filename);
-  if (params.DEPOSIT_CHAIN_ID === undefined) params.DEPOSIT_CHAIN_ID = 5;
-  if (params.DEPOSIT_NETWORK_ID === undefined) params.DEPOSIT_NETWORK_ID = 5;
-  await writeParams(filename, params as IBeaconParams);
-}

--- a/packages/lodestar-cli/src/testnets/altona.ts
+++ b/packages/lodestar-cli/src/testnets/altona.ts
@@ -5,6 +5,10 @@ import {IBeaconNodeOptionsPartial} from "../options";
 // Use a Typescript file instead of JSON so it's automatically included in the built files
 
 export const altonaConfig: IBeaconNodeOptionsPartial = {
+  params: {
+    DEPOSIT_CHAIN_ID: 5,
+    DEPOSIT_NETWORK_ID: 5,
+  },
   api: {
     rest: {
       enabled: true,

--- a/packages/lodestar-cli/src/testnets/medalla.ts
+++ b/packages/lodestar-cli/src/testnets/medalla.ts
@@ -5,6 +5,10 @@ import {IBeaconNodeOptionsPartial} from "../options";
 // Use a Typescript file instead of JSON so it's automatically included in the built files
 
 export const medallaConfig: IBeaconNodeOptionsPartial = {
+  params: {
+    DEPOSIT_CHAIN_ID: 5,
+    DEPOSIT_NETWORK_ID: 5,
+  },
   api: {
     rest: {
       enabled: true,


### PR DESCRIPTION
`appendTestnetParamsConfig` did not work, because `readParamsConfig` and `writeParamsConfig` are not inverses of each other. Reading doesn't return `IBeaconParams`, just a `Record<string, unknown>`. This lets us merge params from different sources before a single conversion to `IBeaconParams`. Current behavior generates config.yaml with invalid hex strings.

Instead of patching the testnet config.yaml files we download, add params to the testnet beacon.config.json.