### PR TITLE
Regular sync: Handle empty range and avoid listening to gossip blocks

### DIFF
--- a/packages/lodestar/src/network/peers/score/simpleRpcScore.ts
+++ b/packages/lodestar/src/network/peers/score/simpleRpcScore.ts
@@ -11,7 +11,7 @@ const scoreConstants: Record<RpcScoreEvent, number> = {
   [RpcScoreEvent.UNKNOWN_ERROR]: -10,
 };
 
-const DEFAULT_SCORE = 100;
+export const DEFAULT_SCORE = 100;
 const MAX_SCORE = 200;
 const MIN_SCORE = 0;
 

--- a/packages/lodestar/src/network/peers/score/simpleRpcScore.ts
+++ b/packages/lodestar/src/network/peers/score/simpleRpcScore.ts
@@ -11,7 +11,7 @@ const scoreConstants: Record<RpcScoreEvent, number> = {
   [RpcScoreEvent.UNKNOWN_ERROR]: -10,
 };
 
-export const DEFAULT_SCORE = 100;
+export const DEFAULT_RPC_SCORE = 100;
 const MAX_SCORE = 200;
 const MIN_SCORE = 0;
 
@@ -23,11 +23,11 @@ export class SimpleRpcScoreTracker implements IRpcScoreTracker {
   }
 
   public getScore(peer: PeerId): number {
-    return this.store.getRpcScore(peer) ?? DEFAULT_SCORE;
+    return this.store.getRpcScore(peer) ?? DEFAULT_RPC_SCORE;
   }
 
   public reset(peer: PeerId): void {
-    this.store.setRpcScore(peer, DEFAULT_SCORE);
+    this.store.setRpcScore(peer, DEFAULT_RPC_SCORE);
   }
 
   public update(peer: PeerId, event: RpcScoreEvent): void {

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -213,6 +213,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
   private getSyncPeers = async (): Promise<PeerId[]> => {
     if (!checkBestPeer(this.bestPeer!, this.chain.forkChoice, this.network)) {
       this.logger.info("Regular Sync: wait for best peer");
+      this.bestPeer = undefined;
       await this.waitForBestPeer(this.controller.signal);
     }
     return [this.bestPeer!];
@@ -229,7 +230,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
       this.bestPeer = getBestPeer(this.config, peers, this.network.peerMetadata);
       if (checkBestPeer(this.bestPeer, this.chain.forkChoice, this.network)) {
         const peerHeadSlot = this.network.peerMetadata.getStatus(this.bestPeer)!.headSlot;
-        this.logger.verbose(`Found best peer ${this.bestPeer.toB58String()}`, {
+        this.logger.info(`Found best peer ${this.bestPeer.toB58String()}`, {
           peerHeadSlot,
           currentSlot: this.chain.clock.currentSlot,
         });

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -14,7 +14,7 @@ import {blockToHeader} from "@chainsafe/lodestar-beacon-state-transition";
 import {GENESIS_EPOCH, ZERO_HASH} from "../../constants";
 import {IPeerMetadataStore} from "../../network/peers/interface";
 import {getSyncPeers} from "./peers";
-import {DEFAULT_SCORE} from "../../network/peers";
+import {DEFAULT_RPC_SCORE} from "../../network/peers";
 
 export function getHighestCommonSlot(peerStatuses: (Status | null)[]): Slot {
   const slotStatuses = peerStatuses.reduce<Map<Slot, number>>((current, status) => {
@@ -275,6 +275,6 @@ export function checkBestPeer(peer: PeerId, forkChoice: IForkChoice, network: IN
       return !!status && status.headSlot > forkChoice.getHead().slot;
     },
     10,
-    DEFAULT_SCORE - 1
+    DEFAULT_RPC_SCORE - 1
   ).includes(peer);
 }

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -14,6 +14,7 @@ import {blockToHeader} from "@chainsafe/lodestar-beacon-state-transition";
 import {GENESIS_EPOCH, ZERO_HASH} from "../../constants";
 import {IPeerMetadataStore} from "../../network/peers/interface";
 import {getSyncPeers} from "./peers";
+import {DEFAULT_SCORE} from "../../network/peers";
 
 export function getHighestCommonSlot(peerStatuses: (Status | null)[]): Slot {
   const slotStatuses = peerStatuses.reduce<Map<Slot, number>>((current, status) => {
@@ -274,6 +275,6 @@ export function checkBestPeer(peer: PeerId, forkChoice: IForkChoice, network: IN
       return !!status && status.headSlot > forkChoice.getHead().slot;
     },
     10,
-    100
+    DEFAULT_SCORE - 1
   ).includes(peer);
 }


### PR DESCRIPTION
resolves #1614 
This is all about regular sync:
+ When best peer returns an empty range, do not trust that. Just use same start and expand end.
+ Do not listen for gossip blocks, otherwise it'll trigger unexpected fetch
+ Tweak best peer min score, set bestPeer to undefined in order to find a new best peer