### PR TITLE
Cache balances when processing epoch

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/processFinalUpdates.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/processFinalUpdates.ts
@@ -1,5 +1,5 @@
-import {readOnlyMap, List} from "@chainsafe/ssz";
 import {Eth1Data, PendingAttestation} from "@chainsafe/lodestar-types";
+import {List} from "@chainsafe/ssz";
 import {bigIntMin, intDiv} from "@chainsafe/lodestar-utils";
 
 import {getRandaoMix} from "../../util";
@@ -35,7 +35,7 @@ export function processFinalUpdates(
   }
 
   // update effective balances with hysteresis
-  const balances = readOnlyMap(state.balances, (balance) => balance);
+  const balances = process.balances;
   for (let i = 0; i < process.statuses.length; i++) {
     const status = process.statuses[i];
     const balance = balances[i];

--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/processFinalUpdates.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/processFinalUpdates.ts
@@ -1,5 +1,5 @@
 import {Eth1Data, PendingAttestation} from "@chainsafe/lodestar-types";
-import {List} from "@chainsafe/ssz";
+import {List, readOnlyMap} from "@chainsafe/ssz";
 import {bigIntMin, intDiv} from "@chainsafe/lodestar-utils";
 
 import {getRandaoMix} from "../../util";
@@ -35,7 +35,10 @@ export function processFinalUpdates(
   }
 
   // update effective balances with hysteresis
-  const balances = process.balances;
+  const balances =
+    process.balances && process.balances.length > 0
+      ? process.balances
+      : readOnlyMap(state.balances, (balance) => balance);
   for (let i = 0; i < process.statuses.length; i++) {
     const status = process.statuses[i];
     const balance = balances[i];

--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/processRewardsAndPenalties.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/processRewardsAndPenalties.ts
@@ -24,6 +24,7 @@ export function processRewardsAndPenalties(epochCtx: EpochContext, process: IEpo
       newBalances[i] -= penalty;
     }
   });
+  process.balances = newBalances;
   // important: do not change state one balance at a time
   // set them all at once, constructing the tree in one go
   state.balances = newBalances as List<bigint>;

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochProcess.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochProcess.ts
@@ -31,6 +31,8 @@ export interface IEpochProcess {
   prevEpoch: Epoch;
   currentEpoch: Epoch;
   statuses: IAttesterStatus[];
+  // only available after processRewardsAndPenalties
+  balances: Gwei[];
   totalActiveStake: Gwei;
   prevEpochUnslashedStake: IEpochStakeSummary;
   currEpochUnslashedTargetStake: Gwei;
@@ -51,6 +53,7 @@ export function createIEpochProcess(): IEpochProcess {
     prevEpoch: 0,
     currentEpoch: 0,
     statuses: [],
+    balances: [],
     totalActiveStake: BigInt(0),
     prevEpochUnslashedStake: {
       sourceStake: BigInt(0),

--- a/packages/lodestar-beacon-state-transition/test/perf/epoch_processing.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/epoch_processing.test.ts
@@ -81,7 +81,7 @@ describe("Epoch Processing Performance Tests", function () {
     logger.profile("processFinalUpdates");
     processFinalUpdates(epochCtx, process, state);
     logger.profile("processFinalUpdates");
-    expect(Date.now() - start).lt(250);
+    expect(Date.now() - start).lte(30);
   });
 
   it("processForkChanged", async () => {


### PR DESCRIPTION
we can save one `balances` loop in `TreeBacked<BeaconState>` by

+ New `balances` array inside EpochProcess
+ Populate it in `processRewardsAndPenalties`
+ Use it in `processFinalUpdates`
+ Save 165ms with over 110000 validators (same validator number in Pyrmont and Medalla)