### PR TITLE
Use validator balances of justified checkpoint for forkchoice

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/index.ts
@@ -1,6 +1,7 @@
 import {BeaconState} from "@chainsafe/lodestar-types";
 
-import {prepareEpochProcessState, EpochContext} from "../util";
+import {prepareEpochProcessState} from "../util";
+import {StateTransitionEpochContext} from "../util/epochContext";
 import {processJustificationAndFinalization} from "./processJustificationAndFinalization";
 import {processRewardsAndPenalties} from "./processRewardsAndPenalties";
 import {processRegistryUpdates} from "./processRegistryUpdates";
@@ -16,7 +17,7 @@ export {
   processFinalUpdates,
 };
 
-export function processEpoch(epochCtx: EpochContext, state: BeaconState): void {
+export function processEpoch(epochCtx: StateTransitionEpochContext, state: BeaconState): void {
   const process = prepareEpochProcessState(epochCtx, state);
   epochCtx.epochProcess = process;
   processJustificationAndFinalization(epochCtx, process, state);

--- a/packages/lodestar-beacon-state-transition/src/fast/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/index.ts
@@ -41,7 +41,7 @@ export function fastStateTransition(
 }
 
 /**
- * Trim epochProcess in epochCtx, and insert epochProcess to the final exchange interface IStateContext
+ * Trim epochProcess in epochCtx, and insert the standard/exchange interface epochProcess to the final IStateContext
  */
 export function toIStateContext(epochCtx: StateTransitionEpochContext, state: BeaconState): IStateContext {
   const epochProcess = epochCtx.epochProcess;

--- a/packages/lodestar-beacon-state-transition/src/fast/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/index.ts
@@ -14,7 +14,7 @@ export function fastStateTransition(
   signedBlock: SignedBeaconBlock,
   options?: {verifyStateRoot?: boolean; verifyProposer?: boolean; verifySignatures?: boolean}
 ): IStateContext {
-  const epochCtx = eiEpochCtx as StateTransitionEpochContext;
+  const epochCtx = new StateTransitionEpochContext(undefined, eiEpochCtx);
   const {verifyStateRoot = true, verifyProposer = true, verifySignatures = true} = options || {};
   const types = epochCtx.config.types;
 
@@ -48,7 +48,7 @@ export function toIStateContext(epochCtx: StateTransitionEpochContext, state: Be
   epochCtx.epochProcess = undefined;
   return {
     state: state,
-    epochCtx: epochCtx,
+    epochCtx: new EpochContext(undefined, epochCtx),
     epochProcess,
   };
 }

--- a/packages/lodestar-beacon-state-transition/src/fast/slot/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/slot/index.ts
@@ -1,12 +1,12 @@
 import {BeaconState, Slot} from "@chainsafe/lodestar-types";
 
-import {EpochContext} from "../util";
+import {StateTransitionEpochContext} from "../util/epochContext";
 import {processEpoch} from "../epoch";
 import {processSlot} from "./processSlot";
 
 export {processSlot};
 
-export function processSlots(epochCtx: EpochContext, state: BeaconState, slot: Slot): void {
+export function processSlots(epochCtx: StateTransitionEpochContext, state: BeaconState, slot: Slot): void {
   if (!(state.slot < slot)) {
     throw new Error("State slot must transition to a future slot: " + `stateSlot=${state.slot} slot=${slot}`);
   }

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
@@ -36,6 +36,9 @@ class PubkeyIndexMap extends Map<ByteVector, ValidatorIndex> {
   }
 }
 
+/**
+ * Exchange Interface of EpochContext, this is what exported from lodestar-beacon-state-transition
+ **/
 export class EpochContext {
   // TODO: this is a hack, we need a safety mechanism in case a bad eth1 majority vote is in,
   // or handle non finalized data differently, or use an immutable.js structure for cheap copies
@@ -49,7 +52,6 @@ export class EpochContext {
   public currentShuffling!: IEpochShuffling;
   public nextShuffling!: IEpochShuffling;
   public config: IBeaconConfig;
-  public epochProcess?: IEpochProcess;
 
   constructor(config: IBeaconConfig) {
     this.config = config;
@@ -91,7 +93,6 @@ export class EpochContext {
     ctx.previousShuffling = this.previousShuffling;
     ctx.currentShuffling = this.currentShuffling;
     ctx.nextShuffling = this.nextShuffling;
-    ctx.epochProcess = this.epochProcess;
     return ctx;
   }
 
@@ -235,5 +236,19 @@ export class EpochContext {
     } else {
       throw new Error(`crosslink committee retrieval: out of range epoch: ${epoch}`);
     }
+  }
+}
+
+/**
+ * Business object of lodestar-beacon-state-stransition module.
+ * This is internal/private at the module level.
+ */
+export class StateTransitionEpochContext extends EpochContext {
+  public epochProcess?: IEpochProcess;
+
+  public copy(): StateTransitionEpochContext {
+    const ctx = super.copy() as StateTransitionEpochContext;
+    ctx.epochProcess = this.epochProcess;
+    return ctx;
   }
 }

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
@@ -53,11 +53,16 @@ export class EpochContext {
   public nextShuffling!: IEpochShuffling;
   public config: IBeaconConfig;
 
-  constructor(config: IBeaconConfig) {
-    this.config = config;
-    this.pubkey2index = new PubkeyIndexMap();
-    this.index2pubkey = [];
-    this.proposers = [];
+  constructor(config?: IBeaconConfig, epochCtx?: EpochContext) {
+    this.config = (epochCtx?.config || config)!;
+    this.pubkey2index = epochCtx?.pubkey2index || new PubkeyIndexMap();
+    this.index2pubkey = epochCtx?.index2pubkey || [];
+    this.proposers = epochCtx?.proposers || [];
+    if (epochCtx) {
+      this.previousShuffling = epochCtx.previousShuffling;
+      this.currentShuffling = epochCtx.currentShuffling;
+      this.nextShuffling = epochCtx.nextShuffling;
+    }
   }
 
   public loadState(state: BeaconState): void {
@@ -246,8 +251,9 @@ export class EpochContext {
 export class StateTransitionEpochContext extends EpochContext {
   public epochProcess?: IEpochProcess;
 
-  public copy(): StateTransitionEpochContext {
-    const ctx = super.copy() as StateTransitionEpochContext;
+  // need to return EpochContext in order to override
+  public copy(): EpochContext {
+    const ctx = new StateTransitionEpochContext(undefined, this);
     ctx.epochProcess = this.epochProcess;
     return ctx;
   }

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
@@ -37,7 +37,7 @@ class PubkeyIndexMap extends Map<ByteVector, ValidatorIndex> {
 }
 
 /**
- * Exchange Interface of EpochContext, this is what exported from lodestar-beacon-state-transition
+ * The standard / Exchange Interface of EpochContext, this is what's exported from lodestar-beacon-state-transition
  **/
 export class EpochContext {
   // TODO: this is a hack, we need a safety mechanism in case a bad eth1 majority vote is in,
@@ -245,7 +245,7 @@ export class EpochContext {
 }
 
 /**
- * Business object of lodestar-beacon-state-stransition module.
+ * State Transition specific version of EpochContext.
  * This is internal/private at the module level.
  */
 export class StateTransitionEpochContext extends EpochContext {

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochProcess.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochProcess.ts
@@ -18,7 +18,7 @@ import {
   FLAG_CURR_HEAD_ATTESTER,
 } from "./attesterStatus";
 import {IEpochStakeSummary} from "./epochStakeSummary";
-import {EpochContext} from "./epochContext";
+import {StateTransitionEpochContext} from "./epochContext";
 import {createIFlatValidator, isActiveIFlatValidator} from "./flatValidator";
 
 export interface IEpochProcess {
@@ -62,7 +62,7 @@ export function createIEpochProcess(): IEpochProcess {
   };
 }
 
-export function prepareEpochProcessState(epochCtx: EpochContext, state: BeaconState): IEpochProcess {
+export function prepareEpochProcessState(epochCtx: StateTransitionEpochContext, state: BeaconState): IEpochProcess {
   const out = createIEpochProcess();
 
   const config = epochCtx.config;

--- a/packages/lodestar-beacon-state-transition/src/fast/util/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/index.ts
@@ -1,16 +1,21 @@
 import {BeaconState} from "@chainsafe/lodestar-types";
 import {EpochContext} from "./epochContext";
+import {IEpochProcess} from "./epochProcess";
 
 export * from "./block";
 export * from "./attesterStatus";
-export * from "./epochContext";
+export {EpochContext} from "./epochContext";
 export * from "./epochProcess";
 export * from "./epochShuffling";
 export * from "./epochStakeSummary";
 export * from "./flatValidator";
 export * from "./interface";
 
+/**
+ * Exchange Interface of StateContext
+ */
 export interface IStateContext {
   state: BeaconState;
   epochCtx: EpochContext;
+  epochProcess?: IEpochProcess;
 }

--- a/packages/lodestar-fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/lodestar-fork-choice/src/forkChoice/forkChoice.ts
@@ -594,6 +594,11 @@ export class ForkChoice implements IForkChoice {
       });
     }
 
+    // at regular sync time we don't want to wait for clock time next epoch to update bestJustifiedCheckpoint
+    if (computeEpochAtSlot(this.config, state.slot) < computeEpochAtSlot(this.config, this.fcStore.currentSlot)) {
+      return true;
+    }
+
     // We know that the slot for `new_justified_checkpoint.root` is not greater than
     // `state.slot`, since a state cannot justify its own slot.
     //

--- a/packages/lodestar-fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/lodestar-fork-choice/src/forkChoice/forkChoice.ts
@@ -16,7 +16,6 @@ import {
   computeEpochAtSlot,
   ZERO_HASH,
 } from "@chainsafe/lodestar-beacon-state-transition";
-import {IEpochProcess} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
 import {computeDeltas, HEX_ZERO_HASH, IVoteTracker, ProtoArray} from "../protoArray";
@@ -248,10 +247,10 @@ export class ForkChoice implements IForkChoice {
    *
    * The supplied block **must** pass the `state_transition` function as it will not be run here.
    *
-   * `epochProcess` is passed in so that justified balances can be updated synchronously.
+   * `justifiedBalances` balances of justified state which is updated synchronously.
    * This ensures that the forkchoice is never out of sync.
    */
-  public onBlock(block: BeaconBlock, state: BeaconState, epochProcess?: IEpochProcess): void {
+  public onBlock(block: BeaconBlock, state: BeaconState, justifiedBalances?: Gwei[]): void {
     // Parent block must be known
     if (!this.protoArray.hasBlock(toHexString(block.parentRoot))) {
       throw new ForkChoiceError({
@@ -310,15 +309,14 @@ export class ForkChoice implements IForkChoice {
 
     // Update justified checkpoint.
     if (state.currentJustifiedCheckpoint.epoch > this.fcStore.justifiedCheckpoint.epoch) {
-      if (!epochProcess) {
+      if (!justifiedBalances) {
         throw new ForkChoiceError({
           code: ForkChoiceErrorCode.ERR_UNABLE_TO_SET_JUSTIFIED_CHECKPOINT,
-          error: new Error("No epoch process supplied"),
+          error: new Error("No validator balances supplied"),
         });
       }
       if (state.currentJustifiedCheckpoint.epoch > this.fcStore.bestJustifiedCheckpoint.epoch) {
-        const balances = epochProcess.statuses.map((s) => (s.active ? s.validator.effectiveBalance : BigInt(0)));
-        this.updateBestJustified(state.currentJustifiedCheckpoint, balances);
+        this.updateBestJustified(state.currentJustifiedCheckpoint, justifiedBalances);
       }
       if (this.shouldUpdateJustifiedCheckpoint(state)) {
         // wait to update until after finalized checkpoint is set
@@ -345,14 +343,13 @@ export class ForkChoice implements IForkChoice {
 
     // This needs to be performed after finalized checkpoint has been updated
     if (shouldUpdateJustified) {
-      if (!epochProcess) {
+      if (!justifiedBalances) {
         throw new ForkChoiceError({
           code: ForkChoiceErrorCode.ERR_UNABLE_TO_SET_JUSTIFIED_CHECKPOINT,
-          error: new Error("No epoch process supplied"),
+          error: new Error("No validator balances supplied"),
         });
       }
-      const balances = epochProcess.statuses.map((s) => (s.active ? s.validator.effectiveBalance : BigInt(0)));
-      this.updateJustified(state.currentJustifiedCheckpoint, balances);
+      this.updateJustified(state.currentJustifiedCheckpoint, justifiedBalances);
     }
 
     const targetSlot = computeStartSlotAtEpoch(this.config, computeEpochAtSlot(this.config, block.slot));

--- a/packages/lodestar-fork-choice/src/forkChoice/interface.ts
+++ b/packages/lodestar-fork-choice/src/forkChoice/interface.ts
@@ -3,12 +3,12 @@ import {
   BeaconState,
   Checkpoint,
   Epoch,
+  Gwei,
   IndexedAttestation,
   Root,
   Slot,
   ValidatorIndex,
 } from "@chainsafe/lodestar-types";
-import {IEpochProcess} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 import {IBlockSummary} from "./blockSummary";
 
 export interface IForkChoice {
@@ -52,10 +52,10 @@ export interface IForkChoice {
    *
    * The supplied block **must** pass the `state_transition` function as it will not be run here.
    *
-   * `epochProcess` is passed in so that justified balances can be updated synchronously.
+   * `justifiedBalances` validator balances of justified checkpoint which is updated synchronously.
    * This ensures that the forkchoice is never out of sync.
    */
-  onBlock(block: BeaconBlock, state: BeaconState, epochProcess?: IEpochProcess): void;
+  onBlock(block: BeaconBlock, state: BeaconState, justifiedBalances?: Gwei[]): void;
   /**
    * Register `attestation` with the fork choice DAG so that it may influence future calls to `getHead`.
    *

--- a/packages/lodestar/src/chain/blocks/process.ts
+++ b/packages/lodestar/src/chain/blocks/process.ts
@@ -5,21 +5,24 @@ import {IBlockJob} from "../interface";
 import {runStateTransition} from "./stateTransition";
 import {IStateRegenerator, RegenError} from "../regen";
 import {BlockError, BlockErrorCode} from "../errors";
+import {IBeaconDb} from "../../db";
 
 export async function processBlock({
   forkChoice,
   regen,
   emitter,
+  db,
   job,
 }: {
   forkChoice: IForkChoice;
   regen: IStateRegenerator;
   emitter: ChainEventEmitter;
+  db: IBeaconDb;
   job: IBlockJob;
 }): Promise<void> {
   try {
     const preStateContext = await regen.getPreState(job.signedBlock.message);
-    await runStateTransition(emitter, forkChoice, preStateContext, job);
+    await runStateTransition(emitter, forkChoice, db, preStateContext, job);
   } catch (e) {
     if (e instanceof RegenError) {
       throw new BlockError({

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -9,6 +9,7 @@ import {JobQueue} from "../../util/queue";
 
 import {processBlock} from "./process";
 import {validateBlock} from "./validate";
+import {IBeaconDb} from "../../db";
 
 type BlockProcessorModules = {
   config: IBeaconConfig;
@@ -16,6 +17,7 @@ type BlockProcessorModules = {
   regen: IStateRegenerator;
   emitter: ChainEventEmitter;
   clock: IBeaconClock;
+  db: IBeaconDb;
 };
 
 /**

--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -12,7 +12,7 @@ import {
 import {processSlots} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/slot";
 import {IBlockSummary, IForkChoice} from "@chainsafe/lodestar-fork-choice";
 
-import {ITreeStateContext} from "../../db/api/beacon/stateContextCache";
+import {LodestarEpochContext, ITreeStateContext} from "../../db/api/beacon/stateContextCache";
 import {ChainEvent, ChainEventEmitter} from "../emitter";
 import {IBlockJob} from "../interface";
 import {sleep} from "@chainsafe/lodestar-utils";
@@ -170,7 +170,7 @@ export async function runStateTransition(
 function toTreeStateContext(stateCtx: IStateContext): ITreeStateContext {
   const treeStateCtx: ITreeStateContext = {
     state: stateCtx.state as TreeBacked<BeaconState>,
-    epochCtx: stateCtx.epochCtx,
+    epochCtx: new LodestarEpochContext(undefined, stateCtx.epochCtx),
   };
   if (stateCtx.epochProcess) {
     treeStateCtx.epochCtx.epochBalances = stateCtx.epochProcess.statuses.map((s) =>

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -225,6 +225,7 @@ export class BeaconChain implements IBeaconChain {
       regen: this.regen,
       emitter: this.internalEmitter,
       signal: this.abortController!.signal,
+      db: this.db,
     });
     handleChainEvents.bind(this)(this.abortController.signal);
   }

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -29,7 +29,7 @@ import {toHexString, TreeBacked} from "@chainsafe/ssz";
 import {AbortController} from "abort-controller";
 import {EMPTY_SIGNATURE, FAR_FUTURE_EPOCH, GENESIS_SLOT, ZERO_HASH} from "../constants";
 import {IBeaconDb} from "../db";
-import {ITreeStateContext} from "../db/api/beacon/stateContextCache";
+import {LodestarEpochContext, ITreeStateContext} from "../db/api/beacon/stateContextCache";
 import {IEth1Provider} from "../eth1";
 import {IBeaconMetrics} from "../metrics";
 import {sortBlocks} from "../sync/utils";
@@ -328,7 +328,10 @@ export class BeaconChain implements IBeaconChain {
   /**
    * Restore state cache and forkchoice from last finalized state.
    */
-  private async restoreHeadState(lastKnownState: TreeBacked<BeaconState>, epochCtx: EpochContext): Promise<void> {
+  private async restoreHeadState(
+    lastKnownState: TreeBacked<BeaconState>,
+    epochCtx: LodestarEpochContext
+  ): Promise<void> {
     const stateRoot = this.config.types.BeaconState.hashTreeRoot(lastKnownState);
     this.logger.info("Restoring from last known state", {
       slot: lastKnownState.slot,

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -10,7 +10,7 @@ import {assembleBody} from "./body";
 import {fastStateTransition} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconChain} from "../../interface";
 import {EMPTY_SIGNATURE, ZERO_HASH} from "../../../constants";
-import {IStateContext} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
+import {IStateContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {IEth1ForBlockProduction} from "../../../eth1";
 
 export async function assembleBlock(

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -150,7 +150,7 @@ export class StateRegenerator implements IStateRegenerator {
         });
       }
       try {
-        stateCtx = await runStateTransition(this.emitter, this.forkChoice, stateCtx, {
+        stateCtx = await runStateTransition(this.emitter, this.forkChoice, this.db, stateCtx, {
           signedBlock: block,
           trusted: true,
           reprocess: true,

--- a/packages/lodestar/src/db/api/beacon/stateContextCache.ts
+++ b/packages/lodestar/src/db/api/beacon/stateContextCache.ts
@@ -1,11 +1,17 @@
 import {ByteVector, toHexString, TreeBacked} from "@chainsafe/ssz";
-import {BeaconState} from "@chainsafe/lodestar-types";
+import {BeaconState, Gwei} from "@chainsafe/lodestar-types";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 
+// lodestar state & epoch context business object
 export interface ITreeStateContext {
   state: TreeBacked<BeaconState>;
-  epochCtx: EpochContext;
+  epochCtx: ILodestarEpochContext;
 }
+
+// lodestar epoch context business object
+export type ILodestarEpochContext = EpochContext & {
+  epochBalances?: Gwei[];
+};
 
 /**
  * In memory cache of BeaconState and connected EpochContext

--- a/packages/lodestar/src/db/api/beacon/stateContextCache.ts
+++ b/packages/lodestar/src/db/api/beacon/stateContextCache.ts
@@ -5,13 +5,20 @@ import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 // lodestar state & epoch context business object
 export interface ITreeStateContext {
   state: TreeBacked<BeaconState>;
-  epochCtx: ILodestarEpochContext;
+  epochCtx: LodestarEpochContext;
 }
 
 // lodestar epoch context business object
-export type ILodestarEpochContext = EpochContext & {
-  epochBalances?: Gwei[];
-};
+export class LodestarEpochContext extends EpochContext {
+  public epochBalances?: Gwei[];
+
+  // need to be return EpochContext in order to override
+  public copy(): EpochContext {
+    const ctx = new LodestarEpochContext(undefined, this);
+    ctx.epochBalances = this.epochBalances;
+    return ctx;
+  }
+}
 
 /**
  * In memory cache of BeaconState and connected EpochContext
@@ -78,7 +85,7 @@ export class StateContextCache {
   private clone(item: ITreeStateContext): ITreeStateContext {
     return {
       state: item.state.clone(),
-      epochCtx: item.epochCtx.copy(),
+      epochCtx: item.epochCtx.copy() as LodestarEpochContext,
     };
   }
 }

--- a/packages/lodestar/src/db/api/beacon/stateContextCache.ts
+++ b/packages/lodestar/src/db/api/beacon/stateContextCache.ts
@@ -2,13 +2,13 @@ import {ByteVector, toHexString, TreeBacked} from "@chainsafe/ssz";
 import {BeaconState, Gwei} from "@chainsafe/lodestar-types";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 
-// lodestar state & epoch context business object
+// Lodestar specifc state context
 export interface ITreeStateContext {
   state: TreeBacked<BeaconState>;
   epochCtx: LodestarEpochContext;
 }
 
-// lodestar epoch context business object
+// Lodestar specific epoch context
 export class LodestarEpochContext extends EpochContext {
   public epochBalances?: Gwei[];
 

--- a/packages/lodestar/src/db/api/beacon/stateContextCheckpointsCache.ts
+++ b/packages/lodestar/src/db/api/beacon/stateContextCheckpointsCache.ts
@@ -1,7 +1,7 @@
 import {toHexString, fromHexString} from "@chainsafe/ssz";
 import {Checkpoint, Epoch} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {ITreeStateContext} from "./stateContextCache";
+import {LodestarEpochContext, ITreeStateContext} from "./stateContextCache";
 
 /**
  * In memory cache of BeaconState and connected EpochContext
@@ -106,7 +106,7 @@ export class CheckpointStateCache {
   private clone(item: ITreeStateContext): ITreeStateContext {
     return {
       state: item.state.clone(),
-      epochCtx: item.epochCtx.copy(),
+      epochCtx: item.epochCtx.copy() as LodestarEpochContext,
     };
   }
 }

--- a/packages/lodestar/test/unit/chain/blocks/process.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/process.test.ts
@@ -8,14 +8,17 @@ import {ChainEventEmitter} from "../../../../src/chain";
 import {BlockErrorCode} from "../../../../src/chain/errors";
 import {processBlock} from "../../../../src/chain/blocks/process";
 import {RegenError, RegenErrorCode, StateRegenerator} from "../../../../src/chain/regen";
+import {StubbedBeaconDb} from "../../../utils/stub";
 
 describe("processBlock", function () {
   const emitter = new ChainEventEmitter();
   let forkChoice: SinonStubbedInstance<ForkChoice>;
+  let dbStub: StubbedBeaconDb;
   let regen: SinonStubbedInstance<StateRegenerator>;
 
   beforeEach(function () {
     forkChoice = sinon.createStubInstance(ForkChoice);
+    dbStub = new StubbedBeaconDb(sinon);
     regen = sinon.createStubInstance(StateRegenerator);
   });
 
@@ -35,6 +38,7 @@ describe("processBlock", function () {
     try {
       await processBlock({
         forkChoice,
+        db: dbStub,
         regen,
         emitter,
         job,

--- a/packages/spec-test-runner/test/spec/finality/finality_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/finality/finality_fast.test.ts
@@ -13,11 +13,11 @@ describeDirectorySpecTest<IFinalityTestCase, BeaconState>(
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/finality/finality/pyspec_tests"),
   (testcase) => {
     let state = testcase.pre;
-    const epochCtx = new EpochContext(config);
+    let epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
     const verify = !!testcase.meta && !!testcase.meta.blsSetting && testcase.meta.blsSetting === BigInt(1);
     for (let i = 0; i < Number(testcase.meta.blocksCount); i++) {
-      ({state} = fastStateTransition({epochCtx, state}, testcase[`blocks_${i}`] as SignedBeaconBlock, {
+      ({state, epochCtx} = fastStateTransition({epochCtx, state}, testcase[`blocks_${i}`] as SignedBeaconBlock, {
         verifyStateRoot: verify,
         verifyProposer: verify,
         verifySignatures: verify,

--- a/packages/spec-test-runner/test/spec/sanity/blocks/sanity_blocks_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/sanity/blocks/sanity_blocks_fast.test.ts
@@ -13,11 +13,11 @@ describeDirectorySpecTest<IBlockSanityTestCase, BeaconState>(
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/sanity/blocks/pyspec_tests"),
   (testcase) => {
     let state = testcase.pre;
-    const epochCtx = new EpochContext(config);
+    let epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
     const verify = !!testcase.meta && !!testcase.meta.blsSetting && testcase.meta.blsSetting === BigInt(1);
     for (let i = 0; i < Number(testcase.meta.blocksCount); i++) {
-      ({state} = fastStateTransition({epochCtx, state}, testcase[`blocks_${i}`] as SignedBeaconBlock, {
+      ({state, epochCtx} = fastStateTransition({epochCtx, state}, testcase[`blocks_${i}`] as SignedBeaconBlock, {
         verifyStateRoot: verify,
         verifyProposer: verify,
         verifySignatures: verify,


### PR DESCRIPTION
resolves #1692 
+ This comes from the directions in #1693 
+ Use balances of justified checkpoint state instead of current checkpoint for forkchoice
+ Improve memory cache: Caching balances of active validator is much smaller compared to EpochProcess