### PR TITLE
Prevent aggregating same signature twice

### DIFF
--- a/packages/lodestar/src/db/syncCommittee.ts
+++ b/packages/lodestar/src/db/syncCommittee.ts
@@ -140,6 +140,12 @@ function aggregateSignatureInto(
   signature: altair.SyncCommitteeSignature,
   indexInSubCommittee: number
 ): void {
+  if (contribution.aggregationBits[indexInSubCommittee] === true) {
+    throw Error(
+      `Already aggregated SyncCommitteeSignature - subCommitteeIndex=${contribution.subCommitteeIndex} indexInSubCommittee=${indexInSubCommittee}`
+    );
+  }
+
   contribution.aggregationBits[indexInSubCommittee] = true;
 
   contribution.signature = Signature.aggregate([

--- a/packages/lodestar/src/db/syncCommitteeContribution.ts
+++ b/packages/lodestar/src/db/syncCommitteeContribution.ts
@@ -128,7 +128,12 @@ function aggregateContributionInto(
 
   for (const [index, participated] of Array.from(readonlyValues(contribution.aggregationBits)).entries()) {
     if (participated) {
-      aggregate.syncCommitteeBits[indexOffset + index] = true;
+      const syncCommitteeIndex = indexOffset + index;
+      if (aggregate.syncCommitteeBits[syncCommitteeIndex] === true) {
+        throw Error(`Already aggregated SyncCommitteeContribution - syncCommitteeIndex=${syncCommitteeIndex}`);
+      }
+
+      aggregate.syncCommitteeBits[syncCommitteeIndex] = true;
     }
   }
 


### PR DESCRIPTION
**Motivation**

The SyncCommittee objects cache accepted a signature for the same bit multiple times. The code is roughly
```ts
function aggregateInto(index, sig) {
  bits[index] = true;
  aggSig.aggregate(sig);
}
```

If a signature is submitted twice for the same index, it will be aggregated twice breaking its validation. The signature will now be:
```
AggSig = 2 * sig1 + sign ...
```

**Description**

Throw error when attempting to aggregate twice for the same bit.

----

Note: Submitting the same object multiple times happens when running a dev chain with a very low number of validators.