### PR TITLE
Remove unused chain options

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -61,7 +61,6 @@ export interface IBlockProcessJob {
 }
 
 export class BeaconChain extends (EventEmitter as {new (): ChainEventEmitter}) implements IBeaconChain {
-  public readonly chain: string;
   public forkChoice: ILMDGHOST;
   public chainId: Uint16;
   public networkId: Uint64;
@@ -80,7 +79,6 @@ export class BeaconChain extends (EventEmitter as {new (): ChainEventEmitter}) i
   public constructor(opts: IChainOptions, {config, db, eth1, logger, metrics, forkChoice}: IBeaconChainModules) {
     super();
     this.opts = opts;
-    this.chain = opts.name;
     this.config = config;
     this.db = db;
     this.eth1 = eth1;

--- a/packages/lodestar/src/chain/options.ts
+++ b/packages/lodestar/src/chain/options.ts
@@ -1,11 +1,5 @@
-export interface IChainOptions {
-  name: string;
-  dumpState: boolean;
-}
+export type IChainOptions = {};
 
-const config: IChainOptions = {
-  name: "mainnet",
-  dumpState: false,
-};
+const config: IChainOptions = {};
 
 export default config;


### PR DESCRIPTION
Fixes https://github.com/ChainSafe/lodestar/issues/1228
I've left the IChainOpts there empty. It's more consistent with other modules and would require less changes if we need to add options in the future. Should I remove it?