### PR TITLE
implement getValidatorStatus and use it in getStateValidator(s)

### DIFF
--- a/packages/lodestar-types/src/types/api.ts
+++ b/packages/lodestar-types/src/types/api.ts
@@ -108,19 +108,15 @@ export interface BeaconCommitteeResponse {
 }
 
 export enum ValidatorStatus {
-  WAITING_FOR_ELIGIBILITY = "waiting_for_eligibility",
-  WAITING_FOR_FINALITY = "waiting_for_finality",
-  WAITING_IN_QUEUE = "waiting_in_queue",
-  STANDBY_FOR_ACTIVE = "standby_for_active",
-  ACTIVE = "active",
-  ACTIVE_AWAITING_VOLUNTARY_EXIT = "active_awaiting_voluntary_exit",
-  ACTIVE_AWAITING_SLASHED_EXIT = "active_awaiting_slashed_exit",
-  EXITED_VOLUNTARILY = "exited_voluntarily",
+  PENDING_INITIALIZED = "pending_initialized",
+  PENDING_QUEUED = "pending_queued",
+  ACTIVE_ONGOING = "active_ongoing",
+  ACTIVE_EXITING = "active_exiting",
+  ACTIVE_SLASHED = "active_slashed",
+  EXITED_UNSLASHED = "exited_unslashed",
   EXITED_SLASHED = "exited_slashed",
-  WITHDRAWABLE_VOLUNTARILY = "withdrawable_voluntarily",
-  WITHDRAWABLE_SLASHED = "withdrawable_slashed",
-  WITHDRAWN_VOLUNTARILY = "withdrawn_voluntarily",
-  WITHDRAWN_SLASHED = "withdrawn_slashed",
+  WITHDRAWAL_POSSIBLE = "withdrawal_possible",
+  WITHDRAWAL_DONE = "withdrawal_done",
 }
 
 export interface ValidatorResponse {

--- a/packages/lodestar/src/api/impl/beacon/state/interface.ts
+++ b/packages/lodestar/src/api/impl/beacon/state/interface.ts
@@ -27,7 +27,17 @@ export interface IBeaconStateApi {
 
 export type StateId = string | "head" | "genesis" | "finalized" | "justified";
 
-export type ValidatorStatus = "active";
+export type ValidatorStatus =
+  | "active"
+  | "pending_initialized"
+  | "pending_queued"
+  | "active_ongoing"
+  | "active_exiting"
+  | "active_slashed"
+  | "exited_unslashed"
+  | "exited_slashed"
+  | "withdrawal_possible"
+  | "withdrawal_done";
 
 export interface IValidatorFilters {
   indices?: (BLSPubkey | ValidatorIndex)[];

--- a/packages/lodestar/src/api/impl/beacon/state/state.ts
+++ b/packages/lodestar/src/api/impl/beacon/state/state.ts
@@ -18,7 +18,7 @@ import {ApiError, StateNotFound} from "../../errors/api";
 import {IApiModules} from "../../interface";
 import {IBeaconStateApi, ICommitteesFilters, IValidatorFilters, StateId} from "./interface";
 import {getEpochBeaconCommittees, resolveStateId, toValidatorResponse} from "./utils";
-import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {computeEpochAtSlot, getCurrentEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {ValidatorResponse} from "@chainsafe/lodestar-types";
 
 export class BeaconStateApi implements IBeaconStateApi {
@@ -62,7 +62,7 @@ export class BeaconStateApi implements IBeaconStateApi {
     }
     //TODO: implement filters
     return readOnlyMap(state.state.validators, (v, index) =>
-      toValidatorResponse(index, v, state.state.balances[index])
+      toValidatorResponse(index, v, state.state.balances[index], getCurrentEpoch(this.config, state.state))
     );
   }
 
@@ -92,7 +92,8 @@ export class BeaconStateApi implements IBeaconStateApi {
     return toValidatorResponse(
       validatorIndex,
       state.state.validators[validatorIndex],
-      state.state.balances[validatorIndex]
+      state.state.balances[validatorIndex],
+      getCurrentEpoch(this.config, state.state)
     );
   }
 

--- a/packages/lodestar/src/api/impl/beacon/state/utils.ts
+++ b/packages/lodestar/src/api/impl/beacon/state/utils.ts
@@ -43,7 +43,7 @@ export async function resolveStateId(
  * Get the status of the validator
  * based on conditions outlined in https://hackmd.io/ofFJ5gOmQpu1jjHilHbdQQ
  */
-function getValidatorStatus(validator: Validator, currentEpoch: Epoch): ValidatorStatus {
+export function getValidatorStatus(validator: Validator, currentEpoch: Epoch): ValidatorStatus {
   // pending
   if (validator.activationEpoch > currentEpoch) {
     if (validator.activationEligibilityEpoch === FAR_FUTURE_EPOCH) {

--- a/packages/lodestar/test/unit/api/impl/beacon/state/stateValidators.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/state/stateValidators.test.ts
@@ -32,7 +32,7 @@ describe("beacon api impl - state - validators", function () {
     toValidatorResponseStub.returns({
       index: 1,
       balance: BigInt(3200000),
-      status: ValidatorStatus.ACTIVE,
+      status: ValidatorStatus.ACTIVE_ONGOING,
       validator: generateValidator(),
     });
   });
@@ -64,11 +64,11 @@ describe("beacon api impl - state - validators", function () {
       toValidatorResponseStub.onFirstCall().returns({
         index: 1,
         balance: BigInt(3200000),
-        status: ValidatorStatus.WITHDRAWABLE_SLASHED,
+        status: ValidatorStatus.EXITED_SLASHED,
         validator: generateValidator(),
       });
       const api = new BeaconStateApi({}, {config, db, chain});
-      const validators = api.getStateValidators("someState", {statuses: [ValidatorStatus.ACTIVE]});
+      const validators = api.getStateValidators("someState", {statuses: [ValidatorStatus.ACTIVE_ONGOING]});
       expect((await validators).length).to.equal(9);
     });
 

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getValidator.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getValidator.test.ts
@@ -43,7 +43,7 @@ describe("rest - beacon - getStateValidator", function () {
     api.beacon.state.getStateValidator.withArgs("head", config.types.BLSPubkey.fromJson(pubkey)).resolves({
       index: 1,
       balance: BigInt(3200000),
-      status: ValidatorStatus.ACTIVE,
+      status: ValidatorStatus.ACTIVE_ONGOING,
       validator: generateValidator(),
     });
     const response = await supertest(restApi.server.server)
@@ -58,7 +58,7 @@ describe("rest - beacon - getStateValidator", function () {
     api.beacon.state.getStateValidator.withArgs("head", 1).resolves({
       index: 1,
       balance: BigInt(3200000),
-      status: ValidatorStatus.ACTIVE,
+      status: ValidatorStatus.ACTIVE_ONGOING,
       validator: generateValidator(),
     });
     const response = await supertest(restApi.server.server)

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getValidators.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getValidators.test.ts
@@ -42,7 +42,7 @@ describe("rest - beacon - getStateValidators", function () {
       {
         index: 1,
         balance: BigInt(3200000),
-        status: ValidatorStatus.ACTIVE,
+        status: ValidatorStatus.ACTIVE_ONGOING,
         validator: generateValidator(),
       },
     ]);


### PR DESCRIPTION
while working on #1986 , i noticed that we weren't getting the validator(s)'s actual state and just returning `"active"` unconditionally.  this PR fixes that

calculations of the various validator statuses based on https://github.com/ethereum/eth2.0-APIs/blob/e36b026ef1265dba9b9c6bc984236088d3759f87/types/api.yaml#L31 which is based on https://hackmd.io/ofFJ5gOmQpu1jjHilHbdQQ
i also updated the ValidatorStatus list in `lodestar-types` to match the eth2 api spec