### PR TITLE
Update gossipsub

### DIFF
--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -75,7 +75,7 @@
     "it-pushable": "^1.4.0",
     "libp2p": "^0.29.2",
     "libp2p-bootstrap": "^0.12.0",
-    "libp2p-gossipsub": "^0.6.3",
+    "libp2p-gossipsub": "^0.7.0",
     "libp2p-interfaces": "^0.5.2",
     "libp2p-mdns": "^0.15.0",
     "libp2p-mplex": "^0.10.1",

--- a/packages/lodestar/src/network/gossip/constants.ts
+++ b/packages/lodestar/src/network/gossip/constants.ts
@@ -27,3 +27,13 @@ export const enum ExtendedValidatorResult {
   reject = "reject",
   ignore = "ignore",
 }
+
+/**
+ * 4-byte domain for gossip message-id isolation of *invalid* snappy messages
+ */
+export const MESSAGE_DOMAIN_VALID_SNAPPY = Buffer.from("00000000", "hex");
+
+/**
+ * 4-byte domain for gossip message-id isolation of *valid* snappy messages
+ */
+export const MESSAGE_DOMAIN_INVALID_SNAPPY = Buffer.from("01000000", "hex");

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -1,25 +1,30 @@
 import Gossipsub from "libp2p-gossipsub";
-import {assert} from "@chainsafe/lodestar-utils";
 import {InMessage} from "libp2p-interfaces/src/pubsub";
 import {ERR_TOPIC_VALIDATOR_REJECT, ERR_TOPIC_VALIDATOR_IGNORE} from "libp2p-gossipsub/src/constants";
-import {Type} from "@chainsafe/ssz";
-import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {ILogger} from "@chainsafe/lodestar-utils";
+import {Libp2p} from "libp2p-gossipsub/src/interfaces";
 import {compress, uncompress} from "snappyjs";
 
-import {GossipMessageValidatorFn, GossipObject, IGossipMessageValidator} from "./interface";
+import {hash, Type} from "@chainsafe/ssz";
+import {ILogger} from "@chainsafe/lodestar-utils";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {ForkDigest} from "@chainsafe/lodestar-types";
+
+import {GossipMessageValidatorFn, GossipObject, IGossipMessageValidator, ILodestarGossipMessage} from "./interface";
 import {
-  getMessageId,
   getSubnetFromAttestationSubnetTopic,
   isAttestationSubnetTopic,
   topicToGossipEvent,
   getGossipTopic,
+  msgIdToString,
 } from "./utils";
-import {ExtendedValidatorResult, GossipEvent} from "./constants";
+import {
+  ExtendedValidatorResult,
+  GossipEvent,
+  MESSAGE_DOMAIN_INVALID_SNAPPY,
+  MESSAGE_DOMAIN_VALID_SNAPPY,
+} from "./constants";
 import {GOSSIP_MAX_SIZE, ATTESTATION_SUBNET_COUNT} from "../../constants";
 import {getTopicEncoding, GossipEncoding} from "./encoding";
-import {Libp2p} from "libp2p-gossipsub/src/interfaces";
-import {ForkDigest} from "@chainsafe/lodestar-types";
 import {GossipValidationError} from "./errors";
 
 type ValidatorFn = (topic: string, msg: InMessage) => Promise<void>;
