### PR TITLE
Simpify eth2RequestEncode

### DIFF
--- a/packages/lodestar/src/network/encoders/request.ts
+++ b/packages/lodestar/src/network/encoders/request.ts
@@ -8,6 +8,7 @@ import {Method, Methods, ReqRespEncoding} from "../../constants";
 import {toBuffer} from "../../util/buffer";
 import {getCompressor, getDecompressor, maxEncodedLen} from "./utils";
 import {IValidatedRequestBody} from "./interface";
+import {ReqRespSerializeError} from "../error";
 
 export async function streamRequestBodyTo(
   config: IBeaconConfig,
@@ -38,8 +39,12 @@ export function serializeRequestBody(
   if (type == null || requestBody == null) {
     return null;
   } else {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return type.serialize(requestBody as any);
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return type.serialize(requestBody as any);
+    } catch (e) {
+      throw new ReqRespSerializeError(e);
+    }
   }
 }
 

--- a/packages/lodestar/src/network/encoders/request.ts
+++ b/packages/lodestar/src/network/encoders/request.ts
@@ -5,7 +5,7 @@ import {ILogger} from "@chainsafe/lodestar-utils";
 import {RequestBody} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Method, Methods, ReqRespEncoding} from "../../constants";
-import {toBuffer} from "../../util/buffer";
+import {castToBufferUnsafe} from "../../util/buffer";
 import {getCompressor, getDecompressor, maxEncodedLen} from "./utils";
 import {IValidatedRequestBody} from "./interface";
 import {ReqRespSerializeError} from "../error";
@@ -58,7 +58,7 @@ export async function* getRequestBodyEncodedStream(
   const compressor = getCompressor(encoding);
 
   yield Buffer.from(encode(requestBodySerialized.length));
-  yield* compressor(toBuffer(requestBodySerialized));
+  yield* compressor(castToBufferUnsafe(requestBodySerialized));
 }
 
 export function eth2RequestDecode(

--- a/packages/lodestar/src/network/error.ts
+++ b/packages/lodestar/src/network/error.ts
@@ -6,6 +6,14 @@ import PeerId from "peer-id";
  * Error of network req/resp
  */
 
+export class ReqRespSerializeError extends Error {
+  serializeError: Error;
+  constructor(serializeError: Error) {
+    super(`REQRESP_SERIALIZE_BODY_ERROR: ${serializeError.message}`);
+    this.serializeError = serializeError;
+  }
+}
+
 export class RpcError extends Error {
   public status: RpcResponseStatus;
   constructor(status: RpcResponseStatus, message?: string) {

--- a/packages/lodestar/src/network/reqresp/reqUtils.ts
+++ b/packages/lodestar/src/network/reqresp/reqUtils.ts
@@ -16,7 +16,7 @@ import {
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ErrorAborted, ILogger} from "@chainsafe/lodestar-utils";
 import {Method, MethodRequestType, ReqRespEncoding, TTFB_TIMEOUT, REQUEST_TIMEOUT} from "../../constants";
-import {getRequestBodyEncodedStream, serializeRequestBody, streamRequestBodyTo} from "../encoders/request";
+import {streamRequestBodyTo} from "../encoders/request";
 import {eth2ResponseDecode} from "../encoders/response";
 import {REQUEST_TIMEOUT_ERR} from "../error";
 
@@ -74,8 +74,9 @@ export async function* sendRequestStream<T extends ResponseBody>(
       }
       logger.verbose("got stream to peer", {peer: peerId.toB58String(), requestId, encoding});
 
-      if (requestBody == null) return;
-      await streamRequestBodyTo(config, method, encoding, requestBody, conn.stream);
+      if (requestBody) {
+        await streamRequestBodyTo(config, method, encoding, requestBody, conn.stream);
+      }
     })(),
     new Promise((_, reject) => {
       requestTimer = setTimeout(() => {

--- a/packages/lodestar/src/util/buffer.ts
+++ b/packages/lodestar/src/util/buffer.ts
@@ -1,6 +1,6 @@
 /**
  * Cast Uint8Array to Buffer efficiently
  */
-export function toBuffer(bytes: Uint8Array): Buffer {
+export function castToBufferUnsafe(bytes: Uint8Array): Buffer {
   return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.length);
 }

--- a/packages/lodestar/src/util/buffer.ts
+++ b/packages/lodestar/src/util/buffer.ts
@@ -1,0 +1,6 @@
+/**
+ * Cast Uint8Array to Buffer efficiently
+ */
+export function toBuffer(bytes: Uint8Array): Buffer {
+  return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.length);
+}

--- a/packages/lodestar/test/unit/network/encoders/request.test.ts
+++ b/packages/lodestar/test/unit/network/encoders/request.test.ts
@@ -38,6 +38,12 @@ describe("network / encoders", () => {
 
         await expect(simulateRequest(Method.Status, encoding, requestBody)).to.be.rejectedWith(ReqRespSerializeError);
       });
+
+      it(`simulate request no body - ${encoding}`, async function () {
+        // streamRequestBodyTo should not be called with no body, but just make sure it doesn't break
+        const requestBody = (null as any) as RequestBody;
+        await simulateRequest(Method.Status, encoding, requestBody);
+      });
     }
 
     async function simulateRequest(

--- a/packages/lodestar/test/unit/network/encoders/request.test.ts
+++ b/packages/lodestar/test/unit/network/encoders/request.test.ts
@@ -4,14 +4,15 @@ import sinon, {SinonStubbedInstance} from "sinon";
 import {encode} from "varint";
 import pipe from "it-pipe";
 import all from "it-all";
+import {config} from "@chainsafe/lodestar-config/minimal";
+import {ILogger, WinstonLogger} from "@chainsafe/lodestar-utils";
+import {RequestBody, Status} from "@chainsafe/lodestar-types";
 import {eth2RequestDecode, streamRequestBodyTo} from "../../../../src/network/encoders/request";
 import {IValidatedRequestBody} from "../../../../src/network/encoders/interface";
-import {config} from "@chainsafe/lodestar-config/minimal";
 import {Method, ReqRespEncoding} from "../../../../src/constants";
-import {ILogger, WinstonLogger} from "@chainsafe/lodestar-utils";
-import {createStatus} from "./utils";
-import {RequestBody, Status} from "@chainsafe/lodestar-types";
+import {ReqRespSerializeError} from "../../../../src/network/error";
 import {silentLogger} from "../../../utils/logger";
+import {createStatus} from "./utils";
 
 chai.use(chaiAsPromised);
 
@@ -35,9 +36,7 @@ describe("network / encoders", () => {
       it(`simulate request bad body - ${encoding}`, async function () {
         const requestBody = BigInt(0);
 
-        await expect(simulateRequest(Method.Status, encoding, requestBody)).to.be.rejectedWith(
-          "Cannot convert undefined or null to object"
-        );
+        await expect(simulateRequest(Method.Status, encoding, requestBody)).to.be.rejectedWith(ReqRespSerializeError);
       });
     }
 


### PR DESCRIPTION
eth2RequestEncode is not used anywhere for more than a request at once which adds complexity to the implementation.

The goal of this PR is to simplify things assuming there's a single request to be streamed
- Split utility into three functions
  - `serializeRequestBody`: json => Uint8Array
  - `getRequestBodyEncodedStream`: Instantiate compressor and return stream
  - `streamRequestBodyTo`: Calls above fns and pipes to connection sink
- If the body fails to serialize a proper error will be thrown since it happens outside of pipe
- Tests are updated with a `simulateRequest` utility which creates a streamSink to compare the streamed body. It also reduces code duplication with a for loop over encodings