### PR TITLE
Add block proposal logic for slashing protection

### DIFF
--- a/packages/lodestar-db/src/schema.ts
+++ b/packages/lodestar-db/src/schema.ts
@@ -35,6 +35,8 @@ export enum Bucket {
   validator = 16,
   lastProposedBlock = 17,
   proposedAttestations = 18,
+  // validator slashing protection
+  slashingProtectionBlock = 20,
 }
 
 export enum Key {

--- a/packages/lodestar-types/src/ssz/generators/validator.ts
+++ b/packages/lodestar-types/src/ssz/generators/validator.ts
@@ -29,3 +29,11 @@ export const SignedAggregateAndProof = (ssz: IBeaconSSZTypes): ContainerType =>
       signature: ssz.BLSSignature,
     },
   });
+
+export const SlashingProtectionBlock = (ssz: IBeaconSSZTypes): ContainerType =>
+  new ContainerType({
+    fields: {
+      slot: ssz.Slot,
+      signingRoot: ssz.Root,
+    },
+  });

--- a/packages/lodestar-types/src/ssz/interface.ts
+++ b/packages/lodestar-types/src/ssz/interface.ts
@@ -85,6 +85,8 @@ export interface IBeaconSSZTypes {
   SyncingStatus: ContainerType<t.SyncingStatus>;
   AttesterDuty: ContainerType<t.AttesterDuty>;
   ProposerDuty: ContainerType<t.ProposerDuty>;
+  // Validator slashing protection
+  SlashingProtectionBlock: ContainerType<t.SlashingProtectionBlock>;
   // wire
   Status: ContainerType<t.Status>;
   Goodbye: BigIntUintType;
@@ -168,6 +170,8 @@ export const typeNames: (keyof IBeaconSSZTypes)[] = [
   "AggregateAndProof",
   "SignedAggregateAndProof",
   "CommitteeAssignment",
+  // Validator slashing protection
+  "SlashingProtectionBlock",
   // wire
   "Status",
   "Goodbye",

--- a/packages/lodestar-types/src/types/validator.ts
+++ b/packages/lodestar-types/src/types/validator.ts
@@ -4,7 +4,7 @@
  */
 
 import {List} from "@chainsafe/ssz";
-import {BLSSignature, CommitteeIndex, Slot, ValidatorIndex} from "./primitive";
+import {BLSSignature, CommitteeIndex, Root, Slot, ValidatorIndex} from "./primitive";
 import {Attestation} from "./operations";
 
 export interface CommitteeAssignment {
@@ -22,4 +22,9 @@ export interface AggregateAndProof {
 export interface SignedAggregateAndProof {
   message: AggregateAndProof;
   signature: BLSSignature;
+}
+
+export interface SlashingProtectionBlock {
+  slot: Slot;
+  signingRoot: Root;
 }

--- a/packages/lodestar-validator/src/slashingProtection/block/checkAndInsertBlockProposal.ts
+++ b/packages/lodestar-validator/src/slashingProtection/block/checkAndInsertBlockProposal.ts
@@ -1,0 +1,45 @@
+import {BLSPubkey, SlashingProtectionBlock} from "@chainsafe/lodestar-types";
+import {SlashingProtectionBlockRepository} from "./dbRepository";
+import {isEqualRoot, isZeroRoot} from "../utils";
+import {InvalidBlockError, InvalidBlockErrorCode} from "./errors";
+
+/**
+ * Check a block proposal for slash safety, and if it is safe, record it in the database
+ */
+export async function checkAndInsertBlockProposal(
+  pubkey: BLSPubkey,
+  block: SlashingProtectionBlock,
+  signedBlockDb: SlashingProtectionBlockRepository
+): Promise<void> {
+  // Double proposal
+  const sameSlotBlock = await signedBlockDb.getByPubkeyAndSlot(pubkey, block.slot);
+  if (sameSlotBlock && block.slot === sameSlotBlock.slot) {
+    // Interchange format allows for blocks without signing_root, then assume root is equal
+    if (!isZeroRoot(sameSlotBlock.signingRoot) && isEqualRoot(block.signingRoot, sameSlotBlock.signingRoot)) {
+      return; // Ok, same data
+    } else {
+      throw new InvalidBlockError({
+        code: InvalidBlockErrorCode.DOUBLE_BLOCK_PROPOSAL,
+        block,
+        block2: sameSlotBlock,
+      });
+    }
+  }
+
+  // Refuse to sign any block with slot <= min(b.slot for b in data.signed_blocks if b.pubkey == proposer_pubkey),
+  // except if it is a repeat signing as determined by the signing_root.
+  // (spec v4, Slashing Protection Database Interchange Format)
+  const minBlock = await signedBlockDb.getFirstByPubkey(pubkey);
+  if (minBlock && block.slot <= minBlock.slot) {
+    throw new InvalidBlockError({
+      code: InvalidBlockErrorCode.SLOT_LESS_THAN_LOWER_BOUND,
+      slot: block.slot,
+      minSlot: minBlock.slot,
+    });
+  }
+
+  // Attestation is safe, add to DB
+  await signedBlockDb.setByPubkey(pubkey, [block]);
+
+  // TODO: Implement safe clean-up of stored blocks
+}

--- a/packages/lodestar-validator/src/slashingProtection/block/dbRepository.ts
+++ b/packages/lodestar-validator/src/slashingProtection/block/dbRepository.ts
@@ -1,0 +1,52 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {BLSPubkey, SlashingProtectionBlock, Slot} from "@chainsafe/lodestar-types";
+import {intToBytes} from "@chainsafe/lodestar-utils";
+import {IDatabaseController, Bucket, encodeKey} from "@chainsafe/lodestar-db";
+import {Type} from "@chainsafe/ssz";
+
+export class SlashingProtectionBlockRepository {
+  protected type: Type<SlashingProtectionBlock>;
+  protected db: IDatabaseController<Buffer, Buffer>;
+  protected bucket = Bucket.slashingProtectionBlock;
+
+  constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
+    this.db = db;
+    this.type = config.types.SlashingProtectionBlock;
+  }
+
+  async getAllByPubkey(pubkey: BLSPubkey, limit?: number): Promise<SlashingProtectionBlock[]> {
+    const blocks = await this.db.values({
+      limit,
+      gte: this.encodeKey(pubkey, 0),
+      lt: this.encodeKey(pubkey, Number.MAX_SAFE_INTEGER),
+    });
+    return blocks.map((block) => this.type.deserialize(block));
+  }
+
+  async getFirstByPubkey(pubkey: BLSPubkey): Promise<SlashingProtectionBlock | null> {
+    const blocks = await this.getAllByPubkey(pubkey, 1);
+    return blocks[0] ?? null;
+  }
+
+  async getByPubkeyAndSlot(pubkey: BLSPubkey, slot: Slot): Promise<SlashingProtectionBlock | null> {
+    const block = await this.db.get(this.encodeKey(pubkey, slot));
+    return block && this.type.deserialize(block);
+  }
+
+  async setByPubkey(pubkey: BLSPubkey, blocks: SlashingProtectionBlock[]): Promise<void> {
+    await this.db.batchPut(
+      blocks.map((block) => ({
+        key: this.encodeKey(pubkey, block.slot),
+        value: Buffer.from(this.type.serialize(block)),
+      }))
+    );
+  }
+
+  private encodeKey(pubkey: BLSPubkey, slot: Slot): Buffer {
+    return encodeKey(this.bucket, getBlockKey(pubkey, slot));
+  }
+}
+
+function getBlockKey(pubkey: BLSPubkey, slot: Slot): Buffer {
+  return Buffer.concat([Buffer.from(pubkey), intToBytes(BigInt(slot), 8, "be")]);
+}

--- a/packages/lodestar-validator/src/slashingProtection/block/errors.ts
+++ b/packages/lodestar-validator/src/slashingProtection/block/errors.ts
@@ -1,0 +1,31 @@
+import {Slot, SlashingProtectionBlock} from "@chainsafe/lodestar-types";
+import {LodestarError} from "@chainsafe/lodestar-utils";
+
+export enum InvalidBlockErrorCode {
+  /**
+   * The block has the same slot as a block from the DB
+   */
+  DOUBLE_BLOCK_PROPOSAL = "ERR_INVALID_BLOCK_DOUBLE_BLOCK_PROPOSAL",
+  /**
+   * The block is invalid because its slot is less than the lower bound slot for this validator.
+   */
+  SLOT_LESS_THAN_LOWER_BOUND = "ERR_INVALID_BLOCK_SLOT_LESS_THAN_LOWER_BOUND",
+}
+
+export type InvalidBlockErrorType =
+  | {
+      code: InvalidBlockErrorCode.DOUBLE_BLOCK_PROPOSAL;
+      block: SlashingProtectionBlock;
+      block2: SlashingProtectionBlock;
+    }
+  | {
+      code: InvalidBlockErrorCode.SLOT_LESS_THAN_LOWER_BOUND;
+      slot: Slot;
+      minSlot: Slot;
+    };
+
+export class InvalidBlockError extends LodestarError<InvalidBlockErrorType> {
+  constructor(type: InvalidBlockErrorType) {
+    super(type);
+  }
+}

--- a/packages/lodestar-validator/src/slashingProtection/block/index.ts
+++ b/packages/lodestar-validator/src/slashingProtection/block/index.ts
@@ -1,0 +1,2 @@
+export * from "./checkAndInsertBlockProposal";
+export * from "./dbRepository";

--- a/packages/lodestar-validator/src/slashingProtection/utils.ts
+++ b/packages/lodestar-validator/src/slashingProtection/utils.ts
@@ -1,0 +1,15 @@
+import {Epoch, Root} from "@chainsafe/lodestar-types";
+import {toHexString} from "@chainsafe/ssz";
+import {ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
+
+export function isEqualRoot(root1: Root, root2: Root): boolean {
+  return toHexString(root1) === toHexString(root2);
+}
+
+export function isZeroRoot(root: Root): boolean {
+  return isEqualRoot(root, ZERO_HASH);
+}
+
+export function minEpoch(epochs: Epoch[]): Epoch | null {
+  return epochs.length > 0 ? Math.min(...epochs) : null;
+}


### PR DESCRIPTION
Adds block logic for a refactored slashing protection module compatible with the "Slashing Protection Database Interchange Format"

This PR is part of https://github.com/ChainSafe/lodestar/compare/dapplion/slashing-protection/root, see that branch for a reference full implementation