### PR TITLE
Remove profiler from spec tests utils

### DIFF
--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -52,8 +52,7 @@
     "chai": "^4.2.0",
     "mocha": "^8.1.1",
     "rimraf": "^3.0.2",
-    "tar": "^6.0.5",
-    "v8-profiler-next": "^1.1.1"
+    "tar": "^6.0.5"
   },
   "devDependencies": {
     "@types/tar": "^4.0.4"

--- a/packages/spec-test-util/src/multi.ts
+++ b/packages/spec-test-util/src/multi.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any,@typescript-eslint/no-unused-vars */
 import {writeFile} from "fs";
 import {expect} from "chai";
-import profiler from "v8-profiler-next";
 import {loadYamlFile} from "./util";
 
 export interface IBaseCase {
@@ -71,23 +70,7 @@ export function describeMultiSpec<TestCase extends IBaseCase, Result>(
         if (shouldError(testCase, index)) {
           expect(testFunc.bind(null, ...inputs)).to.throw();
         } else {
-          const profileId = `${description}-${Date.now()}.profile`;
-          if (env.GEN_PROFILE_DIR) {
-            profiler.startProfiling(profileId);
-          }
           const result = testFunc(...inputs);
-          if (env.GEN_PROFILE_DIR) {
-            const profile = profiler.stopProfiling(profileId);
-            const directory = env.GEN_PROFILE_DIR || __dirname;
-            profile.export((error, result) => {
-              if (error || result === undefined) {
-                return;
-              }
-              writeFile(`${directory}/${profileId}`, result, () => {
-                profile.delete();
-              });
-            });
-          }
           const actual = getActual(result);
           const expected = getExpected(testCase);
           expectFunc(testCase, expect, expected, actual);

--- a/packages/spec-test-util/src/single.ts
+++ b/packages/spec-test-util/src/single.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any */
 import {expect} from "chai";
-import {readdirSync, readFileSync, writeFile} from "fs";
+import {readdirSync, readFileSync} from "fs";
 import {basename, join, parse} from "path";
-import profiler from "v8-profiler-next";
 import {Type, CompositeType} from "@chainsafe/ssz";
 
 import {isDirectory, loadYamlFile} from "./util";
@@ -117,17 +116,7 @@ function generateTestCase<TestCase, Result>(
         return;
       }
     } else {
-      const profileId = `${name}-${Date.now()}.profile`;
-      const profilingDirectory = process.env.GEN_PROFILE_DIR;
-      if (profilingDirectory) {
-        profiler.startProfiling(profileId);
-      }
       const result = testFunction(testCase, name);
-      if (profilingDirectory) {
-        const profile = profiler.stopProfiling(profileId);
-
-        generateProfileReport(profile, profilingDirectory, profileId);
-      }
       if (!options.getExpected) throw Error("getExpected is not defined");
       if (!options.expectFunc) throw Error("expectFunc is not defined");
       const expected = options.getExpected(testCase);
@@ -185,15 +174,4 @@ function deserializeTestCase<TestCase, Result>(
   } else {
     return loadYamlFile(file);
   }
-}
-
-function generateProfileReport(profile: profiler.CpuProfile, directory: string, profileId: string): void {
-  profile.export((error, result) => {
-    if (error || result === undefined) {
-      return;
-    }
-    writeFile(`${directory}/${profileId}`, result as string, () => {
-      profile.delete();
-    });
-  });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12883,13 +12883,6 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
   integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
 
-v8-profiler-next@^1.1.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/v8-profiler-next/-/v8-profiler-next-1.2.2.tgz#9eae99b8ae62658fd862c4530e6a6a7df72ca699"
-  integrity sha512-I9qiU6UfNJz5QIeXpx31kTh4ypH3r5W0ljgX92jBjfmEYRpSK2DK5OaPQYUr7mKnDgJALtG2eBX9j8fDp+b62w==
-  dependencies:
-    nan "^2.14.0"
-
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"


### PR DESCRIPTION
**Motivation**

- `v8-profiler-next` adds a noticeable time to installation which is apparent in blst-ts which triggers 46 runs per commit.
- We have other better ways to profile Lodestar, be Tuyen's perf tests or just taking a profile on demand on a running node
- If one needs to profile a spec test, can do so wrapping the function to test in the consumer side, outside of this util.

**Description**

Remove profiler code from spec test utils
