### PR TITLE
Abstract assertPeerRelevance function

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -20,11 +20,12 @@ import {
   Root,
   SignedBeaconBlock,
   Slot,
+  Status,
 } from "@chainsafe/lodestar-types";
 import {ILogger, intToBytes} from "@chainsafe/lodestar-utils";
 import {TreeBacked} from "@chainsafe/ssz";
 import {AbortController} from "abort-controller";
-import {FAR_FUTURE_EPOCH} from "../constants";
+import {FAR_FUTURE_EPOCH, GENESIS_EPOCH, ZERO_HASH} from "../constants";
 import {IBeaconDb} from "../db";
 import {CheckpointStateCache, StateContextCache} from "./stateCache";
 import {IBeaconMetrics} from "../metrics";
@@ -284,6 +285,18 @@ export class BeaconChain implements IBeaconChain {
         ? intToBytes(nextVersion.currentVersion, 4)
         : (currentVersion.valueOf() as Uint8Array),
       nextForkEpoch: nextVersion ? nextVersion.epoch : FAR_FUTURE_EPOCH,
+    };
+  }
+
+  public getStatus(): Status {
+    const head = this.forkChoice.getHead();
+    const finalizedCheckpoint = this.forkChoice.getFinalizedCheckpoint();
+    return {
+      forkDigest: this.getForkDigest(),
+      finalizedRoot: finalizedCheckpoint.epoch === GENESIS_EPOCH ? ZERO_HASH : finalizedCheckpoint.root,
+      finalizedEpoch: finalizedCheckpoint.epoch,
+      headRoot: head.blockRoot,
+      headSlot: head.slot,
     };
   }
 }

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -8,6 +8,7 @@ import {
   Root,
   SignedBeaconBlock,
   Slot,
+  Status,
 } from "@chainsafe/lodestar-types";
 import {TreeBacked} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
