### PR TITLE
Re-org range sync utils

### DIFF
--- a/packages/lodestar/src/sync/range/chain.ts
+++ b/packages/lodestar/src/sync/range/chain.ts
@@ -5,7 +5,7 @@ import {ErrorAborted, ILogger} from "@chainsafe/lodestar-utils";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ChainSegmentError} from "../../chain/errors";
 import {ItTrigger} from "../../util/itTrigger";
-import {ChainPeersBalancer} from "./peerBalancer";
+import {ChainPeersBalancer} from "./utils/peerBalancer";
 import {Batch, BatchOpts, BatchMetadata, BatchStatus} from "./batch";
 import {
   validateBatchesStatus,
@@ -13,7 +13,7 @@ import {
   toBeProcessedStartEpoch,
   toBeDownloadedStartEpoch,
   toArr,
-} from "./batches";
+} from "./utils/batches";
 
 export type SyncChainOpts = BatchOpts & {maybeStuckTimeoutMs: number};
 

--- a/packages/lodestar/src/sync/range/utils/batches.ts
+++ b/packages/lodestar/src/sync/range/utils/batches.ts
@@ -1,5 +1,5 @@
 import {Epoch} from "@chainsafe/lodestar-types";
-import {Batch, BatchOpts, BatchStatus} from "./batch";
+import {Batch, BatchOpts, BatchStatus} from "../batch";
 
 /**
  * Validates that the status and ordering of batches is valid

--- a/packages/lodestar/src/sync/range/utils/peerBalancer.ts
+++ b/packages/lodestar/src/sync/range/utils/peerBalancer.ts
@@ -1,7 +1,8 @@
 import PeerId from "peer-id";
-import {shuffle} from "../../util/shuffle";
-import {sortBy} from "../../util/sortBy";
-import {Batch, BatchStatus} from "./batch";
+import {PeerMap} from "../../../util/peerMap";
+import {shuffle} from "../../../util/shuffle";
+import {sortBy} from "../../../util/sortBy";
+import {Batch, BatchStatus} from "../batch";
 
 /**
  * Balance and organize peers to perform requests with a SyncChain
@@ -41,42 +42,5 @@ export class ChainPeersBalancer {
    */
   idlePeers(): PeerId[] {
     return this.peers.filter((peer) => !this.activeRequestsByPeer.get(peer));
-  }
-}
-
-/**
- * Special ES6 Map that allows using PeerId objects as indexers
- * Also, uses a WeakMap to reduce unnecessary calls to `PeerId.toB58String()`
- */
-class PeerMap<T> {
-  private peerIdStringCache: WeakMap<PeerId, string> = new WeakMap();
-  private map: Map<string, T> = new Map();
-
-  static from(peers: PeerId[]): PeerMap<void> {
-    const peerMap = new PeerMap<void>();
-    for (const peer of peers) peerMap.set(peer);
-    return peerMap;
-  }
-
-  set(peer: PeerId, value: T): void {
-    this.map.set(this.getPeerIdString(peer), value);
-  }
-  get(peer: PeerId): T | undefined {
-    return this.map.get(this.getPeerIdString(peer));
-  }
-  has(peer: PeerId): boolean {
-    return this.map.has(this.getPeerIdString(peer));
-  }
-
-  /**
-   * Caches peerId.toB58String result in a WeakMap
-   */
-  private getPeerIdString(peerId: PeerId): string {
-    let peerIdString = this.peerIdStringCache.get(peerId);
-    if (peerIdString === undefined) {
-      peerIdString = peerId.toB58String();
-      this.peerIdStringCache.set(peerId, peerIdString);
-    }
-    return peerIdString;
   }
 }

