### PR TITLE
Compute totalActiveBalance in existing validators loop

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/epochContext.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochContext.ts
@@ -101,6 +101,8 @@ export function createEpochContext(
   const previousEpoch = currentEpoch === GENESIS_EPOCH ? GENESIS_EPOCH : currentEpoch - 1;
   const nextEpoch = currentEpoch + 1;
 
+  let totalActiveBalance = BigInt(0);
+
   const previousActiveIndices: ValidatorIndex[] = [];
   const currentActiveIndices: ValidatorIndex[] = [];
   const nextActiveIndices: ValidatorIndex[] = [];
@@ -110,6 +112,7 @@ export function createEpochContext(
     }
     if (isActiveValidator(v, currentEpoch)) {
       currentActiveIndices.push(i);
+      totalActiveBalance += v.effectiveBalance;
     }
     if (isActiveValidator(v, nextEpoch)) {
       nextActiveIndices.push(i);
@@ -132,7 +135,6 @@ export function createEpochContext(
   // Only after altair, compute the indices of the current sync committee
   const onAltairFork = currentEpoch >= config.ALTAIR_FORK_EPOCH;
 
-  const totalActiveBalance = getTotalBalance(state, currentShuffling.activeIndices);
   const syncParticipantReward = onAltairFork ? computeSyncParticipantReward(config, totalActiveBalance) : BigInt(0);
   const syncProposerReward = onAltairFork
     ? (syncParticipantReward * PROPOSER_WEIGHT) / (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT)

--- a/packages/beacon-state-transition/src/allForks/util/epochContext.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochContext.ts
@@ -119,6 +119,11 @@ export function createEpochContext(
     }
   });
 
+  // Spec: `EFFECTIVE_BALANCE_INCREMENT` Gwei minimum to avoid divisions by zero
+  if (totalActiveBalance < EFFECTIVE_BALANCE_INCREMENT) {
+    totalActiveBalance = EFFECTIVE_BALANCE_INCREMENT;
+  }
+
   const currentShuffling = computeEpochShuffling(state, currentActiveIndices, currentEpoch);
   let previousShuffling;
   if (previousEpoch === currentEpoch) {


### PR DESCRIPTION
**Motivation**

Noticed that we run an extra unnecessary loop over validators in epochCtx creation

**Description**

Compute total active balance on the existing loop over validators