### PR TITLE
Fix filter_block_tree forkchoice spec test

### DIFF
--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -432,15 +432,15 @@ export class ProtoArray {
   /**
    * This is the equivalent to the `filter_block_tree` function in the eth2 spec:
    *
-   * https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/fork-choice.md#filter_block_tree
+   * https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/fork-choice.md#filter_block_tree
    *
    * Any node that has a different finalized or justified epoch should not be viable for the
    * head.
    */
   nodeIsViableForHead(node: IProtoNode): boolean {
     return (
-      (node.justifiedEpoch === this.justifiedEpoch || node.justifiedEpoch === 0) &&
-      (node.finalizedEpoch === this.finalizedEpoch || node.finalizedEpoch === 0)
+      (node.justifiedEpoch === this.justifiedEpoch || this.justifiedEpoch === 0) &&
+      (node.finalizedEpoch === this.finalizedEpoch || this.finalizedEpoch === 0)
     );
   }
 

--- a/packages/spec-test-runner/test/spec/altair/fork_choice/get_head_minimal.test.ts
+++ b/packages/spec-test-runner/test/spec/altair/fork_choice/get_head_minimal.test.ts
@@ -134,8 +134,6 @@ describeDirectorySpecTest<IForkChoiceTestCase, void>(
       };
     },
     timeout: 10000,
-    // TODO: fix this
-    shouldSkip: (testCase, name) => name === "filtered_block_tree",
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     expectFunc: () => {},
   }


### PR DESCRIPTION
**Motivation**

Failed forkchoice spec test.

**Description**

+ Follow https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/fork-choice.md#filter_block_tree: allow eligible nodes if store's justified epoch and finalized epoch are 0, not the node's
Closes #2567