### PR TITLE
Disregard unfinalized blocks upon restart

### DIFF
--- a/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
@@ -45,6 +45,12 @@ export class ArchiveBlocksTask implements ITask {
    */
   public async run(): Promise<void> {
     this.logger.profile("Archive Blocks");
+    const lastFinalizedBlock = await this.db.blockArchive.lastValue();
+    if (lastFinalizedBlock && lastFinalizedBlock.message.slot >= this.finalized.slot) {
+      // restore chain
+      this.logger.info(`Block archive slot ${lastFinalizedBlock.message.slot} is ahead of ${this.finalized.slot}`);
+      return;
+    }
     const allBlockEntries = await this.db.block.entries();
     const blockEntries = allBlockEntries.filter(({value}) => value.message.slot <= this.finalized.slot);
     const blocksByRoot = new Map<string, SignedBeaconBlock>(

--- a/packages/lodestar/src/tasks/tasks/archiveStates.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveStates.ts
@@ -44,6 +44,12 @@ export class ArchiveStatesTask implements ITask {
   public async run(): Promise<void> {
     const epoch = computeEpochAtSlot(this.config, this.finalized.slot);
     this.logger.info(`Started archiving states (finalized epoch #${epoch})...`);
+    const lastFinalizedState = await this.db.stateArchive.lastValue();
+    if (lastFinalizedState && lastFinalizedState.slot >= this.finalized.slot) {
+      // restore chain
+      this.logger.info(`State archive slot ${lastFinalizedState.slot} is ahead of ${this.finalized.slot}`);
+      return;
+    }
     this.logger.profile("Archive States");
     // store the state of finalized checkpoint
     const stateCache = await this.db.stateCache.get(this.finalized.stateRoot);


### PR DESCRIPTION
resolves #1526 
## Current flow
+ Upon restart, load and restore from block 73249 to block 110000 through block processor in order to populate state cache and fork choice
+ Initial sync to start querying from block 73249 again and continue until blocks 110000 which is a duplicate and potentially cause OOM issue
## New flow
+ Upon restart, disregard unfinalized blocks
+ Populate forkchoice from previous finalized slot until current finalized slot to make it head, this is quick
+ Only populate state cache with last finalized state
+ Don't even touch block processor in most cases
+ Initial sync start querying from block 73249 

## Testing
+ Restore: With my database of 110000 blocks, I can go to initial sync quickly without having to load and reprocess from block 73249 till 110000
+ Start from scratch: Starting from a new dir works fine as normal