### PR TITLE
Update abort-controller import

### DIFF
--- a/packages/api/src/client/utils/httpClient.ts
+++ b/packages/api/src/client/utils/httpClient.ts
@@ -1,5 +1,5 @@
 import {fetch} from "cross-fetch";
-import {AbortSignal, AbortController} from "abort-controller";
+import AbortController, {AbortSignal} from "abort-controller";
 import {ErrorAborted, TimeoutError} from "@chainsafe/lodestar-utils";
 import {ReqGeneric, RouteDef} from "../../utils";
 import {stringifyQuery, urlJoin} from "./format";

--- a/packages/api/src/server/events.ts
+++ b/packages/api/src/server/events.ts
@@ -1,4 +1,5 @@
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ServerRoutes} from "./utils";
 import {Api, ReqTypes, routesData, getEventSerdes} from "../routes/events";

--- a/packages/api/test/unit/client/httpClient.test.ts
+++ b/packages/api/test/unit/client/httpClient.test.ts
@@ -1,5 +1,6 @@
 import {ErrorAborted, TimeoutError} from "@chainsafe/lodestar-utils";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
 import fastify, {RouteOptions} from "fastify";

--- a/packages/api/test/unit/events.test.ts
+++ b/packages/api/test/unit/events.test.ts
@@ -1,4 +1,5 @@
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {config} from "@chainsafe/lodestar-config/default";
 import {Api, routesData, EventType, BeaconEvent} from "../../src/routes/events";

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -1,4 +1,5 @@
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 
 import {ErrorAborted} from "@chainsafe/lodestar-utils";
 import {LevelDbController} from "@chainsafe/lodestar-db";

--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -2,7 +2,8 @@ import fs from "fs";
 import {promisify} from "util";
 import rimraf from "rimraf";
 import path from "path";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {GENESIS_SLOT} from "@chainsafe/lodestar-params";
 import {BeaconNode, BeaconDb, initStateFromAnchorState, createNodeJsLibp2p, nodeUtils} from "@chainsafe/lodestar";
 import {SlashingProtection, Validator} from "@chainsafe/lodestar-validator";

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -1,4 +1,5 @@
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {SecretKey} from "@chainsafe/bls";
 import {interopSecretKey} from "@chainsafe/lodestar-beacon-state-transition";
 import {getClient} from "@chainsafe/lodestar-api";

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -14,7 +14,8 @@ import {allForks, ForkDigest, Number64, Root, phase0, Slot} from "@chainsafe/lod
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {TreeBacked} from "@chainsafe/ssz";
 import {LightClientUpdater} from "@chainsafe/lodestar-light-client/lib/server/LightClientUpdater";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {GENESIS_EPOCH, ZERO_HASH} from "../constants";
 import {IBeaconDb} from "../db";
 import {CheckpointStateCache, StateContextCache} from "./stateCache";

--- a/packages/lodestar/src/network/reqresp/reqResp.ts
+++ b/packages/lodestar/src/network/reqresp/reqResp.ts
@@ -6,7 +6,8 @@ import {ForkName} from "@chainsafe/lodestar-params";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import LibP2p from "libp2p";
 import PeerId from "peer-id";
 import {timeoutOptions} from "../../constants";

--- a/packages/lodestar/src/network/reqresp/request/responseTimeoutsHandler.ts
+++ b/packages/lodestar/src/network/reqresp/request/responseTimeoutsHandler.ts
@@ -1,4 +1,5 @@
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import pipe from "it-pipe";
 import {timeoutOptions} from "../../../constants";
 import {abortableSource} from "../../../util/abortableSource";

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -2,7 +2,8 @@
  * @module node
  */
 
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import LibP2p from "libp2p";
 
 import {TreeBacked} from "@chainsafe/ssz";

