### PR TITLE
EpochProcess: Prepare activeValidatorIndices for the next epoch

### DIFF
--- a/packages/beacon-state-transition/src/allForks/stateTransition.ts
+++ b/packages/beacon-state-transition/src/allForks/stateTransition.ts
@@ -144,7 +144,7 @@ function processSlotsWithTransientCache(
         metrics?.registerValidatorStatuses(process.currentEpoch, process.statuses);
 
         postState.slot++;
-        rotateEpochs(postState.epochCtx, postState, process.indicesBounded);
+        rotateEpochs(postState.epochCtx, postState, process.nextEpochActiveValidatorIndices);
       } finally {
         if (timer) timer();
       }

--- a/packages/beacon-state-transition/src/allForks/util/cachedBeaconState.ts
+++ b/packages/beacon-state-transition/src/allForks/util/cachedBeaconState.ts
@@ -215,7 +215,9 @@ export class BeaconStateContext<T extends allForks.BeaconState> {
     const state = (this.type.createTreeBacked(this.tree) as unknown) as TreeBacked<altair.BeaconState>;
     this.currentSyncCommittee = this.nextSyncCommittee;
     state.currentSyncCommittee = state.nextSyncCommittee;
-    const nextSyncCommittee = ssz.altair.SyncCommittee.createTreeBackedFromStruct(getNextSyncCommittee(state));
+    const nextSyncCommittee = ssz.altair.SyncCommittee.createTreeBackedFromStruct(
+      getNextSyncCommittee(state, this.epochCtx.nextShuffling.activeIndices)
+    );
     this.nextSyncCommittee = convertToIndexedSyncCommittee(nextSyncCommittee, this.epochCtx.pubkey2index);
     state.nextSyncCommittee = nextSyncCommittee;
   }

--- a/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
@@ -55,7 +55,7 @@ export interface IEpochProcess {
   validators: phase0.Validator[];
   balances?: BigUint64Array;
   // to be used for rotateEpochs()
-  indicesBounded: [ValidatorIndex, Epoch, Epoch][];
+  nextEpochActiveValidatorIndices: ValidatorIndex[];
 }
 
 export function createIEpochProcess(): IEpochProcess {
@@ -79,7 +79,7 @@ export function createIEpochProcess(): IEpochProcess {
     churnLimit: 0,
     statuses: [],
     validators: [],
-    indicesBounded: [],
+    nextEpochActiveValidatorIndices: [],
   };
 }
 
