### PR TITLE
Fix events query serializing

### DIFF
--- a/packages/api/src/client/events.ts
+++ b/packages/api/src/client/events.ts
@@ -1,7 +1,7 @@
 import EventSource from "eventsource";
-import qs from "qs";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Api, BeaconEvent, routesData, getEventSerdes} from "../routes/events";
+import {stringifyQuery} from "./utils/format";
 
 /**
  * REST HTTP client for events routes
@@ -11,7 +11,7 @@ export function getClient(config: IBeaconConfig, baseUrl: string): Api {
 
   return {
     eventstream: async (topics, signal, onEvent) => {
-      const query = qs.stringify({topics});
+      const query = stringifyQuery({topics});
       // TODO: Use a proper URL formatter
       const url = `${baseUrl}${routesData.eventstream.url}?${query}`;
       const eventSource = new EventSource(url);

--- a/packages/api/src/client/utils/format.ts
+++ b/packages/api/src/client/utils/format.ts
@@ -1,0 +1,22 @@
+import qs from "qs";
+
+/**
+ * Eth2.0 API requires the query with format:
+ * - arrayFormat: repeat `topic=topic1&topic=topic2`
+ */
+export function stringifyQuery(query: unknown): string {
+  return qs.stringify(query, {arrayFormat: "repeat"});
+}
+
+/**
+ * TODO: Optimize, two regex is a bit wasteful
+ */
+export function urlJoin(...args: string[]): string {
+  return (
+    args
+      .join("/")
+      .replace(/([^:]\/)\/+/g, "$1")
+      // Remove duplicate slashes in the front
+      .replace(/^(\/)+/, "/")
+  );
+}

--- a/packages/api/src/client/utils/httpClient.ts
+++ b/packages/api/src/client/utils/httpClient.ts
@@ -1,8 +1,8 @@
 import {fetch} from "cross-fetch";
-import qs from "qs";
 import {AbortSignal, AbortController} from "abort-controller";
 import {ErrorAborted, TimeoutError} from "@chainsafe/lodestar-utils";
 import {ReqGeneric, RouteDef} from "../../utils";
+import {stringifyQuery, urlJoin} from "./format";
 
 export class HttpError extends Error {
   status: number;
@@ -121,25 +121,4 @@ function getErrorMessage(errBody: string): string {
   } catch (e) {
     return errBody;
   }
-}
-
-/**
- * Eth2.0 API requires the query with format:
- * - arrayFormat: repeat `topic=topic1&topic=topic2`
- */
-export function stringifyQuery(query: unknown): string {
-  return qs.stringify(query, {arrayFormat: "repeat"});
-}
-
-/**
- * TODO: Optimize, two regex is a bit wasteful
- */
-export function urlJoin(...args: string[]): string {
-  return (
-    args
-      .join("/")
-      .replace(/([^:]\/)\/+/g, "$1")
-      // Remove duplicate slashes in the front
-      .replace(/^(\/)+/, "/")
-  );
 }

--- a/packages/api/test/unit/client/format.test.ts
+++ b/packages/api/test/unit/client/format.test.ts
@@ -1,0 +1,9 @@
+import {expect} from "chai";
+import {EventType} from "../../../src/routes/events";
+import {stringifyQuery} from "../../../src/client/utils/format";
+
+describe("client / utils / format", () => {
+  it("Should repeat topic query", () => {
+    expect(stringifyQuery({topics: [EventType.finalizedCheckpoint]})).to.equal("topics=finalized_checkpoint");
+  });
+});

--- a/packages/api/test/unit/client/httpClient.test.ts
+++ b/packages/api/test/unit/client/httpClient.test.ts
@@ -13,7 +13,7 @@ interface IUser {
   name: string;
 }
 
-describe("httpClient test", () => {
+describe("httpClient json client", () => {
   const afterEachCallbacks: (() => Promise<any> | any)[] = [];
   afterEach(async () => {
     while (afterEachCallbacks.length > 0) {


### PR DESCRIPTION
**Motivation**

Events API client did not use the proper serializer for the query. It serializes topics as `topics[0]=head&topics[1]=chain_reorg` instead of `topics=head&topics=chain_reorg`. This breaks all requests to the eventstream endpoint.

**Description**

Fix the issue by using the same query serializer everywhere. Add test for events server query parser + the query serializer