### PR TITLE
Store pending blocks to db

### DIFF
--- a/packages/lodestar-db/src/schema.ts
+++ b/packages/lodestar-db/src/schema.ts
@@ -41,6 +41,7 @@ export enum Bucket {
   slashingProtectionAttestationLowerBound = 22,
   slashingProtectionMinSpanDistance = 23,
   slashingProtectionMaxSpanDistance = 24,
+  pendingBlock = 25, // Root -> SignedBeaconBlock
 }
 
 export enum Key {

--- a/packages/lodestar/src/chain/blocks/pool.ts
+++ b/packages/lodestar/src/chain/blocks/pool.ts
@@ -99,6 +99,10 @@ export class BlockPool {
     return this.blocks.size;
   }
 
+  public has(blockRoot: Root): boolean {
+    return Boolean(this.blocks.get(this.getBlockKeyByRoot(blockRoot)));
+  }
+
   public getByParent(parentRoot: Root): Uint8Array[] {
     const hexArr = Array.from(this.blocksByParent.get(toHexString(parentRoot))?.values() ?? []);
     return hexArr.map((hex) => fromHexString(hex));
@@ -119,5 +123,9 @@ export class BlockPool {
 
   private getBlockKey(block: SignedBeaconBlock): string {
     return toHexString(this.config.types.BeaconBlock.hashTreeRoot(block.message));
+  }
+
+  private getBlockKeyByRoot(root: Root): string {
+    return toHexString(root);
   }
 }

--- a/packages/lodestar/src/chain/blocks/pool.ts
+++ b/packages/lodestar/src/chain/blocks/pool.ts
@@ -95,6 +95,10 @@ export class BlockPool {
     return fromHexString(root);
   }
 
+  public getTotalPendingBlocks(): number {
+    return this.blocks.size;
+  }
+
   public getByParent(parentRoot: Root): Uint8Array[] {
     const hexArr = Array.from(this.blocksByParent.get(toHexString(parentRoot))?.values() ?? []);
     return hexArr.map((hex) => fromHexString(hex));

--- a/packages/lodestar/src/chain/blocks/pool.ts
+++ b/packages/lodestar/src/chain/blocks/pool.ts
@@ -1,8 +1,6 @@
-import {toHexString} from "@chainsafe/ssz";
+import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Root, SignedBeaconBlock, Slot} from "@chainsafe/lodestar-types";
-
-import {IBlockJob} from "../interface";
 
 /**
  * The BlockPool is a cache of blocks that are pending processing.
@@ -14,17 +12,17 @@ import {IBlockJob} from "../interface";
 export class BlockPool {
   private readonly config: IBeaconConfig;
   /**
-   * Blocks indexed by blockRoot
+   * Map of root as key and parentRoot as value
    */
-  private blocks: Map<string, IBlockJob>;
+  private blocks: Map<string, string>;
   /**
    * Blocks indexed by parentRoot, then blockRoot
    */
-  private blocksByParent: Map<string, Map<string, IBlockJob>>;
+  private blocksByParent: Map<string, Set<string>>;
   /**
    * Blocks indexed by slot, then blockRoot
    */
-  private blocksBySlot: Map<Slot, Map<string, IBlockJob>>;
+  private blocksBySlot: Map<Slot, Set<string>>;
 
   constructor({config}: {config: IBeaconConfig}) {
     this.config = config;
@@ -34,45 +32,43 @@ export class BlockPool {
     this.blocksBySlot = new Map();
   }
 
-  public addByParent(job: IBlockJob): void {
-    const {signedBlock} = job;
+  public addByParent(signedBlock: SignedBeaconBlock): void {
     // put block in two indices:
     // blocks
     const blockKey = this.getBlockKey(signedBlock);
-    this.blocks.set(blockKey, job);
+    this.blocks.set(blockKey, toHexString(signedBlock.message.parentRoot));
     // blocks by parent
     const parentKey = this.getParentKey(signedBlock);
     let blocksWithParent = this.blocksByParent.get(parentKey);
     if (!blocksWithParent) {
-      blocksWithParent = new Map();
+      blocksWithParent = new Set();
       this.blocksByParent.set(parentKey, blocksWithParent);
     }
-    blocksWithParent.set(blockKey, job);
+    blocksWithParent.add(blockKey);
   }
 
-  public addBySlot(job: IBlockJob): void {
-    const {signedBlock} = job;
+  public addBySlot(signedBlock: SignedBeaconBlock): void {
     // put block in two indices:
     // blocks
     const blockKey = this.getBlockKey(signedBlock);
-    this.blocks.set(blockKey, job);
+    this.blocks.set(blockKey, toHexString(signedBlock.message.parentRoot));
     // blocks by slot
     const slotKey = this.getSlotKey(signedBlock);
     let blocksAtSlot = this.blocksBySlot.get(slotKey);
     if (!blocksAtSlot) {
-      blocksAtSlot = new Map();
+      blocksAtSlot = new Set();
       this.blocksBySlot.set(slotKey, blocksAtSlot);
     }
-    blocksAtSlot.set(blockKey, job);
+    blocksAtSlot.add(blockKey);
   }
 
-  public remove(job: IBlockJob): void {
+  public remove(signedBlock: SignedBeaconBlock): void {
     // remove block from three indices:
     // blocks
-    const blockKey = this.getBlockKey(job.signedBlock);
+    const blockKey = this.getBlockKey(signedBlock);
     this.blocks.delete(blockKey);
     // blocks by slot
-    const slotKey = this.getSlotKey(job.signedBlock);
+    const slotKey = this.getSlotKey(signedBlock);
     const blocksAtSlot = this.blocksBySlot.get(slotKey);
     if (blocksAtSlot) {
       blocksAtSlot.delete(blockKey);
@@ -81,7 +77,7 @@ export class BlockPool {
       }
     }
     // blocks by parent
-    const parentKey = this.getParentKey(job.signedBlock);
+    const parentKey = this.getParentKey(signedBlock);
     const blocksWithParent = this.blocksByParent.get(parentKey);
     if (blocksWithParent) {
       blocksWithParent.delete(blockKey);
@@ -91,32 +87,22 @@ export class BlockPool {
     }
   }
 
-  public get(blockRoot: Root): IBlockJob | undefined {
-    return this.blocks.get(toHexString(blockRoot));
-  }
-
-  public has(blockRoot: Root): boolean {
-    return Boolean(this.get(blockRoot));
-  }
-
-  public getByParent(parentRoot: Root): IBlockJob[] {
-    return Array.from(this.blocksByParent.get(toHexString(parentRoot))?.values() ?? []);
-  }
-
   public getMissingAncestor(blockRoot: Root): Root {
-    let root = blockRoot;
-    while (this.blocks.has(toHexString(root))) {
-      root = this.blocks.get(toHexString(root))?.signedBlock.message.parentRoot!;
+    let root = toHexString(blockRoot);
+    while (this.blocks.has(root)) {
+      root = this.blocks.get(root)!;
     }
-    return root;
+    return fromHexString(root);
   }
 
-  public getPendingBlocks(): IBlockJob[] {
-    return Array.from(this.blocks.values() ?? []);
+  public getByParent(parentRoot: Root): Uint8Array[] {
+    const hexArr = Array.from(this.blocksByParent.get(toHexString(parentRoot))?.values() ?? []);
+    return hexArr.map((hex) => fromHexString(hex));
   }
 
-  public getBySlot(slot: Slot): IBlockJob[] {
-    return Array.from(this.blocksBySlot.get(slot)?.values() ?? []);
+  public getBySlot(slot: Slot): Uint8Array[] {
+    const hexArr = Array.from(this.blocksBySlot.get(slot)?.values() ?? []);
+    return hexArr.map((hex) => fromHexString(hex));
   }
 
   private getParentKey(block: SignedBeaconBlock): string {

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -113,12 +113,8 @@ export async function onClockSlot(this: BeaconChain, slot: Slot): Promise<void> 
       }
     })
   );
-  const pendingJobs = this.pendingBlocks.getPendingBlocks();
   this.logger.debug("Block pools: ", {
-    pendingBlocks: pendingJobs
-      .map((job) => job.signedBlock.message.slot)
-      .sort((a, b) => a - b)
-      .join(","),
+    pendingBlocks: this.pendingBlocks.getTotalPendingBlocks(),
     currentSlot: this.clock.currentSlot,
   });
 }

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -292,8 +292,10 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
         reason: err.type.code,
         blockRoot: toHexString(blockRoot),
       });
-      await this.db.pendingBlock.add(err.job.signedBlock);
+      // add to pendingBlocks first which is not await
+      // this is to process a block range
       this.pendingBlocks.addByParent(err.job.signedBlock);
+      await this.db.pendingBlock.add(err.job.signedBlock);
       break;
     case BlockErrorCode.ERR_INCORRECT_PROPOSER:
     case BlockErrorCode.ERR_REPEAT_PROPOSAL:

--- a/packages/lodestar/src/db/api/beacon/beacon.ts
+++ b/packages/lodestar/src/db/api/beacon/beacon.ts
@@ -22,10 +22,12 @@ import {
 import {StateContextCache} from "./stateContextCache";
 import {CheckpointStateCache} from "./stateContextCheckpointsCache";
 import {SeenAttestationCache} from "./seenAttestationCache";
+import {PendingBlockRepository} from "./repositories/pendingBlock";
 
 export class BeaconDb extends DatabaseService implements IBeaconDb {
   public badBlock: BadBlockRepository;
   public block: BlockRepository;
+  public pendingBlock: PendingBlockRepository;
   public stateCache: StateContextCache;
   public checkpointStateCache: CheckpointStateCache;
   public seenAttestationCache: SeenAttestationCache;
@@ -46,6 +48,7 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
     super(opts);
     this.badBlock = new BadBlockRepository(this.config, this.db);
     this.block = new BlockRepository(this.config, this.db);
+    this.pendingBlock = new PendingBlockRepository(this.config, this.db);
     this.stateCache = new StateContextCache();
     this.checkpointStateCache = new CheckpointStateCache(this.config);
     this.seenAttestationCache = new SeenAttestationCache(5000);

--- a/packages/lodestar/src/db/api/beacon/interface.ts
+++ b/packages/lodestar/src/db/api/beacon/interface.ts
@@ -21,6 +21,7 @@ import {
 import {StateContextCache} from "./stateContextCache";
 import {CheckpointStateCache} from "./stateContextCheckpointsCache";
 import {SeenAttestationCache} from "./seenAttestationCache";
+import {PendingBlockRepository} from "./repositories/pendingBlock";
 
 /**
  * The DB service manages the data layer of the beacon chain
@@ -33,6 +34,9 @@ export interface IBeaconDb {
 
   // unfinalized blocks
   block: BlockRepository;
+
+  // pending block
+  pendingBlock: PendingBlockRepository;
 
   // unfinalized states
   stateCache: StateContextCache;

--- a/packages/lodestar/src/db/api/beacon/repositories/pendingBlock.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/pendingBlock.ts
@@ -5,7 +5,7 @@ import {IDatabaseController, Bucket, Repository} from "@chainsafe/lodestar-db";
 /**
  * Blocks by root
  *
- * Used to store unfinalized blocks
+ * Used to store pending blocks
  */
 export class PendingBlockRepository extends Repository<Uint8Array, SignedBeaconBlock> {
   public constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {

--- a/packages/lodestar/src/db/api/beacon/repositories/pendingBlock.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/pendingBlock.ts
@@ -1,0 +1,21 @@
+import {SignedBeaconBlock} from "@chainsafe/lodestar-types";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IDatabaseController, Bucket, Repository} from "@chainsafe/lodestar-db";
+
+/**
+ * Blocks by root
+ *
+ * Used to store unfinalized blocks
+ */
+export class PendingBlockRepository extends Repository<Uint8Array, SignedBeaconBlock> {
+  public constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
+    super(config, db, Bucket.pendingBlock, config.types.SignedBeaconBlock);
+  }
+
+  /**
+   * Id is hashTreeRoot of unsigned BeaconBlock
+   */
+  public getId(value: SignedBeaconBlock): Uint8Array {
+    return this.config.types.BeaconBlock.hashTreeRoot(value.message);
+  }
+}

--- a/packages/lodestar/test/unit/chain/blocks/pool.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/pool.test.ts
@@ -1,7 +1,6 @@
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import {expect} from "chai";
 import {BlockPool} from "../../../../src/chain/blocks";
-import {IBlockJob} from "../../../../src/chain";
 
 describe("BlockPool", function () {
   let pool: BlockPool;
@@ -15,13 +14,8 @@ describe("BlockPool", function () {
     const ancestorRoot = firstBlock.message.parentRoot;
     const secondBlock = config.types.SignedBeaconBlock.defaultValue();
     secondBlock.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(firstBlock.message);
-    const jobs: IBlockJob[] = [firstBlock, secondBlock].map((block) => ({
-      signedBlock: block,
-      trusted: false,
-      reprocess: false,
-    }));
-    pool.addBySlot(jobs[0]);
-    pool.addByParent(jobs[1]);
+    pool.addBySlot(firstBlock);
+    pool.addByParent(secondBlock);
     const root = pool.getMissingAncestor(config.types.BeaconBlock.hashTreeRoot(secondBlock.message));
     expect(config.types.Root.equals(ancestorRoot, root)).to.be.true;
   });

--- a/packages/lodestar/test/utils/stub/beaconDb.ts
+++ b/packages/lodestar/test/utils/stub/beaconDb.ts
@@ -21,12 +21,14 @@ import {StateContextCache} from "../../../src/db/api/beacon/stateContextCache";
 import {SeenAttestationCache} from "../../../src/db/api/beacon/seenAttestationCache";
 import {CheckpointStateCache} from "../../../src/db/api/beacon/stateContextCheckpointsCache";
 import {config as minimalConfig} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {PendingBlockRepository} from "../../../src/db/api/beacon/repositories/pendingBlock";
 
 export class StubbedBeaconDb extends BeaconDb {
   public db!: SinonStubbedInstance<LevelDbController>;
 
   public badBlock: SinonStubbedInstance<BadBlockRepository> & BadBlockRepository;
   public block: SinonStubbedInstance<BlockRepository> & BlockRepository;
+  public pendingBlock: SinonStubbedInstance<PendingBlockRepository> & PendingBlockRepository;
   public stateCache: SinonStubbedInstance<StateContextCache> & StateContextCache;
   public blockArchive: SinonStubbedInstance<BlockArchiveRepository> & BlockArchiveRepository;
   public stateArchive: SinonStubbedInstance<StateArchiveRepository> & StateArchiveRepository;
@@ -52,6 +54,7 @@ export class StubbedBeaconDb extends BeaconDb {
     super({config, controller: null!});
     this.badBlock = sinon.createStubInstance(BadBlockRepository) as any;
     this.block = sinon.createStubInstance(BlockRepository) as any;
+    this.pendingBlock = sinon.createStubInstance(PendingBlockRepository) as any;
     this.stateCache = sinon.createStubInstance(StateContextCache) as any;
     this.blockArchive = sinon.createStubInstance(BlockArchiveRepository) as any;
     this.stateArchive = sinon.createStubInstance(StateArchiveRepository) as any;


### PR DESCRIPTION
resolves #1663 

in this infinality time of medalla, it's not sustainable to store pending blocks in memory. So I created `pendingBlock` repository for this purpose and `BlockPool` acts as an index for it, similar to what forkchoice does (vs `block` repository)