### PR TITLE
Fix queue metrics error

### DIFF
--- a/packages/lodestar/src/util/queue/metrics.ts
+++ b/packages/lodestar/src/util/queue/metrics.ts
@@ -1,4 +1,4 @@
-import {CollectFunction, Gauge, Histogram} from "prom-client";
+import {Gauge, Histogram} from "prom-client";
 import {IBeaconMetrics} from "../../metrics";
 
 export type QueueMetricsOpts = {
@@ -29,9 +29,9 @@ export function createQueueMetrics(
       name: `${prefix}_length`,
       help: `Count of total queue length of ${prefix}`,
       registers: [metrics.registry],
-      collect: ((lengthGauge: Gauge<string>) => {
-        lengthGauge.set(hooks.getQueueLength());
-      }) as CollectFunction<Gauge<string>>,
+      collect() {
+        this.set(hooks.getQueueLength());
+      },
     }),
 
     droppedJobs: new Gauge({


### PR DESCRIPTION
**Motivation**

Running current master, noticed metrics are erroring

**Description**

Fixes broken metrics

**Steps to test or reproduce**
```bash
lodestar beacon --network pyrmont
curl localhost:8080/metrics
```
```
TypeError: Cannot read property 'set' of undefined                                                                                       
    at Gauge.collect (/Code/lodestar/packages/lodestar/src/util/queue/metrics.ts:33:21)                                     
    at Gauge.get (/Code/lodestar/node_modules/prom-client/lib/gauge.js:86:19)                                               
    at Registry.getMetricAsPrometheusString (/Code/lodestar/node_modules/prom-client/lib/registry.js:26:29)                 
    at Registry.metrics (/Code/lodestar/node_modules/prom-client/lib/registry.js:70:23)                                     
    at HttpMetricsServer.onRequest (/Code/lodestar/packages/lodestar/src/metrics/server/http.ts:48:64)
    at Server.emit (events.js:315:20)                               
    at Server.EventEmitter.emit (domain.js:483:12)                                                                                       
    at parserOnIncoming (_http_server.js:790:12)                                                                                         
    at HTTPParser.parserOnHeadersComplete (_http_common.js:119:17)