### PR TITLE
Remove cached fork digest in BeaconChain

### DIFF
--- a/packages/lodestar/src/chain/emitter.ts
+++ b/packages/lodestar/src/chain/emitter.ts
@@ -5,21 +5,38 @@ import {
   Attestation,
   Checkpoint,
   Epoch,
-  ForkDigest,
   Root,
   SignedBeaconBlock,
   SignedVoluntaryExit,
   Slot,
+  Version,
 } from "@chainsafe/lodestar-types";
 import {IBlockSummary} from "@chainsafe/lodestar-fork-choice";
 import {ITreeStateContext} from "../db/api/beacon/stateContextCache";
 import {IBlockJob} from "./interface";
 import {AttestationError, BlockError} from "./errors";
 
+export enum ChainEvent {
+  attestation = "attestation",
+  block = "block",
+  checkpoint = "checkpoint",
+  justified = "justified",
+  finalized = "finalized",
+  voluntaryExit = "voluntaryExit",
+  forkDigest = "forkDigest",
+  clockSlot = "clock:slot",
+  clockEpoch = "clock:epoch",
+  errorBlock = "error:block",
+  errorAttestation = "error:attestation",
+  forkChoiceHead = "forkChoice:head",
+  forkChoiceReorg = "forkChoice:reorg",
+  forkChoiceJustified = "forkChoice:justified",
+  forkChoiceFinalized = "forkChoice:finalized",
+}
+
 export interface IChainEvents {
   // old, to be deprecated
   unknownBlockRoot: (root: Root) => void;
-  forkVersion: () => void;
 
   // new
   attestation: (attestation: Attestation) => void;
@@ -28,7 +45,7 @@ export interface IChainEvents {
   justified: (checkpoint: Checkpoint, stateContext: ITreeStateContext) => void;
   finalized: (checkpoint: Checkpoint, stateContext: ITreeStateContext) => void;
   voluntaryExit: (exit: SignedVoluntaryExit) => void;
-  forkDigest: (forkDigest: ForkDigest) => void;
+  forkVersion: (version: Version) => void;
 
   "clock:slot": (slot: Slot) => void;
   "clock:epoch": (epoch: Epoch) => void;

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -1,5 +1,5 @@
 import {readOnlyMap, toHexString} from "@chainsafe/ssz";
-import {Attestation, Checkpoint, SignedBeaconBlock, Slot} from "@chainsafe/lodestar-types";
+import {Attestation, Checkpoint, SignedBeaconBlock, Slot, Version} from "@chainsafe/lodestar-types";
 import {ILogger, toJson} from "@chainsafe/lodestar-utils";
 import {IBlockSummary} from "@chainsafe/lodestar-fork-choice";
 
@@ -111,9 +111,8 @@ export async function onClockSlot(this: BeaconChain, slot: Slot): Promise<void> 
   );
 }
 
