### PR TITLE
Handle beaconBlocksByRoot error

### DIFF
--- a/packages/lodestar/src/chain/attestation/pool.ts
+++ b/packages/lodestar/src/chain/attestation/pool.ts
@@ -133,9 +133,11 @@ export class AttestationProcessor implements IAttestationProcessor {
   }
 
   private addPendingBlockAttestation(blockRoot: Root, attestation: Attestation, attestationHash: Root): void {
-    this.chain.emitter.emit("unknownBlockRoot", blockRoot);
     const blockPendingAttestations =
       this.pendingBlockAttestations.get(toHexString(blockRoot)) || new Map<AttestationRootHex, Attestation>();
+    if (blockPendingAttestations.size === 0) {
+      this.chain.emitter.emit("unknownBlockRoot", blockRoot);
+    }
     blockPendingAttestations.set(toHexString(attestationHash), attestation);
     this.pendingBlockAttestations.set(toHexString(blockRoot), blockPendingAttestations);
   }

--- a/packages/lodestar/src/network/reqResp.ts
+++ b/packages/lodestar/src/network/reqResp.ts
@@ -336,7 +336,7 @@ export class ReqResp extends (EventEmitter as IReqEventEmitterClass) implements 
         this.handleResponses<T>(peerId, method, encoding, requestId, requestSingleChunk, requestOnly, body)
       );
     } catch (e) {
-      this.logger.warn(`failed to send request ${requestId} to peer ${peerId.toB58String()}`, {
+      this.logger.verbose(`failed to send request ${requestId} to peer ${peerId.toB58String()}`, {
         method,
         reason: e.message,
       });

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -212,10 +212,12 @@ export class BeaconSync implements IBeaconSync {
           return await this.chain.receiveBlock(blocks[0]);
         }
       } catch (e) {
-        this.logger.warn("Failed to get unknown block root from peer", {
+        this.logger.verbose("Failed to get unknown block root from peer", {
           blockRoot: toHexString(root),
           peer: peer.toB58String(),
           error: e.message,
+          maxRetry,
+          retry,
         });
       }
       retry++;

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -209,6 +209,7 @@ export class BeaconSync implements IBeaconSync {
       try {
         const blocks = await this.network.reqResp.beaconBlocksByRoot(peer, [root] as List<Root>);
         if (blocks && blocks[0]) {
+          this.logger.verbose(`Fould block ${blocks[0].message.slot} for root ${toHexString(root)}`);
           return await this.chain.receiveBlock(blocks[0]);
         }
       } catch (e) {


### PR DESCRIPTION
resolves #1498 

This is what discussed in the planning meeting: we want to handle error in onUnknownBlockRoot