### PR TITLE
Improve processEffectiveBalanceUpdates

### DIFF
--- a/packages/beacon-state-transition/src/allForks/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processEffectiveBalanceUpdates.ts
@@ -22,7 +22,7 @@ export function processEffectiveBalanceUpdates(
   (process.balances ?? state.balances).forEach((balance: bigint, i: number) => {
     const effectiveBalance = process.validators[i].effectiveBalance;
     const isTooBig = effectiveBalance > balance + DOWNWARD_THRESHOLD;
-    const isTooSmall = effectiveBalance !== MAX_EFFECTIVE_BALANCE && effectiveBalance < balance - UPWARD_THRESHOLD;
+    const isTooSmall = effectiveBalance < MAX_EFFECTIVE_BALANCE && effectiveBalance < balance - UPWARD_THRESHOLD;
     if (isTooBig || isTooSmall) {
       validators.update(i, {
         effectiveBalance: bigIntMin(balance - (balance % EFFECTIVE_BALANCE_INCREMENT), MAX_EFFECTIVE_BALANCE),

--- a/packages/beacon-state-transition/src/allForks/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processEffectiveBalanceUpdates.ts
@@ -21,7 +21,9 @@ export function processEffectiveBalanceUpdates(
   // update effective balances with hysteresis
   (process.balances ?? state.balances).forEach((balance: bigint, i: number) => {
     const effectiveBalance = process.validators[i].effectiveBalance;
-    if (balance + DOWNWARD_THRESHOLD < effectiveBalance || effectiveBalance + UPWARD_THRESHOLD < balance) {
+    const isTooBig = effectiveBalance > balance + DOWNWARD_THRESHOLD;
+    const isTooSmall = effectiveBalance !== MAX_EFFECTIVE_BALANCE && effectiveBalance < balance - UPWARD_THRESHOLD;
+    if (isTooBig || isTooSmall) {
       validators.update(i, {
         effectiveBalance: bigIntMin(balance - (balance % EFFECTIVE_BALANCE_INCREMENT), MAX_EFFECTIVE_BALANCE),
       });

--- a/packages/beacon-state-transition/src/allForks/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processEffectiveBalanceUpdates.ts
@@ -21,9 +21,12 @@ export function processEffectiveBalanceUpdates(
   // update effective balances with hysteresis
   (process.balances ?? state.balances).forEach((balance: bigint, i: number) => {
     const effectiveBalance = process.validators[i].effectiveBalance;
-    const isTooBig = effectiveBalance > balance + DOWNWARD_THRESHOLD;
-    const isTooSmall = effectiveBalance < MAX_EFFECTIVE_BALANCE && effectiveBalance < balance - UPWARD_THRESHOLD;
-    if (isTooBig || isTooSmall) {
+    if (
+      // Too big
+      effectiveBalance > balance + DOWNWARD_THRESHOLD ||
+      // Too small. Check effectiveBalance < MAX_EFFECTIVE_BALANCE to prevent unnecessary updates
+      (effectiveBalance < MAX_EFFECTIVE_BALANCE && effectiveBalance < balance - UPWARD_THRESHOLD)
+    ) {
       validators.update(i, {
         effectiveBalance: bigIntMin(balance - (balance % EFFECTIVE_BALANCE_INCREMENT), MAX_EFFECTIVE_BALANCE),
       });


### PR DESCRIPTION
**Motivation**

+ It takes so long to process epoch on mainnet (5.4s in my environment)
+ I added some log, it showed that it updates around 75000 effective balance of validators per epoch

**Description**

+ Since we have `MAX_EFFECTIVE_BALANCE`, it turns out that we waste our time to update effective balance for most/all of validators
+ We should NOT update if we see that the effective balance is too small to balance, but it's already `MAX_EFFECTIVE_BALANCE`. New log shows that we have to update 0 effective balance.
+ Epoch transition is reduced from 5.4s to ~650ms
<img width="512" alt="Screen Shot 2021-07-29 at 09 00 22" src="https://user-images.githubusercontent.com/10568965/127420599-9c345d68-a28d-401d-85f2-12c917b0234f.png">

Closes #2901 

**Steps to test or reproduce**

+ Sync mainnet