### PR TITLE
lodestar-validator comment updates

### DIFF
--- a/packages/lodestar-validator/src/api/LocalClock.ts
+++ b/packages/lodestar-validator/src/api/LocalClock.ts
@@ -69,7 +69,7 @@ export class LocalClock implements IBeaconClock {
         });
       }
     }
-    //recursively invoke onNextSlot
+    // recursively invoke onNextSlot
     this.timeoutId = setTimeout(this.onNextSlot, this.msUntilNextSlot());
   };
 

--- a/packages/lodestar-validator/src/api/impl/rest/beacon/state.ts
+++ b/packages/lodestar-validator/src/api/impl/rest/beacon/state.ts
@@ -4,6 +4,9 @@ import {IBeaconStateApi} from "../../../interface/beacon";
 import {RestApi} from "./abstract";
 
 export class RestBeaconStateApi extends RestApi implements IBeaconStateApi {
+  /**
+   * Fetch given validator from a given state
+   */
   public async getStateValidator(
     stateId: "head",
     validatorId: ValidatorIndex | BLSPubkey
@@ -26,6 +29,7 @@ export class RestBeaconStateApi extends RestApi implements IBeaconStateApi {
       return null;
     }
   }
+
   public async getFork(stateId: "head"): Promise<Fork | null> {
     try {
       return this.config.types.Fork.fromJson((await this.client.get<{data: Json}>(`/states/${stateId}/fork`)).data, {

--- a/packages/lodestar-validator/src/api/impl/rest/validator/validator.ts
+++ b/packages/lodestar-validator/src/api/impl/rest/validator/validator.ts
@@ -19,6 +19,9 @@ import {Json, toHexString} from "@chainsafe/ssz";
 import {HttpClient, urlJoin} from "../../../../util";
 import {IValidatorApi} from "../../../interface/validators";
 
+/**
+ * Rest API class for fetching and performing validator duties
+ */
 export class RestValidatorApi implements IValidatorApi {
   private readonly clientV2: HttpClient;
 

--- a/packages/lodestar-validator/src/api/interface/validators.ts
+++ b/packages/lodestar-validator/src/api/interface/validators.ts
@@ -16,7 +16,7 @@ import {
 export interface IValidatorApi {
   getProposerDuties(epoch: Epoch, validatorPubKeys: BLSPubkey[]): Promise<ProposerDuty[]>;
 
-  getAttesterDuties(epoch: Epoch, validatorPubKeys: ValidatorIndex[]): Promise<AttesterDuty[]>;
+  getAttesterDuties(epoch: Epoch, indices: ValidatorIndex[]): Promise<AttesterDuty[]>;
 
   /**
    * Requests a BeaconNode to produce a valid block,

--- a/packages/lodestar-validator/src/services/block.ts
+++ b/packages/lodestar-validator/src/services/block.ts
@@ -18,6 +18,9 @@ import {BeaconEventType} from "../api/interface/events";
 import {ClockEventType} from "../api/interface/clock";
 import {ISlashingProtection} from "../slashingProtection";
 
+/**
+ * Service that sets up and handles validator block proposal duties.
+ */
 export default class BlockProposingService {
   private readonly config: IBeaconConfig;
   private readonly provider: IApiClient;
@@ -50,6 +53,9 @@ export default class BlockProposingService {
     this.graffiti = graffiti;
   }
 
+  /**
+   * Starts the BlockService by updating the validator block proposal duties and turning on the relevant listeners for clock events.
+   */
   public start = async (): Promise<void> => {
     const currentEpoch = this.provider.clock.currentEpoch;
     // trigger getting duties for current epoch
@@ -60,14 +66,25 @@ export default class BlockProposingService {
     this.provider.on(BeaconEventType.HEAD, this.onHead);
   };
 
+  /**
+   * Stops the BlockService by turning off the relevant listeners for clock events.
+   */
   public stop = async (): Promise<void> => {
-    // nothing here yet, but if future cleanup needs to be done (for example, clearing timers), put it here
+    this.provider.off(ClockEventType.CLOCK_EPOCH, this.onClockEpoch);
+    this.provider.off(ClockEventType.CLOCK_SLOT, this.onClockSlot);
+    this.provider.off(BeaconEventType.HEAD, this.onHead);
   };
 
+  /**
+   * Update validator duties on each epoch.
+   */
   public onClockEpoch = async ({epoch}: {epoch: Epoch}): Promise<void> => {
     await this.updateDuties(epoch);
   };
 
+  /**
+   * Create and publish a block if the validator is a proposer for a given clock slot.
+   */
   public onClockSlot = async ({slot}: {slot: Slot}): Promise<void> => {
     const proposerPubKey = this.nextProposals.get(slot);
     if (proposerPubKey && slot !== 0) {
@@ -89,6 +106,9 @@ export default class BlockProposingService {
     }
   };
 
+  /**
+   * Update list of block proposal duties on head upate.
+   */
   public onHead = async ({slot, epochTransition}: {slot: Slot; epochTransition: boolean}): Promise<void> => {
     if (epochTransition) {
       // refetch this epoch's duties
@@ -96,6 +116,9 @@ export default class BlockProposingService {
     }
   };
 
+  /**
+   * Fetch validator block proposal duties from the validator api and update local list of block duties accordingly.
+   */
   public updateDuties = async (epoch: Epoch): Promise<void> => {
     this.logger.info("on new block epoch", {epoch, validator: toHexString(this.publicKeys[0])});
     const proposerDuties = await this.provider.validator.getProposerDuties(epoch, this.publicKeys).catch((e) => {
@@ -114,7 +137,7 @@ export default class BlockProposingService {
   };
 
   /**
-   * IFF a validator is selected construct a block to propose.
+   * IFF a validator is selected, construct a block to propose.
    */
   public async createAndPublishBlock(
     proposerIndex: number,

--- a/packages/lodestar-validator/src/services/utils.ts
+++ b/packages/lodestar-validator/src/services/utils.ts
@@ -2,6 +2,9 @@ import {AttesterDuty} from "@chainsafe/lodestar-types";
 import {intDiv} from "@chainsafe/lodestar-utils";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
+/**
+ * Return the modulo needed to calculate whether the validator is an aggregator.
+ */
 export function getAggregatorModulo(config: IBeaconConfig, duty: AttesterDuty): number {
   return Math.max(1, intDiv(duty.committeeLength, config.params.TARGET_COMMITTEE_SIZE));
 }

--- a/packages/lodestar-validator/src/slashingProtection/attestation/attestationByTargetRepository.ts
+++ b/packages/lodestar-validator/src/slashingProtection/attestation/attestationByTargetRepository.ts
@@ -4,6 +4,11 @@ import {IDatabaseController, Bucket, encodeKey, IDatabaseApiOptions, bucketLen, 
 import {Type} from "@chainsafe/ssz";
 import {uniqueVectorArr, blsPubkeyLen} from "../utils";
 
+/**
+ * Manages validator db storage of attestations.
+ * Entries in the db are indexed by an encoded key which combines the validator's public key and the
+ * attestation's target epoch.
+ */
 export class AttestationByTargetRepository {
   protected type: Type<SlashingProtectionAttestation>;
   protected db: IDatabaseController<Buffer, Buffer>;

--- a/packages/lodestar-validator/src/slashingProtection/attestation/attestationLowerBoundRepository.ts
+++ b/packages/lodestar-validator/src/slashingProtection/attestation/attestationLowerBoundRepository.ts
@@ -2,6 +2,10 @@ import {BLSPubkey, SlashingProtectionAttestationLowerBound} from "@chainsafe/lod
 import {IDatabaseController, Bucket, encodeKey, IDatabaseApiOptions} from "@chainsafe/lodestar-db";
 import {Type} from "@chainsafe/ssz";
 
+/**
+ * Manages validator db storage of the minimum source and target epochs required of a validator
+ * attestation.
+ */
 export class AttestationLowerBoundRepository {
   protected type: Type<SlashingProtectionAttestationLowerBound>;
   protected db: IDatabaseController<Buffer, Buffer>;

--- a/packages/lodestar-validator/src/slashingProtection/block/blockBySlotRepository.ts
+++ b/packages/lodestar-validator/src/slashingProtection/block/blockBySlotRepository.ts
@@ -4,6 +4,11 @@ import {IDatabaseController, Bucket, encodeKey, IDatabaseApiOptions, bucketLen, 
 import {Type} from "@chainsafe/ssz";
 import {uniqueVectorArr, blsPubkeyLen} from "../utils";
 
+/**
+ * Manages validator db storage of blocks.
+ * Entries in the db are indexed by an encoded key which combines the validator's public key and the
+ * block's slot.
+ */
 export class BlockBySlotRepository {
   protected type: Type<SlashingProtectionBlock>;
   protected db: IDatabaseController<Buffer, Buffer>;

--- a/packages/lodestar-validator/src/slashingProtection/index.ts
+++ b/packages/lodestar-validator/src/slashingProtection/index.ts
@@ -22,6 +22,10 @@ export {InvalidBlockError, InvalidBlockErrorCode} from "./block";
 export {InterchangeError, InterchangeErrorErrorCode} from "./interchange";
 export {ISlashingProtection};
 
+/**
+ * Handles slashing protection for validator proposer and attester duties as well as slashing protection
+ * during a validator interchange import/export process.
+ */
 export class SlashingProtection extends DatabaseService implements ISlashingProtection {
   private blockService: SlashingProtectionBlockService;
   private attestationService: SlashingProtectionAttestationService;

--- a/packages/lodestar-validator/src/slashingProtection/minMaxSurround/distanceStoreRepository.ts
+++ b/packages/lodestar-validator/src/slashingProtection/minMaxSurround/distanceStoreRepository.ts
@@ -4,6 +4,9 @@ import {IDatabaseController, Bucket, encodeKey, IDatabaseApiOptions} from "@chai
 import {Type} from "@chainsafe/ssz";
 import {IDistanceEntry, IDistanceStore} from "./interface";
 
+/**
+ * Manages validator db storage of min/max ranges for min/max surround vote slashing protection.
+ */
 export class DistanceStoreRepository implements IDistanceStore {
   minSpan: SpanDistanceRepository;
   maxSpan: SpanDistanceRepository;


### PR DESCRIPTION
part of the effort tracked in #1775 

adds some clarifying comments to the lodestar-validator package

also
- removed isRunning from validator.ts (it wasn't being used)
- turned off validator events in blockService.stop()
- corrected the naming of  param in the public interface for `getAttesterDuties`
