### PR TITLE
Add retry on large eth1 requests

### DIFF
--- a/packages/lodestar/src/eth1/eth1ForBlockProduction.ts
+++ b/packages/lodestar/src/eth1/eth1ForBlockProduction.ts
@@ -5,7 +5,6 @@ import {getNewEth1Data} from "@chainsafe/lodestar-beacon-state-transition/lib/fa
 import {ILogger, sleep} from "@chainsafe/lodestar-utils";
 import {AbortSignal} from "abort-controller";
 import {IBeaconDb} from "../db";
-import {linspace} from "../util/numpy";
 import {Eth1DepositsCache} from "./eth1DepositsCache";
 import {Eth1DataCache} from "./eth1DataCache";
 import {getEth1VotesToConsider, pickEth1Vote} from "./utils/eth1Vote";
@@ -178,8 +177,7 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
       lastProcessedDepositBlockNumber
     );
 
-    const blockNumbers = linspace(fromBlock, toBlock);
-    const eth1Blocks = await this.eth1Provider.getBlocksByNumber(blockNumbers, this.signal);
+    const eth1Blocks = await this.eth1Provider.getBlocksByNumber(fromBlock, toBlock, this.signal);
     this.logger.verbose(`Fetched eth1 blocks ${eth1Blocks.length}`, {fromBlock, toBlock});
 
     const eth1Datas = await this.depositsCache.getEth1DataForBlocks(eth1Blocks, lastProcessedDepositBlockNumber);

--- a/packages/lodestar/src/eth1/interface.ts
+++ b/packages/lodestar/src/eth1/interface.ts
@@ -13,8 +13,8 @@ export interface IEth1Provider {
   deployBlock: number;
   getBlockNumber(signal?: AbortSignal): Promise<number>;
   getBlockByNumber(blockNumber: number, signal?: AbortSignal): Promise<Eth1Block>;
-  getBlocksByNumber(blockNumbers: number[], signal?: AbortSignal): Promise<Eth1Block[]>;
-  getDepositEvents(fromBlock: number, toBlock?: number, signal?: AbortSignal): Promise<DepositEvent[]>;
+  getBlocksByNumber(fromBlock: number, toBlock: number, signal?: AbortSignal): Promise<Eth1Block[]>;
+  getDepositEvents(fromBlock: number, toBlock: number, signal?: AbortSignal): Promise<DepositEvent[]>;
   validateContract(signal?: AbortSignal): Promise<void>;
 }
 

--- a/packages/lodestar/src/eth1/jsonRpcHttpClient.ts
+++ b/packages/lodestar/src/eth1/jsonRpcHttpClient.ts
@@ -88,7 +88,13 @@ function parseJson<T>(json: string): T {
   try {
     return JSON.parse(json);
   } catch (e) {
-    throw Error(`Error parsing JSON: ${e.message}\n${json.slice(0, maxStringLengthToPrint)}`);
+    throw new ErrorParseJson(json, e);
+  }
+}
+
+export class ErrorParseJson extends Error {
+  constructor(json: string, e: Error) {
+    super(`Error parsing JSON: ${e.message}\n${json.slice(0, maxStringLengthToPrint)}`);
   }
 }
 

--- a/packages/lodestar/src/util/chunkify.ts
+++ b/packages/lodestar/src/util/chunkify.ts
@@ -1,0 +1,27 @@
+/**
+ * Split an inclusive range into a sequence of contiguous inclusive ranges
+ * ```
+ * [[a,b], [c,d] ... Sn] = chunkifyInclusiveRange([a,z], n)
+ * // where
+ * [a,z] = [a,b] U [c,d] U ... U Sn
+ * ```
+ * @param from range start inclusive
+ * @param to range end inclusive
+ * @param chunks Maximum number of chunks, if range is big enough
+ */
+export function chunkifyInclusiveRange(from: number, to: number, chunkCount: number): number[][] {
+  // Enforce chunkCount >= 1
+  if (chunkCount < 1) chunkCount = 1;
+
+  const totalItems = to - from + 1;
+  const itemsPerChunk = Math.ceil(totalItems / chunkCount);
+
+  const chunks: number[][] = [];
+  for (let i = 0; i < chunkCount; i++) {
+    const _from = from + i * itemsPerChunk;
+    const _to = Math.min(from + (i + 1) * itemsPerChunk - 1, to);
+    chunks.push([_from, _to]);
+    if (_to >= to) break;
+  }
+  return chunks;
+}

