### PR TITLE
Improve AggregateAndProof gossip validation

### DIFF
--- a/packages/lodestar/src/chain/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/aggregateAndProof.ts
@@ -68,8 +68,6 @@ export async function validateGossipAggregateAndProof(
     });
   }
 
-  // TODO: check pool of aggregates if already seen (not a dos vector check)
-
   await validateAggregateAttestation(config, chain, signedAggregateAndProof, attestationJob);
 }
 

--- a/packages/lodestar/src/db/beacon.ts
+++ b/packages/lodestar/src/db/beacon.ts
@@ -48,7 +48,7 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
     this.badBlock = new BadBlockRepository(this.config, this.db);
     this.block = new BlockRepository(this.config, this.db);
     this.pendingBlock = new PendingBlockRepository(this.config, this.db);
-    this.seenAttestationCache = new SeenAttestationCache(5000);
+    this.seenAttestationCache = new SeenAttestationCache(this.config, 5000);
     this.blockArchive = new BlockArchiveRepository(this.config, this.db);
     this.stateArchive = new StateArchiveRepository(this.config, this.db);
     this.attestation = new AttestationRepository(this.config, this.db);

--- a/packages/lodestar/src/db/beacon.ts
+++ b/packages/lodestar/src/db/beacon.ts
@@ -48,7 +48,7 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
     this.badBlock = new BadBlockRepository(this.config, this.db);
     this.block = new BlockRepository(this.config, this.db);
     this.pendingBlock = new PendingBlockRepository(this.config, this.db);
-    this.seenAttestationCache = new SeenAttestationCache(this.config, 5000);
+    this.seenAttestationCache = new SeenAttestationCache(this.config, 2048);
     this.blockArchive = new BlockArchiveRepository(this.config, this.db);
     this.stateArchive = new StateArchiveRepository(this.config, this.db);
     this.attestation = new AttestationRepository(this.config, this.db);

