### PR TITLE
Add generic batch BLS verification

### DIFF
--- a/docker/grafana/provisioning/dashboards/lodestar.json
+++ b/docker/grafana/provisioning/dashboards/lodestar.json
@@ -3456,7 +3456,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "delta(lodestar_bls_thread_pool_batch_retries[$__rate_interval])",
+              "expr": "rate(lodestar_bls_thread_pool_batch_retries[$__rate_interval])",
               "interval": "",
               "legendFormat": "pool",
               "refId": "A"

--- a/docker/grafana/provisioning/dashboards/lodestar.json
+++ b/docker/grafana/provisioning/dashboards/lodestar.json
@@ -2867,11 +2867,50 @@
       "id": 92,
       "panels": [
         {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {},
+              "custom": {},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 24,
+            "x": 0,
+            "y": 21
+          },
+          "id": 154,
+          "options": {
+            "content": "Verifies signature sets in a thread pool of workers. Must ensure that signatures are verified fast and efficiently.",
+            "mode": "markdown"
+          },
+          "pluginVersion": "7.4.5",
+          "targets": [
+            {
+              "expr": "rate(lodestar_bls_thread_pool_time_seconds_sum[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "{{workerId}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "About",
+          "type": "text"
+        },
+        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
           "dashes": false,
           "datasource": null,
+          "description": "Utilization rate = total CPU time per worker per second. Graph is stacked. This ratios should be high since BLS verification is the limiting factor in the node's throughput.",
           "fieldConfig": {
             "defaults": {
               "color": {},
@@ -2890,7 +2929,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 21
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 94,
@@ -2920,7 +2959,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(lodestar_bls_thread_pool_success_time_seconds_sum[$__rate_interval])",
+              "expr": "rate(lodestar_bls_thread_pool_time_seconds_sum[$__rate_interval])",
               "interval": "",
               "legendFormat": "{{workerId}}",
               "refId": "A"
@@ -2930,7 +2969,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "BLS thread pool utilization rate",
+          "title": "BLS thread pool - utilization rate",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2969,6 +3008,7 @@
         },
         {
           "datasource": null,
+          "description": "Raw throughput of the thread pool. How many individual signature sets are successfully validated per second",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2979,7 +3019,7 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 10,
+                "fillOpacity": 23,
                 "gradientMode": "opacity",
                 "hideFrom": {
                   "graph": false,
@@ -3009,7 +3049,7 @@
                   }
                 ]
               },
-              "unit": "s"
+              "unit": "none"
             },
             "overrides": []
           },
@@ -3017,9 +3057,9 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 21
+            "y": 24
           },
-          "id": 95,
+          "id": 96,
           "options": {
             "graph": {},
             "legend": {
@@ -3027,14 +3067,14 @@
               "displayMode": "hidden",
               "placement": "bottom"
             },
-            "tooltip": {
+            "tooltipOptions": {
               "mode": "multi"
             }
           },
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "delta(lodestar_bls_thread_pool_queue_job_wait_time_seconds_sum[$__rate_interval])/delta(lodestar_bls_thread_pool_queue_job_wait_time_seconds_count[$__rate_interval])",
+              "expr": "rate(lodestar_bls_thread_pool_success_jobs_signature_sets_count[$__rate_interval])",
               "interval": "",
               "legendFormat": "pool",
               "refId": "A"
@@ -3042,11 +3082,12 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "BLS thread pool job wait time",
+          "title": "BLS thread pool - sig sets / sec",
           "type": "timeseries"
         },
         {
           "datasource": null,
+          "description": "Average sync time to validate a single signature set. Note that the set may have been verified in batch. In most normal hardware this value should be ~1-2ms",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3095,9 +3136,529 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 29
+            "y": 32
           },
