### PR TITLE
Remove winston `handleExceptions: true` option

### DIFF
--- a/packages/utils/src/logger/transport.ts
+++ b/packages/utils/src/logger/transport.ts
@@ -17,14 +17,12 @@ export function fromTransportOpts(transportOpts: TransportOpts): TransportStream
       return new transports.Console({
         debugStdout: true,
         level: transportOpts.level,
-        handleExceptions: true,
       });
 
     case TransportType.file:
       return new transports.File({
         level: transportOpts.level,
         filename: transportOpts.filename,
-        handleExceptions: true,
       });
   }
 }


### PR DESCRIPTION
We create many winston child loggers. Winston seems to register new listeners to process everytime we do so triggering
```
(node:15628) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 uncaughtException listeners added to [process]. Use emitter.setMaxListeners() to increase limit
```
I've added a logger to the process.on function and got this trace many times
```
    at ExceptionHandler.handle (/home/lion/Code/eth2.0/lodestar/node_modules/winston/lib/winston/exception-handler.js:51:15)
    at DerivedLogger.add (/home/lion/Code/eth2.0/lodestar/node_modules/winston/lib/winston/logger.js:360:23)
    at /home/lion/Code/eth2.0/lodestar/node_modules/winston/lib/winston/logger.js:118:44
    at Array.forEach (<anonymous>)
    at DerivedLogger.configure (/home/lion/Code/eth2.0/lodestar/node_modules/winston/lib/winston/logger.js:118:18)
    at new Logger (/home/lion/Code/eth2.0/lodestar/node_modules/winston/lib/winston/logger.js:42:10)
    at new DerivedLogger (/home/lion/Code/eth2.0/lodestar/node_modules/winston/lib/winston/create-logger.js:44:7)
    at module.exports (/home/lion/Code/eth2.0/lodestar/node_modules/winston/lib/winston/create-logger.js:48:18)
    at new WinstonLogger (/home/lion/Code/eth2.0/lodestar/packages/utils/src/logger/winston.ts:25:20)
```