### PR TITLE
Improve BLS thread pool metrics

### DIFF
--- a/docker/grafana/provisioning/dashboards/lodestar.json
+++ b/docker/grafana/provisioning/dashboards/lodestar.json
@@ -938,7 +938,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 14,
@@ -1034,7 +1034,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 16,
@@ -1135,7 +1135,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 11
+            "y": 26
           },
           "hiddenSeries": false,
           "id": 44,
@@ -1231,7 +1231,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 11
+            "y": 26
           },
           "hiddenSeries": false,
           "id": 58,
@@ -1326,7 +1326,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 60,
@@ -1421,7 +1421,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 62,
@@ -1516,7 +1516,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27
+            "y": 42
           },
           "hiddenSeries": false,
           "id": 64,
@@ -1643,7 +1643,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27
+            "y": 42
           },
           "hiddenSeries": false,
           "id": 40,
@@ -1748,7 +1748,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 50
           },
           "hiddenSeries": false,
           "id": 6,
@@ -1845,7 +1845,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 50
           },
           "hiddenSeries": false,
           "id": 42,
@@ -1875,7 +1875,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(process_cpu_user_seconds_total[1m])",
+              "expr": "rate(process_cpu_user_seconds_total[$__rate_interval])",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -2788,6 +2788,496 @@
         "x": 0,
         "y": 20
       },
+      "id": 92,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 61
+          },
+          "hiddenSeries": false,
+          "id": 94,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(lodestar_bls_thread_pool_success_time_seconds_sum[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "BLS thread pool utilization rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 61
+          },
+          "hiddenSeries": false,
+          "id": 95,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "delta(lodestar_bls_thread_pool_queue_job_wait_time_seconds_sum[$__rate_interval])/delta(lodestar_bls_thread_pool_queue_job_wait_time_seconds_count[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "BLS thread pool job wait time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 69
+          },
+          "hiddenSeries": false,
+          "id": 96,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "delta(lodestar_bls_thread_pool_success_time_seconds_sum[$__rate_interval])/delta(lodestar_bls_thread_pool_success_jobs_signature_sets_count[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "BLS thread pool signature set verification time / set",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 4,
+            "w": 12,
+            "x": 12,
+            "y": 69
+          },
+          "hiddenSeries": false,
+          "id": 97,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "delta(lodestar_bls_thread_pool_jobs_started_total[$__rate_interval])/delta(lodestar_bls_thread_pool_job_groups_started_total[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "BLS thread pool average job group size",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 4,
+            "w": 12,
+            "x": 12,
+            "y": 73
+          },
+          "hiddenSeries": false,
+          "id": 98,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "delta(lodestar_bls_thread_pool_success_jobs_signature_sets_count[$__rate_interval])/delta(lodestar_bls_thread_pool_jobs_started_total[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "BLS thread pool average signature sets per job",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "BLS worker pool",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
       "id": 25,
       "panels": [
         {
@@ -2995,7 +3485,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 22
       },
       "id": 75,
       "panels": [
@@ -3017,7 +3507,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 14
+            "y": 63
           },
           "hiddenSeries": false,
           "id": 77,
@@ -3112,7 +3602,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 14
+            "y": 63
           },
           "hiddenSeries": false,
           "id": 80,
@@ -3207,7 +3697,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 71
           },
           "hiddenSeries": false,
           "id": 79,
@@ -3231,6 +3721,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
+          "seriesOverrides": [],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
@@ -3302,7 +3793,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 22
+            "y": 71
           },
           "hiddenSeries": false,
           "id": 78,
@@ -3397,7 +3888,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 30
+            "y": 79
           },
           "hiddenSeries": false,
           "id": 82,
@@ -3474,6 +3965,101 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 79
+          },
+          "hiddenSeries": false,
+          "id": 88,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "lodestar_gossip_validation_queue_length",
+              "interval": "",
+              "legendFormat": "{{topic}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Gossip validation queue length",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 2,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "title": "Gossip validation",
@@ -3486,7 +4072,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 23
       },
       "id": 86,
       "panels": [
@@ -3514,7 +4100,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 15
+            "y": 23
           },
           "hiddenSeries": false,
           "id": 84,
