### PR TITLE
Import AbortController as named import

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -2,7 +2,7 @@
  * @module chain
  */
 
-import AbortController from "abort-controller";
+import {AbortController} from "abort-controller";
 import {toHexString, TreeBacked} from "@chainsafe/ssz";
 import {
   Attestation,

--- a/packages/lodestar/src/network/encoders/response.ts
+++ b/packages/lodestar/src/network/encoders/response.ts
@@ -3,7 +3,7 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {Method, MethodResponseType, Methods, ReqRespEncoding, RequestId, RpcResponseStatus} from "../../constants";
 import {decode, encode} from "varint";
-import AbortController from "abort-controller";
+import {AbortController} from "abort-controller";
 import {encodeResponseStatus, getCompressor, getDecompressor, maxEncodedLen} from "./utils";
 import BufferList from "bl";
 import {ResponseBody, P2pErrorMessage} from "@chainsafe/lodestar-types";

--- a/packages/lodestar/src/network/reqResp.ts
+++ b/packages/lodestar/src/network/reqResp.ts
@@ -29,7 +29,7 @@ import {
 } from "../constants";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {duplex as abortDuplex} from "abortable-iterator";
-import AbortController from "abort-controller";
+import {AbortController} from "abort-controller";
 import all from "it-all";
 import {
   createResponseEvent,

--- a/packages/lodestar/src/network/util.ts
+++ b/packages/lodestar/src/network/util.ts
@@ -5,7 +5,7 @@
 
 import PeerId from "peer-id";
 import {Type} from "@chainsafe/ssz";
-import AbortController from "abort-controller";
+import {AbortController} from "abort-controller";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Method, MethodResponseType, Methods, RequestId, RESP_TIMEOUT, TTFB_TIMEOUT} from "../constants";
 import {source as abortSource} from "abortable-iterator";

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -20,7 +20,7 @@ import {BeaconMetrics, HttpMetricsServer} from "../metrics";
 import {Api, IApi, RestApi} from "../api";
 import {GossipMessageValidator} from "../network/gossip/validator";
 import {TasksService} from "../tasks";
-import AbortController from "abort-controller";
+import {AbortController} from "abort-controller";
 
 export interface IService {
   start(): Promise<void>;

--- a/packages/lodestar/test/unit/chain/clock/local.test.ts
+++ b/packages/lodestar/test/unit/chain/clock/local.test.ts
@@ -1,5 +1,5 @@
 import sinon, {SinonFakeTimers} from "sinon";
-import AbortController from "abort-controller";
+import {AbortController} from "abort-controller";
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 

--- a/packages/lodestar/test/unit/network/encoders/response.test.ts
+++ b/packages/lodestar/test/unit/network/encoders/response.test.ts
@@ -1,6 +1,6 @@
 import pipe from "it-pipe";
 import all from "it-all";
-import AbortController from "abort-controller";
+import {AbortController} from "abort-controller";
 import {source as abortSource} from "abortable-iterator";
 import {
   eth2ResponseDecode,

--- a/packages/lodestar/test/unit/sync/utils/attestation-collector.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/attestation-collector.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 import sinon from "sinon";
-import AbortController from "abort-controller";
+import {AbortController} from "abort-controller";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import * as attestationUtils from "@chainsafe/lodestar-beacon-state-transition/lib/util/attestation";
 

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -1,4 +1,4 @@
-import AbortController from "abort-controller";
+import {AbortController} from "abort-controller";
 
 import {TreeBacked} from "@chainsafe/ssz";
 import {


### PR DESCRIPTION
Apply eslint warning: 
```
Using exported name 'AbortController' as identifier for default export  import/no-named-as-default
```