### PR TITLE
Make processEth1Data faster

### DIFF
--- a/packages/beacon-state-transition/src/allForks/block/processEth1Data.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processEth1Data.ts
@@ -1,6 +1,6 @@
 import {EPOCHS_PER_ETH1_VOTING_PERIOD, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
-import {allForks, phase0, ssz} from "@chainsafe/lodestar-types";
-import {readonlyValues} from "@chainsafe/ssz";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
+import {readonlyValues, toHexString} from "@chainsafe/ssz";
 
 import {CachedBeaconState} from "../util";
 
@@ -22,22 +22,39 @@ export function getNewEth1Data(
   newEth1Data: phase0.Eth1Data
 ): phase0.Eth1Data | null {
   const SLOTS_PER_ETH1_VOTING_PERIOD = EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH;
+  const SLOTS_PER_ETH1_VOTING_PERIOD_HALF = SLOTS_PER_ETH1_VOTING_PERIOD / 2;
 
   // If there are not more than 50% votes, then we do not have to count to find a winner.
-  if ((state.eth1DataVotes.length + 1) * 2 <= SLOTS_PER_ETH1_VOTING_PERIOD) {
+  if (state.eth1DataVotes.length + 1 <= SLOTS_PER_ETH1_VOTING_PERIOD_HALF) {
     return null;
   }
-  if (ssz.phase0.Eth1Data.equals(state.eth1Data, newEth1Data)) {
+
+  const newEth1DataSerialized = serializeEth1Data(newEth1Data);
+  if (serializeEth1Data(state.eth1Data) === newEth1DataSerialized) {
     return null; // Nothing to do if the state already has this as eth1data (happens a lot after majority vote is in)
   }
-  const sameVotesCount = Array.from(readonlyValues(state.eth1DataVotes)).filter((e) =>
-    ssz.phase0.Eth1Data.equals(e, newEth1Data)
-  ).length;
 
   // The +1 is to account for the `eth1Data` supplied to the function.
-  if ((sameVotesCount + 1) * 2 > SLOTS_PER_ETH1_VOTING_PERIOD) {
-    return newEth1Data;
-  } else {
-    return null;
+  let sameVotesCount = 1;
+  for (const eth1DataVote of readonlyValues(state.eth1DataVotes)) {
+    if (serializeEth1Data(eth1DataVote) === newEth1DataSerialized) {
+      sameVotesCount++;
+
+      // Would result in a change of eth1Data to the new one
+      if (sameVotesCount > SLOTS_PER_ETH1_VOTING_PERIOD_HALF) {
+        return newEth1Data;
+      }
+    }
   }
+
+  // Not enough votes, won't change the result
+  return null;
+}
+
+/**
+ * Serialize eth1Data types to a unique string ID. It is only used for comparison.
+ * This serializer is x15 times faster than ssz.phase0.Eth1Data.equals()
+ */
+function serializeEth1Data(eth1Data: phase0.Eth1Data): string {
+  return toHexString(eth1Data.blockHash) + eth1Data.depositCount.toString(16) + toHexString(eth1Data.depositRoot);
 }

--- a/packages/beacon-state-transition/test/perf/allForks/util/eth1Data.test.ts
+++ b/packages/beacon-state-transition/test/perf/allForks/util/eth1Data.test.ts
@@ -1,0 +1,46 @@
+import {phase0, ssz} from "@chainsafe/lodestar-types";
+import {toHexString} from "@chainsafe/ssz";
+import {itBench, setBenchOpts} from "@dapplion/benchmark";
+
+// Benchmark data from July 2021 - Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz
+//
+// ✓ ssz.phase0.Eth1Data.equals                                          17059.32 ops/s    58.61900 us/op        -      84668 runs   5.01 s
+// ✓ compare with serializeEth1Data                                      257201.6 ops/s    3.888000 us/op        -    1180606 runs   5.07 s
+
+describe("eth1Data isEqual", () => {
+  setBenchOpts({
+    maxMs: 10 * 1000,
+    minMs: 5 * 1000,
+    runs: 1024,
+  });
+
+  const eth1Data1: phase0.Eth1Data = {
+    depositRoot: Buffer.alloc(32, 1),
+    depositCount: 1263512,
+    blockHash: Buffer.alloc(32, 2),
+  };
+
+  // Almost identical eth1Data, just changes the last byte
+  const eth1Data2: phase0.Eth1Data = {
+    depositRoot: Buffer.alloc(32, 1),
+    depositCount: 1263512,
+    blockHash: Buffer.concat([Buffer.alloc(31, 2), Buffer.alloc(1, 3)]),
+  };
+
+  if (!process.env.CI) {
+    itBench("ssz.phase0.Eth1Data.equals", () => {
+      ssz.phase0.Eth1Data.equals(eth1Data1, eth1Data2);
+    });
+
+    itBench("compare with serializeEth1Data", () => {
+      serializeEth1Data(eth1Data1) === serializeEth1Data(eth1Data2);
+    });
+  }
+});
+
+/**
+ * Serialize eth1Data types to a unique string ID. It is only used for comparison.
+ */
+function serializeEth1Data(eth1Data: phase0.Eth1Data): string {
+  return toHexString(eth1Data.blockHash) + eth1Data.depositCount.toString(16) + toHexString(eth1Data.depositRoot);
+}

--- a/packages/beacon-state-transition/test/perf/allForks/util/eth1Data.test.ts
+++ b/packages/beacon-state-transition/test/perf/allForks/util/eth1Data.test.ts
@@ -4,8 +4,10 @@ import {itBench, setBenchOpts} from "@dapplion/benchmark";
 
 // Benchmark data from July 2021 - Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz
 //
-// ✓ ssz.phase0.Eth1Data.equals                                          17059.32 ops/s    58.61900 us/op        -      84668 runs   5.01 s
-// ✓ compare with serializeEth1Data                                      257201.6 ops/s    3.888000 us/op        -    1180606 runs   5.07 s
+// eth1Data isEqual
+// ✓ each field with ssz.Root.equals                                      1364256 ops/s    733.0000 ns/op        -    4619587 runs   5.28 s
+// ✓ compare with serializeEth1Data                                      257267.8 ops/s    3.887000 us/op        -    1183689 runs   5.08 s
+// ✓ ssz.phase0.Eth1Data.equals                                          16932.79 ops/s    59.05700 us/op        -      84084 runs   5.01 s
 
 describe("eth1Data isEqual", () => {
   setBenchOpts({
@@ -28,12 +30,18 @@ describe("eth1Data isEqual", () => {
   };
 
   if (!process.env.CI) {
-    itBench("ssz.phase0.Eth1Data.equals", () => {
-      ssz.phase0.Eth1Data.equals(eth1Data1, eth1Data2);
+    itBench("each field with ssz.Root.equals", () => {
+      eth1Data1.depositCount === eth1Data2.depositCount &&
+        ssz.Root.equals(eth1Data1.depositRoot, eth1Data2.depositRoot) &&
+        ssz.Root.equals(eth1Data1.blockHash, eth1Data2.blockHash);
     });
 
     itBench("compare with serializeEth1Data", () => {
       serializeEth1Data(eth1Data1) === serializeEth1Data(eth1Data2);
+    });
+
+    itBench("ssz.phase0.Eth1Data.equals", () => {
+      ssz.phase0.Eth1Data.equals(eth1Data1, eth1Data2);
     });
   }
 });


### PR DESCRIPTION
**Motivation**

`getNewEth1Data` has shown up in CPU profiles in the past. The issue is comparing many eth1Data objects using ssz utility when it's not strictly necessary.

**Description**

Use serializeEth1Data to compare eth1Data objects