### PR TITLE
Add withTimeout utility

### DIFF
--- a/packages/lodestar-utils/package.json
+++ b/packages/lodestar-utils/package.json
@@ -39,6 +39,7 @@
     "@chainsafe/bls": "5.1.0",
     "@chainsafe/ssz": "^0.6.13",
     "abort-controller": "^3.0.0",
+    "any-signal": "2.1.1",
     "bigint-buffer": "^1.1.5",
     "chalk": "^2.4.2",
     "event-iterator": "^2.0.0",

--- a/packages/lodestar-utils/src/errors.ts
+++ b/packages/lodestar-utils/src/errors.ts
@@ -34,3 +34,12 @@ export class ErrorAborted extends Error {
     super(`Aborted ${message || ""}`);
   }
 }
+
+/**
+ * Throw this error when wrapped timeout expires
+ */
+export class TimeoutError extends Error {
+  constructor(message?: string) {
+    super(`Timeout ${message || ""}`);
+  }
+}

--- a/packages/lodestar-utils/src/index.ts
+++ b/packages/lodestar-utils/src/index.ts
@@ -9,6 +9,7 @@ export * from "./misc";
 export * from "./objects";
 export * from "./sleep";
 export * from "./sort";
+export * from "./timeout";
 export * from "./verifyMerkleBranch";
 export * from "./json";
 export * from "./interop";

--- a/packages/lodestar-utils/src/timeout.ts
+++ b/packages/lodestar-utils/src/timeout.ts
@@ -1,0 +1,20 @@
+import {AbortSignal, AbortController} from "abort-controller";
+import {anySignal} from "any-signal";
+import {TimeoutError} from "./errors";
+import {sleep} from "./sleep";
+
+export async function withTimeout<T>(asyncFn: () => Promise<T>, timeoutMs: number, signal?: AbortSignal): Promise<T> {
+  const timeoutAbortController = new AbortController();
+  const bothSignal = anySignal([timeoutAbortController.signal, ...(signal ? [signal] : [])]);
+
+  async function timeoutPromise(): Promise<never> {
+    await sleep(timeoutMs, bothSignal as AbortSignal);
+    throw new TimeoutError();
+  }
+
+  try {
+    return await Promise.race([asyncFn(), timeoutPromise()]);
+  } finally {
+    timeoutAbortController.abort();
+  }
+}

--- a/packages/lodestar-utils/test/unit/timeout.test.ts
+++ b/packages/lodestar-utils/test/unit/timeout.test.ts
@@ -1,0 +1,79 @@
+import chai, {expect} from "chai";
+import chaiAsPromised from "chai-as-promised";
+import {AbortController} from "abort-controller";
+import {withTimeout} from "../../src/timeout";
+import {ErrorAborted, TimeoutError} from "../../src/errors";
+
+chai.use(chaiAsPromised);
+
+describe("withTimeout", function () {
+  const data = "DATA";
+  const shortTimeoutMs = 10;
+  // Sleep for longer than the current test timeout.
+  // If the abort signal doesn't work mocha will throw a timeout error
+  const longTimeoutMs = 2 * this.timeout();
+
+  const pendingTimeouts: NodeJS.Timeout[] = [];
+
+  // Clear the timeouts of the mock async functions to not hang tests
+  afterEach(() => {
+    for (const pendingTimeout of pendingTimeouts) {
+      clearTimeout(pendingTimeout);
+    }
+  });
+
+  /**
+   * Simulates an async task that may or may not resolve quickly
+   * Simple pause for testing only. Clears the timeouts to not hang the tests
+   */
+  async function pause<T>(ms: number, returnValue: T): Promise<T> {
+    await new Promise((r) => {
+      pendingTimeouts.push(setTimeout(r, ms));
+    });
+    return returnValue;
+  }
+
+  it("Should resolve timeout", async function () {
+    const res = await withTimeout(() => pause(shortTimeoutMs, data), longTimeoutMs);
+    expect(res).to.equal(data);
+  });
+
+  it("Should resolve timeout with not triggered signal", async function () {
+    const controller = new AbortController();
+
+    const res = await withTimeout(() => pause(shortTimeoutMs, data), longTimeoutMs, controller.signal);
+    expect(res).to.equal(data);
+  });
+
+  it("Should abort timeout with triggered signal", async function () {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), shortTimeoutMs);
+
+    await expect(withTimeout(() => pause(longTimeoutMs, data), longTimeoutMs, controller.signal)).to.rejectedWith(
+      ErrorAborted
+    );
+  });
+
+  it("Should timeout with no signal", async function () {
+    await expect(withTimeout(() => pause(longTimeoutMs, data), shortTimeoutMs)).to.rejectedWith(TimeoutError);
+  });
+
+  it("Should timeout with not triggered signal", async function () {
+    const controller = new AbortController();
+
+    await expect(withTimeout(() => pause(longTimeoutMs, data), shortTimeoutMs, controller.signal)).to.rejectedWith(
+      TimeoutError
+    );
+  });
+
+  it("Should abort timeout with already aborted signal", async function () {
+    const controller = new AbortController();
+
+    controller.abort();
+    expect(controller.signal.aborted, "Signal should already be aborted").to.be.true;
+
+    await expect(withTimeout(() => pause(shortTimeoutMs, data), shortTimeoutMs, controller.signal)).to.rejectedWith(
+      ErrorAborted
+    );
+  });
+});

