### PR TITLE
Add light client getState

### DIFF
--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -42,7 +42,9 @@
     "@chainsafe/lodestar-params": "^0.21.0",
     "@chainsafe/lodestar-types": "^0.21.0",
     "@chainsafe/lodestar-utils": "^0.21.0",
-    "@chainsafe/ssz": "^0.8.4"
+    "@chainsafe/persistent-merkle-tree": "^0.3.0",
+    "@chainsafe/ssz": "^0.8.2",
+    "axios": "^0.21.1"
   },
   "keywords": [
     "ethereum",

--- a/packages/light-client/src/getState.ts
+++ b/packages/light-client/src/getState.ts
@@ -1,0 +1,24 @@
+import axios from "axios";
+
+import {TreeBacked} from "@chainsafe/ssz";
+import {phase0} from "@chainsafe/lodestar-types";
+import {deserializeProof} from "@chainsafe/persistent-merkle-tree";
+import {config} from "@chainsafe/lodestar-config/mainnet";
+
+const BEACON_URL = "http://localhost:9596";
+const STATE_PROOF_URL = `${BEACON_URL}/eth/v1/lodestar/proof`;
+
+const client = axios.create();
+
+type Path = (string | number)[];
+
+export async function getState(id: string, paths: Path[]): Promise<TreeBacked<phase0.BeaconState>> {
+  const resp = await client.request({
+    url: `${STATE_PROOF_URL}/${id}`,
+    method: "POST",
+    data: {paths},
+    responseType: "arraybuffer",
+  });
+  const proof = deserializeProof(resp.data as Uint8Array);
+  return config.types.phase0.BeaconState.createTreeBackedFromProofUnsafe(proof);
+}


### PR DESCRIPTION
**Motivation**

Part of the light client hackathon.
We want the light client to be able to fetch a state proof, reassemble it into an ssz partial. This PR introduces minimal code for a POC of this.

**Description**

- Add light client `getState` function. It uses the lodestar `/proof/:stateId` REST endpoint to request a proof of a state and return a partial `TreeBacked<BeaconState>`.
The proof is specified by the stateId, eg: `"head"` and the paths, eg: `[["slot"], ["validators", 0, "exitEpoch"]]`.
This is a POC because the proof is not verified against a known state root -- but it is actually reassembling a state from a multiproof.