### PR TITLE
Fix issue in parseJsonRpcErrorCode

### DIFF
--- a/packages/lodestar/src/eth1/provider/jsonRpcHttpClient.ts
+++ b/packages/lodestar/src/eth1/provider/jsonRpcHttpClient.ts
@@ -192,6 +192,6 @@ function parseJsonRpcErrorCode(code: number): string {
   if (code === -32601) return "Method not found";
   if (code === -32602) return "Invalid params";
   if (code === -32603) return "Internal error";
-  if (code >= -32000 && code <= -32099) return "Server error";
+  if (code <= -32000 && code >= -32099) return "Server error";
   return `Unknown error code ${code}`;
 }


### PR DESCRIPTION
Checks were turned around and always returned false.

**Motivation**

Fix a minor bug

**Description**

Checks were turned around in "if (code >= -32000 && code <= -32099) return "Server error";" and so always returned false.