### PR TITLE
Make lodestar-api package public

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@chainsafe/lodestar-api",
-  "private": true,
   "description": "A Typescript implementation of the eth2 light client",
   "license": "Apache-2.0",
   "author": "ChainSafe Systems",


### PR DESCRIPTION
Package is published on NPM and ready to use.