### PR TITLE
Add attestation logic for slashing protection

### DIFF
--- a/packages/lodestar-db/src/schema.ts
+++ b/packages/lodestar-db/src/schema.ts
@@ -35,6 +35,8 @@ export enum Bucket {
   validator = 16,
   lastProposedBlock = 17,
   proposedAttestations = 18,
+  // validator slashing protection
+  slashingProtectionAttestation = 21,
 }
 
 export enum Key {

--- a/packages/lodestar-types/src/ssz/generators/validator.ts
+++ b/packages/lodestar-types/src/ssz/generators/validator.ts
@@ -29,3 +29,12 @@ export const SignedAggregateAndProof = (ssz: IBeaconSSZTypes): ContainerType =>
       signature: ssz.BLSSignature,
     },
   });
+
+export const SlashingProtectionAttestation = (ssz: IBeaconSSZTypes): ContainerType =>
+  new ContainerType({
+    fields: {
+      sourceEpoch: ssz.Epoch,
+      targetEpoch: ssz.Epoch,
+      signingRoot: ssz.Root,
+    },
+  });

--- a/packages/lodestar-types/src/ssz/interface.ts
+++ b/packages/lodestar-types/src/ssz/interface.ts
@@ -85,6 +85,8 @@ export interface IBeaconSSZTypes {
   SyncingStatus: ContainerType<t.SyncingStatus>;
   AttesterDuty: ContainerType<t.AttesterDuty>;
   ProposerDuty: ContainerType<t.ProposerDuty>;
+  // Validator slashing protection
+  SlashingProtectionAttestation: ContainerType<t.SlashingProtectionAttestation>;
   // wire
   Status: ContainerType<t.Status>;
   Goodbye: BigIntUintType;
@@ -168,6 +170,8 @@ export const typeNames: (keyof IBeaconSSZTypes)[] = [
   "AggregateAndProof",
   "SignedAggregateAndProof",
   "CommitteeAssignment",
+  // Validator slashing protection
+  "SlashingProtectionAttestation",
   // wire
   "Status",
   "Goodbye",

--- a/packages/lodestar-types/src/types/validator.ts
+++ b/packages/lodestar-types/src/types/validator.ts
@@ -4,7 +4,7 @@
  */
 
 import {List} from "@chainsafe/ssz";
-import {BLSSignature, CommitteeIndex, Slot, ValidatorIndex} from "./primitive";
+import {BLSSignature, CommitteeIndex, Epoch, Root, Slot, ValidatorIndex} from "./primitive";
 import {Attestation} from "./operations";
 
 export interface CommitteeAssignment {
@@ -22,4 +22,10 @@ export interface AggregateAndProof {
 export interface SignedAggregateAndProof {
   message: AggregateAndProof;
   signature: BLSSignature;
+}
+
+export interface SlashingProtectionAttestation {
+  sourceEpoch: Epoch;
+  targetEpoch: Epoch;
+  signingRoot: Root;
 }

--- a/packages/lodestar-validator/src/slashingProtection/attestation/checkAndInsertAttestation.ts
+++ b/packages/lodestar-validator/src/slashingProtection/attestation/checkAndInsertAttestation.ts
@@ -24,9 +24,8 @@ export async function checkAndInsertAttestation(
   // Merging those ranges
   //   0 <= s2 < t1 - 1
   //   s1 + 1 <= t2
-  const potentialAttestationConflicts = await signedAttestationDb.getByPubkeyAndTargetEpoch(pubKey, {
-    gte: att.sourceEpoch + 1,
-  });
+  // EDIT: fetch the entire range or tests do not pass
+  const potentialAttestationConflicts = await signedAttestationDb.getByPubkeyAndTargetEpoch(pubKey, {});
 
   // Although it's not required to avoid slashing, we disallow attestations
   // which are obviously invalid by virtue of their source epoch exceeding their target.

--- a/packages/lodestar-validator/src/slashingProtection/attestation/checkAndInsertAttestation.ts
+++ b/packages/lodestar-validator/src/slashingProtection/attestation/checkAndInsertAttestation.ts
@@ -1,0 +1,83 @@
+import {BLSPubkey, SlashingProtectionAttestation} from "@chainsafe/lodestar-types";
+import {isEqualRoot, isZeroRoot, minEpoch} from "../utils";
+import {InvalidAttestationError, InvalidAttestationErrorCode} from "./errors";
+import {SlashingProtectionAttestationRepository} from "./dbRepository";
+
+/**
+ * Check an attestation for slash safety, and if it is safe, record it in the database
+ */
+export async function checkAndInsertAttestation(
+  pubKey: BLSPubkey,
+  att: SlashingProtectionAttestation,
+  signedAttestationDb: SlashingProtectionAttestationRepository
+): Promise<void> {
+  // Potential slashing attestation range (with s2 < t2, s1 < t1)
+  // - Double vote
+  //   t1 = t2
+  // - new [s2,t2] surrounds prev [s1,t1]
+  //   0 <= s2 < s1
+  //   t1 < t2
+  // - prev [s1,t1] surrounds new [s2,t2]
+  //   s1 < s2 < t1 - 1
+  //   s1 + 1 < t2 < t1
+  //
+  // Merging those ranges
+  //   0 <= s2 < t1 - 1
+  //   s1 + 1 <= t2
+  const potentialAttestationConflicts = await signedAttestationDb.getByPubkeyAndTargetEpoch(pubKey, {
+    gte: att.sourceEpoch + 1,
+  });
+
+  // Although it's not required to avoid slashing, we disallow attestations
+  // which are obviously invalid by virtue of their source epoch exceeding their target.
+  if (att.sourceEpoch > att.targetEpoch) {
+    throw new InvalidAttestationError({code: InvalidAttestationErrorCode.SOURCE_EXCEEDS_TARGET});
+  }
+
+  for (const prev of potentialAttestationConflicts) {
+    // Double vote
+    if (att.targetEpoch === prev.targetEpoch) {
+      // Interchange format allows for attestations without signing_root, then assume root is equal
+      if (!isZeroRoot(prev.signingRoot) && isEqualRoot(att.signingRoot, prev.signingRoot)) {
+        return; // Ok, same data
+      } else {
+        throw new InvalidAttestationError({code: InvalidAttestationErrorCode.DOUBLE_VOTE, att, prev});
+      }
+    }
+
+    // Surround vote
+    if (prev.sourceEpoch < att.sourceEpoch && prev.targetEpoch > att.targetEpoch) {
+      throw new InvalidAttestationError({code: InvalidAttestationErrorCode.PREV_SURROUNDS_NEW, att, prev});
+    }
+    if (prev.sourceEpoch > att.sourceEpoch && prev.targetEpoch < att.targetEpoch) {
+      throw new InvalidAttestationError({code: InvalidAttestationErrorCode.NEW_SURROUNDS_PREV, att, prev});
+    }
+  }
+
+  // Refuse to sign any attestation with:
+  // - source.epoch < min(att.source_epoch for att in data.signed_attestations if att.pubkey == attester_pubkey), OR
+  // - target_epoch <= min(att.target_epoch for att in data.signed_attestations if att.pubkey == attester_pubkey)
+  // (spec v4, Slashing Protection Database Interchange Format)
+  const minSourceEpoch = minEpoch(potentialAttestationConflicts.map((att) => att.sourceEpoch));
+  if (minSourceEpoch && att.sourceEpoch < minSourceEpoch) {
+    throw new InvalidAttestationError({
+      code: InvalidAttestationErrorCode.SOURCE_LESS_THAN_LOWER_BOUND,
+      sourceEpoch: att.sourceEpoch,
+      minSourceEpoch,
+    });
+  }
+
+  const minTargetEpoch = minEpoch(potentialAttestationConflicts.map((att) => att.targetEpoch));
+  if (minTargetEpoch && att.targetEpoch <= minTargetEpoch) {
+    throw new InvalidAttestationError({
+      code: InvalidAttestationErrorCode.TARGET_LESS_THAN_OR_EQ_LOWER_BOUND,
+      targetEpoch: att.targetEpoch,
+      minTargetEpoch,
+    });
+  }
+
+  // Attestation is safe, add to DB
+  await signedAttestationDb.setByPubkey(pubKey, [att]);
+
+  // TODO: Implement safe clean-up of stored attestations
+}

--- a/packages/lodestar-validator/src/slashingProtection/attestation/dbRepository.ts
+++ b/packages/lodestar-validator/src/slashingProtection/attestation/dbRepository.ts
@@ -1,0 +1,53 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {BLSPubkey, Epoch, SlashingProtectionAttestation} from "@chainsafe/lodestar-types";
+import {intToBytes} from "@chainsafe/lodestar-utils";
+import {IDatabaseController, Bucket, encodeKey} from "@chainsafe/lodestar-db";
+import {Type} from "@chainsafe/ssz";
+
+interface ITargetEpochFilter {
+  gte?: number;
+  lt?: number;
+}
+
+export class SlashingProtectionAttestationRepository {
+  protected type: Type<SlashingProtectionAttestation>;
+  protected db: IDatabaseController<Buffer, Buffer>;
+  protected bucket = Bucket.slashingProtectionAttestation;
+
+  constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
+    this.db = db;
+    this.type = config.types.SlashingProtectionAttestation;
+  }
+
+  async getAllByPubkey(pubKey: BLSPubkey): Promise<SlashingProtectionAttestation[]> {
+    return this.getByPubkeyAndTargetEpoch(pubKey, {});
+  }
+
+  async getByPubkeyAndTargetEpoch(
+    pubKey: BLSPubkey,
+    options: ITargetEpochFilter
+  ): Promise<SlashingProtectionAttestation[]> {
+    const data = await this.db.values({
+      gte: this.encodeKey(pubKey, options.gte ?? 0),
+      lt: this.encodeKey(pubKey, options.lt ?? Number.MAX_SAFE_INTEGER),
+    });
+    return data.map((data) => this.type.deserialize(data));
+  }
+
+  async setByPubkey(pubKey: BLSPubkey, attestations: SlashingProtectionAttestation[]): Promise<void> {
+    await this.db.batchPut(
+      attestations.map((attestation) => ({
+        key: this.encodeKey(pubKey, attestation.targetEpoch),
+        value: Buffer.from(this.type.serialize(attestation)),
+      }))
+    );
+  }
+
+  private encodeKey(pubKey: BLSPubkey, targetEpoch: Epoch): Buffer {
+    return encodeKey(this.bucket, getAttestationKey(pubKey, targetEpoch));
+  }
+}
+
+function getAttestationKey(pubkey: BLSPubkey, targetEpoch: Epoch): Buffer {
+  return Buffer.concat([Buffer.from(pubkey), intToBytes(BigInt(targetEpoch), 8, "be")]);
+}

--- a/packages/lodestar-validator/src/slashingProtection/attestation/errors.ts
+++ b/packages/lodestar-validator/src/slashingProtection/attestation/errors.ts
@@ -1,0 +1,67 @@
+import {Epoch, SlashingProtectionAttestation} from "@chainsafe/lodestar-types";
+import {LodestarError} from "@chainsafe/lodestar-utils";
+
+export enum InvalidAttestationErrorCode {
+  /**
+   * The attestation has the same target epoch as an attestation from the DB
+   */
+  DOUBLE_VOTE = "ERR_INVALID_ATTESTATION_DOUBLE_VOTE",
+  /**
+   * The attestation surrounds an existing attestation from the database `prev`
+   */
+  NEW_SURROUNDS_PREV = "ERR_INVALID_ATTESTATION_NEW_SURROUNDS_PREV",
+  /**
+   * The attestation is surrounded by an existing attestation from the database `prev`
+   */
+  PREV_SURROUNDS_NEW = "ERR_INVALID_ATTESTATION_PREV_SURROUNDS_NEW",
+  /**
+   * The attestation is invalid because its source epoch is greater than its target epoch
+   */
+  SOURCE_EXCEEDS_TARGET = "ERR_INVALID_ATTESTATION_SOURCE_EXCEEDS_TARGET",
+  /**
+   * The attestation is invalid because its source epoch is less than the lower bound on source
+   * epochs for this validator.
+   */
+  SOURCE_LESS_THAN_LOWER_BOUND = "ERR_INVALID_ATTESTATION_SOURCE_LESS_THAN_LOWER_BOUND",
+  /**
+   * The attestation is invalid because its target epoch is less than or equal to the lower
+   * bound on target epochs for this validator.
+   */
+  TARGET_LESS_THAN_OR_EQ_LOWER_BOUND = "ERR_INVALID_ATTESTATION_TARGET_LESS_THAN_OR_EQ_LOWER_BOUND",
+}
+
+export type InvalidAttestationErrorType =
+  | {
+      code: InvalidAttestationErrorCode.DOUBLE_VOTE;
+      att: SlashingProtectionAttestation;
+      prev: SlashingProtectionAttestation;
+    }
+  | {
+      code: InvalidAttestationErrorCode.NEW_SURROUNDS_PREV;
+      att: SlashingProtectionAttestation;
+      prev: SlashingProtectionAttestation;
+    }
+  | {
+      code: InvalidAttestationErrorCode.PREV_SURROUNDS_NEW;
+      att: SlashingProtectionAttestation;
+      prev: SlashingProtectionAttestation;
+    }
+  | {
+      code: InvalidAttestationErrorCode.SOURCE_EXCEEDS_TARGET;
+    }
+  | {
+      code: InvalidAttestationErrorCode.SOURCE_LESS_THAN_LOWER_BOUND;
+      sourceEpoch: Epoch;
+      minSourceEpoch: Epoch;
+    }
+  | {
+      code: InvalidAttestationErrorCode.TARGET_LESS_THAN_OR_EQ_LOWER_BOUND;
+      targetEpoch: Epoch;
+      minTargetEpoch: Epoch;
+    };
+
+export class InvalidAttestationError extends LodestarError<InvalidAttestationErrorType> {
+  constructor(type: InvalidAttestationErrorType) {
+    super(type);
+  }
+}

--- a/packages/lodestar-validator/src/slashingProtection/attestation/index.ts
+++ b/packages/lodestar-validator/src/slashingProtection/attestation/index.ts
@@ -1,0 +1,2 @@
+export * from "./checkAndInsertAttestation";
+export * from "./dbRepository";

--- a/packages/lodestar-validator/src/slashingProtection/utils.ts
+++ b/packages/lodestar-validator/src/slashingProtection/utils.ts
@@ -1,0 +1,15 @@
+import {Epoch, Root} from "@chainsafe/lodestar-types";
+import {toHexString} from "@chainsafe/ssz";
+import {ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
+
+export function isEqualRoot(root1: Root, root2: Root): boolean {
+  return toHexString(root1) === toHexString(root2);
+}
+
+export function isZeroRoot(root: Root): boolean {
+  return isEqualRoot(root, ZERO_HASH);
+}
+
+export function minEpoch(epochs: Epoch[]): Epoch | null {
+  return epochs.length > 0 ? Math.min(...epochs) : null;
+}


### PR DESCRIPTION
Adds attestation logic for a refactored slashing protection module compatible with the "Slashing Protection Database Interchange Format"

This PR is part of https://github.com/ChainSafe/lodestar/compare/dapplion/slashing-protection/root, see that branch for a reference full implementation