### PR TITLE
Use readOnlyEntries to build IFlatValidator

### DIFF
--- a/packages/lodestar-beacon-state-transition/package.json
+++ b/packages/lodestar-beacon-state-transition/package.json
@@ -38,7 +38,7 @@
     "@chainsafe/bls": "2.0.0",
     "@chainsafe/lodestar-config": "^0.11.0",
     "@chainsafe/lodestar-utils": "^0.11.0",
-    "@chainsafe/ssz": "^0.6.11",
+    "@chainsafe/ssz": "^0.6.12",
     "bigint-buffer": "^1.1.5",
     "buffer-xor": "^2.0.2"
   },

--- a/packages/lodestar-beacon-state-transition/src/fast/util/flatValidator.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/flatValidator.ts
@@ -1,3 +1,4 @@
+import {readOnlyEntries} from "@chainsafe/ssz";
 import {Gwei, Epoch, Validator} from "@chainsafe/lodestar-types";
 
 /**
@@ -12,15 +13,15 @@ export interface IFlatValidator {
   withdrawableEpoch: Epoch;
 }
 
+/**
+ * Convert a Validator (most likely with a tree-backing)
+ * into a IFlatValidator
+ */
 export function createIFlatValidator(v: Validator): IFlatValidator {
-  return {
-    effectiveBalance: v.effectiveBalance,
-    slashed: v.slashed,
-    activationEligibilityEpoch: v.activationEligibilityEpoch,
-    activationEpoch: v.activationEpoch,
-    exitEpoch: v.exitEpoch,
-    withdrawableEpoch: v.withdrawableEpoch,
-  };
+  return readOnlyEntries(v).reduce((flat, [k, v]) => {
+    flat[k] = v;
+    return flat;
+  }, {} as Record<string, Validator[keyof Validator]>) as unknown as IFlatValidator;
 }
 
 export function isActiveIFlatValidator(v: IFlatValidator, epoch: Epoch): boolean {

--- a/packages/lodestar-cli/package.json
+++ b/packages/lodestar-cli/package.json
@@ -56,7 +56,7 @@
     "@chainsafe/lodestar-types": "^0.11.0",
     "@chainsafe/lodestar-utils": "^0.11.0",
     "@chainsafe/lodestar-validator": "^0.11.0",
-    "@chainsafe/ssz": "^0.6.11",
+    "@chainsafe/ssz": "^0.6.12",
     "@iarna/toml": "^2.2.3",
     "@types/lockfile": "^1.0.1",
     "bigint-buffer": "^1.1.5",

--- a/packages/lodestar-params/package.json
+++ b/packages/lodestar-params/package.json
@@ -48,7 +48,7 @@
     "mocha": "^6.2.2"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^0.6.11",
+    "@chainsafe/ssz": "^0.6.12",
     "@types/js-yaml": "^3.12.2",
     "js-yaml": "^3.13.1"
   }

--- a/packages/lodestar-spec-test-util/package.json
+++ b/packages/lodestar-spec-test-util/package.json
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "@chainsafe/lodestar-utils": "^0.11.0",
-    "@chainsafe/ssz": "^0.6.11",
+    "@chainsafe/ssz": "^0.6.12",
     "camelcase": "^5.3.1",
     "chai": "^4.2.0",
     "deepmerge": "^4.0.0",

--- a/packages/lodestar-types/package.json
+++ b/packages/lodestar-types/package.json
@@ -36,7 +36,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/lodestar-params": "^0.11.0",
-    "@chainsafe/ssz": "^0.6.11"
+    "@chainsafe/ssz": "^0.6.12"
   },
   "devDependencies": {
     "@types/chai": "4.2.0",

--- a/packages/lodestar-utils/package.json
+++ b/packages/lodestar-utils/package.json
@@ -36,7 +36,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/ssz": "^0.6.11",
+    "@chainsafe/ssz": "^0.6.12",
     "bigint-buffer": "^1.1.5",
     "camelcase": "^5.3.1",
     "chalk": "^2.4.2",

--- a/packages/lodestar-validator/package.json
+++ b/packages/lodestar-validator/package.json
@@ -48,7 +48,7 @@
     "@chainsafe/lodestar-config": "^0.11.0",
     "@chainsafe/lodestar-types": "^0.11.0",
     "@chainsafe/lodestar-utils": "^0.11.0",
-    "@chainsafe/ssz": "^0.6.11",
+    "@chainsafe/ssz": "^0.6.12",
     "axios": "^0.19.0",
     "axios-mock-adapter": "^1.17.0",
     "bigint-buffer": "^1.1.5",

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -50,7 +50,7 @@
     "@chainsafe/lodestar-utils": "^0.11.0",
     "@chainsafe/lodestar-validator": "^0.11.0",
     "@chainsafe/snappy-stream": "3.0.4",
-    "@chainsafe/ssz": "^0.6.11",
+    "@chainsafe/ssz": "^0.6.12",
     "@types/async": "^3.0.1",
     "@types/datastore-level": "^1.1.1",
     "abort-controller": "^3.0.0",

--- a/packages/spec-test-runner/package.json
+++ b/packages/spec-test-runner/package.json
@@ -40,7 +40,7 @@
     "@chainsafe/lodestar-types": "^0.11.0",
     "@chainsafe/lodestar-utils": "^0.11.0",
     "@chainsafe/lodestar-validator": "^0.11.0",
-    "@chainsafe/ssz": "^0.6.11",
+    "@chainsafe/ssz": "^0.6.12",
     "@types/chai": "4.2.0",
     "@types/chai-as-promised": "^7.1.1",
     "@types/mocha": "^5.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,10 +941,10 @@
     fast-crc32c "^1.0.1"
     snappy "^6.0.1"
 
-"@chainsafe/ssz@^0.6.11":
-  version "0.6.11"
-  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.6.11.tgz#076c2aa72dce646ab8ceef8ef8f57f476e6120fa"
-  integrity sha512-g/EbsgnKh2H/DKmHmH606QcMhejwyGYTpuM5uJLPHOfNmY0joa9eYtgwOj1CKgXsurZZ1bhU9/BfpXIVqusC3g==
+"@chainsafe/ssz@^0.6.12":
+  version "0.6.12"
+  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.6.12.tgz#5b6352d483f1bb887800b42173133a9ef55f58a3"
+  integrity sha512-TuqTqULShmXLU7KTFPMVhbKOWvzzsU3lu4D19ezKa1yvxsl6Re+K1VsVE/ck6SNkFJ+pPm3ELmba08NbnkdT1A==
   dependencies:
     "@chainsafe/as-sha256" "^0.2.0"
     "@chainsafe/persistent-merkle-tree" "^0.2.1"


### PR DESCRIPTION
Depends on https://github.com/ChainSafe/ssz/pull/59 and subsequent release

Iterate at depth through each tree-backed validator to create `IFlatValidator`s for epoch transition calculations.
Speeds up epoch transition by ~100ms on Medalla, from ~800ms to ~700ms