### PR TITLE
Rename WinstonLogger to Logger

### DIFF
--- a/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/block/block.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/block/block.test.ts
@@ -1,5 +1,5 @@
 import {config} from "@chainsafe/lodestar-config/mainnet";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Logger} from "@chainsafe/lodestar-utils";
 import {List} from "@chainsafe/ssz";
 import {expect} from "chai";
 import {generatePerformanceBlock, generatePerformanceState, initBLS} from "../../../util";
@@ -8,7 +8,7 @@ import {phase0} from "../../../../../src";
 describe("Process Blocks Performance Test", function () {
   this.timeout(0);
   let stateCtx: phase0.fast.IStateContext;
-  const logger = new WinstonLogger();
+  const logger = new Logger();
   before(async () => {
     await initBLS();
     const origState = await generatePerformanceState();

--- a/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/epoch/epoch.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/epoch/epoch.test.ts
@@ -1,5 +1,5 @@
 import {config} from "@chainsafe/lodestar-config/mainnet";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Logger} from "@chainsafe/lodestar-utils";
 import {generatePerformanceState, initBLS} from "../../../util";
 import {expect} from "chai";
 import {phase0} from "../../../../../src";
@@ -8,7 +8,7 @@ describe("Epoch Processing Performance Tests", function () {
   let state: phase0.fast.CachedValidatorsBeaconState;
   let epochCtx: phase0.fast.EpochContext;
   let process: phase0.fast.IEpochProcess;
-  const logger = new WinstonLogger();
+  const logger = new Logger();
 
   before(async function () {
     this.timeout(0);

--- a/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/epoch/getAttestationDeltas.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/epoch/getAttestationDeltas.test.ts
@@ -1,5 +1,5 @@
 import {config} from "@chainsafe/lodestar-config/mainnet";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Logger} from "@chainsafe/lodestar-utils";
 import {generatePerformanceState, initBLS} from "../../../util";
 import {expect} from "chai";
 import {phase0} from "../../../../../src";
@@ -8,7 +8,7 @@ describe("getAttestationDeltas", function () {
   let state: phase0.fast.CachedValidatorsBeaconState;
   let epochCtx: phase0.EpochContext;
   let epochProcess: phase0.fast.IEpochProcess;
-  const logger = new WinstonLogger();
+  const logger = new Logger();
 
   before(async function () {
     this.timeout(0);

--- a/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/epoch/processRewardsAndPenalties.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/epoch/processRewardsAndPenalties.test.ts
@@ -1,5 +1,5 @@
 import {config} from "@chainsafe/lodestar-config/mainnet";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Logger} from "@chainsafe/lodestar-utils";
 import {generatePerformanceState, initBLS} from "../../../util";
 import {expect} from "chai";
 import {phase0} from "../../../../../src";
@@ -8,7 +8,7 @@ describe("processRewardsAndPenalties", function () {
   let state: phase0.fast.CachedValidatorsBeaconState;
   let epochCtx: phase0.EpochContext;
   let epochProcess: phase0.fast.IEpochProcess;
-  const logger = new WinstonLogger();
+  const logger = new Logger();
 
   before(async function () {
     this.timeout(0);

--- a/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/slot/slots.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/phase0/fast/slot/slots.test.ts
@@ -1,12 +1,12 @@
 import {config} from "@chainsafe/lodestar-config/mainnet";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Logger} from "@chainsafe/lodestar-utils";
 import {expect} from "chai";
 import {phase0} from "../../../../../src";
 import {initBLS, generatePerformanceState} from "../../../util";
 
 describe("Process Slots Performance Test", function () {
   this.timeout(0);
-  const logger = new WinstonLogger();
+  const logger = new Logger();
   let state: phase0.fast.CachedValidatorsBeaconState;
   let epochCtx: phase0.fast.EpochContext;
 

--- a/packages/lodestar-beacon-state-transition/test/perf/util.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/util.ts
@@ -1,13 +1,13 @@
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {Gwei, phase0} from "@chainsafe/lodestar-types";
 import {init} from "@chainsafe/bls";
-import {WinstonLogger, interopSecretKeys} from "@chainsafe/lodestar-utils";
+import {Logger, interopSecretKeys} from "@chainsafe/lodestar-utils";
 import {fromHexString, List, TreeBacked} from "@chainsafe/ssz";
 import {getBeaconProposerIndex} from "../../src/util/proposer";
 
 let archivedState: TreeBacked<phase0.BeaconState> | null = null;
 let signedBlock: TreeBacked<phase0.SignedBeaconBlock> | null = null;
-const logger = new WinstonLogger();
+const logger = new Logger();
 
 /**
  * This is generated from Medalla state 756416

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/utils.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/utils.ts
@@ -1,5 +1,5 @@
 import {Root} from "@chainsafe/lodestar-types";
-import {LogLevel, WinstonLogger} from "@chainsafe/lodestar-utils";
+import {LogLevel, Logger} from "@chainsafe/lodestar-utils";
 import {SlashingProtection} from "@chainsafe/lodestar-validator";
 import {LevelDbController} from "@chainsafe/lodestar-db";
 import {ApiClientOverRest} from "@chainsafe/lodestar-validator";
@@ -16,7 +16,7 @@ export function getSlashingProtection(args: IGlobalArgs): SlashingProtection {
   const validatorPaths = getValidatorPaths(args);
   const dbPath = validatorPaths.validatorsDbDir;
   const config = getBeaconConfigFromArgs(args);
-  const logger = new WinstonLogger({level: LogLevel.error});
+  const logger = new Logger({level: LogLevel.error});
   return new SlashingProtection({
     config: config,
     controller: new LevelDbController({name: dbPath}, {logger}),
@@ -30,7 +30,7 @@ export async function getGenesisValidatorsRoot(args: IGlobalArgs & ISlashingProt
   const server = args.server;
 
   const config = getBeaconConfigFromArgs(args);
-  const logger = new WinstonLogger({level: LogLevel.error});
+  const logger = new Logger({level: LogLevel.error});
 
   const api = new ApiClientOverRest(config, server, logger);
   const genesis = await api.beacon.getGenesis();

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/voluntaryExit.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/voluntaryExit.ts
@@ -1,6 +1,6 @@
 import {ICliCommand, initBLS, YargsError} from "../../../../util";
 import {IGlobalArgs} from "../../../../options";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Logger} from "@chainsafe/lodestar-utils";
 import {Validator} from "@chainsafe/lodestar-validator";
 import {ValidatorDirManager} from "../../../../validatorDir";
 import {getAccountPaths} from "../../paths";
@@ -107,7 +107,7 @@ BE UNTIL AT LEAST TWO YEARS AFTER THE PHASE 0 MAINNET LAUNCH.
       config,
       api: args.server,
       secretKeys: [secretKey],
-      logger: new WinstonLogger(),
+      logger: new Logger(),
       graffiti: args.graffiti,
     });
 

--- a/packages/lodestar-cli/src/cmds/beacon/handler.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/handler.ts
@@ -1,6 +1,6 @@
 import {AbortController} from "abort-controller";
 
-import {consoleTransport, ErrorAborted, fileTransport, WinstonLogger} from "@chainsafe/lodestar-utils";
+import {consoleTransport, ErrorAborted, fileTransport, Logger} from "@chainsafe/lodestar-utils";
 import {LevelDbController} from "@chainsafe/lodestar-db";
 import {BeaconNode, BeaconDb, createNodeJsLibp2p} from "@chainsafe/lodestar";
 
@@ -39,7 +39,7 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
   const abortController = new AbortController();
 
   // Logger setup
-  const logger = new WinstonLogger({level: args.logLevel}, [
+  const logger = new Logger({level: args.logLevel}, [
     consoleTransport,
     ...(beaconPaths.logFile ? [fileTransport(beaconPaths.logFile)] : []),
   ]);

--- a/packages/lodestar-cli/src/cmds/dev/handler.ts
+++ b/packages/lodestar-cli/src/cmds/dev/handler.ts
@@ -4,7 +4,7 @@ import {promisify} from "util";
 import rimraf from "rimraf";
 import {join} from "path";
 import {BeaconNode, BeaconDb, initStateFromAnchorState, createNodeJsLibp2p, nodeUtils} from "@chainsafe/lodestar";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Logger} from "@chainsafe/lodestar-utils";
 import {Validator} from "@chainsafe/lodestar-validator";
 import {LevelDbController} from "@chainsafe/lodestar-db";
 import {getInteropValidator} from "../validator/utils/interop/validator";
@@ -44,7 +44,7 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
 
   // BeaconNode setup
   const libp2p = await createNodeJsLibp2p(peerId, options.network);
-  const logger = new WinstonLogger({level: args.logLevel});
+  const logger = new Logger({level: args.logLevel});
 
   const db = new BeaconDb({config, controller: new LevelDbController(options.db, {logger})});
   await db.start();

--- a/packages/lodestar-cli/src/cmds/validator/handler.ts
+++ b/packages/lodestar-cli/src/cmds/validator/handler.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import {consoleTransport, fileTransport, LogLevel, WinstonLogger} from "@chainsafe/lodestar-utils";
+import {consoleTransport, fileTransport, LogLevel, Logger} from "@chainsafe/lodestar-utils";
 import {ApiClientOverRest} from "@chainsafe/lodestar-validator";
 import {Validator, SlashingProtection} from "@chainsafe/lodestar-validator";
 import {LevelDbController} from "@chainsafe/lodestar-db";
@@ -27,7 +27,7 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
   const config = getBeaconConfigFromArgs(args);
   const logFilePath = getBeaconPaths(args).logFile;
 
-  const logger = new WinstonLogger({level: args.logLevel as LogLevel}, [
+  const logger = new Logger({level: args.logLevel as LogLevel}, [
     consoleTransport,
     ...(logFilePath ? [fileTransport(logFilePath)] : []),
   ]);

--- a/packages/lodestar-db/test/unit/controller/level.test.ts
+++ b/packages/lodestar-db/test/unit/controller/level.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Logger} from "@chainsafe/lodestar-utils";
 // @ts-ignore
 import leveldown from "leveldown";
 import all from "it-all";
@@ -7,7 +7,7 @@ import {LevelDbController} from "../../../src/controller";
 
 describe("LevelDB controller", () => {
   const dbLocation = "./.__testdb";
-  const db = new LevelDbController({name: dbLocation}, {logger: new WinstonLogger()});
+  const db = new LevelDbController({name: dbLocation}, {logger: new Logger()});
 
   before(async () => {
     await db.start();

--- a/packages/lodestar-utils/src/logger/winston.ts
+++ b/packages/lodestar-utils/src/logger/winston.ts
@@ -23,7 +23,7 @@ export const fileTransport = (filename: string): TransportStream => {
   });
 };
 
-export class WinstonLogger implements ILogger {
+export class Logger implements ILogger {
   private winston: Logger;
   private _level: LogLevel;
   private _silent: boolean;
@@ -104,8 +104,8 @@ export class WinstonLogger implements ILogger {
     return this._silent;
   }
 
-  child(options: ILoggerOptions): WinstonLogger {
-    const logger = Object.create(WinstonLogger.prototype);
+  child(options: ILoggerOptions): Logger {
+    const logger = Object.create(Logger.prototype);
     const winston = this.winston.child({namespace: options.module, level: options.level});
     //use more verbose log
     if (this.winston.levels[this._level] > this.winston.levels[options.level ?? LogLevel.error]) {

--- a/packages/lodestar-utils/test/unit/logger/winston.test.ts
+++ b/packages/lodestar-utils/test/unit/logger/winston.test.ts
@@ -1,4 +1,4 @@
-import {Context, ILogger, LodestarError, LogFormat, logFormats, WinstonLogger} from "../../../src";
+import {Context, ILogger, LodestarError, LogFormat, logFormats, Logger} from "../../../src";
 import TransportStream from "winston-transport";
 import {MESSAGE} from "triple-beam";
 import {expect} from "chai";
@@ -72,7 +72,7 @@ describe("winston logger", () => {
         it(`${id} ${format} output`, () => {
           let allOutput = "";
           const callbackTransport = new CallbackTransport((data: any) => (allOutput += data));
-          const logger = new WinstonLogger({format, hideTimestamp: true}, [callbackTransport]);
+          const logger = new Logger({format, hideTimestamp: true}, [callbackTransport]);
           logger.warn(message, context, error);
           expect(allOutput).to.equal(output[format]);
         });
@@ -81,7 +81,7 @@ describe("winston logger", () => {
   });
 
   it("should log profile", () => {
-    const logger: ILogger = new WinstonLogger();
+    const logger: ILogger = new Logger();
 
     logger.profile("test");
 

--- a/packages/lodestar-validator/src/api/impl/instance.ts
+++ b/packages/lodestar-validator/src/api/impl/instance.ts
@@ -3,7 +3,7 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IValidatorApi} from "../interface/validators";
 import {IBeaconApi} from "../interface/beacon";
 import {INodeApi} from "../interface/node";
-import {WinstonLogger, ILogger} from "@chainsafe/lodestar-utils";
+import {Logger, ILogger} from "@chainsafe/lodestar-utils";
 import {IEventsApi} from "../interface/events";
 import {IConfigApi} from "../interface/config";
 
@@ -31,7 +31,7 @@ export class ApiClientOverInstance extends AbstractApiClient {
   configApi: IConfigApi;
 
   constructor(opts: IApiClientOverInstanceOpts) {
-    super(opts.config, opts.logger || new WinstonLogger());
+    super(opts.config, opts.logger || new Logger());
     this.beacon = opts.beacon;
     this.validator = opts.validator;
     this.events = opts.events;

--- a/packages/lodestar-validator/test/e2e/slashing-protection-interchange-tests/run.test.ts
+++ b/packages/lodestar-validator/test/e2e/slashing-protection-interchange-tests/run.test.ts
@@ -3,7 +3,7 @@ import chaiAsPromised from "chai-as-promised";
 import {fromHexString} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
 import {LevelDbController} from "@chainsafe/lodestar-db";
-import {LogLevel, WinstonLogger} from "@chainsafe/lodestar-utils";
+import {LogLevel, Logger} from "@chainsafe/lodestar-utils";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
 // Test files
@@ -22,7 +22,7 @@ describe("slashing-protection-interchange-tests", () => {
   const testCases = loadTestCases();
 
   const dbLocation = "./.__testdb";
-  const controller = new LevelDbController({name: dbLocation}, {logger: new WinstonLogger({level: LogLevel.error})});
+  const controller = new LevelDbController({name: dbLocation}, {logger: new Logger({level: LogLevel.error})});
 
   for (const testCase of testCases) {
     describe(testCase.name, async () => {

--- a/packages/lodestar-validator/test/utils/logger.ts
+++ b/packages/lodestar-validator/test/utils/logger.ts
@@ -1,4 +1,4 @@
-import {WinstonLogger, LogLevel} from "@chainsafe/lodestar-utils";
+import {Logger, LogLevel} from "@chainsafe/lodestar-utils";
 
 /**
  * Run the test with ENVs to control log level:
@@ -8,8 +8,8 @@ import {WinstonLogger, LogLevel} from "@chainsafe/lodestar-utils";
  * VERBOSE=1 mocha .ts
  * ```
  */
-export function testLogger(module?: string): WinstonLogger {
-  return new WinstonLogger({level: getLogLevel(), module});
+export function testLogger(module?: string): Logger {
+  return new Logger({level: getLogLevel(), module});
 }
 
 function getLogLevel(): LogLevel {

--- a/packages/lodestar/test/e2e/db/api/beacon/repositories/blockArchive.test.ts
+++ b/packages/lodestar/test/e2e/db/api/beacon/repositories/blockArchive.test.ts
@@ -1,7 +1,7 @@
 import {BeaconDb} from "../../../../../../src/db";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {LevelDbController} from "@chainsafe/lodestar-db";
-import {ILogger, WinstonLogger} from "@chainsafe/lodestar-utils";
+import {ILogger, Logger} from "@chainsafe/lodestar-utils";
 import {generateSignedBlock} from "../../../../../utils/block";
 import {fromHexString} from "@chainsafe/ssz";
 import {IBlockSummary} from "@chainsafe/lodestar-fork-choice";
@@ -32,7 +32,7 @@ describe("BlockArchiveRepository", function () {
       "0xa11dd7547cfda02799745e305ec149d8a90d3ff12cac5a9cb60b0e07bb7e1b06117b0055822099b78422c982cc2f5148023a3fe61a7505f08857b9d30f675600e404f4993ecc4ef75d657e6c84e859aefcd458fb544fb2caa773e916297d6124"
     ),
   });
-  const logger: ILogger = new WinstonLogger();
+  const logger: ILogger = new Logger();
 
   before(async () => {
     db = new BeaconDb({

--- a/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
@@ -4,7 +4,7 @@ import {promisify} from "es6-promisify";
 // @ts-ignore
 import leveldown from "leveldown";
 import {AbortController} from "abort-controller";
-import {WinstonLogger, LogLevel, sleep} from "@chainsafe/lodestar-utils";
+import {Logger, LogLevel, sleep} from "@chainsafe/lodestar-utils";
 import {LevelDbController} from "@chainsafe/lodestar-db";
 
 import {Eth1ForBlockProduction, Eth1Provider} from "../../../src/eth1";
@@ -36,7 +36,7 @@ describe("eth1 / Eth1Provider", function () {
   const controller = new AbortController();
 
   const config = getTestnetConfig();
-  const logger = new WinstonLogger({level: LogLevel.verbose});
+  const logger = new Logger({level: LogLevel.verbose});
   const eth1Provider = new Eth1Provider(config, eth1Options);
 
   let db: BeaconDb;

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -4,7 +4,7 @@ import {expect} from "chai";
 import PeerId from "peer-id";
 import {Discv5Discovery, ENR} from "@chainsafe/discv5";
 import {config} from "@chainsafe/lodestar-config/mainnet";
-import {ILogger, sleep, WinstonLogger} from "@chainsafe/lodestar-utils";
+import {ILogger, sleep, Logger} from "@chainsafe/lodestar-utils";
 
 import {IBeaconChain} from "../../../src/chain";
 import {IBeaconDb} from "../../../src/db";
@@ -36,7 +36,7 @@ describe("[network] network", function () {
   let peerIdB: PeerId;
   let libP2pA: LibP2p;
   let libP2pB: LibP2p;
-  const logger: ILogger = new WinstonLogger();
+  const logger: ILogger = new Logger();
   logger.silent = true;
   const metrics = new BeaconMetrics({enabled: true, timeout: 5000, pushGateway: false}, {logger});
   let db: StubbedBeaconDb & IBeaconDb;

--- a/packages/lodestar/test/e2e/network/reqresp.test.ts
+++ b/packages/lodestar/test/e2e/network/reqresp.test.ts
@@ -3,7 +3,7 @@ import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
 import {AbortController} from "abort-controller";
 import {config} from "@chainsafe/lodestar-config/mainnet";
-import {LogLevel, sleep, WinstonLogger} from "@chainsafe/lodestar-utils";
+import {LogLevel, sleep, Logger} from "@chainsafe/lodestar-utils";
 import {phase0} from "@chainsafe/lodestar-types";
 import {Method, ReqRespEncoding} from "../../../src/constants";
 import {BeaconMetrics} from "../../../src/metrics";
@@ -35,7 +35,7 @@ describe("[network] network", function () {
     disconnectTimeout: 5000,
     localMultiaddrs: [],
   };
-  const logger = new WinstonLogger({level: LogLevel.error});
+  const logger = new Logger({level: LogLevel.error});
   const metrics = new BeaconMetrics({enabled: true, timeout: 5000, pushGateway: false}, {logger});
   const state = generateState();
   const chain = new MockBeaconChain({genesisTime: 0, chainId: 0, networkId: BigInt(0), state, config});

--- a/packages/lodestar/test/sim/multiNodeSingleThread.test.ts
+++ b/packages/lodestar/test/sim/multiNodeSingleThread.test.ts
@@ -1,5 +1,5 @@
 import {IBeaconParams} from "@chainsafe/lodestar-params";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Logger} from "@chainsafe/lodestar-utils";
 import {getDevBeaconNode} from "../utils/node/beacon";
 import {waitForEvent} from "../utils/events/resolver";
 import {phase0} from "@chainsafe/lodestar-types";
@@ -31,7 +31,7 @@ describe("Run multi node single thread interop validators (no eth1) until checkp
       const minGenesisTime = Math.floor(Date.now() / 1000);
       const genesisDelay = 2 * beaconParams.SECONDS_PER_SLOT;
       const genesisTime = minGenesisTime + genesisDelay;
-      const logger = new WinstonLogger();
+      const logger = new Logger();
 
       for (let i = 0; i < nodeCount; i++) {
         const node = await getDevBeaconNode({

--- a/packages/lodestar/test/unit/api/impl/debug/beacon/index.test.ts
+++ b/packages/lodestar/test/unit/api/impl/debug/beacon/index.test.ts
@@ -1,6 +1,6 @@
 import {ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Logger} from "@chainsafe/lodestar-utils";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {expect} from "chai";
 import sinon, {SinonStub} from "sinon";
@@ -18,7 +18,7 @@ describe("api - debug - beacon", function () {
   let forkchoiceStub: SinonStubbedInstance<IForkChoice>;
   let dbStub: StubbedBeaconDb;
   let resolveStateIdStub: SinonStub;
-  const logger = new WinstonLogger();
+  const logger = new Logger();
 
   beforeEach(() => {
     resolveStateIdStub = sinon.stub(stateApiUtils, "resolveStateId");

--- a/packages/lodestar/test/unit/chain/chain.test.ts
+++ b/packages/lodestar/test/unit/chain/chain.test.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import sinon, {SinonStubbedInstance} from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/minimal";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Logger} from "@chainsafe/lodestar-utils";
 import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
 
 import {BeaconChain, IBeaconChain} from "../../../src/chain";
@@ -17,7 +17,7 @@ import {StateContextCache} from "../../../src/chain/stateCache";
 describe("BeaconChain", function () {
   const sandbox = sinon.createSandbox();
   let dbStub: StubbedBeaconDb, metrics: any;
-  const logger = new WinstonLogger();
+  const logger = new Logger();
   let chain: IBeaconChain;
 
   beforeEach(() => {

--- a/packages/lodestar/test/unit/chain/genesis/genesis.test.ts
+++ b/packages/lodestar/test/unit/chain/genesis/genesis.test.ts
@@ -4,7 +4,7 @@ import {SecretKey, PublicKey} from "@chainsafe/bls";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {computeDomain, computeSigningRoot} from "@chainsafe/lodestar-beacon-state-transition";
 import {ValidatorIndex, phase0} from "@chainsafe/lodestar-types";
-import {ErrorAborted, WinstonLogger, interopSecretKey} from "@chainsafe/lodestar-utils";
+import {ErrorAborted, Logger, interopSecretKey} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
 import {AbortController} from "abort-controller";
 import {IEth1Provider} from "../../../../src/eth1";
@@ -68,7 +68,7 @@ describe("genesis builder", function () {
 
     const genesisBuilder = new GenesisBuilder(schlesiConfig, {
       eth1Provider,
-      logger: new WinstonLogger(),
+      logger: new Logger(),
       // eslint-disable-next-line @typescript-eslint/naming-convention
       MAX_BLOCKS_PER_POLL: 1,
     });
@@ -102,7 +102,7 @@ describe("genesis builder", function () {
 
     const genesisBuilder = new GenesisBuilder(schlesiConfig, {
       eth1Provider,
-      logger: new WinstonLogger(),
+      logger: new Logger(),
       signal: controller.signal,
       // eslint-disable-next-line @typescript-eslint/naming-convention
       MAX_BLOCKS_PER_POLL: 1,

--- a/packages/lodestar/test/unit/metrics/beacon.test.ts
+++ b/packages/lodestar/test/unit/metrics/beacon.test.ts
@@ -1,9 +1,9 @@
 import {expect} from "chai";
 import {BeaconMetrics} from "../../../src/metrics";
-import {ILogger, WinstonLogger} from "@chainsafe/lodestar-utils";
+import {ILogger, Logger} from "@chainsafe/lodestar-utils";
 
 describe("BeaconMetrics", () => {
-  const logger: ILogger = new WinstonLogger();
+  const logger: ILogger = new Logger();
   it("updated metrics should be reflected in the registry", () => {
     const m = new BeaconMetrics({enabled: true, timeout: 5000, pushGateway: false, serverPort: 0}, {logger});
     // basic assumptions

--- a/packages/lodestar/test/unit/metrics/server/http.test.ts
+++ b/packages/lodestar/test/unit/metrics/server/http.test.ts
@@ -1,8 +1,8 @@
 import request from "supertest";
 import {Metrics, HttpMetricsServer} from "../../../../src/metrics";
-import {ILogger, WinstonLogger} from "@chainsafe/lodestar-utils";
+import {ILogger, Logger} from "@chainsafe/lodestar-utils";
 describe("HttpMetricsServer", () => {
-  const logger: ILogger = new WinstonLogger();
+  const logger: ILogger = new Logger();
   it("should serve metrics on /metrics", async () => {
     const options = {enabled: true, timeout: 5000, serverPort: 0, pushGateway: false};
     const metrics = new Metrics(options);

--- a/packages/lodestar/test/unit/network/reqresp/response/index.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/response/index.test.ts
@@ -2,7 +2,7 @@ import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
 import PeerId from "peer-id";
 import {config} from "@chainsafe/lodestar-config/minimal";
-import {LodestarError, LogLevel, WinstonLogger} from "@chainsafe/lodestar-utils";
+import {LodestarError, LogLevel, Logger} from "@chainsafe/lodestar-utils";
 import {Method, ReqRespEncoding, RpcResponseStatus} from "../../../../../src/constants";
 import {ReqRespHandler} from "../../../../../src/network";
 import {handleRequest} from "../../../../../src/network/reqresp/response";
@@ -14,7 +14,7 @@ chai.use(chaiAsPromised);
 
 describe("network / reqresp / response / handleRequest", () => {
   // Use LogLevel.verbose to debug tests if necessary
-  const logger = new WinstonLogger({level: LogLevel.error});
+  const logger = new Logger({level: LogLevel.error});
   const peerId = new PeerId(new Uint8Array([1]));
 
   const testCases: {

--- a/packages/lodestar/test/unit/network/tasks/checkPeerAliveTask.test.ts
+++ b/packages/lodestar/test/unit/network/tasks/checkPeerAliveTask.test.ts
@@ -2,7 +2,7 @@ import sinon, {SinonStubbedInstance} from "sinon";
 import {CheckPeerAliveTask} from "../../../../src/network/tasks/checkPeerAliveTask";
 import {INetwork, IReqResp, Network} from "../../../../src/network";
 import {ReqResp} from "../../../../src/network/reqresp/reqResp";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Logger} from "@chainsafe/lodestar-utils";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {expect} from "chai";
 import PeerId from "peer-id";
@@ -22,7 +22,7 @@ describe("CheckPeerAliveTask", function () {
     peerMetadataStub = getStubbedMetadataStore();
     networkStub.peerMetadata = peerMetadataStub;
     task = new CheckPeerAliveTask(config, {
-      logger: new WinstonLogger(),
+      logger: new Logger(),
       network: networkStub,
     });
 

--- a/packages/lodestar/test/unit/network/tasks/diversifyPeersBySubnetTask.test.ts
+++ b/packages/lodestar/test/unit/network/tasks/diversifyPeersBySubnetTask.test.ts
@@ -3,7 +3,7 @@ import {INetwork, IReqResp, Network} from "../../../../src/network";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {ReqResp} from "../../../../src/network/reqresp/reqResp";
 import {DiversifyPeersBySubnetTask} from "../../../../src/network/tasks/diversifyPeersBySubnetTask";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Logger} from "@chainsafe/lodestar-utils";
 import {expect} from "chai";
 import PeerId from "peer-id";
 import {getStubbedMetadataStore, StubbedIPeerMetadataStore} from "../../../utils/peer";
@@ -21,7 +21,7 @@ describe("DiversifyPeersBySubnetTask", function () {
     peerMetadataStore = getStubbedMetadataStore();
     networkStub.peerMetadata = peerMetadataStore;
     task = new DiversifyPeersBySubnetTask(config, {
-      logger: new WinstonLogger(),
+      logger: new Logger(),
       network: networkStub,
     });
   });

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
@@ -4,7 +4,7 @@ import {config} from "@chainsafe/lodestar-config/minimal";
 import {BlockRangeFetcher} from "../../../../../src/sync/regular/oneRangeAhead/fetcher";
 import {BeaconChain, IBeaconChain} from "../../../../../src/chain";
 import {INetwork, Network} from "../../../../../src/network";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Logger} from "@chainsafe/lodestar-utils";
 import PeerId from "peer-id";
 import * as blockUtils from "../../../../../src/sync/utils/blocks";
 import * as slotUtils from "@chainsafe/lodestar-beacon-state-transition/lib/util/slot";
@@ -22,7 +22,7 @@ describe("BlockRangeFetcher", function () {
   let metadataStub: StubbedIPeerMetadataStore;
   let getBlockRangeStub: SinonStub;
   let getCurrentSlotStub: SinonStub;
-  const logger = new WinstonLogger();
+  const logger = new Logger();
   const sandbox = sinon.createSandbox();
   let getPeers: SinonStub;
 

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/oneRangeAhead.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/oneRangeAhead.test.ts
@@ -6,7 +6,7 @@ import sinon from "sinon";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {BeaconChain, ChainEventEmitter, ForkChoice, IBeaconChain} from "../../../../../src/chain";
 import {INetwork, Network} from "../../../../../src/network";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Logger} from "@chainsafe/lodestar-utils";
 import {generateBlockSummary, generateEmptySignedBlock} from "../../../../utils/block";
 import {expect} from "chai";
 import {Eth2Gossipsub} from "../../../../../src/network/gossip";
@@ -24,7 +24,7 @@ describe("ORARegularSync", function () {
   let networkStub: SinonStubbedInstance<INetwork>;
   let gossipStub: SinonStubbedInstance<Eth2Gossipsub>;
   let getCurrentSlotStub: SinonStub;
-  const logger = new WinstonLogger({module: "ORARegularSync"});
+  const logger = new Logger({module: "ORARegularSync"});
 
   beforeEach(() => {
     forkChoiceStub = sinon.createStubInstance(ForkChoice);

--- a/packages/lodestar/test/unit/tasks/interopSubnetsJoiningTask.test.ts
+++ b/packages/lodestar/test/unit/tasks/interopSubnetsJoiningTask.test.ts
@@ -5,7 +5,7 @@ import sinon from "sinon";
 import {ChainEvent, IBeaconChain} from "../../../src/chain";
 import {Eth2Gossipsub} from "../../../src/network/gossip";
 import {InteropSubnetsJoiningTask} from "../../../src/tasks/tasks/interopSubnetsJoiningTask";
-import {WinstonLogger} from "@chainsafe/lodestar-utils";
+import {Logger} from "@chainsafe/lodestar-utils";
 import {expect} from "chai";
 import {MockBeaconChain} from "../../utils/mocks/chain/chain";
 import {generateState} from "../../utils/state";
@@ -21,7 +21,7 @@ describe("interopSubnetsJoiningTask", () => {
   let gossipStub: SinonStubbedInstance<Eth2Gossipsub>;
 
   let chain: IBeaconChain;
-  const logger = new WinstonLogger();
+  const logger = new Logger();
   let task: InteropSubnetsJoiningTask;
   let state: phase0.BeaconState;
 

--- a/packages/lodestar/test/utils/logger.ts
+++ b/packages/lodestar/test/utils/logger.ts
@@ -1,4 +1,4 @@
-import {WinstonLogger, LogLevel} from "@chainsafe/lodestar-utils";
+import {Logger, LogLevel} from "@chainsafe/lodestar-utils";
 export {LogLevel};
 
 /**
@@ -9,8 +9,8 @@ export {LogLevel};
  * VERBOSE=1 mocha .ts
  * ```
  */
-export function testLogger(module?: string, defaultLogLevel = LogLevel.error): WinstonLogger {
-  return new WinstonLogger({level: getLogLevelFromEnvs() || defaultLogLevel, module});
+export function testLogger(module?: string, defaultLogLevel = LogLevel.error): Logger {
+  return new Logger({level: getLogLevelFromEnvs() || defaultLogLevel, module});
 }
 
 function getLogLevelFromEnvs(): LogLevel | null {

--- a/packages/lodestar/test/utils/node/validator.ts
+++ b/packages/lodestar/test/utils/node/validator.ts
@@ -1,5 +1,5 @@
 import {LevelDbController} from "@chainsafe/lodestar-db";
-import {ILogger, intDiv, LogLevel, WinstonLogger, interopSecretKey} from "@chainsafe/lodestar-utils";
+import {ILogger, intDiv, LogLevel, Logger, interopSecretKey} from "@chainsafe/lodestar-utils";
 import {IEventsApi} from "@chainsafe/lodestar-validator/lib/api/interface/events";
 import {ApiClientOverInstance, IApiClient, SlashingProtection, Validator} from "@chainsafe/lodestar-validator";
 import tmp from "tmp";
@@ -61,7 +61,7 @@ export function getDevValidator({
   logger?: ILogger;
   useRestApi?: boolean;
 }): Validator {
-  if (!logger) logger = new WinstonLogger({level: LogLevel.info, module: "validator"});
+  if (!logger) logger = new Logger({level: LogLevel.info, module: "validator"});
   const tmpDir = tmp.dirSync({unsafeCleanup: true});
   return new Validator({
     config: node.config,


### PR DESCRIPTION
The fact that we use winston as a logger library is an implementation detail that other components should not be aware of. We only have 1 logger, with a generic interface ILogger, to it makes that the class is named Logger