### PR TITLE
Enable sourceMap option to debug

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,6 +6,7 @@
     "lib": ["es2020", "esnext.bigint", "es2020.string", "es2020.symbol.wellknown"],
 
     "strict": true,
+    "sourceMap": true,
     "alwaysStrict": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
**Motivation**

I was not able to debug on either vscode or Chrome Dev Tools, I could only do that with `lib/**/*.js` files

**Description**

Enable `sourceMap` option helps me do that