### PR TITLE
Improve BLS multi-thread worker pool strategy

### DIFF
--- a/packages/beacon-state-transition/src/fast/signatureSets/attesterSlashings.ts
+++ b/packages/beacon-state-transition/src/fast/signatureSets/attesterSlashings.ts
@@ -1,16 +1,25 @@
 import {readonlyValues} from "@chainsafe/ssz";
-import {allForks} from "@chainsafe/lodestar-types";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {ISignatureSet} from "../../util";
 import {CachedBeaconState} from "../util";
 import {getIndexedAttestationSignatureSet} from "./indexedAttestation";
 
+/** Get signature sets from a single AttesterSlashing object */
+export function getAttesterSlashingSignatureSets(
+  state: CachedBeaconState<allForks.BeaconState>,
+  attesterSlashing: phase0.AttesterSlashing
+): ISignatureSet[] {
+  return [attesterSlashing.attestation1, attesterSlashing.attestation2].map((attestation) =>
+    getIndexedAttestationSignatureSet(state, attestation)
+  );
+}
+
+/** Get signature sets from all AttesterSlashing objects in a block */
 export function getAttesterSlashingsSignatureSets(
   state: CachedBeaconState<allForks.BeaconState>,
   signedBlock: allForks.SignedBeaconBlock
 ): ISignatureSet[] {
   return Array.from(readonlyValues(signedBlock.message.body.attesterSlashings), (attesterSlashing) =>
-    [attesterSlashing.attestation1, attesterSlashing.attestation2].map((attestation) =>
-      getIndexedAttestationSignatureSet(state, attestation)
-    )
+    getAttesterSlashingSignatureSets(state, attesterSlashing)
   ).flat(1);
 }

