### PR TITLE
Order Archive tasks

### DIFF
--- a/packages/lodestar/src/tasks/index.ts
+++ b/packages/lodestar/src/tasks/index.ts
@@ -69,10 +69,8 @@ export class TasksService implements IService {
   };
 
   private handleFinalizedCheckpointChores = async (finalized: BlockSummary, pruned: BlockSummary[]): Promise<void> => {
-    await Promise.all([
-      new ArchiveBlocksTask(this.config, {db: this.db, logger: this.logger}, finalized, pruned).run(),
-      new ArchiveStatesTask(this.config, {db: this.db, logger: this.logger}, finalized, pruned).run()
-    ]);
+    await new ArchiveBlocksTask(this.config, {db: this.db, logger: this.logger}, finalized, pruned).run();
+    await new ArchiveStatesTask(this.config, {db: this.db, logger: this.logger}, finalized, pruned).run();
   };
 
 }


### PR DESCRIPTION
resolves #1381 

+ Order Archive tasks to make sure we finish saving archived blocks before state so when we restart, based on the last known state we're sure we can get expected archived blocks