### PR TITLE
Create empty arrays more efficiently

### DIFF
--- a/packages/beacon-state-transition/src/altair/naive/epoch/flag.ts
+++ b/packages/beacon-state-transition/src/altair/naive/epoch/flag.ts
@@ -1,11 +1,12 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {altair, ParticipationFlags} from "@chainsafe/lodestar-types";
 import {List} from "@chainsafe/ssz";
+import {newZeroedArray} from "../../../util";
 
 /**
  * Call to ``process_participation_flag_updates`` added to ``process_epoch`` in HF1
  */
 export function processParticipationFlagUpdates(config: IBeaconConfig, state: altair.BeaconState): void {
   state.previousEpochParticipation = state.currentEpochParticipation;
-  state.currentEpochParticipation = Array.from({length: state.validators.length}, () => 0) as List<ParticipationFlags>;
+  state.currentEpochParticipation = newZeroedArray(state.validators.length) as List<ParticipationFlags>;
 }

--- a/packages/beacon-state-transition/src/altair/naive/upgrade.ts
+++ b/packages/beacon-state-transition/src/altair/naive/upgrade.ts
@@ -2,10 +2,11 @@ import {List} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {phase0, altair, ParticipationFlags, Uint8} from "@chainsafe/lodestar-types";
 
-import {getCurrentEpoch} from "../../util";
+import {getCurrentEpoch, newZeroedArray} from "../../util";
 
 export function upgrade(config: IBeaconConfig, pre: phase0.BeaconState): altair.BeaconState {
   const epoch = getCurrentEpoch(config, pre);
+  const validatorCount = pre.validators.length;
   const {previousEpochAttestations: _1, currentEpochAttestations: _2, ...old} = pre;
   return {
     ...(old as Omit<phase0.BeaconState, "previousEpochAttestations" | "currentEpochAttestations">),
@@ -14,9 +15,9 @@ export function upgrade(config: IBeaconConfig, pre: phase0.BeaconState): altair.
       currentVersion: config.params.ALTAIR_FORK_VERSION,
       epoch,
     },
-    previousEpochParticipation: Array.from({length: pre.validators.length}, () => 0) as List<ParticipationFlags>,
-    currentEpochParticipation: Array.from({length: pre.validators.length}, () => 0) as List<ParticipationFlags>,
-    inactivityScores: Array.from({length: pre.validators.length}, () => 0) as List<Uint8>,
+    previousEpochParticipation: newZeroedArray(validatorCount) as List<ParticipationFlags>,
+    currentEpochParticipation: newZeroedArray(validatorCount) as List<ParticipationFlags>,
+    inactivityScores: newZeroedArray(validatorCount) as List<Uint8>,
     currentSyncCommittee: config.types.altair.SyncCommittee.defaultValue(),
     nextSyncCommittee: config.types.altair.SyncCommittee.defaultValue(),
   };

