### PR TITLE
Control error logging in validator at the logger level

### DIFF
--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -3,7 +3,7 @@ import {phase0, Slot, CommitteeIndex, ssz} from "@chainsafe/lodestar-types";
 import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {prettyBytes, sleep} from "@chainsafe/lodestar-utils";
 import {Api} from "@chainsafe/lodestar-api";
-import {extendError, notAborted, IClock, ILoggerVc} from "../util";
+import {extendError, IClock, ILoggerVc} from "../util";
 import {ValidatorStore} from "./validatorStore";
 import {AttestationDutiesService, AttDutyAndProof} from "./attestationDuties";
 import {groupAttDutiesByCommitteeIndex} from "./utils";
@@ -41,7 +41,7 @@ export class AttestationService {
       Array.from(dutiesByCommitteeIndex.entries()).map(async ([committeeIndex, duties]) => {
         if (duties.length === 0) return;
         await this.publishAttestationsAndAggregates(slot, committeeIndex, duties, signal).catch((e) => {
-          if (notAborted(e)) this.logger.error("Error on attestations routine", {slot, committeeIndex}, e);
+          this.logger.error("Error on attestations routine", {slot, committeeIndex}, e);
         });
       })
     );
@@ -101,7 +101,7 @@ export class AttestationService {
         signedAttestations.push(await this.validatorStore.signAttestation(duty, attestation, currentEpoch));
         this.logger.debug("Signed attestation", logCtxValidator);
       } catch (e) {
-        if (notAborted(e)) this.logger.error("Error signing attestation", logCtxValidator, e);
+        this.logger.error("Error signing attestation", logCtxValidator, e);
       }
     }
 
@@ -110,7 +110,7 @@ export class AttestationService {
         await this.api.beacon.submitPoolAttestations(signedAttestations);
         this.logger.info("Published attestations", {...logCtx, count: signedAttestations.length});
       } catch (e) {
-        if (notAborted(e)) this.logger.error("Error publishing attestations", logCtx, e);
+        this.logger.error("Error publishing attestations", logCtx, e);
       }
     }
 
@@ -158,7 +158,7 @@ export class AttestationService {
           this.logger.debug("Signed aggregateAndProofs", logCtxValidator);
         }
       } catch (e) {
-        if (notAborted(e)) this.logger.error("Error signing aggregateAndProofs", logCtxValidator, e);
+        this.logger.error("Error signing aggregateAndProofs", logCtxValidator, e);
       }
     }
 
@@ -167,7 +167,7 @@ export class AttestationService {
         await this.api.validator.publishAggregateAndProofs(signedAggregateAndProofs);
         this.logger.info("Published aggregateAndProofs", {...logCtx, count: signedAggregateAndProofs.length});
       } catch (e) {
-        if (notAborted(e)) this.logger.error("Error publishing aggregateAndProofs", logCtx, e);
+        this.logger.error("Error publishing aggregateAndProofs", logCtx, e);
       }
     }
   }

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -2,7 +2,7 @@ import {BLSPubkey, Slot} from "@chainsafe/lodestar-types";
 import {prettyBytes} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
 import {Api} from "@chainsafe/lodestar-api";
-import {IClock, extendError, notAborted, ILoggerVc} from "../util";
+import {IClock, extendError, ILoggerVc} from "../util";
 import {ValidatorStore} from "./validatorStore";
 import {BlockDutiesService, GENESIS_SLOT} from "./blockDuties";
 
@@ -37,7 +37,7 @@ export class BlockProposingService {
     }
 
     Promise.all(proposers.map((pubkey) => this.createAndPublishBlock(pubkey, slot))).catch((e) => {
-      if (notAborted(e)) this.logger.error("Error on block duties", {slot}, e);
+      this.logger.error("Error on block duties", {slot}, e);
     });
   };
 
@@ -63,7 +63,7 @@ export class BlockProposingService {
       });
       this.logger.info("Published block", {...logCtx, graffiti});
     } catch (e) {
-      if (notAborted(e)) this.logger.error("Error proposing block", logCtx, e);
+      this.logger.error("Error proposing block", logCtx, e);
     }
   }
 }

--- a/packages/validator/src/services/blockDuties.ts
+++ b/packages/validator/src/services/blockDuties.ts
@@ -2,7 +2,7 @@ import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {BLSPubkey, Epoch, Root, Slot, ssz} from "@chainsafe/lodestar-types";
 import {toHexString} from "@chainsafe/ssz";
 import {Api, routes} from "@chainsafe/lodestar-api";
-import {IClock, extendError, isSyncing, notAborted, differenceHex, ILoggerVc} from "../util";
+import {IClock, extendError, differenceHex, ILoggerVc} from "../util";
 import {ValidatorStore} from "./validatorStore";
 
 /** Only retain `HISTORICAL_DUTIES_EPOCHS` duties prior to the current epoch */
@@ -70,8 +70,7 @@ export class BlockDutiesService {
         await this.pollBeaconProposersAndNotify(slot);
       }
     } catch (e) {
-      if (isSyncing(e)) this.logger.isSyncing(e);
-      else if (notAborted(e)) this.logger.error("Error on pollBeaconProposers", {}, e);
+      this.logger.error("Error on pollBeaconProposers", {}, e);
     } finally {
       this.pruneOldDuties(computeEpochAtSlot(slot));
     }

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -4,7 +4,7 @@ import {Slot, CommitteeIndex, altair, Root} from "@chainsafe/lodestar-types";
 import {prettyBytes, sleep} from "@chainsafe/lodestar-utils";
 import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {Api} from "@chainsafe/lodestar-api";
