### PR TITLE
Add more fork-choice metrics

### DIFF
--- a/docker/grafana/provisioning/dashboards/lodestar.json
+++ b/docker/grafana/provisioning/dashboards/lodestar.json
@@ -4156,6 +4156,10 @@
     {
       "collapsed": true,
       "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -4213,7 +4217,8 @@
                     "value": 80
                   }
                 ]
-              }
+              },
+              "unit": "s"
             },
             "overrides": []
           },
@@ -4221,7 +4226,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2
+            "y": 33
           },
           "id": 130,
           "options": {
@@ -4243,7 +4248,7 @@
               "refId": "A"
             }
           ],
-          "title": "find head avg time(seconds)",
+          "title": "find head avg time (seconds)",
           "type": "timeseries"
         },
         {
@@ -4317,7 +4322,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2
+            "y": 33
           },
           "id": 138,
           "options": {
@@ -4408,7 +4413,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 10
+            "y": 41
           },
           "id": 132,
           "options": {
@@ -4430,7 +4435,7 @@
               "refId": "A"
             }
           ],
-          "title": "find head utilization/slot",
+          "title": "find head / slot",
           "type": "timeseries"
         },
         {
@@ -4438,7 +4443,35 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
@@ -4450,7 +4483,7 @@
                   },
                   {
                     "color": "red",
-                    "value": 1
+                    "value": 80
                   }
                 ]
               }
@@ -4459,25 +4492,20 @@
           },
           "gridPos": {
             "h": 8,
-            "w": 3,
+            "w": 12,
             "x": 12,
-            "y": 10
+            "y": 41
           },
           "id": 140,
           "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
             },
-            "text": {},
-            "textMode": "auto"
+            "tooltip": {
+              "mode": "single"
+            }
           },
           "pluginVersion": "8.0.0",
           "targets": [
@@ -4490,7 +4518,85 @@
             }
           ],
           "title": "Fork Choice Errors",
-          "type": "stat"
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 49
+          },
+          "id": 146,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "rate(beacon_fork_choice_find_head_seconds_sum[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "process  time",
+              "refId": "A"
+            }
+          ],
+          "title": "find head utilization rate",
+          "type": "timeseries"
         },
         {
           "datasource": null,
@@ -4520,8 +4626,8 @@
           "gridPos": {
             "h": 8,
             "w": 3,
-            "x": 15,
-            "y": 10
+            "x": 12,
+            "y": 49
           },
           "id": 144,
           "options": {

--- a/docker/grafana/provisioning/dashboards/lodestar.json
+++ b/docker/grafana/provisioning/dashboards/lodestar.json
@@ -5618,6 +5618,409 @@
       ],
       "title": "Gossip Stats",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 136,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "points",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "id": 130,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "delta(beacon_fork_choice_find_head_seconds_sum[$__rate_interval])/delta(beacon_fork_choice_find_head_seconds_count[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "find head",
+              "refId": "A"
+            }
+          ],
+          "title": "find head avg time(seconds)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 24,
+                "gradientMode": "hue",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "{instance=\"beacon_node:8008\", job=\"Lodestar\"}"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "purple",
+                      "mode": "palette-classic"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 2
+          },
+          "id": 138,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.0.0",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "delta(beacon_fork_choice_changed_head_total[$__rate_interval])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "New Heads",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "delta(beacon_fork_choice_requests_total[$__rate_interval])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total Requests",
+              "refId": "B"
+            }
+          ],
+          "title": "Total findHead Requests vs new heads found",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 132,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "12*rate(beacon_fork_choice_find_head_seconds_count[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "find head utilization/slot",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 3,
+            "x": 12,
+            "y": 10
+          },
+          "id": 140,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "8.0.0",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "beacon_fork_choice_errors_total",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Fork Choice Errors",
+          "type": "stat"
+        },
+        {
+          "datasource": null,
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 3,
+            "x": 15,
+            "y": 10
+          },
+          "id": 144,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "8.0.0",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "beacon_fork_choice_reorg_total",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Forks",
+          "type": "stat"
+        }
+      ],
+      "title": "Fork-Choice Stats",
+      "type": "row"
     }
   ],
   "refresh": "30s",

