### PR TITLE
metrics and rest api cli options fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "9000:9000" # P2P port
       - "9596:9596" # REST API port
-    command: beacon --rootDir /data --api.rest.host 0.0.0.0 --metrics.enabled --logFile /logs/beacon.log --logLevelFile debug --logRotate --logMaxFiles 5
+    command: beacon --rootDir /data --api.rest.enabled --api.rest.host 0.0.0.0 --metrics.enabled --logFile /logs/beacon.log --logLevelFile debug --logRotate --logMaxFiles 5
 
   prometheus:
     build: docker/prometheus

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -61,12 +61,10 @@ export function getNetworkBeaconNodeOptions(network: NetworkName): RecursivePart
   const {depositContractDeployBlock, bootEnrs, beaconParams} = getNetworkData(network);
   const networkId = parseInt((beaconParams.DEPOSIT_NETWORK_ID || 1) as string, 10);
   return {
-    api: {rest: {enabled: true}},
     eth1: {
       providerUrl: getEth1ProviderUrl(networkId),
       depositContractDeployBlock,
     },
-    metrics: {enabled: true},
     network: {
       discv5: {
         enabled: true,


### PR DESCRIPTION
**Motivation**
This PR removes default rest and metric options from  `getNetworkBeaconNodeOptions` so that metric and api server don't start without explicit cli options as per their expected default behavior.
<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #2775

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
