### PR TITLE
Print nested errors stack traces prettier

### DIFF
--- a/packages/lodestar-utils/test/unit/logger/format.test.ts
+++ b/packages/lodestar-utils/test/unit/logger/format.test.ts
@@ -1,0 +1,31 @@
+import {expect} from "chai";
+import {printStackTraceLast, extractStackTraceFromJson} from "../../../src/logger/format";
+import {toJson} from "../../../src/json";
+import {LodestarError} from "../../../src/errors";
+
+describe("logger / format / printStackTraceLast", () => {
+  it("Should print nested error stack traces together", () => {
+    type TestNestedErrorType = {
+      code: "TEST_NESTED_ERROR";
+      nestedError: Error;
+    };
+
+    class TestNestedError extends LodestarError<TestNestedErrorType> {}
+
+    const nestedError = new Error("TEST_ERROR");
+    const testNestedError = new TestNestedError({code: "TEST_NESTED_ERROR", nestedError});
+
+    const expectedStacks = [nestedError.stack, testNestedError.stack];
+
+    const nestedErrorAsJson = toJson(testNestedError);
+    const stacks = extractStackTraceFromJson(nestedErrorAsJson);
+
+    expect(stacks).to.deep.equal(expectedStacks, "Wrong extracted stacks");
+
+    const logString = printStackTraceLast(testNestedError);
+    expect(logString).to.equal(
+      // eslint-disable-next-line quotes
+      ['code=TEST_NESTED_ERROR, nestedError={"message":"TEST_ERROR"}', ...expectedStacks].join("\n")
+    );
+  });
+});

--- a/packages/lodestar-utils/test/unit/logger/winston.test.ts
+++ b/packages/lodestar-utils/test/unit/logger/winston.test.ts
@@ -58,7 +58,7 @@ describe("winston logger", () => {
           message: "foo bar",
           error: error,
           output: {
-            human: `[]                 \u001b[33mwarn\u001b[39m: foo bar code=SAMPLE_ERROR, data={"foo":"bar"} \n${error.stack}`,
+            human: `[]                 \u001b[33mwarn\u001b[39m: foo bar code=SAMPLE_ERROR, data={"foo":"bar"}\n${error.stack}`,
             // eslint-disable-next-line quotes
             json: `{"module":"","error":{"code":"SAMPLE_ERROR","data":{"foo":"bar"},"stack":"$STACK"},"level":"warn","message":"foo bar"}`,
           },


### PR DESCRIPTION
Don't print nested error stack traces in an unreadable JSON-ified string look. Instead pile stack traces from nested to parent. Fixes https://github.com/ChainSafe/lodestar/issues/1932

**before**
```
code=TEST_NESTED_ERROR, nestedError={"message":"TEST_ERROR","stack":"Error: TEST_ERROR\n    at Context.<anonymous> (/home/lion/Code/eth2.0/lodestar/packages/lodestar-utils/test/unit/logger/format.test.ts:15:25)\n    at callFn (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runnable.js:358:21)\n    at Test.Runnable.run (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runnable.js:346:5)\n    at Runner.runTest (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:621:10)\n    at /home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:745:12\n    at next (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:538:14)\n    at /home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:548:7\n    at next (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:430:14)\n    at Immediate._onImmediate (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:516:5)\n    at processImmediate (internal/timers.js:461:21)"} 
      Error: TEST_NESTED_ERROR
          at Context.<anonymous> (/home/lion/Code/eth2.0/lodestar/packages/lodestar-utils/test/unit/logger/format.test.ts:16:29)
          at callFn (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runnable.js:358:21)
          at Test.Runnable.run (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runnable.js:346:5)
          at Runner.runTest (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:621:10)
          at /home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:745:12
          at next (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:538:14)
          at /home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:548:7
          at next (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:430:14)
          at Immediate._onImmediate (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:516:5)
          at processImmediate (internal/timers.js:461:21)
```

**with this PR**
```
code=TEST_NESTED_ERROR, nestedError={"message":"TEST_ERROR"}
Error: TEST_ERROR
    at Context.<anonymous> (/home/lion/Code/eth2.0/lodestar/packages/lodestar-utils/test/unit/logger/format.test.ts:15:25)
    at callFn (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runnable.js:358:21)
    at Test.Runnable.run (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runnable.js:346:5)
    at Runner.runTest (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:621:10)
    at /home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:745:12
    at next (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:538:14)
    at /home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:548:7
    at next (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:430:14)
    at Immediate._onImmediate (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:516:5)
    at processImmediate (internal/timers.js:461:21)
Error: TEST_NESTED_ERROR
    at Context.<anonymous> (/home/lion/Code/eth2.0/lodestar/packages/lodestar-utils/test/unit/logger/format.test.ts:16:29)
    at callFn (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runnable.js:358:21)
    at Test.Runnable.run (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runnable.js:346:5)
    at Runner.runTest (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:621:10)
    at /home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:745:12
    at next (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:538:14)
    at /home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:548:7
    at next (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:430:14)
    at Immediate._onImmediate (/home/lion/Code/eth2.0/lodestar/node_modules/mocha/lib/runner.js:516:5)
    at processImmediate (internal/timers.js:461:21)
```