### PR TITLE
Shortcut to enable all namespaces

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/api.ts
+++ b/packages/cli/src/options/beaconNodeOptions/api.ts
@@ -1,6 +1,8 @@
 import {defaultOptions, IBeaconNodeOptions, allNamespaces} from "@chainsafe/lodestar";
 import {ICliCommandOptions} from "../../util";
 
+const enabledAll = "*";
+
 export interface IApiArgs {
   "api.rest.api": string[];
   "api.rest.cors": string;
@@ -24,12 +26,16 @@ export function parseArgs(args: IApiArgs): IBeaconNodeOptions["api"] {
 export const options: ICliCommandOptions<IApiArgs> = {
   "api.rest.api": {
     type: "array",
-    choices: allNamespaces,
-    description: "Pick namespaces to expose for HTTP API",
+    choices: [...allNamespaces, enabledAll],
+    description: `Pick namespaces to expose for HTTP API. Set to '${enabledAll}' to enable all namespaces`,
     defaultDescription: JSON.stringify(defaultOptions.api.rest.api),
     group: "api",
-    // Parse ["debug,lodestar"] to ["debug", "lodestar"]
-    coerce: (namespaces: string[]): string[] => namespaces.map((val) => val.split(",")).flat(1),
+    coerce: (namespaces: string[]): string[] => {
+      // Enable all
+      if (namespaces.includes(enabledAll)) return allNamespaces;
+      // Parse ["debug,lodestar"] to ["debug", "lodestar"]
+      return namespaces.map((val) => val.split(",")).flat(1);
+    },
   },
 
   "api.rest.cors": {


### PR DESCRIPTION
**Motivation**

For testing and other usages it's very convenient to enable all namespaces without typing the full list manually

**Description**

Setting `--api.rest.api '*'` enables all available namespaces

```
lion@lion-gram:~/Code/eth2.0/lodestar/packages/cli$ ./bin/lodestar beacon --api.rest.api '*' --api.rest.enabled
Jul-06 12:28:53.267 []                 info: Lodestar version=0.25.1 dapplion/enable-all-namespaces 149f1ae6, network=mainnet
Jul-06 12:29:31.662 [API]              info: Started REST api server address=http://127.0.0.1:9596, namespaces=["beacon","config","debug","events","lightclient","lodestar","node","validator"]
```