### PR TITLE
Don't use intDiv

### DIFF
--- a/packages/beacon-state-transition/src/fast/util/epochShuffling.ts
+++ b/packages/beacon-state-transition/src/fast/util/epochShuffling.ts
@@ -77,8 +77,8 @@ export function computeEpochShuffling(
 
   const sliceCommittee = (slot: number, committeeIndex: number): ValidatorIndex[] => {
     const index = slot * committeesPerSlot + committeeIndex;
-    const startOffset = intDiv(activeValidatorCount * index, committeeCount);
-    const endOffset = intDiv(activeValidatorCount * (index + 1), committeeCount);
+    const startOffset = Math.floor((activeValidatorCount * index) / committeeCount);
+    const endOffset = Math.floor((activeValidatorCount * (index + 1)) / committeeCount);
     if (!(startOffset <= endOffset)) {
       throw new Error(`Invalid offsets: start ${startOffset} must be less than or equal end ${endOffset}`);
     }

--- a/packages/beacon-state-transition/src/phase0/fast/epoch/getAttestationDeltas.ts
+++ b/packages/beacon-state-transition/src/phase0/fast/epoch/getAttestationDeltas.ts
@@ -1,5 +1,5 @@
 import {phase0} from "@chainsafe/lodestar-types";
-import {bigIntSqrt, bigIntMax, intDiv} from "@chainsafe/lodestar-utils";
+import {bigIntSqrt, bigIntMax} from "@chainsafe/lodestar-utils";
 import {BASE_REWARDS_PER_EPOCH as BASE_REWARDS_PER_EPOCH_CONST} from "../../../constants";
 
 import {
@@ -48,13 +48,13 @@ export function getAttestationDeltas(
   for (const [i, status] of process.statuses.entries()) {
     const effBalance = status.validator.effectiveBalance;
     const baseReward = Number((effBalance * BASE_REWARD_FACTOR) / balanceSqRoot / BASE_REWARDS_PER_EPOCH);
-    const proposerReward = intDiv(baseReward, params.PROPOSER_REWARD_QUOTIENT);
+    const proposerReward = Math.floor(baseReward / params.PROPOSER_REWARD_QUOTIENT);
 
     // inclusion speed bonus
     if (hasMarkers(status.flags, FLAG_PREV_SOURCE_ATTESTER | FLAG_UNSLASHED)) {
       rewards[status.proposerIndex] += proposerReward;
       const maxAttesterReward = baseReward - proposerReward;
-      rewards[i] += intDiv(maxAttesterReward, status.inclusionDelay);
+      rewards[i] += Math.floor(maxAttesterReward / status.inclusionDelay);
     }
     if (hasMarkers(status.flags, FLAG_ELIGIBLE_ATTESTER)) {
       // expected FFG source

--- a/packages/beacon-state-transition/src/util/seed.ts
+++ b/packages/beacon-state-transition/src/util/seed.ts
@@ -5,7 +5,7 @@
 import {hash} from "@chainsafe/ssz";
 import {Epoch, Bytes32, DomainType, allForks} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {assert, bytesToBigInt, intToBytes, intDiv} from "@chainsafe/lodestar-utils";
+import {assert, bytesToBigInt, intToBytes} from "@chainsafe/lodestar-utils";
 
 /**
  * Return the shuffled validator index corresponding to ``seed`` (and ``index_count``).
@@ -26,8 +26,8 @@ export function computeShuffledIndex(config: IBeaconConfig, index: number, index
     );
     const flip = (pivot + indexCount - permuted) % indexCount;
     const position = Math.max(permuted, flip);
-    const source = hash(Buffer.concat([_seed, intToBytes(i, 1), intToBytes(intDiv(position, 256), 4)]));
-    const byte = source[intDiv(position % 256, 8)];
+    const source = hash(Buffer.concat([_seed, intToBytes(i, 1), intToBytes(Math.floor(position / 256), 4)]));
+    const byte = source[Math.floor((position % 256) / 8)];
     const bit = (byte >> position % 8) % 2;
     permuted = bit ? flip : permuted;
   }

--- a/packages/beacon-state-transition/src/util/slot.ts
+++ b/packages/beacon-state-transition/src/util/slot.ts
@@ -1,12 +1,11 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Number64, Slot, Epoch} from "@chainsafe/lodestar-types";
-import {intDiv} from "@chainsafe/lodestar-utils";
 import {computeStartSlotAtEpoch, computeEpochAtSlot} from ".";
 import {GENESIS_SLOT} from "../constants";
 
 export function getSlotsSinceGenesis(config: IBeaconConfig, genesisTime: Number64): Slot {
   const diffInSeconds = Date.now() / 1000 - genesisTime;
-  return intDiv(diffInSeconds, config.params.SECONDS_PER_SLOT);
+  return Math.floor(diffInSeconds / config.params.SECONDS_PER_SLOT);
 }
 
 export function getCurrentSlot(config: IBeaconConfig, genesisTime: Number64): Slot {


### PR DESCRIPTION
**Motivation**

Benchmarking getAttestationDeltas()

**Description**

Calling `intDiv()` added 25% extra CPU time in `getAttestationDeltas()`. `Math.floor(a / b)` in almost as readable as `intDiv()`, and in hot paths it makes sense to save up on extra function invocation. I've replaced intDiv() in the places that could be hot paths only.