### PR TITLE
Use enum for ForkName

### DIFF
--- a/packages/beacon-state-transition/src/fast/stateTransition.ts
+++ b/packages/beacon-state-transition/src/fast/stateTransition.ts
@@ -1,3 +1,4 @@
+import {ForkName} from "@chainsafe/lodestar-config";
 import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {processBlock, processSlots} from "../phase0/fast";
 import {verifyProposerSignature} from "./signatureSets";
@@ -27,7 +28,7 @@ export function fastStateTransition(
 
   // process slots (including those with no blocks) since block
   switch (preFork) {
-    case "phase0":
+    case ForkName.phase0:
       processSlots(postState as CachedBeaconState<phase0.BeaconState>, block.slot);
       break;
     default:
@@ -46,7 +47,7 @@ export function fastStateTransition(
 
   // process block
   switch (blockFork) {
-    case "phase0":
+    case ForkName.phase0:
       processBlock(postState as CachedBeaconState<phase0.BeaconState>, block as phase0.BeaconBlock, verifySignatures);
       break;
     default:

--- a/packages/beacon-state-transition/src/fast/util/epochProcess.ts
+++ b/packages/beacon-state-transition/src/fast/util/epochProcess.ts
@@ -1,3 +1,4 @@
+import {ForkName} from "@chainsafe/lodestar-config";
 import {List, readonlyValues} from "@chainsafe/ssz";
 import {Epoch, ValidatorIndex, Gwei, phase0, allForks} from "@chainsafe/lodestar-types";
 import {intDiv} from "@chainsafe/lodestar-utils";
@@ -230,7 +231,7 @@ export function prepareEpochProcessState<T extends allForks.BeaconState>(state: 
       }
     }
   };
-  if (forkName === "phase0") {
+  if (forkName === ForkName.phase0) {
     statusProcessEpoch(
       out.statuses,
       ((state as unknown) as CachedBeaconState<phase0.BeaconState>).previousEpochAttestations,

--- a/packages/beacon-state-transition/src/util/fork.ts
+++ b/packages/beacon-state-transition/src/util/fork.ts
@@ -1,5 +1,5 @@
 import {Version, Root, phase0, ForkDigest} from "@chainsafe/lodestar-types";
-import {IBeaconConfig, IForkName} from "@chainsafe/lodestar-config";
+import {IBeaconConfig, ForkName} from "@chainsafe/lodestar-config";
 import {byteArrayEquals, toHexString} from "@chainsafe/ssz";
 
 /**
@@ -26,7 +26,7 @@ export function computeForkNameFromForkDigest(
   config: IBeaconConfig,
   genesisValidatorsRoot: Root,
   forkDigest: ForkDigest
-): IForkName {
+): ForkName {
   for (const {name, version} of Object.values(config.getForkInfoRecord())) {
     if (
       byteArrayEquals(forkDigest as Uint8Array, computeForkDigest(config, version, genesisValidatorsRoot) as Uint8Array)

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,7 +1,7 @@
 import {GENESIS_SLOT, IBeaconParams} from "@chainsafe/lodestar-params";
 import {createIBeaconSSZTypes, IAllForksSSZTypes, Slot, Version} from "@chainsafe/lodestar-types";
 
-import {IBeaconConfig, IForkInfo, IForkName} from "./interface";
+import {IBeaconConfig, IForkInfo, ForkName} from "./interface";
 
 export * from "./interface";
 
@@ -10,25 +10,25 @@ export function createIBeaconConfig(params: IBeaconParams): IBeaconConfig {
   return {
     params,
     types,
-    getForkInfoRecord(): Record<IForkName, IForkInfo> {
+    getForkInfoRecord(): Record<ForkName, IForkInfo> {
       return {
         phase0: {
-          name: "phase0",
+          name: ForkName.phase0,
           slot: GENESIS_SLOT,
           version: params.GENESIS_FORK_VERSION,
         },
         altair: {
-          name: "altair",
+          name: ForkName.altair,
           slot: params.ALTAIR_FORK_SLOT,
           version: params.ALTAIR_FORK_VERSION,
         },
       };
     },
-    getForkName(slot: Slot): IForkName {
+    getForkName(slot: Slot): ForkName {
       if (slot < params.ALTAIR_FORK_SLOT) {
-        return "phase0";
+        return ForkName.phase0;
       } else {
-        return "altair";
+        return ForkName.altair;
       }
     },
     getForkVersion(slot: Slot): Version {

--- a/packages/config/src/interface.ts
+++ b/packages/config/src/interface.ts
@@ -1,10 +1,13 @@
 import {IBeaconParams} from "@chainsafe/lodestar-params";
 import {IAllForksSSZTypes, IBeaconSSZTypes, Slot, Version} from "@chainsafe/lodestar-types";
 
-export type IForkName = "phase0" | "altair";
+export enum ForkName {
+  phase0 = "phase0",
+  altair = "altair",
+}
 
 export interface IForkInfo {
-  name: IForkName;
+  name: ForkName;
   slot: Slot;
   version: Version;
 }
@@ -12,11 +15,11 @@ export interface IForkInfo {
 export interface IBeaconConfig {
   params: IBeaconParams;
   types: IBeaconSSZTypes;
-  getForkInfoRecord(): Record<IForkName, IForkInfo>;
+  getForkInfoRecord(): Record<ForkName, IForkInfo>;
   /**
    * Get the hard-fork name at a given slot
    */
-  getForkName(slot: Slot): IForkName;
+  getForkName(slot: Slot): ForkName;
   /**
    * Get the hard-fork version at a given slot
    */

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -10,7 +10,7 @@ import {
   computeStartSlotAtEpoch,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
-import {IBeaconConfig, IForkName} from "@chainsafe/lodestar-config";
+import {IBeaconConfig, ForkName} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {allForks, ForkDigest, Number64, Root, Slot} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
@@ -262,7 +262,7 @@ export class BeaconChain implements IBeaconChain {
     return computeForkDigest(this.config, state.fork.currentVersion, this.genesisValidatorsRoot);
   }
 
-  getForkName(): IForkName {
+  getForkName(): ForkName {
     return computeForkNameFromForkDigest(this.config, this.genesisValidatorsRoot, this.getForkDigest());
   }
 

--- a/packages/lodestar/src/chain/emitter.ts
+++ b/packages/lodestar/src/chain/emitter.ts
@@ -3,7 +3,7 @@ import StrictEventEmitter from "strict-event-emitter-types";
 
 import {phase0, Epoch, Slot, Version, allForks} from "@chainsafe/lodestar-types";
 import {IBlockSummary} from "@chainsafe/lodestar-fork-choice";
-import {IForkName} from "@chainsafe/lodestar-config";
+import {ForkName} from "@chainsafe/lodestar-config";
 import {IBlockJob} from "./interface";
 import {AttestationError, BlockError} from "./errors";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
@@ -118,7 +118,7 @@ export interface IChainEvents {
   [ChainEvent.checkpoint]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<allForks.BeaconState>) => void;
   [ChainEvent.justified]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<allForks.BeaconState>) => void;
   [ChainEvent.finalized]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<allForks.BeaconState>) => void;
-  [ChainEvent.forkVersion]: (version: Version, fork: IForkName) => void;
+  [ChainEvent.forkVersion]: (version: Version, fork: ForkName) => void;
 
   [ChainEvent.clockSlot]: (slot: Slot) => void;
   [ChainEvent.clockEpoch]: (epoch: Epoch) => void;

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -1,5 +1,5 @@
 import {allForks, Number64, Root, Slot} from "@chainsafe/lodestar-types";
-import {IForkName} from "@chainsafe/lodestar-config";
+import {ForkName} from "@chainsafe/lodestar-config";
 import {phase0, CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 
@@ -75,9 +75,9 @@ export interface IBeaconChain {
    */
   getForkDigest(): phase0.ForkDigest;
   /**
-   * Get the IForkName from the head state
+   * Get the ForkName from the head state
    */
-  getForkName(): IForkName;
+  getForkName(): ForkName;
   /**
    * Get ENRForkID from the head state
    */

--- a/packages/lodestar/src/db/repositories/block/index.ts
+++ b/packages/lodestar/src/db/repositories/block/index.ts
@@ -1,5 +1,5 @@
 import {ContainerType} from "@chainsafe/ssz";
-import {IBeaconConfig, IForkName} from "@chainsafe/lodestar-config";
+import {IBeaconConfig, ForkName} from "@chainsafe/lodestar-config";
 import {Bucket, IDatabaseController, Repository} from "@chainsafe/lodestar-db";
 import {allForks, Slot} from "@chainsafe/lodestar-types";
 import {GenericBlockRepository} from "./abstract";
@@ -13,14 +13,14 @@ export class BlockRepository {
   protected config: IBeaconConfig;
   protected db: IDatabaseController<Buffer, Buffer>;
 
-  protected repositories: Map<IForkName, Repository<Uint8Array, allForks.SignedBeaconBlock>>;
+  protected repositories: Map<ForkName, Repository<Uint8Array, allForks.SignedBeaconBlock>>;
 
   constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
     this.config = config;
     this.db = db;
     this.repositories = new Map([
       [
-        "phase0",
+        ForkName.phase0,
         new GenericBlockRepository(
           config,
           db,
@@ -29,7 +29,7 @@ export class BlockRepository {
         ),
       ],
       [
-        "altair",
+        ForkName.altair,
         new GenericBlockRepository(
           config,
           db,
@@ -61,7 +61,7 @@ export class BlockRepository {
   }
 
   async batchDelete(ids: {root: Uint8Array; slot: Slot}[]): Promise<void> {
-    const idsByFork = {} as Record<IForkName, Uint8Array[]>;
+    const idsByFork = {} as Record<ForkName, Uint8Array[]>;
     for (const {root, slot} of ids) {
       const forkName = this.config.getForkName(slot);
       if (!idsByFork[forkName]) idsByFork[forkName] = [];
@@ -70,12 +70,12 @@ export class BlockRepository {
     }
     await Promise.all(
       Object.keys(idsByFork).map((forkName) =>
-        this.getRepositoryByForkName(forkName as IForkName).batchDelete(idsByFork[forkName as IForkName])
+        this.getRepositoryByForkName(forkName as ForkName).batchDelete(idsByFork[forkName as ForkName])
       )
     );
   }
 
-  private getRepositoryByForkName(forkName: IForkName): Repository<Uint8Array, allForks.SignedBeaconBlock> {
+  private getRepositoryByForkName(forkName: ForkName): Repository<Uint8Array, allForks.SignedBeaconBlock> {
     const repo = this.repositories.get(forkName);
     if (!repo) {
       throw new Error("No supported block repository for fork: " + forkName);

--- a/packages/lodestar/src/db/repositories/block/index.ts
+++ b/packages/lodestar/src/db/repositories/block/index.ts
@@ -3,6 +3,7 @@ import {IBeaconConfig, ForkName} from "@chainsafe/lodestar-config";
 import {Bucket, IDatabaseController, Repository} from "@chainsafe/lodestar-db";
 import {allForks, Slot} from "@chainsafe/lodestar-types";
 import {GenericBlockRepository} from "./abstract";
+import {groupByFork} from "../../../util/forkName";
 
 /**
  * Blocks by root
@@ -61,16 +62,10 @@ export class BlockRepository {
   }
 
   async batchDelete(ids: {root: Uint8Array; slot: Slot}[]): Promise<void> {
-    const idsByFork = {} as Record<ForkName, Uint8Array[]>;
-    for (const {root, slot} of ids) {
-      const forkName = this.config.getForkName(slot);
-      if (!idsByFork[forkName]) idsByFork[forkName] = [];
-
-      idsByFork[forkName].push(root);
-    }
+    const idsByFork = groupByFork(this.config, ids, (id) => id.slot);
     await Promise.all(
-      Object.keys(idsByFork).map((forkName) =>
-        this.getRepositoryByForkName(forkName as ForkName).batchDelete(idsByFork[forkName as ForkName])
+      Array.from(idsByFork.entries()).map(([forkName, idsInFork]) =>
+        this.getRepositoryByForkName(forkName).batchDelete(idsInFork.map((id) => id.root))
       )
     );
   }

--- a/packages/lodestar/src/db/repositories/blockArchive/index.ts
+++ b/packages/lodestar/src/db/repositories/blockArchive/index.ts
@@ -1,4 +1,4 @@
-import {IBeaconConfig, IForkName} from "@chainsafe/lodestar-config";
+import {IBeaconConfig, ForkName} from "@chainsafe/lodestar-config";
 import {IDatabaseController, Repository, IKeyValue, IFilterOptions, Bucket} from "@chainsafe/lodestar-db";
 import {IBlockSummary} from "@chainsafe/lodestar-fork-choice";
 import {Slot, Root, allForks} from "@chainsafe/lodestar-types";
@@ -17,14 +17,14 @@ export class BlockArchiveRepository {
   protected config: IBeaconConfig;
   protected db: IDatabaseController<Buffer, Buffer>;
 
-  protected repositories: Map<IForkName, Repository<Slot, allForks.SignedBeaconBlock>>;
+  protected repositories: Map<ForkName, Repository<Slot, allForks.SignedBeaconBlock>>;
 
   constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
     this.config = config;
     this.db = db;
     this.repositories = new Map([
       [
-        "phase0",
+        ForkName.phase0,
         new GenericBlockArchiveRepository(
           config,
           db,
@@ -33,7 +33,7 @@ export class BlockArchiveRepository {
         ),
       ],
       [
-        "altair",
+        ForkName.altair,
         new GenericBlockArchiveRepository(
           config,
           db,
@@ -73,7 +73,7 @@ export class BlockArchiveRepository {
   async batchPut(items: Array<IKeyValue<Slot, allForks.SignedBeaconBlock>>): Promise<void> {
     await Promise.all(
       Object.entries(this.groupItemsByFork(items)).map(([forkName, items]) =>
-        this.getRepositoryByForkName(forkName as IForkName).batchPut(items)
+        this.getRepositoryByForkName(forkName as ForkName).batchPut(items)
       )
     );
   }
@@ -81,7 +81,7 @@ export class BlockArchiveRepository {
   async batchAdd(values: allForks.SignedBeaconBlock[]): Promise<void> {
     await Promise.all(
       Object.entries(this.groupValuesByFork(values)).map(([forkName, values]) =>
-        this.getRepositoryByForkName(forkName as IForkName).batchAdd(values)
+        this.getRepositoryByForkName(forkName as ForkName).batchAdd(values)
       )
     );
   }
@@ -89,7 +89,7 @@ export class BlockArchiveRepository {
   async batchPutBinary(items: Array<IKeyValueSummary<Slot, Buffer, IBlockSummary>>): Promise<void> {
     await Promise.all(
       Object.entries(this.groupItemsByFork(items)).map(([forkName, items]) =>
-        this.getRepositoryByForkName(forkName as IForkName).batchPutBinary(items)
+        this.getRepositoryByForkName(forkName as ForkName).batchPutBinary(items)
       )
     );
   }
@@ -112,7 +112,7 @@ export class BlockArchiveRepository {
     return all(this.valuesStream(opts));
   }
 
-  private getRepositoryByForkName(forkName: IForkName): Repository<Slot, allForks.SignedBeaconBlock> {
+  private getRepositoryByForkName(forkName: ForkName): Repository<Slot, allForks.SignedBeaconBlock> {
     const repo = this.repositories.get(forkName);
     if (!repo) {
       throw new Error("No supported block archive repository for fork: " + forkName);
@@ -124,8 +124,8 @@ export class BlockArchiveRepository {
     return this.getRepositoryByForkName(this.config.getForkName(slot));
   }
 
-  private groupValuesByFork(values: allForks.SignedBeaconBlock[]): Record<IForkName, allForks.SignedBeaconBlock[]> {
-    const valuesByFork = {} as Record<IForkName, allForks.SignedBeaconBlock[]>;
+  private groupValuesByFork(values: allForks.SignedBeaconBlock[]): Record<ForkName, allForks.SignedBeaconBlock[]> {
+    const valuesByFork = {} as Record<ForkName, allForks.SignedBeaconBlock[]>;
     for (const value of values) {
       const forkName = this.config.getForkName(value.message.slot);
       if (!valuesByFork[forkName]) valuesByFork[forkName] = [];
@@ -134,8 +134,8 @@ export class BlockArchiveRepository {
     return valuesByFork;
   }
 
-  private groupItemsByFork<T>(items: Array<IKeyValue<Slot, T>>): Record<IForkName, IKeyValue<Slot, T>[]> {
-    const itemsByFork = {} as Record<IForkName, IKeyValue<Slot, T>[]>;
+  private groupItemsByFork<T>(items: Array<IKeyValue<Slot, T>>): Record<ForkName, IKeyValue<Slot, T>[]> {
+    const itemsByFork = {} as Record<ForkName, IKeyValue<Slot, T>[]>;
     for (const kv of items) {
       const forkName = this.config.getForkName(kv.key);
       if (!itemsByFork[forkName]) itemsByFork[forkName] = [];

--- a/packages/lodestar/src/db/repositories/pendingBlock/index.ts
+++ b/packages/lodestar/src/db/repositories/pendingBlock/index.ts
@@ -1,5 +1,5 @@
 import {ContainerType} from "@chainsafe/ssz";
-import {IBeaconConfig, IForkName} from "@chainsafe/lodestar-config";
+import {IBeaconConfig, ForkName} from "@chainsafe/lodestar-config";
 import {Bucket, IDatabaseController, Repository} from "@chainsafe/lodestar-db";
 import {allForks, Slot} from "@chainsafe/lodestar-types";
 import {GenericBlockRepository} from "./abstract";
@@ -13,14 +13,14 @@ export class PendingBlockRepository {
   protected config: IBeaconConfig;
   protected db: IDatabaseController<Buffer, Buffer>;
 
-  protected repositories: Map<IForkName, Repository<Uint8Array, allForks.SignedBeaconBlock>>;
+  protected repositories: Map<ForkName, Repository<Uint8Array, allForks.SignedBeaconBlock>>;
 
   constructor(config: IBeaconConfig, db: IDatabaseController<Buffer, Buffer>) {
     this.config = config;
     this.db = db;
     this.repositories = new Map([
       [
-        "phase0",
+        ForkName.phase0,
         new GenericBlockRepository(
           config,
           db,
@@ -29,7 +29,7 @@ export class PendingBlockRepository {
         ),
       ],
       [
-        "altair",
+        ForkName.altair,
         new GenericBlockRepository(
           config,
           db,
@@ -61,7 +61,7 @@ export class PendingBlockRepository {
   }
 
   async batchDelete(ids: {root: Uint8Array; slot: Slot}[]): Promise<void> {
-    const idsByFork = {} as Record<IForkName, Uint8Array[]>;
+    const idsByFork = {} as Record<ForkName, Uint8Array[]>;
     for (const {root, slot} of ids) {
       const forkName = this.config.getForkName(slot);
       if (!idsByFork[forkName]) idsByFork[forkName] = [];
@@ -70,12 +70,12 @@ export class PendingBlockRepository {
     }
     await Promise.all(
       Object.keys(idsByFork).map((forkName) =>
-        this.getRepositoryByForkName(forkName as IForkName).batchDelete(idsByFork[forkName as IForkName])
+        this.getRepositoryByForkName(forkName as ForkName).batchDelete(idsByFork[forkName as ForkName])
       )
     );
   }
 
-  private getRepositoryByForkName(forkName: IForkName): Repository<Uint8Array, allForks.SignedBeaconBlock> {
+  private getRepositoryByForkName(forkName: ForkName): Repository<Uint8Array, allForks.SignedBeaconBlock> {
     const repo = this.repositories.get(forkName);
     if (!repo) {
       throw new Error("No supported block repository for fork: " + forkName);

--- a/packages/lodestar/src/network/gossip/interface.ts
+++ b/packages/lodestar/src/network/gossip/interface.ts
@@ -5,7 +5,7 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import StrictEventEmitter from "strict-event-emitter-types";
 import {EventEmitter} from "events";
-import {IBeaconConfig, IForkName} from "@chainsafe/lodestar-config";
+import {IBeaconConfig, ForkName} from "@chainsafe/lodestar-config";
 import LibP2p from "libp2p";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {InMessage} from "libp2p-interfaces/src/pubsub";
@@ -32,7 +32,7 @@ export enum GossipEncoding {
  */
 export interface IGossipTopic {
   type: GossipType;
-  fork: IForkName;
+  fork: ForkName;
   encoding?: GossipEncoding;
 }
 

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -1,4 +1,5 @@
 import {AbortSignal} from "abort-controller";
+import {ForkName} from "@chainsafe/lodestar-config";
 import {ATTESTATION_SUBNET_COUNT} from "@chainsafe/lodestar-types";
 import {mapValues} from "@chainsafe/lodestar-utils";
 import {IMetrics} from "../../metrics";
@@ -106,7 +107,7 @@ export function createValidatorFnsByTopic(
 
   // TODO: other fork topics should get added here
   // phase0
-  const fork = "phase0";
+  const fork = ForkName.phase0;
 
   for (const type of staticGossipTypes) {
     const topic = {type, fork, encoding: DEFAULT_ENCODING} as GossipTopic;

--- a/packages/lodestar/src/sync/gossip/handler.ts
+++ b/packages/lodestar/src/sync/gossip/handler.ts
@@ -122,7 +122,7 @@ export class BeaconGossipHandler {
       {type: GossipType.attester_slashing, handler: this.onAttesterSlashing},
     ];
     for (const {type, handler} of topicHandlers) {
-      const topic = {type, fork: "phase0"};
+      const topic = {type, fork: ForkName.phase0};
       this.network.gossip.handleTopic(topic as GossipTopic, handler as GossipHandlerFn);
     }
     // TODO altair
@@ -141,7 +141,7 @@ export class BeaconGossipHandler {
       {type: GossipType.attester_slashing, handler: this.onAttesterSlashing},
     ];
     for (const {type, handler} of topicHandlers) {
-      const topic = {type, fork: "phase0"};
+      const topic = {type, fork: ForkName.phase0};
       this.network.gossip.unhandleTopic(topic as GossipTopic, handler as GossipHandlerFn);
     }
     // TODO altair

--- a/packages/lodestar/src/sync/gossip/handler.ts
+++ b/packages/lodestar/src/sync/gossip/handler.ts
@@ -1,5 +1,5 @@
 import {phase0, Version} from "@chainsafe/lodestar-types";
-import {IBeaconConfig, IForkName} from "@chainsafe/lodestar-config";
+import {IBeaconConfig, ForkName} from "@chainsafe/lodestar-config";
 
 import {INetwork} from "../../network";
 import {ChainEvent, IBeaconChain} from "../../chain";
@@ -11,9 +11,7 @@ enum GossipHandlerStatus {
   Stopped = "Stopped",
 }
 
-type GossipHandlerState =
-  | {status: GossipHandlerStatus.Stopped}
-  | {status: GossipHandlerStatus.Started; fork: IForkName};
+type GossipHandlerState = {status: GossipHandlerStatus.Stopped} | {status: GossipHandlerStatus.Started; fork: ForkName};
 
 export class BeaconGossipHandler {
   private readonly config: IBeaconConfig;
@@ -85,7 +83,7 @@ export class BeaconGossipHandler {
     await this.db.voluntaryExit.add(exit);
   };
 
-  private subscribeAtFork = (fork: IForkName): void => {
+  private subscribeAtFork = (fork: ForkName): void => {
     this.network.gossip.subscribeTopic({type: GossipType.beacon_block, fork});
     this.network.gossip.subscribeTopic({type: GossipType.beacon_aggregate_and_proof, fork});
     this.network.gossip.subscribeTopic({type: GossipType.voluntary_exit, fork});
@@ -93,7 +91,7 @@ export class BeaconGossipHandler {
     this.network.gossip.subscribeTopic({type: GossipType.attester_slashing, fork});
   };
 
-  private unsubscribeAtFork = (fork: IForkName): void => {
+  private unsubscribeAtFork = (fork: ForkName): void => {
     this.network.gossip.unsubscribeTopic({type: GossipType.beacon_block, fork});
     this.network.gossip.unsubscribeTopic({type: GossipType.beacon_aggregate_and_proof, fork});
     this.network.gossip.unsubscribeTopic({type: GossipType.voluntary_exit, fork});
@@ -101,7 +99,7 @@ export class BeaconGossipHandler {
     this.network.gossip.unsubscribeTopic({type: GossipType.attester_slashing, fork});
   };
 
-  private handleForkVersion = (_forkVersion: Version, fork: IForkName): void => {
+  private handleForkVersion = (_forkVersion: Version, fork: ForkName): void => {
     if (this.state.status !== GossipHandlerStatus.Started) {
       return;
     }

--- a/packages/lodestar/src/sync/utils/attestation-collector.ts
+++ b/packages/lodestar/src/sync/utils/attestation-collector.ts
@@ -1,6 +1,6 @@
 import {ChainEvent, IBeaconChain} from "../../chain";
 import {IBeaconDb} from "../../db";
-import {IBeaconConfig, IForkName} from "@chainsafe/lodestar-config";
+import {IBeaconConfig, ForkName} from "@chainsafe/lodestar-config";
 import {phase0, CommitteeIndex, Slot, ATTESTATION_SUBNET_COUNT} from "@chainsafe/lodestar-types";
 import {INetwork} from "../../network";
 import {computeSubnetForSlot} from "@chainsafe/lodestar-beacon-state-transition";
@@ -35,7 +35,7 @@ export class AttestationCollector {
     this.chain.emitter.on(ChainEvent.clockSlot, this.checkDuties);
     for (let subnet = 0; subnet < ATTESTATION_SUBNET_COUNT; subnet++) {
       this.network.gossip.handleTopic(
-        {type: GossipType.beacon_attestation, fork: "phase0", subnet},
+        {type: GossipType.beacon_attestation, fork: ForkName.phase0, subnet},
         this.handleCommitteeAttestation as GossipHandlerFn
       );
     }
@@ -45,7 +45,7 @@ export class AttestationCollector {
     for (const timer of this.timers) clearTimeout(timer);
     for (let subnet = 0; subnet < ATTESTATION_SUBNET_COUNT; subnet++) {
       this.network.gossip.unhandleTopic(
-        {type: GossipType.beacon_attestation, fork: "phase0", subnet},
+        {type: GossipType.beacon_attestation, fork: ForkName.phase0, subnet},
         this.handleCommitteeAttestation as GossipHandlerFn
       );
     }
@@ -85,7 +85,7 @@ export class AttestationCollector {
     this.aggregationDuties.delete(slot);
   };
 
-  private unsubscribeSubnet = (subnet: number, fork: IForkName): void => {
+  private unsubscribeSubnet = (subnet: number, fork: ForkName): void => {
     try {
       this.network.gossip.unsubscribeTopic({type: GossipType.beacon_attestation, fork, subnet});
     } catch (e) {

--- a/packages/lodestar/src/tasks/tasks/interopSubnetsJoiningTask.ts
+++ b/packages/lodestar/src/tasks/tasks/interopSubnetsJoiningTask.ts
@@ -1,5 +1,5 @@
 import {INetwork} from "../../network";
-import {IBeaconConfig, IForkName} from "@chainsafe/lodestar-config";
+import {IBeaconConfig, ForkName} from "@chainsafe/lodestar-config";
 import {ATTESTATION_SUBNET_COUNT} from "../../constants";
 import {randBetween, ILogger} from "@chainsafe/lodestar-utils";
 import {ChainEvent, IBeaconChain} from "../../chain";
@@ -18,7 +18,7 @@ export class InteropSubnetsJoiningTask {
   private readonly logger: ILogger;
   private currentSubnets: Set<number>;
   private nextForkSubnets: Set<number>;
-  private currentFork!: IForkName;
+  private currentFork!: ForkName;
 
   private currentTimers: NodeJS.Timeout[] = [];
   private nextForkTimers: NodeJS.Timeout[] = [];
@@ -53,7 +53,7 @@ export class InteropSubnetsJoiningTask {
     this.cleanUpCurrentSubscriptions();
   }
 
-  private run = (fork: IForkName): void => {
+  private run = (fork: ForkName): void => {
     for (let i = 0; i < this.config.params.RANDOM_SUBNETS_PER_VALIDATOR; i++) {
       this.subscribeToRandomSubnet(fork);
     }
@@ -125,7 +125,7 @@ export class InteropSubnetsJoiningTask {
    * This can be either for the current fork or next fork.
    * @return choosen subnet
    */
-  private subscribeToRandomSubnet(fork: IForkName): number {
+  private subscribeToRandomSubnet(fork: ForkName): number {
     const subnet = randBetween(0, ATTESTATION_SUBNET_COUNT);
     this.network.gossip.subscribeTopic({type: GossipType.beacon_attestation, fork, subnet});
     const attnets = this.network.metadata.attnets;
@@ -151,7 +151,7 @@ export class InteropSubnetsJoiningTask {
     return subnet;
   }
 
-  private handleChangeSubnets = (fork: IForkName, subnet: number): void => {
+  private handleChangeSubnets = (fork: ForkName, subnet: number): void => {
     this.network.gossip.unsubscribeTopic({type: GossipType.beacon_attestation, fork, subnet});
     const attnets = this.network.metadata.attnets;
     if (attnets[subnet]) {

--- a/packages/lodestar/src/util/forkName.ts
+++ b/packages/lodestar/src/util/forkName.ts
@@ -1,0 +1,19 @@
+import {ForkName, IBeaconConfig} from "@chainsafe/lodestar-config";
+import {Slot} from "@chainsafe/lodestar-types";
+
+/**
+ * Group an array of items by ForkName according to the slot associted to each item
+ */
+export function groupByFork<T>(config: IBeaconConfig, items: T[], getSlot: (item: T) => Slot): Map<ForkName, T[]> {
+  const itemsByFork = new Map<ForkName, T[]>();
+  for (const item of items) {
+    const forkName = config.getForkName(getSlot(item));
+    let itemsInFork = itemsByFork.get(forkName);
+    if (!itemsInFork) {
+      itemsInFork = [];
+      itemsByFork.set(forkName, itemsInFork);
+    }
+    itemsInFork.push(item);
+  }
+  return itemsByFork;
+}

--- a/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
@@ -3,6 +3,7 @@ import Libp2p from "libp2p";
 import {InMessage} from "libp2p-interfaces/src/pubsub";
 import {ERR_TOPIC_VALIDATOR_REJECT} from "libp2p-gossipsub/src/constants";
 import {config} from "@chainsafe/lodestar-config/minimal";
+import {ForkName} from "@chainsafe/lodestar-config";
 
 import {
   Eth2Gossipsub,
@@ -29,7 +30,11 @@ describe("gossipsub", function () {
 
   beforeEach(async function () {
     const signedBlock = generateEmptySignedBlock();
-    topicString = getGossipTopicString(config, {type: GossipType.beacon_block, fork: "phase0"}, genesisValidatorsRoot);
+    topicString = getGossipTopicString(
+      config,
+      {type: GossipType.beacon_block, fork: ForkName.phase0},
+      genesisValidatorsRoot
+    );
     message = {
       data: encodeMessageData(GossipEncoding.ssz_snappy, config.types.phase0.SignedBeaconBlock.serialize(signedBlock)),
       receivedFrom: "0",

--- a/packages/lodestar/test/unit/network/gossip/topic.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/topic.test.ts
@@ -1,5 +1,6 @@
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/minimal";
+import {ForkName} from "@chainsafe/lodestar-config";
 
 import {
   getGossipTopic,
@@ -13,12 +14,12 @@ describe("GossipTopic", function () {
   it("should round trip encode/decode gossip topics", async () => {
     const genesisValidatorsRoot = Buffer.alloc(32);
     const topics: GossipTopic[] = [
-      {type: GossipType.beacon_block, fork: "phase0", encoding: DEFAULT_ENCODING},
-      {type: GossipType.beacon_aggregate_and_proof, fork: "phase0", encoding: DEFAULT_ENCODING},
-      {type: GossipType.beacon_attestation, fork: "phase0", subnet: 5, encoding: DEFAULT_ENCODING},
-      {type: GossipType.voluntary_exit, fork: "phase0", encoding: DEFAULT_ENCODING},
-      {type: GossipType.proposer_slashing, fork: "phase0", encoding: DEFAULT_ENCODING},
-      {type: GossipType.attester_slashing, fork: "phase0", encoding: DEFAULT_ENCODING},
+      {type: GossipType.beacon_block, fork: ForkName.phase0, encoding: DEFAULT_ENCODING},
+      {type: GossipType.beacon_aggregate_and_proof, fork: ForkName.phase0, encoding: DEFAULT_ENCODING},
+      {type: GossipType.beacon_attestation, fork: ForkName.phase0, subnet: 5, encoding: DEFAULT_ENCODING},
+      {type: GossipType.voluntary_exit, fork: ForkName.phase0, encoding: DEFAULT_ENCODING},
+      {type: GossipType.proposer_slashing, fork: ForkName.phase0, encoding: DEFAULT_ENCODING},
+      {type: GossipType.attester_slashing, fork: ForkName.phase0, encoding: DEFAULT_ENCODING},
     ];
     for (const topic of topics) {
       const topicString = getGossipTopicString(config, topic, genesisValidatorsRoot);

--- a/packages/lodestar/test/unit/sync/gossip/handler.test.ts
+++ b/packages/lodestar/test/unit/sync/gossip/handler.test.ts
@@ -1,6 +1,7 @@
 import sinon, {SinonStubbedInstance} from "sinon";
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/mainnet";
+import {ForkName} from "@chainsafe/lodestar-config";
 
 import {BeaconChain, ChainEventEmitter, IBeaconChain} from "../../../../src/chain";
 import {INetwork, Network} from "../../../../src/network";
@@ -28,7 +29,7 @@ describe("gossip handler", function () {
   beforeEach(async function () {
     chainStub = sinon.createStubInstance(BeaconChain);
     chainStub.emitter = new ChainEventEmitter();
-    chainStub.getForkName.returns("phase0");
+    chainStub.getForkName.returns(ForkName.phase0);
     networkStub = sinon.createStubInstance(Network);
     const multiaddr = "/ip4/127.0.0.1/tcp/0";
     const libp2p = await createNode(multiaddr);
@@ -61,7 +62,7 @@ describe("gossip handler", function () {
   it("should handle incoming gossip objects", async function () {
     const handler = new BeaconGossipHandler(config, chainStub, networkStub, dbStub);
     handler.start();
-    const fork = "phase0";
+    const fork = ForkName.phase0;
     const {
       SignedBeaconBlock,
       SignedAggregateAndProof,

--- a/packages/lodestar/test/unit/sync/utils/attestation-collector.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/attestation-collector.test.ts
@@ -11,6 +11,7 @@ import {Eth2Gossipsub, GossipType} from "../../../../src/network/gossip";
 import {BeaconDb} from "../../../../src/db";
 import {generateCachedState} from "../../../utils/state";
 import {testLogger} from "../../../utils/logger";
+import {ForkName} from "@chainsafe/lodestar-config";
 
 describe("Attestation collector", function () {
   const sandbox = sinon.createSandbox();
@@ -39,7 +40,7 @@ describe("Attestation collector", function () {
       chain: {
         clock: realClock,
         getHeadState: () => generateCachedState(),
-        getForkName: () => "phase0",
+        getForkName: () => ForkName.phase0,
         emitter,
       },
       // @ts-ignore
@@ -54,13 +55,15 @@ describe("Attestation collector", function () {
     });
     collector.subscribeToCommitteeAttestations(1, 1);
     expect(
-      fakeGossip.subscribeTopic.withArgs({type: GossipType.beacon_attestation, fork: "phase0", subnet: 10}).calledOnce
+      fakeGossip.subscribeTopic.withArgs({type: GossipType.beacon_attestation, fork: ForkName.phase0, subnet: 10})
+        .calledOnce
     ).to.be.true;
     sandbox.clock.tick(config.params.SECONDS_PER_SLOT * 1000);
     await subscribed;
     sandbox.clock.tick(config.params.SECONDS_PER_SLOT * 1000);
     expect(
-      fakeGossip.unsubscribeTopic.withArgs({type: GossipType.beacon_attestation, fork: "phase0", subnet: 10}).calledOnce
+      fakeGossip.unsubscribeTopic.withArgs({type: GossipType.beacon_attestation, fork: ForkName.phase0, subnet: 10})
+        .calledOnce
     ).to.be.true;
     collector.stop();
     abortController.abort();
@@ -81,7 +84,7 @@ describe("Attestation collector", function () {
       chain: {
         clock: realClock,
         getHeadState: () => generateCachedState(),
-        getForkName: () => "phase0",
+        getForkName: () => ForkName.phase0,
         emitter,
       },
       // @ts-ignore

--- a/packages/lodestar/test/unit/tasks/interopSubnetsJoiningTask.test.ts
+++ b/packages/lodestar/test/unit/tasks/interopSubnetsJoiningTask.test.ts
@@ -11,7 +11,7 @@ import {MockBeaconChain} from "../../utils/mocks/chain/chain";
 import {generateState} from "../../utils/state";
 import {allForks} from "@chainsafe/lodestar-types";
 import {MetadataController} from "../../../src/network/metadata";
-import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {ForkName, IBeaconConfig} from "@chainsafe/lodestar-config";
 import {TreeBacked} from "@chainsafe/ssz";
 
 describe("interopSubnetsJoiningTask", () => {
@@ -65,7 +65,7 @@ describe("interopSubnetsJoiningTask", () => {
     expect(config.types.ForkDigest.equals(oldForkDigest, chain.getForkDigest())).to.be.false;
     // not subscribe, just unsubscribe at that time
     const unSubscribePromise = new Promise((resolve) => gossipStub.unsubscribeTopic.callsFake(resolve));
-    chain.emitter.emit(ChainEvent.forkVersion, state.fork.currentVersion, "phase0");
+    chain.emitter.emit(ChainEvent.forkVersion, state.fork.currentVersion, ForkName.phase0);
     await unSubscribePromise;
     expect(gossipStub.unsubscribeTopic.callCount).to.be.equal(config.params.RANDOM_SUBNETS_PER_VALIDATOR);
   });

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -3,7 +3,7 @@ import sinon from "sinon";
 
 import {TreeBacked} from "@chainsafe/ssz";
 import {allForks, ForkDigest, Number64, Root, Slot, Uint16, Uint64} from "@chainsafe/lodestar-types";
-import {IBeaconConfig, IForkName} from "@chainsafe/lodestar-config";
+import {IBeaconConfig, ForkName} from "@chainsafe/lodestar-config";
 import {
   CachedBeaconState,
   computeForkDigest,
@@ -122,7 +122,7 @@ export class MockBeaconChain implements IBeaconChain {
     return computeForkDigest(this.config, this.state.fork.currentVersion, this.genesisValidatorsRoot);
   }
 
-  getForkName(): IForkName {
+  getForkName(): ForkName {
     return computeForkNameFromForkDigest(this.config, this.genesisValidatorsRoot, this.getForkDigest());
   }
 


### PR DESCRIPTION
**Motivation**

Typing the same string is not as clean as an enum. Switched to enum for consistency with the rest of the codebase.

**Description**

- Use enum for ForkName
- Use Map s in the abstract db repos to prevent casting to ForkName