### PR TITLE
beaconBlockByRange handler to work with BlockArchiver

### DIFF
--- a/packages/lodestar/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/lodestar/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -1,18 +1,25 @@
 import {GENESIS_SLOT} from "@chainsafe/lodestar-beacon-state-transition";
-import {MAX_REQUEST_BLOCKS, phase0} from "@chainsafe/lodestar-types";
+import {MAX_REQUEST_BLOCKS, phase0, Slot} from "@chainsafe/lodestar-types";
 import {IBlockFilterOptions} from "../../../db/api/beacon/repositories";
 import {IBeaconChain} from "../../../chain";
 import {IBeaconDb} from "../../../db";
 import {RpcResponseStatus} from "../../../constants";
 import {ResponseError} from "../response";
+import {IArchivingStatus, ITaskService} from "../../../tasks/interface";
+import {checkLinearChainSegment} from "../../../../src/util/chain";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
-// TODO: Unit test
-
-export async function* onBeaconBlocksByRange(
+/**
+ * Need to retry again if BlockArchiver is running at an overlapsed range.
+ */
+export async function onBeaconBlocksByRange(
+  config: IBeaconConfig,
   requestBody: phase0.BeaconBlocksByRangeRequest,
   chain: IBeaconChain,
-  db: IBeaconDb
-): AsyncIterable<phase0.SignedBeaconBlock> {
+  db: IBeaconDb,
+  chores?: ITaskService
+): Promise<phase0.SignedBeaconBlock[]> {
+  if (!chores) throw new ResponseError(RpcResponseStatus.SERVER_ERROR, "node is not fully started");
   if (requestBody.step < 1) {
     throw new ResponseError(RpcResponseStatus.INVALID_REQUEST, "step < 1");
   }
@@ -26,25 +33,123 @@ export async function* onBeaconBlocksByRange(
   if (requestBody.count > MAX_REQUEST_BLOCKS) {
     requestBody.count = MAX_REQUEST_BLOCKS;
   }
+  const archiveStatus = chores.getBlockArchivingStatus();
+  let blocks: phase0.SignedBeaconBlock[];
+  // BlockArchiver is running with a ranges overlapped requestBody
+  if (shouldWaitForBlockArchiver(requestBody, archiveStatus)) {
+    // BLockArchiver finishes its run
+    await chores.waitForBlockArchiver();
+    blocks = await handleBeaconBlocksByRange(requestBody, chain, db);
+  } else {
+    blocks = await handleBeaconBlocksByRange(requestBody, chain, db);
+    const newArchiveStatus = chores.getBlockArchivingStatus();
+    // BlockArchiver is running with an overlappsed range
+    if (shouldWaitForBlockArchiver(requestBody, archiveStatus, newArchiveStatus)) {
+      await chores.waitForBlockArchiver();
+      blocks = await handleBeaconBlocksByRange(requestBody, chain, db);
+    } else if (shouldRetry(requestBody, archiveStatus, newArchiveStatus)) {
+      // BlockArchiver finishes its run during handleBeaconBlocksByRange
+      blocks = await handleBeaconBlocksByRange(requestBody, chain, db);
+    }
+  }
+  // before we return, make sure client can process our response, otherwise they'll downvote us
+  if (requestBody.step === 1 && blocks.length > 1) {
+    try {
+      checkLinearChainSegment(config, blocks);
+    } catch (e) {
+      throw new ResponseError(RpcResponseStatus.SERVER_ERROR, (e as Error).message);
+    }
+  }
+  return blocks;
+}
 
-  const archiveBlocksStream = db.blockArchive.valuesStream({
+/**
+ * If no newArchiveStatus, return true if archiveStatus is running with an overlapping range.
+ * Else
+ *      + if same IArchivingStatus, return false
+ *      + else if different IArchivingStatus and newArchiveStatus is running with an overlapping range, return true
+ *      + else return false
+ */
+export function shouldWaitForBlockArchiver(
+  requestBody: phase0.BeaconBlocksByRangeRequest,
+  archiveStatus: IArchivingStatus,
+  newArchiveStatus?: IArchivingStatus
+): boolean {
+  // 1st check
+  if (!newArchiveStatus) {
+    return (
+      archiveStatus.finalizingSlot !== null &&
+      isOverlappedRange(requestBody, archiveStatus.lastFinalizedSlot, archiveStatus.finalizingSlot)
+    );
+  } else {
+    // 2nd check
+    if (isSameArchiveStatus(archiveStatus, newArchiveStatus)) {
+      return false;
+    } else {
+      return (
+        newArchiveStatus.finalizingSlot !== null &&
+        // BlockArchiver may run at the same time with an overlappsed range
+        isOverlappedRange(requestBody, newArchiveStatus.lastFinalizedSlot, newArchiveStatus.finalizingSlot)
+      );
+    }
+  }
+}
+
+/**
+ * if different IArchivingStatus and newArchiveStatus is complete with an overlapping range, return true
+ * if different IArchivingStatus and newArchiveStatus is complete without an overllaping range, return false
+ */
+export function shouldRetry(
+  requestBody: phase0.BeaconBlocksByRangeRequest,
+  archiveStatus: IArchivingStatus,
+  newArchiveStatus: IArchivingStatus
+): boolean {
+  return (
+    !isSameArchiveStatus(archiveStatus, newArchiveStatus) &&
+    newArchiveStatus.finalizingSlot == null &&
+    isOverlappedRange(requestBody, archiveStatus.lastFinalizedSlot, newArchiveStatus.lastFinalizedSlot)
+  );
+}
+
+export function isSameArchiveStatus(archiveStatus: IArchivingStatus, newArchiveStatus: IArchivingStatus): boolean {
+  return (
+    archiveStatus.lastFinalizedSlot === newArchiveStatus.lastFinalizedSlot &&
+    archiveStatus.finalizingSlot === newArchiveStatus.finalizingSlot
+  );
+}
+
+/**
+ * Start and end are inclusive.
+ * @param requestBody
+ * @param start
+ * @param end
+ */
+export function isOverlappedRange(requestBody: phase0.BeaconBlocksByRangeRequest, start: Slot, end: Slot): boolean {
+  const requestStart = requestBody.startSlot;
+  const requestEnd = requestBody.startSlot + requestBody.count * requestBody.step;
+
+  return (start >= requestStart && start < requestEnd) || (end >= requestStart && end < requestEnd);
+}
+
+export async function handleBeaconBlocksByRange(
+  requestBody: phase0.BeaconBlocksByRangeRequest,
+  chain: IBeaconChain,
+  db: IBeaconDb
+): Promise<phase0.SignedBeaconBlock[]> {
+  const archivedBlocks = await db.blockArchive.values({
     gte: requestBody.startSlot,
     lt: requestBody.startSlot + requestBody.count * requestBody.step,
     step: requestBody.step,
   } as IBlockFilterOptions);
-  yield* injectRecentBlocks(archiveBlocksStream, chain, requestBody);
+  return await injectRecentBlocks(archivedBlocks, chain, requestBody);
 }
 
-export async function* injectRecentBlocks(
-  archiveStream: AsyncIterable<phase0.SignedBeaconBlock>,
+async function injectRecentBlocks(
+  archiveBlocks: phase0.SignedBeaconBlock[] = [],
   chain: IBeaconChain,
   request: phase0.BeaconBlocksByRangeRequest
-): AsyncGenerator<phase0.SignedBeaconBlock> {
-  let slot = -1;
-  for await (const archiveBlock of archiveStream) {
-    yield archiveBlock;
-    slot = archiveBlock.message.slot;
-  }
+): Promise<phase0.SignedBeaconBlock[]> {
+  let slot = archiveBlocks.length > 0 ? archiveBlocks[archiveBlocks.length - 1].message.slot : -1;
   slot = slot === -1 ? request.startSlot : slot + request.step;
   const upperSlot = request.startSlot + request.count * request.step;
   const slots = [] as number[];
@@ -54,9 +159,5 @@ export async function* injectRecentBlocks(
   }
 
   const blocks = (await chain.getUnfinalizedBlocksAtSlots(slots)) || [];
-  for (const block of blocks) {
-    if (block) {
-      yield block;
-    }
-  }
+  return [...archiveBlocks, ...blocks];
 }

--- a/packages/lodestar/src/network/reqresp/handlers/index.ts
+++ b/packages/lodestar/src/network/reqresp/handlers/index.ts
@@ -1,6 +1,8 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {phase0} from "@chainsafe/lodestar-types";
 import {IBeaconChain} from "../../../chain";
 import {IBeaconDb} from "../../../db";
+import {ITaskService} from "../../../tasks/interface";
 import {onBeaconBlocksByRange} from "./beaconBlocksByRange";
 import {onBeaconBlocksByRoot} from "./beaconBlocksByRoot";
 
@@ -8,6 +10,7 @@ export interface IReqRespHandler {
   onStatus(): AsyncIterable<phase0.Status>;
   onBeaconBlocksByRange(req: phase0.RequestBody): AsyncIterable<phase0.SignedBeaconBlock>;
   onBeaconBlocksByRoot(req: phase0.RequestBody): AsyncIterable<phase0.SignedBeaconBlock>;
+  registerChores(chores: ITaskService): void;
 }
 
 /**
@@ -15,10 +18,13 @@ export interface IReqRespHandler {
  * fetching state from the chain and database as needed.
  */
 export class ReqRespHandler implements IReqRespHandler {
+  private config: IBeaconConfig;
   private db: IBeaconDb;
   private chain: IBeaconChain;
+  private chores: ITaskService | undefined;
 
-  constructor({db, chain}: {db: IBeaconDb; chain: IBeaconChain}) {
+  constructor({config, db, chain}: {config: IBeaconConfig; db: IBeaconDb; chain: IBeaconChain}) {
+    this.config = config;
     this.db = db;
     this.chain = chain;
   }
@@ -28,10 +34,14 @@ export class ReqRespHandler implements IReqRespHandler {
   }
 
   async *onBeaconBlocksByRange(req: phase0.BeaconBlocksByRangeRequest): AsyncIterable<phase0.SignedBeaconBlock> {
-    yield* onBeaconBlocksByRange(req, this.chain, this.db);
+    yield* await onBeaconBlocksByRange(this.config, req, this.chain, this.db, this.chores);
   }
 
   async *onBeaconBlocksByRoot(req: phase0.BeaconBlocksByRootRequest): AsyncIterable<phase0.SignedBeaconBlock> {
     yield* onBeaconBlocksByRoot(req, this.db);
+  }
+
+  registerChores(chores: ITaskService): void {
+    this.chores = chores;
   }
 }

--- a/packages/lodestar/src/network/reqresp/interface.ts
+++ b/packages/lodestar/src/network/reqresp/interface.ts
@@ -9,6 +9,7 @@ import {INetworkEventBus} from "../events";
 import {IReqRespHandler} from "./handlers";
 
 export interface IReqResp {
+  reqRespHandler: IReqRespHandler;
   start(): void;
   stop(): void;
   status(peerId: PeerId, request: phase0.Status): Promise<phase0.Status>;

--- a/packages/lodestar/src/network/reqresp/reqResp.ts
+++ b/packages/lodestar/src/network/reqresp/reqResp.ts
@@ -27,10 +27,10 @@ export type IReqRespOptions = Partial<typeof timeoutOptions>;
  * https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/p2p-interface.md#the-reqresp-domain
  */
 export class ReqResp implements IReqResp {
+  reqRespHandler: IReqRespHandler;
   private config: IBeaconConfig;
   private libp2p: LibP2p;
   private logger: ILogger;
-  private reqRespHandler: IReqRespHandler;
   private metadataController: MetadataController;
   private peerMetadata: IPeerMetadataStore;
   private peerRpcScores: IPeerRpcScoreStore;

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -142,22 +142,23 @@ export class BeaconNode {
       metrics,
       chain,
       db,
-      reqRespHandler: new ReqRespHandler({db, chain}),
+      reqRespHandler: new ReqRespHandler({config, db, chain}),
     });
+    const chores = new TasksService(config, {
+      db,
+      chain,
+      network,
+      logger: logger.child(opts.logger.chores),
+    });
+    network.reqResp.reqRespHandler.registerChores(chores);
     const sync = new BeaconSync(opts.sync, {
       config,
       db,
       chain,
       metrics,
       network,
+      chores,
       logger: logger.child(opts.logger.sync),
-    });
-    const chores = new TasksService(config, {
-      db,
-      chain,
-      sync,
-      network,
-      logger: logger.child(opts.logger.chores),
     });
 
     const api = new Api(opts.api, {
@@ -195,7 +196,7 @@ export class BeaconNode {
 
     await network.start();
     await sync.start();
-    chores.start();
+    await chores.start();
 
     void runNodeNotifier({network, chain, sync, config, logger, signal});
 

--- a/packages/lodestar/src/sync/interface.ts
+++ b/packages/lodestar/src/sync/interface.ts
@@ -8,6 +8,7 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBeaconDb} from "../db/api";
 import {AttestationCollector} from "./utils";
 import {BeaconGossipHandler} from "./gossip";
+import {ITaskService} from "../tasks/interface";
 
 export enum SyncMode {
   WAITING_PEERS,
@@ -41,6 +42,7 @@ export interface ISyncModules {
   db: IBeaconDb;
   logger: ILogger;
   chain: IBeaconChain;
+  chores: ITaskService;
   metrics?: IBeaconMetrics;
   regularSync?: IRegularSync;
   gossipHandler?: BeaconGossipHandler;

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
@@ -11,7 +11,7 @@ import {getBlockRange} from "../../utils/blocks";
 import {ISlotRange} from "../../interface";
 import {ZERO_HASH} from "../../../constants";
 import {IBlockRangeFetcher} from "./interface";
-import {checkLinearChainSegment} from "../../utils/sync";
+import {checkLinearChainSegment} from "../../../util/chain";
 
 /**
  * Get next range by issuing beacon_blocks_by_range requests.

--- a/packages/lodestar/src/sync/utils/sync.ts
+++ b/packages/lodestar/src/sync/utils/sync.ts
@@ -1,9 +1,8 @@
 import PeerId from "peer-id";
-import {phase0, Root} from "@chainsafe/lodestar-types";
+import {Root} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {INetwork} from "../../network";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {toHexString} from "@chainsafe/ssz";
 import {ZERO_HASH} from "../../constants";
 import {IPeerMetadataStore} from "../../network/peers";
 import {getSyncPeers} from "./peers";
@@ -54,24 +53,4 @@ export function getBestPeerCandidates(forkChoice: IForkChoice, network: INetwork
     },
     10
   );
-}
-
-/**
- * Some clients may send orphaned/non-canonical blocks.
- * Check each block should link to a previous parent block and be a parent of next block.
- * Throw errors if they're not so that it'll fetch again
- */
-export function checkLinearChainSegment(
-  config: IBeaconConfig,
-  blocks: phase0.SignedBeaconBlock[] | null,
-  ancestorRoot: Root | null = null
-): void {
-  if (!blocks || blocks.length <= 1) throw new Error("Not enough blocks to validate");
-  let parentRoot = ancestorRoot;
-  for (const block of blocks) {
-    if (parentRoot && !config.types.Root.equals(block.message.parentRoot, parentRoot)) {
-      throw new Error(`Block ${block.message.slot} does not link to parent ${toHexString(parentRoot)}`);
-    }
-    parentRoot = config.types.phase0.BeaconBlock.hashTreeRoot(block.message);
-  }
 }

--- a/packages/lodestar/src/tasks/interface.ts
+++ b/packages/lodestar/src/tasks/interface.ts
@@ -2,6 +2,18 @@
  * @module chores
  */
 
+import {Slot} from "@chainsafe/lodestar-types";
+
 export interface ITask {
   run(): Promise<void>;
+}
+
+export interface ITaskService {
+  getBlockArchivingStatus: () => IArchivingStatus;
+  waitForBlockArchiver: () => Promise<void>;
+}
+
+export interface IArchivingStatus {
+  lastFinalizedSlot: Slot;
+  finalizingSlot: Slot | null;
 }

--- a/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
@@ -7,7 +7,8 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBlockSummary, IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {IBeaconDb} from "../../db/api";
-import {ITask} from "../interface";
+import {computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {IArchivingStatus} from "../interface";
 export interface IArchiveBlockModules {
   db: IBeaconDb;
   forkChoice: IForkChoice;
@@ -17,28 +18,40 @@ export interface IArchiveBlockModules {
 /**
  * Archives finalized blocks from active bucket to archive bucket.
  */
-export class ArchiveBlocksTask implements ITask {
+export class ArchiveBlocksTask {
   private readonly config: IBeaconConfig;
   private readonly db: IBeaconDb;
   private readonly forkChoice: IForkChoice;
   private readonly logger: ILogger;
 
-  private finalized: phase0.Checkpoint;
+  private finalizingSlot: number | null;
+  private lastFinalizedSlot = 0;
+  // beacon_blocks_by_range handlers waiting for this
+  private subscribedPromises: (() => void)[];
 
-  constructor(config: IBeaconConfig, modules: IArchiveBlockModules, finalized: phase0.Checkpoint) {
+  constructor(config: IBeaconConfig, modules: IArchiveBlockModules) {
     this.config = config;
     this.db = modules.db;
     this.forkChoice = modules.forkChoice;
     this.logger = modules.logger;
-    this.finalized = finalized;
+    this.finalizingSlot = null;
+    this.subscribedPromises = [];
+  }
+
+  /**
+   * Initialize the task with a last finalized block from db.
+   */
+  init(lastFinalizedSlot: number): void {
+    this.lastFinalizedSlot = lastFinalizedSlot;
   }
 
   /**
    * Only archive blocks on the same chain to the finalized checkpoint.
    */
-  async run(): Promise<void> {
+  async run(finalizedCheckpoint: phase0.Checkpoint): Promise<void> {
+    this.finalizingSlot = computeStartSlotAtEpoch(this.config, finalizedCheckpoint.epoch);
     // Use fork choice to determine the blocks to archive and delete
-    const allCanonicalSummaries = this.forkChoice.iterateBlockSummaries(this.finalized.root);
+    const allCanonicalSummaries = this.forkChoice.iterateBlockSummaries(finalizedCheckpoint.root);
     let i = 0;
     // this number of blocks per chunk is tested in e2e test blockArchive.test.ts
     const BATCH_SIZE = 1000;
@@ -54,10 +67,33 @@ export class ArchiveBlocksTask implements ITask {
       });
       i = upperBound;
     }
-    await this.deleteNonCanonicalBlocks();
+    await this.deleteNonCanonicalBlocks(finalizedCheckpoint);
     this.logger.verbose("Archiving of finalized blocks complete", {
       totalArchived: allCanonicalSummaries.length,
-      finalizedEpoch: this.finalized.epoch,
+      finalizedEpoch: finalizedCheckpoint.epoch,
+    });
+    this.lastFinalizedSlot = this.finalizingSlot;
+    this.finalizingSlot = null;
+    this.subscribedPromises.forEach((resolve) => resolve());
+    this.subscribedPromises = [];
+  }
+
+  /**
+   * Returns the blocks being moved from blocks db to archivedBlocks db.
+   */
+  getArchivingStatus(): IArchivingStatus {
+    return {
+      lastFinalizedSlot: this.lastFinalizedSlot,
+      finalizingSlot: this.finalizingSlot,
+    };
+  }
+
+  /**
+   * Wait for run() to be done.
+   */
+  waitUntilComplete(): Promise<void> {
+    return new Promise((resolve) => {
+      this.subscribedPromises.push(resolve);
     });
   }
 
@@ -83,9 +119,9 @@ export class ArchiveBlocksTask implements ITask {
     ]);
   }
 
-  private async deleteNonCanonicalBlocks(): Promise<void> {
+  private async deleteNonCanonicalBlocks(finalizedCheckpoint: phase0.Checkpoint): Promise<void> {
     // loop through forkchoice single time
-    const nonCanonicalSummaries = this.forkChoice.iterateNonAncestors(this.finalized.root);
+    const nonCanonicalSummaries = this.forkChoice.iterateNonAncestors(finalizedCheckpoint.root);
     await this.db.block.batchDelete(nonCanonicalSummaries.map((summary) => summary.blockRoot));
   }
 }

--- a/packages/lodestar/src/util/chain.ts
+++ b/packages/lodestar/src/util/chain.ts
@@ -1,0 +1,23 @@
+import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {Root} from "@chainsafe/lodestar-types";
+import {toHexString} from "@chainsafe/ssz";
+
+/**
+ * Check each block should link to a previous parent block and be a parent of next block.
+ * Throw errors if they're not so that it'll fetch again
+ */
+export function checkLinearChainSegment(
+  config: IBeaconConfig,
+  blocks: phase0.SignedBeaconBlock[] | null,
+  ancestorRoot: Root | null = null
+): void {
+  if (!blocks || blocks.length <= 1) throw new Error("Not enough blocks to validate");
+  let parentRoot = ancestorRoot;
+  for (const block of blocks) {
+    if (parentRoot && !config.types.Root.equals(block.message.parentRoot, parentRoot)) {
+      throw new Error(`Block ${block.message.slot} does not link to parent ${toHexString(parentRoot)}`);
+    }
+    parentRoot = config.types.phase0.BeaconBlock.hashTreeRoot(block.message);
+  }
+}

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -61,7 +61,7 @@ describe("network", function () {
 
     const chain = new MockBeaconChain({genesisTime: 0, chainId: 0, networkId: BigInt(0), state, config});
     const db = new StubbedBeaconDb(sinon, config);
-    const reqRespHandler = new ReqRespHandler({db, chain});
+    const reqRespHandler = new ReqRespHandler({config, db, chain});
 
     const [libp2pA, libp2pB] = await Promise.all([createNode(multiaddr), createNode(multiaddr)]);
     const loggerA = testLogger("A");

--- a/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
@@ -2,7 +2,7 @@ import {EventEmitter} from "events";
 import sinon from "sinon";
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/mainnet";
-import {IReqResp} from "../../../../src/network/reqresp";
+import {IReqResp, ReqRespHandler} from "../../../../src/network/reqresp";
 import {PeerRpcScoreStore, PeerManager, Libp2pPeerMetadataStore} from "../../../../src/network/peers";
 import {NetworkEvent, NetworkEventBus} from "../../../../src/network";
 import {Method} from "../../../../src/constants";
@@ -79,6 +79,7 @@ describe("network / peers / PeerManager", function () {
     ping = sinon.stub();
     beaconBlocksByRange = sinon.stub();
     beaconBlocksByRoot = sinon.stub();
+    reqRespHandler = sinon.createStubInstance(ReqRespHandler);
   }
 
   it("Should request metadata on receivedPing of unknown peer", async () => {

--- a/packages/lodestar/test/e2e/network/reqresp.test.ts
+++ b/packages/lodestar/test/e2e/network/reqresp.test.ts
@@ -66,6 +66,8 @@ describe("network / ReqResp", function () {
       onStatus: notImplemented,
       onBeaconBlocksByRange: notImplemented,
       onBeaconBlocksByRoot: notImplemented,
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      registerChores: () => {},
       ...reqRespHandlerPartial,
     };
     const opts = {...networkOptsDefault, ...reqRespOpts};

--- a/packages/lodestar/test/unit/network/reqresp/handlers/beaconBlocksByRange.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/handlers/beaconBlocksByRange.test.ts
@@ -1,0 +1,253 @@
+import {initBLS} from "@chainsafe/lodestar-cli/src/util";
+import {config} from "@chainsafe/lodestar-config/minimal";
+import {expect} from "chai";
+import sinon, {SinonStubbedInstance} from "sinon";
+import {RpcResponseStatus} from "../../../../../src/constants";
+import {
+  handleBeaconBlocksByRange,
+  isOverlappedRange,
+  onBeaconBlocksByRange,
+  shouldRetry,
+  shouldWaitForBlockArchiver,
+} from "../../../../../src/network/reqresp/handlers/beaconBlocksByRange";
+import {ResponseError} from "../../../../../src/network/reqresp/response";
+import {TasksService} from "../../../../../src/tasks";
+import {IArchivingStatus, ITaskService} from "../../../../../src/tasks/interface";
+import {generateEmptySignedBlock} from "../../../../utils/block";
+import {StubbedBeaconChain, StubbedBeaconDb} from "../../../../utils/stub";
+
+describe("shouldWaitForBlockArchiver", function () {
+  const requestBody = {
+    startSlot: 40,
+    count: 30,
+    step: 1,
+  };
+  const testCases: {desc: string; archiveStatus: IArchivingStatus; expected: boolean}[] = [
+    {
+      desc: "first check, BlockArchiver is not running",
+      archiveStatus: {lastFinalizedSlot: 32, finalizingSlot: null},
+      expected: false,
+    },
+    {
+      desc: "first check, BlockArchiver is running at different range",
+      archiveStatus: {lastFinalizedSlot: 1000, finalizingSlot: 1032},
+      expected: false,
+    },
+    {
+      desc: "first, BlockArchiver is running at overlappsed range",
+      archiveStatus: {lastFinalizedSlot: 32, finalizingSlot: 64},
+      expected: true,
+    },
+  ];
+  for (const tc of testCases) {
+    it(tc.desc, function () {
+      expect(shouldWaitForBlockArchiver(requestBody, tc.archiveStatus)).to.be.equal(tc.expected);
+    });
+  }
+  const testCases2: {
+    desc: string;
+    archiveStatus: IArchivingStatus;
+    newArchiveStatus: IArchivingStatus;
+    expected: boolean;
+  }[] = [
+    {
+      desc: "2nd check, same archive status",
+      archiveStatus: {lastFinalizedSlot: 32, finalizingSlot: null},
+      newArchiveStatus: {lastFinalizedSlot: 32, finalizingSlot: null},
+      expected: false,
+    },
+    {
+      desc: "2nd check, different archive status - Block Archiver is running at different range",
+      archiveStatus: {lastFinalizedSlot: 32, finalizingSlot: null},
+      newArchiveStatus: {lastFinalizedSlot: 1000, finalizingSlot: 1032},
+      expected: false,
+    },
+    {
+      desc: "2nd check, different archive status - Block Archiver is running at overlappsed range",
+      archiveStatus: {lastFinalizedSlot: 32, finalizingSlot: null},
+      newArchiveStatus: {lastFinalizedSlot: 32, finalizingSlot: 64},
+      expected: true,
+    },
+  ];
+  for (const tc of testCases2) {
+    it(tc.desc, function () {
+      expect(shouldWaitForBlockArchiver(requestBody, tc.archiveStatus, tc.newArchiveStatus)).to.be.equal(tc.expected);
+    });
+  }
+});
+
+describe("shouldRetry", function () {
+  const requestBody = {
+    startSlot: 40,
+    count: 30,
+    step: 1,
+  };
+  const testCases: {
+    desc: string;
+    archiveStatus: IArchivingStatus;
+    newArchiveStatus: IArchivingStatus;
+    expected: boolean;
+  }[] = [
+    {
+      desc: "2nd check, same archive status",
+      archiveStatus: {lastFinalizedSlot: 32, finalizingSlot: null},
+      newArchiveStatus: {lastFinalizedSlot: 32, finalizingSlot: null},
+      expected: false,
+    },
+    {
+      desc: "2nd check, different archive status - Block Archiver is running at different range",
+      archiveStatus: {lastFinalizedSlot: 32, finalizingSlot: null},
+      newArchiveStatus: {lastFinalizedSlot: 1000, finalizingSlot: 1032},
+      expected: false,
+    },
+    {
+      desc: "2nd check, different archive status - Block Archiver is completed at different range",
+      archiveStatus: {lastFinalizedSlot: 32, finalizingSlot: null},
+      newArchiveStatus: {lastFinalizedSlot: 1032, finalizingSlot: null},
+      expected: false,
+    },
+    {
+      desc: "2nd check, different archive status - Block Archiver is completed at overlappsed range",
+      archiveStatus: {lastFinalizedSlot: 32, finalizingSlot: null},
+      newArchiveStatus: {lastFinalizedSlot: 64, finalizingSlot: null},
+      expected: true,
+    },
+  ];
+
+  for (const tc of testCases) {
+    it(tc.desc, function () {
+      expect(shouldRetry(requestBody, tc.archiveStatus, tc.newArchiveStatus)).to.be.equal(tc.expected);
+    });
+  }
+});
+
+describe("isOverlappedRange", function () {
+  const requestBody = {
+    startSlot: 40,
+    count: 30,
+    step: 1,
+  };
+  it("should be overlappsed", function () {
+    expect(isOverlappedRange(requestBody, 62, 96)).to.be.true;
+    expect(isOverlappedRange(requestBody, 32, 64)).to.be.true;
+  });
+  it("should not be overlappsed", function () {
+    expect(isOverlappedRange(requestBody, 0, 32)).to.be.false;
+    expect(isOverlappedRange(requestBody, 96, 128)).to.be.false;
+  });
+});
+
+describe("handleBeaconBlocksByRange", function () {
+  const requestBody = {
+    startSlot: 2021,
+    count: 30,
+    step: 4,
+  };
+  const sandbox = sinon.createSandbox();
+  let dbStub: StubbedBeaconDb;
+  let chainStub: StubbedBeaconChain;
+  before(async () => {
+    await initBLS();
+  });
+  beforeEach(function () {
+    dbStub = new StubbedBeaconDb(sandbox);
+    chainStub = new StubbedBeaconChain(sandbox, config);
+  });
+
+  it("should resolve unfinalized blocks only", async function () {
+    dbStub.blockArchive.values.resolves(undefined);
+    const blocks = [generateEmptySignedBlock()];
+    blocks[0].message.slot = 2021;
+    chainStub.getUnfinalizedBlocksAtSlots = sandbox.stub().resolves(blocks);
+    const result = await handleBeaconBlocksByRange(requestBody, chainStub, dbStub);
+    expect(result).to.be.deep.equal(blocks);
+  });
+
+  it("should resolve finalized blocks only", async function () {
+    const blocks = [generateEmptySignedBlock()];
+    blocks[0].message.slot = 2021;
+    dbStub.blockArchive.values.resolves(blocks);
+    chainStub.getUnfinalizedBlocksAtSlots = sandbox.stub().resolves([]);
+    const result = await handleBeaconBlocksByRange(requestBody, chainStub, dbStub);
+    expect(result).to.be.deep.equal(blocks);
+  });
+
+  it("should resolve both finalized blocks and unfinalized blocks", async function () {
+    const finalizedBlocks = [generateEmptySignedBlock()];
+    finalizedBlocks[0].message.slot = 2021;
+    dbStub.blockArchive.values.resolves(finalizedBlocks);
+    const unfinalizedBlocks = [generateEmptySignedBlock()];
+    unfinalizedBlocks[0].message.slot = 2025;
+    chainStub.getUnfinalizedBlocksAtSlots = sandbox.stub().resolves(unfinalizedBlocks);
+    const result = await handleBeaconBlocksByRange(requestBody, chainStub, dbStub);
+    expect(result).to.be.deep.equal([...finalizedBlocks, ...unfinalizedBlocks]);
+  });
+});
+
+describe("onBeaconBlocksByRange", function () {
+  const requestBody = {
+    startSlot: 2021,
+    count: 30,
+    step: 1,
+  };
+  const block1 = generateEmptySignedBlock();
+  block1.message.slot = requestBody.startSlot;
+  const block2 = generateEmptySignedBlock();
+  block2.message.slot = requestBody.startSlot + requestBody.step;
+  block2.message.parentRoot = config.types.phase0.BeaconBlock.hashTreeRoot(block1.message);
+  const sandbox = sinon.createSandbox();
+  let dbStub: StubbedBeaconDb;
+  let chainStub: StubbedBeaconChain;
+  let choresStub: SinonStubbedInstance<ITaskService>;
+  before(async () => {
+    await initBLS();
+  });
+  beforeEach(function () {
+    dbStub = new StubbedBeaconDb(sandbox);
+    chainStub = new StubbedBeaconChain(sandbox, config);
+    choresStub = sandbox.createStubInstance(TasksService);
+    dbStub.blockArchive.values.resolves([block1, block2]);
+    chainStub.getUnfinalizedBlocksAtSlots = sandbox.stub().resolves([]);
+  });
+
+  it("should throw error if not linear chain segment", async function () {
+    choresStub.getBlockArchivingStatus.returns({lastFinalizedSlot: 3000, finalizingSlot: null});
+    // the returned 2 blocks do not have parent-child relationship
+    dbStub.blockArchive.values.resolves([generateEmptySignedBlock(), generateEmptySignedBlock()]);
+    try {
+      await onBeaconBlocksByRange(config, requestBody, chainStub, dbStub, choresStub);
+      expect.fail("Expect error to be thrown due to non linear chain segment");
+    } catch (e) {
+      expect((e as ResponseError).status).to.be.equal(RpcResponseStatus.SERVER_ERROR);
+    }
+  });
+
+  it("should return linear chain segment without waiting for BlockArchiver", async function () {
+    choresStub.getBlockArchivingStatus.returns({lastFinalizedSlot: 3000, finalizingSlot: null});
+    const blocks = await onBeaconBlocksByRange(config, requestBody, chainStub, dbStub, choresStub);
+    expect(blocks).to.be.deep.equal([block1, block2]);
+    expect(choresStub.waitForBlockArchiver.called).to.be.false;
+  });
+
+  it("should wait for BlockArchiver after 1st check", async function () {
+    choresStub.getBlockArchivingStatus.returns({lastFinalizedSlot: 2021, finalizingSlot: 2053});
+    choresStub.waitForBlockArchiver.resolves();
+    const blocks = await onBeaconBlocksByRange(config, requestBody, chainStub, dbStub, choresStub);
+    expect(blocks).to.be.deep.equal([block1, block2]);
+    expect(choresStub.waitForBlockArchiver.calledOnce).to.be.true;
+    expect(choresStub.getBlockArchivingStatus.calledOnce).to.be.true;
+  });
+
+  it("should wait for BlockArchiver after 2nd check", async function () {
+    // 1st check is fine
+    choresStub.getBlockArchivingStatus.onFirstCall().returns({lastFinalizedSlot: 2021, finalizingSlot: null});
+    choresStub.getBlockArchivingStatus.onSecondCall().returns({lastFinalizedSlot: 2021, finalizingSlot: 2053});
+    choresStub.waitForBlockArchiver.resolves();
+    const blocks = await onBeaconBlocksByRange(config, requestBody, chainStub, dbStub, choresStub);
+    expect(blocks).to.be.deep.equal([block1, block2]);
+    expect(choresStub.waitForBlockArchiver.calledOnce).to.be.true;
+    expect(choresStub.getBlockArchivingStatus.calledTwice).to.be.true;
+    // handleBeaconBlocksByRange is called twice
+    expect(dbStub.blockArchive.values.calledTwice).to.be.true;
+  });
+});

--- a/packages/lodestar/test/unit/sync/utils/sync.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/sync.test.ts
@@ -5,8 +5,8 @@ import sinon, {SinonStubbedInstance} from "sinon";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {ForkChoice} from "@chainsafe/lodestar-fork-choice";
 
-import {checkBestPeer, checkLinearChainSegment, getBestHead, getBestPeer} from "../../../../src/sync/utils";
-import {generateBlockSummary, generateEmptySignedBlock} from "../../../utils/block";
+import {checkBestPeer, getBestHead, getBestPeer} from "../../../../src/sync/utils";
+import {generateBlockSummary} from "../../../utils/block";
 import {ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
 import {INetwork, Network} from "../../../../src/network";
 import {IPeerRpcScoreStore, PeerRpcScoreStore, ScoreState} from "../../../../src/network/peers";
@@ -153,44 +153,6 @@ describe("sync utils", function () {
       expect(networkStub.getConnectedPeers.calledOnce).to.be.true;
       expect(peerScoreStub.getScoreState.calledOnce).to.be.true;
       expect(forkChoiceStub.getHead.calledOnce).to.be.true;
-    });
-  });
-
-  describe("checkLinearChainSegment", function () {
-    it("should throw error if not enough block", () => {
-      expect(() => checkLinearChainSegment(config, null)).to.throw("Not enough blocks to validate");
-      expect(() => checkLinearChainSegment(config, [])).to.throw("Not enough blocks to validate");
-      expect(() => checkLinearChainSegment(config, [generateEmptySignedBlock()])).to.throw(
-        "Not enough blocks to validate"
-      );
-    });
-
-    it("should throw error if first block not link to ancestor root", () => {
-      const block = generateEmptySignedBlock();
-      expect(() => checkLinearChainSegment(config, [block, block])).to.throw(
-        "Block 0 does not link to parent 0xeade62f0457b2fdf48e7d3fc4b60736688286be7c7a3ac4c9a16a5e0600bd9e4"
-      );
-    });
-
-    it("should throw error if second block not link to first block", () => {
-      const firstBlock = generateEmptySignedBlock();
-      const ancestorRoot = firstBlock.message.parentRoot;
-      const secondBlock = generateEmptySignedBlock();
-      secondBlock.message.slot = 1;
-      // secondBlock.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(firstBlock.message);
-      expect(() => checkLinearChainSegment(config, [firstBlock, secondBlock], ancestorRoot)).to.throw(
-        "Block 1 does not link to parent 0xeade62f0457b2fdf48e7d3fc4b60736688286be7c7a3ac4c9a16a5e0600bd9e4"
-      );
-    });
-
-    it("should form linear chain segment", () => {
-      const firstBlock = generateEmptySignedBlock();
-      const ancestorRoot = firstBlock.message.parentRoot;
-      const secondBlock = generateEmptySignedBlock();
-      secondBlock.message.slot = 1;
-      secondBlock.message.parentRoot = config.types.phase0.BeaconBlock.hashTreeRoot(firstBlock.message);
-      checkLinearChainSegment(config, [firstBlock, secondBlock], ancestorRoot);
-      // no error thrown means success
     });
   });
 });

--- a/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
+++ b/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
@@ -38,19 +38,13 @@ describe("block archiver task", function () {
     ];
     forkChoiceStub.iterateBlockSummaries.returns(canonicalBlocks);
     forkChoiceStub.iterateNonAncestors.returns([generateBlockSummary({slot: 3})]);
-    const archiverTask = new ArchiveBlocksTask(
-      config,
-      {
-        db: dbStub,
-        forkChoice: forkChoiceStub,
-        logger,
-      },
-      {
-        epoch: 5,
-        root: ZERO_HASH,
-      }
-    );
-    await archiverTask.run();
+    const archiverTask = new ArchiveBlocksTask(config, {
+      db: dbStub,
+      forkChoice: forkChoiceStub,
+      logger,
+    });
+    archiverTask.init(0);
+    await archiverTask.run({epoch: 5, root: ZERO_HASH});
     expect(
       dbStub.blockArchive.batchPutBinary.calledWith(
         canonicalBlocks.map((summary) => ({

--- a/packages/lodestar/test/utils/chain.test.ts
+++ b/packages/lodestar/test/utils/chain.test.ts
@@ -1,0 +1,42 @@
+import {config} from "@chainsafe/lodestar-config/minimal";
+import {expect} from "chai";
+import {checkLinearChainSegment} from "../../src/util/chain";
+import {generateEmptySignedBlock} from "./block";
+
+describe("checkLinearChainSegment", function () {
+  it("should throw error if not enough block", () => {
+    expect(() => checkLinearChainSegment(config, null)).to.throw("Not enough blocks to validate");
+    expect(() => checkLinearChainSegment(config, [])).to.throw("Not enough blocks to validate");
+    expect(() => checkLinearChainSegment(config, [generateEmptySignedBlock()])).to.throw(
+      "Not enough blocks to validate"
+    );
+  });
+
+  it("should throw error if first block not link to ancestor root", () => {
+    const block = generateEmptySignedBlock();
+    expect(() => checkLinearChainSegment(config, [block, block])).to.throw(
+      "Block 0 does not link to parent 0xeade62f0457b2fdf48e7d3fc4b60736688286be7c7a3ac4c9a16a5e0600bd9e4"
+    );
+  });
+
+  it("should throw error if second block not link to first block", () => {
+    const firstBlock = generateEmptySignedBlock();
+    const ancestorRoot = firstBlock.message.parentRoot;
+    const secondBlock = generateEmptySignedBlock();
+    secondBlock.message.slot = 1;
+    // secondBlock.message.parentRoot = config.types.BeaconBlock.hashTreeRoot(firstBlock.message);
+    expect(() => checkLinearChainSegment(config, [firstBlock, secondBlock], ancestorRoot)).to.throw(
+      "Block 1 does not link to parent 0xeade62f0457b2fdf48e7d3fc4b60736688286be7c7a3ac4c9a16a5e0600bd9e4"
+    );
+  });
+
+  it("should form linear chain segment", () => {
+    const firstBlock = generateEmptySignedBlock();
+    const ancestorRoot = firstBlock.message.parentRoot;
+    const secondBlock = generateEmptySignedBlock();
+    secondBlock.message.slot = 1;
+    secondBlock.message.parentRoot = config.types.phase0.BeaconBlock.hashTreeRoot(firstBlock.message);
+    checkLinearChainSegment(config, [firstBlock, secondBlock], ancestorRoot);
+    // no error thrown means success
+  });
+});


### PR DESCRIPTION
resolves #2127 

Most of the time a `beaconBlocksByRange` handler does not need to deal with BlockArchiver, just in edge case when both run at the same time with an overlapped range 

+ Add new methods to BlockArchive task to know its status: `getArchivingStatus()` which returns a last finalized slot and a finalizing slot (`null` if not running); and `waitUntilComplete()` to wait for a `run()` to be done
+ if `beaconBlocksByRange` handler found that `BlockArchiver` is running with an overlapped range, it'd wait for BlockArchiver to finish first before querying database (a `BlockArchiver.run` takes less than 300ms so I hope it's ok)
+ if `step=1` do a linear chain segment check to make sure we return a good result to clients in order to avoid the downvote