### PR TITLE
Bump butlerlogic/action-autotag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Create tag
         id: tag
-        uses: butlerlogic/action-autotag@1.1.1
+        uses: butlerlogic/action-autotag@1.1.2
         with:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           root: "packages/lodestar" # lerna doesn't update version root package.json and this action cannot read from lerna.json


### PR DESCRIPTION
**Motivation**

CI in master is failing with
```
Error: Cannot find module '/app/node_modules/@actions/http-client/index.js'. Please verify that the package.json has a valid "main" entry
    at tryPackage (internal/modules/cjs/loader.js:318:19)
    at Function.Module._findPath (internal/modules/cjs/loader.js:679:18)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:949:27)
    at Function.Module._load (internal/modules/cjs/loader.js:838:27)
    at Module.require (internal/modules/cjs/loader.js:1022:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (/app/node_modules/@actions/github/lib/github.js:14:33)
    at Module._compile (internal/modules/cjs/loader.js:1118:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1138:10)
    at Module.load (internal/modules/cjs/loader.js:982:32) {
  code: 'MODULE_NOT_FOUND',
  path: '/app/node_modules/@actions/http-client/package.json',
  requestPath: '@actions/http-client'
}
```

**Description**

Bump to latest action tag to (hopefully) fix the issue
