### PR TITLE
get genesisStateFileUrl if testnet arg is passed to beacon

### DIFF
--- a/packages/lodestar-cli/src/cmds/beacon/handler.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/handler.ts
@@ -15,6 +15,7 @@ import {getBeaconPaths} from "./paths";
 import {onGracefulShutdown} from "../../util/process";
 import {FileENR, overwriteEnrWithCliArgs, readPeerId} from "../../config";
 import {initBeaconState} from "./initBeaconState";
+import {getGenesisFileUrl} from "../../testnets";
 
 /**
  * Run a beacon node
@@ -57,6 +58,10 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
   const dbClose = (): Promise<void> => db.stop();
   abortController.signal.addEventListener("abort", dbClose, {once: true});
   await db.start();
+
+  if (args.testnet && !args.genesisStateFile) {
+    args.genesisStateFile = getGenesisFileUrl(args.testnet) ?? undefined;
+  }
 
   // BeaconNode setup
   const anchorState = await initBeaconState(options, args, config, db, logger, abortController.signal);

--- a/packages/lodestar-cli/src/cmds/beacon/handler.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/handler.ts
@@ -15,7 +15,6 @@ import {getBeaconPaths} from "./paths";
 import {onGracefulShutdown} from "../../util/process";
 import {FileENR, overwriteEnrWithCliArgs, readPeerId} from "../../config";
 import {initBeaconState} from "./initBeaconState";
-import {getGenesisFileUrl} from "../../testnets";
 
 /**
  * Run a beacon node
@@ -58,10 +57,6 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
   const dbClose = (): Promise<void> => db.stop();
   abortController.signal.addEventListener("abort", dbClose, {once: true});
   await db.start();
-
-  if (args.testnet && !args.genesisStateFile) {
-    args.genesisStateFile = getGenesisFileUrl(args.testnet) ?? undefined;
-  }
 
   // BeaconNode setup
   const anchorState = await initBeaconState(options, args, config, db, logger, abortController.signal);

--- a/packages/lodestar-cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/initBeaconState.ts
@@ -11,6 +11,8 @@ import {IBeaconNodeOptions} from "@chainsafe/lodestar/lib/node";
 
 import {downloadOrLoadFile} from "../../util";
 import {IBeaconArgs} from "./options";
+import {IGlobalArgs} from "../../options/globalOptions";
+import {getGenesisFileUrl} from "../../testnets";
 
 /**
  * Initialize a beacon state, picking the strategy based on the `IBeaconArgs`
@@ -22,7 +24,7 @@ import {IBeaconArgs} from "./options";
  */
 export async function initBeaconState(
   options: IBeaconNodeOptions,
-  args: IBeaconArgs,
+  args: IBeaconArgs & IGlobalArgs,
   config: IBeaconConfig,
   db: IBeaconDb,
   logger: ILogger,
@@ -31,6 +33,11 @@ export async function initBeaconState(
   const shouldInitFromFile = Boolean(args.weakSubjectivityStateFile || (!args.forceGenesis && args.genesisStateFile));
   const shouldInitFromDb = (await db.stateArchive.lastKey()) != null;
   let anchorState;
+
+  if (args.testnet && !args.genesisStateFile) {
+    args.genesisStateFile = getGenesisFileUrl(args.testnet) ?? undefined;
+  }
+
   if (shouldInitFromFile) {
     const anchorStateFile = (args.weakSubjectivityStateFile || args.genesisStateFile) as string;
     anchorState = await initStateFromAnchorState(


### PR DESCRIPTION
fixes #1730  (a regression issue caused by the functionality for downloading of genesis.ssz being removed) by downloading the genesis.ssz when running `beacon` if the `--testnet` param is passed