### PR TITLE
Accept validator paths with pubkey prefixed and not prefixed

### DIFF
--- a/packages/lodestar-cli/src/util/format.ts
+++ b/packages/lodestar-cli/src/util/format.ts
@@ -1,0 +1,6 @@
+/**
+ * 0x prefix a string if not prefixed already
+ */
+export function add0xPrefix(hex: string): string {
+  if (!hex.startsWith("0x")) return `0x${hex}`;
+}

--- a/packages/lodestar-cli/src/util/fs.ts
+++ b/packages/lodestar-cli/src/util/fs.ts
@@ -1,5 +1,4 @@
 import fs from "fs";
-import {stripOffNewlines} from "./stripOffNewlines";
 
 /**
  * Create a file with `600 (-rw-------)` permissions
@@ -18,23 +17,3 @@ export function ensureDirExists(dirPath: string): void {
   if (!fs.existsSync(dirPath)) fs.mkdirSync(dirPath, {recursive: true});
 }
 
-/**
- * Utility to read file as UTF8 and strip any trailing new lines
- * All passphrase files must be read with this function
- */
-export function readPassphraseFile(passphraseFile: string): string {
-  const data = fs.readFileSync(passphraseFile, "utf8");
-  const passphrase = stripOffNewlines(data);
-
-  // Validate the passphraseFile contents to prevent the user to create a wallet with a password
-  // that is the contents a random unintended file
-  try {
-    if (passphrase.includes("\n")) throw Error("contains multiple lines");
-    // 512 is an arbitrary high number that should be longer than any actual passphrase
-    if (passphrase.length > 512) throw Error("is really long");
-  } catch (e) {
-    throw new Error(`passphraseFile ${passphraseFile} ${e.message}. Is this a well-formated passphraseFile?`);
-  }
-
-  return passphrase;
-}

--- a/packages/lodestar-cli/src/util/index.ts
+++ b/packages/lodestar-cli/src/util/index.ts
@@ -4,6 +4,7 @@ export * from "./ethers";
 export * from "./fs";
 export * from "./file";
 export * from "./graffiti";
+export * from "./passphrase";
 export * from "./paths";
 export * from "./randomPassword";
 export * from "./recursivelyFind";

--- a/packages/lodestar-cli/src/util/passphrase.ts
+++ b/packages/lodestar-cli/src/util/passphrase.ts
@@ -1,0 +1,46 @@
+import fs from "fs";
+import {stripOffNewlines} from "./stripOffNewlines";
+import {writeFile600Perm} from "./fs";
+import {getValidatorPassphrasePath} from "../validatorDir/paths";
+
+/**
+ * Utility to read file as UTF8 and strip any trailing new lines
+ * All passphrase files must be read with this function
+ */
+export function readPassphraseFile(passphraseFile: string): string {
+  const data = fs.readFileSync(passphraseFile, "utf8");
+  const passphrase = stripOffNewlines(data);
+
+  // Validate the passphraseFile contents to prevent the user to create a wallet with a password
+  // that is the contents a random unintended file
+  try {
+    if (passphrase.includes("\n")) throw Error("contains multiple lines");
+    // 512 is an arbitrary high number that should be longer than any actual passphrase
+    if (passphrase.length > 512) throw Error("is really long");
+  } catch (e) {
+    throw new Error(
+      `passphraseFile ${passphraseFile} ${e.message}. Is this a well-formated passphraseFile?`
+    );
+  }
+
+  return passphrase;
+}
+
+export function readValidatorPassphrase({secretsDir, pubkey}: {secretsDir: string; pubkey: string}): string {
+  const notPrefixedPath = getValidatorPassphrasePath({secretsDir, pubkey});
+  const prefixedPath = getValidatorPassphrasePath({secretsDir, pubkey, prefixed: true});
+  if (fs.existsSync(notPrefixedPath)) {
+    return readPassphraseFile(notPrefixedPath);
+  } else {
+    return readPassphraseFile(prefixedPath);
+  }
+}
+
+export function writeValidatorPassphrase(
+  {secretsDir, pubkey, passphrase}: {secretsDir: string; pubkey: string; passphrase: string}
+): void {
+  writeFile600Perm(
+    getValidatorPassphrasePath({secretsDir, pubkey, prefixed: true}),
+    passphrase
+  );
+}

