### PR TITLE
Fix getSyncCommitteeDuties api

### DIFF
--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -280,18 +280,17 @@ export function getValidatorApi({
       // Ensures `epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD <= current_epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD + 1`
       const syncComitteeValidatorIndexMap = getSyncComitteeValidatorIndexMap(state, epoch);
 
-      const duties: routes.validator.SyncDuty[] = validatorIndices
-        .map((validatorIndex) => {
-          const validatorSyncCommitteeIndices = syncComitteeValidatorIndexMap.get(validatorIndex);
-          return validatorSyncCommitteeIndices
-            ? {
-                pubkey: state.validators[validatorIndex].pubkey,
-                validatorIndex,
-                validatorSyncCommitteeIndices,
-              }
-            : null;
-        })
-        .filter(notNullish);
+      const duties: routes.validator.SyncDuty[] = [];
+      for (const validatorIndex of validatorIndices) {
+        const validatorSyncCommitteeIndices = syncComitteeValidatorIndexMap.get(validatorIndex);
+        if (validatorSyncCommitteeIndices) {
+          duties.push({
+            pubkey: state.validators[validatorIndex].pubkey,
+            validatorIndex,
+            validatorSyncCommitteeIndices,
+          });
+        }
+      }
 
       return {
         data: duties,

--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -28,7 +28,6 @@ import {CommitteeSubscription} from "../../../network/subnets";
 import {OpSource} from "../../../metrics/validatorMonitor";
 import {computeSubnetForCommitteesAtSlot, getSyncComitteeValidatorIndexMap} from "./utils";
 import {ApiModules} from "../types";
-import {notNullish} from "../../../../../utils/lib";
 
 /**
  * Validator clock may be advanced from beacon's clock. If the validator requests a resource in a


### PR DESCRIPTION
**Motivation**

On oonoonba, we always have all validators stay in sync committee which does not seem right.

**Description**

At api side, we should not return anything without sync duty, see https://ethereum.github.io/eth2.0-APIs/#/Validator/getSyncCommitteeDuties
Closes #2738


