### PR TITLE
Handle fork transitions in gossip

### DIFF
--- a/packages/lodestar/src/network/forks.ts
+++ b/packages/lodestar/src/network/forks.ts
@@ -1,0 +1,94 @@
+import {ForkName, IBeaconConfig, IForkInfo} from "@chainsafe/lodestar-config";
+import {Epoch} from "@chainsafe/lodestar-types";
+
+/**
+ * Subscribe topics to the new fork N epochs before the fork. Remove all subscriptions N epochs after the fork
+ *
+ * This lookahead ensures a smooth fork transition. During `FORK_EPOCH_LOOKAHEAD` both forks will be active.
+ *
+ * ```
+ *    phase0     phase0     phase0       -
+ *      -        altair     altair     altair
+ * |----------|----------|----------|----------|
+ * 0        fork-2      fork      fork+2       oo
+ * ```
+ */
+const FORK_EPOCH_LOOKAHEAD = 2;
+
+/**
+ * Return the list of `ForkName`s meant to be active at `epoch`
+ */
+export function getActiveForks(config: IBeaconConfig, epoch: Epoch): ForkName[] {
+  // Compute prev and next fork shifted, so next fork is still next at forkEpoch + FORK_EPOCH_LOOKAHEAD
+  const forks = getCurrentAndNextFork(config, epoch - FORK_EPOCH_LOOKAHEAD - 1);
+
+  // Before fork is scheduled
+  if (!forks.nextFork) {
+    return [forks.currentFork.name];
+  }
+
+  const prevFork = forks.currentFork.name;
+  const nextFork = forks.nextFork.name;
+  const forkEpoch = forks.nextFork.epoch;
+
+  // Way before fork
+  if (epoch < forkEpoch - FORK_EPOCH_LOOKAHEAD) return [prevFork];
+  // Way after fork
+  if (epoch > forkEpoch + FORK_EPOCH_LOOKAHEAD) return [nextFork];
+  // During fork transition
+  return [prevFork, nextFork];
+}
+
+/**
+ * Helper to run hooks at the start and end of the fork transition, with `FORK_EPOCH_LOOKAHEAD`
+ */
+export function runForkTransitionHooks(
+  config: IBeaconConfig,
+  epoch: Epoch,
+  hooks: {
+    /** ONLY ONCE: Two epoch before the fork run this function */
+    beforeForkTransition(nextFork: ForkName): void;
+    /** ONLY ONCE: Two epochs after the fork run this function */
+    afterForkTransition(prevFork: ForkName): void;
+  }
+): void {
+  // Compute prev and next fork shifted, so next fork is still next at forkEpoch + FORK_EPOCH_LOOKAHEAD
+  const forks = getCurrentAndNextFork(config, epoch - FORK_EPOCH_LOOKAHEAD - 1);
+
+  // Only when fork is scheduled
+  if (forks.nextFork) {
+    const prevFork = forks.currentFork.name;
+    const nextFork = forks.nextFork.name;
+    const forkEpoch = forks.nextFork.epoch;
+
+    if (epoch === forkEpoch - FORK_EPOCH_LOOKAHEAD) {
+      hooks.beforeForkTransition(nextFork);
+    }
+
+    if (epoch === forkEpoch + FORK_EPOCH_LOOKAHEAD) {
+      hooks.afterForkTransition(prevFork);
+    }
+  }
+}
+
+/**
+ * Return the currentFork and nextFork given a fork schedule and `epoch`
+ */
+export function getCurrentAndNextFork(
+  config: IBeaconConfig,
+  epoch: Epoch
+): {currentFork: IForkInfo; nextFork: IForkInfo | undefined} {
+  // NOTE: forks are sorted by ascending epoch, phase0 first
+  const forks = Object.values(config.forks);
+  let currentForkIdx = -1;
+  // findLastIndex
+  for (let i = 0; i < forks.length; i++) {
+    if (epoch >= forks[i].epoch) currentForkIdx = i;
+  }
+  const nextForkIdx = currentForkIdx + 1;
+  const hasNextFork = forks[nextForkIdx] && forks[nextForkIdx].epoch !== Infinity;
+  return {
+    currentFork: forks[currentForkIdx] || forks[0],
+    nextFork: hasNextFork ? forks[nextForkIdx] : undefined,
+  };
+}

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -217,85 +217,44 @@ export class Eth2Gossipsub extends Gossipsub {
   }
 
   async publishBeaconBlock(signedBlock: allForks.SignedBeaconBlock): Promise<void> {
-    await this.publishObject(
-      {
-        type: GossipType.beacon_block,
-        fork: this.config.getForkName(signedBlock.message.slot),
-      },
-      signedBlock
-    );
+    const fork = this.config.getForkName(signedBlock.message.slot);
+
+    await this.publishObject({type: GossipType.beacon_block, fork}, signedBlock);
   }
 
   async publishBeaconAggregateAndProof(aggregateAndProof: phase0.SignedAggregateAndProof): Promise<void> {
-    await this.publishObject(
-      {
-        type: GossipType.beacon_aggregate_and_proof,
-        fork: this.config.getForkName(aggregateAndProof.message.aggregate.data.slot),
-      },
-      aggregateAndProof
-    );
+    const fork = this.config.getForkName(aggregateAndProof.message.aggregate.data.slot);
+    await this.publishObject({type: GossipType.beacon_aggregate_and_proof, fork}, aggregateAndProof);
   }
 
   async publishBeaconAttestation(attestation: phase0.Attestation, subnet: number): Promise<void> {
-    await this.publishObject(
-      {
-        type: GossipType.beacon_attestation,
-        fork: this.config.getForkName(attestation.data.slot),
-        subnet,
-      },
-      attestation
-    );
+    const fork = this.config.getForkName(attestation.data.slot);
+    await this.publishObject({type: GossipType.beacon_attestation, fork, subnet}, attestation);
   }
 
   async publishVoluntaryExit(voluntaryExit: phase0.SignedVoluntaryExit): Promise<void> {
-    await this.publishObject(
-      {
-        type: GossipType.voluntary_exit,
-        fork: this.config.getForkName(computeEpochAtSlot(this.config, voluntaryExit.message.epoch)),
-      },
-      voluntaryExit
-    );
+    const fork = this.config.getForkName(computeEpochAtSlot(this.config, voluntaryExit.message.epoch));
+    await this.publishObject({type: GossipType.voluntary_exit, fork}, voluntaryExit);
   }
 
   async publishProposerSlashing(proposerSlashing: phase0.ProposerSlashing): Promise<void> {
-    await this.publishObject(
-      {
-        type: GossipType.proposer_slashing,
-        fork: this.config.getForkName(proposerSlashing.signedHeader1.message.slot),
-      },
-      proposerSlashing
-    );
+    const fork = this.config.getForkName(proposerSlashing.signedHeader1.message.slot);
+    await this.publishObject({type: GossipType.proposer_slashing, fork}, proposerSlashing);
   }
 
   async publishAttesterSlashing(attesterSlashing: phase0.AttesterSlashing): Promise<void> {
-    await this.publishObject(
-      {
-        type: GossipType.attester_slashing,
-        fork: this.config.getForkName(attesterSlashing.attestation1.data.slot),
-      },
-      attesterSlashing
-    );
+    const fork = this.config.getForkName(attesterSlashing.attestation1.data.slot);
+    await this.publishObject({type: GossipType.attester_slashing, fork}, attesterSlashing);
   }
 
   async publishSyncCommitteeSignature(signature: altair.SyncCommitteeSignature, subnet: number): Promise<void> {
-    await this.publishObject(
-      {
-        type: GossipType.sync_committee,
-        fork: this.config.getForkName(signature.slot),
-        subnet,
-      },
-      signature
-    );
+    const fork = this.config.getForkName(signature.slot);
+    await this.publishObject({type: GossipType.sync_committee, fork, subnet}, signature);
   }
 
   async publishContributionAndProof(contributionAndProof: altair.SignedContributionAndProof): Promise<void> {
-    await this.publishObject(
-      {
-        type: GossipType.sync_committee_contribution_and_proof,
-        fork: this.config.getForkName(contributionAndProof.message.contribution.slot),
-      },
-      contributionAndProof
-    );
+    const fork = this.config.getForkName(contributionAndProof.message.contribution.slot);
+    await this.publishObject({type: GossipType.sync_committee_contribution_and_proof, fork}, contributionAndProof);
   }
 
   private getGossipTopicString(topic: GossipTopic): string {

--- a/packages/lodestar/src/network/interface.ts
+++ b/packages/lodestar/src/network/interface.ts
@@ -38,6 +38,12 @@ export interface INetwork {
   /** Subscribe, search peers, join long-lived syncnets */
   prepareSyncCommitteeSubnets(subscriptions: CommitteeSubscription[]): void;
   reStatusPeers(peers: PeerId[]): void;
+
+  // Gossip handler
+  subscribeGossipCoreTopics(): void;
+  unsubscribeGossipCoreTopics(): void;
+  isSubscribedToGossipCoreTopics(): boolean;
+
   // Service
   start(): Promise<void>;
   stop(): Promise<void>;

--- a/packages/lodestar/src/network/metadata/utils.ts
+++ b/packages/lodestar/src/network/metadata/utils.ts
@@ -2,7 +2,7 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Epoch, phase0} from "@chainsafe/lodestar-types";
 import {FAR_FUTURE_EPOCH} from "../../constants";
 import {IForkDigestContext} from "../../util/forkDigestContext";
-import {getCurrentAndNextFork} from "../util";
+import {getCurrentAndNextFork} from "../forks";
 
 export function getENRForkID(
   config: IBeaconConfig,

--- a/packages/lodestar/src/network/util.ts
+++ b/packages/lodestar/src/network/util.ts
@@ -8,8 +8,6 @@ import Multiaddr from "multiaddr";
 import {networkInterfaces} from "os";
 import {ENR} from "@chainsafe/discv5";
 import MetadataBook from "libp2p/src/peer-store/metadata-book";
-import {IBeaconConfig, IForkInfo} from "@chainsafe/lodestar-config";
-import {Epoch} from "@chainsafe/lodestar-types";
 
 // peers
 
@@ -69,23 +67,4 @@ export function prettyPrintPeerId(peerId: PeerId): string {
 
 export function getAgentVersionFromPeerStore(peerId: PeerId, metadataBook: MetadataBook): string {
   return new TextDecoder().decode(metadataBook.getValue(peerId, "AgentVersion")) || "N/A";
-}
-
-export function getCurrentAndNextFork(
-  config: IBeaconConfig,
-  epoch: Epoch
-): {currentFork: IForkInfo; nextFork: IForkInfo | undefined} {
-  // NOTE: forks are sorted by ascending epoch, phase0 first
-  const forks = Object.values(config.forks);
-  let currentForkIdx = -1;
-  // findLastIndex
-  for (let i = 0; i < forks.length; i++) {
-    if (epoch >= forks[i].epoch) currentForkIdx = i;
-  }
-  const nextForkIdx = currentForkIdx + 1;
-  const hasNextFork = forks[nextForkIdx] && forks[nextForkIdx].epoch !== Infinity;
-  return {
-    currentFork: forks[currentForkIdx] || forks[0],
-    nextFork: hasNextFork ? forks[nextForkIdx] : undefined,
-  };
 }

--- a/packages/lodestar/src/sync/gossip/index.ts
+++ b/packages/lodestar/src/sync/gossip/index.ts
@@ -1,1 +1,0 @@
-export * from "./handler";

--- a/packages/lodestar/src/sync/index.ts
+++ b/packages/lodestar/src/sync/index.ts
@@ -3,4 +3,3 @@
  */
 export * from "./interface";
 export * from "./sync";
-export * from "./gossip";

--- a/packages/lodestar/src/sync/interface.ts
+++ b/packages/lodestar/src/sync/interface.ts
@@ -2,7 +2,6 @@ import {ILogger} from "@chainsafe/lodestar-utils";
 import {Slot, phase0} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {INetwork} from "../network";
-import {BeaconGossipHandler} from "./gossip";
 import {IBeaconChain} from "../chain";
 import {IMetrics} from "../metrics";
 import {IBeaconDb} from "../db";
@@ -53,5 +52,4 @@ export interface ISyncModules {
   metrics: IMetrics | null;
   logger: ILogger;
   chain: IBeaconChain;
-  gossipHandler?: BeaconGossipHandler;
 }

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -38,15 +38,14 @@ export class BeaconSync implements IBeaconSync {
   private readonly slotImportTolerance: Slot;
 
   constructor(opts: ISyncOptions, modules: ISyncModules) {
-    const {config, chain, metrics, network, logger} = modules;
+    const {config, chain, metrics, network, db, logger} = modules;
     this.opts = opts;
     this.config = config;
     this.network = network;
     this.chain = chain;
     this.logger = logger;
     this.rangeSync = new RangeSync(modules);
-    this.gossip =
-      modules.gossipHandler || new BeaconGossipHandler(modules.config, modules.chain, modules.network, modules.db);
+    this.gossip = modules.gossipHandler || new BeaconGossipHandler(config, chain, network, db, logger);
     this.slotImportTolerance = modules.config.params.SLOTS_PER_EPOCH;
 
     // Subscribe to RangeSync completing a SyncChain and recompute sync state

--- a/packages/lodestar/test/unit/network/gossip/handler.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/handler.test.ts
@@ -24,6 +24,7 @@ import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {ISubnetsService} from "../../../../src/network/subnetsService";
 
 describe("gossip handler", function () {
+  const logger = testLogger();
   const attnetsService = {} as ISubnetsService;
   let forkDigestContext: SinonStubbedInstance<ForkDigestContext>;
   let chainStub: SinonStubbedInstance<IBeaconChain>;
@@ -45,7 +46,7 @@ describe("gossip handler", function () {
       config,
       libp2p,
       validatorFns: new Map<string, TopicValidatorFn>(),
-      logger: testLogger(),
+      logger,
       forkDigestContext,
       metrics: null,
     });
@@ -61,7 +62,7 @@ describe("gossip handler", function () {
   });
 
   it("should subscribe/unsubscribe on start/stop", function () {
-    const handler = new GossipHandler(config, chainStub, gossipsub, attnetsService, dbStub, networkStub);
+    const handler = new GossipHandler(config, chainStub, gossipsub, attnetsService, dbStub, logger);
     expect(gossipsub.subscriptions.size).to.equal(0);
     handler.subscribeCoreTopics();
     expect(gossipsub.subscriptions.size).to.equal(5);
@@ -71,7 +72,7 @@ describe("gossip handler", function () {
   });
 
   it("should handle incoming gossip objects", async function () {
-    const handler = new GossipHandler(config, chainStub, gossipsub, attnetsService, dbStub, networkStub);
+    const handler = new GossipHandler(config, chainStub, gossipsub, attnetsService, dbStub, logger);
     handler.subscribeCoreTopics();
     const fork = ForkName.phase0;
     const {

--- a/packages/lodestar/test/unit/network/gossip/handler.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/handler.test.ts
@@ -13,7 +13,7 @@ import {
   encodeMessageData,
   TopicValidatorFn,
 } from "../../../../src/network/gossip";
-import {BeaconGossipHandler} from "../../../../src/sync/gossip";
+import {GossipHandler} from "../../../../src/network/gossip/handler";
 
 import {StubbedBeaconDb} from "../../../utils/stub";
 import {testLogger} from "../../../utils/logger";
@@ -21,8 +21,10 @@ import {createNode} from "../../../utils/network";
 import {ForkDigestContext} from "../../../../src/util/forkDigestContext";
 import {generateBlockSummary} from "../../../utils/block";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
+import {ISubnetsService} from "../../../../src/network/subnetsService";
 
 describe("gossip handler", function () {
+  const attnetsService = {} as ISubnetsService;
   let forkDigestContext: SinonStubbedInstance<ForkDigestContext>;
   let chainStub: SinonStubbedInstance<IBeaconChain>;
   let networkStub: SinonStubbedInstance<INetwork>;
@@ -59,18 +61,18 @@ describe("gossip handler", function () {
   });
 
   it("should subscribe/unsubscribe on start/stop", function () {
-    const handler = new BeaconGossipHandler(config, chainStub, networkStub, dbStub);
+    const handler = new GossipHandler(config, chainStub, gossipsub, attnetsService, dbStub, networkStub);
     expect(gossipsub.subscriptions.size).to.equal(0);
-    handler.start();
+    handler.subscribeCoreTopics();
     expect(gossipsub.subscriptions.size).to.equal(5);
-    handler.stop();
+    handler.unsubscribeCoreTopics();
     expect(gossipsub.subscriptions.size).to.equal(0);
     handler.close();
   });
 
   it("should handle incoming gossip objects", async function () {
-    const handler = new BeaconGossipHandler(config, chainStub, networkStub, dbStub);
-    handler.start();
+    const handler = new GossipHandler(config, chainStub, gossipsub, attnetsService, dbStub, networkStub);
+    handler.subscribeCoreTopics();
     const fork = ForkName.phase0;
     const {
       SignedBeaconBlock,
@@ -121,7 +123,7 @@ describe("gossip handler", function () {
     });
     expect(dbStub.attesterSlashing.add.calledOnce).to.be.true;
 
-    handler.stop();
+    handler.unsubscribeCoreTopics();
     handler.close();
   });
 });

--- a/packages/lodestar/test/unit/network/util.test.ts
+++ b/packages/lodestar/test/unit/network/util.test.ts
@@ -8,12 +8,8 @@ import {createEnr, createPeerId} from "@chainsafe/lodestar-cli/src/config";
 import {Method, Version, Encoding} from "../../../src/network/reqresp/types";
 import {defaultNetworkOptions} from "../../../src/network/options";
 import {formatProtocolId, parseProtocolId} from "../../../src/network/reqresp/utils";
-import {
-  createNodeJsLibp2p,
-  getAgentVersionFromPeerStore,
-  getCurrentAndNextFork,
-  isLocalMultiAddr,
-} from "../../../src/network";
+import {createNodeJsLibp2p, getAgentVersionFromPeerStore, isLocalMultiAddr} from "../../../src/network";
+import {getCurrentAndNextFork} from "../../../src/network/forks";
 
 describe("Test isLocalMultiAddr", () => {
   it("should return true for 127.0.0.1", () => {


### PR DESCRIPTION
**Motivation**

Handle fork transition properly in Gossip handler

**Description**

Follow same strategy than in SubnetService https://github.com/ChainSafe/lodestar/blob/765067145921fa1d2fe1209b6699d437cb65b0f8/packages/lodestar/src/network/subnetsService.ts#L167

- On start-up: subscribe to 
- ONLY ONCE: Two epoch before the fork, re-subscribe all existing random subscriptions to the new fork
- ONLY ONCE: Two epochs after the fork, un-subscribe all subnets from the old fork

Also re-organizes the gossip handler code a bit :)