### PR TITLE
Automatic release and publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,23 @@ jobs:
       - name: Build
         run: yarn run build
       
-      - name: Publish to npm registry
-        run: yarn publish --no-git-tag-version --no-commit-hooks --non-interactive
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # - name: Publish to npm registry
+      #   run: yarn run publish 
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Generate changelog
+        id: changelog
+        uses: heinrichreimer/github-changelog-generator-action@v2.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issues: false
+          issuesWoLabels: false
+          pullRequests: true
+          prWoLabels: true
+          filterByMilestone: false
+          unreleased: false
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -65,8 +78,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ needs.tag.outputs.tag }}
-          body: ""
+          body: ${{ steps.changelog.output.changelog }}
           release_name: Release ${{ needs.tag.outputs.tag }}
+
       #in case of failure
       - name: Rollback on failure
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: butlerlogic/action-autotag@1.1.1
         with:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          strategy: package # Optional, since "package" is the default strategy
+          root: "packages/lodestar" # lerna doesn't update version root package.json and this action cannot read from lerna.json
           tag_prefix: "v"
     outputs:
       tag: ${{ steps.tag.outputs.tagname }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,10 @@ jobs:
           issuesWoLabels: false
           pullRequests: true
           prWoLabels: true
+          author: true
+          usernamesAsGithubLogins: true
+          compareLink: true
+          onlyLastTag: true
           filterByMilestone: false
           unreleased: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
           tag_name: ${{ needs.tag.outputs.tag }}
           body_path: "CHANGELOG.md"
           release_name: Release ${{ needs.tag.outputs.tag }}
+          prerelease: true # we can promote to in github
 
       #in case of failure
       - name: Rollback on failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ needs.tag.outputs.tag }}
-          body: ${{ steps.changelog.outputs.changelog }}
+          body_path: "CHANGELOG.md"
           release_name: Release ${{ needs.tag.outputs.tag }}
 
       #in case of failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,13 +60,13 @@ jobs:
         run: yarn install --frozen-lockfile --ignore-optional
 
       - name: Build
-        if: steps.cache-deps.outputs.cache-hit != 'true'
+        if: steps.cache-deps.outputs.cache-hit == 'true'
         run: yarn run build
       
-      # - name: Publish to npm registry
-      #   run: yarn run publish 
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm registry
+        run: yarn run publish 
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Generate changelog
         id: changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
         run: yarn install --frozen-lockfile --ignore-optional
 
       - name: Build
+        if: steps.cache-deps.outputs.cache-hit != 'true'
         run: yarn run build
       
       # - name: Publish to npm registry
@@ -78,7 +79,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ needs.tag.outputs.tag }}
-          body: ${{ steps.changelog.output.changelog }}
+          body: ${{ steps.changelog.outputs.changelog }}
           release_name: Release ${{ needs.tag.outputs.tag }}
 
       #in case of failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Generate changelog
         id: changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.1.1
+        uses: heinrichreimer/github-changelog-generator-action@v2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issues: false
@@ -80,7 +80,6 @@ jobs:
           author: true
           usernamesAsGithubLogins: true
           compareLink: true
-          onlyLastTag: true
           filterByMilestone: false
           unreleased: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Get latest tag
+        uses: actions-ecosystem/action-get-latest-tag@v1
+        with:
+          with_initial_version: false
+        id: get-latest-tag
+
       - name: Create tag
         id: tag
         uses: butlerlogic/action-autotag@1.1.1
@@ -21,6 +28,7 @@ jobs:
           tag_prefix: "v"
     outputs:
       tag: ${{ steps.tag.outputs.tagname }}
