### PR TITLE
Fix eth1.providerUrls defaults

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/eth1.ts
+++ b/packages/cli/src/options/beaconNodeOptions/eth1.ts
@@ -9,9 +9,16 @@ export interface IEth1Args {
 }
 
 export function parseArgs(args: IEth1Args): IBeaconNodeOptions["eth1"] {
+  // Support deprecated flag 'eth1.providerUrl' only if 'eth1.providerUrls' is not defined
+  // Safe default to '--eth1.providerUrl' only if it's defined. Prevent returning providerUrls: [undefined]
+  let providerUrls = args["eth1.providerUrls"];
+  if (!providerUrls && args["eth1.providerUrl"]) {
+    providerUrls = [args["eth1.providerUrl"]];
+  }
+
   return {
     enabled: args["eth1.enabled"],
-    providerUrls: args["eth1.providerUrls"] ?? [args["eth1.providerUrl"]],
+    providerUrls: providerUrls,
     depositContractDeployBlock: args["eth1.depositContractDeployBlock"],
   };
 }

--- a/packages/lodestar/src/eth1/eth1ForBlockProduction.ts
+++ b/packages/lodestar/src/eth1/eth1ForBlockProduction.ts
@@ -18,6 +18,8 @@ const MAX_BLOCKS_PER_LOG_QUERY = 1000;
 const AUTO_UPDATE_PERIOD_MS = 60 * 1000;
 /** Miliseconds to wait after getting 429 Too Many Requests */
 const RATE_LIMITED_WAIT_MS = 30 * 1000;
+/** Min time to wait on auto update loop on unknown error */
+const MIN_WAIT_ON_ERORR_MS = 1 * 1000;
 
 /**
  * Main class handling eth1 data fetching, processing and storing
@@ -132,6 +134,7 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
           await sleep(RATE_LIMITED_WAIT_MS, this.signal);
         } else {
           this.logger.error("Error updating eth1 chain cache", {}, e);
+          await sleep(MIN_WAIT_ON_ERORR_MS, this.signal);
         }
       }
     }

--- a/packages/lodestar/src/eth1/provider/jsonRpcHttpClient.ts
+++ b/packages/lodestar/src/eth1/provider/jsonRpcHttpClient.ts
@@ -33,7 +33,17 @@ export class JsonRpcHttpClient {
       /** If returns true, do not fallback to other urls and throw early */
       shouldNotFallback?: (error: Error) => boolean;
     }
-  ) {}
+  ) {
+    // Sanity check for all URLs to be properly defined. Otherwise it will error in loop on fetch
+    if (urls.length === 0) {
+      throw Error("No urls provided to JsonRpcHttpClient");
+    }
+    for (const [i, url] of urls.entries()) {
+      if (!url) {
+        throw Error(`JsonRpcHttpClient.urls[${i}] is empty or undefined: ${url}`);
+      }
+    }
+  }
 
   /**
    * Perform RPC request


### PR DESCRIPTION
**Motivation**

Running current master without setting neither `eth1.providerUrl` or `eth1.providerUrls` causes the node to error in an infinite loop.

**Description**

- Fix CLI options handling to not return `[undefined]` if not option is set
- In the JSON RPC provider, guard against malformed urls
- sleep at least 1 second to prevent infinite loops in case of sync errors