### PR TITLE
Fix getParticipantIndices from SyncAggregate struct

### DIFF
--- a/packages/beacon-state-transition/src/altair/block/processSyncCommittee.ts
+++ b/packages/beacon-state-transition/src/altair/block/processSyncCommittee.ts
@@ -4,16 +4,15 @@ import {DOMAIN_SYNC_COMMITTEE} from "@chainsafe/lodestar-params";
 import {
   computeEpochAtSlot,
   computeSigningRoot,
+  extractParticipantIndices,
   getBlockRootAtSlot,
   getDomain,
   increaseBalance,
   ISignatureSet,
   SignatureSetType,
   verifySignatureSet,
-  zipIndexesInBitList,
 } from "../../util";
 import {CachedBeaconState} from "../../allForks/util";
-import {BitList, isTreeBacked, TreeBacked} from "@chainsafe/ssz";
 
 export function processSyncCommittee(
   state: CachedBeaconState<altair.BeaconState>,
@@ -89,13 +88,5 @@ function getParticipantIndices(
   syncAggregate: altair.SyncAggregate
 ): number[] {
   const committeeIndices = state.currSyncCommitteeIndexes;
-
-  // the only time aggregate is not a TreeBacked is when producing a new block
-  return isTreeBacked(syncAggregate)
-    ? zipIndexesInBitList(
-        committeeIndices,
-        syncAggregate.syncCommitteeBits as TreeBacked<BitList>,
-        ssz.altair.SyncCommitteeBits
-      )
-    : committeeIndices.filter((index) => !!syncAggregate.syncCommitteeBits[index]);
+  return extractParticipantIndices(committeeIndices, syncAggregate);
 }

--- a/packages/beacon-state-transition/src/util/syncCommittee.ts
+++ b/packages/beacon-state-transition/src/util/syncCommittee.ts
@@ -4,9 +4,12 @@ import {
   SYNC_COMMITTEE_SUBNET_COUNT,
   TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE,
 } from "@chainsafe/lodestar-params";
+import {altair} from "@chainsafe/lodestar-types";
+import {ssz} from "@chainsafe/lodestar-types";
 import {BLSSignature, phase0} from "@chainsafe/lodestar-types";
 import {bytesToInt, intDiv} from "@chainsafe/lodestar-utils";
-import {hash} from "@chainsafe/ssz";
+import {BitList, hash, isTreeBacked, TreeBacked} from "@chainsafe/ssz";
+import {zipIndexesInBitList} from "./aggregationBits";
 
 /**
  * TODO
@@ -24,4 +27,25 @@ export function isSyncCommitteeAggregator(selectionProof: BLSSignature): boolean
     intDiv(intDiv(SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_SUBNET_COUNT), TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE)
   );
   return bytesToInt(hash(selectionProof.valueOf() as Uint8Array).slice(0, 8)) % modulo === 0;
+}
+
+export function extractParticipantIndices(
+  committeeIndices: phase0.ValidatorIndex[],
+  syncAggregate: altair.SyncAggregate
+): phase0.ValidatorIndex[] {
+  if (isTreeBacked(syncAggregate)) {
+    return zipIndexesInBitList(
+      committeeIndices,
+      syncAggregate.syncCommitteeBits as TreeBacked<BitList>,
+      ssz.altair.SyncCommitteeBits
+    );
+  } else {
+    const participantIndices = [];
+    for (const [i, index] of committeeIndices.entries()) {
+      if (syncAggregate.syncCommitteeBits[i]) {
+        participantIndices.push(index);
+      }
+    }
+    return participantIndices;
+  }
 }

--- a/packages/beacon-state-transition/test/unit/util/syncCommittee.test.ts
+++ b/packages/beacon-state-transition/test/unit/util/syncCommittee.test.ts
@@ -1,0 +1,30 @@
+import {SYNC_COMMITTEE_SIZE} from "@chainsafe/lodestar-params";
+import {ssz} from "@chainsafe/lodestar-types";
+import {expect} from "chai";
+import {extractParticipantIndices} from "../../../src";
+
+describe("extractParticipantIndices", function () {
+  const committeeIndices = Array.from({length: SYNC_COMMITTEE_SIZE}, (_, i) => i * 2);
+  // 3 first bits are true
+  const syncCommitteeBits = Array.from({length: SYNC_COMMITTEE_SIZE}, (_, i) => {
+    return i < 3 ? true : false;
+  });
+
+  it("should extract from TreeBacked SyncAggregate", function () {
+    const syncAggregate = ssz.altair.SyncAggregate.defaultTreeBacked();
+    syncAggregate.syncCommitteeBits = syncCommitteeBits;
+    expect(extractParticipantIndices(committeeIndices, syncAggregate)).to.be.deep.equal(
+      [0, 2, 4],
+      "Incorrect participant indices from TreeBacked SyncAggregate"
+    );
+  });
+
+  it("should extract from struct SyncAggregate", function () {
+    const syncAggregate = ssz.altair.SyncAggregate.defaultValue();
+    syncAggregate.syncCommitteeBits = syncCommitteeBits;
+    expect(extractParticipantIndices(committeeIndices, syncAggregate)).to.be.deep.equal(
+      [0, 2, 4],
+      "Incorrect participant indices from TreeBacked SyncAggregate"
+    );
+  });
+});


### PR DESCRIPTION
**Motivation**
`getParticipantIndices` is correct for tree backed object but not struct

**Description**

+ same way to get attesting indexes from a struct https://github.com/ChainSafe/lodestar/blob/0c4f8315fa4596e5bb0ff8ada8e8d8c38499b6da/packages/beacon-state-transition/src/allForks/util/epochContext.ts#L414
