### PR TITLE
ReqResp does not return null in any case

### DIFF
--- a/packages/lodestar/src/network/interface.ts
+++ b/packages/lodestar/src/network/interface.ts
@@ -23,12 +23,12 @@ import {IRpcScoreTracker} from "./peers/score";
 import {ReqRespHandler} from "./reqresp";
 
 export interface IReqResp {
-  status(peerId: PeerId, request: Status): Promise<Status | null>;
+  status(peerId: PeerId, request: Status): Promise<Status>;
   goodbye(peerId: PeerId, request: Goodbye): Promise<void>;
-  ping(peerId: PeerId, request: Ping): Promise<Ping | null>;
-  metadata(peerId: PeerId): Promise<Metadata | null>;
-  beaconBlocksByRange(peerId: PeerId, request: BeaconBlocksByRangeRequest): Promise<SignedBeaconBlock[] | null>;
-  beaconBlocksByRoot(peerId: PeerId, request: BeaconBlocksByRootRequest): Promise<SignedBeaconBlock[] | null>;
+  ping(peerId: PeerId, request: Ping): Promise<Ping>;
+  metadata(peerId: PeerId): Promise<Metadata>;
+  beaconBlocksByRange(peerId: PeerId, request: BeaconBlocksByRangeRequest): Promise<SignedBeaconBlock[]>;
+  beaconBlocksByRoot(peerId: PeerId, request: BeaconBlocksByRootRequest): Promise<SignedBeaconBlock[]>;
   registerHandler(handler: ReqRespHandler): void;
   unregisterHandler(): ReqRespHandler | null;
 }

--- a/packages/lodestar/src/network/reqresp/reqResp.ts
+++ b/packages/lodestar/src/network/reqresp/reqResp.ts
@@ -125,7 +125,7 @@ export class ReqResp implements IReqResp {
     this.controller?.abort();
   }
 
