### PR TITLE
add config api namespace to api options for api.rest.api

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/api.ts
+++ b/packages/cli/src/options/beaconNodeOptions/api.ts
@@ -24,7 +24,7 @@ export function parseArgs(args: IApiArgs): IBeaconNodeOptions["api"] {
 export const options: ICliCommandOptions<IApiArgs> = {
   "api.rest.api": {
     type: "array",
-    choices: ["beacon", "validator", "node", "events", "debug", "lodestar"],
+    choices: ["beacon", "config", "validator", "node", "events", "debug", "lodestar"],
     description: "Pick namespaces to expose for HTTP API",
     defaultDescription: JSON.stringify(defaultOptions.api.rest.api),
     group: "api",

--- a/packages/lodestar/src/api/rest/options.ts
+++ b/packages/lodestar/src/api/rest/options.ts
@@ -11,7 +11,7 @@ export interface IRestApiOptions {
 export const defaultApiRestOptions: IRestApiOptions = {
   enabled: false,
   // ApiNamespace.DEBUG is not turned on by default
-  api: [ApiNamespace.BEACON, ApiNamespace.NODE, ApiNamespace.VALIDATOR, ApiNamespace.EVENTS],
+  api: [ApiNamespace.BEACON, ApiNamespace.CONFIG, ApiNamespace.NODE, ApiNamespace.VALIDATOR, ApiNamespace.EVENTS],
   host: "127.0.0.1",
   port: 9596,
   cors: "*",


### PR DESCRIPTION
forgot to add the CONFIG namespace to the list of cli options for `api.rest.api`.  also adds it to the `defaultApiRestOptions`