### PR TITLE
List all API namespaces in CLI args

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,5 +1,5 @@
 export * as routes from "./routes";
-export {Api} from "./interface";
+export * from "./interface";
 export {getClient} from "./client";
 
 // Node: Don't export server here so it's not bundled to all consumers

--- a/packages/api/src/interface.ts
+++ b/packages/api/src/interface.ts
@@ -17,3 +17,17 @@ export type Api = {
   node: NodeApi;
   validator: ValidatorApi;
 };
+
+// Declare namespaces for CLI options
+export type ApiNamespace = keyof Api;
+const allNamespacesObj: {[K in keyof Api]: true} = {
+  beacon: true,
+  config: true,
+  debug: true,
+  events: true,
+  lightclient: true,
+  lodestar: true,
+  node: true,
+  validator: true,
+};
+export const allNamespaces = Object.keys(allNamespacesObj) as ApiNamespace[];

--- a/packages/cli/src/options/beaconNodeOptions/api.ts
+++ b/packages/cli/src/options/beaconNodeOptions/api.ts
@@ -1,4 +1,4 @@
-import {defaultOptions, IBeaconNodeOptions} from "@chainsafe/lodestar";
+import {defaultOptions, IBeaconNodeOptions, allNamespaces} from "@chainsafe/lodestar";
 import {ICliCommandOptions} from "../../util";
 
 export interface IApiArgs {
@@ -24,7 +24,7 @@ export function parseArgs(args: IApiArgs): IBeaconNodeOptions["api"] {
 export const options: ICliCommandOptions<IApiArgs> = {
   "api.rest.api": {
     type: "array",
-    choices: ["beacon", "config", "validator", "node", "events", "debug", "lodestar"],
+    choices: allNamespaces,
     description: "Pick namespaces to expose for HTTP API",
     defaultDescription: JSON.stringify(defaultOptions.api.rest.api),
     group: "api",

--- a/packages/lodestar/src/api/rest/index.ts
+++ b/packages/lodestar/src/api/rest/index.ts
@@ -8,6 +8,7 @@ import {ErrorAborted, ILogger} from "@chainsafe/lodestar-utils";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IMetrics} from "../../metrics";
 import {ApiError} from "../impl/errors";
+export {allNamespaces} from "@chainsafe/lodestar-api";
 
 export type RestApiOptions = {
   enabled: boolean;

--- a/packages/lodestar/src/node/options.ts
+++ b/packages/lodestar/src/node/options.ts
@@ -10,6 +10,8 @@ import {defaultLoggerOptions, IBeaconLoggerOptions} from "./loggerOptions";
 import {defaultMetricsOptions, IMetricsOptions} from "../metrics/options";
 import {defaultNetworkOptions, INetworkOptions} from "../network/options";
 import {defaultSyncOptions, ISyncOptions} from "../sync/options";
+// Re-export so the CLI doesn't need to depend on lodestar-api
+export {allNamespaces} from "../api/rest/index";
 
 export interface IBeaconNodeOptions {
   api: IApiOptions;


### PR DESCRIPTION
**Motivation**

CLI `api.rest.api` option was not in sync with new namespaces.

**Description**

This approach enforces with Typescript that all existing yargs will always be aware of all existing API namespaces.