### PR TITLE
Remove ERR_ prefix from error code enums

### DIFF
--- a/packages/lodestar-fork-choice/src/forkChoice/errors.ts
+++ b/packages/lodestar-fork-choice/src/forkChoice/errors.ts
@@ -9,25 +9,10 @@ export enum InvalidBlockCode {
 }
 
 export type InvalidBlock =
-  | {
-      code: InvalidBlockCode.UNKNOWN_PARENT;
-      root: Uint8Array;
-    }
-  | {
-      code: InvalidBlockCode.FUTURE_SLOT;
-      currentSlot: Slot;
-      blockSlot: Slot;
-    }
-  | {
-      code: InvalidBlockCode.FINALIZED_SLOT;
-      finalizedSlot: Slot;
-      blockSlot: Slot;
-    }
-  | {
-      code: InvalidBlockCode.NOT_FINALIZED_DESCENDANT;
-      finalizedRoot: Uint8Array;
-      blockAncestor?: Uint8Array;
-    };
+  | {code: InvalidBlockCode.UNKNOWN_PARENT; root: Uint8Array}
+  | {code: InvalidBlockCode.FUTURE_SLOT; currentSlot: Slot; blockSlot: Slot}
+  | {code: InvalidBlockCode.FINALIZED_SLOT; finalizedSlot: Slot; blockSlot: Slot}
+  | {code: InvalidBlockCode.NOT_FINALIZED_DESCENDANT; finalizedRoot: Uint8Array; blockAncestor?: Uint8Array};
 
 export enum InvalidAttestationCode {
   /**
@@ -66,110 +51,43 @@ export enum InvalidAttestationCode {
 }
 
 export type InvalidAttestation =
-  | {
-      code: InvalidAttestationCode.EMPTY_AGGREGATION_BITFIELD;
-    }
-  | {
-      code: InvalidAttestationCode.UNKNOWN_HEAD_BLOCK;
-      beaconBlockRoot: Uint8Array;
-    }
-  | {
-      code: InvalidAttestationCode.BAD_TARGET_EPOCH;
-      target: Epoch;
-      slot: Slot;
-    }
-  | {
-      code: InvalidAttestationCode.UNKNOWN_TARGET_ROOT;
-      root: Uint8Array;
-    }
-  | {
-      code: InvalidAttestationCode.FUTURE_EPOCH;
-      attestationEpoch: Epoch;
-      currentEpoch: Epoch;
-    }
-  | {
-      code: InvalidAttestationCode.PAST_EPOCH;
-      attestationEpoch: Epoch;
-      currentEpoch: Epoch;
-    }
-  | {
-      code: InvalidAttestationCode.INVALID_TARGET;
-      attestation: Uint8Array;
-      local: Uint8Array;
-    }
-  | {
-      code: InvalidAttestationCode.ATTESTS_TO_FUTURE_BLOCK;
-      block: Slot;
-      attestation: Slot;
-    };
+  | {code: InvalidAttestationCode.EMPTY_AGGREGATION_BITFIELD}
+  | {code: InvalidAttestationCode.UNKNOWN_HEAD_BLOCK; beaconBlockRoot: Uint8Array}
+  | {code: InvalidAttestationCode.BAD_TARGET_EPOCH; target: Epoch; slot: Slot}
+  | {code: InvalidAttestationCode.UNKNOWN_TARGET_ROOT; root: Uint8Array}
+  | {code: InvalidAttestationCode.FUTURE_EPOCH; attestationEpoch: Epoch; currentEpoch: Epoch}
+  | {code: InvalidAttestationCode.PAST_EPOCH; attestationEpoch: Epoch; currentEpoch: Epoch}
+  | {code: InvalidAttestationCode.INVALID_TARGET; attestation: Uint8Array; local: Uint8Array}
+  | {code: InvalidAttestationCode.ATTESTS_TO_FUTURE_BLOCK; block: Slot; attestation: Slot};
 
 export enum ForkChoiceErrorCode {
-  ERR_INVALID_ATTESTATION = "ERR_INVALID_ATTESTATION",
-  ERR_INVALID_BLOCK = "ERR_INVALID_BLOCK",
-  ERR_PROTO_ARRAY_ERROR = "ERR_PROTO_ARRAY_ERROR",
-  ERR_INVALID_PROTO_ARRAY_BYTES = "ERR_INVALID_PROTO_ARRAY_BYTES",
-  ERR_MISSING_PROTO_ARRAY_BLOCK = "ERR_MISSING_PROTO_ARRAY_BLOCK",
-  ERR_UNKNOWN_ANCESTOR = "ERR_UNKNOWN_ANCESTOR",
-  ERR_INCONSISTENT_ON_TICK = "ERR_INCONSISTENT_ON_TICK",
-  ERR_BEACON_STATE_ERROR = "ERR_BEACON_STATE_ERROR",
-  ERR_ATTEMPT_TO_REVERT_JUSTIFICATION = "ERR_ATTEMPT_TO_REVERT_JUSTIFICATION",
-  ERR_FORK_CHOICE_STORE_ERROR = "ERR_FORK_CHOICE_STORE_ERROR",
-  ERR_UNABLE_TO_SET_JUSTIFIED_CHECKPOINT = "ERR_UNABLE_TO_SET_JUSTIFIED_CHECKPOINT",
-  ERR_AFTER_BLOCK_FAILED = "ERR_AFTER_BLOCK_FAILED",
+  INVALID_ATTESTATION = "FORKCHOICE_ERROR_INVALID_ATTESTATION",
+  INVALID_BLOCK = "FORKCHOICE_ERROR_INVALID_BLOCK",
+  PROTO_ARRAY_ERROR = "FORKCHOICE_ERROR_PROTO_ARRAY_ERROR",
+  INVALID_PROTO_ARRAY_BYTES = "FORKCHOICE_ERROR_INVALID_PROTO_ARRAY_BYTES",
+  MISSING_PROTO_ARRAY_BLOCK = "FORKCHOICE_ERROR_MISSING_PROTO_ARRAY_BLOCK",
+  UNKNOWN_ANCESTOR = "FORKCHOICE_ERROR_UNKNOWN_ANCESTOR",
+  INCONSISTENT_ON_TICK = "FORKCHOICE_ERROR_INCONSISTENT_ON_TICK",
+  BEACON_STATE_ERROR = "FORKCHOICE_ERROR_BEACON_STATE_ERROR",
+  ATTEMPT_TO_REVERT_JUSTIFICATION = "FORKCHOICE_ERROR_ATTEMPT_TO_REVERT_JUSTIFICATION",
+  FORK_CHOICE_STORE_ERROR = "FORKCHOICE_ERROR_FORK_CHOICE_STORE_ERROR",
+  UNABLE_TO_SET_JUSTIFIED_CHECKPOINT = "FORKCHOICE_ERROR_UNABLE_TO_SET_JUSTIFIED_CHECKPOINT",
+  AFTER_BLOCK_FAILED = "FORKCHOICE_ERROR_AFTER_BLOCK_FAILED",
 }
 
 export type ForkChoiceErrorType =
-  | {
-      code: ForkChoiceErrorCode.ERR_INVALID_ATTESTATION;
-      err: InvalidAttestation;
-    }
-  | {
-      code: ForkChoiceErrorCode.ERR_INVALID_BLOCK;
-      err: InvalidBlock;
-    }
-  | {
-      code: ForkChoiceErrorCode.ERR_PROTO_ARRAY_ERROR;
-      err: string;
-    }
-  | {
-      code: ForkChoiceErrorCode.ERR_INVALID_PROTO_ARRAY_BYTES;
-      err: string;
-    }
-  | {
-      code: ForkChoiceErrorCode.ERR_MISSING_PROTO_ARRAY_BLOCK;
-      root: Uint8Array;
-    }
-  | {
-      code: ForkChoiceErrorCode.ERR_UNKNOWN_ANCESTOR;
-      ancestorSlot: Slot;
-      descendantRoot: Uint8Array;
-    }
-  | {
-      code: ForkChoiceErrorCode.ERR_INCONSISTENT_ON_TICK;
-      previousSlot: Slot;
-      time: Slot;
-    }
-  | {
-      code: ForkChoiceErrorCode.ERR_BEACON_STATE_ERROR;
-      error: Error;
-    }
-  | {
-      code: ForkChoiceErrorCode.ERR_ATTEMPT_TO_REVERT_JUSTIFICATION;
-      store: Slot;
-      state: Slot;
-    }
-  | {
-      code: ForkChoiceErrorCode.ERR_FORK_CHOICE_STORE_ERROR;
-      error: Error;
-    }
-  | {
-      code: ForkChoiceErrorCode.ERR_UNABLE_TO_SET_JUSTIFIED_CHECKPOINT;
-      error: Error;
-    }
-  | {
-      code: ForkChoiceErrorCode.ERR_AFTER_BLOCK_FAILED;
-      error: Error;
-    };
+  | {code: ForkChoiceErrorCode.INVALID_ATTESTATION; err: InvalidAttestation}
+  | {code: ForkChoiceErrorCode.INVALID_BLOCK; err: InvalidBlock}
+  | {code: ForkChoiceErrorCode.PROTO_ARRAY_ERROR; err: string}
+  | {code: ForkChoiceErrorCode.INVALID_PROTO_ARRAY_BYTES; err: string}
+  | {code: ForkChoiceErrorCode.MISSING_PROTO_ARRAY_BLOCK; root: Uint8Array}
+  | {code: ForkChoiceErrorCode.UNKNOWN_ANCESTOR; ancestorSlot: Slot; descendantRoot: Uint8Array}
+  | {code: ForkChoiceErrorCode.INCONSISTENT_ON_TICK; previousSlot: Slot; time: Slot}
+  | {code: ForkChoiceErrorCode.BEACON_STATE_ERROR; error: Error}
+  | {code: ForkChoiceErrorCode.ATTEMPT_TO_REVERT_JUSTIFICATION; store: Slot; state: Slot}
+  | {code: ForkChoiceErrorCode.FORK_CHOICE_STORE_ERROR; error: Error}
+  | {code: ForkChoiceErrorCode.UNABLE_TO_SET_JUSTIFIED_CHECKPOINT; error: Error}
+  | {code: ForkChoiceErrorCode.AFTER_BLOCK_FAILED; error: Error};
 
 export class ForkChoiceError extends LodestarError<ForkChoiceErrorType> {
   constructor(type: ForkChoiceErrorType) {

--- a/packages/lodestar-fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/lodestar-fork-choice/src/forkChoice/forkChoice.ts
@@ -123,7 +123,7 @@ export class ForkChoice implements IForkChoice {
     const block = this.protoArray.getBlock(toHexString(blockRoot));
     if (!block) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_MISSING_PROTO_ARRAY_BLOCK,
+        code: ForkChoiceErrorCode.MISSING_PROTO_ARRAY_BLOCK,
         root: blockRoot.valueOf() as Uint8Array,
       });
     }
@@ -137,7 +137,7 @@ export class ForkChoice implements IForkChoice {
         }
       }
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_UNKNOWN_ANCESTOR,
+        code: ForkChoiceErrorCode.UNKNOWN_ANCESTOR,
         descendantRoot: blockRoot.valueOf() as Uint8Array,
         ancestorSlot,
       });
@@ -176,14 +176,14 @@ export class ForkChoice implements IForkChoice {
     const headIndex = this.protoArray.indices.get(headRoot);
     if (headIndex === undefined) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_MISSING_PROTO_ARRAY_BLOCK,
+        code: ForkChoiceErrorCode.MISSING_PROTO_ARRAY_BLOCK,
         root: fromHexString(headRoot),
       });
     }
     const headNode = this.protoArray.nodes[headIndex];
     if (headNode === undefined) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_MISSING_PROTO_ARRAY_BLOCK,
+        code: ForkChoiceErrorCode.MISSING_PROTO_ARRAY_BLOCK,
         root: fromHexString(headRoot),
       });
     }
@@ -225,7 +225,7 @@ export class ForkChoice implements IForkChoice {
     // Parent block must be known
     if (!this.protoArray.hasBlock(toHexString(block.parentRoot))) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_INVALID_BLOCK,
+        code: ForkChoiceErrorCode.INVALID_BLOCK,
         err: {
           code: InvalidBlockCode.UNKNOWN_PARENT,
           root: block.parentRoot.valueOf() as Uint8Array,
@@ -239,7 +239,7 @@ export class ForkChoice implements IForkChoice {
     // Note: presently, we do not delay consideration. We just drop the block.
     if (block.slot > this.fcStore.currentSlot) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_INVALID_BLOCK,
+        code: ForkChoiceErrorCode.INVALID_BLOCK,
         err: {
           code: InvalidBlockCode.FUTURE_SLOT,
           currentSlot: this.fcStore.currentSlot,
@@ -253,7 +253,7 @@ export class ForkChoice implements IForkChoice {
     const finalizedSlot = computeStartSlotAtEpoch(this.config, this.fcStore.finalizedCheckpoint.epoch);
     if (block.slot <= finalizedSlot) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_INVALID_BLOCK,
+        code: ForkChoiceErrorCode.INVALID_BLOCK,
         err: {
           code: InvalidBlockCode.FINALIZED_SLOT,
           finalizedSlot,
@@ -267,7 +267,7 @@ export class ForkChoice implements IForkChoice {
     const finalizedRoot = this.fcStore.finalizedCheckpoint.root;
     if (!this.config.types.Root.equals(blockAncestor, finalizedRoot)) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_INVALID_BLOCK,
+        code: ForkChoiceErrorCode.INVALID_BLOCK,
         err: {
           code: InvalidBlockCode.NOT_FINALIZED_DESCENDANT,
           finalizedRoot: finalizedRoot.valueOf() as Uint8Array,
@@ -282,7 +282,7 @@ export class ForkChoice implements IForkChoice {
     if (state.currentJustifiedCheckpoint.epoch > this.fcStore.justifiedCheckpoint.epoch) {
       if (!justifiedBalances) {
         throw new ForkChoiceError({
-          code: ForkChoiceErrorCode.ERR_UNABLE_TO_SET_JUSTIFIED_CHECKPOINT,
+          code: ForkChoiceErrorCode.UNABLE_TO_SET_JUSTIFIED_CHECKPOINT,
           error: new Error("No validator balances supplied"),
         });
       }
@@ -316,7 +316,7 @@ export class ForkChoice implements IForkChoice {
     if (shouldUpdateJustified) {
       if (!justifiedBalances) {
         throw new ForkChoiceError({
-          code: ForkChoiceErrorCode.ERR_UNABLE_TO_SET_JUSTIFIED_CHECKPOINT,
+          code: ForkChoiceErrorCode.UNABLE_TO_SET_JUSTIFIED_CHECKPOINT,
           error: new Error("No validator balances supplied"),
         });
       }
@@ -460,7 +460,7 @@ export class ForkChoice implements IForkChoice {
     const block = this.getBlock(this.fcStore.finalizedCheckpoint.root);
     if (!block) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_MISSING_PROTO_ARRAY_BLOCK,
+        code: ForkChoiceErrorCode.MISSING_PROTO_ARRAY_BLOCK,
         root: this.fcStore.finalizedCheckpoint.root.valueOf() as Uint8Array,
       });
     }
@@ -566,7 +566,7 @@ export class ForkChoice implements IForkChoice {
     // This sanity check is not in the spec, but the invariant is implied
     if (justifiedSlot >= state.slot) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_ATTEMPT_TO_REVERT_JUSTIFICATION,
+        code: ForkChoiceErrorCode.ATTEMPT_TO_REVERT_JUSTIFICATION,
         store: justifiedSlot,
         state: state.slot,
       });
@@ -610,7 +610,7 @@ export class ForkChoice implements IForkChoice {
     // return early here to avoid wasting precious resources verifying the rest of it.
     if (!indexedAttestation.attestingIndices.length) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_INVALID_ATTESTATION,
+        code: ForkChoiceErrorCode.INVALID_ATTESTATION,
         err: {
           code: InvalidAttestationCode.EMPTY_AGGREGATION_BITFIELD,
         },
@@ -623,7 +623,7 @@ export class ForkChoice implements IForkChoice {
     // Attestation must be from the current of previous epoch.
     if (target.epoch > epochNow) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_INVALID_ATTESTATION,
+        code: ForkChoiceErrorCode.INVALID_ATTESTATION,
         err: {
           code: InvalidAttestationCode.FUTURE_EPOCH,
           attestationEpoch: target.epoch,
@@ -632,7 +632,7 @@ export class ForkChoice implements IForkChoice {
       });
     } else if (target.epoch + 1 < epochNow) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_INVALID_ATTESTATION,
+        code: ForkChoiceErrorCode.INVALID_ATTESTATION,
         err: {
           code: InvalidAttestationCode.PAST_EPOCH,
           attestationEpoch: target.epoch,
@@ -643,7 +643,7 @@ export class ForkChoice implements IForkChoice {
 
     if (target.epoch !== computeEpochAtSlot(this.config, indexedAttestation.data.slot)) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_INVALID_ATTESTATION,
+        code: ForkChoiceErrorCode.INVALID_ATTESTATION,
         err: {
           code: InvalidAttestationCode.BAD_TARGET_EPOCH,
           target: target.epoch,
@@ -658,7 +658,7 @@ export class ForkChoice implements IForkChoice {
     // surface.
     if (!this.protoArray.hasBlock(toHexString(target.root))) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_INVALID_ATTESTATION,
+        code: ForkChoiceErrorCode.INVALID_ATTESTATION,
         err: {
           code: InvalidAttestationCode.UNKNOWN_TARGET_ROOT,
           root: target.root.valueOf() as Uint8Array,
@@ -677,7 +677,7 @@ export class ForkChoice implements IForkChoice {
     const block = this.protoArray.getBlock(toHexString(indexedAttestation.data.beaconBlockRoot));
     if (!block) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_INVALID_ATTESTATION,
+        code: ForkChoiceErrorCode.INVALID_ATTESTATION,
         err: {
           code: InvalidAttestationCode.UNKNOWN_HEAD_BLOCK,
           beaconBlockRoot: indexedAttestation.data.beaconBlockRoot.valueOf() as Uint8Array,
@@ -696,7 +696,7 @@ export class ForkChoice implements IForkChoice {
 
     if (!this.config.types.Root.equals(expectedTarget, target.root)) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_INVALID_ATTESTATION,
+        code: ForkChoiceErrorCode.INVALID_ATTESTATION,
         err: {
           code: InvalidAttestationCode.INVALID_TARGET,
           attestation: target.root.valueOf() as Uint8Array,
@@ -709,7 +709,7 @@ export class ForkChoice implements IForkChoice {
     // should not be considered.
     if (block.slot > indexedAttestation.data.slot) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_INVALID_ATTESTATION,
+        code: ForkChoiceErrorCode.INVALID_ATTESTATION,
         err: {
           code: InvalidAttestationCode.ATTESTS_TO_FUTURE_BLOCK,
           block: block.slot,
@@ -772,7 +772,7 @@ export class ForkChoice implements IForkChoice {
 
     if (time > previousSlot + 1) {
       throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.ERR_INCONSISTENT_ON_TICK,
+        code: ForkChoiceErrorCode.INCONSISTENT_ON_TICK,
         previousSlot,
         time,
       });

--- a/packages/lodestar-fork-choice/src/protoArray/computeDeltas.ts
+++ b/packages/lodestar-fork-choice/src/protoArray/computeDeltas.ts
@@ -47,7 +47,7 @@ export function computeDeltas(
       if (currentDeltaIndex !== undefined) {
         if (currentDeltaIndex >= deltas.length) {
           throw new ProtoArrayError({
-            code: ProtoArrayErrorCode.ERR_INVALID_NODE_DELTA,
+            code: ProtoArrayErrorCode.INVALID_NODE_DELTA,
             index: currentDeltaIndex,
           });
         }
@@ -59,7 +59,7 @@ export function computeDeltas(
       if (nextDeltaIndex !== undefined) {
         if (nextDeltaIndex >= deltas.length) {
           throw new ProtoArrayError({
-            code: ProtoArrayErrorCode.ERR_INVALID_NODE_DELTA,
+            code: ProtoArrayErrorCode.INVALID_NODE_DELTA,
             index: nextDeltaIndex,
           });
         }

--- a/packages/lodestar-fork-choice/src/protoArray/errors.ts
+++ b/packages/lodestar-fork-choice/src/protoArray/errors.ts
@@ -3,78 +3,38 @@ import {LodestarError} from "@chainsafe/lodestar-utils";
 import {HexRoot} from "./interface";
 
 export enum ProtoArrayErrorCode {
-  ERR_FINALIZED_NODE_UNKNOWN = "ERR_FINALIZED_NODE_UNKNOWN",
-  ERR_JUSTIFIED_NODE_UNKNOWN = "ERR_JUSTIFIED_NODE_UNKNOWN",
-  ERR_INVALID_FINALIZED_ROOT_CHANGE = "ERR_INVALID_FINALIZED_ROOT_CHANGE",
-  ERR_INVALID_NODE_INDEX = "ERR_INVALID_NODE_INDEX",
-  ERR_INVALID_PARENT_INDEX = "ERR_INVALID_PARENT_INDEX",
-  ERR_INVALID_BEST_CHILD_INDEX = "ERR_INVALID_BEST_CHILD_INDEX",
-  ERR_INVALID_JUSTIFIED_INDEX = "ERR_INVALID_JUSTIFIED_INDEX",
-  ERR_INVALID_BEST_DESCENDANT_INDEX = "ERR_INVALID_BEST_DESCENDANT_INDEX",
-  ERR_INVALID_PARENT_DELTA = "ERR_INVALID_PARENT_DELTA",
-  ERR_INVALID_NODE_DELTA = "ERR_INVALID_NODE_DELTA",
-  ERR_INDEX_OVERFLOW = "ERR_INDEX_OVERFLOW",
-  ERR_INVALID_DELTA_LEN = "ERR_INVALID_DELTA_LEN",
-  ERR_REVERTED_FINALIZED_EPOCH = "ERR_REVERTED_FINALIZED_EPOCH",
-  ERR_INVALID_BEST_NODE = "ERR_INVALID_BEST_NODE",
+  FINALIZED_NODE_UNKNOWN = "PROTO_ARRAY_ERROR_FINALIZED_NODE_UNKNOWN",
+  JUSTIFIED_NODE_UNKNOWN = "PROTO_ARRAY_ERROR_JUSTIFIED_NODE_UNKNOWN",
+  INVALID_FINALIZED_ROOT_CHANGE = "PROTO_ARRAY_ERROR_INVALID_FINALIZED_ROOT_CHANGE",
+  INVALID_NODE_INDEX = "PROTO_ARRAY_ERROR_INVALID_NODE_INDEX",
+  INVALID_PARENT_INDEX = "PROTO_ARRAY_ERROR_INVALID_PARENT_INDEX",
+  INVALID_BEST_CHILD_INDEX = "PROTO_ARRAY_ERROR_INVALID_BEST_CHILD_INDEX",
+  INVALID_JUSTIFIED_INDEX = "PROTO_ARRAY_ERROR_INVALID_JUSTIFIED_INDEX",
+  INVALID_BEST_DESCENDANT_INDEX = "PROTO_ARRAY_ERROR_INVALID_BEST_DESCENDANT_INDEX",
+  INVALID_PARENT_DELTA = "PROTO_ARRAY_ERROR_INVALID_PARENT_DELTA",
+  INVALID_NODE_DELTA = "PROTO_ARRAY_ERROR_INVALID_NODE_DELTA",
+  INDEX_OVERFLOW = "PROTO_ARRAY_ERROR_INDEX_OVERFLOW",
+  INVALID_DELTA_LEN = "PROTO_ARRAY_ERROR_INVALID_DELTA_LEN",
+  REVERTED_FINALIZED_EPOCH = "PROTO_ARRAY_ERROR_REVERTED_FINALIZED_EPOCH",
+  INVALID_BEST_NODE = "PROTO_ARRAY_ERROR_INVALID_BEST_NODE",
 }
 
 export type ProtoArrayErrorType =
+  | {code: ProtoArrayErrorCode.FINALIZED_NODE_UNKNOWN; root: HexRoot}
+  | {code: ProtoArrayErrorCode.JUSTIFIED_NODE_UNKNOWN; root: HexRoot}
+  | {code: ProtoArrayErrorCode.INVALID_FINALIZED_ROOT_CHANGE}
+  | {code: ProtoArrayErrorCode.INVALID_NODE_INDEX; index: number}
+  | {code: ProtoArrayErrorCode.INVALID_PARENT_INDEX; index: number}
+  | {code: ProtoArrayErrorCode.INVALID_BEST_CHILD_INDEX; index: number}
+  | {code: ProtoArrayErrorCode.INVALID_JUSTIFIED_INDEX; index: number}
+  | {code: ProtoArrayErrorCode.INVALID_BEST_DESCENDANT_INDEX; index: number}
+  | {code: ProtoArrayErrorCode.INVALID_PARENT_DELTA; index: number}
+  | {code: ProtoArrayErrorCode.INVALID_NODE_DELTA; index: number}
+  | {code: ProtoArrayErrorCode.INDEX_OVERFLOW; value: string}
+  | {code: ProtoArrayErrorCode.INVALID_DELTA_LEN; deltas: number; indices: number}
+  | {code: ProtoArrayErrorCode.REVERTED_FINALIZED_EPOCH; currentFinalizedEpoch: Epoch; newFinalizedEpoch: Epoch}
   | {
-      code: ProtoArrayErrorCode.ERR_FINALIZED_NODE_UNKNOWN;
-      root: HexRoot;
-    }
-  | {
-      code: ProtoArrayErrorCode.ERR_JUSTIFIED_NODE_UNKNOWN;
-      root: HexRoot;
-    }
-  | {
-      code: ProtoArrayErrorCode.ERR_INVALID_FINALIZED_ROOT_CHANGE;
-    }
-  | {
-      code: ProtoArrayErrorCode.ERR_INVALID_NODE_INDEX;
-      index: number;
-    }
-  | {
-      code: ProtoArrayErrorCode.ERR_INVALID_PARENT_INDEX;
-      index: number;
-    }
-  | {
-      code: ProtoArrayErrorCode.ERR_INVALID_BEST_CHILD_INDEX;
-      index: number;
-    }
-  | {
-      code: ProtoArrayErrorCode.ERR_INVALID_JUSTIFIED_INDEX;
-      index: number;
-    }
-  | {
-      code: ProtoArrayErrorCode.ERR_INVALID_BEST_DESCENDANT_INDEX;
-      index: number;
-    }
-  | {
-      code: ProtoArrayErrorCode.ERR_INVALID_PARENT_DELTA;
-      index: number;
-    }
-  | {
-      code: ProtoArrayErrorCode.ERR_INVALID_NODE_DELTA;
-      index: number;
-    }
-  | {
-      code: ProtoArrayErrorCode.ERR_INDEX_OVERFLOW;
-      value: string;
-    }
-  | {
-      code: ProtoArrayErrorCode.ERR_INVALID_DELTA_LEN;
-      deltas: number;
-      indices: number;
-    }
-  | {
-      code: ProtoArrayErrorCode.ERR_REVERTED_FINALIZED_EPOCH;
-      currentFinalizedEpoch: Epoch;
-      newFinalizedEpoch: Epoch;
-    }
-  | {
-      code: ProtoArrayErrorCode.ERR_INVALID_BEST_NODE;
+      code: ProtoArrayErrorCode.INVALID_BEST_NODE;
       startRoot: HexRoot;
       justifiedEpoch: Epoch;
       finalizedEpoch: Epoch;

--- a/packages/lodestar-fork-choice/src/protoArray/protoArray.ts
+++ b/packages/lodestar-fork-choice/src/protoArray/protoArray.ts
@@ -82,7 +82,7 @@ export class ProtoArray {
   applyScoreChanges(deltas: Gwei[], justifiedEpoch: Epoch, finalizedEpoch: Epoch): void {
     if (deltas.length !== this.indices.size) {
       throw new ProtoArrayError({
-        code: ProtoArrayErrorCode.ERR_INVALID_DELTA_LEN,
+        code: ProtoArrayErrorCode.INVALID_DELTA_LEN,
         deltas: deltas.length,
         indices: this.indices.size,
       });
@@ -98,7 +98,7 @@ export class ProtoArray {
       const node = this.nodes[nodeIndex];
       if (node === undefined) {
         throw new ProtoArrayError({
-          code: ProtoArrayErrorCode.ERR_INVALID_NODE_INDEX,
+          code: ProtoArrayErrorCode.INVALID_NODE_INDEX,
           index: nodeIndex,
         });
       }
@@ -113,7 +113,7 @@ export class ProtoArray {
       const nodeDelta = deltas[nodeIndex];
       if (nodeDelta === undefined) {
         throw new ProtoArrayError({
-          code: ProtoArrayErrorCode.ERR_INVALID_NODE_DELTA,
+          code: ProtoArrayErrorCode.INVALID_NODE_DELTA,
           index: nodeIndex,
         });
       }
@@ -127,7 +127,7 @@ export class ProtoArray {
         const parentDelta = deltas[parentIndex];
         if (parentDelta === undefined) {
           throw new ProtoArrayError({
-            code: ProtoArrayErrorCode.ERR_INVALID_PARENT_DELTA,
+            code: ProtoArrayErrorCode.INVALID_PARENT_DELTA,
             index: parentIndex,
           });
         }
@@ -181,7 +181,7 @@ export class ProtoArray {
     const justifiedIndex = this.indices.get(justifiedRoot);
     if (justifiedIndex === undefined) {
       throw new ProtoArrayError({
-        code: ProtoArrayErrorCode.ERR_JUSTIFIED_NODE_UNKNOWN,
+        code: ProtoArrayErrorCode.JUSTIFIED_NODE_UNKNOWN,
         root: justifiedRoot,
       });
     }
@@ -189,7 +189,7 @@ export class ProtoArray {
     const justifiedNode = this.nodes[justifiedIndex];
     if (justifiedNode === undefined) {
       throw new ProtoArrayError({
-        code: ProtoArrayErrorCode.ERR_INVALID_JUSTIFIED_INDEX,
+        code: ProtoArrayErrorCode.INVALID_JUSTIFIED_INDEX,
         index: justifiedIndex,
       });
     }
@@ -199,7 +199,7 @@ export class ProtoArray {
     const bestNode = this.nodes[bestDescendantIndex];
     if (bestNode === undefined) {
       throw new ProtoArrayError({
-        code: ProtoArrayErrorCode.ERR_INVALID_BEST_DESCENDANT_INDEX,
+        code: ProtoArrayErrorCode.INVALID_BEST_DESCENDANT_INDEX,
         index: bestDescendantIndex,
       });
     }
@@ -207,7 +207,7 @@ export class ProtoArray {
     // Perform a sanity check that the node is indeed valid to be the head
     if (!this.nodeIsViableForHead(bestNode)) {
       throw new ProtoArrayError({
-        code: ProtoArrayErrorCode.ERR_INVALID_BEST_NODE,
+        code: ProtoArrayErrorCode.INVALID_BEST_NODE,
         startRoot: justifiedRoot,
         justifiedEpoch: this.justifiedEpoch,
         finalizedEpoch: this.finalizedEpoch,
@@ -239,7 +239,7 @@ export class ProtoArray {
     const finalizedIndex = this.indices.get(finalizedRoot);
     if (finalizedIndex === undefined) {
       throw new ProtoArrayError({
-        code: ProtoArrayErrorCode.ERR_FINALIZED_NODE_UNKNOWN,
+        code: ProtoArrayErrorCode.FINALIZED_NODE_UNKNOWN,
         root: finalizedRoot,
       });
     }
@@ -254,7 +254,7 @@ export class ProtoArray {
       const node = this.nodes[nodeIndex];
       if (node === undefined) {
         throw new ProtoArrayError({
-          code: ProtoArrayErrorCode.ERR_INVALID_NODE_INDEX,
+          code: ProtoArrayErrorCode.INVALID_NODE_INDEX,
           index: nodeIndex,
         });
       }
@@ -270,7 +270,7 @@ export class ProtoArray {
     for (const [key, value] of this.indices.entries()) {
       if (value < finalizedIndex) {
         throw new ProtoArrayError({
-          code: ProtoArrayErrorCode.ERR_INDEX_OVERFLOW,
+          code: ProtoArrayErrorCode.INDEX_OVERFLOW,
           value: "indices",
         });
       }
@@ -288,7 +288,7 @@ export class ProtoArray {
       if (bestChild !== undefined) {
         if (bestChild < finalizedIndex) {
           throw new ProtoArrayError({
-            code: ProtoArrayErrorCode.ERR_INDEX_OVERFLOW,
+            code: ProtoArrayErrorCode.INDEX_OVERFLOW,
             value: "bestChild",
           });
         }
@@ -298,7 +298,7 @@ export class ProtoArray {
       if (bestDescendant !== undefined) {
         if (bestDescendant < finalizedIndex) {
           throw new ProtoArrayError({
-            code: ProtoArrayErrorCode.ERR_INDEX_OVERFLOW,
+            code: ProtoArrayErrorCode.INDEX_OVERFLOW,
             value: "bestDescendant",
           });
         }
@@ -326,7 +326,7 @@ export class ProtoArray {
     const childNode = this.nodes[childIndex];
     if (childNode === undefined) {
       throw new ProtoArrayError({
-        code: ProtoArrayErrorCode.ERR_INVALID_NODE_INDEX,
+        code: ProtoArrayErrorCode.INVALID_NODE_INDEX,
         index: childIndex,
       });
     }
@@ -334,7 +334,7 @@ export class ProtoArray {
     const parentNode = this.nodes[parentIndex];
     if (parentNode === undefined) {
       throw new ProtoArrayError({
-        code: ProtoArrayErrorCode.ERR_INVALID_NODE_INDEX,
+        code: ProtoArrayErrorCode.INVALID_NODE_INDEX,
         index: parentIndex,
       });
     }
@@ -365,7 +365,7 @@ export class ProtoArray {
         const bestChildNode = this.nodes[bestChildIndex];
         if (bestChildNode === undefined) {
           throw new ProtoArrayError({
-            code: ProtoArrayErrorCode.ERR_INVALID_BEST_CHILD_INDEX,
+            code: ProtoArrayErrorCode.INVALID_BEST_CHILD_INDEX,
             index: bestChildIndex,
           });
         }
@@ -417,7 +417,7 @@ export class ProtoArray {
       const bestDescendantNode = this.nodes[bestDescendantIndex];
       if (bestDescendantNode === undefined) {
         throw new ProtoArrayError({
-          code: ProtoArrayErrorCode.ERR_INVALID_BEST_DESCENDANT_INDEX,
+          code: ProtoArrayErrorCode.INVALID_BEST_DESCENDANT_INDEX,
           index: bestDescendantIndex,
         });
       }
@@ -456,7 +456,7 @@ export class ProtoArray {
     let node = this.nodes[startIndex];
     if (node === undefined) {
       throw new ProtoArrayError({
-        code: ProtoArrayErrorCode.ERR_INVALID_NODE_INDEX,
+        code: ProtoArrayErrorCode.INVALID_NODE_INDEX,
         index: startIndex,
       });
     }
@@ -466,7 +466,7 @@ export class ProtoArray {
       node = this.nodes[nodeParent];
       if (node === undefined) {
         throw new ProtoArrayError({
-          code: ProtoArrayErrorCode.ERR_INVALID_NODE_INDEX,
+          code: ProtoArrayErrorCode.INVALID_NODE_INDEX,
           index: nodeParent,
         });
       }
@@ -489,7 +489,7 @@ export class ProtoArray {
     let node = this.nodes[startIndex];
     if (node === undefined) {
       throw new ProtoArrayError({
-        code: ProtoArrayErrorCode.ERR_INVALID_NODE_INDEX,
+        code: ProtoArrayErrorCode.INVALID_NODE_INDEX,
         index: startIndex,
       });
     }
@@ -500,7 +500,7 @@ export class ProtoArray {
       node = this.nodes[parentIndex];
       if (node === undefined) {
         throw new ProtoArrayError({
-          code: ProtoArrayErrorCode.ERR_INVALID_NODE_INDEX,
+          code: ProtoArrayErrorCode.INVALID_NODE_INDEX,
           index: parentIndex,
         });
       }
@@ -541,7 +541,7 @@ export class ProtoArray {
       const node = this.nodes[index];
       if (node === undefined) {
         throw new ProtoArrayError({
-          code: ProtoArrayErrorCode.ERR_INVALID_NODE_INDEX,
+          code: ProtoArrayErrorCode.INVALID_NODE_INDEX,
           index,
         });
       }

--- a/packages/lodestar/src/api/impl/beacon/pool/pool.ts
+++ b/packages/lodestar/src/api/impl/beacon/pool/pool.ts
@@ -54,7 +54,7 @@ export class BeaconPoolApi implements IBeaconPoolApi {
       attestationPreStateContext = await this.chain.regen.getCheckpointState(attestation.data.target);
     } catch (e) {
       throw new AttestationError({
-        code: AttestationErrorCode.ERR_MISSING_ATTESTATION_PRESTATE,
+        code: AttestationErrorCode.MISSING_ATTESTATION_PRESTATE,
         job: attestationJob,
       });
     }

--- a/packages/lodestar/src/chain/attestation/process.ts
+++ b/packages/lodestar/src/chain/attestation/process.ts
@@ -31,7 +31,7 @@ export async function processAttestation({
     targetState = await regen.getCheckpointState(target);
   } catch (e) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_TARGET_STATE_MISSING,
+      code: AttestationErrorCode.TARGET_STATE_MISSING,
       job,
     });
   }
@@ -41,7 +41,7 @@ export async function processAttestation({
     indexedAttestation = targetState.epochCtx.getIndexedAttestation(attestation);
   } catch (e) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_NO_COMMITTEE_FOR_SLOT_AND_INDEX,
+      code: AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX,
       slot: attestation.data.slot,
       index: attestation.data.index,
       job,
@@ -52,7 +52,7 @@ export async function processAttestation({
   //we need to check this again, because gossip validation might put it in pool before it validated signature
   if (!isValidIndexedAttestation(targetState.epochCtx, targetState.state, indexedAttestation, true)) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_INVALID_SIGNATURE,
+      code: AttestationErrorCode.INVALID_SIGNATURE,
       job,
     });
   }

--- a/packages/lodestar/src/chain/attestation/validate.ts
+++ b/packages/lodestar/src/chain/attestation/validate.ts
@@ -30,14 +30,14 @@ export async function validateAttestation({
 
   if (target.epoch !== computeEpochAtSlot(config, attestation.data.slot)) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_BAD_TARGET_EPOCH,
+      code: AttestationErrorCode.BAD_TARGET_EPOCH,
       job,
     });
   }
 
   if (target.epoch < previousEpoch) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_PAST_EPOCH,
+      code: AttestationErrorCode.PAST_EPOCH,
       attestationEpoch: target.epoch,
       currentEpoch,
       job,
@@ -46,7 +46,7 @@ export async function validateAttestation({
 
   if (target.epoch > currentEpoch) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_FUTURE_EPOCH,
+      code: AttestationErrorCode.FUTURE_EPOCH,
       attestationEpoch: target.epoch,
       currentEpoch,
       job,
@@ -55,7 +55,7 @@ export async function validateAttestation({
 
   if (currentSlot - 1 < attestation.data.slot) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_FUTURE_SLOT,
+      code: AttestationErrorCode.FUTURE_SLOT,
       attestationSlot: attestation.data.slot,
       latestPermissibleSlot: currentSlot - 1,
       job,
@@ -64,7 +64,7 @@ export async function validateAttestation({
 
   if (!forkChoice.hasBlock(target.root)) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_UNKNOWN_TARGET_ROOT,
+      code: AttestationErrorCode.UNKNOWN_TARGET_ROOT,
       root: target.root.valueOf() as Uint8Array,
       job,
     });
@@ -72,7 +72,7 @@ export async function validateAttestation({
 
   if (!forkChoice.hasBlock(attestation.data.beaconBlockRoot)) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_UNKNOWN_BEACON_BLOCK_ROOT,
+      code: AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT,
       beaconBlockRoot: attestation.data.beaconBlockRoot.valueOf() as Uint8Array,
       job,
     });
@@ -80,7 +80,7 @@ export async function validateAttestation({
 
   if (!forkChoice.isDescendant(target.root, attestation.data.beaconBlockRoot)) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_HEAD_NOT_TARGET_DESCENDANT,
+      code: AttestationErrorCode.HEAD_NOT_TARGET_DESCENDANT,
       job,
     });
   }

--- a/packages/lodestar/src/chain/blocks/process.ts
+++ b/packages/lodestar/src/chain/blocks/process.ts
@@ -26,7 +26,7 @@ export async function processBlock({
   } catch (e) {
     if (e instanceof RegenError) {
       throw new BlockError({
-        code: BlockErrorCode.ERR_PRESTATE_MISSING,
+        code: BlockErrorCode.PRESTATE_MISSING,
         job,
       });
     }
@@ -36,7 +36,7 @@ export async function processBlock({
     }
 
     throw new BlockError({
-      code: BlockErrorCode.ERR_BEACON_CHAIN_ERROR,
+      code: BlockErrorCode.BEACON_CHAIN_ERROR,
       error: e,
       job,
     });

--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -151,7 +151,7 @@ export async function runStateTransition(
 
     if (!verifySignatureSetsBatch(signatureSets)) {
       throw new BlockError({
-        code: BlockErrorCode.ERR_INVALID_SIGNATURE,
+        code: BlockErrorCode.INVALID_SIGNATURE,
         job,
       });
     }

--- a/packages/lodestar/src/chain/blocks/validate.ts
+++ b/packages/lodestar/src/chain/blocks/validate.ts
@@ -22,14 +22,14 @@ export async function validateBlock({
     const blockSlot = job.signedBlock.message.slot;
     if (blockSlot === 0) {
       throw new BlockError({
-        code: BlockErrorCode.ERR_GENESIS_BLOCK,
+        code: BlockErrorCode.GENESIS_BLOCK,
         job,
       });
     }
 
     if (!job.reprocess && forkChoice.hasBlock(blockHash)) {
       throw new BlockError({
-        code: BlockErrorCode.ERR_BLOCK_IS_ALREADY_KNOWN,
+        code: BlockErrorCode.BLOCK_IS_ALREADY_KNOWN,
         job,
       });
     }
@@ -38,7 +38,7 @@ export async function validateBlock({
     const finalizedSlot = computeStartSlotAtEpoch(config, finalizedCheckpoint.epoch);
     if (blockSlot <= finalizedSlot) {
       throw new BlockError({
-        code: BlockErrorCode.ERR_WOULD_REVERT_FINALIZED_SLOT,
+        code: BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT,
         blockSlot,
         finalizedSlot,
         job,
@@ -48,7 +48,7 @@ export async function validateBlock({
     const currentSlot = clock.currentSlot;
     if (blockSlot > currentSlot) {
       throw new BlockError({
-        code: BlockErrorCode.ERR_FUTURE_SLOT,
+        code: BlockErrorCode.FUTURE_SLOT,
         blockSlot,
         currentSlot,
         job,
@@ -57,7 +57,7 @@ export async function validateBlock({
 
     if (!forkChoice.hasBlock(job.signedBlock.message.parentRoot)) {
       throw new BlockError({
-        code: BlockErrorCode.ERR_PARENT_UNKNOWN,
+        code: BlockErrorCode.PARENT_UNKNOWN,
         parentRoot: job.signedBlock.message.parentRoot.valueOf() as Uint8Array,
         job,
       });
@@ -68,7 +68,7 @@ export async function validateBlock({
     }
 
     throw new BlockError({
-      code: BlockErrorCode.ERR_BEACON_CHAIN_ERROR,
+      code: BlockErrorCode.BEACON_CHAIN_ERROR,
       error: e,
       job,
     });

--- a/packages/lodestar/src/chain/errors/attestationError.ts
+++ b/packages/lodestar/src/chain/errors/attestationError.ts
@@ -7,167 +7,164 @@ export enum AttestationErrorCode {
   /**
    * The target state cannot be fetched
    */
-  ERR_TARGET_STATE_MISSING = "ERR_TARGET_STATE_MISSING",
+  TARGET_STATE_MISSING = "ATTESTATION_ERROR_TARGET_STATE_MISSING",
   /**
    * The attestation is from a slot that is later than the current slot (with respect to the gossip clock disparity).
    */
-  ERR_FUTURE_SLOT = "ERR_FUTURE_SLOT",
+  FUTURE_SLOT = "ATTESTATION_ERROR_FUTURE_SLOT",
   /**
    * The attestation is from a slot that is prior to the earliest permissible slot
    * (with respect to the gossip clock disparity).
    */
-  ERR_PAST_SLOT = "ERR_PAST_SLOT",
+  PAST_SLOT = "ATTESTATION_ERROR_PAST_SLOT",
   /**
    * The attestations aggregation bits were empty when they shouldn't be.
    */
-  ERR_EMPTY_AGGREGATION_BITFIELD = "ERR_EMPTY_AGGREGATION_BITFIELD",
+  EMPTY_AGGREGATION_BITFIELD = "ATTESTATION_ERROR_EMPTY_AGGREGATION_BITFIELD",
   /**
    * The `selection_proof` on the aggregate attestation does not elect it as an aggregator.
    */
-  ERR_INVALID_SELECTION_PROOF = "ERR_INVALID_SELECTION_PROOF",
+  INVALID_SELECTION_PROOF = "ATTESTATION_ERROR_INVALID_SELECTION_PROOF",
   /**
    * The `selection_proof` on the aggregate attestation selects it as a validator,
    * however the aggregator index is not in the committee for that attestation.
    */
-  ERR_AGGREGATOR_NOT_IN_COMMITTEE = "ERR_AGGREGATOR_NOT_IN_COMMITTEE",
+  AGGREGATOR_NOT_IN_COMMITTEE = "ATTESTATION_ERROR_AGGREGATOR_NOT_IN_COMMITTEE",
   /**
    * The aggregator index refers to a validator index that we have not seen.
    */
-  ERR_AGGREGATOR_PUBKEY_UNKNOWN = "ERR_AGGREGATOR_PUBKEY_UNKNOWN",
+  AGGREGATOR_PUBKEY_UNKNOWN = "ATTESTATION_ERROR_AGGREGATOR_PUBKEY_UNKNOWN",
   /**
    * The attestation has been seen before; either in a block, on the gossip network or from a local validator.
    */
-  ERR_ATTESTATION_ALREADY_KNOWN = "ERR_ATTESTATION_ALREADY_KNOWN",
+  ATTESTATION_ALREADY_KNOWN = "ATTESTATION_ERROR_ATTESTATION_ALREADY_KNOWN",
   /**
    * There has already been an aggregation observed for this validator, we refuse to process a second.
    */
-  ERR_AGGREGATE_ALREADY_KNOWN = "ERR_AGGREGATE_ALREADY_KNOWN",
+  AGGREGATE_ALREADY_KNOWN = "ATTESTATION_ERROR_AGGREGATE_ALREADY_KNOWN",
   /**
    * The aggregator index is higher than the maximum possible validator count.
    */
-  ERR_AGGREGATOR_INDEX_TOO_HIGH = "ERR_AGGREGATOR_INDEX_TOO_HIGH",
+  AGGREGATOR_INDEX_TOO_HIGH = "ATTESTATION_ERROR_AGGREGATOR_INDEX_TOO_HIGH",
   /**
    * The `attestation.data.beacon_block_root` block is unknown.
    */
-  ERR_UNKNOWN_BEACON_BLOCK_ROOT = "ERR_UNKNOWN_BEACON_BLOCK_ROOT",
+  UNKNOWN_BEACON_BLOCK_ROOT = "ATTESTATION_ERROR_UNKNOWN_BEACON_BLOCK_ROOT",
   /**
    * The `attestation.data.slot` is not from the same epoch as `data.target.epoch`.
    */
-  ERR_BAD_TARGET_EPOCH = "ERR_BAD_TARGET_EPOCH",
+  BAD_TARGET_EPOCH = "ATTESTATION_ERROR_BAD_TARGET_EPOCH",
   /**
    * The `attestation.data.beaconBlockRoot` is not a descendant of `data.target.root`.
    */
-  ERR_HEAD_NOT_TARGET_DESCENDANT = "ERR_HEAD_NOT_TARGET_DESCENDANT",
+  HEAD_NOT_TARGET_DESCENDANT = "ATTESTATION_ERROR_HEAD_NOT_TARGET_DESCENDANT",
   /**
    * The target root of the attestation points to a block that we have not verified.
    */
-  ERR_UNKNOWN_TARGET_ROOT = "ERR_UNKNOWN_TARGET_ROOT",
+  UNKNOWN_TARGET_ROOT = "ATTESTATION_ERROR_UNKNOWN_TARGET_ROOT",
   /**
    * A signature on the attestation is invalid.
    */
-  ERR_INVALID_SIGNATURE = "ERR_INVALID_SIGNATURE",
+  INVALID_SIGNATURE = "ATTESTATION_ERROR_INVALID_SIGNATURE",
   /**
    * There is no committee for the slot and committee index of this attestation
    * and the attestation should not have been produced.
    */
-  ERR_NO_COMMITTEE_FOR_SLOT_AND_INDEX = "ERR_NO_COMMITTEE_FOR_SLOT_AND_INDEX",
+  NO_COMMITTEE_FOR_SLOT_AND_INDEX = "ATTESTATION_ERROR_NO_COMMITTEE_FOR_SLOT_AND_INDEX",
   /**
    * The unaggregated attestation doesn't have only one aggregation bit set.
    */
-  ERR_NOT_EXACTLY_ONE_AGGREGATION_BIT_SET = "ERR_NOT_EXACTLY_ONE_AGGREGATION_BIT_SET",
+  NOT_EXACTLY_ONE_AGGREGATION_BIT_SET = "ATTESTATION_ERROR_NOT_EXACTLY_ONE_AGGREGATION_BIT_SET",
   /**
    * We have already observed an attestation for the `validator_index` and refuse to process another.
    */
-  ERR_PRIOR_ATTESTATION_KNOWN = "ERR_PRIOR_ATTESTATION_KNOWN",
+  PRIOR_ATTESTATION_KNOWN = "ATTESTATION_ERROR_PRIOR_ATTESTATION_KNOWN",
   /**
    * The attestation is for an epoch in the future (with respect to the gossip clock disparity).
    */
-  ERR_FUTURE_EPOCH = "ERR_FUTURE_EPOCH",
+  FUTURE_EPOCH = "ATTESTATION_ERROR_FUTURE_EPOCH",
   /**
    * The attestation is for an epoch in the past (with respect to the gossip clock disparity).
    */
-  ERR_PAST_EPOCH = "ERR_PAST_EPOCH",
+  PAST_EPOCH = "ATTESTATION_ERROR_PAST_EPOCH",
   /**
    * The attestation is attesting to a state that is later than itself. (Viz., attesting to the future).
    */
-  ERR_ATTESTS_TO_FUTURE_BLOCK = "ERR_ATTESTS_TO_FUTURE_BLOCK",
+  ATTESTS_TO_FUTURE_BLOCK = "ATTESTATION_ERROR_ATTESTS_TO_FUTURE_BLOCK",
   /**
    * The attestation was received on an invalid attestation subnet.
    */
-  ERR_INVALID_SUBNET_ID = "ERR_INVALID_SUBNET_ID",
+  INVALID_SUBNET_ID = "ATTESTATION_ERROR_INVALID_SUBNET_ID",
   /**
    * The attestation failed the `state_processing` verification stage.
    */
-  ERR_INVALID = "ERR_INVALID",
+  INVALID = "ATTESTATION_ERROR_INVALID",
   /**
    * There was an error whilst processing the attestation. It is not known if it is valid or invalid.
    */
-  ERR_BEACON_CHAIN_ERROR = "ERR_BEACON_CHAIN_ERROR",
+  BEACON_CHAIN_ERROR = "ATTESTATION_ERROR_BEACON_CHAIN_ERROR",
   /**
    * Number of aggregation bits does not match committee size
    */
-  ERR_WRONG_NUMBER_OF_AGGREGATION_BITS = "ERR_WRONG_NUMBER_OF_AGGREGATION_BITS",
+  WRONG_NUMBER_OF_AGGREGATION_BITS = "ATTESTATION_ERROR_WRONG_NUMBER_OF_AGGREGATION_BITS",
   /**
    * Block did not pass validation during block processing.
    */
-  ERR_KNOWN_BAD_BLOCK = "ERR_KNOWN_BAD_BLOCK",
+  KNOWN_BAD_BLOCK = "ATTESTATION_ERROR_KNOWN_BAD_BLOCK",
   /**
    * The current finalized checkpoint is not an ancestor of the block defined by attestation.data.beacon_block_root.
    */
-  ERR_FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT = "ERR_FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT",
+  FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT = "ATTESTATION_ERROR_FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT",
   /**
    * The The attestation target block is not an ancestor of the block named in the LMD vote.
    */
-  ERR_TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK = "ERR_TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK",
+  TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK = "ATTESTATION_ERROR_TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK",
   /**
    * Committee index out of range.
    */
-  ERR_COMMITTEE_INDEX_OUT_OF_RANGE = "ERR_COMMITTEE_INDEX_OUT_OF_RANGE",
+  COMMITTEE_INDEX_OUT_OF_RANGE = "ATTESTATION_ERROR_COMMITTEE_INDEX_OUT_OF_RANGE",
   /**
    * Missing attestation pre-state.
    */
-  ERR_MISSING_ATTESTATION_PRESTATE = "ERR_MISSING_ATTESTATION_PRESTATE",
+  MISSING_ATTESTATION_PRESTATE = "ATTESTATION_ERROR_MISSING_ATTESTATION_PRESTATE",
   /**
    * Invalid aggregator.
    */
-  ERR_INVALID_AGGREGATOR = "ERR_INVALID_AGGREGATOR",
+  INVALID_AGGREGATOR = "ATTESTATION_ERROR_INVALID_AGGREGATOR",
 }
 
 export type AttestationErrorType =
