### PR TITLE
Fix winston logger and tests

### DIFF
--- a/packages/cli/src/util/logger.ts
+++ b/packages/cli/src/util/logger.ts
@@ -1,4 +1,4 @@
-import {ILogger, LogLevel, TransportType, WinstonLogger} from "@chainsafe/lodestar-utils";
+import {ILogger, LogLevel, TransportType, TransportOpts, WinstonLogger} from "@chainsafe/lodestar-utils";
 
 export function errorLogger(): ILogger {
   return new WinstonLogger({level: LogLevel.error});
@@ -8,8 +8,10 @@ export function errorLogger(): ILogger {
  * Setup a CLI logger, common for beacon, validator and dev commands
  */
 export function getCliLogger(args: {logLevel?: LogLevel; logLevelFile?: LogLevel}, paths: {logFile?: string}): ILogger {
-  return new WinstonLogger({level: args.logLevel}, [
-    {type: TransportType.console},
-    ...(paths.logFile ? [{type: TransportType.file, filename: paths.logFile, level: args.logLevelFile}] : []),
-  ]);
+  const transports: TransportOpts[] = [{type: TransportType.console}];
+  if (paths.logFile) {
+    transports.push({type: TransportType.file, filename: paths.logFile, level: args.logLevelFile});
+  }
+
+  return new WinstonLogger({level: args.logLevel}, transports);
 }

--- a/packages/lodestar/test/utils/logger.ts
+++ b/packages/lodestar/test/utils/logger.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
-import {WinstonLogger, LogLevel, TransportType} from "@chainsafe/lodestar-utils";
+import {WinstonLogger, LogLevel, TransportType, TransportOpts} from "@chainsafe/lodestar-utils";
 export {LogLevel};
 
 /**
@@ -11,10 +11,12 @@ export {LogLevel};
  * ```
  */
 export function testLogger(module?: string, defaultLogLevel = LogLevel.error, logFile?: string): WinstonLogger {
-  return new WinstonLogger({level: getLogLevelFromEnvs() || defaultLogLevel, module}, [
-    {type: TransportType.console},
-    ...(logFile ? [{type: TransportType.file, filename: logFile, level: LogLevel.debug}] : []),
-  ]);
+  const transports: TransportOpts[] = [{type: TransportType.console}];
+  if (logFile) {
+    transports.push({type: TransportType.file, filename: logFile, level: LogLevel.debug});
+  }
+
+  return new WinstonLogger({level: getLogLevelFromEnvs() || defaultLogLevel, module}, transports);
 }
 
 function getLogLevelFromEnvs(): LogLevel | null {

--- a/packages/utils/src/logger/interface.ts
+++ b/packages/utils/src/logger/interface.ts
@@ -13,6 +13,15 @@ export enum LogLevel {
   silly = "silly",
 }
 
+export const logLevelNum: {[K in LogLevel]: number} = {
+  [LogLevel.error]: 0,
+  [LogLevel.warn]: 1,
+  [LogLevel.info]: 2,
+  [LogLevel.verbose]: 3,
+  [LogLevel.debug]: 4,
+  [LogLevel.silly]: 5,
+};
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const LogLevels = Object.values(LogLevel);
 

--- a/packages/utils/src/logger/transport.ts
+++ b/packages/utils/src/logger/transport.ts
@@ -5,11 +5,13 @@ import TransportStream from "winston-transport";
 export enum TransportType {
   console = "console",
   file = "file",
+  stream = "stream",
 }
 
 export type TransportOpts =
   | {type: TransportType.console; level?: LogLevel}
-  | {type: TransportType.file; level?: LogLevel; filename: string};
+  | {type: TransportType.file; level?: LogLevel; filename: string}
+  | {type: TransportType.stream; level?: LogLevel; stream: NodeJS.WritableStream};
 
 export function fromTransportOpts(transportOpts: TransportOpts): TransportStream {
   switch (transportOpts.type) {
@@ -24,6 +26,13 @@ export function fromTransportOpts(transportOpts: TransportOpts): TransportStream
       return new transports.File({
         level: transportOpts.level,
         filename: transportOpts.filename,
+        handleExceptions: true,
+      });
+
+    case TransportType.stream:
+      return new transports.Stream({
+        level: transportOpts.level,
+        stream: transportOpts.stream,
         handleExceptions: true,
       });
   }


### PR DESCRIPTION
**Motivation**

- Log to file in tests is not as stable as logging to stream. Tests may randomly fail. Now they should never fail
- Child logger option parsing did not override the transport default, ignoring the `logger.yyy.level debug` cli options

**Description**

Closes https://github.com/ChainSafe/lodestar/issues/2305
Closes https://github.com/ChainSafe/lodestar/issues/2310
