### PR TITLE
Allow exiting process by force

### DIFF
--- a/packages/lodestar-cli/src/cmds/beacon/handler.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/handler.ts
@@ -49,9 +49,8 @@ export async function beaconHandler(options: IBeaconArgs & IGlobalArgs): Promise
   const node = new BeaconNode(options, {config, libp2p, logger});
 
   onProcessSIGINT(async () => {
-    await node.stop();
-    await writeEnr(beaconPaths.enrFile, enr, peerId);
-  });
+    await Promise.all([node.stop(), writeEnr(beaconPaths.enrFile, enr, peerId)]);
+  }, logger.info);
 
   if (options.genesisStateFile) {
     await node.chain.initializeBeaconChain(

--- a/packages/lodestar-cli/src/cmds/beacon/handler.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/handler.ts
@@ -1,5 +1,4 @@
 import * as fs from "fs";
-import process from "process";
 import {initBLS} from "@chainsafe/bls";
 import {BeaconNode} from "@chainsafe/lodestar/lib/node";
 import {createNodeJsLibp2p} from "@chainsafe/lodestar/lib/network/nodejs";
@@ -14,6 +13,7 @@ import {initCmd} from "../init/handler";
 import {IBeaconArgs} from "./options";
 import {getBeaconPaths} from "./paths";
 import {updateENR} from "../../util/enr";
+import {onProcessSIGINT} from "../../util/process";
 
 /**
  * Run a beacon node
@@ -48,13 +48,11 @@ export async function beaconHandler(options: IBeaconArgs & IGlobalArgs): Promise
 
   const node = new BeaconNode(options, {config, libp2p, logger});
 
-  async function cleanup(): Promise<void> {
+  onProcessSIGINT(async () => {
     await node.stop();
     await writeEnr(beaconPaths.enrFile, enr, peerId);
-  }
+  });
 
-  process.on("SIGTERM", cleanup);
-  process.on("SIGINT", cleanup);
   if (options.genesisStateFile) {
     await node.chain.initializeBeaconChain(
       config.types.BeaconState.tree.deserialize(await fs.promises.readFile(options.genesisStateFile))

--- a/packages/lodestar-cli/src/cmds/dev/handler.ts
+++ b/packages/lodestar-cli/src/cmds/dev/handler.ts
@@ -1,5 +1,4 @@
 import fs, {mkdirSync} from "fs";
-import process from "process";
 import {initBLS} from "@chainsafe/bls";
 import {BeaconNode} from "@chainsafe/lodestar/lib/node";
 import {createNodeJsLibp2p} from "@chainsafe/lodestar/lib/network/nodejs";
@@ -17,6 +16,7 @@ import {mergeConfigOptions} from "../../config/beacon";
 import {getBeaconConfig} from "../../util";
 import {getBeaconPaths} from "../beacon/paths";
 import {IDiscv5DiscoveryInputOptions} from "@chainsafe/discv5";
+import {onProcessSIGINT} from "../../util/process";
 
 /**
  * Run a beacon node
@@ -58,9 +58,24 @@ export async function devHandler(options: IDevArgs & IGlobalArgs): Promise<void>
     );
   }
 
+  let validators: Validator[] = [];
+
+  onProcessSIGINT(async () => {
+    logger.info("Stopping validators");
+    await Promise.all(validators.map((v) => v.stop()));
+    logger.info("Stopping BN");
+    await node.stop();
+    if (options.reset) {
+      logger.info("Cleaning directories");
+      //delete db directory
+      rimraf.sync(chainDir);
+      rimraf.sync(validatorsDir);
+    }
+    logger.info("Cleanup completed");
+  });
+
   await node.start();
 
-  let validators: Validator[];
   if (options.startValidators) {
     const range = options.startValidators.split(":").map((s) => parseInt(s));
     const api = getValidatorApiClient(options.server, logger, node);
@@ -77,21 +92,4 @@ export async function devHandler(options: IDevArgs & IGlobalArgs): Promise<void>
     });
     validators.forEach((v) => v.start());
   }
-
-  async function cleanup(): Promise<void> {
-    logger.info("Stopping validators");
-    await Promise.all(validators.map((v) => v.stop()));
-    logger.info("Stopping BN");
-    await node.stop();
-    if (options.reset) {
-      logger.info("Cleaning directories");
-      //delete db directory
-      rimraf.sync(chainDir);
-      rimraf.sync(validatorsDir);
-    }
-    logger.info("Cleanup completed");
-  }
-
-  process.on("SIGTERM", cleanup);
-  process.on("SIGINT", cleanup);
 }

--- a/packages/lodestar-cli/src/cmds/validator/handler.ts
+++ b/packages/lodestar-cli/src/cmds/validator/handler.ts
@@ -1,5 +1,4 @@
 import fs from "fs";
-import process from "process";
 import {initBLS} from "@chainsafe/bls";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {ApiClientOverRest} from "@chainsafe/lodestar-validator/lib/api/impl/rest/apiClient";
@@ -14,6 +13,7 @@ import {getValidatorPaths} from "./paths";
 import {IValidatorCliArgs} from "./options";
 import {getMergedIBeaconConfig} from "../../config/params";
 import {initCmd} from "../init/handler";
+import {onProcessSIGINT} from "../../util/process";
 
 /**
  * Run a validator client
@@ -66,14 +66,11 @@ export async function validatorHandler(options: IValidatorCliArgs & IGlobalArgs)
     }
   );
 
-  async function cleanup(): Promise<void> {
+  onProcessSIGINT(async () => {
     logger.info("Stopping validators");
     await Promise.all(validators.map((v) => v.stop()));
     logger.info("Cleanup completed");
-  }
-
-  process.on("SIGTERM", cleanup);
-  process.on("SIGINT", cleanup);
+  });
 
   await Promise.all(validators.map((validator) => validator.start()));
 }

--- a/packages/lodestar-cli/src/cmds/validator/handler.ts
+++ b/packages/lodestar-cli/src/cmds/validator/handler.ts
@@ -67,10 +67,8 @@ export async function validatorHandler(options: IValidatorCliArgs & IGlobalArgs)
   );
 
   onProcessSIGINT(async () => {
-    logger.info("Stopping validators");
     await Promise.all(validators.map((v) => v.stop()));
-    logger.info("Cleanup completed");
-  });
+  }, logger.info);
 
   await Promise.all(validators.map((validator) => validator.start()));
 }

--- a/packages/lodestar-cli/src/util/process.ts
+++ b/packages/lodestar-cli/src/util/process.ts
@@ -6,17 +6,22 @@ const exitSignals = ["SIGTERM", "SIGINT"] as NodeJS.Signals[];
  * user forcibly kills the process by doing CTRL+C again
  * @param cleanUpFunction
  */
-export function onProcessSIGINT(cleanUpFunction: () => Promise<void>): void {
+export function onProcessSIGINT(
+  cleanUpFunction: () => Promise<void>,
+  // eslint-disable-next-line no-console
+  logFn: (msg: string) => void = console.log
+): void {
   for (const signal of exitSignals) {
     process.once(signal, async () => {
-      // eslint-disable-next-line no-console
-      console.log("Stopping gracefully, use Ctrl+C again to force process exit");
+      logFn("Stopping gracefully, use Ctrl+C again to force process exit");
+
       process.on(signal, () => {
-        // eslint-disable-next-line no-console
-        console.log("Forcing process exit");
+        logFn("Forcing process exit");
         process.exit(1);
       });
+
       await cleanUpFunction();
+      logFn("Cleanup completed");
     });
   }
 }

--- a/packages/lodestar-cli/src/util/process.ts
+++ b/packages/lodestar-cli/src/util/process.ts
@@ -1,0 +1,22 @@
+const exitSignals = ["SIGTERM", "SIGINT"] as NodeJS.Signals[];
+
+/**
+ * All CLI handlers should register this callback to exit properly and not leave
+ * a process hanging forever. Pass a clean function that will be run until the
+ * user forcibly kills the process by doing CTRL+C again
+ * @param cleanUpFunction
+ */
+export function onProcessSIGINT(cleanUpFunction: () => Promise<void>): void {
+  for (const signal of exitSignals) {
+    process.once(signal, async () => {
+      // eslint-disable-next-line no-console
+      console.log("Stopping gracefully, use Ctrl+C again to force process exit");
+      process.on(signal, () => {
+        // eslint-disable-next-line no-console
+        console.log("Forcing process exit");
+        process.exit(1);
+      });
+      await cleanUpFunction();
+    });
+  }
+}


### PR DESCRIPTION
The current way of handling process signals causes almost always to create a zombie unexited process.
According to the docs https://nodejs.org/api/process.html#process_signal_events

> 'SIGTERM' and 'SIGINT' have default handlers on non-Windows platforms that reset the terminal mode before exiting with code 128 + signal number. If one of these signals has a listener installed, its default behavior will be removed (Node.js will no longer exit).

So by attaching a cleanup listener to SIGINT and never calling process.exit() afterwards the only option for the process to exit is if the event loop becomes empty. This would be ideal but it's a very difficult task to accomplish having so many components and dependencies. A single unresolved promise or listener would leave the process zombie.

This PR adds a second listener to SIGINT so that if the user hits CTRL+C twice the process will exit by force.