### PR TITLE
Update branding in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ![ES Version](https://img.shields.io/badge/ES-2020-yellow)
 ![Node Version](https://img.shields.io/badge/node-12.x-green)
 
-Lodestar is a Typescript implementation of the Ethereum 2.0 specification developed by ChainSafe.
+[Lodestar](https://lodestar.chainsafe.io) is a Typescript implementation of the Ethereum 2.0 specification developed by [ChainSafe Systems](https://chainsafe.io).
 
 ## Getting started
 

--- a/packages/benchmark-utils/README.md
+++ b/packages/benchmark-utils/README.md
@@ -1,3 +1,9 @@
 # benchmark-utils
 
+> This package is part of [ChainSafe's Lodestar](https://lodestar.chainsafe.io) project
+
 Tools to setup benchmark suites more easily.
+
+## License
+
+Apache-2.0 [ChainSafe Systems](https://chainsafe.io)

--- a/packages/lodestar-beacon-state-transition/README.md
+++ b/packages/lodestar-beacon-state-transition/README.md
@@ -6,6 +6,8 @@
 ![ES Version](https://img.shields.io/badge/ES-2020-yellow)
 ![Node Version](https://img.shields.io/badge/node-12.x-green)
 
+> This package is part of [ChainSafe's Lodestar](https://lodestar.chainsafe.io) project
+
 The beacon state transition and state transition utilities
 
 ## Usage
@@ -34,4 +36,4 @@ try {
 
 ## License
 
-Apache-2.0
+Apache-2.0 [ChainSafe Systems](https://chainsafe.io)

--- a/packages/lodestar-cli/README.md
+++ b/packages/lodestar-cli/README.md
@@ -5,6 +5,8 @@
 ![ES Version](https://img.shields.io/badge/ES-2020-yellow)
 ![Node Version](https://img.shields.io/badge/node-12.x-green)
 
+> This package is part of [ChainSafe's Lodestar](https://lodestar.chainsafe.io) project
+
 Command line tool for Lodestar
 
 ## Getting started
@@ -19,3 +21,7 @@ We have an experimental new CLI called `lodestar` which currently provides a sub
 
 `./bin/lodestar beacon init` - this will write a configuration and network identity to disk, by default `./.lodestar`
 `./bin/lodestar beacon run` - this will run a beacon node using a configuration from disk, by default `./.lodestar`
+
+## License
+
+LGPL-3.0 [ChainSafe Systems](https://chainsafe.io)

--- a/packages/lodestar-config/README.md
+++ b/packages/lodestar-config/README.md
@@ -6,6 +6,8 @@
 ![ES Version](https://img.shields.io/badge/ES-2020-yellow)
 ![Node Version](https://img.shields.io/badge/node-12.x-green)
 
+> This package is part of [ChainSafe's Lodestar](https://lodestar.chainsafe.io) project
+
 Configuration variables for an Eth2 network -- consists of params and ssz types (from [lodestar-params](https://github.com/ChainSafe/lodestar/tree/master/packages/lodestar-params) and [lodestar-types](https://github.com/ChainSafe/lodestar/tree/master/packages/lodestar-types) respectively).
 
 ## Usage
@@ -26,4 +28,4 @@ const BeaconStateType = mainnetConfig.types.BeaconState;
 
 ## License
 
-Apache-2.0
+Apache-2.0 [ChainSafe Systems](https://chainsafe.io)

--- a/packages/lodestar-fork-choice/README.md
+++ b/packages/lodestar-fork-choice/README.md
@@ -1,14 +1,15 @@
-# `@chainsafe/lodestar-db`
+# lodestar-fork-choice
 
 > This package is part of [ChainSafe's Lodestar](https://lodestar.chainsafe.io) project
 
 ## Usage
 
 ```
-const lodestarDb = require('@chainsafe/lodestar-db');
+const lodestarForkChoice = require('@chainsafe/lodestar-fork-choice');
 
 // TODO: DEMONSTRATE API
 ```
+
 ## License
 
 Apache-2.0 [ChainSafe Systems](https://chainsafe.io)

--- a/packages/lodestar-params/README.md
+++ b/packages/lodestar-params/README.md
@@ -6,6 +6,8 @@
 ![ES Version](https://img.shields.io/badge/ES-2020-yellow)
 ![Node Version](https://img.shields.io/badge/node-12.x-green)
 
+> This package is part of [ChainSafe's Lodestar](https://lodestar.chainsafe.io) project
+
 Parameters for configuring an Eth2 network
 
 ## Usage
@@ -29,4 +31,4 @@ const testnetParams: IBeaconParams = {
 
 ## License
 
-Apache-2.0
+Apache-2.0 [ChainSafe Systems](https://chainsafe.io)

--- a/packages/lodestar-spec-test-util/README.md
+++ b/packages/lodestar-spec-test-util/README.md
@@ -1,5 +1,7 @@
 # lodestar-spec-test-util
 
+> This package is part of [ChainSafe's Lodestar](https://lodestar.chainsafe.io) project
+
 Mocha / Chai utility for interacting with eth2.0 spec tests
 
 ## API
@@ -25,3 +27,7 @@ Compares actual vs expected for all test cases
 ## Profiling
 
 Set env variable GEN_PROFILE_DIR with path to directory where you wish your cpu profiles to be generated.
+
+## License
+
+Apache-2.0 [ChainSafe Systems](https://chainsafe.io)

--- a/packages/lodestar-types/README.md
+++ b/packages/lodestar-types/README.md
@@ -6,6 +6,8 @@
 ![ES Version](https://img.shields.io/badge/ES-2020-yellow)
 ![Node Version](https://img.shields.io/badge/node-12.x-green)
 
+> This package is part of [ChainSafe's Lodestar](https://lodestar.chainsafe.io) project
+
 Typescript and SSZ types for Eth2 datastructures
 
 ## Usage
@@ -47,4 +49,4 @@ testnetTypes.BeaconState.defaultValue();
 
 ## License
 
-Apache-2.0
+Apache-2.0 [ChainSafe Systems](https://chainsafe.io)

--- a/packages/lodestar-utils/README.md
+++ b/packages/lodestar-utils/README.md
@@ -1,2 +1,10 @@
+# lodestar-utils
+
 ![ES Version](https://img.shields.io/badge/ES-2020-yellow)
 ![Node Version](https://img.shields.io/badge/node-12.x-green)
+
+> This package is part of [ChainSafe's Lodestar](https://lodestar.chainsafe.io) project
+
+## License
+
+Apache-2.0 [ChainSafe Systems](https://chainsafe.io)

--- a/packages/lodestar-validator/README.md
+++ b/packages/lodestar-validator/README.md
@@ -5,6 +5,8 @@
 ![ES Version](https://img.shields.io/badge/ES-2020-yellow)
 ![Node Version](https://img.shields.io/badge/node-12.x-green)
 
+> This package is part of [ChainSafe's Lodestar](https://lodestar.chainsafe.io) project
+
 Typescript implementation of the Eth2.0 validator client. Enables developers to submit their own
 eth2 api compatible beacon nodes/databases/loggers.
 
@@ -13,3 +15,7 @@ eth2 api compatible beacon nodes/databases/loggers.
 - Follow the [installation guide](https://chainsafe.github.io/lodestar/installation) to install Lodestar.
 - Quickly try out the whole stack by [starting a local testnet](https://chainsafe.github.io/lodestar/usage).
 - View the [typedoc code docs](https://chainsafe.github.io/lodestar/packages).
+
+## License
+
+LGPL-3.0 [ChainSafe Systems](https://chainsafe.io)

--- a/packages/lodestar/README.md
+++ b/packages/lodestar/README.md
@@ -6,6 +6,8 @@
 ![ES Version](https://img.shields.io/badge/ES-2020-yellow)
 ![Node Version](https://img.shields.io/badge/node-12.x-green)
 
+> This package is part of [ChainSafe's Lodestar](https://lodestar.chainsafe.io) project
+
 ## Prerequisites
 
 - [Lerna](https://github.com/lerna/lerna)
@@ -24,3 +26,7 @@ You will need to go over the [specification](https://github.com/ethereum/eth2.0-
 ## Contributors
 
 Read our [contributors document](/CONTRIBUTING.md), [submit an issue](https://github.com/ChainSafe/lodestar/issues/new/choose) or talk to us on our [discord](https://discord.gg/yjyvFRP)!
+
+## License
+
+LGPL-3.0 [ChainSafe Systems](https://chainsafe.io)


### PR DESCRIPTION
Potential resolution for https://github.com/ChainSafe/lodestar/issues/1695

Add link to lodestar.chainsafe.io in a header to each package's README
Add link to chainsafe.io in the License section of each package's README

See https://github.com/ChainSafe/lodestar/blob/ae7dcfe7b9e62b33ab5e999c01f6a1cda21e8743/packages/lodestar-types/README.md