### PR TITLE
Apply peer scoring for regular sync

### DIFF
--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -109,10 +109,10 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
       if (await this.checkSyncComplete()) {
         return;
       }
-      this.logger.info(
-        `Regular Sync: Synced up to slot ${lastProcessedBlock.message.slot} ` +
-          `gossipParentBlockRoot=${this.gossipParentBlockRoot && toHexString(this.gossipParentBlockRoot)}`
-      );
+      this.logger.info(`Regular Sync: Synced up to slot ${lastProcessedBlock.message.slot} `, {
+        currentSlot: this.chain.clock.currentSlot,
+        gossipParentBlockRoot: this.gossipParentBlockRoot ? toHexString(this.gossipParentBlockRoot) : "undefined",
+      });
       // don't want to trigger another sync from other sources than regular sync
       if (this.currentTarget === lastProcessedBlock.message.slot) {
         this.lastProcessedBlock = {
@@ -229,7 +229,10 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
       this.bestPeer = getBestPeer(this.config, peers, this.network.peerMetadata);
       if (checkBestPeer(this.bestPeer, this.chain.forkChoice, this.network)) {
         const peerHeadSlot = this.network.peerMetadata.getStatus(this.bestPeer)!.headSlot;
-        this.logger.verbose(`Found best peer ${this.bestPeer.toB58String()} with head slot ${peerHeadSlot}`);
+        this.logger.verbose(`Found best peer ${this.bestPeer.toB58String()}`, {
+          peerHeadSlot,
+          currentSlot: this.chain.clock.currentSlot,
+        });
       } else {
         // continue to find best peer
         this.bestPeer = undefined;

--- a/packages/lodestar/src/sync/utils/blocks.ts
+++ b/packages/lodestar/src/sync/utils/blocks.ts
@@ -48,7 +48,7 @@ export async function getBlockRange(
   range: ISlotRange,
   blocksPerChunk?: number,
   maxRetry = 6
-): Promise<SignedBeaconBlock[]> {
+): Promise<SignedBeaconBlock[] | null> {
   const totalBlocks = range.end - range.start;
   blocksPerChunk = blocksPerChunk || Math.ceil(totalBlocks / peers.length);
   if (blocksPerChunk < 5) {
@@ -83,8 +83,9 @@ export async function getBlockRange(
       )
     ).filter(notNullish);
     retry++;
-    if (retry > maxRetry || retry > peers.length) {
+    if ((retry > maxRetry || retry > peers.length) && chunks.length > 0) {
       logger.error("Max req retry for blocks by range. Failed chunks: " + JSON.stringify(chunks));
+      return null;
     }
   }
   return sortBlocks(blocks);

--- a/packages/lodestar/test/unit/sync/utils/block.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/block.test.ts
@@ -32,7 +32,7 @@ describe("sync - block utils", function () {
         .withArgs(sinon.match(peers[0]).or(sinon.match(peers[1])), sinon.match.any)
         .resolves([generateEmptySignedBlock(), generateEmptySignedBlock(), generateEmptySignedBlock()]);
       const blocks = await getBlockRange(logger, rpcStub, peers, {start: 0, end: 4}, 2);
-      expect(blocks.length).to.be.equal(3);
+      expect(blocks?.length).to.be.equal(3);
     });
 
     it("refetch failed chunks", async function () {
@@ -45,7 +45,7 @@ describe("sync - block utils", function () {
       const blockPromise = getBlockRange(logger, rpcStub, peers, {start: 0, end: 4}, 2);
       await timer.tickAsync(1000);
       const blocks = await blockPromise;
-      expect(blocks.length).to.be.equal(2);
+      expect(blocks?.length).to.be.equal(2);
       timer.reset();
     });
 
@@ -54,7 +54,7 @@ describe("sync - block utils", function () {
       const peers: PeerId[] = [peer1];
       rpcStub.beaconBlocksByRange.resolves([]);
       const blocks = await getBlockRange(logger, rpcStub, peers, {start: 4, end: 4}, 2);
-      expect(blocks.length).to.be.equal(0);
+      expect(blocks?.length).to.be.equal(0);
     });
   });
 


### PR DESCRIPTION
## Goals
+ Peer scoring for regular sync
+ When fetching a block range, if maxRetry reached then return null to allow sync (especially regular sync) to handle "Failed to get range"