### PR TITLE
Expose EpochProcess in EpochContext

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/index.ts
@@ -18,6 +18,7 @@ export {
 
 export function processEpoch(epochCtx: EpochContext, state: BeaconState): void {
   const process = prepareEpochProcessState(epochCtx, state);
+  epochCtx.epochProcess = process;
   processJustificationAndFinalization(epochCtx, process, state);
   processRewardsAndPenalties(epochCtx, process, state);
   processRegistryUpdates(epochCtx, process, state);

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
@@ -25,6 +25,7 @@ import {
   isAggregatorFromCommitteeLength,
 } from "../../util";
 import {computeEpochShuffling, IEpochShuffling} from "./epochShuffling";
+import {IEpochProcess} from "./epochProcess";
 
 class PubkeyIndexMap extends Map<ByteVector, ValidatorIndex> {
   get(key: ByteVector): ValidatorIndex | undefined {
@@ -48,6 +49,7 @@ export class EpochContext {
   public currentShuffling!: IEpochShuffling;
   public nextShuffling!: IEpochShuffling;
   public config: IBeaconConfig;
+  public epochProcess?: IEpochProcess;
 
   constructor(config: IBeaconConfig) {
     this.config = config;
@@ -89,6 +91,7 @@ export class EpochContext {
     ctx.previousShuffling = this.previousShuffling;
     ctx.currentShuffling = this.currentShuffling;
     ctx.nextShuffling = this.nextShuffling;
+    ctx.epochProcess = this.epochProcess;
     return ctx;
   }
 


### PR DESCRIPTION
part of #1517 
Allows us to fetch cached validator statuses and balances for updating the fork choice