### PR TITLE
Remove slightly unnecessary notNullish usage

### DIFF
--- a/packages/lodestar-light-client/src/sync/validation.ts
+++ b/packages/lodestar-light-client/src/sync/validation.ts
@@ -1,6 +1,6 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {lightclient} from "@chainsafe/lodestar-types";
-import {assert, intDiv, verifyMerkleBranch, notNullish} from "@chainsafe/lodestar-utils";
+import {assert, intDiv, verifyMerkleBranch} from "@chainsafe/lodestar-utils";
 import {
   FINALIZED_ROOT_INDEX,
   NEXT_SYNC_COMMITTEE_INDEX,
@@ -72,15 +72,12 @@ export function isValidLightclientUpdate(
     );
   }
   assert.gte(Array.from(update.syncCommitteeBits).filter((bit) => !!bit).length, MIN_SYNC_COMMITTEE_PARTICIPANTS);
-  const participantPubkeys = Array.from(update.syncCommitteeBits)
-    .map((bit) => {
-      if (bit) {
-        return syncCommittee.pubkeys.valueOf() as Uint8Array;
-      } else {
-        return null;
-      }
-    })
-    .filter(notNullish);
+  const participantPubkeys: Uint8Array[] = [];
+  for (const bit of Array.from(update.syncCommitteeBits)) {
+    if (bit) {
+      participantPubkeys.push(syncCommittee.pubkeys.valueOf() as Uint8Array);
+    }
+  }
   const domain = computeDomain(config, config.params.DOMAIN_SYNC_COMMITTEE, update.forkVersion);
   const signingRoot = computeSigningRoot(config, config.types.lightclient.BeaconBlockHeader, signedHeader, domain);
   assert.true(verifyAggregate(participantPubkeys, signingRoot, update.syncCommitteeSignature.valueOf() as Uint8Array));

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -6,7 +6,7 @@ import bls, {Signature} from "@chainsafe/bls";
 import {computeStartSlotAtEpoch, computeSubnetForCommitteesAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Bytes96, CommitteeIndex, Epoch, Root, phase0, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
-import {assert, ILogger, notNullish} from "@chainsafe/lodestar-utils";
+import {assert, ILogger} from "@chainsafe/lodestar-utils";
 import {readOnlyForEach, TreeBacked} from "@chainsafe/ssz";
 import {IAttestationJob, IBeaconChain} from "../../../chain";
 import {assembleAttestationData} from "../../../chain/factory/attestation";
@@ -113,7 +113,7 @@ export class ValidatorApi implements IValidatorApi {
         }
         return assembleAttesterDuty(this.config, {pubkey: validator.pubkey, index: validatorIndex}, epochCtx, epoch);
       })
