### PR TITLE
Do not pass gossip aggregate and proof attestation to chain

### DIFF
--- a/packages/lodestar/src/sync/gossip/handler.ts
+++ b/packages/lodestar/src/sync/gossip/handler.ts
@@ -68,10 +68,7 @@ export class BeaconGossipHandler implements IGossipHandler {
   };
 
   private onAggregatedAttestation = async (aggregate: SignedAggregateAndProof): Promise<void> => {
-    await Promise.all([
-      this.db.aggregateAndProof.add(aggregate.message),
-      this.chain.receiveAttestation(aggregate.message.aggregate),
-    ]);
+    await this.db.aggregateAndProof.add(aggregate.message);
   };
 
   private onAttesterSlashing = async (attesterSlashing: AttesterSlashing): Promise<void> => {


### PR DESCRIPTION
+ Gossip aggregate and proof attestations are not meant to process, they are meant  save to a pool to include in future blocks. According to the p2p spec: 
```
The beacon_aggregate_and_proof topic is used to propagate aggregated attestations (as SignedAggregateAndProofs) to subscribing nodes (typically validators) to be included in future blocks.
```

+ Another reason is a gossip aggregate and proof may not be included in any blocks. If we pass it to forkchoice, we may have different forkchoice head compared to other nodes.

+ I checked Prysm, it just save gossip aggregate and proofs to pool without processing them. Someone can check with Lighthouse to see if they process them or just save.