### PR TITLE
Use createValidatorFlat instead of createFlat

### DIFF
--- a/packages/beacon-state-transition/src/fast/util/cachedBeaconState.ts
+++ b/packages/beacon-state-transition/src/fast/util/cachedBeaconState.ts
@@ -14,7 +14,7 @@ import {allForks} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Tree} from "@chainsafe/persistent-merkle-tree";
 import {MutableVector} from "@chainsafe/persistent-ts";
-import {createFlat} from "./flat";
+import {createValidatorFlat} from "./flat";
 import {createEpochContext, EpochContext, EpochContextOpts} from "./epochContext";
 import {CachedValidatorList, CachedValidatorListProxyHandler} from "./cachedValidatorList";
 import {CachedBalanceList, CachedBalanceListProxyHandler} from "./cachedBalanceList";
@@ -44,7 +44,9 @@ export function createCachedBeaconState<T extends allForks.BeaconState>(
   state: TreeBacked<T>,
   opts?: EpochContextOpts
 ): CachedBeaconState<T> {
-  const cachedValidators = MutableVector.from(Array.from(readonlyValues(state.validators), (v) => createFlat(v)));
+  const cachedValidators = MutableVector.from(
+    Array.from(readonlyValues(state.validators), (v) => createValidatorFlat(v))
+  );
   const cachedBalances = MutableVector.from(readonlyValues(state.balances));
   const epochCtx = createEpochContext(config, state, cachedValidators, opts);
   return new Proxy(
@@ -81,7 +83,8 @@ export class BeaconStateContext<T extends allForks.BeaconState> {
       new CachedValidatorList(
         this.type.fields["validators"] as CompositeListType<List<T["validators"][number]>>,
         this.type.tree_getProperty(this.tree, "validators") as Tree,
-        validatorCache
+        validatorCache,
+        createValidatorFlat
       ),
       CachedValidatorListProxyHandler
     ) as unknown) as CachedValidatorList<T["validators"][number]> & T["validators"];

--- a/packages/beacon-state-transition/src/fast/util/cachedBeaconState.ts
+++ b/packages/beacon-state-transition/src/fast/util/cachedBeaconState.ts
@@ -83,8 +83,7 @@ export class BeaconStateContext<T extends allForks.BeaconState> {
       new CachedValidatorList(
         this.type.fields["validators"] as CompositeListType<List<T["validators"][number]>>,
         this.type.tree_getProperty(this.tree, "validators") as Tree,
-        validatorCache,
-        createValidatorFlat
+        validatorCache
       ),
       CachedValidatorListProxyHandler
     ) as unknown) as CachedValidatorList<T["validators"][number]> & T["validators"];

--- a/packages/beacon-state-transition/src/fast/util/flat.ts
+++ b/packages/beacon-state-transition/src/fast/util/flat.ts
@@ -1,13 +1,16 @@
-import {ObjectLike, readonlyEntries} from "@chainsafe/ssz";
+import {BLSPubkey, Bytes32, Validator} from "@chainsafe/lodestar-types/phase0";
 
 // A "flat" validator is a concrete `Validator`
 // For intermediate computation, the TreeBacked representation slows things down, so a regular object is used instead.
-
-export function createFlat<T = ObjectLike>(value: T): T {
-  const flat = {} as Record<string, T[keyof T]>;
-  for (const [k, v] of readonlyEntries(value)) {
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    flat[k as string] = ((v as unknown) as object).valueOf() as T[keyof T];
-  }
-  return (flat as unknown) as T;
+export function createValidatorFlat(v: Validator): Validator {
+  return {
+    pubkey: v.pubkey.valueOf() as BLSPubkey,
+    withdrawalCredentials: v.withdrawalCredentials.valueOf() as Bytes32,
+    effectiveBalance: v.effectiveBalance,
+    slashed: v.slashed,
+    activationEligibilityEpoch: v.activationEligibilityEpoch,
+    activationEpoch: v.activationEpoch,
+    exitEpoch: v.exitEpoch,
+    withdrawableEpoch: v.withdrawableEpoch,
+  };
 }

--- a/packages/beacon-state-transition/src/fast/util/flat.ts
+++ b/packages/beacon-state-transition/src/fast/util/flat.ts
@@ -1,11 +1,11 @@
-import {BLSPubkey, Bytes32, Validator} from "@chainsafe/lodestar-types/phase0";
+import {phase0} from "@chainsafe/lodestar-types";
 
 // A "flat" validator is a concrete `Validator`
 // For intermediate computation, the TreeBacked representation slows things down, so a regular object is used instead.
-export function createValidatorFlat(v: Validator): Validator {
+export function createValidatorFlat(v: phase0.Validator): phase0.Validator {
   return {
-    pubkey: v.pubkey.valueOf() as BLSPubkey,
-    withdrawalCredentials: v.withdrawalCredentials.valueOf() as Bytes32,
+    pubkey: v.pubkey.valueOf() as phase0.BLSPubkey,
+    withdrawalCredentials: v.withdrawalCredentials.valueOf() as phase0.Bytes32,
     effectiveBalance: v.effectiveBalance,
     slashed: v.slashed,
     activationEligibilityEpoch: v.activationEligibilityEpoch,


### PR DESCRIPTION
**Motivation**

Due to #2331 , all flow looping through `state.validators` and access validator properties takes so much time (>= 3x) like `processValidatorExit`, `getEffectiveBalances` ...

**Description**

Drop the generic version `createFlat` in favor of `createValidatorFlat`.

Closes #2325 
