### PR TITLE
Checkpoint state cache

### DIFF
--- a/packages/lodestar/src/chain/attestation/processor.ts
+++ b/packages/lodestar/src/chain/attestation/processor.ts
@@ -43,7 +43,7 @@ export async function processAttestation(
       //should not happen
       return;
     }
-    await db.checkpointStateCache.add(target, attestationPreState);
+    await db.checkpointStateCtxCache.add(target, attestationPreState);
     const indexedAttestation = attestationPreState.epochCtx.getIndexedAttestation(attestation);
     //TODO: we could signal to skip this in case it came from validated from gossip or from block
     //we need to check this again, because gossip validation might put it in pool before it validated signature

--- a/packages/lodestar/src/chain/forkChoice/arrayDag/lmdGhost.ts
+++ b/packages/lodestar/src/chain/forkChoice/arrayDag/lmdGhost.ts
@@ -400,6 +400,30 @@ export class ArrayDagLMDGHOST implements ILMDGHOST {
       .map((node) => this.toBlockSummary(node));
   }
 
+  /**
+   * If chain is like A - B - C - D then params are like
+   * @param ancestorRoot block root of A
+   * @param stateRoots state roots of B, C, D
+   * @returns block summaries of B, C, D
+   */
+  public getBlockSummariesByAncestorBlockRoot(
+    ancestorRoot: Uint8Array,
+    stateRoots: Uint8Array[]
+  ): BlockSummary[] | null {
+    let node = this.getNode(ancestorRoot);
+    if (!node) return null;
+    const summaries: BlockSummary[] = [];
+    for (const stateRoot of stateRoots) {
+      const children = Object.values(node.children).map((index) => this.nodes[index]);
+      const child = children.find((item) => this.config.types.Root.equals(item.stateRoot, stateRoot));
+      if (child) {
+        summaries.push(this.toBlockSummary(child));
+        node = child;
+      }
+    }
+    return summaries;
+  }
+
   public hasBlock(blockRoot: Uint8Array): boolean {
     return !!this.getNode(blockRoot);
   }

