### PR TITLE
Re-org gossip validation fns

### DIFF
--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -1,29 +1,5 @@
-import {ERR_TOPIC_VALIDATOR_IGNORE, ERR_TOPIC_VALIDATOR_REJECT} from "libp2p-gossipsub/src/constants";
-import {ATTESTATION_SUBNET_COUNT, phase0} from "@chainsafe/lodestar-types";
-import {Json, toHexString} from "@chainsafe/ssz";
-
-import {IAttestationJob} from "../../chain";
-import {
-  validateGossipAggregateAndProof,
-  validateGossipAttestation,
-  validateGossipBlock,
-  validateGossipProposerSlashing,
-  validateGossipVoluntaryExit,
-  validateGossipAttesterSlashing,
-} from "../../chain/validation";
-import {
-  BlockError,
-  BlockErrorCode,
-  AttestationError,
-  AttestationErrorCode,
-  AttesterSlashingError,
-  AttesterSlashingErrorCode,
-  ProposerSlashingError,
-  ProposerSlashingErrorCode,
-  VoluntaryExitError,
-  VoluntaryExitErrorCode,
-} from "../../chain/errors";
-
+import {ERR_TOPIC_VALIDATOR_REJECT} from "libp2p-gossipsub/src/constants";
+import {ATTESTATION_SUBNET_COUNT} from "@chainsafe/lodestar-types";
 import {
   GossipType,
   IGossipMessage,
@@ -31,11 +7,11 @@ import {
   ObjectValidatorFn,
   IObjectValidatorModules,
   GossipTopic,
-  IBeaconAttestationTopic,
 } from "./interface";
 import {getGossipTopicString} from "./topic";
 import {GossipValidationError} from "./errors";
 import {DEFAULT_ENCODING} from "./constants";
+import {objectValidatorFns} from "./validatorFns";
 
 // Gossip validation functions are wrappers around chain-level validation functions
 // With a few additional elements:
@@ -49,224 +25,6 @@ import {DEFAULT_ENCODING} from "./constants";
 // - Gossip type conversion - Gossip validation functions operate on messages of binary data.
 //   This data must be deserialized into the proper type, determined by the topic (fork digest)
 //   This deserialization must have happened prior to the topic validator running.
-
-export async function validateBeaconBlock(
-  {chain, db, config, logger}: IObjectValidatorModules,
-  _topic: GossipTopic,
-  signedBlock: phase0.SignedBeaconBlock
-): Promise<void> {
-  try {
-    await validateGossipBlock(config, chain, db, {
-      signedBlock,
-      reprocess: false,
-      prefinalized: false,
-      validSignatures: false,
-      validProposerSignature: false,
-    });
-    logger.debug("gossip - Block - accept", {
-      root: toHexString(config.types.phase0.BeaconBlock.hashTreeRoot(signedBlock.message)),
-      slot: signedBlock.message.slot,
-    });
-  } catch (e) {
-    if (!(e instanceof BlockError)) {
-      logger.error("Gossip block validation threw a non-BlockError", e);
-      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
-    }
-
-    switch (e.type.code) {
-      case BlockErrorCode.PROPOSAL_SIGNATURE_INVALID:
-      case BlockErrorCode.INCORRECT_PROPOSER:
-      case BlockErrorCode.KNOWN_BAD_BLOCK:
-        logger.debug("gossip - Block - reject", e.type);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
-
-      case BlockErrorCode.FUTURE_SLOT:
-      case BlockErrorCode.PARENT_UNKNOWN: // IGNORE
-        chain.receiveBlock(signedBlock);
-      /** eslit-disable-next-line no-fallthrough */
-      case BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT:
-      case BlockErrorCode.REPEAT_PROPOSAL:
-      default:
-        logger.debug("gossip - Block - ignore", e.type as Json);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
-    }
-  }
-}
-
-export async function validateAggregatedAttestation(
-  {chain, db, config, logger}: IObjectValidatorModules,
-  _topic: GossipTopic,
-  signedAggregateAndProof: phase0.SignedAggregateAndProof
-): Promise<void> {
-  const attestation = signedAggregateAndProof.message.aggregate;
-
-  try {
-    await validateGossipAggregateAndProof(config, chain, db, signedAggregateAndProof, {
-      attestation: attestation,
-      validSignature: false,
-    });
-    logger.debug("gossip - AggregateAndProof - accept");
-  } catch (e) {
-    if (!(e instanceof AttestationError)) {
-      logger.error("Gossip aggregate and proof validation threw a non-AttestationError", e);
-      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
-    }
-
-    switch (e.type.code) {
-      case AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS:
-      case AttestationErrorCode.KNOWN_BAD_BLOCK:
-      case AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE:
-      case AttestationErrorCode.INVALID_SELECTION_PROOF:
-      case AttestationErrorCode.INVALID_SIGNATURE:
-      case AttestationErrorCode.INVALID_AGGREGATOR:
-        logger.debug("gossip - AggregateAndProof - reject", e.type);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
-
-      case AttestationErrorCode.FUTURE_SLOT: // IGNORE
-        chain.receiveAttestation(attestation);
-      /** eslit-disable-next-line no-fallthrough */
-      case AttestationErrorCode.PAST_SLOT:
-      case AttestationErrorCode.AGGREGATE_ALREADY_KNOWN:
-      case AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE:
-      default:
-        logger.debug("gossip - AggregateAndProof - ignore", e.type as Json);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
-    }
-  } finally {
-    db.seenAttestationCache.addAggregateAndProof(signedAggregateAndProof.message);
-  }
-}
-
-export async function validateCommitteeAttestation(
-  {chain, db, config, logger}: IObjectValidatorModules,
-  topic: IBeaconAttestationTopic,
-  attestation: phase0.Attestation
-): Promise<void> {
-  const subnet = topic.subnet;
-
-  try {
-    const attestationJob: IAttestationJob = {
-      attestation,
-      validSignature: false,
-    };
-
-    await validateGossipAttestation(config, chain, db, attestationJob, subnet);
-    logger.debug("gossip - Attestation - accept", {subnet});
-  } catch (e) {
-    if (!(e instanceof AttestationError)) {
-      logger.error("Gossip attestation validation threw a non-AttestationError", e);
-      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
-    }
-    switch (e.type.code) {
-      case AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE:
-      case AttestationErrorCode.INVALID_SUBNET_ID:
-      case AttestationErrorCode.BAD_TARGET_EPOCH:
-      case AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET:
-      case AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS:
-      case AttestationErrorCode.INVALID_SIGNATURE:
-      case AttestationErrorCode.KNOWN_BAD_BLOCK:
-      case AttestationErrorCode.FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT:
-      case AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK:
-        logger.debug("gossip - Attestation - reject", e.type);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
-
-      case AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT:
-      case AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE: // IGNORE
-        // attestation might be valid after we receive block
-        chain.receiveAttestation(attestation);
-      /** eslit-disable-next-line no-fallthrough */
-      case AttestationErrorCode.PAST_SLOT:
-      case AttestationErrorCode.FUTURE_SLOT:
-      case AttestationErrorCode.ATTESTATION_ALREADY_KNOWN:
-      default:
-        logger.debug("gossip - Attestation - ignore", e.type as Json);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
-    }
-  } finally {
-    db.seenAttestationCache.addCommitteeAttestation(attestation);
-  }
-}
-
-export async function validateVoluntaryExit(
-  {chain, db, config, logger}: IObjectValidatorModules,
-  _topic: GossipTopic,
-  voluntaryExit: phase0.SignedVoluntaryExit
-): Promise<void> {
-  try {
-    await validateGossipVoluntaryExit(config, chain, db, voluntaryExit);
-    logger.debug("gossip - VoluntaryExit - accept");
-  } catch (e) {
-    if (!(e instanceof VoluntaryExitError)) {
-      logger.error("Gossip voluntary exit validation threw a non-VoluntaryExitError", e);
-      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
-    }
-
-    switch (e.type.code) {
-      case VoluntaryExitErrorCode.INVALID_EXIT:
-        logger.debug("gossip - VoluntaryExit - reject", e.type);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
-
-      case VoluntaryExitErrorCode.EXIT_ALREADY_EXISTS:
-      default:
-        logger.debug("gossip - VoluntaryExit - ignore", e.type);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
-    }
-  }
-}
-
-export async function validateProposerSlashing(
-  {chain, db, config, logger}: IObjectValidatorModules,
-  _topic: GossipTopic,
-  proposerSlashing: phase0.ProposerSlashing
-): Promise<void> {
-  try {
-    await validateGossipProposerSlashing(config, chain, db, proposerSlashing);
-    logger.debug("gossip - ProposerSlashing - accept");
-  } catch (e) {
-    if (!(e instanceof ProposerSlashingError)) {
-      logger.error("Gossip proposer slashing validation threw a non-ProposerSlashingError", e);
-      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
-    }
-
-    switch (e.type.code) {
-      case ProposerSlashingErrorCode.INVALID_SLASHING:
-        logger.debug("gossip - ProposerSlashing - reject", e.type);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
-
-      case ProposerSlashingErrorCode.SLASHING_ALREADY_EXISTS:
-      default:
-        logger.debug("gossip - ProposerSlashing - ignore", e.type);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
-    }
-  }
-}
-
-export async function validateAttesterSlashing(
-  {chain, db, config, logger}: IObjectValidatorModules,
-  _topic: GossipTopic,
-  attesterSlashing: phase0.AttesterSlashing
-): Promise<void> {
-  try {
-    await validateGossipAttesterSlashing(config, chain, db, attesterSlashing);
-    logger.debug("gossip - AttesterSlashing - accept");
-  } catch (e) {
-    if (!(e instanceof AttesterSlashingError)) {
-      logger.error("Gossip attester slashing validation threw a non-AttesterSlashingError", e);
-      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
-    }
-
-    switch (e.type.code) {
-      case AttesterSlashingErrorCode.INVALID_SLASHING:
-        logger.debug("gossip - AttesterSlashing - reject", e.type);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
-
-      case AttesterSlashingErrorCode.SLASHING_ALREADY_EXISTS:
-      default:
-        logger.debug("gossip - AttesterSlashing - ignore", e.type);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
-    }
-  }
-}
 
 /**
  * Wrap an ObjectValidatorFn as a TopicValidatorFn
@@ -290,38 +48,23 @@ export function createTopicValidatorFn(
 export function createTopicValidatorFnMap(modules: IObjectValidatorModules): Map<string, TopicValidatorFn> {
   const validatorFns = new Map<string, TopicValidatorFn>();
   const genesisValidatorsRoot = modules.chain.genesisValidatorsRoot;
+
   // TODO: other fork topics should get added here
   // phase0
   const fork = "phase0";
-  const staticTopics: {
-    type: GossipType;
-    objectValidatorFn: ObjectValidatorFn;
-  }[] = [
-    {
-      type: GossipType.beacon_block,
-      objectValidatorFn: validateBeaconBlock as ObjectValidatorFn,
-    },
-    {
-      type: GossipType.beacon_aggregate_and_proof,
-      objectValidatorFn: validateAggregatedAttestation as ObjectValidatorFn,
-    },
-    {
-      type: GossipType.voluntary_exit,
-      objectValidatorFn: validateVoluntaryExit as ObjectValidatorFn,
-    },
-    {
-      type: GossipType.proposer_slashing,
-      objectValidatorFn: validateProposerSlashing as ObjectValidatorFn,
-    },
-    {
-      type: GossipType.attester_slashing,
-      objectValidatorFn: validateAttesterSlashing as ObjectValidatorFn,
-    },
+  const staticGossipTypes: GossipType[] = [
+    GossipType.beacon_block,
+    GossipType.beacon_aggregate_and_proof,
+    GossipType.voluntary_exit,
+    GossipType.proposer_slashing,
+    GossipType.attester_slashing,
   ];
-  for (const {type, objectValidatorFn} of staticTopics) {
+
+  for (const type of staticGossipTypes) {
+    const objectValidatorFn = objectValidatorFns[type];
     const topic = {type, fork, encoding: DEFAULT_ENCODING} as GossipTopic;
     const topicString = getGossipTopicString(modules.config, topic, genesisValidatorsRoot);
-    const topicValidatorFn = createTopicValidatorFn(modules, objectValidatorFn);
+    const topicValidatorFn = createTopicValidatorFn(modules, objectValidatorFn as ObjectValidatorFn);
     validatorFns.set(topicString, topicValidatorFn);
   }
   // create an entry for every committee subnet - phase0
@@ -333,7 +76,10 @@ export function createTopicValidatorFnMap(modules: IObjectValidatorModules): Map
       subnet,
     } as GossipTopic;
     const topicString = getGossipTopicString(modules.config, topic, genesisValidatorsRoot);
-    const topicValidatorFn = createTopicValidatorFn(modules, validateCommitteeAttestation as ObjectValidatorFn);
+    const topicValidatorFn = createTopicValidatorFn(
+      modules,
+      objectValidatorFns[GossipType.beacon_attestation] as ObjectValidatorFn
+    );
     validatorFns.set(topicString, topicValidatorFn);
   }
   return validatorFns;

--- a/packages/lodestar/src/network/gossip/validatorFns/aggregatedAttestation.ts
+++ b/packages/lodestar/src/network/gossip/validatorFns/aggregatedAttestation.ts
@@ -1,0 +1,51 @@
+import {ERR_TOPIC_VALIDATOR_IGNORE, ERR_TOPIC_VALIDATOR_REJECT} from "libp2p-gossipsub/src/constants";
+import {phase0} from "@chainsafe/lodestar-types";
+import {Json} from "@chainsafe/ssz";
+import {validateGossipAggregateAndProof} from "../../../chain/validation";
+import {AttestationError, AttestationErrorCode} from "../../../chain/errors";
+import {IObjectValidatorModules, GossipTopic} from "../interface";
+import {GossipValidationError} from "../errors";
+
+export async function validateAggregatedAttestation(
+  {chain, db, config, logger}: IObjectValidatorModules,
+  _topic: GossipTopic,
+  signedAggregateAndProof: phase0.SignedAggregateAndProof
+): Promise<void> {
+  const attestation = signedAggregateAndProof.message.aggregate;
+
+  try {
+    await validateGossipAggregateAndProof(config, chain, db, signedAggregateAndProof, {
+      attestation: attestation,
+      validSignature: false,
+    });
+    logger.debug("gossip - AggregateAndProof - accept");
+  } catch (e) {
+    if (!(e instanceof AttestationError)) {
+      logger.error("Gossip aggregate and proof validation threw a non-AttestationError", e);
+      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
+    }
+
+    switch (e.type.code) {
+      case AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS:
+      case AttestationErrorCode.KNOWN_BAD_BLOCK:
+      case AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE:
+      case AttestationErrorCode.INVALID_SELECTION_PROOF:
+      case AttestationErrorCode.INVALID_SIGNATURE:
+      case AttestationErrorCode.INVALID_AGGREGATOR:
+        logger.debug("gossip - AggregateAndProof - reject", e.type);
+        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
+
+      case AttestationErrorCode.FUTURE_SLOT: // IGNORE
+        chain.receiveAttestation(attestation);
+      /** eslit-disable-next-line no-fallthrough */
+      case AttestationErrorCode.PAST_SLOT:
+      case AttestationErrorCode.AGGREGATE_ALREADY_KNOWN:
+      case AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE:
+      default:
+        logger.debug("gossip - AggregateAndProof - ignore", e.type as Json);
+        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
+    }
+  } finally {
+    db.seenAttestationCache.addAggregateAndProof(signedAggregateAndProof.message);
+  }
+}

