### PR TITLE
Remove un-used dep from spec utils

### DIFF
--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -45,7 +45,6 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "5.1.0",
     "@chainsafe/lodestar-utils": "^0.18.0",
     "@chainsafe/ssz": "^0.8.0",
     "axios": "^0.21.0",


### PR DESCRIPTION
**Motivation**

There's a circular dependency between bls <> spec-test-utils. However bls doesn't seem to be used in spec-test-utils.

**Description**

Remove the circular dependency