@@ -93,6 +94,7 @@ export interface IBeaconChain {
    */
   getENRForkID(): ENRForkID;
   getGenesisTime(): Number64;
+  getStatus(): Status;
 
   getHeadStateContextAtCurrentEpoch(): Promise<ITreeStateContext>;
   getHeadStateContextAtCurrentSlot(): Promise<ITreeStateContext>;

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -2,7 +2,7 @@
  * @module sync
  */
 
-import {computeStartSlotAtEpoch, GENESIS_SLOT, getBlockRootAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {GENESIS_SLOT} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {
   BeaconBlocksByRangeRequest,
@@ -16,17 +16,17 @@ import {
   SignedBeaconBlock,
   Status,
 } from "@chainsafe/lodestar-types";
-import {ILogger} from "@chainsafe/lodestar-utils";
-import {toHexString} from "@chainsafe/ssz";
+import {ILogger, LodestarError} from "@chainsafe/lodestar-utils";
 import PeerId from "peer-id";
 import {IBeaconChain} from "../../chain";
-import {GENESIS_EPOCH, Method, ReqRespEncoding, RpcResponseStatus, ZERO_HASH} from "../../constants";
+import {Method, ReqRespEncoding, RpcResponseStatus} from "../../constants";
 import {IBeaconDb} from "../../db";
 import {IBlockFilterOptions} from "../../db/api/beacon/repositories";
 import {createRpcProtocol, INetwork, NetworkEvent} from "../../network";
 import {ResponseError} from "../../network/reqresp/response";
 import {handlePeerMetadataSequence} from "../../network/peers/utils";
-import {createStatus, syncPeersStatus} from "../utils/sync";
+import {syncPeersStatus} from "../utils/sync";
+import {assertPeerRelevance} from "../utils/assertPeerRelevance";
 import {IReqRespHandler} from "./interface";
 
 export interface IReqRespHandlerModules {
@@ -81,7 +81,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
   public async start(): Promise<void> {
     this.network.reqResp.registerHandler(this.onRequest.bind(this));
     this.network.on(NetworkEvent.peerConnect, this.handshake);
-    const myStatus = await createStatus(this.chain);
+    const myStatus = this.chain.getStatus();
     await syncPeersStatus(this.network, myStatus);
   }
 
@@ -126,89 +126,23 @@ export class BeaconReqRespHandler implements IReqRespHandler {
     }
   }
 
-  // Must be public for testing
-  async shouldDisconnectOnStatus(request: Status): Promise<boolean> {
-    const currentForkDigest = this.chain.getForkDigest();
-    if (!this.config.types.ForkDigest.equals(currentForkDigest, request.forkDigest)) {
-      this.logger.verbose("Fork digest mismatch", {
-        expected: toHexString(currentForkDigest),
-        received: toHexString(request.forkDigest),
+  private async *onStatus(status: Status, peerId: PeerId): AsyncIterable<Status> {
+    try {
+      await assertPeerRelevance(status, this.chain, this.config);
+    } catch (e) {
+      this.logger.debug("Irrelevant peer", {
+        peer: peerId.toB58String(),
+        reason: e instanceof LodestarError ? e.getMetadata() : e.message,
       });
-      return true;
-    }
-    if (request.finalizedEpoch === GENESIS_EPOCH) {
-      if (!this.config.types.Root.equals(request.finalizedRoot, ZERO_HASH)) {
-        this.logger.verbose("Genesis finalized root must be zeroed", {
-          expected: toHexString(ZERO_HASH),
-          received: toHexString(request.finalizedRoot),
-        });
-        return true;
-      }
-    } else {
-      // we're on a further (or equal) finalized epoch
-      // but the peer's block root at that epoch may not match match ours
-      const headSummary = this.chain.forkChoice.getHead();
-      const finalizedCheckpoint = this.chain.forkChoice.getFinalizedCheckpoint();
-      const requestFinalizedSlot = computeStartSlotAtEpoch(this.config, request.finalizedEpoch);
-
-      if (request.finalizedEpoch === finalizedCheckpoint.epoch) {
-        if (!this.config.types.Root.equals(request.finalizedRoot, finalizedCheckpoint.root)) {
-          this.logger.verbose("Status with same finalized epoch has different root", {
-            expected: toHexString(finalizedCheckpoint.root),
-            received: toHexString(request.finalizedRoot),
-          });
-          return true;
-        }
-      } else if (request.finalizedEpoch < finalizedCheckpoint.epoch) {
-        // If it is within recent history, we can directly check against the block roots in the state
-        if (headSummary.slot - requestFinalizedSlot < this.config.params.SLOTS_PER_HISTORICAL_ROOT) {
-          const headState = this.chain.getHeadState();
-          // This will get the latest known block at the start of the epoch.
-          const expected = getBlockRootAtSlot(this.config, headState, requestFinalizedSlot);
-          if (!this.config.types.Root.equals(request.finalizedRoot, expected)) {
-            this.logger.verbose("Status with different finalized root", {
-              received: toHexString(request.finalizedRoot),
-              epected: toHexString(expected),
-              epoch: request.finalizedEpoch,
-            });
-            return true;
-          }
-        } else {
-          // finalized checkpoint of status is from an old long-ago epoch.
-          // We need to ask the chain for most recent canonical block at the finalized checkpoint start slot.
-          // The problem is that the slot may be a skip slot.
-          // And the block root may be from multiple epochs back even.
-          // The epoch in the checkpoint is there to checkpoint the tail end of skip slots, even if there is no block.
-          // TODO: accepted for now. Need to maintain either a list of finalized block roots,
-          // or inefficiently loop from finalized slot backwards, until we find the block we need to check against.
-          return false;
-        }
-      } else {
-        // request status finalized checkpoint is in the future, we do not know if it is a true finalized root
-        this.logger.verbose("Status with future finalized epoch", {
-          finalizedEpoch: request.finalizedEpoch,
-          finalizedRoot: toHexString(request.finalizedRoot),
-        });
-      }
-    }
-    return false;
-  }
-
-  private async *onStatus(requestBody: Status, peerId: PeerId): AsyncIterable<Status> {
-    if (await this.shouldDisconnectOnStatus(requestBody)) {
-      try {
-        await this.network.reqResp.goodbye(peerId, BigInt(GoodByeReasonCode.IRRELEVANT_NETWORK));
-      } catch {
-        // ignore error
-        return;
-      }
+      await this.network.reqResp.goodbye(peerId, BigInt(GoodByeReasonCode.IRRELEVANT_NETWORK));
+      return;
     }
 
     // set status on peer
-    this.network.peerMetadata.setStatus(peerId, requestBody);
+    this.network.peerMetadata.setStatus(peerId, status);
 
     // send status response
-    yield await createStatus(this.chain);
+    yield this.chain.getStatus();
   }
 
   private async *onGoodbye(requestBody: Goodbye, peerId: PeerId): AsyncIterable<bigint> {
@@ -275,7 +209,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
 
   private handshake = async (peerId: PeerId, direction: "inbound" | "outbound"): Promise<void> => {
     if (direction === "outbound") {
-      const request = await createStatus(this.chain);
+      const request = this.chain.getStatus();
       try {
         this.network.peerMetadata.setStatus(peerId, await this.network.reqResp.status(peerId, request));
       } catch (e) {

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -15,13 +15,7 @@ import {BlockError, BlockErrorCode} from "../chain/errors";
 import {getPeersInitialSync} from "./utils/bestPeers";
 import {ORARegularSync} from "./regular/oneRangeAhead/oneRangeAhead";
 import {SyncChain, ProcessChainSegment, DownloadBeaconBlocksByRange, GetPeersAndTargetEpoch} from "./range/chain";
-import {
-  assertSequentialBlocksInRange,
-  AttestationCollector,
-  createStatus,
-  RoundRobinArray,
-  syncPeersStatus,
-} from "./utils";
+import {assertSequentialBlocksInRange, AttestationCollector, RoundRobinArray, syncPeersStatus} from "./utils";
 
 export class BeaconSync implements IBeaconSync {
   private readonly opts: ISyncOptions;
@@ -190,7 +184,7 @@ export class BeaconSync implements IBeaconSync {
     this.stopSyncTimer();
     this.statusSyncTimer = setInterval(async () => {
       try {
-        await syncPeersStatus(this.network, await createStatus(this.chain));
+        await syncPeersStatus(this.network, this.chain.getStatus());
       } catch (e) {
         this.logger.error("Error on syncPeersStatus", e);
       }

--- a/packages/lodestar/src/sync/utils/assertPeerRelevance.ts
+++ b/packages/lodestar/src/sync/utils/assertPeerRelevance.ts
@@ -1,0 +1,110 @@
+import {computeStartSlotAtEpoch, getBlockRootAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {Epoch, ForkDigest, Root, Status} from "@chainsafe/lodestar-types";
+import {LodestarError} from "@chainsafe/lodestar-utils";
+import {toHexString} from "@chainsafe/ssz";
+import {IBeaconChain} from "../../chain";
+import {GENESIS_EPOCH} from "../../constants";
+
+// TODO: Why this value? (From Lighthouse)
+const FUTURE_SLOT_TOLERANCE = 1;
+
+export enum IrrelevantPeerErrorCode {
+  INCOMPATIBLE_FORKS = "IRRELEVANT_PEER_INCOMPATIBLE_FORKS",
+  DIFFERENT_CLOCKS = "IRRELEVANT_PEER_DIFFERENT_CLOCKS",
+  GENESIS_NONZERO = "IRRELEVANT_PEER_GENESIS_NONZERO",
+  DIFFERENT_FINALIZED = "IRRELEVANT_PEER_DIFFERENT_FINALIZED",
+}
+
+type IrrelevantPeerErrorType =
+  | {code: IrrelevantPeerErrorCode.INCOMPATIBLE_FORKS; ours: ForkDigest; theirs: ForkDigest}
+  | {code: IrrelevantPeerErrorCode.DIFFERENT_CLOCKS; slotDiff: number}
+  | {code: IrrelevantPeerErrorCode.GENESIS_NONZERO; root: string}
+  | {code: IrrelevantPeerErrorCode.DIFFERENT_FINALIZED; expectedRoot: string; remoteRoot: string};
+
+export class IrrelevantPeerError extends LodestarError<IrrelevantPeerErrorType> {}
+
+/**
+ * Process a `Status` message to determine if a peer is relevant to us. If the peer is
+ * irrelevant the reason is returned.
+ */
+export async function assertPeerRelevance(remote: Status, chain: IBeaconChain, config: IBeaconConfig): Promise<void> {
+  const local = chain.getStatus();
+
+  // The node is on a different network/fork
+  if (!config.types.ForkDigest.equals(local.forkDigest, remote.forkDigest)) {
+    throw new IrrelevantPeerError({
+      code: IrrelevantPeerErrorCode.INCOMPATIBLE_FORKS,
+      ours: local.forkDigest,
+      theirs: remote.forkDigest,
+    });
+  }
+
+  // The remote's head is on a slot that is significantly ahead of what we consider the
+  // current slot. This could be because they are using a different genesis time, or that
+  // their or our system's clock is incorrect.
+  const slotDiff = remote.headSlot - chain.clock.currentSlot;
+  if (slotDiff > FUTURE_SLOT_TOLERANCE) {
+    throw new IrrelevantPeerError({code: IrrelevantPeerErrorCode.DIFFERENT_CLOCKS, slotDiff});
+  }
+
+  // TODO: Is this check necessary?
+  if (remote.finalizedEpoch === GENESIS_EPOCH && !isZeroRoot(config, remote.finalizedRoot)) {
+    throw new IrrelevantPeerError({
+      code: IrrelevantPeerErrorCode.GENESIS_NONZERO,
+      root: toHexString(remote.finalizedRoot),
+    });
+  }
+
+  // The remote's finalized epoch is less than or equal to ours, but the block root is
+  // different to the one in our chain. Therefore, the node is on a different chain and we
+  // should not communicate with them.
+
+  if (
+    remote.finalizedEpoch <= local.finalizedEpoch &&
+    !isZeroRoot(config, remote.finalizedRoot) &&
+    !isZeroRoot(config, local.finalizedRoot)
+  ) {
+    const remoteRoot = remote.finalizedRoot;
+    const expectedRoot =
+      remote.finalizedEpoch === local.finalizedEpoch
+        ? local.finalizedRoot
+        : // This will get the latest known block at the start of the epoch.
+          await getRootAtHistoricalEpoch(config, chain, remote.finalizedEpoch);
+
+    if (!config.types.Root.equals(remoteRoot, expectedRoot)) {
+      throw new IrrelevantPeerError({
+        code: IrrelevantPeerErrorCode.DIFFERENT_FINALIZED,
+        expectedRoot: toHexString(expectedRoot), // forkChoice returns Tree BranchNode which the logger prints as {}
+        remoteRoot: toHexString(remoteRoot),
+      });
+    }
+  }
+
+  // Note: Accept request status finalized checkpoint in the future, we do not know if it is a true finalized root
+}
+
+export function isZeroRoot(config: IBeaconConfig, root: Root): boolean {
+  const ZERO_ROOT = config.types.Root.defaultValue();
+  return config.types.Root.equals(root, ZERO_ROOT);
+}
+
+async function getRootAtHistoricalEpoch(config: IBeaconConfig, chain: IBeaconChain, epoch: Epoch): Promise<Root> {
+  const headState = chain.getHeadState();
+
+  const slot = computeStartSlotAtEpoch(config, epoch);
+
+  // This will get the latest known block at the start of the epoch.
+  // NOTE: Throws if the epoch if from a long-ago epoch
+  return getBlockRootAtSlot(config, headState, slot);
+
+  // NOTE: Previous code tolerated long-ago epochs
+  // ^^^^
+  // finalized checkpoint of status is from an old long-ago epoch.
+  // We need to ask the chain for most recent canonical block at the finalized checkpoint start slot.
+  // The problem is that the slot may be a skip slot.
+  // And the block root may be from multiple epochs back even.
+  // The epoch in the checkpoint is there to checkpoint the tail end of skip slots, even if there is no block.
+  // TODO: accepted for now. Need to maintain either a list of finalized block roots,
+  // or inefficiently loop from finalized slot backwards, until we find the block we need to check against.
+}

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -2,27 +2,14 @@ import PeerId from "peer-id";
 import {Checkpoint, SignedBeaconBlock, Status, Root} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {getStatusProtocols, INetwork} from "../../network";
-import {IBeaconChain} from "../../chain";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {toHexString} from "@chainsafe/ssz";
-import {GENESIS_EPOCH, ZERO_HASH} from "../../constants";
+import {ZERO_HASH} from "../../constants";
 import {IPeerMetadataStore} from "../../network/peers/interface";
 import {getSyncPeers} from "./peers";
 
 export function getStatusFinalizedCheckpoint(status: Status): Checkpoint {
   return {epoch: status.finalizedEpoch, root: status.finalizedRoot};
-}
-
-export async function createStatus(chain: IBeaconChain): Promise<Status> {
-  const head = chain.forkChoice.getHead();
-  const finalizedCheckpoint = chain.forkChoice.getFinalizedCheckpoint();
-  return {
-    forkDigest: chain.getForkDigest(),
-    finalizedRoot: finalizedCheckpoint.epoch === GENESIS_EPOCH ? ZERO_HASH : finalizedCheckpoint.root,
-    finalizedEpoch: finalizedCheckpoint.epoch,
-    headRoot: head.blockRoot,
-    headSlot: head.slot,
-  };
 }
 
 export async function syncPeersStatus(network: INetwork, status: Status): Promise<void> {

--- a/packages/lodestar/test/unit/sync/reqResp.test.ts
+++ b/packages/lodestar/test/unit/sync/reqResp.test.ts
@@ -78,6 +78,7 @@ describe("sync req resp", function () {
       headSlot: 1,
     };
     chainStub.stateCache.get.returns(generateState() as any);
+    chainStub.clock = {currentSlot: 0} as any;
 
     const res = await all(syncRpc.onRequest(Method.Status, body, peerId));
     expect(res).have.length(1, "Wrong number of chunks responded");

--- a/packages/lodestar/test/unit/sync/utils/assertPeerRelevance.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/assertPeerRelevance.test.ts
@@ -1,0 +1,108 @@
+import chai, {expect} from "chai";
+import chaiAsPromised from "chai-as-promised";
+import {config} from "@chainsafe/lodestar-config/minimal";
+import {Status} from "@chainsafe/lodestar-types";
+import {MockBeaconChain} from "../../../utils/mocks/chain/chain";
+import {
+  assertPeerRelevance,
+  IrrelevantPeerError,
+  IrrelevantPeerErrorCode,
+} from "../../../../src/sync/utils/assertPeerRelevance";
+import {IBeaconClock} from "../../../../src/chain/clock";
+import {expectRejectedWithLodestarError} from "../../../utils/errors";
+import {toHexString} from "@chainsafe/ssz";
+
+chai.use(chaiAsPromised);
+
+describe("sync / utils / assertPeerRelevance", () => {
+  const correctForkDigest = Buffer.alloc(4, 0);
+  const differentForkDigest = Buffer.alloc(4, 1);
+  const ZERO_HASH = Buffer.alloc(32, 0);
+  const differedRoot = Buffer.alloc(32, 1);
+
+  // Partial instance with only the methods needed for the test
+  const chain = ({
+    getStatus: () => ({
+      forkDigest: correctForkDigest,
+      finalizedRoot: ZERO_HASH,
+      finalizedEpoch: 0,
+      headRoot: ZERO_HASH,
+      headSlot: 0,
+    }),
+    clock: {
+      currentSlot: 0,
+    } as Partial<IBeaconClock>,
+  } as Partial<MockBeaconChain>) as MockBeaconChain;
+
+  const testCases: {id: string; remote: Status; error?: IrrelevantPeerError}[] = [
+    {
+      id: "Reject incompatible forks",
+      remote: {
+        forkDigest: differentForkDigest,
+        finalizedRoot: ZERO_HASH,
+        finalizedEpoch: 0,
+        headRoot: ZERO_HASH,
+        headSlot: 0,
+      },
+      error: new IrrelevantPeerError({
+        code: IrrelevantPeerErrorCode.INCOMPATIBLE_FORKS,
+        ours: correctForkDigest,
+        theirs: differentForkDigest,
+      }),
+    },
+    {
+      id: "Head is too far away from our clock",
+      remote: {
+        forkDigest: correctForkDigest,
+        finalizedRoot: differedRoot,
+        finalizedEpoch: 0,
+        headRoot: ZERO_HASH,
+        headSlot: 100, // Too far from current slot (= 0)
+      },
+      error: new IrrelevantPeerError({code: IrrelevantPeerErrorCode.DIFFERENT_CLOCKS, slotDiff: 100}),
+    },
+    {
+      id: "Reject non zeroed genesis",
+      remote: {
+        forkDigest: correctForkDigest,
+        finalizedRoot: differedRoot, // non zero root
+        finalizedEpoch: 0, // at genesis
+        headRoot: ZERO_HASH,
+        headSlot: 0,
+      },
+      error: new IrrelevantPeerError({code: IrrelevantPeerErrorCode.GENESIS_NONZERO, root: toHexString(differedRoot)}),
+    },
+    {
+      id: "Accept a finalized epoch equal to ours, with same root",
+      remote: {
+        forkDigest: correctForkDigest,
+        finalizedRoot: ZERO_HASH,
+        finalizedEpoch: 0,
+        headRoot: ZERO_HASH,
+        headSlot: 0,
+      },
+    },
+    {
+      id: "Accept finalized epoch greater than ours",
+      remote: {
+        forkDigest: correctForkDigest,
+        finalizedRoot: ZERO_HASH,
+        finalizedEpoch: 100, // Greater than ours (= 0)
+        headRoot: ZERO_HASH,
+        headSlot: 0,
+      },
+    },
+  ];
+
+  for (const {id, remote, error} of testCases) {
+    it(id, async () => {
+      const promise = assertPeerRelevance(remote, chain, config);
+      if (error) {
+        expect;
+        await expectRejectedWithLodestarError(promise, error);
+      } else {
+        await promise;
+      }
+    });
+  }
+});

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -10,6 +10,7 @@ import {
   Number64,
   SignedBeaconBlock,
   Slot,
+  Status,
   Uint16,
   Uint64,
 } from "@chainsafe/lodestar-types";
@@ -167,5 +168,15 @@ export class MockBeaconChain implements IBeaconChain {
 
   async getStateContextByBlockRoot(): Promise<ITreeStateContext | null> {
     return null;
+  }
+
+  getStatus(): Status {
+    return {
+      forkDigest: this.getForkDigest(),
+      finalizedRoot: Buffer.alloc(32),
+      finalizedEpoch: 0,
+      headRoot: Buffer.alloc(32),
+      headSlot: 0,
+    };
   }
 }


### PR DESCRIPTION
Isolate logic to decide if a peer is relevant or not in a standalone function that return if relevant, throws if not. The assert format allows the consumer to log the reason.

Also tweaks the logic to align it with Lighthouse interpretation of the spec.

Attaches `createStatus` method to the chain instance. Reduces code duplication and allows for easier testing mocking a single method instead of having to stub imports.
