### PR TITLE
Add benchmark for ssz.Root.equals

### DIFF
--- a/packages/beacon-state-transition/test/perf/phase0/block/block.perf.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/block/block.perf.ts
@@ -1,8 +1,9 @@
 import {init} from "@chainsafe/bls";
 import {MAX_VOLUNTARY_EXITS} from "@chainsafe/lodestar-params";
 import {phase0} from "@chainsafe/lodestar-types";
+import {ssz} from "@chainsafe/lodestar-types";
 import {BenchmarkRunner} from "@chainsafe/lodestar-utils/test_utils/benchmark";
-import {List} from "@chainsafe/ssz";
+import {byteArrayEquals, List, fromHexString} from "@chainsafe/ssz";
 import {allForks} from "../../../../src";
 import {generatePerformanceBlock, generatePerfTestCachedBeaconState} from "../../util";
 
@@ -57,5 +58,36 @@ export async function runBlockTransitionTests(): Promise<void> {
     });
   }
 
+  runner.done();
+}
+
+// As of Jun 17 2021
+// Compare state root
+// ================================================================
+// ssz.Root.equals                                                        891265.6 ops/s      1.122000 us/op 10017946 runs    15.66 s
+// ssz.Root.equals with valueOf()                                         692041.5 ops/s      1.445000 us/op 8179741 runs    15.28 s
+// byteArrayEquals with valueOf()                                         853971.0 ops/s      1.171000 us/op 9963051 runs    16.07 s
+export async function runRootComparisonTests(): Promise<void> {
+  await init("blst-native");
+  const runner = new BenchmarkRunner("Compare state root", {
+    maxMs: 60 * 1000,
+    minMs: 15 * 1000,
+    runs: 64,
+  });
+  const stateRoot = fromHexString("0x6c86ca3c4c6688cf189421b8a68bf2dbc91521609965e6f4e207d44347061fee");
+  const signedBlock = generatePerformanceBlock();
+  const blockStateRoot = signedBlock.message.stateRoot;
+  await runner.run({
+    id: "ssz.Root.equals",
+    run: () => ssz.Root.equals(blockStateRoot, stateRoot),
+  });
+  await runner.run({
+    id: "ssz.Root.equals with valueOf()",
+    run: () => ssz.Root.equals(blockStateRoot.valueOf() as Uint8Array, stateRoot),
+  });
+  await runner.run({
+    id: "byteArrayEquals with valueOf()",
+    run: () => byteArrayEquals(blockStateRoot.valueOf() as Uint8Array, stateRoot),
+  });
   runner.done();
 }

--- a/packages/beacon-state-transition/test/perf/runAll.ts
+++ b/packages/beacon-state-transition/test/perf/runAll.ts
@@ -1,4 +1,4 @@
-import {runBlockTransitionTests} from "./phase0/block/block.perf";
+import {runBlockTransitionTests, runRootComparisonTests} from "./phase0/block/block.perf";
 import {runEpochTransitionStepTests} from "./phase0/epoch/epoch.perf";
 import {runGetAttestationDeltaTest} from "./phase0/epoch/getAttestationDeltas.perf";
 import {runEpochTransitionTests} from "./phase0/slot/slots.perf";
@@ -6,6 +6,7 @@ import {runAggregationBitsTest} from "./util/aggregationBits.perf";
 
 async function runAll(): Promise<void> {
   await runBlockTransitionTests();
+  await runRootComparisonTests();
   await runEpochTransitionStepTests();
   await runGetAttestationDeltaTest();
   await runEpochTransitionTests();


### PR DESCRIPTION
**Motivation**

+ `byteArrayEquals` is better than `ssz.Root.equals` in terms of performance

**Description**

Added benchmark result:
```
// Compare state root
// ================================================================
// ssz.Root.equals                                                        17262.51 ops/s      57.92900 us/op 256558 runs    15.01 s
// ssz.Root.equals with valueOf()                                         61656.08 ops/s      16.21900 us/op 903088 runs    15.03 s
// byteArrayEquals with valueOf()                                         848896.4 ops/s      1.178000 us/op 9904067 runs    15.38 s
```

Closes #2708

**Update**
+ Only add performance test, `ssz.Root.equals` is improved in ssz
