### PR TITLE
Import AbortSignal wherever used

### DIFF
--- a/packages/lodestar-validator/src/api/LocalClock.ts
+++ b/packages/lodestar-validator/src/api/LocalClock.ts
@@ -1,3 +1,4 @@
+import {AbortSignal} from "abort-controller";
 import {Epoch, Slot} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {computeEpochAtSlot, getCurrentSlot} from "@chainsafe/lodestar-beacon-state-transition";

--- a/packages/lodestar-validator/src/util/misc.ts
+++ b/packages/lodestar-validator/src/util/misc.ts
@@ -1,3 +1,5 @@
+import {AbortSignal} from "abort-controller";
+
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -1,3 +1,4 @@
+import {AbortSignal} from "abort-controller";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 

--- a/packages/lodestar/src/chain/clock/LocalClock.ts
+++ b/packages/lodestar/src/chain/clock/LocalClock.ts
@@ -1,3 +1,4 @@
+import {AbortSignal} from "abort-controller";
 import {Epoch, Slot} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ErrorAborted} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -1,3 +1,4 @@
+import {AbortSignal} from "abort-controller";
 import {readOnlyMap, toHexString} from "@chainsafe/ssz";
 import {Attestation, Checkpoint, SignedBeaconBlock, Slot, Version} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/src/chain/regen/queued.ts
+++ b/packages/lodestar/src/chain/regen/queued.ts
@@ -1,3 +1,4 @@
+import {AbortSignal} from "abort-controller";
 import {BeaconBlock, Root, Checkpoint, Slot} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";

--- a/packages/lodestar/src/util/queue.ts
+++ b/packages/lodestar/src/util/queue.ts
@@ -1,3 +1,4 @@
+import {AbortSignal} from "abort-controller";
 import pushable, {Pushable} from "it-pushable";
 import pipe from "it-pipe";
 


### PR DESCRIPTION
Would it be possible to remove AbortSignal from Typescript's global scope? Probably it's baked into DOM types, but it results in different types which cause types problems, and not sure if it can cause problems in runtime