### PR TITLE
Add wtfnode api endpoint

### DIFF
--- a/packages/lodestar-cli/src/options/beaconNodeOptions/api.ts
+++ b/packages/lodestar-cli/src/options/beaconNodeOptions/api.ts
@@ -24,7 +24,7 @@ export function parseArgs(args: IApiArgs): IBeaconNodeOptions["api"] {
 export const options: ICliCommandOptions<IApiArgs> = {
   "api.rest.api": {
     type: "array",
-    choices: ["beacon", "validator", "node", "events"],
+    choices: ["beacon", "validator", "node", "events", "debug", "lodestar"],
     description: "Pick namespaces to expose for HTTP API",
     defaultDescription: JSON.stringify(defaultOptions.api.rest.api),
     group: "api",

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -87,7 +87,8 @@
     "snappyjs": "^0.6.0",
     "stream-to-it": "^0.2.0",
     "strict-event-emitter-types": "^2.0.0",
-    "varint": "^5.0.0"
+    "varint": "^5.0.0",
+    "wtfnode": "^0.8.4"
   },
   "devDependencies": {
     "@chainsafe/benchmark-utils": "^0.16.0",

--- a/packages/lodestar/src/api/impl/api.ts
+++ b/packages/lodestar/src/api/impl/api.ts
@@ -6,6 +6,7 @@ import {IValidatorApi, ValidatorApi} from "./validator";
 import {EventsApi, IEventsApi} from "./events";
 import {DebugApi, IDebugApi} from "./debug";
 import {ConfigApi, IConfigApi} from "./config";
+import {LodestarApi, ILodestarApi} from "./lodestar";
 
 export class Api implements IApi {
   public beacon: IBeaconApi;
@@ -14,6 +15,7 @@ export class Api implements IApi {
   public events: IEventsApi;
   public debug: IDebugApi;
   public config: IConfigApi;
+  public lodestar: ILodestarApi;
 
   public constructor(opts: Partial<IApiOptions>, modules: IApiModules) {
     this.beacon = new BeaconApi(opts, modules);
@@ -22,5 +24,6 @@ export class Api implements IApi {
     this.events = new EventsApi(opts, modules);
     this.debug = new DebugApi(opts, modules);
     this.config = new ConfigApi(opts, modules);
+    this.lodestar = new LodestarApi();
   }
 }

--- a/packages/lodestar/src/api/impl/interface.ts
+++ b/packages/lodestar/src/api/impl/interface.ts
@@ -13,6 +13,7 @@ import {IValidatorApi} from "./validator";
 import {IEventsApi} from "./events";
 import {IDebugApi} from "./debug/interface";
 import {IConfigApi} from "./config/interface";
+import {ILodestarApi} from "./lodestar";
 
 export const enum ApiNamespace {
   BEACON = "beacon",
@@ -21,6 +22,7 @@ export const enum ApiNamespace {
   EVENTS = "events",
   DEBUG = "debug",
   CONFIG = "config",
+  LODESTAR = "lodestar",
 }
 
 export interface IApiModules {
@@ -40,4 +42,5 @@ export interface IApi {
   events: IEventsApi;
   debug: IDebugApi;
   config: IConfigApi;
+  lodestar: ILodestarApi;
 }

--- a/packages/lodestar/src/api/impl/lodestar/index.ts
+++ b/packages/lodestar/src/api/impl/lodestar/index.ts
@@ -1,0 +1,27 @@
+export interface ILodestarApi {
+  getWtfNode(): string;
+}
+
+export class LodestarApi implements ILodestarApi {
+  /**
+   * Get a wtfnode dump of all active handles
+   * Will only load the wtfnode after the first call, and registers async hooks
+   * and other listeners to the global process instance
+   */
+  getWtfNode(): string {
+    // Browser interop
+    if (typeof require !== "function") throw Error("NodeJS only");
+
+    // eslint-disable-next-line
+    const wtfnode = require("wtfnode");
+    const logs: string[] = [];
+    function logger(...args: string[]): void {
+      for (const arg of args) logs.push(arg);
+    }
+    wtfnode.setLogger("info", logger);
+    wtfnode.setLogger("warn", logger);
+    wtfnode.setLogger("error", logger);
+    wtfnode.dump();
+    return logs.join("\n");
+  }
+}

--- a/packages/lodestar/src/api/impl/lodestar/index.ts
+++ b/packages/lodestar/src/api/impl/lodestar/index.ts
@@ -3,6 +3,15 @@ export interface ILodestarApi {
 }
 
 export class LodestarApi implements ILodestarApi {
+  constructor() {
+    // Allows to load wtfnode listeners immedeatelly. Usefull when dockerized,
+    // so after an unexpected restart wtfnode becomes properly loaded again
+    if (process?.env?.START_WTF_NODE) {
+      // eslint-disable-next-line
+      require("wtfnode");
+    }
+  }
+
   /**
    * Get a wtfnode dump of all active handles
    * Will only load the wtfnode after the first call, and registers async hooks

--- a/packages/lodestar/src/api/rest/controllers/lodestar/index.ts
+++ b/packages/lodestar/src/api/rest/controllers/lodestar/index.ts
@@ -1,0 +1,10 @@
+import {ApiController} from "../types";
+import {DefaultQuery} from "fastify";
+
+export const getWtfNode: ApiController<DefaultQuery> = {
+  url: "/wtfnode/",
+  handler: function (req, resp) {
+    resp.status(200).send(this.api.lodestar.getWtfNode());
+  },
+  opts: {},
+};

--- a/packages/lodestar/src/api/rest/routes/index.ts
+++ b/packages/lodestar/src/api/rest/routes/index.ts
@@ -6,6 +6,7 @@ import {registerDebugRoutes} from "./debug";
 import {registerEventsRoutes} from "./events";
 import {registerNodeRoutes} from "./node";
 import {registerValidatorRoutes} from "./validator";
+import {registerLodestarRoutes} from "./lodestar";
 
 export * from "./beacon";
 export * from "./validator";
@@ -30,6 +31,9 @@ export function registerRoutes(server: FastifyInstance, enabledNamespaces: ApiNa
       }
       if (enabledNamespaces.includes(ApiNamespace.CONFIG)) {
         registerConfigRoutes(fastify);
+      }
+      if (enabledNamespaces.includes(ApiNamespace.LODESTAR)) {
+        registerLodestarRoutes(fastify);
       }
     },
     {prefix: "/eth"}

--- a/packages/lodestar/src/api/rest/routes/lodestar.ts
+++ b/packages/lodestar/src/api/rest/routes/lodestar.ts
@@ -1,0 +1,14 @@
+import {FastifyInstance} from "fastify";
+import {getWtfNode} from "../controllers/lodestar";
+
+/**
+ * Register /lodestar route
+ */
+export function registerLodestarRoutes(server: FastifyInstance): void {
+  server.register(
+    async function (fastify) {
+      fastify.get(getWtfNode.url, getWtfNode.opts, getWtfNode.handler);
+    },
+    {prefix: "/v1/lodestar"}
+  );
+}

--- a/packages/lodestar/test/utils/stub/api.ts
+++ b/packages/lodestar/test/utils/stub/api.ts
@@ -8,6 +8,7 @@ import {EventsApi} from "../../../src/api/impl/events";
 import {DebugApi} from "../../../src/api/impl/debug";
 import {DebugBeaconApi} from "../../../src/api/impl/debug/beacon";
 import {ConfigApi} from "../../../src/api/impl/config";
+import {LodestarApi} from "../../../src/api/impl/lodestar";
 import {StubbedConfigApi} from "./configApi";
 
 export class StubbedApi implements SinonStubbedInstance<IApi> {
@@ -17,6 +18,7 @@ export class StubbedApi implements SinonStubbedInstance<IApi> {
   events: SinonStubbedInstance<EventsApi>;
   debug: SinonStubbedInstance<DebugApi>;
   config: SinonStubbedInstance<ConfigApi>;
+  lodestar: SinonStubbedInstance<LodestarApi>;
 
   constructor(sandbox: SinonSandbox = sinon) {
     this.beacon = new StubbedBeaconApi(sandbox);
@@ -26,5 +28,6 @@ export class StubbedApi implements SinonStubbedInstance<IApi> {
     const debugBeacon = sandbox.createStubInstance(DebugBeaconApi);
     this.debug = {beacon: debugBeacon} as SinonStubbedInstance<DebugApi>;
     this.config = new StubbedConfigApi(sandbox);
+    this.lodestar = sandbox.createStubInstance(LodestarApi);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12974,6 +12974,11 @@ ws@7.2.3:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.3.tgz#a5411e1fb04d5ed0efee76d26d5c46d830c39b46"
   integrity sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==
 
+wtfnode@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/wtfnode/-/wtfnode-0.8.4.tgz#91ecf78a40ce222a73a063f26d72bea52357efcc"
+  integrity sha512-64GEKtMt/MUBuAm+8kHqP74ojjafzu00aT0JKsmkIwYmjRQ/odO0yhbzKLm+Z9v1gMla+8dwITRKzTAlHsB+Og==
+
 xsalsa20@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/xsalsa20/-/xsalsa20-1.1.0.tgz#bee27174af1913aaec0fe677d8ba161ec12bf87d"


### PR DESCRIPTION
Run wtfnode on demand through a dedicated API route.

I've added this to debug the socket open handles leak but I think it's a very valuable tool to keep mid-term. `wtfnode` is loaded with a lazy require call so it will only be loaded after the first call to the API route. Otherwise won't be run at all and don't disturb non-debug runs

**Sample response**

Replies with a plain text formated dump

http://localhost:9596/eth/v1/lodestar/wtfnode/

```
[WTF Node?] open handles:
- File descriptors: (note: stdio always exists)
  - fd 1 (tty) (stdio)
  - fd 2 (tty) (stdio)
  - fd 0 (tty)
- Sockets:
  - 192.168.1.36:45442 -> 91.105.22.151:9000
  - 192.168.1.36:50264 -> 188.166.75.68:13000
  - 192.168.1.36:50558 -> 69.230.152.160:9000
  - 192.168.1.36:49432 -> 85.5.238.105:13000
  - 192.168.1.36:49006 -> 71.47.209.223:13000
  - 192.168.1.36:45112 -> 93.56.200.143:13000
  - 192.168.1.36:41760 -> 86.20.4.83:9000
  - 192.168.1.36:50024 -> 46.39.104.43:9000
  - 192.168.1.36:43430 -> undefined:undefined
    - Listeners:
      - connect: onConnect @ /home/lion/Code/eth2.0/lodestar/node_modules/libp2p-tcp/src/index.js:101
  - 192.168.1.36:55328 -> undefined:undefined
    - Listeners:
      - connect: onConnect @ /home/lion/Code/eth2.0/lodestar/node_modules/libp2p-tcp/src/index.js:101
```

