### PR TITLE
Spec v0.12.3 - use raw SHA256 as message-id and reduce size to 8 bytes #2044

### DIFF
--- a/packages/lodestar/src/network/gossip/utils.ts
+++ b/packages/lodestar/src/network/gossip/utils.ts
@@ -75,8 +75,17 @@ export function normalizeInRpcMessage(rawMessage: Message): ILodestarGossipMessa
   };
 }
 
+/**
+ * ETH2 spec defines the message ID as:
+ * ```
+ * message-id: SHA256(message.data)[:8]
+ * ```
+ * Spec v0.12.3
+ */
 export function getMessageId(rawMessage: Message): string {
-  return Buffer.from(hash(rawMessage.data || ZERO_HASH)).toString("base64");
+  return Buffer.from(hash(rawMessage.data || ZERO_HASH))
+    .slice(0, 8)
+    .toString("hex");
 }
 
 export async function getBlockStateContext(


### PR DESCRIPTION
Fixes https://github.com/ChainSafe/lodestar/issues/1574

Update to spec v0.12.3

 - Remove the base64 encoding as described in the previous spec.
 - Use only the first 8 bytes as the message id instead of the whole
32 bytes.