### PR TITLE
Fix CLI dev command paths

### DIFF
--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -54,22 +54,15 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
   await db.start();
 
   let anchorState;
-  if (args.genesisValidators) {
-    anchorState = await nodeUtils.initDevState(config, db, args.genesisValidators);
-    nodeUtils.storeSSZState(config, anchorState, path.join(beaconPaths.rootDir, "dev", "genesis.ssz"));
-  } else if (args.genesisStateFile) {
-    anchorState = await initStateFromAnchorState(
-      config,
-      db,
-      logger,
-      config
-        .getForkTypes(GENESIS_SLOT)
-        .BeaconState.createTreeBackedFromBytes(
-          await fs.promises.readFile(path.join(beaconPaths.rootDir, args.genesisStateFile))
-        )
-    );
+  if (args.genesisStateFile) {
+    const state = config
+      .getForkTypes(GENESIS_SLOT)
+      .BeaconState.createTreeBackedFromBytes(await fs.promises.readFile(args.genesisStateFile));
+    anchorState = await initStateFromAnchorState(config, db, logger, state);
   } else {
-    throw new Error("Unable to start node: no available genesis state");
+    const validatorCount = args.genesisValidators || 8;
+    const genesisTime = args.genesisTime;
+    anchorState = await nodeUtils.initDevState(config, db, validatorCount, genesisTime);
   }
 
   const validators: Validator[] = [];
@@ -97,6 +90,15 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
   if (args.startValidators) {
     const secretKeys: SecretKey[] = [];
     const [fromIndex, toIndex] = args.startValidators.split(":").map((s) => parseInt(s));
+
+    if (fromIndex > toIndex) {
+      throw Error(`Invalid startValidators arg - fromIndex > toIndex: ${args.startValidators}`);
+    }
+
+    if (toIndex >= anchorState.validators.length) {
+      throw Error("Invalid startValidators arg - toIndex > state.validators.length");
+    }
+
     for (let i = fromIndex; i < toIndex; i++) {
       secretKeys.push(interopSecretKey(i));
     }

--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -56,7 +56,7 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
   let anchorState;
   if (args.genesisValidators) {
     anchorState = await nodeUtils.initDevState(config, db, args.genesisValidators);
-    nodeUtils.storeSSZState(config, anchorState, path.join(args.rootDir, "dev", "genesis.ssz"));
+    nodeUtils.storeSSZState(config, anchorState, path.join(beaconPaths.rootDir, "dev", "genesis.ssz"));
   } else if (args.genesisStateFile) {
     anchorState = await initStateFromAnchorState(
       config,
@@ -65,7 +65,7 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
       config
         .getForkTypes(GENESIS_SLOT)
         .BeaconState.createTreeBackedFromBytes(
-          await fs.promises.readFile(path.join(args.rootDir, args.genesisStateFile))
+          await fs.promises.readFile(path.join(beaconPaths.rootDir, args.genesisStateFile))
         )
     );
   } else {

--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -116,7 +116,13 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
     onGracefulShutdownCbs.push(async () => controller.abort());
 
     // Initailize genesis once for all validators
-    const validator = await Validator.initializeFromBeaconNode({config, slashingProtection, api, logger, secretKeys});
+    const validator = await Validator.initializeFromBeaconNode({
+      config,
+      slashingProtection,
+      api,
+      logger: logger.child({module: "vali"}),
+      secretKeys,
+    });
 
     onGracefulShutdownCbs.push(() => validator.stop());
     await validator.start();

--- a/packages/cli/src/cmds/dev/options.ts
+++ b/packages/cli/src/cmds/dev/options.ts
@@ -6,6 +6,7 @@ import {globalOptions, beaconNodeOptions} from "../../options";
 interface IDevOwnArgs {
   genesisValidators?: number;
   startValidators?: string;
+  genesisTime?: number;
   reset?: boolean;
   server: string;
 }
@@ -22,6 +23,12 @@ const devOwnOptions: ICliCommandOptions<IDevOwnArgs> = {
     description: "Start interop validators in given range",
     default: "0:8",
     type: "string",
+    group: "dev",
+  },
+
+  genesisTime: {
+    description: "genesis_time to initialize interop genesis state",
+    type: "number",
     group: "dev",
   },
 


### PR DESCRIPTION
**Motivation**

Fix a bug in CLI dev args usage, where it's not using the parsed beaconPaths but args.rootDir directory. If the option is not used it will throw since the default is not applied at the yargs level.

**Description**

Improve CLI dev command args. Add extra sanity checks.