### PR TITLE
Add Eth1Blocks cache for eth1 data for block production

### DIFF
--- a/packages/lodestar/src/db/api/beacon/beacon.ts
+++ b/packages/lodestar/src/db/api/beacon/beacon.ts
@@ -18,6 +18,7 @@ import {
   ProposerSlashingRepository,
   StateArchiveRepository,
   VoluntaryExitRepository,
+  Eth1BlockRepository,
 } from "./repositories";
 import {StateContextCache} from "./stateContextCache";
 import {CheckpointStateCache} from "./stateContextCheckpointsCache";
@@ -41,6 +42,7 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
 
   public depositDataRoot: DepositDataRootRepository;
   public eth1Data: Eth1DataRepository;
+  public eth1Block: Eth1BlockRepository;
 
   public constructor(opts: IDatabaseApiOptions) {
     super(opts);
@@ -59,6 +61,7 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
     this.depositData = new DepositDataRepository(this.config, this.db);
     this.depositDataRoot = new DepositDataRootRepository(this.config, this.db);
     this.eth1Data = new Eth1DataRepository(this.config, this.db);
+    this.eth1Block = new Eth1BlockRepository(this.config, this.db);
   }
 
   /**

--- a/packages/lodestar/src/db/api/beacon/interface.ts
+++ b/packages/lodestar/src/db/api/beacon/interface.ts
@@ -14,6 +14,7 @@ import {
   DepositDataRepository,
   DepositDataRootRepository,
   Eth1DataRepository,
+  Eth1BlockRepository,
   ProposerSlashingRepository,
   StateArchiveRepository,
   VoluntaryExitRepository,
@@ -54,6 +55,7 @@ export interface IBeaconDb {
   proposerSlashing: ProposerSlashingRepository;
   attesterSlashing: AttesterSlashingRepository;
   depositData: DepositDataRepository;
+  eth1Block: Eth1BlockRepository;
 
   // eth1 processing
 

--- a/packages/lodestar/src/db/api/beacon/repositories/eth1Block.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/eth1Block.ts
@@ -1,0 +1,25 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IEth1Block, Eth1BlockGenerator} from "../../../../eth1/types";
+
+import {IDatabaseController} from "../../../controller";
+import {Bucket} from "../../schema";
+import {Repository} from "./abstract";
+
+export class Eth1BlockRepository extends Repository<number, IEth1Block> {
+  public constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
+    super(config, db, Bucket.eth1Block, Eth1BlockGenerator(config.types));
+  }
+
+  public async deleteOld(upToBlockNumber: number): Promise<void> {
+    await this.batchDelete(await this.keys({lt: upToBlockNumber}));
+  }
+
+  public async batchPutValues(blocks: IEth1Block[]): Promise<void> {
+    await this.batchPut(
+      blocks.map((block) => ({
+        key: block.number,
+        value: block,
+      }))
+    );
+  }
+}

--- a/packages/lodestar/src/db/api/beacon/repositories/index.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/index.ts
@@ -14,3 +14,4 @@ export * from "./voluntaryExit";
 
 export * from "./depositDataRoot";
 export * from "./eth1Data";
+export * from "./eth1Block";

--- a/packages/lodestar/src/db/api/schema.ts
+++ b/packages/lodestar/src/db/api/schema.ts
@@ -34,6 +34,8 @@ export enum Bucket {
   validator,
   lastProposedBlock,
   proposedAttestations,
+  // Added latter
+  eth1Block,
 }
 
 export enum Key {

--- a/packages/lodestar/src/eth1/eth1BlocksCache.ts
+++ b/packages/lodestar/src/eth1/eth1BlocksCache.ts
@@ -1,0 +1,42 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IBeaconDb} from "../db";
+import {IEth1Block} from "./types";
+
+/**
+ * Stores eth1 block headers.
+ * To construct a full eth1Data object, use the DepositCache
+ */
+export class Eth1BlockCache {
+  db: IBeaconDb;
+  config: IBeaconConfig;
+
+  constructor(config: IBeaconConfig, db: IBeaconDb) {
+    this.config = config;
+    this.db = db;
+  }
+
+  async insertBlockHeaders(blockHeaders: IEth1Block[]): Promise<void> {
+    await this.db.eth1Block.batchPutValues(blockHeaders);
+  }
+
+  /**
+   * Returns a stream of blocks from DB
+   * Blocks a guaranteed to be returned with;
+   * - Monotonically decreasing block numbers.
+   * - Non-uniformly decreasing block timestamps.
+   *
+   * Eth1 blocks should be pruned regularly at the end of an Eth1 voting period,
+   * so there should never be a significant amount of blocks to read
+   */
+  getReverseStream(): AsyncIterable<IEth1Block> {
+    return this.db.eth1Block.valuesStream({reverse: true});
+  }
+
+  /**
+   * Returns the highest blockNumber stored in DB if any
+   */
+  async getHighestBlockNumber(): Promise<number | null> {
+    const lastestBlockHeader = await this.db.eth1Block.lastValue();
+    return lastestBlockHeader && lastestBlockHeader.number;
+  }
+}

--- a/packages/lodestar/src/eth1/types.ts
+++ b/packages/lodestar/src/eth1/types.ts
@@ -1,0 +1,17 @@
+import {Bytes32, Number64, IBeaconSSZTypes} from "@chainsafe/lodestar-types";
+import {ContainerType} from "@chainsafe/ssz";
+
+export interface IEth1Block {
+  hash: Bytes32;
+  number: Number64;
+  timestamp: Number64;
+}
+
+export const Eth1BlockGenerator = (ssz: IBeaconSSZTypes): ContainerType<IEth1Block> =>
+  new ContainerType({
+    fields: {
+      hash: ssz.Bytes32,
+      number: ssz.Number64,
+      timestamp: ssz.Number64,
+    },
+  });


### PR DESCRIPTION
Adds a new repository to the DB and it's wrapper `Eth1BlockCache`. Part of https://github.com/ChainSafe/lodestar/pull/1518. See https://github.com/ChainSafe/lodestar/pull/1518 for an overview of the target architecture that this component will be part of.

The current repository `eth1Data` will be deprecated. Eth1 data is best fetched and stored separately: (1) `blockHash` fetched from block headers directly, and (2) `depositCount` and `depositRoot` fetched from the deposit logs directly.