### PR TITLE
Regular Sync: check linear chain segment to avoid orphaned block

### DIFF
--- a/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
@@ -67,11 +67,9 @@ export class BlockRangeFetcher implements IBlockRangeFetcher {
         if (peer) {
           // peers may return incorrect empty range, or 1 block, or 2 blocks or unlinear chain segment
           // if we try the same peer it'll just return same result so switching peer here
-          badPeers.add(peer!.toB58String()!);
-          peer = (await this.getPeers(Array.from(badPeers)))[0];
-        } else {
-          peer = (await this.getPeers())[0];
+          badPeers.add(peer.toB58String());
         }
+        peer = (await this.getPeers(Array.from(badPeers)))[0];
         slotRange = {start: this.rangeStart, end: this.rangeEnd};
         // result = await getBlockRange(this.logger, this.network.reqResp, peers, slotRange);
         // Work around of https://github.com/ChainSafe/lodestar/issues/1690

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
@@ -134,9 +134,10 @@ export class BlockRangeFetcher implements IBlockRangeFetcher {
         ...range,
         peerHead: peerHeadSlot,
       });
-      // don't trust empty range as it's rarely happen, peer may return it incorrectly or not up to date
+      // don't trust empty range as it's rarely happen, peer may return it incorrectly most of the time
       // same range start, expand range end
-      this.rangeEnd = this.getNewTarget();
+      // slowly increase rangeEnd, using getNewTarget() may cause giant range very quickly
+      this.rangeEnd += 1;
     } else {
       this.logger.verbose("Regular Sync: Queried range passed peer head, sleep then try again", {
         range,

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
@@ -81,9 +81,17 @@ export class BlockRangeFetcher implements IBlockRangeFetcher {
           }),
         ])) as SignedBeaconBlock[] | null;
         if (timer) clearTimeout(timer);