@@ -45,7 +50,7 @@ export class LodestarGossipsub extends Gossipsub {
     libp2p: Libp2p,
     options = {}
   ) {
-    super(libp2p, Object.assign(options, {msgIdFn: getMessageId, signMessages: false, strictSigning: false}));
+    super(libp2p, Object.assign(options, {globalSignaturePolicy: "StrictNoSign", D: 8, Dlow: 6}));
     this.transformedObjects = new Map();
     this.config = config;
     this.validator = validator;
@@ -107,11 +112,6 @@ export class LodestarGossipsub extends Gossipsub {
     if (!this.genericIsValid(message)) {
       throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
     }
-    // Gossipsub checks this already
-    assert.true(
-      this.transformedObjects.get(getMessageId(message)) === undefined,
-      "Duplicate message for topic " + topic
-    );
     try {
       const validatorFn = this.getLodestarTopicValidator(topic);
       const objSubnet = this.deserializeGossipMessage(topic, message);
@@ -124,7 +124,10 @@ export class LodestarGossipsub extends Gossipsub {
           throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
         default:
           // no error means accept
-          this.transformedObjects.set(getMessageId(message), {createdAt: new Date(), object: transformedObj!});
+          this.transformedObjects.set(msgIdToString(this.getMsgId(message)), {
+            createdAt: new Date(),
+            object: transformedObj,
+          });
       }
     } catch (e) {
       if (e.code === ERR_TOPIC_VALIDATOR_REJECT) {
@@ -141,7 +144,7 @@ export class LodestarGossipsub extends Gossipsub {
    */
   public _emitMessage(message: InMessage): void {
     message.topicIDs.forEach((topic) => {
-      const transformedObj = this.transformedObjects.get(getMessageId(message));
+      const transformedObj = this.transformedObjects.get(msgIdToString(this.getMsgId(message)));
       if (transformedObj && transformedObj.object) {
         super.emit(topic, transformedObj.object);
       }
@@ -149,16 +152,38 @@ export class LodestarGossipsub extends Gossipsub {
   }
 
   /**
-   * Override https://github.com/ChainSafe/js-libp2p-gossipsub/blob/v0.6.3/ts/index.ts#L1034
+   * Override default `_buildMessage` to snappy-compress the data
    */
-  public _publish(message: InMessage): Promise<void> {
-    assert.true(message.topicIDs && message.topicIDs.length === 1, "lodestar only supports 1 topic per message");
-    assert.true(!!message.data, "message to publish should have data");
-    const encoding = getTopicEncoding(message.topicIDs[0]);
+  public _buildMessage(msg: InMessage): Promise<InMessage> {
+    const encoding = getTopicEncoding(msg.topicIDs[0]);
     if (encoding === GossipEncoding.SSZ_SNAPPY) {
-      message.data = compress<Uint8Array>(message.data!);
+      msg.data = compress(msg.data!);
     }
-    return super._publish(message);
+    return super._buildMessage(msg);
+  }
+
+  /**
+   * Override default `getMsgId` function to cache the message-id
+   */
+  public getMsgId(msg: ILodestarGossipMessage): Uint8Array {
+    if (!msg.msgId) {
+      msg.msgId = this.computeMsgId(msg);
+    }
+    return msg.msgId;
+  }
+
+  private computeMsgId(msg: InMessage): Uint8Array {
+    const encoding = getTopicEncoding(msg.topicIDs[0]);
+    const data = msg.data!;
+    if (encoding === GossipEncoding.SSZ_SNAPPY) {
+      try {
+        const uncompressed = uncompress(data);
+        return hash(Buffer.concat([MESSAGE_DOMAIN_VALID_SNAPPY, uncompressed])).slice(0, 20);
+      } catch (e) {
+        return hash(Buffer.concat([MESSAGE_DOMAIN_INVALID_SNAPPY, data])).slice(0, 20);
+      }
+    }
+    return hash(data).slice(0, 20);
   }
 
   private genericIsValid(message: InMessage): boolean | undefined {
@@ -194,13 +219,14 @@ export class LodestarGossipsub extends Gossipsub {
     return result as GossipMessageValidatorFn;
   }
 
-  private deserializeGossipMessage(topic: string, message: InMessage): {object: GossipObject; subnet?: number} {
+  private deserializeGossipMessage(topic: string, msg: InMessage): {object: GossipObject; subnet?: number} {
+    let data = msg.data!;
     if (getTopicEncoding(topic) === GossipEncoding.SSZ_SNAPPY) {
-      message.data = uncompress(message.data!);
+      data = uncompress(data);
     }
     if (isAttestationSubnetTopic(topic)) {
       const subnet = getSubnetFromAttestationSubnetTopic(topic);
-      return {object: this.config.types.Attestation.deserialize(message.data!), subnet};
+      return {object: this.config.types.Attestation.deserialize(data), subnet};
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let objType: Type<any>;
@@ -224,7 +250,7 @@ export class LodestarGossipsub extends Gossipsub {
       default:
         throw new Error(`Don't know how to deserialize object received under topic ${topic}`);
     }
-    return {object: objType.deserialize(message.data!)};
+    return {object: objType.deserialize(data)};
   }
 
   private cleanUp(): void {

--- a/packages/lodestar/src/network/gossip/interface.ts
+++ b/packages/lodestar/src/network/gossip/interface.ts
@@ -17,7 +17,7 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import LibP2p from "libp2p";
 import {ILogger} from "@chainsafe/lodestar-utils/lib/logger";
 import {IService} from "../../node";
-import {Message} from "libp2p-gossipsub/src/message";
+import {InMessage} from "libp2p-interfaces/src/pubsub";
 import {IBeaconChain} from "../../chain";
 import {ForkDigest} from "@chainsafe/lodestar-types";
 
@@ -103,6 +103,14 @@ export type GossipObject =
 
 export type GossipMessageValidatorFn = (message: GossipObject, subnet?: number) => Promise<ExtendedValidatorResult>;
 
-export interface ILodestarGossipMessage extends Message {
-  messageId: string;
+/**
+ * Overridden `InMessage`
+ *
+ * Since computing a msgId requires uncompressing the data, we cache the msgId
+ */
+export interface ILodestarGossipMessage extends InMessage {
+  /**
+   * Cached message id
+   */
+  msgId?: Uint8Array;
 }

--- a/packages/lodestar/src/network/gossip/utils.ts
+++ b/packages/lodestar/src/network/gossip/utils.ts
@@ -2,14 +2,13 @@
  * @module network/gossip
  */
 
+import {toHexString} from "@chainsafe/ssz";
 import {ForkDigest} from "@chainsafe/lodestar-types";
-import {AttestationSubnetRegExp, GossipEvent, GossipTopicRegExp} from "./constants";
 import {assert} from "@chainsafe/lodestar-utils";
-import {InMessage} from "libp2p-interfaces/src/pubsub";
+
+import {AttestationSubnetRegExp, GossipEvent, GossipTopicRegExp} from "./constants";
 import {IGossipEvents} from "./interface";
-import {hash, toHexString} from "@chainsafe/ssz";
 import {GossipEncoding} from "./encoding";
-import {ZERO_HASH} from "../../constants";
 
 export function getGossipTopic(
   event: GossipEvent,
@@ -59,6 +58,6 @@ export function getSubnetFromAttestationSubnetTopic(topic: string): number {
   return parseInt(subnetStr);
 }
 
-export function getMessageId(message: InMessage): string {
-  return Buffer.from(hash(message.data || ZERO_HASH)).toString("base64");
+export function msgIdToString(msgId: Uint8Array): string {
+  return Buffer.from(msgId).toString("base64");
 }

--- a/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
@@ -57,17 +57,4 @@ describe("gossipsub", function () {
     await gossipSub.libP2pTopicValidator(message.topicIDs[0], message);
     // no error means pass validation
   });
-
-  it("should return false because of duplicate", async () => {
-    validator.isValidIncomingBlock = () => Promise.resolve(ExtendedValidatorResult.accept);
-    await gossipSub.libP2pTopicValidator(message.topicIDs[0], message);
-    // pass validation
-    // receive again => duplicate
-    try {
-      await gossipSub.libP2pTopicValidator(message.topicIDs[0], message);
-      assert.fail("Expect error here because of duplicate");
-    } catch (e) {
-      expect(e.message).to.be.equal("Duplicate message for topic /eth2/00000000/beacon_block/ssz");
-    }
-  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7748,20 +7748,21 @@ libp2p-crypto@^0.18.0:
     uint8arrays "^1.1.0"
     ursa-optional "^0.10.1"
 
-libp2p-gossipsub@^0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/libp2p-gossipsub/-/libp2p-gossipsub-0.6.3.tgz#190a33edfba6f349267d5a3d0d0a8c6147ebebed"
-  integrity sha512-eaRGtMYns29zPYDjbyvtdIJRGfmnsdwmx5QxqPUcHbmUnwDX1FfeKxT1hY8EuDhhGSsinoZO9w3d6TXUrr1jbQ==
+libp2p-gossipsub@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/libp2p-gossipsub/-/libp2p-gossipsub-0.7.0.tgz#92964135163b5f29df6bf24b18fd76df37b5002e"
+  integrity sha512-uHohd/1SMBg36BNZSMYIwoAsOKFqt8FJh9dq7izHd4PKMyKDlRMdc1LYdqdMMj+MBcDctulMw4zGeGE8WTK62A==
   dependencies:
     "@types/debug" "^4.1.5"
     debug "^4.1.1"
     denque "^1.4.1"
     err-code "^2.0.0"
     it-pipe "^1.0.1"
-    libp2p-interfaces "^0.5.2"
+    libp2p-interfaces "^0.7.2"
     peer-id "^0.14.0"
     protons "^2.0.0"
     time-cache "^0.3.0"
+    uint8arrays "^1.1.0"
 
 libp2p-interfaces@^0.5.1, libp2p-interfaces@^0.5.2:
   version "0.5.2"
@@ -7787,6 +7788,40 @@ libp2p-interfaces@^0.5.1, libp2p-interfaces@^0.5.2:
     libp2p-tcp "^0.15.0"
     multiaddr "^8.0.0"
     multibase "^3.0.0"
+    p-defer "^3.0.0"
+    p-limit "^2.3.0"
+    p-wait-for "^3.1.0"
+    peer-id "^0.14.0"
+    protons "^2.0.0"
+    sinon "^9.0.2"
+    streaming-iterables "^5.0.2"
+    uint8arrays "^1.1.0"
+
+libp2p-interfaces@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/libp2p-interfaces/-/libp2p-interfaces-0.7.2.tgz#77281294b6bba72d0e9bf6c0e0b3471e37330cc3"
+  integrity sha512-uI4vPiwdi9pKScLoAvwMqXiEjUtUACavtqZEvdm36T1PcmzsfDbGDKGCkGoDENQ/kztsggfb/9PoEAiNw3CQxQ==
+  dependencies:
+    abort-controller "^3.0.0"
+    abortable-iterator "^3.0.0"
+    chai "^4.2.0"
+    chai-checkmark "^1.0.1"
+    class-is "^1.1.0"
+    debug "^4.1.1"
+    delay "^4.3.0"
+    detect-node "^2.0.4"
+    dirty-chai "^2.0.1"
+    err-code "^2.0.0"
+    it-goodbye "^2.0.1"
+    it-length-prefixed "^3.1.0"
+    it-pair "^1.0.0"
+    it-pipe "^1.1.0"
+    it-pushable "^1.4.0"
+    libp2p-crypto "^0.18.0"
+    libp2p-tcp "^0.15.0"
+    multiaddr "^8.0.0"
+    multibase "^3.0.0"
+    multihashes "^3.0.1"
     p-defer "^3.0.0"
     p-limit "^2.3.0"
     p-wait-for "^3.1.0"


### PR DESCRIPTION
- Update gossipsub to v0.7.0
- Update msg id to be 1.0 compatible (and also compatible with newest gossipsub)
- Update gossip mesh params to be 1.0 compatible
- Minor tweaks to lodestar gossipsub (cache msg id, override different methods, etc)
