### PR TITLE
Support parsing altair sync committee gossip topics

### DIFF
--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -11,7 +11,7 @@ import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {IMetrics} from "../../metrics";
 import {GossipHandlerFn, GossipObject, GossipTopic, GossipType, IGossipMessage, TopicValidatorFnMap} from "./interface";
 import {msgIdToString, getMsgId, messageIsValid} from "./utils";
-import {getGossipSSZSerializer, getGossipTopic, getGossipTopicString} from "./topic";
+import {getGossipSSZSerializer, parseGossipTopic, stringifyGossipTopic} from "./topic";
 import {encodeMessageData} from "./encoding";
 import {DEFAULT_ENCODING} from "./constants";
 import {GossipValidationError} from "./errors";
@@ -258,13 +258,13 @@ export class Eth2Gossipsub extends Gossipsub {
   }
 
   private getGossipTopicString(topic: GossipTopic): string {
-    return getGossipTopicString(this.forkDigestContext, topic);
+    return stringifyGossipTopic(this.forkDigestContext, topic);
   }
 
   private getGossipTopic(topicString: string): GossipTopic {
     let topic = this.gossipTopics.get(topicString);
     if (topic == null) {
-      topic = getGossipTopic(this.forkDigestContext, topicString);
+      topic = parseGossipTopic(this.forkDigestContext, topicString);
       this.gossipTopics.set(topicString, topic);
     }
     return topic;

--- a/packages/lodestar/src/network/gossip/interface.ts
+++ b/packages/lodestar/src/network/gossip/interface.ts
@@ -40,17 +40,21 @@ export interface IGossipTopic {
   encoding?: GossipEncoding;
 }
 
-export type GossipTopicMap = {
-  [GossipType.beacon_block]: IGossipTopic & {type: GossipType.beacon_block};
-  [GossipType.beacon_aggregate_and_proof]: IGossipTopic & {type: GossipType.beacon_aggregate_and_proof};
-  [GossipType.beacon_attestation]: IGossipTopic & {type: GossipType.beacon_attestation; subnet: number};
-  [GossipType.voluntary_exit]: IGossipTopic & {type: GossipType.voluntary_exit};
-  [GossipType.proposer_slashing]: IGossipTopic & {type: GossipType.proposer_slashing};
-  [GossipType.attester_slashing]: IGossipTopic & {type: GossipType.attester_slashing};
-  [GossipType.sync_committee_contribution_and_proof]: IGossipTopic & {
+export type GossipTopicTypeMap = {
+  [GossipType.beacon_block]: {type: GossipType.beacon_block};
+  [GossipType.beacon_aggregate_and_proof]: {type: GossipType.beacon_aggregate_and_proof};
+  [GossipType.beacon_attestation]: {type: GossipType.beacon_attestation; subnet: number};
+  [GossipType.voluntary_exit]: {type: GossipType.voluntary_exit};
+  [GossipType.proposer_slashing]: {type: GossipType.proposer_slashing};
+  [GossipType.attester_slashing]: {type: GossipType.attester_slashing};
+  [GossipType.sync_committee_contribution_and_proof]: {
     type: GossipType.sync_committee_contribution_and_proof;
   };
-  [GossipType.sync_committee]: IGossipTopic & {type: GossipType.sync_committee; subnet: number};
+  [GossipType.sync_committee]: {type: GossipType.sync_committee; subnet: number};
+};
+
+export type GossipTopicMap = {
+  [K in keyof GossipTopicTypeMap]: GossipTopicTypeMap[K] & IGossipTopic;
 };
 
 /**

--- a/packages/lodestar/src/network/gossip/validator.ts
+++ b/packages/lodestar/src/network/gossip/validator.ts
@@ -4,7 +4,7 @@ import {ATTESTATION_SUBNET_COUNT} from "@chainsafe/lodestar-params";
 import {mapValues} from "@chainsafe/lodestar-utils";
 import {IMetrics} from "../../metrics";
 import {JobQueue, JobQueueOpts, QueueType} from "../../util/queue";
-import {getGossipTopicString} from "./topic";
+import {stringifyGossipTopic} from "./topic";
 import {DEFAULT_ENCODING} from "./constants";
 import {validatorFns} from "./validatorFns";
 import {parseGossipMsg} from "./message";
@@ -113,7 +113,7 @@ export function createValidatorFnsByTopic(
 
   for (const type of staticGossipTypes) {
     const topic = {type, fork, encoding: DEFAULT_ENCODING} as GossipTopic;
-    const topicString = getGossipTopicString(modules.chain.forkDigestContext, topic);
+    const topicString = stringifyGossipTopic(modules.chain.forkDigestContext, topic);
     validatorFnsByTopic.set(topicString, validatorFnsByType[type]);
   }
 
@@ -125,7 +125,7 @@ export function createValidatorFnsByTopic(
       encoding: DEFAULT_ENCODING,
       subnet,
     } as GossipTopic;
-    const topicString = getGossipTopicString(modules.chain.forkDigestContext, topic);
+    const topicString = stringifyGossipTopic(modules.chain.forkDigestContext, topic);
     const topicValidatorFn = validatorFnsByType[GossipType.beacon_attestation];
     validatorFnsByTopic.set(topicString, topicValidatorFn);
   }

--- a/packages/lodestar/src/util/forkDigestContext.ts
+++ b/packages/lodestar/src/util/forkDigestContext.ts
@@ -15,6 +15,7 @@ export type IForkDigestContext = {
  */
 export class ForkDigestContext implements IForkDigestContext {
   private forkDigestByForkName = new Map<ForkName, ForkDigest>();
+  /** Map of ForkDigest in hex format without prefix: `0011aabb` */
   private forkNameByForkDigest = new Map<ForkDigestHex, ForkName>();
 
   constructor(config: IBeaconConfig, genesisValidatorsRoot: Root) {

--- a/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
@@ -8,7 +8,7 @@ import {ForkName} from "@chainsafe/lodestar-config";
 
 import {
   Eth2Gossipsub,
-  getGossipTopicString,
+  stringifyGossipTopic,
   GossipType,
   TopicValidatorFn,
   GossipValidationError,
@@ -38,7 +38,7 @@ describe("gossipsub", function () {
     forkDigestContext.forkDigest2ForkName.returns(ForkName.phase0);
 
     const signedBlock = generateEmptySignedBlock();
-    topicString = getGossipTopicString(forkDigestContext, {type: GossipType.beacon_block, fork: ForkName.phase0});
+    topicString = stringifyGossipTopic(forkDigestContext, {type: GossipType.beacon_block, fork: ForkName.phase0});
     message = {
       data: encodeMessageData(GossipEncoding.ssz_snappy, config.types.phase0.SignedBeaconBlock.serialize(signedBlock)),
       receivedFrom: "0",

--- a/packages/lodestar/test/unit/network/gossip/handler.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/handler.test.ts
@@ -7,7 +7,7 @@ import {BeaconChain, ChainEventEmitter, IBeaconChain} from "../../../../src/chai
 import {INetwork, Network} from "../../../../src/network";
 import {
   Eth2Gossipsub,
-  getGossipTopicString,
+  stringifyGossipTopic,
   GossipEncoding,
   GossipType,
   encodeMessageData,
@@ -94,7 +94,7 @@ describe("gossip handler", function () {
     await gossipsub._processRpcMessage({
       data: encodeMessageData(GossipEncoding.ssz_snappy, SignedBeaconBlock.serialize(SignedBeaconBlock.defaultValue())),
       receivedFrom: "foo",
-      topicIDs: [getGossipTopicString(forkDigestContext, {type: GossipType.beacon_block, fork})],
+      topicIDs: [stringifyGossipTopic(forkDigestContext, {type: GossipType.beacon_block, fork})],
     });
     expect(chainStub.receiveBlock.calledOnce).to.be.true;
 
@@ -104,7 +104,7 @@ describe("gossip handler", function () {
         SignedAggregateAndProof.serialize(SignedAggregateAndProof.defaultValue())
       ),
       receivedFrom: "foo",
-      topicIDs: [getGossipTopicString(forkDigestContext, {type: GossipType.beacon_aggregate_and_proof, fork})],
+      topicIDs: [stringifyGossipTopic(forkDigestContext, {type: GossipType.beacon_aggregate_and_proof, fork})],
     });
     expect(dbStub.aggregateAndProof.add.calledOnce).to.be.true;
 
@@ -114,21 +114,21 @@ describe("gossip handler", function () {
         SignedVoluntaryExit.serialize(SignedVoluntaryExit.defaultValue())
       ),
       receivedFrom: "foo",
-      topicIDs: [getGossipTopicString(forkDigestContext, {type: GossipType.voluntary_exit, fork})],
+      topicIDs: [stringifyGossipTopic(forkDigestContext, {type: GossipType.voluntary_exit, fork})],
     });
     expect(dbStub.voluntaryExit.add.calledOnce).to.be.true;
 
     await gossipsub._processRpcMessage({
       data: encodeMessageData(GossipEncoding.ssz_snappy, ProposerSlashing.serialize(ProposerSlashing.defaultValue())),
       receivedFrom: "foo",
-      topicIDs: [getGossipTopicString(forkDigestContext, {type: GossipType.proposer_slashing, fork})],
+      topicIDs: [stringifyGossipTopic(forkDigestContext, {type: GossipType.proposer_slashing, fork})],
     });
     expect(dbStub.proposerSlashing.add.calledOnce).to.be.true;
 
     await gossipsub._processRpcMessage({
       data: encodeMessageData(GossipEncoding.ssz_snappy, AttesterSlashing.serialize(AttesterSlashing.defaultValue())),
       receivedFrom: "foo",
-      topicIDs: [getGossipTopicString(forkDigestContext, {type: GossipType.attester_slashing, fork})],
+      topicIDs: [stringifyGossipTopic(forkDigestContext, {type: GossipType.attester_slashing, fork})],
     });
     expect(dbStub.attesterSlashing.add.calledOnce).to.be.true;
 

--- a/packages/lodestar/test/unit/network/gossip/topic.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/topic.test.ts
@@ -2,32 +2,47 @@ import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/mainnet";
 import {ForkName} from "@chainsafe/lodestar-config";
 import {
-  getGossipTopic,
-  getGossipTopicString,
+  parseGossipTopic,
+  stringifyGossipTopic,
   GossipType,
-  GossipTopic,
-  DEFAULT_ENCODING,
+  GossipEncoding,
+  GossipTopicMap,
 } from "../../../../src/network/gossip";
 import {ForkDigestContext} from "../../../../src/util/forkDigestContext";
 
 describe("GossipTopic", function () {
   const genesisValidatorsRoot = config.types.Root.defaultValue();
   const forkDigestContext = new ForkDigestContext(config, genesisValidatorsRoot);
+  const encoding = GossipEncoding.ssz_snappy;
 
-  const topics: GossipTopic[] = [
-    {type: GossipType.beacon_block, fork: ForkName.phase0, encoding: DEFAULT_ENCODING},
-    {type: GossipType.beacon_aggregate_and_proof, fork: ForkName.phase0, encoding: DEFAULT_ENCODING},
-    {type: GossipType.beacon_attestation, fork: ForkName.phase0, subnet: 5, encoding: DEFAULT_ENCODING},
-    {type: GossipType.voluntary_exit, fork: ForkName.phase0, encoding: DEFAULT_ENCODING},
-    {type: GossipType.proposer_slashing, fork: ForkName.phase0, encoding: DEFAULT_ENCODING},
-    {type: GossipType.attester_slashing, fork: ForkName.phase0, encoding: DEFAULT_ENCODING},
-  ];
-  for (const topic of topics) {
-    it(`should round trip encode/decode gossip topic ${topic.type} ${topic.fork} ${topic.encoding}`, async () => {
-      const topicString = getGossipTopicString(forkDigestContext, topic);
-      const outputTopic = getGossipTopic(forkDigestContext, topicString);
-      expect(outputTopic).to.deep.equal(topic);
-    });
+  // Enforce with Typescript that we test all GossipType
+  const testCases: {[K in GossipType]: GossipTopicMap[K][]} = {
+    [GossipType.beacon_block]: [{type: GossipType.beacon_block, fork: ForkName.phase0, encoding}],
+    [GossipType.beacon_aggregate_and_proof]: [
+      {type: GossipType.beacon_aggregate_and_proof, fork: ForkName.phase0, encoding},
+    ],
+    [GossipType.beacon_attestation]: [
+      {type: GossipType.beacon_attestation, fork: ForkName.phase0, subnet: 5, encoding},
+    ],
+    [GossipType.voluntary_exit]: [{type: GossipType.voluntary_exit, fork: ForkName.phase0, encoding}],
+    [GossipType.proposer_slashing]: [{type: GossipType.proposer_slashing, fork: ForkName.phase0, encoding}],
+    [GossipType.attester_slashing]: [{type: GossipType.attester_slashing, fork: ForkName.phase0, encoding}],
+    [GossipType.sync_committee_contribution_and_proof]: [
+      {type: GossipType.sync_committee_contribution_and_proof, fork: ForkName.phase0, encoding},
+    ],
+    [GossipType.sync_committee]: [{type: GossipType.sync_committee, fork: ForkName.phase0, subnet: 5, encoding}],
+  };
+
+  for (const topics of Object.values(testCases)) {
+    if (topics.length === 0) throw Error("Must have a least 1 testCase for each GossipType");
+
+    for (const topic of topics) {
+      it(`should round trip encode/decode gossip topic ${topic.type} ${topic.fork} ${topic.encoding}`, async () => {
+        const topicString = stringifyGossipTopic(forkDigestContext, topic);
+        const outputTopic = parseGossipTopic(forkDigestContext, topicString);
+        expect(outputTopic).to.deep.equal(topic);
+      });
+    }
   }
 
   const topicStrings: string[] = [
@@ -39,12 +54,15 @@ describe("GossipTopic", function () {
     "/eth2/18ae4ccb/beacon_attestation_foo/ssz_snappy",
     // invalid gossip type
     "/eth2/18ae4ccb/something_different/ssz_snappy",
+    "/eth2/18ae4ccb/beacon_attestation/ssz_snappy",
+    "/eth2/18ae4ccb/beacon_attestation_/ssz_snappy",
+    "/eth2/18ae4ccb/beacon_attestation_PP/ssz_snappy",
     // invalid encoding
     "/eth2/18ae4ccb/beacon_attestation_5/ssz_supersnappy",
   ];
   for (const topicString of topicStrings) {
     it(`should fail to decode invalid gossip topic string ${topicString}`, async () => {
-      expect(() => getGossipTopic(forkDigestContext, topicString), topicString).to.throw();
+      expect(() => parseGossipTopic(forkDigestContext, topicString), topicString).to.throw();
     });
   }
 });


### PR DESCRIPTION
**Motivation**

Gossip topic parser does not support altair sync committee topics.

**Description**

I've refactored the parsing functions to not use a Regex. Also now Typescript won't compile if we forget to add tests for new GossipType.

Closes https://github.com/ChainSafe/lodestar/issues/2588