### PR TITLE
Fix no block found error when archiving block

### DIFF
--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -552,10 +552,13 @@ export class ForkChoice implements IForkChoice {
   }
 
   /**
-   * Iterates backwards through block summaries, starting from a block root
+   * Iterates backwards through block summaries, starting from a block root.
+   * Return only the non-finalized blocks.
    */
   iterateBlockSummaries(blockRoot: phase0.Root): IBlockSummary[] {
-    return this.protoArray.iterateNodes(toHexString(blockRoot)).map(toBlockSummary);
+    const blocks = this.protoArray.iterateNodes(toHexString(blockRoot)).map(toBlockSummary);
+    // the last node is the previous finalized one, it's there to check onBlock finalized checkpoint only.
+    return blocks.slice(0, blocks.length - 1);
   }
 
   /**

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -1,0 +1,56 @@
+import {ForkChoice, IForkChoiceStore, ProtoArray, toBlockSummary} from "../../../src";
+import {config} from "@chainsafe/lodestar-config/default";
+import {expect} from "chai";
+import {fromHexString} from "@chainsafe/ssz";
+
+describe("Forkchoice", function () {
+  const genesisSlot = 0;
+  const genesisEpoch = 0;
+
+  const stateRoot = "0xb021a96da54dd89dfafc0e8817e23fe708f5746e924855f49b3f978133c3ac6a";
+  const finalizedRoot = "0x86d2ebb56a21be95b9036f4596ff4feaa336acf5fd8739cf39f5d58955b1295b";
+  const parentRoot = "0x853d08094d83f1db67159144db54ec0c882eb9715184c4bde8f4191c926a1671";
+  const finalizedDesc = "0x37487efdbfbeeb82d7d35c6eb96438c4576f645b0f4c0386184592abab4b1736";
+
+  const protoArr = ProtoArray.initialize({
+    slot: genesisSlot,
+    stateRoot,
+    parentRoot,
+    blockRoot: finalizedRoot,
+    justifiedEpoch: genesisEpoch,
+    finalizedEpoch: genesisEpoch,
+  });
+
+  // Add block that is a finalized descendant.
+  const block = {
+    slot: genesisSlot + 1,
+    blockRoot: finalizedDesc,
+    parentRoot: finalizedRoot,
+    stateRoot,
+    targetRoot: finalizedRoot,
+    justifiedEpoch: genesisEpoch,
+    finalizedEpoch: genesisEpoch,
+  };
+
+  const fcStore: IForkChoiceStore = {
+    currentSlot: block.slot,
+    justifiedCheckpoint: {root: fromHexString(finalizedRoot), epoch: genesisEpoch},
+    finalizedCheckpoint: {root: fromHexString(finalizedRoot), epoch: genesisEpoch},
+    bestJustifiedCheckpoint: {root: fromHexString(finalizedRoot), epoch: genesisEpoch},
+  };
+
+  it("iterateBlockSummaries", function () {
+    protoArr.onBlock(block);
+    const forkchoice = new ForkChoice({
+      config,
+      fcStore,
+      protoArray: protoArr,
+      queuedAttestations: new Set(),
+      justifiedBalances: [],
+    });
+    const summaries = forkchoice.iterateBlockSummaries(fromHexString(finalizedDesc));
+    // there are 2 blocks in protoArray but iterateBlockSummaries should only return non-finalized blocks
+    expect(summaries.length).to.be.equals(1, "should not return the finalized block");
+    expect(summaries[0]).to.be.deep.equals(toBlockSummary(block), "the block summary is not correct");
+  });
+});

--- a/packages/lodestar/src/chain/initState.ts
+++ b/packages/lodestar/src/chain/initState.ts
@@ -156,7 +156,7 @@ export async function initStateFromAnchorState(
   logger: ILogger,
   anchorState: TreeBacked<allForks.BeaconState>
 ): Promise<TreeBacked<allForks.BeaconState>> {
-  logger.info("Initializing beacon state", {
+  logger.info("Initializing beacon state from anchor state", {
     slot: anchorState.slot,
     epoch: computeEpochAtSlot(anchorState.slot),
     stateRoot: toHexString(config.getForkTypes(anchorState.slot).BeaconState.hashTreeRoot(anchorState)),

--- a/packages/lodestar/src/tasks/index.ts
+++ b/packages/lodestar/src/tasks/index.ts
@@ -76,6 +76,8 @@ export class TasksService {
 
   private processFinalizedCheckpoint = async (finalized: phase0.Checkpoint): Promise<void> => {
     try {
+      const finalizedEpoch = finalized.epoch;
+      this.logger.verbose("Start processing finalized checkpoint", {epoch: finalizedEpoch});
       await new ArchiveBlocksTask(
         this.config,
         {db: this.db, forkChoice: this.chain.forkChoice, logger: this.logger},
@@ -85,7 +87,6 @@ export class TasksService {
       // should be after ArchiveBlocksTask to handle restart cleanly
       await this.statesArchiver.maybeArchiveState(finalized);
 
-      const finalizedEpoch = finalized.epoch;
       await Promise.all([
         this.chain.checkpointStateCache.pruneFinalized(finalizedEpoch),
         this.chain.stateCache.deleteAllBeforeEpoch(finalizedEpoch),

--- a/packages/lodestar/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/lodestar/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -143,10 +143,12 @@ describe("LodestarForkChoice", function () {
       forkChoice.onBlock(block24.message, state24, justifiedBalances);
       forkChoice.onBlock(block28.message, state28, justifiedBalances);
       expect(forkChoice.iterateBlockSummaries(ssz.phase0.BeaconBlock.hashTreeRoot(block16.message)).length).to.be.equal(
-        4
+        3,
+        "iterateBlockSummaries should return 3 blocks"
       );
       expect(forkChoice.iterateBlockSummaries(ssz.phase0.BeaconBlock.hashTreeRoot(block24.message)).length).to.be.equal(
-        6
+        5,
+        "iterateBlockSummaries should return 5 blocks"
       );
       expect(forkChoice.getBlock(ssz.phase0.BeaconBlock.hashTreeRoot(block08.message))).to.be.not.null;
       expect(forkChoice.getBlock(ssz.phase0.BeaconBlock.hashTreeRoot(block12.message))).to.be.not.null;
@@ -155,10 +157,12 @@ describe("LodestarForkChoice", function () {
       forkChoice.onBlock(block32.message, state32, justifiedBalances);
       forkChoice.prune(ssz.phase0.BeaconBlock.hashTreeRoot(block16.message));
       expect(forkChoice.iterateBlockSummaries(ssz.phase0.BeaconBlock.hashTreeRoot(block16.message)).length).to.be.equal(
-        1
+        0,
+        "iterateBlockSummaries should not return finalized block"
       );
       expect(forkChoice.iterateBlockSummaries(ssz.phase0.BeaconBlock.hashTreeRoot(block24.message)).length).to.be.equal(
-        3
+        2,
+        "iterateBlockSummaries should return 2 blocks"
       );
       expect(forkChoice.getBlock(ssz.phase0.BeaconBlock.hashTreeRoot(block08.message))).to.be.null;
       expect(forkChoice.getBlock(ssz.phase0.BeaconBlock.hashTreeRoot(block12.message))).to.be.null;

--- a/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
+++ b/packages/lodestar/test/unit/tasks/tasks/blockArchiver.test.ts
@@ -23,11 +23,6 @@ describe("block archiver task", function () {
     forkChoiceStub = sinon.createStubInstance(ForkChoice);
   });
 
-  /**
-   * A(1) - B(2) - D(4) - finalized(5) - E
-   *      \
-   *       C(3)
-   */
   it("should archive finalized blocks", async function () {
     const blockBuffer = Buffer.from(ssz.phase0.SignedBeaconBlock.serialize(generateEmptySignedBlock()));
     dbStub.block.getBinary.resolves(blockBuffer);
@@ -54,8 +49,7 @@ describe("block archiver task", function () {
     await archiverTask.run();
     expect(
       dbStub.blockArchive.batchPutBinary.calledWith(
-        // don't want to process the finalized block, keep it in both db and forkchoice until next time
-        canonicalBlocks.slice(1).map((summary) => ({
+        canonicalBlocks.map((summary) => ({
           key: summary.slot,
           value: blockBuffer,
           summary,
@@ -63,8 +57,11 @@ describe("block archiver task", function () {
       )
     ).to.be.true;
     // delete canonical blocks
-    expect(dbStub.block.batchDelete.calledWith([blocks[3], blocks[1], blocks[0]].map((summary) => summary.blockRoot)))
-      .to.be.true;
+    expect(
+      dbStub.block.batchDelete.calledWith(
+        [blocks[4], blocks[3], blocks[1], blocks[0]].map((summary) => summary.blockRoot)
+      )
+    ).to.be.true;
     // delete non canonical blocks
     expect(dbStub.block.batchDelete.calledWith([blocks[2]].map((summary) => summary.blockRoot))).to.be.true;
   });


### PR DESCRIPTION
**Motivation**

+ Right now for a finalized checkpoint event, `archiveBlock` do not process the finalized block until the next run
+ The reason is we want to sync `block` db and `forkchoice`

But that's not a good idea bc when we restart or boot from a ws checkpoint, we put the finalized block header into forkchoice but (sometimes) we don't have the block in `block` db, hence `archiveBlock` failed, and it keeps failing for subsequent runs 

**Description**

+ Make `block` db consistent to `stateArchive` db. When handling a finalized checkpoint, process the finalized block in that same run. The finalized block still stay in forkchoice just for the next `onBlock` check
+ `iterateBlockSummary` should only return the non-finalized blocks

Closes #2740 

**Steps to test or reproduce**

+ Sync prater and restart multiple times
+ Or start from `--weakSubjectivitySyncLatest`