--- a/packages/lodestar-validator/package.json
+++ b/packages/lodestar-validator/package.json
@@ -52,7 +52,6 @@
     "@chainsafe/ssz": "^0.6.13",
     "abort-controller": "^3.0.0",
     "abortable-iterator": "^3.0.0",
-    "any-signal": "2.1.1",
     "axios": "^0.19.0",
     "axios-mock-adapter": "^1.17.0",
     "bigint-buffer": "^1.1.5",

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -59,7 +59,6 @@
     "@types/datastore-level": "^1.1.1",
     "abort-controller": "^3.0.0",
     "abortable-iterator": "^3.0.0",
-    "any-signal": "2.1.1",
     "bl": "^4.0.2",
     "cross-fetch": "^3.0.6",
     "datastore-level": "^2.0.0",

--- a/packages/lodestar/src/network/util.ts
+++ b/packages/lodestar/src/network/util.ts
@@ -10,8 +10,8 @@ import {source as abortSource} from "abortable-iterator";
 import Multiaddr from "multiaddr";
 import {networkInterfaces} from "os";
 import {ENR} from "@chainsafe/discv5";
+import {withTimeout} from "@chainsafe/lodestar-utils";
 import {RESPONSE_TIMEOUT_ERR} from "./error";
-import {anySignal} from "any-signal";
 
 // req/resp
 
@@ -136,29 +136,15 @@ export async function dialProtocol(
   timeout: number,
   signal?: AbortSignal
 ): ReturnType<LibP2p["dialProtocol"]> {
-  const abortController = new AbortController();
-
-  const timer = setTimeout(() => {
-    abortController.abort();
-  }, timeout);
-
-  const signals = [abortController.signal];
-  if (signal) {
-    signals.push(signal);
-  }
-
-  const abortSignal = anySignal(signals);
-
-  try {
-    const conn = await libp2p.dialProtocol(peerId, protocol, {signal: abortSignal});
-    if (!conn) {
-      throw new Error("timeout");
-    }
-    return conn;
-  } catch (e) {
-    const err = new Error(e.code || e.message);
-    throw err;
-  } finally {
-    clearTimeout(timer);
-  }
+  return await withTimeout(
+    async (timeoutAndParentSignal) => {
+      const conn = await libp2p.dialProtocol(peerId, protocol, {signal: timeoutAndParentSignal});
+      if (!conn) {
+        throw new Error("timeout");
+      }
+      return conn;
+    },
+    timeout,
+    signal
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12853,3 +12853,4 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+


### PR DESCRIPTION
Abstract and generalizes a very useful helper to wrap async functions in a timeout with an abort signal. This utility is currently only used in the dialProtocol utility but personally, I have to use it in other functions on a PR I'm working on.
