### PR TITLE
Only send a single sync committee signature per validator

### DIFF
--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -5,7 +5,7 @@ import {
 } from "@chainsafe/lodestar-params";
 import {computeSyncPeriodAtEpoch, computeSyncPeriodAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {BLSSignature, Epoch, Root, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {BLSSignature, Epoch, Root, Slot, SyncPeriod, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
 import {Api, routes} from "@chainsafe/lodestar-api";
@@ -45,7 +45,7 @@ type DutyAtPeriod = {dependentRoot: Root; duty: routes.validator.SyncDuty};
  */
 export class SyncCommitteeDutiesService {
   /** Maps a validator public key to their duties for each slot */
-  private readonly dutiesByPeriodByIndex = new Map<ValidatorIndex, Map<Slot, DutyAtPeriod>>();
+  private readonly dutiesByIndexByPeriod = new Map<SyncPeriod, Map<ValidatorIndex, DutyAtPeriod>>();
 
   constructor(
     private readonly config: IBeaconConfig,
@@ -72,10 +72,10 @@ export class SyncCommitteeDutiesService {
     const period = computeSyncPeriodAtSlot(slot + 1); // See note above for the +1 offset
     const duties: SyncDutyAndProof[] = [];
 
-    for (const dutiesByPeriod of this.dutiesByPeriodByIndex.values()) {
-      const dutyAtPeriod = dutiesByPeriod.get(period);
-      // Validator always has a duty during the entire period
-      if (dutyAtPeriod) {
+    const dutiesByIndex = this.dutiesByIndexByPeriod.get(period);
+    if (dutiesByIndex) {
+      for (const dutyAtPeriod of dutiesByIndex.values()) {
+        // Validator always has a duty during the entire period
         for (const index of dutyAtPeriod.duty.validatorSyncCommitteeIndices) {
           duties.push(
             // Compute a different DutyAndProof for each validatorSyncCommitteeIndices. Unwrapping here simplifies downstream code.
@@ -152,9 +152,9 @@ export class SyncCommitteeDutiesService {
     // if the BN goes offline or we swap to a different one.
     const indexSet = new Set(indexArr);
     for (const period of [currentPeriod, currentPeriod + 1]) {
-      for (const [validatorIndex, dutiesByPeriod] of this.dutiesByPeriodByIndex.entries()) {
-        const dutyAtEpoch = dutiesByPeriod.get(period);
-        if (dutyAtEpoch) {
+      const dutiesByIndex = this.dutiesByIndexByPeriod.get(period);
+      if (dutiesByIndex) {
+        for (const [validatorIndex, dutyAtEpoch] of dutiesByIndex.entries()) {
           if (indexSet.has(validatorIndex)) {
             const fromEpoch = period * EPOCHS_PER_SYNC_COMMITTEE_PERIOD;
             const untilEpoch = (period + 1) * EPOCHS_PER_SYNC_COMMITTEE_PERIOD;
@@ -194,20 +194,20 @@ export class SyncCommitteeDutiesService {
       throw extendError(e, "Failed to obtain SyncDuties");
     });
     const dependentRoot = syncDuties.dependentRoot;
-    const relevantDuties = syncDuties.data.filter((duty) => this.indicesService.hasValidatorIndex(duty.validatorIndex));
     const period = computeSyncPeriodAtEpoch(epoch);
 
-    this.logger.debug("Downloaded SyncDuties", {
-      epoch,
-      dependentRoot: toHexString(dependentRoot),
-      count: relevantDuties.length,
-    });
+    let count = 0;
 
-    for (const duty of relevantDuties) {
-      let dutiesByPeriod = this.dutiesByPeriodByIndex.get(duty.validatorIndex);
-      if (!dutiesByPeriod) {
-        dutiesByPeriod = new Map<Epoch, DutyAtPeriod>();
-        this.dutiesByPeriodByIndex.set(duty.validatorIndex, dutiesByPeriod);
+    for (const duty of syncDuties.data) {
+      if (!this.indicesService.hasValidatorIndex(duty.validatorIndex)) {
+        continue;
+      }
+      count++;
+
+      let dutiesByIndex = this.dutiesByIndexByPeriod.get(period);
+      if (!dutiesByIndex) {
+        dutiesByIndex = new Map<ValidatorIndex, DutyAtPeriod>();
+        this.dutiesByIndexByPeriod.set(period, dutiesByIndex);
       }
 
       // TODO: Enable dependentRoot functionality
@@ -219,8 +219,10 @@ export class SyncCommitteeDutiesService {
       // - The dependent root has changed, signalling a re-org.
 
       // Using `alreadyWarnedReorg` avoids excessive logs.
-      dutiesByPeriod.set(period, {dependentRoot, duty});
+      dutiesByIndex.set(duty.validatorIndex, {dependentRoot, duty});
     }
+
+    this.logger.debug("Downloaded SyncDuties", {epoch, dependentRoot: toHexString(dependentRoot), count});
   }
 
   private async getDutyAndProof(slot: Slot, duty: SyncDutySubCommittee): Promise<SyncDutyAndProof> {
@@ -244,11 +246,9 @@ export class SyncCommitteeDutiesService {
   /** Run at least once per period to prune duties map */
   private pruneOldDuties(currentEpoch: Epoch): void {
     const currentPeriod = computeSyncPeriodAtEpoch(currentEpoch);
-    for (const attMap of this.dutiesByPeriodByIndex.values()) {
-      for (const period of attMap.keys()) {
-        if (period + HISTORICAL_DUTIES_PERIODS < currentPeriod) {
-          attMap.delete(period);
-        }
+    for (const period of this.dutiesByIndexByPeriod.keys()) {
+      if (period + HISTORICAL_DUTIES_PERIODS < currentPeriod) {
+        this.dutiesByIndexByPeriod.delete(period);
       }
     }
   }

--- a/packages/validator/test/unit/services/syncCommitteDuties.test.ts
+++ b/packages/validator/test/unit/services/syncCommitteDuties.test.ts
@@ -90,26 +90,22 @@ describe("SyncCommitteeDutiesService", function () {
     );
 
     // Duties for this and next epoch should be persisted
-    expect(Object.fromEntries(dutiesService["dutiesByPeriodByIndex"].get(index) || new Map())).to.deep.equal(
+    const dutiesByIndexByPeriodObj = Object.fromEntries(
+      Array.from(dutiesService["dutiesByIndexByPeriod"].entries()).map(([period, dutiesByIndex]) => [
+        period,
+        Object.fromEntries(dutiesByIndex),
+      ])
+    );
+    expect(dutiesByIndexByPeriodObj).to.deep.equal(
       {
-        0: {dependentRoot: ZERO_HASH, duty},
-        1: {dependentRoot: ZERO_HASH, duty},
+        0: {[index]: {dependentRoot: ZERO_HASH, duty}},
+        1: {[index]: {dependentRoot: ZERO_HASH, duty}},
       },
-      "Wrong dutiesService.attesters Map"
+      "Wrong dutiesService.dutiesByIndexByPeriod Map"
     );
 
     expect(await dutiesService.getDutiesAtSlot(slot)).to.deep.equal(
-      [
-        {
-          duty: {
-            pubkey: duty.pubkey,
-            validatorIndex: duty.validatorIndex,
-            validatorSyncCommitteeIndex: duty.validatorSyncCommitteeIndices[0],
-          },
-          selectionProof: null,
-          subCommitteeIndex: 0,
-        },
-      ],
+      [{duty, selectionProofs: [{selectionProof: null, subCommitteeIndex: 0}]}],
       "Wrong getAttestersAtSlot()"
     );
 

--- a/packages/validator/test/unit/services/syncCommittee.test.ts
+++ b/packages/validator/test/unit/services/syncCommittee.test.ts
@@ -5,7 +5,7 @@ import bls from "@chainsafe/bls";
 import {createIBeaconConfig} from "@chainsafe/lodestar-config";
 import {config as mainnetConfig} from "@chainsafe/lodestar-config/default";
 import {SyncCommitteeService} from "../../../src/services/syncCommittee";
-import {SyncDutyAndProof} from "../../../src/services/syncCommitteeDuties";
+import {SyncDutyAndProofs} from "../../../src/services/syncCommitteeDuties";
 import {ValidatorStore} from "../../../src/services/validatorStore";
 import {getApiClientStub} from "../../utils/apiStub";
 import {testLogger} from "../../utils/logger";
@@ -53,15 +53,14 @@ describe("SyncCommitteeService", function () {
     const syncCommitteeSignature = ssz.altair.SyncCommitteeSignature.defaultValue();
     const contribution = ssz.altair.SyncCommitteeContribution.defaultValue();
     const contributionAndProof = ssz.altair.SignedContributionAndProof.defaultValue();
-    const duties: SyncDutyAndProof[] = [
+    const duties: SyncDutyAndProofs[] = [
       {
         duty: {
           pubkey: pubkeys[0],
           validatorIndex: 0,
-          validatorSyncCommitteeIndex: 7,
+          validatorSyncCommitteeIndices: [7],
         },
-        selectionProof: ZERO_HASH,
-        subCommitteeIndex: 0,
+        selectionProofs: [{selectionProof: ZERO_HASH, subCommitteeIndex: 0}],
       },
     ];
 


### PR DESCRIPTION
**Motivation**

If a validator is assigned multiple sync committee indexes they will sign and send multiple sync committee signatures. This is unnecessary and will cause a ton of errors in the beacon node side.

```
Eph 3/6 1.644 [API]             error: Error on publishContributionAndProofs [12] slot=101, subCommitteeIndex=2 code=SYNC_COMMITTEE_ERROR_NOT_CURRENT_SLOT, currentSlot=102, slot=101                                                                                           Error: SYNC_COMMITTEE_ERROR_NOT_CURRENT_SLOT                                                                                                at validateGossipSyncCommitteeExceptSig (/home/cayman/Code/lodestar/packages/lodestar/src/chain/validation/syncCommittee.ts:85:11)      at validateSyncCommitteeGossipContributionAndProof (/home/cayman/Code/lodestar/packages/lodestar/src/chain/validation/syncCommitteeC
ontributionAndProof.ts:30:3)                                                                                                            
    at map (/home/cayman/Code/lodestar/packages/lodestar/src/api/impl/validator/index.ts:370:19)                                        
    at Array.map (<anonymous>)                                                                                                          
    at Object.publishContributionAndProofs (/home/cayman/Code/lodestar/packages/lodestar/src/api/impl/validator/index.ts:367:31)        
    at Object.handler (/home/cayman/Code/lodestar/packages/api/src/server/utils/server.ts:70:29)                                        
    at preHandlerCallback (/home/cayman/Code/lodestar/node_modules/fastify/lib/handleRequest.js:124:28)                                 
    at preValidationCallback (/home/cayman/Code/lodestar/node_modules/fastify/lib/handleRequest.js:107:5)                                   at handler (/home/cayman/Code/lodestar/node_modules/fastify/lib/handleRequest.js:70:7)                                              
    at done (/home/cayman/Code/lodestar/node_modules/fastify/lib/contentTypeParser.js:151:7) 
```

**Description**

- Sign and send a single sync committee signature per validator.
- Update the types to make this easier to track manage.
- Change the data ordering the sync committee nested Maps data structure to make pruning easier