### PR TITLE
Allow to disable bls batch verify in block processor

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -3,11 +3,13 @@ import {ICliCommandOptions} from "../../util";
 
 export interface IChainArgs {
   "chain.useSingleThreadVerifier": boolean;
+  "chain.disableBlsBatchVerify": boolean;
 }
 
 export function parseArgs(args: IChainArgs): IBeaconNodeOptions["chain"] {
   return {
     useSingleThreadVerifier: args["chain.useSingleThreadVerifier"],
+    disableBlsBatchVerify: args["chain.disableBlsBatchVerify"],
   };
 }
 
@@ -17,6 +19,16 @@ export const options: ICliCommandOptions<IChainArgs> = {
     type: "boolean",
     description: "Disable spawning worker threads for BLS verification, use single thread implementation.",
     defaultDescription: String(defaultOptions.chain.useSingleThreadVerifier),
+    group: "chain",
+  },
+
+  "chain.disableBlsBatchVerify": {
+    hidden: true,
+    type: "boolean",
+    description:
+      "Do not use BLS batch verify to validate all block signatures at once. \
+Will double processing times. Use only for debugging purposes.",
+    defaultDescription: String(defaultOptions.chain.disableBlsBatchVerify),
     group: "chain",
   },
 };

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -14,6 +14,7 @@ describe("options / beaconNodeOptions", () => {
       "api.rest.port": 7654,
 
       "chain.useSingleThreadVerifier": true,
+      "chain.disableBlsBatchVerify": true,
 
       "eth1.enabled": true,
       "eth1.providerUrl": "http://my.node:8545",
@@ -51,6 +52,7 @@ describe("options / beaconNodeOptions", () => {
       },
       chain: {
         useSingleThreadVerifier: true,
+        disableBlsBatchVerify: true,
       },
       eth1: {
         enabled: true,

--- a/packages/lodestar/src/chain/blocks/processor.ts
+++ b/packages/lodestar/src/chain/blocks/processor.ts
@@ -1,32 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
 import {AbortSignal} from "abort-controller";
-import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {allForks} from "@chainsafe/lodestar-types";
 
 import {IBlockJob, IChainSegmentJob} from "../interface";
-import {ChainEvent, ChainEventEmitter} from "../emitter";
-import {IBeaconClock} from "../clock";
-import {IStateRegenerator} from "../regen";
+import {ChainEvent} from "../emitter";
 import {JobQueue} from "../../util/queue";
-import {CheckpointStateCache} from "../stateCache";
 import {BlockError, BlockErrorCode, ChainSegmentError} from "../errors";
-import {IMetrics} from "../../metrics";
-import {IBlsVerifier} from "../bls";
 
-import {processBlock, processChainSegment} from "./process";
-import {validateBlock} from "./validate";
+import {processBlock, processChainSegment, BlockProcessModules} from "./process";
+import {validateBlock, BlockValidateModules} from "./validate";
 
-type BlockProcessorModules = {
-  config: IBeaconConfig;
-  forkChoice: IForkChoice;
-  regen: IStateRegenerator;
-  emitter: ChainEventEmitter;
-  bls: IBlsVerifier;
-  metrics: IMetrics | null;
-  clock: IBeaconClock;
-  checkpointStateCache: CheckpointStateCache;
-};
+export type BlockProcessorModules = BlockProcessModules & BlockValidateModules;
 
 /**
  * BlockProcessor processes block jobs in a queued fashion, one after the other.

--- a/packages/lodestar/src/chain/blocks/validate.ts
+++ b/packages/lodestar/src/chain/blocks/validate.ts
@@ -6,10 +6,13 @@ import {IBlockJob} from "../interface";
 import {IBeaconClock} from "../clock";
 import {BlockError, BlockErrorCode} from "../errors";
 
-export function validateBlock(
-  {config, forkChoice, clock}: {config: IBeaconConfig; forkChoice: IForkChoice; clock: IBeaconClock},
-  job: IBlockJob
-): void {
+export type BlockValidateModules = {
+  config: IBeaconConfig;
+  forkChoice: IForkChoice;
+  clock: IBeaconClock;
+};
+
+export function validateBlock({config, forkChoice, clock}: BlockValidateModules, job: IBlockJob): void {
   try {
     const blockHash = config
       .getForkTypes(job.signedBlock.message.slot)

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -113,6 +113,7 @@ export class BeaconChain implements IBeaconChain {
       emitter,
       checkpointStateCache,
       signal,
+      opts,
     });
 
     this.forkChoice = forkChoice;

--- a/packages/lodestar/src/chain/options.ts
+++ b/packages/lodestar/src/chain/options.ts
@@ -1,8 +1,10 @@
 import {BlsVerifierOpts} from "./bls";
+import {BlockProcessOpts} from "./blocks/process";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type IChainOptions = BlsVerifierOpts;
+export type IChainOptions = BlsVerifierOpts & BlockProcessOpts;
 
 export const defaultChainOptions: IChainOptions = {
   useSingleThreadVerifier: false,
+  disableBlsBatchVerify: false,
 };


### PR DESCRIPTION
**Motivation**

For debugging purposes you may want to know which signature in a bundle is invalid. 

**Description**

This flag allows you to do that by verifying all signatures individually.