--- a/packages/lodestar/src/util/retry.ts
+++ b/packages/lodestar/src/util/retry.ts
@@ -1,0 +1,36 @@
+export interface IRetryOptions {
+  /**
+   * The maximum amount of times to retry the operation. Default is 5
+   */
+  retries?: number;
+  /**
+   * An optional Function that is invoked after the provided callback throws
+   * It expects a boolean to know if it should retry or not
+   * Useful to make retrying conditional on the type of error thrown
+   */
+  shouldRetry?: (lastError: Error) => boolean;
+}
+
+/**
+ * Retry a given function on error.
+ * @param fn Async callback to retry. Invoked with 1 parameter
+ * A Number identifying the attempt. The absolute first attempt (before any retries) is 1
+ * @param opts
+ */
+export async function retry<A>(fn: (attempt: number) => A | Promise<A>, opts?: IRetryOptions): Promise<A> {
+  const maxRetries = opts?.retries || 5;
+  const shouldRetry = opts?.shouldRetry;
+
+  let lastError: Error = Error("RetryError");
+  for (let i = 1; i <= maxRetries; i++) {
+    try {
+      return await fn(i);
+    } catch (e) {
+      lastError = e;
+      if (shouldRetry && !shouldRetry(lastError)) {
+        break;
+      }
+    }
+  }
+  throw lastError;
+}

