### PR TITLE
Explicitly convert checkpoint subtrees to struct

### DIFF
--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -280,6 +280,8 @@ export class ForkChoice implements IForkChoice {
         });
       }
       if (state.currentJustifiedCheckpoint.epoch > this.fcStore.bestJustifiedCheckpoint.epoch) {
+        // `valueOf` coerses the checkpoint, which may be tree-backed, into a javascript object
+        // See https://github.com/ChainSafe/lodestar/issues/2258
         this.updateBestJustified(state.currentJustifiedCheckpoint.valueOf() as phase0.Checkpoint, justifiedBalances);
       }
       if (this.shouldUpdateJustifiedCheckpoint(state)) {
@@ -290,6 +292,8 @@ export class ForkChoice implements IForkChoice {
 
     // Update finalized checkpoint.
     if (state.finalizedCheckpoint.epoch > this.fcStore.finalizedCheckpoint.epoch) {
+      // `valueOf` coerses the checkpoint, which may be tree-backed, into a javascript object
+      // See https://github.com/ChainSafe/lodestar/issues/2258
       this.fcStore.finalizedCheckpoint = state.finalizedCheckpoint.valueOf() as phase0.Checkpoint;
       const finalizedSlot = computeStartSlotAtEpoch(this.config, this.fcStore.finalizedCheckpoint.epoch);
 
@@ -316,6 +320,8 @@ export class ForkChoice implements IForkChoice {
           error: new Error("No validator balances supplied"),
         });
       }
+      // `valueOf` coerses the checkpoint, which may be tree-backed, into a javascript object
+      // See https://github.com/ChainSafe/lodestar/issues/2258
       this.updateJustified(state.currentJustifiedCheckpoint.valueOf() as phase0.Checkpoint, justifiedBalances);
     }
 

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -280,7 +280,7 @@ export class ForkChoice implements IForkChoice {
         });
       }
       if (state.currentJustifiedCheckpoint.epoch > this.fcStore.bestJustifiedCheckpoint.epoch) {
-        this.updateBestJustified(state.currentJustifiedCheckpoint, justifiedBalances);
+        this.updateBestJustified(state.currentJustifiedCheckpoint.valueOf() as phase0.Checkpoint, justifiedBalances);
       }
       if (this.shouldUpdateJustifiedCheckpoint(state)) {
         // wait to update until after finalized checkpoint is set
@@ -290,7 +290,7 @@ export class ForkChoice implements IForkChoice {
 
     // Update finalized checkpoint.
     if (state.finalizedCheckpoint.epoch > this.fcStore.finalizedCheckpoint.epoch) {
-      this.fcStore.finalizedCheckpoint = state.finalizedCheckpoint;
+      this.fcStore.finalizedCheckpoint = state.finalizedCheckpoint.valueOf() as phase0.Checkpoint;
       const finalizedSlot = computeStartSlotAtEpoch(this.config, this.fcStore.finalizedCheckpoint.epoch);
 
       if (
@@ -316,7 +316,7 @@ export class ForkChoice implements IForkChoice {
           error: new Error("No validator balances supplied"),
         });
       }
-      this.updateJustified(state.currentJustifiedCheckpoint, justifiedBalances);
+      this.updateJustified(state.currentJustifiedCheckpoint.valueOf() as phase0.Checkpoint, justifiedBalances);
     }
 
     const targetSlot = computeStartSlotAtEpoch(this.config, computeEpochAtSlot(this.config, block.slot));


### PR DESCRIPTION
**Motivation**

See #2258 

**Description**

Resolves #2258
(Along with https://github.com/ChainSafe/lodestar/blob/master/packages/beacon-state-transition/src/phase0/fast/util/flat.ts#L10 tweaked in #2289)

Inspecting a heap snapshot, the only remaining subtrees are in the fork choice, fixed here.