### PR TITLE
Persist eth1 genesis progress on error

### DIFF
--- a/packages/lodestar-db/src/schema.ts
+++ b/packages/lodestar-db/src/schema.ts
@@ -26,6 +26,8 @@ export enum Bucket {
   phase0_eth1Data = 8, // timestamp -> Eth1Data
   index_depositDataRoot = 9, // depositIndex -> Root<DepositData>
   phase0_depositEvent = 19, // depositIndex -> DepositEvent
+  phase0_preGenesisState = 30, // Single = phase0.BeaconState
+  phase0_preGenesisStateLastProcessedBlock = 31, // Single = Uint8
   // op pool
   phase0_attestation = 10, // Root -> Attestation
   phase0_aggregateAndProof = 11, // Root -> AggregateAndProof

--- a/packages/lodestar/src/chain/genesis/genesis.ts
+++ b/packages/lodestar/src/chain/genesis/genesis.ts
@@ -17,37 +17,61 @@ import {
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {IEth1StreamParams, IEth1Provider, getDepositsAndBlockStreamForGenesis, getDepositsStream} from "../../eth1";
-import {IGenesisBuilder, IGenesisBuilderKwargs, IGenesisResult} from "./interface";
+import {IGenesisBuilder, IGenesisResult} from "./interface";
+
+export interface IGenesisBuilderKwargs {
+  config: IBeaconConfig;
+  eth1Provider: IEth1Provider;
+  logger: ILogger;
+
+  /** Use to restore pending progress */
+  pendingStatus?: {
+    state: TreeBacked<phase0.BeaconState>;
+    depositTree: TreeBacked<List<Root>>;
+    lastProcessedBlockNumber: number;
+  };
+
+  signal?: AbortSignal;
+  maxBlocksPerPoll?: number;
+}
 
 export class GenesisBuilder implements IGenesisBuilder {
+  // Expose state to persist on error
+  state: TreeBacked<phase0.BeaconState>;
+  depositTree: TreeBacked<List<Root>>;
+  lastProcessedBlockNumber: number;
+
   private readonly config: IBeaconConfig;
   private readonly eth1Provider: IEth1Provider;
   private readonly logger: ILogger;
   private readonly signal?: AbortSignal;
   private readonly eth1Params: IEth1StreamParams;
-  private state: TreeBacked<phase0.BeaconState>;
-  private depositTree: TreeBacked<List<Root>>;
-  private depositCache: Set<number>;
+  private readonly depositCache = new Set<number>();
 
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  constructor(config: IBeaconConfig, {eth1Provider, logger, signal, MAX_BLOCKS_PER_POLL}: IGenesisBuilderKwargs) {
+  constructor({config, eth1Provider, logger, signal, pendingStatus, maxBlocksPerPoll}: IGenesisBuilderKwargs) {
     this.config = config;
     this.eth1Provider = eth1Provider;
     this.logger = logger;
     this.signal = signal;
     this.eth1Params = {
       ...config.params,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      MAX_BLOCKS_PER_POLL: MAX_BLOCKS_PER_POLL || 10000,
+      maxBlocksPerPoll: maxBlocksPerPoll || 10000,
     };
 
-    this.state = getGenesisBeaconState(
-      config,
-      config.types.phase0.Eth1Data.defaultValue(),
-      getTemporaryBlockHeader(config, config.types.phase0.BeaconBlock.defaultValue())
-    );
-    this.depositTree = config.types.phase0.DepositDataRootList.tree.defaultValue();
-    this.depositCache = new Set<number>();
+    if (pendingStatus) {
+      this.logger.info("Restoring pending genesis state", {block: pendingStatus.lastProcessedBlockNumber});
+      this.state = pendingStatus.state;
+      this.depositTree = pendingStatus.depositTree;
+      this.lastProcessedBlockNumber = pendingStatus.lastProcessedBlockNumber;
+    } else {
+      this.state = getGenesisBeaconState(
+        config,
+        config.types.phase0.Eth1Data.defaultValue(),
+        getTemporaryBlockHeader(config, config.types.phase0.BeaconBlock.defaultValue())
+      );
+      this.depositTree = config.types.phase0.DepositDataRootList.tree.defaultValue();
+      this.lastProcessedBlockNumber = this.eth1Provider.deployBlock;
+    }
   }
 
   /**
@@ -56,11 +80,9 @@ export class GenesisBuilder implements IGenesisBuilder {
   async waitForGenesis(): Promise<IGenesisResult> {
     await this.eth1Provider.validateContract();
 
-    // TODO: Load data from data from this.db.depositData, this.db.depositDataRoot
+    // Load data from data from this.db.depositData, this.db.depositDataRoot
     // And start from a more recent fromBlock
-    const blockNumberLastestInDb = this.eth1Provider.deployBlock;
-
-    const blockNumberValidatorGenesis = await this.waitForGenesisValidators(blockNumberLastestInDb);
+    const blockNumberValidatorGenesis = await this.waitForGenesisValidators(this.lastProcessedBlockNumber);
 
     const depositsAndBlocksStream = getDepositsAndBlockStreamForGenesis(
       blockNumberValidatorGenesis,
@@ -73,6 +95,8 @@ export class GenesisBuilder implements IGenesisBuilder {
       this.applyDeposits(depositEvents);
       applyTimestamp(this.config, this.state, block.timestamp);
       applyEth1BlockHash(this.config, this.state, block.blockHash);
+      this.lastProcessedBlockNumber = block.blockNumber;
+
       if (isValidGenesisState(this.config, this.state)) {
         this.logger.info("Found genesis state", {blockNumber: block.blockNumber});
         return {
@@ -98,6 +122,8 @@ export class GenesisBuilder implements IGenesisBuilder {
 
     for await (const {depositEvents, blockNumber} of depositsStream) {
       this.applyDeposits(depositEvents);
+      this.lastProcessedBlockNumber = blockNumber;
+
       if (isValidGenesisValidators(this.config, this.state)) {
         this.logger.info("Found enough genesis validators", {blockNumber});
         return blockNumber;

--- a/packages/lodestar/src/chain/genesis/interface.ts
+++ b/packages/lodestar/src/chain/genesis/interface.ts
@@ -1,16 +1,5 @@
-import {IEth1Provider} from "../../eth1";
-import {ILogger} from "@chainsafe/lodestar-utils";
 import {TreeBacked, List} from "@chainsafe/ssz";
 import {phase0, Root} from "@chainsafe/lodestar-types";
-import {AbortSignal} from "abort-controller";
-
-export interface IGenesisBuilderKwargs {
-  eth1Provider: IEth1Provider;
-  logger: ILogger;
-  signal?: AbortSignal;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  MAX_BLOCKS_PER_POLL?: number;
-}
 
 export interface IGenesisResult {
   state: TreeBacked<phase0.BeaconState>;

--- a/packages/lodestar/src/chain/initState.ts
+++ b/packages/lodestar/src/chain/initState.ts
@@ -69,21 +69,47 @@ export async function initStateFromEth1(
 ): Promise<TreeBacked<phase0.BeaconState>> {
   logger.info("Listening to eth1 for genesis state");
 
-  const builder = new GenesisBuilder(config, {eth1Provider, logger, signal});
+  const statePreGenesis = await db.preGenesisState.get();
+  const depositDataRoot = await db.depositDataRoot.getDepositRootTree();
+  const lastProcessedBlockNumber = await db.preGenesisStateLastProcessedBlock.get();
 
-  const genesisResult = await builder.waitForGenesis();
-  const genesisBlock = createGenesisBlock(config, genesisResult.state);
-  const stateRoot = config.types.phase0.BeaconState.hashTreeRoot(genesisResult.state);
-  const blockRoot = config.types.phase0.BeaconBlock.hashTreeRoot(genesisBlock.message);
-
-  logger.info("Initializing genesis state", {
-    stateRoot: toHexString(stateRoot),
-    blockRoot: toHexString(blockRoot),
-    validatorCount: genesisResult.state.validators.length,
+  const builder = new GenesisBuilder({
+    config,
+    eth1Provider,
+    logger,
+    signal,
+    pendingStatus:
+      statePreGenesis && depositDataRoot && lastProcessedBlockNumber != null
+        ? {state: statePreGenesis, depositTree: depositDataRoot, lastProcessedBlockNumber}
+        : undefined,
   });
 
-  await persistGenesisResult(db, genesisResult, genesisBlock);
-  return genesisResult.state;
+  try {
+    const genesisResult = await builder.waitForGenesis();
+    const genesisBlock = createGenesisBlock(config, genesisResult.state);
+    const stateRoot = config.types.phase0.BeaconState.hashTreeRoot(genesisResult.state);
+    const blockRoot = config.types.phase0.BeaconBlock.hashTreeRoot(genesisBlock.message);
+
+    logger.info("Initializing genesis state", {
+      stateRoot: toHexString(stateRoot),
+      blockRoot: toHexString(blockRoot),
+      validatorCount: genesisResult.state.validators.length,
+    });
+
+    await persistGenesisResult(db, genesisResult, genesisBlock);
+
+    logger.verbose("Clearing pending genesis state if any");
+    await db.preGenesisState.delete();
+    await db.preGenesisStateLastProcessedBlock.delete();
+
+    return genesisResult.state;
+  } catch (e) {
+    logger.info("Persisting genesis state", {block: builder.lastProcessedBlockNumber});
+    await db.preGenesisState.put(builder.state);
+    await db.depositDataRoot.putList(builder.depositTree);
+    await db.preGenesisStateLastProcessedBlock.put(builder.lastProcessedBlockNumber);
+    throw e;
+  }
 }
 
 /**

--- a/packages/lodestar/src/db/api/beacon/beacon.ts
+++ b/packages/lodestar/src/db/api/beacon/beacon.ts
@@ -19,6 +19,7 @@ import {
   StateArchiveRepository,
   VoluntaryExitRepository,
 } from "./repositories";
+import {PreGenesisState, PreGenesisStateLastProcessedBlock} from "./single";
 import {SeenAttestationCache} from "./seenAttestationCache";
 import {PendingBlockRepository} from "./repositories/pendingBlock";
 
@@ -39,6 +40,8 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
 
   depositDataRoot: DepositDataRootRepository;
   eth1Data: Eth1DataRepository;
+  preGenesisState: PreGenesisState;
+  preGenesisStateLastProcessedBlock: PreGenesisStateLastProcessedBlock;
 
   constructor(opts: IDatabaseApiOptions) {
     super(opts);
@@ -56,6 +59,8 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
     this.depositEvent = new DepositEventRepository(this.config, this.db);
     this.depositDataRoot = new DepositDataRootRepository(this.config, this.db);
     this.eth1Data = new Eth1DataRepository(this.config, this.db);
+    this.preGenesisState = new PreGenesisState(this.config, this.db);
+    this.preGenesisStateLastProcessedBlock = new PreGenesisStateLastProcessedBlock(this.config, this.db);
   }
 
   /**

--- a/packages/lodestar/src/db/api/beacon/interface.ts
+++ b/packages/lodestar/src/db/api/beacon/interface.ts
@@ -18,6 +18,7 @@ import {
   StateArchiveRepository,
   VoluntaryExitRepository,
 } from "./repositories";
+import {PreGenesisState, PreGenesisStateLastProcessedBlock} from "./single";
 import {SeenAttestationCache} from "./seenAttestationCache";
 import {PendingBlockRepository} from "./repositories/pendingBlock";
 
@@ -54,6 +55,8 @@ export interface IBeaconDb {
   depositEvent: DepositEventRepository;
 
   // eth1 processing
+  preGenesisState: PreGenesisState;
+  preGenesisStateLastProcessedBlock: PreGenesisStateLastProcessedBlock;
 
   // all deposit data roots and merkle tree
   depositDataRoot: DepositDataRootRepository;

--- a/packages/lodestar/src/db/api/beacon/single/index.ts
+++ b/packages/lodestar/src/db/api/beacon/single/index.ts
@@ -1,0 +1,2 @@
+export * from "./preGenesisState";
+export * from "./preGenesisStateLastProcessedBlock";

--- a/packages/lodestar/src/db/api/beacon/single/preGenesisState.ts
+++ b/packages/lodestar/src/db/api/beacon/single/preGenesisState.ts
@@ -1,0 +1,31 @@
+import {TreeBacked, CompositeType} from "@chainsafe/ssz";
+import {phase0} from "@chainsafe/lodestar-types";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IDatabaseController, Bucket} from "@chainsafe/lodestar-db";
+
+export class PreGenesisState {
+  private readonly bucket: Bucket;
+  private readonly type: CompositeType<TreeBacked<phase0.BeaconState>>;
+  private readonly db: IDatabaseController<Buffer, Buffer>;
+  private readonly key: Buffer;
+
+  constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
+    this.db = db;
+    this.type = (config.types.phase0.BeaconState as unknown) as CompositeType<TreeBacked<phase0.BeaconState>>;
+    this.bucket = Bucket.phase0_preGenesisState;
+    this.key = Buffer.from(new Uint8Array([this.bucket]));
+  }
+
+  async put(value: TreeBacked<phase0.BeaconState>): Promise<void> {
+    await this.db.put(this.key, this.type.serialize(value) as Buffer);
+  }
+
+  async get(): Promise<TreeBacked<phase0.BeaconState> | null> {
+    const value = await this.db.get(this.key);
+    return value ? this.type.tree.deserialize(value) : null;
+  }
+
+  async delete(): Promise<void> {
+    await this.db.delete(this.key);
+  }
+}

--- a/packages/lodestar/src/db/api/beacon/single/preGenesisStateLastProcessedBlock.ts
+++ b/packages/lodestar/src/db/api/beacon/single/preGenesisStateLastProcessedBlock.ts
@@ -1,0 +1,30 @@
+import {NumberUintType} from "@chainsafe/ssz";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IDatabaseController, Bucket} from "@chainsafe/lodestar-db";
+
+export class PreGenesisStateLastProcessedBlock {
+  private readonly bucket: Bucket;
+  private readonly type: NumberUintType;
+  private readonly db: IDatabaseController<Buffer, Buffer>;
+  private readonly key: Buffer;
+
+  constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
+    this.db = db;
+    this.type = config.types.Number64;
+    this.bucket = Bucket.phase0_preGenesisStateLastProcessedBlock;
+    this.key = Buffer.from(new Uint8Array([this.bucket]));
+  }
+
+  async put(value: number): Promise<void> {
+    await this.db.put(this.key, this.type.serialize(value) as Buffer);
+  }
+
+  async get(): Promise<number | null> {
+    const value = await this.db.get(this.key);
+    return value ? this.type.deserialize(value) : null;
+  }
+
+  async delete(): Promise<void> {
+    await this.db.delete(this.key);
+  }
+}

--- a/packages/lodestar/src/eth1/interface.ts
+++ b/packages/lodestar/src/eth1/interface.ts
@@ -39,8 +39,7 @@ export type IEth1StreamParams = Pick<
   IBeaconConfig["params"],
   "ETH1_FOLLOW_DISTANCE" | "MIN_GENESIS_TIME" | "GENESIS_DELAY" | "SECONDS_PER_ETH1_BLOCK"
 > & {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  MAX_BLOCKS_PER_POLL: number;
+  maxBlocksPerPoll: number;
 };
 
 export type IJson = string | number | boolean | undefined | IJson[] | {[key: string]: IJson};

--- a/packages/lodestar/src/eth1/stream.ts
+++ b/packages/lodestar/src/eth1/stream.ts
@@ -24,7 +24,7 @@ export async function* getDepositsStream(
 
   while (true) {
     const remoteFollowBlock = await getRemoteFollowBlock(provider, params);
-    const toBlock = Math.min(remoteFollowBlock, fromBlock + params.MAX_BLOCKS_PER_POLL);
+    const toBlock = Math.min(remoteFollowBlock, fromBlock + params.maxBlocksPerPoll);
     const logs = await provider.getDepositEvents(fromBlock, toBlock);
     for (const batchedDeposits of groupDepositEventsByBlock(logs)) {
       yield batchedDeposits;
@@ -62,7 +62,7 @@ export async function* getDepositsAndBlockStreamForGenesis(
     const remoteFollowBlock = await getRemoteFollowBlock(provider, params);
     const nextBlockDiff = optimizeNextBlockDiffForGenesis(block, params);
     fromBlock = toBlock;
-    toBlock = Math.min(remoteFollowBlock, fromBlock + Math.min(nextBlockDiff, params.MAX_BLOCKS_PER_POLL));
+    toBlock = Math.min(remoteFollowBlock, fromBlock + Math.min(nextBlockDiff, params.maxBlocksPerPoll));
 
     // If reached head, sleep for an eth1 block. Throws if signal is aborted
     await sleep(toBlock >= remoteFollowBlock ? params.SECONDS_PER_ETH1_BLOCK * 1000 : 10, signal);

--- a/packages/lodestar/test/e2e/eth1/stream.test.ts
+++ b/packages/lodestar/test/e2e/eth1/stream.test.ts
@@ -14,10 +14,9 @@ describe("Eth1 streams", function () {
     depositContractDeployBlock: testnet.depositBlock,
   });
 
-  const MAX_BLOCKS_PER_POLL = 1000;
+  const maxBlocksPerPoll = 1000;
   const depositsToFetch = 1000;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  const eth1Params = {...config.params, MAX_BLOCKS_PER_POLL};
+  const eth1Params = {...config.params, maxBlocksPerPoll};
 
   it(`Should fetch ${depositsToFetch} deposits with getDepositsStream`, async function () {
     const controller = new AbortController();

--- a/packages/lodestar/test/unit/chain/genesis/genesis.test.ts
+++ b/packages/lodestar/test/unit/chain/genesis/genesis.test.ts
@@ -66,11 +66,11 @@ describe("genesis builder", function () {
       },
     };
 
-    const genesisBuilder = new GenesisBuilder(schlesiConfig, {
+    const genesisBuilder = new GenesisBuilder({
+      config: schlesiConfig,
       eth1Provider,
       logger: new WinstonLogger(),
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      MAX_BLOCKS_PER_POLL: 1,
+      maxBlocksPerPoll: 1,
     });
 
     const {state} = await genesisBuilder.waitForGenesis();
@@ -100,12 +100,12 @@ describe("genesis builder", function () {
       },
     };
 
-    const genesisBuilder = new GenesisBuilder(schlesiConfig, {
+    const genesisBuilder = new GenesisBuilder({
+      config: schlesiConfig,
       eth1Provider,
       logger: new WinstonLogger(),
       signal: controller.signal,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      MAX_BLOCKS_PER_POLL: 1,
+      maxBlocksPerPoll: 1,
     });
 
     await expect(genesisBuilder.waitForGenesis()).to.rejectedWith(ErrorAborted);


### PR DESCRIPTION
While keeping eth1 genesis builder detached from the db, persist current progress on error.

#### How to test

To test this branch run the cli with
```
lodestar beacon --forceGenesis --rootDir ./lodestar-db
```
Then CTRL+C after it has processed 1 deposit and it will abort after a few seconds, when done processing that batch (deposit 192 in mainnet). Then run again with the same command and check the logs saying it's processing deposit 193, not deposit 1.