### PR TITLE
Add forkChoice head and reorg events

### DIFF
--- a/packages/lodestar-fork-choice/src/forkChoice/interface.ts
+++ b/packages/lodestar-fork-choice/src/forkChoice/interface.ts
@@ -3,12 +3,12 @@ import {
   BeaconState,
   Checkpoint,
   Epoch,
-  Gwei,
   IndexedAttestation,
   Root,
   Slot,
   ValidatorIndex,
 } from "@chainsafe/lodestar-types";
+import {IEpochProcess} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 import {IBlockSummary} from "./blockSummary";
 
 export interface IForkChoice {
@@ -51,8 +51,11 @@ export interface IForkChoice {
    * ## Notes:
    *
    * The supplied block **must** pass the `state_transition` function as it will not be run here.
+   *
+   * `epochProcess` is passed in so that justified balances can be updated synchronously.
+   * This ensures that the forkchoice is never out of sync.
    */
-  onBlock(block: BeaconBlock, state: BeaconState): void;
+  onBlock(block: BeaconBlock, state: BeaconState, epochProcess?: IEpochProcess): void;
   /**
    * Register `attestation` with the fork choice DAG so that it may influence future calls to `getHead`.
    *
@@ -73,7 +76,6 @@ export interface IForkChoice {
    */
   onAttestation(attestation: IndexedAttestation): void;
   getLatestMessage(validatorIndex: ValidatorIndex): ILatestMessage | undefined;
-  updateBalances(justifiedStateBalances: Gwei[]): void;
   /**
    * Call `onTick` for all slots between `fcStore.getCurrentSlot()` and the provided `currentSlot`.
    */

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -18,11 +18,15 @@ import {
   Uint64,
 } from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {computeEpochAtSlot, computeForkDigest, EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
-import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
+import {
+  blockToHeader,
+  computeEpochAtSlot,
+  computeForkDigest,
+  EpochContext,
+} from "@chainsafe/lodestar-beacon-state-transition";
+import {ILogger} from "@chainsafe/lodestar-utils";
 import {intToBytes} from "@chainsafe/lodestar-utils";
-import {ForkChoice, IForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {hasMarkers, FLAG_ELIGIBLE_ATTESTER} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
+import {IForkChoice, ForkChoice, ProtoArray} from "@chainsafe/lodestar-fork-choice";
 
 import {EMPTY_SIGNATURE, GENESIS_SLOT, FAR_FUTURE_EPOCH, ZERO_HASH} from "../constants";
 import {IBeaconDb} from "../db";
@@ -349,30 +353,27 @@ export class BeaconChain implements IBeaconChain {
   private async initForkChoice(
     anchorState: TreeBacked<BeaconState>
   ): Promise<{forkChoice: ForkChoice; checkpoint: Checkpoint}> {
+    let blockHeader;
+    let blockRoot;
+    let justifiedCheckpoint;
+    let finalizedCheckpoint;
     if (anchorState.latestBlockHeader.slot === GENESIS_SLOT) {
       const block = getEmptyBlock();
       block.stateRoot = this.config.types.BeaconState.hashTreeRoot(anchorState);
-      const blockRoot = this.config.types.BeaconBlock.hashTreeRoot(block);
+      blockHeader = blockToHeader(this.config, block);
+      blockRoot = this.config.types.BeaconBlockHeader.hashTreeRoot(blockHeader);
       const blockCheckpoint = {
         root: blockRoot,
-        epoch: computeEpochAtSlot(this.config, anchorState.slot),
+        epoch: 0,
       };
-      const store = new ForkChoiceStore({
-        emitter: this.emitter,
-        currentSlot: this.clock.currentSlot,
-        justifiedCheckpoint: blockCheckpoint,
-        finalizedCheckpoint: blockCheckpoint,
-      });
-      return {
-        forkChoice: ForkChoice.fromGenesis(this.config, store, block),
-        checkpoint: blockCheckpoint,
-      };
+      justifiedCheckpoint = finalizedCheckpoint = blockCheckpoint;
     } else {
-      const blockHeader = this.config.types.BeaconBlockHeader.clone(anchorState.latestBlockHeader);
+      blockHeader = this.config.types.BeaconBlockHeader.clone(anchorState.latestBlockHeader);
       if (this.config.types.Root.equals(blockHeader.stateRoot, ZERO_HASH)) {
         blockHeader.stateRoot = anchorState.hashTreeRoot();
       }
-      const finalizedCheckpoint = {
+      blockRoot = this.config.types.BeaconBlockHeader.hashTreeRoot(blockHeader);
+      finalizedCheckpoint = {
         root: this.config.types.BeaconBlockHeader.hashTreeRoot(blockHeader),
         epoch: computeEpochAtSlot(this.config, anchorState.slot),
       };
@@ -380,21 +381,34 @@ export class BeaconChain implements IBeaconChain {
       // So that we don't allow the chain to initially justify with a block that isn't also finalizing the anchor state.
       // If that happens, we will create an invalid head state,
       // with the head not matching the fork choice justified and finalized epochs.
-      const justifiedCheckpoint = {
-        root: this.config.types.BeaconBlockHeader.hashTreeRoot(blockHeader),
-        epoch: computeEpochAtSlot(this.config, anchorState.slot) + 1,
-      };
-      const store = new ForkChoiceStore({
-        emitter: this.emitter,
-        currentSlot: this.clock.currentSlot,
-        justifiedCheckpoint,
-        finalizedCheckpoint,
-      });
-      return {
-        forkChoice: ForkChoice.fromCheckpointState(this.config, store, anchorState),
-        checkpoint: finalizedCheckpoint,
+      justifiedCheckpoint = {
+        root: finalizedCheckpoint.root,
+        epoch: finalizedCheckpoint.epoch + 1,
       };
     }
+    const fcStore = new ForkChoiceStore({
+      emitter: this.emitter,
+      currentSlot: this.clock.currentSlot,
+      justifiedCheckpoint,
+      finalizedCheckpoint,
+    });
+    const protoArray = ProtoArray.initialize({
+      slot: blockHeader.slot,
+      parentRoot: toHexString(blockHeader.parentRoot),
+      stateRoot: toHexString(blockHeader.stateRoot),
+      blockRoot: toHexString(blockRoot),
+      justifiedEpoch: justifiedCheckpoint.epoch,
+      finalizedEpoch: finalizedCheckpoint.epoch,
+    });
+    return {
+      forkChoice: new ForkChoice({
+        config: this.config,
+        fcStore,
+        protoArray,
+        queuedAttestations: new Set(),
+      }),
+      checkpoint: finalizedCheckpoint,
+    };
   }
 
   private handleForkVersionChanged = async (): Promise<void> => {
@@ -440,21 +454,6 @@ export class BeaconChain implements IBeaconChain {
 
   private onForkChoiceJustified = async (cp: Checkpoint): Promise<void> => {
     this.logger.verbose("Fork choice justified", this.config.types.Checkpoint.toJson(cp));
-    const stateCtx = await this.db.checkpointStateCache.get(cp);
-    if (stateCtx) {
-      const epochProcess = stateCtx.epochCtx.epochProcess;
-      if (epochProcess) {
-        const balances = epochProcess.statuses.map((status) =>
-          hasMarkers(status.flags, FLAG_ELIGIBLE_ATTESTER) ? status.validator.effectiveBalance : BigInt(0)
-        );
-        this.forkChoice.updateBalances(balances);
-        this.logger.verbose("Fork choice balances updated");
-      } else {
-        this.logger.error("Unable to update fork choice balances: no epoch process found");
-      }
-    } else {
-      this.logger.error("Unable to update fork choice balances: no state context found");
-    }
   };
 
   private onForkChoiceFinalized = async (cp: Checkpoint): Promise<void> => {

--- a/packages/lodestar/src/chain/forkChoice/index.ts
+++ b/packages/lodestar/src/chain/forkChoice/index.ts
@@ -2,9 +2,6 @@
  * @module chain/forkChoice
  */
 
-//export * from "./interface";
-//export * from "./arrayDag";
-//export * from "./attestationAggregator";
 import {ForkChoice} from "@chainsafe/lodestar-fork-choice";
 
 export * from "./store";

--- a/packages/lodestar/test/unit/chain/blocks/process.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/process.test.ts
@@ -14,6 +14,7 @@ import {processBlock} from "../../../../src/chain/blocks/process";
 import {generateState} from "../../../utils/state";
 import {StubbedBeaconDb} from "../../../utils/stub";
 import {silentLogger} from "../../../utils/logger";
+import { generateBlockSummary } from "../../../utils/block";
 
 describe("block process stream", function () {
   const logger = silentLogger;
@@ -97,13 +98,10 @@ describe("block process stream", function () {
       trusted: false,
       reprocess: false,
     };
-    const parentBlock = config.types.SignedBeaconBlock.defaultValue();
-    forkChoiceStub.getBlock
-      .withArgs(receivedJob.signedBlock.message.parentRoot.valueOf() as Uint8Array)
-      .resolves(parentBlock);
+    forkChoiceStub.getBlock.returns(generateBlockSummary());
+    forkChoiceStub.getHead.returns(generateBlockSummary());
     dbStub.stateCache.get.resolves({state: generateState(), epochCtx: new EpochContext(config)});
     stateTransitionStub.returns({state: generateState(), epochCtx: new EpochContext(config)});
-    //dbStub.chain.getChainHeadRoot.resolves(Buffer.alloc(32, 1));
     forkChoiceStub.getHeadRoot.returns(Buffer.alloc(32, 1));
     const result = await pipe(
       [receivedJob],
@@ -123,9 +121,8 @@ describe("block process stream", function () {
       reprocess: false,
     };
     const parentBlock = config.types.SignedBeaconBlock.defaultValue();
-    forkChoiceStub.getBlock
-      .withArgs(receivedJob.signedBlock.message.parentRoot.valueOf() as Uint8Array)
-      .resolves(parentBlock);
+    forkChoiceStub.getBlock.returns(generateBlockSummary());
+    forkChoiceStub.getHead.returns(generateBlockSummary());
     dbStub.stateCache.get.resolves({state: generateState(), epochCtx: new EpochContext(config)});
     stateTransitionStub.returns({state: generateState(), epochCtx: new EpochContext(config)});
     forkChoiceStub.getHeadRoot.returns(Buffer.alloc(32, 2));


### PR DESCRIPTION
A few updates here:
- update fork choice balances synchronously, as part of `onBlock`. This is a nice change, because it ensures that our fork choice is never out of sync. (Previously, once the fork choice justified a new checkpoint, the `updateBalances` method _must_ be called immediately, or else any `getHead` call will result in an error!!)
- update fork choice initialization in BeaconChain. Should be followed up in a future PR with refactored initializer method(s).
- add `forkChoice:head` and `forkChoice:reorg` events, in a similar style that other events are called in the block processor.