### PR TITLE
Add queue job wait time metric

### DIFF
--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -50,6 +50,7 @@ export class BlockProcessor {
         length: modules.metrics.blockProcessorQueueLength,
         droppedJobs: modules.metrics.blockProcessorQueueDroppedJobs,
         jobTime: modules.metrics.blockProcessorQueueJobTime,
+        jobWaitTime: modules.metrics.blockProcessorQueueJobWaitTime,
       }
     );
   }

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -73,21 +73,29 @@ export function createLodestarMetrics(register: RegistryMetricCreator, metadata:
       help: "Time to process gossip validation queue job in seconds",
       labelNames: ["topic"],
     }),
+    gossipValidationQueueJobWaitTime: register.histogram<"topic">({
+      name: "lodestar_gossip_validation_queue_job_wait_time_seconds",
+      help: "Time from job added to the queue to starting the job in seconds",
+      labelNames: ["topic"],
+      buckets: [0.1, 1, 10, 100],
+    }),
 
-    blockProcessorQueueLength: register.gauge<"topic">({
+    blockProcessorQueueLength: register.gauge({
       name: "lodestar_block_processor_queue_length",
       help: "Count of total block processor queue length",
-      labelNames: ["topic"],
     }),
-    blockProcessorQueueDroppedJobs: register.gauge<"topic">({
+    blockProcessorQueueDroppedJobs: register.gauge({
       name: "lodestar_block_processor_queue_dropped_jobs_total",
       help: "Count of total block processor queue dropped jobs",
-      labelNames: ["topic"],
     }),
-    blockProcessorQueueJobTime: register.histogram<"topic">({
+    blockProcessorQueueJobTime: register.histogram({
       name: "lodestar_block_processor_queue_job_time_seconds",
       help: "Time to process block processor queue job in seconds",
-      labelNames: ["topic"],
+    }),
+    blockProcessorQueueJobWaitTime: register.histogram({
+      name: "lodestar_block_processor_queue_job_wait_time_seconds",
+      help: "Time from job added to the queue to starting the job in seconds",
+      buckets: [0.1, 1, 10, 100],
     }),
   };
 }

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -67,6 +67,7 @@ export function wrapWithQueue<K extends GossipType>(
       length: metrics.gossipValidationQueueLength.child({topic: type}),
       droppedJobs: metrics.gossipValidationQueueDroppedJobs.child({topic: type}),
       jobTime: metrics.gossipValidationQueueJobTime.child({topic: type}),
+      jobWaitTime: metrics.gossipValidationQueueJobWaitTime.child({topic: type}),
     }
   );
   return async function (_topicStr, gossipMsg) {


### PR DESCRIPTION
**Motivation**

Right now we track the job time of our queues. Under load queues get filled quickly, so it is important to know how long the jobs have to wait before starting. From the consumer's point of view the total time to resolve a call through a queue is `wait time + process time`

**Description**

Add a new metric jobWaitTime to the queues. Use fewer buckets since granular resolution here is not super important.