### PR TITLE
Fix drop job logic for LIFO queues

### DIFF
--- a/packages/lodestar/src/util/queue/index.ts
+++ b/packages/lodestar/src/util/queue/index.ts
@@ -65,7 +65,13 @@ export class JobQueue {
 
     if (this.jobs.length + 1 > this.opts.maxLength) {
       this.metrics?.droppedJobs.inc();
-      throw new QueueError({code: QueueErrorCode.QUEUE_MAX_LENGTH});
+      if (this.opts.type === QueueType.LIFO) {
+        // In LIFO queues keep the latest job and drop the oldest
+        this.jobs.shift();
+      } else {
+        // In FIFO queues drop the latest job
+        throw new QueueError({code: QueueErrorCode.QUEUE_MAX_LENGTH});
+      }
     }
 
     return await new Promise<R>((resolve, reject) => {


### PR DESCRIPTION
**Motivation**

See https://github.com/ChainSafe/lodestar/issues/2422


**Description**

LIFO queues prioritize newer jobs, so if the queue is full newer jobs should be kept and drop older.

Closes https://github.com/ChainSafe/lodestar/issues/2422