### PR TITLE
Emit clock slot event on updated currentSlot

### DIFF
--- a/packages/lodestar/src/chain/clock/LocalClock.ts
+++ b/packages/lodestar/src/chain/clock/LocalClock.ts
@@ -41,7 +41,12 @@ export class LocalClock implements IBeaconClock {
   }
 
   get currentSlot(): Slot {
-    return getCurrentSlot(this.config, this.genesisTime);
+    const slot = getCurrentSlot(this.config, this.genesisTime);
+    if (slot > this._currentSlot) {
+      clearTimeout(this.timeoutId);
+      this.onNextSlot(slot);
+    }
+    return slot;
   }
 
   /**
@@ -90,8 +95,8 @@ export class LocalClock implements IBeaconClock {
     });
   }
 
-  private onNextSlot = (): void => {
-    const clockSlot = getCurrentSlot(this.config, this.genesisTime);
+  private onNextSlot = (slot?: Slot): void => {
+    const clockSlot = slot ?? getCurrentSlot(this.config, this.genesisTime);
     // process multiple clock slots in the case the main thread has been saturated for > SECONDS_PER_SLOT
     while (this._currentSlot < clockSlot) {
       const previousSlot = this._currentSlot;

--- a/packages/lodestar/src/chain/clock/LocalClock.ts
+++ b/packages/lodestar/src/chain/clock/LocalClock.ts
@@ -15,7 +15,7 @@ import {MAXIMUM_GOSSIP_CLOCK_DISPARITY} from "../../constants";
 export class LocalClock implements IBeaconClock {
   private readonly config: IBeaconConfig;
   private readonly genesisTime: number;
-  private timeoutId: NodeJS.Timeout;
+  private timeoutId: number;
   private readonly emitter: ChainEventEmitter;
   private readonly signal: AbortSignal;
   private _currentSlot: number;


### PR DESCRIPTION
**Motivation**

Currently, we can run into a situation where the `clock.currentSlot` is updated but that slot's event has not yet been triggered (and important callbacks have not yet been executed).
This can lead to confusing bugs, like:
```
Eph 1/3 0.084 [NODE-A CHAIN]    error: Block error slot=11 code=BLOCK_ERROR_BEACON_CHAIN_ERROR, error={"code":"FORKCHOICE_ERROR_INVALID_BLOCK","err":{"code":"FUTURE_SLOT","currentSlot":10,"blockSlot":11}}
Error: FORKCHOICE_ERROR_INVALID_BLOCK
    at LodestarForkChoice.onBlock (/home/runner/work/lodestar/lodestar/packages/fork-choice/src/forkChoice/forkChoice.ts:238:13)
    at Object.runStateTransition (/home/runner/work/lodestar/lodestar/packages/lodestar/src/chain/blocks/stateTransition.ts:151:14)
    at Object.processBlock (/home/runner/work/lodestar/lodestar/packages/lodestar/src/chain/blocks/process.ts:60:11)
    at processBlockJob (/home/runner/work/lodestar/lodestar/packages/lodestar/src/chain/blocks/processor.ts:80:5)
    at Object.job (/home/runner/work/lodestar/lodestar/packages/lodestar/src/chain/blocks/processor.ts:59:42)
    at Object.wrapError (/home/runner/work/lodestar/lodestar/packages/lodestar/src/util/wrapError.ts:18:32)
    at Timeout.JobQueue.runJob [as _onTimeout] (/home/runner/work/lodestar/lodestar/packages/lodestar/src/util/queue/index.ts:93:17)
Error: BLOCK_ERROR_BEACON_CHAIN_ERROR
    at Object.processBlock (/home/runner/work/lodestar/lodestar/packages/lodestar/src/chain/blocks/process.ts:73:11)
```
Where even though the block passes validation (including that `block.slot >= clock.currentSlot`), the fork choice store isn't yet updated.

**Description**

Update the `clock.currentSlot` getter to trigger clock events if the call results in an updated slot. This will give important slot event handlers a chance to run before the consumer of a currentSlot continues.

Specifically, with regards to the above error, when the block in question is now validated (and checked against `clock.currentSlot`), the slot event handler will be called, allowing the fork choice to be updated before continuing block processing at that slot.