### PR TITLE
Log hygiene - info level

### DIFF
--- a/packages/lodestar-validator/src/services/attestation.ts
+++ b/packages/lodestar-validator/src/services/attestation.ts
@@ -167,7 +167,7 @@ export class AttestationService {
     // TODO: is this how we should handle a non-matching validator?
     if (!validator) return;
 
-    this.logger.info("Handling attestation duty", {
+    this.logger.debug("Handling attestation duty", {
       slot: duty.slot,
       committee: duty.committeeIndex,
       validator: toHexString(duty.pubkey),
@@ -215,7 +215,7 @@ export class AttestationService {
     }
     try {
       await this.provider.beacon.pool.submitAttestation(attestation);
-      this.logger.info("Published new attestation", {
+      this.logger.info("Published attestation", {
         slot: attestation.data.slot,
         committee: attestation.data.index,
         attestation: toHexString(this.config.types.phase0.Attestation.hashTreeRoot(attestation)),
@@ -270,7 +270,7 @@ export class AttestationService {
     genesisValidatorsRoot: Root,
     validator: ValidatorAndSecret
   ): Promise<void> => {
-    this.logger.info("Aggregating attestations", {committeeIndex: duty.committeeIndex, slot: duty.slot});
+    this.logger.verbose("Aggregating attestations", {committeeIndex: duty.committeeIndex, slot: duty.slot});
     let aggregate: phase0.Attestation;
     try {
       aggregate = await this.provider.validator.getAggregatedAttestation(
@@ -293,7 +293,7 @@ export class AttestationService {
     };
     try {
       await this.provider.validator.publishAggregateAndProofs([signedAggregateAndProof]);
-      this.logger.info("Published signed aggregate and proof", {committeeIndex: duty.committeeIndex, slot: duty.slot});
+      this.logger.info("Published aggregateAndProof", {committeeIndex: duty.committeeIndex, slot: duty.slot});
     } catch (e) {
       this.logger.error(
         "Failed to publish aggregate and proof",
@@ -380,7 +380,7 @@ export class AttestationService {
       data: attestationData,
       signature: validator.secretKey.sign(signingRoot).toBytes(),
     };
-    this.logger.info("Signed new attestation", {
+    this.logger.verbose("Signed new attestation", {
       block: toHexString(attestation.data.target.root),
       committeeIndex,
       slot,

--- a/packages/lodestar-validator/src/services/block.ts
+++ b/packages/lodestar-validator/src/services/block.ts
@@ -79,7 +79,7 @@ export default class BlockProposingService {
     const proposerPubKey = this.nextProposals.get(slot);
     if (proposerPubKey && slot !== 0) {
       this.nextProposals.delete(slot);
-      this.logger.info("Validator is proposer!", {
+      this.logger.verbose("Validator is proposer!", {
         slot,
         validator: toHexString(proposerPubKey),
       });
@@ -109,7 +109,7 @@ export default class BlockProposingService {
    * Fetch validator block proposal duties from the validator api and update local list of block duties accordingly.
    */
   updateDuties = async (epoch: Epoch): Promise<void> => {
-    this.logger.info("on new block epoch", {epoch, validator: toHexString(this.validators.keys().next().value)});
+    this.logger.debug("on new block epoch", {epoch, validator: toHexString(this.validators.keys().next().value)});
     const proposerDuties = await this.provider.validator.getProposerDuties(epoch, []).catch((e) => {
       this.logger.error("Failed to obtain proposer duties", e);
       return null;
@@ -174,7 +174,7 @@ export default class BlockProposingService {
     };
     try {
       await this.provider.beacon.blocks.publishBlock(signedBlock);
-      this.logger.info("Proposed block", {
+      this.logger.info("Published block", {
         hash: toHexString(this.config.types.phase0.BeaconBlock.hashTreeRoot(block)),
         slot,
       });

--- a/packages/lodestar-validator/src/validator.ts
+++ b/packages/lodestar-validator/src/validator.ts
@@ -50,7 +50,7 @@ export class Validator {
    */
   async start(): Promise<void> {
     await this.setup();
-    this.logger.info("Checking if chain has started...");
+    this.logger.info("Waiting for chain start...");
     this.apiClient.once("beaconChainStarted", this.run);
   }
 
@@ -59,7 +59,7 @@ export class Validator {
    * Should only be called once the beacon chain has been started.
    */
   run = async (): Promise<void> => {
-    this.logger.info("Chain start has occured!");
+    this.logger.info("Chain has started");
     if (!this.blockService) throw Error("blockService not setup");
     if (!this.attestationService) throw Error("attestationService not setup");
     // Run both services at once to prevent missing first attestation
@@ -118,9 +118,8 @@ export class Validator {
     };
 
     try {
-      this.logger.info(`Waiting for voluntary exit request for validator ${publicKey} to be submitted...`);
       await this.apiClient.beacon.pool.submitVoluntaryExit(signedVoluntaryExit);
-      this.logger.info("Submitted voluntary exit to the network.");
+      this.logger.info(`Submitted voluntary exit for ${publicKey} to the network`);
     } finally {
       await this.apiClient.disconnect();
     }
@@ -140,7 +139,6 @@ export class Validator {
    * Creates a new block processing service and attestation service.
    */
   private async setup(): Promise<void> {
-    this.logger.info("Setting up validator client...");
     await this.setupAPI();
     const validators = mapSecretKeysToValidators(this.opts.secretKeys);
 
@@ -166,7 +164,6 @@ export class Validator {
    * Establishes a connection to a specified beacon chain url.
    */
   private async setupAPI(): Promise<void> {
-    this.logger.info("RPC connection setting up");
     await this.apiClient.connect();
     this.logger.info("RPC connection successfully established", {url: this.apiClient.url});
   }

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -321,7 +321,7 @@ export class Eth2Gossipsub extends Gossipsub {
         }
       }
     }
-    this.logger.info("Current gossip subscriptions", {
+    this.logger.verbose("Current gossip subscriptions", {
       subscriptions: Array.from(this.subscriptions),
     });
   };


### PR DESCRIPTION
- Beacon node: Move gossip subscription log to verbose so the only periodic info log is the periodic notifier https://github.com/ChainSafe/lodestar/blob/master/packages/lodestar/src/node/notifier.ts
- Validator: Log only once per successful published block, aggregate and attestation. Move other logs to verbose
- Genesis: Log once every 30s instead of spam

Fixes https://github.com/ChainSafe/lodestar/issues/2078