### PR TITLE
Spec tests 0.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "webpack": "^4.42.0"
   },
   "optionalDependencies": {
-    "@chainsafe/eth2-spec-tests": "0.12.1"
+    "@chainsafe/eth2-spec-tests": "0.12.3"
   }
 }

--- a/packages/spec-test-runner/test/spec/finality/finality_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/finality/finality_fast.test.ts
@@ -1,0 +1,54 @@
+import {join} from "path";
+import {expect} from "chai";
+import {BeaconState, SignedBeaconBlock} from "@chainsafe/lodestar-types";
+import {EpochContext, fastStateTransition} from "@chainsafe/lodestar-beacon-state-transition";
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util/lib/single";
+import {IFinalityTestCase} from "./type";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
+
+describeDirectorySpecTest<IFinalityTestCase, BeaconState>(
+  "finality fast",
+  join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/finality/finality/pyspec_tests"),
+  (testcase) => {
+    let state = testcase.pre;
+    const epochCtx = new EpochContext(config);
+    epochCtx.loadState(state);
+    const verify = !!testcase.meta && !!testcase.meta.blsSetting && testcase.meta.blsSetting === BigInt(1);
+    for (let i = 0; i < Number(testcase.meta.blocksCount); i++) {
+      ({state} = fastStateTransition({epochCtx, state}, testcase[`blocks_${i}`] as SignedBeaconBlock, {
+        verifyStateRoot: verify,
+        verifyProposer: verify,
+        verifySignatures: verify,
+      }));
+    }
+    return state;
+  },
+  {
+    inputTypes: {
+      meta: InputType.YAML,
+    },
+    sszTypes: {
+      pre: config.types.BeaconState,
+      post: config.types.BeaconState,
+      ...generateBlocksSZZTypeMapping(200, config),
+    },
+    shouldError: (testCase) => {
+      return !testCase.post;
+    },
+    timeout: 10000000,
+    getExpected: (testCase) => testCase.post,
+    expectFunc: (testCase, expected, actual) => {
+      expect(config.types.BeaconState.equals(actual, expected)).to.be.true;
+    },
+  }
+);
+
+function generateBlocksSZZTypeMapping(n: number, config: IBeaconConfig): object {
+  const blocksMapping: any = {};
+  for (let i = 0; i < n; i++) {
+    blocksMapping[`blocks_${i}`] = config.types.SignedBeaconBlock;
+  }
+  return blocksMapping;
+}

--- a/packages/spec-test-runner/test/spec/finality/finality_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/finality/finality_mainnet.test.ts
@@ -1,0 +1,52 @@
+import {join} from "path";
+import {expect} from "chai";
+import {BeaconState, SignedBeaconBlock} from "@chainsafe/lodestar-types";
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import {stateTransition} from "@chainsafe/lodestar-beacon-state-transition";
+import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util/lib/single";
+import {IFinalityTestCase} from "./type";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
+
+describeDirectorySpecTest<IFinalityTestCase, BeaconState>(
+  "block sanity mainnet",
+  join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/finality/finality/pyspec_tests"),
+  (testcase) => {
+    let state = testcase.pre;
+    const verify = !!testcase.meta && !!testcase.meta.blsSetting && testcase.meta.blsSetting === BigInt(1);
+    for (let i = 0; i < Number(testcase.meta.blocksCount); i++) {
+      state = stateTransition(config, state, testcase[`blocks_${i}`] as SignedBeaconBlock, {
+        verifyStateRoot: verify,
+        verifyProposer: verify,
+        verifySignatures: verify,
+      });
+    }
+    return state;
+  },
+  {
+    inputTypes: {
+      meta: InputType.YAML,
+    },
+    sszTypes: {
+      pre: config.types.BeaconState,
+      post: config.types.BeaconState,
+      ...generateBlocksSZZTypeMapping(200, config),
+    },
+    shouldError: (testCase) => {
+      return !testCase.post;
+    },
+    timeout: 10000000,
+    getExpected: (testCase) => testCase.post,
+    expectFunc: (testCase, expected, actual) => {
+      expect(config.types.BeaconState.equals(actual, expected)).to.be.true;
+    },
+  }
+);
+
+function generateBlocksSZZTypeMapping(n: number, config: IBeaconConfig): object {
+  const blocksMapping: any = {};
+  for (let i = 0; i < n; i++) {
+    blocksMapping[`blocks_${i}`] = config.types.SignedBeaconBlock;
+  }
+  return blocksMapping;
+}

