### PR TITLE
Remove evil mocha import

### DIFF
--- a/packages/lodestar-spec-test-util/src/multi.ts
+++ b/packages/lodestar-spec-test-util/src/multi.ts
@@ -2,7 +2,6 @@
 import {writeFile} from "fs";
 import {expect} from "chai";
 import profiler from "v8-profiler-next";
-import {describe, it} from "mocha";
 import {loadYamlFile} from "./util";
 
 export interface IBaseCase {

--- a/packages/lodestar-spec-test-util/src/single.ts
+++ b/packages/lodestar-spec-test-util/src/single.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {expect} from "chai";
 import {readdirSync, readFileSync, writeFile} from "fs";
-import {describe, it} from "mocha";
 import {basename, join, parse} from "path";
 import profiler from "v8-profiler-next";
 import {Type} from "@chainsafe/ssz";


### PR DESCRIPTION
This import has caused major issues when running as a dependency because mocha's describe stops being a global function and becomes local. It caused serious issues where no test was running and took a long time to debug. describe should always be available in the global scope.