### PR TITLE
Add Eth1DepositsCache cache for eth1 data for block production

### DIFF
--- a/packages/lodestar/src/db/api/beacon/beacon.ts
+++ b/packages/lodestar/src/db/api/beacon/beacon.ts
@@ -16,6 +16,7 @@ import {
   DepositDataRootRepository,
   Eth1DataRepository,
   DepositEventRepository,
+  Eth1DataDepositRepository,
   ProposerSlashingRepository,
   StateArchiveRepository,
   VoluntaryExitRepository,
@@ -43,6 +44,7 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
   public depositDataRoot: DepositDataRootRepository;
   public eth1Data: Eth1DataRepository;
   public depositEvent: DepositEventRepository;
+  public eth1DataDeposit: Eth1DataDepositRepository;
 
   public constructor(opts: IDatabaseApiOptions) {
     super(opts);
@@ -62,6 +64,7 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
     this.depositDataRoot = new DepositDataRootRepository(this.config, this.db);
     this.eth1Data = new Eth1DataRepository(this.config, this.db);
     this.depositEvent = new DepositEventRepository(this.config, this.db);
+    this.eth1DataDeposit = new Eth1DataDepositRepository(this.config, this.db);
   }
 
   /**

--- a/packages/lodestar/src/db/api/beacon/beacon.ts
+++ b/packages/lodestar/src/db/api/beacon/beacon.ts
@@ -15,6 +15,7 @@ import {
   DepositDataRepository,
   DepositDataRootRepository,
   Eth1DataRepository,
+  DepositEventRepository,
   ProposerSlashingRepository,
   StateArchiveRepository,
   VoluntaryExitRepository,
@@ -41,6 +42,7 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
 
   public depositDataRoot: DepositDataRootRepository;
   public eth1Data: Eth1DataRepository;
+  public depositEvent: DepositEventRepository;
 
   public constructor(opts: IDatabaseApiOptions) {
     super(opts);
@@ -59,6 +61,7 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
     this.depositData = new DepositDataRepository(this.config, this.db);
     this.depositDataRoot = new DepositDataRootRepository(this.config, this.db);
     this.eth1Data = new Eth1DataRepository(this.config, this.db);
+    this.depositEvent = new DepositEventRepository(this.config, this.db);
   }
 
   /**

--- a/packages/lodestar/src/db/api/beacon/interface.ts
+++ b/packages/lodestar/src/db/api/beacon/interface.ts
@@ -15,6 +15,7 @@ import {
   DepositDataRootRepository,
   Eth1DataRepository,
   DepositEventRepository,
+  Eth1DataDepositRepository,
   ProposerSlashingRepository,
   StateArchiveRepository,
   VoluntaryExitRepository,
@@ -62,6 +63,7 @@ export interface IBeaconDb {
   depositDataRoot: DepositDataRootRepository;
   eth1Data: Eth1DataRepository;
   depositEvent: DepositEventRepository;
+  eth1DataDeposit: Eth1DataDepositRepository;
 
   processBlockOperations(signedBlock: SignedBeaconBlock): Promise<void>;
 }

--- a/packages/lodestar/src/db/api/beacon/interface.ts
+++ b/packages/lodestar/src/db/api/beacon/interface.ts
@@ -14,6 +14,7 @@ import {
   DepositDataRepository,
   DepositDataRootRepository,
   Eth1DataRepository,
+  DepositEventRepository,
   ProposerSlashingRepository,
   StateArchiveRepository,
   VoluntaryExitRepository,
@@ -60,6 +61,7 @@ export interface IBeaconDb {
   // all deposit data roots and merkle tree
   depositDataRoot: DepositDataRootRepository;
   eth1Data: Eth1DataRepository;
+  depositEvent: DepositEventRepository;
 
   processBlockOperations(signedBlock: SignedBeaconBlock): Promise<void>;
 }

--- a/packages/lodestar/src/db/api/beacon/repositories/depositDataRoot.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/depositDataRoot.ts
@@ -38,6 +38,15 @@ export class DepositDataRootRepository extends Repository<number, Root> {
     }
   }
 
+  public async batchPutValues(values: {index: number; root: Root}[]): Promise<void> {
+    await this.batchPut(
+      values.map((value) => ({
+        key: value.index,
+        value: value.root,
+      }))
+    );
+  }
+
   public async getTreeBacked(depositIndex: number): Promise<TreeBacked<List<Root>>> {
     const depositRootTree = await this.getDepositRootTree();
     const tree = depositRootTree.clone();
@@ -52,7 +61,7 @@ export class DepositDataRootRepository extends Repository<number, Root> {
     return tree;
   }
 
-  private async getDepositRootTree(): Promise<TreeBacked<List<Root>>> {
+  public async getDepositRootTree(): Promise<TreeBacked<List<Root>>> {
     if (!this.depositRootTree) {
       const values = (await this.values()) as List<Vector<number>>;
       this.depositRootTree = this.config.types.DepositDataRootList.tree.createValue(values);

--- a/packages/lodestar/src/db/api/beacon/repositories/depositEvent.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/depositEvent.ts
@@ -21,6 +21,15 @@ export class DepositEventRepository extends Repository<number, IDepositEvent> {
     await this.batchDelete(Array.from({length: depositCount - firstDepositIndex}, (_, i) => i + firstDepositIndex));
   }
 
+  public async batchPutValues(values: IDepositEvent[]): Promise<void> {
+    await this.batchPut(
+      values.map((value) => ({
+        key: value.index,
+        value,
+      }))
+    );
+  }
+
   /**
    * Returns deposit events in DB. Range is inclusive
    */

--- a/packages/lodestar/src/db/api/beacon/repositories/depositEvent.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/depositEvent.ts
@@ -1,0 +1,41 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IDepositEvent, DepositEventGenerator} from "../../../../eth1/types";
+
+import {IDatabaseController} from "../../../controller";
+import {Bucket} from "../../schema";
+import {Repository} from "./abstract";
+
+/**
+ * DepositEvent indexed by deposit index
+ */
+export class DepositEventRepository extends Repository<number, IDepositEvent> {
+  public constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
+    super(config, db, Bucket.depositEvent, DepositEventGenerator(config.types));
+  }
+
+  public async deleteOld(depositCount: number): Promise<void> {
+    const firstDepositIndex = await this.firstKey();
+    if (firstDepositIndex !== 0 && !firstDepositIndex) {
+      return;
+    }
+    await this.batchDelete(Array.from({length: depositCount - firstDepositIndex}, (_, i) => i + firstDepositIndex));
+  }
+
+  /**
+   * Returns deposit events in DB. Range is inclusive
+   */
+  public async getRange(fromIndex: number, toIndex: number): Promise<IDepositEvent[]> {
+    const depositDatas = await this.values({gte: fromIndex, lte: toIndex});
+
+    // DB may not return any deposits matching the query above
+    const expectedLength = toIndex - fromIndex;
+    if (depositDatas.length < expectedLength) {
+      throw Error("Not enough deposits in DB");
+    }
+    if (depositDatas.length > expectedLength) {
+      throw Error("Too many deposits returned by DB");
+    }
+
+    return depositDatas;
+  }
+}

