### PR TITLE
Add attestations to the performance tests

### DIFF
--- a/packages/beacon-state-transition/test/perf/phase0/fast/block/block.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/fast/block/block.test.ts
@@ -47,7 +47,7 @@ describe("Process Blocks Performance Test", function () {
       verifySignatures: false,
       verifyStateRoot: false,
     });
-    expect(Date.now() - start).lt(180);
+    expect(Date.now() - start).lt(430);
     logger.profile(`Process block ${signedBlock.message.slot} with ${numValidatorExits} validator exits`);
   });
 

--- a/packages/beacon-state-transition/test/perf/phase0/fast/epoch/epoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/fast/epoch/epoch.test.ts
@@ -31,7 +31,7 @@ describe("Epoch Processing Performance Tests", function () {
     },
     {
       testFunc: phase0.fast.processRewardsAndPenalties,
-      expected: 110,
+      expected: 240,
     },
     {
       testFunc: phase0.fast.processRegistryUpdates,
@@ -43,7 +43,7 @@ describe("Epoch Processing Performance Tests", function () {
     },
     {
       testFunc: phase0.fast.processFinalUpdates,
-      expected: 15,
+      expected: 36,
     },
   ];
 
@@ -53,7 +53,7 @@ describe("Epoch Processing Performance Tests", function () {
       logger.profile(name);
       testValue.testFunc && testValue.testFunc(state, process);
       logger.profile(name);
-      expect(Date.now() - start).lt(testValue.expected);
+      expect(Date.now() - start).lte(testValue.expected);
     });
   }
 });

--- a/packages/beacon-state-transition/test/perf/phase0/fast/epoch/getAttestationDeltas.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/fast/epoch/getAttestationDeltas.test.ts
@@ -19,7 +19,7 @@ describe("getAttestationDeltas", function () {
     epochProcess = fast.prepareEpochProcessState(state);
     let minTime = Number.MAX_SAFE_INTEGER;
     let maxTime = 0;
-    const MAX_TRY = 10000;
+    const MAX_TRY = 1000;
     const from = process.hrtime.bigint();
     for (let i = 0; i < MAX_TRY; i++) {
       const start = Date.now();
@@ -31,8 +31,8 @@ describe("getAttestationDeltas", function () {
     const to = process.hrtime.bigint();
     const average = Number((to - from) / BigInt(MAX_TRY) / BigInt(1000000));
     logger.info("getAttestationDeltas in ms", {minTime, maxTime, average, maxTry: MAX_TRY});
-    expect(minTime).to.be.lte(28, "Minimal getAttestationDeltas is not less than 28ms");
-    expect(maxTime).to.be.lte(800, "Maximal getAttestationDeltas is not less than 800ms");
-    expect(average).to.be.lte(33, "Average getAttestationDeltas is not less than 33ms");
+    expect(minTime).to.be.lte(96, "Minimal getAttestationDeltas is not less than 96ms");
+    expect(maxTime).to.be.lte(278, "Maximal getAttestationDeltas is not less than 278ms");
+    expect(average).to.be.lte(107, "Average getAttestationDeltas is not less than 107ms");
   });
 });

--- a/packages/beacon-state-transition/test/perf/phase0/fast/epoch/processRewardsAndPenalties.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/fast/epoch/processRewardsAndPenalties.test.ts
@@ -19,7 +19,7 @@ describe("processRewardsAndPenalties", function () {
     epochProcess = fast.prepareEpochProcessState(state);
     let minTime = Number.MAX_SAFE_INTEGER;
     let maxTime = 0;
-    const MAX_TRY = 10000;
+    const MAX_TRY = 1000;
     const from = process.hrtime.bigint();
     for (let i = 0; i < MAX_TRY; i++) {
       const start = Date.now();
@@ -31,8 +31,8 @@ describe("processRewardsAndPenalties", function () {
     const to = process.hrtime.bigint();
     const average = Number((to - from) / BigInt(MAX_TRY) / BigInt(1000000));
     logger.info("processRewardsAndPenalties in ms", {minTime, maxTime, average, maxTry: MAX_TRY});
-    expect(minTime).to.be.lte(67, "Minimal processRewardsAndPenalties is not less than 67ms");
-    expect(maxTime).to.be.lte(700, "Maximal processRewardsAndPenalties is not less than 700ms");
-    expect(average).to.be.lte(84, "Average processRewardsAndPenalties is not less than 84ms");
+    expect(minTime).to.be.lte(174, "Minimal processRewardsAndPenalties is not less than 174ms");
+    expect(maxTime).to.be.lte(1300, "Maximal processRewardsAndPenalties is not less than 1300ms");
+    expect(average).to.be.lte(235, "Average processRewardsAndPenalties is not less than 235ms");
   });
 });

--- a/packages/beacon-state-transition/test/perf/phase0/fast/slot/slots.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/fast/slot/slots.test.ts
@@ -9,26 +9,28 @@ describe("Process Slots Performance Test", function () {
   const logger = profilerLogger();
   let state: fast.CachedBeaconState<phase0.BeaconState>;
 
-  function processEpochTest(numSlot: Slot, expectedValue: number): void {
-    logger.profile(`Process ${numSlot} slots`);
-    const start = Date.now();
-    phase0.fast.processSlots(state, state.slot + numSlot);
-    logger.profile(`Process ${numSlot} slots`);
-    expect(Date.now() - start).lt(expectedValue);
+  function processEpochTest(numSlot: Slot, expectedValue: number, maxTry = 10): void {
+    logger.profile(`Process ${numSlot} slots ${maxTry} times`);
+    let duration = 0;
+    for (let i = 0; i < maxTry; i++) {
+      state = generatePerfTestCachedBeaconState({goBackOneSlot: true});
+      const start = Date.now();
+      phase0.fast.processSlots(state, state.slot + numSlot);
+      duration += Date.now() - start;
+    }
+    logger.profile(`Process ${numSlot} slots ${maxTry} times`);
+    const average = duration / maxTry;
+    expect(average).lt(expectedValue, `process ${numSlot} takes longer than ${expectedValue} ms`);
   }
 
   const testValues = [
-    {numSlot: 32, expectedValue: 320, name: "process 1 empty epoch"},
-    {numSlot: 64, expectedValue: 620, name: "process double empty epochs"},
-    {numSlot: 128, expectedValue: 1270, name: "process 4 empty epochs"},
+    {numSlot: 32, expectedValue: 3700, name: "process 1 empty epoch"},
+    {numSlot: 64, expectedValue: 5600, name: "process double empty epochs"},
+    {numSlot: 128, expectedValue: 8500, name: "process 4 empty epochs"},
   ];
 
   before(async () => {
     await initBLS();
-  });
-
-  beforeEach(async () => {
-    state = generatePerfTestCachedBeaconState();
   });
 
   for (const testValue of testValues) {


### PR DESCRIPTION
**Motivation**

+ Get performance statistic after `0.21.0`
+ Increase number of validators to 250k to match Prater network
+ Add attestations to the performance beacon state, it makes average epoch transition 3.7s which is close to lodestar's performance in Prater

**Description**

part of #2309 

