### PR TITLE
Add state transition function metrics

### DIFF
--- a/packages/beacon-state-transition/src/index.ts
+++ b/packages/beacon-state-transition/src/index.ts
@@ -4,6 +4,7 @@
 
 export * from "./constants";
 export * from "./util";
+export * from "./metrics";
 
 export * as phase0 from "./phase0";
 export * as altair from "./altair";

--- a/packages/beacon-state-transition/src/metrics.ts
+++ b/packages/beacon-state-transition/src/metrics.ts
@@ -1,0 +1,8 @@
+export interface IBeaconStateTransitionMetrics {
+  stfnEpochTransition: IHistogram;
+  stfnProcessBlock: IHistogram;
+}
+
+interface IHistogram {
+  startTimer(): () => void;
+}

--- a/packages/beacon-state-transition/src/phase0/fast/block/index.ts
+++ b/packages/beacon-state-transition/src/phase0/fast/block/index.ts
@@ -1,5 +1,5 @@
 import {allForks, phase0} from "@chainsafe/lodestar-types";
-
+import {IBeaconStateTransitionMetrics} from "../../../metrics";
 import {CachedBeaconState, processBlockHeader, processEth1Data, processRandao} from "../../../fast";
 import {processOperations} from "./processOperations";
 import {processAttestation} from "./processAttestation";
