### PR TITLE
Speed up epoch transition using persistent vector

### DIFF
--- a/packages/lodestar-beacon-state-transition/package.json
+++ b/packages/lodestar-beacon-state-transition/package.json
@@ -41,7 +41,8 @@
     "@chainsafe/lodestar-utils": "^0.13.0",
     "@chainsafe/ssz": "^0.6.13",
     "bigint-buffer": "^1.1.5",
-    "buffer-xor": "^2.0.2"
+    "buffer-xor": "^2.0.2",
+    "immutable": "4.0.0-rc.12"
   },
   "devDependencies": {
     "@chainsafe/blst": "^0.1.3",

--- a/packages/lodestar-beacon-state-transition/package.json
+++ b/packages/lodestar-beacon-state-transition/package.json
@@ -41,8 +41,7 @@
     "@chainsafe/lodestar-utils": "^0.13.0",
     "@chainsafe/ssz": "^0.6.13",
     "bigint-buffer": "^1.1.5",
-    "buffer-xor": "^2.0.2",
-    "immutable": "4.0.0-rc.12"
+    "buffer-xor": "^2.0.2"
   },
   "devDependencies": {
     "@chainsafe/blst": "^0.1.3",

--- a/packages/lodestar-beacon-state-transition/src/fast/block/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/index.ts
@@ -1,5 +1,5 @@
-import {EpochContext} from "../util";
-import {BeaconBlock, BeaconState} from "@chainsafe/lodestar-types";
+import {EpochContext, CachedValidatorsBeaconState} from "../util";
+import {BeaconBlock} from "@chainsafe/lodestar-types";
 
 import {processBlockHeader} from "./processBlockHeader";
 import {processRandao} from "./processRandao";
@@ -25,7 +25,7 @@ export {
 
 export function processBlock(
   epochCtx: EpochContext,
-  state: BeaconState,
+  state: CachedValidatorsBeaconState,
   block: BeaconBlock,
   verifySignatures = true
 ): void {

--- a/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
@@ -31,7 +31,7 @@ export function initiateValidatorExit(
   }
 
   // set validator exit epoch and withdrawable epoch
-  state.setValidator(index, {
+  state.updateValidator(index, {
     exitEpoch: exitQueueEpoch,
     withdrawableEpoch: exitQueueEpoch + config.params.MIN_VALIDATOR_WITHDRAWABILITY_DELAY,
   });

--- a/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
@@ -25,7 +25,7 @@ export function initiateValidatorExit(
   const exitEpochs = validatorExitEpochs.filter((exitEpoch) => exitEpoch !== FAR_FUTURE_EPOCH);
   exitEpochs.push(computeActivationExitEpoch(config, currentEpoch));
   let exitQueueEpoch = Math.max(...exitEpochs);
-  const exitQueueChurn = validatorExitEpochs.filter((exitEpoch) => exitEpoch === exitQueueEpoch).length;
+  const exitQueueChurn = validatorExitEpochs.filter((exitEpoch) => exitEpoch === exitQueueEpoch).size;
   if (exitQueueChurn >= getChurnLimit(config, epochCtx.currentShuffling.activeIndices.length)) {
     exitQueueEpoch += 1;
   }

--- a/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
@@ -1,25 +1,27 @@
-import {readOnlyMap} from "@chainsafe/ssz";
-import {BeaconState, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {ValidatorIndex} from "@chainsafe/lodestar-types";
 
 import {FAR_FUTURE_EPOCH} from "../../constants";
 import {computeActivationExitEpoch, getChurnLimit} from "../../util";
-import {EpochContext} from "../util";
+import {EpochContext, CachedValidatorsBeaconState} from "../util";
 
 /**
  * Initiate the exit of the validator with index ``index``.
  */
-export function initiateValidatorExit(epochCtx: EpochContext, state: BeaconState, index: ValidatorIndex): void {
+export function initiateValidatorExit(
+  epochCtx: EpochContext,
+  state: CachedValidatorsBeaconState,
+  index: ValidatorIndex
+): void {
   const config = epochCtx.config;
   // return if validator already initiated exit
-  const validator = state.validators[index];
-  if (validator.exitEpoch !== FAR_FUTURE_EPOCH) {
+  if (state.validators[index].exitEpoch !== FAR_FUTURE_EPOCH) {
     return;
   }
 
   const currentEpoch = epochCtx.currentShuffling.epoch;
 
   // compute exit queue epoch
-  const validatorExitEpochs = readOnlyMap(state.validators, (v) => v.exitEpoch);
+  const validatorExitEpochs = state.flatValidators().map((v) => v.exitEpoch);
   const exitEpochs = validatorExitEpochs.filter((exitEpoch) => exitEpoch !== FAR_FUTURE_EPOCH);
   exitEpochs.push(computeActivationExitEpoch(config, currentEpoch));
   let exitQueueEpoch = Math.max(...exitEpochs);
@@ -29,6 +31,8 @@ export function initiateValidatorExit(epochCtx: EpochContext, state: BeaconState
   }
 
   // set validator exit epoch and withdrawable epoch
-  validator.exitEpoch = exitQueueEpoch;
-  validator.withdrawableEpoch = validator.exitEpoch + config.params.MIN_VALIDATOR_WITHDRAWABILITY_DELAY;
+  state.setValidator(index, {
+    exitEpoch: exitQueueEpoch,
+    withdrawableEpoch: exitQueueEpoch + config.params.MIN_VALIDATOR_WITHDRAWABILITY_DELAY,
+  });
 }

--- a/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/initiateValidatorExit.ts
@@ -21,11 +21,11 @@ export function initiateValidatorExit(
   const currentEpoch = epochCtx.currentShuffling.epoch;
 
   // compute exit queue epoch
-  const validatorExitEpochs = state.flatValidators().map((v) => v.exitEpoch);
+  const validatorExitEpochs = state.flatValidators().readOnlyMap((v) => v.exitEpoch);
   const exitEpochs = validatorExitEpochs.filter((exitEpoch) => exitEpoch !== FAR_FUTURE_EPOCH);
   exitEpochs.push(computeActivationExitEpoch(config, currentEpoch));
   let exitQueueEpoch = Math.max(...exitEpochs);
-  const exitQueueChurn = validatorExitEpochs.filter((exitEpoch) => exitEpoch === exitQueueEpoch).size;
+  const exitQueueChurn = validatorExitEpochs.filter((exitEpoch) => exitEpoch === exitQueueEpoch).length;
   if (exitQueueChurn >= getChurnLimit(config, epochCtx.currentShuffling.activeIndices.length)) {
     exitQueueEpoch += 1;
   }

--- a/packages/lodestar-beacon-state-transition/src/fast/block/processAttesterSlashing.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/processAttesterSlashing.ts
@@ -1,13 +1,13 @@
-import {AttesterSlashing, BeaconState, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {AttesterSlashing, ValidatorIndex} from "@chainsafe/lodestar-types";
 
 import {isSlashableValidator, isSlashableAttestationData} from "../../util";
-import {EpochContext} from "../util";
+import {EpochContext, CachedValidatorsBeaconState} from "../util";
 import {slashValidator} from "./slashValidator";
 import {isValidIndexedAttestation} from "./isValidIndexedAttestation";
 
 export function processAttesterSlashing(
   epochCtx: EpochContext,
-  state: BeaconState,
+  state: CachedValidatorsBeaconState,
   attesterSlashing: AttesterSlashing,
   verifySignatures = true
 ): void {

--- a/packages/lodestar-beacon-state-transition/src/fast/block/processDeposit.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/processDeposit.ts
@@ -1,12 +1,12 @@
 import bls from "@chainsafe/bls";
-import {BeaconState, Deposit} from "@chainsafe/lodestar-types";
+import {Deposit} from "@chainsafe/lodestar-types";
 import {verifyMerkleBranch, bigIntMin} from "@chainsafe/lodestar-utils";
 
 import {DEPOSIT_CONTRACT_TREE_DEPTH, DomainType, FAR_FUTURE_EPOCH} from "../../constants";
 import {computeDomain, computeSigningRoot, increaseBalance} from "../../util";
-import {EpochContext} from "../util";
+import {EpochContext, CachedValidatorsBeaconState} from "../util";
 
-export function processDeposit(epochCtx: EpochContext, state: BeaconState, deposit: Deposit): void {
+export function processDeposit(epochCtx: EpochContext, state: CachedValidatorsBeaconState, deposit: Deposit): void {
   const config = epochCtx.config;
   const {EFFECTIVE_BALANCE_INCREMENT, MAX_EFFECTIVE_BALANCE} = config.params;
   // verify the merkle branch
@@ -43,7 +43,7 @@ export function processDeposit(epochCtx: EpochContext, state: BeaconState, depos
     }
 
     // add validator and balance entries
-    state.validators.push({
+    state.addValidator({
       pubkey: pubkey,
       withdrawalCredentials: deposit.data.withdrawalCredentials,
       activationEligibilityEpoch: FAR_FUTURE_EPOCH,

--- a/packages/lodestar-beacon-state-transition/src/fast/block/processOperations.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/processOperations.ts
@@ -3,13 +3,12 @@ import {
   Attestation,
   AttesterSlashing,
   BeaconBlockBody,
-  BeaconState,
   Deposit,
   ProposerSlashing,
   VoluntaryExit,
 } from "@chainsafe/lodestar-types";
 
-import {EpochContext} from "../util";
+import {EpochContext, CachedValidatorsBeaconState} from "../util";
 import {processProposerSlashing} from "./processProposerSlashing";
 import {processAttesterSlashing} from "./processAttesterSlashing";
 import {processAttestation} from "./processAttestation";
@@ -17,11 +16,16 @@ import {processDeposit} from "./processDeposit";
 import {processVoluntaryExit} from "./processVoluntaryExit";
 
 type Operation = ProposerSlashing | AttesterSlashing | Attestation | Deposit | VoluntaryExit;
-type OperationFunction = (epochCtx: EpochContext, state: BeaconState, op: Operation, verify: boolean) => void;
+type OperationFunction = (
+  epochCtx: EpochContext,
+  state: CachedValidatorsBeaconState,
+  op: Operation,
+  verify: boolean
+) => void;
 
 export function processOperations(
   epochCtx: EpochContext,
-  state: BeaconState,
+  state: CachedValidatorsBeaconState,
   body: BeaconBlockBody,
   verifySignatures = true
 ): void {

--- a/packages/lodestar-beacon-state-transition/src/fast/block/processProposerSlashing.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/processProposerSlashing.ts
@@ -1,13 +1,13 @@
 import {BeaconState, ProposerSlashing} from "@chainsafe/lodestar-types";
 import {DomainType} from "../../constants";
 import {computeEpochAtSlot, computeSigningRoot, getDomain, isSlashableValidator} from "../../util";
-import {EpochContext} from "../util";
+import {EpochContext, CachedValidatorsBeaconState} from "../util";
 import {slashValidator} from "./slashValidator";
 import {ISignatureSet, SignatureSetType, verifySignatureSet} from "../signatureSets";
 
 export function processProposerSlashing(
   epochCtx: EpochContext,
-  state: BeaconState,
+  state: CachedValidatorsBeaconState,
   proposerSlashing: ProposerSlashing,
   verifySignatures = true
 ): void {

--- a/packages/lodestar-beacon-state-transition/src/fast/block/processVoluntaryExit.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/processVoluntaryExit.ts
@@ -2,12 +2,12 @@ import {BeaconState, SignedVoluntaryExit} from "@chainsafe/lodestar-types";
 import {DomainType, FAR_FUTURE_EPOCH} from "../../constants";
 import {computeSigningRoot, getDomain, isActiveValidator} from "../../util";
 import {ISignatureSet, SignatureSetType, verifySignatureSet} from "../signatureSets";
-import {EpochContext} from "../util";
+import {EpochContext, CachedValidatorsBeaconState} from "../util";
 import {initiateValidatorExit} from "./initiateValidatorExit";
 
 export function processVoluntaryExit(
   epochCtx: EpochContext,
-  state: BeaconState,
+  state: CachedValidatorsBeaconState,
   signedVoluntaryExit: SignedVoluntaryExit,
   verifySignature = true
 ): void {

--- a/packages/lodestar-beacon-state-transition/src/fast/block/slashValidator.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/block/slashValidator.ts
@@ -19,7 +19,7 @@ export function slashValidator(
   const epoch = epochCtx.currentShuffling.epoch;
   initiateValidatorExit(epochCtx, state, slashedIndex);
   const validator = state.validators[slashedIndex];
-  state.setValidator(slashedIndex, {
+  state.updateValidator(slashedIndex, {
     slashed: true,
     withdrawableEpoch: Math.max(validator.withdrawableEpoch, epoch + EPOCHS_PER_SLASHINGS_VECTOR),
   });

--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/index.ts
@@ -1,6 +1,4 @@
-import {BeaconState} from "@chainsafe/lodestar-types";
-
-import {prepareEpochProcessState} from "../util";
+import {CachedValidatorsBeaconState, prepareEpochProcessState} from "../util";
 import {StateTransitionEpochContext} from "../util/epochContext";
 import {processJustificationAndFinalization} from "./processJustificationAndFinalization";
 import {processRewardsAndPenalties} from "./processRewardsAndPenalties";
@@ -20,7 +18,7 @@ export {
   getAttestationDeltas,
 };
 
-export function processEpoch(epochCtx: StateTransitionEpochContext, state: BeaconState): void {
+export function processEpoch(epochCtx: StateTransitionEpochContext, state: CachedValidatorsBeaconState): void {
   const process = prepareEpochProcessState(epochCtx, state);
   epochCtx.epochProcess = process;
   processJustificationAndFinalization(epochCtx, process, state);

--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/processFinalUpdates.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/processFinalUpdates.ts
@@ -1,11 +1,15 @@
 import {readOnlyMap, List} from "@chainsafe/ssz";
-import {BeaconState, Eth1Data, PendingAttestation} from "@chainsafe/lodestar-types";
+import {Eth1Data, PendingAttestation} from "@chainsafe/lodestar-types";
 import {bigIntMin, intDiv} from "@chainsafe/lodestar-utils";
 
 import {getRandaoMix} from "../../util";
-import {EpochContext, IEpochProcess} from "../util";
+import {EpochContext, IEpochProcess, CachedValidatorsBeaconState} from "../util";
 
-export function processFinalUpdates(epochCtx: EpochContext, process: IEpochProcess, state: BeaconState): void {
+export function processFinalUpdates(
+  epochCtx: EpochContext,
+  process: IEpochProcess,
+  state: CachedValidatorsBeaconState
+): void {
   const config = epochCtx.config;
   const currentEpoch = process.currentEpoch;
   const nextEpoch = currentEpoch + 1;
@@ -37,10 +41,9 @@ export function processFinalUpdates(epochCtx: EpochContext, process: IEpochProce
     const balance = balances[i];
     const effectiveBalance = status.validator.effectiveBalance;
     if (balance + DOWNWARD_THRESHOLD < effectiveBalance || effectiveBalance + UPWARD_THRESHOLD < balance) {
-      state.validators[i].effectiveBalance = bigIntMin(
-        balance - (balance % EFFECTIVE_BALANCE_INCREMENT),
-        MAX_EFFECTIVE_BALANCE
-      );
+      state.setValidator(i, {
+        effectiveBalance: bigIntMin(balance - (balance % EFFECTIVE_BALANCE_INCREMENT), MAX_EFFECTIVE_BALANCE),
+      });
     }
   }
 

--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/processFinalUpdates.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/processFinalUpdates.ts
@@ -41,7 +41,7 @@ export function processFinalUpdates(
     const balance = balances[i];
     const effectiveBalance = status.validator.effectiveBalance;
     if (balance + DOWNWARD_THRESHOLD < effectiveBalance || effectiveBalance + UPWARD_THRESHOLD < balance) {
-      state.setValidator(i, {
+      state.updateValidator(i, {
         effectiveBalance: bigIntMin(balance - (balance % EFFECTIVE_BALANCE_INCREMENT), MAX_EFFECTIVE_BALANCE),
       });
     }

--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/processRegistryUpdates.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/processRegistryUpdates.ts
@@ -1,20 +1,22 @@
-import {BeaconState} from "@chainsafe/lodestar-types";
-
 import {computeActivationExitEpoch} from "../../util";
-import {EpochContext, IEpochProcess} from "../util";
+import {EpochContext, IEpochProcess, CachedValidatorsBeaconState} from "../util";
 
-export function processRegistryUpdates(epochCtx: EpochContext, process: IEpochProcess, state: BeaconState): void {
+export function processRegistryUpdates(
+  epochCtx: EpochContext,
+  process: IEpochProcess,
+  state: CachedValidatorsBeaconState
+): void {
   const config = epochCtx.config;
   let exitEnd = process.exitQueueEnd;
   let endChurn = process.exitQueueEndChurn;
   const {MIN_VALIDATOR_WITHDRAWABILITY_DELAY} = epochCtx.config.params;
   // process ejections
   for (const index of process.indicesToEject) {
-    const validator = state.validators[index];
-
     // set validator exit epoch and withdrawable epoch
-    validator.exitEpoch = exitEnd;
-    validator.withdrawableEpoch = exitEnd + MIN_VALIDATOR_WITHDRAWABILITY_DELAY;
+    state.setValidator(index, {
+      exitEpoch: exitEnd,
+      withdrawableEpoch: exitEnd + MIN_VALIDATOR_WITHDRAWABILITY_DELAY,
+    });
 
     endChurn += 1;
     if (endChurn >= process.churnLimit) {
@@ -25,7 +27,9 @@ export function processRegistryUpdates(epochCtx: EpochContext, process: IEpochPr
 
   // set new activation eligibilities
   for (const index of process.indicesToSetActivationEligibility) {
-    state.validators[index].activationEligibilityEpoch = epochCtx.currentShuffling.epoch + 1;
+    state.setValidator(index, {
+      activationEligibilityEpoch: epochCtx.currentShuffling.epoch + 1,
+    });
   }
 
   const finalityEpoch = state.finalizedCheckpoint.epoch;
@@ -35,6 +39,8 @@ export function processRegistryUpdates(epochCtx: EpochContext, process: IEpochPr
     if (process.statuses[index].validator.activationEligibilityEpoch > finalityEpoch) {
       break; // remaining validators all have an activationEligibilityEpoch that is higher anyway, break early
     }
-    state.validators[index].activationEpoch = computeActivationExitEpoch(config, process.currentEpoch);
+    state.setValidator(index, {
+      activationEpoch: computeActivationExitEpoch(config, process.currentEpoch),
+    });
   }
 }

--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/processRegistryUpdates.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/processRegistryUpdates.ts
@@ -13,7 +13,7 @@ export function processRegistryUpdates(
   // process ejections
   for (const index of process.indicesToEject) {
     // set validator exit epoch and withdrawable epoch
-    state.setValidator(index, {
+    state.updateValidator(index, {
       exitEpoch: exitEnd,
       withdrawableEpoch: exitEnd + MIN_VALIDATOR_WITHDRAWABILITY_DELAY,
     });
@@ -27,7 +27,7 @@ export function processRegistryUpdates(
 
   // set new activation eligibilities
   for (const index of process.indicesToSetActivationEligibility) {
-    state.setValidator(index, {
+    state.updateValidator(index, {
       activationEligibilityEpoch: epochCtx.currentShuffling.epoch + 1,
     });
   }
@@ -39,7 +39,7 @@ export function processRegistryUpdates(
     if (process.statuses[index].validator.activationEligibilityEpoch > finalityEpoch) {
       break; // remaining validators all have an activationEligibilityEpoch that is higher anyway, break early
     }
-    state.setValidator(index, {
+    state.updateValidator(index, {
       activationEpoch: computeActivationExitEpoch(config, process.currentEpoch),
     });
   }

--- a/packages/lodestar-beacon-state-transition/src/fast/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/index.ts
@@ -1,6 +1,6 @@
-import {BeaconState, SignedBeaconBlock} from "@chainsafe/lodestar-types";
+import {SignedBeaconBlock} from "@chainsafe/lodestar-types";
 
-import {verifyBlockSignature} from "./util";
+import {CachedValidatorsBeaconState, verifyBlockSignature} from "./util";
 import {IStateContext} from "./util";
 import {StateTransitionEpochContext} from "./util/epochContext";
 import {EpochContext} from "./util/epochContext";
@@ -22,7 +22,7 @@ export function fastStateTransition(
   const types = epochCtx.config.types;
 
   const block = signedBlock.message;
-  const postState = types.BeaconState.clone(state);
+  const postState = state.clone();
   // process slots (including those with no blocks) since block
   processSlots(epochCtx, postState, block.slot);
 
@@ -46,7 +46,10 @@ export function fastStateTransition(
 /**
  * Trim epochProcess in epochCtx, and insert the standard/exchange interface epochProcess to the final IStateContext
  */
-export function toIStateContext(epochCtx: StateTransitionEpochContext, state: BeaconState): IStateContext {
+export function toIStateContext(
+  epochCtx: StateTransitionEpochContext,
+  state: CachedValidatorsBeaconState
+): IStateContext {
   const epochProcess = epochCtx.epochProcess;
   epochCtx.epochProcess = undefined;
   return {

--- a/packages/lodestar-beacon-state-transition/src/fast/slot/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/slot/index.ts
@@ -1,12 +1,17 @@
-import {BeaconState, Slot} from "@chainsafe/lodestar-types";
+import {Slot} from "@chainsafe/lodestar-types";
 
 import {StateTransitionEpochContext} from "../util/epochContext";
 import {processEpoch} from "../epoch";
 import {processSlot} from "./processSlot";
+import {CachedValidatorsBeaconState} from "../util/interface";
 
 export {processSlot};
 
-export function processSlots(epochCtx: StateTransitionEpochContext, state: BeaconState, slot: Slot): void {
+export function processSlots(
+  epochCtx: StateTransitionEpochContext,
+  state: CachedValidatorsBeaconState,
+  slot: Slot
+): void {
   if (!(state.slot < slot)) {
     throw new Error("State slot must transition to a future slot: " + `stateSlot=${state.slot} slot=${slot}`);
   }

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
@@ -145,8 +145,7 @@ export class EpochContext {
     const nextEpoch = this.currentShuffling.epoch + 1;
     const indicesBounded = state
       .flatValidators()
-      .map((v, i) => [i, v.activationEpoch, v.exitEpoch])
-      .toJS();
+      .readOnlyMap<[number, Epoch, Epoch]>((v, i) => [i, v.activationEpoch, v.exitEpoch]);
     this.nextShuffling = computeEpochShuffling(this.config, state, indicesBounded, nextEpoch);
     this._resetProposers(state);
   }

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
@@ -26,6 +26,7 @@ import {
 } from "../../util";
 import {computeEpochShuffling, IEpochShuffling} from "./epochShuffling";
 import {IEpochProcess} from "./epochProcess";
+import {CachedValidatorsBeaconState} from "./interface";
 
 export class PubkeyIndexMap extends Map<ByteVector, ValidatorIndex> {
   get(key: ByteVector): ValidatorIndex | undefined {
@@ -138,15 +139,13 @@ export class EpochContext {
    * Called to re-use information, such as the shuffling of the next epoch, after transitioning into a
    * new epoch.
    */
-  public rotateEpochs(state: BeaconState): void {
+  public rotateEpochs(state: CachedValidatorsBeaconState): void {
     this.previousShuffling = this.currentShuffling;
     this.currentShuffling = this.nextShuffling;
     const nextEpoch = this.currentShuffling.epoch + 1;
-    const indicesBounded: [ValidatorIndex, Epoch, Epoch][] = readOnlyMap(state.validators, (v, i) => [
-      i,
-      v.activationEpoch,
-      v.exitEpoch,
-    ]);
+    const indicesBounded: [ValidatorIndex, Epoch, Epoch][] = state
+      .flatValidators()
+      .map((v, i) => [i, v.activationEpoch, v.exitEpoch]);
     this.nextShuffling = computeEpochShuffling(this.config, state, indicesBounded, nextEpoch);
     this._resetProposers(state);
   }

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
@@ -143,9 +143,10 @@ export class EpochContext {
     this.previousShuffling = this.currentShuffling;
     this.currentShuffling = this.nextShuffling;
     const nextEpoch = this.currentShuffling.epoch + 1;
-    const indicesBounded: [ValidatorIndex, Epoch, Epoch][] = state
+    const indicesBounded = state
       .flatValidators()
-      .map((v, i) => [i, v.activationEpoch, v.exitEpoch]);
+      .map((v, i) => [i, v.activationEpoch, v.exitEpoch])
+      .toJS();
     this.nextShuffling = computeEpochShuffling(this.config, state, indicesBounded, nextEpoch);
     this._resetProposers(state);
   }

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochProcess.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochProcess.ts
@@ -91,7 +91,7 @@ export function prepareEpochProcessState(
   let exitQueueEnd = computeActivationExitEpoch(config, currentEpoch);
 
   let activeCount = 0;
-  state.flatValidators().forEach((v, i) => {
+  state.flatValidators().readOnlyForEach((v, i) => {
     const status = createIAttesterStatus(v);
 
     if (v.slashed) {

--- a/packages/lodestar-beacon-state-transition/src/fast/util/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/index.ts
@@ -1,6 +1,6 @@
-import {BeaconState} from "@chainsafe/lodestar-types";
 import {EpochContext} from "./epochContext";
 import {IEpochProcess} from "./epochProcess";
+import {CachedValidatorsBeaconState} from "./interface";
 
 export * from "./block";
 export * from "./attesterStatus";
@@ -15,7 +15,7 @@ export * from "./interface";
  * Exchange Interface of StateContext
  */
 export interface IStateContext {
-  state: BeaconState;
+  state: CachedValidatorsBeaconState;
   epochCtx: EpochContext;
   epochProcess?: IEpochProcess;
 }

--- a/packages/lodestar-beacon-state-transition/src/fast/util/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/index.ts
@@ -10,6 +10,7 @@ export * from "./epochShuffling";
 export * from "./epochStakeSummary";
 export * from "./flatValidator";
 export * from "./interface";
+export * from "./persistentVector";
 
 /**
  * Exchange Interface of StateContext

--- a/packages/lodestar-beacon-state-transition/src/fast/util/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/index.ts
@@ -10,7 +10,6 @@ export * from "./epochShuffling";
 export * from "./epochStakeSummary";
 export * from "./flatValidator";
 export * from "./interface";
-export * from "./persistentVector";
 
 /**
  * Exchange Interface of StateContext

--- a/packages/lodestar-beacon-state-transition/src/fast/util/interface.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/interface.ts
@@ -1,6 +1,8 @@
 import {IReadonlyEpochShuffling} from ".";
-import {ValidatorIndex, Slot} from "@chainsafe/lodestar-types";
-import {ByteVector} from "@chainsafe/ssz";
+import {ValidatorIndex, Slot, BeaconState, Validator} from "@chainsafe/lodestar-types";
+import {ByteVector, readOnlyForEach} from "@chainsafe/ssz";
+import {createIFlatValidator, IFlatValidator} from "./flatValidator";
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 
 /**
  * Readonly interface for EpochContext.
@@ -12,3 +14,137 @@ export type ReadonlyEpochContext = {
   readonly previousShuffling?: IReadonlyEpochShuffling;
   getBeaconProposer: (slot: Slot) => ValidatorIndex;
 };
+
+/**
+ * Instead of accesing `validators` array directly inside BeaconState, use:
+ * + flatValidators() for the loop
+ * + setValidator() for an update
+ * + addValidator() for a creation
+ * that'd update both the cached validators array and the one in the original state.
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface CachedValidatorsBeaconState extends BeaconState {
+  flatValidators(): IFlatValidator[];
+  setValidator(i: ValidatorIndex, value: Partial<IFlatValidator>): void;
+  addValidator(validator: Validator): void;
+  getOriginalState(): BeaconState;
+  clone(): CachedValidatorsBeaconState;
+}
+
+/**
+ * Looping through validators inside TreeBacked<BeaconState> is so expensive.
+ * Cache validators from TreeBacked<BeaconState>.
+ * When write, write to both the cache and TreeBacked.
+ * When read, just return the cache.
+ */
+export class CachedValidatorsBeaconState {
+  public _state: BeaconState;
+  private _cachedValidators: IFlatValidator[];
+  private isSynced: boolean;
+
+  constructor(state: BeaconState, cachedValidators?: IFlatValidator[]) {
+    this._state = state;
+    if (cachedValidators && cachedValidators.length > 0) {
+      this._cachedValidators = cachedValidators;
+      this.isSynced = true;
+    } else {
+      this._cachedValidators = [];
+      this.isSynced = false;
+    }
+  }
+
+  public createProxy(): CachedValidatorsBeaconState {
+    return new Proxy(this, new CachedValidatorsBeaconStateProxyHandler());
+  }
+
+  /**
+   * Write to both the cached validator and BeaconState
+   */
+  public setValidator(i: ValidatorIndex, value: Partial<IFlatValidator>): void {
+    if (this._cachedValidators) {
+      const validator = this._cachedValidators[i];
+      this._cachedValidators[i] = {...validator, ...value};
+    }
+    const validator = this._state.validators[i];
+    if (value.activationEligibilityEpoch !== undefined)
+      validator.activationEligibilityEpoch = value.activationEligibilityEpoch;
+    if (value.activationEpoch !== undefined) validator.activationEpoch = value.activationEpoch;
+    if (value.effectiveBalance !== undefined) validator.effectiveBalance = value.effectiveBalance;
+    if (value.exitEpoch !== undefined) validator.exitEpoch = value.exitEpoch;
+    if (value.slashed !== undefined) validator.slashed = value.slashed;
+    if (value.withdrawableEpoch !== undefined) validator.withdrawableEpoch = value.withdrawableEpoch;
+  }
+
+  /**
+   * Add validator to both the cache and BeaconState
+   */
+  public addValidator(validator: Validator): void {
+    if (this.isSynced) {
+      this._cachedValidators.push(createIFlatValidator(validator));
+    }
+    this._state.validators.push(validator);
+  }
+
+  /**
+   * Loop through the cached validators, not the TreeBacked validators inside BeaconState.
+   */
+  public flatValidators(): IFlatValidator[] {
+    this.sync();
+    return this._cachedValidators;
+  }
+
+  public clone(): CachedValidatorsBeaconState {
+    const clonedState = config.types.BeaconState.clone(this._state);
+    return cloneCachedValidatorsBeaconState(clonedState, [...this._cachedValidators]);
+  }
+
+  public getOriginalState(): BeaconState {
+    return this._state;
+  }
+
+  private sync(): void {
+    if (this.isSynced) return;
+    readOnlyForEach(this._state.validators, (validator) => {
+      this._cachedValidators!.push(createIFlatValidator(validator));
+    });
+    this.isSynced = true;
+  }
+}
+
+export function createCachedValidatorsBeaconState(state: BeaconState): CachedValidatorsBeaconState {
+  return new CachedValidatorsBeaconState(state).createProxy();
+}
+
+function cloneCachedValidatorsBeaconState(
+  state: BeaconState,
+  cachedValidators: IFlatValidator[]
+): CachedValidatorsBeaconState {
+  return new CachedValidatorsBeaconState(state, cachedValidators).createProxy();
+}
+
+class CachedValidatorsBeaconStateProxyHandler implements ProxyHandler<CachedValidatorsBeaconState> {
+  /**
+   * Forward all BeaconState property getters to _state.
+   * StateTransitionBeaconState should handle validators, setValidator
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public get(target: CachedValidatorsBeaconState, p: keyof BeaconState): any {
+    if (target[p] !== undefined) {
+      return target[p];
+    }
+    return target._state[p];
+  }
+
+  /**
+   * Forward all BeaconState property setters to _state.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public set(target: CachedValidatorsBeaconState, p: keyof BeaconState, value: any): boolean {
+    if (target[p] !== undefined) {
+      target[p] = value;
+    } else {
+      target._state[p] = value;
+    }
+    return true;
+  }
+}

--- a/packages/lodestar-beacon-state-transition/src/fast/util/persistentVector.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/persistentVector.ts
@@ -315,6 +315,13 @@ export class Vector<T> implements Iterable<T> {
     return this.readOnlyMap<T>((v) => v);
   }
 
+  /**
+   * Clone to a new vector.
+   */
+  public clone(): Vector<T> {
+    return new Vector(this._root, this._levelShift, this._tail, this.length);
+  }
+
   private getTailLength(): number {
     return this.length - this.getTailOffset();
   }

--- a/packages/lodestar-beacon-state-transition/src/fast/util/persistentVector.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/persistentVector.ts
@@ -1,0 +1,325 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+const BIT_WIDTH = 5;
+const BIT_MASK = 0b11111;
+const BRANCH_SIZE = 1 << BIT_WIDTH;
+const DEFAULT_LEVEL_SHIFT = 5;
+
+function isFullBranch(length: number): boolean {
+  return (
+    // initially we initialize Vector with an empty branch (DEFAULT_LEVEL_SHIFT)
+    // length === 1 << 5 ||
+    length === 1 << 10 || length === 1 << 15 || length === 1 << 20 || length === 1 << 25 || length === 1 << 30
+  );
+}
+
+interface VLeaf<T> {
+  leaf: true;
+  values: T[];
+}
+interface VBranch<T> {
+  leaf: false;
+  // We have explicit nulls because when popping we can null old branches on purpose.
+  nodes: (VNode<T> | null)[];
+}
+type VNode<T> = VLeaf<T> | VBranch<T>;
+
+function emptyBranch<T>(): VBranch<T> {
+  return {leaf: false, nodes: Array(BRANCH_SIZE).fill(null)};
+}
+
+function emptyLeaf<T>(): VLeaf<T> {
+  return {leaf: true, values: Array(BRANCH_SIZE).fill(null)};
+}
+
+function copyVNode<T>(vnode: VNode<T>): VNode<T> {
+  if (vnode.leaf) {
+    return {leaf: true, values: [...vnode.values]};
+  } else {
+    return {leaf: false, nodes: [...vnode.nodes]};
+  }
+}
+
+function copyVBranch<T>(vnode: VBranch<T>): VBranch<T> {
+  return {leaf: false, nodes: [...vnode.nodes]};
+}
+
+export class Vector<T> implements Iterable<T> {
+  private constructor(
+    private readonly _root: VBranch<T>,
+    private readonly _levelShift: number,
+    private readonly _tail: T[],
+    public readonly length: number
+  ) {}
+
+  /**
+   * Create an empty vector of a certain type.
+   */
+  public static empty<T>(): Vector<T> {
+    return new Vector(emptyBranch(), DEFAULT_LEVEL_SHIFT, Array(BRANCH_SIZE).fill(null), 0);
+  }
+
+  /**
+   * Create a new vector containing certain elements.
+   *
+   * @param values the values that this vector will contain
+   */
+  public static of<T>(...values: T[]): Vector<T> {
+    let acc = Vector.empty<T>();
+    for (const v of values) acc = acc.append(v);
+    return acc;
+  }
+
+  /**
+   * O(log_32(N)) Return the value at a certain index, if it exists.
+   *
+   * This returns null if the index is out of the vector's bounds.
+   *
+   * @param index the index to look up
+   */
+  public get(index: number): T | null {
+    if (index < 0 || index >= this.length) return null;
+    if (index >= this.getTailOffset()) {
+      return this._tail[index % BRANCH_SIZE];
+    }
+    let shift = this._levelShift;
+    let cursor: VNode<T> = this._root;
+    while (!cursor.leaf) {
+      // This cast is fine because we checked the length prior
+      cursor = cursor.nodes[(index >>> shift) & BIT_MASK] as VNode<T>;
+      shift -= BIT_WIDTH;
+    }
+    return cursor.values[index & BIT_MASK];
+  }
+
+  /**
+   * O(log_32(N)) Return a new vector with an element set to a new value.
+   *
+   * This will do nothing if the index is negative, or out of the bounds of the vector.
+   *
+   * @param index the index to set
+   * @param value the value to set at that index
+   */
+  public set(index: number, value: T): Vector<T> {
+    if (index < 0 || index >= this.length) return this;
+    if (index >= this.getTailOffset()) {
+      const newTail = [...this._tail];
+      newTail[index & BIT_MASK] = value;
+      // root is not changed
+      return new Vector(this._root, this._levelShift, newTail, this.length);
+    }
+    const base = copyVBranch(this._root);
+    let shift = this._levelShift;
+    let cursor: VNode<T> = base;
+    while (!cursor.leaf) {
+      const subIndex = (index >>> shift) & BIT_MASK;
+      // This cast is fine because we checked the length prior
+      const next: VNode<T> = copyVNode(cursor.nodes[subIndex] as VNode<T>);
+      cursor.nodes[subIndex] = next;
+      cursor = next;
+      shift -= BIT_WIDTH;
+    }
+    cursor.values[index & BIT_MASK] = value;
+    // tail is not changed
+    return new Vector(base, this._levelShift, this._tail, this.length);
+  }
+
+  /**
+   * O(log_32(N)) Append a value to the end of this vector.
+   *
+   * This is useful for building up a vector from values.
+   *
+   * @param value the value to push to the end of the vector
+   */
+  public append(value: T): Vector<T> {
+    if (this.length - this.getTailOffset() < BRANCH_SIZE) {
+      // has space in tail
+      const newTail = [...this._tail];
+      newTail[this.length % BRANCH_SIZE] = value;
+      // root is not changed
+      return new Vector(this._root, this._levelShift, newTail, this.length + 1);
+    }
+    let base: VBranch<T>;
+    let levelShift = this._levelShift;
+    if (isFullBranch(this.length - BRANCH_SIZE)) {
+      base = emptyBranch();
+      base.nodes[0] = this._root;
+      levelShift += BIT_WIDTH;
+    } else {
+      base = copyVBranch(this._root);
+    }
+    // getTailOffset is actually the 1st item in tail
+    // we now move it to the tree
+    const index = this.getTailOffset();
+    let shift = levelShift;
+    let cursor: VNode<T> = base;
+    while (!cursor.leaf) {
+      const subIndex = (index >>> shift) & BIT_MASK;
+      shift -= BIT_WIDTH;
+      let next: VNode<T> | null = cursor.nodes[subIndex];
+      if (!next) {
+        next = shift === 0 ? emptyLeaf() : emptyBranch();
+      } else {
+        next = copyVNode(next);
+      }
+      cursor.nodes[subIndex] = next;
+      cursor = next;
+    }
+    // it's safe to update cursor bc "next" is a new instance anyway
+    cursor.values = [...this._tail];
+    return new Vector(base, levelShift, [value, ...Array(BRANCH_SIZE - 1).fill(null)], this.length + 1);
+  }
+
+  /**
+   * Return a new Vector with the last element removed.
+   *
+   * This does nothing if the Vector contains no elements.
+   */
+  public pop(): Vector<T> {
+    if (this.length === 0) return this;
+    // we always have a non-empty tail
+    const tailLength = this.getTailLength();
+    if (tailLength >= 2) {
+      // ignore the last item
+      const newTailLength = (this.length - 1) % BRANCH_SIZE;
+      const newTail = [...this._tail.slice(0, newTailLength), ...Array(BRANCH_SIZE - newTailLength).fill(null)];
+      return new Vector(this._root, this._levelShift, newTail, this.length - 1);
+    }
+    // tail has exactly 1 item, promote the right most leaf node as tail
+    const lastItemIndexInTree = this.getTailOffset() - 1;
+    // Tree has no item
+    if (lastItemIndexInTree < 0) {
+      return Vector.empty<T>();
+    }
+    const base = copyVBranch(this._root);
+    let shift = this._levelShift;
+    let cursor: VNode<T> = base;
+    // we always have a parent bc we create an empty branch initially
+    let parent: VNode<T> | null = null;
+    let subIndex: number | null = null;
+    while (!cursor.leaf) {
+      subIndex = (lastItemIndexInTree >>> shift) & BIT_MASK;
+      // This cast is fine because we checked the length prior
+      const next: VNode<T> = copyVNode(cursor.nodes[subIndex] as VNode<T>);
+      cursor.nodes[subIndex] = next;
+      parent = cursor;
+      cursor = next;
+      shift -= BIT_WIDTH;
+    }
+    const newTail = [...cursor.values];
+    parent!.nodes[subIndex!] = emptyLeaf<T>();
+    let newLevelShift = this._levelShift;
+    let newRoot: VBranch<T> = base;
+    if (isFullBranch(this.length - 1 - BRANCH_SIZE)) {
+      newRoot = base.nodes[0] as VBranch<T>;
+      newLevelShift -= BIT_WIDTH;
+    }
+    return new Vector(copyVBranch(newRoot), newLevelShift, newTail, this.length - 1);
+  }
+
+  /**
+   * Implement Iterable interface.
+   */
+  public *[Symbol.iterator](): Generator<T> {
+    let toYield = this.getTailOffset();
+    function* iterNode(node: VNode<T>): Generator<T> {
+      if (node.leaf) {
+        for (const v of node.values) {
+          if (toYield <= 0) break;
+          yield v;
+          --toYield;
+        }
+      } else {
+        for (const next of node.nodes) {
+          // This check also assures us that the link won't be null
+          if (toYield <= 0) break;
+          yield* iterNode(next as VNode<T>);
+        }
+      }
+    }
+    yield* iterNode(this._root);
+    const tailLength = this.getTailLength();
+    for (let i = 0; i < tailLength; i++) yield this._tail[i];
+  }
+
+  /**
+   * Faster way to loop than the regular loop above.
+   * Same to iterator function but this doesn't yield to improve performance.
+   */
+  public readOnlyForEach(func: (t: T, i: number) => void): void {
+    let index = 0;
+    const tailOffset = this.getTailOffset();
+    const iterNode = (node: VNode<T>): void => {
+      if (node.leaf) {
+        for (const v of node.values) {
+          if (index < tailOffset) {
+            func(v, index);
+            index++;
+          } else {
+            break;
+          }
+        }
+      } else {
+        for (const next of node.nodes) {
+          if (index >= tailOffset) break;
+          iterNode(next as VNode<T>);
+        }
+      }
+    };
+    iterNode(this._root);
+    const tailLength = this.getTailLength();
+    for (let i = 0; i < tailLength; i++) {
+      const value = this._tail[i];
+      func(value, index);
+      index++;
+    }
+  }
+
+  /**
+   * Map to an array of T2.
+   */
+  public readOnlyMap<T2>(func: (t: T, i: number) => T2): T2[] {
+    const result: T2[] = [];
+    let index = 0;
+    const tailOffset = this.getTailOffset();
+    const iterNode = (node: VNode<T>): void => {
+      if (node.leaf) {
+        for (const v of node.values) {
+          if (index < tailOffset) {
+            result.push(func(v, index));
+            index++;
+          } else {
+            break;
+          }
+        }
+      } else {
+        for (const next of node.nodes) {
+          if (index >= tailOffset) break;
+          iterNode(next as VNode<T>);
+        }
+      }
+    };
+    iterNode(this._root);
+    const tailLength = this.getTailLength();
+    for (let i = 0; i < tailLength; i++) {
+      const value = this._tail[i];
+      result.push(func(value, index));
+      index++;
+    }
+    return result;
+  }
+
+  /**
+   * Convert to regular typescript array
+   */
+  public toTS(): Array<T> {
+    return this.readOnlyMap<T>((v) => v);
+  }
+
+  private getTailLength(): number {
+    return this.length - this.getTailOffset();
+  }
+
+  private getTailOffset(): number {
+    return this.length < BRANCH_SIZE ? 0 : ((this.length - 1) >>> BIT_WIDTH) << BIT_WIDTH;
+  }
+}

--- a/packages/lodestar-beacon-state-transition/test/perf/epoch_processing.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/epoch_processing.test.ts
@@ -41,7 +41,7 @@ describe("Epoch Processing Performance Tests", function () {
     process = prepareEpochProcessState(epochCtx, state);
     logger.profile("prepareEpochProcessState");
     // not stable, sometimes < 1400, sometimes > 2000
-    expect(Date.now() - start).lt(1500);
+    expect(Date.now() - start).lt(100);
   });
 
   it("processJustificationAndFinalization", async () => {

--- a/packages/lodestar-beacon-state-transition/test/perf/epoch_processing.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/epoch_processing.test.ts
@@ -1,7 +1,11 @@
 import {config} from "@chainsafe/lodestar-config/mainnet";
-import {BeaconState} from "@chainsafe/lodestar-types";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
-import {IEpochProcess, prepareEpochProcessState} from "../../src/fast/util";
+import {
+  CachedValidatorsBeaconState,
+  createCachedValidatorsBeaconState,
+  IEpochProcess,
+  prepareEpochProcessState,
+} from "../../src/fast/util";
 import {EpochContext, StateTransitionEpochContext} from "../../src/fast/util/epochContext";
 import {
   processFinalUpdates,
@@ -15,7 +19,7 @@ import {generatePerformanceState, initBLS} from "./util";
 import {expect} from "chai";
 
 describe("Epoch Processing Performance Tests", function () {
-  let state: BeaconState;
+  let state: CachedValidatorsBeaconState;
   let epochCtx: StateTransitionEpochContext;
   let process: IEpochProcess;
   const logger = new WinstonLogger();
@@ -23,11 +27,12 @@ describe("Epoch Processing Performance Tests", function () {
   before(async function () {
     this.timeout(0);
     await initBLS();
-    state = await generatePerformanceState();
+    const origState = await generatePerformanceState();
     // go back 1 slot to process epoch
-    state.slot -= 1;
+    origState.slot -= 1;
     epochCtx = new EpochContext(config);
-    epochCtx.loadState(state);
+    epochCtx.loadState(origState);
+    state = createCachedValidatorsBeaconState(origState);
   });
 
   it("prepareEpochProcessState", async () => {

--- a/packages/lodestar-beacon-state-transition/test/perf/sanity/blocks.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/sanity/blocks.test.ts
@@ -4,6 +4,7 @@ import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {List} from "@chainsafe/ssz";
 import {expect} from "chai";
 import {EpochContext, fastStateTransition, IStateContext} from "../../../src/fast";
+import {createCachedValidatorsBeaconState} from "../../../src/fast/util";
 import {generatePerformanceBlock, generatePerformanceState, initBLS} from "../util";
 
 describe("Process Blocks Performance Test", function () {
@@ -12,10 +13,10 @@ describe("Process Blocks Performance Test", function () {
   const logger = new WinstonLogger();
   before(async () => {
     await initBLS();
-    const state = await generatePerformanceState();
+    const origState = await generatePerformanceState();
     const epochCtx = new EpochContext(config);
-    epochCtx.loadState(state);
-    stateCtx = {state, epochCtx};
+    epochCtx.loadState(origState);
+    stateCtx = {state: createCachedValidatorsBeaconState(origState), epochCtx};
   });
 
   it("should process block", async () => {
@@ -50,8 +51,7 @@ describe("Process Blocks Performance Test", function () {
       verifySignatures: false,
       verifyStateRoot: false,
     });
-    // could be up to 7000
-    expect(Date.now() - start).lt(6000);
+    expect(Date.now() - start).lt(1400);
     logger.profile(`Process block ${signedBlock.message.slot} with ${numValidatorExits} validator exits`);
   });
 });

--- a/packages/lodestar-beacon-state-transition/test/perf/sanity/blocks.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/sanity/blocks.test.ts
@@ -28,7 +28,7 @@ describe("Process Blocks Performance Test", function () {
       verifySignatures: false,
       verifyStateRoot: false,
     });
-    expect(Date.now() - start).lt(25);
+    expect(Date.now() - start).lte(25);
     logger.profile(`Process block ${signedBlock.message.slot}`);
   });
 
@@ -51,7 +51,7 @@ describe("Process Blocks Performance Test", function () {
       verifySignatures: false,
       verifyStateRoot: false,
     });
-    expect(Date.now() - start).lt(1400);
+    expect(Date.now() - start).lt(200);
     logger.profile(`Process block ${signedBlock.message.slot} with ${numValidatorExits} validator exits`);
   });
 });

--- a/packages/lodestar-beacon-state-transition/test/perf/sanity/slots.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/sanity/slots.test.ts
@@ -1,23 +1,27 @@
 import {config} from "@chainsafe/lodestar-config/mainnet";
-import {BeaconState} from "@chainsafe/lodestar-types";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {expect} from "chai";
 import {EpochContext} from "../../../src/fast";
 import {processSlots} from "../../../src/fast/slot";
 import {StateTransitionEpochContext} from "../../../src/fast/util/epochContext";
+import {CachedValidatorsBeaconState, createCachedValidatorsBeaconState} from "../../../src/fast/util";
 import {generatePerformanceState, initBLS} from "../util";
 
 describe("Process Slots Performance Test", function () {
   this.timeout(0);
   const logger = new WinstonLogger();
-  let state: BeaconState;
+  let state: CachedValidatorsBeaconState;
   let epochCtx: StateTransitionEpochContext;
 
   before(async () => {
     await initBLS();
-    state = await generatePerformanceState();
+  });
+
+  beforeEach(async () => {
+    const origState = await generatePerformanceState();
     epochCtx = new EpochContext(config);
-    epochCtx.loadState(state);
+    epochCtx.loadState(origState);
+    state = createCachedValidatorsBeaconState(origState);
   });
 
   it("process 1 empty epoch", async () => {
@@ -26,7 +30,7 @@ describe("Process Slots Performance Test", function () {
     const start = Date.now();
     processSlots(epochCtx, state, state.slot + numSlot);
     logger.profile(`Process ${numSlot} slots`);
-    expect(Date.now() - start).lt(2800);
+    expect(Date.now() - start).lt(2300);
   });
 
   it("process double empty epochs", async () => {
@@ -35,7 +39,7 @@ describe("Process Slots Performance Test", function () {
     const start = Date.now();
     processSlots(epochCtx, state, state.slot + numSlot);
     logger.profile(`Process ${numSlot} slots`);
-    expect(Date.now() - start).lt(5300);
+    expect(Date.now() - start).lt(3200);
   });
 
   it("process 4 empty epochs", async () => {
@@ -44,6 +48,6 @@ describe("Process Slots Performance Test", function () {
     const start = Date.now();
     processSlots(epochCtx, state, state.slot + numSlot);
     logger.profile(`Process ${numSlot} slots`);
-    expect(Date.now() - start).lt(11000);
+    expect(Date.now() - start).lt(5100);
   });
 });

--- a/packages/lodestar-beacon-state-transition/test/perf/sanity/slots.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/sanity/slots.test.ts
@@ -30,7 +30,7 @@ describe("Process Slots Performance Test", function () {
     const start = Date.now();
     processSlots(epochCtx, state, state.slot + numSlot);
     logger.profile(`Process ${numSlot} slots`);
-    expect(Date.now() - start).lt(2300);
+    expect(Date.now() - start).lt(1100);
   });
 
   it("process double empty epochs", async () => {
@@ -39,7 +39,7 @@ describe("Process Slots Performance Test", function () {
     const start = Date.now();
     processSlots(epochCtx, state, state.slot + numSlot);
     logger.profile(`Process ${numSlot} slots`);
-    expect(Date.now() - start).lt(3200);
+    expect(Date.now() - start).lt(2200);
   });
 
   it("process 4 empty epochs", async () => {
@@ -48,6 +48,6 @@ describe("Process Slots Performance Test", function () {
     const start = Date.now();
     processSlots(epochCtx, state, state.slot + numSlot);
     logger.profile(`Process ${numSlot} slots`);
-    expect(Date.now() - start).lt(5100);
+    expect(Date.now() - start).lt(4300);
   });
 });

--- a/packages/lodestar-beacon-state-transition/test/unit/fast/util/interface.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/fast/util/interface.test.ts
@@ -1,0 +1,81 @@
+import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
+import {BeaconState, Validator} from "@chainsafe/lodestar-types";
+import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {List, TreeBacked} from "@chainsafe/ssz";
+import {expect} from "chai";
+import {createCachedValidatorsBeaconState, CachedValidatorsBeaconState} from "../../../../src/fast/util";
+import {generateState} from "../../../utils/state";
+
+const NUM_VALIDATORS = 100000;
+
+describe("StateTransitionBeaconState", function () {
+  let state: TreeBacked<BeaconState>;
+  let wrappedState: CachedValidatorsBeaconState;
+  const logger = new WinstonLogger();
+
+  before(function () {
+    this.timeout(0);
+    const validators: Validator[] = [];
+    for (let i = 0; i < NUM_VALIDATORS; i++) {
+      validators.push({
+        pubkey: Buffer.alloc(48),
+        withdrawalCredentials: Buffer.alloc(32),
+        effectiveBalance: BigInt(1000000),
+        slashed: false,
+        activationEligibilityEpoch: i + 10,
+        activationEpoch: i,
+        exitEpoch: i + 20,
+        withdrawableEpoch: i + 30,
+      });
+    }
+    const defaultState = generateState({validators: validators as List<Validator>});
+    state = config.types.BeaconState.tree.createValue(defaultState);
+  });
+
+  beforeEach(() => {
+    state = state.clone();
+    wrappedState = createCachedValidatorsBeaconState(state);
+  });
+
+  it("should read the same value of TreeBacked<BeaconState>", () => {
+    expect(state.validators[1000].activationEpoch).to.be.equal(1000);
+    expect(wrappedState.validators[1000].activationEpoch).to.be.equal(1000);
+    expect(wrappedState.flatValidators()[1000].activationEpoch).to.be.equal(1000);
+  });
+
+  it("should modify both state and wrappedState", () => {
+    wrappedState.setValidator(1000, {activationEpoch: 2020});
+    expect(wrappedState.flatValidators()[1000].activationEpoch).to.be.equal(2020);
+    expect(state.validators[1000].activationEpoch).to.be.equal(2020);
+  });
+
+  it("should add validator to both state and wrappedState", () => {
+    wrappedState.addValidator({
+      pubkey: Buffer.alloc(48),
+      withdrawalCredentials: Buffer.alloc(32),
+      effectiveBalance: BigInt(1000000),
+      slashed: false,
+      activationEligibilityEpoch: NUM_VALIDATORS + 10,
+      activationEpoch: NUM_VALIDATORS,
+      exitEpoch: NUM_VALIDATORS + 20,
+      withdrawableEpoch: NUM_VALIDATORS + 30,
+    });
+
+    expect(wrappedState.flatValidators().length).to.be.equal(NUM_VALIDATORS + 1);
+    expect(state.validators.length).to.be.equal(NUM_VALIDATORS + 1);
+    expect(wrappedState.flatValidators()[NUM_VALIDATORS].activationEpoch).to.be.equal(NUM_VALIDATORS);
+    expect(state.validators[NUM_VALIDATORS].activationEpoch).to.be.equal(NUM_VALIDATORS);
+  });
+
+  it("should not take time from 2nd loop", () => {
+    logger.profile("First loop");
+    wrappedState.flatValidators().forEach((v) => v.activationEpoch);
+    logger.profile("First loop");
+    logger.profile("Second loop");
+    wrappedState.flatValidators().forEach((v) => v.activationEpoch);
+    logger.profile("Second loop");
+    logger.profile("Third loop");
+    wrappedState.flatValidators().forEach((v) => v.activationEpoch);
+    logger.profile("Third loop");
+  });
+});

--- a/packages/lodestar-beacon-state-transition/test/unit/fast/util/interface.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/fast/util/interface.test.ts
@@ -42,9 +42,25 @@ describe("StateTransitionBeaconState", function () {
   });
 
   it("should modify both state and wrappedState", () => {
-    wrappedState.setValidator(1000, {activationEpoch: 2020});
+    const oldFlatValidator = wrappedState.flatValidators().get(1000);
+    wrappedState.updateValidator(1000, {activationEpoch: 2020, exitEpoch: 2030});
     expect(wrappedState.flatValidators().get(1000)!.activationEpoch).to.be.equal(2020);
+    expect(wrappedState.flatValidators().get(1000)!.exitEpoch).to.be.equal(2030);
+    // other property is the same
+    expect(wrappedState.flatValidators().get(1000)!.effectiveBalance).to.be.equal(oldFlatValidator?.effectiveBalance);
+    expect(wrappedState.flatValidators().get(1000)!.slashed).to.be.equal(oldFlatValidator?.slashed);
+    expect(wrappedState.flatValidators().get(1000)!.activationEligibilityEpoch).to.be.equal(
+      oldFlatValidator?.activationEligibilityEpoch
+    );
+    expect(wrappedState.flatValidators().get(1000)!.withdrawableEpoch).to.be.equal(oldFlatValidator?.withdrawableEpoch);
+
     expect(state.validators[1000].activationEpoch).to.be.equal(2020);
+    expect(state.validators[1000].exitEpoch).to.be.equal(2030);
+    // other property is the same
+    expect(state.validators[1000].effectiveBalance).to.be.equal(oldFlatValidator?.effectiveBalance);
+    expect(state.validators[1000].slashed).to.be.equal(oldFlatValidator?.slashed);
+    expect(state.validators[1000].activationEligibilityEpoch).to.be.equal(oldFlatValidator?.activationEligibilityEpoch);
+    expect(state.validators[1000].withdrawableEpoch).to.be.equal(oldFlatValidator?.withdrawableEpoch);
   });
 
   it("should add validator to both state and wrappedState", () => {

--- a/packages/lodestar-beacon-state-transition/test/unit/fast/util/interface.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/fast/util/interface.test.ts
@@ -1,6 +1,5 @@
 import {config} from "@chainsafe/lodestar-config/lib/presets/mainnet";
 import {BeaconState, Validator} from "@chainsafe/lodestar-types";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {List, TreeBacked} from "@chainsafe/ssz";
 import {expect} from "chai";
 import {createCachedValidatorsBeaconState, CachedValidatorsBeaconState} from "../../../../src/fast/util";
@@ -11,7 +10,6 @@ const NUM_VALIDATORS = 100000;
 describe("StateTransitionBeaconState", function () {
   let state: TreeBacked<BeaconState>;
   let wrappedState: CachedValidatorsBeaconState;
-  const logger = new WinstonLogger();
 
   before(function () {
     this.timeout(0);
@@ -40,12 +38,12 @@ describe("StateTransitionBeaconState", function () {
   it("should read the same value of TreeBacked<BeaconState>", () => {
     expect(state.validators[1000].activationEpoch).to.be.equal(1000);
     expect(wrappedState.validators[1000].activationEpoch).to.be.equal(1000);
-    expect(wrappedState.flatValidators()[1000].activationEpoch).to.be.equal(1000);
+    expect(wrappedState.flatValidators().get(1000)!.activationEpoch).to.be.equal(1000);
   });
 
   it("should modify both state and wrappedState", () => {
     wrappedState.setValidator(1000, {activationEpoch: 2020});
-    expect(wrappedState.flatValidators()[1000].activationEpoch).to.be.equal(2020);
+    expect(wrappedState.flatValidators().get(1000)!.activationEpoch).to.be.equal(2020);
     expect(state.validators[1000].activationEpoch).to.be.equal(2020);
   });
 
@@ -63,19 +61,7 @@ describe("StateTransitionBeaconState", function () {
 
     expect(wrappedState.flatValidators().length).to.be.equal(NUM_VALIDATORS + 1);
     expect(state.validators.length).to.be.equal(NUM_VALIDATORS + 1);
-    expect(wrappedState.flatValidators()[NUM_VALIDATORS].activationEpoch).to.be.equal(NUM_VALIDATORS);
+    expect(wrappedState.flatValidators().get(NUM_VALIDATORS)!.activationEpoch).to.be.equal(NUM_VALIDATORS);
     expect(state.validators[NUM_VALIDATORS].activationEpoch).to.be.equal(NUM_VALIDATORS);
-  });
-
-  it("should not take time from 2nd loop", () => {
-    logger.profile("First loop");
-    wrappedState.flatValidators().forEach((v) => v.activationEpoch);
-    logger.profile("First loop");
-    logger.profile("Second loop");
-    wrappedState.flatValidators().forEach((v) => v.activationEpoch);
-    logger.profile("Second loop");
-    logger.profile("Third loop");
-    wrappedState.flatValidators().forEach((v) => v.activationEpoch);
-    logger.profile("Third loop");
   });
 });

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -10,6 +10,7 @@ import {
   AttestationData,
   AttesterDuty,
   BeaconBlock,
+  BeaconState,
   Bytes96,
   CommitteeIndex,
   Epoch,
@@ -20,7 +21,7 @@ import {
   ValidatorIndex,
 } from "@chainsafe/lodestar-types";
 import {assert, ILogger} from "@chainsafe/lodestar-utils";
-import {readOnlyForEach} from "@chainsafe/ssz";
+import {readOnlyForEach, TreeBacked} from "@chainsafe/ssz";
 import {IAttestationJob, IBeaconChain} from "../../../chain";
 import {assembleAttestationData} from "../../../chain/factory/attestation";
 import {assembleBlock} from "../../../chain/factory/block";
@@ -85,7 +86,13 @@ export class ValidatorApi implements IValidatorApi {
       await checkSyncStatus(this.config, this.sync);
       const headRoot = this.chain.forkChoice.getHeadRoot();
       const {state, epochCtx} = await this.chain.regen.getBlockSlotState(headRoot, slot);
-      return await assembleAttestationData(epochCtx.config, state, headRoot, slot, committeeIndex);
+      return await assembleAttestationData(
+        epochCtx.config,
+        state.getOriginalState() as TreeBacked<BeaconState>,
+        headRoot,
+        slot,
+        committeeIndex
+      );
     } catch (e) {
       this.logger.warn("Failed to produce attestation data", e);
       throw e;

--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -23,6 +23,8 @@ import {sleep} from "@chainsafe/lodestar-utils";
 import {IBeaconDb} from "../../db";
 import {BlockError, BlockErrorCode} from "../errors";
 import {verifySignatureSetsBatch} from "../bls";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
+import {StateTransitionEpochContext} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util/epochContext";
 
 /**
  * Emits a properly formed "checkpoint" event, given a checkpoint state context
@@ -65,26 +67,30 @@ export async function processSlotsToNearestCheckpoint(
   emitter: ChainEventEmitter,
   stateCtx: ITreeStateContext,
   slot: Slot
-): Promise<ITreeStateContext> {
+): Promise<IStateContext> {
   const config = stateCtx.epochCtx.config;
   const {SLOTS_PER_EPOCH} = config.params;
   const preSlot = stateCtx.state.slot;
   const postSlot = slot;
   const preEpoch = computeEpochAtSlot(config, preSlot);
-  let postCtx = cloneStateCtx(stateCtx);
+  const postCtx = cloneStateCtx(stateCtx);
+  const stateTransitionState = createCachedValidatorsBeaconState(postCtx.state);
+  const stateTranstionEpochContext = new StateTransitionEpochContext(undefined, postCtx.epochCtx);
   for (
     let nextEpochSlot = computeStartSlotAtEpoch(config, preEpoch + 1);
     nextEpochSlot <= postSlot;
     nextEpochSlot += SLOTS_PER_EPOCH
   ) {
-    processSlots(postCtx.epochCtx, postCtx.state, nextEpochSlot);
-    postCtx = toTreeStateContext(toIStateContext(postCtx.epochCtx, postCtx.state));
-    emitCheckpointEvent(emitter, postCtx);
-    postCtx = cloneStateCtx(postCtx);
+    processSlots(stateTranstionEpochContext, stateTransitionState, nextEpochSlot);
+    const checkpointCtx = toTreeStateContext(toIStateContext(stateTranstionEpochContext, stateTransitionState));
+    emitCheckpointEvent(emitter, cloneStateCtx(checkpointCtx));
     // this avoids keeping our node busy processing blocks
     await sleep(0);
   }
-  return postCtx;
+  return {
+    epochCtx: stateTranstionEpochContext,
+    state: stateTransitionState,
+  };
 }
 
 /**
@@ -97,12 +103,11 @@ export async function processSlotsByCheckpoint(
   stateCtx: ITreeStateContext,
   slot: Slot
 ): Promise<ITreeStateContext> {
-  let postCtx = await processSlotsToNearestCheckpoint(emitter, stateCtx, slot);
+  const postCtx = await processSlotsToNearestCheckpoint(emitter, stateCtx, slot);
   if (postCtx.state.slot < slot) {
     processSlots(postCtx.epochCtx, postCtx.state, slot);
-    postCtx = toTreeStateContext(toIStateContext(postCtx.epochCtx, postCtx.state));
   }
-  return postCtx;
+  return toTreeStateContext(postCtx);
 }
 
 export function emitForkChoiceHeadEvents(
@@ -196,7 +201,7 @@ export async function runStateTransition(
  */
 function toTreeStateContext(stateCtx: IStateContext): ITreeStateContext {
   const treeStateCtx: ITreeStateContext = {
-    state: stateCtx.state as TreeBacked<BeaconState>,
+    state: stateCtx.state.getOriginalState() as TreeBacked<BeaconState>,
     epochCtx: new LodestarEpochContext(undefined, stateCtx.epochCtx),
   };
 

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -148,8 +148,8 @@ export class BeaconChain implements IBeaconChain {
     return headStateRoot;
   }
   public async getHeadState(): Promise<TreeBacked<BeaconState>> {
-    // head state should always have epoch ctx
-    return (await this.getHeadStateContext()).state;
+    //head state should always have epoch ctx
+    return (await this.getHeadStateContext()).state.getOriginalState() as TreeBacked<BeaconState>;
   }
   public async getHeadEpochContext(): Promise<EpochContext> {
     // head should always have epoch ctx

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -219,7 +219,7 @@ export async function onBlock(
   job: IBlockJob
 ): Promise<void> {
   const blockRoot = this.config.types.BeaconBlock.hashTreeRoot(block.message);
-  this.logger.debug("Block processed", {
+  this.logger.info("Block processed", {
     slot: block.message.slot,
     root: toHexString(blockRoot),
   });
@@ -309,7 +309,7 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
     return;
   }
 
-  this.logger.debug("Block error", {}, err);
+  this.logger.error("Block error", {}, err);
   const blockRoot = this.config.types.BeaconBlock.hashTreeRoot(err.job.signedBlock.message);
 
   switch (err.type.code) {

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -3,6 +3,7 @@
  */
 
 import {processBlock} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/block";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {BeaconBlock, Bytes96, Root, Slot} from "@chainsafe/lodestar-types";
 import {ZERO_HASH} from "../../../constants";
@@ -43,7 +44,7 @@ export async function assembleBlock(
  */
 function computeNewStateRoot(config: IBeaconConfig, stateContext: ITreeStateContext, block: BeaconBlock): Root {
   const postState = {
-    state: stateContext.state.clone(),
+    state: createCachedValidatorsBeaconState(stateContext.state.clone()),
     epochCtx: stateContext.epochCtx.copy(),
   };
   processBlock(postState.epochCtx, postState.state, block, true);

--- a/packages/lodestar/src/chain/initState.ts
+++ b/packages/lodestar/src/chain/initState.ts
@@ -16,6 +16,7 @@ import {Eth1Provider} from "../eth1";
 import {IBeaconMetrics} from "../metrics";
 import {GenesisBuilder} from "./genesis/genesis";
 import {IGenesisResult} from "./genesis/interface";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
 export async function persistGenesisResult(
   db: IBeaconDb,
@@ -138,7 +139,7 @@ export async function restoreStateCaches(
   const epochCtx = new EpochContext(config);
   epochCtx.loadState(state);
 
-  const stateCtx = {state, epochCtx};
+  const stateCtx = {state: createCachedValidatorsBeaconState(state), epochCtx};
   await Promise.all([db.stateCache.add(stateCtx), db.checkpointStateCache.add(checkpoint, stateCtx)]);
 }
 

--- a/packages/lodestar/src/db/api/beacon/stateContextCache.ts
+++ b/packages/lodestar/src/db/api/beacon/stateContextCache.ts
@@ -1,10 +1,11 @@
 import {ByteVector, toHexString, TreeBacked} from "@chainsafe/ssz";
 import {BeaconState, Gwei} from "@chainsafe/lodestar-types";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
 // Lodestar specifc state context
 export interface ITreeStateContext {
-  state: TreeBacked<BeaconState>;
+  state: CachedValidatorsBeaconState; // TreeBacked<BeaconState>
   epochCtx: LodestarEpochContext;
 }
 
@@ -40,7 +41,9 @@ export class StateContextCache {
   }
 
   public async add(item: ITreeStateContext): Promise<void> {
-    this.cache[toHexString(item.state.hashTreeRoot())] = this.clone(item);
+    this.cache[toHexString((item.state.getOriginalState() as TreeBacked<BeaconState>).hashTreeRoot())] = this.clone(
+      item
+    );
   }
 
   public async delete(root: ByteVector): Promise<void> {

--- a/packages/lodestar/src/tasks/tasks/archiveStates.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveStates.ts
@@ -6,7 +6,8 @@ import {ITask} from "../interface";
 import {IBeaconDb} from "../../db/api";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils";
-import {Checkpoint} from "@chainsafe/lodestar-types";
+import {BeaconState, Checkpoint} from "@chainsafe/lodestar-types";
+import {TreeBacked} from "@chainsafe/ssz";
 
 export interface IArchiveStatesModules {
   db: IBeaconDb;
@@ -41,7 +42,7 @@ export class ArchiveStatesTask implements ITask {
       throw Error("No state in cache for finalized checkpoint state epoch #" + this.finalized.epoch);
     }
     const finalizedState = stateCache.state;
-    await this.db.stateArchive.put(finalizedState.slot, finalizedState);
+    await this.db.stateArchive.put(finalizedState.slot, finalizedState.getOriginalState() as TreeBacked<BeaconState>);
     // don't delete states before the finalized state, auto-prune will take care of it
     this.logger.info("Archive states completed", {finalizedEpoch: this.finalized.epoch});
     this.logger.profile("Archive States epoch #" + this.finalized.epoch);

--- a/packages/lodestar/test/e2e/chain/factory/block/assembleBlock.test.ts
+++ b/packages/lodestar/test/e2e/chain/factory/block/assembleBlock.test.ts
@@ -72,7 +72,9 @@ describe("produce block", function () {
     sinon.stub(epochCtx, "getBeaconProposer").returns(20);
     const slotState = state.clone();
     slotState.slot = 1;
-    regenStub.getBlockSlotState.withArgs(sinon.match.any, 1).resolves({state: createCachedValidatorsBeaconState(slotState), epochCtx});
+    regenStub.getBlockSlotState
+      .withArgs(sinon.match.any, 1)
+      .resolves({state: createCachedValidatorsBeaconState(slotState), epochCtx});
     forkChoiceStub.getHead.returns(parentBlockSummary);
     dbStub.depositDataRoot.getTreeBacked.resolves(depositDataRootList);
     dbStub.proposerSlashing.values.resolves([]);

--- a/packages/lodestar/test/e2e/chain/factory/block/assembleBlock.test.ts
+++ b/packages/lodestar/test/e2e/chain/factory/block/assembleBlock.test.ts
@@ -27,6 +27,7 @@ import {ValidatorApi} from "../../../../../src/api/impl/validator";
 import {StubbedBeaconDb} from "../../../../utils/stub";
 import {silentLogger} from "../../../../utils/logger";
 import {StateRegenerator} from "../../../../../src/chain/regen";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
 describe("produce block", function () {
   this.timeout("10 min");
@@ -90,7 +91,8 @@ describe("produce block", function () {
       return await assembleBlock(config, chainStub, dbStub, eth1, slot, randao);
     });
     const block = await blockProposingService.createAndPublishBlock(0, 1, state.fork, ZERO_HASH);
-    expect(() => fastStateTransition({state, epochCtx}, block!, {verifyStateRoot: false})).to.not.throw();
+    const wrappedState = createCachedValidatorsBeaconState(state);
+    expect(() => fastStateTransition({state: wrappedState, epochCtx}, block!, {verifyStateRoot: false})).to.not.throw();
   });
 
   function getBlockProposingService(secretKey: SecretKey): BlockProposingService {

--- a/packages/lodestar/test/e2e/chain/factory/block/assembleBlock.test.ts
+++ b/packages/lodestar/test/e2e/chain/factory/block/assembleBlock.test.ts
@@ -72,7 +72,7 @@ describe("produce block", function () {
     sinon.stub(epochCtx, "getBeaconProposer").returns(20);
     const slotState = state.clone();
     slotState.slot = 1;
-    regenStub.getBlockSlotState.withArgs(sinon.match.any, 1).resolves({state: slotState, epochCtx});
+    regenStub.getBlockSlotState.withArgs(sinon.match.any, 1).resolves({state: createCachedValidatorsBeaconState(slotState), epochCtx});
     forkChoiceStub.getHead.returns(parentBlockSummary);
     dbStub.depositDataRoot.getTreeBacked.resolves(depositDataRootList);
     dbStub.proposerSlashing.values.resolves([]);

--- a/packages/lodestar/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/state/utils.test.ts
@@ -12,7 +12,7 @@ import {getEpochBeaconCommittees, resolveStateId} from "../../../../../../src/ap
 import {BeaconChain, IBeaconChain} from "../../../../../../src/chain";
 import {IBeaconClock} from "../../../../../../src/chain/clock/interface";
 import {generateBlockSummary} from "../../../../../utils/block";
-import {generateState} from "../../../../../utils/state";
+import {generateCachedState, generateState} from "../../../../../utils/state";
 import {StubbedBeaconDb} from "../../../../../utils/stub";
 import {generateValidator} from "../../../../../utils/validator";
 
@@ -30,7 +30,7 @@ describe("beacon state api utils", function () {
 
     it("resolve head state id - success", async function () {
       forkChoiceStub.getHead.returns(generateBlockSummary({stateRoot: Buffer.alloc(32, 1)}));
-      dbStub.stateCache.get.resolves({state: generateState(), epochCtx: null!});
+      dbStub.stateCache.get.resolves({state: generateCachedState(), epochCtx: null!});
       const state = await resolveStateId(config, dbStub, forkChoiceStub, "head");
       expect(state).to.not.be.null;
       expect(forkChoiceStub.getHead.calledOnce).to.be.true;
@@ -46,7 +46,7 @@ describe("beacon state api utils", function () {
 
     it("resolve finalized state id - success", async function () {
       forkChoiceStub.getFinalizedCheckpoint.returns({root: Buffer.alloc(32, 1), epoch: 1});
-      dbStub.stateCache.get.resolves({state: generateState(), epochCtx: null!});
+      dbStub.stateCache.get.resolves({state: generateCachedState(), epochCtx: null!});
       const state = await resolveStateId(config, dbStub, forkChoiceStub, "finalized");
       expect(state).to.not.be.null;
       expect(forkChoiceStub.getFinalizedCheckpoint.calledOnce).to.be.true;
@@ -64,7 +64,7 @@ describe("beacon state api utils", function () {
 
     it("resolve justified state id - success", async function () {
       forkChoiceStub.getJustifiedCheckpoint.returns({root: Buffer.alloc(32, 1), epoch: 1});
-      dbStub.stateCache.get.resolves({state: generateState(), epochCtx: null!});
+      dbStub.stateCache.get.resolves({state: generateCachedState(), epochCtx: null!});
       const state = await resolveStateId(config, dbStub, forkChoiceStub, "justified");
       expect(state).to.not.be.null;
       expect(forkChoiceStub.getJustifiedCheckpoint.calledOnce).to.be.true;
@@ -81,14 +81,14 @@ describe("beacon state api utils", function () {
     });
 
     it("resolve state by root", async function () {
-      dbStub.stateCache.get.resolves({state: generateState(), epochCtx: null!});
+      dbStub.stateCache.get.resolves({state: generateCachedState(), epochCtx: null!});
       const state = await resolveStateId(config, dbStub, forkChoiceStub, toHexString(Buffer.alloc(32, 1)));
       expect(state).to.not.be.null;
       expect(dbStub.stateCache.get.calledOnce).to.be.true;
     });
 
     it.skip("resolve finalized state by root", async function () {
-      dbStub.stateCache.get.resolves({state: generateState(), epochCtx: null!});
+      dbStub.stateCache.get.resolves({state: generateCachedState(), epochCtx: null!});
       const state = await resolveStateId(config, dbStub, forkChoiceStub, toHexString(Buffer.alloc(32, 1)));
       expect(state).to.be.null;
       expect(dbStub.stateCache.get.calledOnce).to.be.true;
@@ -103,7 +103,7 @@ describe("beacon state api utils", function () {
       forkChoiceStub.getCanonicalBlockSummaryAtSlot
         .withArgs(123)
         .returns(generateBlockSummary({stateRoot: Buffer.alloc(32, 1)}));
-      dbStub.stateCache.get.resolves({state: generateState(), epochCtx: null!});
+      dbStub.stateCache.get.resolves({state: generateCachedState(), epochCtx: null!});
       const state = await resolveStateId(config, dbStub, forkChoiceStub, "123");
       expect(state).to.not.be.null;
       expect(forkChoiceStub.getCanonicalBlockSummaryAtSlot.withArgs(123).calledOnce).to.be.true;
@@ -165,7 +165,7 @@ describe("beacon state api utils", function () {
 
     function getApiContext(): ApiStateContext {
       return {
-        state: generateState(),
+        state: generateCachedState(),
         epochCtx: {
           currentShuffling: {
             committees: [

--- a/packages/lodestar/test/unit/api/impl/validator/duties/proposer.test.ts
+++ b/packages/lodestar/test/unit/api/impl/validator/duties/proposer.test.ts
@@ -13,6 +13,7 @@ import {generateState} from "../../../../../utils/state";
 import {StubbedBeaconDb} from "../../../../../utils/stub";
 import {BeaconSync, IBeaconSync} from "../../../../../../src/sync";
 import {generateValidators} from "../../../../../utils/validator";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
 describe("get proposers api impl", function () {
   const sandbox = sinon.createSandbox();
@@ -79,7 +80,7 @@ describe("get proposers api impl", function () {
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
     chainStub.getHeadStateContextAtCurrentEpoch.resolves({
-      state,
+      state: createCachedValidatorsBeaconState(state),
       epochCtx,
     });
     sinon.stub(epochCtx, "getBeaconProposer").returns(1);

--- a/packages/lodestar/test/unit/chain/attestation/process.test.ts
+++ b/packages/lodestar/test/unit/chain/attestation/process.test.ts
@@ -11,7 +11,7 @@ import {ChainEvent, ChainEventEmitter} from "../../../../src/chain";
 import {StateRegenerator} from "../../../../src/chain/regen";
 import {AttestationErrorCode} from "../../../../src/chain/errors";
 import {generateAttestation} from "../../../utils/attestation";
-import {generateState} from "../../../utils/state";
+import {generateCachedState} from "../../../utils/state";
 
 describe("processAttestation", function () {
   const emitter = new ChainEventEmitter();
@@ -47,7 +47,7 @@ describe("processAttestation", function () {
 
   it("should throw on errored getIndexedAttestation", async function () {
     const attestation = generateAttestation();
-    const state = generateState();
+    const state = generateCachedState();
     const epochCtx = sinon.createStubInstance(EpochContext);
     epochCtx.getIndexedAttestation.throws();
     regen.getCheckpointState.resolves({state, epochCtx: (epochCtx as unknown) as EpochContext});
@@ -66,7 +66,7 @@ describe("processAttestation", function () {
 
   it("should throw on invalid indexed attestation", async function () {
     const attestation = generateAttestation();
-    const state = generateState();
+    const state = generateCachedState();
     const epochCtx = sinon.createStubInstance(EpochContext);
     epochCtx.getIndexedAttestation.returns({} as IndexedAttestation);
     regen.getCheckpointState.resolves({state, epochCtx: (epochCtx as unknown) as EpochContext});
@@ -86,7 +86,7 @@ describe("processAttestation", function () {
 
   it("should emit 'attestation' event on processed attestation", async function () {
     const attestation = generateAttestation();
-    const state = generateState();
+    const state = generateCachedState();
     const epochCtx = sinon.createStubInstance(EpochContext);
     epochCtx.getIndexedAttestation.returns({} as IndexedAttestation);
     regen.getCheckpointState.resolves({state, epochCtx: (epochCtx as unknown) as EpochContext});

--- a/packages/lodestar/test/unit/chain/chain.test.ts
+++ b/packages/lodestar/test/unit/chain/chain.test.ts
@@ -1,7 +1,6 @@
 import {expect} from "chai";
 import sinon from "sinon";
 
-import {TreeBacked} from "@chainsafe/ssz";
 import {BeaconState} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {bytesToInt, WinstonLogger} from "@chainsafe/lodestar-utils";
@@ -14,6 +13,7 @@ import {generateBlockSummary} from "../../utils/block";
 import {generateState} from "../../utils/state";
 import {StubbedBeaconDb} from "../../utils/stub";
 import {generateValidators} from "../../utils/validator";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
 describe("BeaconChain", function () {
   const sandbox = sinon.createSandbox();
@@ -26,7 +26,10 @@ describe("BeaconChain", function () {
     metrics = new BeaconMetrics({enabled: false} as any, {logger});
     const state: BeaconState = generateState();
     state.validators = generateValidators(5, {activationEpoch: 0});
-    dbStub.stateCache.get.resolves({state: state as TreeBacked<BeaconState>, epochCtx: new EpochContext(config)});
+    dbStub.stateCache.get.resolves({
+      state: createCachedValidatorsBeaconState(state),
+      epochCtx: new EpochContext(config),
+    });
     dbStub.stateArchive.lastValue.resolves(state as any);
     chain = new BeaconChain({opts: defaultChainOptions, config, db: dbStub, logger, metrics, anchorState: state});
   });

--- a/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
@@ -13,7 +13,7 @@ import * as blockBodyAssembly from "../../../../../src/chain/factory/block/body"
 import {StateRegenerator} from "../../../../../src/chain/regen";
 import {Eth1ForBlockProduction} from "../../../../../src/eth1/";
 import {generateBlockSummary, generateEmptyBlock} from "../../../../utils/block";
-import {generateState} from "../../../../utils/state";
+import {generateCachedState, generateState} from "../../../../utils/state";
 import {StubbedBeaconDb, StubbedChain} from "../../../../utils/stub";
 
 describe("block assembly", function () {
@@ -48,7 +48,7 @@ describe("block assembly", function () {
     const epochCtx = new EpochContext(config);
     sinon.stub(epochCtx).getBeaconProposer.returns(2);
     regenStub.getBlockSlotState.resolves({
-      state: generateState({slot: 1}),
+      state: generateCachedState({slot: 1}),
       epochCtx: epochCtx,
     });
     beaconDB.depositDataRoot.getTreeBacked.resolves(config.types.DepositDataRootList.tree.defaultValue());

--- a/packages/lodestar/test/unit/chain/validation/aggregateAndProof.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/aggregateAndProof.test.ts
@@ -16,7 +16,7 @@ import {validateGossipAggregateAndProof} from "../../../../src/chain/validation"
 import {ATTESTATION_PROPAGATION_SLOT_RANGE, MAXIMUM_GOSSIP_CLOCK_DISPARITY} from "../../../../src/constants";
 import * as validationUtils from "../../../../src/chain/validation/utils";
 import {generateSignedAggregateAndProof} from "../../../utils/aggregateAndProof";
-import {generateState} from "../../../utils/state";
+import {generateCachedState} from "../../../utils/state";
 import {StubbedBeaconDb} from "../../../utils/stub";
 import {AttestationErrorCode} from "../../../../src/chain/errors";
 
@@ -196,7 +196,7 @@ describe("gossip aggregate and proof test", function () {
         },
       },
     });
-    const state = generateState();
+    const state = generateCachedState();
     const epochCtx = sinon.createStubInstance(EpochContext);
     regen.getBlockSlotState.resolves({
       state,
@@ -226,7 +226,7 @@ describe("gossip aggregate and proof test", function () {
         },
       },
     });
-    const state = generateState();
+    const state = generateCachedState();
     const epochCtx = sinon.createStubInstance(EpochContext);
     regen.getBlockSlotState.resolves({
       state,
@@ -254,7 +254,7 @@ describe("gossip aggregate and proof test", function () {
         },
       },
     });
-    const state = generateState();
+    const state = generateCachedState();
     const epochCtx = sinon.createStubInstance(EpochContext);
     epochCtx.index2pubkey = [];
     const privateKey = bls.SecretKey.fromBytes(bigIntToBytes(BigInt(1), 32));
@@ -286,7 +286,7 @@ describe("gossip aggregate and proof test", function () {
         },
       },
     });
-    const state = generateState();
+    const state = generateCachedState();
     const epochCtx = sinon.createStubInstance(EpochContext);
     epochCtx.index2pubkey = [];
     const privateKey = bls.SecretKey.fromBytes(bigIntToBytes(BigInt(1), 32));
@@ -327,7 +327,7 @@ describe("gossip aggregate and proof test", function () {
         },
       },
     });
-    const state = generateState();
+    const state = generateCachedState();
     const epochCtx = sinon.createStubInstance(EpochContext);
     epochCtx.index2pubkey = [];
     const privateKey = bls.SecretKey.fromBytes(bigIntToBytes(BigInt(1), 32));
@@ -361,7 +361,7 @@ describe("gossip aggregate and proof test", function () {
         },
       },
     });
-    const state = generateState();
+    const state = generateCachedState();
     const epochCtx = sinon.createStubInstance(EpochContext);
     epochCtx.index2pubkey = [];
     const privateKey = bls.SecretKey.fromKeygen();

--- a/packages/lodestar/test/unit/chain/validation/attestation.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/attestation.test.ts
@@ -16,7 +16,7 @@ import {IStateRegenerator, StateRegenerator} from "../../../../src/chain/regen";
 import {ATTESTATION_PROPAGATION_SLOT_RANGE} from "../../../../src/constants";
 import {validateGossipAttestation} from "../../../../src/chain/validation";
 import {generateAttestation} from "../../../utils/attestation";
-import {generateState} from "../../../utils/state";
+import {generateCachedState} from "../../../utils/state";
 import {LocalClock} from "../../../../src/chain/clock";
 import {IEpochShuffling} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util/epochShuffling";
 import {AttestationErrorCode} from "../../../../src/chain/errors";
@@ -235,7 +235,7 @@ describe("gossip attestation validation", function () {
     db.seenAttestationCache.hasCommitteeAttestation.resolves(false);
     forkChoice.hasBlock.returns(true);
     const attestationPreState = {
-      state: generateState(),
+      state: generateCachedState(),
       epochCtx: new EpochContext(config),
     };
     regen.getCheckpointState.resolves(attestationPreState);
@@ -265,7 +265,7 @@ describe("gossip attestation validation", function () {
     db.seenAttestationCache.hasCommitteeAttestation.resolves(false);
     forkChoice.hasBlock.returns(true);
     const attestationPreState = {
-      state: generateState(),
+      state: generateCachedState(),
       epochCtx: new EpochContext(config),
     };
     attestationPreState.epochCtx.getIndexedAttestation = () => toIndexedAttestation(attestation);
@@ -300,7 +300,7 @@ describe("gossip attestation validation", function () {
     db.seenAttestationCache.hasCommitteeAttestation.resolves(false);
     forkChoice.hasBlock.returns(true);
     const attestationPreState = {
-      state: generateState(),
+      state: generateCachedState(),
       epochCtx: new EpochContext(config),
     };
     attestationPreState.epochCtx.previousShuffling = {
@@ -338,7 +338,7 @@ describe("gossip attestation validation", function () {
     db.seenAttestationCache.hasCommitteeAttestation.resolves(false);
     forkChoice.hasBlock.returns(true);
     const attestationPreState = {
-      state: generateState(),
+      state: generateCachedState(),
       epochCtx: new EpochContext(config),
     };
     attestationPreState.epochCtx.previousShuffling = {
@@ -379,7 +379,7 @@ describe("gossip attestation validation", function () {
     db.seenAttestationCache.hasCommitteeAttestation.resolves(false);
     forkChoice.hasBlock.returns(true);
     const attestationPreState = {
-      state: generateState(),
+      state: generateCachedState(),
       epochCtx: new EpochContext(config),
     };
     attestationPreState.epochCtx.previousShuffling = {
@@ -423,7 +423,7 @@ describe("gossip attestation validation", function () {
     db.seenAttestationCache.hasCommitteeAttestation.resolves(false);
     forkChoice.hasBlock.returns(true);
     const attestationPreState = {
-      state: generateState(),
+      state: generateCachedState(),
       epochCtx: new EpochContext(config),
     };
     attestationPreState.epochCtx.previousShuffling = {
@@ -485,7 +485,7 @@ describe("gossip attestation validation", function () {
     db.seenAttestationCache.hasCommitteeAttestation.resolves(false);
     forkChoice.hasBlock.returns(true);
     const attestationPreState = {
-      state: generateState(),
+      state: generateCachedState(),
       epochCtx: new EpochContext(config),
     };
     attestationPreState.epochCtx.previousShuffling = {
@@ -525,7 +525,7 @@ describe("gossip attestation validation", function () {
     forkChoice.isDescendant.returns(true);
     forkChoice.isDescendantOfFinalized.returns(false);
     const attestationPreState = {
-      state: generateState(),
+      state: generateCachedState(),
       epochCtx: new EpochContext(config),
     };
     attestationPreState.epochCtx.previousShuffling = {
@@ -557,7 +557,7 @@ describe("gossip attestation validation", function () {
     const attestation = generateAttestation({
       aggregationBits: [true] as BitList,
     });
-    const state = generateState();
+    const state = generateCachedState();
     const attestationPreState = {
       state,
       epochCtx: new EpochContext(config),

--- a/packages/lodestar/test/unit/chain/validation/block.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/block.test.ts
@@ -11,7 +11,7 @@ import {StateRegenerator} from "../../../../src/chain/regen";
 import {validateGossipBlock} from "../../../../src/chain/validation";
 import {generateSignedBlock, getNewBlockJob} from "../../../utils/block";
 import {StubbedBeaconDb} from "../../../utils/stub";
-import {generateState} from "../../../utils/state";
+import {generateCachedState} from "../../../utils/state";
 import {BlockErrorCode} from "../../../../src/chain/errors";
 
 describe("gossip block validation", function () {
@@ -122,7 +122,7 @@ describe("gossip block validation", function () {
     dbStub.badBlock.has.resolves(false);
     dbStub.block.get.resolves(null);
     regenStub.getBlockSlotState.resolves({
-      state: generateState(),
+      state: generateCachedState(),
       epochCtx: new EpochContext(config),
     });
     verifySignatureStub.returns(false);
@@ -150,7 +150,7 @@ describe("gossip block validation", function () {
     dbStub.block.get.resolves(null);
     const epochCtxStub = sinon.createStubInstance(EpochContext);
     regenStub.getBlockSlotState.resolves({
-      state: generateState(),
+      state: generateCachedState(),
       epochCtx: (epochCtxStub as unknown) as EpochContext,
     });
     verifySignatureStub.returns(true);
@@ -181,7 +181,7 @@ describe("gossip block validation", function () {
     forkChoiceStub.isDescendantOfFinalized.returns(true);
     const epochCtxStub = sinon.createStubInstance(EpochContext);
     regenStub.getBlockSlotState.resolves({
-      state: generateState(),
+      state: generateCachedState(),
       epochCtx: (epochCtxStub as unknown) as EpochContext,
     });
     verifySignatureStub.returns(true);

--- a/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
@@ -15,6 +15,7 @@ import {generateState} from "../../../utils/state";
 import {generateEmptySignedVoluntaryExit} from "../../../utils/attestation";
 import {validateGossipVoluntaryExit} from "../../../../src/chain/validation/voluntaryExit";
 import {VoluntaryExitErrorCode} from "../../../../src/chain/errors/voluntaryExitError";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
 describe("validate voluntary exit", () => {
   const sandbox = sinon.createSandbox();
@@ -48,7 +49,7 @@ describe("validate voluntary exit", () => {
     });
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
-    regenStub.getCheckpointState.resolves({state, epochCtx});
+    regenStub.getCheckpointState.resolves({state: createCachedValidatorsBeaconState(state), epochCtx});
     try {
       await validateGossipVoluntaryExit(config, chainStub, dbStub, voluntaryExit);
     } catch (error) {
@@ -69,7 +70,7 @@ describe("validate voluntary exit", () => {
     });
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
-    regenStub.getCheckpointState.resolves({state, epochCtx});
+    regenStub.getCheckpointState.resolves({state: createCachedValidatorsBeaconState(state), epochCtx});
     isValidIncomingVoluntaryExitStub.returns(false);
     try {
       await validateGossipVoluntaryExit(config, chainStub, dbStub, voluntaryExit);
@@ -91,7 +92,7 @@ describe("validate voluntary exit", () => {
     });
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
-    regenStub.getCheckpointState.resolves({state, epochCtx});
+    regenStub.getCheckpointState.resolves({state: createCachedValidatorsBeaconState(state), epochCtx});
     isValidIncomingVoluntaryExitStub.returns(true);
     const validationTest = await validateGossipVoluntaryExit(config, chainStub, dbStub, voluntaryExit);
     expect(validationTest).to.not.throw;

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -26,6 +26,7 @@ import {IStateRegenerator, StateRegenerator} from "../../../../src/chain/regen";
 import {StubbedBeaconDb} from "../../stub";
 import {BlockPool} from "../../../../src/chain/blocks";
 import {AttestationPool} from "../../../../src/chain/attestation";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
 export interface IMockChainParams {
   genesisTime: Number64;
@@ -82,21 +83,21 @@ export class MockBeaconChain implements IBeaconChain {
 
   public async getHeadStateContext(): Promise<ITreeStateContext> {
     return {
-      state: this.state!,
+      state: createCachedValidatorsBeaconState(this.state!),
       epochCtx: new EpochContext(this.config),
     };
   }
 
   public async getHeadStateContextAtCurrentEpoch(): Promise<ITreeStateContext> {
     return {
-      state: this.state!,
+      state: createCachedValidatorsBeaconState(this.state!),
       epochCtx: new EpochContext(this.config),
     };
   }
 
   public async getHeadStateContextAtCurrentSlot(): Promise<ITreeStateContext> {
     return {
-      state: this.state!,
+      state: createCachedValidatorsBeaconState(this.state!),
       epochCtx: new EpochContext(this.config),
     };
   }
@@ -112,7 +113,7 @@ export class MockBeaconChain implements IBeaconChain {
   }
 
   public async getHeadState(): Promise<TreeBacked<BeaconState>> {
-    return (await this.getHeadStateContext()).state;
+    return (await this.getHeadStateContext()).state.getOriginalState() as TreeBacked<BeaconState>;
   }
 
   public async getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<SignedBeaconBlock[] | null> {

--- a/packages/lodestar/test/utils/state.ts
+++ b/packages/lodestar/test/utils/state.ts
@@ -3,6 +3,10 @@ import {GENESIS_EPOCH, GENESIS_SLOT, ZERO_HASH} from "../../src/constants";
 import {generateEmptyBlock} from "./block";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {TreeBacked, List} from "@chainsafe/ssz";
+import {
+  CachedValidatorsBeaconState,
+  createCachedValidatorsBeaconState,
+} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
 /**
  * Copy of BeaconState, but all fields are marked optional to allow for swapping out variables as needed.
@@ -74,4 +78,8 @@ export function generateState(opts: TestBeaconState = {}): TreeBacked<BeaconStat
     resultState[key] = opts[key];
   }
   return resultState;
+}
+
+export function generateCachedState(opts: TestBeaconState = {}): CachedValidatorsBeaconState {
+  return createCachedValidatorsBeaconState(generateState(opts));
 }

--- a/packages/persistent-ts/.babelrc
+++ b/packages/persistent-ts/.babelrc
@@ -1,0 +1,3 @@
+{
+  "extends": "../../.babelrc"
+}

--- a/packages/persistent-ts/LICENSE
+++ b/packages/persistent-ts/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) Lúcás Meier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/persistent-ts/README.md
+++ b/packages/persistent-ts/README.md
@@ -1,0 +1,72 @@
+# persistent-ts
+
+Persistent data structures for TypeScript.
+
+Persistent data structures are entirely immutable, but efficiently share elements between
+each other. For example, prepending to a persisistent list only creates a new node that
+references the old list. Prepending to an array, however, requires copying an entire array.
+Persistent data structures are thus better suited for use in immutable environments.
+
+This library isn't as developed as others, such as
+[immutable js](https://github.com/immutable-js/immutable-js).
+However, it can provide alternative data structures, and hopefully more readable implementations.
+Unlike _immutable js_ specifically, this implementation is also Typescript first, whereas
+that library adds type annotations after the fact. This makes for an api centered around
+generics, and not necessarily acccomadating JS' indiosyncracies.
+
+## Data Structures Implemented
+
+This library only implements a handful of data structures at the moment.
+
+### List
+
+`List` is a singly linked list. Here's a sample of its operations:
+
+```ts
+// ()
+List.empty<number>();
+
+// (1, 2, 3, 4)
+List.of(1, 2, 3, 4);
+
+// (1, 2)
+List.of(1).prepend(2);
+
+// 1
+List.of(1, 2, 3).head();
+
+// (2, 3)
+List.of(1, 2, 3).tail();
+
+// (1, 2, 3)
+List.of(1, 2, 3, 4).take(3);
+
+// (4)
+List.of(1, 2, 3, 4).drop(3);
+
+//[1, 2, 3, 4]
+[...List.of(1, 2, 3, 4)];
+```
+
+### Vector
+
+`Vector` is a Radix Tree in the vein of clojure's data structure.
+This can be used as an immutable sequence with efficient random access and
+appending. Here's a sample of its operations:
+
+```ts
+// []
+Vector.empty<number>();
+
+// [1]
+Vector.empty().append(1);
+
+// []
+Vector.of(1).pop();
+
+// 3
+Vector.of(1, 2, 3).get(2);
+
+// [1, 2, 100]
+Vector.of(1, 2, 3).set(2, 100);
+```

--- a/packages/persistent-ts/package.json
+++ b/packages/persistent-ts/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@chainsafe/persistent-ts",
+  "version": "0.13.0",
+  "description": "Persistent data structures for TypeScript.",
+  "main": "lib/index.js",
+  "files": [
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "lib/**/*.js.map"
+  ],
+  "scripts": {
+    "build": "concurrently \"yarn build:lib\" \"yarn build:types\"",
+    "build:lib": "babel src -x .ts -d lib --source-maps",
+    "build:lib:watch": "yarn run build:lib --watch",
+    "build:release": "yarn clean && yarn build",
+    "build:types": "tsc --incremental --declaration --outDir lib --project tsconfig.build.json --emitDeclarationOnly",
+    "build:types:watch": "yarn run build:types --watch --preserveWatchOutput",
+    "check-types": "tsc --noEmit",
+    "clean": "rm -rf lib && rm -f tsconfig.tsbuildinfo && rm -f tsconfig.build.tsbuildinfo",
+    "lint": "eslint --color --ext .ts src/ test/",
+    "lint:fix": "yarn run lint --fix",
+    "prepublishOnly": "yarn build",
+    "test:unit": "mocha 'test/unit/**/*.test.ts'",
+    "test:perf": "mocha 'test/perf/**/*.test.ts'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cronokirby/persistent-ts.git"
+  },
+  "keywords": [
+    "persistent",
+    "functional",
+    "typescript"
+  ],
+  "author": "Lúcás Meier",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/cronokirby/persistent-ts/issues"
+  },
+  "homepage": "https://github.com/cronokirby/persistent-ts#readme",
+  "devDependencies": {
+    "fast-check": "^1.15.1"
+  },
+  "jest": {
+    "transform": {
+      ".ts": "ts-jest"
+    },
+    "testRegex": "\\.test.ts$",
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ]
+  }
+}

--- a/packages/persistent-ts/src/List.ts
+++ b/packages/persistent-ts/src/List.ts
@@ -1,0 +1,197 @@
+type Node<T> = {next: null} | {value: T; next: Node<T>};
+// We can share a single empty node between all lists.
+const EMPTY_NODE = {next: null};
+
+/**
+ * List<T> represents an immutable list containing values of type T.
+ *
+ * This class is implemented as a singly linked-list, with all the caveats involved.
+ *
+ * This class is best used when many values need to be stored and then consumed
+ * linearly in a first-in-last-out fashion. If direct indexing or quick storing
+ * at the front and back is needed, then a list isn't the best choice.
+ *
+ * Because a List is Iterable, you can loop over it using `for of` and use the spread operator.
+ */
+export class List<T> implements Iterable<T> {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  private constructor(private readonly _node: Node<T>) {}
+
+  /**
+   * O(1) Create a new empty list.
+   */
+  public static empty<T>(): List<T> {
+    return new List(EMPTY_NODE as Node<T>);
+  }
+
+  /**
+   * O(N) Create a list from an array of values.
+   *
+   * @param values an array of values the list will contain, in the same order
+   */
+  public static of<T>(...values: T[]): List<T> {
+    let ret = List.empty<T>();
+    for (let i = values.length - 1; i >= 0; --i) {
+      ret = ret.prepend(values[i]);
+    }
+    return ret;
+  }
+
+  /**
+   * Check whether or not a list is empty.
+   *
+   * This is equivalent to checking if a list has no elements.
+   */
+  public isEmpty(): boolean {
+    return !this._node.next;
+  }
+
+  /**
+   * O(1) Add a new value to the front of the list.
+   *
+   * @param value the value to add to the front of the list
+   */
+  public prepend(value: T): List<T> {
+    return new List({value, next: this._node});
+  }
+
+  /**
+   * O(1) Get the value at the front of the list, if it exists.
+   *
+   * This function will return null if `isEmpty()` returns
+   * true, or if the value at the front of the list happens to be
+   * `null`. Because of this, be careful when storing values that might
+   * be `null` inside the list, because this function may return `null`
+   * even if the list isn't empty.
+   */
+  public head(): T | null {
+    return this._node.next ? this._node.value : null;
+  }
+
+  /**
+   * O(1) Return a list containing the values past the head of the list.
+   *
+   * For example: `List.of(1, 2).tail()` gives `List.of(2)`.
+   *
+   * If the list is empty, this method returns an empty list.
+   *
+   * `l.tail().prepend(l.head())` will always be `l` for any non-empty list `l`.
+   */
+  public tail(): List<T> {
+    return this._node.next ? new List(this._node.next) : this;
+  }
+
+  /**
+   * O(amount) Take a certain number of elements from the front of a List.
+   *
+   * If the amount is 0, and empty list is returned. Negative numbers are treated
+   * the same way.
+   *
+   * If the list has less than the amount taken, the entire list is taken.
+   *
+   * @param amount the number of elements to take from the front of the list
+   */
+  public take(amount: number): List<T> {
+    if (amount <= 0 || !this._node.next) return List.empty();
+    const base: Node<T> = {
+      value: this._node.value,
+      next: EMPTY_NODE as Node<T>,
+    };
+    let latest = base;
+    let list = this.tail();
+    for (let i = 1; i < amount; ++i) {
+      // We check specifically against empty in case a value is null inside a list
+      if (list.isEmpty()) break;
+      const next: Node<T> = {
+        value: list.head() as T,
+        next: EMPTY_NODE as Node<T>,
+      };
+      latest.next = next;
+      latest = next;
+      list = list.tail();
+    }
+    return new List(base);
+  }
+
+  /**
+   * O(amount) Return a list with `amount` elements removed from the front.
+   *
+   * If `amount` is greater than or equal to the size of the list,
+   * an empty list is returned.
+   *
+   * If `amount` is less than or equal to 0, the list is returned without modification.
+   *
+   * `l.drop(1)` is always equal to `l.tail()`.
+   *
+   * @param amount the number of elements to drop
+   */
+  public drop(amount: number): List<T> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let list: List<T> = this;
+    for (let i = 0; i < amount; ++i) {
+      if (list.isEmpty()) break;
+      list = list.tail();
+    }
+    return list;
+  }
+
+  /**
+   * O(Nthis) Concatenate this list and another.
+   *
+   * This returns a list containing all the elements in `this` followed
+   * by all the elements in `that`.
+   *
+   * This could be done via `List.of(...this, ...that)` but this would
+   * copy the elements of both lists, whereas this implementation only
+   * needs to copy elements from the first list.
+   *
+   * @param that the list to append to this list
+   */
+  public concat(that: List<T>): List<T> {
+    if (!this._node.next) return that;
+    const base: Node<T> = {
+      value: this._node.value,
+      next: that._node,
+    };
+    let latest = base;
+    let cursor = this._node.next;
+    while (cursor.next) {
+      const next: Node<T> = {
+        value: cursor.value as T,
+        next: that._node,
+      };
+      latest.next = next;
+      latest = next;
+      cursor = cursor.next;
+    }
+    return new List(base);
+  }
+
+  public *[Symbol.iterator](): Iterator<T> {
+    let node = this._node;
+    while (node.next) {
+      yield node.value;
+      node = node.next;
+    }
+  }
+
+  /**
+   * O(N) Test whether or not a list is logically equal to another.
+   *
+   * This returns true if the lists have the same size, and each element in a given
+   * position is `===` to the element in the same position in the other list.
+   *
+   * @param that the list to compare for equality with this one.
+   */
+  public equals(that: List<T>): boolean {
+    let thisNode = this._node;
+    let thatNode = that._node;
+    while (thisNode.next) {
+      if (!thatNode.next) return false;
+      if (thisNode.value !== thatNode.value) return false;
+      thisNode = thisNode.next;
+      thatNode = thatNode.next;
+    }
+    return !thatNode.next;
+  }
+}

--- a/packages/persistent-ts/src/Vector.ts
+++ b/packages/persistent-ts/src/Vector.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 const BIT_WIDTH = 5;
 const BIT_MASK = 0b11111;
 const BRANCH_SIZE = 1 << BIT_WIDTH;
@@ -12,26 +11,26 @@ function isFullBranch(length: number): boolean {
   );
 }
 
-interface VLeaf<T> {
+interface ILeaf<T> {
   leaf: true;
   values: T[];
 }
-interface VBranch<T> {
+interface IBranch<T> {
   leaf: false;
   // We have explicit nulls because when popping we can null old branches on purpose.
-  nodes: (VNode<T> | null)[];
+  nodes: (INode<T> | null)[];
 }
-type VNode<T> = VLeaf<T> | VBranch<T>;
+type INode<T> = ILeaf<T> | IBranch<T>;
 
-function emptyBranch<T>(): VBranch<T> {
+function emptyBranch<T>(): IBranch<T> {
   return {leaf: false, nodes: Array(BRANCH_SIZE).fill(null)};
 }
 
-function emptyLeaf<T>(): VLeaf<T> {
+function emptyLeaf<T>(): ILeaf<T> {
   return {leaf: true, values: Array(BRANCH_SIZE).fill(null)};
 }
 
-function copyVNode<T>(vnode: VNode<T>): VNode<T> {
+function copyNode<T>(vnode: INode<T>): INode<T> {
   if (vnode.leaf) {
     return {leaf: true, values: [...vnode.values]};
   } else {
@@ -39,15 +38,18 @@ function copyVNode<T>(vnode: VNode<T>): VNode<T> {
   }
 }
 
-function copyVBranch<T>(vnode: VBranch<T>): VBranch<T> {
+function copyBranch<T>(vnode: IBranch<T>): IBranch<T> {
   return {leaf: false, nodes: [...vnode.nodes]};
 }
 
+/**
+ * The main class.
+ */
 export class Vector<T> implements Iterable<T> {
   private constructor(
-    private readonly _root: VBranch<T>,
-    private readonly _levelShift: number,
-    private readonly _tail: T[],
+    private readonly root: IBranch<T>,
+    private readonly levelShift: number,
+    private readonly tail: T[],
     public readonly length: number
   ) {}
 
@@ -79,13 +81,13 @@ export class Vector<T> implements Iterable<T> {
   public get(index: number): T | null {
     if (index < 0 || index >= this.length) return null;
     if (index >= this.getTailOffset()) {
-      return this._tail[index % BRANCH_SIZE];
+      return this.tail[index % BRANCH_SIZE];
     }
-    let shift = this._levelShift;
-    let cursor: VNode<T> = this._root;
+    let shift = this.levelShift;
+    let cursor: INode<T> = this.root;
     while (!cursor.leaf) {
       // This cast is fine because we checked the length prior
-      cursor = cursor.nodes[(index >>> shift) & BIT_MASK] as VNode<T>;
+      cursor = cursor.nodes[(index >>> shift) & BIT_MASK] as INode<T>;
       shift -= BIT_WIDTH;
     }
     return cursor.values[index & BIT_MASK];
@@ -102,25 +104,25 @@ export class Vector<T> implements Iterable<T> {
   public set(index: number, value: T): Vector<T> {
     if (index < 0 || index >= this.length) return this;
     if (index >= this.getTailOffset()) {
-      const newTail = [...this._tail];
+      const newTail = [...this.tail];
       newTail[index & BIT_MASK] = value;
       // root is not changed
-      return new Vector(this._root, this._levelShift, newTail, this.length);
+      return new Vector(this.root, this.levelShift, newTail, this.length);
     }
-    const base = copyVBranch(this._root);
-    let shift = this._levelShift;
-    let cursor: VNode<T> = base;
+    const base = copyBranch(this.root);
+    let shift = this.levelShift;
+    let cursor: INode<T> = base;
     while (!cursor.leaf) {
       const subIndex = (index >>> shift) & BIT_MASK;
       // This cast is fine because we checked the length prior
-      const next: VNode<T> = copyVNode(cursor.nodes[subIndex] as VNode<T>);
+      const next: INode<T> = copyNode(cursor.nodes[subIndex] as INode<T>);
       cursor.nodes[subIndex] = next;
       cursor = next;
       shift -= BIT_WIDTH;
     }
     cursor.values[index & BIT_MASK] = value;
     // tail is not changed
-    return new Vector(base, this._levelShift, this._tail, this.length);
+    return new Vector(base, this.levelShift, this.tail, this.length);
   }
 
   /**
@@ -133,39 +135,39 @@ export class Vector<T> implements Iterable<T> {
   public append(value: T): Vector<T> {
     if (this.length - this.getTailOffset() < BRANCH_SIZE) {
       // has space in tail
-      const newTail = [...this._tail];
+      const newTail = [...this.tail];
       newTail[this.length % BRANCH_SIZE] = value;
       // root is not changed
-      return new Vector(this._root, this._levelShift, newTail, this.length + 1);
+      return new Vector(this.root, this.levelShift, newTail, this.length + 1);
     }
-    let base: VBranch<T>;
-    let levelShift = this._levelShift;
+    let base: IBranch<T>;
+    let levelShift = this.levelShift;
     if (isFullBranch(this.length - BRANCH_SIZE)) {
       base = emptyBranch();
-      base.nodes[0] = this._root;
+      base.nodes[0] = this.root;
       levelShift += BIT_WIDTH;
     } else {
-      base = copyVBranch(this._root);
+      base = copyBranch(this.root);
     }
     // getTailOffset is actually the 1st item in tail
     // we now move it to the tree
     const index = this.getTailOffset();
     let shift = levelShift;
-    let cursor: VNode<T> = base;
+    let cursor: INode<T> = base;
     while (!cursor.leaf) {
       const subIndex = (index >>> shift) & BIT_MASK;
       shift -= BIT_WIDTH;
-      let next: VNode<T> | null = cursor.nodes[subIndex];
+      let next: INode<T> | null = cursor.nodes[subIndex];
       if (!next) {
         next = shift === 0 ? emptyLeaf() : emptyBranch();
       } else {
-        next = copyVNode(next);
+        next = copyNode(next);
       }
       cursor.nodes[subIndex] = next;
       cursor = next;
     }
     // it's safe to update cursor bc "next" is a new instance anyway
-    cursor.values = [...this._tail];
+    cursor.values = [...this.tail];
     return new Vector(base, levelShift, [value, ...Array(BRANCH_SIZE - 1).fill(null)], this.length + 1);
   }
 
@@ -181,8 +183,8 @@ export class Vector<T> implements Iterable<T> {
     if (tailLength >= 2) {
       // ignore the last item
       const newTailLength = (this.length - 1) % BRANCH_SIZE;
-      const newTail = [...this._tail.slice(0, newTailLength), ...Array(BRANCH_SIZE - newTailLength).fill(null)];
-      return new Vector(this._root, this._levelShift, newTail, this.length - 1);
+      const newTail = [...this.tail.slice(0, newTailLength), ...Array(BRANCH_SIZE - newTailLength).fill(null)];
+      return new Vector(this.root, this.levelShift, newTail, this.length - 1);
     }
     // tail has exactly 1 item, promote the right most leaf node as tail
     const lastItemIndexInTree = this.getTailOffset() - 1;
@@ -190,16 +192,16 @@ export class Vector<T> implements Iterable<T> {
     if (lastItemIndexInTree < 0) {
       return Vector.empty<T>();
     }
-    const base = copyVBranch(this._root);
-    let shift = this._levelShift;
-    let cursor: VNode<T> = base;
+    const base = copyBranch(this.root);
+    let shift = this.levelShift;
+    let cursor: INode<T> = base;
     // we always have a parent bc we create an empty branch initially
-    let parent: VNode<T> | null = null;
+    let parent: INode<T> | null = null;
     let subIndex: number | null = null;
     while (!cursor.leaf) {
       subIndex = (lastItemIndexInTree >>> shift) & BIT_MASK;
       // This cast is fine because we checked the length prior
-      const next: VNode<T> = copyVNode(cursor.nodes[subIndex] as VNode<T>);
+      const next: INode<T> = copyNode(cursor.nodes[subIndex] as INode<T>);
       cursor.nodes[subIndex] = next;
       parent = cursor;
       cursor = next;
@@ -207,13 +209,13 @@ export class Vector<T> implements Iterable<T> {
     }
     const newTail = [...cursor.values];
     parent!.nodes[subIndex!] = emptyLeaf<T>();
-    let newLevelShift = this._levelShift;
-    let newRoot: VBranch<T> = base;
+    let newLevelShift = this.levelShift;
+    let newRoot: IBranch<T> = base;
     if (isFullBranch(this.length - 1 - BRANCH_SIZE)) {
-      newRoot = base.nodes[0] as VBranch<T>;
+      newRoot = base.nodes[0] as IBranch<T>;
       newLevelShift -= BIT_WIDTH;
     }
-    return new Vector(copyVBranch(newRoot), newLevelShift, newTail, this.length - 1);
+    return new Vector(copyBranch(newRoot), newLevelShift, newTail, this.length - 1);
   }
 
   /**
@@ -221,7 +223,7 @@ export class Vector<T> implements Iterable<T> {
    */
   public *[Symbol.iterator](): Generator<T> {
     let toYield = this.getTailOffset();
-    function* iterNode(node: VNode<T>): Generator<T> {
+    function* iterNode(node: INode<T>): Generator<T> {
       if (node.leaf) {
         for (const v of node.values) {
           if (toYield <= 0) break;
@@ -232,13 +234,13 @@ export class Vector<T> implements Iterable<T> {
         for (const next of node.nodes) {
           // This check also assures us that the link won't be null
           if (toYield <= 0) break;
-          yield* iterNode(next as VNode<T>);
+          yield* iterNode(next as INode<T>);
         }
       }
     }
-    yield* iterNode(this._root);
+    yield* iterNode(this.root);
     const tailLength = this.getTailLength();
-    for (let i = 0; i < tailLength; i++) yield this._tail[i];
+    for (let i = 0; i < tailLength; i++) yield this.tail[i];
   }
 
   /**
@@ -248,7 +250,7 @@ export class Vector<T> implements Iterable<T> {
   public readOnlyForEach(func: (t: T, i: number) => void): void {
     let index = 0;
     const tailOffset = this.getTailOffset();
-    const iterNode = (node: VNode<T>): void => {
+    const iterNode = (node: INode<T>): void => {
       if (node.leaf) {
         for (const v of node.values) {
           if (index < tailOffset) {
@@ -261,14 +263,14 @@ export class Vector<T> implements Iterable<T> {
       } else {
         for (const next of node.nodes) {
           if (index >= tailOffset) break;
-          iterNode(next as VNode<T>);
+          iterNode(next as INode<T>);
         }
       }
     };
-    iterNode(this._root);
+    iterNode(this.root);
     const tailLength = this.getTailLength();
     for (let i = 0; i < tailLength; i++) {
-      const value = this._tail[i];
+      const value = this.tail[i];
       func(value, index);
       index++;
     }
@@ -281,7 +283,7 @@ export class Vector<T> implements Iterable<T> {
     const result: T2[] = [];
     let index = 0;
     const tailOffset = this.getTailOffset();
-    const iterNode = (node: VNode<T>): void => {
+    const iterNode = (node: INode<T>): void => {
       if (node.leaf) {
         for (const v of node.values) {
           if (index < tailOffset) {
@@ -294,14 +296,14 @@ export class Vector<T> implements Iterable<T> {
       } else {
         for (const next of node.nodes) {
           if (index >= tailOffset) break;
-          iterNode(next as VNode<T>);
+          iterNode(next as INode<T>);
         }
       }
     };
-    iterNode(this._root);
+    iterNode(this.root);
     const tailLength = this.getTailLength();
     for (let i = 0; i < tailLength; i++) {
-      const value = this._tail[i];
+      const value = this.tail[i];
       result.push(func(value, index));
       index++;
     }
@@ -319,7 +321,7 @@ export class Vector<T> implements Iterable<T> {
    * Clone to a new vector.
    */
   public clone(): Vector<T> {
-    return new Vector(this._root, this._levelShift, this._tail, this.length);
+    return new Vector(this.root, this.levelShift, this.tail, this.length);
   }
 
   private getTailLength(): number {

--- a/packages/persistent-ts/src/index.ts
+++ b/packages/persistent-ts/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./List";
+export * from "./Vector";

--- a/packages/persistent-ts/test/perf/Vector.test.ts
+++ b/packages/persistent-ts/test/perf/Vector.test.ts
@@ -1,0 +1,47 @@
+import {expect} from "chai";
+import {Vector} from "../../src/Vector";
+
+it("should be able to handle 10M elements", function () {
+  this.timeout(0);
+  let start = Date.now();
+  let acc = Vector.empty<number>();
+  const times = 10000000;
+  for (let i = 0; i < times; ++i) {
+    acc = acc.append(i);
+  }
+  expect(acc.length).to.be.equal(times);
+  console.log(`Finish append ${times} items in`, Date.now() - start);
+  start = Date.now();
+  let index = 0;
+  for (const _ of acc) {
+    // expect(item).to.be.equal(index);
+    index++;
+  }
+  expect(index).to.be.equal(times);
+  console.log(`Finish regular iterator ${times} in`, Date.now() - start);
+  // start = Date.now();
+  // for (let i = 0; i < times; ++i) {
+  //   expect(acc.get(i)).to.be.equal(i);
+  // }
+  // console.log(`Finish regular for of ${times} items in`, Date.now() - start);
+  start = Date.now();
+  let count = 0;
+  acc.readOnlyForEach(() => {
+    count++;
+  });
+  expect(count).to.be.equal(times);
+  console.log(`Finish readOnlyForEach of ${times} items in`, Date.now() - start);
+  start = Date.now();
+  const tsArray = acc.toTS();
+  expect(tsArray.length).to.be.equal(times);
+  console.log(`Finish toTS of ${times} items in`, Date.now() - start);
+  start = Date.now();
+  const newArr = acc.readOnlyMap<number>((v) => v * 2);
+  console.log(`Finish readOnlyMap of ${times} items in`, Date.now() - start);
+  expect(newArr[1]).to.be.equal(2);
+  expect(newArr.length).to.be.equal(times);
+  start = Date.now();
+  const newArr2 = tsArray.map((v) => v * 2);
+  console.log(`Finish regular map of regular array of ${times} items in`, Date.now() - start);
+  expect(newArr).to.be.deep.equal(newArr2);
+});

--- a/packages/persistent-ts/test/unit/List.test.ts
+++ b/packages/persistent-ts/test/unit/List.test.ts
@@ -1,0 +1,90 @@
+import fc from "fast-check";
+import {expect} from "chai";
+import {List} from "../../src/List";
+
+it("List.empty isEmpty", () => {
+  const empty = List.empty();
+  expect(empty.isEmpty()).to.be.true;
+});
+
+it("List.singleton is not Empty", () => {
+  const singleton = List.of(1);
+  expect(singleton.isEmpty()).to.be.false;
+});
+
+it("List.equals works", () => {
+  const empty = List.empty<number>();
+  const single1 = List.of(1);
+  const single2 = List.of(2);
+  expect(single1.equals(empty)).to.be.false;
+  expect(single1.equals(single2)).to.be.false;
+  expect(empty.equals(empty)).to.be.true;
+  expect(single1.equals(single1)).to.be.true;
+});
+
+it("List.prepend works", () => {
+  const single1 = List.of(1);
+  const prepend1 = List.empty().prepend(1);
+  expect(prepend1.equals(single1)).to.be.true;
+  expect(single1.prepend(1).equals(single1)).to.be.false;
+});
+
+it("List is iterable", () => {
+  const array = [1, 2, 3];
+  const list = List.of(...array);
+  expect(Array.from(list)).to.be.deep.equal(array);
+  expect(Array.from(List.empty())).to.be.deep.equal([]);
+  expect(List.of(...list).equals(list)).to.be.true;
+});
+
+it("List.head works", () => {
+  expect(List.empty().head()).to.be.null;
+  expect(List.of(1).head()).to.be.equal(1);
+});
+
+it("List.tail works", () => {
+  const empty = List.empty();
+  expect(empty.tail().equals(empty)).to.be.true;
+});
+
+it("List.take works", () => {
+  const empty = List.empty<number>();
+  const simple = List.of(1, 2, 3);
+  expect(simple.take(0).equals(empty)).to.be.true;
+  expect(simple.take(0).equals(simple)).to.be.false;
+  expect(simple.take(3).equals(simple)).to.be.true;
+  expect(simple.take(1).equals(List.of(1))).to.be.true;
+});
+
+it("List.drop works", () => {
+  const empty = List.empty<number>();
+  expect(empty.drop(0).equals(empty)).to.be.true;
+  expect(empty.drop(1).equals(empty)).to.be.true;
+  const simple = List.of(1, 2, 3);
+  expect(simple.drop(3).equals(empty)).to.be.true;
+  expect(simple.drop(1).equals(List.of(2, 3))).to.be.true;
+});
+
+it("List.prepend properties", () => {
+  fc.assert(
+    fc.property(fc.array(fc.integer()), (data) => {
+      const list = List.of(...data);
+      const value = 1;
+      const extra = list.prepend(value);
+      expect(extra.tail().equals(list)).to.be.true;
+      expect(extra.head()).to.be.equal(value);
+    })
+  );
+});
+
+it("List can be reassembled from take and drop", () => {
+  const gen = fc.tuple(fc.array(fc.integer()), fc.nat());
+  fc.assert(
+    fc.property(gen, ([items, amount]) => {
+      const list = List.of(items);
+      const left = list.take(amount);
+      const right = list.drop(amount);
+      expect(left.concat(right).equals(list)).to.be.true;
+    })
+  );
+});

--- a/packages/persistent-ts/test/unit/Vector.test.ts
+++ b/packages/persistent-ts/test/unit/Vector.test.ts
@@ -1,0 +1,141 @@
+import fc from "fast-check";
+import {expect} from "chai";
+import {Vector} from "../../src/Vector";
+
+it("Vector.empty has a length of 0", () => {
+  const empty = Vector.empty<void>();
+  expect(empty.length).to.be.equal(0);
+});
+
+it("Vector.append increments the length", () => {
+  const empty = Vector.empty<number>();
+  expect(empty.append(1).length).to.be.equal(1);
+  expect(empty.append(1).append(2).length).to.be.equal(2);
+});
+
+it("Vector.append works with many elements", () => {
+  let acc = Vector.empty<number>();
+  const times = 1025;
+  for (let i = 0; i < times; ++i) {
+    acc = acc.append(i);
+  }
+  expect(acc.length).to.be.equal(times);
+  for (let i = 0; i < times; ++i) {
+    expect(acc.get(i)).to.be.equal(i);
+  }
+  let i = 0;
+  for (const item of acc) {
+    expect(item).to.be.equal(i);
+    i++;
+  }
+  expect(i).to.be.equal(times);
+});
+
+it("Vector iterator should work fine", () => {
+  const times = 1025;
+  const originalArr = Array.from({length: times}, (_, i) => 2 * i);
+  const acc = Vector.of(...originalArr);
+  expect(acc.length).to.be.equal(times);
+  let i = 0;
+  for (const item of acc) {
+    expect(item).to.be.equal(2 * i);
+    i++;
+  }
+  expect(i).to.be.equal(times);
+  const newArr = [...acc];
+  expect(newArr).to.be.deep.equal(originalArr);
+});
+
+it("Vector readOnlyForEach should work fine", () => {
+  let acc = Vector.empty<number>();
+  const times = 1025;
+  for (let i = 0; i < times; ++i) {
+    acc = acc.append(2 * i);
+  }
+  expect(acc.length).to.be.equal(times);
+  let count = 0;
+  acc.readOnlyForEach((v, i) => {
+    expect(v).to.be.equal(2 * i);
+    count++;
+  });
+  expect(count).to.be.equal(times);
+});
+
+it("Vector readOnlyMap should work fine", () => {
+  const times = 1025;
+  const originalArr = Array.from({length: times}, (_, i) => i);
+  const newArr = originalArr.map((v) => v * 2);
+  const acc = Vector.of(...originalArr);
+  expect(acc.length).to.be.equal(times);
+  const newArr2 = acc.readOnlyMap<number>((v) => v * 2);
+  expect(newArr2).to.be.deep.equal(newArr);
+});
+
+it("Vector toTS should convert to regular javascript array", () => {
+  const times = 1025;
+  const originalArr = Array.from({length: times}, (_, i) => i);
+  const acc = Vector.of(...originalArr);
+  expect(acc.toTS()).to.be.deep.equal(originalArr);
+});
+
+it("Vector.get works", () => {
+  const element = 1;
+  const empty = Vector.empty<number>();
+  const single = empty.append(element);
+  expect(single.get(-1)).to.be.null;
+  expect(single.get(1)).to.be.null;
+  expect(empty.get(0)).to.be.null;
+  expect(single.get(0)).to.be.equal(element);
+});
+
+it("Vector.set works", () => {
+  const a = 0;
+  const b = 1;
+  const empty = Vector.empty<number>();
+  const single = empty.append(a);
+  expect(single.set(0, b).get(0)).to.be.equal(b);
+});
+
+it("Vector.set should not effect original vector", () => {
+  const times = 1025;
+  const originalArr = Array.from({length: times}, (_, i) => 2 * i);
+  const originalVector = Vector.of(...originalArr);
+  let newVector: Vector<number> = originalVector;
+  for (let i = 0; i < times; i++) {
+    newVector = newVector.set(i, i * 4);
+  }
+  for (let i = 0; i < times; i++) {
+    expect(newVector!.get(i)).to.be.equal(originalVector.get(i)! * 2);
+  }
+  expect([...newVector]).to.be.deep.equal(originalArr.map((item) => item * 2));
+  expect([...newVector].length).to.be.equal(1025);
+  expect(newVector.length).to.be.equal(1025);
+});
+
+it("Vector.pop works with many elements", () => {
+  let acc = Vector.empty<number>();
+  expect(acc.pop()).to.be.equal(acc);
+  const times = 1025;
+  for (let i = 0; i < 2 * times; ++i) {
+    acc = acc.append(i);
+  }
+  for (let i = 0; i < times; ++i) {
+    acc = acc.pop();
+  }
+  expect(acc.length).to.be.equal(times);
+  for (let i = 0; i < times; ++i) {
+    const g = acc.get(i);
+    expect(g).to.be.equal(i);
+  }
+});
+
+it("A Vector created from an array will spread to the same array", () => {
+  fc.assert(
+    fc.property(fc.array(fc.integer()), (data) => {
+      let acc = Vector.empty<number>();
+      for (const d of data) acc = acc.append(d);
+      const arr = [...acc];
+      expect(arr).to.be.deep.equal(data);
+    })
+  );
+});

--- a/packages/persistent-ts/tsconfig.build.json
+++ b/packages/persistent-ts/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig",
+  "include": ["src"],
+  "compilerOptions": {
+    "typeRoots": ["../../node_modules/@types"],
+    "outDir": "lib",
+    "rootDir": "./src"
+  }
+}

--- a/packages/persistent-ts/tsconfig.json
+++ b/packages/persistent-ts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig",
+  "include": ["src", "test"],
+  "compilerOptions": {
+    "typeRoots": ["../../node_modules/@types"],
+    "outDir": "lib",
+    /* Redirect output structure to the directory. */
+    "rootDirs": ["./src", "./test"]
+  }
+}

--- a/packages/spec-test-runner/test/spec/epoch_processing/finalUpdates/final_updates_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/epoch_processing/finalUpdates/final_updates_fast.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/lodestar-config/mainnet";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {processFinalUpdates} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/epoch";
 import {prepareEpochProcessState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util/interface";
 import {BeaconState} from "@chainsafe/lodestar-types";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util/lib/single";
 import {IStateTestCase} from "../../../utils/specTestTypes/stateTestCase";
@@ -17,8 +18,9 @@ describeDirectorySpecTest<IStateTestCase, BeaconState>(
     const state = testcase.pre;
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
-    const process = prepareEpochProcessState(epochCtx, state);
-    processFinalUpdates(epochCtx, process, state);
+    const wrappedState = createCachedValidatorsBeaconState(state);
+    const process = prepareEpochProcessState(epochCtx, wrappedState);
+    processFinalUpdates(epochCtx, process, wrappedState);
     return state;
   },
   {

--- a/packages/spec-test-runner/test/spec/epoch_processing/justification/justification_and_finalization_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/epoch_processing/justification/justification_and_finalization_fast.test.ts
@@ -5,6 +5,8 @@ import {config} from "@chainsafe/lodestar-config/mainnet";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {processJustificationAndFinalization} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/epoch";
 import {prepareEpochProcessState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util/interface";
+
 import {BeaconState} from "@chainsafe/lodestar-types";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util/lib/single";
 import {IStateTestCase} from "../../../utils/specTestTypes/stateTestCase";
@@ -17,8 +19,9 @@ describeDirectorySpecTest<IStateTestCase, BeaconState>(
     const state = testcase.pre;
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
-    const process = prepareEpochProcessState(epochCtx, state);
-    processJustificationAndFinalization(epochCtx, process, state);
+    const wrappedState = createCachedValidatorsBeaconState(state);
+    const process = prepareEpochProcessState(epochCtx, wrappedState);
+    processJustificationAndFinalization(epochCtx, process, wrappedState);
     return state;
   },
   {

--- a/packages/spec-test-runner/test/spec/epoch_processing/registryUpdates/registry_updates_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/epoch_processing/registryUpdates/registry_updates_fast.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/lodestar-config/mainnet";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {processRegistryUpdates} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/epoch";
 import {prepareEpochProcessState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util/interface";
 import {BeaconState} from "@chainsafe/lodestar-types";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util/lib/single";
 import {IStateTestCase} from "../../../utils/specTestTypes/stateTestCase";
@@ -17,8 +18,9 @@ describeDirectorySpecTest<IStateTestCase, BeaconState>(
     const state = testcase.pre;
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
-    const process = prepareEpochProcessState(epochCtx, state);
-    processRegistryUpdates(epochCtx, process, state);
+    const wrappedState = createCachedValidatorsBeaconState(state);
+    const process = prepareEpochProcessState(epochCtx, wrappedState);
+    processRegistryUpdates(epochCtx, process, wrappedState);
     return state;
   },
   {

--- a/packages/spec-test-runner/test/spec/epoch_processing/rewardsAndPenalties/rewards_and_penalties_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/epoch_processing/rewardsAndPenalties/rewards_and_penalties_fast.test.ts
@@ -5,6 +5,7 @@ import {config} from "@chainsafe/lodestar-config/minimal";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {processRewardsAndPenalties} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/epoch";
 import {prepareEpochProcessState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util/interface";
 import {BeaconState} from "@chainsafe/lodestar-types";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util/lib/single";
 import {IStateTestCase} from "../../../utils/specTestTypes/stateTestCase";
@@ -17,8 +18,9 @@ describeDirectorySpecTest<IStateTestCase, BeaconState>(
     const state = testcase.pre;
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
-    const process = prepareEpochProcessState(epochCtx, state);
-    processRewardsAndPenalties(epochCtx, process, state);
+    const wrappedState = createCachedValidatorsBeaconState(state);
+    const process = prepareEpochProcessState(epochCtx, wrappedState);
+    processRewardsAndPenalties(epochCtx, process, wrappedState);
     return state;
   },
   {

--- a/packages/spec-test-runner/test/spec/epoch_processing/slashings/slashings_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/epoch_processing/slashings/slashings_fast.test.ts
@@ -6,6 +6,7 @@ import {BeaconState} from "@chainsafe/lodestar-types";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {processSlashings} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/epoch";
 import {prepareEpochProcessState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util/interface";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util/lib/single";
 import {IStateTestCase} from "../../../utils/specTestTypes/stateTestCase";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
@@ -17,8 +18,9 @@ describeDirectorySpecTest<IStateTestCase, BeaconState>(
     const state = testcase.pre;
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
-    const process = prepareEpochProcessState(epochCtx, state);
-    processSlashings(epochCtx, process, state);
+    const wrappedState = createCachedValidatorsBeaconState(state);
+    const process = prepareEpochProcessState(epochCtx, wrappedState);
+    processSlashings(epochCtx, process, wrappedState);
     return state;
   },
   {

--- a/packages/spec-test-runner/test/spec/operations/attesterSlashing/attester_slashing_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/operations/attesterSlashing/attester_slashing_fast.test.ts
@@ -4,6 +4,7 @@ import {BeaconState} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {processAttesterSlashing} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/block";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util/interface";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util/lib/single";
 import {IProcessAttesterSlashingTestCase} from "./type";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
@@ -16,7 +17,8 @@ describeDirectorySpecTest<IProcessAttesterSlashingTestCase, BeaconState>(
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
     const verify = !!testcase.meta && !!testcase.meta.blsSetting && testcase.meta.blsSetting === BigInt(1);
-    processAttesterSlashing(epochCtx, state, testcase.attester_slashing, verify);
+    const wrappedState = createCachedValidatorsBeaconState(state);
+    processAttesterSlashing(epochCtx, wrappedState, testcase.attester_slashing, verify);
     return state;
   },
   {

--- a/packages/spec-test-runner/test/spec/operations/deposit/deposit_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/operations/deposit/deposit_fast.test.ts
@@ -4,6 +4,7 @@ import {BeaconState} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {processDeposit} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/block";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util/interface";
 import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util/lib/single";
 import {IProcessDepositTestCase} from "./type";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
@@ -15,7 +16,8 @@ describeDirectorySpecTest<IProcessDepositTestCase, BeaconState>(
     const state = testcase.pre;
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
-    processDeposit(epochCtx, state, testcase.deposit);
+    const wrappedState = createCachedValidatorsBeaconState(state);
+    processDeposit(epochCtx, wrappedState, testcase.deposit);
     return state;
   },
   {

--- a/packages/spec-test-runner/test/spec/operations/proposerSlashing/proposer_slashing_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/operations/proposerSlashing/proposer_slashing_fast.test.ts
@@ -4,6 +4,7 @@ import {BeaconState} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {processProposerSlashing} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/block";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util/interface";
 import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util/lib/single";
 import {IProcessProposerSlashingTestCase} from "./type";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
@@ -15,7 +16,8 @@ describeDirectorySpecTest<IProcessProposerSlashingTestCase, BeaconState>(
     const state = testcase.pre;
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
-    processProposerSlashing(epochCtx, state, testcase.proposer_slashing);
+    const wrappedState = createCachedValidatorsBeaconState(state);
+    processProposerSlashing(epochCtx, wrappedState, testcase.proposer_slashing);
     return state;
   },
   {

--- a/packages/spec-test-runner/test/spec/operations/voluntaryExit/voluntary_exit_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/operations/voluntaryExit/voluntary_exit_fast.test.ts
@@ -4,6 +4,7 @@ import {BeaconState} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {processVoluntaryExit} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/block";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util/interface";
 import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util/lib/single";
 import {IProcessVoluntaryExitTestCase} from "./type";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
@@ -15,7 +16,8 @@ describeDirectorySpecTest<IProcessVoluntaryExitTestCase, BeaconState>(
     const state = testcase.pre;
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
-    processVoluntaryExit(epochCtx, state, testcase.voluntary_exit);
+    const wrappedState = createCachedValidatorsBeaconState(state);
+    processVoluntaryExit(epochCtx, wrappedState, testcase.voluntary_exit);
     return state;
   },
   {

--- a/packages/spec-test-runner/test/spec/rewards/rewards_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/rewards/rewards_fast.test.ts
@@ -1,5 +1,8 @@
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
-import {createCachedValidatorsBeaconState, prepareEpochProcessState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
+import {
+  createCachedValidatorsBeaconState,
+  prepareEpochProcessState,
+} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 import {getAttestationDeltas} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/epoch";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util";

--- a/packages/spec-test-runner/test/spec/rewards/rewards_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/rewards/rewards_fast.test.ts
@@ -1,5 +1,5 @@
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
-import {prepareEpochProcessState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
+import {createCachedValidatorsBeaconState, prepareEpochProcessState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 import {getAttestationDeltas} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/epoch";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util";
@@ -16,7 +16,8 @@ for (const testSuite of ["basic", "leak", "random"]) {
       const state = testcase.pre;
       const epochCtx = new EpochContext(config);
       epochCtx.loadState(state);
-      const process = prepareEpochProcessState(epochCtx, state);
+      const wrappedState = createCachedValidatorsBeaconState(state);
+      const process = prepareEpochProcessState(epochCtx, wrappedState);
       const [rewards, penalties] = getAttestationDeltas(epochCtx, process, state);
       return {
         rewards,

--- a/packages/spec-test-runner/test/spec/sanity/blocks/sanity_blocks_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/sanity/blocks/sanity_blocks_fast.test.ts
@@ -1,22 +1,24 @@
 import {join} from "path";
 import {expect} from "chai";
 import {BeaconState, SignedBeaconBlock} from "@chainsafe/lodestar-types";
-import {EpochContext, fastStateTransition, IStateContext} from "@chainsafe/lodestar-beacon-state-transition";
+import {EpochContext, fastStateTransition} from "@chainsafe/lodestar-beacon-state-transition";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util/lib/single";
 import {IBlockSanityTestCase} from "./type";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
 describeDirectorySpecTest<IBlockSanityTestCase, BeaconState>(
   "block sanity mainnet",
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/sanity/blocks/pyspec_tests"),
   (testcase) => {
     const state = config.types.BeaconState.tree.createValue(testcase.pre);
+    const wrappedState = createCachedValidatorsBeaconState(state);
     const epochCtx = new EpochContext(config);
-    epochCtx.loadState(state);
+    epochCtx.loadState(wrappedState);
+    let stateContext = {epochCtx, state: wrappedState};
     const verify = !!testcase.meta && !!testcase.meta.blsSetting && testcase.meta.blsSetting === BigInt(1);
-    let stateContext: IStateContext = {epochCtx, state};
     for (let i = 0; i < Number(testcase.meta.blocksCount); i++) {
       stateContext = fastStateTransition(stateContext, testcase[`blocks_${i}`] as SignedBeaconBlock, {
         verifyStateRoot: verify,
@@ -24,7 +26,7 @@ describeDirectorySpecTest<IBlockSanityTestCase, BeaconState>(
         verifySignatures: verify,
       });
     }
-    return stateContext.state;
+    return stateContext.state.getOriginalState();
   },
   {
     inputTypes: {

--- a/packages/spec-test-runner/test/spec/sanity/slots/sanity_slots_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/sanity/slots/sanity_slots_fast.test.ts
@@ -4,6 +4,7 @@ import {config} from "@chainsafe/lodestar-config/mainnet";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {processSlots} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/slot";
 import {BeaconState} from "@chainsafe/lodestar-types";
+import {createCachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util/interface";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util/lib/single";
 import {IProcessSlotsTestCase} from "./type";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
@@ -15,7 +16,8 @@ describeDirectorySpecTest<IProcessSlotsTestCase, BeaconState>(
     const state = config.types.BeaconState.tree.createValue(testcase.pre);
     const epochCtx = new EpochContext(config);
     epochCtx.loadState(state);
-    processSlots(epochCtx, state, state.slot + Number(testcase.slots));
+    const wrappedState = createCachedValidatorsBeaconState(state);
+    processSlots(epochCtx, wrappedState, state.slot + Number(testcase.slots));
     return state;
   },
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12853,3 +12853,4 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -6868,11 +6868,6 @@ immediate@^3.2.3, immediate@~3.2.3:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
   integrity sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=
 
-immutable@4.0.0-rc.12:
-  version "4.0.0-rc.12"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
-  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
-
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
@@ -12858,4 +12853,3 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -6868,6 +6868,11 @@ immediate@^3.2.3, immediate@~3.2.3:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
   integrity sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=
 
+immutable@4.0.0-rc.12:
+  version "4.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
+  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
+
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5891,6 +5891,14 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
+fast-check@^1.15.1:
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-1.26.0.tgz#3a85998a9c30ed7f58976276e06046645e0de18a"
+  integrity sha512-B1AjSfe0bmi6FdFIzmrrGSjrsF6e2MCmZiM6zJaRbBMP+gIvdNakle5FIMKi0xbS9KlN9BZho1R7oB/qoNIQuA==
+  dependencies:
+    pure-rand "^2.0.0"
+    tslib "^2.0.0"
+
 fast-crc32c@^1.0.1:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/fast-crc32c/-/fast-crc32c-1.0.7.tgz#a7ab81b8665a6faee42ffe36ac930b15afc17396"
@@ -10308,6 +10316,11 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+pure-rand@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-2.0.0.tgz#3324633545207907fe964c2f0ebf05d8e9a7f129"
+  integrity sha512-mk98aayyd00xbfHgE3uEmAUGzz3jCdm8Mkf5DUXUhc7egmOaGG2D7qhVlynGenNe9VaNJZvzO9hkc8myuTkDgw==
+
 q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
@@ -12057,6 +12070,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
+tslib@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
+
 tsutils@^3.17.1:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
@@ -12853,4 +12871,3 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
-


### PR DESCRIPTION
resolves #1789, resolves #1878, and resolves #1761

+ Create a CachedValidatorsBeaconState that cache validators using persistent vector (see https://github.com/tuyennhv/persistent-ts/pull/1) and use it everywhere
+ Persistent vector is an immutable data structure, similar to the persistent-merkle-tree we used: it shares a lot of data across beacon state since validators are rarely changed and it has cheap `clone()`
+ Persistent vector loop speed is comparable to regular javascript array loop while it's slow if we loop through `TreeBacked<BeaconState>.validators`
+ When we want to mutate validators inside state, use `setValidator()` and `addValidator()` instead of accessing `validators` directly
+ Average epoch transition time in my local environment for Pyrmont sync was reduced from `3.5s-4.2s` to `1.2s-1.6s`. This should speed up the validator exit process too.
## Testing
+ Pyrmont: synced from slot 0 to head and stay synced for more than 4 hours (tested 2 times)
+ Don't see any memory differences during Pyrmont sync
+ Performance tests

|test|master|this branch|
|----|------|-----------|
|prepareEpochProcessState|1500|100|
|process block of 16 validator exits|6000|200|
|transition - 32 slots|2800|1100|
|transition - 64 slots|5300|2200|
|transition - 128 slots|11000|4300|

## TODO
+ Persistent vector was started from https://github.com/cronokirby/persistent-ts, we should consider having a separate repository for it or just have a separate package like in this PR