### PR TITLE
validator client --logLevel

### DIFF
--- a/packages/lodestar-cli/src/cmds/validator/handler.ts
+++ b/packages/lodestar-cli/src/cmds/validator/handler.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import {consoleTransport, fileTransport, WinstonLogger} from "@chainsafe/lodestar-utils";
+import {consoleTransport, fileTransport, LogLevel, WinstonLogger} from "@chainsafe/lodestar-utils";
 import {ApiClientOverRest} from "@chainsafe/lodestar-validator/lib/api/impl/rest/apiClient";
 import {Validator, SlashingProtection} from "@chainsafe/lodestar-validator";
 import {LevelDbController} from "@chainsafe/lodestar-db";
@@ -27,7 +27,10 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
   const config = getBeaconConfigFromArgs(args);
   const logFilePath = getBeaconPaths(args).logFile;
 
-  const logger = new WinstonLogger({}, [consoleTransport, ...(logFilePath ? [fileTransport(logFilePath)] : [])]);
+  const logger = new WinstonLogger({level: args.logLevel as LogLevel}, [
+    consoleTransport,
+    ...(logFilePath ? [fileTransport(logFilePath)] : []),
+  ]);
 
   const validatorDirManager = new ValidatorDirManager(accountPaths);
   const secretKeys = await validatorDirManager.decryptAllValidators({force});

--- a/packages/lodestar-cli/src/cmds/validator/options.ts
+++ b/packages/lodestar-cli/src/cmds/validator/options.ts
@@ -2,6 +2,7 @@ import {ICliCommandOptions} from "../../util";
 import {defaultValidatorPaths} from "./paths";
 import {accountValidatorOptions, IAccountValidatorArgs} from "../account/cmds/validator/options";
 import {beaconOptions} from "../beacon/options";
+import {LogLevels} from "@chainsafe/lodestar-utils";
 
 export type IValidatorCliArgs = IAccountValidatorArgs & {
   validatorsDbDir?: string;
@@ -9,6 +10,7 @@ export type IValidatorCliArgs = IAccountValidatorArgs & {
   force: boolean;
   graffiti: string;
   logFile: string;
+  logLevel: string;
 };
 
 export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
@@ -37,6 +39,12 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
   graffiti: {
     description: "Specify your custom graffiti to be included in blocks (plain UTF8 text, 32 characters max)",
     // Don't use a default here since it should be computed only if necessary by getDefaultGraffiti()
+    type: "string",
+  },
+
+  logLevel: {
+    description: "Set the log level for the winston logger.",
+    choices: LogLevels,
     type: "string",
   },
 };


### PR DESCRIPTION
resolves #2013 
since there isn't really a config file for the validator client like there is for the beacon node (and since we don't have all those different node modules which have their own individual log levels in validator like we do in beacon), i figured the most efficient solution was adding `--logLevel` as a CLI option for the validator.  however, if anyone wants me to expand this solution, i'm open to suggestions.