### PR TITLE
Ignore aggregate already known errors in API

### DIFF
--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -21,6 +21,7 @@ import {SyncState} from "../../../sync";
 import {toGraffitiBuffer} from "../../../util/graffiti";
 import {ApiError} from "../errors";
 import {validateSyncCommitteeGossipContributionAndProof} from "../../../chain/validation/syncCommitteeContributionAndProof";
+import {SyncContributionError, SyncContributionErrorCode} from "../../../db/syncCommitteeContribution";
 import {CommitteeSubscription} from "../../../network/subnets";
 import {getSyncComitteeValidatorIndexMap} from "./utils";
 import {ApiModules} from "../types";
@@ -397,6 +398,11 @@ export function getValidatorApi({
             db.syncCommitteeContribution.add(contributionAndProof.message);
             await network.gossip.publishContributionAndProof(contributionAndProof);
           } catch (e) {
+            if (e instanceof SyncContributionError && e.type.code === SyncContributionErrorCode.ALREADY_KNOWN) {
+              logger.debug("Ignoring known contributionAndProof");
+              return; // Ok to submit the same aggregate twice
+            }
+
             errors.push(e);
             logger.error(
               `Error on publishContributionAndProofs [${i}]`,

--- a/packages/lodestar/src/db/syncCommitteeContribution.ts
+++ b/packages/lodestar/src/db/syncCommitteeContribution.ts
@@ -4,6 +4,7 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {phase0, altair, Slot} from "@chainsafe/lodestar-types";
 import {newFilledArray} from "@chainsafe/lodestar-beacon-state-transition";
 import {readonlyValues, toHexString} from "@chainsafe/ssz";
+import {LodestarError} from "@chainsafe/lodestar-utils";
 
 /**
  * SyncCommittee aggregates are only useful for the next block they have signed.
@@ -115,6 +116,18 @@ export class SyncCommitteeContributionCache {
   }
 }
 
+export enum SyncContributionErrorCode {
+  ALREADY_KNOWN = "SYNC_COMMITTEE_CONTRIBUTION_ERROR_ALREADY_KNOWN",
+}
+
+type SyncContributionErrorType = {
+  code: SyncContributionErrorCode.ALREADY_KNOWN;
+  syncCommitteeIndex: number;
+  slot: Slot;
+};
+
+export class SyncContributionError extends LodestarError<SyncContributionErrorType> {}
+
 /**
  * Aggregate a new contribution into `aggregate` mutating it
  */
@@ -130,7 +143,11 @@ function aggregateContributionInto(
     if (participated) {
       const syncCommitteeIndex = indexOffset + index;
       if (aggregate.syncCommitteeBits[syncCommitteeIndex] === true) {
-        throw Error(`Already aggregated SyncCommitteeContribution - syncCommitteeIndex=${syncCommitteeIndex}`);
+        throw new SyncContributionError({
+          code: SyncContributionErrorCode.ALREADY_KNOWN,
+          syncCommitteeIndex,
+          slot: contribution.slot,
+        });
       }
 
       aggregate.syncCommitteeBits[syncCommitteeIndex] = true;


### PR DESCRIPTION
**Motivation**

Submitting known aggregates should not return a 500 error code in the API. It is possible that multiple aggregators are connected to the same beacon node.

**Description**

Ignore aggregate already known errors and return 200 code.

Closes https://github.com/ChainSafe/lodestar/issues/2579
Closes https://github.com/ChainSafe/lodestar/issues/2597

---

Merge after https://github.com/ChainSafe/lodestar/pull/2595