### PR TITLE
Remove unsafe uses of setTimeout

### DIFF
--- a/packages/lodestar/src/sync/utils/attestation-collector.ts
+++ b/packages/lodestar/src/sync/utils/attestation-collector.ts
@@ -65,11 +65,9 @@ export class AttestationCollector implements IService {
       const subnet = computeSubnetForSlot(this.config, headState, slot, committeeIndex);
       this.network.gossip.subscribeToAttestationSubnet(forkDigest, subnet, this.handleCommitteeAttestation);
       this.timers.push(
-        (setTimeout(
-          this.unsubscribeSubnet,
-          this.config.params.SECONDS_PER_SLOT * 1000,
-          subnet
-        ) as unknown) as NodeJS.Timeout
+        setTimeout(() => {
+          this.unsubscribeSubnet(subnet);
+        }, this.config.params.SECONDS_PER_SLOT * 1000)
       );
     });
     this.aggregationDuties.delete(slot);

--- a/packages/lodestar/src/tasks/tasks/interopSubnetsJoiningTask.ts
+++ b/packages/lodestar/src/tasks/tasks/interopSubnetsJoiningTask.ts
@@ -81,11 +81,10 @@ export class InteropSubnetsJoiningTask {
           intToBytes(nextFork.currentVersion, 4),
           state.genesisValidatorsRoot
         );
-        this.nextForkSubsTimer = (setTimeout(
-          this.run,
-          timeToPreparedEpoch,
-          nextForkDigest
-        ) as unknown) as NodeJS.Timeout;
+        this.nextForkSubsTimer = setTimeout(() => {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          this.run(nextForkDigest).catch();
+        }, timeToPreparedEpoch);
       }
     }
   };
@@ -141,12 +140,10 @@ export class InteropSubnetsJoiningTask {
       ? this.currentTimers
       : this.nextForkTimers;
     timers.push(
-      (setTimeout(
-        this.handleChangeSubnets,
-        subscriptionLifetime * this.config.params.SLOTS_PER_EPOCH * this.config.params.SECONDS_PER_SLOT * 1000,
-        forkDigest,
-        subnet
-      ) as unknown) as NodeJS.Timeout
+      setTimeout(() => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        this.handleChangeSubnets(forkDigest, subnet);
+      }, subscriptionLifetime * this.config.params.SLOTS_PER_EPOCH * this.config.params.SECONDS_PER_SLOT * 1000)
     );
     if (timers.length > this.config.params.RANDOM_SUBNETS_PER_VALIDATOR) {
       timers.shift();


### PR DESCRIPTION
Fixes https://github.com/ChainSafe/lodestar/issues/1184

No floating promises rule complains about the handlers inside setTimeout. I've added an eslint ignore since that's not the focus of this PR. But if you have a definitive answer about how those should be handled please leave a comment.