### PR TITLE
Remove passing gossip attestations to forkchoice

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -11,7 +11,6 @@ import {
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {
-  Attestation,
   BeaconState,
   Checkpoint,
   ENRForkID,
@@ -215,12 +214,6 @@ export class BeaconChain implements IBeaconChain {
 
   public async getFinalizedCheckpoint(): Promise<Checkpoint> {
     return this.forkChoice.getFinalizedCheckpoint();
-  }
-
-  public async receiveAttestation(attestation: Attestation): Promise<void> {
-    this.attestationProcessor
-      .processAttestationJob({attestation, validSignature: false})
-      .catch(() => /* unreachable */ ({}));
   }
 
   public async receiveBlock(signedBlock: SignedBeaconBlock, trusted = false): Promise<void> {

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -97,11 +97,6 @@ export interface IBeaconChain {
   getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<SignedBeaconBlock[] | null>;
 
   /**
-   * Add attestation to the fork-choice rule
-   */
-  receiveAttestation(attestation: Attestation): Promise<void>;
-
-  /**
    * Pre-process and run the per slot state transition function
    */
   receiveBlock(signedBlock: SignedBeaconBlock, trusted?: boolean): Promise<void>;

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -134,8 +134,6 @@ export class GossipMessageValidator implements IGossipMessageValidator {
 
         case AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT:
         case AttestationErrorCode.MISSING_ATTESTATION_PRESTATE:
-          // attestation might be valid after we receive block
-          await this.chain.receiveAttestation(attestation);
           this.logger.warn("Ignoring gossip attestation", logContext, e);
           return ExtendedValidatorResult.ignore;
 
@@ -191,7 +189,6 @@ export class GossipMessageValidator implements IGossipMessageValidator {
           return ExtendedValidatorResult.reject;
 
         case AttestationErrorCode.FUTURE_SLOT:
-          await this.chain.receiveAttestation(attestation);
           this.logger.warn("Ignoring gossip aggregate and proof", logContext, e);
           return ExtendedValidatorResult.ignore;
 

--- a/packages/lodestar/test/unit/chain/validation/attestation.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/attestation.test.ts
@@ -177,7 +177,6 @@ describe("gossip attestation validation", function () {
     } catch (error) {
       expect(error.type).to.have.property("code", AttestationErrorCode.ATTESTATION_ALREADY_KNOWN);
     }
-    expect(chain.receiveAttestation.called).to.be.false;
     expect(db.seenAttestationCache.hasCommitteeAttestation.calledOnceWith(attestation)).to.be.true;
   });
 
@@ -254,7 +253,6 @@ describe("gossip attestation validation", function () {
     } catch (error) {
       expect(error.type).to.have.property("code", AttestationErrorCode.INVALID_SUBNET_ID);
     }
-    expect(chain.receiveAttestation.called).to.be.false;
     expect(computeAttestationSubnetStub.calledOnceWith(config, attestationPreState.epochCtx, attestation)).to.be.true;
   });
 
@@ -286,7 +284,6 @@ describe("gossip attestation validation", function () {
     } catch (error) {
       expect(error.type).to.have.property("code", AttestationErrorCode.INVALID_SIGNATURE);
     }
-    expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
   });
 
@@ -324,7 +321,6 @@ describe("gossip attestation validation", function () {
     } catch (error) {
       expect(error.type).to.have.property("code", AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE);
     }
-    expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
   });
 
@@ -368,7 +364,6 @@ describe("gossip attestation validation", function () {
     } catch (error) {
       expect(error.type).to.have.property("code", AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE);
     }
-    expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
   });
 
@@ -406,7 +401,6 @@ describe("gossip attestation validation", function () {
     } catch (error) {
       expect(error.type).to.have.property("code", AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS);
     }
-    expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
   });
 
@@ -590,7 +584,6 @@ describe("gossip attestation validation", function () {
       0
     );
     expect(validationTest).to.not.throw;
-    expect(chain.receiveAttestation.called).to.be.false;
     expect(db.seenAttestationCache.addCommitteeAttestation.calledOnce).to.be.true;
   });
 });

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -143,10 +143,6 @@ export class MockBeaconChain implements IBeaconChain {
     return Math.floor(Date.now() / 1000);
   }
 
-  async receiveAttestation(): Promise<void> {
-    return;
-  }
-
   async receiveBlock(): Promise<void> {
     return;
   }


### PR DESCRIPTION
resolves #1938

A lot of gossip attestations are not included in any blocks so when receiving them through gossip, we should not include them in forkchoice. If we add them, potentially we'll have different forkchoice head compared to other clients.