### PR TITLE
Prevent copying .git to the final layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ COPY . .
 RUN yarn install --non-interactive --frozen-lockfile
 
 RUN node ./scripts/getGitData /usr/app/.git-data.json
+# Prevent copying .git to the final layer
+RUN rm -r .git
 
 # Copy built src + node_modules to a new layer to prune unnecessary fs
 # Previous layer weights 7.25GB, while this final 488MB (as of Oct 2020)

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN yarn install --non-interactive --frozen-lockfile --ignore-scripts
 COPY . .
 RUN yarn install --non-interactive --frozen-lockfile
 
-RUN node ./scripts/getGitData /usr/app/.git-data.json
-# Prevent copying .git to the final layer
-RUN rm -r .git
+# rm .git afterwards to prevent copying it to the final layer (~350MB)
+RUN node ./scripts/getGitData /usr/app/.git-data.json && rm -r .git
+
 
 # Copy built src + node_modules to a new layer to prune unnecessary fs
 # Previous layer weights 7.25GB, while this final 488MB (as of Oct 2020)


### PR DESCRIPTION
Unnecessary bloats the size of the final layer

```
  517.8 MiB [##########] /node_modules
  389.2 MiB [#######   ] /.git
   29.2 MiB [          ] /packages
  568.0 KiB [          ]  yarn.lock
  168.0 KiB [          ] /audits
```