--- a/docker/grafana/provisioning/dashboards/lodestar.json
+++ b/docker/grafana/provisioning/dashboards/lodestar.json
@@ -4162,6 +4162,409 @@
         "x": 0,
         "y": 23
       },
+      "id": 136,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "points",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "id": 130,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "delta(beacon_fork_choice_find_head_seconds_sum[$__rate_interval])/delta(beacon_fork_choice_find_head_seconds_count[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "find head",
+              "refId": "A"
+            }
+          ],
+          "title": "find head avg time(seconds)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "left",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 24,
+                "gradientMode": "hue",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                  "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "{instance=\"beacon_node:8008\", job=\"Lodestar\"}"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "purple",
+                      "mode": "palette-classic"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 2
+          },
+          "id": 138,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.0.0",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "delta(beacon_fork_choice_changed_head_total[$__rate_interval])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Changed Heads",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "delta(beacon_fork_choice_requests_total[$__rate_interval])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total Requests",
+              "refId": "B"
+            }
+          ],
+          "title": "Total findHead Requests vs changed heads",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 132,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "12*rate(beacon_fork_choice_find_head_seconds_count[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "find head utilization/slot",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 3,
+            "x": 12,
+            "y": 10
+          },
+          "id": 140,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "8.0.0",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "beacon_fork_choice_errors_total",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Fork Choice Errors",
+          "type": "stat"
+        },
+        {
+          "datasource": null,
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 3,
+            "x": 15,
+            "y": 10
+          },
+          "id": 144,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "8.0.0",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "beacon_fork_choice_reorg_total",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Reorgs",
+          "type": "stat"
+        }
+      ],
+      "title": "Fork-Choice Stats",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
       "id": 75,
       "panels": [
         {
@@ -4760,7 +5163,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 25
       },
       "id": 86,
       "panels": [
@@ -4972,7 +5375,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 26
       },
       "id": 28,
       "panels": [
@@ -5504,7 +5907,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 27
       },
       "id": 66,
       "panels": [
@@ -5617,409 +6020,6 @@
         }
       ],
       "title": "Gossip Stats",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 27
-      },
-      "id": 136,
-      "panels": [
-        {
-          "datasource": null,
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "points",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 2
-          },
-          "id": 130,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "hidden",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single"
-            }
-          },
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "delta(beacon_fork_choice_find_head_seconds_sum[$__rate_interval])/delta(beacon_fork_choice_find_head_seconds_count[$__rate_interval])",
-              "interval": "",
-              "legendFormat": "find head",
-              "refId": "A"
-            }
-          ],
-          "title": "find head avg time(seconds)",
-          "type": "timeseries"
-        },
-        {
-          "datasource": null,
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "left",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 24,
-                "gradientMode": "hue",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineStyle": {
-                  "fill": "solid"
-                },
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "normal"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              }
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "{instance=\"beacon_node:8008\", job=\"Lodestar\"}"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "purple",
-                      "mode": "palette-classic"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 2
-          },
-          "id": 138,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "8.0.0",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "delta(beacon_fork_choice_changed_head_total[$__rate_interval])",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "New Heads",
-              "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "delta(beacon_fork_choice_requests_total[$__rate_interval])",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "Total Requests",
-              "refId": "B"
-            }
-          ],
-          "title": "Total findHead Requests vs new heads found",
-          "type": "timeseries"
-        },
-        {
-          "datasource": null,
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 10
-          },
-          "id": 132,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "hidden",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single"
-            }
-          },
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "12*rate(beacon_fork_choice_find_head_seconds_count[$__rate_interval])",
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "find head utilization/slot",
-          "type": "timeseries"
-        },
-        {
-          "datasource": null,
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 1
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 3,
-            "x": 12,
-            "y": 10
-          },
-          "id": 140,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.0.0",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "beacon_fork_choice_errors_total",
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "Fork Choice Errors",
-          "type": "stat"
-        },
-        {
-          "datasource": null,
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 3,
-            "x": 15,
-            "y": 10
-          },
-          "id": 144,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.0.0",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "beacon_fork_choice_reorg_total",
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "Forks",
-          "type": "stat"
-        }
-      ],
-      "title": "Fork-Choice Stats",
       "type": "row"
     }
   ],

