### PR TITLE
Add rewards spec tests

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/epoch/balanceUpdates/attestation.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/balanceUpdates/attestation.ts
@@ -61,25 +61,25 @@ function getAttestationComponentDeltas(
   return [rewards, penalties];
 }
 
-function getSourceDeltas(config: IBeaconConfig, state: BeaconState): [bigint[], bigint[]] {
+export function getSourceDeltas(config: IBeaconConfig, state: BeaconState): [bigint[], bigint[]] {
   const previousEpoch = getPreviousEpoch(config, state);
   const matchingSourceAttestations = getMatchingSourceAttestations(config, state, previousEpoch);
   return getAttestationComponentDeltas(config, state, matchingSourceAttestations);
 }
 
-function getTargetDeltas(config: IBeaconConfig, state: BeaconState): [bigint[], bigint[]] {
+export function getTargetDeltas(config: IBeaconConfig, state: BeaconState): [bigint[], bigint[]] {
   const previousEpoch = getPreviousEpoch(config, state);
   const matchingTargetAttestations = getMatchingTargetAttestations(config, state, previousEpoch);
   return getAttestationComponentDeltas(config, state, matchingTargetAttestations);
 }
 
-function getHeadDeltas(config: IBeaconConfig, state: BeaconState): [bigint[], bigint[]] {
+export function getHeadDeltas(config: IBeaconConfig, state: BeaconState): [bigint[], bigint[]] {
   const previousEpoch = getPreviousEpoch(config, state);
   const matchingHeadAttestations = getMatchingHeadAttestations(config, state, previousEpoch);
   return getAttestationComponentDeltas(config, state, matchingHeadAttestations);
 }
 
-function getInclusionDelayDeltas(config: IBeaconConfig, state: BeaconState): bigint[] {
+export function getInclusionDelayDeltas(config: IBeaconConfig, state: BeaconState): bigint[] {
   const previousEpoch = getPreviousEpoch(config, state);
   const rewards = Array.from({length: state.validators.length}, () => BigInt(0));
   const matchingSourceAttestations = getMatchingSourceAttestations(config, state, previousEpoch);
@@ -97,7 +97,7 @@ function getInclusionDelayDeltas(config: IBeaconConfig, state: BeaconState): big
   return rewards;
 }
 
-function getInactivityPenaltyDeltas(config: IBeaconConfig, state: BeaconState): bigint[] {
+export function getInactivityPenaltyDeltas(config: IBeaconConfig, state: BeaconState): bigint[] {
   const penalties = Array.from({length: state.validators.length}, () => BigInt(0));
   const previousEpoch = getPreviousEpoch(config, state);
   const matchingTargetAttestations = getMatchingTargetAttestations(config, state, previousEpoch);

--- a/packages/lodestar-beacon-state-transition/src/epoch/balanceUpdates/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/balanceUpdates/index.ts
@@ -9,6 +9,8 @@ import {GENESIS_EPOCH} from "../../constants";
 import {getCurrentEpoch, increaseBalance, decreaseBalance} from "../../util";
 import {getAttestationDeltas} from "./attestation";
 
+export * from "./attestation";
+
 export function processRewardsAndPenalties(config: IBeaconConfig, state: BeaconState): void {
   if (getCurrentEpoch(config, state) == GENESIS_EPOCH) {
     return;

--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/index.ts
@@ -8,6 +8,7 @@ import {processRegistryUpdates} from "./processRegistryUpdates";
 import {processSlashings} from "./processSlashings";
 import {processFinalUpdates} from "./processFinalUpdates";
 import {processForkChanged} from "./processFork";
+import {getAttestationDeltas} from "./getAttestationDeltas";
 
 export {
   processJustificationAndFinalization,
@@ -16,6 +17,7 @@ export {
   processSlashings,
   processFinalUpdates,
   processForkChanged,
+  getAttestationDeltas,
 };
 
 export function processEpoch(epochCtx: StateTransitionEpochContext, state: BeaconState): void {

--- a/packages/spec-test-runner/test/spec/rewards/basic/rewards_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/rewards/basic/rewards_mainnet.test.ts
@@ -1,0 +1,68 @@
+import {
+  getSourceDeltas,
+  getTargetDeltas,
+  getHeadDeltas,
+  getInclusionDelayDeltas,
+  getInactivityPenaltyDeltas,
+} from "@chainsafe/lodestar-beacon-state-transition";
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util";
+import {expect} from "chai";
+import {join} from "path";
+import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
+import {IAttestationDeltas, IAttestationDeltasType, IDeltas, IDeltasType, IRewardsTestCase} from "../types";
+
+["basic", "leak", "random"].forEach((testSuite) => {
+  describeDirectorySpecTest<IRewardsTestCase, IAttestationDeltas>(
+    "process attestation mainnet",
+    join(SPEC_TEST_LOCATION, `/tests/mainnet/phase0/rewards/${testSuite}/pyspec_tests`),
+    (testcase) => {
+      const state = testcase.pre;
+      const sourceDeltas = getSourceDeltas(config, state);
+      const targetDeltas = getTargetDeltas(config, state);
+      const headDeltas = getHeadDeltas(config, state);
+      const inclusionDelayDeltas = getInclusionDelayDeltas(config, state);
+      const inactivityPenaltyDeltas = getInactivityPenaltyDeltas(config, state);
+      return {
+        sourceDeltas: {rewards: sourceDeltas[0], penalties: sourceDeltas[1]},
+        targetDeltas: {rewards: targetDeltas[0], penalties: targetDeltas[1]},
+        headDeltas: {rewards: headDeltas[0], penalties: headDeltas[1]},
+        inclusionDelayDeltas: {rewards: inclusionDelayDeltas, penalties: []},
+        inactivityPenaltyDeltas: {rewards: [], penalties: inactivityPenaltyDeltas},
+      };
+    },
+    {
+      inputTypes: {
+        meta: InputType.YAML,
+      },
+      sszTypes: {
+        pre: config.types.BeaconState,
+        ...generateSZZTypeMapping(),
+      },
+      timeout: 100000000,
+      shouldError: (testCase) => !testCase.post,
+      getExpected: (testCase) => {
+        return {
+          sourceDeltas: testCase["source_deltas"] as IDeltas,
+          targetDeltas: testCase["target_deltas"] as IDeltas,
+          headDeltas: testCase["head_deltas"] as IDeltas,
+          inclusionDelayDeltas: testCase["inclusion_delay_deltas"] as IDeltas,
+          inactivityPenaltyDeltas: testCase["inactivity_penalty_deltas"] as IDeltas,
+        };
+      },
+      expectFunc: (testCase, expected, actual) => {
+        expect(IAttestationDeltasType.equals(actual, expected)).to.be.true;
+      },
+    }
+  );
+});
+
+function generateSZZTypeMapping(): Record<string, unknown> {
+  const typeMappings: any = {};
+  typeMappings["source_deltas"] = IDeltasType;
+  typeMappings["target_deltas"] = IDeltasType;
+  typeMappings["head_deltas"] = IDeltasType;
+  typeMappings["inclusion_delay_deltas"] = IDeltasType;
+  typeMappings["inactivity_penalty_deltas"] = IDeltasType;
+  return typeMappings;
+}

--- a/packages/spec-test-runner/test/spec/rewards/rewards_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/rewards/rewards_fast.test.ts
@@ -1,0 +1,72 @@
+import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
+import {prepareEpochProcessState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
+import {getAttestationDeltas} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/epoch";
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util";
+import {join} from "path";
+import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
+import {generateSZZTypeMapping, IDeltas, IDeltasType, IRewardsTestCase} from "./types";
+import {expect} from "chai";
+
+["basic", "leak", "random"].forEach((testSuite) => {
+  describeDirectorySpecTest<IRewardsTestCase, IDeltas>(
+    "process attestation mainnet",
+    join(SPEC_TEST_LOCATION, `/tests/mainnet/phase0/rewards/${testSuite}/pyspec_tests`),
+    (testcase) => {
+      const state = testcase.pre;
+      const epochCtx = new EpochContext(config);
+      epochCtx.loadState(state);
+      const process = prepareEpochProcessState(epochCtx, state);
+      const [rewards, penalties] = getAttestationDeltas(epochCtx, process, state);
+      return {
+        rewards,
+        penalties,
+      };
+    },
+    {
+      inputTypes: {
+        meta: InputType.YAML,
+      },
+      sszTypes: {
+        pre: config.types.BeaconState,
+        ...generateSZZTypeMapping(),
+      },
+      timeout: 100000000,
+      shouldError: (testCase) => !testCase.post,
+      getExpected: (testCase) => {
+        const sourceDeltas = testCase["source_deltas"] as IDeltas;
+        const targetDeltas = testCase["target_deltas"] as IDeltas;
+        const headDeltas = testCase["head_deltas"] as IDeltas;
+        const inclusionDelayDeltas = testCase["inclusion_delay_deltas"] as IDeltas;
+        const inactivityPenaltyDeltas = testCase["inactivity_penalty_deltas"] as IDeltas;
+        const rewards = [
+          sourceDeltas.rewards,
+          targetDeltas.rewards,
+          headDeltas.rewards,
+          inclusionDelayDeltas.rewards,
+          inactivityPenaltyDeltas.rewards,
+        ].reduce((previousValue, currentValue) => {
+          previousValue.forEach((_, index) => (previousValue[index] += currentValue[index]));
+          return previousValue;
+        });
+        const penalties = [
+          sourceDeltas.penalties,
+          targetDeltas.penalties,
+          headDeltas.penalties,
+          inclusionDelayDeltas.penalties,
+          inactivityPenaltyDeltas.penalties,
+        ].reduce((previousValue, currentValue) => {
+          previousValue.forEach((_, index) => (previousValue[index] += currentValue[index]));
+          return previousValue;
+        });
+        return {
+          rewards,
+          penalties,
+        };
+      },
+      expectFunc: (testCase, expected, actual) => {
+        expect(IDeltasType.equals(actual, expected)).to.be.true;
+      },
+    }
+  );
+});

--- a/packages/spec-test-runner/test/spec/rewards/rewards_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/rewards/rewards_mainnet.test.ts
@@ -9,8 +9,14 @@ import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util";
 import {expect} from "chai";
 import {join} from "path";
-import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
-import {IAttestationDeltas, IAttestationDeltasType, IDeltas, IDeltasType, IRewardsTestCase} from "../types";
+import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
+import {
+  generateSZZTypeMapping,
+  IAttestationDeltas,
+  IAttestationDeltasType,
+  IDeltas,
+  IRewardsTestCase,
+} from "./types";
 
 ["basic", "leak", "random"].forEach((testSuite) => {
   describeDirectorySpecTest<IRewardsTestCase, IAttestationDeltas>(
@@ -56,13 +62,3 @@ import {IAttestationDeltas, IAttestationDeltasType, IDeltas, IDeltasType, IRewar
     }
   );
 });
-
-function generateSZZTypeMapping(): Record<string, unknown> {
-  const typeMappings: any = {};
-  typeMappings["source_deltas"] = IDeltasType;
-  typeMappings["target_deltas"] = IDeltasType;
-  typeMappings["head_deltas"] = IDeltasType;
-  typeMappings["inclusion_delay_deltas"] = IDeltasType;
-  typeMappings["inactivity_penalty_deltas"] = IDeltasType;
-  return typeMappings;
-}

--- a/packages/spec-test-runner/test/spec/rewards/rewards_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/rewards/rewards_mainnet.test.ts
@@ -10,13 +10,7 @@ import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-tes
 import {expect} from "chai";
 import {join} from "path";
 import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
-import {
-  generateSZZTypeMapping,
-  IAttestationDeltas,
-  IAttestationDeltasType,
-  IDeltas,
-  IRewardsTestCase,
-} from "./types";
+import {generateSZZTypeMapping, IAttestationDeltas, IAttestationDeltasType, IDeltas, IRewardsTestCase} from "./types";
 
 ["basic", "leak", "random"].forEach((testSuite) => {
   describeDirectorySpecTest<IRewardsTestCase, IAttestationDeltas>(

--- a/packages/spec-test-runner/test/spec/rewards/types.ts
+++ b/packages/spec-test-runner/test/spec/rewards/types.ts
@@ -1,0 +1,44 @@
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import {BeaconState, Gwei} from "@chainsafe/lodestar-types";
+import {ContainerType, ListType} from "@chainsafe/ssz";
+
+export interface IDeltas {
+  rewards: Gwei[];
+  penalties: Gwei[];
+}
+
+export interface IAttestationDeltas {
+  sourceDeltas: IDeltas;
+  targetDeltas: IDeltas;
+  headDeltas: IDeltas;
+  inclusionDelayDeltas: IDeltas;
+  inactivityPenaltyDeltas: IDeltas;
+}
+
+export const IDeltasType = new ContainerType({
+  fields: {
+    rewards: new ListType({
+      elementType: config.types.Gwei,
+      limit: config.params.VALIDATOR_REGISTRY_LIMIT,
+    }),
+    penalties: new ListType({
+      elementType: config.types.Gwei,
+      limit: config.params.VALIDATOR_REGISTRY_LIMIT,
+    }),
+  },
+});
+
+export const IAttestationDeltasType = new ContainerType({
+  fields: {
+    sourceDeltas: IDeltasType,
+    targetDeltas: IDeltasType,
+    headDeltas: IDeltasType,
+    inclusionDelayDeltas: IDeltasType,
+    inactivityPenaltyDeltas: IDeltasType,
+  },
+});
+
+export interface IRewardsTestCase {
+  [k: string]: IDeltas | unknown | null | undefined;
+  pre: BeaconState;
+}

--- a/packages/spec-test-runner/test/spec/rewards/types.ts
+++ b/packages/spec-test-runner/test/spec/rewards/types.ts
@@ -42,3 +42,13 @@ export interface IRewardsTestCase {
   [k: string]: IDeltas | unknown | null | undefined;
   pre: BeaconState;
 }
+
+export function generateSZZTypeMapping(): Record<string, unknown> {
+  const typeMappings: any = {};
+  typeMappings["source_deltas"] = IDeltasType;
+  typeMappings["target_deltas"] = IDeltasType;
+  typeMappings["head_deltas"] = IDeltasType;
+  typeMappings["inclusion_delay_deltas"] = IDeltasType;
+  typeMappings["inactivity_penalty_deltas"] = IDeltasType;
+  return typeMappings;
+}


### PR DESCRIPTION
resolves #1607 

+ For the regular state transition, test source/target/head/inclusion delay/inactivity deltas separately
+ For fast state transition, accumulate everything and test as a whole. The result shows that it's a huge improvement over the regular state transition.