-        // 0-1 block result should go through and we'll handle it in next round
-        if (result && result.length > 1) {
-          checkLinearChainSegment(this.config, result);
+        if (result) {
+          // we queried from last fetched block
+          result = result.filter(
+            (signedBlock) =>
+              !this.config.types.Root.equals(
+                this.lastFetchCheckpoint.blockRoot,
+                this.config.types.BeaconBlock.hashTreeRoot(signedBlock.message)
+              )
+          );
+          // 0-1 block result should go through and we'll handle it in next round
+          if (result.length > 1) checkLinearChainSegment(this.config, result);
         }
       } catch (e) {
         this.logger.verbose("Regular Sync: Failed to get block range ", {...(slotRange ?? {}), error: e.message});

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
@@ -101,7 +101,8 @@ export class BlockRangeFetcher implements IBlockRangeFetcher {
 
   // always set range based on last fetch block bc sometimes the previous fetch may not return all blocks
   private updateNextRange(): void {
-    this.rangeStart = this.lastFetchCheckpoint.slot + 1;
+    // this.lastFetchCheckpoint.slot + 1 maybe an orphaned block and peers will return empty range
+    this.rangeStart = this.lastFetchCheckpoint.slot;
     this.rangeEnd = this.rangeStart;
     this.rangeEnd = this.getNewTarget();
   }

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
@@ -56,6 +56,7 @@ export class BlockRangeFetcher implements IBlockRangeFetcher {
     this.updateNextRange();
     let result: SignedBeaconBlock[] | null = null;
     let peer: PeerId | null = null;
+    const badPeers = new Set<string>();
     // expect at least 2 blocks since we check linear chain
     while (!result || result!.length <= 1) {
       let slotRange: ISlotRange | null = null;
@@ -66,7 +67,8 @@ export class BlockRangeFetcher implements IBlockRangeFetcher {
         if (peer) {
           // peers may return incorrect empty range, or 1 block, or 2 blocks or unlinear chain segment
           // if we try the same peer it'll just return same result so switching peer here
-          peer = (await this.getPeers([peer!.toB58String()!]))[0];
+          badPeers.add(peer!.toB58String()!);
+          peer = (await this.getPeers(Array.from(badPeers)))[0];
         } else {
           peer = (await this.getPeers())[0];
         }

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
@@ -117,9 +117,13 @@ export class ORARegularSync extends (EventEmitter as {new (): RegularSyncEventEm
 
   /**
    * Make sure the best peer is not disconnected and it's better than us.
+   * @param excludedPeers don't want to return peers in this list
    */
   private getSyncPeers = async (excludedPeers: string[] = []): Promise<PeerId[]> => {
-    if (!checkBestPeer(this.bestPeer!, this.chain.forkChoice, this.network)) {
+    if (
+      excludedPeers.includes(this.bestPeer?.toB58String() ?? "") ||
+      !checkBestPeer(this.bestPeer!, this.chain.forkChoice, this.network)
+    ) {
       this.logger.info("Regular Sync: wait for best peer");
       this.bestPeer = await this.waitForBestPeer(this.controller.signal, excludedPeers);
       if (this.controller.signal.aborted) return [];

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -265,6 +265,13 @@ export function getBestPeer(config: IBeaconConfig, peers: PeerId[], peerMetaStor
  * Check if a peer is good to be a best peer.
  */
 export function checkBestPeer(peer: PeerId, forkChoice: IForkChoice, network: INetwork): boolean {
+  return getBestPeerCandidates(forkChoice, network).includes(peer);
+}
+
+/**
+ * Return candidate for gest peer.
+ */
+export function getBestPeerCandidates(forkChoice: IForkChoice, network: INetwork): PeerId[] {
   return getSyncPeers(
     network,
     (peer) => {
@@ -273,7 +280,7 @@ export function checkBestPeer(peer: PeerId, forkChoice: IForkChoice, network: IN
     },
     10,
     DEFAULT_RPC_SCORE - 1
-  ).includes(peer);
+  );
 }
 
 /**

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -14,7 +14,6 @@ import {blockToHeader} from "@chainsafe/lodestar-beacon-state-transition";
 import {GENESIS_EPOCH, ZERO_HASH} from "../../constants";
 import {IPeerMetadataStore} from "../../network/peers/interface";
 import {getSyncPeers} from "./peers";
-import {DEFAULT_RPC_SCORE} from "../../network/peers";
 
 export function getHighestCommonSlot(peerStatuses: (Status | null)[]): Slot {
   const slotStatuses = peerStatuses.reduce<Map<Slot, number>>((current, status) => {
@@ -278,8 +277,7 @@ export function getBestPeerCandidates(forkChoice: IForkChoice, network: INetwork
       const status = network.peerMetadata.getStatus(peer);
       return !!status && status.headSlot > forkChoice.getHead().slot;
     },
-    10,
-    DEFAULT_RPC_SCORE - 1
+    10
   );
 }
 

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -283,14 +283,14 @@ export function checkBestPeer(peer: PeerId, forkChoice: IForkChoice, network: IN
  */
 export function checkLinearChainSegment(
   config: IBeaconConfig,
-  ancestorRoot: Root,
-  blocks: SignedBeaconBlock[] | null
+  blocks: SignedBeaconBlock[] | null,
+  ancestorRoot: Root | null = null
 ): void {
-  if (!blocks || blocks.length <= 1) throw "Not enough blocks to validate";
+  if (!blocks || blocks.length <= 1) throw new Error("Not enough blocks to validate");
   let parentRoot = ancestorRoot;
   blocks.forEach((block) => {
-    if (!config.types.Root.equals(block.message.parentRoot, parentRoot)) {
-      throw `Block ${block.message.slot} does not link to parent ${toHexString(parentRoot)}`;
+    if (parentRoot && !config.types.Root.equals(block.message.parentRoot, parentRoot)) {
+      throw new Error(`Block ${block.message.slot} does not link to parent ${toHexString(parentRoot)}`);
     }
     parentRoot = config.types.BeaconBlock.hashTreeRoot(block.message);
   });

--- a/packages/lodestar/test/unit/chain/clock/local.test.ts
+++ b/packages/lodestar/test/unit/chain/clock/local.test.ts
@@ -1,4 +1,4 @@
-import sinon, {SinonFakeTimers} from "sinon";
+import sinon from "sinon";
 import {AbortController} from "abort-controller";
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
@@ -7,14 +7,14 @@ import {LocalClock} from "../../../../src/chain/clock/LocalClock";
 import {ChainEvent, ChainEventEmitter} from "../../../../src/chain/emitter";
 
 describe("LocalClock", function () {
-  let realClock: SinonFakeTimers;
+  const sandbox = sinon.createSandbox();
 
   beforeEach(() => {
-    realClock = sinon.useFakeTimers();
+    sandbox.useFakeTimers();
   });
 
   afterEach(() => {
-    realClock.restore();
+    sandbox.restore();
   });
 
   it("Should notify on new slot", async function () {
@@ -28,7 +28,7 @@ describe("LocalClock", function () {
     });
     const spy = sinon.spy();
     emitter.on(ChainEvent.clockSlot, spy);
-    realClock.tick(config.params.SECONDS_PER_SLOT * 1000);
+    sandbox.clock.tick(config.params.SECONDS_PER_SLOT * 1000);
     expect(spy.calledOnce).to.be.true;
     expect(spy.calledWith(clock.currentSlot)).to.be.true;
     abortController.abort();
@@ -45,7 +45,7 @@ describe("LocalClock", function () {
     });
     const spy = sinon.spy();
     emitter.on(ChainEvent.clockEpoch, spy);
-    realClock.tick(config.params.SLOTS_PER_EPOCH * config.params.SECONDS_PER_SLOT * 1000);
+    sandbox.clock.tick(config.params.SLOTS_PER_EPOCH * config.params.SECONDS_PER_SLOT * 1000);
     expect(spy.calledOnce).to.be.true;
     expect(spy.calledWith(clock.currentEpoch)).to.be.true;
     abortController.abort();

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonFakeTimers, SinonStub, SinonStubbedInstance} from "sinon";
+import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
 import {BlockRangeFetcher} from "../../../../../src/sync/regular/oneRangeAhead/fetcher";
 import {BeaconChain, IBeaconChain} from "../../../../../src/chain";
@@ -22,14 +22,13 @@ describe("BlockRangeFetcher", function () {
   let metadataStub: SinonStubbedInstance<IPeerMetadataStore>;
   let getBlockRangeStub: SinonStub;
   let getCurrentSlotStub: SinonStub;
-  const getPeers = async (): Promise<PeerId[]> => {
-    return [await PeerId.create()];
-  };
   const logger = new WinstonLogger();
   const sandbox = sinon.createSandbox();
+  let getPeers: SinonStub;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     sandbox.useFakeTimers();
+    getPeers = sandbox.stub();
     getBlockRangeStub = sandbox.stub(blockUtils, "getBlockRange");
     getCurrentSlotStub = sandbox.stub(slotUtils, "getCurrentSlot");
     chainStub = sandbox.createStubInstance(BeaconChain);
@@ -48,6 +47,7 @@ describe("BlockRangeFetcher", function () {
       },
       getPeers
     );
+    getPeers.resolves([await PeerId.create()]);
   });
 
   afterEach(() => {
@@ -126,25 +126,38 @@ describe("BlockRangeFetcher", function () {
     expect(result).to.be.deep.equal([firstBlock]);
   });
 
-  it("should handle getBlockRange returning no block", async () => {
+  it("should handle getBlockRange returning no block or single block", async () => {
+    // expect 2 things
+    // switch peer since some weird peers keep returning 0 block or 1 block
+    // same start, expand end
+    const firstPeerId = await PeerId.create();
+    getPeers.onFirstCall().resolves([firstPeerId]);
+    const secondPeerId = await PeerId.create();
+    getPeers.onSecondCall().resolves([secondPeerId]);
     // fetcher should not trust a getBlockRange returning empty array using handleEmptyRange
     fetcher.setLastProcessedBlock({blockRoot: ZERO_HASH, slot: 1000});
     getCurrentSlotStub.returns(2000);
-    getBlockRangeStub.onFirstCall().resolves([]);
     const firstBlock = generateEmptySignedBlock();
     firstBlock.message.slot = 1010;
     const secondBlock = generateEmptySignedBlock();
     secondBlock.message.slot = 1011;
     secondBlock.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(firstBlock.message);
-    getBlockRangeStub.onSecondCall().resolves([firstBlock, secondBlock]);
+    getBlockRangeStub.onFirstCall().resolves([]);
+    getBlockRangeStub.onSecondCall().resolves([firstBlock]);
+    getBlockRangeStub.onThirdCall().resolves([firstBlock, secondBlock]);
     metadataStub.getStatus.returns({headSlot: 3000} as Status);
     const result = await fetcher.getNextBlockRange();
+    expect(getPeers.calledThrice).to.be.true;
+    // should switch peer
+    expect(getPeers.calledWithExactly([firstPeerId.toB58String()])).to.be.true;
+    expect(getPeers.calledWithExactly([secondPeerId.toB58String()])).to.be.true;
     // second block is ignored since we can't validate if it's orphaned block or not
     expect(result).to.be.deep.equal([firstBlock]);
     expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1066})).to.be.true;
     // same start, expand end
     expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1131})).to.be.true;
-    expect(getBlockRangeStub.calledTwice).to.be.true;
+    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1196})).to.be.true;
+    expect(getBlockRangeStub.calledThrice).to.be.true;
   });
 
   it("should handle getBlockRange timeout", async () => {

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
@@ -163,8 +163,8 @@ describe("BlockRangeFetcher", function () {
     expect(result).to.be.deep.equal([firstBlock]);
     expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1065})).to.be.true;
     // same start, expand end
-    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1130})).to.be.true;
-    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1195})).to.be.true;
+    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1066})).to.be.true;
+    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1067})).to.be.true;
     expect(getBlockRangeStub.calledThrice).to.be.true;
   });
 
