### PR TITLE
get head metric

### DIFF
--- a/packages/fork-choice/src/index.ts
+++ b/packages/fork-choice/src/index.ts
@@ -1,2 +1,3 @@
+export * from "./metrics";
 export * from "./protoArray";
 export * from "./forkChoice";

--- a/packages/fork-choice/src/metrics.ts
+++ b/packages/fork-choice/src/metrics.ts
@@ -1,0 +1,7 @@
+export interface IForkChoiceMetrics {
+  forkChoiceFindHead: IHistogram;
+}
+
+interface IHistogram {
+  startTimer(): () => void;
+}

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -89,7 +89,13 @@ export class BeaconChain implements IBeaconChain {
     const stateCache = new StateContextCache();
     const checkpointStateCache = new CheckpointStateCache(config);
     const cachedState = restoreStateCaches(config, stateCache, checkpointStateCache, anchorState);
-    const forkChoice = new LodestarForkChoice({config, emitter, currentSlot: clock.currentSlot, state: cachedState});
+    const forkChoice = new LodestarForkChoice({
+      config,
+      emitter,
+      currentSlot: clock.currentSlot,
+      state: cachedState,
+      metrics,
+    });
     const regen = new QueuedStateRegenerator({
       config,
       emitter,

--- a/packages/lodestar/src/chain/forkChoice/forkChoice.ts
+++ b/packages/lodestar/src/chain/forkChoice/forkChoice.ts
@@ -11,6 +11,7 @@ import {computeAnchorCheckpoint} from "../initState";
 import {ChainEventEmitter} from "../emitter";
 import {ForkChoiceStore} from "./store";
 import {getEffectiveBalances, CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {IMetrics} from "../../metrics";
 
 /**
  * Fork Choice extended with a ChainEventEmitter
@@ -21,11 +22,13 @@ export class LodestarForkChoice extends ForkChoice {
     emitter,
     currentSlot,
     state,
+    metrics,
   }: {
     config: IBeaconConfig;
     emitter: ChainEventEmitter;
     currentSlot: Slot;
     state: CachedBeaconState<allForks.BeaconState>;
+    metrics: IMetrics | null;
   }) {
     const {blockHeader, checkpoint} = computeAnchorCheckpoint(config, state);
     const finalizedCheckpoint = {...checkpoint};
@@ -60,6 +63,7 @@ export class LodestarForkChoice extends ForkChoice {
 
       queuedAttestations: new Set(),
       justifiedBalances,
+      metrics,
     });
   }
 }

--- a/packages/lodestar/src/metrics/metrics/beacon.ts
+++ b/packages/lodestar/src/metrics/metrics/beacon.ts
@@ -120,5 +120,11 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
       name: "beacon_observed_epoch_aggregators",
       help: "number of aggregators for which we have seen an attestation, not necessarily included on chain.",
     }),
+
+    forkChoiceFindHead: register.histogram({
+      name: "beacon_fork_choice_find_head_seconds",
+      help: "Time taken to find head in seconds",
+      buckets: [0.1, 1, 10],
+    }),
   };
 }


### PR DESCRIPTION
**Motivation**

forkChoice metric for beacon_fork_choice_find_head for #2558 with regard to #2455

**Description**
This commit implements the fork_choice_find_head metric as a reference for other fork choice metrics. 
![image](https://user-images.githubusercontent.com/76567250/121356172-3fcd8e00-c94e-11eb-9caa-d3fa63005fba.png)

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
