### PR TITLE
Add produceBlockV2 route

### DIFF
--- a/packages/api/test/unit/validator.test.ts
+++ b/packages/api/test/unit/validator.test.ts
@@ -44,7 +44,7 @@ describe("validator", () => {
     },
     produceBlockV2: {
       args: [32000, Buffer.alloc(96, 1), "graffiti"],
-      res: {data: ssz.phase0.BeaconBlock.defaultValue(), version: ForkName.altair},
+      res: {data: ssz.altair.BeaconBlock.defaultValue(), version: ForkName.altair},
     },
     produceAttestationData: {
       args: [2, 32000],

--- a/packages/api/test/unit/validator.test.ts
+++ b/packages/api/test/unit/validator.test.ts
@@ -42,6 +42,10 @@ describe("validator", () => {
       args: [32000, Buffer.alloc(96, 1), "graffiti"],
       res: {data: ssz.phase0.BeaconBlock.defaultValue(), version: ForkName.phase0},
     },
+    produceBlockV2: {
+      args: [32000, Buffer.alloc(96, 1), "graffiti"],
+      res: {data: ssz.phase0.BeaconBlock.defaultValue(), version: ForkName.altair},
+    },
     produceAttestationData: {
       args: [2, 32000],
       res: {data: ssz.phase0.AttestationData.defaultValue()},

--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -133,27 +133,30 @@ export function getValidatorApi({
     }
   }
 
-  return {
-    async produceBlock(slot, randaoReveal, graffiti = "") {
-      let timer;
-      metrics?.blockProductionRequests.inc();
-      try {
-        notWhileSyncing();
-        await waitForSlot(slot); // Must never request for a future slot > currentSlot
+  const produceBlock: routes.validator.Api["produceBlock"] = async function produceBlock(slot, randaoReveal, graffiti) {
+    let timer;
+    metrics?.blockProductionRequests.inc();
+    try {
+      notWhileSyncing();
+      await waitForSlot(slot); // Must never request for a future slot > currentSlot
 
-        timer = metrics?.blockProductionTime.startTimer();
-        const block = await assembleBlock(
-          {config, chain, db, eth1, metrics},
-          slot,
-          randaoReveal,
-          toGraffitiBuffer(graffiti)
-        );
-        metrics?.blockProductionSuccess.inc();
-        return {data: block, version: config.getForkName(block.slot)};
-      } finally {
-        if (timer) timer();
-      }
-    },
+      timer = metrics?.blockProductionTime.startTimer();
+      const block = await assembleBlock(
+        {config, chain, db, eth1, metrics},
+        slot,
+        randaoReveal,
+        toGraffitiBuffer(graffiti || "")
+      );
+      metrics?.blockProductionSuccess.inc();
+      return {data: block, version: config.getForkName(block.slot)};
+    } finally {
+      if (timer) timer();
+    }
+  };
+
+  return {
+    produceBlock: produceBlock,
+    produceBlockV2: produceBlock,
 
     async produceAttestationData(committeeIndex, slot) {
       notWhileSyncing();

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -67,7 +67,7 @@ export class Validator {
     const indicesService = new IndicesService(logger, api, validatorStore);
     this.chainHeaderTracker = new ChainHeaderTracker(logger, api);
     const loggerVc = getLoggerVc(logger, clock);
-    new BlockProposingService(loggerVc, api, clock, validatorStore, graffiti);
+    new BlockProposingService(config, loggerVc, api, clock, validatorStore, graffiti);
     new AttestationService(loggerVc, api, clock, validatorStore, indicesService);
     new SyncCommitteeService(config, loggerVc, api, clock, validatorStore, this.chainHeaderTracker, indicesService);
 

--- a/packages/validator/test/unit/services/block.test.ts
+++ b/packages/validator/test/unit/services/block.test.ts
@@ -2,16 +2,18 @@ import {AbortController} from "@chainsafe/abort-controller";
 import {expect} from "chai";
 import sinon from "sinon";
 import bls from "@chainsafe/bls";
+import {createIChainForkConfig} from "@chainsafe/lodestar-config";
+import {config as mainnetConfig} from "@chainsafe/lodestar-config/default";
 import {Root} from "@chainsafe/lodestar-types";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {routes} from "@chainsafe/lodestar-api";
+import {ForkName} from "@chainsafe/lodestar-params";
 import {generateEmptySignedBlock} from "@chainsafe/lodestar/test/utils/block";
 import {BlockProposingService} from "../../../src/services/block";
 import {ValidatorStore} from "../../../src/services/validatorStore";
 import {getApiClientStub} from "../../utils/apiStub";
 import {loggerVc} from "../../utils/logger";
 import {ClockMock} from "../../utils/clock";
-import {ForkName} from "@chainsafe/lodestar-params";
 
 type ProposerDutiesRes = {dependentRoot: Root; data: routes.validator.ProposerDuty[]};
 
@@ -23,6 +25,8 @@ describe("BlockDutiesService", function () {
   const validatorStore = sinon.createStubInstance(ValidatorStore) as ValidatorStore &
     sinon.SinonStubbedInstance<ValidatorStore>;
   let pubkeys: Uint8Array[]; // Initialize pubkeys in before() so bls is already initialized
+
+  const config = createIChainForkConfig(mainnetConfig);
 
   before(() => {
     const secretKeys = Array.from({length: 2}, (_, i) => bls.SecretKey.fromBytes(Buffer.alloc(32, i + 1)));
@@ -44,7 +48,7 @@ describe("BlockDutiesService", function () {
     api.validator.getProposerDuties.resolves(duties);
 
     const clock = new ClockMock();
-    const blockService = new BlockProposingService(loggerVc, api, clock, validatorStore);
+    const blockService = new BlockProposingService(config, loggerVc, api, clock, validatorStore);
 
     const signedBlock = generateEmptySignedBlock();
     validatorStore.signRandao.resolves(signedBlock.message.body.randaoReveal);


### PR DESCRIPTION
**Motivation**

As noted by Discord user `BeroBurny` Lodestar does include the produceBlockV2 route https://github.com/ethereum/eth2.0-APIs/pull/140. We have participated in altair successfully since our route produceBlock (v1) supports all forks.

**Description**

Use the same logic, types and handlers of produceBlock to produceBlockV2. This change would allow a Lodestar node and validator to be compatible with other implementations

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