@@ -196,7 +196,7 @@ describe("BlockRangeFetcher", function () {
     expect(result).to.be.deep.equal([secondBlock]);
     expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1065})).to.be.true;
     // same start, expand end
-    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1130})).to.be.true;
+    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1066})).to.be.true;
     expect(getBlockRangeStub.calledTwice).to.be.true;
   });
 

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
@@ -63,7 +63,7 @@ describe("BlockRangeFetcher", function () {
     secondBlock.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(firstBlock.message);
     getBlockRangeStub.resolves([firstBlock, secondBlock]);
     await fetcher.getNextBlockRange();
-    expect(getBlockRangeStub.calledOnceWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1066})).to.be
+    expect(getBlockRangeStub.calledOnceWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1065})).to.be
       .true;
   });
 
@@ -83,11 +83,11 @@ describe("BlockRangeFetcher", function () {
     getBlockRangeStub.onFirstCall().resolves([firstBlock, secondBlock]);
     getBlockRangeStub.onSecondCall().resolves([secondBlock, thirdBlock]);
     let result = await fetcher.getNextBlockRange();
-    expect(getBlockRangeStub.calledOnceWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1066})).to.be
+    expect(getBlockRangeStub.calledOnceWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1065})).to.be
       .true;
     expect(result).to.be.deep.equal([firstBlock]);
     result = await fetcher.getNextBlockRange();
