### PR TITLE
num to bytes and bytes to num for safe ints, defaults to bigint for u…

### DIFF
--- a/packages/lodestar-utils/src/buf64copy.ts
+++ b/packages/lodestar-utils/src/buf64copy.ts
@@ -1,0 +1,178 @@
+export function copyFromBuf64LE(sbuffer: Buffer, tbuffer: Buffer, length: number): void {
+  //unrolled fast copy
+  switch (length) {
+    case 8:
+      tbuffer[7] = sbuffer[7];
+    /* falls through */
+    case 7:
+      tbuffer[6] = sbuffer[6];
+    /* falls through */
+    case 6:
+      tbuffer[5] = sbuffer[5];
+    /* falls through */
+    case 5:
+      tbuffer[4] = sbuffer[4];
+    /* falls through */
+    case 4:
+      tbuffer[3] = sbuffer[3];
+    /* falls through */
+    case 3:
+      tbuffer[2] = sbuffer[2];
+    /* falls through */
+    case 2:
+      tbuffer[1] = sbuffer[1];
+    /* falls through */
+    case 1:
+      tbuffer[0] = sbuffer[0];
+      break;
+    default:
+  }
+}
+
+export function copyFromBuf64BE(sbuffer: Buffer, tbuffer: Buffer, length: number): void {
+  switch (
+    length //we need to unroll it for fast computation, buffer copy/looping takes too much time
+  ) {
+    case 8:
+      tbuffer[0] = sbuffer[0]; //length is 8 here
+    /* falls through */
+    case 7:
+      tbuffer[length - 7] = sbuffer[1];
+    /* falls through */
+    case 6:
+      tbuffer[length - 6] = sbuffer[2];
+    /* falls through */
+    case 5:
+      tbuffer[length - 5] = sbuffer[3];
+    /* falls through */
+    case 4:
+      tbuffer[length - 4] = sbuffer[4];
+    /* falls through */
+    case 3:
+      tbuffer[length - 3] = sbuffer[5];
+    /* falls through */
+    case 2:
+      tbuffer[length - 2] = sbuffer[6];
+    /* falls through */
+    case 1:
+      tbuffer[length - 1] = sbuffer[7];
+      break;
+    default:
+  }
+}
+
+export function copyToBuf64LE(sbuffer: Uint8Array, tbuffer: Buffer, length: number): void {
+  switch (
+    length //we need to unroll it for fast computation, buffer copy/looping takes too much time
+  ) {
+    case 8:
+      tbuffer[7] = sbuffer[7];
+    /* falls through */
+    case 7:
+      tbuffer[6] = sbuffer[6];
+    /* falls through */
+    case 6:
+      tbuffer[5] = sbuffer[5];
+    /* falls through */
+    case 5:
+      tbuffer[4] = sbuffer[4];
+    /* falls through */
+    case 4:
+      tbuffer[3] = sbuffer[3];
+    /* falls through */
+    case 3:
+      tbuffer[2] = sbuffer[2];
+    /* falls through */
+    case 2:
+      tbuffer[1] = sbuffer[1];
+    /* falls through */
+    case 1:
+      tbuffer[0] = sbuffer[0];
+      break;
+    default:
+  }
+  switch (
+    length //zero the rest
+  ) {
+    case 1:
+      tbuffer[1] = 0;
+    /* falls through */
+    case 2:
+      tbuffer[2] = 0;
+    /* falls through */
+    case 3:
+      tbuffer[3] = 0;
+    /* falls through */
+    case 4:
+      tbuffer[4] = 0;
+    /* falls through */
+    case 5:
+      tbuffer[5] = 0;
+    /* falls through */
+    case 6:
+      tbuffer[6] = 0;
+    /* falls through */
+    case 7:
+      tbuffer[7] = 0;
+      break;
+    default:
+  }
+}
+
+export function copyToBuf64BE(sbuffer: Uint8Array, tbuffer: Buffer, length: number): void {
+  switch (
+    length //we need to unroll it for fast computation, buffer copy/looping takes too much time
+  ) {
+    case 8:
+      tbuffer[0] = sbuffer[0];
+    /* falls through */
+    case 7:
+      tbuffer[1] = sbuffer[length - 7];
+    /* falls through */
+    case 6:
+      tbuffer[2] = sbuffer[length - 6];
+    /* falls through */
+    case 5:
+      tbuffer[3] = sbuffer[length - 5];
+    /* falls through */
+    case 4:
+      tbuffer[4] = sbuffer[length - 4];
+    /* falls through */
+    case 3:
+      tbuffer[5] = sbuffer[length - 3];
+    /* falls through */
+    case 2:
+      tbuffer[6] = sbuffer[length - 2];
+    /* falls through */
+    case 1:
+      tbuffer[7] = sbuffer[length - 1];
+      break;
+    default:
+  }
+  switch (
+    length //zero the rest
+  ) {
+    case 1:
+      tbuffer[6] = 0;
+    /* falls through */
+    case 2:
+      tbuffer[5] = 0;
+    /* falls through */
+    case 3:
+      tbuffer[4] = 0;
+    /* falls through */
+    case 4:
+      tbuffer[3] = 0;
+    /* falls through */
+    case 5:
+      tbuffer[2] = 0;
+    /* falls through */
+    case 6:
+      tbuffer[1] = 0;
+    /* falls through */
+    case 7:
+      tbuffer[0] = 0;
+      break;
+    default:
+  }
+}