-  | {code: AttestationErrorCode.ERR_TARGET_STATE_MISSING}
-  | {code: AttestationErrorCode.ERR_FUTURE_SLOT; attestationSlot: Slot; latestPermissibleSlot: Slot}
-  | {code: AttestationErrorCode.ERR_PAST_SLOT; attestationSlot: Slot; earliestPermissibleSlot: Slot}
-  | {code: AttestationErrorCode.ERR_EMPTY_AGGREGATION_BITFIELD}
-  | {code: AttestationErrorCode.ERR_INVALID_SELECTION_PROOF}
-  | {code: AttestationErrorCode.ERR_AGGREGATOR_NOT_IN_COMMITTEE}
-  | {
-      code: AttestationErrorCode.ERR_AGGREGATOR_PUBKEY_UNKNOWN;
-      aggregatorIndex: ValidatorIndex;
-    }
-  | {code: AttestationErrorCode.ERR_ATTESTATION_ALREADY_KNOWN; root: Uint8Array}
-  | {code: AttestationErrorCode.ERR_AGGREGATE_ALREADY_KNOWN}
-  | {code: AttestationErrorCode.ERR_AGGREGATOR_INDEX_TOO_HIGH; aggregatorIndex: ValidatorIndex}
-  | {code: AttestationErrorCode.ERR_UNKNOWN_BEACON_BLOCK_ROOT; beaconBlockRoot: Uint8Array}
-  | {code: AttestationErrorCode.ERR_BAD_TARGET_EPOCH}
-  | {code: AttestationErrorCode.ERR_HEAD_NOT_TARGET_DESCENDANT}
-  | {code: AttestationErrorCode.ERR_UNKNOWN_TARGET_ROOT; root: Uint8Array}
-  | {code: AttestationErrorCode.ERR_INVALID_SIGNATURE}
-  | {code: AttestationErrorCode.ERR_NO_COMMITTEE_FOR_SLOT_AND_INDEX; slot: Slot; index: CommitteeIndex}
-  | {code: AttestationErrorCode.ERR_NOT_EXACTLY_ONE_AGGREGATION_BIT_SET; numBits: number}
-  | {code: AttestationErrorCode.ERR_PRIOR_ATTESTATION_KNOWN; validatorIndex: ValidatorIndex; epoch: Epoch}
-  | {code: AttestationErrorCode.ERR_FUTURE_EPOCH; attestationEpoch: Epoch; currentEpoch: Epoch}
-  | {code: AttestationErrorCode.ERR_PAST_EPOCH; attestationEpoch: Epoch; currentEpoch: Epoch}
-  | {code: AttestationErrorCode.ERR_ATTESTS_TO_FUTURE_BLOCK; block: Slot; attestation: Slot}
-  | {code: AttestationErrorCode.ERR_INVALID_SUBNET_ID; received: number; expected: number}
-  | {code: AttestationErrorCode.ERR_INVALID; error: Error}
-  | {code: AttestationErrorCode.ERR_BEACON_CHAIN_ERROR; error: Error}
-  | {code: AttestationErrorCode.ERR_WRONG_NUMBER_OF_AGGREGATION_BITS}
-  | {code: AttestationErrorCode.ERR_KNOWN_BAD_BLOCK}
-  | {code: AttestationErrorCode.ERR_FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT}
-  | {code: AttestationErrorCode.ERR_TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK}
-  | {code: AttestationErrorCode.ERR_COMMITTEE_INDEX_OUT_OF_RANGE; index: number}
-  | {code: AttestationErrorCode.ERR_MISSING_ATTESTATION_PRESTATE}
-  | {code: AttestationErrorCode.ERR_INVALID_AGGREGATOR};
+  | {code: AttestationErrorCode.TARGET_STATE_MISSING}
+  | {code: AttestationErrorCode.FUTURE_SLOT; attestationSlot: Slot; latestPermissibleSlot: Slot}
+  | {code: AttestationErrorCode.PAST_SLOT; attestationSlot: Slot; earliestPermissibleSlot: Slot}
+  | {code: AttestationErrorCode.EMPTY_AGGREGATION_BITFIELD}
+  | {code: AttestationErrorCode.INVALID_SELECTION_PROOF}
+  | {code: AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE}
+  | {code: AttestationErrorCode.AGGREGATOR_PUBKEY_UNKNOWN; aggregatorIndex: ValidatorIndex}
+  | {code: AttestationErrorCode.ATTESTATION_ALREADY_KNOWN; root: Uint8Array}
+  | {code: AttestationErrorCode.AGGREGATE_ALREADY_KNOWN}
+  | {code: AttestationErrorCode.AGGREGATOR_INDEX_TOO_HIGH; aggregatorIndex: ValidatorIndex}
+  | {code: AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT; beaconBlockRoot: Uint8Array}
+  | {code: AttestationErrorCode.BAD_TARGET_EPOCH}
+  | {code: AttestationErrorCode.HEAD_NOT_TARGET_DESCENDANT}
+  | {code: AttestationErrorCode.UNKNOWN_TARGET_ROOT; root: Uint8Array}
+  | {code: AttestationErrorCode.INVALID_SIGNATURE}
+  | {code: AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX; slot: Slot; index: CommitteeIndex}
+  | {code: AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET; numBits: number}
+  | {code: AttestationErrorCode.PRIOR_ATTESTATION_KNOWN; validatorIndex: ValidatorIndex; epoch: Epoch}
+  | {code: AttestationErrorCode.FUTURE_EPOCH; attestationEpoch: Epoch; currentEpoch: Epoch}
+  | {code: AttestationErrorCode.PAST_EPOCH; attestationEpoch: Epoch; currentEpoch: Epoch}
+  | {code: AttestationErrorCode.ATTESTS_TO_FUTURE_BLOCK; block: Slot; attestation: Slot}
+  | {code: AttestationErrorCode.INVALID_SUBNET_ID; received: number; expected: number}
+  | {code: AttestationErrorCode.INVALID; error: Error}
+  | {code: AttestationErrorCode.BEACON_CHAIN_ERROR; error: Error}
+  | {code: AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS}
+  | {code: AttestationErrorCode.KNOWN_BAD_BLOCK}
+  | {code: AttestationErrorCode.FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT}
+  | {code: AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK}
+  | {code: AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE; index: number}
+  | {code: AttestationErrorCode.MISSING_ATTESTATION_PRESTATE}
+  | {code: AttestationErrorCode.INVALID_AGGREGATOR};
 
 type IJobObject = {
   job: IAttestationJob;

--- a/packages/lodestar/src/chain/errors/attesterSlashingError.ts
+++ b/packages/lodestar/src/chain/errors/attesterSlashingError.ts
@@ -1,12 +1,12 @@
 import {LodestarError} from "@chainsafe/lodestar-utils";
 
 export enum AttesterSlashingErrorCode {
-  ERR_SLASHING_ALREADY_EXISTS = "ERR_SLASHING_ALREADY_EXISTS",
-  ERR_INVALID_SLASHING = "ERR_INVALID_SLASHING",
+  SLASHING_ALREADY_EXISTS = "ATTESTATION_SLASHING_ERROR_SLASHING_ALREADY_EXISTS",
+  INVALID_SLASHING = "ATTESTATION_SLASHING_ERROR_INVALID_SLASHING",
 }
 export type AttesterSlashingErrorType =
-  | {code: AttesterSlashingErrorCode.ERR_SLASHING_ALREADY_EXISTS}
-  | {code: AttesterSlashingErrorCode.ERR_INVALID_SLASHING};
+  | {code: AttesterSlashingErrorCode.SLASHING_ALREADY_EXISTS}
+  | {code: AttesterSlashingErrorCode.INVALID_SLASHING};
 
 export class AttesterSlashingError extends LodestarError<AttesterSlashingErrorType> {
   constructor(type: AttesterSlashingErrorType) {

--- a/packages/lodestar/src/chain/errors/blockError.ts
+++ b/packages/lodestar/src/chain/errors/blockError.ts
@@ -7,102 +7,102 @@ export enum BlockErrorCode {
   /**
    * The prestate cannot be fetched
    */
-  ERR_PRESTATE_MISSING = "ERR_PRESTATE_MISSING",
+  PRESTATE_MISSING = "BLOCK_ERROR_PRESTATE_MISSING",
   /**
    * The parent block was unknown.
    */
-  ERR_PARENT_UNKNOWN = "ERR_PARENT_UNKNOWN",
+  PARENT_UNKNOWN = "BLOCK_ERROR_PARENT_UNKNOWN",
   /**
    * The block slot is greater than the present slot.
    */
-  ERR_FUTURE_SLOT = "ERR_FUTURE_SLOT",
+  FUTURE_SLOT = "BLOCK_ERROR_FUTURE_SLOT",
   /**
    * The block state_root does not match the generated state.
    */
-  ERR_STATE_ROOT_MISMATCH = "ERR_STATE_ROOT_MISMATCH",
+  STATE_ROOT_MISMATCH = "BLOCK_ERROR_STATE_ROOT_MISMATCH",
   /**
    * The block was a genesis block, these blocks cannot be re-imported.
    */
-  ERR_GENESIS_BLOCK = "ERR_GENESIS_BLOCK",
+  GENESIS_BLOCK = "BLOCK_ERROR_GENESIS_BLOCK",
   /**
    * The slot is finalized, no need to import.
    */
-  ERR_WOULD_REVERT_FINALIZED_SLOT = "ERR_WOULD_REVERT_FINALIZED_SLOT",
+  WOULD_REVERT_FINALIZED_SLOT = "BLOCK_ERROR_WOULD_REVERT_FINALIZED_SLOT",
   /**
    * Block is already known, no need to re-import.
    */
-  ERR_BLOCK_IS_ALREADY_KNOWN = "ERR_BLOCK_IS_ALREADY_KNOWN",
+  BLOCK_IS_ALREADY_KNOWN = "BLOCK_ERROR_BLOCK_IS_ALREADY_KNOWN",
   /**
    * A block for this proposer and slot has already been observed.
    */
-  ERR_REPEAT_PROPOSAL = "ERR_REPEAT_PROPOSAL",
+  REPEAT_PROPOSAL = "BLOCK_ERROR_REPEAT_PROPOSAL",
   /**
    * The block slot exceeds the MAXIMUM_BLOCK_SLOT_NUMBER.
    */
-  ERR_BLOCK_SLOT_LIMIT_REACHED = "ERR_BLOCK_SLOT_LIMIT_REACHED",
+  BLOCK_SLOT_LIMIT_REACHED = "BLOCK_ERROR_BLOCK_SLOT_LIMIT_REACHED",
   /**
    * The `BeaconBlock` has a `proposer_index` that does not match the index we computed locally.
    */
-  ERR_INCORRECT_PROPOSER = "ERR_INCORRECT_PROPOSER",
+  INCORRECT_PROPOSER = "BLOCK_ERROR_INCORRECT_PROPOSER",
   /**
    * The proposal signature in invalid.
    */
-  ERR_PROPOSAL_SIGNATURE_INVALID = "ERR_PROPOSAL_SIGNATURE_INVALID",
+  PROPOSAL_SIGNATURE_INVALID = "BLOCK_ERROR_PROPOSAL_SIGNATURE_INVALID",
   /**
    * The `block.proposer_index` is not known.
    */
-  ERR_UNKNOWN_PROPOSER = "ERR_UNKNOWN_PROPOSER",
+  UNKNOWN_PROPOSER = "BLOCK_ERROR_UNKNOWN_PROPOSER",
   /**
    * A signature in the block is invalid (exactly which is unknown).
    */
-  ERR_INVALID_SIGNATURE = "ERR_INVALID_SIGNATURE",
+  INVALID_SIGNATURE = "BLOCK_ERROR_INVALID_SIGNATURE",
   /**
    * The provided block is from an later slot than its parent.
    */
-  ERR_BLOCK_IS_NOT_LATER_THAN_PARENT = "ERR_BLOCK_IS_NOT_LATER_THAN_PARENT",
+  BLOCK_IS_NOT_LATER_THAN_PARENT = "BLOCK_ERROR_BLOCK_IS_NOT_LATER_THAN_PARENT",
   /**
    * At least one block in the chain segment did not have it's parent root set to the root of the prior block.
    */
-  ERR_NON_LINEAR_PARENT_ROOTS = "ERR_NON_LINEAR_PARENT_ROOTS",
+  NON_LINEAR_PARENT_ROOTS = "BLOCK_ERROR_NON_LINEAR_PARENT_ROOTS",
   /**
    * The slots of the blocks in the chain segment were not strictly increasing.
    * I.e., a child had lower slot than a parent.
    */
-  ERR_NON_LINEAR_SLOTS = "ERR_NON_LINEAR_SLOTS",
+  NON_LINEAR_SLOTS = "BLOCK_ERROR_NON_LINEAR_SLOTS",
   /**
    * The block failed the specification's `per_block_processing` function, it is invalid.
    */
-  ERR_PER_BLOCK_PROCESSING_ERROR = "ERR_PER_BLOCK_PROCESSING_ERROR",
+  PER_BLOCK_PROCESSING_ERROR = "BLOCK_ERROR_PER_BLOCK_PROCESSING_ERROR",
   /**
    * There was an error whilst processing the block. It is not necessarily invalid.
    */
-  ERR_BEACON_CHAIN_ERROR = "ERR_BEACON_CHAIN_ERROR",
+  BEACON_CHAIN_ERROR = "BLOCK_ERROR_BEACON_CHAIN_ERROR",
   /**
    * Block did not pass validation during block processing.
    */
-  ERR_KNOWN_BAD_BLOCK = "ERR_KNOWN_BAD_BLOCK",
+  KNOWN_BAD_BLOCK = "BLOCK_ERROR_KNOWN_BAD_BLOCK",
 }
 
 export type BlockErrorType =
-  | {code: BlockErrorCode.ERR_PRESTATE_MISSING}
-  | {code: BlockErrorCode.ERR_PARENT_UNKNOWN; parentRoot: Root}
-  | {code: BlockErrorCode.ERR_FUTURE_SLOT; blockSlot: Slot; currentSlot: Slot}
-  | {code: BlockErrorCode.ERR_STATE_ROOT_MISMATCH}
-  | {code: BlockErrorCode.ERR_GENESIS_BLOCK}
-  | {code: BlockErrorCode.ERR_WOULD_REVERT_FINALIZED_SLOT; blockSlot: Slot; finalizedSlot: Slot}
-  | {code: BlockErrorCode.ERR_BLOCK_IS_ALREADY_KNOWN}
-  | {code: BlockErrorCode.ERR_REPEAT_PROPOSAL; proposer: ValidatorIndex}
-  | {code: BlockErrorCode.ERR_BLOCK_SLOT_LIMIT_REACHED}
-  | {code: BlockErrorCode.ERR_INCORRECT_PROPOSER; blockProposer: ValidatorIndex}
-  | {code: BlockErrorCode.ERR_PROPOSAL_SIGNATURE_INVALID}
-  | {code: BlockErrorCode.ERR_UNKNOWN_PROPOSER; proposer: ValidatorIndex}
-  | {code: BlockErrorCode.ERR_INVALID_SIGNATURE}
-  | {code: BlockErrorCode.ERR_BLOCK_IS_NOT_LATER_THAN_PARENT; blockSlot: Slot; stateSlot: Slot}
-  | {code: BlockErrorCode.ERR_NON_LINEAR_PARENT_ROOTS}
-  | {code: BlockErrorCode.ERR_NON_LINEAR_SLOTS}
-  | {code: BlockErrorCode.ERR_PER_BLOCK_PROCESSING_ERROR; error: Error}
-  | {code: BlockErrorCode.ERR_BEACON_CHAIN_ERROR; error: Error}
-  | {code: BlockErrorCode.ERR_KNOWN_BAD_BLOCK};
+  | {code: BlockErrorCode.PRESTATE_MISSING}
+  | {code: BlockErrorCode.PARENT_UNKNOWN; parentRoot: Root}
+  | {code: BlockErrorCode.FUTURE_SLOT; blockSlot: Slot; currentSlot: Slot}
+  | {code: BlockErrorCode.STATE_ROOT_MISMATCH}
+  | {code: BlockErrorCode.GENESIS_BLOCK}
+  | {code: BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT; blockSlot: Slot; finalizedSlot: Slot}
+  | {code: BlockErrorCode.BLOCK_IS_ALREADY_KNOWN}
+  | {code: BlockErrorCode.REPEAT_PROPOSAL; proposer: ValidatorIndex}
+  | {code: BlockErrorCode.BLOCK_SLOT_LIMIT_REACHED}
+  | {code: BlockErrorCode.INCORRECT_PROPOSER; blockProposer: ValidatorIndex}
+  | {code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID}
+  | {code: BlockErrorCode.UNKNOWN_PROPOSER; proposer: ValidatorIndex}
+  | {code: BlockErrorCode.INVALID_SIGNATURE}
+  | {code: BlockErrorCode.BLOCK_IS_NOT_LATER_THAN_PARENT; blockSlot: Slot; stateSlot: Slot}
+  | {code: BlockErrorCode.NON_LINEAR_PARENT_ROOTS}
+  | {code: BlockErrorCode.NON_LINEAR_SLOTS}
+  | {code: BlockErrorCode.PER_BLOCK_PROCESSING_ERROR; error: Error}
+  | {code: BlockErrorCode.BEACON_CHAIN_ERROR; error: Error}
+  | {code: BlockErrorCode.KNOWN_BAD_BLOCK};
 
 type JobObject = {
   job: IBlockJob;

--- a/packages/lodestar/src/chain/errors/proposerSlahingError.ts
+++ b/packages/lodestar/src/chain/errors/proposerSlahingError.ts
@@ -1,12 +1,12 @@
 import {LodestarError} from "@chainsafe/lodestar-utils";
 
 export enum ProposerSlashingErrorCode {
-  ERR_SLASHING_ALREADY_EXISTS = "ERR_SLASHING_ALREADY_EXISTS",
-  ERR_INVALID_SLASHING = "ERR_INVALID_SLASHING",
+  SLASHING_ALREADY_EXISTS = "PROPOSER_SLASHING_ERROR_SLASHING_ALREADY_EXISTS",
+  INVALID_SLASHING = "PROPOSER_SLASHING_ERROR_INVALID_SLASHING",
 }
 export type ProposerSlashingErrorType =
-  | {code: ProposerSlashingErrorCode.ERR_SLASHING_ALREADY_EXISTS}
-  | {code: ProposerSlashingErrorCode.ERR_INVALID_SLASHING};
+  | {code: ProposerSlashingErrorCode.SLASHING_ALREADY_EXISTS}
+  | {code: ProposerSlashingErrorCode.INVALID_SLASHING};
 
 export class ProposerSlashingError extends LodestarError<ProposerSlashingErrorType> {
   constructor(type: ProposerSlashingErrorType) {

--- a/packages/lodestar/src/chain/errors/voluntaryExitError.ts
+++ b/packages/lodestar/src/chain/errors/voluntaryExitError.ts
@@ -1,12 +1,12 @@
 import {LodestarError} from "@chainsafe/lodestar-utils";
 
 export enum VoluntaryExitErrorCode {
-  ERR_EXIT_ALREADY_EXISTS = "ERR_EXIT_ALREADY_EXISTS",
-  ERR_INVALID_EXIT = "ERR_INVALID_EXIT",
+  EXIT_ALREADY_EXISTS = "VOLUNTARY_EXIT_ERROR_EXIT_ALREADY_EXISTS",
+  INVALID_EXIT = "VOLUNTARY_EXIT_ERROR_INVALID_EXIT",
 }
 export type VoluntaryExitErrorType =
-  | {code: VoluntaryExitErrorCode.ERR_EXIT_ALREADY_EXISTS}
-  | {code: VoluntaryExitErrorCode.ERR_INVALID_EXIT};
+  | {code: VoluntaryExitErrorCode.EXIT_ALREADY_EXISTS}
+  | {code: VoluntaryExitErrorCode.INVALID_EXIT};
 
 export class VoluntaryExitError extends LodestarError<VoluntaryExitErrorType> {
   constructor(type: VoluntaryExitErrorType) {

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -278,7 +278,7 @@ export async function onErrorAttestation(this: BeaconChain, err: AttestationErro
   const attestationRoot = this.config.types.Attestation.hashTreeRoot(err.job.attestation);
 
   switch (err.type.code) {
-    case AttestationErrorCode.ERR_FUTURE_SLOT:
+    case AttestationErrorCode.FUTURE_SLOT:
       this.logger.debug("Add attestation to pool", {
         reason: err.type.code,
         attestationRoot: toHexString(attestationRoot),
@@ -286,7 +286,7 @@ export async function onErrorAttestation(this: BeaconChain, err: AttestationErro
       this.pendingAttestations.putBySlot(err.type.attestationSlot, err.job);
       break;
 
-    case AttestationErrorCode.ERR_UNKNOWN_TARGET_ROOT:
+    case AttestationErrorCode.UNKNOWN_TARGET_ROOT:
       this.logger.debug("Add attestation to pool", {
         reason: err.type.code,
         attestationRoot: toHexString(attestationRoot),
@@ -294,7 +294,7 @@ export async function onErrorAttestation(this: BeaconChain, err: AttestationErro
       this.pendingAttestations.putByBlock(err.type.root, err.job);
       break;
 
-    case AttestationErrorCode.ERR_UNKNOWN_BEACON_BLOCK_ROOT:
+    case AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT:
       this.pendingAttestations.putByBlock(err.type.beaconBlockRoot, err.job);
       break;
 
@@ -313,7 +313,7 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
   const blockRoot = this.config.types.BeaconBlock.hashTreeRoot(err.job.signedBlock.message);
 
   switch (err.type.code) {
-    case BlockErrorCode.ERR_FUTURE_SLOT:
+    case BlockErrorCode.FUTURE_SLOT:
       this.logger.debug("Add block to pool", {
         reason: err.type.code,
         blockRoot: toHexString(blockRoot),
@@ -322,7 +322,7 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
       this.pendingBlocks.addBySlot(err.job.signedBlock);
       break;
 
-    case BlockErrorCode.ERR_PARENT_UNKNOWN:
+    case BlockErrorCode.PARENT_UNKNOWN:
       this.logger.debug("Add block to pool", {
         reason: err.type.code,
         blockRoot: toHexString(blockRoot),
@@ -333,12 +333,12 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
       await this.db.pendingBlock.add(err.job.signedBlock);
       break;
 
-    case BlockErrorCode.ERR_INCORRECT_PROPOSER:
-    case BlockErrorCode.ERR_REPEAT_PROPOSAL:
-    case BlockErrorCode.ERR_STATE_ROOT_MISMATCH:
-    case BlockErrorCode.ERR_PER_BLOCK_PROCESSING_ERROR:
-    case BlockErrorCode.ERR_BLOCK_IS_NOT_LATER_THAN_PARENT:
-    case BlockErrorCode.ERR_UNKNOWN_PROPOSER:
+    case BlockErrorCode.INCORRECT_PROPOSER:
+    case BlockErrorCode.REPEAT_PROPOSAL:
+    case BlockErrorCode.STATE_ROOT_MISMATCH:
+    case BlockErrorCode.PER_BLOCK_PROCESSING_ERROR:
+    case BlockErrorCode.BLOCK_IS_NOT_LATER_THAN_PARENT:
+    case BlockErrorCode.UNKNOWN_PROPOSER:
       await this.db.badBlock.put(blockRoot);
       this.logger.warn("Found bad block", {blockRoot: toHexString(blockRoot)}, err);
       break;

--- a/packages/lodestar/src/chain/regen/errors.ts
+++ b/packages/lodestar/src/chain/regen/errors.ts
@@ -1,23 +1,23 @@
 import {Root, Slot} from "@chainsafe/lodestar-types";
 
 export enum RegenErrorCode {
-  ERR_BLOCK_NOT_IN_FORKCHOICE = "ERR_BLOCK_NOT_IN_FORKCHOICE",
-  ERR_STATE_NOT_IN_FORKCHOICE = "ERR_STATE_NOT_IN_FORKCHOICE",
-  ERR_SLOT_BEFORE_BLOCK_SLOT = "ERR_SLOT_BEFORE_BLOCK_SLOT",
-  ERR_NO_SEED_STATE = "ERR_NO_SEED_STATE",
-  ERR_TOO_MANY_BLOCK_PROCESSED = "ERR_TOO_MANY_BLOCK_PROCESSED",
-  ERR_BLOCK_NOT_IN_DB = "ERR_BLOCK_NOT_IN_DB",
-  ERR_STATE_TRANSITION_ERROR = "ERR_STATE_TRANSITION_ERROR",
+  BLOCK_NOT_IN_FORKCHOICE = "REGEN_ERROR_BLOCK_NOT_IN_FORKCHOICE",
+  STATE_NOT_IN_FORKCHOICE = "REGEN_ERROR_STATE_NOT_IN_FORKCHOICE",
+  SLOT_BEFORE_BLOCK_SLOT = "REGEN_ERROR_SLOT_BEFORE_BLOCK_SLOT",
+  NO_SEED_STATE = "REGEN_ERROR_NO_SEED_STATE",
+  TOO_MANY_BLOCK_PROCESSED = "REGEN_ERROR_TOO_MANY_BLOCK_PROCESSED",
+  BLOCK_NOT_IN_DB = "REGEN_ERROR_BLOCK_NOT_IN_DB",
+  STATE_TRANSITION_ERROR = "REGEN_ERROR_STATE_TRANSITION_ERROR",
 }
 
 export type RegenErrorType =
-  | {code: RegenErrorCode.ERR_BLOCK_NOT_IN_FORKCHOICE; blockRoot: Root}
-  | {code: RegenErrorCode.ERR_STATE_NOT_IN_FORKCHOICE; stateRoot: Root}
-  | {code: RegenErrorCode.ERR_SLOT_BEFORE_BLOCK_SLOT; slot: Slot; blockSlot: Slot}
-  | {code: RegenErrorCode.ERR_NO_SEED_STATE}
-  | {code: RegenErrorCode.ERR_TOO_MANY_BLOCK_PROCESSED; stateRoot: Root}
-  | {code: RegenErrorCode.ERR_BLOCK_NOT_IN_DB; blockRoot: Root}
-  | {code: RegenErrorCode.ERR_STATE_TRANSITION_ERROR; error: Error};
+  | {code: RegenErrorCode.BLOCK_NOT_IN_FORKCHOICE; blockRoot: Root}
+  | {code: RegenErrorCode.STATE_NOT_IN_FORKCHOICE; stateRoot: Root}
+  | {code: RegenErrorCode.SLOT_BEFORE_BLOCK_SLOT; slot: Slot; blockSlot: Slot}
+  | {code: RegenErrorCode.NO_SEED_STATE}
+  | {code: RegenErrorCode.TOO_MANY_BLOCK_PROCESSED; stateRoot: Root}
+  | {code: RegenErrorCode.BLOCK_NOT_IN_DB; blockRoot: Root}
+  | {code: RegenErrorCode.STATE_TRANSITION_ERROR; error: Error};
 
 export class RegenError extends Error {
   type: RegenErrorType;

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -40,7 +40,7 @@ export class StateRegenerator implements IStateRegenerator {
     const parentBlock = this.forkChoice.getBlock(block.parentRoot);
     if (!parentBlock) {
       throw new RegenError({
-        code: RegenErrorCode.ERR_BLOCK_NOT_IN_FORKCHOICE,
+        code: RegenErrorCode.BLOCK_NOT_IN_FORKCHOICE,
         blockRoot: block.parentRoot,
       });
     }
@@ -74,14 +74,14 @@ export class StateRegenerator implements IStateRegenerator {
     const block = this.forkChoice.getBlock(blockRoot);
     if (!block) {
       throw new RegenError({
-        code: RegenErrorCode.ERR_BLOCK_NOT_IN_FORKCHOICE,
+        code: RegenErrorCode.BLOCK_NOT_IN_FORKCHOICE,
         blockRoot,
       });
     }
 
     if (slot < block.slot) {
       throw new RegenError({
-        code: RegenErrorCode.ERR_SLOT_BEFORE_BLOCK_SLOT,
+        code: RegenErrorCode.SLOT_BEFORE_BLOCK_SLOT,
         slot,
         blockSlot: block.slot,
       });
@@ -122,7 +122,7 @@ export class StateRegenerator implements IStateRegenerator {
 
     if (!block) {
       throw new RegenError({
-        code: RegenErrorCode.ERR_STATE_NOT_IN_FORKCHOICE,
+        code: RegenErrorCode.STATE_NOT_IN_FORKCHOICE,
         stateRoot,
       });
     }
@@ -148,14 +148,14 @@ export class StateRegenerator implements IStateRegenerator {
 
     if (stateCtx === null) {
       throw new RegenError({
-        code: RegenErrorCode.ERR_NO_SEED_STATE,
+        code: RegenErrorCode.NO_SEED_STATE,
       });
     }
 
     const MAX_EPOCH_TO_PROCESS = 5;
     if (blocksToReplay.length > MAX_EPOCH_TO_PROCESS * this.config.params.SLOTS_PER_EPOCH) {
       throw new RegenError({
-        code: RegenErrorCode.ERR_TOO_MANY_BLOCK_PROCESSED,
+        code: RegenErrorCode.TOO_MANY_BLOCK_PROCESSED,
         stateRoot,
       });
     }
@@ -164,7 +164,7 @@ export class StateRegenerator implements IStateRegenerator {
       const block = await this.db.block.get(b.blockRoot);
       if (!block) {
         throw new RegenError({
-          code: RegenErrorCode.ERR_BLOCK_NOT_IN_DB,
+          code: RegenErrorCode.BLOCK_NOT_IN_DB,
           blockRoot: b.blockRoot,
         });
       }
@@ -179,7 +179,7 @@ export class StateRegenerator implements IStateRegenerator {
         });
       } catch (e) {
         throw new RegenError({
-          code: RegenErrorCode.ERR_STATE_TRANSITION_ERROR,
+          code: RegenErrorCode.STATE_TRANSITION_ERROR,
           error: e,
         });
       }

--- a/packages/lodestar/src/chain/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/aggregateAndProof.ts
@@ -25,7 +25,7 @@ export async function validateGossipAggregateAndProof(
 
   if (attestationSlot < earliestPermissibleSlot) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_PAST_SLOT,
+      code: AttestationErrorCode.PAST_SLOT,
       earliestPermissibleSlot,
       attestationSlot,
       job: attestationJob,
@@ -34,7 +34,7 @@ export async function validateGossipAggregateAndProof(
 
   if (attestationSlot > latestPermissibleSlot) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_FUTURE_SLOT,
+      code: AttestationErrorCode.FUTURE_SLOT,
       attestationSlot,
       latestPermissibleSlot,
       job: attestationJob,
@@ -43,7 +43,7 @@ export async function validateGossipAggregateAndProof(
 
   if (await db.seenAttestationCache.hasAggregateAndProof(aggregateAndProof)) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_AGGREGATE_ALREADY_KNOWN,
+      code: AttestationErrorCode.AGGREGATE_ALREADY_KNOWN,
       job: attestationJob,
     });
   }
@@ -51,14 +51,14 @@ export async function validateGossipAggregateAndProof(
   if (!hasAttestationParticipants(aggregate)) {
     // missing attestation participants
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_WRONG_NUMBER_OF_AGGREGATION_BITS,
+      code: AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS,
       job: attestationJob,
     });
   }
 
   if (await isAttestingToInValidBlock(db, aggregate)) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_KNOWN_BAD_BLOCK,
+      code: AttestationErrorCode.KNOWN_BAD_BLOCK,
       job: attestationJob,
     });
   }
@@ -85,7 +85,7 @@ export async function validateAggregateAttestation(
     attestationPreState = await chain.regen.getBlockSlotState(attestation.data.target.root, attestation.data.slot);
   } catch (e) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_MISSING_ATTESTATION_PRESTATE,
+      code: AttestationErrorCode.MISSING_ATTESTATION_PRESTATE,
       job: attestationJob,
     });
   }
@@ -96,21 +96,21 @@ export async function validateAggregateAttestation(
     committee = epochCtx.getBeaconCommittee(attestation.data.slot, attestation.data.index);
   } catch (error) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_AGGREGATOR_NOT_IN_COMMITTEE,
+      code: AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE,
       job: attestationJob,
     });
   }
 
   if (!committee.includes(aggregateAndProof.message.aggregatorIndex)) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_AGGREGATOR_NOT_IN_COMMITTEE,
+      code: AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE,
       job: attestationJob,
     });
   }
 
   if (!isAggregatorFromCommitteeLength(config, committee.length, aggregateAndProof.message.selectionProof)) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_INVALID_AGGREGATOR,
+      code: AttestationErrorCode.INVALID_AGGREGATOR,
       job: attestationJob,
     });
   }
@@ -126,7 +126,7 @@ export async function validateAggregateAttestation(
     )
   ) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_INVALID_SELECTION_PROOF,
+      code: AttestationErrorCode.INVALID_SELECTION_PROOF,
       job: attestationJob,
     });
   }
@@ -141,7 +141,7 @@ export async function validateAggregateAttestation(
     )
   ) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_INVALID_SIGNATURE,
+      code: AttestationErrorCode.INVALID_SIGNATURE,
       job: attestationJob,
     });
   }
@@ -150,7 +150,7 @@ export async function validateAggregateAttestation(
 
   if (!isValidIndexedAttestation(epochCtx, state, epochCtx.getIndexedAttestation(attestation))) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_INVALID_SIGNATURE,
+      code: AttestationErrorCode.INVALID_SIGNATURE,
       job: attestationJob,
     });
   }

