### PR TITLE
rcconfig option for any cmd

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,7 +1,7 @@
 // Must not use `* as yargs`, see https://github.com/yargs/yargs/issues/1131
 import yargs from "yargs";
 import {cmds} from "./cmds";
-import {globalOptions} from "./options";
+import {globalOptions, rcConfigOption} from "./options";
 import {registerCommandToYargs} from "./util";
 
 const topBanner = "🌟 Lodestar: Ethereum 2.0 TypeScript Implementation of the Beacon Chain";
@@ -38,6 +38,7 @@ export function getLodestarCli(): yargs.Argv {
 
   // throw an error if we see an unrecognized cmd
   lodestar.recommendCommands().strict();
+  lodestar.config(...rcConfigOption);
 
   return lodestar;
 }

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -1,7 +1,7 @@
 import {defaultGlobalPaths} from "../paths/global";
 import {paramsOptions, IParamsArgs} from "./paramsOptions";
 import {NetworkName, networkNames} from "../networks";
-import {ICliCommandOptions} from "../util";
+import {ICliCommandOptions, readFile} from "../util";
 
 interface IGlobalSingleArgs {
   rootDir: string;
@@ -38,6 +38,12 @@ const globalSingleOptions: ICliCommandOptions<IGlobalSingleArgs> = {
     type: "string",
   },
 };
+
+export const rcConfigOption: [string, string, (configPath: string) => Record<string, unknown>] = [
+  "rcConfig",
+  "RC file to supplement command line args, accepted formats: .yml, .yaml, .json",
+  (configPath: string): Record<string, unknown> => readFile(configPath, ["json", "yml", "yaml"]),
+];
 
 export type IGlobalArgs = IGlobalSingleArgs & IParamsArgs;
 

--- a/packages/cli/src/util/file.ts
+++ b/packages/cli/src/util/file.ts
@@ -82,9 +82,11 @@ export function writeFile(filepath: string, obj: Json): void {
  * Read a JSON serializable object from a file
  *
  * Parse either from json, yaml, or toml
+ * Optional acceptedFormats object can be passed which can be an array of accepted formats, in future can be extended to include parseFn for the accepted formats
  */
-export function readFile<T = Json>(filepath: string): T {
+export function readFile<T = Json>(filepath: string, acceptedFormats?: Json[]): T {
   const fileFormat = path.extname(filepath).substr(1);
+  if (acceptedFormats && !acceptedFormats.includes(fileFormat)) throw new Error(`UnsupportedFileFormat: ${filepath}`);
   const contents = fs.readFileSync(filepath, "utf-8");
   return parse(contents, fileFormat as FileFormat);
 }
@@ -93,9 +95,9 @@ export function readFile<T = Json>(filepath: string): T {
  * @see readFile
  * If `filepath` does not exist returns null
  */
-export function readFileIfExists<T = Json>(filepath: string): T | null {
+export function readFileIfExists<T = Json>(filepath: string, acceptedFormats?: Json[]): T | null {
   try {
-    return readFile(filepath);
+    return readFile(filepath, acceptedFormats);
   } catch (e) {
     if ((e as {code: string}).code === "ENOENT") {
       return null;


### PR DESCRIPTION
**Motivation**

<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR enables supplementing any cli arguments with additional options by providing a corresponding `--rcConfig` file to the lodestar cli in jso, tnl or yaml format.
 


**Description**

here is how it looks in the cli help:
![image](https://user-images.githubusercontent.com/76567250/129449424-15fd76b7-18fe-4faa-8a58-ffc566ffc737.png)

config example for beacon (yml):
![image](https://user-images.githubusercontent.com/76567250/129448130-b8af59d2-0c6a-4f05-8fc8-83146b826dad.png)

config example for validator (yml): 
![image](https://user-images.githubusercontent.com/76567250/129448078-36637818-1511-4fae-80d6-da1fe064636e.png)

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #2814

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
