### PR TITLE
Aggregated attestation pool: handle 1 attestation includes another

### DIFF
--- a/packages/lodestar/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/lodestar/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -81,11 +81,19 @@ describe("MatchingDataAttestationGroup", function () {
   });
 
   it("add - new data, getAttestations() return 2", () => {
+    const attestation2 = {...attestationSeed, ...{aggregationBits: [true, false, true] as List<boolean>}};
+    const result = attestationGroup.add({attestation: attestation2, attestingIndices: new Set([100, 300])});
+    expect(result).to.be.equal(InsertOutcome.NewData, "incorrect InsertOutcome");
+    const attestations = attestationGroup.getAttestations();
+    expect(attestations).to.be.deep.equal([attestation1, attestation2], "Incorrect attestations for block");
+  });
+
+  it("add - new data, remove existing attestation, getAttestations() return 1", () => {
     const attestation2 = {...attestationSeed, ...{aggregationBits: [true, true, true] as List<boolean>}};
     const result = attestationGroup.add({attestation: attestation2, attestingIndices: new Set(committee)});
     expect(result).to.be.equal(InsertOutcome.NewData, "incorrect InsertOutcome");
     const attestations = attestationGroup.getAttestations();
-    expect(attestations).to.be.deep.equal([attestation1, attestation2], "Incorrect attestations for block");
+    expect(attestations).to.be.deep.equal([attestation2], "should return only new attestation");
   });
 
   it("add - already known, getAttestations() return 1", () => {
@@ -133,21 +141,21 @@ describe("MatchingDataAttestationGroup", function () {
   });
 
   it("getAttestationsForBlock - return 2", () => {
-    const attestation2 = {...attestationSeed, ...{aggregationBits: [true, true, true] as List<boolean>}};
-    const result = attestationGroup.add({attestation: attestation2, attestingIndices: new Set(committee)});
+    const attestation2 = {...attestationSeed, ...{aggregationBits: [true, false, true] as List<boolean>}};
+    const result = attestationGroup.add({attestation: attestation2, attestingIndices: new Set([100, 300])});
     expect(result).to.be.equal(InsertOutcome.NewData, "incorrect InsertOutcome");
     const attestations = attestationGroup.getAttestationsForBlock(new Set([200]));
     expect(attestations).to.be.deep.equal(
       [
         {
+          attestation: attestation2,
+          attestingIndices: new Set([100, 300]),
+          notSeenAttesterCount: 2,
+        },
+        {
           attestation: attestation1,
           attestingIndices: new Set([100, 200]),
           notSeenAttesterCount: 1,
-        },
-        {
-          attestation: attestation2,
-          attestingIndices: new Set(committee),
-          notSeenAttesterCount: 2,
         },
       ],
       "incorrect attestations"


### PR DESCRIPTION
**Motivation**

+ We include up to 4 attestations of same data, 1 includes another. This is because we only check if an existing attestation contains another one, if a new attestation contains a superset of `aggregationBits` we don't check that
+ We include up to 4 attestations of same data in block which is too many. In mainnet, a slot has 64 committees and a block has ~~64~~ 128 attestations at most so we should reduce to 2.

**Description**

+ When an attestation comes, check which one has more `attestingIndices` first before checking for an inclusion. If new attestation's `aggregationBits` is a superset of an existing one, remove the existing one and add new.
+ Introduce `MAX_RETAINED_ATTESTATIONS_PER_GROUP` vs `MAX_ATTESTATIONS_PER_GROUP`

Closes #2882

**Test result with altair-devnet-1**


|Slot|This PR|The explorer (other clients)|
|----|-------|-------------|
|63819|2 * 63818 attestations|2 * 63818 attestations|
|63829|2 * 63828 attestations + 2 * 63822 attestations|2 * 63828 attestations|
|63844|2 * 63843 attestations + 2 * 63822 attestations|2 * 63843 attestations|
|63877|2 * 63876 attestations + 1 * 63856 attestation | 2 * 63876 attestations|


Not sure why we still have 1-2 extra old attestations included in block? if any attesters inside any attestation haven't seen by chain, we always include those, not sure why other clients don't!

At least, this PR confirms that we always have 2 attestations voted for previous block/slot which is the main point of the PR.


