### PR TITLE
Initial Sync: do not import orphaned blocks

### DIFF
--- a/packages/lodestar/src/sync/options.ts
+++ b/packages/lodestar/src/sync/options.ts
@@ -9,7 +9,7 @@ export interface ISyncOptions {
 }
 
 export const defaultSyncOptions: Required<ISyncOptions> = {
-  minPeers: 4,
+  minPeers: 3,
   //2 epochs
   maxSlotImport: 64,
   blockPerChunk: 64,

--- a/packages/lodestar/src/sync/options.ts
+++ b/packages/lodestar/src/sync/options.ts
@@ -9,7 +9,7 @@ export interface ISyncOptions {
 }
 
 export const defaultSyncOptions: Required<ISyncOptions> = {
-  minPeers: 2,
+  minPeers: 4,
   //2 epochs
   maxSlotImport: 64,
   blockPerChunk: 64,

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -16,6 +16,9 @@ import {IPeerMetadataStore} from "../../network/peers/interface";
 import {getSyncPeers} from "./peers";
 import {DEFAULT_RPC_SCORE} from "../../network/peers";
 
+// timeout for getBlockRange is 3 minutes
+const GET_BLOCK_RANGE_TIMEOUT = 3 * 60 * 1000;
+
 export function getHighestCommonSlot(peerStatuses: (Status | null)[]): Slot {
   const slotStatuses = peerStatuses.reduce<Map<Slot, number>>((current, status) => {
     if (status && current.has(status.headSlot)) {
@@ -112,7 +115,7 @@ export function fetchBlockChunks(
             new Promise((_, reject) => {
               timer = setTimeout(() => {
                 reject(new Error("beacon_blocks_by_range timeout"));
-              }, 3 * 60 * 1000); // 3 minutes
+              }, GET_BLOCK_RANGE_TIMEOUT);
             }),
           ])) as SignedBeaconBlock[] | null;
           if (timer) clearTimeout(timer);

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -182,7 +182,9 @@ export function processSyncBlocks(
       blockBuffer.push(...blocks);
     }
     blockBuffer = sortBlocks(blockBuffer);
-    while (blockBuffer.length > 0) {
+    // last block may be an orphaned block and some weird peers still return it
+    // we don't want to import it
+    while (blockBuffer.length > 1) {
       const signedBlock = blockBuffer.shift()!;
       const block = signedBlock.message;
       if (

--- a/packages/lodestar/test/unit/sync/utils/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/sync.test.ts
@@ -185,7 +185,7 @@ describe("sync utils", function () {
       chainStub.forkChoice = forkChoiceStub;
     });
 
-    it("should work", async function () {
+    it("should not import last fetched block", async function () {
       const lastProcessedBlock = blockToHeader(config, generateEmptySignedBlock().message);
       const blockRoot = config.types.BeaconBlockHeader.hashTreeRoot(lastProcessedBlock);
       const block1 = generateEmptySignedBlock();
@@ -194,8 +194,12 @@ describe("sync utils", function () {
       const block2 = generateEmptySignedBlock();
       block2.message.slot = 3;
       block2.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(block1.message);
+      // last fetched block maybe an orphaned block
+      const block3 = generateEmptySignedBlock();
+      block3.message.slot = 4;
+      block3.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(block2.message);
       const lastProcesssedSlot = await pipe(
-        [[block2], [block1]],
+        [[block3], [block2], [block1]],
         processSyncBlocks(config, chainStub, logger, true, {blockRoot, slot: lastProcessedBlock.slot})
       );
       expect(chainStub.receiveBlock.calledTwice).to.be.true;

--- a/packages/lodestar/test/unit/sync/utils/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/sync.test.ts
@@ -192,18 +192,44 @@ describe("sync utils", function () {
       block1.message.parentRoot = blockRoot;
       block1.message.slot = 1;
       const block2 = generateEmptySignedBlock();
-      block2.message.slot = 3;
+      block2.message.slot = 2;
       block2.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(block1.message);
       // last fetched block maybe an orphaned block
       const block3 = generateEmptySignedBlock();
-      block3.message.slot = 4;
+      block3.message.slot = 3;
       block3.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(block2.message);
       const lastProcesssedSlot = await pipe(
-        [[block3], [block2], [block1]],
-        processSyncBlocks(config, chainStub, logger, true, {blockRoot, slot: lastProcessedBlock.slot})
+        [[block1, block2, block3]],
+        processSyncBlocks(config, chainStub, logger, true, {blockRoot, slot: lastProcessedBlock.slot}, true)
       );
+      expect(chainStub.receiveBlock.calledWith(block1, true)).to.be.true;
+      expect(chainStub.receiveBlock.calledWith(block2, true)).to.be.true;
       expect(chainStub.receiveBlock.calledTwice).to.be.true;
-      expect(lastProcesssedSlot).to.be.equal(3);
+      expect(lastProcesssedSlot).to.be.equal(2);
+    });
+
+    it("should not import orphaned block", async function () {
+      const lastProcessedBlock = blockToHeader(config, generateEmptySignedBlock().message);
+      const blockRoot = config.types.BeaconBlockHeader.hashTreeRoot(lastProcessedBlock);
+      const block1 = generateEmptySignedBlock();
+      block1.message.parentRoot = blockRoot;
+      block1.message.slot = 1;
+      const block2 = generateEmptySignedBlock();
+      block2.message.slot = 2;
+      block2.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(block1.message);
+      // last fetched block maybe an orphaned block
+      const orphanedBlock = generateEmptySignedBlock();
+      orphanedBlock.message.slot = 3;
+      const lastBlock = generateEmptySignedBlock();
+      lastBlock.message.slot = 4;
+      const lastProcesssedSlot = await pipe(
+        [[block1, block2, orphanedBlock, lastBlock]],
+        processSyncBlocks(config, chainStub, logger, true, {blockRoot, slot: lastProcessedBlock.slot}, true)
+      );
+      // only block 1 is imported bc block2 does not link to a child
+      // don't import orphaned and last block
+      expect(chainStub.receiveBlock.calledOnceWith(block1, true)).to.be.true;
+      expect(lastProcesssedSlot).to.be.equal(1);
     });
 
     it("should handle failed to get range - initial sync", async function () {


### PR DESCRIPTION
resolves #1785 
+ avoid orphaned block
+ avoid req/resp timeout which cause the sync stall
+ set `minPeers=3`