--- a/packages/lodestar/src/network/gossip/validatorFns/attestation.ts
+++ b/packages/lodestar/src/network/gossip/validatorFns/attestation.ts
@@ -1,0 +1,58 @@
+import {ERR_TOPIC_VALIDATOR_IGNORE, ERR_TOPIC_VALIDATOR_REJECT} from "libp2p-gossipsub/src/constants";
+import {phase0} from "@chainsafe/lodestar-types";
+import {Json} from "@chainsafe/ssz";
+import {IAttestationJob} from "../../../chain";
+import {validateGossipAttestation} from "../../../chain/validation";
+import {AttestationError, AttestationErrorCode} from "../../../chain/errors";
+import {IObjectValidatorModules, IBeaconAttestationTopic} from "../interface";
+import {GossipValidationError} from "../errors";
+
+export async function validateCommitteeAttestation(
+  {chain, db, config, logger}: IObjectValidatorModules,
+  topic: IBeaconAttestationTopic,
+  attestation: phase0.Attestation
+): Promise<void> {
+  const subnet = topic.subnet;
+
+  try {
+    const attestationJob: IAttestationJob = {
+      attestation,
+      validSignature: false,
+    };
+
+    await validateGossipAttestation(config, chain, db, attestationJob, subnet);
+    logger.debug("gossip - Attestation - accept", {subnet});
+  } catch (e) {
+    if (!(e instanceof AttestationError)) {
+      logger.error("Gossip attestation validation threw a non-AttestationError", e);
+      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
+    }
+    switch (e.type.code) {
+      case AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE:
+      case AttestationErrorCode.INVALID_SUBNET_ID:
+      case AttestationErrorCode.BAD_TARGET_EPOCH:
+      case AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET:
+      case AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS:
+      case AttestationErrorCode.INVALID_SIGNATURE:
+      case AttestationErrorCode.KNOWN_BAD_BLOCK:
+      case AttestationErrorCode.FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT:
+      case AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK:
+        logger.debug("gossip - Attestation - reject", e.type);
+        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
+
+      case AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT:
+      case AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE: // IGNORE
+        // attestation might be valid after we receive block
+        chain.receiveAttestation(attestation);
+      /** eslit-disable-next-line no-fallthrough */
+      case AttestationErrorCode.PAST_SLOT:
+      case AttestationErrorCode.FUTURE_SLOT:
+      case AttestationErrorCode.ATTESTATION_ALREADY_KNOWN:
+      default:
+        logger.debug("gossip - Attestation - ignore", e.type as Json);
+        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
+    }
+  } finally {
+    db.seenAttestationCache.addCommitteeAttestation(attestation);
+  }
+}

