### PR TITLE
Avoid recalculating rewards penalties for same effective balance

### DIFF
--- a/packages/beacon-state-transition/src/altair/epoch/balance.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/balance.ts
@@ -20,7 +20,102 @@ import {
 } from "../../allForks/util";
 import {isInInactivityLeak, newZeroedBigIntArray} from "../../util";
 
+interface IRewardPenaltyItem {
+  baseReward: bigint;
+  timelySourceReward: bigint;
+  timelySourcePenalty: bigint;
+  timelyTargetReward: bigint;
+  timelyTargetPenalty: bigint;
+  timelyHeadReward: bigint;
+}
+
 /**
+ * An aggregate of getFlagIndexDeltas and getInactivityPenaltyDeltas that loop through process.statuses 1 time instead of 4.
+ */
+export function getRewardsPenaltiesDeltas(
+  state: CachedBeaconState<altair.BeaconState>,
+  process: IEpochProcess
+): [Gwei[], Gwei[]] {
+  const validatorCount = state.validators.length;
+  const activeIncrements = process.totalActiveStake / EFFECTIVE_BALANCE_INCREMENT;
+  const rewards = newZeroedBigIntArray(validatorCount);
+  const penalties = newZeroedBigIntArray(validatorCount);
+
+  const isInInactivityLeakBn = isInInactivityLeak((state as unknown) as phase0.BeaconState);
+  const rewardPenaltyItemCache = new Map<number, IRewardPenaltyItem>();
+  const {config} = state;
+  const penaltyDenominator = config.INACTIVITY_SCORE_BIAS * INACTIVITY_PENALTY_QUOTIENT_ALTAIR;
+  for (let i = 0; i < process.statuses.length; i++) {
+    const status = process.statuses[i];
+    if (!hasMarkers(status.flags, FLAG_ELIGIBLE_ATTESTER)) {
+      continue;
+    }
+    const effectiveBalance = process.validators[i].effectiveBalance;
+    const effectiveBalanceNbr = Number(effectiveBalance);
+    let rewardPenaltyItem = rewardPenaltyItemCache.get(effectiveBalanceNbr);
+    if (!rewardPenaltyItem) {
+      const baseReward = getBaseReward(process, i);
+      const tsWeigh = PARTICIPATION_FLAG_WEIGHTS[TIMELY_SOURCE_FLAG_INDEX];
+      const ttWeigh = PARTICIPATION_FLAG_WEIGHTS[TIMELY_TARGET_FLAG_INDEX];
+      const thWeigh = PARTICIPATION_FLAG_WEIGHTS[TIMELY_HEAD_FLAG_INDEX];
+      const tsUnslashedParticipatingIncrements =
+        process.prevEpochUnslashedStake["sourceStake"] / EFFECTIVE_BALANCE_INCREMENT;
+      const ttUnslashedParticipatingIncrements =
+        process.prevEpochUnslashedStake["targetStake"] / EFFECTIVE_BALANCE_INCREMENT;
+      const thUnslashedParticipatingIncrements =
+        process.prevEpochUnslashedStake["headStake"] / EFFECTIVE_BALANCE_INCREMENT;
+      const tsRewardNumerator = baseReward * tsWeigh * tsUnslashedParticipatingIncrements;
+      const ttRewardNumerator = baseReward * ttWeigh * ttUnslashedParticipatingIncrements;
+      const thRewardNumerator = baseReward * thWeigh * thUnslashedParticipatingIncrements;
+      rewardPenaltyItem = {
+        baseReward,
+        timelySourceReward: tsRewardNumerator / (activeIncrements * WEIGHT_DENOMINATOR),
+        timelyTargetReward: ttRewardNumerator / (activeIncrements * WEIGHT_DENOMINATOR),
+        timelyHeadReward: thRewardNumerator / (activeIncrements * WEIGHT_DENOMINATOR),
+        timelySourcePenalty: (baseReward * tsWeigh) / WEIGHT_DENOMINATOR,
+        timelyTargetPenalty: (baseReward * ttWeigh) / WEIGHT_DENOMINATOR,
+      };
+      rewardPenaltyItemCache.set(effectiveBalanceNbr, rewardPenaltyItem);
+    }
+    const {
+      timelySourceReward,
+      timelySourcePenalty,
+      timelyTargetReward,
+      timelyTargetPenalty,
+      timelyHeadReward,
+    } = rewardPenaltyItem;
+    // same logic to getFlagIndexDeltas
+    if (hasMarkers(status.flags, FLAG_PREV_SOURCE_ATTESTER_OR_UNSLASHED)) {
+      if (!isInInactivityLeakBn) {
+        rewards[i] += timelySourceReward;
+      }
+    } else {
+      penalties[i] += timelySourcePenalty;
+    }
+    if (hasMarkers(status.flags, FLAG_PREV_TARGET_ATTESTER_OR_UNSLASHED)) {
+      if (!isInInactivityLeakBn) {
+        rewards[i] += timelyTargetReward;
+      }
+    } else {
+      penalties[i] += timelyTargetPenalty;
+    }
+    if (hasMarkers(status.flags, FLAG_PREV_HEAD_ATTESTER_OR_UNSLASHED)) {
+      if (!isInInactivityLeakBn) {
+        rewards[i] += timelyHeadReward;
+      }
+    }
+    // Same logic to getInactivityPenaltyDeltas
+    // TODO: if we have limited value in inactivityScores we can provide a cache too
+    if (!hasMarkers(status.flags, FLAG_PREV_TARGET_ATTESTER_OR_UNSLASHED)) {
+      const penaltyNumerator = effectiveBalance * BigInt(state.inactivityScores[i]);
+      penalties[i] += penaltyNumerator / penaltyDenominator;
+    }
+  }
+  return [rewards, penalties];
+}
+
+/**
+ * This is for spec test only as it's inefficient to loop through process.status for each flag.
  * Return the deltas for a given flag index by scanning through the participation flags.
  */
 export function getFlagIndexDeltas(
@@ -58,7 +153,7 @@ export function getFlagIndexDeltas(
     if (!hasMarkers(status.flags, FLAG_ELIGIBLE_ATTESTER)) {
       continue;
     }
-    const baseReward = getBaseReward(state, process, i);
+    const baseReward = getBaseReward(process, i);
     if (hasMarkers(status.flags, flag)) {
       if (!isInInactivityLeak((state as unknown) as phase0.BeaconState)) {
         const rewardNumerator = baseReward * weight * unslashedParticipatingIncrements;
@@ -72,6 +167,7 @@ export function getFlagIndexDeltas(
 }
 
 /**
+ * This is for spec test only as it's inefficient to loop through process.status one more time.
  * Return the inactivity penalty deltas by considering timely target participation flags and inactivity scores.
  */
 export function getInactivityPenaltyDeltas(
@@ -96,11 +192,7 @@ export function getInactivityPenaltyDeltas(
   return [rewards, penalties];
 }
 
-export function getBaseReward(
-  state: CachedBeaconState<altair.BeaconState>,
-  process: IEpochProcess,
-  index: ValidatorIndex
-): bigint {
-  const increments = state.validators[index].effectiveBalance / EFFECTIVE_BALANCE_INCREMENT;
+function getBaseReward(process: IEpochProcess, index: ValidatorIndex): bigint {
+  const increments = process.validators[index].effectiveBalance / EFFECTIVE_BALANCE_INCREMENT;
   return increments * process.baseRewardPerIncrement;
 }

--- a/packages/beacon-state-transition/src/altair/epoch/balance.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/balance.ts
@@ -42,6 +42,8 @@ export function getRewardsPenaltiesDeltas(
   const penalties = newZeroedBigIntArray(validatorCount);
 
   const isInInactivityLeakBn = isInInactivityLeak((state as unknown) as phase0.BeaconState);
+  // effectiveBalance is multiple of EFFECTIVE_BALANCE_INCREMENT and less than MAX_EFFECTIVE_BALANCE
+  // so there are limited values of them like 32000000000, 31000000000, 30000000000
   const rewardPenaltyItemCache = new Map<number, IRewardPenaltyItem>();
   const {config} = state;
   const penaltyDenominator = config.INACTIVITY_SCORE_BIAS * INACTIVITY_PENALTY_QUOTIENT_ALTAIR;

--- a/packages/beacon-state-transition/src/altair/epoch/processRewardsAndPenalties.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processRewardsAndPenalties.ts
@@ -1,8 +1,8 @@
 import {altair} from "@chainsafe/lodestar-types";
 import {getCurrentEpoch} from "../../util";
 import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
-import {getFlagIndexDeltas, getInactivityPenaltyDeltas} from "./balance";
-import {GENESIS_EPOCH, PARTICIPATION_FLAG_WEIGHTS} from "@chainsafe/lodestar-params";
+import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
+import {getRewardsPenaltiesDeltas} from "./balance";
 
 export function processRewardsAndPenalties(state: CachedBeaconState<altair.BeaconState>, process: IEpochProcess): void {
   const {balances} = state;
@@ -11,26 +11,41 @@ export function processRewardsAndPenalties(state: CachedBeaconState<altair.Beaco
     return;
   }
 
-  const flagDeltas = Array.from({length: PARTICIPATION_FLAG_WEIGHTS.length}, (_, flag) =>
-    getFlagIndexDeltas(state, process, flag)
-  );
-
-  const inactivityPenaltyDeltas = getInactivityPenaltyDeltas(state, process);
-  flagDeltas.push(inactivityPenaltyDeltas);
+  const [rewards, penalties] = getRewardsPenaltiesDeltas(state, process);
 
   const newBalances = new BigUint64Array(balances.length);
   balances.forEach((balance, i) => {
     let newBalance = balance;
-    for (const [rewards, penalties] of flagDeltas) {
-      const b = newBalance + BigInt(rewards[i] - penalties[i]);
-      if (b > 0) {
-        newBalance = b;
-      } else {
-        newBalance = BigInt(0);
-      }
+    const b = newBalance + BigInt(rewards[i] - penalties[i]);
+    if (b > 0) {
+      newBalance = b;
+    } else {
+      newBalance = BigInt(0);
     }
     newBalances[i] = newBalance;
   });
+
+  // naive version, leave here for debugging purpose
+  // const flagDeltas = Array.from({length: PARTICIPATION_FLAG_WEIGHTS.length}, (_, flag) =>
+  //   getFlagIndexDeltas(state, process, flag)
+  // );
+
+  // const inactivityPenaltyDeltas = getInactivityPenaltyDeltas(state, process);
+  // flagDeltas.push(inactivityPenaltyDeltas);
+
+  // const newBalances = new BigUint64Array(balances.length);
+  // balances.forEach((balance, i) => {
+  //   let newBalance = balance;
+  //   for (const [rewards, penalties] of flagDeltas) {
+  //     const b = newBalance + BigInt(rewards[i] - penalties[i]);
+  //     if (b > 0) {
+  //       newBalance = b;
+  //     } else {
+  //       newBalance = BigInt(0);
+  //     }
+  //   }
+  //   newBalances[i] = newBalance;
+  // });
 
   // important: do not change state one balance at a time
   // set them all at once, constructing the tree in one go

--- a/packages/beacon-state-transition/src/phase0/epoch/getAttestationDeltas.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/getAttestationDeltas.ts
@@ -24,6 +24,17 @@ const FLAG_PREV_SOURCE_ATTESTER_OR_UNSLASHED = FLAG_PREV_SOURCE_ATTESTER | FLAG_
 const FLAG_PREV_TARGET_ATTESTER_OR_UNSLASHED = FLAG_PREV_TARGET_ATTESTER | FLAG_UNSLASHED;
 const FLAG_PREV_HEAD_ATTESTER_OR_UNSLASHED = FLAG_PREV_HEAD_ATTESTER | FLAG_UNSLASHED;
 
+interface IRewardPenaltyItem {
+  baseReward: number;
+  proposerReward: number;
+  maxAttesterReward: number;
+  sourceCheckpointReward: number;
+  targetCheckpointReward: number;
+  headReward: number;
+  basePenalty: number;
+  finalityDelayPenalty: number;
+}
+
 /**
  * Return attestation reward/penalty deltas for each validator.
  */
@@ -53,24 +64,51 @@ export function getAttestationDeltas(
   const proposerRewardQuotient = Number(PROPOSER_REWARD_QUOTIENT);
   const isInInactivityLeak = finalityDelay > MIN_EPOCHS_TO_INACTIVITY_PENALTY;
 
+  const rewardPnaltyItemCache = new Map<number, IRewardPenaltyItem>();
   for (const [i, status] of process.statuses.entries()) {
     const effBalance = process.validators[i].effectiveBalance;
-    const baseReward = Number((effBalance * BASE_REWARD_FACTOR) / balanceSqRoot / BASE_REWARDS_PER_EPOCH);
-    const proposerReward = Math.floor(baseReward / proposerRewardQuotient);
+    let rewardItem = rewardPnaltyItemCache.get(Number(effBalance));
+    if (!rewardItem) {
+      const baseReward = Number((effBalance * BASE_REWARD_FACTOR) / balanceSqRoot / BASE_REWARDS_PER_EPOCH);
+      const proposerReward = Math.floor(baseReward / proposerRewardQuotient);
+      rewardItem = {
+        baseReward,
+        proposerReward,
+        maxAttesterReward: baseReward - proposerReward,
+        sourceCheckpointReward: isInInactivityLeak
+          ? baseReward
+          : Number((BigInt(baseReward) * prevEpochSourceStake) / totalBalance),
+        targetCheckpointReward: isInInactivityLeak
+          ? baseReward
+          : Number((BigInt(baseReward) * prevEpochTargetStake) / totalBalance),
+        headReward: isInInactivityLeak ? baseReward : Number((BigInt(baseReward) * prevEpochHeadStake) / totalBalance),
+        basePenalty: baseReward * BASE_REWARDS_PER_EPOCH_CONST - proposerReward,
+        finalityDelayPenalty: Number((effBalance * finalityDelay) / INACTIVITY_PENALTY_QUOTIENT),
+      };
+      rewardPnaltyItemCache.set(Number(effBalance), rewardItem);
+    }
+
+    const {
+      baseReward,
+      proposerReward,
+      maxAttesterReward,
+      sourceCheckpointReward,
+      targetCheckpointReward,
+      headReward,
+      basePenalty,
+      finalityDelayPenalty,
+    } = rewardItem;
 
     // inclusion speed bonus
     if (hasMarkers(status.flags, FLAG_PREV_SOURCE_ATTESTER_OR_UNSLASHED)) {
       rewards[status.proposerIndex] += proposerReward;
-      const maxAttesterReward = baseReward - proposerReward;
       rewards[i] += Math.floor(maxAttesterReward / status.inclusionDelay);
     }
     if (hasMarkers(status.flags, FLAG_ELIGIBLE_ATTESTER)) {
       // expected FFG source
       if (hasMarkers(status.flags, FLAG_PREV_SOURCE_ATTESTER_OR_UNSLASHED)) {
         // justification-participation reward
-        rewards[i] += isInInactivityLeak
-          ? baseReward
-          : Number((BigInt(baseReward) * prevEpochSourceStake) / totalBalance);
+        rewards[i] += sourceCheckpointReward;
       } else {
         // justification-non-participation R-penalty
         penalties[i] += baseReward;
@@ -79,9 +117,7 @@ export function getAttestationDeltas(
       // expected FFG target
       if (hasMarkers(status.flags, FLAG_PREV_TARGET_ATTESTER_OR_UNSLASHED)) {
         // boundary-attestation reward
-        rewards[i] += isInInactivityLeak
-          ? baseReward
-          : Number((BigInt(baseReward) * prevEpochTargetStake) / totalBalance);
+        rewards[i] += targetCheckpointReward;
       } else {
         // boundary-attestation-non-participation R-penalty
         penalties[i] += baseReward;
@@ -90,9 +126,7 @@ export function getAttestationDeltas(
       // expected head
       if (hasMarkers(status.flags, FLAG_PREV_HEAD_ATTESTER_OR_UNSLASHED)) {
         // canonical-participation reward
-        rewards[i] += isInInactivityLeak
-          ? baseReward
-          : Number((BigInt(baseReward) * prevEpochHeadStake) / totalBalance);
+        rewards[i] += headReward;
       } else {
         // non-canonical-participation R-penalty
         penalties[i] += baseReward;
@@ -100,10 +134,10 @@ export function getAttestationDeltas(
 
       // take away max rewards if we're not finalizing
       if (isInInactivityLeak) {
-        penalties[i] += baseReward * BASE_REWARDS_PER_EPOCH_CONST - proposerReward;
+        penalties[i] += basePenalty;
 
         if (!hasMarkers(status.flags, FLAG_PREV_TARGET_ATTESTER_OR_UNSLASHED)) {
-          penalties[i] += Number((effBalance * finalityDelay) / INACTIVITY_PENALTY_QUOTIENT);
+          penalties[i] += finalityDelayPenalty;
         }
       }
     }

--- a/packages/beacon-state-transition/src/phase0/epoch/getAttestationDeltas.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/getAttestationDeltas.ts
@@ -64,6 +64,8 @@ export function getAttestationDeltas(
   const proposerRewardQuotient = Number(PROPOSER_REWARD_QUOTIENT);
   const isInInactivityLeak = finalityDelay > MIN_EPOCHS_TO_INACTIVITY_PENALTY;
 
+  // effectiveBalance is multiple of EFFECTIVE_BALANCE_INCREMENT and less than MAX_EFFECTIVE_BALANCE
+  // so there are limited values of them like 32000000000, 31000000000, 30000000000
   const rewardPnaltyItemCache = new Map<number, IRewardPenaltyItem>();
   for (const [i, status] of process.statuses.entries()) {
     const effBalance = process.validators[i].effectiveBalance;

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/rewards_and_penalties/rewardsAndPenalties.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/rewards_and_penalties/rewardsAndPenalties.ts
@@ -1,5 +1,4 @@
 import {join} from "path";
-import {expect} from "chai";
 
 import {describeDirectorySpecTest, InputType} from "@chainsafe/lodestar-spec-test-util";
 import {altair, allForks} from "@chainsafe/lodestar-beacon-state-transition";
@@ -9,6 +8,7 @@ import {IAltairStateTestCase} from "../../stateTestCase";
 import {TreeBacked} from "@chainsafe/ssz";
 import {createIChainForkConfig} from "@chainsafe/lodestar-config";
 import {PresetName} from "@chainsafe/lodestar-params";
+import {expectEqualBeaconState} from "../../util";
 
 export function runRewardsAndPenalties(presetName: PresetName): void {
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -43,7 +43,7 @@ export function runRewardsAndPenalties(presetName: PresetName): void {
       },
       getExpected: (testCase) => testCase.post,
       expectFunc: (testCase, expected, actual) => {
-        expect(ssz.altair.BeaconState.equals(actual, expected)).to.be.true;
+        expectEqualBeaconState(expected, actual);
       },
     }
   );


### PR DESCRIPTION
**Motivation**

+ Effective balance is always a multiple of EFFECTIVE_BALANCE_INCREMENT (1ETH) and not greater than MAX_EFFECTIVE_BALANCE (32ETH) so we don't want to calculate rewards and penalties deltas from the same data
+ For altair, we calculate source/target/head/penalty rewards/penalties deltas separately, it requires multiple loops over `process.statuses` and multiple BigInt arrays

**Description**

+ Use a cache (for both phase0 and altair)
+ Altair: loop though `process.statuses` only 1 time, this combines with the cache gives an (>10x) improvement as in the benchmark diff

Closes #2832

