### PR TITLE
Add total Reqresp timeouts

### DIFF
--- a/packages/lodestar/src/network/reqresp/reqResp.ts
+++ b/packages/lodestar/src/network/reqresp/reqResp.ts
@@ -76,6 +76,7 @@ export class ReqResp implements IReqResp {
                 peerId,
                 method,
                 encoding,
+                this.controller.signal,
                 this.respCount++
               );
               // TODO: Do success peer scoring here

--- a/packages/lodestar/src/network/reqresp/reqResp.ts
+++ b/packages/lodestar/src/network/reqresp/reqResp.ts
@@ -145,7 +145,7 @@ export class ReqResp implements IReqResp {
     peerId: PeerId,
     method: Method,
     body: phase0.RequestBody,
-    maxResponses?: number
+    maxResponses = 1
   ): Promise<T> {
     try {
       const encoding = this.peerMetadata.encoding.get(peerId) ?? ReqRespEncoding.SSZ_SNAPPY;

--- a/packages/lodestar/src/network/reqresp/request/errors.ts
+++ b/packages/lodestar/src/network/reqresp/request/errors.ts
@@ -18,6 +18,8 @@ export enum RequestErrorCode {
   REQUEST_TIMEOUT = "REQUEST_ERROR_REQUEST_TIMEOUT",
   /** Error when sending request to responder */
   REQUEST_ERROR = "REQUEST_ERROR_REQUEST_ERROR",
+  /** Reponder did not deliver a full reponse before max maxTotalResponseTimeout() */
+  RESPONSE_TIMEOUT = "REQUEST_ERROR_RESPONSE_TIMEOUT",
   /** A single-response method returned 0 chunks */
   EMPTY_RESPONSE = "REQUEST_ERROR_EMPTY_RESPONSE",
   /** Time to first byte timeout */
@@ -34,6 +36,7 @@ type RequestErrorType =
   | {code: RequestErrorCode.DIAL_ERROR; error: Error}
   | {code: RequestErrorCode.REQUEST_TIMEOUT}
   | {code: RequestErrorCode.REQUEST_ERROR; error: Error}
+  | {code: RequestErrorCode.RESPONSE_TIMEOUT}
   | {code: RequestErrorCode.EMPTY_RESPONSE}
   | {code: RequestErrorCode.TTFB_TIMEOUT}
   | {code: RequestErrorCode.RESP_TIMEOUT};

--- a/packages/lodestar/src/network/reqresp/request/responseTimeoutsHandler.ts
+++ b/packages/lodestar/src/network/reqresp/request/responseTimeoutsHandler.ts
@@ -5,6 +5,12 @@ import {timeoutOptions} from "../../../constants";
 import {onChunk} from "../utils/onChunk";
 import {RequestErrorCode, RequestInternalError} from "./errors";
 
+/** Returns the maximum total timeout possible for a response. See @responseTimeoutsHandler */
+export function maxTotalResponseTimeout(maxResponses = 1, options?: Partial<typeof timeoutOptions>): number {
+  const {TTFB_TIMEOUT, RESP_TIMEOUT} = {...timeoutOptions, ...options};
+  return TTFB_TIMEOUT + maxResponses * RESP_TIMEOUT;
+}
+
 /**
  * Wraps responseDecoder to isolate the logic that handles response timeouts.
  * - TTFB_TIMEOUT: The requester MUST wait a maximum of TTFB_TIMEOUT for the first response byte to arrive

--- a/packages/lodestar/test/unit/network/reqresp/response/index.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/response/index.test.ts
@@ -1,5 +1,6 @@
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
+import {AbortController} from "abort-controller";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {LodestarError} from "@chainsafe/lodestar-utils";
 import {Method, ReqRespEncoding, RpcResponseStatus} from "../../../../../src/constants";
@@ -18,6 +19,10 @@ describe("network / reqresp / response / handleRequest", async () => {
   const peerId = getValidPeerId();
   const multiaddr = "/ip4/127.0.0.1/tcp/0";
   const libp2p = await createNode(multiaddr);
+
+  let controller: AbortController;
+  beforeEach(() => (controller = new AbortController()));
+  afterEach(() => controller.abort());
 
   const testCases: {
     id: string;
@@ -71,7 +76,8 @@ describe("network / reqresp / response / handleRequest", async () => {
         stream,
         peerId,
         method,
-        encoding
+        encoding,
+        controller.signal
       );
 
       // Make sure the test error-ed with expected error, otherwise it's hard to debug with responseChunks


### PR DESCRIPTION
**Motivation**

In certain conditions, the timeouts in `responseTimeoutsHandler()` won't fire, causing the Sync to get stuck

**Description**

This PR adds a maximum general timeout to prevent the Sync from getting stuck. Meanwhile will try to debug the underlying issue

Closes https://github.com/ChainSafe/lodestar/issues/2321

This PR is complementary to https://github.com/ChainSafe/lodestar/pull/2387, both should be merged