### PR TITLE
Handle gracefully sync duties errors

### DIFF
--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -31,42 +31,46 @@ export class SyncCommitteeService {
   }
 
   private runSyncCommitteeTasks = async (slot: Slot, signal: AbortSignal): Promise<void> => {
-    // Before altair fork no need to check duties
-    if (computeEpochAtSlot(slot) < this.config.ALTAIR_FORK_EPOCH) {
-      return;
+    try {
+      // Before altair fork no need to check duties
+      if (computeEpochAtSlot(slot) < this.config.ALTAIR_FORK_EPOCH) {
+        return;
+      }
+
+      // Fetch info first so a potential delay is absorved by the sleep() below
+      const dutiesAtSlot = await this.dutiesService.getDutiesAtSlot(slot);
+      if (dutiesAtSlot.length === 0) {
+        return;
+      }
+
+      // Lighthouse recommends to always wait to 1/3 of the slot, even if the block comes early
+      await sleep(this.clock.msToSlotFraction(slot, 1 / 3), signal);
+
+      // Step 1. Download, sign and publish an `SyncCommitteeSignature` for each validator.
+      //         Differs from AttestationService, `SyncCommitteeSignature` are equal for all
+      const beaconBlockRoot = await this.produceAndPublishSyncCommittees(slot, dutiesAtSlot);
+
+      // Step 2. If an attestation was produced, make an aggregate.
+      // First, wait until the `aggregation_production_instant` (2/3rds of the way though the slot)
+      await sleep(this.clock.msToSlotFraction(slot, 2 / 3), signal);
+
+      // await for all so if the Beacon node is overloaded it auto-throttles
+      // TODO: This approach is convervative to reduce the node's load, review
+      const dutiesBySubcommitteeIndex = groupSyncDutiesBySubCommitteeIndex(dutiesAtSlot);
+      await Promise.all(
+        Array.from(dutiesBySubcommitteeIndex.entries()).map(async ([subcommitteeIndex, duties]) => {
+          if (duties.length === 0) return;
+          // Then download, sign and publish a `SignedAggregateAndProof` for each
+          // validator that is elected to aggregate for this `slot` and `subcommitteeIndex`.
+          await this.produceAndPublishAggregates(slot, subcommitteeIndex, beaconBlockRoot, duties).catch((e) => {
+            if (notAborted(e))
+              this.logger.error("Error on SyncCommitteeContribution", {slot, index: subcommitteeIndex}, e);
+          });
+        })
+      );
+    } catch (e) {
+      this.logger.error("Error on runSyncCommitteeTasks", {slot}, e);
     }
-
-    // Fetch info first so a potential delay is absorved by the sleep() below
-    const dutiesAtSlot = await this.dutiesService.getDutiesAtSlot(slot);
-    if (dutiesAtSlot.length === 0) {
-      return;
-    }
-
-    // Lighthouse recommends to always wait to 1/3 of the slot, even if the block comes early
-    await sleep(this.clock.msToSlotFraction(slot, 1 / 3), signal);
-
-    // Step 1. Download, sign and publish an `SyncCommitteeSignature` for each validator.
-    //         Differs from AttestationService, `SyncCommitteeSignature` are equal for all
-    const beaconBlockRoot = await this.produceAndPublishSyncCommittees(slot, dutiesAtSlot);
-
-    // Step 2. If an attestation was produced, make an aggregate.
-    // First, wait until the `aggregation_production_instant` (2/3rds of the way though the slot)
-    await sleep(this.clock.msToSlotFraction(slot, 2 / 3), signal);
-
-    // await for all so if the Beacon node is overloaded it auto-throttles
-    // TODO: This approach is convervative to reduce the node's load, review
-    const dutiesBySubcommitteeIndex = groupSyncDutiesBySubCommitteeIndex(dutiesAtSlot);
-    await Promise.all(
-      Array.from(dutiesBySubcommitteeIndex.entries()).map(async ([subcommitteeIndex, duties]) => {
-        if (duties.length === 0) return;
-        // Then download, sign and publish a `SignedAggregateAndProof` for each
-        // validator that is elected to aggregate for this `slot` and `subcommitteeIndex`.
-        await this.produceAndPublishAggregates(slot, subcommitteeIndex, beaconBlockRoot, duties).catch((e) => {
-          if (notAborted(e))
-            this.logger.error("Error on SyncCommitteeContribution", {slot, index: subcommitteeIndex}, e);
-        });
-      })
-    );
   };
 
   /**


### PR DESCRIPTION
**Motivation**

The main sync duties routine was missing a try catch and errors propagated to the clock stopping the runEverySlot fn. If a blockRoot for a single error was not found and the API server throws an error the validator will stop producing sync aggregates for the process lifetime.

**Description**

- Add a catch to the clock runEverySlot fn so a throw does not prevent future fn runs
- Add a try / catch in sync routine to gracefully handle and log errors

---- 

Merge after https://github.com/ChainSafe/lodestar/pull/2697 