### PR TITLE
Fix off by one issue in sync committees

### DIFF
--- a/packages/lodestar/src/api/impl/beacon/blocks/index.ts
+++ b/packages/lodestar/src/api/impl/beacon/blocks/index.ts
@@ -112,8 +112,14 @@ export class BeaconBlockApi implements IBeaconBlocksApi {
     // Fast path: From head state already available in memory get historical blockRoot
     const slot = parseInt(blockId);
     if (!Number.isNaN(slot)) {
-      const state = this.chain.getHeadState();
-      if (slot < state.slot && state.slot <= slot + this.config.params.SLOTS_PER_HISTORICAL_ROOT) {
+      const head = this.chain.forkChoice.getHead();
+
+      if (slot === head.slot) {
+        return head.blockRoot;
+      }
+
+      if (slot < head.slot && head.slot <= slot + this.config.params.SLOTS_PER_HISTORICAL_ROOT) {
+        const state = this.chain.getHeadState();
         return state.blockRoots[slot % this.config.params.SLOTS_PER_HISTORICAL_ROOT];
       }
     }

--- a/packages/lodestar/src/chain/validation/syncCommittee.ts
+++ b/packages/lodestar/src/chain/validation/syncCommittee.ts
@@ -1,6 +1,6 @@
-import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconState, computeSyncPeriodAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
-import {altair, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {altair} from "@chainsafe/lodestar-types";
 import {BeaconState} from "@chainsafe/lodestar-types/lib/allForks";
 import {IBeaconDb} from "../../db";
 import {GossipAction, ISyncCommitteeJob, SyncCommitteeError, SyncCommitteeErrorCode} from "../errors";
@@ -108,7 +108,7 @@ export function validateGossipSyncCommitteeExceptSig(
 
   // [REJECT] The subnet_id is valid for the given validator, i.e. subnet_id in compute_subnets_for_sync_committee(state, sync_committee_signature.validator_index).
   // Note this validation implies the validator is part of the broader current sync committee along with the correct subcommittee.
-  const indexInSubCommittee = getIndexInSubCommittee(headState, subnet, data.validatorIndex);
+  const indexInSubCommittee = getIndexInSubCommittee(headState, subnet, data);
   if (indexInSubCommittee === null) {
     throw new SyncCommitteeError(GossipAction.REJECT, {
       code: SyncCommitteeErrorCode.VALIDATOR_NOT_IN_SYNC_COMMITTEE,
@@ -126,9 +126,20 @@ export function validateGossipSyncCommitteeExceptSig(
 function getIndexInSubCommittee(
   headState: CachedBeaconState<BeaconState>,
   subnet: number,
-  validatorIndex: ValidatorIndex
+  data: Pick<altair.SyncCommitteeSignature, "slot" | "validatorIndex">
 ): IndexInSubCommittee | null {
-  const indexesInCommittee = headState.currSyncComitteeValidatorIndexMap.get(validatorIndex);
+  // Note: The range of slots a validator has to perform duties is off by one.
+  // The previous slot wording means that if your validator is in a sync committee for a period that runs from slot
+  // 100 to 200,then you would actually produce signatures in slot 99 - 199.
+  const statePeriod = computeSyncPeriodAtSlot(headState.config, headState.slot);
+  const dataPeriod = computeSyncPeriodAtSlot(headState.config, data.slot + 1); // See note above for the +1 offset
+
+  const syncComitteeValidatorIndexMap =
+    dataPeriod === statePeriod + 1
+      ? headState.nextSyncComitteeValidatorIndexMap
+      : headState.currSyncComitteeValidatorIndexMap;
+
+  const indexesInCommittee = syncComitteeValidatorIndexMap.get(data.validatorIndex);
   if (indexesInCommittee === undefined) {
     // Not part of the sync committee
     return null;

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -93,7 +93,7 @@ export class SyncCommitteeService {
     // Produce one attestation data per slot and subcommitteeIndex
     // Spec: the validator should prepare a SyncCommitteeSignature for the previous slot (slot - 1)
     // as soon as they have determined the head block of slot - 1
-    const beaconBlockRoot = await this.apiClient.beacon.blocks.getBlockRoot(slot - 1).catch((e) => {
+    const beaconBlockRoot = await this.apiClient.beacon.blocks.getBlockRoot(slot).catch((e) => {
       throw extendError(e, "Error producing SyncCommitteeSignature");
     });
 

--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -47,9 +47,16 @@ export class SyncCommitteeDutiesService {
     clock.runEveryEpoch(this.runDutiesTasks);
   }
 
-  /** Returns all `ValidatorDuty` for the given `slot` */
+  /**
+   * Returns all `ValidatorDuty` for the given `slot`
+   *
+   * Note: The range of slots a validator has to perform duties is off by one.
+   * The previous slot wording means that if your validator is in a sync committee for a period that runs from slot
+   * 100 to 200,then you would actually produce signatures in slot 99 - 199.
+   * https://github.com/ethereum/eth2.0-specs/pull/2400
+   */
   async getDutiesAtSlot(slot: Slot): Promise<SyncDutyAndProof[]> {
-    const period = computeSyncPeriodAtSlot(this.config, slot);
+    const period = computeSyncPeriodAtSlot(this.config, slot + 1); // See note above for the +1 offset
     const duties: SyncDutyAndProof[] = [];
 
     for (const dutiesByPeriod of this.dutiesByPeriodByIndex.values()) {


### PR DESCRIPTION
**Motivation**

As per the changes in ethereum/eth2.0-specs#2400 sync committee duties are now performed from one slot prior to the start of the sync committee period to one slot prior to the end.

**Description**

Closes https://github.com/ChainSafe/lodestar/issues/2516