### PR TITLE
Connect to the correct chainId with ethers default provider

### DIFF
--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/deposit.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/deposit.ts
@@ -91,7 +91,10 @@ The deposit contract address will be determined by the spec config flag.",
     // eslint-disable-next-line no-console
     console.log(`Starting ${validatorDirsToSubmit.length} deposits`);
 
-    const eth1Signer = await getEthersSigner(options);
+    const eth1Signer = await getEthersSigner({
+      ...options,
+      chainId: config.params.DEPOSIT_NETWORK_ID
+    });
 
     for (const validatorDir of validatorDirsToSubmit) {
       const {rlp, depositData} = validatorDir.eth1DepositData(config);

--- a/packages/lodestar-cli/src/util/ethers.ts
+++ b/packages/lodestar-cli/src/util/ethers.ts
@@ -10,19 +10,21 @@ export async function getEthersSigner({
   rpcUrl,
   rpcPassword,
   ipcPath,
+  chainId
 }: {
   keystorePath?: string;
   keystorePassword?: string;
   rpcUrl?: string;
   rpcPassword?: string;
   ipcPath?: string;
+  chainId: number;
 }): Promise<ethers.Signer> {
   if (keystorePath) {
     const keystoreJson = fs.readFileSync(keystorePath, "utf8");
     const wallet = await ethers.Wallet.fromEncryptedJson(keystoreJson, keystorePassword);
     const eth1Provider = rpcUrl
       ? new ethers.providers.JsonRpcProvider(rpcUrl)
-      : ethers.getDefaultProvider();
+      : new ethers.providers.InfuraProvider({name: "deposit", chainId});
     return wallet.connect(eth1Provider);
   }
 


### PR DESCRIPTION
On CLI cmd `accounts validator deposit`, fetch deposit chain ID from params to initialize an ethers default provider

Fixes https://github.com/ChainSafe/lodestar/issues/1340.