### PR TITLE
file read write fixes

### DIFF
--- a/packages/cli/src/config/fileEnr.ts
+++ b/packages/cli/src/config/fileEnr.ts
@@ -1,5 +1,5 @@
 import {createKeypairFromPeerId, ENR, ENRKey, ENRValue} from "@chainsafe/discv5";
-import {writeFileSync, readFileSync} from "fs";
+import {writeFile, readFile} from "../util";
 import PeerId from "peer-id";
 
 /**
@@ -24,7 +24,7 @@ export class FileENR extends ENR {
   }
 
   static initFromFile(filename: string, peerId: PeerId): FileENR {
-    const enr = FileENR.decodeTxt(readFileSync(filename, "utf8")) as FileENR;
+    const enr = FileENR.decodeTxt(readFile(filename)) as FileENR;
     return this.initFromENR(filename, peerId, enr);
   }
   static initFromENR(filename: string, peerId: PeerId, enr: ENR): FileENR {
@@ -38,7 +38,7 @@ export class FileENR extends ENR {
   saveToFile(): void {
     if (!this.localPeerId) return;
     const keypair = createKeypairFromPeerId(this.localPeerId);
-    writeFileSync(this.filename, this.encodeTxt(keypair.privateKey));
+    writeFile(this.filename, this.encodeTxt(keypair.privateKey));
   }
 
   set(key: ENRKey, value: ENRValue): this {

--- a/packages/cli/src/util/file.ts
+++ b/packages/cli/src/util/file.ts
@@ -44,7 +44,7 @@ export function parse<T = Json>(contents: string, fileFormat: FileFormat): T {
     case FileFormat.yml:
       return load(contents, {schema: yamlSchema}) as T;
     default:
-      throw new Error("Invalid filetype");
+      return (contents as unknown) as T;
   }
 }
 
@@ -62,7 +62,7 @@ export function stringify<T = Json>(obj: T, fileFormat: FileFormat): string {
       contents = dump(obj, {schema: yamlSchema});
       break;
     default:
-      throw new Error("Invalid filetype");
+      contents = (obj as unknown) as string;
   }
   return contents;
 }


### PR DESCRIPTION
**Motivation**

this is to fix reading a file when fileformat is not identifiable as yaml, yml or json. this fixes the reading of the enr from already saved enr file as earlier that was breaking.

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #2561 

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