--- a/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
@@ -1,5 +1,6 @@
 import {expect} from "chai";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {bls, init, PublicKey} from "@chainsafe/bls";
 import {BlsMultiThreadWorkerPool} from "../../../../src/chain/bls/multithread";
 import {testLogger} from "../../../utils/logger";

--- a/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
@@ -3,7 +3,8 @@ import "mocha";
 import {expect} from "chai";
 import {promisify} from "es6-promisify";
 import leveldown from "leveldown";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {LevelDbController} from "@chainsafe/lodestar-db";
 

--- a/packages/lodestar/test/e2e/eth1/jsonRpcHttpClient.test.ts
+++ b/packages/lodestar/test/e2e/eth1/jsonRpcHttpClient.test.ts
@@ -2,7 +2,8 @@ import "mocha";
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
 import http from "http";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {JsonRpcHttpClient} from "../../../src/eth1/jsonRpcHttpClient";
 import {goerliRpcUrl} from "../../testParams";
 import {IRpcPayload} from "../../../src/eth1/interface";

--- a/packages/lodestar/test/e2e/eth1/stream.test.ts
+++ b/packages/lodestar/test/e2e/eth1/stream.test.ts
@@ -1,6 +1,7 @@
 import "mocha";
 import {expect} from "chai";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {getTestnetConfig, testnet} from "../../utils/testnet";
 import {getDepositsStream, getDepositsAndBlockStreamForGenesis, Eth1Provider} from "../../../src/eth1";
 

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -1,6 +1,7 @@
 import sinon from "sinon";
 import {expect} from "chai";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 
 import PeerId from "peer-id";
 import {Discv5Discovery, ENR} from "@chainsafe/discv5";

--- a/packages/lodestar/test/e2e/network/reqresp.test.ts
+++ b/packages/lodestar/test/e2e/network/reqresp.test.ts
@@ -1,7 +1,8 @@
 import sinon from "sinon";
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import PeerId from "peer-id";
 import {config} from "@chainsafe/lodestar-config/default";
 import {sleep as _sleep} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/test/unit/api/impl/events/events.test.ts
+++ b/packages/lodestar/test/unit/api/impl/events/events.test.ts
@@ -1,4 +1,5 @@
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {expect} from "chai";
 import sinon, {SinonStubbedInstance} from "sinon";
 import {routes} from "@chainsafe/lodestar-api";

--- a/packages/lodestar/test/unit/chain/clock/local.test.ts
+++ b/packages/lodestar/test/unit/chain/clock/local.test.ts
@@ -1,5 +1,6 @@
 import sinon from "sinon";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/default";
 