--- a/packages/lodestar/src/network/gossip/validatorFns/attesterSlashing.ts
+++ b/packages/lodestar/src/network/gossip/validatorFns/attesterSlashing.ts
@@ -1,0 +1,33 @@
+import {ERR_TOPIC_VALIDATOR_IGNORE, ERR_TOPIC_VALIDATOR_REJECT} from "libp2p-gossipsub/src/constants";
+import {phase0} from "@chainsafe/lodestar-types";
+import {validateGossipAttesterSlashing} from "../../../chain/validation";
+import {AttesterSlashingError, AttesterSlashingErrorCode} from "../../../chain/errors";
+import {IObjectValidatorModules, GossipTopic} from "../interface";
+import {GossipValidationError} from "../errors";
+
+export async function validateAttesterSlashing(
+  {chain, db, config, logger}: IObjectValidatorModules,
+  _topic: GossipTopic,
+  attesterSlashing: phase0.AttesterSlashing
+): Promise<void> {
+  try {
+    await validateGossipAttesterSlashing(config, chain, db, attesterSlashing);
+    logger.debug("gossip - AttesterSlashing - accept");
+  } catch (e) {
+    if (!(e instanceof AttesterSlashingError)) {
+      logger.error("Gossip attester slashing validation threw a non-AttesterSlashingError", e);
+      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
+    }
+
+    switch (e.type.code) {
+      case AttesterSlashingErrorCode.INVALID_SLASHING:
+        logger.debug("gossip - AttesterSlashing - reject", e.type);
+        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
+
+      case AttesterSlashingErrorCode.SLASHING_ALREADY_EXISTS:
+      default:
+        logger.debug("gossip - AttesterSlashing - ignore", e.type);
+        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
+    }
+  }
+}

