### PR TITLE
Fix SyncCommitteeContribution and SyncCommitteeMessage

### DIFF
--- a/packages/lodestar/src/db/syncCommitteeContribution.ts
+++ b/packages/lodestar/src/db/syncCommitteeContribution.ts
@@ -143,11 +143,9 @@ function aggregateContributionInto(
     if (participated) {
       const syncCommitteeIndex = indexOffset + index;
       if (aggregate.syncCommitteeBits[syncCommitteeIndex] === true) {
-        throw new SyncContributionError({
-          code: SyncContributionErrorCode.ALREADY_KNOWN,
-          syncCommitteeIndex,
-          slot: contribution.slot,
-        });
+        // there are multiple SyncCommitteeContribution messaages of the same sub committee
+        // this means we aggregated a contribution of same sub committee already
+        return;
       }
 
       aggregate.syncCommitteeBits[syncCommitteeIndex] = true;


### PR DESCRIPTION
**Motivation**
This is all about gossip for altair, detected with yeerongpilly

1. This error happens all the time
```
(node:3783) UnhandledPromiseRejectionWarning: Error: SYNC_COMMITTEE_CONTRIBUTION_ERROR_ALREADY_KNOWN
    at aggregateContributionInto (/root/workspace/node/lodestar/packages/lodestar/src/db/syncCommitteeContribution.ts:146:15)
```
it's not really an error, a sub committee has multiple aggregators, hence multiple contributions.

2. We miss adding altair validator functions to topic string, hence SyncCommittee messages never go through our validator function and we miss its indexed data

```
(node:1) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 34732)
(node:1) UnhandledPromiseRejectionWarning: Error: Already aggregated SyncCommitteeMessage - subCommitteeIndex=3 indexInSubCommittee=undefined
    at aggregateSignatureInto (/usr/app/packages/lodestar/src/db/syncCommittee.ts:144:11)
    at SyncCommitteeCache.add (/usr/app/packages/lodestar/src/db/syncCommittee.ts:79:7)
    at GossipHandler.onSyncCommitteeSignature (/usr/app/packages/lodestar/src/network/gossip/handler.ts:131:27)

```

**Description**

1. Instead of throwing error, just ignore the latter contribution.
2. Add missing altair validator functions to topic string map

Closes #2797

**Steps to test or reproduce**

Sync `yeerongpilly`