### PR TITLE
Remove unnecessary stubs of logger

### DIFF
--- a/packages/lodestar-validator/test/unit/api/rcpClientOverInstance.test.ts
+++ b/packages/lodestar-validator/test/unit/api/rcpClientOverInstance.test.ts
@@ -5,7 +5,7 @@ import {ApiClientOverInstance} from "../../../src/api";
 import {MockBeaconApi} from "../../utils/mocks/beacon";
 import {MockNodeApi} from "../../utils/mocks/node";
 import {MockValidatorApi} from "../../utils/mocks/validator";
-import {WinstonLogger, LogLevel} from "@chainsafe/lodestar-utils";
+import {silentLogger} from "../../utils/logger";
 
 describe("RpcClientOverInstance test", function () {
   let clock: any, sandbox: any;
@@ -34,7 +34,7 @@ describe("RpcClientOverInstance test", function () {
       }),
       node: new MockNodeApi(),
       validator: new MockValidatorApi(),
-      logger: new WinstonLogger({level: LogLevel.error}),
+      logger: silentLogger,
     });
   }
 

--- a/packages/lodestar-validator/test/unit/services/attestation.test.ts
+++ b/packages/lodestar-validator/test/unit/services/attestation.test.ts
@@ -2,7 +2,6 @@ import sinon, {SinonSpy} from "sinon";
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 import {Keypair, PrivateKey} from "@chainsafe/bls";
-import {ILogger, WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import EventSource from "eventsource";
 import {ApiClientOverInstance} from "../../../src/api";
 import {AttestationService} from "../../../src/services/attestation";
@@ -16,6 +15,7 @@ import {
   generateEmptyAttestation,
 } from "@chainsafe/lodestar/test/utils/attestation";
 import {generateEmptySignedBlock} from "@chainsafe/lodestar/test/utils/block";
+import {silentLogger} from "../../utils/logger";
 
 const clock = sinon.useFakeTimers({now: Date.now(), shouldAdvanceTime: true, toFake: ["setTimeout"]});
 
@@ -23,7 +23,7 @@ describe("validator attestation service", function () {
   const sandbox = sinon.createSandbox();
 
   let rpcClientStub: any, dbStub: any, eventSourceSpy: SinonSpy;
-  const logger: ILogger = sinon.createStubInstance(WinstonLogger);
+  const logger = silentLogger;
 
   beforeEach(() => {
     rpcClientStub = sandbox.createStubInstance(ApiClientOverInstance);

--- a/packages/lodestar-validator/test/unit/services/block.test.ts
+++ b/packages/lodestar-validator/test/unit/services/block.test.ts
@@ -2,23 +2,23 @@ import sinon from "sinon";
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 import {Keypair} from "@chainsafe/bls";
-import {ILogger, WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {ApiClientOverInstance} from "../../../src/api";
 import {generateEmptySignedBlock, generateEmptyBlock} from "@chainsafe/lodestar/test/utils/block";
 import BlockProposingService from "../../../src/services/block";
 import {generateFork} from "../../utils/fork";
 import {MockValidatorDB} from "../../utils/mocks/MockValidatorDB";
 import {ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
+import {silentLogger} from "../../utils/logger";
 
 describe("block proposing service", function () {
   const sandbox = sinon.createSandbox();
 
-  let rpcClientStub: any, dbStub: any, logger: any;
+  let rpcClientStub: any, dbStub: any;
+  const logger = silentLogger;
 
   beforeEach(() => {
     rpcClientStub = sandbox.createStubInstance(ApiClientOverInstance);
     dbStub = sandbox.createStubInstance(MockValidatorDB);
-    logger = sandbox.createStubInstance(WinstonLogger);
   });
 
   afterEach(() => {
@@ -58,7 +58,7 @@ describe("block proposing service", function () {
       .withArgs(slot, sinon.match.any, sinon.match.any)
       .resolves(generateEmptyBlock());
     dbStub.getBlock.resolves(generateEmptySignedBlock());
-    const service = new BlockProposingService(config, [Keypair.generate()], rpcClientStub, dbStub, logger as ILogger);
+    const service = new BlockProposingService(config, [Keypair.generate()], rpcClientStub, dbStub, logger);
     const result = await service.createAndPublishBlock(0, slot, generateFork(), ZERO_HASH);
     expect(result).to.not.be.null;
     expect(rpcClientStub.validator.publishBlock.calledOnce).to.be.true;

--- a/packages/lodestar-validator/test/unit/utils/httpClient.test.ts
+++ b/packages/lodestar-validator/test/unit/utils/httpClient.test.ts
@@ -2,8 +2,7 @@ import {assert} from "chai";
 import Axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import {HttpClient} from "../../../src/util";
-import {ILogger, WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
-import sinon from "sinon";
+import {silentLogger} from "../../utils/logger";
 
 interface IUser {
   id?: number;
@@ -16,8 +15,7 @@ describe("httpClient test", () => {
 
   beforeEach(() => {
     mock = new MockAdapter(Axios);
-    const logger: ILogger = sinon.createStubInstance(WinstonLogger);
-    httpClient = new HttpClient({}, {logger});
+    httpClient = new HttpClient({}, {logger: silentLogger});
   });
 
   it("should handle successful GET request correctly", async () => {

--- a/packages/lodestar-validator/test/unit/validator.test.ts
+++ b/packages/lodestar-validator/test/unit/validator.test.ts
@@ -1,7 +1,6 @@
 import {expect} from "chai";
 import {Keypair} from "@chainsafe/bls/lib/keypair";
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import sinon from "sinon";
 import {ApiClientOverInstance} from "../../src/api";
 import {MockBeaconApi} from "../utils/mocks/beacon";
@@ -9,6 +8,7 @@ import {MockValidatorApi} from "../utils/mocks/validator";
 import {IValidatorOptions, Validator} from "../../src";
 import {MockValidatorDB} from "../utils/mocks/MockValidatorDB";
 import {MockNodeApi} from "../utils/mocks/node";
+import {silentLogger} from "../utils/logger";
 
 describe("Validator", () => {
   it.skip("Should be able to connect with the beacon chain", async () => {
@@ -26,7 +26,7 @@ describe("Validator", () => {
       keypairs: [Keypair.generate()],
       config,
       db: sinon.createStubInstance(MockValidatorDB),
-      logger: sinon.createStubInstance(WinstonLogger),
+      logger: silentLogger,
     };
 
     const validator = new Validator(validatorCtx);

--- a/packages/lodestar-validator/test/utils/logger.ts
+++ b/packages/lodestar-validator/test/utils/logger.ts
@@ -1,0 +1,4 @@
+import {ILogger, WinstonLogger, LogLevel} from "@chainsafe/lodestar-utils/lib/logger";
+
+export const silentLogger: ILogger = new WinstonLogger({level: LogLevel.error});
+silentLogger.silent = true;

--- a/packages/lodestar/test/e2e/chain/factory/block/assembleBlock.test.ts
+++ b/packages/lodestar/test/e2e/chain/factory/block/assembleBlock.test.ts
@@ -16,7 +16,6 @@ import {
   fastStateTransition,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {generateValidator} from "../../../../utils/validator";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {generateDeposit} from "../../../../utils/deposit";
 import {BeaconChain} from "../../../../../src/chain";
 import {ArrayDagLMDGHOST} from "../../../../../src/chain/forkChoice";
@@ -25,6 +24,7 @@ import BlockProposingService from "@chainsafe/lodestar-validator/lib/services/bl
 import {ApiClientOverInstance} from "@chainsafe/lodestar-validator/lib";
 import {ValidatorApi} from "../../../../../src/api/impl/validator";
 import {StubbedBeaconDb} from "../../../../utils/stub";
+import {silentLogger} from "../../../../utils/logger";
 
 describe("produce block", function () {
   this.timeout("10 min");
@@ -86,7 +86,7 @@ describe("produce block", function () {
       [keypair],
       rpcClientStub,
       (validatorDbStub as unknown) as IValidatorDB,
-      sinon.createStubInstance(WinstonLogger)
+      silentLogger
     );
   }
 });

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlock.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlock.test.ts
@@ -1,6 +1,5 @@
 import {RestApi} from "../../../../../../src/api/rest";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {ValidatorApi} from "../../../../../../src/api/impl/validator";
 import sinon from "sinon";
 import {ApiNamespace} from "../../../../../../src/api";
@@ -10,6 +9,7 @@ import {expect} from "chai";
 import {getBlock} from "../../../../../../src/api/rest/controllers/beacon/blocks";
 import {generateEmptySignedBlock} from "../../../../../utils/block";
 import {StubbedNodeApi} from "../../../../../utils/stub/nodeApi";
+import {silentLogger} from "../../../../../utils/logger";
 
 describe("rest - beacon - getBlock", function () {
   let api: RestApi;
@@ -27,7 +27,7 @@ describe("rest - beacon - getBlock", function () {
       },
       {
         config,
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger: silentLogger,
         validator: sinon.createStubInstance(ValidatorApi),
         node: new StubbedNodeApi(),
         beacon: beaconApiStub,

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockAttestations.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockAttestations.test.ts
@@ -2,7 +2,6 @@ import {RestApi} from "../../../../../../src/api/rest";
 import {List} from "@chainsafe/ssz";
 import {Attestation} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {ValidatorApi} from "../../../../../../src/api/impl/validator";
 import sinon from "sinon";
 import {ApiNamespace} from "../../../../../../src/api";
@@ -13,6 +12,7 @@ import {getBlockAttestations} from "../../../../../../src/api/rest/controllers/b
 import {generateSignedBlock} from "../../../../../utils/block";
 import {generateEmptyAttestation} from "../../../../../utils/attestation";
 import {StubbedNodeApi} from "../../../../../utils/stub/nodeApi";
+import {silentLogger} from "../../../../../utils/logger";
 
 describe("rest - beacon - getBlockAttestations", function () {
   let api: RestApi;
@@ -30,7 +30,7 @@ describe("rest - beacon - getBlockAttestations", function () {
       },
       {
         config,
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger: silentLogger,
         validator: sinon.createStubInstance(ValidatorApi),
         node: new StubbedNodeApi(),
         beacon: beaconApiStub,

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockHeader.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockHeader.test.ts
@@ -1,6 +1,5 @@
 import {RestApi} from "../../../../../../src/api/rest";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {ValidatorApi} from "../../../../../../src/api/impl/validator";
 import sinon from "sinon";
 import {ApiNamespace} from "../../../../../../src/api";
@@ -10,6 +9,7 @@ import {expect} from "chai";
 import {generateSignedBeaconHeaderResponse} from "../../../../../utils/api";
 import {getBlockHeader} from "../../../../../../src/api/rest/controllers/beacon/blocks";
 import {StubbedNodeApi} from "../../../../../utils/stub/nodeApi";
+import {silentLogger} from "../../../../../utils/logger";
 
 describe("rest - beacon - getBlockHeader", function () {
   let api: RestApi;
@@ -27,7 +27,7 @@ describe("rest - beacon - getBlockHeader", function () {
       },
       {
         config,
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger: silentLogger,
         validator: sinon.createStubInstance(ValidatorApi),
         node: new StubbedNodeApi(),
         beacon: beaconApiStub,

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockHeaders.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockHeaders.test.ts
@@ -1,6 +1,5 @@
 import {RestApi} from "../../../../../../src/api/rest";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {ValidatorApi} from "../../../../../../src/api/impl/validator";
 import sinon from "sinon";
 import {ApiNamespace} from "../../../../../../src/api";
@@ -11,6 +10,7 @@ import {generateSignedBeaconHeaderResponse} from "../../../../../utils/api";
 import {toHexString} from "@chainsafe/ssz";
 import {getBlockHeaders} from "../../../../../../src/api/rest/controllers/beacon/blocks";
 import {StubbedNodeApi} from "../../../../../utils/stub/nodeApi";
+import {silentLogger} from "../../../../../utils/logger";
 
 describe("rest - beacon - getBlockHeaders", function () {
   let api: RestApi;
@@ -28,7 +28,7 @@ describe("rest - beacon - getBlockHeaders", function () {
       },
       {
         config,
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger: silentLogger,
         validator: sinon.createStubInstance(ValidatorApi),
         node: new StubbedNodeApi(),
         beacon: beaconApiStub,

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockRoot.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockRoot.test.ts
@@ -1,6 +1,5 @@
 import {RestApi} from "../../../../../../src/api/rest";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {ValidatorApi} from "../../../../../../src/api/impl/validator";
 import sinon from "sinon";
 import {ApiNamespace} from "../../../../../../src/api";
@@ -11,6 +10,7 @@ import {getBlockRoot} from "../../../../../../src/api/rest/controllers/beacon/bl
 import {generateEmptySignedBlock} from "../../../../../utils/block";
 import {toHexString} from "@chainsafe/ssz";
 import {StubbedNodeApi} from "../../../../../utils/stub/nodeApi";
+import {silentLogger} from "../../../../../utils/logger";
 
 describe("rest - beacon - getBlockRoot", function () {
   let api: RestApi;
@@ -28,7 +28,7 @@ describe("rest - beacon - getBlockRoot", function () {
       },
       {
         config,
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger: silentLogger,
         validator: sinon.createStubInstance(ValidatorApi),
         node: new StubbedNodeApi(),
         beacon: beaconApiStub,

--- a/packages/lodestar/test/unit/api/rest/beacon/getGenesis.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/getGenesis.test.ts
@@ -1,11 +1,11 @@
 import {RestApi} from "../../../../../src/api/rest";
 import {ApiNamespace} from "../../../../../src/api";
 import sinon, {SinonStubbedInstance} from "sinon";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 import {BeaconApi} from "../../../../../src/api/impl/beacon";
 import {ValidatorApi} from "../../../../../src/api/impl/validator";
 import {StubbedNodeApi} from "../../../../utils/stub/nodeApi";
+import {silentLogger} from "../../../../utils/logger";
 import supertest from "supertest";
 import {expect} from "chai";
 import {getGenesis} from "../../../../../lib/api/rest/controllers/beacon";
@@ -27,7 +27,7 @@ describe("rest - beacon - getGenesis", function () {
         port: 0,
       },
       {
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger: silentLogger,
         beacon: beaconApiStub,
         validator: validatorApiStub,
         node: new StubbedNodeApi(),

--- a/packages/lodestar/test/unit/api/rest/beacon/index.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/index.test.ts
@@ -1,7 +1,6 @@
 import {RestApi} from "../../../../../src/api/rest";
 import {ApiNamespace} from "../../../../../src/api";
 import sinon, {SinonStubbedInstance} from "sinon";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 import supertest from "supertest";
 import {expect} from "chai";
@@ -13,6 +12,7 @@ import {generateEmptySignedBlock} from "../../../../utils/block";
 import EventSource from "eventsource";
 import {LodestarEventIterator} from "../../../../../src/util/events";
 import {StubbedNodeApi} from "../../../../utils/stub/nodeApi";
+import {silentLogger} from "../../../../utils/logger";
 
 describe("Test beacon rest api", function () {
   this.timeout(10000);
@@ -31,7 +31,7 @@ describe("Test beacon rest api", function () {
         port: 0,
       },
       {
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger: silentLogger,
         beacon: beaconApi,
         validator: validatorApi,
         node: new StubbedNodeApi(),

--- a/packages/lodestar/test/unit/api/rest/beacon/pool/getPoolAttestations.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/pool/getPoolAttestations.test.ts
@@ -1,6 +1,5 @@
 import {RestApi} from "../../../../../../src/api/rest";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {ValidatorApi} from "../../../../../../src/api/impl/validator";
 import sinon from "sinon";
 import {ApiNamespace} from "../../../../../../src/api";
@@ -12,6 +11,7 @@ import {generateEmptySignedBlock} from "../../../../../utils/block";
 import {StubbedNodeApi} from "../../../../../utils/stub/nodeApi";
 import {generateAttestation} from "../../../../../utils/attestation";
 import {getPoolAttestations} from "../../../../../../src/api/rest/controllers/beacon/pool";
+import {silentLogger} from "../../../../../utils/logger";
 
 describe("rest - beacon - getPoolAttestations", function () {
   let api: RestApi;
@@ -29,7 +29,7 @@ describe("rest - beacon - getPoolAttestations", function () {
       },
       {
         config,
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger: silentLogger,
         validator: sinon.createStubInstance(ValidatorApi),
         node: new StubbedNodeApi(),
         beacon: beaconApiStub,

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getStateFinalityCheckpoints.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getStateFinalityCheckpoints.test.ts
@@ -1,6 +1,5 @@
 import {RestApi} from "../../../../../../src/api/rest";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {ValidatorApi} from "../../../../../../src/api/impl/validator";
 import sinon from "sinon";
 import {ApiNamespace} from "../../../../../../src/api";
@@ -11,6 +10,7 @@ import {getBlock} from "../../../../../../src/api/rest/controllers/beacon/blocks
 import {StubbedNodeApi} from "../../../../../utils/stub/nodeApi";
 import {generateState} from "../../../../../utils/state";
 import {getStateFinalityCheckpoints} from "../../../../../../src/api/rest/controllers/beacon/state";
+import {silentLogger} from "../../../../../utils/logger";
 
 describe("rest - beacon - getStateFinalityCheckpoints", function () {
   let api: RestApi;
@@ -28,7 +28,7 @@ describe("rest - beacon - getStateFinalityCheckpoints", function () {
       },
       {
         config,
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger: silentLogger,
         validator: sinon.createStubInstance(ValidatorApi),
         node: new StubbedNodeApi(),
         beacon: beaconApiStub,

--- a/packages/lodestar/test/unit/api/rest/node/getHealth.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getHealth.test.ts
@@ -1,5 +1,4 @@
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import sinon from "sinon";
 import supertest from "supertest";
 import {StubbedNodeApi} from "../../../../utils/stub/nodeApi";
@@ -8,6 +7,7 @@ import {ApiNamespace} from "../../../../../src/api";
 import {RestApi} from "../../../../../src/api/rest";
 import {ValidatorApi} from "../../../../../src/api/impl/validator";
 import {getHealth} from "../../../../../src/api/rest/controllers/node";
+import {silentLogger} from "../../../../utils/logger";
 
 describe("rest - node - getHealth", function () {
   let api: RestApi;
@@ -25,7 +25,7 @@ describe("rest - node - getHealth", function () {
       },
       {
         config,
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger: silentLogger,
         validator: sinon.createStubInstance(ValidatorApi),
         beacon: sinon.createStubInstance(BeaconApi),
         node: nodeApiStub,

--- a/packages/lodestar/test/unit/api/rest/node/getNetworkIdentity.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getNetworkIdentity.test.ts
@@ -1,5 +1,4 @@
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import sinon from "sinon";
 import supertest from "supertest";
 import {expect} from "chai";
@@ -9,6 +8,7 @@ import {getNetworkIdentity} from "../../../../../src/api/rest/controllers/node/g
 import {ApiNamespace} from "../../../../../src/api";
 import {RestApi} from "../../../../../src/api/rest";
 import {ValidatorApi} from "../../../../../src/api/impl/validator";
+import {silentLogger} from "../../../../utils/logger";
 
 describe("rest - node - getNetworkIdentity", function () {
   let api: RestApi;
@@ -26,7 +26,7 @@ describe("rest - node - getNetworkIdentity", function () {
       },
       {
         config,
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger: silentLogger,
         validator: sinon.createStubInstance(ValidatorApi),
         beacon: sinon.createStubInstance(BeaconApi),
         node: nodeApiStub,

--- a/packages/lodestar/test/unit/api/rest/node/getPeer.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getPeer.test.ts
@@ -1,5 +1,4 @@
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import sinon from "sinon";
 import supertest from "supertest";
 import {expect} from "chai";
@@ -9,6 +8,7 @@ import {ApiNamespace} from "../../../../../src/api";
 import {RestApi} from "../../../../../src/api/rest";
 import {ValidatorApi} from "../../../../../src/api/impl/validator";
 import {getPeer} from "../../../../../src/api/rest/controllers/node";
+import {silentLogger} from "../../../../utils/logger";
 
 describe("rest - node - getPeer", function () {
   let api: RestApi;
@@ -26,7 +26,7 @@ describe("rest - node - getPeer", function () {
       },
       {
         config,
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger: silentLogger,
         validator: sinon.createStubInstance(ValidatorApi),
         beacon: sinon.createStubInstance(BeaconApi),
         node: nodeApiStub,

--- a/packages/lodestar/test/unit/api/rest/node/getPeers.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getPeers.test.ts
@@ -1,5 +1,4 @@
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import sinon from "sinon";
 import supertest from "supertest";
 import {expect} from "chai";
@@ -9,6 +8,7 @@ import {ApiNamespace} from "../../../../../src/api";
 import {RestApi} from "../../../../../src/api/rest";
 import {ValidatorApi} from "../../../../../src/api/impl/validator";
 import {getPeers} from "../../../../../src/api/rest/controllers/node";
+import {silentLogger} from "../../../../utils/logger";
 
 describe("rest - node - getPeers", function () {
   let api: RestApi;
@@ -26,7 +26,7 @@ describe("rest - node - getPeers", function () {
       },
       {
         config,
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger: silentLogger,
         validator: sinon.createStubInstance(ValidatorApi),
         beacon: sinon.createStubInstance(BeaconApi),
         node: nodeApiStub,

--- a/packages/lodestar/test/unit/api/rest/node/getSyncingStatus.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getSyncingStatus.test.ts
@@ -1,5 +1,4 @@
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import sinon from "sinon";
 import supertest from "supertest";
 import {expect} from "chai";
@@ -9,6 +8,7 @@ import {ApiNamespace} from "../../../../../src/api";
 import {RestApi} from "../../../../../src/api/rest";
 import {ValidatorApi} from "../../../../../src/api/impl/validator";
 import {getSyncingStatus} from "../../../../../src/api/rest/controllers/node";
+import {silentLogger} from "../../../../utils/logger";
 
 describe("rest - node - getSyncingStatus", function () {
   let api: RestApi;
@@ -26,7 +26,7 @@ describe("rest - node - getSyncingStatus", function () {
       },
       {
         config,
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger: silentLogger,
         validator: sinon.createStubInstance(ValidatorApi),
         beacon: sinon.createStubInstance(BeaconApi),
         node: nodeApiStub,

--- a/packages/lodestar/test/unit/api/rest/node/getVersion.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getVersion.test.ts
@@ -1,5 +1,4 @@
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import sinon from "sinon";
 import supertest from "supertest";
 import {expect} from "chai";
@@ -9,6 +8,7 @@ import {ApiNamespace} from "../../../../../src/api";
 import {RestApi} from "../../../../../src/api/rest";
 import {ValidatorApi} from "../../../../../src/api/impl/validator";
 import {getVersion} from "../../../../../src/api/rest/controllers/node";
+import {silentLogger} from "../../../../utils/logger";
 
 describe("rest - node - getVersion", function () {
   let api: RestApi;
@@ -26,7 +26,7 @@ describe("rest - node - getVersion", function () {
       },
       {
         config,
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger: silentLogger,
         validator: sinon.createStubInstance(ValidatorApi),
         beacon: sinon.createStubInstance(BeaconApi),
         node: nodeApiStub,

--- a/packages/lodestar/test/unit/chain/attestation/pool.test.ts
+++ b/packages/lodestar/test/unit/chain/attestation/pool.test.ts
@@ -1,7 +1,6 @@
 import {SinonStub, SinonStubbedInstance} from "sinon";
 import {ArrayDagLMDGHOST, BeaconChain, IBeaconChain, ILMDGHOST} from "../../../../src/chain";
 import {StubbedBeaconDb} from "../../../utils/stub";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {AttestationProcessor} from "../../../../src/chain/attestation";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import sinon from "sinon";
@@ -14,13 +13,14 @@ import {generateBlockSummary, generateSignedBlock} from "../../../utils/block";
 import {FAR_FUTURE_EPOCH} from "../../../../src/constants";
 import {LocalClock} from "../../../../src/chain/clock/local/LocalClock";
 import {Slot, Attestation} from "@chainsafe/lodestar-types";
+import {silentLogger} from "../../../utils/logger";
 
 describe("attestation pool", function () {
   let chain: SinonStubbedInstance<IBeaconChain>;
   let db: StubbedBeaconDb;
   let forkChoice: SinonStubbedInstance<ILMDGHOST>;
   let processAttestationStub: SinonStub;
-  const logger = sinon.createStubInstance(WinstonLogger);
+  const logger = silentLogger;
 
   beforeEach(function () {
     chain = sinon.createStubInstance(BeaconChain);

--- a/packages/lodestar/test/unit/chain/attestation/processor.test.ts
+++ b/packages/lodestar/test/unit/chain/attestation/processor.test.ts
@@ -1,6 +1,5 @@
 import {SinonStub, SinonStubbedInstance} from "sinon";
 import {ArrayDagLMDGHOST, BeaconChain, IBeaconChain, ILMDGHOST} from "../../../../src/chain";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {StubbedBeaconDb} from "../../../utils/stub";
 import sinon from "sinon";
 import {generateAttestation} from "../../../utils/attestation";
@@ -13,6 +12,7 @@ import {generateState} from "../../../utils/state";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {IndexedAttestation} from "@chainsafe/lodestar-types";
 import {List} from "@chainsafe/ssz";
+import {silentLogger} from "../../../utils/logger";
 
 describe("chain attestation processor", function () {
   let chain: SinonStubbedInstance<IBeaconChain>;
@@ -21,7 +21,7 @@ describe("chain attestation processor", function () {
   let attestationPrestateStub: SinonStub;
   let isValidIndexedAttestationStub: SinonStub;
 
-  const logger = sinon.createStubInstance(WinstonLogger);
+  const logger = silentLogger;
 
   beforeEach(function () {
     chain = sinon.createStubInstance(BeaconChain);

--- a/packages/lodestar/test/unit/chain/blocks/post.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/post.test.ts
@@ -4,7 +4,6 @@ import {Attestation} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import sinon, {SinonStubbedInstance} from "sinon";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {expect} from "chai";
 import {BeaconChain, ChainEventEmitter, ArrayDagLMDGHOST} from "../../../../src/chain";
 import {generateState} from "../../../utils/state";
@@ -14,8 +13,10 @@ import {Gauge} from "prom-client";
 import {AttestationProcessor} from "../../../../src/chain/attestation";
 import {generateEmptyAttestation} from "../../../utils/attestation";
 import {StubbedBeaconDb} from "../../../utils/stub";
+import {silentLogger} from "../../../utils/logger";
 
 describe("post block process stream", function () {
+  const logger = silentLogger;
   let epochCtxStub: SinonStubbedInstance<EpochContext>;
   let forkChoiceStub: SinonStubbedInstance<ArrayDagLMDGHOST>;
   let dbStub: StubbedBeaconDb;
@@ -63,15 +64,7 @@ describe("post block process stream", function () {
     };
     await pipe(
       [item],
-      postProcess(
-        config,
-        sinon.createStubInstance(WinstonLogger),
-        dbStub,
-        forkChoiceStub,
-        metricsStub,
-        eventBusStub,
-        attestationProcessorStub
-      )
+      postProcess(config, logger, dbStub, forkChoiceStub, metricsStub, eventBusStub, attestationProcessorStub)
     );
     expect(slotMetricsStub.set.withArgs(0).calledOnce).to.be.true;
   });
@@ -91,15 +84,7 @@ describe("post block process stream", function () {
     };
     await pipe(
       [item],
-      postProcess(
-        config,
-        sinon.createStubInstance(WinstonLogger),
-        dbStub,
-        forkChoiceStub,
-        metricsStub,
-        eventBusStub,
-        attestationProcessorStub
-      )
+      postProcess(config, logger, dbStub, forkChoiceStub, metricsStub, eventBusStub, attestationProcessorStub)
     );
     expect(slotMetricsStub.set.withArgs(0).calledOnce).to.be.true;
     // @ts-ignore
@@ -129,15 +114,7 @@ describe("post block process stream", function () {
     dbStub.block.get.resolves(block);
     await pipe(
       [item],
-      postProcess(
-        config,
-        sinon.createStubInstance(WinstonLogger),
-        dbStub,
-        forkChoiceStub,
-        metricsStub,
-        eventBusStub,
-        attestationProcessorStub
-      )
+      postProcess(config, logger, dbStub, forkChoiceStub, metricsStub, eventBusStub, attestationProcessorStub)
     );
     expect(slotMetricsStub.set.withArgs(0).calledOnce).to.be.true;
     // @ts-ignore

--- a/packages/lodestar/test/unit/chain/blocks/process.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/process.test.ts
@@ -1,7 +1,6 @@
 import pipe from "it-pipe";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {ILMDGHOST, ArrayDagLMDGHOST} from "../../../../src/chain/forkChoice";
 import {collect} from "./utils";
 import {expect} from "chai";
@@ -12,8 +11,10 @@ import * as stateTransitionUtils from "@chainsafe/lodestar-beacon-state-transiti
 import {generateState} from "../../../utils/state";
 import {StubbedBeaconDb} from "../../../utils/stub";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
+import {silentLogger} from "../../../utils/logger";
 
 describe("block process stream", function () {
+  const logger = silentLogger;
   let dbStub: StubbedBeaconDb;
   let forkChoiceStub: SinonStubbedInstance<ILMDGHOST>;
   let blockPoolStub: SinonStubbedInstance<BlockPool>;
@@ -43,14 +44,7 @@ describe("block process stream", function () {
     dbStub.block.get.withArgs(receivedJob.signedBlock.message.parentRoot.valueOf() as Uint8Array).resolves(null);
     const result = await pipe(
       [receivedJob],
-      processBlock(
-        config,
-        sinon.createStubInstance(WinstonLogger),
-        dbStub,
-        forkChoiceStub,
-        (blockPoolStub as unknown) as BlockPool,
-        chainStub
-      ),
+      processBlock(config, logger, dbStub, forkChoiceStub, (blockPoolStub as unknown) as BlockPool, chainStub),
       collect
     );
     expect(result).to.have.length(0);
@@ -68,14 +62,7 @@ describe("block process stream", function () {
     dbStub.stateCache.get.resolves(null);
     const result = await pipe(
       [receivedJob],
-      processBlock(
-        config,
-        sinon.createStubInstance(WinstonLogger),
-        dbStub,
-        forkChoiceStub,
-        (blockPoolStub as unknown) as BlockPool,
-        chainStub
-      ),
+      processBlock(config, logger, dbStub, forkChoiceStub, (blockPoolStub as unknown) as BlockPool, chainStub),
       collect
     );
     expect(result).to.have.length(0);
@@ -95,14 +82,7 @@ describe("block process stream", function () {
     stateTransitionStub.throws();
     const result = await pipe(
       [receivedJob],
-      processBlock(
-        config,
-        sinon.createStubInstance(WinstonLogger),
-        dbStub,
-        forkChoiceStub,
-        (blockPoolStub as unknown) as BlockPool,
-        chainStub
-      ),
+      processBlock(config, logger, dbStub, forkChoiceStub, (blockPoolStub as unknown) as BlockPool, chainStub),
       collect
     );
     expect(result).to.have.length(0);
@@ -125,14 +105,7 @@ describe("block process stream", function () {
     forkChoiceStub.headBlockRoot.returns(Buffer.alloc(32, 1));
     const result = await pipe(
       [receivedJob],
-      processBlock(
-        config,
-        sinon.createStubInstance(WinstonLogger),
-        dbStub,
-        forkChoiceStub,
-        (blockPoolStub as unknown) as BlockPool,
-        chainStub
-      ),
+      processBlock(config, logger, dbStub, forkChoiceStub, (blockPoolStub as unknown) as BlockPool, chainStub),
       collect
     );
     expect(result).to.have.length(1);
@@ -160,14 +133,7 @@ describe("block process stream", function () {
     dbStub.block.get.resolves(receivedJob.signedBlock);
     const result = await pipe(
       [receivedJob],
-      processBlock(
-        config,
-        sinon.createStubInstance(WinstonLogger),
-        dbStub,
-        forkChoiceStub,
-        (blockPoolStub as unknown) as BlockPool,
-        chainStub
-      ),
+      processBlock(config, logger, dbStub, forkChoiceStub, (blockPoolStub as unknown) as BlockPool, chainStub),
       collect
     );
     expect(result).to.have.length(1);

--- a/packages/lodestar/test/unit/chain/blocks/validate.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/validate.test.ts
@@ -4,18 +4,18 @@ import {SinonStubbedInstance} from "sinon";
 import {BlockRepository} from "../../../../src/db/api/beacon/repositories";
 import sinon from "sinon";
 import {validateBlock} from "../../../../src/chain/blocks/validate";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {ILMDGHOST, ArrayDagLMDGHOST} from "../../../../src/chain/forkChoice";
 import {collect} from "./utils";
 import {expect} from "chai";
 import {getBlockSummary} from "../../../utils/headBlockInfo";
 import {BeaconChain, IBeaconChain} from "../../../../src/chain";
+import {silentLogger} from "../../../utils/logger";
 
 describe("block validate stream", function () {
+  const logger = silentLogger;
   let blockDbStub: SinonStubbedInstance<BlockRepository>;
   let forkChoiceStub: SinonStubbedInstance<ILMDGHOST>;
   let chainStub: SinonStubbedInstance<IBeaconChain>;
-
 
   beforeEach(function () {
     blockDbStub = sinon.createStubInstance(BlockRepository);
@@ -28,7 +28,7 @@ describe("block validate stream", function () {
     forkChoiceStub.hasBlock.withArgs(config.types.BeaconBlock.hashTreeRoot(receivedBlock.message)).returns(true);
     const result = await pipe(
       [{signedBlock: receivedBlock, trusted: false}],
-      validateBlock(config, sinon.createStubInstance(WinstonLogger), forkChoiceStub, chainStub),
+      validateBlock(config, logger, forkChoiceStub, chainStub),
       collect
     );
     expect(result).to.have.length(0);
@@ -41,7 +41,7 @@ describe("block validate stream", function () {
     forkChoiceStub.getFinalized.returns({epoch: 1, root: Buffer.alloc(0)});
     const result = await pipe(
       [{signedBlock: receivedBlock, trusted: false}],
-      validateBlock(config, sinon.createStubInstance(WinstonLogger), forkChoiceStub, chainStub),
+      validateBlock(config, logger, forkChoiceStub, chainStub),
       collect
     );
     expect(result).to.have.length(0);
@@ -56,7 +56,7 @@ describe("block validate stream", function () {
     blockDbStub.get.resolves(config.types.SignedBeaconBlock.defaultValue());
     const result = await pipe(
       [{signedBlock: receivedBlock, trusted: false}],
-      validateBlock(config, sinon.createStubInstance(WinstonLogger), forkChoiceStub, chainStub),
+      validateBlock(config, logger, forkChoiceStub, chainStub),
       collect
     );
     expect(result).to.have.length(1);

--- a/packages/lodestar/test/unit/chain/genesis/genesis.test.ts
+++ b/packages/lodestar/test/unit/chain/genesis/genesis.test.ts
@@ -9,9 +9,9 @@ import {computeDomain, computeSigningRoot, DomainType} from "@chainsafe/lodestar
 import {DepositData, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {GenesisBuilder} from "../../../../src/chain/genesis/genesis";
 import {StubbedBeaconDb} from "../../../utils/stub";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {expect} from "chai";
 import {toHexString} from "@chainsafe/ssz";
+import {silentLogger} from "../../../utils/logger";
 
 describe("genesis builder", function () {
   const schlesiConfig = Object.assign({}, {params: config.params}, config);
@@ -23,7 +23,7 @@ describe("genesis builder", function () {
   const sandbox = sinon.createSandbox();
   let genesisBuilder: GenesisBuilder;
   let eth1Stub: SinonStubbedInstance<EthersEth1Notifier>;
-  let dbStub: StubbedBeaconDb, loggerStub: any;
+  let dbStub: StubbedBeaconDb;
   const events: IDepositEvent[] = [];
   const keypairs: Keypair[] = [];
 
@@ -44,11 +44,10 @@ describe("genesis builder", function () {
 
     eth1Stub = sandbox.createStubInstance(EthersEth1Notifier);
     dbStub = new StubbedBeaconDb(sandbox);
-    loggerStub = sandbox.createStubInstance(WinstonLogger);
     genesisBuilder = new GenesisBuilder(schlesiConfig, {
       eth1: eth1Stub,
       db: dbStub,
-      logger: loggerStub,
+      logger: silentLogger,
     });
   });
 

--- a/packages/lodestar/test/unit/db/api/repositories/blockArchive.test.ts
+++ b/packages/lodestar/test/unit/db/api/repositories/blockArchive.test.ts
@@ -1,23 +1,22 @@
 import {expect} from "chai";
 import rimraf from "rimraf";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {intToBytes, WinstonLogger} from "@chainsafe/lodestar-utils";
+import {intToBytes} from "@chainsafe/lodestar-utils";
 
 import {LevelDbController} from "../../../../../src/db/controller";
 import {generateEmptySignedBlock} from "../../../../utils/block";
 import {BlockArchiveRepository} from "../../../../../src/db/api/beacon/repositories";
 import sinon from "sinon";
 import {Bucket, encodeKey} from "../../../../../src/db/api/schema";
+import {silentLogger} from "../../../../utils/logger";
 
 describe("block archive repository", function () {
-  const logger = new WinstonLogger();
-  logger.silent = true;
   const testDir = "./.tmp";
   let blockArchive: BlockArchiveRepository;
   let controller: LevelDbController;
 
   beforeEach(async function () {
-    controller = new LevelDbController({name: testDir}, {logger});
+    controller = new LevelDbController({name: testDir}, {logger: silentLogger});
     blockArchive = new BlockArchiveRepository(config, controller);
     await controller.start();
   });

--- a/packages/lodestar/test/unit/db/controller/level.test.ts
+++ b/packages/lodestar/test/unit/db/controller/level.test.ts
@@ -5,22 +5,19 @@ import level from "level";
 import leveldown from "leveldown";
 import {LevelDbController} from "../../../../src/db/controller";
 import {promisify} from "es6-promisify";
-import {ILogger, WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
+import {silentLogger} from "../../../utils/logger";
 
 describe("LevelDB controller", () => {
-  const logger: ILogger = new WinstonLogger();
   const dbLocation = "./.__testdb";
-  const db = new LevelDbController({name: dbLocation}, {logger});
+  const db = new LevelDbController({name: dbLocation}, {logger: silentLogger});
 
   before(async () => {
-    logger.silent = true;
     await db.start();
   });
 
   after(async () => {
     await db.stop();
     await promisify<void, string>(leveldown.destroy)(dbLocation);
-    logger.silent = false;
   });
 
   it("test put/get/delete", async () => {

--- a/packages/lodestar/test/unit/network/encoders/request.test.ts
+++ b/packages/lodestar/test/unit/network/encoders/request.test.ts
@@ -9,8 +9,10 @@ import {expect} from "chai";
 import {createStatus} from "./utils";
 import {encode} from "varint";
 import {Status} from "@chainsafe/lodestar-types";
+import {silentLogger} from "../../../utils/logger";
 
 describe("request encoders", function () {
+  const logger = silentLogger;
   let loggerStub: SinonStubbedInstance<ILogger>;
 
   beforeEach(function () {
@@ -20,8 +22,8 @@ describe("request encoders", function () {
   it("should work - basic request - ssz", async function () {
     const requests = await pipe(
       [BigInt(0)],
-      eth2RequestEncode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ),
-      eth2RequestDecode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ),
+      eth2RequestEncode(config, logger, Method.Ping, ReqRespEncoding.SSZ),
+      eth2RequestDecode(config, logger, Method.Ping, ReqRespEncoding.SSZ),
       collect
     );
     expect(requests.length).to.be.equal(1);
@@ -31,8 +33,8 @@ describe("request encoders", function () {
   it("should work - basic request - ssz_snappy", async function () {
     const requests = await pipe(
       [BigInt(0)],
-      eth2RequestEncode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ_SNAPPY),
-      eth2RequestDecode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ_SNAPPY),
+      eth2RequestEncode(config, logger, Method.Ping, ReqRespEncoding.SSZ_SNAPPY),
+      eth2RequestDecode(config, logger, Method.Ping, ReqRespEncoding.SSZ_SNAPPY),
       collect
     );
     expect(requests.length).to.be.equal(1);
@@ -43,8 +45,8 @@ describe("request encoders", function () {
     const status = createStatus();
     const requests = await pipe(
       [status],
-      eth2RequestEncode(config, loggerStub, Method.Status, ReqRespEncoding.SSZ),
-      eth2RequestDecode(config, loggerStub, Method.Status, ReqRespEncoding.SSZ),
+      eth2RequestEncode(config, logger, Method.Status, ReqRespEncoding.SSZ),
+      eth2RequestDecode(config, logger, Method.Status, ReqRespEncoding.SSZ),
       collect
     );
     expect(requests.length).to.be.equal(1);
@@ -55,8 +57,8 @@ describe("request encoders", function () {
     const status = createStatus();
     const requests = await pipe(
       [status],
-      eth2RequestEncode(config, loggerStub, Method.Status, ReqRespEncoding.SSZ_SNAPPY),
-      eth2RequestDecode(config, loggerStub, Method.Status, ReqRespEncoding.SSZ_SNAPPY),
+      eth2RequestEncode(config, logger, Method.Status, ReqRespEncoding.SSZ_SNAPPY),
+      eth2RequestDecode(config, logger, Method.Status, ReqRespEncoding.SSZ_SNAPPY),
       collect
     );
     expect(requests.length).to.be.equal(1);
@@ -66,8 +68,8 @@ describe("request encoders", function () {
   it("should work - multiple request - ssz", async function () {
     const requests = await pipe(
       [BigInt(1), BigInt(2)],
-      eth2RequestEncode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ),
-      eth2RequestDecode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ),
+      eth2RequestEncode(config, logger, Method.Ping, ReqRespEncoding.SSZ),
+      eth2RequestDecode(config, logger, Method.Ping, ReqRespEncoding.SSZ),
       collect
     );
     expect(requests.length).to.be.equal(1);
@@ -77,8 +79,8 @@ describe("request encoders", function () {
   it("should work - multiple request - ssz_snappy", async function () {
     const requests = await pipe(
       [BigInt(1), BigInt(2)],
-      eth2RequestEncode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ_SNAPPY),
-      eth2RequestDecode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ_SNAPPY),
+      eth2RequestEncode(config, logger, Method.Ping, ReqRespEncoding.SSZ_SNAPPY),
+      eth2RequestDecode(config, logger, Method.Ping, ReqRespEncoding.SSZ_SNAPPY),
       collect
     );
     expect(requests.length).to.be.equal(1);
@@ -86,18 +88,14 @@ describe("request encoders", function () {
   });
 
   it("should work - no request body - ssz", async function () {
-    const requests = await pipe(
-      [],
-      eth2RequestDecode(config, loggerStub, Method.Metadata, ReqRespEncoding.SSZ),
-      collect
-    );
+    const requests = await pipe([], eth2RequestDecode(config, logger, Method.Metadata, ReqRespEncoding.SSZ), collect);
     expect(requests.length).to.be.equal(1);
   });
 
   it("should work - no request body - ssz_snappy", async function () {
     const requests = await pipe(
       [],
-      eth2RequestDecode(config, loggerStub, Method.Metadata, ReqRespEncoding.SSZ_SNAPPY),
+      eth2RequestDecode(config, logger, Method.Metadata, ReqRespEncoding.SSZ_SNAPPY),
       collect
     );
     expect(requests.length).to.be.equal(1);
@@ -163,7 +161,7 @@ describe("request encoders", function () {
       status.finalizedEpoch = 100;
       const validatedRequestBody: unknown[] = await pipe(
         [Buffer.from(encode(config.types.Status.minSize())), config.types.Status.serialize(status)],
-        eth2RequestDecode(config, loggerStub, Method.Status, ReqRespEncoding.SSZ),
+        eth2RequestDecode(config, logger, Method.Status, ReqRespEncoding.SSZ),
         collect
       );
       expect(validatedRequestBody).to.be.deep.equal([{isValid: true, body: status}]);

--- a/packages/lodestar/test/unit/network/encoders/response.test.ts
+++ b/packages/lodestar/test/unit/network/encoders/response.test.ts
@@ -8,8 +8,6 @@ import {
   decodeP2pErrorMessage,
 } from "../../../../src/network/encoders/response";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import sinon, {SinonStubbedInstance} from "sinon";
-import {ILogger, WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {Method, ReqRespEncoding, RpcResponseStatus} from "../../../../src/constants";
 import {collect} from "../../chain/blocks/utils";
 import {expect} from "chai";
@@ -20,20 +18,17 @@ import {ResponseBody, SignedBeaconBlock, Status} from "@chainsafe/lodestar-types
 import {encode} from "varint";
 import {fail} from "assert";
 import {randomRequestId} from "../../../../src/network";
+import {silentLogger} from "../../../utils/logger";
 
 const fakeController = {abort: () => {}} as AbortController;
 describe("response decoders", function () {
-  let loggerStub: SinonStubbedInstance<ILogger>;
-
-  beforeEach(function () {
-    loggerStub = sinon.createStubInstance(WinstonLogger);
-  });
+  const logger = silentLogger;
 
   it("should work - no response - ssz", async function () {
     const responses = await pipe(
       [],
-      eth2ResponseEncode(config, loggerStub, Method.Goodbye, ReqRespEncoding.SSZ),
-      eth2ResponseDecode(config, loggerStub, Method.Goodbye, ReqRespEncoding.SSZ, "abc", fakeController),
+      eth2ResponseEncode(config, logger, Method.Goodbye, ReqRespEncoding.SSZ),
+      eth2ResponseDecode(config, logger, Method.Goodbye, ReqRespEncoding.SSZ, "abc", fakeController),
       collect
     );
     expect(responses.length).to.be.equal(0);
@@ -42,8 +37,8 @@ describe("response decoders", function () {
   it("should work - no response - ssz_snappy", async function () {
     const responses = await pipe(
       [],
-      eth2ResponseEncode(config, loggerStub, Method.Goodbye, ReqRespEncoding.SSZ_SNAPPY),
-      eth2ResponseDecode(config, loggerStub, Method.Goodbye, ReqRespEncoding.SSZ_SNAPPY, "abc", fakeController),
+      eth2ResponseEncode(config, logger, Method.Goodbye, ReqRespEncoding.SSZ_SNAPPY),
+      eth2ResponseDecode(config, logger, Method.Goodbye, ReqRespEncoding.SSZ_SNAPPY, "abc", fakeController),
       collect
     );
     expect(responses.length).to.be.equal(0);
@@ -52,8 +47,8 @@ describe("response decoders", function () {
   it("should work - single error - ssz", async function () {
     const responses = await pipe(
       [{status: 1}],
-      eth2ResponseEncode(config, loggerStub, Method.Goodbye, ReqRespEncoding.SSZ),
-      eth2ResponseDecode(config, loggerStub, Method.Goodbye, ReqRespEncoding.SSZ, "abc", fakeController),
+      eth2ResponseEncode(config, logger, Method.Goodbye, ReqRespEncoding.SSZ),
+      eth2ResponseDecode(config, logger, Method.Goodbye, ReqRespEncoding.SSZ, "abc", fakeController),
       collect
     );
     expect(responses.length).to.be.equal(0);
@@ -62,8 +57,8 @@ describe("response decoders", function () {
   it("should work - single error - ssz_snappy", async function () {
     const responses = await pipe(
       [{status: 1}],
-      eth2ResponseEncode(config, loggerStub, Method.Goodbye, ReqRespEncoding.SSZ_SNAPPY),
-      eth2ResponseDecode(config, loggerStub, Method.Goodbye, ReqRespEncoding.SSZ_SNAPPY, "abc", fakeController),
+      eth2ResponseEncode(config, logger, Method.Goodbye, ReqRespEncoding.SSZ_SNAPPY),
+      eth2ResponseDecode(config, logger, Method.Goodbye, ReqRespEncoding.SSZ_SNAPPY, "abc", fakeController),
       collect
     );
     expect(responses.length).to.be.equal(0);
@@ -72,8 +67,8 @@ describe("response decoders", function () {
   it("should work - single response simple- ssz", async function () {
     const responses = await pipe(
       [{status: 0, body: BigInt(1)}],
-      eth2ResponseEncode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ),
-      eth2ResponseDecode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ, "abc", fakeController),
+      eth2ResponseEncode(config, logger, Method.Ping, ReqRespEncoding.SSZ),
+      eth2ResponseDecode(config, logger, Method.Ping, ReqRespEncoding.SSZ, "abc", fakeController),
       collect
     );
     expect(responses.length).to.be.equal(1);
@@ -83,8 +78,8 @@ describe("response decoders", function () {
   it("should work - single response simple - ssz_snappy", async function () {
     const responses = await pipe(
       [{status: 0, body: BigInt(1)}],
-      eth2ResponseEncode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ_SNAPPY),
-      eth2ResponseDecode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ_SNAPPY, "abc", fakeController),
+      eth2ResponseEncode(config, logger, Method.Ping, ReqRespEncoding.SSZ_SNAPPY),
+      eth2ResponseDecode(config, logger, Method.Ping, ReqRespEncoding.SSZ_SNAPPY, "abc", fakeController),
       collect
     );
     expect(responses.length).to.be.equal(1);
@@ -102,8 +97,8 @@ describe("response decoders", function () {
         controller.signal,
         {returnOnAbort: true}
       ),
-      eth2ResponseEncode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ),
-      eth2ResponseDecode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ, "abc", controller),
+      eth2ResponseEncode(config, logger, Method.Ping, ReqRespEncoding.SSZ),
+      eth2ResponseDecode(config, logger, Method.Ping, ReqRespEncoding.SSZ, "abc", controller),
       collect
     );
     expect(responses.length).to.be.equal(1);
@@ -121,8 +116,8 @@ describe("response decoders", function () {
         controller.signal,
         {returnOnAbort: true}
       ),
-      eth2ResponseEncode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ_SNAPPY),
-      eth2ResponseDecode(config, loggerStub, Method.Ping, ReqRespEncoding.SSZ_SNAPPY, "abc", controller),
+      eth2ResponseEncode(config, logger, Method.Ping, ReqRespEncoding.SSZ_SNAPPY),
+      eth2ResponseDecode(config, logger, Method.Ping, ReqRespEncoding.SSZ_SNAPPY, "abc", controller),
       collect
     );
     expect(responses.length).to.be.equal(1);
@@ -133,8 +128,8 @@ describe("response decoders", function () {
     const status = createStatus();
     const responses = await pipe(
       [{status: 0, body: status}],
-      eth2ResponseEncode(config, loggerStub, Method.Status, ReqRespEncoding.SSZ),
-      eth2ResponseDecode(config, loggerStub, Method.Status, ReqRespEncoding.SSZ, "abc", fakeController),
+      eth2ResponseEncode(config, logger, Method.Status, ReqRespEncoding.SSZ),
+      eth2ResponseDecode(config, logger, Method.Status, ReqRespEncoding.SSZ, "abc", fakeController),
       collect
     );
     expect(responses.length).to.be.equal(1);
@@ -145,8 +140,8 @@ describe("response decoders", function () {
     const status = createStatus();
     const responses = await pipe(
       [{status: 0, body: status}],
-      eth2ResponseEncode(config, loggerStub, Method.Status, ReqRespEncoding.SSZ_SNAPPY),
-      eth2ResponseDecode(config, loggerStub, Method.Status, ReqRespEncoding.SSZ_SNAPPY, "abc", fakeController),
+      eth2ResponseEncode(config, logger, Method.Status, ReqRespEncoding.SSZ_SNAPPY),
+      eth2ResponseDecode(config, logger, Method.Status, ReqRespEncoding.SSZ_SNAPPY, "abc", fakeController),
       collect
     );
     expect(responses.length).to.be.equal(1);
@@ -157,8 +152,8 @@ describe("response decoders", function () {
     const chunks = generateBlockChunks(10);
     const responses = (await pipe(
       chunks,
-      eth2ResponseEncode(config, loggerStub, Method.BeaconBlocksByRange, ReqRespEncoding.SSZ),
-      eth2ResponseDecode(config, loggerStub, Method.BeaconBlocksByRange, ReqRespEncoding.SSZ, "abc", fakeController),
+      eth2ResponseEncode(config, logger, Method.BeaconBlocksByRange, ReqRespEncoding.SSZ),
+      eth2ResponseDecode(config, logger, Method.BeaconBlocksByRange, ReqRespEncoding.SSZ, "abc", fakeController),
       collect
     )) as ResponseBody[];
     expect(responses.length).to.be.equal(10);
@@ -172,15 +167,8 @@ describe("response decoders", function () {
     const chunks = generateBlockChunks(10);
     const responses = (await pipe(
       chunks,
-      eth2ResponseEncode(config, loggerStub, Method.BeaconBlocksByRange, ReqRespEncoding.SSZ_SNAPPY),
-      eth2ResponseDecode(
-        config,
-        loggerStub,
-        Method.BeaconBlocksByRange,
-        ReqRespEncoding.SSZ_SNAPPY,
-        "abc",
-        fakeController
-      ),
+      eth2ResponseEncode(config, logger, Method.BeaconBlocksByRange, ReqRespEncoding.SSZ_SNAPPY),
+      eth2ResponseDecode(config, logger, Method.BeaconBlocksByRange, ReqRespEncoding.SSZ_SNAPPY, "abc", fakeController),
       collect
     )) as ResponseBody[];
     expect(responses.length).to.be.equal(10);
@@ -197,8 +185,8 @@ describe("response decoders", function () {
     chunks[4].body = encodeP2pErrorMessage(config, "Invalid request");
     const responses = (await pipe(
       abortSource(chunks, controller.signal, {returnOnAbort: true}),
-      eth2ResponseEncode(config, loggerStub, Method.BeaconBlocksByRange, ReqRespEncoding.SSZ),
-      eth2ResponseDecode(config, loggerStub, Method.BeaconBlocksByRange, ReqRespEncoding.SSZ, "abc", controller),
+      eth2ResponseEncode(config, logger, Method.BeaconBlocksByRange, ReqRespEncoding.SSZ),
+      eth2ResponseDecode(config, logger, Method.BeaconBlocksByRange, ReqRespEncoding.SSZ, "abc", controller),
       collect
     )) as ResponseBody[];
     expect(responses.length).to.be.equal(4);
@@ -209,15 +197,8 @@ describe("response decoders", function () {
     chunks[5].status = RpcResponseStatus.ERR_INVALID_REQ;
     const responses = (await pipe(
       chunks,
-      eth2ResponseEncode(config, loggerStub, Method.BeaconBlocksByRange, ReqRespEncoding.SSZ_SNAPPY),
-      eth2ResponseDecode(
-        config,
-        loggerStub,
-        Method.BeaconBlocksByRange,
-        ReqRespEncoding.SSZ_SNAPPY,
-        "abc",
-        fakeController
-      ),
+      eth2ResponseEncode(config, logger, Method.BeaconBlocksByRange, ReqRespEncoding.SSZ_SNAPPY),
+      eth2ResponseDecode(config, logger, Method.BeaconBlocksByRange, ReqRespEncoding.SSZ_SNAPPY, "abc", fakeController),
       collect
     )) as ResponseBody[];
     expect(responses.length).to.be.equal(5);
@@ -230,7 +211,7 @@ describe("response decoders", function () {
           [Buffer.concat([Buffer.alloc(1), Buffer.from(encode(99999999999999999999999))])],
           eth2ResponseDecode(
             config,
-            loggerStub,
+            logger,
             Method.BeaconBlocksByRange,
             ReqRespEncoding.SSZ_SNAPPY,
             randomRequestId(),
@@ -252,7 +233,7 @@ describe("response decoders", function () {
           [Buffer.concat([Buffer.alloc(1), Buffer.alloc(12, 0)])],
           eth2ResponseDecode(
             config,
-            loggerStub,
+            logger,
             Method.Status,
             ReqRespEncoding.SSZ_SNAPPY,
             randomRequestId(),
@@ -276,7 +257,7 @@ describe("response decoders", function () {
               Buffer.alloc(config.types.Status.minSize() + 10),
             ]),
           ],
-          eth2ResponseDecode(config, loggerStub, Method.Status, ReqRespEncoding.SSZ, randomRequestId(), fakeController),
+          eth2ResponseDecode(config, logger, Method.Status, ReqRespEncoding.SSZ, randomRequestId(), fakeController),
           collect
         );
         fail("expect error here");
@@ -297,7 +278,7 @@ describe("response decoders", function () {
           ],
           eth2ResponseDecode(
             config,
-            loggerStub,
+            logger,
             Method.Status,
             ReqRespEncoding.SSZ_SNAPPY,
             randomRequestId(),
@@ -322,7 +303,7 @@ describe("response decoders", function () {
             config.types.Status.serialize(status),
           ]),
         ],
-        eth2ResponseDecode(config, loggerStub, Method.Status, ReqRespEncoding.SSZ, randomRequestId(), fakeController),
+        eth2ResponseDecode(config, logger, Method.Status, ReqRespEncoding.SSZ, randomRequestId(), fakeController),
         collect
       );
       expect(response).to.be.deep.equal([status]);

--- a/packages/lodestar/test/unit/network/gossip/gossip.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/gossip.test.ts
@@ -3,7 +3,6 @@ import {INetworkOptions} from "../../../../src/network/options";
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 import sinon from "sinon";
 import {NodejsNode} from "../../../../src/network/nodejs";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {IBeaconChain} from "../../../../src/chain";
 import {expect} from "chai";
 import {GossipEvent} from "../../../../src/network/gossip/constants";
@@ -17,6 +16,7 @@ import {generateEmptySignedBlock} from "../../../utils/block";
 import {GossipEncoding} from "../../../../src/network/gossip/encoding";
 import {BeaconState} from "@chainsafe/lodestar-types";
 import {TreeBacked} from "@chainsafe/ssz";
+import {silentLogger} from "../../../utils/logger";
 
 describe("Network Gossip", function () {
   let gossip: Gossip;
@@ -35,8 +35,7 @@ describe("Network Gossip", function () {
       disconnectTimeout: 0,
     };
     const libp2p = sandbox.createStubInstance(NodejsNode);
-    const logger = new WinstonLogger();
-    logger.silent = true;
+    const logger = silentLogger;
     const validator = {} as IGossipMessageValidator;
     state = generateState();
     chain = new MockBeaconChain({

--- a/packages/lodestar/test/unit/network/gossip/handlers/aggregateAndProof.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/handlers/aggregateAndProof.test.ts
@@ -4,9 +4,9 @@ import {handleIncomingAggregateAndProof} from "../../../../../src/network/gossip
 import {AggregateAndProof, SignedAggregateAndProof} from "@chainsafe/lodestar-types";
 import {generateEmptyAttestation} from "../../../../utils/attestation";
 import {expect} from "chai";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {GossipEvent} from "../../../../../src/network/gossip/constants";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {silentLogger} from "../../../../utils/logger";
 
 describe("gossip handlers - aggregate and proof", function () {
   const sandbox = sinon.createSandbox();
@@ -15,7 +15,7 @@ describe("gossip handlers - aggregate and proof", function () {
 
   beforeEach(function () {
     gossipStub = sandbox.createStubInstance(Gossip);
-    gossipStub.logger = sandbox.createStubInstance(WinstonLogger);
+    gossipStub.logger = silentLogger;
     gossipStub.config = config;
   });
 

--- a/packages/lodestar/test/unit/network/gossip/handlers/attestaterSlashing.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/handlers/attestaterSlashing.test.ts
@@ -1,11 +1,11 @@
 import sinon from "sinon";
 import {Gossip} from "../../../../../src/network/gossip/gossip";
 import {expect} from "chai";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {GossipEvent} from "../../../../../src/network/gossip/constants";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import {generateEmptyAttesterSlashing} from "../../../../utils/slashings";
 import {handleIncomingAttesterSlashing} from "../../../../../src/network/gossip/handlers/attesterSlashing";
+import {silentLogger} from "../../../../utils/logger";
 
 describe("gossip handlers - attesterSlashing", function () {
   const sandbox = sinon.createSandbox();
@@ -14,7 +14,7 @@ describe("gossip handlers - attesterSlashing", function () {
 
   beforeEach(function () {
     gossipStub = sandbox.createStubInstance(Gossip);
-    gossipStub.logger = sandbox.createStubInstance(WinstonLogger);
+    gossipStub.logger = silentLogger;
     gossipStub.config = config;
   });
 

--- a/packages/lodestar/test/unit/network/gossip/handlers/block.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/handlers/block.test.ts
@@ -1,11 +1,11 @@
 import sinon from "sinon";
 import {Gossip} from "../../../../../src/network/gossip/gossip";
 import {expect} from "chai";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {GossipEvent} from "../../../../../src/network/gossip/constants";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import {generateEmptySignedBlock} from "../../../../utils/block";
 import {handleIncomingBlock} from "../../../../../src/network/gossip/handlers/block";
+import {silentLogger} from "../../../../utils/logger";
 
 describe("gossip handlers - block", function () {
   const sandbox = sinon.createSandbox();
@@ -14,7 +14,7 @@ describe("gossip handlers - block", function () {
 
   beforeEach(function () {
     gossipStub = sandbox.createStubInstance(Gossip);
-    gossipStub.logger = sandbox.createStubInstance(WinstonLogger);
+    gossipStub.logger = silentLogger;
     gossipStub.config = config;
   });
 

--- a/packages/lodestar/test/unit/network/gossip/handlers/proposerSlashing.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/handlers/proposerSlashing.test.ts
@@ -1,11 +1,11 @@
 import sinon from "sinon";
 import {Gossip} from "../../../../../src/network/gossip/gossip";
 import {expect} from "chai";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {GossipEvent} from "../../../../../src/network/gossip/constants";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import {generateEmptyProposerSlashing} from "../../../../utils/slashings";
 import {handleIncomingProposerSlashing} from "../../../../../src/network/gossip/handlers/proposerSlashing";
+import {silentLogger} from "../../../../utils/logger";
 
 describe("gossip handlers - proposerSlashing", function () {
   const sandbox = sinon.createSandbox();
@@ -14,7 +14,7 @@ describe("gossip handlers - proposerSlashing", function () {
 
   beforeEach(function () {
     gossipStub = sandbox.createStubInstance(Gossip);
-    gossipStub.logger = sandbox.createStubInstance(WinstonLogger);
+    gossipStub.logger = silentLogger;
     gossipStub.config = config;
   });
 

--- a/packages/lodestar/test/unit/network/gossip/handlers/voluntaryExit.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/handlers/voluntaryExit.test.ts
@@ -1,11 +1,11 @@
 import sinon from "sinon";
 import {Gossip} from "../../../../../src/network/gossip/gossip";
 import {expect} from "chai";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {GossipEvent} from "../../../../../src/network/gossip/constants";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import {generateEmptySignedVoluntaryExit} from "../../../../utils/voluntaryExits";
 import {handleIncomingVoluntaryExit} from "../../../../../src/network/gossip/handlers/voluntaryExit";
+import {silentLogger} from "../../../../utils/logger";
 
 describe("gossip handlers - voluntaryExit", function () {
   const sandbox = sinon.createSandbox();
@@ -14,7 +14,7 @@ describe("gossip handlers - voluntaryExit", function () {
 
   beforeEach(function () {
     gossipStub = sandbox.createStubInstance(Gossip);
-    gossipStub.logger = sandbox.createStubInstance(WinstonLogger);
+    gossipStub.logger = silentLogger;
     gossipStub.config = config;
   });
 

--- a/packages/lodestar/test/unit/network/gossip/validation/aggregateAndProof.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/validation/aggregateAndProof.test.ts
@@ -1,7 +1,6 @@
 import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
 import {BeaconChain, IBeaconChain} from "../../../../../src/chain";
 import {StubbedBeaconDb} from "../../../../utils/stub";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {validateGossipAggregateAndProof} from "../../../../../src/network/gossip/validation";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import {generateSignedAggregateAndProof} from "../../../../utils/aggregateAndProof";
@@ -16,9 +15,10 @@ import * as blockUtils from "@chainsafe/lodestar-beacon-state-transition/lib/fas
 import {generateState} from "../../../../utils/state";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {PrivateKey, PublicKey} from "@chainsafe/bls";
+import {silentLogger} from "../../../../utils/logger";
 
 describe("gossip aggregate and proof test", function () {
-  const logger = sinon.createStubInstance(WinstonLogger);
+  const logger = silentLogger;
   let chain: SinonStubbedInstance<IBeaconChain>;
   let db: StubbedBeaconDb;
   let getAttestationPreStateStub: SinonStub;

--- a/packages/lodestar/test/unit/network/gossip/validation/attestation.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/validation/attestation.test.ts
@@ -1,5 +1,4 @@
 import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
-import {ILogger, WinstonLogger} from "@chainsafe/lodestar-utils";
 import {BeaconChain, IBeaconChain} from "../../../../../src/chain";
 import {StubbedBeaconDb} from "../../../../utils/stub";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
@@ -15,9 +14,10 @@ import * as attestationUtils from "@chainsafe/lodestar-beacon-state-transition/l
 import * as blockUtils from "@chainsafe/lodestar-beacon-state-transition/lib/fast/block/isValidIndexedAttestation";
 import {IndexedAttestation} from "@chainsafe/lodestar-types";
 import {BitList} from "@chainsafe/ssz";
+import {silentLogger} from "../../../../utils/logger";
 
 describe("gossip attestation validation", function () {
-  let logger: SinonStubbedInstance<ILogger>;
+  const logger = silentLogger;
   let chain: SinonStubbedInstance<IBeaconChain>;
   let db: StubbedBeaconDb;
   let getBlockStateContextStub: SinonStub;
@@ -26,7 +26,6 @@ describe("gossip attestation validation", function () {
   let isValidIndexedAttestationStub: SinonStub;
 
   beforeEach(function () {
-    logger = sinon.createStubInstance(WinstonLogger);
     chain = sinon.createStubInstance(BeaconChain);
     chain.getGenesisTime.returns(Math.floor(Date.now() / 1000));
     db = new StubbedBeaconDb(sinon, config);

--- a/packages/lodestar/test/unit/network/gossip/validator.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/validator.test.ts
@@ -2,7 +2,6 @@ import sinon from "sinon";
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import * as validatorStatusUtils from "@chainsafe/lodestar-beacon-state-transition/lib/util/validatorStatus";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {generateState} from "../../../utils/state";
 import {generateEmptySignedVoluntaryExit} from "../../../utils/attestation";
 import {
@@ -17,12 +16,12 @@ import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconDb} from "../../../../src/db";
 import {StubbedBeaconDb, StubbedChain} from "../../../utils/stub";
 import {ExtendedValidatorResult} from "../../../../src/network/gossip/constants";
+import {silentLogger} from "../../../utils/logger";
 
 describe("GossipMessageValidator", () => {
   const sandbox = sinon.createSandbox();
   let validator: GossipMessageValidator;
   let dbStub: StubbedBeaconDb,
-    logger: any,
     isValidIncomingVoluntaryExitStub: any,
     isValidIncomingProposerSlashingStub: any,
     isValidIncomingAttesterSlashingStub: any,
@@ -36,13 +35,11 @@ describe("GossipMessageValidator", () => {
     chainStub.forkChoice = sandbox.createStubInstance(ArrayDagLMDGHOST);
 
     dbStub = new StubbedBeaconDb(sandbox);
-    logger = new WinstonLogger();
-    logger.silent = true;
     validator = new GossipMessageValidator({
       chain: chainStub,
       db: (dbStub as unknown) as IBeaconDb,
       config,
-      logger,
+      logger: silentLogger,
     });
   });
 

--- a/packages/lodestar/test/unit/network/reqResp.test.ts
+++ b/packages/lodestar/test/unit/network/reqResp.test.ts
@@ -4,21 +4,21 @@ import {BeaconBlocksByRangeRequest, SignedBeaconBlock, Slot, Status} from "@chai
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 import {ReqResp} from "../../../src/network/reqResp";
 import {NodejsNode} from "../../../src/network/nodejs";
-import {ILogger, WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {INetworkOptions} from "../../../src/network/options";
 import {generateEmptySignedBlock} from "../../utils/block";
 import {createNode} from "../../utils/network";
 import {ReputationStore} from "../../../src/sync/IReputation";
-import sinon, {SinonStubbedInstance} from "sinon";
+import sinon from "sinon";
 import {TTFB_TIMEOUT} from "../../../src/constants";
 import {AbortSignal} from "abort-controller/dist/abort-controller";
+import {silentLogger} from "../../utils/logger";
 
 const multiaddr = "/ip4/127.0.0.1/tcp/0";
 
 describe("[network] rpc", () => {
+  const logger = silentLogger;
   const sandbox = sinon.createSandbox();
   let nodeA: NodejsNode, nodeB: NodejsNode, rpcA: ReqResp, rpcB: ReqResp;
-  let loggerStub: SinonStubbedInstance<ILogger>;
 
   const networkOptions: INetworkOptions = {
     maxPeers: 10,
@@ -30,7 +30,6 @@ describe("[network] rpc", () => {
   };
   beforeEach(async function () {
     this.timeout(10000);
-    loggerStub = sandbox.createStubInstance(WinstonLogger);
     // setup
     nodeA = await createNode(multiaddr);
     nodeB = await createNode(multiaddr);
@@ -39,13 +38,13 @@ describe("[network] rpc", () => {
     rpcA = new ReqResp(networkOptions, {
       config,
       libp2p: nodeA,
-      logger: loggerStub,
+      logger,
       peerReputations: new ReputationStore(),
     });
     rpcB = new ReqResp(networkOptions, {
       config,
       libp2p: nodeB,
-      logger: loggerStub,
+      logger,
       peerReputations: new ReputationStore(),
     });
     await Promise.all([rpcA.start(), rpcB.start()]);
@@ -221,7 +220,7 @@ describe("[network] rpc", () => {
     const rpcC = new ReqResp(networkOptions, {
       config,
       libp2p: libP2pMock,
-      logger: loggerStub,
+      logger,
       peerReputations: new ReputationStore(),
     });
     try {

--- a/packages/lodestar/test/unit/sync/initial/fast.test.ts
+++ b/packages/lodestar/test/unit/sync/initial/fast.test.ts
@@ -2,7 +2,6 @@ import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
 import {FastSync} from "../../../../src/sync/initial/fast";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import {BeaconChain, IBeaconChain, ILMDGHOST, ArrayDagLMDGHOST, ChainEventEmitter} from "../../../../src/chain";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {INetwork, Libp2pNetwork} from "../../../../src/network";
 import {ReputationStore} from "../../../../src/sync/IReputation";
 import * as syncUtils from "../../../../src/sync/utils";
@@ -12,10 +11,12 @@ import {expect} from "chai";
 import {SyncStats} from "../../../../src/sync/stats";
 import {StubbedBeaconDb} from "../../../utils/stub";
 import {generateEmptySignedBlock} from "../../../utils/block";
+import {silentLogger} from "../../../utils/logger";
 
 describe("fast sync", function () {
   const sandbox = sinon.createSandbox();
 
+  const logger = silentLogger;
   let chainStub: SinonStubbedInstance<IBeaconChain>;
   let forkChoiceStub: SinonStubbedInstance<ILMDGHOST>;
   let networkStub: SinonStubbedInstance<INetwork>;
@@ -44,7 +45,7 @@ describe("fast sync", function () {
       {
         config,
         chain: chainStub,
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger,
         network: networkStub,
         stats: sinon.createStubInstance(SyncStats),
         reputationStore: repsStub,
@@ -71,7 +72,7 @@ describe("fast sync", function () {
         config,
         //@ts-ignore
         chain: chainEventEmitter,
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger,
         network: networkStub,
         stats: statsStub,
         reputationStore: repsStub,
@@ -109,7 +110,7 @@ describe("fast sync", function () {
         config,
         //@ts-ignore
         chain: chainEventEmitter,
-        logger: sinon.createStubInstance(WinstonLogger),
+        logger,
         network: networkStub,
         stats: statsStub,
         reputationStore: repsStub,

--- a/packages/lodestar/test/unit/sync/reqRes.test.ts
+++ b/packages/lodestar/test/unit/sync/reqRes.test.ts
@@ -14,7 +14,6 @@ import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 import {GENESIS_EPOCH, Method, ZERO_HASH, ReqRespEncoding} from "../../../src/constants";
 import {BeaconChain, ILMDGHOST, ArrayDagLMDGHOST} from "../../../src/chain";
 import {Libp2pNetwork} from "../../../src/network";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {generateState} from "../../utils/state";
 import {ReqResp} from "../../../src/network/reqResp";
 import {ReputationStore, IReputation} from "../../../src/sync/IReputation";
@@ -25,6 +24,7 @@ import {StubbedBeaconDb} from "../../utils/stub";
 import {getBlockSummary} from "../../utils/headBlockInfo";
 import {computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {generatePeer} from "../../utils/peer";
+import {silentLogger} from "../../utils/logger";
 
 describe("sync req resp", function () {
   const sandbox = sinon.createSandbox();
@@ -33,7 +33,6 @@ describe("sync req resp", function () {
     networkStub: SinonStubbedInstance<Libp2pNetwork>,
     repsStub: SinonStubbedInstance<ReputationStore>,
     forkChoiceStub: SinonStubbedInstance<ILMDGHOST>,
-    logger: WinstonLogger,
     reqRespStub: SinonStubbedInstance<ReqResp>;
   let dbStub: StubbedBeaconDb;
 
@@ -52,8 +51,6 @@ describe("sync req resp", function () {
     networkStub.reqResp = (reqRespStub as unknown) as ReqResp & SinonStubbedInstance<ReqResp>;
     dbStub = new StubbedBeaconDb(sandbox);
     repsStub = sandbox.createStubInstance(ReputationStore);
-    logger = new WinstonLogger();
-    logger.silent = true;
 
     syncRpc = new BeaconReqRespHandler({
       config,
@@ -61,13 +58,12 @@ describe("sync req resp", function () {
       chain: chainStub,
       network: networkStub,
       reputationStore: repsStub,
-      logger,
+      logger: silentLogger,
     });
   });
 
   afterEach(() => {
     sandbox.restore();
-    logger.silent = false;
   });
 
   it("should start and stop sync rpc", async function () {
@@ -78,7 +74,7 @@ describe("sync req resp", function () {
       latestMetadata: null,
       latestStatus: null,
       score: 0,
-      encoding: ReqRespEncoding.SSZ_SNAPPY
+      encoding: ReqRespEncoding.SSZ_SNAPPY,
     });
 
     try {
@@ -102,7 +98,7 @@ describe("sync req resp", function () {
       latestMetadata: null,
       latestStatus: null,
       score: 0,
-      encoding: ReqRespEncoding.SSZ_SNAPPY
+      encoding: ReqRespEncoding.SSZ_SNAPPY,
     };
     repsStub.get.returns(reputation);
     repsStub.getFromPeerId.returns(reputation);
@@ -130,7 +126,7 @@ describe("sync req resp", function () {
       latestMetadata: null,
       latestStatus: null,
       score: 0,
-      encoding: ReqRespEncoding.SSZ_SNAPPY
+      encoding: ReqRespEncoding.SSZ_SNAPPY,
     });
     try {
       reqRespStub.sendResponse.throws(new Error("server error"));

--- a/packages/lodestar/test/unit/sync/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/sync.test.ts
@@ -4,7 +4,6 @@ import {BeaconReqRespHandler, IReqRespHandler} from "../../../src/sync/reqResp";
 import {AttestationCollector} from "../../../src/sync/utils";
 import {BeaconGossipHandler, IGossipHandler} from "../../../src/sync/gossip";
 import {INetwork, Libp2pNetwork} from "../../../src/network";
-import {ILogger, WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {IRegularSync, NaiveRegularSync} from "../../../src/sync/regular";
 import {FastSync, InitialSync} from "../../../src/sync/initial";
 import {BeaconSync, SyncMode} from "../../../src/sync";
@@ -15,6 +14,7 @@ import {ReputationStore} from "../../../src/sync/IReputation";
 import {generateEmptySignedBlock} from "../../utils/block";
 import {ISyncOptions} from "../../../src/sync/options";
 import {IBeaconSync} from "../../../lib/sync";
+import {silentLogger} from "../../utils/logger";
 
 describe("sync", function () {
   let chainStub: SinonStubbedInstance<IBeaconChain>;
@@ -22,7 +22,6 @@ describe("sync", function () {
   let attestationCollectorStub: SinonStubbedInstance<AttestationCollector>;
   let gossipStub: SinonStubbedInstance<IGossipHandler>;
   let networkStub: SinonStubbedInstance<INetwork>;
-  let loggerStub: SinonStubbedInstance<ILogger>;
   let regularSyncStub: SinonStubbedInstance<IRegularSync>;
   let initialSyncStub: SinonStubbedInstance<InitialSync>;
   let clock: SinonFakeTimers;
@@ -39,7 +38,7 @@ describe("sync", function () {
       gossipHandler: gossipStub,
       reputationStore: sinon.createStubInstance(ReputationStore),
       attestationCollector: (attestationCollectorStub as unknown) as AttestationCollector,
-      logger: loggerStub,
+      logger: silentLogger,
     });
   };
 
@@ -49,7 +48,6 @@ describe("sync", function () {
     attestationCollectorStub = sinon.createStubInstance(AttestationCollector);
     gossipStub = sinon.createStubInstance(BeaconGossipHandler);
     networkStub = sinon.createStubInstance(Libp2pNetwork);
-    loggerStub = sinon.createStubInstance(WinstonLogger);
     regularSyncStub = sinon.createStubInstance(NaiveRegularSync);
     initialSyncStub = sinon.createStubInstance(FastSync);
     clock = sinon.useFakeTimers();

--- a/packages/lodestar/test/unit/sync/utils/attestation-collector.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/attestation-collector.test.ts
@@ -1,7 +1,6 @@
 import {expect} from "chai";
 import sinon from "sinon";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 
 import {AttestationCollector} from "../../../../src/sync/utils";
 import {LocalClock} from "../../../../src/chain/clock/local/LocalClock";
@@ -9,13 +8,14 @@ import {Gossip} from "../../../../src/network/gossip/gossip";
 import {BeaconDb} from "../../../../src/db";
 import * as attestationUtils from "@chainsafe/lodestar-beacon-state-transition/lib/util/attestation";
 import {generateState} from "../../../utils/state";
+import {silentLogger} from "../../../utils/logger";
 
 describe("Attestation collector", function () {
   const sandbox = sinon.createSandbox();
+  const logger = silentLogger;
 
   it("should subscribe and collect attestations", async function () {
     const clock = sandbox.useFakeTimers();
-    const loggerStub = sandbox.createStubInstance(WinstonLogger);
     const fakeGossip = sandbox.createStubInstance(Gossip);
     const dbStub = sandbox.createStubInstance(BeaconDb);
     const computeSubnetStub = sandbox.stub(attestationUtils, "computeSubnetForSlot");
@@ -31,7 +31,7 @@ describe("Attestation collector", function () {
         gossip: fakeGossip,
       },
       db: dbStub,
-      logger: loggerStub,
+      logger,
     });
     await realClock.start();
     await collector.start();
@@ -53,7 +53,6 @@ describe("Attestation collector", function () {
 
   it("should skip if there is no duties", async function () {
     const clock = sandbox.useFakeTimers();
-    const loggerStub = sandbox.createStubInstance(WinstonLogger);
     const realClock = new LocalClock(config, Math.round(new Date().getTime() / 1000));
     const fakeGossip = sandbox.createStubInstance(Gossip);
     const collector = new AttestationCollector(config, {
@@ -66,7 +65,7 @@ describe("Attestation collector", function () {
       network: {
         gossip: fakeGossip,
       },
-      logger: loggerStub,
+      logger,
     });
     await realClock.start();
     await collector.start();

--- a/packages/lodestar/test/unit/sync/utils/block.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/block.test.ts
@@ -7,18 +7,17 @@ import {blockToHeader} from "@chainsafe/lodestar-beacon-state-transition";
 import {config} from "@chainsafe/lodestar-config/src/presets/minimal";
 import PeerId from "peer-id";
 import {BeaconBlockHeader, SignedBeaconBlock} from "@chainsafe/lodestar-types";
-import {ILogger, WinstonLogger} from "@chainsafe/lodestar-utils";
+import {silentLogger} from "../../../utils/logger";
 
 describe("sync - block utils", function () {
   describe("get block range from multiple peers", function () {
     const sandbox = sinon.createSandbox();
 
+    const logger = silentLogger;
     let rpcStub: SinonStubbedInstance<ReqResp>;
-    let loggerStub: SinonStubbedInstance<ILogger>;
 
     beforeEach(function () {
       rpcStub = sandbox.createStubInstance(ReqResp);
-      loggerStub = sandbox.createStubInstance(WinstonLogger);
     });
 
     afterEach(function () {
@@ -32,7 +31,7 @@ describe("sync - block utils", function () {
       rpcStub.beaconBlocksByRange
         .withArgs(sinon.match(peers[0]).or(sinon.match(peers[1])), sinon.match.any)
         .resolves([generateEmptySignedBlock(), generateEmptySignedBlock(), generateEmptySignedBlock()]);
-      const blocks = await getBlockRange(loggerStub, rpcStub, peers, {start: 0, end: 4}, 2);
+      const blocks = await getBlockRange(logger, rpcStub, peers, {start: 0, end: 4}, 2);
       expect(blocks.length).to.be.equal(3);
     });
 
@@ -43,7 +42,7 @@ describe("sync - block utils", function () {
       const peers = [peer1, peer2];
       rpcStub.beaconBlocksByRange.onFirstCall().resolves(null);
       rpcStub.beaconBlocksByRange.onSecondCall().resolves([generateEmptySignedBlock(), generateEmptySignedBlock()]);
-      const blockPromise = getBlockRange(loggerStub, rpcStub, peers, {start: 0, end: 4}, 2);
+      const blockPromise = getBlockRange(logger, rpcStub, peers, {start: 0, end: 4}, 2);
       await timer.tickAsync(1000);
       const blocks = await blockPromise;
       expect(blocks.length).to.be.equal(2);
@@ -54,7 +53,7 @@ describe("sync - block utils", function () {
       const peer1 = new PeerId(Buffer.from("lodestar"));
       const peers: PeerId[] = [peer1];
       rpcStub.beaconBlocksByRange.resolves([]);
-      const blocks = await getBlockRange(loggerStub, rpcStub, peers, {start: 4, end: 4}, 2);
+      const blocks = await getBlockRange(logger, rpcStub, peers, {start: 4, end: 4}, 2);
       expect(blocks.length).to.be.equal(0);
     });
   });

--- a/packages/lodestar/test/unit/sync/utils/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/sync.test.ts
@@ -22,15 +22,16 @@ import {BeaconChain, IBeaconChain, ILMDGHOST, ArrayDagLMDGHOST} from "../../../.
 import {collect} from "../../chain/blocks/utils";
 import {ReqResp} from "../../../../src/network/reqResp";
 import {generateEmptySignedBlock} from "../../../utils/block";
-import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import PeerId from "peer-id";
 import {ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
 import {getEmptySignedBlock} from "../../../../src/chain/genesis/util";
 import {Method} from "../../../../src/constants";
 import {INetwork, Libp2pNetwork} from "../../../../src/network";
 import {generatePeer} from "../../../utils/peer";
+import {silentLogger} from "../../../utils/logger";
 
 describe("sync utils", function () {
+  const logger = silentLogger;
   let timer: SinonFakeTimers;
 
   beforeEach(function () {
@@ -167,7 +168,7 @@ describe("sync utils", function () {
       let result = pipe(
         [{start: 0, end: 10}],
         fetchBlockChunks(
-          sinon.createStubInstance(WinstonLogger),
+          logger,
           sinon.createStubInstance(BeaconChain),
           sinon.createStubInstance(ReqResp),
           getPeersStub
@@ -186,7 +187,7 @@ describe("sync utils", function () {
       const result = await pipe(
         [{start: 0, end: 10}],
         fetchBlockChunks(
-          sinon.createStubInstance(WinstonLogger),
+          logger,
           sinon.createStubInstance(BeaconChain),
           sinon.createStubInstance(ReqResp),
           getPeersStub
@@ -218,7 +219,7 @@ describe("sync utils", function () {
       block2.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(block1.message);
       const lastProcesssedSlot = await pipe(
         [[block2], [block1]],
-        processSyncBlocks(config, chainStub, sinon.createStubInstance(WinstonLogger), true, lastProcessedBlock)
+        processSyncBlocks(config, chainStub, logger, true, lastProcessedBlock)
       );
       expect(chainStub.receiveBlock.calledTwice).to.be.true;
       expect(lastProcesssedSlot).to.be.equal(3);
@@ -230,7 +231,7 @@ describe("sync utils", function () {
       const lastProcessSlot = await pipe(
         // failed to fetch range
         [null],
-        processSyncBlocks(config, chainStub, sinon.createStubInstance(WinstonLogger), true, lastProcessedBlock)
+        processSyncBlocks(config, chainStub, logger, true, lastProcessedBlock)
       );
       expect(lastProcessSlot).to.be.equal(10);
     });
@@ -240,7 +241,7 @@ describe("sync utils", function () {
       const lastProcessSlot = await pipe(
         // failed to fetch range
         [null],
-        processSyncBlocks(config, chainStub, sinon.createStubInstance(WinstonLogger), false, null)
+        processSyncBlocks(config, chainStub, logger, false, null)
       );
       expect(lastProcessSlot).to.be.equal(100);
     });
@@ -251,7 +252,7 @@ describe("sync utils", function () {
       const lastProcessSlot = await pipe(
         // failed to fetch range
         [[]],
-        processSyncBlocks(config, chainStub, sinon.createStubInstance(WinstonLogger), true, lastProcessedBlock)
+        processSyncBlocks(config, chainStub, logger, true, lastProcessedBlock)
       );
       expect(lastProcessSlot).to.be.null;
     });
@@ -260,7 +261,7 @@ describe("sync utils", function () {
       const lastProcessSlot = await pipe(
         // failed to fetch range
         [[]],
-        processSyncBlocks(config, chainStub, sinon.createStubInstance(WinstonLogger), false, null)
+        processSyncBlocks(config, chainStub, logger, false, null)
       );
       expect(lastProcessSlot).to.be.null;
     });

--- a/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
+++ b/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
@@ -8,15 +8,16 @@ import {WinstonLogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {ArchiveBlocksTask} from "../../../../src/tasks/tasks/archiveBlocks";
 import {generateEmptySignedBlock} from "../../../utils/block";
 import {StubbedBeaconDb} from "../../../utils/stub";
+import {silentLogger} from "../../../utils/logger";
 
 describe("block archiver task", function () {
   const sandbox = sinon.createSandbox();
+  const logger = silentLogger;
 
-  let dbStub: StubbedBeaconDb, loggerStub: any;
+  let dbStub: StubbedBeaconDb;
 
   beforeEach(function () {
     dbStub = new StubbedBeaconDb(sandbox);
-    loggerStub = sandbox.createStubInstance(WinstonLogger);
   });
 
   /**
@@ -46,7 +47,7 @@ describe("block archiver task", function () {
       config,
       {
         db: dbStub,
-        logger: loggerStub,
+        logger,
       },
       {
         slot: finalizedBlock.message.slot,

--- a/packages/lodestar/test/utils/logger.ts
+++ b/packages/lodestar/test/utils/logger.ts
@@ -1,0 +1,4 @@
+import {ILogger, WinstonLogger, LogLevel} from "@chainsafe/lodestar-utils/lib/logger";
+
+export const silentLogger: ILogger = new WinstonLogger({level: LogLevel.error});
+silentLogger.silent = true;

--- a/packages/lodestar/test/utils/node/beacon.ts
+++ b/packages/lodestar/test/utils/node/beacon.ts
@@ -4,13 +4,14 @@ import {createEnr} from "@chainsafe/lodestar-cli/src/network";
 import {params as minimalParams} from "@chainsafe/lodestar-params/lib/presets/minimal";
 import {createIBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBeaconParams} from "@chainsafe/lodestar-params";
-import {LogLevel, WinstonLogger, ILogger} from "@chainsafe/lodestar-utils";
+import {ILogger} from "@chainsafe/lodestar-utils";
 import {BeaconNode} from "../../../src/node";
 import {InteropEth1Notifier} from "../../../src/eth1/impl/interop";
 import {createNodeJsLibp2p} from "../../../src/network/nodejs";
 import {createPeerId} from "../../../src/network";
 import {initDevChain} from "../../../src/node/utils/state";
 import {IBeaconNodeOptions} from "../../../lib/node/options";
+import {silentLogger} from "../logger";
 
 type RecursivePartial<T> = {
   [P in keyof T]?: T[P] extends (infer U)[]
@@ -50,7 +51,7 @@ export async function getDevBeaconNode({
     ),
     {
       config,
-      logger: logger || new WinstonLogger({level: LogLevel.error}),
+      logger: logger || silentLogger,
       eth1: new InteropEth1Notifier(),
       libp2p: await createNodeJsLibp2p(
         peerId,


### PR DESCRIPTION
Potentially fixes https://github.com/ChainSafe/lodestar/issues/1169

There's extensive usage of sinon stub for a logger that is not used for any useful stubbing: i.e. verifying calls, passing mock values. I've replaced all those occurrences with a silentLogger that those that. Does stubbing the logger have any purpose that I'm not seeing?