--- a/packages/lodestar/src/chain/validation/attestation.ts
+++ b/packages/lodestar/src/chain/validation/attestation.ts
@@ -21,14 +21,14 @@ export async function validateGossipAttestation(
   const numBits = getAttestationAttesterCount(attestation);
   if (numBits !== 1) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_NOT_EXACTLY_ONE_AGGREGATION_BIT_SET,
+      code: AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET,
       numBits,
       job: attestationJob,
     });
   }
   if (await isAttestingToInValidBlock(db, attestation)) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_KNOWN_BAD_BLOCK,
+      code: AttestationErrorCode.KNOWN_BAD_BLOCK,
       job: attestationJob,
     });
   }
@@ -37,7 +37,7 @@ export async function validateGossipAttestation(
   const attestationSlot = attestation.data.slot;
   if (attestationSlot < earliestPermissibleSlot) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_PAST_SLOT,
+      code: AttestationErrorCode.PAST_SLOT,
       earliestPermissibleSlot,
       attestationSlot,
       job: attestationJob,
@@ -46,7 +46,7 @@ export async function validateGossipAttestation(
 
   if (attestationSlot > latestPermissibleSlot) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_FUTURE_SLOT,
+      code: AttestationErrorCode.FUTURE_SLOT,
       latestPermissibleSlot,
       attestationSlot,
       job: attestationJob,
@@ -56,7 +56,7 @@ export async function validateGossipAttestation(
   // no other validator attestation for same target epoch has been seen
   if (await db.seenAttestationCache.hasCommitteeAttestation(attestation)) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_ATTESTATION_ALREADY_KNOWN,
+      code: AttestationErrorCode.ATTESTATION_ALREADY_KNOWN,
       root: config.types.Attestation.hashTreeRoot(attestation),
       job: attestationJob,
     });
@@ -64,14 +64,14 @@ export async function validateGossipAttestation(
 
   if (await db.badBlock.has(attestation.data.beaconBlockRoot.valueOf() as Uint8Array)) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_KNOWN_BAD_BLOCK,
+      code: AttestationErrorCode.KNOWN_BAD_BLOCK,
       job: attestationJob,
     });
   }
 
   if (!chain.forkChoice.hasBlock(attestation.data.beaconBlockRoot)) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_UNKNOWN_BEACON_BLOCK_ROOT,
