### PR TITLE
Fix debug state api limitation

### DIFF
--- a/packages/lodestar/src/api/impl/beacon/state/utils.ts
+++ b/packages/lodestar/src/api/impl/beacon/state/utils.ts
@@ -212,13 +212,13 @@ async function stateBySlot(
 ): Promise<allForks.BeaconState | null> {
   const blockSummary = forkChoice.getCanonicalBlockSummaryAtSlot(slot);
   if (blockSummary) {
-    return stateCache.get(blockSummary.stateRoot) ?? null;
-  } else {
-    if (opts?.regenFinalizedState) {
-      return await getFinalizedState(config, db, forkChoice, slot);
-    }
-    return await db.stateArchive.get(slot);
+    const state = stateCache.get(blockSummary.stateRoot) ?? null;
+    if (state) return state;
   }
+  if (opts?.regenFinalizedState) {
+    return await getFinalizedState(config, db, forkChoice, slot);
+  }
+  return await db.stateArchive.get(slot);
 }
 
 export function filterStateValidatorsByStatuses(

--- a/packages/lodestar/src/api/impl/beacon/state/utils.ts
+++ b/packages/lodestar/src/api/impl/beacon/state/utils.ts
@@ -212,12 +212,16 @@ async function stateBySlot(
 ): Promise<allForks.BeaconState | null> {
   const blockSummary = forkChoice.getCanonicalBlockSummaryAtSlot(slot);
   if (blockSummary) {
-    const state = stateCache.get(blockSummary.stateRoot) ?? null;
-    if (state) return state;
+    const state = stateCache.get(blockSummary.stateRoot);
+    if (state) {
+      return state;
+    }
   }
+
   if (opts?.regenFinalizedState) {
     return await getFinalizedState(config, db, forkChoice, slot);
   }
+
   return await db.stateArchive.get(slot);
 }
 


### PR DESCRIPTION
There were cases when I was testing the weak subjectivity state fetching where I couldn't get a very recently finalized state by its slot.  The `debug/state` would not fetch the state if we couldn't find a block summary in the fork choice and it wouldn't trigger the state API's state regen functionality.  This PR extends the existing solution to regen a state regardless of whether a block summary is found.  