### PR TITLE
Close stream after request finishes

### DIFF
--- a/packages/lodestar/src/network/reqResp.ts
+++ b/packages/lodestar/src/network/reqResp.ts
@@ -331,7 +331,6 @@ export class ReqResp extends (EventEmitter as IReqEventEmitterClass) implements 
         eth2RequestEncode(config, logger, method, encoding),
         conn.stream
       );
-      // @ts-ignore
       conn.stream.reset();
       yield* pipe(
         abortDuplex(conn.stream, controller.signal, {returnOnAbort: true}),

--- a/packages/lodestar/src/network/reqResp.ts
+++ b/packages/lodestar/src/network/reqResp.ts
@@ -326,9 +326,14 @@ export class ReqResp extends (EventEmitter as IReqEventEmitterClass) implements 
       }
       logger.verbose(`got stream to ${peerId.toB58String()}`, {requestId, encoding});
       const controller = new AbortController();
-      yield* pipe(
+      await pipe(
         body !== null && body !== undefined ? [body] : [null],
         eth2RequestEncode(config, logger, method, encoding),
+        conn.stream
+      );
+      // @ts-ignore
+      conn.stream.reset();
+      yield* pipe(
         abortDuplex(conn.stream, controller.signal, {returnOnAbort: true}),
         eth2ResponseTimer(controller),
         eth2ResponseDecode(config, logger, method, encoding, requestId, controller)

--- a/yarn.lock
+++ b/yarn.lock
@@ -10920,7 +10920,7 @@ libp2p-tcp@^0.14.6:
 
 "libp2p-ts@https://github.com/ChainSafe/libp2p-ts.git":
   version "0.1.0"
-  resolved "https://github.com/ChainSafe/libp2p-ts.git#8bf05918fb98c44bde75d20a90777e90ca7e2f93"
+  resolved "https://github.com/ChainSafe/libp2p-ts.git#fca072c9764436ef71f974a211bb1befae432575"
   dependencies:
     "@chainsafe/discv5" "^0.3.1"
     "@types/node" "^13.7.0"


### PR DESCRIPTION
See https://discordapp.com/channels/593655374469660673/593655641445367808/754016419380854915

According to the spec:
> The requester MUST close the write side of the stream once it finishes writing the request message. At this point, the stream will be half-closed.

This resolves many of the timeouts we were seeing.

Creating an issue to add `stream.reset` to types.