### PR TITLE
Limit # of gindices allowed in proofs

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/api.ts
+++ b/packages/cli/src/options/beaconNodeOptions/api.ts
@@ -4,6 +4,7 @@ import {ICliCommandOptions} from "../../util";
 const enabledAll = "*";
 
 export interface IApiArgs {
+  "api.maxGindicesInProof": number;
   "api.rest.api": string[];
   "api.rest.cors": string;
   "api.rest.enabled": boolean;
@@ -13,6 +14,7 @@ export interface IApiArgs {
 
 export function parseArgs(args: IApiArgs): IBeaconNodeOptions["api"] {
   return {
+    maxGindicesInProof: args["api.maxGindicesInProof"],
     rest: {
       api: args["api.rest.api"] as IBeaconNodeOptions["api"]["rest"]["api"],
       cors: args["api.rest.cors"],
@@ -24,6 +26,14 @@ export function parseArgs(args: IApiArgs): IBeaconNodeOptions["api"] {
 }
 
 export const options: ICliCommandOptions<IApiArgs> = {
+  "api.maxGindicesInProof": {
+    hidden: true,
+    type: "number",
+    description: "Limit max number of gindices in a single proof request. DoS vector protection",
+    defaultDescription: String(defaultOptions.api.maxGindicesInProof),
+    group: "api",
+  },
+
   "api.rest.api": {
     type: "array",
     choices: [...allNamespaces, enabledAll],

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -7,6 +7,7 @@ describe("options / beaconNodeOptions", () => {
   it("Should parse BeaconNodeArgs", () => {
     // Cast to match the expected fully defined type
     const beaconNodeArgsPartial = {
+      "api.maxGindicesInProof": 1000,
       "api.rest.api": [],
       "api.rest.cors": "*",
       "api.rest.enabled": true,
@@ -45,6 +46,7 @@ describe("options / beaconNodeOptions", () => {
 
     const expectedOptions: RecursivePartial<IBeaconNodeOptions> = {
       api: {
+        maxGindicesInProof: 1000,
         rest: {
           api: [],
           cors: "*",

--- a/packages/lodestar/src/api/impl/api.ts
+++ b/packages/lodestar/src/api/impl/api.ts
@@ -1,4 +1,5 @@
 import {Api} from "@chainsafe/lodestar-api";
+import {IApiOptions} from "../options";
 import {ApiModules} from "./types";
 import {getBeaconApi} from "./beacon";
 import {getConfigApi} from "./config";
@@ -9,13 +10,13 @@ import {getLodestarApi} from "./lodestar";
 import {getNodeApi} from "./node";
 import {getValidatorApi} from "./validator";
 
-export function getApi(modules: ApiModules): Api {
+export function getApi(opts: IApiOptions, modules: ApiModules): Api {
   return {
     beacon: getBeaconApi(modules),
     config: getConfigApi(modules),
     debug: getDebugApi(modules),
     events: getEventsApi(modules),
-    lightclient: getLightclientApi(modules),
+    lightclient: getLightclientApi(opts, modules),
     lodestar: getLodestarApi(modules),
     node: getNodeApi(modules),
     validator: getValidatorApi(modules),

--- a/packages/lodestar/src/api/impl/lightclient/index.ts
+++ b/packages/lodestar/src/api/impl/lightclient/index.ts
@@ -4,8 +4,12 @@ import {resolveStateId} from "../beacon/state/utils";
 import {routes} from "@chainsafe/lodestar-api";
 import {ApiError} from "../errors";
 import {linspace} from "../../../util/numpy";
+import {isCompositeType} from "@chainsafe/ssz";
+import {ProofType} from "@chainsafe/persistent-merkle-tree";
 
 // TODO: Import from lightclient/server package
+
+const MAX_GINDICES_IN_PROOF = 512;
 
 export function getLightclientApi({
   chain,
@@ -18,7 +22,32 @@ export function getLightclientApi({
     async getStateProof(stateId, paths) {
       const state = await resolveStateId(config, chain, db, stateId);
       const stateTreeBacked = ssz.altair.BeaconState.createTreeBackedFromStruct(state as altair.BeaconState);
-      return {data: stateTreeBacked.createProof(paths)};
+      const tree = stateTreeBacked.tree;
+      // Logic from TreeBacked#createProof is (mostly) copied here to expose the # of gindices in the proof
+      let gindices = paths
+        .map((path) => {
+          const {type, gindex} = ssz.altair.BeaconState.getPathInfo(path);
+          if (!isCompositeType(type)) {
+            return gindex;
+          } else {
+            // if the path subtype is composite, include the gindices of all the leaves
+            return type.tree_getLeafGindices(
+              type.hasVariableSerializedLength() ? tree.getSubtree(gindex) : undefined,
+              gindex
+            );
+          }
+        })
+        .flat(1);
+      gindices = Array.from(new Set(gindices));
+      if (gindices.length > MAX_GINDICES_IN_PROOF) {
+        throw new Error("Requested proof is too large.");
+      }
+      return {
+        data: tree.getProof({
+          type: ProofType.treeOffset,
+          gindices,
+        }),
+      };
     },
 
     // Sync API

--- a/packages/lodestar/src/api/options.ts
+++ b/packages/lodestar/src/api/options.ts
@@ -1,9 +1,11 @@
 import {restApiOptionsDefault, RestApiOptions} from "./rest";
 
 export interface IApiOptions {
+  maxGindicesInProof?: number;
   rest: RestApiOptions;
 }
 
 export const defaultApiOptions: IApiOptions = {
+  maxGindicesInProof: 512,
   rest: restApiOptionsDefault,
 };

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -165,7 +165,7 @@ export class BeaconNode {
       logger: logger.child(opts.logger.chores),
     });
 
-    const api = getApi({
+    const api = getApi(opts.api, {
       config,
       logger: logger.child(opts.logger.api),
       db,


### PR DESCRIPTION
**Motivation**

It's currently possible to request gigantic proofs (eg: a proof of the entire beacon state)
We want some some sort of resistance against this DoS vector.

**Description**

Add a `MAX_GINDICES_PER_PROOF` constant and throw an error if proofs will contain more than the max # of gindices.
In order to apply this logic, some ssz logic was mostly copy/pasted to expose the gindex calculations.