### PR TITLE
Fix typo in sim tests workflow

### DIFF
--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -40,8 +40,8 @@
     "test:unit": "TS_NODE_PROJECT=tsconfig.test.json nyc --cache-dir .nyc_output/.cache -e .ts mocha 'test/unit/**/*.test.ts'",
     "test:e2e": "TS_NODE_PROJECT=tsconfig.test.json mocha 'test/e2e/**/*.test.ts'",
     "test:sim": "TS_NODE_PROJECT=tsconfig.test.json mocha 'test/sim/**/*.test.ts'",
-    "test:sim:singleThread": "TS_NODE_PROJECT=tsconfig.test.json mocha 'test/sim/multiNodeMultiThread.test.ts'",
-    "test:sim:multiThread": "TS_NODE_PROJECT=tsconfig.test.json mocha 'test/sim/singleNodeSingleThread.test.ts'"
+    "test:sim:singleThread": "TS_NODE_PROJECT=tsconfig.test.json mocha 'test/sim/singleNodeSingleThread.test.ts'",
+    "test:sim:multiThread": "TS_NODE_PROJECT=tsconfig.test.json mocha 'test/sim/multiNodeMultiThread.test.ts'"
   },
   "dependencies": {
     "@chainsafe/bls": "5.1.0",


### PR DESCRIPTION
`yarn test:sim:singleThread` was running `test/sim/multiNodeMultiThread.test.ts` instead of  `test/sim/singleNodeSingleThread.test.ts`