### PR TITLE
SyncCommittee: track chain head by event stream api

### DIFF
--- a/packages/validator/src/constants.ts
+++ b/packages/validator/src/constants.ts
@@ -1,0 +1,1 @@
+export const ZERO_HASH = Buffer.alloc(32, 0);

--- a/packages/validator/src/constants.ts
+++ b/packages/validator/src/constants.ts
@@ -1,1 +1,0 @@
-export const ZERO_HASH = Buffer.alloc(32, 0);

--- a/packages/validator/src/services/chainHeaderTracker.ts
+++ b/packages/validator/src/services/chainHeaderTracker.ts
@@ -1,0 +1,39 @@
+import {Api, routes} from "@chainsafe/lodestar-api";
+import {phase0} from "@chainsafe/lodestar-types";
+import {GENESIS_SLOT} from "@chainsafe/lodestar-params";
+import {ZERO_HASH} from "../constants";
+
+const {EventType} = routes.events;
+
+/**
+ * Track the head slot/root using the event stream api "head".
+ */
+export class ChainHeaderTracker {
+  private headBlockSlot: phase0.Slot;
+  private headBlockRoot: phase0.Root;
+
+  constructor(private readonly api: Api) {
+    this.headBlockSlot = GENESIS_SLOT;
+    this.headBlockRoot = ZERO_HASH;
+  }
+
+  start(signal: AbortSignal): void {
+    this.api.events.eventstream([EventType.head], signal, this.onHeadUpdate);
+  }
+
+  getCurrentChainHead(slot: phase0.Slot): phase0.Root | null {
+    if (slot > this.headBlockSlot) {
+      return this.headBlockRoot;
+    }
+    // We don't know head of an old block
+    return null;
+  }
+
+  private onHeadUpdate = (event: routes.events.BeaconEvent): void => {
+    if (event.type === EventType.head) {
+      const {message} = event;
+      this.headBlockSlot = message.slot;
+      this.headBlockRoot = message.block;
+    }
+  };
+}