--- a/packages/lodestar/src/db/api/beacon/repositories/eth1DataDeposit.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/eth1DataDeposit.ts
@@ -1,0 +1,16 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IEth1DataDeposit, Eth1DataDepositGenerator} from "../../../../eth1/types";
+
+import {IDatabaseController} from "../../../controller";
+import {Bucket} from "../../schema";
+import {Repository} from "./abstract";
+
+export class Eth1DataDepositRepository extends Repository<number, IEth1DataDeposit> {
+  public constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
+    super(config, db, Bucket.eth1DataDeposit, Eth1DataDepositGenerator(config.types));
+  }
+
+  public async deleteOld(upToBlockNumber: number): Promise<void> {
+    await this.batchDelete(await this.keys({lt: upToBlockNumber}));
+  }
+}

--- a/packages/lodestar/src/db/api/beacon/repositories/eth1DataDeposit.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/eth1DataDeposit.ts
@@ -13,4 +13,13 @@ export class Eth1DataDepositRepository extends Repository<number, IEth1DataDepos
   public async deleteOld(upToBlockNumber: number): Promise<void> {
     await this.batchDelete(await this.keys({lt: upToBlockNumber}));
   }
+
+  public async batchPutValues(values: IEth1DataDeposit[]): Promise<void> {
+    await this.batchPut(
+      values.map((value) => ({
+        key: value.blockNumber,
+        value,
+      }))
+    );
+  }
 }

--- a/packages/lodestar/src/db/api/beacon/repositories/index.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/index.ts
@@ -14,3 +14,4 @@ export * from "./voluntaryExit";
 
 export * from "./depositDataRoot";
 export * from "./eth1Data";
+export * from "./depositEvent";

--- a/packages/lodestar/src/db/api/beacon/repositories/index.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/index.ts
@@ -15,3 +15,4 @@ export * from "./voluntaryExit";
 export * from "./depositDataRoot";
 export * from "./eth1Data";
 export * from "./depositEvent";
+export * from "./eth1DataDeposit";

