### PR TITLE
Deal with circular references

### DIFF
--- a/packages/lodestar-utils/package.json
+++ b/packages/lodestar-utils/package.json
@@ -42,13 +42,11 @@
     "chalk": "^2.4.2",
     "event-iterator": "^2.0.0",
     "js-yaml": "^3.13.1",
-    "lodash": "^4.17.20",
     "winston": "^3.2.1",
     "winston-transport": "^4.3.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^3.12.1",
-    "@types/lodash": "^4.14.161",
     "@types/triple-beam": "^1.3.2",
     "triple-beam": "^1.3.0"
   },

--- a/packages/lodestar-utils/src/json.ts
+++ b/packages/lodestar-utils/src/json.ts
@@ -1,5 +1,5 @@
 import {Json, toHexString} from "@chainsafe/ssz";
-import {mapValues, pick} from "lodash";
+import {pick} from "lodash";
 import {LodestarError} from "./errors";
 
 export function errorToObject(obj: Error): Json {
@@ -15,11 +15,10 @@ export function toJson(arg: unknown): Json {
 
     case "object":
       if (arg === null) return "null";
-      if (Array.isArray(arg)) return arg.map(toJson);
       if (arg instanceof Uint8Array) return toHexString(arg);
       if (arg instanceof LodestarError) return toJson(arg.toObject());
       if (arg instanceof Error) return toJson(errorToObject(arg));
-      return mapValues(arg, (value) => toJson(value)) as Json;
+      return arg as Json;
 
     // Already valid JSON
     case "number":
@@ -34,7 +33,7 @@ export function toJson(arg: unknown): Json {
 export function toString(json: Json, nested = false): string {
   switch (typeof json) {
     case "object": {
-      if (nested) return JSON.stringify(json);
+      if (nested) return JSONStringifyCircular(json);
       if (json === null) return "null";
       if (Array.isArray(json)) return json.map((item) => toString(item, true)).join(", ");
       return Object.entries(json)
@@ -47,5 +46,21 @@ export function toString(json: Json, nested = false): string {
     case "boolean":
     default:
       return String(json);
+  }
+}
+
+/**
+ * Does not throw on circular references, prevent silencing the actual logged error
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function JSONStringifyCircular(value: any): string {
+  try {
+    return JSON.stringify(value);
+  } catch (e) {
+    if (e instanceof TypeError && e.message.includes("circular")) {
+      return "ERROR_CIRCULAR_REFERENCE";
+    } else {
+      throw e;
+    }
   }
 }

--- a/packages/lodestar-utils/src/json.ts
+++ b/packages/lodestar-utils/src/json.ts
@@ -1,10 +1,5 @@
 import {Json, toHexString} from "@chainsafe/ssz";
-import {pick} from "lodash";
 import {LodestarError} from "./errors";
-
-export function errorToObject(obj: Error): Json {
-  return pick(obj, Object.getOwnPropertyNames(obj)) as Json;
-}
 
 export function toJson(arg: unknown): Json {
   switch (typeof arg) {
@@ -47,6 +42,13 @@ export function toString(json: Json, nested = false): string {
     default:
       return String(json);
   }
+}
+
+function errorToObject(err: Error): Json {
+  return {
+    message: err.message,
+    ...(err.stack ? {stack: err.stack} : {}),
+  };
 }
 
 /**

--- a/packages/lodestar-utils/test/unit/json.test.ts
+++ b/packages/lodestar-utils/test/unit/json.test.ts
@@ -74,10 +74,9 @@ describe("Json helper", () => {
         const data = "foo";
         const error = new SampleError(data);
         return {
-          id: "External error with metadata",
+          id: "External error with metadata (ignored)",
           arg: error,
           json: {
-            data,
             message: error.message,
             stack: error.stack,
           },

--- a/packages/lodestar-utils/test/unit/json.test.ts
+++ b/packages/lodestar-utils/test/unit/json.test.ts
@@ -3,6 +3,10 @@ import {expect} from "chai";
 import {LodestarError, toJson, toString} from "../../src";
 
 describe("Json helper", () => {
+  const circularReference = {};
+  // @ts-ignore
+  circularReference.myself = circularReference;
+
   describe("toJson", () => {
     interface ITestCase {
       id: string;
@@ -91,6 +95,9 @@ describe("Json helper", () => {
           },
         };
       },
+
+      // Circular references
+      {id: "circular reference", arg: circularReference, json: circularReference},
     ];
 
     for (const testCase of testCases) {
@@ -129,6 +136,9 @@ describe("Json helper", () => {
       {id: "object of basic types", json: {a: 1, b: 2}, output: "a=1, b=2"},
       // eslint-disable-next-line quotes
       {id: "object of objects", json: {a: {b: 1}}, output: `a={"b":1}`},
+
+      // Circular references
+      {id: "circular reference", json: circularReference, output: "myself=ERROR_CIRCULAR_REFERENCE"},
     ];
 
     for (const testCase of testCases) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2823,11 +2823,6 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.157.tgz#fdac1c52448861dfde1a2e1515dbc46e54926dc8"
   integrity sha512-Ft5BNFmv2pHDgxV5JDsndOWTRJ+56zte0ZpYLowp03tW+K+t8u8YMOzAnpuqPgzX6WO1XpDIUm7u04M8vdDiVQ==
 
-"@types/lodash@^4.14.161":
-  version "4.14.161"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.161.tgz#a21ca0777dabc6e4f44f3d07f37b765f54188b18"
-  integrity sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==
-
 "@types/long@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
@@ -9182,11 +9177,6 @@ lodash@^4.1.2, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.1
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-
-lodash@^4.17.20:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-symbols@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
In Zinken launch, a circular reference prevented the logger from showing an important error. 

```
(node:19660) UnhandledPromiseRejectionWarning: RangeError: Maximum call stack size exceeded
    at Object (<anonymous>)
    at baseGetTag (/home/ubuntu/lodestar/packages/lodestar-utils/node_modules/lodash/lodash.js:3067:51)
    at isFunction (/home/ubuntu/lodestar/packages/lodestar-utils/node_modules/lodash/lodash.js:11679:17)
    at isArrayLike (/home/ubuntu/lodestar/packages/lodestar-utils/node_modules/lodash/lodash.js:11359:58)
    at keys (/home/ubuntu/lodestar/packages/lodestar-utils/node_modules/lodash/lodash.js:13333:14)
    at /home/ubuntu/lodestar/packages/lodestar-utils/node_modules/lodash/lodash.js:4920:21
    at baseForOwn (/home/ubuntu/lodestar/packages/lodestar-utils/node_modules/lodash/lodash.js:2990:24)
    at mapValues (/home/ubuntu/lodestar/packages/lodestar-utils/node_modules/lodash/lodash.js:13426:7)
    at toJson (/home/ubuntu/lodestar/packages/lodestar-utils/src/json.ts:22:14)
    at /home/ubuntu/lodestar/packages/lodestar-utils/src/json.ts:22:40
```

This PR allows the toJson and toString methods to deal with circular references and not throw errors. 

Then, in case of circular references the logger will still print part of the original intended message. However, if a circular reference occurs, it typically will come from un-intended metdata so it's okay to omit it.