### PR TITLE
Save checkpoint states in block processor

### DIFF
--- a/packages/lodestar/src/chain/blocks/convertBlock.ts
+++ b/packages/lodestar/src/chain/blocks/convertBlock.ts
@@ -1,5 +1,5 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {IBlockProcessJob} from "../chain";
+import {IBlockProcessJob} from "../interface";
 
 /**
  * Convert incoming blocks to TreeBacked backing

--- a/packages/lodestar/src/chain/blocks/pool.ts
+++ b/packages/lodestar/src/chain/blocks/pool.ts
@@ -3,7 +3,7 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {SignedBeaconBlock} from "@chainsafe/lodestar-types";
 import {toHexString} from "@chainsafe/ssz";
 
-import {IBlockProcessJob} from "../chain";
+import {IBlockProcessJob} from "../interface";
 import {ChainEventEmitter} from "../emitter";
 import {ILMDGHOST} from "../forkChoice";
 

--- a/packages/lodestar/src/chain/blocks/post.ts
+++ b/packages/lodestar/src/chain/blocks/post.ts
@@ -41,10 +41,6 @@ export function postProcess(
         const preJustifiedEpoch = preStateContext.state.currentJustifiedCheckpoint.epoch;
         const currentEpoch = computeEpochAtSlot(config, postStateContext.state.slot);
         if (computeEpochAtSlot(config, preSlot) < currentEpoch) {
-          eventBus.emit("checkpoint", {
-            epoch: currentEpoch,
-            root: block.message.parentRoot,
-          });
           // newly justified epoch
           if (preJustifiedEpoch < postStateContext.state.currentJustifiedCheckpoint.epoch) {
             newJustifiedEpoch(logger, metrics, eventBus, postStateContext.state);

--- a/packages/lodestar/src/chain/blocks/process.ts
+++ b/packages/lodestar/src/chain/blocks/process.ts
@@ -169,8 +169,7 @@ export async function runStateTransition(
       verifyProposer: !job.trusted,
       verifySignatures: !job.trusted,
     }) as ITreeStateContext;
-    const blockSlot = job.signedBlock.message.slot;
-    if (blockSlot % SLOTS_PER_EPOCH === 0) {
+    if (postSlot % SLOTS_PER_EPOCH === 0) {
       emitCheckpointEvent(emitter, postStateContext);
     }
     return postStateContext;

--- a/packages/lodestar/src/chain/blocks/process.ts
+++ b/packages/lodestar/src/chain/blocks/process.ts
@@ -3,6 +3,7 @@ import {
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   fastStateTransition,
+  ZERO_HASH,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {IStateContext} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 import {processSlots} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/slot";
@@ -134,10 +135,14 @@ export function emitCheckpointEvent(emitter: ChainEventEmitter, checkpointStateC
   const config = checkpointStateContext.epochCtx.config;
   const slot = checkpointStateContext.state.slot;
   assert.true(slot % config.params.SLOTS_PER_EPOCH === 0, "Checkpoint state slot must be first in an epoch");
+  const blockHeader = config.types.BeaconBlockHeader.clone(checkpointStateContext.state.latestBlockHeader);
+  if (config.types.Root.equals(blockHeader.stateRoot, ZERO_HASH)) {
+    blockHeader.stateRoot = config.types.BeaconState.hashTreeRoot(checkpointStateContext.state);
+  }
   emitter.emit(
     "checkpoint",
     {
-      root: config.types.BeaconBlockHeader.hashTreeRoot(checkpointStateContext.state.latestBlockHeader),
+      root: config.types.BeaconBlockHeader.hashTreeRoot(blockHeader),
       epoch: computeEpochAtSlot(config, slot),
     },
     checkpointStateContext

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -11,11 +11,10 @@ import {processBlock} from "./process";
 import {BlockPool} from "./pool";
 import {postProcess} from "./post";
 import {IService} from "../../node";
-import {IBlockProcessJob} from "../chain";
 import {IBeaconDb} from "../../db/api";
 import {ILMDGHOST} from "../forkChoice";
 import {IBeaconMetrics} from "../../metrics";
-import {IAttestationProcessor} from "../interface";
+import {IAttestationProcessor, IBlockProcessJob} from "../interface";
 import {ChainEventEmitter} from "../emitter";
 import {convertBlock} from "./convertBlock";
 

--- a/packages/lodestar/src/chain/blocks/validate.ts
+++ b/packages/lodestar/src/chain/blocks/validate.ts
@@ -1,9 +1,9 @@
-import {IBlockProcessJob} from "../chain";
 import {toHexString} from "@chainsafe/ssz";
 import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {ILMDGHOST} from "../forkChoice";
+import {IBlockProcessJob} from "../interface";
 import {ChainEventEmitter} from "../emitter";
 
 export function validateBlock(

--- a/packages/lodestar/src/chain/emitter.ts
+++ b/packages/lodestar/src/chain/emitter.ts
@@ -4,12 +4,14 @@ import StrictEventEmitter from "strict-event-emitter-types";
 import {Attestation, Checkpoint, Epoch, ForkDigest, Root, SignedBeaconBlock, Slot} from "@chainsafe/lodestar-types";
 
 import {BlockSummary} from "./forkChoice";
+import {ITreeStateContext} from "../db/api/beacon/stateContextCache";
+import {BlockError} from "./interface";
 
 export interface IChainEvents {
   // old, to be deprecated
   unknownBlockRoot: (root: Root) => void;
   block: (signedBlock: SignedBeaconBlock) => void;
-  checkpoint: (checkpoint: Checkpoint) => void;
+  checkpoint: (checkpoint: Checkpoint, stateContext: ITreeStateContext) => void;
   attestation: (attestation: Attestation) => void;
   justified: (checkpoint: Checkpoint) => void;
   finalized: (checkpoint: Checkpoint) => void;
@@ -19,6 +21,8 @@ export interface IChainEvents {
   // new
   "clock:slot": (slot: Slot) => void;
   "clock:epoch": (epoch: Epoch) => void;
+
+  "error:block": (error: BlockError) => void;
 
   "forkChoice:head": (head: BlockSummary) => void;
   "forkChoice:reorg": (head: BlockSummary, oldHead: BlockSummary) => void;

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -20,6 +20,17 @@ import {ITreeStateContext} from "../db/api/beacon/stateContextCache";
 import {IService} from "../node";
 import {ChainEventEmitter} from "./emitter";
 
+export interface IBlockProcessJob {
+  signedBlock: SignedBeaconBlock;
+  trusted: boolean;
+  reprocess: boolean;
+}
+
+export type BlockError = {
+  message?: string;
+  job: IBlockProcessJob;
+};
+
 /**
  * The IBeaconChain service deals with processing incoming blocks, advancing a state transition
  * and applying the fork choice rule to update the chain head

--- a/packages/lodestar/test/unit/chain/blocks/post.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/post.test.ts
@@ -88,8 +88,6 @@ describe("post block process stream", function () {
     );
     expect(slotMetricsStub.set.withArgs(0).calledOnce).to.be.true;
     // @ts-ignore
-    expect(eventBusStub.emit.withArgs("checkpoint").calledOnce).to.be.true;
-    // @ts-ignore
     expect(dbStub.processBlockOperations.calledOnce).to.be.true;
     expect(attestationProcessorStub.receiveBlock.calledOnce).to.be.true;
   });
@@ -117,8 +115,6 @@ describe("post block process stream", function () {
       postProcess(config, logger, dbStub, forkChoiceStub, metricsStub, eventBusStub, attestationProcessorStub)
     );
     expect(slotMetricsStub.set.withArgs(0).calledOnce).to.be.true;
-    // @ts-ignore
-    expect(eventBusStub.emit.withArgs("checkpoint").calledOnce).to.be.true;
     // @ts-ignore
     expect(dbStub.processBlockOperations.calledOnce).to.be.true;
     expect(attestationProcessorStub.receiveBlock.calledOnce).to.be.true;

--- a/packages/lodestar/test/unit/chain/blocks/process.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/process.test.ts
@@ -78,7 +78,7 @@ describe("block process stream", function () {
     forkChoiceStub.getBlockSummaryByBlockRoot
       .withArgs(receivedJob.signedBlock.message.parentRoot.valueOf() as Uint8Array)
       .resolves(parentBlock);
-    dbStub.stateCache.get.resolves(generateState() as any);
+    dbStub.stateCache.get.resolves({state: generateState(), epochCtx: new EpochContext(config)});
     stateTransitionStub.throws();
     const result = await pipe(
       [receivedJob],
@@ -86,7 +86,7 @@ describe("block process stream", function () {
       collect
     );
     expect(result).to.have.length(0);
-    expect(dbStub.badBlock.put.calledOnce).to.be.true;
+    expect(eventBusStub.emit.calledWith("error:block" as any)).to.be.true;
   });
 
   it("successful block process - not new chain head", async function () {
@@ -99,7 +99,7 @@ describe("block process stream", function () {
     forkChoiceStub.getBlockSummaryByBlockRoot
       .withArgs(receivedJob.signedBlock.message.parentRoot.valueOf() as Uint8Array)
       .resolves(parentBlock);
-    dbStub.stateCache.get.resolves(generateState() as any);
+    dbStub.stateCache.get.resolves({state: generateState(), epochCtx: new EpochContext(config)});
     stateTransitionStub.resolves({state: generateState(), epochCtx: new EpochContext(config)});
     //dbStub.chain.getChainHeadRoot.resolves(Buffer.alloc(32, 1));
     forkChoiceStub.headBlockRoot.returns(Buffer.alloc(32, 1));
@@ -109,7 +109,6 @@ describe("block process stream", function () {
       collect
     );
     expect(result).to.have.length(1);
-    expect(dbStub.badBlock.put.notCalled).to.be.true;
     expect(dbStub.block.put.calledOnce).to.be.true;
     expect(dbStub.stateCache.add.calledOnce).to.be.true;
     expect(blockPoolStub.onProcessedBlock.calledOnce).to.be.true;
@@ -125,7 +124,7 @@ describe("block process stream", function () {
     forkChoiceStub.getBlockSummaryByBlockRoot
       .withArgs(receivedJob.signedBlock.message.parentRoot.valueOf() as Uint8Array)
       .resolves(parentBlock);
-    dbStub.stateCache.get.resolves(generateState() as any);
+    dbStub.stateCache.get.resolves({state: generateState(), epochCtx: new EpochContext(config)});
     stateTransitionStub.returns({state: generateState(), epochCtx: new EpochContext(config)});
     forkChoiceStub.headBlockRoot.returns(Buffer.alloc(32, 2));
     dbStub.depositData.values.resolves([]);
@@ -137,7 +136,6 @@ describe("block process stream", function () {
       collect
     );
     expect(result).to.have.length(1);
-    expect(dbStub.badBlock.put.notCalled).to.be.true;
     expect(dbStub.block.put.calledOnce).to.be.true;
     expect(dbStub.stateCache.add.calledOnce).to.be.true;
     expect(blockPoolStub.onProcessedBlock.calledOnce).to.be.true;

--- a/packages/lodestar/test/unit/chain/blocks/process.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/process.test.ts
@@ -100,7 +100,7 @@ describe("block process stream", function () {
       .withArgs(receivedJob.signedBlock.message.parentRoot.valueOf() as Uint8Array)
       .resolves(parentBlock);
     dbStub.stateCache.get.resolves({state: generateState(), epochCtx: new EpochContext(config)});
-    stateTransitionStub.resolves({state: generateState(), epochCtx: new EpochContext(config)});
+    stateTransitionStub.returns({state: generateState(), epochCtx: new EpochContext(config)});
     //dbStub.chain.getChainHeadRoot.resolves(Buffer.alloc(32, 1));
     forkChoiceStub.headBlockRoot.returns(Buffer.alloc(32, 1));
     const result = await pipe(

--- a/packages/lodestar/test/unit/sync/initial/fast.test.ts
+++ b/packages/lodestar/test/unit/sync/initial/fast.test.ts
@@ -93,8 +93,8 @@ describe("fast sync", function () {
       done();
     });
     sync.start();
-    chainStub.emitter.emit("checkpoint", {epoch: 1, root: Buffer.alloc(32)} as Checkpoint);
-    chainStub.emitter.emit("checkpoint", target);
+    chainStub.emitter.emit("checkpoint", {epoch: 1, root: Buffer.alloc(32)} as Checkpoint, {} as any);
+    chainStub.emitter.emit("checkpoint", target, {} as any);
   });
 
   //TODO: make sync abortable (test hangs on sleeping 6s when waiting for peers)
@@ -133,7 +133,7 @@ describe("fast sync", function () {
       done();
     });
     sync.start();
-    chainStub.emitter.emit("checkpoint", target1);
-    chainStub.emitter.emit("checkpoint", target2);
+    chainStub.emitter.emit("checkpoint", target1, {} as any);
+    chainStub.emitter.emit("checkpoint", target2, {} as any);
   });
 });


### PR DESCRIPTION
This PR centers around splitting up the state transition inside our block processor to expose true checkpoint states (eg: states where `state.slot % SLOTS_PER_EPOCH === 0`).
We do this by stopping after each epoch transition, and emitting the state directly after the epoch transition.
(This can be extended to `await` and allow other tasks to complete after each epoch :dancers: )

This PR doesn't change any behavior, just adds an additional source of data for the checkpoint state cache. In the future, we can persist some of these states or use the checkpoint state cache to regenerate pruned states.