### PR TITLE
Fix package.json root files relative paths

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,8 +17,8 @@
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "lib/**/*.js.map",
-    "./*.d.ts",
-    "./*.js"
+    "*.d.ts",
+    "*.js"
   ],
   "scripts": {
     "clean": "rm -rf lib && rm -f *.tsbuildinfo",

--- a/packages/beacon-state-transition/package.json
+++ b/packages/beacon-state-transition/package.json
@@ -17,8 +17,8 @@
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "lib/**/*.js.map",
-    "./*.d.ts",
-    "./*.js"
+    "*.d.ts",
+    "*.js"
   ],
   "scripts": {
     "clean": "rm -rf lib && rm -f *.tsbuildinfo",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -14,8 +14,8 @@
     "lib/**/*.js",
     "lib/**/*.js.map",
     "lib/**/*.d.ts",
-    "./*.d.ts",
-    "./*.js"
+    "*.d.ts",
+    "*.js"
   ],
   "scripts": {
     "clean": "rm -rf lib && rm -f *.tsbuildinfo",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -16,8 +16,8 @@
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "lib/**/*.js.map",
-    "./*.d.ts",
-    "./*.js"
+    "*.d.ts",
+    "*.js"
   ],
   "scripts": {
     "clean": "rm -rf lib && rm -f *.tsbuildinfo",

--- a/packages/fork-choice/package.json
+++ b/packages/fork-choice/package.json
@@ -17,8 +17,8 @@
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "lib/**/*.js.map",
-    "./*.d.ts",
-    "./*.js"
+    "*.d.ts",
+    "*.js"
   ],
   "scripts": {
     "clean": "rm -rf lib && rm -f *.tsbuildinfo",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -17,8 +17,8 @@
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "lib/**/*.js.map",
-    "./*.d.ts",
-    "./*.js"
+    "*.d.ts",
+    "*.js"
   ],
   "scripts": {
     "clean": "rm -rf lib && rm -f *.tsbuildinfo",

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -17,8 +17,8 @@
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "lib/**/*.js.map",
-    "./*.d.ts",
-    "./*.js"
+    "*.d.ts",
+    "*.js"
   ],
   "scripts": {
     "clean": "rm -rf lib && rm -f *.tsbuildinfo",

--- a/packages/params/package.json
+++ b/packages/params/package.json
@@ -14,8 +14,8 @@
     "lib/**/*.js",
     "lib/**/*.js.map",
     "lib/**/*.d.ts",
-    "./*.d.ts",
-    "./*.js"
+    "*.d.ts",
+    "*.js"
   ],
   "scripts": {
     "clean": "rm -rf lib && rm -f *.tsbuildinfo",

--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -14,8 +14,8 @@
     "lib/**/*.js",
     "lib/**/*.js.map",
     "lib/**/*.d.ts",
-    "./*.d.ts",
-    "./*.js"
+    "*.d.ts",
+    "*.js"
   ],
   "bin": {
     "eth2-spec-test-download": "lib/downloadTestsCli.js"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -17,8 +17,8 @@
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "lib/**/*.js.map",
-    "./*.d.ts",
-    "./*.js"
+    "*.d.ts",
+    "*.js"
   ],
   "scripts": {
     "clean": "rm -rf lib && rm -f *.tsbuildinfo",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,8 +17,8 @@
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "lib/**/*.js.map",
-    "./*.d.ts",
-    "./*.js"
+    "*.d.ts",
+    "*.js"
   ],
   "scripts": {
     "clean": "rm -rf lib && rm -f *.tsbuildinfo",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -13,8 +13,8 @@
     "lib/**/*.js",
     "lib/**/*.js.map",
     "lib/**/*.d.ts",
-    "./*.d.ts",
-    "./*.js"
+    "*.d.ts",
+    "*.js"
   ],
   "scripts": {
     "clean": "rm -rf lib && rm -f *.tsbuildinfo",


### PR DESCRIPTION
**Motivation**

PR https://github.com/ChainSafe/lodestar/pull/2669 did not solve the issue since npm publish does not include root files with a relative link of `./*.js` but only with `*.js`. NPM installations are still broken but should be fixed with this PR.

**Description**

Update root files paths in package.json