+      code: AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT,
       beaconBlockRoot: attestation.data.beaconBlockRoot as Uint8Array,
       job: attestationJob,
     });
@@ -82,7 +82,7 @@ export async function validateGossipAttestation(
     attestationPreStateContext = await chain.regen.getCheckpointState(attestation.data.target);
   } catch (e) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_MISSING_ATTESTATION_PRESTATE,
+      code: AttestationErrorCode.MISSING_ATTESTATION_PRESTATE,
       job: attestationJob,
     });
   }
@@ -90,7 +90,7 @@ export async function validateGossipAttestation(
   const expectedSubnet = computeSubnetForAttestation(config, attestationPreStateContext.epochCtx, attestation);
   if (subnet !== expectedSubnet) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_INVALID_SUBNET_ID,
+      code: AttestationErrorCode.INVALID_SUBNET_ID,
       received: subnet,
       expected: expectedSubnet,
       job: attestationJob,
@@ -106,14 +106,14 @@ export async function validateGossipAttestation(
     )
   ) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_INVALID_SIGNATURE,
+      code: AttestationErrorCode.INVALID_SIGNATURE,
       job: attestationJob,
     });
   }
 
   if (!config.types.Epoch.equals(attestation.data.target.epoch, computeEpochAtSlot(config, attestationSlot))) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_BAD_TARGET_EPOCH,
