### PR TITLE
Update yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1099,7 +1099,7 @@
   dependencies:
     assert "^2.0.0"
 
-"@chainsafe/bls-hd-key@0.2.1":
+"@chainsafe/bls-hd-key@^0.2.0":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@chainsafe/bls-hd-key/-/bls-hd-key-0.2.1.tgz#3387a63f36f3cac20276bef40bb16a46294e6724"
   integrity sha512-FGmRLcOd9KxfH9q7x+FT20lJy9ooQ/Xd5fFLFGpPaf9GW4AnE0oGPGakPuV5//g8db7OzZ3ZfVMKtB4M7qq/wA==
@@ -8537,11 +8537,6 @@ loader-utils@^1.2.3:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
-
-loady@~0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/loady/-/loady-0.0.1.tgz#24a99c14cfed9cd0bffed365b1836035303f7e5d"
-  integrity sha512-PW5Z13Jd0v6ZcA1P6ZVUc3EV8BJwQuAiwUvvT6VQGHoaZ1d/tu7r1QZctuKfQqwy9SFBWeAGfcIdLxhp7ZW3Rw==
 
 loady@~0.0.5:
   version "0.0.5"


### PR DESCRIPTION
**Motivation**

Probably because of the manual manipulation in https://github.com/ChainSafe/lodestar/pull/2410 yarn.lock required an update

**Description**

Ran locally `yarn` and produced this diff