### PR TITLE
add missing (& remove uneeded) lodestar-* deps

### DIFF
--- a/packages/lodestar-db/package.json
+++ b/packages/lodestar-db/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "@chainsafe/lodestar-config": "^0.13.0",
-    "@chainsafe/lodestar-types": "^0.13.0",
     "@chainsafe/lodestar-utils": "^0.13.0",
     "@chainsafe/ssz": "^0.6.13",
     "it-all": "^1.0.2",

--- a/packages/lodestar-fork-choice/package.json
+++ b/packages/lodestar-fork-choice/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@chainsafe/lodestar-beacon-state-transition": "^0.13.0",
     "@chainsafe/lodestar-config": "^0.13.0",
-    "@chainsafe/lodestar-params": "^0.13.0",
     "@chainsafe/lodestar-types": "^0.13.0",
     "@chainsafe/lodestar-utils": "^0.13.0",
     "@chainsafe/ssz": "^0.6.13"

--- a/packages/lodestar-validator/package.json
+++ b/packages/lodestar-validator/package.json
@@ -49,6 +49,7 @@
     "@chainsafe/lodestar-config": "^0.13.0",
     "@chainsafe/lodestar-types": "^0.13.0",
     "@chainsafe/lodestar-utils": "^0.13.0",
+    "@chainsafe/lodestar-db" : "^0.13.0",
     "@chainsafe/ssz": "^0.6.13",
     "abort-controller": "^3.0.0",
     "abortable-iterator": "^3.0.0",

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -53,6 +53,7 @@
     "@chainsafe/lodestar-types": "^0.13.0",
     "@chainsafe/lodestar-utils": "^0.13.0",
     "@chainsafe/lodestar-validator": "^0.13.0",
+    "@chainsafe/lodestar-fork-choice": "^0.13.0",
     "@chainsafe/snappy-stream": "3.0.5",
     "@chainsafe/ssz": "^0.6.13",
     "@ethersproject/abi": "^5.0.0",


### PR DESCRIPTION
when making the lodestar-* dependency diagram (in #1905 ), I saw some lodestar-* dependencies that were listed in some package.json's that weren't used anymore as well as some that needed to be listed that weren't.  this PR rectifies that