### PR TITLE
Remove libp2p-ts dependency

### DIFF
--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -3,6 +3,6 @@
   "include": ["src"],
   "compilerOptions": {
     "outDir": "lib",
-    "typeRoots": ["../../node_modules/@types", "../../node_modules/libp2p-ts/types", "./node_modules/@types"]
+    "typeRoots": ["../../node_modules/@types", "./node_modules/@types"]
   }
 }

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -3,6 +3,6 @@
   "include": ["src"],
   "compilerOptions": {
     "outDir": "lib",
-    "typeRoots": ["../../node_modules/@types", "./node_modules/@types"]
+    "typeRoots": ["../../node_modules/@types", "./node_modules/@types", "./types"]
   }
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "typeRoots": ["../../node_modules/@types", "./node_modules/@types"]
+    "typeRoots": ["../../node_modules/@types", "./node_modules/@types", "./types"]
   }
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "typeRoots": ["../../node_modules/@types", "../../node_modules/libp2p-ts/types", "./node_modules/@types"]
+    "typeRoots": ["../../node_modules/@types", "./node_modules/@types"]
   }
 }

--- a/packages/cli/types/libp2p-bootstrap/index.d.ts
+++ b/packages/cli/types/libp2p-bootstrap/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for libp2p-railing 0.9.1
+// Project: https://github.com/libp2p/js-libp2p-bootstrap
+// Definitions by: Jaco Greeff <https://github.com/jacogr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type PeerInfo = {
+  id: import("peer-id");
+  multiaddrs: import("multiaddr")[];
+};
+
+declare namespace LibP2pBootstrap {
+  type Options = {
+    list: Array<string | import("multiaddr")>,
+    interval?: number
+  };
+
+  type Events = 'peer';
+}
+
+declare class LibP2pBootstrap {
+  constructor (options: LibP2pBootstrap.Options);
+
+  on (event: LibP2pBootstrap.Events, cb: (peerInfo: PeerInfo) => any): this;
+}
+
+declare module 'libp2p-bootstrap' {
+export default LibP2pBootstrap;
+}

--- a/packages/cli/types/libp2p-bootstrap/tsconfig.json
+++ b/packages/cli/types/libp2p-bootstrap/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "libp2p-bootstrap-tests.ts"]
+}

--- a/packages/cli/types/libp2p-bootstrap/tslint.json
+++ b/packages/cli/types/libp2p-bootstrap/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/packages/cli/types/libp2p-mdns/index.d.ts
+++ b/packages/cli/types/libp2p-mdns/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for libp2p-mdns 0.12.0
+// Project: https://github.com/libp2p/js-libp2p-mdns
+// Definitions by: Jaco Greeff <https://github.com/jacogr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="libp2p-bootstrap"/>
+
+declare namespace LibP2pMdns {
+  type Options = {
+    broadcast?: boolean,
+    interval?: number,
+    peerInfo: PeerInfo,
+    port?: number,
+    serviceTag?: string
+  };
+
+  type Events = 'peer';
+}
+
+declare class LibP2pMdns extends LibP2pBootstrap {
+  constructor (options: LibP2pMdns.Options);
+
+  on (event: LibP2pMdns.Events, cb: (peerInfo: PeerInfo) => any): this;
+}
+
+declare module 'libp2p-mdns' {
+export default LibP2pMdns;
+}

--- a/packages/cli/types/libp2p-mdns/tsconfig.json
+++ b/packages/cli/types/libp2p-mdns/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "bn.js-tests.ts"]
+}

--- a/packages/cli/types/libp2p-mdns/tslint.json
+++ b/packages/cli/types/libp2p-mdns/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/packages/cli/types/time-cache/index.d.ts
+++ b/packages/cli/types/time-cache/index.d.ts
@@ -1,0 +1,8 @@
+declare class TimeCache {
+  put(data: string): void;
+  has(data: string): boolean;
+}
+
+declare module "time-cache" {
+  export default TimeCache;
+}

