### PR TITLE
Enforce not committing .only in tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,8 @@ module.exports = {
   plugins: [
     "@typescript-eslint",
     "eslint-plugin-import",
-    "eslint-plugin-node"
+    "eslint-plugin-node",
+    "no-only-tests"
   ],
   extends: [
     "eslint:recommended",
@@ -81,7 +82,10 @@ module.exports = {
     "no-prototype-builtins": 0,
     "prefer-const": "error",
     "quotes": ["error", "double"],
-    "semi": "off"
+    "semi": "off",
+
+    // Prevents accidentally pushing a commit with .only in Mocha tests
+    "no-only-tests/no-only-tests": "error"
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "codecov": "^3.6.5",
     "eslint": "^6.8.0",
     "eslint-plugin-import": "^2.20.1",
+    "eslint-plugin-no-only-tests": "^2.4.0",
     "eslint-plugin-node": "^11.1.0",
     "lerna": "^3.20.2",
     "mocha": "^6.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6630,6 +6630,11 @@ eslint-plugin-import@^2.20.1:
     read-pkg-up "^2.0.0"
     resolve "^1.12.0"
 
+eslint-plugin-no-only-tests@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.4.0.tgz#7d565434aa7d16ccc7eea957c391d98f827332ca"
+  integrity sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==
+
 eslint-plugin-node@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"


### PR DESCRIPTION
If unchecked the CI pipeline can look like it's all good when only one single test was run.