### PR TITLE
Run mainnet by default in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     restart: always
     volumes:
       - lodestar:/root/.local/share/lodestar
-    command: beacon --network ${NETWORK:-pyrmont}
+    command: beacon
     ports:
       - "9000:9000"
 


### PR DESCRIPTION
Lodestar-cli supports passing args as envs so if you need to run Pyrmont you can set LODESTAR_NETWORK=pyrmont