### PR TITLE
Fix active validator indices for next shuffling epoch

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/epochContext.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochContext.ts
@@ -262,12 +262,15 @@ export function computeSyncParticipantReward(config: IBeaconConfig, totalActiveB
  */
 export function afterProcessEpoch(state: CachedBeaconState<allForks.BeaconState>, epochProcess: IEpochProcess): void {
   const {epochCtx} = state;
-  const activeValidatorIndices = epochProcess.nextEpochActiveValidatorIndices;
   epochCtx.previousShuffling = epochCtx.currentShuffling;
   epochCtx.currentShuffling = epochCtx.nextShuffling;
   const currEpoch = epochCtx.currentShuffling.epoch;
   const nextEpoch = currEpoch + 1;
-  epochCtx.nextShuffling = computeEpochShuffling(state, activeValidatorIndices, nextEpoch);
+  epochCtx.nextShuffling = computeEpochShuffling(
+    state,
+    epochProcess.nextEpochShufflingActiveValidatorIndices,
+    nextEpoch
+  );
   epochCtx.proposers = computeProposers(state, epochCtx.currentShuffling);
 
   // TODO: DEDUPLICATE from createEpochContext
@@ -296,7 +299,7 @@ export function afterProcessEpoch(state: CachedBeaconState<allForks.BeaconState>
   }
 
   if (currEpoch >= epochCtx.config.ALTAIR_FORK_EPOCH) {
-    const totalActiveBalance = getTotalBalance(state, activeValidatorIndices);
+    const totalActiveBalance = getTotalBalance(state, epochCtx.currentShuffling.activeIndices);
     epochCtx.syncParticipantReward = computeSyncParticipantReward(epochCtx.config, totalActiveBalance);
     epochCtx.syncProposerReward =
       (epochCtx.syncParticipantReward * PROPOSER_WEIGHT) / (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT);

--- a/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
@@ -100,7 +100,7 @@ export interface IEpochProcess {
   validators: phase0.Validator[];
   balances?: BigUint64Array;
   // to be used for afterProcessEpoch()
-  nextEpochActiveValidatorIndices: ValidatorIndex[];
+  nextEpochShufflingActiveValidatorIndices: ValidatorIndex[];
 }
 
 export function beforeProcessEpoch<T extends allForks.BeaconState>(state: CachedBeaconState<T>): IEpochProcess {
@@ -108,7 +108,8 @@ export function beforeProcessEpoch<T extends allForks.BeaconState>(state: Cached
   const forkName = config.getForkName(state.slot);
   const currentEpoch = epochCtx.currentShuffling.epoch;
   const prevEpoch = epochCtx.previousShuffling.epoch;
-  const nextEpoch = currentEpoch + 1;
+  // active validator indices for nextShuffling is ready, we want to precalculate for the one after that
+  const nextShufflingEpoch = currentEpoch + 2;
 
   const slashingsEpoch = currentEpoch + intDiv(EPOCHS_PER_SLASHINGS_VECTOR, 2);
 
@@ -116,7 +117,7 @@ export function beforeProcessEpoch<T extends allForks.BeaconState>(state: Cached
   const indicesEligibleForActivationQueue: ValidatorIndex[] = [];
   const indicesEligibleForActivation: ValidatorIndex[] = [];
   const indicesToEject: ValidatorIndex[] = [];
-  const nextEpochActiveValidatorIndices: ValidatorIndex[] = [];
+  const nextEpochShufflingActiveValidatorIndices: ValidatorIndex[] = [];
 
   const statuses: IAttesterStatus[] = [];
 
@@ -158,8 +159,8 @@ export function beforeProcessEpoch<T extends allForks.BeaconState>(state: Cached
     }
 
     statuses.push(status);
-    if (isActiveValidator(v, nextEpoch)) {
-      nextEpochActiveValidatorIndices.push(i);
+    if (isActiveValidator(v, nextShufflingEpoch)) {
+      nextEpochShufflingActiveValidatorIndices.push(i);
     }
   });
 
@@ -261,7 +262,7 @@ export function beforeProcessEpoch<T extends allForks.BeaconState>(state: Cached
     indicesEligibleForActivationQueue,
     indicesEligibleForActivation,
     indicesToEject,
-    nextEpochActiveValidatorIndices,
+    nextEpochShufflingActiveValidatorIndices,
 
     statuses,
     validators,


### PR DESCRIPTION
**Motivation**

+ Sync gets stuck on all networks
+ Root cause is we precompute active validator indices of next epoch, we should compute for `nextEpoch + 1`
+ @dapplion For spec tests, we always calculate active validator indices when we create EpochContext while this happens in EpochProcess, that's why we didn't see it in spec tests

**Description**

+ Precompute active validator indices for `nextEpoch + 1` since active indices for `nextEpochShuffling` is always available

Closes #2949

**Test Result**
+ Works fine with `altair-devnet-3`
+ Sync mainnet to slot ~1_000_000
