### PR TITLE
Fix out-of-sync node due to FUTURE_SLOT error

### DIFF
--- a/packages/lodestar/src/chain/blocks/pool.ts
+++ b/packages/lodestar/src/chain/blocks/pool.ts
@@ -121,8 +121,12 @@ export class BlockPool {
   }
 
   public getBySlot(slot: Slot): Uint8Array[] {
-    const hexArr = Array.from(this.blocksBySlot.get(slot)?.values() ?? []);
-    return hexArr.map((hex) => fromHexString(hex));
+    const slots = Array.from(this.blocksBySlot.keys()).filter((cachedSlot) => cachedSlot <= slot);
+    const hexArr: string[] = [];
+    for (const cachedSlot of slots) {
+      hexArr.push(...Array.from(this.blocksBySlot.get(cachedSlot)?.values() ?? []));
+    }
+    return Array.from(new Set(hexArr)).map((hex) => fromHexString(hex));
   }
 
   private getParentKey(block: SignedBeaconBlock): string {

--- a/packages/lodestar/src/chain/blocks/validate.ts
+++ b/packages/lodestar/src/chain/blocks/validate.ts
@@ -45,12 +45,12 @@ export async function validateBlock({
       });
     }
 
-    const currentSlot = clock.currentSlot;
-    if (blockSlot > currentSlot) {
+    const maxPeerCurrentSlot = clock.maxPeerCurrentSlot;
+    if (blockSlot > maxPeerCurrentSlot) {
       throw new BlockError({
         code: BlockErrorCode.FUTURE_SLOT,
         blockSlot,
-        currentSlot,
+        currentSlot: maxPeerCurrentSlot,
         job,
       });
     }

--- a/packages/lodestar/src/chain/blocks/validate.ts
+++ b/packages/lodestar/src/chain/blocks/validate.ts
@@ -45,12 +45,12 @@ export async function validateBlock({
       });
     }
 
