### PR TITLE
Add release nightly workflow

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      # <common-build> - Uses YAML anchors in the future
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: "14.16.0"
+      - name: Restore dependencies
+        uses: actions/cache@master
+        id: cache-deps
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-14.16.0
+      - name: Install & build
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile --ignore-optional
+      - name: Build
+        run: yarn build
+        if: steps.cache-deps.outputs.cache-hit == 'true'
+      # </common-build>
+
+      # From https://github.com/lerna/lerna/issues/2404
+      - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm registry
+        run: yarn run publish-nightly
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       previous_tag: ${{ steps.get-latest-tag.outputs.tag }}
       version: ${{ steps.tag.outputs.version }}
 
-  release:
+  publish:
     name: Publish
     runs-on: ubuntu-latest
     needs: tag

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "benchmark": "lerna run benchmark",
     "cli": "node --trace-deprecation --max-old-space-size=8192 ./packages/cli/bin/lodestar",
     "publish": "lerna publish from-package --yes --no-verify-access",
+    "publish-nightly": "yarn run publish --canary minor --dist-tag next",
     "release": "lerna version --no-push --sign-git-commit",
     "postrelease": "git tag -d $(git describe --abbrev=0)"
   },


### PR DESCRIPTION
**Motivation**

See https://github.com/ChainSafe/lodestar/issues/2646

**Description**

Adds a new workflow to run on every commit to master to publish a nightly version to NPM, tagged as next. uses the lerna command

```
lerna publish --canary minor --dist-tag next
```

Closes https://github.com/ChainSafe/lodestar/issues/2646