### PR TITLE
De-duplicate performance tests between forks

### DIFF
--- a/packages/beacon-state-transition/src/altair/epoch/index.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/index.ts
@@ -19,13 +19,10 @@ import {processSyncCommitteeUpdates} from "./processSyncCommitteeUpdates";
 export {getFlagIndexDeltas, getInactivityPenaltyDeltas} from "./balance";
 
 export {
-  processJustificationAndFinalization,
   processInactivityUpdates,
   processRewardsAndPenalties,
-  processRegistryUpdates,
   processSlashings,
   processSyncCommitteeUpdates,
-  processEffectiveBalanceUpdates,
   processParticipationFlagUpdates,
 };
 

--- a/packages/beacon-state-transition/src/phase0/epoch/index.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/index.ts
@@ -14,13 +14,7 @@ import {getAttestationDeltas} from "./getAttestationDeltas";
 import {processParticipationRecordUpdates} from "./processParticipationRecordUpdates";
 import {allForks, phase0} from "@chainsafe/lodestar-types";
 
-export {
-  processJustificationAndFinalization,
-  processRewardsAndPenalties,
-  processRegistryUpdates,
-  processSlashings,
-  getAttestationDeltas,
-};
+export {processRewardsAndPenalties, processSlashings, getAttestationDeltas};
 
 export function processEpoch(state: CachedBeaconState<phase0.BeaconState>): IEpochProcess {
   const epochProcess = prepareEpochProcessState(state);

--- a/packages/beacon-state-transition/test/perf/altair/epoch/epoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/epoch/epoch.test.ts
@@ -14,16 +14,8 @@ describe("Altair epoch transition steps", () => {
 
   const idPrefix = `epoch altair - ${perfStateId}`;
 
-  itBench({
-    id: `${idPrefix} - processJustificationAndFinalization`,
-    beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
-    fn: (state) => altair.processJustificationAndFinalization(state, epochProcess),
-  });
+  // Note: tests altair only methods. All other are benchmarked in phase/epoch
 
-  // As of Jun 18
-  // Altair epoch transition steps
-  // ================================================================
-  // processInactivityUpdates                                              0.6118570 ops/s      1.634369  s/op     36 runs    60.48 s
   itBench({
     id: `${idPrefix} - processInactivityUpdates`,
     beforeEach: () => originalState.clone(),
@@ -37,58 +29,9 @@ describe("Altair epoch transition steps", () => {
   });
 
   itBench({
-    id: `${idPrefix} - processRegistryUpdates`,
-    beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
-    fn: (state) => altair.processRegistryUpdates(state, epochProcess),
-  });
-
-  itBench({
     id: `${idPrefix} - processSlashings`,
     beforeEach: () => originalState.clone(),
     fn: (state) => altair.processSlashings(state, epochProcess),
-  });
-
-  if (!process.env.CI) {
-    // very simple and fast function, no need to benchmark
-    itBench({
-      id: `${idPrefix} - processEth1DataReset`,
-      beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
-      fn: (state) => allForks.processEth1DataReset(state, epochProcess),
-    });
-
-    // very simple and fast function, no need to benchmark
-    itBench({
-      id: `${idPrefix} - processHistoricalRootsUpdate`,
-      beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
-      fn: (state) => allForks.processHistoricalRootsUpdate(state, epochProcess),
-    });
-
-    // very simple and fast function, no need to benchmark
-    itBench({
-      id: `${idPrefix} - processSyncCommitteeUpdates`,
-      beforeEach: () => originalState.clone(),
-      fn: (state) => altair.processSyncCommitteeUpdates(state, epochProcess),
-    });
-
-    // very simple and fast function, no need to benchmark
-    itBench({
-      id: `${idPrefix} - processSlashingsReset`,
-      beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
-      fn: (state) => allForks.processSlashingsReset(state, epochProcess),
-    });
-
-    // very simple and fast function, no need to benchmark
-    itBench({
-      id: `${idPrefix} - processRandaoMixesReset`,
-      beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
-      fn: (state) => allForks.processRandaoMixesReset(state, epochProcess),
-    });
-  }
-
-  itBench({
-    id: `${idPrefix} - processEffectiveBalanceUpdates`,
-    beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
-    fn: (state) => allForks.processEffectiveBalanceUpdates(state, epochProcess),
   });
 
   itBench({
@@ -97,10 +40,12 @@ describe("Altair epoch transition steps", () => {
     fn: (state) => altair.processParticipationFlagUpdates(state),
   });
 
-  // do prepareEpochProcessState last
-  itBench({
-    id: `${idPrefix} - prepareEpochProcessState`,
-    beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
-    fn: (state) => void allForks.prepareEpochProcessState(state),
-  });
+  // very simple and fast function, no need to benchmark
+  if (!process.env.CI) {
+    itBench({
+      id: `${idPrefix} - processSyncCommitteeUpdates`,
+      beforeEach: () => originalState.clone(),
+      fn: (state) => altair.processSyncCommitteeUpdates(state, epochProcess),
+    });
+  }
 });

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.test.ts
@@ -17,7 +17,7 @@ describe("Phase 0 epoch transition steps", () => {
   itBench({
     id: `${idPrefix} - processJustificationAndFinalization`,
     beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
-    fn: (state) => phase0.processJustificationAndFinalization(state, epochProcess),
+    fn: (state) => allForks.processJustificationAndFinalization(state, epochProcess),
   });
 
   itBench({
@@ -29,7 +29,7 @@ describe("Phase 0 epoch transition steps", () => {
   itBench({
     id: `${idPrefix} - processRegistryUpdates`,
     beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
-    fn: (state) => phase0.processRegistryUpdates(state, epochProcess),
+    fn: (state) => allForks.processRegistryUpdates(state, epochProcess),
   });
 
   itBench({
@@ -37,6 +37,43 @@ describe("Phase 0 epoch transition steps", () => {
     beforeEach: () => originalState.clone(),
     fn: (state) => phase0.processSlashings(state, epochProcess),
   });
+
+  itBench({
+    id: `${idPrefix} - processEffectiveBalanceUpdates`,
+    beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
+    fn: (state) => allForks.processEffectiveBalanceUpdates(state, epochProcess),
+  });
+
+  // very simple and fast functions, no need to benchmark
+  if (!process.env.CI) {
+    itBench({
+      id: `${idPrefix} - processEth1DataReset`,
+      beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
+      fn: (state) => allForks.processEth1DataReset(state, epochProcess),
+    });
+
+    itBench({
+      id: `${idPrefix} - processSlashingsReset`,
+      beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
+      fn: (state) => allForks.processSlashingsReset(state, epochProcess),
+    });
+
+    itBench({
+      id: `${idPrefix} - processRandaoMixesReset`,
+      beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
+      fn: (state) => allForks.processRandaoMixesReset(state, epochProcess),
+    });
+
+    itBench({
+      id: `${idPrefix} - processHistoricalRootsUpdate`,
+      beforeEach: () => originalState.clone() as allForks.CachedBeaconState<allForks.BeaconState>,
+      fn: (state) => allForks.processHistoricalRootsUpdate(state, epochProcess),
+    });
+
+    // processParticipationRecordUpdates, no need to benchmark. Way too simple
+  }
+
+  // Other items in phase0 epoch processing are too small to care about performance
 
   // Non-action perf
 

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/effective_balance_updates/effective_balance_updates.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/effective_balance_updates/effective_balance_updates.ts
@@ -23,7 +23,7 @@ export function runEffectiveBalanceUpdates(presetName: PresetName): void {
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
       const epochProcess = allForks.prepareEpochProcessState(wrappedState);
-      altair.processEffectiveBalanceUpdates(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
+      allForks.processEffectiveBalanceUpdates(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/justification_and_finalization/justificationAndFinalization.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/justification_and_finalization/justificationAndFinalization.ts
@@ -24,7 +24,10 @@ export function runJustificationAndFinalization(presetName: PresetName): void {
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
       const epochProcess = allForks.prepareEpochProcessState(wrappedState);
-      altair.processJustificationAndFinalization(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
+      allForks.processJustificationAndFinalization(
+        wrappedState as CachedBeaconState<allForks.BeaconState>,
+        epochProcess
+      );
       return wrappedState;
     },
     {

--- a/packages/spec-test-runner/test/spec/phase0/epoch_processing/justification/justification_and_finalization_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/epoch_processing/justification/justification_and_finalization_mainnet.test.ts
@@ -17,7 +17,7 @@ describeDirectorySpecTest<IStateTestCase, phase0.BeaconState>(
       testcase.pre as TreeBacked<phase0.BeaconState>
     );
     const epochProcess = allForks.prepareEpochProcessState(wrappedState);
-    phase0.processJustificationAndFinalization(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
+    allForks.processJustificationAndFinalization(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
     return wrappedState;
   },
   {

--- a/packages/spec-test-runner/test/spec/phase0/epoch_processing/registryUpdates/registry_updates_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/epoch_processing/registryUpdates/registry_updates_mainnet.test.ts
@@ -18,7 +18,7 @@ describeDirectorySpecTest<IStateTestCase, phase0.BeaconState>(
       testcase.pre as TreeBacked<phase0.BeaconState>
     );
     const epochProcess = allForks.prepareEpochProcessState(wrappedState);
-    phase0.processRegistryUpdates(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
+    allForks.processRegistryUpdates(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
     return wrappedState;
   },
   {


### PR DESCRIPTION
**Motivation**

Clear up a bit how allForks epoch functions are consumed and exported. Also de-duplicate perf tests on phase0 + altair for functions that are common to both forks

**Description**

De-duplicate exports and perf tests