### PR TITLE
getLatestWeakSubjectivityCheckpointEpoch api endpoint

### DIFF
--- a/packages/lodestar/src/api/impl/api.ts
+++ b/packages/lodestar/src/api/impl/api.ts
@@ -24,6 +24,6 @@ export class Api implements IApi {
     this.events = new EventsApi(opts, modules);
     this.debug = new DebugApi(opts, modules);
     this.config = new ConfigApi(opts, modules);
-    this.lodestar = new LodestarApi();
+    this.lodestar = new LodestarApi(modules);
   }
 }

--- a/packages/lodestar/src/api/impl/lodestar/index.ts
+++ b/packages/lodestar/src/api/impl/lodestar/index.ts
@@ -1,6 +1,5 @@
-import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {allForks, Epoch} from "@chainsafe/lodestar-types";
+import {Epoch} from "@chainsafe/lodestar-types";
 import {IApiModules} from "..";
 import {getLatestWeakSubjectivityCheckpointEpoch} from "../../../../../beacon-state-transition/lib/fast/util/weakSubjectivity";
 import {IBeaconChain} from "../../../chain";
@@ -51,6 +50,6 @@ export class LodestarApi implements ILodestarApi {
 
   async getLatestWeakSubjectivityCheckpointEpoch(): Promise<Epoch> {
     const state = this.chain.getHeadState();
-    return getLatestWeakSubjectivityCheckpointEpoch(this.config, state as CachedBeaconState<allForks.BeaconState>);
+    return getLatestWeakSubjectivityCheckpointEpoch(this.config, state);
   }
 }

