### PR TITLE
Add log debug to file in docker setup

### DIFF
--- a/docker-compose.validator.yml
+++ b/docker-compose.validator.yml
@@ -8,10 +8,12 @@ services:
       - beacon_node
     volumes:
       - validator:/data
+      - logs:/logs
       - ./keystores:/keystores
       - ./secrets:/secrets
     env_file: .env
-    command: validator --rootDir /data --keystoresDir /keystores --secretsDir /secrets --server http://beacon_node:9596
+    command: validator --rootDir /data --keystoresDir /keystores --secretsDir /secrets --server http://beacon_node:9596 --logFile /logs/validator.log --logLevelFile debug
 
 volumes:
   validator:
+  logs:

--- a/docker-compose.validator.yml
+++ b/docker-compose.validator.yml
@@ -4,8 +4,6 @@ services:
     build: .
     image: lodestar
     restart: always
-    depends_on:
-      - beacon_node
     volumes:
       - validator:/data
       - logs:/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ services:
     restart: always
     volumes:
       - "prometheus:/prometheus"
-    depends_on:
-      - beacon_node
 
   grafana:
     build: docker/grafana
@@ -28,8 +26,6 @@ services:
       - "3000:3000"
     volumes:
       - "grafana:/var/lib/grafana"
-    depends_on:
-      - prometheus
 
 volumes:
   beacon_node:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,12 @@ services:
     restart: always
     volumes:
       - beacon_node:/data
+      - logs:/logs
     env_file: .env
     ports:
       - "9000:9000" # P2P port
       - "9596:9596" # REST API port
-    command: beacon --rootDir /data --api.rest.host 0.0.0.0 --metrics.enabled
+    command: beacon --rootDir /data --api.rest.host 0.0.0.0 --metrics.enabled --logFile /logs/beacon.log --logLevelFile debug
 
   prometheus:
     build: docker/prometheus
@@ -32,5 +33,6 @@ services:
 
 volumes:
   beacon_node:
+  logs:
   prometheus:
   grafana:


### PR DESCRIPTION
**Motivation**

When running the node not having the debug logs often means an issue can't be solved, it's very important information.

**Description**

Adds log debug to file in the default docker setup.

Note: the size of this files can grow really fast, we should add some log rotation mechanism in a new PR.