### PR TITLE
Fix validateAggregateAttestation types + error

### DIFF
--- a/packages/lodestar/src/api/impl/beacon/pool/pool.ts
+++ b/packages/lodestar/src/api/impl/beacon/pool/pool.ts
@@ -53,6 +53,7 @@ export class BeaconPoolApi implements IBeaconPoolApi {
     } catch (e) {
       throw new AttestationError({
         code: AttestationErrorCode.MISSING_ATTESTATION_PRESTATE,
+        error: e as Error,
         job: attestationJob,
       });
     }

--- a/packages/lodestar/src/chain/errors/attestationError.ts
+++ b/packages/lodestar/src/chain/errors/attestationError.ts
@@ -163,7 +163,7 @@ export type AttestationErrorType =
   | {code: AttestationErrorCode.FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT}
   | {code: AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK}
   | {code: AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE; index: number}
-  | {code: AttestationErrorCode.MISSING_ATTESTATION_PRESTATE}
+  | {code: AttestationErrorCode.MISSING_ATTESTATION_PRESTATE; error: Error}
   | {code: AttestationErrorCode.INVALID_AGGREGATOR};
 
 type IJobObject = {

--- a/packages/lodestar/src/chain/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/aggregateAndProof.ts
@@ -91,6 +91,7 @@ export async function validateAggregateAttestation(
   } catch (e) {
     throw new AttestationError({
       code: AttestationErrorCode.MISSING_ATTESTATION_PRESTATE,
+      error: e as Error,
       job: attestationJob,
     });
   }

--- a/packages/lodestar/src/chain/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/aggregateAndProof.ts
@@ -1,8 +1,13 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {ValidatorIndex} from "@chainsafe/lodestar-types";
 import {IAttestationJob, IBeaconChain} from "..";
 import {IBeaconDb} from "../../db/api";
-import {computeEpochAtSlot, isAggregatorFromCommitteeLength} from "@chainsafe/lodestar-beacon-state-transition";
-import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
+import {
+  phase0,
+  CachedBeaconState,
+  computeEpochAtSlot,
+  isAggregatorFromCommitteeLength,
+} from "@chainsafe/lodestar-beacon-state-transition";
 import {isAttestingToInValidBlock} from "./attestation";
 import {isValidAggregateAndProofSignature, isValidSelectionProofSignature} from "./utils";
 import {AttestationError, AttestationErrorCode} from "../errors";
@@ -78,7 +83,8 @@ export async function validateAggregateAttestation(
   attestationJob: IAttestationJob
 ): Promise<void> {
   const attestation = aggregateAndProof.message.aggregate;
-  let attestationPreState;
+
+  let attestationPreState: CachedBeaconState<phase0.BeaconState>;
   try {
     // the target state, advanced to the attestation slot
     attestationPreState = await chain.regen.getBlockSlotState(attestation.data.target.root, attestation.data.slot);
@@ -89,7 +95,7 @@ export async function validateAggregateAttestation(
     });
   }
 
-  let committee;
+  let committee: ValidatorIndex[];
   try {
     committee = attestationPreState.getBeaconCommittee(attestation.data.slot, attestation.data.index);
   } catch (error) {

--- a/packages/lodestar/src/chain/validation/attestation.ts
+++ b/packages/lodestar/src/chain/validation/attestation.ts
@@ -1,7 +1,7 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBeaconDb} from "../../db/api";
 import {IAttestationJob, IBeaconChain} from "..";
-import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconState, computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {AttestationError, AttestationErrorCode} from "../errors";
 import {ATTESTATION_PROPAGATION_SLOT_RANGE} from "../../constants";
@@ -73,7 +73,7 @@ export async function validateGossipAttestation(
     });
   }
 
-  let attestationPreState;
+  let attestationPreState: CachedBeaconState<phase0.BeaconState>;
   try {
     attestationPreState = await chain.regen.getCheckpointState(attestation.data.target);
   } catch (e) {

--- a/packages/lodestar/src/chain/validation/attestation.ts
+++ b/packages/lodestar/src/chain/validation/attestation.ts
@@ -79,6 +79,7 @@ export async function validateGossipAttestation(
   } catch (e) {
     throw new AttestationError({
       code: AttestationErrorCode.MISSING_ATTESTATION_PRESTATE,
+      error: e as Error,
       job: attestationJob,
     });
   }


### PR DESCRIPTION
**Motivation**

1. Untyped variables in validateAggregateAttestation
2. MISSING_ATTESTATION_PRESTATE assumes that `getBlockSlotState` throws for a specific reason but could be any error. Add sub error to error type

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->


**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