--- a/packages/lodestar/src/db/api/schema.ts
+++ b/packages/lodestar/src/db/api/schema.ts
@@ -36,6 +36,7 @@ export enum Bucket {
   proposedAttestations,
   // added latter
   depositEvent,
+  eth1DataDeposit,
 }
 
 export enum Key {

--- a/packages/lodestar/src/db/api/schema.ts
+++ b/packages/lodestar/src/db/api/schema.ts
@@ -34,6 +34,8 @@ export enum Bucket {
   validator,
   lastProposedBlock,
   proposedAttestations,
+  // added latter
+  depositEvent,
 }
 
 export enum Key {

--- a/packages/lodestar/src/eth1/eth1DepositCache.ts
+++ b/packages/lodestar/src/eth1/eth1DepositCache.ts
@@ -1,0 +1,110 @@
+import {Deposit} from "@chainsafe/lodestar-types";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IBeaconDb} from "../db";
+import {
+  getEth1DataDepositFromDeposits,
+  appendEth1DataDeposit,
+  assertConsecutiveDeposits,
+  getDepositsWithProofs,
+} from "./utils";
+import {IDepositEvent, IEth1Block, IEth1DataWithBlock} from "./types";
+
+export class Eth1DepositsCache {
+  db: IBeaconDb;
+  config: IBeaconConfig;
+
+  constructor(config: IBeaconConfig, db: IBeaconDb) {
+    this.config = config;
+    this.db = db;
+  }
+
+  /**
+   * Returns a list of `Deposit` objects, within the given deposit index `range`.
+   *
+   * The `depositCount` is used to generate the proofs for the `Deposits`. For example, if we
+   * have 100 proofs, but the eth2 chain only acknowledges 50 of them, we must produce our
+   * proofs with respect to a tree size of 50.
+   */
+  async getDeposits({
+    fromIndex,
+    toIndex,
+    depositCount,
+  }: {
+    fromIndex: number;
+    toIndex: number;
+    depositCount: number;
+  }): Promise<Deposit[]> {
+    if (depositCount < toIndex) {
+      throw Error("Deposit count requests more deposits than should exist");
+    }
+
+    // ### TODO: Range is inclusive or exclusive?
+    // Must assert that `toIndex <= logs.length`
+    const depositEvents = await this.db.depositEvent.getRange(fromIndex, toIndex);
+    const depositRootTree = await this.db.depositDataRoot.getDepositRootTree();
+    return getDepositsWithProofs(depositEvents, depositRootTree, depositCount);
+  }
+
+  /**
+   * Add deposit events to cache
+   * This function enforces that `logs` are imported one-by-one with no gaps between
+   * `log.index`, starting at `log.index == 0`.
+   */
+  async insertLogs(depositEvents: IDepositEvent[]): Promise<void> {
+    const lastLog = await this.db.depositEvent.lastValue();
+    const firstEvent = depositEvents[0];
+
+    if (lastLog) {
+      if (firstEvent.index <= lastLog.index) {
+        throw Error("DuplicateDistinctLog");
+      }
+      if (firstEvent.index > lastLog.index + 1) {
+        throw Error("Non consecutive logs");
+      }
+    }
+    assertConsecutiveDeposits(depositEvents);
+
+    // Pre-compute partial eth1 data from deposits
+    // Add data for both getEth1DataDepositFromDeposits and db.depositDataRoot.batchPut
+    const depositRootTree = await this.db.depositDataRoot.getDepositRootTree();
+    const depositRoots = depositEvents.map((depositEvent) => ({
+      blockNumber: depositEvent.blockNumber,
+      index: depositEvent.index,
+      root: this.config.types.DepositData.hashTreeRoot(depositEvent.depositData),
+    }));
+    const eth1DatasDeposit = getEth1DataDepositFromDeposits(depositRoots, depositRootTree);
+
+    // Store everything in batch at once
+    await Promise.all([
+      this.db.depositEvent.batchPutValues(depositEvents),
+      this.db.depositDataRoot.batchPutValues(depositRoots),
+      this.db.eth1DataDeposit.batchPutValues(eth1DatasDeposit),
+    ]);
+  }
+
+  /**
+   * Appends partial eth1 data (depositRoot, depositCount) in a block range (inclusive)
+   * Returned array is sequential and ascending in blockNumber
+   * @param fromBlock
+   * @param toBlock
+   */
+  async appendEth1DataDeposit(
+    blocks: IEth1Block[],
+    lastProcessedDepositBlockNumber?: number
+  ): Promise<IEth1DataWithBlock[]> {
+    const highestBlock = blocks[blocks.length - 1]?.number;
+    return await appendEth1DataDeposit(
+      blocks,
+      this.db.eth1DataDeposit.valuesStream({lte: highestBlock, reverse: true}),
+      lastProcessedDepositBlockNumber
+    );
+  }
+
+  /**
+   * Returns the highest blockNumber stored in DB if any
+   */
+  async geHighestDepositEventBlockNumber(): Promise<number | null> {
+    const latestDepositEvent = await this.db.depositEvent.lastValue();
+    return latestDepositEvent && latestDepositEvent.blockNumber;
+  }
+}

--- a/packages/lodestar/src/eth1/stream.ts
+++ b/packages/lodestar/src/eth1/stream.ts
@@ -25,8 +25,8 @@ export async function* getDepositsStream(
     const remoteFollowBlock = await getRemoteFollowBlock(provider, params);
     const toBlock = Math.min(remoteFollowBlock, fromBlock + params.MAX_BLOCKS_PER_POLL);
     const logs = await provider.getDepositEvents(fromBlock, toBlock);
-    for (const batchedDeposits of groupDepositEventsByBlock(logs)) {
-      yield batchedDeposits;
+    for (const [blockNumber, depositEvents] of groupDepositEventsByBlock(logs)) {
+      yield {blockNumber, depositEvents};
     }
 
     fromBlock = toBlock;

--- a/packages/lodestar/src/eth1/types.ts
+++ b/packages/lodestar/src/eth1/types.ts
@@ -1,4 +1,4 @@
-import {Number64, DepositData, IBeaconSSZTypes} from "@chainsafe/lodestar-types";
+import {Number64, DepositData, IBeaconSSZTypes, Root} from "@chainsafe/lodestar-types";
 import {ContainerType} from "@chainsafe/ssz";
 
 export interface IDepositEvent {
@@ -15,5 +15,21 @@ export const DepositEventGenerator = (ssz: IBeaconSSZTypes): ContainerType<IDepo
       depositData: ssz.DepositData,
       blockNumber: ssz.Number64,
       index: ssz.Number64,
+    },
+  });
+
+export interface IEth1DataDeposit {
+  /// The block number of the log that included this `depositRoot`, `depositCount` values.
+  blockNumber: Number64;
+  depositRoot: Root;
+  depositCount: Number64;
+}
+
+export const Eth1DataDepositGenerator = (ssz: IBeaconSSZTypes): ContainerType<IEth1DataDeposit> =>
+  new ContainerType({
+    fields: {
+      blockNumber: ssz.Number64,
+      depositRoot: ssz.Root,
+      depositCount: ssz.Number64,
     },
   });

--- a/packages/lodestar/src/eth1/types.ts
+++ b/packages/lodestar/src/eth1/types.ts
@@ -1,5 +1,16 @@
-import {Number64, DepositData, IBeaconSSZTypes, Root} from "@chainsafe/lodestar-types";
+import {Number64, DepositData, IBeaconSSZTypes, Root, Bytes32, Eth1Data} from "@chainsafe/lodestar-types";
 import {ContainerType} from "@chainsafe/ssz";
+
+export interface IEth1Block {
+  hash: Bytes32; // Use blockHash to be consistent with the Eth1Data type
+  number: Number64; // Use blockNumber to be consistent with the IEth1DataDeposit type
+  timestamp: Number64;
+}
+
+export interface IEth1DataWithBlock extends Eth1Data {
+  blockNumber: number;
+  timestamp: number;
+}
 
 export interface IDepositEvent {
   depositData: DepositData;

--- a/packages/lodestar/src/eth1/types.ts
+++ b/packages/lodestar/src/eth1/types.ts
@@ -1,0 +1,19 @@
+import {Number64, DepositData, IBeaconSSZTypes} from "@chainsafe/lodestar-types";
+import {ContainerType} from "@chainsafe/ssz";
+
+export interface IDepositEvent {
+  depositData: DepositData;
+  /// The block number of the log that included this `DepositData`.
+  blockNumber: Number64;
+  /// The index included with the deposit log.
+  index: Number64;
+}
+
+export const DepositEventGenerator = (ssz: IBeaconSSZTypes): ContainerType<IDepositEvent> =>
+  new ContainerType({
+    fields: {
+      depositData: ssz.DepositData,
+      blockNumber: ssz.Number64,
+      index: ssz.Number64,
+    },
+  });

--- a/packages/lodestar/src/eth1/utils/deposits.ts
+++ b/packages/lodestar/src/eth1/utils/deposits.ts
@@ -1,0 +1,22 @@
+import {Deposit, Root} from "@chainsafe/lodestar-types";
+import {TreeBacked, List} from "@chainsafe/ssz";
+import {IDepositEvent} from "../types";
+import {getTreeAtIndex} from "../../util/tree";
+
+/**
+ * Returns a Deposit array with proofs computed at `depositCount`
+ * `depositRootTree` must already include the roots of the deposits
+ */
+export function getDepositsWithProofs(
+  depositEvents: IDepositEvent[],
+  depositRootTree: TreeBacked<List<Root>>,
+  depositCount: number
+): Deposit[] {
+  // Get tree at this particular depositCount to compute correct proofs
+  const treeAtDepositCount = getTreeAtIndex(depositRootTree, depositCount);
+
+  return depositEvents.map((log) => ({
+    proof: treeAtDepositCount.tree().getSingleProof(treeAtDepositCount.gindexOfProperty(log.index)),
+    data: log.depositData,
+  }));
+}

--- a/packages/lodestar/src/eth1/utils/eth1DataDeposit.ts
+++ b/packages/lodestar/src/eth1/utils/eth1DataDeposit.ts
@@ -1,0 +1,124 @@
+import {Root} from "@chainsafe/lodestar-types";
+import {List, TreeBacked} from "@chainsafe/ssz";
+import {getTreeAtIndex} from "../../util/tree";
+import {groupDepositEventsByBlock} from "./groupDepositEventsByBlock";
+import {IEth1DataDeposit, IEth1Block, IEth1DataWithBlock} from "../types";
+
+/**
+ * Extract partial eth1 data (depositRoot, depositCount) from downloaded deposits
+ * Last deposit per block
+ *
+ * Store as
+ * blockNumber - depositCount - depositRoot
+ * 1034          456            0x1256a1
+ * ---- (non consecutive blocks, blocks without deposits)
+ * 1030          450            0x08821b
+ * 1029          448            0x66d411
+ *
+ * Read as: for blockNumber, retrieve first partial eth1Data that is equal or less than blockNumber
+ * MUST store and check lastProcessedBlockNumber to prevent returning incorrect old data
+ */
+export function getEth1DataDepositFromDeposits(
+  depositRoots: {index: number; root: Uint8Array; blockNumber: number}[],
+  depositRootTreeFull: TreeBacked<List<Root>>
+): IEth1DataDeposit[] {
+  if (depositRoots.length === 0) return [];
+
+  const previousIndex = depositRoots[0].index - 1;
+  const depositRootTree = getTreeAtIndex(depositRootTreeFull, previousIndex);
+
+  return groupDepositEventsByBlock(depositRoots).map(
+    ([blockNumber, depositRootsByBlock]): IEth1DataDeposit => {
+      for (const depositRoot of depositRootsByBlock) {
+        depositRootTree.push(depositRoot.root);
+      }
+      return {
+        blockNumber,
+        depositRoot: depositRootTree.hashTreeRoot(),
+        depositCount: depositRootTree.length,
+      };
+    }
+  );
+}
+
+/**
+ * Performs a backfill on sparse Eth1DataDeposit data.
+ * Assumes that for blockNumber N, its depositRoot,depositCount is equal to the previous nearest
+ * available data with blockNumber < N.
+ */
+export function mapEth1DataDepositToBlockRange(
+  fromBlock: number,
+  toBlock: number,
+  eth1Datas: IEth1DataDeposit[]
+): {[blockNumber: number]: IEth1DataDeposit} {
+  if (eth1Datas.length === 0) {
+    throw Error("eth1Data array is empty");
+  }
+
+  const lowestBlockNumber = eth1Datas[0].blockNumber;
+  const highestBlockNumber = eth1Datas[eth1Datas.length - 1].blockNumber;
+  if (fromBlock < lowestBlockNumber) {
+    throw Error(
+      `Not enough eth1Data available for range [${fromBlock}, ${toBlock}], provided: [${lowestBlockNumber}, ${highestBlockNumber}]`
+    );
+  }
+
+  const eth1DataDepositMap: {[blockNumber: number]: IEth1DataDeposit} = {};
+
+  let pointer = 0;
+  for (let blockNumber = fromBlock; blockNumber <= toBlock; blockNumber++) {
+    for (let i = pointer; i < eth1Datas.length; i++) {
+      if (
+        i === eth1Datas.length - 1 ||
+        (eth1Datas[i].blockNumber <= blockNumber && eth1Datas[i + 1].blockNumber > blockNumber)
+      ) {
+        eth1DataDepositMap[blockNumber] = eth1Datas[i];
+        pointer = i;
+        break;
+      }
+    }
+  }
+
+  return eth1DataDepositMap;
+}
+
+/**
+ * Appends partial eth1 data (depositRoot, depositCount) in a sequence of blocks
+ * eth1 data deposit is inferred from sparse eth1 data obtained from the deposit logs
+ */
+export async function appendEth1DataDeposit(
+  blocks: IEth1Block[],
+  eth1DataDepositDescendingStream: AsyncIterable<IEth1DataDeposit>,
+  lastProcessedDepositBlockNumber?: number
+): Promise<IEth1DataWithBlock[]> {
+  // Exclude blocks for which there is no valid eth1 data deposit
+  if (lastProcessedDepositBlockNumber) {
+    blocks = blocks.filter((block) => block.number <= lastProcessedDepositBlockNumber);
+  }
+
+  // A valid block can be constructed using previous `state.eth1Data`, don't throw
+  if (blocks.length === 0) {
+    return [];
+  }
+
+  const fromBlock = blocks[0].number;
+  const toBlock = blocks[blocks.length - 1].number;
+
+  // Take blocks until the block under the range lower bound (included)
+  const eth1DatasDeposit: IEth1DataDeposit[] = [];
+  for await (const eth1DataBlock of eth1DataDepositDescendingStream) {
+    eth1DatasDeposit.push(eth1DataBlock);
+    if (eth1DataBlock.blockNumber < fromBlock) break;
+  }
+
+  // Convert sparse eth1 data deposit into consecutive
+  const eth1DataDepositMap = mapEth1DataDepositToBlockRange(fromBlock, toBlock, eth1DatasDeposit.reverse());
+
+  return blocks.map((block) => ({
+    blockHash: block.hash,
+    depositCount: eth1DataDepositMap[block.number]?.depositCount,
+    depositRoot: eth1DataDepositMap[block.number]?.depositRoot,
+    blockNumber: block.number,
+    timestamp: block.timestamp,
+  }));
+}

--- a/packages/lodestar/src/eth1/utils/eth1DepositEvent.ts
+++ b/packages/lodestar/src/eth1/utils/eth1DepositEvent.ts
@@ -1,0 +1,12 @@
+/**
+ * Assert that an array of deposits are consecutive and ascending
+ */
+export function assertConsecutiveDeposits(depositEvents: {index: number}[]): void {
+  for (let i = 0; i < depositEvents.length - 1; i++) {
+    const indexLeft = depositEvents[i].index;
+    const indexRight = depositEvents[i + 1].index;
+    if (indexLeft !== indexRight - 1) {
+      throw Error(`Non consecutive deposits. deposit[${i}] = ${indexLeft}, deposit[${i + 1}] ${indexRight}`);
+    }
+  }
+}

--- a/packages/lodestar/src/eth1/utils/groupDepositEventsByBlock.ts
+++ b/packages/lodestar/src/eth1/utils/groupDepositEventsByBlock.ts
@@ -1,23 +1,15 @@
-import {IDepositEvent} from "../interface";
-
 /**
  * Return deposit events of blocks grouped/sorted by block number and deposit index
  * Blocks without events are omitted
  * @param depositEvents range deposit events
  */
-export function groupDepositEventsByBlock(
-  depositEvents: IDepositEvent[]
-): {
-  depositEvents: IDepositEvent[];
-  blockNumber: number;
-}[] {
+export function groupDepositEventsByBlock<T extends {index: number; blockNumber: number}>(
+  depositEvents: T[]
+): [number, T[]][] {
   depositEvents.sort((event1, event2) => event1.index - event2.index);
-  const depositsByBlockMap = new Map<number, IDepositEvent[]>();
+  const depositsByBlockMap = new Map<number, T[]>();
   for (const deposit of depositEvents) {
     depositsByBlockMap.set(deposit.blockNumber, [...(depositsByBlockMap.get(deposit.blockNumber) || []), deposit]);
   }
-  return Array.from(depositsByBlockMap.entries()).map(([blockNumber, depositEvents]) => ({
-    blockNumber,
-    depositEvents,
-  }));
+  return Array.from(depositsByBlockMap.entries()).map(([blockNumber, depositEvents]) => [blockNumber, depositEvents]);
 }

--- a/packages/lodestar/src/eth1/utils/index.ts
+++ b/packages/lodestar/src/eth1/utils/index.ts
@@ -1,0 +1,6 @@
+export * from "./deposits";
+export * from "./eth1DataDeposit";
+export * from "./eth1DepositEvent";
+export * from "./groupDepositEventsByBlock";
+export * from "./optimizeNextBlockDiffForGenesis";
+export * from "./retryProvider";

--- a/packages/lodestar/src/util/tree.ts
+++ b/packages/lodestar/src/util/tree.ts
@@ -1,0 +1,14 @@
+import {TreeBacked, List} from "@chainsafe/ssz";
+
+export function getTreeAtIndex<T>(tree: TreeBacked<List<T>>, index: number): TreeBacked<List<T>> {
+  const newTree = tree.clone();
+  let maxIndex = newTree.length - 1;
+  if (index > maxIndex) {
+    throw new Error(`Cannot get tree for index: ${index}, current length: ${maxIndex}`);
+  }
+  while (maxIndex > index) {
+    newTree.pop();
+    maxIndex = newTree.length - 1;
+  }
+  return newTree;
+}

--- a/packages/lodestar/test/unit/eth1/utils/deposits.test.ts
+++ b/packages/lodestar/test/unit/eth1/utils/deposits.test.ts
@@ -1,0 +1,50 @@
+import {expect} from "chai";
+import {Root} from "@chainsafe/lodestar-types";
+import {List} from "@chainsafe/ssz";
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import {verifyMerkleBranch} from "@chainsafe/lodestar-utils";
+import {IDepositEvent} from "../../../../src/eth1/types";
+import {generateDepositData} from "../../../utils/deposit";
+import {getDepositsWithProofs} from "../../../../src/eth1/utils";
+
+describe("eth1 / util / deposits", function () {
+  it("return empty array if no pending deposits", async function () {
+    const initialValues = [Buffer.alloc(32)] as List<Root>;
+    const depositRootTree = config.types.DepositDataRootList.tree.createValue(initialValues);
+    const deposits = getDepositsWithProofs([], depositRootTree, 0);
+    expect(deposits).to.be.deep.equal([]);
+  });
+
+  it("return deposits with valid proofs", async function () {
+    const depositEvents = Array.from(
+      {length: 2},
+      (_, index): IDepositEvent => ({
+        depositData: generateDepositData(),
+        blockNumber: index,
+        index,
+      })
+    );
+
+    const depositRootTree = config.types.DepositDataRootList.tree.defaultValue();
+    for (const depositLog of depositEvents) {
+      depositRootTree.push(config.types.DepositData.hashTreeRoot(depositLog.depositData));
+    }
+
+    const deposits = getDepositsWithProofs(depositEvents, depositRootTree, 1);
+
+    const depositsRoot = depositRootTree.hashTreeRoot();
+    expect(deposits.length).to.be.equal(2);
+    deposits.forEach((deposit, index) => {
+      expect(
+        verifyMerkleBranch(
+          config.types.DepositData.hashTreeRoot(deposit.data),
+          Array.from(deposit.proof).map((p) => p.valueOf() as Uint8Array),
+          33,
+          index,
+          depositsRoot.valueOf() as Uint8Array
+        ),
+        `Wrong merkle proof on deposit ${index}`
+      ).to.be.true;
+    });
+  });
+});

--- a/packages/lodestar/test/unit/eth1/utils/eth1DataDeposit.test.ts
+++ b/packages/lodestar/test/unit/eth1/utils/eth1DataDeposit.test.ts
@@ -1,0 +1,206 @@
+import {expect} from "chai";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {Root} from "@chainsafe/lodestar-types";
+import {List, toHexString} from "@chainsafe/ssz";
+import {mapValues} from "lodash";
+import {iteratorFromArray} from "../../../utils/iterator";
+import {IEth1DataDeposit, IEth1Block} from "../../../../src/eth1/types";
+import {
+  getEth1DataDepositFromDeposits,
+  mapEth1DataDepositToBlockRange,
+  appendEth1DataDeposit,
+} from "../../../../src/eth1/utils";
+
+describe("eth1 / util / getEth1DataDepositFromLogs", function () {
+  it("should return eth1 data (depositRoot, depositCount) for block-spaced logs", () => {
+    // Arbitrary list of consecutive non-uniform (blockNumber-wise) deposit roots
+    const depositRoots: {index: number; root: Uint8Array; blockNumber: number}[] = [
+      {index: 10, blockNumber: 5},
+      {index: 11, blockNumber: 5},
+      {index: 12, blockNumber: 5},
+      {index: 13, blockNumber: 46},
+      {index: 14, blockNumber: 46},
+      {index: 15, blockNumber: 60},
+      {index: 16, blockNumber: 60},
+      {index: 17, blockNumber: 83},
+      {index: 18, blockNumber: 83},
+      {index: 19, blockNumber: 99},
+    ].map(({index, blockNumber}) => ({index, blockNumber, root: new Uint8Array(Array(32).fill(index))}));
+
+    // Create an existing deposit tree with more deposits than the earliest item in `depositRoots`
+    const existingTreeLength = depositRoots[0].index;
+    const values = Array.from({length: existingTreeLength}, (_, i) => Buffer.alloc(32, String(i))) as List<Root>;
+    const depositRootTree = config.types.DepositDataRootList.tree.createValue(values);
+
+    const eth1DataDeposits = getEth1DataDepositFromDeposits(depositRoots, depositRootTree);
+    // Convert to hex to ease result checking
+    const eth1DataDepositsHex = eth1DataDeposits.map((eth1DataDeposit) => ({
+      ...eth1DataDeposit,
+      depositRoot: toHexString(eth1DataDeposit.depositRoot),
+    }));
+
+    expect(eth1DataDepositsHex).to.deep.equal([
+      {
+        blockNumber: 5,
+        depositRoot: "0xcab74cd3e62f92390eed488aa198cbf2b0d53e4900413ebcdb23ea0f8e66aa12",
+        depositCount: 13,
+      },
+      {
+        blockNumber: 46,
+        depositRoot: "0x372b399ae4b7855549e0c71de92a95e28445e14e746bc5c1bae724d1e22e0383",
+        depositCount: 15,
+      },
+      {
+        blockNumber: 60,
+        depositRoot: "0xa7a09ed38e1d7b865dc9ba09ee9cdd56660ecbb2361e512b33b3f91ac7935d73",
+        depositCount: 17,
+      },
+      {
+        blockNumber: 83,
+        depositRoot: "0xf35238eaf9983fb5ed38fd48d8ea132d6e8f1df328f3d4247ebd2e1b0cbd82bc",
+        depositCount: 19,
+      },
+      {
+        blockNumber: 99,
+        depositRoot: "0x8918169e9186c2eafee39da6ca5caa8423a299068f956c86b35f98d2ec9a1c1b",
+        depositCount: 20,
+      },
+    ]);
+  });
+});
+
+describe("eth1 / util / mapEth1DataDepositToBlockRange", function () {
+  // Arbitrary list of consecutive non-uniform (blockNumber-wise) deposit roots
+  const eth1DataDepositArr: IEth1DataDeposit[] = [
+    {blockNumber: 0, depositCount: 13},
+    {blockNumber: 3, depositCount: 15},
+    {blockNumber: 4, depositCount: 17},
+    {blockNumber: 7, depositCount: 19},
+    {blockNumber: 9, depositCount: 20},
+  ].map(({blockNumber, depositCount}) => ({
+    blockNumber,
+    depositCount,
+    depositRoot: new Uint8Array(Array(32).fill(blockNumber)),
+  }));
+
+  const testCases: {
+    id: string;
+    fromBlock: number;
+    toBlock: number;
+    expectedResult: {[blockNumber: number]: {depositCount: number}};
+  }[] = [
+    {
+      id: "sequential eth1DataDeposit items - full array",
+      fromBlock: 0,
+      toBlock: 10,
+      expectedResult: {
+        0: {depositCount: 13},
+        1: {depositCount: 13},
+        2: {depositCount: 13},
+        3: {depositCount: 15},
+        4: {depositCount: 17},
+        5: {depositCount: 17},
+        6: {depositCount: 17},
+        7: {depositCount: 19},
+        8: {depositCount: 19},
+        9: {depositCount: 20},
+        10: {depositCount: 20},
+      },
+    },
+    {
+      id: "sequential eth1DataDeposit items - small array",
+      fromBlock: 3,
+      toBlock: 4,
+      expectedResult: {
+        3: {depositCount: 15},
+        4: {depositCount: 17},
+      },
+    },
+    {
+      id: "sequential eth1DataDeposit items - future block",
+      fromBlock: 9,
+      toBlock: 11,
+      expectedResult: {
+        9: {depositCount: 20},
+        10: {depositCount: 20},
+        11: {depositCount: 20},
+      },
+    },
+  ];
+
+  for (const {id, fromBlock, toBlock, expectedResult} of testCases) {
+    it(id, () => {
+      const eth1DataDepositMap = mapEth1DataDepositToBlockRange(fromBlock, toBlock, eth1DataDepositArr);
+      const eth1DataDepositMapSlim = mapValues(eth1DataDepositMap, (eth1DataDeposit) => ({
+        depositCount: eth1DataDeposit.depositCount,
+      }));
+      expect(eth1DataDepositMapSlim).to.deep.equal(expectedResult);
+    });
+  }
+});
+
+describe("eth1 / util / appendEth1DataDeposit", function () {
+  it("Should append eth1DataDeposit", async function () {
+    // Arbitrary list of consecutive non-uniform (blockNumber-wise) deposit roots
+    const eth1DataDepositArr: IEth1DataDeposit[] = [
+      {blockNumber: 0, depositCount: 13},
+      {blockNumber: 3, depositCount: 15},
+      {blockNumber: 4, depositCount: 17},
+      {blockNumber: 7, depositCount: 19},
+    ].map(({blockNumber, depositCount}) => ({
+      blockNumber,
+      depositCount,
+      depositRoot: new Uint8Array(Array(32).fill(blockNumber)),
+    }));
+
+    // Consecutive block headers to be filled with eth1Data above
+    const eth1Blocks: IEth1Block[] = [2, 3, 4, 5, 6, 7, 8].map((blockNumber) => ({
+      hash: new Uint8Array(Array(32).fill(blockNumber)),
+      number: blockNumber,
+      timestamp: blockNumber,
+    }));
+
+    const lastProcessedDepositBlockNumber = 11;
+
+    // Result must contain all blocks from eth1Blocks, with backfilled eth1DataDeposit
+    const expectedEth1Data = [
+      {blockNumber: 2, depositCount: 13},
+      {blockNumber: 3, depositCount: 15},
+      {blockNumber: 4, depositCount: 17},
+      {blockNumber: 5, depositCount: 17},
+      {blockNumber: 6, depositCount: 17},
+      {blockNumber: 7, depositCount: 19},
+      {blockNumber: 8, depositCount: 19},
+    ];
+
+    const eth1Datas = await appendEth1DataDeposit(
+      eth1Blocks,
+      // Simulate a descending stream reading from DB
+      iteratorFromArray<IEth1DataDeposit>(eth1DataDepositArr.reverse()),
+      lastProcessedDepositBlockNumber
+    );
+
+    const eth1DatasSlim = eth1Datas.map((eth1Data) => ({
+      blockNumber: eth1Data.blockNumber,
+      depositCount: eth1Data.depositCount,
+    }));
+
+    expect(eth1DatasSlim).to.deep.equal(expectedEth1Data);
+  });
+
+  it("should not throw for empty data", async function () {
+    // Arbitrary list of consecutive non-uniform (blockNumber-wise) deposit roots
+    const eth1DataDepositArr: IEth1DataDeposit[] = [];
+    const eth1Blocks: IEth1Block[] = [];
+    const lastProcessedDepositBlockNumber = undefined;
+
+    const eth1Datas = await appendEth1DataDeposit(
+      eth1Blocks,
+      // Simulate a descending stream reading from DB
+      iteratorFromArray<IEth1DataDeposit>(eth1DataDepositArr),
+      lastProcessedDepositBlockNumber
+    );
+
+    expect(eth1Datas).to.deep.equal([]);
+  });
+});

--- a/packages/lodestar/test/unit/eth1/utils/eth1DepositEvent.test.ts
+++ b/packages/lodestar/test/unit/eth1/utils/eth1DepositEvent.test.ts
@@ -1,0 +1,46 @@
+import {expect} from "chai";
+import {assertConsecutiveDeposits} from "../../../../src/eth1/utils/eth1DepositEvent";
+
+describe("eth1 / util / assertConsecutiveDeposits", function () {
+  const testCases: {
+    id: string;
+    ok: boolean;
+    depositEvents: {index: number}[];
+  }[] = [
+    {
+      id: "sequential deposits",
+      ok: true,
+      depositEvents: [{index: 4}, {index: 5}, {index: 6}],
+    },
+    {
+      id: "non sequential deposits",
+      ok: false,
+      depositEvents: [{index: 4}, {index: 7}, {index: 9}],
+    },
+    {
+      id: "sequential descending deposits",
+      ok: false,
+      depositEvents: [{index: 6}, {index: 5}, {index: 4}],
+    },
+    {
+      id: "single deposit",
+      ok: true,
+      depositEvents: [{index: 4}],
+    },
+    {
+      id: "empty array",
+      ok: true,
+      depositEvents: [],
+    },
+  ];
+
+  for (const {id, ok, depositEvents} of testCases) {
+    it(id, () => {
+      if (ok) {
+        assertConsecutiveDeposits(depositEvents);
+      } else {
+        expect(() => assertConsecutiveDeposits(depositEvents)).to.throw();
+      }
+    });
+  }
+});

--- a/packages/lodestar/test/unit/eth1/utils/groupDepositEventsByBlock.test.ts
+++ b/packages/lodestar/test/unit/eth1/utils/groupDepositEventsByBlock.test.ts
@@ -1,14 +1,16 @@
 import {expect} from "chai";
-import {IDepositEvent} from "../../../../src/eth1";
-import {groupDepositEventsByBlock} from "../../../../src/eth1/utils/groupDepositEventsByBlock";
+import {IDepositEvent} from "../../../../src/eth1/types";
+import {groupDepositEventsByBlock} from "../../../../src/eth1/utils";
 
 describe("eth1 / util / groupDepositEventsByBlock", function () {
   it("should return deposit events by block sorted by index", () => {
-    const depositData = {
-      amount: BigInt(0),
-      signature: Buffer.alloc(96),
-      withdrawalCredentials: Buffer.alloc(32),
-      pubkey: Buffer.alloc(48),
+    const depositData: Pick<IDepositEvent, "depositData"> = {
+      depositData: {
+        amount: BigInt(0),
+        signature: Buffer.alloc(96),
+        withdrawalCredentials: Buffer.alloc(32),
+        pubkey: Buffer.alloc(48),
+      },
     };
     const depositEvents: IDepositEvent[] = [
       {blockNumber: 1, index: 0, ...depositData},
@@ -20,9 +22,9 @@ describe("eth1 / util / groupDepositEventsByBlock", function () {
     const blockEvents = groupDepositEventsByBlock(depositEvents);
 
     // Keep only the relevant info of the result
-    const blockEventsIndexOnly = blockEvents.map((blockEvent) => ({
-      blockNumber: blockEvent.blockNumber,
-      deposits: blockEvent.depositEvents.map((deposit) => deposit.index),
+    const blockEventsIndexOnly = blockEvents.map(([blockNumber, depositEvents]) => ({
+      blockNumber: blockNumber,
+      deposits: depositEvents.map((deposit) => deposit.index),
     }));
 
     expect(blockEventsIndexOnly).to.deep.equal([

--- a/packages/lodestar/test/utils/iterator.ts
+++ b/packages/lodestar/test/utils/iterator.ts
@@ -1,0 +1,5 @@
+export async function* iteratorFromArray<T>(values: T[]): AsyncIterable<T> {
+  for (let i = 0; i < values.length; i++) {
+    yield values[i];
+  }
+}


### PR DESCRIPTION
Adds two new repository to the DB and their wrapper Eth1DepositsCache. Part of #1518. See #1518 for an overview of the target architecture that this component will be part of.

The current repositories eth1Data and depositData will be deprecated. Eth1 data is best fetched and stored separately: (1) blockHash fetched from block headers directly, and (2) depositCount and depositRoot fetched from the deposit logs directly. To do so it's necessary to store each deposit log blockNumber and index, so just keeping depositData is not sufficient.

Most of the logic added in this PR is to convert non-consecutive deposit logs into consecutive consumable eth1Data.