--- a/packages/fork-choice/src/metrics.ts
+++ b/packages/fork-choice/src/metrics.ts
@@ -1,8 +1,14 @@
 export interface IForkChoiceMetrics {
-  forkChoiceFindHead: IHistogram<"syncStatus" | "resStatus">;
+  forkChoiceFindHead: IHistogram;
+  forkChoiceHeadRequests: IGauge;
+  forkChoiceErrors: IGauge;
+  forkChoiceNewHeads: IGauge;
+  forkChoiceNewChains: IGauge;
 }
 
-type Labels<T extends string> = Partial<Record<T, string | number>>;
-interface IHistogram<T extends string> {
-  startTimer(arg?: Labels<T>): (arg?: Labels<T>) => void;
+interface IHistogram {
+  startTimer(): () => void;
+}
+interface IGauge {
+  inc(value?: number): void;
 }

--- a/packages/fork-choice/src/metrics.ts
+++ b/packages/fork-choice/src/metrics.ts
@@ -1,9 +1,9 @@
 export interface IForkChoiceMetrics {
   forkChoiceFindHead: IHistogram;
-  forkChoiceHeadRequests: IGauge;
+  forkChoiceRequests: IGauge;
   forkChoiceErrors: IGauge;
-  forkChoiceNewHeads: IGauge;
-  forkChoiceNewChains: IGauge;
+  forkChoiceChangedHead: IGauge;
+  forkChoiceReorg: IGauge;
 }
 
 interface IHistogram {

--- a/packages/fork-choice/src/metrics.ts
+++ b/packages/fork-choice/src/metrics.ts
@@ -1,7 +1,8 @@
 export interface IForkChoiceMetrics {
-  forkChoiceFindHead: IHistogram;
+  forkChoiceFindHead: IHistogram<"syncStatus" | "resStatus">;
 }
 
-interface IHistogram {
-  startTimer(): () => void;
+type Labels<T extends string> = Partial<Record<T, string | number>>;
+interface IHistogram<T extends string> {
+  startTimer(arg?: Labels<T>): (arg?: Labels<T>) => void;
 }

--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -115,7 +115,7 @@ export async function runStateTransition(
     }
 
     emitBlockEvent(emitter, job, postState);
-    emitForkChoiceHeadEvents(emitter, forkChoice, forkChoice.getHead(), oldHead);
+    emitForkChoiceHeadEvents(emitter, forkChoice, forkChoice.getHead(), oldHead, metrics);
   }
 
   return postState;
@@ -151,7 +151,8 @@ function emitForkChoiceHeadEvents(
   emitter: ChainEventEmitter,
   forkChoice: IForkChoice,
   head: IBlockSummary,
-  oldHead: IBlockSummary
+  oldHead: IBlockSummary,
+  metrics: IMetrics | null
 ): void {
   const headRoot = head.blockRoot;
   const oldHeadRoot = oldHead.blockRoot;
@@ -164,8 +165,10 @@ function emitForkChoiceHeadEvents(
       const firstAncestor = headHistory.find((summary) => oldHeadHistory.includes(summary));
       const distance = oldHead.slot - (firstAncestor?.slot ?? oldHead.slot);
       emitter.emit(ChainEvent.forkChoiceReorg, head, oldHead, distance);
+      metrics?.forkChoiceReorg.inc();
     }
     emitter.emit(ChainEvent.forkChoiceHead, head);
+    metrics?.forkChoiceChangedHead.inc();
   }
 }
 

--- a/packages/lodestar/src/metrics/metrics/beacon.ts
+++ b/packages/lodestar/src/metrics/metrics/beacon.ts
@@ -121,9 +121,10 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
       help: "number of aggregators for which we have seen an attestation, not necessarily included on chain.",
     }),
 
