### PR TITLE
config file is now used to dump finalized options

### DIFF
--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -103,7 +103,7 @@ export const beaconPathsOptions: ICliCommandOptions<IBeaconPaths> = {
   },
 
   configFile: {
-    description: "Beacon node configuration file path",
+    description: "File path to write finalized (non default) Beacon node options",
     defaultDescription: defaultBeaconPaths.configFile,
     type: "string",
   },

--- a/packages/cli/src/cmds/init/handler.ts
+++ b/packages/cli/src/cmds/init/handler.ts
@@ -48,6 +48,8 @@ export async function initializeOptionsAndConfig(args: IBeaconArgs & IGlobalArgs
     }
   }
 
+  beaconNodeOptions.writeTo(beaconPaths.configFile);
+
   // initialize params file, if it doesn't exist
   const config = getBeaconConfigFromArgs(args);
 

--- a/packages/cli/src/cmds/init/handler.ts
+++ b/packages/cli/src/cmds/init/handler.ts
@@ -25,7 +25,7 @@ export type ReturnType = {
  */
 export async function initHandler(args: IBeaconArgs & IGlobalArgs): Promise<ReturnType> {
   const {beaconNodeOptions, config} = await initializeOptionsAndConfig(args);
-  await persistOptionsAndConfig(args, beaconNodeOptions, config);
+  await persistOptionsAndConfig(args, config);
   return {beaconNodeOptions, config};
 }
 
@@ -33,7 +33,6 @@ export async function initializeOptionsAndConfig(args: IBeaconArgs & IGlobalArgs
   const beaconPaths = getBeaconPaths(args);
   const beaconNodeOptions = new BeaconNodeOptions({
     network: args.network || "mainnet",
-    configFile: beaconPaths.configFile,
     beaconNodeOptionsCli: parseBeaconNodeArgs(args),
   });
 
@@ -60,7 +59,6 @@ export async function initializeOptionsAndConfig(args: IBeaconArgs & IGlobalArgs
  */
 export async function persistOptionsAndConfig(
   args: IBeaconArgs & IGlobalArgs,
-  beaconNodeOptions: BeaconNodeOptions,
   beaconConfig: IChainForkConfig
 ): Promise<void> {
   const beaconPaths = getBeaconPaths(args);
@@ -91,10 +89,5 @@ export async function persistOptionsAndConfig(
 
   if (!fs.existsSync(beaconPaths.paramsFile)) {
     writeBeaconParams(beaconPaths.paramsFile, beaconConfig);
-  }
-
-  // initialize beacon configuration file, if it doesn't exist
-  if (!fs.existsSync(beaconPaths.configFile)) {
-    beaconNodeOptions.writeTo(beaconPaths.configFile);
   }
 }

--- a/packages/cli/src/cmds/init/index.ts
+++ b/packages/cli/src/cmds/init/index.ts
@@ -1,10 +1,7 @@
 import {ICliCommand, ICliCommandOptions} from "../../util";
 import {IGlobalArgs} from "../../options";
 import {IBeaconArgs, beaconOptions} from "../beacon/options";
-import {getBeaconPaths} from "../beacon/paths";
 import {initHandler, ReturnType} from "./handler";
-
-const defaultBeaconPathsPyrmont = getBeaconPaths({rootDir: ".pyrmont"});
 
 export {ReturnType};
 
@@ -16,9 +13,7 @@ This step is not required, and should only be used to prepare special configurat
   examples: [
     {
       command: "init --network pyrmont",
-      description:
-        "Initialize a configuration for the Pyrmont testnet. " +
-        `Then, you can edit the config file ${defaultBeaconPathsPyrmont.configFile} to customize your beacon node settings`,
+      description: "Initialize a configuration for the Pyrmont testnet. ",
     },
   ],
   options: beaconOptions as ICliCommandOptions<IBeaconArgs>,

--- a/packages/cli/src/config/beaconNodeOptions.ts
+++ b/packages/cli/src/config/beaconNodeOptions.ts
@@ -2,7 +2,7 @@ import deepmerge from "deepmerge";
 import {Json} from "@chainsafe/ssz";
 import {defaultOptions, IBeaconNodeOptions} from "@chainsafe/lodestar";
 import {isPlainObject, RecursivePartial} from "@chainsafe/lodestar-utils";
-import {writeFile, readFileIfExists} from "../util";
+import {writeFile} from "../util";
 import {getNetworkBeaconNodeOptions, NetworkName} from "../networks";
 
 export class BeaconNodeOptions {
@@ -16,16 +16,13 @@ export class BeaconNodeOptions {
    */
   constructor({
     network,
-    configFile,
     beaconNodeOptionsCli,
   }: {
     network?: NetworkName;
-    configFile?: string;
     beaconNodeOptionsCli: RecursivePartial<IBeaconNodeOptions>;
   }) {
     this.beaconNodeOptions = mergeBeaconNodeOptions(
       network ? getNetworkBeaconNodeOptions(network) : {},
-      configFile ? readBeaconNodeOptionsIfExists(configFile) : {},
       beaconNodeOptionsCli
     );
   }
@@ -55,14 +52,6 @@ export class BeaconNodeOptions {
 
 export function writeBeaconNodeOptions(filename: string, config: Partial<IBeaconNodeOptions>): void {
   writeFile(filename, config as Json);
-}
-
-/**
- * This needs to be a synchronous function because it will be run as part of the yargs 'build' step
- * If the config file is not found, the default values will apply.
- */
-export function readBeaconNodeOptionsIfExists(filepath: string): RecursivePartial<IBeaconNodeOptions> {
-  return readFileIfExists(filepath) || {};
 }
 
 /**

--- a/packages/cli/src/util/file.ts
+++ b/packages/cli/src/util/file.ts
@@ -55,7 +55,12 @@ export function stringify<T = Json>(obj: T, fileFormat: FileFormat): string {
   let contents: string;
   switch (fileFormat) {
     case FileFormat.json:
-      contents = JSON.stringify(obj, null, 2);
+      contents = JSON.stringify(
+        obj,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        (_, _v) => (typeof _v === "bigint" ? _v.toString() : _v),
+        2
+      );
       break;
     case FileFormat.yaml:
     case FileFormat.yml:

--- a/packages/cli/test/unit/config/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/config/beaconNodeOptions.test.ts
@@ -7,7 +7,6 @@ describe("config / beaconNodeOptions", () => {
   it("Should return pyrmont options", () => {
     const beaconNodeOptions = new BeaconNodeOptions({
       network: "pyrmont",
-      configFile: "./no/file",
       beaconNodeOptionsCli: {},
     });
 
@@ -21,7 +20,6 @@ describe("config / beaconNodeOptions", () => {
     const editedPartialOptions = {eth1: {enabled: false}};
 
     const beaconNodeOptions = new BeaconNodeOptions({
-      configFile: "./no/file",
       beaconNodeOptionsCli: initialPartialOptions,
     });
     beaconNodeOptions.set(editedPartialOptions);
@@ -32,7 +30,6 @@ describe("config / beaconNodeOptions", () => {
 
   it("Should return default options", () => {
     const beaconNodeOptions = new BeaconNodeOptions({
-      configFile: "./no/file",
       beaconNodeOptionsCli: {},
     });
 


### PR DESCRIPTION
**Motivation**
Beacon node now will not use configFile to read beacon options, rather the use of--configFile is now to dump finalized beaconNode options, 
even though we discussed logging the options instead of writing them back to file (for inspection/debugging), found  writing to file much cleaner instead of logging the options on the logger. let know if you feel differently. @dapplion @wemeetagain 
<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**
![image](https://user-images.githubusercontent.com/76567250/130604741-5911e9af-9c3b-47d0-a484-3cbf1cb33f6f.png)

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