-          "id": 96,
+          "id": 151,
+          "options": {
+            "graph": {},
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltipOptions": {
+              "mode": "multi"
+            }
+          },
+          "pluginVersion": "7.4.5",
+          "targets": [
+            {
+              "expr": "sum(delta(lodestar_bls_thread_pool_time_seconds_sum[$__rate_interval]))/sum(delta(lodestar_bls_thread_pool_success_jobs_signature_sets_count[$__rate_interval]))",
+              "interval": "",
+              "legendFormat": "pool",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "BLS thread pool - sig set verification time / set",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "description": "How much async time job spent waiting in the job queue before being picked up. This number should be really low <100ms to ensure signatures are validated fast.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 32
+          },
+          "id": 95,
+          "options": {
+            "graph": {},
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltipOptions": {
+              "mode": "multi"
+            }
+          },
+          "pluginVersion": "7.4.5",
+          "targets": [
+            {
+              "expr": "delta(lodestar_bls_thread_pool_queue_job_wait_time_seconds_sum[$__rate_interval])/delta(lodestar_bls_thread_pool_queue_job_wait_time_seconds_count[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "pool",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "BLS thread pool - job wait time",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "description": "Total length of the job queue. Note: this queue is not bounded",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 40
+          },
+          "id": 150,
+          "options": {
+            "graph": {},
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltipOptions": {
+              "mode": "multi"
+            }
+          },
+          "pluginVersion": "7.4.5",
+          "targets": [
+            {
+              "expr": "lodestar_bls_thread_pool_queue_length",
+              "interval": "",
+              "legendFormat": "pool",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "BLS thread pool - queue length",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "description": "What percentage of total signature sets were verified in batch, which is an optimization to reduce verification costs by x2. For a synced node this should be ~100%",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 40
+          },
+          "id": 147,
+          "options": {
+            "graph": {},
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltipOptions": {
+              "mode": "multi"
+            }
+          },
+          "pluginVersion": "7.4.5",
+          "targets": [
+            {
+              "expr": "delta(lodestar_bls_thread_pool_batch_sigs_success_total[$__rate_interval])/delta(lodestar_bls_thread_pool_success_jobs_signature_sets_count[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "pool",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "BLS thread pool - % of sigs verified in batch",
+          "type": "timeseries"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "How many signature set batches fail per second. On failure all signatures in the batch have to be verified twice, so this number should be very low to make the optimization worth it.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {},
+              "custom": {},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 48
+          },
+          "hiddenSeries": false,
+          "id": 152,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "delta(lodestar_bls_thread_pool_batch_retries[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "pool",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "BLS thread pool - batch retries / sec",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "How many individual signature sets are invalid vs (valid + invalid). We don't control this number since peers may send us invalid signatures. This number should be very low since we should ban bad peers. If it's too high the batch optimization may not be worth it.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {},
+              "custom": {},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 48
+          },
+          "hiddenSeries": false,
+          "id": 153,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "delta(lodestar_bls_thread_pool_error_jobs_signature_sets_count[$__rate_interval])/(delta(lodestar_bls_thread_pool_success_jobs_signature_sets_count[$__rate_interval])+delta(lodestar_bls_thread_pool_error_jobs_signature_sets_count[$__rate_interval]))",
+              "interval": "",
+              "legendFormat": "pool",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "BLS thread pool - sig error rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "datasource": null,
+          "description": "Async time from sending a message to the worker and the worker receiving it.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 23,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 0,
+            "y": 56
+          },
+          "id": 148,
           "options": {
             "graph": {},
             "legend": {
@@ -3112,7 +3673,7 @@
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "sum(delta(lodestar_bls_thread_pool_success_time_seconds_sum[$__rate_interval]))/sum(delta(lodestar_bls_thread_pool_success_jobs_signature_sets_count[$__rate_interval]))",
+              "expr": "delta(lodestar_bls_thread_pool_latency_to_worker_sum[$__rate_interval])/delta(lodestar_bls_thread_pool_latency_to_worker_count[$__rate_interval])",
               "interval": "",
               "legendFormat": "pool",
               "refId": "A"
@@ -3120,11 +3681,12 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "BLS thread pool signature set verification time / set",
+          "title": "BLS worker pool - to worker latency",
           "type": "timeseries"
         },
         {
           "datasource": null,
+          "description": "Average sets per job. A set may contain +1 signatures. This number should be higher than 1 to reduce communication costs",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3170,10 +3732,10 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 4,
+            "h": 6,
             "w": 12,
             "x": 12,
-            "y": 29
+            "y": 56
           },
           "id": 97,
           "options": {
@@ -3198,11 +3760,91 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "BLS thread pool average job group size",
+          "title": "BLS worker pool - sets per job",
           "type": "timeseries"
         },
         {
           "datasource": null,
+          "description": "Async time sending a message from a worker to the main thread and it receiving it.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 23,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 0,
+            "y": 62
+          },
+          "id": 149,
+          "options": {
+            "graph": {},
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "pluginVersion": "7.4.5",
+          "targets": [
+            {
+              "expr": "delta(lodestar_bls_thread_pool_latency_from_worker_sum[$__rate_interval])/delta(lodestar_bls_thread_pool_latency_from_worker_count[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "pool",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "BLS worker pool - from worker latency",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "description": "Average signatures per set. This number is decided by the time of object submitted to the pool:\n- Sync blocks: 128\n- Aggregates: 3\n- Attestations: 1",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3248,10 +3890,10 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 4,
+            "h": 6,
             "w": 12,
             "x": 12,
-            "y": 33
+            "y": 62
           },
           "id": 98,
           "maxDataPoints": null,
@@ -3269,7 +3911,7 @@
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "delta(lodestar_bls_thread_pool_success_jobs_signature_sets_count[$__rate_interval])/(delta(lodestar_bls_thread_pool_jobs_started_total[$__rate_interval])>0)",
+              "expr": "delta(lodestar_bls_thread_pool_sig_sets_started_total[$__rate_interval])/(delta(lodestar_bls_thread_pool_jobs_started_total[$__rate_interval])>0)",
               "interval": "",
               "legendFormat": "pool",
               "refId": "A"
@@ -3277,7 +3919,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "BLS thread pool average signature sets per job",
+          "title": "BLS worker pool - sigs per set",
           "type": "timeseries"
         }
       ],
@@ -4318,6 +4960,7 @@
                 "fillOpacity": 0,
                 "gradientMode": "none",
                 "hideFrom": {
+                  "graph": false,
                   "legend": false,
                   "tooltip": false,
                   "viz": false
@@ -4330,13 +4973,8 @@
                 },
                 "showPoints": "auto",
                 "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
+                "stacking": {},
+                "thresholdsStyle": {}
               },
               "mappings": [],
               "thresholds": {
@@ -4360,7 +4998,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 33
+            "y": 24
           },
           "id": 130,
           "options": {
@@ -4370,6 +5008,9 @@
               "placement": "bottom"
             },
             "tooltip": {
+              "mode": "single"
+            },
+            "tooltipOptions": {
               "mode": "single"
             }
           },
@@ -4400,6 +5041,7 @@
                 "fillOpacity": 24,
                 "gradientMode": "hue",
                 "hideFrom": {
+                  "graph": false,
                   "legend": false,
                   "tooltip": false,
                   "viz": false
@@ -4415,13 +5057,8 @@
                 },
                 "showPoints": "never",
                 "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "normal"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
+                "stacking": {},
+                "thresholdsStyle": {}
               },
               "mappings": [],
               "thresholds": {
@@ -4456,7 +5093,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 33
+            "y": 24
           },
           "id": 138,
           "options": {
@@ -4466,6 +5103,9 @@
               "placement": "bottom"
             },
             "tooltip": {
+              "mode": "single"
+            },
+            "tooltipOptions": {
               "mode": "single"
             }
           },
@@ -4506,6 +5146,7 @@
                 "fillOpacity": 0,
                 "gradientMode": "none",
                 "hideFrom": {
+                  "graph": false,
                   "legend": false,
                   "tooltip": false,
                   "viz": false
@@ -4518,13 +5159,8 @@
                 },
                 "showPoints": "auto",
                 "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
+                "stacking": {},
+                "thresholdsStyle": {}
               },
               "mappings": [],
               "thresholds": {
@@ -4547,7 +5183,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 32
           },
           "id": 132,
           "options": {
@@ -4557,6 +5193,9 @@
               "placement": "bottom"
             },
             "tooltip": {
+              "mode": "single"
+            },
+            "tooltipOptions": {
               "mode": "single"
             }
           },
@@ -4587,6 +5226,7 @@
                 "fillOpacity": 0,
                 "gradientMode": "none",
                 "hideFrom": {
+                  "graph": false,
                   "legend": false,
                   "tooltip": false,
                   "viz": false
@@ -4599,13 +5239,8 @@
                 },
                 "showPoints": "auto",
                 "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
+                "stacking": {},
+                "thresholdsStyle": {}
               },
               "mappings": [],
               "thresholds": {
@@ -4628,7 +5263,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 32
           },
           "id": 140,
           "options": {
@@ -4638,6 +5273,9 @@
               "placement": "bottom"
             },
             "tooltip": {
+              "mode": "single"
+            },
+            "tooltipOptions": {
               "mode": "single"
             }
           },
@@ -4669,6 +5307,7 @@
                 "fillOpacity": 0,
                 "gradientMode": "none",
                 "hideFrom": {
+                  "graph": false,
                   "legend": false,
                   "tooltip": false,
                   "viz": false
@@ -4681,13 +5320,8 @@
                 },
                 "showPoints": "auto",
                 "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
