### PR TITLE
Metrics should be defined or null

### DIFF
--- a/packages/lodestar/src/api/rest/interface.ts
+++ b/packages/lodestar/src/api/rest/interface.ts
@@ -23,5 +23,5 @@ export interface IRestApiModules {
   config: IBeaconConfig;
   logger: ILogger;
   api: IApi;
-  metrics?: IMetrics;
+  metrics: IMetrics | null;
 }

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -23,7 +23,7 @@ type BlockProcessorModules = {
   regen: IStateRegenerator;
   emitter: ChainEventEmitter;
   bls: IBlsVerifier;
-  metrics?: IMetrics;
+  metrics: IMetrics | null;
   clock: IBeaconClock;
   checkpointStateCache: CheckpointStateCache;
 };
@@ -46,12 +46,14 @@ export class BlockProcessor {
     this.modules = modules;
     this.jobQueue = new JobQueue(
       {maxLength, signal},
-      modules.metrics && {
-        length: modules.metrics.blockProcessorQueueLength,
-        droppedJobs: modules.metrics.blockProcessorQueueDroppedJobs,
-        jobTime: modules.metrics.blockProcessorQueueJobTime,
-        jobWaitTime: modules.metrics.blockProcessorQueueJobWaitTime,
-      }
+      modules.metrics
+        ? {
+            length: modules.metrics.blockProcessorQueueLength,
+            droppedJobs: modules.metrics.blockProcessorQueueDroppedJobs,
+            jobTime: modules.metrics.blockProcessorQueueJobTime,
+            jobWaitTime: modules.metrics.blockProcessorQueueJobWaitTime,
+          }
+        : undefined
     );
   }
 

--- a/packages/lodestar/src/chain/bls/multithread/index.ts
+++ b/packages/lodestar/src/chain/bls/multithread/index.ts
@@ -15,7 +15,7 @@ import {IMetrics} from "../../../metrics";
 
 export type BlsMultiThreadWorkerPoolModules = {
   logger: ILogger;
-  metrics?: IMetrics;
+  metrics: IMetrics | null;
   signal: AbortSignal;
 };
 
