### PR TITLE
Fix error response message printing

### DIFF
--- a/packages/lodestar/test/e2e/sync/reqResp.test.ts
+++ b/packages/lodestar/test/e2e/sync/reqResp.test.ts
@@ -211,9 +211,8 @@ describe("[sync] rpc", function () {
         } else {
           // i should be 1
           const errBuf = val.slice();
-          const err = config.types.P2pErrorMessage.deserialize(errBuf);
           // message from the server side
-          expect(decodeP2pErrorMessage(config, err)).to.be.equal("Invalid Request");
+          expect(decodeP2pErrorMessage(config, errBuf)).to.be.equal("Invalid Request");
         }
         i++;
       }


### PR DESCRIPTION
- removed non ascii and non printable characters
- fixed bug where we allowed encoding messages longer than 256 bytes
- added unit tests

resolves #1318 