-    expect(getBlockRangeStub.lastCall.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1011, end: 1076})).to
+    expect(getBlockRangeStub.lastCall.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1010, end: 1075})).to
       .be.true;
     expect(result).to.be.deep.equal([secondBlock]);
   });
@@ -103,7 +103,7 @@ describe("BlockRangeFetcher", function () {
     secondBlock.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(firstBlock.message);
     getBlockRangeStub.onSecondCall().resolves([firstBlock, secondBlock]);
     const result = await fetcher.getNextBlockRange();
-    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1066})).to.be.true;
+    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1065})).to.be.true;
     expect(getBlockRangeStub.calledTwice).to.be.true;
     // second block is ignored since we can't validate if it's orphaned block or not
     expect(result).to.be.deep.equal([firstBlock]);
@@ -120,7 +120,7 @@ describe("BlockRangeFetcher", function () {
     secondBlock.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(firstBlock.message);
     getBlockRangeStub.onSecondCall().resolves([firstBlock, secondBlock]);
     const result = await fetcher.getNextBlockRange();
-    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1066})).to.be.true;
+    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1065})).to.be.true;
     expect(getBlockRangeStub.calledTwice).to.be.true;
     // second block is ignored since we can't validate if it's orphaned block or not
     expect(result).to.be.deep.equal([firstBlock]);
