### PR TITLE
Handle multiple errors in APi routes

### DIFF
--- a/packages/lodestar/src/api/impl/beacon/index.ts
+++ b/packages/lodestar/src/api/impl/beacon/index.ts
@@ -5,7 +5,9 @@ import {getBeaconBlockApi} from "./blocks";
 import {getBeaconPoolApi} from "./pool";
 import {getBeaconStateApi} from "./state";
 
-export function getBeaconApi(modules: Pick<ApiModules, "chain" | "config" | "network" | "db">): routes.beacon.Api {
+export function getBeaconApi(
+  modules: Pick<ApiModules, "chain" | "config" | "logger" | "network" | "db">
+): routes.beacon.Api {
   const block = getBeaconBlockApi(modules);
   const pool = getBeaconPoolApi(modules);
   const state = getBeaconStateApi(modules);

--- a/packages/lodestar/src/api/impl/beacon/pool/index.ts
+++ b/packages/lodestar/src/api/impl/beacon/pool/index.ts
@@ -14,9 +14,10 @@ import {ApiModules} from "../../types";
 export function getBeaconPoolApi({
   chain,
   config,
+  logger,
   network,
   db,
-}: Pick<ApiModules, "chain" | "config" | "network" | "db">): IBeaconPoolApi {
+}: Pick<ApiModules, "chain" | "config" | "logger" | "network" | "db">): IBeaconPoolApi {
   return {
     async getPoolAttestations(filters) {
       const attestations = (await db.attestation.values()).filter((attestation) => {
@@ -45,27 +46,42 @@ export function getBeaconPoolApi({
     },
 
     async submitPoolAttestations(attestations) {
-      for (const attestation of attestations) {
-        const attestationJob = {
-          attestation,
-          validSignature: false,
-        } as IAttestationJob;
-        let attestationTargetState;
-        try {
-          attestationTargetState = await chain.regen.getCheckpointState(attestation.data.target);
-        } catch (e) {
-          throw new AttestationError({
-            code: AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE,
-            error: e as Error,
-            job: attestationJob,
-          });
-        }
-        const subnet = allForks.computeSubnetForAttestation(config, attestationTargetState.epochCtx, attestation);
-        await validateGossipAttestation(config, chain, db, attestationJob, subnet);
-        await Promise.all([
-          network.gossip.publishBeaconAttestation(attestation, subnet),
-          db.attestation.add(attestation),
-        ]);
+      const errors: Error[] = [];
+
+      await Promise.all(
+        attestations.map(async (attestation, i) => {
+          try {
+            const attestationJob = {attestation, validSignature: false} as IAttestationJob;
+
+            const attestationTargetState = await chain.regen.getCheckpointState(attestation.data.target).catch((e) => {
+              throw new AttestationError({
+                code: AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE,
+                error: e as Error,
+                job: attestationJob,
+              });
+            });
+
+            const subnet = allForks.computeSubnetForAttestation(config, attestationTargetState.epochCtx, attestation);
+            await validateGossipAttestation(config, chain, db, attestationJob, subnet);
+            await Promise.all([
+              network.gossip.publishBeaconAttestation(attestation, subnet),
+              db.attestation.add(attestation),
+            ]);
+          } catch (e) {
+            errors.push(e);
+            logger.error(
+              `Error on submitPoolAttestations [${i}]`,
+              {slot: attestation.data.slot, index: attestation.data.index},
+              e
+            );
+          }
+        })
+      );
+
+      if (errors.length > 1) {
+        throw Error("Multiple errors on submitPoolAttestations\n" + errors.map((e) => e.message).join("\n"));
+      } else if (errors.length === 1) {
+        throw errors[0];
       }
     },
 
@@ -107,28 +123,45 @@ export function getBeaconPoolApi({
       // TODO: Cache this value
       const SYNC_COMMITTEE_SUBNET_SIZE = Math.floor(config.params.SYNC_COMMITTEE_SIZE / SYNC_COMMITTEE_SUBNET_COUNT);
 
+      const errors: Error[] = [];
+
       await Promise.all(
-        signatures.map(async (signature) => {
-          const indexesInCommittee = state.currSyncComitteeValidatorIndexMap.get(signature.validatorIndex);
-          if (indexesInCommittee === undefined || indexesInCommittee.length === 0) {
-            return; // Not a sync committee member
+        signatures.map(async (signature, i) => {
+          try {
+            const indexesInCommittee = state.currSyncComitteeValidatorIndexMap.get(signature.validatorIndex);
+            if (indexesInCommittee === undefined || indexesInCommittee.length === 0) {
+              return; // Not a sync committee member
+            }
+
+            // Verify signature only, all other data is very likely to be correct, since the `signature` object is created by this node.
+            // Worst case if `signature` is not valid, gossip peers will drop it and slightly downscore us.
+            await validateSyncCommitteeSigOnly(chain, state, signature);
+
+            await Promise.all(
+              indexesInCommittee.map(async (indexInCommittee) => {
+                // Sync committee subnet members are just sequential in the order they appear in SyncCommitteeIndexes array
+                const subnet = Math.floor(indexInCommittee / SYNC_COMMITTEE_SUBNET_SIZE);
+                const indexInSubCommittee = indexInCommittee % SYNC_COMMITTEE_SUBNET_SIZE;
+                db.syncCommittee.add(subnet, signature, indexInSubCommittee);
+                await network.gossip.publishSyncCommitteeSignature(signature, subnet);
+              })
+            );
+          } catch (e) {
+            errors.push(e);
+            logger.error(
+              `Error on submitPoolSyncCommitteeSignatures [${i}]`,
+              {slot: signature.slot, validatorIndex: signature.validatorIndex},
+              e
+            );
           }
-
-          // Verify signature only, all other data is very likely to be correct, since the `signature` object is created by this node.
-          // Worst case if `signature` is not valid, gossip peers will drop it and slightly downscore us.
-          await validateSyncCommitteeSigOnly(chain, state, signature);
-
-          await Promise.all(
-            indexesInCommittee.map(async (indexInCommittee) => {
-              // Sync committee subnet members are just sequential in the order they appear in SyncCommitteeIndexes array
-              const subnet = Math.floor(indexInCommittee / SYNC_COMMITTEE_SUBNET_SIZE);
-              const indexInSubCommittee = indexInCommittee % SYNC_COMMITTEE_SUBNET_SIZE;
-              db.syncCommittee.add(subnet, signature, indexInSubCommittee);
-              await network.gossip.publishSyncCommitteeSignature(signature, subnet);
-            })
-          );
         })
       );
+
+      if (errors.length > 1) {
+        throw Error("Multiple errors on publishAggregateAndProofs\n" + errors.map((e) => e.message).join("\n"));
+      } else if (errors.length === 1) {
+        throw errors[0];
+      }
     },
   };
 }

--- a/packages/lodestar/test/unit/api/impl/beacon/beacon.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/beacon.test.ts
@@ -5,8 +5,10 @@ import {StubbedBeaconDb} from "../../../../utils/stub";
 import {config} from "@chainsafe/lodestar-config/minimal";
 import {expect} from "chai";
 import {setupApiImplTestServer, ApiImplTestModules} from "../index.test";
+import {testLogger} from "../../../../utils/logger";
 
 describe("beacon api implementation", function () {
+  const logger = testLogger();
   let dbStub: StubbedBeaconDb;
   let server: ApiImplTestModules;
 
@@ -21,6 +23,7 @@ describe("beacon api implementation", function () {
         config,
         chain: server.chainStub,
         db: dbStub,
+        logger,
         network: server.networkStub,
       });
 

--- a/packages/lodestar/test/unit/api/impl/beacon/pool/pool.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/pool/pool.test.ts
@@ -21,8 +21,10 @@ import {Eth2Gossipsub} from "../../../../../../src/network/gossip";
 import {generateEmptySignedBlockHeader} from "../../../../../utils/block";
 import {setupApiImplTestServer} from "../../index.test";
 import {SinonStubFn} from "../../../../../utils/types";
+import {testLogger} from "../../../../../utils/logger";
 
 describe("beacon pool api impl", function () {
+  const logger = testLogger();
   let poolApi: ReturnType<typeof getBeaconPoolApi>;
   let dbStub: StubbedBeaconDb;
   let chainStub: SinonStubbedInstance<IBeaconChain>;
@@ -45,6 +47,7 @@ describe("beacon pool api impl", function () {
     poolApi = getBeaconPoolApi({
       config,
       db: server.dbStub,
+      logger,
       network: networkStub,
       chain: chainStub,
     });


### PR DESCRIPTION
**Motivation**

See https://github.com/ChainSafe/lodestar/issues/2593. If more than one error is thrown in routes accepting an array of objects no one will ever see those errors. The logger is at the API handler level so both the node and validator will only log the first error.

**Description**

Log all errors in the node's side. Then return the errors concatenated to the validator client.

Closes https://github.com/ChainSafe/lodestar/issues/2593