--- a/packages/light-client/tsconfig.build.json
+++ b/packages/light-client/tsconfig.build.json
@@ -3,6 +3,6 @@
   "include": ["src"],
   "compilerOptions": {
     "outDir": "lib",
-    "typeRoots": ["../../node_modules/@types", "../../node_modules/libp2p-ts/types", "./node_modules/@types"]
+    "typeRoots": ["../../node_modules/@types", "./node_modules/@types"]
   }
 }

--- a/packages/light-client/tsconfig.json
+++ b/packages/light-client/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "typeRoots": ["../../node_modules/@types", "../../node_modules/libp2p-ts/types", "./node_modules/@types"]
+    "typeRoots": ["../../node_modules/@types", "./node_modules/@types"]
   }
 }

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -106,7 +106,6 @@
     "@types/varint": "^5.0.0",
     "benchmark": "^2.1.4",
     "eventsource": "^1.0.7",
-    "libp2p-ts": "https://github.com/ChainSafe/libp2p-ts.git",
     "rewiremock": "^3.14.3",
     "rimraf": "^3.0.2",
     "tmp": "^0.2.1"

--- a/packages/lodestar/src/api/impl/node/utils.ts
+++ b/packages/lodestar/src/api/impl/node/utils.ts
@@ -1,10 +1,11 @@
+import {Connection} from "libp2p";
 import {PeerStatus, PeerState} from "../../../network";
 import {NodePeer} from "../../types";
 
 /**
  * Format a list of connections from libp2p connections manager into the API's format NodePeer
  */