@@ -153,10 +153,10 @@ describe("BlockRangeFetcher", function () {
     expect(getPeers.calledWithExactly([secondPeerId.toB58String()])).to.be.true;
     // second block is ignored since we can't validate if it's orphaned block or not
     expect(result).to.be.deep.equal([firstBlock]);
-    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1066})).to.be.true;
+    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1065})).to.be.true;
     // same start, expand end
-    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1131})).to.be.true;
-    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1196})).to.be.true;
+    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1130})).to.be.true;
+    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1195})).to.be.true;
     expect(getBlockRangeStub.calledThrice).to.be.true;
   });
 
@@ -198,7 +198,7 @@ describe("BlockRangeFetcher", function () {
     // 2nd block is not validated so it's not returned
     expect(result).to.be.deep.equal([firstBlock]);
     expect(getBlockRangeStub.calledTwice).to.be.true;
-    expect(getBlockRangeStub.alwaysCalledWith(logger, sinon.match.any, sinon.match.any, {start: 1001, end: 1066})).to.be
+    expect(getBlockRangeStub.alwaysCalledWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1065})).to.be
       .true;
   });
 });

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
@@ -22,21 +22,21 @@ describe("BlockRangeFetcher", function () {
   let metadataStub: SinonStubbedInstance<IPeerMetadataStore>;
   let getBlockRangeStub: SinonStub;
   let getCurrentSlotStub: SinonStub;
-  let clock: SinonFakeTimers;
   const getPeers = async (): Promise<PeerId[]> => {
     return [await PeerId.create()];
   };
   const logger = new WinstonLogger();
+  const sandbox = sinon.createSandbox();
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers();
-    getBlockRangeStub = sinon.stub(blockUtils, "getBlockRange");
-    getCurrentSlotStub = sinon.stub(slotUtils, "getCurrentSlot");
-    chainStub = sinon.createStubInstance(BeaconChain);
-    clockStub = sinon.createStubInstance(LocalClock);
+    sandbox.useFakeTimers();
+    getBlockRangeStub = sandbox.stub(blockUtils, "getBlockRange");
+    getCurrentSlotStub = sandbox.stub(slotUtils, "getCurrentSlot");
+    chainStub = sandbox.createStubInstance(BeaconChain);
+    clockStub = sandbox.createStubInstance(LocalClock);
     chainStub.clock = clockStub;
-    networkStub = sinon.createStubInstance(Libp2pNetwork);
-    metadataStub = sinon.createStubInstance(Libp2pPeerMetadataStore);
+    networkStub = sandbox.createStubInstance(Libp2pNetwork);
+    metadataStub = sandbox.createStubInstance(Libp2pPeerMetadataStore);
     networkStub.peerMetadata = metadataStub;
     fetcher = new BlockRangeFetcher(
       {},
@@ -51,8 +51,7 @@ describe("BlockRangeFetcher", function () {
   });
 
   afterEach(() => {
-    sinon.restore();
-    clock.restore();
+    sandbox.restore();
   });
 
   it("should fetch next range initially", async () => {
@@ -164,7 +163,7 @@ describe("BlockRangeFetcher", function () {
     const triggerTimeout = async (): Promise<void> => {
       await getPeers();
       // want to run this after the getPeers() call inside getNextBlockRange()
-      clock.tick(3 * 60 * 1000);
+      sandbox.clock.tick(3 * 60 * 1000);
     };
     await Promise.all([fetcher.getNextBlockRange(), triggerTimeout()]);
     expect(getBlockRangeStub.calledTwice).to.be.true;

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
@@ -158,7 +158,7 @@ describe("BlockRangeFetcher", function () {
     expect(getPeers.calledThrice).to.be.true;
     // should switch peer
     expect(getPeers.calledWithExactly([firstPeerId.toB58String()])).to.be.true;
-    expect(getPeers.calledWithExactly([secondPeerId.toB58String()])).to.be.true;
+    expect(getPeers.calledWithExactly([firstPeerId.toB58String(), secondPeerId.toB58String()])).to.be.true;
     // second block is ignored since we can't validate if it's orphaned block or not
     expect(result).to.be.deep.equal([firstBlock]);
     expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1065})).to.be.true;

--- a/packages/lodestar/test/unit/sync/stats/rate.test.ts
+++ b/packages/lodestar/test/unit/sync/stats/rate.test.ts
@@ -3,6 +3,13 @@ import {expect} from "chai";
 import sinon from "sinon";
 
 describe("rate counter", function () {
+  const sandbox = sinon.createSandbox();
+  beforeEach(() => {
+    sandbox.useFakeTimers();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
   it("should throw if period less than one", function () {
     expect(() => new RateCounter(0)).to.throw();
   });
@@ -14,16 +21,15 @@ describe("rate counter", function () {
   });
 
   it("should get rate", async function () {
-    const timer = sinon.useFakeTimers();
     const rate = new RateCounter(10);
     await rate.start();
     rate.increment(2);
-    timer.tick(2000);
+    sandbox.clock.tick(2000);
     expect(rate.rate()).to.equal(1);
-    timer.tick(8000);
+    sandbox.clock.tick(8000);
     expect(rate.rate()).to.equal(0);
     rate.increment(1);
-    timer.tick(2000);
+    sandbox.clock.tick(2000);
     expect(rate.rate()).to.equal(0.5);
     await rate.stop();
   });

--- a/packages/lodestar/test/unit/sync/utils/attestation-collector.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/attestation-collector.test.ts
@@ -11,14 +11,18 @@ import {Gossip} from "../../../../src/network/gossip/gossip";
 import {BeaconDb} from "../../../../src/db";
 import {generateState} from "../../../utils/state";
 import {silentLogger} from "../../../utils/logger";
-import { sleep } from "@chainsafe/lodestar-utils";
 
 describe("Attestation collector", function () {
   const sandbox = sinon.createSandbox();
   const logger = silentLogger;
+  beforeEach(() => {
+    sandbox.useFakeTimers();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
 
   it("should subscribe and collect attestations", async function () {
-    const clock = sandbox.useFakeTimers();
     const fakeGossip = sandbox.createStubInstance(Gossip);
     const dbStub = sandbox.createStubInstance(BeaconDb);
     const computeSubnetStub = sandbox.stub(attestationUtils, "computeSubnetForSlot");
@@ -49,13 +53,13 @@ describe("Attestation collector", function () {
     computeSubnetStub.returns(10);
     await collector.subscribeToCommitteeAttestations(1, 1);
     expect(fakeGossip.subscribeToAttestationSubnet.withArgs(sinon.match.any, 10).calledOnce).to.be.true;
-    clock.tick(config.params.SECONDS_PER_SLOT * 1000);
+    sandbox.clock.tick(config.params.SECONDS_PER_SLOT * 1000);
     await new Promise((resolve) => {
       fakeGossip.subscribeToAttestationSubnet.callsFake(resolve);
     });
     expect(fakeGossip.subscribeToAttestationSubnet.withArgs(sinon.match.any, 10, sinon.match.func).calledOnce).to.be
       .true;
-    clock.tick(config.params.SECONDS_PER_SLOT * 1000);
+    sandbox.clock.tick(config.params.SECONDS_PER_SLOT * 1000);
     expect(fakeGossip.unsubscribeFromAttestationSubnet.withArgs(sinon.match.any, 10, sinon.match.func).calledOnce).to.be
       .true;
     await collector.stop();
@@ -63,7 +67,6 @@ describe("Attestation collector", function () {
   });
 
   it("should skip if there is no duties", async function () {
-    const clock = sandbox.useFakeTimers();
     const emitter = new ChainEventEmitter();
     const abortController = new AbortController();
     const realClock = new LocalClock({
@@ -88,7 +91,7 @@ describe("Attestation collector", function () {
       logger,
     });
     await collector.start();
-    clock.tick(config.params.SECONDS_PER_SLOT * 1000);
+    sandbox.clock.tick(config.params.SECONDS_PER_SLOT * 1000);
     expect(fakeGossip.subscribeToAttestationSubnet.called).to.be.false;
     await collector.stop();
     abortController.abort();

--- a/packages/lodestar/test/unit/sync/utils/block.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/block.test.ts
@@ -17,6 +17,7 @@ describe("sync - block utils", function () {
     let rpcStub: SinonStubbedInstance<ReqResp>;
 
     beforeEach(function () {
+      sandbox.useFakeTimers();
       rpcStub = sandbox.createStubInstance(ReqResp);
     });
 
@@ -36,17 +37,15 @@ describe("sync - block utils", function () {
     });
 
     it("refetch failed chunks", async function () {
-      const timer = sinon.useFakeTimers();
       const peer1 = await PeerId.create();
       const peer2 = await PeerId.create();
       const peers = [peer1, peer2];
       rpcStub.beaconBlocksByRange.onFirstCall().resolves(null);
       rpcStub.beaconBlocksByRange.onSecondCall().resolves([generateEmptySignedBlock(), generateEmptySignedBlock()]);
       const blockPromise = getBlockRange(logger, rpcStub, peers, {start: 0, end: 4}, 2);
-      await timer.tickAsync(1000);
+      await sandbox.clock.tickAsync(1000);
       const blocks = await blockPromise;
       expect(blocks?.length).to.be.equal(2);
-      timer.reset();
     });
 
     it("no chunks", async function () {

--- a/packages/lodestar/test/unit/sync/utils/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/sync.test.ts
@@ -3,7 +3,7 @@ import deepmerge from "deepmerge";
 import all from "it-all";
 import pipe from "it-pipe";
 import PeerId from "peer-id";
-import sinon, {SinonFakeTimers, SinonStub, SinonStubbedInstance} from "sinon";
+import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
 
 import {Checkpoint, Status} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/lib/presets/minimal";
@@ -33,7 +33,7 @@ import {Libp2pPeerMetadataStore} from "../../../../src/network/peers/metastore";
 import {silentLogger} from "../../../utils/logger";
 import {IRpcScoreTracker, SimpleRpcScoreTracker} from "../../../../src/network/peers";
 
-describe.skip("sync utils", function () {
+describe("sync utils", function () {
   const logger = silentLogger;
   const sandbox = sinon.createSandbox();
 
@@ -141,6 +141,7 @@ describe.skip("sync utils", function () {
     let getPeersStub: SinonStub, getBlockRangeStub: SinonStub;
 
     beforeEach(function () {
+      sandbox.useFakeTimers();
       getPeersStub = sinon.stub();
       getBlockRangeStub = sandbox.stub(blockUtils, "getBlockRange");
     });

--- a/packages/lodestar/test/unit/sync/utils/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/sync.test.ts
@@ -33,16 +33,16 @@ import {Libp2pPeerMetadataStore} from "../../../../src/network/peers/metastore";
 import {silentLogger} from "../../../utils/logger";
 import {IRpcScoreTracker, SimpleRpcScoreTracker} from "../../../../src/network/peers";
 
-describe("sync utils", function () {
+describe.skip("sync utils", function () {
   const logger = silentLogger;
-  let timer: SinonFakeTimers;
+  const sandbox = sinon.createSandbox();
 
   beforeEach(function () {
-    timer = sinon.useFakeTimers();
+    sandbox.useFakeTimers();
   });
 
   after(function () {
-    timer.restore();
+    sandbox.restore();
   });
 
   describe("get highest common slot", function () {
@@ -157,7 +157,7 @@ describe("sync utils", function () {
         fetchBlockChunks(logger, sinon.createStubInstance(ReqResp), getPeersStub),
         all
       );
-      await timer.tickAsync(30000);
+      await sandbox.clock.tickAsync(30000);
       result = await result;
       expect(result.length).to.be.equal(1);
       expect(result[0]).to.be.null;

--- a/packages/lodestar/test/unit/sync/utils/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/sync.test.ts
@@ -377,14 +377,14 @@ describe.skip("sync utils", function () {
 
   describe("checkLinearChainSegment", function () {
     it("should throw error if not enough block", () => {
-      expect(() => checkLinearChainSegment(config, ZERO_HASH, null)).to.throw("Not enough blocks to validate");
-      expect(() => checkLinearChainSegment(config, ZERO_HASH, [])).to.throw("Not enough blocks to validate");
-      expect(() => checkLinearChainSegment(config, ZERO_HASH, [generateEmptySignedBlock()])).to.throw("Not enough blocks to validate");
+      expect(() => checkLinearChainSegment(config, null)).to.throw("Not enough blocks to validate");
+      expect(() => checkLinearChainSegment(config, [])).to.throw("Not enough blocks to validate");
+      expect(() => checkLinearChainSegment(config, [generateEmptySignedBlock()])).to.throw("Not enough blocks to validate");
     });
 
     it("should throw error if first block not link to ancestor root", () => {
       const block = generateEmptySignedBlock();
-      expect(() => checkLinearChainSegment(config, ZERO_HASH, [block, block])).to.throw("Block 0 does not link to parent 0xeade62f0457b2fdf48e7d3fc4b60736688286be7c7a3ac4c9a16a5e0600bd9e4");
+      expect(() => checkLinearChainSegment(config, [block, block])).to.throw("Block 0 does not link to parent 0xeade62f0457b2fdf48e7d3fc4b60736688286be7c7a3ac4c9a16a5e0600bd9e4");
     });
 
     it("should throw error if second block not link to first block", () => {
@@ -393,7 +393,7 @@ describe.skip("sync utils", function () {
       const secondBlock = generateEmptySignedBlock();
       secondBlock.message.slot = 1;
       // secondBlock.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(firstBlock.message);
-      expect(() => checkLinearChainSegment(config, ancestorRoot, [firstBlock, secondBlock])).to.throw("Block 1 does not link to parent 0xeade62f0457b2fdf48e7d3fc4b60736688286be7c7a3ac4c9a16a5e0600bd9e4");
+      expect(() => checkLinearChainSegment(config, [firstBlock, secondBlock], ancestorRoot)).to.throw("Block 1 does not link to parent 0xeade62f0457b2fdf48e7d3fc4b60736688286be7c7a3ac4c9a16a5e0600bd9e4");
     });
 
     it("should form linear chain segment", () => {
@@ -402,7 +402,7 @@ describe.skip("sync utils", function () {
       const secondBlock = generateEmptySignedBlock();
       secondBlock.message.slot = 1;
       secondBlock.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(firstBlock.message);
-      checkLinearChainSegment(config, ancestorRoot, [firstBlock, secondBlock]);
+      checkLinearChainSegment(config, [firstBlock, secondBlock], ancestorRoot);
       // no error thrown means success
     });
   });


### PR DESCRIPTION
resolves #1727 
and fix some found issues during the test of regular sync (hard coded to get through the big unfinality period)

+ avoid orphaned block to be imported by using a linear chain
+ a linear chain segment means every block being parent of next block and child of previous block
+ always switch peer in case of error, `getBestPeer()` now support an `excludedList` of bad peers to make sure we don't retry the old bad peers
+ slowly expand range end in the case of `handleEmptyRange`
+ have to go with sandbox fake timers instead of sinon to get through unit tests