--- a/packages/lodestar/test/unit/chain/genesis/genesis.test.ts
+++ b/packages/lodestar/test/unit/chain/genesis/genesis.test.ts
@@ -13,7 +13,8 @@ import {
 import {ValidatorIndex, phase0, ssz} from "@chainsafe/lodestar-types";
 import {ErrorAborted} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {IEth1Provider} from "../../../../src/eth1";
 import {GenesisBuilder} from "../../../../src/chain/genesis/genesis";
 import {testLogger} from "../../../utils/logger";

--- a/packages/lodestar/test/unit/network/reqresp/request/responseTimeoutsHandler.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/request/responseTimeoutsHandler.test.ts
@@ -1,4 +1,5 @@
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import all from "it-all";
 import pipe from "it-pipe";
 import {LodestarError, sleep as _sleep} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/test/unit/network/reqresp/response/index.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/response/index.test.ts
@@ -1,6 +1,7 @@
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {config} from "@chainsafe/lodestar-config/default";
 import {LodestarError} from "@chainsafe/lodestar-utils";
 import {RespStatus} from "../../../../../src/constants";

--- a/packages/lodestar/test/unit/util/queue.test.ts
+++ b/packages/lodestar/test/unit/util/queue.test.ts
@@ -1,5 +1,6 @@
 import {sleep} from "@chainsafe/lodestar-utils";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {expect} from "chai";
 
 import {JobQueue, QueueError, QueueErrorCode, QueueType} from "../../../src/util/queue";

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -1,4 +1,5 @@
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import sinon from "sinon";
 
 import {TreeBacked} from "@chainsafe/ssz";

--- a/packages/utils/src/timeout.ts
+++ b/packages/utils/src/timeout.ts
@@ -1,4 +1,5 @@
-import {AbortSignal, AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController, {AbortSignal} from "abort-controller";
 import {anySignal} from "any-signal";
 import {TimeoutError} from "./errors";
 import {sleep} from "./sleep";

--- a/packages/utils/test/unit/sleep.test.ts
+++ b/packages/utils/test/unit/sleep.test.ts
@@ -1,6 +1,7 @@
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {sleep} from "../../src/sleep";
 import {ErrorAborted} from "../../src/errors";
 

--- a/packages/utils/test/unit/timeout.test.ts
+++ b/packages/utils/test/unit/timeout.test.ts
@@ -1,6 +1,7 @@
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {withTimeout} from "../../src/timeout";
 import {ErrorAborted, TimeoutError} from "../../src/errors";
 

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -1,4 +1,5 @@
-import {AbortController, AbortSignal} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController, {AbortSignal} from "abort-controller";
 import {SecretKey} from "@chainsafe/bls";
 import {ssz} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -1,4 +1,5 @@
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {expect} from "chai";
 import sinon from "sinon";
 import bls from "@chainsafe/bls";

--- a/packages/validator/test/unit/services/attestationDuties.test.ts
+++ b/packages/validator/test/unit/services/attestationDuties.test.ts
@@ -1,4 +1,5 @@
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {toBufferBE} from "bigint-buffer";
 import {expect} from "chai";
 import sinon from "sinon";

--- a/packages/validator/test/unit/services/block.test.ts
+++ b/packages/validator/test/unit/services/block.test.ts
@@ -1,4 +1,5 @@
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {expect} from "chai";
 import sinon from "sinon";
 import bls from "@chainsafe/bls";

--- a/packages/validator/test/unit/services/blockDuties.test.ts
+++ b/packages/validator/test/unit/services/blockDuties.test.ts
@@ -1,4 +1,5 @@
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {expect} from "chai";
 import sinon from "sinon";
 import bls from "@chainsafe/bls";

--- a/packages/validator/test/unit/services/syncCommitteDuties.test.ts
+++ b/packages/validator/test/unit/services/syncCommitteDuties.test.ts
@@ -1,4 +1,5 @@
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {toBufferBE} from "bigint-buffer";
 import {expect} from "chai";
 import sinon from "sinon";

--- a/packages/validator/test/unit/services/syncCommittee.test.ts
+++ b/packages/validator/test/unit/services/syncCommittee.test.ts
@@ -1,4 +1,5 @@
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {expect} from "chai";
 import sinon from "sinon";
 import bls from "@chainsafe/bls";

--- a/packages/validator/test/unit/utils/clock.test.ts
+++ b/packages/validator/test/unit/utils/clock.test.ts
@@ -1,6 +1,7 @@
 import sinon from "sinon";
 import {expect} from "chai";
-import {AbortController} from "abort-controller";
+// eslint-disable-next-line import/no-named-as-default
+import AbortController from "abort-controller";
 import {config} from "@chainsafe/lodestar-config/default";
 import {Clock} from "../../../src/util/clock";
 import {testLogger} from "../../utils/logger";


### PR DESCRIPTION
**Motivation**

See https://github.com/mysticatea/abort-controller/issues/32
Due to a missing export statement in the `abort-controller` package, using the named export `AbortController` will break when run in the browser.

**Description**

Update all named import `AbortController` with the default import, named the same.
This goes against one of our linter rules `import/no-named-as-default`, so every import is accompanied with an eslint-disable statement.

We should discuss whether or not this is the best course of action, considering the underlying issue may come back when we use `AbortController` in the future (and use the named export).

