### PR TITLE
JSON friendly logger statements

### DIFF
--- a/packages/lodestar-beacon-state-transition/test/perf/util.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/util.ts
@@ -112,7 +112,7 @@ export async function generatePerformanceBlock(): Promise<TreeBacked<SignedBeaco
     );
     // eth1Data, graffiti, attestations
     signedBlock = config.types.SignedBeaconBlock.tree.createValue(block);
-    logger.info("Loaded block at slot", signedBlock.message.slot);
+    logger.info("Loaded block", {slot: signedBlock.message.slot});
   }
   return signedBlock.clone();
 }

--- a/packages/lodestar-db/src/controller/impl/level.ts
+++ b/packages/lodestar-db/src/controller/impl/level.ts
@@ -32,7 +32,7 @@ export class LevelDbController implements IDatabaseController<Buffer, Buffer> {
 
   public async start(): Promise<void> {
     await this.db.open();
-    this.logger.info(`Connected to LevelDB database at ${this.opts.name}`);
+    this.logger.info("Connected to LevelDB database", {name: this.opts.name});
   }
 
   public async stop(): Promise<void> {

--- a/packages/lodestar-utils/src/logger/interface.ts
+++ b/packages/lodestar-utils/src/logger/interface.ts
@@ -52,13 +52,13 @@ export interface ILogger {
   level: LogLevel;
   silent: boolean;
 
-  error(message: string, context?: Context | Error): void;
-  warn(message: string, context?: Context | Error): void;
-  info(message: string, context?: Context): void;
-  important(message: string, context?: Context): void;
-  verbose(message: string, context?: Context): void;
-  debug(message: string, context?: Context): void;
-  silly(message: string, context?: Context): void;
+  error(message: string, ...context: (Context | Error)[]): void;
+  warn(message: string, ...context: (Context | Error)[]): void;
+  info(message: string, ...context: Context[]): void;
+  important(message: string, ...context: Context[]): void;
+  verbose(message: string, ...context: Context[]): void;
+  debug(message: string, ...context: Context[]): void;
+  silly(message: string, ...context: Context[]): void;
   profile(message: string, option?: {level: string; message: string}): void;
   stream(): Writable;
   // custom

--- a/packages/lodestar-utils/src/logger/interface.ts
+++ b/packages/lodestar-utils/src/logger/interface.ts
@@ -48,9 +48,7 @@ export type Context =
     }
   | Context[];
 
-export type Contexts = (Context | Error)[];
-
-export type LogHandler = (message: string, ...context: (Context | Error)[]) => void;
+export type LogHandler = (message: string, context?: Context, error?: Error) => void;
 
 export interface ILogger {
   level: LogLevel;

--- a/packages/lodestar-utils/src/logger/interface.ts
+++ b/packages/lodestar-utils/src/logger/interface.ts
@@ -48,17 +48,21 @@ export type Context =
     }
   | Context[];
 
+export type Contexts = (Context | Error)[];
+
+export type LogHandler = (message: string, ...context: (Context | Error)[]) => void;
+
 export interface ILogger {
   level: LogLevel;
   silent: boolean;
 
-  error(message: string, ...context: (Context | Error)[]): void;
-  warn(message: string, ...context: (Context | Error)[]): void;
-  info(message: string, ...context: Context[]): void;
-  important(message: string, ...context: Context[]): void;
-  verbose(message: string, ...context: Context[]): void;
-  debug(message: string, ...context: Context[]): void;
-  silly(message: string, ...context: Context[]): void;
+  error: LogHandler;
+  warn: LogHandler;
+  info: LogHandler;
+  important: LogHandler;
+  verbose: LogHandler;
+  debug: LogHandler;
+  silly: LogHandler;
   profile(message: string, option?: {level: string; message: string}): void;
   stream(): Writable;
   // custom

--- a/packages/lodestar-utils/src/logger/winston.ts
+++ b/packages/lodestar-utils/src/logger/winston.ts
@@ -51,32 +51,32 @@ export class WinstonLogger implements ILogger {
     }
   }
 
-  public error(message: string, ...context: (Context | Error)[]): void {
-    this.createLogEntry(LogLevel.error, message, context);
+  public error(message: string, context?: Context, error?: Error): void {
+    this.createLogEntry(LogLevel.error, message, context, error);
   }
 
-  public warn(message: string, ...context: (Context | Error)[]): void {
-    this.createLogEntry(LogLevel.warn, message, context);
+  public warn(message: string, context?: Context, error?: Error): void {
+    this.createLogEntry(LogLevel.warn, message, context, error);
   }
 
-  public info(message: string, ...context: (Context | Error)[]): void {
-    this.createLogEntry(LogLevel.info, message, context);
+  public info(message: string, context?: Context, error?: Error): void {
+    this.createLogEntry(LogLevel.info, message, context, error);
   }
 
-  public important(message: string, ...context: (Context | Error)[]): void {
-    this.createLogEntry(LogLevel.info, chalk.red(message as string), context);
+  public important(message: string, context?: Context, error?: Error): void {
+    this.createLogEntry(LogLevel.info, chalk.red(message as string), context, error);
   }
 
-  public verbose(message: string, ...context: (Context | Error)[]): void {
-    this.createLogEntry(LogLevel.verbose, message, context);
+  public verbose(message: string, context?: Context, error?: Error): void {
+    this.createLogEntry(LogLevel.verbose, message, context, error);
   }
 
-  public debug(message: string, ...context: (Context | Error)[]): void {
-    this.createLogEntry(LogLevel.debug, message, context);
+  public debug(message: string, context?: Context, error?: Error): void {
+    this.createLogEntry(LogLevel.debug, message, context, error);
   }
 
-  public silly(message: string, ...context: (Context | Error)[]): void {
-    this.createLogEntry(LogLevel.silly, message, context);
+  public silly(message: string, context?: Context, error?: Error): void {
+    this.createLogEntry(LogLevel.silly, message, context, error);
   }
 
   public profile(message: string, option?: {level: string; message: string}): void {
@@ -120,11 +120,11 @@ export class WinstonLogger implements ILogger {
     });
   }
 
-  private createLogEntry(level: LogLevel, message: string, context: (Context | Error)[]): void {
+  private createLogEntry(level: LogLevel, message: string, context?: Context, error?: Error): void {
     //don't propagate if silenced or message level is more detailed than logger level
     if (this.silent || this.winston.levels[level] > this.winston.levels[this._level]) {
       return;
     }
-    this.winston[level](message, {context});
+    this.winston[level](message, {context, error});
   }
 }

--- a/packages/lodestar-utils/src/logger/winston.ts
+++ b/packages/lodestar-utils/src/logger/winston.ts
@@ -51,31 +51,31 @@ export class WinstonLogger implements ILogger {
     }
   }
 
-  public debug(message: string, context?: Context): void {
-    this.createLogEntry(LogLevel.debug, message, context);
-  }
-
-  public info(message: string, context?: Context): void {
-    this.createLogEntry(LogLevel.info, message, context);
-  }
-
-  public important(message: string, context?: Context): void {
-    this.createLogEntry(LogLevel.info, chalk.red(message as string), context);
-  }
-
-  public error(message: string, context?: Context | Error): void {
+  public error(message: string, ...context: (Context | Error)[]): void {
     this.createLogEntry(LogLevel.error, message, context);
   }
 
-  public warn(message: string, context?: Context | Error): void {
+  public warn(message: string, ...context: (Context | Error)[]): void {
     this.createLogEntry(LogLevel.warn, message, context);
   }
 
-  public verbose(message: string, context?: Context): void {
+  public info(message: string, ...context: Context[]): void {
+    this.createLogEntry(LogLevel.info, message, context);
+  }
+
+  public important(message: string, ...context: Context[]): void {
+    this.createLogEntry(LogLevel.info, chalk.red(message as string), context);
+  }
+
+  public verbose(message: string, ...context: Context[]): void {
     this.createLogEntry(LogLevel.verbose, message, context);
   }
 
-  public silly(message: string, context?: Context): void {
+  public debug(message: string, ...context: Context[]): void {
+    this.createLogEntry(LogLevel.debug, message, context);
+  }
+
+  public silly(message: string, ...context: Context[]): void {
     this.createLogEntry(LogLevel.silly, message, context);
   }
 
@@ -120,7 +120,7 @@ export class WinstonLogger implements ILogger {
     });
   }
 
-  private createLogEntry(level: LogLevel, message: string, context?: Context | Error): void {
+  private createLogEntry(level: LogLevel, message: string, context: (Context | Error)[]): void {
     //don't propagate if silenced or message level is more detailed than logger level
     if (this.silent || this.winston.levels[level] > this.winston.levels[this._level]) {
       return;

--- a/packages/lodestar-utils/src/logger/winston.ts
+++ b/packages/lodestar-utils/src/logger/winston.ts
@@ -59,23 +59,23 @@ export class WinstonLogger implements ILogger {
     this.createLogEntry(LogLevel.warn, message, context);
   }
 
-  public info(message: string, ...context: Context[]): void {
+  public info(message: string, ...context: (Context | Error)[]): void {
     this.createLogEntry(LogLevel.info, message, context);
   }
 
-  public important(message: string, ...context: Context[]): void {
+  public important(message: string, ...context: (Context | Error)[]): void {
     this.createLogEntry(LogLevel.info, chalk.red(message as string), context);
   }
 
-  public verbose(message: string, ...context: Context[]): void {
+  public verbose(message: string, ...context: (Context | Error)[]): void {
     this.createLogEntry(LogLevel.verbose, message, context);
   }
 
-  public debug(message: string, ...context: Context[]): void {
+  public debug(message: string, ...context: (Context | Error)[]): void {
     this.createLogEntry(LogLevel.debug, message, context);
   }
 
-  public silly(message: string, ...context: Context[]): void {
+  public silly(message: string, ...context: (Context | Error)[]): void {
     this.createLogEntry(LogLevel.silly, message, context);
   }
 

--- a/packages/lodestar-validator/src/api/impl/rest/beacon/beacon.ts
+++ b/packages/lodestar-validator/src/api/impl/rest/beacon/beacon.ts
@@ -31,7 +31,7 @@ export class RestBeaconApi implements IBeaconApi {
       const genesisResponse = await this.clientV2.get<{data: Json}>("/genesis");
       return this.config.types.Genesis.fromJson(genesisResponse.data, {case: "snake"});
     } catch (e) {
-      this.logger.error("Failed to obtain genesis time", {reason: e.message});
+      this.logger.error("Failed to obtain genesis time", {error: e.message});
       return null;
     }
   }

--- a/packages/lodestar-validator/src/api/impl/rest/beacon/state.ts
+++ b/packages/lodestar-validator/src/api/impl/rest/beacon/state.ts
@@ -22,7 +22,7 @@ export class RestBeaconStateApi extends RestApi implements IBeaconStateApi {
         }
       );
     } catch (e) {
-      this.logger.error("Failed to fetch validator", {validatorId: id, reason: e.message});
+      this.logger.error("Failed to fetch validator", {validatorId: id, error: e.message});
       return null;
     }
   }
@@ -32,7 +32,7 @@ export class RestBeaconStateApi extends RestApi implements IBeaconStateApi {
         case: "snake",
       });
     } catch (e) {
-      this.logger.error("Failed to fetch head fork version", {reason: e.message});
+      this.logger.error("Failed to fetch head fork version", {error: e.message});
       return null;
     }
   }

--- a/packages/lodestar-validator/src/services/attestation.ts
+++ b/packages/lodestar-validator/src/services/attestation.ts
@@ -262,7 +262,7 @@ export class AttestationService {
     fork: Fork,
     genesisValidatorsRoot: Root
   ): Promise<void> => {
-    this.logger.info(`Aggregating attestations for committee ${duty.committeeIndex} at slot ${duty.slot}`);
+    this.logger.info("Aggregating attestations", {committeeIndex: duty.committeeIndex, slot: duty.slot});
     let aggregate: Attestation;
     try {
       aggregate = await this.provider.validator.getAggregatedAttestation(
@@ -290,9 +290,7 @@ export class AttestationService {
     };
     try {
       await this.provider.validator.publishAggregateAndProofs([signedAggregateAndProof]);
-      this.logger.info(
-        `Published signed aggregate and proof for committee ${duty.committeeIndex} at slot ${duty.slot}`
-      );
+      this.logger.info("Published signed aggregate and proof", {committeeIndex: duty.committeeIndex, slot: duty.slot});
     } catch (e) {
       this.logger.error(
         `Failed to publish aggregate and proof for committee ${duty.committeeIndex} at slot ${duty.slot}`,
@@ -358,10 +356,11 @@ export class AttestationService {
       data: attestationData,
       signature: this.secretKeys[attesterIndex].sign(signingRoot).toBytes(),
     };
-    this.logger.info(
-      `Signed new attestation for block ${toHexString(attestation.data.target.root)} ` +
-        `and committee ${committeeIndex} at slot ${slot}`
-    );
+    this.logger.info("Signed new attestation", {
+      block: toHexString(attestation.data.target.root),
+      committeeIndex,
+      slot,
+    });
     return attestation;
   }
 

--- a/packages/lodestar-validator/src/services/attestation.ts
+++ b/packages/lodestar-validator/src/services/attestation.ts
@@ -119,7 +119,7 @@ export class AttestationService {
         this.validators.map((v) => v?.index ?? null).filter((i) => i !== null) as ValidatorIndex[]
       );
     } catch (e) {
-      this.logger.error(`Failed to obtain attester duty for epoch ${epoch}`, e.message);
+      this.logger.error("Failed to obtain attester duty", {epoch, error: e.message});
       return;
     }
     const fork = await this.provider.beacon.state.getFork("head");
@@ -293,7 +293,8 @@ export class AttestationService {
       this.logger.info("Published signed aggregate and proof", {committeeIndex: duty.committeeIndex, slot: duty.slot});
     } catch (e) {
       this.logger.error(
-        `Failed to publish aggregate and proof for committee ${duty.committeeIndex} at slot ${duty.slot}`,
+        "Failed to publish aggregate and proof",
+        {committeeIndex: duty.committeeIndex, slot: duty.slot},
         e
       );
     }

--- a/packages/lodestar-validator/src/services/block.ts
+++ b/packages/lodestar-validator/src/services/block.ts
@@ -157,9 +157,7 @@ export default class BlockProposingService {
     };
     try {
       await this.provider.beacon.blocks.publishBlock(signedBlock);
-      this.logger.info(
-        `Proposed block with hash ${toHexString(this.config.types.BeaconBlock.hashTreeRoot(block))} and slot ${slot}`
-      );
+      this.logger.info("Proposed block", {hash: toHexString(this.config.types.BeaconBlock.hashTreeRoot(block)), slot});
     } catch (e) {
       this.logger.error(`Failed to publish block for slot ${slot}`, e);
     }

--- a/packages/lodestar-validator/src/services/block.ts
+++ b/packages/lodestar-validator/src/services/block.ts
@@ -133,7 +133,7 @@ export default class BlockProposingService {
         this.graffiti || ""
       );
     } catch (e) {
-      this.logger.error(`Failed to produce block for slot ${slot}`, e);
+      this.logger.error("Failed to produce block", {slot}, e);
     }
     if (!block) {
       return null;
@@ -159,7 +159,7 @@ export default class BlockProposingService {
       await this.provider.beacon.blocks.publishBlock(signedBlock);
       this.logger.info("Proposed block", {hash: toHexString(this.config.types.BeaconBlock.hashTreeRoot(block)), slot});
     } catch (e) {
-      this.logger.error(`Failed to publish block for slot ${slot}`, e);
+      this.logger.error("Failed to publish block", {slot}, e);
     }
     return signedBlock;
   }

--- a/packages/lodestar-validator/src/util/httpClient.ts
+++ b/packages/lodestar-validator/src/util/httpClient.ts
@@ -27,11 +27,11 @@ export class HttpClient {
     try {
       if (query) url += "?" + querystring.stringify(query);
       const result: AxiosResponse<T> = await this.client.get<T>(url, opts);
-      this.logger.verbose(`HttpClient GET url=${url} result=${JSON.stringify(result.data)}`);
+      this.logger.verbose("HttpClient GET", {url, result: JSON.stringify(result.data)});
       return result.data;
-    } catch (reason) {
-      this.logger.verbose(`HttpClient GET error url=${url}`);
-      throw this.handleError(reason);
+    } catch (e) {
+      this.logger.verbose("HttpClient GET error", {url}, e);
+      throw this.handleError(e);
     }
   }
 
@@ -39,11 +39,11 @@ export class HttpClient {
     try {
       if (query) url += "?" + querystring.stringify(query);
       const result: AxiosResponse<T2> = await this.client.post(url, data);
-      this.logger.verbose(`HttpClient POST url=${url} result=${JSON.stringify(result.data)}`);
+      this.logger.verbose("HttpClient POST", {url, result: JSON.stringify(result.data)});
       return result.data;
-    } catch (reason) {
-      this.logger.verbose(`HttpClient POST error url=${url}`);
-      throw this.handleError(reason);
+    } catch (e) {
+      this.logger.verbose("HttpClient POST error", {url}, e);
+      throw this.handleError(e);
     }
   }
 

--- a/packages/lodestar-validator/src/validator.ts
+++ b/packages/lodestar-validator/src/validator.ts
@@ -105,8 +105,8 @@ export class Validator {
    * Establishes a connection to a specified beacon chain url.
    */
   private async setupAPI(): Promise<void> {
-    this.logger.info("Setting up RPC connection...");
+    this.logger.info("RPC connection setting up");
     await this.apiClient.connect();
-    this.logger.info(`RPC connection successfully established: ${this.apiClient.url}!`);
+    this.logger.info("RPC connection successfully established", {url: this.apiClient.url});
   }
 }

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -83,7 +83,7 @@ export class ValidatorApi implements IValidatorApi {
       const {state, epochCtx} = await this.chain.regen.getBlockSlotState(headRoot, slot);
       return await assembleAttestationData(epochCtx.config, state, headRoot, slot, committeeIndex);
     } catch (e) {
-      this.logger.warn(`Failed to produce attestation data because: ${e.message}`);
+      this.logger.warn("Failed to produce attestation data", e);
       throw e;
     }
   }
@@ -177,7 +177,7 @@ export class ValidatorApi implements IValidatorApi {
             this.network.gossip.publishAggregatedAttestation(signedAggregateAndProof),
           ]);
         } catch (e) {
-          this.logger.warn("Failed to publish aggregate and proof", {reason: e.message});
+          this.logger.warn("Failed to publish aggregate and proof", e);
         }
       })
     );

--- a/packages/lodestar/src/api/rest/index.ts
+++ b/packages/lodestar/src/api/rest/index.ts
@@ -25,7 +25,7 @@ export class RestApi {
         const address = await api.server.listen(_opts.port, _opts.host);
         logger.info("Started rest api server", {address});
       } catch (e) {
-        logger.error(`Failed to start rest api server on ${_opts.host}:${_opts.port}`, e);
+        logger.error("Failed to start rest api server", {host: _opts.host, port: _opts.port}, e);
         throw e;
       }
     }

--- a/packages/lodestar/src/api/rest/index.ts
+++ b/packages/lodestar/src/api/rest/index.ts
@@ -23,7 +23,7 @@ export class RestApi {
     if (_opts.enabled) {
       try {
         const address = await api.server.listen(_opts.port, _opts.host);
-        logger.info(`Started rest api server on ${address}`);
+        logger.info("Started rest api server", {address});
       } catch (e) {
         logger.error(`Failed to start rest api server on ${_opts.host}:${_opts.port}`, e);
         throw e;

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -36,7 +36,7 @@ function wrapHandler<
       await handler(...args);
       emitter.emit(event, ...((args as unknown) as ListenerType<Callback>));
     } catch (e) {
-      logger.error(`Error handling event: ${event}`, e);
+      logger.error("Error handling event", {event}, e);
     }
   };
 }
@@ -269,7 +269,7 @@ export async function onBlock(
 
 export async function onErrorAttestation(this: BeaconChain, err: AttestationError): Promise<void> {
   if (!(err instanceof AttestationError)) {
-    this.logger.error("Non AttestationError received:", err);
+    this.logger.error("Non AttestationError received", err);
     return;
   }
 
@@ -304,7 +304,7 @@ export async function onErrorAttestation(this: BeaconChain, err: AttestationErro
 
 export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<void> {
   if (!(err instanceof BlockError)) {
-    this.logger.error("Non BlockError received:", err);
+    this.logger.error("Non BlockError received", err);
     return;
   }
 

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -1,6 +1,6 @@
 import {readOnlyMap, toHexString} from "@chainsafe/ssz";
 import {Attestation, Checkpoint, SignedBeaconBlock, Slot, Version} from "@chainsafe/lodestar-types";
-import {ILogger, toJson} from "@chainsafe/lodestar-utils";
+import {ILogger} from "@chainsafe/lodestar-utils";
 import {IBlockSummary} from "@chainsafe/lodestar-fork-choice";
 
 import {ITreeStateContext} from "../db/api/beacon/stateContextCache";
@@ -273,7 +273,7 @@ export async function onErrorAttestation(this: BeaconChain, err: AttestationErro
     return;
   }
 
-  this.logger.debug("Attestation error", toJson(err));
+  this.logger.debug("Attestation error", err);
   const attestationRoot = this.config.types.Attestation.hashTreeRoot(err.job.attestation);
 
   switch (err.type.code) {
@@ -308,7 +308,7 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
     return;
   }
 
-  this.logger.debug("Block error", toJson(err));
+  this.logger.debug("Block error", err);
   const blockRoot = this.config.types.BeaconBlock.hashTreeRoot(err.job.signedBlock.message);
 
   switch (err.type.code) {
@@ -339,10 +339,7 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
     case BlockErrorCode.ERR_BLOCK_IS_NOT_LATER_THAN_PARENT:
     case BlockErrorCode.ERR_UNKNOWN_PROPOSER:
       await this.db.badBlock.put(blockRoot);
-      this.logger.warn("Found bad block", {
-        blockRoot: toHexString(blockRoot),
-        error: toJson(err),
-      });
+      this.logger.warn("Found bad block", {blockRoot: toHexString(blockRoot)}, err);
       break;
   }
 }

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -269,11 +269,11 @@ export async function onBlock(
 
 export async function onErrorAttestation(this: BeaconChain, err: AttestationError): Promise<void> {
   if (!(err instanceof AttestationError)) {
-    this.logger.error("Non AttestationError received", err);
+    this.logger.error("Non AttestationError received", {}, err);
     return;
   }
 
-  this.logger.debug("Attestation error", err);
+  this.logger.debug("Attestation error", {}, err);
   const attestationRoot = this.config.types.Attestation.hashTreeRoot(err.job.attestation);
 
   switch (err.type.code) {
@@ -304,11 +304,11 @@ export async function onErrorAttestation(this: BeaconChain, err: AttestationErro
 
 export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<void> {
   if (!(err instanceof BlockError)) {
-    this.logger.error("Non BlockError received", err);
+    this.logger.error("Non BlockError received", {}, err);
     return;
   }
 
-  this.logger.debug("Block error", err);
+  this.logger.debug("Block error", {}, err);
   const blockRoot = this.config.types.BeaconBlock.hashTreeRoot(err.job.signedBlock.message);
 
   switch (err.type.code) {

--- a/packages/lodestar/src/chain/genesis/genesis.ts
+++ b/packages/lodestar/src/chain/genesis/genesis.ts
@@ -75,7 +75,7 @@ export class GenesisBuilder implements IGenesisBuilder {
       applyTimestamp(this.config, this.state, block.timestamp);
       applyEth1BlockHash(this.config, this.state, block.blockHash);
       if (isValidGenesisState(this.config, this.state)) {
-        this.logger.info(`Found genesis state at eth1 block ${block.blockNumber}`);
+        this.logger.info("Found genesis state", {blockNumber: block.blockNumber});
         return {
           state: this.state,
           depositTree: this.depositTree,
@@ -100,7 +100,7 @@ export class GenesisBuilder implements IGenesisBuilder {
     for await (const {depositEvents, blockNumber} of depositsStream) {
       this.applyDeposits(depositEvents);
       if (isValidGenesisValidators(this.config, this.state)) {
-        this.logger.info(`Found enough validators at eth1 block ${blockNumber}`);
+        this.logger.info("Found enough genesis validators", {blockNumber});
         return blockNumber;
       } else {
         this.logger.info(

--- a/packages/lodestar/src/eth1/eth1ForBlockProduction.ts
+++ b/packages/lodestar/src/eth1/eth1ForBlockProduction.ts
@@ -144,7 +144,7 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
     const toBlock = Math.min(remoteFollowBlock, fromBlock + this.MAX_BLOCKS_PER_LOG_QUERY - 1);
 
     const depositEvents = await this.eth1Provider.getDepositEvents(fromBlock, toBlock);
-    this.logger.verbose(`Fetched deposits ${depositEvents.length}`, {fromBlock, toBlock});
+    this.logger.verbose("Fetched deposits", {depositCount: depositEvents.length, fromBlock, toBlock});
 
     await this.depositsCache.add(depositEvents);
     // Store the `toBlock` since that block may not contain
@@ -180,7 +180,7 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
     );
 
     const eth1Blocks = await this.eth1Provider.getBlocksByNumber(fromBlock, toBlock, this.signal);
-    this.logger.verbose(`Fetched eth1 blocks ${eth1Blocks.length}`, {fromBlock, toBlock});
+    this.logger.verbose("Fetched eth1 blocks", {blockCount: eth1Blocks.length, fromBlock, toBlock});
 
     const eth1Datas = await this.depositsCache.getEth1DataForBlocks(eth1Blocks, lastProcessedDepositBlockNumber);
     await this.eth1DataCache.add(eth1Datas);

--- a/packages/lodestar/src/metrics/server/http.ts
+++ b/packages/lodestar/src/metrics/server/http.ts
@@ -37,7 +37,7 @@ export class HttpMetricsServer implements IMetricsServer {
       try {
         await this.terminator.terminate();
       } catch (e) {
-        this.logger.warn("Failed to stop metrics server. Error: " + e.message);
+        this.logger.warn("Failed to stop metrics server", e);
       }
     }
   }

--- a/packages/lodestar/src/metrics/server/http.ts
+++ b/packages/lodestar/src/metrics/server/http.ts
@@ -25,7 +25,7 @@ export class HttpMetricsServer implements IMetricsServer {
   public async start(): Promise<void> {
     if (this.opts.enabled) {
       const {serverPort, listenAddr} = this.opts;
-      this.logger.info(`Starting metrics HTTP server on port ${serverPort}`);
+      this.logger.info("Starting metrics HTTP server", {port: serverPort || null});
       const listen = this.http.listen.bind(this.http);
       return new Promise((resolve, reject) => {
         listen(serverPort, listenAddr).once("listening", resolve).once("error", reject);

--- a/packages/lodestar/src/network/encoders/request.ts
+++ b/packages/lodestar/src/network/encoders/request.ts
@@ -24,7 +24,7 @@ export function eth2RequestEncode(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           serialized = type.serialize(request as any);
         } catch (e) {
-          logger.warn("Malformed input. Failed to serialize request for method " + method);
+          logger.warn("Malformed input. Failed to serialize request", {method}, e);
           continue;
         }
         yield Buffer.from(encode(serialized.length));

--- a/packages/lodestar/src/network/encoders/request.ts
+++ b/packages/lodestar/src/network/encoders/request.ts
@@ -60,9 +60,10 @@ export function eth2RequestDecode(
         if (sszDataLength === null) {
           sszDataLength = decode(chunk.slice());
           if (decode.bytes > 10) {
-            logger.error(
-              `eth2RequestDecode: Invalid number of bytes for protobuf varint ${decode.bytes}` + `, method ${method}`
-            );
+            logger.error("eth2RequestDecode: Invalid number of bytes for protobuf varint", {
+              bytes: decode.bytes,
+              method,
+            });
             yield {isValid: false};
             break;
           }
@@ -72,15 +73,12 @@ export function eth2RequestDecode(
           }
         }
         if (sszDataLength < type.minSize() || sszDataLength > type.maxSize()) {
-          logger.error(`eth2RequestDecode: Invalid szzLength of ${sszDataLength} for method ${method}`);
+          logger.error("eth2RequestDecode: Invalid szzLength", {sszDataLength, method});
           yield {isValid: false};
           break;
         }
         if (chunk.length > maxEncodedLen(sszDataLength, encoding)) {
-          logger.error(
-            `eth2RequestDecode: too much bytes read (${chunk.length}) for method ${method}, ` +
-              `sszLength ${sszDataLength}`
-          );
+          logger.error("eth2RequestDecode: too much bytes read", {chunkLength: chunk.length, sszDataLength, method});
           yield {isValid: false};
           break;
         }
@@ -88,7 +86,7 @@ export function eth2RequestDecode(
         try {
           uncompressed = decompressor.uncompress(chunk.slice());
         } catch (e) {
-          logger.error("Failed to decompress request data. Error: " + e.message);
+          logger.error("Failed to decompress request data", {error: e.message});
           yield {isValid: false};
           break;
         }
@@ -99,14 +97,14 @@ export function eth2RequestDecode(
           continue;
         }
         if (buffer.length > sszDataLength) {
-          logger.error("Too long message received for method " + method);
+          logger.error("Too long message received", {method});
           yield {isValid: false};
           break;
         }
         try {
           yield {isValid: true, body: type.deserialize(buffer.slice(0, sszDataLength)) as RequestBody};
         } catch (e) {
-          logger.error(`Malformed input. Failed to deserialize ${method} request type. Error: ${e.message}`);
+          logger.error("Malformed input. Failed to deserialize request type", {method, error: e.message});
           yield {isValid: false};
           break;
         }

--- a/packages/lodestar/src/network/encoders/response.ts
+++ b/packages/lodestar/src/network/encoders/response.ts
@@ -37,7 +37,7 @@ export function eth2ResponseEncode(
           const serialized = type.serialize(chunk.body as any);
           serializedData = Buffer.from(serialized.buffer, serialized.byteOffset, serialized.length);
         } catch (e) {
-          logger.warn(`Failed to ssz serialize chunk of method ${method}. Error: ${e.message}`);
+          logger.warn("Failed to ssz serialize chunk", {method}, e);
         }
         //yield encoded ssz length
         yield Buffer.from(encode(serializedData!.length));
@@ -81,7 +81,7 @@ export function eth2ResponseDecode(
             errorMessage = decodeP2pErrorMessage(config, buffer.slice());
             buffer = new BufferList();
           } catch (e) {
-            logger.warn("Failed to get error message from response", {method, requestId, error: e.message});
+            logger.warn("Failed to get error message from response", {method, requestId}, e);
           }
           logger.warn("eth2ResponseDecode: Received err status", {status, errorMessage, method, requestId});
           controller.abort();
@@ -111,7 +111,7 @@ export function eth2ResponseDecode(
           uncompressed = decompressor.uncompress(buffer.slice());
           buffer.consume(buffer.length);
         } catch (e) {
-          logger.warn(`Failed to uncompress data for method ${method}. Error: ${e.message}`, {requestId, encoding});
+          logger.warn("Failed to uncompress data", {method, requestId, encoding}, e);
         }
         if (uncompressed) {
           uncompressedData.append(uncompressed);
@@ -131,10 +131,7 @@ export function eth2ResponseDecode(
                 continue;
               }
             } catch (e) {
-              logger.warn(`Failed to ssz deserialize data for method ${method}. Error: ${e.message}`, {
-                requestId,
-                encoding,
-              });
+              logger.warn("Failed to ssz deserialize data", {method, requestId, encoding}, e);
             }
           }
         }

--- a/packages/lodestar/src/network/gossip/gossip.ts
+++ b/packages/lodestar/src/network/gossip/gossip.ts
@@ -256,7 +256,7 @@ export class Gossip extends (EventEmitter as {new (): GossipEventEmitter}) imple
 
   private logSubscriptions = (): void => {
     if (this.pubsub && this.pubsub.subscriptions) {
-      this.logger.info("Current gossip subscriptions: " + Array.from(this.pubsub.subscriptions).join(","));
+      this.logger.info("Current gossip subscriptions", {subscriptions: Array.from(this.pubsub.subscriptions)});
     } else {
       this.logger.info("Gossipsub not started");
     }

--- a/packages/lodestar/src/network/gossip/handlers/aggregateAndProof.ts
+++ b/packages/lodestar/src/network/gossip/handlers/aggregateAndProof.ts
@@ -12,10 +12,10 @@ import {GossipObject} from "../interface";
 export async function handleIncomingAggregateAndProof(this: Gossip, obj: GossipObject): Promise<void> {
   try {
     const signedAggregateAndProof = obj as SignedAggregateAndProof;
-    this.logger.verbose(
-      `Received AggregateAndProof from validator #${signedAggregateAndProof.message.aggregatorIndex}` +
-        ` for target ${toHexString(signedAggregateAndProof.message.aggregate.data.target.root)}`
-    );
+    this.logger.verbose("Received AggregateAndProof", {
+      validator: signedAggregateAndProof.message.aggregatorIndex,
+      target: toHexString(signedAggregateAndProof.message.aggregate.data.target.root),
+    });
     this.emit(GossipEvent.AGGREGATE_AND_PROOF, signedAggregateAndProof);
   } catch (e) {
     this.logger.warn("Incoming aggregate and proof error", e);
@@ -32,8 +32,8 @@ export async function publishAggregatedAttestation(
     Buffer.from(this.config.types.SignedAggregateAndProof.serialize(signedAggregateAndProof))
   );
 
-  this.logger.verbose(
-    `Publishing SignedAggregateAndProof for validator #${signedAggregateAndProof.message.aggregatorIndex}` +
-      ` for target ${toHexString(signedAggregateAndProof.message.aggregate.data.target.root)}`
-  );
+  this.logger.verbose("Publishing SignedAggregateAndProof", {
+    validator: signedAggregateAndProof.message.aggregatorIndex,
+    target: toHexString(signedAggregateAndProof.message.aggregate.data.target.root),
+  });
 }

--- a/packages/lodestar/src/network/gossip/handlers/attestation.ts
+++ b/packages/lodestar/src/network/gossip/handlers/attestation.ts
@@ -15,10 +15,12 @@ export function getCommitteeAttestationHandler(subnet: number): GossipHandlerFn 
   return function handleIncomingCommitteeAttestation(this: Gossip, obj: GossipObject): void {
     try {
       const attestation = obj as Attestation;
-      this.logger.verbose(
-        `Received committee attestation for block ${toHexString(attestation.data.beaconBlockRoot)}` +
-          `subnet: ${subnet}, (${attestation.data.source.epoch}, ${attestation.data.target.epoch})`
-      );
+      this.logger.verbose("Received committee attestation", {
+        block: toHexString(attestation.data.beaconBlockRoot),
+        subnet,
+        source: attestation.data.source.epoch,
+        target: attestation.data.target.epoch,
+      });
       // attestation subnet event is dynamic, so it is not typed and declared in IGossipEvents
       // @ts-ignore
       this.emit(getAttestationSubnetEvent(subnet), {attestation, subnet});
@@ -42,5 +44,5 @@ export async function publishCommiteeAttestation(this: Gossip, attestation: Atte
     Buffer.from(this.config.types.Attestation.serialize(attestation))
   );
   const attestationHex = toHexString(this.config.types.Attestation.hashTreeRoot(attestation));
-  this.logger.verbose(`Publishing attestation ${attestationHex} for subnet ${subnet}`);
+  this.logger.verbose("Publishing attestation", {attestationHex, subnet});
 }

--- a/packages/lodestar/src/network/gossip/handlers/block.ts
+++ b/packages/lodestar/src/network/gossip/handlers/block.ts
@@ -11,7 +11,7 @@ import {GossipObject} from "../interface";
 export async function handleIncomingBlock(this: Gossip, obj: GossipObject): Promise<void> {
   try {
     const signedBlock = obj as SignedBeaconBlock;
-    this.logger.verbose(`Incoming gossip block at slot: ${signedBlock.message.slot}`);
+    this.logger.verbose("Incoming gossip block", {slot: signedBlock.message.slot});
     this.emit(GossipEvent.BLOCK, signedBlock);
   } catch (e) {
     this.logger.warn("Incoming block error", e);
@@ -24,5 +24,5 @@ export async function publishBlock(this: Gossip, signedBlock: SignedBeaconBlock)
     getGossipTopic(GossipEvent.BLOCK, forkDigestValue),
     Buffer.from(this.config.types.SignedBeaconBlock.serialize(signedBlock))
   );
-  this.logger.verbose(`Publishing block at slot: ${signedBlock.message.slot}`);
+  this.logger.verbose("Publishing block", {block: signedBlock.message.slot});
 }

--- a/packages/lodestar/src/network/gossip/handlers/proposerSlashing.ts
+++ b/packages/lodestar/src/network/gossip/handlers/proposerSlashing.ts
@@ -11,7 +11,7 @@ import {GossipObject} from "../interface";
 export async function handleIncomingProposerSlashing(this: Gossip, obj: GossipObject): Promise<void> {
   try {
     const proposerSlashing = obj as ProposerSlashing;
-    this.logger.verbose(`Received slashing for proposer #${proposerSlashing.signedHeader1.message.proposerIndex}`);
+    this.logger.verbose("Received slashing", {proposer: proposerSlashing.signedHeader1.message.proposerIndex});
     this.emit(GossipEvent.PROPOSER_SLASHING, proposerSlashing);
   } catch (e) {
     this.logger.warn("Incoming proposer slashing error", e);
@@ -24,7 +24,7 @@ export async function publishProposerSlashing(this: Gossip, proposerSlashing: Pr
     getGossipTopic(GossipEvent.PROPOSER_SLASHING, forkDigestValue),
     Buffer.from(this.config.types.ProposerSlashing.serialize(proposerSlashing))
   );
-  this.logger.verbose(
-    `Publishing proposer slashing for validator #${proposerSlashing.signedHeader1.message.proposerIndex}`
-  );
+  this.logger.verbose("Publishing proposer slashing", {
+    validator: proposerSlashing.signedHeader1.message.proposerIndex,
+  });
 }

--- a/packages/lodestar/src/network/gossip/handlers/voluntaryExit.ts
+++ b/packages/lodestar/src/network/gossip/handlers/voluntaryExit.ts
@@ -11,7 +11,7 @@ import {GossipObject} from "../interface";
 export async function handleIncomingVoluntaryExit(this: Gossip, obj: GossipObject): Promise<void> {
   try {
     const voluntaryExit = obj as SignedVoluntaryExit;
-    this.logger.verbose(`Received voluntary exit for validator #${voluntaryExit.message.validatorIndex}`);
+    this.logger.verbose("Received voluntary exit", {validator: voluntaryExit.message.validatorIndex});
     this.emit(GossipEvent.VOLUNTARY_EXIT, voluntaryExit);
   } catch (e) {
     this.logger.warn("Incoming voluntary exit error", e);
@@ -24,5 +24,5 @@ export async function publishVoluntaryExit(this: Gossip, voluntaryExit: SignedVo
     getGossipTopic(GossipEvent.VOLUNTARY_EXIT, forkDigestValue),
     Buffer.from(this.config.types.SignedVoluntaryExit.serialize(voluntaryExit))
   );
-  this.logger.verbose(`Publishing voluntary exit for validator #${voluntaryExit.message.validatorIndex}`);
+  this.logger.verbose("Publishing voluntary exit", {validator: voluntaryExit.message.validatorIndex});
 }

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -71,17 +71,17 @@ export class GossipMessageValidator implements IGossipMessageValidator {
         case BlockErrorCode.ERR_PROPOSAL_SIGNATURE_INVALID:
         case BlockErrorCode.ERR_INCORRECT_PROPOSER:
         case BlockErrorCode.ERR_KNOWN_BAD_BLOCK:
-          this.logger.warn("Rejecting gossip block", {...e.getMetadata(), ...logContext});
+          this.logger.warn("Rejecting gossip block", logContext, e.getMetadata());
           return ExtendedValidatorResult.reject;
         case BlockErrorCode.ERR_FUTURE_SLOT:
         case BlockErrorCode.ERR_PARENT_UNKNOWN:
           await this.chain.receiveBlock(signedBlock);
-          this.logger.warn("Ignoring gossip block", {...e.getMetadata(), ...logContext});
+          this.logger.warn("Ignoring gossip block", logContext, e.getMetadata());
           return ExtendedValidatorResult.ignore;
         case BlockErrorCode.ERR_WOULD_REVERT_FINALIZED_SLOT:
         case BlockErrorCode.ERR_REPEAT_PROPOSAL:
         default:
-          this.logger.warn("Ignoring gossip block", {...e.getMetadata(), ...logContext});
+          this.logger.warn("Ignoring gossip block", logContext, e.getMetadata());
           return ExtendedValidatorResult.ignore;
       }
     }
@@ -121,19 +121,19 @@ export class GossipMessageValidator implements IGossipMessageValidator {
         case AttestationErrorCode.ERR_KNOWN_BAD_BLOCK:
         case AttestationErrorCode.ERR_FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT:
         case AttestationErrorCode.ERR_TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK:
-          this.logger.warn("Rejecting gossip attestation", {...e.getMetadata(), ...logContext});
+          this.logger.warn("Rejecting gossip attestation", logContext, e.getMetadata());
           return ExtendedValidatorResult.reject;
         case AttestationErrorCode.ERR_UNKNOWN_BEACON_BLOCK_ROOT:
         case AttestationErrorCode.ERR_MISSING_ATTESTATION_PRESTATE:
           // attestation might be valid after we receive block
           await this.chain.receiveAttestation(attestation);
-          this.logger.warn("Ignoring gossip attestation", {...e.getMetadata(), ...logContext});
+          this.logger.warn("Ignoring gossip attestation", logContext, e.getMetadata());
           return ExtendedValidatorResult.ignore;
         case AttestationErrorCode.ERR_PAST_SLOT:
         case AttestationErrorCode.ERR_FUTURE_SLOT:
         case AttestationErrorCode.ERR_ATTESTATION_ALREADY_KNOWN:
         default:
-          this.logger.warn("Ignoring gossip attestation", {...e.getMetadata(), ...logContext});
+          this.logger.warn("Ignoring gossip attestation", logContext, e.getMetadata());
           return ExtendedValidatorResult.ignore;
       }
     } finally {
@@ -173,17 +173,17 @@ export class GossipMessageValidator implements IGossipMessageValidator {
         case AttestationErrorCode.ERR_INVALID_SELECTION_PROOF:
         case AttestationErrorCode.ERR_INVALID_SIGNATURE:
         case AttestationErrorCode.ERR_INVALID_AGGREGATOR:
-          this.logger.warn("Rejecting gossip aggregate and proof", {...e.getMetadata(), ...logContext});
+          this.logger.warn("Rejecting gossip aggregate and proof", logContext, e.getMetadata());
           return ExtendedValidatorResult.reject;
         case AttestationErrorCode.ERR_FUTURE_SLOT:
           await this.chain.receiveAttestation(attestation);
-          this.logger.warn("Ignoring gossip aggregate and proof", {...e.getMetadata(), ...logContext});
+          this.logger.warn("Ignoring gossip aggregate and proof", logContext, e.getMetadata());
           return ExtendedValidatorResult.ignore;
         case AttestationErrorCode.ERR_PAST_SLOT:
         case AttestationErrorCode.ERR_AGGREGATE_ALREADY_KNOWN:
         case AttestationErrorCode.ERR_MISSING_ATTESTATION_PRESTATE:
         default:
-          this.logger.warn("Ignoring gossip aggregate and proof", {...e.getMetadata(), ...logContext});
+          this.logger.warn("Ignoring gossip aggregate and proof", logContext, e.getMetadata());
           return ExtendedValidatorResult.ignore;
       }
     } finally {

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -71,17 +71,17 @@ export class GossipMessageValidator implements IGossipMessageValidator {
         case BlockErrorCode.ERR_PROPOSAL_SIGNATURE_INVALID:
         case BlockErrorCode.ERR_INCORRECT_PROPOSER:
         case BlockErrorCode.ERR_KNOWN_BAD_BLOCK:
-          this.logger.warn("Rejecting gossip block", logContext, e.getMetadata());
+          this.logger.warn("Rejecting gossip block", logContext, e);
           return ExtendedValidatorResult.reject;
         case BlockErrorCode.ERR_FUTURE_SLOT:
         case BlockErrorCode.ERR_PARENT_UNKNOWN:
           await this.chain.receiveBlock(signedBlock);
-          this.logger.warn("Ignoring gossip block", logContext, e.getMetadata());
+          this.logger.warn("Ignoring gossip block", logContext, e);
           return ExtendedValidatorResult.ignore;
         case BlockErrorCode.ERR_WOULD_REVERT_FINALIZED_SLOT:
         case BlockErrorCode.ERR_REPEAT_PROPOSAL:
         default:
-          this.logger.warn("Ignoring gossip block", logContext, e.getMetadata());
+          this.logger.warn("Ignoring gossip block", logContext, e);
           return ExtendedValidatorResult.ignore;
       }
     }
@@ -121,19 +121,19 @@ export class GossipMessageValidator implements IGossipMessageValidator {
         case AttestationErrorCode.ERR_KNOWN_BAD_BLOCK:
         case AttestationErrorCode.ERR_FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT:
         case AttestationErrorCode.ERR_TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK:
-          this.logger.warn("Rejecting gossip attestation", logContext, e.getMetadata());
+          this.logger.warn("Rejecting gossip attestation", logContext, e);
           return ExtendedValidatorResult.reject;
         case AttestationErrorCode.ERR_UNKNOWN_BEACON_BLOCK_ROOT:
         case AttestationErrorCode.ERR_MISSING_ATTESTATION_PRESTATE:
           // attestation might be valid after we receive block
           await this.chain.receiveAttestation(attestation);
-          this.logger.warn("Ignoring gossip attestation", logContext, e.getMetadata());
+          this.logger.warn("Ignoring gossip attestation", logContext, e);
           return ExtendedValidatorResult.ignore;
         case AttestationErrorCode.ERR_PAST_SLOT:
         case AttestationErrorCode.ERR_FUTURE_SLOT:
         case AttestationErrorCode.ERR_ATTESTATION_ALREADY_KNOWN:
         default:
-          this.logger.warn("Ignoring gossip attestation", logContext, e.getMetadata());
+          this.logger.warn("Ignoring gossip attestation", logContext, e);
           return ExtendedValidatorResult.ignore;
       }
     } finally {
@@ -173,17 +173,17 @@ export class GossipMessageValidator implements IGossipMessageValidator {
         case AttestationErrorCode.ERR_INVALID_SELECTION_PROOF:
         case AttestationErrorCode.ERR_INVALID_SIGNATURE:
         case AttestationErrorCode.ERR_INVALID_AGGREGATOR:
-          this.logger.warn("Rejecting gossip aggregate and proof", logContext, e.getMetadata());
+          this.logger.warn("Rejecting gossip aggregate and proof", logContext, e);
           return ExtendedValidatorResult.reject;
         case AttestationErrorCode.ERR_FUTURE_SLOT:
           await this.chain.receiveAttestation(attestation);
-          this.logger.warn("Ignoring gossip aggregate and proof", logContext, e.getMetadata());
+          this.logger.warn("Ignoring gossip aggregate and proof", logContext, e);
           return ExtendedValidatorResult.ignore;
         case AttestationErrorCode.ERR_PAST_SLOT:
         case AttestationErrorCode.ERR_AGGREGATE_ALREADY_KNOWN:
         case AttestationErrorCode.ERR_MISSING_ATTESTATION_PRESTATE:
         default:
-          this.logger.warn("Ignoring gossip aggregate and proof", logContext, e.getMetadata());
+          this.logger.warn("Ignoring gossip aggregate and proof", logContext, e);
           return ExtendedValidatorResult.ignore;
       }
     } finally {
@@ -204,11 +204,11 @@ export class GossipMessageValidator implements IGossipMessageValidator {
       }
       switch (e.type.code) {
         case VoluntaryExitErrorCode.ERR_INVALID_EXIT:
-          this.logger.warn("Rejecting gossip voluntary exit", e.getMetadata());
+          this.logger.warn("Rejecting gossip voluntary exit", {}, e);
           return ExtendedValidatorResult.reject;
         case VoluntaryExitErrorCode.ERR_EXIT_ALREADY_EXISTS:
         default:
-          this.logger.warn("Ignoring gossip voluntary exit", e.getMetadata());
+          this.logger.warn("Ignoring gossip voluntary exit", {}, e);
           return ExtendedValidatorResult.ignore;
       }
     }
@@ -227,11 +227,11 @@ export class GossipMessageValidator implements IGossipMessageValidator {
       }
       switch (e.type.code) {
         case ProposerSlashingErrorCode.ERR_INVALID_SLASHING:
-          this.logger.warn("Rejecting gossip proposer slashing", e.getMetadata());
+          this.logger.warn("Rejecting gossip proposer slashing", {}, e);
           return ExtendedValidatorResult.reject;
         case ProposerSlashingErrorCode.ERR_SLASHING_ALREADY_EXISTS:
         default:
-          this.logger.warn("Ignoring gossip proposer slashing", e.getMetadata());
+          this.logger.warn("Ignoring gossip proposer slashing", {}, e);
           return ExtendedValidatorResult.ignore;
       }
     }
@@ -250,11 +250,11 @@ export class GossipMessageValidator implements IGossipMessageValidator {
       }
       switch (e.type.code) {
         case AttesterSlashingErrorCode.ERR_INVALID_SLASHING:
-          this.logger.warn("Rejecting gossip attester slashing", e.getMetadata());
+          this.logger.warn("Rejecting gossip attester slashing", {}, e);
           return ExtendedValidatorResult.reject;
         case AttesterSlashingErrorCode.ERR_SLASHING_ALREADY_EXISTS:
         default:
-          this.logger.warn("Ignoring gossip attester slashing", e.getMetadata());
+          this.logger.warn("Ignoring gossip attester slashing", {}, e);
           return ExtendedValidatorResult.ignore;
       }
     }

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -178,12 +178,12 @@ export class Libp2pNetwork extends (EventEmitter as {new (): NetworkEventEmitter
     );
     if (peerIds.length === 0) {
       // the validator must discover new peers on this topic
-      this.logger.verbose(`Finding new peers for subnet ${subnet}`);
+      this.logger.verbose("Finding new peers", {subnet});
       const found = await this.connectToNewPeersBySubnet(parseInt(subnet));
       if (found) {
-        this.logger.verbose(`Found new peer for subnet ${subnet}`);
+        this.logger.verbose("Found new peer", {subnet});
       } else {
-        this.logger.verbose(`Not found any peers for subnet ${subnet}`);
+        this.logger.verbose("Not found any peers", {subnet});
       }
     }
   }
@@ -205,7 +205,7 @@ export class Libp2pNetwork extends (EventEmitter as {new (): NetworkEventEmitter
         break;
       } catch (e) {
         // this runs too frequently so make it verbose
-        this.logger.verbose(`Cannot connect to peer ${peer.peerId.toB58String()} for subnet ${subnet}`, e.message);
+        this.logger.verbose("Cannot connect to peer", {peerId: peer.peerId.toB58String(), subnet, error: e.message});
       }
     }
     return found;
@@ -235,13 +235,13 @@ export class Libp2pNetwork extends (EventEmitter as {new (): NetworkEventEmitter
 
   private emitPeerConnect = (conn: LibP2pConnection): void => {
     this.metrics.peers.inc();
-    this.logger.verbose("peer connected " + conn.remotePeer.toB58String() + " " + conn.stat.direction);
+    this.logger.verbose("peer connected", {peerId: conn.remotePeer.toB58String(), direction: conn.stat.direction});
     //tmp fix, we will just do double status exchange but nothing major
     this.emit("peer:connect", conn.remotePeer, conn.stat.direction);
   };
 
   private emitPeerDisconnect = (conn: LibP2pConnection): void => {
-    this.logger.verbose("peer disconnected " + conn.remotePeer.toB58String());
+    this.logger.verbose("peer disconnected", {peerId: conn.remotePeer.toB58String()});
     this.metrics.peers.dec();
     this.emit("peer:disconnect", conn.remotePeer);
   };

--- a/packages/lodestar/src/network/reqresp/reqUtils.ts
+++ b/packages/lodestar/src/network/reqresp/reqUtils.ts
@@ -40,10 +40,7 @@ export async function sendRequest<T extends ResponseBody | ResponseBody[]>(
       handleResponses<T>(modules, peerId, method, encoding, requestId, requestSingleChunk, requestOnly, body)
     );
   } catch (e) {
-    modules.logger.warn(`failed to send request ${requestId} to peer ${peerId.toB58String()}`, {
-      method,
-      reason: e.message,
-    });
+    modules.logger.warn("failed to send request", {requestId, peerId: peerId.toB58String(), method}, e);
     throw e;
   }
 }

--- a/packages/lodestar/src/network/tasks/checkPeerAliveTask.ts
+++ b/packages/lodestar/src/network/tasks/checkPeerAliveTask.ts
@@ -51,7 +51,7 @@ export class CheckPeerAliveTask {
           peerSeq = await this.network.reqResp.ping(peer, seq);
           if (peerSeq === null) throw new Error("ping method return null for peer " + peer.toB58String());
         } catch (e) {
-          this.logger.warn("Cannot ping peer" + peer.toB58String() + ", disconnecting it. Error:", e.message);
+          this.logger.warn("Cannot ping peer, disconnecting it", {peerId: peer.toB58String(), error: e.message});
           // a peer may still be good for gossip blocks even it does not response to ping
           // temporarily disable this due to https://github.com/ChainSafe/lodestar/issues/1619
           // await this.network.disconnect(peer);

--- a/packages/lodestar/src/network/tasks/diversifyPeersBySubnetTask.ts
+++ b/packages/lodestar/src/network/tasks/diversifyPeersBySubnetTask.ts
@@ -67,7 +67,7 @@ export class DiversifyPeersBySubnetTask {
       try {
         await Promise.all(toDiscPeers.map((peer) => this.network.disconnect(peer)));
       } catch (e) {
-        this.logger.warn("Cannot disconnect peers", e.message);
+        this.logger.warn("Cannot disconnect peers", {error: e.message});
       }
     }
     await Promise.all(
@@ -75,7 +75,7 @@ export class DiversifyPeersBySubnetTask {
         try {
           await this.network.searchSubnetPeers(String(subnet));
         } catch (e) {
-          this.logger.warn("Cannot connect to peers for subnet " + subnet, e.message);
+          this.logger.warn("Cannot connect to peers on subnet", {subnet, error: e.message});
         }
       })
     );

--- a/packages/lodestar/src/network/tasks/diversifyPeersBySubnetTask.ts
+++ b/packages/lodestar/src/network/tasks/diversifyPeersBySubnetTask.ts
@@ -51,7 +51,7 @@ export class DiversifyPeersBySubnetTask {
     this.logger.profile("DiversifyPeersBySubnetTask");
     const missingSubnets = this.isSynced ? findMissingSubnets(this.network) : [];
     if (missingSubnets.length > 0) {
-      this.logger.verbose(`Search for ${missingSubnets.length} peers with subnets: ` + missingSubnets.join(","));
+      this.logger.verbose("Searching peers for missing subnets", {missingSubnets});
     } else {
       this.logger.info(
         this.isSynced
@@ -63,7 +63,10 @@ export class DiversifyPeersBySubnetTask {
       ? gossipPeersToDisconnect(this.network, missingSubnets.length, this.network.getMaxPeer()) || []
       : syncPeersToDisconnect(this.network) || [];
     if (toDiscPeers.length > 0) {
-      this.logger.verbose(`Disconnecting ${toDiscPeers.length} peers to find ${missingSubnets.length} new peers`);
+      this.logger.verbose("Disconnecting peers to find new peers", {
+        peersToDisconnect: toDiscPeers.length,
+        peersToConnect: missingSubnets.length,
+      });
       try {
         await Promise.all(toDiscPeers.map((peer) => this.network.disconnect(peer)));
       } catch (e) {

--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -144,7 +144,8 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
           if (typeof lastSlot === "number") {
             if (lastSlot === getLastProcessedBlock().slot) {
               // failed at start of range
-              logger.warn(`Failed to process range, retrying, lastSlot=${lastSlot} range=${JSON.stringify(slotRange)}`);
+
+              logger.warn("Failed to process block range, retrying", {lastSlot, ...slotRange});
               setBlockImportTarget(lastSlot);
             } else {
               // success
@@ -154,7 +155,7 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
             }
           } else {
             // no blocks in range
-            logger.warn(`Didn't receive any valid block in range range ${JSON.stringify(slotRange)}`);
+            logger.warn("Didn't receive any valid block in block range", {...slotRange});
             //we didn't receive any block, set target from last requested slot
             setBlockImportTarget(slotRange.end);
           }

--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -79,7 +79,7 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
       await this.stop();
       return;
     }
-    this.logger.info("Start initial sync from finalized slot " + this.blockImportTarget);
+    this.logger.info("Start initial sync", {finalizedSlot: this.blockImportTarget});
     this.setBlockImportTarget();
     await this.stats.start();
     await this.sync();
@@ -116,7 +116,7 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
   private setBlockImportTarget = (fromSlot?: Slot): void => {
     const lastTarget = fromSlot ?? this.blockImportTarget;
     const newTarget = this.getNewBlockImportTarget(lastTarget);
-    this.logger.info(`Fetching blocks for ${lastTarget + 1}...${newTarget} slot range`);
+    this.logger.info("Fetching blocks range", {fromSlot: lastTarget + 1, toSlot: newTarget});
     this.syncTriggerSource.push({start: lastTarget + 1, end: newTarget});
     this.updateBlockImportTarget(newTarget);
   };

--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -109,7 +109,7 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
   }
 
   private updateBlockImportTarget = (target: Slot): void => {
-    this.logger.verbose(`updating block target ${target}`);
+    this.logger.verbose("updating block target", {target});
     this.blockImportTarget = target;
   };
 
@@ -140,7 +140,7 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
             fetchBlockChunks(logger, network.reqResp, getInitialSyncPeers),
             processSyncBlocks(config, chain, logger, true, getLastProcessedBlock(), true)
           );
-          logger.verbose("last processed slot=" + lastSlot + ` range=${JSON.stringify(slotRange)}`);
+          logger.verbose("last processed slot range", {lastSlot, ...slotRange});
           if (typeof lastSlot === "number") {
             if (lastSlot === getLastProcessedBlock().slot) {
               // failed at start of range
@@ -196,7 +196,7 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
       const newTarget = getCommonFinalizedCheckpoint(this.config, this.getPeerStatuses())!;
       if (newTarget.epoch > this.targetCheckpoint!.epoch) {
         this.targetCheckpoint = newTarget;
-        this.logger.verbose(`Set new target checkpoint to ${newTarget.epoch}`);
+        this.logger.verbose("Set new target checkpoint", {epoch: newTarget.epoch});
         return;
       }
       this.logger.important(`Reach common finalized checkpoint at epoch ${this.targetCheckpoint!.epoch}`);

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -61,7 +61,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
     const currentSlot = this.chain.clock.currentSlot;
     this.logger.info("Started regular syncing", {currentSlot, headSlot});
     if (headSlot >= currentSlot) {
-      this.logger.info(`Regular Sync: node is up to date, headSlot=${headSlot}`);
+      this.logger.info("Regular Sync: node is up to date", {headSlot});
       this.emit("syncCompleted");
       await this.stop();
       return;
@@ -105,7 +105,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
   private setTarget = (newTarget?: Slot, triggerSync = true): void => {
     newTarget = newTarget ?? this.getNewTarget();
     if (triggerSync && newTarget > this.currentTarget) {
-      this.logger.info(`Regular Sync: Requesting blocks from slot ${this.currentTarget + 1} to slot ${newTarget}`);
+      this.logger.info("Regular Sync: Requesting blocks range", {fromSlot: this.currentTarget + 1, toSlot: newTarget});
       this.targetSlotRangeSource.push({start: this.currentTarget + 1, end: newTarget});
     }
     this.currentTarget = newTarget;
@@ -130,7 +130,8 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
         };
         this.setTarget();
         this.subscribeToBlock = false;
-        this.logger.info(`Regular Sync: Synced up to slot ${lastProcessedBlock.message.slot} `, {
+        this.logger.info("Regular Sync: Sync progress", {
+          lastProcessedSlot: lastProcessedBlock.message.slot,
           currentSlot: this.chain.clock.currentSlot,
           gossipParentBlockRoot: this.gossipParentBlockRoot ? toHexString(this.gossipParentBlockRoot) : "undefined",
         });
@@ -259,7 +260,8 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
       this.bestPeer = getBestPeer(this.config, peers, this.network.peerMetadata);
       if (checkBestPeer(this.bestPeer, this.chain.forkChoice, this.network)) {
         const peerHeadSlot = this.network.peerMetadata.getStatus(this.bestPeer)!.headSlot;
-        this.logger.info(`Regular Sync: Found best peer ${this.bestPeer.toB58String()}`, {
+        this.logger.info("Regular Sync: Found best peer", {
+          peerId: this.bestPeer.toB58String(),
           peerHeadSlot,
           currentSlot: this.chain.clock.currentSlot,
         });

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -224,7 +224,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
   };
 
   private handleFailedToGetRange = (range: ISlotRange): void => {
-    this.logger.warn(`Regular Sync: retrying range ${JSON.stringify(range)}`);
+    this.logger.warn("Regular Sync: retrying block range", {...range});
     // retry again
     this.setTarget(range.start - 1, false);
     this.setTarget();

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -68,7 +68,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
     }
     this.currentTarget = headSlot;
     this.lastProcessedBlock = this.chain.forkChoice.getHead();
-    this.logger.verbose(`Regular Sync: Current slot at start: ${currentSlot}`);
+    this.logger.verbose("Regular Sync: Current slot at start", {currentSlot});
     this.targetSlotRangeSource = pushable<ISlotRange>();
     this.controller = new AbortController();
     await this.waitForBestPeer(this.controller.signal);
@@ -141,10 +141,10 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
 
   private onGossipBlock = async (block: SignedBeaconBlock): Promise<void> => {
     this.gossipParentBlockRoot = block.message.parentRoot;
-    this.logger.verbose(
-      `Regular Sync: Set gossip parent block to ${toHexString(this.gossipParentBlockRoot)}` +
-        `, gossip slot ${block.message.slot}`
-    );
+    this.logger.verbose("Regular Sync: Set gossip parent block", {
+      root: toHexString(this.gossipParentBlockRoot),
+      slot: block.message.slot,
+    });
     await this.checkSyncComplete();
   };
 

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
@@ -47,7 +47,7 @@ export class ORARegularSync extends (EventEmitter as {new (): RegularSyncEventEm
     const headSlot = this.chain.forkChoice.getHead().slot;
     const currentSlot = this.chain.clock.currentSlot;
     this.logger.info("Started regular syncing", {currentSlot, headSlot});
-    this.logger.verbose(`Regular Sync: Current slot at start: ${currentSlot}`);
+    this.logger.verbose("Regular Sync: Current slot at start", {currentSlot});
     this.controller = new AbortController();
     await this.processor.start();
     this.network.gossip.subscribeToBlock(await this.chain.getForkDigest(), this.onGossipBlock);
@@ -87,7 +87,7 @@ export class ORARegularSync extends (EventEmitter as {new (): RegularSyncEventEm
 
   private onProcessedBlock = async (signedBlock: SignedBeaconBlock): Promise<void> => {
     if (signedBlock.message.slot >= this.chain.clock.currentSlot) {
-      this.logger.info(`Regular Sync: processed up to current slot ${signedBlock.message.slot}`);
+      this.logger.info("Regular Sync: processed up to current slot", {slot: signedBlock.message.slot});
       this.emit("syncCompleted");
       await this.stop();
     }
@@ -108,7 +108,8 @@ export class ORARegularSync extends (EventEmitter as {new (): RegularSyncEventEm
         return;
       }
       this.blockBuffer = result[0];
-      this.logger.info(`Regular Sync: Synced up to slot ${lastSlot} `, {
+      this.logger.info("Regular Sync: Synced up to slot", {
+        lastProcessedSlot: lastSlot,
         currentSlot: this.chain.clock.currentSlot,
       });
     }
@@ -142,7 +143,8 @@ export class ORARegularSync extends (EventEmitter as {new (): RegularSyncEventEm
       if (peers && peers.length > 0) {
         bestPeer = getBestPeer(this.config, peers, this.network.peerMetadata);
         const peerHeadSlot = this.network.peerMetadata.getStatus(bestPeer)!.headSlot;
-        this.logger.info(`Regular Sync: Found best peer ${bestPeer.toB58String()}`, {
+        this.logger.info("Regular Sync: Found best peer", {
+          peerId: bestPeer.toB58String(),
           peerHeadSlot,
           currentSlot: this.chain.clock.currentSlot,
         });

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/oneRangeAhead.ts
@@ -54,7 +54,7 @@ export class ORARegularSync extends (EventEmitter as {new (): RegularSyncEventEm
     this.chain.emitter.on(ChainEvent.block, this.onProcessedBlock);
     this.setLastProcessedBlock(this.chain.forkChoice.getHead());
     this.sync().catch((e) => {
-      this.logger.error("Regular Sync: error", e);
+      this.logger.error("Regular Sync", e);
     });
   }
 

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
@@ -40,7 +40,7 @@ export class BlockRangeProcessor implements IBlockRangeProcessor {
     if (!blocks || !blocks.length) return;
     await new Promise((resolve) => {
       const sortedBlocks = sortBlocks(blocks);
-      this.logger.info("Imported blocks for slots: ", blocks.map((block) => block.message.slot).join(","));
+      this.logger.info("Imported blocks for slots", {blocks: blocks.map((block) => block.message.slot)});
       const lastRoot = this.config.types.BeaconBlock.hashTreeRoot(sortedBlocks[sortedBlocks.length - 1].message);
       this.target = {
         root: lastRoot,

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -94,7 +94,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
           try {
             await this.network.reqResp.goodbye(peer.id, BigInt(GoodByeReasonCode.CLIENT_SHUTDOWN));
           } catch (e) {
-            this.logger.verbose("Failed to send goodbye", {reason: e.message});
+            this.logger.verbose("Failed to send goodbye", {error: e.message});
           }
         })
     );
@@ -167,18 +167,18 @@ export class BeaconReqRespHandler implements IReqRespHandler {
   public async shouldDisconnectOnStatus(request: Status): Promise<boolean> {
     const currentForkDigest = await this.chain.getForkDigest();
     if (!this.config.types.ForkDigest.equals(currentForkDigest, request.forkDigest)) {
-      this.logger.verbose(
-        "Fork digest mismatch " +
-          `expected=${toHexString(currentForkDigest)} received=${toHexString(request.forkDigest)}`
-      );
+      this.logger.verbose("Fork digest mismatch", {
+        expected: toHexString(currentForkDigest),
+        received: toHexString(request.forkDigest),
+      });
       return true;
     }
     if (request.finalizedEpoch === GENESIS_EPOCH) {
       if (!this.config.types.Root.equals(request.finalizedRoot, ZERO_HASH)) {
-        this.logger.verbose(
-          "Genesis finalized root must be zeroed " +
-            `expected=${toHexString(ZERO_HASH)} received=${toHexString(request.finalizedRoot)}`
-        );
+        this.logger.verbose("Genesis finalized root must be zeroed", {
+          expected: toHexString(ZERO_HASH),
+          received: toHexString(request.finalizedRoot),
+        });
         return true;
       }
     } else {
@@ -190,10 +190,10 @@ export class BeaconReqRespHandler implements IReqRespHandler {
 
       if (request.finalizedEpoch === finalizedCheckpoint.epoch) {
         if (!this.config.types.Root.equals(request.finalizedRoot, finalizedCheckpoint.root)) {
-          this.logger.verbose(
-            "Status with same finalized epoch has different root " +
-              `expected=${toHexString(finalizedCheckpoint.root)} received=${toHexString(request.finalizedRoot)}`
-          );
+          this.logger.verbose("Status with same finalized epoch has different root", {
+            expected: toHexString(finalizedCheckpoint.root),
+            received: toHexString(request.finalizedRoot),
+          });
           return true;
         }
       } else if (request.finalizedEpoch < finalizedCheckpoint.epoch) {
@@ -222,9 +222,10 @@ export class BeaconReqRespHandler implements IReqRespHandler {
         }
       } else {
         // request status finalized checkpoint is in the future, we do not know if it is a true finalized root
-        this.logger.verbose(
-          "Status with future finalized epoch " + `${request.finalizedEpoch}: ${toHexString(request.finalizedRoot)}`
-        );
+        this.logger.verbose("Status with future finalized epoch", {
+          finalizedEpoch: request.finalizedEpoch,
+          finalizedRoot: toHexString(request.finalizedRoot),
+        });
       }
     }
     return false;
@@ -382,8 +383,9 @@ export class BeaconReqRespHandler implements IReqRespHandler {
       try {
         this.network.peerMetadata.setStatus(peerId, await this.network.reqResp.status(peerId, request));
       } catch (e) {
-        this.logger.verbose(`Failed to get peer ${peerId.toB58String()} latest status and metadata`, {
-          reason: e.message,
+        this.logger.verbose("Failed to get peer latest status and metadata", {
+          peerId: peerId.toB58String(),
+          error: e.message,
         });
         await this.network.disconnect(peerId);
       }

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -152,7 +152,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
         status
       );
     } catch (e) {
-      this.logger.error("Failed to create response status", e.message);
+      this.logger.error("Failed to create response status", {error: e.message});
       await sendResponse(
         {config: this.config, logger: this.logger},
         request.id,
@@ -326,7 +326,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
         responseStream
       );
     } catch (e) {
-      this.logger.error(`Error processing request id ${request.id}: ${e.message}`);
+      this.logger.error("Error processing request", {id: request.id, error: e.message});
       await sendResponse(
         {config: this.config, logger: this.logger},
         request.id,

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -264,7 +264,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
     );
     // no need to wait
     handlePeerMetadataSequence(this.network, this.logger, peerId, request.body).catch(() => {
-      this.logger.warn(`Failed to handle peer ${peerId.toB58String()} metadata sequence ${request}`);
+      this.logger.warn("Failed to handle peer metadata sequence", {peerId: peerId.toB58String(), request});
     });
   }
 
@@ -303,10 +303,11 @@ export class BeaconReqRespHandler implements IReqRespHandler {
     }
     try {
       if (request.body.count > MAX_REQUEST_BLOCKS) {
-        this.logger.warn(
-          `Request id ${request.id} asked for ${request.body.count} blocks, ` +
-            `just return ${MAX_REQUEST_BLOCKS} maximum`
-        );
+        this.logger.warn("Request asked for more blocks than maximum", {
+          id: request.id,
+          requestedCount: request.body.count,
+          maxCount: MAX_REQUEST_BLOCKS,
+        });
         request.body.count = MAX_REQUEST_BLOCKS;
       }
       const archiveBlocksStream = this.db.blockArchive.valuesStream({

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -247,6 +247,6 @@ export class BeaconSync implements IBeaconSync {
       retry++;
     } // end while
     this.processingRoots.delete(missingRootHex);
-    if (!found) this.logger.error("Failed to get unknown ancestor root", missingRootHex);
+    if (!found) this.logger.error("Failed to get unknown ancestor root", {missingRootHex});
   };
 }

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -216,7 +216,7 @@ export class BeaconSync implements IBeaconSync {
       return;
     } else {
       this.processingRoots.add(missingRootHex);
-      this.logger.verbose("Finding block for unknown ancestor root", missingRootHex);
+      this.logger.verbose("Finding block for unknown ancestor root", {blockRoot: missingRootHex});
     }
     const peerBalancer = new RoundRobinArray(this.getUnknownRootPeers());
     let retry = 0;
@@ -230,7 +230,7 @@ export class BeaconSync implements IBeaconSync {
       try {
         const blocks = await this.network.reqResp.beaconBlocksByRoot(peer, [unknownAncestorRoot] as List<Root>);
         if (blocks && blocks[0]) {
-          this.logger.verbose("Found block for root", {slot: blocks[0].message.slot, root: missingRootHex});
+          this.logger.verbose("Found block for root", {slot: blocks[0].message.slot, blockRoot: missingRootHex});
           found = true;
           await this.chain.receiveBlock(blocks[0]);
           break;
@@ -247,6 +247,6 @@ export class BeaconSync implements IBeaconSync {
       retry++;
     } // end while
     this.processingRoots.delete(missingRootHex);
-    if (!found) this.logger.error("Failed to get unknown ancestor root", {missingRootHex});
+    if (!found) this.logger.error("Failed to get unknown ancestor root", {blockRoot: missingRootHex});
   };
 }

--- a/packages/lodestar/src/sync/utils/blocks.ts
+++ b/packages/lodestar/src/sync/utils/blocks.ts
@@ -75,7 +75,7 @@ export async function getBlockRange(
             blocks = blocks.concat(chunkBlocks);
             return null;
           } else {
-            logger.warn(`Failed to obtain chunk ${JSON.stringify(chunk)} ` + `from peer ${peer!.toB58String()}`);
+            logger.warn("Failed to obtain chunk from peer", {peerId: peer!.toB58String(), ...chunk});
             //if failed to obtain blocks, try in next round on another peer
             return chunk;
           }

--- a/packages/lodestar/src/sync/utils/blocks.ts
+++ b/packages/lodestar/src/sync/utils/blocks.ts
@@ -84,7 +84,7 @@ export async function getBlockRange(
     ).filter(notNullish);
     retry++;
     if ((retry > maxRetry || retry > peers.length) && chunks.length > 0) {
-      logger.error("Max req retry for blocks by range. Failed chunks: " + JSON.stringify(chunks));
+      logger.error("Max req retry for blocks by range. Failed chunks", JSON.stringify(chunks));
       return null;
     }
   }

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -119,7 +119,7 @@ export function fetchBlockChunks(
           ])) as SignedBeaconBlock[] | null;
           if (timer) clearTimeout(timer);
         } catch (e) {
-          logger.debug("Failed to get block range " + JSON.stringify(slotRange) + ". Error: " + e.message);
+          logger.debug("Failed to get block range", {...slotRange}, e);
           yield null;
           return;
         }

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -190,7 +190,7 @@ export function processSyncBlocks(
         });
         return headSlot;
       }
-      logger.info("Imported blocks for slots: " + blocks.map((block) => block.message.slot).join(","));
+      logger.info("Imported blocks for slots", {blocks: blocks.map((block) => block.message.slot).join(",")});
       blockBuffer.push(...blocks);
     }
     blockBuffer = sortBlocks(blockBuffer);

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -144,11 +144,12 @@ export function validateBlocks(
         if (isValidChainOfBlocks(config, head, blockChunk)) {
           yield blockChunk;
         } else {
-          logger.warn(
-            "Hash chain doesnt match! " +
-              `Head(${head.slot}): ${toHexString(config.types.BeaconBlockHeader.hashTreeRoot(head))}` +
-              `Blocks: (${blockChunk[0].message.slot}..${blockChunk[blockChunk.length - 1].message.slot})`
-          );
+          logger.warn("Hash chain doesnt match!", {
+            headSlot: head.slot,
+            headHash: toHexString(config.types.BeaconBlockHeader.hashTreeRoot(head)),
+            fromSlot: blockChunk[0].message.slot,
+            toSlot: blockChunk[blockChunk.length - 1].message.slot,
+          });
           //discard blocks and trigger resync so we try to fetch blocks again
           onBlockVerificationFail();
         }
@@ -185,9 +186,7 @@ export function processSyncBlocks(
     for await (const blocks of source) {
       if (!blocks) {
         // failed to fetch range, trigger sync to retry
-        logger.warn("Failed to get blocks for range", {
-          headSlot,
-        });
+        logger.warn("Failed to get blocks for range", {headSlot});
         return headSlot;
       }
       logger.info("Imported blocks for slots", {blocks: blocks.map((block) => block.message.slot).join(",")});

--- a/packages/lodestar/src/tasks/index.ts
+++ b/packages/lodestar/src/tasks/index.ts
@@ -92,7 +92,7 @@ export class TasksService implements IService {
       this.chain.forkChoice.prune(finalized.root);
       this.logger.info("Finish processing finalized checkpoint", {epoch: finalized.epoch});
     } catch (e) {
-      this.logger.error(`Error processing finalized checkpoint on epoch ${finalized.epoch}`, e);
+      this.logger.error("Error processing finalized checkpoint", {epoch: finalized.epoch}, e);
     }
   };
 

--- a/packages/lodestar/src/tasks/index.ts
+++ b/packages/lodestar/src/tasks/index.ts
@@ -90,9 +90,9 @@ export class TasksService implements IService {
       ]);
       // tasks rely on extended fork choice
       this.chain.forkChoice.prune(finalized.root);
-      this.logger.info("Finish processing finalized checkpoint for epoch #", finalized.epoch);
+      this.logger.info("Finish processing finalized checkpoint", {epoch: finalized.epoch});
     } catch (e) {
-      this.logger.error("Error processing finalized checkpoint of epoch #" + finalized.epoch, e);
+      this.logger.error(`Error processing finalized checkpoint on epoch ${finalized.epoch}`, e);
     }
   };
 

--- a/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
@@ -58,7 +58,7 @@ export class ArchiveBlocksTask implements ITask {
     }
     await this.deleteNonCanonicalBlocks();
     this.logger.profile("Archive Blocks epoch #" + this.finalized.epoch);
-    this.logger.info("Archiving of finalized blocks complete.", {
+    this.logger.info("Archiving of finalized blocks complete", {
       totalArchived: allCanonicalSummaries.length,
       finalizedEpoch: this.finalized.epoch,
     });

--- a/packages/lodestar/src/tasks/tasks/archiveStates.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveStates.ts
@@ -33,7 +33,7 @@ export class ArchiveStatesTask implements ITask {
   }
 
   public async run(): Promise<void> {
-    this.logger.info(`Started archiving states (finalized epoch #${this.finalized.epoch})...`);
+    this.logger.info("Archive states started", {finalizedEpoch: this.finalized.epoch});
     this.logger.profile("Archive States epoch #" + this.finalized.epoch);
     // store the state of finalized checkpoint
     const stateCache = await this.db.checkpointStateCache.get(this.finalized);
@@ -43,7 +43,7 @@ export class ArchiveStatesTask implements ITask {
     const finalizedState = stateCache.state;
     await this.db.stateArchive.add(finalizedState);
     // don't delete states before the finalized state, auto-prune will take care of it
-    this.logger.info(`Archiving of finalized states completed (finalized epoch #${this.finalized.epoch})`);
+    this.logger.info("Archive states completed", {finalizedEpoch: this.finalized.epoch});
     this.logger.profile("Archive States epoch #" + this.finalized.epoch);
   }
 }

--- a/packages/lodestar/test/unit/network/encoders/request.test.ts
+++ b/packages/lodestar/test/unit/network/encoders/request.test.ts
@@ -119,7 +119,7 @@ describe("request encoders", function () {
         all
       );
       expect(validatedRequestBody).to.be.deep.equal([{isValid: false}]);
-      const err = "eth2RequestDecode: Invalid number of bytes for protobuf varint 11, method status";
+      const err = "eth2RequestDecode: Invalid number of bytes for protobuf varint";
       expect(loggerStub.error.calledOnceWith(err)).to.be.true;
     });
 
@@ -130,7 +130,7 @@ describe("request encoders", function () {
         all
       );
       expect(validatedRequestBody).to.be.deep.equal([{isValid: false}]);
-      const err = "eth2RequestDecode: Invalid szzLength of 0 for method status";
+      const err = "eth2RequestDecode: Invalid szzLength";
       expect(loggerStub.error.calledOnceWith(err)).to.be.true;
     });
 
@@ -141,7 +141,7 @@ describe("request encoders", function () {
         all
       );
       expect(validatedRequestBody).to.be.deep.equal([{isValid: false}]);
-      const err = "eth2RequestDecode: too much bytes read (94) for method status, sszLength 84";
+      const err = "eth2RequestDecode: too much bytes read";
       expect(loggerStub.error.calledOnceWith(err)).to.be.true;
     });
 
@@ -152,7 +152,7 @@ describe("request encoders", function () {
         all
       );
       expect(validatedRequestBody).to.be.deep.equal([{isValid: false}]);
-      const err = "Failed to decompress request data. Error: Unsupported snappy chunk type";
+      const err = "Failed to decompress request data";
       expect(loggerStub.error.calledOnceWith(err)).to.be.true;
     });
 


### PR DESCRIPTION
Make almost all lodestar monorepo logger statements JSON friendly. Fixes https://github.com/ChainSafe/lodestar/issues/1249

Extends the API of the logger to force the error to always be the third argument. This way the error is identified in the JSON renderization and simplifies the logic
```ts
type LogHandler = (message: string, context?: Context, error?: Error) => void
```