+      previous_tag: ${{ steps.get-latest-tag.outputs.tag }}
       version: ${{ steps.tag.outputs.version }}
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  tag:
+    name: Check and Tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create tag
+        id: tag
+        uses: butlerlogic/action-autotag@1.1.1
+        with:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          strategy: package # Optional, since "package" is the default strategy
+          tag_prefix: "v"
+    outputs:
+      tag: ${{ steps.tag.outputs.tagname }}
+      version: ${{ steps.tag.outputs.version }}
+
+  release:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: tag
+    if: needs.tag.outputs.tag != ''
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      
+      - name: Setup Nodejs
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Restore dependencies
+        uses: actions/cache@master
+        id: cache-deps
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional
+      
+      - name: Install & build
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile --ignore-optional
+
+      - name: Build
+        run: yarn run build
+      
+      - name: Publish to npm registry
+        run: yarn publish --no-git-tag-version --no-commit-hooks --non-interactive
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.tag.outputs.tag }}
+          body: ""
+          release_name: Release ${{ needs.tag.outputs.tag }}
+      #in case of failure
+      - name: Rollback on failure
+        if: failure()
+        uses: author/action-rollback@9ec72a6af74774e00343c6de3e946b0901c23013
+        with:
+          id: ${{ steps.create_release.outputs.id }}
+          tag: ${{ needs.tag.outputs.tag }}
+          delete_orphan_tag: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - [Meeting Notes](#meeting-notes)
 - [Donations](#donations)
 - [Packages](#packages)
+- [Creating Release](#creating-release)
 
 ## Contributors
 
@@ -56,3 +57,9 @@ This monorepo repository contains a suite of Ethereum 2.0 packages.
 | [@chainsafe/lodestar-utils](https://github.com/ChainSafe/lodestar/tree/master/packages/lodestar-utils)                                     | [![npm](https://img.shields.io/npm/v/@chainsafe/lodestar-utils)](https://www.npmjs.com/package/@chainsafe/lodestar-utils)                                     | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)  | [![documentation](https://img.shields.io/badge/typedoc-blue)](https://chainsafe.github.io/lodestar/lodestar-utils)                                        | Misc utility functions used across lodestar |
 | [@chainsafe/lodestar-config](https://github.com/ChainSafe/lodestar/tree/master/packages/lodestar-config)                                   | [![npm](https://img.shields.io/npm/v/@chainsafe/lodestar-config)](https://www.npmjs.com/package/@chainsafe/lodestar-config)                                   | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)  | [![documentation](https://img.shields.io/badge/typedoc-blue)](https://chainsafe.github.io/lodestar/lodestar-config)                                       | Eth2 types and params bundled together      |
 | [@chainsafe/lodestar-spec-test-util](https://github.com/ChainSafe/lodestar/tree/master/packages/lodestar-spec-test-util)                   | [![npm](https://img.shields.io/npm/v/@chainsafe/lodestar-spec-test-util)](https://www.npmjs.com/package/@chainsafe/lodestar-spec-test-util)                   | [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)  | [![documentation](https://img.shields.io/badge/typedoc-blue)](https://chainsafe.github.io/lodestar/lodestar-spec-test-util)                               | Test harness for Eth2 spec tests            |
+
+
+### Creating Release
+- run `yarn run release` in project root directory
+- choose version increment
+- open PR to master

--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,10 @@
   "npmClient": "yarn",
   "useWorkspaces": true,
   "version": "0.12.0",
-  "stream": "true"
+  "stream": "true",
+  "command": {
+    "version": {
+      "message": "chore(release): %s"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.11.0",
   "scripts": {
     "postinstall": "lerna run clean && lerna run build",
     "build": "lerna run build",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "test:spec-min": "lerna run test:spec-min --no-bail",
     "test:spec-fast": "lerna run test:spec-fast --no-bail",
     "test:spec-main": "lerna run test:spec-main --no-bail",
-    "cli": "node --trace-deprecation ./packages/lodestar-cli/bin/lodestar"
+    "cli": "node --trace-deprecation ./packages/lodestar-cli/bin/lodestar",
+    "publish": "lerna publish from-git --yes",
+    "release": "lerna version --no-git-tag-version --no-push --sign-git-commit"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test:spec-main": "lerna run test:spec-main --no-bail",
     "cli": "node --trace-deprecation ./packages/lodestar-cli/bin/lodestar",
     "publish": "lerna publish from-git --yes",
-    "release": "lerna version --no-git-tag-version --no-push --sign-git-commit"
+    "release": "lerna version --no-push --sign-git-commit",
+    "postrelease": "git tag -d $(git describe --abbrev=0)"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",


### PR DESCRIPTION
- added command to bump versions
- added note on cutting release
- ci will on version bump detection, create tag, publish on npm and generate release page with changelog based on PR titles

resolves #1876

If something goes wrong, tag and release will rollback. Only untested feature is actual publish on npm