### PR TITLE
Regular Sync: Emit syncCompleted if head is up to date

### DIFF
--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -61,6 +61,7 @@ export class NaiveRegularSync extends (EventEmitter as { new(): RegularSyncEvent
     const currentSlot = getCurrentSlot(this.config, state.genesisTime);
     if (headSlot >= currentSlot) {
       this.logger.info(`Regular Sync: node is up to date, headSlot=${headSlot}`);
+      this.emit("syncCompleted");
       return;
     }
     this.currentTarget = headSlot;

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -62,6 +62,7 @@ export class NaiveRegularSync extends (EventEmitter as { new(): RegularSyncEvent
     if (headSlot >= currentSlot) {
       this.logger.info(`Regular Sync: node is up to date, headSlot=${headSlot}`);
       this.emit("syncCompleted");
+      await this.stop();
       return;
     }
     this.currentTarget = headSlot;

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -132,7 +132,7 @@ export class BeaconSync implements IBeaconSync {
     if(this.mode === SyncMode.STOPPED) return;
     this.mode = SyncMode.REGULAR_SYNCING;
     await this.initialSync.stop();
-    this.startSyncTimer(this.config.params.SECONDS_PER_SLOT * 1000);
+    this.startSyncTimer(3 * this.config.params.SECONDS_PER_SLOT * 1000);
     this.regularSync.on("syncCompleted", this.stopSyncTimer.bind(this));
     await this.gossip.start();
     await this.regularSync.start();

--- a/packages/lodestar/test/e2e/noEth1Sim.test.ts
+++ b/packages/lodestar/test/e2e/noEth1Sim.test.ts
@@ -29,7 +29,7 @@ describe("no eth1 sim (multi-node test)", function () {
       for (let i=0; i<nodeCount; i++) {
         const node = await getDevBeaconNode({
           params: beaconParams,
-          options: {sync: {minPeers: 0}},
+          options: {sync: {minPeers: 1}},
           validatorCount: nodeCount * validatorsPerNode,
           genesisTime,
           logger: logger.child({module: `Node ${i}`})


### PR DESCRIPTION
Currently we're before medalla genesis.
Regular sync is started and it notices it's up to date but it didn't emit `syncCompleted` event and peer status timer just continue to run

## Fix:
+ Emit `syncCompleted` in that case
+ Make timer to run per 3 slots instead of per slot