### PR TITLE
Render pre-genesis Eph timestamps better

### DIFF
--- a/packages/utils/src/logger/util.ts
+++ b/packages/utils/src/logger/util.ts
@@ -4,11 +4,12 @@ import {EpochSlotOpts} from "./interface";
  * Formats time as: `EPOCH/SLOT_INDEX SECONDS.MILISECONDS
  */
 export function formatEpochSlotTime(opts: EpochSlotOpts, now = Date.now()): string {
-  const secSinceGenesis = now / 1000 - opts.genesisTime;
-  const slot = Math.floor(secSinceGenesis / opts.secondsPerSlot);
-  const epoch = Math.floor(slot / opts.slotsPerEpoch);
-  const slotIndex = slot % opts.slotsPerEpoch;
-  const slotSec = secSinceGenesis % opts.secondsPerSlot;
-
+  const nowSec = now / 1000;
+  const secSinceGenesis = nowSec - opts.genesisTime;
+  const epoch = Math.floor(secSinceGenesis / (opts.slotsPerEpoch * opts.secondsPerSlot));
+  const epochStartSec = opts.genesisTime + epoch * opts.slotsPerEpoch * opts.secondsPerSlot;
+  const secSinceStartEpoch = nowSec - epochStartSec;
+  const slotIndex = Math.floor(secSinceStartEpoch / opts.secondsPerSlot);
+  const slotSec = secSinceStartEpoch % opts.secondsPerSlot;
   return `Eph ${epoch}/${slotIndex} ${slotSec.toFixed(3)}`;
 }

--- a/packages/utils/test/unit/logger/util.test.ts
+++ b/packages/utils/test/unit/logger/util.test.ts
@@ -2,13 +2,21 @@ import {expect} from "chai";
 import {formatEpochSlotTime} from "../../../src/logger/util";
 
 describe("logger / util / formatEpochSlotTime", () => {
-  it("Should format epoch slot time", () => {
-    const now = 1619171569709;
-    const genesisTime = (now - 1235423) / 1000;
-    const secondsPerSlot = 12;
-    const slotsPerEpoch = 32;
-    const expectLog = "Eph 3/6 11.423";
+  const nowSec = 1619171569;
+  const secondsPerSlot = 12;
+  const slotsPerEpoch = 32;
 
-    expect(formatEpochSlotTime({genesisTime, secondsPerSlot, slotsPerEpoch}, now)).to.equal(expectLog);
-  });
+  const testCases: {epoch: number; slot: number; sec: number}[] = [
+    {epoch: 3, slot: 6, sec: 11.423},
+    {epoch: -1, slot: 31, sec: 11.423},
+    {epoch: 0, slot: 0, sec: 0.001},
+  ];
+
+  for (const {epoch, slot, sec} of testCases) {
+    const expectLog = `Eph ${epoch}/${slot} ${sec}`; // "Eph 3/6 11.423";
+    it(expectLog, () => {
+      const genesisTime = nowSec - epoch * slotsPerEpoch * secondsPerSlot - slot * secondsPerSlot - sec;
+      expect(formatEpochSlotTime({genesisTime, secondsPerSlot, slotsPerEpoch}, nowSec * 1000)).to.equal(expectLog);
+    });
+  }
 });


### PR DESCRIPTION
**Motivation**

Log Eph format counts pre-genesis epoch, slot and seconds in reverse. It's a bit confusing

**Description**

Counts epochs in reverse but slot and seconds are counted relative to the closest previous epoch.

**Before**
```
Eph -1/-1 -0.100
```
**After**
```
Eph -1/31 11.900
```