### PR TITLE
Faster attestation verification

### DIFF
--- a/packages/lodestar-beacon-state-transition/package.json
+++ b/packages/lodestar-beacon-state-transition/package.json
@@ -35,7 +35,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/bls": "2.0.0",
+    "@chainsafe/bls": "4.0.0",
     "@chainsafe/lodestar-config": "^0.11.0",
     "@chainsafe/lodestar-utils": "^0.11.0",
     "@chainsafe/ssz": "^0.6.13",

--- a/packages/lodestar-beacon-state-transition/src/fast/block/isValidIndexedAttestation.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/isValidIndexedAttestation.ts
@@ -38,11 +38,12 @@ export function isValidIndexedAttestation(
   const pubkeys = indices.map((i) => epochCtx.index2pubkey[i]);
   const domain = getDomain(config, state, DomainType.BEACON_ATTESTER, indexedAttestation.data.target.epoch);
   const signingRoot = computeSigningRoot(config, config.types.AttestationData, indexedAttestation.data, domain);
-  const firstPubkey = pubkeys.shift();
-  if (firstPubkey === undefined) throw Error("pubkeys is empty");
-  return pubkeys
-    .reduce((aggregate, pubkey) => {
-      return aggregate.add(pubkey);
-    }, firstPubkey)
-    .verifyMessage(Signature.fromCompressedBytes(indexedAttestation.signature.valueOf() as Uint8Array), signingRoot);
+  try {
+    return Signature.fromCompressedBytes(indexedAttestation.signature.valueOf() as Uint8Array).verifyAggregate(
+      pubkeys,
+      signingRoot
+    );
+  } catch (e) {
+    return false;
+  }
 }

--- a/packages/lodestar-cli/package.json
+++ b/packages/lodestar-cli/package.json
@@ -48,7 +48,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "2.0.0",
+    "@chainsafe/bls": "4.0.0",
     "@chainsafe/bls-keygen": "^0.2.1",
     "@chainsafe/bls-keystore": "2.0.0",
     "@chainsafe/discv5": "0.3.1",

