### PR TITLE
Process sync objects with concurrency

### DIFF
--- a/packages/lodestar/src/network/gossip/validation/queue.ts
+++ b/packages/lodestar/src/network/gossip/validation/queue.ts
@@ -16,8 +16,8 @@ const gossipQueueOpts: {[K in GossipType]: Pick<JobQueueOpts, "maxLength" | "typ
   [GossipType.voluntary_exit]: {maxLength: 4096, type: QueueType.FIFO},
   [GossipType.proposer_slashing]: {maxLength: 4096, type: QueueType.FIFO},
   [GossipType.attester_slashing]: {maxLength: 4096, type: QueueType.FIFO},
-  [GossipType.sync_committee_contribution_and_proof]: {maxLength: 4096, type: QueueType.LIFO},
-  [GossipType.sync_committee]: {maxLength: 4096, type: QueueType.LIFO},
+  [GossipType.sync_committee_contribution_and_proof]: {maxLength: 4096, type: QueueType.LIFO, maxConcurrency: 16},
+  [GossipType.sync_committee]: {maxLength: 4096, type: QueueType.LIFO, maxConcurrency: 64},
 };
 
 /**


### PR DESCRIPTION
**Motivation**

In altair-devnet-2 we are too slow processing sync objects.

**Description**

Increase concurrency to be able to process more objects in one slot