### PR TITLE
Debug api to download state

### DIFF
--- a/packages/lodestar-db/src/schema.ts
+++ b/packages/lodestar-db/src/schema.ts
@@ -42,6 +42,7 @@ export enum Bucket {
   slashingProtectionMinSpanDistance = 23,
   slashingProtectionMaxSpanDistance = 24,
   pendingBlock = 25, // Root -> SignedBeaconBlock
+  stateArchiveRootIndex = 26, // State Root -> slot
 }
 
 export enum Key {

--- a/packages/lodestar/src/api/impl/beacon/state/utils.ts
+++ b/packages/lodestar/src/api/impl/beacon/state/utils.ts
@@ -30,7 +30,7 @@ export async function resolveStateId(
   } else if (stateId.startsWith("0x")) {
     return await stateByRoot(db, stateId);
   } else {
-    //block id must be slot
+    // state id must be slot
     const slot = parseInt(stateId, 10);
     if (isNaN(slot) && isNaN(slot - 0)) {
       throw new Error("Invalid state id");

--- a/packages/lodestar/src/api/impl/debug/beacon/index.ts
+++ b/packages/lodestar/src/api/impl/debug/beacon/index.ts
@@ -1,17 +1,25 @@
-import {SlotRoot} from "@chainsafe/lodestar-types";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {BeaconState, SlotRoot} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {IBeaconChain} from "../../../../chain";
+import {IBeaconDb} from "../../../../db";
 import {IApiOptions} from "../../../options";
+import {StateId} from "../../beacon/state";
+import {resolveStateId} from "../../beacon/state/utils";
 import {IApiModules} from "../../interface";
 import {IDebugBeaconApi} from "./interface";
 
 export class DebugBeaconApi implements IDebugBeaconApi {
+  private readonly config: IBeaconConfig;
   private readonly chain: IBeaconChain;
+  private readonly db: IBeaconDb;
   private readonly logger: ILogger;
 
-  public constructor(opts: Partial<IApiOptions>, modules: Pick<IApiModules, "logger" | "chain">) {
+  public constructor(opts: Partial<IApiOptions>, modules: Pick<IApiModules, "config" | "logger" | "chain" | "db">) {
+    this.config = modules.config;
     this.logger = modules.logger;
     this.chain = modules.chain;
+    this.db = modules.db;
   }
 
   public async getHeads(): Promise<SlotRoot[] | null> {
@@ -22,6 +30,16 @@ export class DebugBeaconApi implements IDebugBeaconApi {
     } catch (e) {
       this.logger.error("Failed to get forkchoice heads", e);
       return null;
+    }
+  }
+
+  public async getState(stateId: StateId): Promise<BeaconState | null> {
+    try {
+      const stateContext = await resolveStateId(this.config, this.db, this.chain.forkChoice, stateId);
+      return stateContext?.state || null;
+    } catch (e) {
+      this.logger.error("Failed to resolve state", {state: stateId, error: e});
+      throw e;
     }
   }
 }

--- a/packages/lodestar/src/api/impl/debug/beacon/interface.ts
+++ b/packages/lodestar/src/api/impl/debug/beacon/interface.ts
@@ -1,5 +1,7 @@
-import {SlotRoot} from "@chainsafe/lodestar-types";
+import {BeaconState, SlotRoot} from "@chainsafe/lodestar-types";
+import {StateId} from "../../beacon/state";
 
 export interface IDebugBeaconApi {
   getHeads(): Promise<SlotRoot[] | null>;
+  getState(stateId: StateId): Promise<BeaconState | null>;
 }

--- a/packages/lodestar/src/api/impl/debug/debug.ts
+++ b/packages/lodestar/src/api/impl/debug/debug.ts
@@ -7,7 +7,7 @@ import {IDebugApi} from "./interface";
 export class DebugApi implements IDebugApi {
   public beacon: IDebugBeaconApi;
 
-  public constructor(opts: Partial<IApiOptions>, modules: Pick<IApiModules, "logger" | "chain">) {
+  public constructor(opts: Partial<IApiOptions>, modules: Pick<IApiModules, "config" | "logger" | "chain" | "db">) {
     this.beacon = new DebugBeaconApi(opts, modules);
   }
 }

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlock.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlock.ts
@@ -1,6 +1,6 @@
 import {ApiController} from "../../types";
 import {DefaultQuery} from "fastify";
-import {FastifyError} from "fastify";
+import {toRestValidationError} from "../../utils";
 
 export const getBlock: ApiController<DefaultQuery, {blockId: string}> = {
   url: "/blocks/:blockId",
@@ -16,16 +16,7 @@ export const getBlock: ApiController<DefaultQuery, {blockId: string}> = {
       });
     } catch (e) {
       if (e.message === "Invalid block id") {
-        //TODO: fix when unifying errors
-        throw {
-          statusCode: 400,
-          validation: [
-            {
-              dataPath: "block_id",
-              message: e.message,
-            },
-          ],
-        } as FastifyError;
+        throw toRestValidationError("block_id", e.message);
       }
       throw e;
     }

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockAttestations.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockAttestations.ts
@@ -1,6 +1,6 @@
 import {ApiController} from "../../types";
 import {DefaultQuery} from "fastify";
-import {FastifyError} from "fastify";
+import {toRestValidationError} from "../../utils";
 
 export const getBlockAttestations: ApiController<DefaultQuery, {blockId: string}> = {
   url: "/blocks/:blockId/attestations",
@@ -18,16 +18,7 @@ export const getBlockAttestations: ApiController<DefaultQuery, {blockId: string}
       });
     } catch (e) {
       if (e.message === "Invalid block id") {
-        //TODO: fix when unifying errors
-        throw {
-          statusCode: 400,
-          validation: [
-            {
-              dataPath: "block_id",
-              message: e.message,
-            },
-          ],
-        } as FastifyError;
+        throw toRestValidationError("block_id", e.message);
       }
       throw e;
     }

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockHeader.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockHeader.ts
@@ -1,6 +1,6 @@
 import {ApiController} from "../../types";
 import {DefaultQuery} from "fastify";
-import {FastifyError} from "fastify";
+import {toRestValidationError} from "../../utils";
 
 export const getBlockHeader: ApiController<DefaultQuery, {blockId: string}> = {
   url: "/headers/:blockId",
@@ -16,16 +16,7 @@ export const getBlockHeader: ApiController<DefaultQuery, {blockId: string}> = {
       });
     } catch (e) {
       if (e.message === "Invalid block id") {
-        //TODO: fix when unifying errors
-        throw {
-          statusCode: 400,
-          validation: [
-            {
-              dataPath: "block_id",
-              message: e.message,
-            },
-          ],
-        } as FastifyError;
+        throw toRestValidationError("block_id", e.message);
       }
       throw e;
     }

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockRoot.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockRoot.ts
@@ -1,6 +1,6 @@
 import {ApiController} from "../../types";
 import {DefaultQuery} from "fastify";
-import {FastifyError} from "fastify";
+import {toRestValidationError} from "../../utils";
 
 export const getBlockRoot: ApiController<DefaultQuery, {blockId: string}> = {
   url: "/blocks/:blockId/root",
@@ -18,16 +18,7 @@ export const getBlockRoot: ApiController<DefaultQuery, {blockId: string}> = {
       });
     } catch (e) {
       if (e.message === "Invalid block id") {
-        //TODO: fix when unifying errors
-        throw {
-          statusCode: 400,
-          validation: [
-            {
-              dataPath: "block_id",
-              message: e.message,
-            },
-          ],
-        } as FastifyError;
+        throw toRestValidationError("block_id", e.message);
       }
       throw e;
     }

