### PR TITLE
State repository in parallel to StateContextCache

### DIFF
--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -47,7 +47,7 @@ export interface IBeaconChain {
   getENRForkID(): Promise<ENRForkID>;
   getGenesisTime(): Number64;
   getHeadStateContext(): Promise<ITreeStateContext>;
-  getHeadState(): Promise<TreeBacked<BeaconState>>;
+  getHeadState(): Promise<BeaconState>;
   getHeadEpochContext(): Promise<EpochContext>;
 
   getHeadBlock(): Promise<SignedBeaconBlock | null>;

--- a/packages/lodestar/src/db/api/beacon/beacon.ts
+++ b/packages/lodestar/src/db/api/beacon/beacon.ts
@@ -22,6 +22,7 @@ import {
 import {StateContextCache} from "./stateContextCache";
 import {CheckpointStateCache} from "./stateContextCheckpointsCache";
 import {SeenAttestationCache} from "./seenAttestationCache";
+import {StateRepository} from "./repositories/state";
 
 export class BeaconDb extends DatabaseService implements IBeaconDb {
   public badBlock: BadBlockRepository;
@@ -41,12 +42,14 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
 
   public depositDataRoot: DepositDataRootRepository;
   public eth1Data: Eth1DataRepository;
+  public state: StateRepository;
 
   public constructor(opts: IDatabaseApiOptions) {
     super(opts);
     this.badBlock = new BadBlockRepository(this.config, this.db);
     this.block = new BlockRepository(this.config, this.db);
-    this.stateCache = new StateContextCache();
+    this.state = new StateRepository(this.config, this.db);
+    this.stateCache = new StateContextCache(this.state);
     this.checkpointStateCache = new CheckpointStateCache(this.config);
     this.seenAttestationCache = new SeenAttestationCache(5000);
     this.blockArchive = new BlockArchiveRepository(this.config, this.db);

--- a/packages/lodestar/src/db/api/beacon/interface.ts
+++ b/packages/lodestar/src/db/api/beacon/interface.ts
@@ -21,6 +21,7 @@ import {
 import {StateContextCache} from "./stateContextCache";
 import {CheckpointStateCache} from "./stateContextCheckpointsCache";
 import {SeenAttestationCache} from "./seenAttestationCache";
+import {StateRepository} from "./repositories/state";
 
 /**
  * The DB service manages the data layer of the beacon chain
@@ -33,6 +34,9 @@ export interface IBeaconDb {
 
   // unfinalized blocks
   block: BlockRepository;
+
+  // unfinalized states
+  state: StateRepository;
 
   // unfinalized states
   stateCache: StateContextCache;

--- a/packages/lodestar/src/db/api/beacon/repositories/state.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/state.ts
@@ -1,0 +1,24 @@
+import {Repository} from ".";
+import {BeaconState} from "@chainsafe/lodestar-types";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IDatabaseController} from "../../..";
+import {Bucket} from "../../schema";
+
+/**
+ * States by root.
+ * Although the interface is BeaconState.
+ *
+ * Used to store unfinalized states
+ */
+export class StateRepository extends Repository<Uint8Array, BeaconState> {
+  public constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
+    super(config, db, Bucket.state, config.types.BeaconState);
+  }
+
+  /**
+   * Id is hashTreeRoot of BeaconState
+   */
+  public getId(value: BeaconState): Uint8Array {
+    return this.config.types.BeaconState.hashTreeRoot(value);
+  }
+}

--- a/packages/lodestar/src/db/api/beacon/repositories/stateArchive.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/stateArchive.ts
@@ -1,4 +1,3 @@
-import {TreeBacked, CompositeType} from "@chainsafe/ssz";
 import {BeaconState, Epoch} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
@@ -7,16 +6,12 @@ import {IDatabaseController} from "../../../controller";
 import {Bucket} from "../../schema";
 import {Repository} from "./abstract";
 
-export class StateArchiveRepository extends Repository<Epoch, TreeBacked<BeaconState>> {
+export class StateArchiveRepository extends Repository<Epoch, BeaconState> {
   public constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
-    super(config, db, Bucket.state, (config.types.BeaconState as unknown) as CompositeType<TreeBacked<BeaconState>>);
+    super(config, db, Bucket.state, config.types.BeaconState);
   }
 
-  public getId(state: TreeBacked<BeaconState>): Epoch {
+  public getId(state: BeaconState): Epoch {
     return computeEpochAtSlot(this.config, state.slot);
-  }
-
-  public decodeValue(data: Buffer): TreeBacked<BeaconState> {
-    return ((this.type as unknown) as CompositeType<BeaconState>).tree.deserialize(data);
   }
 }

--- a/packages/lodestar/src/tasks/tasks/archiveStates.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveStates.ts
@@ -45,12 +45,10 @@ export class ArchiveStatesTask implements ITask {
     const epoch = computeEpochAtSlot(this.config, this.finalized.slot);
     this.logger.info(`Started archiving states (finalized epoch #${epoch})...`);
     this.logger.profile("Archive States");
-    // store the state of finalized checkpoint
-    const stateCache = await this.db.stateCache.get(this.finalized.stateRoot);
-    if (!stateCache) {
+    const finalizedState = await this.db.state.get(this.finalized.stateRoot);
+    if (!finalizedState) {
       throw Error(`No state cache in db for finalized stateRoot ${toHexString(this.finalized.stateRoot)}`);
     }
-    const finalizedState = stateCache.state;
     await this.db.stateArchive.add(finalizedState);
     // delete states before the finalized state
     const prunedStates = this.pruned.map((summary) => summary.stateRoot);

--- a/packages/lodestar/test/unit/chain/chain.test.ts
+++ b/packages/lodestar/test/unit/chain/chain.test.ts
@@ -27,7 +27,7 @@ describe("BeaconChain", function () {
     metrics = new BeaconMetrics({enabled: false} as any, {logger});
     const state: BeaconState = generateState();
     state.validators = generateValidators(5, {activationEpoch: 0});
-    dbStub.stateCache.get.resolves({state: state as TreeBacked<BeaconState>, epochCtx: new EpochContext(config)});
+    dbStub.state.get.resolves(state);
     dbStub.stateArchive.lastValue.resolves(state as any);
     chain = new BeaconChain(chainOpts, {config, db: dbStub, eth1Provider, logger, metrics});
     await chain.start();

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -77,7 +77,7 @@ export class MockBeaconChain implements IBeaconChain {
     return (await this.getHeadStateContext()).epochCtx;
   }
 
-  public async getHeadState(): Promise<TreeBacked<BeaconState>> {
+  public async getHeadState(): Promise<BeaconState> {
     return (await this.getHeadStateContext()).state;
   }
 

--- a/packages/lodestar/test/utils/stub/beaconDb.ts
+++ b/packages/lodestar/test/utils/stub/beaconDb.ts
@@ -20,12 +20,14 @@ import {StateContextCache} from "../../../src/db/api/beacon/stateContextCache";
 import {SeenAttestationCache} from "../../../src/db/api/beacon/seenAttestationCache";
 import {CheckpointStateCache} from "../../../src/db/api/beacon/stateContextCheckpointsCache";
 import {config as minimalConfig} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {StateRepository} from "../../../src/db/api/beacon/repositories/state";
 
 export class StubbedBeaconDb extends BeaconDb {
   public db!: SinonStubbedInstance<LevelDbController>;
 
   public badBlock: SinonStubbedInstance<BadBlockRepository> & BadBlockRepository;
   public block: SinonStubbedInstance<BlockRepository> & BlockRepository;
+  public state: SinonStubbedInstance<StateRepository> & StateRepository;
   public stateCache: SinonStubbedInstance<StateContextCache> & StateContextCache;
   public blockArchive: SinonStubbedInstance<BlockArchiveRepository> & BlockArchiveRepository;
   public stateArchive: SinonStubbedInstance<StateArchiveRepository> & StateArchiveRepository;
@@ -51,6 +53,7 @@ export class StubbedBeaconDb extends BeaconDb {
     super({config, controller: null!});
     this.badBlock = sinon.createStubInstance(BadBlockRepository) as any;
     this.block = sinon.createStubInstance(BlockRepository) as any;
+    this.state = sinon.createStubInstance(StateRepository) as any;
     this.stateCache = sinon.createStubInstance(StateContextCache) as any;
     this.blockArchive = sinon.createStubInstance(BlockArchiveRepository) as any;
     this.stateArchive = sinon.createStubInstance(StateArchiveRepository) as any;


### PR DESCRIPTION
resolves #1508 
resolves #1511 

## Root cause
+ Some scenarios need state but it was pruned in StateContextCache due to max size limitation
## Solution
+ Introduce back StateRepository in parallel to StateContextCache, it uses BeaconState instead of TreeBacked<BeaconState> and it's only pruned in ArchiveTask unlike StateContextCache
+ StateContextCache: TreeBacked<BeaconState> is great for state transition due to its memory efficient and the cached hashTreeRoot but it takes time to build it and data is not available after we prune per checkpoint, so use it for state transition
+ StateRepository: BeaconState is simple and not suitable for state transition, but it's always available in StateRepository, so use it for Rest API, archive state and some other scenarios that need BeaconData only (not the tree)