### PR TITLE
Remove missing bin

### DIFF
--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -13,9 +13,6 @@
   },
   "version": "0.24.0",
   "main": "lib/index.js",
-  "bin": {
-    "lodestar": "./bin/lodestar"
-  },
   "files": [
     "lib/**/*.d.ts",
     "lib/**/*.js",


### PR DESCRIPTION
**Motivation**

`@chainsafe/lodestar-cli` can't be installed.

```
19476 warn lodeee@1.0.0 No description
19477 warn lodeee@1.0.0 No repository field.
19478 verbose stack Error: ENOENT: no such file or directory, chmod '/root/lodeee/node_modules/@chainsafe/lodestar-cli/node_modules/@chainsafe/lodestar/bin/lodestar'
19479 verbose cwd /root/lodeee
19480 verbose Linux 5.4.0-67-generic
19481 verbose argv "/root/.nvm/versions/node/v14.16.0/bin/node" "/root/.nvm/versions/node/v14.16.0/bin/npm" "i" "@chainsafe/lodestar-cli"
19482 verbose node v14.16.0
19483 verbose npm  v6.14.11
19484 error code ENOENT
19485 error syscall chmod
19486 error path /root/lodeee/node_modules/@chainsafe/lodestar-cli/node_modules/@chainsafe/lodestar/bin/lodestar
19487 error errno -2
19488 error enoent ENOENT: no such file or directory, chmod '/root/lodeee/node_modules/@chainsafe/lodestar-cli/node_modules/@chainsafe/lodestar/bin/lodestar'
19489 error enoent This is related to npm not being able to find a file.
19490 verbose exit [ -2, true ]
```

**Description**

Remove a reference to a non-existent bin in the lodestar package