--- a/packages/lodestar/src/util/peerMap.ts
+++ b/packages/lodestar/src/util/peerMap.ts
@@ -1,0 +1,77 @@
+import PeerId from "peer-id";
+
+export class PeerSet {
+  private peerMap = new PeerMap<PeerId>();
+
+  add(peer: PeerId): void {
+    this.peerMap.set(peer, peer);
+  }
+  delete(peer: PeerId): boolean {
+    return this.peerMap.delete(peer);
+  }
+  has(peer: PeerId): boolean {
+    return this.peerMap.has(peer);
+  }
+
+  get size(): number {
+    return this.peerMap.size;
+  }
+  values(): PeerId[] {
+    return this.peerMap.values();
+  }
+}
+
+/**
+ * Special ES6 Map that allows using PeerId objects as indexers
+ * Also, uses a WeakMap to reduce unnecessary calls to `PeerId.toB58String()`
+ */
+export class PeerMap<T> {
+  private map: Map<string, T> = new Map();
+  private peers: Map<string, PeerId> = new Map();
+
+  static from(peers: PeerId[]): PeerMap<void> {
+    const peerMap = new PeerMap<void>();
+    for (const peer of peers) peerMap.set(peer);
+    return peerMap;
+  }
+
+  set(peer: PeerId, value: T): void {
+    this.peers.set(this.getPeerIdString(peer), peer);
+    this.map.set(this.getPeerIdString(peer), value);
+  }
+  get(peer: PeerId): T | undefined {
+    return this.map.get(this.getPeerIdString(peer));
+  }
+  has(peer: PeerId): boolean {
+    return this.map.has(this.getPeerIdString(peer));
+  }
+  delete(peer: PeerId): boolean {
+    this.peers.delete(this.getPeerIdString(peer));
+    return this.map.delete(this.getPeerIdString(peer));
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+  keys(): PeerId[] {
+    return Array.from(this.peers.values());
+  }
+  values(): T[] {
+    return Array.from(this.map.values());
+  }
+  entries(): [PeerId, T][] {
+    const entries: [PeerId, T][] = [];
+    for (const peer of this.peers.values()) {
+      const value = this.get(peer);
+      if (value !== undefined) entries.push([peer, value]);
+    }
+    return entries;
+  }
+
+  /**
+   * Caches peerId.toB58String result in a WeakMap
+   */
+  private getPeerIdString(peerId: PeerId): string {
+    return peerId.toB58String();
+  }
+}

--- a/packages/lodestar/src/util/sortBy.ts
+++ b/packages/lodestar/src/util/sortBy.ts
@@ -2,6 +2,7 @@
  * Sort by multiple prioritized conditions
  * - Sort is stable
  * - Sort does not mutate the original array
+ * - Sorts by number in ascending order: [-1,0,1,2]
  * @param condition Must return an number, used to sort compare each item
  * - conditions[0] has priority over conditions[1]
  */

--- a/packages/lodestar/test/unit/sync/range/utils/batches.test.ts
+++ b/packages/lodestar/test/unit/sync/range/utils/batches.test.ts
@@ -2,14 +2,14 @@ import {expect} from "chai";
 import PeerId from "peer-id";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {Epoch} from "@chainsafe/lodestar-types";
-import {testLogger} from "../../../utils/logger";
-import {Batch, BatchOpts, BatchStatus} from "../../../../src/sync/range/batch";
+import {testLogger} from "../../../../utils/logger";
+import {Batch, BatchOpts, BatchStatus} from "../../../../../src/sync/range/batch";
 import {
   validateBatchesStatus,
   getNextBatchToProcess,
   toBeProcessedStartEpoch,
   toBeDownloadedStartEpoch,
-} from "../../../../src/sync/range/batches";
+} from "../../../../../src/sync/range/utils/batches";
 
 describe("sync / range / batches", () => {
   const logger = testLogger();

--- a/packages/lodestar/test/unit/sync/range/utils/peerBalancer.test.ts
+++ b/packages/lodestar/test/unit/sync/range/utils/peerBalancer.test.ts
@@ -1,9 +1,9 @@
 import {expect} from "chai";
 import PeerId from "peer-id";
 import {config} from "@chainsafe/lodestar-config/minimal";
-import {testLogger} from "../../../utils/logger";
-import {Batch, BatchOpts} from "../../../../src/sync/range/batch";
-import {ChainPeersBalancer} from "../../../../src/sync/range/peerBalancer";
+import {testLogger} from "../../../../utils/logger";
+import {Batch, BatchOpts} from "../../../../../src/sync/range/batch";
+import {ChainPeersBalancer} from "../../../../../src/sync/range/utils/peerBalancer";
 
 describe("sync / range / peerBalancer", () => {
   const opts: BatchOpts = {epochsPerBatch: 1};

--- a/packages/lodestar/test/unit/util/peerMap.test.ts
+++ b/packages/lodestar/test/unit/util/peerMap.test.ts
@@ -1,0 +1,23 @@
+import {expect} from "chai";
+import PeerId from "peer-id";
+import {PeerMap, PeerSet} from "../../../src/util/peerMap";
+
+describe("util / peerMap", () => {
+  const peer1 = new PeerId(Buffer.from([0])); // Offset by one, PeerId encodes to B58String 0 as "1"
+
+  describe("PeerMap", () => {
+    it("Should compute correct size", () => {
+      const peerMap = new PeerMap();
+      peerMap.set(peer1, true);
+      expect(peerMap.size).to.equal(1, "Wrong peerMap.size");
+    });
+  });
+
+  describe("PeerSet", () => {
+    it("Should compute correct size", () => {
+      const peerSet = new PeerSet();
+      peerSet.add(peer1);
+      expect(peerSet.size).to.equal(1, "Wrong peerSet.size");
+    });
+  });
+});


### PR DESCRIPTION
- Move range sync utils to `src/sync/range/utils`
- Move the more generic PeerMap util to `src/util` and test it

Note: A motivation for this PR is to reduce the diff of range-sync branch, committing first the least complex changes