### PR TITLE
Add dependentRoot to duties API

### DIFF
--- a/packages/beacon-state-transition/src/util/index.ts
+++ b/packages/beacon-state-transition/src/util/index.ts
@@ -18,6 +18,7 @@ export * from "./interop";
 export * from "./proposer";
 export * from "./seed";
 export * from "./shuffle";
+export * from "./shufflingDecisionRoot";
 export * from "./signatureSets";
 export * from "./signingRoot";
 export * from "./slot";

--- a/packages/beacon-state-transition/src/util/shufflingDecisionRoot.ts
+++ b/packages/beacon-state-transition/src/util/shufflingDecisionRoot.ts
@@ -8,10 +8,8 @@ import {computeEpochAtSlot, computeStartSlotAtEpoch, getCurrentEpoch, getPreviou
  * Returns the block root which decided the proposer shuffling for the current epoch. This root
  * can be used to key this proposer shuffling.
  *
- * ## Notes
- *
  * Returns `null` on the one-off scenario where the genesis block decides its own shuffling.
- * It should be set to the latest block applied to `self` or the genesis block root.
+ * It should be set to the latest block applied to this `state` or the genesis block root.
  */
 export function proposerShufflingDecisionRoot(config: IBeaconConfig, state: BeaconState): Root | null {
   const decisionSlot = proposerShufflingDecisionSlot(config, state);
@@ -33,13 +31,11 @@ function proposerShufflingDecisionSlot(config: IBeaconConfig, state: BeaconState
 }
 
 /**
- * Returns the block root which decided the attester shuffling for the given `relativeEpoch`.
+ * Returns the block root which decided the attester shuffling for the given `requestedEpoch`.
  * This root can be used to key that attester shuffling.
  *
- * ## Notes
- *
  * Returns `null` on the one-off scenario where the genesis block decides its own shuffling.
- * It should be set to the latest block applied to `self` or the genesis block root.
+ * It should be set to the latest block applied to this `state` or the genesis block root.
  */
 export function attesterShufflingDecisionRoot(
   config: IBeaconConfig,
@@ -65,13 +61,11 @@ function attesterShufflingDecisionSlot(config: IBeaconConfig, state: BeaconState
 }
 
 /**
- * Converts the `other` epoch into a `RelativeEpoch`, with respect to `base`
+ * Returns the epoch at which the proposer shuffling was decided.
  *
- * ## Errors
- * Returns an error when:
- * - `EpochTooLow` when `other` is more than 1 prior to `base`.
- * - `EpochTooHigh` when `other` is more than 1 after `base`.
- *
+ * Throws an error when:
+ * - `EpochTooLow` when `requestedEpoch` is more than 1 prior to `currentEpoch`.
+ * - `EpochTooHigh` when `requestedEpoch` is more than 1 after `currentEpoch`.
  */
 function attesterShufflingDecisionEpoch(config: IBeaconConfig, state: BeaconState, requestedEpoch: Epoch): Epoch {
   const currentEpoch = getCurrentEpoch(config, state);

--- a/packages/beacon-state-transition/src/util/shufflingDecisionRoot.ts
+++ b/packages/beacon-state-transition/src/util/shufflingDecisionRoot.ts
@@ -61,7 +61,9 @@ function attesterShufflingDecisionSlot(config: IBeaconConfig, state: BeaconState
 }
 
 /**
- * Returns the epoch at which the proposer shuffling was decided.
+ * Returns the epoch at which the attester shuffling was decided.
+ *
+ * Spec ref: https://github.com/ethereum/eth2.0-APIs/blob/46d2b82127cb1ffce51bbc748a7df2677fc0215a/apis/validator/duties/attester.yaml#L15
  *
  * Throws an error when:
  * - `EpochTooLow` when `requestedEpoch` is more than 1 prior to `currentEpoch`.

--- a/packages/beacon-state-transition/src/util/shufflingDecisionRoot.ts
+++ b/packages/beacon-state-transition/src/util/shufflingDecisionRoot.ts
@@ -1,0 +1,91 @@
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {BeaconState} from "@chainsafe/lodestar-types/lib/allForks";
+import {Epoch, Root, Slot} from "../phase0";
+import {getBlockRootAtSlot} from "./blockRoot";
+import {computeEpochAtSlot, computeStartSlotAtEpoch, getCurrentEpoch, getPreviousEpoch} from "./epoch";
+
+/**
+ * Returns the block root which decided the proposer shuffling for the current epoch. This root
+ * can be used to key this proposer shuffling.
+ *
+ * ## Notes
+ *
+ * Returns `null` on the one-off scenario where the genesis block decides its own shuffling.
+ * It should be set to the latest block applied to `self` or the genesis block root.
+ */
+export function proposerShufflingDecisionRoot(config: IBeaconConfig, state: BeaconState): Root | null {
+  const decisionSlot = proposerShufflingDecisionSlot(config, state);
+  if (state.slot == decisionSlot) {
+    return null;
+  } else {
+    return getBlockRootAtSlot(config, state, decisionSlot);
+  }
+}
+
+/**
+ * Returns the slot at which the proposer shuffling was decided. The block root at this slot
+ * can be used to key the proposer shuffling for the current epoch.
+ */
+function proposerShufflingDecisionSlot(config: IBeaconConfig, state: BeaconState): Slot {
+  const epoch = computeEpochAtSlot(config, state.slot);
+  const startSlot = computeStartSlotAtEpoch(config, epoch);
+  return Math.max(startSlot - 1, 0);
+}
+
+/**
+ * Returns the block root which decided the attester shuffling for the given `relativeEpoch`.
+ * This root can be used to key that attester shuffling.
+ *
+ * ## Notes
+ *
+ * Returns `null` on the one-off scenario where the genesis block decides its own shuffling.
+ * It should be set to the latest block applied to `self` or the genesis block root.
+ */
+export function attesterShufflingDecisionRoot(
+  config: IBeaconConfig,
+  state: BeaconState,
+  requestedEpoch: Epoch
+): Root | null {
+  const decisionSlot = attesterShufflingDecisionSlot(config, state, requestedEpoch);
+  if (state.slot == decisionSlot) {
+    return null;
+  } else {
+    return getBlockRootAtSlot(config, state, decisionSlot);
+  }
+}
+
+/**
+ * Returns the slot at which the proposer shuffling was decided. The block root at this slot
+ * can be used to key the proposer shuffling for the current epoch.
+ */
+function attesterShufflingDecisionSlot(config: IBeaconConfig, state: BeaconState, requestedEpoch: Epoch): Slot {
+  const epoch = attesterShufflingDecisionEpoch(config, state, requestedEpoch);
+  const slot = computeStartSlotAtEpoch(config, epoch);
+  return Math.max(slot - 1, 0);
+}
+
+/**
+ * Converts the `other` epoch into a `RelativeEpoch`, with respect to `base`
+ *
+ * ## Errors
+ * Returns an error when:
+ * - `EpochTooLow` when `other` is more than 1 prior to `base`.
+ * - `EpochTooHigh` when `other` is more than 1 after `base`.
+ *
+ */
+function attesterShufflingDecisionEpoch(config: IBeaconConfig, state: BeaconState, requestedEpoch: Epoch): Epoch {
+  const currentEpoch = getCurrentEpoch(config, state);
+
+  // Next
+  if (requestedEpoch === currentEpoch + 1) return getCurrentEpoch(config, state);
+  // Current
+  if (requestedEpoch === currentEpoch) return getPreviousEpoch(config, state);
+  // Previous
+  if (requestedEpoch === currentEpoch - 1) return Math.max(getPreviousEpoch(config, state) - 1, 0);
+
+  if (requestedEpoch < currentEpoch) {
+    throw Error(`EpochTooLow: current ${currentEpoch} requested ${requestedEpoch}`);
+  } else {
+    throw Error(`EpochTooHigh: current ${currentEpoch} requested ${requestedEpoch}`);
+  }
+}

--- a/packages/lodestar/src/api/impl/validator/interface.ts
+++ b/packages/lodestar/src/api/impl/validator/interface.ts
@@ -7,8 +7,8 @@ import {BLSSignature, CommitteeIndex, Epoch, Root, phase0, Slot, ValidatorIndex}
  * The API interface defines the calls that can be made from a Validator
  */
 export interface IValidatorApi {
-  getProposerDuties(epoch: Epoch): Promise<phase0.ProposerDuty[]>;
-  getAttesterDuties(epoch: Epoch, validatorIndices: ValidatorIndex[]): Promise<phase0.AttesterDuty[]>;
+  getProposerDuties(epoch: Epoch): Promise<phase0.ProposerDutiesApi>;
+  getAttesterDuties(epoch: Epoch, validatorIndices: ValidatorIndex[]): Promise<phase0.AttesterDutiesApi>;
   /**
    * Requests a BeaconNode to produce a valid block,
    * which can then be signed by a ValidatorClient.

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -93,7 +93,7 @@ export class ValidatorApi implements IValidatorApi {
     }
   }
 
-  async getProposerDuties(epoch: Epoch): Promise<{data: phase0.ProposerDuty[]; dependentRoot: Root}> {
+  async getProposerDuties(epoch: Epoch): Promise<phase0.ProposerDutiesApi> {
     await checkSyncStatus(this.config, this.sync);
 
     const state = await this.chain.getHeadStateAtCurrentEpoch();
@@ -116,10 +116,7 @@ export class ValidatorApi implements IValidatorApi {
     };
   }
 
-  async getAttesterDuties(
-    epoch: number,
-    validatorIndices: ValidatorIndex[]
-  ): Promise<{data: phase0.AttesterDuty[]; dependentRoot: Root}> {
+  async getAttesterDuties(epoch: number, validatorIndices: ValidatorIndex[]): Promise<phase0.AttesterDutiesApi> {
     await checkSyncStatus(this.config, this.sync);
     if (validatorIndices.length === 0) throw new ApiError(400, "No validator to get attester duties");
     if (epoch > this.chain.clock.currentEpoch + 1)

--- a/packages/lodestar/src/api/rest/validator/duties/getAttesterDuties.ts
+++ b/packages/lodestar/src/api/rest/validator/duties/getAttesterDuties.ts
@@ -7,10 +7,8 @@ export const getAttesterDuties: ApiController<null, {epoch: number}, ValidatorIn
   id: "getAttesterDuties",
 
   handler: async function (req) {
-    const responseValue = await this.api.validator.getAttesterDuties(req.params.epoch, req.body);
-    return {
-      data: responseValue.map((value) => this.config.types.phase0.AttesterDuty.toJson(value, {case: "snake"})),
-    };
+    const value = await this.api.validator.getAttesterDuties(req.params.epoch, req.body);
+    return this.config.types.phase0.AttesterDutiesApi.toJson(value, {case: "snake"});
   },
 
   schema: {

--- a/packages/lodestar/src/api/rest/validator/duties/getProposerDuties.ts
+++ b/packages/lodestar/src/api/rest/validator/duties/getProposerDuties.ts
@@ -6,10 +6,8 @@ export const getProposerDuties: ApiController<null, {epoch: number}> = {
   id: "getProposerDuties",
 
   handler: async function (req) {
-    const duties = await this.api.validator.getProposerDuties(req.params.epoch);
-    return {
-      data: duties.map((d) => this.config.types.phase0.ProposerDuty.toJson(d, {case: "snake"})),
-    };
+    const value = await this.api.validator.getProposerDuties(req.params.epoch);
+    return this.config.types.phase0.ProposerDutiesApi.toJson(value, {case: "snake"});
   },
 
   schema: {

--- a/packages/lodestar/test/unit/api/impl/validator/duties/proposer.test.ts
+++ b/packages/lodestar/test/unit/api/impl/validator/duties/proposer.test.ts
@@ -29,6 +29,7 @@ describe("get proposers api impl", function () {
     syncStub = server.syncStub;
     chainStub.clock = server.sandbox.createStubInstance(LocalClock);
     chainStub.forkChoice = server.sandbox.createStubInstance(ForkChoice);
+    chainStub.getCanonicalBlockAtSlot.resolves(config.types.phase0.SignedBeaconBlock.defaultValue());
     dbStub = server.dbStub;
     // @ts-ignore
     api = new ValidatorApi({}, {db: dbStub, chain: chainStub, sync: syncStub, config});
@@ -80,6 +81,6 @@ describe("get proposers api impl", function () {
     chainStub.getHeadStateAtCurrentEpoch.resolves(cachedState);
     sinon.stub(cachedState.epochCtx, "getBeaconProposer").returns(1);
     const result = await api.getProposerDuties(0);
-    expect(result.length).to.be.equal(config.params.SLOTS_PER_EPOCH);
+    expect(result.data.length).to.be.equal(config.params.SLOTS_PER_EPOCH);
   });
 });

--- a/packages/lodestar/test/unit/api/rest/validator/getAttesterDuties.test.ts
+++ b/packages/lodestar/test/unit/api/rest/validator/getAttesterDuties.test.ts
@@ -6,6 +6,7 @@ import {ApiResponseBody, urlJoin} from "../utils";
 import {setupRestApiTestServer, VALIDATOR_PREFIX} from "../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {RestApi, ValidatorApi} from "../../../../../src/api";
+import {ZERO_HASH} from "../../../../../src/constants";
 
 describe("rest - validator - getAttesterDuties", function () {
   let restApi: RestApi;
@@ -17,10 +18,10 @@ describe("rest - validator - getAttesterDuties", function () {
   });
 
   it("should succeed", async function () {
-    validatorStub.getAttesterDuties.resolves([
-      config.types.phase0.AttesterDuty.defaultValue(),
-      config.types.phase0.AttesterDuty.defaultValue(),
-    ]);
+    validatorStub.getAttesterDuties.resolves({
+      dependentRoot: ZERO_HASH,
+      data: [config.types.phase0.AttesterDuty.defaultValue(), config.types.phase0.AttesterDuty.defaultValue()],
+    });
     const response = await supertest(restApi.server.server)
       .post(urlJoin(VALIDATOR_PREFIX, getAttesterDuties.url.replace(":epoch", "0")))
       .send(["1", "4"])
@@ -32,10 +33,10 @@ describe("rest - validator - getAttesterDuties", function () {
   });
 
   it("invalid epoch", async function () {
-    validatorStub.getAttesterDuties.resolves([
-      config.types.phase0.AttesterDuty.defaultValue(),
-      config.types.phase0.AttesterDuty.defaultValue(),
-    ]);
+    validatorStub.getAttesterDuties.resolves({
+      dependentRoot: ZERO_HASH,
+      data: [config.types.phase0.AttesterDuty.defaultValue(), config.types.phase0.AttesterDuty.defaultValue()],
+    });
     await supertest(restApi.server.server)
       .post(urlJoin(VALIDATOR_PREFIX, getAttesterDuties.url.replace(":epoch", "a")))
       .send(["1", "4"])
@@ -44,10 +45,10 @@ describe("rest - validator - getAttesterDuties", function () {
   });
 
   it("no validator indices", async function () {
-    validatorStub.getAttesterDuties.resolves([
-      config.types.phase0.AttesterDuty.defaultValue(),
-      config.types.phase0.AttesterDuty.defaultValue(),
-    ]);
+    validatorStub.getAttesterDuties.resolves({
+      dependentRoot: ZERO_HASH,
+      data: [config.types.phase0.AttesterDuty.defaultValue(), config.types.phase0.AttesterDuty.defaultValue()],
+    });
     await supertest(restApi.server.server)
       .post(urlJoin(VALIDATOR_PREFIX, getAttesterDuties.url.replace(":epoch", "1")))
       .send([])
@@ -56,10 +57,10 @@ describe("rest - validator - getAttesterDuties", function () {
   });
 
   it("invalid validator index", async function () {
-    validatorStub.getAttesterDuties.resolves([
-      config.types.phase0.AttesterDuty.defaultValue(),
-      config.types.phase0.AttesterDuty.defaultValue(),
-    ]);
+    validatorStub.getAttesterDuties.resolves({
+      dependentRoot: ZERO_HASH,
+      data: [config.types.phase0.AttesterDuty.defaultValue(), config.types.phase0.AttesterDuty.defaultValue()],
+    });
     await supertest(restApi.server.server)
       .post(urlJoin(VALIDATOR_PREFIX, getAttesterDuties.url.replace(":epoch", "1")))
       .send([1, "a"])

--- a/packages/lodestar/test/unit/api/rest/validator/getProposerDuties.test.ts
+++ b/packages/lodestar/test/unit/api/rest/validator/getProposerDuties.test.ts
@@ -7,6 +7,7 @@ import {setupRestApiTestServer, VALIDATOR_PREFIX} from "../index.test";
 import {RestApi, ValidatorApi} from "../../../../../src/api";
 import {SinonStubbedInstance} from "sinon";
 import {ProposerDuty} from "@chainsafe/lodestar-types/phase0";
+import {ZERO_HASH} from "../../../../../src/constants";
 
 describe("rest - validator - getProposerDuties", function () {
   let restApi: RestApi;
@@ -18,10 +19,10 @@ describe("rest - validator - getProposerDuties", function () {
   });
 
   it("should succeed", async function () {
-    validatorStub.getProposerDuties.resolves([
-      config.types.phase0.ProposerDuty.defaultValue(),
-      config.types.phase0.ProposerDuty.defaultValue(),
-    ]);
+    validatorStub.getProposerDuties.resolves({
+      dependentRoot: ZERO_HASH,
+      data: [config.types.phase0.ProposerDuty.defaultValue(), config.types.phase0.ProposerDuty.defaultValue()],
+    });
     const response = await supertest(restApi.server.server)
       .get(urlJoin(VALIDATOR_PREFIX, getProposerDuties.url.replace(":epoch", "1")))
       .expect(200)

--- a/packages/types/src/phase0/ssz/generators/api.ts
+++ b/packages/types/src/phase0/ssz/generators/api.ts
@@ -1,7 +1,8 @@
-import {ContainerType} from "@chainsafe/ssz";
+import {ContainerType, ListType} from "@chainsafe/ssz";
 import {IPhase0SSZTypes} from "../interface";
 import {StringType} from "../utils";
 import {ValidatorStatus} from "../../types";
+import {IPhase0Params} from "@chainsafe/lodestar-params";
 
 export const SignedBeaconHeaderResponse = (ssz: IPhase0SSZTypes): ContainerType =>
   new ContainerType({
@@ -41,6 +42,28 @@ export const ProposerDuty = (ssz: IPhase0SSZTypes): ContainerType =>
       slot: ssz.Slot,
       validatorIndex: ssz.ValidatorIndex,
       pubkey: ssz.BLSPubkey,
+    },
+  });
+
+export const AttesterDutiesApi = (ssz: IPhase0SSZTypes, params: IPhase0Params): ContainerType =>
+  new ContainerType({
+    fields: {
+      data: new ListType({
+        elementType: ssz.AttesterDuty,
+        limit: params.VALIDATOR_REGISTRY_LIMIT,
+      }),
+      dependentRoot: ssz.Root,
+    },
+  });
+
+export const ProposerDutiesApi = (ssz: IPhase0SSZTypes, params: IPhase0Params): ContainerType =>
+  new ContainerType({
+    fields: {
+      data: new ListType({
+        elementType: ssz.ProposerDuty,
+        limit: params.VALIDATOR_REGISTRY_LIMIT,
+      }),
+      dependentRoot: ssz.Root,
     },
   });
 

--- a/packages/types/src/phase0/ssz/interface.ts
+++ b/packages/types/src/phase0/ssz/interface.ts
@@ -59,6 +59,8 @@ export type IPhase0SSZTypes = IPrimitiveSSZTypes & {
   SyncingStatus: ContainerType<phase0.SyncingStatus>;
   AttesterDuty: ContainerType<phase0.AttesterDuty>;
   ProposerDuty: ContainerType<phase0.ProposerDuty>;
+  AttesterDutiesApi: ContainerType<phase0.AttesterDutiesApi>;
+  ProposerDutiesApi: ContainerType<phase0.ProposerDutiesApi>;
   BeaconCommitteeSubscription: ContainerType<phase0.BeaconCommitteeSubscription>;
   // Validator slashing protection
   SlashingProtectionBlock: ContainerType<phase0.SlashingProtectionBlock>;
@@ -149,6 +151,8 @@ export const phase0TypeNames: (keyof IPhase0SSZTypes)[] = [
   "SyncingStatus",
   "AttesterDuty",
   "ProposerDuty",
+  "AttesterDutiesApi",
+  "ProposerDutiesApi",
   "BeaconCommitteeSubscription",
   "Genesis",
   "ChainHead",

--- a/packages/types/src/phase0/types/api.ts
+++ b/packages/types/src/phase0/types/api.ts
@@ -50,6 +50,16 @@ export interface ProposerDuty {
   pubkey: BLSPubkey;
 }
 
+export interface AttesterDutiesApi {
+  data: AttesterDuty[];
+  dependentRoot: Root;
+}
+
+export interface ProposerDutiesApi {
+  data: ProposerDuty[];
+  dependentRoot: Root;
+}
+
 export interface BeaconCommitteeSubscription {
   validatorIndex: number;
   committeeIndex: number;

--- a/packages/validator/src/api/interface.ts
+++ b/packages/validator/src/api/interface.ts
@@ -87,8 +87,8 @@ export interface IApiClient {
   };
 
   validator: {
-    getProposerDuties(epoch: Epoch): Promise<phase0.ProposerDuty[]>;
-    getAttesterDuties(epoch: Epoch, validatorIndices: ValidatorIndex[]): Promise<phase0.AttesterDuty[]>;
+    getProposerDuties(epoch: Epoch): Promise<phase0.ProposerDutiesApi>;
+    getAttesterDuties(epoch: Epoch, validatorIndices: ValidatorIndex[]): Promise<phase0.AttesterDutiesApi>;
     produceBlock(slot: Slot, randaoReveal: BLSSignature, graffiti: string): Promise<phase0.BeaconBlock>;
     produceAttestationData(index: CommitteeIndex, slot: Slot): Promise<phase0.AttestationData>;
     getAggregatedAttestation(attestationDataRoot: Root, slot: Slot): Promise<phase0.Attestation>;

--- a/packages/validator/src/api/rest/validator.ts
+++ b/packages/validator/src/api/rest/validator.ts
@@ -9,19 +9,19 @@ export function ValidatorApi(types: IBeaconSSZTypes, client: HttpClient): IApiCl
   const prefix = "/eth/v1/validator";
 
   return {
-    async getProposerDuties(epoch: Epoch): Promise<phase0.ProposerDuty[]> {
+    async getProposerDuties(epoch: Epoch): Promise<phase0.ProposerDutiesApi> {
       const res = await client.get<{data: Json[]; dependentRoot: string}>(
         prefix + `/duties/proposer/${epoch.toString()}`
       );
-      return res.data.map((value) => types.phase0.ProposerDuty.fromJson(value, {case: "snake"}));
+      return types.phase0.ProposerDutiesApi.fromJson(res, {case: "snake"});
     },
 
-    async getAttesterDuties(epoch: Epoch, indices: ValidatorIndex[]): Promise<phase0.AttesterDuty[]> {
+    async getAttesterDuties(epoch: Epoch, indices: ValidatorIndex[]): Promise<phase0.AttesterDutiesApi> {
       const res = await client.post<string[], {data: Json[]; dependentRoot: string}>(
         prefix + `/duties/attester/${epoch.toString()}`,
         indices.map((index) => types.ValidatorIndex.toJson(index) as string)
       );
-      return res.data.map((value) => types.phase0.AttesterDuty.fromJson(value, {case: "snake"}));
+      return types.phase0.AttesterDutiesApi.fromJson(res, {case: "snake"});
     },
 
     async produceBlock(slot: Slot, randaoReveal: Uint8Array, graffiti: string): Promise<phase0.BeaconBlock> {

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -111,7 +111,8 @@ export class AttestationService {
       for (const v of this.validators.values()) {
         if (v.validator?.index != null) indices.push(v.validator?.index);
       }
-      attesterDuties = await this.provider.validator.getAttesterDuties(epoch, indices);
+      const res = await this.provider.validator.getAttesterDuties(epoch, indices);
+      attesterDuties = res.data;
     } catch (e) {
       this.logger.error("Failed to obtain attester duty", {epoch, error: (e as Error).message});
       return;

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -108,10 +108,11 @@ export default class BlockProposingService {
    */
   updateDuties = async (epoch: Epoch): Promise<void> => {
     this.logger.debug("on new block epoch", {epoch, validator: toHexString(this.validators.keys().next().value)});
-    const proposerDuties = await this.provider.validator.getProposerDuties(epoch).catch((e) => {
+    const res = await this.provider.validator.getProposerDuties(epoch).catch((e) => {
       this.logger.error("Failed to obtain proposer duties", e);
       return null;
     });
+    const proposerDuties = res?.data;
     if (!proposerDuties) {
       return;
     }

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -20,6 +20,7 @@ import {SinonStubbedApi} from "../../utils/apiStub";
 import {generateFork} from "../../utils/fork";
 import {testLogger} from "../../utils/logger";
 
+const ZERO_HASH = Buffer.alloc(32, 0);
 const clock = sinon.useFakeTimers({now: Date.now(), shouldAdvanceTime: true, toFake: ["setTimeout"]});
 
 describe("validator attestation service", function () {
@@ -59,7 +60,7 @@ describe("validator attestation service", function () {
       slashingProtectionStub,
       logger
     );
-    rpcClientStub.validator.getAttesterDuties.resolves([]);
+    rpcClientStub.validator.getAttesterDuties.resolves({dependentRoot: ZERO_HASH, data: []});
     const defaultValidator = config.types.phase0.ValidatorResponse.defaultValue();
     rpcClientStub.beacon.state.getStateValidators.resolves([
       {...defaultValidator, validator: {...defaultValidator.validator, pubkey: secretKeys[0].toPublicKey().toBytes()}},
@@ -86,7 +87,7 @@ describe("validator attestation service", function () {
       validatorIndex: 0,
       pubkey: secretKeys[0].toPublicKey().toBytes(),
     };
-    rpcClientStub.validator.getAttesterDuties.resolves([duty]);
+    rpcClientStub.validator.getAttesterDuties.resolves({dependentRoot: ZERO_HASH, data: [duty]});
     const defaultValidator = config.types.phase0.ValidatorResponse.defaultValue();
     rpcClientStub.beacon.state.getStateValidators.resolves([
       {...defaultValidator, validator: {...defaultValidator.validator, pubkey: secretKeys[0].toPublicKey().toBytes()}},
@@ -105,7 +106,7 @@ describe("validator attestation service", function () {
       slashingProtectionStub,
       logger
     );
-    rpcClientStub.validator.getAttesterDuties.resolves([]);
+    rpcClientStub.validator.getAttesterDuties.resolves({dependentRoot: ZERO_HASH, data: []});
     await service.onClockSlot({slot: 0});
   });
 
@@ -118,7 +119,7 @@ describe("validator attestation service", function () {
       slashingProtectionStub,
       logger
     );
-    rpcClientStub.validator.getAttesterDuties.resolves([]);
+    rpcClientStub.validator.getAttesterDuties.resolves({dependentRoot: ZERO_HASH, data: []});
     sandbox.stub(rpcClientStub.clock, "currentEpoch").get(() => 1);
     await service.start();
     const pubkey = secretKeys[0].toPublicKey().toBytes();
@@ -153,7 +154,7 @@ describe("validator attestation service", function () {
       slashingProtectionStub,
       logger
     );
-    rpcClientStub.validator.getAttesterDuties.resolves([]);
+    rpcClientStub.validator.getAttesterDuties.resolves({dependentRoot: ZERO_HASH, data: []});
     sandbox.stub(rpcClientStub.clock, "currentEpoch").get(() => 1);
     await service.start();
     const pubkey = secretKeys[0].toPublicKey().toBytes();
@@ -193,7 +194,7 @@ describe("validator attestation service", function () {
       slashingProtectionStub,
       logger
     );
-    rpcClientStub.validator.getAttesterDuties.resolves([]);
+    rpcClientStub.validator.getAttesterDuties.resolves({dependentRoot: ZERO_HASH, data: []});
     sandbox.stub(rpcClientStub.clock, "currentEpoch").get(() => 1);
     await service.start();
     const pubkey = secretKeys[0].toPublicKey().toBytes();


### PR DESCRIPTION
**Motivation**

Update duties API endpoints to return dependentRoot as detailed here https://github.com/ethereum/eth2.0-APIs/blob/46d2b82127cb1ffce51bbc748a7df2677fc0215a/apis/validator/duties/attester.yaml#L50

It allows to know when a re-org has changed the duties.

**Description**

This PR extends the existing API endpoints to return dependentRoot but the validator client does nothing with them yet. This will be tackled in a future PR.

Closes https://github.com/ChainSafe/lodestar/issues/2378