--- a/packages/spec-test-runner/test/spec/finality/finality_minimal.test.ts
+++ b/packages/spec-test-runner/test/spec/finality/finality_minimal.test.ts
@@ -1,0 +1,52 @@
+import {join} from "path";
+import {expect} from "chai";
+import {BeaconState, SignedBeaconBlock} from "@chainsafe/lodestar-types";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {stateTransition} from "@chainsafe/lodestar-beacon-state-transition";
+import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util/lib/single";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IFinalityTestCase} from "./type";
+import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
+
+describeDirectorySpecTest<IFinalityTestCase, BeaconState>(
+  "finality minimal",
+  join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/finality/finality/pyspec_tests"),
+  (testcase) => {
+    let state = testcase.pre;
+    const verify = !!testcase.meta && !!testcase.meta.blsSetting && testcase.meta.blsSetting === BigInt(1);
+    for (let i = 0; i < Number(testcase.meta.blocksCount); i++) {
+      state = stateTransition(config, state, testcase[`blocks_${i}`] as SignedBeaconBlock, {
+        verifyStateRoot: verify,
+        verifyProposer: verify,
+        verifySignatures: verify,
+      });
+    }
+    return state;
+  },
+  {
+    inputTypes: {
+      meta: InputType.YAML,
+    },
+    sszTypes: {
+      pre: config.types.BeaconState,
+      post: config.types.BeaconState,
+      ...generateBlocksSZZTypeMapping(200, config),
+    },
+    shouldError: (testCase) => {
+      return !testCase.post;
+    },
+    timeout: 60000,
+    getExpected: (testCase) => testCase.post,
+    expectFunc: (testCase, expected, actual) => {
+      expect(config.types.BeaconState.equals(actual, expected)).to.be.true;
+    },
+  }
+);
+
+function generateBlocksSZZTypeMapping(n: number, config: IBeaconConfig): object {
+  const blocksMapping: any = {};
+  for (let i = 0; i < n; i++) {
+    blocksMapping[`blocks_${i}`] = config.types.SignedBeaconBlock;
+  }
+  return blocksMapping;
+}

--- a/packages/spec-test-runner/test/spec/finality/type.ts
+++ b/packages/spec-test-runner/test/spec/finality/type.ts
@@ -1,0 +1,12 @@
+import {BeaconState, SignedBeaconBlock, Uint64} from "@chainsafe/lodestar-types";
+import {IBaseSpecTest} from "../type";
+
+export interface IFinalityTestCase extends IBaseSpecTest {
+  meta: {
+    blocksCount: Uint64;
+    blsSetting: BigInt;
+  };
+  pre: BeaconState;
+  post: BeaconState;
+  [k: string]: SignedBeaconBlock | unknown | null | undefined;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,10 +1092,10 @@
   dependencies:
     buffer "^5.4.3"
 
-"@chainsafe/eth2-spec-tests@0.12.1":
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/eth2-spec-tests/-/eth2-spec-tests-0.12.1.tgz#8d172ebc40a4269e071bb20f607b3a5f4a557bc9"
-  integrity sha512-M4XsIuNU/LG4FdExZRxgotcj2ePX2uMtfcTI736HZBYBioyilSh2/dk6NekwQcd7qP/eRlIZ2CrWYwneY0cM/A==
+"@chainsafe/eth2-spec-tests@0.12.3":
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/@chainsafe/eth2-spec-tests/-/eth2-spec-tests-0.12.3.tgz#c2b4157a74505423612e4ab48ee0ee8745655dff"
+  integrity sha512-1MPLUSuW5RoSobf2p6/h5d3nDPYChkFcC7217f5cYO0Y8aUnPN4we3OYSHzyRTTUzB5DWXDjLe0RczCeBZX7Sg==
 
 "@chainsafe/persistent-merkle-tree@^0.2.1":
   version "0.2.1"


### PR DESCRIPTION
- bumped spect tests to 0.12.3
- added new finality tests

Note: new finality tests are extremely slow, on average 150s with fast spec. 

resolves #1606 