### PR TITLE
Benchmark array-ish structures

### DIFF
--- a/packages/beacon-state-transition/test/perf/dataStructures/arrayish.memory.ts
+++ b/packages/beacon-state-transition/test/perf/dataStructures/arrayish.memory.ts
@@ -15,10 +15,12 @@ enum TestType {
   MutableVector,
   MutableVectorClone,
   MutableVectorCloneAndMutate,
+  Set,
+  Map,
 }
 
-const size = 1000;
-const testType = TestType.MutableVector;
+const size = 100;
+const testType = TestType.Set;
 
 let arrayNumGlobal: number[] | null = null;
 let mutableVectorGlobal: MutableVector<number> | null = null;
@@ -29,7 +31,10 @@ for (let i = 0; i < 1e8; i++) {
     // ---- | ------ | ------ |
     // rssM | 855.46 | 8107.7 |
     case TestType.ArrayNew: {
-      const arrNum = Array.from({length: size}, (_, k) => k);
+      const arrNum = new Array(size);
+      for (let j = 0; j < size; j++) {
+        arrNum[j] = j;
+      }
       refs.push(arrNum);
       break;
     }
@@ -100,6 +105,30 @@ for (let i = 0; i < 1e8; i++) {
         newArr.set(j, i);
       }
       refs.push(newArr);
+      break;
+    }
+
+    // size | 100    | 1000   |
+    // ---- | ------ | ------ |
+    // rssM | 2646.8 | 20855. |
+    case TestType.Set: {
+      const set = new Set<number>();
+      for (let j = 0; j < size; j++) {
+        set.add(j);
+      }
+      refs.push(set);
+      break;
+    }
+
+    // size | 100    | 1000   |
+    // ---- | ------ | ------ |
+    // rssM | 3668.4 | 29089. |
+    case TestType.Map: {
+      const map = new Map<number, number>();
+      for (let j = 0; j < size; j++) {
+        map.set(j, j);
+      }
+      refs.push(map);
       break;
     }
 

