### PR TITLE
Benchmark shuffle

### DIFF
--- a/packages/beacon-state-transition/test/perf/runner.ts
+++ b/packages/beacon-state-transition/test/perf/runner.ts
@@ -1,0 +1,90 @@
+type PromiseOptional<T> = T | Promise<T>;
+export type BenchmarkOpts = {
+  runs?: number;
+  maxMs?: number;
+};
+
+/* eslint-disable no-console */
+
+export class BenchmarkRunner {
+  opts: BenchmarkOpts;
+  constructor(title: string, opts?: BenchmarkOpts) {
+    this.opts = opts || {};
+    console.log(formatTitle(title));
+  }
+
+  async run<T1, R = void>({before, run, check, id, ...opts}: RunOpts<T1, R>): Promise<number> {
+    const runs = opts.runs || this.opts.runs || 512;
+    const maxMs = opts.maxMs || this.opts.maxMs || 2000;
+
+    const diffsNanoSec: bigint[] = [];
+
+    const start = Date.now();
+    let i = 0;
+    while (i++ < runs && Date.now() - start < maxMs) {
+      const input = before ? await before(i) : undefined;
+
+      const start = process.hrtime.bigint();
+      const result = await run(input as T1);
+      const end = process.hrtime.bigint();
+
+      if (check && check(result)) throw Error("Result fails check test");
+
+      diffsNanoSec.push(end - start);
+    }
+
+    const average = averageBigint(diffsNanoSec);
+    const averageNs = Number(average);
+    // eslint-disable-next-line no-console
+    console.log(formatRow({id, averageNs, runsDone: i - 1})); // ±1.74%
+
+    return averageNs;
+  }
+}
+
+type RunOpts<T1, R = void> = {
+  before?: (i?: number) => PromiseOptional<T1>;
+  run: (input: T1) => PromiseOptional<R>;
+  check?: (result: R) => boolean;
+  runs?: number;
+  maxMs?: number;
+  id: string;
+};
+
+function averageBigint(arr: bigint[]): bigint {
+  const total = arr.reduce((total, value) => total + value);
+  return total / BigInt(arr.length);
+}
+
+function formatRow({id, averageNs, runsDone}: {id: string; averageNs: number; runsDone: number}): string {
+  const precision = 7;
+  const idLen = 64;
+
+  const opsPerSec = 1e9 / averageNs;
+
+  // ================================================================================================================
+  // Scalar multiplication G1 (255-bit, constant-time)                              7219.330 ops/s       138517 ns/op
+  // Scalar multiplication G2 (255-bit, constant-time)                              3133.117 ops/s       319171 ns/op
+
+  const [avgNum, unit] = prettyNs(averageNs);
+  const row = [
+    `${opsPerSec.toPrecision(precision).padStart(13)} ops/s`,
+    `${avgNum.toPrecision(precision).padStart(13)} ${unit}/op`,
+    `${String(runsDone).padStart(6)} runs`,
+  ].join(" ");
+
+  return id.slice(0, idLen).padEnd(idLen) + " " + row;
+}
+
+export function formatTitle(title: string): string {
+  return `
+${title}
+${"=".repeat(64)}`;
+}
+
+function prettyNs(ns: number): [number, string] {
+  if (ns > 1e9) return [ns / 1e9, " s"];
+  if (ns > 1e6) return [ns / 1e6, "ms"];
+  if (ns > 1e3) return [ns / 1e3, "μs"];
+  return [ns, "ns"];
+}

