### PR TITLE
Fix log level settings in WinstonLogger

### DIFF
--- a/packages/lodestar/test/utils/logger.ts
+++ b/packages/lodestar/test/utils/logger.ts
@@ -10,13 +10,13 @@ export {LogLevel};
  * VERBOSE=1 mocha .ts
  * ```
  */
-export function testLogger(module?: string, defaultLogLevel = LogLevel.error, logFile?: string): WinstonLogger {
-  const transports: TransportOpts[] = [{type: TransportType.console}];
+export function testLogger(module?: string, logLevel = LogLevel.error, logFile?: string): WinstonLogger {
+  const transports: TransportOpts[] = [{type: TransportType.console, level: getLogLevelFromEnvs() || logLevel}];
   if (logFile) {
     transports.push({type: TransportType.file, filename: logFile, level: LogLevel.debug});
   }
 
-  return new WinstonLogger({level: getLogLevelFromEnvs() || defaultLogLevel, module}, transports);
+  return new WinstonLogger({module}, transports);
 }
 
 function getLogLevelFromEnvs(): LogLevel | null {


### PR DESCRIPTION
**Motivation**

A regression in the WinstonLogger levels logic caused the testLogger() to get info level when it should get error level.

**Description**

Improve the logic to pick the correct level and apply the default log level only when no option is specified.
