### PR TITLE
Add slashing protection interchange import / export cmds

### DIFF
--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/index.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/index.ts
@@ -5,10 +5,11 @@ import {create} from "./create";
 import {deposit} from "./deposit";
 import {importCmd} from "./import";
 import {list} from "./list";
+import {slashingProtection} from "./slashingProtection";
 
 export const validator: ICliCommand<IAccountValidatorArgs, IGlobalArgs> = {
   command: "validator <command>",
   describe: "Provides commands for managing Eth2 validators.",
   options: accountValidatorOptions,
-  subcommands: [create, deposit, importCmd, list],
+  subcommands: [create, deposit, importCmd, list, slashingProtection],
 };

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/export.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/export.ts
@@ -1,0 +1,48 @@
+import {InterchangeFormatVersion} from "@chainsafe/lodestar-validator/lib/slashingProtection/interchange";
+import {Json} from "@chainsafe/ssz";
+import {ICliCommand, writeFile} from "../../../../../util";
+import {IAccountValidatorArgs} from "../options";
+import {IGlobalArgs} from "../../../../../options";
+import {getGenesisValidatorsRoot, getSlashingProtection} from "./utils";
+
+/* eslint-disable no-console */
+
+interface ISlashingProtectionArgs {
+  file: string;
+}
+
+export const exportCmd: ICliCommand<ISlashingProtectionArgs, IAccountValidatorArgs & IGlobalArgs> = {
+  command: "export",
+
+  describe: "Export an interchange file.",
+
+  examples: [
+    {
+      command: "account validator slashing-protection export --testnet medalla --file interchange.json",
+      description: "Export an interchange JSON file for all validators in the slashing protection DB",
+    },
+  ],
+
+  options: {
+    file: {
+      description: "The slashing protection interchange file to export to (.json).",
+      demandOption: true,
+      normalize: true,
+      type: "string",
+    },
+  },
+
+  handler: async (args) => {
+    const genesisValidatorsRoot = getGenesisValidatorsRoot(args);
+    const slashingProtection = getSlashingProtection(args);
+
+    // TODO: Allow format version and pubkeys to be customized with CLI args
+    const formatVersion: InterchangeFormatVersion = {version: "4", format: "complete"};
+    const pubkeys = await slashingProtection.listPubkeys();
+
+    const interchange = await slashingProtection.exportInterchange(genesisValidatorsRoot, pubkeys, formatVersion);
+    writeFile(args.file, (interchange as unknown) as Json);
+
+    console.log("Export completed successfully");
+  },
+};

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/export.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/export.ts
@@ -1,17 +1,18 @@
 import {InterchangeFormatVersion} from "@chainsafe/lodestar-validator/lib/slashingProtection/interchange";
 import {Json} from "@chainsafe/ssz";
 import {ICliCommand, writeFile} from "../../../../../util";
-import {IAccountValidatorArgs} from "../options";
 import {IGlobalArgs} from "../../../../../options";
+import {IAccountValidatorArgs} from "../options";
+import {ISlashingProtectionArgs} from "./options";
 import {getGenesisValidatorsRoot, getSlashingProtection} from "./utils";
 
 /* eslint-disable no-console */
 
