### PR TITLE
Fix vscode self reference

### DIFF
--- a/packages/lodestar-validator/src/slashingProtection/index.ts
+++ b/packages/lodestar-validator/src/slashingProtection/index.ts
@@ -15,7 +15,7 @@ import {
   serializeInterchange,
 } from "./interchange";
 import {MinMaxSurround, DistanceStoreRepository} from "./minMaxSurround";
-import {uniqueVectorArr} from "@chainsafe/lodestar-validator/src/slashingProtection/utils";
+import {uniqueVectorArr} from "./utils";
 
 export {InvalidAttestationError, InvalidAttestationErrorCode} from "./attestation";
 export {InvalidBlockError, InvalidBlockErrorCode} from "./block";


### PR DESCRIPTION
I found one more place in lodestar-validator that refer to itself