### PR TITLE
Improve rotateEpochs and exitQueueEndChurn

### DIFF
--- a/packages/beacon-state-transition/src/allForks/stateTransition.ts
+++ b/packages/beacon-state-transition/src/allForks/stateTransition.ts
@@ -144,7 +144,7 @@ function processSlotsWithTransientCache(
         metrics?.registerValidatorStatuses(process.currentEpoch, process.statuses);
 
         postState.slot++;
-        rotateEpochs(postState.epochCtx, postState, postState.validators);
+        rotateEpochs(postState.epochCtx, postState, process.indicesBounded);
       } finally {
         if (timer) timer();
       }

--- a/packages/beacon-state-transition/src/allForks/util/epochContext.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochContext.ts
@@ -204,17 +204,12 @@ export function computeSyncParticipantReward(config: IBeaconConfig, totalActiveB
 export function rotateEpochs(
   epochCtx: EpochContext,
   state: allForks.BeaconState,
-  validators: CachedValidatorList<phase0.Validator>
+  indicesBounded: [ValidatorIndex, Epoch, Epoch][]
 ): void {
   epochCtx.previousShuffling = epochCtx.currentShuffling;
   epochCtx.currentShuffling = epochCtx.nextShuffling;
   const currEpoch = epochCtx.currentShuffling.epoch;
   const nextEpoch = currEpoch + 1;
-  const indicesBounded: [ValidatorIndex, Epoch, Epoch][] = validators.map((v, i) => [
-    i,
-    v.activationEpoch,
-    v.exitEpoch,
-  ]);
   epochCtx.nextShuffling = computeEpochShuffling(state, indicesBounded, nextEpoch);
   epochCtx.proposers = computeProposers(state, epochCtx.currentShuffling);
 

--- a/packages/beacon-state-transition/src/allForks/util/epochContext.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochContext.ts
@@ -36,7 +36,6 @@ import {
 } from "../../util";
 import {computeEpochShuffling, IEpochShuffling} from "./epochShuffling";
 import {MutableVector} from "@chainsafe/persistent-ts";
-import {CachedValidatorList} from "./cachedValidatorList";
 import {computeBaseRewardPerIncrement} from "../../altair/misc";
 
 export type AttesterDuty = {

--- a/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
@@ -121,8 +121,13 @@ export function prepareEpochProcessState<T extends allForks.BeaconState>(state: 
       activeCount += 1;
     }
 
-    if (v.exitEpoch !== FAR_FUTURE_EPOCH && v.exitEpoch > exitQueueEnd) {
-      exitQueueEnd = v.exitEpoch;
+    if (v.exitEpoch !== FAR_FUTURE_EPOCH) {
+      if (v.exitEpoch > exitQueueEnd) {
+        exitQueueEnd = v.exitEpoch;
+        exitQueueEndChurn = 1;
+      } else if (v.exitEpoch === exitQueueEnd) {
+        exitQueueEndChurn += 1;
+      }
     }
 
     if (v.activationEligibilityEpoch === FAR_FUTURE_EPOCH && v.effectiveBalance === MAX_EFFECTIVE_BALANCE) {
@@ -153,12 +158,6 @@ export function prepareEpochProcessState<T extends allForks.BeaconState>(state: 
   out.indicesToMaybeActivate.sort(
     (a, b) => out.validators[a].activationEligibilityEpoch - out.validators[b].activationEligibilityEpoch || a - b
   );
-
-  for (const validator of out.validators) {
-    if (validator.exitEpoch === exitQueueEnd) {
-      exitQueueEndChurn += 1;
-    }
-  }
 
   const churnLimit = getChurnLimit(config, activeCount);
   if (exitQueueEndChurn >= churnLimit) {

--- a/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
@@ -54,6 +54,8 @@ export interface IEpochProcess {
   statuses: IAttesterStatus[];
   validators: phase0.Validator[];
   balances?: BigUint64Array;
+  // to be used for rotateEpochs()
+  indicesBounded: [ValidatorIndex, Epoch, Epoch][];
 }
 
 export function createIEpochProcess(): IEpochProcess {
@@ -77,6 +79,7 @@ export function createIEpochProcess(): IEpochProcess {
     churnLimit: 0,
     statuses: [],
     validators: [],
+    indicesBounded: [],
   };
 }
 
@@ -136,6 +139,7 @@ export function prepareEpochProcessState<T extends allForks.BeaconState>(state: 
 
     out.statuses.push(status);
     out.validators.push(v);
+    out.indicesBounded.push([i, v.activationEpoch, v.exitEpoch]);
   });
 
   if (out.totalActiveStake < EFFECTIVE_BALANCE_INCREMENT) {

--- a/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
@@ -99,7 +99,8 @@ export function prepareEpochProcessState<T extends allForks.BeaconState>(state: 
 
   let activeCount = 0;
 
-  validators.forEach((v, i) => {
+  out.validators = validators.persistent.toArray();
+  out.validators.forEach((v, i) => {
     const status = createIAttesterStatus();
 
     if (v.slashed) {
@@ -143,7 +144,6 @@ export function prepareEpochProcessState<T extends allForks.BeaconState>(state: 
     }
 
     out.statuses.push(status);
-    out.validators.push(v);
     out.indicesBounded.push([i, v.activationEpoch, v.exitEpoch]);
   });
 


### PR DESCRIPTION
**Motivation**

+ The validator for loop inside `rotateEpochs` may take up to 700ms in Prater

**Description**
+ Save 1 validator loop in `rotateEpochs` by preparing necessary validator data in `prepareEpochProcessState`
+ Calculate exitQueueEndChurn in the main for loop of `prepareEpochProcessState`

Closes #2830

**Steps to test or reproduce**

Sync prater