### PR TITLE
lodesar-fork-choice: remove fromGenesis and fromCheckpointState

### DIFF
--- a/packages/lodestar-fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/lodestar-fork-choice/src/forkChoice/forkChoice.ts
@@ -110,56 +110,6 @@ export class ForkChoice implements IForkChoice {
   }
 
   /**
-   * Instantiates a ForkChoice from genesis parameters
-   */
-  public static fromGenesis(config: IBeaconConfig, fcStore: IForkChoiceStore, genesisBlock: BeaconBlock): ForkChoice {
-    const protoArray = ProtoArray.initialize({
-      slot: genesisBlock.slot,
-      parentRoot: toHexString(genesisBlock.parentRoot),
-      stateRoot: toHexString(genesisBlock.stateRoot),
-      blockRoot: toHexString(fcStore.finalizedCheckpoint.root),
-      justifiedEpoch: fcStore.justifiedCheckpoint.epoch,
-      finalizedEpoch: fcStore.finalizedCheckpoint.epoch,
-    });
-
-    return new ForkChoice({
-      config,
-      fcStore,
-      protoArray,
-      queuedAttestations: new Set(),
-    });
-  }
-
-  /**
-   * Instantiates a ForkChoice from a weak subjectivity state
-   */
-  public static fromCheckpointState(
-    config: IBeaconConfig,
-    fcStore: IForkChoiceStore,
-    anchorState: BeaconState
-  ): ForkChoice {
-    const blockHeader = config.types.BeaconBlockHeader.clone(anchorState.latestBlockHeader);
-    if (config.types.Root.equals(blockHeader.stateRoot, ZERO_HASH)) {
-      blockHeader.stateRoot = config.types.BeaconState.hashTreeRoot(anchorState);
-    }
-    const protoArray = ProtoArray.initialize({
-      slot: anchorState.latestBlockHeader.slot,
-      parentRoot: toHexString(blockHeader.parentRoot),
-      stateRoot: toHexString(blockHeader.stateRoot),
-      blockRoot: toHexString(config.types.BeaconBlockHeader.hashTreeRoot(blockHeader)),
-      justifiedEpoch: fcStore.justifiedCheckpoint.epoch,
-      finalizedEpoch: fcStore.finalizedCheckpoint.epoch,
-    });
-
-    return new ForkChoice({
-      config,
-      fcStore,
-      protoArray,
-      queuedAttestations: new Set(),
-    });
-  }
-
-  /**
    * Returns the block root of an ancestor of `blockRoot` at the given `slot`.
    * (Note: `slot` refers to the block that is *returned*, not the one that is supplied.)
    *


### PR DESCRIPTION
remove old ways of generating fork choice object that are no longer useful

context: https://discord.com/channels/593655374469660673/593655641445367808/786374754637447169