### PR TITLE
exec options to ignore stderr for obtaining git data

### DIFF
--- a/packages/cli/scripts/getGitData.js
+++ b/packages/cli/scripts/getGitData.js
@@ -1,17 +1,29 @@
 /* eslint-disable */
 const fs = require("fs");
 const {execSync} = require("child_process");
+const shell = (cmd) =>
+  execSync(cmd, {stdio: ["ignore", "pipe", "ignore"]})
+    .toString()
+    .trim();
+
+function getGitData() {
+  try {
+    const branch = shell("git rev-parse --abbrev-ref HEAD");
+    const commit = shell("git rev-parse --verify HEAD");
+    return {branch, commit};
+  } catch (e) {
+    return {};
+  }
+}
 
 // Persist git data and distribute through NPM so CLI consumers can know exactly
 // at what commit was this src build. This is used in the metrics and to log initially
 
-const shell = (cmd) => execSync(cmd).toString().trim();
-
 const version = JSON.parse(fs.readFileSync("package.json")).version;
-const branch = shell("git rev-parse --abbrev-ref HEAD");
-const commit = shell("git rev-parse --verify HEAD");
+const gitData = getGitData();
+const branch = gitData?.branch || "-";
+const commit = gitData?.commit || "-";
 
 const data = {version, branch, commit};
 const versionDataFile = process.argv[2];
 fs.writeFileSync(versionDataFile, JSON.stringify(data, null, 2));
-console.log(data);

--- a/packages/cli/src/util/gitData.ts
+++ b/packages/cli/src/util/gitData.ts
@@ -55,7 +55,10 @@ function formatVersion({semver, branch, commit}: Partial<GitData>): string {
 
 function getGitData(): Partial<GitData> {
   try {
-    const shell = (cmd: string): string => execSync(cmd).toString().trim();
+    const shell = (cmd: string): string =>
+      execSync(cmd, {stdio: ["ignore", "pipe", "ignore"]})
+        .toString()
+        .trim();
     const branch = shell("git rev-parse --abbrev-ref HEAD");
     const commit = shell("git rev-parse --verify HEAD");
     return {branch, commit};


### PR DESCRIPTION
**Motivation**
This PR passing stdio options to execSync to ignore the stdin, stderr but still pipe back stdout to get the result. patched at places where gitdata is being fetched. 
As a result, any error is silently ignored and '-' are bundled as verison.branch.
<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes  #2780

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
