### PR TITLE
Store AggregateAndProof by Attestation Root

### DIFF
--- a/packages/lodestar/src/db/api/beacon/repositories/attestation.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/attestation.ts
@@ -1,11 +1,10 @@
-import {Attestation, BeaconState, CommitteeIndex, Epoch} from "@chainsafe/lodestar-types";
+import {Attestation, CommitteeIndex, Epoch} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 
 import {IDatabaseController} from "../../../controller";
 import {Bucket} from "../../schema";
 import {Repository} from "./abstract";
-import {TreeBacked} from "@chainsafe/ssz";
 
 /**
  * Attestation indexed by root
@@ -35,8 +34,8 @@ export class AttestationRepository extends Repository<Uint8Array, Attestation> {
     return attestations.filter((attestation) => attestation.data.target.epoch === epoch);
   }
 
-  public async removeOld(state: TreeBacked<BeaconState>): Promise<void> {
-    const finalizedEpochStartSlot = computeStartSlotAtEpoch(this.config, state.finalizedCheckpoint.epoch);
+  public async pruneFinalized(finalizedEpoch: Epoch): Promise<void> {
+    const finalizedEpochStartSlot = computeStartSlotAtEpoch(this.config, finalizedEpoch);
     const attestations: Attestation[] = await this.values();
     await this.batchRemove(
       attestations.filter((a) => {

--- a/packages/lodestar/src/tasks/index.ts
+++ b/packages/lodestar/src/tasks/index.ts
@@ -81,7 +81,11 @@ export class TasksService implements IService {
       finalized
     ).run();
     await new ArchiveStatesTask(this.config, {db: this.db, logger: this.logger}, finalized).run();
-    await this.db.checkpointStateCache.pruneFinalized(finalized.epoch);
+    await Promise.all([
+      this.db.checkpointStateCache.pruneFinalized(finalized.epoch),
+      this.db.attestation.pruneFinalized(finalized.epoch),
+      this.db.aggregateAndProof.pruneFinalized(finalized.epoch),
+    ]);
     // tasks rely on extended fork choice
     this.chain.forkChoice.prune();
   };


### PR DESCRIPTION
resolves #1637 
Improve `removeIncluded()` repository api by:
+ store AggregateAndProof by Atttestation Root
+ removeIncluded() now uses `batchDelete()` which is just i/o operation, we delegate the task to LevelDB
+ Remove old items per finalized epochs