--- a/packages/lodestar-cli/src/validatorDir/ValidatorDir.ts
+++ b/packages/lodestar-cli/src/validatorDir/ValidatorDir.ts
@@ -5,7 +5,7 @@ import {Keypair, PrivateKey} from "@chainsafe/bls";
 import {Keystore} from "@chainsafe/bls-keystore";
 import {DepositData} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {stripOffNewlines, YargsError} from "../util";
+import {YargsError, readValidatorPassphrase} from "../util";
 import {decodeEth1TxData} from "../depositContract/depositData";
 import {
   VOTING_KEYSTORE_FILE,
@@ -114,8 +114,7 @@ export class ValidatorDir {
   */
   unlockKeypair(keystorePath: string, secretsDir: string): Keypair {
     const keystore = Keystore.fromJSON(fs.readFileSync(keystorePath, "utf8"));
-    const passwordPath = path.join(secretsDir, keystore.pubkey);
-    const password = stripOffNewlines(fs.readFileSync(passwordPath, "utf8"));
+    const password = readValidatorPassphrase({secretsDir, pubkey: keystore.pubkey});
     const privKey = keystore.decrypt(password);
     return new Keypair(PrivateKey.fromBytes(privKey));
   }

--- a/packages/lodestar-cli/src/validatorDir/paths.ts
+++ b/packages/lodestar-cli/src/validatorDir/paths.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { add0xPrefix } from "../util/format";
+import {add0xPrefix} from "../util/format";
 
 export const VOTING_KEYSTORE_FILE = "voting-keystore.json";
 export const WITHDRAWAL_KEYSTORE_FILE = "withdrawal-keystore.json";

--- a/packages/lodestar-cli/src/validatorDir/paths.ts
+++ b/packages/lodestar-cli/src/validatorDir/paths.ts
@@ -1,3 +1,6 @@
+import path from "path";
+import { add0xPrefix } from "../util/format";
+
 export const VOTING_KEYSTORE_FILE = "voting-keystore.json";
 export const WITHDRAWAL_KEYSTORE_FILE = "withdrawal-keystore.json";
 export const ETH1_DEPOSIT_DATA_FILE = "eth1-deposit-data.rlp";
@@ -7,3 +10,17 @@ export const ETH1_DEPOSIT_TX_HASH_FILE = "eth1-deposit-tx-hash.txt";
  * The file used for indicating if a directory is in-use by another process.
  */
 export const LOCK_FILE = ".lock";
+
+// Dynamic paths computed from the validator pubkey
+
+export function getValidatorDirPath(
+  {keystoresDir, pubkey, prefixed}: {keystoresDir: string; pubkey: string; prefixed?: boolean}
+): string {
+  return path.join(keystoresDir, prefixed ? add0xPrefix(pubkey) : pubkey);
+}
+
+export function getValidatorPassphrasePath(
+  {secretsDir, pubkey, prefixed}: {secretsDir: string; pubkey: string; prefixed?: boolean}
+): string {
+  return path.join(secretsDir, prefixed ? add0xPrefix(pubkey) : pubkey);
+}


### PR DESCRIPTION
Fixes an inconsistency introduced in https://github.com/ChainSafe/lodestar/pull/1303 where the validators secrets are stored in `secretsDir/0x${pubkey}` while other parts of the code expect them to be at `secretsDir/${pubkey}`

This PR adds utilities to compute validator paths to prevent inconsistencies. It prefers to prefix with 0x the pubkey for all paths, but accepts both formats.