+      code: AttestationErrorCode.BAD_TARGET_EPOCH,
       job: attestationJob,
     });
   }
@@ -121,14 +121,14 @@ export async function validateGossipAttestation(
   try {
     if (!isCommitteeIndexWithinRange(attestationPreStateContext.epochCtx, attestation.data)) {
       throw new AttestationError({
-        code: AttestationErrorCode.ERR_COMMITTEE_INDEX_OUT_OF_RANGE,
+        code: AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE,
         index: attestation.data.index,
         job: attestationJob,
       });
     }
   } catch (error) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_COMMITTEE_INDEX_OUT_OF_RANGE,
+      code: AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE,
       index: attestation.data.index,
       job: attestationJob,
     });
@@ -136,21 +136,21 @@ export async function validateGossipAttestation(
 
   if (!doAggregationBitsMatchCommitteeSize(attestationPreStateContext, attestation)) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_WRONG_NUMBER_OF_AGGREGATION_BITS,
+      code: AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS,
       job: attestationJob,
     });
   }
 
   if (!chain.forkChoice.isDescendant(attestation.data.target.root, attestation.data.beaconBlockRoot)) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK,
+      code: AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK,
       job: attestationJob,
     });
   }
 
   if (!chain.forkChoice.isDescendantOfFinalized(attestation.data.beaconBlockRoot)) {
     throw new AttestationError({
-      code: AttestationErrorCode.ERR_FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT,
+      code: AttestationErrorCode.FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT,
       job: attestationJob,
     });
   }

