### PR TITLE
Benchmark only 1 epoch of empty slots

### DIFF
--- a/packages/beacon-state-transition/test/perf/phase0/block/block.perf.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/block/block.perf.ts
@@ -36,7 +36,7 @@ export async function runBlockTransitionTests(): Promise<void> {
 
   const testCases = [
     {signedBlock, name: "Process regular block"},
-    {signedBlock: validatorExitsBlock, name: `Process blocks with ${numValidatorExits} validator exits`},
+    {signedBlock: validatorExitsBlock, name: `Process block with ${numValidatorExits} validator exits`},
   ];
 
   for (const {name, signedBlock} of testCases) {

--- a/packages/beacon-state-transition/test/perf/phase0/slot/slots.perf.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/slot/slots.perf.ts
@@ -2,11 +2,8 @@ import {generatePerfTestCachedBeaconState, initBLS} from "../../util";
 import {BenchmarkRunner} from "@chainsafe/lodestar-utils/test_utils/benchmark";
 import {allForks} from "../../../../src";
 
-const testCases = [
-  {numSlot: 32, name: "process 1 empty epoch"},
-  {numSlot: 64, name: "process double empty epochs"},
-  {numSlot: 128, name: "process 4 empty epochs"},
-];
+// Testing going through 1,2,4 epoch transitions has the same proportional result
+const testCases = [{numSlot: 32, name: "process 1 empty epoch"}];
 
 // As of Jun 01 2021
 // Epoch transitions


### PR DESCRIPTION
**Motivation**

Testing going through 1,2,4 epoch transitions has the same proportional result

**Description**

Only benchmark for 1 epoch transition, save job time,