### PR TITLE
Move runStateTransition sleep

### DIFF
--- a/packages/lodestar/src/chain/blocks/process.ts
+++ b/packages/lodestar/src/chain/blocks/process.ts
@@ -1,5 +1,6 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
+import {sleep} from "@chainsafe/lodestar-utils";
 import {ChainEventEmitter} from "../emitter";
 import {IBlockJob, IChainSegmentJob} from "../interface";
 import {runStateTransition} from "./stateTransition";
@@ -146,6 +147,8 @@ export async function processChainSegment({
           validSignatures: true,
         });
         importedBlocks++;
+        // this avoids keeping our node busy processing blocks
+        await sleep(0);
       }
     } catch (e) {
       if (e instanceof RegenError) {

--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -156,7 +156,5 @@ export async function runStateTransition(
   emitBlockEvent(emitter, job, postState);
   emitForkChoiceHeadEvents(emitter, forkChoice, forkChoice.getHead(), oldHead);
 
-  // this avoids keeping our node busy processing blocks
-  await sleep(0);
   return postState;
 }

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -6,6 +6,7 @@ import {
   computeStartSlotAtEpoch,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
+import {sleep} from "@chainsafe/lodestar-utils";
 
 import {CheckpointStateCache, StateContextCache} from "../stateCache";
 import {ChainEventEmitter} from "../emitter";
@@ -189,6 +190,8 @@ export class StateRegenerator implements IStateRegenerator {
           validSignatures: true,
           validProposerSignature: true,
         });
+        // this avoids keeping our node busy processing blocks
+        await sleep(0);
       } catch (e) {
         throw new RegenError({
           code: RegenErrorCode.STATE_TRANSITION_ERROR,


### PR DESCRIPTION
**Motivation**

With #2275, iterating through jobs in the queue yield to the event loop (with a `sleep(0)`).
This PR explores moving the `runStateTransition` `sleep(0)` call into the async iterators that call it.
This may be preferable for a few reasons:
- More abstractly, yielding to the event loop is something that should be done when async iterating over CPU-heavy operations, between iterations. It's more clear to put the `sleep(0)` in the async iteration, since it can be argued that the iteration over many values is the reason for needing the `sleep(0)` in the first place.
- Possibly resolves #2179. As seen in #2184, the interaction in `runStateTransition` between the logic and `sleep` cause states to occasionally be retained. By removing the `sleep`, this PR might resolve the issue. Further testing required.