### PR TITLE
Process altair attestations in batch

### DIFF
--- a/packages/beacon-state-transition/src/allForks/signatureSets/indexedAttestation.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/indexedAttestation.ts
@@ -18,22 +18,33 @@ export function verifyIndexedAttestationSignature(
   return verifySignatureSet(getIndexedAttestationSignatureSet(state, indexedAttestation, indices));
 }
 
+export function getAttestationWithIndicesSignatureSet(
+  state: CachedBeaconState<allForks.BeaconState>,
+  attestation: Pick<phase0.Attestation, "data" | "signature">,
+  indices: number[]
+): ISignatureSet {
+  const {epochCtx} = state;
+  const slot = computeStartSlotAtEpoch(attestation.data.target.epoch);
+  const domain = state.config.getDomain(DOMAIN_BEACON_ATTESTER, slot);
+
+  return {
+    type: SignatureSetType.aggregate,
+    pubkeys: indices.map((i) => epochCtx.index2pubkey[i]),
+    signingRoot: computeSigningRoot(ssz.phase0.AttestationData, attestation.data, domain),
+    signature: attestation.signature.valueOf() as Uint8Array,
+  };
+}
+
 export function getIndexedAttestationSignatureSet(
   state: CachedBeaconState<allForks.BeaconState>,
   indexedAttestation: phase0.IndexedAttestation,
   indices?: number[]
 ): ISignatureSet {
-  const {epochCtx} = state;
-  const slot = computeStartSlotAtEpoch(indexedAttestation.data.target.epoch);
-  const domain = state.config.getDomain(DOMAIN_BEACON_ATTESTER, slot);
-
-  if (!indices) indices = Array.from(readonlyValues(indexedAttestation.attestingIndices));
-  return {
-    type: SignatureSetType.aggregate,
-    pubkeys: indices.map((i) => epochCtx.index2pubkey[i]),
-    signingRoot: computeSigningRoot(ssz.phase0.AttestationData, indexedAttestation.data, domain),
-    signature: indexedAttestation.signature.valueOf() as Uint8Array,
-  };
+  return getAttestationWithIndicesSignatureSet(
+    state,
+    indexedAttestation,
+    indices ?? Array.from(readonlyValues(indexedAttestation.attestingIndices))
+  );
 }
 
 export function getAttestationsSignatureSets(

--- a/packages/beacon-state-transition/src/altair/block/index.ts
+++ b/packages/beacon-state-transition/src/altair/block/index.ts
@@ -3,7 +3,7 @@ import {allForks, altair} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "../../allForks/util";
 import {processBlockHeader, processEth1Data, processRandao} from "../../allForks/block";
 import {processOperations} from "./processOperations";
-import {processAttestation} from "./processAttestation";
+import {processAttestations} from "./processAttestation";
 import {processAttesterSlashing} from "./processAttesterSlashing";
 import {processDeposit} from "./processDeposit";
 import {processProposerSlashing} from "./processProposerSlashing";
@@ -13,7 +13,7 @@ import {BlockProcess} from "../../util";
 
 export {
   processOperations,
-  processAttestation,
+  processAttestations,
   processAttesterSlashing,
   processDeposit,
   processProposerSlashing,

--- a/packages/beacon-state-transition/src/altair/upgradeState.ts
+++ b/packages/beacon-state-transition/src/altair/upgradeState.ts
@@ -4,7 +4,7 @@ import {getCurrentEpoch, newZeroedArray} from "../util";
 import {List, TreeBacked} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IParticipationStatus} from "../allForks/util/cachedEpochParticipation";
-import {getAttestationParticipationStatus} from "./block/processAttestation";
+import {getAttestationParticipationStatus, RootCache} from "./block/processAttestation";
 import {getNextSyncCommittee} from "./util/syncCommittee";
 
 /**
@@ -54,13 +54,16 @@ function translateParticipation(
   state: CachedBeaconState<altair.BeaconState>,
   pendingAttesations: phase0.PendingAttestation[]
 ): void {
+  const {epochCtx} = state;
+  const rootCache = new RootCache(state);
   const epochParticipation = state.previousEpochParticipation;
   for (const attestation of pendingAttesations) {
     const data = attestation.data;
     const {timelySource, timelyTarget, timelyHead} = getAttestationParticipationStatus(
-      state,
       data,
-      attestation.inclusionDelay
+      attestation.inclusionDelay,
+      rootCache,
+      epochCtx
     );
 
     const attestingIndices = state.getAttestingIndices(data, attestation.aggregationBits);

--- a/packages/spec-test-runner/test/spec/altair/operations/attestations/attestations.ts
+++ b/packages/spec-test-runner/test/spec/altair/operations/attestations/attestations.ts
@@ -22,7 +22,7 @@ export function runAttestations(presetName: PresetName): void {
         config,
         testcase.pre as TreeBacked<altair.BeaconState>
       ) as CachedBeaconState<altair.BeaconState>;
-      altair.processAttestation(wrappedState, testcase.attestation, {});
+      altair.processAttestations(wrappedState, [testcase.attestation], {});
       return wrappedState;
     },
     {


### PR DESCRIPTION
**Motivation**

Small optimizations on altair attestation processing

**Description**

- Only update the balance of the proposer once for all attestations
- Prepare signature set more efficiently
- Cache block roots to reach each one once