@@ -3610,7 +4196,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 15
+            "y": 23
           },
           "hiddenSeries": false,
           "id": 87,
@@ -3698,7 +4284,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 24
       },
       "id": 66,
       "panels": [
@@ -3727,7 +4313,7 @@
             "h": 7,
             "w": 10,
             "x": 0,
-            "y": 8
+            "y": 56
           },
           "id": 68,
           "options": {
@@ -3781,7 +4367,7 @@
             "h": 7,
             "w": 14,
             "x": 10,
-            "y": 8
+            "y": 56
           },
           "id": 70,
           "options": {
@@ -3831,5 +4417,5 @@
   "timezone": "",
   "title": "Lodestar",
   "uid": "lodestar",
-  "version": 4
+  "version": 5
 }

--- a/docker/grafana/provisioning/dashboards/lodestar.json
+++ b/docker/grafana/provisioning/dashboards/lodestar.json
@@ -1959,7 +1959,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 48,
@@ -2057,7 +2057,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 50,
@@ -2808,7 +2808,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 61
+            "y": 21
           },
           "hiddenSeries": false,
           "id": 94,
@@ -2903,7 +2903,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 61
+            "y": 21
           },
           "hiddenSeries": false,
           "id": 95,
@@ -2998,7 +2998,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 69
+            "y": 29
           },
           "hiddenSeries": false,
           "id": 96,
@@ -3093,7 +3093,7 @@
             "h": 4,
             "w": 12,
             "x": 12,
-            "y": 69
+            "y": 29
           },
           "hiddenSeries": false,
           "id": 97,
@@ -3188,7 +3188,7 @@
             "h": 4,
             "w": 12,
             "x": 12,
-            "y": 73
+            "y": 33
           },
           "hiddenSeries": false,
           "id": 98,
@@ -3299,7 +3299,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5
+            "y": 22
           },
           "hiddenSeries": false,
           "id": 26,
@@ -3396,7 +3396,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5
+            "y": 22
           },
           "hiddenSeries": false,
           "id": 81,
@@ -3507,7 +3507,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 63
+            "y": 23
           },
           "hiddenSeries": false,
           "id": 77,
@@ -3602,7 +3602,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 63
+            "y": 23
           },
           "hiddenSeries": false,
           "id": 80,
@@ -3697,7 +3697,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 71
+            "y": 31
           },
           "hiddenSeries": false,
           "id": 79,
@@ -3793,7 +3793,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 71
+            "y": 31
           },
           "hiddenSeries": false,
           "id": 78,
@@ -3823,7 +3823,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "lodestar_gossip_validation_queue_dropped_jobs_total/(lodestar_gossip_validation_queue_job_time_seconds_count+lodestar_gossip_validation_queue_dropped_jobs_total)",
+              "expr": "delta(lodestar_gossip_validation_queue_dropped_jobs_total[$__rate_interval])/(delta(lodestar_gossip_validation_queue_job_time_seconds_count[$__rate_interval])+delta(lodestar_gossip_validation_queue_dropped_jobs_total[$__rate_interval]))",
               "interval": "",
               "legendFormat": "{{topic}}",
               "refId": "A"
@@ -3888,7 +3888,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 79
+            "y": 39
           },
           "hiddenSeries": false,
           "id": 82,
@@ -3984,7 +3984,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 79
+            "y": 39
           },
           "hiddenSeries": false,
           "id": 88,
@@ -4100,7 +4100,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 84,
@@ -4196,7 +4196,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 87,

