### PR TITLE
Add interchange format parser and serializer

### DIFF
--- a/packages/lodestar-validator/src/slashingProtection/interchange/errors.ts
+++ b/packages/lodestar-validator/src/slashingProtection/interchange/errors.ts
@@ -1,0 +1,19 @@
+import {Root} from "@chainsafe/lodestar-types";
+import {LodestarError} from "@chainsafe/lodestar-utils";
+
+export enum InterchangeErrorErrorCode {
+  UNSUPPORTED_FORMAT = "ERR_INTERCHANGE_UNSUPPORTED_FORMAT",
+  UNSUPPORTED_VERSION = "ERR_INTERCHANGE_UNSUPPORTED_VERSION",
+  GENESIS_VALIDATOR_MISMATCH = "ERR_INTERCHANGE_GENESIS_VALIDATOR_MISMATCH",
+}
+
+type InterchangeErrorErrorType =
+  | {code: InterchangeErrorErrorCode.UNSUPPORTED_FORMAT; format: string}
+  | {code: InterchangeErrorErrorCode.UNSUPPORTED_VERSION; version: string}
+  | {code: InterchangeErrorErrorCode.GENESIS_VALIDATOR_MISMATCH; root: Root; extectedRoot: Root};
+
+export class InterchangeError extends LodestarError<InterchangeErrorErrorType> {
+  constructor(type: InterchangeErrorErrorType) {
+    super(type);
+  }
+}

--- a/packages/lodestar-validator/src/slashingProtection/interchange/formats/completeV4.ts
+++ b/packages/lodestar-validator/src/slashingProtection/interchange/formats/completeV4.ts
@@ -1,0 +1,128 @@
+import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
+import {IInterchangeLodestar} from "../types";
+import {numToString} from "../../utils";
+
+/* eslint-disable @typescript-eslint/camelcase */
+
+/**
+ * A complete record of all blocks and attestations signed by a set of validators
+ * Spec from: https://hackmd.io/@sproul/Bk0Y0qdGD
+ */
+export interface IInterchangeCompleteV4 {
+  metadata: {
+    interchange_format: "complete";
+    interchange_format_version: "4";
+    /**
+     * ```
+     * "0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673"
+     * ```
+     */
+    genesis_validators_root: string;
+  };
+  data: {
+    /**
+     * pubkey: BLSPubkey is the BLS public key of the validator encoded as 0x-prefixed hex
+     * ```
+     * "0xb845089a1457f811bfc000588fbb4e713669be8ce060ea6be3c6ece09afc3794106c91ca73acda5e5457122d58723bed"
+     * ```
+     */
+    pubkey: string;
+    /**
+     * signed_blocks is a list of objects with fields
+     */
+    signed_blocks: {
+      /**
+       * slot: Slot, the slot of the block that was signed
+       * ```
+       * "81952"
+       * ```
+       */
+      slot: string;
+      /**
+       * signing_root: Root (optional) is compute_signing_root(block, domain), where:
+       * - block is the block that was signed as type BeaconBlock or equivalently BeaconBlockHeader
+       * - domain is equal to compute_domain(DOMAIN_BEACON_PROPOSER, fork, metadata.genesis_validators_root), where:
+       *   - metadata.genesis_validators_root is the genesis_validators_root from this interchange file
+       *   - fork: Version is the fork that the block was signed against
+       * ```
+       * "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850b"
+       * ```
+       */
+      signing_root?: string;
+    }[];
+    /**
+     * signed_attestations is a list of objects with fields
+     */
+    signed_attestations: {
+      /**
+       * source_epoch: Epoch, the attestation.data.source.epoch of the signed attestation
+       * ```
+       * "2290"
+       * ```
+       */
+      source_epoch: string;
+      /**
+       * target_epoch: Epoch, the attestation.data.target.epoch of the signed attestation
+       * ```
+       * "3007"
+       * ```
+       */
+      target_epoch: string;
+      /**
+       * signing_root: Root (optional) is compute_signing_root(attestation, domain), where:
+       * - attestation is the attestation that was signed as type AttestationData
+       * - domain is equal to compute_domain(DOMAIN_BEACON_ATTESTER, fork, metadata.genesis_validators_root), where:
+       *   - metadata.genesis_validators_root is the genesis_validators_root from this interchange file
+       *   - fork: Version is the fork that the attestation was signed against
+       * ```
+       * "0x587d6a4f59a58fe24f406e0502413e77fe1babddee641fda30034ed37ecc884d"
+       * ```
+       */
+      signing_root?: string;
+    }[];
+  }[];
+}
+
+export function serializeInterchangeCompleteV4({
+  data,
+  genesisValidatorsRoot,
+}: IInterchangeLodestar): IInterchangeCompleteV4 {
+  return {
+    metadata: {
+      interchange_format: "complete",
+      interchange_format_version: "4",
+      genesis_validators_root: toHexString(genesisValidatorsRoot),
+    },
+    data: data.map((validator) => ({
+      pubkey: toHexString(validator.pubkey),
+      signed_blocks: validator.signedBlocks.map((block) => ({
+        slot: numToString(block.slot),
+        signing_root: toHexString(block.signingRoot),
+      })),
+      signed_attestations: validator.signedAttestations.map((att) => ({
+        source_epoch: numToString(att.sourceEpoch),
+        target_epoch: numToString(att.targetEpoch),
+        signing_root: toHexString(att.signingRoot),
+      })),
+    })),
+  };
+}
+
+export function parseInterchangeCompleteV4(interchange: IInterchangeCompleteV4): IInterchangeLodestar {
+  return {
+    genesisValidatorsRoot: fromHexString(interchange.metadata.genesis_validators_root),
+    data: interchange.data.map((validator) => ({
+      pubkey: fromHexString(validator.pubkey),
+      signedBlocks: validator.signed_blocks.map((block) => ({
+        slot: parseInt(block.slot, 10),
+        signingRoot: block.signing_root ? fromHexString(block.signing_root) : ZERO_HASH,
+      })),
+      signedAttestations: validator.signed_attestations.map((att) => ({
+        sourceEpoch: parseInt(att.source_epoch, 10),
+        targetEpoch: parseInt(att.target_epoch, 10),
+        signingRoot: att.signing_root ? fromHexString(att.signing_root) : ZERO_HASH,
+      })),
+    })),
+  };
+}

