### PR TITLE
Remove getAttesterDuties limit in REST API

### DIFF
--- a/packages/lodestar/src/api/rest/validator/duties/getAttesterDuties.ts
+++ b/packages/lodestar/src/api/rest/validator/duties/getAttesterDuties.ts
@@ -27,7 +27,6 @@ export const getAttesterDuties: ApiController<null, {epoch: number}, ValidatorIn
     body: {
       type: "array",
       minItems: 1,
-      maxItems: 100,
       items: {
         type: "number",
         minimum: 0,


### PR DESCRIPTION
**Motivation**

This limit seems arbitrary and we hope to support more than 100 eventually.

**Description**

IMO no limit is better than a random limit. It might be useful against DOS but it should either be customizable with a flag or find some alternative