### PR TITLE
Don't re-verify attestation signatures

### DIFF
--- a/packages/lodestar/src/chain/attestation/process.ts
+++ b/packages/lodestar/src/chain/attestation/process.ts
@@ -47,8 +47,8 @@ export async function processAttestation({
     });
   }
 
-  //TODO: we could signal to skip this in case it came from validated from gossip or from block
-  // we need to check this again, because gossip validation might put it in pool before it validated signature
+  // Only verify signature if necessary. Most attestations come from blocks that did full signature verification
+  // Otherwise, gossip validation might put it in pool before it validating signature
   if (!phase0.fast.isValidIndexedAttestation(targetState, indexedAttestation, !job.validSignature)) {
     throw new AttestationError({
       code: AttestationErrorCode.INVALID_SIGNATURE,

--- a/packages/lodestar/src/chain/attestation/process.ts
+++ b/packages/lodestar/src/chain/attestation/process.ts
@@ -49,7 +49,7 @@ export async function processAttestation({
 
   //TODO: we could signal to skip this in case it came from validated from gossip or from block
   // we need to check this again, because gossip validation might put it in pool before it validated signature
-  if (!phase0.fast.isValidIndexedAttestation(targetState, indexedAttestation, true)) {
+  if (!phase0.fast.isValidIndexedAttestation(targetState, indexedAttestation, !job.validSignature)) {
     throw new AttestationError({
       code: AttestationErrorCode.INVALID_SIGNATURE,
       job,


### PR DESCRIPTION
**Motivation**

Node running Prater genesis spent ~1000ms validating signatures of attestations probably wastefully

![Screenshot from 2021-03-24 22-35-35](https://user-images.githubusercontent.com/35266934/112387484-1d828780-8cf2-11eb-990a-40909a6299dc.png)

![Screenshot from 2021-03-24 22-43-11](https://user-images.githubusercontent.com/35266934/112387649-5589ca80-8cf2-11eb-9254-f185d2845157.png)


We already use the job boolean properly https://github.com/ChainSafe/lodestar/blob/0cc2f3e5a095988f07e40e060e7cbf649ccbd3cb/packages/lodestar/src/chain/eventHandlers.ts#L238-L242


**Description**

Only verify signatures if necessary
