### PR TITLE
Set CLI arg network to a default

### DIFF
--- a/packages/lodestar-cli/src/options/globalOptions.ts
+++ b/packages/lodestar-cli/src/options/globalOptions.ts
@@ -10,6 +10,8 @@ interface IGlobalSingleArgs {
   paramsFile: string;
 }
 
+export const defaultNetwork: NetworkName = "mainnet";
+
 const globalSingleOptions: ICliCommandOptions<IGlobalSingleArgs> = {
   rootDir: {
     description: "Lodestar root directory",
@@ -20,6 +22,7 @@ const globalSingleOptions: ICliCommandOptions<IGlobalSingleArgs> = {
   network: {
     description: "Name of the Eth2 chain network to join",
     type: "string",
+    default: defaultNetwork,
     choices: networkNames,
   },
 


### PR DESCRIPTION
If `--network` is not set the `initBeaconState` logic would not fetch the genesisStateFile due to faulty logic. This PR fixes the bug from two approaches:
- Sets `mainnet` as default value to the `--network` arg
- Simplifies the logic of the `initBeaconState`