### PR TITLE
Don't log ErrorAborted in rest api errorHandler

### DIFF
--- a/packages/lodestar/src/api/rest/errorHandler.ts
+++ b/packages/lodestar/src/api/rest/errorHandler.ts
@@ -1,5 +1,6 @@
 import {FastifyError, FastifyReply, FastifyRequest} from "fastify";
 import {ServerResponse} from "http";
+import {ErrorAborted} from "@chainsafe/lodestar-utils";
 import {ApiError} from "../impl/errors";
 
 export function errorHandler(e: Error, req: FastifyRequest, resp: FastifyReply<ServerResponse>): void {
@@ -8,7 +9,13 @@ export function errorHandler(e: Error, req: FastifyRequest, resp: FastifyReply<S
     resp.status(400).send((e as FastifyError).validation);
     return;
   }
+
+  // Don't log ErrorAborted errors, they happen on node shutdown and are not usefull
+  if (!(e instanceof ErrorAborted)) {
+    const config = (resp.context.config || {}) as {url: string};
+    req.log.error(`Request ${req.id} ${config.url} failed with unexpected error: `, e.stack || e.message);
+  }
+
   const statusCode = e instanceof ApiError ? (e as ApiError).statusCode : 500;
-  req.log.error(`Request ${req.id} failed with unexpected error: `, e.message, e.stack);
   resp.status(statusCode).send(e);
 }


### PR DESCRIPTION
**Motivation**

When stopping the node you might trigger a bunch of `ErrorAborted`s if the validator has some pending requests

**Description**

Don't log them, and log the route's url since the request.id is not useful on its own.