--- a/packages/lodestar/src/db/seenAttestationCache.ts
+++ b/packages/lodestar/src/db/seenAttestationCache.ts
@@ -13,7 +13,7 @@ import {assert} from "@chainsafe/lodestar-utils";
  */
 export class SeenAttestationCache {
   private cache: Map<string, boolean>;
-  // key as AttestationDelta root hex, value as aggregationBits
+  // key as AttestationData root hex, value as aggregationBits
   private attDataCache: Map<string, boolean[]>;
   private readonly config: IBeaconConfig;
   private readonly maxSize: number;
@@ -42,10 +42,9 @@ export class SeenAttestationCache {
         cachedAggBit.length,
         "Length of AggregateAndProof aggregationBits is not the same to cache"
       );
-      this.attDataCache.set(
-        key,
-        aggBit.map((_, i) => aggBit[i] || cachedAggBit[i])
-      );
+      for (const [i, bit] of aggBit.entries()) {
+        if (bit) cachedAggBit[i] = true;
+      }
     }
     // delete oldest key if needed
     if (this.attDataCache.size > this.maxSize) {
@@ -97,6 +96,8 @@ export class SeenAttestationCache {
    * We're only interested in the AttestationData + aggregationBits inside AggregateAndProof.
    */
   private aggregateAndProofKey(value: phase0.AggregateAndProof): string {
-    return toHexString(this.config.types.phase0.AttestationData.hashTreeRoot(value.aggregate.data));
+    return toHexString(
+      this.config.getTypes(value.aggregate.data.slot).AttestationData.hashTreeRoot(value.aggregate.data)
+    );
   }
 }

--- a/packages/lodestar/src/db/seenAttestationCache.ts
+++ b/packages/lodestar/src/db/seenAttestationCache.ts
@@ -3,6 +3,8 @@
  *
  */
 import {phase0} from "@chainsafe/lodestar-types";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {toHexString} from "@chainsafe/ssz";
 
 /**
  * USed to verify gossip attestation. When there are multiple
@@ -10,10 +12,11 @@ import {phase0} from "@chainsafe/lodestar-types";
  */
 export class SeenAttestationCache {
   private cache: Map<string, boolean>;
-
+  private readonly config: IBeaconConfig;
   private readonly maxSize: number;
 
-  constructor(maxSize = 1000) {
+  constructor(config: IBeaconConfig, maxSize = 1000) {
+    this.config = config;
     this.maxSize = maxSize;
     this.cache = new Map<string, boolean>();
   }
@@ -59,8 +62,10 @@ export class SeenAttestationCache {
     );
   }
 
-  // serialize aggregate key as concatenation of interested properties
-  private aggregateAndProofKey(aggreate: phase0.AggregateAndProof): string {
-    return "" + aggreate.aggregatorIndex + aggreate.aggregate.data.target.epoch;
+  /**
+   * We're only interested in the Attestation inside AggregateAndProof.
+   */
+  private aggregateAndProofKey(value: phase0.AggregateAndProof): string {
+    return toHexString(this.config.types.phase0.Attestation.hashTreeRoot(value.aggregate));
   }
 }

--- a/packages/lodestar/src/network/gossip/topic.ts
+++ b/packages/lodestar/src/network/gossip/topic.ts
@@ -111,9 +111,9 @@ export function getGossipSSZDeserializer(config: IBeaconConfig, topic: GossipTop
 
   switch (topic.type) {
     case GossipType.beacon_block:
-      // Deserialize tree-backed block, all other gossip can be deserialized to struct
-      return sszType.createTreeBackedFromBytes.bind(sszType);
     case GossipType.beacon_aggregate_and_proof:
+      // all other gossip can be deserialized to struct
+      return sszType.createTreeBackedFromBytes.bind(sszType);
     case GossipType.beacon_attestation:
     case GossipType.proposer_slashing:
     case GossipType.attester_slashing:

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -20,7 +20,8 @@ import {
 // Numbers from https://github.com/sigp/lighthouse/blob/b34a79dc0b02e04441ba01fd0f304d1e203d877d/beacon_node/network/src/beacon_processor/mod.rs#L69
 const gossipQueueOpts: {[K in GossipType]: {maxLength: number; type: QueueType}} = {
   [GossipType.beacon_block]: {maxLength: 1024, type: QueueType.FIFO},
-  [GossipType.beacon_aggregate_and_proof]: {maxLength: 1024, type: QueueType.LIFO},
+  // this is different from lighthouse's, there are more gossip aggregate_and_proof than gossip block
+  [GossipType.beacon_aggregate_and_proof]: {maxLength: 4096, type: QueueType.LIFO},
   [GossipType.beacon_attestation]: {maxLength: 16384, type: QueueType.LIFO},
   [GossipType.voluntary_exit]: {maxLength: 4096, type: QueueType.FIFO},
   [GossipType.proposer_slashing]: {maxLength: 4096, type: QueueType.FIFO},

--- a/packages/lodestar/test/unit/db/seenAttestationCache.test.ts
+++ b/packages/lodestar/test/unit/db/seenAttestationCache.test.ts
@@ -1,0 +1,35 @@
+import {config} from "@chainsafe/lodestar-config/minimal";
+import {BitList} from "@chainsafe/ssz";
+import {expect} from "chai";
+import {SeenAttestationCache} from "../../../lib/db/seenAttestationCache";
+import {generateEmptyAggregateAndProof} from "../../utils/attestation";
+
+describe("SeenAttestationCache", function () {
+  let cache: SeenAttestationCache;
+  beforeEach(() => {
+    cache = new SeenAttestationCache(config);
+    const aggProof = generateEmptyAggregateAndProof();
+    aggProof.aggregate.aggregationBits = [true, false, true] as BitList;
+    cache.addAggregateAndProof(aggProof);
+  });
+
+  it("should found an AggregateAndProof with subset attesters", () => {
+    const aggProof = generateEmptyAggregateAndProof();
+    aggProof.aggregate.aggregationBits = [true, false, false] as BitList;
+    expect(cache.hasAggregateAndProof(aggProof)).to.be.true;
+  });
+
+  it("should not found an AggregateAndProof with different attesters", () => {
+    const aggProof = generateEmptyAggregateAndProof();
+    aggProof.aggregate.aggregationBits = [false, true, false] as BitList;
+    expect(cache.hasAggregateAndProof(aggProof)).to.be.false;
+    cache.addAggregateAndProof(aggProof);
+    expect(cache.hasAggregateAndProof(aggProof)).to.be.true;
+  });
+
+  it("should not found an AggregateAndProof with different AttestationDelta", () => {
+    const aggProof = generateEmptyAggregateAndProof();
+    aggProof.aggregate.data.slot = 2021;
+    expect(cache.hasAggregateAndProof(aggProof)).to.be.false;
+  });
+});


### PR DESCRIPTION
**Motivation**

+ AggregateAndProof as TreeBacked to avoid multiple `struct_hashTreeRoot`
+ Increase JobQueue for AggregateAndProof 
+ Filter out known aggregated attestation

**Description**

part of #2306
