### PR TITLE
Remove unnecessary CLI alias-es

### DIFF
--- a/packages/lodestar-cli/src/cmds/account/cmds/wallet/create.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/wallet/create.ts
@@ -52,7 +52,7 @@ export const create: ICliCommand<IWalletCreateArgs, IAccountWalletArgs & IGlobal
   If the file does not exist, a random password will be generated and saved at that \
   path. To avoid confusion, if the file does not already exist it must include a \
   '.pass' suffix.",
-      alias: ["passphrase-file", "p"],
+      alias: ["p"],
       demandOption: true,
       type: "string",
     },
@@ -68,7 +68,6 @@ wallets are supported presently.",
 
     mnemonicOutputPath: {
       description: "If present, the mnemonic will be saved to this file",
-      alias: ["mnemonic-output-path"],
       type: "string",
     },
   },

--- a/packages/lodestar-cli/src/cmds/beacon/options.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/options.ts
@@ -35,7 +35,6 @@ const beaconPathsOptions: ICliCommandOptions<IBeaconPaths> = {
   },
 
   dbDir: {
-    alias: ["db.dir", "db.name"],
     description: "Beacon DB directory",
     defaultDescription: defaultBeaconPaths.dbDir,
     hidden: true,
@@ -44,7 +43,6 @@ const beaconPathsOptions: ICliCommandOptions<IBeaconPaths> = {
   },
 
   configFile: {
-    alias: ["config"],
     description: "Beacon node configuration file path",
     defaultDescription: defaultBeaconPaths.configFile,
     type: "string",
@@ -77,7 +75,6 @@ const beaconPathsOptions: ICliCommandOptions<IBeaconPaths> = {
 
   logFile: {
     description: "Path to output all logs to a persistent log file",
-    alias: ["log.file"],
     type: "string",
     normalize: true,
   },

--- a/packages/lodestar-cli/src/cmds/validator/options.ts
+++ b/packages/lodestar-cli/src/cmds/validator/options.ts
@@ -20,7 +20,6 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
   validatorsDbDir: {
     description: "Data directory for validator databases.",
     defaultDescription: defaultValidatorPaths.validatorsDbDir,
-    alias: ["dbDir", "db.dir", "db.name"],
     normalize: true,
     type: "string",
   },


### PR DESCRIPTION
Yargs automatically converts pascalCase arg names to kebab-case. Other aliases are historical baggage.