### PR TITLE
Sync: handle failed to get block range

### DIFF
--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -20,7 +20,7 @@ import {GENESIS_EPOCH, Method} from "../../../constants";
 import {ISyncStats, SyncStats} from "../../stats";
 import {IBeaconDb} from "../../../db";
 
-export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}) implements InitialSync {
+export class FastSync extends (EventEmitter as {new(): InitialSyncEventEmitter}) implements InitialSync {
   private readonly opts: ISyncOptions;
   private readonly config: IBeaconConfig;
   private readonly chain: IBeaconChain;
@@ -121,7 +121,7 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
   };
 
   private setBlockImportTarget = (fromSlot?: Slot): void => {
-    const lastTarget = typeof fromSlot === "number" ? fromSlot : this.blockImportTarget;
+    const lastTarget = fromSlot ?? this.blockImportTarget;
     const newTarget = this.getNewBlockImportTarget(lastTarget);
     this.logger.info(`Fetching blocks for ${lastTarget + 1}...${newTarget} slot range`);
     this.syncTriggerSource.push({start: lastTarget + 1, end: newTarget});
@@ -183,8 +183,8 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
     );
     this.logger.important(
       `Sync progress - currentEpoch=${processedCheckpoint.epoch},` +
-        ` targetEpoch=${this.targetCheckpoint!.epoch}, speed=${this.stats.getSyncSpeed().toFixed(1)} slots/s` +
-        `, estimateTillComplete=${Math.round((estimate / 3600) * 10) / 10} hours`
+      ` targetEpoch=${this.targetCheckpoint!.epoch}, speed=${this.stats.getSyncSpeed().toFixed(1)} slots/s` +
+      `, estimateTillComplete=${Math.round((estimate / 3600) * 10) / 10} hours`
     );
     if (processedCheckpoint.epoch === this.targetCheckpoint!.epoch) {
       //this doesn't work because finalized checkpoint root is first slot of that epoch as per ffg,

--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -20,7 +20,7 @@ import {GENESIS_EPOCH, Method} from "../../../constants";
 import {ISyncStats, SyncStats} from "../../stats";
 import {IBeaconDb} from "../../../db";
 
-export class FastSync extends (EventEmitter as {new(): InitialSyncEventEmitter}) implements InitialSync {
+export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}) implements InitialSync {
   private readonly opts: ISyncOptions;
   private readonly config: IBeaconConfig;
   private readonly chain: IBeaconChain;
@@ -183,8 +183,8 @@ export class FastSync extends (EventEmitter as {new(): InitialSyncEventEmitter})
     );
     this.logger.important(
       `Sync progress - currentEpoch=${processedCheckpoint.epoch},` +
-      ` targetEpoch=${this.targetCheckpoint!.epoch}, speed=${this.stats.getSyncSpeed().toFixed(1)} slots/s` +
-      `, estimateTillComplete=${Math.round((estimate / 3600) * 10) / 10} hours`
+        ` targetEpoch=${this.targetCheckpoint!.epoch}, speed=${this.stats.getSyncSpeed().toFixed(1)} slots/s` +
+        `, estimateTillComplete=${Math.round((estimate / 3600) * 10) / 10} hours`
     );
     if (processedCheckpoint.epoch === this.targetCheckpoint!.epoch) {
       //this doesn't work because finalized checkpoint root is first slot of that epoch as per ffg,

--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -121,7 +121,7 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
   };
 
   private setBlockImportTarget = (fromSlot?: Slot): void => {
-    const lastTarget = fromSlot || this.blockImportTarget;
+    const lastTarget = typeof fromSlot === "number" ? fromSlot : this.blockImportTarget;
     const newTarget = this.getNewBlockImportTarget(lastTarget);
     this.logger.info(`Fetching blocks for ${lastTarget + 1}...${newTarget} slot range`);
     this.syncTriggerSource.push({start: lastTarget + 1, end: newTarget});
@@ -147,17 +147,19 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
             processSyncBlocks(config, chain, logger, true, getLastProcessedBlock(), true)
           );
           logger.verbose("last processed slot=" + lastSlot + ` range=${JSON.stringify(slotRange)}`);
-          if (lastSlot) {
+          if (typeof lastSlot === "number") {
             if (lastSlot === getLastProcessedBlock().message.slot) {
               // failed at start of range
               logger.warn(`Failed to process range, retrying, lastSlot=${lastSlot} range=${JSON.stringify(slotRange)}`);
               setBlockImportTarget(lastSlot);
             } else {
-              //set new target from last block we've processed
+              // success
+              // set new target from last block we've processed
               // it will trigger new sync once last block is processed
               updateBlockImportTarget(lastSlot);
             }
           } else {
+            // no blocks in range
             logger.warn(`Didn't receive any valid block in range range ${JSON.stringify(slotRange)}`);
             //we didn't receive any block, set target from last requested slot
             setBlockImportTarget(slotRange.end);

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -95,7 +95,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
   }
 
   private setTarget = (newTarget?: Slot, triggerSync = true): void => {
-    newTarget = newTarget || this.getNewTarget();
+    newTarget = typeof newTarget === "number" ? newTarget : this.getNewTarget();
     if (triggerSync && newTarget > this.currentTarget) {
       this.logger.info(`Regular Sync: Requesting blocks from slot ${this.currentTarget + 1} to slot ${newTarget}`);
       this.targetSlotRangeSource.push({start: this.currentTarget + 1, end: newTarget});
@@ -140,7 +140,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
   private async sync(): Promise<void> {
     const {config, logger, chain, controller} = this;
     const reqResp = this.network.reqResp;
-    const {getSyncPeers, setTarget, handleEmptyRange} = this;
+    const {getSyncPeers, setTarget, handleEmptyRange, handleFailedToGetRange} = this;
     await pipe(this.targetSlotRangeSource, (source) => {
       return (async function () {
         for await (const range of abortSource(source, controller.signal, {returnOnAbort: true})) {
@@ -150,8 +150,13 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
             processSyncBlocks(config, chain, logger, false, null)
           );
           if (lastFetchedSlot) {
-            // not trigger sync until after we process lastFetchedSlot
-            setTarget(lastFetchedSlot, false);
+            // failed to fetch range
+            if (lastFetchedSlot === chain.forkChoice.headBlockSlot()) {
+              handleFailedToGetRange(range);
+            } else {
+              // success, not trigger sync until after we process lastFetchedSlot
+              setTarget(lastFetchedSlot, false);
+            }
           } else {
             // no block, retry expanded range with same start slot
             await handleEmptyRange(range);
@@ -175,6 +180,13 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
       this.setTarget(range.start - 1, false);
       this.setTarget();
     }
+  };
+
+  private handleFailedToGetRange = (range: ISlotRange): void => {
+    this.logger.warn(`Regular Sync: retrying range ${JSON.stringify(range)}`);
+    // retry again
+    this.setTarget(range.start - 1, false);
+    this.setTarget();
   };
 
   /**

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -20,7 +20,7 @@ import {toHexString} from "@chainsafe/ssz";
 import {sleep} from "../../../util/sleep";
 import {EventEmitter} from "events";
 
-export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEventEmitter}) implements IRegularSync {
+export class NaiveRegularSync extends (EventEmitter as {new(): RegularSyncEventEmitter}) implements IRegularSync {
   private readonly config: IBeaconConfig;
 
   private readonly network: INetwork;
@@ -95,7 +95,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
   }
 
   private setTarget = (newTarget?: Slot, triggerSync = true): void => {
-    newTarget = typeof newTarget === "number" ? newTarget : this.getNewTarget();
+    newTarget = newTarget ?? this.getNewTarget();
     if (triggerSync && newTarget > this.currentTarget) {
       this.logger.info(`Regular Sync: Requesting blocks from slot ${this.currentTarget + 1} to slot ${newTarget}`);
       this.targetSlotRangeSource.push({start: this.currentTarget + 1, end: newTarget});
@@ -110,7 +110,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
       }
       this.logger.info(
         `Regular Sync: Synced up to slot ${lastProcessedBlock.message.slot} ` +
-          `gossipParentBlockRoot=${this.gossipParentBlockRoot && toHexString(this.gossipParentBlockRoot)}`
+        `gossipParentBlockRoot=${this.gossipParentBlockRoot && toHexString(this.gossipParentBlockRoot)}`
       );
       this.setTarget();
     }
@@ -120,7 +120,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
     this.gossipParentBlockRoot = block.message.parentRoot;
     this.logger.verbose(
       `Regular Sync: Set gossip parent block to ${toHexString(this.gossipParentBlockRoot)}` +
-        `, gossip slot ${block.message.slot}`
+      `, gossip slot ${block.message.slot}`
     );
     await this.checkSyncComplete();
   };

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -20,7 +20,7 @@ import {toHexString} from "@chainsafe/ssz";
 import {sleep} from "../../../util/sleep";
 import {EventEmitter} from "events";
 
-export class NaiveRegularSync extends (EventEmitter as {new(): RegularSyncEventEmitter}) implements IRegularSync {
+export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEventEmitter}) implements IRegularSync {
   private readonly config: IBeaconConfig;
 
   private readonly network: INetwork;
@@ -110,7 +110,7 @@ export class NaiveRegularSync extends (EventEmitter as {new(): RegularSyncEventE
       }
       this.logger.info(
         `Regular Sync: Synced up to slot ${lastProcessedBlock.message.slot} ` +
-        `gossipParentBlockRoot=${this.gossipParentBlockRoot && toHexString(this.gossipParentBlockRoot)}`
+          `gossipParentBlockRoot=${this.gossipParentBlockRoot && toHexString(this.gossipParentBlockRoot)}`
       );
       this.setTarget();
     }
@@ -120,7 +120,7 @@ export class NaiveRegularSync extends (EventEmitter as {new(): RegularSyncEventE
     this.gossipParentBlockRoot = block.message.parentRoot;
     this.logger.verbose(
       `Regular Sync: Set gossip parent block to ${toHexString(this.gossipParentBlockRoot)}` +
-      `, gossip slot ${block.message.slot}`
+        `, gossip slot ${block.message.slot}`
     );
     await this.checkSyncComplete();
   };

--- a/packages/lodestar/test/unit/sync/utils/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/sync.test.ts
@@ -175,7 +175,8 @@ describe("sync utils", function () {
       );
       await timer.tickAsync(30000);
       result = await result;
-      expect(result.length).to.be.equal(0);
+      expect(result.length).to.be.equal(1);
+      expect(result[0]).to.be.null;
     });
 
     it("happy path", async function () {
@@ -214,11 +215,53 @@ describe("sync utils", function () {
       const block2 = generateEmptySignedBlock();
       block2.message.slot = 3;
       block2.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(block1.message);
-      await pipe(
+      const lastProcesssedSlot = await pipe(
         [[block2], [block1]],
         processSyncBlocks(config, chainStub, sinon.createStubInstance(WinstonLogger), true, lastProcessedBlock)
       );
       expect(chainStub.receiveBlock.calledTwice).to.be.true;
+      expect(lastProcesssedSlot).to.be.equal(3);
+    });
+
+    it("should handle failed to get range - initial sync", async function () {
+      const lastProcessedBlock = generateEmptySignedBlock();
+      lastProcessedBlock.message.slot = 10;
+      const lastProcessSlot = await pipe(
+        // failed to fetch range
+        [null],
+        processSyncBlocks(config, chainStub, sinon.createStubInstance(WinstonLogger), true, lastProcessedBlock)
+      );
+      expect(lastProcessSlot).to.be.equal(10);
+    });
+
+    it("should handle failed to get range - regular sync", async function () {
+      forkChoiceStub.headBlockSlot.returns(100);
+      const lastProcessSlot = await pipe(
+        // failed to fetch range
+        [null],
+        processSyncBlocks(config, chainStub, sinon.createStubInstance(WinstonLogger), false, null)
+      );
+      expect(lastProcessSlot).to.be.equal(100);
+    });
+
+    it("should handle empty range - initial sync", async function () {
+      const lastProcessedBlock = generateEmptySignedBlock();
+      lastProcessedBlock.message.slot = 10;
+      const lastProcessSlot = await pipe(
+        // failed to fetch range
+        [[]],
+        processSyncBlocks(config, chainStub, sinon.createStubInstance(WinstonLogger), true, lastProcessedBlock)
+      );
+      expect(lastProcessSlot).to.be.null;
+    });
+
+    it("should handle empty range - regular sync", async function () {
+      const lastProcessSlot = await pipe(
+        // failed to fetch range
+        [[]],
+        processSyncBlocks(config, chainStub, sinon.createStubInstance(WinstonLogger), false, null)
+      );
+      expect(lastProcessSlot).to.be.null;
     });
   });
 
@@ -343,14 +386,14 @@ describe("sync utils", function () {
       expect(checkBestPeer(null!, null!, null!, null!)).to.be.false;
     });
 
-    it("peer is disconnected", async function() {
+    it("peer is disconnected", async function () {
       const peer1 = await PeerId.create();
       networkStub.getPeers.returns([]);
       expect(checkBestPeer(peer1, null!, networkStub, null!)).to.be.false;
       expect(networkStub.getPeers.calledOnce).to.be.true;
     });
 
-    it("peer is connected but no status", async function() {
+    it("peer is connected but no status", async function () {
       const peer1 = await PeerId.create();
       networkStub.getPeers.returns([peer1]);
       const reps = new ReputationStore();
@@ -359,7 +402,7 @@ describe("sync utils", function () {
       expect(forkChoiceStub.headBlockSlot.calledOnce).to.be.false;
     });
 
-    it("peer head slot is not better than us", async function() {
+    it("peer head slot is not better than us", async function () {
       const peer1 = await PeerId.create();
       networkStub.getPeers.returns([peer1]);
       const reps = new ReputationStore();
@@ -376,7 +419,7 @@ describe("sync utils", function () {
       expect(forkChoiceStub.headBlockSlot.calledOnce).to.be.true;
     });
 
-    it("peer is good for best peer", async function() {
+    it("peer is good for best peer", async function () {
       const peer1 = await PeerId.create();
       networkStub.getPeers.returns([peer1]);
       const reps = new ReputationStore();


### PR DESCRIPTION
resolves #1433 

In case of failed to fetch block range, we need to yield null instead of yield nothing so that we can handle in `processSyncBlocks`. Otherwise it's not possible to distinguish empty range vs failed range in `processSyncBlocks` since it always pass `for..await`.