### PR TITLE
Simplify block processor types

### DIFF
--- a/packages/beacon-state-transition/src/altair/block/index.ts
+++ b/packages/beacon-state-transition/src/altair/block/index.ts
@@ -9,6 +9,7 @@ import {processDeposit} from "./processDeposit";
 import {processProposerSlashing} from "./processProposerSlashing";
 import {processVoluntaryExit} from "./processVoluntaryExit";
 import {processSyncAggregate} from "./processSyncCommittee";
+import {BlockProcess} from "../../util";
 
 export {
   processOperations,
@@ -25,7 +26,7 @@ export function processBlock(
   block: altair.BeaconBlock,
   verifySignatures = true
 ): void {
-  const blockProcess = {validatorExitCache: {}};
+  const blockProcess: BlockProcess = {};
   processBlockHeader(state as CachedBeaconState<allForks.BeaconState>, block);
   processRandao(state as CachedBeaconState<allForks.BeaconState>, block, verifySignatures);
   processEth1Data(state as CachedBeaconState<allForks.BeaconState>, block.body);

--- a/packages/beacon-state-transition/src/altair/block/processAttestation.ts
+++ b/packages/beacon-state-transition/src/altair/block/processAttestation.ts
@@ -24,7 +24,7 @@ export function processAttestation(
   state: CachedBeaconState<altair.BeaconState>,
   attestation: phase0.Attestation,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess,
   verifySignature = true
 ): void {
   const {epochCtx} = state;

--- a/packages/beacon-state-transition/src/altair/block/processAttesterSlashing.ts
+++ b/packages/beacon-state-transition/src/altair/block/processAttesterSlashing.ts
@@ -7,7 +7,7 @@ import {BlockProcess} from "../../util/blockProcess";
 export function processAttesterSlashing(
   state: CachedBeaconState<altair.BeaconState>,
   attesterSlashing: phase0.AttesterSlashing,
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess,
   verifySignatures = true
 ): void {
   processAttesterSlashingAllForks(

--- a/packages/beacon-state-transition/src/altair/block/processOperations.ts
+++ b/packages/beacon-state-transition/src/altair/block/processOperations.ts
@@ -26,7 +26,7 @@ type OperationFunction = (
 export function processOperations(
   state: CachedBeaconState<altair.BeaconState>,
   body: altair.BeaconBlockBody,
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess,
   verifySignatures = true
 ): void {
   // verify that outstanding deposits are processed up to the maximum number of deposits

--- a/packages/beacon-state-transition/src/altair/block/processProposerSlashing.ts
+++ b/packages/beacon-state-transition/src/altair/block/processProposerSlashing.ts
@@ -7,7 +7,7 @@ import {BlockProcess} from "../../util/blockProcess";
 export function processProposerSlashing(
   state: CachedBeaconState<altair.BeaconState>,
   proposerSlashing: phase0.ProposerSlashing,
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess,
   verifySignatures = true
 ): void {
   processProposerSlashingAllForks(

--- a/packages/beacon-state-transition/src/altair/block/processVoluntaryExit.ts
+++ b/packages/beacon-state-transition/src/altair/block/processVoluntaryExit.ts
@@ -6,7 +6,7 @@ import {BlockProcess} from "../../util/blockProcess";
 export function processVoluntaryExit(
   state: CachedBeaconState<altair.BeaconState>,
   signedVoluntaryExit: phase0.SignedVoluntaryExit,
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess,
   verifySignature = true
 ): void {
   processVoluntaryExitAllForks(

--- a/packages/beacon-state-transition/src/phase0/block/index.ts
+++ b/packages/beacon-state-transition/src/phase0/block/index.ts
@@ -7,6 +7,7 @@ import {processDeposit} from "./processDeposit";
 import {processAttesterSlashing} from "./processAttesterSlashing";
 import {processProposerSlashing} from "./processProposerSlashing";
 import {processVoluntaryExit} from "./processVoluntaryExit";
+import {BlockProcess} from "../../util";
 
 // Extra utils used by other modules
 export {isValidIndexedAttestation} from "../../allForks/block";
@@ -26,7 +27,7 @@ export function processBlock(
   block: phase0.BeaconBlock,
   verifySignatures = true
 ): void {
-  const blockProcess = {validatorExitCache: {}};
+  const blockProcess: BlockProcess = {};
   processBlockHeader(state as CachedBeaconState<allForks.BeaconState>, block);
   processRandao(state as CachedBeaconState<allForks.BeaconState>, block, verifySignatures);
   processEth1Data(state as CachedBeaconState<allForks.BeaconState>, block.body);

--- a/packages/beacon-state-transition/src/phase0/block/processAttestation.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processAttestation.ts
@@ -10,7 +10,7 @@ export function processAttestation(
   state: CachedBeaconState<phase0.BeaconState>,
   attestation: phase0.Attestation,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess,
   verifySignature = true
 ): void {
   const {epochCtx} = state;

--- a/packages/beacon-state-transition/src/phase0/block/processAttesterSlashing.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processAttesterSlashing.ts
@@ -8,7 +8,7 @@ import {BlockProcess} from "../../util/blockProcess";
 export function processAttesterSlashing(
   state: CachedBeaconState<phase0.BeaconState>,
   attesterSlashing: phase0.AttesterSlashing,
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess,
   verifySignatures = true
 ): void {
   processAttesterSlashingAllForks(

--- a/packages/beacon-state-transition/src/phase0/block/processProposerSlashing.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processProposerSlashing.ts
@@ -7,7 +7,7 @@ import {BlockProcess} from "../../util/blockProcess";
 export function processProposerSlashing(
   state: CachedBeaconState<phase0.BeaconState>,
   proposerSlashing: phase0.ProposerSlashing,
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess,
   verifySignatures = true
 ): void {
   processProposerSlashingAllForks(

--- a/packages/beacon-state-transition/src/phase0/block/processVoluntaryExit.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processVoluntaryExit.ts
@@ -6,7 +6,7 @@ import {BlockProcess} from "../../util/blockProcess";
 export function processVoluntaryExit(
   state: CachedBeaconState<phase0.BeaconState>,
   signedVoluntaryExit: phase0.SignedVoluntaryExit,
-  blockProcess: BlockProcess = {validatorExitCache: {}},
+  blockProcess: BlockProcess,
   verifySignature = true
 ): void {
   processVoluntaryExitAllForks(

--- a/packages/beacon-state-transition/src/util/blockProcess.ts
+++ b/packages/beacon-state-transition/src/util/blockProcess.ts
@@ -1,8 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface BlockProcess {
-  validatorExitCache: {
-    exitQueueEpoch?: number;
-    exitQueueChurn?: number;
-    churnLimit?: number;
+  validatorExitCache?: {
+    exitQueueEpoch: number;
+    exitQueueChurn: number;
+    churnLimit: number;
   };
 }

--- a/packages/spec-test-runner/test/spec/altair/operations/attestations/attestations.ts
+++ b/packages/spec-test-runner/test/spec/altair/operations/attestations/attestations.ts
@@ -22,7 +22,7 @@ export function runAttestations(presetName: PresetName): void {
         config,
         testcase.pre as TreeBacked<altair.BeaconState>
       ) as CachedBeaconState<altair.BeaconState>;
-      altair.processAttestation(wrappedState, testcase.attestation);
+      altair.processAttestation(wrappedState, testcase.attestation, {});
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/operations/attesterSlashing/attesterSlashing.ts
+++ b/packages/spec-test-runner/test/spec/altair/operations/attesterSlashing/attesterSlashing.ts
@@ -23,7 +23,7 @@ export function runAttesterSlashing(presetName: PresetName): void {
         testcase.pre as TreeBacked<altair.BeaconState>
       );
       const verify = !!testcase.meta && !!testcase.meta.blsSetting && testcase.meta.blsSetting === BigInt(1);
-      altair.processAttesterSlashing(wrappedState, testcase.attester_slashing, undefined, verify);
+      altair.processAttesterSlashing(wrappedState, testcase.attester_slashing, {}, verify);
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/operations/proposerSlashing/proposerSlashing.ts
+++ b/packages/spec-test-runner/test/spec/altair/operations/proposerSlashing/proposerSlashing.ts
@@ -22,7 +22,7 @@ export function runProposerSlashing(presetName: PresetName): void {
         config,
         testcase.pre as TreeBacked<altair.BeaconState>
       );
-      altair.processProposerSlashing(wrappedState, testcase.proposer_slashing);
+      altair.processProposerSlashing(wrappedState, testcase.proposer_slashing, {});
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/operations/voluntaryExit/voluntaryExit.ts
+++ b/packages/spec-test-runner/test/spec/altair/operations/voluntaryExit/voluntaryExit.ts
@@ -22,7 +22,7 @@ export function runVoluntaryExit(presetName: PresetName): void {
         config,
         testcase.pre as TreeBacked<altair.BeaconState>
       );
-      altair.processVoluntaryExit(wrappedState, testcase.voluntary_exit);
+      altair.processVoluntaryExit(wrappedState, testcase.voluntary_exit, {});
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/phase0/operations/attestations/attestations_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/operations/attestations/attestations_mainnet.test.ts
@@ -17,7 +17,7 @@ describeDirectorySpecTest<IProcessAttestationTestCase, phase0.BeaconState>(
       config,
       testcase.pre as TreeBacked<phase0.BeaconState>
     );
-    phase0.processAttestation(wrappedState, testcase.attestation);
+    phase0.processAttestation(wrappedState, testcase.attestation, {});
     return wrappedState;
   },
   {

--- a/packages/spec-test-runner/test/spec/phase0/operations/attesterSlashing/attester_slashing_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/operations/attesterSlashing/attester_slashing_mainnet.test.ts
@@ -18,7 +18,7 @@ describeDirectorySpecTest<IProcessAttesterSlashingTestCase, phase0.BeaconState>(
       testcase.pre as TreeBacked<phase0.BeaconState>
     );
     const verify = !!testcase.meta && !!testcase.meta.blsSetting && testcase.meta.blsSetting === BigInt(1);
-    phase0.processAttesterSlashing(wrappedState, testcase.attester_slashing, undefined, verify);
+    phase0.processAttesterSlashing(wrappedState, testcase.attester_slashing, {}, verify);
     return wrappedState;
   },
   {

--- a/packages/spec-test-runner/test/spec/phase0/operations/proposerSlashing/proposer_slashing_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/operations/proposerSlashing/proposer_slashing_mainnet.test.ts
@@ -17,7 +17,7 @@ describeDirectorySpecTest<IProcessProposerSlashingTestCase, phase0.BeaconState>(
       config,
       testcase.pre as TreeBacked<phase0.BeaconState>
     );
-    phase0.processProposerSlashing(wrappedState, testcase.proposer_slashing);
+    phase0.processProposerSlashing(wrappedState, testcase.proposer_slashing, {});
     return wrappedState;
   },
   {

--- a/packages/spec-test-runner/test/spec/phase0/operations/voluntaryExit/voluntary_exit_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/operations/voluntaryExit/voluntary_exit_mainnet.test.ts
@@ -17,7 +17,7 @@ describeDirectorySpecTest<IProcessVoluntaryExitTestCase, phase0.BeaconState>(
       config,
       testcase.pre as TreeBacked<phase0.BeaconState>
     );
-    phase0.processVoluntaryExit(wrappedState, testcase.voluntary_exit);
+    phase0.processVoluntaryExit(wrappedState, testcase.voluntary_exit, {});
     return wrappedState;
   },
   {


### PR DESCRIPTION
**Motivation**

BlockProcessor types don't accurately reflect its usage. All properties in `validatorExitCache` will either be all defined or not defined.



**Description**

Adjust BlockProcessor type to its usage

before
```ts
export interface BlockProcess {
  validatorExitCache: {
    exitQueueEpoch?: number;
    exitQueueChurn?: number;
    churnLimit?: number;
  }
}
```

after
```ts
export interface BlockProcess {
  validatorExitCache?: {
    exitQueueEpoch: number;
    exitQueueChurn: number;
    churnLimit: number;
  };
}
```