@@ -69,7 +69,7 @@ type WorkerDescriptor = {
  */
 export class BlsMultiThreadWorkerPool {
   private readonly logger: ILogger;
-  private readonly metrics?: IMetrics;
+  private readonly metrics: IMetrics | null;
   private readonly signal: AbortSignal;
 
   private readonly format: PointFormat;

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -36,7 +36,7 @@ export interface IBeaconChainModules {
   config: IBeaconConfig;
   db: IBeaconDb;
   logger: ILogger;
-  metrics?: IMetrics;
+  metrics: IMetrics | null;
   anchorState: TreeBacked<allForks.BeaconState>;
 }
 
@@ -60,7 +60,7 @@ export class BeaconChain implements IBeaconChain {
   protected readonly config: IBeaconConfig;
   protected readonly db: IBeaconDb;
   protected readonly logger: ILogger;
-  protected readonly metrics?: IMetrics;
+  protected readonly metrics: IMetrics | null;
   protected readonly opts: IChainOptions;
   /**
    * Internal event emitter is used internally to the chain to update chain state

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -24,7 +24,7 @@ interface IGossipsubModules {
   validatorFns: TopicValidatorFnMap;
   forkDigestContext: IForkDigestContext;
   logger: ILogger;
-  metrics?: IMetrics;
+  metrics: IMetrics | null;
 }
 
 /**
@@ -44,7 +44,7 @@ export class Eth2Gossipsub extends Gossipsub {
   private readonly config: IBeaconConfig;
   private readonly forkDigestContext: IForkDigestContext;
   private readonly logger: ILogger;
-  private readonly metrics?: IMetrics;
+  private readonly metrics: IMetrics | null;
   /**
    * Cached gossip objects
    *

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -31,7 +31,7 @@ const gossipQueueOpts: {[K in GossipType]: {maxLength: number; type: QueueType}}
 
 export function createTopicValidatorFnMap(
   modules: IObjectValidatorModules,
-  metrics: IMetrics | undefined,
+  metrics: IMetrics | null,
   signal: AbortSignal
 ): TopicValidatorFnMap {
   const wrappedValidatorFns = mapValues(validatorFns, (validatorFn, type) =>
@@ -59,17 +59,19 @@ export function wrapWithQueue<K extends GossipType>(
   validatorFn: ValidatorFn<K>,
   modules: IObjectValidatorModules,
   queueOpts: JobQueueOpts,
-  metrics: IMetrics | undefined,
+  metrics: IMetrics | null,
   type: GossipType
 ): TopicValidatorFn {
   const jobQueue = new JobQueue(
     queueOpts,
-    metrics && {
-      length: metrics.gossipValidationQueueLength.child({topic: type}),
-      droppedJobs: metrics.gossipValidationQueueDroppedJobs.child({topic: type}),
-      jobTime: metrics.gossipValidationQueueJobTime.child({topic: type}),
-      jobWaitTime: metrics.gossipValidationQueueJobWaitTime.child({topic: type}),
-    }
+    metrics
+      ? {
+          length: metrics.gossipValidationQueueLength.child({topic: type}),
+          droppedJobs: metrics.gossipValidationQueueDroppedJobs.child({topic: type}),
+          jobTime: metrics.gossipValidationQueueJobTime.child({topic: type}),
+          jobWaitTime: metrics.gossipValidationQueueJobWaitTime.child({topic: type}),
+        }
+      : undefined
   );
   return async function (_topicStr, gossipMsg) {
     const {gossipTopic, gossipObject} = parseGossipMsg<K>(gossipMsg);

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -28,7 +28,7 @@ interface INetworkModules {
   config: IBeaconConfig;
   libp2p: LibP2p;
   logger: ILogger;
-  metrics?: IMetrics;
+  metrics: IMetrics | null;
   chain: IBeaconChain;
   db: IBeaconDb;
   reqRespHandler: IReqRespHandler;

--- a/packages/lodestar/src/network/peers/peerManager.ts
+++ b/packages/lodestar/src/network/peers/peerManager.ts
@@ -51,7 +51,7 @@ export type PeerManagerOpts = {
 export type PeerManagerModules = {
   libp2p: LibP2p;
   logger: ILogger;
-  metrics?: IMetrics;
+  metrics: IMetrics | null;
   reqResp: IReqResp;
   chain: IBeaconChain;
   config: IBeaconConfig;
@@ -71,7 +71,7 @@ export type PeerManagerModules = {
 export class PeerManager {
   private libp2p: LibP2p;
   private logger: ILogger;
-  private metrics?: IMetrics;
+  private metrics: IMetrics | null;
   private reqResp: IReqResp;
   private chain: IBeaconChain;
   private config: IBeaconConfig;

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -27,7 +27,7 @@ export interface IBeaconNodeModules {
   opts: IBeaconNodeOptions;
   config: IBeaconConfig;
   db: IBeaconDb;
-  metrics?: IMetrics;
+  metrics: IMetrics | null;
   network: INetwork;
   chain: IBeaconChain;
   api: IApi;
@@ -61,7 +61,7 @@ export class BeaconNode {
   opts: IBeaconNodeOptions;
   config: IBeaconConfig;
   db: IBeaconDb;
-  metrics?: IMetrics;
+  metrics: IMetrics | null;
   metricsServer?: HttpMetricsServer;
   network: INetwork;
   chain: IBeaconChain;
@@ -121,7 +121,7 @@ export class BeaconNode {
     // start db if not already started
     await db.start();
 
-    const metrics = opts.metrics.enabled ? createMetrics(opts.metrics) : undefined;
+    const metrics = opts.metrics.enabled ? createMetrics(opts.metrics) : null;
     if (metrics) {
       initBeaconMetrics(metrics, anchorState);
     }

--- a/packages/lodestar/src/sync/interface.ts
+++ b/packages/lodestar/src/sync/interface.ts
@@ -41,7 +41,7 @@ export interface ISyncModules {
   db: IBeaconDb;
   logger: ILogger;
   chain: IBeaconChain;
-  metrics?: IMetrics;
+  metrics: IMetrics | null;
   regularSync?: IRegularSync;
   gossipHandler?: BeaconGossipHandler;
   attestationCollector?: AttestationCollector;

--- a/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
@@ -30,7 +30,7 @@ describe("chain / bls / multithread queue", function () {
       });
     }
 
-    const pool = new BlsMultiThreadWorkerPool("blst-native", {logger, signal: controller.signal});
+    const pool = new BlsMultiThreadWorkerPool("blst-native", {logger, metrics: null, signal: controller.signal});
     const isValidArr = await Promise.all(
       Array.from({length: 8}, (i) => i).map(() => pool.verifySignatureSets(sets, true))
     );

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -63,7 +63,7 @@ describe("network", function () {
     const loggerA = testLogger("A");
     const loggerB = testLogger("B");
 
-    const modules = {config, chain, db, reqRespHandler, signal: controller.signal};
+    const modules = {config, chain, db, reqRespHandler, signal: controller.signal, metrics: null};
     const netA = new Network(opts, {...modules, libp2p: libp2pA, logger: loggerA});
     const netB = new Network(opts, {...modules, libp2p: libp2pB, logger: loggerB});
 

--- a/packages/lodestar/test/e2e/network/reqresp.test.ts
+++ b/packages/lodestar/test/e2e/network/reqresp.test.ts
@@ -75,7 +75,7 @@ describe("network / ReqResp", function () {
       ...reqRespHandlerPartial,
     };
     const opts = {...networkOptsDefault, ...reqRespOpts};
-    const modules = {config, db, chain, reqRespHandler, signal: controller.signal};
+    const modules = {config, db, chain, reqRespHandler, signal: controller.signal, metrics: null};
     const netA = new Network(opts, {...modules, libp2p: libp2pA, logger: testLogger("A")});
     const netB = new Network(opts, {...modules, libp2p: libp2pB, logger: testLogger("B")});
     await Promise.all([netA.start(), netB.start()]);

--- a/packages/lodestar/test/unit/api/rest/debug/getState.test.ts
+++ b/packages/lodestar/test/unit/api/rest/debug/getState.test.ts
@@ -25,11 +25,7 @@ describe("rest - debug - getState", function () {
         host: "127.0.0.1",
         port: 0,
       },
-      {
-        config,
-        logger: testLogger(),
-        api,
-      }
+      {config, logger: testLogger(), api, metrics: null}
     );
     debugBeaconStub = api.debug.beacon as SinonStubbedInstance<DebugBeaconApi>;
   });

--- a/packages/lodestar/test/unit/api/rest/index.test.ts
+++ b/packages/lodestar/test/unit/api/rest/index.test.ts
@@ -28,10 +28,6 @@ export async function setupRestApiTestServer(): Promise<RestApi> {
       host: "127.0.0.1",
       port: 0,
     },
-    {
-      config,
-      logger: testLogger(),
-      api,
-    }
+    {config, logger: testLogger(), api, metrics: null}
   );
 }

--- a/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
@@ -23,6 +23,8 @@ import {testLogger} from "../../../utils/logger";
 import {ForkDigestContext} from "../../../../src/util/forkDigestContext";
 
 describe("gossipsub", function () {
+  const logger = testLogger();
+  const metrics = null;
   let validatorFns: TopicValidatorFnMap;
   let gossipSub: Eth2Gossipsub;
   let message: InMessage;
@@ -52,7 +54,7 @@ describe("gossipsub", function () {
     validatorFns.set(topicString, () => {
       throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
     });
-    gossipSub = new Eth2Gossipsub({config, validatorFns, logger: testLogger(), forkDigestContext, libp2p});
+    gossipSub = new Eth2Gossipsub({config, validatorFns, logger, forkDigestContext, libp2p, metrics});
 
     try {
       await gossipSub.validate(message);
@@ -63,7 +65,7 @@ describe("gossipsub", function () {
   });
 
   it("should not throw on successful validation", async () => {
-    gossipSub = new Eth2Gossipsub({config, validatorFns, logger: testLogger(), forkDigestContext, libp2p});
+    gossipSub = new Eth2Gossipsub({config, validatorFns, logger, forkDigestContext, libp2p, metrics});
     await gossipSub.validate(message);
     // no error means pass validation
   });

--- a/packages/lodestar/test/unit/sync/gossip/handler.test.ts
+++ b/packages/lodestar/test/unit/sync/gossip/handler.test.ts
@@ -42,6 +42,7 @@ describe("gossip handler", function () {
       validatorFns: new Map<string, TopicValidatorFn>(),
       logger: testLogger(),
       forkDigestContext,
+      metrics: null,
     });
     networkStub.gossip = gossipsub;
     gossipsub.start();


### PR DESCRIPTION
**Motivation**

Typing the metrics module as `IMetrics | undefined` is dangerous because you can forget to add and Typescript won't alert us.

**Description**

Type it as `IMetrics | null` so types ensure we pass metrics to all functions that need it.