### PR TITLE
Sync: Use SlotRoot instead of ISyncCheckpoint

### DIFF
--- a/packages/lodestar/src/sync/interface.ts
+++ b/packages/lodestar/src/sync/interface.ts
@@ -1,7 +1,7 @@
 import {IService} from "../node";
 import {INetwork} from "../network";
 import {ILogger} from "@chainsafe/lodestar-utils";
-import {CommitteeIndex, Slot, SyncingStatus, Root} from "@chainsafe/lodestar-types";
+import {CommitteeIndex, Slot, SyncingStatus} from "@chainsafe/lodestar-types";
 import {InitialSync} from "./initial";
 import {IRegularSync} from "./regular";
 import {IGossipHandler} from "./gossip";
@@ -24,11 +24,6 @@ export interface ISyncModule {
 export interface ISlotRange {
   start: Slot;
   end: Slot;
-}
-
-export interface ISyncCheckpoint {
-  slot: Slot;
-  blockRoot: Root;
 }
 
 export interface ISyncModules {

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -1,5 +1,6 @@
 import PeerId from "peer-id";
 import {AbortController, AbortSignal} from "abort-controller";
+import {SlotRoot} from "@chainsafe/lodestar-types";
 import {source as abortSource} from "abortable-iterator";
 import {IRegularSync, IRegularSyncModules, RegularSyncEventEmitter} from "../interface";
 import {INetwork} from "../../../network";
@@ -13,7 +14,7 @@ import {sleep} from "@chainsafe/lodestar-utils";
 import pushable, {Pushable} from "it-pushable";
 import pipe from "it-pipe";
 import {checkBestPeer, fetchBlockChunks, getBestPeer, processSyncBlocks} from "../../utils";
-import {ISlotRange, ISyncCheckpoint} from "../../interface";
+import {ISlotRange} from "../../interface";
 import {GossipEvent} from "../../../network/gossip/constants";
 import {toHexString} from "@chainsafe/ssz";
 import {EventEmitter} from "events";
@@ -41,7 +42,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
   /**
    * The last processed block
    */
-  private lastProcessedBlock!: ISyncCheckpoint;
+  private lastProcessedBlock!: SlotRoot;
   // only listen for blocks from this sync instead of gossip
   private subscribeToBlock: boolean;
 
@@ -67,7 +68,8 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
       return;
     }
     this.currentTarget = headSlot;
-    this.lastProcessedBlock = this.chain.forkChoice.getHead();
+    const head = this.chain.forkChoice.getHead();
+    this.lastProcessedBlock = {slot: head.slot, root: head.blockRoot};
     this.logger.verbose("Regular Sync: Current slot at start", {currentSlot});
     this.targetSlotRangeSource = pushable<ISlotRange>();
     this.controller = new AbortController();
@@ -126,7 +128,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
       if (this.currentTarget === lastProcessedBlock.message.slot) {
         this.lastProcessedBlock = {
           slot: lastProcessedBlock.message.slot,
-          blockRoot: this.config.types.BeaconBlock.hashTreeRoot(lastProcessedBlock.message),
+          root: this.config.types.BeaconBlock.hashTreeRoot(lastProcessedBlock.message),
         };
         this.setTarget();
         this.subscribeToBlock = false;
@@ -231,7 +233,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
   /**
    * Make sure we get up-to-date lastProcessedBlock from sync().
    */
-  private getLastProcessedBlock = (): ISyncCheckpoint => {
+  private getLastProcessedBlock = (): SlotRoot => {
     return this.lastProcessedBlock;
   };
 

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/interface.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/interface.ts
@@ -1,10 +1,11 @@
 import {SignedBeaconBlock} from "@chainsafe/lodestar-types";
-import {IRegularSyncModules, ISyncCheckpoint} from "../..";
+import {SlotRoot} from "@chainsafe/lodestar-types";
+import {IRegularSyncModules} from "../..";
 import {IService} from "../../../node";
 import {AbortSignal} from "abort-controller";
 
 export interface IBlockRangeFetcher {
-  setLastProcessedBlock(lastProcessedBlock: ISyncCheckpoint): void;
+  setLastProcessedBlock(lastProcessedBlock: SlotRoot): void;
   getNextBlockRange(): Promise<SignedBeaconBlock[]>;
 }
 

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -1,10 +1,11 @@
 import PeerId from "peer-id";
 import {AbortSignal} from "abort-controller";
+import {SlotRoot} from "@chainsafe/lodestar-types";
 import {Checkpoint, SignedBeaconBlock, Slot, Status, Root} from "@chainsafe/lodestar-types";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {getStatusProtocols, INetwork, IReqResp} from "../../network";
-import {ISlotRange, ISyncCheckpoint} from "../interface";
+import {ISlotRange} from "../interface";
 import {IBeaconChain} from "../../chain";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {getBlockRange, isValidChainOfBlocks, sortBlocks} from "./blocks";
@@ -172,13 +173,13 @@ export function processSyncBlocks(
   chain: IBeaconChain,
   logger: ILogger,
   isInitialSync: boolean,
-  lastProcessedBlock: ISyncCheckpoint,
+  lastProcessedBlock: SlotRoot,
   trusted = false
 ): (source: AsyncIterable<SignedBeaconBlock[] | null>) => Promise<Slot | null> {
   return async (source) => {
     let blockBuffer: SignedBeaconBlock[] = [];
     let lastProcessedSlot: Slot | null = null;
-    let {slot: headSlot, blockRoot: headRoot} = lastProcessedBlock;
+    let {slot: headSlot, root: headRoot} = lastProcessedBlock;
     for await (const blocks of source) {
       if (!blocks) {
         // failed to fetch range, trigger sync to retry

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
@@ -55,7 +55,7 @@ describe("BlockRangeFetcher", function () {
   });
 
   it("should fetch next range initially", async () => {
-    fetcher.setLastProcessedBlock({blockRoot: ZERO_HASH, slot: 1000});
+    fetcher.setLastProcessedBlock({root: ZERO_HASH, slot: 1000});
     getCurrentSlotStub.returns(2000);
     const firstBlock = generateEmptySignedBlock();
     const secondBlock = generateEmptySignedBlock();
@@ -70,7 +70,7 @@ describe("BlockRangeFetcher", function () {
   it("should fetch next range based on last fetch block", async () => {
     // handle the case when peer does not return all blocks
     // next fetch should start from last fetch block
-    fetcher.setLastProcessedBlock({blockRoot: ZERO_HASH, slot: 1000});
+    fetcher.setLastProcessedBlock({root: ZERO_HASH, slot: 1000});
     getCurrentSlotStub.returns(2000);
     const firstBlock = generateEmptySignedBlock();
     firstBlock.message.slot = 1010;
@@ -96,7 +96,7 @@ describe("BlockRangeFetcher", function () {
     // should switch peer
     const firstPeerId = await PeerId.create();
     getPeers.onFirstCall().resolves([firstPeerId]);
-    fetcher.setLastProcessedBlock({blockRoot: ZERO_HASH, slot: 1000});
+    fetcher.setLastProcessedBlock({root: ZERO_HASH, slot: 1000});
     getCurrentSlotStub.returns(2000);
     getBlockRangeStub.onFirstCall().throws("");
     const firstBlock = generateEmptySignedBlock();
@@ -117,7 +117,7 @@ describe("BlockRangeFetcher", function () {
     // should switch peer
     const firstPeerId = await PeerId.create();
     getPeers.onFirstCall().resolves([firstPeerId]);
-    fetcher.setLastProcessedBlock({blockRoot: ZERO_HASH, slot: 1000});
+    fetcher.setLastProcessedBlock({root: ZERO_HASH, slot: 1000});
     getCurrentSlotStub.returns(2000);
     getBlockRangeStub.onFirstCall().resolves(null);
     const firstBlock = generateEmptySignedBlock();
@@ -143,7 +143,7 @@ describe("BlockRangeFetcher", function () {
     const secondPeerId = await PeerId.create();
     getPeers.onSecondCall().resolves([secondPeerId]);
     // fetcher should not trust a getBlockRange returning empty array using handleEmptyRange
-    fetcher.setLastProcessedBlock({blockRoot: ZERO_HASH, slot: 1000});
+    fetcher.setLastProcessedBlock({root: ZERO_HASH, slot: 1000});
     getCurrentSlotStub.returns(2000);
     const firstBlock = generateEmptySignedBlock();
     firstBlock.message.slot = 1010;
@@ -177,7 +177,7 @@ describe("BlockRangeFetcher", function () {
     getCurrentSlotStub.returns(2000);
     const firstBlock = generateEmptySignedBlock();
     firstBlock.message.slot = 1000;
-    fetcher.setLastProcessedBlock({blockRoot: config.types.BeaconBlock.hashTreeRoot(firstBlock.message), slot: 1000});
+    fetcher.setLastProcessedBlock({root: config.types.BeaconBlock.hashTreeRoot(firstBlock.message), slot: 1000});
     const secondBlock = generateEmptySignedBlock();
     secondBlock.message.slot = 1001;
     secondBlock.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(firstBlock.message);
@@ -230,7 +230,7 @@ describe("BlockRangeFetcher", function () {
     // should switch peer or the sync will keep getting the same chain segment and be stale
     const firstPeerId = await PeerId.create();
     getPeers.onFirstCall().resolves([firstPeerId]);
-    fetcher.setLastProcessedBlock({blockRoot: ZERO_HASH, slot: 1000});
+    fetcher.setLastProcessedBlock({root: ZERO_HASH, slot: 1000});
     getCurrentSlotStub.returns(2000);
     // first call returns non-linear chain
     getBlockRangeStub.onFirstCall().resolves([generateEmptySignedBlock(), generateEmptySignedBlock()]);

--- a/packages/lodestar/test/unit/sync/utils/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/sync.test.ts
@@ -202,7 +202,7 @@ describe("sync utils", function () {
       block3.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(block2.message);
       const lastProcesssedSlot = await pipe(
         [[block1, block2, block3]],
-        processSyncBlocks(config, chainStub, logger, true, {blockRoot, slot: lastProcessedBlock.slot}, true)
+        processSyncBlocks(config, chainStub, logger, true, {root: blockRoot, slot: lastProcessedBlock.slot}, true)
       );
       expect(chainStub.receiveBlock.calledWith(block1, true)).to.be.true;
       expect(chainStub.receiveBlock.calledWith(block2, true)).to.be.true;
@@ -226,7 +226,7 @@ describe("sync utils", function () {
       lastBlock.message.slot = 4;
       const lastProcesssedSlot = await pipe(
         [[block1, block2, orphanedBlock, lastBlock]],
-        processSyncBlocks(config, chainStub, logger, true, {blockRoot, slot: lastProcessedBlock.slot}, true)
+        processSyncBlocks(config, chainStub, logger, true, {root: blockRoot, slot: lastProcessedBlock.slot}, true)
       );
       // only block 1 is imported bc block2 does not link to a child
       // don't import orphaned and last block
@@ -235,7 +235,7 @@ describe("sync utils", function () {
     });
 
     it("should handle failed to get range - initial sync", async function () {
-      const lastProcessedBlock = {blockRoot: ZERO_HASH, slot: 10};
+      const lastProcessedBlock = {root: ZERO_HASH, slot: 10};
       const lastProcessSlot = await pipe(
         // failed to fetch range
         [null],
@@ -248,13 +248,13 @@ describe("sync utils", function () {
       const lastProcessSlot = await pipe(
         // failed to fetch range
         [null],
-        processSyncBlocks(config, chainStub, logger, false, {slot: 100, blockRoot: ZERO_HASH})
+        processSyncBlocks(config, chainStub, logger, false, {slot: 100, root: ZERO_HASH})
       );
       expect(lastProcessSlot).to.be.equal(100);
     });
 
     it("should handle empty range - initial sync", async function () {
-      const lastProcessedBlock = {blockRoot: ZERO_HASH, slot: 10};
+      const lastProcessedBlock = {root: ZERO_HASH, slot: 10};
       const lastProcessSlot = await pipe(
         // failed to fetch range
         [[]],
@@ -267,7 +267,7 @@ describe("sync utils", function () {
       const lastProcessSlot = await pipe(
         // empty range
         [[]],
-        processSyncBlocks(config, chainStub, logger, false, {slot: 100, blockRoot: ZERO_HASH})
+        processSyncBlocks(config, chainStub, logger, false, {slot: 100, root: ZERO_HASH})
       );
       expect(lastProcessSlot).to.be.null;
     });


### PR DESCRIPTION
+ Sync should use the newly created `SlotRoot` instead of its own specific `ISyncCheckpoint`
+ Remove `ISyncCheckpoint`