### PR TITLE
Fix getRandaoRevealSignatureSet

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/fast/block/processAttesterSlashing.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/processAttesterSlashing.ts
@@ -1,4 +1,4 @@
-import {AttesterSlashing, BeaconState} from "@chainsafe/lodestar-types";
+import {AttesterSlashing, BeaconState, ValidatorIndex} from "@chainsafe/lodestar-types";
 
 import {isSlashableValidator, isSlashableAttestationData} from "../../util";
 import {EpochContext} from "../util";
@@ -27,7 +27,7 @@ export function processAttesterSlashing(
   let slashedAny = false;
   const attSet1 = new Set(attestation1.attestingIndices);
   const attSet2 = new Set(attestation2.attestingIndices);
-  const indices = [];
+  const indices: ValidatorIndex[] = [];
   for (const i of attSet1.values()) {
     if (attSet2.has(i)) {
       indices.push(i);

--- a/packages/lodestar-beacon-state-transition/src/fast/block/processRandao.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/processRandao.ts
@@ -2,7 +2,7 @@ import xor from "buffer-xor";
 import {hash} from "@chainsafe/ssz";
 import {BeaconBlock, BeaconState} from "@chainsafe/lodestar-types";
 import {DomainType} from "../../constants";
-import {computeSigningRoot, getDomain, getRandaoMix} from "../../util";
+import {computeEpochAtSlot, computeSigningRoot, getDomain, getRandaoMix} from "../../util";
 import {EpochContext} from "../util";
 import {ISignatureSet, SignatureSetType, verifySignatureSet} from "../signatureSets";
 
@@ -40,13 +40,13 @@ export function getRandaoRevealSignatureSet(
   block: BeaconBlock
 ): ISignatureSet {
   const config = epochCtx.config;
-  const epoch = epochCtx.currentShuffling.epoch;
-  const proposerIndex = epochCtx.getBeaconProposer(block.slot);
+  // should not get epoch from epochCtx
+  const epoch = computeEpochAtSlot(config, block.slot);
   const domain = getDomain(config, state, DomainType.RANDAO);
 
   return {
     type: SignatureSetType.single,
-    pubkey: epochCtx.index2pubkey[proposerIndex],
+    pubkey: epochCtx.index2pubkey[block.proposerIndex],
     signingRoot: computeSigningRoot(config, config.types.Epoch, epoch, domain),
     signature: block.body.randaoReveal,
   };


### PR DESCRIPTION
resolves #1859 
+ epochCtx may not be respective to the block so should not use it in getRandaoRevealSignatureSet
+ tested with Pyrmont and enabled signature verification for initial sync