--- a/packages/lodestar/src/chain/forkChoice/interface.ts
+++ b/packages/lodestar/src/chain/forkChoice/interface.ts
@@ -27,6 +27,7 @@ export interface ILMDGHOST {
   getCanonicalBlockSummaryAtSlot(slot: Slot): BlockSummary | null;
   getBlockSummaryByBlockRoot(blockRoot: Uint8Array): BlockSummary | null;
   getBlockSummaryByParentBlockRoot(blockRoot: Uint8Array): BlockSummary[];
+  getBlockSummariesByAncestorBlockRoot(ancestorRoot: Uint8Array, stateRoots: Uint8Array[]): BlockSummary[] | null;
   hasBlock(blockRoot: Uint8Array): boolean;
 }
 

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -48,6 +48,7 @@ export interface IBeaconChain {
   getGenesisTime(): Number64;
   getHeadStateContext(): Promise<ITreeStateContext>;
   getHeadState(): Promise<TreeBacked<BeaconState>>;
+  getState(stateRoot: Uint8Array): Promise<TreeBacked<BeaconState>>;
   getHeadEpochContext(): Promise<EpochContext>;
 
   getHeadBlock(): Promise<SignedBeaconBlock | null>;

--- a/packages/lodestar/src/db/api/beacon/beacon.ts
+++ b/packages/lodestar/src/db/api/beacon/beacon.ts
@@ -20,14 +20,16 @@ import {
   VoluntaryExitRepository,
 } from "./repositories";
 import {StateContextCache} from "./stateContextCache";
-import {CheckpointStateCache} from "./stateContextCheckpointsCache";
+import {CheckpointStateContextCache} from "./stateContextCheckpointsCache";
 import {SeenAttestationCache} from "./seenAttestationCache";
+import {CheckpointStateCache} from "./checkpointStateCache";
 
 export class BeaconDb extends DatabaseService implements IBeaconDb {
   public badBlock: BadBlockRepository;
   public block: BlockRepository;
   public stateCache: StateContextCache;
   public checkpointStateCache: CheckpointStateCache;
+  public checkpointStateCtxCache: CheckpointStateContextCache;
   public seenAttestationCache: SeenAttestationCache;
   public blockArchive: BlockArchiveRepository;
   public stateArchive: StateArchiveRepository;
@@ -47,7 +49,8 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
     this.badBlock = new BadBlockRepository(this.config, this.db);
     this.block = new BlockRepository(this.config, this.db);
     this.stateCache = new StateContextCache();
-    this.checkpointStateCache = new CheckpointStateCache(this.config);
+    this.checkpointStateCache = new CheckpointStateCache();
+    this.checkpointStateCtxCache = new CheckpointStateContextCache(this.config);
     this.seenAttestationCache = new SeenAttestationCache(5000);
     this.blockArchive = new BlockArchiveRepository(this.config, this.db);
     this.stateArchive = new StateArchiveRepository(this.config, this.db);

--- a/packages/lodestar/src/db/api/beacon/checkpointStateCache.ts
+++ b/packages/lodestar/src/db/api/beacon/checkpointStateCache.ts
@@ -1,7 +1,8 @@
 import {toHexString, fromHexString} from "@chainsafe/ssz";
 import {ITreeStateContext, clone} from "./stateContextCache";
 
-const MAX_STATES = 64;
+// 112 for StateContextCache
+const MAX_STATES = 16;
 
 /**
  * Checkpoint state is state of 1st block of each epoch.

--- a/packages/lodestar/src/db/api/beacon/checkpointStateCache.ts
+++ b/packages/lodestar/src/db/api/beacon/checkpointStateCache.ts
@@ -1,0 +1,94 @@
+import {toHexString, fromHexString} from "@chainsafe/ssz";
+import {ITreeStateContext} from "./stateContextCache";
+
+/**
+ * Checkpoint state is state of 1st block of each epoch.
+ */
+export class CheckpointStateCache {
+  // TODO: cache epoch to state root to produce weak subjectivity checkpoint state
+  // checkpoint state by root
+  private statesByRoot: Record<string, ITreeStateContext>;
+  // map a state root to its parent state root
+  private stateRootToParent: Record<string, string>;
+
+  constructor() {
+    this.statesByRoot = {};
+    this.stateRootToParent = {};
+  }
+
+  /**
+   * Return checkpoint state from a state root.
+   */
+  public async get(stateRoot: Uint8Array): Promise<ITreeStateContext | null> {
+    const item = this.statesByRoot[toHexString(stateRoot)];
+    if (!item) {
+      return null;
+    }
+    return this.clone(item);
+  }
+
+  /**
+   * Get state roots of parent until a checkpoint state.
+   * A -> B -> C -> D then getStateRootAncestors(D) returns [A, B, C, D] where A is checkpoint state.
+   */
+  public async getStateRootAncestors(stateRoot: Uint8Array): Promise<Uint8Array[] | null> {
+    return getStateRootAncestors(stateRoot, this.statesByRoot, this.stateRootToParent);
+  }
+
+  public async add(item: ITreeStateContext): Promise<void> {
+    const root = toHexString(item.state.hashTreeRoot());
+    this.statesByRoot[root] = this.clone(item);
+    this.stateRootToParent[root] = root;
+  }
+
+  public async addStateRoot(stateRoot: Uint8Array, parentStateRoot: Uint8Array): Promise<void> {
+    this.stateRootToParent[toHexString(stateRoot)] = toHexString(parentStateRoot);
+  }
+
+  public async delete(root: Uint8Array): Promise<void> {
+    const rootHex = toHexString(root);
+    delete this.statesByRoot[rootHex];
+    delete this.stateRootToParent[rootHex];
+  }
+
+  public async batchDelete(roots: Uint8Array[]): Promise<void> {
+    await Promise.all(roots.map((root) => this.delete(root)));
+  }
+
+  public clear(): void {
+    this.statesByRoot = {};
+    this.stateRootToParent = {};
+  }
+
+  public get size(): number {
+    return Object.keys(this.statesByRoot).length;
+  }
+
+  // TODO: move to util
+  private clone(item: ITreeStateContext): ITreeStateContext {
+    return {
+      state: item.state.clone(),
+      epochCtx: item.epochCtx.copy(),
+    };
+  }
+}
+
+export function getStateRootAncestors(
+  stateRoot: Uint8Array,
+  statesByRoot: Record<string, ITreeStateContext>,
+  stateRootToParent: Record<string, string>
+): Uint8Array[] | null {
+  const keys = Object.keys(statesByRoot);
+  let rootHex = toHexString(stateRoot);
+  const result: Uint8Array[] = [];
+  while (!keys.includes(rootHex) && stateRootToParent[rootHex]) {
+    result.unshift(fromHexString(rootHex));
+    rootHex = stateRootToParent[rootHex];
+  }
+  if (keys.includes(rootHex)) {
+    result.unshift(fromHexString(rootHex));
+    return result;
+  } else {
+    return null;
+  }
+}

--- a/packages/lodestar/src/db/api/beacon/interface.ts
+++ b/packages/lodestar/src/db/api/beacon/interface.ts
@@ -19,8 +19,9 @@ import {
   VoluntaryExitRepository,
 } from "./repositories";
 import {StateContextCache} from "./stateContextCache";
-import {CheckpointStateCache} from "./stateContextCheckpointsCache";
+import {CheckpointStateContextCache} from "./stateContextCheckpointsCache";
 import {SeenAttestationCache} from "./seenAttestationCache";
+import {CheckpointStateCache} from "./checkpointStateCache";
 
 /**
  * The DB service manages the data layer of the beacon chain
@@ -36,7 +37,11 @@ export interface IBeaconDb {
 
   // unfinalized states
   stateCache: StateContextCache;
+
+  // unfinalized states at the beginning of each epoch
   checkpointStateCache: CheckpointStateCache;
+
+  checkpointStateCtxCache: CheckpointStateContextCache;
 
   //cache
   seenAttestationCache: SeenAttestationCache;

--- a/packages/lodestar/src/db/api/beacon/stateContextCache.ts
+++ b/packages/lodestar/src/db/api/beacon/stateContextCache.ts
@@ -23,11 +23,11 @@ export class StateContextCache {
     if (!item) {
       return null;
     }
-    return this.clone(item);
+    return clone(item);
   }
 
   public async add(item: ITreeStateContext): Promise<void> {
-    this.cache[toHexString(item.state.hashTreeRoot())] = this.clone(item);
+    this.cache[toHexString(item.state.hashTreeRoot())] = clone(item);
   }
 
   public async delete(root: ByteVector): Promise<void> {
@@ -66,13 +66,13 @@ export class StateContextCache {
    * @param epoch
    */
   public async valuesUnsafe(): Promise<ITreeStateContext[]> {
-    return Object.values(this.cache).map((item) => this.clone(item));
+    return Object.values(this.cache).map((item) => clone(item));
   }
+}
 
-  private clone(item: ITreeStateContext): ITreeStateContext {
-    return {
-      state: item.state.clone(),
-      epochCtx: item.epochCtx.copy(),
-    };
-  }
+export function clone(item: ITreeStateContext): ITreeStateContext {
+  return {
+    state: item.state.clone(),
+    epochCtx: item.epochCtx.copy(),
+  };
 }

--- a/packages/lodestar/src/db/api/beacon/stateContextCache.ts
+++ b/packages/lodestar/src/db/api/beacon/stateContextCache.ts
@@ -7,6 +7,9 @@ export interface ITreeStateContext {
   epochCtx: EpochContext;
 }
 
+// 16 for CheckpointStateCache
+const MAX_STATES = 128;
+
 /**
  * In memory cache of BeaconState and connected EpochContext
  *
@@ -51,7 +54,6 @@ export class StateContextCache {
    * Without more thought, this currently breaks our assumptions about recent state availablity
    */
   public prune(): void {
-    const MAX_STATES = 128;
     const keys = Object.keys(this.cache);
     if (keys.length > MAX_STATES) {
       // object keys are stored in insertion order, delete keys starting from the front (but keeping the first)

--- a/packages/lodestar/src/db/api/beacon/stateContextCheckpointsCache.ts
+++ b/packages/lodestar/src/db/api/beacon/stateContextCheckpointsCache.ts
@@ -9,7 +9,7 @@ import {ITreeStateContext} from "./stateContextCache";
  *
  * Similar API to Repository
  */
-export class CheckpointStateCache {
+export class CheckpointStateContextCache {
   private readonly config: IBeaconConfig;
   private cache: Record<string, ITreeStateContext>;
   private epochIndex: Record<Epoch, string[]>;

--- a/packages/lodestar/src/network/gossip/utils.ts
+++ b/packages/lodestar/src/network/gossip/utils.ts
@@ -104,7 +104,7 @@ export async function getAttestationPreState(
   db: IBeaconDb,
   cp: Checkpoint
 ): Promise<ITreeStateContext | null> {
-  const preStateContext = await db.checkpointStateCache.get(cp);
+  const preStateContext = await db.checkpointStateCtxCache.get(cp);
   if (preStateContext) {
     return preStateContext;
   }
@@ -115,7 +115,7 @@ export async function getAttestationPreState(
   const epochStartSlot = computeStartSlotAtEpoch(config, cp.epoch);
   if (epochStartSlot > baseState.state.slot) {
     processSlots(baseState.epochCtx, baseState.state, epochStartSlot);
-    await db.checkpointStateCache.add(cp, baseState);
+    await db.checkpointStateCtxCache.add(cp, baseState);
   }
   return baseState;
 }

--- a/packages/lodestar/src/tasks/index.ts
+++ b/packages/lodestar/src/tasks/index.ts
@@ -72,6 +72,11 @@ export class TasksService implements IService {
 
   private handleFinalizedCheckpointChores = async (finalized: BlockSummary, pruned: BlockSummary[]): Promise<void> => {
     await new ArchiveBlocksTask(this.config, {db: this.db, logger: this.logger}, finalized, pruned).run();
-    await new ArchiveStatesTask(this.config, {db: this.db, logger: this.logger}, finalized, pruned).run();
+    await new ArchiveStatesTask(
+      this.config,
+      {db: this.db, chain: this.chain, logger: this.logger},
+      finalized,
+      pruned
+    ).run();
   };
 }

--- a/packages/lodestar/src/tasks/tasks/archiveStates.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveStates.ts
@@ -58,7 +58,7 @@ export class ArchiveStatesTask implements ITask {
     const prunedStates = this.pruned.map((summary) => summary.stateRoot);
     await Promise.all([
       this.db.stateCache.batchDelete(prunedStates),
-      this.db.checkpointStateCache.batchDelete(prunedStates),
+      this.db.checkpointStateCache.prune(this.finalized.stateRoot, prunedStates),
     ]);
     this.logger.info(`Archiving of finalized states completed (finalized epoch #${epoch})`);
     this.logger.profile("Archive States");

--- a/packages/lodestar/test/unit/chain/chain.test.ts
+++ b/packages/lodestar/test/unit/chain/chain.test.ts
@@ -1,7 +1,7 @@
 import chainOpts from "../../../src/chain/options";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import sinon from "sinon";
-import {expect} from "chai";
+import sinon, {SinonStub} from "sinon";
+import {expect, assert} from "chai";
 import {IEth1Provider, Eth1Provider} from "../../../src/eth1";
 import eth1Options from "../../../src/eth1/options";
 import {bytesToInt, WinstonLogger} from "@chainsafe/lodestar-utils";
@@ -11,20 +11,26 @@ import {generateState} from "../../utils/state";
 import {StubbedBeaconDb} from "../../utils/stub";
 import {generateValidators} from "../../utils/validator";
 
-import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
+import {EpochContext, ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
 import {TreeBacked} from "@chainsafe/ssz";
 import {BeaconState} from "@chainsafe/lodestar-types";
+import {initBLS} from "@chainsafe/bls";
+import {generateEmptySignedBlock} from "../../utils/block";
+import * as processBlock from "../../../src/chain/blocks/process";
 
 describe("BeaconChain", function () {
   const sandbox = sinon.createSandbox();
   let dbStub: StubbedBeaconDb, eth1Provider: IEth1Provider, metrics: any;
+  let runStateTransitionStub: SinonStub;
   const logger = new WinstonLogger();
   let chain: IBeaconChain;
 
   beforeEach(async () => {
+    await initBLS();
     dbStub = new StubbedBeaconDb(sandbox);
     eth1Provider = new Eth1Provider(config, eth1Options);
     metrics = new BeaconMetrics({enabled: false} as any, {logger});
+    runStateTransitionStub = sandbox.stub(processBlock, "runStateTransition");
     const state: BeaconState = generateState();
     state.validators = generateValidators(5, {activationEpoch: 0});
     dbStub.stateCache.get.resolves({state: state as TreeBacked<BeaconState>, epochCtx: new EpochContext(config)});
@@ -79,6 +85,52 @@ describe("BeaconChain", function () {
       chain.emitter.emit("forkVersion");
       await received;
       expect(spy.callCount).to.be.equal(1);
+    });
+  });
+
+  describe("getState", () => {
+    it("should get state from cache", async () => {
+      const state = await chain.getState(ZERO_HASH);
+      expect(!!state).to.be.true;
+      expect(dbStub.checkpointStateCache.getStateRootAncestors.calledOnce).to.be.false;
+    });
+
+    it("should call checkpointStateCache and throw error", async () => {
+      dbStub.stateCache.get.resolves(null);
+      try {
+        await chain.getState(ZERO_HASH);
+        assert.fail("Expect error thrown");
+      } catch (err) {
+        expect(dbStub.checkpointStateCache.getStateRootAncestors.calledOnce).to.be.true;
+      }
+    });
+
+    it("should replay blocks to create state", async () => {
+      dbStub.stateCache.get.resolves(null);
+      dbStub.checkpointStateCache.getStateRootAncestors.resolves([ZERO_HASH, ZERO_HASH]);
+      const state1 = generateState();
+      const epochContext1 = new EpochContext(config);
+      dbStub.checkpointStateCache.get.resolves({
+        state: state1,
+        epochCtx: epochContext1,
+      });
+      chain.forkChoice.getBlockSummariesByAncestorBlockRoot = () => [
+        {
+          blockRoot: ZERO_HASH,
+          parentRoot: ZERO_HASH,
+          stateRoot: ZERO_HASH,
+          slot: 0,
+          finalizedCheckpoint: {epoch: 0, root: ZERO_HASH},
+          justifiedCheckpoint: {epoch: 0, root: ZERO_HASH},
+        },
+      ];
+      dbStub.block.get.resolves(generateEmptySignedBlock());
+      runStateTransitionStub.resolves({
+        state: state1,
+        epoch: epochContext1,
+      });
+      await chain.getState(ZERO_HASH);
+      expect(runStateTransitionStub.calledOnce).to.be.true;
     });
   });
 });

--- a/packages/lodestar/test/unit/db/api/beacon/checkpointStateCache.test.ts
+++ b/packages/lodestar/test/unit/db/api/beacon/checkpointStateCache.test.ts
@@ -1,0 +1,41 @@
+import {generateState} from "../../../../utils/state";
+import {toHexString, TreeBacked} from "@chainsafe/ssz";
+import {EpochContext, ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import {ITreeStateContext} from "../../../../../src/db/api/beacon/stateContextCache";
+import {BeaconState} from "@chainsafe/lodestar-types";
+import {expect} from "chai";
+import {getStateRootAncestors} from "../../../../../src/db/api/beacon/checkpointStateCache";
+
+describe("getStateRootAncestors", function () {
+  let statesByRoot: Record<string, ITreeStateContext>;
+  let stateRootToParent: Record<string, string>;
+  let state1: TreeBacked<BeaconState>;
+  let state2: TreeBacked<BeaconState>;
+
+  beforeEach(() => {
+    statesByRoot = {};
+    state1 = generateState();
+    state1.slot = 10;
+    state2 = generateState();
+    state2.slot = 11;
+    const epochContext1 = new EpochContext(config);
+    statesByRoot[toHexString(state1.hashTreeRoot())] = {
+      state: state1,
+      epochCtx: epochContext1,
+    };
+    stateRootToParent = {};
+    stateRootToParent[toHexString(state2.hashTreeRoot())] = toHexString(state1.hashTreeRoot());
+  });
+
+  it("should return correct state root array", () => {
+    const state1Root = state1.hashTreeRoot();
+    const state2Root = state2.hashTreeRoot();
+    expect(getStateRootAncestors(state2Root, statesByRoot, stateRootToParent)).to.be.deep.equal([state1Root, state2Root]);
+    expect(getStateRootAncestors(state1Root, statesByRoot, stateRootToParent)).to.be.deep.equal([state1Root]);
+  });
+
+  it("should return null", () => {
+    expect(getStateRootAncestors(ZERO_HASH, statesByRoot, stateRootToParent)).to.be.null;
+  });
+});

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -81,6 +81,10 @@ export class MockBeaconChain implements IBeaconChain {
     return (await this.getHeadStateContext()).state;
   }
 
+  public async getState(stateRoot: Uint8Array): Promise<TreeBacked<BeaconState>> {
+    return (await this.getHeadStateContext()).state;
+  }
+
   public async getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<SignedBeaconBlock[] | null> {
     if (!slots) {
       return [];

--- a/packages/lodestar/test/utils/stub/beaconDb.ts
+++ b/packages/lodestar/test/utils/stub/beaconDb.ts
@@ -18,7 +18,8 @@ import {
 } from "../../../src/db/api/beacon/repositories";
 import {StateContextCache} from "../../../src/db/api/beacon/stateContextCache";
 import {SeenAttestationCache} from "../../../src/db/api/beacon/seenAttestationCache";
-import {CheckpointStateCache} from "../../../src/db/api/beacon/stateContextCheckpointsCache";
+import {CheckpointStateContextCache} from "../../../src/db/api/beacon/stateContextCheckpointsCache";
+import {CheckpointStateCache} from "../../../src/db/api/beacon/checkpointStateCache";
 import {config as minimalConfig} from "@chainsafe/lodestar-config/lib/presets/minimal";
 
 export class StubbedBeaconDb extends BeaconDb {
@@ -27,6 +28,7 @@ export class StubbedBeaconDb extends BeaconDb {
   public badBlock: SinonStubbedInstance<BadBlockRepository> & BadBlockRepository;
   public block: SinonStubbedInstance<BlockRepository> & BlockRepository;
   public stateCache: SinonStubbedInstance<StateContextCache> & StateContextCache;
+  public checkpointStateCache: SinonStubbedInstance<CheckpointStateCache> & CheckpointStateCache;
   public blockArchive: SinonStubbedInstance<BlockArchiveRepository> & BlockArchiveRepository;
   public stateArchive: SinonStubbedInstance<StateArchiveRepository> & StateArchiveRepository;
 
@@ -40,7 +42,7 @@ export class StubbedBeaconDb extends BeaconDb {
   public depositDataRoot: SinonStubbedInstance<DepositDataRootRepository> & DepositDataRootRepository;
   public eth1Data: SinonStubbedInstance<Eth1DataRepository> & Eth1DataRepository;
 
-  public checkpointStateCache: SinonStubbedInstance<CheckpointStateCache> & CheckpointStateCache;
+  public checkpointStateCtxCache: SinonStubbedInstance<CheckpointStateContextCache> & CheckpointStateContextCache;
   public seenAttestationCache: SinonStubbedInstance<SeenAttestationCache> & SeenAttestationCache;
 
   public processBlockOperations: SinonStubbedInstance<(signedBlock: SignedBeaconBlock) => Promise<void>> &
@@ -52,6 +54,7 @@ export class StubbedBeaconDb extends BeaconDb {
     this.badBlock = sinon.createStubInstance(BadBlockRepository) as any;
     this.block = sinon.createStubInstance(BlockRepository) as any;
     this.stateCache = sinon.createStubInstance(StateContextCache) as any;
+    this.checkpointStateCache = sinon.createStubInstance(CheckpointStateCache) as any;
     this.blockArchive = sinon.createStubInstance(BlockArchiveRepository) as any;
     this.stateArchive = sinon.createStubInstance(StateArchiveRepository) as any;
 
@@ -65,7 +68,7 @@ export class StubbedBeaconDb extends BeaconDb {
     this.depositDataRoot = sinon.createStubInstance(DepositDataRootRepository) as any;
     this.eth1Data = sinon.createStubInstance(Eth1DataRepository) as any;
     this.seenAttestationCache = sinon.createStubInstance(SeenAttestationCache) as any;
-    this.checkpointStateCache = sinon.createStubInstance(CheckpointStateCache) as any;
+    this.checkpointStateCtxCache = sinon.createStubInstance(CheckpointStateContextCache) as any;
     this.processBlockOperations = sinon.stub(this, "processBlockOperations") as any;
   }
 }


### PR DESCRIPTION
resolves #1508 

+ Implement checkpoint state cache - state and epoch context at 1st block of each epoch
+ Old item is pruned in ArchiveTasks
+ CheckpointStateCache stores a map of  state root to its parent state root, it helps us know how to replay blocks
+ To form a state from state root, trace state roots in CheckpointStateCache until a checkpoint state and replay blocks from there
+ Only use CheckpointStateCache if state is not available in the regular StateContextCache

## Testing
+ At slot 18k/epoch 560 for now and not see the error `No state cache in db for finalized stateRoot` anymore, need some more time to test