### PR TITLE
Fix dev command

### DIFF
--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -67,7 +67,12 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
       .BeaconState.createTreeBackedFromBytes(await fs.promises.readFile(args.genesisStateFile));
     anchorState = await initStateFromAnchorState(config, db, logger, state);
   } else {
-    anchorState = await nodeUtils.initDevState(config, db, validatorCount, genesisTime);
+    anchorState = await initStateFromAnchorState(
+      config,
+      db,
+      logger,
+      await nodeUtils.initDevState(config, db, validatorCount, genesisTime)
+    );
   }
 
   const validators: Validator[] = [];


### PR DESCRIPTION
**Motivation**

Dev command was not archiving blocks.
It wasn't archiving blocks because block 0 wasn't in the db.

```
Eph 4/0 0.082 [CHORES]          error: Error processing finalized checkpoint epoch=2 message=No block found for root 0x2d23c1364851648c9
398644cd8a382c644cdd6934baa4e3f25fa154be60cf50c                                                                                         
Error: No block found for root 0x2d23c1364851648c9398644cd8a382c644cdd6934baa4e3f25fa154be60cf50c                                       
    at /home/cayman/Code/lodestar/packages/lodestar/src/tasks/tasks/archiveBlocks.ts:75:19                                              
    at async Promise.all (index 15)                                                                                                     
    at ArchiveBlocksTask.processCanonicalBlocks (/home/cayman/Code/lodestar/packages/lodestar/src/tasks/tasks/archiveBlocks.ts:71:7)    
    at ArchiveBlocksTask.run (/home/cayman/Code/lodestar/packages/lodestar/src/tasks/tasks/archiveBlocks.ts:52:7)                       
    at TasksService.processFinalizedCheckpoint (/home/cayman/Code/lodestar/packages/lodestar/src/tasks/index.ts:79:7)                   
    at Object.job (/home/cayman/Code/lodestar/packages/lodestar/src/tasks/index.ts:74:43)                                               
    at Timeout._onTimeout (/home/cayman/Code/lodestar/packages/lodestar/src/util/queue/index.ts:106:22)
```

**Description**

Use the same initialization flow as other places in the dev command.
