### PR TITLE
Improve BLOCK_ERROR_PARENT_UNKNOWN log

### DIFF
--- a/packages/lodestar/src/chain/validation/block.ts
+++ b/packages/lodestar/src/chain/validation/block.ts
@@ -59,7 +59,7 @@ export async function validateGossipBlock(
   } catch (e) {
     throw new BlockError({
       code: BlockErrorCode.PARENT_UNKNOWN,
-      parentRoot: block.message.parentRoot,
+      parentRoot: block.message.parentRoot.valueOf() as Uint8Array,
       job: blockJob,
     });
   }


### PR DESCRIPTION
**Motivation**

Accessing a root from either SignedBeaconBlock or BeaconState is actually a tree, we need to use `valueOf()` to get a real Uint8Array which is logger friendly

**Description**

Closes #2251

