### PR TITLE
Add fieldName on createIBeaconParams error

### DIFF
--- a/packages/params/src/utils.ts
+++ b/packages/params/src/utils.ts
@@ -8,7 +8,12 @@ export function createIBeaconParams(input: Record<string, unknown>): Partial<IBe
   const params: Partial<IBeaconParams> = {};
   for (const [fieldName, fieldType] of Object.entries(BeaconParams.fields)) {
     if (input[fieldName] != null) {
-      (params as Record<string, unknown>)[fieldName] = fieldType.fromJson(input[fieldName] as Json) as unknown;
+      try {
+        (params as Record<string, unknown>)[fieldName] = fieldType.fromJson(input[fieldName] as Json) as unknown;
+      } catch (e) {
+        (e as Error).message = `Error parsing '${fieldName}': ${(e as Error).message}`;
+        throw e;
+      }
     }
   }
   return params;


### PR DESCRIPTION
**Motivation**

Otherwise it's impossible to debug bad configs. You just get a random SSZ error without any context.

**Description**

Add fieldName to error