### PR TITLE
Fix all lint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -80,7 +80,7 @@ module.exports = {
         varsIgnorePattern: "^_",
       },
     ],
-    "@typescript-eslint/ban-ts-comment": "warn",
+    "@typescript-eslint/ban-ts-comment": "error",
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/semi": "error",
     "@typescript-eslint/type-annotation-spacing": "error",
@@ -90,6 +90,7 @@ module.exports = {
     "@typescript-eslint/no-unsafe-call": "error",
     "@typescript-eslint/no-unsafe-member-access": "error",
     "@typescript-eslint/no-unsafe-return": "error",
+    "@typescript-eslint/no-non-null-assertion": "error",
     "import/no-extraneous-dependencies": [
       "error",
       {

--- a/packages/beacon-state-transition/package.json
+++ b/packages/beacon-state-transition/package.json
@@ -36,7 +36,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/bls": "6.0.0",
+    "@chainsafe/bls": "6.0.1",
     "@chainsafe/lodestar-config": "^0.21.0",
     "@chainsafe/lodestar-params": "^0.21.0",
     "@chainsafe/lodestar-types": "^0.21.0",

--- a/packages/beacon-state-transition/src/altair/block/processDeposit.ts
+++ b/packages/beacon-state-transition/src/altair/block/processDeposit.ts
@@ -40,9 +40,6 @@ export function processDeposit(state: CachedBeaconState<altair.BeaconState>, dep
     const signingRoot = computeSigningRoot(config, config.types.phase0.DepositMessage, depositMessage, domain);
     try {
       // Pubkeys must be checked for group + inf. This must be done only once when the validator deposit is processed
-      // > Check group + inf here
-      // !!! UNTIL MERGED https://github.com/ChainSafe/bls/pull/91
-      // @ts-ignore
       const publicKey = bls.PublicKey.fromBytes(pubkey, CoordType.affine, true);
       const signature = bls.Signature.fromBytes(deposit.data.signature.valueOf() as Uint8Array, CoordType.affine, true);
       if (!signature.verify(publicKey, signingRoot)) {

--- a/packages/beacon-state-transition/src/phase0/block/processDeposit.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processDeposit.ts
@@ -40,9 +40,6 @@ export function processDeposit(state: CachedBeaconState<phase0.BeaconState>, dep
     const signingRoot = computeSigningRoot(config, config.types.phase0.DepositMessage, depositMessage, domain);
     try {
       // Pubkeys must be checked for group + inf. This must be done only once when the validator deposit is processed
-      // > Check group + inf here
-      // !!! UNTIL MERGED https://github.com/ChainSafe/bls/pull/91
-      // @ts-ignore
       const publicKey = bls.PublicKey.fromBytes(pubkey, CoordType.affine, true);
       const signature = bls.Signature.fromBytes(deposit.data.signature.valueOf() as Uint8Array, CoordType.affine, true);
       if (!signature.verify(publicKey, signingRoot)) {

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/arrayCreation.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/arrayCreation.test.ts
@@ -1,4 +1,7 @@
+import {profilerLogger} from "../../../utils/logger";
+
 describe("array creation", function () {
+  const logger = profilerLogger();
   const testCases: {id: string; fn: (n: number) => void}[] = [
     {
       id: "Array.from(() => 0)",
@@ -36,7 +39,7 @@ describe("array creation", function () {
       }
       const to = process.hrtime.bigint();
       const diffMs = Number(to - from) / 1e6;
-      console.log(`${id}: ${diffMs / opsRun} ms`);
+      logger.info(`${id}: ${diffMs / opsRun} ms`);
     });
   }
 });

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/bitopts.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/bitopts.test.ts
@@ -1,7 +1,9 @@
 import {FLAG_PREV_SOURCE_ATTESTER, FLAG_UNSLASHED} from "../../../../src/allForks";
+import {profilerLogger} from "../../../utils/logger";
 
 describe("bit opts", function () {
   this.timeout(0);
+  const logger = profilerLogger();
 
   it("Benchmark bitshift", () => {
     const validators = 200_000; // Prater validators
@@ -14,6 +16,6 @@ describe("bit opts", function () {
     }
     const to = process.hrtime.bigint();
     const diffMs = Number(to - from) / 1e6;
-    console.log(`Time spent on OR in getAttestationDeltas: ${diffMs * ((orOptsPerRun * validators) / opsRun)} ms`);
+    logger.info(`Time spent on OR in getAttestationDeltas: ${diffMs * ((orOptsPerRun * validators) / opsRun)} ms`);
   });
 });

--- a/packages/beacon-state-transition/test/perf/phase0/slot/slots.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/slot/slots.test.ts
@@ -20,7 +20,7 @@ describe("Process Slots Performance Test", function () {
     }
     logger.profile(`Process ${numSlot} slots ${maxTry} times`);
     const average = duration / maxTry;
-    console.log(`Processing ${numSlot} slots in ${average}ms`);
+    logger.info(`Processing ${numSlot} slots in ${average}ms`);
     expect(average).lt(expectedValue, `process ${numSlot} takes longer than ${expectedValue} ms`);
   }
 

--- a/packages/beacon-state-transition/test/perf/util.ts
+++ b/packages/beacon-state-transition/test/perf/util.ts
@@ -207,6 +207,7 @@ export async function initBLS(): Promise<void> {
   try {
     await init("blst-native");
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.warn("Performance warning: Using fallback wasm BLS implementation");
     await init("herumi");
   }

--- a/packages/beacon-state-transition/test/setup.ts
+++ b/packages/beacon-state-transition/test/setup.ts
@@ -2,9 +2,5 @@ import {init} from "@chainsafe/bls";
 import {before} from "mocha";
 
 before(async function () {
-  try {
-    await init("blst-native");
-  } catch (e) {
-    console.log(e);
-  }
+  await init("blst-native");
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "6.0.0",
+    "@chainsafe/bls": "6.0.1",
     "@chainsafe/bls-keygen": "^0.3.0",
     "@chainsafe/bls-keystore": "2.0.0",
     "@chainsafe/blst": "^0.2.0",

--- a/packages/cli/src/cmds/account/cmds/validator/recover.ts
+++ b/packages/cli/src/cmds/account/cmds/validator/recover.ts
@@ -17,6 +17,8 @@ import bls from "@chainsafe/bls";
 import {Keystore} from "@chainsafe/bls-keystore";
 import {getBeaconConfigFromArgs} from "../../../../config";
 
+/* eslint-disable no-console */
+
 export type IValidatorRecoverArgs = Pick<IValidatorCreateArgs, "count" | "depositGwei" | "storeWithdrawalKeystore"> & {
   mnemonicInputPath: string;
   firstIndex: number;

--- a/packages/cli/src/cmds/account/cmds/wallet/recover.ts
+++ b/packages/cli/src/cmds/account/cmds/wallet/recover.ts
@@ -5,6 +5,8 @@ import inquirer from "inquirer";
 import {createWalletFromArgsAndMnemonic} from "./utils";
 import {IWalletCreateArgs, walletCreateOptions} from "./create";
 
+/* eslint-disable no-console */
+
 export type IWalletRecoverArgs = IWalletCreateArgs & {
   mnemonicInputPath: string;
 };
@@ -54,7 +56,7 @@ export const recover: ICliCommand<IWalletRecoverArgs, IGlobalArgs, ReturnType> =
 
     const {uuid} = await createWalletFromArgsAndMnemonic(args, mnemonic);
 
-    console.log!(`Your wallet has been successfully recovered.
+    console.log(`Your wallet has been successfully recovered.
 Your wallet's UUID is:
 
 \t${uuid}

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -13,11 +13,12 @@ export interface INetworkArgs {
 
 export function parseArgs(args: INetworkArgs): IBeaconNodeOptions["network"] {
   return {
-    // @ts-ignore
     discv5: {
       enabled: args["network.discv5.enabled"],
       bindAddr: args["network.discv5.bindAddr"],
       bootEnrs: args["network.discv5.bootEnrs"],
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+      enr: undefined as any,
     },
     maxPeers: args["network.maxPeers"],
     targetPeers: args["network.targetPeers"],

--- a/packages/cli/src/util/bls.ts
+++ b/packages/cli/src/util/bls.ts
@@ -4,6 +4,7 @@ export async function initBLS(): Promise<void> {
   try {
     await init("blst-native");
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.warn("Performance warning: Using fallback wasm BLS implementation");
     await init("herumi");
   }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -41,5 +41,9 @@
     "it-all": "^1.0.2",
     "level": "^6.0.1",
     "levelup": "^4.4.0"
+  },
+  "devDependencies": {
+    "@types/level": "^6.0.0",
+    "@types/leveldown": "^4.0.2"
   }
 }

--- a/packages/db/src/controller/level.ts
+++ b/packages/db/src/controller/level.ts
@@ -3,7 +3,6 @@
  */
 
 import {LevelUp} from "levelup";
-//@ts-ignore
 import level from "level";
 import all from "it-all";
 import {ILogger} from "@chainsafe/lodestar-utils";

--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -1,6 +1,5 @@
 import {expect} from "chai";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
-// @ts-ignore
 import leveldown from "leveldown";
 import all from "it-all";
 import {LevelDbController} from "../../../src/controller";

--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -15,8 +15,7 @@ describe("LevelDB controller", () => {
   after(async () => {
     await db.stop();
     await new Promise<void>((resolve, reject) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      leveldown.destroy(dbLocation, (err: Error) => {
+      leveldown.destroy(dbLocation, (err) => {
         if (err) reject(err);
         else resolve();
       });

--- a/packages/light-client-demo/package.json
+++ b/packages/light-client-demo/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "@chainsafe/bls": "6.0.0",
+    "@chainsafe/bls": "6.0.1",
     "@chainsafe/lodestar-config": "^0.21.0",
     "@chainsafe/lodestar-light-client": "^0.21.0",
     "@chainsafe/lodestar-types": "^0.21.0",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -36,7 +36,7 @@
     "test:e2e": "mocha 'test/e2e/**/*.test.ts'"
   },
   "dependencies": {
-    "@chainsafe/bls": "6.0.0",
+    "@chainsafe/bls": "6.0.1",
     "@chainsafe/lodestar-beacon-state-transition": "^0.21.0",
     "@chainsafe/lodestar-config": "^0.21.0",
     "@chainsafe/lodestar-params": "^0.21.0",

--- a/packages/light-client/test/sim/altairChainSimulator.ts
+++ b/packages/light-client/test/sim/altairChainSimulator.ts
@@ -9,7 +9,7 @@ import {ServerOpts} from "../lightclientApiServer";
 import {leveGenesisTime, leveParams} from "../../src/leve";
 import {generateBalances, generateValidators, getInteropSyncCommittee} from "../utils";
 
-/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable @typescript-eslint/naming-convention, no-console */
 
 async function runAltairChainSimulator(): Promise<void> {
   await init("blst-native");

--- a/packages/light-client/test/unit/sync.test.ts
+++ b/packages/light-client/test/unit/sync.test.ts
@@ -14,7 +14,7 @@ import {ServerOpts} from "../lightclientApiServer";
 import {IClock} from "../../src/utils/clock";
 import {generateBalances, generateValidators, getInteropSyncCommittee} from "../utils";
 
-/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable @typescript-eslint/naming-convention, no-console */
 
 describe("Lightclient flow with LightClientUpdater", () => {
   const config = createIBeaconConfig({

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -99,6 +99,7 @@
     "@types/eventsource": "^1.1.5",
     "@types/http-terminator": "^2.0.1",
     "@types/it-all": "^1.0.0",
+    "@types/leveldown": "^4.0.2",
     "@types/prometheus-gc-stats": "^0.6.1",
     "@types/supertest": "^2.0.8",
     "@types/tmp": "^0.2.0",

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -45,7 +45,7 @@
     "test:sim:multiThread": "mocha 'test/sim/multiNodeMultiThread.test.ts'"
   },
   "dependencies": {
-    "@chainsafe/bls": "6.0.0",
+    "@chainsafe/bls": "6.0.1",
     "@chainsafe/discv5": "^0.5.1",
     "@chainsafe/lodestar-beacon-state-transition": "^0.21.0",
     "@chainsafe/lodestar-config": "^0.21.0",

--- a/packages/lodestar/src/chain/attestation/processor.ts
+++ b/packages/lodestar/src/chain/attestation/processor.ts
@@ -13,7 +13,7 @@ import {ChainEvent, ChainEventEmitter} from "../emitter";
 import {IStateRegenerator} from "../regen";
 
 import {processAttestation} from "./process";
-import {AttestationError, AttestationErrorCode} from "../errors";
+import {AttestationError, AttestationErrorCode, AttestationErrorType} from "../errors";
 
 type AttestationProcessorModules = {
   config: IBeaconConfig;
@@ -67,8 +67,8 @@ export function mapAttestationError(e: Error, job: IAttestationJob): Attestation
       (key) => InvalidAttestationCode[key as keyof typeof InvalidAttestationCode] === attError.code
     );
     const code = AttestationErrorCode[codeName as keyof typeof AttestationErrorCode];
-    // @ts-ignore
-    const lodestarErr = new AttestationError({job, ...attError, code});
+    const errType = {...attError, code} as AttestationErrorType;
+    const lodestarErr = new AttestationError({job, ...errType});
     lodestarErr.stack = e.stack;
     return lodestarErr;
   }

--- a/packages/lodestar/src/chain/blocks/pool.ts
+++ b/packages/lodestar/src/chain/blocks/pool.ts
@@ -107,7 +107,11 @@ export class BlockPool {
     let root = toHexString(blockRoot);
 
     while (this.blocks.has(root)) {
-      root = this.blocks.get(root)!.parentRoot;
+      const block = this.blocks.get(root);
+      if (!block) {
+        throw Error(`Unknown root ${root}`);
+      }
+      root = block.parentRoot;
     }
 
     return fromHexString(root);

--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -1,4 +1,4 @@
-import {byteArrayEquals} from "@chainsafe/ssz";
+import {byteArrayEquals, toHexString} from "@chainsafe/ssz";
 import {Gwei, Slot} from "@chainsafe/lodestar-types";
 import {assert} from "@chainsafe/lodestar-utils";
 import {
@@ -94,7 +94,12 @@ export async function runStateTransition(
   let justifiedBalances: Gwei[] = [];
   if (postState.currentJustifiedCheckpoint.epoch > forkChoice.getJustifiedCheckpoint().epoch) {
     const justifiedState = checkpointStateCache.get(postState.currentJustifiedCheckpoint);
-    justifiedBalances = getEffectiveBalances(justifiedState!);
+    if (!justifiedState) {
+      const epoch = postState.currentJustifiedCheckpoint.epoch;
+      const root = toHexString(postState.currentJustifiedCheckpoint.root);
+      throw Error(`State not available for justified checkpoint ${epoch} ${root}`);
+    }
+    justifiedBalances = getEffectiveBalances(justifiedState);
   }
   forkChoice.onBlock(job.signedBlock.message, postState, justifiedBalances);
 

--- a/packages/lodestar/src/chain/bls/multithread/index.ts
+++ b/packages/lodestar/src/chain/bls/multithread/index.ts
@@ -1,6 +1,7 @@
 import {spawn, Worker} from "threads";
 // `threads` library creates self global variable which breaks `timeout-abort-controller` https://github.com/jacobheun/timeout-abort-controller/issues/9
 // Don't add an eslint disable here as a reminder that this has to be fixed eventually
+// eslint-disable-next-line
 // @ts-ignore
 // eslint-disable-next-line
 self = undefined;

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -5,6 +5,7 @@ import {
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
 } from "@chainsafe/lodestar-beacon-state-transition";
+import {toHexString} from "@chainsafe/ssz";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {sleep} from "@chainsafe/lodestar-utils";
 
@@ -179,7 +180,10 @@ export class StateRegenerator implements IStateRegenerator {
     }
 
     for (const b of blocksToReplay.reverse()) {
-      const structBlock = (await this.db.block.get(b.blockRoot))!;
+      const structBlock = await this.db.block.get(b.blockRoot);
+      if (!structBlock) {
+        throw Error(`No block found for ${toHexString(b.blockRoot)}`);
+      }
       const block = this.config.getTypes(b.slot).SignedBeaconBlock.createTreeBackedFromStruct(structBlock);
       if (!block) {
         throw new RegenError({

--- a/packages/lodestar/src/network/metadata/metadata.ts
+++ b/packages/lodestar/src/network/metadata/metadata.ts
@@ -36,7 +36,7 @@ export class MetadataController {
     this._metadata = opts.metadata || this.config.types.altair.Metadata.defaultValue();
   }
 
-  start(enr: ENR): void {
+  start(enr: ENR | undefined): void {
     this.enr = enr;
     if (this.enr) {
       this.enr.set(

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -118,7 +118,7 @@ export class Network implements INetwork {
   async start(): Promise<void> {
     await this.libp2p.start();
     this.reqResp.start();
-    this.metadata.start(this.getEnr()!);
+    this.metadata.start(this.getEnr());
     this.peerManager.start();
     this.gossip.start();
     const multiaddresses = this.libp2p.multiaddrs.map((m) => m.toString()).join(",");

--- a/packages/lodestar/src/network/options.ts
+++ b/packages/lodestar/src/network/options.ts
@@ -5,9 +5,6 @@ export interface INetworkOptions extends PeerManagerOpts {
   localMultiaddrs: string[];
   bootMultiaddrs: string[];
   discv5?: IDiscv5DiscoveryInputOptions;
-  rpcTimeout: number;
-  connectTimeout: number;
-  disconnectTimeout: number;
 }
 
 export const defaultDiscv5Options: IDiscv5DiscoveryInputOptions = {
@@ -24,7 +21,4 @@ export const defaultNetworkOptions: INetworkOptions = {
   localMultiaddrs: ["/ip4/0.0.0.0/tcp/9000"],
   bootMultiaddrs: [],
   discv5: defaultDiscv5Options,
-  rpcTimeout: 5000,
-  connectTimeout: 3000,
-  disconnectTimeout: 3000,
 };

--- a/packages/lodestar/src/network/peers/metastore.ts
+++ b/packages/lodestar/src/network/peers/metastore.ts
@@ -48,6 +48,7 @@ export class Libp2pPeerMetadataStore implements IPeerMetadataStore {
       set: (peer: PeerId, value: T): void => {
         if (value != null) {
           // TODO: fix upstream type (which also contains @ts-ignore)
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           this.metabook.set(peer, key, Buffer.from(type.serialize(value)));
         } else {

--- a/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
+++ b/packages/lodestar/src/tasks/tasks/archiveBlocks.ts
@@ -3,6 +3,7 @@
  */
 
 import {phase0} from "@chainsafe/lodestar-types";
+import {toHexString} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBlockSummary, IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {ILogger} from "@chainsafe/lodestar-utils";
@@ -67,7 +68,10 @@ export class ArchiveBlocksTask implements ITask {
     const canonicalBlockEntries = (
       await Promise.all(
         canonicalSummaries.map(async (summary) => {
-          const blockBuffer = (await this.db.block.getBinary(summary.blockRoot))!;
+          const blockBuffer = await this.db.block.getBinary(summary.blockRoot);
+          if (!blockBuffer) {
+            throw Error(`No block found for root ${toHexString(summary.blockRoot)}`);
+          }
           return {
             key: summary.slot,
             value: blockBuffer,

--- a/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
@@ -2,7 +2,6 @@
 import "mocha";
 import {expect} from "chai";
 import {promisify} from "es6-promisify";
-// @ts-ignore
 import leveldown from "leveldown";
 import {AbortController} from "abort-controller";
 import {sleep} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -27,9 +27,6 @@ const opts: INetworkOptions = {
   maxPeers: 1,
   targetPeers: 1,
   bootMultiaddrs: [],
-  rpcTimeout: 5000,
-  connectTimeout: 5000,
-  disconnectTimeout: 5000,
   localMultiaddrs: [],
 };
 

--- a/packages/lodestar/test/e2e/network/reqresp.test.ts
+++ b/packages/lodestar/test/e2e/network/reqresp.test.ts
@@ -34,9 +34,6 @@ describe("network / ReqResp", function () {
     maxPeers: 1,
     targetPeers: 1,
     bootMultiaddrs: [],
-    rpcTimeout: 5000,
-    connectTimeout: 5000,
-    disconnectTimeout: 5000,
     localMultiaddrs: [],
   };
   const state = generateState();

--- a/packages/lodestar/test/rewiremock.ts
+++ b/packages/lodestar/test/rewiremock.ts
@@ -1,4 +1,4 @@
 // rewiremock.es6.js
-import rewiremock from "rewiremock";
-rewiremock.overrideEntryPoint(module); // this is important. This command is "transfering" this module parent to rewiremock
+import rewiremock, {overrideEntryPoint} from "rewiremock";
+overrideEntryPoint(module); // this is important. This command is "transfering" this module parent to rewiremock
 export {rewiremock};

--- a/packages/lodestar/test/setup.ts
+++ b/packages/lodestar/test/setup.ts
@@ -2,9 +2,5 @@ import {init} from "@chainsafe/bls";
 import {before} from "mocha";
 
 before(async function () {
-  try {
-    await init("blst-native");
-  } catch (e) {
-    console.log(e);
-  }
+  await init("blst-native");
 });

--- a/packages/lodestar/test/unit/api/impl/node/node.test.ts
+++ b/packages/lodestar/test/unit/api/impl/node/node.test.ts
@@ -74,7 +74,7 @@ describe("node api implementation", function () {
     });
 
     it("should get node identity - no enr", async function () {
-      networkStub.getEnr.returns(null!);
+      networkStub.getEnr.returns((null as unknown) as ENR);
       const identity = await api.getNodeIdentity();
       expect(identity.enr).equal("");
     });

--- a/packages/lodestar/test/unit/network/peers/metastore.test.ts
+++ b/packages/lodestar/test/unit/network/peers/metastore.test.ts
@@ -23,6 +23,8 @@ describe("Libp2pPeerMetadataStore", function () {
       getValue: sinon.stub().callsFake(() => {
         return stored;
       }) as SinonStub<[PeerId, string], Buffer>,
+      // TODO: fix upstream type (which also contains @ts-ignore)
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       set: sinon.stub().callsFake(
         (peerId: PeerId, key: string, value: Buffer): ProtoBook => {

--- a/packages/lodestar/test/utils/state.ts
+++ b/packages/lodestar/test/utils/state.ts
@@ -111,9 +111,9 @@ export function generateState(
   // const resultState = state.clone();
 
   for (const key in opts) {
-    // @ts-ignore
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    resultState[key] = opts[key];
+    const newValue = opts[key as keyof TestBeaconState];
+    // eslint-disable-next-line
+    resultState[key as keyof TreeBacked<allForks.BeaconState>] = (newValue as unknown) as any;
   }
   return resultState;
 }

--- a/packages/lodestar/test/utils/stub/beaconDb.ts
+++ b/packages/lodestar/test/utils/stub/beaconDb.ts
@@ -53,7 +53,8 @@ export class StubbedBeaconDb extends BeaconDb {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(sinon: SinonSandbox, config = minimalConfig) {
-    super({config, controller: null!});
+    // eslint-disable-next-line
+    super({config, controller: {} as any});
     this.badBlock = createStubInstance(BadBlockRepository);
     this.block = createStubInstance(BlockRepository);
     this.pendingBlock = createStubInstance(PendingBlockRepository);

--- a/packages/spec-test-runner/package.json
+++ b/packages/spec-test-runner/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@chainsafe/bit-utils": "0.1.6",
-    "@chainsafe/bls": "6.0.0",
+    "@chainsafe/bls": "6.0.1",
     "@chainsafe/lodestar": "^0.21.0",
     "@chainsafe/lodestar-beacon-state-transition": "^0.21.0",
     "@chainsafe/lodestar-config": "^0.21.0",

--- a/packages/spec-test-runner/test/mocha-hooks.ts
+++ b/packages/spec-test-runner/test/mocha-hooks.ts
@@ -8,6 +8,7 @@ export const mochaHooks: RootHookObject = {
         done();
       })
       .catch((e) => {
+        // eslint-disable-next-line no-console
         console.error(e);
         done();
       });

--- a/packages/spec-test-runner/test/spec/bls/aggregate_verify.test.ts
+++ b/packages/spec-test-runner/test/spec/bls/aggregate_verify.test.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import bls from "@chainsafe/bls";
+import {fromHexString} from "@chainsafe/ssz";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util/lib";
 
 import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
@@ -19,18 +20,11 @@ describeDirectorySpecTest<IAggregateSigsVerifyTestCase, boolean>(
   "bls/aggregate_verify/small",
   path.join(SPEC_TEST_LOCATION, "tests/general/phase0/bls/aggregate_verify/small"),
   (testCase) => {
-    const pubkeys = testCase.data.input.pubkeys.map((pubkey) => {
-      return Buffer.from(pubkey.replace("0x", ""), "hex");
-    });
-    const messages = testCase.data.input.messages.map((message) => {
-      return Buffer.from(message.replace("0x", ""), "hex");
-    });
-    return bls.verifyMultiple(pubkeys, messages, Buffer.from(testCase.data.input.signature.replace("0x", ""), "hex"));
+    const {pubkeys, messages, signature} = testCase.data.input;
+    return bls.verifyMultiple(pubkeys.map(fromHexString), messages.map(fromHexString), fromHexString(signature));
   },
   {
-    inputTypes: {
-      data: InputType.YAML,
-    },
+    inputTypes: {data: InputType.YAML},
     getExpected: (testCase) => testCase.data.output,
   }
 );

--- a/packages/spec-test-runner/test/spec/bls/verify.test.ts
+++ b/packages/spec-test-runner/test/spec/bls/verify.test.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util/lib";
 import bls from "@chainsafe/bls";
-
+import {fromHexString} from "@chainsafe/ssz";
 import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
 
 interface IVerifyTestCase {
@@ -16,19 +16,14 @@ interface IVerifyTestCase {
 }
 
 describeDirectorySpecTest<IVerifyTestCase, boolean>(
-  "BLS - verify",
+  "bls/verify/small",
   path.join(SPEC_TEST_LOCATION, "tests/general/phase0/bls/verify/small"),
   (testCase) => {
-    return bls.verify(
-      Buffer.from(testCase.data.input.pubkey.replace("0x", ""), "hex"),
-      Buffer.from(testCase.data.input.message.replace("0x", ""), "hex"),
-      Buffer.from(testCase.data.input.signature.replace("0x", ""), "hex")
-    );
+    const {pubkey, message, signature} = testCase.data.input;
+    return bls.verify(fromHexString(pubkey), fromHexString(message), fromHexString(signature));
   },
   {
-    inputTypes: {
-      data: InputType.YAML,
-    },
+    inputTypes: {data: InputType.YAML},
     getExpected: (testCase) => testCase.data.output,
   }
 );

--- a/packages/spec-test-runner/test/spec/naive/phase0/sanity/slots/sanity_slots_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/naive/phase0/sanity/slots/sanity_slots_mainnet.test.ts
@@ -7,6 +7,8 @@ import {IProcessSlotsTestCase} from "./type";
 import {SPEC_TEST_LOCATION} from "../../../../../utils/specTestCases";
 import {BeaconState} from "@chainsafe/lodestar-types/phase0";
 
+/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+
 describeDirectorySpecTest<IProcessSlotsTestCase, phase0.BeaconState>(
   "slot sanity mainnet",
   join(SPEC_TEST_LOCATION, "/tests/mainnet/phase0/sanity/slots/pyspec_tests"),
@@ -16,10 +18,12 @@ describeDirectorySpecTest<IProcessSlotsTestCase, phase0.BeaconState>(
     return state;
   },
   {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     inputTypes: {
       slots: InputType.YAML,
     },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     sszTypes: {
       pre: config.types.phase0.BeaconState,

--- a/packages/spec-test-runner/test/spec/naive/phase0/sanity/slots/sanity_slots_minimal.test.ts
+++ b/packages/spec-test-runner/test/spec/naive/phase0/sanity/slots/sanity_slots_minimal.test.ts
@@ -7,6 +7,8 @@ import {IProcessSlotsTestCase} from "./type";
 import {SPEC_TEST_LOCATION} from "../../../../../utils/specTestCases";
 import {BeaconState} from "@chainsafe/lodestar-types/phase0";
 
+/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+
 describeDirectorySpecTest<IProcessSlotsTestCase, phase0.BeaconState>(
   "slot sanity minimal",
   join(SPEC_TEST_LOCATION, "/tests/minimal/phase0/sanity/slots/pyspec_tests"),
@@ -16,10 +18,12 @@ describeDirectorySpecTest<IProcessSlotsTestCase, phase0.BeaconState>(
     return state;
   },
   {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     inputTypes: {
       slots: InputType.YAML,
     },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     sszTypes: {
       pre: config.types.phase0.BeaconState,

--- a/packages/spec-test-runner/test/spec/phase0/fork_choice/get_head_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/fork_choice/get_head_mainnet.test.ts
@@ -35,9 +35,11 @@ describeDirectorySpecTest<IForkChoiceTestCase, void>(
         forkchoice.updateTime(Number(step.tick) / SECONDS_PER_SLOT);
       } else if (isAttestation(step)) {
         const attestation = testcase.attestations.get(step.attestation);
-        forkchoice.onAttestation(cachedState.epochCtx.getIndexedAttestation(attestation!));
+        if (!attestation) throw Error(`No attestation ${step.attestation}`);
+        forkchoice.onAttestation(cachedState.epochCtx.getIndexedAttestation(attestation));
       } else if (isBlock(step)) {
-        const signedBlock = testcase.blocks.get(step.block)!;
+        const signedBlock = testcase.blocks.get(step.block);
+        if (!signedBlock) throw Error(`No block ${step.block}`);
         expect(signedBlock).not.to.be.undefined;
         try {
           cachedState = allForks.stateTransition(cachedState, signedBlock, {

--- a/packages/spec-test-runner/test/spec/phase0/genesis/initialization/genesis_initialization_minimal.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/genesis/initialization/genesis_initialization_minimal.test.ts
@@ -29,19 +29,23 @@ describeDirectorySpecTest<IGenesisInitSpecTest, phase0.BeaconState>(
     }
     return initializeBeaconStateFromEth1(
       config,
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       config.types.Root.fromJson(testcase.eth1.eth1BlockHash),
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       Number(testcase.eth1.eth1Timestamp),
       deposits
     ) as phase0.BeaconState;
   },
   {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     inputTypes: {
       meta: InputType.YAML,
       eth1: InputType.YAML,
     },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     sszTypes: {
       eth1_block_hash: config.types.Root,

--- a/packages/spec-test-runner/test/spec/phase0/genesis/validity/genesis_validity_minimal.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/genesis/validity/genesis_validity_minimal.test.ts
@@ -23,6 +23,7 @@ describeDirectorySpecTest<IGenesisValidityTestCase, boolean>(
       is_valid: InputType.YAML,
       genesis: InputType.SSZ_SNAPPY,
     },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     sszTypes: {
       genesis: config.types.phase0.BeaconState,

--- a/packages/spec-test-runner/test/spec/phase0/sanity/slots/sanity_slots_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/sanity/slots/sanity_slots_mainnet.test.ts
@@ -21,6 +21,7 @@ describeDirectorySpecTest<IProcessSlotsTestCase, phase0.BeaconState>(
     return wrappedState;
   },
   {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     inputTypes: {
       pre: {
@@ -33,6 +34,7 @@ describeDirectorySpecTest<IProcessSlotsTestCase, phase0.BeaconState>(
       },
       slots: InputType.YAML,
     },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     sszTypes: {
       pre: config.types.phase0.BeaconState,

--- a/packages/spec-test-runner/test/spec/ssz/util/testCases.ts
+++ b/packages/spec-test-runner/test/spec/ssz/util/testCases.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 import {describeDirectorySpecTest, InputType, safeType} from "@chainsafe/lodestar-spec-test-util";
 import {Bytes32, IBeaconSSZTypes} from "@chainsafe/lodestar-types";
 import {join} from "path";
@@ -7,6 +6,8 @@ import {expect} from "chai";
 import {CompositeType} from "@chainsafe/ssz";
 import {IBaseSSZStaticTestCase} from "../type";
 import {SPEC_TEST_LOCATION} from "../../../utils/specTestCases";
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, no-console */
 
 interface IResult {
   root: Bytes32;
@@ -65,8 +66,10 @@ export function testStatic(type: keyof IBeaconSSZTypes["phase0"]): void {
             // debugger;
           }
           const structural = sszType.deserialize(testCase.serialized_raw);
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           const tree = sszType.createTreeBackedFromBytes(testCase.serialized_raw);
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           const treeFromStructural = sszType.createTreeBackedFromStruct(structural);
           expect(tree.serialize(), "tree serialization != structural serialization").to.deep.equal(

--- a/packages/spec-test-util/src/single.ts
+++ b/packages/spec-test-util/src/single.ts
@@ -3,10 +3,7 @@ import {expect} from "chai";
 import {readdirSync, readFileSync} from "fs";
 import {basename, join, parse} from "path";
 import {Type, CompositeType} from "@chainsafe/ssz";
-// @ts-ignore
 import {uncompress} from "snappyjs";
-declare function uncompress(data: Buffer): Buffer;
-
 import {isDirectory, loadYamlFile} from "./util";
 
 export enum InputType {
@@ -205,7 +202,7 @@ function deserializeInputFile<TestCase, Result>(
       }
     }
     if (sszType) {
-      if ((options.inputTypes![inputName as keyof TestCase]! as ExpandedInputType).treeBacked) {
+      if ((options.inputTypes?.[inputName as keyof TestCase] as ExpandedInputType).treeBacked) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         return (sszType as CompositeType<any>).createTreeBackedFromBytes(data);
       } else {

--- a/packages/spec-test-util/tsconfig.build.json
+++ b/packages/spec-test-util/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.build.json",
   "include": ["src"],
   "compilerOptions": {
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "typeRoots": ["../../node_modules/@types", "./node_modules/@types", "./types"]
   }
 }

--- a/packages/spec-test-util/tsconfig.json
+++ b/packages/spec-test-util/tsconfig.json
@@ -1,4 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {}
+  "compilerOptions": {
+    "typeRoots": ["../../node_modules/@types", "./node_modules/@types", "./types"]
+  }
 }

--- a/packages/spec-test-util/types/snappyjs/index.d.ts
+++ b/packages/spec-test-util/types/snappyjs/index.d.ts
@@ -1,0 +1,4 @@
+declare module "snappyjs" {
+  export function compress<T extends ArrayBuffer | Buffer | Uint8Array>(input: T): T;
+  export function uncompress<T extends ArrayBuffer | Buffer | Uint8Array>(input: T): T;
+}

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -9,12 +9,11 @@ function isObjectObject(val: unknown): boolean {
   return val != null && typeof val === "object" && Array.isArray(val) === false;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isPlainObject(o: any): boolean {
+export function isPlainObject(o: unknown): boolean {
   if (isObjectObject(o) === false) return false;
 
   // If has modified constructor
-  const ctor = o.constructor;
+  const ctor = (o as Record<string, unknown>).constructor;
   if (typeof ctor !== "function") return false;
 
   // If has modified prototype

--- a/packages/utils/src/yaml/index.ts
+++ b/packages/utils/src/yaml/index.ts
@@ -6,7 +6,6 @@ export function loadYaml(yaml: string): Record<string, unknown> {
   return objectToExpectedCase(load(yaml, {schema}));
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function dumpYaml(yaml: any): string {
+export function dumpYaml(yaml: unknown): string {
   return dump(yaml, {schema});
 }

--- a/packages/utils/src/yaml/int.ts
+++ b/packages/utils/src/yaml/int.ts
@@ -160,20 +160,25 @@ export const intType = new Type("tag:yaml.org,2002:int", {
   construct: constructYamlInteger,
   predicate: isInteger,
   instanceOf: BigInt,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   represent: {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     binary: function (obj: number) {
       return obj >= 0 ? "0b" + obj.toString(2) : "-0b" + obj.toString(2).slice(1);
     },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     octal: function (obj: number) {
       return obj >= 0 ? "0" + obj.toString(8) : "-0" + obj.toString(8).slice(1);
     },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     decimal: function (obj: number) {
       return obj.toString(10);
     },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     hexadecimal: function (obj: number) {
       return obj >= 0 ? "0x" + obj.toString(16).toUpperCase() : "-0x" + obj.toString(16).toUpperCase().slice(1);

--- a/packages/utils/src/yaml/schema.ts
+++ b/packages/utils/src/yaml/schema.ts
@@ -1,10 +1,14 @@
 import {Schema} from "js-yaml";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import failsafe from "js-yaml/lib/js-yaml/schema/failsafe";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import nullType from "js-yaml/lib/js-yaml/type/null";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import boolType from "js-yaml/lib/js-yaml/type/bool";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import floatType from "js-yaml/lib/js-yaml/type/float";
 import {intType} from "./int";

--- a/packages/utils/test/unit/json.test.ts
+++ b/packages/utils/test/unit/json.test.ts
@@ -5,8 +5,7 @@ import {LodestarError, toJson, toString, CIRCULAR_REFERENCE_TAG} from "../../src
 
 describe("Json helper", () => {
   const circularReference = {};
-  // @ts-ignore
-  circularReference.myself = circularReference;
+  (circularReference as {myself: unknown}).myself = circularReference;
 
   describe("toJson", () => {
     interface ITestCase {

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -44,7 +44,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "6.0.0",
+    "@chainsafe/bls": "6.0.1",
     "@chainsafe/lodestar-beacon-state-transition": "^0.21.0",
     "@chainsafe/lodestar-config": "^0.21.0",
     "@chainsafe/lodestar-db": "^0.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2001,10 +2001,10 @@
     ethereum-cryptography "^0.1.3"
     uuid "^3.3.3"
 
-"@chainsafe/bls@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/bls/-/bls-6.0.0.tgz#f0622b1b1acca63dc079e5d9acc32790381e1ae2"
-  integrity sha512-jySH6rU06NaH+9JwuMmY9LFEgkCBxoDgeqfRaHj1NzzWxlfKXXBP72OpDJolapQLQ774bQLrvUYnr6RDn9Fh4A==
+"@chainsafe/bls@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/bls/-/bls-6.0.1.tgz#3771182db88e28a6d305c0f4285668d36b5d5da3"
+  integrity sha512-bOyQsjv4H79S7CL4cNX71wY+8lSPcRqou0yNTteMoTCpIOFScFyWqiuUfoBcigHlADbNzoE9SA9pyn02zOSQNw==
   dependencies:
     "@chainsafe/bls-keygen" "^0.3.0"
     bls-eth-wasm "^0.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3583,6 +3583,14 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
   integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
 
+"@types/encoding-down@*":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/encoding-down/-/encoding-down-5.0.0.tgz#0b5b90b93ac3aa75148f19508044e7bd36463557"
+  integrity sha512-G0MlS/+/U2RIQLcSEhhAcoMrXw3hXUCFSKbhbeEljoKMra2kq+NPX6tfOveSWQLX2hJXBo+YrvKgAGe+tFL1Aw==
+  dependencies:
+    "@types/abstract-leveldown" "*"
+    "@types/level-codec" "*"
+
 "@types/err-code@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/err-code/-/err-code-2.0.0.tgz#42550e9e7a487e6c64342799e803f33d4d0f985c"
@@ -3719,6 +3727,28 @@
   resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.1.tgz#e45a45324fca9dab716ab1230ee249c9fb52cfa7"
   integrity sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==
   dependencies:
+    "@types/node" "*"
+
+"@types/level-codec@*":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@types/level-codec/-/level-codec-9.0.0.tgz#9f1dc7f9017b6fba094a450602ec0b91cc384059"
+  integrity sha512-SWYkVJylo1dqblkhrr7UtmsQh4wdZA9bV1y3QJSywMPSqGfW0p1w37N1EayZtKbg1dGReIIQEEOtxk4wZvGrWQ==
+
+"@types/level@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@types/level/-/level-6.0.0.tgz#0bc0aaf1106598e1774e1dc5b69f0d58885d9d34"
+  integrity sha512-NjaUpukKfCvnV4Wk0jUaodFi2/66HxgpYghc2aV8iP+zk2NMt/9ps1eVlifqOU/+eLzMlDIY69NWkbPaAstukQ==
+  dependencies:
+    "@types/abstract-leveldown" "*"
+    "@types/encoding-down" "*"
+    "@types/levelup" "*"
+
+"@types/leveldown@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/leveldown/-/leveldown-4.0.2.tgz#edb44a33668ae58656721bb1852345e6a2f2e42a"
+  integrity sha512-VW6QbUnPb5yLbUBcXEh93lFNphyxkBul7Ae41OCgROd76WfLM3qzAbuzErx1LtsTqwcNlbavTr9rWXHCiGVF8A==
+  dependencies:
+    "@types/abstract-leveldown" "*"
     "@types/node" "*"
 
 "@types/levelup@*":


### PR DESCRIPTION
**Motivation**

We had some lint warning for months now, potentially making issues like https://github.com/ChainSafe/lodestar/issues/2504 harder to track.

To all Lodestar contributors please we must keep an eye on lint warnings as target to have 0 of them.

**Description**

- Fixes all lint warnings in the Lodestar monorepo.
- Increases the level to error for:
  - `@typescript-eslint/no-non-null-assertion`
  - `@typescript-eslint/ban-ts-comment`