### PR TITLE
Emit checkpoint events at skipped slots

### DIFF
--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -74,10 +74,17 @@ export async function runStateTransition(
   const config = preState.config;
   const {SLOTS_PER_EPOCH} = config.params;
   const postSlot = job.signedBlock.message.slot;
+  const preEpoch = preState.currentShuffling.epoch;
+  const postEpoch = computeEpochAtSlot(config, postSlot);
+  let middleState = preState;
+  // if it's a epoch transition and block is not the start of epoch, we want to emit checkpoint events at epoch boundary
+  if (preEpoch < postEpoch && postSlot !== computeStartSlotAtEpoch(config, postEpoch)) {
+    middleState = await processSlotsToNearestCheckpoint({emitter, metrics}, preState, postSlot);
+  }
 
   // if block is trusted don't verify proposer or op signature
   const postState = allForks.stateTransition(
-    preState,
+    middleState,
     job.signedBlock,
     {
       verifyStateRoot: true,


### PR DESCRIPTION
**Motivation**

We want to emit checkpoint events for skipped slots at start of epochs because the cached state contexts may become a justified checkpoint later.

**Description**

When run state transition, check if its an epoch transition and there is skipped slot at start of epoch then run `processSlotsToNearestCheckpoint` to emit checkpoint events
Closes #2504

**Steps to test or reproduce**

Sync Prater, make sure it passes finalized epoch 5

**Testing**
Current I'm syncing Prater, at finalized epoch 30 now.