### PR TITLE
Move CLI script to .sh file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
         run: yarn build
         if: steps.cache-deps.outputs.cache-hit == 'true'
       # </common-build>
+      - name: Test root binary exists
+        run: ./lodestar --version
       - name: Check Types
         run: yarn run check-types
       - name: Lint

--- a/lodestar
+++ b/lodestar
@@ -1,1 +1,7 @@
-packages/cli/bin/lodestar
+#!/usr/bin/env bash
+
+# Convenience script to run the lodestar binary from built source
+#
+# ./lodestar.sh beacon --network prater
+
+node --trace-deprecation --max-old-space-size=6144 ./packages/cli/bin/lodestar "$@"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "test:spec-main": "lerna run test:spec-main --no-bail",
     "benchmark": "node --max-old-space-size=4096 -r ts-node/register -r ./packages/lodestar/test/setup.ts ./node_modules/.bin/benchmark 'packages/*/test/perf/**/*.test.ts'",
     "benchmark:local": "yarn benchmark --local",
-    "cli": "node --trace-deprecation --max-old-space-size=8192 ./packages/cli/bin/lodestar",
     "publish:release": "lerna publish from-package --yes --no-verify-access",
     "release": "lerna version --no-push --sign-git-commit",
     "postrelease": "git tag -d $(git describe --abbrev=0)",


### PR DESCRIPTION
**Motivation**

Remove cli link in package.json. Running the node through yarn is very problematic because signals are not properly propagated potentially causing zombie processes.

**Description**

This script forces people to not use yarn to run this command, so signal handling is fine. It replaces the existing soft link so it can also extend the memory limit of node.