### PR TITLE
Improve sim tests a bit

### DIFF
--- a/packages/lodestar/test/e2e/sync/sync.test.ts
+++ b/packages/lodestar/test/e2e/sync/sync.test.ts
@@ -58,7 +58,7 @@ describe("sync", function () {
     });
 
     const head = await bn.chain.getHeadBlock();
-    if (!head) throw Error("First beacon node has not head block");
+    if (!head) throw Error("First beacon node has no head block");
     const waitForSynced = waitForEvent<phase0.SignedBeaconBlock>(bn2.chain.emitter, ChainEvent.block, 100000, (block) =>
       config.types.phase0.SignedBeaconBlock.equals(block, head)
     );

--- a/packages/lodestar/test/sim/multiNodeMultiThread.test.ts
+++ b/packages/lodestar/test/sim/multiNodeMultiThread.test.ts
@@ -103,11 +103,11 @@ describe("Run multi node multi thread interop validators (no eth1) until checkpo
           )
         );
         console.log("Success: Terminating workers");
-        await Promise.all(workers.map((worker) => worker.terminate()));
       } catch (e) {
         console.log("Failure: Terminating workers. Error:", e);
-        await Promise.all(workers.map((worker) => worker.terminate()));
         throw e;
+      } finally {
+        await Promise.all(workers.map((worker) => worker.terminate()));
       }
     });
   }

--- a/packages/lodestar/test/sim/multiNodeSingleThread.test.ts
+++ b/packages/lodestar/test/sim/multiNodeSingleThread.test.ts
@@ -10,6 +10,8 @@ import {ChainEvent} from "../../src/chain";
 import {testLogger, LogLevel} from "../utils/logger";
 import {connect} from "../utils/network";
 import {logFiles} from "./params";
+import {simTestInfoTracker} from "../utils/node/simTest";
+import {ILogger, sleep} from "@chainsafe/lodestar-utils";
 
 /* eslint-disable no-console */
 
@@ -31,6 +33,7 @@ describe("Run multi node single thread interop validators (no eth1) until checkp
 
       const nodes: BeaconNode[] = [];
       const validators: Validator[] = [];
+      const loggers: ILogger[] = [];
       // delay a bit so regular sync sees it's up to date and sync is completed from the beginning
       const minGenesisTime = Math.floor(Date.now() / 1000);
       const genesisDelay = 2 * beaconParams.SECONDS_PER_SLOT;
@@ -55,20 +58,24 @@ describe("Run multi node single thread interop validators (no eth1) until checkp
           logFile: logFiles.multinodeSinglethread,
         });
 
-        validators.push(...nodeValidators);
+        loggers.push(logger);
         nodes.push(node);
+        validators.push(...nodeValidators);
       }
+
+      const stopInfoTracker = simTestInfoTracker(nodes[0], loggers[0]);
 
       onDoneHandlers.push(async () => {
         await Promise.all(validators.map((validator) => validator.stop()));
         console.log("--- Stopped all validators ---");
         // wait for 1 slot
-        await new Promise((r) => setTimeout(r, 1 * beaconParams.SECONDS_PER_SLOT * 1000));
+        await sleep(1 * beaconParams.SECONDS_PER_SLOT * 1000);
 
+        stopInfoTracker();
         await Promise.all(nodes.map((node) => node.close()));
         console.log("--- Stopped all nodes ---");
         // Wait a bit for nodes to shutdown
-        await new Promise((r) => setTimeout(r, 3000));
+        await sleep(3000);
       });
 
       // Connect all nodes with each other

--- a/packages/lodestar/test/sim/multiNodeSingleThread.test.ts
+++ b/packages/lodestar/test/sim/multiNodeSingleThread.test.ts
@@ -3,7 +3,7 @@ import {Network} from "../../src/network";
 import {getDevBeaconNode} from "../utils/node/beacon";
 import {waitForEvent} from "../utils/events/resolver";
 import {phase0} from "@chainsafe/lodestar-types";
-import {getDevValidator} from "../utils/node/validator";
+import {getDevValidators} from "../utils/node/validator";
 import {Validator} from "@chainsafe/lodestar-validator/lib";
 import {BeaconNode} from "../../src/node";
 import {ChainEvent} from "../../src/chain";
@@ -46,19 +46,16 @@ describe("Run multi node single thread interop validators (no eth1) until checkp
           logger,
         });
 
-        const startIndex = i * validatorsPerNode;
-        const endIndex = i * validatorsPerNode + validatorsPerNode - 1;
-        validators.push(
-          getDevValidator({
-            node,
-            startIndex,
-            count: validatorsPerNode,
-            logger: logger.child({
-              module: `Vali ${startIndex}-${endIndex}`,
-            }),
-          })
-        );
+        const nodeValidators = getDevValidators({
+          node,
+          validatorsPerClient: validatorsPerNode,
+          validatorClientCount: 1,
+          startIndex: i * validatorsPerNode,
+          logLevel: LogLevel.info,
+          logFile: logFiles.multinodeSinglethread,
+        });
 
+        validators.push(...nodeValidators);
         nodes.push(node);
       }
 

