### PR TITLE
Use verifySignatureSetsBatch for state transition function

### DIFF
--- a/packages/lodestar-beacon-state-transition/package.json
+++ b/packages/lodestar-beacon-state-transition/package.json
@@ -36,7 +36,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/bls": "5.0.1",
+    "@chainsafe/bls": "5.1.0",
     "@chainsafe/lodestar-config": "^0.12.0",
     "@chainsafe/lodestar-utils": "^0.12.0",
     "@chainsafe/ssz": "^0.6.13",

--- a/packages/lodestar-cli/package.json
+++ b/packages/lodestar-cli/package.json
@@ -48,7 +48,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "5.0.1",
+    "@chainsafe/bls": "5.1.0",
     "@chainsafe/bls-keygen": "^0.3.0",
     "@chainsafe/bls-keystore": "2.0.0",
     "@chainsafe/blst": "^0.1.3",

--- a/packages/lodestar-spec-test-util/package.json
+++ b/packages/lodestar-spec-test-util/package.json
@@ -45,7 +45,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "5.0.1",
+    "@chainsafe/bls": "5.1.0",
     "@chainsafe/lodestar-utils": "^0.12.0",
     "@chainsafe/ssz": "^0.6.13",
     "axios": "^0.21.0",

--- a/packages/lodestar-utils/package.json
+++ b/packages/lodestar-utils/package.json
@@ -36,7 +36,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/bls": "5.0.1",
+    "@chainsafe/bls": "5.1.0",
     "@chainsafe/ssz": "^0.6.13",
     "abort-controller": "^3.0.0",
     "bigint-buffer": "^1.1.5",

--- a/packages/lodestar-validator/package.json
+++ b/packages/lodestar-validator/package.json
@@ -44,7 +44,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "5.0.1",
+    "@chainsafe/bls": "5.1.0",
     "@chainsafe/lodestar-beacon-state-transition": "^0.12.0",
     "@chainsafe/lodestar-config": "^0.12.0",
     "@chainsafe/lodestar-types": "^0.12.0",

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -44,7 +44,7 @@
     "test:sim:multiThread": "TS_NODE_PROJECT=tsconfig.test.json mocha 'test/sim/singleNodeSingleThread.test.ts'"
   },
   "dependencies": {
-    "@chainsafe/bls": "5.0.1",
+    "@chainsafe/bls": "5.1.0",
     "@chainsafe/discv5": "^0.5.0",
     "@chainsafe/lodestar-beacon-state-transition": "^0.12.0",
     "@chainsafe/lodestar-config": "^0.12.0",

--- a/packages/lodestar/src/chain/bls.ts
+++ b/packages/lodestar/src/chain/bls.ts
@@ -1,0 +1,29 @@
+import {bls, PublicKey, Signature} from "@chainsafe/bls";
+import {ISignatureSet, SignatureSetType} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/signatureSets";
+
+export function verifySignatureSetsBatch(signatureSets: ISignatureSet[]): boolean {
+  const publicKeys: PublicKey[] = [];
+  const messages: Uint8Array[] = [];
+  const signatures: Signature[] = [];
+
+  for (const signatureSet of signatureSets) {
+    publicKeys.push(getAggregatedPubkey(signatureSet));
+    messages.push(signatureSet.signingRoot as Uint8Array);
+    signatures.push(bls.Signature.fromBytes(signatureSet.signature.valueOf() as Uint8Array));
+  }
+
+  return bls.Signature.verifyMultipleSignatures(publicKeys, messages, signatures);
+}
+
+function getAggregatedPubkey(signatureSet: ISignatureSet): PublicKey {
+  switch (signatureSet.type) {
+    case SignatureSetType.single:
+      return signatureSet.pubkey;
+
+    case SignatureSetType.aggregate:
+      return bls.PublicKey.aggregate(signatureSet.pubkeys);
+
+    default:
+      throw Error("Unknown signature set type");
+  }
+}

--- a/packages/lodestar/src/chain/errors/blockError.ts
+++ b/packages/lodestar/src/chain/errors/blockError.ts
@@ -96,6 +96,7 @@ export type BlockErrorType =
   | {code: BlockErrorCode.ERR_INCORRECT_PROPOSER; blockProposer: ValidatorIndex}
   | {code: BlockErrorCode.ERR_PROPOSAL_SIGNATURE_INVALID}
   | {code: BlockErrorCode.ERR_UNKNOWN_PROPOSER; proposer: ValidatorIndex}
+  | {code: BlockErrorCode.ERR_INVALID_SIGNATURE}
   | {code: BlockErrorCode.ERR_BLOCK_IS_NOT_LATER_THAN_PARENT; blockSlot: Slot; stateSlot: Slot}
   | {code: BlockErrorCode.ERR_NON_LINEAR_PARENT_ROOTS}
   | {code: BlockErrorCode.ERR_NON_LINEAR_SLOTS}

--- a/packages/spec-test-runner/package.json
+++ b/packages/spec-test-runner/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@chainsafe/bit-utils": "0.1.6",
-    "@chainsafe/bls": "5.0.1",
+    "@chainsafe/bls": "5.1.0",
     "@chainsafe/lodestar": "^0.12.0",
     "@chainsafe/lodestar-beacon-state-transition": "^0.12.0",
     "@chainsafe/lodestar-config": "^0.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,10 +1129,10 @@
     ethereum-cryptography "^0.1.3"
     uuid "^3.3.3"
 
-"@chainsafe/bls@5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/bls/-/bls-5.0.1.tgz#cb9b6a297b76815f4ccdde595f57775305bfcf00"
-  integrity sha512-MYImjOqlXb7LzR3I7xzBejQDSyQ1gqjWEReSVY6BgnrzRkYe+MNpku9CSi2khrfGn+Tftxl4olPb4GC4kHyBrw==
+"@chainsafe/bls@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/bls/-/bls-5.1.0.tgz#e1b447f3dacef9c74f237afd320e00974716e8ed"
+  integrity sha512-WrKcQiFD1GG04OBnWeeb51Gr0ETx9v4n13S+GI24HQx+NeG1A0LfS44zeu3Tp4PGLbU2cziZudlC0WjF3y/HLQ==
   dependencies:
     "@chainsafe/bls-keygen" "^0.3.0"
     bls-eth-wasm "^0.4.4"


### PR DESCRIPTION
Uses BLS verifyMultipleSignatures to verify all signatures of a block at once to reduce the total verification time by 50% in the best case.