### PR TITLE
Enable no-unsafe eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,6 +86,10 @@ module.exports = {
     "@typescript-eslint/type-annotation-spacing": "error",
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/explicit-member-accessibility": ["error", {accessibility: "no-public"}],
+    "@typescript-eslint/no-unsafe-assignment": "error",
+    "@typescript-eslint/no-unsafe-call": "error",
+    "@typescript-eslint/no-unsafe-member-access": "error",
+    "@typescript-eslint/no-unsafe-return": "error",
     "import/no-extraneous-dependencies": [
       "error",
       {

--- a/packages/benchmark-utils/src/index.ts
+++ b/packages/benchmark-utils/src/index.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 import fs, {writeFile} from "fs";
 import {BENCH_DIR} from "./constant";
 import Benchmark from "benchmark";

--- a/packages/benchmark-utils/src/index.ts
+++ b/packages/benchmark-utils/src/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import fs, {writeFile} from "fs";
 import {BENCH_DIR} from "./constant";
 import Benchmark from "benchmark";

--- a/packages/lodestar-beacon-state-transition/src/phase0/fast/util/cachedBeaconState.ts
+++ b/packages/lodestar-beacon-state-transition/src/phase0/fast/util/cachedBeaconState.ts
@@ -90,7 +90,7 @@ export const CachedBeaconStateProxyHandler: ProxyHandler<CachedBeaconState<allFo
     } else if (key in target) {
       return target[key as keyof CachedBeaconState<allForks.BeaconState>];
     } else if (key in target.type.tree) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       return (target.type.tree as any)[key].bind(target.type.tree, target.tree);
     } else {
       return undefined;

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/blockHeader.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/blockHeader.test.ts
@@ -1,4 +1,4 @@
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utils from "../../../../src/util";
@@ -13,7 +13,7 @@ import {generateValidator} from "../../../utils/validator";
 describe("process block - block header", function () {
   const sandbox = sinon.createSandbox();
 
-  let getBeaconProposeIndexStub: any;
+  let getBeaconProposeIndexStub: SinonStub;
 
   beforeEach(() => {
     getBeaconProposeIndexStub = sandbox.stub(utils, "getBeaconProposerIndex");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/blockHeader.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/blockHeader.test.ts
@@ -1,4 +1,4 @@
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utils from "../../../../src/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/blockHeader.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/blockHeader.test.ts
@@ -1,4 +1,4 @@
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utils from "../../../../src/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/blockHeader.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/blockHeader.test.ts
@@ -1,4 +1,4 @@
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utils from "../../../../src/util";
@@ -7,13 +7,14 @@ import {processBlockHeader} from "../../../../src/phase0/naive/block";
 import {generateState} from "../../../utils/state";
 import {generateEmptyBlock} from "../../../utils/block";
 import {generateValidator} from "../../../utils/validator";
+import {SinonStubFn} from "../../../utils/types";
 
 /* eslint-disable no-empty */
 
 describe("process block - block header", function () {
   const sandbox = sinon.createSandbox();
 
-  let getBeaconProposeIndexStub: SinonStub;
+  let getBeaconProposeIndexStub: SinonStubFn<typeof utils["getBeaconProposerIndex"]>;
 
   beforeEach(() => {
     getBeaconProposeIndexStub = sandbox.stub(utils, "getBeaconProposerIndex");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/index.test.ts
@@ -1,6 +1,6 @@
 import {generateState} from "../../../utils/state";
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as processEth1Data from "../../../../src/phase0/naive/block/eth1Data";
@@ -13,7 +13,10 @@ import {generateEmptyBlock} from "../../../utils/block";
 describe("process block", function () {
   const sandbox = sinon.createSandbox();
 
-  let processEth1Stub: any, processBlockHeaderStub: any, processRandaoStub: any, processOperationsStub: any;
+  let processEth1Stub: SinonStub,
+    processBlockHeaderStub: SinonStub,
+    processRandaoStub: SinonStub,
+    processOperationsStub: SinonStub;
 
   beforeEach(() => {
     processBlockHeaderStub = sandbox.stub(processBlockHeader, "processBlockHeader");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/index.test.ts
@@ -1,6 +1,6 @@
 import {generateState} from "../../../utils/state";
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as processEth1Data from "../../../../src/phase0/naive/block/eth1Data";
@@ -9,14 +9,15 @@ import * as processRandao from "../../../../src/phase0/naive/block/randao";
 import * as processOperations from "../../../../src/phase0/naive/block/operations";
 import {processBlock} from "../../../../src/phase0/naive";
 import {generateEmptyBlock} from "../../../utils/block";
+import {SinonStubFn} from "../../../utils/types";
 
 describe("process block", function () {
   const sandbox = sinon.createSandbox();
 
-  let processEth1Stub: SinonStub,
-    processBlockHeaderStub: SinonStub,
-    processRandaoStub: SinonStub,
-    processOperationsStub: SinonStub;
+  let processEth1Stub: SinonStubFn<typeof processEth1Data["processEth1Data"]>,
+    processBlockHeaderStub: SinonStubFn<typeof processBlockHeader["processBlockHeader"]>,
+    processRandaoStub: SinonStubFn<typeof processRandao["processRandao"]>,
+    processOperationsStub: SinonStubFn<typeof processOperations["processOperations"]>;
 
   beforeEach(() => {
     processBlockHeaderStub = sandbox.stub(processBlockHeader, "processBlockHeader");
@@ -30,10 +31,10 @@ describe("process block", function () {
   });
 
   it("should process block", function () {
-    processEth1Stub.returns(0);
-    processBlockHeaderStub.returns(0);
-    processRandaoStub.returns(0);
-    processOperationsStub.returns(0);
+    processEth1Stub.returns();
+    processBlockHeaderStub.returns();
+    processRandaoStub.returns();
+    processOperationsStub.returns();
     processBlock(config, generateState(), generateEmptyBlock(), false);
     expect(processEth1Stub.calledOnce).to.be.true;
     expect(processBlockHeaderStub.calledOnce).to.be.true;

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/index.test.ts
@@ -1,6 +1,6 @@
 import {generateState} from "../../../utils/state";
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as processEth1Data from "../../../../src/phase0/naive/block/eth1Data";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/index.test.ts
@@ -1,6 +1,6 @@
 import {generateState} from "../../../utils/state";
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as processEth1Data from "../../../../src/phase0/naive/block/eth1Data";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attestation.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attestation.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {ZERO_HASH} from "../../../../../src/constants";
 import * as utils from "../../../../../src/util";
@@ -10,11 +10,11 @@ import {generateEmptyAttestation} from "../../../../utils/attestation";
 describe("process block - attestation", function () {
   const sandbox = sinon.createSandbox();
 
-  let currentEpochStub: any,
-    previousEpochStub: any,
-    validateIndexedAttestationStub: any,
-    getBeaconProposerIndexStub: any,
-    getBeaconComitteeStub: any;
+  let currentEpochStub: SinonStub,
+    previousEpochStub: SinonStub,
+    validateIndexedAttestationStub: SinonStub,
+    getBeaconProposerIndexStub: SinonStub,
+    getBeaconComitteeStub: SinonStub;
 
   beforeEach(() => {
     currentEpochStub = sandbox.stub(utils, "getCurrentEpoch");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attestation.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attestation.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {ZERO_HASH} from "../../../../../src/constants";
 import * as utils from "../../../../../src/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attestation.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attestation.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {ZERO_HASH} from "../../../../../src/constants";
 import * as utils from "../../../../../src/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attestation.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attestation.test.ts
@@ -1,20 +1,21 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {ZERO_HASH} from "../../../../../src/constants";
 import * as utils from "../../../../../src/util";
 import {phase0} from "../../../../../src";
 import {generateState} from "../../../../utils/state";
 import {generateEmptyAttestation} from "../../../../utils/attestation";
+import {SinonStubFn} from "../../../../utils/types";
 
 describe("process block - attestation", function () {
   const sandbox = sinon.createSandbox();
 
-  let currentEpochStub: SinonStub,
-    previousEpochStub: SinonStub,
-    validateIndexedAttestationStub: SinonStub,
-    getBeaconProposerIndexStub: SinonStub,
-    getBeaconComitteeStub: SinonStub;
+  let currentEpochStub: SinonStubFn<typeof utils["getCurrentEpoch"]>,
+    previousEpochStub: SinonStubFn<typeof utils["getPreviousEpoch"]>,
+    validateIndexedAttestationStub: SinonStubFn<typeof utils["isValidIndexedAttestation"]>,
+    getBeaconProposerIndexStub: SinonStubFn<typeof utils["getBeaconProposerIndex"]>,
+    getBeaconComitteeStub: SinonStubFn<typeof utils["getBeaconCommittee"]>;
 
   beforeEach(() => {
     currentEpochStub = sandbox.stub(utils, "getCurrentEpoch");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attesterSlashing.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attesterSlashing.test.ts
@@ -1,6 +1,6 @@
 import {generateState} from "../../../../utils/state";
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {List} from "@chainsafe/ssz";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utils from "../../../../../src/util";
@@ -10,10 +10,10 @@ import {phase0} from "../../../../../src";
 describe("process block - attester slashings", function () {
   const sandbox = sinon.createSandbox();
 
-  let isSlashableAttestationStub: any,
-    validateIndexedAttestationStub: any,
-    isSlashableValidatorStub: any,
-    slashValidatorStub: any;
+  let isSlashableAttestationStub: SinonStub,
+    validateIndexedAttestationStub: SinonStub,
+    isSlashableValidatorStub: SinonStub,
+    slashValidatorStub: SinonStub;
 
   beforeEach(() => {
     isSlashableAttestationStub = sandbox.stub(utils, "isSlashableAttestationData");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attesterSlashing.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attesterSlashing.test.ts
@@ -1,6 +1,6 @@
 import {generateState} from "../../../../utils/state";
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {List} from "@chainsafe/ssz";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utils from "../../../../../src/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attesterSlashing.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attesterSlashing.test.ts
@@ -1,19 +1,20 @@
 import {generateState} from "../../../../utils/state";
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {List} from "@chainsafe/ssz";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utils from "../../../../../src/util";
 import {generateEmptyAttesterSlashing} from "../../../../utils/slashings";
 import {phase0} from "../../../../../src";
+import {SinonStubFn} from "../../../../utils/types";
 
 describe("process block - attester slashings", function () {
   const sandbox = sinon.createSandbox();
 
-  let isSlashableAttestationStub: SinonStub,
-    validateIndexedAttestationStub: SinonStub,
-    isSlashableValidatorStub: SinonStub,
-    slashValidatorStub: SinonStub;
+  let isSlashableAttestationStub: SinonStubFn<typeof utils["isSlashableAttestationData"]>,
+    validateIndexedAttestationStub: SinonStubFn<typeof utils["isValidIndexedAttestation"]>,
+    isSlashableValidatorStub: SinonStubFn<typeof utils["isSlashableValidator"]>,
+    slashValidatorStub: SinonStubFn<typeof utils["slashValidator"]>;
 
   beforeEach(() => {
     isSlashableAttestationStub = sandbox.stub(utils, "isSlashableAttestationData");
@@ -57,8 +58,8 @@ describe("process block - attester slashings", function () {
     attesterSlashing.attestation1.data.source.epoch = 2;
     attesterSlashing.attestation2.data.source.epoch = 3;
     isSlashableAttestationStub.returns(true);
-    validateIndexedAttestationStub.withArgs(state, attesterSlashing.attestation1).returns(true);
-    validateIndexedAttestationStub.withArgs(state, attesterSlashing.attestation2).returns(false);
+    validateIndexedAttestationStub.withArgs(config, state, attesterSlashing.attestation1).returns(true);
+    validateIndexedAttestationStub.withArgs(config, state, attesterSlashing.attestation2).returns(false);
     try {
       phase0.processAttesterSlashing(config, state, attesterSlashing);
       expect.fail();

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attesterSlashing.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/attesterSlashing.test.ts
@@ -1,6 +1,6 @@
 import {generateState} from "../../../../utils/state";
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {List} from "@chainsafe/ssz";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utils from "../../../../../src/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/deposit.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/deposit.test.ts
@@ -8,11 +8,15 @@ import {bigIntMin, intToBytes, assert} from "@chainsafe/lodestar-utils";
 import {generateState} from "../../../../utils/state";
 import {generateDeposit} from "../../../../utils/deposit";
 import {generateValidator} from "../../../../utils/validator";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {phase0} from "@chainsafe/lodestar-types";
 
 describe("process block - deposits", function () {
   const sandbox = sinon.createSandbox();
   const verifyMerkleBranchStub = sinon.stub();
-  let processDeposit: any, getTemporaryBlockHeaderStub, getBeaconProposeIndexStub;
+  let processDeposit: (config: IBeaconConfig, state: phase0.BeaconState, deposit: phase0.Deposit) => void,
+    getTemporaryBlockHeaderStub,
+    getBeaconProposeIndexStub;
   const blsStub = sinon.stub();
 
   before(function () {

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/index.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {List} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/mainnet";
@@ -22,11 +22,11 @@ import {generateEmptySignedVoluntaryExit} from "../../../../utils/voluntaryExits
 describe("process block - process operations", function () {
   const sandbox = sinon.createSandbox();
 
-  let processProposerSlashingStub: any,
-    processAttesterSlashingStub: any,
-    processAttestationStub: any,
-    processDepositStub: any,
-    processVoluntaryExitStub: any;
+  let processProposerSlashingStub: SinonStub,
+    processAttesterSlashingStub: SinonStub,
+    processAttestationStub: SinonStub,
+    processDepositStub: SinonStub,
+    processVoluntaryExitStub: SinonStub;
 
   beforeEach(() => {
     processProposerSlashingStub = sandbox.stub(processProposerSlashing, "processProposerSlashing");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/index.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {List} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/mainnet";
@@ -16,17 +16,18 @@ import {generateDeposit} from "../../../../utils/deposit";
 import {generateEmptyAttesterSlashing, generateEmptyProposerSlashing} from "../../../../utils/slashings";
 import {generateEmptyAttestation} from "../../../../utils/attestation";
 import {generateEmptySignedVoluntaryExit} from "../../../../utils/voluntaryExits";
+import {SinonStubFn} from "../../../../utils/types";
 
 /* eslint-disable no-empty */
 
 describe("process block - process operations", function () {
   const sandbox = sinon.createSandbox();
 
-  let processProposerSlashingStub: SinonStub,
-    processAttesterSlashingStub: SinonStub,
-    processAttestationStub: SinonStub,
-    processDepositStub: SinonStub,
-    processVoluntaryExitStub: SinonStub;
+  let processProposerSlashingStub: SinonStubFn<typeof processProposerSlashing["processProposerSlashing"]>,
+    processAttesterSlashingStub: SinonStubFn<typeof processAttesterSlashing["processAttesterSlashing"]>,
+    processAttestationStub: SinonStubFn<typeof processAttestation["processAttestation"]>,
+    processDepositStub: SinonStubFn<typeof processDeposit["processDeposit"]>,
+    processVoluntaryExitStub: SinonStubFn<typeof processVoluntaryExit["processVoluntaryExit"]>;
 
   beforeEach(() => {
     processProposerSlashingStub = sandbox.stub(processProposerSlashing, "processProposerSlashing");
@@ -74,7 +75,7 @@ describe("process block - process operations", function () {
   it("should fail to process operations - attesterSlashings length  exceed maxAttesterSlashings", function () {
     const state = generateState();
     const body = generateEmptyBlock().body;
-    processProposerSlashingStub.returns(0);
+    processProposerSlashingStub.returns();
     body.attesterSlashings = Array.from({length: config.params.MAX_ATTESTER_SLASHINGS + 1}, () =>
       config.types.phase0.AttesterSlashing.defaultValue()
     ) as List<phase0.AttesterSlashing>;
@@ -90,8 +91,8 @@ describe("process block - process operations", function () {
   it("should fail to process operations - attestation length  exceed maxAttestation", function () {
     const state = generateState();
     const body = generateEmptyBlock().body;
-    processProposerSlashingStub.returns(0);
-    processAttesterSlashingStub.returns(0);
+    processProposerSlashingStub.returns();
+    processAttesterSlashingStub.returns();
     body.attestations = Array.from({length: config.params.MAX_ATTESTATIONS + 1}, () =>
       config.types.phase0.Attestation.defaultValue()
     ) as List<phase0.Attestation>;
@@ -123,10 +124,10 @@ describe("process block - process operations", function () {
   it("should fail to process operations - voluntaryExit length  exceed maxVoluntaryExit", function () {
     const state = generateState();
     const body = generateEmptyBlock().body;
-    processProposerSlashingStub.returns(0);
-    processAttesterSlashingStub.returns(0);
-    processAttestationStub.returns(0);
-    processDepositStub.returns(0);
+    processProposerSlashingStub.returns();
+    processAttesterSlashingStub.returns();
+    processAttestationStub.returns();
+    processDepositStub.returns();
     body.voluntaryExits = Array.from({length: config.params.MAX_VOLUNTARY_EXITS + 1}, () =>
       config.types.phase0.SignedVoluntaryExit.defaultValue()
     ) as List<phase0.SignedVoluntaryExit>;
@@ -150,11 +151,11 @@ describe("process block - process operations", function () {
   it("should fail to process operations - transfer length  exceed maxTransfer", function () {
     const state = generateState();
     const body = generateEmptyBlock().body;
-    processProposerSlashingStub.returns(0);
-    processAttesterSlashingStub.returns(0);
-    processAttestationStub.returns(0);
-    processDepositStub.returns(0);
-    processVoluntaryExitStub.returns(0);
+    processProposerSlashingStub.returns();
+    processAttesterSlashingStub.returns();
+    processAttestationStub.returns();
+    processDepositStub.returns();
+    processVoluntaryExitStub.returns();
     body.proposerSlashings.push(generateEmptyProposerSlashing());
     body.attesterSlashings.push(generateEmptyAttesterSlashing());
     body.attestations.push(generateEmptyAttestation());
@@ -177,11 +178,11 @@ describe("process block - process operations", function () {
   it("should  process operations ", function () {
     const state = generateState();
     const body = generateEmptyBlock().body;
-    processProposerSlashingStub.returns(0);
-    processAttesterSlashingStub.returns(0);
-    processAttestationStub.returns(0);
-    processDepositStub.returns(0);
-    processVoluntaryExitStub.returns(0);
+    processProposerSlashingStub.returns();
+    processAttesterSlashingStub.returns();
+    processAttestationStub.returns();
+    processDepositStub.returns();
+    processVoluntaryExitStub.returns();
     body.proposerSlashings.push(generateEmptyProposerSlashing());
     body.attesterSlashings.push(generateEmptyAttesterSlashing());
     body.attestations.push(generateEmptyAttestation());

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/index.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {List} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/mainnet";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/index.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {List} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/mainnet";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/proposerSlashings.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/proposerSlashings.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {processProposerSlashing} from "../../../../../src/phase0/naive/block/operations";
 import * as utils from "../../../../../src/util";
@@ -13,7 +13,7 @@ import {generateState} from "../../../../utils/state";
 describe("process block - proposer slashings", function () {
   const sandbox = sinon.createSandbox();
 
-  let isSlashableValidatorStub: any, slashValidatorStub: any;
+  let isSlashableValidatorStub: SinonStub, slashValidatorStub: SinonStub;
 
   beforeEach(() => {
     isSlashableValidatorStub = sandbox.stub(validatorUtils, "isSlashableValidator");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/proposerSlashings.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/proposerSlashings.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {processProposerSlashing} from "../../../../../src/phase0/naive/block/operations";
 import * as utils from "../../../../../src/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/proposerSlashings.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/proposerSlashings.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {processProposerSlashing} from "../../../../../src/phase0/naive/block/operations";
 import * as utils from "../../../../../src/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/proposerSlashings.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/proposerSlashings.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {processProposerSlashing} from "../../../../../src/phase0/naive/block/operations";
 import * as utils from "../../../../../src/util";
@@ -7,13 +7,15 @@ import * as validatorUtils from "../../../../../src/util/validator";
 import {generateEmptyProposerSlashing} from "../../../../utils/slashings";
 import {generateValidators} from "../../../../utils/validator";
 import {generateState} from "../../../../utils/state";
+import {SinonStubFn} from "../../../../utils/types";
 
 /* eslint-disable no-empty */
 
 describe("process block - proposer slashings", function () {
   const sandbox = sinon.createSandbox();
 
-  let isSlashableValidatorStub: SinonStub, slashValidatorStub: SinonStub;
+  let isSlashableValidatorStub: SinonStubFn<typeof validatorUtils["isSlashableValidator"]>,
+    slashValidatorStub: SinonStubFn<typeof utils["slashValidator"]>;
 
   beforeEach(() => {
     isSlashableValidatorStub = sandbox.stub(validatorUtils, "isSlashableValidator");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/voluntaryExit.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/voluntaryExit.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {FAR_FUTURE_EPOCH} from "../../../../../src/constants";
 import * as utils from "../../../../../src/util";
@@ -13,7 +13,7 @@ import {generateState} from "../../../../utils/state";
 describe("process block - voluntary exits", function () {
   const sandbox = sinon.createSandbox();
 
-  let isActiveValidatorStub: any, initiateValidatorExitStub: any;
+  let isActiveValidatorStub: SinonStub, initiateValidatorExitStub: SinonStub;
 
   beforeEach(() => {
     isActiveValidatorStub = sandbox.stub(validatorUtils, "isActiveValidator");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/voluntaryExit.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/voluntaryExit.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {FAR_FUTURE_EPOCH} from "../../../../../src/constants";
 import * as utils from "../../../../../src/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/voluntaryExit.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/voluntaryExit.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {FAR_FUTURE_EPOCH} from "../../../../../src/constants";
 import * as utils from "../../../../../src/util";
@@ -9,11 +9,13 @@ import {processVoluntaryExit} from "../../../../../src/phase0/naive/block/operat
 import {generateValidator} from "../../../../utils/validator";
 import {generateEmptySignedVoluntaryExit} from "../../../../utils/voluntaryExits";
 import {generateState} from "../../../../utils/state";
+import {SinonStubFn} from "../../../../utils/types";
 
 describe("process block - voluntary exits", function () {
   const sandbox = sinon.createSandbox();
 
-  let isActiveValidatorStub: SinonStub, initiateValidatorExitStub: SinonStub;
+  let isActiveValidatorStub: SinonStubFn<typeof validatorUtils["isActiveValidator"]>,
+    initiateValidatorExitStub: SinonStubFn<typeof utils["initiateValidatorExit"]>;
 
   beforeEach(() => {
     isActiveValidatorStub = sandbox.stub(validatorUtils, "isActiveValidator");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/voluntaryExit.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/operations/voluntaryExit.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {FAR_FUTURE_EPOCH} from "../../../../../src/constants";
 import * as utils from "../../../../../src/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/randao.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/randao.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {processRandao} from "../../../../src/phase0/naive/block";
 import * as utils from "../../../../src/util";
@@ -11,7 +11,7 @@ import {generateValidators} from "../../../utils/validator";
 describe.skip("process block - randao", function () {
   const sandbox = sinon.createSandbox();
 
-  let getBeaconProposerStub: any;
+  let getBeaconProposerStub: SinonStub;
 
   beforeEach(() => {
     getBeaconProposerStub = sandbox.stub(utils, "getBeaconProposerIndex");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/randao.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/randao.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {processRandao} from "../../../../src/phase0/naive/block";
 import * as utils from "../../../../src/util";
@@ -7,11 +7,12 @@ import {getCurrentEpoch} from "../../../../src/util";
 import {generateEmptyBlock} from "../../../utils/block";
 import {generateState} from "../../../utils/state";
 import {generateValidators} from "../../../utils/validator";
+import {SinonStubFn} from "../../../utils/types";
 
 describe.skip("process block - randao", function () {
   const sandbox = sinon.createSandbox();
 
-  let getBeaconProposerStub: SinonStub;
+  let getBeaconProposerStub: SinonStubFn<typeof utils["getBeaconProposerIndex"]>;
 
   beforeEach(() => {
     getBeaconProposerStub = sandbox.stub(utils, "getBeaconProposerIndex");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/randao.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/randao.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {processRandao} from "../../../../src/phase0/naive/block";
 import * as utils from "../../../../src/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/randao.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/block/randao.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {processRandao} from "../../../../src/phase0/naive/block";
 import * as utils from "../../../../src/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/attestation.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/attestation.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utilsEpoch from "../../../../../src/phase0/naive/epoch/util";
@@ -14,16 +14,16 @@ import {generateEmptyAttestation} from "../../../../utils/attestation";
 describe.skip("process epoch - balance updates", function () {
   const sandbox = sinon.createSandbox();
 
-  let getAttestingBalanceStub: any,
-    getMatchingHeadAttestationsStub: any,
-    getMatchingSourceAttestationsStub: any,
-    getMatchingTargetAttestationsStub: any,
-    getTotalActiveBalanceStub: any,
-    getUnslashedAttestingIndicesStub: any,
-    getBaseRewardStub: any,
-    getAttestingIndicesStub: any,
-    getPreviousEpochStub: any,
-    isActiveValidatorStub: any;
+  let getAttestingBalanceStub: SinonStub,
+    getMatchingHeadAttestationsStub: SinonStub,
+    getMatchingSourceAttestationsStub: SinonStub,
+    getMatchingTargetAttestationsStub: SinonStub,
+    getTotalActiveBalanceStub: SinonStub,
+    getUnslashedAttestingIndicesStub: SinonStub,
+    getBaseRewardStub: SinonStub,
+    getAttestingIndicesStub: SinonStub,
+    getPreviousEpochStub: SinonStub,
+    isActiveValidatorStub: SinonStub;
 
   beforeEach(() => {
     getAttestingBalanceStub = sandbox.stub(utilsEpoch, "getAttestingBalance");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/attestation.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/attestation.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utilsEpoch from "../../../../../src/phase0/naive/epoch/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/attestation.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/attestation.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utilsEpoch from "../../../../../src/phase0/naive/epoch/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/attestation.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/attestation.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utilsEpoch from "../../../../../src/phase0/naive/epoch/util";
@@ -10,20 +10,21 @@ import {generateState} from "../../../../utils/state";
 import {generateValidators} from "../../../../utils/validator";
 import {getAttestationDeltas} from "../../../../../src/phase0/naive/epoch/balanceUpdates/attestation";
 import {generateEmptyAttestation} from "../../../../utils/attestation";
+import {SinonStubFn} from "../../../../utils/types";
 
 describe.skip("process epoch - balance updates", function () {
   const sandbox = sinon.createSandbox();
 
-  let getAttestingBalanceStub: SinonStub,
-    getMatchingHeadAttestationsStub: SinonStub,
-    getMatchingSourceAttestationsStub: SinonStub,
-    getMatchingTargetAttestationsStub: SinonStub,
-    getTotalActiveBalanceStub: SinonStub,
-    getUnslashedAttestingIndicesStub: SinonStub,
-    getBaseRewardStub: SinonStub,
-    getAttestingIndicesStub: SinonStub,
-    getPreviousEpochStub: SinonStub,
-    isActiveValidatorStub: SinonStub;
+  let getAttestingBalanceStub: SinonStubFn<typeof utilsEpoch["getAttestingBalance"]>,
+    getMatchingHeadAttestationsStub: SinonStubFn<typeof utilsEpoch["getMatchingHeadAttestations"]>,
+    getMatchingSourceAttestationsStub: SinonStubFn<typeof utilsEpoch["getMatchingSourceAttestations"]>,
+    getMatchingTargetAttestationsStub: SinonStubFn<typeof utilsEpoch["getMatchingTargetAttestations"]>,
+    getTotalActiveBalanceStub: SinonStubFn<typeof utils["getTotalActiveBalance"]>,
+    getUnslashedAttestingIndicesStub: SinonStubFn<typeof utilsEpoch["getUnslashedAttestingIndices"]>,
+    getBaseRewardStub: SinonStubFn<typeof baseReward["getBaseReward"]>,
+    getAttestingIndicesStub: SinonStubFn<typeof utils["getAttestingIndices"]>,
+    getPreviousEpochStub: SinonStubFn<typeof utils["getPreviousEpoch"]>,
+    isActiveValidatorStub: SinonStubFn<typeof utils["isActiveValidator"]>;
 
   beforeEach(() => {
     getAttestingBalanceStub = sandbox.stub(utilsEpoch, "getAttestingBalance");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/index.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utils from "../../../../../src/util";
@@ -11,7 +11,10 @@ import {generateState} from "../../../../utils/state";
 
 describe("process epoch - balance updates", function () {
   const sandbox = sinon.createSandbox();
-  let getCurrentEpochStub: any, getAttestationDeltasStub: any, increaseBalanceStub: any, decreaseBalanceStub: any;
+  let getCurrentEpochStub: SinonStub,
+    getAttestationDeltasStub: SinonStub,
+    increaseBalanceStub: SinonStub,
+    decreaseBalanceStub: SinonStub;
 
   beforeEach(() => {
     getCurrentEpochStub = sandbox.stub(utils, "getCurrentEpoch");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/index.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utils from "../../../../../src/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/index.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utils from "../../../../../src/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/index.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utils from "../../../../../src/util";
@@ -8,13 +8,14 @@ import {processRewardsAndPenalties} from "../../../../../src/phase0/naive/epoch/
 import * as attestationDeltas from "../../../../../src/phase0/naive/epoch/balanceUpdates/attestation";
 import {generateValidator} from "../../../../utils/validator";
 import {generateState} from "../../../../utils/state";
+import {SinonStubFn} from "../../../../utils/types";
 
 describe("process epoch - balance updates", function () {
   const sandbox = sinon.createSandbox();
-  let getCurrentEpochStub: SinonStub,
-    getAttestationDeltasStub: SinonStub,
-    increaseBalanceStub: SinonStub,
-    decreaseBalanceStub: SinonStub;
+  let getCurrentEpochStub: SinonStubFn<typeof utils["getCurrentEpoch"]>,
+    getAttestationDeltasStub: SinonStubFn<typeof attestationDeltas["getAttestationDeltas"]>,
+    increaseBalanceStub: SinonStubFn<typeof utils["increaseBalance"]>,
+    decreaseBalanceStub: SinonStubFn<typeof utils["decreaseBalance"]>;
 
   beforeEach(() => {
     getCurrentEpochStub = sandbox.stub(utils, "getCurrentEpoch");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/util.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/util.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utils from "../../../../../src/util";
@@ -11,7 +11,7 @@ import {BASE_REWARDS_PER_EPOCH} from "../../../../../src/constants";
 
 describe.skip("process epoch - balance updates", function () {
   const sandbox = sinon.createSandbox();
-  let getTotalActiveBalanceStub: any;
+  let getTotalActiveBalanceStub: SinonStub;
 
   beforeEach(() => {
     getTotalActiveBalanceStub = sandbox.stub(utils, "getTotalActiveBalance");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/util.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/util.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utils from "../../../../../src/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/util.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/util.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utils from "../../../../../src/util";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/util.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/balanceUpdates/util.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import * as utils from "../../../../../src/util";
@@ -8,10 +8,11 @@ import {generateValidators} from "../../../../utils/validator";
 import {getBaseReward} from "../../../../../src/phase0/naive/epoch/balanceUpdates/util";
 import {bigIntSqrt} from "@chainsafe/lodestar-utils";
 import {BASE_REWARDS_PER_EPOCH} from "../../../../../src/constants";
+import {SinonStubFn} from "../../../../utils/types";
 
 describe.skip("process epoch - balance updates", function () {
   const sandbox = sinon.createSandbox();
-  let getTotalActiveBalanceStub: SinonStub;
+  let getTotalActiveBalanceStub: SinonStubFn<typeof utils["getTotalActiveBalance"]>;
 
   beforeEach(() => {
     getTotalActiveBalanceStub = sandbox.stub(utils, "getTotalActiveBalance");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/index.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {GENESIS_SLOT} from "../../../../src/constants";
@@ -15,10 +15,10 @@ import {generateState} from "../../../utils/state";
 describe("process epoch - crosslinks", function () {
   const sandbox = sinon.createSandbox();
 
-  let processJustificationAndFinalizationStub: any,
-    processRewardsAndPenaltiesStub: any,
-    processRegistryUpdatesStub: any,
-    processSlashingsStub: any;
+  let processJustificationAndFinalizationStub: SinonStub,
+    processRewardsAndPenaltiesStub: SinonStub,
+    processRegistryUpdatesStub: SinonStub,
+    processSlashingsStub: SinonStub;
 
   beforeEach(() => {
     processJustificationAndFinalizationStub = sandbox.stub(justificationUtils, "processJustificationAndFinalization");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/index.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {GENESIS_SLOT} from "../../../../src/constants";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/index.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {GENESIS_SLOT} from "../../../../src/constants";
@@ -9,16 +9,19 @@ import * as balanceUpdateUtils from "../../../../src/phase0/naive/epoch/balanceU
 import * as registryUpdateUtils from "../../../../src/phase0/naive/epoch/registryUpdates";
 import * as slashingUtils from "../../../../src/phase0/naive/epoch/slashings";
 import {generateState} from "../../../utils/state";
+import {SinonStubFn} from "../../../utils/types";
 
 /* eslint-disable no-empty */
 
 describe("process epoch - crosslinks", function () {
   const sandbox = sinon.createSandbox();
 
-  let processJustificationAndFinalizationStub: SinonStub,
-    processRewardsAndPenaltiesStub: SinonStub,
-    processRegistryUpdatesStub: SinonStub,
-    processSlashingsStub: SinonStub;
+  let processJustificationAndFinalizationStub: SinonStubFn<
+      typeof justificationUtils["processJustificationAndFinalization"]
+    >,
+    processRewardsAndPenaltiesStub: SinonStubFn<typeof balanceUpdateUtils["processRewardsAndPenalties"]>,
+    processRegistryUpdatesStub: SinonStubFn<typeof registryUpdateUtils["processRegistryUpdates"]>,
+    processSlashingsStub: SinonStubFn<typeof slashingUtils["processSlashings"]>;
 
   beforeEach(() => {
     processJustificationAndFinalizationStub = sandbox.stub(justificationUtils, "processJustificationAndFinalization");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/index.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/index.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {GENESIS_SLOT} from "../../../../src/constants";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/justification.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/justification.test.ts
@@ -1,4 +1,4 @@
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {expect} from "chai";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
@@ -10,12 +10,12 @@ import {processJustificationAndFinalization} from "../../../../src/phase0/naive/
 describe.skip("process epoch - justification and finalization", function () {
   const sandbox = sinon.createSandbox();
 
-  let getBlockRootStub: any,
-    getCurrentEpochStub: any,
-    getPreviousEpochStub: any,
-    getAttestingBalanceStub: any,
-    getMatchingTargetAttestationsStub: any,
-    getTotalActiveBalanceStub: any;
+  let getBlockRootStub: SinonStub,
+    getCurrentEpochStub: SinonStub,
+    getPreviousEpochStub: SinonStub,
+    getAttestingBalanceStub: SinonStub,
+    getMatchingTargetAttestationsStub: SinonStub,
+    getTotalActiveBalanceStub: SinonStub;
 
   beforeEach(() => {
     getBlockRootStub = sandbox.stub(utils1, "getBlockRoot");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/justification.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/justification.test.ts
@@ -1,4 +1,4 @@
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {expect} from "chai";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";
@@ -6,16 +6,17 @@ import * as utils1 from "../../../../src/util";
 import * as utils2 from "../../../../src/phase0/naive/epoch/util";
 import {generateState} from "../../../utils/state";
 import {processJustificationAndFinalization} from "../../../../src/phase0/naive/epoch/justification";
+import {SinonStubFn} from "../../../utils/types";
 
 describe.skip("process epoch - justification and finalization", function () {
   const sandbox = sinon.createSandbox();
 
-  let getBlockRootStub: SinonStub,
-    getCurrentEpochStub: SinonStub,
-    getPreviousEpochStub: SinonStub,
-    getAttestingBalanceStub: SinonStub,
-    getMatchingTargetAttestationsStub: SinonStub,
-    getTotalActiveBalanceStub: SinonStub;
+  let getBlockRootStub: SinonStubFn<typeof utils1["getBlockRoot"]>,
+    getCurrentEpochStub: SinonStubFn<typeof utils1["getCurrentEpoch"]>,
+    getPreviousEpochStub: SinonStubFn<typeof utils1["getPreviousEpoch"]>,
+    getAttestingBalanceStub: SinonStubFn<typeof utils2["getAttestingBalance"]>,
+    getMatchingTargetAttestationsStub: SinonStubFn<typeof utils2["getMatchingTargetAttestations"]>,
+    getTotalActiveBalanceStub: SinonStubFn<typeof utils1["getTotalActiveBalance"]>;
 
   beforeEach(() => {
     getBlockRootStub = sandbox.stub(utils1, "getBlockRoot");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/justification.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/justification.test.ts
@@ -1,4 +1,4 @@
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {expect} from "chai";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/justification.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/justification.test.ts
@@ -1,4 +1,4 @@
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {expect} from "chai";
 
 import {config} from "@chainsafe/lodestar-config/mainnet";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/registryUpdates.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/registryUpdates.test.ts
@@ -1,4 +1,4 @@
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {expect} from "chai";
 
 import {List} from "@chainsafe/ssz";
@@ -12,7 +12,7 @@ import {generateValidator} from "../../../utils/validator";
 describe.skip("process epoch - slashings", function () {
   const sandbox = sinon.createSandbox();
 
-  let getCurrentEpochStub: any, isActiveValidatorStub: any, initiateValidatorExitStub: any;
+  let getCurrentEpochStub: SinonStub, isActiveValidatorStub: SinonStub, initiateValidatorExitStub: SinonStub;
 
   beforeEach(() => {
     getCurrentEpochStub = sandbox.stub(utils, "getCurrentEpoch");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/registryUpdates.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/registryUpdates.test.ts
@@ -1,4 +1,4 @@
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {expect} from "chai";
 
 import {List} from "@chainsafe/ssz";
@@ -8,11 +8,14 @@ import * as utils from "../../../../src/util";
 import {processRegistryUpdates} from "../../../../src/phase0/naive/epoch/registryUpdates";
 import {generateState} from "../../../utils/state";
 import {generateValidator} from "../../../utils/validator";
+import {SinonStubFn} from "../../../utils/types";
 
 describe.skip("process epoch - slashings", function () {
   const sandbox = sinon.createSandbox();
 
-  let getCurrentEpochStub: SinonStub, isActiveValidatorStub: SinonStub, initiateValidatorExitStub: SinonStub;
+  let getCurrentEpochStub: SinonStubFn<typeof utils["getCurrentEpoch"]>,
+    isActiveValidatorStub: SinonStubFn<typeof utils["isActiveValidator"]>,
+    initiateValidatorExitStub: SinonStubFn<typeof utils["initiateValidatorExit"]>;
 
   beforeEach(() => {
     getCurrentEpochStub = sandbox.stub(utils, "getCurrentEpoch");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/registryUpdates.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/registryUpdates.test.ts
@@ -1,4 +1,4 @@
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {expect} from "chai";
 
 import {List} from "@chainsafe/ssz";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/registryUpdates.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/registryUpdates.test.ts
@@ -1,4 +1,4 @@
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {expect} from "chai";
 
 import {List} from "@chainsafe/ssz";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/slashing.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/slashing.test.ts
@@ -1,4 +1,4 @@
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {expect} from "chai";
 import {List} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
@@ -13,7 +13,7 @@ import {intDiv} from "@chainsafe/lodestar-utils";
 describe.skip("process epoch - slashings", function () {
   const sandbox = sinon.createSandbox();
 
-  let getCurrentEpochStub: any, getTotalBalanceStub: any, decreaseBalanceStub: any;
+  let getCurrentEpochStub: SinonStub, getTotalBalanceStub: SinonStub, decreaseBalanceStub: SinonStub;
 
   beforeEach(() => {
     getCurrentEpochStub = sandbox.stub(utils, "getCurrentEpoch");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/slashing.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/slashing.test.ts
@@ -1,4 +1,4 @@
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {expect} from "chai";
 import {List} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
@@ -9,11 +9,14 @@ import {processSlashings} from "../../../../src/phase0/naive/epoch/slashings";
 import {generateState} from "../../../utils/state";
 import {generateValidator} from "../../../utils/validator";
 import {intDiv} from "@chainsafe/lodestar-utils";
+import {SinonStubFn} from "../../../utils/types";
 
 describe.skip("process epoch - slashings", function () {
   const sandbox = sinon.createSandbox();
 
-  let getCurrentEpochStub: SinonStub, getTotalBalanceStub: SinonStub, decreaseBalanceStub: SinonStub;
+  let getCurrentEpochStub: SinonStubFn<typeof utils["getCurrentEpoch"]>,
+    getTotalBalanceStub: SinonStubFn<typeof utils["getTotalBalance"]>,
+    decreaseBalanceStub: SinonStubFn<typeof utils["decreaseBalance"]>;
 
   beforeEach(() => {
     getCurrentEpochStub = sandbox.stub(utils, "getCurrentEpoch");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/slashing.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/slashing.test.ts
@@ -1,4 +1,4 @@
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import {expect} from "chai";
 import {List} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/slashing.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/slashing.test.ts
@@ -1,4 +1,4 @@
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {expect} from "chai";
 import {List} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/util.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/util.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 
 import {List} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
@@ -20,11 +20,11 @@ import {generateState} from "../../../utils/state";
 describe("process epoch - crosslinks", function () {
   const sandbox = sinon.createSandbox();
 
-  let getActiveValidatorIndicesStub: any,
-    getTotalBalanceStub: any,
-    getBlockRootStub: any,
-    getBlockRootAtSlotStub: any,
-    getAttestingIndicesStub: any;
+  let getActiveValidatorIndicesStub: SinonStub,
+    getTotalBalanceStub: SinonStub,
+    getBlockRootStub: SinonStub,
+    getBlockRootAtSlotStub: SinonStub,
+    getAttestingIndicesStub: SinonStub;
 
   beforeEach(() => {
     getActiveValidatorIndicesStub = sandbox.stub(utils, "getActiveValidatorIndices");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/util.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/util.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 
 import {List} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/util.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/util.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 
 import {List} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
@@ -16,15 +16,16 @@ import {FAR_FUTURE_EPOCH} from "../../../../src/constants";
 import {generateEmptyAttestation} from "../../../utils/attestation";
 import {generateValidator} from "../../../utils/validator";
 import {generateState} from "../../../utils/state";
+import {SinonStubFn} from "../../../utils/types";
 
 describe("process epoch - crosslinks", function () {
   const sandbox = sinon.createSandbox();
 
-  let getActiveValidatorIndicesStub: SinonStub,
-    getTotalBalanceStub: SinonStub,
-    getBlockRootStub: SinonStub,
-    getBlockRootAtSlotStub: SinonStub,
-    getAttestingIndicesStub: SinonStub;
+  let getActiveValidatorIndicesStub: SinonStubFn<typeof utils["getActiveValidatorIndices"]>,
+    getTotalBalanceStub: SinonStubFn<typeof utils["getTotalBalance"]>,
+    getBlockRootStub: SinonStubFn<typeof utils["getBlockRoot"]>,
+    getBlockRootAtSlotStub: SinonStubFn<typeof utils["getBlockRootAtSlot"]>,
+    getAttestingIndicesStub: SinonStubFn<typeof utils["getAttestingIndices"]>;
 
   beforeEach(() => {
     getActiveValidatorIndicesStub = sandbox.stub(utils, "getActiveValidatorIndices");

--- a/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/util.test.ts
+++ b/packages/lodestar-beacon-state-transition/test/unit/stateTransition/epoch/util.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 
 import {List} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";

--- a/packages/lodestar-beacon-state-transition/test/utils/types.ts
+++ b/packages/lodestar-beacon-state-transition/test/utils/types.ts
@@ -1,0 +1,5 @@
+import {SinonStub} from "sinon";
+
+export type SinonStubFn<T extends (...args: any[]) => any> = T extends (...args: infer TArgs) => infer TReturnValue
+  ? SinonStub<TArgs, TReturnValue>
+  : never;

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/import.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/import.ts
@@ -157,7 +157,7 @@ async function getKeystorePassphrase(keystore: Keystore, passphrasePaths: string
       console.log(`Imported passphrase ${passphraseFile}`);
       return passphrase;
     } catch (e) {
-      console.log(`Imported passphrase ${passphraseFile}, but it's invalid: ${e.message}`);
+      console.log(`Imported passphrase ${passphraseFile}, but it's invalid: ${(e as Error).message}`);
     }
   }
 
@@ -177,7 +177,7 @@ required each time the validator client starts
           await keystore.decrypt(stripOffNewlines(input));
           return true;
         } catch (e) {
-          return `Invalid password: ${e.message}`;
+          return `Invalid password: ${(e as Error).message}`;
         }
       },
     },

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/import.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/slashingProtection/import.ts
@@ -4,6 +4,7 @@ import {IGlobalArgs} from "../../../../../options";
 import {IAccountValidatorArgs} from "../options";
 import {ISlashingProtectionArgs} from "./options";
 import {getGenesisValidatorsRoot, getSlashingProtection} from "./utils";
+import {IInterchangeCompleteV4} from "@chainsafe/lodestar-validator/lib/slashingProtection/interchange/formats/completeV4";
 
 /* eslint-disable no-console */
 
@@ -36,7 +37,7 @@ export const importCmd: ICliCommand<IImportArgs, ISlashingProtectionArgs & IAcco
     const slashingProtection = getSlashingProtection(args);
 
     const importFile = await fs.promises.readFile(args.file, "utf8");
-    const importFileJson = JSON.parse(importFile);
+    const importFileJson = JSON.parse(importFile) as IInterchangeCompleteV4;
     await slashingProtection.importInterchange(importFileJson, genesisValidatorsRoot);
 
     console.log("Import completed successfully");

--- a/packages/lodestar-cli/src/cmds/account/cmds/validator/voluntaryExit.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/validator/voluntaryExit.ts
@@ -58,7 +58,7 @@ like to choose for the voluntary exit.",
     if (!publicKey) {
       const publicKeys = readdirSync(accountPaths.keystoresDir);
 
-      const validator = await inquirer.prompt([
+      const validator = await inquirer.prompt<{publicKey: string}>([
         {
           name: "publicKey",
           type: "list",
@@ -69,7 +69,7 @@ like to choose for the voluntary exit.",
       publicKey = validator.publicKey;
     }
 
-    const confirmation = await inquirer.prompt([
+    const confirmation = await inquirer.prompt<{choice: string}>([
       {
         name: "choice",
         type: "list",

--- a/packages/lodestar-cli/src/cmds/account/cmds/wallet/recover.ts
+++ b/packages/lodestar-cli/src/cmds/account/cmds/wallet/recover.ts
@@ -42,7 +42,7 @@ export const recover: ICliCommand<IWalletRecoverArgs, IGlobalArgs, ReturnType> =
     if (mnemonicInputPath) {
       mnemonic = await fs.promises.readFile(mnemonicInputPath, "utf8");
     } else {
-      const input = await inquirer.prompt([
+      const input = await inquirer.prompt<{mnemonic: string}>([
         {
           name: "mnemonic",
           type: "input",

--- a/packages/lodestar-cli/src/cmds/init/handler.ts
+++ b/packages/lodestar-cli/src/cmds/init/handler.ts
@@ -44,7 +44,7 @@ export async function initializeOptionsAndConfig(args: IBeaconArgs & IGlobalArgs
       beaconNodeOptions.set({network: {discv5: {bootEnrs}}});
     } catch (e) {
       // eslint-disable-next-line no-console
-      console.error(`Error fetching latest bootnodes: ${e.stack}`);
+      console.error(`Error fetching latest bootnodes: ${(e as Error).stack}`);
     }
   }
 

--- a/packages/lodestar-cli/src/config/enr.ts
+++ b/packages/lodestar-cli/src/config/enr.ts
@@ -40,7 +40,7 @@ export function overwriteEnrWithCliArgs(enr: ENR, enrArgs: IENRJson, options: IB
         enr.tcp = tcpOpts.port;
       }
     } catch (e) {
-      throw new Error(`Invalid tcp multiaddr: ${e.message}`);
+      throw new Error(`Invalid tcp multiaddr: ${(e as Error).message}`);
     }
   }
 
@@ -51,7 +51,7 @@ export function overwriteEnrWithCliArgs(enr: ENR, enrArgs: IENRJson, options: IB
         enr.udp = udpOpts.port;
       }
     } catch (e) {
-      throw new Error(`Invalid udp multiaddr: ${e.message}`);
+      throw new Error(`Invalid udp multiaddr: ${(e as Error).message}`);
     }
   }
 

--- a/packages/lodestar-cli/src/util/file.ts
+++ b/packages/lodestar-cli/src/util/file.ts
@@ -12,6 +12,7 @@ export const yamlSchema = new Schema({
     new Type("tag:yaml.org,2002:str", {
       kind: "scalar",
       construct: function (data) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return data !== null ? data : "";
       },
     }),
@@ -38,10 +39,10 @@ export enum FileFormat {
 export function parse<T = Json>(contents: string, fileFormat: FileFormat): T {
   switch (fileFormat) {
     case FileFormat.json:
-      return JSON.parse(contents);
+      return JSON.parse(contents) as T;
     case FileFormat.yaml:
     case FileFormat.yml:
-      return load(contents, {schema: yamlSchema});
+      return load(contents, {schema: yamlSchema}) as T;
     default:
       throw new Error("Invalid filetype");
   }
@@ -96,7 +97,7 @@ export function readFileIfExists<T = Json>(filepath: string): T | null {
   try {
     return readFile(filepath);
   } catch (e) {
-    if (e.code === "ENOENT") {
+    if ((e as {code: string}).code === "ENOENT") {
       return null;
     } else {
       throw e;

--- a/packages/lodestar-cli/src/util/object.ts
+++ b/packages/lodestar-cli/src/util/object.ts
@@ -6,6 +6,7 @@ import {RecursivePartial} from "@chainsafe/lodestar-utils";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function removeUndefinedRecursive<T extends {[key: string]: any}>(obj: T): RecursivePartial<T> {
   for (const key of Object.keys(obj)) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const value = obj[key];
     if (value && typeof value === "object") removeUndefinedRecursive(value);
     else if (value === undefined) delete obj[key];

--- a/packages/lodestar-cli/src/util/passphrase.ts
+++ b/packages/lodestar-cli/src/util/passphrase.ts
@@ -18,7 +18,9 @@ export function readPassphraseFile(passphraseFile: string): string {
     // 512 is an arbitrary high number that should be longer than any actual passphrase
     if (passphrase.length > 512) throw Error("is really long");
   } catch (e) {
-    throw new Error(`passphraseFile ${passphraseFile} ${e.message}. Is this a well-formated passphraseFile?`);
+    throw new Error(
+      `passphraseFile ${passphraseFile} ${(e as Error).message}. Is this a well-formated passphraseFile?`
+    );
   }
 
   return passphrase;

--- a/packages/lodestar-cli/src/wallet/WalletManager.ts
+++ b/packages/lodestar-cli/src/wallet/WalletManager.ts
@@ -53,7 +53,7 @@ export class WalletManager {
       .filter((file) => isUuid(file) && fs.statSync(path.join(this.walletsDir, file)).isDirectory())
       .map((walletUuid) => {
         const walletInfoPath = path.join(this.walletsDir, walletUuid, walletUuid);
-        const walletInfo = JSON.parse(fs.readFileSync(walletInfoPath, "utf8"));
+        const walletInfo = JSON.parse(fs.readFileSync(walletInfoPath, "utf8")) as IWalletKeystoreJson;
         if (walletInfo.uuid !== walletUuid)
           throw new YargsError(`Wallet UUID mismatch, ${walletInfo.uuid} !== ${walletUuid}`);
 

--- a/packages/lodestar-cli/test/e2e/cmds/init.test.ts
+++ b/packages/lodestar-cli/test/e2e/cmds/init.test.ts
@@ -23,7 +23,9 @@ describe("cmds / init", function () {
     ]);
 
     expect(fs.existsSync(beaconPaths.configFile), `Must write config file to ${beaconPaths.configFile}`).to.be.true;
-    const beaconConfig: IBeaconNodeOptions = JSON.parse(fs.readFileSync(beaconPaths.configFile, "utf8"));
+    const beaconConfig: IBeaconNodeOptions = JSON.parse(
+      fs.readFileSync(beaconPaths.configFile, "utf8")
+    ) as IBeaconNodeOptions;
 
     expect(beaconConfig.eth1.depositContractDeployBlock).to.equal(
       depositContractDeployBlock,

--- a/packages/lodestar-db/src/controller/impl/level.ts
+++ b/packages/lodestar-db/src/controller/impl/level.ts
@@ -33,6 +33,7 @@ export class LevelDbController implements IDatabaseController<Buffer, Buffer> {
   constructor(opts: ILevelDBOptions, {logger}: {logger: ILogger}) {
     this.opts = opts;
     this.logger = logger;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
     this.db = opts.db || level(opts.name || "beaconchain", {keyEncoding: "binary", valueEncoding: "binary"});
   }
 
@@ -57,9 +58,9 @@ export class LevelDbController implements IDatabaseController<Buffer, Buffer> {
 
   async get(key: Buffer): Promise<Buffer | null> {
     try {
-      return await this.db.get(key);
+      return (await this.db.get(key)) as Buffer | null;
     } catch (e) {
-      if (e.notFound) {
+      if ((e as {notFound: unknown}).notFound) {
         return null;
       }
       throw e;

--- a/packages/lodestar-db/test/unit/controller/level.test.ts
+++ b/packages/lodestar-db/test/unit/controller/level.test.ts
@@ -16,6 +16,7 @@ describe("LevelDB controller", () => {
   after(async () => {
     await db.stop();
     await new Promise<void>((resolve, reject) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       leveldown.destroy(dbLocation, (err: Error) => {
         if (err) reject(err);
         else resolve();

--- a/packages/lodestar-fork-choice/src/protoArray/protoArray.ts
+++ b/packages/lodestar-fork-choice/src/protoArray/protoArray.ts
@@ -27,7 +27,7 @@ export class ProtoArray {
     this.justifiedEpoch = justifiedEpoch;
     this.finalizedEpoch = finalizedEpoch;
     this.nodes = [];
-    this.indices = new Map();
+    this.indices = new Map<string, number>();
   }
 
   static initialize({

--- a/packages/lodestar-params/src/utils.ts
+++ b/packages/lodestar-params/src/utils.ts
@@ -15,7 +15,7 @@ export function createIBeaconParams(input: Record<string, unknown>): Partial<IBe
 }
 
 export function loadConfigYaml(configYaml: string): Record<string, unknown> {
-  return load(configYaml, {schema});
+  return load(configYaml, {schema}) as Record<string, unknown>;
 }
 
 export const schema = new Schema({
@@ -24,6 +24,7 @@ export const schema = new Schema({
     new Type("tag:yaml.org,2002:str", {
       kind: "scalar",
       construct: function (data) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return data !== null ? data : "";
       },
     }),

--- a/packages/lodestar-spec-test-util/src/downloadTests.ts
+++ b/packages/lodestar-spec-test-util/src/downloadTests.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import fs from "fs";
 import path from "path";
 import rimraf from "rimraf";

--- a/packages/lodestar-spec-test-util/src/downloadTests.ts
+++ b/packages/lodestar-spec-test-util/src/downloadTests.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
 import fs from "fs";
 import path from "path";
 import rimraf from "rimraf";

--- a/packages/lodestar-spec-test-util/src/multi.ts
+++ b/packages/lodestar-spec-test-util/src/multi.ts
@@ -1,3 +1,7 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/no-unused-vars */
 import {writeFile} from "fs";
 import {expect} from "chai";

--- a/packages/lodestar-spec-test-util/src/multi.ts
+++ b/packages/lodestar-spec-test-util/src/multi.ts
@@ -1,8 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any,@typescript-eslint/no-unused-vars */
 import {writeFile} from "fs";
 import {expect} from "chai";
 import profiler from "v8-profiler-next";

--- a/packages/lodestar-spec-test-util/src/single.ts
+++ b/packages/lodestar-spec-test-util/src/single.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {expect} from "chai";
 import {readdirSync, readFileSync, writeFile} from "fs";

--- a/packages/lodestar-spec-test-util/src/single.ts
+++ b/packages/lodestar-spec-test-util/src/single.ts
@@ -1,7 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any */
 import {expect} from "chai";
 import {readdirSync, readFileSync, writeFile} from "fs";
 import {basename, join, parse} from "path";

--- a/packages/lodestar-spec-test-util/src/transform.ts
+++ b/packages/lodestar-spec-test-util/src/transform.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {Type, UintType, BigIntUintType, byteType, isCompositeType} from "@chainsafe/ssz";
 
@@ -30,6 +32,6 @@ export function safeType(type: Type<any>): Type<any> {
     const newtype = Object.create(Object.getPrototypeOf(type), props);
     newtype.structural._type = newtype;
     newtype.tree._type = newtype;
-    return newtype;
+    return newtype as Type<any>;
   }
 }

--- a/packages/lodestar-spec-test-util/src/transform.ts
+++ b/packages/lodestar-spec-test-util/src/transform.ts
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+, @typescript-eslint/no-explicit-any */
 import {Type, UintType, BigIntUintType, byteType, isCompositeType} from "@chainsafe/ssz";
 
 /**

--- a/packages/lodestar-spec-test-util/test/e2e/multi/index.test.ts
+++ b/packages/lodestar-spec-test-util/test/e2e/multi/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 import {IBaseCase, describeMultiSpec} from "../../../src";
 import path from "path";
 

--- a/packages/lodestar-spec-test-util/test/e2e/single/index.test.ts
+++ b/packages/lodestar-spec-test-util/test/e2e/single/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import {unlinkSync, writeFileSync} from "fs";
 import {join} from "path";
 
@@ -54,6 +55,7 @@ describeDirectorySpecTest<ISimpleCase, number>(
 );
 
 function yamlToSSZ(file: string, sszSchema: Type<any>): void {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const input: any = sszSchema.fromJson(loadYamlFile(file) as Json);
   if (input.number) {
     input.number = Number(input.number);

--- a/packages/lodestar-types/src/lightclient/ssz/index.ts
+++ b/packages/lodestar-types/src/lightclient/ssz/index.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment */
 import {IBeaconParams} from "@chainsafe/lodestar-params";
 
 import {IPhase0SSZTypes} from "../../phase0";

--- a/packages/lodestar-types/src/lightclient/ssz/index.ts
+++ b/packages/lodestar-types/src/lightclient/ssz/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {IBeaconParams} from "@chainsafe/lodestar-params";
 
 import {IPhase0SSZTypes} from "../../phase0";

--- a/packages/lodestar-types/src/phase0/ssz/generators/index.ts
+++ b/packages/lodestar-types/src/phase0/ssz/generators/index.ts
@@ -13,6 +13,7 @@ import * as wire from "./wire";
 import * as api from "./api";
 
 import {IPhase0SSZTypes, phase0TypeNames} from "../interface";
+import {IPrimitiveSSZTypes} from "../../../primitive/IPrimitiveSSZTypes";
 
 const allGenerators = {
   ...misc,
@@ -27,10 +28,10 @@ const allGenerators = {
 export function createIPhase0SSZTypes(params: IPhase0Params): IPhase0SSZTypes {
   const types: IPhase0SSZTypes = {} as IPhase0SSZTypes;
   // primitive types (don't need generators)
-  for (const type in primitive) {
+  for (const type in primitive as IPrimitiveSSZTypes) {
     // @ts-ignore
     // eslint-disable-next-line import/namespace
-    types[type] = primitive[type];
+    types[type] = primitive[type] as IPhase0SSZTypes;
   }
   // relies on list of typenames in dependency order
   for (const type of phase0TypeNames) {

--- a/packages/lodestar-types/src/phase0/ssz/generators/index.ts
+++ b/packages/lodestar-types/src/phase0/ssz/generators/index.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment */
 /**
  * @module sszTypes/generators
  */

--- a/packages/lodestar-types/src/phase0/ssz/generators/index.ts
+++ b/packages/lodestar-types/src/phase0/ssz/generators/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /**
  * @module sszTypes/generators
  */

--- a/packages/lodestar-types/src/phase1/ssz/generators/index.ts
+++ b/packages/lodestar-types/src/phase1/ssz/generators/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {IBeaconParams} from "@chainsafe/lodestar-params";
 
 import {ILightclientSSZTypes} from "../../../lightclient";

--- a/packages/lodestar-types/test/unit/consistency.test.ts
+++ b/packages/lodestar-types/test/unit/consistency.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 import {assert} from "chai";
 import fs from "fs";
 import path from "path";
@@ -24,9 +25,9 @@ describe("@chainsafe/lodestar-types phase0", () => {
       .replace(/\/\/.*\n/g, "")
       // remove multiline comments
       .replace(/\/\*[\s\S]*?\*\//gm, "");
-    let match;
+    let match: RegExpExecArray | null;
     // extract interface definitions
-    const interfaceRe: any = /export interface (.*) {([\s\S]*?)}/g;
+    const interfaceRe = /export interface (.*) {([\s\S]*?)}/g;
     // eslint-disable-next-line no-cond-assign
     while ((match = interfaceRe.exec(fileStr))) {
       const name = match[1];
@@ -38,9 +39,9 @@ describe("@chainsafe/lodestar-types phase0", () => {
         // split fields by ;
         .split(";")
         // remove blank matches
-        .filter((s: any) => s)
+        .filter((s: string) => s)
         // separate the field name from type
-        .map((s: any) => {
+        .map((s: string) => {
           // eslint-disable-next-line prefer-const
           let [name, type] = s.split(":");
           // replace string [] with real []

--- a/packages/lodestar-types/test/unit/consistency.test.ts
+++ b/packages/lodestar-types/test/unit/consistency.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 import {assert} from "chai";
 import fs from "fs";

--- a/packages/lodestar-types/test/unit/consistency.test.ts
+++ b/packages/lodestar-types/test/unit/consistency.test.ts
@@ -1,6 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return */
 import {assert} from "chai";
 import fs from "fs";
 import path from "path";

--- a/packages/lodestar-utils/src/logger/winston.ts
+++ b/packages/lodestar-utils/src/logger/winston.ts
@@ -65,7 +65,7 @@ export class WinstonLogger implements ILogger {
   }
 
   child(options: ILoggerOptions): WinstonLogger {
-    const logger = Object.create(WinstonLogger.prototype);
+    const logger = Object.create(WinstonLogger.prototype) as WinstonLogger;
     const winston = this.winston.child({namespace: options.module, level: options.level});
     //use more verbose log
     if (this.winston.levels[this._level] > this.winston.levels[options.level ?? LogLevel.error]) {

--- a/packages/lodestar-utils/src/objects.ts
+++ b/packages/lodestar-utils/src/objects.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {toExpectedCase} from "@chainsafe/ssz/lib/backings/utils";
 
 /**

--- a/packages/lodestar-utils/src/objects.ts
+++ b/packages/lodestar-utils/src/objects.ts
@@ -1,6 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
 import {toExpectedCase} from "@chainsafe/ssz/lib/backings/utils";
 
 /**

--- a/packages/lodestar-utils/test/unit/json.test.ts
+++ b/packages/lodestar-utils/test/unit/json.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {fromHexString, Json} from "@chainsafe/ssz";
 import {expect} from "chai";
 import {LodestarError, toJson, toString, CIRCULAR_REFERENCE_TAG} from "../../src";

--- a/packages/lodestar-utils/test/unit/json.test.ts
+++ b/packages/lodestar-utils/test/unit/json.test.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
 import {fromHexString, Json} from "@chainsafe/ssz";
 import {expect} from "chai";
 import {LodestarError, toJson, toString, CIRCULAR_REFERENCE_TAG} from "../../src";

--- a/packages/lodestar-validator/src/api/impl/rest/beacon/beacon.ts
+++ b/packages/lodestar-validator/src/api/impl/rest/beacon/beacon.ts
@@ -31,7 +31,7 @@ export class RestBeaconApi implements IBeaconApi {
       const genesisResponse = await this.clientV2.get<{data: Json}>("/genesis");
       return this.config.types.phase0.Genesis.fromJson(genesisResponse.data, {case: "snake"});
     } catch (e) {
-      this.logger.error("Failed to obtain genesis time", {error: e.message});
+      this.logger.error("Failed to obtain genesis time", {error: (e as Error).message});
       return null;
     }
   }

--- a/packages/lodestar-validator/src/api/impl/rest/beacon/state.ts
+++ b/packages/lodestar-validator/src/api/impl/rest/beacon/state.ts
@@ -25,7 +25,7 @@ export class RestBeaconStateApi extends RestApi implements IBeaconStateApi {
         }
       );
     } catch (e) {
-      this.logger.error("Failed to fetch validator", {validatorId: id, error: e.message});
+      this.logger.error("Failed to fetch validator", {validatorId: id, error: (e as Error).message});
       return null;
     }
   }
@@ -39,7 +39,7 @@ export class RestBeaconStateApi extends RestApi implements IBeaconStateApi {
         }
       );
     } catch (e) {
-      this.logger.error("Failed to fetch head fork version", {error: e.message});
+      this.logger.error("Failed to fetch head fork version", {error: (e as Error).message});
       return null;
     }
   }

--- a/packages/lodestar-validator/src/services/attestation.ts
+++ b/packages/lodestar-validator/src/services/attestation.ts
@@ -26,7 +26,10 @@ export class AttestationService {
   private readonly slashingProtection: ISlashingProtection;
   private readonly logger: ILogger;
 
-  private nextAttesterDuties: Map<Slot, Map<PublicKeyHex, IAttesterDuty>> = new Map();
+  private nextAttesterDuties: Map<Slot, Map<PublicKeyHex, IAttesterDuty>> = new Map<
+    Slot,
+    Map<PublicKeyHex, IAttesterDuty>
+  >();
   private controller: AbortController | undefined;
 
   constructor(
@@ -111,7 +114,7 @@ export class AttestationService {
       }
       attesterDuties = await this.provider.validator.getAttesterDuties(epoch, indices);
     } catch (e) {
-      this.logger.error("Failed to obtain attester duty", {epoch, error: e.message});
+      this.logger.error("Failed to obtain attester duty", {epoch, error: (e as Error).message});
       return;
     }
     const fork = await this.provider.beacon.state.getFork("head");
@@ -186,7 +189,7 @@ export class AttestationService {
       this.logger.error("Failed to produce attestation", {
         slot: duty.slot,
         committee: duty.committeeIndex,
-        error: e.message,
+        error: (e as Error).message,
       });
     }
     if (!attestation) {
@@ -352,7 +355,9 @@ export class AttestationService {
     try {
       attestationData = await this.provider.validator.produceAttestationData(committeeIndex, slot);
     } catch (e) {
-      e.message = `Failed to obtain attestation data at slot ${slot} and committee ${committeeIndex}: ${e.message}`;
+      (e as Error).message = `Failed to obtain attestation data at slot ${slot} and committee ${committeeIndex}: ${
+        (e as Error).message
+      }`;
       throw e;
     }
 

--- a/packages/lodestar-validator/src/services/block.ts
+++ b/packages/lodestar-validator/src/services/block.ts
@@ -25,7 +25,7 @@ export default class BlockProposingService {
   private readonly logger: ILogger;
   private readonly graffiti?: string;
 
-  private nextProposals: Map<Slot, BLSPubkey> = new Map();
+  private nextProposals: Map<Slot, BLSPubkey> = new Map<Slot, BLSPubkey>();
 
   constructor(
     config: IBeaconConfig,

--- a/packages/lodestar-validator/src/services/utils.ts
+++ b/packages/lodestar-validator/src/services/utils.ts
@@ -2,7 +2,7 @@ import {SecretKey} from "@chainsafe/bls";
 import {PublicKeyHex, ValidatorAndSecret} from "../types";
 
 export function mapSecretKeysToValidators(secretKeys: SecretKey[]): Map<PublicKeyHex, ValidatorAndSecret> {
-  const validators: Map<PublicKeyHex, ValidatorAndSecret> = new Map();
+  const validators: Map<PublicKeyHex, ValidatorAndSecret> = new Map<PublicKeyHex, ValidatorAndSecret>();
   for (const secretKey of secretKeys) {
     validators.set(secretKey.toPublicKey().toHex(), {validator: null, secretKey});
   }

--- a/packages/lodestar-validator/src/util/httpClient.ts
+++ b/packages/lodestar-validator/src/util/httpClient.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import Axios, {AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse} from "axios";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import querystring from "querystring";

--- a/packages/lodestar-validator/src/util/httpClient.ts
+++ b/packages/lodestar-validator/src/util/httpClient.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
 import Axios, {AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse} from "axios";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import querystring from "querystring";

--- a/packages/lodestar-validator/test/unit/api/rcpClientOverInstance.test.ts
+++ b/packages/lodestar-validator/test/unit/api/rcpClientOverInstance.test.ts
@@ -1,4 +1,4 @@
-import sinon from "sinon";
+import sinon, {SinonFakeTimers, SinonSandbox} from "sinon";
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {LodestarEventIterator} from "@chainsafe/lodestar-utils";
@@ -13,7 +13,7 @@ import {ClockEventType} from "../../../src/api/interface/clock";
 import {MockConfigApi} from "../../utils/mocks/config";
 
 describe("RpcClientOverInstance test", function () {
-  let clock: any, sandbox: any;
+  let clock: SinonFakeTimers, sandbox: SinonSandbox;
 
   before(() => {
     sandbox = sinon.createSandbox();

--- a/packages/lodestar-validator/test/unit/slashingProtection/minMaxSurround/surroundTests.test.ts
+++ b/packages/lodestar-validator/test/unit/slashingProtection/minMaxSurround/surroundTests.test.ts
@@ -218,7 +218,7 @@ describe("surroundTests", () => {
               expect(e.type.att2Target).to.equal(slashableEpoch, "Wrong slashableEpoch");
             }
           } else {
-            throw Error(`Wrong error type: ${e.stack}`);
+            throw Error(`Wrong error type: ${(e as Error).stack}`);
           }
         }
       } else {

--- a/packages/lodestar-validator/test/unit/utils/httpClient.test.ts
+++ b/packages/lodestar-validator/test/unit/utils/httpClient.test.ts
@@ -42,7 +42,7 @@ describe("httpClient test", () => {
     try {
       await httpClient.get<IUser>("/wrong_url");
     } catch (e) {
-      assert.equal(e.message, "Endpoint not found");
+      assert.equal((e as Error).message, "Endpoint not found");
     }
   });
 
@@ -51,7 +51,7 @@ describe("httpClient test", () => {
     try {
       await httpClient.get<IUser>("/users/!");
     } catch (e) {
-      assert.equal(e.message, "Request failed with response status 500");
+      assert.equal((e as Error).message, "Request failed with response status 500");
     }
   });
 });

--- a/packages/lodestar/src/api/impl/debug/beacon/index.ts
+++ b/packages/lodestar/src/api/impl/debug/beacon/index.ts
@@ -1,4 +1,5 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {IBlockSummary} from "@chainsafe/lodestar-fork-choice";
 import {phase0} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {IBeaconChain} from "../../../../chain";
@@ -26,7 +27,7 @@ export class DebugBeaconApi implements IDebugBeaconApi {
     try {
       return this.chain.forkChoice
         .getHeads()
-        .map((blockSummary) => ({slot: blockSummary.slot, root: blockSummary.blockRoot}));
+        .map((blockSummary: IBlockSummary) => ({slot: blockSummary.slot, root: blockSummary.blockRoot}));
     } catch (e) {
       this.logger.error("Failed to get forkchoice heads", e);
       return null;
@@ -37,7 +38,8 @@ export class DebugBeaconApi implements IDebugBeaconApi {
     try {
       return await resolveStateId(this.chain, this.db, stateId);
     } catch (e) {
-      this.logger.error("Failed to resolve state", {state: stateId, error: e});
+      (e as Error).message;
+      this.logger.error("Failed to resolve state", {state: stateId, error: {...(e as Error)}});
       throw e;
     }
   }

--- a/packages/lodestar/src/api/impl/lodestar/index.ts
+++ b/packages/lodestar/src/api/impl/lodestar/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 export interface ILodestarApi {
   getWtfNode(): string;
 }

--- a/packages/lodestar/src/api/impl/lodestar/index.ts
+++ b/packages/lodestar/src/api/impl/lodestar/index.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 export interface ILodestarApi {
   getWtfNode(): string;
 }

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlock.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlock.ts
@@ -15,8 +15,8 @@ export const getBlock: ApiController<DefaultQuery, {blockId: string}> = {
         data: this.config.types.phase0.SignedBeaconBlock.toJson(data, {case: "snake"}),
       });
     } catch (e) {
-      if (e.message === "Invalid block id") {
-        throw toRestValidationError("block_id", e.message);
+      if ((e as Error).message === "Invalid block id") {
+        throw toRestValidationError("block_id", (e as Error).message);
       }
       throw e;
     }

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockAttestations.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockAttestations.ts
@@ -17,8 +17,8 @@ export const getBlockAttestations: ApiController<DefaultQuery, {blockId: string}
         }),
       });
     } catch (e) {
-      if (e.message === "Invalid block id") {
-        throw toRestValidationError("block_id", e.message);
+      if ((e as Error).message === "Invalid block id") {
+        throw toRestValidationError("block_id", (e as Error).message);
       }
       throw e;
     }

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockHeader.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockHeader.ts
@@ -15,8 +15,8 @@ export const getBlockHeader: ApiController<DefaultQuery, {blockId: string}> = {
         data: this.config.types.phase0.SignedBeaconHeaderResponse.toJson(data, {case: "snake"}),
       });
     } catch (e) {
-      if (e.message === "Invalid block id") {
-        throw toRestValidationError("block_id", e.message);
+      if ((e as Error).message === "Invalid block id") {
+        throw toRestValidationError("block_id", (e as Error).message);
       }
       throw e;
     }

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockRoot.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockRoot.ts
@@ -17,8 +17,8 @@ export const getBlockRoot: ApiController<DefaultQuery, {blockId: string}> = {
         },
       });
     } catch (e) {
-      if (e.message === "Invalid block id") {
-        throw toRestValidationError("block_id", e.message);
+      if ((e as Error).message === "Invalid block id") {
+        throw toRestValidationError("block_id", (e as Error).message);
       }
       throw e;
     }

--- a/packages/lodestar/src/api/rest/controllers/beacon/state/getStateFinalityCheckpoints.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/state/getStateFinalityCheckpoints.ts
@@ -30,8 +30,8 @@ export const getStateFinalityCheckpoints: ApiController<DefaultQuery, Params> = 
         },
       });
     } catch (e) {
-      if (e.message === "Invalid state id") {
-        throw toRestValidationError("state_id", e.message);
+      if ((e as Error).message === "Invalid state id") {
+        throw toRestValidationError("state_id", (e as Error).message);
       }
       throw e;
     }

--- a/packages/lodestar/src/api/rest/controllers/beacon/state/getStateFork.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/state/getStateFork.ts
@@ -20,8 +20,8 @@ export const getStateFork: ApiController<DefaultQuery, Params> = {
         data: this.config.types.phase0.Fork.toJson(fork, {case: "snake"}),
       });
     } catch (e) {
-      if (e.message === "Invalid state id") {
-        throw toRestValidationError("state_id", e.message);
+      if ((e as Error).message === "Invalid state id") {
+        throw toRestValidationError("state_id", (e as Error).message);
       }
       throw e;
     }

--- a/packages/lodestar/src/api/rest/controllers/debug/beacon/getStates.ts
+++ b/packages/lodestar/src/api/rest/controllers/debug/beacon/getStates.ts
@@ -23,8 +23,8 @@ export const getState: ApiController<DefaultQuery, {stateId: string}> = {
         });
       }
     } catch (e) {
-      if (e.message === "Invalid state id") {
-        throw toRestValidationError("state_id", e.message);
+      if ((e as Error).message === "Invalid state id") {
+        throw toRestValidationError("state_id", (e as Error).message);
       }
       throw e;
     }

--- a/packages/lodestar/src/api/rest/controllers/validator/publishAggregateAndProof.ts
+++ b/packages/lodestar/src/api/rest/controllers/validator/publishAggregateAndProof.ts
@@ -16,7 +16,7 @@ export const publishAggregateAndProof: ApiController<DefaultQuery, DefaultParams
           this.config.types.phase0.SignedAggregateAndProof.fromJson(aggreagteJson, {case: "snake"})
         );
       } catch (e) {
-        this.log.warn("Failed to parse AggregateAndProof", e.message);
+        this.log.warn("Failed to parse AggregateAndProof", (e as Error).message);
       }
     }
     await this.api.validator.publishAggregateAndProofs(signedAggregateAndProofs);

--- a/packages/lodestar/src/api/rest/logger/fastify.ts
+++ b/packages/lodestar/src/api/rest/logger/fastify.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import {Stream} from "stream";
 import {IncomingMessage} from "http";
 import {FastifyRequest} from "fastify";
@@ -28,14 +29,8 @@ export class FastifyLogger {
   }
 
   private handle = (chunk: string): void => {
-    const log: {
-      level: number;
-      msg: string;
-      responseTime: number;
-      reqId: number;
-      req?: {msg: string};
-      res?: {statusCode: number};
-    } = JSON.parse(chunk);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const log = JSON.parse(chunk);
     if (log.req) {
       this.log.debug(log.req.msg);
     } else if (log.res) {

--- a/packages/lodestar/src/chain/attestation/pool.ts
+++ b/packages/lodestar/src/chain/attestation/pool.ts
@@ -29,9 +29,9 @@ export class AttestationPool {
   constructor({config}: {config: IBeaconConfig}) {
     this.config = config;
 
-    this.attestations = new Map();
-    this.attestationsByBlock = new Map();
-    this.attestationsBySlot = new Map();
+    this.attestations = new Map<string, IAttestationJob>();
+    this.attestationsByBlock = new Map<string, Map<string, IAttestationJob>>();
+    this.attestationsBySlot = new Map<number, Map<string, IAttestationJob>>();
   }
 
   putByBlock(blockRoot: Root, job: IAttestationJob): void {

--- a/packages/lodestar/src/chain/blocks/pool.ts
+++ b/packages/lodestar/src/chain/blocks/pool.ts
@@ -27,9 +27,9 @@ export class BlockPool {
   constructor({config}: {config: IBeaconConfig}) {
     this.config = config;
 
-    this.blocks = new Map();
-    this.blocksByParent = new Map();
-    this.blocksBySlot = new Map();
+    this.blocks = new Map<string, string>();
+    this.blocksByParent = new Map<string, Set<string>>();
+    this.blocksBySlot = new Map<number, Set<string>>();
   }
 
   addByParent(signedBlock: phase0.SignedBeaconBlock): void {

--- a/packages/lodestar/src/chain/blocks/process.ts
+++ b/packages/lodestar/src/chain/blocks/process.ts
@@ -65,7 +65,7 @@ export async function processBlock({
 
     throw new BlockError({
       code: BlockErrorCode.BEACON_CHAIN_ERROR,
-      error: e,
+      error: e as Error,
       job,
     });
   }
@@ -166,7 +166,7 @@ export async function processChainSegment({
 
       throw new ChainSegmentError({
         code: BlockErrorCode.BEACON_CHAIN_ERROR,
-        error: e,
+        error: e as Error,
         job,
         importedBlocks,
       });

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -14,6 +14,7 @@ import {IBeaconMetrics} from "../../metrics";
 
 import {processBlock, processChainSegment} from "./process";
 import {validateBlock} from "./validate";
+import {LodestarError} from "@chainsafe/lodestar-utils";
 
 type BlockProcessorModules = {
   config: IBeaconConfig;

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {AbortSignal} from "abort-controller";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
@@ -14,7 +16,6 @@ import {IBeaconMetrics} from "../../metrics";
 
 import {processBlock, processChainSegment} from "./process";
 import {validateBlock} from "./validate";
-import {LodestarError} from "@chainsafe/lodestar-utils";
 
 type BlockProcessorModules = {
   config: IBeaconConfig;

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -15,7 +15,6 @@ import {IBeaconMetrics} from "../../metrics";
 
 import {processBlock, processChainSegment} from "./process";
 import {validateBlock} from "./validate";
-import {LodestarError} from "@chainsafe/lodestar-utils";
 
 type BlockProcessorModules = {
   config: IBeaconConfig;

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -15,6 +15,7 @@ import {IBeaconMetrics} from "../../metrics";
 
 import {processBlock, processChainSegment} from "./process";
 import {validateBlock} from "./validate";
+import {LodestarError} from "@chainsafe/lodestar-utils";
 
 type BlockProcessorModules = {
   config: IBeaconConfig;

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
 import {AbortSignal} from "abort-controller";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";

--- a/packages/lodestar/src/chain/blocks/validate.ts
+++ b/packages/lodestar/src/chain/blocks/validate.ts
@@ -62,7 +62,7 @@ export function validateBlock({
 
     throw new BlockError({
       code: BlockErrorCode.BEACON_CHAIN_ERROR,
-      error: e,
+      error: e as Error,
       job,
     });
   }

--- a/packages/lodestar/src/chain/errors/blockError.ts
+++ b/packages/lodestar/src/chain/errors/blockError.ts
@@ -117,7 +117,7 @@ export class BlockError extends LodestarError<BlockErrorType> {
   }
 }
 
-type ChainSegmentJobObject = {
+export type ChainSegmentJobObject = {
   job: IChainSegmentJob;
   importedBlocks: number;
 };

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -192,7 +192,7 @@ export class StateRegenerator implements IStateRegenerator {
       } catch (e) {
         throw new RegenError({
           code: RegenErrorCode.STATE_TRANSITION_ERROR,
-          error: e,
+          error: e as Error,
         });
       }
     }

--- a/packages/lodestar/src/db/api/beacon/seenAttestationCache.ts
+++ b/packages/lodestar/src/db/api/beacon/seenAttestationCache.ts
@@ -15,7 +15,7 @@ export class SeenAttestationCache {
 
   constructor(maxSize = 1000) {
     this.maxSize = maxSize;
-    this.cache = new Map();
+    this.cache = new Map<string, boolean>();
   }
 
   addCommitteeAttestation(attestation: phase0.Attestation): void {

--- a/packages/lodestar/src/db/api/beacon/single/preGenesisState.ts
+++ b/packages/lodestar/src/db/api/beacon/single/preGenesisState.ts
@@ -12,7 +12,7 @@ export class PreGenesisState {
   constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
     this.db = db;
     this.type = (config.types.phase0.BeaconState as unknown) as CompositeType<TreeBacked<phase0.BeaconState>>;
-    this.bucket = Bucket.phase0_preGenesisState;
+    this.bucket = Bucket.phase0_preGenesisState as Bucket;
     this.key = Buffer.from(new Uint8Array([this.bucket]));
   }
 

--- a/packages/lodestar/src/db/api/beacon/single/preGenesisStateLastProcessedBlock.ts
+++ b/packages/lodestar/src/db/api/beacon/single/preGenesisStateLastProcessedBlock.ts
@@ -11,7 +11,7 @@ export class PreGenesisStateLastProcessedBlock {
   constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
     this.db = db;
     this.type = config.types.Number64;
-    this.bucket = Bucket.phase0_preGenesisStateLastProcessedBlock;
+    this.bucket = Bucket.phase0_preGenesisStateLastProcessedBlock as Bucket;
     this.key = Buffer.from(new Uint8Array([this.bucket]));
   }
 

--- a/packages/lodestar/src/eth1/jsonRpcHttpClient.ts
+++ b/packages/lodestar/src/eth1/jsonRpcHttpClient.ts
@@ -90,7 +90,7 @@ async function fetchJson<R, T = unknown>(url: string, json: T, signal?: AbortSig
  */
 function parseJson<T>(json: string): T {
   try {
-    return JSON.parse(json);
+    return JSON.parse(json) as T;
   } catch (e) {
     throw new ErrorParseJson(json, e);
   }

--- a/packages/lodestar/src/metrics/gitData.ts
+++ b/packages/lodestar/src/metrics/gitData.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 type GitData = {
   /** "0.16.0" */
   semver: string;

--- a/packages/lodestar/src/metrics/gitData.ts
+++ b/packages/lodestar/src/metrics/gitData.ts
@@ -1,6 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
 type GitData = {
   /** "0.16.0" */
   semver: string;

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -4,7 +4,7 @@ import {InMessage} from "libp2p-interfaces/src/pubsub";
 import Libp2p from "libp2p";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ATTESTATION_SUBNET_COUNT, phase0, Root} from "@chainsafe/lodestar-types";
-import {ILogger, LodestarError, toJson} from "@chainsafe/lodestar-utils";
+import {ILogger, toJson} from "@chainsafe/lodestar-utils";
 import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 
 import {IBeaconMetrics} from "../../metrics";
@@ -23,7 +23,6 @@ import {encodeMessageData, decodeMessageData} from "./encoding";
 import {DEFAULT_ENCODING} from "./constants";
 import {GossipValidationError} from "./errors";
 import {ERR_TOPIC_VALIDATOR_REJECT} from "libp2p-gossipsub/src/constants";
-import {BlockError} from "../../chain/errors";
 
 interface IGossipsubModules {
   config: IBeaconConfig;

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -4,7 +4,7 @@ import {InMessage} from "libp2p-interfaces/src/pubsub";
 import Libp2p from "libp2p";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ATTESTATION_SUBNET_COUNT, phase0, Root} from "@chainsafe/lodestar-types";
-import {ILogger, toJson} from "@chainsafe/lodestar-utils";
+import {ILogger, LodestarError, toJson} from "@chainsafe/lodestar-utils";
 import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 
 import {IBeaconMetrics} from "../../metrics";
@@ -23,6 +23,7 @@ import {encodeMessageData, decodeMessageData} from "./encoding";
 import {DEFAULT_ENCODING} from "./constants";
 import {GossipValidationError} from "./errors";
 import {ERR_TOPIC_VALIDATOR_REJECT} from "libp2p-gossipsub/src/constants";
+import {BlockError} from "../../chain/errors";
 
 interface IGossipsubModules {
   config: IBeaconConfig;

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -190,7 +190,7 @@ export class Network extends (EventEmitter as {new (): NetworkEventEmitter}) imp
     try {
       await this.libp2p.hangUp(peerId);
     } catch (e) {
-      this.logger.warn("Unclean disconnect", {reason: e.message});
+      this.logger.warn("Unclean disconnect", {reason: (e as Error).message});
     }
   }
 
@@ -232,7 +232,11 @@ export class Network extends (EventEmitter as {new (): NetworkEventEmitter}) imp
         break;
       } catch (e) {
         // this runs too frequently so make it verbose
-        this.logger.verbose("Cannot connect to peer", {peerId: peer.peerId.toB58String(), subnet, error: e.message});
+        this.logger.verbose("Cannot connect to peer", {
+          peerId: peer.peerId.toB58String(),
+          subnet,
+          error: (e as Error).message,
+        });
       }
     }
 

--- a/packages/lodestar/src/network/peers/utils.ts
+++ b/packages/lodestar/src/network/peers/utils.ts
@@ -46,7 +46,7 @@ export async function handlePeerMetadataSequence(
       logger.verbose("Getting peer metadata", {peer: peer.toB58String()});
       network.peerMetadata.metadata.set(peer, await network.reqResp.metadata(peer));
     } catch (e) {
-      logger.verbose("Cannot get peer metadata", {peer: peer.toB58String(), e: e.message});
+      logger.verbose("Cannot get peer metadata", {peer: peer.toB58String(), e: (e as Error).message});
     }
   } else {
     logger.debug("Peer latest metadata already known", {

--- a/packages/lodestar/src/network/reqresp/encoders/responseDecode.ts
+++ b/packages/lodestar/src/network/reqresp/encoders/responseDecode.ts
@@ -93,7 +93,7 @@ export async function readErrorMessage(bufferedSource: BufferedSource): Promise<
     const bytes = buffer.slice();
     try {
       return decodeErrorMessage(bytes);
-    } catch (e) {
+    } catch {
       return bytes.toString("hex");
     }
   }

--- a/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/decode.ts
+++ b/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/decode.ts
@@ -95,7 +95,7 @@ async function readSszSnappyBody(bufferedSource: BufferedSource, sszDataLength: 
         uncompressedData.append(uncompressed);
       }
     } catch (e) {
-      throw new SszSnappyError({code: SszSnappyErrorCode.DECOMPRESSOR_ERROR, decompressorError: e});
+      throw new SszSnappyError({code: SszSnappyErrorCode.DECOMPRESSOR_ERROR, decompressorError: e as Error});
     }
 
     // SHOULD consider invalid reading more bytes than `n` SSZ bytes
@@ -132,6 +132,6 @@ function deserializeSszBody<T extends RequestOrResponseBody>(
       return type.deserialize(bytes) as T;
     }
   } catch (e) {
-    throw new SszSnappyError({code: SszSnappyErrorCode.DESERIALIZE_ERROR, deserializeError: e});
+    throw new SszSnappyError({code: SszSnappyErrorCode.DESERIALIZE_ERROR, deserializeError: e as Error});
   }
 }

--- a/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/encode.ts
+++ b/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/encode.ts
@@ -44,6 +44,6 @@ function serializeSszBody<T extends RequestOrResponseBody>(body: T, type: Reques
     const bytes = type.serialize(body as any);
     return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.length);
   } catch (e) {
-    throw new SszSnappyError({code: SszSnappyErrorCode.SERIALIZE_ERROR, serializeError: e});
+    throw new SszSnappyError({code: SszSnappyErrorCode.SERIALIZE_ERROR, serializeError: e as Error});
   }
 }

--- a/packages/lodestar/src/network/reqresp/reqResp.ts
+++ b/packages/lodestar/src/network/reqresp/reqResp.ts
@@ -81,7 +81,7 @@ export class ReqResp implements IReqResp {
               this.respCount++
             );
             // TODO: Do success peer scoring here
-          } catch (e) {
+          } catch {
             // TODO: Do error peer scoring here
             // Must not throw since this is an event handler
           }
@@ -181,7 +181,7 @@ export class ReqResp implements IReqResp {
 
       return result;
     } catch (e) {
-      const peerAction = onOutgoingReqRespError(e, method);
+      const peerAction = onOutgoingReqRespError(e as Error, method);
       if (peerAction !== null) this.peerRpcScores.applyAction(peerId, peerAction);
 
       throw e;

--- a/packages/lodestar/src/network/reqresp/request/index.ts
+++ b/packages/lodestar/src/network/reqresp/request/index.ts
@@ -81,7 +81,7 @@ export async function sendRequest<T extends phase0.ResponseBody | phase0.Respons
       if (e instanceof TimeoutError) {
         throw new RequestInternalError({code: RequestErrorCode.DIAL_TIMEOUT});
       } else {
-        throw new RequestInternalError({code: RequestErrorCode.DIAL_ERROR, error: e});
+        throw new RequestInternalError({code: RequestErrorCode.DIAL_ERROR, error: e as Error});
       }
     });
 
@@ -103,7 +103,7 @@ export async function sendRequest<T extends phase0.ResponseBody | phase0.Respons
       if (e instanceof TimeoutError) {
         throw new RequestInternalError({code: RequestErrorCode.REQUEST_TIMEOUT});
       } else {
-        throw new RequestInternalError({code: RequestErrorCode.REQUEST_ERROR, error: e});
+        throw new RequestInternalError({code: RequestErrorCode.REQUEST_ERROR, error: e as Error});
       }
     });
 
@@ -130,7 +130,7 @@ export async function sendRequest<T extends phase0.ResponseBody | phase0.Respons
       stream.close();
     }
   } catch (e) {
-    logger.verbose("Req  error", logCtx, e);
+    logger.verbose("Req  error", logCtx, e as Error);
 
     const metadata: IRequestErrorMetadata = {method, encoding, peer};
 

--- a/packages/lodestar/src/network/reqresp/request/responseTimeoutsHandler.ts
+++ b/packages/lodestar/src/network/reqresp/request/responseTimeoutsHandler.ts
@@ -53,7 +53,7 @@ export function responseTimeoutsHandler<T>(
       );
     } catch (e) {
       // Rethrow error properly typed so the peer score can pick it up
-      switch (e.message) {
+      switch ((e as Error).message) {
         case RequestErrorCode.TTFB_TIMEOUT:
           throw new RequestInternalError({code: RequestErrorCode.TTFB_TIMEOUT});
         case RequestErrorCode.RESP_TIMEOUT:

--- a/packages/lodestar/src/network/reqresp/response/index.ts
+++ b/packages/lodestar/src/network/reqresp/response/index.ts
@@ -39,8 +39,8 @@ export async function handleRequest(
     // in case request whose body is a List fails at chunk_i > 0, without breaking out of the for..await..of
     (async function* () {
       try {
-        const requestBody = await pipe(stream.source, requestDecode(config, method, encoding)).catch((e) => {
-          throw new ResponseError(RpcResponseStatus.INVALID_REQUEST, e.message);
+        const requestBody = await pipe(stream.source, requestDecode(config, method, encoding)).catch((e: unknown) => {
+          throw new ResponseError(RpcResponseStatus.INVALID_REQUEST, (e as Error).message);
         });
 
         logger.debug("Resp received request", {...logCtx, requestBody} as Context);
@@ -53,11 +53,11 @@ export async function handleRequest(
         );
       } catch (e) {
         const status = e instanceof ResponseError ? e.status : RpcResponseStatus.SERVER_ERROR;
-        yield* responseEncodeError(status, e.message);
+        yield* responseEncodeError(status, (e as Error).message);
 
         // Should not throw an error here or libp2p-mplex throws with 'AbortError: stream reset'
         // throw e;
-        responseError = e;
+        responseError = e as Error;
       }
     })(),
     stream.sink

--- a/packages/lodestar/src/network/reqresp/utils/bufferedSource.ts
+++ b/packages/lodestar/src/network/reqresp/utils/bufferedSource.ts
@@ -32,6 +32,7 @@ export class BufferedSource {
           return {done: false, value: that.buffer};
         }
 
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const {done, value: chunk} = await that.source.next();
         if (done === true) {
           that.isDone = true;

--- a/packages/lodestar/src/network/tasks/checkPeerAliveTask.ts
+++ b/packages/lodestar/src/network/tasks/checkPeerAliveTask.ts
@@ -49,7 +49,10 @@ export class CheckPeerAliveTask {
         try {
           peerSeq = await this.network.reqResp.ping(peer, seq);
         } catch (e) {
-          this.logger.warn("Cannot ping peer, disconnecting it", {peerId: peer.toB58String(), error: e.message});
+          this.logger.warn("Cannot ping peer, disconnecting it", {
+            peerId: peer.toB58String(),
+            error: (e as Error).message,
+          });
           // a peer may still be good for gossip blocks even it does not response to ping
           // temporarily disable this due to https://github.com/ChainSafe/lodestar/issues/1619
           // await this.network.disconnect(peer);

--- a/packages/lodestar/src/network/tasks/diversifyPeersBySubnetTask.ts
+++ b/packages/lodestar/src/network/tasks/diversifyPeersBySubnetTask.ts
@@ -74,14 +74,14 @@ export class DiversifyPeersBySubnetTask {
       try {
         await Promise.all(toDiscPeers.map((peer) => this.network.disconnect(peer)));
       } catch (e) {
-        this.logger.warn("Cannot disconnect peers", {error: e.message});
+        this.logger.warn("Cannot disconnect peers", {error: (e as Error).message});
       }
     }
 
     try {
       await this.network.searchSubnetPeers(missingSubnets.map((subnet) => String(subnet)));
     } catch (e) {
-      this.logger.warn("Cannot connect to peers on subnet", {subnet: missingSubnets, error: e.message});
+      this.logger.warn("Cannot connect to peers on subnet", {subnet: missingSubnets, error: (e as Error).message});
     }
   };
 }

--- a/packages/lodestar/src/sync/range/chain.ts
+++ b/packages/lodestar/src/sync/range/chain.ts
@@ -67,7 +67,7 @@ export class SyncChain {
   private batchProcessor = new ItTrigger();
   private maybeStuckTimeout!: NodeJS.Timeout; // clearTimeout(undefined) is okay
   /** Sorted map of batches undergoing some kind of processing. */
-  private batches: Map<Epoch, Batch> = new Map();
+  private batches: Map<Epoch, Batch> = new Map<Epoch, Batch>();
 
   private logger: ILogger;
   private config: IBeaconConfig;

--- a/packages/lodestar/src/sync/range/utils/wrapError.ts
+++ b/packages/lodestar/src/sync/range/utils/wrapError.ts
@@ -17,6 +17,6 @@ export async function wrapError<T>(promise: Promise<T>): Promise<Result<T>> {
   try {
     return {err: null, result: await promise};
   } catch (err) {
-    return {err};
+    return {err: err as Error};
   }
 }

--- a/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
+++ b/packages/lodestar/src/sync/regular/oneRangeAhead/fetcher.ts
@@ -96,7 +96,10 @@ export class BlockRangeFetcher implements IBlockRangeFetcher {
           if (result.length > 1) checkLinearChainSegment(this.config, result);
         }
       } catch (e) {
-        this.logger.verbose("Regular Sync: Failed to get block range ", {...(slotRange ?? {}), error: e.message});
+        this.logger.verbose("Regular Sync: Failed to get block range ", {
+          ...(slotRange ?? {}),
+          error: (e as Error).message,
+        });
         // sync is stopped for whatever reasons
         if (e instanceof ErrorAborted) return [];
         result = null;

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -88,7 +88,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
           try {
             await this.goodbye(peer.id, GoodByeReasonCode.CLIENT_SHUTDOWN);
           } catch (e) {
-            this.logger.verbose("Failed to send goodbye", {error: e.message});
+            this.logger.verbose("Failed to send goodbye", {error: (e as Error).message});
           }
         })
     );
@@ -130,7 +130,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
     } catch (e) {
       this.logger.debug("Irrelevant peer", {
         peer: peerId.toB58String(),
-        reason: e instanceof LodestarError ? e.getMetadata() : e.message,
+        reason: e instanceof LodestarError ? e.getMetadata() : (e as Error).message,
       });
       await this.goodbye(peerId, GoodByeReasonCode.IRRELEVANT_NETWORK);
       return;
@@ -183,7 +183,7 @@ export class BeaconReqRespHandler implements IReqRespHandler {
       } catch (e) {
         this.logger.verbose("Failed to get peer latest status and metadata", {
           peerId: peerId.toB58String(),
-          error: e.message,
+          error: (e as Error).message,
         });
         await this.network.disconnect(peerId);
       }

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -254,7 +254,7 @@ export class BeaconSync implements IBeaconSync {
         this.logger.verbose("Failed to get unknown ancestor root from peer", {
           parentRootHex,
           peer: peer.toB58String(),
-          error: e.message,
+          error: (e as Error).message,
           maxRetry,
           retry,
         });

--- a/packages/lodestar/src/sync/utils/attestation-collector.ts
+++ b/packages/lodestar/src/sync/utils/attestation-collector.ts
@@ -21,7 +21,7 @@ export class AttestationCollector {
   private readonly db: IBeaconDb;
   private readonly logger: ILogger;
   private timers: NodeJS.Timeout[] = [];
-  private aggregationDuties: Map<Slot, Set<CommitteeIndex>> = new Map();
+  private aggregationDuties: Map<Slot, Set<CommitteeIndex>> = new Map<Slot, Set<CommitteeIndex>>();
 
   constructor(config: IBeaconConfig, modules: IAttestationCollectorModules) {
     this.config = config;

--- a/packages/lodestar/src/util/io.ts
+++ b/packages/lodestar/src/util/io.ts
@@ -2,7 +2,7 @@ import readline from "readline";
 
 interface IHiddenReadlineInterface extends readline.Interface {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  output?: any;
+  output?: {write: (arg0: string) => void};
   // eslint-disable-next-line @typescript-eslint/naming-convention
   _writeToOutput?(stringToWrite: string): void;
 }
@@ -12,8 +12,8 @@ export function promptPassword(passwordPrompt: string): Promise<string> {
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
   rl._writeToOutput = function _writeToOutput(stringToWrite: string): void {
-    if (stringToWrite === passwordPrompt || stringToWrite.match(/\n/g)) rl.output.write(stringToWrite);
-    else rl.output.write("*");
+    if (stringToWrite === passwordPrompt || stringToWrite.match(/\n/g)) rl.output?.write(stringToWrite);
+    else rl.output?.write("*");
   };
 
   return new Promise((resolve): void => {

--- a/packages/lodestar/src/util/peerMap.ts
+++ b/packages/lodestar/src/util/peerMap.ts
@@ -26,8 +26,8 @@ export class PeerSet {
  * Also, uses a WeakMap to reduce unnecessary calls to `PeerId.toB58String()`
  */
 export class PeerMap<T> {
-  private map: Map<string, T> = new Map();
-  private peers: Map<string, PeerId> = new Map();
+  private map: Map<string, T> = new Map<string, T>();
+  private peers: Map<string, PeerId> = new Map<string, PeerId>();
 
   static from(peers: PeerId[]): PeerMap<void> {
     const peerMap = new PeerMap<void>();

--- a/packages/lodestar/src/util/queue.ts
+++ b/packages/lodestar/src/util/queue.ts
@@ -55,7 +55,7 @@ export class JobQueue {
     } else {
       const start = Date.now();
       try {
-        const result = await job();
+        const result = (await job()) as Job;
         resolve(result);
       } catch (e) {
         reject(e);

--- a/packages/lodestar/src/util/retry.ts
+++ b/packages/lodestar/src/util/retry.ts
@@ -26,7 +26,7 @@ export async function retry<A>(fn: (attempt: number) => A | Promise<A>, opts?: I
     try {
       return await fn(i);
     } catch (e) {
-      lastError = e;
+      lastError = e as Error;
       if (shouldRetry && !shouldRetry(lastError)) {
         break;
       }

--- a/packages/lodestar/test/e2e/chain/factory/block/assembleBlock.test.ts
+++ b/packages/lodestar/test/e2e/chain/factory/block/assembleBlock.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon from "sinon";
+import sinon, {SinonStub} from "sinon";
 import bls, {SecretKey} from "@chainsafe/bls";
 import {List} from "@chainsafe/ssz";
 import {config} from "@chainsafe/lodestar-config/minimal";
@@ -90,8 +90,8 @@ describe("produce block", function () {
 
     const secretKey = secretKeys[validatorIndex];
     const blockProposingService = getBlockProposingService(secretKey);
-    // @ts-ignore
-    blockProposingService.getRpcClient().validator.produceBlock.callsFake(async (slot, randao) => {
+    const produceBlock = blockProposingService.getRpcClient().validator.produceBlock as SinonStub;
+    produceBlock.callsFake(async (slot, randao) => {
       return await assembleBlock(config, chainStub, dbStub, eth1, slot, randao);
     });
     const block = await blockProposingService.createAndPublishBlock(

--- a/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
@@ -2,7 +2,7 @@ import "mocha";
 import {expect} from "chai";
 import {promisify} from "es6-promisify";
 // @ts-ignore
-import leveldown from "leveldown";
+import {destroy} from "leveldown";
 import {AbortController} from "abort-controller";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {LevelDbController} from "@chainsafe/lodestar-db";
@@ -47,7 +47,7 @@ describe("eth1 / Eth1Provider", function () {
 
   before(async () => {
     // Nuke DB to make sure it's empty
-    await promisify<void, string>(leveldown.destroy)(dbLocation);
+    await promisify<void, string>(destroy)(dbLocation);
 
     dbController = new LevelDbController({name: dbLocation}, {logger});
     db = new BeaconDb({
@@ -62,7 +62,7 @@ describe("eth1 / Eth1Provider", function () {
     clearInterval(interval);
     controller.abort();
     await db.stop();
-    await promisify<void, string>(leveldown.destroy)(dbLocation);
+    await promisify<void, string>(destroy)(dbLocation);
   });
 
   it("Should fetch real Pyrmont eth1 data for block proposing", async function () {

--- a/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
@@ -1,8 +1,9 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import "mocha";
 import {expect} from "chai";
 import {promisify} from "es6-promisify";
 // @ts-ignore
-import {destroy} from "leveldown";
+import leveldown from "leveldown";
 import {AbortController} from "abort-controller";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {LevelDbController} from "@chainsafe/lodestar-db";
@@ -47,7 +48,7 @@ describe("eth1 / Eth1Provider", function () {
 
   before(async () => {
     // Nuke DB to make sure it's empty
-    await promisify<void, string>(destroy)(dbLocation);
+    await promisify<void, string>(leveldown.destroy)(dbLocation);
 
     dbController = new LevelDbController({name: dbLocation}, {logger});
     db = new BeaconDb({
@@ -62,7 +63,7 @@ describe("eth1 / Eth1Provider", function () {
     clearInterval(interval);
     controller.abort();
     await db.stop();
-    await promisify<void, string>(destroy)(dbLocation);
+    await promisify<void, string>(leveldown.destroy)(dbLocation);
   });
 
   it("Should fetch real Pyrmont eth1 data for block proposing", async function () {

--- a/packages/lodestar/test/e2e/eth1/jsonRpcHttpClient.test.ts
+++ b/packages/lodestar/test/e2e/eth1/jsonRpcHttpClient.test.ts
@@ -112,7 +112,8 @@ describe("eth1 / jsonRpcHttpClient", function () {
   });
 
   for (const testCase of testCases) {
-    const {id, requestListener, abort, error} = testCase;
+    const {id, requestListener, abort} = testCase;
+    const error = testCase.error as Error;
     let {url, payload} = testCase;
 
     it(id, async function () {

--- a/packages/lodestar/test/sim/threaded/noEth1SimWorker.ts
+++ b/packages/lodestar/test/sim/threaded/noEth1SimWorker.ts
@@ -1,4 +1,5 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
+/* eslint-disable @typescript-eslint/no-floating-promises, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
+// NOTE: @typescript*no-unsafe* rules are disabled above because `workerData` is typed as `any`
 import {parentPort, workerData} from "worker_threads";
 
 import {init} from "@chainsafe/bls";

--- a/packages/lodestar/test/unit/api/impl/beacon/beacon.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/beacon.test.ts
@@ -1,5 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import {BeaconApi} from "../../../../../src/api/impl/beacon";
-import sinon, {SinonStubbedInstance} from "sinon";
+import sinon from "sinon";
 import {StubbedBeaconDb} from "../../../../utils/stub";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {expect} from "chai";
@@ -27,7 +28,6 @@ describe("beacon api implementation", function () {
 
   describe("getGenesis", function () {
     it("success", async function () {
-      /** eslint-disable @typescript-eslint/no-unsafe-member-access */
       (server.chainStub as any).genesisTime = 0;
       (server.chainStub as any).genesisValidatorsRoot = Buffer.alloc(32);
       const genesis = await api.getGenesis();

--- a/packages/lodestar/test/unit/api/impl/beacon/beacon.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/beacon.test.ts
@@ -1,5 +1,5 @@
 import {BeaconApi} from "../../../../../src/api/impl/beacon";
-import sinon from "sinon";
+import sinon, {SinonStubbedInstance} from "sinon";
 import {StubbedBeaconDb} from "../../../../utils/stub";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {expect} from "chai";
@@ -27,6 +27,7 @@ describe("beacon api implementation", function () {
 
   describe("getGenesis", function () {
     it("success", async function () {
+      /** eslint-disable @typescript-eslint/no-unsafe-member-access */
       (server.chainStub as any).genesisTime = 0;
       (server.chainStub as any).genesisValidatorsRoot = Buffer.alloc(32);
       const genesis = await api.getGenesis();

--- a/packages/lodestar/test/unit/api/impl/beacon/beacon.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/beacon.test.ts
@@ -28,6 +28,7 @@ describe("beacon api implementation", function () {
 
   describe("getGenesis", function () {
     it("success", async function () {
+      /** eslint-disable @typescript-eslint/no-unsafe-member-access */
       (server.chainStub as any).genesisTime = 0;
       (server.chainStub as any).genesisValidatorsRoot = Buffer.alloc(32);
       const genesis = await api.getGenesis();

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlock.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlock.test.ts
@@ -1,15 +1,16 @@
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import * as blockUtils from "../../../../../../src/api/impl/beacon/blocks/utils";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {expect, use} from "chai";
 import chaiAsPromised from "chai-as-promised";
 import {generateEmptySignedBlock} from "../../../../../utils/block";
 import {setupApiImplTestServer, ApiImplTestModules} from "../../index.test";
+import {SinonStubFn} from "../../../../../utils/types";
 
 use(chaiAsPromised);
 
 describe("api - beacon - getBlock", function () {
-  let resolveBlockIdStub: SinonStub;
+  let resolveBlockIdStub: SinonStubFn<typeof blockUtils["resolveBlockId"]>;
   let server: ApiImplTestModules;
 
   before(function () {

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlockHeader.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlockHeader.test.ts
@@ -1,15 +1,16 @@
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import * as blockUtils from "../../../../../../src/api/impl/beacon/blocks/utils";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {expect, use} from "chai";
 import chaiAsPromised from "chai-as-promised";
 import {generateEmptySignedBlock} from "../../../../../utils/block";
 import {ApiImplTestModules, setupApiImplTestServer} from "../../index.test";
+import {SinonStubFn} from "../../../../../utils/types";
 
 use(chaiAsPromised);
 
 describe("api - beacon - getBlockHeader", function () {
-  let resolveBlockIdStub: SinonStub;
+  let resolveBlockIdStub: SinonStubFn<typeof blockUtils["resolveBlockId"]>;
   let server: ApiImplTestModules;
 
   before(function () {

--- a/packages/lodestar/test/unit/api/impl/beacon/pool/pool.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/pool/pool.test.ts
@@ -1,6 +1,6 @@
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {BeaconPoolApi} from "../../../../../../src/api/impl/beacon/pool";
 import {Network} from "../../../../../../src/network/network";
 import {
@@ -20,6 +20,7 @@ import {List} from "@chainsafe/ssz";
 import {Eth2Gossipsub} from "../../../../../../src/network/gossip";
 import {generateEmptySignedBlockHeader} from "../../../../../utils/block";
 import {setupApiImplTestServer} from "../../index.test";
+import {SinonStubFn} from "../../../../../utils/types";
 
 describe("beacon pool api impl", function () {
   let poolApi: BeaconPoolApi;
@@ -27,9 +28,9 @@ describe("beacon pool api impl", function () {
   let chainStub: SinonStubbedInstance<IBeaconChain>;
   let networkStub: SinonStubbedInstance<Network>;
   let gossipStub: SinonStubbedInstance<Eth2Gossipsub>;
-  let validateGossipAttesterSlashing: SinonStub;
-  let validateGossipProposerSlashing: SinonStub;
-  let validateVoluntaryExit: SinonStub;
+  let validateGossipAttesterSlashing: SinonStubFn<typeof attesterSlashingValidation["validateGossipAttesterSlashing"]>;
+  let validateGossipProposerSlashing: SinonStubFn<typeof proposerSlashingValidation["validateGossipProposerSlashing"]>;
+  let validateVoluntaryExit: SinonStubFn<typeof voluntaryExitValidation["validateGossipVoluntaryExit"]>;
 
   beforeEach(function () {
     const server = setupApiImplTestServer();

--- a/packages/lodestar/test/unit/api/impl/beacon/state/state.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/state/state.test.ts
@@ -1,17 +1,18 @@
 import {BeaconStateApi} from "../../../../../../src/api/impl/beacon/state/state";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {StubbedBeaconDb} from "../../../../../utils/stub";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {IBeaconStateApi} from "../../../../../../src/api/impl/beacon/state/interface";
 import * as stateApiUtils from "../../../../../../src/api/impl/beacon/state/utils";
 import {generateState} from "../../../../../utils/state";
 import {expect} from "chai";
 import {ApiImplTestModules, setupApiImplTestServer} from "../../index.test";
+import {SinonStubFn} from "../../../../../utils/types";
 
 describe("beacon api impl - states", function () {
   let api: IBeaconStateApi;
-  let resolveStateIdStub: SinonStub;
-  let getEpochBeaconCommitteesStub: SinonStub;
+  let resolveStateIdStub: SinonStubFn<typeof stateApiUtils["resolveStateId"]>;
+  let getEpochBeaconCommitteesStub: SinonStubFn<typeof stateApiUtils["getEpochBeaconCommittees"]>;
   let server: ApiImplTestModules;
 
   before(function () {
@@ -38,7 +39,7 @@ describe("beacon api impl - states", function () {
 
   describe("getState", function () {
     it("should get state by id", async function () {
-      resolveStateIdStub.resolves({state: generateState()});
+      resolveStateIdStub.resolves(generateState());
       const state = await api.getState("something");
       expect(state).to.not.be.null;
     });
@@ -59,13 +60,13 @@ describe("beacon api impl - states", function () {
     const state = generateState();
 
     it("no filters", async function () {
-      resolveStateIdStub.resolves({state});
+      resolveStateIdStub.resolves(state);
       getEpochBeaconCommitteesStub.returns([[[1, 4, 5]], [[2, 3, 6]]]);
       const committees = await api.getStateCommittees("blem");
       expect(committees).to.have.length(2);
     });
     it("slot and committee filter", async function () {
-      resolveStateIdStub.resolves({state});
+      resolveStateIdStub.resolves(state);
       getEpochBeaconCommitteesStub.returns([
         [[1, 4, 5]],
         [

--- a/packages/lodestar/test/unit/api/impl/beacon/state/stateValidators.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/state/stateValidators.test.ts
@@ -12,6 +12,7 @@ import {generateValidator, generateValidators} from "../../../../../utils/valida
 import {BeaconChain} from "../../../../../../src/chain";
 import {StubbedBeaconDb} from "../../../../../utils/stub";
 import {setupApiImplTestServer, ApiImplTestModules} from "../../index.test";
+import {PubkeyIndexMap} from "@chainsafe/lodestar-beacon-state-transition/lib/phase0/fast";
 
 use(chaiAsPromised);
 
@@ -97,9 +98,9 @@ describe("beacon api impl - state - validators", function () {
     it("validator by root not found", async function () {
       resolveStateIdStub.resolves(generateState({validators: generateValidators(10)}));
       chainStub.getHeadState.returns({
-        pubkey2index: {
+        pubkey2index: ({
           get: () => undefined,
-        } as any,
+        } as unknown) as PubkeyIndexMap,
       } as CachedBeaconState<phase0.BeaconState>);
       const api = new BeaconStateApi({}, {config, db: dbStub, chain: chainStub});
       await expect(api.getStateValidator("someState", Buffer.alloc(32, 1))).to.be.rejectedWith("Validator not found");
@@ -107,9 +108,9 @@ describe("beacon api impl - state - validators", function () {
     it("validator by root found", async function () {
       resolveStateIdStub.resolves(generateState({validators: generateValidators(10)}));
       chainStub.getHeadState.returns({
-        pubkey2index: {
+        pubkey2index: ({
           get: () => 2,
-        } as any,
+        } as unknown) as PubkeyIndexMap,
       } as CachedBeaconState<phase0.BeaconState>);
       const api = new BeaconStateApi({}, {config, db: dbStub, chain: chainStub});
       expect(await api.getStateValidator("someState", Buffer.alloc(32, 1))).to.not.be.null;

--- a/packages/lodestar/test/unit/api/impl/debug/beacon/index.test.ts
+++ b/packages/lodestar/test/unit/api/impl/debug/beacon/index.test.ts
@@ -2,7 +2,7 @@ import {ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 import {SinonStubbedInstance} from "sinon";
 import * as stateApiUtils from "../../../../../../src/api/impl/beacon/state/utils";
 import {DebugBeaconApi} from "../../../../../../src/api/impl/debug/beacon";
@@ -12,13 +12,14 @@ import {StubbedBeaconDb} from "../../../../../utils/stub";
 import {generateState} from "../../../../../utils/state";
 import {setupApiImplTestServer} from "../../index.test";
 import {testLogger} from "../../../../../utils/logger";
+import {SinonStubFn} from "../../../../../utils/types";
 
 describe("api - debug - beacon", function () {
   let debugApi: DebugBeaconApi;
   let chainStub: SinonStubbedInstance<IBeaconChain>;
   let forkchoiceStub: SinonStubbedInstance<IForkChoice>;
   let dbStub: StubbedBeaconDb;
-  let resolveStateIdStub: SinonStub;
+  let resolveStateIdStub: SinonStubFn<typeof stateApiUtils["resolveStateId"]>;
   const logger = testLogger();
 
   beforeEach(function () {
@@ -56,7 +57,7 @@ describe("api - debug - beacon", function () {
   });
 
   it("getState - should return state", async function () {
-    resolveStateIdStub.resolves({state: generateState()});
+    resolveStateIdStub.resolves(generateState());
     const state = await debugApi.getState("something");
     expect(state).to.not.be.null;
   });

--- a/packages/lodestar/test/unit/api/impl/events/events.test.ts
+++ b/packages/lodestar/test/unit/api/impl/events/events.test.ts
@@ -1,4 +1,13 @@
-import {BeaconEvent, BeaconEventType, EventsApi} from "../../../../../src/api/impl/events";
+import {
+  BeaconAttestationEvent,
+  BeaconBlockEvent,
+  BeaconChainReorgEvent,
+  BeaconEventType,
+  BeaconHeadEvent,
+  EventsApi,
+  FinalizedCheckpointEvent,
+  VoluntaryExitEvent,
+} from "../../../../../src/api/impl/events";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import sinon, {SinonStubbedInstance} from "sinon";
 import {BeaconChain, ChainEvent, ChainEventEmitter, IBeaconChain} from "../../../../../src/chain";
@@ -27,8 +36,8 @@ describe("Events api impl", function () {
       chainEventEmmitter.emit(ChainEvent.forkChoiceHead, headSummary);
       const event = await stream[Symbol.asyncIterator]().next();
       expect(event?.value).to.not.be.null;
-      expect((event.value as BeaconEvent).type).to.equal(BeaconEventType.HEAD);
-      expect((event.value as BeaconEvent).message).to.not.be.null;
+      expect((event.value as BeaconHeadEvent).type).to.equal(BeaconEventType.HEAD);
+      expect((event.value as BeaconHeadEvent).message).to.not.be.null;
       stream.stop();
     });
 
@@ -38,8 +47,8 @@ describe("Events api impl", function () {
       chainEventEmmitter.emit(ChainEvent.forkChoiceHead, headSummary);
       const event = await stream[Symbol.asyncIterator]().next();
       expect(event?.value).to.not.be.null;
-      expect((event.value as BeaconEvent).type).to.equal(BeaconEventType.HEAD);
-      expect((event.value as BeaconEvent).message).to.not.be.null;
+      expect((event.value as BeaconHeadEvent).type).to.equal(BeaconEventType.HEAD);
+      expect((event.value as BeaconHeadEvent).message).to.not.be.null;
       stream.stop();
     });
 
@@ -49,8 +58,8 @@ describe("Events api impl", function () {
       chainEventEmmitter.emit(ChainEvent.block, block, null as any, null as any);
       const event = await stream[Symbol.asyncIterator]().next();
       expect(event?.value).to.not.be.null;
-      expect((event.value as BeaconEvent).type).to.equal(BeaconEventType.BLOCK);
-      expect((event.value as BeaconEvent).message).to.not.be.null;
+      expect((event.value as BeaconBlockEvent).type).to.equal(BeaconEventType.BLOCK);
+      expect((event.value as BeaconBlockEvent).message).to.not.be.null;
       stream.stop();
     });
 
@@ -60,8 +69,8 @@ describe("Events api impl", function () {
       chainEventEmmitter.emit(ChainEvent.attestation, attestation);
       const event = await stream[Symbol.asyncIterator]().next();
       expect(event?.value).to.not.be.null;
-      expect((event.value as BeaconEvent).type).to.equal(BeaconEventType.ATTESTATION);
-      expect((event.value as BeaconEvent).message).to.equal(attestation);
+      expect((event.value as BeaconAttestationEvent).type).to.equal(BeaconEventType.ATTESTATION);
+      expect((event.value as BeaconAttestationEvent).message).to.equal(attestation);
       stream.stop();
     });
 
@@ -73,8 +82,8 @@ describe("Events api impl", function () {
       chainEventEmmitter.emit(ChainEvent.block, block, null as any, null as any);
       const event = await stream[Symbol.asyncIterator]().next();
       expect(event?.value).to.not.be.null;
-      expect((event.value as BeaconEvent).type).to.equal(BeaconEventType.VOLUNTARY_EXIT);
-      expect((event.value as BeaconEvent).message).to.equal(exit);
+      expect((event.value as VoluntaryExitEvent).type).to.equal(BeaconEventType.VOLUNTARY_EXIT);
+      expect((event.value as VoluntaryExitEvent).message).to.equal(exit);
       stream.stop();
     });
 
@@ -84,8 +93,8 @@ describe("Events api impl", function () {
       chainEventEmmitter.emit(ChainEvent.finalized, checkpoint, null as any);
       const event = await stream[Symbol.asyncIterator]().next();
       expect(event?.value).to.not.be.null;
-      expect((event.value as BeaconEvent).type).to.equal(BeaconEventType.FINALIZED_CHECKPOINT);
-      expect((event.value as BeaconEvent).message).to.not.be.null;
+      expect((event.value as FinalizedCheckpointEvent).type).to.equal(BeaconEventType.FINALIZED_CHECKPOINT);
+      expect((event.value as FinalizedCheckpointEvent).message).to.not.be.null;
       stream.stop();
     });
 
@@ -96,9 +105,9 @@ describe("Events api impl", function () {
       chainEventEmmitter.emit(ChainEvent.forkChoiceReorg, oldHead, newHead, 3);
       const event = await stream[Symbol.asyncIterator]().next();
       expect(event?.value).to.not.be.null;
-      expect((event.value as BeaconEvent).type).to.equal(BeaconEventType.CHAIN_REORG);
-      expect((event.value as BeaconEvent).message).to.not.be.null;
-      expect((event.value as BeaconEvent).message.depth).to.equal(3);
+      expect((event.value as BeaconChainReorgEvent).type).to.equal(BeaconEventType.CHAIN_REORG);
+      expect((event.value as BeaconChainReorgEvent).message).to.not.be.null;
+      expect((event.value as BeaconChainReorgEvent).message.depth).to.equal(3);
       stream.stop();
     });
   });

--- a/packages/lodestar/test/unit/api/impl/events/events.test.ts
+++ b/packages/lodestar/test/unit/api/impl/events/events.test.ts
@@ -1,4 +1,4 @@
-import {BeaconEventType, EventsApi} from "../../../../../src/api/impl/events";
+import {BeaconEvent, BeaconEventType, EventsApi} from "../../../../../src/api/impl/events";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import sinon, {SinonStubbedInstance} from "sinon";
 import {BeaconChain, ChainEvent, ChainEventEmitter, IBeaconChain} from "../../../../../src/chain";
@@ -27,8 +27,8 @@ describe("Events api impl", function () {
       chainEventEmmitter.emit(ChainEvent.forkChoiceHead, headSummary);
       const event = await stream[Symbol.asyncIterator]().next();
       expect(event?.value).to.not.be.null;
-      expect(event.value.type).to.equal(BeaconEventType.HEAD);
-      expect(event.value.message).to.not.be.null;
+      expect((event.value as BeaconEvent).type).to.equal(BeaconEventType.HEAD);
+      expect((event.value as BeaconEvent).message).to.not.be.null;
       stream.stop();
     });
 
@@ -38,8 +38,8 @@ describe("Events api impl", function () {
       chainEventEmmitter.emit(ChainEvent.forkChoiceHead, headSummary);
       const event = await stream[Symbol.asyncIterator]().next();
       expect(event?.value).to.not.be.null;
-      expect(event.value.type).to.equal(BeaconEventType.HEAD);
-      expect(event.value.message).to.not.be.null;
+      expect((event.value as BeaconEvent).type).to.equal(BeaconEventType.HEAD);
+      expect((event.value as BeaconEvent).message).to.not.be.null;
       stream.stop();
     });
 
@@ -49,8 +49,8 @@ describe("Events api impl", function () {
       chainEventEmmitter.emit(ChainEvent.block, block, null as any, null as any);
       const event = await stream[Symbol.asyncIterator]().next();
       expect(event?.value).to.not.be.null;
-      expect(event.value.type).to.equal(BeaconEventType.BLOCK);
-      expect(event.value.message).to.not.be.null;
+      expect((event.value as BeaconEvent).type).to.equal(BeaconEventType.BLOCK);
+      expect((event.value as BeaconEvent).message).to.not.be.null;
       stream.stop();
     });
 
@@ -60,8 +60,8 @@ describe("Events api impl", function () {
       chainEventEmmitter.emit(ChainEvent.attestation, attestation);
       const event = await stream[Symbol.asyncIterator]().next();
       expect(event?.value).to.not.be.null;
-      expect(event.value.type).to.equal(BeaconEventType.ATTESTATION);
-      expect(event.value.message).to.equal(attestation);
+      expect((event.value as BeaconEvent).type).to.equal(BeaconEventType.ATTESTATION);
+      expect((event.value as BeaconEvent).message).to.equal(attestation);
       stream.stop();
     });
 
@@ -73,8 +73,8 @@ describe("Events api impl", function () {
       chainEventEmmitter.emit(ChainEvent.block, block, null as any, null as any);
       const event = await stream[Symbol.asyncIterator]().next();
       expect(event?.value).to.not.be.null;
-      expect(event.value.type).to.equal(BeaconEventType.VOLUNTARY_EXIT);
-      expect(event.value.message).to.equal(exit);
+      expect((event.value as BeaconEvent).type).to.equal(BeaconEventType.VOLUNTARY_EXIT);
+      expect((event.value as BeaconEvent).message).to.equal(exit);
       stream.stop();
     });
 
@@ -84,8 +84,8 @@ describe("Events api impl", function () {
       chainEventEmmitter.emit(ChainEvent.finalized, checkpoint, null as any);
       const event = await stream[Symbol.asyncIterator]().next();
       expect(event?.value).to.not.be.null;
-      expect(event.value.type).to.equal(BeaconEventType.FINALIZED_CHECKPOINT);
-      expect(event.value.message).to.not.be.null;
+      expect((event.value as BeaconEvent).type).to.equal(BeaconEventType.FINALIZED_CHECKPOINT);
+      expect((event.value as BeaconEvent).message).to.not.be.null;
       stream.stop();
     });
 
@@ -96,9 +96,9 @@ describe("Events api impl", function () {
       chainEventEmmitter.emit(ChainEvent.forkChoiceReorg, oldHead, newHead, 3);
       const event = await stream[Symbol.asyncIterator]().next();
       expect(event?.value).to.not.be.null;
-      expect(event.value.type).to.equal(BeaconEventType.CHAIN_REORG);
-      expect(event.value.message).to.not.be.null;
-      expect(event.value.message.depth).to.equal(3);
+      expect((event.value as BeaconEvent).type).to.equal(BeaconEventType.CHAIN_REORG);
+      expect((event.value as BeaconEvent).message).to.not.be.null;
+      expect((event.value as BeaconEvent).message.depth).to.equal(3);
       stream.stop();
     });
   });

--- a/packages/lodestar/test/unit/api/impl/validator/duties/proposer.test.ts
+++ b/packages/lodestar/test/unit/api/impl/validator/duties/proposer.test.ts
@@ -44,7 +44,7 @@ describe("get proposers api impl", function () {
       await api.getProposerDuties(1);
       expect.fail("Expect error here");
     } catch (e) {
-      expect(e.message.startsWith("Node is syncing")).to.be.true;
+      expect((e as Error).message.startsWith("Node is syncing")).to.be.true;
     }
   });
 
@@ -55,7 +55,7 @@ describe("get proposers api impl", function () {
       await api.getProposerDuties(1);
       expect.fail("Expect error here");
     } catch (e) {
-      expect(e.message.startsWith("Node is stopped")).to.be.true;
+      expect((e as Error).message.startsWith("Node is stopped")).to.be.true;
     }
   });
 

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlock.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlock.test.ts
@@ -3,7 +3,7 @@ import supertest from "supertest";
 
 import {getBlock} from "../../../../../../src/api/rest/controllers/beacon/blocks";
 import {generateEmptySignedBlock} from "../../../../../utils/block";
-import {urlJoin} from "../../utils";
+import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {IBeaconBlocksApi} from "../../../../../../src/api/impl/beacon/blocks";
@@ -29,7 +29,7 @@ describe("rest - beacon - getBlock", function () {
       .get(urlJoin(BEACON_PREFIX, getBlock.url.replace(":blockId", "head")))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
   });
 
   it("should not found block header", async function () {

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockAttestations.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockAttestations.test.ts
@@ -7,7 +7,7 @@ import {phase0} from "@chainsafe/lodestar-types";
 import {getBlockAttestations} from "../../../../../../src/api/rest/controllers/beacon/blocks";
 import {generateSignedBlock} from "../../../../../utils/block";
 import {generateEmptyAttestation} from "../../../../../utils/attestation";
-import {urlJoin} from "../../utils";
+import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {RestApi} from "../../../../../../src/api";
@@ -40,8 +40,8 @@ describe("rest - beacon - getBlockAttestations", function () {
       .get(urlJoin(BEACON_PREFIX, getBlockAttestations.url.replace(":blockId", "head")))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
-    expect(response.body.data.length).to.equal(2);
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data.length).to.equal(2);
   });
 
   it("should not found block", async function () {

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockHeader.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockHeader.test.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import supertest from "supertest";
 import {getBlockHeader} from "../../../../../../src/api/rest/controllers/beacon/blocks";
 import {generateSignedBeaconHeaderResponse} from "../../../../../utils/api";
-import {urlJoin} from "../../utils";
+import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {RestApi} from "../../../../../../src/api";
@@ -27,7 +27,7 @@ describe("rest - beacon - getBlockHeader", function () {
       .get(urlJoin(BEACON_PREFIX, getBlockHeader.url.replace(":blockId", "head")))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
   });
 
   it("should not found block header", async function () {

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockHeaders.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockHeaders.test.ts
@@ -4,7 +4,7 @@ import {toHexString} from "@chainsafe/ssz";
 
 import {getBlockHeaders} from "../../../../../../src/api/rest/controllers/beacon/blocks";
 import {generateSignedBeaconHeaderResponse} from "../../../../../utils/api";
-import {urlJoin} from "../../utils";
+import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {RestApi} from "../../../../../../src/api";
@@ -29,7 +29,7 @@ describe("rest - beacon - getBlockHeaders", function () {
       .get(urlJoin(BEACON_PREFIX, getBlockHeaders.url))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data.length).to.be.equal(1);
+    expect((response.body as ApiResponseBody).data.length).to.be.equal(1);
   });
 
   it("should parse slot param", async function () {
@@ -41,7 +41,7 @@ describe("rest - beacon - getBlockHeaders", function () {
       .query({slot: "1"})
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data.length).to.be.equal(1);
+    expect((response.body as ApiResponseBody).data.length).to.be.equal(1);
   });
 
   it("should parse parentRoot param", async function () {
@@ -54,7 +54,7 @@ describe("rest - beacon - getBlockHeaders", function () {
       .query({parent_root: toHexString(Buffer.alloc(32, 1))})
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data.length).to.be.equal(1);
+    expect((response.body as ApiResponseBody).data.length).to.be.equal(1);
   });
 
   it("should throw validation error on invalid slot", async function () {

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockRoot.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockRoot.test.ts
@@ -5,7 +5,7 @@ import {config} from "@chainsafe/lodestar-config/minimal";
 
 import {getBlockRoot} from "../../../../../../src/api/rest/controllers/beacon/blocks";
 import {generateEmptySignedBlock} from "../../../../../utils/block";
-import {urlJoin} from "../../utils";
+import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {RestApi} from "../../../../../../src/api";
@@ -31,7 +31,7 @@ describe("rest - beacon - getBlockRoot", function () {
       .get(urlJoin(BEACON_PREFIX, getBlockRoot.url.replace(":blockId", "head")))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data.root).to.be.equal(
+    expect((response.body as ApiResponseBody).data.root).to.be.equal(
       toHexString(config.types.phase0.BeaconBlock.hashTreeRoot(block.message))
     );
   });

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockRoot.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockRoot.test.ts
@@ -5,7 +5,7 @@ import {config} from "@chainsafe/lodestar-config/minimal";
 
 import {getBlockRoot} from "../../../../../../src/api/rest/controllers/beacon/blocks";
 import {generateEmptySignedBlock} from "../../../../../utils/block";
-import {ApiResponseBody, urlJoin} from "../../utils";
+import {urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {RestApi} from "../../../../../../src/api";
@@ -31,7 +31,8 @@ describe("rest - beacon - getBlockRoot", function () {
       .get(urlJoin(BEACON_PREFIX, getBlockRoot.url.replace(":blockId", "head")))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect((response.body as ApiResponseBody).data.root).to.be.equal(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(response.body.data.root).to.be.equal(
       toHexString(config.types.phase0.BeaconBlock.hashTreeRoot(block.message))
     );
   });

--- a/packages/lodestar/test/unit/api/rest/beacon/getGenesis.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/getGenesis.test.ts
@@ -3,7 +3,7 @@ import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 
 import {getGenesis} from "../../../../../src/api/rest/controllers/beacon";
-import {urlJoin} from "../utils";
+import {ApiResponseBody, urlJoin} from "../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../index.test";
 import {BeaconApi, RestApi} from "../../../../../src/api";
 import {SinonStubbedInstance} from "sinon";
@@ -27,8 +27,10 @@ describe("rest - beacon - getGenesis", function () {
       .get(urlJoin(BEACON_PREFIX, getGenesis.url))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(response.body.data.genesis_time).to.equal("0");
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(response.body.data.genesis_validators_root).to.not.be.empty;
   });
 

--- a/packages/lodestar/test/unit/api/rest/beacon/pool/getAttesterSlashings.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/pool/getAttesterSlashings.test.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import supertest from "supertest";
 import {getAttesterSlashings} from "../../../../../../src/api/rest/controllers/beacon/pool/getAttesterSlashings";
 import {generateEmptyAttesterSlashing} from "../../../../../utils/slashings";
-import {urlJoin} from "../../utils";
+import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {BeaconPoolApi} from "../../../../../../src/api/impl/beacon/pool";
@@ -16,6 +16,6 @@ describe("rest - beacon - getAttesterSlashings", function () {
       .get(urlJoin(BEACON_PREFIX, getAttesterSlashings.url))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data.length).to.be.equal(1);
+    expect((response.body as ApiResponseBody).data.length).to.be.equal(1);
   });
 });

--- a/packages/lodestar/test/unit/api/rest/beacon/pool/getPoolAttestations.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/pool/getPoolAttestations.test.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import supertest from "supertest";
 import {getPoolAttestations} from "../../../../../../src/api/rest/controllers/beacon/pool";
 import {generateAttestation} from "../../../../../utils/attestation";
-import {urlJoin} from "../../utils";
+import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {BeaconPoolApi} from "../../../../../../src/api/impl/beacon/pool";
@@ -18,6 +18,6 @@ describe("rest - beacon - getPoolAttestations", function () {
       .query({slot: "1", committee_index: "1"})
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data.length).to.be.equal(1);
+    expect((response.body as ApiResponseBody).data.length).to.be.equal(1);
   });
 });

--- a/packages/lodestar/test/unit/api/rest/beacon/pool/getProposerSlashings.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/pool/getProposerSlashings.test.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import supertest from "supertest";
 import {getProposerSlashings} from "../../../../../../src/api/rest/controllers/beacon/pool/getProposerSlashings";
 import {generateEmptyProposerSlashing} from "../../../../../utils/slashings";
-import {urlJoin} from "../../utils";
+import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {BeaconPoolApi} from "../../../../../../src/api/impl/beacon/pool";
@@ -16,6 +16,6 @@ describe("rest - beacon - getProposerSlashings", function () {
       .get(urlJoin(BEACON_PREFIX, getProposerSlashings.url))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data.length).to.be.equal(1);
+    expect((response.body as ApiResponseBody).data.length).to.be.equal(1);
   });
 });

--- a/packages/lodestar/test/unit/api/rest/beacon/pool/getVoluntaryExits.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/pool/getVoluntaryExits.test.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import supertest from "supertest";
 import {getVoluntaryExits} from "../../../../../../src/api/rest/controllers/beacon/pool/getVoluntaryExits";
 import {generateEmptySignedVoluntaryExit} from "../../../../../utils/attestation";
-import {urlJoin} from "../../utils";
+import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {BeaconPoolApi} from "../../../../../../src/api/impl/beacon/pool";
@@ -16,6 +16,6 @@ describe("rest - beacon - getVoluntaryExits", function () {
       .get(urlJoin(BEACON_PREFIX, getVoluntaryExits.url))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data.length).to.be.equal(1);
+    expect((response.body as ApiResponseBody).data.length).to.be.equal(1);
   });
 });

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getBeaconCommittees.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getBeaconCommittees.test.ts
@@ -4,7 +4,7 @@ import {expect} from "chai";
 import supertest from "supertest";
 import {StateNotFound} from "../../../../../../src/api/impl/errors/api";
 import {getStateBeaconCommittees} from "../../../../../../src/api/rest/controllers/beacon/state";
-import {urlJoin} from "../../utils";
+import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {RestApi} from "../../../../../../src/api";
@@ -31,8 +31,8 @@ describe("rest - beacon - getStateBeaconCommittees", function () {
       .get(urlJoin(BEACON_PREFIX, getStateBeaconCommittees.url.replace(":stateId", "head")))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
-    expect(response.body.data.length).to.be.equal(1);
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data.length).to.be.equal(1);
   });
 
   it("should succeed with filters", async function () {
@@ -52,8 +52,8 @@ describe("rest - beacon - getStateBeaconCommittees", function () {
       })
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
-    expect(response.body.data.length).to.be.equal(1);
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data.length).to.be.equal(1);
   });
 
   it("string slot", async function () {

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getStateFinalityCheckpoints.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getStateFinalityCheckpoints.test.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import supertest from "supertest";
 import {getStateFinalityCheckpoints} from "../../../../../../src/api/rest/controllers/beacon/state";
 import {generateState} from "../../../../../utils/state";
-import {urlJoin} from "../../utils";
+import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";
 import {BeaconStateApi} from "../../../../../../src/api/impl/beacon/state";
 import {SinonStubbedInstance} from "sinon";
@@ -23,7 +23,8 @@ describe("rest - beacon - getStateFinalityCheckpoints", function () {
       .get(urlJoin(BEACON_PREFIX, getStateFinalityCheckpoints.url.replace(":stateId", "head")))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(response.body.data.finalized).to.not.be.undefined;
   });
 

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getStateFork.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getStateFork.test.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
 import supertest from "supertest";
 import {generateState} from "../../../../../utils/state";
-import {urlJoin} from "../../utils";
+import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";
 import {getStateFork} from "../../../../../../src/api/rest/controllers/beacon/state/getStateFork";
 import {SinonStubbedInstance} from "sinon";
@@ -23,7 +23,8 @@ describe("rest - beacon - getStateFork", function () {
       .get(urlJoin(BEACON_PREFIX, getStateFork.url.replace(":stateId", "head")))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(response.body.data.current_version).to.not.be.undefined;
   });
 

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getValidator.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getValidator.test.ts
@@ -5,7 +5,7 @@ import supertest from "supertest";
 import {StateNotFound} from "../../../../../../src/api/impl/errors/api";
 import {getStateValidator} from "../../../../../../src/api/rest/controllers/beacon/state/getValidator";
 import {generateValidator} from "../../../../../utils/validator";
-import {urlJoin} from "../../utils";
+import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";
 import {phase0} from "@chainsafe/lodestar-types";
 import {BeaconStateApi} from "../../../../../../src/api/impl/beacon/state";
@@ -33,7 +33,8 @@ describe("rest - beacon - getStateValidator", function () {
       .get(urlJoin(BEACON_PREFIX, getStateValidator.url.replace(":stateId", "head").replace(":validatorId", pubkey)))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(response.body.data.balance).to.not.be.undefined;
   });
 
@@ -48,7 +49,8 @@ describe("rest - beacon - getStateValidator", function () {
       .get(urlJoin(BEACON_PREFIX, getStateValidator.url.replace(":stateId", "head").replace(":validatorId", "1")))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(response.body.data.balance).to.not.be.undefined;
   });
 

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getValidators.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getValidators.test.ts
@@ -3,7 +3,7 @@ import supertest from "supertest";
 import {StateNotFound} from "../../../../../../src/api/impl/errors/api";
 import {getStateValidators} from "../../../../../../src/api/rest/controllers/beacon";
 import {generateValidator} from "../../../../../utils/validator";
-import {urlJoin} from "../../utils";
+import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";
 import {phase0} from "@chainsafe/lodestar-types";
 import {SinonStubbedInstance} from "sinon";
@@ -32,8 +32,8 @@ describe("rest - beacon - getStateValidators", function () {
       .get(urlJoin(BEACON_PREFIX, getStateValidators.url.replace(":stateId", "head")))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
-    expect(response.body.data.length).to.equal(1);
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data.length).to.equal(1);
   });
 
   it("should not found state", async function () {

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getValidatorsBalances.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getValidatorsBalances.test.ts
@@ -4,7 +4,7 @@ import {expect} from "chai";
 import supertest from "supertest";
 import {StateNotFound} from "../../../../../../src/api/impl/errors/api";
 import {getStateValidatorsBalances} from "../../../../../../src/api/rest/controllers/beacon";
-import {urlJoin} from "../../utils";
+import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {RestApi} from "../../../../../../src/api";
@@ -30,8 +30,8 @@ describe("rest - beacon - getStateValidatorsBalances", function () {
       .get(urlJoin(BEACON_PREFIX, getStateValidatorsBalances.url.replace(":stateId", "head")))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
-    expect(response.body.data.length).to.equal(1);
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data.length).to.equal(1);
   });
 
   it("should success with indices filter", async function () {
@@ -54,8 +54,8 @@ describe("rest - beacon - getStateValidatorsBalances", function () {
       })
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
-    expect(response.body.data.length).to.equal(2);
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data.length).to.equal(2);
   });
 
   it("should not found state", async function () {

--- a/packages/lodestar/test/unit/api/rest/config/getDepositContract.test.ts
+++ b/packages/lodestar/test/unit/api/rest/config/getDepositContract.test.ts
@@ -6,6 +6,7 @@ import {CONFIG_PREFIX, setupRestApiTestServer} from "../index.test";
 import {getDepositContract} from "../../../../../src/api/rest/controllers/config";
 import {ConfigApi} from "../../../../../src/api/impl/config";
 import {SinonStubbedInstance} from "sinon";
+import {ApiResponseBody} from "../utils";
 
 describe("rest - config - getDepositContract", function () {
   it("ready", async function () {
@@ -23,9 +24,11 @@ describe("rest - config - getDepositContract", function () {
     const response = await supertest(restApi.server.server)
       .get(urlJoin(CONFIG_PREFIX, getDepositContract.url))
       .expect(200);
-    expect(response.body.data).to.not.be.undefined;
-    expect(Object.keys(response.body.data).length).to.equal(2);
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    expect(Object.keys((response.body as ApiResponseBody).data).length).to.equal(2);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(response.body.data.chain_id).to.equal(Object.values(expectedJson)[0]);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(response.body.data.address).to.equal(Object.values(expectedJson)[1]);
   });
 });

--- a/packages/lodestar/test/unit/api/rest/config/getForkSchedule.test.ts
+++ b/packages/lodestar/test/unit/api/rest/config/getForkSchedule.test.ts
@@ -6,6 +6,7 @@ import {CONFIG_PREFIX, setupRestApiTestServer} from "../index.test";
 import {getForkSchedule} from "../../../../../src/api/rest/controllers/config";
 import {SinonStubbedInstance} from "sinon";
 import {ConfigApi} from "../../../../../src/api/impl/config";
+import {ApiResponseBody} from "../utils";
 
 describe("rest - config - getForkSchedule", function () {
   it("ready", async function () {
@@ -16,7 +17,7 @@ describe("rest - config - getForkSchedule", function () {
     const response = await supertest(restApi.server.server)
       .get(urlJoin(CONFIG_PREFIX, getForkSchedule.url))
       .expect(200);
-    expect(response.body.data).to.not.be.undefined;
-    expect(response.body.data).to.deep.equal(expectedData);
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.deep.equal(expectedData);
   });
 });

--- a/packages/lodestar/test/unit/api/rest/config/getSpec.test.ts
+++ b/packages/lodestar/test/unit/api/rest/config/getSpec.test.ts
@@ -7,6 +7,7 @@ import {CONFIG_PREFIX, setupRestApiTestServer} from "../index.test";
 import {getSpec} from "../../../../../src/api/rest/controllers/config";
 import {SinonStubbedInstance} from "sinon";
 import {ConfigApi} from "../../../../../src/api/impl/config";
+import {ApiResponseBody} from "../utils";
 
 describe("rest - config - getSpec", function () {
   it("ready", async function () {
@@ -14,7 +15,7 @@ describe("rest - config - getSpec", function () {
     const configStub = restApi.server.api.config as SinonStubbedInstance<ConfigApi>;
     configStub.getSpec.resolves(config.params);
     const response = await supertest(restApi.server.server).get(urlJoin(CONFIG_PREFIX, getSpec.url)).expect(200);
-    expect(response.body.data).to.not.be.undefined;
-    expect(response.body.data).to.deep.equal(BeaconParams.toJson(config.params));
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.deep.equal(BeaconParams.toJson(config.params));
   });
 });

--- a/packages/lodestar/test/unit/api/rest/debug/beacon/getHeads.test.ts
+++ b/packages/lodestar/test/unit/api/rest/debug/beacon/getHeads.test.ts
@@ -5,6 +5,7 @@ import {SinonStubbedInstance} from "sinon";
 import {DebugBeaconApi} from "../../../../../../src/api/impl/debug/beacon";
 import {RestApi} from "../../../../../../src/api";
 import {setupRestApiTestServer} from "../../index.test";
+import {ApiResponseBody} from "../../utils";
 
 describe("rest - debug - beacon - getHeads", function () {
   let debugBeaconStub: SinonStubbedInstance<DebugBeaconApi>;
@@ -21,7 +22,7 @@ describe("rest - debug - beacon - getHeads", function () {
       .get("/eth/v1/debug/beacon/heads")
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
   });
 
   it("should not found heads", async function () {

--- a/packages/lodestar/test/unit/api/rest/debug/beacon/getState.test.ts
+++ b/packages/lodestar/test/unit/api/rest/debug/beacon/getState.test.ts
@@ -8,6 +8,7 @@ import {testLogger} from "../../../../../utils/logger";
 import {SinonStubbedInstance} from "sinon";
 import {DebugBeaconApi} from "../../../../../../src/api/impl/debug/beacon";
 import {generateState} from "../../../../../utils/state";
+import {ApiResponseBody} from "../../utils";
 
 describe("rest - debug - beacon - getState", function () {
   let restApi: RestApi;
@@ -43,7 +44,7 @@ describe("rest - debug - beacon - getState", function () {
       .get("/eth/v1/debug/beacon/states/0xSomething")
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
   });
 
   it("should get state ssz successfully", async function () {

--- a/packages/lodestar/test/unit/api/rest/node/getNetworkIdentity.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getNetworkIdentity.test.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import supertest from "supertest";
 
 import {getNetworkIdentity} from "../../../../../src/api/rest/controllers/node/getNetworkIdentity";
-import {urlJoin} from "../utils";
+import {ApiResponseBody, urlJoin} from "../utils";
 import {NODE_PREFIX, setupRestApiTestServer} from "../index.test";
 import {StubbedNodeApi} from "../../../../utils/stub/nodeApi";
 
@@ -25,8 +25,9 @@ describe("rest - node - getNetworkIdentity", function () {
       .get(urlJoin(NODE_PREFIX, getNetworkIdentity.url))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
-    expect(response.body.data).to.not.be.empty;
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.empty;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(response.body.data.p2p_addresses.length).to.equal(1);
   });
 });

--- a/packages/lodestar/test/unit/api/rest/node/getPeer.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getPeer.test.ts
@@ -30,7 +30,8 @@ describe("rest - node - getPeer", function () {
       .expect("Content-Type", "application/json; charset=utf-8");
     expect((response.body as ApiResponseBody).data).to.not.be.undefined;
     expect((response.body as ApiResponseBody).data).to.not.be.empty;
-    expect((response.body as ApiResponseBody).data.peer_id).to.equal("16");
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(response.body.data.peer_id).to.equal("16");
   });
 
   it("peer not found", async function () {

--- a/packages/lodestar/test/unit/api/rest/node/getPeer.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getPeer.test.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import supertest from "supertest";
 
 import {getPeer} from "../../../../../src/api/rest/controllers/node";
-import {urlJoin} from "../utils";
+import {ApiResponseBody, urlJoin} from "../utils";
 import {NODE_PREFIX, setupRestApiTestServer} from "../index.test";
 import {RestApi} from "../../../../../src/api";
 import {StubbedNodeApi} from "../../../../utils/stub/nodeApi";
@@ -28,8 +28,9 @@ describe("rest - node - getPeer", function () {
       .get(urlJoin(NODE_PREFIX, getPeer.url.replace(":peerId", "16")))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
-    expect(response.body.data).to.not.be.empty;
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.empty;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(response.body.data.peer_id).to.equal("16");
   });
 

--- a/packages/lodestar/test/unit/api/rest/node/getPeer.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getPeer.test.ts
@@ -30,8 +30,7 @@ describe("rest - node - getPeer", function () {
       .expect("Content-Type", "application/json; charset=utf-8");
     expect((response.body as ApiResponseBody).data).to.not.be.undefined;
     expect((response.body as ApiResponseBody).data).to.not.be.empty;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(response.body.data.peer_id).to.equal("16");
+    expect((response.body as ApiResponseBody).data.peer_id).to.equal("16");
   });
 
   it("peer not found", async function () {

--- a/packages/lodestar/test/unit/api/rest/node/getPeer.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getPeer.test.ts
@@ -31,7 +31,7 @@ describe("rest - node - getPeer", function () {
     expect((response.body as ApiResponseBody).data).to.not.be.undefined;
     expect((response.body as ApiResponseBody).data).to.not.be.empty;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(response.body.data).to.equal("16");
+    expect(response.body.data.peer_id).to.equal("16");
   });
 
   it("peer not found", async function () {

--- a/packages/lodestar/test/unit/api/rest/node/getPeer.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getPeer.test.ts
@@ -30,7 +30,8 @@ describe("rest - node - getPeer", function () {
       .expect("Content-Type", "application/json; charset=utf-8");
     expect((response.body as ApiResponseBody).data).to.not.be.undefined;
     expect((response.body as ApiResponseBody).data).to.not.be.empty;
-    expect((response.body as ApiResponseBody).data.peer_id).to.equal("16");
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(response.body.data).to.equal("16");
   });
 
   it("peer not found", async function () {

--- a/packages/lodestar/test/unit/api/rest/node/getPeers.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getPeers.test.ts
@@ -2,11 +2,11 @@ import {expect} from "chai";
 import supertest from "supertest";
 
 import {getPeers} from "../../../../../src/api/rest/controllers/node";
-import {urlJoin} from "../utils";
+import {ApiResponseBody, urlJoin} from "../utils";
 import {NODE_PREFIX, setupRestApiTestServer} from "../index.test";
 import {StubbedNodeApi} from "../../../../utils/stub/nodeApi";
 
-describe("rest - node - getPeers", function () {
+describe.only("rest - node - getPeers", function () {
   it("should succeed", async function () {
     const restApi = await setupRestApiTestServer();
     const nodeStub = restApi.server.api.node as StubbedNodeApi;
@@ -25,9 +25,9 @@ describe("rest - node - getPeers", function () {
       .query({state: "connected"})
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
-    expect(response.body.data).to.not.be.empty;
-    expect(response.body.data.length).to.equal(1);
-    expect(response.body.data[0].peer_id).to.equal("16");
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.empty;
+    expect((response.body as ApiResponseBody).data.length).to.equal(1);
+    expect((response.body as ApiResponseBody).data[0].peer_id).to.equal("16");
   });
 });

--- a/packages/lodestar/test/unit/api/rest/node/getPeers.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getPeers.test.ts
@@ -6,7 +6,7 @@ import {ApiResponseBody, urlJoin} from "../utils";
 import {NODE_PREFIX, setupRestApiTestServer} from "../index.test";
 import {StubbedNodeApi} from "../../../../utils/stub/nodeApi";
 
-describe.only("rest - node - getPeers", function () {
+describe("rest - node - getPeers", function () {
   it("should succeed", async function () {
     const restApi = await setupRestApiTestServer();
     const nodeStub = restApi.server.api.node as StubbedNodeApi;
@@ -28,6 +28,7 @@ describe.only("rest - node - getPeers", function () {
     expect((response.body as ApiResponseBody).data).to.not.be.undefined;
     expect((response.body as ApiResponseBody).data).to.not.be.empty;
     expect((response.body as ApiResponseBody).data.length).to.equal(1);
-    expect((response.body as ApiResponseBody).data[0].peer_id).to.equal("16");
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(response.body.data[0].peer_id).to.equal("16");
   });
 });

--- a/packages/lodestar/test/unit/api/rest/node/getSyncingStatus.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getSyncingStatus.test.ts
@@ -19,9 +19,9 @@ describe("rest - node - getSyncingStatus", function () {
       .get(urlJoin(NODE_PREFIX, getSyncingStatus.url))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
-    expect(response.body.data).to.not.be.empty;
-    expect(response.body.data.head_slot).to.equal("3");
-    expect(response.body.data.sync_distance).to.equal("2");
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.empty;
+    expect((response.body as ApiResponseBody).data.head_slot).to.equal("3");
+    expect((response.body as ApiResponseBody).data.sync_distance).to.equal("2");
   });
 });

--- a/packages/lodestar/test/unit/api/rest/node/getSyncingStatus.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getSyncingStatus.test.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import supertest from "supertest";
 
 import {getSyncingStatus} from "../../../../../src/api/rest/controllers/node";
-import {urlJoin} from "../utils";
+import {ApiResponseBody, urlJoin} from "../utils";
 import {NODE_PREFIX, setupRestApiTestServer} from "../index.test";
 import {StubbedNodeApi} from "../../../../utils/stub/nodeApi";
 
@@ -21,7 +21,9 @@ describe("rest - node - getSyncingStatus", function () {
       .expect("Content-Type", "application/json; charset=utf-8");
     expect((response.body as ApiResponseBody).data).to.not.be.undefined;
     expect((response.body as ApiResponseBody).data).to.not.be.empty;
-    expect((response.body as ApiResponseBody).data.head_slot).to.equal("3");
-    expect((response.body as ApiResponseBody).data.sync_distance).to.equal("2");
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(response.body.data.head_slot).to.equal("3");
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(response.body.data.sync_distance).to.equal("2");
   });
 });

--- a/packages/lodestar/test/unit/api/rest/node/getVersion.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getVersion.test.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import supertest from "supertest";
 
 import {getVersion} from "../../../../../src/api/rest/controllers/node";
-import {urlJoin} from "../utils";
+import {ApiResponseBody, urlJoin} from "../utils";
 import {NODE_PREFIX, setupRestApiTestServer} from "../index.test";
 import {StubbedNodeApi} from "../../../../utils/stub/nodeApi";
 
@@ -18,6 +18,7 @@ describe("rest - node - getVersion", function () {
       .expect("Content-Type", "application/json; charset=utf-8");
     expect((response.body as ApiResponseBody).data).to.not.be.undefined;
     expect((response.body as ApiResponseBody).data).to.not.be.empty;
-    expect((response.body as ApiResponseBody).data.version).to.equal("test");
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(response.body.data.version).to.equal("test");
   });
 });

--- a/packages/lodestar/test/unit/api/rest/node/getVersion.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getVersion.test.ts
@@ -16,8 +16,8 @@ describe("rest - node - getVersion", function () {
       .get(urlJoin(NODE_PREFIX, getVersion.url))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
-    expect(response.body.data).to.not.be.empty;
-    expect(response.body.data.version).to.equal("test");
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.empty;
+    expect((response.body as ApiResponseBody).data.version).to.equal("test");
   });
 });

--- a/packages/lodestar/test/unit/api/rest/utils.ts
+++ b/packages/lodestar/test/unit/api/rest/utils.ts
@@ -1,5 +1,3 @@
-import { Type } from "@chainsafe/ssz";
-
 export function urlJoin(...args: string[]): string {
   return (
     args
@@ -10,4 +8,4 @@ export function urlJoin(...args: string[]): string {
   );
 }
 
-export type ApiResponseBody = {data: [Type<JSON>]};
+export type ApiResponseBody = {data: [JSON]};

--- a/packages/lodestar/test/unit/api/rest/utils.ts
+++ b/packages/lodestar/test/unit/api/rest/utils.ts
@@ -1,3 +1,5 @@
+import { Type } from "@chainsafe/ssz";
+
 export function urlJoin(...args: string[]): string {
   return (
     args
@@ -7,3 +9,5 @@ export function urlJoin(...args: string[]): string {
       .replace(/^(\/)+/, "/")
   );
 }
+
+export type ApiResponseBody = {data: [Type<JSON>]};

--- a/packages/lodestar/test/unit/api/rest/validator/attesterDuties.test.ts
+++ b/packages/lodestar/test/unit/api/rest/validator/attesterDuties.test.ts
@@ -2,7 +2,7 @@ import {config} from "@chainsafe/lodestar-config/minimal";
 import {expect} from "chai";
 import supertest from "supertest";
 import {attesterDutiesController} from "../../../../../src/api/rest/controllers/validator/duties/attesterDuties";
-import {urlJoin} from "../utils";
+import {ApiResponseBody, urlJoin} from "../utils";
 import {setupRestApiTestServer, VALIDATOR_PREFIX} from "../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {RestApi, ValidatorApi} from "../../../../../src/api";
@@ -26,8 +26,8 @@ describe("rest - validator - attesterDuties", function () {
       .send(["1", "4"])
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.be.instanceOf(Array);
-    expect(response.body.data).to.have.length(2);
+    expect((response.body as ApiResponseBody).data).to.be.instanceOf(Array);
+    expect((response.body as ApiResponseBody).data).to.have.length(2);
     expect(validatorStub.getAttesterDuties.withArgs(0, [1, 4]).calledOnce).to.be.true;
   });
 

--- a/packages/lodestar/test/unit/api/rest/validator/produceAggregatedAttestation.test.ts
+++ b/packages/lodestar/test/unit/api/rest/validator/produceAggregatedAttestation.test.ts
@@ -4,7 +4,7 @@ import {expect} from "chai";
 import supertest from "supertest";
 import {produceAggregatedAttestation} from "../../../../../src/api/rest/controllers/validator";
 import {generateEmptyAttestation} from "../../../../utils/attestation";
-import {urlJoin} from "../utils";
+import {ApiResponseBody, urlJoin} from "../utils";
 import {setupRestApiTestServer, VALIDATOR_PREFIX} from "../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {RestApi, ValidatorApi} from "../../../../../src/api";
@@ -29,8 +29,8 @@ describe("rest - validator - produceAggregatedAttestation", function () {
         slot: 0,
       })
       .expect(200);
-    expect(response.body.data).to.not.be.undefined;
-    expect(response.body.data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
     expect(validatorStub.getAggregatedAttestation.withArgs(root, 0).calledOnce).to.be.true;
   });
 

--- a/packages/lodestar/test/unit/api/rest/validator/produceAttestationData.test.ts
+++ b/packages/lodestar/test/unit/api/rest/validator/produceAttestationData.test.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import supertest from "supertest";
 import {produceAttestationData} from "../../../../../src/api/rest/controllers/validator/produceAttestationData";
 import {generateEmptyAttestation} from "../../../../utils/attestation";
-import {urlJoin} from "../utils";
+import {ApiResponseBody, urlJoin} from "../utils";
 import {setupRestApiTestServer, VALIDATOR_PREFIX} from "../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {RestApi, ValidatorApi} from "../../../../../src/api";
@@ -26,8 +26,8 @@ describe("rest - validator - produceAttestationData", function () {
         slot: 0,
       })
       .expect(200);
-    expect(response.body.data).to.not.be.undefined;
-    expect(response.body.data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
     expect(validatorStub.produceAttestationData.withArgs(1, 0).calledOnce).to.be.true;
   });
 

--- a/packages/lodestar/test/unit/api/rest/validator/produceBlock.test.ts
+++ b/packages/lodestar/test/unit/api/rest/validator/produceBlock.test.ts
@@ -3,7 +3,7 @@ import {expect} from "chai";
 import supertest from "supertest";
 import {produceBlockController} from "../../../../../src/api/rest/controllers/validator/produceBlock";
 import {generateEmptyBlock} from "../../../../utils/block";
-import {urlJoin} from "../utils";
+import {ApiResponseBody, urlJoin} from "../utils";
 import {setupRestApiTestServer, VALIDATOR_PREFIX} from "../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {RestApi, ValidatorApi} from "../../../../../src/api";
@@ -28,7 +28,7 @@ describe("rest - validator - produceBlock", function () {
       })
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.not.be.undefined;
+    expect((response.body as ApiResponseBody).data).to.not.be.undefined;
     expect(validatorStub.produceBlock.withArgs(5, Buffer.alloc(32, 1), "0x2123"));
   });
 

--- a/packages/lodestar/test/unit/api/rest/validator/proposerDuties.test.ts
+++ b/packages/lodestar/test/unit/api/rest/validator/proposerDuties.test.ts
@@ -6,6 +6,7 @@ import {urlJoin} from "../utils";
 import {setupRestApiTestServer, VALIDATOR_PREFIX} from "../index.test";
 import {RestApi, ValidatorApi} from "../../../../../src/api";
 import {SinonStubbedInstance} from "sinon";
+import {ProposerDuty} from "@chainsafe/lodestar-types/phase0";
 
 describe("rest - validator - proposerDuties", function () {
   let restApi: RestApi;
@@ -25,8 +26,8 @@ describe("rest - validator - proposerDuties", function () {
       .get(urlJoin(VALIDATOR_PREFIX, proposerDutiesController.url.replace(":epoch", "1")))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(response.body.data).to.be.instanceOf(Array);
-    expect(response.body.data).to.have.length(2);
+    expect((response.body as {data: ProposerDuty}).data).to.be.instanceOf(Array);
+    expect((response.body as {data: ProposerDuty}).data).to.have.length(2);
     expect(validatorStub.getProposerDuties.withArgs(1).calledOnce).to.be.true;
   });
 

--- a/packages/lodestar/test/unit/chain/attestation/process.test.ts
+++ b/packages/lodestar/test/unit/chain/attestation/process.test.ts
@@ -11,6 +11,7 @@ import {StateRegenerator} from "../../../../src/chain/regen";
 import {AttestationErrorCode} from "../../../../src/chain/errors";
 import {generateAttestation} from "../../../utils/attestation";
 import {generateCachedState} from "../../../utils/state";
+import {LodestarError} from "@chainsafe/lodestar-utils";
 
 describe("processAttestation", function () {
   const emitter = new ChainEventEmitter();
@@ -40,7 +41,7 @@ describe("processAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.TARGET_STATE_MISSING);
+      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.TARGET_STATE_MISSING);
     }
   });
 
@@ -58,7 +59,9 @@ describe("processAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX);
+      expect((e as LodestarError<{code: string}>).type.code).to.equal(
+        AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX
+      );
     }
   });
 
@@ -77,7 +80,7 @@ describe("processAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.INVALID_SIGNATURE);
+      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.INVALID_SIGNATURE);
     }
   });
 

--- a/packages/lodestar/test/unit/chain/attestation/process.test.ts
+++ b/packages/lodestar/test/unit/chain/attestation/process.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
+import sinon, {SinonStubbedInstance} from "sinon";
 
 import {ForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
@@ -12,12 +12,13 @@ import {AttestationErrorCode} from "../../../../src/chain/errors";
 import {generateAttestation} from "../../../utils/attestation";
 import {generateCachedState} from "../../../utils/state";
 import {LodestarError} from "@chainsafe/lodestar-utils";
+import {SinonStubFn} from "../../../utils/types";
 
 describe("processAttestation", function () {
   const emitter = new ChainEventEmitter();
   let forkChoice: SinonStubbedInstance<ForkChoice>;
   let regen: SinonStubbedInstance<StateRegenerator>;
-  let isValidIndexedAttestationStub: SinonStub;
+  let isValidIndexedAttestationStub: SinonStubFn<typeof attestationUtils["isValidIndexedAttestation"]>;
 
   beforeEach(function () {
     forkChoice = sinon.createStubInstance(ForkChoice);

--- a/packages/lodestar/test/unit/chain/attestation/process.test.ts
+++ b/packages/lodestar/test/unit/chain/attestation/process.test.ts
@@ -11,8 +11,8 @@ import {StateRegenerator} from "../../../../src/chain/regen";
 import {AttestationErrorCode} from "../../../../src/chain/errors";
 import {generateAttestation} from "../../../utils/attestation";
 import {generateCachedState} from "../../../utils/state";
-import {LodestarError} from "@chainsafe/lodestar-utils";
 import {SinonStubFn} from "../../../utils/types";
+import {AttestationError} from "../../../../lib/chain/errors";
 
 describe("processAttestation", function () {
   const emitter = new ChainEventEmitter();
@@ -42,7 +42,7 @@ describe("processAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.TARGET_STATE_MISSING);
+      expect((e as AttestationError).type.code).to.equal(AttestationErrorCode.TARGET_STATE_MISSING);
     }
   });
 
@@ -60,9 +60,7 @@ describe("processAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect((e as LodestarError<{code: string}>).type.code).to.equal(
-        AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX
-      );
+      expect((e as AttestationError).type.code).to.equal(AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX);
     }
   });
 
@@ -81,7 +79,7 @@ describe("processAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.INVALID_SIGNATURE);
+      expect((e as AttestationError).type.code).to.equal(AttestationErrorCode.INVALID_SIGNATURE);
     }
   });
 

--- a/packages/lodestar/test/unit/chain/attestation/validate.test.ts
+++ b/packages/lodestar/test/unit/chain/attestation/validate.test.ts
@@ -9,6 +9,7 @@ import {validateAttestation} from "../../../../src/chain/attestation/validate";
 import {LocalClock} from "../../../../src/chain/clock/LocalClock";
 import {AttestationErrorCode} from "../../../../src/chain/errors";
 import {generateAttestation} from "../../../utils/attestation";
+import {LodestarError} from "@chainsafe/lodestar-utils";
 
 describe("velidateAttestation", function () {
   let forkChoice: SinonStubbedInstance<ForkChoice>;
@@ -37,7 +38,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.BAD_TARGET_EPOCH);
+      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.BAD_TARGET_EPOCH);
     }
   });
 
@@ -56,7 +57,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.PAST_EPOCH);
+      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.PAST_EPOCH);
     }
   });
 
@@ -75,7 +76,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.FUTURE_EPOCH);
+      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.FUTURE_EPOCH);
     }
   });
 
@@ -97,7 +98,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.FUTURE_SLOT);
+      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.FUTURE_SLOT);
     }
   });
 
@@ -120,7 +121,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.UNKNOWN_TARGET_ROOT);
+      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.UNKNOWN_TARGET_ROOT);
     }
   });
 
@@ -150,7 +151,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT);
+      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT);
     }
   });
 
@@ -177,7 +178,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(AttestationErrorCode.HEAD_NOT_TARGET_DESCENDANT);
+      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.HEAD_NOT_TARGET_DESCENDANT);
     }
   });
 });

--- a/packages/lodestar/test/unit/chain/attestation/validate.test.ts
+++ b/packages/lodestar/test/unit/chain/attestation/validate.test.ts
@@ -7,9 +7,8 @@ import {ForkChoice} from "@chainsafe/lodestar-fork-choice";
 
 import {validateAttestation} from "../../../../src/chain/attestation/validate";
 import {LocalClock} from "../../../../src/chain/clock/LocalClock";
-import {AttestationErrorCode} from "../../../../src/chain/errors";
+import {AttestationError, AttestationErrorCode} from "../../../../src/chain/errors";
 import {generateAttestation} from "../../../utils/attestation";
-import {LodestarError} from "@chainsafe/lodestar-utils";
 
 describe("velidateAttestation", function () {
   let forkChoice: SinonStubbedInstance<ForkChoice>;
@@ -38,7 +37,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.BAD_TARGET_EPOCH);
+      expect((e as AttestationError).type.code).to.equal(AttestationErrorCode.BAD_TARGET_EPOCH);
     }
   });
 
@@ -57,7 +56,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.PAST_EPOCH);
+      expect((e as AttestationError).type.code).to.equal(AttestationErrorCode.PAST_EPOCH);
     }
   });
 
@@ -76,7 +75,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.FUTURE_EPOCH);
+      expect((e as AttestationError).type.code).to.equal(AttestationErrorCode.FUTURE_EPOCH);
     }
   });
 
@@ -98,7 +97,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.FUTURE_SLOT);
+      expect((e as AttestationError).type.code).to.equal(AttestationErrorCode.FUTURE_SLOT);
     }
   });
 
@@ -121,7 +120,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.UNKNOWN_TARGET_ROOT);
+      expect((e as AttestationError).type.code).to.equal(AttestationErrorCode.UNKNOWN_TARGET_ROOT);
     }
   });
 
@@ -151,7 +150,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT);
+      expect((e as AttestationError).type.code).to.equal(AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT);
     }
   });
 
@@ -178,7 +177,7 @@ describe("velidateAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect((e as LodestarError<{code: string}>).type.code).to.equal(AttestationErrorCode.HEAD_NOT_TARGET_DESCENDANT);
+      expect((e as AttestationError).type.code).to.equal(AttestationErrorCode.HEAD_NOT_TARGET_DESCENDANT);
     }
   });
 });

--- a/packages/lodestar/test/unit/chain/blocks/process.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/process.test.ts
@@ -10,6 +10,7 @@ import {CheckpointStateCache} from "../../../../src/chain/stateCache";
 import {processBlock} from "../../../../src/chain/blocks/process";
 import {RegenError, RegenErrorCode, StateRegenerator} from "../../../../src/chain/regen";
 import {getNewBlockJob} from "../../../utils/block";
+import {LodestarError} from "@chainsafe/lodestar-utils";
 
 describe("processBlock", function () {
   const emitter = new ChainEventEmitter();
@@ -42,7 +43,7 @@ describe("processBlock", function () {
       });
       expect.fail("block should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(BlockErrorCode.PARENT_UNKNOWN);
+      expect((e as LodestarError<{code: string}>).type.code).to.equal(BlockErrorCode.PARENT_UNKNOWN);
     }
   });
 
@@ -62,7 +63,7 @@ describe("processBlock", function () {
       });
       expect.fail("block should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(BlockErrorCode.PRESTATE_MISSING);
+      expect((e as LodestarError<{code: string}>).type.code).to.equal(BlockErrorCode.PRESTATE_MISSING);
     }
   });
 });

--- a/packages/lodestar/test/unit/chain/blocks/process.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/process.test.ts
@@ -5,12 +5,11 @@ import {config} from "@chainsafe/lodestar-config/minimal";
 import {ForkChoice} from "@chainsafe/lodestar-fork-choice";
 
 import {ChainEventEmitter} from "../../../../src/chain";
-import {BlockErrorCode} from "../../../../src/chain/errors";
+import {BlockError, BlockErrorCode} from "../../../../src/chain/errors";
 import {CheckpointStateCache} from "../../../../src/chain/stateCache";
 import {processBlock} from "../../../../src/chain/blocks/process";
 import {RegenError, RegenErrorCode, StateRegenerator} from "../../../../src/chain/regen";
 import {getNewBlockJob} from "../../../utils/block";
-import {LodestarError} from "@chainsafe/lodestar-utils";
 
 describe("processBlock", function () {
   const emitter = new ChainEventEmitter();
@@ -43,7 +42,7 @@ describe("processBlock", function () {
       });
       expect.fail("block should throw");
     } catch (e) {
-      expect((e as LodestarError<{code: string}>).type.code).to.equal(BlockErrorCode.PARENT_UNKNOWN);
+      expect((e as BlockError).type.code).to.equal(BlockErrorCode.PARENT_UNKNOWN);
     }
   });
 
@@ -63,7 +62,7 @@ describe("processBlock", function () {
       });
       expect.fail("block should throw");
     } catch (e) {
-      expect((e as LodestarError<{code: string}>).type.code).to.equal(BlockErrorCode.PRESTATE_MISSING);
+      expect((e as BlockError).type.code).to.equal(BlockErrorCode.PRESTATE_MISSING);
     }
   });
 });

--- a/packages/lodestar/test/unit/chain/blocks/validate.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/validate.test.ts
@@ -8,6 +8,7 @@ import {validateBlock} from "../../../../src/chain/blocks/validate";
 import {LocalClock} from "../../../../src/chain/clock";
 import {BlockErrorCode} from "../../../../src/chain/errors";
 import {getNewBlockJob} from "../../../utils/block";
+import {LodestarError} from "@chainsafe/lodestar-utils";
 
 describe("validateBlock", function () {
   let forkChoice: SinonStubbedInstance<ForkChoice>;
@@ -29,7 +30,7 @@ describe("validateBlock", function () {
       validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(BlockErrorCode.GENESIS_BLOCK);
+      expect((e as LodestarError<{code: string}>).type.code).to.equal(BlockErrorCode.GENESIS_BLOCK);
     }
   });
 
@@ -42,7 +43,7 @@ describe("validateBlock", function () {
       validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(BlockErrorCode.BLOCK_IS_ALREADY_KNOWN);
+      expect((e as LodestarError<{code: string}>).type.code).to.equal(BlockErrorCode.BLOCK_IS_ALREADY_KNOWN);
     }
   });
 
@@ -56,7 +57,7 @@ describe("validateBlock", function () {
       validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT);
+      expect((e as LodestarError<{code: string}>).type.code).to.equal(BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT);
     }
   });
 
@@ -71,7 +72,7 @@ describe("validateBlock", function () {
       validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
     } catch (e) {
-      expect(e.type.code).to.equal(BlockErrorCode.FUTURE_SLOT);
+      expect((e as LodestarError<{code: string}>).type.code).to.equal(BlockErrorCode.FUTURE_SLOT);
     }
   });
 });

--- a/packages/lodestar/test/unit/chain/blocks/validate.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/validate.test.ts
@@ -6,9 +6,8 @@ import {ForkChoice} from "@chainsafe/lodestar-fork-choice";
 
 import {validateBlock} from "../../../../src/chain/blocks/validate";
 import {LocalClock} from "../../../../src/chain/clock";
-import {BlockErrorCode} from "../../../../src/chain/errors";
+import {BlockError, BlockErrorCode} from "../../../../src/chain/errors";
 import {getNewBlockJob} from "../../../utils/block";
-import {LodestarError} from "@chainsafe/lodestar-utils";
 
 describe("validateBlock", function () {
   let forkChoice: SinonStubbedInstance<ForkChoice>;
@@ -30,7 +29,7 @@ describe("validateBlock", function () {
       validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
     } catch (e) {
-      expect((e as LodestarError<{code: string}>).type.code).to.equal(BlockErrorCode.GENESIS_BLOCK);
+      expect((e as BlockError).type.code).to.equal(BlockErrorCode.GENESIS_BLOCK);
     }
   });
 
@@ -43,7 +42,7 @@ describe("validateBlock", function () {
       validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
     } catch (e) {
-      expect((e as LodestarError<{code: string}>).type.code).to.equal(BlockErrorCode.BLOCK_IS_ALREADY_KNOWN);
+      expect((e as BlockError).type.code).to.equal(BlockErrorCode.BLOCK_IS_ALREADY_KNOWN);
     }
   });
 
@@ -57,7 +56,7 @@ describe("validateBlock", function () {
       validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
     } catch (e) {
-      expect((e as LodestarError<{code: string}>).type.code).to.equal(BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT);
+      expect((e as BlockError).type.code).to.equal(BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT);
     }
   });
 
@@ -72,7 +71,7 @@ describe("validateBlock", function () {
       validateBlock({config, forkChoice, clock, job});
       expect.fail("block should throw");
     } catch (e) {
-      expect((e as LodestarError<{code: string}>).type.code).to.equal(BlockErrorCode.FUTURE_SLOT);
+      expect((e as BlockError).type.code).to.equal(BlockErrorCode.FUTURE_SLOT);
     }
   });
 });

--- a/packages/lodestar/test/unit/chain/chain.test.ts
+++ b/packages/lodestar/test/unit/chain/chain.test.ts
@@ -6,7 +6,7 @@ import {createCachedBeaconState} from "@chainsafe/lodestar-beacon-state-transiti
 
 import {BeaconChain, IBeaconChain} from "../../../src/chain";
 import {defaultChainOptions} from "../../../src/chain/options";
-import {BeaconMetrics} from "../../../src/metrics";
+import {BeaconMetrics, IBeaconMetrics} from "../../../src/metrics";
 import {generateBlockSummary} from "../../utils/block";
 import {generateState} from "../../utils/state";
 import {StubbedBeaconDb} from "../../utils/stub";
@@ -15,7 +15,7 @@ import {testLogger} from "../../utils/logger";
 
 describe("BeaconChain", function () {
   const sandbox = sinon.createSandbox();
-  let dbStub: StubbedBeaconDb, metrics: any;
+  let dbStub: StubbedBeaconDb, metrics: IBeaconMetrics | undefined;
   const logger = testLogger();
   let chain: IBeaconChain;
 

--- a/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
@@ -18,7 +18,7 @@ import {StubbedBeaconDb, StubbedChain} from "../../../../utils/stub";
 describe("block assembly", function () {
   const sandbox = sinon.createSandbox();
 
-  let assembleBodyStub: any,
+  let assembleBodyStub: SinonStub,
     chainStub: StubbedChain,
     forkChoiceStub: SinonStubbedInstance<ForkChoice>,
     regenStub: SinonStubbedInstance<StateRegenerator>,

--- a/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
@@ -1,4 +1,4 @@
-import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
+import sinon, {SinonStubbedInstance} from "sinon";
 import {expect} from "chai";
 
 import {config} from "@chainsafe/lodestar-config/minimal";
@@ -14,15 +14,16 @@ import {Eth1ForBlockProduction} from "../../../../../src/eth1/";
 import {generateBlockSummary, generateEmptyBlock} from "../../../../utils/block";
 import {generateCachedState} from "../../../../utils/state";
 import {StubbedBeaconDb, StubbedChain} from "../../../../utils/stub";
+import {SinonStubFn} from "../../../../utils/types";
 
 describe("block assembly", function () {
   const sandbox = sinon.createSandbox();
 
-  let assembleBodyStub: SinonStub,
+  let assembleBodyStub: SinonStubFn<typeof blockBodyAssembly["assembleBody"]>,
     chainStub: StubbedChain,
     forkChoiceStub: SinonStubbedInstance<ForkChoice>,
     regenStub: SinonStubbedInstance<StateRegenerator>,
-    processBlockStub: SinonStub,
+    processBlockStub: SinonStubFn<typeof processBlock["processBlock"]>,
     beaconDB: StubbedBeaconDb;
 
   beforeEach(() => {

--- a/packages/lodestar/test/unit/chain/validation/aggregateAndProof.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/aggregateAndProof.test.ts
@@ -4,7 +4,7 @@ import {rewiremock} from "../../../rewiremock";
 
 import {List} from "@chainsafe/ssz";
 import bls from "@chainsafe/bls";
-import {bigIntToBytes} from "@chainsafe/lodestar-utils";
+import {bigIntToBytes, LodestarError} from "@chainsafe/lodestar-utils";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import * as validatorUtils from "@chainsafe/lodestar-beacon-state-transition/lib/util/validator";
 import {getCurrentSlot} from "@chainsafe/lodestar-beacon-state-transition";
@@ -109,7 +109,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.PAST_SLOT);
+      expect((error as LodestarError<{code: string}>).type).to.have.property("code", AttestationErrorCode.PAST_SLOT);
     }
   });
 
@@ -132,7 +132,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.FUTURE_SLOT);
+      expect((error as LodestarError<{code: string}>).type).to.have.property("code", AttestationErrorCode.FUTURE_SLOT);
     }
   });
 
@@ -151,7 +151,10 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.AGGREGATE_ALREADY_KNOWN);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.AGGREGATE_ALREADY_KNOWN
+      );
     }
     expect(db.seenAttestationCache.hasAggregateAndProof.withArgs(item.message).calledOnce).to.be.true;
   });
@@ -171,7 +174,10 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS
+      );
     }
   });
 
@@ -191,7 +197,10 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.KNOWN_BAD_BLOCK);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.KNOWN_BAD_BLOCK
+      );
     }
     expect(db.badBlock.has.withArgs(item.message.aggregate.data.beaconBlockRoot.valueOf() as Uint8Array).calledOnce).to
       .be.true;
@@ -213,7 +222,10 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.MISSING_ATTESTATION_PRESTATE);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.MISSING_ATTESTATION_PRESTATE
+      );
     }
     expect(regen.getBlockSlotState.withArgs(item.message.aggregate.data.target.root, sinon.match.any).calledOnce).to.be
       .true;
@@ -237,7 +249,10 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE
+      );
     }
     expect(
       (state.getBeaconCommittee as SinonStub).withArgs(
@@ -266,7 +281,10 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.INVALID_AGGREGATOR);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.INVALID_AGGREGATOR
+      );
     }
     expect(isAggregatorStub.withArgs(config, 1, item.message.selectionProof).calledOnce).to.be.true;
   });

--- a/packages/lodestar/test/unit/chain/validation/aggregateAndProof.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/aggregateAndProof.test.ts
@@ -1,4 +1,4 @@
-import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
+import sinon, {SinonStubbedInstance} from "sinon";
 import {expect} from "chai";
 import {rewiremock} from "../../../rewiremock";
 
@@ -21,15 +21,16 @@ import {generateCachedState} from "../../../utils/state";
 import {StubbedBeaconDb} from "../../../utils/stub";
 import {AttestationErrorCode} from "../../../../src/chain/errors";
 import {expectRejectedWithLodestarError} from "../../../utils/errors";
+import {SinonStubFn} from "../../../utils/types";
 
 describe("gossip aggregate and proof test", function () {
   let chain: SinonStubbedInstance<IBeaconChain>;
   let regen: SinonStubbedInstance<IStateRegenerator>;
   let db: StubbedBeaconDb;
-  let isAggregatorStub: SinonStub;
-  let isValidSelectionProofStub: SinonStub;
-  let isValidSignatureStub: SinonStub;
-  let isValidIndexedAttestationStub: SinonStub;
+  let isAggregatorStub: SinonStubFn<typeof validatorUtils["isAggregatorFromCommitteeLength"]>;
+  let isValidSelectionProofStub: SinonStubFn<typeof validationUtils["isValidSelectionProofSignature"]>;
+  let isValidSignatureStub: SinonStubFn<typeof validationUtils["isValidAggregateAndProofSignature"]>;
+  let isValidIndexedAttestationStub: SinonStubFn<typeof blockUtils["isValidIndexedAttestation"]>;
 
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   async function mockValidateGossipAggregateAndProof({
@@ -255,7 +256,7 @@ describe("gossip aggregate and proof test", function () {
       );
     }
     expect(
-      (state.getBeaconCommittee as SinonStub).withArgs(
+      (state.getBeaconCommittee as SinonStubFn<typeof state["getBeaconCommittee"]>).withArgs(
         item.message.aggregate.data.slot,
         item.message.aggregate.data.index
       ).calledOnce

--- a/packages/lodestar/test/unit/chain/validation/aggregateAndProof.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/aggregateAndProof.test.ts
@@ -4,7 +4,7 @@ import {rewiremock} from "../../../rewiremock";
 
 import {List} from "@chainsafe/ssz";
 import bls from "@chainsafe/bls";
-import {bigIntToBytes, LodestarError} from "@chainsafe/lodestar-utils";
+import {bigIntToBytes} from "@chainsafe/lodestar-utils";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import * as validatorUtils from "@chainsafe/lodestar-beacon-state-transition/lib/util/validator";
 import {getCurrentSlot} from "@chainsafe/lodestar-beacon-state-transition";
@@ -22,6 +22,7 @@ import {StubbedBeaconDb} from "../../../utils/stub";
 import {AttestationErrorCode} from "../../../../src/chain/errors";
 import {expectRejectedWithLodestarError} from "../../../utils/errors";
 import {SinonStubFn} from "../../../utils/types";
+import {AttestationError} from "../../../../lib/chain/errors";
 
 describe("gossip aggregate and proof test", function () {
   let chain: SinonStubbedInstance<IBeaconChain>;
@@ -110,7 +111,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property("code", AttestationErrorCode.PAST_SLOT);
+      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.PAST_SLOT);
     }
   });
 
@@ -133,7 +134,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property("code", AttestationErrorCode.FUTURE_SLOT);
+      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.FUTURE_SLOT);
     }
   });
 
@@ -152,10 +153,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
-        "code",
-        AttestationErrorCode.AGGREGATE_ALREADY_KNOWN
-      );
+      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.AGGREGATE_ALREADY_KNOWN);
     }
     expect(db.seenAttestationCache.hasAggregateAndProof.withArgs(item.message).calledOnce).to.be.true;
   });
@@ -175,7 +173,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
+      expect((error as AttestationError).type).to.have.property(
         "code",
         AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS
       );
@@ -198,10 +196,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
-        "code",
-        AttestationErrorCode.KNOWN_BAD_BLOCK
-      );
+      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.KNOWN_BAD_BLOCK);
     }
     expect(db.badBlock.has.withArgs(item.message.aggregate.data.beaconBlockRoot.valueOf() as Uint8Array).calledOnce).to
       .be.true;
@@ -223,7 +218,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
+      expect((error as AttestationError).type).to.have.property(
         "code",
         AttestationErrorCode.MISSING_ATTESTATION_PRESTATE
       );
@@ -250,7 +245,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
+      expect((error as AttestationError).type).to.have.property(
         "code",
         AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE
       );
@@ -282,10 +277,7 @@ describe("gossip aggregate and proof test", function () {
         validSignature: false,
       } as IAttestationJob);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
-        "code",
-        AttestationErrorCode.INVALID_AGGREGATOR
-      );
+      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.INVALID_AGGREGATOR);
     }
     expect(isAggregatorStub.withArgs(config, 1, item.message.selectionProof).calledOnce).to.be.true;
   });

--- a/packages/lodestar/test/unit/chain/validation/attestation.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/attestation.test.ts
@@ -19,6 +19,8 @@ import {generateCachedState} from "../../../utils/state";
 import {LocalClock} from "../../../../src/chain/clock";
 import {AttestationErrorCode} from "../../../../src/chain/errors";
 import {Gwei} from "@chainsafe/lodestar-types";
+import {LodestarError} from "@chainsafe/lodestar-utils";
+import {IEpochShuffling} from "@chainsafe/lodestar-beacon-state-transition/lib/phase0/fast";
 
 describe("gossip attestation validation", function () {
   let chain: SinonStubbedInstance<IBeaconChain>;
@@ -69,7 +71,10 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
+      );
     }
   });
 
@@ -87,7 +92,10 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
+      );
     }
   });
 
@@ -106,7 +114,10 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.KNOWN_BAD_BLOCK);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.KNOWN_BAD_BLOCK
+      );
     }
     expect(db.badBlock.has.calledOnceWith(attestation.data.beaconBlockRoot.valueOf() as Uint8Array)).to.be.true;
   });
@@ -130,7 +141,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.PAST_SLOT);
+      expect((error as LodestarError<{code: string}>).type).to.have.property("code", AttestationErrorCode.PAST_SLOT);
     }
   });
 
@@ -153,7 +164,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.FUTURE_SLOT);
+      expect((error as LodestarError<{code: string}>).type).to.have.property("code", AttestationErrorCode.FUTURE_SLOT);
     }
   });
 
@@ -174,7 +185,10 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.ATTESTATION_ALREADY_KNOWN);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.ATTESTATION_ALREADY_KNOWN
+      );
     }
     expect(chain.receiveAttestation.called).to.be.false;
     expect(db.seenAttestationCache.hasCommitteeAttestation.calledOnceWith(attestation)).to.be.true;
@@ -198,7 +212,10 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT
+      );
     }
     expect(forkChoice.hasBlock.calledOnceWith(attestation.data.beaconBlockRoot)).to.be.true;
   });
@@ -222,7 +239,10 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.MISSING_ATTESTATION_PRESTATE);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.MISSING_ATTESTATION_PRESTATE
+      );
     }
     expect(regen.getCheckpointState.calledOnceWith(attestation.data.target)).to.be.true;
   });
@@ -248,7 +268,10 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.INVALID_SUBNET_ID);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.INVALID_SUBNET_ID
+      );
     }
     expect(chain.receiveAttestation.called).to.be.false;
     expect(computeAttestationSubnetStub.calledOnceWith(config, attestationPreState, attestation)).to.be.true;
@@ -277,7 +300,10 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.INVALID_SIGNATURE);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.INVALID_SIGNATURE
+      );
     }
     expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
@@ -312,7 +338,10 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE
+      );
     }
     expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
@@ -353,7 +382,10 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE
+      );
     }
     expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
@@ -388,7 +420,10 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS
+      );
     }
     expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
@@ -426,7 +461,10 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.BAD_TARGET_EPOCH);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.BAD_TARGET_EPOCH
+      );
     }
   });
 
@@ -471,7 +509,8 @@ describe("gossip attestation validation", function () {
       activeIndices: [],
       epoch: 0,
       committees: [[[1]]],
-    } as any;
+      shuffling: [],
+    } as IEpochShuffling;
     attestationPreState.epochCtx.getIndexedAttestation = () => toIndexedAttestation(attestation);
     regen.getCheckpointState.resolves(attestationPreState);
     computeAttestationSubnetStub.returns(0);
@@ -488,7 +527,10 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK
+      );
     }
   });
 
@@ -508,7 +550,8 @@ describe("gossip attestation validation", function () {
       activeIndices: [],
       epoch: 0,
       committees: [[[1]]],
-    } as any;
+      shuffling: [],
+    } as IEpochShuffling;
     attestationPreState.epochCtx.getIndexedAttestation = () => toIndexedAttestation(attestation);
     regen.getCheckpointState.resolves(attestationPreState);
     computeAttestationSubnetStub.returns(0);
@@ -525,7 +568,10 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect(error.type).to.have.property("code", AttestationErrorCode.FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        AttestationErrorCode.FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT
+      );
     }
   });
 
@@ -538,7 +584,8 @@ describe("gossip attestation validation", function () {
       activeIndices: [],
       epoch: 0,
       committees: [[[1]]],
-    } as any;
+      shuffling: [],
+    } as IEpochShuffling;
     attestationPreState.epochCtx.getIndexedAttestation = () => toIndexedAttestation(attestation);
     regen.getCheckpointState.resolves(attestationPreState);
     computeAttestationSubnetStub.returns(0);

--- a/packages/lodestar/test/unit/chain/validation/attestation.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/attestation.test.ts
@@ -1,4 +1,4 @@
-import sinon, {createStubInstance, SinonStub, SinonStubbedInstance} from "sinon";
+import sinon, {createStubInstance, SinonStubbedInstance} from "sinon";
 import {BeaconChain, ChainEventEmitter, ForkChoiceStore, IBeaconChain} from "../../../../src/chain";
 import {StubbedBeaconDb} from "../../../utils/stub";
 import {expect} from "chai";
@@ -21,14 +21,15 @@ import {AttestationErrorCode} from "../../../../src/chain/errors";
 import {Gwei} from "@chainsafe/lodestar-types";
 import {LodestarError} from "@chainsafe/lodestar-utils";
 import {IEpochShuffling} from "@chainsafe/lodestar-beacon-state-transition/lib/phase0/fast";
+import {SinonStubFn} from "../../../utils/types";
 
 describe("gossip attestation validation", function () {
   let chain: SinonStubbedInstance<IBeaconChain>;
   let forkChoice: SinonStubbedInstance<IForkChoice>;
   let regen: SinonStubbedInstance<IStateRegenerator>;
   let db: StubbedBeaconDb;
-  let computeAttestationSubnetStub: SinonStub;
-  let isValidIndexedAttestationStub: SinonStub;
+  let computeAttestationSubnetStub: SinonStubFn<typeof attestationUtils["computeSubnetForAttestation"]>;
+  let isValidIndexedAttestationStub: SinonStubFn<typeof blockUtils["isValidIndexedAttestation"]>;
   let forkChoiceStub: SinonStubbedInstance<ForkChoice>;
   let toIndexedAttestation: (attestation: phase0.Attestation) => phase0.IndexedAttestation;
 

--- a/packages/lodestar/test/unit/chain/validation/attestation.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/attestation.test.ts
@@ -19,9 +19,9 @@ import {generateCachedState} from "../../../utils/state";
 import {LocalClock} from "../../../../src/chain/clock";
 import {AttestationErrorCode} from "../../../../src/chain/errors";
 import {Gwei} from "@chainsafe/lodestar-types";
-import {LodestarError} from "@chainsafe/lodestar-utils";
 import {IEpochShuffling} from "@chainsafe/lodestar-beacon-state-transition/lib/phase0/fast";
 import {SinonStubFn} from "../../../utils/types";
+import {AttestationError} from "../../../../lib/chain/errors";
 
 describe("gossip attestation validation", function () {
   let chain: SinonStubbedInstance<IBeaconChain>;
@@ -72,7 +72,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
+      expect((error as AttestationError).type).to.have.property(
         "code",
         AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
       );
@@ -93,7 +93,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
+      expect((error as AttestationError).type).to.have.property(
         "code",
         AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
       );
@@ -115,10 +115,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
-        "code",
-        AttestationErrorCode.KNOWN_BAD_BLOCK
-      );
+      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.KNOWN_BAD_BLOCK);
     }
     expect(db.badBlock.has.calledOnceWith(attestation.data.beaconBlockRoot.valueOf() as Uint8Array)).to.be.true;
   });
@@ -142,7 +139,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property("code", AttestationErrorCode.PAST_SLOT);
+      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.PAST_SLOT);
     }
   });
 
@@ -165,7 +162,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property("code", AttestationErrorCode.FUTURE_SLOT);
+      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.FUTURE_SLOT);
     }
   });
 
@@ -186,10 +183,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
-        "code",
-        AttestationErrorCode.ATTESTATION_ALREADY_KNOWN
-      );
+      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.ATTESTATION_ALREADY_KNOWN);
     }
     expect(chain.receiveAttestation.called).to.be.false;
     expect(db.seenAttestationCache.hasCommitteeAttestation.calledOnceWith(attestation)).to.be.true;
@@ -213,10 +207,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
-        "code",
-        AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT
-      );
+      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT);
     }
     expect(forkChoice.hasBlock.calledOnceWith(attestation.data.beaconBlockRoot)).to.be.true;
   });
@@ -240,7 +231,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
+      expect((error as AttestationError).type).to.have.property(
         "code",
         AttestationErrorCode.MISSING_ATTESTATION_PRESTATE
       );
@@ -269,10 +260,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
-        "code",
-        AttestationErrorCode.INVALID_SUBNET_ID
-      );
+      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.INVALID_SUBNET_ID);
     }
     expect(chain.receiveAttestation.called).to.be.false;
     expect(computeAttestationSubnetStub.calledOnceWith(config, attestationPreState, attestation)).to.be.true;
@@ -301,10 +289,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
-        "code",
-        AttestationErrorCode.INVALID_SIGNATURE
-      );
+      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.INVALID_SIGNATURE);
     }
     expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
@@ -339,7 +324,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
+      expect((error as AttestationError).type).to.have.property(
         "code",
         AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE
       );
@@ -383,7 +368,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
+      expect((error as AttestationError).type).to.have.property(
         "code",
         AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE
       );
@@ -421,7 +406,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
+      expect((error as AttestationError).type).to.have.property(
         "code",
         AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS
       );
@@ -462,10 +447,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
-        "code",
-        AttestationErrorCode.BAD_TARGET_EPOCH
-      );
+      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.BAD_TARGET_EPOCH);
     }
   });
 
@@ -528,7 +510,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
+      expect((error as AttestationError).type).to.have.property(
         "code",
         AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK
       );
@@ -569,7 +551,7 @@ describe("gossip attestation validation", function () {
         0
       );
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
+      expect((error as AttestationError).type).to.have.property(
         "code",
         AttestationErrorCode.FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT
       );

--- a/packages/lodestar/test/unit/chain/validation/attesterSlashing.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/attesterSlashing.test.ts
@@ -11,6 +11,7 @@ import {StubbedBeaconDb, StubbedChain} from "../../../utils/stub";
 import {generateCachedState} from "../../../utils/state";
 import {validateGossipAttesterSlashing} from "../../../../src/chain/validation/attesterSlashing";
 import {AttesterSlashingErrorCode} from "../../../../src/chain/errors/attesterSlashingError";
+import {LodestarError} from "@chainsafe/lodestar-utils";
 
 describe("GossipMessageValidator", () => {
   const sandbox = sinon.createSandbox();
@@ -34,7 +35,10 @@ describe("GossipMessageValidator", () => {
       try {
         await validateGossipAttesterSlashing(config, chainStub, dbStub, slashing);
       } catch (error) {
-        expect(error.type).to.have.property("code", AttesterSlashingErrorCode.SLASHING_ALREADY_EXISTS);
+        expect((error as LodestarError<{code: string}>).type).to.have.property(
+          "code",
+          AttesterSlashingErrorCode.SLASHING_ALREADY_EXISTS
+        );
       }
     });
 
@@ -47,7 +51,10 @@ describe("GossipMessageValidator", () => {
       try {
         await validateGossipAttesterSlashing(config, chainStub, dbStub, slashing);
       } catch (error) {
-        expect(error.type).to.have.property("code", AttesterSlashingErrorCode.INVALID_SLASHING);
+        expect((error as LodestarError<{code: string}>).type).to.have.property(
+          "code",
+          AttesterSlashingErrorCode.INVALID_SLASHING
+        );
       }
     });
 

--- a/packages/lodestar/test/unit/chain/validation/attesterSlashing.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/attesterSlashing.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {generateEmptyAttesterSlashing} from "@chainsafe/lodestar-beacon-state-transition/test/utils/slashings";
@@ -12,10 +12,13 @@ import {generateCachedState} from "../../../utils/state";
 import {validateGossipAttesterSlashing} from "../../../../src/chain/validation/attesterSlashing";
 import {AttesterSlashingErrorCode} from "../../../../src/chain/errors/attesterSlashingError";
 import {LodestarError} from "@chainsafe/lodestar-utils";
+import {SinonStubFn} from "../../../utils/types";
 
 describe("GossipMessageValidator", () => {
   const sandbox = sinon.createSandbox();
-  let dbStub: StubbedBeaconDb, isValidIncomingAttesterSlashingStub: SinonStub, chainStub: StubbedChain;
+  let dbStub: StubbedBeaconDb,
+    isValidIncomingAttesterSlashingStub: SinonStubFn<typeof validatorStatusUtils["isValidAttesterSlashing"]>,
+    chainStub: StubbedChain;
 
   beforeEach(() => {
     isValidIncomingAttesterSlashingStub = sandbox.stub(validatorStatusUtils, "isValidAttesterSlashing");

--- a/packages/lodestar/test/unit/chain/validation/attesterSlashing.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/attesterSlashing.test.ts
@@ -11,8 +11,8 @@ import {StubbedBeaconDb, StubbedChain} from "../../../utils/stub";
 import {generateCachedState} from "../../../utils/state";
 import {validateGossipAttesterSlashing} from "../../../../src/chain/validation/attesterSlashing";
 import {AttesterSlashingErrorCode} from "../../../../src/chain/errors/attesterSlashingError";
-import {LodestarError} from "@chainsafe/lodestar-utils";
 import {SinonStubFn} from "../../../utils/types";
+import {AttestationError} from "../../../../lib/chain/errors";
 
 describe("GossipMessageValidator", () => {
   const sandbox = sinon.createSandbox();
@@ -38,7 +38,7 @@ describe("GossipMessageValidator", () => {
       try {
         await validateGossipAttesterSlashing(config, chainStub, dbStub, slashing);
       } catch (error) {
-        expect((error as LodestarError<{code: string}>).type).to.have.property(
+        expect((error as AttestationError).type).to.have.property(
           "code",
           AttesterSlashingErrorCode.SLASHING_ALREADY_EXISTS
         );
@@ -54,10 +54,7 @@ describe("GossipMessageValidator", () => {
       try {
         await validateGossipAttesterSlashing(config, chainStub, dbStub, slashing);
       } catch (error) {
-        expect((error as LodestarError<{code: string}>).type).to.have.property(
-          "code",
-          AttesterSlashingErrorCode.INVALID_SLASHING
-        );
+        expect((error as AttestationError).type).to.have.property("code", AttesterSlashingErrorCode.INVALID_SLASHING);
       }
     });
 

--- a/packages/lodestar/test/unit/chain/validation/block.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/block.test.ts
@@ -12,6 +12,7 @@ import {generateSignedBlock, getNewBlockJob} from "../../../utils/block";
 import {StubbedBeaconDb} from "../../../utils/stub";
 import {generateCachedState} from "../../../utils/state";
 import {BlockErrorCode} from "../../../../src/chain/errors";
+import {LodestarError} from "@chainsafe/lodestar-utils";
 
 describe("gossip block validation", function () {
   let chainStub: SinonStubbedInstance<IBeaconChain>;
@@ -44,7 +45,10 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect(error.type).to.have.property("code", BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT
+      );
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(chainStub.getGenesisTime.notCalled).to.be.true;
@@ -62,7 +66,7 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect(error.type).to.have.property("code", BlockErrorCode.KNOWN_BAD_BLOCK);
+      expect((error as LodestarError<{code: string}>).type).to.have.property("code", BlockErrorCode.KNOWN_BAD_BLOCK);
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(dbStub.badBlock.has.withArgs(sinon.match.defined).calledOnce).to.be.true;
@@ -82,7 +86,7 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect(error.type).to.have.property("code", BlockErrorCode.REPEAT_PROPOSAL);
+      expect((error as LodestarError<{code: string}>).type).to.have.property("code", BlockErrorCode.REPEAT_PROPOSAL);
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(dbStub.badBlock.has.withArgs(sinon.match.defined).calledOnce).to.be.true;
@@ -103,7 +107,7 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect(error.type).to.have.property("code", BlockErrorCode.PARENT_UNKNOWN);
+      expect((error as LodestarError<{code: string}>).type).to.have.property("code", BlockErrorCode.PARENT_UNKNOWN);
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(dbStub.badBlock.has.withArgs(sinon.match.defined).calledOnce).to.be.true;
@@ -125,7 +129,10 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect(error.type).to.have.property("code", BlockErrorCode.PROPOSAL_SIGNATURE_INVALID);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        BlockErrorCode.PROPOSAL_SIGNATURE_INVALID
+      );
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(dbStub.badBlock.has.withArgs(sinon.match.defined).calledOnce).to.be.true;
@@ -151,7 +158,7 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect(error.type).to.have.property("code", BlockErrorCode.INCORRECT_PROPOSER);
+      expect((error as LodestarError<{code: string}>).type).to.have.property("code", BlockErrorCode.INCORRECT_PROPOSER);
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(dbStub.badBlock.has.withArgs(sinon.match.defined).calledOnce).to.be.true;

--- a/packages/lodestar/test/unit/chain/validation/block.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/block.test.ts
@@ -12,8 +12,8 @@ import {generateSignedBlock, getNewBlockJob} from "../../../utils/block";
 import {StubbedBeaconDb} from "../../../utils/stub";
 import {generateCachedState} from "../../../utils/state";
 import {BlockErrorCode} from "../../../../src/chain/errors";
-import {LodestarError} from "@chainsafe/lodestar-utils";
 import {SinonStubFn} from "../../../utils/types";
+import {BlockError} from "../../../../lib/chain/errors";
 
 describe("gossip block validation", function () {
   let chainStub: SinonStubbedInstance<IBeaconChain>;
@@ -46,10 +46,7 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
-        "code",
-        BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT
-      );
+      expect((error as BlockError).type).to.have.property("code", BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT);
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(chainStub.getGenesisTime.notCalled).to.be.true;
@@ -67,7 +64,7 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property("code", BlockErrorCode.KNOWN_BAD_BLOCK);
+      expect((error as BlockError).type).to.have.property("code", BlockErrorCode.KNOWN_BAD_BLOCK);
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(dbStub.badBlock.has.withArgs(sinon.match.defined).calledOnce).to.be.true;
@@ -87,7 +84,7 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property("code", BlockErrorCode.REPEAT_PROPOSAL);
+      expect((error as BlockError).type).to.have.property("code", BlockErrorCode.REPEAT_PROPOSAL);
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(dbStub.badBlock.has.withArgs(sinon.match.defined).calledOnce).to.be.true;
@@ -108,7 +105,7 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property("code", BlockErrorCode.PARENT_UNKNOWN);
+      expect((error as BlockError).type).to.have.property("code", BlockErrorCode.PARENT_UNKNOWN);
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(dbStub.badBlock.has.withArgs(sinon.match.defined).calledOnce).to.be.true;
@@ -130,10 +127,7 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
-        "code",
-        BlockErrorCode.PROPOSAL_SIGNATURE_INVALID
-      );
+      expect((error as BlockError).type).to.have.property("code", BlockErrorCode.PROPOSAL_SIGNATURE_INVALID);
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(dbStub.badBlock.has.withArgs(sinon.match.defined).calledOnce).to.be.true;
@@ -159,7 +153,7 @@ describe("gossip block validation", function () {
     try {
       await validateGossipBlock(config, chainStub, dbStub, job);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property("code", BlockErrorCode.INCORRECT_PROPOSER);
+      expect((error as BlockError).type).to.have.property("code", BlockErrorCode.INCORRECT_PROPOSER);
     }
     expect(chainStub.getFinalizedCheckpoint.calledOnce).to.be.true;
     expect(dbStub.badBlock.has.withArgs(sinon.match.defined).calledOnce).to.be.true;

--- a/packages/lodestar/test/unit/chain/validation/block.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/block.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
+import sinon, {SinonStubbedInstance} from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/minimal";
 import * as specUtils from "@chainsafe/lodestar-beacon-state-transition/lib/phase0/fast/util/block";
@@ -13,13 +13,14 @@ import {StubbedBeaconDb} from "../../../utils/stub";
 import {generateCachedState} from "../../../utils/state";
 import {BlockErrorCode} from "../../../../src/chain/errors";
 import {LodestarError} from "@chainsafe/lodestar-utils";
+import {SinonStubFn} from "../../../utils/types";
 
 describe("gossip block validation", function () {
   let chainStub: SinonStubbedInstance<IBeaconChain>;
   let forkChoiceStub: SinonStubbedInstance<ForkChoice>;
   let regenStub: SinonStubbedInstance<StateRegenerator>;
   let dbStub: StubbedBeaconDb;
-  let verifySignatureStub: SinonStub;
+  let verifySignatureStub: SinonStubFn<typeof specUtils["verifyBlockSignature"]>;
 
   beforeEach(function () {
     chainStub = sinon.createStubInstance(BeaconChain);
@@ -165,7 +166,11 @@ describe("gossip block validation", function () {
     expect(regenStub.getBlockSlotState.calledOnce).to.be.true;
     expect(chainStub.receiveBlock.calledOnce).to.be.false;
     expect(verifySignatureStub.calledOnce).to.be.true;
-    expect((state.epochCtx.getBeaconProposer as SinonStub).withArgs(signedBlock.message.slot).calledOnce).to.be.true;
+    expect(
+      (state.epochCtx.getBeaconProposer as SinonStubFn<typeof state.epochCtx["getBeaconProposer"]>).withArgs(
+        signedBlock.message.slot
+      ).calledOnce
+    ).to.be.true;
   });
 
   it("should accept - valid block", async function () {
@@ -190,6 +195,10 @@ describe("gossip block validation", function () {
     expect(dbStub.badBlock.has.withArgs(sinon.match.defined).calledOnce).to.be.true;
     expect(regenStub.getBlockSlotState.calledOnce).to.be.true;
     expect(verifySignatureStub.calledOnce).to.be.true;
-    expect((state.epochCtx.getBeaconProposer as SinonStub).withArgs(signedBlock.message.slot).calledOnce).to.be.true;
+    expect(
+      (state.epochCtx.getBeaconProposer as SinonStubFn<typeof state.epochCtx["getBeaconProposer"]>).withArgs(
+        signedBlock.message.slot
+      ).calledOnce
+    ).to.be.true;
   });
 });

--- a/packages/lodestar/test/unit/chain/validation/proposerSlashing.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/proposerSlashing.test.ts
@@ -11,6 +11,7 @@ import {StubbedBeaconDb, StubbedChain} from "../../../utils/stub";
 import {generateCachedState} from "../../../utils/state";
 import {ProposerSlashingErrorCode} from "../../../../src/chain/errors/proposerSlashingError";
 import {validateGossipProposerSlashing} from "../../../../src/chain/validation/proposerSlashing";
+import {LodestarError} from "@chainsafe/lodestar-utils";
 
 describe("validate proposer slashing", () => {
   const sandbox = sinon.createSandbox();
@@ -33,7 +34,10 @@ describe("validate proposer slashing", () => {
     try {
       await validateGossipProposerSlashing(config, chainStub, dbStub, slashing);
     } catch (error) {
-      expect(error.type).to.have.property("code", ProposerSlashingErrorCode.SLASHING_ALREADY_EXISTS);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        ProposerSlashingErrorCode.SLASHING_ALREADY_EXISTS
+      );
     }
   });
 
@@ -46,7 +50,10 @@ describe("validate proposer slashing", () => {
     try {
       await validateGossipProposerSlashing(config, chainStub, dbStub, slashing);
     } catch (error) {
-      expect(error.type).to.have.property("code", ProposerSlashingErrorCode.INVALID_SLASHING);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        ProposerSlashingErrorCode.INVALID_SLASHING
+      );
     }
   });
 

--- a/packages/lodestar/test/unit/chain/validation/proposerSlashing.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/proposerSlashing.test.ts
@@ -9,9 +9,8 @@ import {ForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {BeaconChain} from "../../../../src/chain";
 import {StubbedBeaconDb, StubbedChain} from "../../../utils/stub";
 import {generateCachedState} from "../../../utils/state";
-import {ProposerSlashingErrorCode} from "../../../../src/chain/errors/proposerSlashingError";
+import {ProposerSlashingError, ProposerSlashingErrorCode} from "../../../../src/chain/errors/proposerSlashingError";
 import {validateGossipProposerSlashing} from "../../../../src/chain/validation/proposerSlashing";
-import {LodestarError} from "@chainsafe/lodestar-utils";
 import {SinonStubFn} from "../../../utils/types";
 
 describe("validate proposer slashing", () => {
@@ -37,7 +36,7 @@ describe("validate proposer slashing", () => {
     try {
       await validateGossipProposerSlashing(config, chainStub, dbStub, slashing);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
+      expect((error as ProposerSlashingError).type).to.have.property(
         "code",
         ProposerSlashingErrorCode.SLASHING_ALREADY_EXISTS
       );
@@ -53,7 +52,7 @@ describe("validate proposer slashing", () => {
     try {
       await validateGossipProposerSlashing(config, chainStub, dbStub, slashing);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
+      expect((error as ProposerSlashingError).type).to.have.property(
         "code",
         ProposerSlashingErrorCode.INVALID_SLASHING
       );

--- a/packages/lodestar/test/unit/chain/validation/proposerSlashing.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/proposerSlashing.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub} from "sinon";
+import sinon from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {generateEmptyProposerSlashing} from "@chainsafe/lodestar-beacon-state-transition/test/utils/slashings";
@@ -12,10 +12,13 @@ import {generateCachedState} from "../../../utils/state";
 import {ProposerSlashingErrorCode} from "../../../../src/chain/errors/proposerSlashingError";
 import {validateGossipProposerSlashing} from "../../../../src/chain/validation/proposerSlashing";
 import {LodestarError} from "@chainsafe/lodestar-utils";
+import {SinonStubFn} from "../../../utils/types";
 
 describe("validate proposer slashing", () => {
   const sandbox = sinon.createSandbox();
-  let dbStub: StubbedBeaconDb, isValidIncomingProposerSlashingStub: SinonStub, chainStub: StubbedChain;
+  let dbStub: StubbedBeaconDb,
+    isValidIncomingProposerSlashingStub: SinonStubFn<typeof validatorStatusUtils["isValidProposerSlashing"]>,
+    chainStub: StubbedChain;
 
   beforeEach(() => {
     isValidIncomingProposerSlashingStub = sandbox.stub(validatorStatusUtils, "isValidProposerSlashing");

--- a/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
@@ -15,6 +15,7 @@ import {generateState} from "../../../utils/state";
 import {generateEmptySignedVoluntaryExit} from "../../../utils/attestation";
 import {validateGossipVoluntaryExit} from "../../../../src/chain/validation/voluntaryExit";
 import {VoluntaryExitErrorCode} from "../../../../src/chain/errors/voluntaryExitError";
+import {LodestarError} from "@chainsafe/lodestar-utils";
 
 describe("validate voluntary exit", () => {
   const sandbox = sinon.createSandbox();
@@ -53,7 +54,10 @@ describe("validate voluntary exit", () => {
     try {
       await validateGossipVoluntaryExit(config, chainStub, dbStub, voluntaryExit);
     } catch (error) {
-      expect(error.type).to.have.property("code", VoluntaryExitErrorCode.EXIT_ALREADY_EXISTS);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        VoluntaryExitErrorCode.EXIT_ALREADY_EXISTS
+      );
     }
   });
 
@@ -76,7 +80,10 @@ describe("validate voluntary exit", () => {
     try {
       await validateGossipVoluntaryExit(config, chainStub, dbStub, voluntaryExit);
     } catch (error) {
-      expect(error.type).to.have.property("code", VoluntaryExitErrorCode.INVALID_EXIT);
+      expect((error as LodestarError<{code: string}>).type).to.have.property(
+        "code",
+        VoluntaryExitErrorCode.INVALID_EXIT
+      );
     }
   });
 

--- a/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
@@ -15,8 +15,8 @@ import {generateState} from "../../../utils/state";
 import {generateEmptySignedVoluntaryExit} from "../../../utils/attestation";
 import {validateGossipVoluntaryExit} from "../../../../src/chain/validation/voluntaryExit";
 import {VoluntaryExitErrorCode} from "../../../../src/chain/errors/voluntaryExitError";
-import {LodestarError} from "@chainsafe/lodestar-utils";
 import {SinonStubFn} from "../../../utils/types";
+import {VoluntaryExitError} from "../../../../lib/chain/errors";
 
 describe("validate voluntary exit", () => {
   const sandbox = sinon.createSandbox();
@@ -55,10 +55,7 @@ describe("validate voluntary exit", () => {
     try {
       await validateGossipVoluntaryExit(config, chainStub, dbStub, voluntaryExit);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
-        "code",
-        VoluntaryExitErrorCode.EXIT_ALREADY_EXISTS
-      );
+      expect((error as VoluntaryExitError).type).to.have.property("code", VoluntaryExitErrorCode.EXIT_ALREADY_EXISTS);
     }
   });
 
@@ -81,10 +78,7 @@ describe("validate voluntary exit", () => {
     try {
       await validateGossipVoluntaryExit(config, chainStub, dbStub, voluntaryExit);
     } catch (error) {
-      expect((error as LodestarError<{code: string}>).type).to.have.property(
-        "code",
-        VoluntaryExitErrorCode.INVALID_EXIT
-      );
+      expect((error as VoluntaryExitError).type).to.have.property("code", VoluntaryExitErrorCode.INVALID_EXIT);
     }
   });
 

--- a/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
+import sinon, {SinonStubbedInstance} from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {createCachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
@@ -16,11 +16,12 @@ import {generateEmptySignedVoluntaryExit} from "../../../utils/attestation";
 import {validateGossipVoluntaryExit} from "../../../../src/chain/validation/voluntaryExit";
 import {VoluntaryExitErrorCode} from "../../../../src/chain/errors/voluntaryExitError";
 import {LodestarError} from "@chainsafe/lodestar-utils";
+import {SinonStubFn} from "../../../utils/types";
 
 describe("validate voluntary exit", () => {
   const sandbox = sinon.createSandbox();
   let dbStub: StubbedBeaconDb,
-    isValidIncomingVoluntaryExitStub: SinonStub,
+    isValidIncomingVoluntaryExitStub: SinonStubFn<typeof validatorStatusUtils["isValidVoluntaryExit"]>,
     chainStub: StubbedChain,
     regenStub: SinonStubbedInstance<StateRegenerator>;
 

--- a/packages/lodestar/test/unit/db/api/beacon.test.ts
+++ b/packages/lodestar/test/unit/db/api/beacon.test.ts
@@ -1,6 +1,6 @@
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
-import sinon from "sinon";
+import sinon, {SinonStubbedInstance} from "sinon";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {LevelDbController} from "@chainsafe/lodestar-db";
 import {BeaconDb} from "../../../../src/db/api";
@@ -29,13 +29,34 @@ describe("beacon db - post block processing", function () {
       config,
       controller: sandbox.createStubInstance(LevelDbController),
     }) as StubbedBeaconDb;
-    dbStub.depositEvent = sandbox.createStubInstance(DepositEventRepository) as any;
-    dbStub.voluntaryExit = sandbox.createStubInstance(VoluntaryExitRepository) as any;
-    dbStub.proposerSlashing = sandbox.createStubInstance(ProposerSlashingRepository) as any;
-    dbStub.attesterSlashing = sandbox.createStubInstance(AttesterSlashingRepository) as any;
-    dbStub.attestation = sandbox.createStubInstance(AttestationRepository) as any;
-    dbStub.aggregateAndProof = sandbox.createStubInstance(AggregateAndProofRepository) as any;
-    dbStub.stateArchive = sandbox.createStubInstance(StateArchiveRepository) as any;
+    dbStub.depositEvent = sandbox.createStubInstance(DepositEventRepository) as SinonStubbedInstance<
+      DepositEventRepository
+    > &
+      DepositEventRepository;
+    dbStub.voluntaryExit = sandbox.createStubInstance(VoluntaryExitRepository) as SinonStubbedInstance<
+      VoluntaryExitRepository
+    > &
+      VoluntaryExitRepository;
+    dbStub.proposerSlashing = sandbox.createStubInstance(ProposerSlashingRepository) as SinonStubbedInstance<
+      ProposerSlashingRepository
+    > &
+      ProposerSlashingRepository;
+    dbStub.attesterSlashing = sandbox.createStubInstance(AttesterSlashingRepository) as SinonStubbedInstance<
+      AttesterSlashingRepository
+    > &
+      AttesterSlashingRepository;
+    dbStub.attestation = sandbox.createStubInstance(AttestationRepository) as SinonStubbedInstance<
+      AttestationRepository
+    > &
+      AttestationRepository;
+    dbStub.aggregateAndProof = sandbox.createStubInstance(AggregateAndProofRepository) as SinonStubbedInstance<
+      AggregateAndProofRepository
+    > &
+      AggregateAndProofRepository;
+    dbStub.stateArchive = sandbox.createStubInstance(StateArchiveRepository) as SinonStubbedInstance<
+      StateArchiveRepository
+    > &
+      StateArchiveRepository;
 
     // Add to state
     dbStub.stateArchive.lastValue.resolves(

--- a/packages/lodestar/test/unit/db/api/repository.test.ts
+++ b/packages/lodestar/test/unit/db/api/repository.test.ts
@@ -105,13 +105,19 @@ describe("database repository", function () {
 
   it("should delete given items", async function () {
     await repository.batchDelete(["1", "2", "3"]);
-    expect(controller.batchDelete.withArgs(sinon.match((criteria) => criteria.length === 3)).calledOnce).to.be.true;
+    expect(
+      controller.batchDelete.withArgs(sinon.match((criteria: ContainerType<TestType>[]) => criteria.length === 3))
+        .calledOnce
+    ).to.be.true;
   });
 
   it("should delete given items by value", async function () {
     const item = {bool: true, bytes: Buffer.alloc(32)};
     await repository.batchRemove([item, item]);
-    expect(controller.batchDelete.withArgs(sinon.match((criteria) => criteria.length === 2)).calledOnce).to.be.true;
+    expect(
+      controller.batchDelete.withArgs(sinon.match((criteria: ContainerType<TestType>[]) => criteria.length === 2))
+        .calledOnce
+    ).to.be.true;
   });
 
   it("should add multiple values", async function () {
@@ -119,7 +125,10 @@ describe("database repository", function () {
       {bool: true, bytes: Buffer.alloc(32)},
       {bool: false, bytes: Buffer.alloc(32)},
     ]);
-    expect(controller.batchPut.withArgs(sinon.match((criteria) => criteria.length === 2)).calledOnce).to.be.true;
+    expect(
+      controller.batchPut.withArgs(sinon.match((criteria: ContainerType<TestType>[]) => criteria.length === 2))
+        .calledOnce
+    ).to.be.true;
   });
 
   it("should fetch values stream", async function () {

--- a/packages/lodestar/test/unit/eth1/utils/deposits.test.ts
+++ b/packages/lodestar/test/unit/eth1/utils/deposits.test.ts
@@ -26,7 +26,7 @@ describe("eth1 / util / deposits", function () {
       eth1DepositIndex: number;
       depositIndexes: number[];
       expectedReturnedIndexes?: number[];
-      error?: any;
+      error?: unknown;
     }
 
     const {MAX_DEPOSITS} = config.params;
@@ -97,7 +97,7 @@ describe("eth1 / util / deposits", function () {
           const result = await resultPromise;
           expect(result.map((deposit) => deposit.index)).to.deep.equal(expectedReturnedIndexes);
         } else if (error) {
-          await expect(resultPromise).to.be.rejectedWith(error);
+          await expect(resultPromise).to.be.rejectedWith(error as Error);
         } else {
           throw Error("Test case must have 'result' or 'error'");
         }

--- a/packages/lodestar/test/unit/eth1/utils/eth1Data.test.ts
+++ b/packages/lodestar/test/unit/eth1/utils/eth1Data.test.ts
@@ -13,6 +13,7 @@ import {
   ErrorNoDepositsForBlockRange,
   ErrorNotEnoughDepositRoots,
 } from "../../../../src/eth1/utils/eth1Data";
+import {DepositData} from "@chainsafe/lodestar-types/phase0";
 
 chai.use(chaiAsPromised);
 
@@ -24,7 +25,7 @@ describe("eth1 / util / getEth1DataForBlocks", function () {
     depositRootTree: TreeBacked<List<Root>>;
     lastProcessedDepositBlockNumber: number;
     expectedEth1Data?: Partial<phase0.Eth1Data & phase0.Eth1Block>[];
-    error?: any;
+    error?: unknown;
   }
 
   const testCases: (() => ITestCase)[] = [
@@ -120,7 +121,7 @@ describe("eth1 / util / getEth1DataForBlocks", function () {
         const eth1DatasPartial = eth1Datas.map((eth1Data) => pick(eth1Data, Object.keys(expectedEth1Data[0])));
         expect(eth1DatasPartial).to.deep.equal(expectedEth1Data);
       } else if (error) {
-        await expect(eth1DatasPromise).to.be.rejectedWith(error);
+        await expect(eth1DatasPromise).to.be.rejectedWith(error as Error);
       } else {
         throw Error("Test case must have 'expectedEth1Data' or 'error'");
       }
@@ -273,6 +274,6 @@ function getMockDeposit({blockNumber, index}: {blockNumber: number; index: numbe
   return {
     blockNumber,
     index,
-    depositData: {} as any, // Not used
+    depositData: {} as DepositData, // Not used
   };
 }

--- a/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
@@ -35,7 +35,7 @@ describe("gossipsub", function () {
       topicIDs: [topicString],
     };
 
-    validatorFns = new Map();
+    validatorFns = new Map<string, TopicValidatorFn>();
     const multiaddr = "/ip4/127.0.0.1/tcp/0";
     libp2p = await createNode(multiaddr);
   });
@@ -50,7 +50,7 @@ describe("gossipsub", function () {
       await gossipSub.validate(message);
       assert.fail("Expect error here");
     } catch (e) {
-      expect(e.code).to.be.equal(ERR_TOPIC_VALIDATOR_REJECT);
+      expect((e as GossipValidationError).code).to.be.equal(ERR_TOPIC_VALIDATOR_REJECT);
     }
   });
 

--- a/packages/lodestar/test/unit/network/peers/metastore.test.ts
+++ b/packages/lodestar/test/unit/network/peers/metastore.test.ts
@@ -14,7 +14,7 @@ describe("Libp2pPeerMetadataStore", function () {
   beforeEach(function () {
     let stored: Buffer;
     metabookStub = {
-      data: new Map(),
+      data: new Map<string, Map<string, Buffer>>(),
       delete: sinon.stub(),
       deleteValue: sinon.stub(),
       get: sinon.stub(),

--- a/packages/lodestar/test/unit/network/peers/metastore.test.ts
+++ b/packages/lodestar/test/unit/network/peers/metastore.test.ts
@@ -24,6 +24,7 @@ describe("Libp2pPeerMetadataStore", function () {
       set: sinon.stub().callsFake(
         (peerId: PeerId, key: string, value: Buffer): ProtoBook => {
           stored = value;
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           return (metabookStub as unknown) as ProtoBook;
         }
       ) as SinonStub<[PeerId, string, Buffer], ProtoBook>,

--- a/packages/lodestar/test/unit/network/peers/utils.test.ts
+++ b/packages/lodestar/test/unit/network/peers/utils.test.ts
@@ -176,7 +176,9 @@ describe("network peer utils", function () {
       scoreTrackerStub.getScore.withArgs(peers[0]).returns(10);
       scoreTrackerStub.getScore.withArgs(peers[1]).returns(20);
       scoreTrackerStub.getScore.withArgs(peers[2]).returns(30);
-      const connectedPeers = peers.map((peerId) => ({id: peerId} as Pick<LibP2p.Peer, "id">)) as LibP2p.Peer[];
+      const connectedPeers = peers.map(
+        (peerId) => ({id: peerId, protocols: getSyncProtocols()} as Pick<LibP2p.Peer, "id" | "protocols">)
+      ) as LibP2p.Peer[];
       expect(syncPeersToDisconnect(connectedPeers, networkStub)).to.be.deep.equal([peer1, peer2]);
     });
 

--- a/packages/lodestar/test/unit/network/peers/utils.test.ts
+++ b/packages/lodestar/test/unit/network/peers/utils.test.ts
@@ -1,4 +1,4 @@
-import sinon, {SinonStub, SinonStubbedInstance} from "sinon";
+import sinon, {SinonStubbedInstance} from "sinon";
 import {getSyncProtocols, INetwork, IReqResp, Network} from "../../../../src/network";
 import PeerId from "peer-id";
 import {expect} from "chai";
@@ -14,13 +14,14 @@ import {testLogger} from "../../../utils/logger";
 import {ReqResp} from "../../../../src/network/reqresp/reqResp";
 import {IPeerRpcScoreStore, PeerRpcScoreStore} from "../../../../src/network/peers";
 import {getStubbedMetadataStore, StubbedIPeerMetadataStore} from "../../../utils/peer";
+import {SinonStubFn} from "../../../utils/types";
 
 describe("network peer utils", function () {
   const logger = testLogger();
   let networkStub: SinonStubbedInstance<INetwork>;
   let peerMetadataStoreStub: StubbedIPeerMetadataStore;
   let scoreTrackerStub: SinonStubbedInstance<IPeerRpcScoreStore>;
-  let getSyncPeersStub: SinonStub;
+  let getSyncPeersStub: SinonStubFn<typeof peersUtil["getSyncPeers"]>;
 
   beforeEach(() => {
     peerMetadataStoreStub = getStubbedMetadataStore();
@@ -161,11 +162,11 @@ describe("network peer utils", function () {
     });
 
     it("should return all non sync peers", () => {
-      networkStub.getPeers.returns(peers.map((peerId) => ({id: peerId} as LibP2p.Peer)));
+      networkStub.getPeers.returns(peers.map((peerId) => ({id: peerId} as Pick<LibP2p.Peer, "id">)) as LibP2p.Peer[]);
 
       // so none of them are good score sync peers
       getSyncPeersStub.returns([]);
-      const connectedPeers = peers.map((peerId) => ({id: peerId} as LibP2p.Peer));
+      const connectedPeers = peers.map((peerId) => ({id: peerId} as Pick<LibP2p.Peer, "id">)) as LibP2p.Peer[];
       expect(syncPeersToDisconnect(connectedPeers, networkStub)).to.be.deep.equal(peers);
     });
 
@@ -175,7 +176,7 @@ describe("network peer utils", function () {
       scoreTrackerStub.getScore.withArgs(peers[0]).returns(10);
       scoreTrackerStub.getScore.withArgs(peers[1]).returns(20);
       scoreTrackerStub.getScore.withArgs(peers[2]).returns(30);
-      const connectedPeers = peers.map((peerId) => ({id: peerId, protocols: getSyncProtocols()} as LibP2p.Peer));
+      const connectedPeers = peers.map((peerId) => ({id: peerId} as Pick<LibP2p.Peer, "id">)) as LibP2p.Peer[];
       expect(syncPeersToDisconnect(connectedPeers, networkStub)).to.be.deep.equal([peer1, peer2]);
     });
 
@@ -204,7 +205,7 @@ describe("network peer utils", function () {
       peer1 = await PeerId.create();
       peer2 = await PeerId.create();
       peers = [peer1, peer2];
-      connectedPeers = peers.map((peerId) => ({id: peerId} as LibP2p.Peer));
+      connectedPeers = peers.map((peerId) => ({id: peerId} as Pick<LibP2p.Peer, "id">)) as LibP2p.Peer[];
     });
 
     afterEach(() => {

--- a/packages/lodestar/test/unit/sync/gossip/handler.test.ts
+++ b/packages/lodestar/test/unit/sync/gossip/handler.test.ts
@@ -10,6 +10,7 @@ import {
   GossipEncoding,
   GossipType,
   encodeMessageData,
+  TopicValidatorFn,
 } from "../../../../src/network/gossip";
 import {BeaconGossipHandler} from "../../../../src/sync/gossip";
 
@@ -35,7 +36,7 @@ describe("gossip handler", function () {
       config,
       genesisValidatorsRoot,
       libp2p,
-      validatorFns: new Map(),
+      validatorFns: new Map<string, TopicValidatorFn>(),
       logger: testLogger(),
     });
     networkStub.gossip = gossipsub;

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/fetcher.test.ts
@@ -13,6 +13,7 @@ import {generateEmptySignedBlock} from "../../../../utils/block";
 import {phase0} from "@chainsafe/lodestar-types";
 import {getStubbedMetadataStore, StubbedIPeerMetadataStore} from "../../../../utils/peer";
 import {testLogger} from "../../../../utils/logger";
+import {SinonStubFn} from "../../../../utils/types";
 
 describe("BlockRangeFetcher", function () {
   let fetcher: BlockRangeFetcher;
@@ -20,8 +21,8 @@ describe("BlockRangeFetcher", function () {
   let clockStub: SinonStubbedInstance<IBeaconClock>;
   let networkStub: SinonStubbedInstance<INetwork>;
   let metadataStub: StubbedIPeerMetadataStore;
-  let getBlockRangeStub: SinonStub;
-  let getCurrentSlotStub: SinonStub;
+  let getBlockRangeStub: SinonStubFn<typeof blockUtils["getBlockRange"]>;
+  let getCurrentSlotStub: SinonStubFn<typeof slotUtils["getCurrentSlot"]>;
   const logger = testLogger();
   const sandbox = sinon.createSandbox();
   let getPeers: SinonStub;

--- a/packages/lodestar/test/unit/sync/regular/oneRangeAhead/oneRangeAhead.test.ts
+++ b/packages/lodestar/test/unit/sync/regular/oneRangeAhead/oneRangeAhead.test.ts
@@ -1,4 +1,4 @@
-import {SinonStub, SinonStubbedInstance} from "sinon";
+import {SinonStubbedInstance} from "sinon";
 import {ORARegularSync} from "../../../../../src/sync/regular/oneRangeAhead/oneRangeAhead";
 import {IBlockRangeFetcher} from "../../../../../src/sync/regular/oneRangeAhead/interface";
 import {BlockRangeFetcher} from "../../../../../src/sync/regular/oneRangeAhead/fetcher";
@@ -14,6 +14,7 @@ import {IBeaconClock, LocalClock} from "../../../../../src/chain/clock";
 import * as slotUtils from "@chainsafe/lodestar-beacon-state-transition/lib/util/slot";
 import {sleep} from "@chainsafe/lodestar-cli/src/util";
 import {phase0} from "@chainsafe/lodestar-types";
+import {SinonStubFn} from "../../../../utils/types";
 
 describe("ORARegularSync", function () {
   let sync: ORARegularSync;
@@ -23,7 +24,7 @@ describe("ORARegularSync", function () {
   let forkChoiceStub: SinonStubbedInstance<ForkChoice>;
   let networkStub: SinonStubbedInstance<INetwork>;
   let gossipStub: SinonStubbedInstance<Eth2Gossipsub>;
-  let getCurrentSlotStub: SinonStub;
+  let getCurrentSlotStub: SinonStubFn<typeof slotUtils["getCurrentSlot"]>;
   const logger = testLogger("ORARegularSync");
 
   beforeEach(() => {

--- a/packages/lodestar/test/utils/errors.ts
+++ b/packages/lodestar/test/utils/errors.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import {LodestarError, mapValues} from "@chainsafe/lodestar-utils";
 import {Json} from "@chainsafe/ssz";
 
-export function expectThrowsLodestarError(fn: () => any, expectedErr: LodestarError<any>): void {
+export function expectThrowsLodestarError(fn: () => void, expectedErr: LodestarError<any>): void {
   try {
     const value = fn();
     const json = JSON.stringify(value, null, 2);
@@ -13,7 +13,7 @@ export function expectThrowsLodestarError(fn: () => any, expectedErr: LodestarEr
 }
 
 export async function expectRejectedWithLodestarError(
-  promise: Promise<any>,
+  promise: Promise<unknown>,
   expectedErr: LodestarError<any> | string
 ): Promise<void> {
   try {

--- a/packages/lodestar/test/utils/logger.ts
+++ b/packages/lodestar/test/utils/logger.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {WinstonLogger, LogLevel, TransportType} from "@chainsafe/lodestar-utils";
 export {LogLevel};
 

--- a/packages/lodestar/test/utils/logger.ts
+++ b/packages/lodestar/test/utils/logger.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
 import {WinstonLogger, LogLevel, TransportType} from "@chainsafe/lodestar-utils";
 export {LogLevel};
 

--- a/packages/lodestar/test/utils/peer.ts
+++ b/packages/lodestar/test/utils/peer.ts
@@ -8,7 +8,7 @@ export function generatePeer(id: PeerId): Peer {
   return {
     id,
     addresses: [],
-    metadata: new Map(),
+    metadata: new Map<string, Buffer>(),
     protocols: [],
   };
 }

--- a/packages/lodestar/test/utils/state.ts
+++ b/packages/lodestar/test/utils/state.ts
@@ -82,6 +82,7 @@ export function generateState(opts: TestBeaconState = {}, config = minimalConfig
   const resultState = state.clone();
   for (const key in opts) {
     // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     resultState[key] = opts[key];
   }
   return resultState;

--- a/packages/lodestar/test/utils/stub/beaconDb.ts
+++ b/packages/lodestar/test/utils/stub/beaconDb.ts
@@ -20,6 +20,7 @@ import {
 import {SeenAttestationCache} from "../../../src/db/api/beacon/seenAttestationCache";
 import {minimalConfig} from "@chainsafe/lodestar-config/minimal";
 import {PendingBlockRepository} from "../../../src/db/api/beacon/repositories/pendingBlock";
+import {SignedBeaconBlock} from "@chainsafe/lodestar-types/phase0";
 
 export class StubbedBeaconDb extends BeaconDb {
   db!: SinonStubbedInstance<LevelDbController>;
@@ -48,22 +49,57 @@ export class StubbedBeaconDb extends BeaconDb {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(sinon: SinonSandbox, config = minimalConfig) {
     super({config, controller: null!});
-    this.badBlock = sinon.createStubInstance(BadBlockRepository) as any;
-    this.block = sinon.createStubInstance(BlockRepository) as any;
-    this.pendingBlock = sinon.createStubInstance(PendingBlockRepository) as any;
-    this.blockArchive = sinon.createStubInstance(BlockArchiveRepository) as any;
-    this.stateArchive = sinon.createStubInstance(StateArchiveRepository) as any;
+    this.badBlock = sinon.createStubInstance(BadBlockRepository) as SinonStubbedInstance<BadBlockRepository> &
+      BadBlockRepository;
+    this.block = sinon.createStubInstance(BlockRepository) as SinonStubbedInstance<BlockRepository> & BlockRepository;
+    this.pendingBlock = sinon.createStubInstance(PendingBlockRepository) as SinonStubbedInstance<
+      PendingBlockRepository
+    > &
+      PendingBlockRepository;
+    this.blockArchive = sinon.createStubInstance(BlockArchiveRepository) as SinonStubbedInstance<
+      BlockArchiveRepository
+    > &
+      BlockArchiveRepository;
+    this.stateArchive = sinon.createStubInstance(StateArchiveRepository) as SinonStubbedInstance<
+      StateArchiveRepository
+    > &
+      StateArchiveRepository;
 
-    this.attestation = sinon.createStubInstance(AttestationRepository) as any;
-    this.aggregateAndProof = sinon.createStubInstance(AggregateAndProofRepository) as any;
-    this.voluntaryExit = sinon.createStubInstance(VoluntaryExitRepository) as any;
-    this.proposerSlashing = sinon.createStubInstance(ProposerSlashingRepository) as any;
-    this.attesterSlashing = sinon.createStubInstance(AttesterSlashingRepository) as any;
-    this.depositEvent = sinon.createStubInstance(DepositEventRepository) as any;
+    this.attestation = sinon.createStubInstance(AttestationRepository) as SinonStubbedInstance<AttestationRepository> &
+      AttestationRepository;
+    this.aggregateAndProof = sinon.createStubInstance(AggregateAndProofRepository) as SinonStubbedInstance<
+      AggregateAndProofRepository
+    > &
+      AggregateAndProofRepository;
+    this.voluntaryExit = sinon.createStubInstance(VoluntaryExitRepository) as SinonStubbedInstance<
+      VoluntaryExitRepository
+    > &
+      VoluntaryExitRepository;
+    this.proposerSlashing = sinon.createStubInstance(ProposerSlashingRepository) as SinonStubbedInstance<
+      ProposerSlashingRepository
+    > &
+      ProposerSlashingRepository;
+    this.attesterSlashing = sinon.createStubInstance(AttesterSlashingRepository) as SinonStubbedInstance<
+      AttesterSlashingRepository
+    > &
+      AttesterSlashingRepository;
+    this.depositEvent = sinon.createStubInstance(DepositEventRepository) as SinonStubbedInstance<
+      DepositEventRepository
+    > &
+      DepositEventRepository;
 
-    this.depositDataRoot = sinon.createStubInstance(DepositDataRootRepository) as any;
-    this.eth1Data = sinon.createStubInstance(Eth1DataRepository) as any;
-    this.seenAttestationCache = sinon.createStubInstance(SeenAttestationCache) as any;
-    this.processBlockOperations = sinon.stub(this, "processBlockOperations") as any;
+    this.depositDataRoot = sinon.createStubInstance(DepositDataRootRepository) as SinonStubbedInstance<
+      DepositDataRootRepository
+    > &
+      DepositDataRootRepository;
+    this.eth1Data = sinon.createStubInstance(Eth1DataRepository) as SinonStubbedInstance<Eth1DataRepository> &
+      Eth1DataRepository;
+    this.seenAttestationCache = sinon.createStubInstance(SeenAttestationCache) as SinonStubbedInstance<
+      SeenAttestationCache
+    > &
+      SeenAttestationCache;
+    this.processBlockOperations = sinon.stub(this, "processBlockOperations") as (
+      signedBlock: SignedBeaconBlock
+    ) => Promise<void>;
   }
 }

--- a/packages/lodestar/test/utils/stub/chain.ts
+++ b/packages/lodestar/test/utils/stub/chain.ts
@@ -37,10 +37,15 @@ export class StubbedBeaconChain extends BeaconChain {
         balances: Array.from({length: 64}, () => BigInt(0)),
       } as phase0.BeaconState),
     });
-    this.forkChoice = sinon.createStubInstance(ForkChoice) as any;
-    this.stateCache = sinon.createStubInstance(StateContextCache) as any;
-    this.checkpointStateCache = sinon.createStubInstance(CheckpointStateCache) as any;
-    this.clock = sinon.createStubInstance(LocalClock) as any;
-    this.regen = sinon.createStubInstance(StateRegenerator) as any;
+    this.forkChoice = sinon.createStubInstance(ForkChoice) as SinonStubbedInstance<ForkChoice> & ForkChoice;
+    this.stateCache = sinon.createStubInstance(StateContextCache) as SinonStubbedInstance<StateContextCache> &
+      StateContextCache;
+    this.checkpointStateCache = sinon.createStubInstance(CheckpointStateCache) as SinonStubbedInstance<
+      CheckpointStateCache
+    > &
+      CheckpointStateCache;
+    this.clock = sinon.createStubInstance(LocalClock) as SinonStubbedInstance<LocalClock> & LocalClock;
+    this.regen = sinon.createStubInstance(StateRegenerator) as SinonStubbedInstance<StateRegenerator> &
+      StateRegenerator;
   }
 }

--- a/packages/lodestar/test/utils/types.ts
+++ b/packages/lodestar/test/utils/types.ts
@@ -1,0 +1,5 @@
+import {SinonStub} from "sinon";
+
+export type SinonStubFn<T extends (...args: any[]) => any> = T extends (...args: infer TArgs) => infer TReturnValue
+  ? SinonStub<TArgs, TReturnValue>
+  : never;

--- a/packages/persistent-ts/src/Vector.ts
+++ b/packages/persistent-ts/src/Vector.ts
@@ -23,11 +23,11 @@ interface IBranch<T> {
 type INode<T> = ILeaf<T> | IBranch<T>;
 
 function emptyBranch<T>(): IBranch<T> {
-  return {leaf: false, nodes: Array(BRANCH_SIZE).fill(null)};
+  return {leaf: false, nodes: Array<INode<T> | null>(BRANCH_SIZE).fill(null)};
 }
 
 function emptyLeaf<T>(): ILeaf<T> {
-  return {leaf: true, values: Array(BRANCH_SIZE).fill(null)};
+  return {leaf: true, values: Array(BRANCH_SIZE).fill(null) as T[]};
 }
 
 function copyNode<T>(vnode: INode<T>): INode<T> {
@@ -57,7 +57,7 @@ export class Vector<T> implements Iterable<T> {
    * Create an empty vector of a certain type.
    */
   static empty<T>(): Vector<T> {
-    return new Vector(emptyBranch(), DEFAULT_LEVEL_SHIFT, Array(BRANCH_SIZE).fill(null), 0);
+    return new Vector<T>(emptyBranch(), DEFAULT_LEVEL_SHIFT, Array(BRANCH_SIZE).fill(null), 0);
   }
 
   /**
@@ -168,7 +168,7 @@ export class Vector<T> implements Iterable<T> {
     }
     // it's safe to update cursor bc "next" is a new instance anyway
     cursor.values = [...this.tail];
-    return new Vector(base, levelShift, [value, ...Array(BRANCH_SIZE - 1).fill(null)], this.length + 1);
+    return new Vector<T>(base, levelShift, [value, ...(Array(BRANCH_SIZE - 1).fill(null) as T[])], this.length + 1);
   }
 
   /**
@@ -183,7 +183,7 @@ export class Vector<T> implements Iterable<T> {
     if (tailLength >= 2) {
       // ignore the last item
       const newTailLength = (this.length - 1) % BRANCH_SIZE;
-      const newTail = [...this.tail.slice(0, newTailLength), ...Array(BRANCH_SIZE - newTailLength).fill(null)];
+      const newTail = [...this.tail.slice(0, newTailLength), ...(Array(BRANCH_SIZE - newTailLength).fill(null) as T[])];
       return new Vector(this.root, this.levelShift, newTail, this.length - 1);
     }
     // tail has exactly 1 item, promote the right most leaf node as tail

--- a/packages/spec-test-runner/test/spec/bls/aggregate_sigs.test.ts
+++ b/packages/spec-test-runner/test/spec/bls/aggregate_sigs.test.ts
@@ -23,7 +23,7 @@ describeDirectorySpecTest<IAggregateSigsTestCase, string | null>(
       );
       return `0x${Buffer.from(result).toString("hex")}`;
     } catch (e) {
-      if (e.message === "signatures is null or undefined or empty array") {
+      if ((e as Error).message === "signatures is null or undefined or empty array") {
         return null;
       }
       throw e;

--- a/packages/spec-test-runner/test/spec/finality/finality_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/finality/finality_fast.test.ts
@@ -62,7 +62,7 @@ function generateBlocksSZZTypeMapping(
   n: number,
   config: IBeaconConfig
 ): Record<string, typeof config.types.phase0.SignedBeaconBlock> {
-  const blocksMapping: any = {};
+  const blocksMapping: Record<string, typeof config.types.phase0.SignedBeaconBlock> = {};
   for (let i = 0; i < n; i++) {
     blocksMapping[`blocks_${i}`] = config.types.phase0.SignedBeaconBlock;
   }

--- a/packages/spec-test-runner/test/spec/finality/finality_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/finality/finality_mainnet.test.ts
@@ -46,7 +46,7 @@ function generateBlocksSZZTypeMapping(
   n: number,
   config: IBeaconConfig
 ): Record<string, typeof config.types.phase0.SignedBeaconBlock> {
-  const blocksMapping: any = {};
+  const blocksMapping: Record<string, typeof config.types.phase0.SignedBeaconBlock> = {};
   for (let i = 0; i < n; i++) {
     blocksMapping[`blocks_${i}`] = config.types.phase0.SignedBeaconBlock;
   }

--- a/packages/spec-test-runner/test/spec/finality/finality_minimal.test.ts
+++ b/packages/spec-test-runner/test/spec/finality/finality_minimal.test.ts
@@ -46,7 +46,7 @@ function generateBlocksSZZTypeMapping(
   n: number,
   config: IBeaconConfig
 ): Record<string, typeof config.types.phase0.SignedBeaconBlock> {
-  const blocksMapping: any = {};
+  const blocksMapping: Record<string, typeof config.types.phase0.SignedBeaconBlock> = {};
   for (let i = 0; i < n; i++) {
     blocksMapping[`blocks_${i}`] = config.types.phase0.SignedBeaconBlock;
   }

--- a/packages/spec-test-runner/test/spec/lightclient_patch/sanity/blocks/mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/lightclient_patch/sanity/blocks/mainnet.test.ts
@@ -55,7 +55,7 @@ function generateBlocksSZZTypeMapping(
   n: number,
   config: IBeaconConfig
 ): Record<string, typeof config.types.lightclient.SignedBeaconBlock> {
-  const blocksMapping: any = {};
+  const blocksMapping: Record<string, typeof config.types.lightclient.SignedBeaconBlock> = {};
   for (let i = 0; i < n; i++) {
     blocksMapping[`blocks_${i}`] = config.types.lightclient.SignedBeaconBlock;
   }

--- a/packages/spec-test-runner/test/spec/lightclient_patch/sanity/blocks/minimal.test.ts
+++ b/packages/spec-test-runner/test/spec/lightclient_patch/sanity/blocks/minimal.test.ts
@@ -55,7 +55,7 @@ function generateBlocksSZZTypeMapping(
   n: number,
   config: IBeaconConfig
 ): Record<string, typeof config.types.lightclient.SignedBeaconBlock> {
-  const blocksMapping: any = {};
+  const blocksMapping: Record<string, typeof config.types.lightclient.SignedBeaconBlock> = {};
   for (let i = 0; i < n; i++) {
     blocksMapping[`blocks_${i}`] = config.types.lightclient.SignedBeaconBlock;
   }

--- a/packages/spec-test-runner/test/spec/rewards/types.ts
+++ b/packages/spec-test-runner/test/spec/rewards/types.ts
@@ -46,7 +46,7 @@ export interface IRewardsTestCase {
 }
 
 export function generateSZZTypeMapping(): Record<string, unknown> {
-  const typeMappings: any = {};
+  const typeMappings: Record<string, unknown> = {};
   typeMappings["source_deltas"] = DeltasType;
   typeMappings["target_deltas"] = DeltasType;
   typeMappings["head_deltas"] = DeltasType;

--- a/packages/spec-test-runner/test/spec/sanity/blocks/sanity_blocks_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/sanity/blocks/sanity_blocks_fast.test.ts
@@ -8,6 +8,7 @@ import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-tes
 import {IBlockSanityTestCase} from "./type";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
+import {BeaconState} from "@chainsafe/lodestar-types/phase0";
 
 describeDirectorySpecTest<IBlockSanityTestCase, phase0.BeaconState>(
   "block sanity mainnet",
@@ -52,7 +53,7 @@ describeDirectorySpecTest<IBlockSanityTestCase, phase0.BeaconState>(
       return !testCase.post;
     },
     timeout: 10000000,
-    getExpected: (testCase) => testCase.post,
+    getExpected: (testCase) => testCase.post as BeaconState,
     expectFunc: (testCase, expected, actual) => {
       expect(config.types.phase0.BeaconState.equals(actual, expected)).to.be.true;
     },
@@ -63,7 +64,7 @@ function generateBlocksSZZTypeMapping(
   n: number,
   config: IBeaconConfig
 ): Record<string, typeof config.types.phase0.SignedBeaconBlock> {
-  const blocksMapping: any = {};
+  const blocksMapping: Record<string, typeof config.types.phase0.SignedBeaconBlock> = {};
   for (let i = 0; i < n; i++) {
     blocksMapping[`blocks_${i}`] = config.types.phase0.SignedBeaconBlock;
   }

--- a/packages/spec-test-runner/test/spec/sanity/blocks/sanity_blocks_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/sanity/blocks/sanity_blocks_mainnet.test.ts
@@ -6,12 +6,13 @@ import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-tes
 import {IBlockSanityTestCase} from "./type";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
+import {BeaconState} from "@chainsafe/lodestar-types/phase0";
 
 describeDirectorySpecTest<IBlockSanityTestCase, phase0.BeaconState>(
   "block sanity mainnet",
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/sanity/blocks/pyspec_tests"),
   (testcase) => {
-    let state = testcase.pre;
+    let state = testcase.pre as BeaconState;
     const verify = !!testcase.meta && !!testcase.meta.blsSetting && testcase.meta.blsSetting === BigInt(1);
     for (let i = 0; i < Number(testcase.meta.blocksCount); i++) {
       state = phase0.stateTransition(config, state, testcase[`blocks_${i}`] as phase0.SignedBeaconBlock, {
@@ -35,7 +36,7 @@ describeDirectorySpecTest<IBlockSanityTestCase, phase0.BeaconState>(
       return !testCase.post;
     },
     timeout: 10000000,
-    getExpected: (testCase) => testCase.post,
+    getExpected: (testCase) => testCase.post as BeaconState,
     expectFunc: (testCase, expected, actual) => {
       expect(config.types.phase0.BeaconState.equals(actual, expected)).to.be.true;
     },
@@ -46,7 +47,7 @@ function generateBlocksSZZTypeMapping(
   n: number,
   config: IBeaconConfig
 ): Record<string, typeof config.types.phase0.SignedBeaconBlock> {
-  const blocksMapping: any = {};
+  const blocksMapping: Record<string, typeof config.types.phase0.SignedBeaconBlock> = {};
   for (let i = 0; i < n; i++) {
     blocksMapping[`blocks_${i}`] = config.types.phase0.SignedBeaconBlock;
   }

--- a/packages/spec-test-runner/test/spec/sanity/blocks/sanity_blocks_minimal.test.ts
+++ b/packages/spec-test-runner/test/spec/sanity/blocks/sanity_blocks_minimal.test.ts
@@ -6,12 +6,13 @@ import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-tes
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBlockSanityTestCase} from "./type";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
+import {BeaconState} from "@chainsafe/lodestar-types/phase0";
 
 describeDirectorySpecTest<IBlockSanityTestCase, phase0.BeaconState>(
   "block sanity minimal",
   join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/sanity/blocks/pyspec_tests"),
   (testcase) => {
-    let state = testcase.pre;
+    let state = testcase.pre as BeaconState;
     const verify = !!testcase.meta && !!testcase.meta.blsSetting && testcase.meta.blsSetting === BigInt(1);
     for (let i = 0; i < Number(testcase.meta.blocksCount); i++) {
       state = phase0.stateTransition(config, state, testcase[`blocks_${i}`] as phase0.SignedBeaconBlock, {
@@ -35,7 +36,7 @@ describeDirectorySpecTest<IBlockSanityTestCase, phase0.BeaconState>(
       return !testCase.post;
     },
     timeout: 60000,
-    getExpected: (testCase) => testCase.post,
+    getExpected: (testCase) => testCase.post as BeaconState,
     expectFunc: (testCase, expected, actual) => {
       expect(config.types.phase0.BeaconState.equals(actual, expected)).to.be.true;
     },
@@ -46,7 +47,7 @@ function generateBlocksSZZTypeMapping(
   n: number,
   config: IBeaconConfig
 ): Record<string, typeof config.types.phase0.SignedBeaconBlock> {
-  const blocksMapping: any = {};
+  const blocksMapping: Record<string, typeof config.types.phase0.SignedBeaconBlock> = {};
   for (let i = 0; i < n; i++) {
     blocksMapping[`blocks_${i}`] = config.types.phase0.SignedBeaconBlock;
   }

--- a/packages/spec-test-runner/test/spec/sanity/slots/sanity_slots_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/sanity/slots/sanity_slots_fast.test.ts
@@ -7,6 +7,7 @@ import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util";
 import {IProcessSlotsTestCase} from "./type";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
+import {BeaconState} from "@chainsafe/lodestar-types/phase0";
 
 describeDirectorySpecTest<IProcessSlotsTestCase, phase0.BeaconState>(
   "slot sanity mainnet",
@@ -41,7 +42,7 @@ describeDirectorySpecTest<IProcessSlotsTestCase, phase0.BeaconState>(
       return !testCase.post;
     },
     timeout: 10000000,
-    getExpected: (testCase) => testCase.post,
+    getExpected: (testCase) => testCase.post as BeaconState,
     expectFunc: (testCase, expected, actual) => {
       expect(config.types.phase0.BeaconState.equals(actual, expected)).to.be.true;
     },

--- a/packages/spec-test-runner/test/spec/sanity/slots/sanity_slots_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/sanity/slots/sanity_slots_mainnet.test.ts
@@ -5,12 +5,13 @@ import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util";
 import {IProcessSlotsTestCase} from "./type";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
+import {BeaconState} from "@chainsafe/lodestar-types/phase0";
 
 describeDirectorySpecTest<IProcessSlotsTestCase, phase0.BeaconState>(
   "slot sanity mainnet",
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/sanity/slots/pyspec_tests"),
   (testcase) => {
-    const state = testcase.pre;
+    const state = testcase.pre as BeaconState;
     phase0.processSlots(config, state, state.slot + Number(testcase.slots));
     return state;
   },
@@ -28,7 +29,7 @@ describeDirectorySpecTest<IProcessSlotsTestCase, phase0.BeaconState>(
       return !testCase.post;
     },
     timeout: 10000000,
-    getExpected: (testCase) => testCase.post,
+    getExpected: (testCase) => testCase.post as BeaconState,
     expectFunc: (testCase, expected, actual) => {
       expect(config.types.phase0.BeaconState.equals(actual, expected)).to.be.true;
     },

--- a/packages/spec-test-runner/test/spec/sanity/slots/sanity_slots_minimal.test.ts
+++ b/packages/spec-test-runner/test/spec/sanity/slots/sanity_slots_minimal.test.ts
@@ -5,12 +5,13 @@ import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util";
 import {IProcessSlotsTestCase} from "./type";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
+import {BeaconState} from "@chainsafe/lodestar-types/phase0";
 
 describeDirectorySpecTest<IProcessSlotsTestCase, phase0.BeaconState>(
   "slot sanity minimal",
   join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/sanity/slots/pyspec_tests"),
   (testcase) => {
-    const state = testcase.pre;
+    const state = testcase.pre as BeaconState;
     phase0.processSlots(config, state, state.slot + Number(testcase.slots));
     return state;
   },
@@ -28,7 +29,7 @@ describeDirectorySpecTest<IProcessSlotsTestCase, phase0.BeaconState>(
       return !testCase.post;
     },
     timeout: 10000000,
-    getExpected: (testCase) => testCase.post,
+    getExpected: (testCase) => testCase.post as BeaconState,
     expectFunc: (testCase, expected, actual) => {
       expect(config.types.phase0.BeaconState.equals(actual, expected)).to.be.true;
     },

--- a/packages/spec-test-runner/test/spec/ssz/util/testCases.ts
+++ b/packages/spec-test-runner/test/spec/ssz/util/testCases.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import {describeDirectorySpecTest, InputType, safeType} from "@chainsafe/lodestar-spec-test-util";
 import {Bytes32, IBeaconSSZTypes} from "@chainsafe/lodestar-types";
 import {join} from "path";

--- a/packages/spec-test-runner/test/spec/ssz/util/testCases.ts
+++ b/packages/spec-test-runner/test/spec/ssz/util/testCases.ts
@@ -1,6 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 import {describeDirectorySpecTest, InputType, safeType} from "@chainsafe/lodestar-spec-test-util";
 import {Bytes32, IBeaconSSZTypes} from "@chainsafe/lodestar-types";
 import {join} from "path";


### PR DESCRIPTION
Eslint v7 has 4 new rules very useful to guard against using `any` types inadvertently.

- Disallows assigning any to variables and properties ([no-unsafe-assignment](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unsafe-assignment.md))
- Disallows calling an any type value ([no-unsafe-call](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unsafe-call.md))
- Disallows member access on any typed variables ([no-unsafe-member-access](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unsafe-member-access.md))
- Disallows returning any from a function ([no-unsafe-return](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unsafe-return.md))

The purpose of this PR is gauge interest by Lodestar maintainers before actually working on the issues they raise. I've counted 800 lint errors of no-unsafe-* rules, mostly in tests accessing un-typed stubs


3xtr4t3rr3str14l EDIT: added in the changes required by these rules being applied.