--- a/packages/lodestar/src/network/gossip/validatorFns/block.ts
+++ b/packages/lodestar/src/network/gossip/validatorFns/block.ts
@@ -1,0 +1,50 @@
+import {ERR_TOPIC_VALIDATOR_IGNORE, ERR_TOPIC_VALIDATOR_REJECT} from "libp2p-gossipsub/src/constants";
+import {phase0} from "@chainsafe/lodestar-types";
+import {Json, toHexString} from "@chainsafe/ssz";
+import {validateGossipBlock} from "../../../chain/validation";
+import {BlockError, BlockErrorCode} from "../../../chain/errors";
+import {IObjectValidatorModules, GossipTopic} from "../interface";
+import {GossipValidationError} from "../errors";
+
+export async function validateBeaconBlock(
+  {chain, db, config, logger}: IObjectValidatorModules,
+  _topic: GossipTopic,
+  signedBlock: phase0.SignedBeaconBlock
+): Promise<void> {
+  try {
+    await validateGossipBlock(config, chain, db, {
+      signedBlock,
+      reprocess: false,
+      prefinalized: false,
+      validSignatures: false,
+      validProposerSignature: false,
+    });
+    logger.debug("gossip - Block - accept", {
+      root: toHexString(config.types.phase0.BeaconBlock.hashTreeRoot(signedBlock.message)),
+      slot: signedBlock.message.slot,
+    });
+  } catch (e) {
+    if (!(e instanceof BlockError)) {
+      logger.error("Gossip block validation threw a non-BlockError", e);
+      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
+    }
+
+    switch (e.type.code) {
+      case BlockErrorCode.PROPOSAL_SIGNATURE_INVALID:
+      case BlockErrorCode.INCORRECT_PROPOSER:
+      case BlockErrorCode.KNOWN_BAD_BLOCK:
+        logger.debug("gossip - Block - reject", e.type);
+        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
+
+      case BlockErrorCode.FUTURE_SLOT:
+      case BlockErrorCode.PARENT_UNKNOWN: // IGNORE
+        chain.receiveBlock(signedBlock);
+      /** eslit-disable-next-line no-fallthrough */
+      case BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT:
+      case BlockErrorCode.REPEAT_PROPOSAL:
+      default:
+        logger.debug("gossip - Block - ignore", e.type as Json);
+        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
+    }
+  }
+}

