### PR TITLE
cli/cmds: fix dev startValidator index to 0:7

### DIFF
--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -102,7 +102,7 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
   if (args.startValidators) {
     const secretKeys: SecretKey[] = [];
     const [fromIndex, valCount] = args.startValidators.split(":").map((s) => parseInt(s));
-    const toIndex = valCount - 1;
+    const toIndex = valCount - fromIndex - 1;
     const maxIndex = anchorState.validators.length - 1;
 
     if (fromIndex > toIndex) {

--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -102,7 +102,7 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
   if (args.startValidators) {
     const secretKeys: SecretKey[] = [];
     const [fromIndex, toIndex] = args.startValidators.split(":").map((s) => parseInt(s));
-    const maxIndex = anchorState.validators.length - 1;
+    const maxIndex = anchorState.validators.length;
 
     if (fromIndex > toIndex) {
       throw Error(`Invalid startValidators arg '${args.startValidators}' - fromIndex > toIndex`);

--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -101,15 +101,16 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
 
   if (args.startValidators) {
     const secretKeys: SecretKey[] = [];
-    const [fromIndex, toIndex] = args.startValidators.split(":").map((s) => parseInt(s));
-    const maxIndex = anchorState.validators.length;
+    const [fromIndex, valCount] = args.startValidators.split(":").map((s) => parseInt(s));
+    const toIndex = valCount - 1;
+    const maxIndex = anchorState.validators.length - 1;
 
     if (fromIndex > toIndex) {
       throw Error(`Invalid startValidators arg '${args.startValidators}' - fromIndex > toIndex`);
     }
 
     if (toIndex > maxIndex) {
-      throw Error(`Invalid startValidators arg '${args.startValidators}' - state has ${maxIndex} validators`);
+      throw Error(`Invalid startValidators arg '${args.startValidators}' - state has ${valCount} validators`);
     }
 
     for (let i = fromIndex; i <= toIndex; i++) {

--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -101,9 +101,9 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
 
   if (args.startValidators) {
     const secretKeys: SecretKey[] = [];
-    const [fromIndex, valCount] = args.startValidators.split(":").map((s) => parseInt(s));
-    const toIndex = valCount - fromIndex - 1;
-    const maxIndex = anchorState.validators.length - 1;
+    const [fromIndex, toIndex] = args.startValidators.split(":").map((s) => parseInt(s));
+    const valCount = anchorState.validators.length;
+    const maxIndex = fromIndex + valCount - 1;
 
     if (fromIndex > toIndex) {
       throw Error(`Invalid startValidators arg '${args.startValidators}' - fromIndex > toIndex`);

--- a/packages/cli/src/cmds/dev/options.ts
+++ b/packages/cli/src/cmds/dev/options.ts
@@ -21,7 +21,7 @@ const devOwnOptions: ICliCommandOptions<IDevOwnArgs> = {
 
   startValidators: {
     description: "Start interop validators in given range",
-    default: "0:8",
+    default: "0:7",
     type: "string",
     group: "dev",
   },


### PR DESCRIPTION
**Motivation**

`lodestar dev` fails with:

```
 ✖ Error: Invalid startValidators arg '0:8' - state has 7 validators
    at Object.devHandler [as handler] (/home/user/.opt/chainsafe/lodestar/packages/cli/src/cmds/dev/handler.ts:116:13)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

**Description**

Default `startValidators=0:8` seems to be off by 1 and should be `0:7` for 8 validators.

I also clarified the variable names.

**Steps to test or reproduce**

```sh
git checkout master
lodestar dev
```