### PR TITLE
Append \n at the end of benchmark result

### DIFF
--- a/packages/utils/src/perf/utils/runner.ts
+++ b/packages/utils/src/perf/utils/runner.ts
@@ -144,9 +144,11 @@ function formatResultRow({id, averageNs, runsDone, factor}: BenchmarkResult): st
  * ```
  */
 function formatAsBenchmarkJs(results: BenchmarkResult[]): string {
-  return results
-    .map(({id, averageNs, runsDone}) => `${id} x ${1e9 / averageNs} ops/sec ±0.00% (${runsDone} runs sampled)`)
-    .join("\n");
+  return (
+    results
+      .map(({id, averageNs, runsDone}) => `${id} x ${1e9 / averageNs} ops/sec ±0.00% (${runsDone} runs sampled)`)
+      .join("\n") + "\n"
+  );
 }
 
 export function formatTitle(title: string): string {


### PR DESCRIPTION
**Motivation**

Incorect benchmark json result

**Description**

Append new line at the end of benchmark result
Closes #2640 

**Test result in local environment**
`benchmark-output.txt`
```
Process regular block x 120.26709879437044 ops/sec ±0.00% (12 runs sampled)
Process blocks with 16 validator exits x 1.6331181572777904 ops/sec ±0.00% (1 runs sampled)
prepareEpochProcessState x 1.2717782470574508 ops/sec ±0.00% (1 runs sampled)
processJustificationAndFinalization x 8398.562166157153 ops/sec ±0.00% (713 runs sampled)
processRewardsAndPenalties x 4.076260524359474 ops/sec ±0.00% (1 runs sampled)
processRegistryUpdates x 128667.00977869274 ops/sec ±0.00% (4334 runs sampled)
processSlashings x 322.3083465936359 ops/sec ±0.00% (32 runs sampled)
processFinalUpdates x 31.938388038894825 ops/sec ±0.00% (4 runs sampled)
getAttestationDeltas x 7.155237287738902 ops/sec ±0.00% (1 runs sampled)
process 1 empty epoch x 0.48423826058812086 ops/sec ±0.00% (1 runs sampled)
process double empty epochs x 0.4076455499669285 ops/sec ±0.00% (1 runs sampled)
process 4 empty epochs x 0.25099692294413567 ops/sec ±0.00% (1 runs sampled)
```
