### PR TITLE
Type error in catch clause

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,6 +86,7 @@ module.exports = {
     "@typescript-eslint/type-annotation-spacing": "error",
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/explicit-member-accessibility": ["error", {accessibility: "no-public"}],
+    "@typescript-eslint/no-implicit-any-catch": "error",
     "import/no-extraneous-dependencies": [
       "error",
       {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "mocha": "^8.3.0",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
-    "prettier": "^2.0.5",
+    "prettier": "^2.2.0",
     "sinon": "^9.0.2",
     "supertest": "^4.0.2",
     "ts-node": "^9.1.1",

--- a/packages/lodestar-beacon-state-transition/src/phase0/fast/block/isValidIndexedAttestation.ts
+++ b/packages/lodestar-beacon-state-transition/src/phase0/fast/block/isValidIndexedAttestation.ts
@@ -39,7 +39,7 @@ export function isValidIndexedAttestation(
   const signatureSet = getIndexedAttestationSignatureSet(state, indexedAttestation, indices);
   try {
     return verifySignatureSet(signatureSet);
-  } catch (e) {
+  } catch (e: unknown) {
     return false;
   }
 }

--- a/packages/lodestar-beacon-state-transition/src/phase0/fast/util/util.ts
+++ b/packages/lodestar-beacon-state-transition/src/phase0/fast/util/util.ts
@@ -120,7 +120,7 @@ export async function generatePerformanceBlock(): Promise<TreeBacked<phase0.Sign
 export async function initBLS(): Promise<void> {
   try {
     await init("blst-native");
-  } catch (e) {
+  } catch (e: unknown) {
     console.warn("Performance warning: Using fallback wasm BLS implementation");
     await init("herumi");
   }

--- a/packages/lodestar-beacon-state-transition/test/perf/util.ts
+++ b/packages/lodestar-beacon-state-transition/test/perf/util.ts
@@ -121,7 +121,7 @@ export async function generatePerformanceBlock(): Promise<TreeBacked<phase0.Sign
 export async function initBLS(): Promise<void> {
   try {
     await init("blst-native");
-  } catch (e) {
+  } catch (e: unknown) {
     console.warn("Performance warning: Using fallback wasm BLS implementation");
     await init("herumi");
   }

--- a/packages/lodestar-beacon-state-transition/test/setup.ts
+++ b/packages/lodestar-beacon-state-transition/test/setup.ts
@@ -4,7 +4,7 @@ import {before} from "mocha";
 before(async function () {
   try {
     await init("blst-native");
-  } catch (e) {
+  } catch (e: unknown) {
     console.log(e);
   }
 });

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/blockHeader.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/blockHeader.test.ts
@@ -30,7 +30,7 @@ describe("process block - block header", function () {
     try {
       processBlockHeader(config, state, block);
       expect.fail();
-    } catch (e) {}
+    } catch (e: unknown) {}
   });
 
   it("fail to process header - invalid parent header", function () {
@@ -41,7 +41,7 @@ describe("process block - block header", function () {
     try {
       processBlockHeader(config, state, block);
       expect.fail();
-    } catch (e) {}
+    } catch (e: unknown) {}
   });
 
   it("fail to process header - proposerSlashed", function () {
@@ -53,7 +53,7 @@ describe("process block - block header", function () {
     try {
       processBlockHeader(config, state, block);
       expect.fail();
-    } catch (e) {}
+    } catch (e: unknown) {}
   });
 
   it.skip("should process block", function () {

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attesterSlashing.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attesterSlashing.test.ts
@@ -43,7 +43,7 @@ describe("process block - attester slashings", function () {
     try {
       phase0.processAttesterSlashing(config, state, attesterSlashing, true);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       expect(validateIndexedAttestationStub.callCount).equals(1);
       expect(
         validateIndexedAttestationStub.getCall(0).calledWithExactly(config, state, attesterSlashing.attestation1, true)
@@ -62,7 +62,7 @@ describe("process block - attester slashings", function () {
     try {
       phase0.processAttesterSlashing(config, state, attesterSlashing);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       expect(validateIndexedAttestationStub.calledOnce).to.be.true;
     }
   });
@@ -77,7 +77,7 @@ describe("process block - attester slashings", function () {
     try {
       phase0.processAttesterSlashing(config, state, attesterSlashing);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       expect(validateIndexedAttestationStub.calledTwice).to.be.true;
     }
   });

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/deposit.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/deposit.test.ts
@@ -50,7 +50,7 @@ describe("process block - deposits", function () {
     verifyMerkleBranchStub.returns(false);
     try {
       processDeposit(config, state, generateDeposit());
-    } catch (e) {
+    } catch (e: unknown) {
       expect(verifyMerkleBranchStub.calledOnce).to.be.true;
     }
   });
@@ -60,7 +60,7 @@ describe("process block - deposits", function () {
     verifyMerkleBranchStub.returns(true);
     try {
       processDeposit(config, state, generateDeposit());
-    } catch (e) {
+    } catch (e: unknown) {
       expect(verifyMerkleBranchStub.calledOnce).to.be.true;
     }
   });
@@ -71,7 +71,7 @@ describe("process block - deposits", function () {
     const deposit = generateDeposit();
     try {
       processDeposit(config, state, deposit);
-    } catch (e) {
+    } catch (e: unknown) {
       expect(verifyMerkleBranchStub.calledOnce).to.be.true;
       expect(state.validators.length).to.be.equal(0);
       expect(state.balances.length).to.be.equal(0);

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/index.test.ts
@@ -47,7 +47,7 @@ describe("process block - process operations", function () {
     try {
       processOperations(config, state, body);
       expect.fail();
-    } catch (e) {}
+    } catch (e: unknown) {}
   });
 
   it("should fail to process operations - duplicate transfers", function () {
@@ -56,7 +56,7 @@ describe("process block - process operations", function () {
     try {
       processOperations(config, state, body);
       expect.fail();
-    } catch (e) {}
+    } catch (e: unknown) {}
   });
 
   it("should fail to process operations - proposerSlashings length  exceed maxProposerSlashings ", function () {
@@ -68,7 +68,7 @@ describe("process block - process operations", function () {
     try {
       processOperations(config, state, body);
       expect.fail();
-    } catch (e) {}
+    } catch (e: unknown) {}
   });
 
   it("should fail to process operations - attesterSlashings length  exceed maxAttesterSlashings", function () {
@@ -82,7 +82,7 @@ describe("process block - process operations", function () {
     try {
       processOperations(config, state, body);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       expect(processProposerSlashingStub.calledOnce).to.be.true;
     }
   });
@@ -101,7 +101,7 @@ describe("process block - process operations", function () {
     try {
       processOperations(config, state, body);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       expect(processProposerSlashingStub.calledOnce).to.be.true;
       expect(processAttesterSlashingStub.calledOnce).to.be.true;
     }
@@ -117,7 +117,7 @@ describe("process block - process operations", function () {
     try {
       processOperations(config, state, body);
       expect.fail();
-    } catch (e) {}
+    } catch (e: unknown) {}
   });
 
   it("should fail to process operations - voluntaryExit length  exceed maxVoluntaryExit", function () {
@@ -139,7 +139,7 @@ describe("process block - process operations", function () {
     try {
       processOperations(config, state, body);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       expect(processProposerSlashingStub.calledOnce).to.be.true;
       expect(processAttesterSlashingStub.calledOnce).to.be.true;
       expect(processAttestationStub.calledOnce).to.be.true;
@@ -165,7 +165,7 @@ describe("process block - process operations", function () {
     try {
       processOperations(config, state, body);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       expect(processProposerSlashingStub.calledOnce).to.be.true;
       expect(processAttesterSlashingStub.calledOnce).to.be.true;
       expect(processAttestationStub.calledOnce).to.be.true;
@@ -191,7 +191,7 @@ describe("process block - process operations", function () {
     try {
       processOperations(config, state, body);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       expect(processProposerSlashingStub.calledOnce).to.be.true;
       expect(processAttesterSlashingStub.calledOnce).to.be.true;
       expect(processAttestationStub.calledOnce).to.be.true;

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/proposerSlashings.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/proposerSlashings.test.ts
@@ -32,7 +32,7 @@ describe("process block - proposer slashings", function () {
     try {
       processProposerSlashing(config, state, proposerSlashing);
       expect.fail();
-    } catch (e) {}
+    } catch (e: unknown) {}
   });
 
   it("should fail to process - same headers", function () {
@@ -43,7 +43,7 @@ describe("process block - proposer slashings", function () {
     try {
       processProposerSlashing(config, state, proposerSlashing);
       expect.fail();
-    } catch (e) {}
+    } catch (e: unknown) {}
   });
 
   it("should fail to process - same headers", function () {
@@ -55,7 +55,7 @@ describe("process block - proposer slashings", function () {
     try {
       processProposerSlashing(config, state, proposerSlashing);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       // different slot so it failed without calling isSlashableValidator
       expect(isSlashableValidatorStub.calledOnce).to.be.false;
     }
@@ -70,7 +70,7 @@ describe("process block - proposer slashings", function () {
     try {
       processProposerSlashing(config, state, proposerSlashing, true);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       expect(isSlashableValidatorStub.calledOnce).to.be.true;
     }
   });
@@ -86,7 +86,7 @@ describe("process block - proposer slashings", function () {
     try {
       processProposerSlashing(config, state, proposerSlashing);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       expect(isSlashableValidatorStub.calledOnce).to.be.true;
     }
   });

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/voluntaryExit.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/voluntaryExit.test.ts
@@ -32,7 +32,7 @@ describe("process block - voluntary exits", function () {
     try {
       processVoluntaryExit(config, state, exit);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       expect(isActiveValidatorStub.calledOnce).to.be.true;
     }
   });
@@ -45,7 +45,7 @@ describe("process block - voluntary exits", function () {
     try {
       processVoluntaryExit(config, state, exit);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       expect(isActiveValidatorStub.calledOnce).to.be.true;
     }
   });
@@ -59,7 +59,7 @@ describe("process block - voluntary exits", function () {
     try {
       processVoluntaryExit(config, state, exit);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       expect(isActiveValidatorStub.calledOnce).to.be.true;
     }
   });
@@ -73,7 +73,7 @@ describe("process block - voluntary exits", function () {
     try {
       processVoluntaryExit(config, state, exit);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       expect(isActiveValidatorStub.calledOnce).to.be.true;
     }
   });
@@ -87,7 +87,7 @@ describe("process block - voluntary exits", function () {
     try {
       processVoluntaryExit(config, state, exit);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       expect(isActiveValidatorStub.calledOnce).to.be.true;
     }
   });

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/randao.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/randao.test.ts
@@ -28,7 +28,7 @@ describe.skip("process block - randao", function () {
     try {
       processRandao(config, state, block.body);
       expect.fail();
-    } catch (e) {
+    } catch (e: unknown) {
       expect(getBeaconProposerStub.calledOnce).to.be.true;
     }
   });

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/index.test.ts
@@ -35,14 +35,14 @@ describe("process epoch - crosslinks", function () {
     try {
       processEpoch(config, generateState({slot: GENESIS_SLOT}));
       expect.fail();
-    } catch (e) {}
+    } catch (e: unknown) {}
   });
 
   it("should fail to process - not epoch", function () {
     try {
       processEpoch(config, generateState({slot: 1}));
       expect.fail();
-    } catch (e) {}
+    } catch (e: unknown) {}
   });
 
   it("should process epoch", function () {

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/import.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/import.ts
@@ -156,7 +156,7 @@ async function getKeystorePassphrase(keystore: Keystore, passphrasePaths: string
       await keystore.decrypt(stripOffNewlines(passphrase));
       console.log(`Imported passphrase ${passphraseFile}`);
       return passphrase;
-    } catch (e) {
+    } catch (e: unknown) {
       console.log(`Imported passphrase ${passphraseFile}, but it's invalid: ${e.message}`);
     }
   }
@@ -176,7 +176,7 @@ required each time the validator client starts
           console.log("\nValidating password...");
           await keystore.decrypt(stripOffNewlines(input));
           return true;
-        } catch (e) {
+        } catch (e: unknown) {
           return `Invalid password: ${e.message}`;
         }
       },

--- a/packages/lodestar-cli/src/cmds/beacon/handler.ts
+++ b/packages/lodestar-cli/src/cmds/beacon/handler.ts
@@ -68,7 +68,7 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
     });
 
     abortController.signal.addEventListener("abort", () => node.close(), {once: true});
-  } catch (e) {
+  } catch (e: unknown) {
     await db.stop();
 
     if (e instanceof ErrorAborted) {

--- a/packages/lodestar-cli/src/cmds/init/handler.ts
+++ b/packages/lodestar-cli/src/cmds/init/handler.ts
@@ -42,7 +42,7 @@ export async function initializeOptionsAndConfig(args: IBeaconArgs & IGlobalArgs
     try {
       const bootEnrs = await fetchBootnodes(args.network);
       beaconNodeOptions.set({network: {discv5: {bootEnrs}}});
-    } catch (e) {
+    } catch (e: unknown) {
       // eslint-disable-next-line no-console
       console.error(`Error fetching latest bootnodes: ${e.stack}`);
     }

--- a/packages/lodestar-cli/src/config/enr.ts
+++ b/packages/lodestar-cli/src/config/enr.ts
@@ -39,7 +39,7 @@ export function overwriteEnrWithCliArgs(enr: ENR, enrArgs: IENRJson, options: IB
       if (tcpOpts.transport === "tcp") {
         enr.tcp = tcpOpts.port;
       }
-    } catch (e) {
+    } catch (e: unknown) {
       throw new Error(`Invalid tcp multiaddr: ${e.message}`);
     }
   }
@@ -50,7 +50,7 @@ export function overwriteEnrWithCliArgs(enr: ENR, enrArgs: IENRJson, options: IB
       if (udpOpts.transport === "udp") {
         enr.udp = udpOpts.port;
       }
-    } catch (e) {
+    } catch (e: unknown) {
       throw new Error(`Invalid udp multiaddr: ${e.message}`);
     }
   }

--- a/packages/lodestar-cli/src/util/bls.ts
+++ b/packages/lodestar-cli/src/util/bls.ts
@@ -3,7 +3,7 @@ import {init} from "@chainsafe/bls";
 export async function initBLS(): Promise<void> {
   try {
     await init("blst-native");
-  } catch (e) {
+  } catch (e: unknown) {
     console.warn("Performance warning: Using fallback wasm BLS implementation");
     await init("herumi");
   }

--- a/packages/lodestar-cli/src/util/file.ts
+++ b/packages/lodestar-cli/src/util/file.ts
@@ -95,7 +95,7 @@ export function readFile<T = Json>(filepath: string): T {
 export function readFileIfExists<T = Json>(filepath: string): T | null {
   try {
     return readFile(filepath);
-  } catch (e) {
+  } catch (e: unknown) {
     if (e.code === "ENOENT") {
       return null;
     } else {

--- a/packages/lodestar-cli/src/util/graffiti.ts
+++ b/packages/lodestar-cli/src/util/graffiti.ts
@@ -20,7 +20,7 @@ function guessVersion(): string {
 export function getDefaultGraffiti(): string {
   try {
     return `${lodestarPackageName}-${guessVersion()}`;
-  } catch (e) {
+  } catch (e: unknown) {
     // eslint-disable-next-line no-console
     console.error("Error guessing lodestar version", e);
     return lodestarPackageName;

--- a/packages/lodestar-cli/src/util/passphrase.ts
+++ b/packages/lodestar-cli/src/util/passphrase.ts
@@ -17,7 +17,7 @@ export function readPassphraseFile(passphraseFile: string): string {
     if (passphrase.includes("\n")) throw Error("contains multiple lines");
     // 512 is an arbitrary high number that should be longer than any actual passphrase
     if (passphrase.length > 512) throw Error("is really long");
-  } catch (e) {
+  } catch (e: unknown) {
     throw new Error(`passphraseFile ${passphraseFile} ${e.message}. Is this a well-formated passphraseFile?`);
   }
 

--- a/packages/lodestar-cli/src/validatorDir/ValidatorDir.ts
+++ b/packages/lodestar-cli/src/validatorDir/ValidatorDir.ts
@@ -67,7 +67,7 @@ export class ValidatorDir {
 
     try {
       lockFile.lockSync(this.lockfilePath);
-    } catch (e) {
+    } catch (e: unknown) {
       if (options && options.force) {
         // Ignore error, maybe log?
       } else {

--- a/packages/lodestar-db/src/abstractRepository.ts
+++ b/packages/lodestar-db/src/abstractRepository.ts
@@ -57,7 +57,7 @@ export abstract class Repository<I extends Id, T> {
       const value = await this.db.get(this.encodeKey(id));
       if (!value) return null;
       return value;
-    } catch (e) {
+    } catch (e: unknown) {
       return null;
     }
   }

--- a/packages/lodestar-db/src/controller/impl/level.ts
+++ b/packages/lodestar-db/src/controller/impl/level.ts
@@ -58,7 +58,7 @@ export class LevelDbController implements IDatabaseController<Buffer, Buffer> {
   async get(key: Buffer): Promise<Buffer | null> {
     try {
       return await this.db.get(key);
-    } catch (e) {
+    } catch (e: unknown) {
       if (e.notFound) {
         return null;
       }

--- a/packages/lodestar-light-client/test/setup.ts
+++ b/packages/lodestar-light-client/test/setup.ts
@@ -4,7 +4,7 @@ import {before} from "mocha";
 before(async function () {
   try {
     await init("blst-native");
-  } catch (e) {
+  } catch (e: unknown) {
     console.log(e);
   }
 });

--- a/packages/lodestar-spec-test-util/src/single.ts
+++ b/packages/lodestar-spec-test-util/src/single.ts
@@ -113,7 +113,7 @@ function generateTestCase<TestCase, Result>(
     if (options.shouldError && options.shouldError(testCase)) {
       try {
         testFunction(testCase, name);
-      } catch (e) {
+      } catch (e: unknown) {
         return;
       }
     } else {

--- a/packages/lodestar-utils/src/json.ts
+++ b/packages/lodestar-utils/src/json.ts
@@ -69,7 +69,7 @@ function errorToObject(err: Error): Json {
 function JSONStringifyCircular(value: any): string {
   try {
     return JSON.stringify(value);
-  } catch (e) {
+  } catch (e: unknown) {
     if (e instanceof TypeError && e.message.includes("circular")) {
       return CIRCULAR_REFERENCE_TAG;
     } else {

--- a/packages/lodestar-validator/src/api/impl/rest/beacon/beacon.ts
+++ b/packages/lodestar-validator/src/api/impl/rest/beacon/beacon.ts
@@ -30,7 +30,7 @@ export class RestBeaconApi implements IBeaconApi {
     try {
       const genesisResponse = await this.clientV2.get<{data: Json}>("/genesis");
       return this.config.types.phase0.Genesis.fromJson(genesisResponse.data, {case: "snake"});
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error("Failed to obtain genesis time", {error: e.message});
       return null;
     }

--- a/packages/lodestar-validator/src/api/impl/rest/beacon/state.ts
+++ b/packages/lodestar-validator/src/api/impl/rest/beacon/state.ts
@@ -24,7 +24,7 @@ export class RestBeaconStateApi extends RestApi implements IBeaconStateApi {
           case: "snake",
         }
       );
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error("Failed to fetch validator", {validatorId: id, error: e.message});
       return null;
     }
@@ -38,7 +38,7 @@ export class RestBeaconStateApi extends RestApi implements IBeaconStateApi {
           case: "snake",
         }
       );
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error("Failed to fetch head fork version", {error: e.message});
       return null;
     }

--- a/packages/lodestar-validator/src/services/attestation.ts
+++ b/packages/lodestar-validator/src/services/attestation.ts
@@ -110,7 +110,7 @@ export class AttestationService {
         if (v.validator?.index != null) indices.push(v.validator?.index);
       }
       attesterDuties = await this.provider.validator.getAttesterDuties(epoch, indices);
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error("Failed to obtain attester duty", {epoch, error: e.message});
       return;
     }
@@ -151,7 +151,7 @@ export class AttestationService {
             isAggregator,
           },
         ]);
-      } catch (e) {
+      } catch (e: unknown) {
         this.logger.error("Failed to subscribe to committee subnet", e);
       }
     }
@@ -182,7 +182,7 @@ export class AttestationService {
         return;
       }
       attestation = await this.createAttestation(duty, fork, this.provider.genesisValidatorsRoot, validator);
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error("Failed to produce attestation", {
         slot: duty.slot,
         committee: duty.committeeIndex,
@@ -208,7 +208,7 @@ export class AttestationService {
             }
             await this.aggregateAttestations(duty, attestation, fork, this.provider.genesisValidatorsRoot, validator);
           }
-        } catch (e) {
+        } catch (e: unknown) {
           this.logger.error("Failed to aggregate attestations", e);
         }
       }, (this.config.params.SECONDS_PER_SLOT / 3) * 1000);
@@ -222,7 +222,7 @@ export class AttestationService {
         block: toHexString(attestation.data.target.root),
         validator: toHexString(duty.pubkey),
       });
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error("Failed to publish attestation", e);
     }
   }
@@ -277,7 +277,7 @@ export class AttestationService {
         this.config.types.phase0.AttestationData.hashTreeRoot(attestation.data),
         duty.slot
       );
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error("Failed to produce aggregate and proof", e);
       return;
     }
@@ -294,7 +294,7 @@ export class AttestationService {
     try {
       await this.provider.validator.publishAggregateAndProofs([signedAggregateAndProof]);
       this.logger.info("Published signed aggregate and proof", {committeeIndex: duty.committeeIndex, slot: duty.slot});
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error(
         "Failed to publish aggregate and proof",
         {committeeIndex: duty.committeeIndex, slot: duty.slot},
@@ -351,7 +351,7 @@ export class AttestationService {
     let attestationData: phase0.AttestationData;
     try {
       attestationData = await this.provider.validator.produceAttestationData(committeeIndex, slot);
-    } catch (e) {
+    } catch (e: unknown) {
       e.message = `Failed to obtain attestation data at slot ${slot} and committee ${committeeIndex}: ${e.message}`;
       throw e;
     }
@@ -396,7 +396,7 @@ export class AttestationService {
       if (!v.validator) {
         try {
           v.validator = await this.provider.beacon.state.getStateValidator("head", fromHexString(pk));
-        } catch (e) {
+        } catch (e: unknown) {
           this.logger.error("Failed to get validator details", e);
           v.validator = null;
         }

--- a/packages/lodestar-validator/src/services/block.ts
+++ b/packages/lodestar-validator/src/services/block.ts
@@ -149,7 +149,7 @@ export default class BlockProposingService {
         validatorKeys.secretKey.sign(randaoSigningRoot).toBytes(),
         this.graffiti || ""
       );
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error("Failed to produce block", {slot}, e);
     }
     if (!block) {
@@ -178,7 +178,7 @@ export default class BlockProposingService {
         hash: toHexString(this.config.types.phase0.BeaconBlock.hashTreeRoot(block)),
         slot,
       });
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error("Failed to publish block", {slot}, e);
     }
     return signedBlock;

--- a/packages/lodestar-validator/src/slashingProtection/attestation/service.ts
+++ b/packages/lodestar-validator/src/slashingProtection/attestation/service.ts
@@ -68,7 +68,7 @@ export class SlashingProtectionAttestationService {
     // Check for a surround vote
     try {
       await this.minMaxSurround.assertNoSurround(pubKey, {source: att.sourceEpoch, target: att.targetEpoch});
-    } catch (e) {
+    } catch (e: unknown) {
       if (e instanceof SurroundAttestationError) {
         const prev = await this.attestationByTarget.get(pubKey, e.type.att2Target).catch(() => null);
         switch (e.type.code) {

--- a/packages/lodestar-validator/src/util/httpClient.ts
+++ b/packages/lodestar-validator/src/util/httpClient.ts
@@ -29,7 +29,7 @@ export class HttpClient {
       const result: AxiosResponse<T> = await this.client.get<T>(url, opts);
       this.logger.verbose("HttpClient GET", {url, result: JSON.stringify(result.data)});
       return result.data;
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.verbose("HttpClient GET error", {url}, e);
       throw this.handleError(e);
     }
@@ -41,7 +41,7 @@ export class HttpClient {
       const result: AxiosResponse<T2> = await this.client.post(url, data);
       this.logger.verbose("HttpClient POST", {url, result: JSON.stringify(result.data)});
       return result.data;
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.verbose("HttpClient POST error", {url}, e);
       throw this.handleError(e);
     }

--- a/packages/lodestar-validator/test/unit/slashingProtection/minMaxSurround/surroundTests.test.ts
+++ b/packages/lodestar-validator/test/unit/slashingProtection/minMaxSurround/surroundTests.test.ts
@@ -212,7 +212,7 @@ describe("surroundTests", () => {
         try {
           await minMaxSurround.assertNoSurround(emptyPubkey, {source: sourceEpoch, target: targetEpoch});
           throw Error("Should slash");
-        } catch (e) {
+        } catch (e: unknown) {
           if (e instanceof SurroundAttestationError) {
             if (slashableEpoch) {
               expect(e.type.att2Target).to.equal(slashableEpoch, "Wrong slashableEpoch");

--- a/packages/lodestar-validator/test/unit/utils/httpClient.test.ts
+++ b/packages/lodestar-validator/test/unit/utils/httpClient.test.ts
@@ -41,7 +41,7 @@ describe("httpClient test", () => {
   it("should handle http status code 404 correctly", async () => {
     try {
       await httpClient.get<IUser>("/wrong_url");
-    } catch (e) {
+    } catch (e: unknown) {
       assert.equal(e.message, "Endpoint not found");
     }
   });
@@ -50,7 +50,7 @@ describe("httpClient test", () => {
     mock.onGet("/users/!").reply(500, "internal server error");
     try {
       await httpClient.get<IUser>("/users/!");
-    } catch (e) {
+    } catch (e: unknown) {
       assert.equal(e.message, "Request failed with response status 500");
     }
   });

--- a/packages/lodestar/src/api/impl/beacon/pool/pool.ts
+++ b/packages/lodestar/src/api/impl/beacon/pool/pool.ts
@@ -50,7 +50,7 @@ export class BeaconPoolApi implements IBeaconPoolApi {
     let attestationPreState;
     try {
       attestationPreState = await this.chain.regen.getCheckpointState(attestation.data.target);
-    } catch (e) {
+    } catch (e: unknown) {
       throw new AttestationError({
         code: AttestationErrorCode.MISSING_ATTESTATION_PRESTATE,
         job: attestationJob,

--- a/packages/lodestar/src/api/impl/debug/beacon/index.ts
+++ b/packages/lodestar/src/api/impl/debug/beacon/index.ts
@@ -27,7 +27,7 @@ export class DebugBeaconApi implements IDebugBeaconApi {
       return this.chain.forkChoice
         .getHeads()
         .map((blockSummary) => ({slot: blockSummary.slot, root: blockSummary.blockRoot}));
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error("Failed to get forkchoice heads", e);
       return null;
     }
@@ -36,7 +36,7 @@ export class DebugBeaconApi implements IDebugBeaconApi {
   async getState(stateId: StateId): Promise<phase0.BeaconState | null> {
     try {
       return await resolveStateId(this.chain, this.db, stateId);
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error("Failed to resolve state", {state: stateId, error: e});
       throw e;
     }

--- a/packages/lodestar/src/api/impl/utils.ts
+++ b/packages/lodestar/src/api/impl/utils.ts
@@ -10,7 +10,7 @@ export async function checkSyncStatus(config: IBeaconConfig, sync: IBeaconSync):
     let syncStatus;
     try {
       syncStatus = sync.getSyncStatus();
-    } catch (e) {
+    } catch (e: unknown) {
       throw new ApiError(503, "Node is stopped");
     }
     if (syncStatus.syncDistance > config.params.SLOTS_PER_EPOCH) {

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -72,7 +72,7 @@ export class ValidatorApi implements IValidatorApi {
       const headRoot = this.chain.forkChoice.getHeadRoot();
       const state = await this.chain.regen.getBlockSlotState(headRoot, slot);
       return assembleAttestationData(state.config, state, headRoot, slot, committeeIndex);
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.warn("Failed to produce attestation data", e);
       throw e;
     }
@@ -136,7 +136,7 @@ export class ValidatorApi implements IValidatorApi {
             aggregationBits[index] = true;
           }
         });
-      } catch (e) {
+      } catch (e: unknown) {
         this.logger.verbose("Invalid attestation signature", e);
       }
     }
@@ -171,7 +171,7 @@ export class ValidatorApi implements IValidatorApi {
             this.db.seenAttestationCache.addAggregateAndProof(signedAggregateAndProof.message),
             this.network.gossip.publishBeaconAggregateAndProof(signedAggregateAndProof),
           ]);
-        } catch (e) {
+        } catch (e: unknown) {
           this.logger.warn("Failed to publish aggregate and proof", e);
         }
       })

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlock.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlock.ts
@@ -14,7 +14,7 @@ export const getBlock: ApiController<DefaultQuery, {blockId: string}> = {
       return resp.status(200).send({
         data: this.config.types.phase0.SignedBeaconBlock.toJson(data, {case: "snake"}),
       });
-    } catch (e) {
+    } catch (e: unknown) {
       if (e.message === "Invalid block id") {
         throw toRestValidationError("block_id", e.message);
       }

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockAttestations.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockAttestations.ts
@@ -16,7 +16,7 @@ export const getBlockAttestations: ApiController<DefaultQuery, {blockId: string}
           this.config.types.phase0.Attestation.toJson(attestations, {case: "snake"});
         }),
       });
-    } catch (e) {
+    } catch (e: unknown) {
       if (e.message === "Invalid block id") {
         throw toRestValidationError("block_id", e.message);
       }

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockHeader.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockHeader.ts
@@ -14,7 +14,7 @@ export const getBlockHeader: ApiController<DefaultQuery, {blockId: string}> = {
       return resp.status(200).send({
         data: this.config.types.phase0.SignedBeaconHeaderResponse.toJson(data, {case: "snake"}),
       });
-    } catch (e) {
+    } catch (e: unknown) {
       if (e.message === "Invalid block id") {
         throw toRestValidationError("block_id", e.message);
       }

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockRoot.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockRoot.ts
@@ -16,7 +16,7 @@ export const getBlockRoot: ApiController<DefaultQuery, {blockId: string}> = {
           root: this.config.types.Root.toJson(this.config.types.phase0.BeaconBlock.hashTreeRoot(data.message)),
         },
       });
-    } catch (e) {
+    } catch (e: unknown) {
       if (e.message === "Invalid block id") {
         throw toRestValidationError("block_id", e.message);
       }

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/publishBlock.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/publishBlock.ts
@@ -9,7 +9,7 @@ export const publishBlock: ApiController = {
     let block: phase0.SignedBeaconBlock;
     try {
       block = this.config.types.phase0.SignedBeaconBlock.fromJson(req.body, {case: "snake"});
-    } catch (e) {
+    } catch (e: unknown) {
       throw new ValidationError("Failed to deserialize block");
     }
     await this.api.beacon.blocks.publishBlock(block);

--- a/packages/lodestar/src/api/rest/controllers/beacon/pool/submitAttesterSlashing.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/pool/submitAttesterSlashing.ts
@@ -9,7 +9,7 @@ export const submitAttesterSlashing: ApiController = {
     let slashing: phase0.AttesterSlashing;
     try {
       slashing = this.config.types.phase0.AttesterSlashing.fromJson(req.body, {case: "snake"});
-    } catch (e) {
+    } catch (e: unknown) {
       throw new ValidationError("Failed to deserialize attester slashing");
     }
     await this.api.beacon.pool.submitAttesterSlashing(slashing);

--- a/packages/lodestar/src/api/rest/controllers/beacon/pool/submitPoolAttestation.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/pool/submitPoolAttestation.ts
@@ -9,7 +9,7 @@ export const submitPoolAttestation: ApiController = {
     let attestation: phase0.Attestation;
     try {
       attestation = this.config.types.phase0.Attestation.fromJson(req.body, {case: "snake"});
-    } catch (e) {
+    } catch (e: unknown) {
       throw new ValidationError("Failed to deserialize attestation");
     }
     await this.api.beacon.pool.submitAttestation(attestation);

--- a/packages/lodestar/src/api/rest/controllers/beacon/pool/submitProposerSlashing.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/pool/submitProposerSlashing.ts
@@ -9,7 +9,7 @@ export const submitProposerSlashing: ApiController = {
     let slashing: phase0.ProposerSlashing;
     try {
       slashing = this.config.types.phase0.ProposerSlashing.fromJson(req.body, {case: "snake"});
-    } catch (e) {
+    } catch (e: unknown) {
       throw new ValidationError("Failed to deserialize proposer slashing");
     }
     await this.api.beacon.pool.submitProposerSlashing(slashing);

--- a/packages/lodestar/src/api/rest/controllers/beacon/pool/submitVoluntaryExit.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/pool/submitVoluntaryExit.ts
@@ -9,7 +9,7 @@ export const submitVoluntaryExit: ApiController = {
     let exit: phase0.SignedVoluntaryExit;
     try {
       exit = this.config.types.phase0.SignedVoluntaryExit.fromJson(req.body, {case: "snake"});
-    } catch (e) {
+    } catch (e: unknown) {
       throw new ValidationError("Failed to deserialize voluntary exit");
     }
     await this.api.beacon.pool.submitVoluntaryExit(exit);

--- a/packages/lodestar/src/api/rest/controllers/beacon/state/getStateFinalityCheckpoints.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/state/getStateFinalityCheckpoints.ts
@@ -29,7 +29,7 @@ export const getStateFinalityCheckpoints: ApiController<DefaultQuery, Params> = 
           finalized: this.config.types.phase0.Checkpoint.toJson(state.finalizedCheckpoint, {case: "snake"}),
         },
       });
-    } catch (e) {
+    } catch (e: unknown) {
       if (e.message === "Invalid state id") {
         throw toRestValidationError("state_id", e.message);
       }

--- a/packages/lodestar/src/api/rest/controllers/beacon/state/getStateFork.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/state/getStateFork.ts
@@ -19,7 +19,7 @@ export const getStateFork: ApiController<DefaultQuery, Params> = {
       return resp.status(200).send({
         data: this.config.types.phase0.Fork.toJson(fork, {case: "snake"}),
       });
-    } catch (e) {
+    } catch (e: unknown) {
       if (e.message === "Invalid state id") {
         throw toRestValidationError("state_id", e.message);
       }

--- a/packages/lodestar/src/api/rest/controllers/debug/beacon/getStates.ts
+++ b/packages/lodestar/src/api/rest/controllers/debug/beacon/getStates.ts
@@ -22,7 +22,7 @@ export const getState: ApiController<DefaultQuery, {stateId: string}> = {
           data: this.config.types.phase0.BeaconState.toJson(state, {case: "snake"}),
         });
       }
-    } catch (e) {
+    } catch (e: unknown) {
       if (e.message === "Invalid state id") {
         throw toRestValidationError("state_id", e.message);
       }

--- a/packages/lodestar/src/api/rest/controllers/validator/publishAggregateAndProof.ts
+++ b/packages/lodestar/src/api/rest/controllers/validator/publishAggregateAndProof.ts
@@ -15,7 +15,7 @@ export const publishAggregateAndProof: ApiController<DefaultQuery, DefaultParams
         signedAggregateAndProofs.push(
           this.config.types.phase0.SignedAggregateAndProof.fromJson(aggreagteJson, {case: "snake"})
         );
-      } catch (e) {
+      } catch (e: unknown) {
         this.log.warn("Failed to parse AggregateAndProof", e.message);
       }
     }

--- a/packages/lodestar/src/api/rest/index.ts
+++ b/packages/lodestar/src/api/rest/index.ts
@@ -30,7 +30,7 @@ export class RestApi {
       try {
         const address = await api.server.listen(_opts.port, _opts.host);
         logger.info("Started rest api server", {address});
-      } catch (e) {
+      } catch (e: unknown) {
         logger.error("Failed to start rest api server", {host: _opts.host, port: _opts.port}, e);
         throw e;
       }

--- a/packages/lodestar/src/chain/attestation/process.ts
+++ b/packages/lodestar/src/chain/attestation/process.ts
@@ -28,7 +28,7 @@ export async function processAttestation({
   let targetState;
   try {
     targetState = await regen.getCheckpointState(target);
-  } catch (e) {
+  } catch (e: unknown) {
     throw new AttestationError({
       code: AttestationErrorCode.TARGET_STATE_MISSING,
       job,
@@ -38,7 +38,7 @@ export async function processAttestation({
   let indexedAttestation;
   try {
     indexedAttestation = targetState.epochCtx.getIndexedAttestation(attestation);
-  } catch (e) {
+  } catch (e: unknown) {
     throw new AttestationError({
       code: AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX,
       slot: attestation.data.slot,

--- a/packages/lodestar/src/chain/attestation/processor.ts
+++ b/packages/lodestar/src/chain/attestation/processor.ts
@@ -43,7 +43,7 @@ export async function processAttestationJob(modules: AttestationProcessorModules
   try {
     validateAttestation({...modules, job});
     await processAttestation({...modules, job});
-  } catch (e) {
+  } catch (e: unknown) {
     // above functions only throw AttestationError
     modules.emitter.emit(ChainEvent.errorAttestation, e);
   }

--- a/packages/lodestar/src/chain/blocks/process.ts
+++ b/packages/lodestar/src/chain/blocks/process.ts
@@ -51,7 +51,7 @@ export async function processBlock({
     }
 
     await runStateTransition(emitter, forkChoice, checkpointStateCache, preState, job);
-  } catch (e) {
+  } catch (e: unknown) {
     if (e instanceof RegenError) {
       throw new BlockError({
         code: BlockErrorCode.PRESTATE_MISSING,
@@ -147,7 +147,7 @@ export async function processChainSegment({
         });
         importedBlocks++;
       }
-    } catch (e) {
+    } catch (e: unknown) {
       if (e instanceof RegenError) {
         throw new ChainSegmentError({
           code: BlockErrorCode.PRESTATE_MISSING,

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -71,7 +71,7 @@ export async function processBlockJob(modules: BlockProcessorModules, job: IBloc
   try {
     validateBlock({...modules, job});
     await processBlock({...modules, job});
-  } catch (e) {
+  } catch (e: unknown) {
     // above functions only throw BlockError
     modules.emitter.emit(ChainEvent.errorBlock, e);
   }
@@ -119,7 +119,7 @@ export async function processChainSegmentJob(modules: BlockProcessorModules, job
       validateBlock({...modules, job: {...job, signedBlock: block}});
       // If the block is relevant, add it to the filtered chain segment.
       filteredChainSegment.push(block);
-    } catch (e) {
+    } catch (e: unknown) {
       switch ((e as BlockError).type.code) {
         // If the block is already known, simply ignore this block.
         case BlockErrorCode.BLOCK_IS_ALREADY_KNOWN:

--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -112,14 +112,6 @@ export function emitForkChoiceHeadEvents(
   }
 }
 
-export function emitBlockEvent(
-  emitter: ChainEventEmitter,
-  job: IBlockJob,
-  postState: CachedBeaconState<phase0.BeaconState>
-): void {
-  emitter.emit(ChainEvent.block, job.signedBlock, postState, job);
-}
-
 export async function runStateTransition(
   emitter: ChainEventEmitter,
   forkChoice: IForkChoice,
@@ -153,7 +145,7 @@ export async function runStateTransition(
     emitCheckpointEvent(emitter, postState);
   }
 
-  emitBlockEvent(emitter, job, postState);
+  emitter.emit(ChainEvent.block, job.signedBlock, postState, job);
   emitForkChoiceHeadEvents(emitter, forkChoice, forkChoice.getHead(), oldHead);
 
   // this avoids keeping our node busy processing blocks

--- a/packages/lodestar/src/chain/blocks/validate.ts
+++ b/packages/lodestar/src/chain/blocks/validate.ts
@@ -54,7 +54,7 @@ export function validateBlock({
         job,
       });
     }
-  } catch (e) {
+  } catch (e: unknown) {
     if (e instanceof BlockError) {
       throw e;
     }

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -192,7 +192,7 @@ export class BeaconChain implements IBeaconChain {
     }
     try {
       return await this.regen.getState(blockSummary.stateRoot);
-    } catch (e) {
+    } catch (e: unknown) {
       return null;
     }
   }

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -36,7 +36,7 @@ function wrapHandler<
     try {
       await handler(...args);
       emitter.emit(event, ...((args as unknown) as ListenerType<Callback>));
-    } catch (e) {
+    } catch (e: unknown) {
       logger.error("Error handling event", {event}, e);
     }
   };

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -189,7 +189,7 @@ export class StateRegenerator implements IStateRegenerator {
           validSignatures: true,
           validProposerSignature: true,
         });
-      } catch (e) {
+      } catch (e: unknown) {
         throw new RegenError({
           code: RegenErrorCode.STATE_TRANSITION_ERROR,
           error: e,

--- a/packages/lodestar/src/chain/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/aggregateAndProof.ts
@@ -82,7 +82,7 @@ export async function validateAggregateAttestation(
   try {
     // the target state, advanced to the attestation slot
     attestationPreState = await chain.regen.getBlockSlotState(attestation.data.target.root, attestation.data.slot);
-  } catch (e) {
+  } catch (e: unknown) {
     throw new AttestationError({
       code: AttestationErrorCode.MISSING_ATTESTATION_PRESTATE,
       job: attestationJob,

--- a/packages/lodestar/src/chain/validation/attestation.ts
+++ b/packages/lodestar/src/chain/validation/attestation.ts
@@ -76,7 +76,7 @@ export async function validateGossipAttestation(
   let attestationPreState;
   try {
     attestationPreState = await chain.regen.getCheckpointState(attestation.data.target);
-  } catch (e) {
+  } catch (e: unknown) {
     throw new AttestationError({
       code: AttestationErrorCode.MISSING_ATTESTATION_PRESTATE,
       job: attestationJob,

--- a/packages/lodestar/src/chain/validation/block.ts
+++ b/packages/lodestar/src/chain/validation/block.ts
@@ -56,7 +56,7 @@ export async function validateGossipBlock(
   try {
     // getBlockSlotState also checks for whether the current finalized checkpoint is an ancestor of the block.  as a result, we throw an IGNORE (whereas the spec says we should REJECT for this scenario).  this is something we should change this in the future to make the code airtight to the spec.
     blockState = await chain.regen.getBlockSlotState(block.message.parentRoot, block.message.slot);
-  } catch (e) {
+  } catch (e: unknown) {
     throw new BlockError({
       code: BlockErrorCode.PARENT_UNKNOWN,
       parentRoot: block.message.parentRoot,

--- a/packages/lodestar/src/eth1/jsonRpcHttpClient.ts
+++ b/packages/lodestar/src/eth1/jsonRpcHttpClient.ts
@@ -91,7 +91,7 @@ async function fetchJson<R, T = unknown>(url: string, json: T, signal?: AbortSig
 function parseJson<T>(json: string): T {
   try {
     return JSON.parse(json);
-  } catch (e) {
+  } catch (e: unknown) {
     throw new ErrorParseJson(json, e);
   }
 }

--- a/packages/lodestar/src/metrics/gitData.ts
+++ b/packages/lodestar/src/metrics/gitData.ts
@@ -31,7 +31,7 @@ export function readLodestarGitData(): GitData {
     const gitData = JSON.parse(fs.readFileSync(gitDataFilepath, "utf8"));
     const {version: semver, branch, commit} = gitData;
     return {semver, branch, commit, version: `${semver} ${branch} ${commit.slice(0, 8)}`};
-  } catch (e) {
+  } catch (e: unknown) {
     return {semver: "", branch: "", commit: "", version: e.message};
   }
 }

--- a/packages/lodestar/src/metrics/server/http.ts
+++ b/packages/lodestar/src/metrics/server/http.ts
@@ -36,7 +36,7 @@ export class HttpMetricsServer implements IMetricsServer {
     if (this.opts.enabled) {
       try {
         await this.terminator.terminate();
-      } catch (e) {
+      } catch (e: unknown) {
         this.logger.warn("Failed to stop metrics server", e);
       }
     }

--- a/packages/lodestar/src/network/gossip/encoding.ts
+++ b/packages/lodestar/src/network/gossip/encoding.ts
@@ -74,7 +74,7 @@ export function computeMsgId(topic: string, data: Uint8Array): {msgId: Uint8Arra
       try {
         uncompressed = uncompress(data);
         dataToHash = Buffer.concat([MESSAGE_DOMAIN_VALID_SNAPPY, uncompressed]);
-      } catch (e) {
+      } catch (e: unknown) {
         dataToHash = Buffer.concat([MESSAGE_DOMAIN_INVALID_SNAPPY, data]);
       }
       break;

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -133,7 +133,7 @@ export class Eth2Gossipsub extends Gossipsub {
       // Lodestar ObjectValidatorFns rely on these properties being set
       message.gossipObject = gossipObject;
       message.gossipTopic = gossipTopic;
-    } catch (e) {
+    } catch (e: unknown) {
       const err = new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
       // must set gossip scores manually, since this usually happens in super.validate
       this.score.rejectMessage(message, err.code);

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -71,7 +71,7 @@ export async function validateBeaconBlock(
     logger.verbose("Started gossip block validation", logContext);
     await validateGossipBlock(config, chain, db, blockJob);
     logger.verbose("Received valid gossip block", logContext);
-  } catch (e) {
+  } catch (e: unknown) {
     if (!(e instanceof BlockError)) {
       logger.error("Gossip block validation threw a non-BlockError", e);
       throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
@@ -122,7 +122,7 @@ export async function validateAggregatedAttestation(
     logger.verbose("Started gossip aggregate and proof validation", logContext);
     await validateGossipAggregateAndProof(config, chain, db, signedAggregateAndProof, attestationJob);
     logger.verbose("Received valid gossip aggregate and proof", logContext);
-  } catch (e) {
+  } catch (e: unknown) {
     if (!(e instanceof AttestationError)) {
       logger.error("Gossip aggregate and proof validation threw a non-AttestationError", e);
       throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
@@ -178,7 +178,7 @@ export async function validateCommitteeAttestation(
     logger.verbose("Started gossip committee attestation validation", logContext);
     await validateGossipAttestation(config, chain, db, attestationJob, subnet);
     logger.verbose("Received valid committee attestation", logContext);
-  } catch (e) {
+  } catch (e: unknown) {
     if (!(e instanceof AttestationError)) {
       logger.error("Gossip attestation validation threw a non-AttestationError", e);
       throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
@@ -222,7 +222,7 @@ export async function validateVoluntaryExit(
 ): Promise<void> {
   try {
     await validateGossipVoluntaryExit(config, chain, db, voluntaryExit);
-  } catch (e) {
+  } catch (e: unknown) {
     if (!(e instanceof VoluntaryExitError)) {
       logger.error("Gossip voluntary exit validation threw a non-VoluntaryExitError", e);
       throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
@@ -248,7 +248,7 @@ export async function validateProposerSlashing(
 ): Promise<void> {
   try {
     await validateGossipProposerSlashing(config, chain, db, proposerSlashing);
-  } catch (e) {
+  } catch (e: unknown) {
     if (!(e instanceof ProposerSlashingError)) {
       logger.error("Gossip proposer slashing validation threw a non-ProposerSlashingError", e);
       throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
@@ -274,7 +274,7 @@ export async function validateAttesterSlashing(
 ): Promise<void> {
   try {
     await validateGossipAttesterSlashing(config, chain, db, attesterSlashing);
-  } catch (e) {
+  } catch (e: unknown) {
     if (!(e instanceof AttesterSlashingError)) {
       logger.error("Gossip attester slashing validation threw a non-AttesterSlashingError", e);
       throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -189,7 +189,7 @@ export class Network extends (EventEmitter as {new (): NetworkEventEmitter}) imp
   async disconnect(peerId: PeerId): Promise<void> {
     try {
       await this.libp2p.hangUp(peerId);
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.warn("Unclean disconnect", {reason: e.message});
     }
   }
@@ -230,7 +230,7 @@ export class Network extends (EventEmitter as {new (): NetworkEventEmitter}) imp
         await this.connect(peer.peerId, [peer.multiaddr]);
         found = true;
         break;
-      } catch (e) {
+      } catch (e: unknown) {
         // this runs too frequently so make it verbose
         this.logger.verbose("Cannot connect to peer", {peerId: peer.peerId.toB58String(), subnet, error: e.message});
       }

--- a/packages/lodestar/src/network/peers/utils.ts
+++ b/packages/lodestar/src/network/peers/utils.ts
@@ -45,7 +45,7 @@ export async function handlePeerMetadataSequence(
     try {
       logger.verbose("Getting peer metadata", {peer: peer.toB58String()});
       network.peerMetadata.metadata.set(peer, await network.reqResp.metadata(peer));
-    } catch (e) {
+    } catch (e: unknown) {
       logger.verbose("Cannot get peer metadata", {peer: peer.toB58String(), e: e.message});
     }
   } else {

--- a/packages/lodestar/src/network/reqresp/encoders/responseDecode.ts
+++ b/packages/lodestar/src/network/reqresp/encoders/responseDecode.ts
@@ -93,7 +93,7 @@ export async function readErrorMessage(bufferedSource: BufferedSource): Promise<
     const bytes = buffer.slice();
     try {
       return decodeErrorMessage(bytes);
-    } catch (e) {
+    } catch (e: unknown) {
       return bytes.toString("hex");
     }
   }

--- a/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/decode.ts
+++ b/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/decode.ts
@@ -94,7 +94,7 @@ async function readSszSnappyBody(bufferedSource: BufferedSource, sszDataLength: 
       if (uncompressed !== null) {
         uncompressedData.append(uncompressed);
       }
-    } catch (e) {
+    } catch (e: unknown) {
       throw new SszSnappyError({code: SszSnappyErrorCode.DECOMPRESSOR_ERROR, decompressorError: e});
     }
 
@@ -131,7 +131,7 @@ function deserializeSszBody<T extends RequestOrResponseBody>(
     } else {
       return type.deserialize(bytes) as T;
     }
-  } catch (e) {
+  } catch (e: unknown) {
     throw new SszSnappyError({code: SszSnappyErrorCode.DESERIALIZE_ERROR, deserializeError: e});
   }
 }

--- a/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/encode.ts
+++ b/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/encode.ts
@@ -43,7 +43,7 @@ function serializeSszBody<T extends RequestOrResponseBody>(body: T, type: Reques
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const bytes = type.serialize(body as any);
     return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.length);
-  } catch (e) {
+  } catch (e: unknown) {
     throw new SszSnappyError({code: SszSnappyErrorCode.SERIALIZE_ERROR, serializeError: e});
   }
 }

--- a/packages/lodestar/src/network/reqresp/reqResp.ts
+++ b/packages/lodestar/src/network/reqresp/reqResp.ts
@@ -81,7 +81,7 @@ export class ReqResp implements IReqResp {
               this.respCount++
             );
             // TODO: Do success peer scoring here
-          } catch (e) {
+          } catch (e: unknown) {
             // TODO: Do error peer scoring here
             // Must not throw since this is an event handler
           }
@@ -180,7 +180,7 @@ export class ReqResp implements IReqResp {
       );
 
       return result;
-    } catch (e) {
+    } catch (e: unknown) {
       const peerAction = onOutgoingReqRespError(e, method);
       if (peerAction !== null) this.peerRpcScores.applyAction(peerId, peerAction);
 

--- a/packages/lodestar/src/network/reqresp/request/index.ts
+++ b/packages/lodestar/src/network/reqresp/request/index.ts
@@ -129,7 +129,7 @@ export async function sendRequest<T extends phase0.ResponseBody | phase0.Respons
       // If collectResponses() exhausts the source, it-pushable.end() can be safely called multiple times
       stream.close();
     }
-  } catch (e) {
+  } catch (e: unknown) {
     logger.verbose("Req  error", logCtx, e);
 
     const metadata: IRequestErrorMetadata = {method, encoding, peer};

--- a/packages/lodestar/src/network/reqresp/request/responseTimeoutsHandler.ts
+++ b/packages/lodestar/src/network/reqresp/request/responseTimeoutsHandler.ts
@@ -51,7 +51,7 @@ export function responseTimeoutsHandler<T>(
           restartRespTimeout();
         })
       );
-    } catch (e) {
+    } catch (e: unknown) {
       // Rethrow error properly typed so the peer score can pick it up
       switch (e.message) {
         case RequestErrorCode.TTFB_TIMEOUT:

--- a/packages/lodestar/src/network/reqresp/response/index.ts
+++ b/packages/lodestar/src/network/reqresp/response/index.ts
@@ -51,7 +51,7 @@ export async function handleRequest(
           onChunk(() => logger.debug("Resp sending chunk", logCtx)),
           responseEncodeSuccess(config, method, encoding)
         );
-      } catch (e) {
+      } catch (e: unknown) {
         const status = e instanceof ResponseError ? e.status : RpcResponseStatus.SERVER_ERROR;
         yield* responseEncodeError(status, e.message);
 

--- a/packages/lodestar/src/network/tasks/checkPeerAliveTask.ts
+++ b/packages/lodestar/src/network/tasks/checkPeerAliveTask.ts
@@ -48,7 +48,7 @@ export class CheckPeerAliveTask {
         let peerSeq: BigInt;
         try {
           peerSeq = await this.network.reqResp.ping(peer, seq);
-        } catch (e) {
+        } catch (e: unknown) {
           this.logger.warn("Cannot ping peer, disconnecting it", {peerId: peer.toB58String(), error: e.message});
           // a peer may still be good for gossip blocks even it does not response to ping
           // temporarily disable this due to https://github.com/ChainSafe/lodestar/issues/1619

--- a/packages/lodestar/src/network/tasks/diversifyPeersBySubnetTask.ts
+++ b/packages/lodestar/src/network/tasks/diversifyPeersBySubnetTask.ts
@@ -73,14 +73,14 @@ export class DiversifyPeersBySubnetTask {
       });
       try {
         await Promise.all(toDiscPeers.map((peer) => this.network.disconnect(peer)));
-      } catch (e) {
+      } catch (e: unknown) {
         this.logger.warn("Cannot disconnect peers", {error: e.message});
       }
     }
 
     try {
       await this.network.searchSubnetPeers(missingSubnets.map((subnet) => String(subnet)));
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.warn("Cannot connect to peers on subnet", {subnet: missingSubnets, error: e.message});
     }
   };

--- a/packages/lodestar/src/node/notifier.ts
+++ b/packages/lodestar/src/node/notifier.ts
@@ -94,7 +94,7 @@ export async function runNodeNotifier({
       // Log halfway through each slot
       await sleep(timeToNextHalfSlot(config, chain), signal);
     }
-  } catch (e) {
+  } catch (e: unknown) {
     if (e instanceof ErrorAborted) {
       return; // Ok
     } else {

--- a/packages/lodestar/src/sync/range/utils/wrapError.ts
+++ b/packages/lodestar/src/sync/range/utils/wrapError.ts
@@ -6,7 +6,7 @@ type Result<T> = {err: null; result: T} | {err: Error};
  * ```ts
  * try {
  *   A()
- * } catch (e) {
+ * } catch (e: unknown) {
  *   B()
  * }
  * ```

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
@@ -95,7 +95,7 @@ export class BlockRangeFetcher implements IBlockRangeFetcher {
           // 0-1 block result should go through and we'll handle it in next round
           if (result.length > 1) checkLinearChainSegment(this.config, result);
         }
-      } catch (e) {
+      } catch (e: unknown) {
         this.logger.verbose("Regular Sync: Failed to get block range ", {...(slotRange ?? {}), error: e.message});
         // sync is stopped for whatever reasons
         if (e instanceof ErrorAborted) return [];

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -85,7 +85,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
         .map(async (peer) => {
           try {
             await this.goodbye(peer.id, GoodByeReasonCode.CLIENT_SHUTDOWN);
-          } catch (e) {
+          } catch (e: unknown) {
             this.logger.verbose("Failed to send goodbye", {error: e.message});
           }
         })
@@ -125,7 +125,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
   private async *onStatus(status: phase0.Status, peerId: PeerId): AsyncIterable<phase0.Status> {
     try {
       assertPeerRelevance(status, this.chain, this.config);
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.debug("Irrelevant peer", {
         peer: peerId.toB58String(),
         reason: e instanceof LodestarError ? e.getMetadata() : e.message,
@@ -178,7 +178,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
       const request = this.chain.getStatus();
       try {
         this.network.peerMetadata.status.set(peerId, await this.network.reqResp.status(peerId, request));
-      } catch (e) {
+      } catch (e: unknown) {
         this.logger.verbose("Failed to get peer latest status and metadata", {
           peerId: peerId.toB58String(),
           error: e.message,

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -185,7 +185,7 @@ export class BeaconSync implements IBeaconSync {
     this.statusSyncTimer = setInterval(async () => {
       try {
         await syncPeersStatus(this.network, this.chain.getStatus());
-      } catch (e) {
+      } catch (e: unknown) {
         this.logger.error("Error on syncPeersStatus", e);
       }
     }, interval);
@@ -245,7 +245,7 @@ export class BeaconSync implements IBeaconSync {
           this.chain.receiveBlock(blocks[0]);
           break;
         }
-      } catch (e) {
+      } catch (e: unknown) {
         this.logger.verbose("Failed to get unknown ancestor root from peer", {
           parentRootHex,
           peer: peer.toB58String(),

--- a/packages/lodestar/src/sync/utils/attestation-collector.ts
+++ b/packages/lodestar/src/sync/utils/attestation-collector.ts
@@ -63,7 +63,7 @@ export class AttestationCollector {
       } else {
         this.aggregationDuties.set(slot, new Set([committeeIndex]));
       }
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error("Unable to subscribe to attestation subnet", {subnet});
     }
   }
@@ -88,7 +88,7 @@ export class AttestationCollector {
   private unsubscribeSubnet = (subnet: number, fork: IForkName): void => {
     try {
       this.network.gossip.unsubscribeTopic({type: GossipType.beacon_attestation, fork, subnet});
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error("Unable to unsubscribe to attestation subnet", {subnet});
     }
   };

--- a/packages/lodestar/src/sync/utils/blocks.ts
+++ b/packages/lodestar/src/sync/utils/blocks.ts
@@ -66,7 +66,7 @@ export async function getBlockRange(
           let chunkBlocks;
           try {
             chunkBlocks = await getBlockRangeFromPeer(rpc, peer!, chunk);
-          } catch (e) {
+          } catch (e: unknown) {
             chunkBlocks = null;
           }
           if (chunkBlocks) {

--- a/packages/lodestar/src/tasks/index.ts
+++ b/packages/lodestar/src/tasks/index.ts
@@ -96,7 +96,7 @@ export class TasksService {
       // tasks rely on extended fork choice
       this.chain.forkChoice.prune(finalized.root);
       this.logger.verbose("Finish processing finalized checkpoint", {epoch: finalized.epoch});
-    } catch (e) {
+    } catch (e: unknown) {
       this.logger.error("Error processing finalized checkpoint", {epoch: finalized.epoch}, e);
     }
   };

--- a/packages/lodestar/src/util/queue.ts
+++ b/packages/lodestar/src/util/queue.ts
@@ -57,7 +57,7 @@ export class JobQueue {
       try {
         const result = await job();
         resolve(result);
-      } catch (e) {
+      } catch (e: unknown) {
         reject(e);
       } finally {
         this.opts.onJobDone?.({ms: Date.now() - start});

--- a/packages/lodestar/src/util/retry.ts
+++ b/packages/lodestar/src/util/retry.ts
@@ -25,7 +25,7 @@ export async function retry<A>(fn: (attempt: number) => A | Promise<A>, opts?: I
   for (let i = 1; i <= maxRetries; i++) {
     try {
       return await fn(i);
-    } catch (e) {
+    } catch (e: unknown) {
       lastError = e;
       if (shouldRetry && !shouldRetry(lastError)) {
         break;

--- a/packages/lodestar/test/e2e/sync/sync.test.ts
+++ b/packages/lodestar/test/e2e/sync/sync.test.ts
@@ -37,7 +37,7 @@ describe("syncing", function () {
 
     try {
       await finalizationEventListener;
-    } catch (e) {
+    } catch (e: unknown) {
       assert.fail("Failed to reach finalization");
     }
     const bn2 = await getDevBeaconNode({
@@ -53,7 +53,7 @@ describe("syncing", function () {
     await bn2.network.connect(bn.network.peerId, bn.network.localMultiaddrs);
     try {
       await waitForSynced;
-    } catch (e) {
+    } catch (e: unknown) {
       assert.fail("Failed to sync to other node in time");
     }
     await bn2.close();

--- a/packages/lodestar/test/setup.ts
+++ b/packages/lodestar/test/setup.ts
@@ -4,7 +4,7 @@ import {before} from "mocha";
 before(async function () {
   try {
     await init("blst-native");
-  } catch (e) {
+  } catch (e: unknown) {
     console.log(e);
   }
 });

--- a/packages/lodestar/test/sim/multiNodeMultiThread.test.ts
+++ b/packages/lodestar/test/sim/multiNodeMultiThread.test.ts
@@ -77,7 +77,7 @@ describe("Run multi node multi thread interop validators (no eth1) until checkpo
         );
         console.log("Success: Terminating workers");
         await Promise.all(workers.map((worker) => worker.terminate()));
-      } catch (e) {
+      } catch (e: unknown) {
         console.log("Failure: Terminating workers. Error:", e);
         await Promise.all(workers.map((worker) => worker.terminate()));
         throw e;

--- a/packages/lodestar/test/sim/singleNodeSingleThread.test.ts
+++ b/packages/lodestar/test/sim/singleNodeSingleThread.test.ts
@@ -54,7 +54,7 @@ describe("Run single node single thread interop validators (no eth1) until check
       await Promise.all(validators.map((v) => v.start()));
       try {
         await justificationEventListener;
-      } catch (e) {
+      } catch (e: unknown) {
         await Promise.all(validators.map((v) => v.stop()));
         await bn.close();
         expect(`failed to get event: ${testCase.event}`);

--- a/packages/lodestar/test/unit/api/impl/validator/duties/proposer.test.ts
+++ b/packages/lodestar/test/unit/api/impl/validator/duties/proposer.test.ts
@@ -43,7 +43,7 @@ describe("get proposers api impl", function () {
     try {
       await api.getProposerDuties(1);
       expect.fail("Expect error here");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.message.startsWith("Node is syncing")).to.be.true;
     }
   });
@@ -54,7 +54,7 @@ describe("get proposers api impl", function () {
     try {
       await api.getProposerDuties(1);
       expect.fail("Expect error here");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.message.startsWith("Node is stopped")).to.be.true;
     }
   });

--- a/packages/lodestar/test/unit/chain/attestation/process.test.ts
+++ b/packages/lodestar/test/unit/chain/attestation/process.test.ts
@@ -39,7 +39,7 @@ describe("processAttestation", function () {
         job: {attestation, validSignature: false},
       });
       expect.fail("attestation should throw");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.type.code).to.equal(AttestationErrorCode.TARGET_STATE_MISSING);
     }
   });
@@ -57,7 +57,7 @@ describe("processAttestation", function () {
         job: {attestation, validSignature: false},
       });
       expect.fail("attestation should throw");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.type.code).to.equal(AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX);
     }
   });
@@ -76,7 +76,7 @@ describe("processAttestation", function () {
         job: {attestation, validSignature: false},
       });
       expect.fail("attestation should throw");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.type.code).to.equal(AttestationErrorCode.INVALID_SIGNATURE);
     }
   });

--- a/packages/lodestar/test/unit/chain/attestation/validate.test.ts
+++ b/packages/lodestar/test/unit/chain/attestation/validate.test.ts
@@ -36,7 +36,7 @@ describe("velidateAttestation", function () {
         job: {attestation, validSignature: false},
       });
       expect.fail("attestation should throw");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.type.code).to.equal(AttestationErrorCode.BAD_TARGET_EPOCH);
     }
   });
@@ -55,7 +55,7 @@ describe("velidateAttestation", function () {
         job: {attestation, validSignature: false},
       });
       expect.fail("attestation should throw");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.type.code).to.equal(AttestationErrorCode.PAST_EPOCH);
     }
   });
@@ -74,7 +74,7 @@ describe("velidateAttestation", function () {
         job: {attestation, validSignature: false},
       });
       expect.fail("attestation should throw");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.type.code).to.equal(AttestationErrorCode.FUTURE_EPOCH);
     }
   });
@@ -96,7 +96,7 @@ describe("velidateAttestation", function () {
         job: {attestation, validSignature: false},
       });
       expect.fail("attestation should throw");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.type.code).to.equal(AttestationErrorCode.FUTURE_SLOT);
     }
   });
@@ -119,7 +119,7 @@ describe("velidateAttestation", function () {
         job: {attestation, validSignature: false},
       });
       expect.fail("attestation should throw");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.type.code).to.equal(AttestationErrorCode.UNKNOWN_TARGET_ROOT);
     }
   });
@@ -149,7 +149,7 @@ describe("velidateAttestation", function () {
         job: {attestation, validSignature: false},
       });
       expect.fail("attestation should throw");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.type.code).to.equal(AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT);
     }
   });
@@ -176,7 +176,7 @@ describe("velidateAttestation", function () {
         job: {attestation, validSignature: false},
       });
       expect.fail("attestation should throw");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.type.code).to.equal(AttestationErrorCode.HEAD_NOT_TARGET_DESCENDANT);
     }
   });

--- a/packages/lodestar/test/unit/chain/blocks/process.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/process.test.ts
@@ -41,7 +41,7 @@ describe("processBlock", function () {
         job,
       });
       expect.fail("block should throw");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.type.code).to.equal(BlockErrorCode.PARENT_UNKNOWN);
     }
   });
@@ -61,7 +61,7 @@ describe("processBlock", function () {
         job,
       });
       expect.fail("block should throw");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.type.code).to.equal(BlockErrorCode.PRESTATE_MISSING);
     }
   });

--- a/packages/lodestar/test/unit/chain/blocks/validate.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/validate.test.ts
@@ -28,7 +28,7 @@ describe("validateBlock", function () {
     try {
       validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.type.code).to.equal(BlockErrorCode.GENESIS_BLOCK);
     }
   });
@@ -41,7 +41,7 @@ describe("validateBlock", function () {
     try {
       validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.type.code).to.equal(BlockErrorCode.BLOCK_IS_ALREADY_KNOWN);
     }
   });
@@ -55,7 +55,7 @@ describe("validateBlock", function () {
     try {
       validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.type.code).to.equal(BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT);
     }
   });
@@ -70,7 +70,7 @@ describe("validateBlock", function () {
     try {
       validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.type.code).to.equal(BlockErrorCode.FUTURE_SLOT);
     }
   });

--- a/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
@@ -49,7 +49,7 @@ describe("gossipsub", function () {
     try {
       await gossipSub.validate(message);
       assert.fail("Expect error here");
-    } catch (e) {
+    } catch (e: unknown) {
       expect(e.code).to.be.equal(ERR_TOPIC_VALIDATOR_REJECT);
     }
   });

--- a/packages/lodestar/test/unit/sync/reqResp.test.ts
+++ b/packages/lodestar/test/unit/sync/reqResp.test.ts
@@ -136,7 +136,7 @@ describe("sync req resp", function () {
       for await (const chunk of syncRpc.onRequest(Method.BeaconBlocksByRange, requestBody, peerId)) {
         slots.push((chunk as phase0.SignedBeaconBlock).message.slot);
       }
-    } catch (e) {
+    } catch (e: unknown) {
       console.log({e});
       //
     }

--- a/packages/lodestar/test/unit/util/queue.test.ts
+++ b/packages/lodestar/test/unit/util/queue.test.ts
@@ -40,7 +40,7 @@ describe("Job queue", () => {
     try {
       // the next enqueued job should go over the limit
       await jobQueue.enqueueJob(job);
-    } catch (e) {
+    } catch (e: unknown) {
       assertQueueErrorCode(e, QueueErrorCode.QUEUE_THROTTLED);
     }
 
@@ -70,7 +70,7 @@ describe("Job queue", () => {
     // any subsequently enqueued job should also be rejected
     try {
       await jobQueue.enqueueJob(job);
-    } catch (e) {
+    } catch (e: unknown) {
       assertQueueErrorCode(e, QueueErrorCode.QUEUE_ABORTED);
     }
   });

--- a/packages/lodestar/test/utils/errors.ts
+++ b/packages/lodestar/test/utils/errors.ts
@@ -7,7 +7,7 @@ export function expectThrowsLodestarError(fn: () => any, expectedErr: LodestarEr
     const value = fn();
     const json = JSON.stringify(value, null, 2);
     throw Error(`Expected fn to throw but returned value: \n\n\t${json}`);
-  } catch (e) {
+  } catch (e: unknown) {
     expectLodestarError(e, expectedErr);
   }
 }
@@ -20,7 +20,7 @@ export async function expectRejectedWithLodestarError(
     const value = await promise;
     const json = JSON.stringify(value, null, 2);
     throw Error(`Expected promise to reject but returned value: \n\n\t${json}`);
-  } catch (e) {
+  } catch (e: unknown) {
     if (typeof expectedErr === "string") {
       expectLodestarErrorCode(e, expectedErr);
     } else {

--- a/packages/spec-test-runner/test/spec/bls/aggregate_sigs.test.ts
+++ b/packages/spec-test-runner/test/spec/bls/aggregate_sigs.test.ts
@@ -22,7 +22,7 @@ describeDirectorySpecTest<IAggregateSigsTestCase, string | null>(
         })
       );
       return `0x${Buffer.from(result).toString("hex")}`;
-    } catch (e) {
+    } catch (e: unknown) {
       if (e.message === "signatures is null or undefined or empty array") {
         return null;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10519,10 +10519,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
-  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+prettier@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 private-ip@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
The `e` arg in `} catch (e) {` is typed as `any` effectively ts-ignoring all downstream code that consumes it. Typescript 4.0 allows to type the `e` as unknown https://github.com/microsoft/TypeScript/pull/39015 which is practically the correct type.

**Approach 1: no types at all**
```ts
} catch (e) {
  handleError(e)
}
```

**Approach 2: cast e to Error**
If `handleError` signature changes you will be alerted
```ts
} catch (e: unknown) {
  handleError(e as Error)
}
```

**Approach 3: check for Error**
Probably overkill since the likelyhood of an external library throwing a non-Error instance is extremely low
```ts
} catch (e: unknown) {
  if (e instanceof Error) {
    handleError(e)
  }
}
```

eslint rule [no-implicit-any-catch](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-implicit-any-catch.md) will enforce this pattern

This PR is meant to gauge interest from Lodestar contributors to adopt this type strategy with errors, before actually doing all the changes necessary. I've just bumped prettier to 2.1 to support [type annotations on catch clauses](https://prettier.io/blog/2020/08/24/2.1.0.html#type-annotations-on-catch-clauses-8805httpsgithubcomprettierprettierpull8805-by-fiskerhttpsgithubcomfisker) and run a find and replaces