### PR TITLE
Fix undefined participants

### DIFF
--- a/packages/beacon-state-transition/src/util/aggregationBits.ts
+++ b/packages/beacon-state-transition/src/util/aggregationBits.ts
@@ -54,8 +54,9 @@ export function zipIndexesInBitList(
     const booleansInByte = getUint8ByteToBitBooleanArray(attBytes[iByte]);
     // For each bit in the byte check participation and add to indexesSelected array
     for (let iBit = 0; iBit < BITS_PER_BYTE; iBit++) {
-      if (booleansInByte[iBit]) {
-        indexesSelected.push(indexes[iByte * BITS_PER_BYTE + iBit]);
+      const participantIndex = indexes[iByte * BITS_PER_BYTE + iBit];
+      if (booleansInByte[iBit] && participantIndex !== undefined) {
+        indexesSelected.push(participantIndex);
       }
     }
   }
@@ -79,5 +80,6 @@ export function bitlistToUint8Array(
   for (const node of nodeIterator) {
     chunks.push(node.root);
   }
-  return Buffer.concat(chunks);
+  // the last chunk has 32 bytes but we don't use all of them
+  return Buffer.concat(chunks).subarray(0, Math.ceil(aggregationBits.length / BITS_PER_BYTE));
 }

--- a/packages/beacon-state-transition/test/unit/util/aggregationBits.test.ts
+++ b/packages/beacon-state-transition/test/unit/util/aggregationBits.test.ts
@@ -6,13 +6,18 @@ import {getUint8ByteToBitBooleanArray, bitlistToUint8Array} from "../../../src";
 const BITS_PER_BYTE = 8;
 
 describe("aggregationBits", function () {
-  const testCases: {name: string; data: boolean[]}[] = [
-    {name: "8 bits all true", data: [true, true, true, true, true, true, true, true]},
-    {name: "8 bits with true and false", data: [false, false, false, false, false, true, false, true]},
-    {name: "10 bits with true and fase", data: [false, false, false, false, false, true, false, true, true, true]},
+  const testCases: {name: string; data: boolean[]; numBytes: number}[] = [
+    {name: "8 bits all true", data: [true, true, true, true, true, true, true, true], numBytes: 1},
+    {name: "8 bits with true and false", data: [false, false, false, false, false, true, false, true], numBytes: 1},
+    {
+      name: "10 bits with true and false",
+      data: [false, false, false, false, false, true, false, true, true, true],
+      numBytes: 2,
+    },
     {
       name: "" + config.params.MAX_VALIDATORS_PER_COMMITTEE + " bits all true",
       data: Array.from({length: config.params.MAX_VALIDATORS_PER_COMMITTEE}, () => true),
+      numBytes: Math.ceil(config.params.MAX_VALIDATORS_PER_COMMITTEE / 8),
     },
   ];
 
@@ -21,15 +26,16 @@ describe("aggregationBits", function () {
     expect(getUint8ByteToBitBooleanArray(5)).to.be.deep.equal([true, false, true, false, false, false, false, false]);
   });
 
-  for (const {name, data} of testCases) {
+  for (const {name, data, numBytes} of testCases) {
     it(name, () => {
       const tree = config.types.phase0.CommitteeBits.createTreeBackedFromStruct(data as List<boolean>);
       const aggregationBytes = bitlistToUint8Array(tree, config.types.phase0.CommitteeBits);
+      expect(aggregationBytes.length).to.be.equal(numBytes, "number of bytes is incorrect");
       const aggregationBits: boolean[] = [];
       for (let i = 0; i < tree.length; i++) {
         aggregationBits.push(getAggregationBit(aggregationBytes, i));
       }
-      expect(aggregationBits).to.be.deep.equal(data);
+      expect(aggregationBits).to.be.deep.equal(data, "incorrect extracted aggregationBits");
     });
   }
 


### PR DESCRIPTION
**Motivation**

+ The new way to extract aggregationBits causes some undefined participants

**Description**
+ This is because we don't use up all bytes of the last extracted chunk (32 bytes in total)

Closes #2600

**Steps to test or reproduce**

Sync Prater