### PR TITLE
readable goodbye reason codes

### DIFF
--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -43,6 +43,21 @@ enum GoodByeReasonCode {
   ERROR = 3,
 }
 
+const GoodbyeReasonCodeDescriptions: Record<string, string> = {
+  // spec-defined codes
+  1: "Client shutdown",
+  2: "Irrelevant network",
+  3: "Internal fault/error",
+
+  // Teku-defined codes
+  128: "Unable to verify network",
+
+  // Lighthouse-defined codes
+  129: "Client has too many peers",
+  250: "Peer score too low",
+  251: "Peer banned this node",
+};
+
 /**
  * The BeaconReqRespHandler module handles app-level requests / responses from other peers,
  * fetching state from the chain and database as needed.
@@ -219,7 +234,11 @@ export class BeaconReqRespHandler implements IReqRespHandler {
     peerId: PeerId,
     sink: Sink<unknown, unknown>
   ): Promise<void> {
-    this.logger.info("Received goodbye request", {peer: peerId.toB58String(), reason: request.body});
+    this.logger.info("Received goodbye request", {
+      peer: peerId.toB58String(),
+      reason: request.body,
+      description: GoodbyeReasonCodeDescriptions[request.body.toString()],
+    });
     await sendResponse(
       {config: this.config, logger: this.logger},
       request.id,


### PR DESCRIPTION
I got a list of known goodbye reason codes from someone at Prysm (or at least the ones that Prysm knows about: https://github.com/prysmaticlabs/prysm/blob/master/beacon-chain/p2p/types/rpc_goodbye_codes.go#L8) and added them to our codebase to where we can print a human-readable form of the codes when we receive them.