--- a/packages/lodestar/src/network/gossip/validatorFns/index.ts
+++ b/packages/lodestar/src/network/gossip/validatorFns/index.ts
@@ -1,0 +1,16 @@
+import {GossipType} from "../interface";
+import {validateAggregatedAttestation} from "./aggregatedAttestation";
+import {validateCommitteeAttestation} from "./attestation";
+import {validateAttesterSlashing} from "./attesterSlashing";
+import {validateBeaconBlock} from "./block";
+import {validateProposerSlashing} from "./proposerSlashing";
+import {validateVoluntaryExit} from "./voluntaryExit";
+
+export const objectValidatorFns = {
+  [GossipType.beacon_block]: validateBeaconBlock,
+  [GossipType.beacon_aggregate_and_proof]: validateCommitteeAttestation,
+  [GossipType.beacon_attestation]: validateAggregatedAttestation,
+  [GossipType.voluntary_exit]: validateVoluntaryExit,
+  [GossipType.proposer_slashing]: validateProposerSlashing,
+  [GossipType.attester_slashing]: validateAttesterSlashing,
+};

--- a/packages/lodestar/src/network/gossip/validatorFns/proposerSlashing.ts
+++ b/packages/lodestar/src/network/gossip/validatorFns/proposerSlashing.ts
@@ -1,0 +1,33 @@
+import {ERR_TOPIC_VALIDATOR_IGNORE, ERR_TOPIC_VALIDATOR_REJECT} from "libp2p-gossipsub/src/constants";
+import {phase0} from "@chainsafe/lodestar-types";
+import {validateGossipProposerSlashing} from "../../../chain/validation";
+import {ProposerSlashingError, ProposerSlashingErrorCode} from "../../../chain/errors";
+import {IObjectValidatorModules, GossipTopic} from "../interface";
+import {GossipValidationError} from "../errors";
+
+export async function validateProposerSlashing(
+  {chain, db, config, logger}: IObjectValidatorModules,
+  _topic: GossipTopic,
+  proposerSlashing: phase0.ProposerSlashing
+): Promise<void> {
+  try {
+    await validateGossipProposerSlashing(config, chain, db, proposerSlashing);
+    logger.debug("gossip - ProposerSlashing - accept");
+  } catch (e) {
+    if (!(e instanceof ProposerSlashingError)) {
+      logger.error("Gossip proposer slashing validation threw a non-ProposerSlashingError", e);
+      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
+    }
+
+    switch (e.type.code) {
+      case ProposerSlashingErrorCode.INVALID_SLASHING:
+        logger.debug("gossip - ProposerSlashing - reject", e.type);
+        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
+
+      case ProposerSlashingErrorCode.SLASHING_ALREADY_EXISTS:
+      default:
+        logger.debug("gossip - ProposerSlashing - ignore", e.type);
+        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
+    }
+  }
+}

