### PR TITLE
Remove unused param from lightclient route

### DIFF
--- a/packages/api/src/routes/lightclient.ts
+++ b/packages/api/src/routes/lightclient.ts
@@ -31,7 +31,7 @@ export type Api = {
  */
 export const routesData: RoutesData<Api> = {
   getStateProof: {url: "/eth/v1/lightclient/proof/:stateId", method: "POST"},
-  getBestUpdates: {url: "/eth/v1/lightclient/best_updates/:periods", method: "GET"},
+  getBestUpdates: {url: "/eth/v1/lightclient/best_updates/", method: "GET"},
   getLatestUpdateFinalized: {url: "/eth/v1/lightclient/latest_update_finalized/", method: "GET"},
   getLatestUpdateNonFinalized: {url: "/eth/v1/lightclient/latest_update_nonfinalized/", method: "GET"},
 };


### PR DESCRIPTION
**Motivation**

Route has wrong URL declaration

**Description**

Remove unused param from lightclient route