### PR TITLE
Fix attester duties BigInt error

### DIFF
--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -167,13 +167,15 @@ export class ValidatorApi implements IValidatorApi {
       }
       return validatorIndex;
     });
-    return validatorIndexes.map((validatorIndex) => {
-      const validator = state.validators[validatorIndex];
-      if (!validator) {
-        throw Error(`Validator index ${validatorIndex} not in state`);
-      }
-      return assembleAttesterDuty(this.config, {publicKey: validator.pubkey, index: validatorIndex}, epochCtx, epoch);
-    });
+    return validatorIndexes
+      .map((validatorIndex) => {
+        const validator = state.validators[validatorIndex];
+        if (!validator) {
+          throw Error(`Validator index ${validatorIndex} not in state`);
+        }
+        return assembleAttesterDuty(this.config, {publicKey: validator.pubkey, index: validatorIndex}, epochCtx, epoch);
+      })
+      .filter((duty) => duty.committeeIndex !== null && duty.attestationSlot !== null);
   }
 
   public async publishAggregateAndProof(signedAggregateAndProof: SignedAggregateAndProof): Promise<void> {

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -45,6 +45,7 @@ import {IBeaconSync} from "../../../sync";
 import {toGraffitiBuffer} from "../../../util/graffiti";
 import {ApiError} from "../errors/api";
 import {processSlots} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/slot";
+import {notNullish} from "../../../util/notNullish";
 
 export class ValidatorApi implements IValidatorApi {
   public namespace: ApiNamespace;
@@ -175,7 +176,7 @@ export class ValidatorApi implements IValidatorApi {
         }
         return assembleAttesterDuty(this.config, {publicKey: validator.pubkey, index: validatorIndex}, epochCtx, epoch);
       })
-      .filter((duty) => duty.committeeIndex !== null && duty.attestationSlot !== null);
+      .filter(notNullish) as AttesterDuty[];
   }
 
   public async publishAggregateAndProof(signedAggregateAndProof: SignedAggregateAndProof): Promise<void> {

--- a/packages/lodestar/src/chain/factory/duties/index.ts
+++ b/packages/lodestar/src/chain/factory/duties/index.ts
@@ -8,11 +8,11 @@ export function assembleAttesterDuty(
   validator: {publicKey: BLSPubkey; index: ValidatorIndex},
   epochCtx: EpochContext,
   epoch: Epoch
-): AttesterDuty {
-  let duty: AttesterDuty = generateEmptyAttesterDuty(validator.publicKey);
+): AttesterDuty | null {
+  const duty: AttesterDuty = generateEmptyAttesterDuty(validator.publicKey);
   const committeeAssignment = epochCtx.getCommitteeAssignment(epoch, validator.index);
   if (committeeAssignment) {
-    duty = {
+    return {
       ...duty,
       aggregatorModulo: Math.max(
         1,
@@ -23,7 +23,7 @@ export function assembleAttesterDuty(
     };
   }
 
-  return duty;
+  return null;
 }
 
 export function generateEmptyAttesterDuty(publicKey: BLSPubkey, duty?: Partial<AttesterDuty>): AttesterDuty {

--- a/packages/lodestar/test/unit/chain/factory/duties/assembleValidatorDuty.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/duties/assembleValidatorDuty.test.ts
@@ -50,9 +50,6 @@ describe("assemble validator duty", function () {
     const epochCtx = new EpochContext(config);
     epochCtx.getCommitteeAssignment = () => null;
     const result = assembleAttesterDuty(config, {publicKey, index: validatorIndex}, epochCtx, 3);
-    expect(result).to.not.be.null;
-    expect(result.validatorPubkey).to.be.equal(publicKey);
-    expect(result.attestationSlot).to.be.equal(null);
-    expect(result.committeeIndex).to.be.equal(null);
+    expect(result).to.be.null;
   });
 });


### PR DESCRIPTION
Error can happen if validator is in state but not yet activated in which case he doesn't have attester duties so we set attestation slot and index to null which is not valid.

resolves #1358 