### PR TITLE
Add state regenerator

### DIFF
--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -29,7 +29,6 @@ import {
   getDomain,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {assert, ILogger} from "@chainsafe/lodestar-utils";
-import {processSlots} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/slot";
 
 import {IBeaconDb} from "../../../db";
 import {IBeaconChain} from "../../../chain";
@@ -46,6 +45,7 @@ import {ApiError} from "../errors/api";
 import {notNullish} from "../../../util/notNullish";
 import {ApiNamespace, IApiModules} from "../interface";
 import {IValidatorApi} from "./interface";
+import {waitForBlockSlot} from "../../../network/gossip/validation";
 
 export class ValidatorApi implements IValidatorApi {
   public namespace: ApiNamespace;
@@ -98,18 +98,16 @@ export class ValidatorApi implements IValidatorApi {
   public async produceAttestation(validatorPubKey: BLSPubkey, index: CommitteeIndex, slot: Slot): Promise<Attestation> {
     try {
       await this.checkSyncStatus();
-      const [headBlockRoot, {state: headState, epochCtx}] = await Promise.all([
-        this.chain.forkChoice.getHeadRoot(),
-        this.chain.getHeadStateContext(),
-      ]);
+      const headBlock = this.chain.forkChoice.getHead();
+      const {state, epochCtx} = await this.chain.regen.getBlockSlotState(
+        headBlock.blockRoot,
+        this.chain.clock.currentSlot
+      );
       const validatorIndex = epochCtx.pubkey2index.get(validatorPubKey);
       if (validatorIndex === undefined) {
         throw Error(`Validator pubKey ${toHexString(validatorPubKey)} not in epochCtx`);
       }
-      if (headState.slot < slot) {
-        processSlots(epochCtx, headState, slot);
-      }
-      return await assembleAttestation(epochCtx, headState, headBlockRoot, validatorIndex, index, slot);
+      return await assembleAttestation(epochCtx, state, headBlock.blockRoot, validatorIndex, index, slot);
     } catch (e) {
       this.logger.warn(`Failed to produce attestation because: ${e.message}`);
       throw e;
@@ -118,6 +116,8 @@ export class ValidatorApi implements IValidatorApi {
 
   public async publishBlock(signedBlock: SignedBeaconBlock): Promise<void> {
     await this.checkSyncStatus();
+    await waitForBlockSlot(this.config, this.chain.getGenesisTime(), signedBlock.message.slot);
+    this.chain.clock.currentSlot;
     await Promise.all([this.chain.receiveBlock(signedBlock), this.network.gossip.publishBlock(signedBlock)]);
   }
 
@@ -136,16 +136,12 @@ export class ValidatorApi implements IValidatorApi {
   public async getProposerDuties(epoch: Epoch): Promise<ProposerDuty[]> {
     await this.checkSyncStatus();
     assert.gte(epoch, 0, "Epoch must be positive");
-    const {state, epochCtx} = await this.chain.getHeadStateContext();
-    assert.lte(
-      epoch,
-      computeEpochAtSlot(this.config, state.slot) + 2,
-      "Cannot get duties for epoch more than two ahead"
+    assert.lte(epoch, this.chain.clock.currentEpoch + 2, "Cannot get duties for epoch more than two ahead");
+    const {state, epochCtx} = await this.chain.regen.getBlockSlotState(
+      this.chain.forkChoice.getHeadRoot(),
+      this.chain.clock.currentSlot
     );
     const startSlot = computeStartSlotAtEpoch(this.config, epoch);
-    if (state.slot < startSlot) {
-      processSlots(epochCtx, state, startSlot);
-    }
     const duties: ProposerDuty[] = [];
 
     for (let slot = startSlot; slot < startSlot + this.config.params.SLOTS_PER_EPOCH; slot++) {
@@ -158,11 +154,11 @@ export class ValidatorApi implements IValidatorApi {
   public async getAttesterDuties(epoch: number, validatorPubKeys: BLSPubkey[]): Promise<AttesterDuty[]> {
     await this.checkSyncStatus();
     if (!validatorPubKeys || validatorPubKeys.length === 0) throw new Error("No validator to get attester duties");
-    const {epochCtx, state} = await this.chain.getHeadStateContext();
-    const currentSlot = this.chain.clock.currentSlot;
-    if (state.slot < currentSlot) {
-      processSlots(epochCtx, state, currentSlot);
-    }
+    assert.lte(epoch, this.chain.clock.currentEpoch + 2, "Cannot get duties for epoch more than two ahead");
+    const {epochCtx, state} = await this.chain.regen.getBlockSlotState(
+      this.chain.forkChoice.getHeadRoot(),
+      this.chain.clock.currentSlot
+    );
     const validatorIndexes = validatorPubKeys.map((key) => {
       const validatorIndex = epochCtx.pubkey2index.get(key);
       if (validatorIndex === undefined || !Number.isInteger(validatorIndex)) {

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -98,10 +98,7 @@ export class ValidatorApi implements IValidatorApi {
     try {
       await this.checkSyncStatus();
       const headBlock = this.chain.forkChoice.getHead();
-      const {state, epochCtx} = await this.chain.regen.getBlockSlotState(
-        headBlock.blockRoot,
-        this.chain.clock.currentSlot
-      );
+      const {state, epochCtx} = await this.chain.getHeadStateContextAtCurrentSlot();
       const validatorIndex = epochCtx.pubkey2index.get(validatorPubKey);
       if (validatorIndex === undefined) {
         throw Error(`Validator pubKey ${toHexString(validatorPubKey)} not in epochCtx`);
@@ -135,10 +132,7 @@ export class ValidatorApi implements IValidatorApi {
     await this.checkSyncStatus();
     assert.gte(epoch, 0, "Epoch must be positive");
     assert.lte(epoch, this.chain.clock.currentEpoch + 2, "Cannot get duties for epoch more than two ahead");
-    const {state, epochCtx} = await this.chain.regen.getBlockSlotState(
-      this.chain.forkChoice.getHeadRoot(),
-      this.chain.clock.currentSlot
-    );
+    const {state, epochCtx} = await this.chain.getHeadStateContextAtCurrentEpoch();
     const startSlot = computeStartSlotAtEpoch(this.config, epoch);
     const duties: ProposerDuty[] = [];
 
@@ -153,10 +147,7 @@ export class ValidatorApi implements IValidatorApi {
     await this.checkSyncStatus();
     if (!validatorPubKeys || validatorPubKeys.length === 0) throw new Error("No validator to get attester duties");
     assert.lte(epoch, this.chain.clock.currentEpoch + 2, "Cannot get duties for epoch more than two ahead");
-    const {epochCtx, state} = await this.chain.regen.getBlockSlotState(
-      this.chain.forkChoice.getHeadRoot(),
-      this.chain.clock.currentSlot
-    );
+    const {epochCtx, state} = await this.chain.getHeadStateContextAtCurrentEpoch();
     const validatorIndexes = validatorPubKeys.map((key) => {
       const validatorIndex = epochCtx.pubkey2index.get(key);
       if (validatorIndex === undefined || !Number.isInteger(validatorIndex)) {

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -112,7 +112,6 @@ export class ValidatorApi implements IValidatorApi {
 
   public async publishBlock(signedBlock: SignedBeaconBlock): Promise<void> {
     await this.checkSyncStatus();
-    await this.chain.clock.waitForSlot(signedBlock.message.slot);
     await Promise.all([this.chain.receiveBlock(signedBlock), this.network.gossip.publishBlock(signedBlock)]);
   }
 

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -45,7 +45,6 @@ import {ApiError} from "../errors/api";
 import {notNullish} from "../../../util/notNullish";
 import {ApiNamespace, IApiModules} from "../interface";
 import {IValidatorApi} from "./interface";
-import {waitForBlockSlot} from "../../../network/gossip/validation";
 
 export class ValidatorApi implements IValidatorApi {
   public namespace: ApiNamespace;
@@ -116,8 +115,7 @@ export class ValidatorApi implements IValidatorApi {
 
   public async publishBlock(signedBlock: SignedBeaconBlock): Promise<void> {
     await this.checkSyncStatus();
-    await waitForBlockSlot(this.config, this.chain.getGenesisTime(), signedBlock.message.slot);
-    this.chain.clock.currentSlot;
+    await this.chain.clock.waitForSlot(signedBlock.message.slot);
     await Promise.all([this.chain.receiveBlock(signedBlock), this.network.gossip.publishBlock(signedBlock)]);
   }
 

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -97,13 +97,13 @@ export class ValidatorApi implements IValidatorApi {
   public async produceAttestation(validatorPubKey: BLSPubkey, index: CommitteeIndex, slot: Slot): Promise<Attestation> {
     try {
       await this.checkSyncStatus();
-      const headBlock = this.chain.forkChoice.getHead();
+      const headRoot = this.chain.forkChoice.getHeadRoot();
       const {state, epochCtx} = await this.chain.getHeadStateContextAtCurrentSlot();
       const validatorIndex = epochCtx.pubkey2index.get(validatorPubKey);
       if (validatorIndex === undefined) {
         throw Error(`Validator pubKey ${toHexString(validatorPubKey)} not in epochCtx`);
       }
-      return await assembleAttestation(epochCtx, state, headBlock.blockRoot, validatorIndex, index, slot);
+      return await assembleAttestation(epochCtx, state, headRoot, validatorIndex, index, slot);
     } catch (e) {
       this.logger.warn(`Failed to produce attestation because: ${e.message}`);
       throw e;

--- a/packages/lodestar/src/chain/attestation/processor.ts
+++ b/packages/lodestar/src/chain/attestation/processor.ts
@@ -1,6 +1,5 @@
 import {computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {toHexString} from "@chainsafe/ssz";
-import {getAttestationPreState} from "../../network/gossip/utils";
 // eslint-disable-next-line max-len
 import {isValidIndexedAttestation} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/block/isValidIndexedAttestation";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
@@ -35,9 +34,12 @@ export async function processAttestation(
       return;
     }
 
-    const attestationPreState = await getAttestationPreState(config, chain, db, target);
-    if (!attestationPreState) {
-      //should not happen
+    let attestationPreState;
+    try {
+      attestationPreState = await chain.regen.getCheckpointState(target);
+    } catch (e) {
+      // should not happen
+      logger.error("Attestation prestate not found", e);
       return;
     }
     await db.checkpointStateCache.add(target, attestationPreState);

--- a/packages/lodestar/src/chain/blocks/process.ts
+++ b/packages/lodestar/src/chain/blocks/process.ts
@@ -9,14 +9,16 @@ import {BlockPool} from "./pool";
 import {ChainEventEmitter} from "../emitter";
 import {ITreeStateContext} from "../../db/api/beacon/stateContextCache";
 import {IBlockProcessJob} from "../interface";
-import {getPreState, runStateTransition} from "./stateTransition";
+import {runStateTransition} from "./stateTransition";
 import {IBeaconClock} from "../clock";
+import {IStateRegenerator} from "../regen";
 
 export function processBlock(
   config: IBeaconConfig,
   logger: ILogger,
   db: IBeaconDb,
   forkChoice: IForkChoice,
+  regen: IStateRegenerator,
   pool: BlockPool,
   eventBus: ChainEventEmitter,
   clock: IBeaconClock
@@ -38,7 +40,7 @@ export function processBlock(
         const blockRoot = config.types.BeaconBlock.hashTreeRoot(job.signedBlock.message);
         let preStateContext;
         try {
-          preStateContext = await getPreState(config, db, forkChoice, logger, job);
+          preStateContext = await regen.getPreState(job.signedBlock.message);
         } catch (e) {
           logger.verbose("No pre-state found, dropping block", e);
           pool.addPendingBlock(job);

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -18,6 +18,7 @@ import {IAttestationProcessor, IBlockProcessJob} from "../interface";
 import {ChainEventEmitter} from "../emitter";
 import {convertBlock} from "./convertBlock";
 import {IBeaconClock} from "../clock";
+import {IStateRegenerator} from "../regen";
 
 export class BlockProcessor implements IService {
   private readonly config: IBeaconConfig;
@@ -25,6 +26,7 @@ export class BlockProcessor implements IService {
   private readonly db: IBeaconDb;
   private readonly forkChoice: IForkChoice;
   private readonly clock: IBeaconClock;
+  private readonly regen: IStateRegenerator;
   private readonly metrics: IBeaconMetrics;
   private readonly eventBus: ChainEventEmitter;
   private readonly attestationProcessor: IAttestationProcessor;
@@ -43,6 +45,7 @@ export class BlockProcessor implements IService {
     logger: ILogger,
     db: IBeaconDb,
     forkChoice: IForkChoice,
+    regen: IStateRegenerator,
     metrics: IBeaconMetrics,
     eventBus: ChainEventEmitter,
     clock: IBeaconClock,
@@ -52,6 +55,7 @@ export class BlockProcessor implements IService {
     this.logger = logger;
     this.db = db;
     this.forkChoice = forkChoice;
+    this.regen = regen;
     this.metrics = metrics;
     this.eventBus = eventBus;
     this.clock = clock;
@@ -73,7 +77,7 @@ export class BlockProcessor implements IService {
       },
       convertBlock(this.config),
       validateBlock(this.config, this.logger, this.forkChoice, this.eventBus),
-      processBlock(this.config, this.logger, this.db, this.forkChoice, this.pendingBlocks, this.eventBus, this.clock),
+      processBlock(this.config, this.logger, this.db, this.forkChoice, this.regen, this.pendingBlocks, this.eventBus, this.clock),
       postProcess(
         this.config,
         this.logger,

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -77,7 +77,16 @@ export class BlockProcessor implements IService {
       },
       convertBlock(this.config),
       validateBlock(this.config, this.logger, this.forkChoice, this.eventBus),
-      processBlock(this.config, this.logger, this.db, this.forkChoice, this.regen, this.pendingBlocks, this.eventBus, this.clock),
+      processBlock(
+        this.config,
+        this.logger,
+        this.db,
+        this.forkChoice,
+        this.regen,
+        this.pendingBlocks,
+        this.eventBus,
+        this.clock
+      ),
       postProcess(
         this.config,
         this.logger,

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -22,6 +22,7 @@ import {
   blockToHeader,
   computeEpochAtSlot,
   computeForkDigest,
+  computeStartSlotAtEpoch,
   EpochContext,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {ILogger} from "@chainsafe/lodestar-utils";
@@ -109,6 +110,17 @@ export class BeaconChain implements IBeaconChain {
   public async getHeadEpochContext(): Promise<EpochContext> {
     //head should always have epoch ctx
     return (await this.getHeadStateContext()).epochCtx;
+  }
+
+  public async getHeadStateContextAtCurrentEpoch(): Promise<ITreeStateContext> {
+    const currentEpochStartSlot = computeStartSlotAtEpoch(this.config, this.clock.currentEpoch);
+    const head = this.forkChoice.getHead();
+    const bestSlot = currentEpochStartSlot > head.slot ? currentEpochStartSlot : head.slot;
+    return await this.regen.getBlockSlotState(head.blockRoot, bestSlot);
+  }
+
+  public async getHeadStateContextAtCurrentSlot(): Promise<ITreeStateContext> {
+    return await this.regen.getBlockSlotState(this.forkChoice.getHeadRoot(), this.clock.currentSlot);
   }
 
   public async getHeadBlock(): Promise<SignedBeaconBlock | null> {

--- a/packages/lodestar/src/chain/clock/LocalClock.ts
+++ b/packages/lodestar/src/chain/clock/LocalClock.ts
@@ -50,6 +50,9 @@ export class LocalClock implements IBeaconClock {
     if (this.signal.aborted) {
       throw new ErrorAborted();
     }
+    if (this.currentSlot >= slot) {
+      return;
+    }
     return new Promise((resolve, reject) => {
       const onSlot = (clockSlot: Slot): void => {
         if (clockSlot >= slot) {

--- a/packages/lodestar/src/chain/clock/LocalClock.ts
+++ b/packages/lodestar/src/chain/clock/LocalClock.ts
@@ -1,5 +1,6 @@
 import {Epoch, Slot} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {ErrorAborted} from "@chainsafe/lodestar-utils";
 import {computeEpochAtSlot, getCurrentSlot} from "@chainsafe/lodestar-beacon-state-transition";
 
 import {ChainEventEmitter} from "../emitter";
@@ -14,7 +15,7 @@ export class LocalClock implements IBeaconClock {
   private readonly genesisTime: number;
   private timeoutId: NodeJS.Timeout;
   private readonly emitter: ChainEventEmitter;
-  private readonly signal?: AbortSignal;
+  private readonly signal: AbortSignal;
   private _currentSlot: number;
 
   public constructor({
@@ -26,7 +27,7 @@ export class LocalClock implements IBeaconClock {
     config: IBeaconConfig;
     genesisTime: number;
     emitter: ChainEventEmitter;
-    signal?: AbortSignal;
+    signal: AbortSignal;
   }) {
     this.config = config;
     this.genesisTime = genesisTime;
@@ -34,9 +35,7 @@ export class LocalClock implements IBeaconClock {
     this.signal = signal;
     this.emitter = emitter;
     this._currentSlot = getCurrentSlot(this.config, this.genesisTime);
-    if (this.signal) {
-      this.signal.addEventListener("abort", this.abort);
-    }
+    this.signal.addEventListener("abort", () => clearTimeout(this.timeoutId), {once: true});
   }
 
   public get currentSlot(): Slot {
@@ -47,12 +46,29 @@ export class LocalClock implements IBeaconClock {
     return computeEpochAtSlot(this.config, this.currentSlot);
   }
 
-  public abort = (): void => {
-    clearTimeout(this.timeoutId);
-    if (this.signal) {
-      this.signal.removeEventListener("abort", this.abort);
+  public async waitForSlot(slot: Slot): Promise<void> {
+    if (this.signal.aborted) {
+      throw new ErrorAborted();
     }
-  };
+    return new Promise((resolve, reject) => {
+      const onSlot = (clockSlot: Slot): void => {
+        if (clockSlot >= slot) {
+          onDone();
+        }
+      };
+      const onDone = (): void => {
+        this.emitter.removeListener("clock:slot", onSlot);
+        this.signal.removeEventListener("abort", onAbort);
+        resolve();
+      };
+      const onAbort = (): void => {
+        this.emitter.removeListener("clock:slot", onSlot);
+        reject(new ErrorAborted());
+      };
+      this.emitter.on("clock:slot", onSlot);
+      this.signal.addEventListener("abort", onAbort, {once: true});
+    });
+  }
 
   private onNextSlot = (): void => {
     const clockSlot = getCurrentSlot(this.config, this.genesisTime);

--- a/packages/lodestar/src/chain/clock/interface.ts
+++ b/packages/lodestar/src/chain/clock/interface.ts
@@ -3,5 +3,10 @@ import {Epoch, Slot} from "@chainsafe/lodestar-types";
 export interface IBeaconClock {
   readonly currentSlot: Slot;
   readonly currentEpoch: Epoch;
-  abort(): void;
+  /**
+   * Returns a promise that waits until at least `slot` is reached
+   * Resolves when the current slot >= `slot`
+   * Rejects if the clock is aborted
+   */
+  waitForSlot(slot: Slot): Promise<void>;
 }

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -23,7 +23,8 @@ export async function assembleBlock(
   randaoReveal: Bytes96,
   graffiti = ZERO_HASH
 ): Promise<BeaconBlock> {
-  const [parentBlock, stateContext] = await Promise.all([chain.getHeadBlock(), chain.getHeadStateContext()]);
+  const parentBlock = await chain.getHeadBlock();
+  const stateContext = await chain.regen.getBlockSlotState(chain.forkChoice.getHeadRoot(), slot - 1);
   const parentHeader: BeaconBlockHeader = blockToHeader(config, parentBlock!.message);
   const headState = stateContext!.state.clone();
   headState.slot = slot;

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -24,7 +24,7 @@ export async function assembleBlock(
   graffiti = ZERO_HASH
 ): Promise<BeaconBlock> {
   const head = chain.forkChoice.getHead();
-  const stateContext = await chain.regen.getState(head.stateRoot);
+  const stateContext = await chain.regen.getBlockSlotState(head.blockRoot, slot - 1);
   const headState = stateContext.state.clone();
   headState.slot = slot;
   const block: BeaconBlock = {

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -7,7 +7,7 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
 import {IBeaconDb} from "../../../db/api";
 import {assembleBody} from "./body";
-import {EpochContext, fastStateTransition} from "@chainsafe/lodestar-beacon-state-transition";
+import {fastStateTransition} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconChain} from "../../interface";
 import {EMPTY_SIGNATURE, ZERO_HASH} from "../../../constants";
 import {IStateContext} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -2,12 +2,12 @@
  * @module chain/blockAssembly
  */
 
-import {BeaconBlock, BeaconBlockHeader, Bytes96, Root, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {BeaconBlock, Bytes96, Root, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
 import {IBeaconDb} from "../../../db/api";
 import {assembleBody} from "./body";
-import {blockToHeader, EpochContext, fastStateTransition} from "@chainsafe/lodestar-beacon-state-transition";
+import {EpochContext, fastStateTransition} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconChain} from "../../interface";
 import {EMPTY_SIGNATURE, ZERO_HASH} from "../../../constants";
 import {IStateContext} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
@@ -23,27 +23,26 @@ export async function assembleBlock(
   randaoReveal: Bytes96,
   graffiti = ZERO_HASH
 ): Promise<BeaconBlock> {
-  const parentBlock = await chain.getHeadBlock();
-  const stateContext = await chain.regen.getBlockSlotState(chain.forkChoice.getHeadRoot(), slot - 1);
-  const parentHeader: BeaconBlockHeader = blockToHeader(config, parentBlock!.message);
-  const headState = stateContext!.state.clone();
+  const head = chain.forkChoice.getHead();
+  const stateContext = await chain.regen.getState(head.stateRoot);
+  const headState = stateContext.state.clone();
   headState.slot = slot;
   const block: BeaconBlock = {
     slot,
     proposerIndex,
-    parentRoot: config.types.BeaconBlockHeader.hashTreeRoot(parentHeader),
+    parentRoot: head.blockRoot,
     stateRoot: ZERO_HASH,
     body: await assembleBody(config, db, eth1, headState, randaoReveal, graffiti),
   };
 
   let epochCtx: EpochContext;
-  if (!stateContext!.epochCtx) {
+  if (!stateContext.epochCtx) {
     epochCtx = new EpochContext(config);
-    epochCtx.loadState(stateContext!.state);
+    epochCtx.loadState(stateContext.state);
   } else {
-    epochCtx = stateContext!.epochCtx;
+    epochCtx = stateContext.epochCtx;
   }
-  block.stateRoot = computeNewStateRoot(config, {state: stateContext!.state, epochCtx}, block);
+  block.stateRoot = computeNewStateRoot(config, {state: stateContext.state, epochCtx}, block);
 
   return block;
 }

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -19,6 +19,7 @@ import {IBeaconClock} from "./clock/interface";
 import {ITreeStateContext} from "../db/api/beacon/stateContextCache";
 import {IService} from "../node";
 import {ChainEventEmitter} from "./emitter";
+import {IStateRegenerator} from "./regen";
 
 export interface IBlockProcessJob {
   signedBlock: SignedBeaconBlock;
@@ -38,6 +39,7 @@ export type BlockError = {
 export interface IBeaconChain {
   emitter: ChainEventEmitter;
   forkChoice: IForkChoice;
+  regen: IStateRegenerator;
   clock: IBeaconClock;
   chainId: Uint16;
   networkId: Uint64;

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -60,9 +60,10 @@ export interface IBeaconChain {
   getENRForkID(): Promise<ENRForkID>;
   getGenesisTime(): Number64;
   getHeadStateContext(): Promise<ITreeStateContext>;
+  getHeadStateContextAtCurrentEpoch(): Promise<ITreeStateContext>;
+  getHeadStateContextAtCurrentSlot(): Promise<ITreeStateContext>;
   getHeadState(): Promise<TreeBacked<BeaconState>>;
   getHeadEpochContext(): Promise<EpochContext>;
-
   getHeadBlock(): Promise<SignedBeaconBlock | null>;
 
   getStateContextByBlockRoot(blockRoot: Root): Promise<ITreeStateContext | null>;

--- a/packages/lodestar/src/chain/regen/errors.ts
+++ b/packages/lodestar/src/chain/regen/errors.ts
@@ -1,0 +1,44 @@
+import {Root, Slot} from "@chainsafe/lodestar-types";
+
+export enum RegenErrorCode {
+  ERR_BLOCK_NOT_IN_FORKCHOICE = "ERR_BLOCK_NOT_IN_FORKCHOICE",
+  ERR_STATE_NOT_IN_FORKCHOICE = "ERR_STATE_NOT_IN_FORKCHOICE",
+  ERR_SLOT_BEFORE_BLOCK_SLOT = "ERR_SLOT_BEFORE_BLOCK_SLOT",
+  ERR_NO_SEED_STATE = "ERR_NO_SEED_STATE",
+  ERR_BLOCK_NOT_IN_DB = "ERR_BLOCK_NOT_IN_DB",
+  ERR_STATE_TRANSITION_ERROR = "ERR_STATE_TRANSITION_ERROR",
+}
+
+export type RegenErrorType =
+  | {
+      code: RegenErrorCode.ERR_BLOCK_NOT_IN_FORKCHOICE;
+      blockRoot: Root;
+    }
+  | {
+      code: RegenErrorCode.ERR_STATE_NOT_IN_FORKCHOICE;
+      stateRoot: Root;
+    }
+  | {
+      code: RegenErrorCode.ERR_SLOT_BEFORE_BLOCK_SLOT;
+      slot: Slot;
+      blockSlot: Slot;
+    }
+  | {
+      code: RegenErrorCode.ERR_NO_SEED_STATE;
+    }
+  | {
+      code: RegenErrorCode.ERR_BLOCK_NOT_IN_DB;
+      blockRoot: Root;
+    }
+  | {
+      code: RegenErrorCode.ERR_STATE_TRANSITION_ERROR;
+      error: Error;
+    };
+
+export class RegenError extends Error {
+  type: RegenErrorType;
+  constructor(type: RegenErrorType) {
+    super(type.code);
+    this.type = type;
+  }
+}

--- a/packages/lodestar/src/chain/regen/index.ts
+++ b/packages/lodestar/src/chain/regen/index.ts
@@ -1,0 +1,4 @@
+export * from "./errors";
+export * from "./interface";
+export * from "./regen";
+export * from "./queued";

--- a/packages/lodestar/src/chain/regen/interface.ts
+++ b/packages/lodestar/src/chain/regen/interface.ts
@@ -1,0 +1,29 @@
+import {BeaconBlock, Checkpoint, Root, Slot} from "@chainsafe/lodestar-types";
+import {ITreeStateContext} from "../../db/api/beacon/stateContextCache";
+
+/**
+ * Regenerates states that have already been processed by the fork choice
+ */
+export interface IStateRegenerator {
+  /**
+   * Return a valid pre-state for a beacon block
+   * This will always return a state in the latest viable epoch
+   */
+  getPreState: (block: BeaconBlock) => Promise<ITreeStateContext>;
+
+  /**
+   * Return a valid checkpoint state
+   * This will always return a state with `state.slot % SLOTS_PER_EPOCH === 0`
+   */
+  getCheckpointState: (cp: Checkpoint) => Promise<ITreeStateContext>;
+
+  /**
+   * Return the state of `blockRoot` processed to slot `slot`
+   */
+  getBlockSlotState: (blockRoot: Root, slot: Slot) => Promise<ITreeStateContext>;
+
+  /**
+   * Return the exact state with `stateRoot`
+   */
+  getState: (stateRoot: Root) => Promise<ITreeStateContext>;
+}

--- a/packages/lodestar/src/chain/regen/queued.ts
+++ b/packages/lodestar/src/chain/regen/queued.ts
@@ -1,0 +1,55 @@
+import {BeaconBlock, Root, Checkpoint, Slot} from "@chainsafe/lodestar-types";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
+
+import {ITreeStateContext} from "../../db/api/beacon/stateContextCache";
+import {ChainEventEmitter} from "../emitter";
+import {IBeaconDb} from "../../db";
+import {JobQueue} from "../../util/queue";
+import {IStateRegenerator} from "./interface";
+import {StateRegenerator} from "./regen";
+
+/**
+ * Regenerates states that have already been processed by the fork choice
+ *
+ * All requests are queued so that only a single state at a time may be regenerated at a time
+ */
+export class QueuedStateRegenerator implements IStateRegenerator {
+  private regen: StateRegenerator;
+  private jobQueue: JobQueue;
+
+  constructor({
+    config,
+    emitter,
+    forkChoice,
+    db,
+    signal,
+    queueSize = 256,
+  }: {
+    config: IBeaconConfig;
+    emitter: ChainEventEmitter;
+    forkChoice: IForkChoice;
+    db: IBeaconDb;
+    signal: AbortSignal;
+    queueSize?: number;
+  }) {
+    this.regen = new StateRegenerator({config, emitter, forkChoice, db});
+    this.jobQueue = new JobQueue({queueSize, signal});
+  }
+
+  async getPreState(block: BeaconBlock): Promise<ITreeStateContext> {
+    return await this.jobQueue.enqueueJob(async () => await this.regen.getPreState(block));
+  }
+
+  async getCheckpointState(cp: Checkpoint): Promise<ITreeStateContext> {
+    return await this.jobQueue.enqueueJob(async () => await this.regen.getCheckpointState(cp));
+  }
+
+  async getBlockSlotState(blockRoot: Root, slot: Slot): Promise<ITreeStateContext> {
+    return await this.jobQueue.enqueueJob(async () => await this.regen.getBlockSlotState(blockRoot, slot));
+  }
+
+  async getState(stateRoot: Root): Promise<ITreeStateContext> {
+    return await this.jobQueue.enqueueJob(async () => await this.regen.getState(stateRoot));
+  }
+}

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -1,0 +1,167 @@
+import {BeaconBlock, Checkpoint, Root, Slot} from "@chainsafe/lodestar-types";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
+
+import {ITreeStateContext} from "../../db/api/beacon/stateContextCache";
+import {ChainEventEmitter} from "../emitter";
+import {IBeaconDb} from "../../db";
+import {processSlotsByCheckpoint, runStateTransition} from "../blocks/stateTransition";
+import {IStateRegenerator} from "./interface";
+import {RegenError, RegenErrorCode} from "./errors";
+
+/**
+ * Regenerates states that have already been processed by the fork choice
+ */
+export class StateRegenerator implements IStateRegenerator {
+  private config: IBeaconConfig;
+  private emitter: ChainEventEmitter;
+  private forkChoice: IForkChoice;
+  private db: IBeaconDb;
+
+  constructor({
+    config,
+    emitter,
+    forkChoice,
+    db,
+  }: {
+    config: IBeaconConfig;
+    emitter: ChainEventEmitter;
+    forkChoice: IForkChoice;
+    db: IBeaconDb;
+  }) {
+    this.config = config;
+    this.emitter = emitter;
+    this.forkChoice = forkChoice;
+    this.db = db;
+  }
+
+  async getPreState(block: BeaconBlock): Promise<ITreeStateContext> {
+    const parentBlock = this.forkChoice.getBlock(block.parentRoot);
+    if (!parentBlock) {
+      throw new RegenError({
+        code: RegenErrorCode.ERR_BLOCK_NOT_IN_FORKCHOICE,
+        blockRoot: block.parentRoot,
+      });
+    }
+    const parentEpoch = computeEpochAtSlot(this.config, parentBlock.slot);
+    const blockEpoch = computeEpochAtSlot(this.config, block.slot);
+    const isCheckpointBlock = block.slot % this.config.params.SLOTS_PER_EPOCH === 0;
+    if (parentEpoch < blockEpoch && !isCheckpointBlock) {
+      // If the requested state crosses an epoch boundary and the block isn't a checkpoint block
+      // then we may use the checkpoint state before the block. This may save us at least one epoch transition.
+      return this.getCheckpointState({root: block.parentRoot, epoch: blockEpoch});
+    } else if (parentEpoch < blockEpoch - 1) {
+      // If there's more than one epoch to pre-process (but the block is a checkpoint block)
+      // get the checkpoint state as close as possible
+      return this.getCheckpointState({root: block.parentRoot, epoch: blockEpoch - 1});
+    } else {
+      // Otherwise, get the state normally.
+      return this.getState(parentBlock.stateRoot);
+    }
+  }
+
+  async getCheckpointState(cp: Checkpoint): Promise<ITreeStateContext> {
+    const checkpointStartSlot = computeStartSlotAtEpoch(this.config, cp.epoch);
+    return await this.getBlockSlotState(cp.root, checkpointStartSlot);
+  }
+
+  async getBlockSlotState(blockRoot: Root, slot: Slot): Promise<ITreeStateContext> {
+    const block = this.forkChoice.getBlock(blockRoot);
+    if (!block) {
+      throw new RegenError({
+        code: RegenErrorCode.ERR_BLOCK_NOT_IN_FORKCHOICE,
+        blockRoot,
+      });
+    }
+    if (slot < block.slot) {
+      throw new RegenError({
+        code: RegenErrorCode.ERR_SLOT_BEFORE_BLOCK_SLOT,
+        slot,
+        blockSlot: block.slot,
+      });
+    }
+    const cp = {
+      root: blockRoot,
+      epoch: computeEpochAtSlot(this.config, slot),
+    };
+    const latestCheckpointStateCtx = await this.db.checkpointStateCache.getLatest(cp);
+    if (latestCheckpointStateCtx) {
+      // If a checkpoint state exists with the given checkpoint root, it either is in requested epoch
+      // or needs to have empty slots processed until the requested epoch
+      return await processSlotsByCheckpoint(this.emitter, latestCheckpointStateCtx, slot);
+    } else {
+      // Otherwise, use the fork choice to get the stateRoot from block at the checkpoint root
+      // regenerate that state,
+      // then process empty slots until the requested epoch
+      const blockStateCtx = await this.getState(block.stateRoot);
+      return await processSlotsByCheckpoint(this.emitter, blockStateCtx, slot);
+    }
+  }
+
+  async getState(stateRoot: Root): Promise<ITreeStateContext> {
+    // Trivial case, stateCtx at stateRoot is already cached
+    const cachedStateCtx = await this.db.stateCache.get(stateRoot);
+    if (cachedStateCtx) {
+      return cachedStateCtx;
+    }
+    // Otherwise we have to use the fork choice to traverse backwards, block by block,
+    // searching the state caches
+    // then replay blocks forward to the desired stateRoot
+    const _Root = this.config.types.Root;
+    const block = this.forkChoice
+      .forwardIterateBlockSummaries()
+      .find((summary) => _Root.equals(summary.stateRoot, stateRoot));
+    if (!block) {
+      throw new RegenError({
+        code: RegenErrorCode.ERR_STATE_NOT_IN_FORKCHOICE,
+        stateRoot,
+      });
+    }
+    // blocks to replay, ordered highest to lowest
+    // gets reversed when replayed
+    const blocksToReplay = [block];
+    let stateCtx: ITreeStateContext | null = null;
+    for (const b of this.forkChoice.iterateBlockSummaries(block.parentRoot)) {
+      stateCtx = await this.db.stateCache.get(b.stateRoot);
+      if (stateCtx) {
+        break;
+      }
+      stateCtx = await this.db.checkpointStateCache.getLatest({
+        root: b.blockRoot,
+        epoch: computeEpochAtSlot(this.config, blocksToReplay[blocksToReplay.length - 1].slot - 1),
+      });
+      if (stateCtx) {
+        break;
+      }
+      blocksToReplay.push(b);
+    }
+    if (stateCtx === null) {
+      throw new RegenError({
+        code: RegenErrorCode.ERR_NO_SEED_STATE,
+      });
+    }
+    for (const b of blocksToReplay.reverse()) {
+      const block = await this.db.block.get(b.blockRoot);
+      if (!block) {
+        throw new RegenError({
+          code: RegenErrorCode.ERR_BLOCK_NOT_IN_DB,
+          blockRoot: b.blockRoot,
+        });
+      }
+      try {
+        stateCtx = await runStateTransition(this.emitter, this.forkChoice, stateCtx, {
+          signedBlock: block,
+          trusted: true,
+          reprocess: true,
+        });
+      } catch (e) {
+        throw new RegenError({
+          code: RegenErrorCode.ERR_STATE_TRANSITION_ERROR,
+          error: e,
+        });
+      }
+    }
+    return stateCtx;
+  }
+}

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -108,10 +108,10 @@ export class StateRegenerator implements IStateRegenerator {
     // Otherwise we have to use the fork choice to traverse backwards, block by block,
     // searching the state caches
     // then replay blocks forward to the desired stateRoot
-    const _Root = this.config.types.Root;
+    const rootType = this.config.types.Root;
     const block = this.forkChoice
       .forwardIterateBlockSummaries()
-      .find((summary) => _Root.equals(summary.stateRoot, stateRoot));
+      .find((summary) => rootType.equals(summary.stateRoot, stateRoot));
     if (!block) {
       throw new RegenError({
         code: RegenErrorCode.ERR_STATE_NOT_IN_FORKCHOICE,

--- a/packages/lodestar/src/network/gossip/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/network/gossip/validation/aggregateAndProof.ts
@@ -8,13 +8,10 @@ import {toHexString} from "@chainsafe/ssz";
 import {ATTESTATION_PROPAGATION_SLOT_RANGE, MAXIMUM_GOSSIP_CLOCK_DISPARITY} from "../../../constants";
 import {
   computeEpochAtSlot,
-  computeStartSlotAtEpoch,
   getCurrentSlot,
   isAggregatorFromCommitteeLength,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {isAttestingToInValidBlock} from "./attestation";
-import {getAttestationPreState} from "../utils";
-import {processSlots} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/slot";
 import {Signature} from "@chainsafe/bls";
 import {isValidIndexedAttestation} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/block/isValidIndexedAttestation";
 import {isValidAggregateAndProofSignature, isValidSelectionProofSignature} from "./utils";
@@ -97,17 +94,15 @@ export async function validateAggregateAttestation(
   aggregateAndProof: SignedAggregateAndProof
 ): Promise<ExtendedValidatorResult> {
   const attestation = aggregateAndProof.message.aggregate;
-  const attestationPreState = await getAttestationPreState(config, chain, db, attestation.data.target);
-  if (!attestationPreState) {
+  let attestationPreState;
+  try {
+    // the target state, advanced to the attestation slot
+    attestationPreState = await chain.regen.getBlockSlotState(attestation.data.target.root, attestation.data.slot);
+  } catch (e) {
     logger.warn("Ignored gossip aggregate and proof", {reason: "missing attestation prestate", ...logContext});
     return ExtendedValidatorResult.ignore;
   }
   const {state, epochCtx} = attestationPreState;
-  //committee changes on epoch, so advance only if different epoch
-  const attEpoch = computeEpochAtSlot(config, attestation.data.slot);
-  if (attEpoch > computeEpochAtSlot(config, state.slot)) {
-    processSlots(epochCtx, state, computeStartSlotAtEpoch(config, attEpoch));
-  }
   const committee = epochCtx.getBeaconCommittee(attestation.data.slot, attestation.data.index);
   if (!committee.includes(aggregateAndProof.message.aggregatorIndex)) {
     logger.warn("Rejected gossip aggregate and proof", {reason: "aggregator not in committee", ...logContext});

--- a/packages/lodestar/src/network/gossip/validation/block.ts
+++ b/packages/lodestar/src/network/gossip/validation/block.ts
@@ -7,7 +7,6 @@ import {ExtendedValidatorResult} from "../constants";
 import {ILogger, sleep} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
 import {verifyBlockSignature} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
-import {getBlockStateContext} from "../utils";
 
 export async function validateGossipBlock(
   config: IBeaconConfig,
@@ -52,8 +51,10 @@ export async function validateGossipBlock(
     return ExtendedValidatorResult.ignore;
   }
 
-  const blockContext = await getBlockStateContext(chain.forkChoice, db, block.message.parentRoot, block.message.slot);
-  if (!blockContext) {
+  let blockContext;
+  try {
+    blockContext = await chain.regen.getPreState(block.message);
+  } catch (e) {
     logger.warn("Ignoring gossip block", {
       reason: "missing parent",
       blockSlot,

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -10,7 +10,6 @@ import {
 } from "@chainsafe/lodestar-types";
 import {IBeaconDb} from "../../db";
 import {
-  computeStartSlotAtEpoch,
   isValidAttesterSlashing,
   isValidProposerSlashing,
   isValidVoluntaryExit,
@@ -21,7 +20,6 @@ import {IBeaconChain} from "../../chain";
 import {arrayIntersection, sszEqualPredicate} from "../../util/objects";
 import {ExtendedValidatorResult} from "./constants";
 import {validateGossipAggregateAndProof, validateGossipAttestation, validateGossipBlock} from "./validation";
-import {processSlots} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/slot";
 
 /* eslint-disable @typescript-eslint/interface-name-prefix */
 interface GossipMessageValidatorModules {
@@ -89,11 +87,10 @@ export class GossipMessageValidator implements IGossipMessageValidator {
     if (await this.db.voluntaryExit.has(voluntaryExit.message.validatorIndex)) {
       return ExtendedValidatorResult.ignore;
     }
-    const {state, epochCtx} = await this.chain.getHeadStateContext();
-    const startSlot = computeStartSlotAtEpoch(this.config, voluntaryExit.message.epoch);
-    if (state.slot < startSlot) {
-      processSlots(epochCtx, state, startSlot);
-    }
+    const {state} = await this.chain.regen.getCheckpointState({
+      root: this.chain.forkChoice.getHeadRoot(),
+      epoch: voluntaryExit.message.epoch,
+    });
     if (!isValidVoluntaryExit(this.config, state, voluntaryExit)) {
       return ExtendedValidatorResult.reject;
     }

--- a/packages/lodestar/src/util/queue.ts
+++ b/packages/lodestar/src/util/queue.ts
@@ -1,0 +1,78 @@
+import {EventEmitter} from "events";
+
+export enum QueueErrorCode {
+  ERR_QUEUE_ABORTED = "ERR_QUEUE_ABORTED",
+  ERR_QUEUE_THROTTLED = "ERR_QUEUE_THROTTLED",
+}
+
+export class QueueError extends Error {
+  code: QueueErrorCode;
+  constructor(code: QueueErrorCode, msg?: string) {
+    super(msg || code);
+    this.code = code;
+  }
+}
+
+/**
+ * EventEmitter-based job queue
+ */
+export class JobQueue extends EventEmitter {
+  private finished: number;
+  private next: number;
+  private queueSize: number;
+  private signal: AbortSignal;
+
+  constructor({queueSize, signal}: {queueSize: number; signal: AbortSignal}) {
+    super();
+    this.finished = 0;
+    this.next = 0;
+    this.queueSize = queueSize;
+    this.signal = signal;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async enqueueJob<T extends (...args: any) => any>(job: T): Promise<ReturnType<T>> {
+    const id = await this.startJob();
+    try {
+      const result = await job();
+      await this.finishJob(id);
+      return result;
+    } catch (e) {
+      await this.finishJob(id);
+      throw e;
+    }
+  }
+
+  async startJob(): Promise<number> {
+    if (this.signal.aborted) {
+      throw new QueueError(QueueErrorCode.ERR_QUEUE_ABORTED);
+    }
+    if (this.next + 1 - this.finished > this.queueSize) {
+      throw new QueueError(QueueErrorCode.ERR_QUEUE_THROTTLED);
+    }
+    const prev = this.next;
+    this.next++;
+    const id = this.next;
+    // the job should start right away if there are no outstanding jobs
+    if (prev === this.finished) {
+      return id;
+    }
+    // otherwise wait for the previous job to complete
+    return await new Promise((resolve, reject) => {
+      const abortHandler = (): void => {
+        this.removeAllListeners(prev.toString());
+        reject(new QueueError(QueueErrorCode.ERR_QUEUE_ABORTED));
+      };
+      this.once(prev.toString(), () => {
+        this.signal.removeEventListener("abort", abortHandler);
+        resolve(id);
+      });
+      this.signal.addEventListener("abort", abortHandler, {once: true});
+    });
+  }
+
+  async finishJob(id: number): Promise<void> {
+    this.finished = id;
+    this.emit(id.toString());
+  }
+}

--- a/packages/lodestar/test/unit/api/impl/validator/duties/proposer.test.ts
+++ b/packages/lodestar/test/unit/api/impl/validator/duties/proposer.test.ts
@@ -81,7 +81,7 @@ describe("get proposers api impl", function () {
     });
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
-    regenStub.getBlockSlotState.resolves({
+    chainStub.getHeadStateContextAtCurrentEpoch.resolves({
       state,
       epochCtx,
     });
@@ -105,7 +105,7 @@ describe("get proposers api impl", function () {
     });
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
-    regenStub.getBlockSlotState.resolves({
+    chainStub.getHeadStateContextAtCurrentEpoch.resolves({
       state,
       epochCtx,
     });

--- a/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
@@ -63,7 +63,7 @@ describe("block assembly", function () {
       expect(result.slot).to.equal(1);
       expect(result.stateRoot).to.not.be.null;
       expect(result.parentRoot).to.not.be.null;
-      expect(regenStub.getBlockSlotState.calledOnce).to.be.true;
+      expect(regenStub.getBlockSlotState.calledTwice).to.be.true;
       expect(assembleBodyStub.calledOnce).to.be.true;
     } catch (e) {
       expect.fail(e.stack);

--- a/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
@@ -2,23 +2,26 @@ import sinon, {SinonStubbedInstance} from "sinon";
 import {expect} from "chai";
 
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
-import * as blockBodyAssembly from "../../../../../src/chain/factory/block/body";
-import * as blockTransitions from "@chainsafe/lodestar-beacon-state-transition/lib/fast";
-import {assembleBlock} from "../../../../../src/chain/factory/block";
-import {generateState} from "../../../../utils/state";
-import {ForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {BeaconChain} from "../../../../../src/chain";
-import {generateEmptyBlock, generateEmptySignedBlock} from "../../../../utils/block";
-import {StubbedBeaconDb, StubbedChain} from "../../../../utils/stub";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
+import * as blockTransitions from "@chainsafe/lodestar-beacon-state-transition/lib/fast";
+import {ForkChoice} from "@chainsafe/lodestar-fork-choice";
+
+import {BeaconChain} from "../../../../../src/chain";
+import {LocalClock} from "../../../../../src/chain/clock";
+import {assembleBlock} from "../../../../../src/chain/factory/block";
+import * as blockBodyAssembly from "../../../../../src/chain/factory/block/body";
+import {StateRegenerator} from "../../../../../src/chain/regen";
 import {Eth1ForBlockProduction} from "../../../../../src/eth1/";
+import {generateEmptyBlock, generateEmptySignedBlock} from "../../../../utils/block";
+import {generateState} from "../../../../utils/state";
+import {StubbedBeaconDb, StubbedChain} from "../../../../utils/stub";
 
 describe("block assembly", function () {
   const sandbox = sinon.createSandbox();
 
   let assembleBodyStub: any,
     chainStub: StubbedChain,
-    forkChoiceStub: SinonStubbedInstance<ForkChoice>,
+    regenStub: SinonStubbedInstance<StateRegenerator>,
     stateTransitionStub: any,
     beaconDB: StubbedBeaconDb;
 
@@ -26,9 +29,10 @@ describe("block assembly", function () {
     assembleBodyStub = sandbox.stub(blockBodyAssembly, "assembleBody");
     stateTransitionStub = sandbox.stub(blockTransitions, "fastStateTransition");
 
-    forkChoiceStub = sandbox.createStubInstance(ForkChoice);
     chainStub = (sandbox.createStubInstance(BeaconChain) as unknown) as StubbedChain;
-    chainStub.forkChoice = forkChoiceStub;
+    chainStub.forkChoice = sandbox.createStubInstance(ForkChoice);
+    chainStub.clock = sandbox.createStubInstance(LocalClock);
+    regenStub = chainStub.regen = sandbox.createStubInstance(StateRegenerator);
 
     beaconDB = new StubbedBeaconDb(sandbox);
   });
@@ -39,7 +43,8 @@ describe("block assembly", function () {
 
   it("should assemble block", async function () {
     chainStub.getHeadBlock.resolves(generateEmptySignedBlock());
-    chainStub.getHeadStateContext.resolves({
+    sandbox.stub(chainStub.clock, "currentSlot").get(() => 1);
+    regenStub.getBlockSlotState.resolves({
       state: generateState({slot: 1}),
       epochCtx: new EpochContext(config),
     });
@@ -57,7 +62,7 @@ describe("block assembly", function () {
       expect(result.slot).to.equal(1);
       expect(result.stateRoot).to.not.be.null;
       expect(result.parentRoot).to.not.be.null;
-      expect(chainStub.getHeadStateContext.calledOnce).to.be.true;
+      expect(regenStub.getBlockSlotState.calledOnce).to.be.true;
       expect(chainStub.getHeadBlock.calledOnce).to.be.true;
       expect(assembleBodyStub.calledOnce).to.be.true;
     } catch (e) {

--- a/packages/lodestar/test/unit/network/gossip/validation/aggregateAndProof.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/validation/aggregateAndProof.test.ts
@@ -1,28 +1,30 @@
 import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
-import {BeaconChain, IBeaconChain} from "../../../../../src/chain";
-import {StubbedBeaconDb} from "../../../../utils/stub";
-import {validateGossipAggregateAndProof} from "../../../../../src/network/gossip/validation";
-import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {generateSignedAggregateAndProof} from "../../../../utils/aggregateAndProof";
 import {expect} from "chai";
-import {ExtendedValidatorResult} from "../../../../../src/network/gossip/constants";
-import {ATTESTATION_PROPAGATION_SLOT_RANGE, MAXIMUM_GOSSIP_CLOCK_DISPARITY} from "../../../../../src/constants";
+
 import {List} from "@chainsafe/ssz";
-import * as gossipUtils from "../../../../../src/network/gossip/utils";
-import * as validatorUtils from "@chainsafe/lodestar-beacon-state-transition/lib/util/validator";
-import * as validationUtils from "../../../../../src/network/gossip/validation/utils";
-import {LocalClock} from "../../../../../src/chain/clock";
-import * as blockUtils from "@chainsafe/lodestar-beacon-state-transition/lib/fast/block/isValidIndexedAttestation";
-import {generateState} from "../../../../utils/state";
-import {EpochContext, getCurrentSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {PrivateKey, PublicKey} from "@chainsafe/bls";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import * as validatorUtils from "@chainsafe/lodestar-beacon-state-transition/lib/util/validator";
+import {EpochContext, getCurrentSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import * as blockUtils from "@chainsafe/lodestar-beacon-state-transition/lib/fast/block/isValidIndexedAttestation";
+
+import {BeaconChain, IBeaconChain} from "../../../../../src/chain";
+import {LocalClock} from "../../../../../src/chain/clock";
+import {IStateRegenerator, StateRegenerator} from "../../../../../src/chain/regen";
+import {validateGossipAggregateAndProof} from "../../../../../src/network/gossip/validation";
+import {ATTESTATION_PROPAGATION_SLOT_RANGE, MAXIMUM_GOSSIP_CLOCK_DISPARITY} from "../../../../../src/constants";
+import {ExtendedValidatorResult} from "../../../../../src/network/gossip/constants";
+import * as validationUtils from "../../../../../src/network/gossip/validation/utils";
+import {generateSignedAggregateAndProof} from "../../../../utils/aggregateAndProof";
+import {generateState} from "../../../../utils/state";
 import {silentLogger} from "../../../../utils/logger";
+import {StubbedBeaconDb} from "../../../../utils/stub";
 
 describe("gossip aggregate and proof test", function () {
   const logger = silentLogger;
   let chain: SinonStubbedInstance<IBeaconChain>;
+  let regen: SinonStubbedInstance<IStateRegenerator>;
   let db: StubbedBeaconDb;
-  let getAttestationPreStateStub: SinonStub;
   let isAggregatorStub: SinonStub;
   let isValidSelectionProofStub: SinonStub;
   let isValidSignatureStub: SinonStub;
@@ -33,9 +35,9 @@ describe("gossip aggregate and proof test", function () {
     db = new StubbedBeaconDb(sinon);
     chain.getGenesisTime.returns(Math.floor(Date.now() / 1000));
     chain.clock = sinon.createStubInstance(LocalClock);
+    regen = chain.regen = sinon.createStubInstance(StateRegenerator);
     db.badBlock.has.resolves(false);
     db.seenAttestationCache.hasAggregateAndProof.resolves(false);
-    getAttestationPreStateStub = sinon.stub(gossipUtils, "getAttestationPreState");
     isAggregatorStub = sinon.stub(validatorUtils, "isAggregatorFromCommitteeLength");
     isValidSelectionProofStub = sinon.stub(validationUtils, "isValidSelectionProofSignature");
     isValidSignatureStub = sinon.stub(validationUtils, "isValidAggregateAndProofSignature");
@@ -43,7 +45,6 @@ describe("gossip aggregate and proof test", function () {
   });
 
   afterEach(function () {
-    getAttestationPreStateStub.restore();
     isAggregatorStub.restore();
     isValidSelectionProofStub.restore();
     isValidSignatureStub.restore();
@@ -52,7 +53,9 @@ describe("gossip aggregate and proof test", function () {
 
   it("should ignore - invalid slot (too old)", async function () {
     //move genesis time in past so current slot is high
-    chain.getGenesisTime.returns(Math.floor(Date.now() / 1000) - (ATTESTATION_PROPAGATION_SLOT_RANGE + 1) * config.params.SECONDS_PER_SLOT);
+    chain.getGenesisTime.returns(
+      Math.floor(Date.now() / 1000) - (ATTESTATION_PROPAGATION_SLOT_RANGE + 1) * config.params.SECONDS_PER_SLOT
+    );
     sinon
       .stub(chain.clock, "currentSlot")
       .get(() =>
@@ -77,12 +80,7 @@ describe("gossip aggregate and proof test", function () {
     chain.getGenesisTime.returns(Math.floor(Date.now() / 1000) + MAXIMUM_GOSSIP_CLOCK_DISPARITY + 1);
     sinon
       .stub(chain.clock, "currentSlot")
-      .get(() =>
-        getCurrentSlot(
-          config,
-          Math.floor(Date.now() / 1000) + MAXIMUM_GOSSIP_CLOCK_DISPARITY + 1
-        )
-      );
+      .get(() => getCurrentSlot(config, Math.floor(Date.now() / 1000) + MAXIMUM_GOSSIP_CLOCK_DISPARITY + 1));
     const item = generateSignedAggregateAndProof({
       aggregate: {
         data: {
@@ -146,10 +144,10 @@ describe("gossip aggregate and proof test", function () {
         },
       },
     });
-    getAttestationPreStateStub.resolves(false);
+    regen.getBlockSlotState.throws();
     const result = await validateGossipAggregateAndProof(config, chain, db, logger, item);
     expect(result).to.be.equal(ExtendedValidatorResult.ignore);
-    expect(getAttestationPreStateStub.withArgs(config, chain, db, item.message.aggregate.data.target).calledOnce).to.be
+    expect(regen.getBlockSlotState.withArgs(item.message.aggregate.data.target.root, sinon.match.any).calledOnce).to.be
       .true;
   });
 
@@ -164,9 +162,9 @@ describe("gossip aggregate and proof test", function () {
     });
     const state = generateState();
     const epochCtx = sinon.createStubInstance(EpochContext);
-    getAttestationPreStateStub.resolves({
+    regen.getBlockSlotState.resolves({
       state,
-      epochCtx,
+      epochCtx: (epochCtx as unknown) as EpochContext,
     });
     epochCtx.getBeaconCommittee.returns([]);
     const result = await validateGossipAggregateAndProof(config, chain, db, logger, item);
@@ -188,9 +186,9 @@ describe("gossip aggregate and proof test", function () {
     });
     const state = generateState();
     const epochCtx = sinon.createStubInstance(EpochContext);
-    getAttestationPreStateStub.resolves({
+    regen.getBlockSlotState.resolves({
       state,
-      epochCtx,
+      epochCtx: (epochCtx as unknown) as EpochContext,
     });
     epochCtx.getBeaconCommittee.returns([item.message.aggregatorIndex]);
     isAggregatorStub.returns(false);
@@ -212,9 +210,9 @@ describe("gossip aggregate and proof test", function () {
     const epochCtx = sinon.createStubInstance(EpochContext);
     epochCtx.index2pubkey = [];
     epochCtx.index2pubkey[item.message.aggregatorIndex] = PublicKey.fromPrivateKey(PrivateKey.fromInt(1));
-    getAttestationPreStateStub.resolves({
+    regen.getBlockSlotState.resolves({
       state,
-      epochCtx,
+      epochCtx: (epochCtx as unknown) as EpochContext,
     });
     epochCtx.getBeaconCommittee.returns([item.message.aggregatorIndex]);
     isAggregatorStub.returns(true);
@@ -245,9 +243,9 @@ describe("gossip aggregate and proof test", function () {
     const epochCtx = sinon.createStubInstance(EpochContext);
     epochCtx.index2pubkey = [];
     epochCtx.index2pubkey[item.message.aggregatorIndex] = PublicKey.fromPrivateKey(PrivateKey.fromInt(1));
-    getAttestationPreStateStub.resolves({
+    regen.getBlockSlotState.resolves({
       state,
-      epochCtx,
+      epochCtx: (epochCtx as unknown) as EpochContext,
     });
     epochCtx.getBeaconCommittee.returns([item.message.aggregatorIndex]);
     isAggregatorStub.returns(true);
@@ -279,9 +277,9 @@ describe("gossip aggregate and proof test", function () {
     const epochCtx = sinon.createStubInstance(EpochContext);
     epochCtx.index2pubkey = [];
     epochCtx.index2pubkey[item.message.aggregatorIndex] = PublicKey.fromPrivateKey(PrivateKey.fromInt(1));
-    getAttestationPreStateStub.resolves({
+    regen.getBlockSlotState.resolves({
       state,
-      epochCtx,
+      epochCtx: (epochCtx as unknown) as EpochContext,
     });
     epochCtx.getBeaconCommittee.returns([item.message.aggregatorIndex]);
     isAggregatorStub.returns(true);
@@ -306,9 +304,9 @@ describe("gossip aggregate and proof test", function () {
     const epochCtx = sinon.createStubInstance(EpochContext);
     epochCtx.index2pubkey = [];
     epochCtx.index2pubkey[item.message.aggregatorIndex] = PublicKey.fromPrivateKey(PrivateKey.fromInt(1));
-    getAttestationPreStateStub.resolves({
+    regen.getBlockSlotState.resolves({
       state,
-      epochCtx,
+      epochCtx: (epochCtx as unknown) as EpochContext,
     });
     epochCtx.getBeaconCommittee.returns([item.message.aggregatorIndex]);
     isAggregatorStub.returns(true);

--- a/packages/lodestar/test/unit/network/gossip/validation/block.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/validation/block.test.ts
@@ -47,7 +47,7 @@ describe("gossip block validation", function () {
   });
 
   it("bad block", async function () {
-    chainStub.getGenesisTime.returns(Date.now() / 1000 - config.params.SECONDS_PER_SLOT);
+    sinon.stub(chainStub.clock, "currentSlot").get(() => 1);
     const block = generateSignedBlock({message: {slot: 1}});
     chainStub.getFinalizedCheckpoint.resolves({
       epoch: 0,
@@ -62,7 +62,7 @@ describe("gossip block validation", function () {
   });
 
   it("already proposed", async function () {
-    chainStub.getGenesisTime.returns(Date.now() / 1000 - config.params.SECONDS_PER_SLOT);
+    sinon.stub(chainStub.clock, "currentSlot").get(() => 1);
     const block = generateSignedBlock({message: {slot: 1}});
     chainStub.getFinalizedCheckpoint.resolves({
       epoch: 0,
@@ -78,7 +78,7 @@ describe("gossip block validation", function () {
   });
 
   it("missing parent", async function () {
-    chainStub.getGenesisTime.returns(Date.now() / 1000 - config.params.SECONDS_PER_SLOT);
+    sinon.stub(chainStub.clock, "currentSlot").get(() => 1);
     const block = generateSignedBlock({message: {slot: 1}});
     chainStub.getFinalizedCheckpoint.resolves({
       epoch: 0,
@@ -96,7 +96,7 @@ describe("gossip block validation", function () {
   });
 
   it("invalid signature", async function () {
-    chainStub.getGenesisTime.returns(Date.now() / 1000 - config.params.SECONDS_PER_SLOT);
+    sinon.stub(chainStub.clock, "currentSlot").get(() => 1);
     const block = generateSignedBlock({message: {slot: 1}});
     chainStub.getFinalizedCheckpoint.resolves({
       epoch: 0,
@@ -119,7 +119,7 @@ describe("gossip block validation", function () {
   });
 
   it("wrong proposer", async function () {
-    chainStub.getGenesisTime.returns(Date.now() / 1000 - config.params.SECONDS_PER_SLOT);
+    sinon.stub(chainStub.clock, "currentSlot").get(() => 1);
     const block = generateSignedBlock({message: {slot: 1}});
     chainStub.getFinalizedCheckpoint.resolves({
       epoch: 0,
@@ -145,7 +145,7 @@ describe("gossip block validation", function () {
   });
 
   it("valid block", async function () {
-    chainStub.getGenesisTime.returns(Date.now() / 1000 - config.params.SECONDS_PER_SLOT);
+    sinon.stub(chainStub.clock, "currentSlot").get(() => 1);
     const block = generateSignedBlock({message: {slot: 1}});
     chainStub.getFinalizedCheckpoint.resolves({
       epoch: 0,

--- a/packages/lodestar/test/unit/util/queue.test.ts
+++ b/packages/lodestar/test/unit/util/queue.test.ts
@@ -64,10 +64,8 @@ describe("Job queue", () => {
     const jobs = Promise.allSettled(Array.from({length: queueSize}, () => jobQueue.enqueueJob(job)));
     controller.abort();
     const results = await jobs;
-    // the first job is already in progress before the queue is aborted
-    expect(results[0].status).to.be.equal("fulfilled");
-    // all subsequent jobs should be rejected with ERR_QUEUE_ABORTED
-    results.slice(1).forEach((e) => {
+    // all jobs should be rejected with ERR_QUEUE_ABORTED
+    results.forEach((e) => {
       if (e.status === "rejected") {
         expect(e.reason).to.be.instanceOf(QueueError);
         expect(e.reason.code).to.be.equal(QueueErrorCode.ERR_QUEUE_ABORTED);

--- a/packages/lodestar/test/unit/util/queue.test.ts
+++ b/packages/lodestar/test/unit/util/queue.test.ts
@@ -1,0 +1,86 @@
+import {AbortController} from "abort-controller";
+import {expect} from "chai";
+
+import {JobQueue, QueueError, QueueErrorCode} from "../../../src/util/queue";
+
+describe("Job queue", () => {
+  const queueSize = 3;
+  const jobDuration = 20;
+
+  it("should only allow a single job at a time to run", async () => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+    const jobQueue = new JobQueue({queueSize, signal});
+
+    let activeJobs = 0;
+    const job = async (): Promise<void> => {
+      activeJobs++;
+      await new Promise((resolve) => setTimeout(resolve, jobDuration));
+      if (activeJobs > 1) {
+        throw new Error();
+      }
+      activeJobs--;
+    };
+    try {
+      // Start all jobs at the same time
+      // expect none of the jobs to be running simultaneously
+      await Promise.all(Array.from({length: queueSize}, () => jobQueue.enqueueJob(job)));
+    } catch (e) {
+      expect.fail();
+    }
+  });
+  it("should throw after the queue is full", async () => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+    const jobQueue = new JobQueue({queueSize, signal});
+
+    const job = async (): Promise<void> => {
+      await new Promise((resolve) => setTimeout(resolve, jobDuration));
+    };
+    // Start `queueSize` # of jobs at the same time
+    // the queue is now full
+    const jobs = Promise.all(Array.from({length: queueSize}, () => jobQueue.enqueueJob(job)));
+    try {
+      // the next enqueued job should go over the limit
+      await jobQueue.enqueueJob(job);
+    } catch (e) {
+      expect(e).to.be.instanceOf(QueueError);
+      expect(e.code).to.be.equal(QueueErrorCode.ERR_QUEUE_THROTTLED);
+    }
+    try {
+      await jobs;
+    } catch (e) {
+      expect.fail();
+    }
+  });
+  it("should throw after the queue is aborted", async () => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+    const jobQueue = new JobQueue({queueSize, signal});
+
+    const job = async (): Promise<void> => {
+      await new Promise((resolve) => setTimeout(resolve, jobDuration));
+    };
+    const jobs = Promise.allSettled(Array.from({length: queueSize}, () => jobQueue.enqueueJob(job)));
+    controller.abort();
+    const results = await jobs;
+    // the first job is already in progress before the queue is aborted
+    expect(results[0].status).to.be.equal("fulfilled");
+    // all subsequent jobs should be rejected with ERR_QUEUE_ABORTED
+    results.slice(1).forEach((e) => {
+      if (e.status === "rejected") {
+        expect(e.reason).to.be.instanceOf(QueueError);
+        expect(e.reason.code).to.be.equal(QueueErrorCode.ERR_QUEUE_ABORTED);
+      } else {
+        expect.fail();
+      }
+    });
+    // any subsequently enqueued job should also be rejected
+    try {
+      await jobQueue.enqueueJob(job);
+    } catch (e) {
+      expect(e).to.be.instanceOf(QueueError);
+      expect(e.code).to.be.equal(QueueErrorCode.ERR_QUEUE_ABORTED);
+    }
+  });
+});

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -77,6 +77,20 @@ export class MockBeaconChain implements IBeaconChain {
     };
   }
 
+  public async getHeadStateContextAtCurrentEpoch(): Promise<ITreeStateContext> {
+    return {
+      state: this.state!,
+      epochCtx: new EpochContext(this.config),
+    };
+  }
+
+  public async getHeadStateContextAtCurrentSlot(): Promise<ITreeStateContext> {
+    return {
+      state: this.state!,
+      epochCtx: new EpochContext(this.config),
+    };
+  }
+
   public async getCanonicalBlockAtSlot(slot: Slot): Promise<SignedBeaconBlock> {
     const block = generateEmptySignedBlock();
     block.message.slot = slot;

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -1,4 +1,5 @@
 import {AbortController} from "abort-controller";
+import sinon from "sinon";
 
 import {TreeBacked} from "@chainsafe/ssz";
 import {
@@ -21,6 +22,8 @@ import {IBeaconClock} from "../../../../src/chain/clock/interface";
 import {generateEmptySignedBlock} from "../../block";
 import {ITreeStateContext} from "../../../../src/db/api/beacon/stateContextCache";
 import {LocalClock} from "../../../../src/chain/clock";
+import {IStateRegenerator, StateRegenerator} from "../../../../src/chain/regen";
+import {StubbedBeaconDb} from "../../stub";
 
 export interface IMockChainParams {
   genesisTime: Number64;
@@ -35,6 +38,7 @@ export class MockBeaconChain implements IBeaconChain {
   public chainId: Uint16;
   public networkId: Uint64;
   public clock!: IBeaconClock;
+  public regen: IStateRegenerator;
   public emitter: ChainEventEmitter;
 
   private state: TreeBacked<BeaconState> | null;
@@ -53,6 +57,12 @@ export class MockBeaconChain implements IBeaconChain {
       genesisTime: state!.genesisTime,
       emitter: this.emitter,
       signal: this.abortController.signal,
+    });
+    this.regen = new StateRegenerator({
+      config: this.config,
+      emitter: this.emitter,
+      forkChoice: this.forkChoice,
+      db: new StubbedBeaconDb(sinon),
     });
   }
 


### PR DESCRIPTION
- `IStateRegenerator` interface has been added, along with implementations `StateRegenerator` and `QueuedStateRegenerator`, - `src/chain/regen/`
  - it can regenerate states from blocks _that have already been processed_ , given `forkChoice`, `stateCache`, `checkpointStateCache`, and `db.blocks`
  - it intelligently attempts to perform the smallest amount of regeneration necessary to regen the requested state. To that end, it exposes 4 different methods.
  - it reuses some block processing machinery (`emitCheckpointEvent`, `runStateTransition`) so as to enable re-seeding the checkpoint cache (using the emitted events)
  - it throws a `RegenError` with well-defined error codes and types, this allows us to tighten the interface to disallow nulls.
  - it queues requests, one regeneration allowed at a time
  - `getPreState(block: BeaconBlock): Promise<ITreeStateContext>` - similar to `getPreState` that we were using in our block processor. It can request a more recent checkpoint state if the block occurs after many skip-slots, skipping epoch transitions :) 
  - `getCheckpointState(cp: Checkpoint): Promise<ITreeStateContext>` - returns the checkpoint state. It minimizes regeneration by first searching the checkpoint cache for checkpoint states with cp.root, which may then just be `processSlots`ed. Otherwise regens the 'ol-fashioned way', by state root.
  - `getBlockSlotState(blockRoot: Root, slot: Slot): Promise<ITreeStateContext>` - returns the block state at the requested slot. This is a lot like `getCheckpointState`, but more flexible, especially useful for dealing with the head state, eg: `regen.getBlockSlotState(forkChoice.getHeadRoot(), clock.currentSlot)`. This is nice, because in periods of skip slots, we will only process the checkpoint with the blockRoot once.
  - `getState(stateRoot: Root): Promise<ITreeStateContext>` - returns the state whose root is stateRoot. This is where the actual block replay happens. It iterates backwards thru the block tree from the requested state, to the first state that we have cached, (searching the checkpointStateCache as well!), then replaying the blocks that were iterated thru to the requested state, once a state has been found.