### PR TITLE
updates READMEs in favor of lodestar architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Architecture Overview
 
-- See [architecure diagrams](https://hackmd.io/@wemeetagain/rJTEOdqPS/%2FL5vwdaXGTH-IqYtv6fqVRA) for Lodestar
+- See [architecure docs](https://chainsafe.github.io/lodestar/design/architecture/) for Lodestar
 
 ## Contributors
 

--- a/packages/lodestar/README.md
+++ b/packages/lodestar/README.md
@@ -24,40 +24,7 @@ You will need to go over the [specification](https://github.com/ethereum/eth2.0-
 
 ## Architecture Overview
 
-Here is an overview of the sub-components of this package and their uses:
-
-### api
-  - various REST API calls that can be made for:
-    - beacon
-      - get data about the beacon state and publish new data
-    - events
-      - sets up an event stream to listen for new beacon node events
-    - node
-      - get data about the node process that is running Lodestar
-    - validator
-      - perform (and get relevant data for) validator duties
-### chain
-  - processing block and attestation data to/from the beacon chain
-### db
-  - handles all persistent data stored to the local leveldb while running the beacon chain.  uses [@chainsafe/lodestar-db](https://github.com/ChainSafe/lodestar/tree/master/packages/lodestar-db) under the hood.
-### eth1
-  - handles all interactions with the eth1 blockchain (e.g. deposit data)
-### metrics
-  - exposes Lodestar metrics data that can be read using clients such as [Prometheus & Grafana](https://chainsafe.github.io/lodestar/usage/prometheus-grafana/)
-### network
-  - eth2 network implementation as defined by the [Eth2 Networking Spec](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/p2p-interface.md)
-### node
-  - contains the nodeJS process that bootstraps and runs Lodestar
-  - contains the entrypoint that [@chainsafe/lodestar-cli](https://github.com/ChainSafe/lodestar/tree/master/packages/lodestar-cli/) calls to start the beacon node
-### sync
-  - "syncing" is the process by which the beacon node stays updated with new data published on eth2.  there are two such processes in Lodestar:
-    - initial sync
-      - sync new data until we reach the head of the chain
-    - regular sync
-      - once we have finished initial sync (i.e. reached the head of the chain), regular sync keeps us updated in realtime as the chain head moves forward
-### tasks
-### util
-  - various utility functions used by all of the above
+see [Beacon Node Module Architecture](https://chainsafe.github.io/lodestar/design/architecture/)
 
 ## Contributors
 


### PR DESCRIPTION
since we have design docs in https://chainsafe.github.io/lodestar/ now, we don't need the info to be in the READMEs, and can just have links to the docs instead