### PR TITLE
[DNM] Demo retained BeaconStateContext instance 

### DIFF
--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -224,7 +224,7 @@ export class BeaconNode {
             logger.info("Error dialing discovered peer", {peer: peer.toB58String()}, e);
           });
         }
-        await sleep(30000);
+        await sleep(15000);
       }
     }, 1000);
 


### PR DESCRIPTION
This is to make it simpler to debug the retained BeaconStateContext in #2184
+ Write a simple `runStateTransition3()` which run state transition and store to db only
+ Query blocks of 2 epochs in your existing dir and reprocess them using the above function
+ Start peer manager only, (and ignore sync + chores + notifier)
+ Heap size reach to 2GB at around loop 100-150
+ Check the retained memory  with `BeaconStateContext` row (500MB in the screenshot)
<img width="1089" alt="Screen Shot 2021-03-24 at 11 12 17" src="https://user-images.githubusercontent.com/10568965/112253765-e54b5c80-8c91-11eb-9f1b-4bf15bae3512.png">


How to run:
+ `node --inspect lib/index.js beacon --network ${NETWORK} --root-dir ${YOUR_EXISING_DB}`