### PR TITLE
Adjust sim tests length to match other workflows

### DIFF
--- a/packages/lodestar/test/sim/singleNodeSingleThread.test.ts
+++ b/packages/lodestar/test/sim/singleNodeSingleThread.test.ts
@@ -30,12 +30,9 @@ describe("Run single node single thread interop validators (no eth1) until check
     altairForkEpoch: number;
   }[] = [
     // phase0 fork only
-    {validatorClientCount: 1, validatorsPerClient: 32, event: ChainEvent.justified, altairForkEpoch: Infinity},
     {validatorClientCount: 1, validatorsPerClient: 32, event: ChainEvent.finalized, altairForkEpoch: Infinity},
     // altair fork only
     {validatorClientCount: 1, validatorsPerClient: 32, event: ChainEvent.finalized, altairForkEpoch: 0},
-    // altair fork at epoch 1
-    {validatorClientCount: 1, validatorsPerClient: 32, event: ChainEvent.finalized, altairForkEpoch: 1},
     // altair fork at epoch 2
     {validatorClientCount: 1, validatorsPerClient: 32, event: ChainEvent.finalized, altairForkEpoch: 2},
   ];


### PR DESCRIPTION
**Motivation**

Current workflows length (push / pr):

- Spec tests: 7m 59s / 8m 31s
- Sim test: 12m 16s / 12m 9s
- Tests: 10m 31s / 10m 49s

**Description**

Delete two test cases that are included in the other runs to make the sim tests length similar to "Tests" workflow

- Altair at epoch 1 is tested in altair at epoch 2
- Run to justified checkpoint is included in run to finalized checkpoint