-  public async status(peerId: PeerId, request: Status): Promise<Status | null> {
+  public async status(peerId: PeerId, request: Status): Promise<Status> {
     return await this.sendRequest<Status>(peerId, Method.Status, request);
   }
 
@@ -133,25 +133,19 @@ export class ReqResp implements IReqResp {
     await this.sendRequest<Goodbye>(peerId, Method.Goodbye, request);
   }
 
-  public async ping(peerId: PeerId, request: Ping): Promise<Ping | null> {
+  public async ping(peerId: PeerId, request: Ping): Promise<Ping> {
     return await this.sendRequest<Ping>(peerId, Method.Ping, request);
   }
 
-  public async metadata(peerId: PeerId): Promise<Metadata | null> {
+  public async metadata(peerId: PeerId): Promise<Metadata> {
     return await this.sendRequest<Metadata>(peerId, Method.Metadata, null);
   }
 
-  public async beaconBlocksByRange(
-    peerId: PeerId,
-    request: BeaconBlocksByRangeRequest
-  ): Promise<SignedBeaconBlock[] | null> {
+  public async beaconBlocksByRange(peerId: PeerId, request: BeaconBlocksByRangeRequest): Promise<SignedBeaconBlock[]> {
     return await this.sendRequest<SignedBeaconBlock[]>(peerId, Method.BeaconBlocksByRange, request, request.count);
   }
 
-  public async beaconBlocksByRoot(
-    peerId: PeerId,
-    request: BeaconBlocksByRootRequest
-  ): Promise<SignedBeaconBlock[] | null> {
+  public async beaconBlocksByRoot(peerId: PeerId, request: BeaconBlocksByRootRequest): Promise<SignedBeaconBlock[]> {
     return await this.sendRequest<SignedBeaconBlock[]>(peerId, Method.BeaconBlocksByRoot, request, request.length);
   }
 
@@ -161,7 +155,7 @@ export class ReqResp implements IReqResp {
     method: Method,
     body: RequestBody,
     maxResponses?: number
-  ): Promise<T | null> {
+  ): Promise<T> {
     try {
       const encoding = this.peerMetadata.getEncoding(peerId) ?? ReqRespEncoding.SSZ_SNAPPY;
       const result = await sendRequest<T>(

--- a/packages/lodestar/src/network/reqresp/request/collectResponses.ts
+++ b/packages/lodestar/src/network/reqresp/request/collectResponses.ts
@@ -1,6 +1,7 @@
 import {ResponseBody} from "@chainsafe/lodestar-types";
 import {Method} from "../../../constants";
 import {isRequestSingleChunk} from "../../util";
+import {RequestErrorCode, RequestInternalError} from "./errors";
 
 /**
  * Sink for `<response_chunk>*`, from
@@ -12,13 +13,13 @@ import {isRequestSingleChunk} from "../../util";
 export function collectResponses<T extends ResponseBody | ResponseBody[]>(
   method: Method,
   maxResponses?: number
-): (source: AsyncIterable<ResponseBody>) => Promise<T | null> {
+): (source: AsyncIterable<ResponseBody>) => Promise<T> {
   return async (source) => {
     if (isRequestSingleChunk(method)) {
       for await (const response of source) {
         return response as T;
       }
-      return null;
+      throw new RequestInternalError({code: RequestErrorCode.EMPTY_RESPONSE});
     }
 
     // else: zero or more responses

--- a/packages/lodestar/src/network/reqresp/request/errors.ts
+++ b/packages/lodestar/src/network/reqresp/request/errors.ts
@@ -18,6 +18,8 @@ export enum RequestErrorCode {
   REQUEST_TIMEOUT = "REQUEST_ERROR_REQUEST_TIMEOUT",
   /** Error when sending request to responder */
   REQUEST_ERROR = "REQUEST_ERROR_REQUEST_ERROR",
+  /** A single-response method returned 0 chunks */
+  EMPTY_RESPONSE = "REQUEST_ERROR_EMPTY_RESPONSE",
   /** Time to first byte timeout */
   TTFB_TIMEOUT = "REQUEST_ERROR_TTFB_TIMEOUT",
   /** Timeout between `<response_chunk>` exceed */
@@ -32,6 +34,7 @@ type RequestErrorType =
   | {code: RequestErrorCode.DIAL_ERROR; error: Error}
   | {code: RequestErrorCode.REQUEST_TIMEOUT}
   | {code: RequestErrorCode.REQUEST_ERROR; error: Error}
+  | {code: RequestErrorCode.EMPTY_RESPONSE}
   | {code: RequestErrorCode.TTFB_TIMEOUT}
   | {code: RequestErrorCode.RESP_TIMEOUT};
 

--- a/packages/lodestar/src/network/reqresp/request/index.ts
+++ b/packages/lodestar/src/network/reqresp/request/index.ts
@@ -43,7 +43,7 @@ export async function sendRequest<T extends ResponseBody | ResponseBody[]>(
   maxResponses?: number,
   signal?: AbortSignal,
   options?: Partial<typeof timeoutOptions>
-): Promise<T | null> {
+): Promise<T> {
   const {REQUEST_TIMEOUT, DIAL_TIMEOUT} = {...timeoutOptions, ...options};
   const peer = peerId.toB58String();
   const logCtx = {method, encoding, peer, requestId: randomRequestId()};

--- a/packages/lodestar/src/network/tasks/checkPeerAliveTask.ts
+++ b/packages/lodestar/src/network/tasks/checkPeerAliveTask.ts
@@ -46,10 +46,9 @@ export class CheckPeerAliveTask {
     const seq = this.network.metadata.seqNumber;
     await Promise.all(
       peers.map(async (peer) => {
-        let peerSeq: BigInt | null = null;
+        let peerSeq: BigInt;
         try {
           peerSeq = await this.network.reqResp.ping(peer, seq);
-          if (peerSeq === null) throw new Error("ping method return null for peer " + peer.toB58String());
         } catch (e) {
           this.logger.warn("Cannot ping peer, disconnecting it", {peerId: peer.toB58String(), error: e.message});
           // a peer may still be good for gossip blocks even it does not response to ping

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -153,8 +153,8 @@ export class BeaconSync implements IBeaconSync {
 
   private downloadBeaconBlocksByRange: DownloadBeaconBlocksByRange = async (peerId, request) => {
     const blocks = await this.network.reqResp.beaconBlocksByRange(peerId, request);
-    assertSequentialBlocksInRange(blocks || [], request);
-    return blocks || [];
+    assertSequentialBlocksInRange(blocks, request);
+    return blocks;
   };
 
   private getPeersAndTargetEpoch: GetPeersAndTargetEpoch = () => {
@@ -252,7 +252,7 @@ export class BeaconSync implements IBeaconSync {
       }
       try {
         const blocks = await this.network.reqResp.beaconBlocksByRoot(peer, [unknownAncestorRoot] as List<Root>);
-        if (blocks && blocks[0]) {
+        if (blocks[0]) {
           this.logger.verbose("Found block for root", {slot: blocks[0].message.slot, blockRoot: missingRootHex});
           found = true;
           await this.chain.receiveBlock(blocks[0]);

--- a/packages/lodestar/src/sync/utils/blocks.ts
+++ b/packages/lodestar/src/sync/utils/blocks.ts
@@ -32,7 +32,7 @@ export async function getBlockRangeFromPeer(
   rpc: IReqResp,
   peer: PeerId,
   chunk: ISlotRange
-): Promise<SignedBeaconBlock[] | null> {
+): Promise<SignedBeaconBlock[]> {
   return await rpc.beaconBlocksByRange(peer, {
     startSlot: chunk.start,
     step: 1,

--- a/packages/lodestar/test/e2e/network/reqresp.test.ts
+++ b/packages/lodestar/test/e2e/network/reqresp.test.ts
@@ -91,7 +91,7 @@ describe("[network] network", function () {
     });
 
     const pingRes = await netA.reqResp.ping(netB.peerId, pingBody);
-    expect(pingRes?.toString()).to.deep.equal(pingBody.toString(), "Wrong response body");
+    expect(pingRes.toString()).to.deep.equal(pingBody.toString(), "Wrong response body");
   });
 
   it("should send/receive a metadata message", async function () {

--- a/packages/lodestar/test/e2e/sync/reqResp.test.ts
+++ b/packages/lodestar/test/e2e/sync/reqResp.test.ts
@@ -195,7 +195,6 @@ describe("[sync] rpc", function () {
     const request = [Buffer.alloc(32)] as BeaconBlocksByRootRequest;
     await netA.connect(netB.peerId, netB.localMultiaddrs);
     const response = await netA.reqResp.beaconBlocksByRoot(netB.peerId, request);
-    if (!response) throw Error("beaconBlocksByRoot returned null");
     expect(response.length).to.equal(1);
     const block = response[0];
     expect(block.message.slot).to.equal(BLOCK_SLOT);

--- a/packages/lodestar/test/unit/network/tasks/checkPeerAliveTask.test.ts
+++ b/packages/lodestar/test/unit/network/tasks/checkPeerAliveTask.test.ts
@@ -47,14 +47,6 @@ describe("CheckPeerAliveTask", function () {
     expect(reqRespStub.metadata.called).to.be.false;
   });
 
-  it("ping returns null, should disconnect", async () => {
-    reqRespStub.ping.resolves(null);
-    await task.run();
-
-    // expect(networkStub.disconnect.calledOnce).to.be.true;
-    expect(reqRespStub.metadata.called).to.be.false;
-  });
-
   it("ping successfully, return same sequence number", async () => {
     reqRespStub.ping.resolves(BigInt(1));
     peerMetadataStub.getMetadata.withArgs(peerId).returns({

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
@@ -113,27 +113,6 @@ describe("BlockRangeFetcher", function () {
     expect(getPeers.calledWithExactly([firstPeerId.toB58String()])).to.be.true;
   });
 
-  it("should handle getBlockRange returning null", async () => {
-    // should switch peer
-    const firstPeerId = await PeerId.create();
-    getPeers.onFirstCall().resolves([firstPeerId]);
-    fetcher.setLastProcessedBlock({root: ZERO_HASH, slot: 1000});
-    getCurrentSlotStub.returns(2000);
-    getBlockRangeStub.onFirstCall().resolves(null);
-    const firstBlock = generateEmptySignedBlock();
-    firstBlock.message.slot = 1010;
-    const secondBlock = generateEmptySignedBlock();
-    secondBlock.message.slot = 1020;
-    secondBlock.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(firstBlock.message);
-    getBlockRangeStub.onSecondCall().resolves([firstBlock, secondBlock]);
-    const result = await fetcher.getNextBlockRange();
-    expect(getBlockRangeStub.calledWith(logger, sinon.match.any, sinon.match.any, {start: 1000, end: 1065})).to.be.true;
-    expect(getBlockRangeStub.calledTwice).to.be.true;
-    // second block is ignored since we can't validate if it's orphaned block or not
-    expect(result).to.be.deep.equal([firstBlock]);
-    expect(getPeers.calledWithExactly([firstPeerId.toB58String()])).to.be.true;
-  });
-
   it("should handle getBlockRange returning no block or single block", async () => {
     // expect 2 things
     // switch peer since some weird peers keep returning 0 block or 1 block

--- a/packages/lodestar/test/unit/sync/utils/block.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/block.test.ts
@@ -43,7 +43,7 @@ describe("sync - block utils", function () {
       const peer1 = await PeerId.create();
       const peer2 = await PeerId.create();
       const peers = [peer1, peer2];
-      rpcStub.beaconBlocksByRange.onFirstCall().resolves(null);
+      rpcStub.beaconBlocksByRange.onFirstCall().rejects(Error("TEST_ERROR"));
       rpcStub.beaconBlocksByRange.onSecondCall().resolves([generateEmptySignedBlock(), generateEmptySignedBlock()]);
       const blockPromise = getBlockRange(logger, rpcStub, peers, {start: 0, end: 4}, 2);
       await sandbox.clock.tickAsync(1000);


### PR DESCRIPTION
reqResp request never returns null. For protocols with multiple responses, returns an array possibly empty. For single response protocols, returns 1 response or throw an error. Current types added unnecessary complexity for an out-of-spec situation