+                "stacking": {},
+                "thresholdsStyle": {}
               },
               "mappings": [],
               "thresholds": {
@@ -4707,7 +5341,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 49
+            "y": 40
           },
           "id": 146,
           "options": {
@@ -4717,6 +5351,9 @@
               "placement": "bottom"
             },
             "tooltip": {
+              "mode": "single"
+            },
+            "tooltipOptions": {
               "mode": "single"
             }
           },
@@ -4740,6 +5377,7 @@
               "color": {
                 "mode": "thresholds"
               },
+              "custom": {},
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
@@ -4761,7 +5399,7 @@
             "h": 8,
             "w": 3,
             "x": 12,
-            "y": 49
+            "y": 40
           },
           "id": 144,
           "options": {
@@ -4777,7 +5415,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.0.0",
+          "pluginVersion": "7.4.5",
           "targets": [
             {
               "exemplar": true,
@@ -4833,7 +5471,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 24
+            "y": 25
           },
           "hiddenSeries": false,
           "id": 77,
@@ -4934,7 +5572,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 24
+            "y": 25
           },
           "hiddenSeries": false,
           "id": 80,
@@ -5035,7 +5673,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 32
+            "y": 33
           },
           "hiddenSeries": false,
           "id": 79,
@@ -5163,7 +5801,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 32
+            "y": 33
           },
           "id": 78,
           "options": {
@@ -5215,7 +5853,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 40
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 82,
@@ -5317,7 +5955,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 40
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 88,
@@ -5437,7 +6075,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 25
+            "y": 50
           },
           "hiddenSeries": false,
           "id": 84,
@@ -5533,7 +6171,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 25
+            "y": 50
           },
           "hiddenSeries": false,
           "id": 87,
@@ -6190,7 +6828,7 @@
             "h": 7,
             "w": 10,
             "x": 0,
-            "y": 27
+            "y": 52
           },
           "id": 68,
           "options": {
@@ -6244,7 +6882,7 @@
             "h": 7,
             "w": 14,
             "x": 10,
-            "y": 27
+            "y": 52
           },
           "id": 70,
           "options": {
@@ -7110,5 +7748,5 @@
   "timezone": "",
   "title": "Lodestar",
   "uid": "lodestar",
-  "version": 29
+  "version": 11
 }

--- a/packages/lodestar/src/chain/bls/interface.ts
+++ b/packages/lodestar/src/chain/bls/interface.ts
@@ -1,5 +1,9 @@
 import {ISignatureSet} from "@chainsafe/lodestar-beacon-state-transition/src";
 
+export type VerifySignatureOpts = {
+  batchable?: boolean;
+};
+
 export interface IBlsVerifier {
   /**
    * Verify 1 or more signature sets. Sets may be verified on batch or not depending on their count
@@ -21,8 +25,6 @@ export interface IBlsVerifier {
    * Public keys have already been checked for subgroup and infinity
    * Signatures have already been checked for subgroup
    * Signature checks above could be done here for convienence as well
-   *
-   * @param validateSignature defaults to true
    */
-  verifySignatureSets(sets: ISignatureSet[], validateSignature?: boolean): Promise<boolean>;
+  verifySignatureSets(sets: ISignatureSet[], opts?: VerifySignatureOpts): Promise<boolean>;
 }

--- a/packages/lodestar/src/chain/bls/interface.ts
+++ b/packages/lodestar/src/chain/bls/interface.ts
@@ -1,6 +1,13 @@
 import {ISignatureSet} from "@chainsafe/lodestar-beacon-state-transition/src";
 
 export type VerifySignatureOpts = {
+  /**
+   * A batchable set MAY be verified with more sets to reduce the verification costs.
+   * Multiple sets may be merged and verified as one set. If the result is correct, success is returned
+   * for all them. If at least one set is invalid, all sets are reverified individually. For normal network
+   * conditions this strategy can yield 50% improvement in CPU time spent verifying gossip objects.
+   * Only non-time critical objects should be marked as batchable, since the pool may hold them for 100ms.
+   */
   batchable?: boolean;
 };
 

--- a/packages/lodestar/src/chain/bls/maybeBatch.ts
+++ b/packages/lodestar/src/chain/bls/maybeBatch.ts
@@ -2,7 +2,7 @@ import {bls, CoordType, PublicKey} from "@chainsafe/bls";
 
 const MIN_SET_COUNT_TO_BATCH = 2;
 
