### PR TITLE
fork-choice updateHead timed with a metric

### DIFF
--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -202,9 +202,8 @@ export class ForkChoice implements IForkChoice {
       const blockSummary = toBlockSummary(headNode);
       if (timer) timer();
       return blockSummary;
-    } catch (e) {
+    } finally {
       if (timer) timer();
-      throw e;
     }
   }
 

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -166,7 +166,7 @@ export class ForkChoice implements IForkChoice {
 
   getHead(): IBlockSummary {
     // balances is not changed but votes are changed
-    let timer, blockSummary;
+    let timer;
     try {
       if (!this.synced) {
         timer = this.metrics?.forkChoiceFindHead.startTimer();
@@ -199,11 +199,10 @@ export class ForkChoice implements IForkChoice {
         });
       }
 
-      blockSummary = toBlockSummary(headNode);
+      return toBlockSummary(headNode);
     } finally {
       if (timer) timer();
     }
-    return blockSummary;
   }
 
   getHeads(): IBlockSummary[] {

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -166,7 +166,7 @@ export class ForkChoice implements IForkChoice {
 
   getHead(): IBlockSummary {
     // balances is not changed but votes are changed
-    let timer;
+    let timer, blockSummary;
     try {
       if (!this.synced) {
         timer = this.metrics?.forkChoiceFindHead.startTimer();
@@ -199,12 +199,11 @@ export class ForkChoice implements IForkChoice {
         });
       }
 
-      const blockSummary = toBlockSummary(headNode);
-      if (timer) timer();
-      return blockSummary;
+      blockSummary = toBlockSummary(headNode);
     } finally {
       if (timer) timer();
     }
+    return blockSummary;
   }
 
   getHeads(): IBlockSummary[] {

--- a/packages/fork-choice/src/index.ts
+++ b/packages/fork-choice/src/index.ts
@@ -1,2 +1,3 @@
+export * from "./metrics";
 export * from "./protoArray";
 export * from "./forkChoice";

--- a/packages/fork-choice/src/metrics.ts
+++ b/packages/fork-choice/src/metrics.ts
@@ -1,0 +1,7 @@
+export interface IForkChoiceMetrics {
+  forkChoiceFindHead: IHistogram;
+}
+
+interface IHistogram {
+  startTimer(): () => void;
+}

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -89,7 +89,13 @@ export class BeaconChain implements IBeaconChain {
     const stateCache = new StateContextCache();
     const checkpointStateCache = new CheckpointStateCache(config);
     const cachedState = restoreStateCaches(config, stateCache, checkpointStateCache, anchorState);
-    const forkChoice = new LodestarForkChoice({config, emitter, currentSlot: clock.currentSlot, state: cachedState});
+    const forkChoice = new LodestarForkChoice({
+      config,
+      emitter,
+      currentSlot: clock.currentSlot,
+      state: cachedState,
+      metrics,
+    });
     const regen = new QueuedStateRegenerator({
       config,
       emitter,

--- a/packages/lodestar/src/chain/forkChoice/forkChoice.ts
+++ b/packages/lodestar/src/chain/forkChoice/forkChoice.ts
@@ -11,6 +11,7 @@ import {computeAnchorCheckpoint} from "../initState";
 import {ChainEventEmitter} from "../emitter";
 import {ForkChoiceStore} from "./store";
 import {getEffectiveBalances, CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {IMetrics} from "../../metrics";
 
 /**
  * Fork Choice extended with a ChainEventEmitter
@@ -21,11 +22,13 @@ export class LodestarForkChoice extends ForkChoice {
     emitter,
     currentSlot,
     state,
+    metrics,
   }: {
     config: IBeaconConfig;
     emitter: ChainEventEmitter;
     currentSlot: Slot;
     state: CachedBeaconState<allForks.BeaconState>;
+    metrics?: IMetrics | null;
   }) {
     const {blockHeader, checkpoint} = computeAnchorCheckpoint(config, state);
     const finalizedCheckpoint = {...checkpoint};
@@ -60,6 +63,7 @@ export class LodestarForkChoice extends ForkChoice {
 
       queuedAttestations: new Set(),
       justifiedBalances,
+      metrics,
     });
   }
 }

--- a/packages/lodestar/src/metrics/metrics/beacon.ts
+++ b/packages/lodestar/src/metrics/metrics/beacon.ts
@@ -120,5 +120,11 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
       name: "beacon_observed_epoch_aggregators",
       help: "number of aggregators for which we have seen an attestation, not necessarily included on chain.",
     }),
+
+    forkChoiceFindHead: register.histogram({
+      name: "beacon_fork_choice_find_head_seconds",
+      help: "Time taken to find head in seconds",
+      buckets: [0.1, 1, 10],
+    }),
   };
 }


### PR DESCRIPTION
**Motivation**

this PR is to add fork-choice metrics, timing updateHead (of the refactored code) with  metric : beacon_fork_choice_find_head_seconds as a pilot/reference to add other fork choice metrics post this.


<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
