### PR TITLE
Update docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,32 @@
-supporting-docs
-.github
-assets
-.idea
-.tmp
-.git
-Dockerfile
-*.log
-**/*.log
 node_modules
+Dockerfile
+.git
+
+# Docs
+assets
+supporting-docs
+docs
+typedocs
+mkdocs.yml
+LICENSE
+README.md
+
+# Github & configs
+.github
+.codeclimate.yml
+.codecov.yml
+
+# Tests
+packages/**/test
+.__testdb
+
+# Lodestar artifacts
+**/*-db
+.lodestar
+.medalla
+.spadina
+
+# Other / artifacts
 **/.nyc_output
 **/coverage
 **/node_modules
@@ -15,4 +34,7 @@ node_modules
 **/lib
 **/.tmp
 **/dist
-**/*-db
+*.log
+**/*.log
+.idea
+.tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
-FROM node:12.13-alpine
-
+FROM node:12.13-alpine as build
+WORKDIR /usr/app
 RUN apk update && apk add --no-cache git g++ make python && rm -rf /var/cache/apk/*
 
-WORKDIR /usr/app
+# Installs all deps in the root yarn.lock, which are most of them. To cache before copying the src
+COPY package.json yarn.lock ./
+RUN yarn install --non-interactive --ignore-optional --frozen-lockfile --ignore-scripts
 
-# Install node dependencies - done in a separate step so Docker can cache it.
 COPY . .
+RUN yarn install --non-interactive --ignore-optional --frozen-lockfile
 
-RUN yarn install --force --network-timeout 1000000 --non-interactive --ignore-optional --frozen-lockfile && yarn cache clean
 
-WORKDIR /usr/app/packages/lodestar-cli/bin
+# Copy built src + node_modules to a new layer to prune unnecessary fs
+# Previous layer weights 7.25GB, while this final 488MB (as of Oct 2020)
+FROM node:12.13-alpine
+WORKDIR /usr/app
+COPY --from=build /usr/app .
 
-ENTRYPOINT ["node", "lodestar"]
+ENTRYPOINT ["node", "./packages/lodestar-cli/bin/lodestar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,22 @@
-version: '2'
+version: "2"
 services:
-    prometheus:
-        image: prom/prometheus:v2.9.2
-        depends_on:
-            - lodestar
-        volumes:
-            - ./prometheus.yml:/etc/prometheus/prometheus.yml
-        ports:
-            - '9090:9090'
-    lodestar:
-        build:
-            context: .
-            dockerfile: docker/Dockerfile
-        volumes:
-            - ./:/root/lodestar
-            - node_modules:/root/lodestar/node_modules
+  lodestar:
+    build: .
+    volumes:
+      - lodestar:/usr/app/.spadina
+    command: beacon --testnet spadina
+    ports:
+      - "8008:8008"
+
+  prometheus:
+    image: prom/prometheus:latest
+    depends_on:
+      - lodestar
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+
 volumes:
-  node_modules:
+  lodestar:
+  prometheus:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.4"
 services:
   lodestar:
     build: .

--- a/scripts/prom-start.sh
+++ b/scripts/prom-start.sh
@@ -1,1 +1,0 @@
-./scripts/prometheus --config.file="./prometheus.yml"


### PR DESCRIPTION
- Update Dockerfile with minimal build time and size optimization. Copies root yarn.lock to install most of the dependencies upfront. Uses two layers to bring the final image size down to 488MB.
- Update docker-compose
- Remove prometheus binary. Users should either download it following https://chainsafe.github.io/lodestar/usage/prometheus-grafana/ or use the docker-compose setup. Fixes https://github.com/ChainSafe/lodestar/issues/1554