### PR TITLE
target es2019 in lodestar-cli development tsconfig

### DIFF
--- a/packages/lodestar-cli/tsconfig.json
+++ b/packages/lodestar-cli/tsconfig.json
@@ -7,5 +7,6 @@
       "../../node_modules/@types",
       "../../node_modules/libp2p-ts/types"
     ],
+    "target": "es2019"
   }
 }


### PR DESCRIPTION
Since @wemeetagain added optional chaining in the CLI the code can't be run with ts-node in development. Related to https://github.com/ChainSafe/lodestar/issues/1086