### PR TITLE
Add Optional metrics

### DIFF
--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -20,7 +20,7 @@ type BlockProcessorModules = {
   forkChoice: IForkChoice;
   regen: IStateRegenerator;
   emitter: ChainEventEmitter;
-  metrics: IBeaconMetrics;
+  metrics?: IBeaconMetrics;
   clock: IBeaconClock;
   checkpointStateCache: CheckpointStateCache;
 };
@@ -53,7 +53,7 @@ export class BlockProcessor {
   }
 
   private onJobDone = ({ms}: {ms: number}): void => {
-    this.modules.metrics.blockProcessorTotalAsyncTime.inc(ms / 1000);
+    this.modules.metrics?.blockProcessorTotalAsyncTime.inc(ms / 1000);
   };
 }
 

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -35,7 +35,7 @@ export interface IBeaconChainModules {
   config: IBeaconConfig;
   db: IBeaconDb;
   logger: ILogger;
-  metrics: IBeaconMetrics;
+  metrics?: IBeaconMetrics;
   anchorState: TreeBacked<phase0.BeaconState>;
 }
 
@@ -54,7 +54,7 @@ export class BeaconChain implements IBeaconChain {
   protected readonly config: IBeaconConfig;
   protected readonly db: IBeaconDb;
   protected readonly logger: ILogger;
-  protected readonly metrics: IBeaconMetrics;
+  protected readonly metrics?: IBeaconMetrics;
   protected readonly opts: IChainOptions;
   protected readonly genesisTime: Number64;
   /**

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -145,7 +145,7 @@ export function onCheckpoint(this: BeaconChain, cp: phase0.Checkpoint, stateCont
   this.logger.verbose("Checkpoint processed", this.config.types.phase0.Checkpoint.toJson(cp));
   this.checkpointStateCache.add(cp, stateContext);
 
-  this.metrics.currentValidators.set({status: "active"}, stateContext.epochCtx.currentShuffling.activeIndices.length);
+  this.metrics?.currentValidators.set({status: "active"}, stateContext.epochCtx.currentShuffling.activeIndices.length);
   const parentBlockSummary = this.forkChoice.getBlock(stateContext.state.latestBlockHeader.parentRoot);
 
   if (parentBlockSummary) {
@@ -166,13 +166,13 @@ export function onCheckpoint(this: BeaconChain, cp: phase0.Checkpoint, stateCont
 
 export function onJustified(this: BeaconChain, cp: phase0.Checkpoint, stateContext: ITreeStateContext): void {
   this.logger.verbose("Checkpoint justified", this.config.types.phase0.Checkpoint.toJson(cp));
-  this.metrics.previousJustifiedEpoch.set(stateContext.state.previousJustifiedCheckpoint.epoch);
-  this.metrics.currentJustifiedEpoch.set(cp.epoch);
+  this.metrics?.previousJustifiedEpoch.set(stateContext.state.previousJustifiedCheckpoint.epoch);
+  this.metrics?.currentJustifiedEpoch.set(cp.epoch);
 }
 
 export function onFinalized(this: BeaconChain, cp: phase0.Checkpoint): void {
   this.logger.verbose("Checkpoint finalized", this.config.types.phase0.Checkpoint.toJson(cp));
-  this.metrics.finalizedEpoch.set(cp.epoch);
+  this.metrics?.finalizedEpoch.set(cp.epoch);
 }
 
 export function onForkChoiceJustified(this: BeaconChain, cp: phase0.Checkpoint): void {
@@ -188,7 +188,7 @@ export function onForkChoiceHead(this: BeaconChain, head: IBlockSummary): void {
     headSlot: head.slot,
     headRoot: toHexString(head.blockRoot),
   });
-  this.metrics.headSlot.set(head.slot);
+  this.metrics?.headSlot.set(head.slot);
 }
 
 export function onForkChoiceReorg(this: BeaconChain, head: IBlockSummary, oldHead: IBlockSummary, depth: number): void {

--- a/packages/lodestar/src/metrics/beacon.ts
+++ b/packages/lodestar/src/metrics/beacon.ts
@@ -239,21 +239,17 @@ export class BeaconMetrics extends Metrics implements IBeaconMetrics {
       registers,
     });
 
-    // Private - only used once in start()
+    // Private - only used once now
     this.lodestarVersion = new Gauge({
       name: "lodestar_version",
       help: "Lodestar version",
       labelNames: ["semver", "branch", "commit", "version"],
       registers,
     });
-  }
-
-  public start(): void {
-    super.start();
     this.lodestarVersion.set(readLodestarGitData(), 1);
   }
 
-  public stop(): void {
-    super.stop();
+  public close(): void {
+    super.close();
   }
 }

--- a/packages/lodestar/src/metrics/interface.ts
+++ b/packages/lodestar/src/metrics/interface.ts
@@ -141,6 +141,8 @@ export interface IBeaconMetrics extends IMetrics {
   peerGoodbyeSent: Gauge;
   /** Total number of unique peers that have had a connection with */
   peersTotalUniqueConnected: Gauge;
+
+  close(): void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/packages/lodestar/src/metrics/metrics.ts
+++ b/packages/lodestar/src/metrics/metrics.ts
@@ -16,9 +16,7 @@ export class Metrics implements IMetrics {
   public constructor(opts: IMetricsOptions) {
     this.opts = opts;
     this.registry = new Registry();
-  }
 
-  public start(): void {
     this.defaultInterval = collectDefaultMetrics({
       register: this.registry,
       timeout: this.opts.timeout,
@@ -31,7 +29,7 @@ export class Metrics implements IMetrics {
     gcStats(this.registry)();
   }
 
-  public stop(): void {
+  public close(): void {
     clearInterval(this.defaultInterval as NodeJS.Timeout);
   }
 }

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -28,7 +28,7 @@ interface ILibp2pModules {
   config: IBeaconConfig;
   libp2p: LibP2p;
   logger: ILogger;
-  metrics: IBeaconMetrics;
+  metrics?: IBeaconMetrics;
   validator: IGossipMessageValidator;
   chain: IBeaconChain;
 }
@@ -46,7 +46,7 @@ export class Network extends (EventEmitter as {new (): NetworkEventEmitter}) imp
   private config: IBeaconConfig;
   private libp2p: LibP2p;
   private logger: ILogger;
-  private metrics: IBeaconMetrics;
+  private metrics?: IBeaconMetrics;
   private diversifyPeersTask: DiversifyPeersBySubnetTask;
   private checkPeerAliveTask: CheckPeerAliveTask;
   /** To count total number of unique seen peers */
@@ -264,18 +264,18 @@ export class Network extends (EventEmitter as {new (): NetworkEventEmitter}) imp
     // tmp fix, we will just do double status exchange but nothing major
     // TODO: fix it?
     this.emit(NetworkEvent.peerConnect, conn.remotePeer, conn.stat.direction);
-    this.metrics.peerConnectedEvent.inc({direction: conn.stat.direction});
+    this.metrics?.peerConnectedEvent.inc({direction: conn.stat.direction});
     this.runPeerCountMetrics();
 
     this.seenPeers.add(conn.remotePeer.toB58String());
-    this.metrics.peersTotalUniqueConnected.set(this.seenPeers.size);
+    this.metrics?.peersTotalUniqueConnected.set(this.seenPeers.size);
   };
 
   private emitPeerDisconnect = (conn: LibP2pConnection): void => {
     this.logger.verbose("peer disconnected", {peerId: conn.remotePeer.toB58String()});
 
     this.emit(NetworkEvent.peerDisconnect, conn.remotePeer);
-    this.metrics.peerDisconnectedEvent.inc({direction: conn.stat.direction});
+    this.metrics?.peerDisconnectedEvent.inc({direction: conn.stat.direction});
     this.runPeerCountMetrics();
   };
 
@@ -293,9 +293,9 @@ export class Network extends (EventEmitter as {new (): NetworkEventEmitter}) imp
     }
 
     for (const [direction, peers] of peersByDirection.entries()) {
-      this.metrics.peersByDirection.set({direction}, peers);
+      this.metrics?.peersByDirection.set({direction}, peers);
     }
 
-    this.metrics.peers.set(total);
+    this.metrics?.peers.set(total);
   }
 }

--- a/packages/lodestar/src/sync/interface.ts
+++ b/packages/lodestar/src/sync/interface.ts
@@ -42,7 +42,7 @@ export interface ISyncModules {
   db: IBeaconDb;
   logger: ILogger;
   chain: IBeaconChain;
-  metrics: IBeaconMetrics;
+  metrics?: IBeaconMetrics;
   regularSync?: IRegularSync;
   reqRespHandler?: IReqRespHandler;
   gossipHandler?: IGossipHandler;

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -23,7 +23,7 @@ export interface IReqRespHandlerModules {
   db: IBeaconDb;
   chain: IBeaconChain;
   network: INetwork;
-  metrics: IBeaconMetrics;
+  metrics?: IBeaconMetrics;
   logger: ILogger;
 }
 
@@ -58,7 +58,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
   private db: IBeaconDb;
   private chain: IBeaconChain;
   private network: INetwork;
-  private metrics: IBeaconMetrics;
+  private metrics?: IBeaconMetrics;
   private logger: ILogger;
 
   public constructor({config, db, chain, network, metrics, logger}: IReqRespHandlerModules) {
@@ -144,7 +144,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
   private async *onGoodbye(goodbyeCode: phase0.Goodbye, peerId: PeerId): AsyncIterable<bigint> {
     const reason = GoodbyeReasonCodeDescriptions[goodbyeCode.toString()] || "";
     this.logger.verbose("Received goodbye request", {peer: peerId.toB58String(), code: goodbyeCode, reason});
-    this.metrics.peerGoodbyeReceived.inc({reason});
+    this.metrics?.peerGoodbyeReceived.inc({reason});
 
     yield BigInt(GoodByeReasonCode.CLIENT_SHUTDOWN);
 
@@ -168,7 +168,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
 
   private async goodbye(peerId: PeerId, goodbyeCode: GoodByeReasonCode): Promise<void> {
     const reason = GoodbyeReasonCodeDescriptions[goodbyeCode.toString()] || "";
-    this.metrics.peerGoodbyeSent.inc({reason});
+    this.metrics?.peerGoodbyeSent.inc({reason});
 
     await this.network.reqResp.goodbye(peerId, BigInt(goodbyeCode));
   }

--- a/packages/lodestar/test/unit/metrics/beacon.test.ts
+++ b/packages/lodestar/test/unit/metrics/beacon.test.ts
@@ -6,7 +6,6 @@ describe("BeaconMetrics", () => {
   const logger: ILogger = new WinstonLogger();
   it("updated metrics should be reflected in the registry", () => {
     const m = new BeaconMetrics({enabled: true, timeout: 5000, pushGateway: false, serverPort: 0}, {logger});
-    m.start();
     // basic assumptions
     expect(m.registry.getMetricsAsArray().length).to.be.gt(0);
     expect(m.registry.metrics()).to.not.equal("");
@@ -16,6 +15,6 @@ describe("BeaconMetrics", () => {
     expect(m.registry.getSingleMetricAsString("libp2p_peers").match(/libp2p_peers 1/)).to.not.be.null;
     m.peers.set(20);
     expect(m.registry.getSingleMetricAsString("libp2p_peers").match(/libp2p_peers 20/)).to.not.be.null;
-    m.stop();
+    m.close();
   });
 });

--- a/packages/lodestar/test/unit/metrics/metrics.test.ts
+++ b/packages/lodestar/test/unit/metrics/metrics.test.ts
@@ -4,9 +4,8 @@ import {Metrics} from "../../../src/metrics";
 describe("Metrics", () => {
   it("should get default metrics from registry", () => {
     const m = new Metrics({enabled: true, timeout: 5000, serverPort: 0, pushGateway: false});
-    m.start();
     expect(m.registry.getMetricsAsArray().length).to.be.gt(0);
     expect(m.registry.metrics()).to.not.equal("");
-    m.stop();
+    m.close();
   });
 });

--- a/packages/lodestar/test/unit/metrics/server/http.test.ts
+++ b/packages/lodestar/test/unit/metrics/server/http.test.ts
@@ -7,10 +7,9 @@ describe("HttpMetricsServer", () => {
     const options = {enabled: true, timeout: 5000, serverPort: 0, pushGateway: false};
     const metrics = new Metrics(options);
     const server = new HttpMetricsServer(options, {metrics, logger});
-    metrics.start();
     await server.start();
     await request(server.http).get("/metrics").expect(200);
     await server.stop();
-    metrics.stop();
+    metrics.close();
   });
 });


### PR DESCRIPTION
See #2114 
- Optionally initialize a `BeaconMetrics` instance in `BeaconNode`
- Update downstream modules to accept `BeaconMetrics | undefined`
- Consumers use optional chaining when accessing metrics (eg: `this.metrics?.fooMetric.inc(...)`)
- Clean up `BeaconMetrics` initialization, move `start` to constructor