### PR TITLE
Enable Typescript strict opts

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/phase0/fast/util/cachedBeaconState.ts
+++ b/packages/lodestar-beacon-state-transition/src/phase0/fast/util/cachedBeaconState.ts
@@ -92,6 +92,8 @@ export const CachedBeaconStateProxyHandler: ProxyHandler<CachedBeaconState<allFo
     } else if (key in target.type.tree) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return (target.type.tree as any)[key].bind(target.type.tree, target.tree);
+    } else {
+      return undefined;
     }
   },
   set(target: CachedBeaconState<allForks.BeaconState>, key: string, value: unknown): boolean {

--- a/packages/lodestar-spec-test-util/src/single.ts
+++ b/packages/lodestar-spec-test-util/src/single.ts
@@ -107,7 +107,8 @@ function generateTestCase<TestCase, Result>(
   it(name, function () {
     const testCase = loadInputFiles(testCaseDirectoryPath, options);
     if (options.shouldSkip && options.shouldSkip(testCase, name, index)) {
-      return this.skip();
+      this.skip();
+      return;
     }
     if (options.shouldError && options.shouldError(testCase)) {
       try {

--- a/packages/lodestar/src/api/rest/controllers/debug/beacon/getStates.ts
+++ b/packages/lodestar/src/api/rest/controllers/debug/beacon/getStates.ts
@@ -11,13 +11,14 @@ export const getState: ApiController<DefaultQuery, {stateId: string}> = {
     try {
       const state = await this.api.debug.beacon.getState(req.params.stateId);
       if (!state) {
-        return resp.status(404).send();
+        resp.status(404).send();
+        return;
       }
       if (req.headers[HttpHeader.ACCEPT] === SSZ_MIME_TYPE) {
         const stateSsz = this.config.types.phase0.BeaconState.serialize(state);
         resp.status(200).header(HttpHeader.CONTENT_TYPE, SSZ_MIME_TYPE).send(Buffer.from(stateSsz));
       } else {
-        return resp.status(200).send({
+        resp.status(200).send({
           data: this.config.types.phase0.BeaconState.toJson(state, {case: "snake"}),
         });
       }

--- a/packages/lodestar/src/api/rest/controllers/node/getPeer.ts
+++ b/packages/lodestar/src/api/rest/controllers/node/getPeer.ts
@@ -21,7 +21,8 @@ export const getPeer: ApiController<DefaultQuery, {peerId: string}> = {
   handler: async function (req, resp) {
     const peer = await this.api.node.getPeer(req.params.peerId);
     if (!peer) {
-      return resp.status(404).send();
+      resp.status(404).send();
+      return;
     }
     resp.status(200).send({
       data: {

--- a/packages/lodestar/src/network/peers/metastore.ts
+++ b/packages/lodestar/src/network/peers/metastore.ts
@@ -55,9 +55,7 @@ export class Libp2pPeerMetadataStore implements IPeerMetadataStore {
       },
       get: (peer: PeerId): T | undefined => {
         const value = this.metabook.getValue(peer, key);
-        if (value) {
-          return type.deserialize(value);
-        }
+        return value ? type.deserialize(value) : undefined;
       },
     };
   }

--- a/packages/lodestar/src/network/reqresp/encoders/responseDecode.ts
+++ b/packages/lodestar/src/network/reqresp/encoders/responseDecode.ts
@@ -39,7 +39,7 @@ export function responseDecode(
       // Stream is only allowed to end at the start of a <response_chunk> block
       // The happens when source ends before readResultHeader() can fetch 1 byte
       if (status === StreamStatus.Ended) {
-        return null;
+        break;
       }
 
       // For multiple chunks, only the last chunk is allowed to have a non-zero error

--- a/packages/lodestar/src/network/reqresp/request/errors.ts
+++ b/packages/lodestar/src/network/reqresp/request/errors.ts
@@ -85,5 +85,7 @@ function renderErrorMessage(type: RequestErrorType): string | undefined {
     case RequestErrorCode.SERVER_ERROR:
     case RequestErrorCode.UNKNOWN_ERROR_STATUS:
       return `${type.code}: ${type.errorMessage}`;
+    default:
+      return type.code;
   }
 }

--- a/packages/lodestar/src/sync/range/utils/batches.ts
+++ b/packages/lodestar/src/sync/range/utils/batches.ts
@@ -40,7 +40,7 @@ export function validateBatchesStatus(batches: Batch[]): void {
  * Return the next batch to process if any.
  * @see validateBatchesStatus for batches state description
  */
-export function getNextBatchToProcess(batches: Batch[]): Batch | undefined {
+export function getNextBatchToProcess(batches: Batch[]): Batch | null {
   for (const batch of batches) {
     switch (batch.state.status) {
       // If an AwaitingProcessing batch exists it can only be preceeded by AwaitingValidation
@@ -54,9 +54,11 @@ export function getNextBatchToProcess(batches: Batch[]): Batch | undefined {
       case BatchStatus.AwaitingDownload:
       case BatchStatus.Downloading:
       case BatchStatus.Processing:
-        return;
+        return null;
     }
   }
+  // Exhausted batches
+  return null;
 }
 
 /**

--- a/packages/lodestar/test/unit/sync/range/utils/batches.test.ts
+++ b/packages/lodestar/test/unit/sync/range/utils/batches.test.ts
@@ -125,7 +125,7 @@ describe("sync / range / batches", () => {
         const _batches = batches.map(createBatch);
         const nextBatchToProcess = getNextBatchToProcess(_batches);
         if (nextBatchToProcessIndex === undefined) {
-          expect(nextBatchToProcess).to.equal(undefined);
+          expect(nextBatchToProcess).to.equal(null);
         } else {
           expect(nextBatchToProcess).to.equal(_batches[nextBatchToProcessIndex]);
         }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,8 +4,17 @@
     "module": "commonjs",
     "pretty": true,
     "lib": ["es2020", "esnext.bigint", "es2020.string", "es2020.symbol.wellknown"],
+
     "strict": true,
+    "alwaysStrict": true,
     "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noImplicitReturns": true,
+
     "esModuleInterop": true,
     // Babel builds source, Typescript is used only for .d.ts files
     "declaration": true,


### PR DESCRIPTION
Enable remaining strict options in Typescript with the exception of `noUnusedParameters`, which should be taken care of by eslint
- If we agree to enable them I'll start fixing the issues