### PR TITLE
Add CLI command: account wallet recovery

### DIFF
--- a/packages/lodestar-cli/src/cmds/account/cmds/wallet/create.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/wallet/create.ts
@@ -1,8 +1,8 @@
 import * as bip39 from "bip39";
-import {ICliCommand, ICliCommandOptions} from "../../../../util";
+import {ICliCommand, ICliCommandOptions, initBLS} from "../../../../util";
 import {IGlobalArgs} from "../../../../options";
 import {accountWalletsOptions, IAccountWalletArgs} from "./options";
-import {createWalletFromArgsAndMnemonic, printUuidData} from "./utils";
+import {createWalletFromArgsAndMnemonic} from "./utils";
 
 export const command = "create";
 
@@ -72,6 +72,8 @@ export const create: ICliCommand<IWalletCreateArgs, IAccountWalletArgs & IGlobal
   options: walletCreateOptions,
 
   handler: async (args) => {
+    await initBLS();
+
     // Create a new random mnemonic.
     const mnemonic = bip39.generateMnemonic();
 
@@ -95,8 +97,11 @@ export const create: ICliCommand<IWalletCreateArgs, IAccountWalletArgs & IGlobal
   recover your private keys in the case of data loss. Writing it on 
   a piece of paper and storing it in a safe place would be prudent.
 
-  `,
-      printUuidData(uuid)
+  Your wallet's UUID is:
+
+  \t${uuid}
+
+  You do not need to backup your UUID or keep it secret.`
     );
 
     // Return values for testing

--- a/packages/lodestar-cli/src/cmds/account/cmds/wallet/create.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/wallet/create.ts
@@ -1,22 +1,55 @@
-import fs from "fs";
-import path from "path";
 import * as bip39 from "bip39";
-import {randomPassword, writeFile600Perm, YargsError, readPassphraseFile, ICliCommand, initBLS} from "../../../../util";
-import {WalletManager} from "../../../../wallet";
-import {getAccountPaths} from "../../paths";
+import {ICliCommand, ICliCommandOptions} from "../../../../util";
 import {IGlobalArgs} from "../../../../options";
-import {IAccountWalletArgs} from "./options";
+import {accountWalletsOptions, IAccountWalletArgs} from "./options";
+import {createWalletFromArgsAndMnemonic, printUuidData} from "./utils";
 
 export const command = "create";
 
 export const description = "Creates a new HD (hierarchical-deterministic) EIP-2386 wallet";
 
-interface IWalletCreateArgs {
+export type IWalletCreateArgs = {
   name: string;
   passphraseFile: string;
   type: string;
   mnemonicOutputPath?: string;
-}
+};
+
+export const walletCreateOptions: ICliCommandOptions<IWalletCreateArgs> = {
+  ...accountWalletsOptions,
+  name: {
+    description:
+      "The wallet will be created with this name. It is not allowed to \
+create two wallets with the same name for the same --base-dir.",
+    alias: ["n"],
+    demandOption: true,
+    type: "string",
+  },
+
+  passphraseFile: {
+    description:
+      "A path to a file containing the password which will unlock the wallet. \
+If the file does not exist, a random password will be generated and saved at that \
+path. To avoid confusion, if the file does not already exist it must include a \
+'.pass' suffix.",
+    alias: ["p"],
+    demandOption: true,
+    type: "string",
+  },
+
+  type: {
+    description: "The type of wallet to create. Only HD (hierarchical-deterministic) \
+wallets are supported presently.",
+    choices: ["hd"],
+    default: "hd",
+    type: "string",
+  },
+
+  mnemonicOutputPath: {
+    description: "If present, the mnemonic will be saved to this file",
+    type: "string",
+  },
+};
 
 export type ReturnType = {
   mnemonic: string;
@@ -36,71 +69,17 @@ export const create: ICliCommand<IWalletCreateArgs, IAccountWalletArgs & IGlobal
     },
   ],
 
