### PR TITLE
Update ssz to v0.8.5

### DIFF
--- a/packages/beacon-state-transition/package.json
+++ b/packages/beacon-state-transition/package.json
@@ -43,7 +43,7 @@
     "@chainsafe/lodestar-utils": "^0.21.0",
     "@chainsafe/persistent-merkle-tree": "^0.3.2",
     "@chainsafe/persistent-ts": "^0.19.0",
-    "@chainsafe/ssz": "^0.8.4",
+    "@chainsafe/ssz": "^0.8.5",
     "bigint-buffer": "^1.1.5",
     "buffer-xor": "^2.0.2"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,7 +61,7 @@
     "@chainsafe/lodestar-types": "^0.21.0",
     "@chainsafe/lodestar-utils": "^0.21.0",
     "@chainsafe/lodestar-validator": "^0.21.0",
-    "@chainsafe/ssz": "^0.8.4",
+    "@chainsafe/ssz": "^0.8.5",
     "@types/lockfile": "^1.0.1",
     "abort-controller": "^3.0.0",
     "bip39": "^3.0.2",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@chainsafe/lodestar-config": "^0.21.0",
     "@chainsafe/lodestar-utils": "^0.21.0",
-    "@chainsafe/ssz": "^0.8.4",
+    "@chainsafe/ssz": "^0.8.5",
     "it-all": "^1.0.2",
     "level": "^6.0.1",
     "levelup": "^4.4.0"

--- a/packages/fork-choice/package.json
+++ b/packages/fork-choice/package.json
@@ -41,7 +41,7 @@
     "@chainsafe/lodestar-config": "^0.21.0",
     "@chainsafe/lodestar-types": "^0.21.0",
     "@chainsafe/lodestar-utils": "^0.21.0",
-    "@chainsafe/ssz": "^0.8.4"
+    "@chainsafe/ssz": "^0.8.5"
   },
   "keywords": [
     "ethereum",

--- a/packages/light-client-demo/package.json
+++ b/packages/light-client-demo/package.json
@@ -20,7 +20,7 @@
     "@chainsafe/lodestar-types": "^0.21.0",
     "@chainsafe/lodestar-utils": "^0.21.0",
     "@chainsafe/persistent-merkle-tree": "^0.3.2",
-    "@chainsafe/ssz": "^0.8.4",
+    "@chainsafe/ssz": "^0.8.5",
     "@types/debounce": "^1.2.0",
     "@typescript-eslint/eslint-plugin": "^2.32.0",
     "@typescript-eslint/parser": "^2.32.0",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -43,7 +43,7 @@
     "@chainsafe/lodestar-types": "^0.21.0",
     "@chainsafe/lodestar-utils": "^0.21.0",
     "@chainsafe/persistent-merkle-tree": "^0.3.2",
-    "@chainsafe/ssz": "^0.8.2",
+    "@chainsafe/ssz": "^0.8.5",
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.1.4",
     "mitt": "^2.1.0"

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -57,7 +57,7 @@
     "@chainsafe/lodestar-validator": "^0.21.0",
     "@chainsafe/persistent-merkle-tree": "^0.3.2",
     "@chainsafe/snappy-stream": "3.0.5",
-    "@chainsafe/ssz": "^0.8.4",
+    "@chainsafe/ssz": "^0.8.5",
     "@ethersproject/abi": "^5.0.0",
     "@types/datastore-level": "^1.1.1",
     "abort-controller": "^3.0.0",

--- a/packages/params/package.json
+++ b/packages/params/package.json
@@ -45,7 +45,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/ssz": "^0.8.4",
+    "@chainsafe/ssz": "^0.8.5",
     "@types/js-yaml": "^3.12.2",
     "axios": "^0.21.0",
     "js-yaml": "^3.13.1"

--- a/packages/spec-test-runner/package.json
+++ b/packages/spec-test-runner/package.json
@@ -42,7 +42,7 @@
     "@chainsafe/lodestar-types": "^0.21.0",
     "@chainsafe/lodestar-utils": "^0.21.0",
     "@chainsafe/lodestar-validator": "^0.21.0",
-    "@chainsafe/ssz": "^0.8.4",
+    "@chainsafe/ssz": "^0.8.5",
     "@types/yargs": "^13.0.2"
   },
   "keywords": [

--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "@chainsafe/lodestar-utils": "^0.21.0",
-    "@chainsafe/ssz": "^0.8.4",
+    "@chainsafe/ssz": "^0.8.5",
     "axios": "^0.21.0",
     "chai": "^4.2.0",
     "mocha": "^8.1.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -36,7 +36,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/lodestar-params": "^0.21.0",
-    "@chainsafe/ssz": "^0.8.4"
+    "@chainsafe/ssz": "^0.8.5"
   },
   "keywords": [
     "ethereum",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -36,7 +36,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/ssz": "^0.8.4",
+    "@chainsafe/ssz": "^0.8.5",
     "abort-controller": "^3.0.0",
     "any-signal": "2.1.1",
     "bigint-buffer": "^1.1.5",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -51,7 +51,7 @@
     "@chainsafe/lodestar-params": "^0.21.0",
     "@chainsafe/lodestar-types": "^0.21.0",
     "@chainsafe/lodestar-utils": "^0.21.0",
-    "@chainsafe/ssz": "^0.8.4",
+    "@chainsafe/ssz": "^0.8.5",
     "abort-controller": "^3.0.0",
     "axios": "^0.21.1",
     "axios-mock-adapter": "^1.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2067,10 +2067,10 @@
     fast-crc32c "^1.0.1"
     snappy "6.3.4"
 
-"@chainsafe/ssz@^0.8.2", "@chainsafe/ssz@^0.8.4":
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.8.4.tgz#498c8f063c81f4156f3738af60102875e53ee35b"
-  integrity sha512-IISbZQjf5QiFcQ+yBzStwANaBR39Dq9RCp46RJdCDrn2UqS8izBjesz3M5CKpnwiD7n+yDx7IYdIALfqzbxyGQ==
+"@chainsafe/ssz@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.8.5.tgz#9040369fc24788e352d319fa0b9533dc1403c11d"
+  integrity sha512-Zmn9fDnhkg8ZM9muusn4SdS25S3xca0jnaYR2SeQ4AS+XFbwHlsSLVahK+lbnyT0HYOc1vLLYkufYwdd7TzclQ==
   dependencies:
     "@chainsafe/as-sha256" "^0.2.2"
     "@chainsafe/persistent-merkle-tree" "^0.3.2"


### PR DESCRIPTION
**Motivation**

This should give us the ability to request proofs for entire state subtrees / composite types. Will be used in the light client demo.

**Description**

Update ssz to v0.8.5