### PR TITLE
Support returning ssz format in debug.getState routes

### DIFF
--- a/packages/api/src/client/debug.ts
+++ b/packages/api/src/client/debug.ts
@@ -1,6 +1,6 @@
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
-import {IHttpClient, generateGenericJsonClient} from "./utils";
-import {Api, ReqTypes, routesData, getReqSerializers, getReturnTypes} from "../routes/debug";
+import {IHttpClient, getFetchOptsSerializers, generateGenericJsonClient} from "./utils";
+import {Api, ReqTypes, routesData, getReqSerializers, getReturnTypes, StateFormat} from "../routes/debug";
 
 /**
  * REST HTTP client for debug routes
@@ -8,6 +8,33 @@ import {Api, ReqTypes, routesData, getReqSerializers, getReturnTypes} from "../r
 export function getClient(_config: IChainForkConfig, httpClient: IHttpClient): Api {
   const reqSerializers = getReqSerializers();
   const returnTypes = getReturnTypes();
-  // All routes return JSON, use a client auto-generator
-  return generateGenericJsonClient<Api, ReqTypes>(routesData, reqSerializers, returnTypes, httpClient);
+  // Some routes return JSON, use a client auto-generator
+  const client = generateGenericJsonClient<Api, ReqTypes>(routesData, reqSerializers, returnTypes, httpClient);
+  // For `getState()` generate request serializer
+  const fetchOptsSerializers = getFetchOptsSerializers<Api, ReqTypes>(routesData, reqSerializers);
+
+  return {
+    ...client,
+
+    async getState(stateId: string, format?: StateFormat) {
+      if (format === "ssz") {
+        const buffer = await httpClient.arrayBuffer(fetchOptsSerializers.getState(stateId, format));
+        // Casting to any otherwise Typescript doesn't like the multi-type return
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
+        return new Uint8Array(buffer) as any;
+      } else {
+        return client.getState(stateId, format);
+      }
+    },
+    async getStateV2(stateId: string, format?: StateFormat) {
+      if (format === "ssz") {
+        const buffer = await httpClient.arrayBuffer(fetchOptsSerializers.getStateV2(stateId, format));
+        // Casting to any otherwise Typescript doesn't like the multi-type return
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
+        return new Uint8Array(buffer) as any;
+      } else {
+        return client.getStateV2(stateId, format);
+      }
+    },
+  };
 }

--- a/packages/api/src/client/utils/client.ts
+++ b/packages/api/src/client/utils/client.ts
@@ -36,6 +36,7 @@ export function getFetchOptsSerializer<Fn extends (...args: any) => any, ReqType
       method: routeDef.method,
       query: req.query,
       body: req.body as unknown,
+      headers: req.headers,
     };
   };
 }

--- a/packages/api/src/client/utils/httpClient.ts
+++ b/packages/api/src/client/utils/httpClient.ts
@@ -20,6 +20,7 @@ export type FetchOpts = {
   method: RouteDef["method"];
   query?: ReqGeneric["query"];
   body?: ReqGeneric["body"];
+  headers?: ReqGeneric["headers"];
 };
 
 export interface IHttpClient {
@@ -74,11 +75,16 @@ export class HttpClient implements IHttpClient {
 
     try {
       const url = urlJoin(this.baseUrl, opts.url) + (opts.query ? "?" + stringifyQuery(opts.query) : "");
-      const bodyArgs = opts.body
-        ? {headers: {"Content-Type": "application/json"}, body: JSON.stringify(opts.body)}
-        : {};
 
-      const res = await this.fetch(url, {method: opts.method, ...bodyArgs, signal: controller.signal});
+      const headers = opts.headers || {};
+      if (opts.body) headers["Content-Type"] = "application/json";
+
+      const res = await this.fetch(url, {
+        method: opts.method,
+        headers: headers as Record<string, string>,
+        body: opts.body ? JSON.stringify(opts.body) : undefined,
+        signal: controller.signal,
+      });
 
       if (!res.ok) {
         const errBody = await res.text();

--- a/packages/api/src/server/debug.ts
+++ b/packages/api/src/server/debug.ts
@@ -3,8 +3,6 @@ import {jsonOpts} from "../utils";
 import {ServerRoutes, getGenericJsonServer} from "./utils";
 import {Api, ReqTypes, routesData, getReturnTypes, getReqSerializers} from "../routes/debug";
 
-const mimeTypeSSZ = "application/octet-stream";
-
 export function getRoutes(config: IChainForkConfig, api: Api): ServerRoutes<Api, ReqTypes> {
   const reqSerializers = getReqSerializers();
   const returnTypes = getReturnTypes();
@@ -23,10 +21,9 @@ export function getRoutes(config: IChainForkConfig, api: Api): ServerRoutes<Api,
       ...serverRoutes.getState,
       handler: async (req) => {
         const data = await api.getState(...reqSerializers.getState.parseReq(req));
-        const type = config.getForkTypes(data.data.slot).BeaconState;
-        if (req.headers["accept"] === mimeTypeSSZ) {
+        if (data instanceof Uint8Array) {
           // Fastify 3.x.x will automatically add header `Content-Type: application/octet-stream` if Buffer
-          return Buffer.from(type.serialize(data.data));
+          return Buffer.from(data);
         } else {
           return returnTypes.getState.toJson(data, jsonOpts);
         }
@@ -36,10 +33,9 @@ export function getRoutes(config: IChainForkConfig, api: Api): ServerRoutes<Api,
       ...serverRoutes.getStateV2,
       handler: async (req) => {
         const data = await api.getStateV2(...reqSerializers.getStateV2.parseReq(req));
-        const type = config.getForkTypes(data.data.slot).BeaconState;
-        if (req.headers["accept"] === mimeTypeSSZ) {
+        if (data instanceof Uint8Array) {
           // Fastify 3.x.x will automatically add header `Content-Type: application/octet-stream` if Buffer
-          return Buffer.from(type.serialize(data.data));
+          return Buffer.from(data);
         } else {
           return returnTypes.getStateV2.toJson(data, jsonOpts);
         }

--- a/packages/api/src/utils/types.ts
+++ b/packages/api/src/utils/types.ts
@@ -31,6 +31,7 @@ export type ReqGeneric = {
   params?: Record<string, string | number>;
   query?: Record<string, string | number | (string | number)[]>;
   body?: any;
+  headers?: Record<string, string[] | string | undefined>;
 };
 
 export type ReqEmpty = ReqGeneric;

--- a/packages/lodestar/src/api/impl/debug/index.ts
+++ b/packages/lodestar/src/api/impl/debug/index.ts
@@ -18,14 +18,26 @@ export function getDebugApi({
       };
     },
 
-    async getState(stateId) {
+    async getState(stateId: string, format?: routes.debug.StateFormat) {
       const state = await resolveStateId(config, chain, db, stateId, {regenFinalizedState: true});
-      return {data: state};
+      if (format === "ssz") {
+        // Casting to any otherwise Typescript doesn't like the multi-type return
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
+        return config.getForkTypes(state.slot).BeaconState.serialize(state) as any;
+      } else {
+        return {data: state};
+      }
     },
 
-    async getStateV2(stateId) {
+    async getStateV2(stateId: string, format?: routes.debug.StateFormat) {
       const state = await resolveStateId(config, chain, db, stateId, {regenFinalizedState: true});
-      return {data: state, version: config.getForkName(state.slot)};
+      if (format === "ssz") {
+        // Casting to any otherwise Typescript doesn't like the multi-type return
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
+        return config.getForkTypes(state.slot).BeaconState.serialize(state) as any;
+      } else {
+        return {data: state, version: config.getForkName(state.slot)};
+      }
     },
 
     async connectToPeer(peerIdStr, multiaddrStr) {

--- a/packages/validator/test/utils/apiStub.ts
+++ b/packages/validator/test/utils/apiStub.ts
@@ -10,7 +10,10 @@ export function getApiClientStub(
   return {
     beacon: sandbox.stub(api.beacon),
     config: sandbox.stub(api.config),
-    debug: sandbox.stub(api.debug),
+    // Typescript errors due to the multiple return types of debug.getState()
+    // Since the return type of this function is typed, casting to any to patch the error quickly
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    debug: sandbox.stub(api.debug) as any,
     events: sandbox.stub(api.events),
     lightclient: sandbox.stub(api.lightclient),
     lodestar: sandbox.stub(api.lodestar),


### PR DESCRIPTION
**Motivation**

Current client does not support requesting states as raw bytes (ssz serialized). This is very useful in some applications.

**Description**

Support returning state as ssz serialized with a format argument