### PR TITLE
Add clock slot and genesis time metrics

### DIFF
--- a/docker/grafana/provisioning/dashboards/lodestar.json
+++ b/docker/grafana/provisioning/dashboards/lodestar.json
@@ -33,7 +33,12 @@
       "type": "row"
     },
     {
-      "aliasColors": {},
+      "aliasColors": {
+        "(time() - lodestar_genesis_time) / 12": "rgba(48, 208, 255, 0.51)",
+        "clock slot": "rgba(105, 220, 255, 0.53)",
+        "head slot": "green",
+        "process restart": "dark-red"
+      },
       "bars": false,
       "dashLength": 10,
       "dashes": false,
@@ -75,16 +80,37 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "process restart",
+          "yaxis": 2
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "beacon_head_slot",
+          "expr": "(time() - lodestar_genesis_time) / 12",
+          "hide": false,
+          "instant": false,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "clock slot",
+          "refId": "C"
+        },
+        {
+          "expr": "beacon_head_slot",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "head slot",
           "refId": "A"
+        },
+        {
+          "expr": "changes(process_start_time_seconds[5m])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "process restart",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -115,11 +141,12 @@
           "show": true
         },
         {
+          "decimals": 0,
           "format": "short",
           "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
+          "max": "1",
+          "min": "0.1",
           "show": true
         }
       ],

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -93,6 +93,7 @@ export function handleChainEvents(this: BeaconChain, signal: AbortSignal): void 
 export async function onClockSlot(this: BeaconChain, slot: Slot): Promise<void> {
   this.logger.verbose("Clock slot", {slot});
   this.forkChoice.updateTime(slot);
+  this.metrics?.clockSlot.set(slot);
 
   await Promise.all(
     // Attestations can only affect the fork choice of subsequent slots.

--- a/packages/lodestar/src/metrics/metrics.ts
+++ b/packages/lodestar/src/metrics/metrics.ts
@@ -1,6 +1,7 @@
 /**
  * @module metrics
  */
+import {BeaconState} from "@chainsafe/lodestar-types/lib/allForks";
 import {collectDefaultMetrics, Registry} from "prom-client";
 import gcStats from "prometheus-gc-stats";
 import {createBeaconMetrics, IBeaconMetrics} from "./metrics/beacon";
@@ -10,10 +11,10 @@ import {RegistryMetricCreator} from "./utils/registryMetricCreator";
 
 export type IMetrics = IBeaconMetrics & ILodestarMetrics & {register: Registry};
 
-export function createMetrics(opts?: IMetricsOptions): IMetrics {
+export function createMetrics(opts?: IMetricsOptions, anchorState?: BeaconState): IMetrics {
   const register = new RegistryMetricCreator();
   const beacon = createBeaconMetrics(register);
-  const lodestar = createLodestarMetrics(register, opts?.metadata);
+  const lodestar = createLodestarMetrics(register, opts?.metadata, anchorState);
 
   collectDefaultMetrics({
     register,

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -1,3 +1,4 @@
+import {BeaconState} from "@chainsafe/lodestar-types/lib/allForks";
 import {RegistryMetricCreator} from "../utils/registryMetricCreator";
 import {IMetricsOptions} from "../options";
 
@@ -7,7 +8,11 @@ export type ILodestarMetrics = ReturnType<typeof createLodestarMetrics>;
  * Extra Lodestar custom metrics
  */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
-export function createLodestarMetrics(register: RegistryMetricCreator, metadata: IMetricsOptions["metadata"]) {
+export function createLodestarMetrics(
+  register: RegistryMetricCreator,
+  metadata: IMetricsOptions["metadata"],
+  anchorState?: BeaconState
+) {
   if (metadata) {
     register.static<"semver" | "branch" | "commit" | "version" | "network">({
       name: "lodestar_version",
@@ -16,7 +21,24 @@ export function createLodestarMetrics(register: RegistryMetricCreator, metadata:
     });
   }
 
+  // Initial static metrics
+  if (anchorState) {
+    register
+      .gauge({
+        name: "lodestar_genesis_time",
+        help: "Genesis time in seconds",
+      })
+      .set(anchorState.genesisTime);
+  }
+
   return {
+    clockSlot: register.gauge({
+      name: "lodestar_clock_slot",
+      help: "Current clock slot",
+    }),
+
+    // Peers
+
     peersByDirection: register.gauge<"direction">({
       name: "lodestar_peers_by_direction",
       help: "number of peers, labeled by direction",

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -121,7 +121,7 @@ export class BeaconNode {
     // start db if not already started
     await db.start();
 
-    const metrics = opts.metrics.enabled ? createMetrics(opts.metrics) : null;
+    const metrics = opts.metrics.enabled ? createMetrics(opts.metrics, anchorState) : null;
     if (metrics) {
       initBeaconMetrics(metrics, anchorState);
     }


### PR DESCRIPTION
**Motivation**

Allow to monitor from Grafana charts the sync status and compute clock drift

**Description**

After merging the slot chart can be modified to add
```
(time() - lodestar_genesis_time) / 12
```
```
lodestar_clock_slot
```
To monitor everything in one chart

![Screenshot from 2021-05-02 15-48-05](https://user-images.githubusercontent.com/35266934/116815504-24f14800-ab5e-11eb-8e43-3b679121d1b7.png)



Also consider adding a new chart with
```
lodestar_clock_slot - (time() - lodestar_genesis_time) / 12
```
to measure clock drift

Closes https://github.com/ChainSafe/lodestar/issues/2462
