### PR TITLE
github: add weekly release pull request on wednesday

### DIFF
--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -1,0 +1,58 @@
+name: Release weekly (create PR only)
+
+concurrency:
+  group: cd-release-weekly
+
+on:
+  push:
+    branches:
+      - "q9-ga-releases" # @TODO @q9f remove (just testing)
+  schedule:
+    - cron: '23 4 * * WED'
+
+jobs:
+  prepare:
+    name: Prepare Pull-Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          fetch-depth: 0
+      - name: Setup NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14.17.5"
+          registry-url: "https://registry.npmjs.org"
+      - name: Restore dependencies
+        uses: actions/cache@master
+        id: cache-deps
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-14.16.0
+      - name: Install & build
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile --ignore-optional
+      - name: Build
+        run: yarn build
+        if: steps.cache-deps.outputs.cache-hit == 'true'
+      - name: Bump minor version
+        run: |
+          node_modules/.bin/lerna version minor --yes --no-push --force-publish
+      - name: Create Pull-Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          author: q9f <q9f@users.noreply.github.com>
+          commiter: q9f <q9f@users.noreply.github.com>
+          branch: gacpr-release
+          branch-suffix: short-commit-hash
+          delete-branch: true
+          title: "Weekly minor release"
+          draft: true
+      - name: Check outputs
+        run: |
+          echo "Pull-Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull-Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -4,9 +4,6 @@ concurrency:
   group: cd-release-weekly
 
 on:
-  push:
-    branches:
-      - "q9-ga-weekly" # @TODO @q9f remove (just testing)
   schedule:
     - cron: '23 4 * * WED'
 
@@ -23,7 +20,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v2
         with:
-          node-version: "14.17.5"
+          node-version: "lts/fermium"
           registry-url: "https://registry.npmjs.org"
       - name: Restore dependencies
         uses: actions/cache@master
@@ -32,22 +29,22 @@ jobs:
           path: |
             node_modules
             packages/*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-14.16.0
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-fermium
+      - name: Bump minor version
+        run: |
+          node_modules/.bin/lerna version minor --yes \
+          --no-git-tag-version --no-push
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --ignore-optional
       - name: Build
         run: yarn build
         if: steps.cache-deps.outputs.cache-hit == 'true'
-      - name: Bump minor version
-        run: |
-          node_modules/.bin/lerna version minor --yes \
-          --no-git-tag-version --no-push
       - name: Create Pull-Request
         uses: peter-evans/create-pull-request@v3
         with:
           author: q9f <q9f@users.noreply.github.com>
-          commiter: q9f <q9f@users.noreply.github.com>
+          committer: q9f <q9f@users.noreply.github.com>
           branch: gacpr-release
           branch-suffix: short-commit-hash
           delete-branch: true

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -49,6 +49,7 @@ jobs:
           branch-suffix: short-commit-hash
           delete-branch: true
           title: "Weekly minor release"
+          commit-message: "Weekly minor release"
           draft: true
       - name: Check outputs
         run: |

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -6,7 +6,7 @@ concurrency:
 on:
   push:
     branches:
-      - "q9-ga-releases" # @TODO @q9f remove (just testing)
+      - "q9-ga-weekly" # @TODO @q9f remove (just testing)
   schedule:
     - cron: '23 4 * * WED'
 
@@ -41,7 +41,8 @@ jobs:
         if: steps.cache-deps.outputs.cache-hit == 'true'
       - name: Bump minor version
         run: |
-          node_modules/.bin/lerna version minor --yes --no-push --force-publish
+          node_modules/.bin/lerna version minor --yes \
+          --no-git-tag-version --no-push
       - name: Create Pull-Request
         uses: peter-evans/create-pull-request@v3
         with:


### PR DESCRIPTION
**Motivation**

As discussed on discord, we can make Github remind us to author regular releases.

**Description**

1. Run by cron on every (!) Wednesday at 4:23 am
2. Sets up the repository, NodeJS, etc. from master
3. Run `lerna version minor`
4. Creates a draft PR that can be closed or merged, example: #2993 

There is, however, no easy way to do fortnightly cron runs. On a linux host you can "hack" cron to only evaluate the job every other week but on Github actions this would not work.

If weekly is too noisy we can also just stick to manual releases.
