### PR TITLE
Do not need to get head state through regen

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -99,13 +99,9 @@ export class BeaconChain implements IBeaconChain {
   }
 
   public async getHeadStateContext(): Promise<ITreeStateContext> {
-    //head state should always exist
     const head = this.forkChoice.getHead();
-    const headStateRoot =
-      (await this.db.checkpointStateCache.getLatest({
-        root: head.blockRoot,
-        epoch: Infinity,
-      })) || (await this.regen.getState(head.stateRoot));
+    // head state should always exist in state cache
+    const headStateRoot = await this.db.stateCache.get(head.stateRoot);
     if (!headStateRoot) throw Error("headStateRoot does not exist");
     return headStateRoot;
   }


### PR DESCRIPTION
part of #1715 
head state is always available in the state cache so we don't need to go through regen module to get it. Otherwise:
+ the consume api has to wait for existing jobs in the queue unnecessarily
+ It'll throw `ERR_QUEUE_THROTTLED` because we get head state very frequently