-import {IClock, extendError, notAborted, ILoggerVc} from "../util";
+import {IClock, extendError, ILoggerVc} from "../util";
 import {ValidatorStore} from "./validatorStore";
 import {SyncCommitteeDutiesService, SyncDutyAndProofs} from "./syncCommitteeDuties";
 import {groupSyncDutiesBySubCommitteeIndex, SubCommitteeDuty} from "./utils";
@@ -65,8 +65,7 @@ export class SyncCommitteeService {
           // Then download, sign and publish a `SignedAggregateAndProof` for each
           // validator that is elected to aggregate for this `slot` and `subcommitteeIndex`.
           await this.produceAndPublishAggregates(slot, subcommitteeIndex, beaconBlockRoot, duties).catch((e) => {
-            if (notAborted(e))
-              this.logger.error("Error on SyncCommitteeContribution", {slot, index: subcommitteeIndex}, e);
+            this.logger.error("Error on SyncCommitteeContribution", {slot, index: subcommitteeIndex}, e);
           });
         })
       );
@@ -111,7 +110,7 @@ export class SyncCommitteeService {
         );
         this.logger.debug("Signed SyncCommitteeMessage", logCtxValidator);
       } catch (e) {
-        if (notAborted(e)) this.logger.error("Error signing SyncCommitteeMessage", logCtxValidator, e);
+        this.logger.error("Error signing SyncCommitteeMessage", logCtxValidator, e);
       }
     }
 
@@ -120,7 +119,7 @@ export class SyncCommitteeService {
         await this.api.beacon.submitPoolSyncCommitteeSignatures(signatures);
         this.logger.info("Published SyncCommitteeMessage", {...logCtx, count: signatures.length});
       } catch (e) {
-        if (notAborted(e)) this.logger.error("Error publishing SyncCommitteeMessage", logCtx, e);
+        this.logger.error("Error publishing SyncCommitteeMessage", logCtx, e);
       }
     }
 
@@ -170,7 +169,7 @@ export class SyncCommitteeService {
           this.logger.debug("Signed SyncCommitteeContribution", logCtxValidator);
         }
       } catch (e) {
-        if (notAborted(e)) this.logger.error("Error signing SyncCommitteeContribution", logCtxValidator, e);
+        this.logger.error("Error signing SyncCommitteeContribution", logCtxValidator, e);
       }
     }
 
@@ -179,7 +178,7 @@ export class SyncCommitteeService {
         await this.api.validator.publishContributionAndProofs(signedContributions);
         this.logger.info("Published SyncCommitteeContribution", {...logCtx, count: signedContributions.length});
       } catch (e) {
-        if (notAborted(e)) this.logger.error("Error publishing SyncCommitteeContribution", logCtx, e);
+        this.logger.error("Error publishing SyncCommitteeContribution", logCtx, e);
       }
     }
   }

--- a/packages/validator/src/util/clock.ts
+++ b/packages/validator/src/util/clock.ts
@@ -4,6 +4,7 @@ import {GENESIS_SLOT, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {Epoch, Number64, Slot} from "@chainsafe/lodestar-types";
 import {computeEpochAtSlot, getCurrentSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {isAbortedError} from "./error";
 
 type RunEveryFn = (slot: Slot, signal: AbortSignal) => Promise<void>;
 
@@ -34,7 +35,9 @@ export class Clock implements IClock {
   start(signal: AbortSignal): void {
     for (const {timeItem, fn} of this.fns) {
       this.runAtMostEvery(timeItem, signal, fn).catch((e) => {
-        this.logger.error("runAtMostEvery", {}, e);
+        if (!isAbortedError(e)) {
+          this.logger.error("runAtMostEvery", {}, e);
+        }
       });
     }
   }

--- a/packages/validator/src/util/error.ts
+++ b/packages/validator/src/util/error.ts
@@ -1,4 +1,3 @@
-import {HttpError} from "@chainsafe/lodestar-api";
 import {ErrorAborted} from "@chainsafe/lodestar-utils";
 
 /**
@@ -10,16 +9,8 @@ export function extendError(e: Error, prependMessage: string): Error {
 }
 
 /**
- * Returns true if arg `e` is not an instance of `ErrorAborted`
+ * Returns true if arg `e` is an instance of `ErrorAborted`
  */
-export function notAborted(e: Error): boolean {
-  return !(e instanceof ErrorAborted);
-}
-
-/**
- * Returns true if it's an network error with code 503 = Node is syncing
- * https://github.com/ethereum/eth2.0-APIs/blob/e68a954e1b6f6eb5421abf4532c171ce301c6b2e/types/http.yaml#L62
- */
-export function isSyncing(e: Error): boolean {
-  return !(e instanceof HttpError && e.status === 503);
+export function isAbortedError(e: Error): boolean {
+  return e instanceof ErrorAborted;
 }


### PR DESCRIPTION
**Motivation**

PR https://github.com/ChainSafe/lodestar/pull/2817 reduced verbosity of is syncing errors on **some** handlers.

**Description**

Applies the same logic to all handlers since it unpredictable at what point of the validator flow the node may start or stop syncing.