--- a/packages/beacon-state-transition/src/altair/state_accessor/balance.ts
+++ b/packages/beacon-state-transition/src/altair/state_accessor/balance.ts
@@ -3,6 +3,7 @@ import {altair, Gwei, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {bigIntSqrt} from "@chainsafe/lodestar-utils";
 import {getUnslashedParticipatingIndices} from "./index";
 import {getPreviousEpoch} from "../../util/epoch";
+import {newZeroedBigIntArray} from "../../../src/util";
 import {getTotalBalance, getTotalActiveBalance} from "../../util/balance";
 import {TIMELY_TARGET_FLAG_INDEX, WEIGHT_DENOMINATOR} from "../constants";
 import {getFlagIndicesAndWeights} from "../misc";
@@ -17,8 +18,9 @@ export function getFlagIndexDeltas(
   flagIndex: number,
   weight: bigint
 ): [Gwei[], Gwei[]] {
-  const rewards = Array.from({length: state.validators.length}, () => BigInt(0));
-  const penalties = Array.from({length: state.validators.length}, () => BigInt(0));
+  const validatorCount = state.validators.length;
+  const rewards = newZeroedBigIntArray(validatorCount);
+  const penalties = newZeroedBigIntArray(validatorCount);
 
   const unslashedParticipatingIndices = getUnslashedParticipatingIndices(
     config,
@@ -50,8 +52,9 @@ export function getFlagIndexDeltas(
  * Return the inactivity penalty deltas by considering timely target participation flags and inactivity scores.
  */
 export function getInactivityPenaltyDeltas(config: IBeaconConfig, state: altair.BeaconState): [Gwei[], Gwei[]] {
-  const rewards = Array.from({length: state.validators.length}, () => BigInt(0));
-  const penalties = Array.from({length: state.validators.length}, () => BigInt(0));
+  const validatorCount = state.validators.length;
+  const rewards = newZeroedBigIntArray(validatorCount);
+  const penalties = newZeroedBigIntArray(validatorCount);
   const previousEpoch = getPreviousEpoch(config, state);
 
   if (phase0.isInInactivityLeak(config, (state as unknown) as phase0.BeaconState)) {

--- a/packages/beacon-state-transition/src/phase0/fast/block/processDeposit.ts
+++ b/packages/beacon-state-transition/src/phase0/fast/block/processDeposit.ts
@@ -13,7 +13,7 @@ export function processDeposit(state: CachedBeaconState<phase0.BeaconState>, dep
   if (
     !verifyMerkleBranch(
       config.types.phase0.DepositData.hashTreeRoot(deposit.data),
-      Array.from({length: deposit.proof.length}, (_, i) => deposit.proof[i].valueOf() as Uint8Array),
+      Array.from(deposit.proof).map((p) => p.valueOf() as Uint8Array),
       DEPOSIT_CONTRACT_TREE_DEPTH + 1,
       state.eth1DepositIndex,
       state.eth1Data.depositRoot.valueOf() as Uint8Array

--- a/packages/beacon-state-transition/src/phase0/fast/epoch/getAttestationDeltas.ts
+++ b/packages/beacon-state-transition/src/phase0/fast/epoch/getAttestationDeltas.ts
@@ -1,7 +1,7 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {bigIntSqrt, bigIntMax, intDiv} from "@chainsafe/lodestar-utils";
 import {BASE_REWARDS_PER_EPOCH as BASE_REWARDS_PER_EPOCH_CONST} from "../../../constants";
-
+import {newZeroedArray} from "../../../util";
 import {
   IEpochProcess,
   hasMarkers,
@@ -22,8 +22,8 @@ export function getAttestationDeltas(
 ): [number[], number[]] {
   const params = state.config.params;
   const validatorCount = process.statuses.length;
-  const rewards = Array.from({length: validatorCount}, () => 0);
-  const penalties = Array.from({length: validatorCount}, () => 0);
+  const rewards = newZeroedArray(validatorCount);
+  const penalties = newZeroedArray(validatorCount);
 
   const increment = params.EFFECTIVE_BALANCE_INCREMENT;
   let totalBalance = bigIntMax(process.totalActiveStake, increment);

--- a/packages/beacon-state-transition/src/phase0/naive/epoch/balanceUpdates/attestation.ts
+++ b/packages/beacon-state-transition/src/phase0/naive/epoch/balanceUpdates/attestation.ts
@@ -12,6 +12,7 @@ import {
   getTotalActiveBalance,
   getTotalBalance,
   isActiveValidator,
+  newZeroedBigIntArray,
 } from "../../../../util";
 
 import {
@@ -47,8 +48,9 @@ export function getAttestationComponentDeltas(
 ): [bigint[], bigint[]] {
   const unslashedAttestingIndices = getUnslashedAttestingIndices(config, state, attestations);
   const attestingBalance = getTotalBalance(config, state, unslashedAttestingIndices);
-  const rewards = Array.from({length: state.validators.length}, () => BigInt(0));
-  const penalties = Array.from({length: state.validators.length}, () => BigInt(0));
+  const validatorCount = state.validators.length;
+  const rewards = newZeroedBigIntArray(validatorCount);
+  const penalties = newZeroedBigIntArray(validatorCount);
   const totalBalance = getTotalActiveBalance(config, state);
 
   for (const index of getEligibleValidatorIndices(config, state)) {
@@ -101,7 +103,7 @@ export function getHeadDeltas(config: IBeaconConfig, state: phase0.BeaconState):
  */
 export function getInclusionDelayDeltas(config: IBeaconConfig, state: phase0.BeaconState): bigint[] {
   const previousEpoch = getPreviousEpoch(config, state);
-  const rewards = Array.from({length: state.validators.length}, () => BigInt(0));
+  const rewards = newZeroedBigIntArray(state.validators.length);
   const matchingSourceAttestations = getMatchingSourceAttestations(config, state, previousEpoch);
 
   for (const index of getUnslashedAttestingIndices(config, state, matchingSourceAttestations)) {
@@ -123,7 +125,7 @@ export function getInclusionDelayDeltas(config: IBeaconConfig, state: phase0.Bea
  * Return inactivity reward/penalty deltas for each validator.
  */
 export function getInactivityPenaltyDeltas(config: IBeaconConfig, state: phase0.BeaconState): bigint[] {
-  const penalties = Array.from({length: state.validators.length}, () => BigInt(0));
+  const penalties = newZeroedBigIntArray(state.validators.length);
   const previousEpoch = getPreviousEpoch(config, state);
   const matchingTargetAttestations = getMatchingTargetAttestations(config, state, previousEpoch);
   if (isInInactivityLeak(config, state)) {

--- a/packages/beacon-state-transition/src/util/array.ts
+++ b/packages/beacon-state-transition/src/util/array.ts
@@ -1,0 +1,24 @@
+/**
+ * Returns an array of size `n` filled with 0
+ * 20 times faster than
+ * ```
+ * Array.from({length: n}, () => 0)
+ * ```
+ * - Array.from: 40ms / 200_000 elements
+ * - This fn: 2.2ms / 200_000 elements
+ */
+export function newZeroedArray(n: number): number[] {
+  const arr = new Array<number>(n);
+  for (let i = 0; i < n; ++i) {
+    arr[i] = 0;
+  }
+  return arr;
+}
+
+export function newZeroedBigIntArray(n: number): bigint[] {
+  const arr = new Array<bigint>(n);
+  for (let i = 0; i < n; ++i) {
+    arr[i] = BigInt(0);
+  }
+  return arr;
+}

--- a/packages/beacon-state-transition/src/util/index.ts
+++ b/packages/beacon-state-transition/src/util/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from "./activation";
+export * from "./array";
 export * from "./attestation";
 export * from "./balance";
 export * from "./block";

--- a/packages/beacon-state-transition/test/perf/phase0/fast/epoch/arrayCreation.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/fast/epoch/arrayCreation.test.ts
@@ -1,0 +1,42 @@
+describe("array creation", function () {
+  const testCases: {id: string; fn: (n: number) => void}[] = [
+    {
+      id: "Array.from(() => 0)",
+      fn: (n) => Array.from({length: n}, () => 0),
+    },
+    {
+      id: "Array.from().fill(0)",
+      fn: (n) => Array.from({length: n}).fill(0),
+    },
+    {
+      id: "Array.from()",
+      fn: (n) => Array.from({length: n}),
+    },
+    {
+      id: "new Array()",
+      fn: (n) => new Array<number>(n),
+    },
+    {
+      id: "new Array(); for loop",
+      fn: (n) => {
+        const a = new Array(n);
+        for (let i = 0; i < n; ++i) a[i] = 0;
+      },
+    },
+  ];
+
+  for (const {id, fn} of testCases) {
+    it(id, () => {
+      const opsRun = 10;
+      const elem = 200_000;
+
+      const from = process.hrtime.bigint();
+      for (let i = 0; i < opsRun; i++) {
+        fn(elem);
+      }
+      const to = process.hrtime.bigint();
+      const diffMs = Number(to - from) / 1e6;
+      console.log(`${id}: ${diffMs / opsRun} ms`);
+    });
+  }
+});

--- a/packages/beacon-state-transition/test/utils/state.ts
+++ b/packages/beacon-state-transition/test/utils/state.ts
@@ -1,11 +1,11 @@
 import {List, Vector} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
+import {config} from "@chainsafe/lodestar-config/mainnet";
 
 import {GENESIS_EPOCH, GENESIS_SLOT, ZERO_HASH} from "../../src/constants";
+import {newZeroedBigIntArray} from "../../src/util";
 
 import {generateEmptyBlock} from "./block";
-
-import {config} from "@chainsafe/lodestar-config/mainnet";
 
 /**
  * Copy of BeaconState, but all fields are marked optional to allow for swapping out variables as needed.
@@ -48,7 +48,7 @@ export function generateState(opts?: TestBeaconState): phase0.BeaconState {
     validators: ([] as phase0.Validator[]) as List<phase0.Validator>,
     balances: ([] as bigint[]) as List<bigint>,
     randaoMixes: Array.from({length: config.params.EPOCHS_PER_HISTORICAL_VECTOR}, () => ZERO_HASH),
-    slashings: Array.from({length: config.params.EPOCHS_PER_SLASHINGS_VECTOR}, () => BigInt(0)),
+    slashings: newZeroedBigIntArray(config.params.EPOCHS_PER_SLASHINGS_VECTOR),
     previousEpochAttestations: ([] as phase0.PendingAttestation[]) as List<phase0.PendingAttestation>,
     currentEpochAttestations: ([] as phase0.PendingAttestation[]) as List<phase0.PendingAttestation>,
     justificationBits: [false, false, false, false],


### PR DESCRIPTION
**Motivation**

Benchmarked getAttestationDeltas()

**Description**

Creating arrays in a different way is significanly faster that what we use.

Using `newZeroedArray()` saves about 95 ms per epoch transition in Prater