### PR TITLE
Add fork_choice spec test

### DIFF
--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -195,6 +195,10 @@ export class ForkChoice implements IForkChoice {
     return this.fcStore.justifiedCheckpoint;
   }
 
+  getBestJustifiedCheckpoint(): phase0.Checkpoint {
+    return this.fcStore.bestJustifiedCheckpoint;
+  }
+
   /**
    * Add `block` to the fork choice DAG.
    *

--- a/packages/spec-test-runner/test/spec/fork_choice/get_head_fast.test.ts
+++ b/packages/spec-test-runner/test/spec/fork_choice/get_head_fast.test.ts
@@ -1,0 +1,113 @@
+import {join} from "path";
+import {expect} from "chai";
+import {config} from "@chainsafe/lodestar-config/mainnet";
+import {createCachedBeaconState, phase0, fast} from "@chainsafe/lodestar-beacon-state-transition";
+import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util";
+import {
+  ANCHOR_STATE_FILE_NAME,
+  ANCHOR_BLOCK_FILE_NAME,
+  ATTESTATION_FILE_NAME,
+  BLOCK_FILE_NAME,
+  IForkChoiceTestCase,
+  isTick,
+  isAttestation,
+  isBlock,
+  isCheck,
+} from "./type";
+import {LodestarForkChoice} from "@chainsafe/lodestar/lib/chain/forkChoice/forkChoice";
+import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
+import {ChainEventEmitter} from "@chainsafe/lodestar/lib/chain/emitter";
+import {toHexString} from "@chainsafe/ssz";
+
+describeDirectorySpecTest<IForkChoiceTestCase, void>(
+  "forkchoice get_head",
+  join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/fork_choice/get_head/pyspec_tests"),
+  (testcase) => {
+    const emitter = new ChainEventEmitter();
+    const {steps, anchorState} = testcase;
+    const currentSlot = anchorState.slot;
+    const tbState = config.getTypes(currentSlot).BeaconState.createTreeBackedFromStruct(anchorState);
+    let cachedState = createCachedBeaconState(config, tbState);
+    const forkchoice = new LodestarForkChoice({config, emitter, currentSlot, state: cachedState});
+    const {SECONDS_PER_SLOT} = cachedState.config.params;
+    for (const step of steps) {
+      if (isTick(step)) {
+        forkchoice.updateTime(Number(step.tick) / SECONDS_PER_SLOT);
+      } else if (isAttestation(step)) {
+        const attestation = testcase.attestations.get(step.attestation);
+        forkchoice.onAttestation(cachedState.epochCtx.getIndexedAttestation(attestation!));
+      } else if (isBlock(step)) {
+        const signedBlock = testcase.blocks.get(step.block)!;
+        expect(signedBlock).not.to.be.undefined;
+        try {
+          cachedState = fast.fastStateTransition(cachedState, signedBlock, {
+            verifyStateRoot: false,
+            verifyProposer: false,
+            verifySignatures: false,
+          });
+        } catch (e) {
+          // some tests add old blocks, fastStateTransition should throw error but this is fine
+        }
+
+        forkchoice.onBlock(signedBlock.message, cachedState);
+      } else if (isCheck(step)) {
+        const {
+          head: expectedHead,
+          time: expectedTime,
+          justifiedCheckpointRoot,
+          finalizedCheckpointRoot,
+          bestJustifiedCheckpoint,
+        } = step.checks;
+        const head = forkchoice.getHead();
+        expect(head.slot).to.be.equal(Number(expectedHead.slot));
+        expect(toHexString(head.blockRoot)).to.be.equal(expectedHead.root);
+        // time in spec mapped to Slot in our forkchoice implementation
+        if (expectedTime) expect(forkchoice.getTime() * SECONDS_PER_SLOT).to.be.equal(Number(expectedTime));
+        if (justifiedCheckpointRoot)
+          expect(toHexString(forkchoice.getJustifiedCheckpoint().root)).to.be.equal(justifiedCheckpointRoot);
+        if (finalizedCheckpointRoot)
+          expect(toHexString(forkchoice.getFinalizedCheckpoint().root)).to.be.equal(finalizedCheckpointRoot);
+        if (bestJustifiedCheckpoint)
+          expect(toHexString(forkchoice.getBestJustifiedCheckpoint().root)).to.be.equal(bestJustifiedCheckpoint);
+      }
+    }
+  },
+  {
+    inputTypes: {
+      meta: InputType.YAML,
+      steps: InputType.YAML,
+    },
+    sszTypes: {
+      [ANCHOR_STATE_FILE_NAME]: config.types.phase0.BeaconState,
+      [ANCHOR_BLOCK_FILE_NAME]: config.types.phase0.BeaconBlock,
+      [BLOCK_FILE_NAME]: config.types.phase0.SignedBeaconBlock,
+      [ATTESTATION_FILE_NAME]: config.types.phase0.Attestation,
+    },
+    mapToTestCase: (t: Record<string, any>) => {
+      // t has input file name as key
+      const blocks = new Map<string, phase0.SignedBeaconBlock>();
+      const attestations = new Map<string, phase0.Attestation>();
+      for (const key in t) {
+        const blockMatch = key.match(BLOCK_FILE_NAME);
+        if (blockMatch) {
+          blocks.set(key, t[key]);
+        }
+        const attMatch = key.match(ATTESTATION_FILE_NAME);
+        if (attMatch) {
+          attestations.set(key, t[key]);
+        }
+      }
+      return {
+        meta: t["meta"] as IForkChoiceTestCase["meta"],
+        anchorState: t[ANCHOR_STATE_FILE_NAME] as IForkChoiceTestCase["anchorState"],
+        anchorBlock: t[ANCHOR_BLOCK_FILE_NAME] as IForkChoiceTestCase["anchorBlock"],
+        steps: t["steps"] as IForkChoiceTestCase["steps"],
+        blocks,
+        attestations,
+      };
+    },
+    timeout: 10000000,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    expectFunc: () => {},
+  }
+);

--- a/packages/spec-test-runner/test/spec/fork_choice/type.ts
+++ b/packages/spec-test-runner/test/spec/fork_choice/type.ts
@@ -1,0 +1,59 @@
+import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
+import {IBaseSpecTest} from "../type";
+
+export const ANCHOR_STATE_FILE_NAME = "anchor_state";
+export const ANCHOR_BLOCK_FILE_NAME = "anchor_block";
+export const BLOCK_FILE_NAME = "^(block)_([0-9a-zA-Z]+)$";
+export const ATTESTATION_FILE_NAME = "^(attestation)_([0-9a-zA-Z])+$";
+
+export interface IForkChoiceTestCase extends IBaseSpecTest {
+  meta?: {
+    description?: string;
+    blsSetting: BigInt;
+  };
+  anchorState: phase0.BeaconState;
+  anchorBlock: phase0.BeaconBlock;
+  steps: Step[];
+  blocks: Map<string, phase0.SignedBeaconBlock>;
+  attestations: Map<string, phase0.Attestation>;
+}
+
+export function isTick(step: Step): step is IOnTick {
+  return (step as IOnTick).tick > 0;
+}
+
+export function isAttestation(step: Step): step is IOnAttestation {
+  return typeof (step as IOnAttestation).attestation === "string";
+}
+
+export function isBlock(step: Step): step is IOnBlock {
+  return typeof (step as IOnBlock).block === "string";
+}
+
+export function isCheck(step: Step): step is IChecks {
+  return typeof (step as IChecks).checks === "object";
+}
+
+type Step = IOnTick | IOnAttestation | IOnBlock | IChecks;
+
+interface IOnTick {
+  tick: number;
+}
+
+interface IOnAttestation {
+  attestation: string;
+}
+
+interface IOnBlock {
+  block: string;
+}
+
+interface IChecks {
+  checks: {
+    head: {slot: number; root: string};
+    time?: number;
+    justifiedCheckpointRoot?: string;
+    finalizedCheckpointRoot?: string;
+    bestJustifiedCheckpoint?: string;
+  };
+}


### PR DESCRIPTION
**Motivation**

Make sure our forkchoice implementation conform to the spec.

**Description**

This fork_choice test has an abnormal structure:
+ It's step-by-step, not one-shot
+ Input file name follows regular expression

So in order to do that
+ Modify `sszTypes` definition to base on regular expression instead of exact string comparison.
+ Add `mapToTestCase` function to help map loaded test case to our test case definition.

Other spec tests are kept as is.

This is for phase_0, seems like we have same tests for altair, will add later.

part of #1472 

**Steps to test or reproduce**
`yarn test:spec-fast`