--- a/packages/lodestar/src/chain/validation/attesterSlashing.ts
+++ b/packages/lodestar/src/chain/validation/attesterSlashing.ts
@@ -20,14 +20,14 @@ export async function validateGossipAttesterSlashing(
 
   if (await db.attesterSlashing.hasAll(attesterSlashedIndices)) {
     throw new AttesterSlashingError({
-      code: AttesterSlashingErrorCode.ERR_SLASHING_ALREADY_EXISTS,
+      code: AttesterSlashingErrorCode.SLASHING_ALREADY_EXISTS,
     });
   }
 
   const state = await chain.getHeadState();
   if (!isValidAttesterSlashing(config, state, attesterSlashing)) {
     throw new AttesterSlashingError({
-      code: AttesterSlashingErrorCode.ERR_INVALID_SLASHING,
+      code: AttesterSlashingErrorCode.INVALID_SLASHING,
     });
   }
 }

--- a/packages/lodestar/src/chain/validation/block.ts
+++ b/packages/lodestar/src/chain/validation/block.ts
@@ -20,7 +20,7 @@ export async function validateGossipBlock(
   // block is too old
   if (blockSlot <= finalizedSlot) {
     throw new BlockError({
-      code: BlockErrorCode.ERR_WOULD_REVERT_FINALIZED_SLOT,
+      code: BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT,
       blockSlot,
       finalizedSlot,
       job: blockJob,
@@ -30,7 +30,7 @@ export async function validateGossipBlock(
   const currentSlot = chain.clock.currentSlot;
   if (currentSlot < blockSlot) {
     throw new BlockError({
-      code: BlockErrorCode.ERR_FUTURE_SLOT,
+      code: BlockErrorCode.FUTURE_SLOT,
       currentSlot,
       blockSlot,
       job: blockJob,
@@ -39,14 +39,14 @@ export async function validateGossipBlock(
 
   if (await db.badBlock.has(blockRoot)) {
     throw new BlockError({
-      code: BlockErrorCode.ERR_KNOWN_BAD_BLOCK,
+      code: BlockErrorCode.KNOWN_BAD_BLOCK,
       job: blockJob,
     });
   }
 
   if (await hasProposerAlreadyProposed(db, blockRoot, block.message.proposerIndex)) {
     throw new BlockError({
-      code: BlockErrorCode.ERR_REPEAT_PROPOSAL,
+      code: BlockErrorCode.REPEAT_PROPOSAL,
       proposer: block.message.proposerIndex,
       job: blockJob,
     });
@@ -58,7 +58,7 @@ export async function validateGossipBlock(
     blockContext = await chain.regen.getBlockSlotState(block.message.parentRoot, block.message.slot);
   } catch (e) {
     throw new BlockError({
-      code: BlockErrorCode.ERR_PARENT_UNKNOWN,
+      code: BlockErrorCode.PARENT_UNKNOWN,
       parentRoot: block.message.parentRoot,
       job: blockJob,
     });
@@ -66,7 +66,7 @@ export async function validateGossipBlock(
 
   if (!verifyBlockSignature(blockContext.epochCtx, blockContext.state, block)) {
     throw new BlockError({
-      code: BlockErrorCode.ERR_PROPOSAL_SIGNATURE_INVALID,
+      code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID,
       job: blockJob,
     });
   }
@@ -75,14 +75,14 @@ export async function validateGossipBlock(
     const validProposer = isExpectedProposer(blockContext.epochCtx, block.message);
     if (!validProposer) {
       throw new BlockError({
-        code: BlockErrorCode.ERR_INCORRECT_PROPOSER,
+        code: BlockErrorCode.INCORRECT_PROPOSER,
         blockProposer: block.message.proposerIndex,
         job: blockJob,
       });
     }
   } catch (error) {
     throw new BlockError({
-      code: BlockErrorCode.ERR_INCORRECT_PROPOSER,
+      code: BlockErrorCode.INCORRECT_PROPOSER,
       blockProposer: block.message.proposerIndex,
       job: blockJob,
     });

--- a/packages/lodestar/src/chain/validation/proposerSlashing.ts
+++ b/packages/lodestar/src/chain/validation/proposerSlashing.ts
@@ -13,14 +13,14 @@ export async function validateGossipProposerSlashing(
 ): Promise<void> {
   if (await db.proposerSlashing.has(proposerSlashing.signedHeader1.message.proposerIndex)) {
     throw new ProposerSlashingError({
-      code: ProposerSlashingErrorCode.ERR_SLASHING_ALREADY_EXISTS,
+      code: ProposerSlashingErrorCode.SLASHING_ALREADY_EXISTS,
     });
   }
 
   const state = await chain.getHeadState();
   if (!isValidProposerSlashing(config, state, proposerSlashing)) {
     throw new ProposerSlashingError({
-      code: ProposerSlashingErrorCode.ERR_INVALID_SLASHING,
+      code: ProposerSlashingErrorCode.INVALID_SLASHING,
     });
   }
 }

--- a/packages/lodestar/src/chain/validation/voluntaryExit.ts
+++ b/packages/lodestar/src/chain/validation/voluntaryExit.ts
@@ -13,7 +13,7 @@ export async function validateGossipVoluntaryExit(
 ): Promise<void> {
   if (await db.voluntaryExit.has(voluntaryExit.message.validatorIndex)) {
     throw new VoluntaryExitError({
-      code: VoluntaryExitErrorCode.ERR_EXIT_ALREADY_EXISTS,
+      code: VoluntaryExitErrorCode.EXIT_ALREADY_EXISTS,
     });
   }
 
@@ -24,7 +24,7 @@ export async function validateGossipVoluntaryExit(
 
   if (!isValidVoluntaryExit(config, state, voluntaryExit)) {
     throw new VoluntaryExitError({
-      code: VoluntaryExitErrorCode.ERR_INVALID_EXIT,
+      code: VoluntaryExitErrorCode.INVALID_EXIT,
     });
   }
 }

--- a/packages/lodestar/src/constants/network.ts
+++ b/packages/lodestar/src/constants/network.ts
@@ -76,7 +76,7 @@ export enum ReqRespEncoding {
 
 export enum RpcResponseStatus {
   SUCCESS = 0,
-  ERR_INVALID_REQ = 1,
+  INVALID_REQ = 1,
   SERVER_ERROR = 2,
 }
 

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -71,20 +71,20 @@ export class GossipMessageValidator implements IGossipMessageValidator {
       }
 
       switch (e.type.code) {
-        case BlockErrorCode.ERR_PROPOSAL_SIGNATURE_INVALID:
-        case BlockErrorCode.ERR_INCORRECT_PROPOSER:
-        case BlockErrorCode.ERR_KNOWN_BAD_BLOCK:
+        case BlockErrorCode.PROPOSAL_SIGNATURE_INVALID:
+        case BlockErrorCode.INCORRECT_PROPOSER:
+        case BlockErrorCode.KNOWN_BAD_BLOCK:
           this.logger.warn("Rejecting gossip block", logContext, e);
           return ExtendedValidatorResult.reject;
 
-        case BlockErrorCode.ERR_FUTURE_SLOT:
-        case BlockErrorCode.ERR_PARENT_UNKNOWN:
+        case BlockErrorCode.FUTURE_SLOT:
+        case BlockErrorCode.PARENT_UNKNOWN:
           await this.chain.receiveBlock(signedBlock);
           this.logger.warn("Ignoring gossip block", logContext, e);
           return ExtendedValidatorResult.ignore;
 
-        case BlockErrorCode.ERR_WOULD_REVERT_FINALIZED_SLOT:
-        case BlockErrorCode.ERR_REPEAT_PROPOSAL:
+        case BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT:
+        case BlockErrorCode.REPEAT_PROPOSAL:
         default:
           this.logger.warn("Ignoring gossip block", logContext, e);
           return ExtendedValidatorResult.ignore;
@@ -120,28 +120,28 @@ export class GossipMessageValidator implements IGossipMessageValidator {
         return ExtendedValidatorResult.ignore;
       }
       switch (e.type.code) {
-        case AttestationErrorCode.ERR_COMMITTEE_INDEX_OUT_OF_RANGE:
-        case AttestationErrorCode.ERR_INVALID_SUBNET_ID:
-        case AttestationErrorCode.ERR_BAD_TARGET_EPOCH:
-        case AttestationErrorCode.ERR_NOT_EXACTLY_ONE_AGGREGATION_BIT_SET:
-        case AttestationErrorCode.ERR_WRONG_NUMBER_OF_AGGREGATION_BITS:
-        case AttestationErrorCode.ERR_INVALID_SIGNATURE:
-        case AttestationErrorCode.ERR_KNOWN_BAD_BLOCK:
-        case AttestationErrorCode.ERR_FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT:
-        case AttestationErrorCode.ERR_TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK:
+        case AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE:
+        case AttestationErrorCode.INVALID_SUBNET_ID:
+        case AttestationErrorCode.BAD_TARGET_EPOCH:
+        case AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET:
+        case AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS:
+        case AttestationErrorCode.INVALID_SIGNATURE:
+        case AttestationErrorCode.KNOWN_BAD_BLOCK:
+        case AttestationErrorCode.FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT:
+        case AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK:
           this.logger.warn("Rejecting gossip attestation", logContext, e);
           return ExtendedValidatorResult.reject;
 
-        case AttestationErrorCode.ERR_UNKNOWN_BEACON_BLOCK_ROOT:
-        case AttestationErrorCode.ERR_MISSING_ATTESTATION_PRESTATE:
+        case AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT:
+        case AttestationErrorCode.MISSING_ATTESTATION_PRESTATE:
           // attestation might be valid after we receive block
           await this.chain.receiveAttestation(attestation);
           this.logger.warn("Ignoring gossip attestation", logContext, e);
           return ExtendedValidatorResult.ignore;
 
-        case AttestationErrorCode.ERR_PAST_SLOT:
-        case AttestationErrorCode.ERR_FUTURE_SLOT:
-        case AttestationErrorCode.ERR_ATTESTATION_ALREADY_KNOWN:
+        case AttestationErrorCode.PAST_SLOT:
+        case AttestationErrorCode.FUTURE_SLOT:
+        case AttestationErrorCode.ATTESTATION_ALREADY_KNOWN:
         default:
           this.logger.warn("Ignoring gossip attestation", logContext, e);
           return ExtendedValidatorResult.ignore;
@@ -181,23 +181,23 @@ export class GossipMessageValidator implements IGossipMessageValidator {
       }
 
       switch (e.type.code) {
-        case AttestationErrorCode.ERR_WRONG_NUMBER_OF_AGGREGATION_BITS:
-        case AttestationErrorCode.ERR_KNOWN_BAD_BLOCK:
-        case AttestationErrorCode.ERR_AGGREGATOR_NOT_IN_COMMITTEE:
-        case AttestationErrorCode.ERR_INVALID_SELECTION_PROOF:
-        case AttestationErrorCode.ERR_INVALID_SIGNATURE:
-        case AttestationErrorCode.ERR_INVALID_AGGREGATOR:
+        case AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS:
+        case AttestationErrorCode.KNOWN_BAD_BLOCK:
+        case AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE:
+        case AttestationErrorCode.INVALID_SELECTION_PROOF:
+        case AttestationErrorCode.INVALID_SIGNATURE:
+        case AttestationErrorCode.INVALID_AGGREGATOR:
           this.logger.warn("Rejecting gossip aggregate and proof", logContext, e);
           return ExtendedValidatorResult.reject;
 
-        case AttestationErrorCode.ERR_FUTURE_SLOT:
+        case AttestationErrorCode.FUTURE_SLOT:
           await this.chain.receiveAttestation(attestation);
           this.logger.warn("Ignoring gossip aggregate and proof", logContext, e);
           return ExtendedValidatorResult.ignore;
 
-        case AttestationErrorCode.ERR_PAST_SLOT:
-        case AttestationErrorCode.ERR_AGGREGATE_ALREADY_KNOWN:
-        case AttestationErrorCode.ERR_MISSING_ATTESTATION_PRESTATE:
+        case AttestationErrorCode.PAST_SLOT:
+        case AttestationErrorCode.AGGREGATE_ALREADY_KNOWN:
+        case AttestationErrorCode.MISSING_ATTESTATION_PRESTATE:
         default:
           this.logger.warn("Ignoring gossip aggregate and proof", logContext, e);
           return ExtendedValidatorResult.ignore;
@@ -220,11 +220,11 @@ export class GossipMessageValidator implements IGossipMessageValidator {
       }
 
       switch (e.type.code) {
-        case VoluntaryExitErrorCode.ERR_INVALID_EXIT:
+        case VoluntaryExitErrorCode.INVALID_EXIT:
           this.logger.warn("Rejecting gossip voluntary exit", {}, e);
           return ExtendedValidatorResult.reject;
 
-        case VoluntaryExitErrorCode.ERR_EXIT_ALREADY_EXISTS:
+        case VoluntaryExitErrorCode.EXIT_ALREADY_EXISTS:
         default:
           this.logger.warn("Ignoring gossip voluntary exit", {}, e);
           return ExtendedValidatorResult.ignore;
@@ -245,11 +245,11 @@ export class GossipMessageValidator implements IGossipMessageValidator {
       }
 
       switch (e.type.code) {
-        case ProposerSlashingErrorCode.ERR_INVALID_SLASHING:
+        case ProposerSlashingErrorCode.INVALID_SLASHING:
           this.logger.warn("Rejecting gossip proposer slashing", {}, e);
           return ExtendedValidatorResult.reject;
 
-        case ProposerSlashingErrorCode.ERR_SLASHING_ALREADY_EXISTS:
+        case ProposerSlashingErrorCode.SLASHING_ALREADY_EXISTS:
         default:
           this.logger.warn("Ignoring gossip proposer slashing", {}, e);
           return ExtendedValidatorResult.ignore;
@@ -270,11 +270,11 @@ export class GossipMessageValidator implements IGossipMessageValidator {
       }
 
       switch (e.type.code) {
-        case AttesterSlashingErrorCode.ERR_INVALID_SLASHING:
+        case AttesterSlashingErrorCode.INVALID_SLASHING:
           this.logger.warn("Rejecting gossip attester slashing", {}, e);
           return ExtendedValidatorResult.reject;
 
-        case AttesterSlashingErrorCode.ERR_SLASHING_ALREADY_EXISTS:
+        case AttesterSlashingErrorCode.SLASHING_ALREADY_EXISTS:
         default:
           this.logger.warn("Ignoring gossip attester slashing", {}, e);
           return ExtendedValidatorResult.ignore;

--- a/packages/lodestar/src/network/reqresp/reqResp.ts
+++ b/packages/lodestar/src/network/reqresp/reqResp.ts
@@ -149,7 +149,7 @@ export class ReqResp extends (EventEmitter as IReqEventEmitterClass) implements 
             method,
             encoding,
             sink,
-            new RpcError(RpcResponseStatus.ERR_INVALID_REQ, "Invalid request")
+            new RpcError(RpcResponseStatus.INVALID_REQ, "Invalid request")
           );
         } else {
           emit(

--- a/packages/lodestar/src/sync/regular/naive/naive.ts
+++ b/packages/lodestar/src/sync/regular/naive/naive.ts
@@ -114,7 +114,7 @@ export class NaiveRegularSync extends (EventEmitter as {new (): RegularSyncEvent
   };
 
   private onErrorBlock = async (err: BlockError): Promise<void> => {
-    if (err.type.code === BlockErrorCode.ERR_BLOCK_IS_ALREADY_KNOWN) {
+    if (err.type.code === BlockErrorCode.BLOCK_IS_ALREADY_KNOWN) {
       await this.onProcessedBlock(err.job.signedBlock);
     }
   };

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/processor.ts
@@ -61,7 +61,7 @@ export class BlockRangeProcessor implements IBlockRangeProcessor {
   };
 
   private onErrorBlock = async (err: BlockError): Promise<void> => {
-    if (err.type.code === BlockErrorCode.ERR_BLOCK_IS_ALREADY_KNOWN) {
+    if (err.type.code === BlockErrorCode.BLOCK_IS_ALREADY_KNOWN) {
       await this.onProcessedBlock(err.job.signedBlock);
     }
   };

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -298,7 +298,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
         request.method,
         request.encoding,
         sink,
-        new RpcError(RpcResponseStatus.ERR_INVALID_REQ, "Invalid request")
+        new RpcError(RpcResponseStatus.INVALID_REQ, "Invalid request")
       );
       return;
     }

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -208,7 +208,7 @@ export class BeaconSync implements IBeaconSync {
   }
 
   private onUnknownBlockRoot = async (err: BlockError): Promise<void> => {
-    if (err.type.code !== BlockErrorCode.ERR_PARENT_UNKNOWN) return;
+    if (err.type.code !== BlockErrorCode.PARENT_UNKNOWN) return;
     const blockRoot = this.config.types.BeaconBlock.hashTreeRoot(err.job.signedBlock.message);
     const unknownAncestorRoot = this.chain.pendingBlocks.getMissingAncestor(blockRoot);
     const missingRootHex = toHexString(unknownAncestorRoot);

--- a/packages/lodestar/test/e2e/sync/reqResp.test.ts
+++ b/packages/lodestar/test/e2e/sync/reqResp.test.ts
@@ -207,7 +207,7 @@ describe("[sync] rpc", function () {
       for await (const val of source) {
         if (i === 0) {
           const status = val.slice()[0];
-          expect(status).to.be.equal(RpcResponseStatus.ERR_INVALID_REQ);
+          expect(status).to.be.equal(RpcResponseStatus.INVALID_REQ);
         } else {
           // i should be 1
           const errBuf = val.slice();

--- a/packages/lodestar/test/unit/chain/attestation/process.test.ts
+++ b/packages/lodestar/test/unit/chain/attestation/process.test.ts
@@ -41,7 +41,7 @@ describe("processAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.ERR_TARGET_STATE_MISSING);
+      expect(e.type.code).to.equal(AttestationErrorCode.TARGET_STATE_MISSING);
     }
   });
 
@@ -60,7 +60,7 @@ describe("processAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.ERR_NO_COMMITTEE_FOR_SLOT_AND_INDEX);
+      expect(e.type.code).to.equal(AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX);
     }
   });
 
@@ -80,7 +80,7 @@ describe("processAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.ERR_INVALID_SIGNATURE);
+      expect(e.type.code).to.equal(AttestationErrorCode.INVALID_SIGNATURE);
     }
   });
 

--- a/packages/lodestar/test/unit/chain/attestation/validate.test.ts
+++ b/packages/lodestar/test/unit/chain/attestation/validate.test.ts
@@ -37,7 +37,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.ERR_BAD_TARGET_EPOCH);
+      expect(e.type.code).to.equal(AttestationErrorCode.BAD_TARGET_EPOCH);
     }
   });
 
@@ -56,7 +56,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.ERR_PAST_EPOCH);
+      expect(e.type.code).to.equal(AttestationErrorCode.PAST_EPOCH);
     }
   });
 
@@ -75,7 +75,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.ERR_FUTURE_EPOCH);
+      expect(e.type.code).to.equal(AttestationErrorCode.FUTURE_EPOCH);
     }
   });
 
@@ -97,7 +97,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.ERR_FUTURE_SLOT);
+      expect(e.type.code).to.equal(AttestationErrorCode.FUTURE_SLOT);
     }
   });
 
@@ -120,7 +120,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.ERR_UNKNOWN_TARGET_ROOT);
+      expect(e.type.code).to.equal(AttestationErrorCode.UNKNOWN_TARGET_ROOT);
     }
   });
 
@@ -150,7 +150,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.ERR_UNKNOWN_BEACON_BLOCK_ROOT);
+      expect(e.type.code).to.equal(AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT);
     }
   });
 
