### PR TITLE
Add connect and disconnect peer API

### DIFF
--- a/packages/lodestar/src/api/impl/debug/debug.ts
+++ b/packages/lodestar/src/api/impl/debug/debug.ts
@@ -1,3 +1,5 @@
+import Multiaddr from "multiaddr";
+import PeerId from "peer-id";
 import {IApiOptions} from "../../options";
 import {IApiModules} from "../interface";
 import {DebugBeaconApi} from "./beacon";
@@ -7,7 +9,18 @@ import {IDebugApi} from "./interface";
 export class DebugApi implements IDebugApi {
   beacon: IDebugBeaconApi;
 
-  constructor(opts: Partial<IApiOptions>, modules: Pick<IApiModules, "config" | "logger" | "chain" | "db">) {
+  constructor(
+    opts: Partial<IApiOptions>,
+    private readonly modules: Pick<IApiModules, "config" | "logger" | "chain" | "db" | "network">
+  ) {
     this.beacon = new DebugBeaconApi(opts, modules);
+  }
+
+  async connectToPeer(peer: PeerId, multiaddr: Multiaddr[]): Promise<void> {
+    await this.modules.network.connectToPeer(peer, multiaddr);
+  }
+
+  async disconnectPeer(peer: PeerId): Promise<void> {
+    await this.modules.network.disconnectPeer(peer);
   }
 }

--- a/packages/lodestar/src/api/impl/debug/interface.ts
+++ b/packages/lodestar/src/api/impl/debug/interface.ts
@@ -1,5 +1,10 @@
+import Multiaddr from "multiaddr";
+import PeerId from "peer-id";
 import {IDebugBeaconApi} from "./beacon/interface";
 
 export interface IDebugApi {
   beacon: IDebugBeaconApi;
+
+  connectToPeer(peer: PeerId, multiaddr: Multiaddr[]): Promise<void>;
+  disconnectPeer(peer: PeerId): Promise<void>;
 }

--- a/packages/lodestar/src/api/rest/debug/connectToPeer.ts
+++ b/packages/lodestar/src/api/rest/debug/connectToPeer.ts
@@ -1,0 +1,36 @@
+import Multiaddr from "multiaddr";
+import {createFromB58String} from "peer-id";
+import {ApiController} from "../types";
+
+export const connectToPeer: ApiController<null, {peerId: string}, string[]> = {
+  url: "/eth/v1/debug/connect/:peerId",
+  method: "POST",
+  id: "connectToPeer",
+
+  handler: async function (req) {
+    const multiaddrStr = req.body || [];
+    const multiaddr = multiaddrStr.map((addr) => new Multiaddr(addr));
+    const peer = createFromB58String(req.params.peerId);
+    await this.api.debug.connectToPeer(peer, multiaddr);
+    return {};
+  },
+
+  schema: {
+    params: {
+      type: "object",
+      required: ["peerId"],
+      properties: {
+        peerId: {
+          types: "string",
+        },
+      },
+    },
+
+    body: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    },
+  },
+};

--- a/packages/lodestar/src/api/rest/debug/disconnectPeer.ts
+++ b/packages/lodestar/src/api/rest/debug/disconnectPeer.ts
@@ -1,0 +1,26 @@
+import {createFromB58String} from "peer-id";
+import {ApiController} from "../types";
+
+export const disconnectPeer: ApiController<null, {peerId: string}> = {
+  url: "/eth/v1/debug/disconnect/:peerId",
+  method: "POST",
+  id: "disconnectPeer",
+
+  handler: async function (req) {
+    const peer = createFromB58String(req.params.peerId);
+    await this.api.debug.disconnectPeer(peer);
+    return {};
+  },
+
+  schema: {
+    params: {
+      type: "object",
+      required: ["peerId"],
+      properties: {
+        peerId: {
+          types: "string",
+        },
+      },
+    },
+  },
+};

--- a/packages/lodestar/src/api/rest/debug/index.ts
+++ b/packages/lodestar/src/api/rest/debug/index.ts
@@ -1,4 +1,6 @@
+import {connectToPeer} from "./connectToPeer";
+import {disconnectPeer} from "./disconnectPeer";
 import {getDebugChainHeads} from "./getDebugChainHeads";
 import {getState, getStateV2} from "./getStates";
 
-export const debugRoutes = [getDebugChainHeads, getState, getStateV2];
+export const debugRoutes = [connectToPeer, disconnectPeer, getDebugChainHeads, getState, getStateV2];

--- a/packages/lodestar/src/network/interface.ts
+++ b/packages/lodestar/src/network/interface.ts
@@ -47,6 +47,10 @@ export interface INetwork {
   // Service
   start(): Promise<void>;
   stop(): Promise<void>;
+
+  // Debug
+  connectToPeer(peer: PeerId, multiaddr: Multiaddr[]): Promise<void>;
+  disconnectPeer(peer: PeerId): Promise<void>;
 }
 
 export type PeerDirection = Connection["stat"]["direction"];

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -199,4 +199,15 @@ export class Network implements INetwork {
   isSubscribedToGossipCoreTopics(): boolean {
     return this.gossipHandler.isSubscribedToCoreTopics;
   }
+
+  // Debug
+
+  async connectToPeer(peer: PeerId, multiaddr: Multiaddr[]): Promise<void> {
+    this.libp2p.peerStore.addressBook.add(peer, multiaddr);
+    await this.libp2p.dial(peer);
+  }
+
+  async disconnectPeer(peer: PeerId): Promise<void> {
+    await this.libp2p.hangUp(peer);
+  }
 }

--- a/packages/lodestar/test/utils/network.ts
+++ b/packages/lodestar/test/utils/network.ts
@@ -30,12 +30,11 @@ export async function createNode(
 // Helpers to manipulate network's libp2p instance for testing only
 
 export async function connect(network: Network, peer: PeerId, multiaddr: Multiaddr[]): Promise<void> {
-  network["libp2p"].peerStore.addressBook.add(peer, multiaddr);
-  await network["libp2p"].dial(peer);
+  await network.connectToPeer(peer, multiaddr);
 }
 
 export async function disconnect(network: Network, peer: PeerId): Promise<void> {
-  await network["libp2p"].hangUp(peer);
+  await network.disconnectPeer(peer);
 }
 
 export function onPeerConnect(network: Network): Promise<void> {

--- a/packages/lodestar/test/utils/stub/api.ts
+++ b/packages/lodestar/test/utils/stub/api.ts
@@ -28,7 +28,8 @@ export class StubbedApi implements SinonStubbedInstance<IApi> {
     this.validator = sandbox.createStubInstance(ValidatorApi);
     this.events = sandbox.createStubInstance(EventsApi);
     const debugBeacon = sandbox.createStubInstance(DebugBeaconApi);
-    this.debug = {beacon: debugBeacon} as SinonStubbedInstance<DebugApi>;
+    this.debug = sandbox.createStubInstance(DebugApi);
+    this.debug.beacon = debugBeacon;
     this.config = new StubbedConfigApi(sandbox);
     this.lightclient = sandbox.createStubInstance(LightclientApi);
     this.lodestar = sandbox.createStubInstance(LodestarApi);


### PR DESCRIPTION
**Motivation**

It's useful to be able to connect and disconnect peers on running nodes through the API

**Description**

Adds two new routes:
- POST `/eth/v1/debug/connect/:peerId`, body = Multiaddr[]
- POST `/eth/v1/debug/disconnect/:peerId`