### PR TITLE
Run release nightly jobs with concurrency of 1

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -2,8 +2,7 @@ name: Release nightly
 
 # only one per github sha can be run
 concurrency:
-  group: ${{ github.sha }}
-  cancel-in-progress: true
+  group: cd-release-nightly
 
 on:
   push:


### PR DESCRIPTION
**Motivation**

CI broke with

```
Found 13 packages to publish:
 - @chainsafe/lodestar-api => 0.25.2-dev.2+88233ba3dd3
 - @chainsafe/lodestar-beacon-state-transition => 0.25.2-dev.2+88233ba3dd3
 - @chainsafe/lodestar-cli => 0.25.2-dev.2+88233ba3dd3
 - @chainsafe/lodestar-config => 0.25.2-dev.2+88233ba3dd3
 - @chainsafe/lodestar-db => 0.25.2-dev.2+88233ba3dd3
 - @chainsafe/lodestar-fork-choice => 0.25.2-dev.2+88233ba3dd3
 - @chainsafe/lodestar-light-client => 0.25.2-dev.2+88233ba3dd3
 - @chainsafe/lodestar => 0.25.2-dev.2+88233ba3dd3
 - @chainsafe/lodestar-params => 0.25.2-dev.2+88233ba3dd3
 - @chainsafe/lodestar-spec-test-util => 0.25.2-dev.2+88233ba3dd3
 - @chainsafe/lodestar-types => 0.25.2-dev.2+88233ba3dd3
 - @chainsafe/lodestar-utils => 0.25.2-dev.2+88233ba3dd3
 - @chainsafe/lodestar-validator => 0.25.2-dev.2+88233ba3dd3

lerna info auto-confirmed 
lerna info publish Publishing packages to npm...
lerna http fetch PUT 403 https://registry.npmjs.org/@chainsafe%2flodestar-params 292ms
lerna ERR! E403 You cannot publish over the previously published versions: 0.25.2-dev.2.
```



**Description**

Since the releases are numbered sequentially, run in series. Lerna is a bit dumb?