--- a/packages/lodestar/src/api/impl/lodestar/index.ts
+++ b/packages/lodestar/src/api/impl/lodestar/index.ts
@@ -1,10 +1,21 @@
+import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition/src/fast";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {allForks, Epoch} from "@chainsafe/lodestar-types";
+import {IApiModules} from "..";
+import {getLatestWeakSubjectivityCheckpointEpoch} from "../../../../../beacon-state-transition/src/fast/util/weakSubjectivity";
+
 /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 export interface ILodestarApi {
   getWtfNode(): string;
+  getLatestWeakSubjectivityCheckpointEpoch(state: allForks.BeaconState): Promise<Epoch>;
 }
 
 export class LodestarApi implements ILodestarApi {
-  constructor() {
+  private readonly config: IBeaconConfig;
+
+  constructor(modules: Pick<IApiModules, "config">) {
+    this.config = modules.config;
+
     // Allows to load wtfnode listeners immedeatelly. Usefull when dockerized,
     // so after an unexpected restart wtfnode becomes properly loaded again
     if (process?.env?.START_WTF_NODE) {
@@ -33,5 +44,11 @@ export class LodestarApi implements ILodestarApi {
     wtfnode.setLogger("error", logger);
     wtfnode.dump();
     return logs.join("\n");
+  }
+
+  async getLatestWeakSubjectivityCheckpointEpoch(
+    state: allForks.BeaconState | CachedBeaconState<allForks.BeaconState>
+  ): Promise<Epoch> {
+    return getLatestWeakSubjectivityCheckpointEpoch(this.config, state as CachedBeaconState<allForks.BeaconState>);
   }
 }

--- a/packages/lodestar/src/api/rest/controllers/lodestar/index.ts
+++ b/packages/lodestar/src/api/rest/controllers/lodestar/index.ts
@@ -10,7 +10,7 @@ export const getWtfNode: ApiController<DefaultQuery> = {
 };
 
 export const getLatestWeakSubjectivityCheckpointEpoch: ApiController<DefaultQuery> = {
-  url: "/wsEpoch/",
+  url: "/ws_epoch/",
   handler: async function (req, resp) {
     return resp.status(200).send(this.api.lodestar.getLatestWeakSubjectivityCheckpointEpoch);
   },

--- a/packages/lodestar/src/api/rest/controllers/lodestar/index.ts
+++ b/packages/lodestar/src/api/rest/controllers/lodestar/index.ts
@@ -12,9 +12,7 @@ export const getWtfNode: ApiController<DefaultQuery> = {
 export const getLatestWeakSubjectivityCheckpointEpoch: ApiController<DefaultQuery> = {
   url: "/wsEpoch/",
   handler: async function (req, resp) {
-    const state = await this.api.beacon.state.getState("head");
-    if (state === null) return resp.status(404).send("State not found");
-    return resp.status(200).send(() => this.api.lodestar.getLatestWeakSubjectivityCheckpointEpoch(state));
+    return resp.status(200).send(this.api.lodestar.getLatestWeakSubjectivityCheckpointEpoch);
   },
   opts: {},
 };

--- a/packages/lodestar/src/api/rest/controllers/lodestar/index.ts
+++ b/packages/lodestar/src/api/rest/controllers/lodestar/index.ts
@@ -8,3 +8,13 @@ export const getWtfNode: ApiController<DefaultQuery> = {
   },
   opts: {},
 };
+
+export const getLatestWeakSubjectivityCheckpointEpoch: ApiController<DefaultQuery> = {
+  url: "/wsEpoch/",
+  handler: async function (req, resp) {
+    const state = await this.api.beacon.state.getState("head");
+    if (state === null) return resp.status(404).send("State not found");
+    return resp.status(200).send(() => this.api.lodestar.getLatestWeakSubjectivityCheckpointEpoch(state));
+  },
+  opts: {},
+};

--- a/packages/lodestar/src/api/rest/routes/lodestar.ts
+++ b/packages/lodestar/src/api/rest/routes/lodestar.ts
@@ -1,5 +1,5 @@
 import {FastifyInstance} from "fastify";
-import {getWtfNode} from "../controllers/lodestar";
+import {getWtfNode, getLatestWeakSubjectivityCheckpointEpoch} from "../controllers/lodestar";
 
 /**
  * Register /lodestar route
@@ -8,6 +8,11 @@ export function registerLodestarRoutes(server: FastifyInstance): void {
   server.register(
     async function (fastify) {
       fastify.get(getWtfNode.url, getWtfNode.opts, getWtfNode.handler);
+      fastify.get(
+        getLatestWeakSubjectivityCheckpointEpoch.url,
+        getLatestWeakSubjectivityCheckpointEpoch.opts,
+        getLatestWeakSubjectivityCheckpointEpoch.handler
+      );
     },
     {prefix: "/v1/lodestar"}
   );

--- a/packages/lodestar/test/unit/api/impl/lodestar/lodestar.test.ts
+++ b/packages/lodestar/test/unit/api/impl/lodestar/lodestar.test.ts
@@ -1,0 +1,19 @@
+import {createCachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {config} from "@chainsafe/lodestar-config/minimal";
+import {expect} from "chai";
+import {ILodestarApi, LodestarApi} from "../../../../../src/api/impl/lodestar";
+import {generateState} from "../../../../utils/state";
+
+describe("Lodestar api impl", function () {
+  let api: ILodestarApi;
+
+  beforeEach(async function () {
+    api = new LodestarApi({config});
+  });
+
+  it("should get latest weak subjectivity checkpoint epoch", async function () {
+    const cachedState = createCachedBeaconState(config, generateState());
+    const epoch = await api.getLatestWeakSubjectivityCheckpointEpoch(cachedState);
+    expect(epoch).to.be.equal(0);
+  });
+});

--- a/packages/lodestar/test/unit/api/impl/lodestar/lodestar.test.ts
+++ b/packages/lodestar/test/unit/api/impl/lodestar/lodestar.test.ts
@@ -1,19 +1,26 @@
 import {createCachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {expect} from "chai";
+import {SinonStubbedInstance} from "sinon";
 import {ILodestarApi, LodestarApi} from "../../../../../src/api/impl/lodestar";
+import {BeaconChain} from "../../../../../src/chain";
 import {generateState} from "../../../../utils/state";
+import {ApiImplTestModules, setupApiImplTestServer} from "../index.test";
 
 describe("Lodestar api impl", function () {
   let api: ILodestarApi;
+  let server: ApiImplTestModules;
+  let chainStub: SinonStubbedInstance<BeaconChain>;
 
   beforeEach(async function () {
-    api = new LodestarApi({config});
+    server = setupApiImplTestServer();
+    chainStub = server.chainStub;
+    chainStub.getHeadState.returns(createCachedBeaconState(config, generateState()));
+    api = new LodestarApi({config, chain: chainStub});
   });
 
   it("should get latest weak subjectivity checkpoint epoch", async function () {
-    const cachedState = createCachedBeaconState(config, generateState());
-    const epoch = await api.getLatestWeakSubjectivityCheckpointEpoch(cachedState);
+    const epoch = await api.getLatestWeakSubjectivityCheckpointEpoch();
     expect(epoch).to.be.equal(0);
   });
 });

--- a/packages/lodestar/test/unit/api/rest/index.test.ts
+++ b/packages/lodestar/test/unit/api/rest/index.test.ts
@@ -8,6 +8,7 @@ export const BEACON_PREFIX = "/eth/v1/beacon";
 export const CONFIG_PREFIX = "/eth/v1/config";
 export const NODE_PREFIX = "/eth/v1/node";
 export const VALIDATOR_PREFIX = "/eth/v1/validator";
+export const LODESTAR_PREFIX = "/eth/v1/lodestar";
 
 export async function setupRestApiTestServer(): Promise<RestApi> {
   const api = new StubbedApi();
@@ -20,6 +21,7 @@ export async function setupRestApiTestServer(): Promise<RestApi> {
         ApiNamespace.EVENTS,
         ApiNamespace.NODE,
         ApiNamespace.VALIDATOR,
+        ApiNamespace.LODESTAR,
       ],
       cors: "*",
       enabled: true,

--- a/packages/lodestar/test/unit/api/rest/lodestar/index.test.ts
+++ b/packages/lodestar/test/unit/api/rest/lodestar/index.test.ts
@@ -1,0 +1,24 @@
+import supertest from "supertest";
+
+import {getLatestWeakSubjectivityCheckpointEpoch} from "../../../../../src/api/rest/controllers/lodestar";
+import {urlJoin} from "../utils";
+import {LODESTAR_PREFIX, setupRestApiTestServer} from "../index.test";
+import {RestApi} from "../../../../../src/api";
+import {StubbedLodestarApi} from "../../../../utils/stub/lodestarApi";
+
+describe("rest - lodestar - getLatestWeakSubjectivityCheckpointEpoch", function () {
+  let restApi: RestApi;
+  let lodestarApiStub: StubbedLodestarApi;
+
+  before(async function () {
+    restApi = await setupRestApiTestServer();
+    lodestarApiStub = restApi.server.api.lodestar as StubbedLodestarApi;
+  });
+
+  it("success", async function () {
+    lodestarApiStub.getLatestWeakSubjectivityCheckpointEpoch.resolves(0);
+    await supertest(restApi.server.server)
+      .get(urlJoin(LODESTAR_PREFIX, getLatestWeakSubjectivityCheckpointEpoch.url))
+      .expect(200);
+  });
+});

--- a/packages/lodestar/test/utils/stub/lodestarApi.ts
+++ b/packages/lodestar/test/utils/stub/lodestarApi.ts
@@ -1,0 +1,17 @@
+import Sinon, {SinonSandbox, SinonStubbedInstance} from "sinon";
+import {ApiNamespace} from "../../../src/api";
+import {ILodestarApi} from "../../../src/api/impl/lodestar";
+
+export class StubbedLodestarApi implements SinonStubbedInstance<ILodestarApi> {
+  namespace: ApiNamespace.LODESTAR = ApiNamespace.LODESTAR;
+
+  getWtfNode: Sinon.SinonStubbedMember<ILodestarApi["getWtfNode"]>;
+  getLatestWeakSubjectivityCheckpointEpoch: Sinon.SinonStubbedMember<
+    ILodestarApi["getLatestWeakSubjectivityCheckpointEpoch"]
+  >;
+
+  constructor(sandbox: SinonSandbox = Sinon) {
+    this.getWtfNode = sandbox.stub();
+    this.getLatestWeakSubjectivityCheckpointEpoch = sandbox.stub();
+  }
+}


### PR DESCRIPTION
make an api endpoint for getLatestWeakSubjectivityCheckpointEpoch that we can use to build a weak subjectivity beacon state