### PR TITLE
check for db and/or passed-in genesisStateFile before downloading testnet genesis.ssz

### DIFF
--- a/packages/lodestar-cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/initBeaconState.ts
@@ -30,11 +30,13 @@ export async function initBeaconState(
   logger: ILogger,
   signal: AbortSignal
 ): Promise<TreeBacked<BeaconState>> {
-  if (args.testnet && !args.genesisStateFile) {
+  const shouldInitFromDb = (await db.stateArchive.lastKey()) != null;
+
+  if (args.testnet && !args.genesisStateFile && !shouldInitFromDb) {
     args.genesisStateFile = getGenesisFileUrl(args.testnet) ?? undefined;
   }
+
   const shouldInitFromFile = Boolean(args.weakSubjectivityStateFile || (!args.forceGenesis && args.genesisStateFile));
-  const shouldInitFromDb = (await db.stateArchive.lastKey()) != null;
   let anchorState;
 
   if (shouldInitFromFile) {

--- a/packages/lodestar-cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/initBeaconState.ts
@@ -30,13 +30,12 @@ export async function initBeaconState(
   logger: ILogger,
   signal: AbortSignal
 ): Promise<TreeBacked<BeaconState>> {
-  const shouldInitFromFile = Boolean(args.weakSubjectivityStateFile || (!args.forceGenesis && args.genesisStateFile));
-  const shouldInitFromDb = (await db.stateArchive.lastKey()) != null;
-  let anchorState;
-
   if (args.testnet && !args.genesisStateFile) {
     args.genesisStateFile = getGenesisFileUrl(args.testnet) ?? undefined;
   }
+  const shouldInitFromFile = Boolean(args.weakSubjectivityStateFile || (!args.forceGenesis && args.genesisStateFile));
+  const shouldInitFromDb = (await db.stateArchive.lastKey()) != null;
+  let anchorState;
 
   if (shouldInitFromFile) {
     const anchorStateFile = (args.weakSubjectivityStateFile || args.genesisStateFile) as string;


### PR DESCRIPTION
The genesisStateFile wasn't actually being downloaded if we didn't already have something in the db.  This changes the process to where we only download if we aren't going to init from db and we aren't manually passing in a genesisStateFile via the cli option.