### PR TITLE
Use single validator instance for all keypairs

### DIFF
--- a/packages/lodestar-cli/src/cmds/validator/paths.ts
+++ b/packages/lodestar-cli/src/cmds/validator/paths.ts
@@ -1,11 +1,9 @@
-import path from "path";
 import {IGlobalArgs} from "../../options";
 import {IGlobalPaths, getGlobalPaths} from "../../paths/global";
 import {joinIfRelative} from "../../util";
 
 export type IValidatorPaths = {
   validatorsDbDir: string;
-  validatorDbDir: (pubkey: string) => string;
 };
 
 /**
@@ -14,8 +12,7 @@ export type IValidatorPaths = {
  * ```bash
  * $validatorRootDir
  * └── validator-db
- *     └── 0x8e41b969493454318c27ec6fac90645769331c07ebc8db5037...
- *         └── (db files)
+ *     └── (db files)
  * ```
  */
 export function getValidatorPaths(
@@ -29,7 +26,6 @@ export function getValidatorPaths(
   return {
     ...globalPaths,
     validatorsDbDir,
-    validatorDbDir: (pubkey: string) => path.join(validatorsDbDir, pubkey),
   };
 }
 


### PR DESCRIPTION
***Note***: This is a breaking change with existing validator dbs. Now there's a single DB for all validators.