### PR TITLE
Implement getIndexedSyncCommittee

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/indexedSyncCommittee.ts
+++ b/packages/beacon-state-transition/src/allForks/util/indexedSyncCommittee.ts
@@ -1,5 +1,7 @@
-import {altair, phase0, ssz} from "@chainsafe/lodestar-types";
+import {altair, phase0, ssz, allForks, Slot} from "@chainsafe/lodestar-types";
 import {TreeBacked, Vector} from "@chainsafe/ssz";
+import {computeSyncPeriodAtSlot} from "../../util/epoch";
+import {CachedBeaconState} from "./cachedBeaconState";
 import {PubkeyIndexMap} from "./epochContext";
 
 type SyncComitteeValidatorIndexMap = Map<phase0.ValidatorIndex, number[]>;
@@ -104,4 +106,24 @@ function computeSyncCommitteeIndices(
     }
   }
   return result;
+}
+
+/**
+ * Note: The range of slots a validator has to perform duties is off by one.
+ * The previous slot wording means that if your validator is in a sync committee for a period that runs from slot
+ * 100 to 200,then you would actually produce signatures in slot 99 - 199.
+ */
+export function getIndexedSyncCommittee(
+  state: CachedBeaconState<allForks.BeaconState> | CachedBeaconState<altair.BeaconState>,
+  slot: Slot
+): IndexedSyncCommittee {
+  const statePeriod = computeSyncPeriodAtSlot(state.slot);
+  const slotPeriod = computeSyncPeriodAtSlot(slot + 1); // See note above for the +1 offset
+  if (slotPeriod === statePeriod) {
+    return state.currentSyncCommittee;
+  } else if (slotPeriod === statePeriod + 1) {
+    return state.nextSyncCommittee;
+  } else {
+    throw new Error(`State ${state.slot} does not contain sync committee for slot ${slot}`);
+  }
 }

--- a/packages/lodestar/src/api/impl/beacon/pool/index.ts
+++ b/packages/lodestar/src/api/impl/beacon/pool/index.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import {Api as IBeaconPoolApi} from "@chainsafe/lodestar-api/lib/routes/beacon/pool";
 import {Epoch} from "@chainsafe/lodestar-types";
+import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
 import {validateGossipAttestation} from "../../../../chain/validation";
 import {validateGossipAttesterSlashing} from "../../../../chain/validation/attesterSlashing";
@@ -117,7 +118,8 @@ export function getBeaconPoolApi({
       await Promise.all(
         signatures.map(async (signature, i) => {
           try {
-            const indexesInCommittee = state.currentSyncCommittee.validatorIndexMap.get(signature.validatorIndex);
+            const synCommittee = allForks.getIndexedSyncCommittee(state, signature.slot);
+            const indexesInCommittee = synCommittee.validatorIndexMap.get(signature.validatorIndex);
             if (indexesInCommittee === undefined || indexesInCommittee.length === 0) {
               return; // Not a sync committee member
             }

--- a/packages/lodestar/src/chain/validation/signatureSets/syncCommitteeContribution.ts
+++ b/packages/lodestar/src/chain/validation/signatureSets/syncCommitteeContribution.ts
@@ -1,5 +1,6 @@
 import {PublicKey} from "@chainsafe/bls";
 import {altair, ssz} from "@chainsafe/lodestar-types";
+import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {DOMAIN_SYNC_COMMITTEE, SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
 import {readonlyValues} from "@chainsafe/ssz";
 import {
@@ -36,11 +37,11 @@ function getContributionPubkeys(
   const subCommitteeSize = Math.floor(SYNC_COMMITTEE_SIZE / SYNC_COMMITTEE_SUBNET_COUNT);
   const startIndex = contribution.subCommitteeIndex * subCommitteeSize;
   const aggBits = Array.from(readonlyValues(contribution.aggregationBits));
-
+  const syncCommittee = allForks.getIndexedSyncCommittee(state, contribution.slot);
   for (const [i, bit] of aggBits.entries()) {
     if (bit) {
       const indexInCommittee = startIndex + i;
-      const validatorIndex = state.currentSyncCommittee.validatorIndices[indexInCommittee];
+      const validatorIndex = syncCommittee.validatorIndices[indexInCommittee];
       const pubkey = state.index2pubkey[validatorIndex];
       pubkeys.push(pubkey);
     }


### PR DESCRIPTION
**Motivation**

+ Teku found invalid sync committee messages at the edge of sync committee period
+ It's due to the wrong sync committee used. The spec said `for every slot in the current sync committee period, the validator should prepare a SyncCommitteeMessage for the previous slot (slot - 1)`

**Description**
+ In lodestar, we already have the logic to get correct sync committee, we want to apply it in every place we need a sync committee
+ So I implement `getIndexedSyncCommiteee()` and use it whenever we want an IndexedSyncCommittee, this is the same to the spec, for example
```
if compute_sync_committee_period(get_current_epoch(state)) == compute_sync_committee_period(next_slot_epoch):
        sync_committee = state.current_sync_committee
    else:
        sync_committee = state.next_sync_committee
```


Closes #2878

**Steps to test or reproduce**

Join `altair-devnet-1`