@@ -177,7 +177,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.ERR_HEAD_NOT_TARGET_DESCENDANT);
+      expect(e.type.code).to.equal(AttestationErrorCode.HEAD_NOT_TARGET_DESCENDANT);
     }
   });
 });

--- a/packages/lodestar/test/unit/chain/blocks/process.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/process.test.ts
@@ -31,7 +31,7 @@ describe("processBlock", function () {
     const signedBlock = config.types.SignedBeaconBlock.defaultValue();
     signedBlock.message.slot = 1;
     const job = getNewBlockJob(signedBlock);
-    regen.getPreState.rejects(new RegenError({code: RegenErrorCode.ERR_STATE_TRANSITION_ERROR, error: new Error()}));
+    regen.getPreState.rejects(new RegenError({code: RegenErrorCode.STATE_TRANSITION_ERROR, error: new Error()}));
     try {
       await processBlock({
         forkChoice,
@@ -42,7 +42,7 @@ describe("processBlock", function () {
       });
       expect.fail("block should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(BlockErrorCode.ERR_PRESTATE_MISSING);
+      expect(e.type.code).to.equal(BlockErrorCode.PRESTATE_MISSING);
     }
   });
 });

--- a/packages/lodestar/test/unit/chain/blocks/validate.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/validate.test.ts
@@ -29,7 +29,7 @@ describe("validateBlock", function () {
       await validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(BlockErrorCode.ERR_GENESIS_BLOCK);
+      expect(e.type.code).to.equal(BlockErrorCode.GENESIS_BLOCK);
     }
   });
 
@@ -42,7 +42,7 @@ describe("validateBlock", function () {
       await validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(BlockErrorCode.ERR_BLOCK_IS_ALREADY_KNOWN);
+      expect(e.type.code).to.equal(BlockErrorCode.BLOCK_IS_ALREADY_KNOWN);
     }
   });
 
@@ -56,7 +56,7 @@ describe("validateBlock", function () {
       await validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(BlockErrorCode.ERR_WOULD_REVERT_FINALIZED_SLOT);
+      expect(e.type.code).to.equal(BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT);
     }
   });
 
@@ -71,7 +71,7 @@ describe("validateBlock", function () {
       await validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(BlockErrorCode.ERR_FUTURE_SLOT);
+      expect(e.type.code).to.equal(BlockErrorCode.FUTURE_SLOT);
     }
   });
 
@@ -87,7 +87,7 @@ describe("validateBlock", function () {
       await validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(BlockErrorCode.ERR_PARENT_UNKNOWN);
+      expect(e.type.code).to.equal(BlockErrorCode.PARENT_UNKNOWN);
     }
   });
 });

--- a/packages/lodestar/test/unit/chain/validation/aggregateAndProof.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/aggregateAndProof.test.ts
@@ -77,7 +77,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_PAST_SLOT);
+      expect(error.type).to.have.property("code", AttestationErrorCode.PAST_SLOT);
     }
   });
 
@@ -100,7 +100,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_FUTURE_SLOT);
+      expect(error.type).to.have.property("code", AttestationErrorCode.FUTURE_SLOT);
     }
   });
 
@@ -119,7 +119,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_AGGREGATE_ALREADY_KNOWN);
+      expect(error.type).to.have.property("code", AttestationErrorCode.AGGREGATE_ALREADY_KNOWN);
     }
     expect(db.seenAttestationCache.hasAggregateAndProof.withArgs(item.message).calledOnce).to.be.true;
   });
