### PR TITLE
Reprocess attestations in batch

### DIFF
--- a/packages/lodestar/src/chain/attestation/process.ts
+++ b/packages/lodestar/src/chain/attestation/process.ts
@@ -1,11 +1,105 @@
-import {allForks} from "@chainsafe/lodestar-types";
-import {CachedBeaconState, phase0} from "@chainsafe/lodestar-beacon-state-transition";
+import {allForks, CachedBeaconState, phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 
 import {IAttestationJob} from "../interface";
 import {AttestationError, AttestationErrorCode} from "../errors";
 import {ChainEvent, ChainEventEmitter} from "../emitter";
 import {IStateRegenerator} from "../regen";
+import {IBlsVerifier} from "../bls";
+import {notNullish} from "../../../../utils/lib";
+
+/**
+ * Verify attestation signatures in batch.
+ * @returns jobs with valid signatures and indexed attestations.
+ */
+export async function verifyAttestationSignatures({
+  bls,
+  regen,
+  jobs,
+  emitter,
+}: {
+  bls: IBlsVerifier;
+  regen: IStateRegenerator;
+  jobs: IAttestationJob[];
+  emitter: ChainEventEmitter;
+}): Promise<IAttestationJob[]> {
+  const signatureSets = await Promise.all(
+    jobs.map(async (job) => {
+      const attestation = job.attestation;
+      let targetState;
+      try {
+        targetState = await regen.getCheckpointState(attestation.data.target);
+        try {
+          job.indexedAttestation = targetState.getIndexedAttestation(attestation);
+        } catch (e) {
+          emitErrorAttestation(emitter, job, AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX);
+        }
+      } catch (e) {
+        emitErrorAttestation(emitter, job, AttestationErrorCode.UNKNOWN_TARGET_ROOT);
+      }
+      return job.indexedAttestation && targetState
+        ? allForks.getIndexedAttestationSignatureSet(targetState, job.indexedAttestation)
+        : null;
+    })
+  );
+  const isAllValid = await bls.verifySignatureSets(signatureSets.filter(notNullish));
+  let validJobs: IAttestationJob[];
+  if (isAllValid) {
+    validJobs = jobs.filter((job) => job.indexedAttestation);
+  } else {
+    // fallback, rarely happens
+    validJobs = [];
+    for (let i = 0; i < jobs.length; i++) {
+      const signature = signatureSets[i];
+      if (signature) {
+        const valid = await bls.verifySignatureSets([signature]);
+        valid
+          ? validJobs.push(jobs[i])
+          : emitErrorAttestation(emitter, jobs[i], AttestationErrorCode.INVALID_SIGNATURE);
+      }
+    }
+  }
+  return validJobs.map((job) => ({...job, ...{validSignature: true}}));
+}
+
+function emitErrorAttestation(emitter: ChainEventEmitter, job: IAttestationJob, code: AttestationErrorCode): void {
+  const data = job.attestation.data;
+  switch (code) {
+    case AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX:
+      emitter.emit(
+        ChainEvent.errorAttestation,
+        new AttestationError({
+          code: AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX,
+          slot: data.slot,
+          index: data.index,
+          job,
+        })
+      );
+      break;
+    case AttestationErrorCode.UNKNOWN_TARGET_ROOT:
+      emitter.emit(
+        ChainEvent.errorAttestation,
+        new AttestationError({
+          code: AttestationErrorCode.UNKNOWN_TARGET_ROOT,
+          root: job.attestation.data.target.root as Uint8Array,
+          job,
+        })
+      );
+      break;
+    case AttestationErrorCode.INVALID_SIGNATURE:
+      emitter.emit(
+        ChainEvent.errorAttestation,
+        new AttestationError({
+          code: AttestationErrorCode.INVALID_SIGNATURE,
+          job,
+        })
+      );
+      break;
+    default:
+      // should not happen
+      throw new Error("Unhandle AttestationErrorCode");
+  }
+}
 
 /**
  * Expects valid attestation which is to be applied in forkchoice.
@@ -31,14 +125,15 @@ export async function processAttestation({
     targetState = await regen.getCheckpointState(target);
   } catch (e) {
     throw new AttestationError({
-      code: AttestationErrorCode.TARGET_STATE_MISSING,
+      code: AttestationErrorCode.UNKNOWN_TARGET_ROOT,
+      root: target.root as Uint8Array,
       job,
     });
   }
 
   let indexedAttestation: phase0.IndexedAttestation;
   try {
-    indexedAttestation = targetState.epochCtx.getIndexedAttestation(attestation);
+    indexedAttestation = job.indexedAttestation || targetState.epochCtx.getIndexedAttestation(attestation);
   } catch (e) {
     throw new AttestationError({
       code: AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX,

--- a/packages/lodestar/src/chain/attestation/processor.ts
+++ b/packages/lodestar/src/chain/attestation/processor.ts
@@ -26,6 +26,11 @@ type AttestationProcessorModules = {
   regen: IStateRegenerator;
 };
 
+/** In terms of batch signature verification, we can make this the same to MAX_ATTESTATION
+ *  but we also don't want attestations to be delayed a lot.
+ **/
+const ITEMS_PER_BATCH = 10;
+
 export class AttestationProcessor {
   private modules: AttestationProcessorModules;
   private pendingAttestationJobs: IAttestationJob[] = [];
@@ -55,12 +60,12 @@ export class AttestationProcessor {
 }
 
 /**
- * Check if it's enough 128 jobs to process.
+ * Check if it's enough ITEMS_PER_BATCH jobs to process.
  * Return jobs to process or undefined.
  */
 export function needProcessPendingAttestations(
   pendingAttestationJobs: IAttestationJob[],
-  itemsPerBatch = 128
+  itemsPerBatch = ITEMS_PER_BATCH
 ): IAttestationJob[] | null {
   if (pendingAttestationJobs.length >= itemsPerBatch) {
     return pendingAttestationJobs.splice(0, itemsPerBatch);

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -31,6 +31,7 @@ import {LodestarForkChoice} from "./forkChoice";
 import {restoreStateCaches} from "./initState";
 import {BlsVerifier, IBlsVerifier} from "./bls";
 import {ForkDigestContext, IForkDigestContext} from "../util/forkDigestContext";
+import {IAttestationJob} from "../../src/chain";
 
 export interface IBeaconChainModules {
   config: IBeaconConfig;
@@ -232,10 +233,8 @@ export class BeaconChain implements IBeaconChain {
     this.pendingAttestations.putBySlot(attestation.data.slot, {attestation, validSignature: false});
   }
 
-  receiveAttestation(attestation: phase0.Attestation): void {
-    this.attestationProcessor
-      .processAttestationJob({attestation, validSignature: false})
-      .catch(() => /* unreachable */ ({}));
+  receiveAttestation(job: IAttestationJob): void {
+    this.attestationProcessor.processAttestationJob(job).catch(() => /* unreachable */ ({}));
   }
 
   receiveBlock(signedBlock: allForks.SignedBeaconBlock, trusted = false): void {

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -108,7 +108,7 @@ export class BeaconChain implements IBeaconChain {
     });
     this.pendingAttestations = new AttestationPool({config});
     this.pendingBlocks = new BlockPool(config, logger);
-    this.attestationProcessor = new AttestationProcessor({config, forkChoice, emitter, clock, regen});
+    this.attestationProcessor = new AttestationProcessor({config, forkChoice, emitter, clock, regen, bls});
     this.blockProcessor = new BlockProcessor({
       config,
       forkChoice,
@@ -222,6 +222,14 @@ export class BeaconChain implements IBeaconChain {
 
   getFinalizedCheckpoint(): phase0.Checkpoint {
     return this.forkChoice.getFinalizedCheckpoint();
+  }
+
+  pendingAttestationByBlock(attestation: phase0.Attestation, blockRoot: Root): void {
+    this.pendingAttestations.putByBlock(blockRoot, {attestation, validSignature: false});
+  }
+
+  pendingAttestationBySlot(attestation: phase0.Attestation): void {
+    this.pendingAttestations.putBySlot(attestation.data.slot, {attestation, validSignature: false});
   }
 
   receiveAttestation(attestation: phase0.Attestation): void {

--- a/packages/lodestar/src/chain/errors/attestationError.ts
+++ b/packages/lodestar/src/chain/errors/attestationError.ts
@@ -5,10 +5,6 @@ import {IAttestationJob} from "../interface";
 
 export enum AttestationErrorCode {
   /**
-   * The target state cannot be fetched
-   */
-  TARGET_STATE_MISSING = "ATTESTATION_ERROR_TARGET_STATE_MISSING",
-  /**
    * The attestation is from a slot that is later than the current slot (with respect to the gossip clock disparity).
    */
   FUTURE_SLOT = "ATTESTATION_ERROR_FUTURE_SLOT",
@@ -134,7 +130,6 @@ export enum AttestationErrorCode {
 }
 
 export type AttestationErrorType =
-  | {code: AttestationErrorCode.TARGET_STATE_MISSING}
   | {code: AttestationErrorCode.FUTURE_SLOT; attestationSlot: Slot; latestPermissibleSlot: Slot}
   | {code: AttestationErrorCode.PAST_SLOT; attestationSlot: Slot; earliestPermissibleSlot: Slot}
   | {code: AttestationErrorCode.EMPTY_AGGREGATION_BITFIELD}

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -315,15 +315,22 @@ export async function onErrorAttestation(this: BeaconChain, err: AttestationErro
 
   switch (err.type.code) {
     case AttestationErrorCode.FUTURE_SLOT:
-      this.logger.debug("Add attestation to pool", {
+      this.logger.debug("Future slot, add attestation to pool", {
         reason: err.type.code,
         attestationRoot: toHexString(attestationRoot),
       });
       this.pendingAttestations.putBySlot(err.type.attestationSlot, err.job);
       break;
 
+    case AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE:
+      this.logger.debug("missing target state, add attestation to pool", {
+        reason: err.type.code,
+        attestationRoot: toHexString(attestationRoot),
+      });
+      this.pendingAttestations.putByBlock(err.job.attestation.data.target.root, err.job);
+      break;
     case AttestationErrorCode.UNKNOWN_TARGET_ROOT:
-      this.logger.debug("Add attestation to pool", {
+      this.logger.debug("unknown target root, add attestation to pool", {
         reason: err.type.code,
         attestationRoot: toHexString(attestationRoot),
       });

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -95,7 +95,7 @@ export interface IBeaconChain {
   /** Put to AttestationPool to reprocess after we reach attestation slot */
   pendingAttestationBySlot(attestation: phase0.Attestation): void;
   /** Add attestation to the fork-choice rule */
-  receiveAttestation(attestation: phase0.Attestation): void;
+  receiveAttestation(job: IAttestationJob): void;
   /** Pre-process and run the per slot state transition function */
   receiveBlock(signedBlock: allForks.SignedBeaconBlock, trusted?: boolean): void;
   /** Process a block until complete */

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -43,6 +43,7 @@ export interface IBlockJob extends IProcessBlock {
 
 export interface IAttestationJob {
   attestation: phase0.Attestation;
+  indexedAttestation?: phase0.IndexedAttestation;
   /**
    * `true` if the signature has already been verified
    */
@@ -89,6 +90,10 @@ export interface IBeaconChain {
   getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<allForks.SignedBeaconBlock[]>;
   getFinalizedCheckpoint(): phase0.Checkpoint;
 
+  /** Put to AttestationPool to reprocess after we see a blockRoot */
+  pendingAttestationByBlock(attestation: phase0.Attestation, blockRoot: Root): void;
+  /** Put to AttestationPool to reprocess after we reach attestation slot */
+  pendingAttestationBySlot(attestation: phase0.Attestation): void;
   /** Add attestation to the fork-choice rule */
   receiveAttestation(attestation: phase0.Attestation): void;
   /** Pre-process and run the per slot state transition function */

--- a/packages/lodestar/src/network/gossip/validatorFns/aggregatedAttestation.ts
+++ b/packages/lodestar/src/network/gossip/validatorFns/aggregatedAttestation.ts
@@ -21,6 +21,7 @@ export async function validateAggregatedAttestation(
       validSignature: false,
     });
     logger.debug("gossip - AggregateAndProof - accept");
+    chain.receiveAttestation({attestation, indexedAttestation: indexedAtt, validSignature: true});
 
     metrics?.registerAggregatedAttestation(OpSource.gossip, seenTimestampSec, signedAggregateAndProof, indexedAtt);
   } catch (e) {

--- a/packages/lodestar/src/network/gossip/validatorFns/aggregatedAttestation.ts
+++ b/packages/lodestar/src/network/gossip/validatorFns/aggregatedAttestation.ts
@@ -40,7 +40,7 @@ export async function validateAggregatedAttestation(
         throw new GossipValidationError(ERR_TOPIC_VALIDATOR_REJECT);
 
       case AttestationErrorCode.FUTURE_SLOT: // IGNORE
-        chain.receiveAttestation(attestation);
+        chain.pendingAttestationBySlot(attestation);
       /** eslit-disable-next-line no-fallthrough */
       case AttestationErrorCode.PAST_SLOT:
       case AttestationErrorCode.AGGREGATE_ALREADY_KNOWN:

--- a/packages/lodestar/src/network/gossip/validatorFns/attestation.ts
+++ b/packages/lodestar/src/network/gossip/validatorFns/attestation.ts
@@ -24,6 +24,7 @@ export async function validateCommitteeAttestation(
 
     const indexedAtt = await validateGossipAttestation(config, chain, db, attestationJob, subnet);
     logger.debug("gossip - Attestation - accept", {subnet});
+    chain.receiveAttestation({attestation, indexedAttestation: indexedAtt, validSignature: true});
 
     metrics?.registerUnaggregatedAttestation(OpSource.gossip, seenTimestampSec, indexedAtt);
   } catch (e) {

--- a/packages/lodestar/src/network/gossip/validatorFns/attestation.ts
+++ b/packages/lodestar/src/network/gossip/validatorFns/attestation.ts
@@ -47,7 +47,7 @@ export async function validateCommitteeAttestation(
       case AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT:
       case AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE: // IGNORE
         // attestation might be valid after we receive block
-        chain.receiveAttestation(attestation);
+        chain.pendingAttestationByBlock(attestation, attestation.data.target.root);
       /** eslit-disable-next-line no-fallthrough */
       case AttestationErrorCode.PAST_SLOT:
       case AttestationErrorCode.FUTURE_SLOT:

--- a/packages/lodestar/test/unit/chain/attestation/process.test.ts
+++ b/packages/lodestar/test/unit/chain/attestation/process.test.ts
@@ -2,8 +2,9 @@ import {expect} from "chai";
 import sinon, {SinonStubbedInstance} from "sinon";
 
 import {ForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
+import {ISignatureSet, phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import * as attestationUtils from "@chainsafe/lodestar-beacon-state-transition/lib/allForks/block/isValidIndexedAttestation";
+import * as signatureSetUtils from "@chainsafe/lodestar-beacon-state-transition/lib/allForks/signatureSets/indexedAttestation";
 
 import {processAttestation} from "../../../../src/chain/attestation/process";
 import {ChainEvent, ChainEventEmitter} from "../../../../src/chain";
@@ -13,6 +14,112 @@ import {generateAttestation} from "../../../utils/attestation";
 import {generateCachedState} from "../../../utils/state";
 import {SinonStubFn} from "../../../utils/types";
 import {AttestationError} from "../../../../src/chain/errors";
+import {BlsVerifier} from "../../../../src/chain/bls";
+import {IAttestationJob} from "../../../../src/chain";
+import {verifyAttestationSignatures} from "../../../../lib/chain/attestation/process";
+import {List} from "@chainsafe/ssz";
+
+describe("verifyAttestationSignatures", function () {
+  const emitter = new ChainEventEmitter();
+  let regen: SinonStubbedInstance<StateRegenerator>;
+  let bls: SinonStubbedInstance<BlsVerifier>;
+  let getIndexedAttestationSignatureSetStub: SinonStubFn<typeof signatureSetUtils["getIndexedAttestationSignatureSet"]>;
+
+  beforeEach(function () {
+    regen = sinon.createStubInstance(StateRegenerator);
+    bls = sinon.createStubInstance(BlsVerifier);
+    getIndexedAttestationSignatureSetStub = sinon.stub(signatureSetUtils, "getIndexedAttestationSignatureSet");
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("all good attestation jobs", async function () {
+    const attestations = [generateAttestation(), generateAttestation()];
+    const jobs: IAttestationJob[] = attestations.map((attestation) => ({attestation, validSignature: false}));
+    const state = generateCachedState();
+    const indexedAttestation = {attestingIndices: [0] as List<phase0.ValidatorIndex>} as phase0.IndexedAttestation;
+    sinon.stub(state.epochCtx, "getIndexedAttestation").returns(indexedAttestation);
+    regen.getCheckpointState.resolves(state);
+    getIndexedAttestationSignatureSetStub.returns({} as ISignatureSet);
+    bls.verifySignatureSets.resolves(true);
+    const emitStub = sinon.stub(emitter, "emit");
+    const validJobs = await verifyAttestationSignatures({bls, regen, jobs, emitter});
+    expect(validJobs.length).to.be.equal(2, "should return 2 valid jobs");
+    expect(emitStub.calledOnce, "all jobs are good, should not emit errorAttestation events").to.be.false;
+    for (let i = 0; i < 2; i++) {
+      expect(validJobs[i]).to.be.deep.equal({attestation: attestations[i], indexedAttestation, validSignature: true});
+    }
+  });
+
+  it("one good attestation job and one unknown target root", async function () {
+    const attestations = [generateAttestation(), generateAttestation()];
+    const jobs: IAttestationJob[] = attestations.map((attestation) => ({attestation, validSignature: false}));
+    const state = generateCachedState();
+    const indexedAttestation = {attestingIndices: [0] as List<phase0.ValidatorIndex>} as phase0.IndexedAttestation;
+    sinon.stub(state.epochCtx, "getIndexedAttestation").returns(indexedAttestation);
+    regen.getCheckpointState.onFirstCall().resolves(state);
+    regen.getCheckpointState.onSecondCall().throws();
+    getIndexedAttestationSignatureSetStub.returns({} as ISignatureSet);
+    bls.verifySignatureSets.resolves(true);
+    const emitSpy = sinon.spy(emitter, "emit");
+    const validJobs = await verifyAttestationSignatures({bls, regen, jobs, emitter});
+    expect(emitSpy.args.length).to.be.equal(1, "should emit once");
+    expect(emitSpy.args[0][0]).to.be.equal(ChainEvent.errorAttestation, "incorrect emit event");
+    const attestationError = emitSpy.args[0][1] as AttestationError;
+    expect(attestationError.job).to.be.deep.equal(jobs[1]);
+    expect(attestationError.type.code).to.be.equal(AttestationErrorCode.UNKNOWN_TARGET_ROOT);
+    expect(validJobs.length).to.be.equal(1, "should return 1 valid jobs");
+    expect(validJobs[0]).to.be.deep.equal({attestation: attestations[0], indexedAttestation, validSignature: true});
+  });
+
+  it("one good attestation job and one invalid signature", async function () {
+    const attestations = [generateAttestation(), generateAttestation()];
+    const jobs: IAttestationJob[] = attestations.map((attestation) => ({attestation, validSignature: false}));
+    const state = generateCachedState();
+    const indexedAttestation = {attestingIndices: [0] as List<phase0.ValidatorIndex>} as phase0.IndexedAttestation;
+    sinon.stub(state.epochCtx, "getIndexedAttestation").returns(indexedAttestation);
+    regen.getCheckpointState.resolves(state);
+    getIndexedAttestationSignatureSetStub.returns({} as ISignatureSet);
+    // verify both
+    bls.verifySignatureSets.onFirstCall().resolves(false);
+    // fallback, verify first
+    bls.verifySignatureSets.onSecondCall().resolves(true);
+    // fallback, verify second
+    bls.verifySignatureSets.onThirdCall().resolves(false);
+    const emitSpy = sinon.spy(emitter, "emit");
+    const validJobs = await verifyAttestationSignatures({bls, regen, jobs, emitter});
+    expect(emitSpy.args.length).to.be.equal(1, "should emit once");
+    expect(emitSpy.args[0][0]).to.be.equal(ChainEvent.errorAttestation, "incorrect emit event");
+    const attestationError = emitSpy.args[0][1] as AttestationError;
+    expect(attestationError.job).to.be.deep.equal(jobs[1]);
+    expect(attestationError.type.code).to.be.equal(AttestationErrorCode.INVALID_SIGNATURE);
+    expect(validJobs.length).to.be.equal(1, "should return 1 valid jobs");
+    expect(validJobs[0]).to.be.deep.equal({attestation: attestations[0], indexedAttestation, validSignature: true});
+  });
+
+  it("one good attestation and one invalid slot/index", async function () {
+    const attestations = [generateAttestation(), generateAttestation()];
+    const jobs: IAttestationJob[] = attestations.map((attestation) => ({attestation, validSignature: false}));
+    const state = generateCachedState();
+    const indexedAttestation = {attestingIndices: [0] as List<phase0.ValidatorIndex>} as phase0.IndexedAttestation;
+    const getIndexedAttestationStub = sinon.stub(state.epochCtx, "getIndexedAttestation");
+    getIndexedAttestationStub.onFirstCall().returns(indexedAttestation);
+    getIndexedAttestationStub.onSecondCall().throws();
+    regen.getCheckpointState.resolves(state);
+    getIndexedAttestationSignatureSetStub.returns({} as ISignatureSet);
+    bls.verifySignatureSets.resolves(true);
+    const emitSpy = sinon.spy(emitter, "emit");
+    const validJobs = await verifyAttestationSignatures({bls, regen, jobs, emitter});
+    expect(emitSpy.args[0][0]).to.be.equal(ChainEvent.errorAttestation, "incorrect emit event");
+    const attestationError = emitSpy.args[0][1] as AttestationError;
+    expect(attestationError.job).to.be.deep.equal(jobs[1]);
+    expect(attestationError.type.code).to.be.equal(AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX);
+    expect(validJobs.length).to.be.equal(1, "should return 1 valid jobs");
+    expect(validJobs[0]).to.be.deep.equal({attestation: attestations[0], indexedAttestation, validSignature: true});
+  });
+});
 
 describe("processAttestation", function () {
   const emitter = new ChainEventEmitter();
@@ -30,7 +137,7 @@ describe("processAttestation", function () {
     sinon.restore();
   });
 
-  it("should throw on missing target state", async function () {
+  it("should throw on unknown target root", async function () {
     const attestation = generateAttestation();
     regen.getCheckpointState.throws();
     try {
@@ -42,7 +149,7 @@ describe("processAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect((e as AttestationError).type.code).to.equal(AttestationErrorCode.TARGET_STATE_MISSING);
+      expect((e as AttestationError).type.code).to.equal(AttestationErrorCode.UNKNOWN_TARGET_ROOT);
     }
   });
 

--- a/packages/lodestar/test/unit/chain/attestation/process.test.ts
+++ b/packages/lodestar/test/unit/chain/attestation/process.test.ts
@@ -69,7 +69,7 @@ describe("verifyAttestationSignatures", function () {
     expect(emitSpy.args[0][0]).to.be.equal(ChainEvent.errorAttestation, "incorrect emit event");
     const attestationError = emitSpy.args[0][1] as AttestationError;
     expect(attestationError.job).to.be.deep.equal(jobs[1]);
-    expect(attestationError.type.code).to.be.equal(AttestationErrorCode.UNKNOWN_TARGET_ROOT);
+    expect(attestationError.type.code).to.be.equal(AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE);
     expect(validJobs.length).to.be.equal(1, "should return 1 valid jobs");
     expect(validJobs[0]).to.be.deep.equal({attestation: attestations[0], indexedAttestation, validSignature: true});
   });
@@ -149,7 +149,7 @@ describe("processAttestation", function () {
       });
       expect.fail("attestation should throw");
     } catch (e) {
-      expect((e as AttestationError).type.code).to.equal(AttestationErrorCode.UNKNOWN_TARGET_ROOT);
+      expect((e as AttestationError).type.code).to.equal(AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE);
     }
   });
 

--- a/packages/lodestar/test/unit/chain/attestation/processor.test.ts
+++ b/packages/lodestar/test/unit/chain/attestation/processor.test.ts
@@ -1,9 +1,35 @@
 import {ForkChoiceError, ForkChoiceErrorCode, InvalidAttestationCode} from "@chainsafe/lodestar-fork-choice";
 import {expect} from "chai";
 import {IAttestationJob} from "../../../../src/chain";
-import {mapAttestationError} from "../../../../src/chain/attestation";
+import {mapAttestationError, needProcessPendingAttestations} from "../../../../src/chain/attestation";
 import {AttestationErrorCode} from "../../../../src/chain/errors";
 import {generateEmptyAttestation} from "../../../utils/attestation";
+
+describe("needProcessPendingAttestations", function () {
+  const testCases: {numJob: number; numProcess: number | null; numRemaining: number}[] = [
+    {numJob: 4, numProcess: null, numRemaining: 4},
+    {numJob: 5, numProcess: 5, numRemaining: 0},
+    {numJob: 6, numProcess: 5, numRemaining: 1},
+  ];
+  for (const {numJob, numProcess, numRemaining} of testCases) {
+    it(`should return ${numProcess} jobs to process, remaining ${numRemaining}`, () => {
+      const pendingAttestationJobs: IAttestationJob[] = Array.from({length: numJob}, () => ({
+        attestation: generateEmptyAttestation(),
+        validSignature: false,
+      }));
+
+      if (!numProcess) {
+        expect(needProcessPendingAttestations(pendingAttestationJobs, 5), "should return null").to.be.null;
+      } else {
+        expect(
+          needProcessPendingAttestations(pendingAttestationJobs, 5)?.length,
+          `should return ${numProcess} jobs to process`
+        ).to.be.equal(numProcess);
+      }
+      expect(pendingAttestationJobs.length, `remaining jobs should be ${numRemaining}`).to.be.equal(numRemaining);
+    });
+  }
+});
 
 describe("Attestation Processor", function () {
   it("mapAttestationError", function () {

--- a/packages/lodestar/test/unit/chain/validation/attestation.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/attestation.test.ts
@@ -115,7 +115,6 @@ describe("gossip attestation validation", function () {
       AttestationErrorCode.ATTESTATION_ALREADY_KNOWN
     );
 
-    expect(chain.receiveAttestation.called).to.be.false;
     expect(db.seenAttestationCache.hasCommitteeAttestation.calledOnceWith(attestation)).to.be.true;
   });
 
@@ -165,7 +164,6 @@ describe("gossip attestation validation", function () {
       AttestationErrorCode.INVALID_SUBNET_ID
     );
 
-    expect(chain.receiveAttestation.called).to.be.false;
     expect(computeAttestationSubnetStub.calledOnceWith(attestationTargetState, attestation)).to.be.true;
   });
 
@@ -186,7 +184,6 @@ describe("gossip attestation validation", function () {
       AttestationErrorCode.INVALID_INDEXED_ATTESTATION
     );
 
-    expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
   });
 
@@ -213,7 +210,6 @@ describe("gossip attestation validation", function () {
       AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE
     );
 
-    expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
   });
 
@@ -246,7 +242,6 @@ describe("gossip attestation validation", function () {
       AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE
     );
 
-    expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
   });
 
@@ -273,7 +268,6 @@ describe("gossip attestation validation", function () {
       AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS
     );
 
-    expect(chain.receiveAttestation.called).to.be.false;
     expect(isValidIndexedAttestationStub.calledOnce).to.be.true;
   });
 
@@ -414,7 +408,6 @@ describe("gossip attestation validation", function () {
     const validationTest = await validateGossipAttestation(config, chain, db, {attestation, validSignature: false}, 0);
 
     expect(validationTest).to.not.throw;
-    expect(chain.receiveAttestation.called).to.be.false;
     expect(db.seenAttestationCache.addCommitteeAttestation.calledOnce).to.be.true;
   });
 });

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -143,6 +143,10 @@ export class MockBeaconChain implements IBeaconChain {
     return Math.floor(Date.now() / 1000);
   }
 
+  pendingAttestationByBlock(): void {}
+
+  pendingAttestationBySlot(): void {}
+
   async receiveAttestation(): Promise<void> {
     return;
   }


### PR DESCRIPTION
**Motivation**

One of the profile when I joined all attestation subnets show that it takes 23% to process attestations, mainly for signature verification. This comes from:
+ Errorred attestations of `FUTURE_SLOT` or `MISSING_ATTESTATION_TARGET_STATE` where we pass to `processAttestation` just to put to `pendingAttestations` in the end which is redundant, we can pass to `pendingAttestations` directly
+ From the event handler, when we reprocess attestations per slot or per known blocks

**Description**

+ Pass to `pendingAttestations` of chain when we have `FUTURE_SLOT` or `MISSING_ATTESTATION_TARGET_STATE` error
+ When we reprocess attestations per slot or per known blocks, we can do that in batch (10 for now): verify all signatures first then process each attestation separately
+ `IAttestationJob` now has an optional indexed attestation so that we only create it if necessary
+ Also some small fixes: remove unnecessary attestation error code, pass gossip attestations to forkchoice

Closes #1949 , #2748 

**Steps to test or reproduce**

+ Hard code to join all attestation subnets 
+ Sync Prater and take profiles
