### PR TITLE
Track validators connected to node to subscribe random subnets

### DIFF
--- a/packages/lodestar/src/db/api/beacon/activeValidatorCache.ts
+++ b/packages/lodestar/src/db/api/beacon/activeValidatorCache.ts
@@ -1,0 +1,55 @@
+import {ValidatorIndex, Epoch} from "@chainsafe/lodestar-types";
+
+/**
+ * In memory cache of connected validators to this node.
+ *
+ * Similar API to Repository
+ */
+export class ActiveValidatorCache {
+  // validator index and last accessed epoch
+  private cache: Map<ValidatorIndex, Epoch>;
+
+  constructor() {
+    this.cache = new Map();
+  }
+
+  public async get(index: ValidatorIndex): Promise<{index: ValidatorIndex; epoch: Epoch} | null> {
+    const epoch = this.cache.get(index);
+    if (typeof epoch !== "number") return null;
+
+    return {
+      index,
+      epoch: epoch as Epoch,
+    };
+  }
+
+  public async add(index: ValidatorIndex, epoch: Epoch): Promise<void> {
+    this.cache.set(index, epoch);
+  }
+
+  public async delete(index: ValidatorIndex): Promise<void> {
+    this.cache.delete(index);
+  }
+
+  public async batchDelete(indexes: ValidatorIndex[] = []): Promise<void> {
+    indexes.forEach((index) => this.delete(index));
+  }
+
+  public async values(): Promise<ValidatorIndex[]> {
+    return Array.from(this.cache.keys());
+  }
+
+  public clear(): void {
+    this.cache = new Map();
+  }
+
+  public async pruneFinalized(finalizedEpoch: Epoch): Promise<void> {
+    const validatorsToDelete: ValidatorIndex[] = [];
+    for (const [index, epoch] of this.cache) {
+      if (epoch < finalizedEpoch) {
+        validatorsToDelete.push(index);
+      }
+    }
+    await this.batchDelete(validatorsToDelete);
+  }
+}

--- a/packages/lodestar/src/db/api/beacon/beacon.ts
+++ b/packages/lodestar/src/db/api/beacon/beacon.ts
@@ -21,12 +21,14 @@ import {
 } from "./repositories";
 import {SeenAttestationCache} from "./seenAttestationCache";
 import {PendingBlockRepository} from "./repositories/pendingBlock";
