### PR TITLE
Process  attestations one by one in order to cache checkpoint state

### DIFF
--- a/packages/lodestar/src/chain/attestation/pool.ts
+++ b/packages/lodestar/src/chain/attestation/pool.ts
@@ -106,7 +106,10 @@ export class AttestationProcessor implements IAttestationProcessor {
   public async receiveBlock(signedBlock: SignedBeaconBlock): Promise<void> {
     // process block's attestations
     const attestations = signedBlock.message.body.attestations;
-    await Promise.all(Array.from(attestations).map((a) => this.receiveAttestation(a)));
+    // process one by one in order to cache checkpoit state
+    for (const attestation of attestations) {
+      await this.receiveAttestation(attestation);
+    }
     // process pending attestations due to this block
     const blockRoot = this.config.types.BeaconBlock.hashTreeRoot(signedBlock.message);
     const blockPendingAttestations =


### PR DESCRIPTION
At regular sync, it takes a lot of time to process blocks because the checkpoint state cache does not help.
The reason is we process attestations in parallel, I have a lot of logs like this
```
...
@@@ checkpoint cache add 0x1b7f26c5f9e3c338bb78372185f20520635d4576f1820deef0e062c36f136878
@@@ getAttestationPreState process slots 344256 344255 0x2fca93ce4577099fc80939c603230749244ecb6c87de742ab8b8ead035d714dc
@@@ getAttestationPreState - processSlots in 1836
@@@ checkpoint cache add 0x1b7f26c5f9e3c338bb78372185f20520635d4576f1820deef0e062c36f136878
@@@ getAttestationPreState process slots 344256 344255 0x2fca93ce4577099fc80939c603230749244ecb6c87de742ab8b8ead035d714dc
@@@ getAttestationPreState - processSlots in 1823
@@@ checkpoint cache add 0x1b7f26c5f9e3c338bb78372185f20520635d4576f1820deef0e062c36f136878
@@@ getAttestationPreState process slots 344256 344255 0x2fca93ce4577099fc80939c603230749244ecb6c87de742ab8b8ead035d714dc
@@@ getAttestationPreState - processSlots in 1858
...
```
The fix: order attestation process in order to let the checkpoint state cache work.