### PR TITLE
Remove version restrictions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.13-alpine as build
+FROM node:14-alpine as build
 WORKDIR /usr/app
 RUN apk update && apk add --no-cache git g++ make python && rm -rf /var/cache/apk/*
 
@@ -13,7 +13,7 @@ RUN node ./scripts/getGitData /usr/app/.git-data.json
 
 # Copy built src + node_modules to a new layer to prune unnecessary fs
 # Previous layer weights 7.25GB, while this final 488MB (as of Oct 2020)
-FROM node:12.13-alpine
+FROM node:14-alpine
 WORKDIR /usr/app
 COPY --from=build /usr/app .
 ENV DOCKER_LODESTAR_GIT_DATA_FILEPATH /usr/app/.git-data.json

--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "root",
   "private": true,
-  "engines": {
-    "node": ">=12.9.0 <13"
-  },
   "workspaces": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "root",
   "private": true,
+  "engines": {
+    "node": ">=12.9.0"
+  },
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
Lodestar seems compatible with newer version of NodeJS. Versions lower to v12 are currently blocked by libp2p requirements. Should we keep the restriction for lower versions anyway?

Fixes https://github.com/ChainSafe/lodestar/issues/1370
