### PR TITLE
Split attnets and syncnets services

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,10 @@ jobs:
         run: yarn build
         if: steps.cache-deps.outputs.cache-hit == 'true'
       # </common-build>
-      - name: Lint
-        run: yarn lint
       - name: Check Types
         run: yarn run check-types
+      - name: Lint
+        run: yarn lint
       - name: Unit tests
         run: yarn test:unit
       - name: Upload coverage data

--- a/packages/lodestar/src/api/impl/validator/validator.ts
+++ b/packages/lodestar/src/api/impl/validator/validator.ts
@@ -33,7 +33,7 @@ import {ApiError} from "../errors";
 import {ApiNamespace, IApiModules} from "../interface";
 import {IValidatorApi} from "./interface";
 import {validateSyncCommitteeGossipContributionAndProof} from "../../../chain/validation/syncCommitteeContributionAndProof";
-import {CommitteeSubscription} from "../../../network/subnetsService";
+import {CommitteeSubscription} from "../../../network/subnets";
 import {getSyncComitteeValidatorIndexMap} from "./utils";
 
 /**

--- a/packages/lodestar/src/network/gossip/handler.ts
+++ b/packages/lodestar/src/network/gossip/handler.ts
@@ -9,7 +9,7 @@ import {ChainEvent, IBeaconChain} from "../../chain";
 import {IBeaconDb} from "../../db";
 import {GossipHandlerFn, GossipTopic, GossipType} from ".";
 import {Eth2Gossipsub} from "./gossipsub";
-import {ISubnetsService} from "../subnetsService";
+import {IAttnetsService} from "../subnets";
 
 /**
  * Registers handlers to all possible gossip topics and forks.
@@ -23,7 +23,7 @@ export class GossipHandler {
     private readonly config: IBeaconConfig,
     private readonly chain: IBeaconChain,
     private readonly gossip: Eth2Gossipsub,
-    private readonly attnetsService: ISubnetsService,
+    private readonly attnetsService: IAttnetsService,
     private readonly db: IBeaconDb,
     private readonly logger: ILogger
   ) {

--- a/packages/lodestar/src/network/interface.ts
+++ b/packages/lodestar/src/network/interface.ts
@@ -10,7 +10,7 @@ import {Eth2Gossipsub} from "./gossip";
 import {MetadataController} from "./metadata";
 import {IPeerRpcScoreStore, IPeerMetadataStore} from "./peers";
 import {IReqResp} from "./reqresp";
-import {ISubnetsService, CommitteeSubscription} from "./subnetsService";
+import {ISubnetsService, CommitteeSubscription} from "./subnets";
 
 export type PeerSearchOptions = {
   supportsProtocols?: string[];

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -22,7 +22,7 @@ import {IBeaconDb} from "../db";
 import {createTopicValidatorFnMap, Eth2Gossipsub} from "./gossip";
 import {IReqRespHandler} from "./reqresp/handlers";
 import {INetworkEventBus, NetworkEventBus} from "./events";
-import {ISubnetsService, getAttnetsService, getSyncnetsService, CommitteeSubscription} from "./subnetsService";
+import {AttnetsService, SyncnetsService, CommitteeSubscription} from "./subnets";
 import {GossipHandler} from "./gossip/handler";
 
 interface INetworkModules {
@@ -39,8 +39,8 @@ interface INetworkModules {
 export class Network implements INetwork {
   events: INetworkEventBus;
   reqResp: IReqResp;
-  attnetsService: ISubnetsService;
-  syncnetsService: ISubnetsService;
+  attnetsService: AttnetsService;
+  syncnetsService: SyncnetsService;
   gossip: Eth2Gossipsub;
   metadata: MetadataController;
   peerMetadata: IPeerMetadataStore;
@@ -88,8 +88,8 @@ export class Network implements INetwork {
       metrics,
     });
 
-    this.attnetsService = getAttnetsService({...modules, gossip: this.gossip, metadata: this.metadata});
-    this.syncnetsService = getSyncnetsService({...modules, gossip: this.gossip, metadata: this.metadata});
+    this.attnetsService = new AttnetsService(config, chain, this.gossip, metadata, logger);
+    this.syncnetsService = new SyncnetsService(config, chain, this.gossip, metadata, logger);
     this.peerManager = new PeerManager(
       {
         libp2p,

--- a/packages/lodestar/src/network/peers/peerManager.ts
+++ b/packages/lodestar/src/network/peers/peerManager.ts
@@ -8,6 +8,8 @@ import {GoodByeReasonCode, GOODBYE_KNOWN_CODES, Libp2pEvent} from "../../constan
 import {IMetrics} from "../../metrics";
 import {NetworkEvent, INetworkEventBus} from "../events";
 import {IReqResp, ReqRespMethod, RequestTypedContainer} from "../reqresp";
+import {prettyPrintPeerId} from "../util";
+import {ISubnetsService} from "../subnets";
 import {Libp2pPeerMetadataStore} from "./metastore";
 import {PeerDiscovery} from "./discover";
 import {IPeerRpcScoreStore, ScoreState} from "./score";
@@ -19,8 +21,6 @@ import {
   prioritizePeers,
   IrrelevantPeerError,
 } from "./utils";
-import {prettyPrintPeerId} from "../util";
-import {ISubnetsService} from "../subnetsService";
 
 /** heartbeat performs regular updates such as updating reputations and performing discovery requests */
 const HEARTBEAT_INTERVAL_MS = 30 * 1000;