--- a/packages/beacon-state-transition/src/util/signatureSets.ts
+++ b/packages/beacon-state-transition/src/util/signatureSets.ts
@@ -26,10 +26,10 @@ export function verifySignatureSet(signatureSet: ISignatureSet): boolean {
 
   switch (signatureSet.type) {
     case SignatureSetType.single:
-      return signature.verify(signatureSet.pubkey, signatureSet.signingRoot as Uint8Array);
+      return signature.verify(signatureSet.pubkey, signatureSet.signingRoot.valueOf() as Uint8Array);
 
     case SignatureSetType.aggregate:
-      return signature.verifyAggregate(signatureSet.pubkeys, signatureSet.signingRoot as Uint8Array);
+      return signature.verifyAggregate(signatureSet.pubkeys, signatureSet.signingRoot.valueOf() as Uint8Array);
 
     default:
       throw Error("Unknown signature set type");

--- a/packages/lodestar/src/chain/blocks/process.ts
+++ b/packages/lodestar/src/chain/blocks/process.ts
@@ -46,7 +46,7 @@ export async function processBlock({
           )
         : fast.getAllBlockSignatureSets(preState as CachedBeaconState<allForks.BeaconState>, job.signedBlock);
 
-      if (!(await bls.verifySignatureSetsBatch(signatureSets))) {
+      if (signatureSets.length > 0 && !(await bls.verifySignatureSets(signatureSets))) {
         throw new BlockError({
           code: BlockErrorCode.INVALID_SIGNATURE,
           job,
@@ -137,7 +137,7 @@ export async function processChainSegment({
           );
         }
 
-        if (!(await bls.verifySignatureSetsBatch(signatureSets))) {
+        if (signatureSets.length > 0 && !(await bls.verifySignatureSets(signatureSets))) {
           throw new ChainSegmentError({
             code: BlockErrorCode.INVALID_SIGNATURE,
             job,

--- a/packages/lodestar/src/chain/bls/index.ts
+++ b/packages/lodestar/src/chain/bls/index.ts
@@ -4,7 +4,7 @@ import {ILogger} from "@chainsafe/lodestar-utils";
 import {BlsMultiThreadNaive} from "./multithread";
 
 export interface IBlsVerifier {
-  verifySignatureSetsBatch(signatureSets: ISignatureSet[]): Promise<boolean>;
+  verifySignatureSets(signatureSets: ISignatureSet[]): Promise<boolean>;
 }
 
 export class BlsVerifier implements IBlsVerifier {
@@ -13,7 +13,14 @@ export class BlsVerifier implements IBlsVerifier {
     this.pool = new BlsMultiThreadNaive(logger, bls.implementation);
   }
 
-  verifySignatureSetsBatch(signatureSets: ISignatureSet[]): Promise<boolean> {
+  /**
+   * Verify 1 or more signature sets. Sets may be verified on batch or not depending on their count
+   */
+  verifySignatureSets(signatureSets: ISignatureSet[], validateSignature = true): Promise<boolean> {
+    if (signatureSets.length === 0) {
+      throw Error("Empty signature set");
+    }
+
     // Signatures all come from the wire (untrusted) are all bytes compressed, must be:
     // - Parsed from bytes
     // - Uncompressed
@@ -36,7 +43,8 @@ export class BlsVerifier implements IBlsVerifier {
         publicKey: getAggregatedPubkey(signatureSet),
         message: signatureSet.signingRoot as Uint8Array,
         signature: signatureSet.signature,
-      }))
+      })),
+      validateSignature
     );
   }
 }

--- a/packages/lodestar/src/chain/bls/index.ts
+++ b/packages/lodestar/src/chain/bls/index.ts
@@ -38,7 +38,7 @@ export class BlsVerifier implements IBlsVerifier {
     // Public keys have already been checked for subgroup and infinity
     // Signatures have already been checked for subgroup
     // Signature checks above could be done here for convienence as well
-    return this.pool.verifyMultipleAggregateSignatures(
+    return this.pool.verifySignatureSets(
       signatureSets.map((signatureSet) => ({
         publicKey: getAggregatedPubkey(signatureSet),
         message: signatureSet.signingRoot as Uint8Array,

--- a/packages/lodestar/src/chain/bls/index.ts
+++ b/packages/lodestar/src/chain/bls/index.ts
@@ -1,8 +1,6 @@
-import {AbortSignal} from "abort-controller";
 import {bls, PublicKey} from "@chainsafe/bls";
 import {ISignatureSet, SignatureSetType} from "@chainsafe/lodestar-beacon-state-transition";
-import {ILogger} from "@chainsafe/lodestar-utils";
-import {BlsMultiThreadWorkerPool} from "./multithread";
+import {BlsMultiThreadWorkerPool, BlsMultiThreadWorkerPoolModules} from "./multithread";
 
 export interface IBlsVerifier {
   verifySignatureSets(signatureSets: ISignatureSet[]): Promise<boolean>;
@@ -10,8 +8,8 @@ export interface IBlsVerifier {
 
 export class BlsVerifier implements IBlsVerifier {
   private readonly pool: BlsMultiThreadWorkerPool;
-  constructor(logger: ILogger, signal: AbortSignal) {
-    this.pool = new BlsMultiThreadWorkerPool(logger, bls.implementation, signal);
+  constructor(modules: BlsMultiThreadWorkerPoolModules) {
+    this.pool = new BlsMultiThreadWorkerPool(bls.implementation, modules);
   }
 
   /**

--- a/packages/lodestar/src/chain/bls/multithread/index.ts
+++ b/packages/lodestar/src/chain/bls/multithread/index.ts
@@ -1,10 +1,15 @@
-import {spawn, Pool, Worker} from "threads";
+import {spawn, Worker} from "threads";
+import {defaultPoolSize} from "threads/dist/master/implementation";
 // `threads` library creates self global variable which breaks `timeout-abort-controller` https://github.com/jacobheun/timeout-abort-controller/issues/9
+// Don't add an eslint disable here as a reminder that this has to be fixed eventually
 // @ts-ignore
 // eslint-disable-next-line
 self = undefined;
+import {AbortSignal} from "abort-controller";
 import {Implementation, PointFormat, PublicKey} from "@chainsafe/bls";
 import {ILogger} from "@chainsafe/lodestar-utils";
+import {QueueError, QueueErrorCode} from "../../../util/queue";
+import {wrapError} from "../../../util/wrapError";
 import {BlsWorkReq, WorkerData, WorkResult, WorkResultCode} from "./types";
 import {chunkifyMaximizeChunkSize} from "./utils";
 
@@ -21,6 +26,33 @@ type WorkerApi = {
   doManyBlsWorkReq(workReqArr: BlsWorkReq[]): Promise<WorkResult<boolean>[]>;
 };
 
+type JobQueueItem<R = boolean> = {
+  resolve: (result: R | PromiseLike<R>) => void;
+  reject: (error?: Error) => void;
+  addedTimeMs: number;
+  workReq: BlsWorkReq;
+};
+
+enum WorkerStatusCode {
+  notInitialized,
+  initializing,
+  initializationError,
+  idle,
+  running,
+}
+
+type WorkerStatus =
+  | {code: WorkerStatusCode.notInitialized}
+  | {code: WorkerStatusCode.initializing; initPromise: Promise<WorkerApi>}
+  | {code: WorkerStatusCode.initializationError; error: Error}
+  | {code: WorkerStatusCode.idle; workerApi: WorkerApi}
+  | {code: WorkerStatusCode.running; workerApi: WorkerApi};
+
+type WorkerDescriptor = {
+  worker: Worker;
+  status: WorkerStatus;
+};
+
 /**
  * Wraps "threads" library thread pool queue system with the goals:
  * - Complete total outstanding jobs in total minimum time possible.
@@ -29,34 +61,26 @@ type WorkerApi = {
  *   communiction has very high latency, of around ~5 ms. So package multiple small signature
  *   sets into packages of work and send at once to a worker to distribute the latency cost
  */
-export class BlsMultiThreadNaive {
+export class BlsMultiThreadWorkerPool {
   private readonly logger: ILogger;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private readonly pool: Pool<any>;
   private readonly format: PointFormat;
+  private readonly signal: AbortSignal;
+  private readonly jobs: JobQueueItem[] = [];
+  private readonly workers: WorkerDescriptor[];
 
-  constructor(logger: ILogger, implementation: Implementation) {
+  constructor(logger: ILogger, implementation: Implementation, signal: AbortSignal) {
     this.logger = logger;
+    this.signal = signal;
 
     // Use compressed for herumi for now.
     // THe worker is not able to deserialize from uncompressed
     // `Error: err _wrapDeserialize`
     this.format = implementation === "blst-native" ? PointFormat.uncompressed : PointFormat.compressed;
+    this.workers = this.createWorkers(implementation, defaultPoolSize);
 
-    const workerData: WorkerData = {implementation};
-    this.pool = Pool(() =>
-      spawn(new Worker("./worker", {workerData} as ConstructorParameters<typeof Worker>[1]), {
-        // A Lodestar Node may do very expensive task at start blocking the event loop and causing
-        // the initialization to timeout. The number below is big enough to almost disable the timeout
-        timeout: 5 * 60 * 1000,
-      })
-    );
-  }
-
-  async destroy(): Promise<void> {
-    // Stop all JavaScript execution in the worker thread as soon as possible.
-    // Returns a Promise for the exit code that is fulfilled when the 'exit' event is emitted.
-    await this.pool.terminate(true);
+    this.signal.addEventListener("abort", this.abortAllJobs, {once: true});
+    this.signal.addEventListener("abort", this.terminateAllWorkers, {once: true});
   }
 
   async verifySignatureSets(
@@ -84,20 +108,167 @@ export class BlsMultiThreadNaive {
     return results.every((isValid) => isValid === true);
   }
 
-  private async queueBlsWork(workReq: BlsWorkReq): Promise<boolean> {
-    const results = await this.pool.queue(async (task: WorkerApi) => {
-      return task.doManyBlsWorkReq([workReq]);
-    });
+  private createWorkers(implementation: Implementation, poolSize: number): WorkerDescriptor[] {
+    const workers: WorkerDescriptor[] = [];
 
-    const result = results[0];
-    if (result.code === WorkResultCode.success) {
-      // Metrics
-      // this.metrics.blsMultiThreadSigCount.add(workReq.sets.length);
-      // this.metrics.blsMultiThreadWorkerTiem.add(result.workerJobTimeMs);
+    for (let i = 0; i < poolSize; i++) {
+      const workerData: WorkerData = {implementation};
+      const worker = new Worker("./worker", {workerData} as ConstructorParameters<typeof Worker>[1]);
 
-      return result.result;
-    } else {
-      throw Error(result.error.message);
+      const workerDescriptor: WorkerDescriptor = {
+        worker,
+        status: {code: WorkerStatusCode.notInitialized},
+      };
+      workers.push(workerDescriptor);
+
+      // TODO: Consider initializing only when necessary
+      const initPromise = spawn<WorkerApi>(worker, {
+        // A Lodestar Node may do very expensive task at start blocking the event loop and causing
+        // the initialization to timeout. The number below is big enough to almost disable the timeout
+        timeout: 5 * 60 * 1000,
+      });
+
+      workerDescriptor.status = {code: WorkerStatusCode.initializing, initPromise};
+
+      initPromise
+        .then((workerApi) => {
+          workerDescriptor.status = {code: WorkerStatusCode.idle, workerApi};
+          // Potentially run jobs that were queued before initialization of the first worker
+          setTimeout(this.runJob, 0);
+        })
+        .catch((error: Error) => {
+          workerDescriptor.status = {code: WorkerStatusCode.initializationError, error};
+        });
     }
+
+    return workers;
   }
+
+  /**
+   * Queue a task and return a promise that resolves once the task has been dequeued,
+   * started and finished.
+   *
+   * @param task An async function that takes a thread instance and invokes it.
+   */
+  private async queueBlsWork(workReq: BlsWorkReq): Promise<boolean> {
+    if (this.signal.aborted) {
+      throw new QueueError({code: QueueErrorCode.QUEUE_ABORTED});
+    }
+
+    // TODO: Consider if limiting queue size is necessary here.
+    // It would be bad to reject signatures because the node is slow.
+    // However, if the worker communication broke jobs won't ever finish
+
+    // TODO: Throw only if all validators have failed
+    if (
+      this.workers.length > 0 &&
+      this.workers[0].status.code === WorkerStatusCode.initializationError &&
+      this.workers.every((worker) => worker.status.code === WorkerStatusCode.initializationError)
+    ) {
+      throw this.workers[0].status.error;
+    }
+
+    return await new Promise<boolean>((resolve, reject) => {
+      const addedTimeMs = Date.now();
+      this.jobs.push({resolve, reject, addedTimeMs, workReq});
+      setTimeout(this.runJob, 0);
+    });
+  }
+
+  private runJob = async (): Promise<void> => {
+    if (this.signal.aborted) {
+      return;
+    }
+
+    // Find iddle worker
+    const worker = this.workers.find((worker) => worker.status.code === WorkerStatusCode.idle);
+    if (!worker || worker.status.code !== WorkerStatusCode.idle) {
+      return;
+    }
+
+    // Prepare work package
+    const jobs = this.prepareWork();
+    if (jobs.length === 0) {
+      return;
+    }
+
+    // TODO: Metrics
+    // for (const job of jobs) {
+    //   this.metrics?.jobWaitTime.observe((Date.now() - job.addedTimeMs) / 1000);
+    // }
+
+    // TODO: After sending the work to the worker the main thread can drop the job arguments
+    // and free-up memory, only need to keep the job's Promise handlers
+
+    const workerApi = worker.status.workerApi;
+    worker.status = {code: WorkerStatusCode.running, workerApi};
+
+    // Send work package to the worker
+    const workerResult = await wrapError(workerApi.doManyBlsWorkReq(jobs.map((job) => job.workReq)));
+
+    worker.status = {code: WorkerStatusCode.idle, workerApi};
+
+    if (workerResult.err) {
+      // Reject all
+      for (const job of jobs) {
+        job.reject(workerResult.err);
+      }
+    } else {
+      // Un-wrap work package
+      const results = workerResult.result;
+      for (const [i, result] of results.entries()) {
+        const job = jobs[i];
+        if (result.code === WorkResultCode.success) {
+          // Metrics
+          // this.metrics.blsMultiThreadSigCount.add(workReq.sets.length);
+          // this.metrics.blsMultiThreadWorkerTiem.add(result.workerJobTimeMs);
+
+          job.resolve(result.result);
+        } else {
+          job.reject(Error(result.error.message));
+        }
+      }
+    }
+
+    // Potentially run a new job
+    setTimeout(this.runJob, 0);
+  };
+
+  /**
+   * Grab pending work up to a max number of signatures
+   */
+  private prepareWork(): JobQueueItem<boolean>[] {
+    const jobs: JobQueueItem<boolean>[] = [];
+    let totalSigs = 0;
+
+    while (totalSigs < MAX_SIGNATURE_SETS_PER_JOB) {
+      const job = this.jobs.shift();
+      if (!job) {
+        break;
+      }
+
+      jobs.push(job);
+      totalSigs += job.workReq.sets.length;
+    }
+
+    return jobs;
+  }
+
+  /**
+   * Stop all JavaScript execution in the worker thread immediatelly
+   */
+  private terminateAllWorkers = (): void => {
+    for (const [id, worker] of this.workers.entries()) {
+      worker.worker.terminate((error, exitCode = 0) => {
+        if (error) this.logger.error("Error terminating worker", {id, exitCode}, error);
+      });
+    }
+  };
+
+  private abortAllJobs = (): void => {
+    while (this.jobs.length > 0) {
+      const job = this.jobs.shift();
+      if (job) job.reject(new QueueError({code: QueueErrorCode.QUEUE_ABORTED}));
+    }
+  };
 }

--- a/packages/lodestar/src/chain/bls/multithread/index.ts
+++ b/packages/lodestar/src/chain/bls/multithread/index.ts
@@ -1,5 +1,4 @@
 import {spawn, Worker} from "threads";
-import {defaultPoolSize} from "threads/dist/master/implementation";
 // `threads` library creates self global variable which breaks `timeout-abort-controller` https://github.com/jacobheun/timeout-abort-controller/issues/9
 // Don't add an eslint disable here as a reminder that this has to be fixed eventually
 // @ts-ignore
@@ -11,7 +10,7 @@ import {ILogger} from "@chainsafe/lodestar-utils";
 import {QueueError, QueueErrorCode} from "../../../util/queue";
 import {wrapError} from "../../../util/wrapError";
 import {BlsWorkReq, WorkerData, WorkResult, WorkResultCode} from "./types";
-import {chunkifyMaximizeChunkSize} from "./utils";
+import {chunkifyMaximizeChunkSize, getDefaultPoolSize} from "./utils";
 import {IMetrics} from "../../../metrics";
 
 export type BlsMultiThreadWorkerPoolModules = {
@@ -86,7 +85,7 @@ export class BlsMultiThreadWorkerPool {
     // THe worker is not able to deserialize from uncompressed
     // `Error: err _wrapDeserialize`
     this.format = implementation === "blst-native" ? PointFormat.uncompressed : PointFormat.compressed;
-    this.workers = this.createWorkers(implementation, defaultPoolSize);
+    this.workers = this.createWorkers(implementation, getDefaultPoolSize());
 
     this.signal.addEventListener("abort", this.abortAllJobs, {once: true});
     this.signal.addEventListener("abort", this.terminateAllWorkers, {once: true});

--- a/packages/lodestar/src/chain/bls/multithread/index.ts
+++ b/packages/lodestar/src/chain/bls/multithread/index.ts
@@ -5,13 +5,21 @@ import {spawn, Pool, Worker} from "threads";
 self = undefined;
 import {Implementation, PointFormat, PublicKey} from "@chainsafe/bls";
 import {ILogger} from "@chainsafe/lodestar-utils";
-import {BlsWorkReq, WorkerData, WorkResult, BlsWorkCode, WorkResultCode} from "./types";
+import {BlsWorkReq, WorkerData, WorkResult, WorkResultCode} from "./types";
 import {chunkify} from "./utils";
 
 type WorkerApi = {
   doManyBlsWorkReq(workReqArr: BlsWorkReq[]): Promise<WorkResult<boolean>[]>;
 };
 
+/**
+ * Wraps "threads" library thread pool queue system with the goals:
+ * - Complete total outstanding jobs in total minimum time possible.
+ *   Will split large signature sets into smaller sets and send to different workers
+ * - Reduce the latency cost for small signature sets. In NodeJS 12,14 worker <-> main thread
+ *   communiction has very high latency, of around ~5 ms. So package multiple small signature
+ *   sets into packages of work and send at once to a worker to distribute the latency cost
+ */
 export class BlsMultiThreadNaive {
   private readonly logger: ILogger;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -42,22 +50,26 @@ export class BlsMultiThreadNaive {
     await this.pool.terminate(true);
   }
 
-  async verify(publicKey: PublicKey, message: Uint8Array, signature: Uint8Array): Promise<boolean> {
+  async verify(
+    publicKey: PublicKey,
+    message: Uint8Array,
+    signature: Uint8Array,
+    validateSignature: boolean
+  ): Promise<boolean> {
     return await this.queueBlsWork({
-      code: BlsWorkCode.verify,
-      publicKey: publicKey.toBytes(this.format),
-      message,
-      signature: signature,
+      validateSignature,
+      sets: [{publicKey: publicKey.toBytes(this.format), message, signature: signature}],
     });
   }
 
   async verifyMultipleAggregateSignatures(
-    sets: {publicKey: PublicKey; message: Uint8Array; signature: Uint8Array}[]
+    sets: {publicKey: PublicKey; message: Uint8Array; signature: Uint8Array}[],
+    validateSignature: boolean
   ): Promise<boolean> {
     const results = await Promise.all(
       chunkify(sets, 32).map((setsWorker) =>
         this.queueBlsWork({
-          code: BlsWorkCode.batchVerify,
+          validateSignature,
           sets: setsWorker.map((s) => ({
             publicKey: s.publicKey.toBytes(this.format),
             message: s.message,

--- a/packages/lodestar/src/chain/bls/multithread/types.ts
+++ b/packages/lodestar/src/chain/bls/multithread/types.ts
@@ -2,25 +2,21 @@ export type WorkerData = {
   implementation: "herumi" | "blst-native";
 };
 
-export enum BlsWorkCode {
-  batchVerify = "batchVerify",
-  verify = "verify",
-}
+export type BlsWorkReq = {
+  validateSignature: boolean;
+  sets: {publicKey: Uint8Array; message: Uint8Array; signature: Uint8Array}[];
+};
 
-export type BlsWorkReq =
-  | {code: BlsWorkCode.verify; publicKey: Uint8Array; message: Uint8Array; signature: Uint8Array}
-  | {code: BlsWorkCode.batchVerify; sets: {publicKey: Uint8Array; message: Uint8Array; signature: Uint8Array}[]};
-
-export type BlsWorkResult =
-  | {code: BlsWorkCode.verify; valid: WorkResult<boolean>}
-  | {code: BlsWorkCode.batchVerify; valid: WorkResult<boolean>};
+export type BlsWorkResult = WorkResult<boolean>;
 
 export enum WorkResultCode {
   success = "success",
   error = "error",
 }
 
-export type WorkResult<R> = {code: WorkResultCode.success; result: R} | {code: WorkResultCode.error; error: Error};
+export type WorkResult<R> =
+  | {code: WorkResultCode.success; result: R; workerJobTimeMs: number}
+  | {code: WorkResultCode.error; error: Error};
 
 export enum WorkerMessageCode {
   workRequest = "workRequest",

--- a/packages/lodestar/src/chain/bls/multithread/utils.ts
+++ b/packages/lodestar/src/chain/bls/multithread/utils.ts
@@ -17,3 +17,19 @@ export function chunkifyMaximizeChunkSize<T>(arr: T[], minPerChunk: number): T[]
 
   return arrArr;
 }
+
+/**
+ * Cross-platform fetch an aprox number of logical cores
+ */
+export function getDefaultPoolSize(): number {
+  if (typeof navigator !== "undefined") {
+    return navigator.hardwareConcurrency ?? 4;
+  }
+
+  if (typeof require !== "undefined") {
+    // eslint-disable-next-line
+    return require("os").cpus().length;
+  }
+
+  return 8;
+}

--- a/packages/lodestar/src/chain/bls/multithread/utils.ts
+++ b/packages/lodestar/src/chain/bls/multithread/utils.ts
@@ -1,12 +1,18 @@
-export function chunkify<T>(arr: T[], minPerChunk: number): T[][] {
-  if (Math.floor(arr.length / minPerChunk) <= 1) {
+/**
+ * Splits an array into an array of arrays maximizing the size of the smallest chunk.
+ */
+export function chunkifyMaximizeChunkSize<T>(arr: T[], minPerChunk: number): T[][] {
+  const chunkCount = Math.floor(arr.length / minPerChunk);
+  if (chunkCount <= 1) {
     return [arr];
   }
 
+  // Prefer less chunks of bigger size
+  const perChunk = Math.ceil(arr.length / chunkCount);
   const arrArr: T[][] = [];
 
-  for (let i = 0, j = arr.length; i < j; i += minPerChunk) {
-    arrArr.push(arr.slice(i, i + minPerChunk));
+  for (let i = 0; i < arr.length; i += perChunk) {
+    arrArr.push(arr.slice(i, i + perChunk));
   }
 
   return arrArr;

--- a/packages/lodestar/src/chain/bls/multithread/worker.ts
+++ b/packages/lodestar/src/chain/bls/multithread/worker.ts
@@ -33,10 +33,6 @@ function doManyBlsWorkReq(workReqArr: BlsWorkReq[]): WorkResult<boolean>[] {
 }
 
 function verifySignatureSetsMaybeBatch(workReq: BlsWorkReq): boolean {
-  if (workReq.sets.length === 0) {
-    throw Error("Empty signature set");
-  }
-
   if (workReq.sets.length >= MIN_SET_COUNT_TO_BATCH) {
     return bls.Signature.verifyMultipleSignatures(
       workReq.sets.map((s) => ({
@@ -45,6 +41,11 @@ function verifySignatureSetsMaybeBatch(workReq: BlsWorkReq): boolean {
         signature: bls.Signature.fromBytes(s.signature, CoordType.affine, workReq.validateSignature),
       }))
     );
+  }
+
+  // .every on an empty array returns true
+  if (workReq.sets.length === 0) {
+    throw Error("Empty signature set");
   }
 
   // If too few signature sets verify them without batching

--- a/packages/lodestar/src/chain/bls/multithread/worker.ts
+++ b/packages/lodestar/src/chain/bls/multithread/worker.ts
@@ -1,7 +1,9 @@
 import worker from "worker_threads";
 import {expose} from "threads/worker";
 import {bls, init, CoordType} from "@chainsafe/bls";
-import {WorkerData, BlsWorkCode, BlsWorkReq, WorkResult, WorkResultCode} from "./types";
+import {WorkerData, BlsWorkReq, WorkResult, WorkResultCode} from "./types";
+
+const MIN_SET_COUNT_TO_BATCH = 2;
 
 /* eslint-disable no-console */
 
@@ -15,40 +17,40 @@ expose({
     await init(implementation);
     return doManyBlsWorkReq(workReqArr);
   },
-  async echo(hello) {
-    return `${hello} world`;
-  },
 });
 
 function doManyBlsWorkReq(workReqArr: BlsWorkReq[]): WorkResult<boolean>[] {
   return workReqArr.map((workReq) => {
     try {
-      return {code: WorkResultCode.success, result: doBlsWorkReq(workReq)};
+      const start = Date.now();
+      const isValid = verifySignatureSetsMaybeBatch(workReq);
+      const workerJobTimeMs = Date.now() - start;
+      return {code: WorkResultCode.success, result: isValid, workerJobTimeMs};
     } catch (e) {
       return {code: WorkResultCode.error, error: e as Error};
     }
   });
 }
 
-function doBlsWorkReq(workReq: BlsWorkReq): boolean {
-  switch (workReq.code) {
-    case BlsWorkCode.verify: {
-      const pk = bls.PublicKey.fromBytes(workReq.publicKey, CoordType.affine);
-      const sig = bls.Signature.fromBytes(workReq.signature, CoordType.affine, true);
-      return sig.verify(pk, workReq.message);
-    }
-
-    case BlsWorkCode.batchVerify: {
-      return bls.Signature.verifyMultipleSignatures(
-        workReq.sets.map((s) => ({
-          publicKey: bls.PublicKey.fromBytes(s.publicKey, CoordType.affine),
-          message: s.message,
-          signature: bls.Signature.fromBytes(s.signature, CoordType.affine, true),
-        }))
-      );
-    }
-
-    default:
-      throw Error("Unknown work request code");
+function verifySignatureSetsMaybeBatch(workReq: BlsWorkReq): boolean {
+  if (workReq.sets.length === 0) {
+    throw Error("Empty signature set");
   }
+
+  if (workReq.sets.length >= MIN_SET_COUNT_TO_BATCH) {
+    return bls.Signature.verifyMultipleSignatures(
+      workReq.sets.map((s) => ({
+        publicKey: bls.PublicKey.fromBytes(s.publicKey, CoordType.affine),
+        message: s.message,
+        signature: bls.Signature.fromBytes(s.signature, CoordType.affine, workReq.validateSignature),
+      }))
+    );
+  }
+
+  // If too few signature sets verify them without batching
+  return workReq.sets.every((set) => {
+    const pk = bls.PublicKey.fromBytes(set.publicKey, CoordType.affine);
+    const sig = bls.Signature.fromBytes(set.signature, CoordType.affine, workReq.validateSignature);
+    return sig.verify(pk, set.message);
+  });
 }

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -83,7 +83,7 @@ export class BeaconChain implements IBeaconChain {
     this.emitter = new ChainEventEmitter();
     this.internalEmitter = new ChainEventEmitter();
 
-    this.bls = new BlsVerifier(logger, this.abortController.signal);
+    this.bls = new BlsVerifier({logger, metrics, signal: this.abortController.signal});
 
     this.clock = new LocalClock({
       config: this.config,

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -83,7 +83,7 @@ export class BeaconChain implements IBeaconChain {
     this.emitter = new ChainEventEmitter();
     this.internalEmitter = new ChainEventEmitter();
 
-    this.bls = new BlsVerifier(logger);
+    this.bls = new BlsVerifier(logger, this.abortController.signal);
 
     this.clock = new LocalClock({
       config: this.config,

--- a/packages/lodestar/src/chain/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/aggregateAndProof.ts
@@ -130,7 +130,7 @@ export async function validateAggregateAttestation(
     fast.getIndexedAttestationSignatureSet(attestationTargetState, indexedAttestation),
   ];
 
-  if (!(await chain.bls.verifySignatureSetsBatch(signatureSets))) {
+  if (!(await chain.bls.verifySignatureSets(signatureSets))) {
     throw new AttestationError({
       code: AttestationErrorCode.INVALID_SIGNATURE,
       job: attestationJob,

--- a/packages/lodestar/src/chain/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/aggregateAndProof.ts
@@ -127,10 +127,7 @@ export async function validateAggregateAttestation(
   const signatureSets = [
     getSelectionProofSignatureSet(config, attestationTargetState, slot, aggregator, aggregateAndProof),
     getAggregateAndProofSignatureSet(config, attestationTargetState, epoch, aggregator, aggregateAndProof),
-    fast.getIndexedAttestationSignatureSet(
-      attestationTargetState as CachedBeaconState<allForks.BeaconState>,
-      indexedAttestation
-    ),
+    fast.getIndexedAttestationSignatureSet(attestationTargetState, indexedAttestation),
   ];
 
   if (!(await chain.bls.verifySignatureSetsBatch(signatureSets))) {
@@ -143,13 +140,7 @@ export async function validateAggregateAttestation(
   // TODO: once we have pool, check if aggregate block is seen and has target as ancestor
 
   // verifySignature = false, verified in batch above
-  if (
-    !phase0.fast.isValidIndexedAttestation(
-      attestationTargetState as CachedBeaconState<allForks.BeaconState>,
-      indexedAttestation,
-      false
-    )
-  ) {
+  if (!phase0.fast.isValidIndexedAttestation(attestationTargetState, indexedAttestation, false)) {
     throw new AttestationError({
       code: AttestationErrorCode.INVALID_INDEXED_ATTESTATION,
       job: attestationJob,

--- a/packages/lodestar/src/chain/validation/attestation.ts
+++ b/packages/lodestar/src/chain/validation/attestation.ts
@@ -100,7 +100,7 @@ export async function validateGossipAttestation(
   // Do verify signature
   if (!attestationJob.validSignature) {
     const signatureSet = fast.getIndexedAttestationSignatureSet(attestationTargetState, indexedAttestation);
-    if (!(await chain.bls.verifySignatureSetsBatch([signatureSet]))) {
+    if (!(await chain.bls.verifySignatureSets([signatureSet]))) {
       throw new AttestationError({
         code: AttestationErrorCode.INVALID_SIGNATURE,
         job: attestationJob,

--- a/packages/lodestar/src/chain/validation/attesterSlashing.ts
+++ b/packages/lodestar/src/chain/validation/attesterSlashing.ts
@@ -34,7 +34,7 @@ export async function validateGossipAttesterSlashing(
   }
 
   const signatureSets = fast.getAttesterSlashingSignatureSets(state, attesterSlashing);
-  if (!(await chain.bls.verifySignatureSetsBatch(signatureSets))) {
+  if (!(await chain.bls.verifySignatureSets(signatureSets))) {
     throw new AttesterSlashingError({
       code: AttesterSlashingErrorCode.INVALID_SLASHING,
     });

--- a/packages/lodestar/src/chain/validation/block.ts
+++ b/packages/lodestar/src/chain/validation/block.ts
@@ -1,8 +1,7 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBeaconChain, IBlockJob} from "..";
 import {IBeaconDb} from "../../db";
-import {allForks} from "@chainsafe/lodestar-types";
-import {CachedBeaconState, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {fast, phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {BlockError, BlockErrorCode} from "../errors";
 
@@ -65,7 +64,8 @@ export async function validateGossipBlock(
     });
   }
 
-  if (!fast.verifyProposerSignature(blockState as CachedBeaconState<allForks.BeaconState>, block)) {
+  const signatureSet = fast.getProposerSignatureSet(blockState, block);
+  if (!(await chain.bls.verifySignatureSetsBatch([signatureSet]))) {
     throw new BlockError({
       code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID,
       job: blockJob,

--- a/packages/lodestar/src/chain/validation/block.ts
+++ b/packages/lodestar/src/chain/validation/block.ts
@@ -65,7 +65,7 @@ export async function validateGossipBlock(
   }
 
   const signatureSet = fast.getProposerSignatureSet(blockState, block);
-  if (!(await chain.bls.verifySignatureSetsBatch([signatureSet]))) {
+  if (!(await chain.bls.verifySignatureSets([signatureSet]))) {
     throw new BlockError({
       code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID,
       job: blockJob,

--- a/packages/lodestar/src/chain/validation/proposerSlashing.ts
+++ b/packages/lodestar/src/chain/validation/proposerSlashing.ts
@@ -1,4 +1,4 @@
-import {isValidProposerSlashing} from "@chainsafe/lodestar-beacon-state-transition";
+import {isValidProposerSlashing, fast} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {phase0} from "@chainsafe/lodestar-types";
 import {IBeaconChain} from "..";
@@ -18,7 +18,16 @@ export async function validateGossipProposerSlashing(
   }
 
   const state = chain.getHeadState();
-  if (!isValidProposerSlashing(config, state, proposerSlashing)) {
+
+  // verifySignature = false, verified in batch below
+  if (!isValidProposerSlashing(config, state, proposerSlashing, false)) {
+    throw new ProposerSlashingError({
+      code: ProposerSlashingErrorCode.INVALID_SLASHING,
+    });
+  }
+
+  const signatureSets = fast.getProposerSlashingSignatureSets(state, proposerSlashing);
+  if (!(await chain.bls.verifySignatureSetsBatch(signatureSets))) {
     throw new ProposerSlashingError({
       code: ProposerSlashingErrorCode.INVALID_SLASHING,
     });

--- a/packages/lodestar/src/chain/validation/proposerSlashing.ts
+++ b/packages/lodestar/src/chain/validation/proposerSlashing.ts
@@ -27,7 +27,7 @@ export async function validateGossipProposerSlashing(
   }
 
   const signatureSets = fast.getProposerSlashingSignatureSets(state, proposerSlashing);
-  if (!(await chain.bls.verifySignatureSetsBatch(signatureSets))) {
+  if (!(await chain.bls.verifySignatureSets(signatureSets))) {
     throw new ProposerSlashingError({
       code: ProposerSlashingErrorCode.INVALID_SLASHING,
     });

--- a/packages/lodestar/src/chain/validation/voluntaryExit.ts
+++ b/packages/lodestar/src/chain/validation/voluntaryExit.ts
@@ -30,7 +30,7 @@ export async function validateGossipVoluntaryExit(
   }
 
   const signatureSet = fast.getVoluntaryExitSignatureSet(state, voluntaryExit);
-  if (!(await chain.bls.verifySignatureSetsBatch([signatureSet]))) {
+  if (!(await chain.bls.verifySignatureSets([signatureSet]))) {
     throw new VoluntaryExitError({
       code: VoluntaryExitErrorCode.INVALID_EXIT,
     });

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -105,5 +105,29 @@ export function createLodestarMetrics(register: RegistryMetricCreator, metadata:
       // Request times range between 1ms to 100ms in normal conditions. Can get to 1-5 seconds if overloaded
       buckets: [0.01, 0.1, 0.5, 1, 5, 10],
     }),
+
+    // BLS verifier thread pool and queue
+
+    blsThreadPoolSuccessJobsSignatureSetsCount: register.gauge({
+      name: "lodestar_bls_thread_pool_success_jobs_signature_sets_count",
+      help: "Count of total verified signature sets",
+    }),
+    blsThreadPoolSuccessJobsWorkerTime: register.gauge({
+      name: "lodestar_bls_thread_pool_success_time_seconds_sum",
+      help: "Total time spent verifying signature sets measured on the worker",
+    }),
+    blsThreadPoolJobWaitTime: register.histogram({
+      name: "lodestar_bls_thread_pool_queue_job_wait_time_seconds",
+      help: "Time from job added to the queue to starting the job in seconds",
+      buckets: [0.1, 1, 10],
+    }),
+    blsThreadPoolTotalJobsStarted: register.gauge({
+      name: "lodestar_bls_thread_pool_jobs_started_total",
+      help: "Count of total jobs started in bls thread pool, jobs include +1 signature sets",
+    }),
+    blsThreadPoolTotalJobsGroupsStarted: register.gauge({
+      name: "lodestar_bls_thread_pool_job_groups_started_total",
+      help: "Count of total jobs groups started in bls thread pool, job groups include +1 jobs",
+    }),
   };
 }

--- a/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
@@ -30,7 +30,7 @@ describe("chain / bls / multithread queue", function () {
       });
     }
 
-    const pool = new BlsMultiThreadWorkerPool(logger, "blst-native", controller.signal);
+    const pool = new BlsMultiThreadWorkerPool("blst-native", {logger, signal: controller.signal});
     const isValidArr = await Promise.all(
       Array.from({length: 8}, (i) => i).map(() => pool.verifySignatureSets(sets, true))
     );

--- a/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
@@ -1,6 +1,7 @@
 import {expect} from "chai";
+import {AbortController} from "abort-controller";
 import {bls, init, PublicKey} from "@chainsafe/bls";
-import {BlsMultiThreadNaive} from "../../../../src/chain/bls/multithread";
+import {BlsMultiThreadWorkerPool} from "../../../../src/chain/bls/multithread";
 import {testLogger} from "../../../utils/logger";
 
 describe("chain / bls / multithread queue", function () {
@@ -10,6 +11,10 @@ describe("chain / bls / multithread queue", function () {
   before("Init BLS", async () => {
     await init("blst-native");
   });
+
+  let controller: AbortController;
+  beforeEach(() => (controller = new AbortController()));
+  afterEach(() => controller.abort());
 
   it("Should verify some signatures", async () => {
     const sets: {publicKey: PublicKey; message: Uint8Array; signature: Uint8Array}[] = [];
@@ -25,9 +30,9 @@ describe("chain / bls / multithread queue", function () {
       });
     }
 
-    const pool = new BlsMultiThreadNaive(logger, "blst-native");
+    const pool = new BlsMultiThreadWorkerPool(logger, "blst-native", controller.signal);
     const isValidArr = await Promise.all(
-      Array.from({length: 8}, (i) => i).map(() => pool.verifyMultipleAggregateSignatures(sets))
+      Array.from({length: 8}, (i) => i).map(() => pool.verifySignatureSets(sets, true))
     );
     for (const [i, isValid] of isValidArr.entries()) {
       expect(isValid).to.equal(true, `sig set ${i} returned invalid`);

--- a/packages/lodestar/test/unit/chain/validation/aggregateAndProof.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/aggregateAndProof.test.ts
@@ -30,7 +30,7 @@ describe("gossip aggregate and proof test", function () {
   let db: StubbedBeaconDb;
   let isAggregatorStub: SinonStubFn<typeof validatorUtils["isAggregatorFromCommitteeLength"]>;
   let isValidIndexedAttestationStub: SinonStubFn<typeof indexedAttUtils["isValidIndexedAttestation"]>;
-  // This util it not relevant for testing since only the result of verifySignatureSetsBatch() matters
+  // This util it not relevant for testing since only the result of verifySignatureSets() matters
   const getIndexedAttestationSignatureSet: typeof indexedAttSigSet["getIndexedAttestationSignatureSet"] = () =>
     ({} as ISignatureSet);
 
@@ -67,7 +67,7 @@ describe("gossip aggregate and proof test", function () {
     chain.clock = sinon.createStubInstance(LocalClock);
     sinon.stub(chain.clock, "currentSlot").get(() => 0);
     regen = chain.regen = sinon.createStubInstance(StateRegenerator);
-    chain.bls = {verifySignatureSetsBatch: async () => true};
+    chain.bls = {verifySignatureSets: async () => true};
     db.badBlock.has.resolves(false);
     db.seenAttestationCache.hasAggregateAndProof.returns(false);
     isAggregatorStub = sinon.stub(validatorUtils, "isAggregatorFromCommitteeLength");
@@ -280,7 +280,7 @@ describe("gossip aggregate and proof test", function () {
       isAggregatorFromCommitteeLength: sinon.stub().returns(true),
       isValidIndexedAttestation: sinon.stub().returns(true),
     });
-    chain.bls.verifySignatureSetsBatch = async () => false;
+    chain.bls.verifySignatureSets = async () => false;
 
     const item = generateSignedAggregateAndProof({
       aggregate: {
@@ -310,7 +310,7 @@ describe("gossip aggregate and proof test", function () {
       isAggregatorFromCommitteeLength: sinon.stub().returns(true),
       isValidIndexedAttestation: sinon.stub().returns(true),
     });
-    chain.bls.verifySignatureSetsBatch = async () => false;
+    chain.bls.verifySignatureSets = async () => false;
 
     const item = generateSignedAggregateAndProof({
       aggregate: {
@@ -340,7 +340,7 @@ describe("gossip aggregate and proof test", function () {
       isAggregatorFromCommitteeLength: sinon.stub().returns(true),
       isValidIndexedAttestation: sinon.stub().returns(false),
     });
-    chain.bls.verifySignatureSetsBatch = async () => true;
+    chain.bls.verifySignatureSets = async () => true;
 
     const item = generateSignedAggregateAndProof({
       aggregate: {
@@ -370,7 +370,7 @@ describe("gossip aggregate and proof test", function () {
       isAggregatorFromCommitteeLength: sinon.stub().returns(true),
       isValidIndexedAttestation: sinon.stub().returns(true),
     });
-    chain.bls.verifySignatureSetsBatch = async () => true;
+    chain.bls.verifySignatureSets = async () => true;
 
     const item = generateSignedAggregateAndProof({
       aggregate: {

--- a/packages/lodestar/test/unit/chain/validation/attestation.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/attestation.test.ts
@@ -21,7 +21,7 @@ import {AttestationErrorCode} from "../../../../src/chain/errors";
 import {Gwei} from "@chainsafe/lodestar-types";
 import {fast} from "@chainsafe/lodestar-beacon-state-transition";
 import {SinonStubFn} from "../../../utils/types";
-import {AttestationError} from "../../../../src/chain/errors";
+import {expectRejectedWithLodestarError} from "../../../utils/errors";
 
 describe("gossip attestation validation", function () {
   let chain: SinonStubbedInstance<IBeaconChain>;
@@ -40,6 +40,7 @@ describe("gossip attestation validation", function () {
     sinon.stub(chain.clock, "currentSlot").get(() => 0);
     forkChoice = chain.forkChoice = sinon.createStubInstance(ForkChoice);
     regen = chain.regen = sinon.createStubInstance(StateRegenerator);
+    chain.bls = {verifySignatureSets: async () => true};
     db = new StubbedBeaconDb(sinon, config);
     db.badBlock.has.resolves(false);
     computeAttestationSubnetStub = sinon.stub(attestationUtils, "computeSubnetForAttestation");
@@ -60,63 +61,31 @@ describe("gossip attestation validation", function () {
 
   it("should throw error - attestation has empty aggregation bits", async function () {
     const attestation = generateAttestation({aggregationBits: ([] as boolean[]) as BitList});
-    try {
-      await validateGossipAttestation(
-        config,
-        chain,
-        db,
-        {
-          attestation,
-          validSignature: false,
-        },
-        0
-      );
-    } catch (error) {
-      expect((error as AttestationError).type).to.have.property(
-        "code",
-        AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
-      );
-    }
+
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0),
+      AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
+    );
   });
 
   it("should throw error - attestation has more aggregation bits", async function () {
     const attestation = generateAttestation({aggregationBits: [true, true] as BitList});
-    try {
-      await validateGossipAttestation(
-        config,
-        chain,
-        db,
-        {
-          attestation,
-          validSignature: false,
-        },
-        0
-      );
-    } catch (error) {
-      expect((error as AttestationError).type).to.have.property(
-        "code",
-        AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
-      );
-    }
+
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0),
+      AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
+    );
   });
 
   it("should throw error - attestation block is invalid", async function () {
     const attestation = generateAttestation({aggregationBits: [true] as BitList});
     db.badBlock.has.resolves(true);
-    try {
-      await validateGossipAttestation(
-        config,
-        chain,
-        db,
-        {
-          attestation,
-          validSignature: false,
-        },
-        0
-      );
-    } catch (error) {
-      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.KNOWN_BAD_BLOCK);
-    }
+
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0),
+      AttestationErrorCode.KNOWN_BAD_BLOCK
+    );
+
     expect(db.badBlock.has.calledOnceWith(attestation.data.beaconBlockRoot.valueOf() as Uint8Array)).to.be.true;
   });
 
@@ -127,20 +96,11 @@ describe("gossip attestation validation", function () {
         slot: getCurrentSlot(config, chain.getGenesisTime()) - ATTESTATION_PROPAGATION_SLOT_RANGE - 1,
       },
     });
-    try {
-      await validateGossipAttestation(
-        config,
-        chain,
-        db,
-        {
-          attestation,
-          validSignature: false,
-        },
-        0
-      );
-    } catch (error) {
-      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.PAST_SLOT);
-    }
+
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0),
+      AttestationErrorCode.PAST_SLOT
+    );
   });
 
   it("should throw error - future attestation", async function () {
@@ -150,20 +110,11 @@ describe("gossip attestation validation", function () {
         slot: getCurrentSlot(config, chain.getGenesisTime()) + 5,
       },
     });
-    try {
-      await validateGossipAttestation(
-        config,
-        chain,
-        db,
-        {
-          attestation,
-          validSignature: false,
-        },
-        0
-      );
-    } catch (error) {
-      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.FUTURE_SLOT);
-    }
+
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0),
+      AttestationErrorCode.FUTURE_SLOT
+    );
   });
 
   it("should throw error - validator already attested to target epoch", async function () {
@@ -171,20 +122,12 @@ describe("gossip attestation validation", function () {
       aggregationBits: [true] as BitList,
     });
     db.seenAttestationCache.hasCommitteeAttestation.returns(true);
-    try {
-      await validateGossipAttestation(
-        config,
-        chain,
-        db,
-        {
-          attestation,
-          validSignature: false,
-        },
-        0
-      );
-    } catch (error) {
-      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.ATTESTATION_ALREADY_KNOWN);
-    }
+
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0),
+      AttestationErrorCode.ATTESTATION_ALREADY_KNOWN
+    );
+
     expect(chain.receiveAttestation.called).to.be.false;
     expect(db.seenAttestationCache.hasCommitteeAttestation.calledOnceWith(attestation)).to.be.true;
   });
@@ -195,20 +138,12 @@ describe("gossip attestation validation", function () {
     });
     db.seenAttestationCache.hasCommitteeAttestation.returns(false);
     forkChoice.hasBlock.returns(false);
-    try {
-      await validateGossipAttestation(
-        config,
-        chain,
-        db,
-        {
-          attestation,
-          validSignature: false,
-        },
-        0
-      );
-    } catch (error) {
-      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT);
-    }
+
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0),
+      AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT
+    );
+
     expect(forkChoice.hasBlock.calledOnceWith(attestation.data.beaconBlockRoot)).to.be.true;
   });
 
@@ -219,23 +154,12 @@ describe("gossip attestation validation", function () {
     db.seenAttestationCache.hasCommitteeAttestation.returns(false);
     forkChoice.hasBlock.returns(true);
     regen.getCheckpointState.throws();
-    try {
-      await validateGossipAttestation(
-        config,
-        chain,
-        db,
-        {
-          attestation,
-          validSignature: false,
-        },
-        0
-      );
-    } catch (error) {
-      expect((error as AttestationError).type).to.have.property(
-        "code",
-        AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE
-      );
-    }
+
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0),
+      AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE
+    );
+
     expect(regen.getCheckpointState.calledOnceWith(attestation.data.target)).to.be.true;
   });
 
@@ -248,20 +172,12 @@ describe("gossip attestation validation", function () {
     const attestationTargetState = generateCachedState();
     regen.getCheckpointState.resolves(attestationTargetState);
     computeAttestationSubnetStub.returns(5);
-    try {
-      await validateGossipAttestation(
-        config,
-        chain,
-        db,
-        {
-          attestation,
-          validSignature: false,
-        },
-        0
-      );
-    } catch (error) {
-      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.INVALID_SUBNET_ID);
-    }
+
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0),
+      AttestationErrorCode.INVALID_SUBNET_ID
+    );
+
     expect(chain.receiveAttestation.called).to.be.false;
     expect(computeAttestationSubnetStub.calledOnceWith(config, attestationTargetState, attestation)).to.be.true;
   });
@@ -277,20 +193,12 @@ describe("gossip attestation validation", function () {
     regen.getCheckpointState.resolves(attestationTargetState);
     computeAttestationSubnetStub.returns(0);
     isValidIndexedAttestationStub.returns(false);
-    try {
-      await validateGossipAttestation(
-        config,
-        chain,
-        db,
-        {
-          attestation,
-          validSignature: false,
-        },
-        0
-      );
-    } catch (error) {
-      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.INVALID_SIGNATURE);
-    }
+
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0),
+      AttestationErrorCode.INVALID_INDEXED_ATTESTATION
+    );
+
     expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
   });
@@ -312,23 +220,12 @@ describe("gossip attestation validation", function () {
     regen.getCheckpointState.resolves(attestationTargetState);
     computeAttestationSubnetStub.returns(0);
     isValidIndexedAttestationStub.returns(true);
-    try {
-      await validateGossipAttestation(
-        config,
-        chain,
-        db,
-        {
-          attestation,
-          validSignature: false,
-        },
-        0
-      );
-    } catch (error) {
-      expect((error as AttestationError).type).to.have.property(
-        "code",
-        AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE
-      );
-    }
+
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0),
+      AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE
+    );
+
     expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
   });
@@ -356,23 +253,12 @@ describe("gossip attestation validation", function () {
     regen.getCheckpointState.resolves(attestationTargetState);
     computeAttestationSubnetStub.returns(0);
     isValidIndexedAttestationStub.returns(true);
-    try {
-      await validateGossipAttestation(
-        config,
-        chain,
-        db,
-        {
-          attestation,
-          validSignature: false,
-        },
-        0
-      );
-    } catch (error) {
-      expect((error as AttestationError).type).to.have.property(
-        "code",
-        AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE
-      );
-    }
+
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0),
+      AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE
+    );
+
     expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
   });
@@ -394,23 +280,12 @@ describe("gossip attestation validation", function () {
     regen.getCheckpointState.resolves(attestationTargetState);
     computeAttestationSubnetStub.returns(0);
     isValidIndexedAttestationStub.returns(true);
-    try {
-      await validateGossipAttestation(
-        config,
-        chain,
-        db,
-        {
-          attestation,
-          validSignature: false,
-        },
-        0
-      );
-    } catch (error) {
-      expect((error as AttestationError).type).to.have.property(
-        "code",
-        AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS
-      );
-    }
+
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0),
+      AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS
+    );
+
     expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
   });
@@ -435,20 +310,11 @@ describe("gossip attestation validation", function () {
     regen.getCheckpointState.resolves(attestationTargetState);
     computeAttestationSubnetStub.returns(0);
     isValidIndexedAttestationStub.returns(true);
-    try {
-      await validateGossipAttestation(
-        config,
-        chain,
-        db,
-        {
-          attestation,
-          validSignature: false,
-        },
-        0
-      );
-    } catch (error) {
-      expect((error as AttestationError).type).to.have.property("code", AttestationErrorCode.BAD_TARGET_EPOCH);
-    }
+
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0),
+      AttestationErrorCode.BAD_TARGET_EPOCH
+    );
   });
 
   it("should throw error - target block is not an ancestor of the block named in the LMD vote", async function () {
@@ -498,23 +364,11 @@ describe("gossip attestation validation", function () {
     regen.getCheckpointState.resolves(attestationTargetState);
     computeAttestationSubnetStub.returns(0);
     isValidIndexedAttestationStub.returns(true);
-    try {
-      await validateGossipAttestation(
-        config,
-        chain,
-        db,
-        {
-          attestation,
-          validSignature: false,
-        },
-        0
-      );
-    } catch (error) {
-      expect((error as AttestationError).type).to.have.property(
-        "code",
-        AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK
-      );
-    }
+
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0),
+      AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK
+    );
   });
 
   it("should throw error - current finalized_checkpoint not is an ancestor of the block defined by attestation.data.beacon_block_root", async function () {
@@ -539,23 +393,11 @@ describe("gossip attestation validation", function () {
     regen.getCheckpointState.resolves(attestationTargetState);
     computeAttestationSubnetStub.returns(0);
     isValidIndexedAttestationStub.returns(true);
-    try {
-      await validateGossipAttestation(
-        config,
-        chain,
-        db,
-        {
-          attestation,
-          validSignature: false,
-        },
-        0
-      );
-    } catch (error) {
-      expect((error as AttestationError).type).to.have.property(
-        "code",
-        AttestationErrorCode.FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT
-      );
-    }
+
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0),
+      AttestationErrorCode.FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT
+    );
   });
 
   it("should accept", async function () {
@@ -581,16 +423,9 @@ describe("gossip attestation validation", function () {
     forkChoiceStub.hasBlock.returns(true);
     forkChoiceStub.isDescendant.returns(true);
     forkChoiceStub.isDescendantOfFinalized.returns(true);
-    const validationTest = await validateGossipAttestation(
-      config,
-      chain,
-      db,
-      {
-        attestation,
-        validSignature: false,
-      },
-      0
-    );
+
+    const validationTest = await validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0);
+
     expect(validationTest).to.not.throw;
     expect(chain.receiveAttestation.called).to.be.false;
     expect(db.seenAttestationCache.addCommitteeAttestation.calledOnce).to.be.true;


### PR DESCRIPTION
### Motivation

Some weeks ago we landed a naive version of a worker thread pool to verify BLS signatures. It did the essential well, to help the node breathe and survive in Prater. But some obvious work can be done to improve the current impl.

### Description

**Extend usage**

Use the BLS worker pool for **all** gossip validation, not only attestations.

**Reduce latency cost**

Communication between the main thread and workers has significant latency, similar to the cost of a single BLS sig verification. To reduce the impact of this latency in the throughput of validation I've update the pool to allow batching work. It will send packages of multiple groups of signature sets to be verified individually but sending the whole package once. This splits the latency cost between multiple operation. However this strategy only works if all workers are busy so the queue can accumulate work.

**Add metrics**

By using our own custom Thread Pool instead of `threads` implementation it's good to add some metrics to track:
- Average signature verification time. Is blst as efficient as expected in production?
- Job wait time. Does the queue structure delay signature verification significantly?
- Job package size. Does the "reduce latency cost" strategy above work? Are work packages big or too small?