--- a/packages/beacon-state-transition/test/perf/shuffle/numberMath.perf.ts
+++ b/packages/beacon-state-transition/test/perf/shuffle/numberMath.perf.ts
@@ -2,21 +2,61 @@ import {BenchmarkRunner} from "../runner";
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async function () {
-  const runner = new BenchmarkRunner("shuffle list", {
+  const runner = new BenchmarkRunner("shuffle number math ops", {
     runs: 512,
     maxMs: 10 * 1000,
   });
 
-  const j = 12354233;
-  const forRuns = 1e5;
+  const forRuns = 100e5;
+  const j = forRuns / 2;
 
-  const arrSize = 2e5;
+  const arrSize = forRuns;
   const input: number[] = [];
   const inputUint32Array = new Uint32Array(arrSize);
   for (let i = 0; i < arrSize; i++) {
     input[i] = i;
     inputUint32Array[i] = i;
   }
+
+  await runner.run({
+    id: "if(i == 1)",
+    run: () => {
+      for (let i = 0; i < forRuns; i++) {
+        if (i === 1) {
+          //
+        }
+      }
+    },
+  });
+
+  await runner.run({
+    id: "if(i)",
+    run: () => {
+      for (let i = 0; i < forRuns; i++) {
+        if (i) {
+          //
+        }
+      }
+    },
+  });
+
+  await runner.run({
+    id: "i == j",
+    run: () => {
+      for (let i = 0; i < forRuns; i++) {
+        i == j;
+      }
+    },
+  });
+
+  await runner.run({
+    id: "i === j",
+    run: () => {
+      for (let i = 0; i < forRuns; i++) {
+        i === j;
+      }
+    },
+  });
 
   await runner.run({
     id: "bit opts",

--- a/packages/beacon-state-transition/test/perf/shuffle/numberMath.perf.ts
+++ b/packages/beacon-state-transition/test/perf/shuffle/numberMath.perf.ts
@@ -58,8 +58,8 @@ import {BenchmarkRunner} from "../runner";
     id: "swap item in array",
     run: () => {
       for (let i = 0; i < forRuns; i++) {
-        const tmp = input[j];
-        input[j] = input[i];
+        const tmp = input[forRuns - i];
+        input[forRuns - i] = input[i];
         input[i] = tmp;
       }
     },
@@ -69,8 +69,8 @@ import {BenchmarkRunner} from "../runner";
     id: "swap item in Uint32Array",
     run: () => {
       for (let i = 0; i < forRuns; i++) {
-        const tmp = inputUint32Array[j];
-        inputUint32Array[j] = inputUint32Array[i];
+        const tmp = inputUint32Array[forRuns - i];
+        inputUint32Array[forRuns - i] = inputUint32Array[i];
         inputUint32Array[i] = tmp;
       }
     },

--- a/packages/beacon-state-transition/test/perf/shuffle/numberMath.perf.ts
+++ b/packages/beacon-state-transition/test/perf/shuffle/numberMath.perf.ts
@@ -10,8 +10,13 @@ import {BenchmarkRunner} from "../runner";
   const j = 12354233;
   const forRuns = 1e5;
 
+  const arrSize = 2e5;
   const input: number[] = [];
-  for (let i = 0; i < 2e5; i++) input[i] = i;
+  const inputUint32Array = new Uint32Array(arrSize);
+  for (let i = 0; i < arrSize; i++) {
+    input[i] = i;
+    inputUint32Array[i] = i;
+  }
 
   await runner.run({
     id: "bit opts",
@@ -56,6 +61,17 @@ import {BenchmarkRunner} from "../runner";
         const tmp = input[j];
         input[j] = input[i];
         input[i] = tmp;
+      }
+    },
+  });
+
+  await runner.run({
+    id: "swap item in Uint32Array",
+    run: () => {
+      for (let i = 0; i < forRuns; i++) {
+        const tmp = inputUint32Array[j];
+        inputUint32Array[j] = inputUint32Array[i];
+        inputUint32Array[i] = tmp;
       }
     },
   });

--- a/packages/beacon-state-transition/test/perf/shuffle/numberMath.perf.ts
+++ b/packages/beacon-state-transition/test/perf/shuffle/numberMath.perf.ts
@@ -1,0 +1,62 @@
+import {BenchmarkRunner} from "../runner";
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+(async function () {
+  const runner = new BenchmarkRunner("shuffle list", {
+    runs: 512,
+    maxMs: 10 * 1000,
+  });
+
+  const j = 12354233;
+  const forRuns = 1e5;
+
+  const input: number[] = [];
+  for (let i = 0; i < 2e5; i++) input[i] = i;
+
+  await runner.run({
+    id: "bit opts",
+    run: () => {
+      for (let i = 0; i < forRuns; i++) {
+        (j & 0x7) == 0x7;
+      }
+    },
+  });
+
+  await runner.run({
+    id: "modulo",
+    run: () => {
+      for (let i = 0; i < forRuns; i++) {
+        j % 8 == 0;
+      }
+    },
+  });
+
+  await runner.run({
+    id: ">> 3",
+    run: () => {
+      for (let i = 0; i < forRuns; i++) {
+        j >> 3;
+      }
+    },
+  });
+
+  await runner.run({
+    id: "/ 8",
+    run: () => {
+      for (let i = 0; i < forRuns; i++) {
+        j / 8;
+      }
+    },
+  });
+
+  await runner.run({
+    id: "swap item in array",
+    run: () => {
+      for (let i = 0; i < forRuns; i++) {
+        const tmp = input[j];
+        input[j] = input[i];
+        input[i] = tmp;
+      }
+    },
+  });
+})();

--- a/packages/beacon-state-transition/test/perf/shuffle/shuffle.perf.ts
+++ b/packages/beacon-state-transition/test/perf/shuffle/shuffle.perf.ts
@@ -1,0 +1,40 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {unshuffleList} from "../../../src";
+import {BenchmarkRunner} from "../runner";
+
+//          Lightouse  Lodestar
+// 512      254.04 us  1.6034 ms (x6)
+// 16384    6.2046 ms  18.272 ms (x3)
+// 4000000  1.5617 s   4.9690 s  (x3)
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+(async function () {
+  const config = {
+    params: {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      SHUFFLE_ROUND_COUNT: 90,
+    },
+  } as IBeaconConfig;
+  const seed = new Uint8Array([42, 32]);
+
+  const runner = new BenchmarkRunner("shuffle list", {
+    runs: 512,
+    maxMs: 30 * 1000,
+  });
+
+  for (const listSize of [512, 16384, 4000000]) {
+    await runner.run({
+      id: `list size ${listSize}`,
+      before: () => {
+        const input: number[] = [];
+        for (let i = 0; i < listSize; i++) {
+          input[i] = i;
+        }
+        return input;
+      },
+      run: (input) => {
+        unshuffleList(config, input, seed);
+      },
+    });
+  }
+})();

--- a/packages/beacon-state-transition/test/perf/shuffle/shuffle.perf.ts
+++ b/packages/beacon-state-transition/test/perf/shuffle/shuffle.perf.ts
@@ -9,12 +9,8 @@ import {BenchmarkRunner} from "../runner";
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async function () {
-  const config = {
-    params: {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      SHUFFLE_ROUND_COUNT: 90,
-    },
-  } as IBeaconConfig;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const config = {params: {SHUFFLE_ROUND_COUNT: 90}} as IBeaconConfig;
   const seed = new Uint8Array([42, 32]);
 
   const runner = new BenchmarkRunner("shuffle list", {

--- a/packages/beacon-state-transition/test/unit/stateTransition/util/shuffle.test.ts
+++ b/packages/beacon-state-transition/test/unit/stateTransition/util/shuffle.test.ts
@@ -1,0 +1,34 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {expect} from "chai";
+import {unshuffleList} from "../../../../src";
+
+describe("util / shuffle", () => {
+  const testCases: {
+    id: string;
+    input: number[];
+    res: number[];
+  }[] = [
+    // Values from `unshuffleList()` at commit https://github.com/ChainSafe/lodestar/commit/ec065635ca7da7f3788da018bd68c4900f0427d2
+    {
+      id: "8 elements",
+      input: [0, 1, 2, 3, 4, 5, 6, 7],
+      res: [6, 3, 4, 0, 1, 5, 7, 2],
+    },
+    {
+      id: "16 elements",
+      input: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+      res: [8, 4, 11, 7, 10, 6, 0, 3, 15, 12, 5, 14, 1, 9, 13, 2],
+    },
+  ];
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const config = {params: {SHUFFLE_ROUND_COUNT: 90}} as IBeaconConfig;
+  const seed = new Uint8Array([42, 32]);
+
+  for (const {id, input, res} of testCases) {
+    it(id, () => {
+      unshuffleList(config, input, seed);
+      expect(input).to.deep.equal(res);
+    });
+  }
+});


### PR DESCRIPTION
**Motivation**

Research performance improvements for the shuffle routine. See https://github.com/ChainSafe/lodestar/issues/2352

**Description**

- Adds multiple benchmarks to understand the cost of each component
- Inline closure. It's the only optimization that consistently showed significant improvements. It also matches the implementations in Go and Rust. It reduces the total cpu time (expect spent on hashing) by 50%

**Next steps**

- Hashing takes 80% of total CPU time so increasing the performance of our hashing library would have a big impact.
- Then we could consider paralleling this function. Given the overhead cost of message passing in Javascript this is not a route we should take until the validator set is really big.

---

> Proto: Each round can be computed independently (or in groups, e.g. rounds 0-10, 10-20, etc.), and then you can merge them afterwards. If you use some webworker approach, that may be may improve things.

> Proto: The parallelizing thing works like:
> - create a list of 0...N for each worker
> - assign a round start and end to each worker. E.g. worker 2 does rounds 20...30 of the total 90 rounds.
> - every worker runs the list shuffle for their range of rounds
> - a final merge step: apply the "mapping" of each worker to the input, in the order of the rounds

> Memory-wise: Each worker basically requires as much memory as the original algo: N uint32 values.
> Plus some small constant, to cover memory of the hash function and temporary variables.