### PR TITLE
Update slashing-protection-interchange-tests to 5.1.0

### DIFF
--- a/packages/validator/test/e2e/slashing-protection-interchange-tests/params.ts
+++ b/packages/validator/test/e2e/slashing-protection-interchange-tests/params.ts
@@ -1,9 +1,9 @@
 import path from "path";
 
-// Full link: https://github.com/eth2-clients/slashing-protection-interchange-tests/releases/download/v5.0.0/eip-3076-tests-v5.0.0.tar.gz
-export const TESTS_TO_DOWNLOAD = ["eip-3076-tests-v5.0.0"];
+// Full link: https://github.com/eth2-clients/slashing-protection-interchange-tests/releases/download/v5.1.0/eip-3076-tests-v5.1.0.tar.gz
+export const SPEC_TEST_VERSION = "v5.1.0";
+export const TESTS_TO_DOWNLOAD = [`eip-3076-tests-${SPEC_TEST_VERSION}`];
 export const SPEC_TEST_REPO_URL = "https://github.com/eth2-clients/slashing-protection-interchange-tests";
-export const SPEC_TEST_VERSION = "v5.0.0";
 export const SPEC_TEST_LOCATION = path.join(__dirname, "../../slashing-protection-interchange-spec-tests");
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -13,6 +13,7 @@ export interface ISlashingProtectionInterchangeTest {
   steps: [
     {
       should_succeed: boolean;
+      contains_slashable_data: boolean;
       interchange: any;
       blocks: {
         pubkey: string;


### PR DESCRIPTION
resolves #2765 

From the README: 
https://github.com/eth2-clients/slashing-protection-interchange-tests/blob/65f6c5347079d95947af5d0063b8d0b3219cd524/README.md#handling-slashable-data

In the case of `If contains_slashable_data is true`, I chose the strategy `Reject the interchange (or partially import it), in which case the block/attestation checks and all future steps should be ignored.`.  Open to suggestions if someone thinks we should try one of the other strategies.