### PR TITLE
Set strictNullChecks true in lodestar-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/chai": "4.2.0",
     "@types/chai-as-promised": "^7.1.2",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.12.21",
+    "@types/node": "^14.0.27",
     "@types/sinon": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "2.23.0",
     "@typescript-eslint/parser": "2.23.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/chai": "4.2.0",
     "@types/chai-as-promised": "^7.1.2",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^14.0.27",
+    "@types/node": "^12.12.21",
     "@types/sinon": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "2.23.0",
     "@typescript-eslint/parser": "2.23.0",

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/create.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/create.ts
@@ -13,7 +13,7 @@ interface IValidatorCreateArgs {
   passphraseFile: string;
   depositGwei?: string;
   storeWithdrawalKeystore?: boolean;
-  count?: number;
+  count: number;
 }
 
 export const create: ICliCommand<IValidatorCreateArgs, IAccountValidatorArgs & IGlobalArgs> = {

--- a/packages/lodestar-cli/src/cmds/beacon/handler.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/handler.ts
@@ -4,7 +4,7 @@ import {initBLS} from "@chainsafe/bls";
 import {BeaconNode} from "@chainsafe/lodestar/lib/node";
 import {createNodeJsLibp2p} from "@chainsafe/lodestar/lib/network/nodejs";
 import {fileTransport, WinstonLogger} from "@chainsafe/lodestar-utils";
-import {ENR} from "@chainsafe/discv5";
+import {IDiscv5DiscoveryInputOptions} from "@chainsafe/discv5";
 import {consoleTransport} from "@chainsafe/lodestar-utils";
 import {IGlobalArgs} from "../../options";
 import {readPeerId, readEnr, writeEnr} from "../../network";
@@ -29,12 +29,12 @@ export async function beaconHandler(options: IBeaconArgs & IGlobalArgs): Promise
   options = mergeConfigOptions(options);
   const peerId = await readPeerId(beaconPaths.peerIdFile);
   // read local enr from disk
-  options.network.discv5.enr = await readEnr(beaconPaths.enrFile);
+  const enr = await readEnr(beaconPaths.enrFile);
   // set enr overrides
-  updateENR(options.network.discv5.enr, options);
-  if (options.enr?.ip || options.enr?.ip6) {
-    options.network.discv5.enrUpdate = false;
-  }
+  updateENR(enr, options);
+  if (!options.network.discv5) options.network.discv5 = {} as IDiscv5DiscoveryInputOptions;
+  options.network.discv5.enr = enr;
+  options.network.discv5.enrUpdate = !options.enr?.ip && !options.enr?.ip6;
   // TODO: Rename db.name to db.path or db.location
   options.db.name = beaconPaths.dbDir;
 
@@ -52,7 +52,7 @@ export async function beaconHandler(options: IBeaconArgs & IGlobalArgs): Promise
 
   async function cleanup(): Promise<void> {
     await node.stop();
-    await writeEnr(beaconPaths.enrFile, options.network.discv5.enr as ENR, peerId);
+    await writeEnr(beaconPaths.enrFile, enr, peerId);
   }
 
   process.on("SIGTERM", cleanup);

--- a/packages/lodestar-cli/src/cmds/dev/handler.ts
+++ b/packages/lodestar-cli/src/cmds/dev/handler.ts
@@ -16,6 +16,7 @@ import {getValidatorApiClient} from "./utils/validator";
 import {mergeConfigOptions} from "../../config/beacon";
 import {getBeaconConfig} from "../../util";
 import {getBeaconPaths} from "../beacon/paths";
+import {IDiscv5DiscoveryInputOptions} from "@chainsafe/discv5";
 
 /**
  * Run a beacon node
@@ -25,6 +26,7 @@ export async function devHandler(options: IDevArgs & IGlobalArgs): Promise<void>
 
   options = mergeConfigOptions(options);
   const peerId = await createPeerId();
+  if (!options.network.discv5) options.network.discv5 = {} as IDiscv5DiscoveryInputOptions;
   options.network.discv5.enr = await createEnr(peerId);
   const beaconPaths = getBeaconPaths(options);
   options = {...options, ...beaconPaths};

--- a/packages/lodestar-cli/src/cmds/index.ts
+++ b/packages/lodestar-cli/src/cmds/index.ts
@@ -6,4 +6,4 @@ import {dev} from "./dev";
 import {init} from "./init";
 import {validator} from "./validator";
 
-export const cmds: ICliCommand<IGlobalArgs, {}>["subcommands"] = [beacon, validator, account, init, dev];
+export const cmds: Required<ICliCommand<IGlobalArgs, {}>>["subcommands"] = [beacon, validator, account, init, dev];

--- a/packages/lodestar-cli/src/cmds/init/handler.ts
+++ b/packages/lodestar-cli/src/cmds/init/handler.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import path from "path";
 import deepmerge from "deepmerge";
+import {IDiscv5DiscoveryInputOptions} from "@chainsafe/discv5";
 import {initBeaconConfig} from "../../config/beacon";
 import {IGlobalArgs} from "../../options";
 import {mkdir, getBeaconConfig} from "../../util";
@@ -31,6 +32,8 @@ export async function initHandler(options: IBeaconArgs & IGlobalArgs): Promise<v
   if (options.testnet && !fs.existsSync(options.paramsFile)) {
     const testnetConfig = getTestnetConfig(options.testnet);
     try {
+      if (!testnetConfig.network) testnetConfig.network = {};
+      if (!testnetConfig.network.discv5) testnetConfig.network.discv5 = {} as IDiscv5DiscoveryInputOptions;
       testnetConfig.network.discv5.bootEnrs = await fetchBootnodes(options.testnet);
     } catch (e) {
       // eslint-disable-next-line no-console

--- a/packages/lodestar-cli/src/docGeneration.ts
+++ b/packages/lodestar-cli/src/docGeneration.ts
@@ -20,10 +20,10 @@ fs.writeFileSync(docsMarkdownPath, renderMarkdownSections(
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function cmdToMarkdownSection(cmd: ICliCommand<any>, parentCommand?: string): IMarkdownSection {
   const commandJson = [parentCommand, cmd.command.replace("<command>", "")].filter(Boolean).join(" ");
-  const section: IMarkdownSection = {
+  const section = {
     title: `\`${commandJson}\``, 
     body: cmd.describe,
-    subsections: []
+    subsections: [] as IMarkdownSection[]
   };
   if (cmd.options) {
     section.subsections.push({
@@ -32,7 +32,7 @@ function cmdToMarkdownSection(cmd: ICliCommand<any>, parentCommand?: string): IM
       subsections: Object.entries(cmd.options)
         .filter(([, opt]) => !opt.hidden)
         .map(([key, opt]) => {
-          return {title: key, body: opt.description || opt.describe};
+          return {title: key, body: opt.description || opt.describe || ""};
         })
     });
   }

--- a/packages/lodestar-cli/src/network/peerId.ts
+++ b/packages/lodestar-cli/src/network/peerId.ts
@@ -1,5 +1,5 @@
 import PeerId from "peer-id";
-
+import {Json} from "@chainsafe/ssz";
 import {writeFile, readFile} from "../util";
 
 export async function createPeerId(): Promise<PeerId> {
@@ -7,7 +7,7 @@ export async function createPeerId(): Promise<PeerId> {
 }
 
 export async function writePeerId(filename: string, peerId: PeerId): Promise<void> {
-  await writeFile(filename, peerId.toJSON());
+  await writeFile(filename, peerId.toJSON() as Json);
 }
 
 export async function readPeerId(filename: string): Promise<PeerId> {

--- a/packages/lodestar-cli/src/util/enr.ts
+++ b/packages/lodestar-cli/src/util/enr.ts
@@ -15,7 +15,7 @@ export function updateENR(enr: ENR, args: IENRArgs & IBeaconNodeOptions): void {
       throw new Error(`Invalid tcp multiaddr: ${e.message}`);
     }
   }
-  if (args.network.discv5.bindAddr) {
+  if (args.network.discv5?.bindAddr) {
     try {
       const udpOpts = Multiaddr(args.network.multiaddrs[0]).toOptions();
       if (udpOpts.transport === "udp") {

--- a/packages/lodestar-cli/src/util/ethers.ts
+++ b/packages/lodestar-cli/src/util/ethers.ts
@@ -17,7 +17,7 @@ export async function getEthersSigner({
   rpcPassword?: string;
   ipcPath?: string;
 }): Promise<ethers.Signer> {
-  if (keystorePath) {
+  if (keystorePath && keystorePassword) {
     const keystoreJson = fs.readFileSync(keystorePath, "utf8");
     const wallet = await ethers.Wallet.fromEncryptedJson(keystoreJson, keystorePassword);
     const eth1Provider = rpcUrl

--- a/packages/lodestar-cli/src/validatorDir/ValidatorDirBuilder.ts
+++ b/packages/lodestar-cli/src/validatorDir/ValidatorDirBuilder.ts
@@ -33,7 +33,7 @@ interface IValidatorDirBuildOptions {
    * randomly. When this random keystore is generated, calls to this function are ignored and
    * the withdrawal keystore is *always* stored to disk. This is to prevent data loss.
    */
-  storeWithdrawalKeystore: boolean;
+  storeWithdrawalKeystore?: boolean;
   depositGwei: bigint;
   config: IBeaconConfig;
 }