-      .filter(notNullish) as phase0.AttesterDuty[];
+      .filter((duty): duty is phase0.AttesterDuty => duty != null);
   }
 
   public async getAggregatedAttestation(attestationDataRoot: Root, slot: Slot): Promise<phase0.Attestation> {

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -18,7 +18,6 @@ import {FAR_FUTURE_EPOCH, GENESIS_EPOCH, ZERO_HASH} from "../constants";
 import {IBeaconDb} from "../db";
 import {CheckpointStateCache, StateContextCache} from "./stateCache";
 import {IBeaconMetrics} from "../metrics";
-import {notNullish} from "@chainsafe/lodestar-utils";
 import {AttestationPool, AttestationProcessor} from "./attestation";
 import {BlockPool, BlockProcessor} from "./blocks";
 import {IBeaconClock, LocalClock} from "./clock";
@@ -218,7 +217,7 @@ export class BeaconChain implements IBeaconChain {
     }
 
     const unfinalizedBlocks = await Promise.all(slots.map((slot) => blockRootsPerSlot.get(slot)));
-    return unfinalizedBlocks.filter(notNullish);
+    return unfinalizedBlocks.filter((block): block is phase0.SignedBeaconBlock => block != null);
   }
 
   public getFinalizedCheckpoint(): phase0.Checkpoint {

--- a/packages/lodestar/src/network/peers/metastore.ts
+++ b/packages/lodestar/src/network/peers/metastore.ts
@@ -2,7 +2,6 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import PeerId from "peer-id";
 import {phase0} from "@chainsafe/lodestar-types";
 import {BasicType, ContainerType, Json} from "@chainsafe/ssz";
-import {notNullish} from "@chainsafe/lodestar-utils";
 import {ReqRespEncoding} from "../../constants";
 
 /**
@@ -48,7 +47,7 @@ export class Libp2pPeerMetadataStore implements IPeerMetadataStore {
   private typedStore<T>(key: string, type: BasicType<T> | ContainerType<T>): PeerStoreBucket<T> {
     return {
       set: (peer: PeerId, value: T): void => {
-        if (notNullish(value)) {
+        if (value != null) {
           this.metabook.set(peer, key, Buffer.from(type.serialize(value)));
         } else {
           this.metabook.deleteValue(peer, key);

--- a/packages/lodestar/src/network/peers/utils.ts
+++ b/packages/lodestar/src/network/peers/utils.ts
@@ -4,7 +4,6 @@ import {ATTESTATION_SUBNET_COUNT} from "../../constants";
 import {INetwork} from "../interface";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {getSyncProtocols} from "../util";
-import {notNullish} from "@chainsafe/lodestar-utils";
 import {getSyncPeers} from "../../sync/utils/peers";
 
 /**
@@ -42,7 +41,7 @@ export async function handlePeerMetadataSequence(
   metadataSeq: BigInt | null
 ): Promise<void> {
   const latestMetadata = network.peerMetadata.metadata.get(peer);
-  if (notNullish(metadataSeq) && (!latestMetadata || latestMetadata.seqNumber < metadataSeq)) {
+  if (metadataSeq !== null && (!latestMetadata || latestMetadata.seqNumber < metadataSeq)) {
     try {
       logger.verbose("Getting peer metadata", {peer: peer.toB58String()});
       network.peerMetadata.metadata.set(peer, await network.reqResp.metadata(peer));

--- a/packages/lodestar/src/sync/utils/blocks.ts
+++ b/packages/lodestar/src/sync/utils/blocks.ts
@@ -3,7 +3,7 @@ import {phase0, Slot} from "@chainsafe/lodestar-types";
 import {RoundRobinArray} from "./robin";
 import {IReqResp} from "../../network";
 import {ISlotRange} from "../interface";
-import {ILogger, notNullish} from "@chainsafe/lodestar-utils";
+import {ILogger} from "@chainsafe/lodestar-utils";
 
 /**
  * Creates slot chunks returned chunks represents (inclusive) start and (inclusive) end slot
@@ -79,7 +79,7 @@ export async function getBlockRange(
           }
         })
       )
-    ).filter(notNullish);
+    ).filter((chunk): chunk is ISlotRange => chunk != null);
     retry++;
     if ((retry > maxRetry || retry > peers.length) && chunks.length > 0) {
       logger.error("Max req retry for blocks by range. Failed chunks", JSON.stringify(chunks));

--- a/packages/lodestar/tsconfig.json
+++ b/packages/lodestar/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig",
-  "include": ["src", "test", "../lodestar-utils/src/notNullish.ts"],
+  "include": ["src", "test"],
   "exclude": ["../../node_modules/it-pipe"],
   "compilerOptions": {
     "typeRoots": ["../../node_modules/@types", "../../node_modules/libp2p-ts/types", "./types"],


### PR DESCRIPTION
Although I added the `notNullish` utility I believe it encourages patterns that could be simplified with a simple for loop and predeclaring an array, instead of returning null, then looping again to drop those values.

I would be in favor of removing the `notNullish` utility from the utils library but that would be a breaking change.