### PR TITLE
Fix lerna publish nightly command

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release nightly
 
 on:
   push:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "benchmark": "lerna run benchmark",
     "cli": "node --trace-deprecation --max-old-space-size=8192 ./packages/cli/bin/lodestar",
     "publish": "lerna publish from-package --yes --no-verify-access",
-    "publish-nightly": "yarn run publish --canary minor --dist-tag next",
+    "publish-nightly": "yarn run publish --canary --dist-tag next",
     "release": "lerna version --no-push --sign-git-commit",
     "postrelease": "git tag -d $(git describe --abbrev=0)"
   },


### PR DESCRIPTION
**Motivation**

lerna publish command is not properly documented, --canary is of boolean type

https://github.com/lerna/lerna/blob/a47fc294393a3e9507a8207a5a2f07648a524722/commands/publish/command.js#L18

**Description**

Fix command