### PR TITLE
Fix loop edge case in chunkify function

### DIFF
--- a/packages/lodestar/src/sync/utils/blocks.ts
+++ b/packages/lodestar/src/sync/utils/blocks.ts
@@ -20,18 +20,11 @@ export function chunkify(blocksPerChunk: number, currentSlot: Slot, targetSlot: 
   }
   const chunks: ISlotRange[] = [];
   //currentSlot is our state slot so we need block from next slot
-  for (let i = currentSlot; i < targetSlot; i = i + blocksPerChunk + 1) {
-    if (i + blocksPerChunk > targetSlot) {
-      chunks.push({
-        start: i,
-        end: targetSlot,
-      });
-    } else {
-      chunks.push({
-        start: i,
-        end: i + blocksPerChunk,
-      });
-    }
+  for (let i = currentSlot; i <= targetSlot; i = i + blocksPerChunk + 1) {
+    chunks.push({
+      start: i,
+      end: Math.min(i + blocksPerChunk, targetSlot),
+    });
   }
   return chunks;
 }

--- a/packages/lodestar/test/unit/sync/utils/block.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/block.test.ts
@@ -78,6 +78,17 @@ describe("sync - block utils", function () {
       expect(result[2].start).to.be.equal(22);
       expect(result[2].end).to.be.equal(25);
     });
+
+    it("should produce a one-length chunk", function () {
+      const result = chunkify(10, 0, 22);
+      expect(result.length).to.be.equal(3);
+      expect(result[0].start).to.be.equal(0);
+      expect(result[0].end).to.be.equal(10);
+      expect(result[1].start).to.be.equal(11);
+      expect(result[1].end).to.be.equal(21);
+      expect(result[2].start).to.be.equal(22);
+      expect(result[2].end).to.be.equal(22);
+    });
   });
 
   describe("verify header chain", function () {


### PR DESCRIPTION
While investigating some other stuff I found a likely bug in the chunkify function in `blocks.ts`. It seems to not produce the last chunk if it's supposed to be of length 1 (where `start` and `end` both equal `targetSlot`).

An alternate explanation is that the loop exits early if `i + blocksPerChunk` ever ends up equaling `targetSlot - 1`.

Along with a fix, I also included a new test that covers this case.