### PR TITLE
Add Apple M1 support to lodestar

### DIFF
--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -56,7 +56,7 @@
     "@chainsafe/lodestar-utils": "^0.22.0",
     "@chainsafe/lodestar-validator": "^0.22.0",
     "@chainsafe/persistent-merkle-tree": "^0.3.2",
-    "@chainsafe/snappy-stream": "3.0.5",
+    "@chainsafe/snappy-stream": "5.0.0",
     "@chainsafe/ssz": "^0.8.6",
     "@ethersproject/abi": "^5.0.0",
     "@types/datastore-level": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2038,6 +2038,13 @@
     rlp "^2.2.6"
     strict-event-emitter-types "^2.0.0"
 
+"@chainsafe/fast-crc32c@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/fast-crc32c/-/fast-crc32c-3.0.0.tgz#34879af40d7e75643bc5206e6502c2231494a7ba"
+  integrity sha512-++icGd/h7oflrdLhRWrlRZt5dAZGo9W9we6hmLR5xEFFQTxnB1k5nQSshG+DbYQwBtda3NPQjnHHkXYkJI4nog==
+  optionalDependencies:
+    "@node-rs/crc32" "1.1.0"
+
 "@chainsafe/persistent-merkle-tree@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.3.2.tgz#ec2d0c71d84e280c758ef5d828b05a8634df649e"
@@ -2055,17 +2062,17 @@
   resolved "https://registry.yarnpkg.com/@chainsafe/slashing-protection-interchange-tests/-/slashing-protection-interchange-tests-4.0.0.tgz#431837fb113447223bb6fc73954a39d15d58314f"
   integrity sha512-H9sc2PFzsK0YRtjwtaZeJ1k8zIhhvPRZYksbzEuLKBss2iIYsCpNKzvHdbjb6uG/S3LBihpuBc53oJ2az82KSQ==
 
-"@chainsafe/snappy-stream@3.0.5":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@chainsafe/snappy-stream/-/snappy-stream-3.0.5.tgz#9e98a7bdee5ad4aeff67d270ec64a5fbbb7fd6a0"
-  integrity sha512-Z4R8FM2OgNNZQdEZh5QNhXwXfbEmwYQ2ZhTG6Bx07++9bWWuZ7PaCkV7Ub+ivJVv3l+Ut5SOgTCMKIQPRQTy2w==
+"@chainsafe/snappy-stream@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/snappy-stream/-/snappy-stream-5.0.0.tgz#87dfb8dd6e5a20c7e982700974fd59941f5a96c4"
+  integrity sha512-E5Y9KsyTMjXGgoLl2sIetiIpztum4NUznNDAYa+DoN20HjGNUv4ZSB5rnQrlWKVq6POnkL6vPTZC2TLYosR0wA==
   dependencies:
+    "@chainsafe/fast-crc32c" "3.0.0"
     bl "^1.0.0"
     buffer-alloc "^1.2.0"
     buffer-equal "1.0.0"
     buffer-from "^1.1.1"
-    fast-crc32c "^1.0.1"
-    snappy "6.3.4"
+    snappy "^6.3.5"
 
 "@chainsafe/ssz@^0.8.6":
   version "0.8.6"
@@ -3240,6 +3247,11 @@
   resolved "https://registry.yarnpkg.com/@multiformats/base-x/-/base-x-4.0.1.tgz#95ff0fa58711789d53aefb2590a8b7a4e715d121"
   integrity sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==
 
+"@napi-rs/triples@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/triples/-/triples-1.0.2.tgz#2ce4c6a78568358772008f564ee5009093d20a19"
+  integrity sha512-EL3SiX43m9poFSnhDx4d4fn9SSaqyO2rHsCNhETi9bWPmjXK3uPJ0QpPFtx39FEdHcz1vJmsiW41kqc0AgvtzQ==
+
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents":
   version "2.1.8-no-fsevents"
   resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.tgz#da7c3996b8e6e19ebd14d82eaced2313e7769f9b"
@@ -3256,6 +3268,76 @@
     path-is-absolute "^1.0.0"
     readdirp "^2.2.1"
     upath "^1.1.1"
