### PR TITLE
Save 1 epoch transition when the node is synced

### DIFF
--- a/packages/beacon-state-transition/src/fast/stateTransition.ts
+++ b/packages/beacon-state-transition/src/fast/stateTransition.ts
@@ -26,10 +26,7 @@ export function fastStateTransition(
   // process slots (including those with no blocks) since block
   switch (preFork) {
     case "phase0":
-      if (postState.slot < block.slot) {
-        // a cached checkpoint state doesn't need to process slots
-        processSlots(postState as CachedBeaconState<phase0.BeaconState>, block.slot);
-      }
+      processSlots(postState as CachedBeaconState<phase0.BeaconState>, block.slot);
       break;
     default:
       throw new Error(`Slot processing not implemented for fork ${preFork}`);

--- a/packages/beacon-state-transition/src/fast/stateTransition.ts
+++ b/packages/beacon-state-transition/src/fast/stateTransition.ts
@@ -26,7 +26,10 @@ export function fastStateTransition(
   // process slots (including those with no blocks) since block
   switch (preFork) {
     case "phase0":
-      processSlots(postState as CachedBeaconState<phase0.BeaconState>, block.slot);
+      if (postState.slot < block.slot) {
+        // a cached checkpoint state doesn't need to process slots
+        processSlots(postState as CachedBeaconState<phase0.BeaconState>, block.slot);
+      }
       break;
     default:
       throw new Error(`Slot processing not implemented for fork ${preFork}`);

--- a/packages/beacon-state-transition/src/phase0/fast/slot/index.ts
+++ b/packages/beacon-state-transition/src/phase0/fast/slot/index.ts
@@ -3,13 +3,12 @@ import {phase0, Slot} from "@chainsafe/lodestar-types";
 import {processEpoch} from "../epoch";
 import {processSlot} from "./processSlot";
 import {CachedBeaconState, rotateEpochs} from "../../../fast";
+import {assert} from "@chainsafe/lodestar-utils";
 
 export {processSlot};
 
 export function processSlots(state: CachedBeaconState<phase0.BeaconState>, slot: Slot): void {
-  if (!(state.slot < slot)) {
-    throw new Error("State slot must transition to a future slot: " + `stateSlot=${state.slot} slot=${slot}`);
-  }
+  assert.lte(state.slot, slot, `State slot ${state.slot} must transition to a future slot ${slot}`);
   while (state.slot < slot) {
     processSlot(state);
     // process epoch on the start slot of the next epoch


### PR DESCRIPTION
**Motivation**

Reduce 1 epoch transition when the node is synced.
+ we receive a gossip block at start of an epoch and we have to do epoch transition to check block proposer https://github.com/ChainSafe/lodestar/blob/5ed277e2005484b0c8e77a2e2857d501d5b938c5/packages/lodestar/src/chain/validation/block.ts#L59
+ then we do regular `runStateTransition()` which process slots (and epoch) and block inside `beacon-state-transition` module https://github.com/ChainSafe/lodestar/blob/5ed277e2005484b0c8e77a2e2857d501d5b938c5/packages/lodestar/src/chain/blocks/stateTransition.ts#L124


**Description**

Closes #2382

**Tested with prater synced node**

After processing epoch to validate gossip block, we only need to do `processSlot` inside `runStateTransition`
<img width="1294" alt="Screen Shot 2021-04-16 at 08 31 06" src="https://user-images.githubusercontent.com/10568965/114958931-37952d00-9e8e-11eb-907f-9c4c284db85b.png">
[01416_server_prater_synced.cpuprofile.zip](https://github.com/ChainSafe/lodestar/files/6321922/01416_server_prater_synced.cpuprofile.zip)
