### PR TITLE
Use .valueOf() when adding roots to errors

### DIFF
--- a/packages/lodestar/src/chain/validation/attestation.ts
+++ b/packages/lodestar/src/chain/validation/attestation.ts
@@ -208,7 +208,7 @@ function verifyHeadBlockIsKnown(chain: IBeaconChain, beaconBlockRoot: Root): IBl
   if (headBlock === null) {
     throw new AttestationError({
       code: AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT,
-      root: beaconBlockRoot as Uint8Array,
+      root: beaconBlockRoot.valueOf() as Uint8Array,
     });
   }
 
@@ -236,7 +236,7 @@ function verifyAttestationTargetRoot(headBlock: IBlockSummary, targetRoot: Root,
     // https://github.com/ethereum/eth2.0-specs/pull/2001#issuecomment-699246659
     throw new AttestationError({
       code: AttestationErrorCode.INVALID_TARGET_ROOT,
-      targetRoot: targetRoot as Uint8Array,
+      targetRoot: targetRoot.valueOf() as Uint8Array,
       expected: null,
     });
   } else {
@@ -255,7 +255,7 @@ function verifyAttestationTargetRoot(headBlock: IBlockSummary, targetRoot: Root,
       // Reject any attestation with an invalid target root.
       throw new AttestationError({
         code: AttestationErrorCode.INVALID_TARGET_ROOT,
-        targetRoot: targetRoot as Uint8Array,
+        targetRoot: targetRoot.valueOf() as Uint8Array,
         expected: expectedTargetRoot,
       });
     }


### PR DESCRIPTION


**Motivation**

Otherwise the error is rendered as
```
root={"0":97,"1":5,"2":207,"3":47,"4":88,"5":154,"6":23,"7":15,"8":164,"9":40,"10":155,"11":1,"12":84,"13":84,"14":53,"15":191,"16":214,"17":27,"18":93,"19":177,"20":247,"21":250,"22":38,"23":182,"24":184,"25":21,"26":41,"27":138,"28":42,"29":253,"30":50,"31":146,"length":32}
```

**Description**

Use .valueOf() when adding roots to errors