### PR TITLE
Add state cache basic metrics

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -87,8 +87,8 @@ export class BeaconChain implements IBeaconChain {
       genesisTime: this.genesisTime,
       signal: this.abortController.signal,
     });
-    this.stateCache = new StateContextCache();
-    this.checkpointStateCache = new CheckpointStateCache(this.config);
+    this.stateCache = new StateContextCache({metrics});
+    this.checkpointStateCache = new CheckpointStateCache({metrics, config});
     const cachedState = restoreStateCaches(config, this.stateCache, this.checkpointStateCache, anchorState);
     this.forkChoice = new LodestarForkChoice({
       config,

--- a/packages/lodestar/src/metrics/beacon.ts
+++ b/packages/lodestar/src/metrics/beacon.ts
@@ -45,6 +45,8 @@ export class BeaconMetrics extends Metrics implements IBeaconMetrics {
   peersTotalUniqueConnected: Gauge<string>;
   gossipMeshPeersByType: Gauge<string>;
   gossipMeshPeersByBeaconAttestationSubnet: Gauge<string>;
+  stateCacheGetTotal: Gauge<string>;
+  stateCacheHitTotal: Gauge<string>;
 
   private lodestarVersion: Gauge<string>;
   private logger: ILogger;
@@ -245,6 +247,17 @@ export class BeaconMetrics extends Metrics implements IBeaconMetrics {
       name: "lodestar_gossip_mesh_peers_by_beacon_attestation_subnet",
       help: "Number of connected mesh peers per beacon attestation subnet",
       labelNames: ["subnet"],
+      registers,
+    });
+
+    this.stateCacheGetTotal = new Gauge({
+      name: "lodestar_state_cache_get_total",
+      help: "Total number of states requested from the cache",
+      registers,
+    });
+    this.stateCacheHitTotal = new Gauge({
+      name: "lodestar_state_cache_hit_total",
+      help: "Total number of hits to the state cache",
       registers,
     });
 

--- a/packages/lodestar/src/metrics/interface.ts
+++ b/packages/lodestar/src/metrics/interface.ts
@@ -140,6 +140,9 @@ export interface IBeaconMetrics extends IMetrics {
   gossipMeshPeersByType: Gauge<string>;
   /** Gossip mesh peer count by beacon attestation subnet */
   gossipMeshPeersByBeaconAttestationSubnet: Gauge<string>;
+
+  stateCacheGetTotal: Gauge<string>;
+  stateCacheHitTotal: Gauge<string>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/packages/lodestar/test/unit/chain/stateCache/stateContextCache.test.ts
+++ b/packages/lodestar/test/unit/chain/stateCache/stateContextCache.test.ts
@@ -12,7 +12,7 @@ describe("StateContextCache", function () {
 
   beforeEach(function () {
     // max 2 items
-    cache = new StateContextCache(2);
+    cache = new StateContextCache({}, {maxStates: 2});
     const state1 = generateCachedState({slot: 0});
     key1 = state1.hashTreeRoot();
     state1.epochCtx.currentShuffling = {epoch: 0, activeIndices: [], shuffling: [], committees: []};

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -65,8 +65,8 @@ export class MockBeaconChain implements IBeaconChain {
       emitter: this.emitter,
       signal: this.abortController.signal,
     });
-    this.stateCache = new StateContextCache();
-    this.checkpointStateCache = new CheckpointStateCache(this.config);
+    this.stateCache = new StateContextCache({});
+    this.checkpointStateCache = new CheckpointStateCache({config});
     this.pendingBlocks = new BlockPool({
       config: this.config,
     });


### PR DESCRIPTION
**Motivation**

See https://github.com/ChainSafe/lodestar/issues/2153

**Description**

Adds basic metrics for the state cache. Total gets + hit, allows to compute frequency, total usage and hit ratio.

Closes https://github.com/ChainSafe/lodestar/issues/2153

