### PR TITLE
Run with a single VC in single node sim tests

### DIFF
--- a/packages/lodestar/test/sim/singleNodeSingleThread.test.ts
+++ b/packages/lodestar/test/sim/singleNodeSingleThread.test.ts
@@ -34,14 +34,13 @@ describe("Run single node single thread interop validators (no eth1) until check
   }[] = [
     // phase0 fork only
     {validatorClientCount: 1, validatorsPerClient: 32, event: ChainEvent.justified, altairForkEpoch: Infinity},
-    {validatorClientCount: 8, validatorsPerClient: 8, event: ChainEvent.justified, altairForkEpoch: Infinity},
-    {validatorClientCount: 8, validatorsPerClient: 8, event: ChainEvent.finalized, altairForkEpoch: Infinity},
+    {validatorClientCount: 1, validatorsPerClient: 32, event: ChainEvent.finalized, altairForkEpoch: Infinity},
     // altair fork only
-    {validatorClientCount: 8, validatorsPerClient: 8, event: ChainEvent.finalized, altairForkEpoch: 0},
+    {validatorClientCount: 1, validatorsPerClient: 32, event: ChainEvent.finalized, altairForkEpoch: 0},
     // altair fork at epoch 1
-    {validatorClientCount: 8, validatorsPerClient: 8, event: ChainEvent.finalized, altairForkEpoch: 1},
+    {validatorClientCount: 1, validatorsPerClient: 32, event: ChainEvent.finalized, altairForkEpoch: 1},
     // altair fork at epoch 2
-    {validatorClientCount: 8, validatorsPerClient: 8, event: ChainEvent.finalized, altairForkEpoch: 2},
+    {validatorClientCount: 1, validatorsPerClient: 32, event: ChainEvent.finalized, altairForkEpoch: 2},
   ];
 
   for (const {validatorClientCount, validatorsPerClient, event, altairForkEpoch} of testCases) {


### PR DESCRIPTION
**Motivation**

It's not necessary yet to test overloading the node's REST API. Having multiple VCs makes it harder to read the logs. We should test this eventually but not now.

**Description**

Run single node sim tests with 1 VC, and 32 validators