### PR TITLE
lodestar-cli: --testnet zinken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ medalla.json
 .altona
 .medalla
 .spadina
+.zinken
 packages/lodestar/.tmpdb/
 
 # Wallet CLI artifacts

--- a/packages/lodestar-cli/src/options/globalOptions.ts
+++ b/packages/lodestar-cli/src/options/globalOptions.ts
@@ -20,7 +20,7 @@ export const globalOptions = {
   testnet: {
     description: "Use a testnet configuration",
     type: "string",
-    choices: ["altona", "medalla", "spadina"] as TestnetName[],
+    choices: ["altona", "medalla", "spadina", "zinken"] as TestnetName[],
   } as Options,
 
   preset: {

--- a/packages/lodestar-cli/src/testnets/index.ts
+++ b/packages/lodestar-cli/src/testnets/index.ts
@@ -7,8 +7,9 @@ import {IBeaconNodeOptionsPartial} from "../options";
 import {altonaConfig} from "./altona";
 import {medallaConfig} from "./medalla";
 import {spadinaConfig} from "./spadina";
+import {zinkenConfig} from "./zinken";
 
-export type TestnetName = "altona" | "medalla" | "spadina";
+export type TestnetName = "altona" | "medalla" | "spadina" | "zinken";
 
 export function getTestnetConfig(testnet: TestnetName): IBeaconNodeOptionsPartial {
   switch (testnet) {
@@ -18,6 +19,8 @@ export function getTestnetConfig(testnet: TestnetName): IBeaconNodeOptionsPartia
       return medallaConfig;
     case "spadina":
       return spadinaConfig;
+    case "zinken":
+      return zinkenConfig;
     default:
       throw Error(`Testnet not supported: ${testnet}`);
   }
@@ -31,6 +34,8 @@ export function getTestnetParamsUrl(testnet: TestnetName): string | null {
       return "https://raw.githubusercontent.com/eth2-clients/eth2-testnets/master/shared/medalla/config.yaml";
     case "spadina":
       return "https://raw.githubusercontent.com/eth2-clients/eth2-testnets/master/shared/spadina/config.yaml";
+    case "zinken":
+      return "https://raw.githubusercontent.com/eth2-clients/eth2-testnets/master/shared/zinken/config.yaml";
     default:
       throw Error(`Testnet not supported: ${testnet}`);
   }
@@ -48,6 +53,8 @@ export function getGenesisFileUrl(testnet: TestnetName): string | null {
       return "https://github.com/eth2-clients/eth2-testnets/blob/master/shared/medalla/genesis.ssz?raw=true";
     case "spadina":
       return null; // TODO: add genesis.ssz file here
+    case "zinken":
+      return null; // TODO: add genesis.ssz file here
     default:
       throw Error(`Testnet not supported: ${testnet}`);
   }
@@ -61,6 +68,8 @@ function getBootnodesFileUrl(testnet: TestnetName): string {
       return "https://github.com/goerli/medalla/raw/master/medalla/bootnodes.txt";
     case "spadina":
       return "https://github.com/goerli/medalla/raw/master/spadina/bootnodes.txt";
+    case "zinken":
+      return "https://github.com/goerli/medalla/raw/master/zinken/bootnodes.txt";
     default:
       throw Error(`Testnet not supported: ${testnet}`);
   }

--- a/packages/lodestar-cli/src/testnets/zinken.ts
+++ b/packages/lodestar-cli/src/testnets/zinken.ts
@@ -59,7 +59,8 @@ export const zinkenConfig: IBeaconNodeOptionsPartial = {
       enabled: true,
       bindAddr: "/ip4/0.0.0.0/udp/9000",
       bootEnrs: [
-        // TODO: add these when they become available
+        "enr:-KG4QHPtVnKHEOkEJT1f5C6Hs-C_c4SlipTfkPrDIikLTzhqA_3m6bTq-CirsljlVP4IJybXelHE7J3l9DojR14_ZHUGhGV0aDKQ2jUIggAAAAP__________4JpZIJ2NIJpcIQSv2qciXNlY3AyNTZrMaECi_CNPDkKPilhimY7aEY-mBtSzI8AKMDvvv_I2Un74_qDdGNwgiMog3VkcIIjKA",
+        "enr:-Ku4QH63huZ12miIY0kLI9dunG5fwKpnn-zR3XyA_kH6rQpRD1VoyLyzIcFysCJ09JDprdX-EzXp-Nc8swYqBznkXggBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpDaNQiCAAAAA___________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQILqxBY-_SF8o_5FjFD3yM92s50zT_ciFi8hStde5AEjIN1ZHCCH0A",
       ],
     },
     maxPeers: 25,

--- a/packages/lodestar-cli/src/testnets/zinken.ts
+++ b/packages/lodestar-cli/src/testnets/zinken.ts
@@ -1,0 +1,69 @@
+import {IBeaconNodeOptionsPartial} from "../options";
+import {LogLevel} from "@chainsafe/lodestar-utils";
+
+/* eslint-disable max-len */
+
+// Use a Typescript file instead of JSON so it's automatically included in the built files
+
+export const zinkenConfig: IBeaconNodeOptionsPartial = {
+  params: {
+    DEPOSIT_CHAIN_ID: 5,
+    DEPOSIT_NETWORK_ID: 5,
+  },
+  api: {
+    rest: {
+      enabled: true,
+    },
+  },
+  eth1: {
+    providerUrl: "https://goerli.prylabs.net",
+    depositContractDeployBlock: 3488417,
+  },
+  logger: {
+    chain: {
+      level: LogLevel.info,
+    },
+    db: {
+      level: LogLevel.info,
+    },
+    eth1: {
+      level: LogLevel.info,
+    },
+    node: {
+      level: LogLevel.info,
+    },
+    network: {
+      level: LogLevel.info,
+    },
+    sync: {
+      level: LogLevel.info,
+    },
+    api: {
+      level: LogLevel.info,
+    },
+    metrics: {
+      level: LogLevel.info,
+    },
+    chores: {
+      level: LogLevel.info,
+    },
+  },
+  metrics: {
+    enabled: true,
+    serverPort: 8008,
+  },
+  network: {
+    discv5: {
+      // TODO: Add `network.discv5.enabled` to the `IDiscv5DiscoveryInputOptions` type
+      // @ts-ignore
+      enabled: true,
+      bindAddr: "/ip4/0.0.0.0/udp/9000",
+      bootEnrs: [
+        // TODO: add these when they become available
+      ],
+    },
+    maxPeers: 25,
+    bootMultiaddrs: [],
+    localMultiaddrs: ["/ip4/0.0.0.0/tcp/9000"],
+  },
+};


### PR DESCRIPTION
- adds the zinken testnet to the `--testnet` cli option for lodestar-cli

- currently (as of 10/6/2020), many of the required data to operate on the zinken testnet is either a placeholder file (e.g. bootnodes.txt is just an empty file right now) or has config info from a previous testnet.  we should probably check to make sure this all works with the required data before merging, so i've marked this PR as "DO NOT MERGE"