### PR TITLE
Audit slashing protection db

### DIFF
--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -104,7 +104,7 @@ export class ValidatorStore {
 
     const secretKey = this.getSecretKey(duty.pubkey); // Get before writing to slashingProtection
     await this.slashingProtection.checkAndInsertAttestation(duty.pubkey, {
-      sourceEpoch: attestationData.target.epoch,
+      sourceEpoch: attestationData.source.epoch,
       targetEpoch: attestationData.target.epoch,
       signingRoot,
     });

--- a/packages/validator/src/slashingProtection/utils.ts
+++ b/packages/validator/src/slashingProtection/utils.ts
@@ -13,7 +13,7 @@ export function isEqualRoot(root1: Root, root2: Root): boolean {
 
 export function isEqualNonZeroRoot(root1: Root, root2: Root): boolean {
   const ZERO_ROOT = getZeroRoot();
-  return !isEqualRoot(root1, ZERO_ROOT) && !isEqualRoot(root2, ZERO_ROOT) && isEqualRoot(root1, root2);
+  return !isEqualRoot(root1, ZERO_ROOT) && isEqualRoot(root1, root2);
 }
 
 export function fromOptionalHexString(hex: string | undefined): Root {


### PR DESCRIPTION
**Motivation**

In preparation to run a validator in mainnet I've audited in detail the slashing protection db code.

I've also inspect the slashing protection db exports of multiple validators running in Pyrmont and altair-devnet-1.

**Findings**

- Target used as source in attestation check and insert (Severity: `MEDIUM`). A typo set the attestation source epoch to its target epoch. This bug did not break the security guarantees on double votes, but invalidates the protection against surround votes. Note that it is very unlikely to commit a surround vote slashing offence involuntarily.

- Redundant check in signing root comparision (Severity: `VERY LOW`). There a small performance improvement by removing a redundant check if the second root to compare in `isEqualNonZeroRoot` is zero. If the first root is zero, the routine will stop early.

