### PR TITLE
Print pretty time units in benchmark

### DIFF
--- a/packages/utils/src/perf/utils/runner.ts
+++ b/packages/utils/src/perf/utils/runner.ts
@@ -127,10 +127,11 @@ function formatResultRow({id, averageNs, runsDone, factor}: BenchmarkResult): st
   // Scalar multiplication G1 (255-bit, constant-time)                              7219.330 ops/s       138517 ns/op
   // Scalar multiplication G2 (255-bit, constant-time)                              3133.117 ops/s       319171 ns/op
 
+  const [averageTime, timeUnit] = prettyTime(averageNs);
   const row = [
     factor === undefined ? "" : `x${factor.toFixed(2)}`.padStart(6),
     `${opsPerSec.toPrecision(precision).padStart(13)} ops/s`,
-    `${averageNs.toPrecision(precision).padStart(13)} ns/op`,
+    `${averageTime.toPrecision(precision).padStart(13)} ${timeUnit}/op`,
     `${String(runsDone).padStart(6)} runs`,
   ].join(" ");
 
@@ -155,4 +156,11 @@ export function formatTitle(title: string): string {
   return `
 ${title}
 ${"=".repeat(64)}`;
+}
+
+function prettyTime(nanoSec: number): [number, string] {
+  if (nanoSec > 1e9) return [nanoSec / 1e9, " s"];
+  if (nanoSec > 1e6) return [nanoSec / 1e6, "ms"];
+  if (nanoSec > 1e3) return [nanoSec / 1e3, "us"];
+  return [nanoSec, "ns"];
 }


### PR DESCRIPTION
**Motivation**

In benchmark prints large nano second times are hard to read

**Description**

Instead of printing nano seconds, print the closest time unit.

```
Process block
================================================================
Process regular block                                                  190.3136 ops/s      5.254485 ms/op     50 runs
Process blocks with 16 validator exits                                 1.801513 ops/s      555.0891 ms/op     50 runs

Epoch transition steps
================================================================
prepareEpochProcessState                                               1.332269 ops/s      750.5990 ms/op     50 runs
processJustificationAndFinalization                                    7173.961 ops/s      139.3930 us/op    628 runs
processRewardsAndPenalties                                             2.969850 ops/s      336.7173 ms/op     50 runs
processRegistryUpdates                                                 107503.8 ops/s      9.302000 us/op   3580 runs
processSlashings                                                       230.0282 ops/s      4.347294 ms/op     50 runs
processFinalUpdates                                                    22.35642 ops/s      44.72989 ms/op     50 runs

getAttestationDeltas
================================================================
getAttestationDeltas                                                   6.034161 ops/s      165.7231 ms/op     25 runs

Epoch transitions
================================================================
process 1 empty epoch                                                 0.6343101 ops/s      1.576516  s/op      5 runs
process double empty epochs                                           0.3361317 ops/s      2.975024  s/op      5 runs
process 4 empty epochs                                                0.1734872 ops/s      5.764114  s/op      5 runs
```