### PR TITLE
Remove null types from API

### DIFF
--- a/packages/lodestar/src/api/impl/beacon/beacon.ts
+++ b/packages/lodestar/src/api/impl/beacon/beacon.ts
@@ -6,8 +6,6 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {phase0} from "@chainsafe/lodestar-types";
 import {LodestarEventIterator} from "@chainsafe/lodestar-utils";
 import {ChainEvent, IBeaconChain} from "../../../chain";
-import {IBeaconDb} from "../../../db";
-import {IBeaconSync} from "../../../sync";
 import {IApiOptions} from "../../options";
 import {ApiNamespace, IApiModules} from "../interface";
 import {BeaconBlockApi, IBeaconBlocksApi} from "./blocks";
@@ -24,21 +22,17 @@ export class BeaconApi implements IBeaconApi {
 
   private readonly config: IBeaconConfig;
   private readonly chain: IBeaconChain;
-  private readonly db: IBeaconDb;
-  private readonly sync: IBeaconSync;
 
   constructor(opts: Partial<IApiOptions>, modules: Pick<IApiModules, "config" | "chain" | "db" | "network" | "sync">) {
     this.namespace = ApiNamespace.BEACON;
     this.config = modules.config;
     this.chain = modules.chain;
-    this.db = modules.db;
-    this.sync = modules.sync;
     this.state = new BeaconStateApi(opts, modules);
     this.blocks = new BeaconBlockApi(opts, modules);
     this.pool = new BeaconPoolApi(opts, modules);
   }
 
-  async getGenesis(): Promise<phase0.Genesis | null> {
+  async getGenesis(): Promise<phase0.Genesis> {
     return {
       genesisForkVersion: this.config.params.GENESIS_FORK_VERSION,
       genesisTime: BigInt(this.chain.genesisTime),

--- a/packages/lodestar/src/api/impl/beacon/blocks/index.ts
+++ b/packages/lodestar/src/api/impl/beacon/blocks/index.ts
@@ -99,16 +99,13 @@ export class BeaconBlockApi implements IBeaconBlocksApi {
     return result;
   }
 
-  async getBlockHeader(blockId: BlockId): Promise<phase0.SignedBeaconHeaderResponse | null> {
+  async getBlockHeader(blockId: BlockId): Promise<phase0.SignedBeaconHeaderResponse> {
     const block = await this.getBlock(blockId);
-    if (!block) {
-      return null;
-    }
     return toBeaconHeaderResponse(this.config, block, true);
   }
 
-  async getBlock(blockId: BlockId): Promise<phase0.SignedBeaconBlock | null> {
-    return await resolveBlockId(this.config, this.chain.forkChoice, this.db, blockId);
+  async getBlock(blockId: BlockId): Promise<phase0.SignedBeaconBlock> {
+    return await resolveBlockId(this.chain.forkChoice, this.db, blockId);
   }
 
   async publishBlock(signedBlock: phase0.SignedBeaconBlock): Promise<void> {

--- a/packages/lodestar/src/api/impl/beacon/blocks/interface.ts
+++ b/packages/lodestar/src/api/impl/beacon/blocks/interface.ts
@@ -2,8 +2,8 @@ import {Root, phase0, Slot} from "@chainsafe/lodestar-types";
 
 export interface IBeaconBlocksApi {
   getBlockHeaders(filters: Partial<{slot: Slot; parentRoot: Root}>): Promise<phase0.SignedBeaconHeaderResponse[]>;
-  getBlockHeader(blockId: BlockId): Promise<phase0.SignedBeaconHeaderResponse | null>;
-  getBlock(blockId: BlockId): Promise<phase0.SignedBeaconBlock | null>;
+  getBlockHeader(blockId: BlockId): Promise<phase0.SignedBeaconHeaderResponse>;
+  getBlock(blockId: BlockId): Promise<phase0.SignedBeaconBlock>;
   publishBlock(block: phase0.SignedBeaconBlock): Promise<void>;
 }
 

--- a/packages/lodestar/src/api/impl/beacon/interface.ts
+++ b/packages/lodestar/src/api/impl/beacon/interface.ts
@@ -12,8 +12,6 @@ export interface IBeaconApi {
   blocks: IBeaconBlocksApi;
   state: IBeaconStateApi;
   pool: IBeaconPoolApi;
-
-  getGenesis(): Promise<phase0.Genesis | null>;
-
+  getGenesis(): Promise<phase0.Genesis>;
   getBlockStream(): IStoppableEventIterable<phase0.SignedBeaconBlock>;
 }

--- a/packages/lodestar/src/api/impl/beacon/state/interface.ts
+++ b/packages/lodestar/src/api/impl/beacon/state/interface.ts
@@ -2,20 +2,17 @@ import {allForks, BLSPubkey, CommitteeIndex, Epoch, Root, Slot, ValidatorIndex} 
 import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
 
 export interface IBeaconStateApi {
-  getStateRoot(stateId: StateId): Promise<Root | null>;
-  getState(stateId: StateId): Promise<allForks.BeaconState | null>;
-  getStateFinalityCheckpoints(stateId: StateId): Promise<phase0.FinalityCheckpoints | null>;
+  getStateRoot(stateId: StateId): Promise<Root>;
+  getState(stateId: StateId): Promise<allForks.BeaconState>;
+  getStateFinalityCheckpoints(stateId: StateId): Promise<phase0.FinalityCheckpoints>;
   getStateValidators(stateId: StateId, filters?: IValidatorFilters): Promise<phase0.ValidatorResponse[]>;
-  getStateValidator(
-    stateId: StateId,
-    validatorId: BLSPubkey | ValidatorIndex
-  ): Promise<phase0.ValidatorResponse | null>;
+  getStateValidator(stateId: StateId, validatorId: BLSPubkey | ValidatorIndex): Promise<phase0.ValidatorResponse>;
   getStateValidatorBalances(
     stateId: StateId,
     indices?: (BLSPubkey | ValidatorIndex)[]
   ): Promise<phase0.ValidatorBalance[]>;
   getStateCommittees(stateId: StateId, filters?: ICommitteesFilters): Promise<phase0.BeaconCommitteeResponse[]>;
-  getFork(stateId: StateId): Promise<phase0.Fork | null>;
+  getFork(stateId: StateId): Promise<phase0.Fork>;
 }
 
 export type StateId = string | "head" | "genesis" | "finalized" | "justified";

--- a/packages/lodestar/src/api/impl/debug/beacon/index.ts
+++ b/packages/lodestar/src/api/impl/debug/beacon/index.ts
@@ -1,7 +1,5 @@
-import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBlockSummary} from "@chainsafe/lodestar-fork-choice";
 import {allForks, phase0} from "@chainsafe/lodestar-types";
-import {ILogger} from "@chainsafe/lodestar-utils";
 import {IBeaconChain} from "../../../../chain";
 import {IBeaconDb} from "../../../../db";
 import {IApiOptions} from "../../../options";
@@ -11,36 +9,21 @@ import {IApiModules} from "../../interface";
 import {IDebugBeaconApi} from "./interface";
 
 export class DebugBeaconApi implements IDebugBeaconApi {
-  private readonly config: IBeaconConfig;
   private readonly chain: IBeaconChain;
   private readonly db: IBeaconDb;
-  private readonly logger: ILogger;
 
-  constructor(opts: Partial<IApiOptions>, modules: Pick<IApiModules, "config" | "logger" | "chain" | "db">) {
-    this.config = modules.config;
-    this.logger = modules.logger;
+  constructor(opts: Partial<IApiOptions>, modules: Pick<IApiModules, "chain" | "db">) {
     this.chain = modules.chain;
     this.db = modules.db;
   }
 
-  async getHeads(): Promise<phase0.SlotRoot[] | null> {
-    try {
-      return this.chain.forkChoice
-        .getHeads()
-        .map((blockSummary: IBlockSummary) => ({slot: blockSummary.slot, root: blockSummary.blockRoot}));
-    } catch (e) {
-      this.logger.error("Failed to get forkchoice heads", e);
-      return null;
-    }
+  async getHeads(): Promise<phase0.SlotRoot[]> {
+    return this.chain.forkChoice
+      .getHeads()
+      .map((blockSummary: IBlockSummary) => ({slot: blockSummary.slot, root: blockSummary.blockRoot}));
   }
 
-  async getState(stateId: StateId): Promise<allForks.BeaconState | null> {
-    try {
-      return await resolveStateId(this.chain, this.db, stateId);
-    } catch (e) {
-      (e as Error).message;
-      this.logger.error("Failed to resolve state", {state: stateId, error: {...(e as Error)}});
-      throw e;
-    }
+  async getState(stateId: StateId): Promise<allForks.BeaconState> {
+    return await resolveStateId(this.chain, this.db, stateId);
   }
 }

--- a/packages/lodestar/src/api/impl/debug/beacon/interface.ts
+++ b/packages/lodestar/src/api/impl/debug/beacon/interface.ts
@@ -5,6 +5,6 @@ export interface IDebugBeaconApi {
   /**
    * API wrapper function for `getHeads` in `@chainsafe/lodestar-fork-choice`.
    * */
-  getHeads(): Promise<phase0.SlotRoot[] | null>;
-  getState(stateId: StateId): Promise<allForks.BeaconState | null>;
+  getHeads(): Promise<phase0.SlotRoot[]>;
+  getState(stateId: StateId): Promise<allForks.BeaconState>;
 }

--- a/packages/lodestar/src/api/impl/errors.ts
+++ b/packages/lodestar/src/api/impl/errors.ts
@@ -16,3 +16,11 @@ export class DataNotAvailable extends ApiError {
     super(404, "Requested data cannot be served");
   }
 }
+
+export class ValidationError extends ApiError {
+  dataPath?: string;
+  constructor(message?: string, dataPath?: string) {
+    super(400, message);
+    this.dataPath = dataPath;
+  }
+}

--- a/packages/lodestar/src/api/impl/errors/validation.ts
+++ b/packages/lodestar/src/api/impl/errors/validation.ts
@@ -1,6 +1,0 @@
-import {ApiError} from "./api";
-export class ValidationError extends ApiError {
-  constructor(message?: string) {
-    super(400, message);
-  }
-}

--- a/packages/lodestar/src/api/impl/node/interface.ts
+++ b/packages/lodestar/src/api/impl/node/interface.ts
@@ -8,7 +8,7 @@ import {NodeIdentity, NodePeer} from "../../types";
 export interface INodeApi {
   getNodeIdentity(): Promise<NodeIdentity>;
   getPeers(state?: string[], direction?: string[]): Promise<NodePeer[]>;
-  getPeer(peerId: string): Promise<NodePeer | null>;
+  getPeer(peerId: string): Promise<NodePeer>;
   /**
    * Gets the beacon node version.  Format of version string is derived from schema used by other
    * eth2 clients.

--- a/packages/lodestar/src/api/impl/node/node.ts
+++ b/packages/lodestar/src/api/impl/node/node.ts
@@ -9,6 +9,7 @@ import {IApiOptions} from "../../options";
 import {ApiNamespace, IApiModules} from "../interface";
 import {formatNodePeer} from "./utils";
 import {INodeApi} from "./interface";
+import {ApiError} from "../errors";
 
 export class NodeApi implements INodeApi {
   namespace = ApiNamespace.NODE;
@@ -43,9 +44,11 @@ export class NodeApi implements INodeApi {
     return this.sync.isSynced() ? "ready" : "syncing";
   }
 
-  async getPeer(peerIdStr: string): Promise<NodePeer | null> {
+  async getPeer(peerIdStr: string): Promise<NodePeer> {
     const connections = this.network.getConnectionsByPeer().get(peerIdStr);
-    if (!connections) return null; // Node has not seen this peer
+    if (!connections) {
+      throw new ApiError(404, "Node has not seen this peer");
+    }
     return formatNodePeer(peerIdStr, connections);
   }
 

--- a/packages/lodestar/src/api/impl/utils.ts
+++ b/packages/lodestar/src/api/impl/utils.ts
@@ -4,7 +4,7 @@ import {ValidatorIndex} from "@chainsafe/lodestar-types/phase0";
 import {ByteVector} from "@chainsafe/ssz";
 import {IBeaconChain} from "../../chain/interface";
 import {IBeaconSync} from "../../sync";
-import {ApiError} from "./errors/api";
+import {ApiError} from "./errors/errors";
 
 /**
  * Check the sync status of the beacon chain.

--- a/packages/lodestar/src/api/impl/utils.ts
+++ b/packages/lodestar/src/api/impl/utils.ts
@@ -4,7 +4,7 @@ import {ValidatorIndex} from "@chainsafe/lodestar-types/phase0";
 import {ByteVector} from "@chainsafe/ssz";
 import {IBeaconChain} from "../../chain/interface";
 import {IBeaconSync} from "../../sync";
-import {ApiError} from "./errors/errors";
+import {ApiError} from "./errors";
 
 /**
  * Check the sync status of the beacon chain.

--- a/packages/lodestar/src/api/impl/validator/interface.ts
+++ b/packages/lodestar/src/api/impl/validator/interface.ts
@@ -8,21 +8,15 @@ import {BLSSignature, CommitteeIndex, Epoch, Root, phase0, Slot, ValidatorIndex}
  */
 export interface IValidatorApi {
   getProposerDuties(epoch: Epoch): Promise<phase0.ProposerDuty[]>;
-
   getAttesterDuties(epoch: Epoch, validatorIndices: ValidatorIndex[]): Promise<phase0.AttesterDuty[]>;
-
   /**
    * Requests a BeaconNode to produce a valid block,
    * which can then be signed by a ValidatorClient.
    * @returns {Promise<BeaconBlock>} A proposed BeaconBlock object
    */
   produceBlock(slot: Slot, randaoReveal: BLSSignature, graffiti: string): Promise<phase0.BeaconBlock>;
-
   produceAttestationData(index: CommitteeIndex, slot: Slot): Promise<phase0.AttestationData>;
-
   getAggregatedAttestation(attestationDataRoot: Root, slot: Slot): Promise<phase0.Attestation>;
-
   publishAggregateAndProofs(signedAggregateAndProofs: phase0.SignedAggregateAndProof[]): Promise<void>;
-
   prepareBeaconCommitteeSubnet(subscriptions: phase0.BeaconCommitteeSubscription[]): Promise<void>;
 }

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -23,7 +23,7 @@ import {INetwork} from "../../../network";
 import {IBeaconSync} from "../../../sync";
 import {toGraffitiBuffer} from "../../../util/graffiti";
 import {IApiOptions} from "../../options";
-import {ApiError} from "../errors/errors";
+import {ApiError} from "../errors";
 import {ApiNamespace, IApiModules} from "../interface";
 import {checkSyncStatus} from "../utils";
 import {IValidatorApi} from "./interface";

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -23,7 +23,7 @@ import {INetwork} from "../../../network";
 import {IBeaconSync} from "../../../sync";
 import {toGraffitiBuffer} from "../../../util/graffiti";
 import {IApiOptions} from "../../options";
-import {ApiError} from "../errors/api";
+import {ApiError} from "../errors/errors";
 import {ApiNamespace, IApiModules} from "../interface";
 import {checkSyncStatus} from "../utils";
 import {IValidatorApi} from "./interface";

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlock.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlock.ts
@@ -1,26 +1,15 @@
 import {ApiController} from "../../types";
 import {DefaultQuery} from "fastify";
-import {toRestValidationError} from "../../utils";
 
 export const getBlock: ApiController<DefaultQuery, {blockId: string}> = {
   url: "/blocks/:blockId",
   method: "GET",
 
-  handler: async function (req, resp) {
-    try {
-      const data = await this.api.beacon.blocks.getBlock(req.params.blockId);
-      if (!data) {
-        return resp.status(404).send();
-      }
-      return {
-        data: this.config.types.phase0.SignedBeaconBlock.toJson(data, {case: "snake"}),
-      };
-    } catch (e) {
-      if ((e as Error).message === "Invalid block id") {
-        throw toRestValidationError("block_id", (e as Error).message);
-      }
-      throw e;
-    }
+  handler: async function (req) {
+    const data = await this.api.beacon.blocks.getBlock(req.params.blockId);
+    return {
+      data: this.config.types.phase0.SignedBeaconBlock.toJson(data, {case: "snake"}),
+    };
   },
 
   schema: {

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockAttestations.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockAttestations.ts
@@ -1,28 +1,17 @@
 import {ApiController} from "../../types";
 import {DefaultQuery} from "fastify";
-import {toRestValidationError} from "../../utils";
 
 export const getBlockAttestations: ApiController<DefaultQuery, {blockId: string}> = {
   url: "/blocks/:blockId/attestations",
   method: "GET",
 
-  handler: async function (req, resp) {
-    try {
-      const data = await this.api.beacon.blocks.getBlock(req.params.blockId);
-      if (!data) {
-        return resp.status(404).send();
-      }
-      return {
-        data: Array.from(data.message.body.attestations).map((attestations) => {
-          this.config.types.phase0.Attestation.toJson(attestations, {case: "snake"});
-        }),
-      };
-    } catch (e) {
-      if ((e as Error).message === "Invalid block id") {
-        throw toRestValidationError("block_id", (e as Error).message);
-      }
-      throw e;
-    }
+  handler: async function (req) {
+    const data = await this.api.beacon.blocks.getBlock(req.params.blockId);
+    return {
+      data: Array.from(data.message.body.attestations).map((attestations) => {
+        this.config.types.phase0.Attestation.toJson(attestations, {case: "snake"});
+      }),
+    };
   },
 
   schema: {

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockHeader.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockHeader.ts
@@ -1,26 +1,15 @@
 import {ApiController} from "../../types";
 import {DefaultQuery} from "fastify";
-import {toRestValidationError} from "../../utils";
 
 export const getBlockHeader: ApiController<DefaultQuery, {blockId: string}> = {
   url: "/headers/:blockId",
   method: "GET",
 
-  handler: async function (req, resp) {
-    try {
-      const data = await this.api.beacon.blocks.getBlockHeader(req.params.blockId);
-      if (!data) {
-        return resp.status(404).send();
-      }
-      return {
-        data: this.config.types.phase0.SignedBeaconHeaderResponse.toJson(data, {case: "snake"}),
-      };
-    } catch (e) {
-      if ((e as Error).message === "Invalid block id") {
-        throw toRestValidationError("block_id", (e as Error).message);
-      }
-      throw e;
-    }
+  handler: async function (req) {
+    const data = await this.api.beacon.blocks.getBlockHeader(req.params.blockId);
+    return {
+      data: this.config.types.phase0.SignedBeaconHeaderResponse.toJson(data, {case: "snake"}),
+    };
   },
 
   schema: {

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockRoot.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/getBlockRoot.ts
@@ -1,28 +1,17 @@
 import {ApiController} from "../../types";
 import {DefaultQuery} from "fastify";
-import {toRestValidationError} from "../../utils";
 
 export const getBlockRoot: ApiController<DefaultQuery, {blockId: string}> = {
   url: "/blocks/:blockId/root",
   method: "GET",
 
-  handler: async function (req, resp) {
-    try {
-      const data = await this.api.beacon.blocks.getBlock(req.params.blockId);
-      if (!data) {
-        return resp.status(404).send();
-      }
-      return {
-        data: {
-          root: this.config.types.Root.toJson(this.config.types.phase0.BeaconBlock.hashTreeRoot(data.message)),
-        },
-      };
-    } catch (e) {
-      if ((e as Error).message === "Invalid block id") {
-        throw toRestValidationError("block_id", (e as Error).message);
-      }
-      throw e;
-    }
+  handler: async function (req) {
+    const data = await this.api.beacon.blocks.getBlock(req.params.blockId);
+    return {
+      data: {
+        root: this.config.types.Root.toJson(this.config.types.phase0.BeaconBlock.hashTreeRoot(data.message)),
+      },
+    };
   },
 
   schema: {

--- a/packages/lodestar/src/api/rest/controllers/beacon/blocks/publishBlock.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/blocks/publishBlock.ts
@@ -1,6 +1,6 @@
-import {ApiController} from "../../types";
 import {phase0} from "@chainsafe/lodestar-types";
-import {ValidationError} from "../../../../impl/errors/validation";
+import {ApiController} from "../../types";
+import {ValidationError} from "../../../../impl/errors";
 
 export const publishBlock: ApiController = {
   url: "/blocks",
@@ -11,7 +11,7 @@ export const publishBlock: ApiController = {
     try {
       block = this.config.types.phase0.SignedBeaconBlock.fromJson(req.body, {case: "snake"});
     } catch (e) {
-      throw new ValidationError("Failed to deserialize block");
+      throw new ValidationError(`Failed to deserialize block: ${(e as Error).message}`);
     }
     await this.api.beacon.blocks.publishBlock(block);
     return {};

--- a/packages/lodestar/src/api/rest/controllers/beacon/getGenesis.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/getGenesis.ts
@@ -4,11 +4,8 @@ export const getGenesis: ApiController = {
   url: "/genesis",
   method: "GET",
 
-  handler: async function (req, resp) {
+  handler: async function () {
     const genesis = await this.api.beacon.getGenesis();
-    if (!genesis) {
-      return resp.status(404).send();
-    }
     return {
       data: this.config.types.phase0.Genesis.toJson(genesis, {case: "snake"}),
     };

--- a/packages/lodestar/src/api/rest/controllers/beacon/pool/submitAttesterSlashing.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/pool/submitAttesterSlashing.ts
@@ -1,5 +1,5 @@
 import {phase0} from "@chainsafe/lodestar-types";
-import {ValidationError} from "../../../../impl/errors/validation";
+import {ValidationError} from "../../../../impl/errors";
 import {ApiController} from "../../types";
 
 export const submitAttesterSlashing: ApiController = {
@@ -11,7 +11,7 @@ export const submitAttesterSlashing: ApiController = {
     try {
       slashing = this.config.types.phase0.AttesterSlashing.fromJson(req.body, {case: "snake"});
     } catch (e) {
-      throw new ValidationError("Failed to deserialize attester slashing");
+      throw new ValidationError(`SSZ deserialize error: ${(e as Error).message}`);
     }
     await this.api.beacon.pool.submitAttesterSlashing(slashing);
     return {};

--- a/packages/lodestar/src/api/rest/controllers/beacon/pool/submitPoolAttestation.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/pool/submitPoolAttestation.ts
@@ -1,5 +1,5 @@
 import {phase0} from "@chainsafe/lodestar-types";
-import {ValidationError} from "../../../../impl/errors/validation";
+import {ValidationError} from "../../../../impl/errors";
 import {ApiController} from "../../types";
 
 export const submitPoolAttestation: ApiController = {
@@ -11,7 +11,7 @@ export const submitPoolAttestation: ApiController = {
     try {
       attestation = this.config.types.phase0.Attestation.fromJson(req.body, {case: "snake"});
     } catch (e) {
-      throw new ValidationError("Failed to deserialize attestation");
+      throw new ValidationError(`SSZ deserialize error: ${(e as Error).message}`);
     }
     await this.api.beacon.pool.submitAttestation(attestation);
     return {};

--- a/packages/lodestar/src/api/rest/controllers/beacon/pool/submitProposerSlashing.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/pool/submitProposerSlashing.ts
@@ -1,5 +1,5 @@
 import {phase0} from "@chainsafe/lodestar-types";
-import {ValidationError} from "../../../../impl/errors/validation";
+import {ValidationError} from "../../../../impl/errors";
 import {ApiController} from "../../types";
 
 export const submitProposerSlashing: ApiController = {
@@ -11,7 +11,7 @@ export const submitProposerSlashing: ApiController = {
     try {
       slashing = this.config.types.phase0.ProposerSlashing.fromJson(req.body, {case: "snake"});
     } catch (e) {
-      throw new ValidationError("Failed to deserialize proposer slashing");
+      throw new ValidationError(`SSZ deserialize error: ${(e as Error).message}`);
     }
     await this.api.beacon.pool.submitProposerSlashing(slashing);
     return {};

--- a/packages/lodestar/src/api/rest/controllers/beacon/pool/submitVoluntaryExit.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/pool/submitVoluntaryExit.ts
@@ -1,5 +1,5 @@
 import {phase0} from "@chainsafe/lodestar-types";
-import {ValidationError} from "../../../../impl/errors/validation";
+import {ValidationError} from "../../../../impl/errors";
 import {ApiController} from "../../types";
 
 export const submitVoluntaryExit: ApiController = {
@@ -11,7 +11,7 @@ export const submitVoluntaryExit: ApiController = {
     try {
       exit = this.config.types.phase0.SignedVoluntaryExit.fromJson(req.body, {case: "snake"});
     } catch (e) {
-      throw new ValidationError("Failed to deserialize voluntary exit");
+      throw new ValidationError(`SSZ deserialize error: ${(e as Error).message}`);
     }
     await this.api.beacon.pool.submitVoluntaryExit(exit);
     return {};

--- a/packages/lodestar/src/api/rest/controllers/beacon/state/getStateFinalityCheckpoints.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/state/getStateFinalityCheckpoints.ts
@@ -1,7 +1,6 @@
 import {ApiController} from "../../types";
 import {DefaultQuery} from "fastify";
 import {StateId} from "../../../../impl/beacon/state";
-import {toRestValidationError} from "../../utils";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -13,26 +12,16 @@ export const getStateFinalityCheckpoints: ApiController<DefaultQuery, Params> = 
   url: "/states/:stateId/finality_checkpoints",
   method: "GET",
 
-  handler: async function (req, resp) {
-    try {
-      const state = await this.api.beacon.state.getState(req.params.stateId);
-      if (!state) {
-        return resp.status(404).send();
-      }
-      const checkpointType = this.config.types.phase0.Checkpoint;
-      return {
-        data: {
-          previous_justified: checkpointType.toJson(state.previousJustifiedCheckpoint, {case: "snake"}),
-          current_justified: checkpointType.toJson(state.currentJustifiedCheckpoint, {case: "snake"}),
-          finalized: checkpointType.toJson(state.finalizedCheckpoint, {case: "snake"}),
-        },
-      };
-    } catch (e) {
-      if ((e as Error).message === "Invalid state id") {
-        throw toRestValidationError("state_id", (e as Error).message);
-      }
-      throw e;
-    }
+  handler: async function (req) {
+    const state = await this.api.beacon.state.getState(req.params.stateId);
+    const checkpointType = this.config.types.phase0.Checkpoint;
+    return {
+      data: {
+        previous_justified: checkpointType.toJson(state.previousJustifiedCheckpoint, {case: "snake"}),
+        current_justified: checkpointType.toJson(state.currentJustifiedCheckpoint, {case: "snake"}),
+        finalized: checkpointType.toJson(state.finalizedCheckpoint, {case: "snake"}),
+      },
+    };
   },
 
   schema: {

--- a/packages/lodestar/src/api/rest/controllers/beacon/state/getStateFork.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/state/getStateFork.ts
@@ -1,7 +1,6 @@
 import {ApiController} from "../../types";
 import {DefaultQuery} from "fastify";
 import {StateId} from "../../../../impl/beacon/state";
-import {toRestValidationError} from "../../utils";
 
 type Params = {
   stateId: StateId;
@@ -11,21 +10,11 @@ export const getStateFork: ApiController<DefaultQuery, Params> = {
   url: "/states/:stateId/fork",
   method: "GET",
 
-  handler: async function (req, resp) {
-    try {
-      const fork = await this.api.beacon.state.getFork(req.params.stateId);
-      if (!fork) {
-        return resp.status(404).send();
-      }
-      return {
-        data: this.config.types.phase0.Fork.toJson(fork, {case: "snake"}),
-      };
-    } catch (e) {
-      if ((e as Error).message === "Invalid state id") {
-        throw toRestValidationError("state_id", (e as Error).message);
-      }
-      throw e;
-    }
+  handler: async function (req) {
+    const fork = await this.api.beacon.state.getFork(req.params.stateId);
+    return {
+      data: this.config.types.phase0.Fork.toJson(fork, {case: "snake"}),
+    };
   },
 
   schema: {

--- a/packages/lodestar/src/api/rest/controllers/beacon/state/getValidator.ts
+++ b/packages/lodestar/src/api/rest/controllers/beacon/state/getValidator.ts
@@ -1,8 +1,7 @@
 import {DefaultQuery} from "fastify";
-import {StateId} from "../../../../impl/beacon/state/interface";
-import {ApiError} from "../../../../impl/errors/api";
-import {ApiController} from "../../types";
 import {phase0} from "@chainsafe/lodestar-types";
+import {StateId} from "../../../../impl/beacon/state/interface";
+import {ApiController} from "../../types";
 
 type Params = {
   stateId: StateId;
@@ -14,23 +13,19 @@ export const getStateValidator: ApiController<DefaultQuery, Params> = {
   method: "GET",
 
   handler: async function (req) {
-    let validator: phase0.ValidatorResponse | undefined;
+    let validator: phase0.ValidatorResponse;
     if (req.params.validatorId.toLowerCase().startsWith("0x")) {
-      validator =
-        (await this.api.beacon.state.getStateValidator(
-          req.params.stateId,
-          this.config.types.BLSPubkey.fromJson(req.params.validatorId)
-        )) ?? undefined;
+      validator = await this.api.beacon.state.getStateValidator(
+        req.params.stateId,
+        this.config.types.BLSPubkey.fromJson(req.params.validatorId)
+      );
     } else {
-      validator =
-        (await this.api.beacon.state.getStateValidator(
-          req.params.stateId,
-          this.config.types.ValidatorIndex.fromJson(req.params.validatorId)
-        )) ?? undefined;
+      validator = await this.api.beacon.state.getStateValidator(
+        req.params.stateId,
+        this.config.types.ValidatorIndex.fromJson(req.params.validatorId)
+      );
     }
-    if (!validator) {
-      throw new ApiError(404, "Validator not found");
-    }
+
     return {
       data: this.config.types.phase0.ValidatorResponse.toJson(validator, {case: "snake"}),
     };

--- a/packages/lodestar/src/api/rest/controllers/debug/beacon/getHeads.ts
+++ b/packages/lodestar/src/api/rest/controllers/debug/beacon/getHeads.ts
@@ -4,11 +4,8 @@ export const getHeads: ApiController = {
   url: "/beacon/heads",
   method: "GET",
 
-  handler: async function (req, resp) {
+  handler: async function () {
     const heads = await this.api.debug.beacon.getHeads();
-    if (!heads) {
-      return resp.status(404).send();
-    }
     return {
       data: heads.map((head) => this.config.types.phase0.SlotRoot.toJson(head, {case: "snake"})),
     };

--- a/packages/lodestar/src/api/rest/controllers/debug/beacon/getStates.ts
+++ b/packages/lodestar/src/api/rest/controllers/debug/beacon/getStates.ts
@@ -1,6 +1,5 @@
 import {ApiController, HttpHeader} from "../../types";
 import {DefaultQuery} from "fastify";
-import {toRestValidationError} from "../../utils";
 
 const SSZ_MIME_TYPE = "application/octet-stream";
 
@@ -9,25 +8,15 @@ export const getState: ApiController<DefaultQuery, {stateId: string}> = {
   method: "GET",
 
   handler: async function (req, resp) {
-    try {
-      const state = await this.api.debug.beacon.getState(req.params.stateId);
-      if (!state) {
-        return resp.status(404).send();
-      }
-      if (req.headers[HttpHeader.ACCEPT] === SSZ_MIME_TYPE) {
-        const stateSsz = this.config.getTypes(state.slot).BeaconState.serialize(state);
-        return resp.status(200).header(HttpHeader.CONTENT_TYPE, SSZ_MIME_TYPE).send(Buffer.from(stateSsz));
-      } else {
-        // Send 200 JSON
-        return {
-          data: this.config.getTypes(state.slot).BeaconState.toJson(state, {case: "snake"}),
-        };
-      }
-    } catch (e) {
-      if ((e as Error).message === "Invalid state id") {
-        throw toRestValidationError("state_id", (e as Error).message);
-      }
-      throw e;
+    const state = await this.api.debug.beacon.getState(req.params.stateId);
+    if (req.headers[HttpHeader.ACCEPT] === SSZ_MIME_TYPE) {
+      const stateSsz = this.config.getTypes(state.slot).BeaconState.serialize(state);
+      return resp.status(200).header(HttpHeader.CONTENT_TYPE, SSZ_MIME_TYPE).send(Buffer.from(stateSsz));
+    } else {
+      // Send 200 JSON
+      return {
+        data: this.config.getTypes(state.slot).BeaconState.toJson(state, {case: "snake"}),
+      };
     }
   },
 

--- a/packages/lodestar/src/api/rest/controllers/node/getPeer.ts
+++ b/packages/lodestar/src/api/rest/controllers/node/getPeer.ts
@@ -7,11 +7,8 @@ export const getPeer: ApiController<DefaultQuery, {peerId: string}> = {
   url: "/peers/:peerId",
   method: "GET",
 
-  handler: async function (req, resp) {
+  handler: async function (req) {
     const peer = await this.api.node.getPeer(req.params.peerId);
-    if (!peer) {
-      return resp.status(404).send();
-    }
     return {
       data: {
         peer_id: peer.peerId,

--- a/packages/lodestar/src/api/rest/routes/error.ts
+++ b/packages/lodestar/src/api/rest/routes/error.ts
@@ -1,6 +1,6 @@
 import {FastifyError, FastifyReply, FastifyRequest} from "fastify";
 import {ServerResponse} from "http";
-import {ApiError} from "../../impl/errors/errors";
+import {ApiError} from "../../impl/errors";
 
 export function errorHandler(e: Error, req: FastifyRequest, resp: FastifyReply<ServerResponse>): void {
   if ((e as FastifyError).validation) {

--- a/packages/lodestar/src/api/rest/routes/error.ts
+++ b/packages/lodestar/src/api/rest/routes/error.ts
@@ -1,6 +1,6 @@
 import {FastifyError, FastifyReply, FastifyRequest} from "fastify";
 import {ServerResponse} from "http";
-import {ApiError} from "../../impl/errors/api";
+import {ApiError} from "../../impl/errors/errors";
 
 export function errorHandler(e: Error, req: FastifyRequest, resp: FastifyReply<ServerResponse>): void {
   if ((e as FastifyError).validation) {

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlock.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlock.test.ts
@@ -22,27 +22,15 @@ describe("api - beacon - getBlock", function () {
     server.sandbox.restore();
   });
 
-  it("block not found", async function () {
-    resolveBlockIdStub.withArgs(config, sinon.match.any, sinon.match.any, "1").resolves(null);
-    const result = await server.blockApi.getBlock("1");
-    expect(result).to.be.null;
-  });
-
   it("invalid block id", async function () {
-    resolveBlockIdStub.withArgs(config, sinon.match.any, sinon.match.any, "abc").throwsException();
+    resolveBlockIdStub.withArgs(sinon.match.any, sinon.match.any, "abc").throwsException();
     await expect(server.blockApi.getBlock("abc")).to.eventually.be.rejected;
   });
 
   it("success for non finalized block", async function () {
-    resolveBlockIdStub.withArgs(config, sinon.match.any, sinon.match.any, "head").resolves(generateEmptySignedBlock());
+    resolveBlockIdStub.withArgs(sinon.match.any, sinon.match.any, "head").resolves(generateEmptySignedBlock());
     const result = await server.blockApi.getBlock("head");
     expect(result).to.not.be.null;
     expect(() => config.types.phase0.SignedBeaconBlock.assertValidValue(result)).to.not.throw();
-  });
-
-  it.skip("success for finalized block", async function () {
-    resolveBlockIdStub.withArgs(config, sinon.match.any, sinon.match.any, "0").resolves(null);
-    const result = await server.blockApi.getBlock("0");
-    expect(result).to.not.be.null;
   });
 });

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlockHeader.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/getBlockHeader.test.ts
@@ -22,19 +22,13 @@ describe("api - beacon - getBlockHeader", function () {
     server.sandbox.restore();
   });
 
-  it("block not found", async function () {
-    resolveBlockIdStub.withArgs(config, sinon.match.any, sinon.match.any, "1").resolves(null);
-    const result = await server.blockApi.getBlockHeader("1");
-    expect(result).to.be.null;
-  });
-
   it("invalid block id", async function () {
-    resolveBlockIdStub.withArgs(config, sinon.match.any, sinon.match.any, "abc").throwsException();
+    resolveBlockIdStub.withArgs(sinon.match.any, sinon.match.any, "abc").throwsException();
     await expect(server.blockApi.getBlockHeader("abc")).to.eventually.be.rejected;
   });
 
   it("success for block", async function () {
-    resolveBlockIdStub.withArgs(config, sinon.match.any, sinon.match.any, "head").resolves(generateEmptySignedBlock());
+    resolveBlockIdStub.withArgs(sinon.match.any, sinon.match.any, "head").resolves(generateEmptySignedBlock());
     const result = await server.blockApi.getBlockHeader("head");
     expect(result).to.not.be.null;
     expect(() => config.types.phase0.SignedBeaconHeaderResponse.assertValidValue(result)).to.not.throw();

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/utils.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/utils.test.ts
@@ -1,7 +1,6 @@
 import {SinonStubbedInstance} from "sinon";
 import {ForkChoice, IBlockSummary} from "@chainsafe/lodestar-fork-choice";
 import {resolveBlockId} from "../../../../../../src/api/impl/beacon/blocks/utils";
-import {config} from "@chainsafe/lodestar-config/minimal";
 import {expect, use} from "chai";
 import {toHexString} from "@chainsafe/ssz";
 import {generateBlockSummary, generateEmptySignedBlock} from "../../../../../utils/block";
@@ -10,6 +9,8 @@ import {StubbedBeaconDb} from "../../../../../utils/stub";
 import {GENESIS_SLOT} from "../../../../../../src/constants";
 import {bufferEqualsMatcher} from "../../../../../utils/sinon/matcher";
 import {setupApiImplTestServer, ApiImplTestModules} from "../../index.test";
+
+/* eslint-disable @typescript-eslint/no-empty-function */
 
 use(chaiAsPromised);
 
@@ -42,33 +43,33 @@ describe("block api utils", function () {
 
     it("should resolve head", async function () {
       forkChoiceStub.getHead.returns(expectedSummary);
-      await resolveBlockId(config, forkChoiceStub, dbStub, "head");
+      await resolveBlockId(forkChoiceStub, dbStub, "head").catch(() => {});
       expect(dbStub.block.get.withArgs(expectedBuffer, 0).calledOnce).to.be.true;
     });
 
     it("should resolve genesis", async function () {
-      await resolveBlockId(config, forkChoiceStub, dbStub, "genesis");
+      await resolveBlockId(forkChoiceStub, dbStub, "genesis").catch(() => {});
       expect(dbStub.blockArchive.get.withArgs(GENESIS_SLOT).calledOnce).to.be.true;
     });
 
     it("should resolve finalized", async function () {
       const expected = 0;
       forkChoiceStub.getFinalizedCheckpoint.returns({epoch: expected, root: Buffer.alloc(32, 2)});
-      await resolveBlockId(config, forkChoiceStub, dbStub, "finalized");
+      await resolveBlockId(forkChoiceStub, dbStub, "finalized").catch(() => {});
       expect(dbStub.blockArchive.get.withArgs(expected).calledOnce).to.be.true;
     });
 
     it("should resolve finalized block root", async function () {
       forkChoiceStub.getBlock.returns(expectedSummary);
       dbStub.block.get.withArgs(bufferEqualsMatcher(expectedBuffer), 0).resolves(null);
-      await resolveBlockId(config, forkChoiceStub, dbStub, toHexString(expectedBuffer));
+      await resolveBlockId(forkChoiceStub, dbStub, toHexString(expectedBuffer)).catch(() => {});
       expect(dbStub.block.get.withArgs(bufferEqualsMatcher(expectedBuffer), 0).calledOnce).to.be.true;
     });
 
     it("should resolve non finalized block root", async function () {
       forkChoiceStub.getBlock.returns(null);
       dbStub.block.get.withArgs(bufferEqualsMatcher(expectedBuffer), 0).resolves(generateEmptySignedBlock());
-      await resolveBlockId(config, forkChoiceStub, dbStub, toHexString(expectedBuffer));
+      await resolveBlockId(forkChoiceStub, dbStub, toHexString(expectedBuffer)).catch(() => {});
       expect(dbStub.blockArchive.getByRoot.withArgs(bufferEqualsMatcher(expectedBuffer)).calledOnce).to.be.true;
     });
 
@@ -77,19 +78,19 @@ describe("block api utils", function () {
         ...generateBlockSummary(),
         blockRoot: expectedBuffer,
       });
-      await resolveBlockId(config, forkChoiceStub, dbStub, "2");
+      await resolveBlockId(forkChoiceStub, dbStub, "2").catch(() => {});
       expect(forkChoiceStub.getCanonicalBlockSummaryAtSlot.withArgs(2).calledOnce).to.be.true;
     });
 
     it("should resolve finalized slot", async function () {
       forkChoiceStub.getCanonicalBlockSummaryAtSlot.withArgs(2).returns(null);
-      await resolveBlockId(config, forkChoiceStub, dbStub, "2");
+      await resolveBlockId(forkChoiceStub, dbStub, "2").catch(() => {});
       expect(forkChoiceStub.getCanonicalBlockSummaryAtSlot.withArgs(2).calledOnce).to.be.true;
       expect(dbStub.blockArchive.get.withArgs(2).calledOnce).to.be.true;
     });
 
     it("should trow on invalid", async function () {
-      await expect(resolveBlockId(config, forkChoiceStub, dbStub, "asbc")).to.eventually.be.rejected;
+      await expect(resolveBlockId(forkChoiceStub, dbStub, "asbc")).to.eventually.be.rejected;
     });
   });
 });

--- a/packages/lodestar/test/unit/api/impl/beacon/state/fork.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/state/fork.test.ts
@@ -37,10 +37,4 @@ describe("beacon api impl - state - get fork", function () {
     const fork = await api.getFork("something");
     expect(fork).to.not.be.null;
   });
-
-  it("state doesn't exist", async function () {
-    resolveStateIdStub.resolves(null);
-    const fork = await api.getFork("something");
-    expect(fork).to.be.null;
-  });
 });

--- a/packages/lodestar/test/unit/api/impl/beacon/state/state.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/state/state.test.ts
@@ -43,20 +43,9 @@ describe("beacon api impl - states", function () {
       const state = await api.getState("something");
       expect(state).to.not.be.null;
     });
-
-    it("state doesn't exist", async function () {
-      resolveStateIdStub.resolves(null);
-      const state = await api.getState("something");
-      expect(state).to.be.null;
-    });
   });
 
   describe("getStateCommittes", function () {
-    it("no state context", async function () {
-      resolveStateIdStub.resolves(null);
-      await expect(api.getStateCommittees("blem")).to.be.eventually.rejectedWith("State not found");
-    });
-
     const state = generateState();
 
     it("no filters", async function () {

--- a/packages/lodestar/test/unit/api/impl/beacon/state/stateValidators.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/state/stateValidators.test.ts
@@ -45,12 +45,6 @@ describe("beacon api impl - state - validators", function () {
   });
 
   describe("get validators", function () {
-    it("state not found", async function () {
-      resolveStateIdStub.resolves(null);
-      const api = new BeaconStateApi({}, {config, db: dbStub, chain: chainStub});
-      await expect(api.getStateValidators("notfound")).to.be.rejectedWith("State not found");
-    });
-
     it("indices filter", async function () {
       resolveStateIdStub.resolves(generateState({validators: generateValidators(10)}));
       const api = new BeaconStateApi({}, {config, db: dbStub, chain: chainStub});
@@ -110,11 +104,6 @@ describe("beacon api impl - state - validators", function () {
   });
 
   describe("get validator", function () {
-    it("state not found", async function () {
-      resolveStateIdStub.resolves(null);
-      const api = new BeaconStateApi({}, {config, db: dbStub, chain: chainStub});
-      await expect(api.getStateValidator("notfound", 1)).to.be.rejectedWith("State not found");
-    });
     it("validator by index not found", async function () {
       resolveStateIdStub.resolves(generateState({validators: generateValidators(10)}));
       const api = new BeaconStateApi({}, {config, db: dbStub, chain: chainStub});
@@ -148,12 +137,6 @@ describe("beacon api impl - state - validators", function () {
   });
 
   describe("get validators balances", function () {
-    it("state not found", async function () {
-      resolveStateIdStub.resolves(null);
-      const api = new BeaconStateApi({}, {config, db: dbStub, chain: chainStub});
-      await expect(api.getStateValidatorBalances("notfound")).to.be.rejectedWith("State not found");
-    });
-
     it("indices filters", async function () {
       resolveStateIdStub.resolves(
         generateState({

--- a/packages/lodestar/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/state/utils.test.ts
@@ -66,8 +66,7 @@ describe("beacon state api utils", function () {
 
       it("resolve finalized state id - missing state", async function () {
         chainStub.stateCache.get.returns(null);
-        const state = await resolveStateId(chainStub, dbStub, "finalized");
-        expect(state).to.be.null;
+        await expect(resolveStateId(chainStub, dbStub, "finalized")).to.be.rejectedWith();
         expect(chainStub.forkChoice.getFinalizedCheckpoint.calledOnce).to.be.true;
         expect(chainStub.stateCache.get.calledOnce).to.be.true;
       });
@@ -88,8 +87,7 @@ describe("beacon state api utils", function () {
 
       it("resolve justified state id - missing state", async function () {
         chainStub.stateCache.get.returns(null);
-        const state = await resolveStateId(chainStub, dbStub, "justified");
-        expect(state).to.be.null;
+        await expect(resolveStateId(chainStub, dbStub, "justified")).to.be.rejectedWith();
         expect(chainStub.forkChoice.getJustifiedCheckpoint.calledOnce).to.be.true;
         expect(chainStub.stateCache.get.calledOnce).to.be.true;
       });

--- a/packages/lodestar/test/unit/api/impl/debug/beacon/index.test.ts
+++ b/packages/lodestar/test/unit/api/impl/debug/beacon/index.test.ts
@@ -1,6 +1,5 @@
 import {ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {config} from "@chainsafe/lodestar-config/minimal";
 import {expect} from "chai";
 import sinon from "sinon";
 import {SinonStubbedInstance} from "sinon";
@@ -11,7 +10,6 @@ import {generateBlockSummary} from "../../../../../utils/block";
 import {StubbedBeaconDb} from "../../../../../utils/stub";
 import {generateState} from "../../../../../utils/state";
 import {setupApiImplTestServer} from "../../index.test";
-import {testLogger} from "../../../../../utils/logger";
 import {SinonStubFn} from "../../../../../utils/types";
 
 describe("api - debug - beacon", function () {
@@ -20,7 +18,6 @@ describe("api - debug - beacon", function () {
   let forkchoiceStub: SinonStubbedInstance<IForkChoice>;
   let dbStub: StubbedBeaconDb;
   let resolveStateIdStub: SinonStubFn<typeof stateApiUtils["resolveStateId"]>;
-  const logger = testLogger();
 
   beforeEach(function () {
     const server = setupApiImplTestServer();
@@ -29,15 +26,7 @@ describe("api - debug - beacon", function () {
     forkchoiceStub = sinon.createStubInstance(LodestarForkChoice);
     chainStub.forkChoice = forkchoiceStub;
     dbStub = new StubbedBeaconDb(sinon);
-    debugApi = new DebugBeaconApi(
-      {},
-      {
-        config,
-        logger,
-        chain: chainStub,
-        db: dbStub,
-      }
-    );
+    debugApi = new DebugBeaconApi({}, {chain: chainStub, db: dbStub});
   });
 
   afterEach(function () {
@@ -50,21 +39,9 @@ describe("api - debug - beacon", function () {
     expect(heads).to.be.deep.equal([{slot: 1000, root: ZERO_HASH}]);
   });
 
-  it("getHeads - should return null", async function () {
-    forkchoiceStub.getHeads.throws("error from unit test");
-    const heads = await debugApi.getHeads();
-    expect(heads).to.be.null;
-  });
-
   it("getState - should return state", async function () {
     resolveStateIdStub.resolves(generateState());
     const state = await debugApi.getState("something");
     expect(state).to.not.be.null;
-  });
-
-  it("getState - should return null", async function () {
-    resolveStateIdStub.resolves(null);
-    const state = await debugApi.getState("something");
-    expect(state).to.be.null;
   });
 });

--- a/packages/lodestar/test/unit/api/impl/node/node.test.ts
+++ b/packages/lodestar/test/unit/api/impl/node/node.test.ts
@@ -8,12 +8,15 @@ import {createPeerId, INetwork, Network} from "../../../../../src/network";
 import {BeaconSync, IBeaconSync} from "../../../../../src/sync";
 import {createKeypairFromPeerId, ENR} from "@chainsafe/discv5/lib";
 import PeerId from "peer-id";
-import {expect} from "chai";
+import {expect, use} from "chai";
+import chaiAsPromised from "chai-as-promised";
 import Multiaddr from "multiaddr";
 import {MetadataController} from "../../../../../src/network/metadata";
 import {phase0} from "@chainsafe/lodestar-types";
 import {NodePeer} from "../../../../../src/api/types";
 import {PeerStatus, PeerDirection} from "../../../../../src/network";
+
+use(chaiAsPromised);
 
 interface IPeerSummary {
   direction: string | null;
@@ -153,9 +156,7 @@ describe("node api implementation", function () {
     it("peer not found", async function () {
       const connectionsByPeer = new Map<string, Connection[]>();
       networkStub.getConnectionsByPeer.returns(connectionsByPeer);
-
-      const peer = await api.getPeer("not existent");
-      expect(peer).to.be.null;
+      await expect(api.getPeer("not existent")).to.be.rejectedWith();
     });
   });
 

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlock.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlock.test.ts
@@ -31,19 +31,4 @@ describe("rest - beacon - getBlock", function () {
       .expect("Content-Type", "application/json; charset=utf-8");
     expect((response.body as ApiResponseBody).data).to.not.be.undefined;
   });
-
-  it("should not found block header", async function () {
-    beaconBlocksStub.getBlock.withArgs("4").resolves(null);
-    await supertest(restApi.server.server)
-      .get(urlJoin(BEACON_PREFIX, getBlock.url.replace(":blockId", "4")))
-      .expect(404);
-  });
-
-  it("should fail validation", async function () {
-    beaconBlocksStub.getBlock.throws(new Error("Invalid block id"));
-    await supertest(restApi.server.server)
-      .get(urlJoin(BEACON_PREFIX, getBlock.url.replace(":blockId", "abc")))
-      .expect(400)
-      .expect("Content-Type", "application/json; charset=utf-8");
-  });
 });

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockAttestations.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockAttestations.test.ts
@@ -43,19 +43,4 @@ describe("rest - beacon - getBlockAttestations", function () {
     expect((response.body as ApiResponseBody).data).to.not.be.undefined;
     expect((response.body as ApiResponseBody).data.length).to.equal(2);
   });
-
-  it("should not found block", async function () {
-    beaconBlocksStub.getBlock.withArgs("4").resolves(null);
-    await supertest(restApi.server.server)
-      .get(urlJoin(BEACON_PREFIX, getBlockAttestations.url.replace(":blockId", "4")))
-      .expect(404);
-  });
-
-  it("should fail validation", async function () {
-    beaconBlocksStub.getBlock.throws(new Error("Invalid block id"));
-    await supertest(restApi.server.server)
-      .get(urlJoin(BEACON_PREFIX, getBlockAttestations.url.replace(":blockId", "abc")))
-      .expect(400)
-      .expect("Content-Type", "application/json; charset=utf-8");
-  });
 });

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockHeader.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockHeader.test.ts
@@ -29,19 +29,4 @@ describe("rest - beacon - getBlockHeader", function () {
       .expect("Content-Type", "application/json; charset=utf-8");
     expect((response.body as ApiResponseBody).data).to.not.be.undefined;
   });
-
-  it("should not found block header", async function () {
-    beaconBlocksStub.getBlockHeader.withArgs("4").resolves(null);
-    await supertest(restApi.server.server)
-      .get(urlJoin(BEACON_PREFIX, getBlockHeader.url.replace(":blockId", "4")))
-      .expect(404);
-  });
-
-  it("should fail validation", async function () {
-    beaconBlocksStub.getBlockHeader.throws(new Error("Invalid block id"));
-    await supertest(restApi.server.server)
-      .get(urlJoin(BEACON_PREFIX, getBlockHeader.url.replace(":blockId", "abc")))
-      .expect(400)
-      .expect("Content-Type", "application/json; charset=utf-8");
-  });
 });

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockRoot.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockRoot.test.ts
@@ -36,19 +36,4 @@ describe("rest - beacon - getBlockRoot", function () {
       toHexString(config.types.phase0.BeaconBlock.hashTreeRoot(block.message))
     );
   });
-
-  it("should not found block header", async function () {
-    beaconBlocksStub.getBlock.withArgs("4").resolves(null);
-    await supertest(restApi.server.server)
-      .get(urlJoin(BEACON_PREFIX, getBlockRoot.url.replace(":blockId", "4")))
-      .expect(404);
-  });
-
-  it("should fail validation", async function () {
-    beaconBlocksStub.getBlock.throws(new Error("Invalid block id"));
-    await supertest(restApi.server.server)
-      .get(urlJoin(BEACON_PREFIX, getBlockRoot.url.replace(":blockId", "abc")))
-      .expect(400)
-      .expect("Content-Type", "application/json; charset=utf-8");
-  });
 });

--- a/packages/lodestar/test/unit/api/rest/beacon/getGenesis.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/getGenesis.test.ts
@@ -33,9 +33,4 @@ describe("rest - beacon - getGenesis", function () {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(response.body.data.genesis_validators_root).to.not.be.empty;
   });
-
-  it("should return 404 if no genesis", async function () {
-    beaconStub.getGenesis.resolves(null);
-    await supertest(restApi.server.server).get(urlJoin(BEACON_PREFIX, getGenesis.url)).expect(404);
-  });
 });

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getBeaconCommittees.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getBeaconCommittees.test.ts
@@ -2,7 +2,7 @@ import {ValidatorIndex} from "@chainsafe/lodestar-types";
 import {List} from "@chainsafe/ssz";
 import {expect} from "chai";
 import supertest from "supertest";
-import {StateNotFound} from "../../../../../../src/api/impl/errors/errors";
+import {StateNotFound} from "../../../../../../src/api/impl/errors";
 import {getStateBeaconCommittees} from "../../../../../../src/api/rest/controllers/beacon/state";
 import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getBeaconCommittees.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getBeaconCommittees.test.ts
@@ -2,7 +2,7 @@ import {ValidatorIndex} from "@chainsafe/lodestar-types";
 import {List} from "@chainsafe/ssz";
 import {expect} from "chai";
 import supertest from "supertest";
-import {StateNotFound} from "../../../../../../src/api/impl/errors/api";
+import {StateNotFound} from "../../../../../../src/api/impl/errors/errors";
 import {getStateBeaconCommittees} from "../../../../../../src/api/rest/controllers/beacon/state";
 import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getStateFinalityCheckpoints.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getStateFinalityCheckpoints.test.ts
@@ -27,11 +27,4 @@ describe("rest - beacon - getStateFinalityCheckpoints", function () {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(response.body.data.finalized).to.not.be.undefined;
   });
-
-  it("should not found state", async function () {
-    beaconStateStub.getState.withArgs("4").resolves(null);
-    await supertest(restApi.server.server)
-      .get(urlJoin(BEACON_PREFIX, getStateFinalityCheckpoints.url.replace(":stateId", "4")))
-      .expect(404);
-  });
 });

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getStateFork.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getStateFork.test.ts
@@ -27,11 +27,4 @@ describe("rest - beacon - getStateFork", function () {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(response.body.data.current_version).to.not.be.undefined;
   });
-
-  it("should not found state", async function () {
-    beaconStateStub.getFork.withArgs("4").resolves(null);
-    await supertest(restApi.server.server)
-      .get(urlJoin(BEACON_PREFIX, getStateFork.url.replace(":stateId", "4")))
-      .expect(404);
-  });
 });

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getValidator.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getValidator.test.ts
@@ -2,7 +2,7 @@ import {config} from "@chainsafe/lodestar-config/minimal";
 import {toHexString} from "@chainsafe/ssz";
 import {expect} from "chai";
 import supertest from "supertest";
-import {StateNotFound} from "../../../../../../src/api/impl/errors/errors";
+import {StateNotFound} from "../../../../../../src/api/impl/errors";
 import {getStateValidator} from "../../../../../../src/api/rest/controllers/beacon/state/getValidator";
 import {generateValidator} from "../../../../../utils/validator";
 import {ApiResponseBody, urlJoin} from "../../utils";
@@ -52,14 +52,6 @@ describe("rest - beacon - getStateValidator", function () {
     expect((response.body as ApiResponseBody).data).to.not.be.undefined;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(response.body.data.balance).to.not.be.undefined;
-  });
-
-  it("should not found validator", async function () {
-    beaconStateStub.getStateValidator.withArgs("4", 1).resolves(null);
-    await supertest(restApi.server.server)
-      .get(urlJoin(BEACON_PREFIX, getStateValidator.url.replace(":stateId", "4").replace(":validatorId", "1")))
-      .expect(404);
-    expect(beaconStateStub.getStateValidator.calledOnce).to.be.true;
   });
 
   it("should not found state", async function () {

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getValidator.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getValidator.test.ts
@@ -2,7 +2,7 @@ import {config} from "@chainsafe/lodestar-config/minimal";
 import {toHexString} from "@chainsafe/ssz";
 import {expect} from "chai";
 import supertest from "supertest";
-import {StateNotFound} from "../../../../../../src/api/impl/errors/api";
+import {StateNotFound} from "../../../../../../src/api/impl/errors/errors";
 import {getStateValidator} from "../../../../../../src/api/rest/controllers/beacon/state/getValidator";
 import {generateValidator} from "../../../../../utils/validator";
 import {ApiResponseBody, urlJoin} from "../../utils";

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getValidators.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getValidators.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 import supertest from "supertest";
-import {StateNotFound} from "../../../../../../src/api/impl/errors/api";
+import {StateNotFound} from "../../../../../../src/api/impl/errors/errors";
 import {getStateValidators} from "../../../../../../src/api/rest/controllers/beacon";
 import {generateValidator} from "../../../../../utils/validator";
 import {ApiResponseBody, urlJoin} from "../../utils";

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getValidators.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getValidators.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 import supertest from "supertest";
-import {StateNotFound} from "../../../../../../src/api/impl/errors/errors";
+import {StateNotFound} from "../../../../../../src/api/impl/errors";
 import {getStateValidators} from "../../../../../../src/api/rest/controllers/beacon";
 import {generateValidator} from "../../../../../utils/validator";
 import {ApiResponseBody, urlJoin} from "../../utils";

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getValidatorsBalances.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getValidatorsBalances.test.ts
@@ -2,7 +2,7 @@ import {config} from "@chainsafe/lodestar-config/minimal";
 import {toHexString} from "@chainsafe/ssz";
 import {expect} from "chai";
 import supertest from "supertest";
-import {StateNotFound} from "../../../../../../src/api/impl/errors/api";
+import {StateNotFound} from "../../../../../../src/api/impl/errors/errors";
 import {getStateValidatorsBalances} from "../../../../../../src/api/rest/controllers/beacon";
 import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";

--- a/packages/lodestar/test/unit/api/rest/beacon/state/getValidatorsBalances.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/state/getValidatorsBalances.test.ts
@@ -2,7 +2,7 @@ import {config} from "@chainsafe/lodestar-config/minimal";
 import {toHexString} from "@chainsafe/ssz";
 import {expect} from "chai";
 import supertest from "supertest";
-import {StateNotFound} from "../../../../../../src/api/impl/errors/errors";
+import {StateNotFound} from "../../../../../../src/api/impl/errors";
 import {getStateValidatorsBalances} from "../../../../../../src/api/rest/controllers/beacon";
 import {ApiResponseBody, urlJoin} from "../../utils";
 import {BEACON_PREFIX, setupRestApiTestServer} from "../../index.test";

--- a/packages/lodestar/test/unit/api/rest/debug/beacon/getHeads.test.ts
+++ b/packages/lodestar/test/unit/api/rest/debug/beacon/getHeads.test.ts
@@ -24,9 +24,4 @@ describe("rest - debug - beacon - getHeads", function () {
       .expect("Content-Type", "application/json; charset=utf-8");
     expect((response.body as ApiResponseBody).data).to.not.be.undefined;
   });
-
-  it("should not found heads", async function () {
-    debugBeaconStub.getHeads.resolves(null);
-    await supertest(restApi.server.server).get("/eth/v1/debug/beacon/heads").expect(404);
-  });
 });

--- a/packages/lodestar/test/unit/api/rest/debug/beacon/getState.test.ts
+++ b/packages/lodestar/test/unit/api/rest/debug/beacon/getState.test.ts
@@ -57,14 +57,4 @@ describe("rest - debug - beacon - getState", function () {
       .expect("Content-Type", "application/octet-stream");
     expect(response.body).to.be.deep.equal(config.getTypes(state.slot).BeaconState.serialize(state));
   });
-
-  it("should return status code 404", async function () {
-    debugBeaconStub.getState.resolves(null);
-    await supertest(restApi.server.server).get("/eth/v1/debug/beacon/states/0xSomething").expect(404);
-  });
-
-  it("should return status code 400", async function () {
-    debugBeaconStub.getState.throws(new Error("Invalid state id"));
-    await supertest(restApi.server.server).get("/eth/v1/debug/beacon/states/1000x").expect(400);
-  });
 });

--- a/packages/lodestar/test/unit/api/rest/node/getPeer.test.ts
+++ b/packages/lodestar/test/unit/api/rest/node/getPeer.test.ts
@@ -33,11 +33,4 @@ describe("rest - node - getPeer", function () {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(response.body.data.peer_id).to.equal("16");
   });
-
-  it("peer not found", async function () {
-    nodeStub.getPeer.resolves(null);
-    await supertest(restApi.server.server)
-      .get(urlJoin(NODE_PREFIX, getPeer.url.replace(":peerId", "16")))
-      .expect(404);
-  });
 });


### PR DESCRIPTION
**Motivation**

Remove unnecessary complexity.

**Description**

Remove null types, and throw typed errors from the API impl. Simplifies code a bunch, both on the controllers and consumers of the API
