### PR TITLE
Remove objectToExpectedCase usage in API

### DIFF
--- a/packages/lodestar/src/api/rest/controllers/node/getNetworkIdentity.ts
+++ b/packages/lodestar/src/api/rest/controllers/node/getNetworkIdentity.ts
@@ -1,5 +1,6 @@
 import {ApiController} from "../types";
-import {objectToExpectedCase} from "@chainsafe/lodestar-utils";
+
+/* eslint-disable @typescript-eslint/naming-convention */
 
 export const getNetworkIdentity: ApiController = {
   url: "/identity",
@@ -11,7 +12,10 @@ export const getNetworkIdentity: ApiController = {
     const metadataJson = this.config.types.phase0.Metadata.toJson(identity.metadata, {case: "snake"});
     resp.status(200).send({
       data: {
-        ...objectToExpectedCase(identity, "snake"),
+        peer_id: identity.peerId,
+        enr: identity.enr,
+        p2p_addresses: identity.p2pAddresses,
+        discovery_addresses: identity.discoveryAddresses,
         metadata: metadataJson,
       },
     });

--- a/packages/lodestar/src/api/rest/controllers/node/getPeer.ts
+++ b/packages/lodestar/src/api/rest/controllers/node/getPeer.ts
@@ -1,6 +1,7 @@
 import {ApiController} from "../types";
-import {objectToExpectedCase} from "@chainsafe/lodestar-utils";
 import {DefaultQuery} from "fastify";
+
+/* eslint-disable @typescript-eslint/naming-convention */
 
 export const getPeer: ApiController<DefaultQuery, {peerId: string}> = {
   url: "/peers/:peerId",
@@ -23,7 +24,13 @@ export const getPeer: ApiController<DefaultQuery, {peerId: string}> = {
       return resp.status(404).send();
     }
     resp.status(200).send({
-      data: objectToExpectedCase(peer, "snake"),
+      data: {
+        peer_id: peer.peerId,
+        enr: peer.enr,
+        last_seen_p2p_address: peer.lastSeenP2pAddress,
+        state: peer.state,
+        direction: peer.direction,
+      },
     });
   },
 };

--- a/packages/lodestar/src/api/rest/controllers/node/getPeers.ts
+++ b/packages/lodestar/src/api/rest/controllers/node/getPeers.ts
@@ -1,5 +1,6 @@
 import {ApiController} from "../types";
-import {objectToExpectedCase} from "@chainsafe/lodestar-utils";
+
+/* eslint-disable @typescript-eslint/naming-convention */
 
 export const getPeers: ApiController<{state: string[] | string; direction: string[] | string}> = {
   url: "/peers",
@@ -37,7 +38,13 @@ export const getPeers: ApiController<{state: string[] | string; direction: strin
       typeof req.query.direction === "string" ? [req.query.direction] : req.query.direction
     );
     resp.status(200).send({
-      data: peers.map((peer) => objectToExpectedCase(peer, "snake")),
+      data: peers.map((peer) => ({
+        peer_id: peer.peerId,
+        enr: peer.enr,
+        last_seen_p2p_address: peer.lastSeenP2pAddress,
+        state: peer.state,
+        direction: peer.direction,
+      })),
     });
   },
 };


### PR DESCRIPTION
objectToExpectedCase is not safe to use with recursive types. None of the API types are, so there's some underlying issue not fixed with this PR. However it's not necessary to risk a "Maximum call stack size exceeded" error to manually convert came case to snake case just for these routes

Fixes https://github.com/ChainSafe/lodestar/issues/2155