### PR TITLE
Faster block archival

### DIFF
--- a/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
@@ -61,11 +61,11 @@ export class ArchiveBlocksTask implements ITask {
         })
       )
     ).filter((kv) => kv.value);
-    await this.db.blockArchive.batchPut(canonicalBlockEntries);
-    // delete all canonical and non-canonical blocks at once
-    await this.db.block.batchDelete(
-      canonicalSummaries.concat(nonCanonicalSummaries).map((summary) => summary.blockRoot)
-    );
+    await Promise.all([
+      this.db.blockArchive.batchPut(canonicalBlockEntries),
+      // delete all canonical and non-canonical blocks at once
+      this.db.block.batchDelete(canonicalSummaries.concat(nonCanonicalSummaries).map((summary) => summary.blockRoot)),
+    ]);
     this.logger.profile("Archive Blocks");
     this.logger.info("Archiving of finalized blocks complete.", {
       totalArchived: canonicalSummaries.length,

--- a/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
+++ b/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
@@ -3,11 +3,11 @@ import sinon, {SinonStubbedInstance} from "sinon";
 import pipe from "it-pipe";
 
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
-import {computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {computeStartSlotAtEpoch, ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
 
 import {ForkChoice} from "../../../../src/chain";
 import {ArchiveBlocksTask} from "../../../../src/tasks/tasks/archiveBlocks";
-import {generateEmptySignedBlock} from "../../../utils/block";
+import {generateBlockSummary, generateEmptySignedBlock} from "../../../utils/block";
 import {StubbedBeaconDb} from "../../../utils/stub";
 import {silentLogger} from "../../../utils/logger";
 
@@ -29,46 +29,16 @@ describe("block archiver task", function () {
    *       C
    */
   it("should archive finalized blocks on same chain", async function () {
-    const blockA = generateEmptySignedBlock();
-    const blockB = generateEmptySignedBlock();
-    blockB.message.slot = 1;
-    blockB.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(blockA.message);
-    // blockC is not archieved because not on the same chain
-    const blockC = generateEmptySignedBlock();
-    blockC.message.slot = 2;
-    blockC.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(blockB.message);
-    const blockD = generateEmptySignedBlock();
-    blockD.message.slot = 3;
-    blockD.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(blockB.message);
-    const finalizedBlock = generateEmptySignedBlock();
-    finalizedBlock.message.slot = computeStartSlotAtEpoch(config, 3);
-    finalizedBlock.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(blockD.message);
-    // blockE is not archieved due to its epoch
-    const blockE = generateEmptySignedBlock();
-    blockE.message.slot = finalizedBlock.message.slot + 1;
-    const finalizedCheckpoint = {
-      epoch: 3,
-      root: config.types.BeaconBlock.hashTreeRoot(finalizedBlock.message),
-    };
-    const blocks = [
-      {key: config.types.BeaconBlock.hashTreeRoot(blockA.message), value: blockA},
-      {key: config.types.BeaconBlock.hashTreeRoot(blockB.message), value: blockB},
-      {key: config.types.BeaconBlock.hashTreeRoot(blockC.message), value: blockC},
-      {key: config.types.BeaconBlock.hashTreeRoot(blockD.message), value: blockD},
-      {key: config.types.BeaconBlock.hashTreeRoot(finalizedBlock.message), value: finalizedBlock},
-      {key: config.types.BeaconBlock.hashTreeRoot(blockE.message), value: blockE},
+    dbStub.block.get.resolves(generateEmptySignedBlock());
+    const canonicalBlocks = [
+      generateBlockSummary({slot: 5}),
+      generateBlockSummary({slot: 4}),
+      generateBlockSummary({slot: 2}),
+      generateBlockSummary({slot: 1}),
     ];
-    dbStub.block.entriesStream.resolves(pipe(blocks));
-    forkChoiceStub.isDescendant.withArgs(blocks[0].key, finalizedCheckpoint.root).returns(true);
-    forkChoiceStub.isDescendant.withArgs(blocks[1].key, finalizedCheckpoint.root).returns(true);
-    forkChoiceStub.isDescendant.withArgs(blocks[2].key, finalizedCheckpoint.root).returns(false); // not a descendant
-    forkChoiceStub.isDescendant.withArgs(blocks[3].key, finalizedCheckpoint.root).returns(true);
-    forkChoiceStub.isDescendant.withArgs(blocks[4].key, finalizedCheckpoint.root).returns(true);
-    const blockArchiveSpy = sinon.spy();
-    dbStub.blockArchive.add.callsFake(blockArchiveSpy);
-    const blockSpy = sinon.spy();
-    dbStub.block.batchDelete.callsFake(blockSpy);
-
+    forkChoiceStub.iterateBlockSummaries.returns(canonicalBlocks);
+    forkChoiceStub.forwardIterateBlockSummaries.returns([generateBlockSummary({slot: 3})]);
+    forkChoiceStub.isDescendant.returns(false);
     const archiverTask = new ArchiveBlocksTask(
       config,
       {
@@ -76,21 +46,15 @@ describe("block archiver task", function () {
         forkChoice: forkChoiceStub,
         logger,
       },
-      finalizedCheckpoint
+      {
+        epoch: 5,
+        root: ZERO_HASH,
+      }
     );
     await archiverTask.run();
-
-    expect(dbStub.blockArchive.add.calledWith(finalizedBlock)).to.be.true;
-    expect(dbStub.blockArchive.add.calledWith(blockD)).to.be.true;
-    expect(dbStub.blockArchive.add.calledWith(blockB)).to.be.true;
-    expect(dbStub.blockArchive.add.calledWith(blockA)).to.be.true;
-    expect(dbStub.block.batchDelete.calledOnce).to.be.true;
-    expect(blockSpy.args[0][0]).to.be.deep.equal([
-      config.types.BeaconBlock.hashTreeRoot(blockA.message),
-      config.types.BeaconBlock.hashTreeRoot(blockB.message),
-      config.types.BeaconBlock.hashTreeRoot(blockC.message),
-      config.types.BeaconBlock.hashTreeRoot(blockD.message),
-      config.types.BeaconBlock.hashTreeRoot(finalizedBlock.message),
-    ]);
+    expect(
+      dbStub.blockArchive.batchPut.calledWith(canonicalBlocks.map((b) => ({key: b.slot, value: generateEmptySignedBlock()})))
+    ).to.be.true;
+    expect(dbStub.block.batchDelete.calledWith([ZERO_HASH, ZERO_HASH, ZERO_HASH, ZERO_HASH, ZERO_HASH])).to.be.true;
   });
 });


### PR DESCRIPTION
Slow block archival causes many problems.

This new strategy uses fork choice to pre-select the blocks to archive / delete, instead of looping thru the entire `db.block` repository.