### PR TITLE
Improve processBlock performance tests

### DIFF
--- a/packages/beacon-state-transition/src/allForks/block/processVoluntaryExit.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processVoluntaryExit.ts
@@ -6,7 +6,7 @@ import {initiateValidatorExit} from "../../allForks/block";
 import {verifyVoluntaryExitSignature} from "../../allForks/signatureSets";
 import {BlockProcess} from "../../util/blockProcess";
 
-export function processVoluntaryExit(
+export function processVoluntaryExitAllForks(
   state: CachedBeaconState<allForks.BeaconState>,
   signedVoluntaryExit: phase0.SignedVoluntaryExit,
   blockProcess: BlockProcess,

--- a/packages/beacon-state-transition/src/altair/block/processVoluntaryExit.ts
+++ b/packages/beacon-state-transition/src/altair/block/processVoluntaryExit.ts
@@ -1,6 +1,6 @@
 import {allForks, altair, phase0} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "../../allForks";
-import {processVoluntaryExit as processVoluntaryExitAllForks} from "../../allForks/block";
+import {processVoluntaryExitAllForks} from "../../allForks/block";
 import {BlockProcess} from "../../util/blockProcess";
 
 export function processVoluntaryExit(

--- a/packages/beacon-state-transition/src/phase0/block/processVoluntaryExit.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processVoluntaryExit.ts
@@ -1,6 +1,6 @@
 import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "../../allForks/util";
-import {processVoluntaryExit as processVoluntaryExitAllForks} from "../../allForks/block";
+import {processVoluntaryExitAllForks} from "../../allForks/block";
 import {BlockProcess} from "../../util/blockProcess";
 
 export function processVoluntaryExit(

--- a/packages/beacon-state-transition/test/perf/altair/block/processBlock.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/block/processBlock.test.ts
@@ -1,0 +1,124 @@
+import {itBench, setBenchOpts} from "@dapplion/benchmark";
+import {
+  ACTIVE_PRESET,
+  MAX_ATTESTATIONS,
+  MAX_ATTESTER_SLASHINGS,
+  MAX_DEPOSITS,
+  MAX_PROPOSER_SLASHINGS,
+  MAX_VOLUNTARY_EXITS,
+  PresetName,
+  SYNC_COMMITTEE_SIZE,
+} from "@chainsafe/lodestar-params";
+import {allForks} from "../../../../src";
+import {generatePerfTestCachedStateAltair, perfStateId} from "../../util";
+import {getBlockAltair} from "../../phase0/block/util";
+
+// As of Jun 12 2021
+// Process block
+// ================================================================
+// Process block with 0 validator exit                                    233.6434 ops/s      4.280027 ms/op   3491 runs    15.01 s
+// Process block with 1 validator exit                                    41.33581 ops/s      24.19210 ms/op    619 runs    15.00 s
+// Process block with 16 validator exits                                  42.34492 ops/s      23.61558 ms/op    635 runs    15.02 s
+
+// Processing a block consist of three steps
+// 1. Verifying signatures
+// 2. Running block processing (state transition function)
+// 3. Hashing the state
+//
+// Performance cost of each block depends on the size of the state + the operation counts in the block
+//
+//
+// ### Verifying signatures
+// Signature verification is done in bulk using batch BLS verification. Performance is proportional to the amount of
+// sigs to verify and the cost to construct the signature sets from TreeBacked data.
+//
+// - Same as phase0
+// - SyncAggregate sigs:     1 x agg (358 bits on avg) - TODO: assuming same participation as attestations
+//
+// A mainnet average block has:
+//   92 (phase0) + 1 = 93 sigs
+//   8100 (phase0) + 358 = 8458 pubkey aggregations
+// A maxed block would have:
+//   198 (phase0) + 1 = 199 sigs
+//   16896 (phase0) + 512 = 17408 pubkey aggregations
+//
+//
+// ### Running block processing
+// Block processing is relatively fast, most of the cost is reading and writing tree data. The performance of
+// processBlock is properly tracked with this performance test.
+//
+// - processBlockHeader        : phase0 same
+// - processRandao             : phase0 same
+// - processEth1Data           : phase0 same
+// - processOperations         --
+//   - processProposerSlashing : two constants changed, same perf
+//   - processAttesterSlashing : two constants changed, same perf
+//   - processAttestation      : new in altair
+//   - processDeposit          : adds pushing to inactivityScores
+//   - processVoluntaryExit    : phase0 same
+// - processSyncAggregate      : new in altair
+//
+//
+// ### Hashing the state
+// Hashing cost is dependant on how many nodes have been modified in the tree. After mutating the state, just count
+// how many nodes have no cached _root, then multiply by the cost of hashing.
+//
+
+describe("Process block", () => {
+  setBenchOpts({
+    maxMs: 60 * 1000,
+    minMs: 15 * 1000,
+    runs: 1024,
+  });
+
+  if (ACTIVE_PRESET !== PresetName.mainnet) {
+    throw Error(`ACTIVE_PRESET ${ACTIVE_PRESET} must be mainnet`);
+  }
+
+  const baseState = generatePerfTestCachedStateAltair() as allForks.CachedBeaconState<allForks.BeaconState>;
+
+  const worstCaseBlockState = baseState.clone();
+  const worstCaseBlock = getBlockAltair(worstCaseBlockState, {
+    proposerSlashingLen: MAX_PROPOSER_SLASHINGS,
+    attesterSlashingLen: MAX_ATTESTER_SLASHINGS,
+    attestationLen: MAX_ATTESTATIONS,
+    depositsLen: MAX_DEPOSITS,
+    voluntaryExitLen: MAX_VOLUNTARY_EXITS,
+    bitsLen: 128,
+    syncCommitteeBitsLen: SYNC_COMMITTEE_SIZE,
+  });
+
+  const averageMainnetBlockState = baseState.clone();
+  const averageMainnetBlock = getBlockAltair(averageMainnetBlockState, {
+    proposerSlashingLen: 0,
+    attesterSlashingLen: 0,
+    attestationLen: 90,
+    depositsLen: 0,
+    voluntaryExitLen: 0,
+    bitsLen: 90,
+    // TODO: There's no data yet on how full syncCommittee will be. Assume same ratio of attestations
+    syncCommitteeBitsLen: Math.round(SYNC_COMMITTEE_SIZE * 0.7),
+  });
+
+  itBench(
+    {id: `processBlock altair ${perfStateId} - maxed ops`, beforeEach: () => worstCaseBlockState.clone()},
+    (state) => {
+      allForks.stateTransition(state, worstCaseBlock, {
+        verifyProposer: false,
+        verifySignatures: false,
+        verifyStateRoot: false,
+      });
+    }
+  );
+
+  itBench(
+    {id: `processBlock altair ${perfStateId} - average`, beforeEach: () => averageMainnetBlockState.clone()},
+    (state) => {
+      allForks.stateTransition(state, averageMainnetBlock, {
+        verifyProposer: false,
+        verifySignatures: false,
+        verifyStateRoot: false,
+      });
+    }
+  );
+});

--- a/packages/beacon-state-transition/test/perf/analyzeBlocks.ts
+++ b/packages/beacon-state-transition/test/perf/analyzeBlocks.ts
@@ -1,0 +1,87 @@
+import {getClient} from "@chainsafe/lodestar-api";
+import {config} from "@chainsafe/lodestar-config/default";
+
+// Analyze how eth2 blocks are in a target network to prepare accurate performance states and blocks
+
+// Mainnet
+// slot: 1803658,
+// blocks: 2790,
+// attestationsPerBlock: 89.79820788530466,
+// depositsPerBlock: 0.005017921146953405,
+// attesterSlashingsPerBlock: 0,
+// proposerSlashingsPerBlock: 0,
+// voluntaryExitsPerBlock: 0,
+// inclusionDistanceAvg: 3.446696495926749,
+// aggregationBitsAvg: 87.88991645944512
+
+const network = "mainnet";
+const INFURA_CREDENTIALS = "1sla4tyOFn0bB1ohyCKaH2sLmHu:b8cdb9d881039fd04fe982a5ec57b0b8";
+const baseUrl = `https://${INFURA_CREDENTIALS}@eth2-beacon-${network}.infura.io`;
+
+const client = getClient(config, {baseUrl});
+
+async function run(): Promise<void> {
+  const {data: headBlock} = await client.beacon.getBlockHeader("head");
+
+  // Count operations
+  let blocks = 0;
+  let attestations = 0;
+  let deposits = 0;
+  let attesterSlashings = 0;
+  let proposerSlashings = 0;
+  let voluntaryExits = 0;
+
+  // Analyze attestations
+  let inclusionDistance = 0;
+  let aggregationBits = 0;
+
+  const startSlot = headBlock.header.message.slot;
+  const batchSize = 32;
+
+  for (let slot = startSlot; slot > 0; slot -= batchSize) {
+    const blockPromises: ReturnType<typeof client.beacon.getBlock>[] = [];
+    for (let s = slot - batchSize; s < slot; s++) {
+      blockPromises.push(client.beacon.getBlock(s));
+    }
+
+    const results = await Promise.allSettled(blockPromises);
+    for (const result of results) {
+      if (result.status === "rejected") {
+        // Missed block
+        continue;
+      }
+
+      const block = result.value.data;
+
+      blocks++;
+      attestations += block.message.body.attestations.length;
+      deposits += block.message.body.deposits.length;
+      attesterSlashings += block.message.body.attesterSlashings.length;
+      proposerSlashings += block.message.body.proposerSlashings.length;
+      voluntaryExits += block.message.body.voluntaryExits.length;
+
+      for (const attestation of block.message.body.attestations) {
+        inclusionDistance += block.message.slot - attestation.data.slot;
+        aggregationBits += Array.from(attestation.aggregationBits).filter((bit) => bit === true).length;
+      }
+    }
+
+    /* eslint-disable no-console */
+    console.log({
+      slot,
+      blocks,
+      attestationsPerBlock: attestations / blocks,
+      depositsPerBlock: deposits / blocks,
+      attesterSlashingsPerBlock: attesterSlashings / blocks,
+      proposerSlashingsPerBlock: proposerSlashings / blocks,
+      voluntaryExitsPerBlock: voluntaryExits / blocks,
+      inclusionDistanceAvg: inclusionDistance / attestations,
+      aggregationBitsAvg: aggregationBits / attestations,
+    });
+  }
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/beacon-state-transition/test/perf/phase0/block/block.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/block/block.test.ts
@@ -62,8 +62,8 @@ import {LeafNode} from "@chainsafe/persistent-merkle-tree";
 describe("Process block", () => {
   setBenchOpts({
     maxMs: 60 * 1000,
-    minMs: 0 * 1000,
-    runs: 1,
+    minMs: 15 * 1000,
+    runs: 1024,
   });
 
   const baseState = generatePerfTestCachedStatePhase0();

--- a/packages/beacon-state-transition/test/perf/phase0/block/block.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/block/block.test.ts
@@ -1,9 +1,19 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
-import {MAX_VOLUNTARY_EXITS} from "@chainsafe/lodestar-params";
-import {phase0} from "@chainsafe/lodestar-types";
+import {phase0, ssz} from "@chainsafe/lodestar-types";
+import {SecretKey} from "@chainsafe/blst";
+import {
+  DOMAIN_DEPOSIT,
+  MAX_ATTESTATIONS,
+  MAX_ATTESTER_SLASHINGS,
+  MAX_DEPOSITS,
+  MAX_PROPOSER_SLASHINGS,
+  MAX_VOLUNTARY_EXITS,
+} from "@chainsafe/lodestar-params";
+import {config} from "@chainsafe/lodestar-config/default";
 import {List} from "@chainsafe/ssz";
-import {allForks} from "../../../../src";
-import {generatePerformanceBlockPhase0, generatePerfTestCachedStatePhase0, perfStateId} from "../../util";
+import {allForks, computeDomain, computeEpochAtSlot, computeSigningRoot, ZERO_HASH} from "../../../../src";
+import {generatePerfTestCachedStatePhase0, perfStateId} from "../../util";
+import {LeafNode} from "@chainsafe/persistent-merkle-tree";
 
 // As of Jun 12 2021
 // Process block
@@ -12,44 +22,345 @@ import {generatePerformanceBlockPhase0, generatePerfTestCachedStatePhase0, perfS
 // Process block with 1 validator exit                                    41.33581 ops/s      24.19210 ms/op    619 runs    15.00 s
 // Process block with 16 validator exits                                  42.34492 ops/s      23.61558 ms/op    635 runs    15.02 s
 
+// Processing a block consist of three steps
+// 1. Verifying signatures
+// 2. Running block processing (state transition function)
+// 3. Hashing the state
+//
+// Performance cost of each block depends on the size of the state + the operation counts in the block
+//
+// ### Verifying signatures
+// Signature verification is done in bulk using batch BLS verification. Performance is proportional to the amount of
+// sigs to verify and the cost to construct the signature sets from TreeBacked data.
+//
+// - Proposer sig:           1 single
+// - RandaoReveal sig:       1 single
+// - ProposerSlashings sigs: ops x 2 single
+// - AttesterSlashings sigs: ops x 2 agg (90 bits on avg)
+// - Attestations sigs:      ops x 1 agg (90 bits on avg)
+// - VoluntaryExits sigs:    ops x 1 single
+// - Deposits sigs:          ops x 1 single
+//
+// A mainnet average block has:
+//   1 + 1 + 90 = 92 sigs
+//   90 * 90 = 8100 pubkey aggregations
+// A worst case block would have:
+//   1 + 1 + 16 * 2 + 2 * 2 + 128 + 16 + 16 = 198 sigs
+//   2 * 2 * 128 + 128 * 128 = 16896 pubkey aggregations
+//
+// ### Running block processing
+// Block processing is relatively fast, most of the cost is reading and writing tree data.
+//
+//
+//
+//
+// ### Hashing the state
+// Hashing cost is dependant on how many nodes have been modified in the tree. After mutating the state, just count
+// how many nodes have no cached _root, then multiply by the cost of hashing.
+//
+
 describe("Process block", () => {
   setBenchOpts({
     maxMs: 60 * 1000,
-    minMs: 15 * 1000,
-    runs: 64,
+    minMs: 0 * 1000,
+    runs: 1,
   });
 
-  const originalState = generatePerfTestCachedStatePhase0() as allForks.CachedBeaconState<allForks.BeaconState>;
-  const regularBlock = generatePerformanceBlockPhase0();
-  const [oneValidatorExitBlock, maxValidatorExitBlock] = [1, MAX_VOLUNTARY_EXITS].map((numValidatorExits) => {
-    const signedBlock = regularBlock.clone();
-    const exitEpoch = originalState.epochCtx.currentShuffling.epoch;
-    const voluntaryExits: phase0.SignedVoluntaryExit[] = [];
-    for (let i = 0; i < numValidatorExits; i++) {
-      voluntaryExits.push({
-        message: {epoch: exitEpoch, validatorIndex: 40000 + i},
-        signature: Buffer.alloc(96),
-      });
-    }
-    signedBlock.message.body.voluntaryExits = (voluntaryExits as unknown) as List<phase0.SignedVoluntaryExit>;
-    return signedBlock;
+  const baseState = generatePerfTestCachedStatePhase0();
+  // const [oneValidatorExitBlock, maxValidatorExitBlock] = [1, MAX_VOLUNTARY_EXITS].map((numValidatorExits) => {
+  //   const signedBlock = regularBlock.clone();
+  //   const exitEpoch = baseState.epochCtx.currentShuffling.epoch;
+  //   const voluntaryExits: phase0.SignedVoluntaryExit[] = [];
+  //   for (let i = 0; i < numValidatorExits; i++) {
+  //     voluntaryExits.push({
+  //       message: {epoch: exitEpoch, validatorIndex: 40000 + i},
+  //       signature: Buffer.alloc(96),
+  //     });
+  //   }
+  //   signedBlock.message.body.voluntaryExits = (voluntaryExits as unknown) as List<phase0.SignedVoluntaryExit>;
+  //   return signedBlock;
+  // });
+
+  // const block = regularBlock.clone();
+
+  const worstCaseBlockState = baseState.clone();
+  const worstCaseBlock = getBlock(worstCaseBlockState, {
+    proposerSlashingLen: MAX_PROPOSER_SLASHINGS,
+    attesterSlashingLen: MAX_ATTESTER_SLASHINGS,
+    attestationLen: MAX_ATTESTATIONS,
+    depositsLen: MAX_DEPOSITS,
+    voluntaryExitLen: MAX_VOLUNTARY_EXITS,
+    bitsLen: 128,
   });
 
-  const idPrefix = `Process block - ${perfStateId}`;
+  const averageMainnetBlockState = baseState.clone();
+  const averageMainnetBlock = getBlock(averageMainnetBlockState, {
+    proposerSlashingLen: 0,
+    attesterSlashingLen: 0,
+    attestationLen: 90,
+    depositsLen: 0,
+    voluntaryExitLen: 0,
+    bitsLen: 90,
+  });
 
-  const testCases = [
-    {signedBlock: regularBlock, id: `${idPrefix} - with 0 validator exit`},
-    {signedBlock: oneValidatorExitBlock, id: `${idPrefix} - with 1 validator exit`},
-    {signedBlock: maxValidatorExitBlock, id: `${idPrefix} - with ${MAX_VOLUNTARY_EXITS} validator exits`},
-  ];
-
-  for (const {id, signedBlock} of testCases) {
-    itBench({id, beforeEach: () => originalState.clone()}, (state) => {
-      allForks.stateTransition(state, signedBlock, {
+  itBench(
+    {id: `processBlock phase0 - worst case - ${perfStateId}`, beforeEach: () => worstCaseBlockState.clone()},
+    (state) => {
+      allForks.stateTransition(state as allForks.CachedBeaconState<allForks.BeaconState>, worstCaseBlock, {
         verifyProposer: false,
         verifySignatures: false,
         verifyStateRoot: false,
       });
+    }
+  );
+
+  itBench(
+    {id: `processBlock phase0 - average - ${perfStateId}`, beforeEach: () => averageMainnetBlockState.clone()},
+    (state) => {
+      allForks.stateTransition(state as allForks.CachedBeaconState<allForks.BeaconState>, averageMainnetBlock, {
+        verifyProposer: false,
+        verifySignatures: false,
+        verifyStateRoot: false,
+      });
+    }
+  );
+
+  // Add ops
+
+  // Test individual operations maxing them to the worst case
+  // itBench(
+  //   {id: `phase0 processAttestation - ${MAX_ATTESTATIONS} - ${perfStateId}`, beforeEach: () => originalState.clone()},
+  //   (state) => {
+  //     for (let i = 0; i < MAX_ATTESTATIONS; i++) {
+  //       processAttestation(state, attestation, {}, false);
+  //       allForks.stateTransition(state, signedBlock, {
+  //         verifyProposer: false,
+  //         verifySignatures: false,
+  //         verifyStateRoot: false,
+  //       });
+  //     }
+  //   }
+  // );
+
+  // const idPrefix = `Process block - ${perfStateId}`;
+
+  // const testCases = [
+  //   {signedBlock: regularBlock, id: `${idPrefix} - with 0 validator exit`},
+  //   {signedBlock: oneValidatorExitBlock, id: `${idPrefix} - with 1 validator exit`},
+  //   {signedBlock: maxValidatorExitBlock, id: `${idPrefix} - with ${MAX_VOLUNTARY_EXITS} validator exits`},
+  // ];
+
+  // for (const {id, signedBlock} of testCases) {
+  //   itBench({id, beforeEach: () => originalState.clone()}, (state) => {
+  //     allForks.stateTransition(state, signedBlock, {
+  //       verifyProposer: false,
+  //       verifySignatures: false,
+  //       verifyStateRoot: false,
+  //     });
+  //   });
+  // }
+
+  // Process a regular mainnet block
+  // Process a worst case block with all operations full
+});
+
+function getBlock(
+  preState: allForks.CachedBeaconState<phase0.BeaconState>,
+  {
+    proposerSlashingLen,
+    attesterSlashingLen,
+    attestationLen,
+    depositsLen,
+    voluntaryExitLen,
+    bitsLen,
+  }: {
+    proposerSlashingLen: number;
+    attesterSlashingLen: number;
+    attestationLen: number;
+    depositsLen: number;
+    voluntaryExitLen: number;
+    bitsLen: number;
+  }
+): phase0.SignedBeaconBlock {
+  const emptySig = Buffer.alloc(96);
+  const rootA = Buffer.alloc(32, 0xda);
+  const rootB = Buffer.alloc(32, 0xdb);
+  const rootC = Buffer.alloc(32, 0xdc);
+
+  const stateSlot = preState.slot;
+  const stateEpoch = computeEpochAtSlot(stateSlot);
+
+  // Space out exited indexes through the max available range to force expensive tree navigation
+  const minActiveIndex = 0;
+  const maxActiveIndex = 200_000;
+  const totalExits = proposerSlashingLen + attesterSlashingLen * bitsLen + voluntaryExitLen;
+  const exitedIndexStep = Math.floor((maxActiveIndex - minActiveIndex) / totalExits);
+  const proposerSlashingStartIndex = minActiveIndex;
+  const attesterSlashingStartIndex = proposerSlashingStartIndex + proposerSlashingLen * exitedIndexStep;
+  const voluntaryExitStartIndex = attesterSlashingStartIndex + attesterSlashingLen * bitsLen * exitedIndexStep;
+
+  const proposerSlashings = ([] as phase0.ProposerSlashing[]) as List<phase0.ProposerSlashing>;
+  for (let i = 0; i < proposerSlashingLen; i++) {
+    const proposerIndex = proposerSlashingStartIndex + i * exitedIndexStep;
+    proposerSlashings.push({
+      signedHeader1: {
+        message: {slot: 1_800_000, proposerIndex, parentRoot: rootA, stateRoot: rootB, bodyRoot: rootC},
+        signature: emptySig,
+      },
+      signedHeader2: {
+        message: {slot: 1_800_000, proposerIndex, parentRoot: rootC, stateRoot: rootA, bodyRoot: rootB},
+        signature: emptySig,
+      },
     });
   }
-});
+
+  const attSlot = stateSlot - 2;
+  const attEpoch = computeEpochAtSlot(attSlot);
+  const attesterSlashings = ([] as phase0.AttesterSlashing[]) as List<phase0.AttesterSlashing>;
+  for (let i = 0; i < attesterSlashingLen; i++) {
+    // Double vote for 128 participants
+    const startIndex = attesterSlashingStartIndex + i * bitsLen * exitedIndexStep;
+    const attestingIndices = linspace(startIndex, bitsLen, exitedIndexStep) as List<number>;
+
+    const attData: phase0.AttestationData = {
+      slot: attSlot,
+      index: 0,
+      beaconBlockRoot: rootA,
+      source: {epoch: stateEpoch - 3, root: rootC},
+      target: {epoch: attEpoch, root: rootA},
+    };
+    attesterSlashings.push({
+      attestation1: {
+        attestingIndices,
+        data: attData,
+        signature: emptySig,
+      },
+      attestation2: {
+        attestingIndices,
+        data: {...attData, beaconBlockRoot: rootB},
+        signature: emptySig,
+      },
+    });
+  }
+
+  const attestations = ([] as phase0.Attestation[]) as List<phase0.Attestation>;
+  const attIndex = 0;
+  const attCommittee = preState.epochCtx.getBeaconCommittee(attSlot, attIndex);
+  const attSource =
+    attEpoch === stateEpoch ? preState.currentJustifiedCheckpoint : preState.previousJustifiedCheckpoint;
+  for (let i = 0; i < attestationLen; i++) {
+    // Spread attesting indices through the whole range, offset on each attestation
+    attestations.push({
+      aggregationBits: getAggregationBits(attCommittee.length, bitsLen) as List<boolean>,
+      data: {
+        slot: attSlot,
+        index: 0,
+        beaconBlockRoot: rootB,
+        source: attSource,
+        target: {epoch: attEpoch, root: rootA},
+      },
+      signature: emptySig,
+    });
+  }
+
+  // Moved to different function since it's a bit complex
+  const deposits = getDeposits(preState, depositsLen);
+
+  const voluntaryExits = ([] as phase0.SignedVoluntaryExit[]) as List<phase0.SignedVoluntaryExit>;
+  for (let i = 0; i < voluntaryExitLen; i++) {
+    voluntaryExits.push({
+      message: {
+        epoch: stateEpoch,
+        validatorIndex: voluntaryExitStartIndex + i * exitedIndexStep,
+      },
+      signature: emptySig,
+    });
+  }
+
+  const slot = preState.slot + 1;
+  return ssz.phase0.SignedBeaconBlock.createTreeBackedFromStruct({
+    message: {
+      slot,
+      proposerIndex: preState.getBeaconProposer(slot),
+      parentRoot: ssz.phase0.BeaconBlockHeader.hashTreeRoot(preState.latestBlockHeader),
+      // TODO: Compute the state root properly!
+      stateRoot: rootA,
+      body: {
+        randaoReveal: Buffer.alloc(96, 0xdd),
+        eth1Data: {
+          depositRoot: rootA,
+          depositCount: 1000,
+          blockHash: rootB,
+        },
+        graffiti: rootA,
+
+        // Operations
+        proposerSlashings,
+        attesterSlashings,
+        attestations,
+        deposits,
+        voluntaryExits,
+      },
+    },
+    signature: emptySig,
+  });
+}
+
+function getDeposits(preState: allForks.CachedBeaconState<phase0.BeaconState>, count: number): List<phase0.Deposit> {
+  const depositRootTree = ssz.phase0.DepositDataRootList.defaultTreeBacked();
+  const depositCount = preState.eth1Data.depositCount;
+  const withdrawalCredentials = Buffer.alloc(32, 0xee);
+
+  const depositsData: phase0.DepositData[] = [];
+  const deposits = ([] as phase0.Deposit[]) as List<phase0.Deposit>;
+
+  for (let i = 0; i < count; i++) {
+    const sk = SecretKey.fromBytes(Buffer.alloc(32, i + 1));
+    const pubkey = sk.toPublicKey().toBytes();
+    const depositMessage: phase0.DepositMessage = {pubkey, withdrawalCredentials, amount: BigInt(32e9)};
+    // Sign with disposable keys
+    const domain = computeDomain(DOMAIN_DEPOSIT, config.GENESIS_FORK_VERSION, ZERO_HASH);
+    const signingRoot = computeSigningRoot(ssz.phase0.DepositMessage, depositMessage, domain);
+    const signature = sk.sign(signingRoot).toBytes();
+    const depositData: phase0.DepositData = {...depositMessage, signature};
+    depositsData.push(depositData);
+
+    // First, push all deposits to the tree to generate proofs against the same root
+    const index = depositCount + i;
+    const gindex = depositRootTree.type.getPropertyGindex(index);
+    const depositDataRoot = ssz.phase0.DepositData.hashTreeRoot(depositData);
+    depositRootTree.tree.setNode(gindex, new LeafNode(depositDataRoot), true);
+  }
+
+  // Once the tree is complete, create proofs for each
+  for (let i = 0; i < count; i++) {
+    const gindex = depositRootTree.type.getPropertyGindex(depositCount + i);
+    const proof = depositRootTree.tree.getSingleProof(gindex);
+    deposits.push({proof, data: depositsData[i]});
+  }
+
+  // Write eth1Data to state
+  if (count > 0) {
+    preState.eth1Data.depositCount = depositCount + count;
+    preState.eth1Data.depositRoot = depositRootTree.hashTreeRoot();
+  }
+
+  return deposits;
+}
+
+function linspace(from: number, count: number, step: number): number[] {
+  const max = from + count * step;
+  const arr: number[] = [];
+  for (let i = from; i < max; i += step) {
+    arr.push(i);
+  }
+  return arr;
+}
+
+function getAggregationBits(len: number, participants: number): boolean[] {
+  const bits: boolean[] = [];
+  for (let i = 0; i < len; i++) {
+    bits.push(i < participants);
+  }
+  return bits;
+}


### PR DESCRIPTION
**Motivation**

Our current processBlock performance tests are good but don't cover all operations. We need tests that reflect normal network conditions and then worst cases to ensure we can get through those.

**Description**

- Analyze mainnet blocks to understand what's an average block. To recreate just run `ts-node packages/beacon-state-transition/test/perf/analyzeBlocks.ts`
- With those results create two performance tests:
  1. an average mainnet block
  2. a worst case block with maxed operations.
- Add extensive comments explaining the causes of bad performance and how to analyze them