### PR TITLE
Lightclient upgrade

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/lightclient/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/lightclient/index.ts
@@ -1,3 +1,4 @@
 export * from "./sync_committee";
 export * from "./block";
+export * from "./upgrade";
 export * from "./epoch";

--- a/packages/lodestar-beacon-state-transition/src/lightclient/upgrade.ts
+++ b/packages/lodestar-beacon-state-transition/src/lightclient/upgrade.ts
@@ -1,0 +1,22 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {BeaconState, Lightclient, PendingAttestation} from "@chainsafe/lodestar-types";
+import {List} from "@chainsafe/ssz";
+import {getCurrentEpoch} from "..";
+
+export const LIGHTCLIENT_PATCH_FORK_VERSION = Buffer.from("0x01000000", "hex");
+
+export function upgrade(config: IBeaconConfig, pre: BeaconState): Lightclient.BeaconState {
+  const epoch = getCurrentEpoch(config, pre);
+  return {
+    ...pre,
+    fork: {
+      previousVersion: pre.fork.currentVersion,
+      currentVersion: LIGHTCLIENT_PATCH_FORK_VERSION,
+      epoch,
+    },
+    previousEpochAttestations: new Array<PendingAttestation>() as List<PendingAttestation>,
+    currentEpochAttestations: new Array<PendingAttestation>() as List<PendingAttestation>,
+    currentSyncCommittee: config.types.lightclient.SyncCommittee.defaultValue(),
+    nextSyncCommittee: config.types.lightclient.SyncCommittee.defaultValue(),
+  };
+}

--- a/packages/lodestar-types/src/types/lightclient/interface.ts
+++ b/packages/lodestar-types/src/types/lightclient/interface.ts
@@ -2,7 +2,7 @@ import {ContainerType} from "@chainsafe/ssz";
 import * as t from "./types";
 
 export interface ILightclientSSZTypes {
-  SyncCommittee: ContainerType<t.BeaconBlock>;
+  SyncCommittee: ContainerType<t.SyncCommittee>;
   BeaconBlock: ContainerType<t.BeaconBlock>;
   BeaconBlockHeader: ContainerType<t.BeaconBlockHeader>;
   BeaconState: ContainerType<t.BeaconState>;


### PR DESCRIPTION
This just provide method to upgrade state. More concerning issue is that we depend on epochCtx from fast transition in a rest of lodestar code and we should use regular one now.

Only solution I see is to add some logic in block processing to generate new epochCtx after state transition. It's slow, but we don't really care when prototyping lightclient with minimal spec. Is that ok?