@@ -90,6 +90,7 @@ export function prepareEpochProcessState<T extends allForks.BeaconState>(state: 
   const forkName = config.getForkName(state.slot);
   const currentEpoch = epochCtx.currentShuffling.epoch;
   const prevEpoch = epochCtx.previousShuffling.epoch;
+  const nextEpoch = currentEpoch + 1;
   out.currentEpoch = currentEpoch;
   out.prevEpoch = prevEpoch;
 
@@ -144,7 +145,9 @@ export function prepareEpochProcessState<T extends allForks.BeaconState>(state: 
     }
 
     out.statuses.push(status);
-    out.indicesBounded.push([i, v.activationEpoch, v.exitEpoch]);
+    if (isActiveValidator(v, nextEpoch)) {
+      out.nextEpochActiveValidatorIndices.push(i);
+    }
   });
 
   if (out.totalActiveStake < EFFECTIVE_BALANCE_INCREMENT) {

--- a/packages/beacon-state-transition/src/allForks/util/epochShuffling.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochShuffling.ts
@@ -57,17 +57,10 @@ export function computeCommitteeCount(activeValidatorCount: number): number {
 
 export function computeEpochShuffling(
   state: allForks.BeaconState,
-  indicesBounded: [ValidatorIndex, Epoch, Epoch][],
+  activeIndices: ValidatorIndex[],
   epoch: Epoch
 ): IEpochShuffling {
   const seed = getSeed(state, epoch, DOMAIN_BEACON_ATTESTER);
-
-  const activeIndices: ValidatorIndex[] = [];
-  for (const [index, activationEpoch, exitEpoch] of indicesBounded) {
-    if (activationEpoch <= epoch && epoch < exitEpoch) {
-      activeIndices.push(index);
-    }
-  }
 
   // copy
   const shuffling = activeIndices.slice();

--- a/packages/beacon-state-transition/src/altair/epoch/sync_committee.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/sync_committee.ts
@@ -4,22 +4,22 @@ import {altair, ValidatorIndex, allForks} from "@chainsafe/lodestar-types";
 import {intDiv, intToBytes} from "@chainsafe/lodestar-utils";
 import {hash} from "@chainsafe/ssz";
 
-import {computeEpochAtSlot, computeShuffledIndex, getActiveValidatorIndices, getSeed} from "../../util";
+import {computeEpochAtSlot, computeShuffledIndex, getSeed} from "../../util";
 
 const MAX_RANDOM_BYTE = BigInt(2 ** 8 - 1);
 
 /**
- * TODO: NAIVE
- * 
  * Return the sync committee indices for a given state and epoch.
  * Aligns `epoch` to `baseEpoch` so the result is the same with any `epoch` within a sync period.
  *  Note: This function should only be called at sync committee period boundaries, as
     ``get_sync_committee_indices`` is not stable within a given period.
  */
-export function getNextSyncCommitteeIndices(state: allForks.BeaconState): ValidatorIndex[] {
+export function getNextSyncCommitteeIndices(
+  state: allForks.BeaconState,
+  activeValidatorIndices: ValidatorIndex[]
+): ValidatorIndex[] {
   const epoch = computeEpochAtSlot(state.slot) + 1;
 
-  const activeValidatorIndices = getActiveValidatorIndices(state, epoch);
   const activeValidatorCount = activeValidatorIndices.length;
   const seed = getSeed(state, epoch, DOMAIN_SYNC_COMMITTEE);
   let i = 0;
@@ -38,12 +38,13 @@ export function getNextSyncCommitteeIndices(state: allForks.BeaconState): Valida
 }
 
 /**
- * TODO: NAIVE
- *
  * Return the sync committee for a given state and epoch.
  */
-export function getNextSyncCommittee(state: allForks.BeaconState): altair.SyncCommittee {
-  const indices = getNextSyncCommitteeIndices(state);
+export function getNextSyncCommittee(
+  state: allForks.BeaconState,
+  activeValidatorIndices: ValidatorIndex[]
+): altair.SyncCommittee {
+  const indices = getNextSyncCommitteeIndices(state, activeValidatorIndices);
   const pubkeys = indices.map((index) => state.validators[index].pubkey);
   return {
     pubkeys,

--- a/packages/beacon-state-transition/src/util/balance.ts
+++ b/packages/beacon-state-transition/src/util/balance.ts
@@ -24,6 +24,7 @@ export function getTotalBalance(state: allForks.BeaconState, indices: ValidatorI
 }
 
 /**
+ * Call this function with care since it has to loop through validators which is expensive.
  * Return the combined effective balance of the active validators.
  * Note: `getTotalBalance` returns `EFFECTIVE_BALANCE_INCREMENT` Gwei minimum to avoid divisions by zero.
  */

--- a/packages/beacon-state-transition/test/perf/util.ts
+++ b/packages/beacon-state-transition/test/perf/util.ts
@@ -181,7 +181,9 @@ export function generatePerformanceStateAltair(pubkeysArg?: Uint8Array[]): TreeB
       ParticipationFlags
     >;
     state.inactivityScores = Array.from({length: pubkeys.length}, (_, i) => i % 2) as List<ParticipationFlags>;
-    const syncCommittee = getNextSyncCommittee(state);
+    const epoch = computeEpochAtSlot(state.slot);
+    const activeValidatorIndices = getActiveValidatorIndices(state, epoch);
+    const syncCommittee = getNextSyncCommittee(state, activeValidatorIndices);
     state.currentSyncCommittee = syncCommittee;
     state.nextSyncCommittee = syncCommittee;
     altairState = ssz.altair.BeaconState.createTreeBackedFromStruct(state);

--- a/packages/lodestar/src/api/impl/beacon/state/utils.ts
+++ b/packages/lodestar/src/api/impl/beacon/state/utils.ts
@@ -6,6 +6,7 @@ import {
   createCachedBeaconState,
   computeSyncPeriodAtEpoch,
   computeEpochAtSlot,
+  isActiveValidator,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {altair, phase0} from "@chainsafe/lodestar-types";
 import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
@@ -131,12 +132,13 @@ export function getEpochBeaconCommittees(
     }
   }
 
-  const indicesBounded: [ValidatorIndex, Epoch, Epoch][] = Array.from(readonlyValues(state.validators), (v, i) => [
-    i,
-    v.activationEpoch,
-    v.exitEpoch,
-  ]);
-  const shuffling = allForks.computeEpochShuffling(state, indicesBounded, epoch);
+  const activeValidatorIndices: ValidatorIndex[] = [];
+  for (const [i, v] of Array.from(readonlyValues(state.validators)).entries()) {
+    if (isActiveValidator(v, epoch)) {
+      activeValidatorIndices.push(i);
+    }
+  }
+  const shuffling = allForks.computeEpochShuffling(state, activeValidatorIndices, epoch);
   return shuffling.committees;
 }
 


### PR DESCRIPTION
**Motivation**

+ On an altair syncing node, it takes 3.5% of the time to get active validator indices on `rotateEpoch`

**Description**

+ Calculate it in `IEpochProcess` at the end of the previous epoch to save 1 validators loop

Closes #2866

**Steps to test or reproduce**

+ Sync `altair-devnet-1`
+ was able to sync to head with this branch
```
Jul-22 11:44:30.003 []                 info: Synced - finalized: 1551 0x5b68…4f6f - head: 49721 0xf9bd…6132 - clockSlot: 49722 - peers: 17
```