### PR TITLE
Add getMissingAncestor method

### DIFF
--- a/packages/lodestar/src/chain/blocks/pool.ts
+++ b/packages/lodestar/src/chain/blocks/pool.ts
@@ -97,6 +97,16 @@ export class BlockPool {
     }
   }
 
+  getMissingAncestor(blockRoot: Root): Root {
+    let root = toHexString(blockRoot);
+
+    while (this.blocks.has(root)) {
+      root = this.blocks.get(root)!;
+    }
+
+    return fromHexString(root);
+  }
+
   getTotalPendingBlocks(): number {
     return this.blocks.size;
   }

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -217,8 +217,11 @@ export class BeaconSync implements IBeaconSync {
 
   private onUnknownBlockRoot = async (err: BlockError): Promise<void> => {
     if (err.type.code !== BlockErrorCode.PARENT_UNKNOWN) return;
-    const parentRoot = err.type.parentRoot;
+
+    const blockRoot = this.config.types.phase0.BeaconBlock.hashTreeRoot(err.job.signedBlock.message);
+    const parentRoot = this.chain.pendingBlocks.getMissingAncestor(blockRoot);
     const parentRootHex = toHexString(parentRoot);
+
     if (this.processingRoots.has(parentRootHex)) {
       return;
     } else {

--- a/packages/lodestar/test/unit/chain/blocks/pool.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/pool.test.ts
@@ -1,0 +1,22 @@
+import {config} from "@chainsafe/lodestar-config/minimal";
+import {expect} from "chai";
+import {BlockPool} from "../../../../src/chain/blocks";
+
+describe("BlockPool", function () {
+  let pool: BlockPool;
+
+  beforeEach(() => {
+    pool = new BlockPool({config});
+  });
+
+  it("should get missing ancestor", () => {
+    const firstBlock = config.types.phase0.SignedBeaconBlock.defaultValue();
+    const ancestorRoot = firstBlock.message.parentRoot;
+    const secondBlock = config.types.phase0.SignedBeaconBlock.defaultValue();
+    secondBlock.message.parentRoot = config.types.phase0.BeaconBlock.hashTreeRoot(firstBlock.message);
+    pool.addBySlot(firstBlock);
+    pool.addByParent(secondBlock);
+    const root = pool.getMissingAncestor(config.types.phase0.BeaconBlock.hashTreeRoot(secondBlock.message));
+    expect(config.types.Root.equals(ancestorRoot, root)).to.be.true;
+  });
+});


### PR DESCRIPTION
Reverts https://github.com/ChainSafe/lodestar/pull/2099

@tuyennhv noted here https://github.com/ChainSafe/lodestar/issues/2081#issuecomment-797216649 that https://github.com/ChainSafe/lodestar/pull/2099 would result in unnecessary unknownBlockRoot searches, as it ignores existing pendingBlocks.