### PR TITLE
Archive Blocks: process canonical blocks in chunks

### DIFF
--- a/packages/lodestar-fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/lodestar-fork-choice/src/forkChoice/forkChoice.ts
@@ -530,8 +530,8 @@ export class ForkChoice implements IForkChoice {
     return this.protoArray.isDescendant(toHexString(ancestorRoot), toHexString(descendantRoot));
   }
 
-  public prune(): IBlockSummary[] {
-    return this.protoArray.maybePrune(toHexString(this.fcStore.finalizedCheckpoint.root)).map(toBlockSummary);
+  public prune(finalizedRoot: Root): IBlockSummary[] {
+    return this.protoArray.maybePrune(toHexString(finalizedRoot)).map(toBlockSummary);
   }
 
   public setPruneThreshold(threshold: number): void {

--- a/packages/lodestar-fork-choice/src/forkChoice/interface.ts
+++ b/packages/lodestar-fork-choice/src/forkChoice/interface.ts
@@ -105,7 +105,10 @@ export interface IForkChoice {
    * Still returns `true` if `ancestorRoot===descendantRoot` (and the roots are known)
    */
   isDescendant(ancestorRoot: Root, descendantRoot: Root): boolean;
-  prune(): IBlockSummary[];
+  /**
+   * Prune items up to a finalized root.
+   */
+  prune(finalizedRoot: Root): IBlockSummary[];
   setPruneThreshold(threshold: number): void;
   /**
    * Iterates backwards through block summaries, starting from a block root

--- a/packages/lodestar/src/tasks/index.ts
+++ b/packages/lodestar/src/tasks/index.ts
@@ -89,7 +89,8 @@ export class TasksService implements IService {
         this.db.aggregateAndProof.pruneFinalized(finalized.epoch),
       ]);
       // tasks rely on extended fork choice
-      this.chain.forkChoice.prune();
+      this.chain.forkChoice.prune(finalized.root);
+      this.logger.info("Finish processing finalized checkpoint for epoch #", finalized.epoch);
     } catch (e) {
       this.logger.error("Error processing finalized checkpoint of epoch #" + finalized.epoch, e);
     }

--- a/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
@@ -39,7 +39,7 @@ export class ArchiveBlocksTask implements ITask {
    * Only archive blocks on the same chain to the finalized checkpoint.
    */
   public async run(): Promise<void> {
-    this.logger.profile("Archive Blocks");
+    this.logger.profile("Archive Blocks epoch #" + this.finalized.epoch);
     // Use fork choice to determine the blocks to archive and delete
     const allCanonicalSummaries = this.forkChoice.iterateBlockSummaries(this.finalized.root);
     let i = 0;
@@ -57,7 +57,7 @@ export class ArchiveBlocksTask implements ITask {
       i = upperBound;
     }
     await this.deleteNonCanonicalBlocks();
-    this.logger.profile("Archive Blocks");
+    this.logger.profile("Archive Blocks epoch #" + this.finalized.epoch);
     this.logger.info("Archiving of finalized blocks complete.", {
       totalArchived: allCanonicalSummaries.length,
       finalizedEpoch: this.finalized.epoch,

--- a/packages/lodestar/src/tasks/tasks/archiveStates.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveStates.ts
@@ -34,16 +34,16 @@ export class ArchiveStatesTask implements ITask {
 
   public async run(): Promise<void> {
     this.logger.info(`Started archiving states (finalized epoch #${this.finalized.epoch})...`);
-    this.logger.profile("Archive States");
+    this.logger.profile("Archive States epoch #" + this.finalized.epoch);
     // store the state of finalized checkpoint
     const stateCache = await this.db.checkpointStateCache.get(this.finalized);
     if (!stateCache) {
-      throw Error("No state in cache for finalized checkpoint state");
+      throw Error("No state in cache for finalized checkpoint state epoch #" + this.finalized.epoch);
     }
     const finalizedState = stateCache.state;
     await this.db.stateArchive.add(finalizedState);
     // don't delete states before the finalized state, auto-prune will take care of it
     this.logger.info(`Archiving of finalized states completed (finalized epoch #${this.finalized.epoch})`);
-    this.logger.profile("Archive States");
+    this.logger.profile("Archive States epoch #" + this.finalized.epoch);
   }
 }

--- a/packages/lodestar/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/lodestar/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -118,7 +118,7 @@ describe("LodestarForkChoice", function () {
       expect(forkChoice.hasBlock(config.types.BeaconBlock.hashTreeRoot(block08.message))).to.be.true;
       expect(forkChoice.hasBlock(config.types.BeaconBlock.hashTreeRoot(block12.message))).to.be.true;
       forkChoice.onBlock(block32.message, state32, justifiedBalances);
-      forkChoice.prune();
+      forkChoice.prune(config.types.BeaconBlock.hashTreeRoot(block16.message));
       expect(
         forkChoice.iterateBlockSummaries(config.types.BeaconBlock.hashTreeRoot(block16.message)).length
       ).to.be.equal(1);

--- a/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
+++ b/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
@@ -53,8 +53,13 @@ describe("block archiver task", function () {
     );
     await archiverTask.run();
     expect(
-      dbStub.blockArchive.batchPut.calledWith(canonicalBlocks.map((b) => ({key: b.slot, value: generateEmptySignedBlock()})))
+      dbStub.blockArchive.batchPut.calledWith(
+        canonicalBlocks.map((b) => ({key: b.slot, value: generateEmptySignedBlock()}))
+      )
     ).to.be.true;
-    expect(dbStub.block.batchDelete.calledWith([ZERO_HASH, ZERO_HASH, ZERO_HASH, ZERO_HASH, ZERO_HASH])).to.be.true;
+    // delete canonical blocks
+    expect(dbStub.block.batchDelete.calledWith([ZERO_HASH, ZERO_HASH, ZERO_HASH, ZERO_HASH])).to.be.true;
+    // delete non canonical blocks
+    expect(dbStub.block.batchDelete.calledWith([ZERO_HASH])).to.be.true;
   });
 });


### PR DESCRIPTION
resolves #1738 

+ After the long infinality period, number of canonical blocks is 77614
+ Process canonical blocks in chunks to avoid OOM
+ Use db getBinary/batchPutBinary and forkchoice iterateNonAncestors to improve performance