### PR TITLE
Sync uses forkchoice latest() instead of head()

### DIFF
--- a/packages/lodestar/src/chain/blocks/post.ts
+++ b/packages/lodestar/src/chain/blocks/post.ts
@@ -41,7 +41,7 @@ export function postProcess(
         if (computeEpochAtSlot(config, preSlot) < currentEpoch) {
           eventBus.emit("processedCheckpoint", {
             epoch: currentEpoch,
-            root: forkChoice.getCanonicalBlockSummaryAtSlot(preSlot).blockRoot,
+            root: block.message.parentRoot,
           });
           // newly justified epoch
           if (preJustifiedEpoch < postStateContext.state.currentJustifiedCheckpoint.epoch) {

--- a/packages/lodestar/src/chain/forkChoice/arrayDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/arrayDag/lmdGhost.ts
@@ -331,6 +331,13 @@ export class ArrayDagLMDGHOST extends (EventEmitter as {new (): ForkChoiceEventE
     this.synced = true;
   }
 
+  public latest(): BlockSummary {
+    if (!this.nodes || this.nodes.length === 0) {
+      return null;
+    }
+    return this.toBlockSummary(this.nodes[this.nodes.length - 1]);
+  }
+
   public head(): BlockSummary {
     if (!this.headNode()) {
       return null;

--- a/packages/lodestar/src/chain/forkChoice/interface.ts
+++ b/packages/lodestar/src/chain/forkChoice/interface.ts
@@ -19,6 +19,7 @@ export interface ILMDGHOST extends ForkChoiceEventEmitter {
   addBlock(info: BlockSummary): void;
   addAttestation(blockRoot: Uint8Array, attester: ValidatorIndex, weight: Gwei): void;
   head(): BlockSummary;
+  latest(): BlockSummary;
   headBlockSlot(): Slot;
   headBlockRoot(): Uint8Array;
   headStateRoot(): Uint8Array;

--- a/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/statefulDag/lmdGhost.ts
@@ -277,6 +277,10 @@ export class StatefulDagLMDGHOST extends (EventEmitter as {new (): ForkChoiceEve
    * Best justified checkpoint.
    */
   private bestJustifiedCheckpoint: Checkpoint;
+  /**
+   * The lastest block summary
+   */
+  private latestBlockSummary: BlockSummary;
   private synced: boolean;
   private clock: IBeaconClock;
 
@@ -385,6 +389,9 @@ export class StatefulDagLMDGHOST extends (EventEmitter as {new (): ForkChoiceEve
     if (shouldCheckBestTarget) {
       this.ensureCorrectBestTargets();
     }
+    if (!this.latestBlockSummary || this.latestBlockSummary.slot < slot) {
+      this.latestBlockSummary = node.toBlockSummary();
+    }
   }
 
   public getNode(blockRootBuf: Uint8Array): Node {
@@ -428,6 +435,10 @@ export class StatefulDagLMDGHOST extends (EventEmitter as {new (): ForkChoiceEve
     });
 
     this.synced = true;
+  }
+
+  public latest(): BlockSummary {
+    return this.latestBlockSummary;
   }
 
   public head(): BlockSummary {

--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -62,7 +62,7 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
     this.chain.on("processedCheckpoint", this.checkSyncCompleted);
     this.chain.on("processedBlock", this.checkSyncProgress);
     this.syncTriggerSource = pushable<ISlotRange>();
-    this.blockImportTarget = this.chain.forkChoice.latest().slot;
+    this.blockImportTarget = this.chain.forkChoice.headBlockSlot();
     this.targetCheckpoint = getCommonFinalizedCheckpoint(
       this.config,
       this.network.getPeers().map((peer) => this.reps.getFromPeerId(peer))

--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -62,7 +62,7 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
     this.chain.on("processedCheckpoint", this.checkSyncCompleted);
     this.chain.on("processedBlock", this.checkSyncProgress);
     this.syncTriggerSource = pushable<ISlotRange>();
-    this.blockImportTarget = this.chain.forkChoice.headBlockSlot();
+    this.blockImportTarget = this.chain.forkChoice.latest().slot;
     this.targetCheckpoint = getCommonFinalizedCheckpoint(
       this.config,
       this.network.getPeers().map((peer) => this.reps.getFromPeerId(peer))

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -54,17 +54,17 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
 
   public async start(): Promise<void> {
     this.chain.on("processedBlock", this.onProcessedBlock);
-    const headSlot = this.chain.forkChoice.headBlockSlot();
+    const {slot: lastSlot} = this.chain.forkChoice.latest();
     const state = await this.chain.getHeadState();
     const currentSlot = getCurrentSlot(this.config, state.genesisTime);
-    this.logger.info("Started regular syncing", {currentSlot, headSlot});
-    if (headSlot >= currentSlot) {
-      this.logger.info(`Regular Sync: node is up to date, headSlot=${headSlot}`);
+    this.logger.info("Started regular syncing", {currentSlot, lastSlot});
+    if (lastSlot >= currentSlot) {
+      this.logger.info(`Regular Sync: node is up to date, lastSlot=${lastSlot}`);
       this.emit("syncCompleted");
       await this.stop();
       return;
     }
-    this.currentTarget = headSlot;
+    this.currentTarget = lastSlot;
     this.logger.verbose(`Regular Sync: Current slot at start: ${currentSlot}`);
     this.targetSlotRangeSource = pushable<ISlotRange>();
     this.controller = new AbortController();

--- a/packages/lodestar/test/unit/chain/forkChoice/arrayDag.test.ts
+++ b/packages/lodestar/test/unit/chain/forkChoice/arrayDag.test.ts
@@ -727,11 +727,11 @@ describe("ArrayDagLMDGHOST", () => {
     });
   });
 
-  describe("getAncestor", () => {
+  describe("getAncestor and latest", () => {
     /**
      * genesis - a - b -c
      */
-    it("should return correct ancestor", () => {
+    it("should return correct ancestor and latest", () => {
       addBlock(
         lmd,
         GENESIS_SLOT,
@@ -775,6 +775,14 @@ describe("ArrayDagLMDGHOST", () => {
       expect(Buffer.from(lmd.getAncestor(blockC, slotA + 1))).to.be.deep.equal(blockA);
       expect(Buffer.from(lmd.getAncestor(genesis, GENESIS_SLOT))).to.be.deep.equal(genesis);
       expect(lmd.getAncestor(genesis, GENESIS_SLOT - 1)).to.be.equal(null);
+      expect(lmd.latest()).to.be.deep.equal({
+        slot: slotC,
+        blockRoot: blockC,
+        parentRoot: blockB,
+        stateRoot: stateC,
+        justifiedCheckpoint: {root: genesis, epoch: GENESIS_EPOCH},
+        finalizedCheckpoint: {root: genesis, epoch: GENESIS_EPOCH}
+      });
     });
   });
 

--- a/packages/lodestar/test/unit/sync/initial/fast.test.ts
+++ b/packages/lodestar/test/unit/sync/initial/fast.test.ts
@@ -2,7 +2,7 @@ import {describe} from "mocha";
 import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
 import {FastSync} from "../../../../src/sync/initial/fast";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {BeaconChain, IBeaconChain, ILMDGHOST, StatefulDagLMDGHOST} from "../../../../src/chain";
+import {BeaconChain, IBeaconChain, ILMDGHOST, StatefulDagLMDGHOST, BlockSummary} from "../../../../src/chain";
 import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {INetwork, Libp2pNetwork} from "../../../../src/network";
 import {ReputationStore} from "../../../../src/sync/IReputation";
@@ -35,7 +35,7 @@ describe("fast sync", function () {
   });
 
   it("no peers with finalized epoch", async function () {
-    forkChoiceStub.headBlockSlot.returns(0);
+    forkChoiceStub.latest.returns({slot: 0} as BlockSummary);
     const sync = new FastSync(
       {blockPerChunk: 5, maxSlotImport: 10, minPeers: 0},
       {
@@ -57,7 +57,7 @@ describe("fast sync", function () {
   it("should sync till target and end", function (done) {
     const chainEventEmitter = new EventEmitter();
     const forkChoiceStub = sinon.createStubInstance(StatefulDagLMDGHOST);
-    forkChoiceStub.headBlockSlot.returns(0);
+    forkChoiceStub.latest.returns({slot: 0} as BlockSummary);
     // @ts-ignore
     chainEventEmitter.forkChoice = forkChoiceStub;
     const statsStub = sinon.createStubInstance(SyncStats);
@@ -97,7 +97,7 @@ describe("fast sync", function () {
   it("should continue syncing if there is new target", function (done) {
     const chainEventEmitter = new EventEmitter();
     const forkChoiceStub = sinon.createStubInstance(StatefulDagLMDGHOST);
-    forkChoiceStub.headBlockSlot.returns(0);
+    forkChoiceStub.latest.returns({slot: 0} as BlockSummary);
     // @ts-ignore
     chainEventEmitter.forkChoice = forkChoiceStub;
     const statsStub = sinon.createStubInstance(SyncStats);


### PR DESCRIPTION
this is a copy of #1288

+ the current situation with Medalla regular sync is we started with head block, there are more blocks after that in our db. Then we fetch blocks from the best peer and chain processor found we had those blocks already and it does not emit "processedBlock" and regular sync gets stuck.
+ so we should start with `forkchoice.latest()` instead of `forkchoice.head()`