### PR TITLE
Improve toBeProcessedStartEpoch logic

### DIFF
--- a/packages/lodestar/src/sync/range/utils/batches.ts
+++ b/packages/lodestar/src/sync/range/utils/batches.ts
@@ -63,10 +63,10 @@ export function getNextBatchToProcess(batches: Batch[]): Batch | undefined {
  * Compute the startEpoch of the next batch to be processed
  */
 export function toBeProcessedStartEpoch(batches: Batch[], startEpoch: Epoch, opts: BatchOpts): Epoch {
-  const startEpochs = batches
-    .filter((batch) => batch.state.status === BatchStatus.AwaitingValidation)
-    .map((batch) => batch.startEpoch);
-  return startEpochs.length > 0 ? Math.max(...startEpochs) + opts.epochsPerBatch : startEpoch;
+  const lastAwaitingValidation = batches
+    .reverse()
+    .find((batch) => batch.state.status === BatchStatus.AwaitingValidation);
+  return lastAwaitingValidation ? lastAwaitingValidation.startEpoch + opts.epochsPerBatch : startEpoch;
 }
 
 /**


### PR DESCRIPTION
Batches must be sorted, and always match this pattern
```
[AwaitingValidation]* [Processing]? [AwaitingDownload,Downloading,AwaitingProcessing]*
```

So it can directly find the first (from end) in state AwaitingValidation, instead of filtering and then computing the max.