### PR TITLE
Use `allForks.BeaconState` in `IBeaconChain`

### DIFF
--- a/packages/beacon-state-transition/src/util/balance.ts
+++ b/packages/beacon-state-transition/src/util/balance.ts
@@ -5,7 +5,6 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {allForks, Gwei, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {bigIntMax} from "@chainsafe/lodestar-utils";
-import {phase0} from "../index";
 import {CachedBeaconState} from "../fast";
 import {getCurrentEpoch} from "./epoch";
 import {getActiveValidatorIndices, isActiveValidator} from "./validator";
@@ -52,11 +51,11 @@ export function decreaseBalance(state: allForks.BeaconState, index: ValidatorInd
 /**
  * This method is used to get justified balances from a justified state.
  */
-export function getEffectiveBalances(justifiedState: CachedBeaconState<phase0.BeaconState>): Gwei[] {
-  const justifiedEpoch = justifiedState?.currentShuffling.epoch;
+export function getEffectiveBalances(justifiedState: CachedBeaconState<allForks.BeaconState>): Gwei[] {
+  const justifiedEpoch = justifiedState.currentShuffling.epoch;
   const effectiveBalances: Gwei[] = [];
-  justifiedState?.validators.forEach((v) => {
-    effectiveBalances.push(isActiveValidator(v, justifiedEpoch!) ? v.effectiveBalance : BigInt(0));
+  justifiedState.validators.forEach((v) => {
+    effectiveBalances.push(isActiveValidator(v, justifiedEpoch) ? v.effectiveBalance : BigInt(0));
   });
   return effectiveBalances;
 }

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -3,7 +3,7 @@ import {AbortSignal} from "abort-controller";
 import {TreeBacked} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils";
-import {phase0} from "@chainsafe/lodestar-types";
+import {allForks} from "@chainsafe/lodestar-types";
 import {
   IBeaconDb,
   Eth1Provider,
@@ -32,10 +32,10 @@ export async function initBeaconState(
   db: IBeaconDb,
   logger: ILogger,
   signal: AbortSignal
-): Promise<TreeBacked<phase0.BeaconState>> {
-  async function initFromFile(pathOrUrl: string): Promise<TreeBacked<phase0.BeaconState>> {
+): Promise<TreeBacked<allForks.BeaconState>> {
+  async function initFromFile(pathOrUrl: string): Promise<TreeBacked<allForks.BeaconState>> {
     const anchorState = config.types.phase0.BeaconState.createTreeBackedFromBytes(await downloadOrLoadFile(pathOrUrl));
-    return await initStateFromAnchorState(config, db, logger, anchorState);
+    return await initStateFromAnchorState(config, db, logger, anchorState as TreeBacked<allForks.BeaconState>);
   }
 
   const dbHasSomeState = (await db.stateArchive.lastKey()) != null;

--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import {promisify} from "util";
 import rimraf from "rimraf";
 import {join} from "path";
+import {GENESIS_SLOT} from "@chainsafe/lodestar-params";
 import {BeaconNode, BeaconDb, initStateFromAnchorState, createNodeJsLibp2p, nodeUtils} from "@chainsafe/lodestar";
 import {Validator} from "@chainsafe/lodestar-validator";
 import {LevelDbController} from "@chainsafe/lodestar-db";
@@ -60,9 +61,9 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
       config,
       db,
       logger,
-      config.types.phase0.BeaconState.createTreeBackedFromBytes(
-        await fs.promises.readFile(join(args.rootDir, args.genesisStateFile))
-      )
+      config
+        .getTypes(GENESIS_SLOT)
+        .BeaconState.createTreeBackedFromBytes(await fs.promises.readFile(join(args.rootDir, args.genesisStateFile)))
     );
   } else {
     throw new Error("Unable to start node: no available genesis state");

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -1,4 +1,4 @@
-import {Epoch, Gwei, Slot, ValidatorIndex, phase0} from "@chainsafe/lodestar-types";
+import {Epoch, Gwei, Slot, ValidatorIndex, phase0, allForks} from "@chainsafe/lodestar-types";
 import {IBlockSummary} from "./blockSummary";
 
 export interface IForkChoice {
@@ -49,7 +49,7 @@ export interface IForkChoice {
    * `justifiedBalances` validator balances of justified checkpoint which is updated synchronously.
    * This ensures that the forkchoice is never out of sync.
    */
-  onBlock(block: phase0.BeaconBlock, state: phase0.BeaconState, justifiedBalances?: Gwei[]): void;
+  onBlock(block: allForks.BeaconBlock, state: allForks.BeaconState, justifiedBalances?: Gwei[]): void;
   /**
    * Register `attestation` with the fork choice DAG so that it may influence future calls to `getHead`.
    *

--- a/packages/lodestar/src/api/impl/beacon/state/interface.ts
+++ b/packages/lodestar/src/api/impl/beacon/state/interface.ts
@@ -1,9 +1,9 @@
-import {BLSPubkey, CommitteeIndex, Epoch, Root, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {allForks, BLSPubkey, CommitteeIndex, Epoch, Root, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
 
 export interface IBeaconStateApi {
   getStateRoot(stateId: StateId): Promise<Root | null>;
-  getState(stateId: StateId): Promise<phase0.BeaconState | null>;
+  getState(stateId: StateId): Promise<allForks.BeaconState | null>;
   getStateFinalityCheckpoints(stateId: StateId): Promise<phase0.FinalityCheckpoints | null>;
   getStateValidators(stateId: StateId, filters?: IValidatorFilters): Promise<phase0.ValidatorResponse[]>;
   getStateValidator(

--- a/packages/lodestar/src/api/impl/beacon/state/state.ts
+++ b/packages/lodestar/src/api/impl/beacon/state/state.ts
@@ -1,6 +1,6 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {Root, phase0} from "@chainsafe/lodestar-types";
+import {Root, phase0, allForks} from "@chainsafe/lodestar-types";
 import {List, readonlyValues} from "@chainsafe/ssz";
 import {IBeaconChain} from "../../../../chain/interface";
 import {IBeaconDb} from "../../../../db/api";
@@ -29,7 +29,7 @@ export class BeaconStateApi implements IBeaconStateApi {
     if (!state) {
       return null;
     }
-    return this.config.types.phase0.BeaconState.hashTreeRoot(state);
+    return this.config.getTypes(state.slot).BeaconState.hashTreeRoot(state);
   }
 
   async getStateFinalityCheckpoints(stateId: StateId): Promise<phase0.FinalityCheckpoints | null> {
@@ -155,7 +155,7 @@ export class BeaconStateApi implements IBeaconStateApi {
     });
   }
 
-  async getState(stateId: StateId): Promise<phase0.BeaconState | null> {
+  async getState(stateId: StateId): Promise<allForks.BeaconState | null> {
     return await resolveStateId(this.chain, this.db, stateId);
   }
 

--- a/packages/lodestar/src/api/impl/beacon/state/utils.ts
+++ b/packages/lodestar/src/api/impl/beacon/state/utils.ts
@@ -1,6 +1,6 @@
 // this will need async once we wan't to resolve archive slot
 import {GENESIS_SLOT, FAR_FUTURE_EPOCH, CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
-import {phase0} from "@chainsafe/lodestar-types";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {fast} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
@@ -15,7 +15,7 @@ export async function resolveStateId(
   chain: IBeaconChain,
   db: IBeaconDb,
   stateId: StateId
-): Promise<phase0.BeaconState | null> {
+): Promise<allForks.BeaconState | null> {
   stateId = stateId.toLowerCase();
   if (stateId === "head" || stateId === "genesis" || stateId === "finalized" || stateId === "justified") {
     return await stateByName(db, chain.stateCache, chain.forkChoice, stateId);
@@ -85,18 +85,18 @@ export function toValidatorResponse(
 export function getEpochBeaconCommittees(
   config: IBeaconConfig,
   chain: IBeaconChain,
-  state: phase0.BeaconState | CachedBeaconState<phase0.BeaconState>,
+  state: allForks.BeaconState | CachedBeaconState<allForks.BeaconState>,
   epoch: Epoch
 ): ValidatorIndex[][][] {
   let committees: ValidatorIndex[][][] | null = null;
-  if ((state as CachedBeaconState<phase0.BeaconState>).epochCtx) {
+  if ((state as CachedBeaconState<allForks.BeaconState>).epochCtx) {
     switch (epoch) {
       case chain.clock.currentEpoch: {
-        committees = (state as CachedBeaconState<phase0.BeaconState>).currentShuffling.committees;
+        committees = (state as CachedBeaconState<allForks.BeaconState>).currentShuffling.committees;
         break;
       }
       case chain.clock.currentEpoch - 1: {
-        committees = (state as CachedBeaconState<phase0.BeaconState>).previousShuffling.committees;
+        committees = (state as CachedBeaconState<allForks.BeaconState>).previousShuffling.committees;
         break;
       }
     }
@@ -119,7 +119,7 @@ async function stateByName(
   stateCache: StateContextCache,
   forkChoice: IForkChoice,
   stateId: StateId
-): Promise<phase0.BeaconState | null> {
+): Promise<allForks.BeaconState | null> {
   switch (stateId) {
     case "head":
       return stateCache.get(forkChoice.getHead().stateRoot) ?? null;
@@ -138,7 +138,7 @@ async function stateByRoot(
   db: IBeaconDb,
   stateCache: StateContextCache,
   stateId: StateId
-): Promise<phase0.BeaconState | null> {
+): Promise<allForks.BeaconState | null> {
   if (stateId.startsWith("0x")) {
     const stateRoot = fromHexString(stateId);
     const cachedStateCtx = stateCache.get(stateRoot);
@@ -154,7 +154,7 @@ async function stateBySlot(
   stateCache: StateContextCache,
   forkChoice: IForkChoice,
   slot: Slot
-): Promise<phase0.BeaconState | null> {
+): Promise<allForks.BeaconState | null> {
   const blockSummary = forkChoice.getCanonicalBlockSummaryAtSlot(slot);
   if (blockSummary) {
     return stateCache.get(blockSummary.stateRoot) ?? null;

--- a/packages/lodestar/src/api/impl/debug/beacon/index.ts
+++ b/packages/lodestar/src/api/impl/debug/beacon/index.ts
@@ -1,6 +1,6 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBlockSummary} from "@chainsafe/lodestar-fork-choice";
-import {phase0} from "@chainsafe/lodestar-types";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {IBeaconChain} from "../../../../chain";
 import {IBeaconDb} from "../../../../db";
@@ -34,7 +34,7 @@ export class DebugBeaconApi implements IDebugBeaconApi {
     }
   }
 
-  async getState(stateId: StateId): Promise<phase0.BeaconState | null> {
+  async getState(stateId: StateId): Promise<allForks.BeaconState | null> {
     try {
       return await resolveStateId(this.chain, this.db, stateId);
     } catch (e) {

--- a/packages/lodestar/src/api/impl/debug/beacon/interface.ts
+++ b/packages/lodestar/src/api/impl/debug/beacon/interface.ts
@@ -1,4 +1,4 @@
-import {phase0} from "@chainsafe/lodestar-types";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {StateId} from "../../beacon/state";
 
 export interface IDebugBeaconApi {
@@ -6,5 +6,5 @@ export interface IDebugBeaconApi {
    * API wrapper function for `getHeads` in `@chainsafe/lodestar-fork-choice`.
    * */
   getHeads(): Promise<phase0.SlotRoot[] | null>;
-  getState(stateId: StateId): Promise<phase0.BeaconState | null>;
+  getState(stateId: StateId): Promise<allForks.BeaconState | null>;
 }

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -3,7 +3,11 @@
  */
 
 import bls, {Signature} from "@chainsafe/bls";
-import {computeStartSlotAtEpoch, computeSubnetForCommitteesAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {
+  CachedBeaconState,
+  computeStartSlotAtEpoch,
+  computeSubnetForCommitteesAtSlot,
+} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Bytes96, CommitteeIndex, Epoch, Root, phase0, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {assert, ILogger} from "@chainsafe/lodestar-utils";
@@ -71,7 +75,13 @@ export class ValidatorApi implements IValidatorApi {
       await checkSyncStatus(this.config, this.sync);
       const headRoot = this.chain.forkChoice.getHeadRoot();
       const state = await this.chain.regen.getBlockSlotState(headRoot, slot);
-      return assembleAttestationData(state.config, state, headRoot, slot, committeeIndex);
+      return assembleAttestationData(
+        state.config,
+        state as CachedBeaconState<phase0.BeaconState>,
+        headRoot,
+        slot,
+        committeeIndex
+      );
     } catch (e) {
       this.logger.warn("Failed to produce attestation data", e);
       throw e;

--- a/packages/lodestar/src/api/rest/controllers/debug/beacon/getStates.ts
+++ b/packages/lodestar/src/api/rest/controllers/debug/beacon/getStates.ts
@@ -15,11 +15,11 @@ export const getState: ApiController<DefaultQuery, {stateId: string}> = {
         return;
       }
       if (req.headers[HttpHeader.ACCEPT] === SSZ_MIME_TYPE) {
-        const stateSsz = this.config.types.phase0.BeaconState.serialize(state);
+        const stateSsz = this.config.getTypes(state.slot).BeaconState.serialize(state);
         resp.status(200).header(HttpHeader.CONTENT_TYPE, SSZ_MIME_TYPE).send(Buffer.from(stateSsz));
       } else {
         resp.status(200).send({
-          data: this.config.types.phase0.BeaconState.toJson(state, {case: "snake"}),
+          data: this.config.getTypes(state.slot).BeaconState.toJson(state, {case: "snake"}),
         });
       }
     } catch (e) {

--- a/packages/lodestar/src/chain/emitter.ts
+++ b/packages/lodestar/src/chain/emitter.ts
@@ -1,7 +1,7 @@
 import {EventEmitter} from "events";
 import StrictEventEmitter from "strict-event-emitter-types";
 
-import {phase0, Epoch, Slot, Version} from "@chainsafe/lodestar-types";
+import {phase0, Epoch, Slot, Version, allForks} from "@chainsafe/lodestar-types";
 import {IBlockSummary} from "@chainsafe/lodestar-fork-choice";
 import {IForkName} from "@chainsafe/lodestar-config";
 import {IBlockJob} from "./interface";
@@ -108,16 +108,16 @@ export enum ChainEvent {
 export interface IChainEvents {
   [ChainEvent.attestation]: (attestation: phase0.Attestation) => void;
   [ChainEvent.block]: (
-    signedBlock: phase0.SignedBeaconBlock,
-    postState: CachedBeaconState<phase0.BeaconState>,
+    signedBlock: allForks.SignedBeaconBlock,
+    postState: CachedBeaconState<allForks.BeaconState>,
     job: IBlockJob
   ) => void;
   [ChainEvent.errorAttestation]: (error: AttestationError) => void;
   [ChainEvent.errorBlock]: (error: BlockError) => void;
 
-  [ChainEvent.checkpoint]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<phase0.BeaconState>) => void;
-  [ChainEvent.justified]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<phase0.BeaconState>) => void;
-  [ChainEvent.finalized]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<phase0.BeaconState>) => void;
+  [ChainEvent.checkpoint]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<allForks.BeaconState>) => void;
+  [ChainEvent.justified]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<allForks.BeaconState>) => void;
+  [ChainEvent.finalized]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<allForks.BeaconState>) => void;
   [ChainEvent.forkVersion]: (version: Version, fork: IForkName) => void;
 
   [ChainEvent.clockSlot]: (slot: Slot) => void;

--- a/packages/lodestar/src/chain/factory/block/body.ts
+++ b/packages/lodestar/src/chain/factory/block/body.ts
@@ -3,7 +3,7 @@
  */
 
 import {List} from "@chainsafe/ssz";
-import {Bytes96, Bytes32, phase0} from "@chainsafe/lodestar-types";
+import {Bytes96, Bytes32, phase0, allForks} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 
@@ -25,7 +25,7 @@ export async function assembleBody(
       .getBlockAttestations(currentState)
       .then((value) => value.slice(0, config.params.MAX_ATTESTATIONS)),
     db.voluntaryExit.values({limit: config.params.MAX_VOLUNTARY_EXITS}),
-    eth1.getEth1DataAndDeposits(currentState),
+    eth1.getEth1DataAndDeposits(currentState as CachedBeaconState<allForks.BeaconState>),
   ]);
 
   return {

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -28,9 +28,9 @@ export async function assembleBlock(
     proposerIndex: state.getBeaconProposer(slot),
     parentRoot: head.blockRoot,
     stateRoot: ZERO_HASH,
-    body: await assembleBody(config, db, eth1, state, randaoReveal, graffiti),
+    body: await assembleBody(config, db, eth1, state as CachedBeaconState<phase0.BeaconState>, randaoReveal, graffiti),
   };
-  block.stateRoot = computeNewStateRoot(config, state, block);
+  block.stateRoot = computeNewStateRoot(config, state as CachedBeaconState<phase0.BeaconState>, block);
 
   return block;
 }

--- a/packages/lodestar/src/chain/forkChoice/forkChoice.ts
+++ b/packages/lodestar/src/chain/forkChoice/forkChoice.ts
@@ -3,14 +3,14 @@
  */
 
 import {toHexString} from "@chainsafe/ssz";
-import {Slot} from "@chainsafe/lodestar-types";
+import {allForks, Slot} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ForkChoice, ProtoArray} from "@chainsafe/lodestar-fork-choice";
 
 import {computeAnchorCheckpoint} from "../initState";
 import {ChainEventEmitter} from "../emitter";
 import {ForkChoiceStore} from "./store";
-import {getEffectiveBalances, phase0, CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {getEffectiveBalances, CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 
 /**
  * Fork Choice extended with a ChainEventEmitter
@@ -25,7 +25,7 @@ export class LodestarForkChoice extends ForkChoice {
     config: IBeaconConfig;
     emitter: ChainEventEmitter;
     currentSlot: Slot;
-    state: CachedBeaconState<phase0.BeaconState>;
+    state: CachedBeaconState<allForks.BeaconState>;
   }) {
     const {blockHeader, checkpoint} = computeAnchorCheckpoint(config, state);
     const finalizedCheckpoint = {...checkpoint};

--- a/packages/lodestar/src/chain/genesis/genesis.ts
+++ b/packages/lodestar/src/chain/genesis/genesis.ts
@@ -3,7 +3,8 @@
  */
 
 import {TreeBacked, List} from "@chainsafe/ssz";
-import {Root, phase0} from "@chainsafe/lodestar-types";
+import {GENESIS_SLOT} from "@chainsafe/lodestar-params";
+import {Root, phase0, allForks} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {AbortSignal} from "abort-controller";
 import {
@@ -26,7 +27,7 @@ export interface IGenesisBuilderKwargs {
 
   /** Use to restore pending progress */
   pendingStatus?: {
-    state: TreeBacked<phase0.BeaconState>;
+    state: TreeBacked<allForks.BeaconState>;
     depositTree: TreeBacked<List<Root>>;
     lastProcessedBlockNumber: number;
   };
@@ -37,7 +38,7 @@ export interface IGenesisBuilderKwargs {
 
 export class GenesisBuilder implements IGenesisBuilder {
   // Expose state to persist on error
-  state: TreeBacked<phase0.BeaconState>;
+  state: TreeBacked<allForks.BeaconState>;
   depositTree: TreeBacked<List<Root>>;
   /** Is null if no block has been processed yet */
   lastProcessedBlockNumber: number | null = null;
@@ -71,7 +72,7 @@ export class GenesisBuilder implements IGenesisBuilder {
       this.state = getGenesisBeaconState(
         config,
         config.types.phase0.Eth1Data.defaultValue(),
-        getTemporaryBlockHeader(config, config.types.phase0.BeaconBlock.defaultValue())
+        getTemporaryBlockHeader(config, config.getTypes(GENESIS_SLOT).BeaconBlock.defaultValue())
       );
       this.depositTree = config.types.phase0.DepositDataRootList.defaultTreeBacked();
       this.fromBlock = this.eth1Provider.deployBlock;

--- a/packages/lodestar/src/chain/genesis/interface.ts
+++ b/packages/lodestar/src/chain/genesis/interface.ts
@@ -1,8 +1,8 @@
 import {TreeBacked, List} from "@chainsafe/ssz";
-import {phase0, Root} from "@chainsafe/lodestar-types";
+import {allForks, phase0, Root} from "@chainsafe/lodestar-types";
 
 export interface IGenesisResult {
-  state: TreeBacked<phase0.BeaconState>;
+  state: TreeBacked<allForks.BeaconState>;
   depositTree: TreeBacked<List<Root>>;
   block: phase0.Eth1Block;
 }

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -1,4 +1,4 @@
-import {Number64, Root, Slot} from "@chainsafe/lodestar-types";
+import {allForks, Number64, Root, Slot} from "@chainsafe/lodestar-types";
 import {IForkName} from "@chainsafe/lodestar-config";
 import {phase0, CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
@@ -31,11 +31,11 @@ interface IProcessBlock {
 }
 
 export interface IChainSegmentJob extends IProcessBlock {
-  signedBlocks: phase0.SignedBeaconBlock[];
+  signedBlocks: allForks.SignedBeaconBlock[];
 }
 
 export interface IBlockJob extends IProcessBlock {
-  signedBlock: phase0.SignedBeaconBlock;
+  signedBlock: allForks.SignedBeaconBlock;
 }
 
 export interface IAttestationJob {
@@ -67,7 +67,7 @@ export interface IBeaconChain {
    */
   close(): void;
 
-  getHeadState(): CachedBeaconState<phase0.BeaconState>;
+  getHeadState(): CachedBeaconState<allForks.BeaconState>;
   /**
    * Get ForkDigest from the head state
    */
@@ -83,11 +83,11 @@ export interface IBeaconChain {
   getGenesisTime(): Number64;
   getStatus(): phase0.Status;
 
-  getHeadStateAtCurrentEpoch(): Promise<CachedBeaconState<phase0.BeaconState>>;
-  getHeadStateAtCurrentSlot(): Promise<CachedBeaconState<phase0.BeaconState>>;
-  getHeadBlock(): Promise<phase0.SignedBeaconBlock | null>;
+  getHeadStateAtCurrentEpoch(): Promise<CachedBeaconState<allForks.BeaconState>>;
+  getHeadStateAtCurrentSlot(): Promise<CachedBeaconState<allForks.BeaconState>>;
+  getHeadBlock(): Promise<allForks.SignedBeaconBlock | null>;
 
-  getStateByBlockRoot(blockRoot: Root): Promise<CachedBeaconState<phase0.BeaconState> | null>;
+  getStateByBlockRoot(blockRoot: Root): Promise<CachedBeaconState<allForks.BeaconState> | null>;
 
   getFinalizedCheckpoint(): phase0.Checkpoint;
 
@@ -97,9 +97,9 @@ export interface IBeaconChain {
    * forkchoice. Works for finalized slots as well
    * @param slot
    */
-  getCanonicalBlockAtSlot(slot: Slot): Promise<phase0.SignedBeaconBlock | null>;
+  getCanonicalBlockAtSlot(slot: Slot): Promise<allForks.SignedBeaconBlock | null>;
 
-  getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<phase0.SignedBeaconBlock[]>;
+  getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<allForks.SignedBeaconBlock[]>;
 
   /**
    * Add attestation to the fork-choice rule
@@ -109,9 +109,9 @@ export interface IBeaconChain {
   /**
    * Pre-process and run the per slot state transition function
    */
-  receiveBlock(signedBlock: phase0.SignedBeaconBlock, trusted?: boolean): void;
+  receiveBlock(signedBlock: allForks.SignedBeaconBlock, trusted?: boolean): void;
   /**
    * Process a chain of blocks until complete.
    */
-  processChainSegment(signedBlocks: phase0.SignedBeaconBlock[], trusted?: boolean): Promise<void>;
+  processChainSegment(signedBlocks: allForks.SignedBeaconBlock[], trusted?: boolean): Promise<void>;
 }

--- a/packages/lodestar/src/chain/regen/interface.ts
+++ b/packages/lodestar/src/chain/regen/interface.ts
@@ -1,4 +1,4 @@
-import {phase0, Root, Slot} from "@chainsafe/lodestar-types";
+import {allForks, phase0, Root, Slot} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 
 /**
@@ -9,21 +9,21 @@ export interface IStateRegenerator {
    * Return a valid pre-state for a beacon block
    * This will always return a state in the latest viable epoch
    */
-  getPreState: (block: phase0.BeaconBlock) => Promise<CachedBeaconState<phase0.BeaconState>>;
+  getPreState: (block: allForks.BeaconBlock) => Promise<CachedBeaconState<allForks.BeaconState>>;
 
   /**
    * Return a valid checkpoint state
    * This will always return a state with `state.slot % SLOTS_PER_EPOCH === 0`
    */
-  getCheckpointState: (cp: phase0.Checkpoint) => Promise<CachedBeaconState<phase0.BeaconState>>;
+  getCheckpointState: (cp: phase0.Checkpoint) => Promise<CachedBeaconState<allForks.BeaconState>>;
 
   /**
    * Return the state of `blockRoot` processed to slot `slot`
    */
-  getBlockSlotState: (blockRoot: Root, slot: Slot) => Promise<CachedBeaconState<phase0.BeaconState>>;
+  getBlockSlotState: (blockRoot: Root, slot: Slot) => Promise<CachedBeaconState<allForks.BeaconState>>;
 
   /**
    * Return the exact state with `stateRoot`
    */
-  getState: (stateRoot: Root) => Promise<CachedBeaconState<phase0.BeaconState>>;
+  getState: (stateRoot: Root) => Promise<CachedBeaconState<allForks.BeaconState>>;
 }

--- a/packages/lodestar/src/chain/regen/queued.ts
+++ b/packages/lodestar/src/chain/regen/queued.ts
@@ -1,5 +1,5 @@
 import {AbortSignal} from "abort-controller";
-import {Root, phase0, Slot} from "@chainsafe/lodestar-types";
+import {Root, phase0, Slot, allForks} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
@@ -43,19 +43,19 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     this.jobQueue = new JobQueue({maxLength, signal});
   }
 
-  async getPreState(block: phase0.BeaconBlock): Promise<CachedBeaconState<phase0.BeaconState>> {
+  async getPreState(block: allForks.BeaconBlock): Promise<CachedBeaconState<allForks.BeaconState>> {
     return await this.jobQueue.push(async () => await this.regen.getPreState(block));
   }
 
-  async getCheckpointState(cp: phase0.Checkpoint): Promise<CachedBeaconState<phase0.BeaconState>> {
+  async getCheckpointState(cp: phase0.Checkpoint): Promise<CachedBeaconState<allForks.BeaconState>> {
     return await this.jobQueue.push(async () => await this.regen.getCheckpointState(cp));
   }
 
-  async getBlockSlotState(blockRoot: Root, slot: Slot): Promise<CachedBeaconState<phase0.BeaconState>> {
+  async getBlockSlotState(blockRoot: Root, slot: Slot): Promise<CachedBeaconState<allForks.BeaconState>> {
     return await this.jobQueue.push(async () => await this.regen.getBlockSlotState(blockRoot, slot));
   }
 
-  async getState(stateRoot: Root): Promise<CachedBeaconState<phase0.BeaconState>> {
+  async getState(stateRoot: Root): Promise<CachedBeaconState<allForks.BeaconState>> {
     return await this.jobQueue.push(async () => await this.regen.getState(stateRoot));
   }
 }

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -1,4 +1,4 @@
-import {phase0, Root, Slot} from "@chainsafe/lodestar-types";
+import {allForks, phase0, Root, Slot} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {
   CachedBeaconState,
@@ -48,7 +48,7 @@ export class StateRegenerator implements IStateRegenerator {
     this.db = db;
   }
 
-  async getPreState(block: phase0.BeaconBlock): Promise<CachedBeaconState<phase0.BeaconState>> {
+  async getPreState(block: phase0.BeaconBlock): Promise<CachedBeaconState<allForks.BeaconState>> {
     const parentBlock = this.forkChoice.getBlock(block.parentRoot);
     if (!parentBlock) {
       throw new RegenError({
@@ -77,12 +77,12 @@ export class StateRegenerator implements IStateRegenerator {
     return await this.getState(parentBlock.stateRoot);
   }
 
-  async getCheckpointState(cp: phase0.Checkpoint): Promise<CachedBeaconState<phase0.BeaconState>> {
+  async getCheckpointState(cp: phase0.Checkpoint): Promise<CachedBeaconState<allForks.BeaconState>> {
     const checkpointStartSlot = computeStartSlotAtEpoch(this.config, cp.epoch);
     return await this.getBlockSlotState(cp.root, checkpointStartSlot);
   }
 
-  async getBlockSlotState(blockRoot: Root, slot: Slot): Promise<CachedBeaconState<phase0.BeaconState>> {
+  async getBlockSlotState(blockRoot: Root, slot: Slot): Promise<CachedBeaconState<allForks.BeaconState>> {
     const block = this.forkChoice.getBlock(blockRoot);
     if (!block) {
       throw new RegenError({
@@ -117,7 +117,7 @@ export class StateRegenerator implements IStateRegenerator {
     return await processSlotsByCheckpoint(this.emitter, blockStateCtx, slot);
   }
 
-  async getState(stateRoot: Root): Promise<CachedBeaconState<phase0.BeaconState>> {
+  async getState(stateRoot: Root): Promise<CachedBeaconState<allForks.BeaconState>> {
     // Trivial case, state at stateRoot is already cached
     const cachedStateCtx = this.stateCache.get(stateRoot);
     if (cachedStateCtx) {
@@ -142,7 +142,7 @@ export class StateRegenerator implements IStateRegenerator {
     // blocks to replay, ordered highest to lowest
     // gets reversed when replayed
     const blocksToReplay = [block];
-    let state: CachedBeaconState<phase0.BeaconState> | null = null;
+    let state: CachedBeaconState<allForks.BeaconState> | null = null;
     for (const b of this.forkChoice.iterateBlockSummaries(block.parentRoot)) {
       state = this.stateCache.get(b.stateRoot);
       if (state) {
@@ -197,6 +197,6 @@ export class StateRegenerator implements IStateRegenerator {
       }
     }
 
-    return state as CachedBeaconState<phase0.BeaconState>;
+    return state as CachedBeaconState<allForks.BeaconState>;
   }
 }

--- a/packages/lodestar/src/chain/stateCache/stateContextCache.ts
+++ b/packages/lodestar/src/chain/stateCache/stateContextCache.ts
@@ -1,5 +1,5 @@
 import {ByteVector, toHexString} from "@chainsafe/ssz";
-import {phase0, Epoch} from "@chainsafe/lodestar-types";
+import {Epoch, allForks} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 
 const MAX_STATES = 96;
@@ -15,7 +15,7 @@ export class StateContextCache {
    */
   maxStates: number;
 
-  private cache = new Map<string, CachedBeaconState<phase0.BeaconState>>();
+  private cache = new Map<string, CachedBeaconState<allForks.BeaconState>>();
   /** Epoch -> Set<blockRoot> */
   private epochIndex = new Map<Epoch, Set<string>>();
 
@@ -23,7 +23,7 @@ export class StateContextCache {
     this.maxStates = maxStates;
   }
 
-  get(root: ByteVector): CachedBeaconState<phase0.BeaconState> | null {
+  get(root: ByteVector): CachedBeaconState<allForks.BeaconState> | null {
     const item = this.cache.get(toHexString(root));
     if (!item) {
       return null;
@@ -31,7 +31,7 @@ export class StateContextCache {
     return item.clone();
   }
 
-  add(item: CachedBeaconState<phase0.BeaconState>): void {
+  add(item: CachedBeaconState<allForks.BeaconState>): void {
     const key = toHexString(item.hashTreeRoot());
     if (this.cache.get(key)) {
       return;

--- a/packages/lodestar/src/chain/stateCache/stateContextCheckpointsCache.ts
+++ b/packages/lodestar/src/chain/stateCache/stateContextCheckpointsCache.ts
@@ -1,5 +1,5 @@
 import {toHexString, fromHexString} from "@chainsafe/ssz";
-import {phase0, Epoch} from "@chainsafe/lodestar-types";
+import {phase0, Epoch, allForks} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 
@@ -13,7 +13,7 @@ const MAX_EPOCHS = 10;
  */
 export class CheckpointStateCache {
   private readonly config: IBeaconConfig;
-  private cache = new Map<string, CachedBeaconState<phase0.BeaconState>>();
+  private cache = new Map<string, CachedBeaconState<allForks.BeaconState>>();
   /** Epoch -> Set<blockRoot> */
   private epochIndex = new Map<Epoch, Set<string>>();
 
@@ -21,12 +21,12 @@ export class CheckpointStateCache {
     this.config = config;
   }
 
-  get(cp: phase0.Checkpoint): CachedBeaconState<phase0.BeaconState> | null {
+  get(cp: phase0.Checkpoint): CachedBeaconState<allForks.BeaconState> | null {
     const item = this.cache.get(toHexString(this.config.types.phase0.Checkpoint.hashTreeRoot(cp)));
     return item ? item.clone() : null;
   }
 
-  add(cp: phase0.Checkpoint, item: CachedBeaconState<phase0.BeaconState>): void {
+  add(cp: phase0.Checkpoint, item: CachedBeaconState<allForks.BeaconState>): void {
     const key = toHexString(this.config.types.phase0.Checkpoint.hashTreeRoot(cp));
     if (this.cache.has(key)) {
       return;
@@ -44,7 +44,7 @@ export class CheckpointStateCache {
   /**
    * Searches for the latest cached state with a `root`, starting with `epoch` and descending
    */
-  getLatest({root, epoch}: phase0.Checkpoint): CachedBeaconState<phase0.BeaconState> | null {
+  getLatest({root, epoch}: phase0.Checkpoint): CachedBeaconState<allForks.BeaconState> | null {
     const hexRoot = toHexString(root);
     // sort epochs in descending order, only consider epochs lte `epoch`
     const epochs = Array.from(this.epochIndex.keys())

--- a/packages/lodestar/src/chain/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/aggregateAndProof.ts
@@ -86,7 +86,7 @@ export async function validateAggregateAttestation(
 ): Promise<void> {
   const attestation = aggregateAndProof.message.aggregate;
 
-  let attestationTargetState: CachedBeaconState<phase0.BeaconState>;
+  let attestationTargetState: CachedBeaconState<allForks.BeaconState>;
   try {
     // the target state, advanced to the attestation slot
     attestationTargetState = await chain.regen.getCheckpointState(attestation.data.target);

--- a/packages/lodestar/src/chain/validation/attestation.ts
+++ b/packages/lodestar/src/chain/validation/attestation.ts
@@ -74,7 +74,7 @@ export async function validateGossipAttestation(
     });
   }
 
-  let attestationTargetState: CachedBeaconState<phase0.BeaconState>;
+  let attestationTargetState: CachedBeaconState<allForks.BeaconState>;
   try {
     attestationTargetState = await chain.regen.getCheckpointState(attestation.data.target);
   } catch (e) {

--- a/packages/lodestar/src/chain/validation/utils/signature.ts
+++ b/packages/lodestar/src/chain/validation/utils/signature.ts
@@ -1,5 +1,5 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {Epoch, phase0, Slot} from "@chainsafe/lodestar-types";
+import {allForks, Epoch, phase0, Slot} from "@chainsafe/lodestar-types";
 import {PublicKey} from "@chainsafe/bls";
 import {
   computeEpochAtSlot,
@@ -11,7 +11,7 @@ import {
 
 export function getSelectionProofSignatureSet(
   config: IBeaconConfig,
-  state: phase0.BeaconState,
+  state: allForks.BeaconState,
   slot: Slot,
   aggregator: PublicKey,
   aggregateAndProof: phase0.SignedAggregateAndProof
@@ -29,7 +29,7 @@ export function getSelectionProofSignatureSet(
 
 export function getAggregateAndProofSignatureSet(
   config: IBeaconConfig,
-  state: phase0.BeaconState,
+  state: allForks.BeaconState,
   epoch: Epoch,
   aggregator: PublicKey,
   aggregateAndProof: phase0.SignedAggregateAndProof

--- a/packages/lodestar/src/db/api/beacon/single/preGenesisState.ts
+++ b/packages/lodestar/src/db/api/beacon/single/preGenesisState.ts
@@ -1,31 +1,36 @@
-import {TreeBacked, CompositeType} from "@chainsafe/ssz";
-import {phase0} from "@chainsafe/lodestar-types";
+import {TreeBacked, ContainerType} from "@chainsafe/ssz";
+import {GENESIS_SLOT} from "@chainsafe/lodestar-params";
+import {allForks} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IDatabaseController, Bucket} from "@chainsafe/lodestar-db";
 
 export class PreGenesisState {
+  private readonly config: IBeaconConfig;
   private readonly bucket: Bucket;
-  private readonly type: CompositeType<TreeBacked<phase0.BeaconState>>;
   private readonly db: IDatabaseController<Buffer, Buffer>;
   private readonly key: Buffer;
 
   constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
+    this.config = config;
     this.db = db;
-    this.type = (config.types.phase0.BeaconState as unknown) as CompositeType<TreeBacked<phase0.BeaconState>>;
     this.bucket = Bucket.phase0_preGenesisState as Bucket;
     this.key = Buffer.from(new Uint8Array([this.bucket]));
   }
 
-  async put(value: TreeBacked<phase0.BeaconState>): Promise<void> {
-    await this.db.put(this.key, this.type.serialize(value) as Buffer);
+  async put(value: TreeBacked<allForks.BeaconState>): Promise<void> {
+    await this.db.put(this.key, this.type().serialize(value) as Buffer);
   }
 
-  async get(): Promise<TreeBacked<phase0.BeaconState> | null> {
+  async get(): Promise<TreeBacked<allForks.BeaconState> | null> {
     const value = await this.db.get(this.key);
-    return value ? this.type.createTreeBackedFromBytes(value) : null;
+    return value ? this.type().createTreeBackedFromBytes(value) : null;
   }
 
   async delete(): Promise<void> {
     await this.db.delete(this.key);
+  }
+
+  private type(): ContainerType<allForks.BeaconState> {
+    return this.config.getTypes(GENESIS_SLOT).BeaconState;
   }
 }

--- a/packages/lodestar/src/eth1/eth1ForBlockProduction.ts
+++ b/packages/lodestar/src/eth1/eth1ForBlockProduction.ts
@@ -1,3 +1,4 @@
+import {allForks} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {CachedBeaconState, phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {ILogger, sleep} from "@chainsafe/lodestar-utils";
@@ -66,7 +67,7 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
    * Return eth1Data and deposits ready for block production for a given state
    */
   async getEth1DataAndDeposits(
-    state: CachedBeaconState<phase0.BeaconState>
+    state: CachedBeaconState<allForks.BeaconState>
   ): Promise<{
     eth1Data: phase0.Eth1Data;
     deposits: phase0.Deposit[];
@@ -80,7 +81,7 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
    * Returns an eth1Data vote for a given state.
    * Requires internal caches to be updated regularly to return good results
    */
-  private async getEth1Data(state: phase0.BeaconState): Promise<phase0.Eth1Data> {
+  private async getEth1Data(state: allForks.BeaconState): Promise<phase0.Eth1Data> {
     const eth1VotesToConsider = await getEth1VotesToConsider(
       this.config,
       state,
@@ -94,11 +95,12 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
    * Requires internal caches to be updated regularly to return good results
    */
   private async getDeposits(
-    state: CachedBeaconState<phase0.BeaconState>,
+    state: CachedBeaconState<allForks.BeaconState>,
     eth1DataVote: phase0.Eth1Data
   ): Promise<phase0.Deposit[]> {
     // Eth1 data may change due to the vote included in this block
-    const newEth1Data = phase0.fast.getNewEth1Data(state, eth1DataVote) || state.eth1Data;
+    const newEth1Data =
+      phase0.fast.getNewEth1Data(state as CachedBeaconState<phase0.BeaconState>, eth1DataVote) || state.eth1Data;
     return await getDeposits(this.config, state, newEth1Data, this.depositsCache.get.bind(this.depositsCache));
   }
 

--- a/packages/lodestar/src/eth1/eth1ForBlockProductionDisabled.ts
+++ b/packages/lodestar/src/eth1/eth1ForBlockProductionDisabled.ts
@@ -1,4 +1,4 @@
-import {phase0} from "@chainsafe/lodestar-types";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {IEth1ForBlockProduction} from "./interface";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 
@@ -12,7 +12,7 @@ export class Eth1ForBlockProductionDisabled implements IEth1ForBlockProduction {
    * May produce invalid blocks if deposits have to be added
    */
   async getEth1DataAndDeposits(
-    state: CachedBeaconState<phase0.BeaconState>
+    state: CachedBeaconState<allForks.BeaconState>
   ): Promise<{
     eth1Data: phase0.Eth1Data;
     deposits: phase0.Deposit[];

--- a/packages/lodestar/src/eth1/interface.ts
+++ b/packages/lodestar/src/eth1/interface.ts
@@ -4,7 +4,7 @@
 
 import {AbortSignal} from "abort-controller";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {phase0} from "@chainsafe/lodestar-types";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 
 export interface IEth1Provider {
@@ -18,7 +18,7 @@ export interface IEth1Provider {
 
 export interface IEth1ForBlockProduction {
   getEth1DataAndDeposits(
-    state: CachedBeaconState<phase0.BeaconState>
+    state: CachedBeaconState<allForks.BeaconState>
   ): Promise<{
     eth1Data: phase0.Eth1Data;
     deposits: phase0.Deposit[];

--- a/packages/lodestar/src/eth1/utils/deposits.ts
+++ b/packages/lodestar/src/eth1/utils/deposits.ts
@@ -1,5 +1,5 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {Root, phase0} from "@chainsafe/lodestar-types";
+import {Root, phase0, allForks} from "@chainsafe/lodestar-types";
 import {TreeBacked, List, toHexString} from "@chainsafe/ssz";
 import {IFilterOptions} from "@chainsafe/lodestar-db";
 import {getTreeAtIndex} from "../../util/tree";
@@ -9,7 +9,7 @@ export type DepositGetter<T> = (indexRange: IFilterOptions<number>, eth1Data: ph
 export async function getDeposits<T>(
   config: IBeaconConfig,
   // eth1_deposit_index represents the next deposit index to be added
-  state: phase0.BeaconState,
+  state: allForks.BeaconState,
   eth1Data: phase0.Eth1Data,
   depositsGetter: DepositGetter<T>
 ): Promise<T[]> {

--- a/packages/lodestar/src/eth1/utils/eth1Vote.ts
+++ b/packages/lodestar/src/eth1/utils/eth1Vote.ts
@@ -1,5 +1,5 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {phase0} from "@chainsafe/lodestar-types";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {computeTimeAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {readonlyValues, toHexString} from "@chainsafe/ssz";
 import {mostFrequent} from "../../util/objects";
@@ -12,7 +12,7 @@ export type Eth1DataGetter = ({
 
 export async function getEth1VotesToConsider(
   config: IBeaconConfig,
-  state: phase0.BeaconState,
+  state: allForks.BeaconState,
   eth1DataGetter: Eth1DataGetter
 ): Promise<phase0.Eth1Data[]> {
   const periodStart = votingPeriodStartTime(config, state);
@@ -35,7 +35,7 @@ export async function getEth1VotesToConsider(
 
 export function pickEth1Vote(
   config: IBeaconConfig,
-  state: phase0.BeaconState,
+  state: allForks.BeaconState,
   votesToConsider: phase0.Eth1Data[]
 ): phase0.Eth1Data {
   const votesToConsiderHashMap = new Set<string>();
@@ -70,7 +70,7 @@ function serializeEth1Data(eth1Data: phase0.Eth1Data): string {
   return toHexString(eth1Data.blockHash) + eth1Data.depositCount.toString(16) + toHexString(eth1Data.depositRoot);
 }
 
-export function votingPeriodStartTime(config: IBeaconConfig, state: phase0.BeaconState): number {
+export function votingPeriodStartTime(config: IBeaconConfig, state: allForks.BeaconState): number {
   const eth1VotingPeriodStartSlot =
     state.slot - (state.slot % (config.params.EPOCHS_PER_ETH1_VOTING_PERIOD * config.params.SLOTS_PER_EPOCH));
   return computeTimeAtSlot(config, eth1VotingPeriodStartSlot, state.genesisTime);

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -7,7 +7,7 @@ import LibP2p from "libp2p";
 
 import {TreeBacked} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {phase0} from "@chainsafe/lodestar-types";
+import {allForks} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
 
 import {IBeaconDb} from "../db";
@@ -44,7 +44,7 @@ export interface IBeaconNodeInitModules {
   db: IBeaconDb;
   logger: ILogger;
   libp2p: LibP2p;
-  anchorState: TreeBacked<phase0.BeaconState>;
+  anchorState: TreeBacked<allForks.BeaconState>;
 }
 
 export enum BeaconNodeStatus {

--- a/packages/lodestar/src/node/utils/interop/state.ts
+++ b/packages/lodestar/src/node/utils/interop/state.ts
@@ -1,5 +1,5 @@
 import {List, TreeBacked} from "@chainsafe/ssz";
-import {phase0, Root} from "@chainsafe/lodestar-types";
+import {allForks, phase0, Root} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {initializeBeaconStateFromEth1} from "@chainsafe/lodestar-beacon-state-transition";
 
@@ -11,7 +11,7 @@ export function getInteropState(
   depositDataRootList: TreeBacked<List<Root>>,
   genesisTime: number,
   deposits: phase0.Deposit[]
-): TreeBacked<phase0.BeaconState> {
+): TreeBacked<allForks.BeaconState> {
   const state = initializeBeaconStateFromEth1(config, INTEROP_BLOCK_HASH, INTEROP_TIMESTAMP, deposits);
   state.genesisTime = genesisTime;
   return state;

--- a/packages/lodestar/src/node/utils/state.ts
+++ b/packages/lodestar/src/node/utils/state.ts
@@ -1,5 +1,5 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {phase0} from "@chainsafe/lodestar-types";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {interopDeposits} from "./interop/deposits";
 import {getInteropState} from "./interop/state";
 import {mkdirSync, writeFileSync} from "fs";
@@ -12,7 +12,7 @@ export async function initDevState(
   db: IBeaconDb,
   validatorCount: number,
   genesisTime?: number
-): Promise<TreeBacked<phase0.BeaconState>> {
+): Promise<TreeBacked<allForks.BeaconState>> {
   const deposits = interopDeposits(config, config.types.phase0.DepositDataRootList.defaultTreeBacked(), validatorCount);
   await storeDeposits(config, db, deposits);
   const state = getInteropState(
@@ -24,9 +24,9 @@ export async function initDevState(
   return state;
 }
 
-export function storeSSZState(config: IBeaconConfig, state: TreeBacked<phase0.BeaconState>, path: string): void {
+export function storeSSZState(config: IBeaconConfig, state: TreeBacked<allForks.BeaconState>, path: string): void {
   mkdirSync(dirname(path), {recursive: true});
-  writeFileSync(path, config.types.phase0.BeaconState.serialize(state));
+  writeFileSync(path, config.getTypes(state.slot).BeaconState.serialize(state));
 }
 
 async function storeDeposits(config: IBeaconConfig, db: IBeaconDb, deposits: phase0.Deposit[]): Promise<void> {

--- a/packages/lodestar/src/tasks/tasks/archiveStates.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveStates.ts
@@ -5,7 +5,7 @@
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {phase0} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconState, computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconDb} from "../../db/api";
 import {IBeaconChain} from "../../chain";
 
@@ -83,7 +83,7 @@ export class StatesArchiver {
     if (!finalizedState) {
       throw Error("No state in cache for finalized checkpoint state epoch #" + finalized.epoch);
     }
-    await this.db.stateArchive.put(finalizedState.slot, finalizedState);
+    await this.db.stateArchive.put(finalizedState.slot, finalizedState as CachedBeaconState<phase0.BeaconState>);
     // don't delete states before the finalized state, auto-prune will take care of it
     this.logger.verbose("Archive states completed", {finalizedEpoch: finalized.epoch});
   }

--- a/packages/lodestar/test/unit/api/impl/beacon/state/stateValidators.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/state/stateValidators.test.ts
@@ -1,5 +1,5 @@
 import {config} from "@chainsafe/lodestar-config/minimal";
-import {Gwei} from "@chainsafe/lodestar-types";
+import {allForks, Gwei} from "@chainsafe/lodestar-types";
 import {CachedBeaconState, phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {List} from "@chainsafe/ssz";
 import {expect, use} from "chai";
@@ -101,7 +101,7 @@ describe("beacon api impl - state - validators", function () {
         pubkey2index: ({
           get: () => undefined,
         } as unknown) as fast.PubkeyIndexMap,
-      } as CachedBeaconState<phase0.BeaconState>);
+      } as CachedBeaconState<allForks.BeaconState>);
       const api = new BeaconStateApi({}, {config, db: dbStub, chain: chainStub});
       await expect(api.getStateValidator("someState", Buffer.alloc(32, 1))).to.be.rejectedWith("Validator not found");
     });
@@ -111,7 +111,7 @@ describe("beacon api impl - state - validators", function () {
         pubkey2index: ({
           get: () => 2,
         } as unknown) as fast.PubkeyIndexMap,
-      } as CachedBeaconState<phase0.BeaconState>);
+      } as CachedBeaconState<allForks.BeaconState>);
       const api = new BeaconStateApi({}, {config, db: dbStub, chain: chainStub});
       expect(await api.getStateValidator("someState", Buffer.alloc(32, 1))).to.not.be.null;
     });
@@ -136,7 +136,7 @@ describe("beacon api impl - state - validators", function () {
       pubkey2IndexStub.get.withArgs(Buffer.alloc(32, 2)).returns(25);
       chainStub.getHeadState.returns({
         pubkey2index: (pubkey2IndexStub as unknown) as fast.PubkeyIndexMap,
-      } as CachedBeaconState<phase0.BeaconState>);
+      } as CachedBeaconState<allForks.BeaconState>);
       const api = new BeaconStateApi({}, {config, db: dbStub, chain: chainStub});
       const balances = await api.getStateValidatorBalances("somestate", [
         1,

--- a/packages/lodestar/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/state/utils.test.ts
@@ -1,6 +1,6 @@
 import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {config} from "@chainsafe/lodestar-config/minimal";
-import {toHexString} from "@chainsafe/ssz";
+import {toHexString, TreeBacked} from "@chainsafe/ssz";
 import {expect, use} from "chai";
 import chaiAsPromised from "chai-as-promised";
 import sinon, {SinonStubbedInstance} from "sinon";
@@ -45,7 +45,7 @@ describe("beacon state api utils", function () {
     });
 
     it("resolve genesis state id - success", async function () {
-      dbStub.stateArchive.get.withArgs(0).resolves(generateState());
+      dbStub.stateArchive.get.withArgs(0).resolves(generateState() as TreeBacked<phase0.BeaconState>);
       const state = await resolveStateId(chainStub, dbStub, "genesis");
       expect(state).to.not.be.null;
       expect(dbStub.stateArchive.get.withArgs(0).calledOnce).to.be.true;

--- a/packages/lodestar/test/unit/api/rest/debug/beacon/getState.test.ts
+++ b/packages/lodestar/test/unit/api/rest/debug/beacon/getState.test.ts
@@ -55,7 +55,7 @@ describe("rest - debug - beacon - getState", function () {
       .accept("application/octet-stream")
       .expect(200)
       .expect("Content-Type", "application/octet-stream");
-    expect(response.body).to.be.deep.equal(config.types.phase0.BeaconState.serialize(state));
+    expect(response.body).to.be.deep.equal(config.getTypes(state.slot).BeaconState.serialize(state));
   });
 
   it("should return status code 404", async function () {

--- a/packages/lodestar/test/unit/chain/factory/attestation/data.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/attestation/data.test.ts
@@ -1,4 +1,6 @@
 import {expect} from "chai";
+import {phase0} from "@chainsafe/lodestar-types";
+import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {assembleAttestationData} from "../../../../../src/chain/factory/attestation/data";
 import {generateState} from "../../../../utils/state";
@@ -17,7 +19,7 @@ describe("assemble attestation data", function () {
       balances: generateInitialMaxBalances(config),
     });
     const blockRoot = config.types.phase0.BeaconBlock.hashTreeRoot(generateEmptyBlock());
-    const result = assembleAttestationData(config, state, blockRoot, 2, 1);
+    const result = assembleAttestationData(config, state as CachedBeaconState<phase0.BeaconState>, blockRoot, 2, 1);
     expect(result).to.not.be.null;
   });
 });

--- a/packages/lodestar/test/unit/chain/factory/block/body.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/block/body.test.ts
@@ -1,6 +1,8 @@
 import sinon from "sinon";
 import {expect} from "chai";
 
+import {phase0} from "@chainsafe/lodestar-types";
+import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {assembleBody} from "../../../../../src/chain/factory/block/body";
 import {generateCachedState} from "../../../../utils/state";
@@ -34,7 +36,7 @@ describe("blockAssembly - body", function () {
       config,
       dbStub,
       eth1,
-      generateCachedState(),
+      generateCachedState() as CachedBeaconState<phase0.BeaconState>,
       Buffer.alloc(96, 0),
       Buffer.alloc(32, 0)
     );
@@ -66,7 +68,7 @@ describe("blockAssembly - body", function () {
       config,
       dbStub,
       eth1,
-      generateCachedState(),
+      generateCachedState() as CachedBeaconState<phase0.BeaconState>,
       Buffer.alloc(96, 0),
       Buffer.alloc(32, 0)
     );

--- a/packages/lodestar/test/unit/eth1/utils/eth1Vote.test.ts
+++ b/packages/lodestar/test/unit/eth1/utils/eth1Vote.test.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {List, TreeBacked} from "@chainsafe/ssz";
-import {phase0} from "@chainsafe/lodestar-types";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {generateState} from "../../../utils/state";
 import {filterBy} from "../../../utils/db";
@@ -94,7 +94,7 @@ describe("eth1 / util / eth1Vote", function () {
     // Function array to scope votes in each test case defintion
     const testCases: (() => {
       id: string;
-      state: TreeBacked<phase0.BeaconState>;
+      state: TreeBacked<allForks.BeaconState>;
       eth1Datas: IEth1DataWithTimestamp[];
       expectedVotesToConsider: phase0.Eth1Data[];
     })[] = [
@@ -161,7 +161,7 @@ function getEth1DataBlock(eth1DataBlock: Partial<IEth1DataWithTimestamp>): IEth1
  * @param config
  * @param state
  */
-function getTimestampInRange(config: IBeaconConfig, state: TreeBacked<phase0.BeaconState>): number {
+function getTimestampInRange(config: IBeaconConfig, state: TreeBacked<allForks.BeaconState>): number {
   const {SECONDS_PER_ETH1_BLOCK, ETH1_FOLLOW_DISTANCE} = config.params;
   const periodStart = votingPeriodStartTime(config, state);
   return periodStart - SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE;

--- a/packages/lodestar/test/unit/tasks/interopSubnetsJoiningTask.test.ts
+++ b/packages/lodestar/test/unit/tasks/interopSubnetsJoiningTask.test.ts
@@ -9,7 +9,7 @@ import {testLogger} from "../../utils/logger";
 import {expect} from "chai";
 import {MockBeaconChain} from "../../utils/mocks/chain/chain";
 import {generateState} from "../../utils/state";
-import {phase0} from "@chainsafe/lodestar-types";
+import {allForks} from "@chainsafe/lodestar-types";
 import {MetadataController} from "../../../src/network/metadata";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {TreeBacked} from "@chainsafe/ssz";
@@ -23,7 +23,7 @@ describe("interopSubnetsJoiningTask", () => {
   let chain: IBeaconChain;
   const logger = testLogger();
   let task: InteropSubnetsJoiningTask;
-  let state: phase0.BeaconState;
+  let state: allForks.BeaconState;
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const params = Object.assign({}, minimalConfig.params);
@@ -39,7 +39,7 @@ describe("interopSubnetsJoiningTask", () => {
       genesisTime: 0,
       chainId: 0,
       networkId: BigInt(0),
-      state: state as TreeBacked<phase0.BeaconState>,
+      state: state as TreeBacked<allForks.BeaconState>,
       config,
     });
     networkStub.metadata = new MetadataController({}, {config, chain, logger});

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -2,7 +2,7 @@ import {AbortController} from "abort-controller";
 import sinon from "sinon";
 
 import {TreeBacked} from "@chainsafe/ssz";
-import {ForkDigest, Number64, Root, Slot, Uint16, Uint64} from "@chainsafe/lodestar-types";
+import {allForks, ForkDigest, Number64, Root, Slot, Uint16, Uint64} from "@chainsafe/lodestar-types";
 import {IBeaconConfig, IForkName} from "@chainsafe/lodestar-config";
 import {
   CachedBeaconState,
@@ -27,7 +27,7 @@ export interface IMockChainParams {
   genesisTime?: Number64;
   chainId: Uint16;
   networkId: Uint64;
-  state: TreeBacked<phase0.BeaconState>;
+  state: TreeBacked<allForks.BeaconState>;
   config: IBeaconConfig;
 }
 
@@ -46,7 +46,7 @@ export class MockBeaconChain implements IBeaconChain {
   pendingBlocks: BlockPool;
   pendingAttestations: AttestationPool;
 
-  private state: TreeBacked<phase0.BeaconState>;
+  private state: TreeBacked<allForks.BeaconState>;
   private config: IBeaconConfig;
   private abortController: AbortController;
 
@@ -87,25 +87,25 @@ export class MockBeaconChain implements IBeaconChain {
     return null;
   }
 
-  getHeadState(): CachedBeaconState<phase0.BeaconState> {
+  getHeadState(): CachedBeaconState<allForks.BeaconState> {
     return createCachedBeaconState(this.config, this.state);
   }
 
-  async getHeadStateAtCurrentEpoch(): Promise<CachedBeaconState<phase0.BeaconState>> {
+  async getHeadStateAtCurrentEpoch(): Promise<CachedBeaconState<allForks.BeaconState>> {
     return createCachedBeaconState(this.config, this.state);
   }
 
-  async getHeadStateAtCurrentSlot(): Promise<CachedBeaconState<phase0.BeaconState>> {
+  async getHeadStateAtCurrentSlot(): Promise<CachedBeaconState<allForks.BeaconState>> {
     return createCachedBeaconState(this.config, this.state);
   }
 
-  async getCanonicalBlockAtSlot(slot: Slot): Promise<phase0.SignedBeaconBlock> {
+  async getCanonicalBlockAtSlot(slot: Slot): Promise<allForks.SignedBeaconBlock> {
     const block = generateEmptySignedBlock();
     block.message.slot = slot;
     return block;
   }
 
-  async getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<phase0.SignedBeaconBlock[]> {
+  async getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<allForks.SignedBeaconBlock[]> {
     if (!slots) {
       return [];
     }
@@ -153,7 +153,7 @@ export class MockBeaconChain implements IBeaconChain {
     return;
   }
 
-  async getStateByBlockRoot(): Promise<CachedBeaconState<phase0.BeaconState> | null> {
+  async getStateByBlockRoot(): Promise<CachedBeaconState<allForks.BeaconState> | null> {
     return null;
   }
 

--- a/packages/lodestar/test/utils/state.ts
+++ b/packages/lodestar/test/utils/state.ts
@@ -1,7 +1,7 @@
 import {minimalConfig} from "@chainsafe/lodestar-config/minimal";
 import {CachedBeaconState, createCachedBeaconState, phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {List, TreeBacked} from "@chainsafe/ssz";
-import {Gwei, Root} from "@chainsafe/lodestar-types";
+import {allForks, Gwei, Root} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {FAR_FUTURE_EPOCH} from "@chainsafe/lodestar-params";
 
@@ -12,9 +12,9 @@ import {generateValidators} from "./validator";
 /**
  * Copy of BeaconState, but all fields are marked optional to allow for swapping out variables as needed.
  */
-type TestBeaconState = Partial<phase0.BeaconState>;
+type TestBeaconState = Partial<allForks.BeaconState>;
 
-const states = new Map<IBeaconConfig, TreeBacked<phase0.BeaconState>>();
+const states = new Map<IBeaconConfig, TreeBacked<allForks.BeaconState>>();
 
 /**
  * Generate beaconState, by default it will generate a mostly empty state with "just enough" to be valid-ish
@@ -25,7 +25,7 @@ const states = new Map<IBeaconConfig, TreeBacked<phase0.BeaconState>>();
  * @param config
  * @returns {BeaconState}
  */
-export function generateState(opts: TestBeaconState = {}, config = minimalConfig): TreeBacked<phase0.BeaconState> {
+export function generateState(opts: TestBeaconState = {}, config = minimalConfig): TreeBacked<allForks.BeaconState> {
   const defaultState: phase0.BeaconState = {
     genesisTime: Math.floor(Date.now() / 1000),
     genesisValidatorsRoot: ZERO_HASH,
@@ -77,7 +77,9 @@ export function generateState(opts: TestBeaconState = {}, config = minimalConfig
       root: ZERO_HASH,
     },
   };
-  const state = states.get(config) ?? config.types.phase0.BeaconState.createTreeBackedFromStruct(defaultState);
+  const state =
+    states.get(config) ??
+    (config.types.phase0.BeaconState.createTreeBackedFromStruct(defaultState) as TreeBacked<allForks.BeaconState>);
   states.set(config, state);
   const resultState = state.clone();
   for (const key in opts) {
@@ -91,6 +93,6 @@ export function generateState(opts: TestBeaconState = {}, config = minimalConfig
 export function generateCachedState(
   opts: TestBeaconState = {},
   config = minimalConfig
-): CachedBeaconState<phase0.BeaconState> {
+): CachedBeaconState<allForks.BeaconState> {
   return createCachedBeaconState(config, generateState(opts, config));
 }

--- a/packages/lodestar/test/utils/stub/chain.ts
+++ b/packages/lodestar/test/utils/stub/chain.ts
@@ -1,3 +1,4 @@
+import {TreeBacked} from "@chainsafe/ssz";
 import {minimalConfig} from "@chainsafe/lodestar-config/minimal";
 import {SinonSandbox, SinonStubbedInstance} from "sinon";
 import {BeaconChain, ForkChoice} from "../../../src/chain";
@@ -7,7 +8,7 @@ import {CheckpointStateCache, StateContextCache} from "../../../src/chain/stateC
 import {testLogger} from "../logger";
 import {StubbedBeaconDb} from "./beaconDb";
 import {generateValidators} from "../validator";
-import {phase0} from "@chainsafe/lodestar-types";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {FAR_FUTURE_EPOCH} from "@chainsafe/lodestar-beacon-state-transition";
 import {createStubInstance} from "../types";
 
@@ -34,7 +35,7 @@ export class StubbedBeaconChain extends BeaconChain {
           exitEpoch: FAR_FUTURE_EPOCH,
         }),
         balances: Array.from({length: 64}, () => BigInt(0)),
-      } as phase0.BeaconState),
+      } as phase0.BeaconState) as TreeBacked<allForks.BeaconState>,
     });
     this.forkChoice = createStubInstance(ForkChoice);
     this.stateCache = createStubInstance(StateContextCache);

--- a/packages/spec-test-runner/test/spec/genesis/initialization/genesis_initialization_minimal.test.ts
+++ b/packages/spec-test-runner/test/spec/genesis/initialization/genesis_initialization_minimal.test.ts
@@ -27,7 +27,12 @@ describeDirectorySpecTest<IGenesisInitSpecTest, phase0.BeaconState>(
     for (let i = 0; i < Number(testcase.meta.depositsCount); i++) {
       deposits.push(testcase[`deposits_${i}`] as phase0.Deposit);
     }
-    return initializeBeaconStateFromEth1(config, testcase.eth1_block_hash, Number(testcase.eth1_timestamp), deposits);
+    return initializeBeaconStateFromEth1(
+      config,
+      testcase.eth1_block_hash,
+      Number(testcase.eth1_timestamp),
+      deposits
+    ) as phase0.BeaconState;
   },
   {
     // @ts-ignore


### PR DESCRIPTION
**Motivation**

On the quest towards Altair and a fork-compatible beacon node, we need all public interfaces in IBeaconChain to use `allForks` types for input/output.

**Description**

Use `allForks` `SignedBeaconBlock` and `BeaconState` throughout lodestar / chain (and upstream wherever necessary)

Note: There are several places where use of `phase0` remains, and this should/will be addresses in separate PRs:
- database
- duties / chain factory
- add `allForks.AttestationData` and friends, use it instead of `phase0`
- a final comb thru the whole repo to ensure all uses of `phase0` are correct