### PR TITLE
Call state.slot once per function

### DIFF
--- a/packages/beacon-state-transition/src/allForks/slot/index.ts
+++ b/packages/beacon-state-transition/src/allForks/slot/index.ts
@@ -8,11 +8,12 @@ import {ZERO_HASH} from "../../constants";
  */
 export function processSlot(state: CachedBeaconState<allForks.BeaconState>): void {
   const {config} = state;
-  const types = config.getForkTypes(state.slot);
+  const stateSlot = state.slot;
+  const types = config.getForkTypes(stateSlot);
 
   // Cache state root
   const previousStateRoot = types.BeaconState.hashTreeRoot(state);
-  state.stateRoots[state.slot % SLOTS_PER_HISTORICAL_ROOT] = previousStateRoot;
+  state.stateRoots[stateSlot % SLOTS_PER_HISTORICAL_ROOT] = previousStateRoot;
 
   // Cache latest block header state root
   if (ssz.Root.equals(state.latestBlockHeader.stateRoot, ZERO_HASH)) {
@@ -21,5 +22,5 @@ export function processSlot(state: CachedBeaconState<allForks.BeaconState>): voi
 
   // Cache block root
   const previousBlockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(state.latestBlockHeader);
-  state.blockRoots[state.slot % SLOTS_PER_HISTORICAL_ROOT] = previousBlockRoot;
+  state.blockRoots[stateSlot % SLOTS_PER_HISTORICAL_ROOT] = previousBlockRoot;
 }

--- a/packages/beacon-state-transition/src/altair/block/processAttestation.ts
+++ b/packages/beacon-state-transition/src/altair/block/processAttestation.ts
@@ -49,10 +49,11 @@ export function processAttestation(
   ) {
     throw new Error("Attestation is not valid");
   }
+  const stateSlot = state.slot;
   const {timelySource, timelyTarget, timelyHead} = getAttestationParticipationStatus(
     state,
     data,
-    state.slot - data.slot
+    stateSlot - data.slot
   );
 
   // Retrieve the validator indices from the attestation participation bitfield
@@ -86,7 +87,7 @@ export function processAttestation(
   const totalIncrements = totalBalancesWithWeight / EFFECTIVE_BALANCE_INCREMENT;
   const proposerRewardNumerator = totalIncrements * state.baseRewardPerIncrement;
   const proposerReward = proposerRewardNumerator / PROPOSER_REWARD_DOMINATOR;
-  increaseBalance(state, epochCtx.getBeaconProposer(state.slot), proposerReward);
+  increaseBalance(state, epochCtx.getBeaconProposer(stateSlot), proposerReward);
 }
 
 /**


### PR DESCRIPTION
**Motivation**

+ A `state.slot` call means navigating a persistent-merkle-tree node, extract number from bytes
+ A `state.slot ++` means we navigate the Node 2 times

**Description**

+ Avoid duplicate calls of `state.slot` per function by using a separate variable for it