### PR TITLE
add logger to default medalla config in cli

### DIFF
--- a/packages/lodestar-cli/src/testnets/medalla.ts
+++ b/packages/lodestar-cli/src/testnets/medalla.ts
@@ -1,4 +1,5 @@
 import {IBeaconNodeOptionsPartial} from "../options";
+import {LogLevel} from "@chainsafe/lodestar-utils";
 
 /* eslint-disable max-len */
 
@@ -17,6 +18,35 @@ export const medallaConfig: IBeaconNodeOptionsPartial = {
   eth1: {
     provider: {
       url: "https://goerli.prylabs.net",
+    },
+  },
+  logger: {
+    chain: {
+      level: LogLevel.info,
+    },
+    db: {
+      level: LogLevel.info,
+    },
+    eth1: {
+      level: LogLevel.info,
+    },
+    node: {
+      level: LogLevel.info,
+    },
+    network: {
+      level: LogLevel.info,
+    },
+    sync: {
+      level: LogLevel.info,
+    },
+    api: {
+      level: LogLevel.info,
+    },
+    metrics: {
+      level: LogLevel.info,
+    },
+    chores: {
+      level: LogLevel.info,
     },
   },
   metrics: {


### PR DESCRIPTION
i was copying and pasting the logger option too many times to the beacon config, so i made this to fix that