### PR TITLE
Process prepareBeaconCommittee req as array

### DIFF
--- a/packages/lodestar-validator/src/api/impl/rest/validator/validator.ts
+++ b/packages/lodestar-validator/src/api/impl/rest/validator/validator.ts
@@ -16,7 +16,7 @@ import {
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {Json, toHexString} from "@chainsafe/ssz";
 import {HttpClient, urlJoin} from "../../../../util";
-import {IValidatorApi} from "../../../interface/validators";
+import {BeaconCommitteeSubscription, IValidatorApi} from "../../../interface/validators";
 
 /**
  * Rest API class for fetching and performing validator duties
@@ -75,21 +75,7 @@ export class RestValidatorApi implements IValidatorApi {
     );
   }
 
-  public async prepareBeaconCommitteeSubnet(
-    validatorIndex: ValidatorIndex,
-    committeeIndex: CommitteeIndex,
-    committeesAtSlot: number,
-    slot: Slot,
-    isAggregator: boolean
-  ): Promise<void> {
-    return await this.clientV2.post<Json[], void>("/beacon_committee_subscriptions", [
-      {
-        validator_index: validatorIndex,
-        committee_index: committeeIndex,
-        committees_at_slot: committeesAtSlot,
-        slot,
-        is_aggregator: isAggregator,
-      },
-    ]);
+  public async prepareBeaconCommitteeSubnet(subscriptions: BeaconCommitteeSubscription[]): Promise<void> {
+    return await this.clientV2.post<Json[], void>("/beacon_committee_subscriptions", [subscriptions]);
   }
 }

--- a/packages/lodestar-validator/src/api/interface/validators.ts
+++ b/packages/lodestar-validator/src/api/interface/validators.ts
@@ -13,6 +13,14 @@ import {
   ValidatorIndex,
 } from "@chainsafe/lodestar-types";
 
+export type BeaconCommitteeSubscription = {
+  validatorIndex: number;
+  committeeIndex: number;
+  committeesAtSlot: number;
+  slot: number;
+  isAggregator: boolean;
+};
+
 export interface IValidatorApi {
   getProposerDuties(epoch: Epoch, validatorPubKeys: BLSPubkey[]): Promise<ProposerDuty[]>;
 
@@ -31,11 +39,5 @@ export interface IValidatorApi {
 
   publishAggregateAndProofs(signedAggregateAndProofs: SignedAggregateAndProof[]): Promise<void>;
 
-  prepareBeaconCommitteeSubnet(
-    validatorIndex: ValidatorIndex,
-    committeeIndex: CommitteeIndex,
-    committeesAtSlot: number,
-    slot: Slot,
-    isAggregator: boolean
-  ): Promise<void>;
+  prepareBeaconCommitteeSubnet(subscriptions: BeaconCommitteeSubscription[]): Promise<void>;
 }

--- a/packages/lodestar-validator/src/services/attestation.ts
+++ b/packages/lodestar-validator/src/services/attestation.ts
@@ -160,13 +160,15 @@ export class AttestationService {
       }
       attesterDuties.set(toHexString(duty.pubkey), nextDuty);
       try {
-        await this.provider.validator.prepareBeaconCommitteeSubnet(
-          nextDuty.validatorIndex,
-          nextDuty.committeeIndex,
-          nextDuty.committeesAtSlot,
-          nextDuty.slot,
-          isAggregator
-        );
+        await this.provider.validator.prepareBeaconCommitteeSubnet([
+          {
+            validatorIndex: nextDuty.validatorIndex,
+            committeeIndex: nextDuty.committeeIndex,
+            committeesAtSlot: nextDuty.committeesAtSlot,
+            slot: nextDuty.slot,
+            isAggregator,
+          },
+        ]);
       } catch (e) {
         this.logger.error("Failed to subscribe to committee subnet", e);
       }

--- a/packages/lodestar-validator/test/utils/mocks/validator.ts
+++ b/packages/lodestar-validator/test/utils/mocks/validator.ts
@@ -15,7 +15,7 @@ import {
   ValidatorIndex,
 } from "@chainsafe/lodestar-types";
 import {generateEmptyBlock} from "@chainsafe/lodestar/test/utils/block";
-import {IValidatorApi} from "../../../src/api/interface/validators";
+import {BeaconCommitteeSubscription, IValidatorApi} from "../../../src/api/interface/validators";
 
 export interface IMockValidatorAPIOpts {
   head?: SignedBeaconBlock;
@@ -51,13 +51,7 @@ export class MockValidatorApi implements IValidatorApi {
   publishAggregateAndProofs(signedAggregateAndProofs: SignedAggregateAndProof[]): Promise<void> {
     throw new Error("Method not implemented.");
   }
-  prepareBeaconCommitteeSubnet(
-    validatorIndex: number,
-    committeeIndex: number,
-    committeesAtSlot: number,
-    slot: number,
-    isAggregator: boolean
-  ): Promise<void> {
+  prepareBeaconCommitteeSubnet(subscriptions: BeaconCommitteeSubscription[]): Promise<void> {
     throw new Error("Method not implemented.");
   }
 

--- a/packages/lodestar/src/api/impl/validator/interface.ts
+++ b/packages/lodestar/src/api/impl/validator/interface.ts
@@ -16,6 +16,14 @@ import {
   ValidatorIndex,
 } from "@chainsafe/lodestar-types";
 
+export type BeaconCommitteeSubscription = {
+  validatorIndex: number;
+  committeeIndex: number;
+  committeesAtSlot: number;
+  slot: number;
+  isAggregator: boolean;
+};
+
 /**
  * The API interface defines the calls that can be made from a Validator
  */
@@ -37,11 +45,5 @@ export interface IValidatorApi {
 
   publishAggregateAndProofs(signedAggregateAndProofs: SignedAggregateAndProof[]): Promise<void>;
 
-  prepareBeaconCommitteeSubnet(
-    validatorIndex: ValidatorIndex,
-    committeeIndex: CommitteeIndex,
-    committeesAtSlot: number,
-    slot: Slot,
-    isAggregator: boolean
-  ): Promise<void>;
+  prepareBeaconCommitteeSubnet(subscriptions: BeaconCommitteeSubscription[]): Promise<void>;
 }

--- a/packages/lodestar/src/api/rest/controllers/validator/prepareCommitteeSubnet.ts
+++ b/packages/lodestar/src/api/rest/controllers/validator/prepareCommitteeSubnet.ts
@@ -16,17 +16,16 @@ export const prepareCommitteeSubnet: ApiController<DefaultQuery, DefaultParams, 
   url: "/beacon_committee_subscriptions",
 
   handler: async function (req, resp) {
-    await Promise.all(
-      req.body.map(async (committeeSubnetRequest) => {
-        return this.api.validator.prepareBeaconCommitteeSubnet(
-          committeeSubnetRequest.validator_index,
-          committeeSubnetRequest.committee_index,
-          committeeSubnetRequest.committees_at_slot,
-          committeeSubnetRequest.slot,
-          committeeSubnetRequest.is_aggregator
-        );
-      })
+    await this.api.validator.prepareBeaconCommitteeSubnet(
+      req.body.map((item) => ({
+        validatorIndex: item.validator_index,
+        committeeIndex: item.committee_index,
+        committeesAtSlot: item.committees_at_slot,
+        slot: item.slot,
+        isAggregator: item.is_aggregator,
+      }))
     );
+
     resp.status(200).send();
   },
 

--- a/packages/lodestar/test/unit/api/rest/validator/prepareCommitteeSubnet.test.ts
+++ b/packages/lodestar/test/unit/api/rest/validator/prepareCommitteeSubnet.test.ts
@@ -52,7 +52,17 @@ describe("rest - validator - prepareCommitteeSubnet", function () {
         },
       ])
       .expect(200);
-    expect(api.validator.prepareBeaconCommitteeSubnet.withArgs(1, 2, 64, 0, false).calledOnce).to.be.true;
+    expect(
+      api.validator.prepareBeaconCommitteeSubnet.withArgs([
+        {
+          validatorIndex: 1,
+          committeeIndex: 2,
+          committeesAtSlot: 64,
+          slot: 0,
+          isAggregator: false,
+        },
+      ]).calledOnce
+    ).to.be.true;
   });
 
   it("missing param", async function () {


### PR DESCRIPTION
Allows to send multiple subscriptions at once with the JS API. Strongly type items instead of having a fn signature of (number, number, number)