### PR TITLE
Set strictNullChecks true in lodestar - part 2

### DIFF
--- a/packages/lodestar/src/chain/attestation.ts
+++ b/packages/lodestar/src/chain/attestation.ts
@@ -106,10 +106,9 @@ export class AttestationProcessor implements IAttestationProcessor {
       "attestation is not targeting current epoch"
     );
     const block = this.forkChoice.getBlockSummaryByBlockRoot(attestation.data.beaconBlockRoot.valueOf() as Uint8Array);
-    assert.true(
-      !!block,
-      `The block of attestation data ${toHexString(attestation.data.beaconBlockRoot)} does not exist`
-    );
+    if (block === null) {
+      throw Error(`The block of attestation data ${toHexString(attestation.data.beaconBlockRoot)} does not exist`);
+    }
     const targetSlot = computeStartSlotAtEpoch(this.config, target.epoch);
     const ancestor = this.forkChoice.getAncestor(attestation.data.beaconBlockRoot as Uint8Array, targetSlot);
     assert.true(

--- a/packages/lodestar/src/chain/blocks/post.ts
+++ b/packages/lodestar/src/chain/blocks/post.ts
@@ -37,10 +37,13 @@ export function postProcess(
         const preJustifiedEpoch = preStateContext.state.currentJustifiedCheckpoint.epoch;
         const currentEpoch = computeEpochAtSlot(config, postStateContext.state.slot);
         if (computeEpochAtSlot(config, preSlot) < currentEpoch) {
-          eventBus.emit(
-            "processedCheckpoint",
-            {epoch: currentEpoch, root: forkChoice.getCanonicalBlockSummaryAtSlot(preSlot).blockRoot},
-          );
+          const blockSummary = forkChoice.getCanonicalBlockSummaryAtSlot(preSlot);
+          if (blockSummary) {
+            eventBus.emit(
+              "processedCheckpoint",
+              {epoch: currentEpoch, root: blockSummary.blockRoot},
+            );
+          }
           // newly justified epoch
           if (preJustifiedEpoch < postStateContext.state.currentJustifiedCheckpoint.epoch) {
             newJustifiedEpoch(logger, metrics, eventBus, postStateContext.state);

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -328,7 +328,6 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     // add justified block to forkchoice so "this.justified" in forkchoice really map to a block
     if (isStateNotGenesis) {
       const preJustifiedBlock = await this.db.blockArchive.getByRoot(lastKnownState.currentJustifiedCheckpoint.root);
-      if (!preJustifiedBlock) throw Error("lastJustifiedBlock not in db");
       let preFinalizedBlocks = await this.db.blockArchive.values({
         gt: preJustifiedBlock.message.slot, lt: finalizedSlot});
       preFinalizedBlocks = sortBlocks([preJustifiedBlock, ...preFinalizedBlocks]);

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -328,7 +328,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     // add justified block to forkchoice so "this.justified" in forkchoice really map to a block
     if (isStateNotGenesis) {
       const preJustifiedBlock = await this.db.blockArchive.getByRoot(lastKnownState.currentJustifiedCheckpoint.root);
-      if (!preJustifiedBlock) throw Error("lastKnownState not in db");
+      if (!preJustifiedBlock) throw Error("lastJustifiedBlock not in db");
       let preFinalizedBlocks = await this.db.blockArchive.values({
         gt: preJustifiedBlock.message.slot, lt: finalizedSlot});
       preFinalizedBlocks = sortBlocks([preJustifiedBlock, ...preFinalizedBlocks]);

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -85,7 +85,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
     this.eth1 = eth1;
     this.logger = logger;
     this.metrics = metrics;
-    this.forkChoice = forkChoice || new ArrayDagLMDGHOST(config);
+    this.forkChoice = forkChoice || new ArrayDagLMDGHOST(config) as ILMDGHOST;
     this.chainId = 0; // TODO make this real
     this.networkId = BigInt(0); // TODO make this real
     this.attestationProcessor = new AttestationProcessor(this, this.forkChoice, {config, db, logger});

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -63,7 +63,7 @@ export class BeaconChain extends (EventEmitter as { new(): ChainEventEmitter }) 
   public forkChoice: ILMDGHOST;
   public chainId: Uint16;
   public networkId: Uint64;
-  public clock: IBeaconClock;
+  public clock?: IBeaconClock;
   private readonly config: IBeaconConfig;
   private readonly db: IBeaconDb;
   private readonly eth1: IEth1Notifier;

--- a/packages/lodestar/src/chain/factory/attestation/index.ts
+++ b/packages/lodestar/src/chain/factory/attestation/index.ts
@@ -1,4 +1,4 @@
-import {TreeBacked} from "@chainsafe/ssz";
+import {TreeBacked, List} from "@chainsafe/ssz";
 import {Attestation, BeaconState, Slot, ValidatorIndex, CommitteeIndex} from "@chainsafe/lodestar-types";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 
@@ -16,7 +16,7 @@ export async function assembleAttestation(
   if(committee.find((c) => c === validatorIndex) === undefined) {
     throw new Error("Validator not in given committee");
   }
-  const aggregationBits = getAggregationBits(committee, validatorIndex);
+  const aggregationBits = getAggregationBits(committee, validatorIndex) as List<boolean>;
   const data = await assembleAttestationData(epochCtx.config, state, headBlockRoot, slot, index);
   return {
     aggregationBits,

--- a/packages/lodestar/src/chain/factory/block/body.ts
+++ b/packages/lodestar/src/chain/factory/block/body.ts
@@ -2,13 +2,23 @@
  * @module chain/blockAssembly
  */
 
-import {BeaconBlockBody, BeaconState, Bytes96, Bytes32} from "@chainsafe/lodestar-types";
+import {
+  BeaconBlockBody,
+  BeaconState,
+  Bytes96,
+  Bytes32,
+  ProposerSlashing,
+  AttesterSlashing,
+  Attestation,
+  Deposit,
+  SignedVoluntaryExit
+} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
 import {IBeaconDb} from "../../../db";
 import {generateDeposits} from "./deposits";
 import {getEth1Vote} from "./eth1Vote";
-import {TreeBacked} from "@chainsafe/ssz";
+import {TreeBacked, List} from "@chainsafe/ssz";
 
 export async function assembleBody(
   config: IBeaconConfig,
@@ -40,10 +50,10 @@ export async function assembleBody(
     randaoReveal,
     graffiti,
     eth1Data,
-    proposerSlashings,
-    attesterSlashings,
-    attestations,
-    deposits,
-    voluntaryExits,
+    proposerSlashings: proposerSlashings as List<ProposerSlashing>,
+    attesterSlashings: attesterSlashings as List<AttesterSlashing>,
+    attestations: attestations as List<Attestation>,
+    deposits: deposits as List<Deposit>,
+    voluntaryExits: voluntaryExits as List<SignedVoluntaryExit>,
   };
 }

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -33,7 +33,7 @@ export async function assembleBlock(
     slot,
     proposerIndex,
     parentRoot: config.types.BeaconBlockHeader.hashTreeRoot(parentHeader),
-    stateRoot: undefined,
+    stateRoot: ZERO_HASH,
     body: await assembleBody(config, db, headState, randaoReveal, graffiti),
   };
 

--- a/packages/lodestar/src/chain/factory/duties/index.ts
+++ b/packages/lodestar/src/chain/factory/duties/index.ts
@@ -9,10 +9,10 @@ export function assembleAttesterDuty(
   validator: {publicKey: BLSPubkey; index: ValidatorIndex},
   epochCtx: EpochContext,
   epoch: Epoch
-): AttesterDuty  {
+): AttesterDuty | null {
   const committeeAssignment = epochCtx.getCommitteeAssignment(epoch, validator.index);
   if (!committeeAssignment) {
-    throw Error(`No committeeAssignment for validator ${validator.index} at epoch ${epoch}`);
+    return null;
   }
   return {
     validatorPubkey: validator.publicKey,

--- a/packages/lodestar/src/chain/factory/duties/index.ts
+++ b/packages/lodestar/src/chain/factory/duties/index.ts
@@ -31,8 +31,8 @@ export function generateEmptyAttesterDuty(publicKey: BLSPubkey, duty?: Partial<A
   return {
     validatorPubkey: publicKey,
     aggregatorModulo: 1,
-    attestationSlot: null,
-    committeeIndex: null,
+    attestationSlot: -1,
+    committeeIndex: -1,
     ...duty
   };
 }

--- a/packages/lodestar/src/chain/factory/duties/index.ts
+++ b/packages/lodestar/src/chain/factory/duties/index.ts
@@ -10,29 +10,17 @@ export function assembleAttesterDuty(
   epochCtx: EpochContext,
   epoch: Epoch
 ): AttesterDuty  {
-  let duty: AttesterDuty = generateEmptyAttesterDuty(validator.publicKey);
   const committeeAssignment = epochCtx.getCommitteeAssignment(epoch, validator.index);
-  if (committeeAssignment) {
-    duty = {
-      ...duty,
-      aggregatorModulo: Math.max(
-        1,
-        intDiv(committeeAssignment.validators.length, config.params.TARGET_AGGREGATORS_PER_COMMITTEE)
-      ),
-      committeeIndex: committeeAssignment.committeeIndex,
-      attestationSlot: committeeAssignment.slot,
-    };
+  if (!committeeAssignment) {
+    throw Error(`No committeeAssignment for validator ${validator.index} at epoch ${epoch}`);
   }
-
-  return duty;
-}
-
-export function generateEmptyAttesterDuty(publicKey: BLSPubkey, duty?: Partial<AttesterDuty>): AttesterDuty {
   return {
-    validatorPubkey: publicKey,
-    aggregatorModulo: 1,
-    attestationSlot: -1,
-    committeeIndex: -1,
-    ...duty
+    validatorPubkey: validator.publicKey,
+    aggregatorModulo: Math.max(
+      1,
+      intDiv(committeeAssignment.validators.length, config.params.TARGET_AGGREGATORS_PER_COMMITTEE)
+    ),
+    committeeIndex: committeeAssignment.committeeIndex,
+    attestationSlot: committeeAssignment.slot,
   };
 }

--- a/packages/lodestar/src/chain/forkChoice/arrayDag/interface.ts
+++ b/packages/lodestar/src/chain/forkChoice/arrayDag/interface.ts
@@ -8,7 +8,8 @@ import {RootHex, HexCheckpoint} from "../interface";
 export interface NodeInfo {
   slot: Slot;
   blockRoot: RootHex;
-  parent: number;
+  // genesis or first known block will not have a parent
+  parent: number | null;
   justifiedCheckpoint: HexCheckpoint;
   finalizedCheckpoint: HexCheckpoint;
   stateRoot: Root;

--- a/packages/lodestar/src/chain/forkChoice/arrayDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/arrayDag/lmdGhost.ts
@@ -35,6 +35,9 @@ class NodeIndices {
     if (!value) throw Error(`No index for root ${key}`);
     return value;
   }
+  getMaybe(key: RootHex): number | null {
+    return this.map.get(key) ?? null;
+  }
   set(key: RootHex, value: number): void {
     this.map.set(key, value);
   }
@@ -302,10 +305,11 @@ export class ArrayDagLMDGHOST extends (EventEmitter as { new(): ForkChoiceEventE
     }
   }
 
-  public getNode(blockRootBuf: Uint8Array): Node {
+  public getNode(blockRootBuf: Uint8Array): Node | null {
     const blockRoot = toHexString(blockRootBuf);
-    const index = this.nodeIndices.get(blockRoot);
-    return this.nodes[index];
+    const index = this.nodeIndices.getMaybe(blockRoot);
+    if (index === null) return null;
+    return this.nodes[index] ?? null;
   }
 
   public isBestTarget(parent: Node, child: Node): boolean {
@@ -398,7 +402,7 @@ export class ArrayDagLMDGHOST extends (EventEmitter as { new(): ForkChoiceEventE
 
   public getBlockSummaryByBlockRoot(blockRoot: Uint8Array): BlockSummary | null {
     const node = this.getNode(blockRoot);
-    return (node)? this.toBlockSummary(node) : null;
+    return node ? this.toBlockSummary(node) : null;
   }
 
   public getBlockSummaryByParentBlockRoot(blockRoot: Uint8Array): BlockSummary[] {

--- a/packages/lodestar/src/chain/forkChoice/arrayDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/arrayDag/lmdGhost.ts
@@ -155,9 +155,9 @@ export class ArrayDagLMDGHOST extends (EventEmitter as { new(): ForkChoiceEventE
   /**
    * Best justified checkpoint.
    */
-  private bestJustifiedCheckpoint: Checkpoint;
+  private bestJustifiedCheckpoint?: Checkpoint;
   private synced: boolean;
-  private clock: IBeaconClock;
+  private clock?: IBeaconClock;
 
   public constructor(config: IBeaconConfig) {
     super();

--- a/packages/lodestar/src/chain/forkChoice/interface.ts
+++ b/packages/lodestar/src/chain/forkChoice/interface.ts
@@ -27,7 +27,7 @@ export interface ILMDGHOST extends ForkChoiceEventEmitter {
   getAncestor(root: Uint8Array, slot: Slot): Uint8Array | null;
   getBlockSummariesAtSlot(slot: Slot): BlockSummary[];
   getCanonicalBlockSummaryAtSlot(slot: Slot): BlockSummary | null;
-  getBlockSummaryByBlockRoot(blockRoot: Uint8Array): BlockSummary;
+  getBlockSummaryByBlockRoot(blockRoot: Uint8Array): BlockSummary | null;
   getBlockSummaryByParentBlockRoot(blockRoot: Uint8Array): BlockSummary[];
   hasBlock(blockRoot: Uint8Array): boolean;
 }

--- a/packages/lodestar/src/chain/forkChoice/interface.ts
+++ b/packages/lodestar/src/chain/forkChoice/interface.ts
@@ -79,4 +79,4 @@ export interface HexCheckpoint {
 }
 
 // non Existent node
-export const NO_NODE = -1;
+export const NO_NODE = null as null;

--- a/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
@@ -262,9 +262,9 @@ export class StatefulDagLMDGHOST extends (EventEmitter as { new(): ForkChoiceEve
   /**
    * Best justified checkpoint.
    */
-  private bestJustifiedCheckpoint: Checkpoint;
+  private bestJustifiedCheckpoint?: Checkpoint;
   private synced: boolean;
-  private clock: IBeaconClock;
+  private clock?: IBeaconClock;
 
   public constructor(config: IBeaconConfig) {
     super();

--- a/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
@@ -264,7 +264,7 @@ export class StatefulDagLMDGHOST extends (EventEmitter as { new(): ForkChoiceEve
    */
   private bestJustifiedCheckpoint?: Checkpoint;
   private synced: boolean;
-  private clock?: IBeaconClock;
+  private clock: IBeaconClock;
 
   public constructor(config: IBeaconConfig) {
     super();

--- a/packages/lodestar/src/chain/genesis/genesis.ts
+++ b/packages/lodestar/src/chain/genesis/genesis.ts
@@ -85,6 +85,8 @@ export class GenesisBuilder implements IGenesisBuilder {
           return this.state;
         }
       }
+      
+      throw Error("Could not find valid genesis state");
     };
   }
 

--- a/packages/lodestar/src/chain/genesis/util.ts
+++ b/packages/lodestar/src/chain/genesis/util.ts
@@ -14,7 +14,6 @@ import {
   Fork,
   SignedBeaconBlock,
   Root,
-  DepositData,
   AttesterSlashing,
   ProposerSlashing,
   Attestation,
@@ -78,15 +77,15 @@ export function applyDeposits(
     }
   }
   const initDepositCount = depositDataRootList.length;
-  const depositDatas: DepositData[] = fullDepositDataRootList? null : newDeposits.map((deposit) => deposit.data);
+  const depositDatas = fullDepositDataRootList ? null : newDeposits.map((deposit) => deposit.data);
   newDeposits.forEach((deposit, index) => {
     if (fullDepositDataRootList) {
       depositDataRootList.push(fullDepositDataRootList[index + initDepositCount]);
-      state.eth1Data.depositRoot = config.types.DepositDataRootList.hashTreeRoot(depositDataRootList);
-    } else {
+      state.eth1Data.depositRoot = config.types.DepositDataRootList.hashTreeRoot(depositDataRootList as List<Root>);
+    } else if (depositDatas) {
       const depositDataList = depositDatas.slice(0, index + 1);
       state.eth1Data.depositRoot = config.types.DepositDataRootList.hashTreeRoot(
-        depositDataList.map((d) => config.types.DepositData.hashTreeRoot(d))
+        depositDataList.map((d) => config.types.DepositData.hashTreeRoot(d)) as List<Root>
       );
     }
     state.eth1Data.depositCount += 1;

--- a/packages/lodestar/src/chain/genesis/util.ts
+++ b/packages/lodestar/src/chain/genesis/util.ts
@@ -15,6 +15,10 @@ import {
   SignedBeaconBlock,
   Root,
   DepositData,
+  AttesterSlashing,
+  ProposerSlashing,
+  Attestation,
+  SignedVoluntaryExit,
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
@@ -167,11 +171,11 @@ export function getEmptyBlockBody(): BeaconBlockBody {
       blockHash: ZERO_HASH,
     },
     graffiti: ZERO_HASH,
-    proposerSlashings: [],
-    attesterSlashings: [],
-    attestations: [],
-    deposits: [],
-    voluntaryExits: [],
+    proposerSlashings: [] as ProposerSlashing[] as List<ProposerSlashing>,
+    attesterSlashings: [] as AttesterSlashing[] as List<AttesterSlashing>,
+    attestations: [] as Attestation[] as List<Attestation>,
+    deposits: [] as Deposit[] as List<Deposit>,
+    voluntaryExits: [] as SignedVoluntaryExit[] as List<SignedVoluntaryExit>,
   };
 }
 

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -39,7 +39,7 @@ export type ChainEventEmitter = StrictEventEmitter<EventEmitter, IChainEvents>;
  */
 export interface IBeaconChain extends ChainEventEmitter {
   forkChoice: ILMDGHOST;
-  clock: IBeaconClock;
+  clock?: IBeaconClock;
   chainId: Uint16;
   networkId: Uint64;
   currentForkDigest: ForkDigest;

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -39,7 +39,7 @@ export type ChainEventEmitter = StrictEventEmitter<EventEmitter, IChainEvents>;
  */
 export interface IBeaconChain extends ChainEventEmitter {
   forkChoice: ILMDGHOST;
-  clock?: IBeaconClock;
+  clock: IBeaconClock;
   chainId: Uint16;
   networkId: Uint64;
   currentForkDigest: ForkDigest;
@@ -62,7 +62,7 @@ export interface IBeaconChain extends ChainEventEmitter {
   getHeadState(): Promise<TreeBacked<BeaconState>>;
   getHeadEpochContext(): Promise<EpochContext>;
 
-  getHeadBlock(): Promise<SignedBeaconBlock|null>;
+  getHeadBlock(): Promise<SignedBeaconBlock>;
 
   getFinalizedCheckpoint(): Promise<Checkpoint>;
 

--- a/packages/lodestar/src/eth1/impl/ethers.ts
+++ b/packages/lodestar/src/eth1/impl/ethers.ts
@@ -53,8 +53,8 @@ export class EthersEth1Notifier implements IEth1Notifier {
    * Pregenesis block number to check remaining time/block to form genesis.
    * This helps avoid calling too many unnecessary getBlock() calls before genesis.
    */
-  private preGenesisCheckpoint: number;
-  private eth1Source: Pushable<Eth1EventsBlock>;
+  private preGenesisCheckpoint: number | null;
+  private eth1Source: Pushable<Eth1EventsBlock> | null;
 
   public constructor(opts: IEthersEth1Options, {config, db, logger}: IEthersEth1Modules) {
     this.opts = opts;
@@ -71,7 +71,11 @@ export class EthersEth1Notifier implements IEth1Notifier {
       );
     }
     this.contract = opts.contract;
-    this.preGenesisCheckpoint = undefined;
+    this.startedProcessEth1 = false;
+    this.lastProcessedEth1BlockNumber = 0;
+    this.lastDepositCount = 0;
+    this.preGenesisCheckpoint = null;
+    this.eth1Source = null;
   }
 
   /**
@@ -251,14 +255,14 @@ export class EthersEth1Notifier implements IEth1Notifier {
         this.logger.info(`At block ${block.number}, probably ${numBlocksToGenesis} blocks` +
           " to genesis time if there is enough validators");
         // if it's too close to genesis time then always getBlock()
-        this.preGenesisCheckpoint = undefined;
+        this.preGenesisCheckpoint = null;
       } else {
         this.preGenesisCheckpoint = block.number + Math.floor(numBlocksToGenesis / 2);
         this.logger.info(`Set checkpoint to ${this.preGenesisCheckpoint}`);
       }
       return true;
     } else {
-      this.preGenesisCheckpoint = undefined;
+      this.preGenesisCheckpoint = null;
       return false;
     }
   }

--- a/packages/lodestar/src/eth1/impl/ethers.ts
+++ b/packages/lodestar/src/eth1/impl/ethers.ts
@@ -238,7 +238,7 @@ export class EthersEth1Notifier implements IEth1Notifier {
    * After genesis: true
    */
   public passCheckpoint(blockNumber: number): boolean {
-    return (!this.preGenesisCheckpoint || blockNumber >= this.preGenesisCheckpoint);
+    return (this.preGenesisCheckpoint === null || blockNumber >= this.preGenesisCheckpoint);
   }
 
   /**
@@ -331,14 +331,10 @@ export class EthersEth1Notifier implements IEth1Notifier {
     if(!this.contract) {
       await this.initContract();
     }
-    
     const lastEth1Data = await this.db.eth1Data.lastValue();
-    if (lastEth1Data) {
-      const lastProcessedBlockTag = await this.getLastProcessedBlockTag(lastEth1Data);
-      this.lastProcessedEth1BlockNumber = (await this.getBlock(lastProcessedBlockTag)).number;
-      this.lastDepositCount = lastEth1Data.depositCount;
-    }
-    
+    const lastProcessedBlockTag = await this.getLastProcessedBlockTag(lastEth1Data);
+    this.lastProcessedEth1BlockNumber = (await this.getBlock(lastProcessedBlockTag)).number;
+    this.lastDepositCount = lastEth1Data? lastEth1Data.depositCount : 0;
     this.logger.info(
       `Started listening to eth1 provider ${this.opts.provider.url} on chain ${this.config.params.DEPOSIT_NETWORK_ID}`
     );

--- a/packages/lodestar/src/eth1/impl/interop.ts
+++ b/packages/lodestar/src/eth1/impl/interop.ts
@@ -16,7 +16,7 @@ export class InteropEth1Notifier extends EventEmitter implements IEth1Notifier {
   public async stop(): Promise<void> {}
 
   public async getEth1BlockAndDepositEventsSource(): Promise<Pushable<Eth1EventsBlock>> {
-    return null;
+    throw Error("Not implemented");
   }
   public async endEth1BlockAndDepositEventsSource(): Promise<void> {}
 

--- a/packages/lodestar/src/metrics/server/http.ts
+++ b/packages/lodestar/src/metrics/server/http.ts
@@ -42,7 +42,7 @@ export class HttpMetricsServer implements IMetricsServer {
   }
 
   private onRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
-    if (req.method === "GET" && req.url.includes("/metrics")) {
+    if (req.method === "GET" && req.url && req.url.includes("/metrics")) {
       res.writeHead(200, {"content-type": this.metrics.registry.contentType});
       res.end(this.metrics.registry.metrics());
     } else {

--- a/packages/lodestar/src/network/encoders/request.ts
+++ b/packages/lodestar/src/network/encoders/request.ts
@@ -41,7 +41,7 @@ export function eth2RequestDecode(
       const type = Methods[method].requestSSZType(config);
       if(!type) {
         //method has no body, emit null to trigger response
-        yield {isValid: true, body: null};
+        yield {isValid: true};
         return;
       }
       let sszDataLength: number = null;

--- a/packages/lodestar/src/network/encoders/request.ts
+++ b/packages/lodestar/src/network/encoders/request.ts
@@ -44,7 +44,7 @@ export function eth2RequestDecode(
         yield {isValid: true};
         return;
       }
-      let sszDataLength: number = null;
+      let sszDataLength: number | null = null;
       const decompressor = getDecompressor(encoding);
       const buffer = new BufferList();
       for await (let chunk of source) {
@@ -75,7 +75,7 @@ export function eth2RequestDecode(
           yield {isValid: false};
           break;
         }
-        let uncompressed: Buffer;
+        let uncompressed: Buffer | null;
         try {
           uncompressed = decompressor.uncompress(chunk.slice());
         } catch (e) {

--- a/packages/lodestar/src/network/encoders/response.ts
+++ b/packages/lodestar/src/network/encoders/response.ts
@@ -61,9 +61,9 @@ export function eth2ResponseDecode(
       let buffer = new BufferList();
       //holds uncompressed chunks
       let uncompressedData = new BufferList();
-      let status: number = null;
-      let errorMessage: string = null;
-      let sszLength: number = null;
+      let status: number | null = null;
+      let errorMessage: string | null = null;
+      let sszLength: number | null = null;
       const decompressor = getDecompressor(encoding);
       const type = Methods[method].responseSSZType(config);
       for await (const chunk of source) {
@@ -102,14 +102,14 @@ export function eth2ResponseDecode(
             `sszLength ${sszLength}`);
         }
         if(buffer.length === 0) continue;
-        let uncompressed: Buffer;
+        let uncompressed: Buffer | null = null;
         try {
           uncompressed = decompressor.uncompress(buffer.slice());
           buffer.consume(buffer.length);
         } catch (e) {
           logger.warn(`Failed to uncompress data for method ${method}. Error: ${e.message}`, {requestId, encoding});
         }
-        if(uncompressed) {
+        if(uncompressed !== null) {
           uncompressedData.append(uncompressed);
           if(uncompressedData.length > sszLength) {
             throw new Error(`Received too much data for method ${method}`);

--- a/packages/lodestar/src/network/encoders/response.ts
+++ b/packages/lodestar/src/network/encoders/response.ts
@@ -34,7 +34,7 @@ export function eth2ResponseEncode(
           const serialized = type.serialize(chunk.body as any);
           serializedData = Buffer.from(serialized.buffer, serialized.byteOffset, serialized.length);
         } catch (e) {
-          logger.warn(`Failed to ssz serialize chunk of method ${method}. Error: ${e.message}`);
+          throw Error(`Failed to ssz serialize chunk of method ${method}. Error: ${e.message}`);
         }
         //yield encoded ssz length
         yield Buffer.from(encode(serializedData.length));

--- a/packages/lodestar/src/network/gossip/gossip.ts
+++ b/packages/lodestar/src/network/gossip/gossip.ts
@@ -48,7 +48,7 @@ export class Gossip extends (EventEmitter as { new(): GossipEventEmitter }) impl
   protected readonly chain: IBeaconChain;
   protected readonly  logger: ILogger;
 
-  private handlers: Map<string, GossipHandlerFn>;
+  private handlers?: Map<string, GossipHandlerFn>;
   //TODO: make this configurable
   private supportedEncodings = [GossipEncoding.SSZ_SNAPPY, GossipEncoding.SSZ];
   private statusInterval?: NodeJS.Timeout;

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -69,6 +69,7 @@ export class LodestarGossipsub extends Gossipsub {
     const message: ILodestarGossipMessage = normalizeInRpcMessage(rawMessage);
     assert.true(Boolean(message.topicIDs), "topicIds is not defined");
     assert.equal(message.topicIDs.length, 1, "topicIds array must contain one item");
+    if (!message.data) throw Error("Message has not data");
     assert.lte(message.data.length, GOSSIP_MAX_SIZE, "Message exceeds byte size limit");
     const topic = message.topicIDs[0];
     // avoid duplicate
@@ -77,7 +78,7 @@ export class LodestarGossipsub extends Gossipsub {
     }
 
     let validationResult;
-    let transformedObj: GossipObject;
+    let transformedObj: GossipObject | null = null;
     try {
       const validatorFn = this.getTopicValidator(topic);
       const objSubnet = this.deserializeGossipMessage(topic, message);

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -28,7 +28,7 @@ export class LodestarGossipsub extends Gossipsub {
   private transformedObjects: Map<string, {createdAt: Date; object: GossipObject}>;
   private config: IBeaconConfig;
   private validator: IGossipMessageValidator;
-  private interval: NodeJS.Timeout;
+  private interval?: NodeJS.Timeout;
   private timeToLive: number;
   private readonly  logger: ILogger;
 

--- a/packages/lodestar/src/network/gossip/utils.ts
+++ b/packages/lodestar/src/network/gossip/utils.ts
@@ -39,7 +39,7 @@ export function mapGossipEvent(event: keyof IGossipEvents | string): GossipEvent
 export function topicToGossipEvent(topic: string): GossipEvent {
   const groups = topic.match(GossipTopicRegExp);
   const topicName = groups && groups[3];
-  if (topicName === null || topicName === undefined) throw Error(`Bad gossip topic format: ${topic}`);
+  if (!topicName) throw Error(`Bad gossip topic format: ${topic}`);
   return topicName as GossipEvent;
 }
 
@@ -59,7 +59,7 @@ export function isAttestationSubnetTopic(topic: string): boolean {
 export function getSubnetFromAttestationSubnetTopic(topic: string): number {
   const groups = topic.match(AttestationSubnetRegExp);
   const subnetStr = groups && groups[4];
-  if (subnetStr === null || subnetStr === undefined) throw Error(`Bad attestation topic format: ${topic}`);
+  if (!subnetStr) throw Error(`Bad attestation topic format: ${topic}`);
   return parseInt(subnetStr);
 }
 

--- a/packages/lodestar/src/network/interface.ts
+++ b/packages/lodestar/src/network/interface.ts
@@ -64,7 +64,7 @@ export interface INetwork extends NetworkEventEmitter {
    * Our network identity
    */
   peerId: PeerId;
-  multiaddrs: Multiaddr[];
+  multiaddrs?: Multiaddr[];
   getEnr(): ENR|undefined;
   getPeers(): PeerId[];
   getPeerConnection(peerId: PeerId): LibP2pConnection|null;

--- a/packages/lodestar/src/network/interface.ts
+++ b/packages/lodestar/src/network/interface.ts
@@ -64,7 +64,7 @@ export interface INetwork extends NetworkEventEmitter {
    * Our network identity
    */
   peerId: PeerId;
-  multiaddrs?: Multiaddr[];
+  multiaddrs: Multiaddr[];
   getEnr(): ENR|undefined;
   getPeers(): PeerId[];
   getPeerConnection(peerId: PeerId): LibP2pConnection|null;

--- a/packages/lodestar/src/network/interface.ts
+++ b/packages/lodestar/src/network/interface.ts
@@ -38,8 +38,8 @@ export type ReqEventEmitter = StrictEventEmitter<EventEmitter, IReqEvents>;
 export type RespEventEmitter = StrictEventEmitter<EventEmitter, IRespEvents>;
 
 export interface IReqResp extends ReqEventEmitter {
-  sendResponseStream(id: RequestId, err: RpcError, chunkIter: AsyncIterable<ResponseBody>): void;
-  sendResponse(id: RequestId, err: RpcError, response?: ResponseBody): void;
+  sendResponseStream(id: RequestId, err: RpcError | null, chunkIter: AsyncIterable<ResponseBody>): void;
+  sendResponse(id: RequestId, err: RpcError | null, response: ResponseBody | null): void;
   status(peerId: PeerId, request: Status): Promise<Status|null>;
   goodbye(peerId: PeerId, request: Goodbye): Promise<void>;
   ping(peerId: PeerId, request: Ping): Promise<Ping|null>;

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -32,7 +32,7 @@ interface ILibp2pModules {
 export class Libp2pNetwork extends (EventEmitter as { new(): NetworkEventEmitter }) implements INetwork {
 
   public peerId: PeerId;
-  public multiaddrs?: Multiaddr[];
+  public multiaddrs: Multiaddr[];
   public reqResp: ReqResp;
   public gossip: IGossip;
   public metadata: MetadataController;
@@ -53,6 +53,7 @@ export class Libp2pNetwork extends (EventEmitter as { new(): NetworkEventEmitter
     this.metrics = metrics;
     this.peerReputations = reps;
     this.peerId = libp2p.peerId;
+    this.multiaddrs = libp2p.multiaddrs;
     this.libp2p = libp2p;
     this.reqResp = new ReqResp(opts, {config, libp2p, peerReputations: this.peerReputations, logger});
     this.metadata = new MetadataController({}, {config, chain, logger});

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -32,7 +32,7 @@ interface ILibp2pModules {
 export class Libp2pNetwork extends (EventEmitter as { new(): NetworkEventEmitter }) implements INetwork {
 
   public peerId: PeerId;
-  public multiaddrs: Multiaddr[];
+  public multiaddrs?: Multiaddr[];
   public reqResp: ReqResp;
   public gossip: IGossip;
   public metadata: MetadataController;

--- a/packages/lodestar/src/network/reqResp.ts
+++ b/packages/lodestar/src/network/reqResp.ts
@@ -120,15 +120,15 @@ export class ReqResp extends (EventEmitter as IReqEventEmitterClass) implements 
     });
   }
 
-  public sendResponse(id: RequestId, err: RpcError|null, response?: ResponseBody): void {
+  public sendResponse(id: RequestId, err: RpcError | null, response: ResponseBody | null): void {
     return this.sendResponseStream(id, err, async function *() {
-      if(response !== null && response !== undefined) {
+      if(response !== null) {
         yield response;
       }
     }());
   }
 
-  public sendResponseStream(id: RequestId, err: RpcError|null, chunkIter: AsyncIterable<ResponseBody>): void {
+  public sendResponseStream(id: RequestId, err: RpcError | null, chunkIter: AsyncIterable<ResponseBody>): void {
     if(err) {
       const config = this.config;
       this.responseListener.emit(createResponseEvent(id), async function* () {

--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -7,7 +7,7 @@ import {IBeaconChain} from "../../../chain";
 import {IReputationStore} from "../../IReputation";
 import {INetwork} from "../../../network";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
-import {ISyncOptions} from "../../options";
+import syncOptions, {ISyncOptions} from "../../options";
 import {IInitialSyncModules, InitialSync, InitialSyncEventEmitter} from "../interface";
 import {EventEmitter} from "events";
 import {Checkpoint, SignedBeaconBlock, Slot} from "@chainsafe/lodestar-types";
@@ -34,7 +34,7 @@ export class FastSync
   /**
    * Targeted finalized checkpoint. Initial sync should only sync up to that point.
    */
-  private targetCheckpoint: Checkpoint;
+  private targetCheckpoint?: Checkpoint;
   /**
    * Target slot for block import, we won't download blocks past that point.
    */
@@ -98,11 +98,12 @@ export class FastSync
 
   private getNewBlockImportTarget(fromSlot: Slot): Slot {
     const finalizedTargetSlot = this.getHighestBlock();
-    if(fromSlot + this.opts.maxSlotImport > finalizedTargetSlot) {
+    const maxSlotImport = this.opts.maxSlotImport || syncOptions.maxSlotImport;
+    if(fromSlot + maxSlotImport > finalizedTargetSlot) {
       //first slot of epoch is skip slot
       return fromSlot + this.config.params.SLOTS_PER_EPOCH;
     } else {
-      return fromSlot + this.opts.maxSlotImport;
+      return fromSlot + maxSlotImport;
     }
   }
 

--- a/packages/lodestar/src/sync/options.ts
+++ b/packages/lodestar/src/sync/options.ts
@@ -9,7 +9,7 @@ export interface ISyncOptions {
 }
 
 
-const config: ISyncOptions = {
+const config: Required<ISyncOptions> = {
   minPeers: 2,
   //2 epochs
   maxSlotImport: 64,

--- a/packages/lodestar/src/sync/stats/rate.ts
+++ b/packages/lodestar/src/sync/stats/rate.ts
@@ -6,8 +6,8 @@ export class RateCounter {
   private readonly timePeriod: number;
 
   private count = 0;
-  private since: number;
-  private timer: NodeJS.Timeout;
+  private since?: number;
+  private timer?: NodeJS.Timeout;
 
   /**
      *
@@ -36,7 +36,7 @@ export class RateCounter {
   }
 
   public rate(): number {
-    if(this.count == 0) {
+    if(this.count == 0 || this.since === undefined) {
       return 0;
     }
     const diff = new Date().getTime() - this.since;

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -40,7 +40,7 @@ export class BeaconSync implements IBeaconSync {
   private attestationCollector: AttestationCollector;
   private startingBlock: Slot = 0;
 
-  private statusSyncTimer: NodeJS.Timeout;
+  private statusSyncTimer?: NodeJS.Timeout;
 
   constructor(opts: ISyncOptions, modules: ISyncModules) {
     this.opts = opts;

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -167,8 +167,8 @@ export class BeaconSync implements IBeaconSync {
 
   private onUnknownBlockRoot = async (root: Root): Promise<void> => {
     const peerBalancer = new RoundRobinArray(this.getPeers());
-    const maxAttempts = 1000;
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
       const peer = peerBalancer.next();
       if (!peer) {
         return;

--- a/packages/lodestar/test/unit/api/rest/validator/index.test.ts
+++ b/packages/lodestar/test/unit/api/rest/validator/index.test.ts
@@ -11,7 +11,6 @@ import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 
 import {RestApi} from "../../../../../src/api/rest";
 import {ApiNamespace} from "../../../../../src/api";
-import {generateEmptyAttesterDuty} from "../../../../../src/chain/factory/duties";
 import {generateEmptyBlock} from "../../../../utils/block";
 import {
   generateAttestation,
@@ -66,7 +65,12 @@ describe("Test validator rest API", function () {
 
   it("should return attester duties", async function () {
     const publicKey1= Keypair.generate().publicKey.toBytesCompressed();
-    validatorApi.getAttesterDuties.resolves([generateEmptyAttesterDuty(Buffer.alloc(48, 1))]);
+    validatorApi.getAttesterDuties.resolves([{
+      validatorPubkey: Buffer.alloc(48, 1),
+      aggregatorModulo: 1,
+      committeeIndex: 0,
+      attestationSlot: 0
+    }]);
     const response = await supertest(restApi.server.server)
       .get(
         "/validator/duties/2/attester",

--- a/packages/lodestar/test/unit/chain/factory/duties/assembleValidatorDuty.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/duties/assembleValidatorDuty.test.ts
@@ -42,10 +42,7 @@ describe("assemble validator duty", function () {
     const epochCtx = new EpochContext(config);
     epochCtx.getCommitteeAssignment = () => (null);
     const result = assembleAttesterDuty(config, {publicKey, index: validatorIndex}, epochCtx, 3);
-    expect(result).to.not.be.null;
-    expect(result.validatorPubkey).to.be.equal(publicKey);
-    expect(result.attestationSlot).to.be.equal(-1);
-    expect(result.committeeIndex).to.be.equal(-1);
+    expect(result).to.be.null;
   });
 
 });

--- a/packages/lodestar/test/unit/chain/factory/duties/assembleValidatorDuty.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/duties/assembleValidatorDuty.test.ts
@@ -44,8 +44,8 @@ describe("assemble validator duty", function () {
     const result = assembleAttesterDuty(config, {publicKey, index: validatorIndex}, epochCtx, 3);
     expect(result).to.not.be.null;
     expect(result.validatorPubkey).to.be.equal(publicKey);
-    expect(result.attestationSlot).to.be.equal(null);
-    expect(result.committeeIndex).to.be.equal(null);
+    expect(result.attestationSlot).to.be.equal(-1);
+    expect(result.committeeIndex).to.be.equal(-1);
   });
 
 });

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -44,8 +44,8 @@ export class MockBeaconChain extends EventEmitter implements IBeaconChain {
     this.config = config;
   }
 
-  getHeadBlock(): Promise<| null> {
-    return undefined;
+  getHeadBlock(): Promise<SignedBeaconBlock> {
+    throw Error("Not implemented");
   }
 
   public async getHeadStateContext(): Promise<ITreeStateContext| null> {


### PR DESCRIPTION
Parallelizable effort to tackle #885. Sets strictNullChecks = true in a single package so eventually it can be set in the root tsconfig.

Note: There are 80 errors! (down from 271 on part 1) when compiling the current lodestar package with strictNullChecks = true. Extends the progress made on https://github.com/ChainSafe/lodestar/pull/1289 to prevent too big changes at once potentially creating conflicts with other PRs. The PR that manages to bring the error count to 0 will actually set `strictNullChecks = true`.