### PR TITLE
Lazy load lockfile library

### DIFF
--- a/packages/cli/src/util/lockfile.ts
+++ b/packages/cli/src/util/lockfile.ts
@@ -1,0 +1,17 @@
+type Lockfile = {
+  lockSync(path: string): void;
+  unlockSync(path: string): void;
+};
+
+let lockFile: Lockfile | null = null;
+
+/**
+ * When lockfile it's required it registers listeners to process
+ * Since it's only used by the validator client, require lazily to not pollute
+ * beacon_node client context
+ */
+export function getLockFile(): Lockfile {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+  if (!lockFile) lockFile = require("lockfile") as Lockfile;
+  return lockFile;
+}

--- a/packages/cli/src/validatorDir/ValidatorDir.ts
+++ b/packages/cli/src/validatorDir/ValidatorDir.ts
@@ -1,12 +1,13 @@
 import fs from "fs";
 import path from "path";
-import lockFile from "lockfile";
 import bls, {SecretKey} from "@chainsafe/bls";
 import {Keystore} from "@chainsafe/bls-keystore";
 import {phase0} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {YargsError, readValidatorPassphrase} from "../util";
 import {decodeEth1TxData} from "../depositContract/depositData";
+import {add0xPrefix} from "../util/format";
+import {getLockFile} from "../util/lockfile";
 import {
   VOTING_KEYSTORE_FILE,
   WITHDRAWAL_KEYSTORE_FILE,
@@ -15,7 +16,6 @@ import {
   ETH1_DEPOSIT_AMOUNT_FILE,
   ETH1_DEPOSIT_TX_HASH_FILE,
 } from "./paths";
-import {add0xPrefix} from "../util/format";
 
 export interface IValidatorDirOptions {
   force: boolean;
@@ -65,6 +65,7 @@ export class ValidatorDir {
 
     if (!fs.existsSync(this.dir)) throw new YargsError(`Validator directory ${this.dir} does not exist`);
 
+    const lockFile = getLockFile();
     try {
       lockFile.lockSync(this.lockfilePath);
     } catch (e) {
@@ -80,7 +81,7 @@ export class ValidatorDir {
    * Removes the lockfile associated with this validator dir
    */
   close(): void {
-    lockFile.unlockSync(this.lockfilePath);
+    getLockFile().unlockSync(this.lockfilePath);
   }
 
   /**


### PR DESCRIPTION
**Motivation**

`lockfile` registers many listeners to process right on require. We only use lockfile on the validator client so it doesn't feel clean to pollute the process with un-used listeners when running the beacon cmd.

**Description**

Lazy require the library. Trade-off is no types, but the function signatures are extremely simple. Since the lib is used in the constructor using `await import()` is not nice.

```
Trace: process.on() call with [ 'SIGABRT', [Function: listener] ]
Trace: process.on() call with [ 'SIGALRM', [Function: listener] ]
Trace: process.on() call with [ 'SIGHUP', [Function: listener] ]
Trace: process.on() call with [ 'SIGINT', [Function: listener] ]
Trace: process.on() call with [ 'SIGTERM', [Function: listener] ]
Trace: process.on() call with [ 'SIGVTALRM', [Function: listener] ]
Trace: process.on() call with [ 'SIGXCPU', [Function: listener] ]
Trace: process.on() call with [ 'SIGXFSZ', [Function: listener] ]
Trace: process.on() call with [ 'SIGUSR2', [Function: listener] ]
Trace: process.on() call with [ 'SIGTRAP', [Function: listener] ]
Trace: process.on() call with [ 'SIGSYS', [Function: listener] ]
Trace: process.on() call with [ 'SIGQUIT', [Function: listener] ]
Trace: process.on() call with [ 'SIGIOT', [Function: listener] ]
Trace: process.on() call with [ 'SIGIO', [Function: listener] ]
Trace: process.on() call with [ 'SIGPOLL', [Function: listener] ]
Trace: process.on() call with [ 'SIGPWR', [Function: listener] ]
Trace: process.on() call with [ 'SIGSTKFLT', [Function: listener] ]
Trace: process.on() call with [ 'SIGUNUSED', [Function: listener] ]
    at process.on (/home/lion/Code/eth2.0/lodestar/packages/cli/lib/index.js:5:11)
    at /home/lion/Code/eth2.0/lodestar/node_modules/signal-exit/index.js:128:15
    at Array.filter (<anonymous>)
    at load (/home/lion/Code/eth2.0/lodestar/node_modules/signal-exit/index.js:126:21)
    at module.exports (/home/lion/Code/eth2.0/lodestar/node_modules/signal-exit/index.js:36:5)
    at Object.<anonymous> (/home/lion/Code/eth2.0/lodestar/node_modules/lockfile/lockfile.js:34:1)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)

```