--- a/packages/lodestar/src/api/rest/controllers/beacon/state/getStateFinalityCheckpoints.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/state/getStateFinalityCheckpoints.ts
@@ -1,7 +1,7 @@
 import {ApiController} from "../../types";
 import {DefaultQuery} from "fastify";
-import {FastifyError} from "fastify";
 import {StateId} from "../../../../impl/beacon/state";
+import {toRestValidationError} from "../../utils";
 
 type Params = {
   stateId: StateId;
@@ -27,16 +27,7 @@ export const getStateFinalityCheckpoints: ApiController<DefaultQuery, Params> = 
       });
     } catch (e) {
       if (e.message === "Invalid state id") {
-        //TODO: fix when unifying errors
-        throw {
-          statusCode: 400,
-          validation: [
-            {
-              dataPath: "state_id",
-              message: e.message,
-            },
-          ],
-        } as FastifyError;
+        throw toRestValidationError("state_id", e.message);
       }
       throw e;
     }

--- a/packages/lodestar/src/api/rest/controllers/beacon/state/getStateFork.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/state/getStateFork.ts
@@ -1,7 +1,7 @@
 import {ApiController} from "../../types";
 import {DefaultQuery} from "fastify";
-import {FastifyError} from "fastify";
 import {StateId} from "../../../../impl/beacon/state";
