### PR TITLE
Run lodestar with node directly not yarn

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,7 +34,7 @@ yarn run build
 Lodestar should now be ready for use:
 
 ```bash
-yarn run cli --help
+./lodestar --help
 ```
 
 ## Install from NPM

--- a/docs/usage/altona.md
+++ b/docs/usage/altona.md
@@ -5,7 +5,7 @@ Running a Lodestar node on the [Altona](https://github.com/goerli/altona) multi-
 Make sure lodestar is installed in your local environment. The following command should return a non error message. If it fails, go the [install guide](../../installation/).
 
 ```
-yarn run cli --help
+./lodestar --help
 ```
 
 ## Run a beacon node
@@ -13,7 +13,7 @@ yarn run cli --help
 To start a Lodestar beacon run the command:
 
 ```bash
-yarn run cli beacon --testnet altona
+./lodestar beacon --testnet altona
 ```
 
 Immediatelly you should see confirmation that the different modules have started

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -8,5 +8,5 @@
 To run any other command or explore Lodestar options run the help command.
 
 ```bash
-yarn run cli --help
+./lodestar --help
 ```

--- a/docs/usage/key-management.md
+++ b/docs/usage/key-management.md
@@ -67,7 +67,7 @@ This command will:
 To import a keystore that was created via the ETH2.0 Deposit Launch Pad:
 
 ```
-yarn run cli account validator import --testnet medalla --directory <path to your launchpad keys>
+./lodestar account validator import --testnet medalla --directory <path to your launchpad keys>
 ```
 
 You will be prompted to enter a password. Use the same one you used to create the keys initially.
@@ -75,7 +75,7 @@ You will be prompted to enter a password. Use the same one you used to create th
 To confirm your keys have been imported run:
 
 ```
-yarn run cli account validator list --testnet medalla
+./lodestar account validator list --testnet medalla
 ```
 
 This command will print the public address of every active keystore.

--- a/docs/usage/local.md
+++ b/docs/usage/local.md
@@ -7,7 +7,7 @@ To quickly test and run Lodestar we recommend to start a local testnet. We recom
 Run a beacon node with 8 validators and default settings. State will be written to .tmp/state.ssz
 
 ```bash
-yarn run cli dev --dev.genesisValidators 8 --dev.reset
+./lodestar dev --dev.genesisValidators 8 --dev.reset
 ```
 
 **Terminal 2**
@@ -15,7 +15,7 @@ yarn run cli dev --dev.genesisValidators 8 --dev.reset
 Connect to bootnode (node 1 default multiaddrs) but without starting validators.
 
 ```bash
-yarn run cli dev --dev.startValidators 0:0 \
+./lodestar dev --dev.startValidators 0:0 \
   --genesisStateFile ./dev/genesis.ssz \
   --network.localMultiaddrs /ip4/127.0.0.1/tcp/30607 \
   --sync.minPeers 1

--- a/docs/usage/medalla.md
+++ b/docs/usage/medalla.md
@@ -5,7 +5,7 @@ Running a Lodestar node on the [Medalla](https://github.com/goerli/medalla) mult
 Make sure lodestar is installed in your local environment. The following command should return a non error message. If it fails, go the [install guide](../../installation/).
 
 ```
-yarn run cli --help
+./lodestar --help
 ```
 
 ## Run a beacon node
@@ -13,7 +13,7 @@ yarn run cli --help
 To start a Lodestar beacon run the command:
 
 ```bash
-yarn run cli beacon --testnet medalla
+./lodestar beacon --testnet medalla
 ```
 
 <!-- prettier-ignore-start -->
@@ -58,7 +58,7 @@ The `--testnet medalla` flag automatically sets the following configuration opti
 To start a Lodestar validator run the command:
 
 ```bash
-yarn run cli validator --testnet medalla
+./lodestar validator --testnet medalla
 ```
 
 You should see confirmation that modules have started. 

--- a/docs/usage/witti.md
+++ b/docs/usage/witti.md
@@ -5,7 +5,7 @@ Running a Lodestar node on the [Witti](https://github.com/goerli/witti) multi-cl
 Make sure lodestar in installed in your local environment. The following command should return a non error message. If it fails, go the [install guide](../../installation/) and make sure Lodestar is available in your environment.
 
 ```
-yarn run cli --help
+./lodestar --help
 ```
 
 ## Initialize beacon configuration
@@ -78,7 +78,7 @@ We recommend initializing lodestar into a specific directory, which is helpful f
 To initialize the Lodestar configuration, run the command:
 
 ```bash
-yarn run cli beacon init \
+./lodestar beacon init \
     --eth1.enabled=false \
     --chain.genesisStateFile=genesis.ssz \
     --template-config-file witti.json \
@@ -101,7 +101,7 @@ As a result, new files should had been created in `.witti/beacon` with a directo
 To start a Lodestar beacon run the command:
 
 ```bash
-yarn run cli beacon run \
+./lodestar beacon run \
     --root-dir .witti
 ```
 

--- a/lodestar
+++ b/lodestar
@@ -1,0 +1,1 @@
+packages/lodestar-cli/bin/lodestar


### PR DESCRIPTION
I've found that `yarn` does a really bad job at handling child script signals. On CTRL+C it only forwards the first SIGINT and ignores the rest, breaking our graceful shutdown pattern. `npm` does propagate signals correctly but I would recommend users to run lodestar directly with node to prevent further issues.

Also Windows, MacOS, Linux handle CTRL+C differently so the simpler the better

#### Test

Try running
```
node --trace-deprecation ./packages/lodestar-cli/bin/lodestar beacon --testnet spadina
```
vs
```
yarn run cli beacon --testnet spadina
```
And look for this log https://github.com/ChainSafe/lodestar/blob/d9fcdad8a5ea6e43515bdd6e4ed1c4012eb7332b/packages/lodestar-cli/src/util/process.ts#L19 after hitting CTRL+C twice fast 

#### Solution

I propose to run the CLI bin file directly. In this PR I've added a softlink to it, but I'm open to better suggestions if any.
