### PR TITLE
Add proper source map support for Typescript

### DIFF
--- a/packages/lodestar-cli/package.json
+++ b/packages/lodestar-cli/package.json
@@ -72,6 +72,7 @@
     "peer-id": "^0.13.7",
     "read-pkg-up": "^7.0.1",
     "rimraf": "^3.0.0",
+    "source-map-support": "^0.5.19",
     "uuidv4": "^6.1.1",
     "yargs": "^16.0.3"
   },

--- a/packages/lodestar-cli/src/index.ts
+++ b/packages/lodestar-cli/src/index.ts
@@ -5,6 +5,7 @@ import yargs from "yargs";
 import {cmds} from "./cmds";
 import {globalOptions} from "./options";
 import {YargsError, registerCommandToYargs} from "./util";
+import "source-map-support/register";
 
 const topBanner = "🌟 Lodestar: Ethereum 2.0 TypeScript Implementation of the Beacon Chain";
 const bottomBanner = "For more information, check the CLI reference https://chainsafe.github.io/lodestar/reference/cli";

--- a/yarn.lock
+++ b/yarn.lock
@@ -12483,7 +12483,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.13:
+source-map-support@^0.5.13, source-map-support@^0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==


### PR DESCRIPTION
Instead of printing this error in the CLI with javascript source stack traces
```
2020-10-05 19:45:43 [ETH1]            error: Error updating eth1 chain cache message=503 Service Unavailable: no healthy upstream 
Error: 503 Service Unavailable: no healthy upstream
    at fetchJson (/home/lion/Code/eth2.0/lodestar/packages/lodestar/lib/eth1/jsonRpcHttpClient.js:88:11)
    at processTicksAndRejections (internal/process/task_queues.js:94:5)
    at async JsonRpcHttpClient.fetch (/home/lion/Code/eth2.0/lodestar/packages/lodestar/lib/eth1/jsonRpcHttpClient.js:37:17)
    at async Eth1Provider.getBlockNumber (/home/lion/Code/eth2.0/lodestar/packages/lodestar/lib/eth1/eth1JsonRpcClient.js:51:28)
    at async Eth1ForBlockProduction.update (/home/lion/Code/eth2.0/lodestar/packages/lodestar/lib/eth1/eth1ForBlockProduction.js:134:32)
    at async Eth1ForBlockProduction.runAutoUpdate (/home/lion/Code/eth2.0/lodestar/packages/lodestar/lib/eth1/eth1ForBlockProduction.js:117:28)

```
print this one with correct Typescript stack trace
```
2020-10-05 19:59:57 [ETH1]            error: Error updating eth1 chain cache message=503 Service Unavailable: no healthy upstream 
Error: 503 Service Unavailable: no healthy upstream
    at fetchJson (/home/lion/Code/eth2.0/lodestar/packages/lodestar/src/eth1/jsonRpcHttpClient.ts:76:11)
    at processTicksAndRejections (internal/process/task_queues.js:94:5)
    at JsonRpcHttpClient.fetch (/home/lion/Code/eth2.0/lodestar/packages/lodestar/src/eth1/jsonRpcHttpClient.ts:38:34)
    at Eth1Provider.getBlockNumber (/home/lion/Code/eth2.0/lodestar/packages/lodestar/src/eth1/eth1JsonRpcClient.ts:60:28)
    at Eth1ForBlockProduction.update (/home/lion/Code/eth2.0/lodestar/packages/lodestar/src/eth1/eth1ForBlockProduction.ts:129:32)
    at Eth1ForBlockProduction.runAutoUpdate (/home/lion/Code/eth2.0/lodestar/packages/lodestar/src/eth1/eth1ForBlockProduction.ts:113:28)
```

See https://www.npmjs.com/package/source-map-support for reasoning