### PR TITLE
validator client: config api and application to voluntaryExit

### DIFF
--- a/packages/lodestar-cli/src/cmds/dev/utils/validator.ts
+++ b/packages/lodestar-cli/src/cmds/dev/utils/validator.ts
@@ -6,6 +6,7 @@ import {ApiClientOverRest} from "@chainsafe/lodestar-validator/lib/api/impl/rest
 import {NodeApi} from "@chainsafe/lodestar/lib/api/impl/node/node";
 import {Eth1ForBlockProductionDisabled} from "@chainsafe/lodestar/lib/eth1";
 import {IEventsApi} from "@chainsafe/lodestar-validator/lib/api/interface/events";
+import {ConfigApi} from "@chainsafe/lodestar/lib/api/impl/config";
 
 export function getValidatorApiClient(url: string, logger: ILogger, node: BeaconNode): IApiClient {
   if (url === "memory") {
@@ -15,6 +16,7 @@ export function getValidatorApiClient(url: string, logger: ILogger, node: Beacon
       node: new NodeApi({}, {...node}),
       beacon: new BeaconApi({}, {...node}),
       events: new EventsApi({}, {...node}) as IEventsApi,
+      configApi: new ConfigApi({}, {config: node.config}),
     });
   } else {
     return new ApiClientOverRest(node.config, url, logger);

--- a/packages/lodestar-validator/src/api/abstract.ts
+++ b/packages/lodestar-validator/src/api/abstract.ts
@@ -6,6 +6,7 @@ import {EventEmitter} from "events";
 import {pipeToEmitter} from "./impl/rest/events/util";
 import {ApiClientEventEmitter, IApiClient, IBeaconClock} from "./interface";
 import {IBeaconApi} from "./interface/beacon";
+import {IConfigApi} from "./interface/config";
 import {BeaconEvent, BeaconEventType, IEventsApi} from "./interface/events";
 import {INodeApi} from "./interface/node";
 import {IValidatorApi} from "./interface/validators";
@@ -32,6 +33,7 @@ export abstract class AbstractApiClient extends (EventEmitter as {new (): ApiCli
   abstract node: INodeApi;
   abstract events: IEventsApi;
   abstract validator: IValidatorApi;
+  abstract configApi: IConfigApi;
 
   protected constructor(config: IBeaconConfig, logger: ILogger) {
     super();

--- a/packages/lodestar-validator/src/api/impl/instance.ts
+++ b/packages/lodestar-validator/src/api/impl/instance.ts
@@ -5,6 +5,7 @@ import {IBeaconApi} from "../interface/beacon";
 import {INodeApi} from "../interface/node";
 import {WinstonLogger, ILogger} from "@chainsafe/lodestar-utils";
 import {IEventsApi} from "../interface/events";
+import {IConfigApi} from "../interface/config";
 
 export interface IApiClientOverInstanceOpts {
   config: IBeaconConfig;
@@ -13,6 +14,7 @@ export interface IApiClientOverInstanceOpts {
   events: IEventsApi;
   validator: IValidatorApi;
   logger?: ILogger;
+  configApi: IConfigApi;
 }
 
 export class ApiClientOverInstance extends AbstractApiClient {
@@ -26,12 +28,15 @@ export class ApiClientOverInstance extends AbstractApiClient {
 
   public validator: IValidatorApi;
 
+  public configApi: IConfigApi;
+
   public constructor(opts: IApiClientOverInstanceOpts) {
     super(opts.config, opts.logger || new WinstonLogger());
     this.beacon = opts.beacon;
     this.validator = opts.validator;
     this.events = opts.events;
     this.node = opts.node;
+    this.configApi = opts.configApi;
   }
 
   public async connect(): Promise<void> {

--- a/packages/lodestar-validator/src/api/impl/rest/apiClient.ts
+++ b/packages/lodestar-validator/src/api/impl/rest/apiClient.ts
@@ -9,12 +9,15 @@ import {RestNodeApi} from "./node/node";
 import {INodeApi} from "../../interface/node";
 import {RestEventsApi} from "./events/events";
 import {IEventsApi} from "../../interface/events";
+import {RestConfigApi} from "./config/config";
+import {IConfigApi} from "../../interface/config";
 
 export class ApiClientOverRest extends AbstractApiClient {
   public beacon: IBeaconApi;
   public node: INodeApi;
   public events: IEventsApi;
   public validator: IValidatorApi;
+  public configApi: IConfigApi;
 
   public url: string;
 
@@ -25,5 +28,6 @@ export class ApiClientOverRest extends AbstractApiClient {
     this.beacon = new RestBeaconApi(config, restUrl, logger);
     this.events = new RestEventsApi(config, restUrl);
     this.node = new RestNodeApi(config, restUrl, logger);
+    this.configApi = new RestConfigApi(config, restUrl, logger);
   }
 }

--- a/packages/lodestar-validator/src/api/impl/rest/config/config.ts
+++ b/packages/lodestar-validator/src/api/impl/rest/config/config.ts
@@ -1,0 +1,22 @@
+import {Fork} from "@chainsafe/lodestar-types";
+import {ILogger} from "@chainsafe/lodestar-utils";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {Json} from "@chainsafe/ssz";
+import {HttpClient, urlJoin} from "../../../../util";
+import {IConfigApi} from "../../../interface/config";
+
+export class RestConfigApi implements IConfigApi {
+  private readonly client: HttpClient;
+
+  private readonly config: IBeaconConfig;
+
+  public constructor(config: IBeaconConfig, restUrl: string, logger: ILogger) {
+    this.client = new HttpClient({urlPrefix: urlJoin(restUrl, "/eth/v1/config")}, {logger});
+    this.config = config;
+  }
+
+  public async getForkSchedule(): Promise<Fork[]> {
+    const data = (await this.client.get<{data: Json}>("/fork_schedule")).data as [];
+    return data.map((fork) => this.config.types.Fork.fromJson(fork));
+  }
+}

--- a/packages/lodestar-validator/src/api/impl/rest/index.ts
+++ b/packages/lodestar-validator/src/api/impl/rest/index.ts
@@ -1,2 +1,3 @@
 export * from "./beacon/beacon";
 export * from "./validator/validator";
+export * from "./config/config";

--- a/packages/lodestar-validator/src/api/interface.ts
+++ b/packages/lodestar-validator/src/api/interface.ts
@@ -6,6 +6,7 @@ import {EventEmitter} from "events";
 import {INodeApi} from "./interface/node";
 import {BeaconBlockEvent, BeaconChainReorgEvent, BeaconEventType, HeadEvent, IEventsApi} from "./interface/events";
 import {ClockEpochEvent, ClockEventType, ClockSlotEvent} from "./interface/clock";
+import {IConfigApi} from "./interface/config";
 
 export interface IApiClientEvents {
   beaconChainStarted: () => void;
@@ -25,6 +26,7 @@ export interface IBeaconClock {
 
 export interface IApiClient extends ApiClientEventEmitter {
   beacon: IBeaconApi;
+  configApi: IConfigApi;
   node: INodeApi;
   events: IEventsApi;
   validator: IValidatorApi;

--- a/packages/lodestar-validator/src/api/interface/config.ts
+++ b/packages/lodestar-validator/src/api/interface/config.ts
@@ -1,0 +1,5 @@
+import {Fork} from "@chainsafe/lodestar-types";
+
+export interface IConfigApi {
+  getForkSchedule(): Promise<Fork[]>;
+}

--- a/packages/lodestar-validator/src/validator.ts
+++ b/packages/lodestar-validator/src/validator.ts
@@ -94,7 +94,8 @@ export class Validator {
       validatorIndex: stateValidator.index,
     };
 
-    const fork = await this.apiClient.beacon.state.getFork("head");
+    const forkSchedule = await this.apiClient.configApi.getForkSchedule();
+    const fork = forkSchedule[0] || (await this.apiClient.beacon.state.getFork("head"));
     if (!fork) throw new Error("VoluntaryExit: Fork not found");
     const genesisValidatorsRoot = (await this.apiClient.beacon.getGenesis())?.genesisValidatorsRoot;
     const domain = computeDomain(this.config, DomainType.VOLUNTARY_EXIT, fork.currentVersion, genesisValidatorsRoot);

--- a/packages/lodestar-validator/test/unit/api/rcpClientOverInstance.test.ts
+++ b/packages/lodestar-validator/test/unit/api/rcpClientOverInstance.test.ts
@@ -10,6 +10,7 @@ import {MockNodeApi} from "../../utils/mocks/node";
 import {MockValidatorApi} from "../../utils/mocks/validator";
 import {silentLogger} from "../../utils/logger";
 import {ClockEventType} from "../../../src/api/interface/clock";
+import {MockConfigApi} from "../../utils/mocks/config";
 
 describe("RpcClientOverInstance test", function () {
   let clock: any, sandbox: any;
@@ -46,6 +47,7 @@ describe("RpcClientOverInstance test", function () {
       validator: new MockValidatorApi(),
       events,
       logger: silentLogger,
+      configApi: new MockConfigApi({config}),
     });
   }
 

--- a/packages/lodestar-validator/test/unit/validator.test.ts
+++ b/packages/lodestar-validator/test/unit/validator.test.ts
@@ -9,6 +9,7 @@ import {IValidatorOptions, SlashingProtection, Validator} from "../../src";
 import {MockNodeApi} from "../utils/mocks/node";
 import {silentLogger} from "../utils/logger";
 import {RestEventsApi} from "../../src/api/impl/rest/events/events";
+import {MockConfigApi} from "../utils/mocks/config";
 
 describe("Validator", () => {
   it.skip("Should be able to connect with the beacon chain", async () => {
@@ -20,6 +21,7 @@ describe("Validator", () => {
       node: new MockNodeApi(),
       events: sinon.createStubInstance(RestEventsApi),
       validator: new MockValidatorApi(),
+      configApi: new MockConfigApi({config}),
     });
 
     const secretKey = bls.SecretKey.fromKeygen();

--- a/packages/lodestar-validator/test/utils/apiStub.ts
+++ b/packages/lodestar-validator/test/utils/apiStub.ts
@@ -1,7 +1,7 @@
 import {EventEmitter} from "events";
 import sinon, {SinonSandbox, SinonStubbedInstance, SinonStubbedMember} from "sinon";
-import {IBeaconBlocksApi} from "../../lib/api/interface/beacon";
-import {ApiClientEventEmitter, IApiClient, RestValidatorApi} from "../../src/api";
+import {IBeaconBlocksApi} from "../../src/api/interface/beacon";
+import {ApiClientEventEmitter, IApiClient, RestConfigApi, RestValidatorApi} from "../../src/api";
 import {RestBeaconBlocksApi} from "../../src/api/impl/rest/beacon/blocks";
 import {RestBeaconStateApi} from "../../src/api/impl/rest/beacon/state";
 import {RestEventsApi} from "../../src/api/impl/rest/events/events";
@@ -12,6 +12,7 @@ import {INodeApi} from "../../src/api/interface/node";
 import {IValidatorApi} from "../../src/api/interface/validators";
 import {LocalClock} from "../../src/api/LocalClock";
 import {RestBeaconPoolApi} from "../../src/api/impl/rest/beacon/pool";
+import {IConfigApi} from "../../src/api/interface/config";
 
 class SinonStubbedBeaconApi implements IBeaconApi {
   public getGenesis: SinonStubbedMember<IBeaconApi["getGenesis"]>;
@@ -33,6 +34,7 @@ export class SinonStubbedApi extends (EventEmitter as {new (): ApiClientEventEmi
   validator: SinonStubbedInstance<IValidatorApi>;
   events: SinonStubbedInstance<IEventsApi>;
   clock: SinonStubbedInstance<LocalClock>;
+  configApi: SinonStubbedInstance<IConfigApi>;
   url!: string;
   genesisValidatorsRoot: import("@chainsafe/ssz").Vector<number>;
 
@@ -46,6 +48,7 @@ export class SinonStubbedApi extends (EventEmitter as {new (): ApiClientEventEmi
     this.node = sandbox.createStubInstance(RestNodeApi);
     this.validator = sandbox.createStubInstance(RestValidatorApi);
     this.events = sandbox.createStubInstance(RestEventsApi);
+    this.configApi = sandbox.createStubInstance(RestConfigApi);
     this.clock = sandbox.createStubInstance(LocalClock);
     this.genesisValidatorsRoot = Buffer.alloc(32, 0);
   }

--- a/packages/lodestar-validator/test/utils/mocks/config.ts
+++ b/packages/lodestar-validator/test/utils/mocks/config.ts
@@ -1,0 +1,32 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IBeaconParams} from "@chainsafe/lodestar-params";
+import {Contract, Fork} from "@chainsafe/lodestar-types";
+import {fromHex} from "@chainsafe/lodestar-utils";
+import {IConfigApi} from "../../../src/api/interface/config";
+
+export interface IMockConfigApiOpts {
+  config: IBeaconConfig;
+}
+
+export class MockConfigApi implements IConfigApi {
+  private readonly config: IBeaconConfig;
+
+  constructor(opts: IMockConfigApiOpts) {
+    this.config = opts.config;
+  }
+
+  public async getForkSchedule(): Promise<Fork[]> {
+    return [];
+  }
+
+  public async getDepositContract(): Promise<Contract> {
+    return {
+      chainId: 0,
+      address: fromHex("0x1234567890123456789012345678901234567890"),
+    } as Contract;
+  }
+
+  public async getSpec(): Promise<IBeaconParams> {
+    return this.config.params;
+  }
+}

--- a/packages/lodestar-validator/test/utils/mocks/config.ts
+++ b/packages/lodestar-validator/test/utils/mocks/config.ts
@@ -22,7 +22,7 @@ export class MockConfigApi implements IConfigApi {
     return {
       chainId: this.config.params.DEPOSIT_CHAIN_ID,
       address: this.config.params.DEPOSIT_CONTRACT_ADDRESS,
-    } as Contract;
+    };
   }
 
   public async getSpec(): Promise<IBeaconParams> {

--- a/packages/lodestar-validator/test/utils/mocks/config.ts
+++ b/packages/lodestar-validator/test/utils/mocks/config.ts
@@ -1,7 +1,6 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBeaconParams} from "@chainsafe/lodestar-params";
 import {Contract, Fork} from "@chainsafe/lodestar-types";
-import {fromHex} from "@chainsafe/lodestar-utils";
 import {IConfigApi} from "../../../src/api/interface/config";
 
 export interface IMockConfigApiOpts {
@@ -21,8 +20,8 @@ export class MockConfigApi implements IConfigApi {
 
   public async getDepositContract(): Promise<Contract> {
     return {
-      chainId: 0,
-      address: fromHex("0x1234567890123456789012345678901234567890"),
+      chainId: this.config.params.DEPOSIT_CHAIN_ID,
+      address: this.config.params.DEPOSIT_CONTRACT_ADDRESS,
     } as Contract;
   }
 

--- a/packages/lodestar/test/utils/node/validator.ts
+++ b/packages/lodestar/test/utils/node/validator.ts
@@ -10,6 +10,7 @@ import {NodeApi} from "../../../src/api/impl/node/node";
 import {ValidatorApi} from "../../../src/api/impl/validator";
 import {Eth1ForBlockProductionDisabled} from "../../../src/eth1";
 import {BeaconNode} from "../../../src/node";
+import {ConfigApi} from "../../../src/api/impl/config";
 
 export function getDevValidators(
   node: BeaconNode,
@@ -93,5 +94,6 @@ export function getDevValidatorInstanceApiClient(node: BeaconNode, logger: ILogg
     node: new NodeApi({}, {...node}),
     events: new EventsApi({}, {...node}) as IEventsApi,
     beacon: new BeaconApi({}, {...node}),
+    configApi: new ConfigApi({}, {config: node.config}),
   });
 }


### PR DESCRIPTION
created the config api for the validator client and applied the `getForkSchedule` config api call to the voluntaryExit as specified here: https://github.com/ChainSafe/lodestar/pull/1986#discussion_r572670430