+import {toRestValidationError} from "../../utils";
 
 type Params = {
   stateId: StateId;
@@ -21,16 +21,7 @@ export const getStateFork: ApiController<DefaultQuery, Params> = {
       });
     } catch (e) {
       if (e.message === "Invalid state id") {
-        //TODO: fix when unifying errors
-        throw {
-          statusCode: 400,
-          validation: [
-            {
-              dataPath: "state_id",
-              message: e.message,
-            },
-          ],
-        } as FastifyError;
+        throw toRestValidationError("state_id", e.message);
       }
       throw e;
     }

--- a/packages/lodestar/src/api/rest/controllers/debug/beacon/getStates.ts
+++ b/packages/lodestar/src/api/rest/controllers/debug/beacon/getStates.ts
@@ -1,6 +1,6 @@
 import {ApiController, HttpHeader} from "../../types";
 import {DefaultQuery} from "fastify";
-import {FastifyError} from "fastify";
+import {toRestValidationError} from "../../utils";
 
 const SSZ_MIME_TYPE = "application/octet-stream";
 
@@ -23,15 +23,7 @@ export const getState: ApiController<DefaultQuery, {stateId: string}> = {
       }
     } catch (e) {
       if (e.message === "Invalid state id") {
-        throw {
-          statusCode: 400,
-          validation: [
-            {
-              dataPath: "state_id",
-              message: e.message,
-            },
-          ],
-        } as FastifyError;
+        throw toRestValidationError("state_id", e.message);
       }
       throw e;
     }

--- a/packages/lodestar/src/api/rest/controllers/debug/beacon/getStates.ts
+++ b/packages/lodestar/src/api/rest/controllers/debug/beacon/getStates.ts
@@ -1,6 +1,8 @@
-import {ApiController} from "../../types";
+import {ApiController, HttpHeader} from "../../types";
 import {DefaultQuery} from "fastify";
 import {FastifyError} from "fastify";
