### PR TITLE
Reprocess blocks as TreeBacked

### DIFF
--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -240,6 +240,7 @@ export async function onBlock(
       }),
     ]);
   }
+  // if reprocess job, don't have to reprocess block operations or pending blocks
   if (!job.reprocess) {
     await this.db.processBlockOperations(block);
     await Promise.all(

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -240,25 +240,25 @@ export async function onBlock(
       }),
     ]);
   }
-
-  await this.db.processBlockOperations(block);
-
-  await Promise.all(
-    this.pendingBlocks.getByParent(blockRoot).map(async ({root, slot}) => {
-      const pendingBlock = await this.db.pendingBlock.get(root, slot);
-      if (pendingBlock) {
-        this.pendingBlocks.remove(pendingBlock);
-        await this.db.pendingBlock.delete(root, slot);
-        return this.blockProcessor.processBlockJob({
-          signedBlock: pendingBlock,
-          reprocess: false,
-          prefinalized: false,
-          validSignatures: false,
-          validProposerSignature: false,
-        });
-      }
-    })
-  );
+  if (!job.reprocess) {
+    await this.db.processBlockOperations(block);
+    await Promise.all(
+      this.pendingBlocks.getByParent(blockRoot).map(async ({root, slot}) => {
+        const pendingBlock = await this.db.pendingBlock.get(root, slot);
+        if (pendingBlock) {
+          this.pendingBlocks.remove(pendingBlock);
+          await this.db.pendingBlock.delete(root, slot);
+          return this.blockProcessor.processBlockJob({
+            signedBlock: pendingBlock,
+            reprocess: false,
+            prefinalized: false,
+            validSignatures: false,
+            validProposerSignature: false,
+          });
+        }
+      })
+    );
+  }
 }
 
 export async function onErrorAttestation(this: BeaconChain, err: AttestationError): Promise<void> {

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -174,7 +174,8 @@ export class StateRegenerator implements IStateRegenerator {
     }
 
     for (const b of blocksToReplay.reverse()) {
-      const block = await this.db.block.get(b.blockRoot, b.slot);
+      const structBlock = (await this.db.block.get(b.blockRoot, b.slot))!;
+      const block = this.config.getTypes(b.slot).SignedBeaconBlock.createTreeBackedFromStruct(structBlock);
       if (!block) {
         throw new RegenError({
           code: RegenErrorCode.BLOCK_NOT_IN_DB,


### PR DESCRIPTION
**Motivation**

+ Reprocess blocks take time because it's a struct, we should use TreeBacked blocks to make it faster.
+ At `onBlock` event handler, skip some operations if `reprocess=true` 

**Description**


Closes #2359
