### PR TITLE
fix slashingProtection reference

### DIFF
--- a/packages/lodestar-cli/test/unit/config/fileEnr.test.ts
+++ b/packages/lodestar-cli/test/unit/config/fileEnr.test.ts
@@ -5,7 +5,7 @@ import {existsSync} from "fs";
 import rimraf from "rimraf";
 import {initEnr, initPeerId, readPeerId, FileENR} from "../../../src/config";
 import {testFilesDir} from "../../utils";
-import {getBeaconPaths} from "@chainsafe/lodestar-cli/src/cmds/beacon/paths";
+import {getBeaconPaths} from "../../../src/cmds/beacon/paths";
 
 describe("fileENR", function () {
   const rootDir = testFilesDir;

--- a/packages/lodestar-validator/src/slashingProtection/index.ts
+++ b/packages/lodestar-validator/src/slashingProtection/index.ts
@@ -15,7 +15,7 @@ import {
   serializeInterchange,
 } from "./interchange";
 import {MinMaxSurround, DistanceStoreRepository} from "./minMaxSurround";
-import {uniqueVectorArr} from "@chainsafe/lodestar-validator/src/slashingProtection/utils";
+import {uniqueVectorArr} from "../slashingProtection/utils";
 
 export {InvalidAttestationError, InvalidAttestationErrorCode} from "./attestation";
 export {InvalidBlockError, InvalidBlockErrorCode} from "./block";


### PR DESCRIPTION
I was getting an error `Error: Cannot find module '@chainsafe/lodestar-validator/src/slashingProtection/utils'` when trying to run `init`, so i changed the reference to be local rather than referencing the global package name to get past the error.