### PR TITLE
Fix block ordering in getUnfinalizedBlocksAtSlots

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -210,16 +210,23 @@ export class BeaconChain implements IBeaconChain {
     }
   }
 
-  public async getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<SignedBeaconBlock[] | null> {
-    if (!slots) {
-      return null;
+  /** Returned blocks have the same ordering as `slots` */
+  public async getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<SignedBeaconBlock[]> {
+    if (slots.length === 0) {
+      return [];
     }
-    const blockRoots = this.forkChoice
-      .iterateBlockSummaries(this.forkChoice.getHeadRoot())
-      .filter((summary) => slots.includes(summary.slot))
-      .map((summary) => summary.blockRoot);
+
+    const slotsSet = new Set(slots);
+    const blockRootsPerSlot = new Map<Slot, Promise<SignedBeaconBlock | null>>();
+
     // these blocks are on the same chain to head
-    const unfinalizedBlocks = await Promise.all(blockRoots.map((blockRoot) => this.db.block.get(blockRoot)));
+    for (const summary of this.forkChoice.iterateBlockSummaries(this.forkChoice.getHeadRoot())) {
+      if (slotsSet.has(summary.slot)) {
+        blockRootsPerSlot.set(summary.slot, this.db.block.get(summary.blockRoot));
+      }
+    }
+
+    const unfinalizedBlocks = await Promise.all(slots.map((slot) => blockRootsPerSlot.get(slot)));
     return unfinalizedBlocks.filter(notNullish);
   }
 

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -111,7 +111,7 @@ export interface IBeaconChain {
    */
   getCanonicalBlockAtSlot(slot: Slot): Promise<SignedBeaconBlock | null>;
 
-  getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<SignedBeaconBlock[] | null>;
+  getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<SignedBeaconBlock[]>;
 
   /**
    * Add attestation to the fork-choice rule

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -122,7 +122,7 @@ export class MockBeaconChain implements IBeaconChain {
     return this.getHeadStateContext().state.getOriginalState() as TreeBacked<BeaconState>;
   }
 
-  public async getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<SignedBeaconBlock[] | null> {
+  public async getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<SignedBeaconBlock[]> {
     if (!slots) {
       return [];
     }


### PR DESCRIPTION
Forkchoice iterates summaries in descending order, but ReqResp needs the blocks in ascending order.