### PR TITLE
Remove validator only env

### DIFF
--- a/default.env
+++ b/default.env
@@ -1,6 +1,3 @@
 # To specify a specific network (defaults to mainnet) set this value.
 # Allowed values are: mainnet and pyrmont (others may work, but are deprecated)
 LODESTAR_NETWORK=mainnet
-
-# Add an arbitrary string to the proposing block
-LODESTAR_GRAFFITI=lodestar wuz here


### PR DESCRIPTION
yargs strict options do not allow to share ENVs between the beacon node and the validator. The GRAFFITI ENV prevent the beacon node from running at all. 

This is unfortunate and a better solution should be found eventually.

