### PR TITLE
Allow to regen states in API debug states

### DIFF
--- a/packages/lodestar/src/api/impl/debug/beacon/index.ts
+++ b/packages/lodestar/src/api/impl/debug/beacon/index.ts
@@ -5,7 +5,7 @@ import {IBeaconChain} from "../../../../chain";
 import {IBeaconDb} from "../../../../db";
 import {IApiOptions} from "../../../options";
 import {StateId} from "../../beacon/state";
-import {resolveStateId} from "../../beacon/state/utils";
+import {RegenType, resolveStateId} from "../../beacon/state/utils";
 import {IApiModules} from "../../interface";
 import {IDebugBeaconApi} from "./interface";
 
@@ -35,7 +35,7 @@ export class DebugBeaconApi implements IDebugBeaconApi {
 
   async getState(stateId: StateId): Promise<phase0.BeaconState | null> {
     try {
-      return await resolveStateId(this.chain, this.db, stateId);
+      return await resolveStateId(this.chain, this.db, stateId, RegenType.AllowRegen);
     } catch (e) {
       this.logger.error("Failed to resolve state", {state: stateId, error: e});
       throw e;


### PR DESCRIPTION
**Motivation**

We need to serve old states for Weak Subjectivity see https://github.com/ChainSafe/lodestar/issues/2177

**Description**

Only for the debug states endpoint, uses the chain.regen module to fetch states.
Closes https://github.com/ChainSafe/lodestar/issues/2177

**Steps to test or reproduce**

I have not tested any code path
