### PR TITLE
Fix broken webpack build in browser

### DIFF
--- a/packages/config/src/chainConfig/default.ts
+++ b/packages/config/src/chainConfig/default.ts
@@ -1,5 +1,18 @@
-import {ACTIVE_PRESET} from "@chainsafe/lodestar-params";
+import {ACTIVE_PRESET, PresetName} from "@chainsafe/lodestar-params";
 import {IChainConfig} from "./types";
+import {chainConfig as mainnet} from "./presets/mainnet";
+import {chainConfig as minimal} from "./presets/minimal";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-member-access
-export const defaultChainConfig = require(`./presets/${ACTIVE_PRESET}`).chainConfig as IChainConfig;
+let defaultChainConfig: IChainConfig;
+
+switch (ACTIVE_PRESET) {
+  case PresetName.minimal:
+    defaultChainConfig = minimal;
+    break;
+  case PresetName.mainnet:
+  default:
+    defaultChainConfig = mainnet;
+    break;
+}
+
+export {defaultChainConfig};


### PR DESCRIPTION
**Motivation**

Lightclient UI build emits warnings when trying to import .d.ts files with a require statement.

```
Failed to compile.

./node_modules/@chainsafe/lodestar-config/lib/chainConfig/presets/mainnet.d.ts 2:7
Module parse failed: Unexpected token (2:7)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
| import { IChainConfig } from "../types";
> export declare const chainConfig: IChainConfig;
| //# sourceMappingURL=mainnet.d.ts.map

./node_modules/@chainsafe/lodestar-config/lib/chainConfig/presets/minimal.d.ts 2:7
Module parse failed: Unexpected token (2:7)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
| import { IChainConfig } from "../types";
> export declare const chainConfig: IChainConfig;
| //# sourceMappingURL=minimal.d.ts.map
```

https://github.com/ChainSafe/eth2-light-client-demo/runs/2914224290

**Description**

Change how the config presets are imported to match `lodestar-params`

https://github.com/ChainSafe/lodestar/blob/dc16c5acfe646d0cba8b1cec3de7ce88d8835c4c/packages/params/src/activePreset.ts#L11-L20

It does not cause the warnings anymore, and does not need using a dynamic require statement.

Note that the `ACTIVE_PRESET` env technically arbitrary so it's a bit fishy to have a dynamic non-controlled import there when it's not strictly necessary.