### PR TITLE
cli/cmds: restore raw git data version info in metrics

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -15,7 +15,7 @@ import {initializeOptionsAndConfig, persistOptionsAndConfig} from "../init/handl
 import {IBeaconArgs} from "./options";
 import {getBeaconPaths} from "./paths";
 import {initBeaconState} from "./initBeaconState";
-import {getVersion} from "../../util/version";
+import {getVersion, getVersionGitData} from "../../util/version";
 
 /**
  * Runs a beacon node.
@@ -27,11 +27,12 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
   await persistOptionsAndConfig(args, beaconNodeOptions, config);
 
   const version = getVersion();
+  const gitData = getVersionGitData();
   const beaconPaths = getBeaconPaths(args);
   // TODO: Rename db.name to db.path or db.location
   beaconNodeOptions.set({db: {name: beaconPaths.dbDir}});
   // Add metrics metadata to show versioning + network info in Prometheus + Grafana
-  beaconNodeOptions.set({metrics: {metadata: {version, network: args.network}}});
+  beaconNodeOptions.set({metrics: {metadata: {...gitData, version, network: args.network}}});
 
   // ENR setup
   const peerId = await readPeerId(beaconPaths.peerIdFile);

--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -18,6 +18,7 @@ import {getValidatorPaths} from "../validator/paths";
 import {interopSecretKey} from "@chainsafe/lodestar-beacon-state-transition";
 import {SecretKey} from "@chainsafe/bls";
 import {createIBeaconConfig} from "@chainsafe/lodestar-config";
+import {getVersion} from "../../util/version";
 
 /**
  * Run a beacon node with validator
@@ -56,7 +57,7 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
   // BeaconNode setup
   const libp2p = await createNodeJsLibp2p(peerId, options.network);
   const logger = getCliLogger(args, beaconPaths, config);
-  logger.info("Lodestar dev", {network: args.network, preset: args.preset});
+  logger.info("Lodestar", {version: getVersion(), network: args.network, preset: args.preset});
 
   const db = new BeaconDb({config, controller: new LevelDbController(options.db, {logger})});
   await db.start();

--- a/packages/cli/src/util/version.ts
+++ b/packages/cli/src/util/version.ts
@@ -46,6 +46,11 @@ export function getVersion(): string {
   return `${semver}/${gitData.branch}/${numCommits}/${commitSlice} (${ReleaseTrack.git})`;
 }
 
+/** Exposes raw version data wherever needed for reporting (metrics, grafana). */
+export function getVersionGitData(): GitData {
+  return readLodestarGitData();
+}
+
 /** Returns local version from `lerna.json` or `package.json` as `"0.28.2"` */
 function getLocalVersion(): string | undefined {
   return readVersionFromLernaJson() || readCliPackageJson();


### PR DESCRIPTION
**Motivation**

Follow-up of #2958. Restores `GitData` in metrics for beacon nodes.

**Description**

* Before #2958:  `lodestar_version{semver="0.28.1",branch="-",commit="-",version="0.28.1",network="mainnet"} 1`
* After #2958: `lodestar_version{version="v0.28.1/q9-metrics-version/+5/3d315541 (git)",network="mainnet"} 1`
* Here: `lodestar_version{semver="v0.28.1",branch="q9-metrics-version",commit="3d3155414da15211bacac8774114f482d5c0a230",numCommits="+5",version="v0.28.1/q9-metrics-version/+5/3d315541 (git)",network="mainnet"} 1`

It also adds version string to the `dev` node handler _(cosmetic)._