### PR TITLE
Set Root to RootType

### DIFF
--- a/packages/types/src/primitive/sszTypes.ts
+++ b/packages/types/src/primitive/sszTypes.ts
@@ -1,4 +1,12 @@
-import {byteType, booleanType, ByteVectorType, BigIntUintType, number32Type, NumberUintType} from "@chainsafe/ssz";
+import {
+  byteType,
+  booleanType,
+  ByteVectorType,
+  BigIntUintType,
+  number32Type,
+  NumberUintType,
+  RootType,
+} from "@chainsafe/ssz";
 
 export const Boolean = booleanType;
 export const Bytes4 = new ByteVectorType({length: 4});
@@ -21,7 +29,11 @@ export const CommitteeIndex = Number64;
 export const SubCommitteeIndex = Number64;
 export const ValidatorIndex = Number64;
 export const Gwei = Uint64;
-export const Root = Bytes32;
+export const Root = new RootType({
+  expandedType: () => {
+    throw new Error("Generic Root type has no expanded type");
+  },
+});
 export const Version = Bytes4;
 export const DomainType = Bytes4;
 export const ForkDigest = Bytes4;


### PR DESCRIPTION
**Motivation**

`Root.equals` is way slower than it could/should be.
See #2708 https://github.com/ChainSafe/lodestar/pull/2710 and https://github.com/ChainSafe/ssz/pull/130

**Description**

This PR makes `Root` a `RootType`, rather than a `ByteVectorType`.
This will allow `Root` to take advantage of any optimizations we make in `RootType`, in particular chainsafe/ssz#130

Impl note: Since `Root` is a generic root, rather than a root of a specific type, the `expandedType` callback must throw an error.