--- a/packages/lodestar-utils/src/bytes.ts
+++ b/packages/lodestar-utils/src/bytes.ts
@@ -6,14 +6,75 @@ type Endianness = "le" | "be";
  * Return a byte array from a number or BigInt
  */
 export function intToBytes(value: bigint | number, length: number, endianness: Endianness = "le"): Buffer {
-  return bigIntToBytes(BigInt(value), length, endianness);
+  switch(typeof value){
+    case "number":
+      return numberToBytes(value,length,endianness);
+    case "bigint":
+      return bigIntToBytes(value, length, endianness);
+      break;
+    default:
+      throw new Error(`unsupported number type ${typeof value}`);
+  }
 }
 
 /**
  * Convert byte array in LE to integer.
  */
+
+export function numberToBytes(value: number,length: number,endianness: Endianness = "le"): Buffer {
+  //length less than required will lead to truncation on the msb side, same as bigint inttobytes
+  if(value<0)value=-value;//bigint inttobytes always return the absolute value
+  if(value>Number.MAX_SAFE_INTEGER)return intToBytes(BigInt(value),length,endianness);
+  let buffer = new ArrayBuffer(Math.max(length,8));
+  let mvalue;
+  switch(endianness){
+    case "le":
+      new DataView(buffer).setInt32(0, value, true);
+      if(length>4){
+        mvalue= Math.floor(value/2**32);
+        new DataView(buffer).setInt32(4, mvalue, true);
+      }
+      if(buffer.byteLength > length)buffer=buffer.slice(0,length);
+      break;
+    case "be":
+      new DataView(buffer).setInt32(buffer.byteLength-4, value, false);
+      if(length>4){
+        mvalue= Math.floor(value/2**32);
+        new DataView(buffer).setInt32(buffer.byteLength-8, mvalue, false);
+      }
+      if(buffer.byteLength > length)buffer=buffer.slice(buffer.byteLength-length,buffer.byteLength);
+      break;
+    default:
+      throw new Error("endianness must be either 'le' or 'be'");
+  }
+  return Buffer.from(buffer);
+}
+
 export function bytesToInt(value: Uint8Array, endianness: Endianness = "le"): number {
-  return Number(bytesToBigInt(value, endianness));
+  let isbigint: any=false;
+  let buffer=new ArrayBuffer(8);
+  let left,right,view;
+  switch(endianness){
+    case "le":
+      if(value.length>6) isbigint=(value[6]>31)||value.slice(7,value.length).reduce((acc,vrow)=>(acc||(vrow>0)),false);
+      if(isbigint)return Number(bytesToBigInt(value, endianness));
+      Buffer.from(value).copy(Buffer.from(buffer),0,0,Math.min(value.length,8));
+      view = new DataView(buffer);
+      left =  view.getUint32(4, true);
+      right = view.getUint32(0, true);
+      break;
+    case "be":
+      if(value.length>6) isbigint=(value[value.length-7]>31)||value.slice(0,value.length-7).reduce((acc,vrow)=>(acc||(vrow>0)),false);
+      if(isbigint)return Number(bytesToBigInt(value, endianness));
+      Buffer.from(value).copy(Buffer.from(buffer),Math.max(0,8-value.length),Math.max(value.length-8,0),value.length);
+      view = new DataView(buffer);
+      left =  view.getUint32(0, false);
+      right = view.getUint32(4, false);
+      break;
+  }
+
+  const combined=2**32*left + right;
+  return combined;
 }
 
 export function bigIntToBytes(value: bigint, length: number, endianness: Endianness = "le"): Buffer {


### PR DESCRIPTION
…nsafe

**Motivation**

to provide native int to bytes and reverse implementation wherever possible instead of using bigint

**Description**
used javascript dataview for a number to extract bytes whenever number <= MAX_SAFE_INTEGER


Closes #2121

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
