### PR TITLE
Only store eth1Data when necessary

### DIFF
--- a/packages/lodestar/src/eth1/impl/ethers.ts
+++ b/packages/lodestar/src/eth1/impl/ethers.ts
@@ -28,6 +28,8 @@ export interface IEthersEth1Modules {
 }
 
 const ETH1_BLOCK_RETRY = 3;
+// Ideally if it's 1024 blocks to genesis, then we check block 512 -> 256 -> ... 2 -> 1 -> 0 until genesis.
+const CHECKPOINT_STEP = 2;
 
 /**
  * The EthersEth1Notifier watches the eth1 chain using ethers.js
@@ -282,7 +284,7 @@ export class EthersEth1Notifier implements IEth1Notifier {
           " to genesis time if there is enough validators");
         // if it's too close to genesis time then always getBlock(), keep old checkpoint
       } else {
-        this.checkpoint = block.number + Math.floor(numBlocksToGenesis / 2);
+        this.checkpoint = block.number + Math.floor(numBlocksToGenesis / CHECKPOINT_STEP);
         this.logger.info(`Set checkpoint to ${this.checkpoint}`);
       }
       return false;

--- a/packages/lodestar/src/eth1/impl/interop.ts
+++ b/packages/lodestar/src/eth1/impl/interop.ts
@@ -11,6 +11,7 @@ export class InteropEth1Notifier extends EventEmitter implements IEth1Notifier {
   public constructor() {
     super();
   }
+  public async collectEth1Data(blockHash: string): Promise<void> {}
 
   public async start(): Promise<void> {}
   public async stop(): Promise<void> {}
@@ -25,9 +26,6 @@ export class InteropEth1Notifier extends EventEmitter implements IEth1Notifier {
   }
   public async getDepositCount(blockTag: string | number): Promise<number> {
     return 0;
-  }
-  public async getEth1Data(blockHash: string): Promise<Eth1Data> {
-    return null as unknown as Eth1Data;
   }
   public async getDepositEvents(blockTag: string | number): Promise<IDepositEvent[]> {
     return [];

--- a/packages/lodestar/src/eth1/interface.ts
+++ b/packages/lodestar/src/eth1/interface.ts
@@ -23,6 +23,7 @@ export interface IDepositEvent extends DepositData {
 export interface IEth1Notifier {
   start(): Promise<void>;
   stop(): Promise<void>;
+  collectEth1Data(blockHash: string): Promise<void>;
   getEth1BlockAndDepositEventsSource(): Promise<Pushable<Eth1EventsBlock>>;
   endEth1BlockAndDepositEventsSource(): Promise<void>;
 

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -110,6 +110,7 @@ export class BeaconNode {
       config,
       db: this.db,
       chain: this.chain,
+      eth1: this.eth1,
       network: this.network,
       reputationStore: this.reps,
       logger: logger.child(this.conf.logger.sync),

--- a/packages/lodestar/src/sync/interface.ts
+++ b/packages/lodestar/src/sync/interface.ts
@@ -11,6 +11,7 @@ import {IBeaconChain} from "../chain";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBeaconDb} from "../db/api";
 import {AttestationCollector} from "./utils";
+import {IEth1Notifier} from "../eth1";
 
 export interface IBeaconSync extends IService {
   getSyncStatus(): Promise<SyncingStatus>;
@@ -34,6 +35,7 @@ export interface ISyncModules {
   reputationStore: IReputationStore;
   logger: ILogger;
   chain: IBeaconChain;
+  eth1: IEth1Notifier;
   initialSync?: InitialSync;
   regularSync?: IRegularSync;
   reqRespHandler?: IReqRespHandler;

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -145,10 +145,7 @@ export class BeaconSync implements IBeaconSync {
   private async onSyncCompleted(): Promise<void> {
     this.stopSyncTimer();
     const state = await this.chain.getHeadState();
-    const eth1Votes = state.eth1DataVotes;
-    const blockHash = (eth1Votes && eth1Votes.length > 0)?
-      eth1Votes[eth1Votes.length - 1].blockHash : state.eth1Data.blockHash;
-    await this.eth1.collectEth1Data(toHexString(blockHash));
+    await this.eth1.collectEth1Data(toHexString(state.eth1Data.blockHash));
   }
 
   private startSyncTimer(interval: number): void {

--- a/packages/lodestar/test/e2e/chain/genesis/genesis.test.ts
+++ b/packages/lodestar/test/e2e/chain/genesis/genesis.test.ts
@@ -13,7 +13,7 @@ import {GenesisBuilder} from "../../../../src/chain/genesis/genesis";
 import {computeForkDigest} from "@chainsafe/lodestar-beacon-state-transition";
 import {sleep} from "../../../../src/util/sleep";
 
-describe("BeaconChain", function() {
+describe("Altona genesis state", function() {
   this.timeout(10 * 60 * 1000);
 
   let eth1Notifier: IEth1Notifier;

--- a/packages/lodestar/test/unit/sync/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/sync.test.ts
@@ -15,10 +15,12 @@ import {ReputationStore} from "../../../src/sync/IReputation";
 import {generateEmptySignedBlock} from "../../utils/block";
 import {ISyncOptions} from "../../../src/sync/options";
 import {IBeaconSync} from "../../../lib/sync";
+import {IEth1Notifier, EthersEth1Notifier} from "../../../src/eth1";
 
 describe("sync", function () {
 
   let chainStub: SinonStubbedInstance<IBeaconChain>;
+  let eth1Stub: SinonStubbedInstance<IEth1Notifier>;
   let reqRespStub: SinonStubbedInstance<IReqRespHandler>;
   let attestationCollectorStub: SinonStubbedInstance<AttestationCollector>;
   let gossipStub: SinonStubbedInstance<IGossipHandler>;
@@ -33,6 +35,7 @@ describe("sync", function () {
       opts,
       {
         chain: chainStub,
+        eth1: eth1Stub,
         config,
         db: sinon.createStubInstance(BeaconDb),
         regularSync: regularSyncStub,
@@ -48,6 +51,7 @@ describe("sync", function () {
 
   beforeEach(function () {
     chainStub = sinon.createStubInstance(BeaconChain);
+    eth1Stub = sinon.createStubInstance(EthersEth1Notifier);
     reqRespStub = sinon.createStubInstance(BeaconReqRespHandler);
     attestationCollectorStub = sinon.createStubInstance(AttestationCollector);
     gossipStub = sinon.createStubInstance(BeaconGossipHandler);


### PR DESCRIPTION
resolves #1329 

Once sync is completed, it should signal eth1 so eth1 has information on when to fetch eth1 block to store eth1Data.

New `minEth1BlockTimestamp()` function returning minimum eth1 block timestamp for proposing data, use checkpoint strategy similar to pregenesis (that's what we're doing now) to know when to call `getBlock` after genesis.

Ideally we should not store more states to eth1 but we have to stay with this situation for a while until #1103
