### PR TITLE
Add BeaconCommitteeSubscription ssz type

### DIFF
--- a/packages/lodestar/src/api/impl/validator/interface.ts
+++ b/packages/lodestar/src/api/impl/validator/interface.ts
@@ -3,14 +3,6 @@
  */
 import {BLSSignature, CommitteeIndex, Epoch, Root, phase0, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
 
-export type BeaconCommitteeSubscription = {
-  validatorIndex: number;
-  committeeIndex: number;
-  committeesAtSlot: number;
-  slot: number;
-  isAggregator: boolean;
-};
-
 /**
  * The API interface defines the calls that can be made from a Validator
  */
@@ -32,5 +24,5 @@ export interface IValidatorApi {
 
   publishAggregateAndProofs(signedAggregateAndProofs: phase0.SignedAggregateAndProof[]): Promise<void>;
 
-  prepareBeaconCommitteeSubnet(subscriptions: BeaconCommitteeSubscription[]): Promise<void>;
+  prepareBeaconCommitteeSubnet(subscriptions: phase0.BeaconCommitteeSubscription[]): Promise<void>;
 }

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -22,7 +22,7 @@ import {IApiOptions} from "../../options";
 import {ApiError} from "../errors/api";
 import {ApiNamespace, IApiModules} from "../interface";
 import {checkSyncStatus} from "../utils";
-import {BeaconCommitteeSubscription, IValidatorApi} from "./interface";
+import {IValidatorApi} from "./interface";
 
 /**
  * Server implementation for handling validator duties.
@@ -178,7 +178,7 @@ export class ValidatorApi implements IValidatorApi {
     );
   }
 
-  async prepareBeaconCommitteeSubnet(subscriptions: BeaconCommitteeSubscription[]): Promise<void> {
+  async prepareBeaconCommitteeSubnet(subscriptions: phase0.BeaconCommitteeSubscription[]): Promise<void> {
     await checkSyncStatus(this.config, this.sync);
 
     // Determine if the validator is an aggregator. If so, we subscribe to the subnet and

--- a/packages/types/src/phase0/ssz/generators/api.ts
+++ b/packages/types/src/phase0/ssz/generators/api.ts
@@ -44,6 +44,17 @@ export const ProposerDuty = (ssz: IPhase0SSZTypes): ContainerType =>
     },
   });
 
+export const BeaconCommitteeSubscription = (ssz: IPhase0SSZTypes): ContainerType =>
+  new ContainerType({
+    fields: {
+      validatorIndex: ssz.ValidatorIndex,
+      committeeIndex: ssz.CommitteeIndex,
+      committeesAtSlot: ssz.Slot,
+      slot: ssz.Slot,
+      isAggregator: ssz.Boolean,
+    },
+  });
+
 export const SyncingStatus = (ssz: IPhase0SSZTypes): ContainerType =>
   new ContainerType({
     fields: {

--- a/packages/types/src/phase0/ssz/interface.ts
+++ b/packages/types/src/phase0/ssz/interface.ts
@@ -59,6 +59,7 @@ export type IPhase0SSZTypes = IPrimitiveSSZTypes & {
   SyncingStatus: ContainerType<phase0.SyncingStatus>;
   AttesterDuty: ContainerType<phase0.AttesterDuty>;
   ProposerDuty: ContainerType<phase0.ProposerDuty>;
+  BeaconCommitteeSubscription: ContainerType<phase0.BeaconCommitteeSubscription>;
   // Validator slashing protection
   SlashingProtectionBlock: ContainerType<phase0.SlashingProtectionBlock>;
   SlashingProtectionAttestation: ContainerType<phase0.SlashingProtectionAttestation>;
@@ -148,6 +149,7 @@ export const phase0TypeNames: (keyof IPhase0SSZTypes)[] = [
   "SyncingStatus",
   "AttesterDuty",
   "ProposerDuty",
+  "BeaconCommitteeSubscription",
   "Genesis",
   "ChainHead",
   "BlockEventPayload",

--- a/packages/types/src/phase0/types/api.ts
+++ b/packages/types/src/phase0/types/api.ts
@@ -50,6 +50,14 @@ export interface ProposerDuty {
   pubkey: BLSPubkey;
 }
 
+export interface BeaconCommitteeSubscription {
+  validatorIndex: number;
+  committeeIndex: number;
+  committeesAtSlot: number;
+  slot: number;
+  isAggregator: boolean;
+}
+
 export interface SyncingStatus {
   // Head slot node is trying to reach
   headSlot: Uint64;

--- a/packages/validator/src/api/impl/rest/validator/validator.ts
+++ b/packages/validator/src/api/impl/rest/validator/validator.ts
@@ -4,7 +4,7 @@ import {CommitteeIndex, Epoch, Root, phase0, Slot, ValidatorIndex} from "@chains
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {Json, toHexString} from "@chainsafe/ssz";
 import {HttpClient, urlJoin} from "../../../../util";
-import {BeaconCommitteeSubscription, IValidatorApi} from "../../../interface/validators";
+import {IValidatorApi} from "../../../interface/validators";
 
 /**
  * Rest API class for fetching and performing validator duties
@@ -63,7 +63,10 @@ export class RestValidatorApi implements IValidatorApi {
     );
   }
 
-  async prepareBeaconCommitteeSubnet(subscriptions: BeaconCommitteeSubscription[]): Promise<void> {
-    return await this.clientV2.post<Json[], void>("/beacon_committee_subscriptions", subscriptions);
+  async prepareBeaconCommitteeSubnet(subscriptions: phase0.BeaconCommitteeSubscription[]): Promise<void> {
+    return await this.clientV2.post<Json[], void>(
+      "/beacon_committee_subscriptions",
+      subscriptions.map((s) => this.config.types.phase0.BeaconCommitteeSubscription.toJson(s, {case: "snake"}))
+    );
   }
 }

--- a/packages/validator/src/api/interface/validators.ts
+++ b/packages/validator/src/api/interface/validators.ts
@@ -1,13 +1,5 @@
 import {BLSPubkey, CommitteeIndex, Epoch, Root, phase0, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
 
-export type BeaconCommitteeSubscription = {
-  validatorIndex: number;
-  committeeIndex: number;
-  committeesAtSlot: number;
-  slot: number;
-  isAggregator: boolean;
-};
-
 export interface IValidatorApi {
   getProposerDuties(epoch: Epoch, validatorPubKeys: BLSPubkey[]): Promise<phase0.ProposerDuty[]>;
 
@@ -26,5 +18,5 @@ export interface IValidatorApi {
 
   publishAggregateAndProofs(signedAggregateAndProofs: phase0.SignedAggregateAndProof[]): Promise<void>;
 
-  prepareBeaconCommitteeSubnet(subscriptions: BeaconCommitteeSubscription[]): Promise<void>;
+  prepareBeaconCommitteeSubnet(subscriptions: phase0.BeaconCommitteeSubscription[]): Promise<void>;
 }

--- a/packages/validator/test/utils/mocks/validator.ts
+++ b/packages/validator/test/utils/mocks/validator.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {Number64, phase0, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {generateEmptyBlock} from "@chainsafe/lodestar/test/utils/block";
-import {BeaconCommitteeSubscription, IValidatorApi} from "../../../src/api/interface/validators";
+import {IValidatorApi} from "../../../src/api/interface/validators";
 
 export interface IMockValidatorAPIOpts {
   head?: phase0.SignedBeaconBlock;
@@ -37,7 +37,7 @@ export class MockValidatorApi implements IValidatorApi {
   publishAggregateAndProofs(signedAggregateAndProofs: phase0.SignedAggregateAndProof[]): Promise<void> {
     throw new Error("Method not implemented.");
   }
-  prepareBeaconCommitteeSubnet(subscriptions: BeaconCommitteeSubscription[]): Promise<void> {
+  prepareBeaconCommitteeSubnet(subscriptions: phase0.BeaconCommitteeSubscription[]): Promise<void> {
     throw new Error("Method not implemented.");
   }
 


### PR DESCRIPTION
part of #2145

**Motivation**

There is no ssz type for BeaconCommitteeSubscription so validator does not use snack case to conform to the standard api

**Description**

Add ssz type for it and validator should use `toJson({case: "snake"}) to communicate with node.

**Steps to test or reproduce**

Run lodestar e2e test.
