### PR TITLE
Add fromMnemonic option

### DIFF
--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -1,18 +1,15 @@
 import {AbortController} from "@chainsafe/abort-controller";
-import {SecretKey} from "@chainsafe/bls";
-import {interopSecretKey} from "@chainsafe/lodestar-beacon-state-transition";
 import {getClient} from "@chainsafe/lodestar-api";
 import {Validator, SlashingProtection} from "@chainsafe/lodestar-validator";
 import {LevelDbController} from "@chainsafe/lodestar-db";
 import {getBeaconConfigFromArgs} from "../../config";
 import {IGlobalArgs} from "../../options";
-import {YargsError, getDefaultGraffiti, initBLS, mkdir, getCliLogger, parseRange} from "../../util";
-import {ValidatorDirManager} from "../../validatorDir";
+import {YargsError, getDefaultGraffiti, initBLS, mkdir, getCliLogger} from "../../util";
 import {onGracefulShutdown, readLodestarGitData} from "../../util";
-import {getAccountPaths} from "../account/paths";
 import {getBeaconPaths} from "../beacon/paths";
 import {getValidatorPaths} from "./paths";
 import {IValidatorCliArgs} from "./options";
+import {getSecretKeys} from "./keys";
 
 /**
  * Run a validator client
@@ -59,15 +56,4 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
 
   onGracefulShutdownCbs.push(async () => await validator.stop());
   await validator.start();
-}
-
-async function getSecretKeys(args: IValidatorCliArgs & IGlobalArgs): Promise<SecretKey[]> {
-  if (args.interopIndexes) {
-    const indexes = parseRange(args.interopIndexes);
-    return indexes.map((index) => interopSecretKey(index));
-  } else {
-    const accountPaths = getAccountPaths(args);
-    const validatorDirManager = new ValidatorDirManager(accountPaths);
-    return await validatorDirManager.decryptAllValidators({force: args.force});
-  }
 }

--- a/packages/cli/src/cmds/validator/keys.ts
+++ b/packages/cli/src/cmds/validator/keys.ts
@@ -1,0 +1,40 @@
+import {SecretKey} from "@chainsafe/bls";
+import {deriveEth2ValidatorKeys, deriveKeyFromMnemonic} from "@chainsafe/bls-keygen";
+import {interopSecretKey} from "@chainsafe/lodestar-beacon-state-transition";
+import {defaultNetwork, IGlobalArgs} from "../../options";
+import {parseRange, YargsError} from "../../util";
+import {ValidatorDirManager} from "../../validatorDir";
+import {getAccountPaths} from "../account/paths";
+import {IValidatorCliArgs} from "./options";
+
+export async function getSecretKeys(args: IValidatorCliArgs & IGlobalArgs): Promise<SecretKey[]> {
+  // UNSAFE - ONLY USE FOR TESTNETS. Derive keys directly from a mnemonic
+  if (args.fromMnemonic) {
+    if (args.network === defaultNetwork) {
+      throw new YargsError("fromMnemonic must only be used in testnets");
+    }
+    if (!args.mnemonicIndexes) {
+      throw new YargsError("Must specify mnemonicIndexes with fromMnemonic");
+    }
+
+    const masterSK = deriveKeyFromMnemonic(args.fromMnemonic);
+    const indexes = parseRange(args.mnemonicIndexes);
+    return indexes.map((index) => {
+      const {signing} = deriveEth2ValidatorKeys(masterSK, index);
+      return SecretKey.fromBytes(signing);
+    });
+  }
+
+  // Derive interop keys
+  else if (args.interopIndexes) {
+    const indexes = parseRange(args.interopIndexes);
+    return indexes.map((index) => interopSecretKey(index));
+  }
+
+  // Read keys from local account manager
+  else {
+    const accountPaths = getAccountPaths(args);
+    const validatorDirManager = new ValidatorDirManager(accountPaths);
+    return await validatorDirManager.decryptAllValidators({force: args.force});
+  }
+}

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -11,6 +11,8 @@ export type IValidatorCliArgs = IAccountValidatorArgs &
     force: boolean;
     graffiti: string;
     interopIndexes?: string;
+    fromMnemonic?: string;
+    mnemonicIndexes?: string;
     logFile: IBeaconPaths["logFile"];
   };
 
@@ -45,6 +47,18 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
   interopIndexes: {
     hidden: true,
     description: "Range (inclusive) of interop key indexes to validate with: 0..16",
+    type: "string",
+  },
+
+  fromMnemonic: {
+    hidden: true,
+    description: "UNSAFE. Run keys from a mnemonic. Requires mnemonicIndexes option",
+    type: "string",
+  },
+
+  mnemonicIndexes: {
+    hidden: true,
+    description: "UNSAFE. Range (inclusive) of mnemonic key indexes to validate with: 0..16",
     type: "string",
   },
 };


### PR DESCRIPTION
**Motivation**

Running validators in testnets from mnemonics is very time consuming. Keystores have to be generated, encrypted and then decrypted.

**Description**

Add a hidden flag to run keys straight from a mnemonic. This option is labeled as "UNSAFE", hidden and disabled for mainnet.