### PR TITLE
Add block processor utilization chart

### DIFF
--- a/docker/grafana/provisioning/dashboards/lodestar.json
+++ b/docker/grafana/provisioning/dashboards/lodestar.json
@@ -71,7 +71,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.3.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -167,7 +167,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.3.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -263,7 +263,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.3.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -359,7 +359,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.3.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -469,7 +469,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.3.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -563,7 +563,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.3.7",
       "targets": [
         {
           "expr": "libp2p_peers",
@@ -615,7 +615,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.3.7",
       "targets": [
         {
           "expr": "beacon_head_slot",
@@ -666,7 +666,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.3.7",
       "targets": [
         {
           "expr": "beacon_finalized_epoch",
@@ -717,7 +717,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.3.7",
       "targets": [
         {
           "expr": "rate(beacon_head_slot[2m])",
@@ -770,7 +770,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.3.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -867,7 +867,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.3.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -889,6 +889,117 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Slots / sec",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 25,
+      "panels": [],
+      "title": "Sync stats",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "hiddenSeries": false,
+      "id": 26,
+      "legend": {
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(lodestar_block_processor_total_async_time[1m])",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Block processor utilization ratio",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -119,6 +119,7 @@ export class BeaconChain implements IBeaconChain {
       forkChoice: this.forkChoice,
       clock: this.clock,
       regen: this.regen,
+      metrics: this.metrics,
       emitter: this.internalEmitter,
       checkpointStateCache: this.checkpointStateCache,
       signal: this.abortController.signal,

--- a/packages/lodestar/src/metrics/beacon.ts
+++ b/packages/lodestar/src/metrics/beacon.ts
@@ -36,6 +36,7 @@ export class BeaconMetrics extends Metrics implements IBeaconMetrics {
   public previousEpochTargetGwei: Gauge;
   public observedEpochAttesters: Gauge;
   public observedEpochAggregators: Gauge;
+  public blockProcessorTotalAsyncTime: Gauge;
 
   private logger: ILogger;
 
@@ -178,6 +179,14 @@ export class BeaconMetrics extends Metrics implements IBeaconMetrics {
     this.observedEpochAggregators = new Gauge({
       name: "beacon_observed_epoch_aggregators",
       help: "number of aggregators for which we have seen an attestation, not necessarily included on chain.",
+      registers,
+    });
+
+    // Extra Lodestar custom metrics
+
+    this.blockProcessorTotalAsyncTime = new Gauge({
+      name: "lodestar_block_processor_total_async_time",
+      help: "Total number of seconds spent completing block processor async jobs",
       registers,
     });
   }

--- a/packages/lodestar/src/metrics/interface.ts
+++ b/packages/lodestar/src/metrics/interface.ts
@@ -123,6 +123,12 @@ export interface IBeaconMetrics extends IMetrics {
    * That attestation is not necessarily included on chain.
    */
   observedEpochAggregators: Gauge;
+  /**
+   * Total number of seconds spent completing block processor async jobs
+   * Useful to compute the utilitzation ratio of the blockProcessor with:
+   * `rate(lodestar_block_processor_total_async_time[1m])`
+   */
+  blockProcessorTotalAsyncTime: Gauge;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/packages/lodestar/src/util/queue.ts
+++ b/packages/lodestar/src/util/queue.ts
@@ -60,10 +60,10 @@ export class JobQueue {
       } catch (e) {
         reject(e);
       } finally {
-        this.currentSize--;
         this.opts.onJobDone?.({ms: Date.now() - start});
       }
     }
+    this.currentSize--;
   }
 
   enqueueJob<T extends Job>(job: T): Promise<ReturnType<T>> {


### PR DESCRIPTION
Adds a metric to compute the total async time spent running async jobs in the block processor queue. With it, we can compute the utilization ratio with prometheus function `rate`.

This utilization ratio is very important for sync. It should be always 1 or the sync won't be as fast as it could be. If the sync manager doesn't handle peers correctly and is stuck often waiting for timeouts, the utilization ratio will drop indicating this problem.