### PR TITLE
Cleaner validator info logs

### DIFF
--- a/packages/lodestar-utils/src/format.ts
+++ b/packages/lodestar-utils/src/format.ts
@@ -1,0 +1,9 @@
+import {ByteVector, toHexString} from "@chainsafe/ssz";
+
+/**
+ * Format bytes as `0x1234…1234`
+ */
+export function prettyBytes(root: Uint8Array | ByteVector): string {
+  const str = toHexString(root);
+  return `${str.slice(0, 6)}…${str.slice(-4)}`;
+}

--- a/packages/lodestar-utils/src/index.ts
+++ b/packages/lodestar-utils/src/index.ts
@@ -4,6 +4,7 @@ export * from "./yaml";
 export * from "./assert";
 export * from "./bytes";
 export * from "./errors";
+export * from "./format";
 export * from "./math";
 export * from "./objects";
 export * from "./notNullish";

--- a/packages/lodestar-validator/src/services/attestation.ts
+++ b/packages/lodestar-validator/src/services/attestation.ts
@@ -4,7 +4,7 @@
 import {computeEpochAtSlot, computeSigningRoot, getDomain} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {BLSSignature, Epoch, Root, phase0, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
-import {ILogger} from "@chainsafe/lodestar-utils";
+import {ILogger, prettyBytes} from "@chainsafe/lodestar-utils";
 import {fromHexString, List, toHexString} from "@chainsafe/ssz";
 import {AbortController, AbortSignal} from "abort-controller";
 import {IApiClient} from "../api";
@@ -215,13 +215,7 @@ export class AttestationService {
     }
     try {
       await this.provider.beacon.pool.submitAttestation(attestation);
-      this.logger.info("Published attestation", {
-        slot: attestation.data.slot,
-        committee: attestation.data.index,
-        attestation: toHexString(this.config.types.phase0.Attestation.hashTreeRoot(attestation)),
-        block: toHexString(attestation.data.target.root),
-        validator: toHexString(duty.pubkey),
-      });
+      this.logger.info("Published attestation", {slot: attestation.data.slot, validator: prettyBytes(duty.pubkey)});
     } catch (e) {
       this.logger.error("Failed to publish attestation", e);
     }
@@ -293,7 +287,7 @@ export class AttestationService {
     };
     try {
       await this.provider.validator.publishAggregateAndProofs([signedAggregateAndProof]);
-      this.logger.info("Published aggregateAndProof", {committeeIndex: duty.committeeIndex, slot: duty.slot});
+      this.logger.info("Published aggregateAndProof", {slot: duty.slot, validator: prettyBytes(duty.pubkey)});
     } catch (e) {
       this.logger.error(
         "Failed to publish aggregate and proof",

--- a/packages/lodestar-validator/src/services/block.ts
+++ b/packages/lodestar-validator/src/services/block.ts
@@ -5,7 +5,7 @@
 import {BLSPubkey, Epoch, Root, phase0, Slot} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {SecretKey} from "@chainsafe/bls";
-import {ILogger} from "@chainsafe/lodestar-utils";
+import {ILogger, prettyBytes} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
 import {computeEpochAtSlot, computeSigningRoot, getDomain} from "@chainsafe/lodestar-beacon-state-transition";
 import {IApiClient} from "../api";
@@ -174,10 +174,7 @@ export default class BlockProposingService {
     };
     try {
       await this.provider.beacon.blocks.publishBlock(signedBlock);
-      this.logger.info("Published block", {
-        hash: toHexString(this.config.types.phase0.BeaconBlock.hashTreeRoot(block)),
-        slot,
-      });
+      this.logger.info("Published block", {slot, validator: prettyBytes(validatorKeys.publicKey)});
     } catch (e) {
       this.logger.error("Failed to publish block", {slot}, e);
     }

--- a/packages/lodestar/src/node/notifier.ts
+++ b/packages/lodestar/src/node/notifier.ts
@@ -1,7 +1,5 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {Root} from "@chainsafe/lodestar-types";
-import {ErrorAborted, ILogger, sleep} from "@chainsafe/lodestar-utils";
-import {toHexString} from "@chainsafe/ssz";
+import {ErrorAborted, ILogger, sleep, prettyBytes} from "@chainsafe/lodestar-utils";
 import {AbortSignal} from "abort-controller";
 import {IBeaconChain} from "../chain";
 import {INetwork} from "../network";
@@ -55,8 +53,8 @@ export async function runNodeNotifier({
       timeSeries.addPoint(headSlot, Date.now());
 
       const peersRow = `peers: ${connectedPeerCount}`;
-      const finalizedCheckpointRow = `finalized: ${finalizedEpoch} ${prettyRoot(finalizedRoot)}`;
-      const headRow = `head: ${headInfo.slot} ${prettyRoot(headInfo.blockRoot)}`;
+      const finalizedCheckpointRow = `finalized: ${finalizedEpoch} ${prettyBytes(finalizedRoot)}`;
+      const headRow = `head: ${headInfo.slot} ${prettyBytes(headInfo.blockRoot)}`;
       const currentSlotRow = `currentSlot: ${currentSlot}`;
 
       let nodeState: string[] = [];
@@ -108,9 +106,4 @@ function timeToNextHalfSlot(config: IBeaconConfig, chain: IBeaconChain): number 
   const msFromGenesis = Date.now() - chain.getGenesisTime() * 1000;
   const msToNextSlot = msPerSlot - (msFromGenesis % msPerSlot);
   return msToNextSlot > msPerSlot / 2 ? msToNextSlot - msPerSlot / 2 : msToNextSlot + msPerSlot / 2;
-}
-
-function prettyRoot(root: Root): string {
-  const str = toHexString(root);
-  return `${str.slice(0, 6)}…${str.slice(-4)}`;
 }


### PR DESCRIPTION
Instead of logging full hashes of what's being signed, log only the slot and who is signing it with prettyBytes. Lighthouse does not log hashes on the validator client.

Should we log more info about what's being signed at the debug or verbose level?