### PR TITLE
Bump @dapplion/benchmark to 0.2.0

### DIFF
--- a/.benchrc.yaml
+++ b/.benchrc.yaml
@@ -1,0 +1,4 @@
+colors: true
+require:
+  - ts-node/register
+  - packages/lodestar/test/setupBLS.ts

--- a/.mocharc.yaml
+++ b/.mocharc.yaml
@@ -1,2 +1,4 @@
 colors: true
-require: ts-node/register
+require:
+  - ts-node/register
+  - packages/lodestar/test/setupBLS.ts

--- a/.mocharc.yaml
+++ b/.mocharc.yaml
@@ -1,4 +1,3 @@
 colors: true
 require:
   - ts-node/register
-  - packages/lodestar/test/setupBLS.ts

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "check-readme": "lerna run check-readme"
   },
   "devDependencies": {
-    "@dapplion/benchmark": "^0.1.6",
+    "@dapplion/benchmark": "^0.2.0",
     "@types/chai": "4.2.0",
     "@types/chai-as-promised": "^7.1.2",
     "@types/mocha": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:spec-min": "lerna run test:spec-min --no-bail",
     "test:spec-fast": "lerna run test:spec-fast --no-bail",
     "test:spec-main": "lerna run test:spec-main --no-bail",
-    "benchmark": "LODESTAR_PRESET=mainnet NODE_OPTIONS=--max_old_space_size=4096 benchmark 'packages/*/test/perf/**/*.test.ts'",
+    "benchmark": "LODESTAR_PRESET=mainnet NODE_OPTIONS=--max_old_space_size=4096 benchmark -r ./packages/lodestar/test/setupBLS.ts 'packages/*/test/perf/**/*.test.ts'",
     "benchmark:local": "yarn benchmark --local",
     "publish:release": "lerna publish from-package --yes --no-verify-access",
     "release": "lerna version --no-push --sign-git-commit",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:spec-min": "lerna run test:spec-min --no-bail",
     "test:spec-fast": "lerna run test:spec-fast --no-bail",
     "test:spec-main": "lerna run test:spec-main --no-bail",
-    "benchmark": "LODESTAR_PRESET=mainnet NODE_OPTIONS=--max_old_space_size=4096 benchmark -r ./packages/lodestar/test/setupBLS.ts 'packages/*/test/perf/**/*.test.ts'",
+    "benchmark": "LODESTAR_PRESET=mainnet NODE_OPTIONS=--max_old_space_size=4096 benchmark --config .benchrc.yaml 'packages/*/test/perf/**/*.test.ts'",
     "benchmark:local": "yarn benchmark --local",
     "publish:release": "lerna publish from-package --yes --no-verify-access",
     "release": "lerna version --no-push --sign-git-commit",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:spec-min": "lerna run test:spec-min --no-bail",
     "test:spec-fast": "lerna run test:spec-fast --no-bail",
     "test:spec-main": "lerna run test:spec-main --no-bail",
-    "benchmark": "LODESTAR_PRESET=mainnet node --max-old-space-size=4096 -r ts-node/register -r ./packages/lodestar/test/setupBLS.ts ./node_modules/.bin/benchmark 'packages/*/test/perf/**/*.test.ts'",
+    "benchmark": "LODESTAR_PRESET=mainnet NODE_OPTIONS=--max_old_space_size=4096 benchmark 'packages/*/test/perf/**/*.test.ts'",
     "benchmark:local": "yarn benchmark --local",
     "publish:release": "lerna publish from-package --yes --no-verify-access",
     "release": "lerna version --no-push --sign-git-commit",

--- a/packages/beacon-state-transition/test/perf/allForks/util/epochContext.test.ts
+++ b/packages/beacon-state-transition/test/perf/allForks/util/epochContext.test.ts
@@ -22,24 +22,22 @@ describe("epochCtx.getCommitteeAssignments", () => {
     if (state.validators.length !== numValidators) throw Error("constant numValidators is wrong");
   });
 
-  setBenchOpts({
-    maxMs: 10 * 1000,
-    minMs: 5 * 1000,
-    runs: 1024,
-  });
-
-  // Only run for 1000 in CI to ensure performance does not degrade
-  const reqCounts = process.env.CI ? [1000] : [1, 100, 1000];
+  setBenchOpts({maxMs: 10 * 1000});
 
   // the new way of getting attester duties
-  for (const reqCount of reqCounts) {
+  for (const reqCount of [1, 100, 1000]) {
     const validatorCount = numValidators;
     // Space out indexes
     const indexMult = Math.floor(validatorCount / reqCount);
     const indices = Array.from({length: reqCount}, (_, i) => i * indexMult);
 
-    itBench(`getCommitteeAssignments - req ${reqCount} vs - ${validatorCount} vc`, () => {
-      state.epochCtx.getCommitteeAssignments(epoch, indices);
+    itBench({
+      id: `getCommitteeAssignments - req ${reqCount} vs - ${validatorCount} vc`,
+      // Only run for 1000 in CI to ensure performance does not degrade
+      threshold: reqCount < 1000 ? Infinity : undefined,
+      fn: () => {
+        state.epochCtx.getCommitteeAssignments(epoch, indices);
+      },
     });
   }
 });

--- a/packages/beacon-state-transition/test/perf/altair/block/processBlock.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/block/processBlock.test.ts
@@ -65,11 +65,7 @@ import {getBlockAltair} from "../../phase0/block/util";
 //
 
 describe("Process block", () => {
-  setBenchOpts({
-    maxMs: 60 * 1000,
-    minMs: 15 * 1000,
-    runs: 1024,
-  });
+  setBenchOpts({maxMs: 60 * 1000});
 
   if (ACTIVE_PRESET !== PresetName.mainnet) {
     throw Error(`ACTIVE_PRESET ${ACTIVE_PRESET} must be mainnet`);

--- a/packages/beacon-state-transition/test/perf/altair/epoch/epoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/epoch/epoch.test.ts
@@ -3,11 +3,7 @@ import {allForks, altair, CachedBeaconState} from "../../../../src";
 import {generatePerfTestCachedStateAltair, perfStateId} from "../../util";
 
 describe("Altair epoch transition steps", () => {
-  setBenchOpts({
-    maxMs: 60 * 1000,
-    minMs: 15 * 1000,
-    runs: 64,
-  });
+  setBenchOpts({maxMs: 60 * 1000});
 
   const originalState = generatePerfTestCachedStateAltair({goBackOneSlot: true});
   const epochProcess = allForks.beforeProcessEpoch(originalState);

--- a/packages/beacon-state-transition/test/perf/dataStructures/arrayish.test.ts
+++ b/packages/beacon-state-transition/test/perf/dataStructures/arrayish.test.ts
@@ -46,13 +46,7 @@ const ihi = n - 1;
 
 describe("Tree (persistent-merkle-tree)", () => {
   // Don't run on CI
-  if (process.env.CI) return;
-
-  setBenchOpts({
-    maxMs: 10 * 1000,
-    minMs: 1 * 1000,
-    runs: 1024,
-  });
+  setBenchOpts({maxMs: 10 * 1000, skip: Boolean(process.env.CI)});
 
   const d = 40;
   const tree = getTree(d, n);
@@ -119,13 +113,7 @@ describe("Tree (persistent-merkle-tree)", () => {
 
 describe("MutableVector", () => {
   // Don't run on CI
-  if (process.env.CI) return;
-
-  setBenchOpts({
-    maxMs: 10 * 1000,
-    minMs: 1 * 1000,
-    runs: 1024,
-  });
+  setBenchOpts({maxMs: 10 * 1000, skip: Boolean(process.env.CI)});
 
   const items = createArray(n);
   const mutableVector = MutableVector.from(items);
@@ -178,13 +166,7 @@ describe("MutableVector", () => {
 
 describe("Array", () => {
   // Don't run on CI
-  if (process.env.CI) return;
-
-  setBenchOpts({
-    maxMs: 10 * 1000,
-    minMs: 1 * 1000,
-    runs: 1024,
-  });
+  setBenchOpts({maxMs: 10 * 1000, skip: Boolean(process.env.CI)});
 
   const arr = createArray(n);
 

--- a/packages/beacon-state-transition/test/perf/dataStructures/arrayish.test.ts
+++ b/packages/beacon-state-transition/test/perf/dataStructures/arrayish.test.ts
@@ -45,7 +45,7 @@ const ihi = n - 1;
 // ✓ Array 250000 iterate all - loop                                     3009.592 ops/s    332.2710 us/op        -       3006 runs   1.00 s
 
 describe("Tree (persistent-merkle-tree)", () => {
-  // Don't run on CI
+  // Don't track regressions in CI
   setBenchOpts({maxMs: 10 * 1000, skip: Boolean(process.env.CI)});
 
   const d = 40;
@@ -54,7 +54,7 @@ describe("Tree (persistent-merkle-tree)", () => {
   const gihi = toGindex(d, BigInt(ihi));
   const n2 = new LeafNode(Buffer.alloc(32, 2));
 
-  itBench(`Tree ${d} ${n} create`, () => {
+  itBench({id: `Tree ${d} ${n} create`, timeout: 60_000}, () => {
     getTree(d, n);
   });
 
@@ -112,7 +112,7 @@ describe("Tree (persistent-merkle-tree)", () => {
 });
 
 describe("MutableVector", () => {
-  // Don't run on CI
+  // Don't track regressions in CI
   setBenchOpts({maxMs: 10 * 1000, skip: Boolean(process.env.CI)});
 
   const items = createArray(n);
@@ -165,7 +165,7 @@ describe("MutableVector", () => {
 });
 
 describe("Array", () => {
-  // Don't run on CI
+  // Don't track regressions in CI
   setBenchOpts({maxMs: 10 * 1000, skip: Boolean(process.env.CI)});
 
   const arr = createArray(n);

--- a/packages/beacon-state-transition/test/perf/phase0/block/processBlock.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/block/processBlock.test.ts
@@ -67,11 +67,7 @@ import {getBlockPhase0} from "./util";
 //
 
 describe("Process block", () => {
-  setBenchOpts({
-    maxMs: 60 * 1000,
-    minMs: 15 * 1000,
-    runs: 1024,
-  });
+  setBenchOpts({maxMs: 60 * 1000});
 
   if (ACTIVE_PRESET !== PresetName.mainnet) {
     throw Error(`ACTIVE_PRESET ${ACTIVE_PRESET} must be mainnet`);

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.test.ts
@@ -3,11 +3,7 @@ import {allForks, phase0} from "../../../../src";
 import {generatePerfTestCachedStatePhase0, perfStateId} from "../../util";
 
 describe("Phase 0 epoch transition steps", () => {
-  setBenchOpts({
-    maxMs: 60 * 1000,
-    minMs: 15 * 1000,
-    runs: 64,
-  });
+  setBenchOpts({maxMs: 60 * 1000});
 
   const originalState = generatePerfTestCachedStatePhase0({goBackOneSlot: true});
   const epochProcess = allForks.beforeProcessEpoch(originalState);

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/getAttestationDeltas.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/getAttestationDeltas.test.ts
@@ -3,11 +3,7 @@ import {allForks, phase0} from "../../../../src";
 import {generatePerfTestCachedStatePhase0, perfStateId} from "../../util";
 
 describe("getAttestationDeltas", () => {
-  setBenchOpts({
-    maxMs: 60 * 1000,
-    minMs: 15 * 1000,
-    runs: 64,
-  });
+  setBenchOpts({maxMs: 60 * 1000});
 
   const state = generatePerfTestCachedStatePhase0({goBackOneSlot: true});
   const epochProcess = allForks.beforeProcessEpoch(state);

--- a/packages/beacon-state-transition/test/perf/phase0/slot/slots.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/slot/slots.test.ts
@@ -10,11 +10,7 @@ import {allForks} from "../../../../src";
 // process 4 empty epochs                                               0.2250960 ops/s   4.442549e+9 ns/op     10 runs
 
 describe("Epoch transitions", () => {
-  setBenchOpts({
-    maxMs: 60 * 1000,
-    minMs: 15 * 1000,
-    runs: 64,
-  });
+  setBenchOpts({maxMs: 60 * 1000});
 
   const originalState = generatePerfTestCachedStatePhase0({goBackOneSlot: true});
 

--- a/packages/beacon-state-transition/test/perf/shuffle/numberMath.test.ts
+++ b/packages/beacon-state-transition/test/perf/shuffle/numberMath.test.ts
@@ -1,11 +1,7 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
 
 describe.skip("shuffle number math ops", () => {
-  setBenchOpts({
-    maxMs: 10 * 1000,
-    minMs: 1 * 1000,
-    runs: 1024,
-  });
+  setBenchOpts({maxMs: 10 * 1000});
 
   const forRuns = 100e5;
   const j = forRuns / 2;

--- a/packages/beacon-state-transition/test/perf/shuffle/shuffle.test.ts
+++ b/packages/beacon-state-transition/test/perf/shuffle/shuffle.test.ts
@@ -7,11 +7,7 @@ import {unshuffleList} from "../../../src";
 // 4000000  1.5617 s   4.9690 s  (x3)
 
 describe("shuffle list", () => {
-  setBenchOpts({
-    maxMs: 30 * 1000,
-    minMs: 10 * 1000,
-    runs: 512,
-  });
+  setBenchOpts({maxMs: 30 * 1000});
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const seed = new Uint8Array([42, 32]);

--- a/packages/beacon-state-transition/test/perf/util/aggregationBits.test.ts
+++ b/packages/beacon-state-transition/test/perf/util/aggregationBits.test.ts
@@ -5,11 +5,7 @@ import {List, readonlyValues} from "@chainsafe/ssz";
 import {zipIndexesCommitteeBits} from "../../../src";
 
 describe("aggregationBits", () => {
-  setBenchOpts({
-    maxMs: 60 * 1000,
-    minMs: 1 * 1000,
-    runs: 1024,
-  });
+  setBenchOpts({maxMs: 60 * 1000, threshold: Infinity});
 
   const len = MAX_VALIDATORS_PER_COMMITTEE;
   const aggregationBits = Array.from({length: len}, () => true);
@@ -22,13 +18,11 @@ describe("aggregationBits", () => {
   // aggregationBits - 2048 els - zipIndexesInBitList	50.904 us/op	236.17 us/op	0.22
 
   // This benchmark is very unstable in CI. We already know that zipIndexesInBitList is faster
-  if (!process.env.CI) {
-    itBench(`${idPrefix} - readonlyValues`, () => {
-      Array.from(readonlyValues(bitlistTree));
-    });
+  itBench(`${idPrefix} - readonlyValues`, () => {
+    Array.from(readonlyValues(bitlistTree));
+  });
 
-    itBench(`${idPrefix} - zipIndexesInBitList`, () => {
-      zipIndexesCommitteeBits(indexes, bitlistTree);
-    });
-  }
+  itBench(`${idPrefix} - zipIndexesInBitList`, () => {
+    zipIndexesCommitteeBits(indexes, bitlistTree);
+  });
 });

--- a/packages/beacon-state-transition/test/perf/util/rootEquals.test.ts
+++ b/packages/beacon-state-transition/test/perf/util/rootEquals.test.ts
@@ -13,25 +13,18 @@ describe("root equals", () => {
   const stateRoot = fromHexString("0x6c86ca3c4c6688cf189421b8a68bf2dbc91521609965e6f4e207d44347061fee");
   const rootTree = ssz.Root.createTreeBackedFromStruct(stateRoot);
 
-  setBenchOpts({
-    maxMs: 60 * 1000,
-    // This bench is very fast, with 1s it can do 300k runs
-    minMs: 1 * 1000,
-    runs: 1024,
-  });
+  setBenchOpts({maxMs: 60 * 1000, threshold: Infinity});
 
   // This benchmark is very unstable in CI. We already know that "ssz.Root.equals" is the fastest
-  if (!process.env.CI) {
-    itBench("ssz.Root.equals", () => {
-      ssz.Root.equals(rootTree, stateRoot);
-    });
+  itBench("ssz.Root.equals", () => {
+    ssz.Root.equals(rootTree, stateRoot);
+  });
 
-    itBench("ssz.Root.equals with valueOf()", () => {
-      ssz.Root.equals(rootTree.valueOf() as Uint8Array, stateRoot);
-    });
+  itBench("ssz.Root.equals with valueOf()", () => {
+    ssz.Root.equals(rootTree.valueOf() as Uint8Array, stateRoot);
+  });
 
-    itBench("byteArrayEquals with valueOf()", () => {
-      byteArrayEquals(rootTree.valueOf() as Uint8Array, stateRoot);
-    });
-  }
+  itBench("byteArrayEquals with valueOf()", () => {
+    byteArrayEquals(rootTree.valueOf() as Uint8Array, stateRoot);
+  });
 });

--- a/packages/lodestar/test/perf/api/impl/validator/attester.test.ts
+++ b/packages/lodestar/test/perf/api/impl/validator/attester.test.ts
@@ -18,12 +18,6 @@ import {
 // ✓ getPubkeys - persistent - req 100 vs - 200000 vc                    395100.8 ops/s    2.531000 us/op        -     714562 runs   2.05 s
 // ✓ getPubkeys - persistent - req 1000 vs - 200000 vc                   56593.10 ops/s    17.67000 us/op        -     111477 runs   2.00 s
 
-enum Impl {
-  index2pubkey,
-  validatorsArr,
-  persistent,
-}
-
 describe("api / impl / validator", () => {
   let state: ReturnType<typeof generatePerfTestCachedStatePhase0>;
 
@@ -32,48 +26,49 @@ describe("api / impl / validator", () => {
     state = generatePerfTestCachedStatePhase0();
   });
 
-  setBenchOpts({
-    maxMs: 10 * 1000,
-    minMs: 2 * 1000,
-    runs: 1024,
-  });
+  setBenchOpts({maxMs: 10 * 1000});
 
-  // Only run for 1000 in CI to ensure performance does not degrade
   const reqCounts = process.env.CI ? [1000] : [1, 100, 1000];
-  const impls = process.env.CI ? [Impl.persistent] : [Impl.index2pubkey, Impl.validatorsArr, Impl.persistent];
 
-  if (impls.includes(Impl.index2pubkey)) {
-    for (const reqCount of reqCounts) {
-      itBench(`getPubkeys - index2pubkey - req ${reqCount} vs - ${numValidators} vc`, () => {
+  for (const reqCount of reqCounts) {
+    itBench({
+      id: `getPubkeys - index2pubkey - req ${reqCount} vs - ${numValidators} vc`,
+      threshold: Infinity,
+      fn: () => {
         for (let i = 0; i < reqCount; i++) {
           const pubkey = state.index2pubkey[i];
           pubkey.toBytes(PointFormat.compressed);
         }
-      });
-    }
+      },
+    });
   }
 
-  if (impls.includes(Impl.validatorsArr)) {
-    for (const reqCount of reqCounts) {
-      itBench(`getPubkeys - validatorsArr - req ${reqCount} vs - ${numValidators} vc`, () => {
+  for (const reqCount of reqCounts) {
+    itBench({
+      id: `getPubkeys - validatorsArr - req ${reqCount} vs - ${numValidators} vc`,
+      threshold: Infinity,
+      fn: () => {
         for (let i = 0; i < reqCount; i++) {
           const validator = state.validators[i];
           validator.pubkey;
         }
-      });
-    }
+      },
+    });
   }
 
-  if (impls.includes(Impl.persistent)) {
-    for (const reqCount of reqCounts) {
-      itBench(`getPubkeys - persistent - req ${reqCount} vs - ${numValidators} vc`, () => {
+  for (const reqCount of reqCounts) {
+    itBench({
+      id: `getPubkeys - persistent - req ${reqCount} vs - ${numValidators} vc`,
+      // Only track regressions for 1000 in CI to ensure performance does not degrade
+      threshold: reqCount < 1000 ? Infinity : undefined,
+      fn: () => {
         const validators = state.validators.persistent;
         for (let i = 0; i < reqCount; i++) {
           const validator = validators.get(i);
           if (!validator) throw Error(`Index ${i} not found`);
           validator.pubkey;
         }
-      });
-    }
+      },
+    });
   }
 });

--- a/packages/lodestar/test/perf/bls/bls.test.ts
+++ b/packages/lodestar/test/perf/bls/bls.test.ts
@@ -3,11 +3,7 @@ import {bls, PublicKey, SecretKey, Signature} from "@chainsafe/bls";
 import {linspace} from "../../../src/util/numpy";
 
 describe("BLS ops", function () {
-  setBenchOpts({
-    maxMs: 60 * 1000,
-    minMs: 5 * 1000,
-    runs: 1024,
-  });
+  setBenchOpts({maxMs: 60 * 1000});
 
   type Keypair = {publicKey: PublicKey; secretKey: SecretKey};
   type BlsSet = {publicKey: PublicKey; message: Uint8Array; signature: Signature};

--- a/packages/lodestar/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/lodestar/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -16,11 +16,7 @@ import {ssz} from "@chainsafe/lodestar-types";
 // getAttestationsForBlock
 //     ✓ getAttestationsForBlock                                             4.410948 ops/s    226.7086 ms/op        -         64 runs   51.8 s
 describe("getAttestationsForBlock", () => {
-  setBenchOpts({
-    maxMs: 60 * 1000,
-    minMs: 15 * 1000,
-    runs: 64,
-  });
+  setBenchOpts({maxMs: 60 * 1000});
 
   let originalState: allForks.CachedBeaconState<allForks.BeaconState>;
 

--- a/packages/lodestar/test/perf/chain/stateCache/stateContextCheckpointsCache.test.ts
+++ b/packages/lodestar/test/perf/chain/stateCache/stateContextCheckpointsCache.test.ts
@@ -4,16 +4,12 @@ import {allForks, ssz, phase0} from "@chainsafe/lodestar-types";
 import {generateCachedState} from "../../../utils/state";
 import {CheckpointStateCache} from "../../../../src/chain/stateCache";
 
-describe.skip("CheckpointStateCache perf tests", function () {
+describe("CheckpointStateCache perf tests", function () {
   let state: CachedBeaconState<allForks.BeaconState>;
   let checkpoint: phase0.Checkpoint;
   let checkpointStateCache: CheckpointStateCache;
 
-  setBenchOpts({
-    maxMs: 60 * 1000,
-    minMs: 1 * 1000,
-    runs: 1024,
-  });
+  setBenchOpts({maxMs: 10 * 1000, threshold: Infinity});
 
   before(() => {
     checkpointStateCache = new CheckpointStateCache();

--- a/packages/lodestar/test/perf/chain/validation/aggregateAndProof.test.ts
+++ b/packages/lodestar/test/perf/chain/validation/aggregateAndProof.test.ts
@@ -5,11 +5,7 @@ import {generateTestCachedBeaconStateOnlyValidators} from "@chainsafe/lodestar-b
 import {getAggregateAndProofValidData} from "../../../utils/validationData/aggregateAndProof";
 
 describe("validate gossip signedAggregateAndProof", () => {
-  setBenchOpts({
-    maxMs: 60 * 1000,
-    minMs: 2 * 1000,
-    runs: 1024,
-  });
+  setBenchOpts({maxMs: 60 * 1000});
 
   const vc = 64;
   const stateSlot = 100;

--- a/packages/lodestar/test/perf/chain/validation/attestation.test.ts
+++ b/packages/lodestar/test/perf/chain/validation/attestation.test.ts
@@ -5,11 +5,7 @@ import {generateTestCachedBeaconStateOnlyValidators} from "@chainsafe/lodestar-b
 import {getAttestationValidData} from "../../../utils/validationData/attestation";
 
 describe("validate gossip attestation", () => {
-  setBenchOpts({
-    maxMs: 60 * 1000,
-    minMs: 2 * 1000,
-    runs: 1024,
-  });
+  setBenchOpts({maxMs: 60 * 1000});
 
   const vc = 64;
   const stateSlot = 100;

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,10 +521,10 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@dapplion/benchmark@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@dapplion/benchmark/-/benchmark-0.1.6.tgz#d58cc150732a2d743089b9462cdfef9339ef81fa"
-  integrity sha512-qBNXvktHxqnfql2dtjdYqPVj+6OZriuKYNB/ZOdZv58kov9/vEVxFstlXQKCnmxVgC3q4NNmvWXIemTAPZah/A==
+"@dapplion/benchmark@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@dapplion/benchmark/-/benchmark-0.2.0.tgz#0595ac6903e62be918bfc8fb6a557ecb0ded10d5"
+  integrity sha512-fPXqgCdV82uxqg1hxIYoXOSJHYaCOSDdf3AUMM33T21qGdBSjdGUbd4uXkw59Ec7rYNAuoahOTG9Albn9pLkRQ==
   dependencies:
     "@actions/cache" "^1.0.7"
     "@actions/github" "^5.0.0"
@@ -532,7 +532,7 @@
     aws-sdk "^2.932.0"
     csv-parse "^4.16.0"
     csv-stringify "^5.6.2"
-    yargs "^17.0.1"
+    yargs "^17.1.1"
 
 "@eslint/eslintrc@^0.2.1":
   version "0.2.1"
@@ -12220,10 +12220,10 @@ yargs@^16.1.0:
     y18n "^5.0.2"
     yargs-parser "^20.2.2"
 
-yargs@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.0.1.tgz#6a1ced4ed5ee0b388010ba9fd67af83b9362e0bb"
-  integrity sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==
+yargs@^17.1.1:
+  version "17.1.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.1.1.tgz#c2a8091564bdb196f7c0a67c1d12e5b85b8067ba"
+  integrity sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"


### PR DESCRIPTION
**Motivation**

Upgrade to use many new features

**Description**

@tuyennhv @wemeetagain 

Supports:
- `itBench.only`, `ìtBench.skip`
- No need to specify runs, minMs or maxMs unless there's a strong reason to. Now the tool will stop bench-marking when results converge. Only add maxMs if the function to test is very slow and unstable.
- Use the `threshold` option to increase the factor at which a performance difference will be considered a regression. We should benchmark everything but give higher thresholds (or `Infinity`) to those that we don't really want to track but just know.
- Added a `warmUpMs` option to run the function for a bit before benchmarking. Consider increasing if you need higher warm up times.
- Added a `runsFactor`. If a benchmark is like
```ts
itBench("", () => {
  for (let i=0; i<10000; i++) // something
})
```
now you can scale down the results to match that
```ts
itBench({
  id: "", 
  runsFactor: 10000,
  fn: () => {
    for (let i=0; i<10000; i++) // something
  })
```