### PR TITLE
Cache balances as chunks

### DIFF
--- a/packages/lodestar-beacon-state-transition/package.json
+++ b/packages/lodestar-beacon-state-transition/package.json
@@ -42,6 +42,7 @@
     "@chainsafe/lodestar-utils": "^0.17.0",
     "@chainsafe/persistent-ts": "^0.17.0",
     "@chainsafe/ssz": "^0.7.0",
+    "@chainsafe/persistent-merkle-tree": "^0.2.3",
     "bigint-buffer": "^1.1.5",
     "buffer-xor": "^2.0.2"
   },

--- a/packages/lodestar-beacon-state-transition/src/phase0/fast/block/processDeposit.ts
+++ b/packages/lodestar-beacon-state-transition/src/phase0/fast/block/processDeposit.ts
@@ -3,7 +3,7 @@ import {phase0} from "@chainsafe/lodestar-types";
 import {verifyMerkleBranch, bigIntMin} from "@chainsafe/lodestar-utils";
 
 import {DEPOSIT_CONTRACT_TREE_DEPTH, FAR_FUTURE_EPOCH} from "../../../constants";
-import {computeDomain, computeSigningRoot, increaseBalance} from "../../../util";
+import {computeDomain, computeSigningRoot} from "../../../util";
 import {CachedValidatorsBeaconState, EpochContext} from "../util";
 
 export function processDeposit(
@@ -57,10 +57,10 @@ export function processDeposit(
       effectiveBalance: bigIntMin(amount - (amount % EFFECTIVE_BALANCE_INCREMENT), MAX_EFFECTIVE_BALANCE),
       slashed: false,
     });
-    state.balances.push(amount);
+    state.addBalance(amount);
   } else {
     // increase balance by deposit amount
-    increaseBalance(state, cachedIndex, amount);
+    state.increaseBalanceBigInt(cachedIndex, amount);
   }
   // now that there is a new validator, update the epoch context with the new pubkey
   epochCtx.syncPubkeys(state);

--- a/packages/lodestar-beacon-state-transition/src/phase0/fast/block/slashValidator.ts
+++ b/packages/lodestar-beacon-state-transition/src/phase0/fast/block/slashValidator.ts
@@ -1,6 +1,5 @@
 import {ValidatorIndex} from "@chainsafe/lodestar-types";
 
-import {decreaseBalance, increaseBalance} from "../../../util";
 import {CachedValidatorsBeaconState, EpochContext} from "../util";
 import {initiateValidatorExit} from "./initiateValidatorExit";
 
@@ -24,7 +23,7 @@ export function slashValidator(
     withdrawableEpoch: Math.max(validator.withdrawableEpoch, epoch + EPOCHS_PER_SLASHINGS_VECTOR),
   });
   state.slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] += validator.effectiveBalance;
-  decreaseBalance(state, slashedIndex, validator.effectiveBalance / BigInt(MIN_SLASHING_PENALTY_QUOTIENT));
+  state.decreaseBalanceBigInt(slashedIndex, validator.effectiveBalance / BigInt(MIN_SLASHING_PENALTY_QUOTIENT));
 
   // apply proposer and whistleblower rewards
   const proposerIndex = epochCtx.getBeaconProposer(state.slot);
@@ -33,6 +32,6 @@ export function slashValidator(
   }
   const whistleblowerReward = validator.effectiveBalance / BigInt(WHISTLEBLOWER_REWARD_QUOTIENT);
   const proposerReward = whistleblowerReward / BigInt(PROPOSER_REWARD_QUOTIENT);
-  increaseBalance(state, proposerIndex, proposerReward);
-  increaseBalance(state, whistleblowerIndex, whistleblowerReward - proposerReward);
+  state.increaseBalanceBigInt(proposerIndex, proposerReward);
+  state.increaseBalanceBigInt(whistleblowerIndex, whistleblowerReward - proposerReward);
 }

--- a/packages/lodestar-beacon-state-transition/src/phase0/fast/epoch/processFinalUpdates.ts
+++ b/packages/lodestar-beacon-state-transition/src/phase0/fast/epoch/processFinalUpdates.ts
@@ -33,10 +33,11 @@ export function processFinalUpdates(
     state.eth1DataVotes = ([] as phase0.Eth1Data[]) as List<phase0.Eth1Data>;
   }
 
