### PR TITLE
Produce SyncAggregate from best contributions of each subnet

### DIFF
--- a/packages/lodestar/src/chain/opPools/types.ts
+++ b/packages/lodestar/src/chain/opPools/types.ts
@@ -13,6 +13,8 @@ export enum InsertOutcome {
   Old = "Old",
   /** The data is know, and the new participants have been added to the aggregated signature */
   Aggregated = "Aggregated",
+  /** The data is not better than the existing data*/
+  NotBetterThan = "NotBetterThan",
 }
 
 export enum OpPoolErrorCode {


### PR DESCRIPTION
**Motivation**

On `altair-devnet-1`, the participation percent from SyncAggregation is around 50% - 60% in average

**Description**

+ Right now, we do preaggregate which select the first contribution of each subnet
+ This PR stores best contribution of each subnet in a map and do the aggregation at the time of producing block

Closes #2892

**Test result**
+ Command: `curl http:///localhost:9596/eth/v1/validator/blocks/${slots}?randao_reveal=0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505`
+ Note that real result may be better due to the timing to issue `curl`

|Block| Num Participation|Percentage|In the explorer|
|------|------------------|------------|--------------|
|91317|446|87%|87% (lighthouse)|
|91351|424|82%|83% (lighthouse)
