### PR TITLE
Gossip validation - log error metadata instead on logContext

### DIFF
--- a/packages/lodestar/src/chain/blocks/validate.ts
+++ b/packages/lodestar/src/chain/blocks/validate.ts
@@ -30,6 +30,7 @@ export function validateBlock({
     if (!job.reprocess && forkChoice.hasBlock(blockHash)) {
       throw new BlockError({
         code: BlockErrorCode.BLOCK_IS_ALREADY_KNOWN,
+        root: blockHash,
         job,
       });
     }

--- a/packages/lodestar/src/chain/errors/blockError.ts
+++ b/packages/lodestar/src/chain/errors/blockError.ts
@@ -90,7 +90,7 @@ export type BlockErrorType =
   | {code: BlockErrorCode.STATE_ROOT_MISMATCH}
   | {code: BlockErrorCode.GENESIS_BLOCK}
   | {code: BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT; blockSlot: Slot; finalizedSlot: Slot}
-  | {code: BlockErrorCode.BLOCK_IS_ALREADY_KNOWN}
+  | {code: BlockErrorCode.BLOCK_IS_ALREADY_KNOWN; root: Root}
   | {code: BlockErrorCode.REPEAT_PROPOSAL; proposer: ValidatorIndex}
   | {code: BlockErrorCode.BLOCK_SLOT_LIMIT_REACHED}
   | {code: BlockErrorCode.INCORRECT_PROPOSER; blockProposer: ValidatorIndex}


### PR DESCRIPTION
Follow up of https://github.com/ChainSafe/lodestar/pull/2199

Logging so much data about the incoming attestations and aggregates is not actionable. As a consumer of logs the most useful information is the error itself, with its attached metadata. For example for `FUTURE_SLOT` you'll get 
```
attestationSlot: Slot; latestPermissibleSlot: Slot;
```
which is more actionable that the hashTreeRoot of the aggregate. Also, computing the hashTreeRoot of attestations and aggregates is a non-trivial task that currently is done always, even when running in "production" mode, with logLevel >= info.

This PR changes from logging the entire error to only the `type` metadata, ommitting the unnecessary stack trace