### PR TITLE
Fix validator aggregating all the time

### DIFF
--- a/packages/lodestar-validator/src/services/utils.ts
+++ b/packages/lodestar-validator/src/services/utils.ts
@@ -8,3 +8,7 @@ export function mapSecretKeysToValidators(secretKeys: SecretKey[]): Map<PublicKe
   }
   return validators;
 }
+
+export function getAggregationBits(committeeLength: number, validatorIndexInCommittee: number): boolean[] {
+  return Array.from({length: committeeLength}, (_, i) => i === validatorIndexInCommittee);
+}

--- a/packages/lodestar-validator/src/util/aggregator.ts
+++ b/packages/lodestar-validator/src/util/aggregator.ts
@@ -1,7 +1,12 @@
-import {BLSSignature, Number64} from "@chainsafe/lodestar-types";
-import {bytesToInt} from "@chainsafe/lodestar-utils";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {AttesterDuty, BLSSignature, Number64} from "@chainsafe/lodestar-types";
+import {bytesToBigInt, intDiv} from "@chainsafe/lodestar-utils";
 import {hash} from "@chainsafe/ssz";
 
 export function isValidatorAggregator(slotSignature: BLSSignature, modulo: Number64): boolean {
-  return bytesToInt(hash(slotSignature.valueOf() as Uint8Array).slice(0, 8)) % modulo === 0;
+  return bytesToBigInt(hash(slotSignature.valueOf() as Uint8Array).slice(0, 8)) % BigInt(modulo) === BigInt(0);
+}
+
+export function getAggregatorModulo(config: IBeaconConfig, duty: AttesterDuty): number {
+  return Math.max(1, intDiv(duty.committeeLength, config.params.TARGET_AGGREGATORS_PER_COMMITTEE));
 }

--- a/packages/lodestar-validator/test/unit/services/utils.test.ts
+++ b/packages/lodestar-validator/test/unit/services/utils.test.ts
@@ -1,0 +1,13 @@
+import {getAggregationBits} from "../../../src/services/utils";
+import {expect} from "chai";
+
+describe("getAggregationBits", function () {
+  it("should return correct bits", function () {
+    const bits = getAggregationBits(4, 3);
+    expect(bits.length).to.be.equal(4);
+    expect(bits[3]).to.be.true;
+    expect(bits[0]).to.be.false;
+    expect(bits[1]).to.be.false;
+    expect(bits[2]).to.be.false;
+  });
+});

--- a/packages/lodestar-validator/test/unit/utils/aggregator.test.ts
+++ b/packages/lodestar-validator/test/unit/utils/aggregator.test.ts
@@ -1,0 +1,40 @@
+import {getAggregatorModulo, isValidatorAggregator} from "../../../src/util/aggregator";
+import {config} from "@chainsafe/lodestar-config/mainnet";
+import {expect} from "chai";
+import {Signature} from "@chainsafe/bls";
+
+describe("getAggregatorModulo", function () {
+  it("should produce correct result", function () {
+    const result = getAggregatorModulo(config, {
+      slot: 1,
+      committeeIndex: 2,
+      committeeLength: 130,
+      committeesAtSlot: 120,
+      validatorCommitteeIndex: 1,
+      validatorIndex: 0,
+      pubkey: Buffer.alloc(48),
+    });
+    expect(result).to.be.equal(8);
+  });
+});
+
+describe("isValidatorAggregator", function () {
+  it("should be false", function () {
+    const result = isValidatorAggregator(
+      Signature.fromHex(
+        "0x8191d16330837620f0ed85d0d3d52af5b56f7cec12658fa391814251d4b32977eb2e6ca055367354fd63175f8d1d2d7b0678c3c482b738f96a0df40bd06450d99c301a659b8396c227ed781abb37a1604297922219374772ab36b46b84817036"
+      ).toBytes(),
+      8
+    );
+    expect(result).to.be.equal(false);
+  });
+  it("should be true", function () {
+    const result = isValidatorAggregator(
+      Signature.fromHex(
+        "0xa8f8bb92931234ca6d8a34530526bcd6a4cfa3bf33bd0470200dc8fa3ebdc3ba24bc8c6e994d58a0f884eb24336d746c01a29693ed0354c0862c2d5de5859e3f58747045182844d267ba232058f7df1867a406f63a1eb8afec0cf3f00a115125"
+      ).toBytes(),
+      8
+    );
+    expect(result).to.be.equal(true);
+  });
+});


### PR DESCRIPTION
This could also be the reason for validator stressing beacon node since once you attach validator to lodestar beacon node it would subscribe, validate and aggregate attestations every epoch.