@@ -139,7 +139,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_WRONG_NUMBER_OF_AGGREGATION_BITS);
+      expect(error.type).to.have.property("code", AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS);
     }
   });
 
@@ -159,7 +159,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_KNOWN_BAD_BLOCK);
+      expect(error.type).to.have.property("code", AttestationErrorCode.KNOWN_BAD_BLOCK);
     }
     expect(db.badBlock.has.withArgs(item.message.aggregate.data.beaconBlockRoot.valueOf() as Uint8Array).calledOnce).to
       .be.true;
@@ -181,7 +181,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_MISSING_ATTESTATION_PRESTATE);
+      expect(error.type).to.have.property("code", AttestationErrorCode.MISSING_ATTESTATION_PRESTATE);
     }
     expect(regen.getBlockSlotState.withArgs(item.message.aggregate.data.target.root, sinon.match.any).calledOnce).to.be
       .true;
@@ -209,7 +209,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_AGGREGATOR_NOT_IN_COMMITTEE);
+      expect(error.type).to.have.property("code", AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE);
     }
     expect(
       epochCtx.getBeaconCommittee.withArgs(item.message.aggregate.data.slot, item.message.aggregate.data.index)
@@ -240,7 +240,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_INVALID_AGGREGATOR);
+      expect(error.type).to.have.property("code", AttestationErrorCode.INVALID_AGGREGATOR);
     }
     expect(isAggregatorStub.withArgs(config, 1, item.message.selectionProof).calledOnce).to.be.true;
   });
@@ -272,7 +272,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_INVALID_SELECTION_PROOF);
+      expect(error.type).to.have.property("code", AttestationErrorCode.INVALID_SELECTION_PROOF);
     }
     expect(isValidSelectionProofStub.calledOnce).to.be.true;
   });
@@ -305,7 +305,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_INVALID_SIGNATURE);
+      expect(error.type).to.have.property("code", AttestationErrorCode.INVALID_SIGNATURE);
     }
     expect(
       isValidSignatureStub.withArgs(
@@ -347,7 +347,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_INVALID_SIGNATURE);
+      expect(error.type).to.have.property("code", AttestationErrorCode.INVALID_SIGNATURE);
     }
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
   });

--- a/packages/lodestar/test/unit/chain/validation/attestation.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/attestation.test.ts
@@ -70,7 +70,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_NOT_EXACTLY_ONE_AGGREGATION_BIT_SET);
+      expect(error.type).to.have.property("code", AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET);
     }
   });
 
@@ -88,7 +88,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_NOT_EXACTLY_ONE_AGGREGATION_BIT_SET);
+      expect(error.type).to.have.property("code", AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET);
     }
   });
 
@@ -107,7 +107,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_KNOWN_BAD_BLOCK);
+      expect(error.type).to.have.property("code", AttestationErrorCode.KNOWN_BAD_BLOCK);
     }
     expect(db.badBlock.has.calledOnceWith(attestation.data.beaconBlockRoot.valueOf() as Uint8Array)).to.be.true;
   });
@@ -131,7 +131,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_PAST_SLOT);
+      expect(error.type).to.have.property("code", AttestationErrorCode.PAST_SLOT);
     }
   });
 
@@ -154,7 +154,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_FUTURE_SLOT);
+      expect(error.type).to.have.property("code", AttestationErrorCode.FUTURE_SLOT);
     }
   });
 
@@ -175,7 +175,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_ATTESTATION_ALREADY_KNOWN);
+      expect(error.type).to.have.property("code", AttestationErrorCode.ATTESTATION_ALREADY_KNOWN);
     }
     expect(chain.receiveAttestation.called).to.be.false;
     expect(db.seenAttestationCache.hasCommitteeAttestation.calledOnceWith(attestation)).to.be.true;
@@ -199,7 +199,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_UNKNOWN_BEACON_BLOCK_ROOT);
+      expect(error.type).to.have.property("code", AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT);
     }
     expect(forkChoice.hasBlock.calledOnceWith(attestation.data.beaconBlockRoot)).to.be.true;
   });
@@ -223,7 +223,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_MISSING_ATTESTATION_PRESTATE);
+      expect(error.type).to.have.property("code", AttestationErrorCode.MISSING_ATTESTATION_PRESTATE);
     }
     expect(regen.getCheckpointState.calledOnceWith(attestation.data.target)).to.be.true;
   });
@@ -252,7 +252,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_INVALID_SUBNET_ID);
+      expect(error.type).to.have.property("code", AttestationErrorCode.INVALID_SUBNET_ID);
     }
     expect(chain.receiveAttestation.called).to.be.false;
     expect(computeAttestationSubnetStub.calledOnceWith(config, attestationPreState.epochCtx, attestation)).to.be.true;
@@ -284,7 +284,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_INVALID_SIGNATURE);
+      expect(error.type).to.have.property("code", AttestationErrorCode.INVALID_SIGNATURE);
     }
     expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
@@ -322,7 +322,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_COMMITTEE_INDEX_OUT_OF_RANGE);
+      expect(error.type).to.have.property("code", AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE);
     }
     expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
@@ -366,7 +366,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_COMMITTEE_INDEX_OUT_OF_RANGE);
+      expect(error.type).to.have.property("code", AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE);
     }
     expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
@@ -404,7 +404,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_WRONG_NUMBER_OF_AGGREGATION_BITS);
+      expect(error.type).to.have.property("code", AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS);
     }
     expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
@@ -445,7 +445,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_BAD_TARGET_EPOCH);
+      expect(error.type).to.have.property("code", AttestationErrorCode.BAD_TARGET_EPOCH);
     }
   });
 
@@ -509,7 +509,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ERR_TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK);
+      expect(error.type).to.have.property("code", AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK);
     }
   });
 
@@ -549,10 +549,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property(
-        "code",
-        AttestationErrorCode.ERR_FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT
-      );
+      expect(error.type).to.have.property("code", AttestationErrorCode.FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT);
     }
   });
 

--- a/packages/lodestar/test/unit/chain/validation/attesterSlashing.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/attesterSlashing.test.ts
@@ -34,7 +34,7 @@ describe("GossipMessageValidator", () => {
       try {
         await validateGossipAttesterSlashing(config, chainStub, dbStub, slashing);
       } catch (error) {
-        expect(error.type).to.have.property("code", AttesterSlashingErrorCode.ERR_SLASHING_ALREADY_EXISTS);
+        expect(error.type).to.have.property("code", AttesterSlashingErrorCode.SLASHING_ALREADY_EXISTS);
       }
     });
 
@@ -47,7 +47,7 @@ describe("GossipMessageValidator", () => {
       try {
         await validateGossipAttesterSlashing(config, chainStub, dbStub, slashing);
       } catch (error) {
-        expect(error.type).to.have.property("code", AttesterSlashingErrorCode.ERR_INVALID_SLASHING);
+        expect(error.type).to.have.property("code", AttesterSlashingErrorCode.INVALID_SLASHING);
       }
     });
 

--- a/packages/lodestar/test/unit/chain/validation/block.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/block.test.ts
@@ -45,7 +45,7 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect(error.type).to.have.property("code", BlockErrorCode.ERR_WOULD_REVERT_FINALIZED_SLOT);
+      expect(error.type).to.have.property("code", BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT);
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(chainStub.getGenesisTime.notCalled).to.be.true;
@@ -63,7 +63,7 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect(error.type).to.have.property("code", BlockErrorCode.ERR_KNOWN_BAD_BLOCK);
+      expect(error.type).to.have.property("code", BlockErrorCode.KNOWN_BAD_BLOCK);
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(dbStub.badBlock.has.withArgs(sinon.match.defined).calledOnce).to.be.true;
@@ -83,7 +83,7 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect(error.type).to.have.property("code", BlockErrorCode.ERR_REPEAT_PROPOSAL);
+      expect(error.type).to.have.property("code", BlockErrorCode.REPEAT_PROPOSAL);
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(dbStub.badBlock.has.withArgs(sinon.match.defined).calledOnce).to.be.true;
@@ -104,7 +104,7 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect(error.type).to.have.property("code", BlockErrorCode.ERR_PARENT_UNKNOWN);
+      expect(error.type).to.have.property("code", BlockErrorCode.PARENT_UNKNOWN);
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(dbStub.badBlock.has.withArgs(sinon.match.defined).calledOnce).to.be.true;
@@ -129,7 +129,7 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect(error.type).to.have.property("code", BlockErrorCode.ERR_PROPOSAL_SIGNATURE_INVALID);
+      expect(error.type).to.have.property("code", BlockErrorCode.PROPOSAL_SIGNATURE_INVALID);
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(dbStub.badBlock.has.withArgs(sinon.match.defined).calledOnce).to.be.true;
@@ -158,7 +158,7 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect(error.type).to.have.property("code", BlockErrorCode.ERR_INCORRECT_PROPOSER);
+      expect(error.type).to.have.property("code", BlockErrorCode.INCORRECT_PROPOSER);
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(dbStub.badBlock.has.withArgs(sinon.match.defined).calledOnce).to.be.true;

--- a/packages/lodestar/test/unit/chain/validation/proposerSlashing.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/proposerSlashing.test.ts
@@ -33,7 +33,7 @@ describe("validate proposer slashing", () => {
     try {
       await validateGossipProposerSlashing(config, chainStub, dbStub, slashing);
     } catch (error) {
-      expect(error.type).to.have.property("code", ProposerSlashingErrorCode.ERR_SLASHING_ALREADY_EXISTS);
+      expect(error.type).to.have.property("code", ProposerSlashingErrorCode.SLASHING_ALREADY_EXISTS);
     }
   });
 
@@ -46,7 +46,7 @@ describe("validate proposer slashing", () => {
     try {
       await validateGossipProposerSlashing(config, chainStub, dbStub, slashing);
     } catch (error) {
-      expect(error.type).to.have.property("code", ProposerSlashingErrorCode.ERR_INVALID_SLASHING);
+      expect(error.type).to.have.property("code", ProposerSlashingErrorCode.INVALID_SLASHING);
     }
   });
 

--- a/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
@@ -52,7 +52,7 @@ describe("validate voluntary exit", () => {
     try {
       await validateGossipVoluntaryExit(config, chainStub, dbStub, voluntaryExit);
     } catch (error) {
-      expect(error.type).to.have.property("code", VoluntaryExitErrorCode.ERR_EXIT_ALREADY_EXISTS);
+      expect(error.type).to.have.property("code", VoluntaryExitErrorCode.EXIT_ALREADY_EXISTS);
     }
   });
 
@@ -74,7 +74,7 @@ describe("validate voluntary exit", () => {
     try {
       await validateGossipVoluntaryExit(config, chainStub, dbStub, voluntaryExit);
     } catch (error) {
-      expect(error.type).to.have.property("code", VoluntaryExitErrorCode.ERR_INVALID_EXIT);
+      expect(error.type).to.have.property("code", VoluntaryExitErrorCode.INVALID_EXIT);
     }
   });
 

--- a/packages/lodestar/test/unit/network/encoders/response.test.ts
+++ b/packages/lodestar/test/unit/network/encoders/response.test.ts
@@ -200,7 +200,7 @@ describe("response decoders", function () {
   it("should work - response stream with error - ssz", async function () {
     const controller = new AbortController();
     const chunks = generateBlockChunks(10);
-    chunks[4].status = RpcResponseStatus.ERR_INVALID_REQ;
+    chunks[4].status = RpcResponseStatus.INVALID_REQ;
     chunks[4].body = encodeP2pErrorMessage(config, "Invalid request");
 
     const responses = (await pipe(
@@ -215,7 +215,7 @@ describe("response decoders", function () {
 
   it("should work - response stream with error - ssz_snappy", async function () {
     const chunks = generateBlockChunks(10);
-    chunks[5].status = RpcResponseStatus.ERR_INVALID_REQ;
+    chunks[5].status = RpcResponseStatus.INVALID_REQ;
 
     const responses = (await pipe(
       chunks,

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/processor.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/processor.test.ts
@@ -49,7 +49,7 @@ describe("BlockRangeProcessor", function () {
         ChainEvent.errorBlock,
         new BlockError({
           job: {signedBlock: secondBlock} as IBlockJob,
-          code: BlockErrorCode.ERR_BLOCK_IS_ALREADY_KNOWN,
+          code: BlockErrorCode.BLOCK_IS_ALREADY_KNOWN,
         })
       ),
     ]);

--- a/packages/lodestar/test/unit/util/queue.test.ts
+++ b/packages/lodestar/test/unit/util/queue.test.ts
@@ -41,8 +41,7 @@ describe("Job queue", () => {
       // the next enqueued job should go over the limit
       await jobQueue.enqueueJob(job);
     } catch (e) {
-      expect(e).to.be.instanceOf(QueueError);
-      expect(e.type.code).to.be.equal(QueueErrorCode.QUEUE_THROTTLED);
+      assertQueueErrorCode(e, QueueErrorCode.QUEUE_THROTTLED);
     }
 
     await jobs;
@@ -61,8 +60,7 @@ describe("Job queue", () => {
     // all jobs should be rejected with ERR_QUEUE_ABORTED
     results.forEach((e) => {
       if (e.status === "rejected") {
-        expect(e.reason).to.be.instanceOf(QueueError);
-        expect(e.reason.code).to.be.equal(QueueErrorCode.QUEUE_ABORTED);
+        assertQueueErrorCode(e.reason, QueueErrorCode.QUEUE_ABORTED);
       } else {
         expect.fail();
       }
@@ -71,8 +69,15 @@ describe("Job queue", () => {
     try {
       await jobQueue.enqueueJob(job);
     } catch (e) {
-      expect(e).to.be.instanceOf(QueueError);
-      expect(e.type.code).to.be.equal(QueueErrorCode.QUEUE_ABORTED);
+      assertQueueErrorCode(e, QueueErrorCode.QUEUE_ABORTED);
     }
   });
 });
+
+function assertQueueErrorCode(e: QueueError, code: QueueErrorCode): void {
+  if (e instanceof QueueError) {
+    expect(e.type.code).to.be.equal(code, "Wrong QueueErrorCode");
+  } else {
+    throw Error(`Expected e ${QueueError} to be instaceof QueueError`);
+  }
+}

--- a/packages/lodestar/test/unit/util/queue.test.ts
+++ b/packages/lodestar/test/unit/util/queue.test.ts
@@ -42,7 +42,7 @@ describe("Job queue", () => {
       await jobQueue.enqueueJob(job);
     } catch (e) {
       expect(e).to.be.instanceOf(QueueError);
-      expect(e.code).to.be.equal(QueueErrorCode.ERR_QUEUE_THROTTLED);
+      expect(e.code).to.be.equal(QueueErrorCode.QUEUE_THROTTLED);
     }
 
     await jobs;
@@ -62,7 +62,7 @@ describe("Job queue", () => {
     results.forEach((e) => {
       if (e.status === "rejected") {
         expect(e.reason).to.be.instanceOf(QueueError);
-        expect(e.reason.code).to.be.equal(QueueErrorCode.ERR_QUEUE_ABORTED);
+        expect(e.reason.code).to.be.equal(QueueErrorCode.QUEUE_ABORTED);
       } else {
         expect.fail();
       }
@@ -72,7 +72,7 @@ describe("Job queue", () => {
       await jobQueue.enqueueJob(job);
     } catch (e) {
       expect(e).to.be.instanceOf(QueueError);
-      expect(e.code).to.be.equal(QueueErrorCode.ERR_QUEUE_ABORTED);
+      expect(e.code).to.be.equal(QueueErrorCode.QUEUE_ABORTED);
     }
   });
 });

--- a/packages/lodestar/test/unit/util/queue.test.ts
+++ b/packages/lodestar/test/unit/util/queue.test.ts
@@ -42,7 +42,7 @@ describe("Job queue", () => {
       await jobQueue.enqueueJob(job);
     } catch (e) {
       expect(e).to.be.instanceOf(QueueError);
-      expect(e.code).to.be.equal(QueueErrorCode.QUEUE_THROTTLED);
+      expect(e.type.code).to.be.equal(QueueErrorCode.QUEUE_THROTTLED);
     }
 
     await jobs;
@@ -72,7 +72,7 @@ describe("Job queue", () => {
       await jobQueue.enqueueJob(job);
     } catch (e) {
       expect(e).to.be.instanceOf(QueueError);
-      expect(e.code).to.be.equal(QueueErrorCode.QUEUE_ABORTED);
+      expect(e.type.code).to.be.equal(QueueErrorCode.QUEUE_ABORTED);
     }
   });
 });


### PR DESCRIPTION
The ERR_ prefix in the code enum variable name adds unnecessary info in its usage. 

This PR also adds the main error type to the error code enum value so it has complete info when shown in logs