-export async function onForkVersion(this: BeaconChain): Promise<void> {
-  this._currentForkDigest = await this.getCurrentForkDigest();
-  this.internalEmitter.emit("forkDigest", this._currentForkDigest);
+export async function onForkVersion(this: BeaconChain, version: Version): Promise<void> {
+  this.logger.verbose("New fork version", this.config.types.Version.toJson(version));
 }
 
 export async function onCheckpoint(this: BeaconChain, cp: Checkpoint, stateContext: ITreeStateContext): Promise<void> {

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -45,7 +45,6 @@ export interface IBeaconChain {
   clock: IBeaconClock;
   chainId: Uint16;
   networkId: Uint64;
-  currentForkDigest: ForkDigest;
   /**
    * Start beacon chain processing
    */
@@ -57,7 +56,11 @@ export interface IBeaconChain {
   stop(): Promise<void>;
 
   /**
-   * Return ENRForkID.
+   * Get ForkDigest from the head state
+   */
+  getForkDigest(): Promise<ForkDigest>;
+  /**
+   * Get ENRForkID from the head state
    */
   getENRForkID(): Promise<ENRForkID>;
   getGenesisTime(): Number64;

--- a/packages/lodestar/src/network/gossip/gossip.ts
+++ b/packages/lodestar/src/network/gossip/gossip.ts
@@ -65,9 +65,10 @@ export class Gossip extends (EventEmitter as {new (): GossipEventEmitter}) imple
 
   public async start(): Promise<void> {
     await this.pubsub.start();
-    this.pubsub.registerLibp2pTopicValidators(this.chain.currentForkDigest);
-    this.registerHandlers(this.chain.currentForkDigest);
-    this.chain.emitter.on("forkDigest", this.handleForkDigest);
+    const forkDigest = await this.chain.getForkDigest();
+    this.pubsub.registerLibp2pTopicValidators(forkDigest);
+    this.registerHandlers(forkDigest);
+    this.chain.emitter.on("forkVersion", this.handleForkVersion);
     this.emit("gossip:start");
     this.logger.verbose("Gossip is started");
     this.statusInterval = setInterval(this.logSubscriptions, 60000);
@@ -76,7 +77,7 @@ export class Gossip extends (EventEmitter as {new (): GossipEventEmitter}) imple
   public async stop(): Promise<void> {
     this.emit("gossip:stop");
     this.unregisterHandlers();
-    this.chain.emitter.removeListener("forkDigest", this.handleForkDigest);
+    this.chain.emitter.removeListener("forkVersion", this.handleForkVersion);
     await this.pubsub.stop();
     if (this.statusInterval) {
       clearInterval(this.statusInterval);
@@ -191,9 +192,10 @@ export class Gossip extends (EventEmitter as {new (): GossipEventEmitter}) imple
     }
   }
 
-  private handleForkDigest = async (forkDigest: ForkDigest): Promise<void> => {
+  private handleForkVersion = async (): Promise<void> => {
+    const forkDigest = await this.chain.getForkDigest();
     this.logger.important(`Gossip: received new fork digest ${toHexString(forkDigest)}`);
-    this.pubsub.registerLibp2pTopicValidators(this.chain.currentForkDigest);
+    this.pubsub.registerLibp2pTopicValidators(forkDigest);
     this.unregisterHandlers();
     this.registerHandlers(forkDigest);
   };

--- a/packages/lodestar/src/network/metadata/metadata.ts
+++ b/packages/lodestar/src/network/metadata/metadata.ts
@@ -1,6 +1,6 @@
 import {BitVector, toHexString} from "@chainsafe/ssz";
 import {ENR} from "@chainsafe/discv5";
-import {Metadata, ForkDigest} from "@chainsafe/lodestar-types";
+import {Metadata} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBeaconChain} from "../../chain";
 import {ILogger} from "@chainsafe/lodestar-utils";
@@ -35,11 +35,11 @@ export class MetadataController {
       this.enr.set("attnets", Buffer.from(this.config.types.AttestationSubnets.serialize(this._metadata.attnets)));
       this.enr.set("eth2", Buffer.from(this.config.types.ENRForkID.serialize(await this.chain.getENRForkID())));
     }
-    this.chain.emitter.on("forkDigest", this.handleForkDigest);
+    this.chain.emitter.on("forkVersion", this.handleForkVersion);
   }
 
   public async stop(): Promise<void> {
-    this.chain.emitter.removeListener("forkDigest", this.handleForkDigest);
+    this.chain.emitter.removeListener("forkVersion", this.handleForkVersion);
   }
 
   get seqNumber(): bigint {
@@ -62,7 +62,8 @@ export class MetadataController {
     return this._metadata;
   }
 
-  private async handleForkDigest(forkDigest: ForkDigest): Promise<void> {
+  private async handleForkVersion(): Promise<void> {
+    const forkDigest = await this.chain.getForkDigest();
     this.logger.important(`Metadata: received new fork digest ${toHexString(forkDigest)}`);
     if (this.enr) {
       this.enr.set("eth2", Buffer.from(this.config.types.ENRForkID.serialize(await this.chain.getENRForkID())));

--- a/packages/lodestar/src/sync/gossip/handler.ts
+++ b/packages/lodestar/src/sync/gossip/handler.ts
@@ -29,17 +29,18 @@ export class BeaconGossipHandler implements IGossipHandler {
   }
 
   public async start(): Promise<void> {
-    this.currentForkDigest = this.chain.currentForkDigest;
+    this.currentForkDigest = await this.chain.getForkDigest();
     this.subscribe(this.currentForkDigest);
-    this.chain.emitter.on("forkDigest", this.handleForkDigest);
+    this.chain.emitter.on("forkVersion", this.handleForkVersion);
   }
 
   public async stop(): Promise<void> {
     this.unsubscribe(this.currentForkDigest);
-    this.chain.emitter.removeListener("forkDigest", this.handleForkDigest);
+    this.chain.emitter.removeListener("forkVersion", this.handleForkVersion);
   }
 
-  private handleForkDigest = async (forkDigest: ForkDigest): Promise<void> => {
+  private handleForkVersion = async (): Promise<void> => {
+    const forkDigest = await this.chain.getForkDigest();
     this.logger.important(`Gossip handler: received new fork digest ${toHexString(forkDigest)}`);
     this.unsubscribe(this.currentForkDigest);
     this.currentForkDigest = forkDigest;

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -73,7 +73,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
     await this.waitForBestPeer(this.controller.signal);
     const newTarget = this.getNewTarget();
     this.logger.info("Regular Sync: Setting target", {newTargetSlot: newTarget});
-    this.network.gossip.subscribeToBlock(this.chain.currentForkDigest, this.onGossipBlock);
+    this.network.gossip.subscribeToBlock(await this.chain.getForkDigest(), this.onGossipBlock);
     // to avoid listening for "block" event from initial sync, only listen for "block" event of regular sync from here
     this.chain.emitter.on("block", this.onProcessedBlock);
     await Promise.all([this.sync(), this.setTarget()]);
@@ -85,7 +85,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
       this.controller.abort();
     }
     this.chain.emitter.removeListener("block", this.onProcessedBlock);
-    this.network.gossip.unsubscribe(this.chain.currentForkDigest, GossipEvent.BLOCK, this.onGossipBlock);
+    this.network.gossip.unsubscribe(await this.chain.getForkDigest(), GossipEvent.BLOCK, this.onGossipBlock);
   }
 
   public getHighestBlock(): Slot {

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -123,7 +123,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
   }
 
   public async shouldDisconnectOnStatus(request: Status): Promise<boolean> {
-    const currentForkDigest = this.chain.currentForkDigest;
+    const currentForkDigest = await this.chain.getForkDigest();
     if (!this.config.types.ForkDigest.equals(currentForkDigest, request.forkDigest)) {
       this.logger.verbose(
         "Fork digest mismatch " +
@@ -268,7 +268,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
 
   private handshake = async (peerId: PeerId, direction: "inbound" | "outbound"): Promise<void> => {
     if (direction === "outbound") {
-      const request = createStatus(this.chain);
+      const request = await createStatus(this.chain);
       try {
         this.network.peerMetadata.setStatus(peerId, await this.network.reqResp.status(peerId, request));
       } catch (e) {

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -160,10 +160,12 @@ export class BeaconSync implements IBeaconSync {
 
   private startSyncTimer(interval: number): void {
     this.stopSyncTimer();
-    this.statusSyncTimer = setInterval(() => {
-      syncPeersStatus(this.network, createStatus(this.chain)).catch((e) => {
+    this.statusSyncTimer = setInterval(async () => {
+      try {
+        await syncPeersStatus(this.network, await createStatus(this.chain));
+      } catch (e) {
         this.logger.error("Error on syncPeersStatus", e);
-      });
+      }
     }, interval);
   }
 

--- a/packages/lodestar/src/sync/utils/attestation-collector.ts
+++ b/packages/lodestar/src/sync/utils/attestation-collector.ts
@@ -1,7 +1,7 @@
 import {IBeaconChain} from "../../chain";
 import {IBeaconDb} from "../../db";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {Attestation, CommitteeIndex, Slot} from "@chainsafe/lodestar-types";
+import {Attestation, CommitteeIndex, ForkDigest, Slot} from "@chainsafe/lodestar-types";
 import {IService} from "../../node";
 import {INetwork} from "../../network";
 import {computeSubnetForSlot} from "@chainsafe/lodestar-beacon-state-transition";
@@ -41,7 +41,7 @@ export class AttestationCollector implements IService {
   }
 
   public async subscribeToCommitteeAttestations(slot: Slot, committeeIndex: CommitteeIndex): Promise<void> {
-    const forkDigest = this.chain.currentForkDigest;
+    const forkDigest = await this.chain.getForkDigest();
     const headState = await this.chain.getHeadState();
     const subnet = computeSubnetForSlot(this.config, headState, slot, committeeIndex);
     try {
@@ -58,7 +58,7 @@ export class AttestationCollector implements IService {
 
   private checkDuties = async (slot: Slot): Promise<void> => {
     const committees = this.aggregationDuties.get(slot) || new Set();
-    const forkDigest = this.chain.currentForkDigest;
+    const forkDigest = await this.chain.getForkDigest();
     const headState = await this.chain.getHeadState();
     this.timers = [];
     committees.forEach((committeeIndex) => {
@@ -66,15 +66,14 @@ export class AttestationCollector implements IService {
       this.network.gossip.subscribeToAttestationSubnet(forkDigest, subnet, this.handleCommitteeAttestation);
       this.timers.push(
         setTimeout(() => {
-          this.unsubscribeSubnet(subnet);
+          this.unsubscribeSubnet(subnet, forkDigest);
         }, this.config.params.SECONDS_PER_SLOT * 1000)
       );
     });
     this.aggregationDuties.delete(slot);
   };
 
-  private unsubscribeSubnet = (subnet: number): void => {
-    const forkDigest = this.chain.currentForkDigest;
+  private unsubscribeSubnet = (subnet: number, forkDigest: ForkDigest): void => {
     try {
       this.network.gossip.unsubscribeFromAttestationSubnet(forkDigest, subnet, this.handleCommitteeAttestation);
     } catch (e) {

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -214,11 +214,11 @@ export function processSyncBlocks(
   };
 }
 
-export function createStatus(chain: IBeaconChain): Status {
+export async function createStatus(chain: IBeaconChain): Promise<Status> {
   const head = chain.forkChoice.getHead();
   const finalizedCheckpoint = chain.forkChoice.getFinalizedCheckpoint();
   return {
-    forkDigest: chain.currentForkDigest,
+    forkDigest: await chain.getForkDigest(),
     finalizedRoot: finalizedCheckpoint.epoch === GENESIS_EPOCH ? ZERO_HASH : finalizedCheckpoint.root,
     finalizedEpoch: finalizedCheckpoint.epoch,
     headRoot: head.blockRoot,

--- a/packages/lodestar/src/tasks/tasks/interopSubnetsJoiningTask.ts
+++ b/packages/lodestar/src/tasks/tasks/interopSubnetsJoiningTask.ts
@@ -20,7 +20,7 @@ export class InteropSubnetsJoiningTask {
   private readonly logger: ILogger;
   private currentSubnets: Set<number>;
   private nextForkSubnets: Set<number>;
-  private currentForkDigest: ForkDigest;
+  private currentForkDigest!: ForkDigest;
 
   private currentTimers: NodeJS.Timeout[] = [];
   private nextForkTimers: NodeJS.Timeout[] = [];
@@ -33,18 +33,17 @@ export class InteropSubnetsJoiningTask {
     this.logger = modules.logger;
     this.currentSubnets = new Set();
     this.nextForkSubnets = new Set();
-    this.currentForkDigest = this.chain.currentForkDigest;
   }
 
   public async start(): Promise<void> {
-    this.currentForkDigest = this.chain.currentForkDigest;
-    this.chain.emitter.on("forkDigest", this.handleForkDigest);
+    this.currentForkDigest = await this.chain.getForkDigest();
+    this.chain.emitter.on("forkVersion", this.handleForkVersion);
     await this.run(this.currentForkDigest);
     await this.scheduleNextForkSubscription();
   }
 
   public async stop(): Promise<void> {
-    this.chain.emitter.removeListener("forkDigest", this.handleForkDigest);
+    this.chain.emitter.removeListener("forkVersion", this.handleForkVersion);
     if (this.nextForkSubsTimer) {
       clearTimeout(this.nextForkSubsTimer);
     }
@@ -92,7 +91,8 @@ export class InteropSubnetsJoiningTask {
   /**
    * Transition from current fork to next fork.
    */
-  private handleForkDigest = async (forkDigest: ForkDigest): Promise<void> => {
+  private handleForkVersion = async (): Promise<void> => {
+    const forkDigest = await this.chain.getForkDigest();
     this.logger.important(`InteropSubnetsJoiningTask: received new fork digest ${toHexString(forkDigest)}`);
     // at this time current fork digest and next fork digest subnets are subscribed in parallel
     // this cleans up current fork digest subnets subscription and keep subscribed to next fork digest subnets

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -127,7 +127,7 @@ describe("[network] network", function () {
       new Promise((resolve) => netB.on("peer:connect", resolve)),
     ]);
     const spy = sinon.spy();
-    const forkDigest = chain.currentForkDigest;
+    const forkDigest = await chain.getForkDigest();
     const received = new Promise((resolve) => {
       netA.gossip.subscribeToBlock(forkDigest, () => {
         spy();
@@ -183,7 +183,7 @@ describe("[network] network", function () {
     ]);
     await netA.connect(netB.peerId, netB.localMultiaddrs);
     await connected;
-    const forkDigest = chain.currentForkDigest;
+    const forkDigest = await chain.getForkDigest();
     const received = new Promise((resolve, reject) => {
       setTimeout(reject, 4000);
       netA.gossip.subscribeToBlock(forkDigest, (signedBlock: SignedBeaconBlock): void => {
@@ -206,7 +206,7 @@ describe("[network] network", function () {
     ]);
     await netA.connect(netB.peerId, netB.localMultiaddrs);
     await connected;
-    const forkDigest = chain.currentForkDigest;
+    const forkDigest = await chain.getForkDigest();
     const received = new Promise((resolve, reject) => {
       setTimeout(reject, 4000);
       netA.gossip.subscribeToAggregateAndProof(forkDigest, resolve);
@@ -224,7 +224,7 @@ describe("[network] network", function () {
     ]);
     await netA.connect(netB.peerId, netB.localMultiaddrs);
     await connected;
-    const forkDigest = chain.currentForkDigest;
+    const forkDigest = await chain.getForkDigest();
     let callback: (attestation: {attestation: Attestation; subnet: number}) => void;
     const received = new Promise((resolve, reject) => {
       setTimeout(reject, 4000);

--- a/packages/lodestar/test/unit/sync/gossip/handler.test.ts
+++ b/packages/lodestar/test/unit/sync/gossip/handler.test.ts
@@ -9,7 +9,7 @@ import {generateEmptySignedBlock} from "../../../utils/block";
 import {expect} from "chai";
 import {generateEmptyAttesterSlashing, generateEmptyProposerSlashing} from "../../../utils/slashings";
 import {generateEmptySignedAggregateAndProof, generateEmptySignedVoluntaryExit} from "../../../utils/attestation";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {sleep, WinstonLogger} from "@chainsafe/lodestar-utils";
 import {MockBeaconChain} from "../../../utils/mocks/chain/chain";
 import {generateState} from "../../../utils/state";
 import {StubbedBeaconDb} from "../../../utils/stub";
@@ -82,7 +82,7 @@ describe("gossip handler", function () {
     expect(dbStub.voluntaryExit.add.calledOnce).to.be.true;
   });
 
-  it("should handle fork digest changed", async function () {
+  it("should handle fork version changed", async function () {
     // handler is started and fork digest changed after that
     const state: BeaconState = generateState();
     const chain = new MockBeaconChain({
@@ -92,14 +92,16 @@ describe("gossip handler", function () {
       state: state as TreeBacked<BeaconState>,
       config,
     });
-    const oldForkDigest = chain.currentForkDigest;
+    const oldForkDigest = await chain.getForkDigest();
     const handler = new BeaconGossipHandler(chain, networkStub, dbStub, logger);
     await handler.start();
     expect(gossipStub.subscribeToBlock.callCount).to.be.equal(1);
     // fork digest changed due to current version changed
     state.fork.currentVersion = Buffer.from([100, 0, 0, 0]);
-    expect(config.types.ForkDigest.equals(oldForkDigest, chain.currentForkDigest)).to.be.false;
-    chain.emitter.emit("forkDigest", chain.currentForkDigest);
+    expect(config.types.ForkDigest.equals(oldForkDigest, await chain.getForkDigest())).to.be.false;
+    chain.emitter.emit("forkVersion", state.fork.currentVersion);
+    // allow event to be handled
+    await sleep(1);
     expect(gossipStub.unsubscribe.callCount).to.be.equal(5);
     expect(gossipStub.subscribeToBlock.callCount).to.be.equal(2);
     await chain.stop();

--- a/packages/lodestar/test/unit/sync/reqRes.test.ts
+++ b/packages/lodestar/test/unit/sync/reqRes.test.ts
@@ -49,7 +49,7 @@ describe("sync req resp", function () {
     chainStub.getHeadState.resolves(generateState());
     // @ts-ignore
     chainStub.config = config;
-    sandbox.stub(chainStub, "currentForkDigest").get(() => Buffer.alloc(4));
+    chainStub.getForkDigest.resolves(Buffer.alloc(4));
     reqRespStub = sandbox.createStubInstance(ReqResp);
     networkStub = sandbox.createStubInstance(Libp2pNetwork);
     networkStub.reqResp = (reqRespStub as unknown) as ReqResp & SinonStubbedInstance<ReqResp>;
@@ -129,7 +129,7 @@ describe("sync req resp", function () {
       headSlot: 1,
     };
 
-    sandbox.stub(chainStub, "currentForkDigest").get(() => Buffer.alloc(4).fill(1));
+    chainStub.getForkDigest.resolves(Buffer.alloc(4).fill(1));
     expect(await syncRpc.shouldDisconnectOnStatus(body)).to.be.true;
   });
 
@@ -142,7 +142,7 @@ describe("sync req resp", function () {
       headSlot: 1,
     };
 
-    sandbox.stub(chainStub, "currentForkDigest").get(() => body.forkDigest);
+    chainStub.getForkDigest.resolves(body.forkDigest);
     chainStub.getHeadState.resolves(
       generateState({
         slot: computeStartSlotAtEpoch(

--- a/packages/lodestar/test/unit/sync/utils/attestation-collector.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/attestation-collector.test.ts
@@ -11,6 +11,7 @@ import {Gossip} from "../../../../src/network/gossip/gossip";
 import {BeaconDb} from "../../../../src/db";
 import {generateState} from "../../../utils/state";
 import {silentLogger} from "../../../utils/logger";
+import { sleep } from "@chainsafe/lodestar-utils";
 
 describe("Attestation collector", function () {
   const sandbox = sinon.createSandbox();
@@ -34,6 +35,7 @@ describe("Attestation collector", function () {
       chain: {
         clock: realClock,
         getHeadState: () => Promise.resolve(generateState()),
+        getForkDigest: () => Promise.resolve(Buffer.alloc(4)),
         emitter,
       },
       // @ts-ignore
@@ -76,6 +78,7 @@ describe("Attestation collector", function () {
       chain: {
         clock: realClock,
         getHeadState: () => Promise.resolve(generateState()),
+        getForkDigest: () => Promise.resolve(Buffer.alloc(4)),
         emitter,
       },
       // @ts-ignore

--- a/packages/lodestar/test/unit/tasks/interopSubnetsJoiningTask.test.ts
+++ b/packages/lodestar/test/unit/tasks/interopSubnetsJoiningTask.test.ts
@@ -67,14 +67,14 @@ describe("interopSubnetsJoiningTask", () => {
   });
 
   it("should handle fork digest change", async () => {
-    const oldForkDigest = chain.currentForkDigest;
+    const oldForkDigest = await chain.getForkDigest();
     expect(gossipStub.subscribeToAttestationSubnet.callCount).to.be.equal(config.params.RANDOM_SUBNETS_PER_VALIDATOR);
     // fork digest changed due to current version changed
     state.fork.currentVersion = Buffer.from([100, 0, 0, 0]);
-    expect(config.types.ForkDigest.equals(oldForkDigest, chain.currentForkDigest)).to.be.false;
+    expect(config.types.ForkDigest.equals(oldForkDigest, await chain.getForkDigest())).to.be.false;
     // not subscribe, just unsubscribe at that time
     const unSubscribePromise = new Promise((resolve) => gossipStub.unsubscribeFromAttestationSubnet.callsFake(resolve));
-    chain.emitter.emit("forkDigest", chain.currentForkDigest);
+    chain.emitter.emit("forkVersion", state.fork.currentVersion);
     await unSubscribePromise;
     expect(gossipStub.unsubscribeFromAttestationSubnet.callCount).to.be.equal(
       config.params.RANDOM_SUBNETS_PER_VALIDATOR

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -116,7 +116,7 @@ export class MockBeaconChain implements IBeaconChain {
     return this.state!.finalizedCheckpoint;
   }
 
-  public get currentForkDigest(): ForkDigest {
+  public async getForkDigest(): Promise<ForkDigest> {
     return computeForkDigest(this.config, this.state!.fork.currentVersion, this.state!.genesisValidatorsRoot);
   }
 


### PR DESCRIPTION
- Remove the "forkDigest" event - simplify the `ChainEvents` interface to only include primitives, the fork digest is derivative of the fork version
- Remove synchronous `chain.currentForkDigest`, which is essentially a cached copy of the fork digest. Replace with `chain.getForkDigest` async function.