### PR TITLE
Bump libp2p-noise

### DIFF
--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -81,7 +81,7 @@
     "libp2p-interfaces": "^0.8.3",
     "libp2p-mdns": "^0.15.0",
     "libp2p-mplex": "^0.10.1",
-    "libp2p-noise": "^2.0.1",
+    "libp2p-noise": "^2.0.5",
     "libp2p-tcp": "^0.15.3",
     "multiaddr": "^8.1.2",
     "peer-id": "^0.14.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3821,14 +3821,6 @@ bcrypto@^5.0.4:
     bufio "~1.0.7"
     loady "~0.0.1"
 
-bcrypto@^5.2.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/bcrypto/-/bcrypto-5.3.0.tgz#d2d7d8a808b5efeb09fe529034a30bd772902d84"
-  integrity sha512-SP48cpoc4BkEPNOErdsZ1VjbtdXY/C0f5wAywWniLne/Fd/5oOBqLbC6ZavngLvk4oik76g4I7PO5KduJoqECQ==
-  dependencies:
-    bufio "~1.0.7"
-    loady "~0.0.5"
-
 bcrypto@^5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/bcrypto/-/bcrypto-5.4.0.tgz#4046f0c44a4b301eff84de593b4f86fce8d91db2"
@@ -3913,6 +3905,15 @@ bl@^4.0.0, bl@^4.0.2:
   integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
   dependencies:
     buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+
+bl@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-5.0.0.tgz#6928804a41e9da9034868e1c50ca88f21f57aea2"
+  integrity sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==
+  dependencies:
+    buffer "^6.0.3"
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
@@ -4135,7 +4136,7 @@ buffer@^5.2.1, buffer@^5.4.3, buffer@^5.5.0, buffer@^5.6.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
-buffer@^6.0.1:
+buffer@^6.0.1, buffer@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
@@ -7298,10 +7299,15 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@^2.0.3, is-buffer@^2.0.4, is-buffer@~2.0.3:
+is-buffer@^2.0.3, is-buffer@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
+
+is-buffer@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-callable@^1.1.4, is-callable@^1.1.5:
   version "1.1.5"
@@ -7777,6 +7783,15 @@ it-handshake@^1.0.2:
     it-reader "^2.0.0"
     p-defer "^3.0.0"
 
+it-handshake@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/it-handshake/-/it-handshake-2.0.0.tgz#97671f33c13c47218a3df8a8d92de565a075b28c"
+  integrity sha512-K4q+mz8aLlCK3vTjtgNdHC9c/JbuOATsfogarjMsLcBZC5vYfKbX3Gq3AWcCdjIsIrPqzTlhPKSxl64LJkrt2w==
+  dependencies:
+    it-pushable "^1.4.0"
+    it-reader "^3.0.0"
+    p-defer "^3.0.0"
+
 it-length-prefixed@^3.0.0, it-length-prefixed@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/it-length-prefixed/-/it-length-prefixed-3.0.1.tgz#8c4d829576f941eb17b94bc83ed0c3c78bf0a05a"
@@ -7795,6 +7810,15 @@ it-length-prefixed@^3.1.0:
     bl "^4.0.2"
     buffer "^5.5.0"
     varint "^5.0.0"
+
+it-length-prefixed@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/it-length-prefixed/-/it-length-prefixed-5.0.2.tgz#66e8b889d695a57d582963cf053aa7255c31c9d5"
+  integrity sha512-SqAURaKKsjYbROIdTjW3UtqGrdZo1SHnkbeYYp7JwC5P0IIy7r4C0xNkmK2Va/fBmvXA++hMdDON9+2zesQlUA==
+  dependencies:
+    bl "^5.0.0"
+    buffer "^6.0.3"
+    varint "^6.0.0"
 
 it-map@^1.0.4:
   version "1.0.4"
@@ -7815,14 +7839,14 @@ it-pair@^1.0.0:
   dependencies:
     get-iterator "^1.0.2"
 