+
+"@node-rs/crc32-android-arm64@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.1.0.tgz#869f5f4414d145e00e6b12d1841eda0d70188db2"
+  integrity sha512-DXcsyCmTXEHr+aCocDtrSTBkIghvQ87rZNxQrThpNU3RgCAvCtNCPJw4F8/Il5MXN3c+xzl/ZglN03USqSPmAA==
+
+"@node-rs/crc32-darwin-arm64@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.1.0.tgz#b6f41c931f992f8fff93a5c086eb1c7f0b393fa5"
+  integrity sha512-dE04JL+w4+V0YBw+nrnzw7U0c5yTtAWg1jelNuZl+4BWCFrkHpAmUR+dHiz2OhZvbKV7RApwDNmYbvG+ppYK0Q==
+
+"@node-rs/crc32-darwin-x64@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.1.0.tgz#291f4b4b0a562c220537bdf69bd72b19bf7a19be"
+  integrity sha512-/nfj8EixjXc3iuyR5CybB2vOzQ23xjv/MrQiWtozcS2mLNsbMG/Ue0C9QLq4FQbL6HXEnhbrVbAQnByNurP4Ew==
+
+"@node-rs/crc32-linux-arm-gnueabihf@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.1.0.tgz#b54c7f12661f8c2ef0d1200716dce67811beb2ea"
+  integrity sha512-RX7VTEKfM/KMLeRMw89vJdsdvxZafoHQrwUvR290vuHE2Zfqc10YQQMJvq0iU7IaKmgDAnYZtUPhSAv1FdbtFQ==
+
+"@node-rs/crc32-linux-arm64-gnu@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.1.0.tgz#736f745a16fd4c8be448646a957d3115cea9d18f"
+  integrity sha512-Age/YDyYhQEMSBZgHx4RhHXx6xcWNSGA3jDBu5NcBXo5dZZ2b3HAOjosdhfHqTGIrOdd+CAx3BqO5O46UiLU2Q==
+
+"@node-rs/crc32-linux-x64-gnu@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.1.0.tgz#9eca53c5ec185c838fa9ce4344efef7fb020dc3e"
+  integrity sha512-QUB3hkejwnziEyOT4zo51/qHEAW6YMs3eogQxOyB/IIkji8SwC1dgx94PC6MypBWSnjs2eAi0UiiZh6iK5+7kw==
+
+"@node-rs/crc32-linux-x64-musl@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.1.0.tgz#28c5433ac1b5c30cb8b083a02c12ec302b97bb10"
+  integrity sha512-avmN8ZU69+U1kUZ9CKjhpBcwL4LD29pg+sRJ4+zQSbqbAqOaMfWsvEemKymfOENrQJLR80azwKWfgxldP7/X3A==
+
+"@node-rs/crc32-win32-ia32-msvc@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-win32-ia32-msvc/-/crc32-win32-ia32-msvc-1.1.0.tgz#7bf9c3ba184465b30ad1f652cce1e154c0e53d4c"
+  integrity sha512-91SMBA7836eubTR9sd2xCwYt6c2MZwBw8j0x+jt3bxn32opgcwL4n6O89lKpMRZO8k6S8An51hBs1nYBB/5Wwg==
+
+"@node-rs/crc32-win32-x64-msvc@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32-win32-x64-msvc/-/crc32-win32-x64-msvc-1.1.0.tgz#e47d43161bec61c2c9f61bf577bdaa4c2887bc16"
+  integrity sha512-dqEQP+PxidHalhaEdat/54pGKx/aVIt7FDgWho5AEp2Wfc90aUdH4o1UX/sE4azDejo7eXc+kUHrTn3ZZWrRfw==
+
+"@node-rs/crc32@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/crc32/-/crc32-1.1.0.tgz#a0a4cb7f3b2d14a56621a26fb8b760c90782b965"
+  integrity sha512-f3LSfNx3jw93ThDF8SrFOCGeKqBt9gOnOdUyPiBL6peQ5qS8035ByilkNUomcz7OpaAXtRjNWSanP+E2/XKTFw==
+  dependencies:
+    "@node-rs/helper" "^1.1.0"
+  optionalDependencies:
+    "@node-rs/crc32-android-arm64" "^1.1.0"
+    "@node-rs/crc32-darwin-arm64" "^1.1.0"
+    "@node-rs/crc32-darwin-x64" "^1.1.0"
+    "@node-rs/crc32-linux-arm-gnueabihf" "^1.1.0"
+    "@node-rs/crc32-linux-arm64-gnu" "^1.1.0"
+    "@node-rs/crc32-linux-x64-gnu" "^1.1.0"
+    "@node-rs/crc32-linux-x64-musl" "^1.1.0"
+    "@node-rs/crc32-win32-ia32-msvc" "^1.1.0"
+    "@node-rs/crc32-win32-x64-msvc" "^1.1.0"
+
+"@node-rs/helper@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@node-rs/helper/-/helper-1.1.0.tgz#4fcbbebae3b81932d1ff3e431c7cd3886b504742"
+  integrity sha512-r43YnnrY5JNzDuXJdW3sBJrKzvejvFmFWbiItUEoBJsaPzOIWFMhXB7i5j4c9EMXcFfxveF4l7hT+rLmwtjrVQ==
+  dependencies:
+    "@napi-rs/triples" "^1.0.2"
+    tslib "^2.1.0"
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -7856,13 +7938,6 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-crc32c@^1.0.1:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/fast-crc32c/-/fast-crc32c-1.0.7.tgz#a7ab81b8665a6faee42ffe36ac930b15afc17396"
-  integrity sha512-yaAnvfGr8YWu6V2cqr2303/V1jXXVaOJCGtln7awIY/ocxWyUCdYbp8RoN7oSRq4lFA4ygMT/Lk/0sZTduJPPA==
-  optionalDependencies:
-    sse4_crc32 "^6.0.1"
-
 fast-decode-uri-component@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz#46f8b6c22b30ff7a81357d4f59abfae938202543"