--- a/packages/lodestar/src/network/subnets/index.ts
+++ b/packages/lodestar/src/network/subnets/index.ts
@@ -1,0 +1,3 @@
+export * from "./interface";
+export * from "./attnetsService";
+export * from "./syncnetsService";

--- a/packages/lodestar/src/network/subnets/interface.ts
+++ b/packages/lodestar/src/network/subnets/interface.ts
@@ -1,0 +1,20 @@
+import {Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
+
+/** Generic CommitteeSubscription for both beacon attnets subs and syncnets subs */
+export type CommitteeSubscription = {
+  validatorIndex: ValidatorIndex;
+  subnet: number;
+  slot: Slot;
+  isAggregator: boolean;
+};
+
+export interface ISubnetsService {
+  start(): void;
+  stop(): void;
+  addCommitteeSubscriptions(subscriptions: CommitteeSubscription[]): void;
+  getActiveSubnets(): number[];
+}
+
+export interface IAttnetsService extends ISubnetsService {
+  shouldProcess(subnet: number, slot: Slot): boolean;
+}

--- a/packages/lodestar/src/network/subnets/syncnetsService.ts
+++ b/packages/lodestar/src/network/subnets/syncnetsService.ts
@@ -1,0 +1,139 @@
+import {computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition/src/util/epoch";
+import {ForkName, IBeaconConfig} from "@chainsafe/lodestar-config";
+import {SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
+import {Epoch} from "@chainsafe/lodestar-types";
+import {ILogger} from "@chainsafe/lodestar-utils";
+import {ChainEvent, IBeaconChain} from "../../chain";
+import {getActiveForks, runForkTransitionHooks} from "../forks";
+import {Eth2Gossipsub, GossipType} from "../gossip";
+import {MetadataController} from "../metadata";
+import {SubnetMap} from "../peers/utils";
+import {CommitteeSubscription, ISubnetsService} from "./interface";
+
+const gossipType = GossipType.sync_committee;
+
+/**
+ * Manage sync committee subnets. Sync committees are long (~27h) so there aren't random long-lived subscriptions
+ */
+export class SyncnetsService implements ISubnetsService {
+  /**
+   * All currently subscribed subnets. Syncnets do not have additional long-lived
+   * random subscriptions since the committees are already active for long periods of time.
+   * Also, the node will aggregate through the entire period to simplify the validator logic.
+   * So `subscriptionsCommittee` represents subnets to find peers and aggregate data.
+   * This class will tell gossip to subscribe and un-subscribe.
+   * If a value exists for `SubscriptionId` it means that gossip subscription is active in network.gossip
+   */
+  private subscriptionsCommittee = new SubnetMap();
+
+  constructor(
+    private readonly config: IBeaconConfig,
+    private readonly chain: IBeaconChain,
+    private readonly gossip: Eth2Gossipsub,
+    private readonly metadata: MetadataController,
+    private readonly logger: ILogger
+  ) {}
+
+  start(): void {
+    this.chain.emitter.on(ChainEvent.clockEpoch, this.onEpoch);
+  }
+
+  stop(): void {
+    this.chain.emitter.off(ChainEvent.clockEpoch, this.onEpoch);
+  }
+
+  /**
+   * Get all active subnets for the hearbeat.
+   */
+  getActiveSubnets(): number[] {
+    const currentSlot = this.chain.clock.currentSlot;
+    return this.subscriptionsCommittee.getActive(currentSlot);
+  }
+
+  /**
+   * Called from the API when validator is a part of a committee.
+   */
+  addCommitteeSubscriptions(subscriptions: CommitteeSubscription[]): void {
+    // Trigger gossip subscription first, in batch
+    if (subscriptions.length > 0) {
+      this.subscribeToSubnets(subscriptions.map((sub) => sub.subnet));
+    }
+
+    // Then, register the subscriptions
+    for (const {subnet, slot} of subscriptions) {
+      this.subscriptionsCommittee.request({subnet, toSlot: slot});
+    }
+
+    // For syncnets regular subscriptions are persisted in the ENR
+    this.updateMetadata();
+  }
+
+  /**
+   * Run per epoch, clean-up operations that are not urgent
+   */
+  private onEpoch = (epoch: Epoch): void => {
+    try {
+      const slot = computeStartSlotAtEpoch(this.config, epoch);
+      // Unsubscribe to a committee subnet from subscriptionsCommittee.
+      this.unsubscribeSubnets(this.subscriptionsCommittee.getExpired(slot));
+
+      // Fork transition for altair -> nextFork
+      runForkTransitionHooks(this.config, epoch, {
+        beforeForkTransition: (nextFork) => {
+          if (nextFork === ForkName.altair) return;
+          this.logger.info("Suscribing to random attnets to next fork", {nextFork});
+          // ONLY ONCE: Two epoch before the fork, re-subscribe all existing random subscriptions to the new fork
+          for (const subnet of this.subscriptionsCommittee.getAll()) {
+            this.gossip.subscribeTopic({type: gossipType, fork: nextFork, subnet});
+          }
+        },
+        afterForkTransition: (prevFork) => {
+          if (prevFork === ForkName.phase0) return;
+          this.logger.info("Unsuscribing to random attnets from prev fork", {prevFork});
+          // ONLY ONCE: Two epochs after the fork, un-subscribe all subnets from the old fork
+          for (let subnet = 0; subnet < SYNC_COMMITTEE_SUBNET_COUNT; subnet++) {
+            this.gossip.unsubscribeTopic({type: gossipType, fork: prevFork, subnet});
+          }
+        },
+      });
+    } catch (e) {
+      this.logger.error("Error on SyncnetsService.onEpoch", {epoch}, e);
+    }
+  };
+
+  /** Update ENR */
+  private updateMetadata(): void {
+    const subnets = this.config.types.altair.SyncSubnets.defaultValue();
+    for (const subnet of this.subscriptionsCommittee.getAll()) {
+      subnets[subnet] = true;
+    }
+
+    // Only update metadata if necessary, setting `metadata.[key]` triggers a write to disk
+    if (!this.config.types.altair.SyncSubnets.equals(subnets, this.metadata.syncnets)) {
+      this.metadata.syncnets = subnets;
+    }
+  }
+
+  /** Tigger a gossip subcription only if not already subscribed */
+  private subscribeToSubnets(subnets: number[]): void {
+    const forks = getActiveForks(this.config, this.chain.clock.currentEpoch);
+    for (const subnet of subnets) {
+      if (!this.subscriptionsCommittee.has(subnet)) {
+        for (const fork of forks) {
+          this.gossip.subscribeTopic({type: gossipType, fork, subnet});
+        }
+      }
+    }
+  }
+
+  /** Trigger a gossip un-subscrition only if no-one is still subscribed */
+  private unsubscribeSubnets(subnets: number[]): void {
+    const forks = getActiveForks(this.config, this.chain.clock.currentEpoch);
+    for (const subnet of subnets) {
+      // No need to check if active in subscriptionsCommittee since we only have a single SubnetMap
+      for (const fork of forks) {
+        this.gossip.unsubscribeTopic({type: gossipType, fork, subnet});
+      }
+    }
+  }
+}

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -19,7 +19,7 @@ import {generateState} from "../../utils/state";
 import {StubbedBeaconDb} from "../../utils/stub";
 import {connect, disconnect, onPeerConnect, onPeerDisconnect} from "../../utils/network";
 import {testLogger} from "../../utils/logger";
-import {CommitteeSubscription} from "../../../src/network/subnetsService";
+import {CommitteeSubscription} from "../../../src/network/subnets";
 
 const multiaddr = "/ip4/127.0.0.1/tcp/0";
 

--- a/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
@@ -16,7 +16,7 @@ import {sleep} from "@chainsafe/lodestar-utils";
 import {waitForEvent} from "../../../utils/events/resolver";
 import {testLogger} from "../../../utils/logger";
 import {getValidPeerId} from "../../../utils/peer";
-import {ISubnetsService} from "../../../../src/network/subnetsService";
+import {IAttnetsService} from "../../../../src/network/subnets";
 
 const logger = testLogger();
 
@@ -60,7 +60,7 @@ describe("network / peers / PeerManager", function () {
     const peerMetadata = new Libp2pPeerMetadataStore(config, libp2p.peerStore.metadataBook);
     const peerRpcScores = new PeerRpcScoreStore(peerMetadata);
     const networkEventBus = new NetworkEventBus();
-    const mockSubnetsService: ISubnetsService = {
+    const mockSubnetsService: IAttnetsService = {
       getActiveSubnets: () => [],
       shouldProcess: () => true,
       // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/packages/lodestar/test/unit/network/gossip/handler.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/handler.test.ts
@@ -21,11 +21,11 @@ import {createNode} from "../../../utils/network";
 import {ForkDigestContext} from "../../../../src/util/forkDigestContext";
 import {generateBlockSummary} from "../../../utils/block";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {ISubnetsService} from "../../../../src/network/subnetsService";
+import {IAttnetsService} from "../../../../src/network/subnets";
 
 describe("gossip handler", function () {
   const logger = testLogger();
-  const attnetsService = {} as ISubnetsService;
+  const attnetsService = {} as IAttnetsService;
   let forkDigestContext: SinonStubbedInstance<ForkDigestContext>;
   let chainStub: SinonStubbedInstance<IBeaconChain>;
   let networkStub: SinonStubbedInstance<INetwork>;


### PR DESCRIPTION
**Motivation**

Currently the class managing attnets and syncnets was the same. However that implementation was not following the spec since:
- syncnets do not need long lived random subscriptions
- syncnets persist the subscriptions requested by the validators to the ENR instead of the long lived random subscriptions

**Description**

Split into two classes `SyncnetsService` and `AttnetsService`. The design is similar but the functionality is customized to each requirements.