### PR TITLE
Pin nodejs version in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: "12.14.1"
       - name: Restore dependencies
         uses: actions/cache@master
         id: cache-deps


### PR DESCRIPTION
Docs workflow is failing because our package.json requires node to be <13 but ubuntu-latest ships with node14