### PR TITLE
Use TreeBacked pending block

### DIFF
--- a/packages/lodestar/src/db/repositories/pendingBlock.ts
+++ b/packages/lodestar/src/db/repositories/pendingBlock.ts
@@ -26,6 +26,6 @@ export class PendingBlockRepository extends Repository<Uint8Array, allForks.Sign
   }
 
   decodeValue(data: Buffer): allForks.SignedBeaconBlock {
-    return getSignedBlockTypeFromBytes(this.config, data).deserialize(data);
+    return getSignedBlockTypeFromBytes(this.config, data).createTreeBackedFromBytes(data);
   }
 }


### PR DESCRIPTION
**Motivation**

+ We used TreeBacked from gossip, req/resp, reprocess blocks
+ We should use that for pending block as well to improve performance

**Description**

+ Modify `pendingBlock` repo
Closes #2454 

