### PR TITLE
No event when reprocess blocks

### DIFF
--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -99,12 +99,14 @@ export async function runStateTransition(
   }
   forkChoice.onBlock(job.signedBlock.message, postState, justifiedBalances);
 
-  if (postSlot % SLOTS_PER_EPOCH === 0) {
-    emitCheckpointEvent(emitter, postState);
-  }
+  if (!job.reprocess) {
+    if (postSlot % SLOTS_PER_EPOCH === 0) {
+      emitCheckpointEvent(emitter, postState);
+    }
 
-  emitBlockEvent(emitter, job, postState);
-  emitForkChoiceHeadEvents(emitter, forkChoice, forkChoice.getHead(), oldHead);
+    emitBlockEvent(emitter, job, postState);
+    emitForkChoiceHeadEvents(emitter, forkChoice, forkChoice.getHead(), oldHead);
+  }
 
   return postState;
 }


### PR DESCRIPTION
**Motivation**
+ The new `postState.currentJustifiedCheckpoint` does not exist in cache
+ Currently when we reprocess blocks, we emit checkpoint events, and the event handler do `checkpointStateCache.prune` which may prune a checkpoint state cache that later on become a justified checkpoint.

**Description**

When we reprocess blocks, don't emit any events

Closes #2498 
