### PR TITLE
Log report in sim tests

### DIFF
--- a/packages/lodestar/test/e2e/sync/sync.test.ts
+++ b/packages/lodestar/test/e2e/sync/sync.test.ts
@@ -8,7 +8,7 @@ import {config} from "@chainsafe/lodestar-config/minimal";
 import {ChainEvent} from "../../../src/chain";
 import {Network} from "../../../src/network";
 import {connect} from "../../utils/network";
-import {testLogger, LogLevel} from "../../utils/logger";
+import {testLogger, LogLevel, TestLoggerOpts} from "../../utils/logger";
 
 describe("sync", function () {
   const validatorCount = 8;
@@ -22,8 +22,9 @@ describe("sync", function () {
   it("should sync from other BN", async function () {
     this.timeout("10 min");
 
-    const loggerNodeA = testLogger("Node-A", LogLevel.info);
-    const loggerNodeB = testLogger("Node-B", LogLevel.info);
+    const testLoggerOpts: TestLoggerOpts = {logLevel: LogLevel.info};
+    const loggerNodeA = testLogger("Node-A", testLoggerOpts);
+    const loggerNodeB = testLogger("Node-B", testLoggerOpts);
 
     const bn = await getDevBeaconNode({
       params: beaconParams,
@@ -38,7 +39,7 @@ describe("sync", function () {
       validatorClientCount: 1,
       startIndex: 0,
       useRestApi: false,
-      logLevel: LogLevel.info,
+      testLoggerOpts,
     });
 
     await Promise.all(validators.map((validator) => validator.start()));

--- a/packages/lodestar/test/sim/multiNodeMultiThread.test.ts
+++ b/packages/lodestar/test/sim/multiNodeMultiThread.test.ts
@@ -34,10 +34,10 @@ describe("Run multi node multi thread interop validators (no eth1) until checkpo
       const peerIdPrivkeys: string[] = [];
       const nodes: NodeWorkerOptions["nodes"] = [];
       // delay a bit so regular sync sees it's up to date and sync is completed from the beginning
-      const minGenesisTime = Math.floor(Date.now() / 1000);
-      // it takes more time to detect peers in threaded test
-      const genesisDelay = 30 * beaconParams.SECONDS_PER_SLOT;
-      const genesisTime = minGenesisTime + genesisDelay;
+      // When running multi-thread each thread has to compile the entire codebase from Typescript
+      // so it takes a long time before each node is started
+      const genesisSlotsDelay = 30;
+      const genesisTime = Math.floor(Date.now() / 1000) + genesisSlotsDelay * beaconParams.SECONDS_PER_SLOT;
 
       for (let i = 0; i < nodeCount; i++) {
         const p2pPort = 10000 + i;

--- a/packages/lodestar/test/sim/multiNodeMultiThread.test.ts
+++ b/packages/lodestar/test/sim/multiNodeMultiThread.test.ts
@@ -10,15 +10,13 @@ import {createPeerId} from "../../src/network";
 import {logFiles} from "./params";
 import {NodeWorkerOptions} from "./threaded/types";
 
-/* eslint-disable no-console */
+/* eslint-disable no-console, @typescript-eslint/naming-convention */
 
 describe("Run multi node multi thread interop validators (no eth1) until checkpoint", function () {
   const checkpointEvent = ChainEvent.justified;
   const validatorsPerNode = 8;
   const beaconParams: Pick<IBeaconParams, "SECONDS_PER_SLOT" | "SLOTS_PER_EPOCH"> = {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     SECONDS_PER_SLOT: 2,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     SLOTS_PER_EPOCH: 8,
   };
 

--- a/packages/lodestar/test/sim/multiNodeSingleThread.test.ts
+++ b/packages/lodestar/test/sim/multiNodeSingleThread.test.ts
@@ -33,9 +33,8 @@ describe("Run multi node single thread interop validators (no eth1) until checkp
       const validators: Validator[] = [];
       const loggers: ILogger[] = [];
       // delay a bit so regular sync sees it's up to date and sync is completed from the beginning
-      const minGenesisTime = Math.floor(Date.now() / 1000);
-      const genesisDelay = 2 * beaconParams.SECONDS_PER_SLOT;
-      const genesisTime = minGenesisTime + genesisDelay;
+      const genesisSlotsDelay = 3;
+      const genesisTime = Math.floor(Date.now() / 1000) + genesisSlotsDelay * beaconParams.SECONDS_PER_SLOT;
 
       for (let i = 0; i < nodeCount; i++) {
         const testLoggerOpts: TestLoggerOpts = {

--- a/packages/lodestar/test/sim/multiNodeSingleThread.test.ts
+++ b/packages/lodestar/test/sim/multiNodeSingleThread.test.ts
@@ -7,21 +7,19 @@ import {getDevValidators} from "../utils/node/validator";
 import {Validator} from "@chainsafe/lodestar-validator/lib";
 import {BeaconNode} from "../../src/node";
 import {ChainEvent} from "../../src/chain";
-import {testLogger, LogLevel} from "../utils/logger";
+import {testLogger, LogLevel, TestLoggerOpts} from "../utils/logger";
 import {connect} from "../utils/network";
 import {logFiles} from "./params";
 import {simTestInfoTracker} from "../utils/node/simTest";
-import {ILogger, sleep} from "@chainsafe/lodestar-utils";
+import {ILogger, sleep, TimestampFormatCode} from "@chainsafe/lodestar-utils";
 
-/* eslint-disable no-console */
+/* eslint-disable no-console, @typescript-eslint/naming-convention */
 
 describe("Run multi node single thread interop validators (no eth1) until checkpoint", function () {
   const checkpointEvent = ChainEvent.justified;
   const validatorsPerNode = 8;
   const beaconParams: Pick<IBeaconParams, "SECONDS_PER_SLOT" | "SLOTS_PER_EPOCH"> = {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     SECONDS_PER_SLOT: 3,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     SLOTS_PER_EPOCH: 8,
   };
 
@@ -40,7 +38,18 @@ describe("Run multi node single thread interop validators (no eth1) until checkp
       const genesisTime = minGenesisTime + genesisDelay;
 
       for (let i = 0; i < nodeCount; i++) {
-        const logger = testLogger(`Node ${i}`, LogLevel.info, logFiles.multinodeSinglethread);
+        const testLoggerOpts: TestLoggerOpts = {
+          logLevel: LogLevel.info,
+          logFile: logFiles.multinodeSinglethread,
+          timestampFormat: {
+            format: TimestampFormatCode.EpochSlot,
+            genesisTime,
+            slotsPerEpoch: beaconParams.SLOTS_PER_EPOCH,
+            secondsPerSlot: beaconParams.SECONDS_PER_SLOT,
+          },
+        };
+        const logger = testLogger(`Node ${i}`, testLoggerOpts);
+
         const node = await getDevBeaconNode({
           params: beaconParams,
           options: {sync: {minPeers: 1}},
@@ -54,8 +63,7 @@ describe("Run multi node single thread interop validators (no eth1) until checkp
           validatorsPerClient: validatorsPerNode,
           validatorClientCount: 1,
           startIndex: i * validatorsPerNode,
-          logLevel: LogLevel.info,
-          logFile: logFiles.multinodeSinglethread,
+          testLoggerOpts,
         });
 
         loggers.push(logger);

--- a/packages/lodestar/test/sim/singleNodeSingleThread.test.ts
+++ b/packages/lodestar/test/sim/singleNodeSingleThread.test.ts
@@ -5,28 +5,23 @@ import {waitForEvent} from "../utils/events/resolver";
 import {getDevValidators} from "../utils/node/validator";
 import {ChainEvent} from "../../src/chain";
 import {IRestApiOptions} from "../../src/api/rest/options";
-import {testLogger, LogLevel} from "../utils/logger";
+import {testLogger, TestLoggerOpts, LogLevel} from "../utils/logger";
 import {logFiles} from "./params";
 import {simTestInfoTracker} from "../utils/node/simTest";
-import {sleep} from "@chainsafe/lodestar-utils";
+import {sleep, TimestampFormatCode} from "@chainsafe/lodestar-utils";
 
-/* eslint-disable no-console */
+/* eslint-disable no-console, @typescript-eslint/naming-convention */
 
 describe("Run single node single thread interop validators (no eth1) until checkpoint", function () {
   const timeout = 120 * 1000;
-  const testParams: Partial<IBeaconParams> = {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
+  const testParams: Pick<IBeaconParams, "SECONDS_PER_SLOT" | "SLOTS_PER_EPOCH"> = {
     SECONDS_PER_SLOT: 2,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     SLOTS_PER_EPOCH: 8,
   };
   const manyValidatorParams: Partial<IBeaconParams> = {
     ...testParams,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     TARGET_AGGREGATORS_PER_COMMITTEE: 1,
   };
-
-  const loggerNodeA = testLogger("Node-A", LogLevel.info, logFiles.singlenodeSinglethread);
 
   const testCases: {
     validatorClientCount: number;
@@ -42,11 +37,26 @@ describe("Run single node single thread interop validators (no eth1) until check
   for (const testCase of testCases) {
     it(`${testCase.validatorClientCount} vc / ${testCase.validatorsPerClient} validator > until ${testCase.event}`, async function () {
       this.timeout(timeout);
+
+      const genesisTime = Math.floor(Date.now() / 1000);
+      const testLoggerOpts: TestLoggerOpts = {
+        logLevel: LogLevel.info,
+        logFile: logFiles.singlenodeSinglethread,
+        timestampFormat: {
+          format: TimestampFormatCode.EpochSlot,
+          genesisTime,
+          slotsPerEpoch: testParams.SLOTS_PER_EPOCH,
+          secondsPerSlot: testParams.SECONDS_PER_SLOT,
+        },
+      };
+      const loggerNodeA = testLogger("Node-A", testLoggerOpts);
+
       const bn = await getDevBeaconNode({
         params: testCase.params,
         options: {sync: {minPeers: 0}, api: {rest: {enabled: true} as IRestApiOptions}},
         validatorCount: testCase.validatorClientCount * testCase.validatorsPerClient,
         logger: loggerNodeA,
+        genesisTime,
       });
 
       const stopInfoTracker = simTestInfoTracker(bn, loggerNodeA);
@@ -64,8 +74,7 @@ describe("Run single node single thread interop validators (no eth1) until check
         startIndex: 0,
         // At least one sim test must use the REST API for beacon <-> validator comms
         useRestApi: true,
-        logLevel: LogLevel.info,
-        logFile: logFiles.singlenodeSinglethread,
+        testLoggerOpts,
       });
 
       await Promise.all(validators.map((v) => v.start()));

--- a/packages/lodestar/test/sim/singleNodeSingleThread.test.ts
+++ b/packages/lodestar/test/sim/singleNodeSingleThread.test.ts
@@ -37,8 +37,10 @@ describe("Run single node single thread interop validators (no eth1) until check
   for (const testCase of testCases) {
     it(`${testCase.validatorClientCount} vc / ${testCase.validatorsPerClient} validator > until ${testCase.event}`, async function () {
       this.timeout(timeout);
+      // delay a bit so regular sync sees it's up to date and sync is completed from the beginning
+      const genesisSlotsDelay = 3;
+      const genesisTime = Math.floor(Date.now() / 1000) + genesisSlotsDelay * testParams.SECONDS_PER_SLOT;
 
-      const genesisTime = Math.floor(Date.now() / 1000);
       const testLoggerOpts: TestLoggerOpts = {
         logLevel: LogLevel.info,
         logFile: logFiles.singlenodeSinglethread,

--- a/packages/lodestar/test/sim/singleNodeSingleThread.test.ts
+++ b/packages/lodestar/test/sim/singleNodeSingleThread.test.ts
@@ -29,9 +29,9 @@ describe("Run single node single thread interop validators (no eth1) until check
     event: ChainEvent.justified | ChainEvent.finalized;
     params: Partial<IBeaconParams>;
   }[] = [
+    {validatorClientCount: 1, validatorsPerClient: 32, event: ChainEvent.justified, params: manyValidatorParams},
     {validatorClientCount: 8, validatorsPerClient: 8, event: ChainEvent.justified, params: testParams},
     {validatorClientCount: 8, validatorsPerClient: 8, event: ChainEvent.finalized, params: testParams},
-    {validatorClientCount: 1, validatorsPerClient: 32, event: ChainEvent.justified, params: manyValidatorParams},
   ];
 
   for (const testCase of testCases) {

--- a/packages/lodestar/test/sim/threaded/types.ts
+++ b/packages/lodestar/test/sim/threaded/types.ts
@@ -5,7 +5,7 @@ import {IBeaconNodeOptions} from "../../../src/node/options";
 import {Json} from "@chainsafe/ssz";
 
 export type NodeWorkerOptions = {
-  params: Partial<IBeaconParams>;
+  params: Pick<IBeaconParams, "SECONDS_PER_SLOT" | "SLOTS_PER_EPOCH">;
   options: RecursivePartial<IBeaconNodeOptions>;
   validatorCount: number;
   genesisTime: number;

--- a/packages/lodestar/test/utils/logger.ts
+++ b/packages/lodestar/test/utils/logger.ts
@@ -1,6 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
-import {WinstonLogger, LogLevel, TransportType, TransportOpts} from "@chainsafe/lodestar-utils";
+import {WinstonLogger, LogLevel, TransportType, TransportOpts, TimestampFormat} from "@chainsafe/lodestar-utils";
 export {LogLevel};
+
+export type TestLoggerOpts = {
+  logLevel?: LogLevel;
+  logFile?: string;
+  timestampFormat?: TimestampFormat;
+};
 
 /**
  * Run the test with ENVs to control log level:
@@ -10,13 +16,15 @@ export {LogLevel};
  * VERBOSE=1 mocha .ts
  * ```
  */
-export function testLogger(module?: string, logLevel = LogLevel.error, logFile?: string): WinstonLogger {
-  const transports: TransportOpts[] = [{type: TransportType.console, level: getLogLevelFromEnvs() || logLevel}];
-  if (logFile) {
-    transports.push({type: TransportType.file, filename: logFile, level: LogLevel.debug});
+export function testLogger(module?: string, opts?: TestLoggerOpts): WinstonLogger {
+  const transports: TransportOpts[] = [
+    {type: TransportType.console, level: getLogLevelFromEnvs() || opts?.logLevel || LogLevel.error},
+  ];
+  if (opts?.logFile) {
+    transports.push({type: TransportType.file, filename: opts.logFile, level: LogLevel.debug});
   }
 
-  return new WinstonLogger({module}, transports);
+  return new WinstonLogger({module, ...opts}, transports);
 }
 
 function getLogLevelFromEnvs(): LogLevel | null {

--- a/packages/lodestar/test/utils/node/simTest.ts
+++ b/packages/lodestar/test/utils/node/simTest.ts
@@ -1,28 +1,119 @@
 import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {prepareEpochProcessState} from "@chainsafe/lodestar-beacon-state-transition/lib/fast";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBlockSummary} from "@chainsafe/lodestar-fork-choice";
-import {ILogger} from "@chainsafe/lodestar-utils";
+import {Epoch, Slot} from "@chainsafe/lodestar-types";
+import {BeaconBlock} from "@chainsafe/lodestar-types/lib/allForks";
+import {ILogger, mapValues} from "@chainsafe/lodestar-utils";
 import {BeaconNode} from "../../../src";
 import {ChainEvent} from "../../../src/chain";
+import {linspace} from "../../../src/util/numpy";
+
+/* eslint-disable no-console */
 
 export function simTestInfoTracker(bn: BeaconNode, logger: ILogger): () => void {
-  function onHead(head: IBlockSummary): void {
-    // Compute participation (takes 5ms with 64 validators)
-    const state = bn.chain.getHeadState();
-    const process = prepareEpochProcessState(state);
+  let lastSeenEpoch = 0;
 
-    const prevParticipation = Number(process.prevEpochUnslashedStake.targetStake) / Number(process.totalActiveStake);
-    const currParticipation = Number(process.currEpochUnslashedTargetStake) / Number(process.totalActiveStake);
-    logger.info("> Participation", {
-      slot: `${head.slot}/${computeEpochAtSlot(bn.config, head.slot)}`,
-      prev: prevParticipation,
-      curr: currParticipation,
-    });
+  const attestationsPerBlock = new Map<Slot, number>();
+  const inclusionDelayPerBlock = new Map<Slot, number | null>();
+  const prevParticipationPerEpoch = new Map<Epoch, number>();
+  const currParticipationPerEpoch = new Map<Epoch, number>();
+
+  async function onHead(head: IBlockSummary): Promise<void> {
+    const slot = head.slot;
+    const epoch = computeEpochAtSlot(bn.config, slot);
+
+    // For each block
+    // Check if there was a proposed block and how many attestations it includes
+    const block = await bn.chain.getCanonicalBlockAtSlot(head.slot);
+    if (block) {
+      const bits = sumAttestationBits(block.message);
+      const inclDelay = avgInclusionDelay(block.message);
+      attestationsPerBlock.set(slot, bits);
+      inclusionDelayPerBlock.set(slot, inclDelay);
+      logger.info("> Block attestations", {slot, bits, inclDelay});
+    }
+
+    // For each epoch
+    if (epoch > lastSeenEpoch) {
+      lastSeenEpoch = epoch;
+
+      // Compute participation (takes 5ms with 64 validators)
+      const state = await bn.chain.getStateByBlockRoot(head.parentRoot);
+      if (state) {
+        // Need a CachedBeaconState<allForks.BeaconState> where (state.slot + 1) % SLOTS_EPOCH == 0
+        const process = prepareEpochProcessState(state);
+
+        const prevParticipation =
+          Number(process.prevEpochUnslashedStake.targetStake) / Number(process.totalActiveStake);
+        const currParticipation = Number(process.currEpochUnslashedTargetStake) / Number(process.totalActiveStake);
+        prevParticipationPerEpoch.set(epoch - 1, prevParticipation);
+        currParticipationPerEpoch.set(epoch - 1, currParticipation);
+        logger.info("> Participation", {
+          slot: `${head.slot}/${computeEpochAtSlot(bn.config, head.slot)}`,
+          prev: prevParticipation,
+          curr: currParticipation,
+        });
+      }
+    }
   }
 
   bn.chain.emitter.on(ChainEvent.forkChoiceHead, onHead);
 
-  return function () {
+  return function stop() {
     bn.chain.emitter.off(ChainEvent.forkChoiceHead, onHead);
+
+    // Write report
+    console.log("\nEnd of sim test report\n");
+    printEpochSlotGrid(attestationsPerBlock, bn.config, "Attestations per block");
+    printEpochSlotGrid(inclusionDelayPerBlock, bn.config, "Inclusion delay per block");
+    printEpochGrid({curr: currParticipationPerEpoch, prev: prevParticipationPerEpoch}, "Participation per epoch");
   };
+}
+
+function sumAttestationBits(block: BeaconBlock): number {
+  return Array.from(block.body.attestations).reduce(
+    (total, att) => total + Array.from(att.aggregationBits).filter(Boolean).length,
+    0
+  );
+}
+
+function avgInclusionDelay(block: BeaconBlock): number | null {
+  const inclDelay = Array.from(block.body.attestations).map((att) => block.slot - att.data.slot);
+  return avg(inclDelay);
+}
+
+function avg(arr: number[]): number | null {
+  return arr.length === 0 ? null : arr.reduce((p, c) => p + c, 0) / arr.length;
+}
+
+/**
+ * Print a table grid of (Y) epoch / (X) slot_per_epoch
+ */
+function printEpochSlotGrid<T>(map: Map<Slot, T>, config: IBeaconConfig, title: string): void {
+  const lastSlot = Array.from(map.keys())[map.size - 1];
+  const lastEpoch = computeEpochAtSlot(config, lastSlot);
+  const rowsByEpochBySlot = linspace(0, lastEpoch).map((epoch) => {
+    const slots = linspace(epoch * config.params.SLOTS_PER_EPOCH, (epoch + 1) * config.params.SLOTS_PER_EPOCH - 1);
+    return slots.map((slot) => map.get(slot));
+  });
+  console.log(renderTitle(title));
+  console.table(rowsByEpochBySlot);
+}
+
+/**
+ * Print a table grid of (Y) maps object key / (X) epoch
+ */
+function printEpochGrid(maps: Record<string, Map<Epoch, number>>, title: string): void {
+  const lastEpoch = Object.values(maps).reduce((max, map) => {
+    const epoch = Array.from(map.keys())[map.size - 1];
+    return epoch > max ? epoch : max;
+  }, 0);
+  const epochGrid = mapValues(maps, (map) => linspace(0, lastEpoch).map((epoch) => map.get(epoch) || "NA"));
+  console.log(renderTitle(title));
+  console.table(epochGrid);
+}
+
+function renderTitle(title: string): string {
+  return `${title}\n${"=".repeat(title.length)}`;
 }

--- a/packages/lodestar/test/utils/node/simTest.ts
+++ b/packages/lodestar/test/utils/node/simTest.ts
@@ -109,7 +109,7 @@ function printEpochGrid(maps: Record<string, Map<Epoch, number>>, title: string)
     const epoch = Array.from(map.keys())[map.size - 1];
     return epoch > max ? epoch : max;
   }, 0);
-  const epochGrid = mapValues(maps, (map) => linspace(0, lastEpoch).map((epoch) => map.get(epoch) || "NA"));
+  const epochGrid = linspace(0, lastEpoch).map((epoch) => mapValues(maps, (val, key) => maps[key].get(epoch)));
   console.log(renderTitle(title));
   console.table(epochGrid);
 }

--- a/packages/lodestar/test/utils/node/simTest.ts
+++ b/packages/lodestar/test/utils/node/simTest.ts
@@ -15,7 +15,7 @@ export function simTestInfoTracker(bn: BeaconNode, logger: ILogger): () => void 
   let lastSeenEpoch = 0;
 
   const attestationsPerBlock = new Map<Slot, number>();
-  const inclusionDelayPerBlock = new Map<Slot, number | null>();
+  const inclusionDelayPerBlock = new Map<Slot, number>();
   const prevParticipationPerEpoch = new Map<Epoch, number>();
   const currParticipationPerEpoch = new Map<Epoch, number>();
 
@@ -78,13 +78,13 @@ function sumAttestationBits(block: BeaconBlock): number {
   );
 }
 
-function avgInclusionDelay(block: BeaconBlock): number | null {
+function avgInclusionDelay(block: BeaconBlock): number {
   const inclDelay = Array.from(block.body.attestations).map((att) => block.slot - att.data.slot);
   return avg(inclDelay);
 }
 
-function avg(arr: number[]): number | null {
-  return arr.length === 0 ? null : arr.reduce((p, c) => p + c, 0) / arr.length;
+function avg(arr: number[]): number {
+  return arr.length === 0 ? 0 : arr.reduce((p, c) => p + c, 0) / arr.length;
 }
 
 /**

--- a/packages/lodestar/test/utils/node/validator.ts
+++ b/packages/lodestar/test/utils/node/validator.ts
@@ -5,7 +5,7 @@ import {interopSecretKey} from "@chainsafe/lodestar-beacon-state-transition";
 import {IApiClient, SlashingProtection, Validator} from "@chainsafe/lodestar-validator";
 import {Eth1ForBlockProductionDisabled} from "../../../src/eth1";
 import {BeaconNode} from "../../../src/node";
-import {testLogger} from "../logger";
+import {testLogger, TestLoggerOpts} from "../logger";
 import {Api} from "../../../src/api";
 
 export function getDevValidators({
@@ -14,22 +14,20 @@ export function getDevValidators({
   validatorClientCount = 1,
   startIndex = 0,
   useRestApi,
-  logLevel,
-  logFile,
+  testLoggerOpts,
 }: {
   node: BeaconNode;
   validatorsPerClient: number;
   validatorClientCount: number;
   startIndex: number;
   useRestApi?: boolean;
-  logLevel?: LogLevel;
-  logFile?: string | undefined;
+  testLoggerOpts?: TestLoggerOpts;
 }): Validator[] {
   const vcs: Validator[] = [];
   for (let i = 0; i < validatorClientCount; i++) {
     const startIndexVc = startIndex + i * validatorClientCount;
     const endIndex = startIndexVc + validatorsPerClient - 1;
-    const logger = testLogger(`Vali ${startIndexVc}-${endIndex}`, logLevel, logFile);
+    const logger = testLogger(`Vali ${startIndexVc}-${endIndex}`, testLoggerOpts);
 
     const tmpDir = tmp.dirSync({unsafeCleanup: true});
 

--- a/packages/utils/src/logger/interface.ts
+++ b/packages/utils/src/logger/interface.ts
@@ -39,11 +39,25 @@ export const defaultLogLevel = LogLevel.info;
 export type LogFormat = "human" | "json";
 export const logFormats: LogFormat[] = ["human", "json"];
 
+export type EpochSlotOpts = {
+  genesisTime: number;
+  secondsPerSlot: number;
+  slotsPerEpoch: number;
+};
+export enum TimestampFormatCode {
+  DateRegular,
+  EpochSlot,
+}
+export type TimestampFormat =
+  | {format: TimestampFormatCode.DateRegular}
+  | ({format: TimestampFormatCode.EpochSlot} & EpochSlotOpts);
+
 export interface ILoggerOptions {
   level?: LogLevel;
   module?: string;
   format?: LogFormat;
   hideTimestamp?: boolean;
+  timestampFormat?: TimestampFormat;
 }
 
 export type Context =

--- a/packages/utils/src/logger/util.ts
+++ b/packages/utils/src/logger/util.ts
@@ -1,0 +1,14 @@
+import {EpochSlotOpts} from "./interface";
+
+/**
+ * Formats time as: `EPOCH/SLOT_INDEX SECONDS.MILISECONDS
+ */
+export function formatEpochSlotTime(opts: EpochSlotOpts, now = Date.now()): string {
+  const secSinceGenesis = now / 1000 - opts.genesisTime;
+  const slot = Math.floor(secSinceGenesis / opts.secondsPerSlot);
+  const epoch = Math.floor(slot / opts.slotsPerEpoch);
+  const slotIndex = slot % opts.slotsPerEpoch;
+  const slotSec = secSinceGenesis % opts.secondsPerSlot;
+
+  return `${epoch}/${slotIndex} ${slotSec.toFixed(3)}`;
+}

--- a/packages/utils/src/logger/util.ts
+++ b/packages/utils/src/logger/util.ts
@@ -10,5 +10,5 @@ export function formatEpochSlotTime(opts: EpochSlotOpts, now = Date.now()): stri
   const slotIndex = slot % opts.slotsPerEpoch;
   const slotSec = secSinceGenesis % opts.secondsPerSlot;
 
-  return `${epoch}/${slotIndex} ${slotSec.toFixed(3)}`;
+  return `Eph ${epoch}/${slotIndex} ${slotSec.toFixed(3)}`;
 }

--- a/packages/utils/test/unit/logger/util.test.ts
+++ b/packages/utils/test/unit/logger/util.test.ts
@@ -7,7 +7,7 @@ describe("logger / util / formatEpochSlotTime", () => {
     const genesisTime = (now - 1235423) / 1000;
     const secondsPerSlot = 12;
     const slotsPerEpoch = 32;
-    const expectLog = "3/6 11.423";
+    const expectLog = "Eph 3/6 11.423";
 
     expect(formatEpochSlotTime({genesisTime, secondsPerSlot, slotsPerEpoch}, now)).to.equal(expectLog);
   });

--- a/packages/utils/test/unit/logger/util.test.ts
+++ b/packages/utils/test/unit/logger/util.test.ts
@@ -1,0 +1,14 @@
+import {expect} from "chai";
+import {formatEpochSlotTime} from "../../../src/logger/util";
+
+describe("logger / util / formatEpochSlotTime", () => {
+  it("Should format epoch slot time", () => {
+    const now = 1619171569709;
+    const genesisTime = (now - 1235423) / 1000;
+    const secondsPerSlot = 12;
+    const slotsPerEpoch = 32;
+    const expectLog = "3/6 11.423";
+
+    expect(formatEpochSlotTime({genesisTime, secondsPerSlot, slotsPerEpoch}, now)).to.equal(expectLog);
+  });
+});


### PR DESCRIPTION
**Motivation**

Provide more visibility to the sim tests results. In production runs we have metrics, but in the sim tests we are quite blind. This PR wants to print useful info that may be important to asses how well the node is running and help in case of errors

**Description**

When the sim tests finish (both on success and error) will print to console this data:
```
End of sim test report

Attestations per block
======================
┌─────────┬───────────┬───────────┬───────────┬───┬───┬───┬───┬───┐
│ (index) │     0     │     1     │     2     │ 3 │ 4 │ 5 │ 6 │ 7 │
├─────────┼───────────┼───────────┼───────────┼───┼───┼───┼───┼───┤
│    0    │ undefined │ undefined │ undefined │ 0 │ 8 │ 8 │ 8 │ 8 │
│    1    │ undefined │    16     │     8     │ 8 │ 8 │ 8 │ 8 │ 8 │
│    2    │ undefined │    16     │     8     │ 8 │ 8 │ 8 │ 8 │ 8 │
└─────────┴───────────┴───────────┴───────────┴───┴───┴───┴───┴───┘
Inclusion delay per block
=========================
┌─────────┬───────────┬───────────┬───────────┬───┬───┬───┬───┬───┐
│ (index) │     0     │     1     │     2     │ 3 │ 4 │ 5 │ 6 │ 7 │
├─────────┼───────────┼───────────┼───────────┼───┼───┼───┼───┼───┤
│    0    │ undefined │ undefined │ undefined │ 0 │ 1 │ 1 │ 1 │ 1 │
│    1    │ undefined │    1.5    │     1     │ 1 │ 1 │ 1 │ 1 │ 1 │
│    2    │ undefined │    1.5    │     1     │ 1 │ 1 │ 1 │ 1 │ 1 │
└─────────┴───────────┴───────────┴───────────┴───┴───┴───┴───┴───┘
Participation per epoch
=======================
┌─────────┬───────┬───────────────┐
│ (index) │ curr  │     prev      │
├─────────┼───────┼───────────────┤
│    0    │  0.5  │ 0.00048828125 │
│    1    │ 0.875 │     0.625     │
└─────────┴───────┴───────────────┘

```

It also adds a new timestamp format that is relative to genesis with the format
```
Eph EPOCH/SLOT_INDEX SLOT_SEC.MS
```
looking like this

```
Eph 0/6 1.001 [NODE-A]           info: Synced - finalized: 0 0x0000…0000 - head: 6 0xb4da…5364 - peers: 0
Eph 0/7 0.051 [VALI 0-7]         info: Published block slot=7, validator=0x8128…4a5e
Eph 0/7 0.073 [NODE-A]           info: > Block attestations slot=7, bits=8, inclDelay=1
Eph 0/7 0.158 [VALI 0-7]         info: Published attestation slot=7, validator=0x8128…4a5e
Eph 0/7 0.160 [VALI 0-7]         info: Published attestation slot=7, validator=0xa8d4…b8ac
```

The `Eph` prefix is not strictly necessary but it helps to quickly identify that this is not a regular timestamp format and hints the meaning of the numbers.

Closes https://github.com/ChainSafe/lodestar/issues/2407