### PR TITLE
Allow disabling BLS multi-thread pool

### DIFF
--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Simulation single thread multi node test
         run: yarn test:sim:singleThreadMultiNode
         working-directory: packages/lodestar
-      - name: Simulation multi thread multi node test
+      - name: Simulation multi thread multi node test phase0
         run: yarn test:sim:multiThread
         working-directory: packages/lodestar
         env: {RUN_ONLY_SIM_TEST: phase0}

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -15,7 +15,7 @@ export const options: ICliCommandOptions<IChainArgs> = {
   "chain.useSingleThreadVerifier": {
     hidden: true,
     type: "boolean",
-    description: "Disable spawining worker threads for BLS verification, use single thread implementation.",
+    description: "Disable spawning worker threads for BLS verification, use single thread implementation.",
     defaultDescription: String(defaultOptions.chain.useSingleThreadVerifier),
     group: "chain",
   },

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -1,0 +1,22 @@
+import {defaultOptions, IBeaconNodeOptions} from "@chainsafe/lodestar";
+import {ICliCommandOptions} from "../../util";
+
+export interface IChainArgs {
+  "chain.useSingleThreadVerifier": boolean;
+}
+
+export function parseArgs(args: IChainArgs): IBeaconNodeOptions["chain"] {
+  return {
+    useSingleThreadVerifier: args["chain.useSingleThreadVerifier"],
+  };
+}
+
+export const options: ICliCommandOptions<IChainArgs> = {
+  "chain.useSingleThreadVerifier": {
+    hidden: true,
+    type: "boolean",
+    description: "Disable spawining worker threads for BLS verification, use single thread implementation.",
+    defaultDescription: String(defaultOptions.chain.useSingleThreadVerifier),
+    group: "chain",
+  },
+};

--- a/packages/cli/src/options/beaconNodeOptions/index.ts
+++ b/packages/cli/src/options/beaconNodeOptions/index.ts
@@ -21,7 +21,7 @@ export function parseBeaconNodeArgs(args: IBeaconNodeArgs): RecursivePartial<IBe
   // Remove undefined values to allow deepmerge to inject default values downstream
   return removeUndefinedRecursive({
     api: api.parseArgs(args),
-    chain: {},
+    chain: chain.parseArgs(args),
     // db: {},
     eth1: eth1.parseArgs(args),
     logger: logger.parseArgs(args),

--- a/packages/cli/src/options/beaconNodeOptions/index.ts
+++ b/packages/cli/src/options/beaconNodeOptions/index.ts
@@ -2,6 +2,7 @@ import {IBeaconNodeOptions} from "@chainsafe/lodestar";
 import {RecursivePartial} from "@chainsafe/lodestar-utils";
 import {removeUndefinedRecursive} from "../../util";
 import * as api from "./api";
+import * as chain from "./chain";
 import * as eth1 from "./eth1";
 import * as logger from "./logger";
 import * as metrics from "./metrics";
@@ -9,6 +10,7 @@ import * as network from "./network";
 import * as sync from "./sync";
 
 export type IBeaconNodeArgs = api.IApiArgs &
+  chain.IChainArgs &
   eth1.IEth1Args &
   logger.ILoggerArgs &
   metrics.IMetricsArgs &
@@ -19,7 +21,7 @@ export function parseBeaconNodeArgs(args: IBeaconNodeArgs): RecursivePartial<IBe
   // Remove undefined values to allow deepmerge to inject default values downstream
   return removeUndefinedRecursive({
     api: api.parseArgs(args),
-    // chain: {},
+    chain: {},
     // db: {},
     eth1: eth1.parseArgs(args),
     logger: logger.parseArgs(args),
@@ -31,6 +33,7 @@ export function parseBeaconNodeArgs(args: IBeaconNodeArgs): RecursivePartial<IBe
 
 export const beaconNodeOptions = {
   ...api.options,
+  ...chain.options,
   ...eth1.options,
   ...logger.options,
   ...metrics.options,

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -13,6 +13,8 @@ describe("options / beaconNodeOptions", () => {
       "api.rest.host": "127.0.0.1",
       "api.rest.port": 7654,
 
+      "chain.useSingleThreadVerifier": true,
+
       "eth1.enabled": true,
       "eth1.providerUrl": "http://my.node:8545",
       "eth1.depositContractDeployBlock": 1625314,
@@ -46,6 +48,9 @@ describe("options / beaconNodeOptions", () => {
           host: "127.0.0.1",
           port: 7654,
         },
+      },
+      chain: {
+        useSingleThreadVerifier: true,
       },
       eth1: {
         enabled: true,

--- a/packages/cli/test/unit/options/paramsOptions.test.ts
+++ b/packages/cli/test/unit/options/paramsOptions.test.ts
@@ -3,7 +3,7 @@ import {parseBeaconParamsArgs} from "../../../src/options/paramsOptions";
 import {IBeaconParamsUnparsed} from "../../../src/config/types";
 
 describe("options / paramsOptions", () => {
-  it("Should parse BeaconNodeArgs", () => {
+  it("Should parse BeaconParams", () => {
     // Cast to match the expected fully defined type
     const beaconParamsArgs = {
       "params.GENESIS_FORK_VERSION": "0x00000001",

--- a/packages/lodestar/src/chain/bls/index.ts
+++ b/packages/lodestar/src/chain/bls/index.ts
@@ -1,15 +1,23 @@
 import {bls, PublicKey} from "@chainsafe/bls";
 import {ISignatureSet, SignatureSetType} from "@chainsafe/lodestar-beacon-state-transition";
+import {IBlsVerifierImpl} from "./interface";
 import {BlsMultiThreadWorkerPool, BlsMultiThreadWorkerPoolModules} from "./multithread";
+import {BlsSingleThreadVerifier} from "./singleThread";
+
+export type BlsVerifierOpts = {
+  useSingleThreadVerifier?: boolean;
+};
 
 export interface IBlsVerifier {
   verifySignatureSets(signatureSets: ISignatureSet[]): Promise<boolean>;
 }
 
 export class BlsVerifier implements IBlsVerifier {
-  private readonly pool: BlsMultiThreadWorkerPool;
-  constructor(modules: BlsMultiThreadWorkerPoolModules) {
-    this.pool = new BlsMultiThreadWorkerPool(bls.implementation, modules);
+  private readonly pool: IBlsVerifierImpl;
+  constructor(modules: BlsMultiThreadWorkerPoolModules, opts: BlsVerifierOpts) {
+    this.pool = opts.useSingleThreadVerifier
+      ? new BlsSingleThreadVerifier()
+      : new BlsMultiThreadWorkerPool(bls.implementation, modules);
   }
 
   /**

--- a/packages/lodestar/src/chain/bls/interface.ts
+++ b/packages/lodestar/src/chain/bls/interface.ts
@@ -1,0 +1,8 @@
+import {PublicKey} from "@chainsafe/bls";
+
+export interface IBlsVerifierImpl {
+  verifySignatureSets(
+    sets: {publicKey: PublicKey; message: Uint8Array; signature: Uint8Array}[],
+    validateSignature: boolean
+  ): Promise<boolean>;
+}

--- a/packages/lodestar/src/chain/bls/maybeBatch.ts
+++ b/packages/lodestar/src/chain/bls/maybeBatch.ts
@@ -1,0 +1,36 @@
+import {bls, CoordType, PublicKey} from "@chainsafe/bls";
+
+const MIN_SET_COUNT_TO_BATCH = 2;
+
+type SignatureSetDeserialized = {
+  publicKey: PublicKey;
+  message: Uint8Array;
+  signature: Uint8Array;
+};
+
+/**
+ * Verify signatures sets with batch verification or regular core verify depending on the set count.
+ * Abstracted in a separate file to be consumed by the threaded pool and the main thread implementation.
+ */
+export function verifySignatureSetsMaybeBatch(sets: SignatureSetDeserialized[], validateSignature = true): boolean {
+  if (sets.length >= MIN_SET_COUNT_TO_BATCH) {
+    return bls.Signature.verifyMultipleSignatures(
+      sets.map((s) => ({
+        publicKey: s.publicKey,
+        message: s.message,
+        signature: bls.Signature.fromBytes(s.signature, CoordType.affine, validateSignature),
+      }))
+    );
+  }
+
+  // .every on an empty array returns true
+  if (sets.length === 0) {
+    throw Error("Empty signature set");
+  }
+
+  // If too few signature sets verify them without batching
+  return sets.every((set) => {
+    const sig = bls.Signature.fromBytes(set.signature, CoordType.affine, validateSignature);
+    return sig.verify(set.publicKey, set.message);
+  });
+}

--- a/packages/lodestar/src/chain/bls/multithread/index.ts
+++ b/packages/lodestar/src/chain/bls/multithread/index.ts
@@ -9,9 +9,10 @@ import {AbortSignal} from "abort-controller";
 import {Implementation, PointFormat, PublicKey} from "@chainsafe/bls";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {QueueError, QueueErrorCode} from "../../../util/queue";
+import {IMetrics} from "../../../metrics";
+import {IBlsVerifierImpl} from "../interface";
 import {BlsWorkReq, WorkerData, WorkResult, WorkResultCode} from "./types";
 import {chunkifyMaximizeChunkSize, getDefaultPoolSize} from "./utils";
-import {IMetrics} from "../../../metrics";
 
 export type BlsMultiThreadWorkerPoolModules = {
   logger: ILogger;
@@ -67,7 +68,7 @@ type WorkerDescriptor = {
  *   communiction has very high latency, of around ~5 ms. So package multiple small signature
  *   sets into packages of work and send at once to a worker to distribute the latency cost
  */
-export class BlsMultiThreadWorkerPool {
+export class BlsMultiThreadWorkerPool implements IBlsVerifierImpl {
   private readonly logger: ILogger;
   private readonly metrics: IMetrics | null;
   private readonly signal: AbortSignal;

--- a/packages/lodestar/src/chain/bls/multithread/worker.ts
+++ b/packages/lodestar/src/chain/bls/multithread/worker.ts
@@ -2,8 +2,7 @@ import worker from "worker_threads";
 import {expose} from "threads/worker";
 import {bls, init, CoordType} from "@chainsafe/bls";
 import {WorkerData, BlsWorkReq, WorkResult, WorkResultCode} from "./types";
-
-const MIN_SET_COUNT_TO_BATCH = 2;
+import {verifySignatureSetsMaybeBatch} from "../maybeBatch";
 
 /* eslint-disable no-console */
 
@@ -23,35 +22,18 @@ function doManyBlsWorkReq(workReqArr: BlsWorkReq[]): WorkResult<boolean>[] {
   return workReqArr.map((workReq) => {
     try {
       const start = Date.now();
-      const isValid = verifySignatureSetsMaybeBatch(workReq);
+      const isValid = verifySignatureSetsMaybeBatch(
+        workReq.sets.map((set) => ({
+          publicKey: bls.PublicKey.fromBytes(set.publicKey, CoordType.affine),
+          message: set.message,
+          signature: set.signature,
+        })),
+        workReq.validateSignature
+      );
       const workerJobTimeMs = Date.now() - start;
       return {code: WorkResultCode.success, result: isValid, workerJobTimeMs, workerId};
     } catch (e) {
       return {code: WorkResultCode.error, error: e as Error};
     }
-  });
-}
-
-function verifySignatureSetsMaybeBatch(workReq: BlsWorkReq): boolean {
-  if (workReq.sets.length >= MIN_SET_COUNT_TO_BATCH) {
-    return bls.Signature.verifyMultipleSignatures(
-      workReq.sets.map((s) => ({
-        publicKey: bls.PublicKey.fromBytes(s.publicKey, CoordType.affine),
-        message: s.message,
-        signature: bls.Signature.fromBytes(s.signature, CoordType.affine, workReq.validateSignature),
-      }))
-    );
-  }
-
-  // .every on an empty array returns true
-  if (workReq.sets.length === 0) {
-    throw Error("Empty signature set");
-  }
-
-  // If too few signature sets verify them without batching
-  return workReq.sets.every((set) => {
-    const pk = bls.PublicKey.fromBytes(set.publicKey, CoordType.affine);
-    const sig = bls.Signature.fromBytes(set.signature, CoordType.affine, workReq.validateSignature);
-    return sig.verify(pk, set.message);
   });
 }

--- a/packages/lodestar/src/chain/bls/singleThread.ts
+++ b/packages/lodestar/src/chain/bls/singleThread.ts
@@ -1,0 +1,12 @@
+import {PublicKey} from "@chainsafe/bls";
+import {IBlsVerifierImpl} from "./interface";
+import {verifySignatureSetsMaybeBatch} from "./maybeBatch";
+
+export class BlsSingleThreadVerifier implements IBlsVerifierImpl {
+  async verifySignatureSets(
+    sets: {publicKey: PublicKey; message: Uint8Array; signature: Uint8Array}[],
+    validateSignature: boolean
+  ): Promise<boolean> {
+    return verifySignatureSetsMaybeBatch(sets, validateSignature);
+  }
+}

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -32,7 +32,6 @@ import {BlsVerifier, IBlsVerifier} from "./bls";
 import {ForkDigestContext, IForkDigestContext} from "../util/forkDigestContext";
 
 export interface IBeaconChainModules {
-  opts: IChainOptions;
   config: IBeaconConfig;
   db: IBeaconDb;
   logger: ILogger;
@@ -69,7 +68,7 @@ export class BeaconChain implements IBeaconChain {
   protected internalEmitter = new ChainEventEmitter();
   private abortController = new AbortController();
 
-  constructor({opts, config, db, logger, metrics, anchorState}: IBeaconChainModules) {
+  constructor(opts: IChainOptions, {config, db, logger, metrics, anchorState}: IBeaconChainModules) {
     this.opts = opts;
     this.config = config;
     this.db = db;
@@ -82,7 +81,7 @@ export class BeaconChain implements IBeaconChain {
 
     const signal = this.abortController.signal;
     const emitter = this.internalEmitter; // All internal compoments emit to the internal emitter first
-    const bls = new BlsVerifier({logger, metrics, signal: this.abortController.signal});
+    const bls = new BlsVerifier({logger, metrics, signal: this.abortController.signal}, opts);
 
     const clock = new LocalClock({config, emitter, genesisTime: this.genesisTime, signal});
     const stateCache = new StateContextCache();

--- a/packages/lodestar/src/chain/options.ts
+++ b/packages/lodestar/src/chain/options.ts
@@ -1,4 +1,8 @@
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type IChainOptions = {};
+import {BlsVerifierOpts} from "./bls";
 
-export const defaultChainOptions: IChainOptions = {};
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type IChainOptions = BlsVerifierOpts;
+
+export const defaultChainOptions: IChainOptions = {
+  useSingleThreadVerifier: false,
+};

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -126,8 +126,7 @@ export class BeaconNode {
       initBeaconMetrics(metrics, anchorState);
     }
 
-    const chain = new BeaconChain({
-      opts: opts.chain,
+    const chain = new BeaconChain(opts.chain, {
       config,
       db,
       logger: logger.child(opts.logger.chain),

--- a/packages/lodestar/test/sim/multiNodeMultiThread.test.ts
+++ b/packages/lodestar/test/sim/multiNodeMultiThread.test.ts
@@ -87,6 +87,8 @@ function runMultiNodeMultiThreadTest({nodeCount, validatorsPerNode, event, altai
       const options: NodeWorkerOptions = {
         params: {...testParams, ALTAIR_FORK_EPOCH: altairForkEpoch},
         options: {
+          // Don't spawn workers from worker threads
+          chain: {useSingleThreadVerifier: true},
           network: {
             discv5: {bindAddr: `/ip4/127.0.0.1/udp/${p2pPort}`},
             localMultiaddrs: [`/ip4/127.0.0.1/tcp/${p2pPort}`],


### PR DESCRIPTION
**Motivation**

Helpful feature if BLS happens to show issues in multi-thread environments. I've added this now to see if it helps with https://github.com/ChainSafe/lodestar/issues/2542 

**Description**

Expose a new programmatic and cli option `chain.useSingleThreadVerifier` to skip spawning a worker thread pool to verify BLS sigs.

