### PR TITLE
tmp dep for cli e2e tests

### DIFF
--- a/packages/lodestar-cli/test/e2e/constants.ts
+++ b/packages/lodestar-cli/test/e2e/constants.ts
@@ -1,2 +1,6 @@
-export const rootDir = ".tmp";
+import tmp from "tmp";
+
+const tmpDir = tmp.dirSync({unsafeCleanup: true});
+
+export const rootDir = tmpDir.name;
 export const passphraseFile = "primary.pass";


### PR DESCRIPTION
use the `tmp` dependency inside the lodestar-cli e2e tests instead of using a hardcoded ".tmp" directory