-    const maxPeerCurrentSlot = clock.maxPeerCurrentSlot;
-    if (blockSlot > maxPeerCurrentSlot) {
+    const currentSlotWithGossipDisparity = clock.currentSlotWithGossipDisparity;
+    if (blockSlot > currentSlotWithGossipDisparity) {
       throw new BlockError({
         code: BlockErrorCode.FUTURE_SLOT,
         blockSlot,
-        currentSlot: maxPeerCurrentSlot,
+        currentSlot: currentSlotWithGossipDisparity,
         job,
       });
     }

--- a/packages/lodestar/src/chain/clock/LocalClock.ts
+++ b/packages/lodestar/src/chain/clock/LocalClock.ts
@@ -45,11 +45,10 @@ export class LocalClock implements IBeaconClock {
   }
 
   /**
-   * Maximum currentSlot of peers.
    * If it's too close to next slot given MAXIMUM_GOSSIP_CLOCK_DISPARITY, return currentSlot + 1.
    * Otherwise return currentSlot
    */
-  public get maxPeerCurrentSlot(): Slot {
+  public get currentSlotWithGossipDisparity(): Slot {
     const currentSlot = this.currentSlot;
     const nextSlotTime = computeTimeAtSlot(this.config, currentSlot + 1, this.genesisTime) * 1000;
     return nextSlotTime - Date.now() < MAXIMUM_GOSSIP_CLOCK_DISPARITY ? currentSlot + 1 : currentSlot;

--- a/packages/lodestar/src/chain/clock/interface.ts
+++ b/packages/lodestar/src/chain/clock/interface.ts
@@ -10,6 +10,11 @@ import {Epoch, Slot} from "@chainsafe/lodestar-types";
  */
 export interface IBeaconClock {
   readonly currentSlot: Slot;
+  /**
+   * Max current slot of peers.
+   * If it's too close to next slot, maxCurrentSlot = currentSlot + 1
+   */
+  readonly maxPeerCurrentSlot: Slot;
   readonly currentEpoch: Epoch;
   /**
    * Returns a promise that waits until at least `slot` is reached

--- a/packages/lodestar/src/chain/clock/interface.ts
+++ b/packages/lodestar/src/chain/clock/interface.ts
@@ -11,10 +11,9 @@ import {Epoch, Slot} from "@chainsafe/lodestar-types";
 export interface IBeaconClock {
   readonly currentSlot: Slot;
   /**
-   * Max current slot of peers.
    * If it's too close to next slot, maxCurrentSlot = currentSlot + 1
    */
-  readonly maxPeerCurrentSlot: Slot;
+  readonly currentSlotWithGossipDisparity: Slot;
   readonly currentEpoch: Epoch;
   /**
    * Returns a promise that waits until at least `slot` is reached

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -309,7 +309,7 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
     return;
   }
 
-  this.logger.error("Block error", {}, err);
+  this.logger.error("Block error", {slot: err.job.signedBlock.message.slot}, err);
   const blockRoot = this.config.types.BeaconBlock.hashTreeRoot(err.job.signedBlock.message);
 
   switch (err.type.code) {
@@ -318,8 +318,8 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
         reason: err.type.code,
         blockRoot: toHexString(blockRoot),
       });
-      await this.db.pendingBlock.add(err.job.signedBlock);
       this.pendingBlocks.addBySlot(err.job.signedBlock);
+      await this.db.pendingBlock.add(err.job.signedBlock);
       break;
 
     case BlockErrorCode.PARENT_UNKNOWN:

--- a/packages/lodestar/src/chain/validation/block.ts
+++ b/packages/lodestar/src/chain/validation/block.ts
@@ -27,11 +27,11 @@ export async function validateGossipBlock(
     });
   }
 
-  const currentSlot = chain.clock.currentSlot;
-  if (currentSlot < blockSlot) {
+  const maxPeerCurrentSlot = chain.clock.maxPeerCurrentSlot;
+  if (maxPeerCurrentSlot < blockSlot) {
     throw new BlockError({
       code: BlockErrorCode.FUTURE_SLOT,
-      currentSlot,
+      currentSlot: maxPeerCurrentSlot,
       blockSlot,
       job: blockJob,
     });

--- a/packages/lodestar/src/chain/validation/block.ts
+++ b/packages/lodestar/src/chain/validation/block.ts
@@ -27,11 +27,11 @@ export async function validateGossipBlock(
     });
   }
 
-  const maxPeerCurrentSlot = chain.clock.maxPeerCurrentSlot;
-  if (maxPeerCurrentSlot < blockSlot) {
+  const currentSlotWithGossipDisparity = chain.clock.currentSlotWithGossipDisparity;
+  if (currentSlotWithGossipDisparity < blockSlot) {
     throw new BlockError({
       code: BlockErrorCode.FUTURE_SLOT,
-      currentSlot: maxPeerCurrentSlot,
+      currentSlot: currentSlotWithGossipDisparity,
       blockSlot,
       job: blockJob,
     });

--- a/packages/lodestar/src/constants/constants.ts
+++ b/packages/lodestar/src/constants/constants.ts
@@ -22,3 +22,8 @@ export enum DomainType {
   SELECTION_PROOF = 5,
   AGGREGATE_AND_PROOF = 6,
 }
+
+/**
+ * The maximum milliseconds of clock disparity assumed between honest nodes.
+ */
+export const MAXIMUM_GOSSIP_CLOCK_DISPARITY = 500;

--- a/packages/lodestar/src/constants/network.ts
+++ b/packages/lodestar/src/constants/network.ts
@@ -22,11 +22,6 @@ export const ATTESTATION_SUBNET_COUNT = 64;
 export const ATTESTATION_PROPAGATION_SLOT_RANGE = 23;
 
 /**
- * The maximum milliseconds of clock disparity assumed between honest nodes.
- */
-export const MAXIMUM_GOSSIP_CLOCK_DISPARITY = 500;
-
-/**
  *
  * Request/Response constants
  *

--- a/packages/lodestar/test/unit/chain/blocks/validate.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/validate.test.ts
@@ -66,7 +66,7 @@ describe("validateBlock", function () {
     const job = getNewBlockJob(signedBlock);
     forkChoice.hasBlock.returns(false);
     forkChoice.getFinalizedCheckpoint.returns({epoch: 0, root: Buffer.alloc(32)});
-    sinon.stub(clock, "currentSlot").get(() => 0);
+    sinon.stub(clock, "maxPeerCurrentSlot").get(() => 0);
     try {
       await validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
@@ -81,7 +81,7 @@ describe("validateBlock", function () {
     const job = getNewBlockJob(signedBlock);
     forkChoice.hasBlock.returns(false);
     forkChoice.getFinalizedCheckpoint.returns({epoch: 0, root: Buffer.alloc(32)});
-    sinon.stub(clock, "currentSlot").get(() => 1);
+    sinon.stub(clock, "maxPeerCurrentSlot").get(() => 1);
     forkChoice.hasBlock.returns(false);
     try {
       await validateBlock({config, forkChoice, clock, job});

--- a/packages/lodestar/test/unit/chain/blocks/validate.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/validate.test.ts
@@ -66,7 +66,7 @@ describe("validateBlock", function () {
     const job = getNewBlockJob(signedBlock);
     forkChoice.hasBlock.returns(false);
     forkChoice.getFinalizedCheckpoint.returns({epoch: 0, root: Buffer.alloc(32)});
-    sinon.stub(clock, "maxPeerCurrentSlot").get(() => 0);
+    sinon.stub(clock, "currentSlotWithGossipDisparity").get(() => 0);
     try {
       await validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
@@ -81,7 +81,7 @@ describe("validateBlock", function () {
     const job = getNewBlockJob(signedBlock);
     forkChoice.hasBlock.returns(false);
     forkChoice.getFinalizedCheckpoint.returns({epoch: 0, root: Buffer.alloc(32)});
-    sinon.stub(clock, "maxPeerCurrentSlot").get(() => 1);
+    sinon.stub(clock, "currentSlotWithGossipDisparity").get(() => 1);
     forkChoice.hasBlock.returns(false);
     try {
       await validateBlock({config, forkChoice, clock, job});

--- a/packages/lodestar/test/unit/chain/clock/local.test.ts
+++ b/packages/lodestar/test/unit/chain/clock/local.test.ts
@@ -5,49 +5,55 @@ import {config} from "@chainsafe/lodestar-config/minimal";
 
 import {LocalClock} from "../../../../src/chain/clock/LocalClock";
 import {ChainEvent, ChainEventEmitter} from "../../../../src/chain/emitter";
+import {MAXIMUM_GOSSIP_CLOCK_DISPARITY} from "../../../../src/constants";
 
 describe("LocalClock", function () {
   const sandbox = sinon.createSandbox();
+  let abortController: AbortController;
+  let emitter: ChainEventEmitter;
+  let clock: LocalClock;
 
   beforeEach(() => {
     sandbox.useFakeTimers();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
-  it("Should notify on new slot", async function () {
-    const emitter = new ChainEventEmitter();
-    const abortController = new AbortController();
-    const clock = new LocalClock({
+    abortController = new AbortController();
+    emitter = new ChainEventEmitter();
+    clock = new LocalClock({
       config,
       emitter,
       genesisTime: Math.round(new Date().getTime() / 1000),
       signal: abortController.signal,
     });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    abortController.abort();
+  });
+
+  it("Should notify on new slot", async function () {
     const spy = sinon.spy();
     emitter.on(ChainEvent.clockSlot, spy);
     sandbox.clock.tick(config.params.SECONDS_PER_SLOT * 1000);
     expect(spy.calledOnce).to.be.true;
     expect(spy.calledWith(clock.currentSlot)).to.be.true;
-    abortController.abort();
   });
 
   it("Should notify on new epoch", async function () {
-    const emitter = new ChainEventEmitter();
-    const abortController = new AbortController();
-    const clock = new LocalClock({
-      config,
-      emitter,
-      genesisTime: Math.round(new Date().getTime() / 1000),
-      signal: abortController.signal,
-    });
     const spy = sinon.spy();
     emitter.on(ChainEvent.clockEpoch, spy);
     sandbox.clock.tick(config.params.SLOTS_PER_EPOCH * config.params.SECONDS_PER_SLOT * 1000);
     expect(spy.calledOnce).to.be.true;
     expect(spy.calledWith(clock.currentEpoch)).to.be.true;
-    abortController.abort();
+  });
+
+  describe("maxPeerCurrentSlot", () => {
+    it("should be next slot", () => {
+      sandbox.clock.tick(config.params.SECONDS_PER_SLOT * 1000 - (MAXIMUM_GOSSIP_CLOCK_DISPARITY - 50));
+      expect(clock.maxPeerCurrentSlot).to.be.equal(clock.currentSlot + 1);
+    });
+
+    it("should be current slot", () => {
+      expect(clock.maxPeerCurrentSlot).to.be.equal(clock.currentSlot);
+    });
   });
 });

--- a/packages/lodestar/test/unit/chain/clock/local.test.ts
+++ b/packages/lodestar/test/unit/chain/clock/local.test.ts
@@ -46,14 +46,14 @@ describe("LocalClock", function () {
     expect(spy.calledWith(clock.currentEpoch)).to.be.true;
   });
 
-  describe("maxPeerCurrentSlot", () => {
+  describe("currentSlotWithGossipDisparity", () => {
     it("should be next slot", () => {
       sandbox.clock.tick(config.params.SECONDS_PER_SLOT * 1000 - (MAXIMUM_GOSSIP_CLOCK_DISPARITY - 50));
-      expect(clock.maxPeerCurrentSlot).to.be.equal(clock.currentSlot + 1);
+      expect(clock.currentSlotWithGossipDisparity).to.be.equal(clock.currentSlot + 1);
     });
 
     it("should be current slot", () => {
-      expect(clock.maxPeerCurrentSlot).to.be.equal(clock.currentSlot);
+      expect(clock.currentSlotWithGossipDisparity).to.be.equal(clock.currentSlot);
     });
   });
 });

--- a/packages/lodestar/test/unit/chain/validation/block.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/block.test.ts
@@ -52,7 +52,7 @@ describe("gossip block validation", function () {
   });
 
   it("should throw error - bad block", async function () {
-    sinon.stub(chainStub.clock, "currentSlot").get(() => 1);
+    sinon.stub(chainStub.clock, "maxPeerCurrentSlot").get(() => 1);
     const signedBlock = generateSignedBlock({message: {slot: 1}});
     const job = getNewBlockJob(signedBlock);
     chainStub.getFinalizedCheckpoint.resolves({
@@ -71,7 +71,7 @@ describe("gossip block validation", function () {
   });
 
   it("should throw error - already proposed", async function () {
-    sinon.stub(chainStub.clock, "currentSlot").get(() => 1);
+    sinon.stub(chainStub.clock, "maxPeerCurrentSlot").get(() => 1);
     const signedBlock = generateSignedBlock({message: {slot: 1}});
     const job = getNewBlockJob(signedBlock);
     chainStub.getFinalizedCheckpoint.resolves({
@@ -91,7 +91,7 @@ describe("gossip block validation", function () {
   });
 
   it("should throw error - missing parent", async function () {
-    sinon.stub(chainStub.clock, "currentSlot").get(() => 1);
+    sinon.stub(chainStub.clock, "maxPeerCurrentSlot").get(() => 1);
     const signedBlock = generateSignedBlock({message: {slot: 1}});
     const job = getNewBlockJob(signedBlock);
     chainStub.getFinalizedCheckpoint.resolves({
@@ -112,7 +112,7 @@ describe("gossip block validation", function () {
   });
 
   it("should throw error - invalid signature", async function () {
-    sinon.stub(chainStub.clock, "currentSlot").get(() => 1);
+    sinon.stub(chainStub.clock, "maxPeerCurrentSlot").get(() => 1);
     const signedBlock = generateSignedBlock({message: {slot: 1}});
     const job = getNewBlockJob(signedBlock);
     chainStub.getFinalizedCheckpoint.resolves({
@@ -139,7 +139,7 @@ describe("gossip block validation", function () {
   });
 
   it("should throw error - wrong proposer", async function () {
-    sinon.stub(chainStub.clock, "currentSlot").get(() => 1);
+    sinon.stub(chainStub.clock, "maxPeerCurrentSlot").get(() => 1);
     const signedBlock = generateSignedBlock({message: {slot: 1}});
     const job = getNewBlockJob(signedBlock);
     chainStub.getFinalizedCheckpoint.resolves({
@@ -169,7 +169,7 @@ describe("gossip block validation", function () {
   });
 
   it("should accept - valid block", async function () {
-    sinon.stub(chainStub.clock, "currentSlot").get(() => 1);
+    sinon.stub(chainStub.clock, "maxPeerCurrentSlot").get(() => 1);
     const signedBlock = generateSignedBlock({message: {slot: 1}});
     const job = getNewBlockJob(signedBlock);
     chainStub.getFinalizedCheckpoint.resolves({

--- a/packages/lodestar/test/unit/chain/validation/block.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/block.test.ts
@@ -52,7 +52,7 @@ describe("gossip block validation", function () {
   });
 
   it("should throw error - bad block", async function () {
-    sinon.stub(chainStub.clock, "maxPeerCurrentSlot").get(() => 1);
+    sinon.stub(chainStub.clock, "currentSlotWithGossipDisparity").get(() => 1);
     const signedBlock = generateSignedBlock({message: {slot: 1}});
     const job = getNewBlockJob(signedBlock);
     chainStub.getFinalizedCheckpoint.resolves({
@@ -71,7 +71,7 @@ describe("gossip block validation", function () {
   });
 
   it("should throw error - already proposed", async function () {
-    sinon.stub(chainStub.clock, "maxPeerCurrentSlot").get(() => 1);
+    sinon.stub(chainStub.clock, "currentSlotWithGossipDisparity").get(() => 1);
     const signedBlock = generateSignedBlock({message: {slot: 1}});
     const job = getNewBlockJob(signedBlock);
     chainStub.getFinalizedCheckpoint.resolves({
@@ -91,7 +91,7 @@ describe("gossip block validation", function () {
   });
 
   it("should throw error - missing parent", async function () {
-    sinon.stub(chainStub.clock, "maxPeerCurrentSlot").get(() => 1);
+    sinon.stub(chainStub.clock, "currentSlotWithGossipDisparity").get(() => 1);
     const signedBlock = generateSignedBlock({message: {slot: 1}});
     const job = getNewBlockJob(signedBlock);
     chainStub.getFinalizedCheckpoint.resolves({
@@ -112,7 +112,7 @@ describe("gossip block validation", function () {
   });
 
   it("should throw error - invalid signature", async function () {
-    sinon.stub(chainStub.clock, "maxPeerCurrentSlot").get(() => 1);
+    sinon.stub(chainStub.clock, "currentSlotWithGossipDisparity").get(() => 1);
     const signedBlock = generateSignedBlock({message: {slot: 1}});
     const job = getNewBlockJob(signedBlock);
     chainStub.getFinalizedCheckpoint.resolves({
@@ -139,7 +139,7 @@ describe("gossip block validation", function () {
   });
 
   it("should throw error - wrong proposer", async function () {
-    sinon.stub(chainStub.clock, "maxPeerCurrentSlot").get(() => 1);
+    sinon.stub(chainStub.clock, "currentSlotWithGossipDisparity").get(() => 1);
     const signedBlock = generateSignedBlock({message: {slot: 1}});
     const job = getNewBlockJob(signedBlock);
     chainStub.getFinalizedCheckpoint.resolves({
@@ -169,7 +169,7 @@ describe("gossip block validation", function () {
   });
 
   it("should accept - valid block", async function () {
-    sinon.stub(chainStub.clock, "maxPeerCurrentSlot").get(() => 1);
+    sinon.stub(chainStub.clock, "currentSlotWithGossipDisparity").get(() => 1);
     const signedBlock = generateSignedBlock({message: {slot: 1}});
     const job = getNewBlockJob(signedBlock);
     chainStub.getFinalizedCheckpoint.resolves({


### PR DESCRIPTION
resolves #1916 

+ as I see `BLOCK_ERROR_FUTURE_SLOT` quite frequently, I think we need to accept some deltas when determining that error due to time differences. This is part of the spec and was somehow removed after some code refactoring
+ when handling that error, we should add to the cache first then add to `pendingBlock` db
+ at `onClockSlot` we should get all pending blocks of past slots too and process all of them
+ minor point: improve `Block error` debug log to include block slot as well