--- a/packages/lodestar/test/e2e/eth1/eth1JsonRpcClient.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1JsonRpcClient.test.ts
@@ -29,12 +29,9 @@ describe("eth1 / httpEth1Client", function () {
   };
 
   it("getBlocksByNumber: Should fetch a block range", async function () {
-    const blockNumbers = linspace(
-      firstGoerliBlocks[0].blockNumber,
-      firstGoerliBlocks[firstGoerliBlocks.length - 1].blockNumber
-    );
-    const blocks = await eth1JsonRpcClient.getBlocksByNumber(blockNumbers);
-
+    const fromBlock = firstGoerliBlocks[0].blockNumber;
+    const toBlock = firstGoerliBlocks[firstGoerliBlocks.length - 1].blockNumber;
+    const blocks = await eth1JsonRpcClient.getBlocksByNumber(fromBlock, toBlock);
     expect(blocks).to.deep.equal(firstGoerliBlocks);
   });
 

--- a/packages/lodestar/test/unit/chain/genesis/genesis.test.ts
+++ b/packages/lodestar/test/unit/chain/genesis/genesis.test.ts
@@ -62,9 +62,10 @@ describe("genesis builder", function () {
       deployBlock: events[0].blockNumber,
       getBlockNumber: async () => 2000,
       getBlockByNumber: async (number) => blocks[number],
-      getBlocksByNumber: async (numbers) => blocks.filter((b) => numbers.includes(b.blockNumber)),
+      getBlocksByNumber: async (fromBlock, toBlock) =>
+        blocks.filter((b) => b.blockNumber >= fromBlock && b.blockNumber <= toBlock),
       getDepositEvents: async (fromBlock, toBlock) =>
-        events.filter((e) => e.blockNumber >= fromBlock && e.blockNumber <= (toBlock || fromBlock)),
+        events.filter((e) => e.blockNumber >= fromBlock && e.blockNumber <= toBlock),
       validateContract: async () => {
         return;
       },
@@ -92,10 +93,11 @@ describe("genesis builder", function () {
       deployBlock: events[0].blockNumber,
       getBlockNumber: async () => 2000,
       getBlockByNumber: async (number) => blocks[number],
-      getBlocksByNumber: async (numbers) => blocks.filter((b) => numbers.includes(b.blockNumber)),
+      getBlocksByNumber: async (fromBlock, toBlock) =>
+        blocks.filter((b) => b.blockNumber >= fromBlock && b.blockNumber <= toBlock),
       getDepositEvents: async (fromBlock, toBlock) => {
         controller.abort();
-        return events.filter((e) => e.blockNumber >= fromBlock && e.blockNumber <= (toBlock || fromBlock));
+        return events.filter((e) => e.blockNumber >= fromBlock && e.blockNumber <= toBlock);
       },
       validateContract: async () => {
         return;

--- a/packages/lodestar/test/unit/util/chunkify.test.ts
+++ b/packages/lodestar/test/unit/util/chunkify.test.ts
@@ -1,0 +1,83 @@
+import {expect} from "chai";
+import {chunkifyInclusiveRange} from "../../../src/util/chunkify";
+
+describe("chunkifyInclusiveRange", () => {
+  const testCases: {
+    from: number;
+    to: number;
+    chunks: number;
+    result: number[][];
+  }[] = [
+    {
+      from: 0,
+      to: 0,
+      chunks: 0,
+      result: [[0, 0]],
+    },
+    {
+      from: 0,
+      to: 4,
+      chunks: 1,
+      result: [[0, 4]],
+    },
+    {
+      from: 0,
+      to: 4,
+      chunks: 2,
+      result: [
+        [0, 2],
+        [3, 4],
+      ],
+    },
+    {
+      from: 0,
+      to: 4,
+      chunks: 3,
+      result: [
+        [0, 1],
+        [2, 3],
+        [4, 4],
+      ],
+    },
+    {
+      from: 0,
+      to: 4,
+      chunks: 4,
+      result: [
+        [0, 1],
+        [2, 3],
+        [4, 4],
+      ],
+    },
+    {
+      from: 0,
+      to: 4,
+      chunks: 5,
+      result: [
+        [0, 0],
+        [1, 1],
+        [2, 2],
+        [3, 3],
+        [4, 4],
+      ],
+    },
+    {
+      from: 1000,
+      to: 2000,
+      chunks: 5,
+      result: [
+        [1000, 1200],
+        [1201, 1401],
+        [1402, 1602],
+        [1603, 1803],
+        [1804, 2000],
+      ],
+    },
+  ];
+
+  for (const {from, to, chunks, result} of testCases) {
+    it(`[${from},${to}] / ${chunks}`, () => {
+      expect(chunkifyInclusiveRange(from, to, chunks)).to.deep.equal(result);
+    });
+  }
+});

--- a/packages/lodestar/test/unit/util/retry.test.ts
+++ b/packages/lodestar/test/unit/util/retry.test.ts
@@ -1,0 +1,50 @@
+import chai, {expect} from "chai";
+import chaiAsPromised from "chai-as-promised";
+import {retry, IRetryOptions} from "../../../src/util/retry";
+
+chai.use(chaiAsPromised);
+
+describe("retry", () => {
+  interface ITestCase {
+    id: string;
+    fn: (attempt: number) => Promise<any>;
+    opts?: IRetryOptions;
+    result: any | Error;
+  }
+
+  const sampleError = Error("SAMPLE ERROR");
+  const sampleResult = "SAMPLE RESULT";
+  const retries = 3;
+
+  const testCases: ITestCase[] = [
+    {
+      id: "Reject",
+      fn: () => Promise.reject(sampleError),
+      result: sampleError,
+    },
+    {
+      id: "Resolve",
+      fn: () => Promise.resolve(sampleResult),
+      result: sampleResult,
+    },
+    {
+      id: "Succeed at the last attempt",
+      fn: async (attempt) => {
+        if (attempt < retries) throw sampleError;
+        else return sampleResult;
+      },
+      opts: {retries},
+      result: sampleResult,
+    },
+  ];
+
+  for (const {id, fn, opts, result} of testCases) {
+    it(id, async () => {
+      if (result instanceof Error) {
+        await expect(retry(fn, opts)).to.be.rejectedWith(result);
+      } else {
+        expect(await retry(fn, opts)).to.deep.equal(result);
+      }
+    });
+  }
+});


### PR DESCRIPTION
Current eth1 module implementation can request very large amounts of data, which some Eth1 nodes seem to return with a success 200 HTTP code but the body of the request is truncated and contains invalid JSON. 

This PR adds a retry wrapper on the batch blocks request and the logs request. On error, if the error is caused to bad JSON, it will retry the same range of blocks but splitting the range requested into smaller chunks (original range /1, /2, /4).