### PR TITLE
Harden docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,9 @@ COPY --from=build /usr/app .
 # Sanity check
 RUN /usr/app/node_modules/.bin/lodestar --help
 
-ENTRYPOINT ["node", "--max-old-space-size=8192", "/usr/app/node_modules/.bin/lodestar"]
+# NodeJS applications have a default memory limit of 2.5GB.
+# This limit is bit tight for a Prater node, it is recommended to raise the limit
+# since memory may spike during certain network conditions.
+ENV NODE_OPTIONS=--max_old_space_size=6144
+
+ENTRYPOINT ["node", "/usr/app/node_modules/.bin/lodestar"]

--- a/default.env
+++ b/default.env
@@ -6,3 +6,7 @@ LODESTAR_NETWORK=mainnet
 # This limit is bit tight for a Prater node, it is recommended to raise the limit
 # since memory may spike during certain network conditions.
 NODE_OPTIONS=--max_old_space_size=8192
+
+# Set a custom admin password to prevent having to signup.
+# Otherwise Grafana will invite you to change the default password 'admin'
+GF_SECURITY_ADMIN_PASSWORD=

--- a/default.env
+++ b/default.env
@@ -2,11 +2,6 @@
 # Allowed values are: mainnet and pyrmont (others may work, but are deprecated)
 LODESTAR_NETWORK=mainnet
 
-# NodeJS applications have a default memory limit of 2.5GB.
-# This limit is bit tight for a Prater node, it is recommended to raise the limit
-# since memory may spike during certain network conditions.
-NODE_OPTIONS=--max_old_space_size=8192
-
 # Set a custom admin password to prevent having to signup.
 # Otherwise Grafana will invite you to change the default password 'admin'
 GF_SECURITY_ADMIN_PASSWORD=

--- a/docker-compose.validator.yml
+++ b/docker-compose.validator.yml
@@ -10,6 +10,10 @@ services:
       - ./secrets:/secrets
     env_file: .env
     command: validator --rootDir /data --keystoresDir /keystores --secretsDir /secrets --server http://beacon_node:9596 --logFile /logs/validator.log --logLevelFile debug --logRotate --logMaxFiles 5
+    # A validator client requires very little memory. This limit allows to run the validator
+    # along with the beacon_node in a 8GB machine and be safe on memory spikes.
+    env:
+      NODE_OPTIONS: --max_old_space_size=2048
 
 volumes:
   validator:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       - "9000:9000" # P2P port
     #  - "9596:9596" # REST API port
     command: beacon --rootDir /data --api.rest.enabled --api.rest.host 0.0.0.0 --metrics.enabled --logFile /logs/beacon.log --logLevelFile debug --logRotate --logMaxFiles 5
+    # NodeJS applications have a default memory limit of 2.5GB.
+    # This limit is bit tight for a Prater node, it is recommended to raise the limit
+    # since memory may spike during certain network conditions.
+    env:
+      NODE_OPTIONS: --max_old_space_size=6144
 
   prometheus:
     build: docker/prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,10 @@ services:
       - "prometheus:/prometheus"
 
   grafana:
-    build: docker/grafana
+    build:
+      context: docker/grafana
+      args:
+        GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
     restart: always
     ports:
       - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     env_file: .env
     ports:
       - "9000:9000" # P2P port
-      - "9596:9596" # REST API port
+    #  - "9596:9596" # REST API port
     command: beacon --rootDir /data --api.rest.enabled --api.rest.host 0.0.0.0 --metrics.enabled --logFile /logs/beacon.log --logLevelFile debug --logRotate --logMaxFiles 5
 
   prometheus:

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -22,7 +22,7 @@ services:
     build:
       context: grafana
       args:
-        datasource_file: datasource.local.yml
+        DATASOURCE_FILE: datasource.local.yml
     restart: always
     volumes:
       - "grafana:/var/lib/grafana"

--- a/docker/from_source.Dockerfile
+++ b/docker/from_source.Dockerfile
@@ -36,4 +36,9 @@ FROM node:14-alpine
 WORKDIR /usr/app
 COPY --from=build /usr/app .
 
