### PR TITLE
Review gossip validation

### DIFF
--- a/packages/lodestar/src/chain/errors/attestationError.ts
+++ b/packages/lodestar/src/chain/errors/attestationError.ts
@@ -1,7 +1,7 @@
 import {CommitteeIndex, Epoch, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {LodestarError} from "@chainsafe/lodestar-utils";
-
 import {IAttestationJob} from "../interface";
+import {GossipAction} from "./gossipValidation";
 
 export enum AttestationErrorCode {
   /**
@@ -176,5 +176,13 @@ export class AttestationError extends LodestarError<AttestationErrorType> {
   constructor({job, ...type}: AttestationErrorType & IJobObject) {
     super(type);
     this.job = job;
+  }
+}
+
+export class AttestationGossipError extends AttestationError {
+  action: GossipAction;
+  constructor(action: GossipAction, jobAndType: AttestationErrorType & IJobObject) {
+    super(jobAndType);
+    this.action = action;
   }
 }

--- a/packages/lodestar/src/chain/errors/attesterSlashingError.ts
+++ b/packages/lodestar/src/chain/errors/attesterSlashingError.ts
@@ -1,4 +1,4 @@
-import {LodestarError} from "@chainsafe/lodestar-utils";
+import {GossipValidationError} from "./gossipValidation";
 
 export enum AttesterSlashingErrorCode {
   SLASHING_ALREADY_EXISTS = "ATTESTATION_SLASHING_ERROR_SLASHING_ALREADY_EXISTS",
@@ -8,8 +8,4 @@ export type AttesterSlashingErrorType =
   | {code: AttesterSlashingErrorCode.SLASHING_ALREADY_EXISTS}
   | {code: AttesterSlashingErrorCode.INVALID_SLASHING};
 
-export class AttesterSlashingError extends LodestarError<AttesterSlashingErrorType> {
-  constructor(type: AttesterSlashingErrorType) {
-    super(type);
-  }
-}
+export class AttesterSlashingError extends GossipValidationError<AttesterSlashingErrorType> {}

--- a/packages/lodestar/src/chain/errors/blockError.ts
+++ b/packages/lodestar/src/chain/errors/blockError.ts
@@ -2,6 +2,7 @@ import {Root, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {LodestarError} from "@chainsafe/lodestar-utils";
 
 import {IBlockJob, IChainSegmentJob} from "../interface";
+import {GossipAction} from "./gossipValidation";
 
 export enum BlockErrorCode {
   /**
@@ -114,6 +115,14 @@ export class BlockError extends LodestarError<BlockErrorType> {
   constructor({job, ...type}: BlockErrorType & BlockJobObject) {
     super(type);
     this.job = job;
+  }
+}
+
+export class BlockGossipError extends BlockError {
+  action: GossipAction;
+  constructor(action: GossipAction, jobAndType: BlockErrorType & BlockJobObject) {
+    super(jobAndType);
+    this.action = action;
   }
 }
 

--- a/packages/lodestar/src/chain/errors/proposerSlashingError.ts
+++ b/packages/lodestar/src/chain/errors/proposerSlashingError.ts
@@ -1,4 +1,4 @@
-import {LodestarError} from "@chainsafe/lodestar-utils";
+import {GossipValidationError} from "./gossipValidation";
 
 export enum ProposerSlashingErrorCode {
   SLASHING_ALREADY_EXISTS = "PROPOSER_SLASHING_ERROR_SLASHING_ALREADY_EXISTS",
@@ -8,8 +8,4 @@ export type ProposerSlashingErrorType =
   | {code: ProposerSlashingErrorCode.SLASHING_ALREADY_EXISTS}
   | {code: ProposerSlashingErrorCode.INVALID_SLASHING};
 
-export class ProposerSlashingError extends LodestarError<ProposerSlashingErrorType> {
-  constructor(type: ProposerSlashingErrorType) {
-    super(type);
-  }
-}
+export class ProposerSlashingError extends GossipValidationError<ProposerSlashingErrorType> {}

--- a/packages/lodestar/src/chain/errors/syncCommitteeError.ts
+++ b/packages/lodestar/src/chain/errors/syncCommitteeError.ts
@@ -1,5 +1,5 @@
 import {altair, phase0, Slot} from "@chainsafe/lodestar-types";
-import {GossipAction, GossipValidationError} from "./gossipValidation";
+import {GossipValidationError} from "./gossipValidation";
 
 export enum SyncCommitteeErrorCode {
   NOT_CURRENT_SLOT = "SYNC_COMMITTEE_ERROR_NOT_CURRENT_SLOT",
@@ -31,11 +31,4 @@ export interface IContributionAndProofJob {
   validSignature: boolean;
 }
 
-export class SyncCommitteeError extends GossipValidationError<SyncCommitteeErrorType> {
-  action: GossipAction;
-
-  constructor(action: GossipAction, type: SyncCommitteeErrorType) {
-    super(action, type);
-    this.action = action;
-  }
-}
+export class SyncCommitteeError extends GossipValidationError<SyncCommitteeErrorType> {}

--- a/packages/lodestar/src/chain/errors/voluntaryExitError.ts
+++ b/packages/lodestar/src/chain/errors/voluntaryExitError.ts
@@ -1,4 +1,4 @@
-import {LodestarError} from "@chainsafe/lodestar-utils";
+import {GossipValidationError} from "./gossipValidation";
 
 export enum VoluntaryExitErrorCode {
   EXIT_ALREADY_EXISTS = "VOLUNTARY_EXIT_ERROR_EXIT_ALREADY_EXISTS",
@@ -8,8 +8,4 @@ export type VoluntaryExitErrorType =
   | {code: VoluntaryExitErrorCode.EXIT_ALREADY_EXISTS}
   | {code: VoluntaryExitErrorCode.INVALID_EXIT};
 
-export class VoluntaryExitError extends LodestarError<VoluntaryExitErrorType> {
-  constructor(type: VoluntaryExitErrorType) {
-    super(type);
-  }
-}
+export class VoluntaryExitError extends GossipValidationError<VoluntaryExitErrorType> {}

--- a/packages/lodestar/src/chain/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/aggregateAndProof.ts
@@ -5,13 +5,11 @@ import {IBeaconDb} from "../../db";
 import {
   phase0,
   allForks,
-  CachedBeaconState,
   computeEpochAtSlot,
   isAggregatorFromCommitteeLength,
 } from "@chainsafe/lodestar-beacon-state-transition";
-import {isAttestingToInValidBlock} from "./attestation";
 import {getSelectionProofSignatureSet, getAggregateAndProofSignatureSet} from "./signatureSets";
-import {AttestationError, AttestationErrorCode} from "../errors";
+import {AttestationGossipError, AttestationErrorCode, GossipAction} from "../errors";
 import {ATTESTATION_PROPAGATION_SLOT_RANGE} from "../../constants";
 
 export async function validateGossipAggregateAndProof(
@@ -24,21 +22,35 @@ export async function validateGossipAggregateAndProof(
   const aggregateAndProof = signedAggregateAndProof.message;
   const aggregate = aggregateAndProof.aggregate;
 
+  // the target state, advanced to the attestation slot
+  const attestationTargetState = await chain.regen.getCheckpointState(aggregate.data.target).catch((e) => {
+    throw new AttestationGossipError(GossipAction.IGNORE, {
+      code: AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE,
+      error: e as Error,
+      job: attestationJob,
+    });
+  });
+
+  // Note: no need to verify isValidIndexedAttestation(), we just created the indexedAttestation here
+  const indexedAttestation = attestationTargetState.getIndexedAttestation(aggregate);
+
+  // [IGNORE] aggregate.data.slot is within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots
+  // (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
+  // -- i.e. aggregate.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= aggregate.data.slot
+  // (a client MAY queue future aggregates for processing at the appropriate slot).
   const latestPermissibleSlot = chain.clock.currentSlot;
   const earliestPermissibleSlot = chain.clock.currentSlot - ATTESTATION_PROPAGATION_SLOT_RANGE;
   const attestationSlot = aggregate.data.slot;
-
   if (attestationSlot < earliestPermissibleSlot) {
-    throw new AttestationError({
+    throw new AttestationGossipError(GossipAction.IGNORE, {
       code: AttestationErrorCode.PAST_SLOT,
       earliestPermissibleSlot,
       attestationSlot,
       job: attestationJob,
     });
   }
-
   if (attestationSlot > latestPermissibleSlot) {
-    throw new AttestationError({
+    throw new AttestationGossipError(GossipAction.IGNORE, {
       code: AttestationErrorCode.FUTURE_SLOT,
       attestationSlot,
       latestPermissibleSlot,
@@ -46,104 +58,88 @@ export async function validateGossipAggregateAndProof(
     });
   }
 
+  // [REJECT] The aggregate attestation's epoch matches its target
+  // -- i.e. aggregate.data.target.epoch == compute_epoch_at_slot(aggregate.data.slot)
+
+  // [IGNORE] The aggregate is the first valid aggregate received for the aggregator with
+  // index aggregate_and_proof.aggregator_index for the epoch aggregate.data.target.epoch.
   if (db.seenAttestationCache.hasAggregateAndProof(aggregateAndProof)) {
-    throw new AttestationError({
+    throw new AttestationGossipError(GossipAction.REJECT, {
       code: AttestationErrorCode.AGGREGATE_ALREADY_KNOWN,
       job: attestationJob,
     });
   }
 
-  if (!hasAttestationParticipants(aggregate)) {
+  // [REJECT] The attestation has participants -- that is,
+  // len(get_attesting_indices(state, aggregate.data, aggregate.aggregation_bits)) >= 1.
+  if (indexedAttestation.attestingIndices.length < 1) {
     // missing attestation participants
-    throw new AttestationError({
+    throw new AttestationGossipError(GossipAction.REJECT, {
       code: AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS,
-      job: attestationJob,
-    });
-  }
-
-  if (await isAttestingToInValidBlock(db, aggregate)) {
-    throw new AttestationError({
-      code: AttestationErrorCode.KNOWN_BAD_BLOCK,
-      job: attestationJob,
-    });
-  }
-
-  await validateAggregateAttestation(config, chain, signedAggregateAndProof, attestationJob);
-}
-
-export function hasAttestationParticipants(attestation: phase0.Attestation): boolean {
-  return Array.from(attestation.aggregationBits).filter((bit) => !!bit).length >= 1;
-}
-
-export async function validateAggregateAttestation(
-  config: IBeaconConfig,
-  chain: IBeaconChain,
-  aggregateAndProof: phase0.SignedAggregateAndProof,
-  attestationJob: IAttestationJob
-): Promise<void> {
-  const attestation = aggregateAndProof.message.aggregate;
-
-  let attestationTargetState: CachedBeaconState<allForks.BeaconState>;
-  try {
-    // the target state, advanced to the attestation slot
-    attestationTargetState = await chain.regen.getCheckpointState(attestation.data.target);
-  } catch (e) {
-    throw new AttestationError({
-      code: AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE,
-      error: e as Error,
       job: attestationJob,
     });
   }
 
   let committee: ValidatorIndex[];
   try {
-    committee = attestationTargetState.getBeaconCommittee(attestation.data.slot, attestation.data.index);
+    committee = attestationTargetState.getBeaconCommittee(aggregate.data.slot, aggregate.data.index);
   } catch (error) {
-    throw new AttestationError({
+    throw new AttestationGossipError(GossipAction.REJECT, {
       code: AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE,
       job: attestationJob,
     });
   }
 
-  if (!committee.includes(aggregateAndProof.message.aggregatorIndex)) {
-    throw new AttestationError({
-      code: AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE,
-      job: attestationJob,
-    });
-  }
-
-  if (!isAggregatorFromCommitteeLength(config, committee.length, aggregateAndProof.message.selectionProof)) {
-    throw new AttestationError({
+  // [REJECT] aggregate_and_proof.selection_proof selects the validator as an aggregator for the slot
+  // -- i.e. is_aggregator(state, aggregate.data.slot, aggregate.data.index, aggregate_and_proof.selection_proof) returns True.
+  if (!isAggregatorFromCommitteeLength(config, committee.length, aggregateAndProof.selectionProof)) {
+    throw new AttestationGossipError(GossipAction.REJECT, {
       code: AttestationErrorCode.INVALID_AGGREGATOR,
       job: attestationJob,
     });
   }
 
-  const slot = attestation.data.slot;
-  const epoch = computeEpochAtSlot(config, slot);
-  const indexedAttestation = attestationTargetState.getIndexedAttestation(attestation);
-  const aggregator = attestationTargetState.index2pubkey[aggregateAndProof.message.aggregatorIndex];
+  // [REJECT] The aggregator's validator index is within the committee
+  // -- i.e. aggregate_and_proof.aggregator_index in get_beacon_committee(state, aggregate.data.slot, aggregate.data.index).
+  if (!committee.includes(aggregateAndProof.aggregatorIndex)) {
+    throw new AttestationGossipError(GossipAction.REJECT, {
+      code: AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE,
+      job: attestationJob,
+    });
+  }
 
+  // [IGNORE] The block being voted for (aggregate.data.beacon_block_root) has been seen
+  // (via both gossip and non-gossip sources) (a client MAY queue aggregates for processing once block is retrieved).
+
+  // [REJECT] The block being voted for (aggregate.data.beacon_block_root) passes validation.
+  if (await db.badBlock.has(aggregate.data.beaconBlockRoot.valueOf() as Uint8Array)) {
+    throw new AttestationGossipError(GossipAction.REJECT, {
+      code: AttestationErrorCode.KNOWN_BAD_BLOCK,
+      job: attestationJob,
+    });
+  }
+
+  // [REJECT] The current finalized_checkpoint is an ancestor of the block defined by aggregate.data.beacon_block_root
+  // -- i.e. get_ancestor(store, aggregate.data.beacon_block_root, compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)) == store.finalized_checkpoint.root
+
+  // [REJECT] The aggregate_and_proof.selection_proof is a valid signature of the aggregate.data.slot
+  // by the validator with index aggregate_and_proof.aggregator_index.
+  // [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
+  // [REJECT] The signature of aggregate is valid.
+  const slot = aggregate.data.slot;
+  const epoch = computeEpochAtSlot(config, slot);
+  const aggregator = attestationTargetState.index2pubkey[aggregateAndProof.aggregatorIndex];
   const signatureSets = [
-    getSelectionProofSignatureSet(config, attestationTargetState, slot, aggregator, aggregateAndProof),
-    getAggregateAndProofSignatureSet(config, attestationTargetState, epoch, aggregator, aggregateAndProof),
+    getSelectionProofSignatureSet(config, attestationTargetState, slot, aggregator, signedAggregateAndProof),
+    getAggregateAndProofSignatureSet(config, attestationTargetState, epoch, aggregator, signedAggregateAndProof),
     allForks.getIndexedAttestationSignatureSet(attestationTargetState, indexedAttestation),
   ];
-
   if (!(await chain.bls.verifySignatureSets(signatureSets))) {
-    throw new AttestationError({
+    throw new AttestationGossipError(GossipAction.REJECT, {
       code: AttestationErrorCode.INVALID_SIGNATURE,
       job: attestationJob,
     });
   }
 
   // TODO: once we have pool, check if aggregate block is seen and has target as ancestor
-
-  // verifySignature = false, verified in batch above
-  if (!phase0.isValidIndexedAttestation(attestationTargetState, indexedAttestation, false)) {
-    throw new AttestationError({
-      code: AttestationErrorCode.INVALID_INDEXED_ATTESTATION,
-      job: attestationJob,
-    });
-  }
 }

--- a/packages/lodestar/src/chain/validation/attestation.ts
+++ b/packages/lodestar/src/chain/validation/attestation.ts
@@ -1,9 +1,9 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IBeaconDb} from "../../db";
 import {IAttestationJob, IBeaconChain} from "..";
-import {CachedBeaconState, computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
-import {allForks, phase0} from "@chainsafe/lodestar-beacon-state-transition";
-import {AttestationError, AttestationErrorCode} from "../errors";
+import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {AttestationGossipError, AttestationErrorCode, GossipAction} from "../errors";
 import {ATTESTATION_PROPAGATION_SLOT_RANGE} from "../../constants";
 
 export async function validateGossipAttestation(
@@ -14,79 +14,39 @@ export async function validateGossipAttestation(
   subnet: number
 ): Promise<void> {
   const attestation = attestationJob.attestation;
-  const numBits = getAttestationAttesterCount(attestation);
-  if (numBits !== 1) {
-    throw new AttestationError({
-      code: AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET,
-      numBits,
-      job: attestationJob,
-    });
-  }
-  if (await isAttestingToInValidBlock(db, attestation)) {
-    throw new AttestationError({
-      code: AttestationErrorCode.KNOWN_BAD_BLOCK,
-      job: attestationJob,
-    });
-  }
-  const latestPermissibleSlot = chain.clock.currentSlot;
-  const earliestPermissibleSlot = chain.clock.currentSlot - ATTESTATION_PROPAGATION_SLOT_RANGE;
-  const attestationSlot = attestation.data.slot;
-  if (attestationSlot < earliestPermissibleSlot) {
-    throw new AttestationError({
-      code: AttestationErrorCode.PAST_SLOT,
-      earliestPermissibleSlot,
-      attestationSlot,
-      job: attestationJob,
-    });
-  }
 
-  if (attestationSlot > latestPermissibleSlot) {
-    throw new AttestationError({
-      code: AttestationErrorCode.FUTURE_SLOT,
-      latestPermissibleSlot,
-      attestationSlot,
-      job: attestationJob,
-    });
-  }
-
-  // no other validator attestation for same target epoch has been seen
-  if (db.seenAttestationCache.hasCommitteeAttestation(attestation)) {
-    throw new AttestationError({
-      code: AttestationErrorCode.ATTESTATION_ALREADY_KNOWN,
-      root: config.types.phase0.Attestation.hashTreeRoot(attestation),
-      job: attestationJob,
-    });
-  }
-
-  if (await db.badBlock.has(attestation.data.beaconBlockRoot.valueOf() as Uint8Array)) {
-    throw new AttestationError({
-      code: AttestationErrorCode.KNOWN_BAD_BLOCK,
-      job: attestationJob,
-    });
-  }
-
-  if (!chain.forkChoice.hasBlock(attestation.data.beaconBlockRoot)) {
-    throw new AttestationError({
-      code: AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT,
-      beaconBlockRoot: attestation.data.beaconBlockRoot as Uint8Array,
-      job: attestationJob,
-    });
-  }
-
-  let attestationTargetState: CachedBeaconState<allForks.BeaconState>;
-  try {
-    attestationTargetState = await chain.regen.getCheckpointState(attestation.data.target);
-  } catch (e) {
-    throw new AttestationError({
+  const attestationTargetState = await chain.regen.getCheckpointState(attestation.data.target).catch((e) => {
+    throw new AttestationGossipError(GossipAction.IGNORE, {
       code: AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE,
       error: e as Error,
       job: attestationJob,
     });
+  });
+
+  // Note: no need to verify isValidIndexedAttestation(), we just created the indexedAttestation here
+  const indexedAttestation = attestationTargetState.getIndexedAttestation(attestation);
+
+  // [REJECT] The committee index is within the expected range
+  // -- i.e. data.index < get_committee_count_per_slot(state, data.target.epoch)
+  try {
+    if (attestation.data.index >= attestationTargetState.getCommitteeCountAtSlot(attestation.data.slot)) {
+      throw Error("COMMITTEE_INDEX_OUT_OF_RANGE");
+    }
+  } catch (error) {
+    throw new AttestationGossipError(GossipAction.REJECT, {
+      code: AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE,
+      index: attestation.data.index,
+      job: attestationJob,
+    });
   }
 
+  // [REJECT] The attestation is for the correct subnet
+  // -- i.e. compute_subnet_for_attestation(committees_per_slot, attestation.data.slot, attestation.data.index) == subnet_id,
+  // where committees_per_slot = get_committee_count_per_slot(state, attestation.data.target.epoch),
+  // which may be pre-computed along with the committee information for the signature check.
   const expectedSubnet = allForks.computeSubnetForAttestation(config, attestationTargetState, attestation);
   if (subnet !== expectedSubnet) {
-    throw new AttestationError({
+    throw new AttestationGossipError(GossipAction.REJECT, {
       code: AttestationErrorCode.INVALID_SUBNET_ID,
       received: subnet,
       expected: expectedSubnet,
@@ -94,96 +54,117 @@ export async function validateGossipAttestation(
     });
   }
 
-  const indexedAttestation = attestationTargetState.getIndexedAttestation(attestation);
+  // [IGNORE] attestation.data.slot is within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots (within a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
+  //  -- i.e. attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= attestation.data.slot
+  // (a client MAY queue future attestations for processing at the appropriate slot).
+  const latestPermissibleSlot = chain.clock.currentSlot;
+  const earliestPermissibleSlot = chain.clock.currentSlot - ATTESTATION_PROPAGATION_SLOT_RANGE;
+  const attestationSlot = attestation.data.slot;
+  if (attestationSlot < earliestPermissibleSlot) {
+    throw new AttestationGossipError(GossipAction.IGNORE, {
+      code: AttestationErrorCode.PAST_SLOT,
+      earliestPermissibleSlot,
+      attestationSlot,
+      job: attestationJob,
+    });
+  }
+  if (attestationSlot > latestPermissibleSlot) {
+    throw new AttestationGossipError(GossipAction.IGNORE, {
+      code: AttestationErrorCode.FUTURE_SLOT,
+      latestPermissibleSlot,
+      attestationSlot,
+      job: attestationJob,
+    });
+  }
 
-  // Do verify signature
+  // [REJECT] The attestation's epoch matches its target -- i.e. attestation.data.target.epoch == compute_epoch_at_slot(attestation.data.slot)
+  if (!config.types.Epoch.equals(attestation.data.target.epoch, computeEpochAtSlot(config, attestationSlot))) {
+    throw new AttestationGossipError(GossipAction.REJECT, {
+      code: AttestationErrorCode.BAD_TARGET_EPOCH,
+      job: attestationJob,
+    });
+  }
+
+  // [REJECT] The attestation is unaggregated -- that is, it has exactly one participating validator
+  // (len([bit for bit in attestation.aggregation_bits if bit]) == 1, i.e. exactly 1 bit is set).
+  if (indexedAttestation.attestingIndices.length !== 1) {
+    throw new AttestationGossipError(GossipAction.REJECT, {
+      code: AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET,
+      numBits: indexedAttestation.attestingIndices.length,
+      job: attestationJob,
+    });
+  }
+
+  // [REJECT] The number of aggregation bits matches the committee size
+  // -- i.e. len(attestation.aggregation_bits) == len(get_beacon_committee(state, data.slot, data.index)).
+  if (
+    attestation.aggregationBits.length !==
+    attestationTargetState.getBeaconCommittee(attestation.data.slot, attestation.data.index).length
+  ) {
+    throw new AttestationGossipError(GossipAction.REJECT, {
+      code: AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS,
+      job: attestationJob,
+    });
+  }
+
+  // [IGNORE] There has been no other valid attestation seen on an attestation subnet that has an
+  // identical attestation.data.target.epoch and participating validator index.
+  //
+  // no other validator attestation for same target epoch has been seen
+  if (db.seenAttestationCache.hasCommitteeAttestation(attestation)) {
+    throw new AttestationGossipError(GossipAction.IGNORE, {
+      code: AttestationErrorCode.ATTESTATION_ALREADY_KNOWN,
+      root: config.types.phase0.Attestation.hashTreeRoot(attestation),
+      job: attestationJob,
+    });
+  }
+
+  // [IGNORE] The block being voted for (attestation.data.beacon_block_root) has been seen (via both gossip
+  // and non-gossip sources) (a client MAY queue attestations for processing once block is retrieved).
+  if (!chain.forkChoice.hasBlock(attestation.data.beaconBlockRoot)) {
+    throw new AttestationGossipError(GossipAction.IGNORE, {
+      code: AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT,
+      beaconBlockRoot: attestation.data.beaconBlockRoot as Uint8Array,
+      job: attestationJob,
+    });
+  }
+
+  // [REJECT] The block being voted for (attestation.data.beacon_block_root) passes validation.
+  if (await db.badBlock.has(attestation.data.beaconBlockRoot.valueOf() as Uint8Array)) {
+    throw new AttestationGossipError(GossipAction.REJECT, {
+      code: AttestationErrorCode.KNOWN_BAD_BLOCK,
+      job: attestationJob,
+    });
+  }
+
+  // [REJECT] The attestation's target block is an ancestor of the block named in the LMD vote
+  //  --i.e. get_ancestor(store, attestation.data.beacon_block_root, compute_start_slot_at_epoch(attestation.data.target.epoch)) == attestation.data.target.root
+  if (!chain.forkChoice.isDescendant(attestation.data.target.root, attestation.data.beaconBlockRoot)) {
+    throw new AttestationGossipError(GossipAction.REJECT, {
+      code: AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK,
+      job: attestationJob,
+    });
+  }
+
+  // [REJECT] The current finalized_checkpoint is an ancestor of the block defined by attestation.data.beacon_block_root
+  // -- i.e. get_ancestor(store, attestation.data.beacon_block_root, compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)) == store.finalized_checkpoint.root
+  if (!chain.forkChoice.isDescendantOfFinalized(attestation.data.beaconBlockRoot)) {
+    throw new AttestationGossipError(GossipAction.REJECT, {
+      code: AttestationErrorCode.FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT,
+      job: attestationJob,
+    });
+  }
+
+  // [REJECT] The signature of attestation is valid.
   if (!attestationJob.validSignature) {
     const signatureSet = allForks.getIndexedAttestationSignatureSet(attestationTargetState, indexedAttestation);
     if (!(await chain.bls.verifySignatureSets([signatureSet]))) {
-      throw new AttestationError({
+      throw new AttestationGossipError(GossipAction.REJECT, {
         code: AttestationErrorCode.INVALID_SIGNATURE,
         job: attestationJob,
       });
     }
   }
 
-  // verifySignature = false, verified above
-  if (!phase0.isValidIndexedAttestation(attestationTargetState, indexedAttestation, false)) {
-    throw new AttestationError({
-      code: AttestationErrorCode.INVALID_INDEXED_ATTESTATION,
-      job: attestationJob,
-    });
-  }
-
-  if (!config.types.Epoch.equals(attestation.data.target.epoch, computeEpochAtSlot(config, attestationSlot))) {
-    throw new AttestationError({
-      code: AttestationErrorCode.BAD_TARGET_EPOCH,
-      job: attestationJob,
-    });
-  }
-
-  try {
-    if (!isCommitteeIndexWithinRange(attestationTargetState, attestation.data)) {
-      throw new AttestationError({
-        code: AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE,
-        index: attestation.data.index,
-        job: attestationJob,
-      });
-    }
-  } catch (error) {
-    throw new AttestationError({
-      code: AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE,
-      index: attestation.data.index,
-      job: attestationJob,
-    });
-  }
-
-  if (!doAggregationBitsMatchCommitteeSize(attestationTargetState, attestation)) {
-    throw new AttestationError({
-      code: AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS,
-      job: attestationJob,
-    });
-  }
-
-  if (!chain.forkChoice.isDescendant(attestation.data.target.root, attestation.data.beaconBlockRoot)) {
-    throw new AttestationError({
-      code: AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK,
-      job: attestationJob,
-    });
-  }
-
-  if (!chain.forkChoice.isDescendantOfFinalized(attestation.data.beaconBlockRoot)) {
-    throw new AttestationError({
-      code: AttestationErrorCode.FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT,
-      job: attestationJob,
-    });
-  }
   db.seenAttestationCache.addCommitteeAttestation(attestation);
-}
-
-export async function isAttestingToInValidBlock(db: IBeaconDb, attestation: phase0.Attestation): Promise<boolean> {
-  const blockRoot = attestation.data.beaconBlockRoot.valueOf() as Uint8Array;
-  // TODO: check if source and target blocks are not in bad block repository
-  return await db.badBlock.has(blockRoot);
-}
-
-export function getAttestationAttesterCount(attestation: phase0.Attestation): number {
-  return Array.from(attestation.aggregationBits).filter((bit) => !!bit).length;
-}
-
-export function isCommitteeIndexWithinRange(
-  epochCtx: allForks.EpochContext,
-  attestationData: phase0.AttestationData
-): boolean {
-  return attestationData.index < epochCtx.getCommitteeCountAtSlot(attestationData.slot);
-}
-
-export function doAggregationBitsMatchCommitteeSize(
-  epochCtx: allForks.EpochContext,
-  attestation: phase0.Attestation
-): boolean {
-  return (
-    attestation.aggregationBits.length ===
-    epochCtx.getBeaconCommittee(attestation.data.slot, attestation.data.index).length
-  );
 }

--- a/packages/lodestar/src/chain/validation/attesterSlashing.ts
+++ b/packages/lodestar/src/chain/validation/attesterSlashing.ts
@@ -5,6 +5,7 @@ import {IBeaconChain} from "..";
 import {AttesterSlashingError, AttesterSlashingErrorCode} from "../errors/attesterSlashingError";
 import {IBeaconDb} from "../../db";
 import {arrayIntersection, sszEqualPredicate} from "../../util/objects";
+import {GossipAction} from "../errors";
 
 export async function validateGossipAttesterSlashing(
   config: IBeaconConfig,
@@ -12,30 +13,34 @@ export async function validateGossipAttesterSlashing(
   db: IBeaconDb,
   attesterSlashing: phase0.AttesterSlashing
 ): Promise<void> {
+  // [IGNORE] At least one index in the intersection of the attesting indices of each attestation
+  // has not yet beenseen in any prior attester_slashing
+  // -- i.e. attester_slashed_indices = set(attestation_1.attesting_indices).intersection(attestation_2.attesting_indices),
+  // verify if any(attester_slashed_indices.difference(prior_seen_attester_slashed_indices))).
   const attesterSlashedIndices = arrayIntersection<ValidatorIndex>(
     attesterSlashing.attestation1.attestingIndices.valueOf() as ValidatorIndex[],
     attesterSlashing.attestation2.attestingIndices.valueOf() as ValidatorIndex[],
     sszEqualPredicate(config.types.ValidatorIndex)
   );
-
   if (await db.attesterSlashing.hasAll(attesterSlashedIndices)) {
-    throw new AttesterSlashingError({
+    throw new AttesterSlashingError(GossipAction.IGNORE, {
       code: AttesterSlashingErrorCode.SLASHING_ALREADY_EXISTS,
     });
   }
 
   const state = chain.getHeadState();
 
+  // [REJECT] All of the conditions within process_attester_slashing pass validation.
   // verifySignature = false, verified in batch below
   if (!isValidAttesterSlashing(config, state, attesterSlashing, false)) {
-    throw new AttesterSlashingError({
+    throw new AttesterSlashingError(GossipAction.REJECT, {
       code: AttesterSlashingErrorCode.INVALID_SLASHING,
     });
   }
 
   const signatureSets = allForks.getAttesterSlashingSignatureSets(state, attesterSlashing);
   if (!(await chain.bls.verifySignatureSets(signatureSets))) {
-    throw new AttesterSlashingError({
+    throw new AttesterSlashingError(GossipAction.REJECT, {
       code: AttesterSlashingErrorCode.INVALID_SLASHING,
     });
   }

--- a/packages/lodestar/src/chain/validation/block.ts
+++ b/packages/lodestar/src/chain/validation/block.ts
@@ -1,9 +1,9 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {IBeaconChain, IBlockJob} from "..";
-import {IBeaconDb} from "../../db";
 import {computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
-import {BlockError, BlockErrorCode} from "../errors";
+import {IBeaconChain, IBlockJob} from "..";
+import {IBeaconDb} from "../../db";
+import {BlockGossipError, BlockErrorCode, GossipAction} from "../errors";
 
 export async function validateGossipBlock(
   config: IBeaconConfig,
@@ -14,21 +14,23 @@ export async function validateGossipBlock(
   const block = blockJob.signedBlock;
   const blockSlot = block.message.slot;
   const blockRoot = config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message);
-  const finalizedCheckpoint = chain.getFinalizedCheckpoint();
-  const finalizedSlot = computeStartSlotAtEpoch(config, finalizedCheckpoint.epoch);
-  // block is too old
-  if (blockSlot <= finalizedSlot) {
-    throw new BlockError({
-      code: BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT,
-      blockSlot,
-      finalizedSlot,
+
+  // getBlockSlotState also checks for whether the current finalized checkpoint is an ancestor of the block.
+  // As a result, we throw an IGNORE (whereas the spec says we should REJECT for this scenario).
+  // this is something we should change this in the future to make the code airtight to the spec.
+  const blockState = await chain.regen.getBlockSlotState(block.message.parentRoot, block.message.slot).catch(() => {
+    throw new BlockGossipError(GossipAction.IGNORE, {
+      code: BlockErrorCode.PARENT_UNKNOWN,
+      parentRoot: block.message.parentRoot.valueOf() as Uint8Array,
       job: blockJob,
     });
-  }
+  });
 
+  // [IGNORE] The block is not from a future slot (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
+  // -- i.e. validate that signed_beacon_block.message.slot <= current_slot (a client MAY queue future blocks for processing at the appropriate slot).
   const currentSlotWithGossipDisparity = chain.clock.currentSlotWithGossipDisparity;
   if (currentSlotWithGossipDisparity < blockSlot) {
-    throw new BlockError({
+    throw new BlockGossipError(GossipAction.IGNORE, {
       code: BlockErrorCode.FUTURE_SLOT,
       currentSlot: currentSlotWithGossipDisparity,
       blockSlot,
@@ -36,61 +38,69 @@ export async function validateGossipBlock(
     });
   }
 
-  if (await db.badBlock.has(blockRoot)) {
-    throw new BlockError({
-      code: BlockErrorCode.KNOWN_BAD_BLOCK,
+  // [IGNORE] The block is from a slot greater than the latest finalized slot
+  // -- i.e. validate that signed_beacon_block.message.slot > compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)
+  // (a client MAY choose to validate and store such blocks for additional purposes -- e.g. slashing detection, archive nodes, etc).
+  const finalizedCheckpoint = chain.getFinalizedCheckpoint();
+  const finalizedSlot = computeStartSlotAtEpoch(config, finalizedCheckpoint.epoch);
+  if (blockSlot <= finalizedSlot) {
+    throw new BlockGossipError(GossipAction.IGNORE, {
+      code: BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT,
+      blockSlot,
+      finalizedSlot,
       job: blockJob,
     });
   }
 
+  // [IGNORE] The block is the first block with valid signature received for the proposer for the slot, signed_beacon_block.message.slot.
   const existingBlock = await db.block.get(blockRoot);
   if (existingBlock?.message.proposerIndex === block.message.proposerIndex) {
-    throw new BlockError({
+    throw new BlockGossipError(GossipAction.IGNORE, {
       code: BlockErrorCode.REPEAT_PROPOSAL,
       proposer: block.message.proposerIndex,
       job: blockJob,
     });
   }
 
-  let blockState;
-  try {
-    // getBlockSlotState also checks for whether the current finalized checkpoint is an ancestor of the block.  as a result, we throw an IGNORE (whereas the spec says we should REJECT for this scenario).  this is something we should change this in the future to make the code airtight to the spec.
-    blockState = await chain.regen.getBlockSlotState(block.message.parentRoot, block.message.slot);
-  } catch (e) {
-    throw new BlockError({
-      code: BlockErrorCode.PARENT_UNKNOWN,
-      parentRoot: block.message.parentRoot.valueOf() as Uint8Array,
-      job: blockJob,
-    });
-  }
+  // [IGNORE] The block's parent (defined by block.parent_root) has been seen (via both gossip and non-gossip sources)
+  // (a client MAY queue blocks for processing once the parent block is retrieved).
 
-  const signatureSet = allForks.getProposerSignatureSet(blockState, block);
-  if (!(await chain.bls.verifySignatureSets([signatureSet]))) {
-    throw new BlockError({
-      code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID,
-      job: blockJob,
-    });
-  }
+  // [REJECT] The block's parent (defined by block.parent_root) passes validation.
 
+  // [REJECT] The block is from a higher slot than its parent.
+
+  // [REJECT] The current finalized_checkpoint is an ancestor of block
+  // -- i.e. get_ancestor(store, block.parent_root, compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)) == store.finalized_checkpoint.root
+
+  // [REJECT] The block is proposed by the expected proposer_index for the block's slot in the context of
+  // the current shuffling (defined by parent_root/slot). If the proposer_index cannot immediately be verified
+  // against the expected shuffling, the block MAY be queued for later processing while proposers for the
+  // block's branch are calculated -- in such a case do not REJECT, instead IGNORE this message.
   try {
-    const validProposer = isExpectedProposer(blockState.epochCtx, block.message);
-    if (!validProposer) {
-      throw new BlockError({
-        code: BlockErrorCode.INCORRECT_PROPOSER,
-        blockProposer: block.message.proposerIndex,
-        job: blockJob,
-      });
+    if (blockState.epochCtx.getBeaconProposer(block.message.slot) !== block.message.proposerIndex) {
+      throw new Error("INCORRECT_PROPOSER");
     }
   } catch (error) {
-    throw new BlockError({
+    throw new BlockGossipError(GossipAction.REJECT, {
       code: BlockErrorCode.INCORRECT_PROPOSER,
       blockProposer: block.message.proposerIndex,
       job: blockJob,
     });
   }
-}
 
-export function isExpectedProposer(epochCtx: allForks.EpochContext, block: allForks.BeaconBlock): boolean {
-  const supposedProposerIndex = epochCtx.getBeaconProposer(block.slot);
-  return supposedProposerIndex === block.proposerIndex;
+  if (await db.badBlock.has(blockRoot)) {
+    throw new BlockGossipError(GossipAction.REJECT, {
+      code: BlockErrorCode.KNOWN_BAD_BLOCK,
+      job: blockJob,
+    });
+  }
+
+  // [REJECT] The proposer signature, signed_beacon_block.signature, is valid with respect to the proposer_index pubkey.
+  const signatureSet = allForks.getProposerSignatureSet(blockState, block);
+  if (!(await chain.bls.verifySignatureSets([signatureSet]))) {
+    throw new BlockGossipError(GossipAction.REJECT, {
+      code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID,
+      job: blockJob,
+    });
+  }
 }

--- a/packages/lodestar/src/chain/validation/proposerSlashing.ts
+++ b/packages/lodestar/src/chain/validation/proposerSlashing.ts
@@ -4,6 +4,7 @@ import {phase0} from "@chainsafe/lodestar-types";
 import {IBeaconChain} from "..";
 import {ProposerSlashingError, ProposerSlashingErrorCode} from "../errors/proposerSlashingError";
 import {IBeaconDb} from "../../db";
+import {GossipAction} from "../errors";
 
 export async function validateGossipProposerSlashing(
   config: IBeaconConfig,
@@ -11,24 +12,27 @@ export async function validateGossipProposerSlashing(
   db: IBeaconDb,
   proposerSlashing: phase0.ProposerSlashing
 ): Promise<void> {
+  // [IGNORE] The proposer slashing is the first valid proposer slashing received for the proposer
+  // with index proposer_slashing.signed_header_1.message.proposer_index.
   if (await db.proposerSlashing.has(proposerSlashing.signedHeader1.message.proposerIndex)) {
-    throw new ProposerSlashingError({
+    throw new ProposerSlashingError(GossipAction.IGNORE, {
       code: ProposerSlashingErrorCode.SLASHING_ALREADY_EXISTS,
     });
   }
 
   const state = chain.getHeadState();
 
+  // [REJECT] All of the conditions within process_proposer_slashing pass validation.
   // verifySignature = false, verified in batch below
   if (!isValidProposerSlashing(config, state, proposerSlashing, false)) {
-    throw new ProposerSlashingError({
+    throw new ProposerSlashingError(GossipAction.REJECT, {
       code: ProposerSlashingErrorCode.INVALID_SLASHING,
     });
   }
 
   const signatureSets = allForks.getProposerSlashingSignatureSets(state, proposerSlashing);
   if (!(await chain.bls.verifySignatureSets(signatureSets))) {
-    throw new ProposerSlashingError({
+    throw new ProposerSlashingError(GossipAction.REJECT, {
       code: ProposerSlashingErrorCode.INVALID_SLASHING,
     });
   }

--- a/packages/lodestar/src/chain/validation/voluntaryExit.ts
+++ b/packages/lodestar/src/chain/validation/voluntaryExit.ts
@@ -4,6 +4,7 @@ import {phase0} from "@chainsafe/lodestar-types";
 import {IBeaconChain} from "..";
 import {VoluntaryExitError, VoluntaryExitErrorCode} from "../errors/voluntaryExitError";
 import {IBeaconDb} from "../../db";
+import {GossipAction} from "../errors";
 
 export async function validateGossipVoluntaryExit(
   config: IBeaconConfig,
@@ -11,8 +12,10 @@ export async function validateGossipVoluntaryExit(
   db: IBeaconDb,
   voluntaryExit: phase0.SignedVoluntaryExit
 ): Promise<void> {
+  // [IGNORE] The voluntary exit is the first valid voluntary exit received for the validator
+  // with index signed_voluntary_exit.message.validator_index.
   if (await db.voluntaryExit.has(voluntaryExit.message.validatorIndex)) {
-    throw new VoluntaryExitError({
+    throw new VoluntaryExitError(GossipAction.IGNORE, {
       code: VoluntaryExitErrorCode.EXIT_ALREADY_EXISTS,
     });
   }
@@ -22,16 +25,17 @@ export async function validateGossipVoluntaryExit(
     epoch: voluntaryExit.message.epoch,
   });
 
+  // [REJECT] All of the conditions within process_voluntary_exit pass validation.
   // verifySignature = false, verified in batch below
   if (!isValidVoluntaryExit(config, state, voluntaryExit, false)) {
-    throw new VoluntaryExitError({
+    throw new VoluntaryExitError(GossipAction.REJECT, {
       code: VoluntaryExitErrorCode.INVALID_EXIT,
     });
   }
 
   const signatureSet = allForks.getVoluntaryExitSignatureSet(state, voluntaryExit);
   if (!(await chain.bls.verifySignatureSets([signatureSet]))) {
-    throw new VoluntaryExitError({
+    throw new VoluntaryExitError(GossipAction.REJECT, {
       code: VoluntaryExitErrorCode.INVALID_EXIT,
     });
   }

--- a/packages/lodestar/src/network/gossip/validatorFns/attestation.ts
+++ b/packages/lodestar/src/network/gossip/validatorFns/attestation.ts
@@ -3,7 +3,7 @@ import {phase0} from "@chainsafe/lodestar-types";
 import {Json} from "@chainsafe/ssz";
 import {IAttestationJob} from "../../../chain";
 import {validateGossipAttestation} from "../../../chain/validation";
-import {AttestationError, AttestationErrorCode} from "../../../chain/errors";
+import {AttestationGossipError, AttestationErrorCode, GossipAction} from "../../../chain/errors";
 import {IObjectValidatorModules, GossipTopicMap, GossipType} from "../interface";
 import {GossipValidationError} from "../errors";
 
@@ -23,34 +23,25 @@ export async function validateCommitteeAttestation(
     await validateGossipAttestation(config, chain, db, attestationJob, subnet);
     logger.debug("gossip - Attestation - accept", {subnet});
   } catch (e) {
-    if (!(e instanceof AttestationError)) {
-      logger.error("Gossip attestation validation threw a non-AttestationError", e);
+    if (!(e instanceof AttestationGossipError)) {
+      logger.error("gossip - attestation - non-AttestationError", e);
       throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
     }
-    switch (e.type.code) {
-      case AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE:
-      case AttestationErrorCode.INVALID_SUBNET_ID:
-      case AttestationErrorCode.BAD_TARGET_EPOCH:
-      case AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET:
-      case AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS:
-      case AttestationErrorCode.INVALID_SIGNATURE:
-      case AttestationErrorCode.KNOWN_BAD_BLOCK:
-      case AttestationErrorCode.FINALIZED_CHECKPOINT_NOT_AN_ANCESTOR_OF_ROOT:
-      case AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK:
-        logger.debug("gossip - Attestation - reject", e.type);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
 
-      case AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT:
-      case AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE: // IGNORE
-        // attestation might be valid after we receive block
-        chain.receiveAttestation(attestation);
-      /** eslit-disable-next-line no-fallthrough */
-      case AttestationErrorCode.PAST_SLOT:
-      case AttestationErrorCode.FUTURE_SLOT:
-      case AttestationErrorCode.ATTESTATION_ALREADY_KNOWN:
-      default:
-        logger.debug("gossip - Attestation - ignore", e.type as Json);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
+    if (
+      e.type.code === AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT ||
+      e.type.code === AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE
+    ) {
+      // attestation might be valid after we receive block
+      chain.receiveAttestation(attestation);
+    }
+
+    if (e.action === GossipAction.REJECT) {
+      logger.debug("gossip - attestation - reject", e.type as Json);
+      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
+    } else {
+      logger.debug("gossip - attestation - ignore", e.type as Json);
+      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
     }
   } finally {
     db.seenAttestationCache.addCommitteeAttestation(attestation);

--- a/packages/lodestar/src/network/gossip/validatorFns/attesterSlashing.ts
+++ b/packages/lodestar/src/network/gossip/validatorFns/attesterSlashing.ts
@@ -1,7 +1,8 @@
 import {ERR_TOPIC_VALIDATOR_IGNORE, ERR_TOPIC_VALIDATOR_REJECT} from "libp2p-gossipsub/src/constants";
 import {phase0} from "@chainsafe/lodestar-types";
+import {Json} from "@chainsafe/ssz";
 import {validateGossipAttesterSlashing} from "../../../chain/validation";
-import {AttesterSlashingError, AttesterSlashingErrorCode} from "../../../chain/errors";
+import {AttesterSlashingError, GossipAction} from "../../../chain/errors";
 import {IObjectValidatorModules, GossipTopic} from "../interface";
 import {GossipValidationError} from "../errors";
 
@@ -15,19 +16,16 @@ export async function validateAttesterSlashing(
     logger.debug("gossip - AttesterSlashing - accept");
   } catch (e) {
     if (!(e instanceof AttesterSlashingError)) {
-      logger.error("Gossip attester slashing validation threw a non-AttesterSlashingError", e);
+      logger.error("gossip - AttesterSlashing - non-AttesterSlashingError", e);
       throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
     }
 
-    switch (e.type.code) {
-      case AttesterSlashingErrorCode.INVALID_SLASHING:
-        logger.debug("gossip - AttesterSlashing - reject", e.type);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
-
-      case AttesterSlashingErrorCode.SLASHING_ALREADY_EXISTS:
-      default:
-        logger.debug("gossip - AttesterSlashing - ignore", e.type);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
+    if (e.action === GossipAction.REJECT) {
+      logger.debug("gossip - AttesterSlashing - reject", e.type as Json);
+      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
+    } else {
+      logger.debug("gossip - AttesterSlashing - ignore", e.type as Json);
+      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
     }
   }
 }

--- a/packages/lodestar/src/network/gossip/validatorFns/block.ts
+++ b/packages/lodestar/src/network/gossip/validatorFns/block.ts
@@ -2,7 +2,7 @@ import {ERR_TOPIC_VALIDATOR_IGNORE, ERR_TOPIC_VALIDATOR_REJECT} from "libp2p-gos
 import {allForks} from "@chainsafe/lodestar-types";
 import {Json, toHexString} from "@chainsafe/ssz";
 import {validateGossipBlock} from "../../../chain/validation";
-import {BlockError, BlockErrorCode} from "../../../chain/errors";
+import {BlockGossipError, BlockErrorCode, GossipAction} from "../../../chain/errors";
 import {IObjectValidatorModules, GossipTopic} from "../interface";
 import {GossipValidationError} from "../errors";
 
@@ -24,27 +24,22 @@ export async function validateBeaconBlock(
       slot: signedBlock.message.slot,
     });
   } catch (e) {
-    if (!(e instanceof BlockError)) {
-      logger.error("Gossip block validation threw a non-BlockError", e);
+    if (!(e instanceof BlockGossipError)) {
+      logger.error("gossip - Block - non-BlockError", e);
       throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
     }
 
-    switch (e.type.code) {
-      case BlockErrorCode.PROPOSAL_SIGNATURE_INVALID:
-      case BlockErrorCode.INCORRECT_PROPOSER:
-      case BlockErrorCode.KNOWN_BAD_BLOCK:
-        logger.debug("gossip - Block - reject", e.type);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
+    if (e.type.code === BlockErrorCode.FUTURE_SLOT || e.type.code === BlockErrorCode.PARENT_UNKNOWN) {
+      // block might be valid in the future
+      chain.receiveBlock(signedBlock);
+    }
 
-      case BlockErrorCode.FUTURE_SLOT:
-      case BlockErrorCode.PARENT_UNKNOWN: // IGNORE
-        chain.receiveBlock(signedBlock);
-      /** eslit-disable-next-line no-fallthrough */
-      case BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT:
-      case BlockErrorCode.REPEAT_PROPOSAL:
-      default:
-        logger.debug("gossip - Block - ignore", e.type as Json);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
+    if (e.action === GossipAction.REJECT) {
+      logger.debug("gossip - attestation - reject", e.type as Json);
+      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
+    } else {
+      logger.debug("gossip - attestation - ignore", e.type as Json);
+      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
     }
   }
 }

--- a/packages/lodestar/src/network/gossip/validatorFns/voluntaryExit.ts
+++ b/packages/lodestar/src/network/gossip/validatorFns/voluntaryExit.ts
@@ -1,7 +1,8 @@
 import {ERR_TOPIC_VALIDATOR_IGNORE, ERR_TOPIC_VALIDATOR_REJECT} from "libp2p-gossipsub/src/constants";
 import {phase0} from "@chainsafe/lodestar-types";
+import {Json} from "@chainsafe/ssz";
 import {validateGossipVoluntaryExit} from "../../../chain/validation";
-import {VoluntaryExitError, VoluntaryExitErrorCode} from "../../../chain/errors";
+import {GossipAction, VoluntaryExitError} from "../../../chain/errors";
 import {IObjectValidatorModules, GossipTopic} from "../interface";
 import {GossipValidationError} from "../errors";
 
@@ -15,19 +16,16 @@ export async function validateVoluntaryExit(
     logger.debug("gossip - VoluntaryExit - accept");
   } catch (e) {
     if (!(e instanceof VoluntaryExitError)) {
-      logger.error("Gossip voluntary exit validation threw a non-VoluntaryExitError", e);
+      logger.error("gossip - VoluntaryExit - non-VoluntaryExitError", e);
       throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
     }
 
-    switch (e.type.code) {
-      case VoluntaryExitErrorCode.INVALID_EXIT:
-        logger.debug("gossip - VoluntaryExit - reject", e.type);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
-
-      case VoluntaryExitErrorCode.EXIT_ALREADY_EXISTS:
-      default:
-        logger.debug("gossip - VoluntaryExit - ignore", e.type);
-        throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
+    if (e.action === GossipAction.REJECT) {
+      logger.debug("gossip - VoluntaryExit - reject", e.type as Json);
+      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
+    } else {
+      logger.debug("gossip - VoluntaryExit - ignore", e.type as Json);
+      throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE);
     }
   }
 }


### PR DESCRIPTION
**Motivation**

Currently our node is able to process only 0-20% of the the attestations received through gossip. Reviewing our gossip validation I found many inneficiencies:
- Checked badBlock twice
- badBlock check involves a disk read, should be cached in memory
- Committee calculations seem like could be optimized further

**Description**

- Added the exact spec directive as a comment associated with each validation. This is extremely useful to audit the code quickly against the spec. Will be very useful if the gossip checks evolve.
- Re-ordered the gossip validation checks to match the spec, see above.
