### PR TITLE
Add missing getSyncChainsDebugState rest route

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/api.ts
+++ b/packages/cli/src/options/beaconNodeOptions/api.ts
@@ -28,6 +28,8 @@ export const options: ICliCommandOptions<IApiArgs> = {
     description: "Pick namespaces to expose for HTTP API",
     defaultDescription: JSON.stringify(defaultOptions.api.rest.api),
     group: "api",
+    // Parse ["debug,lodestar"] to ["debug", "lodestar"]
+    coerce: (namespaces: string[]): string[] => namespaces.map((val) => val.split(",")).flat(1),
   },
 
   "api.rest.cors": {

--- a/packages/cli/test/e2e/cmds/init.test.ts
+++ b/packages/cli/test/e2e/cmds/init.test.ts
@@ -1,11 +1,13 @@
 import fs from "fs";
 import {expect} from "chai";
+import rimraf from "rimraf";
 import {IBeaconNodeOptions} from "@chainsafe/lodestar";
 import {ReturnType as InitReturnType} from "../../../src/cmds/init";
 import {getBeaconPaths} from "../../../src/cmds/beacon/paths";
 import {depositContractDeployBlock} from "../../../src/networks/pyrmont";
 import {testFilesDir} from "../../utils";
 import {getLodestarCliTestRunner} from "../commandRunner";
+import {ApiNamespace} from "@chainsafe/lodestar/lib/api";
 
 describe("cmds / init", function () {
   const lodestar = getLodestarCliTestRunner();
@@ -13,6 +15,10 @@ describe("cmds / init", function () {
   const rootDir = testFilesDir;
   const networkName = "pyrmont";
   const beaconPaths = getBeaconPaths({rootDir});
+
+  afterEach(() => {
+    rimraf.sync(rootDir);
+  });
 
   it("should init beacon configuration with --network option", async function () {
     await lodestar<InitReturnType>([
@@ -30,6 +36,63 @@ describe("cmds / init", function () {
     expect(beaconConfig.eth1.depositContractDeployBlock).to.equal(
       depositContractDeployBlock,
       "Wrong depositContractDeployBlock for --network pyrmont setting"
+    );
+  });
+
+  it("should parse --api.rest.api options as array", async function () {
+    await lodestar<InitReturnType>([
+      //
+      "init",
+      `--api.rest.api ${ApiNamespace.DEBUG} --api.rest.api ${ApiNamespace.LODESTAR}`,
+      `--rootDir ${rootDir}`,
+    ]);
+
+    expect(fs.existsSync(beaconPaths.configFile), `Must write config file to ${beaconPaths.configFile}`).to.be.true;
+    const beaconConfig: IBeaconNodeOptions = JSON.parse(
+      fs.readFileSync(beaconPaths.configFile, "utf8")
+    ) as IBeaconNodeOptions;
+
+    expect(beaconConfig.api.rest.api).to.deep.equal(
+      [ApiNamespace.DEBUG, ApiNamespace.LODESTAR],
+      "Wrong beaconConfig.api.rest.api"
+    );
+  });
+
+  it("should parse --api.rest.api options as array shortform", async function () {
+    await lodestar<InitReturnType>([
+      //
+      "init",
+      `--api.rest.api ${ApiNamespace.DEBUG} ${ApiNamespace.LODESTAR}`,
+      `--rootDir ${rootDir}`,
+    ]);
+
+    expect(fs.existsSync(beaconPaths.configFile), `Must write config file to ${beaconPaths.configFile}`).to.be.true;
+    const beaconConfig: IBeaconNodeOptions = JSON.parse(
+      fs.readFileSync(beaconPaths.configFile, "utf8")
+    ) as IBeaconNodeOptions;
+
+    expect(beaconConfig.api.rest.api).to.deep.equal(
+      [ApiNamespace.DEBUG, ApiNamespace.LODESTAR],
+      "Wrong beaconConfig.api.rest.api"
+    );
+  });
+
+  it("should parse --api.rest.api options as array CSV", async function () {
+    await lodestar<InitReturnType>([
+      //
+      "init",
+      `--api.rest.api=${ApiNamespace.DEBUG},${ApiNamespace.LODESTAR}`,
+      `--rootDir ${rootDir}`,
+    ]);
+
+    expect(fs.existsSync(beaconPaths.configFile), `Must write config file to ${beaconPaths.configFile}`).to.be.true;
+    const beaconConfig: IBeaconNodeOptions = JSON.parse(
+      fs.readFileSync(beaconPaths.configFile, "utf8")
+    ) as IBeaconNodeOptions;
+
+    expect(beaconConfig.api.rest.api).to.deep.equal(
+      [ApiNamespace.DEBUG, ApiNamespace.LODESTAR],
+      "Wrong beaconConfig.api.rest.api"
     );
   });
 });

--- a/packages/lodestar/src/api/rest/index.ts
+++ b/packages/lodestar/src/api/rest/index.ts
@@ -30,7 +30,7 @@ export class RestApi {
     if (_opts.enabled) {
       try {
         const address = await api.server.listen(_opts.port, _opts.host);
-        logger.info("Started rest api server", {address});
+        logger.info("Started rest api server", {address, namespaces: _opts.api});
       } catch (e) {
         logger.error("Failed to start rest api server", {host: _opts.host, port: _opts.port}, e);
         throw e;

--- a/packages/lodestar/src/api/rest/lodestar/index.ts
+++ b/packages/lodestar/src/api/rest/lodestar/index.ts
@@ -55,4 +55,19 @@ export const createProof: ApiController<{paths: (string | number)[][]}, {stateId
   },
 };
 
-export const lodestarRoutes = [getWtfNode, getLatestWeakSubjectivityCheckpointEpoch, createProof];
+export const getSyncChainsDebugState: ApiController<{paths: (string | number)[][]}, {stateId: string}> = {
+  url: "/sync-chains-debug-state",
+  method: "GET",
+  id: "getSyncChainsDebugState",
+
+  handler: async function () {
+    return this.api.lodestar.getSyncChainsDebugState();
+  },
+};
+
+export const lodestarRoutes = [
+  getWtfNode,
+  getLatestWeakSubjectivityCheckpointEpoch,
+  createProof,
+  getSyncChainsDebugState,
+];


### PR DESCRIPTION
- Add missing getSyncChainsDebugState rest route
- Log api namespaces on initialization
- Allow --api.rest.api to be CSVs