### PR TITLE
lodestar-beacon-state-transition comment updates

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/epoch/balanceUpdates/attestation.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/balanceUpdates/attestation.ts
@@ -23,6 +23,10 @@ import {
 
 import {getBaseReward, isInInactivityLeak, getProposerReward, getFinalityDelay} from "./util";
 
+/**
+ * Both active validators and slashed-but-not-yet-withdrawn validators are eligible to receive
+ * penalties. This is done to prevent self-slashing from being a way to escape inactivity leaks.
+ */
 function getEligibleValidatorIndices(config: IBeaconConfig, state: BeaconState): ValidatorIndex[] {
   const previousEpoch = getPreviousEpoch(config, state);
   return Array.from(state.validators).reduce((indices: ValidatorIndex[], v, index) => {
@@ -33,6 +37,9 @@ function getEligibleValidatorIndices(config: IBeaconConfig, state: BeaconState):
   }, []);
 }
 
+/**
+ * Helper with shared logic for use by get source, target, and head deltas functions
+ */
 function getAttestationComponentDeltas(
   config: IBeaconConfig,
   state: BeaconState,
@@ -61,24 +68,36 @@ function getAttestationComponentDeltas(
   return [rewards, penalties];
 }
 
+/**
+ * Return attester micro-rewards/penalties for source-vote for each validator.
+ */
 export function getSourceDeltas(config: IBeaconConfig, state: BeaconState): [bigint[], bigint[]] {
   const previousEpoch = getPreviousEpoch(config, state);
   const matchingSourceAttestations = getMatchingSourceAttestations(config, state, previousEpoch);
   return getAttestationComponentDeltas(config, state, matchingSourceAttestations);
 }
 
+/**
+ * Return attester micro-rewards/penalties for target-vote for each validator.
+ */
 export function getTargetDeltas(config: IBeaconConfig, state: BeaconState): [bigint[], bigint[]] {
   const previousEpoch = getPreviousEpoch(config, state);
   const matchingTargetAttestations = getMatchingTargetAttestations(config, state, previousEpoch);
   return getAttestationComponentDeltas(config, state, matchingTargetAttestations);
 }
 
+/**
+ * Return attester micro-rewards/penalties for head-vote for each validator.
+ */
 export function getHeadDeltas(config: IBeaconConfig, state: BeaconState): [bigint[], bigint[]] {
   const previousEpoch = getPreviousEpoch(config, state);
   const matchingHeadAttestations = getMatchingHeadAttestations(config, state, previousEpoch);
   return getAttestationComponentDeltas(config, state, matchingHeadAttestations);
 }
 
+/**
+ * Return proposer and inclusion delay micro-rewards/penalties for each validator.
+ */
 export function getInclusionDelayDeltas(config: IBeaconConfig, state: BeaconState): bigint[] {
   const previousEpoch = getPreviousEpoch(config, state);
   const rewards = Array.from({length: state.validators.length}, () => BigInt(0));
@@ -97,6 +116,9 @@ export function getInclusionDelayDeltas(config: IBeaconConfig, state: BeaconStat
   return rewards;
 }
 
+/**
+ * Return inactivity reward/penalty deltas for each validator.
+ */
 export function getInactivityPenaltyDeltas(config: IBeaconConfig, state: BeaconState): bigint[] {
   const penalties = Array.from({length: state.validators.length}, () => BigInt(0));
   const previousEpoch = getPreviousEpoch(config, state);
@@ -117,6 +139,9 @@ export function getInactivityPenaltyDeltas(config: IBeaconConfig, state: BeaconS
   return penalties;
 }
 
+/**
+ * Return attestation reward/penalty deltas for each validator.
+ */
 export function getAttestationDeltas(config: IBeaconConfig, state: BeaconState): [Gwei[], Gwei[]] {
   const [sourceRewards, sourcePenalties] = getSourceDeltas(config, state);
   const [targetRewards, targetPenalties] = getTargetDeltas(config, state);

--- a/packages/lodestar-beacon-state-transition/src/epoch/balanceUpdates/util.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/balanceUpdates/util.ts
@@ -8,6 +8,13 @@ import {getTotalActiveBalance, getPreviousEpoch} from "../../util";
 import {bigIntSqrt} from "@chainsafe/lodestar-utils";
 import {BASE_REWARDS_PER_EPOCH} from "../../constants";
 
+/**
+ * This is the reward that almost all other rewards in Ethereum are computed as a multiple of.
+ * Particularly, note that it's a desired goal of the spec that effective_balance * BASE_REWARD_FACTOR
+ * // integer_squareroot(total_balance) is the average per-epoch reward received by a validator under
+ * theoretical best-case conditions; to achieve this, the base reward equals that amount divided by
+ * BASE_REWARDS_PER_EPOCH, which is the number of times that a reward of this size will be applied.
+ */
 export function getBaseReward(config: IBeaconConfig, state: BeaconState, index: ValidatorIndex): Gwei {
   const totalBalance = getTotalActiveBalance(config, state);
   const effectiveBalance = state.validators[index].effectiveBalance;
@@ -26,6 +33,12 @@ export function getFinalityDelay(config: IBeaconConfig, state: BeaconState): num
   return getPreviousEpoch(config, state) - state.finalizedCheckpoint.epoch;
 }
 
+/**
+ * If the chain has not been finalized for >4 epochs, the chain enters an "inactivity leak" mode,
+ * where inactive validators get progressively penalized more and more, to reduce their influence
+ * until blocks get finalized again. See here (https://github.com/ethereum/annotated-spec/blob/master/phase0/beacon-chain.md#inactivity-quotient) for what the inactivity leak is, what it's for and how
+ * it works.
+ */
 export function isInInactivityLeak(config: IBeaconConfig, state: BeaconState): boolean {
   return getFinalityDelay(config, state) > config.params.MIN_EPOCHS_TO_INACTIVITY_PENALTY;
 }

--- a/packages/lodestar-beacon-state-transition/src/epoch/registryUpdates.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/registryUpdates.ts
@@ -15,6 +15,10 @@ import {
   isEligibleForActivation,
 } from "../util";
 
+/**
+ * Processes (i) the validator activation queue, and (ii) the rule that validators with <=
+ * `EJECTION_BALANCE` ETH get ejected.
+ */
 export function processRegistryUpdates(config: IBeaconConfig, state: BeaconState): BeaconState {
   const currentEpoch = getCurrentEpoch(config, state);
   // Process activation eligibility and ejections

--- a/packages/lodestar-beacon-state-transition/src/epoch/util.ts
+++ b/packages/lodestar-beacon-state-transition/src/epoch/util.ts
@@ -15,6 +15,12 @@ import {
   getTotalBalance,
 } from "../util";
 
+/**
+ * When processing attestations, we already only accept attestations that have the correct Casper FFG
+ * source checkpoint (specifically, the most recent justified checkpoint that the chain knows about).
+ * The goal of this function is to get all attestations that have a correct Casper FFG source. Hence,
+ * it can safely just return all the PendingAttestations for the desired epoch (current or previous).
+ */
 export function getMatchingSourceAttestations(
   config: IBeaconConfig,
   state: BeaconState,
@@ -28,6 +34,10 @@ export function getMatchingSourceAttestations(
   return Array.from(epoch === currentEpoch ? state.currentEpochAttestations : state.previousEpochAttestations);
 }
 
+/**
+ * Returns the subset of PendingAttestations that have the correct Casper FFG target (ie. the
+ * checkpoint that is part of the current chain).
+ */
 export function getMatchingTargetAttestations(
   config: IBeaconConfig,
   state: BeaconState,
@@ -39,6 +49,10 @@ export function getMatchingTargetAttestations(
   );
 }
 
+/**
+ * Returns the subset of PendingAttestations that have the correct head (ie. they voted for a head
+ * that ended up being the head of the chain).
+ */
 export function getMatchingHeadAttestations(
   config: IBeaconConfig,
   state: BeaconState,
@@ -49,6 +63,13 @@ export function getMatchingHeadAttestations(
   );
 }
 
+/**
+ * Gets the list of attesting indices from a set of attestations, filtering out the indices that have
+ * been slashed. The idea here is that if you get slashed, you are still "technically" part of the
+ * validator set (see the note on the validator life cycle (https://github.com/ethereum/annotated-spec/
+ * blob/master/phase0/beacon-chain.md#lifecycle) for reasoning why), but your attestations
+ * do not get counted.
+ */
 export function getUnslashedAttestingIndices(
   config: IBeaconConfig,
   state: BeaconState,

--- a/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
@@ -5,6 +5,9 @@ import {FAR_FUTURE_EPOCH} from "../../constants";
 import {computeActivationExitEpoch, getChurnLimit} from "../../util";
 import {EpochContext} from "../util";
 
+/**
+ * Initiate the exit of the validator with index ``index``.
+ */
 export function initiateValidatorExit(epochCtx: EpochContext, state: BeaconState, index: ValidatorIndex): void {
   const config = epochCtx.config;
   // return if validator already initiated exit

--- a/packages/lodestar-beacon-state-transition/src/fast/block/isValidIndexedAttestation.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/isValidIndexedAttestation.ts
@@ -5,6 +5,9 @@ import {DomainType} from "../../constants";
 import {computeSigningRoot, getDomain} from "../../util";
 import {EpochContext} from "../util";
 
+/**
+ * Check if `indexedAttestation` has sorted and unique indices and a valid aggregate signature.
+ */
 export function isValidIndexedAttestation(
   epochCtx: EpochContext,
   state: BeaconState,

--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/getAttestationDeltas.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/getAttestationDeltas.ts
@@ -13,6 +13,9 @@ import {
   FLAG_PREV_HEAD_ATTESTER,
 } from "../util";
 
+/**
+ * Return attestation reward/penalty deltas for each validator.
+ */
 export function getAttestationDeltas(
   epochCtx: EpochContext,
   process: IEpochProcess,

--- a/packages/lodestar-beacon-state-transition/src/fast/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/index.ts
@@ -9,6 +9,9 @@ import {processBlock} from "./block";
 
 export {IStateContext, EpochContext};
 
+/**
+ * Implementation of protolambda's eth2fastspec (https://github.com/protolambda/eth2fastspec)
+ */
 export function fastStateTransition(
   {state, epochCtx: eiEpochCtx}: IStateContext,
   signedBlock: SignedBeaconBlock,

--- a/packages/lodestar-beacon-state-transition/src/fast/util/attesterStatus.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/attesterStatus.ts
@@ -9,6 +9,11 @@ export const FLAG_CURR_HEAD_ATTESTER = 1 << 5;
 export const FLAG_UNSLASHED = 1 << 6;
 export const FLAG_ELIGIBLE_ATTESTER = 1 << 7;
 
+/**
+ * During the epoch transition, additional data is precomputed to avoid traversing any state a second
+ * time. Attestations are a big part of this, and each validator has a "status" to represent its
+ * precomputed participation.
+ */
 export interface IAttesterStatus {
   flags: number;
   proposerIndex: number; // -1 when not included by any proposer

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochProcess.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochProcess.ts
@@ -21,6 +21,11 @@ import {IEpochStakeSummary} from "./epochStakeSummary";
 import {StateTransitionEpochContext} from "./epochContext";
 import {createIFlatValidator, isActiveIFlatValidator} from "./flatValidator";
 
+/**
+ * The AttesterStatus (and FlatValidator under status.validator) objects and
+ * EpochStakeSummary are tracked in the IEpochProcess and made available as additional context in the
+ * epoch transition.
+ */
 export interface IEpochProcess {
   prevEpoch: Epoch;
   currentEpoch: Epoch;

--- a/packages/lodestar-beacon-state-transition/src/fast/util/flatValidator.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/flatValidator.ts
@@ -2,7 +2,9 @@ import {readOnlyEntries} from "@chainsafe/ssz";
 import {Gwei, Epoch, Validator} from "@chainsafe/lodestar-types";
 
 /**
- * Concrete Validator w/o pubkey & withdrawCredentials
+ * Concrete Validator w/o pubkey & withdrawCredentials.
+ * For intermediate computation the remerkleable representation slows things down, so a regular object
+ * is used instead.
  */
 export interface IFlatValidator {
   effectiveBalance: Gwei;

--- a/packages/lodestar-beacon-state-transition/src/util/fork.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/fork.ts
@@ -1,6 +1,9 @@
 import {Version, Root, ForkData, ForkDigest} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
+/**
+ * Used primarily in signature domains to avoid collisions across forks/chains.
+ */
 export function computeForkDataRoot(config: IBeaconConfig, currentVersion: Version, genesisValidatorsRoot: Root): Root {
   const forkData: ForkData = {
     currentVersion,

--- a/packages/lodestar-beacon-state-transition/src/util/signingRoot.ts
+++ b/packages/lodestar-beacon-state-transition/src/util/signingRoot.ts
@@ -4,10 +4,6 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
 /**
  * Return the signing root of an object by calculating the root of the object-domain tree.
- * @param config
- * @param type
- * @param sszObject
- * @param domain
  */
 export function computeSigningRoot<T>(config: IBeaconConfig, type: Type<T>, sszObject: T, domain: Domain): Uint8Array {
   const domainWrappedObject: SigningData = {


### PR DESCRIPTION
part of the effort documented in #1775 
most of the comments that were added were pulled from either the eth2spec, eth2fastspec (https://github.com/protolambda/eth2fastspec), or Vitalik's annotated spec (https://github.com/ethereum/annotated-spec)