--- a/packages/beacon-state-transition/test/perf/dataStructures/arrayish.memory.ts
+++ b/packages/beacon-state-transition/test/perf/dataStructures/arrayish.memory.ts
@@ -1,0 +1,208 @@
+import {MutableVector} from "@chainsafe/persistent-ts";
+
+const refs: any[] = [];
+const xs: number[] = [];
+const arrayBuffersArr: number[] = [];
+const externalArr: number[] = [];
+const heapTotal: number[] = [];
+const heapUsed: number[] = [];
+const rss: number[] = [];
+
+enum TestType {
+  ArrayNew,
+  ArraySpread,
+  ArraySpreadAndMutate,
+  MutableVector,
+  MutableVectorClone,
+  MutableVectorCloneAndMutate,
+}
+
+const size = 1000;
+const testType = TestType.MutableVector;
+
+let arrayNumGlobal: number[] | null = null;
+let mutableVectorGlobal: MutableVector<number> | null = null;
+
+for (let i = 0; i < 1e8; i++) {
+  switch (testType as TestType) {
+    // size | 100    | 1000   |
+    // ---- | ------ | ------ |
+    // rssM | 855.46 | 8107.7 |
+    case TestType.ArrayNew: {
+      const arrNum = Array.from({length: size}, (_, k) => k);
+      refs.push(arrNum);
+      break;
+    }
+
+    // size | 100    | 1000   |
+    // ---- | ------ | ------ |
+    // rssM | 61.03  | 59.55  |
+    case TestType.ArraySpread: {
+      if (!arrayNumGlobal) {
+        arrayNumGlobal = Array.from({length: size}, (_, k) => k);
+        refs.push(arrayNumGlobal);
+      }
+      refs.push([...arrayNumGlobal]);
+      break;
+    }
+
+    // size | 100    | 1000   |
+    // ---- | ------ | ------ |
+    // rssM | 805.3  | 6240.8 |
+    case TestType.ArraySpreadAndMutate: {
+      if (!arrayNumGlobal) {
+        arrayNumGlobal = Array.from({length: size}, (_, k) => k);
+        refs.push(arrayNumGlobal);
+      }
+      const arrNew = [...arrayNumGlobal];
+      arrNew[Math.floor(size / 2)] = i;
+      refs.push(arrNew);
+      break;
+    }
+
+    // size | 100    | 1000   | 10000  |
+    // ---- | ------ | ------ | ------ |
+    // rssM | 1817.4 | 15518. | 154335 |
+    case TestType.MutableVector: {
+      const items = createArray(size);
+      const mutableVector = MutableVector.from(items);
+      refs.push(mutableVector);
+      break;
+    }
+
+    // size | 100    | 1000   |
+    // ---- | ------ | ------ |
+    // rssM | 58.68  | 55.89  |
+    case TestType.MutableVectorClone: {
+      if (!mutableVectorGlobal) {
+        const items = createArray(size);
+        mutableVectorGlobal = MutableVector.from(items);
+      }
+      refs.push(mutableVectorGlobal.clone());
+      break;
+    }
+
+    // Grid of size / changes, all values = rssM in bytes
+    //       | 100    | 1000   | 10000  |
+    // ----- | ------ | ------ | ------ |
+    // 1     | 793.45 | 801.53 | 1137.9 |
+    // 10    | 803.98 | 802.36 | 1144.9 |
+    // 100   | 1573.2 | 1826.4 | 2172.0 |
+    // 1000  | -      | 11250. | 11886. |
+    // 10000 | -      | -      | 111365 |
+    case TestType.MutableVectorCloneAndMutate: {
+      if (!mutableVectorGlobal) {
+        const items = createArray(size);
+        mutableVectorGlobal = MutableVector.from(items);
+      }
+      const newArr = mutableVectorGlobal.clone();
+      for (let j = 0; j < 10000; j++) {
+        newArr.set(j, i);
+      }
+      refs.push(newArr);
+      break;
+    }
+
+    default: {
+      throw Error(`Unknown TestType: ${testType}`);
+    }
+  }
+
+  // Stores 5 floating point numbers every 5000 pushes to refs.
+  // The added memory should be negligible against refs, and linearRegression
+  // local vars will get garbage collected and won't show up in the .m result
+
+  if (i % 5000 === 0) {
+    xs.push(i);
+    const memoryUsage = process.memoryUsage();
+    arrayBuffersArr.push(memoryUsage.arrayBuffers);
+    externalArr.push(memoryUsage.external);
+    heapTotal.push(memoryUsage.heapTotal);
+    heapUsed.push(memoryUsage.heapUsed);
+    rss.push(memoryUsage.rss);
+
+    const arrayBuffersM = linearRegression(xs, arrayBuffersArr).m;
+    const externalM = linearRegression(xs, externalArr).m;
+    const heapTotalM = linearRegression(xs, heapTotal).m;
+    const heapUsedM = linearRegression(xs, heapUsed).m;
+    const rssM = linearRegression(xs, rss).m;
+
+    console.log(i, {arrayBuffersM, externalM, heapTotalM, heapUsedM, rssM});
+  }
+}
+
+function createArray(n: number): number[] {
+  const items: number[] = [];
+  for (let i = 0; i < n; i++) {
+    items.push(i);
+  }
+  return items;
+}
+
+/**
+ * From https://github.com/simple-statistics/simple-statistics/blob/d0d177baf74976a2421638bce98ab028c5afb537/src/linear_regression.js
+ *
+ * [Simple linear regression](http://en.wikipedia.org/wiki/Simple_linear_regression)
+ * is a simple way to find a fitted line between a set of coordinates.
+ * This algorithm finds the slope and y-intercept of a regression line
+ * using the least sum of squares.
+ *
+ * @param data an array of two-element of arrays,
+ * like `[[0, 1], [2, 3]]`
+ * @returns object containing slope and intersect of regression line
+ * @example
+ * linearRegression([[0, 0], [1, 1]]); // => { m: 1, b: 0 }
+ */
+export function linearRegression(xs: number[], ys: number[]): {m: number; b: number} {
+  let m: number, b: number;
+
+  // Store data length in a local variable to reduce
+  // repeated object property lookups
+  const dataLength = xs.length;
+
+  //if there's only one point, arbitrarily choose a slope of 0
+  //and a y-intercept of whatever the y of the initial point is
+  if (dataLength === 1) {
+    m = 0;
+    b = ys[0];
+  } else {
+    // Initialize our sums and scope the `m` and `b`
+    // variables that define the line.
+    let sumX = 0,
+      sumY = 0,
+      sumXX = 0,
+      sumXY = 0;
+
+    // Use local variables to grab point values
+    // with minimal object property lookups
+    let x: number, y: number;
+
+    // Gather the sum of all x values, the sum of all
+    // y values, and the sum of x^2 and (x*y) for each
+    // value.
+    //
+    // In math notation, these would be SS_x, SS_y, SS_xx, and SS_xy
+    for (let i = 0; i < dataLength; i++) {
+      x = xs[i];
+      y = ys[i];
+
+      sumX += x;
+      sumY += y;
+
+      sumXX += x * x;
+      sumXY += x * y;
+    }
+
+    // `m` is the slope of the regression line
+    m = (dataLength * sumXY - sumX * sumY) / (dataLength * sumXX - sumX * sumX);
+
+    // `b` is the y-intercept of the line.
+    b = sumY / dataLength - (m * sumX) / dataLength;
+  }
+
+  // Return both values as an object.
+  return {
+    m: m,
+    b: b,
+  };
+}