+import {ActiveValidatorCache} from "./activeValidatorCache";
 
 export class BeaconDb extends DatabaseService implements IBeaconDb {
   public badBlock: BadBlockRepository;
   public block: BlockRepository;
   public pendingBlock: PendingBlockRepository;
   public seenAttestationCache: SeenAttestationCache;
+  public activeValidatorCache: ActiveValidatorCache;
   public blockArchive: BlockArchiveRepository;
   public stateArchive: StateArchiveRepository;
 
@@ -46,6 +48,7 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
     this.block = new BlockRepository(this.config, this.db);
     this.pendingBlock = new PendingBlockRepository(this.config, this.db);
     this.seenAttestationCache = new SeenAttestationCache(5000);
+    this.activeValidatorCache = new ActiveValidatorCache();
     this.blockArchive = new BlockArchiveRepository(this.config, this.db);
     this.stateArchive = new StateArchiveRepository(this.config, this.db);
     this.attestation = new AttestationRepository(this.config, this.db);

--- a/packages/lodestar/src/db/api/beacon/interface.ts
+++ b/packages/lodestar/src/db/api/beacon/interface.ts
@@ -20,6 +20,7 @@ import {
 } from "./repositories";
 import {SeenAttestationCache} from "./seenAttestationCache";
 import {PendingBlockRepository} from "./repositories/pendingBlock";
+import {ActiveValidatorCache} from "./activeValidatorCache";
 
 /**
  * The DB service manages the data layer of the beacon chain
@@ -38,6 +39,9 @@ export interface IBeaconDb {
 
   // cache for attestations that have already been seen via gossip or other sources
   seenAttestationCache: SeenAttestationCache;
+
+  // active validators connected to this node
+  activeValidatorCache: ActiveValidatorCache;
 
   // finalized blocks
   blockArchive: BlockArchiveRepository;

--- a/packages/lodestar/src/db/api/beacon/repositories/attestation.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/attestation.ts
@@ -30,9 +30,13 @@ export class AttestationRepository extends Repository<Uint8Array, Attestation> {
     const attestations = await this.values();
     //TODO: add secondary index slot => root => AttestationData
     return attestations.filter((attestation) => {
-      return this.config.types.Root.equals(
-        attestationDataRoot,
-        this.config.types.AttestationData.hashTreeRoot(attestation.data)
+      const attestationData = attestation.data;
+      return (
+        attestationData.slot === slot &&
+        this.config.types.Root.equals(
+          attestationDataRoot,
+          this.config.types.AttestationData.hashTreeRoot(attestationData)
+        )
       );
     });
   }

--- a/packages/lodestar/src/tasks/index.ts
+++ b/packages/lodestar/src/tasks/index.ts
@@ -52,6 +52,7 @@ export class TasksService implements IService {
     this.network = modules.network;
     this.interopSubnetsTask = new InteropSubnetsJoiningTask(this.config, {
       chain: this.chain,
+      db: this.db,
       network: this.network,
       logger: this.logger,
     });
@@ -107,6 +108,7 @@ export class TasksService implements IService {
         this.chain.checkpointStateCache.pruneFinalized(finalized.epoch),
         this.db.attestation.pruneFinalized(finalized.epoch),
         this.db.aggregateAndProof.pruneFinalized(finalized.epoch),
+        this.db.activeValidatorCache.pruneFinalized(finalized.epoch),
       ]);
       // tasks rely on extended fork choice
       this.chain.forkChoice.prune(finalized.root);

--- a/packages/lodestar/test/unit/sync/utils/attestation-collector.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/attestation-collector.test.ts
@@ -40,7 +40,7 @@ describe("Attestation collector", function () {
       chain: {
         clock: realClock,
         getHeadState: () => generateState(),
-        getHeadEpochContext: () => (new EpochContext(config)),
+        getHeadEpochContext: () => new EpochContext(config),
         getForkDigest: () => Buffer.alloc(4),
         emitter,
       },

--- a/packages/lodestar/test/unit/sync/utils/attestation-collector.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/attestation-collector.test.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import sinon from "sinon";
 import {AbortController} from "abort-controller";
 import {config} from "@chainsafe/lodestar-config/minimal";
-import * as attestationUtils from "@chainsafe/lodestar-beacon-state-transition/lib/util/attestation";
+import * as attestationUtils from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util/attestation";
 
 import {AttestationCollector} from "../../../../src/sync/utils";
 import {LocalClock} from "../../../../src/chain/clock/LocalClock";
@@ -11,6 +11,7 @@ import {Gossip} from "../../../../src/network/gossip/gossip";
 import {BeaconDb} from "../../../../src/db";
 import {generateState} from "../../../utils/state";
 import {silentLogger} from "../../../utils/logger";
+import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 
 describe("Attestation collector", function () {
   const sandbox = sinon.createSandbox();
@@ -39,6 +40,7 @@ describe("Attestation collector", function () {
       chain: {
         clock: realClock,
         getHeadState: () => generateState(),
+        getHeadEpochContext: () => (new EpochContext(config)),
         getForkDigest: () => Buffer.alloc(4),
         emitter,
       },

--- a/packages/lodestar/test/unit/tasks/interopSubnetsJoiningTask.test.ts
+++ b/packages/lodestar/test/unit/tasks/interopSubnetsJoiningTask.test.ts
@@ -15,12 +15,14 @@ import {MetadataController} from "../../../src/network/metadata";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {computeForkDigest} from "@chainsafe/lodestar-beacon-state-transition";
 import {TreeBacked} from "@chainsafe/ssz";
+import {StubbedBeaconDb} from "../../utils/stub";
 
 describe("interopSubnetsJoiningTask", () => {
   const sandbox = sinon.createSandbox();
   let clock: SinonFakeTimers;
   let networkStub: SinonStubbedInstance<INetwork>;
   let gossipStub: SinonStubbedInstance<IGossip>;
+  let dbStub: StubbedBeaconDb;
 
   let chain: IBeaconChain;
   const logger = new WinstonLogger();
@@ -53,9 +55,13 @@ describe("interopSubnetsJoiningTask", () => {
       config,
     });
     networkStub.metadata = new MetadataController({}, {config, chain, logger});
+    dbStub = new StubbedBeaconDb(sinon);
+    // 2 active validators
+    dbStub.activeValidatorCache.values.resolves([0, 5]);
     task = new InteropSubnetsJoiningTask(config, {
       network: networkStub,
       chain,
+      db: dbStub,
       logger,
     });
     await task.start();
@@ -67,26 +73,52 @@ describe("interopSubnetsJoiningTask", () => {
     clock.restore();
   });
 
+  it("should not subscribe when there is no active validator", async () => {
+    dbStub.activeValidatorCache.values.resolves([]);
+    chain.emitter.emit(ChainEvent.clockEpoch, 1);
+    expect(gossipStub.subscribeToAttestationSubnet.called).to.be.false;
+  });
+
   it("should handle fork digest change", async () => {
+    chain.emitter.emit(ChainEvent.clockEpoch, 1);
+    await Promise.all([
+      new Promise((resolve) => gossipStub.subscribeToAttestationSubnet.onFirstCall().callsFake(resolve)),
+      new Promise((resolve) => gossipStub.subscribeToAttestationSubnet.onSecondCall().callsFake(resolve)),
+    ]);
     const oldForkDigest = chain.getForkDigest();
-    expect(gossipStub.subscribeToAttestationSubnet.callCount).to.be.equal(config.params.RANDOM_SUBNETS_PER_VALIDATOR);
+    // 2 active validators
+    expect(gossipStub.subscribeToAttestationSubnet.callCount).to.be.equal(2);
     // fork digest changed due to current version changed
     state.fork.currentVersion = Buffer.from([100, 0, 0, 0]);
     expect(config.types.ForkDigest.equals(oldForkDigest, chain.getForkDigest())).to.be.false;
     // not subscribe, just unsubscribe at that time
-    const unSubscribePromise = new Promise((resolve) => gossipStub.unsubscribeFromAttestationSubnet.callsFake(resolve));
-    chain.emitter.emit(ChainEvent.forkVersion, state.fork.currentVersion);
-    await unSubscribePromise;
-    expect(gossipStub.unsubscribeFromAttestationSubnet.callCount).to.be.equal(
-      config.params.RANDOM_SUBNETS_PER_VALIDATOR
+    const unsubsPromise1 = new Promise((resolve) =>
+      gossipStub.unsubscribeFromAttestationSubnet.onFirstCall().callsFake(resolve)
     );
+    const unsubsPromise2 = new Promise((resolve) =>
+      gossipStub.unsubscribeFromAttestationSubnet.onSecondCall().callsFake(resolve)
+    );
+    chain.emitter.emit(ChainEvent.forkVersion, state.fork.currentVersion);
+    await Promise.all([unsubsPromise1, unsubsPromise2]);
+    // 2 active validators
+    expect(gossipStub.unsubscribeFromAttestationSubnet.callCount).to.be.equal(2);
   });
 
   it("should change subnet subscription after 2*EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION", async () => {
+    chain.emitter.emit(ChainEvent.clockEpoch, 1);
+    await Promise.all([
+      new Promise((resolve) => gossipStub.subscribeToAttestationSubnet.onFirstCall().callsFake(resolve)),
+      new Promise((resolve) => gossipStub.subscribeToAttestationSubnet.onSecondCall().callsFake(resolve)),
+    ]);
     const seqNumber = networkStub.metadata.seqNumber;
     expect(Number(seqNumber)).to.be.gt(0);
-    expect(gossipStub.subscribeToAttestationSubnet.callCount).to.be.equal(config.params.RANDOM_SUBNETS_PER_VALIDATOR);
-    const unsubscribePromise = new Promise((resolve) => gossipStub.unsubscribeFromAttestationSubnet.callsFake(resolve));
+    expect(gossipStub.subscribeToAttestationSubnet.callCount).to.be.equal(2);
+    const unsubscribePromise1 = new Promise((resolve) =>
+      gossipStub.unsubscribeFromAttestationSubnet.onFirstCall().callsFake(resolve)
+    );
+    const unsubscribePromise2 = new Promise((resolve) =>
+      gossipStub.unsubscribeFromAttestationSubnet.onSecondCall().callsFake(resolve)
+    );
     clock.tick(
       2 *
         config.params.EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION *
@@ -94,9 +126,10 @@ describe("interopSubnetsJoiningTask", () => {
         config.params.SECONDS_PER_SLOT *
         1000
     );
-    await unsubscribePromise;
-    expect(gossipStub.unsubscribeFromAttestationSubnet.callCount).to.be.gte(config.params.RANDOM_SUBNETS_PER_VALIDATOR);
-    expect(gossipStub.subscribeToAttestationSubnet.callCount).to.be.gte(2 * config.params.RANDOM_SUBNETS_PER_VALIDATOR);
+    await Promise.all([unsubscribePromise1, unsubscribePromise2]);
+    expect(gossipStub.unsubscribeFromAttestationSubnet.callCount).to.be.gte(2);
+    // 2 more because of changing subnets
+    expect(gossipStub.subscribeToAttestationSubnet.callCount).to.be.gte(4);
     expect(Number(networkStub.metadata.seqNumber)).to.be.gt(Number(seqNumber));
   });
 
@@ -110,22 +143,18 @@ describe("interopSubnetsJoiningTask", () => {
     );
     const spy = sandbox.spy();
     gossipStub.subscribeToAttestationSubnet.callsFake(spy);
-    clock.tick(
+    const timeToGetThroughPreparedEpoch =
       (ALL_FORKS[0].epoch - config.params.EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION + 1) *
-        config.params.SLOTS_PER_EPOCH *
-        config.params.SECONDS_PER_SLOT *
-        1000
-    );
-    // at least 1 run right after start, 1 run in scheduleNextForkSubscription
-    expect(gossipStub.subscribeToAttestationSubnet.callCount).to.be.gte(2 * config.params.RANDOM_SUBNETS_PER_VALIDATOR);
+      config.params.SLOTS_PER_EPOCH *
+      config.params.SECONDS_PER_SLOT *
+      1000;
+    clock.tick(timeToGetThroughPreparedEpoch);
+    // wait for async functions
+    await Promise.resolve();
+    // at least 2 run right after start, 2 run in scheduleNextForkSubscription
+    expect(gossipStub.subscribeToAttestationSubnet.callCount).to.be.gte(4);
     // subscribe to next fork digest subnet
     const forkDigestArgs = spy.args.map((callTimeArgs) => callTimeArgs[0]);
-    let callNextForkDigest = false;
-    for (const forkDigest of forkDigestArgs) {
-      if (config.types.ForkDigest.equals(forkDigest, nextForkDigest)) {
-        callNextForkDigest = true;
-      }
-    }
-    expect(callNextForkDigest).to.be.true;
+    expect(forkDigestArgs.some((forkDigest) => config.types.ForkDigest.equals(forkDigest, nextForkDigest))).to.be.true;
   });
 });

--- a/packages/lodestar/test/utils/stub/beaconDb.ts
+++ b/packages/lodestar/test/utils/stub/beaconDb.ts
@@ -20,6 +20,7 @@ import {
 import {SeenAttestationCache} from "../../../src/db/api/beacon/seenAttestationCache";
 import {minimalConfig} from "@chainsafe/lodestar-config/minimal";
 import {PendingBlockRepository} from "../../../src/db/api/beacon/repositories/pendingBlock";
+import {ActiveValidatorCache} from "../../../src/db/api/beacon/activeValidatorCache";
 
 export class StubbedBeaconDb extends BeaconDb {
   public db!: SinonStubbedInstance<LevelDbController>;
@@ -41,6 +42,7 @@ export class StubbedBeaconDb extends BeaconDb {
   public eth1Data: SinonStubbedInstance<Eth1DataRepository> & Eth1DataRepository;
 
   public seenAttestationCache: SinonStubbedInstance<SeenAttestationCache> & SeenAttestationCache;
+  public activeValidatorCache: SinonStubbedInstance<ActiveValidatorCache> & ActiveValidatorCache;
 
   public processBlockOperations: SinonStubbedInstance<(signedBlock: SignedBeaconBlock) => Promise<void>> &
     ((signedBlock: SignedBeaconBlock) => Promise<void>);
@@ -64,6 +66,7 @@ export class StubbedBeaconDb extends BeaconDb {
     this.depositDataRoot = sinon.createStubInstance(DepositDataRootRepository) as any;
     this.eth1Data = sinon.createStubInstance(Eth1DataRepository) as any;
     this.seenAttestationCache = sinon.createStubInstance(SeenAttestationCache) as any;
+    this.activeValidatorCache = sinon.createStubInstance(ActiveValidatorCache) as any;
     this.processBlockOperations = sinon.stub(this, "processBlockOperations") as any;
   }
 }


### PR DESCRIPTION
resolves #1382 

+ Track validators connected to node in newly created `activeValidatorCache`
+ Update it in `beacon_committee_subscriptions` api
+ Remove inactive validators using `pruneFinalized`
+ Use `activeValidatorCache` in `interopJoiningSubnetTask` per new epoch