### PR TITLE
State transition worker thread

### DIFF
--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -85,6 +85,7 @@
     "snappyjs": "^0.6.0",
     "stream-to-it": "^0.2.0",
     "strict-event-emitter-types": "^2.0.0",
+    "threads": "^1.6.3",
     "varint": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/lodestar/src/chain/blocks/stateTransition/index.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition/index.ts
@@ -1,0 +1,1 @@
+export * from "./stateTransition";

--- a/packages/lodestar/src/chain/blocks/stateTransition/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition/stateTransition.ts
@@ -10,11 +10,11 @@ import {
 import {processSlots} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/slot";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 
-import {ITreeStateContext} from "../../db/api/beacon/stateContextCache";
-import {ChainEventEmitter} from "../emitter";
-import {IBlockProcessJob} from "../interface";
+import {ITreeStateContext} from "../../../db/api/beacon/stateContextCache";
+import {ChainEventEmitter} from "../../emitter";
+import {IBlockProcessJob} from "../../interface";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {IBeaconDb} from "../../db";
+import {IBeaconDb} from "../../../db";
 
 // TODO remove after state regenerator exists
 export async function getPreState(

--- a/packages/lodestar/src/chain/blocks/stateTransition/worker/index.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition/worker/index.ts
@@ -1,0 +1,1 @@
+export {threadStateTransitionQueue} from "./worker";

--- a/packages/lodestar/src/chain/blocks/stateTransition/worker/threadStateTransitionWorker.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition/worker/threadStateTransitionWorker.ts
@@ -1,0 +1,50 @@
+import {expose, Transfer} from "threads/worker";
+import {TransferDescriptor} from "threads/dist";
+import {IBeaconParams} from "@chainsafe/lodestar-params";
+import {createIBeaconConfig} from "@chainsafe/lodestar-config";
+import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
+import {Checkpoint, Slot} from "@chainsafe/lodestar-types";
+import {processSlotsToNearestCheckpoint} from "../stateTransition";
+import {Observable, Subject} from "threads/observable";
+import {ChainEventEmitter} from "../../../emitter";
+import {EventEmitter} from "events";
+import {ITreeStateContext} from "../../../../db/api/beacon/stateContextCache";
+import {processSlots} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/slot";
+
+const checkpointSubject = new Subject<Checkpoint>();
+
+const worker = {
+  longCheckpointedStateTransitionWorkerProcess: async function (
+    params: IBeaconParams,
+    serializedState: ArrayBuffer,
+    slot: Slot,
+    emitCheckpoints = false
+  ): Promise<TransferDescriptor<ArrayBuffer>> {
+    const config = createIBeaconConfig(params);
+    const state = config.types.BeaconState.tree.deserialize(new Uint8Array(serializedState));
+    const epochCtx = new EpochContext(config);
+    epochCtx.loadState(state);
+    let newStateContext: ITreeStateContext;
+    if (emitCheckpoints) {
+      const emitter: ChainEventEmitter = new EventEmitter();
+      emitter.on("checkpoint", (c) => {
+        checkpointSubject.next(c);
+      });
+      newStateContext = await processSlotsToNearestCheckpoint(emitter, {state, epochCtx}, slot);
+    } else {
+      processSlots(epochCtx, state, slot);
+      newStateContext = {
+        state,
+        epochCtx,
+      };
+    }
+    return Transfer(config.types.BeaconState.serialize(newStateContext.state));
+  },
+  checkpoints: function () {
+    return Observable.from(checkpointSubject);
+  },
+};
+
+expose(worker);
+
+export type LongStateTransitionWorker = typeof worker;

--- a/packages/lodestar/src/chain/blocks/stateTransition/worker/types.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition/worker/types.ts
@@ -1,0 +1,11 @@
+import {ITreeStateContext} from "../../../../db/api/beacon/stateContextCache";
+import {Slot} from "@chainsafe/lodestar-types";
+import {ChainEventEmitter} from "../../../emitter";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+
+export type SlotProcessJob = {
+  config: IBeaconConfig,
+  preStateContext: ITreeStateContext;
+  targetSlot: Slot;
+  emitter?: ChainEventEmitter;
+};

--- a/packages/lodestar/src/chain/blocks/stateTransition/worker/worker.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition/worker/worker.ts
@@ -3,13 +3,13 @@ import {SlotProcessJob} from "./types";
 import {ITreeStateContext} from "../../../../db/api/beacon/stateContextCache";
 import {ModuleThread, spawn, Thread, Worker} from "threads";
 import {Transfer} from "threads/worker";
-import {LongStateTransitionWorker} from "./stateTransition";
+import {LongStateTransitionWorker} from "./threadStateTransitionWorker";
 import {ChainEventEmitter} from "../../../emitter";
 import {Slot} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 
-export class StateTransitionWorker {
+export class ThreadStateTransitionQueue {
   protected queue?: Pushable<SlotProcessJob>;
   protected resultGenerator?: AsyncGenerator<ITreeStateContext | Error>;
   protected workerThread?: ModuleThread<LongStateTransitionWorker>;
@@ -90,4 +90,4 @@ export class StateTransitionWorker {
   };
 }
 
-export const stateTransitionWorker = new StateTransitionWorker();
+export const threadStateTransitionQueue = new ThreadStateTransitionQueue();

--- a/packages/lodestar/src/chain/blocks/stateTransition/worker/worker.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition/worker/worker.ts
@@ -1,0 +1,93 @@
+import pushable, {Pushable} from "it-pushable/index";
+import {SlotProcessJob} from "./types";
+import {ITreeStateContext} from "../../../../db/api/beacon/stateContextCache";
+import {ModuleThread, spawn, Thread, Worker} from "threads";
+import {Transfer} from "threads/worker";
+import {LongStateTransitionWorker} from "./stateTransition";
+import {ChainEventEmitter} from "../../../emitter";
+import {Slot} from "@chainsafe/lodestar-types";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
+
+export class StateTransitionWorker {
+  protected queue?: Pushable<SlotProcessJob>;
+  protected resultGenerator?: AsyncGenerator<ITreeStateContext | Error>;
+  protected workerThread?: ModuleThread<LongStateTransitionWorker>;
+
+  public async start(): Promise<void> {
+    this.queue = pushable<SlotProcessJob>();
+    this.workerThread = await spawn<LongStateTransitionWorker>(new Worker("./stateTransition"));
+    this.resultGenerator = this.resultGeneratorFunction(this.queue, this.workerThread);
+  }
+
+  public async stop(): Promise<void> {
+    this.queue?.end();
+    this.queue = undefined;
+    if (this.workerThread) {
+      await Thread.terminate(this.workerThread);
+    }
+  }
+
+  public async processSlotsToNearestCheckpoint(
+    config: IBeaconConfig,
+    emitter: ChainEventEmitter,
+    stateCtx: ITreeStateContext,
+    slot: Slot
+  ): Promise<ITreeStateContext> {
+    this.queue?.push({config, preStateContext: stateCtx, targetSlot: slot, emitter});
+    const result = (await this.resultGenerator?.next())?.value;
+    if (result instanceof Error) {
+      throw result;
+    }
+    return result;
+  }
+
+  public async processSlots(
+    config: IBeaconConfig,
+    stateCtx: ITreeStateContext,
+    slot: Slot
+  ): Promise<ITreeStateContext> {
+    this.queue?.push({config, preStateContext: stateCtx, targetSlot: slot});
+    const result = (await this.resultGenerator?.next())?.value;
+    if (result instanceof Error) {
+      throw result;
+    }
+    return result;
+  }
+
+  public isRunning(): boolean {
+    return !!this.queue;
+  }
+
+  protected resultGeneratorFunction = async function* (
+    queue: Pushable<SlotProcessJob>,
+    workerThread: ModuleThread<LongStateTransitionWorker>
+  ): AsyncGenerator<ITreeStateContext | Error> {
+    for await (const job of queue) {
+      try {
+        if (job.emitter) {
+          workerThread.checkpoints().subscribe((checkpoint) => {
+            job.emitter?.emit("checkpoint", checkpoint);
+          });
+        }
+        const result = await workerThread.longCheckpointedStateTransitionWorkerProcess(
+          job.config.params,
+          (Transfer(job.config.types.BeaconState.serialize(job.preStateContext.state)) as unknown) as ArrayBuffer,
+          job.targetSlot,
+          !!job.emitter
+        );
+        const state = job.config.types.BeaconState.tree.deserialize(new Uint8Array((result as unknown) as ArrayBuffer));
+        const epochCtx = new EpochContext(job.config);
+        epochCtx.loadState(state);
+        yield {
+          state,
+          epochCtx,
+        };
+      } catch (e) {
+        yield e;
+      }
+    }
+  };
+}
+
+export const stateTransitionWorker = new StateTransitionWorker();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4269,7 +4269,7 @@ callsites@^2.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
   integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
-callsites@^3.0.0:
+callsites@^3.0.0, callsites@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
@@ -5844,6 +5844,11 @@ eslint@^6.8.0:
     table "^5.2.3"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
+
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
 espree@^6.1.2:
   version "6.2.1"
@@ -7886,6 +7891,13 @@ is-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
   integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
+
+is-observable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
+  integrity sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==
+  dependencies:
+    symbol-observable "^1.1.0"
 
 is-path-inside@^2.1.0:
   version "2.1.0"
@@ -10475,6 +10487,11 @@ object.values@^1.1.0:
     function-bind "^1.1.1"
     has "^1.0.3"
 
+observable-fns@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/observable-fns/-/observable-fns-0.5.1.tgz#9b56478690dd0fa8603e3a7e7d2975d88bca0904"
+  integrity sha512-wf7g4Jpo1Wt2KIqZKLGeiuLOEMqpaOZ5gJn7DmSdqXgTdxRwSdBhWegQQpPteQ2gZvzCKqNNpwb853wcpA0j7A==
+
 octokit-pagination-methods@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
@@ -12928,6 +12945,11 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
+symbol-observable@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
+
 table@^5.2.3:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
@@ -13076,6 +13098,18 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
+threads@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/threads/-/threads-1.6.3.tgz#89324a93509403c90a169344023151ae1fe4986b"
+  integrity sha512-tKwFIWRgfAT85KGkrpDt2jWPO8IVH0sLNfB/pXad/VW9eUIY2Zlz+QyeizypXhPHv9IHfqRzvk2t3mPw+imhWw==
+  dependencies:
+    callsites "^3.1.0"
+    debug "^4.1.1"
+    is-observable "^1.1.0"
+    observable-fns "^0.5.1"
+  optionalDependencies:
+    tiny-worker ">= 2"
+
 through2@^2.0.0, through2@^2.0.2:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
@@ -13132,6 +13166,13 @@ tiny-lru@^7.0.2:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-7.0.6.tgz#b0c3cdede1e5882aa2d1ae21cb2ceccf2a331f24"
   integrity sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==
+
+"tiny-worker@>= 2":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tiny-worker/-/tiny-worker-2.3.0.tgz#715ae34304c757a9af573ae9a8e3967177e6011e"
+  integrity sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==
+  dependencies:
+    esm "^3.2.25"
 
 tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"
@@ -14131,4 +14172,3 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
-


### PR DESCRIPTION
This is some POC and I would like your opinion on direction I've taken.
I've used singleton because:
- block processing and attestation validation are somewhat pure functions so passing another object would be major change in a lot of places
- we have just one thread for that anyways so it isn't really important to create multiple instances of that

Done:
- add threads.js library which provides abstraction so everything works in browser
- add fifo queue with async source and generator so if we have duplicated jobs we can return pregenerated state
- serialize state transition and mark as Transferable (avoids buffer copy)
- add EpochContext regeneration since we cannot serialize it yet
   - I wonder how much time this consumes since it's only done twice but we can definitely improve that
- I'm sending IBeaconParams only and regenerating IBeaconConfig in thread
   - I wish I could do this only once while spawning thread but I don't see any option, I could hack it by exposing additional method in worker thread which I would call to initialize config

TODO:
- add e2e to ensure everything works
- return state from cache if duplicate jobs
- integrate in block process and gossip validation

resolves #1464 