### PR TITLE
Wrap errors in Range Sync Chain

### DIFF
--- a/packages/lodestar/src/sync/range/utils/index.ts
+++ b/packages/lodestar/src/sync/range/utils/index.ts
@@ -1,0 +1,3 @@
+export * from "./batches";
+export * from "./peerBalancer";
+export * from "./wrapError";

--- a/packages/lodestar/src/sync/range/utils/wrapError.ts
+++ b/packages/lodestar/src/sync/range/utils/wrapError.ts
@@ -1,0 +1,22 @@
+type Result<T> = {err: null; result: T} | {err: Error};
+
+/**
+ * Wraps a promise to return either an error or result
+ * Useful for SyncChain code that must ensure in a sample code
+ * ```ts
+ * try {
+ *   A()
+ * } catch (e) {
+ *   B()
+ * }
+ * ```
+ * only EITHER fn A() and fn B() are called, but never both. In the snipped above
+ * if A() throws, B() would be called.
+ */
+export async function wrapError<T>(promise: Promise<T>): Promise<Result<T>> {
+  try {
+    return {err: null, result: await promise};
+  } catch (err) {
+    return {err};
+  }
+}


### PR DESCRIPTION
Range Sync batches have state changing methods `processingSuccess()` and `processingError()`. Only one can be called after processing the batch, if both are called it would result in an error. With the current try / catch pattern, if `processingSuccess()` body throws, `processingError()` will be called too. This PR uses an error handling pattern common in Go and Rust where function calls return a tuple with (err, result). It's very useful here since then we can ensure to only call one of the batch state changing methods with an if.