### PR TITLE
Process finalized checkpoints in order

### DIFF
--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -152,7 +152,9 @@ export class BeaconNode {
       network,
       logger: logger.child(opts.logger.sync),
     });
-    const chores = new TasksService(config, {
+    const chores = new TasksService({
+      config,
+      signal: controller.signal,
       db,
       chain,
       sync,

--- a/packages/lodestar/src/tasks/index.ts
+++ b/packages/lodestar/src/tasks/index.ts
@@ -16,11 +16,6 @@ import {InteropSubnetsJoiningTask} from "./tasks/interopSubnetsJoiningTask";
 import {INetwork, NetworkEvent} from "../network";
 import {JobQueue} from "../util/queue";
 
-/**
- * Minimum number of epochs between archived states
- */
-export const MIN_EPOCHS_PER_DB_STATE = 1024;
-
 export interface ITasksModules {
   db: IBeaconDb;
   logger: ILogger;

--- a/packages/lodestar/src/tasks/index.ts
+++ b/packages/lodestar/src/tasks/index.ts
@@ -3,6 +3,7 @@
  */
 
 import {phase0} from "@chainsafe/lodestar-types";
+import {AbortSignal} from "abort-controller";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils";
 
@@ -13,6 +14,12 @@ import {StatesArchiver} from "./tasks/archiveStates";
 import {IBeaconSync} from "../sync";
 import {InteropSubnetsJoiningTask} from "./tasks/interopSubnetsJoiningTask";
 import {INetwork, NetworkEvent} from "../network";
+import {JobQueue} from "../util/queue";
+
+/**
+ * Minimum number of epochs between archived states
+ */
+export const MIN_EPOCHS_PER_DB_STATE = 1024;
 
 export interface ITasksModules {
   db: IBeaconDb;
@@ -32,11 +39,21 @@ export class TasksService {
   private readonly chain: IBeaconChain;
   private readonly network: INetwork;
   private readonly logger: ILogger;
+  private jobQueue: JobQueue;
 
   private readonly statesArchiver: StatesArchiver;
   private readonly interopSubnetsTask: InteropSubnetsJoiningTask;
 
-  constructor(config: IBeaconConfig, modules: ITasksModules) {
+  constructor({
+    config,
+    signal,
+    maxLength = 256,
+    ...modules
+  }: ITasksModules & {
+    config: IBeaconConfig;
+    signal: AbortSignal;
+    maxLength?: number;
+  }) {
     this.config = config;
     this.db = modules.db;
     this.chain = modules.chain;
@@ -48,6 +65,7 @@ export class TasksService {
       network: this.network,
       logger: this.logger,
     });
+    this.jobQueue = new JobQueue({maxLength, signal});
   }
 
   start(): void {
@@ -76,6 +94,10 @@ export class TasksService {
   };
 
   private onFinalizedCheckpoint = async (finalized: phase0.Checkpoint): Promise<void> => {
+    return this.jobQueue.push(async () => await this.processFinalizedCheckpoint(finalized));
+  };
+
+  private processFinalizedCheckpoint = async (finalized: phase0.Checkpoint): Promise<void> => {
     try {
       await new ArchiveBlocksTask(
         this.config,


### PR DESCRIPTION
resolves #2015 
+ use `JobQueue` to order the finalized checkpoint execution: one finalized checkpoint needs to be processed completely before the next one