### PR TITLE
Cache head in fork choice

### DIFF
--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -32,7 +32,6 @@ import {IForkChoice, ILatestMessage, IQueuedAttestation} from "./interface";
  * This class MUST be used with the following considerations:
  *
  * - Time is not updated automatically, updateTime MUST be called every slot
- * - Justified balances are not updated automatically, updateBalances MUST be called when Store justifiedCheckpoint is updated
  */
 export class ForkChoice implements IForkChoice {
   config: IBeaconConfig;
@@ -148,7 +147,23 @@ export class ForkChoice implements IForkChoice {
   }
 
   /**
+   * Get the cached head root
+   */
+  getHeadRoot(): Uint8Array {
+    const head = this.getHead();
+    return head.blockRoot;
+  }
+
+  /**
+   * Get the cached head
+   */
+  getHead(): IBlockSummary {
+    return this.head;
+  }
+
+  /**
    * Run the fork choice rule to determine the head.
+   * Update the head cache.
    *
    * ## Specification
    *
@@ -156,15 +171,6 @@ export class ForkChoice implements IForkChoice {
    *
    * https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/fork-choice.md#get_head
    */
-  getHeadRoot(): Uint8Array {
-    const head = this.getHead();
-    return head.blockRoot;
-  }
-
-  getHead(): IBlockSummary {
-    return this.head;
-  }
-
   updateHead(): IBlockSummary {
     // balances is not changed but votes are changed
     if (!this.synced) {

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -548,6 +548,7 @@ export class ForkChoice implements IForkChoice {
   }
 
   private updateJustified(justifiedCheckpoint: phase0.Checkpoint, justifiedBalances: Gwei[]): void {
+    this.synced = false;
     this.justifiedBalances = justifiedBalances;
     this.fcStore.justifiedCheckpoint = justifiedCheckpoint;
   }

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -24,6 +24,7 @@ export interface IForkChoice {
    */
   getHeadRoot(): Uint8Array;
   getHead(): IBlockSummary;
+  updateHead(): IBlockSummary;
   /**
    * Retrieves all possible chain heads (leaves of fork choice tree).
    */

--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -107,6 +107,7 @@ export async function runStateTransition(
     justifiedBalances = getEffectiveBalances(justifiedState);
   }
   forkChoice.onBlock(job.signedBlock.message, postState, justifiedBalances);
+  forkChoice.updateHead();
 
   if (!job.reprocess) {
     if (postSlot % SLOTS_PER_EPOCH === 0) {

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -187,6 +187,7 @@ function mockForkChoice(): IForkChoice {
     getAncestor: () => root,
     getHeadRoot: () => root,
     getHead: () => blockSummary,
+    updateHead: () => blockSummary,
     getHeads: () => [blockSummary],
     getFinalizedCheckpoint: () => checkpoint,
     getJustifiedCheckpoint: () => checkpoint,

--- a/packages/spec-test-runner/test/spec/altair/fork_choice/fork_choice.ts
+++ b/packages/spec-test-runner/test/spec/altair/fork_choice/fork_choice.ts
@@ -74,7 +74,7 @@ export function runForkChoiceGetHead(presetName: PresetName): void {
             finalizedCheckpointRoot,
             bestJustifiedCheckpoint,
           } = step.checks;
-          const head = forkchoice.getHead();
+          const head = forkchoice.updateHead();
           expect(head.slot).to.be.equal(Number(expectedHead.slot), `Invalid head slot at step ${i}`);
           expect(toHexString(head.blockRoot)).to.be.equal(expectedHead.root, `Invalid head root at step ${i}`);
           // time in spec mapped to Slot in our forkchoice implementation

--- a/packages/spec-test-runner/test/spec/phase0/fork_choice/get_head_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/fork_choice/get_head_mainnet.test.ts
@@ -61,7 +61,7 @@ describeDirectorySpecTest<IForkChoiceTestCase, void>(
           finalizedCheckpointRoot,
           bestJustifiedCheckpoint,
         } = step.checks;
-        const head = forkchoice.getHead();
+        const head = forkchoice.updateHead();
         expect(head.slot).to.be.equal(Number(expectedHead.slot));
         expect(toHexString(head.blockRoot)).to.be.equal(expectedHead.root);
         // time in spec mapped to Slot in our forkchoice implementation


### PR DESCRIPTION
**Motivation**

We currently recompute the head 'too much'. We would like more control over when the fork choice is doing heavy work and when it's doing light work.

**Description**

Minimal update to add a cache of the head inside the fork choice module.

`forkChoice.getHead` and `getHeadRoot` now use a cached value.
To trigger an update of the head, possibly recomputing balance and vote changes, call `forkChoice.updateHead`

Now we can decide when/where to call `updateHead`.
This PR adds `updateHead` during block processing.
