### PR TITLE
Add Altair VC client

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/epochContext.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochContext.ts
@@ -87,6 +87,7 @@ export function createEpochContext(
     currSyncCommitteeIndexes,
     nextSyncCommitteeIndexes,
     currSyncComitteeValidatorIndexMap: computeSyncComitteeMap(currSyncCommitteeIndexes),
+    nextSyncComitteeValidatorIndexMap: computeSyncComitteeMap(nextSyncCommitteeIndexes),
   });
 }
 
@@ -188,7 +189,8 @@ export function rotateEpochs(
     const nextPeriodEpoch = currEpoch + epochCtx.config.params.EPOCHS_PER_SYNC_COMMITTEE_PERIOD;
     epochCtx.currSyncCommitteeIndexes = epochCtx.nextSyncCommitteeIndexes;
     epochCtx.nextSyncCommitteeIndexes = getSyncCommitteeIndices(epochCtx.config, state, nextPeriodEpoch);
-    epochCtx.currSyncComitteeValidatorIndexMap = computeSyncComitteeMap(epochCtx.currSyncCommitteeIndexes);
+    epochCtx.currSyncComitteeValidatorIndexMap = epochCtx.nextSyncComitteeValidatorIndexMap;
+    epochCtx.nextSyncComitteeValidatorIndexMap = computeSyncComitteeMap(epochCtx.nextSyncCommitteeIndexes);
   }
 
   // If crossing through the altair fork the caches will be empty, fill them up
@@ -197,6 +199,7 @@ export function rotateEpochs(
     epochCtx.currSyncCommitteeIndexes = getSyncCommitteeIndices(epochCtx.config, state, currEpoch);
     epochCtx.nextSyncCommitteeIndexes = getSyncCommitteeIndices(epochCtx.config, state, nextPeriodEpoch);
     epochCtx.currSyncComitteeValidatorIndexMap = computeSyncComitteeMap(epochCtx.currSyncCommitteeIndexes);
+    epochCtx.nextSyncComitteeValidatorIndexMap = computeSyncComitteeMap(epochCtx.nextSyncCommitteeIndexes);
   }
 }
 
@@ -212,6 +215,7 @@ interface IEpochContextData {
   currSyncCommitteeIndexes: ValidatorIndex[];
   nextSyncCommitteeIndexes: ValidatorIndex[];
   currSyncComitteeValidatorIndexMap: SyncComitteeValidatorIndexMap;
+  nextSyncComitteeValidatorIndexMap: SyncComitteeValidatorIndexMap;
 }
 
 /**
@@ -238,16 +242,13 @@ export class EpochContext {
    * Memory cost: 1024 Number integers.
    */
   currSyncCommitteeIndexes: ValidatorIndex[];
-  /**
-   * Update freq: every ~ 27h.
-   * Memory cost: 1024 Number integers.
-   */
   nextSyncCommitteeIndexes: ValidatorIndex[];
   /**
    * Update freq: every ~ 27h.
    * Memory cost: Map of Number -> Number with 1024 entries.
    */
   currSyncComitteeValidatorIndexMap: SyncComitteeValidatorIndexMap;
