### PR TITLE
Resolve OOM issue

### DIFF
--- a/packages/lodestar/src/chain/blocks/process.ts
+++ b/packages/lodestar/src/chain/blocks/process.ts
@@ -14,6 +14,7 @@ import {BlockError, BlockErrorCode, ChainSegmentError} from "../errors";
 import {IBeaconDb} from "../../db";
 import {verifySignatureSetsBatch} from "../bls";
 import {groupBlocksByEpoch} from "./util";
+import {sleep} from "@chainsafe/lodestar-utils";
 
 export async function processBlock({
   forkChoice,
@@ -153,6 +154,8 @@ export async function processChainSegment({
           validSignatures: true,
         });
         importedBlocks++;
+        // we'll likely lose peers without this
+        await sleep(0);
       }
     } catch (e) {
       if (e instanceof RegenError) {

--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -14,7 +14,6 @@ import {IBlockSummary, IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {ITreeStateContext} from "../../db/api/beacon/stateContextCache";
 import {ChainEvent, ChainEventEmitter} from "../emitter";
 import {IBlockJob} from "../interface";
-import {sleep} from "@chainsafe/lodestar-utils";
 import {IBeaconDb} from "../../db";
 import {isActiveIFlatValidator} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
@@ -73,8 +72,6 @@ export async function processSlotsToNearestCheckpoint(
   ) {
     processSlots(postCtx.epochCtx, postCtx.state, nextEpochSlot);
     emitCheckpointEvent(emitter, cloneStateCtx(postCtx));
-    // this avoids keeping our node busy processing blocks
-    await sleep(0);
   }
   return postCtx;
 }
@@ -161,7 +158,5 @@ export async function runStateTransition(
   emitBlockEvent(emitter, job, postStateContext);
   emitForkChoiceHeadEvents(emitter, forkChoice, forkChoice.getHead(), oldHead);
 
-  // this avoids keeping our node busy processing blocks
-  await sleep(0);
   return postStateContext;
 }

--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -14,6 +14,7 @@ import {IBlockSummary, IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {ITreeStateContext} from "../../db/api/beacon/stateContextCache";
 import {ChainEvent, ChainEventEmitter} from "../emitter";
 import {IBlockJob} from "../interface";
+import {sleep} from "@chainsafe/lodestar-utils";
 import {IBeaconDb} from "../../db";
 import {isActiveIFlatValidator} from "@chainsafe/lodestar-beacon-state-transition/lib/fast/util";
 
@@ -72,6 +73,8 @@ export async function processSlotsToNearestCheckpoint(
   ) {
     processSlots(postCtx.epochCtx, postCtx.state, nextEpochSlot);
     emitCheckpointEvent(emitter, cloneStateCtx(postCtx));
+    // we'll likely lose peers without this
+    await sleep(0);
   }
   return postCtx;
 }

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -9,6 +9,7 @@ import {IBeaconDb} from "../../db";
 import {processSlotsByCheckpoint, runStateTransition} from "../blocks/stateTransition";
 import {IStateRegenerator} from "./interface";
 import {RegenError, RegenErrorCode} from "./errors";
+import {sleep} from "@chainsafe/lodestar-utils";
 
 /**
  * Regenerates states that have already been processed by the fork choice
@@ -177,6 +178,8 @@ export class StateRegenerator implements IStateRegenerator {
           validSignatures: true,
           validProposerSignature: true,
         });
+        // we'll likely lose peers without this
+        await sleep(0);
       } catch (e) {
         throw new RegenError({
           code: RegenErrorCode.STATE_TRANSITION_ERROR,


### PR DESCRIPTION
resolves #2005 

+ The current `sleep(0)` inside `runStateTransition()` causes BeaconState/EpochContext stays inside the outer Promise scope until the inner Promise (`sleep(0)`) resolved, gradually it causes a lot of objects in memory like this

<img width="978" alt="Screen Shot 2021-01-29 at 21 26 26" src="https://user-images.githubusercontent.com/10568965/106287054-f58a2100-6278-11eb-9771-e9b351610211.png">

+ Simply move `sleep(0)` to the consumer help fix the issue. **__Note__**: we cannot simply remove these `sleep(0)` calls, otherwise we'll lose peers
+ Work in my local environment: memory stays from 1.1GB to 1.8GB (currently it's 4GB after 1h if I start from epoch 4xxx), testing in contavo 01 now
