### PR TITLE
Fix it-pipe types

### DIFF
--- a/packages/lodestar/src/network/reqresp/reqResp.ts
+++ b/packages/lodestar/src/network/reqresp/reqResp.ts
@@ -59,8 +59,9 @@ export class ReqResp extends (EventEmitter as IReqEventEmitterClass) implements 
       for (const encoding of Object.values(ReqRespEncoding)) {
         this.libp2p.handle(createRpcProtocol(method, encoding), async ({connection, stream}) => {
           const peerId = connection.remotePeer;
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           pipe(
-            stream.source,
+            stream.source as AsyncIterable<Buffer>,
             eth2RequestDecode(this.config, this.logger, method, encoding),
             this.storePeerEncodingPreference(peerId, method, encoding),
             this.handleRpcRequest(peerId, method, encoding, stream.sink)

--- a/packages/lodestar/src/network/reqresp/reqResp.ts
+++ b/packages/lodestar/src/network/reqresp/reqResp.ts
@@ -59,8 +59,7 @@ export class ReqResp extends (EventEmitter as IReqEventEmitterClass) implements 
       for (const encoding of Object.values(ReqRespEncoding)) {
         this.libp2p.handle(createRpcProtocol(method, encoding), async ({connection, stream}) => {
           const peerId = connection.remotePeer;
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          pipe(
+          void pipe(
             stream.source as AsyncIterable<Buffer>,
             eth2RequestDecode(this.config, this.logger, method, encoding),
             this.storePeerEncodingPreference(peerId, method, encoding),

--- a/packages/lodestar/src/network/reqresp/reqUtils.ts
+++ b/packages/lodestar/src/network/reqresp/reqUtils.ts
@@ -96,7 +96,7 @@ export async function* sendRequestStream<T extends ResponseBody>(
   logger.verbose("sent request", {peer: peerId.toB58String(), method});
 
   yield* pipe(
-    abortDuplex(conn!.stream, controller.signal, {returnOnAbort: true}),
+    abortDuplex<Buffer, void>(conn!.stream, controller.signal, {returnOnAbort: true}).source,
     eth2ResponseTimer(controller),
     eth2ResponseDecode(config, logger, method, encoding, requestId, controller)
   ) as AsyncIterable<T>;

--- a/packages/lodestar/src/network/reqresp/reqUtils.ts
+++ b/packages/lodestar/src/network/reqresp/reqUtils.ts
@@ -20,7 +20,7 @@ import {eth2RequestEncode} from "../encoders/request";
 import {eth2ResponseDecode} from "../encoders/response";
 import {REQUEST_TIMEOUT_ERR} from "../error";
 
-interface ILibp2pConn {
+export interface ILibp2pConn {
   stream: {
     source: AsyncIterable<Buffer>;
     sink: (source: AsyncIterable<Buffer>) => void;

--- a/packages/lodestar/test/e2e/sync/reqResp.test.ts
+++ b/packages/lodestar/test/e2e/sync/reqResp.test.ts
@@ -15,7 +15,7 @@ import {createRpcProtocol, Libp2pNetwork} from "../../../src/network";
 import {decodeP2pErrorMessage} from "../../../src/network/encoders/response";
 import {IGossipMessageValidator} from "../../../src/network/gossip/interface";
 import {INetworkOptions} from "../../../src/network/options";
-import {ReqRespRequest} from "../../../src/network/reqresp";
+import {ILibp2pConn, ReqRespRequest} from "../../../src/network/reqresp";
 import {BeaconReqRespHandler, IReqRespHandler} from "../../../src/sync/reqResp";
 import {generateEmptySignedBlock} from "../../utils/block";
 import {getBlockSummary} from "../../utils/headBlockInfo";
@@ -200,7 +200,7 @@ describe("[sync] rpc", function () {
   it("should return invalid request status code", async () => {
     const protocol = createRpcProtocol(Method.Status, ReqRespEncoding.SSZ_SNAPPY);
     await netA.connect(netB.peerId, netB.localMultiaddrs);
-    const {stream} = (await libP2pA.dialProtocol(netB.peerId, protocol)) as {stream: Stream};
+    const {stream} = (await libP2pA.dialProtocol(netB.peerId, protocol)) as ILibp2pConn;
     await pipe([Buffer.from(encode(99999999999999999999999))], stream as any, async (source: AsyncIterable<Buffer>) => {
       let i = 0;
       // 1 chunk of status and 1 chunk of error

--- a/packages/lodestar/test/e2e/sync/reqResp.test.ts
+++ b/packages/lodestar/test/e2e/sync/reqResp.test.ts
@@ -201,7 +201,7 @@ describe("[sync] rpc", function () {
     const protocol = createRpcProtocol(Method.Status, ReqRespEncoding.SSZ_SNAPPY);
     await netA.connect(netB.peerId, netB.localMultiaddrs);
     const {stream} = (await libP2pA.dialProtocol(netB.peerId, protocol)) as {stream: Stream};
-    await pipe([Buffer.from(encode(99999999999999999999999))], stream, async (source: AsyncIterable<Buffer>) => {
+    await pipe([Buffer.from(encode(99999999999999999999999))], stream as any, async (source: AsyncIterable<Buffer>) => {
       let i = 0;
       // 1 chunk of status and 1 chunk of error
       for await (const val of source) {

--- a/packages/lodestar/test/unit/network/encoders/request.test.ts
+++ b/packages/lodestar/test/unit/network/encoders/request.test.ts
@@ -33,7 +33,7 @@ describe("request encoders", function () {
     );
 
     expect(requests.length).to.be.equal(1);
-    expect(config.types.Uint64.equals(requests[0].body, BigInt(0))).to.be.true;
+    expect(config.types.Uint64.equals(requests[0].body as bigint, BigInt(0))).to.be.true;
   });
 
   it("should work - basic request - ssz_snappy", async function () {
@@ -45,7 +45,7 @@ describe("request encoders", function () {
     );
 
     expect(requests.length).to.be.equal(1);
-    expect(config.types.Uint64.equals(requests[0].body, BigInt(0))).to.be.true;
+    expect(config.types.Uint64.equals(requests[0].body as bigint, BigInt(0))).to.be.true;
   });
 
   it("should work - container request - ssz", async function () {
@@ -58,7 +58,7 @@ describe("request encoders", function () {
     );
 
     expect(requests.length).to.be.equal(1);
-    expect(config.types.Status.equals(requests[0].body, status)).to.be.true;
+    expect(config.types.Status.equals(requests[0].body as Status, status)).to.be.true;
   });
 
   it("should work - container request - ssz", async function () {
@@ -71,7 +71,7 @@ describe("request encoders", function () {
     );
 
     expect(requests.length).to.be.equal(1);
-    expect(config.types.Status.equals(requests[0].body, status)).to.be.true;
+    expect(config.types.Status.equals(requests[0].body as Status, status)).to.be.true;
   });
 
   it("should work - multiple request - ssz", async function () {
@@ -83,7 +83,7 @@ describe("request encoders", function () {
     );
 
     expect(requests.length).to.be.equal(1);
-    expect(config.types.Uint64.equals(requests[0].body, BigInt(1))).to.be.true;
+    expect(config.types.Uint64.equals(requests[0].body as bigint, BigInt(1))).to.be.true;
   });
 
   it("should work - multiple request - ssz_snappy", async function () {
@@ -95,7 +95,7 @@ describe("request encoders", function () {
     );
 
     expect(requests.length).to.be.equal(1);
-    expect(config.types.Uint64.equals(requests[0].body, BigInt(1))).to.be.true;
+    expect(config.types.Uint64.equals(requests[0].body as bigint, BigInt(1))).to.be.true;
   });
 
   it("should work - no request body - ssz", async function () {
@@ -171,6 +171,7 @@ describe("request encoders", function () {
     it("should yield correct RequestBody if correct ssz", async function () {
       const status: Status = config.types.Status.defaultValue();
       status.finalizedEpoch = 100;
+      // @ts-ignore
       const validatedRequestBody: unknown[] = await pipe(
         [Buffer.from(encode(config.types.Status.minSize())), config.types.Status.serialize(status)],
         eth2RequestDecode(config, logger, Method.Status, ReqRespEncoding.SSZ),

--- a/packages/lodestar/test/unit/network/encoders/request.test.ts
+++ b/packages/lodestar/test/unit/network/encoders/request.test.ts
@@ -125,7 +125,7 @@ describe("request encoders", function () {
 
   describe("eth2RequestDecode - request validation", () => {
     it("should yield {isValid: false} if it takes more than 10 bytes for varint", async function () {
-      const validatedRequestBody: unknown[] = await pipe(
+      const validatedRequestBody = await pipe(
         [Buffer.from(encode(99999999999999999999999))],
         eth2RequestDecode(config, loggerStub, Method.Status, ReqRespEncoding.SSZ_SNAPPY),
         all
@@ -136,7 +136,7 @@ describe("request encoders", function () {
     });
 
     it("should yield {isValid: false} if failed ssz size bound validation", async function () {
-      const validatedRequestBody: unknown[] = await pipe(
+      const validatedRequestBody = await pipe(
         [Buffer.alloc(12, 0)],
         eth2RequestDecode(config, loggerStub, Method.Status, ReqRespEncoding.SSZ_SNAPPY),
         all
@@ -147,7 +147,7 @@ describe("request encoders", function () {
     });
 
     it("should yield {isValid: false} if it read more than maxEncodedLen", async function () {
-      const validatedRequestBody: unknown[] = await pipe(
+      const validatedRequestBody = await pipe(
         [Buffer.from(encode(config.types.Status.minSize())), Buffer.alloc(config.types.Status.minSize() + 10)],
         eth2RequestDecode(config, loggerStub, Method.Status, ReqRespEncoding.SSZ),
         all
@@ -158,7 +158,7 @@ describe("request encoders", function () {
     });
 
     it("should yield {isValid: false} if failed ssz snappy input malformed", async function () {
-      const validatedRequestBody: unknown[] = await pipe(
+      const validatedRequestBody = await pipe(
         [Buffer.from(encode(config.types.Status.minSize())), Buffer.from("wrong snappy data")],
         eth2RequestDecode(config, loggerStub, Method.Status, ReqRespEncoding.SSZ_SNAPPY),
         all
@@ -171,9 +171,10 @@ describe("request encoders", function () {
     it("should yield correct RequestBody if correct ssz", async function () {
       const status: Status = config.types.Status.defaultValue();
       status.finalizedEpoch = 100;
-      // @ts-ignore
-      const validatedRequestBody: unknown[] = await pipe(
-        [Buffer.from(encode(config.types.Status.minSize())), config.types.Status.serialize(status)],
+      const length = Buffer.from(encode(config.types.Status.minSize()));
+      const statusSerialized = Buffer.from(config.types.Status.serialize(status));
+      const validatedRequestBody = await pipe(
+        [length, statusSerialized],
         eth2RequestDecode(config, logger, Method.Status, ReqRespEncoding.SSZ),
         all
       );

--- a/packages/lodestar/test/unit/network/encoders/response.test.ts
+++ b/packages/lodestar/test/unit/network/encoders/response.test.ts
@@ -48,9 +48,8 @@ describe("response decoders", function () {
   });
 
   it("should work - single error - ssz", async function () {
-    // @ts-ignore
-    const responses: ResponseBody[] = await pipe(
-      [{status: 1}],
+    const responses = await pipe(
+      [{status: 1} as IResponseChunk],
       eth2ResponseEncode(config, logger, Method.Goodbye, ReqRespEncoding.SSZ),
       eth2ResponseDecode(config, logger, Method.Goodbye, ReqRespEncoding.SSZ, "abc", fakeController),
       all
@@ -60,9 +59,8 @@ describe("response decoders", function () {
   });
 
   it("should work - single error - ssz_snappy", async function () {
-    // @ts-ignore
-    const responses: ResponseBody[] = await pipe(
-      [{status: 1}],
+    const responses = await pipe(
+      [{status: 1} as IResponseChunk],
       eth2ResponseEncode(config, logger, Method.Goodbye, ReqRespEncoding.SSZ_SNAPPY),
       eth2ResponseDecode(config, logger, Method.Goodbye, ReqRespEncoding.SSZ_SNAPPY, "abc", fakeController),
       all
@@ -72,9 +70,8 @@ describe("response decoders", function () {
   });
 
   it("should work - single response simple- ssz", async function () {
-    // @ts-ignore
-    const responses: ResponseBody[] = await pipe(
-      [{status: 0, body: BigInt(1)}],
+    const responses = await pipe(
+      [{status: 0, body: BigInt(1)} as IResponseChunk],
       eth2ResponseEncode(config, logger, Method.Ping, ReqRespEncoding.SSZ),
       eth2ResponseDecode(config, logger, Method.Ping, ReqRespEncoding.SSZ, "abc", fakeController),
       all
@@ -85,9 +82,8 @@ describe("response decoders", function () {
   });
 
   it("should work - single response simple - ssz_snappy", async function () {
-    // @ts-ignore
-    const responses: ResponseBody[] = await pipe(
-      [{status: 0, body: BigInt(1)}],
+    const responses = await pipe(
+      [{status: 0, body: BigInt(1)} as IResponseChunk],
       eth2ResponseEncode(config, logger, Method.Ping, ReqRespEncoding.SSZ_SNAPPY),
       eth2ResponseDecode(config, logger, Method.Ping, ReqRespEncoding.SSZ_SNAPPY, "abc", fakeController),
       all
@@ -100,14 +96,9 @@ describe("response decoders", function () {
   it("should work - single response simple (sent multiple)- ssz", async function () {
     const controller = new AbortController();
 
-    // @ts-ignore
-    const responses: ResponseBody[] = await pipe(
-      // @ts-ignore
+    const responses = await pipe(
       abortSource(
-        [
-          {status: 0, body: BigInt(1)},
-          {status: 0, body: BigInt(1)},
-        ],
+        [{status: 0, body: BigInt(1)} as IResponseChunk, {status: 0, body: BigInt(1)} as IResponseChunk],
         controller.signal,
         {returnOnAbort: true}
       ),
@@ -123,14 +114,9 @@ describe("response decoders", function () {
   it("should work - single response simple (sent multiple) - ssz_snappy", async function () {
     const controller = new AbortController();
 
-    // @ts-ignore
     const responses: ResponseBody[] = await pipe(
-      // @ts-ignore
       abortSource(
-        [
-          {status: 0, body: BigInt(1)},
-          {status: 0, body: BigInt(1)},
-        ],
+        [{status: 0, body: BigInt(1)} as IResponseChunk, {status: 0, body: BigInt(1)} as IResponseChunk],
         controller.signal,
         {returnOnAbort: true}
       ),
@@ -146,9 +132,8 @@ describe("response decoders", function () {
   it("should work - single response complex- ssz", async function () {
     const status = createStatus();
 
-    // @ts-ignore
     const responses: ResponseBody[] = await pipe(
-      [{status: 0, body: status}],
+      [{status: 0, body: status} as IResponseChunk],
       eth2ResponseEncode(config, logger, Method.Status, ReqRespEncoding.SSZ),
       eth2ResponseDecode(config, logger, Method.Status, ReqRespEncoding.SSZ, "abc", fakeController),
       all
@@ -161,9 +146,8 @@ describe("response decoders", function () {
   it("should work - single response complex - ssz_snappy", async function () {
     const status = createStatus();
 
-    // @ts-ignore
     const responses: ResponseBody[] = await pipe(
-      [{status: 0, body: status}],
+      [{status: 0, body: status} as IResponseChunk],
       eth2ResponseEncode(config, logger, Method.Status, ReqRespEncoding.SSZ_SNAPPY),
       eth2ResponseDecode(config, logger, Method.Status, ReqRespEncoding.SSZ_SNAPPY, "abc", fakeController),
       all

--- a/packages/lodestar/test/unit/network/encoders/response.test.ts
+++ b/packages/lodestar/test/unit/network/encoders/response.test.ts
@@ -48,7 +48,8 @@ describe("response decoders", function () {
   });
 
   it("should work - single error - ssz", async function () {
-    const responses = await pipe(
+    // @ts-ignore
+    const responses: ResponseBody[] = await pipe(
       [{status: 1}],
       eth2ResponseEncode(config, logger, Method.Goodbye, ReqRespEncoding.SSZ),
       eth2ResponseDecode(config, logger, Method.Goodbye, ReqRespEncoding.SSZ, "abc", fakeController),
@@ -59,7 +60,8 @@ describe("response decoders", function () {
   });
 
   it("should work - single error - ssz_snappy", async function () {
-    const responses = await pipe(
+    // @ts-ignore
+    const responses: ResponseBody[] = await pipe(
       [{status: 1}],
       eth2ResponseEncode(config, logger, Method.Goodbye, ReqRespEncoding.SSZ_SNAPPY),
       eth2ResponseDecode(config, logger, Method.Goodbye, ReqRespEncoding.SSZ_SNAPPY, "abc", fakeController),
@@ -70,7 +72,8 @@ describe("response decoders", function () {
   });
 
   it("should work - single response simple- ssz", async function () {
-    const responses = await pipe(
+    // @ts-ignore
+    const responses: ResponseBody[] = await pipe(
       [{status: 0, body: BigInt(1)}],
       eth2ResponseEncode(config, logger, Method.Ping, ReqRespEncoding.SSZ),
       eth2ResponseDecode(config, logger, Method.Ping, ReqRespEncoding.SSZ, "abc", fakeController),
@@ -78,11 +81,12 @@ describe("response decoders", function () {
     );
 
     expect(responses.length).to.be.equal(1);
-    expect(config.types.Ping.equals(BigInt(1), responses[0])).to.be.true;
+    expect(config.types.Ping.equals(BigInt(1), responses[0] as bigint)).to.be.true;
   });
 
   it("should work - single response simple - ssz_snappy", async function () {
-    const responses = await pipe(
+    // @ts-ignore
+    const responses: ResponseBody[] = await pipe(
       [{status: 0, body: BigInt(1)}],
       eth2ResponseEncode(config, logger, Method.Ping, ReqRespEncoding.SSZ_SNAPPY),
       eth2ResponseDecode(config, logger, Method.Ping, ReqRespEncoding.SSZ_SNAPPY, "abc", fakeController),
@@ -90,13 +94,15 @@ describe("response decoders", function () {
     );
 
     expect(responses.length).to.be.equal(1);
-    expect(config.types.Ping.equals(BigInt(1), responses[0])).to.be.true;
+    expect(config.types.Ping.equals(BigInt(1), responses[0] as bigint)).to.be.true;
   });
 
   it("should work - single response simple (sent multiple)- ssz", async function () {
     const controller = new AbortController();
 
-    const responses = await pipe(
+    // @ts-ignore
+    const responses: ResponseBody[] = await pipe(
+      // @ts-ignore
       abortSource(
         [
           {status: 0, body: BigInt(1)},
@@ -111,13 +117,15 @@ describe("response decoders", function () {
     );
 
     expect(responses.length).to.be.equal(1);
-    expect(config.types.Ping.equals(BigInt(1), responses[0])).to.be.true;
+    expect(config.types.Ping.equals(BigInt(1), responses[0] as bigint)).to.be.true;
   });
 
   it("should work - single response simple (sent multiple) - ssz_snappy", async function () {
     const controller = new AbortController();
 
-    const responses = await pipe(
+    // @ts-ignore
+    const responses: ResponseBody[] = await pipe(
+      // @ts-ignore
       abortSource(
         [
           {status: 0, body: BigInt(1)},
@@ -132,13 +140,14 @@ describe("response decoders", function () {
     );
 
     expect(responses.length).to.be.equal(1);
-    expect(config.types.Ping.equals(BigInt(1), responses[0])).to.be.true;
+    expect(config.types.Ping.equals(BigInt(1), responses[0] as bigint)).to.be.true;
   });
 
   it("should work - single response complex- ssz", async function () {
     const status = createStatus();
 
-    const responses = await pipe(
+    // @ts-ignore
+    const responses: ResponseBody[] = await pipe(
       [{status: 0, body: status}],
       eth2ResponseEncode(config, logger, Method.Status, ReqRespEncoding.SSZ),
       eth2ResponseDecode(config, logger, Method.Status, ReqRespEncoding.SSZ, "abc", fakeController),
@@ -146,13 +155,14 @@ describe("response decoders", function () {
     );
 
     expect(responses.length).to.be.equal(1);
-    expect(config.types.Status.equals(status, responses[0])).to.be.true;
+    expect(config.types.Status.equals(status, responses[0] as Status)).to.be.true;
   });
 
   it("should work - single response complex - ssz_snappy", async function () {
     const status = createStatus();
 
-    const responses = await pipe(
+    // @ts-ignore
+    const responses: ResponseBody[] = await pipe(
       [{status: 0, body: status}],
       eth2ResponseEncode(config, logger, Method.Status, ReqRespEncoding.SSZ_SNAPPY),
       eth2ResponseDecode(config, logger, Method.Status, ReqRespEncoding.SSZ_SNAPPY, "abc", fakeController),
@@ -160,7 +170,7 @@ describe("response decoders", function () {
     );
 
     expect(responses.length).to.be.equal(1);
-    expect(config.types.Status.equals(status, responses[0])).to.be.true;
+    expect(config.types.Status.equals(status, responses[0] as Status)).to.be.true;
   });
 
   it("should work - response stream- ssz", async function () {

--- a/packages/lodestar/test/unit/sync/utils/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/sync.test.ts
@@ -153,13 +153,13 @@ describe("sync utils", function () {
     it("no peers", async function () {
       getPeersStub.resolves([]);
       getBlockRangeStub.resolves([generateEmptySignedBlock()]);
-      let result = pipe(
+      const resultPromise = pipe(
         [{start: 0, end: 10}],
         fetchBlockChunks(logger, sinon.createStubInstance(ReqResp), getPeersStub),
         all
       );
       await sandbox.clock.tickAsync(30000);
-      result = await result;
+      const result = await resultPromise;
       expect(result.length).to.be.equal(1);
       expect(result[0]).to.be.null;
     });

--- a/packages/lodestar/tsconfig.json
+++ b/packages/lodestar/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig",
   "include": ["src", "test"],
+  "exclude": ["../../node_modules/it-pipe"],
   "compilerOptions": {
     "typeRoots": ["../../node_modules/@types", "../../node_modules/libp2p-ts/types", "./types"],
     "outDir": "lib",

--- a/packages/lodestar/types/abortable-iterator/index.d.ts
+++ b/packages/lodestar/types/abortable-iterator/index.d.ts
@@ -1,0 +1,26 @@
+declare module "abortable-iterator" {
+  type Source<T> = AsyncIterable<T>;
+  type Sink<TSource, TReturn = void> = (source: Source<TSource>) => TReturn;
+  type Duplex<TSource = unknown, TReturn = unknown> = {
+    sink: Sink<TSource, TReturn>;
+    source: Source<TSource>;
+  };
+
+  type Options<T> = {
+    onAbort?: (source: Source<T>) => void;
+    abortMessage?: string;
+    abortCode?: string;
+    returnOnAbort?: boolean;
+  };
+
+  function source<T>(source: Source<T>, signal?: AbortSignal, options?: Options<T>): AsyncIterable<T>;
+
+  function duplex<TSource = unknown, TReturn = unknown>(
+    duplex: Duplex<TSource, TReturn>,
+    signal?: AbortSignal,
+    options?: Options<TSource>
+  ): Duplex<TSource, TReturn>;
+
+  export {source, duplex};
+  export default source;
+}

--- a/packages/lodestar/types/abortable-iterator/index.d.ts
+++ b/packages/lodestar/types/abortable-iterator/index.d.ts
@@ -13,6 +13,7 @@ declare module "abortable-iterator" {
     returnOnAbort?: boolean;
   };
 
+  function source<T>(source: T[], signal?: AbortSignal, options?: Options<T>): AsyncIterable<T>;
   function source<T>(source: Source<T>, signal?: AbortSignal, options?: Options<T>): AsyncIterable<T>;
 
   function duplex<TSource = unknown, TReturn = unknown>(

--- a/packages/lodestar/types/it-pipe/index.d.ts
+++ b/packages/lodestar/types/it-pipe/index.d.ts
@@ -1,0 +1,84 @@
+// Overwrite types until this issue is fixed https://github.com/alanshaw/it-pipe/issues/4
+// Original types contain
+// ```
+// export function pipe (first: any, ...rest: any[]): any
+// ```
+// Which act as a @ts-ignore compromising type safety
+
+declare module "it-pipe" {
+  export function pipe<A, B>(first: A | (() => A), second: (source: A) => B): B;
+
+  export function pipe<A, B, C>(first: A | (() => A), second: (source: A) => B, third: (source: B) => C): C;
+
+  export function pipe<A, B, C, D>(
+    first: A | (() => A),
+    second: (source: A) => B,
+    third: (source: B) => C,
+    fourth: (source: C) => D
+  ): D;
+
+  export function pipe<A, B, C, D, E>(
+    first: A | (() => A),
+    second: (source: A) => B,
+    third: (source: B) => C,
+    fourth: (source: C) => D,
+    fifth: (source: D) => E
+  ): E;
+
+  export function pipe<A, B, C, D, E, F>(
+    first: A | (() => A),
+    second: (source: A) => B,
+    third: (source: B) => C,
+    fourth: (source: C) => D,
+    fifth: (source: D) => E,
+    sixth: (source: E) => F
+  ): F;
+
+  export function pipe<A, B, C, D, E, F, G>(
+    first: A | (() => A),
+    second: (source: A) => B,
+    third: (source: B) => C,
+    forth: (source: C) => D,
+    fifth: (source: D) => E,
+    sixth: (source: E) => F,
+    seventh: (source: F) => G
+  ): G;
+
+  export function pipe<A, B, C, D, E, F, G, H>(
+    first: A | (() => A),
+    second: (source: A) => B,
+    third: (source: B) => C,
+    forth: (source: C) => D,
+    fifth: (source: D) => E,
+    sixth: (source: E) => F,
+    seventh: (source: F) => G,
+    eighth: (source: G) => H
+  ): H;
+
+  export function pipe<A, B, C, D, E, F, G, H, I>(
+    first: A | (() => A),
+    second: (source: A) => B,
+    third: (source: B) => C,
+    forth: (source: C) => D,
+    fifth: (source: D) => E,
+    sixth: (source: E) => F,
+    seventh: (source: F) => G,
+    eighth: (source: G) => H,
+    ninth: (source: H) => I
+  ): I;
+
+  export function pipe<A, B, C, D, E, F, G, H, I, J>(
+    first: A | (() => A),
+    second: (source: A) => B,
+    third: (source: B) => C,
+    forth: (source: C) => D,
+    fifth: (source: D) => E,
+    sixth: (source: E) => F,
+    seventh: (source: F) => G,
+    eighth: (source: G) => H,
+    ninth: (source: H) => I,
+    tenth: (source: I) => J
+  ): I;
+
+  export default pipe;
+}

--- a/packages/lodestar/types/it-pipe/index.d.ts
+++ b/packages/lodestar/types/it-pipe/index.d.ts
@@ -6,6 +6,13 @@
 // Which act as a @ts-ignore compromising type safety
 
 declare module "it-pipe" {
+  type Source<T> = AsyncIterable<T>;
+  type Sink<TSource, TReturn = void> = (source: Source<TSource>) => TReturn;
+  type Duplex<TSource = unknown, TReturn = unknown> = {
+    sink: Sink<TSource, TReturn>;
+    source: Source<TSource>;
+  };
+
   export function pipe<A, B>(f1: A | (() => A), f2: (source: A) => B): B;
 
   export function pipe<A, B, C>(f1: A | (() => A), f2: (source: A) => B, f3: (source: B) => C): C;
@@ -82,6 +89,27 @@ declare module "it-pipe" {
 
   export function pipe<A, B, C, D, E>(
     f1: A[],
+    f2: (source: AsyncIterable<A>) => B,
+    f3: (source: B) => C,
+    f4: (source: C) => D,
+    f5: (source: D) => E
+  ): E;
+
+  // First argument is duplex
+
+  export function pipe<A, R, B>(f1: Duplex<A, R>, f2: (source: AsyncIterable<A>) => B): B;
+
+  export function pipe<A, R, B, C>(f1: Duplex<A, R>, f2: (source: AsyncIterable<A>) => B, f3: (source: B) => C): C;
+
+  export function pipe<A, R, B, C, D>(
+    f1: Duplex<A, R>,
+    f2: (source: AsyncIterable<A>) => B,
+    f3: (source: B) => C,
+    f4: (source: C) => D
+  ): D;
+
+  export function pipe<A, R, B, C, D, E>(
+    f1: Duplex<A, R>,
     f2: (source: AsyncIterable<A>) => B,
     f3: (source: B) => C,
     f4: (source: C) => D,

--- a/packages/lodestar/types/it-pipe/index.d.ts
+++ b/packages/lodestar/types/it-pipe/index.d.ts
@@ -1,84 +1,92 @@
 // Overwrite types until this issue is fixed https://github.com/alanshaw/it-pipe/issues/4
 // Original types contain
 // ```
-// export function pipe (first: any, ...rest: any[]): any
+// export function pipe (f1: any, ...rest: any[]): any
 // ```
 // Which act as a @ts-ignore compromising type safety
 
 declare module "it-pipe" {
-  export function pipe<A, B>(first: A | (() => A), second: (source: A) => B): B;
+  export function pipe<A, B>(f1: A | (() => A), f2: (source: A) => B): B;
 
-  export function pipe<A, B, C>(first: A | (() => A), second: (source: A) => B, third: (source: B) => C): C;
+  export function pipe<A, B, C>(f1: A | (() => A), f2: (source: A) => B, f3: (source: B) => C): C;
 
   export function pipe<A, B, C, D>(
-    first: A | (() => A),
-    second: (source: A) => B,
-    third: (source: B) => C,
-    fourth: (source: C) => D
+    f1: A | (() => A),
+    f2: (source: A) => B,
+    f3: (source: B) => C,
+    f4: (source: C) => D
   ): D;
 
   export function pipe<A, B, C, D, E>(
-    first: A | (() => A),
-    second: (source: A) => B,
-    third: (source: B) => C,
-    fourth: (source: C) => D,
-    fifth: (source: D) => E
+    f1: A | (() => A),
+    f2: (source: A) => B,
+    f3: (source: B) => C,
+    f4: (source: C) => D,
+    f5: (source: D) => E
   ): E;
 
   export function pipe<A, B, C, D, E, F>(
-    first: A | (() => A),
-    second: (source: A) => B,
-    third: (source: B) => C,
-    fourth: (source: C) => D,
-    fifth: (source: D) => E,
-    sixth: (source: E) => F
+    f1: A | (() => A),
+    f2: (source: A) => B,
+    f3: (source: B) => C,
+    f4: (source: C) => D,
+    f5: (source: D) => E,
+    f6: (source: E) => F
   ): F;
 
   export function pipe<A, B, C, D, E, F, G>(
-    first: A | (() => A),
-    second: (source: A) => B,
-    third: (source: B) => C,
-    forth: (source: C) => D,
-    fifth: (source: D) => E,
-    sixth: (source: E) => F,
-    seventh: (source: F) => G
+    f1: A | (() => A),
+    f2: (source: A) => B,
+    f3: (source: B) => C,
+    f4: (source: C) => D,
+    f5: (source: D) => E,
+    f6: (source: E) => F,
+    f7: (source: F) => G
   ): G;
 
   export function pipe<A, B, C, D, E, F, G, H>(
-    first: A | (() => A),
-    second: (source: A) => B,
-    third: (source: B) => C,
-    forth: (source: C) => D,
-    fifth: (source: D) => E,
-    sixth: (source: E) => F,
-    seventh: (source: F) => G,
-    eighth: (source: G) => H
+    f1: A | (() => A),
+    f2: (source: A) => B,
+    f3: (source: B) => C,
+    f4: (source: C) => D,
+    f5: (source: D) => E,
+    f6: (source: E) => F,
+    f7: (source: F) => G,
+    f8: (source: G) => H
   ): H;
 
   export function pipe<A, B, C, D, E, F, G, H, I>(
-    first: A | (() => A),
-    second: (source: A) => B,
-    third: (source: B) => C,
-    forth: (source: C) => D,
-    fifth: (source: D) => E,
-    sixth: (source: E) => F,
-    seventh: (source: F) => G,
-    eighth: (source: G) => H,
-    ninth: (source: H) => I
+    f1: A | (() => A),
+    f2: (source: A) => B,
+    f3: (source: B) => C,
+    f4: (source: C) => D,
+    f5: (source: D) => E,
+    f6: (source: E) => F,
+    f7: (source: F) => G,
+    f8: (source: G) => H,
+    f9: (source: H) => I
   ): I;
 
-  export function pipe<A, B, C, D, E, F, G, H, I, J>(
-    first: A | (() => A),
-    second: (source: A) => B,
-    third: (source: B) => C,
-    forth: (source: C) => D,
-    fifth: (source: D) => E,
-    sixth: (source: E) => F,
-    seventh: (source: F) => G,
-    eighth: (source: G) => H,
-    ninth: (source: H) => I,
-    tenth: (source: I) => J
-  ): I;
+  // First argument is array
+
+  export function pipe<A, B>(f1: A[], f2: (source: AsyncIterable<A>) => B): B;
+
+  export function pipe<A, B, C>(f1: A[], f2: (source: AsyncIterable<A>) => B, f3: (source: B) => C): C;
+
+  export function pipe<A, B, C, D>(
+    f1: A[],
+    f2: (source: AsyncIterable<A>) => B,
+    f3: (source: B) => C,
+    f4: (source: C) => D
+  ): D;
+
+  export function pipe<A, B, C, D, E>(
+    f1: A[],
+    f2: (source: AsyncIterable<A>) => B,
+    f3: (source: B) => C,
+    f4: (source: C) => D,
+    f5: (source: D) => E
+  ): E;
 
   export default pipe;
 }


### PR DESCRIPTION
Overwrite types until this issue is fixed https://github.com/alanshaw/it-pipe/issues/4
Original types contain
```
export function pipe (first: any, ...rest: any[]): any
```
Which act as a @ts-ignore compromising type safety