### PR TITLE
lodestar/cli: overhaul util/version and gitdata

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,8 +3,10 @@ import yargs from "yargs";
 import {cmds} from "./cmds";
 import {globalOptions} from "./options";
 import {registerCommandToYargs} from "./util";
+import { getVersion } from "./util/version";
 
-const topBanner = "🌟 Lodestar: Ethereum 2.0 TypeScript Implementation of the Beacon Chain";
+const version = getVersion();
+const topBanner = `🌟 Lodestar: Ethereum 2.0 TypeScript Implementation of the Beacon Chain\n Version: ${version}`;
 const bottomBanner = "For more information, check the CLI reference https://chainsafe.github.io/lodestar/reference/cli";
 
 /**

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,8 +6,14 @@ import {registerCommandToYargs} from "./util";
 import { getVersion } from "./util/version";
 
 const version = getVersion();
-const topBanner = `🌟 Lodestar: Ethereum 2.0 TypeScript Implementation of the Beacon Chain\n Version: ${version}`;
-const bottomBanner = "For more information, check the CLI reference https://chainsafe.github.io/lodestar/reference/cli";
+const topBanner = `🌟 Lodestar: TypeScript Implementation of the Ethereum 2.0 Beacon Chain.
+  * Version: ${version}
+  * by ChainSafe Systems, 2018-2021`;
+const bottomBanner = `📖 For more information, check the CLI reference:
+  * https://chainsafe.github.io/lodestar/reference/cli
+
+✍️ Give feedback and report issues on GitHub:
+  * https://github.com/ChainSafe/lodestar`;
 
 /**
  * Common factory for running the CLI and running integration tests
@@ -29,6 +35,7 @@ export function getLodestarCli(): yargs.Argv {
     .showHelpOnFail(false)
     .usage(topBanner)
     .epilogue(bottomBanner)
+    .version(topBanner)
     .alias("h", "help")
     .alias("v", "version")
     .recommendCommands();

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,7 +3,7 @@ import yargs from "yargs";
 import {cmds} from "./cmds";
 import {globalOptions} from "./options";
 import {registerCommandToYargs} from "./util";
-import { getVersion } from "./util/version";
+import {getVersion} from "./util/version";
 
 const version = getVersion();
 const topBanner = `🌟 Lodestar: TypeScript Implementation of the Ethereum 2.0 Beacon Chain.

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -9,15 +9,16 @@ import {createIBeaconConfig} from "@chainsafe/lodestar-config";
 
 import {IGlobalArgs} from "../../options";
 import {parseEnrArgs} from "../../options/enrOptions";
-import {initBLS, onGracefulShutdown, getCliLogger, readLodestarGitData} from "../../util";
+import {initBLS, onGracefulShutdown, getCliLogger} from "../../util";
 import {FileENR, overwriteEnrWithCliArgs, readPeerId} from "../../config";
 import {initializeOptionsAndConfig, persistOptionsAndConfig} from "../init/handler";
 import {IBeaconArgs} from "./options";
 import {getBeaconPaths} from "./paths";
 import {initBeaconState} from "./initBeaconState";
+import { getVersion } from "../../util/version";
 
 /**
- * Run a beacon node
+ * Runs a beacon node.
  */
 export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<void> {
   await initBLS();
@@ -25,12 +26,12 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
   const {beaconNodeOptions, config} = await initializeOptionsAndConfig(args);
   await persistOptionsAndConfig(args, beaconNodeOptions, config);
 
-  const lodestarGitData = readLodestarGitData();
+  const version = getVersion();
   const beaconPaths = getBeaconPaths(args);
   // TODO: Rename db.name to db.path or db.location
   beaconNodeOptions.set({db: {name: beaconPaths.dbDir}});
   // Add metrics metadata to show versioning + network info in Prometheus + Grafana
-  beaconNodeOptions.set({metrics: {metadata: {...lodestarGitData, network: args.network}}});
+  beaconNodeOptions.set({metrics: {metadata: {version, network: args.network}}});
 
   // ENR setup
   const peerId = await readPeerId(beaconPaths.peerIdFile);
@@ -48,7 +49,7 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
     abortController.abort();
   }, logger.info.bind(logger));
 
