### PR TITLE
Force blst-native on benchmarks

### DIFF
--- a/packages/beacon-state-transition/test/perf/phase0/block/block.perf.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/block/block.perf.ts
@@ -1,9 +1,10 @@
+import {init} from "@chainsafe/bls";
 import {MAX_VOLUNTARY_EXITS} from "@chainsafe/lodestar-params";
 import {phase0} from "@chainsafe/lodestar-types";
 import {BenchmarkRunner} from "@chainsafe/lodestar-utils/test_utils/benchmark";
 import {List} from "@chainsafe/ssz";
 import {allForks} from "../../../../src";
-import {generatePerformanceBlock, generatePerfTestCachedBeaconState, initBLS} from "../../util";
+import {generatePerformanceBlock, generatePerfTestCachedBeaconState} from "../../util";
 
 // As of Jun 01 2021
 // Process block
@@ -18,7 +19,7 @@ export async function runBlockTransitionTests(): Promise<void> {
     minMs: 15 * 1000,
     runs: 64,
   });
-  await initBLS();
+  await init("blst-native");
 
   const originalState = generatePerfTestCachedBeaconState() as allForks.CachedBeaconState<allForks.BeaconState>;
   const signedBlock = generatePerformanceBlock();

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.perf.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.perf.ts
@@ -1,6 +1,7 @@
+import {init} from "@chainsafe/bls";
 import {BenchmarkRunner} from "@chainsafe/lodestar-utils/test_utils/benchmark";
 import {allForks, phase0} from "../../../../src";
-import {generatePerfTestCachedBeaconState, initBLS} from "../../util";
+import {generatePerfTestCachedBeaconState} from "../../util";
 
 export async function runEpochTransitionStepTests(): Promise<void> {
   const runner = new BenchmarkRunner("Epoch transition steps", {
@@ -9,7 +10,7 @@ export async function runEpochTransitionStepTests(): Promise<void> {
     runs: 64,
   });
 
-  await initBLS();
+  await init("blst-native");
 
   const originalState = generatePerfTestCachedBeaconState({goBackOneSlot: true});
   const process = allForks.prepareEpochProcessState(originalState);

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/getAttestationDeltas.perf.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/getAttestationDeltas.perf.ts
@@ -1,6 +1,7 @@
+import {init} from "@chainsafe/bls";
 import {BenchmarkRunner} from "@chainsafe/lodestar-utils/test_utils/benchmark";
 import {allForks, phase0} from "../../../../src";
-import {generatePerfTestCachedBeaconState, initBLS} from "../../util";
+import {generatePerfTestCachedBeaconState} from "../../util";
 
 export async function runGetAttestationDeltaTest(): Promise<void> {
   const runner = new BenchmarkRunner("getAttestationDeltas", {
@@ -9,7 +10,7 @@ export async function runGetAttestationDeltaTest(): Promise<void> {
     runs: 64,
   });
 
-  await initBLS();
+  await init("blst-native");
   const state = generatePerfTestCachedBeaconState({goBackOneSlot: true});
   const epochProcess = allForks.prepareEpochProcessState(state);
 

--- a/packages/beacon-state-transition/test/perf/phase0/slot/slots.perf.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/slot/slots.perf.ts
@@ -1,4 +1,5 @@
-import {generatePerfTestCachedBeaconState, initBLS} from "../../util";
+import {init} from "@chainsafe/bls";
+import {generatePerfTestCachedBeaconState} from "../../util";
 import {BenchmarkRunner} from "@chainsafe/lodestar-utils/test_utils/benchmark";
 import {allForks} from "../../../../src";
 
@@ -19,7 +20,8 @@ export async function runEpochTransitionTests(): Promise<void> {
     runs: 64,
   });
 
-  await initBLS();
+  await init("blst-native");
+
   const originalState = generatePerfTestCachedBeaconState({goBackOneSlot: true});
 
   for (const {name, numSlot} of testCases) {

--- a/packages/beacon-state-transition/test/perf/util.ts
+++ b/packages/beacon-state-transition/test/perf/util.ts
@@ -1,6 +1,6 @@
 import {config} from "@chainsafe/lodestar-config/default";
 import {Gwei, phase0, ssz} from "@chainsafe/lodestar-types";
-import bls, {CoordType, init, PublicKey} from "@chainsafe/bls";
+import bls, {CoordType, PublicKey} from "@chainsafe/bls";
 import {fromHexString, List, TreeBacked} from "@chainsafe/ssz";
 import {getBeaconProposerIndex} from "../../src/util/proposer";
 import {allForks, computeEpochAtSlot} from "../../src";
@@ -218,14 +218,4 @@ export function generatePerformanceBlock(): TreeBacked<phase0.SignedBeaconBlock>
     logger.verbose("Loaded block", {slot: signedBlock.message.slot});
   }
   return signedBlock.clone();
-}
-
-export async function initBLS(): Promise<void> {
-  try {
-    await init("blst-native");
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.warn("Performance warning: Using fallback wasm BLS implementation");
-    await init("herumi");
-  }
 }


### PR DESCRIPTION
**Motivation**

Benchmarks must always be done with blst-native not herumi, otherwise the results will be unpredictable

**Description**

Throw if blst-native is not available