### PR TITLE
Move network configs to lodestar-config

### DIFF
--- a/packages/cli/src/config/beaconParams.ts
+++ b/packages/cli/src/config/beaconParams.ts
@@ -62,15 +62,18 @@ export function getBeaconConfig(args: IBeaconParamsArgs): IChainForkConfig {
  * - CLI flags
  */
 export function getBeaconParams({network, paramsFile, additionalParamsCli}: IBeaconParamsArgs): IChainConfig {
-  const additionalParams = mergeBeaconParams(
-    // Default network params
-    network ? getNetworkBeaconParams(network) : {},
-    // Existing user custom params from file
-    readBeaconParamsIfExists(paramsFile),
-    // Params from CLI flags
-    additionalParamsCli || {}
-  );
-  return createIChainConfig(parsePartialIChainConfigJson(additionalParams));
+  // Default network params
+  const networkParams: Partial<IChainConfig> = network ? getNetworkBeaconParams(network) : {};
+  // Existing user custom params from file
+  const fileParams: Partial<IChainConfig> = parsePartialIChainConfigJson(readBeaconParamsIfExists(paramsFile));
+  // Params from CLI flags
+  const cliParams: Partial<IChainConfig> = parsePartialIChainConfigJson(additionalParamsCli);
+
+  return createIChainConfig({
+    ...networkParams,
+    ...fileParams,
+    ...cliParams,
+  });
 }
 
 export function writeBeaconParams(filepath: string, params: IChainConfig): void {
@@ -79,13 +82,4 @@ export function writeBeaconParams(filepath: string, params: IChainConfig): void 
 
 function readBeaconParamsIfExists(filepath: string): IBeaconParamsUnparsed {
   return readFileIfExists(filepath) || {};
-}
-
-/**
- * Typesafe wrapper to merge partial IBeaconNodeOptions objects
- */
-function mergeBeaconParams(...itemsArr: IBeaconParamsUnparsed[]): IBeaconParamsUnparsed {
-  return itemsArr.reduce((mergedItems, item) => {
-    return {...mergedItems, ...item};
-  }, itemsArr[0]);
 }

--- a/packages/cli/src/networks/altair-devnet-3.ts
+++ b/packages/cli/src/networks/altair-devnet-3.ts
@@ -1,18 +1,22 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {IBeaconParamsUnparsed} from "../config/types";
+import {fromHexString as b} from "@chainsafe/ssz";
+import {mainnetChainConfig} from "@chainsafe/lodestar-config/presets";
+import {IChainConfig} from "@chainsafe/lodestar-config";
 
 /* eslint-disable max-len */
 
 // https://github.com/eth2-clients/eth2-networks/blob/master/shared/altair-devnet-3/config.yaml
-export const beaconParams: IBeaconParamsUnparsed = {
+export const chainConfig: IChainConfig = {
+  ...mainnetChainConfig,
+
   // Genesis
   MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 50000,
   MIN_GENESIS_TIME: 1628604000,
-  GENESIS_FORK_VERSION: "0x19504702",
+  GENESIS_FORK_VERSION: b("0x19504702"),
   GENESIS_DELAY: 86400,
 
   // Altair
-  ALTAIR_FORK_VERSION: "0x01000003",
+  ALTAIR_FORK_VERSION: b("0x01000003"),
   ALTAIR_FORK_EPOCH: 10,
 
   // Time parameters
@@ -23,7 +27,7 @@ export const beaconParams: IBeaconParamsUnparsed = {
   ETH1_FOLLOW_DISTANCE: 2048,
 
   // Validator cycle
-  INACTIVITY_SCORE_BIAS: 4,
+  INACTIVITY_SCORE_BIAS: BigInt(4),
   INACTIVITY_SCORE_RECOVERY_RATE: 16,
   EJECTION_BALANCE: 16000000000,
   MIN_PER_EPOCH_CHURN_LIMIT: 4,
@@ -32,7 +36,7 @@ export const beaconParams: IBeaconParamsUnparsed = {
   // Deposit contract
   DEPOSIT_CHAIN_ID: 5,
   DEPOSIT_NETWORK_ID: 5,
-  DEPOSIT_CONTRACT_ADDRESS: "0x0C862A922512A5416713421DD95ccE5a07AA80ff",
+  DEPOSIT_CONTRACT_ADDRESS: b("0x0C862A922512A5416713421DD95ccE5a07AA80ff"),
 };
 
 export const depositContractDeployBlock = 5288493;

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -4,9 +4,8 @@ import {allForks} from "@chainsafe/lodestar-types";
 import {IBeaconNodeOptions} from "@chainsafe/lodestar";
 // eslint-disable-next-line no-restricted-imports
 import {getStateTypeFromBytes} from "@chainsafe/lodestar/lib/util/multifork";
-import {IChainForkConfig} from "@chainsafe/lodestar-config";
+import {IChainConfig, IChainForkConfig} from "@chainsafe/lodestar-config";
 import {RecursivePartial} from "@chainsafe/lodestar-utils";
-import {IBeaconParamsUnparsed} from "../config/types";
 import * as mainnet from "./mainnet";
 import * as pyrmont from "./pyrmont";
 import * as prater from "./prater";
@@ -20,7 +19,7 @@ export const infuraNetworks: NetworkName[] = ["mainnet", "pyrmont", "prater"];
 function getNetworkData(
   network: NetworkName
 ): {
-  beaconParams: IBeaconParamsUnparsed;
+  chainConfig: IChainConfig;
   depositContractDeployBlock: number;
   genesisFileUrl: string | null;
   bootnodesFileUrl: string;
@@ -51,13 +50,13 @@ export function getEth1ProviderUrl(networkId: number): string {
   }
 }
 
-export function getNetworkBeaconParams(network: NetworkName): IBeaconParamsUnparsed {
-  return getNetworkData(network).beaconParams;
+export function getNetworkBeaconParams(network: NetworkName): IChainConfig {
+  return getNetworkData(network).chainConfig;
 }
 
 export function getNetworkBeaconNodeOptions(network: NetworkName): RecursivePartial<IBeaconNodeOptions> {
-  const {depositContractDeployBlock, bootEnrs, beaconParams} = getNetworkData(network);
-  const networkId = parseInt((beaconParams.DEPOSIT_NETWORK_ID || 1) as string, 10);
+  const {depositContractDeployBlock, bootEnrs, chainConfig} = getNetworkData(network);
+  const networkId = parseInt(String(chainConfig.DEPOSIT_NETWORK_ID || 1), 10);
   return {
     eth1: {
       providerUrls: [getEth1ProviderUrl(networkId)],

--- a/packages/cli/src/networks/mainnet.ts
+++ b/packages/cli/src/networks/mainnet.ts
@@ -1,19 +1,8 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-import {IBeaconParamsUnparsed} from "../config/types";
+import {mainnetChainConfig} from "@chainsafe/lodestar-config/networks";
+
+export const chainConfig = mainnetChainConfig;
 
 /* eslint-disable max-len */
-
-export const beaconParams: IBeaconParamsUnparsed = {
-  DEPOSIT_CONTRACT_ADDRESS: "0x00000000219ab540356cBB839Cbe05303d7705Fa",
-
-  DEPOSIT_CHAIN_ID: 1,
-  DEPOSIT_NETWORK_ID: 1,
-
-  MIN_GENESIS_TIME: 1606824000, // Tuesday, December 1, 2020 12:00:00 PM UTC
-  GENESIS_DELAY: 604800,
-  // MUST NOT use `GENESIS_FORK_VERSION` here so for `minimal` networks the preset value of 0x00000001 take prevalence
-  // GENESIS_FORK_VERSION: "0x00000000",
-};
 
 export const depositContractDeployBlock = 11052984;
 export const genesisFileUrl =

--- a/packages/cli/src/networks/prater.ts
+++ b/packages/cli/src/networks/prater.ts
@@ -1,20 +1,8 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-import {IBeaconParamsUnparsed} from "../config/types";
+import {praterChainConfig} from "@chainsafe/lodestar-config/networks";
+
+export const chainConfig = praterChainConfig;
 
 /* eslint-disable max-len */
-
-export const beaconParams: IBeaconParamsUnparsed = {
-  // Ethereum Goerli testnet
-  DEPOSIT_CHAIN_ID: 5,
-  DEPOSIT_NETWORK_ID: 5,
-  // Prater test deposit contract on Goerli Testnet
-  DEPOSIT_CONTRACT_ADDRESS: "0xff50ed3d0ec03aC01D4C79aAd74928BFF48a7b2b",
-
-  // Mar-01-2021 08:53:32 AM +UTC
-  MIN_GENESIS_TIME: 1614588812,
-  GENESIS_DELAY: 1919188,
-  GENESIS_FORK_VERSION: "0x00001020",
-};
 
 export const depositContractDeployBlock = 4367322;
 export const genesisFileUrl =

--- a/packages/cli/src/networks/pyrmont.ts
+++ b/packages/cli/src/networks/pyrmont.ts
@@ -1,30 +1,8 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-import {IBeaconParamsUnparsed} from "../config/types";
+import {pyrmontChainConfig} from "@chainsafe/lodestar-config/networks";
+
+export const chainConfig = pyrmontChainConfig;
 
 /* eslint-disable max-len */
-
-export const beaconParams: IBeaconParamsUnparsed = {
-  DEPOSIT_CONTRACT_ADDRESS: "0x8c5fecdC472E27Bc447696F431E425D02dd46a8c",
-
-  // Ethereum Goerli testnet
-  DEPOSIT_CHAIN_ID: 5,
-  DEPOSIT_NETWORK_ID: 5,
-
-  MIN_GENESIS_TIME: 1605700800, // Wednesday, November 18, 2020 12:00:00 PM UTC
-  GENESIS_DELAY: 432000,
-  GENESIS_FORK_VERSION: "0x00002009",
-
-  // Altair
-  ALTAIR_FORK_VERSION: "0x01002009",
-  ALTAIR_FORK_EPOCH: 61650,
-
-  // Validator cycle
-  INACTIVITY_SCORE_BIAS: 4,
-  INACTIVITY_SCORE_RECOVERY_RATE: 16,
-  EJECTION_BALANCE: 16000000000,
-  MIN_PER_EPOCH_CHURN_LIMIT: 4,
-  CHURN_LIMIT_QUOTIENT: 65536,
-};
 
 export const depositContractDeployBlock = 3743587;
 export const genesisFileUrl = "https://raw.githubusercontent.com/ChainSafe/pyrmont/master/genesis.ssz";

--- a/packages/config/networks.d.ts
+++ b/packages/config/networks.d.ts
@@ -1,0 +1,1 @@
+export * from "./lib/networks";

--- a/packages/config/networks.js
+++ b/packages/config/networks.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = require("./lib/networks");

--- a/packages/config/presets.d.ts
+++ b/packages/config/presets.d.ts
@@ -1,0 +1,1 @@
+export * from "./lib/networks";

--- a/packages/config/presets.js
+++ b/packages/config/presets.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = require("./lib/networks");

--- a/packages/config/src/chainConfig/networks/mainnet.ts
+++ b/packages/config/src/chainConfig/networks/mainnet.ts
@@ -1,0 +1,20 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import {fromHexString as b} from "@chainsafe/ssz";
+import {IChainConfig} from "..";
+import {chainConfig as mainnet} from "../presets/mainnet";
+
+/* eslint-disable max-len */
+
+export const mainnetChainConfig: IChainConfig = {
+  ...mainnet,
+
+  DEPOSIT_CONTRACT_ADDRESS: b("0x00000000219ab540356cBB839Cbe05303d7705Fa"),
+
+  DEPOSIT_CHAIN_ID: 1,
+  DEPOSIT_NETWORK_ID: 1,
+
+  MIN_GENESIS_TIME: 1606824000, // Tuesday, December 1, 2020 12:00:00 PM UTC
+  GENESIS_DELAY: 604800,
+  // MUST NOT use `GENESIS_FORK_VERSION` here so for `minimal` networks the preset value of 0x00000001 take prevalence
+  // GENESIS_FORK_VERSION: "0x00000000",
+};

--- a/packages/config/src/chainConfig/networks/prater.ts
+++ b/packages/config/src/chainConfig/networks/prater.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import {fromHexString as b} from "@chainsafe/ssz";
+import {IChainConfig} from "..";
+import {chainConfig as mainnet} from "../presets/mainnet";
+
+/* eslint-disable max-len */
+
+export const praterChainConfig: IChainConfig = {
+  ...mainnet,
+
+  // Ethereum Goerli testnet
+  DEPOSIT_CHAIN_ID: 5,
+  DEPOSIT_NETWORK_ID: 5,
+  // Prater test deposit contract on Goerli Testnet
+  DEPOSIT_CONTRACT_ADDRESS: b("0xff50ed3d0ec03aC01D4C79aAd74928BFF48a7b2b"),
+
+  // Mar-01-2021 08:53:32 AM +UTC
+  MIN_GENESIS_TIME: 1614588812,
+  GENESIS_DELAY: 1919188,
+  GENESIS_FORK_VERSION: b("0x00001020"),
+};

--- a/packages/config/src/chainConfig/networks/pyrmont.ts
+++ b/packages/config/src/chainConfig/networks/pyrmont.ts
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import {fromHexString as b} from "@chainsafe/ssz";
+import {IChainConfig} from "..";
+import {chainConfig as mainnet} from "../presets/mainnet";
+
+/* eslint-disable max-len */
+
+export const pyrmontChainConfig: IChainConfig = {
+  ...mainnet,
+
+  DEPOSIT_CONTRACT_ADDRESS: b("0x8c5fecdC472E27Bc447696F431E425D02dd46a8c"),
+
+  // Ethereum Goerli testnet
+  DEPOSIT_CHAIN_ID: 5,
+  DEPOSIT_NETWORK_ID: 5,
+
+  MIN_GENESIS_TIME: 1605700800, // Wednesday, November 18, 2020 12:00:00 PM UTC
+  GENESIS_DELAY: 432000,
+  GENESIS_FORK_VERSION: b("0x00002009"),
+
+  // Altair
+  ALTAIR_FORK_VERSION: b("0x01002009"),
+  ALTAIR_FORK_EPOCH: 61650,
+
+  // Validator cycle
+  INACTIVITY_SCORE_BIAS: BigInt(4),
+  INACTIVITY_SCORE_RECOVERY_RATE: 16,
+  EJECTION_BALANCE: 16000000000,
+  MIN_PER_EPOCH_CHURN_LIMIT: 4,
+  CHURN_LIMIT_QUOTIENT: 65536,
+};

--- a/packages/config/src/chainConfig/presets/mainnet.ts
+++ b/packages/config/src/chainConfig/presets/mainnet.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString} from "@chainsafe/ssz";
+import {fromHexString as b} from "@chainsafe/ssz";
 import {PresetName} from "@chainsafe/lodestar-params";
 import {IChainConfig} from "../types";
 
@@ -12,7 +12,7 @@ export const chainConfig: IChainConfig = {
   // Dec 1, 2020, 12pm UTC
   MIN_GENESIS_TIME: 1606824000,
   // Mainnet initial fork version, recommend altering for testnets
-  GENESIS_FORK_VERSION: fromHexString("0x00000000"),
+  GENESIS_FORK_VERSION: b("0x00000000"),
   // 604800 seconds (7 days)
   GENESIS_DELAY: 604800,
 
@@ -23,13 +23,13 @@ export const chainConfig: IChainConfig = {
   //  - Temporarily set to max uint64 value: 2**64 - 1
 
   // Altair
-  ALTAIR_FORK_VERSION: fromHexString("0x01000000"),
+  ALTAIR_FORK_VERSION: b("0x01000000"),
   ALTAIR_FORK_EPOCH: Infinity,
   // Merge
-  MERGE_FORK_VERSION: fromHexString("0x02000000"),
+  MERGE_FORK_VERSION: b("0x02000000"),
   MERGE_FORK_EPOCH: Infinity,
   // Sharding
-  SHARDING_FORK_VERSION: fromHexString("0x03000000"),
+  SHARDING_FORK_VERSION: b("0x03000000"),
   SHARDING_FORK_EPOCH: Infinity,
 
   // TBD, 2**32 is a placeholder. Merge transition approach is in active R&D.
@@ -66,5 +66,5 @@ export const chainConfig: IChainConfig = {
   // Ethereum PoW Mainnet
   DEPOSIT_CHAIN_ID: 1,
   DEPOSIT_NETWORK_ID: 1,
-  DEPOSIT_CONTRACT_ADDRESS: fromHexString("0x00000000219ab540356cBB839Cbe05303d7705Fa"),
+  DEPOSIT_CONTRACT_ADDRESS: b("0x00000000219ab540356cBB839Cbe05303d7705Fa"),
 };

--- a/packages/config/src/chainConfig/presets/minimal.ts
+++ b/packages/config/src/chainConfig/presets/minimal.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString} from "@chainsafe/ssz";
+import {fromHexString as b} from "@chainsafe/ssz";
 import {PresetName} from "@chainsafe/lodestar-params";
 import {IChainConfig} from "../types";
 
@@ -14,7 +14,7 @@ export const chainConfig: IChainConfig = {
   // Jan 3, 2020
   MIN_GENESIS_TIME: 1578009600,
   // Highest byte set to 0x01 to avoid collisions with mainnet versioning
-  GENESIS_FORK_VERSION: fromHexString("0x00000001"),
+  GENESIS_FORK_VERSION: b("0x00000001"),
   // [customized] Faster to spin up testnets, but does not give validator reasonable warning time for genesis
   GENESIS_DELAY: 300,
 
@@ -24,13 +24,13 @@ export const chainConfig: IChainConfig = {
   // Individual tests/testnets may set different values.
 
   // Altair
-  ALTAIR_FORK_VERSION: fromHexString("0x01000001"),
+  ALTAIR_FORK_VERSION: b("0x01000001"),
   ALTAIR_FORK_EPOCH: Infinity,
   // Merge
-  MERGE_FORK_VERSION: fromHexString("0x02000001"),
+  MERGE_FORK_VERSION: b("0x02000001"),
   MERGE_FORK_EPOCH: Infinity,
   // Sharding
-  SHARDING_FORK_VERSION: fromHexString("0x03000001"),
+  SHARDING_FORK_VERSION: b("0x03000001"),
   SHARDING_FORK_EPOCH: Infinity,
 
   // TBD, 2**32 is a placeholder. Merge transition approach is in active R&D.
@@ -68,5 +68,5 @@ export const chainConfig: IChainConfig = {
   DEPOSIT_CHAIN_ID: 5,
   DEPOSIT_NETWORK_ID: 5,
   // Configured on a per testnet basis
-  DEPOSIT_CONTRACT_ADDRESS: fromHexString("0x1234567890123456789012345678901234567890"),
+  DEPOSIT_CONTRACT_ADDRESS: b("0x1234567890123456789012345678901234567890"),
 };

--- a/packages/config/src/networks.ts
+++ b/packages/config/src/networks.ts
@@ -1,13 +1,13 @@
-import {createIChainForkConfig, IChainForkConfig} from "./beaconConfig";
+import {IChainConfig} from "./chainConfig";
 import {mainnetChainConfig} from "./chainConfig/networks/mainnet";
 import {pyrmontChainConfig} from "./chainConfig/networks/pyrmont";
 import {praterChainConfig} from "./chainConfig/networks/prater";
 
 export {mainnetChainConfig, pyrmontChainConfig, praterChainConfig};
-// for testing purpose only
-export const mainnet = createIChainForkConfig(mainnetChainConfig);
-export const pyrmont = createIChainForkConfig(pyrmontChainConfig);
-export const prater = createIChainForkConfig(praterChainConfig);
 
 export type NetworkName = "mainnet" | "pyrmont" | "prater";
-export const networksChainConfig: Record<NetworkName, IChainForkConfig> = {mainnet, pyrmont, prater};
+export const networksChainConfig: Record<NetworkName, IChainConfig> = {
+  mainnet: mainnetChainConfig,
+  pyrmont: pyrmontChainConfig,
+  prater: praterChainConfig,
+};

--- a/packages/config/src/networks.ts
+++ b/packages/config/src/networks.ts
@@ -1,0 +1,13 @@
+import {createIChainForkConfig, IChainForkConfig} from "./beaconConfig";
+import {mainnetChainConfig} from "./chainConfig/networks/mainnet";
+import {pyrmontChainConfig} from "./chainConfig/networks/pyrmont";
+import {praterChainConfig} from "./chainConfig/networks/prater";
+
+export {mainnetChainConfig, pyrmontChainConfig, praterChainConfig};
+// for testing purpose only
+export const mainnet = createIChainForkConfig(mainnetChainConfig);
+export const pyrmont = createIChainForkConfig(pyrmontChainConfig);
+export const prater = createIChainForkConfig(praterChainConfig);
+
+export type NetworkName = "mainnet" | "pyrmont" | "prater";
+export const networksChainConfig: Record<NetworkName, IChainForkConfig> = {mainnet, pyrmont, prater};

--- a/packages/config/src/presets.ts
+++ b/packages/config/src/presets.ts
@@ -1,0 +1,8 @@
+import {createIChainForkConfig} from "./beaconConfig";
+import {chainConfig as mainnetChainConfig} from "./chainConfig/presets/mainnet";
+import {chainConfig as minimalChainConfig} from "./chainConfig/presets/minimal";
+
+export {mainnetChainConfig, minimalChainConfig};
+// for testing purpose only
+export const mainnet = createIChainForkConfig(mainnetChainConfig);
+export const minimal = createIChainForkConfig(minimalChainConfig);


### PR DESCRIPTION
**Motivation**

Working on improving the performance tests I needed the config of Pyrmont. However it was buried deep in the CLI code. I believe it's useful to expose well-known testnet configs in higher up package like lodestar-config. The CLI can still declare less useful networks like devnets if it really wants.

**Description**

- Move mainnet, pyrmont and prater configs to lodestar-config
- Expose network configs and presets configs in root package on `lodestar-config/networks` and `lodestar-config/presets`. Don't use specific names so we don't have to update them once new testnets appear.

Example usage:

```ts
import {NetworkName, networksChainConfig} from "@chainsafe/lodestar-config/networks";

export function getNetworkConfig(network: NetworkName): IChainConfig {
  return networksChainConfig[network];
}
```