### PR TITLE
Add API endpoint to return state multiproof

### DIFF
--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -55,6 +55,7 @@
     "@chainsafe/lodestar-types": "^0.19.0",
     "@chainsafe/lodestar-utils": "^0.19.0",
     "@chainsafe/lodestar-validator": "^0.19.0",
+    "@chainsafe/persistent-merkle-tree": "^0.3.0",
     "@chainsafe/snappy-stream": "3.0.5",
     "@chainsafe/ssz": "^0.8.2",
     "@ethersproject/abi": "^5.0.0",


### PR DESCRIPTION
**Motivation**

We want to support light client proof req/resp interaction.

**Description**

Naive implementation of a proof endpoint, using existing code.
To consume:
```ts
import {deserializeProof} from "@chainsafe/persistent-merkle-tree";
import {config} from "@chainsafe/lodestar-config/mainnet";
import {phase0} from "@chainsafe/lodestar-types";

// A proof is requested for an array of paths
const paths = [
  ["genesisTime"],
  ["validators", 0, "effectiveBalance"],
];
// Usually against a known state root
const stateRoot = ...;

const resp = await fetch(... stateRoot ...);

// The response is the serialized proof.
// First deserialize into a `IProof`, then use provided methods on `BeaconState` ssz type
const proof = deserializeProof(new Uint8Array(await resp.arrayBuffer()));
// verify the merkle root against the known state root
const state: TreeBacked<phase0.BeaconState> = config.types.phase0.BeaconState.createTreeBackedFromProof(
  stateRoot,
  proof
);
// for testing purposes, no verification of the merkle root
const state2: TreeBacked<phase0.BeaconState> = config.types.phase0.BeaconState.createTreeBackedFromProofUnsafe(
  proof
);
```