-  logger.info("Lodestar", {version: lodestarGitData.version, network: args.network});
+  logger.info("Lodestar", {version: version, network: args.network});
 
   let dbMetrics: null | ReturnType<typeof createDbMetrics> = null;
   // additional metrics registries

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -15,7 +15,7 @@ import {initializeOptionsAndConfig, persistOptionsAndConfig} from "../init/handl
 import {IBeaconArgs} from "./options";
 import {getBeaconPaths} from "./paths";
 import {initBeaconState} from "./initBeaconState";
-import { getVersion } from "../../util/version";
+import {getVersion} from "../../util/version";
 
 /**
  * Runs a beacon node.

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -10,7 +10,7 @@ import {getBeaconPaths} from "../beacon/paths";
 import {getValidatorPaths} from "./paths";
 import {IValidatorCliArgs} from "./options";
 import {getSecretKeys} from "./keys";
-import { getVersion } from "../../util/version";
+import {getVersion} from "../../util/version";
 
 /**
  * Runs a validator client.

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -5,14 +5,15 @@ import {LevelDbController} from "@chainsafe/lodestar-db";
 import {getBeaconConfigFromArgs} from "../../config";
 import {IGlobalArgs} from "../../options";
 import {YargsError, getDefaultGraffiti, initBLS, mkdir, getCliLogger} from "../../util";
-import {onGracefulShutdown, readLodestarGitData} from "../../util";
+import {onGracefulShutdown} from "../../util";
 import {getBeaconPaths} from "../beacon/paths";
 import {getValidatorPaths} from "./paths";
 import {IValidatorCliArgs} from "./options";
 import {getSecretKeys} from "./keys";
+import { getVersion } from "../../util/version";
 
 /**
- * Run a validator client
+ * Runs a validator client.
  */
 export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): Promise<void> {
   await initBLS();
@@ -25,8 +26,8 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
 
   const logger = getCliLogger(args, beaconPaths, config);
 
-  const lodestarGitData = readLodestarGitData();
-  logger.info("Lodestar", {version: lodestarGitData.version, network: args.network});
+  const version = getVersion();
+  logger.info("Lodestar", {version: version, network: args.network});
 
   const secretKeys = await getSecretKeys(args);
   if (secretKeys.length === 0) throw new YargsError("No validator keystores found");

--- a/packages/cli/src/util/gitData/gitDataPath.ts
+++ b/packages/cli/src/util/gitData/gitDataPath.ts
@@ -1,3 +1,8 @@
+/**
+ * Persist git data and distribute through NPM so CLI consumers can know exactly
+ * at what commit was this src build. This is used in the metrics and to log initially.
+ */
+
 import path from "path";
 import fs from "fs";
 

--- a/packages/cli/src/util/gitData/gitDataPath.ts
+++ b/packages/cli/src/util/gitData/gitDataPath.ts
@@ -7,24 +7,24 @@ import fs from "fs";
  */
 export const gitDataPath = path.resolve(__dirname, "../../../.git-data.json");
 
-export type GitDataFile = {
-  /** "developer/feature-1" */
+/** Git data type used to construct version information string and persistence. */
+export type GitData = {
+  /** v0.28.2-alpha */
+  semver?: string;
+  /** "developer-feature" */
   branch?: string;
   /** "80c248bb392f512cc115d95059e22239a17bbd7d" */
   commit?: string;
-  /** 0.28.2 */
-  tag?: string;
-  /** 5 (commits since tag) */
-  numCommits?: number;
+  /** +7 (commits since last tag) */
+  numCommits?: string;
 };
 
-/** Writs a persistent git data file. */
-export function writeGitDataFile(gitData: GitDataFile): void {
+/** Writes a persistent git data file. */
+export function writeGitDataFile(gitData: GitData): void {
   fs.writeFileSync(gitDataPath, JSON.stringify(gitData, null, 2));
 }
 
-
 /** Reads the persistent git data file. */
-export function readGitDataFile(): GitDataFile {
-  return JSON.parse(fs.readFileSync(gitDataPath, "utf8")) as GitDataFile;
+export function readGitDataFile(): GitData {
+  return JSON.parse(fs.readFileSync(gitDataPath, "utf8")) as GitData;
 }

--- a/packages/cli/src/util/gitData/gitDataPath.ts
+++ b/packages/cli/src/util/gitData/gitDataPath.ts
@@ -14,7 +14,7 @@ export const gitDataPath = path.resolve(__dirname, "../../../.git-data.json");
 
 /** Git data type used to construct version information string and persistence. */
 export type GitData = {
-  /** v0.28.2-alpha */
+  /** v0.28.2 */
   semver?: string;
   /** "developer-feature" */
   branch?: string;

--- a/packages/cli/src/util/gitData/gitDataPath.ts
+++ b/packages/cli/src/util/gitData/gitDataPath.ts
@@ -1,8 +1,5 @@
-import fs from "fs";
 import path from "path";
-
-// Persist git data and distribute through NPM so CLI consumers can know exactly
-// at what commit was this src build. This is used in the metrics and to log initially
+import fs from "fs";
 
 /**
  * WARNING!! If you change this path make sure to update:
@@ -13,14 +10,17 @@ export const gitDataPath = path.resolve(__dirname, "../../../.git-data.json");
 export type GitDataFile = {
   /** "developer/feature-1" */
   branch?: string;
-  /** "4f816b16dfde718e2d74f95f2c8292596138c248" */
+  /** "80c248bb392f512cc115d95059e22239a17bbd7d" */
   commit?: string;
 };
 
-export function readGitDataFile(): GitDataFile {
-  return JSON.parse(fs.readFileSync(gitDataPath, "utf8")) as GitDataFile;
-}
-
+/** Writs a persistent git data file. */
 export function writeGitDataFile(gitData: GitDataFile): void {
   fs.writeFileSync(gitDataPath, JSON.stringify(gitData, null, 2));
+}
+
+
+/** Reads the persistent git data file. */
+export function readGitDataFile(): GitDataFile {
+  return JSON.parse(fs.readFileSync(gitDataPath, "utf8")) as GitDataFile;
 }

--- a/packages/cli/src/util/gitData/gitDataPath.ts
+++ b/packages/cli/src/util/gitData/gitDataPath.ts
@@ -12,6 +12,10 @@ export type GitDataFile = {
   branch?: string;
   /** "80c248bb392f512cc115d95059e22239a17bbd7d" */
   commit?: string;
+  /** 0.28.2 */
+  tag?: string;
+  /** 5 (commits since tag) */
+  numCommits?: number;
 };
 
 /** Writs a persistent git data file. */

--- a/packages/cli/src/util/gitData/index.ts
+++ b/packages/cli/src/util/gitData/index.ts
@@ -1,19 +1,19 @@
 import {execSync} from "child_process";
-import {getLocalVersion} from "../version";
 
-// This file is created in the build step and is distributed through NPM
-// MUST be in sync with packages/cli/src/gitData/gitDataPath.ts, and package.json .files
-import {GitDataFile, readGitDataFile} from "./gitDataPath";
+/** 
+ * Persist git data and distribute through NPM so CLI consumers can know exactly
+ * at what commit was this src build. This is used in the metrics and to log initially.
+ */
 
 /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
 type GitData = {
-  /** "0.16.0" */
+  /** "0.28.2-alpha" */
   semver: string;
   /** "developer/feature-1" */
   branch: string;
-  /** "4f816b16dfde718e2d74f95f2c8292596138c248" */
+  /** "80c248bb392f512cc115d95059e22239a17bbd7d" */
   commit: string;
-  /** "0.16.0 developer/feature-1 ac99f2b5" */
+  /** "0.28.2-alpha+7(80c248bb)" */
   version: string;
 };
 
@@ -24,6 +24,7 @@ function shell(cmd: string): string {
     .trim();
 }
 
+/** Tries to get branch from git. */
 function getBranch(): string | undefined {
   try {
     return shell("git rev-parse --abbrev-ref HEAD");
@@ -32,6 +33,7 @@ function getBranch(): string | undefined {
   }
 }
 
+/** Tries to get commit from git. */
 function getCommit(): string | undefined {
   try {
     return shell("git rev-parse --verify HEAD");
@@ -40,43 +42,10 @@ function getCommit(): string | undefined {
   }
 }
 
+/** Gets git data containing current branch and commit. */
 export function getGitData(): Partial<Pick<GitData, "branch" | "commit">> {
   return {
     branch: getBranch(),
     commit: getCommit(),
   };
-}
-
-/**
- * Reads git data from a persisted file at build time + the current version in the package.json
- */
-export function readLodestarGitData(): GitData {
-  try {
-    const semver = getLocalVersion() ?? undefined;
-    const currentGitData = getGitData();
-    const persistedGitData = getPersistedGitData();
-    // If the CLI is run from source, prioritze current git data over .git-data.json file, which might be stale
-    const gitData = {...persistedGitData, ...currentGitData};
-
-    return {
-      semver: semver || "-",
-      branch: gitData?.branch || "-",
-      commit: gitData?.commit || "-",
-      version: formatVersion({...gitData, semver}),
-    };
-  } catch (e) {
-    return {semver: "", branch: "", commit: "", version: e.message};
-  }
-}
-
-function formatVersion({semver, branch, commit}: Partial<GitData>): string {
-  return [semver, branch, commit && commit.slice(0, 8)].filter((s) => s).join(" ");
-}
-
-function getPersistedGitData(): Partial<GitDataFile> {
-  try {
-    return readGitDataFile();
-  } catch (e) {
-    return {};
-  }
 }

--- a/packages/cli/src/util/gitData/index.ts
+++ b/packages/cli/src/util/gitData/index.ts
@@ -63,11 +63,6 @@ function getCommitsSinceRelease(): number | undefined {
   return numCommits;
 }
 
-/** Assumes release on tag commit. */
-function isRelease(): boolean {
-  return getCommitsSinceRelease() === 0;
-}
-
 /** Gets git data containing current branch and commit. */
 export function getGitData(): Partial<Pick<GitData, "branch" | "commit">> {
   return {

--- a/packages/cli/src/util/gitData/index.ts
+++ b/packages/cli/src/util/gitData/index.ts
@@ -57,9 +57,15 @@ export function readLodestarGitData(): GitData {
   try {
     const currentGitData = getGitData();
     const persistedGitData = getPersistedGitData();
+
     // If the CLI is run from source, prioritze current git data
     // over `.git-data.json` file, which might be stale here.
-    const gitData = {...persistedGitData, ...currentGitData};
+    let gitData = {...persistedGitData, ...currentGitData};
+
+    // If the CLI is not run from the git repository, fall back to persistent
+    if (!gitData.semver || !gitData.branch || !gitData.commit) {
+      gitData = persistedGitData;
+    }
 
     return {
       semver: gitData?.semver || "N/A",

--- a/packages/cli/src/util/gitData/index.ts
+++ b/packages/cli/src/util/gitData/index.ts
@@ -4,7 +4,7 @@ import {execSync} from "child_process";
  * This file is created in the build step and is distributed through NPM
  * MUST be in sync with `-/gitDataPath.ts` and `package.json` files.
  */
-import { readGitDataFile, GitData } from "./gitDataPath";
+import {readGitDataFile, GitData} from "./gitDataPath";
 
 /** Silent shell that won't pollute stdout, or stderr */
 function shell(cmd: string): string {
@@ -42,7 +42,7 @@ function getLatestTag(): string | undefined {
 
 /** Gets number of commits since latest tag/release. */
 function getCommitsSinceRelease(): number | undefined {
-  let numCommits: number = 0;
+  let numCommits = 0;
   const latestTag: string | undefined = getLatestTag();
   try {
     numCommits = +shell(`git rev-list ${latestTag}..HEAD --count`);
@@ -58,7 +58,7 @@ export function readLodestarGitData(): GitData {
     const currentGitData = getGitData();
     const persistedGitData = getPersistedGitData();
     // If the CLI is run from source, prioritze current git data 
-    // over .git-data.json file, which might be stale here.
+    // over `.git-data.json` file, which might be stale here.
     const gitData = {...persistedGitData, ...currentGitData};
 
     return {
@@ -73,14 +73,14 @@ export function readLodestarGitData(): GitData {
 }
 
 /** Wrapper for updating git data. ONLY to be used with build scripts! */
-export function _forceUpdateGitData(): Partial<GitData> {
+export function forceUpdateGitData(): Partial<GitData> {
   return getGitData();
 }
 
 /** Gets git data containing current branch and commit info from CLI. */
 function getGitData(): Partial<GitData> {
   const numCommits: number | undefined = getCommitsSinceRelease();
-  let strCommits: string = "";
+  let strCommits = "";
   if (numCommits && numCommits > 0) {
     strCommits = `+${numCommits}`;
   }

--- a/packages/cli/src/util/gitData/index.ts
+++ b/packages/cli/src/util/gitData/index.ts
@@ -1,11 +1,10 @@
 import {execSync} from "child_process";
-import { readGitDataFile, GitData } from "./gitDataPath";
 
 /**
- * Persist git data and distribute through NPM so CLI consumers can know exactly
- * at what commit was this source build. This is also used in the metrics and to log initially.
+ * This file is created in the build step and is distributed through NPM
+ * MUST be in sync with `-/gitDataPath.ts` and `package.json` files.
  */
-
+import { readGitDataFile, GitData } from "./gitDataPath";
 
 /** Silent shell that won't pollute stdout, or stderr */
 function shell(cmd: string): string {

--- a/packages/cli/src/util/gitData/index.ts
+++ b/packages/cli/src/util/gitData/index.ts
@@ -57,18 +57,18 @@ export function readLodestarGitData(): GitData {
   try {
     const currentGitData = getGitData();
     const persistedGitData = getPersistedGitData();
-    // If the CLI is run from source, prioritze current git data 
+    // If the CLI is run from source, prioritze current git data
     // over `.git-data.json` file, which might be stale here.
     const gitData = {...persistedGitData, ...currentGitData};
 
     return {
-      semver: gitData?.semver || "-",
-      branch: gitData?.branch || "-",
-      commit: gitData?.commit || "-",
+      semver: gitData?.semver || "N/A",
+      branch: gitData?.branch || "N/A",
+      commit: gitData?.commit || "N/A",
       numCommits: gitData?.numCommits || "",
     };
   } catch (e) {
-    return {semver: e.message, branch: "", commit: "", numCommits: ""};
+    return {semver: "", branch: "", commit: "", numCommits: ""};
   }
 }
 

--- a/packages/cli/src/util/gitData/index.ts
+++ b/packages/cli/src/util/gitData/index.ts
@@ -1,6 +1,6 @@
 import {execSync} from "child_process";
 
-/** 
+/**
  * Persist git data and distribute through NPM so CLI consumers can know exactly
  * at what commit was this src build. This is used in the metrics and to log initially.
  */
@@ -40,6 +40,32 @@ function getCommit(): string | undefined {
   } catch (e) {
     return undefined;
   }
+}
+
+/** Tries to get the latest tag. */
+function getLatestTag(): string | undefined {
+  try {
+    return shell("git describe --abbrev=0");
+  } catch (e) {
+    return undefined;
+  }
+}
+
+/** Gets number of commits since latest tag/release. */
+function getCommitsSinceRelease(): number | undefined {
+  let numCommits = 0;
+  let latestTag = getLatestTag();
+  try {
+    numCommits = +shell(`git rev-list ${latestTag}..HEAD --count`);
+  } catch (e) {
+    return undefined;
+  }
+  return numCommits;
+}
+
+/** Assumes release on tag commit. */
+function isRelease(): boolean {
+  return getCommitsSinceRelease() === 0;
 }
 
 /** Gets git data containing current branch and commit. */

--- a/packages/cli/src/util/gitData/writeGitData.ts
+++ b/packages/cli/src/util/gitData/writeGitData.ts
@@ -3,7 +3,5 @@
 import {writeGitDataFile} from "./gitDataPath";
 import {getGitData} from "./index";
 
-// Persist git data and distribute through NPM so CLI consumers can know exactly
-// at what commit was this src build. This is used in the metrics and to log initially
-
+/** Script to write the git data file (json) used by the build procedures to persist git data. */
 writeGitDataFile(getGitData());

--- a/packages/cli/src/util/gitData/writeGitData.ts
+++ b/packages/cli/src/util/gitData/writeGitData.ts
@@ -6,7 +6,7 @@
  */
 
 import {writeGitDataFile} from "./gitDataPath";
-import {_forceUpdateGitData} from "./index";
+import {forceUpdateGitData} from "./index";
 
 /** Script to write the git data file (json) used by the build procedures to persist git data. */
-writeGitDataFile(_forceUpdateGitData());
+writeGitDataFile(forceUpdateGitData());

--- a/packages/cli/src/util/gitData/writeGitData.ts
+++ b/packages/cli/src/util/gitData/writeGitData.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 
+/**
+ * Persist git data and distribute through NPM so CLI consumers can know exactly
+ * at what commit was this source build. This is also used in the metrics and to log initially.
+ */
+
 import {writeGitDataFile} from "./gitDataPath";
 import {_forceUpdateGitData} from "./index";
 

--- a/packages/cli/src/util/gitData/writeGitData.ts
+++ b/packages/cli/src/util/gitData/writeGitData.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import {writeGitDataFile} from "./gitDataPath";
-import {getGitData} from "./index";
+import {_forceUpdateGitData} from "./index";
 
 /** Script to write the git data file (json) used by the build procedures to persist git data. */
-writeGitDataFile(getGitData());
+writeGitDataFile(_forceUpdateGitData());

--- a/packages/cli/src/util/graffiti.ts
+++ b/packages/cli/src/util/graffiti.ts
@@ -1,14 +1,15 @@
-import {getLocalVersion} from "./version";
+import {getVersion} from "./version";
 
-const lodestarPackageName = "chainsafe/lodestar";
+const lodestarPackageName = "ChainSafe/Lodestar";
 
 /**
- * Computes a default graffiti fetching dynamically the package info
+ * Computes a default graffiti fetching dynamically the package info.
+ * @returns a string containing package name and version.
  */
 export function getDefaultGraffiti(): string {
   try {
-    const version = getLocalVersion();
-    return version ? `${lodestarPackageName}-${version}` : lodestarPackageName;
+    const version = getVersion();
+    return `${lodestarPackageName}-${version}`;
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error("Error guessing lodestar version", e);

--- a/packages/cli/src/util/version.ts
+++ b/packages/cli/src/util/version.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import findUp from "find-up";
-import { readLodestarGitData } from "./gitData";
-import { GitData } from "./gitData/gitDataPath";
+import {readLodestarGitData} from "./gitData";
+import {GitData} from "./gitData/gitDataPath";
 
 type VersionJson = {
   /** "0.28.2-alpha" */

--- a/packages/cli/src/util/version.ts
+++ b/packages/cli/src/util/version.ts
@@ -4,13 +4,26 @@ import {readLodestarGitData} from "./gitData";
 import {GitData} from "./gitData/gitDataPath";
 
 type VersionJson = {
-  /** "0.28.2-alpha" */
+  /** "0.28.2" */
   version: string;
 };
 
+enum ReleaseTrack {
+  unstable = "unstable",
+  nightly = "nightly",
+  alpha = "alpha",
+  beta = "beta",
+  rc = "release candidate",
+  stable = "stable",
+  lts = "long term support",
+}
+
+/** Defines default release track, i.e., the "stability" of tag releases */
+const defaultReleaseTrack = ReleaseTrack.alpha;
+
 /**
  * Gathers all information on package version including Git data.
- * @returns a version string, e.g., `v0.28.2-alpha/developer-feature/+7(80c248bb)`
+ * @returns a version string, e.g., `v0.28.2/developer-feature/+7/80c248bb (nightly)`
  */
 export function getVersion(): string {
   const gitData: GitData = readLodestarGitData();
@@ -25,14 +38,14 @@ export function getVersion(): string {
 
   // If these values are empty/undefined, we assume tag release.
   if (!commitSlice || !numCommits || numCommits === "") {
-    return `${semver}`;
+    return `${semver} (${defaultReleaseTrack})`;
   }
 
   // Otherwise get branch and commit information
-  return `${semver}/${gitData.branch}/${numCommits}(${commitSlice})`;
+  return `${semver}/${gitData.branch}/${numCommits}/${commitSlice} (${ReleaseTrack.unstable})`;
 }
 
-/** Returns local version from `lerna.json` or `package.json` as `"0.28.2-alpha"` */
+/** Returns local version from `lerna.json` or `package.json` as `"0.28.2"` */
 function getLocalVersion(): string | undefined {
   return readVersionFromLernaJson() || readCliPackageJson();
 }

--- a/packages/cli/src/util/version.ts
+++ b/packages/cli/src/util/version.ts
@@ -9,7 +9,8 @@ type VersionJson = {
 };
 
 enum ReleaseTrack {
-  unstable = "unstable",
+  git = "git",
+  npm = "npm",
   nightly = "nightly",
   alpha = "alpha",
   beta = "beta",
@@ -27,13 +28,13 @@ const defaultReleaseTrack = ReleaseTrack.alpha;
  */
 export function getVersion(): string {
   const gitData: GitData = readLodestarGitData();
-  let semver: string | undefined = gitData.semver;
+  const semver: string | undefined = gitData.semver;
   const numCommits: string | undefined = gitData.numCommits;
   const commitSlice: string | undefined = gitData.commit?.slice(0, 8);
 
-  // Fall back to local version if git is unavailable
-  if (!semver) {
-    semver = `v${getLocalVersion()}`;
+  // Fall back to/assume local package version if git is unavailable
+  if (!semver || semver.includes("N/A")) {
+    return `v${getLocalVersion()} (${ReleaseTrack.npm})`;
   }
 
   // If these values are empty/undefined, we assume tag release.
@@ -42,7 +43,7 @@ export function getVersion(): string {
   }
 
   // Otherwise get branch and commit information
-  return `${semver}/${gitData.branch}/${numCommits}/${commitSlice} (${ReleaseTrack.unstable})`;
+  return `${semver}/${gitData.branch}/${numCommits}/${commitSlice} (${ReleaseTrack.git})`;
 }
 
 /** Returns local version from `lerna.json` or `package.json` as `"0.28.2"` */

--- a/packages/cli/src/util/version.ts
+++ b/packages/cli/src/util/version.ts
@@ -1,28 +1,80 @@
 import fs from "fs";
 import findUp from "find-up";
+import { getCommitsSinceRelease, getLatestTag, getGitData } from "./gitData";
 
 type LernaJson = {
-  /** "0.18.0" */
+  /** "0.28.2-alpha" */
   version: string;
 };
 
-/** Returns local version from `lerna.json` as `"0.18.0"` */
-export function getLocalVersion(): string | null {
+/**
+ * Gathers all information on package version including Git data.
+ * @returns a version string, e.g., "0.28.2-alpha+7(80c248bb)"
+ */
+export function getVersion(): string {
+  let semver = getLatestTag();
+  let numCommits = getCommitsSinceRelease();
+
+  // Fall back to local version if git is unavailable
+  if (semver === undefined) {
+    semver = getLocalVersion();
+  }
+
+  if (numCommits === 0) {
+    return `${semver}`;
+  }
+
+  let gitData = getGitData();
+  let commit = gitData.commit?.slice(0, 8);
+  return `${semver}/${gitData.branch}+${numCommits}(${commit})`;
+}
+
+/** Returns local version from `lerna.json` or `package.json` as `"0.28.2-alpha"` */
+function getLocalVersion(): string | undefined {
   return readVersionFromLernaJson() || readCliPackageJson();
 }
 
-function readVersionFromLernaJson(): string | null {
+function readVersionFromLernaJson(): string | undefined {
   const filePath = findUp.sync("lerna.json");
-  if (!filePath) return null;
+  if (!filePath) return undefined;
 
   const lernaJson = JSON.parse(fs.readFileSync(filePath, "utf8")) as LernaJson;
   return lernaJson.version;
 }
 
-function readCliPackageJson(): string | null {
+function readCliPackageJson(): string | undefined {
   const filePath = findUp.sync("package.json", {cwd: __dirname});
-  if (!filePath) return null;
+  if (!filePath) return undefined;
 
   const packageJson = JSON.parse(fs.readFileSync(filePath, "utf8")) as LernaJson;
   return packageJson.version;
 }
+
+
+// // This file is created in the build step and is distributed through NPM
+// // MUST be in sync with packages/cli/src/gitData/gitDataPath.ts, and package.json .files
+// import {GitDataFile, readGitDataFile} from "./gitDataPath";
+
+// @TODO @q9f - read git data from file instead of exposing git everywhere
+
+// /**
+//  * Reads git data from a persisted file at build time + the current version in the package.json
+//  */
+// export function readLodestarGitData(): GitData {
+//   try {
+//     const semver = getLocalVersion() ?? undefined;
+//     const currentGitData = getGitData();
+//     const persistedGitData = getPersistedGitData();
+//     // If the CLI is run from source, prioritze current git data over .git-data.json file, which might be stale
+//     const gitData = {...persistedGitData, ...currentGitData};
+
+//     return {
+//       semver: semver || "-",
+//       branch: gitData?.branch || "-",
+//       commit: gitData?.commit || "-",
+//       version: formatVersion({...gitData, semver}),
+//     };
+//   } catch (e) {
+//     return {semver: "", branch: "", commit: "", version: e.message};
+//   }
+// }

--- a/packages/cli/src/util/version.ts
+++ b/packages/cli/src/util/version.ts
@@ -33,7 +33,7 @@ export function getVersion(): string {
 
   // Fall back to local version if git is unavailable
   if (!semver) {
-    semver = getLocalVersion();
+    semver = `v${getLocalVersion()}`;
   }
 
   // If these values are empty/undefined, we assume tag release.


### PR DESCRIPTION
**Motivation**

Allow for more information in the version string; also clean up util/version and gitdata and reduce duplicated code.

**Description**

* Refactored git data file code and removed some duplicated structures and unused code.
* `util/gitData/*` no longer generates version strings, it just handles all version information (semver, branch, commit, ...)
* `util/version` now generates a proper version string from available data (either from json or from git)
    * example: `v0.28.1/q9-yarn-semver/+14/b0616bfd (unstable)` (semver/branch/number of commits since last release/commit hash/release track if any)
* `util/version` now defines a default release track _(stability)_, for now: `alpha`
* `cli/cli` improved top banner of the `--help` output and also used same information for `--version`

```
~/.opt/chainsafe/lodestar q9-yarn-semver
❯ ./lodestar --version
🌟 Lodestar: TypeScript Implementation of the Ethereum 2.0 Beacon Chain.
  * Version: v0.28.1/q9-yarn-semver/+14/b0616bfd (unstable)
  * by ChainSafe Systems, 2018-2021

~/.opt/chainsafe/lodestar q9-yarn-semver
❯ ./lodestar --help   
🌟 Lodestar: TypeScript Implementation of the Ethereum 2.0 Beacon Chain.
  * Version: v0.28.1/q9-yarn-semver/+14/b0616bfd (unstable)
  * by ChainSafe Systems, 2018-2021

Commands:
  beacon             Run a beacon chain node
  validator          Run one or multiple validator clients
  account <command>  Utilities for generating and managing Ethereum 2.0 accounts
  init               Initialize Lodestar directories and files necessary to run
                     a beacon chain node. This step is not required, and should
                     only be used to prepare special configurations
  dev                Quickly bootstrap a beacon node and multiple validators.
                     Use for development and testing

Options:
      --rootDir     Lodestar root directory                             [string]
      --network     Name of the Eth2 chain network to join
           [string] [choices: "mainnet", "pyrmont", "prater", "altair-devnet-3"]
                                                            [default: "mainnet"]
      --preset      Specifies the default eth2 spec type
                   [string] [choices: "mainnet", "minimal"] [default: "mainnet"]
      --paramsFile  Network configuration file
                                        [string] [default: $rootDir/config.yaml]
  -h, --help        Show help                                          [boolean]
  -v, --version     Show version number                                [boolean]

📖 For more information, check the CLI reference:
  * https://chainsafe.github.io/lodestar/reference/cli

✍️ Give feedback and report issues on GitHub:
  * https://github.com/ChainSafe/lodestar
```

The code also handles the logic of releases and dirty/nightly builds. A release version string is simply `v0.28.1 (alpha)` whereas dirty builds have all info `v0.28.1/q9-yarn-semver/+14/b0616bfd (unstable)`. If git data is not available, it will fall back to lerna.json/package.json and just use `0.28.1`.

This is my first typescript contribution. Review with care. 🙏🏼 

Fixes #2950 