### PR TITLE
Store state to db only every n epochs

### DIFF
--- a/packages/lodestar-cli/src/util/process.ts
+++ b/packages/lodestar-cli/src/util/process.ts
@@ -21,8 +21,6 @@ export function onGracefulShutdown(
       });
 
       await cleanUpFunction();
-      logFn("Cleanup completed");
-      process.exit(0);
     });
   }
 }


### PR DESCRIPTION
Resolves #1931 

Stores state to `stateArchive` at most every `MIN_EPOCHS_PER_DB_STATE` epochs, currently set to 1024.
On shutdown, store the latest finalized state to `stateArchive`.

Reusing the `stateArchive` bucket for the latest finalized, rather than creating a new bucket, avoids any potential issues with deserializing states before/after forks.

With N set to 1024, syncing mainnet, disk usage is ~1GB.

Possible enhancements:
- expose `MIN_EPOCHS_PER_DB_STATE` as CLI-configurable
- occasionally prune unnecessarily stored states from db (if a node is frequently restarted, current approach will lead to more "unnecessary" states stored to disk)