### PR TITLE
Use TreeBacked<SignedBeaconBlock> to improve sync time

### DIFF
--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -2,10 +2,10 @@ import Gossipsub from "libp2p-gossipsub";
 import {InMessage} from "libp2p-interfaces/src/pubsub";
 import {ERR_TOPIC_VALIDATOR_REJECT, ERR_TOPIC_VALIDATOR_IGNORE} from "libp2p-gossipsub/src/constants";
 import {Libp2p} from "libp2p-gossipsub/src/interfaces";
-import {Type} from "@chainsafe/ssz";
+import {CompositeType} from "@chainsafe/ssz";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {ForkDigest} from "@chainsafe/lodestar-types";
+import {ForkDigest, SignedBeaconBlock} from "@chainsafe/lodestar-types";
 
 import {GossipMessageValidatorFn, GossipObject, IGossipMessageValidator, ILodestarGossipMessage} from "./interface";
 import {
@@ -205,11 +205,11 @@ export class LodestarGossipsub extends Gossipsub {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let objType: Type<any>;
+    let objType: {deserialize: (data: Uint8Array) => any};
     const gossipEvent = topicToGossipEvent(topic);
     switch (gossipEvent) {
       case GossipEvent.BLOCK:
-        objType = this.config.types.SignedBeaconBlock;
+        objType = (this.config.types.SignedBeaconBlock as CompositeType<SignedBeaconBlock>).tree;
         break;
       case GossipEvent.AGGREGATE_AND_PROOF:
         objType = this.config.types.SignedAggregateAndProof;

--- a/packages/lodestar/src/network/util.ts
+++ b/packages/lodestar/src/network/util.ts
@@ -4,9 +4,7 @@
  */
 
 import PeerId from "peer-id";
-import {Type} from "@chainsafe/ssz";
 import {AbortController, AbortSignal} from "abort-controller";
-import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Method, MethodResponseType, Methods, RequestId, RESP_TIMEOUT, TTFB_TIMEOUT} from "../constants";
 import {source as abortSource} from "abortable-iterator";
 import Multiaddr from "multiaddr";
@@ -41,14 +39,6 @@ export function createRpcProtocol(method: Method, encoding: "ssz" | "ssz_snappy"
  */
 export async function createPeerId(): Promise<PeerId> {
   return await PeerId.create({bits: 256, keyType: "secp256k1"});
-}
-
-export function getRequestMethodSSZType(config: IBeaconConfig, method: Method): Type<any> {
-  return Methods[method].requestSSZType(config)!;
-}
-
-export function getResponseMethodSSZType(config: IBeaconConfig, method: Method): Type<any> {
-  return Methods[method].responseSSZType(config);
 }
 
 export function isRequestOnly(method: Method): boolean {

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -196,7 +196,7 @@ export function processSyncBlocks(
       const signedBlock = blockBuffer.shift()!;
       const nextBlock = blockBuffer[0];
       const block = signedBlock.message;
-      const blockRoot = config.types.BeaconBlockHeader.hashTreeRoot(blockToHeader(config, block));
+      const blockRoot = config.types.BeaconBlock.hashTreeRoot(block);
       // only import blocks that's part of a linear chain
       if (
         !isInitialSync ||

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -213,7 +213,7 @@ describe("[network] network", function () {
     block.message.slot = 2020;
     void netB.gossip.publishBlock(block).catch((e) => console.error(e));
     const receivedBlock = await received;
-    expect(receivedBlock).to.be.deep.equal(block);
+    expect(config.types.SignedBeaconBlock.equals(receivedBlock as SignedBeaconBlock, block)).to.be.true;
   });
   it("should receive aggregate on subscription", async function () {
     const connected = Promise.all([


### PR DESCRIPTION
resolves #1860 
+ convert to `TreeBacked<SignedBeaconBlock>` from beacon_blocks_by_range, beacon_blocks_by_root and gossip
+ the below is statistic from syncing Pyrmont till slot 5000

|#|Branch|Time (in min)|
|-|-|-|
|1|master|22|
|2|master|21.5|
|1|this PR|17.5|
|2|this PR|18|