### PR TITLE
Fix nightly release

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - master
-      - nightly-release
 
 jobs:
   publish:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -38,13 +38,14 @@ jobs:
         if: steps.cache-deps.outputs.cache-hit == 'true'
       # </common-build>
       - name: Publish to npm registry
+        # from-package: Base the latest nightly ref count from NPM registry
         # --no-git-reset: Do not delete code version artifcats so the next step can pick the version
         # --canary: Format version with commit (1.1.0-alpha.0+81e3b443)
         # --dist-tag next: Make this nightly version installable with `@next`
         # --preid next: Tag version with `next` instead of `alpha`
         # NOTE: Using --preid next.$(git rev-parse --short=7 HEAD) results in `0.24.3-next.3ddb91d.0+3ddb91d`
         run: |
-          node_modules/.bin/lerna publish --yes --no-verify-access \
+          node_modules/.bin/lerna publish from-package --yes --no-verify-access \
           --canary --dist-tag next --no-git-reset \
           --preid next
         env:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -8,7 +8,8 @@ concurrency:
 on:
   push:
     branches:
-      - "master"
+      - master
+      - nightly-release
 
 jobs:
   publish:
@@ -37,7 +38,11 @@ jobs:
         if: steps.cache-deps.outputs.cache-hit == 'true'
       # </common-build>
       - name: Publish to npm registry
-        run: yarn run publish:nightly
+        # --no-git-reset: Do not delete code version artifcats so the next step can pick the version
+        # --canary: Format version with commit (1.1.0-alpha.0+81e3b443)
+        # --dist-tag next: Make this nightly version installable with `@next`
+        # --preid next: Tag version with `next` instead of `alpha`
+        run: node_modules/.bin/lerna publish --yes --no-verify-access --canary --preid next --dist-tag next --no-git-reset
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -43,12 +43,12 @@ jobs:
         # --no-git-reset: Do not delete code version artifcats so the next step can pick the version
         # --canary: Format version with commit (1.1.0-alpha.0+81e3b443)
         # --dist-tag next: Make this nightly version installable with `@next`
-        # --preid next: Tag version with `next` instead of `alpha`
+        # --preid next: Tag version with `dev` instead of `alpha`
         # --force-publish: lerna doesn't want to publish anything otherwise - "lerna success No changed packages to publish"
         # NOTE: Using --preid next.$(git rev-parse --short=7 HEAD) results in `0.24.3-next.3ddb91d.0+3ddb91d`
         run: |
           node_modules/.bin/lerna publish --yes --no-verify-access \
-          --canary --dist-tag next --no-git-reset --force-publish \
+          --canary --dist-tag dev --no-git-reset --force-publish \
           --preid next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -45,11 +45,11 @@ jobs:
         # --dist-tag next: Make this nightly version installable with `@next`
         # --preid next: Tag version with `dev` instead of `alpha`
         # --force-publish: lerna doesn't want to publish anything otherwise - "lerna success No changed packages to publish"
-        # NOTE: Using --preid next.$(git rev-parse --short=7 HEAD) results in `0.24.3-next.3ddb91d.0+3ddb91d`
+        # NOTE: Using --preid next.$(git rev-parse --short=7 HEAD) results in `0.24.3-dev.3ddb91d.0+3ddb91d`
         run: |
           node_modules/.bin/lerna publish --yes --no-verify-access \
-          --canary --dist-tag dev --no-git-reset --force-publish \
-          --preid next
+          --canary --dist-tag next --no-git-reset --force-publish \
+          --preid dev
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -42,7 +42,10 @@ jobs:
         # --canary: Format version with commit (1.1.0-alpha.0+81e3b443)
         # --dist-tag next: Make this nightly version installable with `@next`
         # --preid next: Tag version with `next` instead of `alpha`
