### PR TITLE
Align libp2p+discv5 ports

### DIFF
--- a/packages/lodestar-cli/src/testnets/medalla.ts
+++ b/packages/lodestar-cli/src/testnets/medalla.ts
@@ -40,6 +40,6 @@ export const medallaConfig: IBeaconNodeOptionsPartial = {
     },
     maxPeers: 25,
     bootnodes: [],
-    multiaddrs: ["/ip4/0.0.0.0/tcp/30607"],
+    multiaddrs: ["/ip4/0.0.0.0/tcp/9000"],
   },
 };

--- a/packages/lodestar/src/network/options.ts
+++ b/packages/lodestar/src/network/options.ts
@@ -13,10 +13,10 @@ export interface INetworkOptions {
 
 const config: INetworkOptions = {
   maxPeers: 25,
-  multiaddrs: ["/ip4/0.0.0.0/tcp/30606"],
+  multiaddrs: ["/ip4/0.0.0.0/tcp/9000"],
   bootnodes: [],
   discv5: {
-    bindAddr: "/ip4/0.0.0.0/udp/5500",
+    bindAddr: "/ip4/0.0.0.0/udp/9000",
     enr: new ENR(),
     bootEnrs: [],
   },


### PR DESCRIPTION
Perhaps we should chose a different port, less likely to be already in use?