### PR TITLE
Compute getCommitteeCountPerSlot per epoch

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/attestation.ts
+++ b/packages/beacon-state-transition/src/allForks/util/attestation.ts
@@ -1,6 +1,6 @@
-import {ATTESTATION_SUBNET_COUNT} from "@chainsafe/lodestar-params";
+import {ATTESTATION_SUBNET_COUNT, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {phase0} from "@chainsafe/lodestar-types";
-import {computeSlotsSinceEpochStart} from "../../util";
+import {computeEpochAtSlot} from "../../util";
 import {EpochContext} from "./epochContext";
 
 /**
@@ -15,8 +15,8 @@ export function computeSubnetForAttestation(epochCtx: EpochContext, attestation:
  * Compute the correct subnet for a slot/committee index
  */
 export function computeSubnetForSlot(epochCtx: EpochContext, slot: number, committeeIndex: number): number {
-  const slotsSinceEpochStart = computeSlotsSinceEpochStart(slot);
-  const committeeCount = epochCtx.getCommitteeCountAtSlot(slot);
-  const committeesSinceEpochStart = committeeCount * slotsSinceEpochStart;
+  const slotsSinceEpochStart = slot % SLOTS_PER_EPOCH;
+  const committeesPerSlot = epochCtx.getCommitteeCountPerSlot(computeEpochAtSlot(slot));
+  const committeesSinceEpochStart = committeesPerSlot * slotsSinceEpochStart;
   return (committeesSinceEpochStart + committeeIndex) % ATTESTATION_SUBNET_COUNT;
 }

--- a/packages/beacon-state-transition/src/allForks/util/epochContext.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochContext.ts
@@ -22,7 +22,7 @@ import {
   SYNC_REWARD_WEIGHT,
   WEIGHT_DENOMINATOR,
 } from "@chainsafe/lodestar-params";
-import {bigIntSqrt, intToBytes} from "@chainsafe/lodestar-utils";
+import {bigIntSqrt, intToBytes, LodestarError} from "@chainsafe/lodestar-utils";
 
 import {
   computeEpochAtSlot,
@@ -281,15 +281,19 @@ export class EpochContext {
    * Return the beacon committee at slot for index.
    */
   getBeaconCommittee(slot: Slot, index: CommitteeIndex): ValidatorIndex[] {
-    const slotCommittees = this._getSlotCommittees(slot);
+    const slotCommittees = this.getShufflingAtSlot(slot).committees[slot % SLOTS_PER_EPOCH];
     if (index >= slotCommittees.length) {
-      throw new Error(`Requesting beacon committee index ${index} over slot committees len ${slotCommittees.length}`);
+      throw new EpochContextError({
+        code: EpochContextErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE,
+        index,
+        maxIndex: slotCommittees.length,
+      });
     }
     return slotCommittees[index];
   }
 
-  getCommitteeCountAtSlot(slot: Slot): number {
-    return this._getSlotCommittees(slot).length;
+  getCommitteeCountPerSlot(epoch: Epoch): number {
+    return this.getShufflingAtEpoch(epoch).committeesPerSlot;
   }
 
   getBeaconProposer(slot: Slot): ValidatorIndex {
@@ -341,16 +345,17 @@ export class EpochContext {
     }
 
     const epochStartSlot = computeStartSlotAtEpoch(epoch);
+    const committeeCountPerSlot = this.getCommitteeCountPerSlot(epoch);
     for (let slot = epochStartSlot; slot < epochStartSlot + SLOTS_PER_EPOCH; slot++) {
-      const slotCommittee = this._getSlotCommittees(slot);
-      const committeeIndex = slotCommittee.findIndex((v) => v.includes(validatorIndex));
-      const committee = slotCommittee[committeeIndex];
-      if (committee) {
-        return {
-          validators: committee as List<number>,
-          committeeIndex,
-          slot,
-        };
+      for (let i = 0; i < committeeCountPerSlot; i++) {
+        const committee = this.getBeaconCommittee(slot, i);
+        if (committee.includes(validatorIndex)) {
+          return {
+            validators: committee as List<number>,
+            committeeIndex: i,
+            slot,
+          };
+        }
       }
     }
     return null;
@@ -366,17 +371,32 @@ export class EpochContext {
     this.index2pubkey[index] = bls.PublicKey.fromBytes(pubkey, CoordType.jacobian); // Optimize for aggregation
   }
 
-  private _getSlotCommittees(slot: Slot): ValidatorIndex[][] {
+  getShufflingAtSlot(slot: Slot): IEpochShuffling {
     const epoch = computeEpochAtSlot(slot);
-    const epochSlot = slot % SLOTS_PER_EPOCH;
+    return this.getShufflingAtEpoch(epoch);
+  }
+
+  getShufflingAtEpoch(epoch: Epoch): IEpochShuffling {
     if (epoch === this.previousShuffling.epoch) {
-      return this.previousShuffling.committees[epochSlot];
+      return this.previousShuffling;
     } else if (epoch === this.currentShuffling.epoch) {
-      return this.currentShuffling.committees[epochSlot];
+      return this.currentShuffling;
     } else if (epoch === this.nextShuffling.epoch) {
-      return this.nextShuffling.committees[epochSlot];
+      return this.nextShuffling;
     } else {
       throw new Error(`Requesting slot committee out of range epoch: ${epoch} current: ${this.currentShuffling.epoch}`);
     }
   }
 }
+
+export enum EpochContextErrorCode {
+  COMMITTEE_INDEX_OUT_OF_RANGE = "EPOCH_CONTEXT_ERROR_COMMITTEE_INDEX_OUT_OF_RANGE",
+}
+
+type EpochContextErrorType = {
+  code: EpochContextErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE;
+  index: number;
+  maxIndex: number;
+};
+
+export class EpochContextError extends LodestarError<EpochContextErrorType> {}

--- a/packages/beacon-state-transition/src/allForks/util/epochShuffling.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochShuffling.ts
@@ -42,18 +42,17 @@ export interface IEpochShuffling {
    * some shards may not have a committee this epoch
    */
   committees: ValidatorIndex[][][];
+
+  /**
+   * Committees per slot, for fast attestation verification
+   */
+  committeesPerSlot: number;
 }
 
 export function computeCommitteeCount(activeValidatorCount: number): number {
   const validatorsPerSlot = intDiv(activeValidatorCount, SLOTS_PER_EPOCH);
-  let committeesPerSlot = intDiv(validatorsPerSlot, TARGET_COMMITTEE_SIZE);
-  if (MAX_COMMITTEES_PER_SLOT < committeesPerSlot) {
-    committeesPerSlot = MAX_COMMITTEES_PER_SLOT;
-  }
-  if (committeesPerSlot === 0) {
-    committeesPerSlot = 1;
-  }
-  return committeesPerSlot;
+  const committeesPerSlot = intDiv(validatorsPerSlot, TARGET_COMMITTEE_SIZE);
+  return Math.max(1, Math.min(MAX_COMMITTEES_PER_SLOT, committeesPerSlot));
 }
 
 export function computeEpochShuffling(
@@ -100,5 +99,6 @@ export function computeEpochShuffling(
     activeIndices,
     shuffling,
     committees,
+    committeesPerSlot,
   };
 }

--- a/packages/beacon-state-transition/src/phase0/block/processAttestation.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processAttestation.ts
@@ -65,7 +65,7 @@ export function validateAttestation(
   const slot = state.slot;
   const data = attestation.data;
   const computedEpoch = computeEpochAtSlot(data.slot);
-  const committeeCount = epochCtx.getCommitteeCountAtSlot(data.slot);
+  const committeeCount = epochCtx.getCommitteeCountPerSlot(data.slot);
   if (!(data.index < committeeCount)) {
     throw new Error(
       "Attestation committee index not within current committee count: " +

--- a/packages/beacon-state-transition/src/phase0/block/processAttestation.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processAttestation.ts
@@ -65,7 +65,7 @@ export function validateAttestation(
   const slot = state.slot;
   const data = attestation.data;
   const computedEpoch = computeEpochAtSlot(data.slot);
-  const committeeCount = epochCtx.getCommitteeCountPerSlot(data.slot);
+  const committeeCount = epochCtx.getCommitteeCountPerSlot(computedEpoch);
   if (!(data.index < committeeCount)) {
     throw new Error(
       "Attestation committee index not within current committee count: " +

--- a/packages/beacon-state-transition/src/util/committee.ts
+++ b/packages/beacon-state-transition/src/util/committee.ts
@@ -35,7 +35,7 @@ export function computeCommittee(
  * Return the number of committees at [[epoch]].
  * Return the number of committees at [[slot]].
  */
-export function getCommitteeCountAtSlot(state: allForks.BeaconState, slot: Slot): number {
+export function getCommitteeCountPerSlot(state: allForks.BeaconState, slot: Slot): number {
   const epoch = computeEpochAtSlot(slot);
   const activeValidatorIndices = getActiveValidatorIndices(state, epoch);
   return Math.max(
@@ -52,7 +52,7 @@ export function getCommitteeCountAtSlot(state: allForks.BeaconState, slot: Slot)
  */
 export function getBeaconCommittee(state: allForks.BeaconState, slot: Slot, index: CommitteeIndex): ValidatorIndex[] {
   const epoch = computeEpochAtSlot(slot);
-  const committeesPerSlot = getCommitteeCountAtSlot(state, slot);
+  const committeesPerSlot = getCommitteeCountPerSlot(state, slot);
   return computeCommittee(
     getActiveValidatorIndices(state, epoch),
     getSeed(state, epoch, DOMAIN_BEACON_ATTESTER),

--- a/packages/beacon-state-transition/src/util/committee.ts
+++ b/packages/beacon-state-transition/src/util/committee.ts
@@ -2,7 +2,7 @@
  * @module chain/stateTransition/util
  */
 
-import {ValidatorIndex, CommitteeIndex, Slot, Bytes32, allForks} from "@chainsafe/lodestar-types";
+import {ValidatorIndex, CommitteeIndex, Slot, Epoch, Bytes32, allForks} from "@chainsafe/lodestar-types";
 import {computeShuffledIndex, getSeed} from "./seed";
 import {getActiveValidatorIndices} from "./validator";
 import {computeEpochAtSlot} from "./epoch";
@@ -35,8 +35,7 @@ export function computeCommittee(
  * Return the number of committees at [[epoch]].
  * Return the number of committees at [[slot]].
  */
-export function getCommitteeCountPerSlot(state: allForks.BeaconState, slot: Slot): number {
-  const epoch = computeEpochAtSlot(slot);
+export function getCommitteeCountPerSlot(state: allForks.BeaconState, epoch: Epoch): number {
   const activeValidatorIndices = getActiveValidatorIndices(state, epoch);
   return Math.max(
     1,
@@ -52,7 +51,7 @@ export function getCommitteeCountPerSlot(state: allForks.BeaconState, slot: Slot
  */
 export function getBeaconCommittee(state: allForks.BeaconState, slot: Slot, index: CommitteeIndex): ValidatorIndex[] {
   const epoch = computeEpochAtSlot(slot);
-  const committeesPerSlot = getCommitteeCountPerSlot(state, slot);
+  const committeesPerSlot = getCommitteeCountPerSlot(state, epoch);
   return computeCommittee(
     getActiveValidatorIndices(state, epoch),
     getSeed(state, epoch, DOMAIN_BEACON_ATTESTER),

--- a/packages/lodestar/src/chain/factory/duties/index.ts
+++ b/packages/lodestar/src/chain/factory/duties/index.ts
@@ -25,7 +25,7 @@ export function assembleAttesterDuty(
       pubkey: validator.pubkey,
       validatorIndex: validator.index,
       committeeLength: committeeAssignment.validators.length,
-      committeesAtSlot: epochCtx.getCommitteeCountAtSlot(committeeAssignment.slot),
+      committeesAtSlot: epochCtx.getCommitteeCountPerSlot(committeeAssignment.slot),
       validatorCommitteeIndex,
       committeeIndex: committeeAssignment.committeeIndex,
       slot: committeeAssignment.slot,

--- a/packages/lodestar/src/chain/factory/duties/index.ts
+++ b/packages/lodestar/src/chain/factory/duties/index.ts
@@ -1,6 +1,6 @@
 import {routes} from "@chainsafe/lodestar-api";
 import {readonlyValues} from "@chainsafe/ssz";
-import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {allForks, computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {BLSPubkey, Epoch, ValidatorIndex, ssz} from "@chainsafe/lodestar-types";
 
@@ -25,7 +25,7 @@ export function assembleAttesterDuty(
       pubkey: validator.pubkey,
       validatorIndex: validator.index,
       committeeLength: committeeAssignment.validators.length,
-      committeesAtSlot: epochCtx.getCommitteeCountPerSlot(committeeAssignment.slot),
+      committeesAtSlot: epochCtx.getCommitteeCountPerSlot(computeEpochAtSlot(committeeAssignment.slot)),
       validatorCommitteeIndex,
       committeeIndex: committeeAssignment.committeeIndex,
       slot: committeeAssignment.slot,

--- a/packages/lodestar/src/chain/validation/attestation.ts
+++ b/packages/lodestar/src/chain/validation/attestation.ts
@@ -163,7 +163,7 @@ export function isCommitteeIndexWithinRange(
   epochCtx: allForks.EpochContext,
   attestationData: phase0.AttestationData
 ): boolean {
-  return attestationData.index < epochCtx.getCommitteeCountPerSlot(attestationData.slot);
+  return attestationData.index < epochCtx.getCommitteeCountPerSlot(computeEpochAtSlot(attestationData.slot));
 }
 
 export function doAggregationBitsMatchCommitteeSize(

--- a/packages/lodestar/src/chain/validation/attestation.ts
+++ b/packages/lodestar/src/chain/validation/attestation.ts
@@ -163,7 +163,7 @@ export function isCommitteeIndexWithinRange(
   epochCtx: allForks.EpochContext,
   attestationData: phase0.AttestationData
 ): boolean {
-  return attestationData.index < epochCtx.getCommitteeCountAtSlot(attestationData.slot);
+  return attestationData.index < epochCtx.getCommitteeCountPerSlot(attestationData.slot);
 }
 
 export function doAggregationBitsMatchCommitteeSize(

--- a/packages/lodestar/test/unit/chain/factory/duties/assembleValidatorDuty.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/duties/assembleValidatorDuty.test.ts
@@ -21,7 +21,7 @@ describe("assemble validator duty", function () {
       slot: 1,
       validators: [1, validatorIndex, 5] as List<number>,
     });
-    state.epochCtx.getCommitteeCountAtSlot = () => 3;
+    state.epochCtx.getCommitteeCountPerSlot = () => 3;
     const result = assembleAttesterDuty(config, {pubkey: publicKey, index: validatorIndex}, state.epochCtx, 2);
     if (result === null) throw Error("Result is null");
     expect(result.pubkey).to.be.equal(publicKey);
@@ -39,7 +39,7 @@ describe("assemble validator duty", function () {
       slot: 1,
       validators: [1, validatorIndex, 5] as List<number>,
     });
-    state.epochCtx.getCommitteeCountAtSlot = () => 3;
+    state.epochCtx.getCommitteeCountPerSlot = () => 3;
     const result = assembleAttesterDuty(config, {pubkey: publicKey, index: validatorIndex}, state.epochCtx, 3);
     if (result === null) throw Error("Result is null");
     expect(result.pubkey).to.be.equal(publicKey);

--- a/packages/lodestar/test/unit/chain/stateCache/stateContextCache.test.ts
+++ b/packages/lodestar/test/unit/chain/stateCache/stateContextCache.test.ts
@@ -1,4 +1,5 @@
 import {expect} from "chai";
+import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
 
 import {StateContextCache} from "../../../../src/chain/stateCache";
 import {generateCachedState} from "../../../utils/state";
@@ -9,24 +10,31 @@ import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 describe("StateContextCache", function () {
   let cache: StateContextCache;
   let key1: ByteVector, key2: ByteVector;
+  const shuffling: allForks.IEpochShuffling = {
+    epoch: 0,
+    activeIndices: [],
+    shuffling: [],
+    committees: [],
+    committeesPerSlot: 1,
+  };
 
   beforeEach(function () {
     // max 2 items
     cache = new StateContextCache(2);
     const state1 = generateCachedState({slot: 0});
     key1 = state1.hashTreeRoot();
-    state1.epochCtx.currentShuffling = {epoch: 0, activeIndices: [], shuffling: [], committees: []};
+    state1.epochCtx.currentShuffling = {...shuffling, epoch: 0};
     cache.add(state1);
     const state2 = generateCachedState({slot: 1 * SLOTS_PER_EPOCH});
     key2 = state2.hashTreeRoot();
-    state2.epochCtx.currentShuffling = {epoch: 1, activeIndices: [], shuffling: [], committees: []};
+    state2.epochCtx.currentShuffling = {...shuffling, epoch: 1};
     cache.add(state2);
   });
 
   it("should prune", function () {
     expect(cache.size).to.be.equal(2, "Size must be same as initial 2");
     const state3 = generateCachedState({slot: 2 * SLOTS_PER_EPOCH});
-    state3.epochCtx.currentShuffling = {epoch: 2, activeIndices: [], shuffling: [], committees: []};
+    state3.epochCtx.currentShuffling = {...shuffling, epoch: 2};
 
     cache.add(state3);
     expect(cache.size).to.be.equal(3, "Size must be 2+1 after .add()");

--- a/packages/lodestar/test/unit/chain/validation/attestation.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/attestation.test.ts
@@ -262,6 +262,7 @@ describe("gossip attestation validation", function () {
       committees: [[[]]],
       activeIndices: [],
       shuffling: [],
+      committeesPerSlot: 1,
     };
     attestationTargetState.epochCtx.getIndexedAttestation = () => toIndexedAttestation(attestation);
     regen.getCheckpointState.resolves(attestationTargetState);
@@ -346,6 +347,7 @@ describe("gossip attestation validation", function () {
       epoch: 0,
       committees: [[[1]]],
       shuffling: [],
+      committeesPerSlot: 1,
     } as allForks.IEpochShuffling;
     attestationTargetState.epochCtx.getIndexedAttestation = () => toIndexedAttestation(attestation);
     regen.getCheckpointState.resolves(attestationTargetState);
@@ -375,6 +377,7 @@ describe("gossip attestation validation", function () {
       epoch: 0,
       committees: [[[1]]],
       shuffling: [],
+      committeesPerSlot: 1,
     } as allForks.IEpochShuffling;
     attestationTargetState.epochCtx.getIndexedAttestation = () => toIndexedAttestation(attestation);
     regen.getCheckpointState.resolves(attestationTargetState);
@@ -397,6 +400,7 @@ describe("gossip attestation validation", function () {
       epoch: 0,
       committees: [[[1]]],
       shuffling: [],
+      committeesPerSlot: 1,
     } as allForks.IEpochShuffling;
     attestationTargetState.epochCtx.getIndexedAttestation = () => toIndexedAttestation(attestation);
     regen.getCheckpointState.resolves(attestationTargetState);


### PR DESCRIPTION
**Motivation**

Optimizing attestation gossip validation I found the function signature `getCommitteeCountAtSlot(slot: Slot)` confusing.

It's a value constant through the epoch (see spec https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#get_committee_count_per_slot) so it makes sense to use `getCommitteeCountPerSlot(epoch: Epoch)`.

**Description**

- Rename `getCommitteeCountAtSlot` to `getCommitteeCountPerSlot`
- Cache `committeeCountPerSlot` in epoch context