### PR TITLE
Rename process to epochProcess

### DIFF
--- a/packages/beacon-state-transition/src/allForks/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processEffectiveBalanceUpdates.ts
@@ -11,7 +11,7 @@ import {IEpochProcess, CachedBeaconState} from "../util";
 
 export function processEffectiveBalanceUpdates(
   state: CachedBeaconState<allForks.BeaconState>,
-  process: IEpochProcess
+  epochProcess: IEpochProcess
 ): void {
   const {validators} = state;
   const HYSTERESIS_INCREMENT = EFFECTIVE_BALANCE_INCREMENT / BigInt(HYSTERESIS_QUOTIENT);
@@ -19,8 +19,8 @@ export function processEffectiveBalanceUpdates(
   const UPWARD_THRESHOLD = HYSTERESIS_INCREMENT * BigInt(HYSTERESIS_UPWARD_MULTIPLIER);
 
   // update effective balances with hysteresis
-  (process.balances ?? state.balances).forEach((balance: bigint, i: number) => {
-    const effectiveBalance = process.validators[i].effectiveBalance;
+  (epochProcess.balances ?? state.balances).forEach((balance: bigint, i: number) => {
+    const effectiveBalance = epochProcess.validators[i].effectiveBalance;
     if (
       // Too big
       effectiveBalance > balance + DOWNWARD_THRESHOLD ||

--- a/packages/beacon-state-transition/src/allForks/epoch/processEth1DataReset.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processEth1DataReset.ts
@@ -3,8 +3,11 @@ import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {List} from "@chainsafe/ssz";
 import {IEpochProcess, CachedBeaconState} from "../util";
 
-export function processEth1DataReset(state: CachedBeaconState<allForks.BeaconState>, process: IEpochProcess): void {
-  const nextEpoch = process.currentEpoch + 1;
+export function processEth1DataReset(
+  state: CachedBeaconState<allForks.BeaconState>,
+  epochProcess: IEpochProcess
+): void {
+  const nextEpoch = epochProcess.currentEpoch + 1;
 
   // reset eth1 data votes
   if (nextEpoch % EPOCHS_PER_ETH1_VOTING_PERIOD === 0) {

--- a/packages/beacon-state-transition/src/allForks/epoch/processHistoricalRootsUpdate.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processHistoricalRootsUpdate.ts
@@ -5,9 +5,9 @@ import {IEpochProcess, CachedBeaconState} from "../util";
 
 export function processHistoricalRootsUpdate(
   state: CachedBeaconState<allForks.BeaconState>,
-  process: IEpochProcess
+  epochProcess: IEpochProcess
 ): void {
-  const nextEpoch = process.currentEpoch + 1;
+  const nextEpoch = epochProcess.currentEpoch + 1;
 
   // set historical root accumulator
   if (nextEpoch % intDiv(SLOTS_PER_HISTORICAL_ROOT, SLOTS_PER_EPOCH) === 0) {

--- a/packages/beacon-state-transition/src/allForks/epoch/processJustificationAndFinalization.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processJustificationAndFinalization.ts
@@ -6,10 +6,10 @@ import {CachedBeaconState, IEpochProcess} from "../util";
 
 export function processJustificationAndFinalization(
   state: CachedBeaconState<allForks.BeaconState>,
-  process: IEpochProcess
+  epochProcess: IEpochProcess
 ): void {
-  const previousEpoch = process.prevEpoch;
-  const currentEpoch = process.currentEpoch;
+  const previousEpoch = epochProcess.prevEpoch;
+  const currentEpoch = epochProcess.currentEpoch;
 
   // Initial FFG checkpoint values have a `0x00` stub for `root`.
   // Skip FFG updates in the first two epochs to avoid corner cases that might result in modifying this stub.
@@ -28,14 +28,14 @@ export function processJustificationAndFinalization(
   }
   bits[0] = false;
 
-  if (process.prevEpochUnslashedStake.targetStake * BigInt(3) >= process.totalActiveStake * BigInt(2)) {
+  if (epochProcess.prevEpochUnslashedStake.targetStake * BigInt(3) >= epochProcess.totalActiveStake * BigInt(2)) {
     state.currentJustifiedCheckpoint = {
       epoch: previousEpoch,
       root: getBlockRoot(state, previousEpoch),
     };
     bits[1] = true;
   }
-  if (process.currEpochUnslashedTargetStake * BigInt(3) >= process.totalActiveStake * BigInt(2)) {
+  if (epochProcess.currEpochUnslashedTargetStake * BigInt(3) >= epochProcess.totalActiveStake * BigInt(2)) {
     state.currentJustifiedCheckpoint = {
       epoch: currentEpoch,
       root: getBlockRoot(state, currentEpoch),

--- a/packages/beacon-state-transition/src/allForks/epoch/processRandaoMixesReset.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processRandaoMixesReset.ts
@@ -3,8 +3,11 @@ import {allForks} from "@chainsafe/lodestar-types";
 import {getRandaoMix} from "../../util";
 import {IEpochProcess, CachedBeaconState} from "../util";
 
-export function processRandaoMixesReset(state: CachedBeaconState<allForks.BeaconState>, process: IEpochProcess): void {
-  const currentEpoch = process.currentEpoch;
+export function processRandaoMixesReset(
+  state: CachedBeaconState<allForks.BeaconState>,
+  epochProcess: IEpochProcess
+): void {
+  const currentEpoch = epochProcess.currentEpoch;
   const nextEpoch = currentEpoch + 1;
 
   // set randao mix

--- a/packages/beacon-state-transition/src/allForks/epoch/processSlashingsReset.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processSlashingsReset.ts
@@ -2,8 +2,11 @@ import {EPOCHS_PER_SLASHINGS_VECTOR} from "@chainsafe/lodestar-params";
 import {allForks} from "@chainsafe/lodestar-types";
 import {IEpochProcess, CachedBeaconState} from "../util";
 
-export function processSlashingsReset(state: CachedBeaconState<allForks.BeaconState>, process: IEpochProcess): void {
-  const nextEpoch = process.currentEpoch + 1;
+export function processSlashingsReset(
+  state: CachedBeaconState<allForks.BeaconState>,
+  epochProcess: IEpochProcess
+): void {
+  const nextEpoch = epochProcess.currentEpoch + 1;
 
   // reset slashings
   state.slashings[nextEpoch % EPOCHS_PER_SLASHINGS_VECTOR] = BigInt(0);

--- a/packages/beacon-state-transition/src/allForks/stateTransition.ts
+++ b/packages/beacon-state-transition/src/allForks/stateTransition.ts
@@ -140,11 +140,11 @@ function processSlotsWithTransientCache(
       const fork = postState.config.getForkName(postState.slot);
       const timer = metrics?.stfnEpochTransition.startTimer();
       try {
-        const process = processEpochByFork[fork](postState);
-        metrics?.registerValidatorStatuses(process.currentEpoch, process.statuses);
+        const epochProcess = processEpochByFork[fork](postState);
+        metrics?.registerValidatorStatuses(epochProcess.currentEpoch, epochProcess.statuses);
 
         postState.slot++;
-        rotateEpochs(postState.epochCtx, postState, process.nextEpochActiveValidatorIndices);
+        rotateEpochs(postState.epochCtx, postState, epochProcess.nextEpochActiveValidatorIndices);
       } finally {
         if (timer) timer();
       }

--- a/packages/beacon-state-transition/src/altair/epoch/index.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/index.ts
@@ -1,5 +1,5 @@
 import {allForks, altair} from "@chainsafe/lodestar-types";
-import {prepareEpochProcessState, CachedBeaconState, IEpochProcess} from "../../allForks/util";
+import {CachedBeaconState, IEpochProcess, prepareEpochProcessState} from "../../allForks/util";
 import {
   processJustificationAndFinalization,
   processRegistryUpdates,
@@ -30,18 +30,18 @@ export {
 };
 
 export function processEpoch(state: CachedBeaconState<altair.BeaconState>): IEpochProcess {
-  const process = prepareEpochProcessState(state);
-  processJustificationAndFinalization(state as CachedBeaconState<allForks.BeaconState>, process);
-  processInactivityUpdates(state, process);
-  processRewardsAndPenalties(state, process);
-  processRegistryUpdates(state as CachedBeaconState<allForks.BeaconState>, process);
-  processSlashings(state, process);
-  processEth1DataReset(state as CachedBeaconState<allForks.BeaconState>, process);
-  processEffectiveBalanceUpdates(state as CachedBeaconState<allForks.BeaconState>, process);
-  processSlashingsReset(state as CachedBeaconState<allForks.BeaconState>, process);
-  processRandaoMixesReset(state as CachedBeaconState<allForks.BeaconState>, process);
-  processHistoricalRootsUpdate(state as CachedBeaconState<allForks.BeaconState>, process);
+  const epochProcess = prepareEpochProcessState(state);
+  processJustificationAndFinalization(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+  processInactivityUpdates(state, epochProcess);
+  processRewardsAndPenalties(state, epochProcess);
+  processRegistryUpdates(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+  processSlashings(state, epochProcess);
+  processEth1DataReset(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+  processEffectiveBalanceUpdates(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+  processSlashingsReset(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+  processRandaoMixesReset(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+  processHistoricalRootsUpdate(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
   processParticipationFlagUpdates(state);
-  processSyncCommitteeUpdates(state, process);
-  return process;
+  processSyncCommitteeUpdates(state, epochProcess);
+  return epochProcess;
 }

--- a/packages/beacon-state-transition/src/altair/epoch/processInactivityUpdates.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processInactivityUpdates.ts
@@ -9,7 +9,10 @@ import {
 } from "../../allForks/util";
 import {isInInactivityLeak} from "../../util";
 
-export function processInactivityUpdates(state: CachedBeaconState<altair.BeaconState>, process: IEpochProcess): void {
+export function processInactivityUpdates(
+  state: CachedBeaconState<altair.BeaconState>,
+  epochProcess: IEpochProcess
+): void {
   if (state.currentShuffling.epoch === GENESIS_EPOCH) {
     return;
   }
@@ -17,8 +20,8 @@ export function processInactivityUpdates(state: CachedBeaconState<altair.BeaconS
   const {INACTIVITY_SCORE_BIAS, INACTIVITY_SCORE_RECOVERY_RATE} = config;
   const inActivityLeak = isInInactivityLeak((state as unknown) as phase0.BeaconState);
   const {inactivityScores} = state;
-  for (let i = 0; i < process.statuses.length; i++) {
-    const status = process.statuses[i];
+  for (let i = 0; i < epochProcess.statuses.length; i++) {
+    const status = epochProcess.statuses[i];
     if (hasMarkers(status.flags, FLAG_ELIGIBLE_ATTESTER)) {
       let inactivityScore = inactivityScores[i];
       const prevInactivityScore = inactivityScore;

--- a/packages/beacon-state-transition/src/altair/epoch/processRewardsAndPenalties.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processRewardsAndPenalties.ts
@@ -4,14 +4,17 @@ import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
 import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
 import {getRewardsPenaltiesDeltas} from "./balance";
 
-export function processRewardsAndPenalties(state: CachedBeaconState<altair.BeaconState>, process: IEpochProcess): void {
+export function processRewardsAndPenalties(
+  state: CachedBeaconState<altair.BeaconState>,
+  epochProcess: IEpochProcess
+): void {
   const {balances} = state;
 
   if (getCurrentEpoch(state) == GENESIS_EPOCH) {
     return;
   }
 
-  const [rewards, penalties] = getRewardsPenaltiesDeltas(state, process);
+  const [rewards, penalties] = getRewardsPenaltiesDeltas(state, epochProcess);
 
   const newBalances = new BigUint64Array(balances.length);
   balances.forEach((balance, i) => {
@@ -51,5 +54,5 @@ export function processRewardsAndPenalties(state: CachedBeaconState<altair.Beaco
   // set them all at once, constructing the tree in one go
   balances.updateAll(newBalances);
   // cache the balances array, too
-  process.balances = newBalances;
+  epochProcess.balances = newBalances;
 }

--- a/packages/beacon-state-transition/src/altair/epoch/processSlashings.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processSlashings.ts
@@ -4,6 +4,6 @@ import {ForkName} from "@chainsafe/lodestar-params";
 import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
 import {processSlashingsAllForks} from "../../phase0/epoch/processSlashings";
 
-export function processSlashings(state: CachedBeaconState<altair.BeaconState>, process: IEpochProcess): void {
-  processSlashingsAllForks(ForkName.altair, state as CachedBeaconState<allForks.BeaconState>, process);
+export function processSlashings(state: CachedBeaconState<altair.BeaconState>, epochProcess: IEpochProcess): void {
+  processSlashingsAllForks(ForkName.altair, state as CachedBeaconState<allForks.BeaconState>, epochProcess);
 }

--- a/packages/beacon-state-transition/src/altair/epoch/processSyncCommitteeUpdates.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processSyncCommitteeUpdates.ts
@@ -4,9 +4,9 @@ import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD} from "@chainsafe/lodestar-params";
 
 export function processSyncCommitteeUpdates(
   state: CachedBeaconState<altair.BeaconState>,
-  process: IEpochProcess
+  epochProcess: IEpochProcess
 ): void {
-  const nextEpoch = process.currentEpoch + 1;
+  const nextEpoch = epochProcess.currentEpoch + 1;
   if (nextEpoch % EPOCHS_PER_SYNC_COMMITTEE_PERIOD === 0) {
     state.rotateSyncCommittee();
   }

--- a/packages/beacon-state-transition/src/phase0/epoch/getAttestationDeltas.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/getAttestationDeltas.ts
@@ -40,23 +40,23 @@ interface IRewardPenaltyItem {
  */
 export function getAttestationDeltas(
   state: CachedBeaconState<phase0.BeaconState>,
-  process: IEpochProcess
+  epochProcess: IEpochProcess
 ): [number[], number[]] {
-  const validatorCount = process.statuses.length;
+  const validatorCount = epochProcess.statuses.length;
   const rewards = newZeroedArray(validatorCount);
   const penalties = newZeroedArray(validatorCount);
 
   const increment = EFFECTIVE_BALANCE_INCREMENT;
-  let totalBalance = bigIntMax(process.totalActiveStake, increment);
+  let totalBalance = bigIntMax(epochProcess.totalActiveStake, increment);
 
   // increment is factored out from balance totals to avoid overflow
-  const prevEpochSourceStake = bigIntMax(process.prevEpochUnslashedStake.sourceStake, increment) / increment;
-  const prevEpochTargetStake = bigIntMax(process.prevEpochUnslashedStake.targetStake, increment) / increment;
-  const prevEpochHeadStake = bigIntMax(process.prevEpochUnslashedStake.headStake, increment) / increment;
+  const prevEpochSourceStake = bigIntMax(epochProcess.prevEpochUnslashedStake.sourceStake, increment) / increment;
+  const prevEpochTargetStake = bigIntMax(epochProcess.prevEpochUnslashedStake.targetStake, increment) / increment;
+  const prevEpochHeadStake = bigIntMax(epochProcess.prevEpochUnslashedStake.headStake, increment) / increment;
 
   // sqrt first, before factoring out the increment for later usage
   const balanceSqRoot = bigIntSqrt(totalBalance);
-  const finalityDelay = BigInt(process.prevEpoch - state.finalizedCheckpoint.epoch);
+  const finalityDelay = BigInt(epochProcess.prevEpoch - state.finalizedCheckpoint.epoch);
 
   totalBalance = totalBalance / increment;
 
@@ -67,8 +67,8 @@ export function getAttestationDeltas(
   // effectiveBalance is multiple of EFFECTIVE_BALANCE_INCREMENT and less than MAX_EFFECTIVE_BALANCE
   // so there are limited values of them like 32000000000, 31000000000, 30000000000
   const rewardPnaltyItemCache = new Map<number, IRewardPenaltyItem>();
-  for (const [i, status] of process.statuses.entries()) {
-    const effBalance = process.validators[i].effectiveBalance;
+  for (const [i, status] of epochProcess.statuses.entries()) {
+    const effBalance = epochProcess.validators[i].effectiveBalance;
     let rewardItem = rewardPnaltyItemCache.get(Number(effBalance));
     if (!rewardItem) {
       const baseReward = Number((effBalance * BASE_REWARD_FACTOR) / balanceSqRoot / BASE_REWARDS_PER_EPOCH);

--- a/packages/beacon-state-transition/src/phase0/epoch/index.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/index.ts
@@ -16,11 +16,11 @@ export {
 };
 
 export function processEpoch(state: CachedBeaconState<phase0.BeaconState>): IEpochProcess {
-  const process = prepareEpochProcessState(state);
-  processJustificationAndFinalization(state as CachedBeaconState<allForks.BeaconState>, process);
-  processRewardsAndPenalties(state, process);
-  processRegistryUpdates(state as CachedBeaconState<allForks.BeaconState>, process);
-  processSlashings(state, process);
-  processFinalUpdates(state, process);
-  return process;
+  const epochProcess = prepareEpochProcessState(state);
+  processJustificationAndFinalization(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+  processRewardsAndPenalties(state, epochProcess);
+  processRegistryUpdates(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+  processSlashings(state, epochProcess);
+  processFinalUpdates(state, epochProcess);
+  return epochProcess;
 }

--- a/packages/beacon-state-transition/src/phase0/epoch/processFinalUpdates.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/processFinalUpdates.ts
@@ -9,11 +9,11 @@ import {
 } from "../../allForks/epoch";
 import {processParticipationRecordUpdates} from "./processParticipationRecordUpdates";
 
-export function processFinalUpdates(state: CachedBeaconState<phase0.BeaconState>, process: IEpochProcess): void {
-  processEth1DataReset(state as CachedBeaconState<allForks.BeaconState>, process);
-  processEffectiveBalanceUpdates(state as CachedBeaconState<allForks.BeaconState>, process);
-  processSlashingsReset(state as CachedBeaconState<allForks.BeaconState>, process);
-  processRandaoMixesReset(state as CachedBeaconState<allForks.BeaconState>, process);
-  processHistoricalRootsUpdate(state as CachedBeaconState<allForks.BeaconState>, process);
+export function processFinalUpdates(state: CachedBeaconState<phase0.BeaconState>, epochProcess: IEpochProcess): void {
+  processEth1DataReset(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+  processEffectiveBalanceUpdates(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+  processSlashingsReset(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+  processRandaoMixesReset(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+  processHistoricalRootsUpdate(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
   processParticipationRecordUpdates(state);
 }

--- a/packages/beacon-state-transition/src/phase0/epoch/processRewardsAndPenalties.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/processRewardsAndPenalties.ts
@@ -4,13 +4,16 @@ import {phase0} from "@chainsafe/lodestar-types";
 import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
 import {getAttestationDeltas} from "./getAttestationDeltas";
 
-export function processRewardsAndPenalties(state: CachedBeaconState<phase0.BeaconState>, process: IEpochProcess): void {
+export function processRewardsAndPenalties(
+  state: CachedBeaconState<phase0.BeaconState>,
+  epochProcess: IEpochProcess
+): void {
   const {balances} = state;
   // No rewards are applied at the end of `GENESIS_EPOCH` because rewards are for work done in the previous epoch
-  if (process.currentEpoch === GENESIS_EPOCH) {
+  if (epochProcess.currentEpoch === GENESIS_EPOCH) {
     return;
   }
-  const [rewards, penalties] = getAttestationDeltas(state, process);
+  const [rewards, penalties] = getAttestationDeltas(state, epochProcess);
   const newBalances = new BigUint64Array(balances.length);
   balances.forEach((balance, i) => {
     const newBalance = balance + BigInt(rewards[i] - penalties[i]);
@@ -23,5 +26,5 @@ export function processRewardsAndPenalties(state: CachedBeaconState<phase0.Beaco
   // set them all at once, constructing the tree in one go
   balances.updateAll(newBalances);
   // cache the balances array, too
-  process.balances = newBalances;
+  epochProcess.balances = newBalances;
 }

--- a/packages/beacon-state-transition/src/phase0/epoch/processSlashings.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/processSlashings.ts
@@ -11,8 +11,8 @@ import {
 import {decreaseBalance} from "../../util";
 import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
 
-export function processSlashings(state: CachedBeaconState<phase0.BeaconState>, process: IEpochProcess): void {
-  processSlashingsAllForks(ForkName.phase0, state as CachedBeaconState<allForks.BeaconState>, process);
+export function processSlashings(state: CachedBeaconState<phase0.BeaconState>, epochProcess: IEpochProcess): void {
+  processSlashingsAllForks(ForkName.phase0, state as CachedBeaconState<allForks.BeaconState>, epochProcess);
 }
 
 export function processSlashingsAllForks(

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.test.ts
@@ -10,38 +10,38 @@ describe("Phase 0 epoch transition steps", () => {
   });
 
   const originalState = generatePerfTestCachedStatePhase0({goBackOneSlot: true});
-  const process = allForks.prepareEpochProcessState(originalState);
+  const epochProcess = allForks.prepareEpochProcessState(originalState);
 
   const idPrefix = `epoch phase0 - ${perfStateId}`;
 
   itBench({
     id: `${idPrefix} - processJustificationAndFinalization`,
     beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
-    fn: (state) => phase0.processJustificationAndFinalization(state, process),
+    fn: (state) => phase0.processJustificationAndFinalization(state, epochProcess),
   });
 
   itBench({
     id: `${idPrefix} - processRewardsAndPenalties`,
     beforeEach: () => originalState.clone(),
-    fn: (state) => phase0.processRewardsAndPenalties(state, process),
+    fn: (state) => phase0.processRewardsAndPenalties(state, epochProcess),
   });
 
   itBench({
     id: `${idPrefix} - processRegistryUpdates`,
     beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
-    fn: (state) => phase0.processRegistryUpdates(state, process),
+    fn: (state) => phase0.processRegistryUpdates(state, epochProcess),
   });
 
   itBench({
     id: `${idPrefix} - processSlashings`,
     beforeEach: () => originalState.clone(),
-    fn: (state) => phase0.processSlashings(state, process),
+    fn: (state) => phase0.processSlashings(state, epochProcess),
   });
 
   itBench({
     id: `${idPrefix} - processFinalUpdates`,
     beforeEach: () => originalState.clone(),
-    fn: (state) => phase0.processFinalUpdates(state, process),
+    fn: (state) => phase0.processFinalUpdates(state, epochProcess),
   });
 
   // Non-action perf

--- a/packages/lodestar/test/utils/node/simTest.ts
+++ b/packages/lodestar/test/utils/node/simTest.ts
@@ -37,11 +37,13 @@ export function simTestInfoTracker(bn: BeaconNode, logger: ILogger): () => void 
   function logParticipation(state: allForks.CachedBeaconState<allForks.BeaconState>): void {
     // Compute participation (takes 5ms with 64 validators)
     // Need a CachedBeaconState<allForks.BeaconState> where (state.slot + 1) % SLOTS_EPOCH == 0
-    const process = allForks.prepareEpochProcessState(state);
+    const epochProcess = allForks.prepareEpochProcessState(state);
     const epoch = computeEpochAtSlot(state.slot);
 
-    const prevParticipation = Number(process.prevEpochUnslashedStake.targetStake) / Number(process.totalActiveStake);
-    const currParticipation = Number(process.currEpochUnslashedTargetStake) / Number(process.totalActiveStake);
+    const prevParticipation =
+      Number(epochProcess.prevEpochUnslashedStake.targetStake) / Number(epochProcess.totalActiveStake);
+    const currParticipation =
+      Number(epochProcess.currEpochUnslashedTargetStake) / Number(epochProcess.totalActiveStake);
     prevParticipationPerEpoch.set(epoch - 1, prevParticipation);
     currParticipationPerEpoch.set(epoch, currParticipation);
     logger.info("> Participation", {

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/effective_balance_updates/effective_balance_updates.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/effective_balance_updates/effective_balance_updates.ts
@@ -22,8 +22,8 @@ export function runEffectiveBalanceUpdates(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const process = allForks.prepareEpochProcessState(wrappedState);
-      altair.processEffectiveBalanceUpdates(wrappedState as CachedBeaconState<allForks.BeaconState>, process);
+      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      altair.processEffectiveBalanceUpdates(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/eth1_data_reset/eth1_data_reset.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/eth1_data_reset/eth1_data_reset.ts
@@ -22,8 +22,8 @@ export function runEth1DataReset(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const process = allForks.prepareEpochProcessState(wrappedState);
-      allForks.processEth1DataReset(wrappedState as CachedBeaconState<allForks.BeaconState>, process);
+      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      allForks.processEth1DataReset(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/historical_roots_update/historicalRootsUpdate.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/historical_roots_update/historicalRootsUpdate.ts
@@ -22,8 +22,8 @@ export function runHistoricalRootsUpdate(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const process = allForks.prepareEpochProcessState(wrappedState);
-      allForks.processHistoricalRootsUpdate(wrappedState as CachedBeaconState<allForks.BeaconState>, process);
+      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      allForks.processHistoricalRootsUpdate(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/inactivity_updates/inactivityUpdates.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/inactivity_updates/inactivityUpdates.ts
@@ -23,8 +23,8 @@ export function runInactivityUpdates(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const process = allForks.prepareEpochProcessState(wrappedState);
-      altair.processInactivityUpdates(wrappedState, process);
+      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      altair.processInactivityUpdates(wrappedState, epochProcess);
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/justification_and_finalization/justificationAndFinalization.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/justification_and_finalization/justificationAndFinalization.ts
@@ -23,8 +23,8 @@ export function runJustificationAndFinalization(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const process = allForks.prepareEpochProcessState(wrappedState);
-      altair.processJustificationAndFinalization(wrappedState as CachedBeaconState<allForks.BeaconState>, process);
+      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      altair.processJustificationAndFinalization(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/randao_mixes_reset/randaoMixesReset.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/randao_mixes_reset/randaoMixesReset.ts
@@ -22,8 +22,8 @@ export function runRandaoMixesReset(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const process = allForks.prepareEpochProcessState(wrappedState);
-      allForks.processRandaoMixesReset(wrappedState as CachedBeaconState<allForks.BeaconState>, process);
+      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      allForks.processRandaoMixesReset(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/registry_updates/registryUpdates.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/registry_updates/registryUpdates.ts
@@ -22,8 +22,8 @@ export function runRegistryUpdates(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const process = allForks.prepareEpochProcessState(wrappedState);
-      allForks.processRegistryUpdates(wrappedState as CachedBeaconState<allForks.BeaconState>, process);
+      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      allForks.processRegistryUpdates(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/rewards_and_penalties/rewardsAndPenalties.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/rewards_and_penalties/rewardsAndPenalties.ts
@@ -22,8 +22,8 @@ export function runRewardsAndPenalties(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const process = allForks.prepareEpochProcessState(wrappedState);
-      altair.processRewardsAndPenalties(wrappedState, process);
+      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      altair.processRewardsAndPenalties(wrappedState, epochProcess);
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/slashings/slashings.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/slashings/slashings.ts
@@ -22,8 +22,8 @@ export function runSlashings(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const process = allForks.prepareEpochProcessState(wrappedState);
-      altair.processSlashings(wrappedState, process);
+      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      altair.processSlashings(wrappedState, epochProcess);
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/slashings_reset/slashings_reset.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/slashings_reset/slashings_reset.ts
@@ -22,8 +22,8 @@ export function runSlashingsReset(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const process = allForks.prepareEpochProcessState(wrappedState);
-      allForks.processSlashingsReset(wrappedState as CachedBeaconState<allForks.BeaconState>, process);
+      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      allForks.processSlashingsReset(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/sync_committee_updates/sync_committee_updates.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/sync_committee_updates/sync_committee_updates.ts
@@ -22,8 +22,8 @@ export function runSyncCommitteeUpdates(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const process = allForks.prepareEpochProcessState(wrappedState);
-      altair.processSyncCommitteeUpdates(wrappedState, process);
+      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      altair.processSyncCommitteeUpdates(wrappedState, epochProcess);
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/rewards/basic/basic.ts
+++ b/packages/spec-test-runner/test/spec/altair/rewards/basic/basic.ts
@@ -28,12 +28,12 @@ export function runBasic(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const process = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
       return {
-        head_deltas: altair.getFlagIndexDeltas(wrappedState, process, TIMELY_HEAD_FLAG_INDEX),
-        source_deltas: altair.getFlagIndexDeltas(wrappedState, process, TIMELY_SOURCE_FLAG_INDEX),
-        target_deltas: altair.getFlagIndexDeltas(wrappedState, process, TIMELY_TARGET_FLAG_INDEX),
-        inactivity_penalty_deltas: altair.getInactivityPenaltyDeltas(wrappedState, process),
+        head_deltas: altair.getFlagIndexDeltas(wrappedState, epochProcess, TIMELY_HEAD_FLAG_INDEX),
+        source_deltas: altair.getFlagIndexDeltas(wrappedState, epochProcess, TIMELY_SOURCE_FLAG_INDEX),
+        target_deltas: altair.getFlagIndexDeltas(wrappedState, epochProcess, TIMELY_TARGET_FLAG_INDEX),
+        inactivity_penalty_deltas: altair.getInactivityPenaltyDeltas(wrappedState, epochProcess),
       };
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/rewards/leak/leak.ts
+++ b/packages/spec-test-runner/test/spec/altair/rewards/leak/leak.ts
@@ -29,12 +29,12 @@ export function runLeak(presetName: PresetName): void {
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
 
-      const process = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
       return {
-        head_deltas: altair.getFlagIndexDeltas(wrappedState, process, TIMELY_HEAD_FLAG_INDEX),
-        source_deltas: altair.getFlagIndexDeltas(wrappedState, process, TIMELY_SOURCE_FLAG_INDEX),
-        target_deltas: altair.getFlagIndexDeltas(wrappedState, process, TIMELY_TARGET_FLAG_INDEX),
-        inactivity_penalty_deltas: altair.getInactivityPenaltyDeltas(wrappedState, process),
+        head_deltas: altair.getFlagIndexDeltas(wrappedState, epochProcess, TIMELY_HEAD_FLAG_INDEX),
+        source_deltas: altair.getFlagIndexDeltas(wrappedState, epochProcess, TIMELY_SOURCE_FLAG_INDEX),
+        target_deltas: altair.getFlagIndexDeltas(wrappedState, epochProcess, TIMELY_TARGET_FLAG_INDEX),
+        inactivity_penalty_deltas: altair.getInactivityPenaltyDeltas(wrappedState, epochProcess),
       };
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/rewards/random/random.ts
+++ b/packages/spec-test-runner/test/spec/altair/rewards/random/random.ts
@@ -28,12 +28,12 @@ export function runRandom(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const process = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
       return {
-        head_deltas: altair.getFlagIndexDeltas(wrappedState, process, TIMELY_HEAD_FLAG_INDEX),
-        source_deltas: altair.getFlagIndexDeltas(wrappedState, process, TIMELY_SOURCE_FLAG_INDEX),
-        target_deltas: altair.getFlagIndexDeltas(wrappedState, process, TIMELY_TARGET_FLAG_INDEX),
-        inactivity_penalty_deltas: altair.getInactivityPenaltyDeltas(wrappedState, process),
+        head_deltas: altair.getFlagIndexDeltas(wrappedState, epochProcess, TIMELY_HEAD_FLAG_INDEX),
+        source_deltas: altair.getFlagIndexDeltas(wrappedState, epochProcess, TIMELY_SOURCE_FLAG_INDEX),
+        target_deltas: altair.getFlagIndexDeltas(wrappedState, epochProcess, TIMELY_TARGET_FLAG_INDEX),
+        inactivity_penalty_deltas: altair.getInactivityPenaltyDeltas(wrappedState, epochProcess),
       };
     },
     {

--- a/packages/spec-test-runner/test/spec/phase0/epoch_processing/justification/justification_and_finalization_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/epoch_processing/justification/justification_and_finalization_mainnet.test.ts
@@ -16,8 +16,8 @@ describeDirectorySpecTest<IStateTestCase, phase0.BeaconState>(
       config,
       testcase.pre as TreeBacked<phase0.BeaconState>
     );
-    const process = allForks.prepareEpochProcessState(wrappedState);
-    phase0.processJustificationAndFinalization(wrappedState as CachedBeaconState<allForks.BeaconState>, process);
+    const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+    phase0.processJustificationAndFinalization(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
     return wrappedState;
   },
   {

--- a/packages/spec-test-runner/test/spec/phase0/epoch_processing/registryUpdates/registry_updates_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/epoch_processing/registryUpdates/registry_updates_mainnet.test.ts
@@ -17,8 +17,8 @@ describeDirectorySpecTest<IStateTestCase, phase0.BeaconState>(
       config,
       testcase.pre as TreeBacked<phase0.BeaconState>
     );
-    const process = allForks.prepareEpochProcessState(wrappedState);
-    phase0.processRegistryUpdates(wrappedState as CachedBeaconState<allForks.BeaconState>, process);
+    const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+    phase0.processRegistryUpdates(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
     return wrappedState;
   },
   {

--- a/packages/spec-test-runner/test/spec/phase0/epoch_processing/rewardsAndPenalties/rewards_and_penalties_minimal.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/epoch_processing/rewardsAndPenalties/rewards_and_penalties_minimal.test.ts
@@ -17,8 +17,8 @@ describeDirectorySpecTest<IStateTestCase, phase0.BeaconState>(
       config,
       testcase.pre as TreeBacked<phase0.BeaconState>
     );
-    const process = allForks.prepareEpochProcessState(wrappedState);
-    phase0.processRewardsAndPenalties(wrappedState, process);
+    const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+    phase0.processRewardsAndPenalties(wrappedState, epochProcess);
     return wrappedState;
   },
   {

--- a/packages/spec-test-runner/test/spec/phase0/epoch_processing/slashings/slashings_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/epoch_processing/slashings/slashings_mainnet.test.ts
@@ -17,8 +17,8 @@ describeDirectorySpecTest<IStateTestCase, phase0.BeaconState>(
       config,
       testcase.pre as TreeBacked<phase0.BeaconState>
     );
-    const process = allForks.prepareEpochProcessState(wrappedState);
-    phase0.processSlashings(wrappedState, process);
+    const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+    phase0.processSlashings(wrappedState, epochProcess);
     return wrappedState;
   },
   {

--- a/packages/spec-test-runner/test/spec/phase0/rewards/rewards_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/rewards/rewards_mainnet.test.ts
@@ -17,8 +17,8 @@ for (const testSuite of ["basic", "leak", "random"]) {
         config,
         testcase.pre as TreeBacked<phase0.BeaconState>
       );
-      const process = allForks.prepareEpochProcessState(wrappedState);
-      const [rewards, penalties] = phase0.getAttestationDeltas(wrappedState, process);
+      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      const [rewards, penalties] = phase0.getAttestationDeltas(wrappedState, epochProcess);
       return {
         rewards: rewards.map((reward) => BigInt(reward)),
         penalties: penalties.map((pen) => BigInt(pen)),


### PR DESCRIPTION
**Motivation**

In NodeJS `process` is a global variable. Using a variable name `process` in a NodeJS app is not great since it can lead to confusion and you can't use the global variable `process` anymore because it's shadowed by the local one.

**Description**

Rename `process` to `epochProcess` to be consistent with its type `IEpochProcess`