### PR TITLE
Optimize gossip AggregateAndProof validation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -66,9 +66,6 @@ module.exports = {
       "peerDependencies": false
     }],
     "func-call-spacing": "off",
-    "max-len": ["error", {
-      "code": 120
-    }],
     //if --fix is run it messes imports like /lib/presets/minimal & /lib/presets/mainnet
     "import/no-duplicates": "off",
     "node/no-deprecated-api": "error",

--- a/packages/lodestar/src/db/api/beacon/seenAttestationCache.ts
+++ b/packages/lodestar/src/db/api/beacon/seenAttestationCache.ts
@@ -23,7 +23,7 @@ export class SeenAttestationCache {
     this.add(key);
   }
 
-  public async addAggregateAndProod(aggregateAndProof: AggregateAndProof): Promise<void> {
+  public async addAggregateAndProof(aggregateAndProof: AggregateAndProof): Promise<void> {
     const key = this.aggregateAndProofKey(aggregateAndProof);
     this.add(key);
   }
@@ -33,7 +33,7 @@ export class SeenAttestationCache {
     return this.cache.has(key);
   }
 
-  public async hasAggreagateAndProof(aggregateAndProof: AggregateAndProof): Promise<boolean> {
+  public async hasAggregateAndProof(aggregateAndProof: AggregateAndProof): Promise<boolean> {
     const key = this.aggregateAndProofKey(aggregateAndProof);
     return this.cache.has(key);
   }

--- a/packages/lodestar/src/network/gossip/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/network/gossip/validation/aggregateAndProof.ts
@@ -1,0 +1,204 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IBeaconChain} from "../../../chain";
+import {IBeaconDb} from "../../../db/api";
+import {Context, ILogger} from "@chainsafe/lodestar-utils";
+import {
+  AggregateAndProof,
+  Attestation,
+  BeaconState,
+  Epoch,
+  SignedAggregateAndProof,
+  Slot,
+} from "@chainsafe/lodestar-types";
+import {ExtendedValidatorResult} from "../constants";
+import {toHexString} from "@chainsafe/ssz";
+import {ATTESTATION_PROPAGATION_SLOT_RANGE, DomainType, MAXIMUM_GOSSIP_CLOCK_DISPARITY} from "../../../constants";
+import {
+  computeEpochAtSlot,
+  computeSigningRoot,
+  computeStartSlotAtEpoch,
+  getCurrentSlot,
+  getDomain,
+  isAggregatorFromCommitteeLength,
+} from "@chainsafe/lodestar-beacon-state-transition";
+import {isAttestingToInValidBlock} from "./attestation";
+import {getAttestationPreState} from "../utils";
+import {processSlots} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/slot";
+import {PublicKey, Signature} from "@chainsafe/bls";
+
+export async function validateGossipAggregateAndProof(
+  config: IBeaconConfig,
+  chain: IBeaconChain,
+  db: IBeaconDb,
+  logger: ILogger,
+  signedAggregateAndProof: SignedAggregateAndProof
+): Promise<ExtendedValidatorResult> {
+  logger.profile("gossipAggregateAndProofValidation");
+  const aggregateAndProof = signedAggregateAndProof.message;
+  const aggregate = aggregateAndProof.aggregate;
+  const root = config.types.AggregateAndProof.hashTreeRoot(aggregateAndProof);
+  const attestationRoot = config.types.Attestation.hashTreeRoot(aggregate);
+  const logContext = getLogContext(aggregate, aggregateAndProof, root, attestationRoot);
+  logger.verbose("Started gossip aggregate and proof validation", logContext);
+  if (!isValidAggregateAndProofSlot(config, chain.getGenesisTime(), aggregate.data.slot)) {
+    logger.warn("Ignored gossip aggregate and proof", {
+      reason: "invalid slot time",
+      currentSlot: getCurrentSlot(config, chain.getGenesisTime()),
+      ...logContext,
+    });
+    //TODO: aggregate and proof pool to wait until proper slot to replay
+    return ExtendedValidatorResult.ignore;
+  }
+  if (await db.seenAttestationCache.hasAggregateAndProof(aggregateAndProof)) {
+    logger.warn("Ignored gossip aggregate and proof", {
+      reason: "seen aggregator and target index",
+      targetEpoch: aggregate.data.target.epoch,
+      ...logContext,
+    });
+    return ExtendedValidatorResult.ignore;
+  }
+  if (!hasAttestationParticipants(aggregate)) {
+    logger.warn("Rejected gossip aggregate and proof", {
+      reason: "missing attestation participants",
+      ...logContext,
+    });
+    return ExtendedValidatorResult.reject;
+  }
+
+  if (await isAttestingToInValidBlock(db, aggregate)) {
+    logger.warn("Rejected gossip aggregate and proof", {
+      reason: "attesting to invalid block",
+      ...logContext,
+    });
+    return ExtendedValidatorResult.reject;
+  }
+
+  //TODO: check pool of aggregates if already seen (not a dos vector check)
+
+  const result = await validateAggregateAttestation(config, chain, db, logger, logContext, signedAggregateAndProof);
+
+  //TODO: once we have pool, check if aggregate block is seen and has target as ancestor
+
+  logger.profile("gossipAggregateAndProofValidation");
+  logger.info("Received gossip aggregate and proof passed validation", logContext);
+  return result;
+}
+
+export function isValidAggregateAndProofSlot(config: IBeaconConfig, genesisTime: number, slot: Slot): boolean {
+  const milliSecPerSlot = config.params.SECONDS_PER_SLOT * 1000;
+  const currentSlotTime = getCurrentSlot(config, genesisTime) * milliSecPerSlot;
+  return (
+    (slot + ATTESTATION_PROPAGATION_SLOT_RANGE) * milliSecPerSlot + MAXIMUM_GOSSIP_CLOCK_DISPARITY >= currentSlotTime &&
+    currentSlotTime >= slot * milliSecPerSlot - MAXIMUM_GOSSIP_CLOCK_DISPARITY
+  );
+}
+
+export function hasAttestationParticipants(attestation: Attestation): boolean {
+  return Array.from(attestation.aggregationBits).filter((bit) => !!bit).length >= 1;
+}
+
+export async function validateAggregateAttestation(
+  config: IBeaconConfig,
+  chain: IBeaconChain,
+  db: IBeaconDb,
+  logger: ILogger,
+  logContext: ReturnType<typeof getLogContext>,
+  aggregateAndProof: SignedAggregateAndProof
+): Promise<ExtendedValidatorResult> {
+  const attestation = aggregateAndProof.message.aggregate;
+  const attestationPreState = await getAttestationPreState(config, chain, db, attestation.data.target);
+  if (!attestationPreState) {
+    logger.warn("Ignored gossip aggregate and proof", {reason: "missing attestation prestate", ...logContext});
+    return ExtendedValidatorResult.ignore;
+  }
+  const {state, epochCtx} = attestationPreState;
+  //committee changes on epoch, so advance only if different epoch
+  const attEpoch = computeEpochAtSlot(config, attestation.data.slot);
+  if (attEpoch > computeEpochAtSlot(config, state.slot)) {
+    processSlots(epochCtx, state, computeStartSlotAtEpoch(config, attEpoch));
+  }
+  const committee = epochCtx.getBeaconCommittee(attestation.data.slot, attestation.data.index);
+  if (!committee.includes(aggregateAndProof.message.aggregatorIndex)) {
+    logger.warn("Rejected gossip aggregate and proof", {reason: "aggregator not in committee", ...logContext});
+    return ExtendedValidatorResult.reject;
+  }
+  if (!isAggregatorFromCommitteeLength(config, committee.length, aggregateAndProof.message.selectionProof)) {
+    logger.warn("Rejected gossip aggregate and proof", {reason: "not valid aggregator", ...logContext});
+    return ExtendedValidatorResult.reject;
+  }
+  const aggregator = epochCtx.index2pubkey[aggregateAndProof.message.aggregatorIndex];
+  if (
+    !isValidSelectionProofSignature(
+      config,
+      state,
+      attestation.data.slot,
+      aggregator,
+      Signature.fromCompressedBytes(aggregateAndProof.message.selectionProof.valueOf() as Uint8Array)
+    )
+  ) {
+    logger.warn("Rejected gossip aggregate and proof", {reason: "invalid selection proof signature", ...logContext});
+    return ExtendedValidatorResult.reject;
+  }
+
+  if (
+    !isValidAggregateAndProofSignature(
+      config,
+      state,
+      computeEpochAtSlot(config, attestation.data.slot),
+      aggregator,
+      aggregateAndProof
+    )
+  ) {
+    logger.warn("Rejected gossip aggregate and proof", {reason: "invalid signature", ...logContext});
+    return ExtendedValidatorResult.reject;
+  }
+  return ExtendedValidatorResult.accept;
+}
+
+export function isValidSelectionProofSignature(
+  config: IBeaconConfig,
+  state: BeaconState,
+  slot: Slot,
+  aggregator: PublicKey,
+  signature: Signature
+): boolean {
+  const epoch = computeEpochAtSlot(config, slot);
+  const selectionProofDomain = getDomain(config, state, DomainType.SELECTION_PROOF, epoch);
+  const selectionProofSigningRoot = computeSigningRoot(config, config.types.Slot, slot, selectionProofDomain);
+  return aggregator.verifyMessage(signature, selectionProofSigningRoot);
+}
+
+export function isValidAggregateAndProofSignature(
+  config: IBeaconConfig,
+  state: BeaconState,
+  epoch: Epoch,
+  aggregator: PublicKey,
+  aggregateAndProof: SignedAggregateAndProof
+): boolean {
+  const aggregatorDomain = getDomain(config, state, DomainType.AGGREGATE_AND_PROOF, epoch);
+  const aggregatorSigningRoot = computeSigningRoot(
+    config,
+    config.types.AggregateAndProof,
+    aggregateAndProof.message,
+    aggregatorDomain
+  );
+  return aggregator.verifyMessage(
+    Signature.fromCompressedBytes(aggregateAndProof.signature.valueOf() as Uint8Array),
+    aggregatorSigningRoot
+  );
+}
+
+//& object so we can spread it
+function getLogContext(
+  aggregate: Attestation,
+  aggregateAndProof: AggregateAndProof,
+  root: Uint8Array,
+  attestationRoot: Uint8Array
+): Context & object {
+  return {
+    attestationSlot: aggregate.data.slot,
+    aggregatorIndex: aggregateAndProof.aggregatorIndex,
+    root: toHexString(root),
+    attestationRoot: toHexString(attestationRoot),
+  };
+}

--- a/packages/lodestar/src/network/gossip/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/network/gossip/validation/aggregateAndProof.ts
@@ -16,9 +16,7 @@ import {isAttestingToInValidBlock} from "./attestation";
 import {getAttestationPreState} from "../utils";
 import {processSlots} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/slot";
 import {Signature} from "@chainsafe/bls";
-import {
-  isValidIndexedAttestation
-} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/block/isValidIndexedAttestation";
+import {isValidIndexedAttestation} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/block/isValidIndexedAttestation";
 import {isValidAggregateAndProofSignature, isValidSelectionProofSignature} from "./utils";
 
 export async function validateGossipAggregateAndProof(

--- a/packages/lodestar/src/network/gossip/validation/index.ts
+++ b/packages/lodestar/src/network/gossip/validation/index.ts
@@ -1,2 +1,3 @@
 export * from "./block";
 export * from "./attestation";
+export * from "./aggregateAndProof";

--- a/packages/lodestar/src/network/gossip/validation/utils/index.ts
+++ b/packages/lodestar/src/network/gossip/validation/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./signature";

--- a/packages/lodestar/src/network/gossip/validation/utils/signature.ts
+++ b/packages/lodestar/src/network/gossip/validation/utils/signature.ts
@@ -1,0 +1,38 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {BeaconState, Epoch, SignedAggregateAndProof, Slot} from "@chainsafe/lodestar-types";
+import {PublicKey, Signature} from "@chainsafe/bls";
+import {computeEpochAtSlot, computeSigningRoot, getDomain} from "@chainsafe/lodestar-beacon-state-transition";
+import {DomainType} from "../../../../constants";
+
+export function isValidSelectionProofSignature(
+  config: IBeaconConfig,
+  state: BeaconState,
+  slot: Slot,
+  aggregator: PublicKey,
+  signature: Signature
+): boolean {
+  const epoch = computeEpochAtSlot(config, slot);
+  const selectionProofDomain = getDomain(config, state, DomainType.SELECTION_PROOF, epoch);
+  const selectionProofSigningRoot = computeSigningRoot(config, config.types.Slot, slot, selectionProofDomain);
+  return aggregator.verifyMessage(signature, selectionProofSigningRoot);
+}
+
+export function isValidAggregateAndProofSignature(
+  config: IBeaconConfig,
+  state: BeaconState,
+  epoch: Epoch,
+  aggregator: PublicKey,
+  aggregateAndProof: SignedAggregateAndProof
+): boolean {
+  const aggregatorDomain = getDomain(config, state, DomainType.AGGREGATE_AND_PROOF, epoch);
+  const aggregatorSigningRoot = computeSigningRoot(
+    config,
+    config.types.AggregateAndProof,
+    aggregateAndProof.message,
+    aggregatorDomain
+  );
+  return aggregator.verifyMessage(
+    Signature.fromCompressedBytes(aggregateAndProof.signature.valueOf() as Uint8Array),
+    aggregatorSigningRoot
+  );
+}

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -25,7 +25,7 @@ import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {IBeaconChain} from "../../chain";
 import {arrayIntersection, sszEqualPredicate} from "../../util/objects";
 import {ExtendedValidatorResult} from "./constants";
-import {validateGossipAttestation, validateGossipBlock} from "./validation";
+import {validateGossipAggregateAndProof, validateGossipAttestation, validateGossipBlock} from "./validation";
 import {processSlots} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/slot";
 import {ATTESTATION_PROPAGATION_SLOT_RANGE, DomainType, MAXIMUM_GOSSIP_CLOCK_DISPARITY} from "../../constants";
 import {verify} from "@chainsafe/bls";
@@ -74,98 +74,18 @@ export class GossipMessageValidator implements IGossipMessageValidator {
   public isValidIncomingAggregateAndProof = async (
     signedAggregationAndProof: SignedAggregateAndProof
   ): Promise<ExtendedValidatorResult> => {
-    const aggregateAndProof = signedAggregationAndProof.message;
-    const aggregate = aggregateAndProof.aggregate;
-    const attestationData = aggregate.data;
-    const slot = attestationData.slot;
-    const {state, epochCtx} = await this.chain.getHeadStateContext();
-    const currentSlot = getCurrentSlot(this.config, state.genesisTime);
-    const milliSecPerSlot = this.config.params.SECONDS_PER_SLOT * 1000;
-    const currentSlotTime = currentSlot * milliSecPerSlot;
-    if (
-      !(
-        (slot + ATTESTATION_PROPAGATION_SLOT_RANGE) * milliSecPerSlot + MAXIMUM_GOSSIP_CLOCK_DISPARITY >=
-          currentSlotTime && currentSlotTime >= slot * milliSecPerSlot - MAXIMUM_GOSSIP_CLOCK_DISPARITY
-      )
-    ) {
+    try {
+      return await validateGossipAggregateAndProof(
+        this.config,
+        this.chain,
+        this.db,
+        this.logger,
+        signedAggregationAndProof
+      );
+    } catch (e) {
+      this.logger.error("Error while validating gossip aggregate and proof", e);
       return ExtendedValidatorResult.ignore;
     }
-    if (state.slot < slot) {
-      processSlots(epochCtx, state, slot);
-    }
-
-    if (await this.db.aggregateAndProof.hasAttestation(aggregate)) {
-      return ExtendedValidatorResult.ignore;
-    }
-
-    const aggregatorIndex = aggregateAndProof.aggregatorIndex;
-    const existingAttestations =
-      (await this.db.aggregateAndProof.getByAggregatorAndEpoch(aggregatorIndex, attestationData.target.epoch)) || [];
-    if (existingAttestations.length > 0) {
-      return ExtendedValidatorResult.ignore;
-    }
-
-    if (epochCtx.getAttestingIndices(attestationData, aggregate.aggregationBits).length < 1) {
-      return ExtendedValidatorResult.reject;
-    }
-
-    const blockRoot = aggregate.data.beaconBlockRoot.valueOf() as Uint8Array;
-    if (!this.chain.forkChoice.hasBlock(blockRoot) || (await this.db.badBlock.has(blockRoot))) {
-      return ExtendedValidatorResult.reject;
-    }
-
-    const selectionProof = aggregateAndProof.selectionProof;
-    if (!epochCtx.isAggregator(slot, attestationData.index, selectionProof)) {
-      return ExtendedValidatorResult.reject;
-    }
-
-    const committee = epochCtx.getBeaconCommittee(attestationData.slot, attestationData.index);
-    if (!committee.includes(aggregatorIndex)) {
-      return ExtendedValidatorResult.reject;
-    }
-
-    const epoch = computeEpochAtSlot(this.config, slot);
-    const selectionProofDomain = getDomain(this.config, state, DomainType.SELECTION_PROOF, epoch);
-    const selectionProofSigningRoot = computeSigningRoot(
-      this.config,
-      this.config.types.Slot,
-      slot,
-      selectionProofDomain
-    );
-    const validatorPubKey = state.validators[aggregatorIndex].pubkey;
-    if (
-      !verify(
-        validatorPubKey.valueOf() as Uint8Array,
-        selectionProofSigningRoot,
-        selectionProof.valueOf() as Uint8Array
-      )
-    ) {
-      return ExtendedValidatorResult.reject;
-    }
-
-    const aggregatorDomain = getDomain(this.config, state, DomainType.AGGREGATE_AND_PROOF, epoch);
-    const aggregatorSigningRoot = computeSigningRoot(
-      this.config,
-      this.config.types.AggregateAndProof,
-      aggregateAndProof,
-      aggregatorDomain
-    );
-    if (
-      !verify(
-        validatorPubKey.valueOf() as Uint8Array,
-        aggregatorSigningRoot,
-        signedAggregationAndProof.signature.valueOf() as Uint8Array
-      )
-    ) {
-      this.logger.warn("Invalid agg and proof sig");
-      return ExtendedValidatorResult.reject;
-    }
-
-    const indexedAttestation = epochCtx.getIndexedAttestation(aggregate);
-    if (!isValidIndexedAttestation(this.config, state, indexedAttestation)) {
-      return ExtendedValidatorResult.reject;
-    }
-    return ExtendedValidatorResult.accept;
   };
 
   public isValidIncomingVoluntaryExit = async (

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -10,13 +10,8 @@ import {
 } from "@chainsafe/lodestar-types";
 import {IBeaconDb} from "../../db";
 import {
-  computeEpochAtSlot,
-  computeSigningRoot,
   computeStartSlotAtEpoch,
-  getCurrentSlot,
-  getDomain,
   isValidAttesterSlashing,
-  isValidIndexedAttestation,
   isValidProposerSlashing,
   isValidVoluntaryExit,
 } from "@chainsafe/lodestar-beacon-state-transition";
@@ -27,8 +22,7 @@ import {arrayIntersection, sszEqualPredicate} from "../../util/objects";
 import {ExtendedValidatorResult} from "./constants";
 import {validateGossipAggregateAndProof, validateGossipAttestation, validateGossipBlock} from "./validation";
 import {processSlots} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/slot";
-import {ATTESTATION_PROPAGATION_SLOT_RANGE, DomainType, MAXIMUM_GOSSIP_CLOCK_DISPARITY} from "../../constants";
-import {verify} from "@chainsafe/bls";
+
 /* eslint-disable @typescript-eslint/interface-name-prefix */
 interface GossipMessageValidatorModules {
   chain: IBeaconChain;

--- a/packages/lodestar/test/unit/network/gossip/validation/aggregateAndProof.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/validation/aggregateAndProof.test.ts
@@ -1,0 +1,305 @@
+import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
+import {BeaconChain, IBeaconChain} from "../../../../../src/chain";
+import {StubbedBeaconDb} from "../../../../utils/stub";
+import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {validateGossipAggregateAndProof} from "../../../../../src/network/gossip/validation";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {generateSignedAggregateAndProof} from "../../../../utils/aggregateAndProof";
+import {expect} from "chai";
+import {ExtendedValidatorResult} from "../../../../../src/network/gossip/constants";
+import {ATTESTATION_PROPAGATION_SLOT_RANGE, MAXIMUM_GOSSIP_CLOCK_DISPARITY} from "../../../../../src/constants";
+import {List} from "@chainsafe/ssz";
+import * as gossipUtils from "../../../../../src/network/gossip/utils";
+import * as validatorUtils from "@chainsafe/lodestar-beacon-state-transition/lib/util/validator";
+import * as validationUtils from "../../../../../src/network/gossip/validation/utils";
+import * as blockUtils from "@chainsafe/lodestar-beacon-state-transition/lib/fast/block/isValidIndexedAttestation";
+import {generateState} from "../../../../utils/state";
+import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
+import {PrivateKey, PublicKey} from "@chainsafe/bls";
+
+describe("gossip aggregate and proof test", function () {
+  const logger = sinon.createStubInstance(WinstonLogger);
+  let chain: SinonStubbedInstance<IBeaconChain>;
+  let db: StubbedBeaconDb;
+  let getAttestationPreStateStub: SinonStub;
+  let isAggregatorStub: SinonStub;
+  let isValidSelectionProofStub: SinonStub;
+  let isValidSignatureStub: SinonStub;
+  let isValidIndexedAttestationStub: SinonStub;
+
+  beforeEach(function () {
+    chain = sinon.createStubInstance(BeaconChain);
+    db = new StubbedBeaconDb(sinon);
+    chain.getGenesisTime.returns(Math.floor(Date.now() / 1000));
+    db.badBlock.has.resolves(false);
+    db.seenAttestationCache.hasAggregateAndProof.resolves(false);
+    getAttestationPreStateStub = sinon.stub(gossipUtils, "getAttestationPreState");
+    isAggregatorStub = sinon.stub(validatorUtils, "isAggregatorFromCommitteeLength");
+    isValidSelectionProofStub = sinon.stub(validationUtils, "isValidSelectionProofSignature");
+    isValidSignatureStub = sinon.stub(validationUtils, "isValidAggregateAndProofSignature");
+    isValidIndexedAttestationStub = sinon.stub(blockUtils, "isValidIndexedAttestation");
+  });
+
+  afterEach(function () {
+    getAttestationPreStateStub.restore();
+    isAggregatorStub.restore();
+    isValidSelectionProofStub.restore();
+    isValidSignatureStub.restore();
+    isValidIndexedAttestationStub.restore();
+  });
+
+  it("should ignore - invalid slot (too old)", async function () {
+    //move genesis time in past so current slot is high
+    chain.getGenesisTime.returns(
+      Math.floor(Date.now() / 1000) - (ATTESTATION_PROPAGATION_SLOT_RANGE + 1) * config.params.SECONDS_PER_SLOT
+    );
+    const item = generateSignedAggregateAndProof({
+      aggregate: {
+        data: {
+          slot: 0,
+        },
+      },
+    });
+    const result = await validateGossipAggregateAndProof(config, chain, db, logger, item);
+    expect(result).to.be.equal(ExtendedValidatorResult.ignore);
+  });
+
+  it("should ignore - invalid slot (too eager)", async function () {
+    //move genesis time so slot 0 has not yet come
+    chain.getGenesisTime.returns(Math.floor(Date.now() / 1000) + MAXIMUM_GOSSIP_CLOCK_DISPARITY + 1);
+    const item = generateSignedAggregateAndProof({
+      aggregate: {
+        data: {
+          slot: 0,
+        },
+      },
+    });
+    const result = await validateGossipAggregateAndProof(config, chain, db, logger, item);
+    expect(result).to.be.equal(ExtendedValidatorResult.ignore);
+  });
+
+  it("should ignore - already seen", async function () {
+    const item = generateSignedAggregateAndProof({
+      aggregate: {
+        data: {
+          slot: 0,
+        },
+      },
+    });
+    db.seenAttestationCache.hasAggregateAndProof.resolves(true);
+    const result = await validateGossipAggregateAndProof(config, chain, db, logger, item);
+    expect(result).to.be.equal(ExtendedValidatorResult.ignore);
+    expect(db.seenAttestationCache.hasAggregateAndProof.withArgs(item.message).calledOnce).to.be.true;
+  });
+
+  it("should reject - no attestation participants", async function () {
+    const item = generateSignedAggregateAndProof({
+      aggregate: {
+        aggregationBits: Array.from([false]) as List<boolean>,
+        data: {
+          slot: 0,
+        },
+      },
+    });
+    const result = await validateGossipAggregateAndProof(config, chain, db, logger, item);
+    expect(result).to.be.equal(ExtendedValidatorResult.reject);
+  });
+
+  it("should reject - attesting to invalid block", async function () {
+    const item = generateSignedAggregateAndProof({
+      aggregate: {
+        aggregationBits: Array.from([true]) as List<boolean>,
+        data: {
+          slot: 0,
+        },
+      },
+    });
+    db.badBlock.has.resolves(true);
+    const result = await validateGossipAggregateAndProof(config, chain, db, logger, item);
+    expect(result).to.be.equal(ExtendedValidatorResult.reject);
+    expect(db.badBlock.has.withArgs(item.message.aggregate.data.beaconBlockRoot.valueOf() as Uint8Array).calledOnce).to
+      .be.true;
+  });
+
+  it("should ignore - missing attestation prestate", async function () {
+    const item = generateSignedAggregateAndProof({
+      aggregate: {
+        aggregationBits: Array.from([true]) as List<boolean>,
+        data: {
+          slot: 0,
+        },
+      },
+    });
+    getAttestationPreStateStub.resolves(false);
+    const result = await validateGossipAggregateAndProof(config, chain, db, logger, item);
+    expect(result).to.be.equal(ExtendedValidatorResult.ignore);
+    expect(getAttestationPreStateStub.withArgs(config, chain, db, item.message.aggregate.data.target).calledOnce).to.be
+      .true;
+  });
+
+  it("should reject - aggregator not in committee", async function () {
+    const item = generateSignedAggregateAndProof({
+      aggregate: {
+        aggregationBits: Array.from([true]) as List<boolean>,
+        data: {
+          slot: 0,
+        },
+      },
+    });
+    const state = generateState();
+    const epochCtx = sinon.createStubInstance(EpochContext);
+    getAttestationPreStateStub.resolves({
+      state,
+      epochCtx,
+    });
+    epochCtx.getBeaconCommittee.returns([]);
+    const result = await validateGossipAggregateAndProof(config, chain, db, logger, item);
+    expect(result).to.be.equal(ExtendedValidatorResult.reject);
+    expect(
+      epochCtx.getBeaconCommittee.withArgs(item.message.aggregate.data.slot, item.message.aggregate.data.index)
+        .calledOnce
+    ).to.be.true;
+  });
+
+  it("should reject - not aggregator", async function () {
+    const item = generateSignedAggregateAndProof({
+      aggregate: {
+        aggregationBits: Array.from([true]) as List<boolean>,
+        data: {
+          slot: 0,
+        },
+      },
+    });
+    const state = generateState();
+    const epochCtx = sinon.createStubInstance(EpochContext);
+    getAttestationPreStateStub.resolves({
+      state,
+      epochCtx,
+    });
+    epochCtx.getBeaconCommittee.returns([item.message.aggregatorIndex]);
+    isAggregatorStub.returns(false);
+    const result = await validateGossipAggregateAndProof(config, chain, db, logger, item);
+    expect(result).to.be.equal(ExtendedValidatorResult.reject);
+    expect(isAggregatorStub.withArgs(config, 1, item.message.selectionProof).calledOnce).to.be.true;
+  });
+
+  it("should reject - invalid selection proof signature", async function () {
+    const item = generateSignedAggregateAndProof({
+      aggregate: {
+        aggregationBits: Array.from([true]) as List<boolean>,
+        data: {
+          slot: 0,
+        },
+      },
+    });
+    const state = generateState();
+    const epochCtx = sinon.createStubInstance(EpochContext);
+    epochCtx.index2pubkey = [];
+    epochCtx.index2pubkey[item.message.aggregatorIndex] = PublicKey.fromPrivateKey(PrivateKey.fromInt(1));
+    getAttestationPreStateStub.resolves({
+      state,
+      epochCtx,
+    });
+    epochCtx.getBeaconCommittee.returns([item.message.aggregatorIndex]);
+    isAggregatorStub.returns(true);
+    isValidSelectionProofStub.returns(false);
+    const result = await validateGossipAggregateAndProof(config, chain, db, logger, item);
+    expect(result).to.be.equal(ExtendedValidatorResult.reject);
+    expect(
+      isValidSelectionProofStub.withArgs(
+        config,
+        state,
+        item.message.aggregate.data.slot,
+        epochCtx.index2pubkey[item.message.aggregatorIndex],
+        sinon.match.any
+      ).calledOnce
+    ).to.be.true;
+  });
+
+  it("should reject - invalid signature", async function () {
+    const item = generateSignedAggregateAndProof({
+      aggregate: {
+        aggregationBits: Array.from([true]) as List<boolean>,
+        data: {
+          slot: 0,
+        },
+      },
+    });
+    const state = generateState();
+    const epochCtx = sinon.createStubInstance(EpochContext);
+    epochCtx.index2pubkey = [];
+    epochCtx.index2pubkey[item.message.aggregatorIndex] = PublicKey.fromPrivateKey(PrivateKey.fromInt(1));
+    getAttestationPreStateStub.resolves({
+      state,
+      epochCtx,
+    });
+    epochCtx.getBeaconCommittee.returns([item.message.aggregatorIndex]);
+    isAggregatorStub.returns(true);
+    isValidSelectionProofStub.returns(true);
+    isValidSignatureStub.returns(false);
+    const result = await validateGossipAggregateAndProof(config, chain, db, logger, item);
+    expect(result).to.be.equal(ExtendedValidatorResult.reject);
+    expect(
+      isValidSignatureStub.withArgs(
+        config,
+        state,
+        0,
+        epochCtx.index2pubkey[item.message.aggregatorIndex],
+        sinon.match.any
+      ).calledOnce
+    ).to.be.true;
+  });
+
+  it("should reject - invalid indexed attestation", async function () {
+    const item = generateSignedAggregateAndProof({
+      aggregate: {
+        aggregationBits: Array.from([true]) as List<boolean>,
+        data: {
+          slot: 0,
+        },
+      },
+    });
+    const state = generateState();
+    const epochCtx = sinon.createStubInstance(EpochContext);
+    epochCtx.index2pubkey = [];
+    epochCtx.index2pubkey[item.message.aggregatorIndex] = PublicKey.fromPrivateKey(PrivateKey.fromInt(1));
+    getAttestationPreStateStub.resolves({
+      state,
+      epochCtx,
+    });
+    epochCtx.getBeaconCommittee.returns([item.message.aggregatorIndex]);
+    isAggregatorStub.returns(true);
+    isValidSelectionProofStub.returns(true);
+    isValidSignatureStub.returns(true);
+    isValidIndexedAttestationStub.returns(false);
+    const result = await validateGossipAggregateAndProof(config, chain, db, logger, item);
+    expect(result).to.be.equal(ExtendedValidatorResult.reject);
+    expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
+  });
+
+  it("should accept", async function () {
+    const item = generateSignedAggregateAndProof({
+      aggregate: {
+        aggregationBits: Array.from([true]) as List<boolean>,
+        data: {
+          slot: 0,
+        },
+      },
+    });
+    const state = generateState();
+    const epochCtx = sinon.createStubInstance(EpochContext);
+    epochCtx.index2pubkey = [];
+    epochCtx.index2pubkey[item.message.aggregatorIndex] = PublicKey.fromPrivateKey(PrivateKey.fromInt(1));
+    getAttestationPreStateStub.resolves({
+      state,
+      epochCtx,
+    });
+    epochCtx.getBeaconCommittee.returns([item.message.aggregatorIndex]);
+    isAggregatorStub.returns(true);
+    isValidSelectionProofStub.returns(true);
+    isValidSignatureStub.returns(true);
+    isValidIndexedAttestationStub.returns(true);
+    const result = await validateGossipAggregateAndProof(config, chain, db, logger, item);
+    expect(result).to.be.equal(ExtendedValidatorResult.accept);
+  });
+});

--- a/packages/lodestar/test/unit/network/gossip/validator.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/validator.test.ts
@@ -1,18 +1,10 @@
-import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
+import sinon from "sinon";
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import * as attestationUtils from "@chainsafe/lodestar-beacon-state-transition/lib/util/attestation";
-import {getAttestingIndicesFromCommittee} from "@chainsafe/lodestar-beacon-state-transition/lib/util/attestation";
 import * as validatorStatusUtils from "@chainsafe/lodestar-beacon-state-transition/lib/util/validatorStatus";
-import * as validatorUtils from "@chainsafe/lodestar-beacon-state-transition/lib/util/validator";
-import * as bls from "@chainsafe/bls";
 import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {generateState} from "../../../utils/state";
-import {
-  generateEmptyAttestation,
-  generateEmptySignedAggregateAndProof,
-  generateEmptySignedVoluntaryExit,
-} from "../../../utils/attestation";
+import {generateEmptySignedVoluntaryExit} from "../../../utils/attestation";
 import {
   generateEmptyAttesterSlashing,
   generateEmptyProposerSlashing,
@@ -24,31 +16,24 @@ import {BeaconChain, StatefulDagLMDGHOST} from "../../../../src/chain";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconDb} from "../../../../src/db";
 import {StubbedBeaconDb, StubbedChain} from "../../../utils/stub";
-import {TreeBacked} from "@chainsafe/ssz";
-import {BeaconState} from "@chainsafe/lodestar-types";
 import {ExtendedValidatorResult} from "../../../../src/network/gossip/constants";
 
-// TODO: fix this
-describe.skip("GossipMessageValidator", () => {
+describe("GossipMessageValidator", () => {
   const sandbox = sinon.createSandbox();
   let validator: GossipMessageValidator;
   let dbStub: StubbedBeaconDb,
     logger: any,
-    isValidIndexedAttestationStub: any,
     isValidIncomingVoluntaryExitStub: any,
     isValidIncomingProposerSlashingStub: any,
     isValidIncomingAttesterSlashingStub: any,
-    chainStub: StubbedChain,
-    isBlsVerifyStub: SinonStub;
+    chainStub: StubbedChain;
 
   beforeEach(() => {
-    isValidIndexedAttestationStub = sandbox.stub(attestationUtils, "isValidIndexedAttestation");
     isValidIncomingVoluntaryExitStub = sandbox.stub(validatorStatusUtils, "isValidVoluntaryExit");
     isValidIncomingProposerSlashingStub = sandbox.stub(validatorStatusUtils, "isValidProposerSlashing");
     isValidIncomingAttesterSlashingStub = sandbox.stub(validatorStatusUtils, "isValidAttesterSlashing");
     chainStub = (sandbox.createStubInstance(BeaconChain) as unknown) as StubbedChain;
     chainStub.forkChoice = sandbox.createStubInstance(StatefulDagLMDGHOST);
-    isBlsVerifyStub = sandbox.stub(bls, "verify");
 
     dbStub = new StubbedBeaconDb(sandbox);
     logger = new WinstonLogger();
@@ -63,332 +48,6 @@ describe.skip("GossipMessageValidator", () => {
 
   afterEach(() => {
     sandbox.restore();
-  });
-
-  describe("validate signed aggregate and proof", () => {
-    it("should return invalid signed aggregation and proof - invalid slot", async () => {
-      const aggregateProof = generateEmptySignedAggregateAndProof();
-      const state = generateState({
-        genesisTime: Math.floor(Date.now() / 1000) - config.params.SECONDS_PER_SLOT,
-        validators: generateValidators(config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT, {
-          activationEpoch: 0,
-          effectiveBalance: config.params.MAX_EFFECTIVE_BALANCE,
-        }),
-        balances: generateInitialMaxBalances(config),
-      });
-      const epochCtx = new EpochContext(config);
-      epochCtx.loadState(state);
-      state.genesisTime = Math.floor(new Date("2000-01-01").getTime()) / 1000;
-      chainStub.getHeadStateContext.resolves({
-        state: state as TreeBacked<BeaconState>,
-        epochCtx: epochCtx,
-      });
-      expect(await validator.isValidIncomingAggregateAndProof(aggregateProof)).to.be.equal(
-        ExtendedValidatorResult.ignore
-      );
-    });
-
-    it("should return invalid signed aggregation and proof - existed", async () => {
-      const state = generateState({
-        genesisTime: Math.floor(Date.now() / 1000) - config.params.SECONDS_PER_SLOT,
-        validators: generateValidators(config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT, {
-          activationEpoch: 0,
-          effectiveBalance: config.params.MAX_EFFECTIVE_BALANCE,
-        }),
-        balances: generateInitialMaxBalances(config),
-      });
-      const epochCtx = new EpochContext(config);
-      epochCtx.loadState(state);
-      chainStub.getHeadStateContext.resolves({
-        state: state as TreeBacked<BeaconState>,
-        epochCtx: epochCtx,
-      });
-      const aggregateProof = generateEmptySignedAggregateAndProof();
-      dbStub.aggregateAndProof.hasAttestation.resolves(true);
-      expect(await validator.isValidIncomingAggregateAndProof(aggregateProof)).to.be.equal(
-        ExtendedValidatorResult.ignore
-      );
-      expect(dbStub.aggregateAndProof.hasAttestation.calledOnce).to.be.true;
-    });
-
-    it("should return invalid signed aggregation and proof - prevent DOS", async () => {
-      const state = generateState({
-        genesisTime: Math.floor(Date.now() / 1000) - config.params.SECONDS_PER_SLOT,
-        validators: generateValidators(config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT, {
-          activationEpoch: 0,
-          effectiveBalance: config.params.MAX_EFFECTIVE_BALANCE,
-        }),
-        balances: generateInitialMaxBalances(config),
-      });
-      const epochCtx = new EpochContext(config);
-      epochCtx.loadState(state);
-      chainStub.getHeadStateContext.resolves({
-        state: state as TreeBacked<BeaconState>,
-        epochCtx: epochCtx,
-      });
-      const aggregateProof = generateEmptySignedAggregateAndProof();
-      dbStub.aggregateAndProof.hasAttestation.resolves(false);
-      dbStub.aggregateAndProof.getByAggregatorAndEpoch.resolves([generateEmptyAttestation()]);
-      expect(await validator.isValidIncomingAggregateAndProof(aggregateProof)).to.be.equal(
-        ExtendedValidatorResult.ignore
-      );
-      expect(dbStub.aggregateAndProof.getByAggregatorAndEpoch.calledOnce).to.be.true;
-      expect(chainStub.forkChoice.hasBlock.calledOnce).to.be.false;
-    });
-
-    it("should return invalid signed aggregation and proof - incorrect number of participants", async () => {
-      const state = generateState({
-        genesisTime: Math.floor(Date.now() / 1000) - config.params.SECONDS_PER_SLOT,
-        validators: generateValidators(config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT, {
-          activationEpoch: 0,
-          effectiveBalance: config.params.MAX_EFFECTIVE_BALANCE,
-        }),
-        balances: generateInitialMaxBalances(config),
-      });
-      const epochCtx = new EpochContext(config);
-      epochCtx.loadState(state);
-      chainStub.getHeadStateContext.resolves({
-        state: state as TreeBacked<BeaconState>,
-        epochCtx: epochCtx,
-      });
-      const aggregateProof = generateEmptySignedAggregateAndProof();
-      dbStub.aggregateAndProof.has.resolves(false);
-      epochCtx.getAttestingIndices = () => [];
-      expect(await validator.isValidIncomingAggregateAndProof(aggregateProof)).to.be.equal(
-        ExtendedValidatorResult.reject
-      );
-    });
-
-    it("should return invalid signed aggregation and proof - block not existed", async () => {
-      const state = generateState({
-        genesisTime: Math.floor(Date.now() / 1000) - config.params.SECONDS_PER_SLOT,
-        validators: generateValidators(config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT, {
-          activationEpoch: 0,
-          effectiveBalance: config.params.MAX_EFFECTIVE_BALANCE,
-        }),
-        balances: generateInitialMaxBalances(config),
-      });
-      const epochCtx = new EpochContext(config);
-      epochCtx.loadState(state);
-      chainStub.getHeadStateContext.resolves({
-        state: state as TreeBacked<BeaconState>,
-        epochCtx: epochCtx,
-      });
-      const aggregateProof = generateEmptySignedAggregateAndProof();
-      dbStub.aggregateAndProof.has.resolves(false);
-      epochCtx.getAttestingIndices = () => [0, 1];
-      chainStub.forkChoice.hasBlock.returns(false);
-      expect(await validator.isValidIncomingAggregateAndProof(aggregateProof)).to.be.equal(
-        ExtendedValidatorResult.reject
-      );
-      expect(chainStub.forkChoice.hasBlock.calledOnce).to.be.true;
-      expect(dbStub.badBlock.has.calledOnce).to.be.false;
-    });
-
-    it("should return invalid signed aggregation and proof - invalid block", async () => {
-      const state = generateState({
-        genesisTime: Math.floor(Date.now() / 1000) - config.params.SECONDS_PER_SLOT,
-        validators: generateValidators(config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT, {
-          activationEpoch: 0,
-          effectiveBalance: config.params.MAX_EFFECTIVE_BALANCE,
-        }),
-        balances: generateInitialMaxBalances(config),
-      });
-      const epochCtx = new EpochContext(config);
-      epochCtx.loadState(state);
-      chainStub.getHeadStateContext.resolves({
-        state: state as TreeBacked<BeaconState>,
-        epochCtx: epochCtx,
-      });
-      const aggregateProof = generateEmptySignedAggregateAndProof();
-      dbStub.aggregateAndProof.has.resolves(false);
-      epochCtx.getAttestingIndices = () => [0, 1];
-      chainStub.forkChoice.hasBlock.returns(true);
-      dbStub.badBlock.has.resolves(true);
-      expect(await validator.isValidIncomingAggregateAndProof(aggregateProof)).to.be.equal(
-        ExtendedValidatorResult.reject
-      );
-      expect(dbStub.badBlock.has.calledOnce).to.be.true;
-    });
-
-    it("should return invalid signed aggregation and proof - not aggregator", async () => {
-      const aggregateProof = generateEmptySignedAggregateAndProof();
-      dbStub.aggregateAndProof.has.resolves(false);
-      chainStub.forkChoice.hasBlock.returns(true);
-      dbStub.badBlock.has.resolves(false);
-      const state = generateState({
-        genesisTime: Math.floor(Date.now() / 1000) - config.params.SECONDS_PER_SLOT,
-        validators: generateValidators(config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT, {
-          activationEpoch: 0,
-          effectiveBalance: config.params.MAX_EFFECTIVE_BALANCE,
-        }),
-        balances: generateInitialMaxBalances(config),
-      });
-      const epochCtx = new EpochContext(config);
-      epochCtx.loadState(state);
-      epochCtx.isAggregator = () => false;
-      epochCtx.getAttestingIndices = () => [0, 1];
-      chainStub.getHeadStateContext.resolves({
-        state: state as TreeBacked<BeaconState>,
-        epochCtx: epochCtx,
-      });
-      expect(await validator.isValidIncomingAggregateAndProof(aggregateProof)).to.be.equal(
-        ExtendedValidatorResult.reject
-      );
-    });
-
-    it("should return invalid signed aggregation and proof - not beacon committee", async () => {
-      const aggregateProof = generateEmptySignedAggregateAndProof();
-      dbStub.aggregateAndProof.has.resolves(false);
-      chainStub.forkChoice.hasBlock.returns(true);
-      dbStub.badBlock.has.resolves(false);
-      const state = generateState({
-        genesisTime: Math.floor(Date.now() / 1000) - config.params.SECONDS_PER_SLOT,
-        validators: generateValidators(config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT, {
-          activationEpoch: 0,
-          effectiveBalance: config.params.MAX_EFFECTIVE_BALANCE,
-        }),
-        balances: generateInitialMaxBalances(config),
-      });
-      const epochCtx = new EpochContext(config);
-      epochCtx.loadState(state);
-      epochCtx.isAggregator = () => true;
-      epochCtx.getBeaconCommittee = () => [1000];
-      epochCtx.getAttestingIndices = () => [0, 1];
-      chainStub.getHeadStateContext.resolves({
-        state: state as TreeBacked<BeaconState>,
-        epochCtx: epochCtx,
-      });
-      expect(await validator.isValidIncomingAggregateAndProof(aggregateProof)).to.be.equal(
-        ExtendedValidatorResult.reject
-      );
-      expect(isBlsVerifyStub.calledOnce).to.be.false;
-    });
-
-    it("should return invalid signed aggregation and proof - invalid selection proof", async () => {
-      const aggregateProof = generateEmptySignedAggregateAndProof();
-      dbStub.aggregateAndProof.has.resolves(false);
-      chainStub.forkChoice.hasBlock.returns(true);
-      dbStub.badBlock.has.resolves(false);
-      chainStub.forkChoice.headStateRoot.returns(Buffer.alloc(0));
-      const state = generateState({
-        genesisTime: Math.floor(Date.now() / 1000) - config.params.SECONDS_PER_SLOT,
-        validators: generateValidators(config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT, {
-          activationEpoch: 0,
-          effectiveBalance: config.params.MAX_EFFECTIVE_BALANCE,
-        }),
-        balances: generateInitialMaxBalances(config),
-      });
-      const epochCtx = new EpochContext(config);
-      epochCtx.loadState(state);
-      epochCtx.getBeaconCommittee = () => [0];
-      epochCtx.getAttestingIndices = () => [0, 1];
-      epochCtx.isAggregator = () => true;
-      chainStub.getHeadStateContext.resolves({
-        state: state as TreeBacked<BeaconState>,
-        epochCtx: epochCtx,
-      });
-      isBlsVerifyStub.returns(false);
-      expect(await validator.isValidIncomingAggregateAndProof(aggregateProof)).to.be.equal(
-        ExtendedValidatorResult.reject
-      );
-      expect(isBlsVerifyStub.calledOnce).to.be.true;
-    });
-
-    it("should return invalid signed aggregation and proof - invalid signature", async () => {
-      const aggregateProof = generateEmptySignedAggregateAndProof();
-      dbStub.aggregateAndProof.has.resolves(false);
-      chainStub.forkChoice.hasBlock.returns(true);
-      dbStub.badBlock.has.resolves(false);
-      chainStub.forkChoice.headStateRoot.returns(Buffer.alloc(0));
-      const state = generateState({
-        genesisTime: Math.floor(Date.now() / 1000) - config.params.SECONDS_PER_SLOT,
-        validators: generateValidators(config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT, {
-          activationEpoch: 0,
-          effectiveBalance: config.params.MAX_EFFECTIVE_BALANCE,
-        }),
-        balances: generateInitialMaxBalances(config),
-      });
-      const epochCtx = new EpochContext(config);
-      epochCtx.loadState(state);
-      epochCtx.getBeaconCommittee = () => [0];
-      epochCtx.getAttestingIndices = () => [0, 1];
-      epochCtx.isAggregator = () => true;
-      chainStub.getHeadStateContext.resolves({
-        state: state as TreeBacked<BeaconState>,
-        epochCtx: epochCtx,
-      });
-      isBlsVerifyStub.onFirstCall().returns(true);
-      isBlsVerifyStub.onSecondCall().returns(false);
-      expect(await validator.isValidIncomingAggregateAndProof(aggregateProof)).to.be.equal(
-        ExtendedValidatorResult.reject
-      );
-      expect(isBlsVerifyStub.calledTwice).to.be.true;
-      expect(isValidIndexedAttestationStub.calledOnce).to.be.false;
-    });
-
-    it("should return invalid signed aggregation and proof - invalid indexed attestation", async () => {
-      const aggregateProof = generateEmptySignedAggregateAndProof();
-      dbStub.aggregateAndProof.has.resolves(false);
-      chainStub.forkChoice.hasBlock.returns(true);
-      dbStub.badBlock.has.resolves(false);
-      chainStub.forkChoice.headStateRoot.returns(Buffer.alloc(0));
-      const state = generateState({
-        genesisTime: Math.floor(Date.now() / 1000) - config.params.SECONDS_PER_SLOT,
-        validators: generateValidators(config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT, {
-          activationEpoch: 0,
-          effectiveBalance: config.params.MAX_EFFECTIVE_BALANCE,
-        }),
-        balances: generateInitialMaxBalances(config),
-      });
-      const epochCtx = new EpochContext(config);
-      epochCtx.loadState(state);
-      epochCtx.getAttestingIndices = () => [0, 1];
-      epochCtx.getBeaconCommittee = () => [0];
-      epochCtx.isAggregator = () => true;
-      chainStub.getHeadStateContext.resolves({
-        state: state as TreeBacked<BeaconState>,
-        epochCtx: epochCtx,
-      });
-      isBlsVerifyStub.onFirstCall().returns(true);
-      isBlsVerifyStub.onSecondCall().returns(true);
-      isValidIndexedAttestationStub.returns(false);
-      expect(await validator.isValidIncomingAggregateAndProof(aggregateProof)).to.be.equal(
-        ExtendedValidatorResult.reject
-      );
-      expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
-    });
-
-    it("should return valid signed aggregation and proof", async () => {
-      const aggregateProof = generateEmptySignedAggregateAndProof();
-      dbStub.aggregateAndProof.has.resolves(false);
-      chainStub.forkChoice.hasBlock.returns(true);
-      dbStub.badBlock.has.resolves(false);
-      chainStub.forkChoice.headStateRoot.returns(Buffer.alloc(0));
-      const state = generateState({
-        genesisTime: Math.floor(Date.now() / 1000) - config.params.SECONDS_PER_SLOT,
-        validators: generateValidators(config.params.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT, {
-          activationEpoch: 0,
-          effectiveBalance: config.params.MAX_EFFECTIVE_BALANCE,
-        }),
-        balances: generateInitialMaxBalances(config),
-      });
-      const epochCtx = new EpochContext(config);
-      epochCtx.loadState(state);
-      epochCtx.getBeaconCommittee = () => [0];
-      epochCtx.getAttestingIndices = () => [0, 1];
-      epochCtx.isAggregator = () => true;
-      chainStub.getHeadStateContext.resolves({
-        state: state as TreeBacked<BeaconState>,
-        epochCtx: epochCtx,
-      });
-      isBlsVerifyStub.returns(true);
-      isValidIndexedAttestationStub.returns(true);
-      expect(await validator.isValidIncomingAggregateAndProof(aggregateProof)).to.be.equal(
-        ExtendedValidatorResult.accept
-      );
-      expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
-    });
   });
 
   describe("validate voluntary exit", () => {

--- a/packages/lodestar/test/utils/aggregateAndProof.ts
+++ b/packages/lodestar/test/utils/aggregateAndProof.ts
@@ -1,12 +1,27 @@
-import {AggregateAndProof} from "@chainsafe/lodestar-types";
+import {AggregateAndProof, SignedAggregateAndProof} from "@chainsafe/lodestar-types";
 import {generateEmptyAttestation} from "./attestation";
 import {EMPTY_SIGNATURE} from "../../src/constants";
+import {DeepPartial} from "./misc";
+import deepmerge from "deepmerge";
+import {isPlainObject} from "@chainsafe/lodestar-utils";
 
-export function generateAggregateAndProof(override: Partial<AggregateAndProof> = {}): AggregateAndProof {
+export function generateAggregateAndProof(override: DeepPartial<AggregateAndProof> = {}): AggregateAndProof {
+  return deepmerge<AggregateAndProof, DeepPartial<AggregateAndProof>>(
+    {
+      aggregatorIndex: 0,
+      aggregate: generateEmptyAttestation(),
+      selectionProof: EMPTY_SIGNATURE,
+    },
+    override,
+    {isMergeableObject: isPlainObject}
+  );
+}
+
+export function generateSignedAggregateAndProof(
+  override: DeepPartial<AggregateAndProof> = {}
+): SignedAggregateAndProof {
   return {
-    aggregatorIndex: 0,
-    aggregate: generateEmptyAttestation(),
-    selectionProof: EMPTY_SIGNATURE,
-    ...override,
+    message: generateAggregateAndProof(override),
+    signature: EMPTY_SIGNATURE,
   };
 }


### PR DESCRIPTION
There is still some outstanding issues like:
- we don't check if gossiped aggregate was something we already received and checked in block or trough api (not a major issue)
- ideally, we would have some pool that would reverify once we have prestate and attestation block (it's fine since we will eventually receive it trough some other block)