### PR TITLE
Cache known block root and accumulate proposer reward

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/cachedBeaconState.ts
+++ b/packages/beacon-state-transition/src/allForks/util/cachedBeaconState.ts
@@ -231,6 +231,7 @@ export class BeaconStateContext<T extends allForks.BeaconState> {
     this.balances.persistent.asTransient();
     this.previousEpochParticipation.persistent.asTransient();
     this.currentEpochParticipation.persistent.asTransient();
+    this.inactivityScores.persistent.asTransient();
   }
 
   /**
@@ -240,6 +241,8 @@ export class BeaconStateContext<T extends allForks.BeaconState> {
     this.validators.persistent.asPersistent();
     this.balances.persistent.asPersistent();
     this.previousEpochParticipation.persistent.asPersistent();
+    this.currentEpochParticipation.persistent.asPersistent();
+    this.inactivityScores.persistent.asPersistent();
   }
 }
 

--- a/packages/beacon-state-transition/src/altair/block/index.ts
+++ b/packages/beacon-state-transition/src/altair/block/index.ts
@@ -9,7 +9,7 @@ import {processDeposit} from "./processDeposit";
 import {processProposerSlashing} from "./processProposerSlashing";
 import {processVoluntaryExit} from "./processVoluntaryExit";
 import {processSyncAggregate} from "./processSyncCommittee";
-import {getEmptyBlockProcess} from "../../util";
+import {getEmptyBlockProcess, increaseBalance} from "../../util";
 
 export {
   processOperations,
@@ -27,9 +27,14 @@ export function processBlock(
   verifySignatures = true
 ): void {
   const blockProcess = getEmptyBlockProcess();
+  // increasing balance on the same validator index multiple times per epoch transition is not efficient
+  blockProcess.increaseBalanceCache = new Map();
   processBlockHeader(state as CachedBeaconState<allForks.BeaconState>, block);
   processRandao(state as CachedBeaconState<allForks.BeaconState>, block, verifySignatures);
   processEth1Data(state as CachedBeaconState<allForks.BeaconState>, block.body);
   processOperations(state, block.body, blockProcess, verifySignatures);
-  processSyncAggregate(state, block, verifySignatures);
+  processSyncAggregate(state, block, blockProcess, verifySignatures);
+  for (const [validatorIndex, increaseBalanceValue] of blockProcess.increaseBalanceCache.entries()) {
+    increaseBalance(state, validatorIndex, increaseBalanceValue);
+  }
 }

--- a/packages/beacon-state-transition/src/altair/block/index.ts
+++ b/packages/beacon-state-transition/src/altair/block/index.ts
@@ -9,6 +9,7 @@ import {processDeposit} from "./processDeposit";
 import {processProposerSlashing} from "./processProposerSlashing";
 import {processVoluntaryExit} from "./processVoluntaryExit";
 import {processSyncAggregate} from "./processSyncCommittee";
+import {getEmptyBlockProcess} from "../../util";
 
 export {
   processOperations,
@@ -25,7 +26,7 @@ export function processBlock(
   block: altair.BeaconBlock,
   verifySignatures = true
 ): void {
-  const blockProcess = {validatorExitCache: {}};
+  const blockProcess = getEmptyBlockProcess();
   processBlockHeader(state as CachedBeaconState<allForks.BeaconState>, block);
   processRandao(state as CachedBeaconState<allForks.BeaconState>, block, verifySignatures);
   processEth1Data(state as CachedBeaconState<allForks.BeaconState>, block.body);

--- a/packages/beacon-state-transition/src/altair/block/processAttesterSlashing.ts
+++ b/packages/beacon-state-transition/src/altair/block/processAttesterSlashing.ts
@@ -2,12 +2,12 @@ import {allForks, altair, phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 import {CachedBeaconState} from "../../allForks/util";
 import {processAttesterSlashing as processAttesterSlashingAllForks} from "../../allForks/block";
-import {BlockProcess} from "../../util/blockProcess";
+import {BlockProcess, getEmptyBlockProcess} from "../../util/blockProcess";
 
 export function processAttesterSlashing(
   state: CachedBeaconState<altair.BeaconState>,
   attesterSlashing: phase0.AttesterSlashing,
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess = getEmptyBlockProcess(),
   verifySignatures = true
 ): void {
   processAttesterSlashingAllForks(

--- a/packages/beacon-state-transition/src/altair/block/processOperations.ts
+++ b/packages/beacon-state-transition/src/altair/block/processOperations.ts
@@ -8,7 +8,7 @@ import {processAttestation} from "./processAttestation";
 import {processDeposit} from "./processDeposit";
 import {processVoluntaryExit} from "./processVoluntaryExit";
 import {MAX_DEPOSITS} from "@chainsafe/lodestar-params";
-import {BlockProcess} from "../../util/blockProcess";
+import {BlockProcess, getEmptyBlockProcess} from "../../util/blockProcess";
 
 type Operation =
   | phase0.ProposerSlashing
@@ -26,7 +26,7 @@ type OperationFunction = (
 export function processOperations(
   state: CachedBeaconState<altair.BeaconState>,
   body: altair.BeaconBlockBody,
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess = getEmptyBlockProcess(),
   verifySignatures = true
 ): void {
   // verify that outstanding deposits are processed up to the maximum number of deposits

--- a/packages/beacon-state-transition/src/altair/block/processProposerSlashing.ts
+++ b/packages/beacon-state-transition/src/altair/block/processProposerSlashing.ts
@@ -2,12 +2,12 @@ import {allForks, altair, phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 import {CachedBeaconState} from "../../allForks/util";
 import {processProposerSlashing as processProposerSlashingAllForks} from "../../allForks/block";
-import {BlockProcess} from "../../util/blockProcess";
+import {BlockProcess, getEmptyBlockProcess} from "../../util/blockProcess";
 
 export function processProposerSlashing(
   state: CachedBeaconState<altair.BeaconState>,
   proposerSlashing: phase0.ProposerSlashing,
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess = getEmptyBlockProcess(),
   verifySignatures = true
 ): void {
   processProposerSlashingAllForks(

--- a/packages/beacon-state-transition/src/altair/block/processVoluntaryExit.ts
+++ b/packages/beacon-state-transition/src/altair/block/processVoluntaryExit.ts
@@ -1,12 +1,12 @@
 import {allForks, altair, phase0} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "../../allForks";
 import {processVoluntaryExit as processVoluntaryExitAllForks} from "../../allForks/block";
-import {BlockProcess} from "../../util/blockProcess";
+import {BlockProcess, getEmptyBlockProcess} from "../../util/blockProcess";
 
 export function processVoluntaryExit(
   state: CachedBeaconState<altair.BeaconState>,
   signedVoluntaryExit: phase0.SignedVoluntaryExit,
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess = getEmptyBlockProcess(),
   verifySignature = true
 ): void {
   processVoluntaryExitAllForks(

--- a/packages/beacon-state-transition/src/phase0/block/index.ts
+++ b/packages/beacon-state-transition/src/phase0/block/index.ts
@@ -7,6 +7,7 @@ import {processDeposit} from "./processDeposit";
 import {processAttesterSlashing} from "./processAttesterSlashing";
 import {processProposerSlashing} from "./processProposerSlashing";
 import {processVoluntaryExit} from "./processVoluntaryExit";
+import {getEmptyBlockProcess} from "../../util";
 
 // Extra utils used by other modules
 export {isValidIndexedAttestation} from "../../allForks/block";
@@ -25,7 +26,7 @@ export function processBlock(
   block: phase0.BeaconBlock,
   verifySignatures = true
 ): void {
-  const blockProcess = {validatorExitCache: {}};
+  const blockProcess = getEmptyBlockProcess();
   processBlockHeader(state as CachedBeaconState<allForks.BeaconState>, block);
   processRandao(state as CachedBeaconState<allForks.BeaconState>, block, verifySignatures);
   processEth1Data(state as CachedBeaconState<allForks.BeaconState>, block.body);

--- a/packages/beacon-state-transition/src/phase0/block/processAttestation.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processAttestation.ts
@@ -4,13 +4,13 @@ import {computeEpochAtSlot} from "../../util";
 import {CachedBeaconState} from "../../allForks/util";
 import {isValidIndexedAttestation} from "../../allForks/block";
 import {MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
-import {BlockProcess} from "../../util/blockProcess";
+import {BlockProcess, getEmptyBlockProcess} from "../../util/blockProcess";
 
 export function processAttestation(
   state: CachedBeaconState<phase0.BeaconState>,
   attestation: phase0.Attestation,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess = getEmptyBlockProcess(),
   verifySignature = true
 ): void {
   const {epochCtx} = state;

--- a/packages/beacon-state-transition/src/phase0/block/processAttesterSlashing.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processAttesterSlashing.ts
@@ -3,12 +3,12 @@ import {ForkName} from "@chainsafe/lodestar-params";
 
 import {CachedBeaconState} from "../../allForks/util";
 import {processAttesterSlashing as processAttesterSlashingAllForks} from "../../allForks/block";
-import {BlockProcess} from "../../util/blockProcess";
+import {BlockProcess, getEmptyBlockProcess} from "../../util/blockProcess";
 
 export function processAttesterSlashing(
   state: CachedBeaconState<phase0.BeaconState>,
   attesterSlashing: phase0.AttesterSlashing,
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess = getEmptyBlockProcess(),
   verifySignatures = true
 ): void {
   processAttesterSlashingAllForks(

--- a/packages/beacon-state-transition/src/phase0/block/processProposerSlashing.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processProposerSlashing.ts
@@ -2,12 +2,12 @@ import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 import {CachedBeaconState} from "../../allForks/util";
 import {processProposerSlashing as processProposerSlashingAllForks} from "../../allForks/block";
-import {BlockProcess} from "../../util/blockProcess";
+import {BlockProcess, getEmptyBlockProcess} from "../../util/blockProcess";
 
 export function processProposerSlashing(
   state: CachedBeaconState<phase0.BeaconState>,
   proposerSlashing: phase0.ProposerSlashing,
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess = getEmptyBlockProcess(),
   verifySignatures = true
 ): void {
   processProposerSlashingAllForks(

--- a/packages/beacon-state-transition/src/phase0/block/processVoluntaryExit.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processVoluntaryExit.ts
@@ -1,12 +1,12 @@
 import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "../../allForks/util";
 import {processVoluntaryExit as processVoluntaryExitAllForks} from "../../allForks/block";
-import {BlockProcess} from "../../util/blockProcess";
+import {BlockProcess, getEmptyBlockProcess} from "../../util/blockProcess";
 
 export function processVoluntaryExit(
   state: CachedBeaconState<phase0.BeaconState>,
   signedVoluntaryExit: phase0.SignedVoluntaryExit,
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess = getEmptyBlockProcess(),
   verifySignature = true
 ): void {
   processVoluntaryExitAllForks(

--- a/packages/beacon-state-transition/src/phase0/epoch/processPendingAttestations.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/processPendingAttestations.ts
@@ -16,6 +16,7 @@ export function statusProcessEpoch<T extends allForks.BeaconState>(
   const rootType = ssz.Root;
   const prevEpoch = epochCtx.previousShuffling.epoch;
   const actualTargetBlockRoot = getBlockRootAtSlot(state, computeStartSlotAtEpoch(epoch));
+  const blockRoots = new Map<phase0.Slot, phase0.Root>();
   for (const att of readonlyValues(attestations)) {
     const aggregationBits = att.aggregationBits;
     const attData = att.data;
@@ -26,7 +27,12 @@ export function statusProcessEpoch<T extends allForks.BeaconState>(
     const attBeaconBlockRoot = attData.beaconBlockRoot;
     const attTarget = attData.target;
     const attVotedTargetRoot = rootType.equals(attTarget.root, actualTargetBlockRoot);
-    const attVotedHeadRoot = rootType.equals(attBeaconBlockRoot, getBlockRootAtSlot(state, attSlot));
+    let actualHeadRoot = blockRoots.get(attSlot);
+    if (!actualHeadRoot) {
+      actualHeadRoot = getBlockRootAtSlot(state, attSlot);
+      blockRoots.set(attSlot, actualHeadRoot);
+    }
+    const attVotedHeadRoot = rootType.equals(attBeaconBlockRoot, actualHeadRoot);
     const committee = epochCtx.getBeaconCommittee(attSlot, committeeIndex);
     const participants = zipIndexesCommitteeBits(committee, aggregationBits);
 

--- a/packages/beacon-state-transition/src/util/blockProcess.ts
+++ b/packages/beacon-state-transition/src/util/blockProcess.ts
@@ -2,6 +2,7 @@ import {phase0} from "../../../types/lib";
 
 export function getEmptyBlockProcess(): BlockProcess {
   return {
+    increaseBalanceCache: null,
     blockRootCache: new Map<phase0.Slot, phase0.Root>(),
     validatorExitCache: {},
   };
@@ -9,6 +10,7 @@ export function getEmptyBlockProcess(): BlockProcess {
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface BlockProcess {
+  increaseBalanceCache: Map<phase0.ValidatorIndex, phase0.Gwei> | null;
   blockRootCache: Map<phase0.Slot, phase0.Root>;
   validatorExitCache: {
     exitQueueEpoch?: number;

--- a/packages/beacon-state-transition/src/util/blockProcess.ts
+++ b/packages/beacon-state-transition/src/util/blockProcess.ts
@@ -1,5 +1,15 @@
+import {phase0} from "../../../types/lib";
+
+export function getEmptyBlockProcess(): BlockProcess {
+  return {
+    blockRootCache: new Map<phase0.Slot, phase0.Root>(),
+    validatorExitCache: {},
+  };
+}
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface BlockProcess {
+  blockRootCache: Map<phase0.Slot, phase0.Root>;
   validatorExitCache: {
     exitQueueEpoch?: number;
     exitQueueChurn?: number;


### PR DESCRIPTION
**Motivation**

+ For both altair and phase0, we keep getting block root for known slot since most attestations of same block point to same value
+ For altair, there are proposal rewards at different places. Note that updating a balance to `persistent-merkle-tree` is not cheap. 

**Description**

+ Cache known block roots for phase0 `processPendingAttesatations` and altair `BlockProcess`
+ Altair: Accumulate proposal reward and only update it once per block
+ Add missing `asTransient()` and `asPersistent()` calls

Closes #2528


