### PR TITLE
Remove unnecessary params

### DIFF
--- a/packages/light-client/src/utils/syncPeriod.ts
+++ b/packages/light-client/src/utils/syncPeriod.ts
@@ -1,24 +1,23 @@
-import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {Epoch, Slot, SyncPeriod} from "@chainsafe/lodestar-types";
 
 /**
  * Return the epoch number at the given slot.
  */
-export function computeEpochAtSlot(config: IBeaconConfig, slot: Slot): Epoch {
+export function computeEpochAtSlot(slot: Slot): Epoch {
   return Math.floor(slot / SLOTS_PER_EPOCH);
 }
 
 /**
  * Return the sync committee period at slot
  */
-export function computeSyncPeriodAtSlot(config: IBeaconConfig, slot: Slot): SyncPeriod {
-  return computeSyncPeriodAtEpoch(config, computeEpochAtSlot(config, slot));
+export function computeSyncPeriodAtSlot(slot: Slot): SyncPeriod {
+  return computeSyncPeriodAtEpoch(computeEpochAtSlot(slot));
 }
 
 /**
  * Return the sync committee period at epoch
  */
-export function computeSyncPeriodAtEpoch(config: IBeaconConfig, epoch: Epoch): SyncPeriod {
+export function computeSyncPeriodAtEpoch(epoch: Epoch): SyncPeriod {
   return Math.floor(epoch / EPOCHS_PER_SYNC_COMMITTEE_PERIOD);
 }


### PR DESCRIPTION
**Motivation**
Debugging the light client demo, these utility functions are used there.

**Description**
These utility functions don't need the config parameter anymore.