### PR TITLE
Improve some spec tests using TreeBacked

### DIFF
--- a/packages/spec-test-runner/test/spec/sanity/blocks/sanity_blocks_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/sanity/blocks/sanity_blocks_fast.test.ts
@@ -1,7 +1,7 @@
 import {join} from "path";
 import {expect} from "chai";
 import {BeaconState, SignedBeaconBlock} from "@chainsafe/lodestar-types";
-import {EpochContext, fastStateTransition} from "@chainsafe/lodestar-beacon-state-transition";
+import {EpochContext, fastStateTransition, IStateContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util/lib/single";
 import {IBlockSanityTestCase} from "./type";
@@ -12,18 +12,19 @@ describeDirectorySpecTest<IBlockSanityTestCase, BeaconState>(
   "block sanity mainnet",
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/sanity/blocks/pyspec_tests"),
   (testcase) => {
-    let state = testcase.pre;
-    let epochCtx = new EpochContext(config);
+    const state = config.types.BeaconState.tree.createValue(testcase.pre);
+    const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
     const verify = !!testcase.meta && !!testcase.meta.blsSetting && testcase.meta.blsSetting === BigInt(1);
+    let stateContext: IStateContext = {epochCtx, state};
     for (let i = 0; i < Number(testcase.meta.blocksCount); i++) {
-      ({state, epochCtx} = fastStateTransition({epochCtx, state}, testcase[`blocks_${i}`] as SignedBeaconBlock, {
+      stateContext = fastStateTransition(stateContext, testcase[`blocks_${i}`] as SignedBeaconBlock, {
         verifyStateRoot: verify,
         verifyProposer: verify,
         verifySignatures: verify,
-      }));
+      });
     }
-    return state;
+    return stateContext.state;
   },
   {
     inputTypes: {

--- a/packages/spec-test-runner/test/spec/sanity/slots/sanity_slots_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/sanity/slots/sanity_slots_fast.test.ts
@@ -12,7 +12,7 @@ describeDirectorySpecTest<IProcessSlotsTestCase, BeaconState>(
   "slot sanity mainnet",
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/sanity/slots/pyspec_tests"),
   (testcase) => {
-    const state = testcase.pre;
+    const state = config.types.BeaconState.tree.createValue(testcase.pre);
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
     processSlots(epochCtx, state, state.slot + Number(testcase.slots));


### PR DESCRIPTION
+ Current finality test:
```
✓ finality_no_updates_at_genesis (67425ms)
    ✓ finality_rule_1 (94851ms)
    ✓ finality_rule_2 (94909ms)
    ✓ finality_rule_3 (166934ms)
    ✓ finality_rule_4 (71585ms)
```
+ Using TreeBaked
```
✓ finality_no_updates_at_genesis (10310ms)
    ✓ finality_rule_1 (10646ms)
    ✓ finality_rule_2 (10443ms)
    ✓ finality_rule_3 (10594ms)
    ✓ finality_rule_4 (10351ms)
```
+ It's not worth to apply for other tests since creating TreeBacked instance also take time