### PR TITLE
Expose log format options to CLI

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -40,7 +40,7 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
   const options = beaconNodeOptions.getWithDefaults();
 
   const abortController = new AbortController();
-  const logger = getCliLogger(args, beaconPaths);
+  const logger = getCliLogger(args, beaconPaths, config);
 
   onGracefulShutdown(async () => {
     abortController.abort();

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -1,16 +1,13 @@
 import {Options} from "yargs";
-import {defaultLogLevel, LogLevel, LogLevels} from "@chainsafe/lodestar-utils";
+import {defaultLogLevel, LogLevels} from "@chainsafe/lodestar-utils";
 import {beaconNodeOptions, paramsOptions, IBeaconNodeArgs, IENRArgs, enrOptions} from "../../options";
 import {defaultBeaconPaths, IBeaconPaths} from "./paths";
-import {ICliCommandOptions} from "../../util";
+import {ICliCommandOptions, ILogArgs} from "../../util";
 
 interface IBeaconExtraArgs {
   forceGenesis?: boolean;
   genesisStateFile?: string;
   weakSubjectivityStateFile?: string;
-  logLevel?: LogLevel;
-  logLevelFile?: LogLevel;
-  logFormatGenesisTime?: number;
 }
 
 export const beaconExtraOptions: ICliCommandOptions<IBeaconExtraArgs> = {
@@ -28,7 +25,9 @@ export const beaconExtraOptions: ICliCommandOptions<IBeaconExtraArgs> = {
     description: "Path or URL to download a weak subjectivity state file in ssz-encoded format",
     type: "string",
   },
+};
 
+export const logOptions: ICliCommandOptions<ILogArgs> = {
   logLevel: {
     choices: LogLevels,
     description: "Logging verbosity level",
@@ -45,8 +44,14 @@ export const beaconExtraOptions: ICliCommandOptions<IBeaconExtraArgs> = {
 
   logFormatGenesisTime: {
     hidden: true,
-    description: "Use EpochSlot TimestampFormat for the logger",
+    description: "Logger format - Use EpochSlot TimestampFormat",
     type: "number",
+  },
+
+  logFormatId: {
+    hidden: true,
+    description: "Logger format - Prefix module field with a string ID",
+    type: "string",
   },
 };
 
@@ -98,11 +103,12 @@ export const beaconPathsOptions: ICliCommandOptions<IBeaconPaths> = {
   },
 };
 
-export type IBeaconArgs = IBeaconNodeArgs & IBeaconPaths & IENRArgs & IBeaconExtraArgs;
+export type IBeaconArgs = IBeaconExtraArgs & ILogArgs & IBeaconPaths & IBeaconNodeArgs & IENRArgs;
 
 export const beaconOptions: {[k: string]: Options} = {
-  ...beaconPathsOptions,
   ...beaconExtraOptions,
+  ...logOptions,
+  ...beaconPathsOptions,
   ...beaconNodeOptions,
   ...paramsOptions,
   ...enrOptions,

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -10,6 +10,7 @@ interface IBeaconExtraArgs {
   weakSubjectivityStateFile?: string;
   logLevel?: LogLevel;
   logLevelFile?: LogLevel;
+  logFormatGenesisTime?: number;
 }
 
 export const beaconExtraOptions: ICliCommandOptions<IBeaconExtraArgs> = {
@@ -40,6 +41,12 @@ export const beaconExtraOptions: ICliCommandOptions<IBeaconExtraArgs> = {
     description: "Logging verbosity level for file transport",
     defaultDescription: defaultLogLevel,
     type: "string",
+  },
+
+  logFormatGenesisTime: {
+    hidden: true,
+    description: "Use EpochSlot TimestampFormat for the logger",
+    type: "number",
   },
 };
 

--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -48,7 +48,7 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
 
   // BeaconNode setup
   const libp2p = await createNodeJsLibp2p(peerId, options.network);
-  const logger = getCliLogger(args, beaconPaths);
+  const logger = getCliLogger(args, beaconPaths, config);
 
   const db = new BeaconDb({config, controller: new LevelDbController(options.db, {logger})});
   await db.start();

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -24,7 +24,7 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
   const beaconPaths = getBeaconPaths(args);
   const config = getBeaconConfigFromArgs(args);
 
-  const logger = getCliLogger(args, beaconPaths);
+  const logger = getCliLogger(args, beaconPaths, config);
 
   const validatorDirManager = new ValidatorDirManager(accountPaths);
   const secretKeys = await validatorDirManager.decryptAllValidators({force: args.force});

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -11,7 +11,6 @@ export type IValidatorCliArgs = IAccountValidatorArgs &
     force: boolean;
     graffiti: string;
     logFile: IBeaconPaths["logFile"];
-    interopIndexes?: string;
   };
 
 export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -1,24 +1,23 @@
-import {LogLevel} from "@chainsafe/lodestar-utils";
-import {ICliCommandOptions} from "../../util";
+import {ICliCommandOptions, ILogArgs} from "../../util";
 import {defaultValidatorPaths} from "./paths";
 import {accountValidatorOptions, IAccountValidatorArgs} from "../account/cmds/validator/options";
-import {beaconExtraOptions, beaconPathsOptions} from "../beacon/options";
+import {logOptions, beaconPathsOptions} from "../beacon/options";
+import {IBeaconPaths} from "../beacon/paths";
 
-export type IValidatorCliArgs = IAccountValidatorArgs & {
-  validatorsDbDir?: string;
-  server: string;
-  force: boolean;
-  graffiti: string;
-  logFile: string;
-  logLevel: LogLevel;
-  logLevelFile: LogLevel;
-};
+export type IValidatorCliArgs = IAccountValidatorArgs &
+  ILogArgs & {
+    validatorsDbDir?: string;
+    server: string;
+    force: boolean;
+    graffiti: string;
+    logFile: IBeaconPaths["logFile"];
+    interopIndexes?: string;
+  };
 
 export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
   ...accountValidatorOptions,
+  ...logOptions,
   logFile: beaconPathsOptions.logFile,
-  logLevel: beaconExtraOptions.logLevel,
-  logLevelFile: beaconExtraOptions.logLevelFile,
 
   validatorsDbDir: {
     description: "Data directory for validator databases.",

--- a/packages/cli/src/util/logger.ts
+++ b/packages/cli/src/util/logger.ts
@@ -9,6 +9,13 @@ import {
   TimestampFormatCode,
 } from "@chainsafe/lodestar-utils";
 
+export interface ILogArgs {
+  logLevel?: LogLevel;
+  logLevelFile?: LogLevel;
+  logFormatGenesisTime?: number;
+  logFormatId?: string;
+}
+
 export function errorLogger(): ILogger {
   return new WinstonLogger({level: LogLevel.error});
 }
@@ -16,21 +23,17 @@ export function errorLogger(): ILogger {
 /**
  * Setup a CLI logger, common for beacon, validator and dev commands
  */
-export function getCliLogger(
-  args: {logLevel?: LogLevel; logLevelFile?: LogLevel; logGenesisTime?: number},
-  paths: {logFile?: string},
-  config: IBeaconConfig
-): ILogger {
+export function getCliLogger(args: ILogArgs, paths: {logFile?: string}, config: IBeaconConfig): ILogger {
   const transports: TransportOpts[] = [{type: TransportType.console}];
   if (paths.logFile) {
     transports.push({type: TransportType.file, filename: paths.logFile, level: args.logLevelFile});
   }
 
   const timestampFormat: TimestampFormat =
-    args.logGenesisTime !== undefined
+    args.logFormatGenesisTime !== undefined
       ? {
           format: TimestampFormatCode.EpochSlot,
-          genesisTime: args.logGenesisTime,
+          genesisTime: args.logFormatGenesisTime,
           secondsPerSlot: config.params.SECONDS_PER_SLOT,
           slotsPerEpoch: config.params.SLOTS_PER_EPOCH,
         }
@@ -38,5 +41,5 @@ export function getCliLogger(
           format: TimestampFormatCode.DateRegular,
         };
 
-  return new WinstonLogger({level: args.logLevel, timestampFormat}, transports);
+  return new WinstonLogger({level: args.logLevel, module: args.logFormatId, timestampFormat}, transports);
 }

--- a/packages/cli/src/util/logger.ts
+++ b/packages/cli/src/util/logger.ts
@@ -1,4 +1,13 @@
-import {ILogger, LogLevel, TransportType, TransportOpts, WinstonLogger} from "@chainsafe/lodestar-utils";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {
+  ILogger,
+  LogLevel,
+  TransportType,
+  TransportOpts,
+  WinstonLogger,
+  TimestampFormat,
+  TimestampFormatCode,
+} from "@chainsafe/lodestar-utils";
 
 export function errorLogger(): ILogger {
   return new WinstonLogger({level: LogLevel.error});
@@ -7,11 +16,27 @@ export function errorLogger(): ILogger {
 /**
  * Setup a CLI logger, common for beacon, validator and dev commands
  */
-export function getCliLogger(args: {logLevel?: LogLevel; logLevelFile?: LogLevel}, paths: {logFile?: string}): ILogger {
+export function getCliLogger(
+  args: {logLevel?: LogLevel; logLevelFile?: LogLevel; logGenesisTime?: number},
+  paths: {logFile?: string},
+  config: IBeaconConfig
+): ILogger {
   const transports: TransportOpts[] = [{type: TransportType.console}];
   if (paths.logFile) {
     transports.push({type: TransportType.file, filename: paths.logFile, level: args.logLevelFile});
   }
 
-  return new WinstonLogger({level: args.logLevel}, transports);
+  const timestampFormat: TimestampFormat =
+    args.logGenesisTime !== undefined
+      ? {
+          format: TimestampFormatCode.EpochSlot,
+          genesisTime: args.logGenesisTime,
+          secondsPerSlot: config.params.SECONDS_PER_SLOT,
+          slotsPerEpoch: config.params.SLOTS_PER_EPOCH,
+        }
+      : {
+          format: TimestampFormatCode.DateRegular,
+        };
+
+  return new WinstonLogger({level: args.logLevel, timestampFormat}, transports);
 }


### PR DESCRIPTION
**Motivation**

Using an Eph timestamp format and customizing a log id is only available to programmatic usage.

**Description**

Expose options:
- `logFormatGenesisTime`: Logger format - Use EpochSlot TimestampFormat
- `logFormatId`: Logger format - Prefix module field with a string ID