### PR TITLE
Revert strict yargs

### DIFF
--- a/packages/lodestar-cli/src/index.ts
+++ b/packages/lodestar-cli/src/index.ts
@@ -31,7 +31,6 @@ yargs
   .epilogue(bottomBanner)
   .alias("h", "help")
   .alias("v", "version")
-  .strict()
   .recommendCommands()
   .help()
   .wrap(yargs.terminalWidth())


### PR DESCRIPTION
Yargs `strict` currently creates an issue for `--options.likeThis`. Reverting until we find a better solution

Reproduce:
```bash
$ lodestar beacon --testnet medalla --metrics.enabled
 ✖ Unknown argument: metrics