+  const balances = state.getBalances();
   // update effective balances with hysteresis
   for (let i = 0; i < process.statuses.length; i++) {
     const status = process.statuses[i];
-    const balance = state.getBalance(i);
+    const balance = balances[i];
     const effectiveBalance = status.validator.effectiveBalance;
     if (balance + DOWNWARD_THRESHOLD < effectiveBalance || effectiveBalance + UPWARD_THRESHOLD < balance) {
       state.updateValidator(i, {

--- a/packages/lodestar-beacon-state-transition/src/phase0/fast/epoch/processFinalUpdates.ts
+++ b/packages/lodestar-beacon-state-transition/src/phase0/fast/epoch/processFinalUpdates.ts
@@ -1,5 +1,5 @@
 import {phase0} from "@chainsafe/lodestar-types";
-import {List, readOnlyMap} from "@chainsafe/ssz";
+import {List} from "@chainsafe/ssz";
 import {bigIntMin, intDiv} from "@chainsafe/lodestar-utils";
 import {getRandaoMix} from "../../../util";
 import {EpochContext, IEpochProcess, CachedValidatorsBeaconState} from "../util";
@@ -34,13 +34,9 @@ export function processFinalUpdates(
   }
 
   // update effective balances with hysteresis
-  const balances =
-    process.balances && process.balances.length > 0
-      ? process.balances
-      : readOnlyMap(state.balances, (balance) => balance);
   for (let i = 0; i < process.statuses.length; i++) {
     const status = process.statuses[i];
-    const balance = balances[i];
+    const balance = state.getBalance(i);
     const effectiveBalance = status.validator.effectiveBalance;
     if (balance + DOWNWARD_THRESHOLD < effectiveBalance || effectiveBalance + UPWARD_THRESHOLD < balance) {
       state.updateValidator(i, {

--- a/packages/lodestar-beacon-state-transition/src/phase0/fast/epoch/processRewardsAndPenalties.ts
+++ b/packages/lodestar-beacon-state-transition/src/phase0/fast/epoch/processRewardsAndPenalties.ts
@@ -1,27 +1,16 @@
-import {phase0} from "@chainsafe/lodestar-types";
-import {readOnlyMap, List} from "@chainsafe/ssz";
-
 import {GENESIS_EPOCH} from "../../../constants";
-import {EpochContext, IEpochProcess} from "../util";
+import {CachedValidatorsBeaconState, EpochContext, IEpochProcess} from "../util";
 import {getAttestationDeltas} from "./getAttestationDeltas";
 
 export function processRewardsAndPenalties(
   epochCtx: EpochContext,
   process: IEpochProcess,
-  state: phase0.BeaconState
+  state: CachedValidatorsBeaconState
 ): void {
   // No rewards are applied at the end of `GENESIS_EPOCH` because rewards are for work done in the previous epoch
   if (process.currentEpoch === GENESIS_EPOCH) {
     return;
   }
-  const [rewards, penalties] = getAttestationDeltas(epochCtx, process, state);
-  const newBalances = readOnlyMap(state.balances, (balance, i) => {
-    const newBalance = balance + BigInt(rewards[i] - penalties[i]);
-    return newBalance < 0 ? BigInt(0) : newBalance;
-  });
-
-  process.balances = newBalances;
-  // important: do not change state one balance at a time
-  // set them all at once, constructing the tree in one go
-  state.balances = newBalances as List<bigint>;
+  const [rewards, penalties] = getAttestationDeltas(epochCtx, process, state.getOriginalState());
+  state.updateBalances(rewards, penalties);
 }

--- a/packages/lodestar-beacon-state-transition/src/phase0/fast/epoch/processSlashings.ts
+++ b/packages/lodestar-beacon-state-transition/src/phase0/fast/epoch/processSlashings.ts
@@ -1,11 +1,13 @@
 import {readOnlyMap} from "@chainsafe/ssz";
-import {phase0} from "@chainsafe/lodestar-types";
 import {bigIntMin} from "@chainsafe/lodestar-utils";
 
-import {decreaseBalance} from "../../../util";
-import {EpochContext, IEpochProcess} from "../util";
+import {CachedValidatorsBeaconState, EpochContext, IEpochProcess} from "../util";
 
-export function processSlashings(epochCtx: EpochContext, process: IEpochProcess, state: phase0.BeaconState): void {
+export function processSlashings(
+  epochCtx: EpochContext,
+  process: IEpochProcess,
+  state: CachedValidatorsBeaconState
+): void {
   const totalBalance = process.totalActiveStake;
   const totalSlashings = readOnlyMap(state.slashings, (s) => s).reduce((a, b) => a + b, BigInt(0));
   const proportionalSlashingMultiplier = BigInt(epochCtx.config.params.PROPORTIONAL_SLASHING_MULTIPLIER);
@@ -15,6 +17,6 @@ export function processSlashings(epochCtx: EpochContext, process: IEpochProcess,
     const effectiveBalance = process.statuses[index].validator.effectiveBalance;
     const penaltyNumerator = (effectiveBalance / increment) * adjustedTotalSlashingBalance;
     const penalty = (penaltyNumerator / totalBalance) * increment;
-    decreaseBalance(state, index, penalty);
+    state.decreaseBalanceBigInt(index, penalty);
   }
 }

--- a/packages/lodestar-beacon-state-transition/src/phase0/fast/util/interface.ts
+++ b/packages/lodestar-beacon-state-transition/src/phase0/fast/util/interface.ts
@@ -119,6 +119,22 @@ export class CachedValidatorsBeaconState {
     return balanceBigIntType.fromBytes(this._balanceChunks.get(chunkIndex)!, offset);
   }
 
+  public getBalances(): bigint[] {
+    const result: bigint[] = [];
+    const length = this._state.balances.length;
+    let i = 0;
+    this._balanceChunks.readOnlyForEach((chunk) => {
+      const bigUintArr = new BigUint64Array(chunk.buffer.slice(0));
+      for (let j = 0; j < 4; j++) {
+        if (i < length) {
+          result.push(bigUintArr[j]);
+        }
+        i++;
+      }
+    });
+    return result;
+  }
+
   /**
    * Process epoch (rewards + penalties)
    * Rebuild the balances tree

--- a/packages/lodestar-beacon-state-transition/src/phase0/fast/util/interface.ts
+++ b/packages/lodestar-beacon-state-transition/src/phase0/fast/util/interface.ts
@@ -308,6 +308,32 @@ export function buildBalancesTree(balanceChunks: Vector<Uint8Array>, length: num
   return tree;
 }
 
+/**
+ * For testing purpose
+ */
+export function buildBalancesTreeBigUint64Array(balances: Vector<BigUint64Array>, length: number, limit: number): Tree {
+  const contents: Node[] = balances.readOnlyMap((balance) => new LeafNode(new Uint8Array(balance.buffer.slice(0))));
+  const tree = new Tree(subtreeFillToContents(contents, getDepth(limit)));
+  setTreeLength(tree, length);
+  return tree;
+}
+
+/**
+ * For testing purpose
+ */
+export function buildBalancesTreeGiantBigUint64Array(balances: BigUint64Array, limit: number): Tree {
+  const numChunk = Math.ceil(balances.length / 4);
+  const contents: Node[] = [];
+  for (let i = 0; i < numChunk; i++) {
+    // 1 chunk = 32 bytes
+    const buffer = balances.buffer.slice(i * 8, (i + 4) * 8);
+    contents.push(new LeafNode(new Uint8Array(buffer)));
+  }
+  const tree = new Tree(subtreeFillToContents(contents, getDepth(limit)));
+  setTreeLength(tree, balances.length);
+  return tree;
+}
+
 function getDepth(limit: number): number {
   const maxChunkCount = Math.ceil((limit * 8) / 32);
   return countToDepth(BigInt(maxChunkCount)) + 1;

--- a/packages/lodestar-beacon-state-transition/src/phase0/fast/util/interface.ts
+++ b/packages/lodestar-beacon-state-transition/src/phase0/fast/util/interface.ts
@@ -227,15 +227,18 @@ export class CachedValidatorsBeaconState {
       const newChunk = new Uint8Array(32);
       newChunk.set(amountArr);
       this._balanceChunks = this._balanceChunks.append(newChunk);
-      balancesBytes8Type.tree.setRootAtChunk(this._balancesTree, this._balanceChunks.length - 1, newChunk);
     } else {
       const offset = getOffset(numBalance);
       const lastChunkIndex = this._balanceChunks.length - 1;
       const newChunk = addUint8Array(this._balanceChunks.get(lastChunkIndex)!, amountArr, offset);
       this._balanceChunks = this._balanceChunks.set(lastChunkIndex, newChunk);
-      balancesBytes8Type.tree.setRootAtChunk(this._balancesTree, lastChunkIndex, newChunk);
     }
-    setTreeLength(this._balancesTree, numBalance + 1);
+    this._state.balances.push(amount);
+    const beaconStateTree = (this._state as TreeBacked<BeaconState>).tree();
+    this._balancesTree = config.types.phase0.BeaconState.tree.getSubtreeAtChunk(
+      beaconStateTree,
+      BALANCES_FIELD_IN_BEACON_STATE
+    );
   }
 
   /**

--- a/packages/lodestar-beacon-state-transition/src/phase0/fast/util/interface.ts
+++ b/packages/lodestar-beacon-state-transition/src/phase0/fast/util/interface.ts
@@ -1,9 +1,28 @@
 import {ValidatorIndex, Slot, phase0} from "@chainsafe/lodestar-types";
-import {ByteVector, readOnlyForEach} from "@chainsafe/ssz";
 import {config} from "@chainsafe/lodestar-config/mainnet";
+import {BasicListType, BigIntUintType, ByteVector, NumberUintType, readOnlyForEach, TreeBacked} from "@chainsafe/ssz";
+import {Tree, Node, countToDepth, LeafNode, subtreeFillToContents} from "@chainsafe/persistent-merkle-tree";
 import {Vector} from "@chainsafe/persistent-ts";
 import {IFlatValidator, createIFlatValidator} from "./flatValidator";
 import {IReadonlyEpochShuffling} from ".";
+import {BeaconState} from "@chainsafe/lodestar-types/lib/phase0/types";
+import {
+  assert,
+  calculateBigIntUint8Array,
+  increaseUint8Array,
+  addUint8Array,
+  decreaseUint8ArrayGte0,
+  subtractUint8ArrayGte0,
+} from "@chainsafe/lodestar-utils";
+
+const balancesBytes8Type = new BasicListType({
+  elementType: config.types.Bytes8,
+  limit: config.params.VALIDATOR_REGISTRY_LIMIT,
+});
+
+const balanceBigIntType = new BigIntUintType({byteLength: 8});
+
+const BALANCES_FIELD_IN_BEACON_STATE = 12;
 
 /**
  * Readonly interface for EpochContext.
@@ -44,9 +63,21 @@ export class CachedValidatorsBeaconState {
   private _state: phase0.BeaconState;
   // this is immutable and shared across BeaconStates for most of the validators
   private _cachedValidators: Vector<IFlatValidator>;
+  // this is shared between persistent-merkle-tree and persistent-ts
+  // 1 chunk = 4 balances in type of Uint8Array(8) => it's a Uint8Array(32)
+  private _balanceChunks: Vector<Uint8Array>;
+  // the leaves of this tree is actually data of _balanceChunks
+  private _balancesTree: Tree;
 
-  constructor(state: phase0.BeaconState, cachedValidators: Vector<IFlatValidator>) {
+  constructor(
+    state: phase0.BeaconState,
+    balanceChunks: Vector<Uint8Array>,
+    balancesTree: Tree,
+    cachedValidators: Vector<IFlatValidator>
+  ) {
     this._state = state;
+    this._balanceChunks = balanceChunks;
+    this._balancesTree = balancesTree;
     this._cachedValidators = cachedValidators;
   }
 
@@ -83,13 +114,145 @@ export class CachedValidatorsBeaconState {
     return this._cachedValidators;
   }
 
+  public getBalance(validatorIndex: number): bigint {
+    const chunkIndex = getChunkIndex(validatorIndex);
+    const offset = getOffset(validatorIndex);
+    return balanceBigIntType.fromBytes(this._balanceChunks.get(chunkIndex)!, offset);
+  }
+
+  /**
+   * Process epoch (rewards + penalties)
+   * Rebuild the balances tree
+   */
+  public updateBalances(rewards: number[], penalties: number[]): void {
+    assert.equal(rewards.length, penalties.length, "rewards and penalties should have same length");
+    assert.equal(
+      rewards.length,
+      this._state.balances.length,
+      "rewards and balances should have same length to balance's"
+    );
+    let deltas: number[] = [];
+    let newBalanceChunks = Vector.empty<Uint8Array>();
+    for (let validatorIndex = 0; validatorIndex < rewards.length; validatorIndex++) {
+      if (validatorIndex % 4 === 0) {
+        deltas = [];
+      }
+      const delta = rewards[validatorIndex] - penalties[validatorIndex];
+      deltas.push(delta);
+      if (validatorIndex % 4 === 3 || validatorIndex === rewards.length - 1) {
+        while (deltas.length < 4) deltas.push(0);
+        const chunkIndex = getChunkIndex(validatorIndex);
+        newBalanceChunks = newBalanceChunks.append(
+          calculateBigIntUint8Array(this._balanceChunks.get(chunkIndex)!, deltas)
+        );
+      }
+    }
+    this._balanceChunks = newBalanceChunks;
+    // build the whole tree again
+    this._balancesTree = buildBalancesTree(
+      this._balanceChunks,
+      this._state.balances.length,
+      config.params.VALIDATOR_REGISTRY_LIMIT
+    );
+    const beaconStateTree = (this._state as TreeBacked<BeaconState>).tree();
+    config.types.phase0.BeaconState.tree.setSubtreeAtChunk(
+      beaconStateTree,
+      BALANCES_FIELD_IN_BEACON_STATE,
+      this._balancesTree
+    );
+  }
+
+  /**
+   * Process block, update both the tree and _balances
+   */
+  public increaseBalance(validatorIndex: number, delta: number): void {
+    assert.gte(delta, 0, "delta in increaseBalance should be >= 0");
+    const chunkIndex = getChunkIndex(validatorIndex);
+    const newChunk = new Uint8Array(32);
+    newChunk.set(this._balanceChunks.get(chunkIndex)!);
+    const offset = getOffset(validatorIndex);
+    // mutate newChunk
+    increaseUint8Array(newChunk, delta, offset);
+    this._balanceChunks = this._balanceChunks.set(chunkIndex, newChunk);
+    balancesBytes8Type.tree.setRootAtChunk(this._balancesTree, chunkIndex, newChunk);
+  }
+
+  /**
+   * Process block, update both the tree and _balances
+   */
+  public increaseBalanceBigInt(validatorIndex: number, amount: bigint): void {
+    assert.true(amount > 0, "amount in increaseBalance should be >= 0");
+    const amountUint8Array = new Uint8Array(8);
+    balanceBigIntType.toBytes(amount, amountUint8Array, 0);
+    const chunkIndex = getChunkIndex(validatorIndex);
+    const offset = getOffset(validatorIndex);
+    const newChunk = addUint8Array(this._balanceChunks.get(chunkIndex)!, amountUint8Array, offset);
+    this._balanceChunks = this._balanceChunks.set(chunkIndex, newChunk);
+    balancesBytes8Type.tree.setRootAtChunk(this._balancesTree, chunkIndex, newChunk);
+  }
+
+  /**
+   * Process block, update both the tree and _balances
+   */
+  public decreaseBalance(validatorIndex: number, delta: number): void {
+    assert.gte(delta, 0, "delta in decreaseBalance should be >= 0");
+    const chunkIndex = getChunkIndex(validatorIndex);
+    const newChunk = new Uint8Array(32);
+    newChunk.set(this._balanceChunks.get(chunkIndex)!);
+    const offset = getOffset(validatorIndex);
+    // mutate newChunk
+    decreaseUint8ArrayGte0(newChunk, delta, offset);
+    this._balanceChunks = this._balanceChunks.set(chunkIndex, newChunk);
+    balancesBytes8Type.tree.setRootAtChunk(this._balancesTree, chunkIndex, newChunk);
+  }
+
+  /**
+   * Process block, update both the tree and _balances
+   */
+  public decreaseBalanceBigInt(validatorIndex: number, delta: bigint): void {
+    assert.true(delta >= 0, "delta in decreaseBalance should be >= 0");
+    const deltaUint8Array = new Uint8Array(8);
+    balanceBigIntType.toBytes(delta, deltaUint8Array, 0);
+    const chunkIndex = getChunkIndex(validatorIndex);
+    const offset = getOffset(validatorIndex);
+    const newChunk = subtractUint8ArrayGte0(this._balanceChunks.get(chunkIndex)!, deltaUint8Array, offset);
+    this._balanceChunks = this._balanceChunks.set(chunkIndex, newChunk);
+    balancesBytes8Type.tree.setRootAtChunk(this._balancesTree, chunkIndex, newChunk);
+  }
+
+  public addBalance(amount: bigint): void {
+    const amountArr = new Uint8Array(8);
+    balanceBigIntType.toBytes(amount, amountArr, 0);
+    const numBalance = this._state.balances.length;
+    if (numBalance % 4 === 0) {
+      const newChunk = new Uint8Array(32);
+      newChunk.set(amountArr);
+      this._balanceChunks = this._balanceChunks.append(newChunk);
+      balancesBytes8Type.tree.setRootAtChunk(this._balancesTree, this._balanceChunks.length - 1, newChunk);
+    } else {
+      const offset = getOffset(numBalance);
+      const lastChunkIndex = this._balanceChunks.length - 1;
+      const newChunk = addUint8Array(this._balanceChunks.get(lastChunkIndex)!, amountArr, offset);
+      this._balanceChunks = this._balanceChunks.set(lastChunkIndex, newChunk);
+      balancesBytes8Type.tree.setRootAtChunk(this._balancesTree, lastChunkIndex, newChunk);
+    }
+    setTreeLength(this._balancesTree, numBalance);
+  }
+
   /**
    * This is very cheap thanks to persistent-merkle-tree and persistent-vector.
    */
   public clone(): CachedValidatorsBeaconState {
     const clonedState = config.types.phase0.BeaconState.clone(this._state);
     const clonedCachedValidators = this._cachedValidators.clone();
-    return new CachedValidatorsBeaconState(clonedState, clonedCachedValidators).createProxy();
+    const balanceTree = this._balancesTree.clone();
+    const balanceChunks = this._balanceChunks.clone();
+    return new CachedValidatorsBeaconState(
+      clonedState,
+      balanceChunks,
+      balanceTree,
+      clonedCachedValidators
+    ).createProxy();
   }
 
   public getOriginalState(): phase0.BeaconState {
@@ -106,7 +269,51 @@ export function createCachedValidatorsBeaconState(state: phase0.BeaconState): Ca
   readOnlyForEach(state.validators, (validator) => {
     tmpValidators.push(createIFlatValidator(validator));
   });
-  return new CachedValidatorsBeaconState(state, Vector.from(tmpValidators)).createProxy();
+  const beaconStateTree = (state as TreeBacked<BeaconState>).tree();
+  const balanceTree = config.types.phase0.BeaconState.tree.getSubtreeAtChunk(
+    beaconStateTree,
+    BALANCES_FIELD_IN_BEACON_STATE
+  );
+  let balanceChunks: Vector<Uint8Array> = Vector.empty<Uint8Array>();
+  const lastChunkIndex = getChunkIndex(state.balances.length - 1);
+  for (let chunkIndex = 0; chunkIndex <= lastChunkIndex; chunkIndex++) {
+    balanceChunks = balanceChunks.append(balancesBytes8Type.tree.getRootAtChunk(balanceTree, chunkIndex));
+  }
+
+  return new CachedValidatorsBeaconState(state, balanceChunks, balanceTree, Vector.from(tmpValidators)).createProxy();
+}
+
+/**
+ * Build tree with tree leaves sharing same data with balanceChunks
+ * @param balanceChunks each item is 32 byte representing 4 balances
+ * @param length number of validators, is not always balanceChunks * 4
+ * @param limit from the config
+ */
+export function buildBalancesTree(balanceChunks: Vector<Uint8Array>, length: number, limit: number): Tree {
+  const contents: Node[] = balanceChunks.readOnlyMap((chunk) => new LeafNode(chunk));
+  const tree = new Tree(subtreeFillToContents(contents, getDepth(limit)));
+  setTreeLength(tree, length);
+  return tree;
+}
+
+function getDepth(limit: number): number {
+  const maxChunkCount = Math.ceil((limit * 8) / 32);
+  return countToDepth(BigInt(maxChunkCount)) + 1;
+}
+
+function setTreeLength(target: Tree, length: number): void {
+  const number32Type = new NumberUintType({byteLength: 4});
+  const chunk = new Uint8Array(32);
+  number32Type.toBytes(length, chunk, 0);
+  target.setRoot(BigInt(3), chunk);
+}
+
+function getChunkIndex(validatorIndex: number): number {
+  return Math.floor(validatorIndex / 4);
+}
+
+function getOffset(validatorIndex: number): number {
+  return (validatorIndex % 4) * 8;
 }
 
 class CachedValidatorsBeaconStateProxyHandler implements ProxyHandler<CachedValidatorsBeaconState> {

--- a/packages/lodestar-beacon-state-transition/test/unit/fast/util/interface.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/fast/util/interface.test.ts
@@ -1,12 +1,14 @@
 import {config} from "@chainsafe/lodestar-config/mainnet";
-import {List, TreeBacked} from "@chainsafe/ssz";
+import {Vector} from "@chainsafe/persistent-ts";
+import {BasicListType, List, ListType, TreeBacked} from "@chainsafe/ssz";
 import {expect} from "chai";
-import {phase0} from "../../../../src";
+import {decreaseBalance, increaseBalance, phase0, ZERO_HASH} from "../../../../src";
+import {BeaconState, buildBalancesTree, createCachedValidatorsBeaconState, Gwei} from "../../../../src/phase0";
 import {generateState} from "../../../utils/state";
 
 const NUM_VALIDATORS = 100000;
 
-describe("StateTransitionBeaconState", function () {
+describe("Cache Validators", function () {
   let state: TreeBacked<phase0.BeaconState>;
   let wrappedState: phase0.fast.CachedValidatorsBeaconState;
 
@@ -78,5 +80,148 @@ describe("StateTransitionBeaconState", function () {
     expect(state.validators.length).to.be.equal(NUM_VALIDATORS + 1);
     expect(wrappedState.flatValidators().get(NUM_VALIDATORS)!.activationEpoch).to.be.equal(NUM_VALIDATORS);
     expect(state.validators[NUM_VALIDATORS].activationEpoch).to.be.equal(NUM_VALIDATORS);
+  });
+});
+
+describe("Cache balances", function () {
+  let state: BeaconState;
+  let originalState: TreeBacked<phase0.BeaconState>;
+  let cachedState: phase0.fast.CachedValidatorsBeaconState;
+  const balances = [
+    BigInt(31217089836),
+    BigInt(31217089837),
+    BigInt(31217089838),
+    BigInt(31217089839),
+    BigInt(31217089840),
+  ];
+
+  before(function () {
+    const regularState = generateState({
+      slot: 2021,
+      balances: balances as List<Gwei>,
+      finalizedCheckpoint: {root: ZERO_HASH, epoch: 10},
+    });
+    regularState.genesisTime = 1614651451;
+    originalState = config.types.phase0.BeaconState.tree.createValue(regularState);
+  });
+
+  beforeEach(function () {
+    state = originalState.clone();
+    cachedState = createCachedValidatorsBeaconState(state);
+  });
+
+  it("same balance", function () {
+    expect(cachedState.getBalance(0)).to.be.equal(state.balances[0]);
+    expect(cachedState.getBalance(1)).to.be.equal(state.balances[1]);
+    increaseBalance(state, 0, BigInt(10000));
+    cachedState.increaseBalance(0, 10000);
+    decreaseBalance(state, 1, BigInt(20000));
+    cachedState.decreaseBalance(1, 20000);
+    expect(cachedState.getBalance(0)).to.be.equal(state.balances[0]);
+    expect(cachedState.getBalance(1)).to.be.equal(state.balances[1]);
+    expect(state.balances[5]).to.be.undefined;
+    state.balances.push(BigInt(2021));
+    cachedState.addBalance(BigInt(2021));
+    // last balance
+    expect(cachedState.getBalance(5)).to.be.equal(state.balances[5]);
+    expect(config.types.phase0.BeaconState.equals(state, cachedState.getOriginalState())).to.be.true;
+  });
+
+  // failed bc we store chunks instead of balance
+  it("same serialization", function () {
+    let serialized1 = config.types.phase0.BeaconState.serialize(state);
+    let serialized2 = config.types.phase0.BeaconState.serialize(cachedState.getOriginalState());
+    expect(serialized1).to.be.deep.equal(serialized2);
+    increaseBalance(state, 0, BigInt(10000));
+    cachedState.increaseBalance(0, 10000);
+    decreaseBalance(state, 4, BigInt(20000));
+    cachedState.decreaseBalance(4, 20000);
+    serialized1 = config.types.phase0.BeaconState.serialize(state);
+    serialized2 = config.types.phase0.BeaconState.serialize(cachedState.getOriginalState());
+    expect(serialized1).to.be.deep.equal(serialized2);
+    state.balances.push(BigInt(2021));
+    cachedState.addBalance(BigInt(2021));
+    serialized1 = config.types.phase0.BeaconState.serialize(state);
+    serialized2 = config.types.phase0.BeaconState.serialize(cachedState.getOriginalState());
+    expect(serialized1).to.be.deep.equal(serialized2);
+  });
+
+  it("same hashTreeRoot", function () {
+    expect(config.types.phase0.BeaconState.hashTreeRoot(cachedState.getOriginalState())).to.be.deep.equal(
+      config.types.phase0.BeaconState.hashTreeRoot(state)
+    );
+    increaseBalance(state, 0, BigInt(10000));
+    cachedState.increaseBalanceBigInt(0, BigInt(10000));
+    decreaseBalance(state, 4, BigInt(20000));
+    cachedState.decreaseBalanceBigInt(4, BigInt(20000));
+    expect(config.types.phase0.BeaconState.hashTreeRoot(cachedState.getOriginalState())).to.be.deep.equal(
+      config.types.phase0.BeaconState.hashTreeRoot(state)
+    );
+    state.balances.push(BigInt(100000));
+    cachedState.addBalance(BigInt(100000));
+    expect(config.types.phase0.BeaconState.hashTreeRoot(cachedState.getOriginalState())).to.be.deep.equal(
+      config.types.phase0.BeaconState.hashTreeRoot(state)
+    );
+  });
+
+  it("updateBalances", function () {
+    for (let i = 0; i < balances.length; i++) {
+      increaseBalance(state, i, BigInt(10000));
+    }
+    const rewards = Array.from({length: balances.length}, () => 10000);
+    const penalties = Array.from({length: balances.length}, () => 0);
+    cachedState.updateBalances(rewards, penalties);
+    expect(config.types.phase0.BeaconState.hashTreeRoot(cachedState.getOriginalState())).to.be.deep.equal(
+      config.types.phase0.BeaconState.hashTreeRoot(state)
+    );
+  });
+
+  it("clone", function () {
+    const cloned = cachedState.clone();
+    const balance0 = cachedState.getBalance(0);
+    cloned.increaseBalance(0, 10000);
+    expect(cachedState.getBalance(0)).to.be.equal(balance0);
+  });
+
+  it("balancesBytes8Type vs BigIntUintType vs subTreeFillsToContent", function () {
+    this.timeout(0);
+    const balancesType = new ListType({
+      elementType: config.types.Gwei,
+      limit: config.params.VALIDATOR_REGISTRY_LIMIT,
+    });
+    const balancesBytes8Type = new BasicListType({
+      elementType: config.types.Bytes8,
+      limit: config.params.VALIDATOR_REGISTRY_LIMIT,
+    });
+    const newBalances = Array.from({length: 100000}, () => BigInt(31217089836));
+    let start = Date.now();
+    const balancesBigIntTree = balancesType.tree.createValue(newBalances);
+    console.log("@@@ build balancesBigIntTree in", Date.now() - start);
+    const newBalancesUint8Array = Array.from(newBalances).map((balance) => {
+      const output = new Uint8Array(8);
+      config.types.phase0.Gwei.toBytes(balance, output, 0);
+      return output;
+    });
+    let chunk = new Uint8Array(32);
+    let chunks: Vector<Uint8Array> = Vector.empty<Uint8Array>();
+    const chunkArr: Uint8Array[] = [];
+    for (let i = 0; i < newBalances.length; i++) {
+      const balance = newBalances[i];
+      if (i % 4 === 0) chunk = new Uint8Array(32);
+      config.types.phase0.Gwei.toBytes(balance, chunk, (i % 4) * 8);
+      if (i % 4 === 3 || i === newBalances.length - 1) {
+        chunks = chunks.append(chunk);
+        chunkArr.push(chunk);
+      }
+    }
+    start = Date.now();
+    const balancesUint8ArrayTree = balancesBytes8Type.tree.createValue(newBalancesUint8Array);
+    console.log("@@@ build balancesUint8ArrayTree in", Date.now() - start);
+    expect(balancesBigIntTree.hashTreeRoot()).to.be.deep.equal(balancesUint8ArrayTree.hashTreeRoot());
+
+    start = Date.now();
+    const tree = buildBalancesTree(chunks, newBalances.length, config.params.VALIDATOR_REGISTRY_LIMIT);
+    console.log("@@@ subTreeFillsToContent in", Date.now() - start);
+    expect(tree.root).to.be.deep.equal(balancesUint8ArrayTree.hashTreeRoot());
   });
 });

--- a/packages/lodestar-beacon-state-transition/test/unit/fast/util/interface.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/fast/util/interface.test.ts
@@ -107,7 +107,7 @@ describe("Cache balances", function () {
 
   beforeEach(function () {
     state = originalState.clone();
-    cachedState = createCachedValidatorsBeaconState(state);
+    cachedState = createCachedValidatorsBeaconState(config.types.phase0.BeaconState.clone(state));
   });
 
   it("same balance", function () {

--- a/packages/lodestar-beacon-state-transition/test/unit/fast/util/interface.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/fast/util/interface.test.ts
@@ -111,19 +111,27 @@ describe("Cache balances", function () {
   });
 
   it("same balance", function () {
+    let balances = cachedState.getBalances();
     expect(cachedState.getBalance(0)).to.be.equal(state.balances[0]);
     expect(cachedState.getBalance(1)).to.be.equal(state.balances[1]);
+    expect(balances[0]).to.be.equal(state.balances[0]);
+    expect(balances[1]).to.be.equal(state.balances[1]);
     increaseBalance(state, 0, BigInt(10000));
     cachedState.increaseBalance(0, 10000);
     decreaseBalance(state, 1, BigInt(20000));
     cachedState.decreaseBalance(1, 20000);
+    balances = cachedState.getBalances();
     expect(cachedState.getBalance(0)).to.be.equal(state.balances[0]);
     expect(cachedState.getBalance(1)).to.be.equal(state.balances[1]);
+    expect(balances[0]).to.be.equal(state.balances[0]);
+    expect(balances[1]).to.be.equal(state.balances[1]);
     expect(state.balances[5]).to.be.undefined;
     state.balances.push(BigInt(2021));
     cachedState.addBalance(BigInt(2021));
     // last balance
+    balances = cachedState.getBalances();
     expect(cachedState.getBalance(5)).to.be.equal(state.balances[5]);
+    expect(balances[5]).to.be.equal(state.balances[5]);
     expect(config.types.phase0.BeaconState.equals(state, cachedState.getOriginalState())).to.be.true;
   });
 

--- a/packages/lodestar-utils/src/math.ts
+++ b/packages/lodestar-utils/src/math.ts
@@ -2,6 +2,8 @@
  * @module util/math
  */
 
+import {assert} from "./assert";
+
 /**
  * Return the min number between two big numbers.
  */
@@ -56,4 +58,147 @@ export function randBetween(min: number, max: number): number {
  */
 export function randBetweenBigInt(min: number, max: number): bigint {
   return BigInt(randBetween(min, max));
+}
+
+/**
+ * Add 2 arrays starting from an index
+ * @param array
+ * @param delta
+ * @param offset
+ */
+export function addUint8Array(array: Uint8Array, delta: Uint8Array, offset: number): Uint8Array {
+  assert.gte(array.length, delta.length, "invalid array lengths");
+  const result = new Uint8Array(array.length);
+  const arrayLength = array.length;
+  const deltaLength = delta.length;
+  let remainder = 0;
+  for (let index = 0; index < arrayLength; index++) {
+    const isInDelta = index >= offset && index < offset + deltaLength;
+    const deltaItem = isInDelta ? delta[index - offset] : 0;
+    const total = array[index] + deltaItem + remainder;
+    result[index] = total & 0xff;
+    remainder = isInDelta ? total >> 8 : 0;
+  }
+  return result;
+}
+
+/**
+ * Subject 2 array (array - delta)
+ * @param array
+ * @param delta
+ */
+export function subtractUint8ArrayGte0(array: Uint8Array, delta: Uint8Array, offset: number): Uint8Array {
+  assert.gte(array.length, delta.length, "The array length to subtract should be gte delta's");
+  const result = new Uint8Array(array.length);
+  const arrayLength = array.length;
+  const deltaLength = delta.length;
+  let remainder = 0;
+  for (let index = 0; index < arrayLength; index++) {
+    const isInDelta = index >= offset && index < offset + deltaLength;
+    const subtract = isInDelta ? array[index] - delta[index - offset] - remainder + 256 : array[index];
+    result[index] = subtract & 0xff;
+    if (isInDelta) {
+      remainder = subtract < 256 ? 1 : 0;
+    }
+  }
+  if (remainder > 0) {
+    for (let index = offset; index < deltaLength + offset; index++) {
+      result[index] = 0;
+    }
+  }
+  return result;
+}
+
+/**
+ * Add/subject multiple bigint under the same Uint8Array
+ * @param array
+ * @param deltas
+ */
+export function calculateBigIntUint8Array(array: Uint8Array, deltas: number[]): Uint8Array {
+  const bigIntLength = 8;
+  assert.equal(array.length / 8, deltas.length, "number of delta is not correct");
+  const result = new Uint8Array(array.length);
+  result.set(array);
+  for (let i = 0; i < deltas.length; i++) {
+    const delta = deltas[i];
+    if (delta > 0) {
+      increaseUint8Array(result, delta, i * bigIntLength, bigIntLength);
+    } else if (delta < 0) {
+      decreaseUint8ArrayGte0(result, -1 * delta, i * bigIntLength, bigIntLength);
+    }
+  }
+  return result;
+}
+
+export function increaseUint8Array(array: Uint8Array, delta: number, offset: number, length = 8): void {
+  assert.gte(delta, 0, "increaseUint8Array delta should be >= 0");
+  let remainder = delta;
+  for (let index = offset; index < length + offset; index++) {
+    if (remainder === 0) {
+      return;
+    } else {
+      const total = array[index] + remainder;
+      array[index] = total & 0xff;
+      remainder = Math.floor(total / 256); // bitshift only works with 32 bits
+    }
+  }
+}
+
+/**
+ * Decrease an array to delta, make sure the result is >= 0
+ */
+export function decreaseUint8ArrayGte0(array: Uint8Array, delta: number, offset: number, length = 8): void {
+  assert.gte(delta, 0, "decreaseUint8Array delta should be >= 0");
+  // remainder is >= 0
+  let remainder = delta;
+  for (let index = offset; index < length + offset; index++) {
+    if (remainder === 0) {
+      return;
+    } else {
+      const subtract = array[index] - remainder;
+      array[index] = subtract & 0xff;
+      remainder = subtract >= 0 ? 0 : Math.ceil((-1 * subtract) / 256);
+    }
+  }
+  if (remainder > 0) {
+    for (let index = offset; index < length + offset; index++) {
+      array[index] = 0;
+    }
+  }
+}
+
+/**
+ * If a > b, return 1, else if a < b, return -1, else return 0
+ * @param a an Uint8Array
+ * @param b an Uint8Array
+ */
+export function compareUint8Array(a: Uint8Array, b: Uint8Array): number {
+  if (a.length > b.length) {
+    const deltaLength = a.length - b.length;
+    for (let i = deltaLength; i < a.length; i++) {
+      if (a[i] > 0) return 1;
+    }
+    return compareUint8ArraySameLength(a.subarray(0, b.length), b);
+  } else if (a.length < b.length) {
+    const deltaLength = b.length - a.length;
+    for (let i = deltaLength; i < b.length; i++) {
+      if (b[i] > 0) return -1;
+    }
+    return compareUint8ArraySameLength(a, b.subarray(0, a.length));
+  } else {
+    return compareUint8ArraySameLength(a, b);
+  }
+}
+
+function compareUint8ArraySameLength(a: Uint8Array, b: Uint8Array): number {
+  assert.equal(a.length, b.length, "arrays to compare should have same length");
+  for (let i = a.length - 1; i >= 0; i--) {
+    if (a[i] > b[i]) {
+      return 1;
+    } else if (a[i] < b[i]) {
+      return -1;
+    }
+  }
+  // end for
+  return 0;
 }

--- a/packages/lodestar-utils/test/unit/math.test.ts
+++ b/packages/lodestar-utils/test/unit/math.test.ts
@@ -1,5 +1,17 @@
-import {assert} from "chai";
-import {bigIntMin, bigIntMax, intDiv, intSqrt, bigIntSqrt} from "../../src";
+import {assert, expect} from "chai";
+import {
+  bigIntMin,
+  bigIntMax,
+  intDiv,
+  intSqrt,
+  bigIntSqrt,
+  addUint8Array,
+  subtractUint8ArrayGte0,
+  compareUint8Array,
+  increaseUint8Array,
+  decreaseUint8ArrayGte0,
+  calculateBigIntUint8Array,
+} from "../../src";
 
 describe("util/maths", function () {
   describe("bigIntMin", () => {
@@ -94,6 +106,215 @@ describe("util/maths", function () {
     it("31 should return 5", () => {
       const result = bigIntSqrt(BigInt(31));
       assert.equal(result.toString(), BigInt(5).toString(), "Should have returned 5!");
+    });
+  });
+
+  const uint8ArrayToNumber = (arr: Uint8Array): number => {
+    let result = 0;
+    for (let i = 0; i < arr.length; i++) {
+      const item = arr[i] & 0xff;
+      const toAdd = item * 2 ** (i * 8);
+      result += toAdd;
+    }
+    return result;
+  };
+
+  describe("addUint8Array", () => {
+    it("should add 2 arrays of same length", () => {
+      const array1 = [
+        Uint8Array.from([250, 255, 255, 255, 255, 255, 255, 0]),
+        Uint8Array.from([250, 255, 255, 255, 255, 255, 0, 0]),
+      ];
+      // same to array1 with 1 addition at start and end
+      const array2 = [
+        Uint8Array.from([120, 250, 255, 255, 255, 255, 255, 255, 0, 120]),
+        Uint8Array.from([240, 250, 255, 255, 255, 255, 255, 0, 0, 240]),
+      ];
+      const deltas = [Uint8Array.from([10, 0, 0, 0, 0, 0, 0]), Uint8Array.from([10, 0, 0, 0, 0, 0, 0])];
+      const expected1 = [Uint8Array.from([4, 0, 0, 0, 0, 0, 0, 1]), Uint8Array.from([4, 0, 0, 0, 0, 0, 1, 0])];
+      // same to expected1 with 1 addition item at start and end
+      const expected2 = [
+        Uint8Array.from([120, 4, 0, 0, 0, 0, 0, 0, 1, 120]),
+        Uint8Array.from([240, 4, 0, 0, 0, 0, 0, 1, 0, 240]),
+      ];
+      for (let i = 0; i < array1.length; i++) {
+        expect(addUint8Array(array1[i], deltas[i], 0)).to.be.deep.equal(expected1[i]);
+        expect(uint8ArrayToNumber(array1[i]) + uint8ArrayToNumber(deltas[i])).to.be.equal(
+          uint8ArrayToNumber(expected1[i])
+        );
+      }
+      for (let i = 0; i < array2.length; i++) {
+        expect(addUint8Array(array2[i], deltas[i], 1)).to.be.deep.equal(expected2[i]);
+      }
+    });
+  });
+
+  describe("subtractUint8ArrayGte0", () => {
+    it("should subtract array of same length", () => {
+      const arrays = [Uint8Array.from([0, 0, 0, 1, 0, 0, 0, 0]), Uint8Array.from([0, 0, 255, 1, 0, 0, 0, 0])];
+      // same to arrays with additional items at start and end
+      const arrays2 = [
+        Uint8Array.from([120, 0, 0, 0, 1, 0, 0, 0, 0, 120]),
+        Uint8Array.from([240, 0, 0, 255, 1, 0, 0, 0, 0, 240]),
+      ];
+      const deltas = [Uint8Array.from([1, 0, 0, 0, 0, 0, 0, 0]), Uint8Array.from([1, 0, 0, 0, 0, 0, 0, 0])];
+      const expected = [
+        Uint8Array.from([255, 255, 255, 0, 0, 0, 0, 0]),
+        Uint8Array.from([255, 255, 254, 1, 0, 0, 0, 0]),
+      ];
+      // same to expected with additional items at start and end
+      const expected2 = [
+        Uint8Array.from([120, 255, 255, 255, 0, 0, 0, 0, 0, 120]),
+        Uint8Array.from([240, 255, 255, 254, 1, 0, 0, 0, 0, 240]),
+      ];
+      for (let i = 0; i < arrays.length; i++) {
+        expect(subtractUint8ArrayGte0(arrays[i], deltas[i], 0)).to.be.deep.equal(expected[i]);
+        expect(uint8ArrayToNumber(arrays[i]) - uint8ArrayToNumber(deltas[i])).to.be.equal(
+          uint8ArrayToNumber(expected[i])
+        );
+      }
+      for (let i = 0; i < arrays.length; i++) {
+        expect(subtractUint8ArrayGte0(arrays2[i], deltas[i], 1)).to.be.deep.equal(expected2[i]);
+      }
+    });
+
+    it("should return at least 0", () => {
+      const array1 = Uint8Array.from([255, 255, 255, 0, 0, 0, 0, 0]);
+      // same to array1 with additional items at start and end
+      const array2 = Uint8Array.from([120, 255, 255, 255, 0, 0, 0, 0, 0, 120]);
+      // even bigger than array1
+      const delta = Uint8Array.from([255, 255, 255, 1, 0, 0, 0, 0]);
+      const expected = Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 0]);
+      // same to expected with additional items at start and end
+      const expected2 = Uint8Array.from([120, 0, 0, 0, 0, 0, 0, 0, 0, 120]);
+      expect(subtractUint8ArrayGte0(array1, delta, 0)).to.be.deep.equal(expected);
+      expect(subtractUint8ArrayGte0(array2, delta, 1)).to.be.deep.equal(expected2);
+    });
+  });
+
+  describe("increaseUint8Array", () => {
+    it("increaseUint8Array", () => {
+      const testArr = Uint8Array.from([255, 255, 255, 1]);
+      // same to testArr with additional items at start and end
+      const testArr2 = Uint8Array.from([120, 255, 255, 255, 1, 120]);
+      const deltas = [1, 10, 1000];
+      const expected = [Uint8Array.from([0, 0, 0, 2]), Uint8Array.from([9, 0, 0, 2]), Uint8Array.from([231, 3, 0, 2])];
+      // same to expected with additional items at start and end
+      const expected2 = [
+        Uint8Array.from([120, 0, 0, 0, 2, 120]),
+        Uint8Array.from([120, 9, 0, 0, 2, 120]),
+        Uint8Array.from([120, 231, 3, 0, 2, 120]),
+      ];
+      for (let i = 0; i < deltas.length; i++) {
+        const arr = new Uint8Array(testArr.length);
+        arr.set(testArr);
+        increaseUint8Array(arr, deltas[i], 0, 4);
+        expect(arr).to.be.deep.equal(expected[i]);
+        expect(uint8ArrayToNumber(testArr) + deltas[i]).to.be.equal(uint8ArrayToNumber(expected[i]));
+      }
+      for (let i = 0; i < deltas.length; i++) {
+        const arr = new Uint8Array(testArr2.length);
+        arr.set(testArr2);
+        increaseUint8Array(arr, deltas[i], 1, 4);
+        expect(arr).to.be.deep.equal(expected2[i]);
+      }
+    });
+  });
+
+  describe("decreaseUint8ArrayGte0", () => {
+    it("should result in a positive number", () => {
+      const arrays = [Uint8Array.from([0, 0, 0, 1, 0, 0, 0, 0]), Uint8Array.from([0, 0, 255, 1, 0, 0, 0, 0])];
+      // same to arrays with additional items at start and end
+      const arrays2 = [
+        Uint8Array.from([120, 0, 0, 0, 1, 0, 0, 0, 0, 120]),
+        Uint8Array.from([120, 0, 0, 255, 1, 0, 0, 0, 0, 120]),
+      ];
+      const deltas = [Uint8Array.from([1, 0, 0, 0, 0, 0, 0, 0]), Uint8Array.from([1, 0, 0, 0, 0, 0, 0, 0])];
+      const expected = [
+        Uint8Array.from([255, 255, 255, 0, 0, 0, 0, 0]),
+        Uint8Array.from([255, 255, 254, 1, 0, 0, 0, 0]),
+      ];
+      // same to expected with additional items at start and end
+      const expected2 = [
+        Uint8Array.from([120, 255, 255, 255, 0, 0, 0, 0, 0, 120]),
+        Uint8Array.from([120, 255, 255, 254, 1, 0, 0, 0, 0, 120]),
+      ];
+      for (let i = 0; i < arrays.length; i++) {
+        const arr = new Uint8Array(arrays[i].length);
+        arr.set(arrays[i]);
+        decreaseUint8ArrayGte0(arr, uint8ArrayToNumber(deltas[i]), 0, 8);
+        expect(arr).to.be.deep.equal(expected[i]);
+        expect(uint8ArrayToNumber(arrays[i]) - uint8ArrayToNumber(deltas[i])).to.be.equal(
+          uint8ArrayToNumber(expected[i])
+        );
+      }
+      for (let i = 0; i < arrays.length; i++) {
+        const arr = new Uint8Array(arrays2[i].length);
+        arr.set(arrays2[i]);
+        decreaseUint8ArrayGte0(arr, uint8ArrayToNumber(deltas[i]), 1, 8);
+        expect(arr).to.be.deep.equal(expected2[i]);
+      }
+    });
+    // fix failed calculation when syncing pyrmont
+    it("should decrease 27150", () => {
+      const delta = 27150;
+      // 32000038926n
+      const initial = Uint8Array.from([14, 216, 89, 115, 7, 0, 0, 0]);
+      const result = new Uint8Array(initial.length);
+      result.set(initial);
+      decreaseUint8ArrayGte0(result, delta, 0, 8);
+      expect(result).to.be.deep.equal(Uint8Array.from([0, 110, 89, 115, 7, 0, 0, 0]));
+      expect(uint8ArrayToNumber(result)).to.be.equal(32000011776);
+    });
+
+    it("should result in 0", () => {
+      const arrays = [Uint8Array.from([0, 0, 0, 1, 0, 0, 0, 0]), Uint8Array.from([0, 0, 255, 1, 0, 0, 0, 0])];
+      // same to arrays with additional items at start and end
+      const arrays2 = [
+        Uint8Array.from([120, 0, 0, 0, 1, 0, 0, 0, 0, 120]),
+        Uint8Array.from([120, 0, 0, 255, 1, 0, 0, 0, 0, 120]),
+      ];
+      const deltas = arrays.map(uint8ArrayToNumber).map((item) => item + 1000);
+      const expected = new Uint8Array(8);
+      // same to expected with additional items at start and end
+      const expected2 = Uint8Array.from([120, 0, 0, 0, 0, 0, 0, 0, 0, 120]);
+      for (let i = 0; i < arrays.length; i++) {
+        const arr = new Uint8Array(arrays[i].length);
+        arr.set(arrays[i]);
+        decreaseUint8ArrayGte0(arr, deltas[i], 0, 8);
+        expect(arr).to.be.deep.equal(expected);
+      }
+      for (let i = 0; i < arrays.length; i++) {
+        const arr = new Uint8Array(arrays2[i].length);
+        arr.set(arrays2[i]);
+        decreaseUint8ArrayGte0(arr, deltas[i], 1, 8);
+        expect(arr).to.be.deep.equal(expected2);
+      }
+    });
+  });
+
+  describe("calculateBigIntUint8Array", () => {
+    it("should calculate a group of 2 bigints", () => {
+      const bigIntArr = Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 1, 255, 255, 255, 255, 255, 255, 255, 0]);
+      const delta = [-1, 1];
+      const expected = Uint8Array.from([255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+      expect(calculateBigIntUint8Array(bigIntArr, delta)).to.be.deep.equal(expected);
+    });
+  });
+
+  describe("compareUint8Array", () => {
+    it("different length", () => {
+      expect(compareUint8Array(Uint8Array.from([4, 3, 2, 1]), Uint8Array.from([4, 3]))).to.be.equal(1);
+      expect(compareUint8Array(Uint8Array.from([4, 3]), Uint8Array.from([4, 3, 2, 1]))).to.be.equal(-1);
+      expect(compareUint8Array(Uint8Array.from([4, 3, 0, 0]), Uint8Array.from([4, 3]))).to.be.equal(0);
+      expect(compareUint8Array(Uint8Array.from([4, 3]), Uint8Array.from([4, 3, 0, 0]))).to.be.equal(0);
+    });
+
+    it("same length", () => {
+      expect(compareUint8Array(Uint8Array.from([4, 3, 2, 1]), Uint8Array.from([4, 3, 2, 0]))).to.be.equal(1);
+      expect(compareUint8Array(Uint8Array.from([4, 3, 2, 0]), Uint8Array.from([4, 3, 2, 1]))).to.be.equal(-1);
+      expect(compareUint8Array(Uint8Array.from([4, 3, 2, 0]), Uint8Array.from([4, 3, 2, 0]))).to.be.equal(0);
+      expect(compareUint8Array(Uint8Array.from([4, 3, 2, 1]), Uint8Array.from([4, 3, 2, 1]))).to.be.equal(0);
     });
   });
 });

--- a/packages/spec-test-runner/test/spec/epoch_processing/justification/justification_and_finalization_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/epoch_processing/justification/justification_and_finalization_fast.test.ts
@@ -10,7 +10,7 @@ describeDirectorySpecTest<IStateTestCase, phase0.BeaconState>(
   "epoch justification and finalization mainnet",
   join(SPEC_TEST_LOCATION, "tests/mainnet/phase0/epoch_processing/justification_and_finalization/pyspec_tests"),
   (testcase) => {
-    const state = testcase.pre;
+    const state = config.types.phase0.BeaconState.tree.createValue(testcase.pre);
     const epochCtx = new phase0.fast.EpochContext(config);
     epochCtx.loadState(state);
     const wrappedState = phase0.fast.createCachedValidatorsBeaconState(state);

--- a/packages/spec-test-runner/test/spec/epoch_processing/registryUpdates/registry_updates_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/epoch_processing/registryUpdates/registry_updates_fast.test.ts
@@ -11,7 +11,7 @@ describeDirectorySpecTest<IStateTestCase, phase0.BeaconState>(
   "epoch registry updates mainnet",
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/epoch_processing/registry_updates/pyspec_tests"),
   (testcase) => {
-    const state = testcase.pre;
+    const state = config.types.phase0.BeaconState.tree.createValue(testcase.pre);
     const epochCtx = new phase0.fast.EpochContext(config);
     epochCtx.loadState(state);
     const wrappedState = phase0.fast.createCachedValidatorsBeaconState(state);

--- a/packages/spec-test-runner/test/spec/epoch_processing/rewardsAndPenalties/rewards_and_penalties_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/epoch_processing/rewardsAndPenalties/rewards_and_penalties_fast.test.ts
@@ -11,7 +11,7 @@ describeDirectorySpecTest<IStateTestCase, phase0.BeaconState>(
   "rewards and penalties minimal",
   join(SPEC_TEST_LOCATION, "tests/minimal/phase0/epoch_processing/rewards_and_penalties/pyspec_tests"),
   (testcase) => {
-    const state = testcase.pre;
+    const state = config.types.phase0.BeaconState.tree.createValue(testcase.pre);
     const epochCtx = new phase0.fast.EpochContext(config);
     epochCtx.loadState(state);
     const wrappedState = phase0.fast.createCachedValidatorsBeaconState(state);

--- a/packages/spec-test-runner/test/spec/epoch_processing/slashings/slashings_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/epoch_processing/slashings/slashings_fast.test.ts
@@ -11,7 +11,7 @@ describeDirectorySpecTest<IStateTestCase, phase0.BeaconState>(
   "epoch slashings mainnet",
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/epoch_processing/slashings/pyspec_tests"),
   (testcase) => {
-    const state = testcase.pre;
+    const state = config.types.phase0.BeaconState.tree.createValue(testcase.pre);
     const epochCtx = new phase0.fast.EpochContext(config);
     epochCtx.loadState(state);
     const wrappedState = phase0.fast.createCachedValidatorsBeaconState(state);

--- a/packages/spec-test-runner/test/spec/operations/attestations/attestations_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/operations/attestations/attestations_fast.test.ts
@@ -10,7 +10,7 @@ describeDirectorySpecTest<IProcessAttestationTestCase, phase0.BeaconState>(
   "process attestation mainnet",
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/operations/attestation/pyspec_tests"),
   (testcase) => {
-    const state = testcase.pre;
+    const state = config.types.phase0.BeaconState.tree.createValue(testcase.pre);
     const epochCtx = new phase0.fast.EpochContext(config);
     epochCtx.loadState(state);
     phase0.fast.processAttestation(epochCtx, state, testcase.attestation);

--- a/packages/spec-test-runner/test/spec/operations/attesterSlashing/attester_slashing_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/operations/attesterSlashing/attester_slashing_fast.test.ts
@@ -10,7 +10,7 @@ describeDirectorySpecTest<IProcessAttesterSlashingTestCase, phase0.BeaconState>(
   "process attester slashing mainnet",
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/operations/attester_slashing/pyspec_tests"),
   (testcase) => {
-    const state = testcase.pre;
+    const state = config.types.phase0.BeaconState.tree.createValue(testcase.pre);
     const epochCtx = new phase0.fast.EpochContext(config);
     epochCtx.loadState(state);
     const verify = !!testcase.meta && !!testcase.meta.blsSetting && testcase.meta.blsSetting === BigInt(1);

--- a/packages/spec-test-runner/test/spec/operations/blockHeader/block_header_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/operations/blockHeader/block_header_fast.test.ts
@@ -10,7 +10,7 @@ describeDirectorySpecTest<IProcessBlockHeader, phase0.BeaconState>(
   "process block header mainnet",
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/operations/block_header/pyspec_tests"),
   (testcase) => {
-    const state = testcase.pre;
+    const state = config.types.phase0.BeaconState.tree.createValue(testcase.pre);
     const epochCtx = new phase0.fast.EpochContext(config);
     epochCtx.loadState(state);
     phase0.fast.processBlockHeader(epochCtx, state, testcase.block);

--- a/packages/spec-test-runner/test/spec/operations/deposit/deposit_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/operations/deposit/deposit_fast.test.ts
@@ -10,7 +10,7 @@ describeDirectorySpecTest<IProcessDepositTestCase, phase0.BeaconState>(
   "process deposit mainnet",
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/operations/deposit/pyspec_tests"),
   (testcase) => {
-    const state = testcase.pre;
+    const state = config.types.phase0.BeaconState.tree.createValue(testcase.pre);
     const epochCtx = new phase0.fast.EpochContext(config);
     epochCtx.loadState(state);
     const wrappedState = phase0.fast.createCachedValidatorsBeaconState(state);

--- a/packages/spec-test-runner/test/spec/operations/proposerSlashing/proposer_slashing_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/operations/proposerSlashing/proposer_slashing_fast.test.ts
@@ -10,7 +10,7 @@ describeDirectorySpecTest<IProcessProposerSlashingTestCase, phase0.BeaconState>(
   "process proposer slashing mainnet",
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/operations/proposer_slashing/pyspec_tests"),
   (testcase) => {
-    const state = testcase.pre;
+    const state = config.types.phase0.BeaconState.tree.createValue(testcase.pre);
     const epochCtx = new phase0.fast.EpochContext(config);
     epochCtx.loadState(state);
     const wrappedState = phase0.fast.createCachedValidatorsBeaconState(state);

--- a/packages/spec-test-runner/test/spec/operations/voluntaryExit/voluntary_exit_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/operations/voluntaryExit/voluntary_exit_fast.test.ts
@@ -10,7 +10,7 @@ describeDirectorySpecTest<IProcessVoluntaryExitTestCase, phase0.BeaconState>(
   "process voluntary exit mainnet",
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/operations/voluntary_exit/pyspec_tests"),
   (testcase) => {
-    const state = testcase.pre;
+    const state = config.types.phase0.BeaconState.tree.createValue(testcase.pre);
     const epochCtx = new phase0.fast.EpochContext(config);
     epochCtx.loadState(state);
     const wrappedState = phase0.fast.createCachedValidatorsBeaconState(state);

--- a/packages/spec-test-runner/test/spec/rewards/rewards_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/rewards/rewards_fast.test.ts
@@ -11,7 +11,7 @@ for (const testSuite of ["basic", "leak", "random"]) {
     "process attestation mainnet",
     join(SPEC_TEST_LOCATION, `/tests/mainnet/phase0/rewards/${testSuite}/pyspec_tests`),
     (testcase) => {
-      const state = testcase.pre;
+      const state = config.types.phase0.BeaconState.tree.createValue(testcase.pre);
       const epochCtx = new phase0.fast.EpochContext(config);
       epochCtx.loadState(state);
       const wrappedState = phase0.fast.createCachedValidatorsBeaconState(state);


### PR DESCRIPTION
Demo #2103 

This is more like a POC, not a real improvement because it saves only 20ms per epoch transition
+ For `processRewardsAndPenalties`, it saves ~60ms by caching chunks of the Tree, and perform `+,-` operations direction on that array
+ But for `processFinalUpdates`, it spend ~40ms to get back balance array as BigInt