### PR TITLE
Run postStateTransition function in a separate context

### DIFF
--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -152,10 +152,6 @@ async function postStateTransition(
   emittedState: CachedBeaconState<phase0.BeaconState>
 ): Promise<void> {
   const config = emittedState.config;
-  if (emittedState.slot % config.params.SLOTS_PER_EPOCH === 0) {
-    emitCheckpointEvent(emitter, emittedState);
-  }
-  emitBlockEvent(emitter, job, emittedState);
   // current justified checkpoint should be prev epoch or current epoch if it's just updated
   // it should always have epochBalances there bc it's a checkpoint state, ie got through processEpoch
   let justifiedBalances: Gwei[] = [];
@@ -165,5 +161,9 @@ async function postStateTransition(
   }
   const oldHead = forkChoice.getHead();
   forkChoice.onBlock(job.signedBlock.message, emittedState, justifiedBalances);
+  if (emittedState.slot % config.params.SLOTS_PER_EPOCH === 0) {
+    emitCheckpointEvent(emitter, emittedState);
+  }
+  emitBlockEvent(emitter, job, emittedState);
   emitForkChoiceHeadEvents(emitter, forkChoice, forkChoice.getHead(), oldHead);
 }

--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -156,8 +156,6 @@ async function postStateTransition(
     emitCheckpointEvent(emitter, emittedState);
   }
   emitBlockEvent(emitter, job, emittedState);
-  const oldHead = forkChoice.getHead();
-  emitForkChoiceHeadEvents(emitter, forkChoice, forkChoice.getHead(), oldHead);
   // current justified checkpoint should be prev epoch or current epoch if it's just updated
   // it should always have epochBalances there bc it's a checkpoint state, ie got through processEpoch
   let justifiedBalances: Gwei[] = [];
@@ -165,5 +163,7 @@ async function postStateTransition(
     const justifiedState = checkpointStateCache.get(emittedState.currentJustifiedCheckpoint);
     justifiedBalances = getEffectiveBalances(justifiedState!);
   }
+  const oldHead = forkChoice.getHead();
   forkChoice.onBlock(job.signedBlock.message, emittedState, justifiedBalances);
+  emitForkChoiceHeadEvents(emitter, forkChoice, forkChoice.getHead(), oldHead);
 }


### PR DESCRIPTION
resolves #2179 

+ Running the `ChainEvent.block` (and others) async handlers in the same Promise of `stateTransition` sometimes cause a lot of states being retained in memory
+ The fix is to use `setImmediate` to run `postStateTransition` in a separate context. `setImmediate` is called before the next event loop so we have the event processed before we finish `runStateTransition` (thanks to `await sleep(0)` at the end of `runStatetransition`). Reference: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#setimmediate-vs-settimeout

## Test with Pyrmont
+ master retains 615 MB of BeaconStateContext instances in memory (note: the dash `-` in `Distance` column means that the instance stays in memory forever)
<img width="1066" alt="BeaconStateContext_master" src="https://user-images.githubusercontent.com/10568965/111437100-496f9d00-8735-11eb-8efb-7ff747fb6394.png">

+ this branch retains 77MB of BeaconStateContext instances in memory - almost no dash `-` in `Distance` column
<img width="1038" alt="BeaconStateContext_fix_retained_state" src="https://user-images.githubusercontent.com/10568965/111437140-568c8c00-8735-11eb-966f-1b1dfcd1d06d.png">
