### PR TITLE
Only subscribe to validator topics when node is synced

### DIFF
--- a/packages/lodestar/src/db/api/beacon/stateContextCheckpointsCache.ts
+++ b/packages/lodestar/src/db/api/beacon/stateContextCheckpointsCache.ts
@@ -75,7 +75,7 @@ export class CheckpointStateCache {
     const epochs = Object.keys(this.epochIndex)
       .map(Number)
       .filter((epoch) => epoch !== finalizedEpoch && epoch !== justifiedEpoch);
-    const MAX_EPOCHS = 20;
+    const MAX_EPOCHS = 10;
     if (epochs.length > MAX_EPOCHS) {
       epochs.slice(0, epochs.length - MAX_EPOCHS).forEach((epoch) => this.deleteAllEpochItems(epoch));
     }

--- a/packages/lodestar/src/sync/gossip/interface.ts
+++ b/packages/lodestar/src/sync/gossip/interface.ts
@@ -1,3 +1,5 @@
 import {IService} from "../../node";
 
-export type IGossipHandler = IService;
+export type IGossipHandler = IService & {
+  handleSyncCompleted(): void;
+};

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -154,6 +154,7 @@ export class BeaconSync implements IBeaconSync {
   private syncCompleted = async (): Promise<void> => {
     this.mode = SyncMode.SYNCED;
     this.stopSyncTimer();
+    this.gossip.handleSyncCompleted();
     await this.network.handleSyncCompleted();
   };
 

--- a/packages/lodestar/test/unit/sync/gossip/handler.test.ts
+++ b/packages/lodestar/test/unit/sync/gossip/handler.test.ts
@@ -60,7 +60,7 @@ describe("gossip handler", function () {
       await callback(generateEmptyAttesterSlashing());
     });
     const handler = new BeaconGossipHandler(chainStub, networkStub, dbStub, logger);
-    await handler.start();
+    await handler.handleSyncCompleted();
     expect(dbStub.attesterSlashing.add.calledOnce).to.be.true;
   });
 
@@ -69,7 +69,7 @@ describe("gossip handler", function () {
       await callback(generateEmptyProposerSlashing());
     });
     const handler = new BeaconGossipHandler(chainStub, networkStub, dbStub, logger);
-    await handler.start();
+    await handler.handleSyncCompleted();
     expect(dbStub.proposerSlashing.add.calledOnce).to.be.true;
   });
 
@@ -78,7 +78,7 @@ describe("gossip handler", function () {
       await callback(generateEmptySignedVoluntaryExit());
     });
     const handler = new BeaconGossipHandler(chainStub, networkStub, dbStub, logger);
-    await handler.start();
+    await handler.handleSyncCompleted();
     expect(dbStub.voluntaryExit.add.calledOnce).to.be.true;
   });
 


### PR DESCRIPTION
resolves #1697 

This is part of the formation that helped me sync up to head:
+ Only subscribe to gossip validator topics when node is synced
+ Reduce `MAX_EPOCHS` in checkpoint state cache to 10 (otherwise we'll get OOM error)