### PR TITLE
Run benchmark actions on all push events

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     # Don't run on forks. Forks don't have access to the S3 credentials and the workflow will fail
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
     steps:
       # <common-build> - Uses YAML anchors in the future


### PR DESCRIPTION
**Motivation**

PR https://github.com/ChainSafe/lodestar/pull/2778 unintentionally disabled running the benchmark action on push events

**Description**

- On PR events, run only if this repo
- On push events, run always