### PR TITLE
New IBeaconConfig with the cache apis

### DIFF
--- a/packages/config/src/beaconConfig.ts
+++ b/packages/config/src/beaconConfig.ts
@@ -1,18 +1,31 @@
+import {Root} from "../../types";
 import {createIChainConfig, IChainConfig} from "./chainConfig";
 import {createIForkConfig, IForkConfig} from "./forkConfig";
+import {createICachedGenesis} from "./genesisConfig";
+import {ICachedGenesis} from "./genesisConfig/types";
 
 /**
  * Chain run-time configuration with additional fork schedule helpers
  */
-export type IBeaconConfig = IChainConfig & IForkConfig;
+export type IChainForkConfig = IChainConfig & IForkConfig;
+
+export type IBeaconConfig = IChainForkConfig & ICachedGenesis;
 
 /**
  * Create an `IBeaconConfig`, filling in missing values with preset defaults
  */
-export function createIBeaconConfig(chainConfig: Partial<IChainConfig>): IBeaconConfig {
+export function createIChainForkConfig(chainConfig: Partial<IChainConfig>): IChainForkConfig {
   const fullChainConfig = createIChainConfig(chainConfig);
   return {
     ...fullChainConfig,
     ...createIForkConfig(fullChainConfig),
+  };
+}
+
+export function createIBeaconConfig(chainConfig: Partial<IChainConfig>, genesisValidatorsRoot: Root): IBeaconConfig {
+  const chainForkConfig = createIChainForkConfig(chainConfig);
+  return {
+    ...chainForkConfig,
+    ...createICachedGenesis(chainForkConfig, genesisValidatorsRoot),
   };
 }

--- a/packages/config/src/default.ts
+++ b/packages/config/src/default.ts
@@ -1,5 +1,6 @@
-import {createIBeaconConfig} from "./beaconConfig";
+import {createIChainForkConfig} from "../src";
 import {defaultChainConfig} from "./chainConfig";
 
 export const chainConfig = defaultChainConfig;
-export const config = createIBeaconConfig(defaultChainConfig);
+// for testing purpose only
+export const config = createIChainForkConfig(defaultChainConfig);

--- a/packages/config/src/genesisConfig/index.ts
+++ b/packages/config/src/genesisConfig/index.ts
@@ -1,0 +1,38 @@
+import {ForkName} from "../../../params";
+import {DomainType, phase0, Root, Slot, ssz, Version} from "../../../types";
+import {IChainForkConfig} from "../beaconConfig";
+import {ICachedGenesis} from "./types";
+
+export function createICachedGenesis(chainForkConfig: IChainForkConfig, genesisValidatorsRoot: Root): ICachedGenesis {
+  const domainCache = new Map<ForkName, Map<DomainType, Buffer>>();
+  return {
+    getDomain(domainType: DomainType, slot: Slot): Buffer {
+      const forkName = chainForkConfig.getForkName(slot);
+      let domainByType = domainCache.get(forkName);
+      if (!domainByType) {
+        domainByType = new Map<DomainType, Buffer>();
+        domainCache.set(forkName, domainByType);
+      }
+      let domain = domainByType.get(domainType);
+      if (!domain) {
+        const forkVersion = chainForkConfig.getForkVersion(slot);
+        domain = computeDomain(domainType, forkVersion, genesisValidatorsRoot);
+        domainByType.set(domainType, domain);
+      }
+      return domain;
+    },
+  };
+}
+
+function computeDomain(domainType: DomainType, forkVersion: Version, genesisValidatorRoot: Root): Buffer {
+  const forkDataRoot = computeForkDataRoot(forkVersion, genesisValidatorRoot);
+  return Buffer.concat([domainType as Buffer, forkDataRoot.slice(0, 28)]);
+}
+
+function computeForkDataRoot(currentVersion: Version, genesisValidatorsRoot: Root): Uint8Array {
+  const forkData: phase0.ForkData = {
+    currentVersion,
+    genesisValidatorsRoot,
+  };
+  return ssz.phase0.ForkData.hashTreeRoot(forkData);
+}

--- a/packages/config/src/genesisConfig/types.ts
+++ b/packages/config/src/genesisConfig/types.ts
@@ -1,0 +1,5 @@
+import {DomainType, Slot} from "../../../types";
+
+export interface ICachedGenesis {
+  getDomain(domainType: DomainType, slot: Slot): Buffer;
+}


### PR DESCRIPTION
## Motivation
+ This starts from #2515 
+ Even through CI failed, I need your reviews before I proceed since the modification is a lot

## Description
+ The old `IBeaconConfig` becomes` IChainForkConfig`
+ New interface `ICachedGenesis` supporting a `getDomain()` api which cache domains inside, need a `genesisValidatorRoot` for this
+ The new `IBeaconConfig` is `IChainForkConfig & ICachedGenesis`

With this new `IBeaconConfig`, we can get cached domain from everywhere including lodestar & validator. A lot of flows don't need that (and we don't have `genesisValidatorRoot`) so they'd use `IChainForkConfig` instead

Once I get a green light on this, I'll close this PR and replace with an official PR.

Part of #2505 