### PR TITLE
Implement initiateMultipleValidatorExits

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/fast/block/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/index.ts
@@ -9,7 +9,7 @@ import {processAttestation} from "./processAttestation";
 import {processAttesterSlashing} from "./processAttesterSlashing";
 import {processDeposit} from "./processDeposit";
 import {processProposerSlashing} from "./processProposerSlashing";
-import {processVoluntaryExit} from "./processVoluntaryExit";
+import {processVoluntaryExits} from "./processVoluntaryExit";
 
 export {
   processBlockHeader,
@@ -20,7 +20,7 @@ export {
   processAttesterSlashing,
   processDeposit,
   processProposerSlashing,
-  processVoluntaryExit,
+  processVoluntaryExits,
 };
 
 export function processBlock(

--- a/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
@@ -42,7 +42,7 @@ export function initiateMultipleValidatorExits(
   state: BeaconState,
   indexes: ValidatorIndex[] = []
 ): void {
-  if (!indexes.length) return;
+  if (!indexes || indexes.length === 0) return;
   const config = epochCtx.config;
   // compute exit queue epoch
   const validatorExitEpochs = readOnlyMap(state.validators, (v) => v.exitEpoch);
@@ -51,10 +51,10 @@ export function initiateMultipleValidatorExits(
   const currentEpoch = epochCtx.currentShuffling.epoch;
   const activationExitEpoch = computeActivationExitEpoch(config, currentEpoch);
   for (const index of indexes) {
-    // return if validator already initiated exit
+    // continue if validator already initiated exit
     const validator = state.validators[index];
     if (validator.exitEpoch !== FAR_FUTURE_EPOCH) {
-      return;
+      continue;
     }
     let exitQueueEpoch = Math.max(...exitEpochs, activationExitEpoch);
     const exitQueueChurn = validatorExitEpochs.filter((exitEpoch) => exitEpoch === exitQueueEpoch).length;

--- a/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
@@ -5,6 +5,9 @@ import {FAR_FUTURE_EPOCH} from "../../constants";
 import {computeActivationExitEpoch, getChurnLimit} from "../../util";
 import {EpochContext} from "../util";
 
+/**
+ * Old implementation following the spec, mainly for the spec test.
+ */
 export function initiateValidatorExit(epochCtx: EpochContext, state: BeaconState, index: ValidatorIndex): void {
   const config = epochCtx.config;
   // return if validator already initiated exit
@@ -28,4 +31,40 @@ export function initiateValidatorExit(epochCtx: EpochContext, state: BeaconState
   // set validator exit epoch and withdrawable epoch
   validator.exitEpoch = exitQueueEpoch;
   validator.withdrawableEpoch = validator.exitEpoch + config.params.MIN_VALIDATOR_WITHDRAWABILITY_DELAY;
+}
+
+/**
+ * Optimized version of initiateValidatorExit where we process validators in batch.
+ * The main thing is to loop through state.validators exactly 1 time.
+ */
+export function initiateMultipleValidatorExits(
+  epochCtx: EpochContext,
+  state: BeaconState,
+  indexes: ValidatorIndex[]
+): void {
+  const config = epochCtx.config;
+  // compute exit queue epoch
+  const validatorExitEpochs = readOnlyMap(state.validators, (v) => v.exitEpoch);
+  const exitEpochs = validatorExitEpochs.filter((exitEpoch) => exitEpoch !== FAR_FUTURE_EPOCH);
+  const churnLimit = getChurnLimit(config, epochCtx.currentShuffling.activeIndices.length);
+  const currentEpoch = epochCtx.currentShuffling.epoch;
+  const activationExitEpoch = computeActivationExitEpoch(config, currentEpoch);
+  for (const index of indexes) {
+    // return if validator already initiated exit
+    const validator = state.validators[index];
+    if (validator.exitEpoch !== FAR_FUTURE_EPOCH) {
+      return;
+    }
+    let exitQueueEpoch = Math.max(...exitEpochs, activationExitEpoch);
+    const exitQueueChurn = validatorExitEpochs.filter((exitEpoch) => exitEpoch === exitQueueEpoch).length;
+    if (exitQueueChurn >= churnLimit) {
+      exitQueueEpoch += 1;
+    }
+
+    // set validator exit epoch and withdrawable epoch
+    validator.exitEpoch = exitQueueEpoch;
+    validator.withdrawableEpoch = exitQueueEpoch + config.params.MIN_VALIDATOR_WITHDRAWABILITY_DELAY;
+    validatorExitEpochs[index] = exitQueueEpoch;
+    exitEpochs.push(exitQueueEpoch);
+  }
 }

--- a/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
@@ -6,7 +6,7 @@ import {computeActivationExitEpoch, getChurnLimit} from "../../util";
 import {EpochContext} from "../util";
 
 /**
- * Initiate a single validator exit.
+ * Initiate a single validator exit, similar to the spec, for backward reference only.
  */
 export function initiateValidatorExit(epochCtx: EpochContext, state: BeaconState, index: ValidatorIndex): void {
   const config = epochCtx.config;

--- a/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
@@ -40,8 +40,9 @@ export function initiateValidatorExit(epochCtx: EpochContext, state: BeaconState
 export function initiateMultipleValidatorExits(
   epochCtx: EpochContext,
   state: BeaconState,
-  indexes: ValidatorIndex[]
+  indexes: ValidatorIndex[] = []
 ): void {
+  if (!indexes.length) return;
   const config = epochCtx.config;
   // compute exit queue epoch
   const validatorExitEpochs = readOnlyMap(state.validators, (v) => v.exitEpoch);

--- a/packages/lodestar-beacon-state-transition/src/fast/block/processVoluntaryExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/processVoluntaryExit.ts
@@ -6,7 +6,27 @@ import {computeSigningRoot, getDomain, isActiveValidator} from "../../util";
 import {EpochContext} from "../util";
 import {initiateValidatorExit} from "./initiateValidatorExit";
 
+/**
+ * This is for the spec test only.
+ * Use verifyVoluntaryExit to process validator exits in batch.
+ */
 export function processVoluntaryExit(
+  epochCtx: EpochContext,
+  state: BeaconState,
+  signedVoluntaryExit: SignedVoluntaryExit,
+  verifySignature = true
+): void {
+  verifyVoluntaryExit(epochCtx, state, signedVoluntaryExit, verifySignature);
+  // initiate exit
+  const voluntaryExit = signedVoluntaryExit.message;
+  initiateValidatorExit(epochCtx, state, voluntaryExit.validatorIndex);
+}
+
+/**
+ * The same to processVoluntaryExit without calling initiateValidatorExit.
+ * We'll do it in batch.
+ */
+export function verifyVoluntaryExit(
   epochCtx: EpochContext,
   state: BeaconState,
   signedVoluntaryExit: SignedVoluntaryExit,
@@ -48,6 +68,4 @@ export function processVoluntaryExit(
       throw new Error("VoluntaryExit has an invalid signature");
     }
   }
-  // initiate exit
-  initiateValidatorExit(epochCtx, state, voluntaryExit.validatorIndex);
 }

--- a/packages/lodestar-beacon-state-transition/src/fast/block/slashValidator.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/slashValidator.ts
@@ -2,7 +2,7 @@ import {BeaconState, ValidatorIndex} from "@chainsafe/lodestar-types";
 
 import {decreaseBalance, increaseBalance} from "../../util";
 import {EpochContext} from "../util";
-import {initiateValidatorExit} from "./initiateValidatorExit";
+import {initiateMultipleValidatorExits} from "./initiateValidatorExit";
 
 export function slashValidator(
   epochCtx: EpochContext,
@@ -17,7 +17,7 @@ export function slashValidator(
     PROPOSER_REWARD_QUOTIENT,
   } = epochCtx.config.params;
   const epoch = epochCtx.currentShuffling.epoch;
-  initiateValidatorExit(epochCtx, state, slashedIndex);
+  initiateMultipleValidatorExits(epochCtx, state, [slashedIndex]);
   const validator = state.validators[slashedIndex];
   validator.slashed = true;
   validator.withdrawableEpoch = Math.max(validator.withdrawableEpoch, epoch + EPOCHS_PER_SLASHINGS_VECTOR);

--- a/packages/spec-test-runner/test/spec/operations/voluntaryExit/voluntary_exit_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/operations/voluntaryExit/voluntary_exit_fast.test.ts
@@ -1,12 +1,13 @@
 import {join} from "path";
 import {expect} from "chai";
-import {BeaconState} from "@chainsafe/lodestar-types";
+import {BeaconState, SignedVoluntaryExit} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
-import {processVoluntaryExit} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/block";
+import {processVoluntaryExits} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/block";
 import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util/lib/single";
 import {IProcessVoluntaryExitTestCase} from "./type";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
+import {List} from "@chainsafe/ssz";
 
 describeDirectorySpecTest<IProcessVoluntaryExitTestCase, BeaconState>(
   "process voluntary exit mainnet",
@@ -15,7 +16,7 @@ describeDirectorySpecTest<IProcessVoluntaryExitTestCase, BeaconState>(
     const state = testcase.pre;
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
-    processVoluntaryExit(epochCtx, state, testcase.voluntary_exit);
+    processVoluntaryExits(epochCtx, state, [testcase.voluntary_exit] as List<SignedVoluntaryExit>);
     return state;
   },
   {


### PR DESCRIPTION
resolves #1761 

+ Keep `initiateValidatorExit` for backward reference, it's the same to the spec
+ Implement `initiateMultipleValidatorExits` which loop through validator array inside state only 1 time
+ Spec test goes through `initiateMultipleValidatorExits`