### PR TITLE
Unify EpochContext

### DIFF
--- a/packages/lodestar-beacon-state-transition/src/fast/epoch/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/epoch/index.ts
@@ -1,5 +1,5 @@
 import {CachedValidatorsBeaconState, prepareEpochProcessState} from "../util";
-import {StateTransitionEpochContext} from "../util/epochContext";
+import {EpochContext} from "../util/epochContext";
 import {processJustificationAndFinalization} from "./processJustificationAndFinalization";
 import {processRewardsAndPenalties} from "./processRewardsAndPenalties";
 import {processRegistryUpdates} from "./processRegistryUpdates";
@@ -18,9 +18,8 @@ export {
   getAttestationDeltas,
 };
 
-export function processEpoch(epochCtx: StateTransitionEpochContext, state: CachedValidatorsBeaconState): void {
+export function processEpoch(epochCtx: EpochContext, state: CachedValidatorsBeaconState): void {
   const process = prepareEpochProcessState(epochCtx, state);
-  epochCtx.epochProcess = process;
   processJustificationAndFinalization(epochCtx, process, state);
   processRewardsAndPenalties(epochCtx, process, state);
   processRegistryUpdates(epochCtx, process, state);

--- a/packages/lodestar-beacon-state-transition/src/fast/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/index.ts
@@ -1,8 +1,7 @@
 import {SignedBeaconBlock} from "@chainsafe/lodestar-types";
 
-import {CachedValidatorsBeaconState, verifyBlockSignature} from "./util";
+import {verifyBlockSignature} from "./util";
 import {IStateContext} from "./util";
-import {StateTransitionEpochContext} from "./util/epochContext";
 import {EpochContext} from "./util/epochContext";
 import {processSlots} from "./slot";
 import {processBlock} from "./block";
@@ -13,11 +12,10 @@ export {IStateContext, EpochContext};
  * Implementation of protolambda's eth2fastspec (https://github.com/protolambda/eth2fastspec)
  */
 export function fastStateTransition(
-  {state, epochCtx: eiEpochCtx}: IStateContext,
+  {state, epochCtx}: IStateContext,
   signedBlock: SignedBeaconBlock,
   options?: {verifyStateRoot?: boolean; verifyProposer?: boolean; verifySignatures?: boolean}
 ): IStateContext {
-  const epochCtx = new StateTransitionEpochContext(undefined, eiEpochCtx);
   const {verifyStateRoot = true, verifyProposer = true, verifySignatures = true} = options || {};
   const types = epochCtx.config.types;
 
@@ -40,21 +38,8 @@ export function fastStateTransition(
       throw new Error("Invalid state root");
     }
   }
-  return toIStateContext(epochCtx, postState);
-}
-
-/**
- * Trim epochProcess in epochCtx, and insert the standard/exchange interface epochProcess to the final IStateContext
- */
-export function toIStateContext(
-  epochCtx: StateTransitionEpochContext,
-  state: CachedValidatorsBeaconState
-): IStateContext {
-  const epochProcess = epochCtx.epochProcess;
-  epochCtx.epochProcess = undefined;
   return {
-    state: state,
-    epochCtx: new EpochContext(undefined, epochCtx),
-    epochProcess,
+    state: postState,
+    epochCtx,
   };
 }

--- a/packages/lodestar-beacon-state-transition/src/fast/slot/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/slot/index.ts
@@ -1,17 +1,13 @@
 import {Slot} from "@chainsafe/lodestar-types";
 
-import {StateTransitionEpochContext} from "../util/epochContext";
 import {processEpoch} from "../epoch";
 import {processSlot} from "./processSlot";
 import {CachedValidatorsBeaconState} from "../util/interface";
+import {EpochContext} from "../util";
 
 export {processSlot};
 
-export function processSlots(
-  epochCtx: StateTransitionEpochContext,
-  state: CachedValidatorsBeaconState,
-  slot: Slot
-): void {
+export function processSlots(epochCtx: EpochContext, state: CachedValidatorsBeaconState, slot: Slot): void {
   if (!(state.slot < slot)) {
     throw new Error("State slot must transition to a future slot: " + `stateSlot=${state.slot} slot=${slot}`);
   }

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochContext.ts
@@ -25,7 +25,6 @@ import {
   isAggregatorFromCommitteeLength,
 } from "../../util";
 import {computeEpochShuffling, IEpochShuffling} from "./epochShuffling";
-import {IEpochProcess} from "./epochProcess";
 import {CachedValidatorsBeaconState} from "./interface";
 
 export class PubkeyIndexMap extends Map<ByteVector, ValidatorIndex> {
@@ -58,16 +57,11 @@ export class EpochContext {
   public nextShuffling!: IEpochShuffling;
   public config: IBeaconConfig;
 
-  constructor(config?: IBeaconConfig, epochCtx?: EpochContext) {
-    this.config = (epochCtx?.config || config)!;
-    this.pubkey2index = epochCtx?.pubkey2index || new PubkeyIndexMap();
-    this.index2pubkey = epochCtx?.index2pubkey || [];
-    this.proposers = epochCtx?.proposers || [];
-    if (epochCtx) {
-      this.previousShuffling = epochCtx.previousShuffling;
-      this.currentShuffling = epochCtx.currentShuffling;
-      this.nextShuffling = epochCtx.nextShuffling;
-    }
+  constructor(config: IBeaconConfig) {
+    this.config = config;
+    this.pubkey2index = new PubkeyIndexMap();
+    this.index2pubkey = [];
+    this.proposers = [];
   }
 
   /**
@@ -264,20 +258,5 @@ export class EpochContext {
     } else {
       throw new Error(`crosslink committee retrieval: out of range epoch: ${epoch}`);
     }
-  }
-}
-
-/**
- * State Transition specific version of EpochContext.
- * This is internal/private at the module level.
- */
-export class StateTransitionEpochContext extends EpochContext {
-  public epochProcess?: IEpochProcess;
-
-  // need to return EpochContext in order to override
-  public copy(): EpochContext {
-    const ctx = new StateTransitionEpochContext(undefined, this);
-    ctx.epochProcess = this.epochProcess;
-    return ctx;
   }
 }

--- a/packages/lodestar-beacon-state-transition/src/fast/util/epochProcess.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/epochProcess.ts
@@ -18,9 +18,9 @@ import {
   FLAG_CURR_HEAD_ATTESTER,
 } from "./attesterStatus";
 import {IEpochStakeSummary} from "./epochStakeSummary";
-import {StateTransitionEpochContext} from "./epochContext";
 import {isActiveIFlatValidator} from "./flatValidator";
 import {CachedValidatorsBeaconState} from "./interface";
+import {EpochContext} from "./epochContext";
 
 /**
  * The AttesterStatus (and FlatValidator under status.validator) objects and
@@ -68,10 +68,7 @@ export function createIEpochProcess(): IEpochProcess {
   };
 }
 
-export function prepareEpochProcessState(
-  epochCtx: StateTransitionEpochContext,
-  state: CachedValidatorsBeaconState
-): IEpochProcess {
+export function prepareEpochProcessState(epochCtx: EpochContext, state: CachedValidatorsBeaconState): IEpochProcess {
   const out = createIEpochProcess();
 
   const config = epochCtx.config;

--- a/packages/lodestar-beacon-state-transition/src/fast/util/index.ts
+++ b/packages/lodestar-beacon-state-transition/src/fast/util/index.ts
@@ -1,5 +1,4 @@
 import {EpochContext} from "./epochContext";
-import {IEpochProcess} from "./epochProcess";
 import {CachedValidatorsBeaconState} from "./interface";
 
 export * from "./block";
@@ -17,5 +16,4 @@ export * from "./interface";
 export interface IStateContext {
   state: CachedValidatorsBeaconState;
   epochCtx: EpochContext;
-  epochProcess?: IEpochProcess;
 }

--- a/packages/lodestar-beacon-state-transition/test/perf/epoch_processing.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/epoch_processing.test.ts
@@ -6,7 +6,7 @@ import {
   IEpochProcess,
   prepareEpochProcessState,
 } from "../../src/fast/util";
-import {EpochContext, StateTransitionEpochContext} from "../../src/fast/util/epochContext";
+import {EpochContext} from "../../src/fast/util/epochContext";
 import {
   processFinalUpdates,
   processJustificationAndFinalization,
@@ -20,7 +20,7 @@ import {expect} from "chai";
 
 describe("Epoch Processing Performance Tests", function () {
   let state: CachedValidatorsBeaconState;
-  let epochCtx: StateTransitionEpochContext;
+  let epochCtx: EpochContext;
   let process: IEpochProcess;
   const logger = new WinstonLogger();
 

--- a/packages/lodestar-beacon-state-transition/test/perf/sanity/slots.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/sanity/slots.test.ts
@@ -3,7 +3,6 @@ import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {expect} from "chai";
 import {EpochContext} from "../../../src/fast";
 import {processSlots} from "../../../src/fast/slot";
-import {StateTransitionEpochContext} from "../../../src/fast/util/epochContext";
 import {CachedValidatorsBeaconState, createCachedValidatorsBeaconState} from "../../../src/fast/util";
 import {generatePerformanceState, initBLS} from "../util";
 
@@ -11,7 +10,7 @@ describe("Process Slots Performance Test", function () {
   this.timeout(0);
   const logger = new WinstonLogger();
   let state: CachedValidatorsBeaconState;
-  let epochCtx: StateTransitionEpochContext;
+  let epochCtx: EpochContext;
 
   before(async () => {
     await initBLS();

--- a/packages/lodestar/src/db/api/beacon/stateContextCache.ts
+++ b/packages/lodestar/src/db/api/beacon/stateContextCache.ts
@@ -1,24 +1,12 @@
 import {ByteVector, toHexString, TreeBacked} from "@chainsafe/ssz";
-import {BeaconState, Gwei} from "@chainsafe/lodestar-types";
+import {BeaconState} from "@chainsafe/lodestar-types";
 import {EpochContext} from "@chainsafe/lodestar-beacon-state-transition";
 import {CachedValidatorsBeaconState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
 // Lodestar specifc state context
 export interface ITreeStateContext {
-  state: CachedValidatorsBeaconState; // TreeBacked<BeaconState>
-  epochCtx: LodestarEpochContext;
-}
-
-// Lodestar specific epoch context
-export class LodestarEpochContext extends EpochContext {
-  public epochBalances?: Gwei[];
-
-  // need to be return EpochContext in order to override
-  public copy(): EpochContext {
-    const ctx = new LodestarEpochContext(undefined, this);
-    ctx.epochBalances = this.epochBalances;
-    return ctx;
-  }
+  state: CachedValidatorsBeaconState;
+  epochCtx: EpochContext;
 }
 
 /**
@@ -91,7 +79,7 @@ export class StateContextCache {
   private clone(item: ITreeStateContext): ITreeStateContext {
     return {
       state: item.state.clone(),
-      epochCtx: item.epochCtx.copy() as LodestarEpochContext,
+      epochCtx: item.epochCtx.copy(),
     };
   }
 }

--- a/packages/lodestar/src/db/api/beacon/stateContextCheckpointsCache.ts
+++ b/packages/lodestar/src/db/api/beacon/stateContextCheckpointsCache.ts
@@ -1,7 +1,7 @@
 import {toHexString, fromHexString} from "@chainsafe/ssz";
 import {Checkpoint, Epoch} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {LodestarEpochContext, ITreeStateContext} from "./stateContextCache";
+import {ITreeStateContext} from "./stateContextCache";
 
 /**
  * In memory cache of BeaconState and connected EpochContext
@@ -109,7 +109,7 @@ export class CheckpointStateCache {
   private clone(item: ITreeStateContext): ITreeStateContext {
     return {
       state: item.state.clone(),
-      epochCtx: item.epochCtx.copy() as LodestarEpochContext,
+      epochCtx: item.epochCtx.copy(),
     };
   }
 }


### PR DESCRIPTION
From https://github.com/ChainSafe/lodestar/issues/1950#issuecomment-760595788

> one good thing with caching IFlatValidator (which is currently in CachedValidatorsBeaconState) is we can pull `epochBalances` directly from there instead of having to publish `epochProcess` (in lodestar-beacon-state-transition) to lodestar, the consequence of that is:
> + No need different types of EpochContext (StateTransitionEpochContext, LodestarEpochContext), only EpochContext
> + `epochProcess` stays internal to lodestar-beacon-state-transition and hence it's not a concern

we need to do this cleanup work before implementing CachedBeaconState

this reverts most of changes in #1702