### PR TITLE
Handle forkChoiceFinalized event - skipped slot checkpoint

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -3,11 +3,7 @@
  */
 
 import {ForkName} from "@chainsafe/lodestar-params";
-import {
-  CachedBeaconState,
-  computeEpochAtSlot,
-  computeStartSlotAtEpoch,
-} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconState, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {allForks, ForkDigest, Number64, Root, phase0, Slot} from "@chainsafe/lodestar-types";
@@ -182,8 +178,8 @@ export class BeaconChain implements IBeaconChain {
   }
 
   async getCanonicalBlockAtSlot(slot: Slot): Promise<allForks.SignedBeaconBlock | null> {
-    const finalizedCheckpoint = this.forkChoice.getFinalizedCheckpoint();
-    if (finalizedCheckpoint.epoch > computeEpochAtSlot(slot)) {
+    const finalizedBlock = this.forkChoice.getFinalizedBlock();
+    if (finalizedBlock.slot > slot) {
       return this.db.blockArchive.get(slot);
     }
     const summary = this.forkChoice.getCanonicalBlockSummaryAtSlot(slot);

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -169,12 +169,20 @@ export function onJustified(
 export async function onFinalized(this: BeaconChain, cp: phase0.Checkpoint): Promise<void> {
   this.logger.verbose("Checkpoint finalized", ssz.phase0.Checkpoint.toJson(cp));
   this.metrics?.finalizedEpoch.set(cp.epoch);
+}
 
+export function onForkChoiceJustified(this: BeaconChain, cp: phase0.Checkpoint): void {
+  this.logger.verbose("Fork choice justified", ssz.phase0.Checkpoint.toJson(cp));
+}
+
+export async function onForkChoiceFinalized(this: BeaconChain, cp: phase0.Checkpoint): Promise<void> {
+  this.logger.verbose("Fork choice finalized", ssz.phase0.Checkpoint.toJson(cp));
   // Only after altair
   if (cp.epoch >= this.config.ALTAIR_FORK_EPOCH) {
     try {
       const state = await this.regen.getCheckpointState(cp);
-      const block = await this.getCanonicalBlockAtSlot(state.slot);
+      // using state.slot is not correct for a checkpoint with skipped slot
+      const block = await this.getCanonicalBlockAtSlot(state.latestBlockHeader.slot);
       if (!block) {
         throw Error(`No block found for checkpoint ${cp.epoch} : ${toHexString(cp.root)}`);
       }
@@ -188,14 +196,6 @@ export async function onFinalized(this: BeaconChain, cp: phase0.Checkpoint): Pro
       this.logger.error("Error lightclientUpdater.onFinalized", {epoch: cp.epoch}, e);
     }
   }
-}
-
-export function onForkChoiceJustified(this: BeaconChain, cp: phase0.Checkpoint): void {
-  this.logger.verbose("Fork choice justified", ssz.phase0.Checkpoint.toJson(cp));
-}
-
-export function onForkChoiceFinalized(this: BeaconChain, cp: phase0.Checkpoint): void {
-  this.logger.verbose("Fork choice finalized", ssz.phase0.Checkpoint.toJson(cp));
 }
 
 export function onForkChoiceHead(this: BeaconChain, head: IBlockSummary): void {


### PR DESCRIPTION
**Motivation**

It failed to handle finalized checkpoint event for skipped slot

**Description**

+ Use `ChainEvent.forkChoiceFinalized` event instead of `ChainEvent.finalized` to coordinate with archive tasks
+ For a skipped slot checkpoint state, use `state.latestBlockHeader.slot` instead of `state.slot` since there is no block at `state.slot`

Closes #2643

**Steps to test or reproduce**

Sync `yeerongpilly`