### PR TITLE
Add internal event emitter

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -75,6 +75,10 @@ export class BeaconChain implements IBeaconChain {
   protected readonly metrics: IBeaconMetrics;
   protected readonly opts: IChainOptions;
   protected genesisTime: Number64 = 0;
+  /**
+   * Internal event emitter is used internally to the chain to update chain state
+   * Once event have been handled internally, they are re-emitted externally for downstream consumers
+   */
   protected internalEmitter: ChainEventEmitter;
   private abortController?: AbortController;
 

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -9,9 +9,9 @@ import {IBlockJob} from "./interface";
 import {ChainEventEmitter, IChainEvents} from "./emitter";
 import {BeaconChain} from "./chain";
 
-interface IEventMap<Events, Key extends keyof Events = keyof Events, Value extends Events[Key] = Events[Key]>
-  extends Map<Key, Value> {
-  set<Key extends keyof Events>(key: Key, value: Events[Key]): this;
+interface IEventMap<Events, Event extends keyof Events = keyof Events, Callback extends Events[Event] = Events[Event]>
+  extends Map<Event, Callback> {
+  set<Event extends keyof Events>(key: Event, value: Events[Event]): this;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -23,13 +23,18 @@ type ListenerType<T> = [T] extends [(...args: infer U) => any] ? U : [T] extends
  * then emits the event on the event emitter using the same args
  */
 function wrapHandler<
-  Key extends keyof IChainEvents = keyof IChainEvents,
-  Value extends IChainEvents[Key] = IChainEvents[Key]
->(event: Key, emitter: ChainEventEmitter, logger: ILogger, handler: (...args: Parameters<Value>) => Promise<void>) {
-  return async (...args: Parameters<Value>): Promise<void> => {
+  Event extends keyof IChainEvents = keyof IChainEvents,
+  Callback extends IChainEvents[Event] = IChainEvents[Event]
+>(
+  event: Event,
+  emitter: ChainEventEmitter,
+  logger: ILogger,
+  handler: (...args: Parameters<Callback>) => Promise<void>
+) {
+  return async (...args: Parameters<Callback>): Promise<void> => {
     try {
       await handler(...args);
-      emitter.emit(event, ...((args as unknown) as ListenerType<Value>));
+      emitter.emit(event, ...((args as unknown) as ListenerType<Callback>));
     } catch (e) {
       logger.error(`Error handling event: ${event}`, e);
     }

--- a/packages/lodestar/test/unit/chain/chain.test.ts
+++ b/packages/lodestar/test/unit/chain/chain.test.ts
@@ -67,20 +67,4 @@ describe("BeaconChain", function () {
       config.params.ALL_FORKS = undefined!;
     });
   });
-
-  describe("forkVersion event", () => {
-    it("should should receive forkDigest event", async () => {
-      chain.forkChoice.getHead = () => generateBlockSummary();
-      const spy = sinon.spy();
-      const received = new Promise((resolve) => {
-        chain.emitter.on("forkDigest", () => {
-          spy();
-          resolve();
-        });
-      });
-      chain.emitter.emit("forkVersion");
-      await received;
-      expect(spy.callCount).to.be.equal(1);
-    });
-  });
 });


### PR DESCRIPTION
This is a solution to the following problem:
External (non-chain) handlers of `ChainEventEmitter` events can't be guaranteed that the proper side effects (internal to the chain) have been performed, at the time that the external handler is triggered.

This problem has been hinted at in #1655, where a new event is introduced, rather than relying on the existing events.
It's done for the following reasons:
1. the BlockPool is currently not part of the public IBeaconChain interface, so the sync can't retrieve the 'missing ancestor'
2. the sync can't really rely on the BlockPool being properly updated when the "error:block" event is fired/handled

Number 1. can be rectified fairly easily, either with a public method or public member on IBeaconChain
its 2. that this PR deals with.

The problem stems from the fact that multiple event handlers can be run concurrently (in the case that handlers are async / have async steps).
This means that external chain event handlers can be interwoven with internal chain event handlers in a way that exposes external handlers to an inconsistent chain state.

There are several ways to handle the problem, this is an attempt to systematically resolve it.

This PR adds an "internal event emitter" that is used to wire together chain submodules.
The chain's event handlers subscribe to this internal emitter.
These handlers perform various important side effects (eg: updating caches/db) that we want completed before external handers can run.
Once the chain's event handler finishes in its entirety (async function completes), the same event, with the same args is emitted from the public/external event emitter, where downstream consumers can attach event handlers.

