### PR TITLE
Update state caches

### DIFF
--- a/packages/lodestar/src/db/api/beacon/stateContextCache.ts
+++ b/packages/lodestar/src/db/api/beacon/stateContextCache.ts
@@ -51,11 +51,11 @@ export class StateContextCache {
    * Without more thought, this currently breaks our assumptions about recent state availablity
    */
   public prune(): void {
-    const MAX_STATES = 128;
+    const MAX_STATES = 96;
     const keys = Object.keys(this.cache);
     if (keys.length > MAX_STATES) {
-      // object keys are stored in insertion order, delete keys starting from the front (but keeping the first)
-      keys.slice(1, MAX_STATES - keys.length).forEach((key) => {
+      // object keys are stored in insertion order, delete keys starting from the front
+      keys.slice(0, keys.length - MAX_STATES).forEach((key) => {
         delete this.cache[key];
       });
     }


### PR DESCRIPTION
Part of #1517 

Updates state caches
- `stateCache`
  - change MAX_STATES to 96
  - delete states starting from the front, including after the first
- `checkpointStateCache`
  - update the secondary index to `Epoch -> Set<HexBlockRoot>` -- **note** NOT `Epoch -> Set<HexCheckpointRoot>`
  - add `getLatest` which is like `get` but will search backwards epoch by epoch to find a match with the requested blockRoot, returns the latest match or null
  - add `pruneFinalized`, prunes epochs before the finalized epoch
  - add `prune`, prunes based on MAX_EPOCHS constant, avoids pruning finalized and justified epochs
  - update `delete` and `deleteAllEpochItems` to use new secondary index