-export function formatNodePeer(peerIdStr: string, connections: LibP2pConnection[]): NodePeer {
+export function formatNodePeer(peerIdStr: string, connections: Connection[]): NodePeer {
   const conn = getRevelantConnection(connections);
 
   return {
@@ -23,8 +24,8 @@ export function formatNodePeer(peerIdStr: string, connections: LibP2pConnection[
  * - Otherwise, the first closing connection
  * - Otherwise, the first closed connection
  */
-function getRevelantConnection(connections: LibP2pConnection[]): LibP2pConnection | null {
-  const byStatus = new Map<PeerStatus, LibP2pConnection>();
+function getRevelantConnection(connections: Connection[]): Connection | null {
+  const byStatus = new Map<PeerStatus, Connection>();
   for (const conn of connections) {
     if (conn.stat.status === "open") return conn;
     if (!byStatus.has(conn.stat.status)) byStatus.set(conn.stat.status, conn);

--- a/packages/lodestar/src/network/interface.ts
+++ b/packages/lodestar/src/network/interface.ts
@@ -1,6 +1,7 @@
 /**
  * @module network
  */
+import {Connection} from "libp2p";
 import {ENR} from "@chainsafe/discv5/lib";
 import Multiaddr from "multiaddr";
 import PeerId from "peer-id";
@@ -26,7 +27,7 @@ export interface INetwork {
   peerId: PeerId;
   localMultiaddrs: Multiaddr[];
   getEnr(): ENR | undefined;
-  getConnectionsByPeer(): Map<string, LibP2pConnection[]>;
+  getConnectionsByPeer(): Map<string, Connection[]>;
   getConnectedPeers(): PeerId[];
   /** Search peers joining subnets */
   requestAttSubnets(requestedSubnets: RequestedSubnet[]): void;
@@ -36,6 +37,6 @@ export interface INetwork {
   stop(): Promise<void>;
 }
 
-export type PeerDirection = LibP2pConnection["stat"]["direction"];
-export type PeerStatus = LibP2pConnection["stat"]["status"];
+export type PeerDirection = Connection["stat"]["direction"];
+export type PeerStatus = Connection["stat"]["status"];
 export type PeerState = "disconnected" | "connecting" | "connected" | "disconnecting";

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -2,7 +2,7 @@
  * @module network
  */
 
-import LibP2p from "libp2p";
+import LibP2p, {Connection} from "libp2p";
 import PeerId from "peer-id";
 import Multiaddr from "multiaddr";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
@@ -109,7 +109,7 @@ export class Network implements INetwork {
     return discv5Discovery?.discv5?.enr ?? undefined;
   }
 
-  getConnectionsByPeer(): Map<string, LibP2pConnection[]> {
+  getConnectionsByPeer(): Map<string, Connection[]> {
     return this.libp2p.connectionManager.connections;
   }
 

--- a/packages/lodestar/src/network/nodejs/bundle.ts
+++ b/packages/lodestar/src/network/nodejs/bundle.ts
@@ -62,6 +62,15 @@ export class NodejsNode extends LibP2p {
             enabled: false,
             active: false,
           },
+          advertise: {
+            enabled: false,
+            ttl: 0,
+            bootDelay: 0,
+          },
+          autoRelay: {
+            enabled: false,
+            maxListeners: 0,
+          },
         },
         peerDiscovery: {
           autoDial: false,

--- a/packages/lodestar/src/network/peers/discover.ts
+++ b/packages/lodestar/src/network/peers/discover.ts
@@ -1,3 +1,4 @@
+import LibP2p from "libp2p";
 import PeerId from "peer-id";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/src/network/peers/metastore.ts
+++ b/packages/lodestar/src/network/peers/metastore.ts
@@ -1,3 +1,4 @@
+import MetadataBook from "libp2p/src/peer-store/metadata-book";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import PeerId from "peer-id";
 import {phase0} from "@chainsafe/lodestar-types";
@@ -48,6 +49,8 @@ export class Libp2pPeerMetadataStore implements IPeerMetadataStore {
     return {
       set: (peer: PeerId, value: T): void => {
         if (value != null) {
+          // TODO: fix upstream type (which also contains @ts-ignore)
+          // @ts-ignore
           this.metabook.set(peer, key, Buffer.from(type.serialize(value)));
         } else {
           this.metabook.deleteValue(peer, key);

--- a/packages/lodestar/src/network/peers/peerManager.ts
+++ b/packages/lodestar/src/network/peers/peerManager.ts
@@ -1,3 +1,4 @@
+import LibP2p, {Connection} from "libp2p";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {phase0} from "@chainsafe/lodestar-types";
 import {ILogger, LodestarError} from "@chainsafe/lodestar-utils";
@@ -352,7 +353,7 @@ export class PeerManager {
    * Registers a peer as connected. The `direction` parameter determines if the peer is being
    * dialed or connecting to us.
    */
-  private onLibp2pPeerConnect = (libp2pConnection: LibP2pConnection): void => {
+  private onLibp2pPeerConnect = (libp2pConnection: Connection): void => {
     const {direction, status} = libp2pConnection.stat;
     const peer = libp2pConnection.remotePeer;
 
@@ -383,7 +384,7 @@ export class PeerManager {
   /**
    * The libp2p Upgrader has ended a connection
    */
-  private onLibp2pPeerDisconnect = (libp2pConnection: LibP2pConnection): void => {
+  private onLibp2pPeerDisconnect = (libp2pConnection: Connection): void => {
     const {direction, status} = libp2pConnection.stat;
     const peer = libp2pConnection.remotePeer;
 

--- a/packages/lodestar/src/network/peers/utils/getConnectedPeerIds.ts
+++ b/packages/lodestar/src/network/peers/utils/getConnectedPeerIds.ts
@@ -1,3 +1,4 @@
+import LibP2p from "libp2p";
 import PeerId from "peer-id";
 
 /**

--- a/packages/lodestar/src/network/reqresp/interface.ts
+++ b/packages/lodestar/src/network/reqresp/interface.ts
@@ -1,3 +1,4 @@
+import LibP2p from "libp2p";
 import PeerId from "peer-id";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {phase0} from "@chainsafe/lodestar-types";

--- a/packages/lodestar/src/network/reqresp/request/index.ts
+++ b/packages/lodestar/src/network/reqresp/request/index.ts
@@ -1,3 +1,4 @@
+import LibP2p, {Connection} from "libp2p";
 import {AbortSignal} from "abort-controller";
 import pipe from "it-pipe";
 import PeerId from "peer-id";
@@ -69,7 +70,7 @@ export async function sendRequest<T extends phase0.ResponseBody | phase0.Respons
     // DIAL_TIMEOUT: Non-spec timeout from dialing protocol until stream opened
     const stream = await withTimeout(
       async (timeoutAndParentSignal) => {
-        const conn = await libp2p.dialProtocol(peerId, protocol, {signal: timeoutAndParentSignal});
+        const conn = (await libp2p.dialProtocol(peerId, protocol, {signal: timeoutAndParentSignal})) as Connection;
         if (!conn) throw Error("dialProtocol timeout");
         // TODO: libp2p-ts type Stream does not declare .abort() and requires casting to unknown here
         // Remove when https://github.com/ChainSafe/lodestar/issues/2167

--- a/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
@@ -1,3 +1,4 @@
+import {Connection} from "libp2p";
 import {EventEmitter} from "events";
 import sinon from "sinon";
 import {expect} from "chai";
@@ -109,7 +110,7 @@ describe("network / peers / PeerManager", function () {
   const libp2pConnectionOutboud = {
     stat: {direction: "outbound", status: "open"},
     remotePeer: peerId1,
-  } as LibP2pConnection;
+  } as Connection;
 
   it("Should emit peer connected event on relevant peer status", async function () {
     const {chain, libp2p, networkEventBus} = await mockModules();

--- a/packages/lodestar/test/unit/api/impl/node/node.test.ts
+++ b/packages/lodestar/test/unit/api/impl/node/node.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
+import {Connection} from "libp2p";
 import {INodeApi} from "../../../../../src/api/impl/node";
 import {NodeApi} from "../../../../../src/api/impl/node/node";
 import sinon, {SinonStubbedInstance} from "sinon";
@@ -99,7 +100,7 @@ describe("node api implementation", function () {
     });
 
     it("should return connected and disconnecting peers", async function () {
-      const connectionsByPeer = new Map<string, LibP2pConnection[]>([
+      const connectionsByPeer = new Map<string, Connection[]>([
         [peer1.toB58String(), [libp2pConnection(peer1, "open", "outbound")]],
         [peer2.toB58String(), [libp2pConnection(peer2, "closing", "inbound")]],
       ]);
@@ -114,7 +115,7 @@ describe("node api implementation", function () {
     });
 
     it("should return disconnected peers", async function () {
-      const connectionsByPeer = new Map<string, LibP2pConnection[]>([
+      const connectionsByPeer = new Map<string, Connection[]>([
         [peer1.toB58String(), [libp2pConnection(peer1, "closed", "outbound")]],
         [peer2.toB58String(), []], // peer2 has no connections in the connection manager
       ]);
@@ -133,7 +134,7 @@ describe("node api implementation", function () {
     it("success", async function () {
       const peer1 = await createPeerId();
       const peer2 = await createPeerId();
-      const connectionsByPeer = new Map<string, LibP2pConnection[]>([
+      const connectionsByPeer = new Map<string, Connection[]>([
         [peer1.toB58String(), [libp2pConnection(peer1, "open", "outbound")]],
         [peer2.toB58String(), [libp2pConnection(peer2, "closing", "inbound")]],
       ]);
@@ -150,7 +151,7 @@ describe("node api implementation", function () {
     });
 
     it("peer not found", async function () {
-      const connectionsByPeer = new Map<string, LibP2pConnection[]>();
+      const connectionsByPeer = new Map<string, Connection[]>();
       networkStub.getConnectionsByPeer.returns(connectionsByPeer);
 
       const peer = await api.getPeer("not existent");
@@ -178,7 +179,7 @@ describe("node api implementation", function () {
   });
 });
 
-export function libp2pConnection(peer: PeerId, status: PeerStatus, direction: PeerDirection): LibP2pConnection {
+export function libp2pConnection(peer: PeerId, status: PeerStatus, direction: PeerDirection): Connection {
   return {
     remoteAddr: new Multiaddr(),
     stat: {
@@ -186,5 +187,5 @@ export function libp2pConnection(peer: PeerId, status: PeerStatus, direction: Pe
       direction,
     },
     remotePeer: peer,
-  } as LibP2pConnection;
+  } as Connection;
 }

--- a/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
+++ b/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
@@ -42,6 +42,7 @@ describe("[network] nodejs libp2p", () => {
     assert(nodeB.connectionManager.get(nodeA.peerId), "nodeB should have connection to nodeA");
 
     // disconnect
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     const p = new Promise((resolve) => nodeB.connectionManager.once(Libp2pEvent.peerDisconnect, resolve));
     await new Promise((resolve) => setTimeout(resolve, 100));
     await nodeA.hangUp(nodeB.peerId);

--- a/packages/lodestar/test/unit/network/peers/metastore.test.ts
+++ b/packages/lodestar/test/unit/network/peers/metastore.test.ts
@@ -5,9 +5,11 @@ import {ReqRespEncoding} from "../../../../src/constants";
 import {expect} from "chai";
 import PeerId from "peer-id";
 import {phase0} from "@chainsafe/lodestar-types";
+import MetadataBook from "libp2p/src/peer-store/metadata-book";
+import ProtoBook from "libp2p/src/peer-store/proto-book";
 
 describe("Libp2pPeerMetadataStore", function () {
-  let metabookStub: SinonStubbedInstance<MetadataBook>;
+  let metabookStub: SinonStubbedInstance<MetadataBook> & MetadataBook;
 
   const peerId = PeerId.createFromB58String("Qma9T5YraSnpRDZqRR4krcSJabThc8nwZuJV3LercPHufi");
 
@@ -21,6 +23,7 @@ describe("Libp2pPeerMetadataStore", function () {
       getValue: sinon.stub().callsFake(() => {
         return stored;
       }) as SinonStub<[PeerId, string], Buffer>,
+      // @ts-ignore
       set: sinon.stub().callsFake(
         (peerId: PeerId, key: string, value: Buffer): ProtoBook => {
           stored = value;

--- a/packages/lodestar/test/utils/network.ts
+++ b/packages/lodestar/test/utils/network.ts
@@ -39,12 +39,14 @@ export async function disconnect(network: Network, peer: PeerId): Promise<void> 
 
 export function onPeerConnect(network: Network): Promise<void> {
   return new Promise<void>((resolve) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     network["libp2p"].connectionManager.on(Libp2pEvent.peerConnect, () => resolve())
   );
 }
 
 export function onPeerDisconnect(network: Network): Promise<void> {
   return new Promise<void>((resolve) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     network["libp2p"].connectionManager.on(Libp2pEvent.peerDisconnect, () => resolve())
   );
 }

--- a/packages/lodestar/test/utils/peer.ts
+++ b/packages/lodestar/test/utils/peer.ts
@@ -1,8 +1,6 @@
 import PeerId from "peer-id";
-import LibP2p from "libp2p";
 import sinon from "sinon";
 import {PeerStoreBucket, IPeerMetadataStore} from "../../src/network/peers/metastore";
-import Peer = LibP2p.Peer;
 
 /**
  * Returns a valid PeerId with opts `bits: 256, keyType: "secp256k1"`
@@ -11,15 +9,6 @@ import Peer = LibP2p.Peer;
 export function getValidPeerId(): PeerId {
   const id = Buffer.from("002508021221039481269fe831799b1a0f1d521c1395b4831514859e4559c44d155eae46f03819", "hex");
   return new PeerId(id);
-}
-
-export function generatePeer(id: PeerId): Peer {
-  return {
-    id,
-    addresses: [],
-    metadata: new Map<string, Buffer>(),
-    protocols: [],
-  };
 }
 
 function getStubbedMetadataStoreItem<T>(): sinon.SinonStubbedInstance<PeerStoreBucket<T>> {

--- a/packages/lodestar/tsconfig.build.json
+++ b/packages/lodestar/tsconfig.build.json
@@ -3,6 +3,6 @@
   "include": ["src"],
   "compilerOptions": {
     "outDir": "lib",
-    "typeRoots": ["../../node_modules/@types", "../../node_modules/libp2p-ts/types", "./node_modules/@types", "./types"]
+    "typeRoots": ["../../node_modules/@types", "./node_modules/@types", "./types"]
   }
 }

--- a/packages/lodestar/tsconfig.json
+++ b/packages/lodestar/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "../../tsconfig.json",
   "exclude": ["../../node_modules/it-pipe"],
   "compilerOptions": {
-    "typeRoots": ["../../node_modules/@types", "../../node_modules/libp2p-ts/types", "./node_modules/@types", "./types"]
+    "typeRoots": ["../../node_modules/@types", "./node_modules/@types", "./types"]
   }
 }

--- a/packages/lodestar/types/libp2p-bootstrap/index.d.ts
+++ b/packages/lodestar/types/libp2p-bootstrap/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for libp2p-railing 0.9.1
+// Project: https://github.com/libp2p/js-libp2p-bootstrap
+// Definitions by: Jaco Greeff <https://github.com/jacogr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type PeerInfo = {
+  id: import("peer-id");
+  multiaddrs: import("multiaddr")[];
+};
+
+declare namespace LibP2pBootstrap {
+  type Options = {
+    list: Array<string | import("multiaddr")>,
+    interval?: number
+  };
+
+  type Events = 'peer';
+}
+
+declare class LibP2pBootstrap {
+  constructor (options: LibP2pBootstrap.Options);
+
+  on (event: LibP2pBootstrap.Events, cb: (peerInfo: PeerInfo) => any): this;
+}
+
+declare module 'libp2p-bootstrap' {
+export default LibP2pBootstrap;
+}

--- a/packages/lodestar/types/libp2p-bootstrap/tsconfig.json
+++ b/packages/lodestar/types/libp2p-bootstrap/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "libp2p-bootstrap-tests.ts"]
+}

--- a/packages/lodestar/types/libp2p-bootstrap/tslint.json
+++ b/packages/lodestar/types/libp2p-bootstrap/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/packages/lodestar/types/libp2p-mdns/index.d.ts
+++ b/packages/lodestar/types/libp2p-mdns/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for libp2p-mdns 0.12.0
+// Project: https://github.com/libp2p/js-libp2p-mdns
+// Definitions by: Jaco Greeff <https://github.com/jacogr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="libp2p-bootstrap"/>
+
+declare namespace LibP2pMdns {
+  type Options = {
+    broadcast?: boolean,
+    interval?: number,
+    peerInfo: PeerInfo,
+    port?: number,
+    serviceTag?: string
+  };
+
+  type Events = 'peer';
+}
+
+declare class LibP2pMdns extends LibP2pBootstrap {
+  constructor (options: LibP2pMdns.Options);
+
+  on (event: LibP2pMdns.Events, cb: (peerInfo: PeerInfo) => any): this;
+}
+
+declare module 'libp2p-mdns' {
+export default LibP2pMdns;
+}

--- a/packages/lodestar/types/libp2p-mdns/tsconfig.json
+++ b/packages/lodestar/types/libp2p-mdns/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "bn.js-tests.ts"]
+}

--- a/packages/lodestar/types/libp2p-mdns/tslint.json
+++ b/packages/lodestar/types/libp2p-mdns/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/packages/lodestar/types/libp2p-mplex/index.d.ts
+++ b/packages/lodestar/types/libp2p-mplex/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for libp2p-mplex 0.8.0
+// Project: https://github.com/libp2p/js-libp2p-mplex
+// Definitions by: Jaco Greeff <https://github.com/jacogr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'libp2p-mplex' {
+  const mplex: import("libp2p-interfaces/src/stream-muxer/types").MuxerFactory;
+  export default mplex;
+}

--- a/packages/lodestar/types/libp2p-mplex/tsconfig.json
+++ b/packages/lodestar/types/libp2p-mplex/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "libp2p-mplex-tests.ts"]
+}

--- a/packages/lodestar/types/libp2p-mplex/tslint.json
+++ b/packages/lodestar/types/libp2p-mplex/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/packages/lodestar/types/libp2p-tcp/index.d.ts
+++ b/packages/lodestar/types/libp2p-tcp/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for libp2p-tcp 0.12.0
+// Project: https://github.com/libp2p/js-libp2p-tcp
+// Definitions by: Jaco Greeff <https://github.com/jacogr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'libp2p-tcp' {
+  const tcp: import("libp2p-interfaces/src/transport/types").TransportFactory<any, any>;
+  export default tcp;
+}

--- a/packages/lodestar/types/libp2p-tcp/libp2p-tcp-tests.ts
+++ b/packages/lodestar/types/libp2p-tcp/libp2p-tcp-tests.ts
@@ -1,0 +1,4 @@
+// @ts-ignore
+import TCP from 'libp2p-tcp';
+
+new TCP();

--- a/packages/lodestar/types/libp2p-tcp/libp2p-tcp-tests.ts
+++ b/packages/lodestar/types/libp2p-tcp/libp2p-tcp-tests.ts
@@ -1,4 +1,0 @@
-// @ts-ignore
-import TCP from 'libp2p-tcp';
-
-new TCP();

--- a/packages/lodestar/types/libp2p-tcp/tsconfig.json
+++ b/packages/lodestar/types/libp2p-tcp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "bn.js-tests.ts"]
+}

--- a/packages/lodestar/types/libp2p-tcp/tslint.json
+++ b/packages/lodestar/types/libp2p-tcp/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/packages/lodestar/types/time-cache/index.d.ts
+++ b/packages/lodestar/types/time-cache/index.d.ts
@@ -1,0 +1,8 @@
+declare class TimeCache {
+  put(data: string): void;
+  has(data: string): boolean;
+}
+
+declare module "time-cache" {
+  export default TimeCache;
+}

--- a/packages/validator/tsconfig.build.json
+++ b/packages/validator/tsconfig.build.json
@@ -3,6 +3,6 @@
   "include": ["src"],
   "compilerOptions": {
     "outDir": "lib",
-    "typeRoots": ["../../node_modules/@types", "../../node_modules/libp2p-ts/types", "./node_modules/@types"]
+    "typeRoots": ["../../node_modules/@types", "./node_modules/@types"]
   }
 }

--- a/packages/validator/tsconfig.json
+++ b/packages/validator/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "typeRoots": ["../../node_modules/@types", "../../node_modules/libp2p-ts/types", "./node_modules/@types"]
+    "typeRoots": ["../../node_modules/@types", "./node_modules/@types"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8394,16 +8394,6 @@ libp2p-tcp@^0.15.3:
     multiaddr "^8.0.0"
     stream-to-it "^0.2.2"
 
-"libp2p-ts@https://github.com/ChainSafe/libp2p-ts.git":
-  version "0.1.0"
-  resolved "https://github.com/ChainSafe/libp2p-ts.git#86c1d9eca212194c8a5ce1ea6572a3bd694103e5"
-  dependencies:
-    "@chainsafe/discv5" "^0.5.0"
-    "@types/node" "^13.7.0"
-    libp2p-crypto "^0.18.0"
-    multiaddr "^8.0.0"
-    peer-id "^0.14.1"
-
 libp2p-utils@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/libp2p-utils/-/libp2p-utils-0.2.0.tgz#9adea1a81943ca7d4d3103aa889796200703f97d"
@@ -13441,4 +13431,3 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-


### PR DESCRIPTION
**Motivation**

Resolves #2167 

**Description**

Minimal fix for #2167 
The types still required are copied from `libp2p-ts` to the lodestar & cli packages
