### PR TITLE
Fetch version from lodestar package package.json

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -43,7 +43,10 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "::set-output name=version::$(node -p "require('./package.json').version")"
+        run: |
+          VERSION=$(node -p "require('./packages/lodestar/package.json').version")
+          echo VERSION $VERSION
+          echo "::set-output name=version::$VERSION"
     outputs:
       version: ${{ steps.version.outputs.version }}
 


### PR DESCRIPTION
**Motivation**

Docker build nightly breaks due to fetching the version from root package.json

```
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @chainsafe/lodestar-cli@undefined.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2021-06-10T10_09_11_007Z-debug.log
The command '/bin/sh -c npm install @chainsafe/lodestar-cli@$VERSION' returned a non-zero code: 1
```

https://github.com/ChainSafe/lodestar/runs/2792369225?check_suite_focus=true

**Description**

Fetch version from lodestar package json