-interface ISlashingProtectionArgs {
+interface IExportArgs {
   file: string;
 }
 
-export const exportCmd: ICliCommand<ISlashingProtectionArgs, IAccountValidatorArgs & IGlobalArgs> = {
+export const exportCmd: ICliCommand<IExportArgs, ISlashingProtectionArgs & IAccountValidatorArgs & IGlobalArgs> = {
   command: "export",
 
   describe: "Export an interchange file.",
@@ -33,7 +34,7 @@ export const exportCmd: ICliCommand<ISlashingProtectionArgs, IAccountValidatorAr
   },
 
   handler: async (args) => {
-    const genesisValidatorsRoot = getGenesisValidatorsRoot(args);
+    const genesisValidatorsRoot = await getGenesisValidatorsRoot(args);
     const slashingProtection = getSlashingProtection(args);
 
     // TODO: Allow format version and pubkeys to be customized with CLI args

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/import.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/import.ts
@@ -1,0 +1,44 @@
+import fs from "fs";
+import {ICliCommand} from "../../../../../util";
+import {IAccountValidatorArgs} from "../options";
+import {IGlobalArgs} from "../../../../../options";
+import {getGenesisValidatorsRoot, getSlashingProtection} from "./utils";
+
+/* eslint-disable no-console */
+
+interface ISlashingProtectionArgs {
+  file: string;
+}
+
+export const importCmd: ICliCommand<ISlashingProtectionArgs, IAccountValidatorArgs & IGlobalArgs> = {
+  command: "import",
+
+  describe: "Import an interchange file.",
+
+  examples: [
+    {
+      command: "account validator slashing-protection import --testnet medalla --file interchange.json",
+      description: "Import an interchange file to the slashing protection DB",
+    },
+  ],
+
+  options: {
+    file: {
+      description: "The slashing protection interchange file to import (.json).",
+      demandOption: true,
+      normalize: true,
+      type: "string",
+    },
+  },
+
+  handler: async (args) => {
+    const genesisValidatorsRoot = getGenesisValidatorsRoot(args);
+    const slashingProtection = getSlashingProtection(args);
+
+    const importFile = await fs.promises.readFile(args.file, "utf8");
+    const importFileJson = JSON.parse(importFile);
+    await slashingProtection.importInterchange(importFileJson, genesisValidatorsRoot);
+
+    console.log("Import completed successfully");
+  },
+};

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/import.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/import.ts
@@ -1,16 +1,17 @@
 import fs from "fs";
 import {ICliCommand} from "../../../../../util";
-import {IAccountValidatorArgs} from "../options";
 import {IGlobalArgs} from "../../../../../options";
+import {IAccountValidatorArgs} from "../options";
+import {ISlashingProtectionArgs} from "./options";
 import {getGenesisValidatorsRoot, getSlashingProtection} from "./utils";
 
 /* eslint-disable no-console */
 
-interface ISlashingProtectionArgs {
+interface IImportArgs {
   file: string;
 }
 
-export const importCmd: ICliCommand<ISlashingProtectionArgs, IAccountValidatorArgs & IGlobalArgs> = {
+export const importCmd: ICliCommand<IImportArgs, ISlashingProtectionArgs & IAccountValidatorArgs & IGlobalArgs> = {
   command: "import",
 
   describe: "Import an interchange file.",
@@ -32,7 +33,7 @@ export const importCmd: ICliCommand<ISlashingProtectionArgs, IAccountValidatorAr
   },
 
   handler: async (args) => {
-    const genesisValidatorsRoot = getGenesisValidatorsRoot(args);
+    const genesisValidatorsRoot = await getGenesisValidatorsRoot(args);
     const slashingProtection = getSlashingProtection(args);
 
     const importFile = await fs.promises.readFile(args.file, "utf8");

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/index.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/index.ts
@@ -1,0 +1,13 @@
+import {ICliCommand} from "../../../../../util";
+import {IAccountValidatorArgs} from "../options";
+import {importCmd} from "./import";
+import {exportCmd} from "./export";
+
+/* eslint-disable no-console */
+
+export const validator: ICliCommand<{}, IAccountValidatorArgs> = {
+  command: "slashing-protection <command>",
+  describe: "Import or export slashing protection data to or from another client.",
+  options: {},
+  subcommands: [importCmd, exportCmd],
+};

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/index.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/index.ts
@@ -1,13 +1,14 @@
 import {ICliCommand} from "../../../../../util";
 import {IAccountValidatorArgs} from "../options";
+import {ISlashingProtectionArgs, slashingProtectionOptions} from "./options";
 import {importCmd} from "./import";
 import {exportCmd} from "./export";
 
 /* eslint-disable no-console */
 
-export const validator: ICliCommand<{}, IAccountValidatorArgs> = {
+export const slashingProtection: ICliCommand<ISlashingProtectionArgs, IAccountValidatorArgs> = {
   command: "slashing-protection <command>",
   describe: "Import or export slashing protection data to or from another client.",
-  options: {},
+  options: slashingProtectionOptions,
   subcommands: [importCmd, exportCmd],
 };

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/options.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/options.ts
@@ -1,8 +1,15 @@
 import {ICliCommandOptions} from "../../../../../util";
 import {IValidatorCliArgs, validatorOptions} from "../../../../validator/options";
 
-export type ISlashingProtectionArgs = Pick<IValidatorCliArgs, "server">;
+export type ISlashingProtectionArgs = Pick<IValidatorCliArgs, "server"> & {
+  force?: boolean;
+};
 
 export const slashingProtectionOptions: ICliCommandOptions<ISlashingProtectionArgs> = {
   server: validatorOptions.server,
+
+  force: {
+    description: "If genesisValidatorsRoot can't be fetched from the Beacon node, use a zero hash",
+    type: "boolean",
+  },
 };

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/options.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/options.ts
@@ -1,0 +1,8 @@
+import {ICliCommandOptions} from "../../../../../util";
+import {IValidatorCliArgs, validatorOptions} from "../../../../validator/options";
+
+export type ISlashingProtectionArgs = Pick<IValidatorCliArgs, "server">;
+
+export const slashingProtectionOptions: ICliCommandOptions<ISlashingProtectionArgs> = {
+  server: validatorOptions.server,
+};

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/utils.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/utils.ts
@@ -2,9 +2,13 @@ import {Root} from "@chainsafe/lodestar-types";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {SlashingProtection} from "@chainsafe/lodestar-validator";
 import {LevelDbController} from "@chainsafe/lodestar-db";
+import {getValidatorPaths} from "../../../../validator/paths";
 import {getBeaconConfigFromArgs} from "../../../../../config";
+import {IGlobalArgs} from "../../../../../options";
 
-export function getSlashingProtection(args): SlashingProtection {
+export function getSlashingProtection(args: IGlobalArgs): SlashingProtection {
+  const validatorPaths = getValidatorPaths(args);
+  const dbPath = validatorPaths.validatorsDbDir;
   const config = getBeaconConfigFromArgs(args);
   const logger = new WinstonLogger();
   return new SlashingProtection({

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/utils.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/utils.ts
@@ -1,0 +1,19 @@
+import {Root} from "@chainsafe/lodestar-types";
+import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {SlashingProtection} from "@chainsafe/lodestar-validator";
+import {LevelDbController} from "@chainsafe/lodestar-db";
+import {getBeaconConfigFromArgs} from "../../../../../config";
+
+export function getSlashingProtection(args): SlashingProtection {
+  const config = getBeaconConfigFromArgs(args);
+  const logger = new WinstonLogger();
+  return new SlashingProtection({
+    config: config,
+    controller: new LevelDbController({name: dbPath}, {logger}),
+  });
+}
+
+export function getGenesisValidatorsRoot(args): Root {
+  const genesisValidatorsRoot = testnet.getGenesisState().genesis_validators_root;
+  return genesisValidatorsRoot;
+}

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/utils.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/utils.ts
@@ -1,8 +1,10 @@
 import {Root} from "@chainsafe/lodestar-types";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {LogLevel, WinstonLogger} from "@chainsafe/lodestar-utils";
 import {SlashingProtection} from "@chainsafe/lodestar-validator";
 import {LevelDbController} from "@chainsafe/lodestar-db";
+import {ApiClientOverRest} from "@chainsafe/lodestar-validator/lib/api/impl/rest/apiClient";
 import {getValidatorPaths} from "../../../../validator/paths";
+import {IValidatorCliArgs} from "../../../../validator/options";
 import {getBeaconConfigFromArgs} from "../../../../../config";
 import {IGlobalArgs} from "../../../../../options";
 
@@ -10,14 +12,25 @@ export function getSlashingProtection(args: IGlobalArgs): SlashingProtection {
   const validatorPaths = getValidatorPaths(args);
   const dbPath = validatorPaths.validatorsDbDir;
   const config = getBeaconConfigFromArgs(args);
-  const logger = new WinstonLogger();
+  const logger = new WinstonLogger({level: LogLevel.error});
   return new SlashingProtection({
     config: config,
     controller: new LevelDbController({name: dbPath}, {logger}),
   });
 }
 
-export function getGenesisValidatorsRoot(args): Root {
-  const genesisValidatorsRoot = testnet.getGenesisState().genesis_validators_root;
-  return genesisValidatorsRoot;
+export async function getGenesisValidatorsRoot(args: IGlobalArgs & Pick<IValidatorCliArgs, "server">): Promise<Root> {
+  const server = args.server;
+
+  // state.genesisValidatorsRoot
+  const config = getBeaconConfigFromArgs(args);
+  const logger = new WinstonLogger({level: LogLevel.error});
+
+  const api = new ApiClientOverRest(config, server, logger);
+  const genesis = await api.beacon.getGenesis();
+  if (!genesis) {
+    throw Error(`Beacon node has not genesis ${server}`);
+  }
+
+  return genesis.genesisValidatorsRoot;
 }

--- a/packages/lodestar-cli/src/cmds/validator/options.ts
+++ b/packages/lodestar-cli/src/cmds/validator/options.ts
@@ -23,7 +23,6 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
   server: {
     description: "Address to connect to BeaconNode",
     default: "http://127.0.0.1:9596",
-    alias: ["server"],
     type: "string",
   },
 

--- a/packages/lodestar-cli/src/util/file.ts
+++ b/packages/lodestar-cli/src/util/file.ts
@@ -65,7 +65,7 @@ export function stringify<T = Json>(obj: T, fileFormat: FileFormat): string {
  * Serialize either to json, yaml, or toml
  */
 export function writeFile(filepath: string, obj: Json): void {
-  mkdir(path.parse(filepath).dir);
+  mkdir(path.dirname(filepath));
   const fileFormat = path.extname(filepath).substr(1);
   fs.writeFileSync(filepath, stringify(obj, fileFormat as FileFormat), "utf-8");
 }
@@ -105,7 +105,7 @@ export async function downloadOrCopyFile(pathDest: string, urlOrPathSrc: string)
   if (isUrl(urlOrPathSrc)) {
     await downloadFile(pathDest, urlOrPathSrc);
   } else {
-    mkdir(path.parse(pathDest).dir);
+    mkdir(path.dirname(pathDest));
     await fs.promises.copyFile(urlOrPathSrc, pathDest);
   }
 }
@@ -115,7 +115,7 @@ export async function downloadOrCopyFile(pathDest: string, urlOrPathSrc: string)
  */
 export async function downloadFile(pathDest: string, url: string): Promise<void> {
   if (!fs.existsSync(pathDest)) {
-    mkdir(path.parse(pathDest).dir);
+    mkdir(path.dirname(pathDest));
     await promisify(stream.pipeline)(got.stream(url), fs.createWriteStream(pathDest));
   }
 }

--- a/packages/lodestar-db/src/schema.ts
+++ b/packages/lodestar-db/src/schema.ts
@@ -55,20 +55,23 @@ export enum Key {
   justifiedBlock = 5,
 }
 
+export const bucketLen = 1;
+export const uintLen = 8;
+
 /**
  * Prepend a bucket to a key
  */
 export function encodeKey(bucket: Bucket, key: Uint8Array | string | number | bigint): Buffer {
   let buf;
   if (typeof key === "string") {
-    buf = Buffer.alloc(key.length + 1);
-    buf.write(key, 1);
+    buf = Buffer.alloc(key.length + bucketLen);
+    buf.write(key, bucketLen);
   } else if (typeof key === "number" || typeof key === "bigint") {
-    buf = Buffer.alloc(9);
-    intToBytes(BigInt(key), 8, "be").copy(buf, 1);
+    buf = Buffer.alloc(uintLen + bucketLen);
+    intToBytes(BigInt(key), uintLen, "be").copy(buf, bucketLen);
   } else {
-    buf = Buffer.alloc(key.length + 1);
-    buf.set(key, 1);
+    buf = Buffer.alloc(key.length + bucketLen);
+    buf.set(key, bucketLen);
   }
   buf.writeUInt8(bucket, 0);
   return buf;

--- a/packages/lodestar-validator/src/slashingProtection/attestation/service.ts
+++ b/packages/lodestar-validator/src/slashingProtection/attestation/service.ts
@@ -143,4 +143,8 @@ export class SlashingProtectionAttestationService {
   async exportAttestations(pubkey: BLSPubkey): Promise<SlashingProtectionAttestation[]> {
     return await this.attestationByTarget.getAll(pubkey);
   }
+
+  async listPubkeys(): Promise<BLSPubkey[]> {
+    return await this.attestationByTarget.listPubkeys();
+  }
 }

--- a/packages/lodestar-validator/src/slashingProtection/block/service.ts
+++ b/packages/lodestar-validator/src/slashingProtection/block/service.ts
@@ -88,4 +88,8 @@ export class SlashingProtectionBlockService {
   async exportBlocks(pubkey: BLSPubkey): Promise<SlashingProtectionBlock[]> {
     return this.blockBySlot.getAll(pubkey);
   }
+
+  async listPubkeys(): Promise<BLSPubkey[]> {
+    return await this.blockBySlot.listPubkeys();
+  }
 }

--- a/packages/lodestar-validator/src/slashingProtection/utils.ts
+++ b/packages/lodestar-validator/src/slashingProtection/utils.ts
@@ -1,6 +1,8 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Epoch, Root} from "@chainsafe/lodestar-types";
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {fromHexString, toHexString, Vector} from "@chainsafe/ssz";
+
+export const blsPubkeyLen = 48;
 
 export function getZeroRoot(config: IBeaconConfig): Root {
   return config.types.Root.defaultValue();
@@ -38,4 +40,14 @@ export function numToString(num: number): string {
 
 export function minEpoch(epochs: Epoch[]): Epoch | null {
   return epochs.length > 0 ? Math.min(...epochs) : null;
+}
+
+export function uniqueVectorArr(buffers: Vector<number>[]): Vector<number>[] {
+  const bufferStr = new Set<string>();
+  return buffers.filter((buffer) => {
+    const str = toHexString(buffer);
+    const seen = bufferStr.has(str);
+    bufferStr.add(str);
+    return !seen;
+  });
 }


### PR DESCRIPTION
Add slashing protection interchange import / export commands

```
account validator slashing-protection export --testnet medalla --file interchange.json
```

Export an interchange JSON file for all validators in the slashing protection DB

```
account validator slashing-protection import --testnet medalla --file interchange.json
```

Import an interchange file to the slashing protection DB

----

The interchange format requires the genesisValidatorsRoot to make sure the data is for the same network. It is fetched by the Beacon node REST API over HTTP.

resolves #1471 