### PR TITLE
Add getAttestationDeltas performance test

### DIFF
--- a/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/block/block.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/block/block.test.ts
@@ -3,8 +3,8 @@ import {SignedBeaconBlock, SignedVoluntaryExit} from "@chainsafe/lodestar-types"
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {List} from "@chainsafe/ssz";
 import {expect} from "chai";
-import {generatePerformanceBlock, generatePerformanceState, initBLS} from "../util";
-import {phase0} from "../../../src";
+import {generatePerformanceBlock, generatePerformanceState, initBLS} from "../../../util";
+import {phase0} from "../../../../../src";
 
 describe("Process Blocks Performance Test", function () {
   this.timeout(0);

--- a/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/epoch/epoch.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/epoch/epoch.test.ts
@@ -1,8 +1,8 @@
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
-import {generatePerformanceState, initBLS} from "./util";
+import {generatePerformanceState, initBLS} from "../../../util";
 import {expect} from "chai";
-import {phase0} from "../../src";
+import {phase0} from "../../../../../src";
 
 describe("Epoch Processing Performance Tests", function () {
   let state: phase0.fast.CachedValidatorsBeaconState;

--- a/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/epoch/getAttestationDeltas.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/epoch/getAttestationDeltas.test.ts
@@ -1,0 +1,45 @@
+import {config} from "@chainsafe/lodestar-config/mainnet";
+import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {generatePerformanceState, initBLS} from "../../../util";
+import {expect} from "chai";
+import {phase0} from "../../../../../src";
+
+describe("getAttestationDeltas", function () {
+  let state: phase0.fast.CachedValidatorsBeaconState;
+  let epochCtx: phase0.EpochContext;
+  let epochProcess: phase0.fast.IEpochProcess;
+  const logger = new WinstonLogger();
+
+  before(async function () {
+    this.timeout(0);
+    await initBLS();
+    const origState = await generatePerformanceState();
+    // go back 1 slot to process epoch
+    origState.slot -= 1;
+    epochCtx = new phase0.EpochContext(config);
+    epochCtx.loadState(origState);
+    state = phase0.fast.createCachedValidatorsBeaconState(origState);
+  });
+
+  it("should getAttestationDeltas", function () {
+    this.timeout(0);
+    epochProcess = phase0.fast.prepareEpochProcessState(epochCtx, state);
+    let minTime = Number.MAX_SAFE_INTEGER;
+    let maxTime = 0;
+    const MAX_TRY = 10000;
+    const from = process.hrtime.bigint();
+    for (let i = 0; i < MAX_TRY; i++) {
+      const start = Date.now();
+      phase0.fast.getAttestationDeltas(epochCtx, epochProcess, state);
+      const duration = Date.now() - start;
+      if (duration < minTime) minTime = duration;
+      if (duration > maxTime) maxTime = duration;
+    }
+    const to = process.hrtime.bigint();
+    const average = Number((to - from) / BigInt(MAX_TRY) / BigInt(1000000));
+    logger.info("getAttestationDeltas in ms", {minTime, maxTime, average, maxTry: MAX_TRY});
+    expect(minTime).to.be.lt(98, "Minimal balances assignment is not less than 98ms");
+    expect(maxTime).to.be.lt(1375, "Maximal balances assignment is not less than 1375ms");
+    expect(average).to.be.lt(130, "Average balances assignment is not less than 130ms");
+  });
+});

--- a/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/slot/slots.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/slot/slots.test.ts
@@ -1,8 +1,8 @@
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {expect} from "chai";
-import {phase0} from "../../../src";
-import {initBLS, generatePerformanceState} from "../util";
+import {phase0} from "../../../../../src";
+import {initBLS, generatePerformanceState} from "../../../util";
 
 describe("Process Slots Performance Test", function () {
   this.timeout(0);

--- a/packages/lodestar-beacon-state-transition/test/perf/util.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/util.ts
@@ -3,7 +3,7 @@ import {BeaconState, Eth1Data, Gwei, SignedBeaconBlock, Validator} from "@chains
 import {init} from "@chainsafe/bls";
 import {WinstonLogger, interopSecretKeys} from "@chainsafe/lodestar-utils";
 import {fromHexString, List, TreeBacked} from "@chainsafe/ssz";
-import {getBeaconProposerIndex} from "../../src/util/proposer";
+import {getBeaconProposerIndex} from "../../lib/util/proposer";
 
 let archivedState: TreeBacked<BeaconState> | null = null;
 let signedBlock: TreeBacked<SignedBeaconBlock> | null = null;


### PR DESCRIPTION
part of #2046 

+ Fix and restructure the current performance tests
+ Add `getAttestationDeltas.test.ts` showing that it may finish in more than 1s as in the profiler:

|#|minTime (ms)|maxTime (ms)|average (ms)|
|-|---------|---------|--------|
|1st|98|1375|130|
|2nd|97|699|131|