@@ -23,10 +23,13 @@ export {
 export function processBlock(
   state: CachedBeaconState<phase0.BeaconState>,
   block: phase0.BeaconBlock,
-  verifySignatures = true
+  verifySignatures = true,
+  metrics?: IBeaconStateTransitionMetrics | null
 ): void {
+  const timer = metrics?.stfnProcessBlock.startTimer();
   processBlockHeader(state as CachedBeaconState<allForks.BeaconState>, block);
   processRandao(state as CachedBeaconState<allForks.BeaconState>, block, verifySignatures);
   processEth1Data(state as CachedBeaconState<allForks.BeaconState>, block.body);
   processOperations(state, block.body, verifySignatures);
+  if (timer) timer();
 }

--- a/packages/beacon-state-transition/src/phase0/fast/slot/index.ts
+++ b/packages/beacon-state-transition/src/phase0/fast/slot/index.ts
@@ -1,21 +1,27 @@
 import {phase0, Slot} from "@chainsafe/lodestar-types";
-
+import {assert} from "@chainsafe/lodestar-utils";
 import {processEpoch} from "../epoch";
 import {processSlot} from "./processSlot";
 import {CachedBeaconState, rotateEpochs} from "../../../fast";
-import {assert} from "@chainsafe/lodestar-utils";
+import {IBeaconStateTransitionMetrics} from "../../../metrics";
 
 export {processSlot};
 
-export function processSlots(state: CachedBeaconState<phase0.BeaconState>, slot: Slot): void {
+export function processSlots(
+  state: CachedBeaconState<phase0.BeaconState>,
+  slot: Slot,
+  metrics?: IBeaconStateTransitionMetrics | null
+): void {
   assert.lte(state.slot, slot, `State slot ${state.slot} must transition to a future slot ${slot}`);
   while (state.slot < slot) {
     processSlot(state);
     // process epoch on the start slot of the next epoch
     if ((state.slot + 1) % state.config.params.SLOTS_PER_EPOCH === 0) {
+      const timer = metrics?.stfnEpochTransition.startTimer();
       processEpoch(state);
       state.slot += 1;
       rotateEpochs(state.epochCtx, state, state.validators);
+      if (timer) timer();
     } else {
       state.slot += 1;
     }

--- a/packages/lodestar/src/api/impl/interface.ts
+++ b/packages/lodestar/src/api/impl/interface.ts
@@ -14,6 +14,7 @@ import {IEventsApi} from "./events";
 import {IDebugApi} from "./debug/interface";
 import {IConfigApi} from "./config/interface";
 import {ILodestarApi} from "./lodestar";
+import {IMetrics} from "../../metrics";
 
 export const enum ApiNamespace {
   BEACON = "beacon",
@@ -27,12 +28,13 @@ export const enum ApiNamespace {
 
 export interface IApiModules {
   config: IBeaconConfig;
-  logger: ILogger;
   chain: IBeaconChain;
-  sync: IBeaconSync;
-  network: INetwork;
   db: IBeaconDb;
   eth1: IEth1ForBlockProduction;
+  logger: ILogger;
+  metrics: IMetrics | null;
+  network: INetwork;
+  sync: IBeaconSync;
 }
 
 export interface IApi {

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -71,8 +71,8 @@ export class BlockProcessor {
  */
 export async function processBlockJob(modules: BlockProcessorModules, job: IBlockJob): Promise<void> {
   try {
-    validateBlock({...modules, job});
-    await processBlock({...modules, job});
+    validateBlock(modules, job);
+    await processBlock(modules, job);
   } catch (e) {
     // above functions only throw BlockError
     modules.emitter.emit(ChainEvent.errorBlock, e);
@@ -118,7 +118,7 @@ export async function processChainSegmentJob(modules: BlockProcessorModules, job
     }
 
     try {
-      validateBlock({...modules, job: {...job, signedBlock: block}});
+      validateBlock(modules, {...job, signedBlock: block});
       // If the block is relevant, add it to the filtered chain segment.
       filteredChainSegment.push(block);
     } catch (e) {
@@ -156,11 +156,5 @@ export async function processChainSegmentJob(modules: BlockProcessorModules, job
     }
   }
 
-  await processChainSegment({
-    ...modules,
-    job: {
-      ...job,
-      signedBlocks: filteredChainSegment,
-    },
-  });
+  await processChainSegment(modules, {...job, signedBlocks: filteredChainSegment});
 }

--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -16,13 +16,105 @@ import {CheckpointStateCache} from "../stateCache";
 import {ChainEvent, ChainEventEmitter} from "../emitter";
 import {IBlockJob} from "../interface";
 import {sleep} from "@chainsafe/lodestar-utils";
+import {IMetrics} from "../../metrics";
+
+/**
+ * Starting at `state.slot`,
+ * process slots forward towards `slot`,
+ * emitting "checkpoint" events after every epoch processed.
+ */
+export async function processSlotsByCheckpoint(
+  {emitter, metrics}: {emitter: ChainEventEmitter; metrics: IMetrics | null},
+  preState: CachedBeaconState<allForks.BeaconState>,
+  slot: Slot
+): Promise<CachedBeaconState<allForks.BeaconState>> {
+  const postState = await processSlotsToNearestCheckpoint({emitter, metrics}, preState, slot);
+  if (postState.slot < slot) {
+    phase0.fast.processSlots(postState as CachedBeaconState<phase0.BeaconState>, slot, metrics);
+  }
+  return postState;
+}
+
+/**
+ * Starting at `state.slot`,
+ * process slots forward towards `slot`,
+ * emitting "checkpoint" events after every epoch processed.
+ *
+ * Stops processing after no more full epochs can be processed.
+ */
+async function processSlotsToNearestCheckpoint(
+  {emitter, metrics}: {emitter: ChainEventEmitter; metrics: IMetrics | null},
+  preState: CachedBeaconState<allForks.BeaconState>,
+  slot: Slot
+): Promise<CachedBeaconState<allForks.BeaconState>> {
+  const config = preState.config;
+  const {SLOTS_PER_EPOCH} = config.params;
+  const preSlot = preState.slot;
+  const postSlot = slot;
+  const preEpoch = computeEpochAtSlot(config, preSlot);
+  const postState = preState.clone();
+  for (
+    let nextEpochSlot = computeStartSlotAtEpoch(config, preEpoch + 1);
+    nextEpochSlot <= postSlot;
+    nextEpochSlot += SLOTS_PER_EPOCH
+  ) {
+    phase0.fast.processSlots(postState as CachedBeaconState<phase0.BeaconState>, nextEpochSlot, metrics);
+    emitCheckpointEvent(emitter, postState.clone());
+    // this avoids keeping our node busy processing blocks
+    await sleep(0);
+  }
+  return postState;
+}
+
+export async function runStateTransition(
+  {emitter, forkChoice, metrics}: {emitter: ChainEventEmitter; forkChoice: IForkChoice; metrics: IMetrics | null},
+  checkpointStateCache: CheckpointStateCache,
+  preState: CachedBeaconState<allForks.BeaconState>,
+  job: IBlockJob
+): Promise<CachedBeaconState<allForks.BeaconState>> {
+  const config = preState.config;
+  const {SLOTS_PER_EPOCH} = config.params;
+  const postSlot = job.signedBlock.message.slot;
+
+  // if block is trusted don't verify proposer or op signature
+  const postState = fast.fastStateTransition(
+    preState,
+    job.signedBlock,
+    {
+      verifyStateRoot: true,
+      verifyProposer: !job.validSignatures && !job.validProposerSignature,
+      verifySignatures: !job.validSignatures,
+    },
+    metrics
+  );
+
+  const oldHead = forkChoice.getHead();
+
+  // current justified checkpoint should be prev epoch or current epoch if it's just updated
+  // it should always have epochBalances there bc it's a checkpoint state, ie got through processEpoch
+  let justifiedBalances: Gwei[] = [];
+  if (postState.currentJustifiedCheckpoint.epoch > forkChoice.getJustifiedCheckpoint().epoch) {
+    const justifiedState = checkpointStateCache.get(postState.currentJustifiedCheckpoint);
+    justifiedBalances = getEffectiveBalances(justifiedState!);
+  }
+  forkChoice.onBlock(job.signedBlock.message, postState, justifiedBalances);
+
+  if (postSlot % SLOTS_PER_EPOCH === 0) {
+    emitCheckpointEvent(emitter, postState);
+  }
+
+  emitBlockEvent(emitter, job, postState);
+  emitForkChoiceHeadEvents(emitter, forkChoice, forkChoice.getHead(), oldHead);
+
+  return postState;
+}
 
 /**
  * Emits a properly formed "checkpoint" event, given a checkpoint state context
  *
  * This will throw an error if the checkpoint state is not a valid checkpoint state, eg: NOT the first slot in an epoch.
  */
-export function emitCheckpointEvent(
+function emitCheckpointEvent(
   emitter: ChainEventEmitter,
   checkpointState: CachedBeaconState<allForks.BeaconState>
 ): void {
@@ -43,55 +135,7 @@ export function emitCheckpointEvent(
   );
 }
 
-/**
- * Starting at `state.slot`,
- * process slots forward towards `slot`,
- * emitting "checkpoint" events after every epoch processed.
- *
- * Stops processing after no more full epochs can be processed.
- */
-export async function processSlotsToNearestCheckpoint(
-  emitter: ChainEventEmitter,
-  preState: CachedBeaconState<allForks.BeaconState>,
-  slot: Slot
-): Promise<CachedBeaconState<allForks.BeaconState>> {
-  const config = preState.config;
-  const {SLOTS_PER_EPOCH} = config.params;
-  const preSlot = preState.slot;
-  const postSlot = slot;
-  const preEpoch = computeEpochAtSlot(config, preSlot);
-  const postState = preState.clone();
-  for (
-    let nextEpochSlot = computeStartSlotAtEpoch(config, preEpoch + 1);
-    nextEpochSlot <= postSlot;
-    nextEpochSlot += SLOTS_PER_EPOCH
-  ) {
-    phase0.fast.processSlots(postState as CachedBeaconState<phase0.BeaconState>, nextEpochSlot);
-    emitCheckpointEvent(emitter, postState.clone());
-    // this avoids keeping our node busy processing blocks
-    await sleep(0);
-  }
-  return postState;
-}
-
-/**
- * Starting at `state.slot`,
- * process slots forward towards `slot`,
- * emitting "checkpoint" events after every epoch processed.
- */
-export async function processSlotsByCheckpoint(
-  emitter: ChainEventEmitter,
-  preState: CachedBeaconState<allForks.BeaconState>,
-  slot: Slot
-): Promise<CachedBeaconState<allForks.BeaconState>> {
-  const postState = await processSlotsToNearestCheckpoint(emitter, preState, slot);
-  if (postState.slot < slot) {
-    phase0.fast.processSlots(postState as CachedBeaconState<phase0.BeaconState>, slot);
-  }
-  return postState;
-}
-
-export function emitForkChoiceHeadEvents(
+function emitForkChoiceHeadEvents(
   emitter: ChainEventEmitter,
   forkChoice: IForkChoice,
   head: IBlockSummary,
@@ -113,49 +157,10 @@ export function emitForkChoiceHeadEvents(
   }
 }
 
-export function emitBlockEvent(
+function emitBlockEvent(
   emitter: ChainEventEmitter,
   job: IBlockJob,
   postState: CachedBeaconState<allForks.BeaconState>
 ): void {
   emitter.emit(ChainEvent.block, job.signedBlock, postState, job);
-}
-
-export async function runStateTransition(
-  emitter: ChainEventEmitter,
-  forkChoice: IForkChoice,
-  checkpointStateCache: CheckpointStateCache,
-  preState: CachedBeaconState<allForks.BeaconState>,
-  job: IBlockJob
-): Promise<CachedBeaconState<allForks.BeaconState>> {
-  const config = preState.config;
-  const {SLOTS_PER_EPOCH} = config.params;
-  const postSlot = job.signedBlock.message.slot;
-
-  // if block is trusted don't verify proposer or op signature
-  const postState = fast.fastStateTransition(preState, job.signedBlock, {
-    verifyStateRoot: true,
-    verifyProposer: !job.validSignatures && !job.validProposerSignature,
-    verifySignatures: !job.validSignatures,
-  });
-
-  const oldHead = forkChoice.getHead();
-
-  // current justified checkpoint should be prev epoch or current epoch if it's just updated
-  // it should always have epochBalances there bc it's a checkpoint state, ie got through processEpoch
-  let justifiedBalances: Gwei[] = [];
-  if (postState.currentJustifiedCheckpoint.epoch > forkChoice.getJustifiedCheckpoint().epoch) {
-    const justifiedState = checkpointStateCache.get(postState.currentJustifiedCheckpoint);
-    justifiedBalances = getEffectiveBalances(justifiedState!);
-  }
-  forkChoice.onBlock(job.signedBlock.message, postState, justifiedBalances);
-
-  if (postSlot % SLOTS_PER_EPOCH === 0) {
-    emitCheckpointEvent(emitter, postState);
-  }
-
-  emitBlockEvent(emitter, job, postState);
-  emitForkChoiceHeadEvents(emitter, forkChoice, forkChoice.getHead(), oldHead);
-
-  return postState;
 }

--- a/packages/lodestar/src/chain/blocks/validate.ts
+++ b/packages/lodestar/src/chain/blocks/validate.ts
@@ -6,17 +6,10 @@ import {IBlockJob} from "../interface";
 import {IBeaconClock} from "../clock";
 import {BlockError, BlockErrorCode} from "../errors";
 
-export function validateBlock({
-  config,
-  forkChoice,
-  clock,
-  job,
-}: {
-  config: IBeaconConfig;
-  forkChoice: IForkChoice;
-  clock: IBeaconClock;
-  job: IBlockJob;
-}): void {
+export function validateBlock(
+  {config, forkChoice, clock}: {config: IBeaconConfig; forkChoice: IForkChoice; clock: IBeaconClock},
+  job: IBlockJob
+): void {
   try {
     const blockHash = config.types.phase0.BeaconBlock.hashTreeRoot(job.signedBlock.message);
     const blockSlot = job.signedBlock.message.slot;

--- a/packages/lodestar/src/chain/regen/queued.ts
+++ b/packages/lodestar/src/chain/regen/queued.ts
@@ -3,14 +3,13 @@ import {Root, phase0, Slot, allForks} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
-
 import {CheckpointStateCache, StateContextCache} from "../stateCache";
 import {ChainEventEmitter} from "../emitter";
+import {IMetrics} from "../../metrics";
 import {IBeaconDb} from "../../db";
 import {JobQueue} from "../../util/queue";
 import {IStateRegenerator} from "./interface";
 import {StateRegenerator} from "./regen";
-import {IMetrics} from "../../metrics";
 
 const REGEN_QUEUE_MAX_LEN = 256;
 

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -14,6 +14,7 @@ import {IBeaconDb} from "../../db";
 import {processSlotsByCheckpoint, runStateTransition} from "../blocks/stateTransition";
 import {IStateRegenerator} from "./interface";
 import {RegenError, RegenErrorCode} from "./errors";
+import {IMetrics} from "../../metrics";
 
 /**
  * Regenerates states that have already been processed by the fork choice
@@ -25,6 +26,7 @@ export class StateRegenerator implements IStateRegenerator {
   private stateCache: StateContextCache;
   private checkpointStateCache: CheckpointStateCache;
   private db: IBeaconDb;
+  private metrics: IMetrics | null;
 
   constructor({
     config,
@@ -33,6 +35,7 @@ export class StateRegenerator implements IStateRegenerator {
     stateCache,
     checkpointStateCache,
     db,
+    metrics,
   }: {
     config: IBeaconConfig;
     emitter: ChainEventEmitter;
@@ -40,6 +43,7 @@ export class StateRegenerator implements IStateRegenerator {
     stateCache: StateContextCache;
     checkpointStateCache: CheckpointStateCache;
     db: IBeaconDb;
+    metrics: IMetrics | null;
   }) {
     this.config = config;
     this.emitter = emitter;
@@ -47,6 +51,7 @@ export class StateRegenerator implements IStateRegenerator {
     this.stateCache = stateCache;
     this.checkpointStateCache = checkpointStateCache;
     this.db = db;
+    this.metrics = metrics;
   }
 
   async getPreState(block: phase0.BeaconBlock): Promise<CachedBeaconState<allForks.BeaconState>> {
@@ -113,14 +118,18 @@ export class StateRegenerator implements IStateRegenerator {
     // If a checkpoint state exists with the given checkpoint root, it either is in requested epoch
     // or needs to have empty slots processed until the requested epoch
     if (latestCheckpointStateCtx) {
-      return await processSlotsByCheckpoint(this.emitter, latestCheckpointStateCtx, slot);
+      return await processSlotsByCheckpoint(
+        {emitter: this.emitter, metrics: this.metrics},
+        latestCheckpointStateCtx,
+        slot
+      );
     }
 
     // Otherwise, use the fork choice to get the stateRoot from block at the checkpoint root
     // regenerate that state,
     // then process empty slots until the requested epoch
     const blockStateCtx = await this.getState(block.stateRoot);
-    return await processSlotsByCheckpoint(this.emitter, blockStateCtx, slot);
+    return await processSlotsByCheckpoint({emitter: this.emitter, metrics: this.metrics}, blockStateCtx, slot);
   }
 
   async getState(stateRoot: Root): Promise<CachedBeaconState<allForks.BeaconState>> {
@@ -189,13 +198,12 @@ export class StateRegenerator implements IStateRegenerator {
       }
 
       try {
-        state = await runStateTransition(this.emitter, this.forkChoice, this.checkpointStateCache, state, {
-          signedBlock: block,
-          reprocess: true,
-          prefinalized: true,
-          validSignatures: true,
-          validProposerSignature: true,
-        });
+        state = await runStateTransition(
+          {emitter: this.emitter, forkChoice: this.forkChoice, metrics: this.metrics},
+          this.checkpointStateCache,
+          state,
+          {signedBlock: block, reprocess: true, prefinalized: true, validSignatures: true, validProposerSignature: true}
+        );
         // this avoids keeping our node busy processing blocks
         await sleep(0);
       } catch (e) {

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -151,6 +151,19 @@ export function createLodestarMetrics(
       buckets: [0.01, 0.1, 0.5, 1, 5, 10],
     }),
 
+    // Beacon state transition metrics
+
+    stfnEpochTransition: register.histogram({
+      name: "lodestar_stfn_epoch_transition_seconds",
+      help: "Time to process a single epoch transition in seconds",
+      buckets: [0.1, 1, 10],
+    }),
+    stfnProcessBlock: register.histogram({
+      name: "lodestar_stfn_process_block_seconds",
+      help: "Time to process a single block in seconds",
+      buckets: [0.1, 1, 10],
+    }),
+
     // BLS verifier thread pool and queue
 
     blsThreadPoolSuccessJobsSignatureSetsCount: register.gauge({

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -179,6 +179,7 @@ export class BeaconNode {
       sync,
       network,
       chain,
+      metrics,
     });
 
     const metricsServer = metrics

--- a/packages/lodestar/test/unit/api/impl/validator/duties/proposer.test.ts
+++ b/packages/lodestar/test/unit/api/impl/validator/duties/proposer.test.ts
@@ -48,6 +48,7 @@ describe("get proposers api impl", function () {
       logger,
       network: server.networkStub,
       sync: syncStub,
+      metrics: null,
     };
     api = new ValidatorApi({}, modules);
   });

--- a/packages/lodestar/test/unit/api/impl/validator/produceAttestationData.test.ts
+++ b/packages/lodestar/test/unit/api/impl/validator/produceAttestationData.test.ts
@@ -31,6 +31,7 @@ describe("api - validator - produceAttestationData", function () {
       logger,
       network: server.networkStub,
       sync: syncStub,
+      metrics: null,
     };
   });
 

--- a/packages/lodestar/test/unit/chain/blocks/validate.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/validate.test.ts
@@ -26,7 +26,7 @@ describe("validateBlock", function () {
     const signedBlock = config.types.phase0.SignedBeaconBlock.defaultValue();
     const job = getNewBlockJob(signedBlock);
     try {
-      validateBlock({config, forkChoice, clock, job});
+      validateBlock({config, forkChoice, clock}, job);
       expect.fail("block should throw");
     } catch (e) {
       expect((e as BlockError).type.code).to.equal(BlockErrorCode.GENESIS_BLOCK);
@@ -39,7 +39,7 @@ describe("validateBlock", function () {
     const job = getNewBlockJob(signedBlock);
     forkChoice.hasBlock.returns(true);
     try {
-      validateBlock({config, forkChoice, clock, job});
+      validateBlock({config, forkChoice, clock}, job);
       expect.fail("block should throw");
     } catch (e) {
       expect((e as BlockError).type.code).to.equal(BlockErrorCode.BLOCK_IS_ALREADY_KNOWN);
@@ -53,7 +53,7 @@ describe("validateBlock", function () {
     forkChoice.hasBlock.returns(false);
     forkChoice.getFinalizedCheckpoint.returns({epoch: 5, root: Buffer.alloc(32)});
     try {
-      validateBlock({config, forkChoice, clock, job});
+      validateBlock({config, forkChoice, clock}, job);
       expect.fail("block should throw");
     } catch (e) {
       expect((e as BlockError).type.code).to.equal(BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT);
@@ -68,7 +68,7 @@ describe("validateBlock", function () {
     forkChoice.getFinalizedCheckpoint.returns({epoch: 0, root: Buffer.alloc(32)});
     sinon.stub(clock, "currentSlot").get(() => 0);
     try {
-      validateBlock({config, forkChoice, clock, job});
+      validateBlock({config, forkChoice, clock}, job);
       expect.fail("block should throw");
     } catch (e) {
       expect((e as BlockError).type.code).to.equal(BlockErrorCode.FUTURE_SLOT);

--- a/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
@@ -54,7 +54,11 @@ describe("block assembly", function () {
     const eth1 = sandbox.createStubInstance(Eth1ForBlockProduction);
     eth1.getEth1DataAndDeposits.resolves({eth1Data: state.eth1Data, deposits: []});
 
-    const result = await assembleBlock(config, chainStub, beaconDB, eth1, 1, Buffer.alloc(96, 0));
+    const result = await assembleBlock(
+      {config, chain: chainStub, db: beaconDB, eth1, metrics: null},
+      1,
+      Buffer.alloc(96, 0)
+    );
     expect(result).to.not.be.null;
     expect(result.slot).to.equal(1);
     expect(result.proposerIndex).to.equal(2);

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -83,6 +83,7 @@ export class MockBeaconChain implements IBeaconChain {
       stateCache: this.stateCache,
       checkpointStateCache: this.checkpointStateCache,
       db: new StubbedBeaconDb(sinon),
+      metrics: null,
     });
     this.forkDigestContext = new ForkDigestContext(this.config, this.genesisValidatorsRoot);
   }


### PR DESCRIPTION
**Motivation**

We need to know how long a epoch transition and block processing takes. This is arguably one of the most important metrics for us that we are currently trying to minimize, so we need to measure it.

**Description**

Closes https://github.com/ChainSafe/lodestar/issues/2426

The consumer code of the beacon state transition function is a bit messy so I've re-arranged it a bit so it's clearer what functions are local and which are exported