-    forkChoiceFindHead: register.histogram({
+    forkChoiceFindHead: register.histogram<"syncStatus" | "resStatus">({
       name: "beacon_fork_choice_find_head_seconds",
       help: "Time taken to find head in seconds",
+      labelNames: ["syncStatus", "resStatus"],
       buckets: [0.1, 1, 10],
     }),
   };

--- a/packages/lodestar/src/metrics/metrics/beacon.ts
+++ b/packages/lodestar/src/metrics/metrics/beacon.ts
@@ -121,11 +121,26 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
       help: "number of aggregators for which we have seen an attestation, not necessarily included on chain.",
     }),
 
-    forkChoiceFindHead: register.histogram<"syncStatus" | "resStatus">({
+    forkChoiceFindHead: register.histogram({
       name: "beacon_fork_choice_find_head_seconds",
       help: "Time taken to find head in seconds",
-      labelNames: ["syncStatus", "resStatus"],
       buckets: [0.1, 1, 10],
+    }),
+    forkChoiceHeadRequests: register.gauge({
+      name: "beacon_fork_choice_requests_total",
+      help: "Count of occasions where fork choice has tried to find a head",
+    }),
+    forkChoiceErrors: register.gauge({
+      name: "beacon_fork_choice_errors_total",
+      help: "Count of occasions where fork choice has returned an error when trying to find a head",
+    }),
+    forkChoiceNewHeads: register.gauge({
+      name: "beacon_fork_choice_changed_head_total",
+      help: "Count of occasions fork choice has found a new head",
+    }),
+    forkChoiceNewChains: register.gauge({
+      name: "beacon_fork_choice_reorg_total",
+      help: "Count of occasions fork choice has switched to a different chain",
     }),
   };
 }

--- a/packages/lodestar/src/metrics/metrics/beacon.ts
+++ b/packages/lodestar/src/metrics/metrics/beacon.ts
@@ -126,7 +126,7 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
       help: "Time taken to find head in seconds",
       buckets: [0.1, 1, 10],
     }),
-    forkChoiceHeadRequests: register.gauge({
+    forkChoiceRequests: register.gauge({
       name: "beacon_fork_choice_requests_total",
       help: "Count of occasions where fork choice has tried to find a head",
     }),
@@ -134,11 +134,11 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
       name: "beacon_fork_choice_errors_total",
       help: "Count of occasions where fork choice has returned an error when trying to find a head",
     }),
-    forkChoiceNewHeads: register.gauge({
+    forkChoiceChangedHead: register.gauge({
       name: "beacon_fork_choice_changed_head_total",
       help: "Count of occasions fork choice has found a new head",
     }),
-    forkChoiceNewChains: register.gauge({
+    forkChoiceReorg: register.gauge({
       name: "beacon_fork_choice_reorg_total",
       help: "Count of occasions fork choice has switched to a different chain",
     }),


### PR DESCRIPTION
This PR now times the update head function with more dimensions along which analysis of fork-choice

![image](https://user-images.githubusercontent.com/76567250/122559278-c1af6c80-d05c-11eb-9c76-362068c0eba1.png)

**Motivation**

<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
partially Closes #2558, allows to construct the following metrics on  grafana

beacon_fork_choice_requests_total -- grafana selector: beacon_fork_choice_find_head_seconds_count{}
beacon_fork_choice_errors_total -- grafana selector: beacon_fork_choice_find_head_seconds_count{resStatus="error"}
beacon_fork_choice_changed_head_total -- grafana selector: beacon_fork_choice_find_head_seconds_count{resStatus="newhead"}
beacon_fork_choice_reorg_total-- grafana selector:  beacon_fork_choice_find_head_seconds_count{resStatus="newfork"}

beacon_fork_choice_find_head_seconds (the original  metric measurement in previous PR) -- grafana selector: beacon_fork_choice_find_head_seconds_sum{syncStatus="unsynced"}

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