--- a/packages/lodestar-validator/src/slashingProtection/interchange/index.ts
+++ b/packages/lodestar-validator/src/slashingProtection/interchange/index.ts
@@ -1,0 +1,59 @@
+import {Root} from "@chainsafe/lodestar-types";
+import {isEqualRoot} from "../utils";
+import {IInterchangeLodestar} from "./types";
+import {InterchangeError, InterchangeErrorErrorCode} from "./errors";
+import {IInterchangeCompleteV4, parseInterchangeCompleteV4, serializeInterchangeCompleteV4} from "./formats/completeV4";
+
+export type Interchange = IInterchangeCompleteV4;
+export type InterchangeFormatVersion = {format: "complete"; version: "4"};
+export {IInterchangeLodestar};
+
+export function parseInterchange(
+  interchange: Interchange,
+  expectedGenesisValidatorsRoot: Root
+): IInterchangeLodestar["data"] {
+  const format = interchange?.metadata?.interchange_format;
+  const version = interchange?.metadata?.interchange_format_version;
+
+  switch (format) {
+    case "complete":
+      switch (version) {
+        case "4": {
+          const {data, genesisValidatorsRoot} = parseInterchangeCompleteV4(interchange);
+          if (!isEqualRoot(genesisValidatorsRoot, expectedGenesisValidatorsRoot)) {
+            throw new InterchangeError({
+              code: InterchangeErrorErrorCode.GENESIS_VALIDATOR_MISMATCH,
+              root: genesisValidatorsRoot,
+              extectedRoot: expectedGenesisValidatorsRoot,
+            });
+          }
+          return data;
+        }
+
+        default:
+          throw new InterchangeError({code: InterchangeErrorErrorCode.UNSUPPORTED_VERSION, version});
+      }
+
+    default:
+      throw new InterchangeError({code: InterchangeErrorErrorCode.UNSUPPORTED_FORMAT, format});
+  }
+}
+
+export function serializeInterchange(
+  interchangeLodestar: IInterchangeLodestar,
+  {format, version}: InterchangeFormatVersion
+): Interchange {
+  switch (format) {
+    case "complete":
+      switch (version) {
+        case "4":
+          return serializeInterchangeCompleteV4(interchangeLodestar);
+
+        default:
+          throw new InterchangeError({code: InterchangeErrorErrorCode.UNSUPPORTED_VERSION, version});
+      }
+
+    default:
+      throw new InterchangeError({code: InterchangeErrorErrorCode.UNSUPPORTED_FORMAT, format});
+  }
+}

--- a/packages/lodestar-validator/src/slashingProtection/interchange/types.ts
+++ b/packages/lodestar-validator/src/slashingProtection/interchange/types.ts
@@ -1,0 +1,29 @@
+import {BLSPubkey, Epoch, Root, Slot} from "@chainsafe/lodestar-types";
+
+/* eslint-disable @typescript-eslint/interface-name-prefix */
+
+/**
+ * For validator slashing protection
+ */
+interface SlashingProtectionBlock {
+  slot: Slot;
+  signingRoot: Root;
+}
+
+/**
+ * For validator slashing protection
+ */
+interface SlashingProtectionAttestation {
+  sourceEpoch: Epoch;
+  targetEpoch: Epoch;
+  signingRoot: Root;
+}
+
+export interface IInterchangeLodestar {
+  genesisValidatorsRoot: Root;
+  data: {
+    pubkey: BLSPubkey;
+    signedBlocks: SlashingProtectionBlock[];
+    signedAttestations: SlashingProtectionAttestation[];
+  }[];
+}

--- a/packages/lodestar-validator/src/slashingProtection/utils.ts
+++ b/packages/lodestar-validator/src/slashingProtection/utils.ts
@@ -1,0 +1,14 @@
+import {Root} from "@chainsafe/lodestar-types";
+import {toHexString} from "@chainsafe/ssz";
+
+export function isEqualRoot(root1: Root, root2: Root): boolean {
+  return toHexString(root1) === toHexString(root2);
+}
+
+/**
+ * Typesafe wrapper around `String()`. The String constructor accepts any which is dangerous
+ * @param num
+ */
+export function numToString(num: number): string {
+  return String(num);
+}


### PR DESCRIPTION
Adds interchange format parser and serializer according to the "Slashing Protection Database Interchange Format"

From https://hackmd.io/@sproul/Bk0Y0qdGD implements:
- Complete v4 format

This PR is part of https://github.com/ChainSafe/lodestar/compare/dapplion/slashing-protection/root, see that branch for a reference full implementation