### PR TITLE
Updatable preset

### DIFF
--- a/packages/lodestar/test/unit/api/impl/config/config.test.ts
+++ b/packages/lodestar/test/unit/api/impl/config/config.test.ts
@@ -31,6 +31,7 @@ describe("config api implementation", function () {
       const {data: spec} = await api.getSpec();
       const expected: Record<string, unknown> = {...params, ...chainConfig};
       delete expected.ACTIVE_PRESET;
+      delete expected.setActivePreset;
       expect(spec).to.deep.equal(expected);
     });
   });

--- a/packages/params/src/activePreset.ts
+++ b/packages/params/src/activePreset.ts
@@ -1,27 +1,32 @@
 // load in an "active" preset
 
-import {IBeaconPreset, PresetName} from "./preset";
+import {PresetName} from "./preset";
 
 import {preset as mainnet} from "./presets/mainnet";
 import {preset as minimal} from "./presets/minimal";
 
-let ACTIVE_PRESET: PresetName;
-let preset: IBeaconPreset;
+const presets = {
+  [PresetName.mainnet]: mainnet,
+  [PresetName.minimal]: minimal,
+};
 
-switch (process.env.LODESTAR_PRESET) {
-  case PresetName.minimal:
-    ACTIVE_PRESET = PresetName.minimal;
-    preset = minimal;
-    break;
-  case PresetName.mainnet:
-  default:
-    ACTIVE_PRESET = PresetName.mainnet;
-    preset = mainnet;
-    break;
+function parsePresetName(name: string): PresetName {
+  return PresetName[name as PresetName] ?? PresetName.mainnet;
 }
 
-export {ACTIVE_PRESET};
-export const {
+/**
+ * The preset name currently exported by this library
+ *
+ * The `LODESTAR_PRESET` environment variable is used to select the active preset
+ * If `LODESTAR_PRESET` is not set, the default is `mainnet`.
+ *
+ * The active preset can be manually overridden with `setActivePreset`
+ */
+export let ACTIVE_PRESET: PresetName = parsePresetName(process?.env?.LODESTAR_PRESET as string);
+
+// These variables must be exported individually and explicitly
+// in order to be accessible as top-level exports
+export let {
   MAX_COMMITTEES_PER_SLOT,
   TARGET_COMMITTEE_SIZE,
   MAX_VALIDATORS_PER_COMMITTEE,
@@ -60,4 +65,57 @@ export const {
   INACTIVITY_PENALTY_QUOTIENT_ALTAIR,
   MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR,
   PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR,
-} = preset;
+} = presets[ACTIVE_PRESET];
+
+/**
+ * Override the active preset
+ *
+ * WARNING: Lodestar libraries rely on preset values being _constant_, so the active preset must be set _before_ loading any other lodestar libraries.
+ *
+ * Only call this function if you _really_ know what you are doing.
+ */
+export function setActivePreset(presetName: PresetName): void {
+  ACTIVE_PRESET = parsePresetName(presetName);
+  const preset = presets[ACTIVE_PRESET];
+
+  // Unfortunately, there is way to dynamically update all of these variables
+  // so they must be updated individually and explicitly
+  MAX_COMMITTEES_PER_SLOT = preset.MAX_COMMITTEES_PER_SLOT;
+  TARGET_COMMITTEE_SIZE = preset.TARGET_COMMITTEE_SIZE;
+  MAX_VALIDATORS_PER_COMMITTEE = preset.MAX_VALIDATORS_PER_COMMITTEE;
+  SHUFFLE_ROUND_COUNT = preset.SHUFFLE_ROUND_COUNT;
+  HYSTERESIS_QUOTIENT = preset.HYSTERESIS_QUOTIENT;
+  HYSTERESIS_DOWNWARD_MULTIPLIER = preset.HYSTERESIS_DOWNWARD_MULTIPLIER;
+  HYSTERESIS_UPWARD_MULTIPLIER = preset.HYSTERESIS_UPWARD_MULTIPLIER;
+  SAFE_SLOTS_TO_UPDATE_JUSTIFIED = preset.SAFE_SLOTS_TO_UPDATE_JUSTIFIED;
+  MIN_DEPOSIT_AMOUNT = preset.MIN_DEPOSIT_AMOUNT;
+  MAX_EFFECTIVE_BALANCE = preset.MAX_EFFECTIVE_BALANCE;
+  EFFECTIVE_BALANCE_INCREMENT = preset.EFFECTIVE_BALANCE_INCREMENT;
+  MIN_ATTESTATION_INCLUSION_DELAY = preset.MIN_ATTESTATION_INCLUSION_DELAY;
+  SLOTS_PER_EPOCH = preset.SLOTS_PER_EPOCH;
+  MIN_SEED_LOOKAHEAD = preset.MIN_SEED_LOOKAHEAD;
+  MAX_SEED_LOOKAHEAD = preset.MAX_SEED_LOOKAHEAD;
+  EPOCHS_PER_ETH1_VOTING_PERIOD = preset.EPOCHS_PER_ETH1_VOTING_PERIOD;
+  SLOTS_PER_HISTORICAL_ROOT = preset.SLOTS_PER_HISTORICAL_ROOT;
+  MIN_EPOCHS_TO_INACTIVITY_PENALTY = preset.MIN_EPOCHS_TO_INACTIVITY_PENALTY;
+  EPOCHS_PER_HISTORICAL_VECTOR = preset.EPOCHS_PER_HISTORICAL_VECTOR;
+  EPOCHS_PER_SLASHINGS_VECTOR = preset.EPOCHS_PER_SLASHINGS_VECTOR;
+  HISTORICAL_ROOTS_LIMIT = preset.HISTORICAL_ROOTS_LIMIT;
+  VALIDATOR_REGISTRY_LIMIT = preset.VALIDATOR_REGISTRY_LIMIT;
+  BASE_REWARD_FACTOR = preset.BASE_REWARD_FACTOR;
+  WHISTLEBLOWER_REWARD_QUOTIENT = preset.WHISTLEBLOWER_REWARD_QUOTIENT;
+  PROPOSER_REWARD_QUOTIENT = preset.PROPOSER_REWARD_QUOTIENT;
+  INACTIVITY_PENALTY_QUOTIENT = preset.INACTIVITY_PENALTY_QUOTIENT;
+  MIN_SLASHING_PENALTY_QUOTIENT = preset.MIN_SLASHING_PENALTY_QUOTIENT;
+  PROPORTIONAL_SLASHING_MULTIPLIER = preset.PROPORTIONAL_SLASHING_MULTIPLIER;
+  MAX_PROPOSER_SLASHINGS = preset.MAX_PROPOSER_SLASHINGS;
+  MAX_ATTESTER_SLASHINGS = preset.MAX_ATTESTER_SLASHINGS;
+  MAX_ATTESTATIONS = preset.MAX_ATTESTATIONS;
+  MAX_DEPOSITS = preset.MAX_DEPOSITS;
+  MAX_VOLUNTARY_EXITS = preset.MAX_VOLUNTARY_EXITS;
+  SYNC_COMMITTEE_SIZE = preset.SYNC_COMMITTEE_SIZE;
+  EPOCHS_PER_SYNC_COMMITTEE_PERIOD = preset.EPOCHS_PER_SYNC_COMMITTEE_PERIOD;
+  INACTIVITY_PENALTY_QUOTIENT_ALTAIR = preset.INACTIVITY_PENALTY_QUOTIENT_ALTAIR;
+  MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR = preset.MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR;
+  PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR = preset.PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR;
+}

--- a/packages/params/src/activePreset.ts
+++ b/packages/params/src/activePreset.ts
@@ -78,7 +78,7 @@ export function setActivePreset(presetName: PresetName): void {
   ACTIVE_PRESET = parsePresetName(presetName);
   const preset = presets[ACTIVE_PRESET];
 
-  // Unfortunately, there is way to dynamically update all of these variables
+  // Unfortunately, there is no way to dynamically update all of these variables
   // so they must be updated individually and explicitly
   MAX_COMMITTEES_PER_SLOT = preset.MAX_COMMITTEES_PER_SLOT;
   TARGET_COMMITTEE_SIZE = preset.TARGET_COMMITTEE_SIZE;

--- a/packages/params/test/unit/activePreset.test.ts
+++ b/packages/params/test/unit/activePreset.test.ts
@@ -1,0 +1,29 @@
+import {preset as mainnetParams} from "../../src/presets/mainnet";
+import {preset as minimalParams} from "../../src/presets/minimal";
+import {ACTIVE_PRESET, PresetName, setActivePreset} from "../../src";
+import {expect} from "chai";
+
+describe("active preset", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const exports = require("../../src") as Record<string, unknown>;
+  const params = {
+    [PresetName.mainnet]: mainnetParams,
+    [PresetName.minimal]: minimalParams,
+  };
+
+  after(() => {
+    // reset preset to initial value
+    setActivePreset(ACTIVE_PRESET);
+  });
+
+  it("setActivePreset should change exported params", () => {
+    for (const presetName of [PresetName.mainnet, PresetName.minimal]) {
+      setActivePreset(presetName);
+
+      expect(exports.ACTIVE_PRESET).to.equal(presetName);
+      for (const [k, v] of Object.entries(params[presetName])) {
+        expect(exports[k]).to.deep.equal(v);
+      }
+    }
+  });
+});


### PR DESCRIPTION
**Motivation**

In some cases, consumers of our libraries may not be able to set environment variables, and so not be able to select alternative presets (eg: minimal, for testing purposes).
For example, `create-react-app` doesn't allow for injecting arbitrary environment variables, only environment variables that are prefixed with `REACT_APP_`.

**Description**

Refactor the active preset selection and add a `setActivePreset` function that can switch the active preset.

Note: manually setting the active preset is potentially dangerous, as downstream lodestar libraries expect preset values to be _constant_.
Some care was given to document the situation in the `setActivePreset` docstring.
