### PR TITLE
Prepare fast state transition functions

### DIFF
--- a/packages/beacon-state-transition/src/fast/block/index.ts
+++ b/packages/beacon-state-transition/src/fast/block/index.ts
@@ -1,0 +1,3 @@
+export * from "./processBlockHeader";
+export * from "./processEth1Data";
+export * from "./processRandao";

--- a/packages/beacon-state-transition/src/fast/block/processBlockHeader.ts
+++ b/packages/beacon-state-transition/src/fast/block/processBlockHeader.ts
@@ -1,9 +1,7 @@
-import {phase0} from "@chainsafe/lodestar-types";
+import {allForks} from "@chainsafe/lodestar-types";
+import {CachedBeaconState} from "../util";
 
-import {CachedBeaconState} from "../../../fast";
-
-export function processBlockHeader(state: CachedBeaconState<phase0.BeaconState>, block: phase0.BeaconBlock): void {
-  const types = state.config.types;
+export function processBlockHeader(state: CachedBeaconState<allForks.BeaconState>, block: allForks.BeaconBlock): void {
   const slot = state.slot;
   // verify that the slots match
   if (block.slot !== slot) {
@@ -24,8 +22,10 @@ export function processBlockHeader(state: CachedBeaconState<phase0.BeaconState>,
         `blockProposerIndex=${block.proposerIndex} stateProposerIndex=${proposerIndex}`
     );
   }
+
+  const types = state.config.getTypes(slot);
   // verify that the parent matches
-  if (!types.Root.equals(block.parentRoot, types.phase0.BeaconBlockHeader.hashTreeRoot(state.latestBlockHeader))) {
+  if (!types.Root.equals(block.parentRoot, types.BeaconBlockHeader.hashTreeRoot(state.latestBlockHeader))) {
     throw new Error("Block parent root does not match state latest block");
   }
   // cache current block as the new latest block
@@ -34,7 +34,7 @@ export function processBlockHeader(state: CachedBeaconState<phase0.BeaconState>,
     proposerIndex: block.proposerIndex,
     parentRoot: block.parentRoot,
     stateRoot: new Uint8Array(32),
-    bodyRoot: types.phase0.BeaconBlockBody.hashTreeRoot(block.body),
+    bodyRoot: types.BeaconBlockBody.hashTreeRoot(block.body),
   };
 
   // verify proposer is not slashed

--- a/packages/beacon-state-transition/src/fast/block/processEth1Data.ts
+++ b/packages/beacon-state-transition/src/fast/block/processEth1Data.ts
@@ -1,8 +1,9 @@
-import {phase0} from "@chainsafe/lodestar-types";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {readonlyValues} from "@chainsafe/ssz";
-import {CachedBeaconState} from "../../../fast";
 
-export function processEth1Data(state: CachedBeaconState<phase0.BeaconState>, body: phase0.BeaconBlockBody): void {
+import {CachedBeaconState} from "../util";
+
+export function processEth1Data(state: CachedBeaconState<allForks.BeaconState>, body: allForks.BeaconBlockBody): void {
   const newEth1Data = getNewEth1Data(state, body.eth1Data);
   if (newEth1Data) {
     state.eth1Data = body.eth1Data;
@@ -16,7 +17,7 @@ export function processEth1Data(state: CachedBeaconState<phase0.BeaconState>, bo
  * result in a change to `state.eth1Data`.
  */
 export function getNewEth1Data(
-  state: CachedBeaconState<phase0.BeaconState>,
+  state: CachedBeaconState<allForks.BeaconState>,
   newEth1Data: phase0.Eth1Data
 ): phase0.Eth1Data | null {
   const {config} = state;

--- a/packages/beacon-state-transition/src/fast/block/processRandao.ts
+++ b/packages/beacon-state-transition/src/fast/block/processRandao.ts
@@ -1,12 +1,13 @@
 import xor from "buffer-xor";
 import {hash} from "@chainsafe/ssz";
-import {allForks, phase0} from "@chainsafe/lodestar-types";
-import {getRandaoMix} from "../../../util";
-import {CachedBeaconState, verifyRandaoSignature} from "../../../fast";
+import {allForks} from "@chainsafe/lodestar-types";
+import {getRandaoMix} from "../../util";
+import {verifyRandaoSignature} from "../signatureSets";
+import {CachedBeaconState} from "../util";
 
 export function processRandao(
-  state: CachedBeaconState<phase0.BeaconState>,
-  block: phase0.BeaconBlock,
+  state: CachedBeaconState<allForks.BeaconState>,
+  block: allForks.BeaconBlock,
   verifySignature = true
 ): void {
   const {config, epochCtx} = state;

--- a/packages/beacon-state-transition/src/fast/epoch/index.ts
+++ b/packages/beacon-state-transition/src/fast/epoch/index.ts
@@ -1,0 +1,5 @@
+export * from "./processEffectiveBalanceUpdates";
+export * from "./processEth1DataReset";
+export * from "./processHistoricalRootsUpdate";
+export * from "./processRandaoMixesReset";
+export * from "./processSlashingsReset";

--- a/packages/beacon-state-transition/src/fast/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/beacon-state-transition/src/fast/epoch/processEffectiveBalanceUpdates.ts
@@ -1,0 +1,35 @@
+import {allForks} from "@chainsafe/lodestar-types";
+import {readonlyValues} from "@chainsafe/ssz";
+import {bigIntMin} from "@chainsafe/lodestar-utils";
+import {IEpochProcess, CachedBeaconState} from "../util";
+
+export function processEffectiveBalanceUpdates(
+  state: CachedBeaconState<allForks.BeaconState>,
+  process: IEpochProcess
+): void {
+  const {config, validators} = state;
+  const {
+    EFFECTIVE_BALANCE_INCREMENT,
+    HYSTERESIS_QUOTIENT,
+    HYSTERESIS_DOWNWARD_MULTIPLIER,
+    HYSTERESIS_UPWARD_MULTIPLIER,
+    MAX_EFFECTIVE_BALANCE,
+  } = config.params;
+  const HYSTERESIS_INCREMENT = EFFECTIVE_BALANCE_INCREMENT / BigInt(HYSTERESIS_QUOTIENT);
+  const DOWNWARD_THRESHOLD = HYSTERESIS_INCREMENT * BigInt(HYSTERESIS_DOWNWARD_MULTIPLIER);
+  const UPWARD_THRESHOLD = HYSTERESIS_INCREMENT * BigInt(HYSTERESIS_UPWARD_MULTIPLIER);
+
+  // update effective balances with hysteresis
+  const balances =
+    process.balances && process.balances.length > 0 ? process.balances : Array.from(readonlyValues(state.balances));
+  for (let i = 0; i < process.statuses.length; i++) {
+    const status = process.statuses[i];
+    const balance = balances[i];
+    const effectiveBalance = status.validator.effectiveBalance;
+    if (balance + DOWNWARD_THRESHOLD < effectiveBalance || effectiveBalance + UPWARD_THRESHOLD < balance) {
+      validators.update(i, {
+        effectiveBalance: bigIntMin(balance - (balance % EFFECTIVE_BALANCE_INCREMENT), MAX_EFFECTIVE_BALANCE),
+      });
+    }
+  }
+}

--- a/packages/beacon-state-transition/src/fast/epoch/processEth1DataReset.ts
+++ b/packages/beacon-state-transition/src/fast/epoch/processEth1DataReset.ts
@@ -1,0 +1,13 @@
+import {allForks, phase0} from "@chainsafe/lodestar-types";
+import {List} from "@chainsafe/ssz";
+import {IEpochProcess, CachedBeaconState} from "../util";
+
+export function processEth1DataReset(state: CachedBeaconState<allForks.BeaconState>, process: IEpochProcess): void {
+  const nextEpoch = process.currentEpoch + 1;
+  const {EPOCHS_PER_ETH1_VOTING_PERIOD} = state.config.params;
+
+  // reset eth1 data votes
+  if (nextEpoch % EPOCHS_PER_ETH1_VOTING_PERIOD === 0) {
+    state.eth1DataVotes = ([] as phase0.Eth1Data[]) as List<phase0.Eth1Data>;
+  }
+}

--- a/packages/beacon-state-transition/src/fast/epoch/processHistoricalRootsUpdate.ts
+++ b/packages/beacon-state-transition/src/fast/epoch/processHistoricalRootsUpdate.ts
@@ -1,0 +1,22 @@
+import {allForks} from "@chainsafe/lodestar-types";
+import {intDiv} from "@chainsafe/lodestar-utils";
+import {IEpochProcess, CachedBeaconState} from "../util";
+
+export function processHistoricalRootsUpdate(
+  state: CachedBeaconState<allForks.BeaconState>,
+  process: IEpochProcess
+): void {
+  const {config} = state;
+  const nextEpoch = process.currentEpoch + 1;
+  const {SLOTS_PER_HISTORICAL_ROOT, SLOTS_PER_EPOCH} = config.params;
+
+  // set historical root accumulator
+  if (nextEpoch % intDiv(SLOTS_PER_HISTORICAL_ROOT, SLOTS_PER_EPOCH) === 0) {
+    state.historicalRoots.push(
+      config.types.phase0.HistoricalBatch.hashTreeRoot({
+        blockRoots: state.blockRoots,
+        stateRoots: state.stateRoots,
+      })
+    );
+  }
+}

--- a/packages/beacon-state-transition/src/fast/epoch/processRandaoMixesReset.ts
+++ b/packages/beacon-state-transition/src/fast/epoch/processRandaoMixesReset.ts
@@ -1,0 +1,13 @@
+import {allForks} from "@chainsafe/lodestar-types";
+import {getRandaoMix} from "../../util";
+import {IEpochProcess, CachedBeaconState} from "../util";
+
+export function processRandaoMixesReset(state: CachedBeaconState<allForks.BeaconState>, process: IEpochProcess): void {
+  const {config} = state;
+  const currentEpoch = process.currentEpoch;
+  const nextEpoch = currentEpoch + 1;
+  const {EPOCHS_PER_HISTORICAL_VECTOR} = config.params;
+
+  // set randao mix
+  state.randaoMixes[nextEpoch % EPOCHS_PER_HISTORICAL_VECTOR] = getRandaoMix(config, state, currentEpoch);
+}

--- a/packages/beacon-state-transition/src/fast/epoch/processSlashingsReset.ts
+++ b/packages/beacon-state-transition/src/fast/epoch/processSlashingsReset.ts
@@ -1,0 +1,10 @@
+import {allForks} from "@chainsafe/lodestar-types";
+import {IEpochProcess, CachedBeaconState} from "../util";
+
+export function processSlashingsReset(state: CachedBeaconState<allForks.BeaconState>, process: IEpochProcess): void {
+  const nextEpoch = process.currentEpoch + 1;
+  const {EPOCHS_PER_SLASHINGS_VECTOR} = state.config.params;
+
+  // reset slashings
+  state.slashings[nextEpoch % EPOCHS_PER_SLASHINGS_VECTOR] = BigInt(0);
+}

--- a/packages/beacon-state-transition/src/fast/index.ts
+++ b/packages/beacon-state-transition/src/fast/index.ts
@@ -1,3 +1,5 @@
 export * from "./signatureSets";
 export * from "./stateTransition";
 export * from "./util";
+export * from "./block";
+export * from "./epoch";

--- a/packages/beacon-state-transition/src/phase0/fast/block/index.ts
+++ b/packages/beacon-state-transition/src/phase0/fast/block/index.ts
@@ -1,9 +1,6 @@
-import {phase0} from "@chainsafe/lodestar-types";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
 
-import {CachedBeaconState} from "../../../fast";
-import {processBlockHeader} from "./processBlockHeader";
-import {processRandao} from "./processRandao";
-import {processEth1Data} from "./processEth1Data";
+import {CachedBeaconState, processBlockHeader, processEth1Data, processRandao} from "../../../fast";
 import {processOperations} from "./processOperations";
 import {processAttestation} from "./processAttestation";
 import {processAttesterSlashing} from "./processAttesterSlashing";
@@ -13,12 +10,8 @@ import {processVoluntaryExit} from "./processVoluntaryExit";
 
 // Extra utils used by other modules
 export {isValidIndexedAttestation} from "./isValidIndexedAttestation";
-export {getNewEth1Data} from "./processEth1Data";
 
 export {
-  processBlockHeader,
-  processRandao,
-  processEth1Data,
   processOperations,
   processAttestation,
   processAttesterSlashing,
@@ -32,8 +25,8 @@ export function processBlock(
   block: phase0.BeaconBlock,
   verifySignatures = true
 ): void {
-  processBlockHeader(state, block);
-  processRandao(state, block, verifySignatures);
-  processEth1Data(state, block.body);
+  processBlockHeader(state as CachedBeaconState<allForks.BeaconState>, block);
+  processRandao(state as CachedBeaconState<allForks.BeaconState>, block, verifySignatures);
+  processEth1Data(state as CachedBeaconState<allForks.BeaconState>, block.body);
   processOperations(state, block.body, verifySignatures);
 }

--- a/packages/beacon-state-transition/src/phase0/fast/epoch/processFinalUpdates.ts
+++ b/packages/beacon-state-transition/src/phase0/fast/epoch/processFinalUpdates.ts
@@ -1,65 +1,20 @@
-import {phase0} from "@chainsafe/lodestar-types";
-import {List, readonlyValues} from "@chainsafe/ssz";
-import {bigIntMin, intDiv} from "@chainsafe/lodestar-utils";
-import {getRandaoMix} from "../../../util";
-import {IEpochProcess, CachedBeaconState} from "../../../fast";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
+import {
+  IEpochProcess,
+  CachedBeaconState,
+  processEth1DataReset,
+  processEffectiveBalanceUpdates,
+  processSlashingsReset,
+  processRandaoMixesReset,
+  processHistoricalRootsUpdate,
+} from "../../../fast";
+import {processParticipationRecordUpdates} from "./processParticipationRecordUpdates";
 
 export function processFinalUpdates(state: CachedBeaconState<phase0.BeaconState>, process: IEpochProcess): void {
-  const {config, validators} = state;
-  const currentEpoch = process.currentEpoch;
-  const nextEpoch = currentEpoch + 1;
-  const {
-    EFFECTIVE_BALANCE_INCREMENT,
-    EPOCHS_PER_ETH1_VOTING_PERIOD,
-    EPOCHS_PER_HISTORICAL_VECTOR,
-    EPOCHS_PER_SLASHINGS_VECTOR,
-    HYSTERESIS_QUOTIENT,
-    HYSTERESIS_DOWNWARD_MULTIPLIER,
-    HYSTERESIS_UPWARD_MULTIPLIER,
-    MAX_EFFECTIVE_BALANCE,
-    SLOTS_PER_HISTORICAL_ROOT,
-    SLOTS_PER_EPOCH,
-  } = config.params;
-  const HYSTERESIS_INCREMENT = EFFECTIVE_BALANCE_INCREMENT / BigInt(HYSTERESIS_QUOTIENT);
-  const DOWNWARD_THRESHOLD = HYSTERESIS_INCREMENT * BigInt(HYSTERESIS_DOWNWARD_MULTIPLIER);
-  const UPWARD_THRESHOLD = HYSTERESIS_INCREMENT * BigInt(HYSTERESIS_UPWARD_MULTIPLIER);
-
-  // reset eth1 data votes
-  if (nextEpoch % EPOCHS_PER_ETH1_VOTING_PERIOD === 0) {
-    state.eth1DataVotes = ([] as phase0.Eth1Data[]) as List<phase0.Eth1Data>;
-  }
-
-  // update effective balances with hysteresis
-  const balances =
-    process.balances && process.balances.length > 0 ? process.balances : Array.from(readonlyValues(state.balances));
-  for (let i = 0; i < process.statuses.length; i++) {
-    const status = process.statuses[i];
-    const balance = balances[i];
-    const effectiveBalance = status.validator.effectiveBalance;
-    if (balance + DOWNWARD_THRESHOLD < effectiveBalance || effectiveBalance + UPWARD_THRESHOLD < balance) {
-      validators.update(i, {
-        effectiveBalance: bigIntMin(balance - (balance % EFFECTIVE_BALANCE_INCREMENT), MAX_EFFECTIVE_BALANCE),
-      });
-    }
-  }
-
-  // reset slashings
-  state.slashings[nextEpoch % EPOCHS_PER_SLASHINGS_VECTOR] = BigInt(0);
-
-  // set randao mix
-  state.randaoMixes[nextEpoch % EPOCHS_PER_HISTORICAL_VECTOR] = getRandaoMix(config, state, currentEpoch);
-
-  // set historical root accumulator
-  if (nextEpoch % intDiv(SLOTS_PER_HISTORICAL_ROOT, SLOTS_PER_EPOCH) === 0) {
-    state.historicalRoots.push(
-      config.types.phase0.HistoricalBatch.hashTreeRoot({
-        blockRoots: state.blockRoots,
-        stateRoots: state.stateRoots,
-      })
-    );
-  }
-
-  // rotate current/previous epoch attestations
-  state.previousEpochAttestations = state.currentEpochAttestations;
-  state.currentEpochAttestations = ([] as phase0.PendingAttestation[]) as List<phase0.PendingAttestation>;
+  processEth1DataReset(state as CachedBeaconState<allForks.BeaconState>, process);
+  processEffectiveBalanceUpdates(state as CachedBeaconState<allForks.BeaconState>, process);
+  processSlashingsReset(state as CachedBeaconState<allForks.BeaconState>, process);
+  processRandaoMixesReset(state as CachedBeaconState<allForks.BeaconState>, process);
+  processHistoricalRootsUpdate(state as CachedBeaconState<allForks.BeaconState>, process);
+  processParticipationRecordUpdates(state);
 }

--- a/packages/beacon-state-transition/src/phase0/fast/epoch/processParticipationRecordUpdates.ts
+++ b/packages/beacon-state-transition/src/phase0/fast/epoch/processParticipationRecordUpdates.ts
@@ -1,0 +1,9 @@
+import {phase0} from "@chainsafe/lodestar-types";
+import {List} from "@chainsafe/ssz";
+import {CachedBeaconState} from "../../../fast";
+
+export function processParticipationRecordUpdates(state: CachedBeaconState<phase0.BeaconState>): void {
+  // rotate current/previous epoch attestations
+  state.previousEpochAttestations = state.currentEpochAttestations;
+  state.currentEpochAttestations = ([] as phase0.PendingAttestation[]) as List<phase0.PendingAttestation>;
+}

--- a/packages/lodestar/src/eth1/eth1ForBlockProduction.ts
+++ b/packages/lodestar/src/eth1/eth1ForBlockProduction.ts
@@ -1,6 +1,6 @@
-import {allForks} from "@chainsafe/lodestar-types";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {CachedBeaconState, phase0} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconState, fast} from "@chainsafe/lodestar-beacon-state-transition";
 import {ILogger, sleep} from "@chainsafe/lodestar-utils";
 import {AbortSignal} from "abort-controller";
 import {IBeaconDb} from "../db";
@@ -99,8 +99,7 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
     eth1DataVote: phase0.Eth1Data
   ): Promise<phase0.Deposit[]> {
     // Eth1 data may change due to the vote included in this block
-    const newEth1Data =
-      phase0.fast.getNewEth1Data(state as CachedBeaconState<phase0.BeaconState>, eth1DataVote) || state.eth1Data;
+    const newEth1Data = fast.getNewEth1Data(state, eth1DataVote) || state.eth1Data;
     return await getDeposits(this.config, state, newEth1Data, this.depositsCache.get.bind(this.depositsCache));
   }
 

--- a/packages/spec-test-runner/test/spec/operations/blockHeader/block_header_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/operations/blockHeader/block_header_fast.test.ts
@@ -2,8 +2,9 @@ import {join} from "path";
 import {expect} from "chai";
 
 import {TreeBacked} from "@chainsafe/ssz";
+import {allForks} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/mainnet";
-import {fast, phase0} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconState, fast, phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util";
 import {IProcessBlockHeader} from "./type";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
@@ -16,7 +17,7 @@ describeDirectorySpecTest<IProcessBlockHeader, phase0.BeaconState>(
       config,
       testcase.pre as TreeBacked<phase0.BeaconState>
     );
-    phase0.fast.processBlockHeader(wrappedState, testcase.block);
+    fast.processBlockHeader(wrappedState as CachedBeaconState<allForks.BeaconState>, testcase.block);
     return wrappedState;
   },
   {


### PR DESCRIPTION
**Motivation**

In the process of adding a fast implementation of the altair state transition, it is useful to make as many existing functions shared across forks as possible.

**Description**

- Move `processBlockHeader`, `processEth1Data`, `processRandao` from `fast/phase0/block` to `fast/block` (changing function signatures to `allForks` types
- Split `processFinalUpdates` into spec-defined functions, move all shared functions to `fast/epoch`
- Update downstream to use new import location
