### PR TITLE
Update IBeaconConfig#getTypes

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,12 +1,5 @@
 import {GENESIS_SLOT, IBeaconParams} from "@chainsafe/lodestar-params";
-import {
-  createIBeaconSSZTypes,
-  IAltairSSZTypes,
-  IPhase0SSZTypes,
-  IPhase1SSZTypes,
-  Slot,
-  Version,
-} from "@chainsafe/lodestar-types";
+import {createIBeaconSSZTypes, IAllForksSSZTypes, Slot, Version} from "@chainsafe/lodestar-types";
 
 import {IBeaconConfig, IForkInfo, IForkName} from "./interface";
 
@@ -54,8 +47,8 @@ export function createIBeaconConfig(params: IBeaconParams): IBeaconConfig {
         return params.PHASE_1_FORK_VERSION;
       }
     },
-    getTypes(slot: Slot): IPhase0SSZTypes | IAltairSSZTypes | IPhase1SSZTypes {
-      return types[this.getForkName(slot)];
+    getTypes(slot: Slot): IAllForksSSZTypes {
+      return types[this.getForkName(slot)] as IAllForksSSZTypes;
     },
   };
 }

--- a/packages/config/src/interface.ts
+++ b/packages/config/src/interface.ts
@@ -1,12 +1,5 @@
 import {IBeaconParams} from "@chainsafe/lodestar-params";
-import {
-  IBeaconSSZTypes,
-  IAltairSSZTypes,
-  IPhase0SSZTypes,
-  IPhase1SSZTypes,
-  Slot,
-  Version,
-} from "@chainsafe/lodestar-types";
+import {IAllForksSSZTypes, IBeaconSSZTypes, Slot, Version} from "@chainsafe/lodestar-types";
 
 export type IForkName = "phase0" | "altair" | "phase1";
 
@@ -31,5 +24,5 @@ export interface IBeaconConfig {
   /**
    * Get SSZ types by hard-fork
    */
-  getTypes(slot: Slot): IPhase0SSZTypes | IAltairSSZTypes | IPhase1SSZTypes;
+  getTypes(slot: Slot): IAllForksSSZTypes;
 }

--- a/packages/types/src/allForks/index.ts
+++ b/packages/types/src/allForks/index.ts
@@ -1,10 +1,28 @@
-// Re-export union types for types that are _known_ to differ
+import {ContainerType} from "@chainsafe/ssz";
 
 import * as phase0 from "../phase0";
 import * as altair from "../altair";
 import * as phase1 from "../phase1";
 
+// Re-export union types for types that are _known_ to differ
+
 export type BeaconBlockBody = phase0.BeaconBlockBody | altair.BeaconBlockBody | phase1.BeaconBlockBody;
 export type BeaconBlock = phase0.BeaconBlock | altair.BeaconBlock | phase1.BeaconBlock;
 export type SignedBeaconBlock = phase0.SignedBeaconBlock | altair.SignedBeaconBlock | phase1.SignedBeaconBlock;
 export type BeaconState = phase0.BeaconState | altair.BeaconState | phase1.BeaconState;
+
+// The difference between IAllSSZTypes and IAllForksSSZTypes:
+// IAllSSZTypes["BeaconState"] = ContainerType<phase0.BeaconState & altair.BeaconState & phase1.BeaconState>
+// IAllForksSSZTypes["BeaconState"] = ContainerType<phase0.BeaconState | altair.BeaconState | phase1.BeaconState>
+
+type IAllSSZTypes = phase0.IPhase0SSZTypes | altair.IAltairSSZTypes | phase1.IPhase1SSZTypes;
+
+export type IAllForksSSZTypes = Omit<
+  IAllSSZTypes,
+  "BeaconBlockBody" | "BeaconBlock" | "SignedBeaconBlock" | "BeaconState"
+> & {
+  BeaconBlockBody: ContainerType<BeaconBlockBody>;
+  BeaconBlock: ContainerType<BeaconBlock>;
+  SignedBeaconBlock: ContainerType<SignedBeaconBlock>;
+  BeaconState: ContainerType<BeaconState>;
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -15,6 +15,8 @@ export * as phase1 from "./phase1";
 
 // Export union types
 export * as allForks from "./allForks";
+// Export IAllForksSSZTypes
+export {IAllForksSSZTypes} from "./allForks";
 
 // Export non-namespaced primitive types
 export * from "./primitive/types";


### PR DESCRIPTION
**Motivation**

Currently, we run into an annoying type situation when trying to perform ssz operations on types from a fork known only at runtime.

eg:
```ts
const block: allForks.BeaconBlock = ...;

config.getTypes(block.slot).BeaconBlock.hashTreeRoot(block);
//                                                   ^^^^^
// Argument of type 'allForks.BeaconBlock' is not assignable to parameter of type 'phase0.BeaconBlock & altair.BeaconBlock & phase1.BeaconBlock'.
```

`getTypes` returns `IPhase0SSZTypes | IAltairSSZTypes ...`.
This means `getTypes().BeaconBlock` resolves to `ContainerType<phase0.BeaconBlock> | ContainerType<altair.BeaconBlock> ...`,
which can be further resolved to `ContainerType<phase0.BeaconBlock & altair.BeaconBlock ...>`.
This intersection type is _not_ what we want, and the way to resolve the issue is with an additional typecast.

**Description**

The `IPhase0SSZTypes | IAltairSSZTypes ...` return type has been replaced with `IAllForksSSZTypes`, which has relevant types replaced with their `allForks` variant.

This allows for code like the example above to work without additional casting.