### PR TITLE
Fix finalized block retrieval in API

### DIFF
--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/utils.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/utils.test.ts
@@ -64,7 +64,7 @@ describe("block api utils", function () {
       forkChoiceStub.getFinalizedBlock.returns(expectedSummary);
       dbStub.blockArchive.getByRoot.withArgs(bufferEqualsMatcher(expectedBuffer)).resolves(null);
       await resolveBlockId(forkChoiceStub, dbStub, toHexString(expectedBuffer)).catch(() => {});
-      expect(dbStub.blockArchive.getByRoot.withArgs(bufferEqualsMatcher(expectedBuffer)).calledOnce).to.be.true;
+      expect(dbStub.blockArchive.get.withArgs(expectedSummary.slot).calledOnce).to.be.true;
     });
 
     it("should resolve non finalized block root", async function () {

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/utils.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/utils.test.ts
@@ -54,16 +54,17 @@ describe("block api utils", function () {
 
     it("should resolve finalized", async function () {
       const expected = 0;
-      forkChoiceStub.getFinalizedCheckpoint.returns({epoch: expected, root: Buffer.alloc(32, 2)});
+      forkChoiceStub.getFinalizedBlock.returns(expectedSummary);
       await resolveBlockId(forkChoiceStub, dbStub, "finalized").catch(() => {});
       expect(dbStub.blockArchive.get.withArgs(expected).calledOnce).to.be.true;
     });
 
     it("should resolve finalized block root", async function () {
       forkChoiceStub.getBlock.returns(expectedSummary);
-      dbStub.block.get.withArgs(bufferEqualsMatcher(expectedBuffer)).resolves(null);
+      forkChoiceStub.getFinalizedBlock.returns(expectedSummary);
+      dbStub.blockArchive.getByRoot.withArgs(bufferEqualsMatcher(expectedBuffer)).resolves(null);
       await resolveBlockId(forkChoiceStub, dbStub, toHexString(expectedBuffer)).catch(() => {});
-      expect(dbStub.block.get.withArgs(bufferEqualsMatcher(expectedBuffer)).calledOnce).to.be.true;
+      expect(dbStub.blockArchive.getByRoot.withArgs(bufferEqualsMatcher(expectedBuffer)).calledOnce).to.be.true;
     });
 
     it("should resolve non finalized block root", async function () {


### PR DESCRIPTION
**Motivation**
Stumbled upon these bugs.

**Description**
Several bugs in `resolveBlockIdOrNull` function.
- if `"finalized"` is provided, the finalized epoch was being used to fetch a block instead of the finalized block slot
  - The finalized block slot should be used to retrieve the finalized block
- if block hash or slot was provided, if the hash or slot corresponded to the finalized block, the block repository was searched, instead of the block archive repository
  - the block archive should be used to retrieve the finalized block