### PR TITLE
Regular sync to start from last processed block instead of forkchoice head

### DIFF
--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -11,7 +11,7 @@ import {IInitialSyncModules, InitialSync, InitialSyncEventEmitter} from "../inte
 import {EventEmitter} from "events";
 import {Checkpoint, SignedBeaconBlock, Slot, Status} from "@chainsafe/lodestar-types";
 import pushable, {Pushable} from "it-pushable";
-import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import pipe from "it-pipe";
 import {ISlotRange, ISyncCheckpoint} from "../../interface";
 import {fetchBlockChunks, getCommonFinalizedCheckpoint, processSyncBlocks} from "../../utils";
@@ -73,7 +73,7 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
     if (
       !this.targetCheckpoint ||
       this.targetCheckpoint.epoch == GENESIS_EPOCH ||
-      this.targetCheckpoint.epoch <= computeEpochAtSlot(this.config, this.blockImportTarget)
+      this.targetCheckpoint.epoch <= this.chain.forkChoice.getFinalizedCheckpoint().epoch
     ) {
       this.logger.info("No peers with higher finalized epoch");
       await this.stop();

--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -93,6 +93,13 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
     this.chain.emitter.removeListener("checkpoint", this.checkSyncCompleted);
   }
 
+  /**
+   * Make sure we get up-to-date lastProcessedBlock from sync().
+   */
+  public getLastProcessedBlock(): ISyncCheckpoint {
+    return this.lastProcessedBlock;
+  }
+
   public getHighestBlock(): Slot {
     return computeStartSlotAtEpoch(this.config, this.targetCheckpoint!.epoch);
   }
@@ -129,11 +136,11 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
         network,
         logger,
         opts,
-        getLastProcessedBlock,
         setBlockImportTarget,
         updateBlockImportTarget,
         getInitialSyncPeers,
       } = this;
+      const getLastProcessedBlock = this.getLastProcessedBlock.bind(this);
       return (async function () {
         for await (const slotRange of source) {
           const lastSlot = await pipe(
@@ -214,13 +221,6 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
       .map((peer) => this.network.peerMetadata.getStatus(peer.id))
       .filter(notNullish);
   }
-
-  /**
-   * Make sure we get up-to-date lastProcessedBlock from sync().
-   */
-  private getLastProcessedBlock = (): ISyncCheckpoint => {
-    return this.lastProcessedBlock;
-  };
 
   /**
    * Returns peers which has same finalized Checkpoint

--- a/packages/lodestar/src/sync/initial/interface.ts
+++ b/packages/lodestar/src/sync/initial/interface.ts
@@ -6,7 +6,7 @@ import {Checkpoint, Epoch} from "@chainsafe/lodestar-types";
 import StrictEventEmitter from "strict-event-emitter-types";
 import {EventEmitter} from "events";
 import {IService} from "../../node";
-import {ISyncModule} from "../interface";
+import {ISyncCheckpoint, ISyncModule} from "../interface";
 import {ISyncStats} from "../stats";
 import {IBeaconDb} from "../../db";
 
@@ -25,4 +25,8 @@ export interface IInitialSyncEvents {
 }
 export type InitialSyncEventEmitter = StrictEventEmitter<EventEmitter, IInitialSyncEvents>;
 
-export type InitialSync = IService & InitialSyncEventEmitter & ISyncModule;
+export type InitialSync = IService &
+  InitialSyncEventEmitter &
+  ISyncModule & {
+    getLastProcessedBlock(): ISyncCheckpoint;
+  };

--- a/packages/lodestar/src/sync/options.ts
+++ b/packages/lodestar/src/sync/options.ts
@@ -12,7 +12,7 @@ const config: Required<ISyncOptions> = {
   minPeers: 2,
   //2 epochs
   maxSlotImport: 64,
-  blockPerChunk: 20,
+  blockPerChunk: 64,
 };
 
 export default config;

--- a/packages/lodestar/src/sync/regular/interface.ts
+++ b/packages/lodestar/src/sync/regular/interface.ts
@@ -1,5 +1,5 @@
 import {IService} from "../../node";
-import {ISyncModule, ISyncModules} from "../index";
+import {ISyncCheckpoint, ISyncModule, ISyncModules} from "../index";
 import {EventEmitter} from "events";
 import StrictEventEmitter from "strict-event-emitter-types";
 
@@ -9,6 +9,10 @@ export interface IRegularSyncEvents {
 
 export type RegularSyncEventEmitter = StrictEventEmitter<EventEmitter, IRegularSyncEvents>;
 
-export type IRegularSync = IService & ISyncModule & RegularSyncEventEmitter;
+export type IRegularSync = IService &
+  ISyncModule &
+  RegularSyncEventEmitter & {
+    setLastProcessedBlock(lastProcessedBlock: ISyncCheckpoint): void;
+  };
 
 export type IRegularSyncModules = Pick<ISyncModules, "config" | "chain" | "network" | "logger">;


### PR DESCRIPTION
resolves #1657
+ At the time of regular sync, forkchoice head() is not updated until the next finalized epoch so we should not use it, use the `lastProcessedBlock` in initial sync instead
+ Change `blockPerChunk` default value from 20 to 64 to be more efficient, similar to initial sync.
+ Fix initial sync bypass condition: finalized epoch maybe different from epoch of finalized block. This happens in case start slot of finalized epoch is a skipped slot.