### PR TITLE
Fix gossip block error handler

### DIFF
--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -107,7 +107,6 @@ export async function runStateTransition(
     justifiedBalances = getEffectiveBalances(justifiedState);
   }
   forkChoice.onBlock(job.signedBlock.message, postState, justifiedBalances);
-  forkChoice.updateHead();
 
   if (!job.reprocess) {
     if (postSlot % SLOTS_PER_EPOCH === 0) {
@@ -115,6 +114,7 @@ export async function runStateTransition(
     }
 
     emitBlockEvent(emitter, job, postState);
+    forkChoice.updateHead();
     emitForkChoiceHeadEvents(emitter, forkChoice, forkChoice.getHead(), oldHead, metrics);
   }
 

--- a/packages/lodestar/src/network/reqresp/handlers/beaconBlocksByRoot.ts
+++ b/packages/lodestar/src/network/reqresp/handlers/beaconBlocksByRoot.ts
@@ -10,7 +10,14 @@ export async function* onBeaconBlocksByRoot(
   for (const blockRoot of requestBody) {
     const root = blockRoot.valueOf() as Uint8Array;
     const summary = chain.forkChoice.getBlock(root);
-    const block = summary ? await db.block.get(root) : await db.blockArchive.getByRoot(root);
+    let block: allForks.SignedBeaconBlock | null = null;
+    // finalized block has summary in forkchoice but it stays in blockArchive db
+    if (summary) {
+      block = await db.block.get(root);
+    }
+    if (!block) {
+      block = await db.blockArchive.getByRoot(root);
+    }
     if (block) {
       yield block;
     }

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -92,7 +92,11 @@ export class AttestationService {
     const signedAttestations: phase0.Attestation[] = [];
 
     for (const {duty} of duties) {
-      const logCtxValidator = {...logCtx, validator: prettyBytes(duty.pubkey)};
+      const logCtxValidator = {
+        ...logCtx,
+        head: prettyBytes(attestation.beaconBlockRoot),
+        validator: prettyBytes(duty.pubkey),
+      };
       try {
         signedAttestations.push(await this.validatorStore.signAttestation(duty, attestation, currentEpoch));
         this.logger.debug("Signed attestation", logCtxValidator);


### PR DESCRIPTION
**Motivation**

+ Node fails to track latest head due to incorrect error handler of Gossip Block handler when a future block or unknown parent root gossip block comes
+ `onBeaconBlockByRoot` handler is not correct for finalized block so we may get lower score as found by @mpetrunic and hence we may not receive gossip block frequently

**Description**

+ Use the new `BlockGossipError` instead of `BlockError`
+ Fix `onBeaconBlockByRoot` for finalized block
+ Add more logs

Other than that, move forkchocie `updateHead` after we emit/process block in order to process updated attestations in the block

Closes #2840

**Steps to test or reproduce**

Sync prater

```
Jul-15 04:43:42.049 []                 info: Synced - finalized: 25561 0xc276…85a0 - head: 818018 0x94c9…d6f7 - clockSlot: 818018 - peers: 26
Jul-15 04:43:54.022 []                 info: Synced - finalized: 25561 0xc276…85a0 - head: 818019 0x0261…af05 - clockSlot: 818019 - peers: 26
Jul-15 04:44:06.002 []                 info: Synced - finalized: 25561 0xc276…85a0 - head: 818020 0xf595…464f - clockSlot: 818020 - peers: 27
```