### PR TITLE
Reduce node is syncing errors verbosity

### DIFF
--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -1,6 +1,7 @@
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {Api} from "../interface";
-import {IHttpClient, HttpClient, HttpClientOptions} from "./utils";
+import {IHttpClient, HttpClient, HttpClientOptions, HttpError} from "./utils";
+export {HttpClient, HttpClientOptions, HttpError};
 
 import * as beacon from "./beacon";
 import * as configApi from "./config";

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,5 +1,5 @@
 export * as routes from "./routes";
 export * from "./interface";
-export {getClient} from "./client";
+export {getClient, HttpClient, HttpClientOptions, HttpError} from "./client";
 
 // Node: Don't export server here so it's not bundled to all consumers

--- a/packages/api/test/unit/client/httpClient.test.ts
+++ b/packages/api/test/unit/client/httpClient.test.ts
@@ -116,6 +116,24 @@ describe("httpClient json client", () => {
     }
   });
 
+  it("should handle http status with custom code 503", async () => {
+    const httpClient = await getServerWithClient({
+      ...testRoute,
+      handler: async (req, res) => {
+        return res.code(503).send("Node is syncing");
+      },
+    });
+
+    try {
+      await httpClient.json(testRoute);
+      return Promise.reject(Error("did not throw"));
+    } catch (e) {
+      if (!(e instanceof HttpError)) throw Error(`Not an HttpError: ${(e as Error).message}`);
+      expect(e.message).to.equal("Service Unavailable: Node is syncing");
+      expect(e.status).to.equal(503, "Wrong error status code");
+    }
+  });
+
   it("should handle aborting request with timeout", async () => {
     const {baseUrl} = await getServer({
       ...testRoute,

--- a/packages/lodestar/src/api/impl/errors.ts
+++ b/packages/lodestar/src/api/impl/errors.ts
@@ -24,3 +24,10 @@ export class ValidationError extends ApiError {
     this.dataPath = dataPath;
   }
 }
+
+// Spec requires 503 - https://github.com/ethereum/eth2.0-APIs/blob/e68a954e1b6f6eb5421abf4532c171ce301c6b2e/types/http.yaml#L62
+export class NodeIsSyncing extends ApiError {
+  constructor(statusMsg: string) {
+    super(503, `Node is syncing - ${statusMsg}`);
+  }
+}

--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -20,7 +20,7 @@ import {validateGossipAggregateAndProof} from "../../../chain/validation";
 import {ZERO_HASH} from "../../../constants";
 import {SyncState} from "../../../sync";
 import {toGraffitiBuffer} from "../../../util/graffiti";
-import {ApiError} from "../errors";
+import {ApiError, NodeIsSyncing} from "../errors";
 import {validateSyncCommitteeGossipContributionAndProof} from "../../../chain/validation/syncCommitteeContributionAndProof";
 import {SyncContributionError, SyncContributionErrorCode} from "../../../db/syncCommitteeContribution";
 import {CommitteeSubscription} from "../../../network/subnets";
@@ -120,7 +120,7 @@ export function getValidatorApi({
         const currentSlot = chain.clock.currentSlot;
         const headSlot = chain.forkChoice.getHead().slot;
         if (currentSlot - headSlot > SYNC_TOLERANCE_EPOCHS * SLOTS_PER_EPOCH) {
-          throw new ApiError(503, `Node is syncing, headSlot ${headSlot} currentSlot ${currentSlot}`);
+          throw new NodeIsSyncing(`headSlot ${headSlot} currentSlot ${currentSlot}`);
         } else {
           return;
         }
@@ -130,7 +130,7 @@ export function getValidatorApi({
         return;
 
       case SyncState.Stalled:
-        throw new ApiError(503, "Node is waiting for peers");
+        throw new NodeIsSyncing("waiting for peers");
     }
   }
 

--- a/packages/lodestar/src/api/rest/index.ts
+++ b/packages/lodestar/src/api/rest/index.ts
@@ -7,7 +7,7 @@ import {registerRoutes, RouteConfig} from "@chainsafe/lodestar-api/server";
 import {ErrorAborted, ILogger} from "@chainsafe/lodestar-utils";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IMetrics} from "../../metrics";
-import {ApiError} from "../impl/errors";
+import {ApiError, NodeIsSyncing} from "../impl/errors";
 export {allNamespaces} from "@chainsafe/lodestar-api";
 
 export type RestApiOptions = {
@@ -94,6 +94,8 @@ export class RestApi {
       this.activeRequests.delete(req.raw);
       // Don't log ErrorAborted errors, they happen on node shutdown and are not usefull
       if (err instanceof ErrorAborted) return;
+      // Don't log NodeISSyncing errors, they happen very frequently while syncing and the validator checks the style
+      if (err instanceof NodeIsSyncing) return;
 
       const {operationId} = res.context.config as RouteConfig;
       this.logger.error(`Req ${req.id} ${operationId} error`, {}, err);

--- a/packages/lodestar/src/api/rest/index.ts
+++ b/packages/lodestar/src/api/rest/index.ts
@@ -94,7 +94,7 @@ export class RestApi {
       this.activeRequests.delete(req.raw);
       // Don't log ErrorAborted errors, they happen on node shutdown and are not usefull
       if (err instanceof ErrorAborted) return;
-      // Don't log NodeISSyncing errors, they happen very frequently while syncing and the validator checks the style
+      // Don't log NodeISSyncing errors, they happen very frequently while syncing and the validator polls duties
       if (err instanceof NodeIsSyncing) return;
 
       const {operationId} = res.context.config as RouteConfig;

--- a/packages/lodestar/test/unit/api/impl/validator/produceAttestationData.test.ts
+++ b/packages/lodestar/test/unit/api/impl/validator/produceAttestationData.test.ts
@@ -55,6 +55,6 @@ describe("api - validator - produceAttestationData", function () {
 
     // Should not allow any call to validator API
     const api = getValidatorApi(modules);
-    await expect(api.produceAttestationData(0, 0)).to.be.rejectedWith("Node is waiting for peers");
+    await expect(api.produceAttestationData(0, 0)).to.be.rejectedWith("Node is syncing - waiting for peers");
   });
 });

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -1,10 +1,9 @@
 import {AbortSignal} from "@chainsafe/abort-controller";
-import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {phase0, Slot, CommitteeIndex, ssz} from "@chainsafe/lodestar-types";
 import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
-import {ILogger, prettyBytes, sleep} from "@chainsafe/lodestar-utils";
+import {prettyBytes, sleep} from "@chainsafe/lodestar-utils";
 import {Api} from "@chainsafe/lodestar-api";
-import {extendError, notAborted, IClock} from "../util";
+import {extendError, notAborted, IClock, ILoggerVc} from "../util";
 import {ValidatorStore} from "./validatorStore";
 import {AttestationDutiesService, AttDutyAndProof} from "./attestationDuties";
 import {groupAttDutiesByCommitteeIndex} from "./utils";
@@ -17,14 +16,13 @@ export class AttestationService {
   private readonly dutiesService: AttestationDutiesService;
 
   constructor(
-    private readonly config: IChainForkConfig,
-    private readonly logger: ILogger,
+    private readonly logger: ILoggerVc,
     private readonly api: Api,
     private readonly clock: IClock,
     private readonly validatorStore: ValidatorStore,
     indicesService: IndicesService
   ) {
-    this.dutiesService = new AttestationDutiesService(config, logger, api, clock, validatorStore, indicesService);
+    this.dutiesService = new AttestationDutiesService(logger, api, clock, validatorStore, indicesService);
 
     // At most every slot, check existing duties from AttestationDutiesService and run tasks
     clock.runEverySlot(this.runAttestationTasks);

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -1,12 +1,9 @@
 import {computeEpochAtSlot, isAggregatorFromCommitteeLength} from "@chainsafe/lodestar-beacon-state-transition";
-import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {BLSSignature, Epoch, Root, Slot, ssz, ValidatorIndex} from "@chainsafe/lodestar-types";
-import {ILogger} from "@chainsafe/lodestar-utils";
 import {Api, routes} from "@chainsafe/lodestar-api";
 import {toHexString} from "@chainsafe/ssz";
 import {IndicesService} from "./indices";
-import {extendError, notAborted} from "../util";
-import {IClock} from "../util/clock";
+import {IClock, extendError, notAborted, isSyncing, ILoggerVc} from "../util";
 import {ValidatorStore} from "./validatorStore";
 
 /** Only retain `HISTORICAL_DUTIES_EPOCHS` duties prior to the current epoch. */
@@ -27,8 +24,7 @@ export class AttestationDutiesService {
   private readonly dutiesByEpochByIndex = new Map<ValidatorIndex, Map<Epoch, AttDutyAtEpoch>>();
 
   constructor(
-    private readonly config: IChainForkConfig,
-    private readonly logger: ILogger,
+    private readonly logger: ILoggerVc,
     private readonly api: Api,
     clock: IClock,
     private readonly validatorStore: ValidatorStore,
@@ -95,7 +91,8 @@ export class AttestationDutiesService {
     for (const epoch of [currentEpoch, nextEpoch]) {
       // Download the duties and update the duties for the current and next epoch.
       await this.pollBeaconAttestersForEpoch(epoch, indexArr).catch((e) => {
-        if (notAborted(e)) this.logger.error("Failed to download attester duties", {epoch}, e);
+        if (isSyncing(e)) this.logger.isSyncing(e);
+        else if (notAborted(e)) this.logger.error("Failed to download attester duties", {epoch}, e);
       });
     }
 

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -1,12 +1,10 @@
 import {BLSPubkey, Slot} from "@chainsafe/lodestar-types";
-import {IChainForkConfig} from "@chainsafe/lodestar-config";
-import {ILogger, prettyBytes} from "@chainsafe/lodestar-utils";
+import {prettyBytes} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
 import {Api} from "@chainsafe/lodestar-api";
-import {extendError, notAborted} from "../util";
+import {IClock, extendError, notAborted, ILoggerVc} from "../util";
 import {ValidatorStore} from "./validatorStore";
 import {BlockDutiesService, GENESIS_SLOT} from "./blockDuties";
-import {IClock} from "../util/clock";
 
 /**
  * Service that sets up and handles validator block proposal duties.
@@ -15,21 +13,13 @@ export class BlockProposingService {
   private readonly dutiesService: BlockDutiesService;
 
   constructor(
-    config: IChainForkConfig,
-    private readonly logger: ILogger,
+    private readonly logger: ILoggerVc,
     private readonly api: Api,
     clock: IClock,
     private readonly validatorStore: ValidatorStore,
     private readonly graffiti?: string
   ) {
-    this.dutiesService = new BlockDutiesService(
-      config,
-      logger,
-      api,
-      clock,
-      validatorStore,
-      this.notifyBlockProductionFn
-    );
+    this.dutiesService = new BlockDutiesService(logger, api, clock, validatorStore, this.notifyBlockProductionFn);
   }
 
   /**

--- a/packages/validator/src/services/blockDuties.ts
+++ b/packages/validator/src/services/blockDuties.ts
@@ -1,12 +1,8 @@
 import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
-import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {BLSPubkey, Epoch, Root, Slot, ssz} from "@chainsafe/lodestar-types";
-import {ILogger} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
 import {Api, routes} from "@chainsafe/lodestar-api";
-import {extendError, notAborted} from "../util";
-import {IClock} from "../util/clock";
-import {differenceHex} from "../util/difference";
+import {IClock, extendError, isSyncing, notAborted, differenceHex, ILoggerVc} from "../util";
 import {ValidatorStore} from "./validatorStore";
 
 /** Only retain `HISTORICAL_DUTIES_EPOCHS` duties prior to the current epoch */
@@ -26,8 +22,7 @@ export class BlockDutiesService {
   private readonly proposers = new Map<Epoch, BlockDutyAtEpoch>();
 
   constructor(
-    private readonly config: IChainForkConfig,
-    private readonly logger: ILogger,
+    private readonly logger: ILoggerVc,
     private readonly api: Api,
     clock: IClock,
     private readonly validatorStore: ValidatorStore,
@@ -64,17 +59,20 @@ export class BlockDutiesService {
   }
 
   private runBlockDutiesTask = async (slot: Slot): Promise<void> => {
-    if (slot < 0) {
-      // Before genesis, fetch the genesis duties but don't notify block production
-      // Only fetch duties once since there is not possible to re-org. TODO: Review
-      if (!this.proposers.has(GENESIS_EPOCH)) {
-        await this.pollBeaconProposers(GENESIS_EPOCH);
+    try {
+      if (slot < 0) {
+        // Before genesis, fetch the genesis duties but don't notify block production
+        // Only fetch duties once since there is not possible to re-org. TODO: Review
+        if (!this.proposers.has(GENESIS_EPOCH)) {
+          await this.pollBeaconProposers(GENESIS_EPOCH);
+        }
+      } else {
+        await this.pollBeaconProposersAndNotify(slot);
       }
-    } else {
-      await this.pollBeaconProposersAndNotify(slot).catch((e) => {
-        if (notAborted(e)) this.logger.error("Error on pollBeaconProposers", {}, e);
-      });
-
+    } catch (e) {
+      if (isSyncing(e)) this.logger.isSyncing(e);
+      else if (notAborted(e)) this.logger.error("Error on pollBeaconProposers", {}, e);
+    } finally {
       this.pruneOldDuties(computeEpochAtSlot(slot));
     }
   };

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -1,14 +1,14 @@
 import {AbortSignal} from "@chainsafe/abort-controller";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {Slot, CommitteeIndex, altair, Root} from "@chainsafe/lodestar-types";
-import {ILogger, prettyBytes, sleep} from "@chainsafe/lodestar-utils";
+import {prettyBytes, sleep} from "@chainsafe/lodestar-utils";
+import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {Api} from "@chainsafe/lodestar-api";
-import {extendError, notAborted, IClock} from "../util";
+import {IClock, extendError, notAborted, ILoggerVc} from "../util";
 import {ValidatorStore} from "./validatorStore";
 import {SyncCommitteeDutiesService, SyncDutyAndProofs} from "./syncCommitteeDuties";
 import {groupSyncDutiesBySubCommitteeIndex, SubCommitteeDuty} from "./utils";
 import {IndicesService} from "./indices";
-import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 
 /**
  * Service that sets up and handles validator sync duties.
@@ -18,7 +18,7 @@ export class SyncCommitteeService {
 
   constructor(
     private readonly config: IChainForkConfig,
-    private readonly logger: ILogger,
+    private readonly logger: ILoggerVc,
     private readonly api: Api,
     private readonly clock: IClock,
     private readonly validatorStore: ValidatorStore,

--- a/packages/validator/src/util/error.ts
+++ b/packages/validator/src/util/error.ts
@@ -1,3 +1,4 @@
+import {HttpError} from "@chainsafe/lodestar-api";
 import {ErrorAborted} from "@chainsafe/lodestar-utils";
 
 /**
@@ -13,4 +14,12 @@ export function extendError(e: Error, prependMessage: string): Error {
  */
 export function notAborted(e: Error): boolean {
   return !(e instanceof ErrorAborted);
+}
+
+/**
+ * Returns true if it's an network error with code 503 = Node is syncing
+ * https://github.com/ethereum/eth2.0-APIs/blob/e68a954e1b6f6eb5421abf4532c171ce301c6b2e/types/http.yaml#L62
+ */
+export function isSyncing(e: Error): boolean {
+  return !(e instanceof HttpError && e.status === 503);
 }

--- a/packages/validator/src/util/index.ts
+++ b/packages/validator/src/util/index.ts
@@ -1,3 +1,6 @@
 export * from "./clock";
+export * from "./difference";
 export * from "./error";
+export * from "./logger";
+export * from "./params";
 export * from "./url";

--- a/packages/validator/src/util/logger.ts
+++ b/packages/validator/src/util/logger.ts
@@ -1,0 +1,34 @@
+import {ILogger} from "@chainsafe/lodestar-utils";
+import {IClock} from "./clock";
+
+export type ILoggerVc = Pick<ILogger, "error" | "warn" | "info" | "verbose" | "debug"> & {
+  isSyncing(e: Error): void;
+};
+
+export function getLoggerVc(logger: ILogger, clock: IClock): ILoggerVc {
+  let hasLogged = false;
+
+  clock.runEverySlot(async () => {
+    if (hasLogged) hasLogged = false;
+  });
+
+  return {
+    error: logger.error.bind(logger),
+    warn: logger.warn.bind(logger),
+    info: logger.info.bind(logger),
+    verbose: logger.verbose.bind(logger),
+    debug: logger.debug.bind(logger),
+
+    /**
+     * Throttle "node is syncing" errors to not pollute the console too much.
+     * Logs once per slot at most.
+     */
+    isSyncing(e: Error) {
+      if (!hasLogged) {
+        hasLogged = true;
+        // Log the full error message, in case the server returns 503 for some unknown reason
+        logger.info(`Node is syncing - ${e.message}`);
+      }
+    },
+  };
+}

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -14,7 +14,7 @@ import {AttestationService} from "./services/attestation";
 import {IndicesService} from "./services/indices";
 import {SyncCommitteeService} from "./services/syncCommittee";
 import {ISlashingProtection} from "./slashingProtection";
-import {assertEqualParams} from "./util/params";
+import {assertEqualParams, getLoggerVc} from "./util";
 
 export type ValidatorOptions = {
   slashingProtection: ISlashingProtection;
@@ -63,9 +63,10 @@ export class Validator {
     const clock = new Clock(config, logger, {genesisTime: Number(genesis.genesisTime)});
     const validatorStore = new ValidatorStore(config, slashingProtection, secretKeys, genesis);
     const indicesService = new IndicesService(logger, api, validatorStore);
-    new BlockProposingService(config, logger, api, clock, validatorStore, graffiti);
-    new AttestationService(config, logger, api, clock, validatorStore, indicesService);
-    new SyncCommitteeService(config, logger, api, clock, validatorStore, indicesService);
+    const loggerVc = getLoggerVc(logger, clock);
+    new BlockProposingService(loggerVc, api, clock, validatorStore, graffiti);
+    new AttestationService(loggerVc, api, clock, validatorStore, indicesService);
+    new SyncCommitteeService(config, loggerVc, api, clock, validatorStore, indicesService);
 
     this.config = config;
     this.logger = logger;

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -2,7 +2,6 @@ import {AbortController} from "@chainsafe/abort-controller";
 import {expect} from "chai";
 import sinon from "sinon";
 import bls from "@chainsafe/bls";
-import {config as mainnetConfig} from "@chainsafe/lodestar-config/default";
 import {
   generateEmptyAttestation,
   generateEmptySignedAggregateAndProof,
@@ -11,10 +10,9 @@ import {AttestationService} from "../../../src/services/attestation";
 import {AttDutyAndProof} from "../../../src/services/attestationDuties";
 import {ValidatorStore} from "../../../src/services/validatorStore";
 import {getApiClientStub} from "../../utils/apiStub";
-import {testLogger} from "../../utils/logger";
+import {loggerVc, testLogger} from "../../utils/logger";
 import {ClockMock} from "../../utils/clock";
 import {IndicesService} from "../../../src/services/indices";
-import {createIChainForkConfig} from "@chainsafe/lodestar-config";
 
 describe("AttestationService", function () {
   const sandbox = sinon.createSandbox();
@@ -25,13 +23,6 @@ describe("AttestationService", function () {
   const validatorStore = sinon.createStubInstance(ValidatorStore) as ValidatorStore &
     sinon.SinonStubbedInstance<ValidatorStore>;
   let pubkeys: Uint8Array[]; // Initialize pubkeys in before() so bls is already initialized
-
-  // Clone before mutating
-  const config: typeof mainnetConfig = createIChainForkConfig({
-    ...mainnetConfig,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    SECONDS_PER_SLOT: 1 / 1000, // Make slot time super short: 1 ms
-  });
 
   before(() => {
     const secretKeys = Array.from({length: 1}, (_, i) => bls.SecretKey.fromBytes(Buffer.alloc(32, i + 1)));
@@ -49,7 +40,7 @@ describe("AttestationService", function () {
   it("Should produce, sign, and publish an attestation + aggregate", async () => {
     const clock = new ClockMock();
     const indicesService = new IndicesService(logger, api, validatorStore);
-    const attestationService = new AttestationService(config, logger, api, clock, validatorStore, indicesService);
+    const attestationService = new AttestationService(loggerVc, api, clock, validatorStore, indicesService);
 
     const attestation = generateEmptyAttestation();
     const aggregate = generateEmptySignedAggregateAndProof();

--- a/packages/validator/test/unit/services/attestationDuties.test.ts
+++ b/packages/validator/test/unit/services/attestationDuties.test.ts
@@ -3,13 +3,12 @@ import {toBufferBE} from "bigint-buffer";
 import {expect} from "chai";
 import sinon from "sinon";
 import bls from "@chainsafe/bls";
-import {config} from "@chainsafe/lodestar-config/default";
 import {toHexString} from "@chainsafe/ssz";
 import {routes} from "@chainsafe/lodestar-api";
 import {AttestationDutiesService} from "../../../src/services/attestationDuties";
 import {ValidatorStore} from "../../../src/services/validatorStore";
 import {getApiClientStub} from "../../utils/apiStub";
-import {testLogger} from "../../utils/logger";
+import {loggerVc, testLogger} from "../../utils/logger";
 import {ClockMock} from "../../utils/clock";
 import {IndicesService} from "../../../src/services/indices";
 import {ssz} from "@chainsafe/lodestar-types";
@@ -74,7 +73,7 @@ describe("AttestationDutiesService", function () {
     // Clock will call runAttesterDutiesTasks() immediatelly
     const clock = new ClockMock();
     const indicesService = new IndicesService(logger, api, validatorStore);
-    const dutiesService = new AttestationDutiesService(config, logger, api, clock, validatorStore, indicesService);
+    const dutiesService = new AttestationDutiesService(loggerVc, api, clock, validatorStore, indicesService);
 
     // Trigger clock onSlot for slot 0
     await clock.tickEpochFns(0, controller.signal);

--- a/packages/validator/test/unit/services/block.test.ts
+++ b/packages/validator/test/unit/services/block.test.ts
@@ -2,7 +2,6 @@ import {AbortController} from "@chainsafe/abort-controller";
 import {expect} from "chai";
 import sinon from "sinon";
 import bls from "@chainsafe/bls";
-import {config} from "@chainsafe/lodestar-config/default";
 import {Root} from "@chainsafe/lodestar-types";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {routes} from "@chainsafe/lodestar-api";
@@ -10,7 +9,7 @@ import {generateEmptySignedBlock} from "@chainsafe/lodestar/test/utils/block";
 import {BlockProposingService} from "../../../src/services/block";
 import {ValidatorStore} from "../../../src/services/validatorStore";
 import {getApiClientStub} from "../../utils/apiStub";
-import {testLogger} from "../../utils/logger";
+import {loggerVc} from "../../utils/logger";
 import {ClockMock} from "../../utils/clock";
 import {ForkName} from "@chainsafe/lodestar-params";
 
@@ -18,7 +17,6 @@ type ProposerDutiesRes = {dependentRoot: Root; data: routes.validator.ProposerDu
 
 describe("BlockDutiesService", function () {
   const sandbox = sinon.createSandbox();
-  const logger = testLogger();
   const ZERO_HASH = Buffer.alloc(32, 0);
 
   const api = getApiClientStub(sandbox);
@@ -46,7 +44,7 @@ describe("BlockDutiesService", function () {
     api.validator.getProposerDuties.resolves(duties);
 
     const clock = new ClockMock();
-    const blockService = new BlockProposingService(config, logger, api, clock, validatorStore);
+    const blockService = new BlockProposingService(loggerVc, api, clock, validatorStore);
 
     const signedBlock = generateEmptySignedBlock();
     validatorStore.signRandao.resolves(signedBlock.message.body.randaoReveal);

--- a/packages/validator/test/unit/services/blockDuties.test.ts
+++ b/packages/validator/test/unit/services/blockDuties.test.ts
@@ -2,20 +2,18 @@ import {AbortController} from "@chainsafe/abort-controller";
 import {expect} from "chai";
 import sinon from "sinon";
 import bls from "@chainsafe/bls";
-import {config} from "@chainsafe/lodestar-config/default";
 import {Root} from "@chainsafe/lodestar-types";
 import {routes} from "@chainsafe/lodestar-api";
 import {BlockDutiesService} from "../../../src/services/blockDuties";
 import {ValidatorStore} from "../../../src/services/validatorStore";
 import {getApiClientStub} from "../../utils/apiStub";
-import {testLogger} from "../../utils/logger";
+import {loggerVc} from "../../utils/logger";
 import {ClockMock} from "../../utils/clock";
 
 type ProposerDutiesRes = {dependentRoot: Root; data: routes.validator.ProposerDuty[]};
 
 describe("BlockDutiesService", function () {
   const sandbox = sinon.createSandbox();
-  const logger = testLogger();
   const ZERO_HASH = Buffer.alloc(32, 0);
 
   const api = getApiClientStub(sandbox);
@@ -47,7 +45,7 @@ describe("BlockDutiesService", function () {
     const notifyBlockProductionFn = sinon.stub(); // Returns void
 
     const clock = new ClockMock();
-    const dutiesService = new BlockDutiesService(config, logger, api, clock, validatorStore, notifyBlockProductionFn);
+    const dutiesService = new BlockDutiesService(loggerVc, api, clock, validatorStore, notifyBlockProductionFn);
 
     // Trigger clock onSlot for slot 0
     await clock.tickSlotFns(0, controller.signal);
@@ -82,7 +80,7 @@ describe("BlockDutiesService", function () {
 
     // Clock will call runAttesterDutiesTasks() immediatelly
     const clock = new ClockMock();
-    const dutiesService = new BlockDutiesService(config, logger, api, clock, validatorStore, notifyBlockProductionFn);
+    const dutiesService = new BlockDutiesService(loggerVc, api, clock, validatorStore, notifyBlockProductionFn);
 
     // Trigger clock onSlot for slot 0
     api.validator.getProposerDuties.resolves(dutiesBeforeReorg);

--- a/packages/validator/test/unit/services/syncCommitteDuties.test.ts
+++ b/packages/validator/test/unit/services/syncCommitteDuties.test.ts
@@ -10,7 +10,7 @@ import {routes} from "@chainsafe/lodestar-api";
 import {SyncCommitteeDutiesService} from "../../../src/services/syncCommitteeDuties";
 import {ValidatorStore} from "../../../src/services/validatorStore";
 import {getApiClientStub} from "../../utils/apiStub";
-import {testLogger} from "../../utils/logger";
+import {loggerVc, testLogger} from "../../utils/logger";
 import {ClockMock} from "../../utils/clock";
 import {IndicesService} from "../../../src/services/indices";
 import {ssz} from "@chainsafe/lodestar-types";
@@ -78,7 +78,7 @@ describe("SyncCommitteeDutiesService", function () {
     // Clock will call runAttesterDutiesTasks() immediatelly
     const clock = new ClockMock();
     const indicesService = new IndicesService(logger, api, validatorStore);
-    const dutiesService = new SyncCommitteeDutiesService(config, logger, api, clock, validatorStore, indicesService);
+    const dutiesService = new SyncCommitteeDutiesService(config, loggerVc, api, clock, validatorStore, indicesService);
 
     // Trigger clock onSlot for slot 0
     await clock.tickEpochFns(0, controller.signal);

--- a/packages/validator/test/unit/services/syncCommittee.test.ts
+++ b/packages/validator/test/unit/services/syncCommittee.test.ts
@@ -8,7 +8,7 @@ import {SyncCommitteeService} from "../../../src/services/syncCommittee";
 import {SyncDutyAndProofs} from "../../../src/services/syncCommitteeDuties";
 import {ValidatorStore} from "../../../src/services/validatorStore";
 import {getApiClientStub} from "../../utils/apiStub";
-import {testLogger} from "../../utils/logger";
+import {loggerVc, testLogger} from "../../utils/logger";
 import {ClockMock} from "../../utils/clock";
 import {IndicesService} from "../../../src/services/indices";
 import {ssz} from "@chainsafe/lodestar-types";
@@ -47,7 +47,7 @@ describe("SyncCommitteeService", function () {
   it("Should produce, sign, and publish a sync committee + contribution", async () => {
     const clock = new ClockMock();
     const indicesService = new IndicesService(logger, api, validatorStore);
-    const syncCommitteeService = new SyncCommitteeService(config, logger, api, clock, validatorStore, indicesService);
+    const syncCommitteeService = new SyncCommitteeService(config, loggerVc, api, clock, validatorStore, indicesService);
 
     const beaconBlockRoot = Buffer.alloc(32, 0x4d);
     const syncCommitteeSignature = ssz.altair.SyncCommitteeMessage.defaultValue();

--- a/packages/validator/test/utils/logger.ts
+++ b/packages/validator/test/utils/logger.ts
@@ -1,4 +1,6 @@
 import {WinstonLogger, LogLevel} from "@chainsafe/lodestar-utils";
+import {getLoggerVc} from "../../src/util";
+import {ClockMock} from "./clock";
 
 /**
  * Run the test with ENVs to control log level:
@@ -18,3 +20,5 @@ function getLogLevel(): LogLevel {
   if (process.env["VERBOSE"]) return LogLevel.verbose;
   return LogLevel.error;
 }
+
+export const loggerVc = getLoggerVc(testLogger(), new ClockMock());


### PR DESCRIPTION
**Motivation**

Our node + validator client are very verbose and alarming when the node is just syncing, see https://github.com/ChainSafe/lodestar/issues/2790

**Description**

- On the node side: Don't log at all NodeIsSyncing errors

- On the validator side: Log at most once per slot at info level that the node is syncing

Closes https://github.com/ChainSafe/lodestar/issues/2790