### PR TITLE
Set caches to transient/persistent

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/cachedBeaconState.ts
+++ b/packages/beacon-state-transition/src/allForks/util/cachedBeaconState.ts
@@ -230,6 +230,7 @@ export class BeaconStateContext<T extends allForks.BeaconState> {
     this.balances.persistent.asTransient();
     this.previousEpochParticipation.persistent.asTransient();
     this.currentEpochParticipation.persistent.asTransient();
+    this.inactivityScores.persistent.asTransient();
   }
 
   /**
@@ -239,6 +240,8 @@ export class BeaconStateContext<T extends allForks.BeaconState> {
     this.validators.persistent.asPersistent();
     this.balances.persistent.asPersistent();
     this.previousEpochParticipation.persistent.asPersistent();
+    this.currentEpochParticipation.persistent.asPersistent();
+    this.inactivityScores.persistent.asPersistent();
   }
 }
 

--- a/packages/beacon-state-transition/test/perf/altair/epoch/epoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/epoch/epoch.test.ts
@@ -12,6 +12,12 @@ describe("Altair epoch transition steps", () => {
   const originalState = generatePerfTestCachedStateAltair({goBackOneSlot: true});
   const epochProcess = allForks.prepareEpochProcessState(originalState);
 
+  const getPerfState = () => {
+    const state = originalState.clone();
+    state.setStateCachesAsTransient();
+    return state;
+  };
+
   const idPrefix = `epoch altair - ${perfStateId}`;
 
   // Note: tests altair only methods. All other are benchmarked in phase/epoch
@@ -40,13 +46,13 @@ describe("Altair epoch transition steps", () => {
 
   itBench({
     id: `${idPrefix} - processInactivityUpdates`,
-    beforeEach: () => originalState.clone(),
+    beforeEach: () => getPerfState(),
     fn: (state) => altair.processInactivityUpdates(state, epochProcess),
   });
 
   itBench({
     id: `${idPrefix} - processRewardsAndPenalties`,
-    beforeEach: () => originalState.clone(),
+    beforeEach: () => getPerfState(),
     fn: (state) => altair.processRewardsAndPenalties(state, epochProcess),
   });
 
@@ -56,7 +62,7 @@ describe("Altair epoch transition steps", () => {
   if (!process.env.CI)
     itBench({
       id: `${idPrefix} - processSlashings`,
-      beforeEach: () => originalState.clone(),
+      beforeEach: () => getPerfState(),
       fn: (state) => altair.processSlashings(state, epochProcess),
     });
 
@@ -68,7 +74,7 @@ describe("Altair epoch transition steps", () => {
 
   itBench({
     id: `${idPrefix} - processParticipationFlagUpdates`,
-    beforeEach: () => originalState.clone(),
+    beforeEach: () => getPerfState(),
     fn: (state) => altair.processParticipationFlagUpdates(state),
   });
 
@@ -76,7 +82,7 @@ describe("Altair epoch transition steps", () => {
   if (!process.env.CI)
     itBench({
       id: `${idPrefix} - processSyncCommitteeUpdates`,
-      beforeEach: () => originalState.clone(),
+      beforeEach: () => getPerfState(),
       fn: (state) => altair.processSyncCommitteeUpdates(state, epochProcess),
     });
 });

--- a/packages/beacon-state-transition/test/perf/altair/epoch/epoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/epoch/epoch.test.ts
@@ -1,5 +1,5 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
-import {allForks, altair} from "../../../../src";
+import {allForks, altair, CachedBeaconState} from "../../../../src";
 import {generatePerfTestCachedStateAltair, perfStateId} from "../../util";
 
 describe("Altair epoch transition steps", () => {
@@ -12,7 +12,7 @@ describe("Altair epoch transition steps", () => {
   const originalState = generatePerfTestCachedStateAltair({goBackOneSlot: true});
   const epochProcess = allForks.prepareEpochProcessState(originalState);
 
-  const getPerfState = () => {
+  const getPerfState = (): CachedBeaconState<altair.BeaconState> => {
     const state = originalState.clone();
     state.setStateCachesAsTransient();
     return state;


### PR DESCRIPTION
**Motivation**
Digging into slow `processInactivityUpdates` in perf tests.

It looks like `inactivityScores` cache wasn't being toggled to transient mode.
Also perf tests weren't properly toggling to transient mode either.
