### PR TITLE
logger time format in milli seconds - YYYY-MMM-DD HH:mm:ss.SSS e.g. 2021-Mar-27 10:17:14.325

### DIFF
--- a/packages/utils/src/logger/format.ts
+++ b/packages/utils/src/logger/format.ts
@@ -30,7 +30,7 @@ export function getFormat(opts: ILoggerOptions): Format {
 
 function humanReadableLogFormat(opts: ILoggerOptions): Format {
   return format.combine(
-    ...(opts.hideTimestamp ? [] : [format.timestamp({format: "YYYY-MM-DD HH:mm:ss"})]),
+    ...(opts.hideTimestamp ? [] : [format.timestamp({format: "YYYY-MMM-DD HH:mm:ss.SSS"})]),
     format.colorize(),
     format.printf(humanReadableTemplateFn)
   );

--- a/packages/utils/src/logger/format.ts
+++ b/packages/utils/src/logger/format.ts
@@ -30,7 +30,7 @@ export function getFormat(opts: ILoggerOptions): Format {
 
 function humanReadableLogFormat(opts: ILoggerOptions): Format {
   return format.combine(
-    ...(opts.hideTimestamp ? [] : [format.timestamp({format: "YYYY-MMM-DD HH:mm:ss.SSS"})]),
+    ...(opts.hideTimestamp ? [] : [format.timestamp({format: "MMM-DD HH:mm:ss.SSS"})]),
     format.colorize(),
     format.printf(humanReadableTemplateFn)
   );


### PR DESCRIPTION
**Motivation**
To change human readable time format in the winston logger to YYYY-MMM-DD HH:mm:ss.SSS e.g. 2021-Mar-27 10:17:14.325
<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**
changes the format string in format.timestamp 
<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #2231


