### PR TITLE
Optimize post block processing

### DIFF
--- a/packages/lodestar/src/db/api/beacon/repositories/depositData.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/depositData.ts
@@ -21,6 +21,10 @@ export class DepositDataRepository extends Repository<number, DepositData> {
   }
 
   public async deleteOld(depositCount: number): Promise<void> {
-    await this.batchDelete(Array.from({length: depositCount}, (_, i) => i));
+    const firstDepositIndex = await this.firstKey();
+    if(firstDepositIndex !== 0 && !firstDepositIndex) {
+      return;
+    }
+    await this.batchDelete(Array.from({length: depositCount - firstDepositIndex}, (_, i) => i + firstDepositIndex));
   }
 }

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -290,7 +290,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
           await getPeerSupportedProtocols(this.config, this.reps, peerId, this.network.reqResp);
         this.reps.get(peerId.toB58String()).supportedProtocols = [Method.Status, ...supportedProtocols];
       } catch (e) {
-        this.logger.error(`Failed to get peer ${peerId.toB58String()} latest status`, e);
+        this.logger.warn(`Failed to get peer ${peerId.toB58String()} latest status`, {reason: e.message});
         await this.network.disconnect(peerId);
       }
     }

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -231,9 +231,12 @@ export async function getPeerSupportedProtocols(
   if (!finalizedBlock || finalizedBlock.length !== 1) {
     return [];
   }
-  const supportedProtocols = [Method.BeaconBlocksByRoot];
   const parentRoot = finalizedBlock[0].message.parentRoot;
   const parentBlock = await reqResp.beaconBlocksByRoot(peerId, [parentRoot]);
+  if(!parentBlock) {
+    return [];
+  }
+  const supportedProtocols = [Method.BeaconBlocksByRoot];
   const testReqResp: BeaconBlocksByRangeRequest = {
     startSlot: parentBlock[0].message.slot,
     count: 2,

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -233,7 +233,7 @@ export async function getPeerSupportedProtocols(
   }
   const parentRoot = finalizedBlock[0].message.parentRoot;
   const parentBlock = await reqResp.beaconBlocksByRoot(peerId, [parentRoot]);
-  if(!parentBlock) {
+  if(!parentBlock || parentBlock.length !== 1) {
     return [];
   }
   const supportedProtocols = [Method.BeaconBlocksByRoot];


### PR DESCRIPTION
Changelog:
- fix "message of undefined" errors in getSupportedPeerProtocol method
- hide scary errors and stacktraces when probing peers - removed stacktrace, message level changed to warn
- rather huge performance boost in method that removes old data from db
   - tldr we were trying to delete 20k deposits from db every time even though they don't exists. This removed 20k key encoding calls as well as level db searches for those keys (@wemeetagain  seems like that was gray blocks in profiler since I don't see them anymore)