### PR TITLE
Add specialized peer metrics

### DIFF
--- a/docker/grafana/provisioning/dashboards/lodestar.json
+++ b/docker/grafana/provisioning/dashboards/lodestar.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 1,
+  "id": 2,
   "links": [],
   "panels": [
     {
@@ -71,7 +71,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.7",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -167,7 +167,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.7",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -263,7 +263,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.7",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -359,7 +359,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.7",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -469,7 +469,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.7",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -561,9 +561,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.3.7",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "libp2p_peers",
@@ -613,9 +614,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.3.7",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "beacon_head_slot",
@@ -664,9 +666,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.3.7",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "beacon_finalized_epoch",
@@ -715,9 +718,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.3.7",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "rate(beacon_head_slot[2m])",
@@ -770,7 +774,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.7",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -867,7 +871,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.7",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -877,7 +881,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(beacon_head_slot[1m])",
+          "expr": "rate(beacon_head_slot[$__rate_interval])",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -934,6 +938,437 @@
         "x": 0,
         "y": 34
       },
+      "id": 28,
+      "panels": [],
+      "title": "Peer stats",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 2,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "hiddenSeries": false,
+      "id": 30,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "changes(lodestar_peer_goodbye_received[$__rate_interval])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 3,
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Goodbyes received",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 2,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "hiddenSeries": false,
+      "id": 34,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "changes(lodestar_peer_connected[$__rate_interval])",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 3,
+          "legendFormat": "{{direction}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Peer connected event",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 2,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "hiddenSeries": false,
+      "id": 32,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "changes(lodestar_peer_goodbye_sent[$__rate_interval])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 3,
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Goodbyes sent",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 2,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "hiddenSeries": false,
+      "id": 36,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "changes(lodestar_peer_disconnected[$__rate_interval])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 3,
+          "legendFormat": "{{direction}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Peer disconnected event",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
       "id": 25,
       "panels": [],
       "title": "Sync stats",
@@ -958,7 +1393,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 35
+        "y": 52
       },
       "hiddenSeries": false,
       "id": 26,
@@ -978,7 +1413,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.7",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -988,7 +1423,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(lodestar_block_processor_total_async_time[1m])",
+          "expr": "rate(lodestar_block_processor_total_async_time[$__rate_interval])",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -1038,7 +1473,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {

--- a/docker/grafana/provisioning/dashboards/lodestar.json
+++ b/docker/grafana/provisioning/dashboards/lodestar.json
@@ -1361,13 +1361,221 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 2,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 51
+      },
+      "hiddenSeries": false,
+      "id": 37,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "lodestar_peers_total_unique_connected",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 3,
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total unique peers connected to",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 2,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 51
+      },
+      "hiddenSeries": false,
+      "id": 38,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "lodestar_peer_connected - lodestar_peer_disconnected - lodestar_peers_by_direction",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 3,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Peer connect events offset (must be 0-1)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 57
       },
       "id": 25,
       "panels": [],
@@ -1393,7 +1601,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 52
+        "y": 58
       },
       "hiddenSeries": false,
       "id": 26,

--- a/packages/lodestar/src/metrics/beacon.ts
+++ b/packages/lodestar/src/metrics/beacon.ts
@@ -42,6 +42,7 @@ export class BeaconMetrics extends Metrics implements IBeaconMetrics {
   peerDisconnectedEvent: Gauge;
   peerGoodbyeReceived: Gauge;
   peerGoodbyeSent: Gauge;
+  peersTotalUniqueConnected: Gauge;
 
   private logger: ILogger;
 
@@ -227,6 +228,12 @@ export class BeaconMetrics extends Metrics implements IBeaconMetrics {
       name: "lodestar_peer_goodbye_sent",
       help: "Number of goodbye sent, labeled by reason",
       labelNames: ["reason"],
+      registers,
+    });
+
+    this.peersTotalUniqueConnected = new Gauge({
+      name: "lodestar_peers_total_unique_connected",
+      help: "Total number of unique peers that have had a connection with",
       registers,
     });
   }

