### PR TITLE
Validate empty password on validator import

### DIFF
--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/import.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/import.ts
@@ -175,8 +175,7 @@ required each time the validator client starts
       message: "Enter the keystore password, or press enter to omit it",
       validate: async (input) => {
         try {
-          // Accept empty passwords
-          if (input) await keystore.decrypt(stripOffNewlines(input));
+          await keystore.decrypt(stripOffNewlines(input));
           return true;
         } catch (e) {
           return `Invalid password: ${e.message}`;

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/import.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/import.ts
@@ -175,6 +175,7 @@ required each time the validator client starts
       message: "Enter the keystore password, or press enter to omit it",
       validate: async (input) => {
         try {
+          console.log("\nValidating password...");
           await keystore.decrypt(stripOffNewlines(input));
           return true;
         } catch (e) {


### PR DESCRIPTION
we were allowing the user to type in a blank password even when the keystore that they were importing with didn't have a blank password.  this fixes that.  also, the official eth2 deposit tool doesn't allow blank passwords, so we probably shouldn't be expecting that scenario anyway.

i also added a console log to let the user know that the cli is validating their password input (before it didn't respond until it either failed or succeeded)