### PR TITLE
Add JobQueue features

### DIFF
--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -19,11 +19,11 @@ import {
 } from "./interface";
 
 // Numbers from https://github.com/sigp/lighthouse/blob/b34a79dc0b02e04441ba01fd0f304d1e203d877d/beacon_node/network/src/beacon_processor/mod.rs#L69
-const gossipQueueOpts: {[K in GossipType]: {maxLength: number; type: QueueType}} = {
+const gossipQueueOpts: {[K in GossipType]: Pick<JobQueueOpts, "maxLength" | "type" | "maxConcurrency">} = {
   [GossipType.beacon_block]: {maxLength: 1024, type: QueueType.FIFO},
   // this is different from lighthouse's, there are more gossip aggregate_and_proof than gossip block
-  [GossipType.beacon_aggregate_and_proof]: {maxLength: 4096, type: QueueType.LIFO},
-  [GossipType.beacon_attestation]: {maxLength: 16384, type: QueueType.LIFO},
+  [GossipType.beacon_aggregate_and_proof]: {maxLength: 4096, type: QueueType.LIFO, maxConcurrency: 16},
+  [GossipType.beacon_attestation]: {maxLength: 16384, type: QueueType.LIFO, maxConcurrency: 64},
   [GossipType.voluntary_exit]: {maxLength: 4096, type: QueueType.FIFO},
   [GossipType.proposer_slashing]: {maxLength: 4096, type: QueueType.FIFO},
   [GossipType.attester_slashing]: {maxLength: 4096, type: QueueType.FIFO},


### PR DESCRIPTION
**Motivation**

To take advantage of BLS batch processing we should allow the gossip validation queues to ingest more than one item at once.

**Description**

- Allow customization concurrency in the JobQueue
- Yield to the macro queue every N milliseconds instead of on every job