-        run: node_modules/.bin/lerna publish --yes --no-verify-access --canary --preid next --dist-tag next --no-git-reset
+        run: |
+          node_modules/.bin/lerna publish --yes --no-verify-access \
+          --canary --preid next --dist-tag next --no-git-reset \
+          --preid next.$(git rev-parse --short=7 HEAD)
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -42,10 +42,11 @@ jobs:
         # --canary: Format version with commit (1.1.0-alpha.0+81e3b443)
         # --dist-tag next: Make this nightly version installable with `@next`
         # --preid next: Tag version with `next` instead of `alpha`
+        # NOTE: Using --preid next.$(git rev-parse --short=7 HEAD) results in `0.24.3-next.3ddb91d.0+3ddb91d`
         run: |
           node_modules/.bin/lerna publish --yes --no-verify-access \
           --canary --dist-tag next --no-git-reset \
-          --preid next.$(git rev-parse --short=7 HEAD)
+          --preid next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
           node-version: "14.16.0"

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -70,5 +70,4 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - run: docker build --tag chainsafe/lodestar:next --build-arg VERSION=${{ needs.publish.outputs.version }} .
-        # Push all tags
-      - run: docker push chainsafe/lodestar
+      - run: docker push chainsafe/lodestar:next

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -43,10 +43,11 @@ jobs:
         # --canary: Format version with commit (1.1.0-alpha.0+81e3b443)
         # --dist-tag next: Make this nightly version installable with `@next`
         # --preid next: Tag version with `next` instead of `alpha`
+        # --force-publish: lerna doesn't want to publish anything otherwise - "lerna success No changed packages to publish"
         # NOTE: Using --preid next.$(git rev-parse --short=7 HEAD) results in `0.24.3-next.3ddb91d.0+3ddb91d`
         run: |
-          node_modules/.bin/lerna publish from-package --yes --no-verify-access \
-          --canary --dist-tag next --no-git-reset \
+          node_modules/.bin/lerna publish --yes --no-verify-access \
+          --canary --dist-tag next --no-git-reset --force-publish \
           --preid next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -40,12 +40,12 @@ jobs:
       # </common-build>
       - name: Publish to npm registry
         # from-package: Base the latest nightly ref count from NPM registry
-        # --no-git-reset: Do not delete code version artifcats so the next step can pick the version
+        # --no-git-reset: Do not delete code version artifacts so the next step can pick the version
         # --canary: Format version with commit (1.1.0-alpha.0+81e3b443)
         # --dist-tag next: Make this nightly version installable with `@next`
-        # --preid next: Tag version with `dev` instead of `alpha`
+        # --preid dev: Tag version with `dev` instead of `alpha`
         # --force-publish: lerna doesn't want to publish anything otherwise - "lerna success No changed packages to publish"
-        # NOTE: Using --preid next.$(git rev-parse --short=7 HEAD) results in `0.24.3-dev.3ddb91d.0+3ddb91d`
+        # NOTE: Using --preid dev.$(git rev-parse --short=7 HEAD) results in `0.24.3-dev.3ddb91d.0+3ddb91d`
         run: |
           node_modules/.bin/lerna publish --yes --no-verify-access \
           --canary --dist-tag next --no-git-reset --force-publish \

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -44,7 +44,7 @@ jobs:
         # --preid next: Tag version with `next` instead of `alpha`
         run: |
           node_modules/.bin/lerna publish --yes --no-verify-access \
-          --canary --preid next --dist-tag next --no-git-reset \
+          --canary --dist-tag next --no-git-reset \
           --preid next.$(git rev-parse --short=7 HEAD)
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -67,6 +67,5 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - run: docker build --tag chainsafe/lodestar:next --build-arg VERSION=${{ needs.publish.outputs.version }} .
-      - run: docker tag chainsafe/lodestar:next chainsafe/lodestar:${{ needs.publish.outputs.version }}
         # Push all tags
       - run: docker push chainsafe/lodestar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,5 +123,4 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - run: docker build --tag chainsafe/lodestar:latest --build-arg VERSION=${{ needs.tag.outputs.tag }} .
       - run: docker tag chainsafe/lodestar:latest chainsafe/lodestar:${{ needs.tag.outputs.tag }}
