### PR TITLE
Extract nextSyncCommitteeIndexes from BeaconState

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/epochContext.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochContext.ts
@@ -262,7 +262,11 @@ export function rotateEpochs(
   // State slot has already been += 1
   if (currEpoch % EPOCHS_PER_SYNC_COMMITTEE_PERIOD === 0 && currEpoch > epochCtx.config.ALTAIR_FORK_EPOCH) {
     epochCtx.currSyncCommitteeIndexes = epochCtx.nextSyncCommitteeIndexes;
-    epochCtx.nextSyncCommitteeIndexes = getNextSyncCommitteeIndices(state);
+    epochCtx.nextSyncCommitteeIndexes = computeSyncCommitteeIndices(
+      epochCtx.pubkey2index,
+      state as altair.BeaconState,
+      true
+    );
     epochCtx.currSyncComitteeValidatorIndexMap = epochCtx.nextSyncComitteeValidatorIndexMap;
     epochCtx.nextSyncComitteeValidatorIndexMap = computeSyncComitteeMap(epochCtx.nextSyncCommitteeIndexes);
   }


### PR DESCRIPTION
**Motivation**

+ We have "Invalid state root" issue when syncing oonoonba at sync committee period boundary
+ It's because we don't have correct sync committee indices

**Description**
+ `getNextSyncCommitteeIndices` should only be called at epoch transition (when we haven't increased the slot) while we called it in `rotateEpochs`, except for at `ALTAIR_FORK_EPOCH`
+ having incorrect epoch means incorrect active validator indices
+ instead we should only extract sync committee indices from BeaconState and the cached `pubkey2indices` since `nextSyncCommittee` is calculated at epoch transition (sync committee period transition) already
Closes #2631

**Steps to test or reproduce**

+ sync `oonoonba` network