### PR TITLE
Set exit epoch explicitly

### DIFF
--- a/packages/lodestar/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/state/utils.test.ts
@@ -142,7 +142,9 @@ describe("beacon state api utils", function () {
       const stateContext = getApiContext();
       stateContext.state = generateState({
         slot: 0,
-        validators: Array.from({length: 24}, () => generateValidator({activationEpoch: 1})) as List<Validator>,
+        validators: Array.from({length: 24}, () => generateValidator({activationEpoch: 0, exitEpoch: 10})) as List<
+          Validator
+        >,
       });
       const committees = getEpochBeaconCommittees(config, chainStub, stateContext, 1);
       expect(committees[0][0][0]).to.not.be.undefined;


### PR DESCRIPTION
https://github.com/chainsafe/lodestar/blob/master/packages/lodestar/test/utils/validator.ts#L18

@dapplion was right, exactly 25% occurences where validator exited so it wasn't in activeValidators array