### PR TITLE
Limit release CI concurrency

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,5 +1,10 @@
 name: Release nightly
 
+# only one per github sha can be run
+concurrency: 
+  group: ${{ github.sha }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+# only one can tun at a time
+concurrency: cd-release
+
 on:
   push:
     branches:


### PR DESCRIPTION
Prevent Release jobs for running at once:
- Release: queue them so we don't release twice for the same version
- Release nightly: run only one per sha, cancel current runs