### PR TITLE
Delete deserialized gossip after emitting

### DIFF
--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -142,8 +142,10 @@ export class LodestarGossipsub extends Gossipsub {
    */
   public _emitMessage(message: InMessage): void {
     for (const topic of message.topicIDs) {
-      const transformedObj = this.transformedObjects.get(msgIdToString(this.getMsgId(message)));
+      const msgIdStr = msgIdToString(this.getMsgId(message));
+      const transformedObj = this.transformedObjects.get(msgIdStr);
       if (transformedObj && transformedObj.object) {
+        this.transformedObjects.delete(msgIdStr);
         super.emit(topic, transformedObj.object);
       }
     }


### PR DESCRIPTION
Inspecting heapdumps, found that many `Tree` objects exist.
Determined that 3% of memory was being retained in `transformedObjects`.