-ENTRYPOINT ["node", "--max-old-space-size=8192", "./packages/cli/bin/lodestar"]
+# NodeJS applications have a default memory limit of 2.5GB.
+# This limit is bit tight for a Prater node, it is recommended to raise the limit
+# since memory may spike during certain network conditions.
+ENV NODE_OPTIONS=--max_old_space_size=6144
+
+ENTRYPOINT ["node", "./packages/cli/bin/lodestar"]

--- a/docker/grafana/Dockerfile
+++ b/docker/grafana/Dockerfile
@@ -5,12 +5,13 @@ COPY provisioning/dashboards/*.json /provisioning/dashboards/
 COPY grafana.ini /etc/grafana.ini
 
 # Modified datasource to work with a network_mode: host
-ARG datasource_file=./datasource.yml
-COPY ${datasource_file} /etc/grafana/provisioning/datasources/datasource.yml
+ARG DATASOURCE_FILE=./datasource.yml
+COPY ${DATASOURCE_FILE} /etc/grafana/provisioning/datasources/datasource.yml
 
-ENV GF_AUTH_ANONYMOUS_ENABLED="true" \
-  GF_AUTH_ANONYMOUS_ORG_ROLE="Admin" \
-  GF_AUTH_DISABLE_LOGIN_FORM="true"
+# Set GF_SECURITY_ADMIN_PASSWORD=your-password to the root .env file
+ARG GF_SECURITY_ADMIN_PASSWORD
+ENV GF_SECURITY_ADMIN_USER=admin \
+  GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD}
 
 CMD [ \
   "--homepath=/usr/share/grafana", \

--- a/docker/grafana/grafana.ini
+++ b/docker/grafana/grafana.ini
@@ -5,24 +5,6 @@
 provisioning = /etc/grafana/provisioning
 data = /var/lib/grafana
 
-[security]
-# disable creation of admin user on first start of grafana
-disable_initial_admin_creation = true
-
-[auth]
-# Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
-disable_login_form = true
-
-# Set to true to disable the signout link in the side menu. useful if you use auth.proxy, defaults to false
-disable_signout_menu = true
-
-[auth.anonymous]
-# enable anonymous access
-enabled = true
-
-# specify role for unauthenticated users
-org_role = Admin
-
 [log]
 # Either "console", "file", "syslog". Default is console and  file
 # Use space to separate multiple modes, e.g. "console file"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:spec-main": "lerna run test:spec-main --no-bail",
     "benchmark": "node --max-old-space-size=4096 -r ts-node/register -r ./packages/lodestar/test/setup.ts ./node_modules/.bin/benchmark 'packages/*/test/perf/**/*.test.ts'",
     "benchmark:local": "yarn benchmark --local",
+    "cli": "node --trace-deprecation --max-old-space-size=8192 ./packages/cli/bin/lodestar",
     "publish:release": "lerna publish from-package --yes --no-verify-access",
     "release": "lerna version --no-push --sign-git-commit",
     "postrelease": "git tag -d $(git describe --abbrev=0)",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "test:spec-main": "lerna run test:spec-main --no-bail",
     "benchmark": "node --max-old-space-size=4096 -r ts-node/register -r ./packages/lodestar/test/setup.ts ./node_modules/.bin/benchmark 'packages/*/test/perf/**/*.test.ts'",
     "benchmark:local": "yarn benchmark --local",
-    "cli": "node --trace-deprecation --max-old-space-size=8192 ./packages/cli/bin/lodestar",
     "publish:release": "lerna publish from-package --yes --no-verify-access",
     "release": "lerna version --no-push --sign-git-commit",
     "postrelease": "git tag -d $(git describe --abbrev=0)",


### PR DESCRIPTION
**Motivation**

Our setup was too focused on our needs of rapid prototyping. This PR improves it a bit to be more secure.

**Description**

- Disable anonymous login in Grafana.
  - Users that just `docker-compose up` the setup, Grafana will prompt to change the password on the first login. Default credentials are u: `admin`, p: `admin`.
  - For us that we constantly re-build Grafana to update the charts we can set `GF_SECURITY_ADMIN_PASSWORD` ENV to a well known password by the team so we can always login with it across builds
 - Don't expose API port by default
 - Move NODE_OPTIONS to ENV to split beacon_node and validator limits. Only extend the memory ceiling for the beacon_node process, not also the validator.