### PR TITLE
Verify SyncCommittee signatures in batch

### DIFF
--- a/packages/beacon-state-transition/src/allForks/signatureSets/index.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/index.ts
@@ -47,7 +47,7 @@ export function getAllBlockSignatureSetsExceptProposer(
   if (computeEpochAtSlot(state.config, signedBlock.message.slot) >= state.config.params.ALTAIR_FORK_EPOCH) {
     const syncCommitteeSignatureSet = getSyncCommitteeSignatureSet(
       state as CachedBeaconState<altair.BeaconState>,
-      (signedBlock as altair.SignedBeaconBlock).message.body.syncAggregate
+      (signedBlock as altair.SignedBeaconBlock).message
     );
     // There may be no participants in this syncCommitteeSignature, so it must not be validated
     if (syncCommitteeSignatureSet) {

--- a/packages/beacon-state-transition/src/altair/block/index.ts
+++ b/packages/beacon-state-transition/src/altair/block/index.ts
@@ -29,5 +29,5 @@ export function processBlock(
   processRandao(state as CachedBeaconState<allForks.BeaconState>, block, verifySignatures);
   processEth1Data(state as CachedBeaconState<allForks.BeaconState>, block.body);
   processOperations(state, block.body, verifySignatures);
-  processSyncCommittee(state, block.body.syncAggregate, verifySignatures);
+  processSyncCommittee(state, block, verifySignatures);
 }

--- a/packages/beacon-state-transition/src/altair/block/processSyncCommittee.ts
+++ b/packages/beacon-state-transition/src/altair/block/processSyncCommittee.ts
@@ -23,7 +23,9 @@ export function processSyncCommittee(
 
   // different from the spec but not sure how to get through signature verification for default/empty SyncAggregate in the spec test
   if (verifySignatures) {
-    const signatureSet = getSyncCommitteeSignatureSet(state, syncAggregate, participantIndices);
+    // This is to conform to the spec - we want the signature to be verified
+    const block = {slot: state.slot, body: {syncAggregate}} as altair.BeaconBlock;
+    const signatureSet = getSyncCommitteeSignatureSet(state, block, participantIndices);
     // When there's no participation we consider the signature valid and just ignore i
     if (signatureSet !== null && !verifySignatureSet(signatureSet)) {
       throw Error("Sync committee signature invalid");
@@ -39,13 +41,13 @@ export function processSyncCommittee(
 
 export function getSyncCommitteeSignatureSet(
   state: CachedBeaconState<altair.BeaconState>,
-  syncAggregate: altair.SyncAggregate,
+  block: altair.BeaconBlock,
   /** Optional parameter to prevent computing it twice */
   participantIndices?: number[]
 ): ISignatureSet | null {
   const {config, epochCtx} = state;
-
-  const previousSlot = Math.max(state.slot, 1) - 1;
+  const {syncAggregate} = block.body;
+  const previousSlot = Math.max(block.slot, 1) - 1;
   const rootSigned = getBlockRootAtSlot(config, state, previousSlot);
 
   if (!participantIndices) {

--- a/packages/beacon-state-transition/src/altair/block/processSyncCommittee.ts
+++ b/packages/beacon-state-transition/src/altair/block/processSyncCommittee.ts
@@ -15,16 +15,15 @@ import {BitList, isTreeBacked, TreeBacked} from "@chainsafe/ssz";
 
 export function processSyncCommittee(
   state: CachedBeaconState<altair.BeaconState>,
-  syncAggregate: altair.SyncAggregate,
+  block: altair.BeaconBlock,
   verifySignatures = true
 ): void {
   const {syncParticipantReward, syncProposerReward} = state.epochCtx;
-  const participantIndices = getParticipantIndices(state, syncAggregate);
+  const participantIndices = getParticipantIndices(state, block.body.syncAggregate);
 
   // different from the spec but not sure how to get through signature verification for default/empty SyncAggregate in the spec test
   if (verifySignatures) {
     // This is to conform to the spec - we want the signature to be verified
-    const block = {slot: state.slot, body: {syncAggregate}} as altair.BeaconBlock;
     const signatureSet = getSyncCommitteeSignatureSet(state, block, participantIndices);
     // When there's no participation we consider the signature valid and just ignore i
     if (signatureSet !== null && !verifySignatureSet(signatureSet)) {

--- a/packages/spec-test-runner/test/spec/altair/operations/syncCommittee/sync_committee_minimal.test.ts
+++ b/packages/spec-test-runner/test/spec/altair/operations/syncCommittee/sync_committee_minimal.test.ts
@@ -20,10 +20,14 @@ describeDirectorySpecTest<IProcessSyncCommitteeTestCase, altair.BeaconState>(
       config,
       testcase.pre as TreeBacked<altair.BeaconState>
     ) as CachedBeaconState<altair.BeaconState>;
-    altair.processSyncCommittee(
-      wrappedState,
-      config.types.altair.SyncAggregate.createTreeBackedFromStruct(testcase["sync_aggregate"])
-    );
+
+    const block = config.types.altair.BeaconBlock.defaultValue();
+
+    // processSyncCommittee() needs the full block to get the slot
+    block.slot = wrappedState.slot;
+    block.body.syncAggregate = config.types.altair.SyncAggregate.createTreeBackedFromStruct(testcase["sync_aggregate"]);
+
+    altair.processSyncCommittee(wrappedState, block);
     return wrappedState;
   },
   {


### PR DESCRIPTION
**Motivation**

A continuation of #2617

**Description**

+ when getting sync committee signature set, previous slot should be from the block instead of state to make sure it's correct
+ signed roots of sync committee signatures are only known after we run state transition for all blocks in segment
+ revert #2624 as it's not necessary anymore

**Steps to test or reproduce**
+ `./bin/lodestar beacon --network oonoonba`