--- a/packages/lodestar/src/chain/bls/multithread/types.ts
+++ b/packages/lodestar/src/chain/bls/multithread/types.ts
@@ -1,5 +1,6 @@
 export type WorkerData = {
   implementation: "herumi" | "blst-native";
+  workerId: number;
 };
 
 export type BlsWorkReq = {
@@ -15,7 +16,7 @@ export enum WorkResultCode {
 }
 
 export type WorkResult<R> =
-  | {code: WorkResultCode.success; result: R; workerJobTimeMs: number}
+  | {code: WorkResultCode.success; result: R; workerJobTimeMs: number; workerId: number}
   | {code: WorkResultCode.error; error: Error};
 
 export enum WorkerMessageCode {

--- a/packages/lodestar/src/chain/bls/multithread/worker.ts
+++ b/packages/lodestar/src/chain/bls/multithread/worker.ts
@@ -10,7 +10,7 @@ const MIN_SET_COUNT_TO_BATCH = 2;
 // Cloned data from instatiation
 const workerData = worker.workerData as WorkerData;
 if (!workerData) throw Error("workerData must be defined");
-const {implementation} = workerData || {};
+const {implementation, workerId} = workerData || {};
 
 expose({
   async doManyBlsWorkReq(workReqArr: BlsWorkReq[]): Promise<WorkResult<boolean>[]> {
@@ -25,7 +25,7 @@ function doManyBlsWorkReq(workReqArr: BlsWorkReq[]): WorkResult<boolean>[] {
       const start = Date.now();
       const isValid = verifySignatureSetsMaybeBatch(workReq);
       const workerJobTimeMs = Date.now() - start;
-      return {code: WorkResultCode.success, result: isValid, workerJobTimeMs};
+      return {code: WorkResultCode.success, result: isValid, workerJobTimeMs, workerId};
     } catch (e) {
       return {code: WorkResultCode.error, error: e as Error};
     }

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -148,7 +148,7 @@ export function createLodestarMetrics(
       buckets: [0.1, 1, 10],
     }),
     blsThreadPoolQueueLength: register.gauge({
-      name: "lodestar_block_processor_queue_length",
+      name: "lodestar_bls_thread_pool_queue_length",
       help: "Count of total block processor queue length",
     }),
     blsThreadPoolTotalJobsGroupsStarted: register.gauge({

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -134,22 +134,30 @@ export function createLodestarMetrics(
       name: "lodestar_bls_thread_pool_success_jobs_signature_sets_count",
       help: "Count of total verified signature sets",
     }),
-    blsThreadPoolSuccessJobsWorkerTime: register.gauge({
+    blsThreadPoolSuccessJobsWorkerTime: register.gauge<"workerId">({
       name: "lodestar_bls_thread_pool_success_time_seconds_sum",
       help: "Total time spent verifying signature sets measured on the worker",
+    }),
+    blsThreadPoolErrorJobsSignatureSetsCount: register.gauge({
+      name: "lodestar_bls_thread_pool_error_jobs_signature_sets_count",
+      help: "Count of total error-ed signature sets",
     }),
     blsThreadPoolJobWaitTime: register.histogram({
       name: "lodestar_bls_thread_pool_queue_job_wait_time_seconds",
       help: "Time from job added to the queue to starting the job in seconds",
       buckets: [0.1, 1, 10],
     }),
-    blsThreadPoolTotalJobsStarted: register.gauge({
-      name: "lodestar_bls_thread_pool_jobs_started_total",
-      help: "Count of total jobs started in bls thread pool, jobs include +1 signature sets",
+    blsThreadPoolQueueLength: register.gauge({
+      name: "lodestar_block_processor_queue_length",
+      help: "Count of total block processor queue length",
     }),
     blsThreadPoolTotalJobsGroupsStarted: register.gauge({
       name: "lodestar_bls_thread_pool_job_groups_started_total",
       help: "Count of total jobs groups started in bls thread pool, job groups include +1 jobs",
+    }),
+    blsThreadPoolTotalJobsStarted: register.gauge({
+      name: "lodestar_bls_thread_pool_jobs_started_total",
+      help: "Count of total jobs started in bls thread pool, jobs include +1 signature sets",
     }),
 
     // Sync
@@ -159,7 +167,6 @@ export function createLodestarMetrics(
       help: "Total number of sync chains started events, labeled by syncType",
       labelNames: ["syncType"],
     }),
-
     syncStatus: register.gauge({
       name: "lodestar_sync_status",
       help: "Range sync status: [Stalled, SyncingFinalized, SyncingHead, Synced]",


### PR DESCRIPTION
**Motivation**

Iterate on the existing BLS thread pool metrics

**Description**

- Add Grafana charts for existing metrics
- Label time per sig count with workerId to check the distribution of load between workers
- Add queue length metric
- Fix time metric unit, ms -> sec