### PR TITLE
Publish nightly version to Docker Hub too

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - run: docker build --tag chainsafe/lodestar:next .
+      - run: docker build --tag chainsafe/lodestar:next --build-arg VERSION=${{ needs.publish.outputs.version }} .
       - run: docker tag chainsafe/lodestar:next chainsafe/lodestar:${{ needs.publish.outputs.version }}
         # Push all tags
       - run: docker push chainsafe/lodestar

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,7 +1,7 @@
 name: Release nightly
 
 # only one per github sha can be run
-concurrency: 
+concurrency:
   group: ${{ github.sha }}
   cancel-in-progress: true
 
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "14.16.0"
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - name: Restore dependencies
         uses: actions/cache@master
         id: cache-deps
@@ -40,3 +40,24 @@ jobs:
         run: yarn run publish:nightly
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Get latest tag
+        uses: actions-ecosystem/action-get-latest-tag@v1
+        with:
+          with_initial_version: false
+        id: tag
+
+  docker:
+    name: Publish to Docker Hub
+    runs-on: ubuntu-latest
+    needs: publish
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # TODO: Prevent Docker Hub tagging this image as "latest", tag as "next" instead
+      - run: docker build --tag chainsafe/lodestar:${{ needs.publish.outputs.tag }} .
+      - run: docker push chainsafe/lodestar:${{ needs.publish.outputs.tag }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -41,11 +41,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Get latest tag
-        uses: actions-ecosystem/action-get-latest-tag@v1
-        with:
-          with_initial_version: false
-        id: tag
+      - name: Get version
+        id: version
+        run: echo "::set-output name=version::$(node -p "require('./package.json').version")"
+    outputs:
+      version: ${{ steps.version.outputs.version }}
 
   docker:
     name: Publish to Docker Hub
@@ -58,6 +58,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      # TODO: Prevent Docker Hub tagging this image as "latest", tag as "next" instead
-      - run: docker build --tag chainsafe/lodestar:${{ needs.publish.outputs.tag }} .
-      - run: docker push chainsafe/lodestar:${{ needs.publish.outputs.tag }}
+      - run: docker build --tag chainsafe/lodestar:next .
+      - run: docker tag chainsafe/lodestar:next chainsafe/lodestar:${{ needs.publish.outputs.version }}
+        # Push all tags - TODO: Prevent Docker Hub tagging this image as "latest"
+      - run: docker push chainsafe/lodestar

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -60,5 +60,5 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - run: docker build --tag chainsafe/lodestar:next .
       - run: docker tag chainsafe/lodestar:next chainsafe/lodestar:${{ needs.publish.outputs.version }}
-        # Push all tags - TODO: Prevent Docker Hub tagging this image as "latest"
+        # Push all tags
       - run: docker push chainsafe/lodestar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - run: docker build --tag chainsafe/lodestar:latest .
+      - run: docker build --tag chainsafe/lodestar:latest --build-arg VERSION=${{ needs.tag.outputs.tag }} .
       - run: docker tag chainsafe/lodestar:latest chainsafe/lodestar:${{ needs.tag.outputs.tag }}
         # Push all tags
       - run: docker push chainsafe/lodestar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,8 +108,9 @@ jobs:
           delete_orphan_tag: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   docker:
-    name: Build docker image
+    name: Publish to Docker Hub
     runs-on: ubuntu-latest
     needs: tag
     if: needs.tag.outputs.tag != ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,5 +121,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - run: docker build --tag chainsafe/lodestar:${{ needs.tag.outputs.tag }} .
-      - run: docker push chainsafe/lodestar:${{ needs.tag.outputs.tag }}
+      - run: docker build --tag chainsafe/lodestar:latest .
+      - run: docker tag chainsafe/lodestar:latest chainsafe/lodestar:${{ needs.tag.outputs.tag }}
+        # Push all tags
+      - run: docker push chainsafe/lodestar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,18 +37,3 @@ jobs:
         run: yarn coverage
       - name: E2e tests
         run: yarn test:e2e
-
-  docker:
-    name: Build docker image
-    runs-on: ubuntu-latest
-    needs: [tests-main]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    steps:
-      - uses: actions/checkout@v2
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - run: docker build --tag chainsafe/lodestar:latest .
-      - run: docker push chainsafe/lodestar:latest

--- a/docker-compose.validator.yml
+++ b/docker-compose.validator.yml
@@ -1,8 +1,7 @@
 version: "3.4"
 services:
   validator:
-    build: .
-    image: lodestar
+    image: chainsafe/lodestar@next
     restart: always
     volumes:
       - validator:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 version: "3.4"
 services:
   beacon_node:
-    build: .
-    image: lodestar
+    image: chainsafe/lodestar@next
     restart: always
     volumes:
       - beacon_node:/data


### PR DESCRIPTION
**Motivation**

With https://github.com/ChainSafe/lodestar/pull/2647 we are releasing nightly versions to NPM. We should do the same for Docker Hub.

**Description**

Grab the tag from lerna's logic and publish to Docker Hub.