### PR TITLE
Use same naming as spec for indicesEligibleForActivation

### DIFF
--- a/packages/beacon-state-transition/src/allForks/epoch/processRegistryUpdates.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processRegistryUpdates.ts
@@ -25,7 +25,7 @@ export function processRegistryUpdates(
   }
 
   // set new activation eligibilities
-  for (const index of epochProcess.indicesToSetActivationEligibility) {
+  for (const index of epochProcess.indicesEligibleForActivationQueue) {
     validators.update(index, {
       activationEligibilityEpoch: epochCtx.currentShuffling.epoch + 1,
     });
@@ -33,7 +33,7 @@ export function processRegistryUpdates(
 
   const finalityEpoch = state.finalizedCheckpoint.epoch;
   // dequeue validators for activation up to churn limit
-  for (const index of epochProcess.indicesToMaybeActivate.slice(0, epochProcess.churnLimit)) {
+  for (const index of epochProcess.indicesEligibleForActivation.slice(0, epochProcess.churnLimit)) {
     // placement in queue is finalized
     if (epochProcess.validators[index].activationEligibilityEpoch > finalityEpoch) {
       break; // remaining validators all have an activationEligibilityEpoch that is higher anyway, break early

--- a/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
@@ -41,10 +41,10 @@ export interface IEpochProcess {
   prevEpochUnslashedStake: IEpochStakeSummary;
   currEpochUnslashedTargetStake: Gwei;
   indicesToSlash: ValidatorIndex[];
-  indicesToSetActivationEligibility: ValidatorIndex[];
+  indicesEligibleForActivationQueue: ValidatorIndex[];
   // ignores churn, apply churn-limit manually.
   // maybe, because finality affects it still
-  indicesToMaybeActivate: ValidatorIndex[];
+  indicesEligibleForActivation: ValidatorIndex[];
 
   indicesToEject: ValidatorIndex[];
   exitQueueEnd: Epoch;
@@ -71,8 +71,8 @@ export function createIEpochProcess(): IEpochProcess {
     },
     currEpochUnslashedTargetStake: BigInt(0),
     indicesToSlash: [],
-    indicesToSetActivationEligibility: [],
-    indicesToMaybeActivate: [],
+    indicesEligibleForActivationQueue: [],
+    indicesEligibleForActivation: [],
     indicesToEject: [],
     exitQueueEnd: 0,
     exitQueueEndChurn: 0,
@@ -133,11 +133,11 @@ export function beforeProcessEpoch<T extends allForks.BeaconState>(state: Cached
     }
 
     if (v.activationEligibilityEpoch === FAR_FUTURE_EPOCH && v.effectiveBalance === MAX_EFFECTIVE_BALANCE) {
-      out.indicesToSetActivationEligibility.push(i);
+      out.indicesEligibleForActivationQueue.push(i);
     }
 
     if (v.activationEpoch === FAR_FUTURE_EPOCH && v.activationEligibilityEpoch <= currentEpoch) {
-      out.indicesToMaybeActivate.push(i);
+      out.indicesEligibleForActivation.push(i);
     }
 
     if (status.active && v.exitEpoch === FAR_FUTURE_EPOCH && v.effectiveBalance <= config.EJECTION_BALANCE) {
@@ -158,7 +158,7 @@ export function beforeProcessEpoch<T extends allForks.BeaconState>(state: Cached
   out.baseRewardPerIncrement = computeBaseRewardPerIncrement(out.totalActiveStake);
 
   // order by sequence of activationEligibilityEpoch setting and then index
-  out.indicesToMaybeActivate.sort(
+  out.indicesEligibleForActivation.sort(
     (a, b) => out.validators[a].activationEligibilityEpoch - out.validators[b].activationEligibilityEpoch || a - b
   );
 


### PR DESCRIPTION
**Motivation**

To follow the code and spec more easily, these names match the spec functions

**Description**

Rename:
- `indicesToSetActivationEligibility` -> `indicesEligibleForActivationQueue`
- `indicesToMaybeActivate` -> `indicesEligibleForActivation`