### PR TITLE
Get connected peers from connection manager

### DIFF
--- a/packages/lodestar/src/api/impl/node/interface.ts
+++ b/packages/lodestar/src/api/impl/node/interface.ts
@@ -7,7 +7,7 @@ import {NodeIdentity, NodePeer} from "../../types";
  */
 export interface INodeApi {
   getNodeIdentity(): Promise<NodeIdentity>;
-  getPeers(): Promise<NodePeer[]>;
+  getPeers(state?: string[], direction?: string[]): Promise<NodePeer[]>;
   getPeer(peerId: string): Promise<NodePeer | null>;
   /**
    * Gets the beacon node version.  Format of version string is derived from schema used by other

--- a/packages/lodestar/src/api/impl/node/node.ts
+++ b/packages/lodestar/src/api/impl/node/node.ts
@@ -7,7 +7,7 @@ import {IBeaconSync} from "../../../sync";
 
 import {IApiOptions} from "../../options";
 import {ApiNamespace, IApiModules} from "../interface";
-import {filterByDirection, filterByState, getPeerState} from "./utils";
+import {filterByStateAndDirection, getPeerState} from "./utils";
 import {INodeApi} from "./interface";
 
 export class NodeApi implements INodeApi {
@@ -54,8 +54,7 @@ export class NodeApi implements INodeApi {
       (state.length === 1 && state[0] === "connected") || direction.length > 0
         ? this.network.getPeers()
         : this.network.getAllPeers();
-    peers = filterByState(peers, this.network, state);
-    peers = filterByDirection(peers, this.network, direction);
+    peers = filterByStateAndDirection(peers, this.network, state, direction);
     for (const peer of peers) {
       const conn = this.network.getPeerConnection(peer.id);
       nodePeers.push({
@@ -63,7 +62,7 @@ export class NodeApi implements INodeApi {
         //TODO: figure out how to get enr of peer
         enr: "",
         lastSeenP2pAddress: conn ? conn.remoteAddr.toString() : "",
-        direction: conn ? conn.stat.direction : "NA",
+        direction: conn ? conn.stat.direction : null,
         state: conn ? getPeerState(conn.stat.status) : "disconnected",
       });
     }

--- a/packages/lodestar/src/api/impl/node/utils.ts
+++ b/packages/lodestar/src/api/impl/node/utils.ts
@@ -15,26 +15,28 @@ export function getPeerState(status: LibP2pConnection["stat"]["status"]): NodePe
   }
 }
 
-export function filterByState(peers: LibP2p.Peer[] = [], network: INetwork, state: string[]): LibP2p.Peer[] {
-  // by default return all
+export function filterByStateAndDirection(
+  peers: LibP2p.Peer[] = [],
+  network: INetwork,
+  state: string[] = [],
+  direction: string[] = []
+): LibP2p.Peer[] {
   if (!state.length) return peers;
   return peers.filter((peer) => {
     const conn = network.getPeerConnection(peer.id);
-    if (!state.includes("disconnected") && (!conn || conn.stat.status === "closed")) return false;
-    // TODO: not sure how to map "connecting" state
-    if (!state.includes("connected") && conn && conn.stat.status === "open") return false;
-    if (!state.includes("disconnecting") && conn && conn.stat.status === "closing") return false;
-    return true;
-  });
-}
+    // by default return all states
+    if (state.length) {
+      if (!state.includes("disconnected") && (!conn || conn.stat.status === "closed")) return false;
+      // TODO: not sure how to map "connecting" state
+      if (!state.includes("connected") && conn && conn.stat.status === "open") return false;
+      if (!state.includes("disconnecting") && conn && conn.stat.status === "closing") return false;
+    }
+    // by default return all directions
+    if (direction.length) {
+      if (!direction.includes("inbound") && conn && conn.stat.direction === "inbound") return false;
+      if (!direction.includes("outbound") && conn && conn.stat.direction === "outbound") return false;
+    }
 
-export function filterByDirection(peers: LibP2p.Peer[] = [], network: INetwork, direction: string[]): LibP2p.Peer[] {
-  // by default return all
-  if (!direction.length) return peers;
-  return peers.filter((peer) => {
-    const conn = network.getPeerConnection(peer.id);
-    if (!direction.includes("inbound") && conn && conn.stat.direction === "inbound") return false;
-    if (!direction.includes("outbound") && conn && conn.stat.direction === "outbound") return false;
     return true;
   });
 }

--- a/packages/lodestar/src/api/impl/node/utils.ts
+++ b/packages/lodestar/src/api/impl/node/utils.ts
@@ -1,4 +1,6 @@
 import {NodePeer} from "../../types";
+import LibP2p from "libp2p";
+import {INetwork} from "../../../network";
 
 export function getPeerState(status: LibP2pConnection["stat"]["status"]): NodePeer["state"] {
   switch (status) {
@@ -11,4 +13,28 @@ export function getPeerState(status: LibP2pConnection["stat"]["status"]): NodePe
     default:
       return "disconnected";
   }
+}
+
+export function filterByState(peers: LibP2p.Peer[] = [], network: INetwork, state: string[]): LibP2p.Peer[] {
+  // by default return all
+  if (!state.length) return peers;
+  return peers.filter((peer) => {
+    const conn = network.getPeerConnection(peer.id);
+    if (!state.includes("disconnected") && (!conn || conn.stat.status === "closed")) return false;
+    // TODO: not sure how to map "connecting" state
+    if (!state.includes("connected") && conn && conn.stat.status === "open") return false;
+    if (!state.includes("disconnecting") && conn && conn.stat.status === "closing") return false;
+    return true;
+  });
+}
+
+export function filterByDirection(peers: LibP2p.Peer[] = [], network: INetwork, direction: string[]): LibP2p.Peer[] {
+  // by default return all
+  if (!direction.length) return peers;
+  return peers.filter((peer) => {
+    const conn = network.getPeerConnection(peer.id);
+    if (!direction.includes("inbound") && conn && conn.stat.direction === "inbound") return false;
+    if (!direction.includes("outbound") && conn && conn.stat.direction === "outbound") return false;
+    return true;
+  });
 }

--- a/packages/lodestar/src/api/rest/controllers/node/getPeers.ts
+++ b/packages/lodestar/src/api/rest/controllers/node/getPeers.ts
@@ -1,13 +1,41 @@
 import {ApiController} from "../types";
 import {objectToExpectedCase} from "@chainsafe/lodestar-utils";
 
-export const getPeers: ApiController = {
+export const getPeers: ApiController<{state: string[] | string; direction: string[] | string}> = {
   url: "/peers",
   opts: {
-    schema: {},
+    schema: {
+      querystring: {
+        type: "object",
+        required: [],
+        properties: {
+          state: {
+            types: "array",
+            uniqueItems: true,
+            maxItems: 4,
+            items: {
+              type: "string",
+              enum: ["disconnected", "connecting", "connected", "disconnecting"],
+            },
+          },
+          direction: {
+            types: "array",
+            uniqueItems: true,
+            maxItems: 2,
+            items: {
+              type: "string",
+              enum: ["inbound", "outbound"],
+            },
+          },
+        },
+      },
+    },
   },
   handler: async function (req, resp) {
-    const peers = await this.api.node.getPeers();
+    const peers = await this.api.node.getPeers(
+      typeof req.query.state === "string" ? [req.query.state] : req.query.state,
+      typeof req.query.direction === "string" ? [req.query.direction] : req.query.direction
+    );
     resp.status(200).send({
       data: peers.map((peer) => objectToExpectedCase(peer, "snake")),
     });

--- a/packages/lodestar/src/api/types/node.ts
+++ b/packages/lodestar/src/api/types/node.ts
@@ -13,5 +13,6 @@ export type NodePeer = {
   enr: string;
   lastSeenP2pAddress: string;
   state: "disconnected" | "connecting" | "connected" | "disconnecting";
-  direction: "inbound" | "outbound" | "NA";
+  // the spec does not specify direction for a disconnected peer, lodestar uses null in that case
+  direction: "inbound" | "outbound" | null;
 };

--- a/packages/lodestar/src/api/types/node.ts
+++ b/packages/lodestar/src/api/types/node.ts
@@ -11,7 +11,7 @@ export type NodeIdentity = {
 export type NodePeer = {
   peerId: string;
   enr: string;
-  address: string;
+  lastSeenP2pAddress: string;
   state: "disconnected" | "connecting" | "connected" | "disconnecting";
-  direction: "inbound" | "outbound";
+  direction: "inbound" | "outbound" | "NA";
 };

--- a/packages/lodestar/src/network/interface.ts
+++ b/packages/lodestar/src/network/interface.ts
@@ -45,7 +45,6 @@ export interface INetworkEvents {
 export type NetworkEventEmitter = StrictEventEmitter<EventEmitter, INetworkEvents>;
 
 export type PeerSearchOptions = {
-  connected: boolean;
   supportsProtocols: string[];
   count?: number;
 };
@@ -63,6 +62,7 @@ export interface INetwork extends NetworkEventEmitter {
   localMultiaddrs: Multiaddr[];
   getEnr(): ENR | undefined;
   getPeers(opts?: Partial<PeerSearchOptions>): LibP2p.Peer[];
+  getAllPeers(): LibP2p.Peer[];
   getMaxPeer(): number;
   /**
    * Get the instance of a connection with a given peer.

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -4,7 +4,7 @@
 
 import {EventEmitter} from "events";
 import LibP2p from "libp2p";
-import PeerId from "peer-id";
+import PeerId, {createFromCID} from "peer-id";
 import Multiaddr from "multiaddr";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils";
@@ -23,6 +23,7 @@ import {IPeerMetadataStore} from "./peers/interface";
 import {Libp2pPeerMetadataStore} from "./peers/metastore";
 import {getPeerCountBySubnet} from "./peers/utils";
 import {IRpcScoreTracker, SimpleRpcScoreTracker} from "./peers/score";
+import {notNullish} from "../util/notNullish";
 
 interface ILibp2pModules {
   config: IBeaconConfig;
@@ -112,29 +113,42 @@ export class Libp2pNetwork extends (EventEmitter as {new (): NetworkEventEmitter
     return discv5Discovery?.discv5?.enr ?? undefined;
   }
 
+  /**
+   * Get connected peers.
+   * @param opts PeerSearchOptions
+   */
   public getPeers(opts: Partial<PeerSearchOptions> = {}): LibP2p.Peer[] {
-    const peers = Array.from(this.libp2p.peerStore.peers.values()).filter((peer) => {
-      if (opts?.connected && !this.getPeerConnection(peer.id)) {
-        return false;
-      }
+    let peers: LibP2p.Peer[];
+    const peerIdStrs = Array.from(this.libp2p.connectionManager.connections.keys());
+    const peerIds = peerIdStrs
+      .map((peerIdStr) => createFromCID(peerIdStr))
+      .filter((peerId) => this.getPeerConnection(peerId));
+    peers = peerIds.map((peerId) => this.libp2p.peerStore.get(peerId)).filter(notNullish);
 
-      this.logger.debug("Peer supported protocols", {
-        id: peer.id.toB58String(),
-        protocols: peer.protocols,
-      });
-
-      if (opts?.supportsProtocols) {
-        for (const protocol of opts.supportsProtocols) {
+    if (opts?.supportsProtocols) {
+      const supportsProtocols = opts.supportsProtocols;
+      peers = peers.filter((peer) => {
+        this.logger.debug("Peer supported protocols", {
+          id: peer.id.toB58String(),
+          protocols: peer.protocols,
+        });
+        for (const protocol of supportsProtocols) {
           if (!peer.protocols.includes(protocol)) {
             return false;
           }
         }
-      }
-
-      return true;
-    });
-
+        return true;
+      });
+    }
     return peers.slice(0, opts?.count ?? peers.length) || [];
+  }
+
+  /**
+   * Get all peers including disconnected ones.
+   * There are probably more than 10k peers, only the api uses this.
+   */
+  public getAllPeers(): LibP2p.Peer[] {
+    return Array.from(this.libp2p.peerStore.peers.values());
   }
 
   public getMaxPeer(): number {
@@ -178,15 +192,14 @@ export class Libp2pNetwork extends (EventEmitter as {new (): NetworkEventEmitter
   }
 
   public async searchSubnetPeers(subnets: string[]): Promise<void> {
-    const knownPeers = Array.from(await this.libp2p.peerStore.peers.values()).map((peer) => peer.id);
-    const connectedPeers = knownPeers.filter((peerId) => !!this.getPeerConnection(peerId));
+    const connectedPeerIds = this.getPeers().map((peer) => peer.id);
 
-    const peerCountBySubnet = getPeerCountBySubnet(connectedPeers, this.peerMetadata, subnets);
+    const peerCountBySubnet = getPeerCountBySubnet(connectedPeerIds, this.peerMetadata, subnets);
     for (const [subnetStr, count] of peerCountBySubnet) {
       if (count === 0) {
         // the validator must discover new peers on this topic
         this.logger.verbose("Finding new peers", {subnet: subnetStr});
-        const found = await this.connectToNewPeersBySubnet(parseInt(subnetStr), knownPeers);
+        const found = await this.connectToNewPeersBySubnet(parseInt(subnetStr));
         if (found) {
           this.logger.verbose("Found new peer", {subnet: subnetStr});
         } else {
@@ -199,12 +212,13 @@ export class Libp2pNetwork extends (EventEmitter as {new (): NetworkEventEmitter
   /**
    * Connect to 1 new peer given a subnet.
    * @param subnet the subnet calculated from committee index
-   * @param knownPeerIds all peer ids in libp2p store
    */
-  private async connectToNewPeersBySubnet(subnet: number, knownPeerIds: PeerId[]): Promise<boolean> {
-    const knownPeers = knownPeerIds.map((peerId) => peerId.toB58String());
+  private async connectToNewPeersBySubnet(subnet: number): Promise<boolean> {
     const discv5Peers = (await this.searchDiscv5Peers(subnet)) || [];
-    const candidatePeers = discv5Peers.filter((peer) => !knownPeers.includes(peer.peerId.toB58String()));
+    // we don't want to connect to known peers
+    const candidatePeers = discv5Peers.filter(
+      (peer) => !this.libp2p.peerStore.addressBook.getMultiaddrsForPeer(peer.peerId)
+    );
 
     let found = false;
     for (const peer of candidatePeers) {

--- a/packages/lodestar/src/network/tasks/checkPeerAliveTask.ts
+++ b/packages/lodestar/src/network/tasks/checkPeerAliveTask.ts
@@ -42,7 +42,7 @@ export class CheckPeerAliveTask {
   public run = async (): Promise<void> => {
     this.logger.info("Running CheckPeerAliveTask");
     this.logger.profile("CheckPeerAliveTask");
-    const peers = this.network.getPeers({connected: true}).map((peer) => peer.id);
+    const peers = this.network.getPeers().map((peer) => peer.id);
     const seq = this.network.metadata.seqNumber;
     await Promise.all(
       peers.map(async (peer) => {

--- a/packages/lodestar/src/network/tasks/diversifyPeersBySubnetTask.ts
+++ b/packages/lodestar/src/network/tasks/diversifyPeersBySubnetTask.ts
@@ -50,7 +50,7 @@ export class DiversifyPeersBySubnetTask {
     this.logger.info("Running DiversifyPeersBySubnetTask");
     this.logger.profile("DiversifyPeersBySubnetTask");
     // network getPeers() is expensive, we don't want to call it multiple times
-    const connectedPeers = this.network.getPeers({connected: true});
+    const connectedPeers = this.network.getPeers();
     const connectedPeerIds = connectedPeers.map((peer) => peer.id);
     const missingSubnets = this.isSynced ? findMissingSubnets(connectedPeerIds, this.network) : [];
     if (missingSubnets.length > 0) {

--- a/packages/lodestar/src/sync/initial/fast/index.ts
+++ b/packages/lodestar/src/sync/initial/fast/index.ts
@@ -209,7 +209,6 @@ export class FastSync extends (EventEmitter as {new (): InitialSyncEventEmitter}
   private getPeerStatuses(): Status[] {
     return this.network
       .getPeers({
-        connected: true,
         supportsProtocols: getSyncProtocols(),
       })
       .map((peer) => this.network.peerMetadata.getStatus(peer.id))

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -89,7 +89,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
     this.network.removeListener("peer:connect", this.handshake);
     await Promise.all(
       this.network
-        .getPeers({connected: true, supportsProtocols: [createRpcProtocol(Method.Goodbye, ReqRespEncoding.SSZ_SNAPPY)]})
+        .getPeers({supportsProtocols: [createRpcProtocol(Method.Goodbye, ReqRespEncoding.SSZ_SNAPPY)]})
         .map(async (peer) => {
           try {
             await this.network.reqResp.goodbye(peer.id, BigInt(GoodByeReasonCode.CLIENT_SHUTDOWN));

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -171,7 +171,7 @@ export class BeaconSync implements IBeaconSync {
 
   private logPeerCount = (): void => {
     this.logger.info("Peer status", {
-      activePeers: this.network.getPeers({connected: true}).length,
+      activePeers: this.network.getPeers().length,
       syncPeers: this.getSyncPeers().length,
       unknownRootPeers: this.getUnknownRootPeers().length,
     });
@@ -200,7 +200,7 @@ export class BeaconSync implements IBeaconSync {
 
   private getPeers(protocols: string[]): PeerId[] {
     return this.network
-      .getPeers({connected: true, supportsProtocols: protocols})
+      .getPeers({supportsProtocols: protocols})
       .filter((peer) => {
         return !!this.network.peerMetadata.getStatus(peer.id) && this.network.peerRpcScores.getScore(peer.id) > 50;
       })

--- a/packages/lodestar/src/sync/utils/peers.ts
+++ b/packages/lodestar/src/sync/utils/peers.ts
@@ -12,7 +12,6 @@ export function getSyncPeers(
   return (
     network
       .getPeers({
-        connected: true,
         supportsProtocols: getSyncProtocols(),
       })
       .map((peer) => peer.id)

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -241,7 +241,7 @@ export async function createStatus(chain: IBeaconChain): Promise<Status> {
 
 export async function syncPeersStatus(network: INetwork, status: Status): Promise<void> {
   await Promise.all(
-    network.getPeers({connected: true, supportsProtocols: getStatusProtocols()}).map(async (peer) => {
+    network.getPeers({supportsProtocols: getStatusProtocols()}).map(async (peer) => {
       try {
         network.peerMetadata.setStatus(peer.id, await network.reqResp.status(peer.id, status));
         // eslint-disable-next-line no-empty

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -101,8 +101,8 @@ describe("[network] network", function () {
     ]);
     expect(connectACount).to.be.equal(1);
     expect(connectBCount).to.be.equal(1);
-    expect(netA.getPeers({connected: true}).length).to.equal(1);
-    expect(netB.getPeers({connected: true}).length).to.equal(1);
+    expect(netA.getPeers().length).to.equal(1);
+    expect(netB.getPeers().length).to.equal(1);
   });
   it("should delete a peer on disconnect", async function () {
     const connected = Promise.all([
@@ -120,8 +120,8 @@ describe("[network] network", function () {
     await netA.disconnect(netB.peerId);
     await disconnection;
     await sleep(200);
-    expect(netA.getPeers({connected: true}).length).to.equal(0);
-    expect(netB.getPeers({connected: true}).length).to.equal(0);
+    expect(netA.getPeers().length).to.equal(0);
+    expect(netB.getPeers().length).to.equal(0);
   });
   it("should not receive duplicate block", async function () {
     const connected = Promise.all([
@@ -274,6 +274,6 @@ describe("[network] network", function () {
     discovery.discv5.addEnr(enrB);
     await netA.searchSubnetPeers([subnet.toString()]);
     await connected;
-    expect(netA.getPeers({connected: true}).length).to.be.equal(1);
+    expect(netA.getPeers().length).to.be.equal(1);
   });
 });

--- a/packages/lodestar/test/unit/api/rest/node/getPeer.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getPeer.test.ts
@@ -37,7 +37,7 @@ describe("rest - node - getPeer", function () {
 
   it("should succeed", async function () {
     api.node.getPeer.resolves({
-      address: "/ip4/127.0.0.1/tcp/36000",
+      lastSeenP2pAddress: "/ip4/127.0.0.1/tcp/36000",
       direction: "inbound",
       enr: "enr-",
       peerId: "16",

--- a/packages/lodestar/test/unit/api/rest/node/getPeers.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getPeers.test.ts
@@ -36,9 +36,9 @@ describe("rest - node - getPeers", function () {
   });
 
   it("should succeed", async function () {
-    api.node.getPeers.resolves([
+    api.node.getPeers.withArgs(["connected"], undefined).resolves([
       {
-        address: "/ip4/127.0.0.1/tcp/36000",
+        lastSeenP2pAddress: "/ip4/127.0.0.1/tcp/36000",
         direction: "inbound",
         enr: "enr-",
         peerId: "16",
@@ -47,6 +47,7 @@ describe("rest - node - getPeers", function () {
     ]);
     const response = await supertest(restApi.server.server)
       .get(urlJoin(NODE_PREFIX, getPeers.url))
+      .query({state: "connected"})
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
     expect(response.body.data).to.not.be.undefined;

--- a/packages/lodestar/test/unit/network/peers/utils.test.ts
+++ b/packages/lodestar/test/unit/network/peers/utils.test.ts
@@ -164,7 +164,7 @@ describe("network peer utils", function () {
     });
 
     it("should return all non sync peers", async () => {
-      networkStub.getPeers.withArgs({connected: true}).returns(peers.map((peerId) => ({id: peerId} as LibP2p.Peer)));
+      networkStub.getPeers.returns(peers.map((peerId) => ({id: peerId} as LibP2p.Peer)));
 
       // so none of them are good score sync peers
       getSyncPeersStub.returns([]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8160,7 +8160,7 @@ libp2p-tcp@^0.15.0, libp2p-tcp@^0.15.1:
 
 "libp2p-ts@https://github.com/ChainSafe/libp2p-ts.git":
   version "0.1.0"
-  resolved "https://github.com/ChainSafe/libp2p-ts.git#6df33647430d0bb296c6f2b4ab4228d661b381cc"
+  resolved "https://github.com/ChainSafe/libp2p-ts.git#86c1d9eca212194c8a5ce1ea6572a3bd694103e5"
   dependencies:
     "@chainsafe/discv5" "^0.5.0"
     "@types/node" "^13.7.0"


### PR DESCRIPTION
resolves #1897 

+ get connected peers directly from libp2p connection manager should be faster than looping through every peers in the libp2p store. Note that libp2p peer store may contain peers from testnets as well.
+ `getPeers()` default to get connected peers, added `getAllPeers()` which loop through peer store just for the api
+ correct `getPeer` Rest api: add `state` and `direction` query params
+ improve `searchSubnetPeers` by not loading all known peers from the peer store


<img width="696" alt="Screen Shot 2020-12-24 at 16 21 13" src="https://user-images.githubusercontent.com/10568965/103078284-1c16c580-4604-11eb-881e-61dd4eba88be.png">
