### PR TITLE
Raise default memory limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ WORKDIR /usr/app
 COPY --from=build /usr/app .
 ENV DOCKER_LODESTAR_GIT_DATA_FILEPATH /usr/app/.git-data.json
 
-ENTRYPOINT ["node", "./packages/cli/bin/lodestar"]
+ENTRYPOINT ["node", "--max-old-space-size=8192", "./packages/cli/bin/lodestar"]

--- a/default.env
+++ b/default.env
@@ -1,3 +1,8 @@
 # To specify a specific network (defaults to mainnet) set this value.
 # Allowed values are: mainnet and pyrmont (others may work, but are deprecated)
 LODESTAR_NETWORK=mainnet
+
+# NodeJS applications have a default memory limit of 2.5GB.
+# This limit is bit tight for a Prater node, it is recommended to raise the limit
+# since memory may spike during certain network conditions.
+NODE_OPTIONS=--max_old_space_size=8192

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:spec-min": "lerna run test:spec-min --no-bail",
     "test:spec-fast": "lerna run test:spec-fast --no-bail",
     "test:spec-main": "lerna run test:spec-main --no-bail",
-    "cli": "node --trace-deprecation ./packages/cli/bin/lodestar",
+    "cli": "node --trace-deprecation --max-old-space-size=8192 ./packages/cli/bin/lodestar",
     "publish": "lerna publish from-package --yes --no-verify-access",
     "release": "lerna version --no-push --sign-git-commit",
     "postrelease": "git tag -d $(git describe --abbrev=0)"


### PR DESCRIPTION
**Motivation**

NodeJS applications have a default memory limit of 2.5GB. This limit is bit tight for a Prater node, it is recommended to raise the limit since memory may spike during certain network conditions.

We are now focusing on Altair + the Lightclient hackaton. This PR would give us some time to avoid out of memory errors during this time. In about a month we should focus again on reducing memory spikes. Our node seems to not have any memory leaks, so I believe raising the limit is safe.

