### PR TITLE
Avoid removing stateRoot of forkchoice head from state context cache

### DIFF
--- a/packages/lodestar/src/chain/regen/errors.ts
+++ b/packages/lodestar/src/chain/regen/errors.ts
@@ -5,6 +5,7 @@ export enum RegenErrorCode {
   ERR_STATE_NOT_IN_FORKCHOICE = "ERR_STATE_NOT_IN_FORKCHOICE",
   ERR_SLOT_BEFORE_BLOCK_SLOT = "ERR_SLOT_BEFORE_BLOCK_SLOT",
   ERR_NO_SEED_STATE = "ERR_NO_SEED_STATE",
+  ERR_TOO_MANY_BLOCK_PROCESSED = "ERR_TOO_MANY_BLOCK_PROCESSED",
   ERR_BLOCK_NOT_IN_DB = "ERR_BLOCK_NOT_IN_DB",
   ERR_STATE_TRANSITION_ERROR = "ERR_STATE_TRANSITION_ERROR",
 }
@@ -25,6 +26,10 @@ export type RegenErrorType =
     }
   | {
       code: RegenErrorCode.ERR_NO_SEED_STATE;
+    }
+  | {
+      code: RegenErrorCode.ERR_TOO_MANY_BLOCK_PROCESSED;
+      stateRoot: Root;
     }
   | {
       code: RegenErrorCode.ERR_BLOCK_NOT_IN_DB;

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -141,7 +141,8 @@ export class StateRegenerator implements IStateRegenerator {
         code: RegenErrorCode.ERR_NO_SEED_STATE,
       });
     }
-    if (blocksToReplay.length > 5 * this.config.params.SLOTS_PER_EPOCH) {
+    const MAX_EPOCH_TO_PROCESS = 5;
+    if (blocksToReplay.length > MAX_EPOCH_TO_PROCESS * this.config.params.SLOTS_PER_EPOCH) {
       throw new RegenError({
         code: RegenErrorCode.ERR_TOO_MANY_BLOCK_PROCESSED,
         stateRoot,

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -141,6 +141,12 @@ export class StateRegenerator implements IStateRegenerator {
         code: RegenErrorCode.ERR_NO_SEED_STATE,
       });
     }
+    if (blocksToReplay.length > 5 * this.config.params.SLOTS_PER_EPOCH) {
+      throw new RegenError({
+        code: RegenErrorCode.ERR_TOO_MANY_BLOCK_PROCESSED,
+        stateRoot,
+      });
+    }
     for (const b of blocksToReplay.reverse()) {
       const block = await this.db.block.get(b.blockRoot);
       if (!block) {

--- a/packages/lodestar/src/db/api/beacon/stateContextCache.ts
+++ b/packages/lodestar/src/db/api/beacon/stateContextCache.ts
@@ -50,13 +50,15 @@ export class StateContextCache {
    * TODO make this more robust.
    * Without more thought, this currently breaks our assumptions about recent state availablity
    */
-  public prune(): void {
+  public prune(headStateRoot: ByteVector): void {
     const MAX_STATES = 96;
     const keys = Object.keys(this.cache);
     if (keys.length > MAX_STATES) {
       // object keys are stored in insertion order, delete keys starting from the front
       keys.slice(0, keys.length - MAX_STATES).forEach((key) => {
-        delete this.cache[key];
+        if (key !== toHexString(headStateRoot)) {
+          delete this.cache[key];
+        }
       });
     }
   }

--- a/packages/lodestar/src/tasks/index.ts
+++ b/packages/lodestar/src/tasks/index.ts
@@ -91,12 +91,13 @@ export class TasksService implements IService {
   };
 
   private onCheckpoint = async (): Promise<void> => {
+    const headStateRoot = this.chain.forkChoice.getHead().stateRoot;
     await Promise.all([
       this.db.checkpointStateCache.prune(
         this.chain.forkChoice.getFinalizedCheckpoint().epoch,
         this.chain.forkChoice.getJustifiedCheckpoint().epoch
       ),
-      this.db.stateCache.prune(),
+      this.db.stateCache.prune(headStateRoot),
     ]);
   };
 }


### PR DESCRIPTION
remedy #1701 
+ throw regen error if we have to replay too many blocks to regen state