### PR TITLE
Simplify BeaconGossipHandler

### DIFF
--- a/packages/lodestar/src/sync/gossip/index.ts
+++ b/packages/lodestar/src/sync/gossip/index.ts
@@ -1,2 +1,1 @@
 export * from "./handler";
-export * from "./interface";

--- a/packages/lodestar/src/sync/gossip/interface.ts
+++ b/packages/lodestar/src/sync/gossip/interface.ts
@@ -1,5 +1,0 @@
-export interface IGossipHandler {
-  start(): void;
-  stop(): void;
-  handleSyncCompleted(): void;
-}

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -176,7 +176,7 @@ export class BeaconSync implements IBeaconSync {
   private syncCompleted = async (): Promise<void> => {
     this.mode = SyncMode.SYNCED;
     this.stopSyncTimer();
-    this.gossip.handleSyncCompleted();
+    this.gossip.start();
     await this.network.handleSyncCompleted();
   };
 

--- a/packages/lodestar/test/unit/sync/gossip/handler.test.ts
+++ b/packages/lodestar/test/unit/sync/gossip/handler.test.ts
@@ -60,7 +60,7 @@ describe("gossip handler", function () {
       callback(generateEmptyAttesterSlashing());
     });
     const handler = new BeaconGossipHandler(chainStub, networkStub, dbStub, logger);
-    handler.handleSyncCompleted();
+    handler.start();
     expect(dbStub.attesterSlashing.add.calledOnce).to.be.true;
   });
 
@@ -69,7 +69,7 @@ describe("gossip handler", function () {
       callback(generateEmptyProposerSlashing());
     });
     const handler = new BeaconGossipHandler(chainStub, networkStub, dbStub, logger);
-    handler.handleSyncCompleted();
+    handler.start();
     expect(dbStub.proposerSlashing.add.calledOnce).to.be.true;
   });
 
@@ -78,7 +78,7 @@ describe("gossip handler", function () {
       callback(generateEmptySignedVoluntaryExit());
     });
     const handler = new BeaconGossipHandler(chainStub, networkStub, dbStub, logger);
-    handler.handleSyncCompleted();
+    handler.start();
     expect(dbStub.voluntaryExit.add.calledOnce).to.be.true;
   });
 


### PR DESCRIPTION
- Store forkDigest in an enum state variable
- Subscribe to all core topics on start
- Sync calls start() instead of handleSyncComplete(), it's the sync instance responsibility to know that gossip must start when completing sync not the other way around