### PR TITLE
Avoid importing lodestar-cli from itself

### DIFF
--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/list.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/list.ts
@@ -3,7 +3,7 @@ import {getAccountPaths} from "../../paths";
 import {IAccountValidatorArgs} from "./options";
 import {ICliCommand} from "../../../../util";
 import {IGlobalArgs} from "../../../../options";
-import {add0xPrefix} from "@chainsafe/lodestar-cli/src/util/format";
+import {add0xPrefix} from "../../../../util/format";
 
 export type ReturnType = string[];
 

--- a/packages/lodestar-cli/src/config/beaconParams.ts
+++ b/packages/lodestar-cli/src/config/beaconParams.ts
@@ -6,7 +6,7 @@ import {writeFile, readFileIfExists} from "../util";
 import {getTestnetBeaconParams, TestnetName} from "../testnets";
 import {getGlobalPaths, IGlobalPaths} from "../paths/global";
 import {IBeaconParamsUnparsed} from "./types";
-import {parseBeaconParamsArgs} from "@chainsafe/lodestar-cli/src/options";
+import {parseBeaconParamsArgs} from "../options";
 
 type IBeaconParamsCliArgs = {
   preset: string;


### PR DESCRIPTION
this fixes the following error when I start our node

```
Error: Cannot find module '@chainsafe/lodestar-cli/src/options'
```