-        # Push all tags
-      - run: docker push chainsafe/lodestar
+      - run: docker push chainsafe/lodestar:latest chainsafe/lodestar:${{ needs.tag.outputs.tag }}

--- a/docker-compose.validator.yml
+++ b/docker-compose.validator.yml
@@ -1,7 +1,7 @@
 version: "3.4"
 services:
   validator:
-    image: chainsafe/lodestar@next
+    image: chainsafe/lodestar:next
     restart: always
     volumes:
       - validator:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.4"
 services:
   beacon_node:
-    image: chainsafe/lodestar@next
+    image: chainsafe/lodestar:next
     restart: always
     volumes:
       - beacon_node:/data

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "benchmark": "lerna run benchmark",
     "cli": "node --trace-deprecation --max-old-space-size=8192 ./packages/cli/bin/lodestar",
     "publish:release": "lerna publish from-package --yes --no-verify-access",
-    "publish:nightly": "lerna publish --yes --no-verify-access --canary --preid next.$(git rev-parse HEAD) --dist-tag next",
     "release": "lerna version --no-push --sign-git-commit",
     "postrelease": "git tag -d $(git describe --abbrev=0)"
   },

--- a/packages/beacon-state-transition/package.json
+++ b/packages/beacon-state-transition/package.json
@@ -32,7 +32,6 @@
     "check-types": "tsc",
     "lint": "eslint --color --ext .ts src/ test/",
     "lint:fix": "yarn run lint --fix",
-    "prepublishOnly": "yarn build",
     "test:unit": "mocha 'test/unit/**/*.test.ts'",
     "test:perf": "mocha 'test/perf/**/*.test.ts'",
     "benchmark": "node -r ts-node/register --max-old-space-size=4096 test/perf/runAll.ts",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -29,7 +29,6 @@
     "check-types": "tsc",
     "lint": "eslint --color --ext .ts src/",
     "lint:fix": "yarn run lint --fix",
-    "prepublishOnly": "yarn build",
     "pretest": "yarn run check-types",
     "test:unit": "nyc --cache-dir .nyc_output/.cache -e .ts mocha 'test/unit/**/*.test.ts'"
   },

--- a/packages/params/package.json
+++ b/packages/params/package.json
@@ -29,7 +29,6 @@
     "check-types": "tsc",
     "lint": "eslint --color --ext .ts src/ test/",
     "lint:fix": "yarn run lint --fix",
-    "prepublishOnly": "yarn build",
     "test": "yarn run check-types",
     "test:unit": "mocha 'test/unit/**/*.test.ts'",
     "test:e2e": "mocha 'test/e2e/**/*.test.ts'"

--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -32,7 +32,6 @@
     "check-types": "tsc",
     "lint": "eslint --color --ext .ts src/ test/",
     "lint:fix": "yarn run lint --fix",
-    "prepublishOnly": "yarn build",
     "pretest": "yarn run check-types",
     "test:e2e": "mocha 'test/e2e/**/*.test.ts'"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -32,7 +32,6 @@
     "check-types": "tsc",
     "lint": "eslint --color --ext .ts src/ test/",
     "lint:fix": "yarn run lint --fix",
-    "prepublishOnly": "yarn build",
     "test:unit": "mocha 'test/**/*.test.ts'"
   },
   "types": "lib/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -32,7 +32,6 @@
     "check-types": "tsc",
     "lint": "eslint --color --ext .ts src/ test/",
     "lint:fix": "yarn run lint --fix",
-    "prepublishOnly": "yarn build",
     "pretest": "yarn run check-types",
     "test:unit": "mocha 'test/**/*.test.ts'"
   },


### PR DESCRIPTION
**Motivation**

Nightly release is broken.

Also the version is so long that NPM breaks, see https://github.com/ChainSafe/lodestar/issues/2703

**Description**

- Use `--no-git-reset` flag to access version artifacts in next step
- Use shorter commit sha