### PR TITLE
Rename to beforeProcessEpoch and afterProcessEpoch

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/epochContext.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochContext.ts
@@ -38,6 +38,8 @@ import {
 import {computeEpochShuffling, IEpochShuffling} from "./epochShuffling";
 import {MutableVector} from "@chainsafe/persistent-ts";
 import {computeBaseRewardPerIncrement} from "../../altair/misc";
+import {CachedBeaconState} from "./cachedBeaconState";
+import {IEpochProcess} from "./epochProcess";
 
 export type AttesterDuty = {
   // Index of validator in validator registry
@@ -210,11 +212,9 @@ export function computeSyncParticipantReward(config: IBeaconConfig, totalActiveB
  * Called to re-use information, such as the shuffling of the next epoch, after transitioning into a
  * new epoch.
  */
-export function rotateEpochs(
-  epochCtx: EpochContext,
-  state: allForks.BeaconState,
-  activeValidatorIndices: ValidatorIndex[]
-): void {
+export function afterProcessEpoch(state: CachedBeaconState<allForks.BeaconState>, epochProcess: IEpochProcess): void {
+  const {epochCtx} = state;
+  const activeValidatorIndices = epochProcess.nextEpochActiveValidatorIndices;
   epochCtx.previousShuffling = epochCtx.currentShuffling;
   epochCtx.currentShuffling = epochCtx.nextShuffling;
   const currEpoch = epochCtx.currentShuffling.epoch;

--- a/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
@@ -54,7 +54,7 @@ export interface IEpochProcess {
   statuses: IAttesterStatus[];
   validators: phase0.Validator[];
   balances?: BigUint64Array;
-  // to be used for rotateEpochs()
+  // to be used for afterProcessEpoch()
   nextEpochActiveValidatorIndices: ValidatorIndex[];
 }
 
@@ -83,7 +83,7 @@ export function createIEpochProcess(): IEpochProcess {
   };
 }
 
-export function prepareEpochProcessState<T extends allForks.BeaconState>(state: CachedBeaconState<T>): IEpochProcess {
+export function beforeProcessEpoch<T extends allForks.BeaconState>(state: CachedBeaconState<T>): IEpochProcess {
   const out = createIEpochProcess();
 
   const {config, epochCtx, validators} = state;

--- a/packages/beacon-state-transition/src/altair/epoch/index.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/index.ts
@@ -1,5 +1,5 @@
 import {allForks, altair} from "@chainsafe/lodestar-types";
-import {CachedBeaconState, IEpochProcess, prepareEpochProcessState} from "../../allForks/util";
+import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
 import {
   processJustificationAndFinalization,
   processRegistryUpdates,
@@ -26,8 +26,7 @@ export {
   processParticipationFlagUpdates,
 };
 
-export function processEpoch(state: CachedBeaconState<altair.BeaconState>): IEpochProcess {
-  const epochProcess = prepareEpochProcessState(state);
+export function processEpoch(state: CachedBeaconState<altair.BeaconState>, epochProcess: IEpochProcess): void {
   processJustificationAndFinalization(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
   processInactivityUpdates(state, epochProcess);
   processRewardsAndPenalties(state, epochProcess);
@@ -40,5 +39,4 @@ export function processEpoch(state: CachedBeaconState<altair.BeaconState>): IEpo
   processHistoricalRootsUpdate(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
   processParticipationFlagUpdates(state);
   processSyncCommitteeUpdates(state, epochProcess);
-  return epochProcess;
 }

--- a/packages/beacon-state-transition/src/phase0/epoch/index.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/index.ts
@@ -1,4 +1,4 @@
-import {CachedBeaconState, IEpochProcess, prepareEpochProcessState} from "../../allForks/util";
+import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
 import {
   processJustificationAndFinalization,
   processRegistryUpdates,
@@ -16,8 +16,7 @@ import {allForks, phase0} from "@chainsafe/lodestar-types";
 
 export {processRewardsAndPenalties, processSlashings, getAttestationDeltas};
 
-export function processEpoch(state: CachedBeaconState<phase0.BeaconState>): IEpochProcess {
-  const epochProcess = prepareEpochProcessState(state);
+export function processEpoch(state: CachedBeaconState<phase0.BeaconState>, epochProcess: IEpochProcess): void {
   processJustificationAndFinalization(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
   processRewardsAndPenalties(state, epochProcess);
   processRegistryUpdates(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
@@ -29,5 +28,4 @@ export function processEpoch(state: CachedBeaconState<phase0.BeaconState>): IEpo
   processRandaoMixesReset(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
   processHistoricalRootsUpdate(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
   processParticipationRecordUpdates(state);
-  return epochProcess;
 }

--- a/packages/beacon-state-transition/test/perf/altair/epoch/epoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/epoch/epoch.test.ts
@@ -10,7 +10,7 @@ describe("Altair epoch transition steps", () => {
   });
 
   const originalState = generatePerfTestCachedStateAltair({goBackOneSlot: true});
-  const epochProcess = allForks.prepareEpochProcessState(originalState);
+  const epochProcess = allForks.beforeProcessEpoch(originalState);
 
   const getPerfState = (): CachedBeaconState<altair.BeaconState> => {
     const state = originalState.clone();
@@ -27,7 +27,7 @@ describe("Altair epoch transition steps", () => {
   //
   // epoch process function              | ms / op     | % bar chart
   // ----------------------------------- | ----------- | --------------
-  // prepareEpochProcessState            | 700.0 ms/op | xxxxxxxxxxxxxx
+  // beforeProcessEpoch                  | 700.0 ms/op | xxxxxxxxxxxxxx
   // processJustificationAndFinalization | 0.180 ms/op |
   // processInactivityUpdates            | 7500. ms/op | xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
   // processRewardsAndPenalties          | 900.0 ms/op | xxxxxxxxxxxxxxxxxx
@@ -41,7 +41,7 @@ describe("Altair epoch transition steps", () => {
   // processParticipationFlagUpdates     | 300.0 ms/op | xxxxxx
   // processSyncCommitteeUpdates         | 0.000 ms/op |
 
-  // prepareEpochProcessState - in phase0
+  // beforeProcessEpoch - in phase0
   // processJustificationAndFinalization - in phase0
 
   itBench({

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.test.ts
@@ -10,7 +10,7 @@ describe("Phase 0 epoch transition steps", () => {
   });
 
   const originalState = generatePerfTestCachedStatePhase0({goBackOneSlot: true});
-  const epochProcess = allForks.prepareEpochProcessState(originalState);
+  const epochProcess = allForks.beforeProcessEpoch(originalState);
 
   const idPrefix = `epoch phase0 - ${perfStateId}`;
 
@@ -19,7 +19,7 @@ describe("Phase 0 epoch transition steps", () => {
   //
   // epoch process function              | ms / op     | % bar chart
   // ----------------------------------- | ----------- | --------------
-  // prepareEpochProcessState            | 700.0 ms/op | xxxxxxxxxxxxxx
+  // beforeProcessEpoch                  | 700.0 ms/op | xxxxxxxxxxxxxx
   // processJustificationAndFinalization | 0.180 ms/op |
   // processRewardsAndPenalties          | 600.0 ms/op | xxxxxxxxxxxx
   // processRegistryUpdates              | 0.017 ms/op |
@@ -32,9 +32,9 @@ describe("Phase 0 epoch transition steps", () => {
   // processParticipationRecordUpdates   | 0.000 ms/op |
 
   itBench({
-    id: `${idPrefix} - prepareEpochProcessState`,
+    id: `${idPrefix} - beforeProcessEpoch`,
     fn: () => {
-      allForks.prepareEpochProcessState(originalState);
+      allForks.beforeProcessEpoch(originalState);
     },
   });
 

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/getAttestationDeltas.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/getAttestationDeltas.test.ts
@@ -10,7 +10,7 @@ describe("getAttestationDeltas", () => {
   });
 
   const state = generatePerfTestCachedStatePhase0({goBackOneSlot: true});
-  const epochProcess = allForks.prepareEpochProcessState(state);
+  const epochProcess = allForks.beforeProcessEpoch(state);
 
   itBench(`getAttestationDeltas - ${perfStateId}`, () => {
     phase0.getAttestationDeltas(state, epochProcess);

--- a/packages/beacon-state-transition/test/perf/sanityCheck.test.ts
+++ b/packages/beacon-state-transition/test/perf/sanityCheck.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import {prepareEpochProcessState} from "../../src/allForks";
+import {beforeProcessEpoch} from "../../src/allForks";
 import {generatePerfTestCachedStateAltair, generatePerfTestCachedStatePhase0, perfStateId} from "./util";
 
 describe("Perf test sanity check", function () {
@@ -25,7 +25,7 @@ describe("Perf test sanity check", function () {
 
   it("targetStake is in the same range", () => {
     const phase0State = generatePerfTestCachedStatePhase0();
-    const epochProcess = prepareEpochProcessState(phase0State);
+    const epochProcess = beforeProcessEpoch(phase0State);
     expect(epochProcess.prevEpochUnslashedStake.targetStake > targetStake).to.equal(
       true,
       `targetStake too low: ${epochProcess.prevEpochUnslashedStake.targetStake} > ${targetStake}`

--- a/packages/lodestar/test/utils/node/simTest.ts
+++ b/packages/lodestar/test/utils/node/simTest.ts
@@ -37,7 +37,7 @@ export function simTestInfoTracker(bn: BeaconNode, logger: ILogger): () => void 
   function logParticipation(state: allForks.CachedBeaconState<allForks.BeaconState>): void {
     // Compute participation (takes 5ms with 64 validators)
     // Need a CachedBeaconState<allForks.BeaconState> where (state.slot + 1) % SLOTS_EPOCH == 0
-    const epochProcess = allForks.prepareEpochProcessState(state);
+    const epochProcess = allForks.beforeProcessEpoch(state);
     const epoch = computeEpochAtSlot(state.slot);
 
     const prevParticipation =

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/effective_balance_updates/effective_balance_updates.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/effective_balance_updates/effective_balance_updates.ts
@@ -22,7 +22,7 @@ export function runEffectiveBalanceUpdates(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.beforeProcessEpoch(wrappedState);
       allForks.processEffectiveBalanceUpdates(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
       return wrappedState;
     },

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/eth1_data_reset/eth1_data_reset.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/eth1_data_reset/eth1_data_reset.ts
@@ -22,7 +22,7 @@ export function runEth1DataReset(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.beforeProcessEpoch(wrappedState);
       allForks.processEth1DataReset(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
       return wrappedState;
     },

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/historical_roots_update/historicalRootsUpdate.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/historical_roots_update/historicalRootsUpdate.ts
@@ -22,7 +22,7 @@ export function runHistoricalRootsUpdate(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.beforeProcessEpoch(wrappedState);
       allForks.processHistoricalRootsUpdate(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
       return wrappedState;
     },

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/inactivity_updates/inactivityUpdates.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/inactivity_updates/inactivityUpdates.ts
@@ -23,7 +23,7 @@ export function runInactivityUpdates(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.beforeProcessEpoch(wrappedState);
       altair.processInactivityUpdates(wrappedState, epochProcess);
       return wrappedState;
     },

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/justification_and_finalization/justificationAndFinalization.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/justification_and_finalization/justificationAndFinalization.ts
@@ -23,7 +23,7 @@ export function runJustificationAndFinalization(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.beforeProcessEpoch(wrappedState);
       allForks.processJustificationAndFinalization(
         wrappedState as CachedBeaconState<allForks.BeaconState>,
         epochProcess

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/randao_mixes_reset/randaoMixesReset.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/randao_mixes_reset/randaoMixesReset.ts
@@ -22,7 +22,7 @@ export function runRandaoMixesReset(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.beforeProcessEpoch(wrappedState);
       allForks.processRandaoMixesReset(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
       return wrappedState;
     },

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/registry_updates/registryUpdates.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/registry_updates/registryUpdates.ts
@@ -22,7 +22,7 @@ export function runRegistryUpdates(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.beforeProcessEpoch(wrappedState);
       allForks.processRegistryUpdates(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
       return wrappedState;
     },

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/rewards_and_penalties/rewardsAndPenalties.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/rewards_and_penalties/rewardsAndPenalties.ts
@@ -22,7 +22,7 @@ export function runRewardsAndPenalties(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.beforeProcessEpoch(wrappedState);
       altair.processRewardsAndPenalties(wrappedState, epochProcess);
       return wrappedState;
     },

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/slashings/slashings.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/slashings/slashings.ts
@@ -22,7 +22,7 @@ export function runSlashings(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.beforeProcessEpoch(wrappedState);
       altair.processSlashings(wrappedState, epochProcess);
       return wrappedState;
     },

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/slashings_reset/slashings_reset.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/slashings_reset/slashings_reset.ts
@@ -22,7 +22,7 @@ export function runSlashingsReset(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.beforeProcessEpoch(wrappedState);
       allForks.processSlashingsReset(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
       return wrappedState;
     },

--- a/packages/spec-test-runner/test/spec/altair/epoch_processing/sync_committee_updates/sync_committee_updates.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing/sync_committee_updates/sync_committee_updates.ts
@@ -22,7 +22,7 @@ export function runSyncCommitteeUpdates(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.beforeProcessEpoch(wrappedState);
       altair.processSyncCommitteeUpdates(wrappedState, epochProcess);
       return wrappedState;
     },

--- a/packages/spec-test-runner/test/spec/altair/rewards/basic/basic.ts
+++ b/packages/spec-test-runner/test/spec/altair/rewards/basic/basic.ts
@@ -28,7 +28,7 @@ export function runBasic(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.beforeProcessEpoch(wrappedState);
       return {
         head_deltas: altair.getFlagIndexDeltas(wrappedState, epochProcess, TIMELY_HEAD_FLAG_INDEX),
         source_deltas: altair.getFlagIndexDeltas(wrappedState, epochProcess, TIMELY_SOURCE_FLAG_INDEX),

--- a/packages/spec-test-runner/test/spec/altair/rewards/leak/leak.ts
+++ b/packages/spec-test-runner/test/spec/altair/rewards/leak/leak.ts
@@ -29,7 +29,7 @@ export function runLeak(presetName: PresetName): void {
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
 
-      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.beforeProcessEpoch(wrappedState);
       return {
         head_deltas: altair.getFlagIndexDeltas(wrappedState, epochProcess, TIMELY_HEAD_FLAG_INDEX),
         source_deltas: altair.getFlagIndexDeltas(wrappedState, epochProcess, TIMELY_SOURCE_FLAG_INDEX),

--- a/packages/spec-test-runner/test/spec/altair/rewards/random/random.ts
+++ b/packages/spec-test-runner/test/spec/altair/rewards/random/random.ts
@@ -28,7 +28,7 @@ export function runRandom(presetName: PresetName): void {
         config,
         (testcase.pre as TreeBacked<altair.BeaconState>).clone()
       );
-      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.beforeProcessEpoch(wrappedState);
       return {
         head_deltas: altair.getFlagIndexDeltas(wrappedState, epochProcess, TIMELY_HEAD_FLAG_INDEX),
         source_deltas: altair.getFlagIndexDeltas(wrappedState, epochProcess, TIMELY_SOURCE_FLAG_INDEX),

--- a/packages/spec-test-runner/test/spec/phase0/epoch_processing/justification/justification_and_finalization_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/epoch_processing/justification/justification_and_finalization_mainnet.test.ts
@@ -16,7 +16,7 @@ describeDirectorySpecTest<IStateTestCase, phase0.BeaconState>(
       config,
       testcase.pre as TreeBacked<phase0.BeaconState>
     );
-    const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+    const epochProcess = allForks.beforeProcessEpoch(wrappedState);
     allForks.processJustificationAndFinalization(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
     return wrappedState;
   },

--- a/packages/spec-test-runner/test/spec/phase0/epoch_processing/registryUpdates/registry_updates_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/epoch_processing/registryUpdates/registry_updates_mainnet.test.ts
@@ -17,7 +17,7 @@ describeDirectorySpecTest<IStateTestCase, phase0.BeaconState>(
       config,
       testcase.pre as TreeBacked<phase0.BeaconState>
     );
-    const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+    const epochProcess = allForks.beforeProcessEpoch(wrappedState);
     allForks.processRegistryUpdates(wrappedState as CachedBeaconState<allForks.BeaconState>, epochProcess);
     return wrappedState;
   },

--- a/packages/spec-test-runner/test/spec/phase0/epoch_processing/rewardsAndPenalties/rewards_and_penalties_minimal.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/epoch_processing/rewardsAndPenalties/rewards_and_penalties_minimal.test.ts
@@ -17,7 +17,7 @@ describeDirectorySpecTest<IStateTestCase, phase0.BeaconState>(
       config,
       testcase.pre as TreeBacked<phase0.BeaconState>
     );
-    const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+    const epochProcess = allForks.beforeProcessEpoch(wrappedState);
     phase0.processRewardsAndPenalties(wrappedState, epochProcess);
     return wrappedState;
   },

--- a/packages/spec-test-runner/test/spec/phase0/epoch_processing/slashings/slashings_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/epoch_processing/slashings/slashings_mainnet.test.ts
@@ -17,7 +17,7 @@ describeDirectorySpecTest<IStateTestCase, phase0.BeaconState>(
       config,
       testcase.pre as TreeBacked<phase0.BeaconState>
     );
-    const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+    const epochProcess = allForks.beforeProcessEpoch(wrappedState);
     phase0.processSlashings(wrappedState, epochProcess);
     return wrappedState;
   },

--- a/packages/spec-test-runner/test/spec/phase0/rewards/rewards_mainnet.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/rewards/rewards_mainnet.test.ts
@@ -17,7 +17,7 @@ for (const testSuite of ["basic", "leak", "random"]) {
         config,
         testcase.pre as TreeBacked<phase0.BeaconState>
       );
-      const epochProcess = allForks.prepareEpochProcessState(wrappedState);
+      const epochProcess = allForks.beforeProcessEpoch(wrappedState);
       const [rewards, penalties] = phase0.getAttestationDeltas(wrappedState, epochProcess);
       return {
         rewards: rewards.map((reward) => BigInt(reward)),


### PR DESCRIPTION
**Motivation**

Working on optimizing the state transition function caches, I find more intuitive to rename this functions to 
```ts
beforeProcessEpoch()
processEpoch()
afterProcessEpoch()
```

Since they do more that just preparing the epoch process.

**Description**

- Rename `prepareEpochProcessState` -> `beforeProcessEpoch`
- Rename `rotateEpochs` -> `afterProcessEpoch`