### PR TITLE
Force exit after graceful shutdown cleanup

### DIFF
--- a/packages/lodestar-cli/src/util/process.ts
+++ b/packages/lodestar-cli/src/util/process.ts
@@ -22,6 +22,7 @@ export function onProcessSIGINT(
 
       await cleanUpFunction();
       logFn("Cleanup completed");
+      process.exit(0);
     });
   }
 }


### PR DESCRIPTION
In an ideal scenario, our clean up function is able to close all handlers and no further action is necessary. While this is not the case this last process.exit() is the difference between having zombie processes really hard to kill for the average user and a clean UX.

resolves #1507 