### PR TITLE
Fast path for regen

### DIFF
--- a/packages/lodestar/src/chain/regen/queued.ts
+++ b/packages/lodestar/src/chain/regen/queued.ts
@@ -2,7 +2,7 @@ import {AbortSignal} from "abort-controller";
 import {Root, phase0, Slot, allForks} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconState, computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {CheckpointStateCache, StateContextCache} from "../stateCache";
 import {ChainEventEmitter} from "../emitter";
 import {IMetrics} from "../../metrics";
@@ -10,6 +10,7 @@ import {IBeaconDb} from "../../db";
 import {JobQueue} from "../../util/queue";
 import {IStateRegenerator} from "./interface";
 import {StateRegenerator} from "./regen";
+import {RegenError, RegenErrorCode} from "./errors";
 
 const REGEN_QUEUE_MAX_LEN = 256;
 
@@ -33,19 +34,60 @@ export class QueuedStateRegenerator implements IStateRegenerator {
   private regen: StateRegenerator;
   private jobQueue: JobQueue;
 
+  private config: IBeaconConfig;
+  private forkChoice: IForkChoice;
+  private stateCache: StateContextCache;
+  private checkpointStateCache: CheckpointStateCache;
+
   constructor(modules: QueuedStateRegeneratorModules) {
     this.regen = new StateRegenerator(modules);
     this.jobQueue = new JobQueue(
       {maxLength: REGEN_QUEUE_MAX_LEN, signal: modules.signal},
       modules.metrics ? modules.metrics.regenQueue : undefined
     );
+    this.config = modules.config;
+    this.forkChoice = modules.forkChoice;
+    this.stateCache = modules.stateCache;
+    this.checkpointStateCache = modules.checkpointStateCache;
   }
 
   async getPreState(block: allForks.BeaconBlock): Promise<CachedBeaconState<allForks.BeaconState>> {
+    // First attempt to fetch the state from caches before queueing
+    const parentBlock = this.forkChoice.getBlock(block.parentRoot);
+    if (!parentBlock) {
+      throw new RegenError({
+        code: RegenErrorCode.BLOCK_NOT_IN_FORKCHOICE,
+        blockRoot: block.parentRoot,
+      });
+    }
+
+    const parentEpoch = computeEpochAtSlot(this.config, parentBlock.slot);
+    const blockEpoch = computeEpochAtSlot(this.config, block.slot);
+
+    // Check the checkpoint cache (if the pre-state is a checkpoint state)
+    if (parentEpoch < blockEpoch) {
+      const checkpointState = this.checkpointStateCache.getLatest({root: block.parentRoot, epoch: blockEpoch});
+      if (checkpointState) {
+        return checkpointState;
+      }
+    }
+    // Check the state cache
+    const state = this.stateCache.get(parentBlock.stateRoot);
+    if (state) {
+      return state;
+    }
+
+    // The state is not immediately available in the caches, enqueue the job
     return await this.jobQueue.push(async () => await this.regen.getPreState(block));
   }
 
   async getCheckpointState(cp: phase0.Checkpoint): Promise<CachedBeaconState<allForks.BeaconState>> {
+    // First attempt to fetch the state from cache before queueing
+    const checkpointState = this.checkpointStateCache.get(cp);
+    if (checkpointState) {
+      return checkpointState;
+    }
+    // The state is not immediately available in the cache, enqueue the job
     return await this.jobQueue.push(async () => await this.regen.getCheckpointState(cp));
   }
 
@@ -54,6 +96,12 @@ export class QueuedStateRegenerator implements IStateRegenerator {
   }
 
   async getState(stateRoot: Root): Promise<CachedBeaconState<allForks.BeaconState>> {
+    // First attempt to fetch the state from cache before queueing
+    const state = this.stateCache.get(stateRoot);
+    if (state) {
+      return state;
+    }
+    // The state is not immediately available in the cache, enqueue the job
     return await this.jobQueue.push(async () => await this.regen.getState(stateRoot));
   }
 }

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -67,21 +67,12 @@ export class StateRegenerator implements IStateRegenerator {
     const blockEpoch = computeEpochAtSlot(this.config, block.slot);
 
     // This may save us at least one epoch transition.
-    // If the requested state crosses an epoch boundary and the block isn't a checkpoint block
+    // If the requested state crosses an epoch boundary
     // then we may use the checkpoint state before the block
-    // If block is a checkpoint block, we may have the checkpoint state with parent root inside the checkpoint state cache
+    // We may have the checkpoint state with parent root inside the checkpoint state cache
     // through gossip validation.
     if (parentEpoch < blockEpoch) {
-      const checkpointState = await this.getCheckpointState({root: block.parentRoot, epoch: blockEpoch});
-      if (checkpointState) {
-        return checkpointState;
-      }
-    }
-
-    // If there's more than one epoch to pre-process (but the block is a checkpoint block)
-    // get the checkpoint state as close as possible
-    if (parentEpoch < blockEpoch - 1) {
-      return await this.getCheckpointState({root: block.parentRoot, epoch: blockEpoch - 1});
+      return await this.getCheckpointState({root: block.parentRoot, epoch: blockEpoch});
     }
 
     // Otherwise, get the state normally.


### PR DESCRIPTION
**Motivation**

Looking at our prater node, many regen jobs are dropped due to the queue always being full.
In practice, many regen jobs may be resolved with already-cached states and do not need to be queued.

**Description**

Add several opportunities for regen methods to first look in the caches before putting the regen job in the queue.
