### PR TITLE
daily log rotate with logRotate cli option

### DIFF
--- a/docker-compose.validator.yml
+++ b/docker-compose.validator.yml
@@ -10,7 +10,7 @@ services:
       - ./keystores:/keystores
       - ./secrets:/secrets
     env_file: .env
-    command: validator --rootDir /data --keystoresDir /keystores --secretsDir /secrets --server http://beacon_node:9596 --logFile /logs/validator.log --logLevelFile debug
+    command: validator --rootDir /data --keystoresDir /keystores --secretsDir /secrets --server http://beacon_node:9596 --logFile /logs/validator.log --logLevelFile debug --logRotate
 
 volumes:
   validator:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "9000:9000" # P2P port
       - "9596:9596" # REST API port
-    command: beacon --rootDir /data --api.rest.host 0.0.0.0 --metrics.enabled --logFile /logs/beacon.log --logLevelFile debug
+    command: beacon --rootDir /data --api.rest.host 0.0.0.0 --metrics.enabled --logFile /logs/beacon.log --logLevelFile debug --logRotate
 
   prometheus:
     build: docker/prometheus

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -53,6 +53,11 @@ export const logOptions: ICliCommandOptions<ILogArgs> = {
     description: "Logger format - Prefix module field with a string ID",
     type: "string",
   },
+
+  logRotate: {
+    description: "Daily rotate log file to keep last 5 (including current)",
+    type: "boolean",
+  },
 };
 
 export const beaconPathsOptions: ICliCommandOptions<IBeaconPaths> = {

--- a/packages/cli/src/util/logger.ts
+++ b/packages/cli/src/util/logger.ts
@@ -15,6 +15,7 @@ export interface ILogArgs {
   logLevelFile?: LogLevel;
   logFormatGenesisTime?: number;
   logFormatId?: string;
+  logRotate?: boolean;
 }
 
 export function errorLogger(): ILogger {
@@ -27,7 +28,12 @@ export function errorLogger(): ILogger {
 export function getCliLogger(args: ILogArgs, paths: {logFile?: string}, config: IBeaconConfig): ILogger {
   const transports: TransportOpts[] = [{type: TransportType.console}];
   if (paths.logFile) {
-    transports.push({type: TransportType.file, filename: paths.logFile, level: args.logLevelFile});
+    transports.push({
+      type: TransportType.file,
+      filename: paths.logFile,
+      level: args.logLevelFile,
+      rotate: args.logRotate,
+    });
   }
 
   const timestampFormat: TimestampFormat =

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -43,7 +43,8 @@
     "chalk": "^2.4.2",
     "js-yaml": "^3.13.1",
     "winston": "^3.3.3",
-    "winston-transport": "^4.3.0"
+    "winston-transport": "^4.3.0",
+    "winston-daily-rotate-file": "^4.5.5"
   },
   "devDependencies": {
     "@types/js-yaml": "^3.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6106,6 +6106,13 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
+file-stream-rotator@^0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/file-stream-rotator/-/file-stream-rotator-0.5.7.tgz#868a2e5966f7640a17dd86eda0e4467c089f6286"
+  integrity sha512-VYb3HZ/GiAGUCrfeakO8Mp54YGswNUHvL7P09WQcXAJNSj3iQ5QraYSp3cIn1MUyw6uzfgN/EFOarCNa4JvUHQ==
+  dependencies:
+    moment "^2.11.2"
+
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
@@ -9095,6 +9102,11 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+moment@^2.11.2:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 moving-average@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/moving-average/-/moving-average-1.0.0.tgz#b1247ba8dd2d7927c619f1eac8036cf933d65adc"
@@ -9739,6 +9751,11 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
+
+object-hash@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
 
 object-inspect@^1.7.0:
   version "1.7.0"
@@ -13051,6 +13068,16 @@ windows-release@^3.1.0:
   integrity sha512-2HetyTg1Y+R+rUgrKeUEhAG/ZuOmTrI1NBb3ZyAGQMYmOJjBBPe4MTodghRkmLJZHwkuPi02anbeGP+Zf401LQ==
   dependencies:
     execa "^1.0.0"
+
+winston-daily-rotate-file@^4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/winston-daily-rotate-file/-/winston-daily-rotate-file-4.5.5.tgz#cfa3a89f4eb0e4126917592b375759b772bcd972"
+  integrity sha512-ds0WahIjiDhKCiMXmY799pDBW+58ByqIBtUcsqr4oDoXrAI3Zn+hbgFdUxzMfqA93OG0mPLYVMiotqTgE/WeWQ==
+  dependencies:
+    file-stream-rotator "^0.5.7"
+    object-hash "^2.0.1"
+    triple-beam "^1.3.0"
+    winston-transport "^4.4.0"
 
 winston-transport@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
**Motivation**
This PR adds the capability to daily log rotate winston log files with `--logRotate` cli option. If enabled  it will log with date pattern `YYYY-MM-DD` and maintain last five day log files.

![image](https://user-images.githubusercontent.com/76567250/121810480-af10ee00-cc7e-11eb-86d6-57d233820dfb.png)

<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number
#2477
**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