--- a/packages/lodestar-validator/package.json
+++ b/packages/lodestar-validator/package.json
@@ -43,7 +43,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "2.0.0",
+    "@chainsafe/bls": "4.0.0",
     "@chainsafe/lodestar-beacon-state-transition": "^0.11.0",
     "@chainsafe/lodestar-config": "^0.11.0",
     "@chainsafe/lodestar-types": "^0.11.0",

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -41,7 +41,7 @@
     "test:unit": "TS_NODE_PROJECT=tsconfig.test.json nyc --cache-dir .nyc_output/.cache -e .ts mocha 'test/unit/**/*.test.ts'"
   },
   "dependencies": {
-    "@chainsafe/bls": "2.0.0",
+    "@chainsafe/bls": "4.0.0",
     "@chainsafe/discv5": "0.3.1",
     "@chainsafe/lodestar-beacon-state-transition": "^0.11.0",
     "@chainsafe/lodestar-config": "^0.11.0",

--- a/packages/spec-test-runner/package.json
+++ b/packages/spec-test-runner/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@chainsafe/bit-utils": "0.1.6",
-    "@chainsafe/bls": "2.0.0",
+    "@chainsafe/bls": "4.0.0",
     "@chainsafe/lodestar": "^0.11.0",
     "@chainsafe/lodestar-beacon-state-transition": "^0.11.0",
     "@chainsafe/lodestar-config": "^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1015,16 +1015,6 @@
   dependencies:
     assert "^2.0.0"
 
-"@chainsafe/bls-hd-key@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/bls-hd-key/-/bls-hd-key-0.0.1.tgz#143ff16d2dcc2ec7a0b51e211d6cadabdd65f2df"
-  integrity sha512-XuGNWhyeX/6lsWdZo0+dzCAsO7anilBb+384KUkH1LNeFjRxtve88wp+l3KiE7UBXBJg8tsgQyeR1weG5/gSaA==
-  dependencies:
-    assert "^2.0.0"
-    bcrypto "^4.2.6"
-    bn.js "^5.0.0"
-    buffer "^5.4.3"
-
 "@chainsafe/bls-hd-key@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@chainsafe/bls-hd-key/-/bls-hd-key-0.1.0.tgz#5e51de16801f4b4b421e418f0d1ef0692df0c585"
@@ -1035,18 +1025,7 @@
     bn.js "^5.1.1"
     buffer "^5.4.3"
 
-"@chainsafe/bls-keygen@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@chainsafe/bls-keygen/-/bls-keygen-0.0.2.tgz#f0ce10f34b0e63c996631c607681aaf1b64283c6"
-  integrity sha512-4Hs2YUafoO5ENQN7bQBKbrp8mwGBGYRgau7gkFzUhTLptY9lbEGENN2sc5GvpKjANfhXTbF/vOy9lghaHsFuNg==
-  dependencies:
-    "@chainsafe/bls-hd-key" "^0.0.1"
-    assert "^2.0.0"
-    bcrypto "^4.2.6"
-    bip39 "^3.0.2"
-    buffer "^5.4.3"
-
-"@chainsafe/bls-keygen@^0.2.1":
+"@chainsafe/bls-keygen@^0.2.0", "@chainsafe/bls-keygen@^0.2.1":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@chainsafe/bls-keygen/-/bls-keygen-0.2.1.tgz#2ddbba1fdb79f893defb6b03a797e708e631d9a1"
   integrity sha512-QEwFbkHUoEDKXbxJ7QObHAvvqfp31cYOQju3gXxGz4RxMDPSHCcUI+76IXrq0hxYHxN149eYGcEYM57Z2YxFuw==
@@ -1067,12 +1046,12 @@
     ethereum-cryptography "^0.1.3"
     uuid "^3.3.3"
 
-"@chainsafe/bls@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/bls/-/bls-2.0.0.tgz#d0e59b890f543d975b637423940397ade7e4581a"
-  integrity sha512-Hb8lsiI9ydPxc1vDhBkM1Mawn0b0WKV3JeDoXXKNKx7ERlSNuEi1EfCIabCQN53ANaotqJmjTosnrD8VyWsqxQ==
+"@chainsafe/bls@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/bls/-/bls-4.0.0.tgz#889ba5a04ebfd2e687302be46d3ea92102c9b94d"
+  integrity sha512-X3uG2nYGtc3WIyOBgn/HFdCkEq6V80JBHyVc9MJry+y1Hcs3lvxzd3n3AXo5mSf3/iVWyrfvt8J6KgWkFKDNQA==
   dependencies:
-    "@chainsafe/bls-keygen" "^0.0.2"
+    "@chainsafe/bls-keygen" "^0.2.0"
     "@chainsafe/eth2-bls-wasm" "^0.5.0"
     assert "^1.4.1"
 
@@ -4577,7 +4556,7 @@ bcrypto@5.1.0:
     bufio "~1.0.6"
     loady "~0.0.1"
 
-bcrypto@^4.2.6, bcrypto@^4.2.8:
+bcrypto@^4.2.8:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/bcrypto/-/bcrypto-4.3.2.tgz#50d4543cc16c39a9fca1d7f457a3850703867814"
   integrity sha512-uGmeiqLvLYUPRa0XoACDgXwxZY9wE1uiFHpdtGSs7FI2YYkakqIWZklkF8sKMzXM/HaHRIjulzQ8xuDoqptjVQ==
@@ -4711,11 +4690,6 @@ bn.js@4.11.8, bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.10.0, bn.js@^4.
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
   integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
-
-bn.js@^5.0.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.1.tgz#48efc4031a9c4041b9c99c6941d903463ab62eb5"
-  integrity sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA==
 
 bn.js@^5.1.1:
   version "5.1.2"


### PR DESCRIPTION
we now utilize decompressed public keys, and aggregation is done without extra wasm calls.