### PR TITLE
Sync.start() should resolve quickly

### DIFF
--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -193,11 +193,7 @@ export class BeaconNode {
     });
 
     await network.start();
-
-    // TODO: refactor the sync module to respect the "start should resolve quickly" interface
-    // Now if sync.start() is awaited it will stall the node start process
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    sync.start();
+    await sync.start();
     chores.start();
 
     void runNodeNotifier({network, chain, sync, config, logger, signal});
@@ -225,7 +221,7 @@ export class BeaconNode {
     if (this.status === BeaconNodeStatus.started) {
       this.status = BeaconNodeStatus.closing;
       await this.chores.stop();
-      await (this.sync as BeaconSync).stop();
+      await this.sync.stop();
       await this.network.stop();
       if (this.metricsServer) await this.metricsServer.stop();
       if (this.restApi) await this.restApi.close();

--- a/packages/lodestar/src/sync/reqResp/interface.ts
+++ b/packages/lodestar/src/sync/reqResp/interface.ts
@@ -7,6 +7,6 @@
  * fetching state from the chain and database as needed.
  */
 export interface IReqRespHandler {
-  start: () => Promise<void>;
+  start: () => void;
   stop: () => Promise<void>;
 }

--- a/packages/lodestar/src/sync/reqResp/reqResp.ts
+++ b/packages/lodestar/src/sync/reqResp/reqResp.ts
@@ -70,11 +70,13 @@ export class BeaconReqRespHandler implements IReqRespHandler {
     this.logger = logger;
   }
 
-  async start(): Promise<void> {
+  start(): void {
     this.network.reqResp.registerHandler(this.onRequest.bind(this));
     this.network.on(NetworkEvent.peerConnect, this.handshake);
     const myStatus = this.chain.getStatus();
-    await syncPeersStatus(this.network, myStatus);
+    syncPeersStatus(this.network, myStatus).catch((e) => {
+      this.logger.error("Error syncing peer statuses", {}, e);
+    });
   }
 
   async stop(): Promise<void> {

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -54,7 +54,7 @@ export class BeaconSync implements IBeaconSync {
 
   async start(): Promise<void> {
     this.mode = SyncMode.WAITING_PEERS as SyncMode;
-    await this.reqResp.start();
+    this.reqResp.start();
     this.attestationCollector.start();
     if (this.mode === SyncMode.STOPPED) {
       return;
@@ -79,11 +79,16 @@ export class BeaconSync implements IBeaconSync {
       this.controller.signal
     );
 
-    await initialSync.sync();
-
-    // Reset state cache size after initial sync
-    this.chain.stateCache.maxStates = maxStates;
-    this.startRegularSync();
+    initialSync
+      .sync()
+      .then(() => {
+        // Reset state cache size after initial sync
+        this.chain.stateCache.maxStates = maxStates;
+        this.startRegularSync();
+      })
+      .catch((e) => {
+        this.logger.error("Error on initial sync", {}, e);
+      });
   }
 
   async stop(): Promise<void> {

--- a/packages/lodestar/test/unit/sync/reqResp.test.ts
+++ b/packages/lodestar/test/unit/sync/reqResp.test.ts
@@ -68,7 +68,7 @@ describe("sync req resp", function () {
     networkStub.hasPeer.returns(true);
     networkStub.getPeers.returns([generatePeer(peerId), generatePeer(peerId)]);
 
-    await syncRpc.start();
+    syncRpc.start();
     await syncRpc.stop();
   });
 


### PR DESCRIPTION
There's no need for start to await initial sync. The start method is not awaited by its caller and it doesn't even await for the entire sync. With this change we can finally close https://github.com/ChainSafe/lodestar/issues/1196

Resolves https://github.com/ChainSafe/lodestar/issues/1196