### PR TITLE
Increase ping interval

### DIFF
--- a/packages/lodestar/src/network/peers/peerManager.ts
+++ b/packages/lodestar/src/network/peers/peerManager.ts
@@ -25,14 +25,14 @@ import {
 /** heartbeat performs regular updates such as updating reputations and performing discovery requests */
 const HEARTBEAT_INTERVAL_MS = 30 * 1000;
 /** The time in seconds between PING events. We do not send a ping if the other peer has PING'd us */
-const PING_INTERVAL_INBOUND_MS = 15 * 1000;
-const PING_INTERVAL_OUTBOUND_MS = 20 * 1000;
+const PING_INTERVAL_INBOUND_MS = 4 * 60 * 1000 - 30 * 1000; // Offset to not ping when outbound reqs
+const PING_INTERVAL_OUTBOUND_MS = 4 * 60 * 1000;
 /** The time in seconds between re-status's peers. */
 const STATUS_INTERVAL_MS = 5 * 60 * 1000;
 /** Expect a STATUS request from on inbound peer for some time. Afterwards the node does a request */
 const STATUS_INBOUND_GRACE_PERIOD = 15 * 1000;
 /** Internal interval to check PING and STATUS timeouts */
-const CHECK_PING_STATUS_INTERVAL = 2 * 1000;
+const CHECK_PING_STATUS_INTERVAL = 10 * 1000;
 
 // TODO:
 // maxPeers and targetPeers should be dynamic on the num of validators connected

--- a/packages/lodestar/src/network/peers/peerManager.ts
+++ b/packages/lodestar/src/network/peers/peerManager.ts
@@ -25,7 +25,7 @@ import {
 /** heartbeat performs regular updates such as updating reputations and performing discovery requests */
 const HEARTBEAT_INTERVAL_MS = 30 * 1000;
 /** The time in seconds between PING events. We do not send a ping if the other peer has PING'd us */
-const PING_INTERVAL_INBOUND_MS = 4 * 60 * 1000 - 30 * 1000; // Offset to not ping when outbound reqs
+const PING_INTERVAL_INBOUND_MS = 4 * 60 * 1000 - 11 * 1000; // Offset to not ping when outbound reqs
 const PING_INTERVAL_OUTBOUND_MS = 4 * 60 * 1000;
 /** The time in seconds between re-status's peers. */
 const STATUS_INTERVAL_MS = 5 * 60 * 1000;


### PR DESCRIPTION
**Motivation**

Metrics seem to indicate that we ping peers too much compared to our peers.

![Screenshot from 2021-08-19 11-52-36](https://user-images.githubusercontent.com/35266934/130048892-207e42d3-9b09-4d20-bd73-21818333ddf1.png)

See **status** for reference where we have a similar rate than our peers.

![Screenshot from 2021-08-19 11-52-49](https://user-images.githubusercontent.com/35266934/130048985-01e76b85-86d3-4b7d-817b-feeada745eae.png)

Given that the network module competes for precious resources in the main thread, reduce frequency to the minimum viable to increase performance. 

Adjusting the rates to our current interval: `new adjusted interval = 1.24/0.09 * 17.5/60 = 4.01 min`

Closes https://github.com/ChainSafe/lodestar/issues/2907

**Description**

Increase ping interval to 4 minutes.