### PR TITLE
Remove abortable source wrapper from response source

### DIFF
--- a/packages/lodestar/src/network/reqresp/request/index.ts
+++ b/packages/lodestar/src/network/reqresp/request/index.ts
@@ -112,7 +112,7 @@ export async function sendRequest<T extends phase0.ResponseBody | phase0.Respons
     logger.debug("Req  request sent", logCtx);
 
     const responses = await pipe(
-      abortSource(stream.source, signal),
+      stream.source,
       responseTimeoutsHandler(responseDecode(config, method, encoding), options),
       collectResponses(method, maxResponses)
     );


### PR DESCRIPTION
There was a memory leak stemming from using `abortable-iterator` and neither fully draining the iterator nor aborting it.
`abortable-iterator` attaches an abort signal listener and only removes the listener after:
- the iterator is `{done: true}` OR
- the iterator is aborted

In our case, `collectResponses` `break`s out of the iterator after `maxResponses` # of iterations.
So every request was leaking a listener.


For now, remove the abortable source wrapper until we can figure out a better solution.