### PR TITLE
Validator deposit: fix path to config.yaml

### DIFF
--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/deposit.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/deposit.ts
@@ -71,7 +71,7 @@ export async function handler(options: IAccountValidatorDepositOptions): Promise
   await initCmd(options as unknown as IInitOptions);
   const validatorName = options.validator;
   const accountPaths = getAccountPaths(options);
-  const config = await getMergedIBeaconConfig(options.preset, options.paramsFile, options.params);
+  const config = await getMergedIBeaconConfig(options.preset, accountPaths.paramsFile, options.params);
 
   if (!config.params.DEPOSIT_CONTRACT_ADDRESS)
     throw new YargsError("deposit_contract not in configuration");


### PR DESCRIPTION
resolves #1321 

With this change I can do a deposit using `--testnet medalla`
```
Debugger attached.
Starting 1 deposits
Submitted deposit. txHash: 0xa06dbc3a79df97fa12a0c60df493c0ac53882c75059d91012cc5031e2a9160e9
Confirmed deposit. blocknumber: 3163402
Waiting for the debugger to disconnect...
```