--- a/packages/lodestar/src/network/gossip/validatorFns/voluntaryExit.ts
+++ b/packages/lodestar/src/network/gossip/validatorFns/voluntaryExit.ts
@@ -1,0 +1,33 @@
+import {ERR_TOPIC_VALIDATOR_IGNORE, ERR_TOPIC_VALIDATOR_REJECT} from "libp2p-gossipsub/src/constants";
+import {phase0} from "@chainsafe/lodestar-types";
+import {validateGossipVoluntaryExit} from "../../../chain/validation";
+import {VoluntaryExitError, VoluntaryExitErrorCode} from "../../../chain/errors";
+import {IObjectValidatorModules, GossipTopic} from "../interface";
+import {GossipValidationError} from "../errors";
+
+export async function validateVoluntaryExit(
+  {chain, db, config, logger}: IObjectValidatorModules,
+  _topic: GossipTopic,
+  voluntaryExit: phase0.SignedVoluntaryExit
+): Promise<void> {
+  try {
+    await validateGossipVoluntaryExit(config, chain, db, voluntaryExit);
+    logger.debug("gossip - VoluntaryExit - accept");
+  } catch (e) {
+    if (!(e instanceof VoluntaryExitError)) {
+      logger.error("Gossip voluntary exit validation threw a non-VoluntaryExitError", e);
+      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
+    }
+
+    switch (e.type.code) {
+      case VoluntaryExitErrorCode.INVALID_EXIT:
+        logger.debug("gossip - VoluntaryExit - reject", e.type);
+        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
+
+      case VoluntaryExitErrorCode.EXIT_ALREADY_EXISTS:
+      default:
+        logger.debug("gossip - VoluntaryExit - ignore", e.type);
+        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
+    }
+  }
+}


### PR DESCRIPTION
**Motivation**

Preparing to develop https://github.com/ChainSafe/lodestar/issues/2265 it is much more convenient to modularize these validation functions in multiple files. To reduce the diff of an upcoming PR with sensitive logic I'm doing this bigger change in a previous single purpose PR

**Description**

Move `packages/lodestar/src/network/gossip/validator.ts` functions to smaller files

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->
