### PR TITLE
Use ReqRespEncoding enum consistently in ReqResp

### DIFF
--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -18,7 +18,7 @@ import {ILogger} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
 import PeerId from "peer-id";
 import {IBeaconChain} from "../../chain";
-import {GENESIS_EPOCH, Method, RpcResponseStatus, ZERO_HASH} from "../../constants";
+import {GENESIS_EPOCH, Method, ReqRespEncoding, RpcResponseStatus, ZERO_HASH} from "../../constants";
 import {IBeaconDb} from "../../db";
 import {IBlockFilterOptions} from "../../db/api/beacon/repositories";
 import {createRpcProtocol, INetwork} from "../../network";
@@ -89,7 +89,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
     this.network.removeListener("peer:connect", this.handshake);
     await Promise.all(
       this.network
-        .getPeers({connected: true, supportsProtocols: [createRpcProtocol(Method.Goodbye, "ssz_snappy")]})
+        .getPeers({connected: true, supportsProtocols: [createRpcProtocol(Method.Goodbye, ReqRespEncoding.SSZ_SNAPPY)]})
         .map(async (peer) => {
           try {
             await this.network.reqResp.goodbye(peer.id, BigInt(GoodByeReasonCode.CLIENT_SHUTDOWN));

--- a/packages/lodestar/test/unit/network/util.test.ts
+++ b/packages/lodestar/test/unit/network/util.test.ts
@@ -1,6 +1,7 @@
 import Multiaddr from "multiaddr";
 import {expect} from "chai";
-import {isLocalMultiAddr} from "../../../src/network";
+import {createRpcProtocol, isLocalMultiAddr, parseProtocolId} from "../../../src/network";
+import {Method, ReqRespEncoding} from "../../../src/constants";
 
 describe("Test isLocalMultiAddr", () => {
   it("should return true for 127.0.0.1", () => {
@@ -12,4 +13,30 @@ describe("Test isLocalMultiAddr", () => {
     const multi0 = Multiaddr("/ip4/0.0.0.0/udp/30303");
     expect(isLocalMultiAddr(multi0)).to.be.false;
   });
+});
+
+describe("ReqResp protocolID parse / render", () => {
+  const testCases: {
+    method: Method;
+    encoding: ReqRespEncoding;
+    version: number;
+    protocolId: string;
+  }[] = [
+    {
+      method: Method.Status,
+      encoding: ReqRespEncoding.SSZ_SNAPPY,
+      version: 1,
+      protocolId: "/eth2/beacon_chain/req/status/1/ssz_snappy",
+    },
+  ];
+
+  for (const {method, encoding, version, protocolId} of testCases) {
+    it(`Should render ${protocolId}`, () => {
+      expect(createRpcProtocol(method, encoding, version)).to.equal(protocolId);
+    });
+
+    it(`Should parse  ${protocolId}`, () => {
+      expect(parseProtocolId(protocolId)).to.deep.equal({method, encoding, version});
+    });
+  }
 });


### PR DESCRIPTION
- Some code was still using the raw string instead of the ReqRespEncoding enum.
- Use template literals instead of .replace()
- I've a added a protocol ID parser which I'm using in an upcoming PR
- Unit test both protocol ID render and parser