+  nextSyncComitteeValidatorIndexMap: SyncComitteeValidatorIndexMap;
   config: IBeaconConfig;
 
   constructor(data: IEpochContextData) {
@@ -261,6 +262,7 @@ export class EpochContext {
     this.currSyncCommitteeIndexes = data.currSyncCommitteeIndexes;
     this.nextSyncCommitteeIndexes = data.nextSyncCommitteeIndexes;
     this.currSyncComitteeValidatorIndexMap = data.currSyncComitteeValidatorIndexMap;
+    this.nextSyncComitteeValidatorIndexMap = data.nextSyncComitteeValidatorIndexMap;
   }
 
   /**

--- a/packages/lodestar/src/api/impl/beacon/blocks/interface.ts
+++ b/packages/lodestar/src/api/impl/beacon/blocks/interface.ts
@@ -1,9 +1,10 @@
 import {Root, phase0, allForks, Slot} from "@chainsafe/lodestar-types";
 
 export interface IBeaconBlocksApi {
+  getBlock(blockId: BlockId): Promise<allForks.SignedBeaconBlock>;
   getBlockHeaders(filters: Partial<{slot: Slot; parentRoot: Root}>): Promise<phase0.SignedBeaconHeaderResponse[]>;
   getBlockHeader(blockId: BlockId): Promise<phase0.SignedBeaconHeaderResponse>;
-  getBlock(blockId: BlockId): Promise<allForks.SignedBeaconBlock>;
+  getBlockRoot(blockId: BlockId): Promise<Root>;
   publishBlock(block: phase0.SignedBeaconBlock): Promise<void>;
 }
 

--- a/packages/lodestar/src/api/impl/beacon/pool/pool.ts
+++ b/packages/lodestar/src/api/impl/beacon/pool/pool.ts
@@ -1,6 +1,6 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {altair, Epoch, phase0} from "@chainsafe/lodestar-types";
-import {computeEpochAtSlot, allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
 import {IAttestationJob, IBeaconChain} from "../../../../chain";
 import {AttestationError, AttestationErrorCode} from "../../../../chain/errors";
@@ -106,14 +106,14 @@ export class BeaconPoolApi implements IBeaconPoolApi {
    * https://github.com/ethereum/eth2.0-APIs/pull/135
    */
   async submitSyncCommitteeSignatures(signatures: altair.SyncCommitteeSignature[]): Promise<void> {
-    // Fetch states for all epochs of the `signatures`
-    const epochs = new Set<Epoch>();
+    // Fetch states for all slots of the `signatures`
+    const slots = new Set<Epoch>();
     for (const signature of signatures) {
-      epochs.add(computeEpochAtSlot(this.config, signature.slot));
+      slots.add(signature.slot);
     }
 
-    // TODO: Fetch states at signature epochs
-    const state = await this.chain.getHeadStateAtCurrentEpoch();
+    // TODO: Fetch states at signature slots
+    const state = this.chain.getHeadState();
 
     // TODO: Cache this value
     const SYNC_COMMITTEE_SUBNET_SIZE = Math.floor(this.config.params.SYNC_COMMITTEE_SIZE / SYNC_COMMITTEE_SUBNET_COUNT);

--- a/packages/lodestar/src/api/impl/validator/utils.ts
+++ b/packages/lodestar/src/api/impl/validator/utils.ts
@@ -1,0 +1,30 @@
+import {
+  CachedBeaconState,
+  computeEpochAtSlot,
+  computeSyncCommitteePeriod,
+} from "@chainsafe/lodestar-beacon-state-transition";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {allForks, altair, Epoch, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {ApiError} from "../errors";
+
+export function getSyncComitteeValidatorIndexMap(
+  config: IBeaconConfig,
+  state: allForks.BeaconState | CachedBeaconState<allForks.BeaconState>,
+  requestedEpoch: Epoch
+): Map<ValidatorIndex, number[]> {
+  const statePeriod = computeSyncCommitteePeriod(config, computeEpochAtSlot(config, state.slot));
+  const requestPeriod = computeSyncCommitteePeriod(config, requestedEpoch);
+
+  if ((state as CachedBeaconState<allForks.BeaconState>).epochCtx) {
+    switch (requestPeriod) {
+      case statePeriod:
+        return (state as CachedBeaconState<altair.BeaconState>).currSyncComitteeValidatorIndexMap;
+      case statePeriod + 1:
+        return (state as CachedBeaconState<altair.BeaconState>).nextSyncComitteeValidatorIndexMap;
+      default:
+        throw new ApiError(400, "Epoch out of bounds");
+    }
+  }
+
+  throw new ApiError(400, "No CachedBeaconState available");
+}

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -140,7 +140,7 @@ export class ValidatorApi implements IValidatorApi {
     const startSlot = computeStartSlotAtEpoch(this.config, epoch);
     await this.waitForSlot(startSlot); // Must never request for a future slot > currentSlot
 
-    const state = this.chain.getHeadState();
+    const state = await this.chain.getHeadStateAtCurrentEpoch();
     const duties: phase0.ProposerDuty[] = [];
 
     for (let slot = startSlot; slot < startSlot + this.config.params.SLOTS_PER_EPOCH; slot++) {

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -9,6 +9,7 @@ import {
   proposerShufflingDecisionRoot,
   attesterShufflingDecisionRoot,
   computeSubnetForCommitteesAtSlot,
+  computeSyncPeriodAtSlot,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {GENESIS_SLOT, SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
@@ -230,7 +231,8 @@ export class ValidatorApi implements IValidatorApi {
     await this.waitForNextClosestEpoch();
 
     // TODO: Get state at `epoch`
-    const state = await this.chain.getHeadStateAtCurrentEpoch();
+    const state = this.chain.getHeadState();
+    const currentStatePeriod = computeSyncPeriodAtSlot(this.config, state.slot);
     // TODO: ensures `epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD <= current_epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD + 1`
     // const syncCommittee = getSyncCommittees(this.config, state, epoch);
 

--- a/packages/lodestar/src/api/rest/beacon/blocks/getBlockRoot.ts
+++ b/packages/lodestar/src/api/rest/beacon/blocks/getBlockRoot.ts
@@ -6,10 +6,10 @@ export const getBlockRoot: ApiController<null, {blockId: string}> = {
   id: "getBlockRoot",
 
   handler: async function (req) {
-    const data = await this.api.beacon.blocks.getBlock(req.params.blockId);
+    const root = await this.api.beacon.blocks.getBlockRoot(req.params.blockId);
     return {
       data: {
-        root: this.config.types.Root.toJson(this.config.types.phase0.BeaconBlock.hashTreeRoot(data.message)),
+        root: this.config.types.Root.toJson(root),
       },
     };
   },

--- a/packages/lodestar/src/api/rest/beacon/blocks/publishBlock.ts
+++ b/packages/lodestar/src/api/rest/beacon/blocks/publishBlock.ts
@@ -1,6 +1,10 @@
 import {phase0} from "@chainsafe/lodestar-types";
+import {SignedBeaconBlock} from "@chainsafe/lodestar-types/lib/allForks";
+import {getSignedBlockType} from "../../../../util/multifork";
 import {ValidationError} from "../../../impl/errors";
 import {ApiController} from "../../types";
+
+// TODO: Watch https://github.com/ethereum/eth2.0-APIs/pull/142 for resolution on how to upgrade this route
 
 export const publishBlock: ApiController = {
   url: "/eth/v1/beacon/blocks",
@@ -8,9 +12,11 @@ export const publishBlock: ApiController = {
   id: "publishBlock",
 
   handler: async function (req) {
+    const type = getSignedBlockType(this.config, req.body as SignedBeaconBlock);
+
     let block: phase0.SignedBeaconBlock;
     try {
-      block = this.config.types.phase0.SignedBeaconBlock.fromJson(req.body, {case: "snake"});
+      block = type.fromJson(req.body, {case: "snake"});
     } catch (e) {
       throw new ValidationError(`Failed to deserialize block: ${(e as Error).message}`);
     }

--- a/packages/lodestar/src/api/rest/beacon/blocks/publishBlock.ts
+++ b/packages/lodestar/src/api/rest/beacon/blocks/publishBlock.ts
@@ -12,10 +12,9 @@ export const publishBlock: ApiController = {
   id: "publishBlock",
 
   handler: async function (req) {
-    const type = getSignedBlockType(this.config, req.body as SignedBeaconBlock);
-
     let block: phase0.SignedBeaconBlock;
     try {
+      const type = getSignedBlockType(this.config, req.body as SignedBeaconBlock);
       block = type.fromJson(req.body, {case: "snake"});
     } catch (e) {
       throw new ValidationError(`Failed to deserialize block: ${(e as Error).message}`);

--- a/packages/lodestar/src/util/multifork.ts
+++ b/packages/lodestar/src/util/multifork.ts
@@ -1,5 +1,5 @@
 import {ForkName, IBeaconConfig} from "@chainsafe/lodestar-config";
-import {allForks, phase0, Slot} from "@chainsafe/lodestar-types";
+import {allForks, Slot} from "@chainsafe/lodestar-types";
 import {bytesToInt} from "@chainsafe/lodestar-utils";
 import {ContainerType} from "@chainsafe/ssz";
 
@@ -35,8 +35,8 @@ const SLOT_BYTES_POSITION_IN_BLOCK = 100;
  */
 const SLOT_BYTES_POSITION_IN_STATE = 40;
 
-type BlockType = ContainerType<phase0.BeaconBlock>;
-type SignedBlockType = ContainerType<phase0.SignedBeaconBlock>;
+type BlockType = ContainerType<allForks.BeaconBlock>;
+type SignedBlockType = ContainerType<allForks.SignedBeaconBlock>;
 type StateType = ContainerType<allForks.BeaconState>;
 
 // Block

--- a/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockRoot.test.ts
+++ b/packages/lodestar/test/unit/api/rest/beacon/blocks/getBlockRoot.test.ts
@@ -1,10 +1,8 @@
 import {expect} from "chai";
 import supertest from "supertest";
 import {toHexString} from "@chainsafe/ssz";
-import {config} from "@chainsafe/lodestar-config/minimal";
 
 import {getBlockRoot} from "../../../../../../src/api/rest/beacon/blocks/getBlockRoot";
-import {generateEmptySignedBlock} from "../../../../../utils/block";
 import {setupRestApiTestServer} from "../../index.test";
 import {SinonStubbedInstance} from "sinon";
 import {RestApi} from "../../../../../../src/api";
@@ -24,15 +22,13 @@ describe("rest - beacon - getBlockRoot", function () {
   });
 
   it("should succeed", async function () {
-    const block = generateEmptySignedBlock();
-    beaconBlocksStub.getBlock.withArgs("head").resolves(block);
+    const root = Buffer.alloc(32, 0x4d);
+    beaconBlocksStub.getBlockRoot.withArgs("head").resolves(root);
     const response = await supertest(restApi.server.server)
       .get(getBlockRoot.url.replace(":blockId", "head"))
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(response.body.data.root).to.be.equal(
-      toHexString(config.types.phase0.BeaconBlock.hashTreeRoot(block.message))
-    );
+    expect(response.body.data.root).to.be.equal(toHexString(root));
   });
 });

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -48,6 +48,7 @@
     "@chainsafe/lodestar-beacon-state-transition": "^0.21.0",
     "@chainsafe/lodestar-config": "^0.21.0",
     "@chainsafe/lodestar-db": "^0.21.0",
+    "@chainsafe/lodestar-params": "^0.21.0",
     "@chainsafe/lodestar-types": "^0.21.0",
     "@chainsafe/lodestar-utils": "^0.21.0",
     "@chainsafe/ssz": "^0.8.4",

--- a/packages/validator/src/api/interface.ts
+++ b/packages/validator/src/api/interface.ts
@@ -1,6 +1,15 @@
 import {EventEmitter} from "events";
 import StrictEventEmitter from "strict-event-emitter-types";
-import {Epoch, Slot, Root, phase0, ValidatorIndex, BLSSignature, CommitteeIndex} from "@chainsafe/lodestar-types";
+import {
+  Epoch,
+  Slot,
+  Root,
+  phase0,
+  ValidatorIndex,
+  BLSSignature,
+  CommitteeIndex,
+  altair,
+} from "@chainsafe/lodestar-types";
 import {IStoppableEventIterable} from "@chainsafe/lodestar-utils";
 import {IValidatorFilters} from "../util";
 
@@ -37,6 +46,7 @@ export interface IApiClient {
     pool: {
       submitAttestations(attestation: phase0.Attestation[]): Promise<void>;
       submitVoluntaryExit(signedVoluntaryExit: phase0.SignedVoluntaryExit): Promise<void>;
+      submitSyncCommitteeSignatures(signatures: altair.SyncCommitteeSignature[]): Promise<void>;
     };
     getGenesis(): Promise<phase0.Genesis>;
   };
@@ -57,11 +67,19 @@ export interface IApiClient {
   validator: {
     getProposerDuties(epoch: Epoch): Promise<phase0.ProposerDutiesApi>;
     getAttesterDuties(epoch: Epoch, validatorIndices: ValidatorIndex[]): Promise<phase0.AttesterDutiesApi>;
+    getSyncCommitteeDuties(epoch: number, validatorIndices: ValidatorIndex[]): Promise<altair.SyncDutiesApi>;
     produceBlock(slot: Slot, randaoReveal: BLSSignature, graffiti: string): Promise<phase0.BeaconBlock>;
     produceAttestationData(index: CommitteeIndex, slot: Slot): Promise<phase0.AttestationData>;
+    produceSyncCommitteeContribution(
+      slot: Slot,
+      subcommitteeIndex: number,
+      beaconBlockRoot: Root
+    ): Promise<altair.SyncCommitteeContribution>;
     getAggregatedAttestation(attestationDataRoot: Root, slot: Slot): Promise<phase0.Attestation>;
     publishAggregateAndProofs(signedAggregateAndProofs: phase0.SignedAggregateAndProof[]): Promise<void>;
+    publishContributionAndProofs(contributionAndProofs: altair.SignedContributionAndProof[]): Promise<void>;
     prepareBeaconCommitteeSubnet(subscriptions: phase0.BeaconCommitteeSubscription[]): Promise<void>;
+    prepareSyncCommitteeSubnets(subscriptions: altair.SyncCommitteeSubscription[]): Promise<void>;
   };
 }
 

--- a/packages/validator/src/api/interface.ts
+++ b/packages/validator/src/api/interface.ts
@@ -14,6 +14,7 @@ import {IStoppableEventIterable} from "@chainsafe/lodestar-utils";
 import {IValidatorFilters} from "../util";
 
 export type StateId = "head";
+export type BlockId = "head" | Slot;
 
 export enum BeaconEventType {
   BLOCK = "block",
@@ -42,6 +43,7 @@ export interface IApiClient {
     };
     blocks: {
       publishBlock(block: phase0.SignedBeaconBlock): Promise<void>;
+      getBlockHeader(blockId: BlockId): Promise<phase0.SignedBeaconBlockHeader>;
     };
     pool: {
       submitAttestations(attestation: phase0.Attestation[]): Promise<void>;

--- a/packages/validator/src/api/interface.ts
+++ b/packages/validator/src/api/interface.ts
@@ -42,8 +42,8 @@ export interface IApiClient {
       getStateValidators(stateId: StateId, filters?: IValidatorFilters): Promise<phase0.ValidatorResponse[]>;
     };
     blocks: {
+      getBlockRoot(blockId: BlockId): Promise<Root>;
       publishBlock(block: phase0.SignedBeaconBlock): Promise<void>;
-      getBlockHeader(blockId: BlockId): Promise<phase0.SignedBeaconBlockHeader>;
     };
     pool: {
       submitAttestations(attestation: phase0.Attestation[]): Promise<void>;

--- a/packages/validator/src/api/rest/beacon.ts
+++ b/packages/validator/src/api/rest/beacon.ts
@@ -1,20 +1,21 @@
-import {altair, BLSPubkey, IBeaconSSZTypes, phase0, ValidatorIndex} from "@chainsafe/lodestar-types";
-import {Json, toHexString} from "@chainsafe/ssz";
+import {ForkName, IBeaconConfig} from "@chainsafe/lodestar-config";
+import {allForks, altair, BLSPubkey, phase0, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {ContainerType, Json, toHexString} from "@chainsafe/ssz";
 import {HttpClient, IValidatorFilters} from "../../util";
 import {IApiClient} from "../interface";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function BeaconApi(types: IBeaconSSZTypes, client: HttpClient): IApiClient["beacon"] {
+export function BeaconApi(config: IBeaconConfig, client: HttpClient): IApiClient["beacon"] {
   return {
     async getGenesis(): Promise<phase0.Genesis> {
       const res = await client.get<{data: Json}>("/eth/v1/beacon/genesis");
-      return types.phase0.Genesis.fromJson(res.data, {case: "snake"});
+      return config.types.phase0.Genesis.fromJson(res.data, {case: "snake"});
     },
 
     state: {
       async getFork(stateId: "head"): Promise<phase0.Fork> {
         const res = await client.get<{data: Json}>(`/eth/v1/beacon/states/${stateId}/fork`);
-        return types.phase0.Fork.fromJson(res.data, {case: "snake"});
+        return config.types.phase0.Fork.fromJson(res.data, {case: "snake"});
       },
 
       async getStateValidators(stateId: "head", filters?: IValidatorFilters): Promise<phase0.ValidatorResponse[]> {
@@ -24,13 +25,13 @@ export function BeaconApi(types: IBeaconSSZTypes, client: HttpClient): IApiClien
         };
 
         const res = await client.get<{data: Json[]}>(`/eth/v1/beacon/states/${stateId}/validators`, query);
-        return res.data.map((value) => types.phase0.ValidatorResponse.fromJson(value, {case: "snake"}));
+        return res.data.map((value) => config.types.phase0.ValidatorResponse.fromJson(value, {case: "snake"}));
       },
     },
 
     blocks: {
-      async publishBlock(block: phase0.SignedBeaconBlock): Promise<void> {
-        await client.post("/eth/v1/beacon/blocks", types.phase0.SignedBeaconBlock.toJson(block, {case: "snake"}));
+      async publishBlock(block: allForks.SignedBeaconBlock): Promise<void> {
+        await client.post("/eth/v1/beacon/blocks", getSignedBlockType(config, block).toJson(block, {case: "snake"}));
       },
     },
 
@@ -38,21 +39,21 @@ export function BeaconApi(types: IBeaconSSZTypes, client: HttpClient): IApiClien
       async submitAttestations(attestations: phase0.Attestation[]): Promise<void> {
         return client.post(
           "/eth/v1/beacon/pool/attestations",
-          attestations.map((attestation) => types.phase0.Attestation.toJson(attestation, {case: "snake"}))
+          attestations.map((attestation) => config.types.phase0.Attestation.toJson(attestation, {case: "snake"}))
         );
       },
 
       async submitVoluntaryExit(signedVoluntaryExit: phase0.SignedVoluntaryExit): Promise<void> {
         await client.post(
           "/eth/v1/beacon/pool/voluntary_exits",
-          types.phase0.SignedVoluntaryExit.toJson(signedVoluntaryExit, {case: "snake"})
+          config.types.phase0.SignedVoluntaryExit.toJson(signedVoluntaryExit, {case: "snake"})
         );
       },
 
       async submitSyncCommitteeSignatures(signatures: altair.SyncCommitteeSignature[]): Promise<void> {
         await client.post(
           "/eth/v1/beacon/pool/sync_committees",
-          signatures.map((item) => types.altair.SyncCommitteeSignature.toJson(item, {case: "snake"}))
+          signatures.map((item) => config.types.altair.SyncCommitteeSignature.toJson(item, {case: "snake"}))
         );
       },
     },
@@ -66,5 +67,22 @@ function formatIndex(validatorId: ValidatorIndex | BLSPubkey): string {
     return validatorId;
   } else {
     return toHexString(validatorId);
+  }
+}
+
+// TODO: Consider de-duplicating this code that also exists in `packages/lodestar/src/util/multifork.ts`
+
+type SignedBlockType = ContainerType<allForks.SignedBeaconBlock>;
+
+function getSignedBlockType(config: IBeaconConfig, block: allForks.SignedBeaconBlock): SignedBlockType {
+  return getSignedBlockTypeFromSlot(config, block.message.slot);
+}
+
+function getSignedBlockTypeFromSlot(config: IBeaconConfig, slot: Slot): SignedBlockType {
+  switch (config.getForkName(slot)) {
+    case ForkName.phase0:
+      return (config.types.phase0.SignedBeaconBlock as unknown) as SignedBlockType;
+    case ForkName.altair:
+      return (config.types.altair.SignedBeaconBlock as unknown) as SignedBlockType;
   }
 }

--- a/packages/validator/src/api/rest/beacon.ts
+++ b/packages/validator/src/api/rest/beacon.ts
@@ -2,7 +2,7 @@ import {ForkName, IBeaconConfig} from "@chainsafe/lodestar-config";
 import {allForks, altair, BLSPubkey, phase0, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {ContainerType, Json, toHexString} from "@chainsafe/ssz";
 import {HttpClient, IValidatorFilters} from "../../util";
-import {IApiClient} from "../interface";
+import {BlockId, IApiClient} from "../interface";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function BeaconApi(config: IBeaconConfig, client: HttpClient): IApiClient["beacon"] {
@@ -32,6 +32,11 @@ export function BeaconApi(config: IBeaconConfig, client: HttpClient): IApiClient
     blocks: {
       async publishBlock(block: allForks.SignedBeaconBlock): Promise<void> {
         await client.post("/eth/v1/beacon/blocks", getSignedBlockType(config, block).toJson(block, {case: "snake"}));
+      },
+
+      async getBlockHeader(blockId: BlockId): Promise<phase0.SignedBeaconBlockHeader> {
+        const res = await client.get<{data: Json}>(`/eth/v1/beacon/headers/${blockId}`);
+        return config.types.phase0.SignedBeaconBlockHeader.fromJson(res.data, {case: "snake"});
       },
     },
 

--- a/packages/validator/src/api/rest/beacon.ts
+++ b/packages/validator/src/api/rest/beacon.ts
@@ -1,5 +1,5 @@
 import {ForkName, IBeaconConfig} from "@chainsafe/lodestar-config";
-import {allForks, altair, BLSPubkey, phase0, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {allForks, altair, BLSPubkey, phase0, Root, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {ContainerType, Json, toHexString} from "@chainsafe/ssz";
 import {HttpClient, IValidatorFilters} from "../../util";
 import {BlockId, IApiClient} from "../interface";
@@ -34,9 +34,9 @@ export function BeaconApi(config: IBeaconConfig, client: HttpClient): IApiClient
         await client.post("/eth/v1/beacon/blocks", getSignedBlockType(config, block).toJson(block, {case: "snake"}));
       },
 
-      async getBlockHeader(blockId: BlockId): Promise<phase0.SignedBeaconBlockHeader> {
-        const res = await client.get<{data: Json}>(`/eth/v1/beacon/headers/${blockId}`);
-        return config.types.phase0.SignedBeaconBlockHeader.fromJson(res.data, {case: "snake"});
+      async getBlockRoot(blockId: BlockId): Promise<Root> {
+        const res = await client.get<{data: Json}>(`/eth/v1/beacon/blocks/${blockId}/root`);
+        return config.types.phase0.Root.fromJson(res.data, {case: "snake"});
       },
     },
 

--- a/packages/validator/src/api/rest/beacon.ts
+++ b/packages/validator/src/api/rest/beacon.ts
@@ -1,21 +1,19 @@
-import {BLSPubkey, IBeaconSSZTypes, phase0, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {altair, BLSPubkey, IBeaconSSZTypes, phase0, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {Json, toHexString} from "@chainsafe/ssz";
 import {HttpClient, IValidatorFilters} from "../../util";
 import {IApiClient} from "../interface";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function BeaconApi(types: IBeaconSSZTypes, client: HttpClient): IApiClient["beacon"] {
-  const prefix = "/eth/v1/beacon";
-
   return {
     async getGenesis(): Promise<phase0.Genesis> {
-      const res = await client.get<{data: Json}>(prefix + "/genesis");
+      const res = await client.get<{data: Json}>("/eth/v1/beacon/genesis");
       return types.phase0.Genesis.fromJson(res.data, {case: "snake"});
     },
 
     state: {
       async getFork(stateId: "head"): Promise<phase0.Fork> {
-        const res = await client.get<{data: Json}>(prefix + `/states/${stateId}/fork`);
+        const res = await client.get<{data: Json}>(`/eth/v1/beacon/states/${stateId}/fork`);
         return types.phase0.Fork.fromJson(res.data, {case: "snake"});
       },
 
@@ -25,29 +23,36 @@ export function BeaconApi(types: IBeaconSSZTypes, client: HttpClient): IApiClien
           ...(filters?.statuses && {statuses: filters.statuses as string[]}),
         };
 
-        const res = await client.get<{data: Json[]}>(prefix + `/states/${stateId}/validators`, query);
+        const res = await client.get<{data: Json[]}>(`/eth/v1/beacon/states/${stateId}/validators`, query);
         return res.data.map((value) => types.phase0.ValidatorResponse.fromJson(value, {case: "snake"}));
       },
     },
 
     blocks: {
       async publishBlock(block: phase0.SignedBeaconBlock): Promise<void> {
-        await client.post(prefix + "/blocks", types.phase0.SignedBeaconBlock.toJson(block, {case: "snake"}));
+        await client.post("/eth/v1/beacon/blocks", types.phase0.SignedBeaconBlock.toJson(block, {case: "snake"}));
       },
     },
 
     pool: {
       async submitAttestations(attestations: phase0.Attestation[]): Promise<void> {
         return client.post(
-          prefix + "/pool/attestations",
+          "/eth/v1/beacon/pool/attestations",
           attestations.map((attestation) => types.phase0.Attestation.toJson(attestation, {case: "snake"}))
         );
       },
 
       async submitVoluntaryExit(signedVoluntaryExit: phase0.SignedVoluntaryExit): Promise<void> {
         await client.post(
-          prefix + "/pool/voluntary_exits",
+          "/eth/v1/beacon/pool/voluntary_exits",
           types.phase0.SignedVoluntaryExit.toJson(signedVoluntaryExit, {case: "snake"})
+        );
+      },
+
+      async submitSyncCommitteeSignatures(signatures: altair.SyncCommitteeSignature[]): Promise<void> {
+        await client.post(
+          "/eth/v1/beacon/pool/sync_committees",
+          signatures.map((item) => types.altair.SyncCommitteeSignature.toJson(item, {case: "snake"}))
         );
       },
     },

--- a/packages/validator/src/api/rest/config.ts
+++ b/packages/validator/src/api/rest/config.ts
@@ -5,11 +5,9 @@ import {IApiClient} from "../interface";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function ConfigApi(types: IBeaconSSZTypes, client: HttpClient): IApiClient["config"] {
-  const prefix = "/eth/v1/config";
-
   return {
     async getForkSchedule(): Promise<phase0.Fork[]> {
-      const res = await client.get<{data: Json[]}>(prefix + "/fork_schedule");
+      const res = await client.get<{data: Json[]}>("/eth/v1/config/fork_schedule");
       return res.data.map((fork) => types.phase0.Fork.fromJson(fork));
     },
   };

--- a/packages/validator/src/api/rest/events.ts
+++ b/packages/validator/src/api/rest/events.ts
@@ -8,12 +8,10 @@ import {IBeaconSSZTypes} from "@chainsafe/lodestar-types";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function EventsApi(types: IBeaconSSZTypes, client: HttpClient): IApiClient["events"] {
-  const prefix = "/eth/v1/events";
-
   return {
     getEventStream(topics: BeaconEventType[]): IStoppableEventIterable<BeaconEvent> {
       const query = topics.map((topic) => `topics=${topic}`).join("&");
-      const url = `${urlJoin(client.baseUrl, prefix)}?${query}`;
+      const url = `${urlJoin(client.baseUrl, "/eth/v1/events")}?${query}`;
 
       const eventSource = new EventSource(url);
       return new LodestarEventIterator(({push}) => {

--- a/packages/validator/src/api/rest/index.ts
+++ b/packages/validator/src/api/rest/index.ts
@@ -16,7 +16,7 @@ export function ApiClientOverRest(config: IBeaconConfig, baseUrl: string): IApiC
   });
 
   return {
-    beacon: BeaconApi(config.types, client),
+    beacon: BeaconApi(config, client),
     config: ConfigApi(config.types, client),
     node: NodeApi(config.types, client),
     events: EventsApi(config.types, client),

--- a/packages/validator/src/api/rest/node.ts
+++ b/packages/validator/src/api/rest/node.ts
@@ -5,16 +5,14 @@ import {Json} from "@chainsafe/ssz";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function NodeApi(types: IBeaconSSZTypes, client: HttpClient): IApiClient["node"] {
-  const prefix = "/eth/v1/node";
-
   return {
     async getVersion(): Promise<string> {
-      const res = await client.get<{data: {version: string}}>(prefix + "/version");
+      const res = await client.get<{data: {version: string}}>("/eth/v1/node/version");
       return res.data.version;
     },
 
     async getSyncingStatus(): Promise<phase0.SyncingStatus> {
-      const res = await client.get<{data: Json}>(prefix + "/syncing");
+      const res = await client.get<{data: Json}>("/eth/v1/node/syncing");
       return types.phase0.SyncingStatus.fromJson(res.data, {case: "snake"});
     },
   };

--- a/packages/validator/src/api/rest/validator.ts
+++ b/packages/validator/src/api/rest/validator.ts
@@ -1,4 +1,13 @@
-import {CommitteeIndex, Epoch, Root, phase0, Slot, ValidatorIndex, IBeaconSSZTypes} from "@chainsafe/lodestar-types";
+import {
+  CommitteeIndex,
+  Epoch,
+  Root,
+  phase0,
+  Slot,
+  ValidatorIndex,
+  IBeaconSSZTypes,
+  altair,
+} from "@chainsafe/lodestar-types";
 import {Json, toHexString} from "@chainsafe/ssz";
 import {HttpClient} from "../../util";
 import {IApiClient} from "../interface";
@@ -6,26 +15,32 @@ import {IApiClient} from "../interface";
 /* eslint-disable @typescript-eslint/naming-convention */
 
 export function ValidatorApi(types: IBeaconSSZTypes, client: HttpClient): IApiClient["validator"] {
-  const prefix = "/eth/v1/validator";
-
   return {
     async getProposerDuties(epoch: Epoch): Promise<phase0.ProposerDutiesApi> {
       const res = await client.get<{data: Json[]; dependentRoot: string}>(
-        prefix + `/duties/proposer/${epoch.toString()}`
+        `/eth/v1/validator/duties/proposer/${epoch.toString()}`
       );
       return types.phase0.ProposerDutiesApi.fromJson(res, {case: "snake"});
     },
 
     async getAttesterDuties(epoch: Epoch, indices: ValidatorIndex[]): Promise<phase0.AttesterDutiesApi> {
       const res = await client.post<string[], {data: Json[]; dependentRoot: string}>(
-        prefix + `/duties/attester/${epoch.toString()}`,
+        `/eth/v1/validator/duties/attester/${epoch.toString()}`,
         indices.map((index) => types.ValidatorIndex.toJson(index) as string)
       );
       return types.phase0.AttesterDutiesApi.fromJson(res, {case: "snake"});
     },
 
+    async getSyncCommitteeDuties(epoch: number, indices: ValidatorIndex[]): Promise<altair.SyncDutiesApi> {
+      const res = await client.post<string[], {data: Json[]; dependentRoot: string}>(
+        `/eth/v1/validator/duties/sync/${epoch.toString()}`,
+        indices.map((index) => types.ValidatorIndex.toJson(index) as string)
+      );
+      return types.altair.SyncDutiesApi.fromJson(res, {case: "snake"});
+    },
+
     async produceBlock(slot: Slot, randaoReveal: Uint8Array, graffiti: string): Promise<phase0.BeaconBlock> {
-      const res = await client.get<{data: Json}>(prefix + `/blocks/${slot}`, {
+      const res = await client.get<{data: Json}>(`/eth/v1/validator/blocks/${slot}`, {
         randao_reveal: toHexString(randaoReveal),
         graffiti,
       });
@@ -33,12 +48,28 @@ export function ValidatorApi(types: IBeaconSSZTypes, client: HttpClient): IApiCl
     },
 
     async produceAttestationData(index: CommitteeIndex, slot: Slot): Promise<phase0.AttestationData> {
-      const res = await client.get<{data: Json[]}>(prefix + "/attestation_data", {committee_index: index, slot});
+      const res = await client.get<{data: Json[]}>("/eth/v1/validator/attestation_data", {
+        committee_index: index,
+        slot,
+      });
       return types.phase0.AttestationData.fromJson(res.data, {case: "snake"});
     },
 
+    async produceSyncCommitteeContribution(
+      slot: Slot,
+      subcommitteeIndex: number,
+      beaconBlockRoot: Root
+    ): Promise<altair.SyncCommitteeContribution> {
+      const res = await client.get<{data: Json}>("/eth/v1/validator/sync_committee_contribution", {
+        subcommittee_index: subcommitteeIndex,
+        slot,
+        beacon_block_root: toHexString(beaconBlockRoot),
+      });
+      return types.altair.SyncCommitteeContribution.fromJson(res.data, {case: "snake"});
+    },
+
     async getAggregatedAttestation(attestationDataRoot: Root, slot: Slot): Promise<phase0.Attestation> {
-      const res = await client.get<{data: Json[]}>(prefix + "/aggregate_attestation", {
+      const res = await client.get<{data: Json[]}>("/eth/v1/validator/aggregate_attestation", {
         attestation_data_root: types.Root.toJson(attestationDataRoot) as string,
         slot,
       });
@@ -47,15 +78,29 @@ export function ValidatorApi(types: IBeaconSSZTypes, client: HttpClient): IApiCl
 
     async publishAggregateAndProofs(signedAggregateAndProofs: phase0.SignedAggregateAndProof[]): Promise<void> {
       await client.post<Json[], void>(
-        prefix + "/aggregate_and_proofs",
+        "/eth/v1/validator/aggregate_and_proofs",
         signedAggregateAndProofs.map((a) => types.phase0.SignedAggregateAndProof.toJson(a, {case: "snake"}))
+      );
+    },
+
+    async publishContributionAndProofs(contributionAndProofs: altair.SignedContributionAndProof[]): Promise<void> {
+      await client.post<Json[], void>(
+        "/eth/v1/validator/contribution_and_proofs",
+        contributionAndProofs.map((item) => types.altair.SignedContributionAndProof.toJson(item, {case: "snake"}))
       );
     },
 
     async prepareBeaconCommitteeSubnet(subscriptions: phase0.BeaconCommitteeSubscription[]): Promise<void> {
       await client.post<Json[], void>(
-        prefix + "/beacon_committee_subscriptions",
+        "/eth/v1/validator/beacon_committee_subscriptions",
         subscriptions.map((s) => types.phase0.BeaconCommitteeSubscription.toJson(s, {case: "snake"}))
+      );
+    },
+
+    async prepareSyncCommitteeSubnets(subscriptions: altair.SyncCommitteeSubscription[]): Promise<void> {
+      await client.post<Json[], void>(
+        "/eth/v1/validator/sync_committee_subscriptions",
+        subscriptions.map((item) => types.altair.SyncCommitteeSubscription.toJson(item, {case: "snake"}))
       );
     },
   };

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -24,11 +24,6 @@ export class AttestationService {
     private readonly validatorStore: ValidatorStore,
     indicesService: IndicesService
   ) {
-    this.config = config;
-    this.logger = logger;
-    this.apiClient = apiClient;
-    this.clock = clock;
-    this.validatorStore = validatorStore;
     this.dutiesService = new AttestationDutiesService(config, logger, apiClient, clock, validatorStore, indicesService);
 
     // At most every slot, check existing duties from AttestationDutiesService and run tasks

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -79,10 +79,10 @@ export class AttestationDutiesService {
    *
    * This function will perform (in the following order):
    *
-   * 1. Poll for current-epoch duties and update the local `this.attesters` map.
+   * 1. Poll for current-epoch duties and update the local duties map.
    * 2. As above, but for the next-epoch.
    * 3. Push out any attestation subnet subscriptions to the BN.
-   * 4. Prune old entries from `this.attesters`.
+   * 4. Prune old entries from duties.
    */
   private async pollBeaconAttesters(currentEpoch: Epoch, indexArr: ValidatorIndex[]): Promise<void> {
     const nextEpoch = currentEpoch + 1;
@@ -134,8 +134,9 @@ export class AttestationDutiesService {
     }
   }
 
-  /** For the given `indexArr`, download the duties for the given `epoch` and
-      store them in `this.attesters`. */
+  /**
+   * For the given `indexArr`, download the duties for the given `epoch` and store them in duties.
+   */
   private async pollBeaconAttestersForEpoch(epoch: Epoch, indexArr: ValidatorIndex[]): Promise<void> {
     // Don't fetch duties for epochs before genesis. However, should fetch epoch 0 duties at epoch -1
     if (epoch < 0) {
@@ -199,7 +200,7 @@ export class AttestationDutiesService {
     };
   }
 
-  /** Run once per epoch to prune `this.attesters` map */
+  /** Run once per epoch to prune duties map */
   private pruneOldDuties(currentEpoch: Epoch): void {
     for (const attMap of this.dutiesByEpochByIndex.values()) {
       for (const epoch of attMap.keys()) {

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -34,11 +34,6 @@ export class AttestationDutiesService {
     private readonly validatorStore: ValidatorStore,
     private readonly indicesService: IndicesService
   ) {
-    this.config = config;
-    this.logger = logger;
-    this.apiClient = apiClient;
-    this.validatorStore = validatorStore;
-
     // Running this task every epoch is safe since a re-org of two epochs is very unlikely
     // TODO: If the re-org event is reliable consider re-running then
     clock.runEveryEpoch(this.runDutiesTasks);

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -3,8 +3,9 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {BLSSignature, Epoch, phase0, Root, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
+import {IndicesService} from "./indices";
 import {IApiClient} from "../api";
-import {extendError, getAggregatorModulo, isValidatorAggregator, notAborted} from "../util";
+import {extendError, isAttestationAggregator, notAborted} from "../util";
 import {IClock} from "../util/clock";
 import {ValidatorStore} from "./validatorStore";
 
@@ -12,32 +13,26 @@ import {ValidatorStore} from "./validatorStore";
 const HISTORICAL_DUTIES_EPOCHS = 2;
 
 /** Neatly joins the server-generated `AttesterData` with the locally-generated `selectionProof`. */
-export type DutyAndProof = {
+export type AttDutyAndProof = {
   duty: phase0.AttesterDuty;
   /** This value is only set to not null if the proof indicates that the validator is an aggregator. */
   selectionProof: BLSSignature | null;
 };
 
 // To assist with readability
-type PubkeyHex = string;
-type AttDutyAtEpoch = {dependentRoot: Root; dutyAndProof: DutyAndProof};
+type AttDutyAtEpoch = {dependentRoot: Root; dutyAndProof: AttDutyAndProof};
 
 export class AttestationDutiesService {
-  private readonly config: IBeaconConfig;
-  private readonly logger: ILogger;
-  private readonly apiClient: IApiClient;
-  private readonly validatorStore: ValidatorStore;
-  /** Indexed by pubkey in hex 0x prefixed */
-  private readonly indices = new Map<PubkeyHex, ValidatorIndex>();
   /** Maps a validator public key to their duties for each epoch */
-  private readonly attesters = new Map<PubkeyHex, Map<Epoch, AttDutyAtEpoch>>();
+  private readonly dutiesByEpochByIndex = new Map<ValidatorIndex, Map<Epoch, AttDutyAtEpoch>>();
 
   constructor(
-    config: IBeaconConfig,
-    logger: ILogger,
-    apiClient: IApiClient,
+    private readonly config: IBeaconConfig,
+    private readonly logger: ILogger,
+    private readonly apiClient: IApiClient,
     clock: IClock,
-    validatorStore: ValidatorStore
+    private readonly validatorStore: ValidatorStore,
+    private readonly indicesService: IndicesService
   ) {
     this.config = config;
     this.logger = logger;
@@ -46,16 +41,16 @@ export class AttestationDutiesService {
 
     // Running this task every epoch is safe since a re-org of two epochs is very unlikely
     // TODO: If the re-org event is reliable consider re-running then
-    clock.runEveryEpoch(this.runAttesterDutiesTasks);
+    clock.runEveryEpoch(this.runDutiesTasks);
   }
 
   /** Returns all `ValidatorDuty` for the given `slot` */
-  getAttestersAtSlot(slot: Slot): DutyAndProof[] {
+  getDutiesAtSlot(slot: Slot): AttDutyAndProof[] {
     const epoch = computeEpochAtSlot(this.config, slot);
-    const duties: DutyAndProof[] = [];
+    const duties: AttDutyAndProof[] = [];
 
-    for (const attMap of this.attesters.values()) {
-      const dutyAtEpoch = attMap.get(epoch);
+    for (const dutiesByEpoch of this.dutiesByEpochByIndex.values()) {
+      const dutyAtEpoch = dutiesByEpoch.get(epoch);
       if (dutyAtEpoch && dutyAtEpoch.dutyAndProof.duty.slot === slot) {
         duties.push(dutyAtEpoch.dutyAndProof);
       }
@@ -64,51 +59,25 @@ export class AttestationDutiesService {
     return duties;
   }
 
-  private runAttesterDutiesTasks = async (epoch: Epoch): Promise<void> => {
+  private runDutiesTasks = async (epoch: Epoch): Promise<void> => {
     await Promise.all([
-      // Run pollBeaconAttesters immeditelly for all known local indices
-      this.pollBeaconAttesters(epoch, this.getAllLocalIndices()).catch((e) => {
+      // Run pollBeaconAttesters immediately for all known local indices
+      this.pollBeaconAttesters(epoch, this.indicesService.getAllLocalIndices()).catch((e) => {
         if (notAborted(e)) this.logger.error("Error on poll attesters", {epoch}, e);
       }),
 
       // At the same time fetch any remaining unknown validator indices, then poll duties for those newIndices only
-      this.pollValidatorIndices()
+      this.indicesService
+        .pollValidatorIndices()
         .then((newIndices) => this.pollBeaconAttesters(epoch, newIndices))
         .catch((e) => {
           if (notAborted(e)) this.logger.error("Error on poll indices and attesters", {epoch}, e);
         }),
     ]);
 
-    // After both, prune once per epoch
+    // After both, prune
     this.pruneOldDuties(epoch);
   };
-
-  /** Iterate through all the voting pubkeys in the `ValidatorStore` and attempt to learn any unknown
-      validator indices. Returns the new discovered indexes */
-  private async pollValidatorIndices(): Promise<ValidatorIndex[]> {
-    const pubkeysToPoll = this.validatorStore
-      .votingPubkeys()
-      .filter((pubkey) => !this.indices.has(toHexString(pubkey)));
-
-    if (pubkeysToPoll.length === 0) {
-      return [];
-    }
-
-    // Query the remote BN to resolve a pubkey to a validator index.
-    const validatorsState = await this.apiClient.beacon.state.getStateValidators("head", {indices: pubkeysToPoll});
-
-    const newIndices = [];
-    for (const validatorState of validatorsState) {
-      const pubkeyHex = toHexString(validatorState.validator.pubkey);
-      if (!this.indices.has(pubkeyHex)) {
-        this.logger.debug("Discovered validator", {pubkey: pubkeyHex, index: validatorState.index});
-        this.indices.set(pubkeyHex, validatorState.index);
-        newIndices.push(validatorState.index);
-      }
-    }
-
-    return newIndices;
-  }
 
   /**
    * Query the beacon node for attestation duties for any known validators.
@@ -135,7 +104,6 @@ export class AttestationDutiesService {
       });
     }
 
-    // This vector is likely to be a little oversized, but it won't reallocate.
     const beaconCommitteeSubscriptions: phase0.BeaconCommitteeSubscription[] = [];
 
     // For this epoch and the next epoch, produce any beacon committee subscriptions.
@@ -145,8 +113,8 @@ export class AttestationDutiesService {
     // if the BN goes offline or we swap to a different one.
     const indexSet = new Set(indexArr);
     for (const epoch of [currentEpoch, nextEpoch]) {
-      for (const attMap of this.attesters.values()) {
-        const dutyAtEpoch = attMap.get(epoch);
+      for (const dutiesByEpoch of this.dutiesByEpochByIndex.values()) {
+        const dutyAtEpoch = dutiesByEpoch.get(epoch);
         if (dutyAtEpoch) {
           const {duty, selectionProof} = dutyAtEpoch.dutyAndProof;
           if (indexSet.has(duty.validatorIndex)) {
@@ -166,7 +134,7 @@ export class AttestationDutiesService {
     if (beaconCommitteeSubscriptions.length > 0) {
       // TODO: Should log or throw?
       await this.apiClient.validator.prepareBeaconCommitteeSubnet(beaconCommitteeSubscriptions).catch((e) => {
-        throw extendError(e, "Failed to subscribe to committee subnet");
+        throw extendError(e, "Failed to subscribe to beacon committee subnets");
       });
     }
   }
@@ -196,25 +164,24 @@ export class AttestationDutiesService {
 
     let alreadyWarnedReorg = false;
     for (const duty of relevantDuties) {
-      const pubkeyHex = toHexString(duty.pubkey);
-      let attMap = this.attesters.get(pubkeyHex);
-      if (!attMap) {
-        attMap = new Map<Epoch, AttDutyAtEpoch>();
-        this.attesters.set(pubkeyHex, attMap);
+      let dutiesByEpoch = this.dutiesByEpochByIndex.get(duty.validatorIndex);
+      if (!dutiesByEpoch) {
+        dutiesByEpoch = new Map<Epoch, AttDutyAtEpoch>();
+        this.dutiesByEpochByIndex.set(duty.validatorIndex, dutiesByEpoch);
       }
 
       // Only update the duties if either is true:
       //
       // - There were no known duties for this epoch.
       // - The dependent root has changed, signalling a re-org.
-      const prior = attMap.get(epoch);
+      const prior = dutiesByEpoch.get(epoch);
       const dependentRootChanged = prior && !this.config.types.Root.equals(prior.dependentRoot, dependentRoot);
 
       if (!prior || dependentRootChanged) {
         const dutyAndProof = await this.getDutyAndProof(duty);
 
         // Using `alreadyWarnedReorg` avoids excessive logs.
-        attMap.set(epoch, {dependentRoot, dutyAndProof});
+        dutiesByEpoch.set(epoch, {dependentRoot, dutyAndProof});
         if (prior && dependentRootChanged && !alreadyWarnedReorg) {
           alreadyWarnedReorg = true;
           this.logger.warn("Attester duties re-org. This may happen from time to time", {
@@ -226,11 +193,9 @@ export class AttestationDutiesService {
     }
   }
 
-  private async getDutyAndProof(duty: phase0.AttesterDuty): Promise<DutyAndProof> {
+  private async getDutyAndProof(duty: phase0.AttesterDuty): Promise<AttDutyAndProof> {
     const selectionProof = await this.validatorStore.signSelectionProof(duty.pubkey, duty.slot);
-
-    const modulo = getAggregatorModulo(this.config, duty);
-    const isAggregator = isValidatorAggregator(selectionProof, modulo);
+    const isAggregator = isAttestationAggregator(this.config, duty, selectionProof);
 
     return {
       duty,
@@ -239,17 +204,9 @@ export class AttestationDutiesService {
     };
   }
 
-  /** Return all known indices from the validatorStore pubkeys */
-  private getAllLocalIndices(): ValidatorIndex[] {
-    return this.validatorStore
-      .votingPubkeys()
-      .map((pubkey) => this.indices.get(toHexString(pubkey)))
-      .filter((index): index is ValidatorIndex => index !== undefined);
-  }
-
   /** Run once per epoch to prune `this.attesters` map */
   private pruneOldDuties(currentEpoch: Epoch): void {
-    for (const attMap of this.attesters.values()) {
+    for (const attMap of this.dutiesByEpochByIndex.values()) {
       for (const epoch of attMap.keys()) {
         if (epoch + HISTORICAL_DUTIES_EPOCHS < currentEpoch) {
           attMap.delete(epoch);

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -15,18 +15,13 @@ export class BlockProposingService {
   private readonly dutiesService: BlockDutiesService;
 
   constructor(
-    private readonly config: IBeaconConfig,
+    config: IBeaconConfig,
     private readonly logger: ILogger,
     private readonly apiClient: IApiClient,
-    private readonly clock: IClock,
+    clock: IClock,
     private readonly validatorStore: ValidatorStore,
     private readonly graffiti?: string
   ) {
-    this.config = config;
-    this.logger = logger;
-    this.apiClient = apiClient;
-    this.validatorStore = validatorStore;
-    this.graffiti = graffiti;
     this.dutiesService = new BlockDutiesService(
       config,
       logger,

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -12,20 +12,15 @@ import {IClock} from "../util/clock";
  * Service that sets up and handles validator block proposal duties.
  */
 export class BlockProposingService {
-  private readonly config: IBeaconConfig;
-  private readonly logger: ILogger;
-  private readonly apiClient: IApiClient;
-  private readonly validatorStore: ValidatorStore;
   private readonly dutiesService: BlockDutiesService;
-  private readonly graffiti?: string;
 
   constructor(
-    config: IBeaconConfig,
-    logger: ILogger,
-    apiClient: IApiClient,
-    clock: IClock,
-    validatorStore: ValidatorStore,
-    graffiti?: string
+    private readonly config: IBeaconConfig,
+    private readonly logger: ILogger,
+    private readonly apiClient: IApiClient,
+    private readonly clock: IClock,
+    private readonly validatorStore: ValidatorStore,
+    private readonly graffiti?: string
   ) {
     this.config = config;
     this.logger = logger;

--- a/packages/validator/src/services/blockDuties.ts
+++ b/packages/validator/src/services/blockDuties.ts
@@ -29,14 +29,10 @@ export class BlockDutiesService {
     private readonly config: IBeaconConfig,
     private readonly logger: ILogger,
     private readonly apiClient: IApiClient,
-    private readonly clock: IClock,
+    clock: IClock,
     private readonly validatorStore: ValidatorStore,
     notifyBlockProductionFn: NotifyBlockProductionFn
   ) {
-    this.config = config;
-    this.logger = logger;
-    this.apiClient = apiClient;
-    this.validatorStore = validatorStore;
     this.notifyBlockProductionFn = notifyBlockProductionFn;
 
     // TODO: Instead of polling every CLOCK_SLOT, poll every CLOCK_EPOCH and track re-org events

--- a/packages/validator/src/services/fork.ts
+++ b/packages/validator/src/services/fork.ts
@@ -16,15 +16,13 @@ export interface IForkService {
  *   the cached value than to stop the validator flow
  */
 export class ForkService implements IForkService {
-  private readonly provider: IApiClient;
-  private readonly logger: ILogger;
   private fork: phase0.Fork | null = null;
   /** Store the promise and return it in getFork() for a potential race condition on start */
   private forkPromise: Promise<phase0.Fork> | null = null;
   /** Prevent calling updateFork() more than once at the same time */
   private forkPromisePending = false;
 
-  constructor(provider: IApiClient, logger: ILogger, clock: IClock) {
+  constructor(private readonly provider: IApiClient, private readonly logger: ILogger, clock: IClock) {
     this.provider = provider;
     this.logger = logger;
 

--- a/packages/validator/src/services/fork.ts
+++ b/packages/validator/src/services/fork.ts
@@ -23,9 +23,6 @@ export class ForkService implements IForkService {
   private forkPromisePending = false;
 
   constructor(private readonly provider: IApiClient, private readonly logger: ILogger, clock: IClock) {
-    this.provider = provider;
-    this.logger = logger;
-
     clock.runEveryEpoch(this.updateFork);
   }
 

--- a/packages/validator/src/services/indices.ts
+++ b/packages/validator/src/services/indices.ts
@@ -1,0 +1,77 @@
+import {ValidatorIndex} from "@chainsafe/lodestar-types";
+import {ILogger} from "@chainsafe/lodestar-utils";
+import {toHexString} from "@chainsafe/ssz";
+import {IApiClient} from "../api";
+import {ValidatorStore} from "./validatorStore";
+
+// To assist with readability
+type PubkeyHex = string;
+
+export class IndicesService {
+  private readonly logger: ILogger;
+  private readonly apiClient: IApiClient;
+  private readonly validatorStore: ValidatorStore;
+  /** Indexed by pubkey in hex 0x prefixed */
+  private readonly pubkey2index = new Map<PubkeyHex, ValidatorIndex>();
+  private readonly indices = new Set<ValidatorIndex>();
+  // Request indices once
+  private pollValidatorIndicesPromise: Promise<ValidatorIndex[]> | null = null;
+
+  constructor(logger: ILogger, apiClient: IApiClient, validatorStore: ValidatorStore) {
+    this.logger = logger;
+    this.apiClient = apiClient;
+    this.validatorStore = validatorStore;
+  }
+
+  /** Return all known indices from the validatorStore pubkeys */
+  getAllLocalIndices(): ValidatorIndex[] {
+    return Array.from(this.indices.values());
+  }
+
+  /** Return true if `index` is active part of this validator client */
+  hasValidatorIndex(index: ValidatorIndex): boolean {
+    return this.indices.has(index);
+  }
+
+  pollValidatorIndices(): Promise<ValidatorIndex[]> {
+    // TODO: ADd comment why
+    if (this.pollValidatorIndicesPromise) {
+      return this.pollValidatorIndicesPromise;
+    }
+
+    this.pollValidatorIndicesPromise = this.pollValidatorIndicesInternal();
+    // TODO this too
+    this.pollValidatorIndicesPromise.finally(() => {
+      this.pollValidatorIndicesPromise = null;
+    });
+    return this.pollValidatorIndicesPromise;
+  }
+
+  /** Iterate through all the voting pubkeys in the `ValidatorStore` and attempt to learn any unknown
+      validator indices. Returns the new discovered indexes */
+  private async pollValidatorIndicesInternal(): Promise<ValidatorIndex[]> {
+    const pubkeysToPoll = this.validatorStore
+      .votingPubkeys()
+      .filter((pubkey) => !this.pubkey2index.has(toHexString(pubkey)));
+
+    if (pubkeysToPoll.length === 0) {
+      return [];
+    }
+
+    // Query the remote BN to resolve a pubkey to a validator index.
+    const validatorsState = await this.apiClient.beacon.state.getStateValidators("head", {indices: pubkeysToPoll});
+
+    const newIndices = [];
+    for (const validatorState of validatorsState) {
+      const pubkeyHex = toHexString(validatorState.validator.pubkey);
+      if (!this.pubkey2index.has(pubkeyHex)) {
+        this.logger.debug("Discovered validator", {pubkey: pubkeyHex, index: validatorState.index});
+        this.pubkey2index.set(pubkeyHex, validatorState.index);
+        this.indices.add(validatorState.index);
+        newIndices.push(validatorState.index);
+      }
+    }
+
+    return newIndices;
+  }
+}

--- a/packages/validator/src/services/indices.ts
+++ b/packages/validator/src/services/indices.ts
@@ -31,13 +31,15 @@ export class IndicesService {
   }
 
   pollValidatorIndices(): Promise<ValidatorIndex[]> {
-    // TODO: ADd comment why
+    // Ensures pollValidatorIndicesInternal() is not called more than once at the same time.
+    // AttestationDutiesService and SyncCommitteeDutiesService will call this function at the same time, so this will
+    // cache the promise and return it to the second caller, preventing calling the API twice for the same data.
     if (this.pollValidatorIndicesPromise) {
       return this.pollValidatorIndicesPromise;
     }
 
     this.pollValidatorIndicesPromise = this.pollValidatorIndicesInternal();
-    // TODO this too
+    // Once the pollValidatorIndicesInternal() resolves or rejects null the cached promise so it can be called again.
     this.pollValidatorIndicesPromise.finally(() => {
       this.pollValidatorIndicesPromise = null;
     });

--- a/packages/validator/src/services/indices.ts
+++ b/packages/validator/src/services/indices.ts
@@ -8,20 +8,17 @@ import {ValidatorStore} from "./validatorStore";
 type PubkeyHex = string;
 
 export class IndicesService {
-  private readonly logger: ILogger;
-  private readonly apiClient: IApiClient;
-  private readonly validatorStore: ValidatorStore;
   /** Indexed by pubkey in hex 0x prefixed */
   private readonly pubkey2index = new Map<PubkeyHex, ValidatorIndex>();
   private readonly indices = new Set<ValidatorIndex>();
   // Request indices once
   private pollValidatorIndicesPromise: Promise<ValidatorIndex[]> | null = null;
 
-  constructor(logger: ILogger, apiClient: IApiClient, validatorStore: ValidatorStore) {
-    this.logger = logger;
-    this.apiClient = apiClient;
-    this.validatorStore = validatorStore;
-  }
+  constructor(
+    private readonly logger: ILogger,
+    private readonly apiClient: IApiClient,
+    private readonly validatorStore: ValidatorStore
+  ) {}
 
   /** Return all known indices from the validatorStore pubkeys */
   getAllLocalIndices(): ValidatorIndex[] {

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -24,11 +24,6 @@ export class SyncCommitteeService {
     private readonly validatorStore: ValidatorStore,
     indicesService: IndicesService
   ) {
-    this.config = config;
-    this.logger = logger;
-    this.apiClient = apiClient;
-    this.clock = clock;
-    this.validatorStore = validatorStore;
     this.dutiesService = new SyncCommitteeDutiesService(
       config,
       logger,

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -152,7 +152,7 @@ export class SyncCommitteeService {
     }
 
     this.logger.verbose("Producing SyncCommitteeContribution", logCtx);
-    const aggregate = await this.apiClient.validator
+    const contribution = await this.apiClient.validator
       .produceSyncCommitteeContribution(slot, subcommitteeIndex, beaconBlockRoot)
       .catch((e) => {
         throw extendError(e, "Error producing SyncCommitteeContribution");
@@ -163,9 +163,11 @@ export class SyncCommitteeService {
     for (const {duty, selectionProof} of duties) {
       const logCtxValidator = {...logCtx, validator: prettyBytes(duty.pubkey)};
       try {
-        // Produce signed aggregates only for validators that are subscribed aggregators.
+        // Produce signed contributions only for validators that are subscribed aggregators.
         if (selectionProof !== null) {
-          signedContributions.push(await this.validatorStore.signContributionAndProof(duty, selectionProof, aggregate));
+          signedContributions.push(
+            await this.validatorStore.signContributionAndProof(duty, selectionProof, contribution)
+          );
           this.logger.debug("Signed SyncCommitteeContribution", logCtxValidator);
         }
       } catch (e) {

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -1,0 +1,187 @@
+import {AbortSignal} from "abort-controller";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {Slot, CommitteeIndex, altair, Root} from "@chainsafe/lodestar-types";
+import {ILogger, prettyBytes, sleep} from "@chainsafe/lodestar-utils";
+import {IApiClient} from "../api";
+import {extendError, notAborted, IClock} from "../util";
+import {ValidatorStore} from "./validatorStore";
+import {SyncCommitteeDutiesService, SyncDutyAndProof} from "./syncCommitteeDuties";
+import {groupSyncDutiesBySubCommitteeIndex} from "./utils";
+import {IndicesService} from "./indices";
+import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+
+/**
+ * Service that sets up and handles validator sync duties.
+ */
+export class SyncCommitteeService {
+  private readonly dutiesService: SyncCommitteeDutiesService;
+
+  constructor(
+    private readonly config: IBeaconConfig,
+    private readonly logger: ILogger,
+    private readonly apiClient: IApiClient,
+    private readonly clock: IClock,
+    private readonly validatorStore: ValidatorStore,
+    indicesService: IndicesService
+  ) {
+    this.config = config;
+    this.logger = logger;
+    this.apiClient = apiClient;
+    this.clock = clock;
+    this.validatorStore = validatorStore;
+    this.dutiesService = new SyncCommitteeDutiesService(
+      config,
+      logger,
+      apiClient,
+      clock,
+      validatorStore,
+      indicesService
+    );
+
+    // At most every slot, check existing duties from SyncCommitteeDutiesService and run tasks
+    clock.runEverySlot(this.runSyncCommitteeTasks);
+  }
+
+  private runSyncCommitteeTasks = async (slot: Slot, signal: AbortSignal): Promise<void> => {
+    // Before altair fork no need to check duties
+    if (computeEpochAtSlot(this.config, slot) < this.config.params.ALTAIR_FORK_EPOCH) {
+      return;
+    }
+
+    // Fetch info first so a potential delay is absorved by the sleep() below
+    const dutiesAtSlot = await this.dutiesService.getDutiesAtSlot(slot);
+    const dutiesBySubcommitteeIndex = groupSyncDutiesBySubCommitteeIndex(this.config, dutiesAtSlot);
+    if (dutiesAtSlot.length === 0) {
+      return;
+    }
+
+    // Lighthouse recommends to always wait to 1/3 of the slot, even if the block comes early
+    await sleep(this.clock.msToSlotFraction(slot, 1 / 3), signal);
+
+    // Step 1. Download, sign and publish an `SyncCommitteeSignature` for each validator.
+    //         Differs from AttestationService, `SyncCommitteeSignature` are equal for all
+    const beaconBlockRoot = await this.produceAndPublishSyncCommittees(slot, dutiesAtSlot);
+
+    // Step 2. If an attestation was produced, make an aggregate.
+    // First, wait until the `aggregation_production_instant` (2/3rds of the way though the slot)
+    await sleep(this.clock.msToSlotFraction(slot, 2 / 3), signal);
+
+    // await for all so if the Beacon node is overloaded it auto-throttles
+    // TODO: This approach is convervative to reduce the node's load, review
+    await Promise.all(
+      Array.from(dutiesBySubcommitteeIndex.entries()).map(async ([subcommitteeIndex, duties]) => {
+        if (duties.length === 0) return;
+        // Then download, sign and publish a `SignedAggregateAndProof` for each
+        // validator that is elected to aggregate for this `slot` and `subcommitteeIndex`.
+        await this.produceAndPublishAggregates(slot, subcommitteeIndex, beaconBlockRoot, duties).catch((e) => {
+          if (notAborted(e))
+            this.logger.error("Error on SyncCommitteeContribution", {slot, index: subcommitteeIndex}, e);
+        });
+      })
+    );
+  };
+
+  /**
+   * Performs the first step of the attesting process: downloading `SyncCommittee` objects,
+   * signing them and returning them to the validator.
+   *
+   * https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#attesting
+   *
+   * Only one `SyncCommittee` is downloaded from the BN. It is then signed by each
+   * validator and the list of individually-signed `SyncCommittee` objects is returned to the BN.
+   */
+  private async produceAndPublishSyncCommittees(slot: Slot, duties: SyncDutyAndProof[]): Promise<Root> {
+    const logCtx = {slot};
+
+    // /eth/v1/beacon/blocks/:blockId/root -> at slot -1
+
+    // Produce one attestation data per slot and subcommitteeIndex
+    // Spec: the validator should prepare a SyncCommitteeSignature for the previous slot (slot - 1)
+    // as soon as they have determined the head block of slot - 1
+    const beaconBlockRoot: Root = await this.apiClient.validator
+      .produceSyncCommitteeData(committeeIndex, slot)
+      .catch((e) => {
+        throw extendError(e, "Error producing SyncCommitteeSignature");
+      });
+
+    const signatures: altair.SyncCommitteeSignature[] = [];
+
+    for (const {duty} of duties) {
+      const logCtxValidator = {...logCtx, validator: prettyBytes(duty.pubkey)};
+      try {
+        signatures.push(
+          await this.validatorStore.signSyncCommitteeSignature(duty.pubkey, duty.validatorIndex, slot, beaconBlockRoot)
+        );
+        this.logger.debug("Signed SyncCommitteeSignature", logCtxValidator);
+      } catch (e) {
+        if (notAborted(e)) this.logger.error("Error signing SyncCommitteeSignature", logCtxValidator, e);
+      }
+    }
+
+    if (signatures.length > 0) {
+      try {
+        await this.apiClient.beacon.pool.submitSyncCommitteeSignatures(signatures);
+        this.logger.info("Published SyncCommitteeSignature", {...logCtx, count: signatures.length});
+      } catch (e) {
+        if (notAborted(e)) this.logger.error("Error publishing SyncCommitteeSignature", logCtx, e);
+      }
+    }
+
+    return beaconBlockRoot;
+  }
+
+  /**
+   * Performs the second step of the attesting process: downloading an aggregated `SyncCommittee`,
+   * converting it into a `SignedAggregateAndProof` and returning it to the BN.
+   *
+   * https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#broadcast-aggregate
+   *
+   * Only one aggregated `SyncCommittee` is downloaded from the BN. It is then signed
+   * by each validator and the list of individually-signed `SignedAggregateAndProof` objects is
+   * returned to the BN.
+   */
+  private async produceAndPublishAggregates(
+    slot: Slot,
+    subcommitteeIndex: CommitteeIndex,
+    beaconBlockRoot: Root,
+    duties: SyncDutyAndProof[]
+  ): Promise<void> {
+    const logCtx = {slot, index: subcommitteeIndex};
+
+    // No validator is aggregator, skip
+    if (duties.every(({selectionProof}) => selectionProof === null)) {
+      return;
+    }
+
+    this.logger.verbose("Producing SyncCommitteeContribution", logCtx);
+    const aggregate = await this.apiClient.validator
+      .produceSyncCommitteeContribution(slot, subcommitteeIndex, beaconBlockRoot)
+      .catch((e) => {
+        throw extendError(e, "Error producing SyncCommitteeContribution");
+      });
+
+    const signedContributions: altair.SignedContributionAndProof[] = [];
+
+    for (const {duty, selectionProof} of duties) {
+      const logCtxValidator = {...logCtx, validator: prettyBytes(duty.pubkey)};
+      try {
+        // Produce signed aggregates only for validators that are subscribed aggregators.
+        if (selectionProof !== null) {
+          signedContributions.push(await this.validatorStore.signContributionAndProof(duty, selectionProof, aggregate));
+          this.logger.debug("Signed SyncCommitteeContribution", logCtxValidator);
+        }
+      } catch (e) {
+        if (notAborted(e)) this.logger.error("Error signing SyncCommitteeContribution", logCtxValidator, e);
+      }
+    }
+
+    if (signedContributions.length > 0) {
+      try {
+        await this.apiClient.validator.publishContributionAndProofs(signedContributions);
+        this.logger.info("Published SyncCommitteeContribution", {...logCtx, count: signedContributions.length});
+      } catch (e) {
+        if (notAborted(e)) this.logger.error("Error publishing SyncCommitteeContribution", logCtx, e);
+      }
+    }
+  }
+}

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -98,11 +98,9 @@ export class SyncCommitteeService {
     // Produce one attestation data per slot and subcommitteeIndex
     // Spec: the validator should prepare a SyncCommitteeSignature for the previous slot (slot - 1)
     // as soon as they have determined the head block of slot - 1
-    const beaconBlockRoot: Root = await this.apiClient.validator
-      .produceSyncCommitteeData(committeeIndex, slot)
-      .catch((e) => {
-        throw extendError(e, "Error producing SyncCommitteeSignature");
-      });
+    const beaconBlockRoot = await this.apiClient.beacon.blocks.getBlockRoot(slot - 1).catch((e) => {
+      throw extendError(e, "Error producing SyncCommitteeSignature");
+    });
 
     const signatures: altair.SyncCommitteeSignature[] = [];
 

--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -1,0 +1,227 @@
+import {computeSyncPeriodAtEpoch, computeSyncPeriodAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {altair, BLSSignature, Epoch, Root, Slot, SyncPeriod, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {ILogger} from "@chainsafe/lodestar-utils";
+import {toHexString} from "@chainsafe/ssz";
+import {IndicesService} from "./indices";
+import {IApiClient} from "../api";
+import {extendError, isSyncCommitteeAggregator, notAborted} from "../util";
+import {IClock} from "../util/clock";
+import {ValidatorStore} from "./validatorStore";
+
+/** Only retain `HISTORICAL_DUTIES_PERIODS` duties prior to the current periods. */
+const HISTORICAL_DUTIES_PERIODS = 2;
+/** Epochs prior to `ALTAIR_FORK_EPOCH` to start fetching duties */
+const ALTAIR_FORK_LOOKAHEAD = 1;
+
+/** Neatly joins the server-generated `AttesterData` with the locally-generated `selectionProof`. */
+export type SyncDutyAndProof = {
+  duty: altair.SyncDuty;
+  /** This value is only set to not null if the proof indicates that the validator is an aggregator. */
+  selectionProof: BLSSignature | null;
+};
+
+// To assist with readability
+type DutyAtPeriod = {dependentRoot: Root; duty: altair.SyncDuty};
+
+/**
+ * Validators are part of a static long (~27h) sync committee, and part of static subnets.
+ * However, the isAggregator role changes per slot.
+ */
+export class SyncCommitteeDutiesService {
+  /** Maps a validator public key to their duties for each slot */
+  private readonly dutiesByPeriodByIndex = new Map<ValidatorIndex, Map<Slot, DutyAtPeriod>>();
+
+  constructor(
+    private readonly config: IBeaconConfig,
+    private readonly logger: ILogger,
+    private readonly apiClient: IApiClient,
+    clock: IClock,
+    private readonly validatorStore: ValidatorStore,
+    private readonly indicesService: IndicesService
+  ) {
+    this.config = config;
+    this.logger = logger;
+    this.apiClient = apiClient;
+    this.validatorStore = validatorStore;
+
+    // Running this task every epoch is safe since a re-org of two epochs is very unlikely
+    // TODO: If the re-org event is reliable consider re-running then
+    clock.runEveryEpoch(this.runDutiesTasks);
+  }
+
+  /** Returns all `ValidatorDuty` for the given `slot` */
+  async getDutiesAtSlot(slot: Slot): Promise<SyncDutyAndProof[]> {
+    const period = computeSyncPeriodAtSlot(this.config, slot);
+    const duties: SyncDutyAndProof[] = [];
+
+    for (const dutiesByPeriod of this.dutiesByPeriodByIndex.values()) {
+      const dutyAtPeriod = dutiesByPeriod.get(period);
+      // Validator always has a duty during the entire period
+      if (dutyAtPeriod) {
+        // getDutyAndProof() is async beacuse it may have to fetch the fork but should never happen in practice
+        duties.push(await this.getDutyAndProof(slot, dutyAtPeriod.duty));
+      }
+    }
+
+    return duties;
+  }
+
+  private runDutiesTasks = async (epoch: Epoch): Promise<void> => {
+    // Before altair fork (+ lookahead) no need to check duties
+    if (epoch < this.config.params.ALTAIR_FORK_EPOCH - ALTAIR_FORK_LOOKAHEAD) {
+      return;
+    }
+
+    const period = computeSyncPeriodAtEpoch(this.config, epoch);
+
+    await Promise.all([
+      // Run pollSyncCommittees immediately for all known local indices
+      this.pollSyncCommittees(period, this.indicesService.getAllLocalIndices()).catch((e) => {
+        if (notAborted(e)) this.logger.error("Error on poll SyncDuties", {period}, e);
+      }),
+
+      // At the same time fetch any remaining unknown validator indices, then poll duties for those newIndices only
+      this.indicesService
+        .pollValidatorIndices()
+        .then((newIndices) => this.pollSyncCommittees(period, newIndices))
+        .catch((e) => {
+          if (notAborted(e)) this.logger.error("Error on poll indices and SyncDuties", {period}, e);
+        }),
+    ]);
+
+    // After both, prune
+    this.pruneOldDuties(period);
+  };
+
+  /**
+   * Query the beacon node for SyncDuties for any known validators.
+   *
+   * This function will perform (in the following order):
+   *
+   * 1. Poll for current-period duties and update the local `this.attesters` map.
+   * 2. As above, but for the next-period.
+   * 3. Push out any Sync subnet subscriptions to the BN.
+   * 4. Prune old entries from `this.attesters`.
+   */
+  private async pollSyncCommittees(currentPeriod: SyncPeriod, indexArr: ValidatorIndex[]): Promise<void> {
+    // No need to bother the BN if we don't have any validators.
+    if (indexArr.length === 0) {
+      return;
+    }
+
+    const nextPeriod = currentPeriod + 1;
+    for (const period of [currentPeriod, nextPeriod]) {
+      // Download the duties and update the duties for the current and next period.
+      await this.pollSyncCommitteesForEpoch(period, indexArr).catch((e) => {
+        if (notAborted(e)) this.logger.error("Failed to download SyncDuties", {period}, e);
+      });
+    }
+
+    const syncCommitteeSubscriptions: altair.SyncCommitteeSubscription[] = [];
+
+    // For this and the next period, produce any beacon committee subscriptions.
+    //
+    // We are *always* pushing out subscriptions, even if we've subscribed before. This is
+    // potentially excessive on the BN in normal cases, but it will help with fast re-subscriptions
+    // if the BN goes offline or we swap to a different one.
+    const indexSet = new Set(indexArr);
+    for (const period of [currentPeriod, nextPeriod]) {
+      for (const [validatorIndex, dutiesByPeriod] of this.dutiesByPeriodByIndex.entries()) {
+        const dutyAtEpoch = dutiesByPeriod.get(period);
+        if (dutyAtEpoch) {
+          if (indexSet.has(validatorIndex)) {
+            syncCommitteeSubscriptions.push({
+              validatorIndex,
+              syncCommitteeIndices: dutyAtEpoch.duty.validatorSyncCommitteeIndices,
+              // TODO: Change after https://github.com/ethereum/eth2.0-APIs/issues/144
+              untilEpoch: (period + 1) * this.config.params.EPOCHS_PER_SYNC_COMMITTEE_PERIOD,
+              // No need to send isAggregator here since the beacon node will assume validator always aggregates
+            });
+          }
+        }
+      }
+    }
+
+    // If there are any subscriptions, push them out to the beacon node.
+    if (syncCommitteeSubscriptions.length > 0) {
+      // TODO: Should log or throw?
+      await this.apiClient.validator.prepareSyncCommitteeSubnets(syncCommitteeSubscriptions).catch((e) => {
+        throw extendError(e, "Failed to subscribe to sync committee subnets");
+      });
+    }
+  }
+
+  /**
+   * For the given `indexArr`, download the duties for the given `period` and store them in `this.attesters`.
+   */
+  private async pollSyncCommitteesForEpoch(period: SyncPeriod, indexArr: ValidatorIndex[]): Promise<void> {
+    // Don't fetch duties for periods before genesis. However, should fetch period 0 duties at period -1
+    if (period < 0) {
+      return;
+    }
+
+    // TODO: Query by period after https://github.com/ethereum/eth2.0-APIs/issues/144
+    const epoch = period * this.config.params.EPOCHS_PER_SYNC_COMMITTEE_PERIOD;
+    const syncDuties = await this.apiClient.validator.getSyncCommitteeDuties(epoch, indexArr).catch((e) => {
+      throw extendError(e, "Failed to obtain SyncDuties");
+    });
+    const dependentRoot = syncDuties.dependentRoot;
+    const relevantDuties = syncDuties.data.filter((duty) => this.indicesService.hasValidatorIndex(duty.validatorIndex));
+
+    this.logger.debug("Downloaded SyncDuties", {
+      period,
+      dependentRoot: toHexString(dependentRoot),
+      count: relevantDuties.length,
+    });
+
+    let alreadyWarnedReorg = false;
+    for (const duty of relevantDuties) {
+      let dutiesByPeriod = this.dutiesByPeriodByIndex.get(duty.validatorIndex);
+      if (!dutiesByPeriod) {
+        dutiesByPeriod = new Map<Epoch, DutyAtPeriod>();
+        this.dutiesByPeriodByIndex.set(duty.validatorIndex, dutiesByPeriod);
+      }
+      // Only update the duties if either is true:
+      //
+      // - There were no known duties for this period.
+      // - The dependent root has changed, signalling a re-org.
+      const prior = dutiesByPeriod.get(period);
+      const dependentRootChanged = prior && !this.config.types.Root.equals(prior.dependentRoot, dependentRoot);
+
+      if (!prior || dependentRootChanged) {
+        // Using `alreadyWarnedReorg` avoids excessive logs.
+        dutiesByPeriod.set(period, {dependentRoot, duty});
+        if (prior && dependentRootChanged && !alreadyWarnedReorg) {
+          alreadyWarnedReorg = true;
+          this.logger.warn("SyncDuties re-org. This may happen from time to time", {
+            priorDependentRoot: toHexString(prior.dependentRoot),
+            dependentRoot: toHexString(dependentRoot),
+          });
+        }
+      }
+    }
+  }
+
+  private async getDutyAndProof(slot: Slot, duty: altair.SyncDuty): Promise<SyncDutyAndProof> {
+    const selectionProof = await this.validatorStore.signSelectionProof(duty.pubkey, slot);
+    const isAggregator = isSyncCommitteeAggregator(this.config, selectionProof);
+
+    return {
+      duty,
+      // selectionProof === null is used to check if is aggregator
+      selectionProof: isAggregator ? selectionProof : null,
+    };
+  }
+
+  /** Run at least once per period to prune `this.attesters` map */
+  private pruneOldDuties(currentPeriod: SyncPeriod): void {
+    for (const attMap of this.dutiesByPeriodByIndex.values()) {
+      for (const period of attMap.keys()) {
+        if (period + HISTORICAL_DUTIES_PERIODS < currentPeriod) {
+          attMap.delete(period);
+        }
+      }
+    }
+  }
+}

--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -40,11 +40,6 @@ export class SyncCommitteeDutiesService {
     private readonly validatorStore: ValidatorStore,
     private readonly indicesService: IndicesService
   ) {
-    this.config = config;
-    this.logger = logger;
-    this.apiClient = apiClient;
-    this.validatorStore = validatorStore;
-
     // Running this task every epoch is safe since a re-org of two epochs is very unlikely
     // TODO: If the re-org event is reliable consider re-running then
     clock.runEveryEpoch(this.runDutiesTasks);

--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -175,31 +175,23 @@ export class SyncCommitteeDutiesService {
       count: relevantDuties.length,
     });
 
-    let alreadyWarnedReorg = false;
     for (const duty of relevantDuties) {
       let dutiesByPeriod = this.dutiesByPeriodByIndex.get(duty.validatorIndex);
       if (!dutiesByPeriod) {
         dutiesByPeriod = new Map<Epoch, DutyAtPeriod>();
         this.dutiesByPeriodByIndex.set(duty.validatorIndex, dutiesByPeriod);
       }
+
+      // TODO: Enable dependentRoot functionality
+      // Meanwhile just overwrite them, since the latest duty will be older and less likely to re-org
+      //
       // Only update the duties if either is true:
       //
       // - There were no known duties for this period.
       // - The dependent root has changed, signalling a re-org.
-      const prior = dutiesByPeriod.get(period);
-      const dependentRootChanged = prior && !this.config.types.Root.equals(prior.dependentRoot, dependentRoot);
 
-      if (!prior || dependentRootChanged) {
-        // Using `alreadyWarnedReorg` avoids excessive logs.
-        dutiesByPeriod.set(period, {dependentRoot, duty});
-        if (prior && dependentRootChanged && !alreadyWarnedReorg) {
-          alreadyWarnedReorg = true;
-          this.logger.warn("SyncDuties re-org. This may happen from time to time", {
-            priorDependentRoot: toHexString(prior.dependentRoot),
-            dependentRoot: toHexString(dependentRoot),
-          });
-        }
-      }
+      // Using `alreadyWarnedReorg` avoids excessive logs.
+      dutiesByPeriod.set(period, {dependentRoot, duty});
     }
   }
 

--- a/packages/validator/src/services/utils.ts
+++ b/packages/validator/src/services/utils.ts
@@ -28,7 +28,7 @@ export function groupAttDutiesByCommitteeIndex(duties: AttDutyAndProof[]): Map<C
     let dutyAndProofArr = dutiesByCommitteeIndex.get(committeeIndex);
     if (!dutyAndProofArr) {
       dutyAndProofArr = [];
-      dutiesByCommitteeIndex.set(committeeIndex, []);
+      dutiesByCommitteeIndex.set(committeeIndex, dutyAndProofArr);
     }
     dutyAndProofArr.push(dutyAndProof);
   }
@@ -51,7 +51,7 @@ export function groupSyncDutiesBySubCommitteeIndex(
       let dutyAndProofArr = dutiesBySubCommitteeIndex.get(subCommitteeIndex);
       if (!dutyAndProofArr) {
         dutyAndProofArr = [];
-        dutiesBySubCommitteeIndex.set(subCommitteeIndex, []);
+        dutiesBySubCommitteeIndex.set(subCommitteeIndex, dutyAndProofArr);
       }
       dutyAndProofArr.push(dutyAndProof);
     }

--- a/packages/validator/src/services/utils.ts
+++ b/packages/validator/src/services/utils.ts
@@ -1,8 +1,11 @@
 import {SecretKey} from "@chainsafe/bls";
-import {CommitteeIndex} from "@chainsafe/lodestar-types";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
+import {CommitteeIndex, SubCommitteeIndex} from "@chainsafe/lodestar-types";
 import {toHexString} from "@chainsafe/ssz";
 import {PubkeyHex, BLSKeypair} from "../types";
-import {DutyAndProof} from "./attestationDuties";
+import {AttDutyAndProof} from "./attestationDuties";
+import {SyncDutyAndProof} from "./syncCommitteeDuties";
 
 export function mapSecretKeysToValidators(secretKeys: SecretKey[]): Map<PubkeyHex, BLSKeypair> {
   const validators: Map<PubkeyHex, BLSKeypair> = new Map<PubkeyHex, BLSKeypair>();
@@ -17,18 +20,42 @@ export function getAggregationBits(committeeLength: number, validatorIndexInComm
   return Array.from({length: committeeLength}, (_, i) => i === validatorIndexInCommittee);
 }
 
-export function groupDutiesByCommitteeIndex(duties: DutyAndProof[]): Map<CommitteeIndex, DutyAndProof[]> {
-  const dutiesByCommitteeIndex = new Map<CommitteeIndex, DutyAndProof[]>();
+export function groupAttDutiesByCommitteeIndex(duties: AttDutyAndProof[]): Map<CommitteeIndex, AttDutyAndProof[]> {
+  const dutiesByCommitteeIndex = new Map<CommitteeIndex, AttDutyAndProof[]>();
 
   for (const dutyAndProof of duties) {
     const {committeeIndex} = dutyAndProof.duty;
-    const dutyAndProofArr = dutiesByCommitteeIndex.get(committeeIndex);
-    if (dutyAndProofArr) {
-      dutyAndProofArr.push(dutyAndProof);
-    } else {
-      dutiesByCommitteeIndex.set(committeeIndex, [dutyAndProof]);
+    let dutyAndProofArr = dutiesByCommitteeIndex.get(committeeIndex);
+    if (!dutyAndProofArr) {
+      dutyAndProofArr = [];
+      dutiesByCommitteeIndex.set(committeeIndex, []);
     }
+    dutyAndProofArr.push(dutyAndProof);
   }
 
   return dutiesByCommitteeIndex;
+}
+
+export function groupSyncDutiesBySubCommitteeIndex(
+  config: IBeaconConfig,
+  duties: SyncDutyAndProof[]
+): Map<SubCommitteeIndex, SyncDutyAndProof[]> {
+  const dutiesBySubCommitteeIndex = new Map<SubCommitteeIndex, SyncDutyAndProof[]>();
+
+  // TODO: Cache this value
+  const SYNC_COMMITTEE_SUBNET_SIZE = Math.floor(config.params.SYNC_COMMITTEE_SIZE / SYNC_COMMITTEE_SUBNET_COUNT);
+
+  for (const dutyAndProof of duties) {
+    for (const committeeIndex of dutyAndProof.duty.validatorSyncCommitteeIndices) {
+      const subCommitteeIndex = Math.floor(committeeIndex / SYNC_COMMITTEE_SUBNET_SIZE);
+      let dutyAndProofArr = dutiesBySubCommitteeIndex.get(subCommitteeIndex);
+      if (!dutyAndProofArr) {
+        dutyAndProofArr = [];
+        dutiesBySubCommitteeIndex.set(subCommitteeIndex, []);
+      }
+      dutyAndProofArr.push(dutyAndProof);
+    }
+  }
+
+  return dutiesBySubCommitteeIndex;
 }

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -166,8 +166,6 @@ export class ValidatorStore {
     selectionProof: BLSSignature,
     contribution: altair.SyncCommitteeContribution
   ): Promise<altair.SignedContributionAndProof> {
-    this.validateAttestationDuty(duty, aggregate.data);
-
     const contributionAndProof: altair.ContributionAndProof = {
       contribution,
       aggregatorIndex: duty.validatorIndex,

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -13,21 +13,16 @@ import {getAggregationBits, mapSecretKeysToValidators} from "./utils";
  * Service that sets up and handles validator attester duties.
  */
 export class ValidatorStore {
-  private readonly config: IBeaconConfig;
-  private readonly forkService: IForkService;
   private readonly validators: Map<PubkeyHex, BLSKeypair>;
-  private readonly slashingProtection: ISlashingProtection;
   private readonly genesisValidatorsRoot: Root;
 
   constructor(
-    config: IBeaconConfig,
-    forkService: IForkService,
-    slashingProtection: ISlashingProtection,
+    private readonly config: IBeaconConfig,
+    private readonly forkService: IForkService,
+    private readonly slashingProtection: ISlashingProtection,
     secretKeys: SecretKey[],
     genesis: Genesis
   ) {
-    this.config = config;
-    this.forkService = forkService;
     this.validators = mapSecretKeysToValidators(secretKeys);
     this.slashingProtection = slashingProtection;
     this.genesisValidatorsRoot = genesis.genesisValidatorsRoot;

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -1,8 +1,8 @@
 import {SecretKey} from "@chainsafe/bls";
 import {computeDomain, computeEpochAtSlot, computeSigningRoot} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {BLSPubkey, BLSSignature, DomainType, Epoch, phase0, Root, Slot} from "@chainsafe/lodestar-types";
-import {Genesis} from "@chainsafe/lodestar-types/phase0";
+import {altair, BLSPubkey, BLSSignature, DomainType, Epoch, phase0, Root, Slot} from "@chainsafe/lodestar-types";
+import {Genesis, ValidatorIndex} from "@chainsafe/lodestar-types/phase0";
 import {List, toHexString} from "@chainsafe/ssz";
 import {ISlashingProtection} from "../slashingProtection";
 import {BLSKeypair, PubkeyHex} from "../types";
@@ -31,6 +31,11 @@ export class ValidatorStore {
     this.validators = mapSecretKeysToValidators(secretKeys);
     this.slashingProtection = slashingProtection;
     this.genesisValidatorsRoot = genesis.genesisValidatorsRoot;
+  }
+
+  /** Return true if there is at least 1 pubkey registered */
+  hasSomeValidators(): boolean {
+    return this.validators.size > 0;
   }
 
   votingPubkeys(): BLSPubkey[] {
@@ -136,6 +141,56 @@ export class ValidatorStore {
     };
   }
 
+  async signSyncCommitteeSignature(
+    pubkey: BLSPubkey,
+    validatorIndex: ValidatorIndex,
+    slot: Slot,
+    beaconBlockRoot: Root
+  ): Promise<altair.SyncCommitteeSignature> {
+    const domain = await this.getDomain(
+      this.config.params.DOMAIN_SYNC_COMMITTEE,
+      computeEpochAtSlot(this.config, slot)
+    );
+    const signingRoot = computeSigningRoot(this.config, this.config.types.Root, beaconBlockRoot, domain);
+
+    return {
+      slot,
+      validatorIndex,
+      beaconBlockRoot,
+      signature: this.getSecretKey(pubkey).sign(signingRoot).toBytes(),
+    };
+  }
+
+  async signContributionAndProof(
+    duty: altair.SyncDuty,
+    selectionProof: BLSSignature,
+    contribution: altair.SyncCommitteeContribution
+  ): Promise<altair.SignedContributionAndProof> {
+    this.validateAttestationDuty(duty, aggregate.data);
+
+    const contributionAndProof: altair.ContributionAndProof = {
+      contribution,
+      aggregatorIndex: duty.validatorIndex,
+      selectionProof,
+    };
+
+    const domain = await this.getDomain(
+      this.config.params.DOMAIN_CONTRIBUTION_AND_PROOF,
+      computeEpochAtSlot(this.config, contribution.slot)
+    );
+    const signingRoot = computeSigningRoot(
+      this.config,
+      this.config.types.altair.ContributionAndProof,
+      contributionAndProof,
+      domain
+    );
+
+    return {
+      message: contributionAndProof,
+      signature: this.getSecretKey(duty.pubkey).sign(signingRoot).toBytes(),
+    };
+  }
+
   async signSelectionProof(pubkey: BLSPubkey, slot: Slot): Promise<BLSSignature> {
     const domain = await this.getDomain(
       this.config.params.DOMAIN_SELECTION_PROOF,
@@ -153,6 +208,7 @@ export class ValidatorStore {
   }
 
   private getSecretKey(pubkey: BLSPubkey): SecretKey {
+    // TODO: Refactor indexing to not have to run toHexString() on the pubkey every time
     const pubkeyHex = toHexString(pubkey);
     const validator = this.validators.get(pubkeyHex);
 

--- a/packages/validator/src/util/aggregator.ts
+++ b/packages/validator/src/util/aggregator.ts
@@ -1,12 +1,24 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {phase0, BLSSignature, Number64} from "@chainsafe/lodestar-types";
-import {bytesToBigInt, intDiv} from "@chainsafe/lodestar-utils";
+import {SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
+import {phase0, BLSSignature} from "@chainsafe/lodestar-types";
+import {bytesToInt, intDiv} from "@chainsafe/lodestar-utils";
 import {hash} from "@chainsafe/ssz";
 
-export function isValidatorAggregator(slotSignature: BLSSignature, modulo: Number64): boolean {
-  return bytesToBigInt(hash(slotSignature.valueOf() as Uint8Array).slice(0, 8)) % BigInt(modulo) === BigInt(0);
+export function isAttestationAggregator(
+  config: IBeaconConfig,
+  duty: phase0.AttesterDuty,
+  slotSignature: BLSSignature
+): boolean {
+  const modulo = Math.max(1, intDiv(duty.committeeLength, config.params.TARGET_AGGREGATORS_PER_COMMITTEE));
+  return bytesToInt(hash(slotSignature.valueOf() as Uint8Array).slice(0, 8)) % modulo === 0;
 }
 
-export function getAggregatorModulo(config: IBeaconConfig, duty: phase0.AttesterDuty): number {
-  return Math.max(1, intDiv(duty.committeeLength, config.params.TARGET_AGGREGATORS_PER_COMMITTEE));
+export function isSyncCommitteeAggregator(config: IBeaconConfig, selectionProof: BLSSignature): boolean {
+  const {SYNC_COMMITTEE_SIZE, TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE} = config.params;
+
+  const modulo = Math.max(
+    1,
+    intDiv(intDiv(SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_SUBNET_COUNT), TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE)
+  );
+  return bytesToInt(hash(selectionProof.valueOf() as Uint8Array).slice(0, 8)) % modulo === 0;
 }

--- a/packages/validator/src/util/aggregator.ts
+++ b/packages/validator/src/util/aggregator.ts
@@ -1,16 +1,16 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
 import {phase0, BLSSignature} from "@chainsafe/lodestar-types";
-import {bytesToInt, intDiv} from "@chainsafe/lodestar-utils";
+import {bytesToBigInt, intDiv} from "@chainsafe/lodestar-utils";
 import {hash} from "@chainsafe/ssz";
 
 export function isAttestationAggregator(
   config: IBeaconConfig,
-  duty: phase0.AttesterDuty,
+  duty: Pick<phase0.AttesterDuty, "committeeLength">,
   slotSignature: BLSSignature
 ): boolean {
   const modulo = Math.max(1, intDiv(duty.committeeLength, config.params.TARGET_AGGREGATORS_PER_COMMITTEE));
-  return bytesToInt(hash(slotSignature.valueOf() as Uint8Array).slice(0, 8)) % modulo === 0;
+  return bytesToBigInt(hash(slotSignature.valueOf() as Uint8Array).slice(0, 8)) % BigInt(modulo) === BigInt(0);
 }
 
 export function isSyncCommitteeAggregator(config: IBeaconConfig, selectionProof: BLSSignature): boolean {
@@ -20,5 +20,5 @@ export function isSyncCommitteeAggregator(config: IBeaconConfig, selectionProof:
     1,
     intDiv(intDiv(SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_SUBNET_COUNT), TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE)
   );
-  return bytesToInt(hash(selectionProof.valueOf() as Uint8Array).slice(0, 8)) % modulo === 0;
+  return bytesToBigInt(hash(selectionProof.valueOf() as Uint8Array).slice(0, 8)) % BigInt(modulo) === BigInt(0);
 }

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -8,11 +8,13 @@ import {ApiClientOverRest} from "./api/rest";
 import {IValidatorOptions} from "./options";
 import {Clock, IClock} from "./util/clock";
 import {signAndSubmitVoluntaryExit} from "./voluntaryExit";
+import {waitForGenesis} from "./genesis";
 import {ForkService} from "./services/fork";
 import {ValidatorStore} from "./services/validatorStore";
 import {BlockProposingService} from "./services/block";
 import {AttestationService} from "./services/attestation";
-import {waitForGenesis} from "./genesis";
+import {IndicesService} from "./services/indices";
+import {SyncCommitteeService} from "./services/syncCommittee";
 
 // TODO: Extend the timeout, and let it be customizable
 /// The global timeout for HTTP requests to the beacon node.
@@ -44,8 +46,10 @@ export class Validator {
     const clock = new Clock(config, logger, {genesisTime: Number(genesis.genesisTime)});
     const forkService = new ForkService(apiClient, logger, clock);
     const validatorStore = new ValidatorStore(config, forkService, slashingProtection, secretKeys, genesis);
+    const indicesService = new IndicesService(logger, apiClient, validatorStore);
     new BlockProposingService(config, logger, apiClient, clock, validatorStore, graffiti);
-    new AttestationService(config, logger, apiClient, clock, validatorStore);
+    new AttestationService(config, logger, apiClient, clock, validatorStore, indicesService);
+    new SyncCommitteeService(config, logger, apiClient, clock, validatorStore, indicesService);
 
     this.config = config;
     this.logger = logger;

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -13,6 +13,7 @@ import {ValidatorStore} from "../../../src/services/validatorStore";
 import {ApiClientStub} from "../../utils/apiStub";
 import {testLogger} from "../../utils/logger";
 import {ClockMock} from "../../utils/clock";
+import {IndicesService} from "../../../src/services/indices";
 
 describe("AttestationService", function () {
   const sandbox = sinon.createSandbox();
@@ -33,6 +34,8 @@ describe("AttestationService", function () {
     const secretKeys = Array.from({length: 1}, (_, i) => bls.SecretKey.fromBytes(Buffer.alloc(32, i + 1)));
     pubkeys = secretKeys.map((sk) => sk.toPublicKey().toBytes());
     validatorStore.votingPubkeys.returns(pubkeys);
+    validatorStore.hasVotingPubkey.returns(true);
+    validatorStore.hasSomeValidators.returns(true);
     validatorStore.signSelectionProof.resolves(ZERO_HASH);
   });
 
@@ -42,7 +45,8 @@ describe("AttestationService", function () {
 
   it("Should produce, sign, and publish an attestation + aggregate", async () => {
     const clock = new ClockMock();
-    const attestationService = new AttestationService(config, logger, apiClient, clock, validatorStore);
+    const indicesService = new IndicesService(logger, apiClient, validatorStore);
+    const attestationService = new AttestationService(config, logger, apiClient, clock, validatorStore, indicesService);
 
     const attestation = generateEmptyAttestation();
     const aggregate = generateEmptySignedAggregateAndProof();

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -8,7 +8,7 @@ import {
   generateEmptySignedAggregateAndProof,
 } from "@chainsafe/lodestar/test/utils/attestation";
 import {AttestationService} from "../../../src/services/attestation";
-import {DutyAndProof} from "../../../src/services/attestationDuties";
+import {AttDutyAndProof} from "../../../src/services/attestationDuties";
 import {ValidatorStore} from "../../../src/services/validatorStore";
 import {ApiClientStub} from "../../utils/apiStub";
 import {testLogger} from "../../utils/logger";
@@ -46,7 +46,7 @@ describe("AttestationService", function () {
 
     const attestation = generateEmptyAttestation();
     const aggregate = generateEmptySignedAggregateAndProof();
-    const duties: DutyAndProof[] = [
+    const duties: AttDutyAndProof[] = [
       {
         duty: {
           slot: 0,
@@ -66,7 +66,7 @@ describe("AttestationService", function () {
     apiClient.validator.getAttesterDuties.resolves({dependentRoot: ZERO_HASH, data: []});
 
     // Mock duties service to return some duties directly
-    attestationService["dutiesService"].getAttestersAtSlot = sinon.stub().returns(duties);
+    attestationService["dutiesService"].getDutiesAtSlot = sinon.stub().returns(duties);
 
     // Mock beacon's attestation and aggregates endpoints
 

--- a/packages/validator/test/unit/services/attestationDuties.test.ts
+++ b/packages/validator/test/unit/services/attestationDuties.test.ts
@@ -86,7 +86,7 @@ describe("AttestationDutiesService", function () {
       "Wrong dutiesService.attesters Map"
     );
 
-    expect(dutiesService.getAttestersAtSlot(slot)).to.deep.equal(
+    expect(dutiesService.getDutiesAtSlot(slot)).to.deep.equal(
       [{duty, selectionProof: null}],
       "Wrong getAttestersAtSlot()"
     );

--- a/packages/validator/test/unit/services/blockDuties.test.ts
+++ b/packages/validator/test/unit/services/blockDuties.test.ts
@@ -26,6 +26,8 @@ describe("BlockDutiesService", function () {
     const secretKeys = Array.from({length: 2}, (_, i) => bls.SecretKey.fromBytes(Buffer.alloc(32, i + 1)));
     pubkeys = secretKeys.map((sk) => sk.toPublicKey().toBytes());
     validatorStore.votingPubkeys.returns(pubkeys);
+    validatorStore.hasVotingPubkey.returns(true);
+    validatorStore.hasSomeValidators.returns(true);
   });
 
   let controller: AbortController; // To stop clock

--- a/packages/validator/test/unit/services/syncCommittee.test.ts
+++ b/packages/validator/test/unit/services/syncCommittee.test.ts
@@ -1,0 +1,115 @@
+import {AbortController} from "abort-controller";
+import {expect} from "chai";
+import sinon from "sinon";
+import bls from "@chainsafe/bls";
+import {createIBeaconConfig} from "@chainsafe/lodestar-config";
+import {config as mainnetConfig} from "@chainsafe/lodestar-config/mainnet";
+import {SyncCommitteeService} from "../../../src/services/syncCommittee";
+import {SyncDutyAndProof} from "../../../src/services/syncCommitteeDuties";
+import {ValidatorStore} from "../../../src/services/validatorStore";
+import {ApiClientStub} from "../../utils/apiStub";
+import {testLogger} from "../../utils/logger";
+import {ClockMock} from "../../utils/clock";
+import {IndicesService} from "../../../src/services/indices";
+
+/* eslint-disable @typescript-eslint/naming-convention */
+
+describe("SyncCommitteeService", function () {
+  const sandbox = sinon.createSandbox();
+  const logger = testLogger();
+  const ZERO_HASH = Buffer.alloc(32, 0);
+
+  const apiClient = ApiClientStub(sandbox);
+  const validatorStore = sinon.createStubInstance(ValidatorStore) as ValidatorStore &
+    sinon.SinonStubbedInstance<ValidatorStore>;
+  let pubkeys: Uint8Array[]; // Initialize pubkeys in before() so bls is already initialized
+
+  const config = createIBeaconConfig({
+    ...mainnetConfig.params,
+    SECONDS_PER_SLOT: 1 / 1000, // Make slot time super short: 1 ms
+    SLOTS_PER_EPOCH: 3,
+    ALTAIR_FORK_EPOCH: 0, // Activate Altair immediatelly
+  });
+
+  before(() => {
+    const secretKeys = Array.from({length: 1}, (_, i) => bls.SecretKey.fromBytes(Buffer.alloc(32, i + 1)));
+    pubkeys = secretKeys.map((sk) => sk.toPublicKey().toBytes());
+    validatorStore.votingPubkeys.returns(pubkeys);
+    validatorStore.hasVotingPubkey.returns(true);
+    validatorStore.hasSomeValidators.returns(true);
+    validatorStore.signSelectionProof.resolves(ZERO_HASH);
+  });
+
+  let controller: AbortController; // To stop clock
+  beforeEach(() => (controller = new AbortController()));
+  afterEach(() => controller.abort());
+
+  it("Should produce, sign, and publish a sync committee + contribution", async () => {
+    const clock = new ClockMock();
+    const indicesService = new IndicesService(logger, apiClient, validatorStore);
+    const syncCommitteeService = new SyncCommitteeService(
+      config,
+      logger,
+      apiClient,
+      clock,
+      validatorStore,
+      indicesService
+    );
+
+    const beaconBlockRoot = Buffer.alloc(32, 0x4d);
+    const syncCommitteeSignature = config.types.altair.SyncCommitteeSignature.defaultValue();
+    const contribution = config.types.altair.SyncCommitteeContribution.defaultValue();
+    const contributionAndProof = config.types.altair.SignedContributionAndProof.defaultValue();
+    const duties: SyncDutyAndProof[] = [
+      {
+        duty: {
+          pubkey: pubkeys[0],
+          validatorIndex: 0,
+          validatorSyncCommitteeIndices: [7],
+        },
+        selectionProof: ZERO_HASH,
+      },
+    ];
+
+    // Return empty replies to duties service
+    apiClient.beacon.state.getStateValidators.resolves([]);
+    apiClient.validator.getSyncCommitteeDuties.resolves({dependentRoot: ZERO_HASH, data: []});
+
+    // Mock duties service to return some duties directly
+    syncCommitteeService["dutiesService"].getDutiesAtSlot = sinon.stub().returns(duties);
+
+    // Mock beacon's sync committee and contribution routes
+
+    apiClient.beacon.blocks.getBlockRoot.resolves(beaconBlockRoot);
+    apiClient.beacon.pool.submitSyncCommitteeSignatures.resolves();
+    apiClient.validator.produceSyncCommitteeContribution.resolves(contribution);
+    apiClient.validator.publishContributionAndProofs.resolves();
+
+    // Mock signing service
+    validatorStore.signSyncCommitteeSignature.resolves(syncCommitteeSignature);
+    validatorStore.signContributionAndProof.resolves(contributionAndProof);
+
+    // Trigger clock onSlot for slot 0
+    await clock.tickSlotFns(0, controller.signal);
+
+    // Must submit the signature received through signSyncCommitteeSignature()
+    expect(apiClient.beacon.pool.submitSyncCommitteeSignatures.callCount).to.equal(
+      1,
+      "submitSyncCommitteeSignatures() must be called once"
+    );
+    expect(apiClient.beacon.pool.submitSyncCommitteeSignatures.getCall(0).args).to.deep.equal(
+      [[syncCommitteeSignature]], // 1 arg, = syncCommitteeSignature[]
+      "wrong submitSyncCommitteeSignatures() args"
+    );
+
+    // Must submit the aggregate received through produceSyncCommitteeContribution() then signContributionAndProof()
+    expect(apiClient.validator.publishContributionAndProofs.callCount).to.equal(
+      1,
+      "publishContributionAndProofs() must be called once"
+    );
+    expect(apiClient.validator.publishContributionAndProofs.getCall(0).args).to.deep.equal(
+      [[contributionAndProof]], // 1 arg, = contributionAndProof[]
+      "wrong publishContributionAndProofs() args"
+    );
+  });
+});

--- a/packages/validator/test/unit/utils/aggregator.test.ts
+++ b/packages/validator/test/unit/utils/aggregator.test.ts
@@ -1,39 +1,68 @@
-import {getAggregatorModulo, isValidatorAggregator} from "../../../src/util/aggregator";
-import {config} from "@chainsafe/lodestar-config/mainnet";
 import {expect} from "chai";
-import {Signature} from "@chainsafe/bls";
+import {phase0} from "@chainsafe/lodestar-types";
+import {config} from "@chainsafe/lodestar-config/mainnet";
+import {fromHexString} from "@chainsafe/ssz";
+import {isAttestationAggregator, isSyncCommitteeAggregator} from "../../../src/util/aggregator";
+import {createIBeaconConfig} from "@chainsafe/lodestar-config";
+import {SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
 
-describe("getAggregatorModulo", function () {
-  it("should produce correct result", function () {
-    const result = getAggregatorModulo(config, {
-      slot: 1,
-      committeeIndex: 2,
-      committeeLength: 130,
-      committeesAtSlot: 120,
-      validatorCommitteeIndex: 1,
-      validatorIndex: 0,
-      pubkey: Buffer.alloc(48),
-    });
-    expect(result).to.be.equal(8);
-  });
-});
+/* eslint-disable @typescript-eslint/naming-convention */
 
-describe("isValidatorAggregator", function () {
+describe("isAttestationAggregator", function () {
+  const duty: phase0.AttesterDuty = {
+    slot: 1,
+    committeeIndex: 2,
+    committeeLength: 130,
+    committeesAtSlot: 120,
+    validatorCommitteeIndex: 1,
+    validatorIndex: 0,
+    pubkey: Buffer.alloc(48),
+  };
+
   it("should be false", function () {
-    const result = isValidatorAggregator(
-      Signature.fromHex(
+    const result = isAttestationAggregator(
+      config,
+      duty,
+      fromHexString(
         "0x8191d16330837620f0ed85d0d3d52af5b56f7cec12658fa391814251d4b32977eb2e6ca055367354fd63175f8d1d2d7b0678c3c482b738f96a0df40bd06450d99c301a659b8396c227ed781abb37a1604297922219374772ab36b46b84817036"
-      ).toBytes(),
-      8
+      )
     );
     expect(result).to.be.equal(false);
   });
   it("should be true", function () {
-    const result = isValidatorAggregator(
-      Signature.fromHex(
+    const result = isAttestationAggregator(
+      config,
+      duty,
+      fromHexString(
         "0xa8f8bb92931234ca6d8a34530526bcd6a4cfa3bf33bd0470200dc8fa3ebdc3ba24bc8c6e994d58a0f884eb24336d746c01a29693ed0354c0862c2d5de5859e3f58747045182844d267ba232058f7df1867a406f63a1eb8afec0cf3f00a115125"
-      ).toBytes(),
-      8
+      )
+    );
+    expect(result).to.be.equal(true);
+  });
+});
+
+describe("isSyncCommitteeAggregator", function () {
+  const configCustom = createIBeaconConfig({
+    ...config.params,
+    SYNC_COMMITTEE_SIZE: 8 * SYNC_COMMITTEE_SUBNET_COUNT,
+    TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE: 1, // Force same modulo as isAttestationAggregator() test
+  });
+
+  it("should be false", function () {
+    const result = isSyncCommitteeAggregator(
+      configCustom,
+      fromHexString(
+        "0x8191d16330837620f0ed85d0d3d52af5b56f7cec12658fa391814251d4b32977eb2e6ca055367354fd63175f8d1d2d7b0678c3c482b738f96a0df40bd06450d99c301a659b8396c227ed781abb37a1604297922219374772ab36b46b84817036"
+      )
+    );
+    expect(result).to.be.equal(false);
+  });
+  it("should be true", function () {
+    const result = isSyncCommitteeAggregator(
+      configCustom,
+      fromHexString(
+        "0xa8f8bb92931234ca6d8a34530526bcd6a4cfa3bf33bd0470200dc8fa3ebdc3ba24bc8c6e994d58a0f884eb24336d746c01a29693ed0354c0862c2d5de5859e3f58747045182844d267ba232058f7df1867a406f63a1eb8afec0cf3f00a115125"
+      )
     );
     expect(result).to.be.equal(true);
   });


### PR DESCRIPTION
**Motivation**

Completes the work started with https://github.com/ChainSafe/lodestar/pull/2514. Part of #2388

**Description**

- Adds a new service pair: `SyncCommitteeService` + `SyncCommitteeDutiesService` which work very similar to the attester services.
- Abstract getting indices in a different service `IndicesService` used by sync and att services
