### PR TITLE
Backward sync controlled by sync

### DIFF
--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -60,7 +60,7 @@ export class BlockProcessor implements IService {
     this.eventBus = eventBus;
     this.clock = clock;
     this.attestationProcessor = attestationProcessor;
-    this.pendingBlocks = new BlockPool(config, this.blockProcessingSource, this.eventBus, forkChoice);
+    this.pendingBlocks = new BlockPool(config, this.blockProcessingSource, this.eventBus);
   }
 
   public async start(): Promise<void> {

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -60,7 +60,6 @@ export class BeaconSync implements IBeaconSync {
     this.mode = SyncMode.WAITING_PEERS as SyncMode;
     await this.reqResp.start();
     await this.attestationCollector.start();
-    this.chain.emitter.on("unknownBlockRoot", this.onUnknownBlockRoot);
     // so we don't wait indefinitely
     await this.waitForPeers();
     if (this.mode === SyncMode.STOPPED) {
@@ -149,6 +148,7 @@ export class BeaconSync implements IBeaconSync {
     await this.initialSync.stop();
     this.startSyncTimer(3 * this.config.params.SECONDS_PER_SLOT * 1000);
     this.regularSync.on("syncCompleted", this.syncCompleted);
+    this.chain.emitter.on("unknownBlockRoot", this.onUnknownBlockRoot);
     await this.gossip.start();
     await this.regularSync.start();
   }


### PR DESCRIPTION
resolves #1346 
+ block pool always emit `unknownBlockRoot`, which is a missing ancestor root. Consumers decide how to handle it.
+ For sync, it'll handle `unknownBlockRoot` from the time of regular sync and keep doing that until the node is stopped.

This should help the current regular sync work better as gossip/pending blocks will grow in 2 directions and will soon overlap with the follow up `beacon_blocks_by_range` fetch.