### PR TITLE
Skip initial sync if already synced

### DIFF
--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -78,7 +78,14 @@ export class BeaconSync implements IBeaconSync {
       this.controller.signal
     );
 
-    await initialSync.sync();
+    const currentSlot = this.chain.clock.currentSlot;
+    const headSlot = this.chain.forkChoice.getHead().slot;
+    const slotImportTolerance = this.config.params.SLOTS_PER_EPOCH;
+    if (currentSlot >= headSlot && headSlot >= currentSlot - slotImportTolerance) {
+      // Synced
+    } else {
+      await initialSync.sync();
+    }
 
     this.startRegularSync();
   }


### PR DESCRIPTION
Should help increase the stability of sim tests.

However does not fix the spammed error

```
 error: Failed to subscribe to committee subnet message=Cannot collect attestations before regular sync
Error: Cannot collect attestations before regular sync
```