### PR TITLE
Don't dump coverage data in test

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,8 +1,6 @@
 {
   "cache": false,
-  "extension": [
-    ".ts"
-  ],
+  "extension": [".ts"],
   "exclude": [
     "**/*.d.ts",
     "**/*.js",
@@ -15,8 +13,5 @@
     "**/node_modules/**"
   ],
   "all": false,
-  "reporter": [
-    "text",
-    "lcov"
-  ]
+  "reporter": ["lcovonly"]
 }


### PR DESCRIPTION
At least for me it's very annoying to have to scroll past the coverage data to find which tests failed. `lcovonly` should store coverage data to `coverage/lcov.info` for the coverage reporter and print nothing to stdout. If someone really wants the print out, `lcov.info` can be rendered by other tools or re-run with a different reporter option