--- a/packages/validator/src/services/chainHeaderTracker.ts
+++ b/packages/validator/src/services/chainHeaderTracker.ts
@@ -25,7 +25,7 @@ export class ChainHeaderTracker {
   }
 
   getCurrentChainHead(slot: phase0.Slot): phase0.Root | null {
-    if (slot > this.headBlockSlot) {
+    if (slot >= this.headBlockSlot) {
       return this.headBlockRoot;
     }
     // We don't know head of an old block

--- a/packages/validator/src/services/chainHeaderTracker.ts
+++ b/packages/validator/src/services/chainHeaderTracker.ts
@@ -2,7 +2,6 @@ import {Api, routes} from "@chainsafe/lodestar-api";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {phase0} from "@chainsafe/lodestar-types";
 import {GENESIS_SLOT} from "@chainsafe/lodestar-params";
-import {ZERO_HASH} from "../constants";
 import {toHexString} from "@chainsafe/ssz";
 
 const {EventType} = routes.events;
@@ -12,11 +11,11 @@ const {EventType} = routes.events;
  */
 export class ChainHeaderTracker {
   private headBlockSlot: phase0.Slot;
-  private headBlockRoot: phase0.Root;
+  private headBlockRoot: phase0.Root | null;
 
   constructor(private readonly logger: ILogger, private readonly api: Api) {
     this.headBlockSlot = GENESIS_SLOT;
-    this.headBlockRoot = ZERO_HASH;
+    this.headBlockRoot = null;
   }
 
   start(signal: AbortSignal): void {

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -93,9 +93,12 @@ export class SyncCommitteeService {
     // Spec: the validator should prepare a SyncCommitteeMessage for the previous slot (slot - 1)
     // as soon as they have determined the head block of slot - 1
 
-    const blockRoot = this.chainHeaderTracker.getCurrentChainHead(slot);
+    let blockRoot = this.chainHeaderTracker.getCurrentChainHead(slot);
     if (blockRoot === null) {
-      throw new Error("not able to get head at slot " + slot);
+      const blockRootData = await this.api.beacon.getBlockRoot("head").catch((e) => {
+        throw extendError(e, "Error producing SyncCommitteeMessage");
+      });
+      blockRoot = blockRootData.data;
     }
 
     const signatures: altair.SyncCommitteeMessage[] = [];

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -65,7 +65,7 @@ export class Validator {
     const clock = new Clock(config, logger, {genesisTime: Number(genesis.genesisTime)});
     const validatorStore = new ValidatorStore(config, slashingProtection, secretKeys, genesis);
     const indicesService = new IndicesService(logger, api, validatorStore);
-    this.chainHeaderTracker = new ChainHeaderTracker(api);
+    this.chainHeaderTracker = new ChainHeaderTracker(logger, api);
     const loggerVc = getLoggerVc(logger, clock);
     new BlockProposingService(loggerVc, api, clock, validatorStore, graffiti);
     new AttestationService(loggerVc, api, clock, validatorStore, indicesService);

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -15,6 +15,7 @@ import {IndicesService} from "./services/indices";
 import {SyncCommitteeService} from "./services/syncCommittee";
 import {ISlashingProtection} from "./slashingProtection";
 import {assertEqualParams, getLoggerVc} from "./util";
+import {ChainHeaderTracker} from "./services/chainHeaderTracker";
 
 export type ValidatorOptions = {
   slashingProtection: ISlashingProtection;
@@ -44,6 +45,7 @@ export class Validator {
   private readonly api: Api;
   private readonly secretKeys: SecretKey[];
   private readonly clock: IClock;
+  private readonly chainHeaderTracker: ChainHeaderTracker;
   private readonly logger: ILogger;
   private state: State = {status: Status.stopped};
 
@@ -63,10 +65,11 @@ export class Validator {
     const clock = new Clock(config, logger, {genesisTime: Number(genesis.genesisTime)});
     const validatorStore = new ValidatorStore(config, slashingProtection, secretKeys, genesis);
     const indicesService = new IndicesService(logger, api, validatorStore);
+    this.chainHeaderTracker = new ChainHeaderTracker(api);
     const loggerVc = getLoggerVc(logger, clock);
     new BlockProposingService(loggerVc, api, clock, validatorStore, graffiti);
     new AttestationService(loggerVc, api, clock, validatorStore, indicesService);
-    new SyncCommitteeService(config, loggerVc, api, clock, validatorStore, indicesService);
+    new SyncCommitteeService(config, loggerVc, api, clock, validatorStore, this.chainHeaderTracker, indicesService);
 
     this.config = config;
     this.logger = logger;
@@ -99,8 +102,9 @@ export class Validator {
     if (this.state.status === Status.running) return;
     const controller = new AbortController();
     this.state = {status: Status.running, controller};
-
-    this.clock.start(controller.signal);
+    const {signal} = controller;
+    this.clock.start(signal);
+    this.chainHeaderTracker.start(signal);
   }
 
   /**

--- a/packages/validator/test/unit/services/syncCommittee.test.ts
+++ b/packages/validator/test/unit/services/syncCommittee.test.ts
@@ -12,6 +12,7 @@ import {loggerVc, testLogger} from "../../utils/logger";
 import {ClockMock} from "../../utils/clock";
 import {IndicesService} from "../../../src/services/indices";
 import {ssz} from "@chainsafe/lodestar-types";
+import {ChainHeaderTracker} from "../../../src/services/chainHeaderTracker";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -23,6 +24,8 @@ describe("SyncCommitteeService", function () {
   const api = getApiClientStub(sandbox);
   const validatorStore = sinon.createStubInstance(ValidatorStore) as ValidatorStore &
     sinon.SinonStubbedInstance<ValidatorStore>;
+  const chainHeaderTracker = sinon.createStubInstance(ChainHeaderTracker) as ChainHeaderTracker &
+    sinon.SinonStubbedInstance<ChainHeaderTracker>;
   let pubkeys: Uint8Array[]; // Initialize pubkeys in before() so bls is already initialized
 
   const config = createIChainForkConfig({
@@ -47,7 +50,15 @@ describe("SyncCommitteeService", function () {
   it("Should produce, sign, and publish a sync committee + contribution", async () => {
     const clock = new ClockMock();
     const indicesService = new IndicesService(logger, api, validatorStore);
-    const syncCommitteeService = new SyncCommitteeService(config, loggerVc, api, clock, validatorStore, indicesService);
+    const syncCommitteeService = new SyncCommitteeService(
+      config,
+      loggerVc,
+      api,
+      clock,
+      validatorStore,
+      chainHeaderTracker,
+      indicesService
+    );
 
     const beaconBlockRoot = Buffer.alloc(32, 0x4d);
     const syncCommitteeSignature = ssz.altair.SyncCommitteeMessage.defaultValue();
@@ -73,7 +84,7 @@ describe("SyncCommitteeService", function () {
 
     // Mock beacon's sync committee and contribution routes
 
-    api.beacon.getBlockRoot.resolves({data: beaconBlockRoot});
+    chainHeaderTracker.getCurrentChainHead.returns(beaconBlockRoot);
     api.beacon.submitPoolSyncCommitteeSignatures.resolves();
     api.validator.produceSyncCommitteeContribution.resolves({data: contribution});
     api.validator.publishContributionAndProofs.resolves();


### PR DESCRIPTION
**Motivation**

+ For SyncCommittee service, we get exact block root from a slot
+ The spec wants the head block root of chain at a slot

**Description**

+ Use event stream api to track the head slot/blockRoot so we don't have to issue http GET requests at every slot
+ This follows Teku strategy

Closes #2823

**Test with yeerongpilly**
+ Node shows that 159092 is skipped slot
```
Jul-09 08:18:30.001 []                 info: Synced - finalized: 4967 0x5dd6…2959 - head: 159091 0xe0da…1384 - clockSlot: 159092 - peers: 3
Jul-09 08:18:42.002 []                 info: Synced - finalized: 4967 0x5dd6…2959 - head: 159093 0x63fe…bd92 - clockSlot: 159093 - peers: 3
Jul-09 08:18:54.008 []                 info: Synced - finalized: 4967 0x5dd6…2959 - head: 159094 0x0b35…64eb - clockSlot: 159094 - peers: 3
```
+ Validator was still able to publish sync committee at that slot
```
Jul-09 08:18:28.861 []                 info: Published SyncCommitteeMessage slot=159092, count=78
Jul-09 08:18:29.523 []                 info: Published attestations slot=159092, index=0, count=17
Jul-09 08:18:32.287 []                 info: Published SyncCommitteeContribution slot=159092, index=1, count=1
Jul-09 08:18:32.291 []                 info: Published SyncCommitteeContribution slot=159092, index=2, count=2
```