+
+const SSZ_MIME_TYPE = "application/octet-stream";
 
 export const getState: ApiController<DefaultQuery, {stateId: string}> = {
   url: "/beacon/states/:stateId",
@@ -11,9 +13,9 @@ export const getState: ApiController<DefaultQuery, {stateId: string}> = {
       if (!state) {
         return resp.status(404).send();
       }
-      if (req.headers["accept"] === "application/octet-stream") {
+      if (req.headers[HttpHeader.ACCEPT] === SSZ_MIME_TYPE) {
         const stateSsz = this.config.types.BeaconState.serialize(state);
-        resp.status(200).header("Content-Type", "application/octet-stream").send(Buffer.from(stateSsz));
+        resp.status(200).header(HttpHeader.CONTENT_TYPE, SSZ_MIME_TYPE).send(Buffer.from(stateSsz));
       } else {
         return resp.status(200).send({
           data: this.config.types.BeaconState.toJson(state, {case: "snake"}),

--- a/packages/lodestar/src/api/rest/controllers/debug/beacon/getStates.ts
+++ b/packages/lodestar/src/api/rest/controllers/debug/beacon/getStates.ts
@@ -1,0 +1,51 @@
+import {ApiController} from "../../types";
+import {DefaultQuery} from "fastify";
+import {FastifyError} from "fastify";
+
+export const getState: ApiController<DefaultQuery, {stateId: string}> = {
+  url: "/beacon/states/:stateId",
+
+  handler: async function (req, resp) {
+    try {
+      const state = await this.api.debug.beacon.getState(req.params.stateId);
+      if (!state) {
+        return resp.status(404).send();
+      }
+      if (req.headers["accept"] === "application/octet-stream") {
+        const stateSsz = this.config.types.BeaconState.serialize(state);
+        resp.status(200).header("Content-Type", "application/octet-stream").send(Buffer.from(stateSsz));
+      } else {
+        return resp.status(200).send({
+          data: this.config.types.BeaconState.toJson(state, {case: "snake"}),
+        });
+      }
+    } catch (e) {
+      if (e.message === "Invalid state id") {
+        throw {
+          statusCode: 400,
+          validation: [
+            {
+              dataPath: "state_id",
+              message: e.message,
+            },
+          ],
+        } as FastifyError;
+      }
+      throw e;
+    }
+  },
+
+  opts: {
+    schema: {
+      params: {
+        type: "object",
+        required: ["stateId"],
+        properties: {
+          blockId: {
+            types: "string",
+          },
+        },
+      },
+    },
+  },
+};

--- a/packages/lodestar/src/api/rest/controllers/types.ts
+++ b/packages/lodestar/src/api/rest/controllers/types.ts
@@ -19,3 +19,8 @@ export interface ApiController<
   handler: ApiHandler<Query, Params, Body, Headers>;
   url: string;
 }
+
+export enum HttpHeader {
+  ACCEPT = "accept",
+  CONTENT_TYPE = "Content-Type",
+}

--- a/packages/lodestar/src/api/rest/controllers/utils.ts
+++ b/packages/lodestar/src/api/rest/controllers/utils.ts
@@ -1,0 +1,16 @@
+import {FastifyError} from "fastify";
+
+/**
+ * The error handler will decide status code 400
+ */
+export function toRestValidationError(field: string, message: string): FastifyError {
+  return {
+    message,
+    validation: [
+      {
+        dataPath: field,
+        message,
+      },
+    ],
+  } as FastifyError;
+}

--- a/packages/lodestar/src/api/rest/routes/debug/index.ts
+++ b/packages/lodestar/src/api/rest/routes/debug/index.ts
@@ -1,5 +1,6 @@
 import {FastifyInstance} from "fastify";
 import {getHeads} from "../../controllers/debug/beacon/getHeads";
+import {getState} from "../../controllers/debug/beacon/getStates";
 
 /**
  * Register /debug route
@@ -9,6 +10,7 @@ export function registerDebugRoutes(server: FastifyInstance): void {
     async function (fastify) {
       //beacon
       fastify.get(getHeads.url, getHeads.opts, getHeads.handler);
+      fastify.get(getState.url, getState.opts, getState.handler);
     },
     {prefix: "/v1/debug"}
   );

--- a/packages/lodestar/src/db/api/beacon/repositories/stateArchive.ts
+++ b/packages/lodestar/src/db/api/beacon/repositories/stateArchive.ts
@@ -1,17 +1,20 @@
 import {TreeBacked, CompositeType} from "@chainsafe/ssz";
-import {BeaconState, Epoch} from "@chainsafe/lodestar-types";
+import {BeaconState, Epoch, Root, Slot} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {bytesToInt} from "@chainsafe/lodestar-utils";
-import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
-import {IDatabaseController, Bucket, Repository} from "@chainsafe/lodestar-db";
+import {bytesToInt, intToBytes} from "@chainsafe/lodestar-utils";
+import {IDatabaseController, Bucket, Repository, encodeKey} from "@chainsafe/lodestar-db";
 
-export class StateArchiveRepository extends Repository<Epoch, TreeBacked<BeaconState>> {
+export class StateArchiveRepository extends Repository<Slot, TreeBacked<BeaconState>> {
   public constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
     super(config, db, Bucket.state, (config.types.BeaconState as unknown) as CompositeType<TreeBacked<BeaconState>>);
   }
 
+  public async put(key: Slot, value: TreeBacked<BeaconState>): Promise<void> {
+    await Promise.all([super.put(key, value), this.storeRootIndex(key, value.hashTreeRoot())]);
+  }
+
   public getId(state: TreeBacked<BeaconState>): Epoch {
-    return computeEpochAtSlot(this.config, state.slot);
+    return state.slot;
   }
 
   public decodeKey(data: Buffer): number {
@@ -20,5 +23,29 @@ export class StateArchiveRepository extends Repository<Epoch, TreeBacked<BeaconS
 
   public decodeValue(data: Buffer): TreeBacked<BeaconState> {
     return ((this.type as unknown) as CompositeType<BeaconState>).tree.deserialize(data);
+  }
+
+  public async getByRoot(stateRoot: Root): Promise<TreeBacked<BeaconState> | null> {
+    const slot = await this.getSlotByRoot(stateRoot);
+    if (slot !== null && Number.isInteger(slot)) {
+      return this.get(slot);
+    }
+    return null;
+  }
+
+  private async getSlotByRoot(root: Root): Promise<Slot | null> {
+    const value = await this.db.get(this.getRootIndexKey(root));
+    if (value) {
+      return bytesToInt(value, "be");
+    }
+    return null;
+  }
+
+  private storeRootIndex(slot: Slot, stateRoot: Root): Promise<void> {
+    return this.db.put(this.getRootIndexKey(stateRoot), intToBytes(slot, 64, "be"));
+  }
+
+  private getRootIndexKey(root: Root): Buffer {
+    return encodeKey(Bucket.stateArchiveRootIndex, root.valueOf() as Uint8Array);
   }
 }

--- a/packages/lodestar/src/tasks/tasks/archiveStates.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveStates.ts
@@ -41,7 +41,7 @@ export class ArchiveStatesTask implements ITask {
       throw Error("No state in cache for finalized checkpoint state epoch #" + this.finalized.epoch);
     }
     const finalizedState = stateCache.state;
-    await this.db.stateArchive.add(finalizedState);
+    await this.db.stateArchive.put(finalizedState.slot, finalizedState);
     // don't delete states before the finalized state, auto-prune will take care of it
     this.logger.info("Archive states completed", {finalizedEpoch: this.finalized.epoch});
     this.logger.profile("Archive States epoch #" + this.finalized.epoch);

--- a/packages/lodestar/test/unit/api/impl/debug/beacon/index.test.ts
+++ b/packages/lodestar/test/unit/api/impl/debug/beacon/index.test.ts
@@ -1,41 +1,67 @@
 import {ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {config} from "@chainsafe/lodestar-config/minimal";
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {SinonStubbedInstance} from "sinon";
+import * as stateApiUtils from "../../../../../../src/api/impl/beacon/state/utils";
 import {DebugBeaconApi} from "../../../../../../src/api/impl/debug/beacon";
 import {BeaconChain, IBeaconChain, LodestarForkChoice} from "../../../../../../src/chain";
 import {generateBlockSummary} from "../../../../../utils/block";
+import {StubbedBeaconDb} from "../../../../../utils/stub";
+import {generateState} from "../../../../../utils/state";
 
-describe("api - debug - beacon - getHeads", function () {
+describe("api - debug - beacon", function () {
   let debugApi: DebugBeaconApi;
   let chainStub: SinonStubbedInstance<IBeaconChain>;
   let forkchoiceStub: SinonStubbedInstance<IForkChoice>;
+  let dbStub: StubbedBeaconDb;
+  let resolveStateIdStub: SinonStub;
   const logger = new WinstonLogger();
 
   beforeEach(() => {
+    resolveStateIdStub = sinon.stub(stateApiUtils, "resolveStateId");
     chainStub = sinon.createStubInstance(BeaconChain);
     forkchoiceStub = sinon.createStubInstance(LodestarForkChoice);
     chainStub.forkChoice = forkchoiceStub;
+    dbStub = new StubbedBeaconDb(sinon);
     debugApi = new DebugBeaconApi(
       {},
       {
+        config,
         logger,
         chain: chainStub,
+        db: dbStub,
       }
     );
   });
 
-  it("should return head", async () => {
+  afterEach(() => {
+    resolveStateIdStub.restore();
+  });
+
+  it("getHeads - should return head", async () => {
     forkchoiceStub.getHeads.returns([generateBlockSummary({slot: 1000})]);
     const heads = await debugApi.getHeads();
     expect(heads).to.be.deep.equal([{slot: 1000, root: ZERO_HASH}]);
   });
 
-  it("should return null", async () => {
+  it("getHeads - should return null", async () => {
     forkchoiceStub.getHeads.throws("error from unit test");
     const heads = await debugApi.getHeads();
     expect(heads).to.be.null;
+  });
+
+  it("getState - should return state", async () => {
+    resolveStateIdStub.resolves({state: generateState()});
+    const state = await debugApi.getState("something");
+    expect(state).to.not.be.null;
+  });
+
+  it("getState - should return null", async () => {
+    resolveStateIdStub.resolves(null);
+    const state = await debugApi.getState("something");
+    expect(state).to.be.null;
   });
 });

--- a/packages/lodestar/test/unit/api/rest/debug/beacon/getState.test.ts
+++ b/packages/lodestar/test/unit/api/rest/debug/beacon/getState.test.ts
@@ -1,0 +1,71 @@
+import {expect} from "chai";
+import supertest from "supertest";
+import {config} from "@chainsafe/lodestar-config/minimal";
+
+import {ApiNamespace, RestApi} from "../../../../../../src/api";
+import {StubbedApi} from "../../../../../utils/stub/api";
+import {silentLogger} from "../../../../../utils/logger";
+import {SinonStubbedInstance} from "sinon";
+import {DebugBeaconApi} from "../../../../../../src/api/impl/debug/beacon";
+import {generateState} from "../../../../../utils/state";
+
+describe("rest - debug - beacon - getState", function () {
+  let restApi: RestApi;
+  let api: StubbedApi;
+
+  beforeEach(async function () {
+    api = new StubbedApi();
+    restApi = await RestApi.init(
+      {
+        api: [ApiNamespace.DEBUG],
+        cors: "*",
+        enabled: true,
+        host: "127.0.0.1",
+        port: 0,
+      },
+      {
+        config,
+        logger: silentLogger,
+        api,
+      }
+    );
+  });
+
+  afterEach(async function () {
+    await restApi.close();
+  });
+
+  it("should get state json successfully", async function () {
+    const debugBeaconStub = api.debug.beacon as SinonStubbedInstance<DebugBeaconApi>;
+    debugBeaconStub.getState.resolves(generateState());
+    const response = await supertest(restApi.server.server)
+      .get("/eth/v1/debug/beacon/states/0xSomething")
+      .expect(200)
+      .expect("Content-Type", "application/json; charset=utf-8");
+    expect(response.body.data).to.not.be.undefined;
+  });
+
+  it("should get state ssz successfully", async function () {
+    const debugBeaconStub = api.debug.beacon as SinonStubbedInstance<DebugBeaconApi>;
+    const state = generateState();
+    debugBeaconStub.getState.resolves(state);
+    const response = await supertest(restApi.server.server)
+      .get("/eth/v1/debug/beacon/states/0xSomething")
+      .accept("application/octet-stream")
+      .expect(200)
+      .expect("Content-Type", "application/octet-stream");
+    expect(response.body).to.be.deep.equal(config.types.BeaconState.serialize(state));
+  });
+
+  it("should return status code 404", async function () {
+    const debugBeaconStub = api.debug.beacon as SinonStubbedInstance<DebugBeaconApi>;
+    debugBeaconStub.getState.resolves(null);
+    await supertest(restApi.server.server).get("/eth/v1/debug/beacon/states/0xSomething").expect(404);
+  });
+
+  it("should return status code 400", async function () {
+    const debugBeaconStub = api.debug.beacon as SinonStubbedInstance<DebugBeaconApi>;
+    debugBeaconStub.getState.throws(new Error("Invalid state id"));
+    await supertest(restApi.server.server).get("/eth/v1/debug/beacon/states/1000x").expect(400);
+  });
+});


### PR DESCRIPTION
resolves #1856 

Some implementation notes:
+ Store finalized state by slot instead of epoch
+ Support storing finalized state by state root
+ Download full beacon state by using `accept` header `application/octet-stream`, otherwise it'll return json instead

## Question: 

+ For old slots, this is only able to download states of finalized checkpoints. We could also download any finalized states by slot by regenerating it from a persisted finalized checkpoint state and run state transitions through related finalized blocks, using a WorkerThread is suitable in this use case. Do we want to do it?