### PR TITLE
Fix yarn:clean in lodestar-params

### DIFF
--- a/packages/lodestar-params/package.json
+++ b/packages/lodestar-params/package.json
@@ -16,7 +16,7 @@
     "lib/**/*.d.ts"
   ],
   "scripts": {
-    "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo",
+    "clean": "rm -rf lib && rm -f tsconfig.build.tsbuildinfo",
     "build": "concurrently \"yarn build:lib\" \"yarn build:types\"",
     "build:release": "yarn clean && yarn build",
     "build:lib": "babel src -x .ts -d lib --source-maps",


### PR DESCRIPTION
Declaration files were not generated in lodestar-params and it turns out that I have to delete`tsconfig.build.tsbuildinfo` manually to make it work.