### PR TITLE
Impove processAttestation for altair

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
@@ -20,6 +20,7 @@ import {
 import {IEpochStakeSummary} from "./epochStakeSummary";
 import {CachedBeaconState} from "./cachedBeaconState";
 import {statusProcessEpoch} from "../../phase0/epoch/processPendingAttestations";
+import {computeBaseRewardPerIncrement} from "../../altair/misc";
 
 /**
  * The AttesterStatus (and FlatValidator under status.validator) objects and
@@ -30,6 +31,8 @@ export interface IEpochProcess {
   prevEpoch: Epoch;
   currentEpoch: Epoch;
   totalActiveStake: Gwei;
+  /** For altair */
+  baseRewardPerIncrement: Gwei;
   prevEpochUnslashedStake: IEpochStakeSummary;
   currEpochUnslashedTargetStake: Gwei;
   indicesToSlash: ValidatorIndex[];
@@ -53,6 +56,7 @@ export function createIEpochProcess(): IEpochProcess {
     prevEpoch: 0,
     currentEpoch: 0,
     totalActiveStake: BigInt(0),
+    baseRewardPerIncrement: BigInt(0),
     prevEpochUnslashedStake: {
       sourceStake: BigInt(0),
       targetStake: BigInt(0),
@@ -138,6 +142,9 @@ export function prepareEpochProcessState<T extends allForks.BeaconState>(state: 
   if (out.totalActiveStake < EFFECTIVE_BALANCE_INCREMENT) {
     out.totalActiveStake = EFFECTIVE_BALANCE_INCREMENT;
   }
+
+  // SPEC: function getBaseRewardPerIncrement()
+  out.baseRewardPerIncrement = computeBaseRewardPerIncrement(config, out.totalActiveStake);
 
   // order by sequence of activationEligibilityEpoch setting and then index
   out.indicesToMaybeActivate.sort(

--- a/packages/beacon-state-transition/src/altair/epoch/balance.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/balance.ts
@@ -1,5 +1,4 @@
 import {altair, Gwei, ValidatorIndex} from "@chainsafe/lodestar-types";
-import {bigIntSqrt} from "@chainsafe/lodestar-utils";
 import {PARTICIPATION_FLAG_WEIGHTS} from "../misc";
 import * as phase0 from "../../phase0";
 import {
@@ -100,17 +99,6 @@ export function getInactivityPenaltyDeltas(
   return [rewards, penalties];
 }
 
-export function getBaseRewardPerIncrement(
-  state: CachedBeaconState<altair.BeaconState>,
-  process: IEpochProcess
-): bigint {
-  const {config} = state;
-  return (
-    (config.params.EFFECTIVE_BALANCE_INCREMENT * BigInt(config.params.BASE_REWARD_FACTOR)) /
-    bigIntSqrt(process.totalActiveStake)
-  );
-}
-
 export function getBaseReward(
   state: CachedBeaconState<altair.BeaconState>,
   process: IEpochProcess,
@@ -118,5 +106,5 @@ export function getBaseReward(
 ): bigint {
   const {config} = state;
   const increments = state.validators[index].effectiveBalance / config.params.EFFECTIVE_BALANCE_INCREMENT;
-  return increments * getBaseRewardPerIncrement(state, process);
+  return increments * process.baseRewardPerIncrement;
 }

--- a/packages/beacon-state-transition/src/altair/misc.ts
+++ b/packages/beacon-state-transition/src/altair/misc.ts
@@ -1,4 +1,6 @@
-import {ParticipationFlags} from "@chainsafe/lodestar-types";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {Gwei, ParticipationFlags} from "@chainsafe/lodestar-types";
+import {bigIntSqrt} from "@chainsafe/lodestar-utils";
 import {TIMELY_HEAD_WEIGHT, TIMELY_SOURCE_WEIGHT, TIMELY_TARGET_WEIGHT} from "./constants";
 
 export const PARTICIPATION_FLAG_WEIGHTS = [TIMELY_SOURCE_WEIGHT, TIMELY_TARGET_WEIGHT, TIMELY_HEAD_WEIGHT];
@@ -10,4 +12,11 @@ export function addFlag(flags: ParticipationFlags, flagIndex: number): Participa
 export function hasFlag(flags: ParticipationFlags, flagIndex: number): boolean {
   const flag = 2 ** flagIndex;
   return (flags & flag) == flag;
+}
+
+export function computeBaseRewardPerIncrement(config: IBeaconConfig, totalActiveStake: Gwei): bigint {
+  return (
+    (config.params.EFFECTIVE_BALANCE_INCREMENT * BigInt(config.params.BASE_REWARD_FACTOR)) /
+    bigIntSqrt(totalActiveStake)
+  );
 }


### PR DESCRIPTION
**Motivation**

See https://github.com/ChainSafe/lodestar/issues/2618

**Description**

Cache `baseRewardPerIncrement` in epoch context. Increases sync speed by a factor of N where N is the number of validators in the chain (a dramatic improvement).

Closes https://github.com/ChainSafe/lodestar/issues/2618