### PR TITLE
Persist temp states to not lose sync progress

### DIFF
--- a/packages/lodestar-spec-test-util/src/single.ts
+++ b/packages/lodestar-spec-test-util/src/single.ts
@@ -185,7 +185,7 @@ function deserializeTestCase<TestCase, Result>(
 
 function generateProfileReport(profile: profiler.CpuProfile, directory: string, profileId: string): void {
   profile.export((error, result) => {
-    if (error) {
+    if (error || result === undefined) {
       return;
     }
     writeFile(`${directory}/${profileId}`, result as string, () => {

--- a/packages/lodestar/src/tasks/index.ts
+++ b/packages/lodestar/src/tasks/index.ts
@@ -9,16 +9,10 @@ import {ILogger} from "@chainsafe/lodestar-utils";
 import {IBeaconDb} from "../db/api";
 import {ChainEvent, IBeaconChain} from "../chain";
 import {ArchiveBlocksTask} from "./tasks/archiveBlocks";
-import {ArchiveStatesTask} from "./tasks/archiveStates";
+import {StatesArchiver} from "./tasks/archiveStates";
 import {IBeaconSync} from "../sync";
 import {InteropSubnetsJoiningTask} from "./tasks/interopSubnetsJoiningTask";
 import {INetwork, NetworkEvent} from "../network";
-import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
-
-/**
- * Minimum number of epochs between archived states
- */
-export const MIN_EPOCHS_PER_DB_STATE = 1024;
 
 export interface ITasksModules {
   db: IBeaconDb;
@@ -39,7 +33,8 @@ export class TasksService {
   private readonly network: INetwork;
   private readonly logger: ILogger;
 
-  private interopSubnetsTask: InteropSubnetsJoiningTask;
+  private readonly statesArchiver: StatesArchiver;
+  private readonly interopSubnetsTask: InteropSubnetsJoiningTask;
 
   constructor(config: IBeaconConfig, modules: ITasksModules) {
     this.config = config;
@@ -47,6 +42,7 @@ export class TasksService {
     this.chain = modules.chain;
     this.logger = modules.logger;
     this.network = modules.network;
+    this.statesArchiver = new StatesArchiver(this.config, modules);
     this.interopSubnetsTask = new InteropSubnetsJoiningTask(this.config, {
       chain: this.chain,
       network: this.network,
@@ -68,11 +64,7 @@ export class TasksService {
     this.network.gossip.off(NetworkEvent.gossipStop, this.handleGossipStop);
     this.interopSubnetsTask.stop();
     // Archive latest finalized state
-    await new ArchiveStatesTask(
-      this.config,
-      {chain: this.chain, db: this.db, logger: this.logger},
-      this.chain.getFinalizedCheckpoint()
-    ).run();
+    await this.statesArchiver.archiveState(this.chain.getFinalizedCheckpoint());
   }
 
   private handleGossipStart = (): void => {
@@ -90,22 +82,17 @@ export class TasksService {
         {db: this.db, forkChoice: this.chain.forkChoice, logger: this.logger},
         finalized
       ).run();
+
       // should be after ArchiveBlocksTask to handle restart cleanly
-      const lastStoredSlot = (await this.db.stateArchive.lastKey()) as number;
-      const lastStoredEpoch = computeEpochAtSlot(this.config, lastStoredSlot);
-      if (finalized.epoch - lastStoredEpoch > MIN_EPOCHS_PER_DB_STATE) {
-        await new ArchiveStatesTask(
-          this.config,
-          {chain: this.chain, db: this.db, logger: this.logger},
-          finalized
-        ).run();
-      }
+      await this.statesArchiver.maybeArchiveState(finalized);
+
       await Promise.all([
         this.chain.checkpointStateCache.pruneFinalized(finalized.epoch),
         this.chain.stateCache.deleteAllBeforeEpoch(finalized.epoch),
         this.db.attestation.pruneFinalized(finalized.epoch),
         this.db.aggregateAndProof.pruneFinalized(finalized.epoch),
       ]);
+
       // tasks rely on extended fork choice
       this.chain.forkChoice.prune(finalized.root);
       this.logger.verbose("Finish processing finalized checkpoint", {epoch: finalized.epoch});

--- a/packages/lodestar/src/tasks/tasks/archiveStates.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveStates.ts
@@ -2,48 +2,107 @@
  * @module tasks
  */
 
-import {ITask} from "../interface";
-import {IBeaconDb} from "../../db/api";
-import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {phase0} from "@chainsafe/lodestar-types";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {IBeaconDb} from "../../db/api";
 import {IBeaconChain} from "../../chain";
 
-export interface IArchiveStatesModules {
+/**
+ * Minimum number of epochs between archived states
+ */
+const PERSIST_STATE_EVERY_EPOCHS = 1024;
+/**
+ * Minimum number of epochs between single temp archived states
+ * These states will be pruned once a new state is persisted
+ */
+const PERSIST_TEMP_STATE_EVERY_EPOCHS = 32;
+
+export type StatesArchiverModules = {
   chain: IBeaconChain;
   db: IBeaconDb;
   logger: ILogger;
-}
+};
 
 /**
  * Archives finalized states from active bucket to archive bucket.
  *
  * Only the new finalized state is stored to disk
  */
-export class ArchiveStatesTask implements ITask {
+export class StatesArchiver {
+  private readonly config: IBeaconConfig;
   private readonly chain: IBeaconChain;
   private readonly db: IBeaconDb;
   private readonly logger: ILogger;
-  private readonly config: IBeaconConfig;
 
-  private finalized: phase0.Checkpoint;
-
-  constructor(config: IBeaconConfig, modules: IArchiveStatesModules, finalized: phase0.Checkpoint) {
+  constructor(config: IBeaconConfig, modules: StatesArchiverModules) {
+    this.config = config;
     this.chain = modules.chain;
     this.db = modules.db;
     this.logger = modules.logger;
-    this.config = config;
-    this.finalized = finalized;
   }
 
-  async run(): Promise<void> {
-    // store the state of finalized checkpoint
-    const finalizedState = this.chain.checkpointStateCache.get(this.finalized);
+  /**
+   * Persist states every some epochs to
+   * - Minimize disk space, storing the least states possible
+   * - Minimize the sync progress lost on unexpected crash, storing temp state every few epochs
+   *
+   * At epoch `e` there will be states peristed at intervals of `PERSIST_STATE_EVERY_EPOCHS` = 32
+   * and one at `PERSIST_TEMP_STATE_EVERY_EPOCHS` = 1024
+   * ```
+   *        |                |             |           .
+   * epoch - 1024*2    epoch - 1024    epoch - 32    epoch
+   * ```
+   */
+  async maybeArchiveState(finalized: phase0.Checkpoint): Promise<void> {
+    const lastStoredSlot = await this.db.stateArchive.lastKey();
+    const lastStoredEpoch = computeEpochAtSlot(this.config, lastStoredSlot || 0);
+
+    if (finalized.epoch - lastStoredEpoch > PERSIST_TEMP_STATE_EVERY_EPOCHS) {
+      await this.archiveState(finalized);
+
+      const storedEpochs = await this.db.stateArchive.keys({
+        lt: finalized.epoch,
+        // Only check the current and previous intervals
+        gte: Math.max(0, (Math.floor(finalized.epoch / PERSIST_STATE_EVERY_EPOCHS) - 1) * PERSIST_STATE_EVERY_EPOCHS),
+      });
+      const statesToDelete = computeEpochsToDelete(storedEpochs, PERSIST_STATE_EVERY_EPOCHS);
+      if (statesToDelete.length > 0) {
+        await this.db.stateArchive.batchDelete(statesToDelete);
+      }
+    }
+  }
+
+  /**
+   * Archives finalized states from active bucket to archive bucket.
+   * Only the new finalized state is stored to disk
+   */
+  async archiveState(finalized: phase0.Checkpoint): Promise<void> {
+    const finalizedState = this.chain.checkpointStateCache.get(finalized);
     if (!finalizedState) {
-      throw Error("No state in cache for finalized checkpoint state epoch #" + this.finalized.epoch);
+      throw Error("No state in cache for finalized checkpoint state epoch #" + finalized.epoch);
     }
     await this.db.stateArchive.put(finalizedState.slot, finalizedState);
     // don't delete states before the finalized state, auto-prune will take care of it
-    this.logger.verbose("Archive states completed", {finalizedEpoch: this.finalized.epoch});
+    this.logger.verbose("Archive states completed", {finalizedEpoch: finalized.epoch});
   }
+}
+
+/**
+ * Keeps first epoch per interval of persistEveryEpochs, deletes the rest
+ */
+export function computeEpochsToDelete(storedEpochs: number[], persistEveryEpochs: number): number[] {
+  const epochBuckets = new Set<number>();
+  const toDelete = new Set<number>();
+  for (const epoch of storedEpochs) {
+    const epochBucket = epoch - (epoch % persistEveryEpochs);
+    if (epochBuckets.has(epochBucket)) {
+      toDelete.add(epoch);
+    } else {
+      epochBuckets.add(epochBucket);
+    }
+  }
+
+  return Array.from(toDelete.values());
 }

--- a/packages/lodestar/test/unit/tasks/tasks/stateArchiver.test.ts
+++ b/packages/lodestar/test/unit/tasks/tasks/stateArchiver.test.ts
@@ -1,0 +1,43 @@
+import {expect} from "chai";
+import {computeEpochsToDelete} from "../../../../src/tasks/tasks/archiveStates";
+
+describe("state archiver task", () => {
+  describe("computeEpochsToDelete", () => {
+    const testCases: {
+      id: string;
+      storedEpochs: number[];
+      persistEveryEpochs?: number;
+      toDelete: number[];
+    }[] = [
+      {
+        id: "Empty",
+        storedEpochs: [],
+        toDelete: [],
+      },
+      {
+        id: "Equally spaced, delete x%8 != 0",
+        storedEpochs: [0, 2, 4, 6, 8, 10, 12, 14, 16],
+        persistEveryEpochs: 8,
+        toDelete: [2, 4, 6, 10, 12, 14],
+      },
+      {
+        id: "Equally spaced with offset",
+        storedEpochs: [0, 3, 5, 7, 9, 11, 13, 15, 17],
+        persistEveryEpochs: 8,
+        toDelete: [3, 5, 7, 11, 13, 15],
+      },
+      {
+        id: "Edge case with offset that causes a very large gap between epochs",
+        storedEpochs: [7, 8, 23, 24],
+        persistEveryEpochs: 8,
+        toDelete: [],
+      },
+    ];
+
+    for (const {id, storedEpochs, persistEveryEpochs, toDelete} of testCases) {
+      it(id, () => {
+        expect(computeEpochsToDelete(storedEpochs, persistEveryEpochs || 1024)).to.deep.equal(toDelete);
+      });
+    }
+  });
+});


### PR DESCRIPTION
**Motivation**

Currently, we store a state every 1024 epochs. At slow sync speeds of 4 slots / second, that's +2 hours of sync progress lost. Fixes https://github.com/ChainSafe/lodestar/issues/2048

![Screenshot from 2021-03-09 10-24-59](https://user-images.githubusercontent.com/35266934/110448708-b6de5680-80c1-11eb-8527-5e56230df655.png)

**Proposed solution**

Store state more frequently, every 32 epochs. Then, after a successful store, keep only the first state every 1024 epochs and delete the rest. In normal conditions, only 0 or 1 states will be deleted. The resulting layout of store states will look like
```
    |         |       |    .
 x-1024*2  x-1024   x-32   x
```

