### PR TITLE
OneRangeAhead Regular Sync 

### DIFF
--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -11,7 +11,7 @@ import {IInitialSyncModules, InitialSync, InitialSyncEventEmitter} from "../inte
 import {EventEmitter} from "events";
 import {Checkpoint, SignedBeaconBlock, Slot, Status} from "@chainsafe/lodestar-types";
 import pushable, {Pushable} from "it-pushable";
-import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import pipe from "it-pipe";
 import {ISlotRange, ISyncCheckpoint} from "../../interface";
 import {fetchBlockChunks, getCommonFinalizedCheckpoint, processSyncBlocks} from "../../utils";
@@ -73,7 +73,7 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
     if (
       !this.targetCheckpoint ||
       this.targetCheckpoint.epoch == GENESIS_EPOCH ||
-      this.targetCheckpoint.epoch <= computeEpochAtSlot(this.config, this.blockImportTarget)
+      this.targetCheckpoint.epoch <= this.chain.forkChoice.getFinalizedCheckpoint().epoch
     ) {
       this.logger.info("No peers with higher finalized epoch");
       await this.stop();

--- a/packages/lodestar/src/sync/options.ts
+++ b/packages/lodestar/src/sync/options.ts
@@ -12,7 +12,7 @@ const config: Required<ISyncOptions> = {
   minPeers: 2,
   //2 epochs
   maxSlotImport: 64,
-  blockPerChunk: 20,
+  blockPerChunk: 64,
 };
 
 export default config;

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
@@ -49,13 +49,15 @@ export class BlockRangeFetcher implements IBlockRangeFetcher {
       let slotRange: ISlotRange | null = null;
       try {
         const peers = await this.getPeers();
-        // node is stopped
-        if (!peers || !peers.length) return [];
         if (result && !result!.length) await this.handleEmptyRange(peers);
         slotRange = {start: this.rangeStart, end: this.rangeEnd};
         result = await getBlockRange(this.logger, this.network.reqResp, peers, slotRange);
       } catch (e) {
-        this.logger.debug("Failed to get block range " + JSON.stringify(slotRange || {}) + ". Error: " + e.message);
+        this.logger.debug(
+          "Regular Sync: Failed to get block range " + JSON.stringify(slotRange || {}) + ". Error: " + e.message
+        );
+        // node is stopped for whatever reasons
+        if (e.message.trim() === "Aborted") return [];
         result = null;
       }
     }

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
@@ -42,7 +42,7 @@ export class BlockRangeFetcher implements IBlockRangeFetcher {
   /**
    * Get next block range.
    */
-  public async next(): Promise<SignedBeaconBlock[]> {
+  public async getNextBlockRange(): Promise<SignedBeaconBlock[]> {
     this.updateNextRange();
     let result: SignedBeaconBlock[] | null = null;
     while (!result || !result!.length) {
@@ -90,7 +90,7 @@ export class BlockRangeFetcher implements IBlockRangeFetcher {
       this.rangeEnd = this.getNewTarget();
     } else {
       this.logger.verbose("Regular Sync: Queried range passed peer head, sleep then try again", {
-        range: JSON.stringify(range),
+        range,
         peerHead: peerHeadSlot,
       });
       // don't want to disturb our peer if we pass peer head

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
@@ -10,8 +10,9 @@ import {INetwork} from "../../../network";
 import {getBlockRange} from "../../utils/blocks";
 import {ISlotRange, ISyncCheckpoint} from "../../interface";
 import {ZERO_HASH} from "../../../constants";
+import {IBlockRangeFetcher} from "./interface";
 
-export class BlockRangeFetcher {
+export class BlockRangeFetcher implements IBlockRangeFetcher {
   protected readonly config: IBeaconConfig;
   private readonly network: INetwork;
   private readonly chain: IBeaconChain;

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
@@ -1,0 +1,95 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {SignedBeaconBlock, Slot} from "@chainsafe/lodestar-types";
+import {ILogger, sleep} from "@chainsafe/lodestar-utils";
+import deepmerge from "deepmerge";
+import PeerId from "peer-id";
+import {IRegularSyncModules} from "..";
+import {defaultOptions, IRegularSyncOptions} from "../options";
+import {IBeaconChain} from "../../../chain";
+import {INetwork} from "../../../network";
+import {getBlockRange} from "../../utils";
+
+// TODO: reusable, unit test
+export class BlockRangeFetcher {
+  protected readonly config: IBeaconConfig;
+  private readonly network: INetwork;
+  private readonly chain: IBeaconChain;
+  private readonly logger: ILogger;
+  private readonly opts: IRegularSyncOptions;
+  // inclusive
+  private rangeStart: Slot = 0;
+  // exclusive
+  private rangeEnd: Slot = 0;
+  private bestPeer: PeerId | undefined;
+  private getPeers: () => Promise<PeerId[]>;
+
+  constructor(
+    options: Partial<IRegularSyncOptions>,
+    modules: IRegularSyncModules,
+    rangeStart: Slot,
+    getPeers: () => Promise<PeerId[]>
+  ) {
+    this.config = modules.config;
+    this.network = modules.network;
+    this.chain = modules.chain;
+    this.logger = modules.logger;
+    this.opts = deepmerge(defaultOptions, options);
+    this.rangeStart = rangeStart;
+    this.rangeEnd = this.rangeStart + 1;
+    this.getPeers = getPeers;
+  }
+
+  /**
+   * Get next block range.
+   */
+  public async next(): Promise<SignedBeaconBlock[]> {
+    this.rangeStart = this.rangeEnd;
+    this.rangeEnd = this.getNewTarget();
+    let result: SignedBeaconBlock[] | null = null;
+    while (!result || !result!.length) {
+      if (result && !result!.length) await this.handleEmptyRange();
+      const slotRange = {start: this.rangeStart, end: this.rangeEnd};
+      try {
+        const peers = await this.getPeers();
+        result = await getBlockRange(this.logger, this.network.reqResp, peers, slotRange);
+      } catch (e) {
+        this.logger.debug("Failed to get block range " + JSON.stringify(slotRange) + ". Error: " + e.message);
+        result = null;
+      }
+    }
+    // success
+    return result!;
+  }
+
+  private async handleEmptyRange(): Promise<void> {
+    if (!this.bestPeer) {
+      return;
+    }
+    const range = {start: this.rangeStart, end: this.rangeEnd};
+    const peerHeadSlot = this.network.peerMetadata.getStatus(this.bestPeer)?.headSlot ?? 0;
+    this.logger.verbose(`Regular Sync: Not found any blocks for range ${JSON.stringify(range)}`);
+    if (range.end <= peerHeadSlot) {
+      // range contains skipped slots, query for next range
+      this.logger.verbose("Regular Sync: queried range is behind peer head, fetch next range", {
+        range: JSON.stringify(range),
+        peerHead: peerHeadSlot,
+      });
+      // don't trust empty range as it's rarely happen, peer may return it incorrectly or not up to date
+      // same range start, expand range end
+      this.rangeEnd = this.getNewTarget();
+    } else {
+      this.logger.verbose("Regular Sync: Queried range passed peer head, sleep then try again", {
+        range: JSON.stringify(range),
+        peerHead: peerHeadSlot,
+      });
+      // don't want to disturb our peer if we pass peer head
+      await sleep(this.config.params.SECONDS_PER_SLOT * 1000);
+    }
+  }
+
+  private getNewTarget(): Slot {
+    const currentSlot = this.chain.clock.currentSlot;
+    // due to exclusive endSlot in chunkify, we want `currentSlot + 1`
+    return Math.min(this.rangeEnd + this.opts.blockPerChunk, currentSlot + 1);
+  }
+}

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
@@ -8,7 +8,7 @@ import {defaultOptions, IRegularSyncOptions} from "../options";
 import {IBeaconChain} from "../../../chain";
 import {INetwork} from "../../../network";
 import {getBlockRange} from "../../utils";
-import {ISlotRange} from "../../interface";
+import {ISlotRange, ISyncCheckpoint} from "../../interface";
 
 // TODO: reusable, unit test
 export class BlockRangeFetcher {
@@ -30,6 +30,11 @@ export class BlockRangeFetcher {
     this.logger = modules.logger;
     this.opts = deepmerge(defaultOptions, options);
     this.getPeers = getPeers;
+  }
+
+  public setLastProcessedBlock(lastProcessedBlock: ISyncCheckpoint): void {
+    this.rangeStart = lastProcessedBlock.slot;
+    this.rangeEnd = this.rangeStart + 1;
   }
 
   /**

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/interface.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/interface.ts
@@ -1,0 +1,17 @@
+import {SignedBeaconBlock} from "@chainsafe/lodestar-types/src";
+import {IRegularSyncModules, ISyncCheckpoint} from "../..";
+import {IService} from "../../../node";
+
+export interface IBlockRangeFetcher {
+  setLastProcessedBlock(lastProcessedBlock: ISyncCheckpoint): void;
+  next(): Promise<SignedBeaconBlock[]>;
+}
+
+export interface IBlockRangeProcessor extends IService {
+  processUntilComplete(blocks: SignedBeaconBlock[], signal: AbortSignal): Promise<void>;
+}
+
+export type ORARegularSyncModules = IRegularSyncModules & {
+  fetcher?: IBlockRangeFetcher;
+  processor?: IBlockRangeProcessor;
+};

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/interface.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/interface.ts
@@ -4,7 +4,7 @@ import {IService} from "../../../node";
 
 export interface IBlockRangeFetcher {
   setLastProcessedBlock(lastProcessedBlock: ISyncCheckpoint): void;
-  next(): Promise<SignedBeaconBlock[]>;
+  getNextBlockRange(): Promise<SignedBeaconBlock[]>;
 }
 
 export interface IBlockRangeProcessor extends IService {

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
@@ -22,21 +22,13 @@ import {IBlockRangeFetcher, IBlockRangeProcessor, ORARegularSyncModules} from ".
  */
 export class ORARegularSync extends (EventEmitter as {new (): RegularSyncEventEmitter}) implements IRegularSync {
   private readonly config: IBeaconConfig;
-
   private readonly network: INetwork;
-
   private readonly chain: IBeaconChain;
-
   private readonly logger: ILogger;
-
   private bestPeer: PeerId | undefined;
-
   private fetcher: IBlockRangeFetcher;
-
   private processor: IBlockRangeProcessor;
-
   private controller!: AbortController;
-
   private blockBuffer: SignedBeaconBlock[];
 
   constructor(options: Partial<IRegularSyncOptions>, modules: ORARegularSyncModules) {
@@ -100,12 +92,12 @@ export class ORARegularSync extends (EventEmitter as {new (): RegularSyncEventEm
   };
 
   private async sync(): Promise<void> {
-    this.blockBuffer = await this.fetcher.next();
+    this.blockBuffer = await this.fetcher.getNextBlockRange();
     while (!this.controller.signal.aborted) {
       // blockBuffer is always not empty
       const lastSlot = this.blockBuffer[this.blockBuffer.length - 1].message.slot;
       const result = await Promise.all([
-        this.fetcher.next(),
+        this.fetcher.getNextBlockRange(),
         this.processor.processUntilComplete([...this.blockBuffer], this.controller.signal),
       ]);
       if (!result[0] || !result[0].length) {

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
@@ -1,0 +1,137 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {SignedBeaconBlock, Slot} from "@chainsafe/lodestar-types";
+import {AbortController, AbortSignal} from "abort-controller";
+import {ILogger, sleep} from "@chainsafe/lodestar-utils";
+import {toHexString} from "@chainsafe/ssz";
+import {EventEmitter} from "events";
+import PeerId from "peer-id";
+import {IRegularSync, IRegularSyncModules, IRegularSyncOptions, RegularSyncEventEmitter} from "..";
+import {IBeaconChain} from "../../../chain";
+import {INetwork} from "../../../network";
+import {GossipEvent} from "../../../network/gossip/constants";
+import {checkBestPeer, getBestPeer} from "../../utils";
+import {getSyncPeers} from "../../utils/peers";
+import {BlockRangeFetcher} from "./fetcher";
+import {processUntilComplete} from "./processor";
+
+/**
+ * One Range Ahead regular sync: fetch one range in advance and buffer blocks.
+ * Fetch next range and process blocks at the same time.
+ */
+export class ORARegularSync extends (EventEmitter as {new (): RegularSyncEventEmitter}) implements IRegularSync {
+  private readonly config: IBeaconConfig;
+
+  private readonly network: INetwork;
+
+  private readonly chain: IBeaconChain;
+
+  private readonly logger: ILogger;
+
+  private bestPeer: PeerId | undefined;
+
+  private fetcher: BlockRangeFetcher;
+
+  private controller!: AbortController;
+
+  private blockBuffer: SignedBeaconBlock[];
+
+  constructor(options: Partial<IRegularSyncOptions>, modules: IRegularSyncModules) {
+    super();
+    this.config = modules.config;
+    this.network = modules.network;
+    this.chain = modules.chain;
+    this.logger = modules.logger;
+    const headSlot = this.chain.forkChoice.getHead().slot;
+    this.fetcher = new BlockRangeFetcher(options, modules, headSlot, this.getSyncPeers.bind(this));
+    this.blockBuffer = [];
+  }
+
+  public async start(): Promise<void> {
+    const headSlot = this.chain.forkChoice.getHead().slot;
+    const currentSlot = this.chain.clock.currentSlot;
+    this.logger.info("Started regular syncing", {currentSlot, headSlot});
+    if (headSlot >= currentSlot) {
+      this.logger.info(`Regular Sync: node is up to date, headSlot=${headSlot}`);
+      this.emit("syncCompleted");
+      await this.stop();
+      return;
+    }
+    this.logger.verbose(`Regular Sync: Current slot at start: ${currentSlot}`);
+    this.controller = new AbortController();
+    this.network.gossip.subscribeToBlock(this.chain.currentForkDigest, this.onGossipBlock);
+    // await Promise.all([this.sync(), this.setTarget()]);
+    this.sync().catch((e) => {
+      this.logger.error("Regular Sync: error", e);
+    });
+  }
+
+  public async stop(): Promise<void> {
+    if (this.controller && !this.controller.signal.aborted) {
+      this.controller.abort();
+    }
+    this.network.gossip.unsubscribe(this.chain.currentForkDigest, GossipEvent.BLOCK, this.onGossipBlock);
+  }
+
+  public getHighestBlock(): Slot {
+    const lastBlock = this.blockBuffer.length > 0 ? this.blockBuffer[this.blockBuffer.length - 1].message.slot : 0;
+    return lastBlock ?? this.chain.forkChoice.getHead().slot;
+  }
+
+  private onGossipBlock = async (block: SignedBeaconBlock): Promise<void> => {
+    const gossipParentBlockRoot = block.message.parentRoot;
+    if (this.chain.forkChoice.hasBlock(gossipParentBlockRoot as Uint8Array)) {
+      this.logger.important("Regular Sync: caught up to gossip block parent " + toHexString(gossipParentBlockRoot));
+      this.emit("syncCompleted");
+      await this.stop();
+    }
+  };
+
+  private async sync(): Promise<void> {
+    this.blockBuffer = await this.fetcher.next();
+    while (!this.controller.signal.aborted) {
+      // blockBuffer is always not empty
+      const lastSlot = this.blockBuffer[this.blockBuffer.length - 1].message.slot;
+      const result = await Promise.all([
+        this.fetcher.next(),
+        processUntilComplete(this.config, this.chain, [...this.blockBuffer], this.controller.signal),
+      ]);
+      this.blockBuffer = result[0];
+      this.logger.info(`Regular Sync: Synced up to slot ${lastSlot} `, {
+        currentSlot: this.chain.clock.currentSlot,
+      });
+    }
+  }
+
+  /**
+   * Make sure the best peer is not disconnected and it's better than us.
+   */
+  private getSyncPeers = async (): Promise<PeerId[]> => {
+    if (!checkBestPeer(this.bestPeer!, this.chain.forkChoice, this.network)) {
+      this.logger.info("Regular Sync: wait for best peer");
+      this.bestPeer = undefined;
+      await this.waitForBestPeer(this.controller.signal);
+    }
+    return [this.bestPeer!];
+  };
+
+  private waitForBestPeer = async (signal: AbortSignal): Promise<void> => {
+    // statusSyncTimer is per slot
+    const waitingTime = this.config.params.SECONDS_PER_SLOT * 1000;
+
+    while (!this.bestPeer) {
+      const peers = getSyncPeers(this.network, undefined, this.network.getMaxPeer());
+      this.bestPeer = getBestPeer(this.config, peers, this.network.peerMetadata);
+      if (checkBestPeer(this.bestPeer, this.chain.forkChoice, this.network)) {
+        const peerHeadSlot = this.network.peerMetadata.getStatus(this.bestPeer)!.headSlot;
+        this.logger.info(`Regular Sync: Found best peer ${this.bestPeer.toB58String()}`, {
+          peerHeadSlot,
+          currentSlot: this.chain.clock.currentSlot,
+        });
+      } else {
+        // continue to find best peer
+        this.bestPeer = undefined;
+        await sleep(waitingTime, signal);
+      }
+    }
+  };
+}

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
@@ -41,8 +41,7 @@ export class ORARegularSync extends (EventEmitter as {new (): RegularSyncEventEm
     this.network = modules.network;
     this.chain = modules.chain;
     this.logger = modules.logger;
-    const headSlot = this.chain.forkChoice.getHead().slot;
-    this.fetcher = new BlockRangeFetcher(options, modules, headSlot, this.getSyncPeers.bind(this));
+    this.fetcher = new BlockRangeFetcher(options, modules, this.getSyncPeers.bind(this));
     this.blockBuffer = [];
   }
 
@@ -110,6 +109,7 @@ export class ORARegularSync extends (EventEmitter as {new (): RegularSyncEventEm
       this.logger.info("Regular Sync: wait for best peer");
       this.bestPeer = undefined;
       await this.waitForBestPeer(this.controller.signal);
+      if (this.controller.signal.aborted) return [];
     }
     return [this.bestPeer!];
   };

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
@@ -6,7 +6,7 @@ import {toHexString} from "@chainsafe/ssz";
 import {EventEmitter} from "events";
 import PeerId from "peer-id";
 import {IRegularSync, IRegularSyncOptions, RegularSyncEventEmitter} from "..";
-import {IBeaconChain} from "../../../chain";
+import {ChainEvent, IBeaconChain} from "../../../chain";
 import {INetwork} from "../../../network";
 import {GossipEvent} from "../../../network/gossip/constants";
 import {checkBestPeer, getBestPeer} from "../../utils";
@@ -58,7 +58,7 @@ export class ORARegularSync extends (EventEmitter as {new (): RegularSyncEventEm
     this.controller = new AbortController();
     await this.processor.start();
     this.network.gossip.subscribeToBlock(await this.chain.getForkDigest(), this.onGossipBlock);
-    this.chain.emitter.on("block", this.onProcessedBlock);
+    this.chain.emitter.on(ChainEvent.block, this.onProcessedBlock);
     this.sync().catch((e) => {
       this.logger.error("Regular Sync: error", e);
     });
@@ -70,7 +70,7 @@ export class ORARegularSync extends (EventEmitter as {new (): RegularSyncEventEm
     }
     await this.processor.stop();
     this.network.gossip.unsubscribe(await this.chain.getForkDigest(), GossipEvent.BLOCK, this.onGossipBlock);
-    this.chain.emitter.off("block", this.onProcessedBlock);
+    this.chain.emitter.off(ChainEvent.block, this.onProcessedBlock);
   }
 
   public setLastProcessedBlock(lastProcessedBlock: ISyncCheckpoint): void {

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
@@ -57,7 +57,7 @@ export class ORARegularSync extends (EventEmitter as {new (): RegularSyncEventEm
     this.logger.verbose(`Regular Sync: Current slot at start: ${currentSlot}`);
     this.controller = new AbortController();
     await this.processor.start();
-    this.network.gossip.subscribeToBlock(this.chain.currentForkDigest, this.onGossipBlock);
+    this.network.gossip.subscribeToBlock(await this.chain.getForkDigest(), this.onGossipBlock);
     this.chain.emitter.on("block", this.onProcessedBlock);
     this.sync().catch((e) => {
       this.logger.error("Regular Sync: error", e);
@@ -69,7 +69,7 @@ export class ORARegularSync extends (EventEmitter as {new (): RegularSyncEventEm
       this.controller.abort();
     }
     await this.processor.stop();
-    this.network.gossip.unsubscribe(this.chain.currentForkDigest, GossipEvent.BLOCK, this.onGossipBlock);
+    this.network.gossip.unsubscribe(await this.chain.getForkDigest(), GossipEvent.BLOCK, this.onGossipBlock);
     this.chain.emitter.off("block", this.onProcessedBlock);
   }
 

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
@@ -51,6 +51,7 @@ export class ORARegularSync extends (EventEmitter as {new (): RegularSyncEventEm
     await this.processor.start();
     this.network.gossip.subscribeToBlock(await this.chain.getForkDigest(), this.onGossipBlock);
     this.chain.emitter.on(ChainEvent.block, this.onProcessedBlock);
+    this.setLastProcessedBlock(this.chain.forkChoice.getHead());
     this.sync().catch((e) => {
       this.logger.error("Regular Sync: error", e);
     });

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
@@ -15,7 +15,7 @@ export class BlockRangeProcessor {
   private readonly chain: IBeaconChain;
   private readonly logger: ILogger;
   private target: {root: Root; resolve: Function; signal: AbortSignal} | null;
-  constructor(modules: IRegularSyncModules) {
+  constructor(modules: Pick<IRegularSyncModules, "config" | "chain" | "logger">) {
     this.config = modules.config;
     this.chain = modules.chain;
     this.logger = modules.logger;

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
@@ -6,11 +6,12 @@ import {IRegularSyncModules} from "..";
 import {IBeaconChain} from "../../../chain";
 import {BlockError, BlockErrorCode} from "../../../chain/errors";
 import {sortBlocks} from "../../utils";
+import {IBlockRangeProcessor} from "./interface";
 
 /**
  * Process a block range until complete.
  */
-export class BlockRangeProcessor {
+export class BlockRangeProcessor implements IBlockRangeProcessor {
   protected readonly config: IBeaconConfig;
   private readonly chain: IBeaconChain;
   private readonly logger: ILogger;

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
@@ -40,7 +40,7 @@ export class BlockRangeProcessor implements IBlockRangeProcessor {
     if (!blocks || !blocks.length) return;
     await new Promise((resolve) => {
       const sortedBlocks = sortBlocks(blocks);
-      this.logger.info("Imported blocks for slots: " + blocks.map((block) => block.message.slot).join(","));
+      this.logger.info("Imported blocks for slots: ", blocks.map((block) => block.message.slot).join(","));
       const lastRoot = this.config.types.BeaconBlock.hashTreeRoot(sortedBlocks[sortedBlocks.length - 1].message);
       this.target = {
         root: lastRoot,

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
@@ -1,39 +1,67 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {SignedBeaconBlock} from "@chainsafe/lodestar-types";
+import {Root, SignedBeaconBlock} from "@chainsafe/lodestar-types";
+import {ILogger} from "@chainsafe/lodestar-utils";
 import {AbortSignal} from "abort-controller";
+import {IRegularSyncModules} from "..";
 import {IBeaconChain} from "../../../chain";
 import {BlockError, BlockErrorCode} from "../../../chain/errors";
 import {sortBlocks} from "../../utils";
 
 /**
- * Process a block list until complete.
+ * Process a block range until complete.
  */
-export async function processUntilComplete(
-  config: IBeaconConfig,
-  chain: IBeaconChain,
-  blocks: SignedBeaconBlock[],
-  signal: AbortSignal
-): Promise<void> {
-  if (!blocks || !blocks.length) return;
-  const sortedBlocks = sortBlocks(blocks);
-  const lastRoot = config.types.BeaconBlock.hashTreeRoot(sortedBlocks[sortedBlocks.length - 1].message);
-  sortedBlocks.forEach((block) => chain.receiveBlock(block, false));
-  await new Promise((resolve) => {
-    const onProcessedBlock = (signedBlock: SignedBeaconBlock): void => {
-      if (signal.aborted) resolve();
-      const root = config.types.BeaconBlock.hashTreeRoot(signedBlock.message);
-      if (config.types.Root.equals(root, lastRoot)) {
-        chain.emitter.removeListener("block", onProcessedBlock);
-        chain.emitter.removeListener("error:block", onErrorBlock);
-        resolve();
-      }
-    };
-    const onErrorBlock = async (err: BlockError): Promise<void> => {
-      if (err.type.code === BlockErrorCode.ERR_BLOCK_IS_ALREADY_KNOWN) {
-        await onProcessedBlock(err.job.signedBlock);
-      }
-    };
-    chain.emitter.on("block", onProcessedBlock);
-    chain.emitter.on("error:block", onErrorBlock);
-  });
+export class BlockRangeProcessor {
+  protected readonly config: IBeaconConfig;
+  private readonly chain: IBeaconChain;
+  private readonly logger: ILogger;
+  private target: {root: Root; resolve: Function; signal: AbortSignal} | null;
+  constructor(modules: IRegularSyncModules) {
+    this.config = modules.config;
+    this.chain = modules.chain;
+    this.logger = modules.logger;
+    this.target = null;
+  }
+
+  public async start(): Promise<void> {
+    this.chain.emitter.on("block", this.onProcessedBlock);
+    this.chain.emitter.on("error:block", this.onErrorBlock);
+  }
+
+  public async stop(): Promise<void> {
+    this.chain.emitter.removeListener("block", this.onProcessedBlock);
+    this.chain.emitter.removeListener("error:block", this.onErrorBlock);
+  }
+
+  /**
+   * Main method.
+   */
+  public async processUntilComplete(blocks: SignedBeaconBlock[], signal: AbortSignal): Promise<void> {
+    if (!blocks || !blocks.length) return;
+    await new Promise((resolve) => {
+      const sortedBlocks = sortBlocks(blocks);
+      this.logger.info("Imported blocks for slots: " + blocks.map((block) => block.message.slot).join(","));
+      const lastRoot = this.config.types.BeaconBlock.hashTreeRoot(sortedBlocks[sortedBlocks.length - 1].message);
+      this.target = {
+        root: lastRoot,
+        resolve,
+        signal,
+      };
+      sortedBlocks.forEach((block) => this.chain.receiveBlock(block, false));
+    });
+  }
+
+  private onProcessedBlock = (signedBlock: SignedBeaconBlock): void => {
+    if (!this.target) return;
+    if (this.target.signal.aborted) this.target.resolve();
+    const root = this.config.types.BeaconBlock.hashTreeRoot(signedBlock.message);
+    if (this.config.types.Root.equals(root, this.target.root)) {
+      this.target.resolve();
+    }
+  };
+
+  private onErrorBlock = async (err: BlockError): Promise<void> => {
+    if (err.type.code === BlockErrorCode.ERR_BLOCK_IS_ALREADY_KNOWN) {
+      await this.onProcessedBlock(err.job.signedBlock);
+    }
+  };
 }

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
@@ -1,0 +1,43 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {SignedBeaconBlock} from "@chainsafe/lodestar-types";
+import {AbortSignal} from "abort-controller";
+import {IBeaconChain} from "../../../chain";
+import {BlockError, BlockErrorCode} from "../../../chain/errors";
+import {sortBlocks} from "../../utils";
+
+/**
+ * Process a block list until complete.
+ */
+export async function processUntilComplete(
+  config: IBeaconConfig,
+  chain: IBeaconChain,
+  blocks: SignedBeaconBlock[],
+  signal: AbortSignal
+): Promise<void> {
+  if (!blocks || !blocks.length) return;
+  const sortedBlocks = sortBlocks(blocks);
+  const lastRoot = config.types.BeaconBlock.hashTreeRoot(sortedBlocks[sortedBlocks.length - 1].message);
+  sortedBlocks.forEach((block) => chain.receiveBlock(block, false));
+  await new Promise((resolve) => {
+    const onProcessedBlock = (signedBlock: SignedBeaconBlock): void => {
+      if (signal.aborted) resolve();
+      const root = config.types.BeaconBlock.hashTreeRoot(signedBlock.message);
+      if (config.types.Root.equals(root, lastRoot)) {
+        chain.emitter.removeListener("block", onProcessedBlock);
+        cleanUp();
+        resolve();
+      }
+    };
+    const onErrorBlock = async (err: BlockError): Promise<void> => {
+      if (err.type.code === BlockErrorCode.ERR_BLOCK_IS_ALREADY_KNOWN) {
+        await onProcessedBlock(err.job.signedBlock);
+      }
+    };
+    const cleanUp = (): void => {
+      chain.emitter.removeListener("block", onProcessedBlock);
+      chain.emitter.removeListener("error:block", onErrorBlock);
+    };
+    chain.emitter.on("block", onProcessedBlock);
+    chain.emitter.on("error:block", onErrorBlock);
+  });
+}

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
@@ -3,7 +3,7 @@ import {Root, SignedBeaconBlock} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {AbortSignal} from "abort-controller";
 import {IRegularSyncModules} from "..";
-import {IBeaconChain} from "../../../chain";
+import {ChainEvent, IBeaconChain} from "../../../chain";
 import {BlockError, BlockErrorCode} from "../../../chain/errors";
 import {sortBlocks} from "../../utils";
 import {IBlockRangeProcessor} from "./interface";
@@ -24,13 +24,13 @@ export class BlockRangeProcessor implements IBlockRangeProcessor {
   }
 
   public async start(): Promise<void> {
-    this.chain.emitter.on("block", this.onProcessedBlock);
-    this.chain.emitter.on("error:block", this.onErrorBlock);
+    this.chain.emitter.on(ChainEvent.block, this.onProcessedBlock);
+    this.chain.emitter.on(ChainEvent.errorBlock, this.onErrorBlock);
   }
 
   public async stop(): Promise<void> {
-    this.chain.emitter.removeListener("block", this.onProcessedBlock);
-    this.chain.emitter.removeListener("error:block", this.onErrorBlock);
+    this.chain.emitter.removeListener(ChainEvent.block, this.onProcessedBlock);
+    this.chain.emitter.removeListener(ChainEvent.errorBlock, this.onErrorBlock);
   }
 
   /**

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
@@ -24,7 +24,7 @@ export async function processUntilComplete(
       const root = config.types.BeaconBlock.hashTreeRoot(signedBlock.message);
       if (config.types.Root.equals(root, lastRoot)) {
         chain.emitter.removeListener("block", onProcessedBlock);
-        cleanUp();
+        chain.emitter.removeListener("error:block", onErrorBlock);
         resolve();
       }
     };
@@ -32,10 +32,6 @@ export async function processUntilComplete(
       if (err.type.code === BlockErrorCode.ERR_BLOCK_IS_ALREADY_KNOWN) {
         await onProcessedBlock(err.job.signedBlock);
       }
-    };
-    const cleanUp = (): void => {
-      chain.emitter.removeListener("block", onProcessedBlock);
-      chain.emitter.removeListener("error:block", onErrorBlock);
     };
     chain.emitter.on("block", onProcessedBlock);
     chain.emitter.on("error:block", onErrorBlock);

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -11,10 +11,10 @@ import {BeaconReqRespHandler, IReqRespHandler} from "./reqResp";
 import {BeaconGossipHandler, IGossipHandler} from "./gossip";
 import {AttestationCollector, createStatus, RoundRobinArray, syncPeersStatus} from "./utils";
 import {ChainEvent, IBeaconChain} from "../chain";
-import {NaiveRegularSync} from "./regular/naive";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {List, toHexString} from "@chainsafe/ssz";
 import {BlockError, BlockErrorCode} from "../chain/errors";
+import {ORARegularSync} from "./regular/oneRangeAhead/oneRangeAhead";
 
 export enum SyncMode {
   WAITING_PEERS,
@@ -50,7 +50,7 @@ export class BeaconSync implements IBeaconSync {
     this.chain = modules.chain;
     this.logger = modules.logger;
     this.initialSync = modules.initialSync || new FastSync(opts, modules);
-    this.regularSync = modules.regularSync || new NaiveRegularSync(opts, modules);
+    this.regularSync = modules.regularSync || new ORARegularSync(opts, modules);
     this.reqResp = modules.reqRespHandler || new BeaconReqRespHandler(modules);
     this.gossip =
       modules.gossipHandler || new BeaconGossipHandler(modules.chain, modules.network, modules.db, this.logger);

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
@@ -51,7 +51,7 @@ describe("BlockRangeFetcher", function () {
     fetcher.setLastProcessedBlock({blockRoot: ZERO_HASH, slot: 1000});
     getCurrentSlotStub.returns(2000);
     getBlockRangeStub.resolves([generateEmptySignedBlock()]);
-    await fetcher.next();
+    await fetcher.getNextBlockRange();
     expect(getBlockRangeStub.calledOnceWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1065}));
   });
 
@@ -66,9 +66,9 @@ describe("BlockRangeFetcher", function () {
     const secondBlock = generateEmptySignedBlock();
     secondBlock.message.slot = 1020;
     getBlockRangeStub.onSecondCall().resolves([secondBlock]);
-    await fetcher.next();
+    await fetcher.getNextBlockRange();
     expect(getBlockRangeStub.calledOnceWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1065}));
-    await fetcher.next();
+    await fetcher.getNextBlockRange();
     expect(getBlockRangeStub.lastCall.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1011, end: 1075}));
   });
 
@@ -79,7 +79,7 @@ describe("BlockRangeFetcher", function () {
     const firstBlock = generateEmptySignedBlock();
     firstBlock.message.slot = 1010;
     getBlockRangeStub.onSecondCall().resolves([firstBlock]);
-    await fetcher.next();
+    await fetcher.getNextBlockRange();
     expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1065}));
     expect(getBlockRangeStub.calledTwice).to.be.true;
   });
@@ -91,7 +91,7 @@ describe("BlockRangeFetcher", function () {
     const firstBlock = generateEmptySignedBlock();
     firstBlock.message.slot = 1010;
     getBlockRangeStub.onSecondCall().resolves([firstBlock]);
-    await fetcher.next();
+    await fetcher.getNextBlockRange();
     expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1065}));
     expect(getBlockRangeStub.calledTwice).to.be.true;
   });
@@ -104,7 +104,7 @@ describe("BlockRangeFetcher", function () {
     const firstBlock = generateEmptySignedBlock();
     firstBlock.message.slot = 1010;
     getBlockRangeStub.onSecondCall().resolves([firstBlock]);
-    await fetcher.next();
+    await fetcher.getNextBlockRange();
     expect(getBlockRangeStub.calledOnceWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1065}));
     // same start, expand end
     expect(getBlockRangeStub.calledOnceWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1129}));

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
@@ -1,4 +1,3 @@
-
 import {expect} from "chai";
 import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
@@ -32,12 +31,16 @@ describe("BlockRangeFetcher", function () {
     clockStub = sinon.createStubInstance(LocalClock);
     chainStub.clock = clockStub;
     networkStub = sinon.createStubInstance(Libp2pNetwork);
-    fetcher = new BlockRangeFetcher({}, {
-      config,
-      network: networkStub,
-      chain: chainStub,
-      logger,
-    }, getPeers);
+    fetcher = new BlockRangeFetcher(
+      {},
+      {
+        config,
+        network: networkStub,
+        chain: chainStub,
+        logger,
+      },
+      getPeers
+    );
   });
 
   afterEach(() => {

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
@@ -1,0 +1,110 @@
+
+import {expect} from "chai";
+import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {BlockRangeFetcher} from "../../../../../src/sync/regular/oneRangeAhead/fetcher";
+import {BeaconChain, IBeaconChain} from "../../../../../src/chain";
+import {INetwork, Libp2pNetwork} from "../../../../../src/network";
+import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import PeerId from "peer-id";
+import * as blockUtils from "../../../../../src/sync/utils/blocks";
+import * as slotUtils from "@chainsafe/lodestar-beacon-state-transition/lib/util/slot";
+import {ZERO_HASH} from "../../../../../src/constants";
+import {IBeaconClock, LocalClock} from "../../../../../src/chain/clock";
+import {generateEmptySignedBlock} from "../../../../utils/block";
+
+describe("BlockRangeFetcher", function () {
+  let fetcher: BlockRangeFetcher;
+  let chainStub: SinonStubbedInstance<IBeaconChain>;
+  let clockStub: SinonStubbedInstance<IBeaconClock>;
+  let networkStub: SinonStubbedInstance<INetwork>;
+  let getBlockRangeStub: SinonStub;
+  let getCurrentSlotStub: SinonStub;
+  const getPeers = async (): Promise<PeerId[]> => {
+    return [await PeerId.create()];
+  };
+  const logger = new WinstonLogger();
+
+  beforeEach(() => {
+    getBlockRangeStub = sinon.stub(blockUtils, "getBlockRange");
+    getCurrentSlotStub = sinon.stub(slotUtils, "getCurrentSlot");
+    chainStub = sinon.createStubInstance(BeaconChain);
+    clockStub = sinon.createStubInstance(LocalClock);
+    chainStub.clock = clockStub;
+    networkStub = sinon.createStubInstance(Libp2pNetwork);
+    fetcher = new BlockRangeFetcher({}, {
+      config,
+      network: networkStub,
+      chain: chainStub,
+      logger,
+    }, getPeers);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should fetch next range initially", async () => {
+    fetcher.setLastProcessedBlock({blockRoot: ZERO_HASH, slot: 1000});
+    getCurrentSlotStub.returns(2000);
+    getBlockRangeStub.resolves([generateEmptySignedBlock()]);
+    await fetcher.next();
+    expect(getBlockRangeStub.calledOnceWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1065}));
+  });
+
+  it("should fetch next range based on last fetch block", async () => {
+    // handle the case when peer does not return all blocks
+    // next fetch should start from last fetch block
+    fetcher.setLastProcessedBlock({blockRoot: ZERO_HASH, slot: 1000});
+    getCurrentSlotStub.returns(2000);
+    const firstBlock = generateEmptySignedBlock();
+    firstBlock.message.slot = 1010;
+    getBlockRangeStub.onFirstCall().resolves([firstBlock]);
+    const secondBlock = generateEmptySignedBlock();
+    secondBlock.message.slot = 1020;
+    getBlockRangeStub.onSecondCall().resolves([secondBlock]);
+    await fetcher.next();
+    expect(getBlockRangeStub.calledOnceWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1065}));
+    await fetcher.next();
+    expect(getBlockRangeStub.lastCall.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1011, end: 1075}));
+  });
+
+  it("should handle getBlockRange error", async () => {
+    fetcher.setLastProcessedBlock({blockRoot: ZERO_HASH, slot: 1000});
+    getCurrentSlotStub.returns(2000);
+    getBlockRangeStub.onFirstCall().throws("");
+    const firstBlock = generateEmptySignedBlock();
+    firstBlock.message.slot = 1010;
+    getBlockRangeStub.onSecondCall().resolves([firstBlock]);
+    await fetcher.next();
+    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1065}));
+    expect(getBlockRangeStub.calledTwice).to.be.true;
+  });
+
+  it("should handle getBlockRange returning null", async () => {
+    fetcher.setLastProcessedBlock({blockRoot: ZERO_HASH, slot: 1000});
+    getCurrentSlotStub.returns(2000);
+    getBlockRangeStub.onFirstCall().resolves(null);
+    const firstBlock = generateEmptySignedBlock();
+    firstBlock.message.slot = 1010;
+    getBlockRangeStub.onSecondCall().resolves([firstBlock]);
+    await fetcher.next();
+    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1065}));
+    expect(getBlockRangeStub.calledTwice).to.be.true;
+  });
+
+  it("should handle getBlockRange returning no block", async () => {
+    // fetcher should not trust a getBlockRange returning empty array using handleEmptyRange
+    fetcher.setLastProcessedBlock({blockRoot: ZERO_HASH, slot: 1000});
+    getCurrentSlotStub.returns(2000);
+    getBlockRangeStub.onFirstCall().resolves([]);
+    const firstBlock = generateEmptySignedBlock();
+    firstBlock.message.slot = 1010;
+    getBlockRangeStub.onSecondCall().resolves([firstBlock]);
+    await fetcher.next();
+    expect(getBlockRangeStub.calledOnceWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1065}));
+    // same start, expand end
+    expect(getBlockRangeStub.calledOnceWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1129}));
+    expect(getBlockRangeStub.calledTwice).to.be.true;
+  });
+});

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/oneRangeAhead.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/oneRangeAhead.test.ts
@@ -1,0 +1,102 @@
+import {SinonStub, SinonStubbedInstance} from "sinon";
+import {ORARegularSync} from "../../../../../src/sync/regular/oneRangeAhead/oneRangeAhead";
+import {IBlockRangeFetcher, IBlockRangeProcessor} from "../../../../../src/sync/regular/oneRangeAhead/interface";
+import {BlockRangeFetcher} from "../../../../../src/sync/regular/oneRangeAhead/fetcher";
+import sinon from "sinon";
+import {BlockRangeProcessor} from "../../../../../src/sync/regular/oneRangeAhead/processor";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import {BeaconChain, ForkChoice, IBeaconChain} from "../../../../../src/chain";
+import {INetwork, Libp2pNetwork} from "../../../../../src/network";
+import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {generateBlockSummary, generateEmptySignedBlock} from "../../../../utils/block";
+import {expect} from "chai";
+import {IGossip} from "../../../../../src/network/gossip/interface";
+import {Gossip} from "../../../../../src/network/gossip/gossip";
+import {IBeaconClock, LocalClock} from "../../../../../src/chain/clock";
+import * as slotUtils from "@chainsafe/lodestar-beacon-state-transition/lib/util/slot";
+import {sleep} from "@chainsafe/lodestar-cli/src/util";
+import {SignedBeaconBlock} from "@chainsafe/lodestar-types";
+import {AbortSignal} from "abort-controller";
+
+describe("ORARegularSync", function () {
+  let sync: ORARegularSync;
+  let fetcherStub: SinonStubbedInstance<IBlockRangeFetcher>;
+  // let fetcherStub: IBlockRangeFetcher;
+  let processorStub: SinonStubbedInstance<IBlockRangeProcessor>;
+  let chainStub: SinonStubbedInstance<IBeaconChain>;
+  let clockStub: SinonStubbedInstance<IBeaconClock>;
+  let forkChoiceStub: SinonStubbedInstance<ForkChoice>;
+  let networkStub: SinonStubbedInstance<INetwork>;
+  let gossipStub: SinonStubbedInstance<IGossip>;
+  let getCurrentSlotStub: SinonStub;
+  const logger = new WinstonLogger({module: "ORARegularSync"});
+
+  beforeEach(() => {
+    forkChoiceStub = sinon.createStubInstance(ForkChoice);
+    chainStub = sinon.createStubInstance(BeaconChain);
+    chainStub.forkChoice = forkChoiceStub;
+    clockStub = sinon.createStubInstance(LocalClock);
+    chainStub.clock = clockStub;
+    networkStub = sinon.createStubInstance(Libp2pNetwork);
+    gossipStub = sinon.createStubInstance(Gossip);
+    networkStub.gossip = gossipStub;
+    fetcherStub = sinon.createStubInstance(BlockRangeFetcher);
+    processorStub = sinon.createStubInstance(BlockRangeProcessor);
+    sync = new ORARegularSync(
+      {},
+      {
+        chain: chainStub,
+        network: networkStub,
+        logger,
+        config,
+        fetcher: fetcherStub,
+        processor: processorStub,
+      }
+    );
+    getCurrentSlotStub = sinon.stub(slotUtils, "getCurrentSlot");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should call fetcher.next and processor.processUntilComplete upon start", async () => {
+    forkChoiceStub.getHead.returns(generateBlockSummary({slot: 1000}));
+    let slot = 1000;
+    fetcherStub.next.callsFake(
+      async (): Promise<SignedBeaconBlock[]> => {
+        await sleep(200);
+        logger.info("Fetched slot " + slot);
+        const block = generateEmptySignedBlock();
+        block.message.slot = slot++;
+        return [block];
+      }
+    );
+    processorStub.processUntilComplete.callsFake(
+      async (blocks: SignedBeaconBlock[], signal: AbortSignal): Promise<void> => {
+        if (!signal.aborted) {
+          await sleep(200);
+          logger.info("Processed until slot " + blocks[blocks.length - 1].message.slot);
+        }
+      }
+    );
+    getCurrentSlotStub.returns(2000);
+    await Promise.all([
+      new Promise((resolve) => {
+        setTimeout(async () => {
+          logger.info("Stopping from unit test...");
+          await sync.stop();
+          // one more round
+          await sleep(200);
+          resolve();
+        }, 1000);
+      }),
+      sync.start(),
+    ]);
+    const fetchCount = fetcherStub.next.callCount;
+    const processCount = processorStub.processUntilComplete.callCount;
+    expect(fetchCount).to.be.greaterThan(1);
+    expect(processCount).to.be.greaterThan(1);
+    expect(fetchCount).to.be.equal(processCount + 1);
+  });
+});

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/oneRangeAhead.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/oneRangeAhead.test.ts
@@ -64,7 +64,7 @@ describe("ORARegularSync", function () {
   it("should call fetcher.next and processor.processUntilComplete upon start", async () => {
     forkChoiceStub.getHead.returns(generateBlockSummary({slot: 1000}));
     let slot = 1000;
-    fetcherStub.next.callsFake(
+    fetcherStub.getNextBlockRange.callsFake(
       async (): Promise<SignedBeaconBlock[]> => {
         await sleep(200);
         logger.info("Fetched slot " + slot);
@@ -94,7 +94,7 @@ describe("ORARegularSync", function () {
       }),
       sync.start(),
     ]);
-    const fetchCount = fetcherStub.next.callCount;
+    const fetchCount = fetcherStub.getNextBlockRange.callCount;
     const processCount = processorStub.processUntilComplete.callCount;
     expect(fetchCount).to.be.greaterThan(1);
     expect(processCount).to.be.greaterThan(1);

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/oneRangeAhead.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/oneRangeAhead.test.ts
@@ -5,7 +5,7 @@ import {BlockRangeFetcher} from "../../../../../src/sync/regular/oneRangeAhead/f
 import sinon from "sinon";
 import {BlockRangeProcessor} from "../../../../../src/sync/regular/oneRangeAhead/processor";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
-import {BeaconChain, ForkChoice, IBeaconChain} from "../../../../../src/chain";
+import {BeaconChain, ChainEventEmitter, ForkChoice, IBeaconChain} from "../../../../../src/chain";
 import {INetwork, Libp2pNetwork} from "../../../../../src/network";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {generateBlockSummary, generateEmptySignedBlock} from "../../../../utils/block";
@@ -35,6 +35,7 @@ describe("ORARegularSync", function () {
     forkChoiceStub = sinon.createStubInstance(ForkChoice);
     chainStub = sinon.createStubInstance(BeaconChain);
     chainStub.forkChoice = forkChoiceStub;
+    chainStub.emitter = new ChainEventEmitter();
     clockStub = sinon.createStubInstance(LocalClock);
     chainStub.clock = clockStub;
     networkStub = sinon.createStubInstance(Libp2pNetwork);

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/processor.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/processor.test.ts
@@ -1,0 +1,53 @@
+import {SinonStubbedInstance} from "sinon";
+import {BlockRangeProcessor} from "../../../../../src/sync/regular/oneRangeAhead/processor";
+import {BeaconChain, ChainEventEmitter, IBeaconChain, IBlockJob} from "../../../../../src/chain";
+import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
+import sinon from "sinon";
+import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {generateEmptySignedBlock} from "../../../../utils/block";
+import {AbortController} from "abort-controller";
+import {ITreeStateContext} from "../../../../../src/db/api/beacon/stateContextCache";
+import {BlockError, BlockErrorCode} from "../../../../../src/chain/errors";
+
+describe("BlockRangeProcessor", function () {
+  let processor: BlockRangeProcessor;
+  let chainStub: SinonStubbedInstance<IBeaconChain>;
+  const logger = new WinstonLogger();
+  const firstBlock = generateEmptySignedBlock();
+  firstBlock.message.slot = 1010;
+  const secondBlock = generateEmptySignedBlock();
+  secondBlock.message.slot = 1020;
+  const abortController = new AbortController();
+
+  beforeEach(async () => {
+    chainStub = sinon.createStubInstance(BeaconChain);
+    chainStub.emitter = new ChainEventEmitter();
+    processor = new BlockRangeProcessor({
+      config,
+      chain: chainStub,
+      logger,
+    });
+    await processor.start();
+  });
+
+  afterEach(async () => {
+    await processor.stop();
+    sinon.restore();
+  });
+
+  it("should process blocks based on block event", async () => {
+    await Promise.all([
+      processor.processUntilComplete([firstBlock, secondBlock], abortController.signal),
+      chainStub.emitter.emit("block", secondBlock, {} as ITreeStateContext, {} as IBlockJob),
+    ]);
+  });
+
+  it("should process blocks based on block:error ERR_BLOCK_IS_ALREADY_KNOWN event", async () => {
+    await Promise.all([
+      processor.processUntilComplete([firstBlock, secondBlock], abortController.signal),
+      chainStub.emitter.emit("error:block", new BlockError({
+        job: {signedBlock: secondBlock} as IBlockJob,
+        code: BlockErrorCode.ERR_BLOCK_IS_ALREADY_KNOWN})),
+    ]);
+  });
+});

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/processor.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/processor.test.ts
@@ -45,9 +45,13 @@ describe("BlockRangeProcessor", function () {
   it("should process blocks based on block:error ERR_BLOCK_IS_ALREADY_KNOWN event", async () => {
     await Promise.all([
       processor.processUntilComplete([firstBlock, secondBlock], abortController.signal),
-      chainStub.emitter.emit("error:block", new BlockError({
-        job: {signedBlock: secondBlock} as IBlockJob,
-        code: BlockErrorCode.ERR_BLOCK_IS_ALREADY_KNOWN})),
+      chainStub.emitter.emit(
+        "error:block",
+        new BlockError({
+          job: {signedBlock: secondBlock} as IBlockJob,
+          code: BlockErrorCode.ERR_BLOCK_IS_ALREADY_KNOWN,
+        })
+      ),
     ]);
   });
 });

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/processor.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/processor.test.ts
@@ -1,6 +1,6 @@
 import {SinonStubbedInstance} from "sinon";
 import {BlockRangeProcessor} from "../../../../../src/sync/regular/oneRangeAhead/processor";
-import {BeaconChain, ChainEventEmitter, IBeaconChain, IBlockJob} from "../../../../../src/chain";
+import {BeaconChain, ChainEvent, ChainEventEmitter, IBeaconChain, IBlockJob} from "../../../../../src/chain";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import sinon from "sinon";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
@@ -38,7 +38,7 @@ describe("BlockRangeProcessor", function () {
   it("should process blocks based on block event", async () => {
     await Promise.all([
       processor.processUntilComplete([firstBlock, secondBlock], abortController.signal),
-      chainStub.emitter.emit("block", secondBlock, {} as ITreeStateContext, {} as IBlockJob),
+      chainStub.emitter.emit(ChainEvent.block, secondBlock, {} as ITreeStateContext, {} as IBlockJob),
     ]);
   });
 
@@ -46,7 +46,7 @@ describe("BlockRangeProcessor", function () {
     await Promise.all([
       processor.processUntilComplete([firstBlock, secondBlock], abortController.signal),
       chainStub.emitter.emit(
-        "error:block",
+        ChainEvent.errorBlock,
         new BlockError({
           job: {signedBlock: secondBlock} as IBlockJob,
           code: BlockErrorCode.ERR_BLOCK_IS_ALREADY_KNOWN,


### PR DESCRIPTION
resolves #1676 

At this time, we need to catch up with ~40000 slots in order to sync to head.

I intended to improve our naive strategy but it was too much change so decided to come up with a new one. Naive was good to start with anyway and we leave it there for backward reference.
+ In term of strategy, the difference is we fetch and process block range at the same time. We do this by fetch one range ahead and buffer it. It's like `Promise.all([fetcher.next(), processor.processUntilComplete())`
+ I separate the fetch to a fetcher - `BlockRangeFetcher` and processor to `BlockRangeProcessor`. The main sync class `ORARegularSync` acts as a controller.
+ It's easier to do unit test for each of them and maintain, I reproduced cases I got in the past in unit tests
+ Performance should be better since we either `fetch` or `process` in naive, now we do both at the same time

I tried syncing a couple of times and felt good about it. Not able to sync up to head (25000 max) bc of different issues:
+ Forkchoice getCanonicalBlockAtSlot()
+ Not enough sync peers
+ Sometimes network req/res still timeout