-  options: {
-    name: {
-      description:
-        "The wallet will be created with this name. It is not allowed to \
-  create two wallets with the same name for the same --base-dir.",
-      alias: ["n"],
-      demandOption: true,
-      type: "string",
-    },
-
-    passphraseFile: {
-      description:
-        "A path to a file containing the password which will unlock the wallet. \
-  If the file does not exist, a random password will be generated and saved at that \
-  path. To avoid confusion, if the file does not already exist it must include a \
-  '.pass' suffix.",
-      alias: ["p"],
-      demandOption: true,
-      type: "string",
-    },
-
-    type: {
-      description:
-        "The type of wallet to create. Only HD (hierarchical-deterministic) \
-wallets are supported presently.",
-      choices: ["hd"],
-      default: "hd",
-      type: "string",
-    },
-
-    mnemonicOutputPath: {
-      description: "If present, the mnemonic will be saved to this file",
-      type: "string",
-    },
-  },
+  options: walletCreateOptions,
 
   handler: async (args) => {
-    await initBLS();
-
-    const {name, type, passphraseFile, mnemonicOutputPath} = args;
-    const accountPaths = getAccountPaths(args);
-
     // Create a new random mnemonic.
     const mnemonic = bip39.generateMnemonic();
 
-    if (path.parse(passphraseFile).ext !== ".pass") {
-      throw new YargsError("passphraseFile must end with .pass, make sure to not provide the actual password");
-    }
-
-    if (!fs.existsSync(passphraseFile)) {
-      writeFile600Perm(passphraseFile, randomPassword());
-    }
-
-    const password = readPassphraseFile(passphraseFile);
-
-    const walletManager = new WalletManager(accountPaths);
-    const wallet = await walletManager.createWallet(name, type, mnemonic, password);
-    const uuid = wallet.toWalletObject().uuid;
-
-    if (mnemonicOutputPath) {
-      writeFile600Perm(mnemonicOutputPath, mnemonic);
-    }
+    const {uuid, password} = await createWalletFromArgsAndMnemonic(args, mnemonic);
 
     // eslint-disable-next-line no-console
-    console.log(`
+    console.log(
+      `
   Your wallet's 12-word BIP-39 mnemonic is:
 
   \t${mnemonic}
@@ -116,12 +95,9 @@ wallets are supported presently.",
   recover your private keys in the case of data loss. Writing it on 
   a piece of paper and storing it in a safe place would be prudent.
 
-  Your wallet's UUID is:
-
-  \t${uuid}
-
-  You do not need to backup your UUID or keep it secret.
-  `);
+  `,
+      printUuidData(uuid)
+    );
 
     // Return values for testing
     return {mnemonic, uuid, password};

--- a/packages/lodestar-cli/src/cmds/account/cmds/wallet/index.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/wallet/index.ts
@@ -3,10 +3,11 @@ import {IGlobalArgs} from "../../../../options";
 import {accountWalletsOptions, IAccountWalletArgs} from "./options";
 import {create} from "./create";
 import {list} from "./list";
+import {recover} from "./recover";
 
 export const wallet: ICliCommand<IAccountWalletArgs, IGlobalArgs> = {
   command: "wallet <command>",
   describe: "Provides commands for managing Eth2 wallets.",
   options: accountWalletsOptions,
-  subcommands: [create, list],
+  subcommands: [create, list, recover],
 };

--- a/packages/lodestar-cli/src/cmds/account/cmds/wallet/recover.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/wallet/recover.ts
@@ -1,8 +1,8 @@
 import * as fs from "fs";
-import {ICliCommand} from "../../../../util";
+import {ICliCommand, initBLS} from "../../../../util";
 import {IGlobalArgs} from "../../../../options";
 import inquirer from "inquirer";
-import {createWalletFromArgsAndMnemonic, printUuidData} from "./utils";
+import {createWalletFromArgsAndMnemonic} from "./utils";
 import {IWalletCreateArgs, walletCreateOptions} from "./create";
 
 export type IWalletRecoverArgs = IWalletCreateArgs & {
@@ -32,6 +32,8 @@ export const recover: ICliCommand<IWalletRecoverArgs, IGlobalArgs, ReturnType> =
   },
 
   handler: async (args) => {
+    await initBLS();
+
     const {mnemonicInputPath} = args;
     let mnemonic;
 
@@ -52,7 +54,13 @@ export const recover: ICliCommand<IWalletRecoverArgs, IGlobalArgs, ReturnType> =
 
     const {uuid} = await createWalletFromArgsAndMnemonic(args, mnemonic);
 
-    console.log!("Your wallet has been successfully recovered.", printUuidData(uuid));
+    console.log!(`Your wallet has been successfully recovered.
+Your wallet's UUID is:
+
+\t${uuid}
+
+You do not need to backup your UUID or keep it secret.
+`);
 
     return [uuid];
   },

--- a/packages/lodestar-cli/src/cmds/account/cmds/wallet/recover.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/wallet/recover.ts
@@ -1,11 +1,12 @@
-import {ICliCommand, readFileIfExists} from "../../../../util";
+import * as fs from "fs";
+import {ICliCommand} from "../../../../util";
 import {IGlobalArgs} from "../../../../options";
 import inquirer from "inquirer";
 import {createWalletFromArgsAndMnemonic, printUuidData} from "./utils";
 import {IWalletCreateArgs, walletCreateOptions} from "./create";
 
 export type IWalletRecoverArgs = IWalletCreateArgs & {
-  mnemonicPath: string;
+  mnemonicInputPath: string;
 };
 
 export type ReturnType = string[];
@@ -24,20 +25,20 @@ export const recover: ICliCommand<IWalletRecoverArgs, IGlobalArgs, ReturnType> =
 
   options: {
     ...walletCreateOptions,
-    mnemonicPath: {
+    mnemonicInputPath: {
       description: "If present, the mnemonic will be read in from this file.",
       type: "string",
     },
   },
 
   handler: async (args) => {
-    const {mnemonicPath} = args;
+    const {mnemonicInputPath} = args;
     let mnemonic;
 
     console.log("\nWARNING: KEY RECOVERY CAN LEAD TO DUPLICATING VALIDATORS KEYS, WHICH CAN LEAD TO SLASHING.\n");
 
-    if (mnemonicPath) {
-      mnemonic = readFileIfExists(mnemonicPath);
+    if (mnemonicInputPath) {
+      mnemonic = await fs.promises.readFile(mnemonicInputPath, "utf8");
     } else {
       const input = await inquirer.prompt([
         {

--- a/packages/lodestar-cli/src/cmds/account/cmds/wallet/recover.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/wallet/recover.ts
@@ -1,0 +1,58 @@
+import {ICliCommand, readFileIfExists} from "../../../../util";
+import {IGlobalArgs} from "../../../../options";
+import inquirer from "inquirer";
+import {createWalletFromArgsAndMnemonic, printUuidData} from "./utils";
+import {IWalletCreateArgs, walletCreateOptions} from "./create";
+
+export type IWalletRecoverArgs = IWalletCreateArgs & {
+  mnemonicPath: string;
+};
+
+export type ReturnType = string[];
+
+export const recover: ICliCommand<IWalletRecoverArgs, IGlobalArgs, ReturnType> = {
+  command: "recover",
+
+  describe: "Recovers an EIP-2386 wallet from a given a BIP-39 mnemonic phrase.",
+
+  examples: [
+    {
+      command: "account wallet recover",
+      description: "Recover wallet",
+    },
+  ],
+
+  options: {
+    ...walletCreateOptions,
+    mnemonicPath: {
+      description: "If present, the mnemonic will be read in from this file.",
+      type: "string",
+    },
+  },
+
+  handler: async (args) => {
+    const {mnemonicPath} = args;
+    let mnemonic;
+
+    console.log("\nWARNING: KEY RECOVERY CAN LEAD TO DUPLICATING VALIDATORS KEYS, WHICH CAN LEAD TO SLASHING.\n");
+
+    if (mnemonicPath) {
+      mnemonic = readFileIfExists(mnemonicPath);
+    } else {
+      const input = await inquirer.prompt([
+        {
+          name: "mnemonic",
+          type: "input",
+          message: "Enter the mnemonic phrase:",
+        },
+      ]);
+      mnemonic = input.mnemonic;
+    }
+
+    const {uuid} = await createWalletFromArgsAndMnemonic(args, mnemonic);
+
+    console.log!("Your wallet has been successfully recovered.", printUuidData(uuid));
+
+    return [uuid];
+  },
+};

--- a/packages/lodestar-cli/src/cmds/account/cmds/wallet/utils.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/wallet/utils.ts
@@ -1,0 +1,46 @@
+import fs from "fs";
+import path from "path";
+import {IGlobalArgs} from "../../../../options";
+import {YargsError, writeFile600Perm, randomPassword, readPassphraseFile, initBLS} from "../../../../util";
+import {WalletManager} from "../../../../wallet";
+import {getAccountPaths} from "../../paths";
+import {IWalletRecoverArgs} from "./recover";
+
+export async function createWalletFromArgsAndMnemonic(
+  args: Pick<IWalletRecoverArgs & IGlobalArgs, "name" | "type" | "passphraseFile" | "mnemonicOutputPath" | "rootDir">,
+  mnemonic: string
+): Promise<{uuid: string; password: string}> {
+  await initBLS();
+
+  const {name, type, passphraseFile, mnemonicOutputPath} = args;
+  const accountPaths = getAccountPaths(args);
+
+  if (path.parse(passphraseFile).ext !== ".pass") {
+    throw new YargsError("passphraseFile must end with .pass, make sure to not provide the actual password");
+  }
+
+  if (!fs.existsSync(passphraseFile)) {
+    writeFile600Perm(passphraseFile, randomPassword());
+  }
+
+  const password = readPassphraseFile(passphraseFile);
+
+  const walletManager = new WalletManager(accountPaths);
+  const wallet = await walletManager.createWallet(name, type, mnemonic, password);
+  const uuid = wallet.toWalletObject().uuid;
+
+  if (mnemonicOutputPath) {
+    writeFile600Perm(mnemonicOutputPath, mnemonic);
+  }
+
+  return {uuid, password};
+}
+
+export function printUuidData(uuid: string): string {
+  return `
+Your wallet's UUID is:
+
+\t${uuid}
+
+You do not need to backup your UUID or keep it secret.`;
+}

--- a/packages/lodestar-cli/src/cmds/account/cmds/wallet/utils.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/wallet/utils.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import {IGlobalArgs} from "../../../../options";
-import {YargsError, writeFile600Perm, randomPassword, readPassphraseFile, initBLS} from "../../../../util";
+import {YargsError, writeFile600Perm, randomPassword, readPassphraseFile} from "../../../../util";
 import {WalletManager} from "../../../../wallet";
 import {getAccountPaths} from "../../paths";
 import {IWalletRecoverArgs} from "./recover";
@@ -10,8 +10,6 @@ export async function createWalletFromArgsAndMnemonic(
   args: Pick<IWalletRecoverArgs & IGlobalArgs, "name" | "type" | "passphraseFile" | "mnemonicOutputPath" | "rootDir">,
   mnemonic: string
 ): Promise<{uuid: string; password: string}> {
-  await initBLS();
-
   const {name, type, passphraseFile, mnemonicOutputPath} = args;
   const accountPaths = getAccountPaths(args);
 
@@ -34,13 +32,4 @@ export async function createWalletFromArgsAndMnemonic(
   }
 
   return {uuid, password};
-}
-
-export function printUuidData(uuid: string): string {
-  return `
-Your wallet's UUID is:
-
-\t${uuid}
-
-You do not need to backup your UUID or keep it secret.`;
 }


### PR DESCRIPTION
adds new cli functionality to recover a wallet from mnemonic.  since there are similar processes used for wallet creation, i pulled some of the common functionality into separate, common functions as well.

based heavily on the lighthouse implementation:
https://github.com/sigp/lighthouse/blob/stable/account_manager/src/wallet/recover.rs

if everyone likes this, i'll use this as a basis to add validator recovery to the cli as well