--- a/packages/beacon-state-transition/test/perf/dataStructures/arrayish.test.ts
+++ b/packages/beacon-state-transition/test/perf/dataStructures/arrayish.test.ts
@@ -61,12 +61,20 @@ describe("Tree (persistent-merkle-tree)", () => {
     tree.getNode(gihi);
   });
 
+  itBench(`Tree ${d} ${n} get(${ihi}) x1000`, () => {
+    for (let i = 0; i < 1000; i++) tree.getNode(gihi);
+  });
+
   itBench(`Tree ${d} ${n} set(${ilo})`, () => {
     tree.setNode(gilo, n2);
   });
 
   itBench(`Tree ${d} ${n} set(${ihi})`, () => {
     tree.setNode(gihi, n2);
+  });
+
+  itBench(`Tree ${d} ${n} set(${ihi}) x1000`, () => {
+    for (let i = 0; i < 1000; i++) tree.setNode(gihi, n2);
   });
 
   itBench(`Tree ${d} ${n} toArray()`, () => {
@@ -123,12 +131,20 @@ describe("MutableVector", () => {
     mutableVector.get(ihi);
   });
 
+  itBench(`MutableVector ${n} get(${ihi}) x1000`, () => {
+    for (let i = 0; i < 1000; i++) mutableVector.get(ihi - i);
+  });
+
   itBench(`MutableVector ${n} set(${ilo})`, () => {
     mutableVector.set(ilo, 10000000);
   });
 
   itBench(`MutableVector ${n} set(${ihi})`, () => {
     mutableVector.set(ihi, 10000000);
+  });
+
+  itBench(`MutableVector ${n} set(${ihi}) x1000`, () => {
+    for (let i = 0; i < 1000; i++) mutableVector.set(ihi - i, 10000000);
   });
 
   itBench(`MutableVector ${n} toArray()`, () => {
@@ -177,12 +193,20 @@ describe("Array", () => {
     arr[ihi];
   });
 
+  itBench(`Array ${n} get(${ihi}) x1000`, () => {
+    for (let i = 0; i < 1000; i++) arr[ihi - 1];
+  });
+
   itBench(`Array ${n} set(${ilo})`, () => {
     arr[ilo] = 10000000;
   });
 
   itBench(`Array ${n} set(${ihi})`, () => {
     arr[ihi] = 10000000;
+  });
+
+  itBench(`Array ${n} set(${ihi}) x1000`, () => {
+    for (let i = 0; i < 1000; i++) arr[ihi - 1] = 10000000;
   });
 
   itBench(`Array ${n} iterate all - loop`, () => {

--- a/packages/beacon-state-transition/test/perf/dataStructures/arrayish.test.ts
+++ b/packages/beacon-state-transition/test/perf/dataStructures/arrayish.test.ts
@@ -15,23 +15,34 @@ const ihi = n - 1;
 // - Memory cost of a full array
 
 // Benchmark data from Aug 2021 - Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz
+// Tree (persistent-merkle-tree)
+// ✓ Tree 40 250000 create                                              0.9570626 ops/s    1.044864  s/op        -          9 runs   10.4 s
+// ✓ Tree 40 250000 get(0)                                               621118.0 ops/s    1.610000 us/op        -     527363 runs   1.03 s
+// ✓ Tree 40 250000 get(249999)                                          600961.5 ops/s    1.664000 us/op        -     512426 runs   1.03 s
+// ✓ Tree 40 250000 set(0)                                               244978.0 ops/s    4.082000 us/op        -     227418 runs   1.01 s
+// ✓ Tree 40 250000 set(249999)                                          197083.2 ops/s    5.074000 us/op        -     183365 runs   1.01 s
+// ✓ Tree 40 250000 toArray()                                            13.48403 ops/s    74.16183 ms/op        -        134 runs   10.0 s
+// ✓ Tree 40 250000 iterate all - toArray() + loop                       13.78103 ops/s    72.56350 ms/op        -        137 runs   10.0 s
+// ✓ Tree 40 250000 iterate all - get(i)                                 2.820850 ops/s    354.5030 ms/op        -         28 runs   10.3 s
+
 // MutableVector
-// ✓ MutableVector 250000 create                                         69.60118 ops/s    14.36757 ms/op   x1.078        695 runs   10.0 s
-// ✓ MutableVector 250000 get(0)                                          2277904 ops/s    439.0000 ns/op   x1.149    1427700 runs   1.07 s
-// ✓ MutableVector 250000 set(0)                                          1055966 ops/s    947.0000 ns/op   x1.205     825882 runs   1.04 s
-// ✓ MutableVector 250000 get(249999)                                     2469136 ops/s    405.0000 ns/op   x1.134    1464511 runs   1.07 s
-// ✓ MutableVector 250000 set(249999)                                     1912046 ops/s    523.0000 ns/op   x1.236    1227883 runs   1.06 s
-// ✓ MutableVector 250000 toArray()                                      173.7822 ops/s    5.754330 ms/op        -       1024 runs   5.90 s
-// ✓ MutableVector 250000 iterate all - toArray() + loop                 165.5760 ops/s    6.039522 ms/op        -       1024 runs   6.19 s
-// ✓ MutableVector 250000 iterate all - get(i)                           342.0903 ops/s    2.923205 ms/op   x1.081       1024 runs   2.99 s
+// ✓ MutableVector 250000 create                                         60.84465 ops/s    16.43530 ms/op        -        609 runs   10.0 s
+// ✓ MutableVector 250000 get(0)                                          1893939 ops/s    528.0000 ns/op        -    1150568 runs   1.07 s
+// ✓ MutableVector 250000 get(249999)                                     1953125 ops/s    512.0000 ns/op        -    1176768 runs   1.08 s
+// ✓ MutableVector 250000 set(0)                                         811030.0 ops/s    1.233000 us/op        -     637508 runs   1.04 s
+// ✓ MutableVector 250000 set(249999)                                     1579779 ops/s    633.0000 ns/op        -    1011919 runs   1.18 s
+// ✓ MutableVector 250000 toArray()                                      134.9621 ops/s    7.409485 ms/op        -       1024 runs   7.59 s
+// ✓ MutableVector 250000 iterate all - toArray() + loop                 117.5826 ops/s    8.504657 ms/op        -       1024 runs   8.71 s
+// ✓ MutableVector 250000 iterate all - get(i)                           274.0159 ops/s    3.649423 ms/op        -       1024 runs   3.74 s
 
 // Array
-// ✓ Array 250000 create                                                 238.7041 ops/s    4.189287 ms/op   x0.941       1024 runs   4.29 s
-// ✓ Array 250000 get(0)                                                  2604167 ops/s    384.0000 ns/op   x0.798    1557414 runs   1.07 s
-// ✓ Array 250000 set(0)                                                  2427184 ops/s    412.0000 ns/op   x0.846    1429521 runs   1.07 s
-// ✓ Array 250000 get(249999)                                             2652520 ops/s    377.0000 ns/op   x0.684    1588011 runs   1.07 s
-// ✓ Array 250000 set(249999)                                             2398082 ops/s    417.0000 ns/op   x0.993    1437819 runs   1.07 s
-// ✓ Array 250000 iterate all - loop                                     3784.639 ops/s    264.2260 us/op   x0.898       3774 runs   1.00 s
+// ✓ Array 250000 create                                                 182.7870 ops/s    5.470849 ms/op        -       1024 runs   5.61 s
+// ✓ Array 250000 clone - spread                                         549.0822 ops/s    1.821221 ms/op        -       1024 runs   1.87 s
+// ✓ Array 250000 get(0)                                                  1968504 ops/s    508.0000 ns/op        -    1176396 runs   1.09 s
+// ✓ Array 250000 get(249999)                                             2032520 ops/s    492.0000 ns/op        -    1200057 runs   1.17 s
+// ✓ Array 250000 set(0)                                                  2100840 ops/s    476.0000 ns/op        -    1248220 runs   1.08 s
+// ✓ Array 250000 set(249999)                                             2100840 ops/s    476.0000 ns/op        -    1245961 runs   1.08 s
+// ✓ Array 250000 iterate all - loop                                     3009.592 ops/s    332.2710 us/op        -       3006 runs   1.00 s
 
 describe("Tree (persistent-merkle-tree)", () => {
   // Don't run on CI

--- a/packages/beacon-state-transition/test/perf/dataStructures/arrayish.test.ts
+++ b/packages/beacon-state-transition/test/perf/dataStructures/arrayish.test.ts
@@ -1,0 +1,131 @@
+import {MutableVector} from "@chainsafe/persistent-ts";
+import {itBench, setBenchOpts} from "@dapplion/benchmark";
+
+const n = 250_000;
+const ilo = 0;
+const ihi = n - 1;
+
+// Understand the cost of each array-ish data structure to:
+// - Get one element
+// - Set one element
+// - Get all elements
+// - Set all elements (re-create the array)
+// - Clone the array for immutable editing
+// - Memory cost of a full array
+
+// Benchmark data from Aug 2021 - Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz
+// MutableVector
+// ✓ MutableVector 250000 create                                         69.60118 ops/s    14.36757 ms/op   x1.078        695 runs   10.0 s
+// ✓ MutableVector 250000 get(0)                                          2277904 ops/s    439.0000 ns/op   x1.149    1427700 runs   1.07 s
+// ✓ MutableVector 250000 set(0)                                          1055966 ops/s    947.0000 ns/op   x1.205     825882 runs   1.04 s
+// ✓ MutableVector 250000 get(249999)                                     2469136 ops/s    405.0000 ns/op   x1.134    1464511 runs   1.07 s
+// ✓ MutableVector 250000 set(249999)                                     1912046 ops/s    523.0000 ns/op   x1.236    1227883 runs   1.06 s
+// ✓ MutableVector 250000 toArray()                                      173.7822 ops/s    5.754330 ms/op        -       1024 runs   5.90 s
+// ✓ MutableVector 250000 iterate all - toArray() + loop                 165.5760 ops/s    6.039522 ms/op        -       1024 runs   6.19 s
+// ✓ MutableVector 250000 iterate all - get(i)                           342.0903 ops/s    2.923205 ms/op   x1.081       1024 runs   2.99 s
+
+// Array
+// ✓ Array 250000 create                                                 238.7041 ops/s    4.189287 ms/op   x0.941       1024 runs   4.29 s
+// ✓ Array 250000 get(0)                                                  2604167 ops/s    384.0000 ns/op   x0.798    1557414 runs   1.07 s
+// ✓ Array 250000 set(0)                                                  2427184 ops/s    412.0000 ns/op   x0.846    1429521 runs   1.07 s
+// ✓ Array 250000 get(249999)                                             2652520 ops/s    377.0000 ns/op   x0.684    1588011 runs   1.07 s
+// ✓ Array 250000 set(249999)                                             2398082 ops/s    417.0000 ns/op   x0.993    1437819 runs   1.07 s
+// ✓ Array 250000 iterate all - loop                                     3784.639 ops/s    264.2260 us/op   x0.898       3774 runs   1.00 s
+
+describe("MutableVector", () => {
+  // Don't run on CI
+  if (process.env.CI) return;
+
+  setBenchOpts({
+    maxMs: 10 * 1000,
+    minMs: 1 * 1000,
+    runs: 1024,
+  });
+
+  const items = createArray(n);
+  const mutableVector = MutableVector.from(items);
+
+  itBench(`MutableVector ${n} create`, () => {
+    MutableVector.from(items);
+  });
+
+  itBench(`MutableVector ${n} get(${ilo})`, () => {
+    mutableVector.get(ilo);
+  });
+
+  itBench(`MutableVector ${n} set(${ilo})`, () => {
+    mutableVector.set(ilo, 10000000);
+  });
+
+  itBench(`MutableVector ${n} get(${ihi})`, () => {
+    mutableVector.get(ihi);
+  });
+
+  itBench(`MutableVector ${n} set(${ihi})`, () => {
+    mutableVector.set(ihi, 10000000);
+  });
+
+  itBench(`MutableVector ${n} toArray()`, () => {
+    mutableVector.toArray();
+  });
+
+  itBench(`MutableVector ${n} iterate all - toArray() + loop`, () => {
+    const mvArr = mutableVector.toArray();
+    for (let i = 0; i < n; i++) {
+      mvArr[i];
+    }
+  });
+
+  itBench(`MutableVector ${n} iterate all - get(i)`, () => {
+    for (let i = 0; i < n; i++) {
+      mutableVector.get(i);
+    }
+  });
+});
+
+describe("Array", () => {
+  // Don't run on CI
+  if (process.env.CI) return;
+
+  setBenchOpts({
+    maxMs: 10 * 1000,
+    minMs: 1 * 1000,
+    runs: 1024,
+  });
+
+  const arr = createArray(n);
+
+  itBench(`Array ${n} create`, () => {
+    createArray(n);
+  });
+
+  itBench(`Array ${n} get(${ilo})`, () => {
+    arr[ilo];
+  });
+
+  itBench(`Array ${n} set(${ilo})`, () => {
+    arr[ilo] = 10000000;
+  });
+
+  itBench(`Array ${n} get(${ihi})`, () => {
+    arr[ihi];
+  });
+
+  itBench(`Array ${n} set(${ihi})`, () => {
+    arr[ihi] = 10000000;
+  });
+
+  itBench(`Array ${n} iterate all - loop`, () => {
+    for (let i = 0; i < n; i++) {
+      arr[i];
+    }
+  });
+});
+
+function createArray(n: number): number[] {
+  const items: number[] = [];
+  for (let i = 0; i < n; i++) {
+    items.push(i);
+  }
+  return items;
+}

--- a/packages/beacon-state-transition/test/perf/dataStructures/arrayish.test.ts
+++ b/packages/beacon-state-transition/test/perf/dataStructures/arrayish.test.ts
@@ -1,4 +1,4 @@
-import {LeafNode, subtreeFillToLength, toGindex, Tree, zeroNode} from "@chainsafe/persistent-merkle-tree";
+import {LeafNode, toGindex, Tree, zeroNode} from "@chainsafe/persistent-merkle-tree";
 import {MutableVector} from "@chainsafe/persistent-ts";
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
 


### PR DESCRIPTION
**Motivation**

To properly optimize our beacon state transition performance and memory usage we need to understand the tradeoffs or our different approaches.

**Description**

Add informational tests (not run in CI) with hardcoded results.

Notable results:
- Iterating an array is x10 faster than iterating a MutableVector
- Iterating a MutableVector is x100 times faster than iterating a Tree
- Regular JS arrays of numbers take 8 bytes per element
- MutableVector of numbers take 15 bytes per element
- Cloning a MutableVector has a fixed cost of ~1000 bytes. Cloning a MutableVector to mutate a few elements is very memory efficient even with the initial 1000 bytes cost