### PR TITLE
Skip parsing context if it's undefined

### DIFF
--- a/packages/lodestar-utils/src/logger/format.ts
+++ b/packages/lodestar-utils/src/logger/format.ts
@@ -76,7 +76,11 @@ function humanReadableTemplateFn(_info: {[key: string]: any; level: string; mess
 /**
  * Extract stack property from context to allow appending at the end of the log
  */
-function splitContextAndStackTrace(context?: Context | Error): {context: string; stack?: string} {
+function splitContextAndStackTrace(context?: Context | Error): {context?: string; stack?: string} {
+  if (!context) {
+    return {};
+  }
+
   const json = toJson(context);
 
   if (typeof json === "object" && json !== null && !Array.isArray(json) && json.stack) {


### PR DESCRIPTION
Prevent logging "undefined" if no context is logged
```
2020-10-05 19:41:20 [SYNC]             info: Waiting for peers... undefined
2020-10-05 19:41:20 [SYNC]             warn: Current peerCount=0, required = 2 undefined
```