### PR TITLE
Simplify required params in light client init

### DIFF
--- a/packages/light-client/src/client/index.ts
+++ b/packages/light-client/src/client/index.ts
@@ -77,17 +77,17 @@ export class Lightclient {
         nextSyncCommittee: deserializeSyncCommittee(state.nextSyncCommittee),
       },
     };
-    const newModules = {...modules} as LightclientModules;
-    // if the clock or genesisValidatorsRoot isn't supplied
-    // then set them in the new modules object
-    if (!modules.clock) {
-      newModules.clock = new Clock(config, state.genesisTime);
-    }
-    if (!modules.genesisValidatorsRoot) {
-      newModules.genesisValidatorsRoot = state.genesisValidatorsRoot.valueOf() as Root;
-    }
 
-    return new Lightclient(newModules, store);
+    return new Lightclient(
+      {
+        ...modules,
+        // if the clock or genesisValidatorsRoot isn't supplied
+        // then set them in the new modules object
+        clock: modules.clock || new Clock(config, state.genesisTime),
+        genesisValidatorsRoot: modules.genesisValidatorsRoot || (state.genesisValidatorsRoot.valueOf() as Root),
+      },
+      store
+    );
   }
 
   static initializeFromTrustedSnapshot(modules: LightclientModules, snapshot: altair.LightClientSnapshot): Lightclient {


### PR DESCRIPTION
**Motivation**

Currently, initializing the light client against a testnet is more difficult than necessary, due to requiring the genesis time and genesis validators root at the point of light client intialization.

The configuration can be simplified by simply querying the information required as part of the initial proof payload.

**Description**

Sets the genesis time and genesis validators root to be _optional_ in `initializeFromTrustedStateRoot`.
This allows the light client to be initialized with only: a config, a beacon node url, a state root checkpoint.