--- a/packages/lodestar/src/metrics/beacon.ts
+++ b/packages/lodestar/src/metrics/beacon.ts
@@ -37,6 +37,11 @@ export class BeaconMetrics extends Metrics implements IBeaconMetrics {
   public observedEpochAttesters: Gauge;
   public observedEpochAggregators: Gauge;
   public blockProcessorTotalAsyncTime: Gauge;
+  peersByDirection: Gauge;
+  peerConnectedEvent: Gauge;
+  peerDisconnectedEvent: Gauge;
+  peerGoodbyeReceived: Gauge;
+  peerGoodbyeSent: Gauge;
 
   private logger: ILogger;
 
@@ -187,6 +192,41 @@ export class BeaconMetrics extends Metrics implements IBeaconMetrics {
     this.blockProcessorTotalAsyncTime = new Gauge({
       name: "lodestar_block_processor_total_async_time",
       help: "Total number of seconds spent completing block processor async jobs",
+      registers,
+    });
+
+    this.peersByDirection = new Gauge({
+      name: "lodestar_peers_by_direction",
+      help: "number of peers, labeled by direction",
+      labelNames: ["direction"],
+      registers,
+    });
+
+    this.peerConnectedEvent = new Gauge({
+      name: "lodestar_peer_connected",
+      help: "Number of peer:connected event, labeled by direction",
+      labelNames: ["direction"],
+      registers,
+    });
+
+    this.peerDisconnectedEvent = new Gauge({
+      name: "lodestar_peer_disconnected",
+      help: "Number of peer:disconnected event, labeled by direction",
+      labelNames: ["direction"],
+      registers,
+    });
+
+    this.peerGoodbyeReceived = new Gauge({
+      name: "lodestar_peer_goodbye_received",
+      help: "Number of goodbye received, labeled by reason",
+      labelNames: ["reason"],
+      registers,
+    });
+
+    this.peerGoodbyeSent = new Gauge({
+      name: "lodestar_peer_goodbye_sent",
+      help: "Number of goodbye sent, labeled by reason",
+      labelNames: ["reason"],
       registers,
     });
   }

--- a/packages/lodestar/src/metrics/interface.ts
+++ b/packages/lodestar/src/metrics/interface.ts
@@ -139,6 +139,8 @@ export interface IBeaconMetrics extends IMetrics {
   peerGoodbyeReceived: Gauge;
   /** Number of goodbye sent, labeled by reason */
   peerGoodbyeSent: Gauge;
+  /** Total number of unique peers that have had a connection with */
+  peersTotalUniqueConnected: Gauge;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/packages/lodestar/src/metrics/interface.ts
+++ b/packages/lodestar/src/metrics/interface.ts
@@ -129,6 +129,16 @@ export interface IBeaconMetrics extends IMetrics {
    * `rate(lodestar_block_processor_total_async_time[1m])`
    */
   blockProcessorTotalAsyncTime: Gauge;
+  /** Peers labeled by direction */
+  peersByDirection: Gauge;
+  /** Number of peer:connected event, labeled by direction */
+  peerConnectedEvent: Gauge;
+  /** Number of peer:disconnected event, labeled by direction */
+  peerDisconnectedEvent: Gauge;
+  /** Number of goodbye received, labeled by reason */
+  peerGoodbyeReceived: Gauge;
+  /** Number of goodbye sent, labeled by reason */
+  peerGoodbyeSent: Gauge;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -49,6 +49,8 @@ export class Network extends (EventEmitter as {new (): NetworkEventEmitter}) imp
   private metrics: IBeaconMetrics;
   private diversifyPeersTask: DiversifyPeersBySubnetTask;
   private checkPeerAliveTask: CheckPeerAliveTask;
+  /** To count total number of unique seen peers */
+  private seenPeers = new Set();
 
   public constructor(
     opts: INetworkOptions & IReqRespOptions,
@@ -268,6 +270,9 @@ export class Network extends (EventEmitter as {new (): NetworkEventEmitter}) imp
     this.emit(NetworkEvent.peerConnect, conn.remotePeer, conn.stat.direction);
     this.metrics.peerConnectedEvent.inc({direction: conn.stat.direction});
     this.runPeerCountMetrics();
+
+    this.seenPeers.add(conn.remotePeer.toB58String());
+    this.metrics.peersTotalUniqueConnected.set(this.seenPeers.size);
   };
 
   private emitPeerDisconnect = (conn: LibP2pConnection): void => {

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -152,6 +152,7 @@ export class BeaconNode {
       config,
       db,
       chain,
+      metrics,
       network,
       logger: logger.child(opts.logger.sync),
     });

--- a/packages/lodestar/src/sync/interface.ts
+++ b/packages/lodestar/src/sync/interface.ts
@@ -5,6 +5,7 @@ import {IRegularSync} from "./regular";
 import {IGossipHandler} from "./gossip";
 import {IReqRespHandler} from "./reqResp";
 import {IBeaconChain} from "../chain";
+import {IBeaconMetrics} from "../metrics";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBeaconDb} from "../db/api";
 import {AttestationCollector} from "./utils";
@@ -41,6 +42,7 @@ export interface ISyncModules {
   db: IBeaconDb;
   logger: ILogger;
   chain: IBeaconChain;
+  metrics: IBeaconMetrics;
   regularSync?: IRegularSync;
   reqRespHandler?: IReqRespHandler;
   gossipHandler?: IGossipHandler;

--- a/packages/lodestar/test/e2e/sync/reqResp.test.ts
+++ b/packages/lodestar/test/e2e/sync/reqResp.test.ts
@@ -102,6 +102,7 @@ describe("[sync] rpc", function () {
       config,
       db,
       chain,
+      metrics,
       network: netA,
       logger,
     });
@@ -110,6 +111,7 @@ describe("[sync] rpc", function () {
       config,
       db,
       chain,
+      metrics,
       network: netB,
       logger: logger,
     });

--- a/packages/lodestar/test/unit/sync/reqResp.test.ts
+++ b/packages/lodestar/test/unit/sync/reqResp.test.ts
@@ -26,6 +26,7 @@ describe("sync req resp", function () {
   const logger = testLogger();
   const sandbox = sinon.createSandbox();
   const metrics = sandbox.createStubInstance(BeaconMetrics);
+  metrics.peerGoodbyeReceived = {inc: sinon.stub()} as any;
   let syncRpc: BeaconReqRespHandler;
   let chainStub: StubbedBeaconChain,
     networkStub: SinonStubbedInstance<Network>,

--- a/packages/lodestar/test/unit/sync/reqResp.test.ts
+++ b/packages/lodestar/test/unit/sync/reqResp.test.ts
@@ -10,6 +10,7 @@ import {IBeaconDb} from "../../../src/db/api";
 import {Network} from "../../../src/network";
 import {ReqResp} from "../../../src/network/reqresp/reqResp";
 import {BeaconReqRespHandler} from "../../../src/sync/reqResp";
+import {BeaconMetrics} from "../../../src/metrics";
 import {generateEmptySignedBlock} from "../../utils/block";
 import {getBlockSummary} from "../../utils/headBlockInfo";
 import {testLogger} from "../../utils/logger";
@@ -24,6 +25,7 @@ describe("sync req resp", function () {
   const peerId = new PeerId(Buffer.from("lodestar"));
   const logger = testLogger();
   const sandbox = sinon.createSandbox();
+  const metrics = sandbox.createStubInstance(BeaconMetrics);
   let syncRpc: BeaconReqRespHandler;
   let chainStub: StubbedBeaconChain,
     networkStub: SinonStubbedInstance<Network>,
@@ -51,6 +53,7 @@ describe("sync req resp", function () {
       db: (dbStub as unknown) as IBeaconDb,
       chain: chainStub,
       network: networkStub,
+      metrics,
       logger,
     });
   });


### PR DESCRIPTION
 - `lodestar_peers_by_direction`:  Peers labeled by direction
 - `lodestar_peer_connected`: Number of peer:connected event, labeled by direction
 - `lodestar_peer_disconnected`: Number of peer:disconnected event, labeled by direction
 - `lodestar_peer_goodbye_received`: Number of goodbye received, labeled by reason
 - `lodestar_peer_goodbye_sent`: Number of goodbye sent, labeled by reason
 - `lodestar_peers_total_unique_connected`: Total number of unique peers that have had a connection with
