### PR TITLE
Increase minMs in benchmark runs

### DIFF
--- a/packages/beacon-state-transition/test/perf/phase0/block/block.perf.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/block/block.perf.ts
@@ -15,6 +15,7 @@ import {generatePerformanceBlock, generatePerfTestCachedBeaconState, initBLS} fr
 export const runBlockTransitionTests = async (): Promise<void> => {
   const runner = new BenchmarkRunner("Process block", {
     maxMs: 5 * 60 * 1000,
+    minMs: 15 * 1000,
     runs: 50,
   });
   await initBLS();

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.perf.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.perf.ts
@@ -45,6 +45,7 @@ let state: allForks.CachedBeaconState<phase0.BeaconState>;
 export const runEpochTransitionStepTests = async (): Promise<void> => {
   const runner = new BenchmarkRunner("Epoch transition steps", {
     maxMs: 10 * 60 * 1000,
+    minMs: 15 * 1000,
     runs: 50,
   });
   await initBLS();

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/getAttestationDeltas.perf.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/getAttestationDeltas.perf.ts
@@ -5,6 +5,7 @@ import {generatePerfTestCachedBeaconState, initBLS} from "../../util";
 export const runGetAttestationDeltaTest = async (): Promise<void> => {
   const runner = new BenchmarkRunner("getAttestationDeltas", {
     maxMs: 5 * 60 * 1000,
+    minMs: 15 * 1000,
     runs: 25,
   });
   await initBLS();

--- a/packages/beacon-state-transition/test/perf/phase0/slot/slots.perf.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/slot/slots.perf.ts
@@ -21,6 +21,7 @@ let state: allForks.CachedBeaconState<phase0.BeaconState>;
 export const runEpochTransitionTests = async (): Promise<void> => {
   const runner = new BenchmarkRunner("Epoch transitions", {
     maxMs: 5 * 60 * 1000,
+    minMs: 15 * 1000,
     runs: 5,
   });
   for (const {name, numSlot} of testCases) {


### PR DESCRIPTION
**Motivation**

Benchmark runs for fast functions are very unstable https://github.com/ChainSafe/lodestar/runs/2792589222.

**Description**

 Increase the min total time to run to 15 sec to even out results