-it-pb-rpc@^0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/it-pb-rpc/-/it-pb-rpc-0.1.8.tgz#eed8ffdcba2a322a20a45c9db9ec5644499ccaf2"
-  integrity sha512-YePzUUonithCTIdVKcOeQEn5mpipCg7ZoWsq7jfjXXtAS6gm6R7KzCe6YBV97i6bljU8hGllTG67FiGfweKNKg==
+it-pb-rpc@^0.1.9:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/it-pb-rpc/-/it-pb-rpc-0.1.11.tgz#22c3d3e4d635ffdd24453a225ff16cc1bde463c5"
+  integrity sha512-1Yvae7LNHNM/WzxWT7OyHqwpA7DZoGos22JioMZ5H6i9iExQf71NHE0phHKEfkJdWLo7SRqPLLbqs2zaeKCwPA==
   dependencies:
-    is-buffer "^2.0.4"
-    it-handshake "^1.0.1"
-    it-length-prefixed "^3.0.1"
+    is-buffer "^2.0.5"
+    it-handshake "^2.0.0"
+    it-length-prefixed "^5.0.2"
 
 it-pipe@^1.0.1, it-pipe@^1.1.0:
   version "1.1.0"
@@ -7850,6 +7874,13 @@ it-reader@^2.0.0:
   integrity sha512-hSysqWTO9Tlwc5EGjVf8JYZzw0D2FsxD/g+eNNWrez9zODxWt6QlN6JAMmycK72Mv4jHEKEXoyzUN4FYGmJaZw==
   dependencies:
     bl "^4.0.0"
+
+it-reader@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/it-reader/-/it-reader-3.0.0.tgz#56596c7742ec7c63b7f7998f6bfa3f712e333d0e"
+  integrity sha512-NxR40odATeaBmSefn6Xn43DplYvn2KtEKQzn4jrTRuPYXMky5M4e+KQ7aTJh0k0vkytLyeenGO1I1GXlGm4laQ==
+  dependencies:
+    bl "^5.0.0"
 
 it-take@1.0.0:
   version "1.0.0"
@@ -8335,23 +8366,22 @@ libp2p-mplex@^0.10.1:
     it-pushable "^1.3.1"
     varint "^5.0.0"
 
-libp2p-noise@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/libp2p-noise/-/libp2p-noise-2.0.1.tgz#f00dc80811c52937cd411d96af6554972ee075c2"
-  integrity sha512-Jhd/jirWL3qkqGqIC1P4SH+OYlmKFll6UjFVYdw7otBKnbmdBUTW2Lg75/L1+7dYKwitHKu5EWlAd3zPU36gfg==
+libp2p-noise@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/libp2p-noise/-/libp2p-noise-2.0.5.tgz#470b3d19af68176b4835b5722e1c68dfa0040860"
+  integrity sha512-hmR1Y4bJ6hxEO+1aIF1HeJrUNh9NHUbH8gUTtMqpIe7zfdggGau9XKMY0InbafBPFF/WxeIOJDKZiQV4qy2fFg==
   dependencies:
-    bcrypto "^5.2.0"
-    buffer "^5.4.3"
-    debug "^4.1.1"
+    bcrypto "^5.4.0"
+    debug "^4.3.1"
     it-buffer "^0.1.1"
     it-length-prefixed "^3.0.0"
     it-pair "^1.0.0"
-    it-pb-rpc "^0.1.8"
+    it-pb-rpc "^0.1.9"
     it-pipe "^1.1.0"
-    libp2p-crypto "^0.18.0"
-    peer-id "^0.14.0"
+    libp2p-crypto "^0.19.0"
+    peer-id "^0.14.3"
     protobufjs "^6.10.1"
-    uint8arrays "^1.1.0"
+    uint8arrays "^2.0.5"
 
 libp2p-tcp@^0.15.0:
   version "0.15.1"


### PR DESCRIPTION
**Motivation**

Apply security updates + use same new bcrypto version 5.4.0.

**Description**

Bump libp2p-noise's dependencies.

@mpetrunic is it safe to bump this now? If you don't mind to a PR on future bumps if necessary