--- a/packages/lodestar-cli/src/wallet/Wallet.ts
+++ b/packages/lodestar-cli/src/wallet/Wallet.ts
@@ -24,8 +24,7 @@ export interface IWalletKeystoreJson {
 }
 
 export class Wallet extends Keystore {
-  keystore: Keystore;
-  name: string;
+  name?: string;
   nextaccount: number;
   version: number;
   type: string;
@@ -60,7 +59,7 @@ export class Wallet extends Keystore {
     return {
       crypto: this.crypto.toObject(),
       uuid: this.uuid,
-      name: this.name,
+      name: this.name || "",
       nextaccount: this.nextaccount,
       version: this.version,
       type: this.type

--- a/packages/lodestar-spec-test-util/src/multi.ts
+++ b/packages/lodestar-spec-test-util/src/multi.ts
@@ -81,7 +81,7 @@ export function describeMultiSpec<TestCase extends IBaseCase, Result>(
             const profile = profiler.stopProfiling(profileId);
             const directory = env.GEN_PROFILE_DIR || __dirname;
             profile.export((error, result) => {
-              if (error) {
+              if (error || result === undefined) {
                 return;
               }
               writeFile(`${directory}/${profileId}`, result, () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2540,10 +2540,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.20.tgz#e6d8b3631af1e59bbb4fda04926b078acdd3c2ef"
   integrity sha512-XgDgo6W10SeGEAM0k7FosJpvLCynOTYns4Xk3J5HGrA+UI/bKZ30PGMzOP5Lh2zs4259I71FSYLAtjnx3qhObw==
 
-"@types/node@^12.12.21", "@types/node@^12.6.1", "@types/node@^12.7.2":
+"@types/node@^12.6.1", "@types/node@^12.7.2":
   version "12.12.36"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.36.tgz#162c8c2a2e659da480049df0e19ae128ad3a1527"
   integrity sha512-hmmypvyO/uTLFYCYu6Hlb3ydeJ11vXRxg8/WJ0E3wvwmPO0y47VqnfmXFVuWlysO0Zyj+je1Y33rQeuYkZ51GQ==
+
+"@types/node@^14.0.27":
+  version "14.0.27"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
+  integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2540,15 +2540,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.20.tgz#e6d8b3631af1e59bbb4fda04926b078acdd3c2ef"
   integrity sha512-XgDgo6W10SeGEAM0k7FosJpvLCynOTYns4Xk3J5HGrA+UI/bKZ30PGMzOP5Lh2zs4259I71FSYLAtjnx3qhObw==
 
+"@types/node@^12.12.21":
+  version "12.12.54"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.54.tgz#a4b58d8df3a4677b6c08bfbc94b7ad7a7a5f82d1"
+  integrity sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w==
+
 "@types/node@^12.6.1", "@types/node@^12.7.2":
   version "12.12.36"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.36.tgz#162c8c2a2e659da480049df0e19ae128ad3a1527"
   integrity sha512-hmmypvyO/uTLFYCYu6Hlb3ydeJ11vXRxg8/WJ0E3wvwmPO0y47VqnfmXFVuWlysO0Zyj+je1Y33rQeuYkZ51GQ==
-
-"@types/node@^14.0.27":
-  version "14.0.27"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
-  integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
Parallelizable effort to tackle #885. Sets strictNullChecks = true in a single package so eventually it can be set in the root tsconfig.

Since `lodestar-cli` depends on `lodestar` until all errors are resolved (see https://github.com/ChainSafe/lodestar/pull/1378) there the check can't be turned on here. This PR fixes the existing errors to ease future work.