### PR TITLE
add epoch and status headers to SyncChain stuck logs

### DIFF
--- a/packages/lodestar/src/sync/range/chain.ts
+++ b/packages/lodestar/src/sync/range/chain.ts
@@ -330,6 +330,8 @@ export class SyncChain {
     return `
 startEpoch: ${this.startEpoch}
 batches: ${this.batches.size}
+\t${"epoch"} \t${"status"}
+\t${"_____"} \t${"______"}
 ${batchesMetadata.map(({startEpoch, status}) => `\t${startEpoch} \t${status}`).join("\n")}
 `;
   }

--- a/packages/lodestar/src/sync/range/chain.ts
+++ b/packages/lodestar/src/sync/range/chain.ts
@@ -331,7 +331,7 @@ export class SyncChain {
 startEpoch: ${this.startEpoch}
 batches: ${this.batches.size}
 \t${"epoch"} \t${"status"}
-\t${"_____"} \t${"______"}
+\t${"-----"} \t${"------"}
 ${batchesMetadata.map(({startEpoch, status}) => `\t${startEpoch} \t${status}`).join("\n")}
 `;
   }


### PR DESCRIPTION
noticed that it might be unclear to someone seeing this log for the first time as to what's being printed out, so added a little clarification so it's immediately obvious what is printed out