### PR TITLE
More detail for state root mismatch error

### DIFF
--- a/packages/beacon-state-transition/src/allForks/stateTransition.ts
+++ b/packages/beacon-state-transition/src/allForks/stateTransition.ts
@@ -65,7 +65,7 @@ export function stateTransition(
   if (verifyStateRoot) {
     if (!ssz.Root.equals(block.stateRoot, postState.tree.root)) {
       throw new Error(
-        `Invalid state root at slot ${block.slot}, wanted ${toHexString(block.stateRoot)}, got ${toHexString(
+        `Invalid state root at slot ${block.slot}, expected=${toHexString(block.stateRoot)}, actual=${toHexString(
           postState.tree.root
         )}`
       );

--- a/packages/beacon-state-transition/src/allForks/stateTransition.ts
+++ b/packages/beacon-state-transition/src/allForks/stateTransition.ts
@@ -8,6 +8,7 @@ import {verifyProposerSignature} from "./signatureSets";
 import {beforeProcessEpoch, CachedBeaconState, IEpochProcess, afterProcessEpoch} from "./util";
 import {processSlot} from "./slot";
 import {computeEpochAtSlot} from "../util";
+import {toHexString} from "@chainsafe/ssz";
 
 type StateAllForks = CachedBeaconState<allForks.BeaconState>;
 type StatePhase0 = CachedBeaconState<phase0Types.BeaconState>;
@@ -63,7 +64,11 @@ export function stateTransition(
   // Verify state root
   if (verifyStateRoot) {
     if (!ssz.Root.equals(block.stateRoot, postState.tree.root)) {
-      throw new Error("Invalid state root");
+      throw new Error(
+        `Invalid state root at slot ${block.slot}, wanted ${toHexString(block.stateRoot)}, got ${toHexString(
+          postState.tree.root
+        )}`
+      );
     }
   }
 


### PR DESCRIPTION
**Motivation**

We want to log more detail for state root mismatch error

**Description**

It's a confirmation that we have same state root to lighthouse/teku:
```
error={"message":"Invalid state root at slot 17216, wanted 0x81cd08439bc1d5dc1014bd3ece8627bd93a6aa59304ad8273793625f7759d9fc, got 0xba91b30d27f8090822d37eb04d8582adca2da3f55cbbfb8dd99600aaa7a20a26"}
```

part of #2960 
