### PR TITLE
Rename Libp2pNetwork to just Network

### DIFF
--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -33,7 +33,7 @@ interface ILibp2pModules {
   chain: IBeaconChain;
 }
 
-export class Libp2pNetwork extends (EventEmitter as {new (): NetworkEventEmitter}) implements INetwork {
+export class Network extends (EventEmitter as {new (): NetworkEventEmitter}) implements INetwork {
   public peerId: PeerId;
   public localMultiaddrs!: Multiaddr[];
   public reqResp: ReqResp;

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -11,7 +11,7 @@ import {phase0} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
 
 import {IBeaconDb} from "../db";
-import {INetwork, Libp2pNetwork} from "../network";
+import {INetwork, Network} from "../network";
 import {BeaconSync, IBeaconSync} from "../sync";
 import {BeaconChain, IBeaconChain, initBeaconMetrics} from "../chain";
 import {BeaconMetrics, HttpMetricsServer, IBeaconMetrics} from "../metrics";
@@ -140,7 +140,7 @@ export class BeaconNode {
       config,
       logger: logger.child(opts.logger.network),
     });
-    const network = new Libp2pNetwork(opts.network, {
+    const network = new Network(opts.network, {
       config,
       libp2p,
       logger: logger.child(opts.logger.network),

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -7,7 +7,7 @@ import PeerId from "peer-id";
 import sinon, {SinonStubbedInstance} from "sinon";
 import {IBeaconChain} from "../../../src/chain";
 import {BeaconMetrics} from "../../../src/metrics";
-import {createPeerId, Libp2pNetwork, NetworkEvent} from "../../../src/network";
+import {createPeerId, Network, NetworkEvent} from "../../../src/network";
 import {ExtendedValidatorResult} from "../../../src/network/gossip/constants";
 import {getAttestationSubnetEvent} from "../../../src/network/gossip/utils";
 import {GossipMessageValidator} from "../../../src/network/gossip/validator";
@@ -32,7 +32,7 @@ const opts: INetworkOptions = {
 
 describe("[network] network", function () {
   this.timeout(5000);
-  let netA: Libp2pNetwork, netB: Libp2pNetwork;
+  let netA: Network, netB: Network;
   let peerIdB: PeerId;
   let libP2pA: LibP2p;
   let libP2pB: LibP2p;
@@ -66,8 +66,8 @@ describe("[network] network", function () {
     });
     peerIdB = await createPeerId();
     [libP2pA, libP2pB] = await Promise.all([createNode(multiaddr), createNode(multiaddr, peerIdB)]);
-    netA = new Libp2pNetwork(opts, {config, libp2p: libP2pA, logger, metrics, validator, chain});
-    netB = new Libp2pNetwork(opts, {config, libp2p: libP2pB, logger, metrics, validator, chain});
+    netA = new Network(opts, {config, libp2p: libP2pA, logger, metrics, validator, chain});
+    netB = new Network(opts, {config, libp2p: libP2pB, logger, metrics, validator, chain});
     await Promise.all([netA.start(), netB.start()]);
   });
 

--- a/packages/lodestar/test/e2e/network/reqresp.test.ts
+++ b/packages/lodestar/test/e2e/network/reqresp.test.ts
@@ -6,7 +6,7 @@ import {LogLevel, sleep, WinstonLogger} from "@chainsafe/lodestar-utils";
 import {phase0} from "@chainsafe/lodestar-types";
 import {Method, ReqRespEncoding} from "../../../src/constants";
 import {BeaconMetrics} from "../../../src/metrics";
-import {createPeerId, IReqRespOptions, Libp2pNetwork, NetworkEvent} from "../../../src/network";
+import {createPeerId, IReqRespOptions, Network, NetworkEvent} from "../../../src/network";
 import {GossipMessageValidator} from "../../../src/network/gossip/validator";
 import {INetworkOptions} from "../../../src/network/options";
 import {RequestError, RequestErrorCode} from "../../../src/network/reqresp/request";
@@ -48,13 +48,13 @@ describe("[network] network", function () {
     }
   });
 
-  async function createAndConnectPeers(reqRespOpts?: IReqRespOptions): Promise<[Libp2pNetwork, Libp2pNetwork]> {
+  async function createAndConnectPeers(reqRespOpts?: IReqRespOptions): Promise<[Network, Network]> {
     const peerIdB = await createPeerId();
     const [libP2pA, libP2pB] = await Promise.all([createNode(multiaddr), createNode(multiaddr, peerIdB)]);
 
     const opts = {...networkOptsDefault, ...reqRespOpts};
-    const netA = new Libp2pNetwork(opts, {config, libp2p: libP2pA, logger: testLogger("A"), metrics, validator, chain});
-    const netB = new Libp2pNetwork(opts, {config, libp2p: libP2pB, logger: testLogger("B"), metrics, validator, chain});
+    const netA = new Network(opts, {config, libp2p: libP2pA, logger: testLogger("A"), metrics, validator, chain});
+    const netB = new Network(opts, {config, libp2p: libP2pB, logger: testLogger("B"), metrics, validator, chain});
     await Promise.all([netA.start(), netB.start()]);
 
     const connected = Promise.all([

--- a/packages/lodestar/test/e2e/sync/reqResp.test.ts
+++ b/packages/lodestar/test/e2e/sync/reqResp.test.ts
@@ -10,7 +10,7 @@ import all from "it-all";
 import {Method, ReqRespEncoding, RpcResponseStatus} from "../../../src/constants";
 import {BeaconMetrics} from "../../../src/metrics";
 import {SszSnappyErrorCode} from "../../../src/network/reqresp/encodingStrategies/sszSnappy";
-import {createRpcProtocol, Libp2pNetwork, NetworkEvent} from "../../../src/network";
+import {createRpcProtocol, Network, NetworkEvent} from "../../../src/network";
 import {decodeErrorMessage} from "../../../src/network/reqresp/utils/errorMessage";
 import {IGossipMessageValidator} from "../../../src/network/gossip/interface";
 import {INetworkOptions} from "../../../src/network/options";
@@ -49,8 +49,8 @@ describe("[sync] rpc", function () {
   const logger = testLogger();
   const metrics = new BeaconMetrics({enabled: false, timeout: 5000, pushGateway: false}, {logger});
 
-  let rpcA: IReqRespHandler, netA: Libp2pNetwork;
-  let rpcB: IReqRespHandler, netB: Libp2pNetwork;
+  let rpcA: IReqRespHandler, netA: Network;
+  let rpcB: IReqRespHandler, netB: Network;
   let libP2pA: Libp2p;
   const validator: IGossipMessageValidator = {} as IGossipMessageValidator;
   let chain: MockBeaconChain;
@@ -77,8 +77,8 @@ describe("[sync] rpc", function () {
       root: config.types.phase0.BeaconBlock.hashTreeRoot(block.message),
     });
     libP2pA = await createNode(multiaddr);
-    netA = new Libp2pNetwork(opts, {config, libp2p: libP2pA, logger, metrics, validator, chain});
-    netB = new Libp2pNetwork(opts, {
+    netA = new Network(opts, {config, libp2p: libP2pA, logger, metrics, validator, chain});
+    netB = new Network(opts, {
       config,
       libp2p: await createNode(multiaddr),
       logger,

--- a/packages/lodestar/test/unit/api/impl/beacon/beacon.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/beacon.test.ts
@@ -6,7 +6,7 @@ import {StubbedBeaconDb} from "../../../../utils/stub";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {expect} from "chai";
 import {generateState} from "../../../../utils/state";
-import {Libp2pNetwork} from "../../../../../src/network/network";
+import {Network} from "../../../../../src/network/network";
 
 describe("beacon api implementation", function () {
   let api: BeaconApi;
@@ -24,7 +24,7 @@ describe("beacon api implementation", function () {
         config,
         chain: chainStub,
         db: dbStub,
-        network: sinon.createStubInstance(Libp2pNetwork),
+        network: sinon.createStubInstance(Network),
         sync: syncStub,
       }
     );

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlock.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlock.test.ts
@@ -9,7 +9,7 @@ import {expect, use} from "chai";
 import chaiAsPromised from "chai-as-promised";
 import {generateEmptySignedBlock} from "../../../../../utils/block";
 import {BeaconSync} from "../../../../../../src/sync/sync";
-import {Libp2pNetwork} from "../../../../../../src/network";
+import {Network} from "../../../../../../src/network";
 
 use(chaiAsPromised);
 
@@ -34,7 +34,7 @@ describe("api - beacon - getBlock", function () {
         chain: chainStub,
         config,
         db: dbStub,
-        network: sinon.createStubInstance(Libp2pNetwork),
+        network: sinon.createStubInstance(Network),
         sync: sinon.createStubInstance(BeaconSync),
       }
     );

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlockHeader.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlockHeader.test.ts
@@ -8,7 +8,7 @@ import {StubbedBeaconDb} from "../../../../../utils/stub";
 import {expect, use} from "chai";
 import chaiAsPromised from "chai-as-promised";
 import {generateEmptySignedBlock} from "../../../../../utils/block";
-import {Libp2pNetwork} from "../../../../../../src/network/network";
+import {Network} from "../../../../../../src/network/network";
 import {BeaconSync} from "../../../../../../src/sync/sync";
 
 use(chaiAsPromised);
@@ -34,7 +34,7 @@ describe("api - beacon - getBlockHeader", function () {
         chain: chainStub,
         config,
         db: dbStub,
-        network: sinon.createStubInstance(Libp2pNetwork),
+        network: sinon.createStubInstance(Network),
         sync: sinon.createStubInstance(BeaconSync),
       }
     );

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlockHeaders.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlockHeaders.test.ts
@@ -13,7 +13,7 @@ import {
 import deepmerge from "deepmerge";
 import {StubbedBeaconDb} from "../../../../../utils/stub";
 import {expect} from "chai";
-import {Libp2pNetwork} from "../../../../../../src/network/network";
+import {Network} from "../../../../../../src/network/network";
 import {BeaconSync} from "../../../../../../src/sync/sync";
 
 describe("api - beacon - getBlockHeaders", function () {
@@ -33,7 +33,7 @@ describe("api - beacon - getBlockHeaders", function () {
         chain: chainStub,
         config,
         db: dbStub,
-        network: sinon.createStubInstance(Libp2pNetwork),
+        network: sinon.createStubInstance(Network),
         sync: sinon.createStubInstance(BeaconSync),
       }
     );

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/publishBlock.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/publishBlock.test.ts
@@ -7,7 +7,7 @@ import {BeaconBlockApi} from "../../../../../../src/api/impl/beacon/blocks";
 import {BeaconChain, IBeaconChain} from "../../../../../../src/chain";
 import {Gossip} from "../../../../../../src/network/gossip/gossip";
 import {INetwork} from "../../../../../../src/network/interface";
-import {Libp2pNetwork} from "../../../../../../src/network/network";
+import {Network} from "../../../../../../src/network/network";
 import {BeaconSync} from "../../../../../../src/sync/sync";
 import {IGossip} from "../../../../../../src/network/gossip/interface";
 import {generateEmptySignedBlock} from "../../../../../utils/block";
@@ -28,7 +28,7 @@ describe("api - beacon - publishBlock", function () {
   beforeEach(function () {
     chainStub = sinon.createStubInstance(BeaconChain);
     syncStub = sinon.createStubInstance(BeaconSync);
-    networkStub = sinon.createStubInstance(Libp2pNetwork);
+    networkStub = sinon.createStubInstance(Network);
     gossipStub = sinon.createStubInstance(Gossip);
     gossipStub.publishBlock = sinon.stub();
     networkStub.gossip = gossipStub;

--- a/packages/lodestar/test/unit/api/impl/beacon/pool/pool.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/pool/pool.test.ts
@@ -2,7 +2,7 @@ import {config} from "@chainsafe/lodestar-config/minimal";
 import {expect} from "chai";
 import sinon, {SinonStub} from "sinon";
 import {BeaconPoolApi} from "../../../../../../src/api/impl/beacon/pool";
-import {Libp2pNetwork} from "../../../../../../src/network/network";
+import {Network} from "../../../../../../src/network/network";
 import {BeaconSync} from "../../../../../../src/sync/sync";
 import {
   generateAttestation,
@@ -27,7 +27,7 @@ describe("beacon pool api impl", function () {
   let poolApi: BeaconPoolApi;
   let dbStub: StubbedBeaconDb;
   let chainStub: SinonStubbedInstance<IBeaconChain>;
-  let networkStub: SinonStubbedInstance<Libp2pNetwork>;
+  let networkStub: SinonStubbedInstance<Network>;
   let gossipStub: SinonStubbedInstance<IGossip>;
   let validateGossipAttesterSlashing: SinonStub;
   let validateGossipProposerSlashing: SinonStub;
@@ -40,7 +40,7 @@ describe("beacon pool api impl", function () {
     gossipStub.publishAttesterSlashing = sinon.stub();
     gossipStub.publishProposerSlashing = sinon.stub();
     gossipStub.publishVoluntaryExit = sinon.stub();
-    networkStub = sinon.createStubInstance(Libp2pNetwork);
+    networkStub = sinon.createStubInstance(Network);
     networkStub.gossip = gossipStub;
     poolApi = new BeaconPoolApi(
       {},

--- a/packages/lodestar/test/unit/api/impl/node/node.test.ts
+++ b/packages/lodestar/test/unit/api/impl/node/node.test.ts
@@ -1,7 +1,7 @@
 import {INodeApi} from "../../../../../src/api/impl/node";
 import {NodeApi} from "../../../../../src/api/impl/node/node";
 import sinon, {SinonStubbedInstance} from "sinon";
-import {createPeerId, INetwork, Libp2pNetwork} from "../../../../../src/network";
+import {createPeerId, INetwork, Network} from "../../../../../src/network";
 import {BeaconSync, IBeaconSync} from "../../../../../src/sync";
 import {createKeypairFromPeerId, ENR} from "@chainsafe/discv5/lib";
 import PeerId from "peer-id";
@@ -34,7 +34,7 @@ describe("node api implementation", function () {
   let syncStub: SinonStubbedInstance<IBeaconSync>;
 
   beforeEach(function () {
-    networkStub = sinon.createStubInstance(Libp2pNetwork);
+    networkStub = sinon.createStubInstance(Network);
     syncStub = sinon.createStubInstance(BeaconSync);
     api = new NodeApi({}, {network: networkStub, sync: syncStub});
   });

--- a/packages/lodestar/test/unit/api/impl/validator/produceAttestationData.test.ts
+++ b/packages/lodestar/test/unit/api/impl/validator/produceAttestationData.test.ts
@@ -8,7 +8,7 @@ import {BeaconChain} from "../../../../../src/chain/chain";
 import {IEth1ForBlockProduction} from "../../../../../src/eth1";
 import {Eth1ForBlockProduction} from "../../../../../src/eth1/eth1ForBlockProduction";
 import {INetwork} from "../../../../../src/network/interface";
-import {Libp2pNetwork} from "../../../../../src/network/network";
+import {Network} from "../../../../../src/network/network";
 import {BeaconSync} from "../../../../../src/sync/sync";
 import {testLogger} from "../../../../utils/logger";
 import {StubbedBeaconDb} from "../../../../utils/stub/beaconDb";
@@ -30,7 +30,7 @@ describe("api - validator - produceAttestationData", function () {
     chainStub = sinon.createStubInstance(BeaconChain);
     dbStub = new StubbedBeaconDb(sinon);
     eth1Stub = sinon.createStubInstance(Eth1ForBlockProduction);
-    networkStub = sinon.createStubInstance(Libp2pNetwork);
+    networkStub = sinon.createStubInstance(Network);
     syncStub = sinon.createStubInstance(BeaconSync);
     modules = {
       chain: chainStub,

--- a/packages/lodestar/test/unit/network/peers/utils.test.ts
+++ b/packages/lodestar/test/unit/network/peers/utils.test.ts
@@ -1,5 +1,5 @@
 import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
-import {getSyncProtocols, INetwork, IReqResp, Libp2pNetwork} from "../../../../src/network";
+import {getSyncProtocols, INetwork, IReqResp, Network} from "../../../../src/network";
 import PeerId from "peer-id";
 import {expect} from "chai";
 import {
@@ -24,7 +24,7 @@ describe("network peer utils", function () {
 
   beforeEach(() => {
     peerMetadataStoreStub = getStubbedMetadataStore();
-    networkStub = sinon.createStubInstance(Libp2pNetwork);
+    networkStub = sinon.createStubInstance(Network);
     scoreTrackerStub = sinon.createStubInstance(PeerRpcScoreStore);
     networkStub.peerRpcScores = scoreTrackerStub;
     networkStub.peerMetadata = peerMetadataStoreStub;

--- a/packages/lodestar/test/unit/network/tasks/checkPeerAliveTask.test.ts
+++ b/packages/lodestar/test/unit/network/tasks/checkPeerAliveTask.test.ts
@@ -1,6 +1,6 @@
 import sinon, {SinonStubbedInstance} from "sinon";
 import {CheckPeerAliveTask} from "../../../../src/network/tasks/checkPeerAliveTask";
-import {INetwork, IReqResp, Libp2pNetwork} from "../../../../src/network";
+import {INetwork, IReqResp, Network} from "../../../../src/network";
 import {ReqResp} from "../../../../src/network/reqresp/reqResp";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {config} from "@chainsafe/lodestar-config/mainnet";
@@ -16,7 +16,7 @@ describe("CheckPeerAliveTask", function () {
   let peerId: PeerId;
 
   beforeEach(async () => {
-    networkStub = sinon.createStubInstance(Libp2pNetwork);
+    networkStub = sinon.createStubInstance(Network);
     reqRespStub = sinon.createStubInstance(ReqResp);
     networkStub.reqResp = reqRespStub;
     peerMetadataStub = getStubbedMetadataStore();

--- a/packages/lodestar/test/unit/network/tasks/diversifyPeersBySubnetTask.test.ts
+++ b/packages/lodestar/test/unit/network/tasks/diversifyPeersBySubnetTask.test.ts
@@ -1,5 +1,5 @@
 import sinon, {SinonStubbedInstance} from "sinon";
-import {INetwork, IReqResp, Libp2pNetwork} from "../../../../src/network";
+import {INetwork, IReqResp, Network} from "../../../../src/network";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {ReqResp} from "../../../../src/network/reqresp/reqResp";
 import {DiversifyPeersBySubnetTask} from "../../../../src/network/tasks/diversifyPeersBySubnetTask";
@@ -15,7 +15,7 @@ describe("DiversifyPeersBySubnetTask", function () {
   let task: DiversifyPeersBySubnetTask;
 
   beforeEach(() => {
-    networkStub = sinon.createStubInstance(Libp2pNetwork);
+    networkStub = sinon.createStubInstance(Network);
     reqRespStub = sinon.createStubInstance(ReqResp);
     networkStub.reqResp = reqRespStub;
     peerMetadataStore = getStubbedMetadataStore();

--- a/packages/lodestar/test/unit/sync/gossip/handler.test.ts
+++ b/packages/lodestar/test/unit/sync/gossip/handler.test.ts
@@ -1,6 +1,6 @@
 import sinon, {SinonStubbedInstance} from "sinon";
 import {BeaconChain, ChainEvent, ChainEventEmitter, IBeaconChain} from "../../../../src/chain";
-import {INetwork, Libp2pNetwork} from "../../../../src/network";
+import {INetwork, Network} from "../../../../src/network";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {IGossip} from "../../../../src/network/gossip/interface";
 import {Gossip} from "../../../../src/network/gossip/gossip";
@@ -26,7 +26,7 @@ describe("gossip handler", function () {
   beforeEach(function () {
     chainStub = sinon.createStubInstance(BeaconChain);
     chainStub.emitter = new ChainEventEmitter();
-    networkStub = sinon.createStubInstance(Libp2pNetwork);
+    networkStub = sinon.createStubInstance(Network);
     gossipStub = sinon.createStubInstance(Gossip);
     networkStub.gossip = gossipStub;
     dbStub = new StubbedBeaconDb(sinon);

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
@@ -3,7 +3,7 @@ import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {BlockRangeFetcher} from "../../../../../src/sync/regular/oneRangeAhead/fetcher";
 import {BeaconChain, IBeaconChain} from "../../../../../src/chain";
-import {INetwork, Libp2pNetwork} from "../../../../../src/network";
+import {INetwork, Network} from "../../../../../src/network";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import PeerId from "peer-id";
 import * as blockUtils from "../../../../../src/sync/utils/blocks";
@@ -34,7 +34,7 @@ describe("BlockRangeFetcher", function () {
     chainStub = sandbox.createStubInstance(BeaconChain);
     clockStub = sandbox.createStubInstance(LocalClock);
     chainStub.clock = clockStub;
-    networkStub = sandbox.createStubInstance(Libp2pNetwork);
+    networkStub = sandbox.createStubInstance(Network);
     metadataStub = getStubbedMetadataStore();
     networkStub.peerMetadata = metadataStub;
     fetcher = new BlockRangeFetcher(

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/oneRangeAhead.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/oneRangeAhead.test.ts
@@ -5,7 +5,7 @@ import {BlockRangeFetcher} from "../../../../../src/sync/regular/oneRangeAhead/f
 import sinon from "sinon";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {BeaconChain, ChainEventEmitter, ForkChoice, IBeaconChain} from "../../../../../src/chain";
-import {INetwork, Libp2pNetwork} from "../../../../../src/network";
+import {INetwork, Network} from "../../../../../src/network";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {generateBlockSummary, generateEmptySignedBlock} from "../../../../utils/block";
 import {expect} from "chai";
@@ -34,7 +34,7 @@ describe("ORARegularSync", function () {
     chainStub.emitter = new ChainEventEmitter();
     clockStub = sinon.createStubInstance(LocalClock);
     chainStub.clock = clockStub;
-    networkStub = sinon.createStubInstance(Libp2pNetwork);
+    networkStub = sinon.createStubInstance(Network);
     gossipStub = sinon.createStubInstance(Gossip);
     networkStub.gossip = gossipStub;
     fetcherStub = sinon.createStubInstance(BlockRangeFetcher);

--- a/packages/lodestar/test/unit/sync/reqResp.test.ts
+++ b/packages/lodestar/test/unit/sync/reqResp.test.ts
@@ -7,7 +7,7 @@ import PeerId from "peer-id";
 import sinon, {SinonStubbedInstance} from "sinon";
 import {GENESIS_EPOCH, Method, ZERO_HASH} from "../../../src/constants";
 import {IBeaconDb} from "../../../src/db/api";
-import {Libp2pNetwork} from "../../../src/network";
+import {Network} from "../../../src/network";
 import {ReqResp} from "../../../src/network/reqresp/reqResp";
 import {BeaconReqRespHandler} from "../../../src/sync/reqResp";
 import {generateEmptySignedBlock} from "../../utils/block";
@@ -26,7 +26,7 @@ describe("sync req resp", function () {
   const sandbox = sinon.createSandbox();
   let syncRpc: BeaconReqRespHandler;
   let chainStub: StubbedBeaconChain,
-    networkStub: SinonStubbedInstance<Libp2pNetwork>,
+    networkStub: SinonStubbedInstance<Network>,
     metaStub: StubbedIPeerMetadataStore,
     reqRespStub: SinonStubbedInstance<ReqResp>;
   let dbStub: StubbedBeaconDb;
@@ -40,7 +40,7 @@ describe("sync req resp", function () {
     chainStub.config = config;
     chainStub.getForkDigest = sandbox.stub().returns(Buffer.alloc(4));
     reqRespStub = sandbox.createStubInstance(ReqResp);
-    networkStub = sandbox.createStubInstance(Libp2pNetwork);
+    networkStub = sandbox.createStubInstance(Network);
     networkStub.reqResp = reqRespStub as ReqResp & SinonStubbedInstance<ReqResp>;
     metaStub = getStubbedMetadataStore();
     networkStub.peerMetadata = metaStub;

--- a/packages/lodestar/test/unit/sync/utils/peer.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/peer.test.ts
@@ -1,5 +1,5 @@
 import {SinonStubbedInstance} from "sinon";
-import {INetwork, Libp2pNetwork} from "../../../../src/network";
+import {INetwork, Network} from "../../../../src/network";
 import sinon from "sinon";
 import {getSyncPeers} from "../../../../src/sync/utils/peers";
 import {expect} from "chai";
@@ -12,7 +12,7 @@ describe("sync peer utils", function () {
   let peerScoreStub: SinonStubbedInstance<IPeerRpcScoreStore>;
 
   beforeEach(function () {
-    networkStub = sinon.createStubInstance(Libp2pNetwork);
+    networkStub = sinon.createStubInstance(Network);
     peerScoreStub = sinon.createStubInstance(PeerRpcScoreStore);
     networkStub.peerRpcScores = peerScoreStub;
   });

--- a/packages/lodestar/test/unit/sync/utils/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/sync.test.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../../src/sync/utils";
 import {generateBlockSummary, generateEmptySignedBlock} from "../../../utils/block";
 import {ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
-import {INetwork, Libp2pNetwork} from "../../../../src/network";
+import {INetwork, Network} from "../../../../src/network";
 import {generatePeer} from "../../../utils/peer";
 import {IPeerRpcScoreStore, PeerRpcScoreStore, ScoreState} from "../../../../src/network/peers";
 import {getStubbedMetadataStore, StubbedIPeerMetadataStore} from "../../../utils/peer";
@@ -98,7 +98,7 @@ describe("sync utils", function () {
 
     beforeEach(() => {
       metastoreStub = getStubbedMetadataStore();
-      networkStub = sinon.createStubInstance(Libp2pNetwork);
+      networkStub = sinon.createStubInstance(Network);
       networkStub.peerMetadata = metastoreStub;
       forkChoiceStub = sinon.createStubInstance(ForkChoice) as SinonStubbedInstance<ForkChoice> & ForkChoice;
       peerScoreStub = sinon.createStubInstance(PeerRpcScoreStore);

--- a/packages/lodestar/test/unit/tasks/interopSubnetsJoiningTask.test.ts
+++ b/packages/lodestar/test/unit/tasks/interopSubnetsJoiningTask.test.ts
@@ -1,5 +1,5 @@
 import {SinonStubbedInstance, SinonFakeTimers} from "sinon";
-import {INetwork, Libp2pNetwork} from "../../../src/network";
+import {INetwork, Network} from "../../../src/network";
 import {IGossip} from "../../../src/network/gossip/interface";
 import {minimalConfig} from "@chainsafe/lodestar-config/minimal";
 import sinon from "sinon";
@@ -32,7 +32,7 @@ describe("interopSubnetsJoiningTask", () => {
 
   beforeEach(() => {
     clock = sandbox.useFakeTimers();
-    networkStub = sandbox.createStubInstance(Libp2pNetwork);
+    networkStub = sandbox.createStubInstance(Network);
     gossipStub = sandbox.createStubInstance(Gossip);
     networkStub.gossip = gossipStub;
     state = generateState();


### PR DESCRIPTION
The directory and file is called `network`, the interface is called `INetwork`, therefore the class should be called `Network`