--- a/packages/lodestar/test/sim/threaded/noEth1SimWorker.ts
+++ b/packages/lodestar/test/sim/threaded/noEth1SimWorker.ts
@@ -6,7 +6,7 @@ import {init} from "@chainsafe/bls";
 import {phase0} from "@chainsafe/lodestar-types";
 
 import {getDevBeaconNode} from "../../utils/node/beacon";
-import {getDevValidator} from "../../utils/node/validator";
+import {getDevValidators} from "../../utils/node/validator";
 import {testLogger, LogLevel} from "../../utils/logger";
 import {connect} from "../../utils/network";
 import {Network} from "../../../src/network";
@@ -16,6 +16,8 @@ import {sleep, withTimeout} from "@chainsafe/lodestar-utils";
 import {fromHexString} from "@chainsafe/ssz";
 import {createFromPrivKey} from "peer-id";
 
+/* eslint-disable no-console */
+
 async function runWorker(): Promise<void> {
   const parent = parentPort;
   if (!parent) throw Error("Must be run in worker_thread");
@@ -23,14 +25,12 @@ async function runWorker(): Promise<void> {
   // blst Native bindings don't work right on worker threads. It errors with
   // (node:1692547) UnhandledPromiseRejectionWarning: Error: Module did not self-register: '/home/cayman/Code/bls/node_modules/@chainsafe/blst/prebuild/linux-x64-72-binding.node'.
   // Related issue: https://github.com/nodejs/node/issues/21783#issuecomment-429637117
-  await init("herumi");
+  await init("blst-native");
 
   const options = workerData.options as NodeWorkerOptions;
   const {nodeIndex, validatorsPerNode, startIndex, checkpointEvent, logFile, nodes} = options;
-  const endIndex = startIndex + validatorsPerNode - 1;
 
   const loggerNode = testLogger(`Node ${nodeIndex}`, LogLevel.info, logFile);
-  const loggerVali = testLogger(`Vali ${startIndex}-${endIndex}`, LogLevel.info, logFile);
   loggerNode.info("Thread started", {
     now: Math.floor(Date.now() / 1000),
     genesisTime: options.genesisTime,
@@ -46,17 +46,22 @@ async function runWorker(): Promise<void> {
     peerId: await createFromPrivKey(fromHexString(options.peerIdPrivkey)),
   });
 
-  const validator = getDevValidator({
+  const validators = getDevValidators({
     node,
+    validatorClientCount: 1,
+    validatorsPerClient: validatorsPerNode,
     startIndex,
-    count: validatorsPerNode,
-    logger: loggerVali,
+    logLevel: LogLevel.info,
+    logFile,
   });
 
-  await validator.start();
+  await Promise.all(validators.map((validator) => validator.start()));
 
   // wait a bit before attempting to connect to the nodes
-  await sleep(Math.max(0, (1000 * options.genesisTime - Date.now()) / 2));
+  const waitMsBeforeConnecting = Math.max(0, (1000 * options.genesisTime - Date.now()) / 2);
+  loggerNode.info(`Waiting ${waitMsBeforeConnecting} ms before connecting to nodes`);
+  await sleep(waitMsBeforeConnecting);
+
   await Promise.all(
     nodes.map(async (nodeToConnect, i) => {
       if (i === nodeIndex) return; // Don't dial self
@@ -69,7 +74,7 @@ async function runWorker(): Promise<void> {
   );
 
   node.chain.emitter.on(checkpointEvent, async (checkpoint) => {
-    await validator.stop();
+    await Promise.all(validators.map((validator) => validator.stop()));
     await node.close();
     parent.postMessage({
       event: checkpointEvent,

--- a/packages/lodestar/test/utils/node/simTest.ts
+++ b/packages/lodestar/test/utils/node/simTest.ts
@@ -1,0 +1,28 @@
+import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {prepareEpochProcessState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast";
+import {IBlockSummary} from "@chainsafe/lodestar-fork-choice";
+import {ILogger} from "@chainsafe/lodestar-utils";
+import {BeaconNode} from "../../../src";
+import {ChainEvent} from "../../../src/chain";
+
+export function simTestInfoTracker(bn: BeaconNode, logger: ILogger): () => void {
+  function onHead(head: IBlockSummary): void {
+    // Compute participation (takes 5ms with 64 validators)
+    const state = bn.chain.getHeadState();
+    const process = prepareEpochProcessState(state);
+
+    const prevParticipation = Number(process.prevEpochUnslashedStake.targetStake) / Number(process.totalActiveStake);
+    const currParticipation = Number(process.currEpochUnslashedTargetStake) / Number(process.totalActiveStake);
+    logger.info("> Participation", {
+      slot: `${head.slot}/${computeEpochAtSlot(bn.config, head.slot)}`,
+      prev: prevParticipation,
+      curr: currParticipation,
+    });
+  }
+
+  bn.chain.emitter.on(ChainEvent.forkChoiceHead, onHead);
+
+  return function () {
+    bn.chain.emitter.off(ChainEvent.forkChoiceHead, onHead);
+  };
+}


### PR DESCRIPTION
- Use blst-native in multi-thread tests
- Use `getDevValidators()` everywhere to get the same validator format, which logs the index range it handles
- Log participation every slot to ease debugging
- Reduce clean-up duplication with finally {} blocks
- Improve logging and shutdown with more sleeps