-type SignatureSetDeserialized = {
+export type SignatureSetDeserialized = {
   publicKey: PublicKey;
   message: Uint8Array;
   signature: Uint8Array;
@@ -12,13 +12,14 @@ type SignatureSetDeserialized = {
  * Verify signatures sets with batch verification or regular core verify depending on the set count.
  * Abstracted in a separate file to be consumed by the threaded pool and the main thread implementation.
  */
-export function verifySignatureSetsMaybeBatch(sets: SignatureSetDeserialized[], validateSignature = true): boolean {
+export function verifySignatureSetsMaybeBatch(sets: SignatureSetDeserialized[]): boolean {
   if (sets.length >= MIN_SET_COUNT_TO_BATCH) {
     return bls.Signature.verifyMultipleSignatures(
       sets.map((s) => ({
         publicKey: s.publicKey,
         message: s.message,
-        signature: bls.Signature.fromBytes(s.signature, CoordType.affine, validateSignature),
+        // true = validate signature
+        signature: bls.Signature.fromBytes(s.signature, CoordType.affine, true),
       }))
     );
   }
@@ -30,7 +31,8 @@ export function verifySignatureSetsMaybeBatch(sets: SignatureSetDeserialized[], 
 
   // If too few signature sets verify them without batching
   return sets.every((set) => {
-    const sig = bls.Signature.fromBytes(set.signature, CoordType.affine, validateSignature);
+    // true = validate signature
+    const sig = bls.Signature.fromBytes(set.signature, CoordType.affine, true);
     return sig.verify(set.publicKey, set.message);
   });
 }

--- a/packages/lodestar/src/chain/bls/multithread/index.ts
+++ b/packages/lodestar/src/chain/bls/multithread/index.ts
@@ -279,7 +279,10 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
         const job = jobs[i];
         const jobResult = results[i];
         const sigSetCount = job.workReq.sets.length;
-        if (jobResult.code === WorkResultCode.success) {
+        if (!jobResult) {
+          job.reject(Error(`No jobResult for index ${i}`));
+          errorCount += sigSetCount;
+        } else if (jobResult.code === WorkResultCode.success) {
           job.resolve(jobResult.result);
           successCount += sigSetCount;
         } else {

--- a/packages/lodestar/src/chain/bls/multithread/index.ts
+++ b/packages/lodestar/src/chain/bls/multithread/index.ts
@@ -281,8 +281,8 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
       }
 
       this.metrics?.blsThreadPool.totalJobsGroupsStarted.inc(1);
-      this.metrics?.blsThreadPool.totalJobsStarted.inc(jobs.length);
-      this.metrics?.blsThreadPool.totalSigSetsStarted.inc(startedSigSets);
+      if (jobs.length > 0) this.metrics?.blsThreadPool.totalJobsStarted.inc(jobs.length);
+      if (startedSigSets > 0) this.metrics?.blsThreadPool.totalSigSetsStarted.inc(startedSigSets);
 
       // Send work package to the worker
       // If the job, metrics or any code below throws: the job will reject never going stale.
@@ -319,13 +319,13 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
       const latencyToWorkerSec = Number(workerStartNs - jobStartNs) / 1e9;
       const latencyFromWorkerSec = Number(jobEndNs - workerEndNs) / 1e9;
 
-      this.metrics?.blsThreadPool.jobsWorkerTime.inc({workerId}, workerJobTimeSec);
+      if (workerJobTimeSec > 0) this.metrics?.blsThreadPool.jobsWorkerTime.inc({workerId}, workerJobTimeSec);
       this.metrics?.blsThreadPool.latencyToWorker.observe(latencyToWorkerSec);
       this.metrics?.blsThreadPool.latencyFromWorker.observe(latencyFromWorkerSec);
-      this.metrics?.blsThreadPool.successJobsSignatureSetsCount.inc(successCount);
-      this.metrics?.blsThreadPool.errorJobsSignatureSetsCount.inc(errorCount);
-      this.metrics?.blsThreadPool.batchRetries.inc(batchRetries);
-      this.metrics?.blsThreadPool.batchSigsSuccess.inc(batchSigsSuccess);
+      if (successCount > 0) this.metrics?.blsThreadPool.successJobsSignatureSetsCount.inc(successCount);
+      if (errorCount > 0) this.metrics?.blsThreadPool.errorJobsSignatureSetsCount.inc(errorCount);
+      if (batchRetries > 0) this.metrics?.blsThreadPool.batchRetries.inc(batchRetries);
+      if (batchSigsSuccess > 0) this.metrics?.blsThreadPool.batchSigsSuccess.inc(batchSigsSuccess);
     } catch (e) {
       // Worker communications should never reject
       if (!this.signal.aborted) this.logger.error("BlsMultiThreadWorkerPool error", {}, e);

--- a/packages/lodestar/src/chain/bls/multithread/types.ts
+++ b/packages/lodestar/src/chain/bls/multithread/types.ts
@@ -1,41 +1,33 @@
+import {VerifySignatureOpts} from "../interface";
+
 export type WorkerData = {
   implementation: "herumi" | "blst-native";
   workerId: number;
 };
 
-export type BlsWorkReq = {
-  validateSignature: boolean;
-  sets: {publicKey: Uint8Array; message: Uint8Array; signature: Uint8Array}[];
+export type SerializedSet = {
+  publicKey: Uint8Array;
+  message: Uint8Array;
+  signature: Uint8Array;
 };
 
-export type BlsWorkResult = WorkResult<boolean>;
+export type BlsWorkReq = {
+  opts: VerifySignatureOpts;
+  sets: SerializedSet[];
+};
 
 export enum WorkResultCode {
   success = "success",
   error = "error",
 }
 
-export type WorkResult<R> =
-  | {code: WorkResultCode.success; result: R; workerJobTimeMs: number; workerId: number}
-  | {code: WorkResultCode.error; error: Error};
+export type WorkResult<R> = {code: WorkResultCode.success; result: R} | {code: WorkResultCode.error; error: Error};
 
-export enum WorkerMessageCode {
-  workRequest = "workRequest",
-  workAcknowledge = "workAcknowledge",
-  workResult = "blsWorkResult",
-  ready = "ready",
-}
-
-export type WorkerMessage =
-  | {code: WorkerMessageCode.workRequest; taskId: number; requests: BlsWorkReq[]}
-  | {code: WorkerMessageCode.workAcknowledge; taskId: number}
-  | {code: WorkerMessageCode.workResult; taskId: number; results: WorkResult<unknown>[]}
-  | {code: WorkerMessageCode.ready};
-
-// export type WorkerApi = {
-//   verify(impl: Implementation, publicKey: Uint8Array, message: Uint8Array, signature: Uint8Array): Promise<boolean>;
-//   verifyMultipleAggregateSignatures(
-//     impl: Implementation,
-//     sets: {publicKey: Uint8Array; message: Uint8Array; signature: Uint8Array}[]
-//   ): Promise<boolean>;
-// };
+export type BlsWorkResult = {
+  workerId: number;
+  batchRetries: number;
+  batchSigsSuccess: number;
+  workerStartNs: bigint;
+  workerEndNs: bigint;
+  results: WorkResult<boolean>[];
+};

--- a/packages/lodestar/src/chain/bls/multithread/types.ts
+++ b/packages/lodestar/src/chain/bls/multithread/types.ts
@@ -24,10 +24,15 @@ export enum WorkResultCode {
 export type WorkResult<R> = {code: WorkResultCode.success; result: R} | {code: WorkResultCode.error; error: Error};
 
 export type BlsWorkResult = {
+  /** Ascending integer identifying the worker for metrics */
   workerId: number;
+  /** Total num of batches that had to be retried */
   batchRetries: number;
+  /** Total num of sigs that have been successfully verified with batching */
   batchSigsSuccess: number;
+  /** Time worker function starts - UNIX timestamp in nanoseconds */
   workerStartNs: bigint;
+  /** Time worker function ends - UNIX timestamp in nanoseconds */
   workerEndNs: bigint;
   results: WorkResult<boolean>[];
 };

--- a/packages/lodestar/src/chain/bls/multithread/worker.ts
+++ b/packages/lodestar/src/chain/bls/multithread/worker.ts
@@ -3,6 +3,16 @@ import {expose} from "threads/worker";
 import {bls, init, CoordType} from "@chainsafe/bls";
 import {verifySignatureSetsMaybeBatch, SignatureSetDeserialized} from "../maybeBatch";
 import {WorkerData, BlsWorkReq, WorkResult, WorkResultCode, SerializedSet, BlsWorkResult} from "./types";
+import {chunkifyMaximizeChunkSize} from "./utils";
+
+/**
+ * Split batchable sets in chunks of minimum size 16.
+ * Batch verify 16 has an aprox cost of 16+1. For 32 it's 32+1. After ~16 the additional savings are not significant.
+ * However, if a sig is invalid the whole batch has to be re-verified. So it's important to keep this number low.
+ * In normal network conditions almost all signatures received by the node are correct.
+ * After observing metrics this number can be reviewed
+ */
+const BATCHABLE_MIN_PER_CHUNK = 16;
 
 /* eslint-disable no-console */
 
@@ -28,8 +38,6 @@ function doManyBlsWorkReq(workReqArr: BlsWorkReq[]): BlsWorkResult {
   const batchable: {idx: number; workReq: BlsWorkReq}[] = [];
   const nonBatchable: {idx: number; workReq: BlsWorkReq}[] = [];
 
-  // TODO: Split batchable into chunks of max size ~ 32 to minimize cost if a sig is wrong
-
   for (let i = 0; i < workReqArr.length; i++) {
     const workReq = workReqArr[i];
     if (workReq.opts.batchable) {
@@ -40,31 +48,36 @@ function doManyBlsWorkReq(workReqArr: BlsWorkReq[]): BlsWorkResult {
   }
 
   if (batchable.length > 0) {
-    const allSets: SignatureSetDeserialized[] = [];
-    for (const {workReq} of batchable) {
-      for (const set of workReq.sets) {
-        allSets.push(deserializeSet(set));
-      }
-    }
+    // Split batchable into chunks of max size ~ 32 to minimize cost if a sig is wrong
+    const batchableChunks = chunkifyMaximizeChunkSize(batchable, BATCHABLE_MIN_PER_CHUNK);
 
-    try {
-      const isValid = verifySignatureSetsMaybeBatch(allSets);
-
-      if (isValid) {
-        // The entire batch is valid
-        for (const {idx, workReq} of batchable) {
-          batchSigsSuccess += workReq.sets.length;
-          results[idx] = {code: WorkResultCode.success, result: isValid};
+    for (const batchableChunk of batchableChunks) {
+      const allSets: SignatureSetDeserialized[] = [];
+      for (const {workReq} of batchableChunk) {
+        for (const set of workReq.sets) {
+          allSets.push(deserializeSet(set));
         }
-      } else {
-        batchRetries++;
-        // Re-verify all sigs
-        nonBatchable.push(...batchable);
       }
-    } catch (e) {
-      // Return error to the main thread so it can be visible
-      for (const {idx} of batchable) {
-        results[idx] = {code: WorkResultCode.error, error: e as Error};
+
+      try {
+        const isValid = verifySignatureSetsMaybeBatch(allSets);
+
+        if (isValid) {
+          // The entire batch is valid
+          for (const {idx, workReq} of batchableChunk) {
+            batchSigsSuccess += workReq.sets.length;
+            results[idx] = {code: WorkResultCode.success, result: isValid};
+          }
+        } else {
+          batchRetries++;
+          // Re-verify all sigs
+          nonBatchable.push(...batchableChunk);
+        }
+      } catch (e) {
+        // Return error to the main thread so it can be visible
+        for (const {idx} of batchableChunk) {
+          results[idx] = {code: WorkResultCode.error, error: e as Error};
+        }
       }
     }
   }

--- a/packages/lodestar/src/chain/bls/multithread/worker.ts
+++ b/packages/lodestar/src/chain/bls/multithread/worker.ts
@@ -1,8 +1,8 @@
 import worker from "worker_threads";
 import {expose} from "threads/worker";
 import {bls, init, CoordType} from "@chainsafe/bls";
-import {WorkerData, BlsWorkReq, WorkResult, WorkResultCode} from "./types";
-import {verifySignatureSetsMaybeBatch} from "../maybeBatch";
+import {verifySignatureSetsMaybeBatch, SignatureSetDeserialized} from "../maybeBatch";
+import {WorkerData, BlsWorkReq, WorkResult, WorkResultCode, SerializedSet, BlsWorkResult} from "./types";
 
 /* eslint-disable no-console */
 
@@ -12,28 +12,86 @@ if (!workerData) throw Error("workerData must be defined");
 const {implementation, workerId} = workerData || {};
 
 expose({
-  async doManyBlsWorkReq(workReqArr: BlsWorkReq[]): Promise<WorkResult<boolean>[]> {
+  async doManyBlsWorkReq(workReqArr: BlsWorkReq[]): Promise<BlsWorkResult> {
     await init(implementation);
     return doManyBlsWorkReq(workReqArr);
   },
 });
 
-function doManyBlsWorkReq(workReqArr: BlsWorkReq[]): WorkResult<boolean>[] {
-  return workReqArr.map((workReq) => {
-    try {
-      const start = Date.now();
-      const isValid = verifySignatureSetsMaybeBatch(
-        workReq.sets.map((set) => ({
-          publicKey: bls.PublicKey.fromBytes(set.publicKey, CoordType.affine),
-          message: set.message,
-          signature: set.signature,
-        })),
-        workReq.validateSignature
-      );
-      const workerJobTimeMs = Date.now() - start;
-      return {code: WorkResultCode.success, result: isValid, workerJobTimeMs, workerId};
-    } catch (e) {
-      return {code: WorkResultCode.error, error: e as Error};
+function doManyBlsWorkReq(workReqArr: BlsWorkReq[]): BlsWorkResult {
+  const startNs = process.hrtime.bigint();
+  const results: WorkResult<boolean>[] = [];
+  let batchRetries = 0;
+  let batchSigsSuccess = 0;
+
+  // If there are multiple batchable sets attempt batch verification with them
+  const batchable: {idx: number; workReq: BlsWorkReq}[] = [];
+  const nonBatchable: {idx: number; workReq: BlsWorkReq}[] = [];
+
+  // TODO: Split batchable into chunks of max size ~ 32 to minimize cost if a sig is wrong
+
+  for (let i = 0; i < workReqArr.length; i++) {
+    const workReq = workReqArr[i];
+    if (workReq.opts.batchable) {
+      batchable.push({idx: i, workReq});
+    } else {
+      nonBatchable.push({idx: i, workReq});
     }
-  });
+  }
+
+  if (batchable.length > 0) {
+    const allSets: SignatureSetDeserialized[] = [];
+    for (const {workReq} of batchable) {
+      for (const set of workReq.sets) {
+        allSets.push(deserializeSet(set));
+      }
+    }
+
+    try {
+      const isValid = verifySignatureSetsMaybeBatch(allSets);
+
+      if (isValid) {
+        // The entire batch is valid
+        for (const {idx, workReq} of batchable) {
+          batchSigsSuccess += workReq.sets.length;
+          results[idx] = {code: WorkResultCode.success, result: isValid};
+        }
+      } else {
+        batchRetries++;
+        // Re-verify all sigs
+        nonBatchable.push(...batchable);
+      }
+    } catch (e) {
+      // Return error to the main thread so it can be visible
+      for (const {idx} of batchable) {
+        results[idx] = {code: WorkResultCode.error, error: e as Error};
+      }
+    }
+  }
+
+  for (const {idx, workReq} of nonBatchable) {
+    try {
+      const isValid = verifySignatureSetsMaybeBatch(workReq.sets.map(deserializeSet));
+      results[idx] = {code: WorkResultCode.success, result: isValid};
+    } catch (e) {
+      results[idx] = {code: WorkResultCode.error, error: e as Error};
+    }
+  }
+
+  return {
+    workerId,
+    batchRetries,
+    batchSigsSuccess,
+    workerStartNs: startNs,
+    workerEndNs: process.hrtime.bigint(),
+    results,
+  };
+}
+
+function deserializeSet(set: SerializedSet): SignatureSetDeserialized {
+  return {
+    publicKey: bls.PublicKey.fromBytes(set.publicKey, CoordType.affine),
+    message: set.message,
+    signature: set.signature,
+  };
 }

--- a/packages/lodestar/src/chain/bls/singleThread.ts
+++ b/packages/lodestar/src/chain/bls/singleThread.ts
@@ -4,14 +4,13 @@ import {verifySignatureSetsMaybeBatch} from "./maybeBatch";
 import {getAggregatedPubkey} from "./utils";
 
 export class BlsSingleThreadVerifier implements IBlsVerifier {
-  async verifySignatureSets(sets: ISignatureSet[], validateSignature = true): Promise<boolean> {
+  async verifySignatureSets(sets: ISignatureSet[]): Promise<boolean> {
     return verifySignatureSetsMaybeBatch(
       sets.map((set) => ({
         publicKey: getAggregatedPubkey(set),
         message: set.signingRoot.valueOf() as Uint8Array,
         signature: set.signature,
-      })),
-      validateSignature
+      }))
     );
   }
 }

--- a/packages/lodestar/src/chain/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/aggregateAndProof.ts
@@ -105,7 +105,7 @@ export async function validateGossipAggregateAndProof(
     getAggregateAndProofSignatureSet(targetState, attEpoch, aggregator, signedAggregateAndProof),
     allForks.getIndexedAttestationSignatureSet(targetState, indexedAttestation),
   ];
-  if (!(await chain.bls.verifySignatureSets(signatureSets))) {
+  if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {
     throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.INVALID_SIGNATURE});
   }
 

--- a/packages/lodestar/src/chain/validation/attestation.ts
+++ b/packages/lodestar/src/chain/validation/attestation.ts
@@ -139,7 +139,7 @@ export async function validateGossipAttestation(
     signature: attestation.signature,
   };
   const signatureSet = getIndexedAttestationSignatureSet(attestationTargetState, indexedAttestation);
-  if (!(await chain.bls.verifySignatureSets([signatureSet]))) {
+  if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true}))) {
     throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.INVALID_SIGNATURE});
   }
 

--- a/packages/lodestar/src/chain/validation/attesterSlashing.ts
+++ b/packages/lodestar/src/chain/validation/attesterSlashing.ts
@@ -35,7 +35,7 @@ export async function validateGossipAttesterSlashing(
   }
 
   const signatureSets = allForks.getAttesterSlashingSignatureSets(state, attesterSlashing);
-  if (!(await chain.bls.verifySignatureSets(signatureSets))) {
+  if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {
     throw new AttesterSlashingError(GossipAction.REJECT, {
       code: AttesterSlashingErrorCode.INVALID,
       error: Error("Invalid signature"),

--- a/packages/lodestar/src/chain/validation/block.ts
+++ b/packages/lodestar/src/chain/validation/block.ts
@@ -54,6 +54,7 @@ export async function validateGossipBlock(
   });
 
   const signatureSet = allForks.getProposerSignatureSet(blockState, block);
+  // Don't batch so verification is not delayed
   if (!(await chain.bls.verifySignatureSets([signatureSet]))) {
     throw new BlockGossipError(GossipAction.REJECT, {code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID});
   }

--- a/packages/lodestar/src/chain/validation/proposerSlashing.ts
+++ b/packages/lodestar/src/chain/validation/proposerSlashing.ts
@@ -27,7 +27,7 @@ export async function validateGossipProposerSlashing(
   }
 
   const signatureSets = allForks.getProposerSlashingSignatureSets(state, proposerSlashing);
-  if (!(await chain.bls.verifySignatureSets(signatureSets))) {
+  if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {
     throw new ProposerSlashingError(GossipAction.REJECT, {
       code: ProposerSlashingErrorCode.INVALID,
       error: Error("Invalid signature"),

--- a/packages/lodestar/src/chain/validation/syncCommittee.ts
+++ b/packages/lodestar/src/chain/validation/syncCommittee.ts
@@ -58,7 +58,7 @@ export async function validateSyncCommitteeSigOnly(
   syncCommittee: altair.SyncCommitteeMessage
 ): Promise<void> {
   const signatureSet = getSyncCommitteeSignatureSet(headState, syncCommittee);
-  if (!(await chain.bls.verifySignatureSets([signatureSet]))) {
+  if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true}))) {
     throw new SyncCommitteeError(GossipAction.REJECT, {
       code: SyncCommitteeErrorCode.INVALID_SIGNATURE,
     });

--- a/packages/lodestar/src/chain/validation/syncCommitteeContributionAndProof.ts
+++ b/packages/lodestar/src/chain/validation/syncCommitteeContributionAndProof.ts
@@ -68,7 +68,7 @@ export async function validateSyncCommitteeGossipContributionAndProof(
     getSyncCommitteeContributionSignatureSet(headState as CachedBeaconState<altair.BeaconState>, contribution),
   ];
 
-  if (!(await chain.bls.verifySignatureSets(signatureSets))) {
+  if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {
     throw new SyncCommitteeError(GossipAction.REJECT, {
       code: SyncCommitteeErrorCode.INVALID_SIGNATURE,
     });

--- a/packages/lodestar/src/chain/validation/voluntaryExit.ts
+++ b/packages/lodestar/src/chain/validation/voluntaryExit.ts
@@ -30,7 +30,7 @@ export async function validateGossipVoluntaryExit(
   }
 
   const signatureSet = allForks.getVoluntaryExitSignatureSet(state, voluntaryExit);
-  if (!(await chain.bls.verifySignatureSets([signatureSet]))) {
+  if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true}))) {
     throw new VoluntaryExitError(GossipAction.REJECT, {
       code: VoluntaryExitErrorCode.INVALID,
       error: Error("Invalid signature"),

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -187,36 +187,63 @@ export function createLodestarMetrics(
 
     // BLS verifier thread pool and queue
 
-    blsThreadPoolSuccessJobsSignatureSetsCount: register.gauge({
-      name: "lodestar_bls_thread_pool_success_jobs_signature_sets_count",
-      help: "Count of total verified signature sets",
-    }),
-    blsThreadPoolSuccessJobsWorkerTime: register.gauge<"workerId">({
-      name: "lodestar_bls_thread_pool_success_time_seconds_sum",
-      help: "Total time spent verifying signature sets measured on the worker",
-      labelNames: ["workerId"],
-    }),
-    blsThreadPoolErrorJobsSignatureSetsCount: register.gauge({
-      name: "lodestar_bls_thread_pool_error_jobs_signature_sets_count",
-      help: "Count of total error-ed signature sets",
-    }),
-    blsThreadPoolJobWaitTime: register.histogram({
-      name: "lodestar_bls_thread_pool_queue_job_wait_time_seconds",
-      help: "Time from job added to the queue to starting the job in seconds",
-      buckets: [0.1, 1, 10],
-    }),
-    blsThreadPoolQueueLength: register.gauge({
-      name: "lodestar_bls_thread_pool_queue_length",
-      help: "Count of total block processor queue length",
-    }),
-    blsThreadPoolTotalJobsGroupsStarted: register.gauge({
-      name: "lodestar_bls_thread_pool_job_groups_started_total",
-      help: "Count of total jobs groups started in bls thread pool, job groups include +1 jobs",
-    }),
-    blsThreadPoolTotalJobsStarted: register.gauge({
-      name: "lodestar_bls_thread_pool_jobs_started_total",
-      help: "Count of total jobs started in bls thread pool, jobs include +1 signature sets",
-    }),
+    blsThreadPool: {
+      jobsWorkerTime: register.gauge<"workerId">({
+        name: "lodestar_bls_thread_pool_time_seconds_sum",
+        help: "Total time spent verifying signature sets measured on the worker",
+        labelNames: ["workerId"],
+      }),
+      successJobsSignatureSetsCount: register.gauge({
+        name: "lodestar_bls_thread_pool_success_jobs_signature_sets_count",
+        help: "Count of total verified signature sets",
+      }),
+      errorJobsSignatureSetsCount: register.gauge({
+        name: "lodestar_bls_thread_pool_error_jobs_signature_sets_count",
+        help: "Count of total error-ed signature sets",
+      }),
+      jobWaitTime: register.histogram({
+        name: "lodestar_bls_thread_pool_queue_job_wait_time_seconds",
+        help: "Time from job added to the queue to starting the job in seconds",
+        buckets: [0.1, 1, 10],
+      }),
+      queueLength: register.gauge({
+        name: "lodestar_bls_thread_pool_queue_length",
+        help: "Count of total block processor queue length",
+      }),
+      totalJobsGroupsStarted: register.gauge({
+        name: "lodestar_bls_thread_pool_job_groups_started_total",
+        help: "Count of total jobs groups started in bls thread pool, job groups include +1 jobs",
+      }),
+      totalJobsStarted: register.gauge({
+        name: "lodestar_bls_thread_pool_jobs_started_total",
+        help: "Count of total jobs started in bls thread pool, jobs include +1 signature sets",
+      }),
+      totalSigSetsStarted: register.gauge({
+        name: "lodestar_bls_thread_pool_sig_sets_started_total",
+        help: "Count of total signature sets started in bls thread pool, sig sets include 1 pk, msg, sig",
+      }),
+      // Re-verifying a batch means doing double work. This number must be very low or it can be a waste of CPU resources
+      batchRetries: register.gauge({
+        name: "lodestar_bls_thread_pool_batch_retries",
+        help: "Count of total batches that failed and had to be verified again.",
+      }),
+      // To count how many sigs are being validated with the optimization of batching them
+      batchSigsSuccess: register.gauge({
+        name: "lodestar_bls_thread_pool_batch_sigs_success_total",
+        help: "Count of total batches that failed and had to be verified again.",
+      }),
+      // To measure the time cost of main thread <-> worker message passing
+      latencyToWorker: register.histogram({
+        name: "lodestar_bls_thread_pool_latency_to_worker",
+        help: "Time from sending the job to the worker and the worker receiving it",
+        buckets: [0.1],
+      }),
+      latencyFromWorker: register.histogram({
+        name: "lodestar_bls_thread_pool_latency_from_worker",
+        help: "Time from the worker sending the result and the main thread receiving it",
+        buckets: [0.1],
+      }),
+    },
 
     // Sync
 

--- a/packages/lodestar/src/metrics/utils/gauge.ts
+++ b/packages/lodestar/src/metrics/utils/gauge.ts
@@ -48,9 +48,9 @@ export class GaugeChild<T extends string> implements IGauge {
   inc(labels: Labels<T>, value?: number): void;
   inc(arg1?: Labels<T> | number, arg2?: number): void {
     if (typeof arg1 === "object") {
-      this.gauge.inc({...this.labelsParent, ...arg1}, arg2 || 0);
+      this.gauge.inc({...this.labelsParent, ...arg1}, arg2 ?? 1);
     } else {
-      this.gauge.inc(this.labelsParent, arg1 || 0);
+      this.gauge.inc(this.labelsParent, arg1 ?? 1);
     }
   }
 

--- a/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
@@ -1,9 +1,13 @@
-import {expect} from "chai";
+import chai, {expect} from "chai";
+import chaiAsPromised from "chai-as-promised";
 import {AbortController} from "@chainsafe/abort-controller";
 import {bls} from "@chainsafe/bls";
 import {ISignatureSet, SignatureSetType} from "@chainsafe/lodestar-beacon-state-transition";
 import {BlsMultiThreadWorkerPool} from "../../../../src/chain/bls/multithread";
 import {testLogger} from "../../../utils/logger";
+import {VerifySignatureOpts} from "../../../../src/chain/bls/interface";
+
+chai.use(chaiAsPromised);
 
 describe("chain / bls / multithread queue", function () {
   this.timeout(30 * 1000);
@@ -13,11 +17,11 @@ describe("chain / bls / multithread queue", function () {
   beforeEach(() => (controller = new AbortController()));
   afterEach(() => controller.abort());
 
-  it("Should verify some signatures", async () => {
-    const sets: ISignatureSet[] = [];
-    for (let i = 0; i < 8; i++) {
+  const sets: ISignatureSet[] = [];
+  before("generate test data", () => {
+    for (let i = 0; i < 3; i++) {
       const sk = bls.SecretKey.fromBytes(Buffer.alloc(32, i + 1));
-      const msg = Buffer.alloc(32, i);
+      const msg = Buffer.alloc(32, i + 1);
       const pk = sk.toPublicKey();
       const sig = sk.sign(msg);
       sets.push({
@@ -27,9 +31,66 @@ describe("chain / bls / multithread queue", function () {
         signature: sig.toBytes(),
       });
     }
+  });
 
+  async function initializePool(): Promise<BlsMultiThreadWorkerPool> {
     const pool = new BlsMultiThreadWorkerPool({logger, metrics: null, signal: controller.signal});
-    const isValidArr = await Promise.all(Array.from({length: 8}, (i) => i).map(() => pool.verifySignatureSets(sets)));
+    // Wait until initialized
+    await pool["waitTillInitialized"]();
+    return pool;
+  }
+
+  async function testManyValidSignatures(
+    testOpts: {sleep?: boolean},
+    verifySignatureOpts?: VerifySignatureOpts
+  ): Promise<void> {
+    const pool = await initializePool();
+
+    const isValidPromiseArr: Promise<boolean>[] = [];
+    for (let i = 0; i < 8; i++) {
+      isValidPromiseArr.push(pool.verifySignatureSets(sets, verifySignatureOpts));
+      if (testOpts.sleep) {
+        // Tick forward so the pool sends a job out
+        await new Promise((r) => setTimeout(r, 5));
+      }
+    }
+
+    const isValidArr = await Promise.all(isValidPromiseArr);
+    for (const [i, isValid] of isValidArr.entries()) {
+      expect(isValid).to.equal(true, `sig set ${i} returned invalid`);
+    }
+  }
+
+  it("Should verify multiple signatures submited syncronously", async () => {
+    // Given the `setTimeout(this.runJob, 0);` all sets should be verified in a single job an worker
+    await testManyValidSignatures({sleep: false});
+  });
+
+  it("Should verify multiple signatures submited asyncronously", async () => {
+    // Because of the sleep, each sets submitted should be verified in a different job and worker
+    await testManyValidSignatures({sleep: true});
+  });
+
+  it("Should verify multiple signatures batched", async () => {
+    // By setting batchable: true, 5*8 = 40 sig sets should be verified in one job, while 3*8=24 should
+    // be verified in another job
+    await testManyValidSignatures({sleep: true}, {batchable: true});
+  });
+
+  it("Should verify multiple signatures batched, first is invalid", async () => {
+    // If the first signature is invalid it should not make the rest throw
+    const pool = await initializePool();
+
+    const invalidSet: ISignatureSet = {...sets[0], signature: Buffer.alloc(32, 0)};
+    const isInvalidPromise = pool.verifySignatureSets([invalidSet], {batchable: true});
+    const isValidPromiseArr: Promise<boolean>[] = [];
+    for (let i = 0; i < 8; i++) {
+      isValidPromiseArr.push(pool.verifySignatureSets(sets, {batchable: true}));
+    }
+
+    await expect(isInvalidPromise).to.rejectedWith("BLST_ERROR: bad point encoding");
+
+    const isValidArr = await Promise.all(isValidPromiseArr);
     for (const [i, isValid] of isValidArr.entries()) {
       expect(isValid).to.equal(true, `sig set ${i} returned invalid`);
     }

--- a/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
@@ -29,9 +29,7 @@ describe("chain / bls / multithread queue", function () {
     }
 
     const pool = new BlsMultiThreadWorkerPool({logger, metrics: null, signal: controller.signal});
-    const isValidArr = await Promise.all(
-      Array.from({length: 8}, (i) => i).map(() => pool.verifySignatureSets(sets, true))
-    );
+    const isValidArr = await Promise.all(Array.from({length: 8}, (i) => i).map(() => pool.verifySignatureSets(sets)));
     for (const [i, isValid] of isValidArr.entries()) {
       expect(isValid).to.equal(true, `sig set ${i} returned invalid`);
     }

--- a/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
@@ -88,7 +88,7 @@ describe("chain / bls / multithread queue", function () {
       isValidPromiseArr.push(pool.verifySignatureSets(sets, {batchable: true}));
     }
 
-    await expect(isInvalidPromise).to.rejectedWith("BLST_ERROR: bad point encoding");
+    await expect(isInvalidPromise).to.rejectedWith("BLST_ERROR");
 
     const isValidArr = await Promise.all(isValidPromiseArr);
     for (const [i, isValid] of isValidArr.entries()) {

--- a/packages/lodestar/test/unit/chain/bls/utils.test.ts
+++ b/packages/lodestar/test/unit/chain/bls/utils.test.ts
@@ -1,0 +1,34 @@
+import {expect} from "chai";
+import {chunkifyMaximizeChunkSize} from "../../../../src/chain/bls/multithread/utils";
+import {linspace} from "../../../../src/util/numpy";
+
+describe("chain / bls / utils / chunkifyMaximizeChunkSize", () => {
+  const minPerChunk = 3;
+  const testCases = [
+    [[0]],
+    [[0, 1]],
+    [[0, 1, 2]],
+    [[0, 1, 2, 3]],
+    [[0, 1, 2, 3, 4]],
+    [
+      [0, 1, 2],
+      [3, 4, 5],
+    ],
+    [
+      [0, 1, 2, 3],
+      [4, 5, 6],
+    ],
+    [
+      [0, 1, 2, 3],
+      [4, 5, 6, 7],
+    ],
+  ];
+
+  for (const [i, testCase] of testCases.entries()) {
+    it(`array len ${i + 1}`, () => {
+      const arr = linspace(0, i);
+      const chunks = chunkifyMaximizeChunkSize(arr, minPerChunk);
+      expect(chunks).to.deep.equal(testCase);
+    });
+  }
+});


### PR DESCRIPTION
**Motivation**

Very promising optimization, it has been very successful in Nimbus and Lighthouse. See https://github.com/ChainSafe/lodestar/issues/2686

**Description**

- Buffer submitted work for 100ms
- Then construct packets of work that will be verified in batch, if some fail re-verify all individually. This logic happens in the worker side to reduce communication.
- Only allow this behaviour on certain work packets. The BLS queue does not apply this strategy to work with a lot a signature sets, only to those with fewer than 3-5 (aggregates + attesations) that manually requested.

Closes https://github.com/ChainSafe/lodestar/issues/2686

**Testing**

The parameters need tweaking and more debugging. I've tested this PR over the weekend and didn't got good results.
- **EDIT: fixed** - 3% of all signatures are invalid according to metrics which makes the batching strategy less efficient
- **EDIT: fixed** - As so, batches are retried very often
- There are some memory issues that cause far OOM. Still need more debugging