### PR TITLE
Fix asssertPeerRelevance during pre-genesis

### DIFF
--- a/packages/lodestar/src/sync/utils/assertPeerRelevance.ts
+++ b/packages/lodestar/src/sync/utils/assertPeerRelevance.ts
@@ -43,7 +43,7 @@ export function assertPeerRelevance(remote: phase0.Status, chain: IBeaconChain, 
   // The remote's head is on a slot that is significantly ahead of what we consider the
   // current slot. This could be because they are using a different genesis time, or that
   // their or our system's clock is incorrect.
-  const slotDiff = remote.headSlot - chain.clock.currentSlot;
+  const slotDiff = remote.headSlot - Math.max(chain.clock.currentSlot, 0);
   if (slotDiff > FUTURE_SLOT_TOLERANCE) {
     throw new IrrelevantPeerError({code: IrrelevantPeerErrorCode.DIFFERENT_CLOCKS, slotDiff});
   }

--- a/packages/lodestar/test/unit/sync/utils/assertPeerRelevance.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/assertPeerRelevance.test.ts
@@ -99,4 +99,20 @@ describe("sync / utils / assertPeerRelevance", () => {
       }
     });
   }
+
+  it("Accept during pre-genesis clock", () => {
+    // clock slot pre-genesis (< 0) by a good margin
+    (chain as any).clock.currentSlot = -50;
+    assertPeerRelevance(
+      {
+        forkDigest: correctForkDigest,
+        finalizedRoot: ZERO_HASH,
+        finalizedEpoch: 0,
+        headRoot: ZERO_HASH,
+        headSlot: 0,
+      },
+      chain,
+      config
+    );
+  });
 });


### PR DESCRIPTION
Peers were not connecting before genesis (due to clock skew between headSlot=0 and currentSlot=-N)

Fixes issues seen in sim tests