### PR TITLE
Review ReqResp stream handling

### DIFF
--- a/packages/lodestar/src/network/reqresp/encoders/requestDecode.ts
+++ b/packages/lodestar/src/network/reqresp/encoders/requestDecode.ts
@@ -25,10 +25,6 @@ export function requestDecode(
 
     // Request has a single payload, so return immediately
     const bufferedSource = new BufferedSource(source as AsyncGenerator<Buffer>);
-    try {
-      return await readEncodedPayload<phase0.RequestBody>(bufferedSource, encoding, type);
-    } finally {
-      await bufferedSource.return();
-    }
+    return await readEncodedPayload<phase0.RequestBody>(bufferedSource, encoding, type);
   };
 }

--- a/packages/lodestar/src/network/reqresp/interface.ts
+++ b/packages/lodestar/src/network/reqresp/interface.ts
@@ -51,4 +51,8 @@ export interface ILibP2pStream {
    * `libp2p-mplex`: Close immediately for reading and writing (remote error)
    */
   reset: () => void;
+  /**
+   * `libp2p-mplex`: Close for reading and writing (local error)
+   */
+  abort: (err: Error) => void;
 }

--- a/packages/lodestar/src/network/reqresp/interface.ts
+++ b/packages/lodestar/src/network/reqresp/interface.ts
@@ -40,6 +40,15 @@ export type ReqRespHandler = (
 export interface ILibP2pStream {
   source: AsyncIterable<Buffer>;
   sink: (source: AsyncIterable<Buffer>) => Promise<void>;
+  /**
+   * `libp2p-mplex`: Close for reading
+   * ```ts
+   * () => stream.source.end()
+   * ```
+   */
   close: () => void;
+  /**
+   * `libp2p-mplex`: Close immediately for reading and writing (remote error)
+   */
   reset: () => void;
 }

--- a/packages/lodestar/src/network/reqresp/response/index.ts
+++ b/packages/lodestar/src/network/reqresp/response/index.ts
@@ -63,6 +63,11 @@ export async function handleRequest(
     stream.sink
   );
 
+  // If streak.sink throws, libp2p-mplex will close stream.source
+  // If `requestDecode()` throws the stream.source must be closed manually
+  // To ensure the stream.source it-pushable instance is always closed, stream.close() is called always
+  stream.close();
+
   // TODO: It may happen that stream.sink returns before returning stream.source first,
   // so you never see "Resp received request" in the logs and the response ends without
   // sending any chunk, triggering EMPTY_RESPONSE error on the requesting side
@@ -75,7 +80,4 @@ export async function handleRequest(
   } else {
     logger.verbose("Resp done", logCtx);
   }
-
-  // Not necessary to call `stream.close()` in finally {}, libp2p-mplex do
-  // when either the source is exhausted or the sink returns
 }

--- a/packages/lodestar/src/network/reqresp/utils/bufferedSource.ts
+++ b/packages/lodestar/src/network/reqresp/utils/bufferedSource.ts
@@ -2,9 +2,7 @@ import BufferList from "bl";
 
 /**
  * Wraps a buffer chunk stream source with another async iterable
- * so it can be reused in multiple for..of statements. Intercepts
- * and ignores all generator return calls until manually calling
- * bufferedSource.return()
+ * so it can be reused in multiple for..of statements.
  *
  * Uses a BufferList internally to make sure all chunks are consumed
  * when switching consumers
@@ -39,21 +37,11 @@ export class BufferedSource {
           that.isDone = true;
           return {done: true, value: undefined};
         } else {
-          // Concat new chunk and return a reference to this instance
-          // peristent BufferList
+          // Concat new chunk and return a reference to its BufferList instance
           that.buffer.append(chunk);
           return {done: false, value: that.buffer};
         }
       },
-
-      // Intercept the return call when breaking out of a for..of
-      async return() {
-        return {done: true, value: undefined};
-      },
     };
-  }
-
-  async return(): Promise<void> {
-    await this.source.return(undefined);
   }
 }

--- a/packages/lodestar/test/e2e/sync/reqResp.test.ts
+++ b/packages/lodestar/test/e2e/sync/reqResp.test.ts
@@ -218,7 +218,7 @@ describe("[sync] rpc", function () {
   it("should return invalid request status code", async () => {
     const protocol = createRpcProtocol(Method.Status, ReqRespEncoding.SSZ_SNAPPY);
     await netA.connect(netB.peerId, netB.localMultiaddrs);
-    const {stream} = (await libP2pA.dialProtocol(netB.peerId, protocol)) as {stream: ILibP2pStream};
+    const {stream} = ((await libP2pA.dialProtocol(netB.peerId, protocol)) as unknown) as {stream: ILibP2pStream};
 
     // Bad encoding, 9e23 exceeds the max 10 varint bytes
     const requestBytes = [Buffer.from(encode(99999999999999999999999))];

--- a/packages/lodestar/test/unit/network/reqresp/utils.ts
+++ b/packages/lodestar/test/unit/network/reqresp/utils.ts
@@ -63,4 +63,5 @@ export class MockLibP2pStream implements ILibP2pStream {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   close: ILibP2pStream["close"] = () => {};
   reset: ILibP2pStream["reset"] = () => this.close();
+  abort: ILibP2pStream["abort"] = () => this.close();
 }


### PR DESCRIPTION
Follow up to https://github.com/ChainSafe/lodestar/pull/2163

After inspecting closely our ReqResp code, `js-libp2p`, `js-libp2p-mplex` and, `it-pushable` with the goals:

- Use abort interators and signals only if necessary
- Ensure to close the stream in all cases

this PR fixes some extra errors caused by a miss-understanding of the implications in upstream communication of the `for .. of` iterator protocol. It adds more clarifying comments to justify the changes and aid maintainability.