### PR TITLE
POC: immutablejs for CachedValidatorsBeaconState

### DIFF
--- a/packages/lodestar-beacon-state-transition/package.json
+++ b/packages/lodestar-beacon-state-transition/package.json
@@ -41,7 +41,8 @@
     "@chainsafe/lodestar-utils": "^0.12.0",
     "@chainsafe/ssz": "^0.6.13",
     "bigint-buffer": "^1.1.5",
-    "buffer-xor": "^2.0.2"
+    "buffer-xor": "^2.0.2",
+    "immutable": "4.0.0-rc.12"
   },
   "devDependencies": {
     "@chainsafe/blst": "^0.1.3",

--- a/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
@@ -25,7 +25,7 @@ export function initiateValidatorExit(
   const exitEpochs = validatorExitEpochs.filter((exitEpoch) => exitEpoch !== FAR_FUTURE_EPOCH);
   exitEpochs.push(computeActivationExitEpoch(config, currentEpoch));
   let exitQueueEpoch = Math.max(...exitEpochs);
-  const exitQueueChurn = validatorExitEpochs.filter((exitEpoch) => exitEpoch === exitQueueEpoch).length;
+  const exitQueueChurn = validatorExitEpochs.filter((exitEpoch) => exitEpoch === exitQueueEpoch).size;
   if (exitQueueChurn >= getChurnLimit(config, epochCtx.currentShuffling.activeIndices.length)) {
     exitQueueEpoch += 1;
   }

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
@@ -143,9 +143,10 @@ export class EpochContext {
     this.previousShuffling = this.currentShuffling;
     this.currentShuffling = this.nextShuffling;
     const nextEpoch = this.currentShuffling.epoch + 1;
-    const indicesBounded: [ValidatorIndex, Epoch, Epoch][] = state
+    const indicesBounded = state
       .flatValidators()
-      .map((v, i) => [i, v.activationEpoch, v.exitEpoch]);
+      .map((v, i) => [i, v.activationEpoch, v.exitEpoch])
+      .toJS();
     this.nextShuffling = computeEpochShuffling(this.config, state, indicesBounded, nextEpoch);
     this._resetProposers(state);
   }

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -10,6 +10,7 @@ import {
   AttestationData,
   AttesterDuty,
   BeaconBlock,
+  BeaconState,
   Bytes96,
   CommitteeIndex,
   Epoch,
@@ -20,7 +21,7 @@ import {
   ValidatorIndex,
 } from "@chainsafe/lodestar-types";
 import {assert, ILogger} from "@chainsafe/lodestar-utils";
-import {readOnlyForEach} from "@chainsafe/ssz";
+import {readOnlyForEach, TreeBacked} from "@chainsafe/ssz";
 import {IAttestationJob, IBeaconChain} from "../../../chain";
 import {assembleAttestationData} from "../../../chain/factory/attestation";
 import {assembleBlock} from "../../../chain/factory/block";
@@ -81,7 +82,13 @@ export class ValidatorApi implements IValidatorApi {
       await checkSyncStatus(this.config, this.sync);
       const headRoot = this.chain.forkChoice.getHeadRoot();
       const {state, epochCtx} = await this.chain.regen.getBlockSlotState(headRoot, slot);
-      return await assembleAttestationData(epochCtx.config, state, headRoot, slot, committeeIndex);
+      return await assembleAttestationData(
+        epochCtx.config,
+        state.getOriginalState() as TreeBacked<BeaconState>,
+        headRoot,
+        slot,
+        committeeIndex
+      );
     } catch (e) {
       this.logger.warn("Failed to produce attestation data", e);
       throw e;

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -149,7 +149,7 @@ export class BeaconChain implements IBeaconChain {
   }
   public async getHeadState(): Promise<TreeBacked<BeaconState>> {
     //head state should always have epoch ctx
-    return (await this.getHeadStateContext()).state;
+    return (await this.getHeadStateContext()).state.getOriginalState() as TreeBacked<BeaconState>;
   }
   public async getHeadEpochContext(): Promise<EpochContext> {
     //head should always have epoch ctx

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -218,7 +218,7 @@ export async function onBlock(
   job: IBlockJob
 ): Promise<void> {
   const blockRoot = this.config.types.BeaconBlock.hashTreeRoot(block.message);
-  this.logger.debug("Block processed", {
+  this.logger.info("Block processed", {
     slot: block.message.slot,
     root: toHexString(blockRoot),
   });
@@ -308,7 +308,7 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
     return;
   }
 
-  this.logger.debug("Block error", {}, err);
+  this.logger.error("Block error", {}, err);
   const blockRoot = this.config.types.BeaconBlock.hashTreeRoot(err.job.signedBlock.message);
 
   switch (err.type.code) {

--- a/packages/lodestar/src/chain/initState.ts
+++ b/packages/lodestar/src/chain/initState.ts
@@ -16,6 +16,7 @@ import {Eth1Provider} from "../eth1";
 import {IBeaconMetrics} from "../metrics";
 import {GenesisBuilder} from "./genesis/genesis";
 import {IGenesisResult} from "./genesis/interface";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
 export async function persistGenesisResult(
   db: IBeaconDb,
@@ -138,7 +139,7 @@ export async function restoreStateCaches(
   const epochCtx = new EpochContext(config);
   epochCtx.loadState(state);
 
-  const stateCtx = {state, epochCtx};
+  const stateCtx = {state: createCachedValidatorsBeaconState(state), epochCtx};
   await Promise.all([db.stateCache.add(stateCtx), db.checkpointStateCache.add(checkpoint, stateCtx)]);
 }
 

--- a/packages/lodestar/src/db/api/beacon/stateContextCache.ts
+++ b/packages/lodestar/src/db/api/beacon/stateContextCache.ts
@@ -1,10 +1,11 @@
 import {ByteVector, toHexString, TreeBacked} from "@chainsafe/ssz";
 import {BeaconState, Gwei} from "@chainsafe/lodestar-types";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
 // Lodestar specifc state context
 export interface ITreeStateContext {
-  state: TreeBacked<BeaconState>;
+  state: CachedValidatorsBeaconState; // TreeBacked<BeaconState>
   epochCtx: LodestarEpochContext;
 }
 
@@ -40,7 +41,9 @@ export class StateContextCache {
   }
 
   public async add(item: ITreeStateContext): Promise<void> {
-    this.cache[toHexString(item.state.hashTreeRoot())] = this.clone(item);
+    this.cache[toHexString((item.state.getOriginalState() as TreeBacked<BeaconState>).hashTreeRoot())] = this.clone(
+      item
+    );
   }
 
   public async delete(root: ByteVector): Promise<void> {

--- a/packages/lodestar/src/tasks/tasks/archiveStates.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveStates.ts
@@ -6,7 +6,8 @@ import {ITask} from "../interface";
 import {IBeaconDb} from "../../db/api";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils";
-import {Checkpoint} from "@chainsafe/lodestar-types";
+import {BeaconState, Checkpoint} from "@chainsafe/lodestar-types";
+import {TreeBacked} from "@chainsafe/ssz";
 
 export interface IArchiveStatesModules {
   db: IBeaconDb;
@@ -41,7 +42,7 @@ export class ArchiveStatesTask implements ITask {
       throw Error("No state in cache for finalized checkpoint state epoch #" + this.finalized.epoch);
     }
     const finalizedState = stateCache.state;
-    await this.db.stateArchive.add(finalizedState);
+    await this.db.stateArchive.add(finalizedState.getOriginalState() as TreeBacked<BeaconState>);
     // don't delete states before the finalized state, auto-prune will take care of it
     this.logger.info("Archive states completed", {finalizedEpoch: this.finalized.epoch});
     this.logger.profile("Archive States epoch #" + this.finalized.epoch);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6868,6 +6868,11 @@ immediate@^3.2.3, immediate@~3.2.3:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
   integrity sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=
 
+immutable@4.0.0-rc.12:
+  version "4.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
+  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
+
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"


### PR DESCRIPTION
just want to have some statistics regarding ImmutableJS as @wemeetagain 's ideas in last meeting
+ this is based on #1816. The difference is we use ImmutableJs for the validators cache and apply CachedValidatorsBeaconState globally across lodestar instead of just state transition.
+ the statistic

|branch|average epoch transition(ms)|time to sync to slot 10000(mins)|
|-|-|-|
|master|4114|49|
|this branch|1395|27|

+ I really don't see any differences in terms of heap memory in my local environment. Perhaps someone can try in your environments too!