### PR TITLE
API route /pool/attestations must expect an array

### DIFF
--- a/packages/lodestar/src/api/impl/beacon/pool/interface.ts
+++ b/packages/lodestar/src/api/impl/beacon/pool/interface.ts
@@ -7,7 +7,7 @@ export interface IAttestationFilters {
 
 export interface IBeaconPoolApi {
   getAttestations(filters?: Partial<IAttestationFilters>): Promise<phase0.Attestation[]>;
-  submitAttestation(attestation: phase0.Attestation): Promise<void>;
+  submitAttestations(attestations: phase0.Attestation[]): Promise<void>;
   getAttesterSlashings(): Promise<phase0.AttesterSlashing[]>;
   submitAttesterSlashing(slashing: phase0.AttesterSlashing): Promise<void>;
   getProposerSlashings(): Promise<phase0.ProposerSlashing[]>;

--- a/packages/lodestar/test/unit/api/rest/beacon/pool/submitPoolAttestation.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/pool/submitPoolAttestation.test.ts
@@ -27,7 +27,7 @@ describe("rest - beacon - submitAttestations", function () {
   it("should succeed", async function () {
     await supertest(restApi.server.server)
       .post(urlJoin(BEACON_PREFIX, submitPoolAttestation.url))
-      .send(config.types.phase0.Attestation.toJson(attestation, {case: "snake"}) as Record<string, unknown>)
+      .send([config.types.phase0.Attestation.toJson(attestation, {case: "snake"}) as Record<string, unknown>])
       .expect(200);
     expect(beaconPoolStub.submitAttestations.calledOnce).to.be.true;
   });
@@ -35,7 +35,7 @@ describe("rest - beacon - submitAttestations", function () {
   it("should fail to parse body", async function () {
     await supertest(restApi.server.server)
       .post(urlJoin(BEACON_PREFIX, submitPoolAttestation.url))
-      .send(config.types.phase0.Attestation.toJson(attestation, {case: "camel"}) as Record<string, unknown>)
+      .send([config.types.phase0.Attestation.toJson(attestation, {case: "camel"}) as Record<string, unknown>])
       .expect(400)
       .expect("Content-Type", "application/json; charset=utf-8");
     expect(beaconPoolStub.submitAttestations.notCalled).to.be.true;

--- a/packages/lodestar/test/unit/api/rest/beacon/pool/submitPoolAttestation.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/pool/submitPoolAttestation.test.ts
@@ -10,7 +10,7 @@ import {SinonStubbedInstance} from "sinon";
 import {RestApi} from "../../../../../../src/api";
 import {BeaconPoolApi} from "../../../../../../src/api/impl/beacon/pool";
 
-describe("rest - beacon - submitAttestation", function () {
+describe("rest - beacon - submitAttestations", function () {
   let attestation: Attestation;
   let restApi: RestApi;
   let beaconPoolStub: SinonStubbedInstance<BeaconPoolApi>;
@@ -29,7 +29,7 @@ describe("rest - beacon - submitAttestation", function () {
       .post(urlJoin(BEACON_PREFIX, submitPoolAttestation.url))
       .send(config.types.phase0.Attestation.toJson(attestation, {case: "snake"}) as Record<string, unknown>)
       .expect(200);
-    expect(beaconPoolStub.submitAttestation.calledOnce).to.be.true;
+    expect(beaconPoolStub.submitAttestations.calledOnce).to.be.true;
   });
 
   it("should fail to parse body", async function () {
@@ -38,6 +38,6 @@ describe("rest - beacon - submitAttestation", function () {
       .send(config.types.phase0.Attestation.toJson(attestation, {case: "camel"}) as Record<string, unknown>)
       .expect(400)
       .expect("Content-Type", "application/json; charset=utf-8");
-    expect(beaconPoolStub.submitAttestation.notCalled).to.be.true;
+    expect(beaconPoolStub.submitAttestations.notCalled).to.be.true;
   });
 });

--- a/packages/validator/src/api/impl/rest/beacon/pool.ts
+++ b/packages/validator/src/api/impl/rest/beacon/pool.ts
@@ -3,10 +3,10 @@ import {IBeaconPoolApi} from "../../../interface/beacon";
 import {RestApi} from "./abstract";
 
 export class RestBeaconPoolApi extends RestApi implements IBeaconPoolApi {
-  async submitAttestation(attestation: phase0.Attestation): Promise<void> {
+  async submitAttestations(attestations: phase0.Attestation[]): Promise<void> {
     return this.client.post(
       "/pool/attestations",
-      this.config.types.phase0.Attestation.toJson(attestation, {case: "snake"})
+      attestations.map((attestation) => this.config.types.phase0.Attestation.toJson(attestation, {case: "snake"}))
     );
   }
 

--- a/packages/validator/src/api/interface/beacon.ts
+++ b/packages/validator/src/api/interface/beacon.ts
@@ -20,6 +20,6 @@ export interface IBeaconBlocksApi {
 }
 
 export interface IBeaconPoolApi {
-  submitAttestation(attestation: phase0.Attestation): Promise<void>;
+  submitAttestations(attestation: phase0.Attestation[]): Promise<void>;
   submitVoluntaryExit(signedVoluntaryExit: phase0.SignedVoluntaryExit): Promise<void>;
 }

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -218,7 +218,7 @@ export class AttestationService {
       }, (this.config.params.SECONDS_PER_SLOT / 3) * 1000);
     }
     try {
-      await this.provider.beacon.pool.submitAttestation(attestation);
+      await this.provider.beacon.pool.submitAttestations([attestation]);
       this.logger.info("Published attestation", {slot: attestation.data.slot, validator: prettyBytes(duty.pubkey)});
     } catch (e) {
       this.logger.error("Failed to publish attestation", e);

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -134,13 +134,13 @@ describe("validator attestation service", function () {
     service["nextAttesterDuties"].set(1, new Map([[toHexString(pubkey), {...duty, isAggregator: false}]]));
     rpcClientStub.beacon.state.getFork.resolves(generateFork());
     rpcClientStub.validator.produceAttestationData.resolves(generateEmptyAttestation().data);
-    rpcClientStub.beacon.pool.submitAttestation.resolves();
+    rpcClientStub.beacon.pool.submitAttestations.resolves();
     slashingProtectionStub.checkAndInsertAttestation.resolves();
     const promise = service.onClockSlot({slot: 1});
     clock.tick(4000);
     await Promise.resolve(promise);
     expect(rpcClientStub.validator.produceAttestationData.withArgs(2, 1).calledOnce).to.be.true;
-    expect(rpcClientStub.beacon.pool.submitAttestation.calledOnce).to.be.true;
+    expect(rpcClientStub.beacon.pool.submitAttestations.calledOnce).to.be.true;
     expect(slashingProtectionStub.checkAndInsertAttestation.calledOnce).to.be.true;
   });
 
@@ -172,7 +172,7 @@ describe("validator attestation service", function () {
     // Simulate double vote detection
     const attestation1 = generateAttestation({data: generateAttestationData(0, 1)});
     rpcClientStub.validator.produceAttestationData.resolves(attestation1.data);
-    rpcClientStub.beacon.pool.submitAttestation.resolves();
+    rpcClientStub.beacon.pool.submitAttestations.resolves();
     slashingProtectionStub.checkAndInsertAttestation.rejects(
       new InvalidAttestationError({code: InvalidAttestationErrorCode.DOUBLE_VOTE} as any)
     );
@@ -181,7 +181,7 @@ describe("validator attestation service", function () {
     clock.tick(4000);
     await Promise.resolve(promise);
     expect(rpcClientStub.validator.produceAttestationData.withArgs(3, 1).calledOnce).to.be.true;
-    expect(rpcClientStub.beacon.pool.submitAttestation.notCalled).to.be.true;
+    expect(rpcClientStub.beacon.pool.submitAttestations.notCalled).to.be.true;
   });
 
   it("on new slot - with duty - SSE message comes before 1/3 slot time", async function () {
@@ -209,7 +209,7 @@ describe("validator attestation service", function () {
     service["nextAttesterDuties"].set(10, new Map([[toHexString(pubkey), {...duty, isAggregator: false}]]));
     rpcClientStub.beacon.state.getFork.resolves(generateFork());
     rpcClientStub.validator.produceAttestationData.resolves(generateEmptyAttestation().data);
-    rpcClientStub.beacon.pool.submitAttestation.resolves();
+    rpcClientStub.beacon.pool.submitAttestations.resolves();
     slashingProtectionStub.checkAndInsertAttestation.resolves();
     const promise = service.onClockSlot({slot: 10});
     rpcClientStub.emit(BeaconEventType.BLOCK, {block: new Uint8Array(32), slot: 10});


### PR DESCRIPTION
**Motivation**

Follow eth2.0 API spec

**Description**

The route /pool/attestations should accept an array of attestations. We want to follow this approach since it's very beneficial to increase the efficiency of the validator client with many validators.

https://github.com/ethereum/eth2.0-APIs/blob/18cb6ff152b33a5f34c377f00611821942955c82/apis/beacon/pool/attestations.yaml#L61

Potentially closes - https://github.com/ChainSafe/lodestar/issues/2361 but I haven't tested it