### PR TITLE
prevent undefined being returned in add0xPrefix

### DIFF
--- a/packages/lodestar-cli/src/util/format.ts
+++ b/packages/lodestar-cli/src/util/format.ts
@@ -2,5 +2,9 @@
  * 0x prefix a string if not prefixed already
  */
 export function add0xPrefix(hex: string): string {
-  if (!hex.startsWith("0x")) return `0x${hex}`;
+  if (!hex.startsWith("0x")) {
+    return `0x${hex}`;
+  } else {
+    return hex;
+  }
 }


### PR DESCRIPTION
-prevents `undefined` from being returned in in the `add0xPrefix`, which is used for joining validator paths together, which can produce the following error:

``` 
✖ TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at validateString (internal/validators.js:120:11)
    at Object.join (path.js:1039:7)
    at getValidatorDirPath (/home/seraph/work/ChainSafe/lodestar/packages/lodestar-cli/lib/validatorDir/paths.js:39:24)
    at ValidatorDirBuilder.build (/home/seraph/work/ChainSafe/lodestar/packages/lodestar-cli/lib/validatorDir/ValidatorDirBuilder.js:58:48)
    at Object.handler (/home/seraph/work/ChainSafe/lodestar/packages/lodestar-cli/lib/cmds/account/cmds/validator/create.js:86:25)
```