@@ -11894,11 +11969,6 @@ node-abi@^2.7.0:
   dependencies:
     semver "^5.4.1"
 
-node-addon-api@^1.3.0:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.1.tgz#cf813cd69bb8d9100f6bdca6755fc268f54ac492"
-  integrity sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==
-
 node-addon-api@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.0.tgz#f9afb8d777a91525244b01775ea0ddbe1125483b"
@@ -14687,10 +14757,10 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-snappy@6.3.4:
-  version "6.3.4"
-  resolved "https://registry.yarnpkg.com/snappy/-/snappy-6.3.4.tgz#59a9223d81391b769927528183e210f60fc7fac1"
-  integrity sha512-DcpD17vdvHk0jUIZ3wkhoxyLiMjM7ZuOc3M5h2qpiZdTLbRorUJdOtB166m+lkoffByg2dkX0CGffYP2PTLoGw==
+snappy@^6.3.5:
+  version "6.3.5"
+  resolved "https://registry.yarnpkg.com/snappy/-/snappy-6.3.5.tgz#c14b8dea8e9bc2687875b5e491d15dd900e6023c"
+  integrity sha512-lonrUtdp1b1uDn1dbwgQbBsb5BbaiLeKq+AGwOk2No+en+VvJThwmtztwulEQsLinRF681pBqib0NUZaizKLIA==
   dependencies:
     bindings "^1.3.1"
     nan "^2.14.1"
@@ -14915,14 +14985,6 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
-
-sse4_crc32@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/sse4_crc32/-/sse4_crc32-6.0.1.tgz#3511c747ce48a224e0554ebb23d5835ba08a9637"
-  integrity sha512-FUTYXpLroqytNKWIfHzlDWoy9E4tmBB/RklNMy6w3VJs+/XEYAHgbiylg4SS43iOk/9bM0BlJ2EDpFAGT66IoQ==
-  dependencies:
-    bindings "^1.3.0"
-    node-addon-api "^1.3.0"
 
 sshpk@^1.7.0:
   version "1.16.1"
@@ -15779,7 +15841,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-tslib@^2.0.3:
+tslib@^2.0.3, tslib@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==


### PR DESCRIPTION
**Motivation**

<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**
The core issue is hardware accelarated sse4_crc32 dependency that is suppose to fallback to 
javascript implementation but it doesn't since nodejs crashes while loading bindings on M1 chip. 
I noticed this issue https://github.com/ashi009/node-fast-crc32c/issues/21#issue-609766808 which actually claims that this lib written in rust even has better performances (library author has no intention on merging this change). I've forked that repo and replaced lib and released under chainsafe org.
I've also updated that dependency in our fork of node-snappy-stream. Hopefully, at some point, somebody (khm google) will force those authors to maintain those "official" libraries.

Tests in all repos are passing and I'm successfully syncing mainnet.

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #2475 

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
