### PR TITLE
github: ensure release script docker job depends on npm job

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -10,8 +10,8 @@ on:
       - master
 
 jobs:
-  publish:
-    name: Publish
+  npm:
+    name: Publish to NPM Registry
     runs-on: ubuntu-latest
     steps:
       # <common-build> - Uses YAML anchors in the future
@@ -64,7 +64,7 @@ jobs:
   docker:
     name: Publish to Docker Hub
     runs-on: ubuntu-latest
-    needs: publish
+    needs: npm
     steps:
       - uses: actions/checkout@v2
       - name: Login to Docker Hub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,4 +124,5 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - run: docker build --tag chainsafe/lodestar:latest --build-arg VERSION=${{ needs.tag.outputs.tag }} .
       - run: docker tag chainsafe/lodestar:latest chainsafe/lodestar:${{ needs.tag.outputs.tag }}
-      - run: docker push chainsafe/lodestar:latest chainsafe/lodestar:${{ needs.tag.outputs.tag }}
+      - run: docker push chainsafe/lodestar:latest
+      - run: docker push chainsafe/lodestar:${{ needs.tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,8 @@ jobs:
       previous_tag: ${{ steps.get-latest-tag.outputs.tag }}
       version: ${{ steps.tag.outputs.version }}
 
-  publish:
-    name: Publish
+  npm:
+    name: Publish to NPM Registry
     runs-on: ubuntu-latest
     needs: tag
     if: needs.tag.outputs.tag != ''
@@ -112,7 +112,7 @@ jobs:
   docker:
     name: Publish to Docker Hub
     runs-on: ubuntu-latest
-    needs: tag
+    needs: npm
     if: needs.tag.outputs.tag != ''
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,5 +124,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - run: docker build --tag chainsafe/lodestar:latest --build-arg VERSION=${{ needs.tag.outputs.tag }} .
       - run: docker tag chainsafe/lodestar:latest chainsafe/lodestar:${{ needs.tag.outputs.tag }}
-      - run: docker push chainsafe/lodestar:latest
-      - run: docker push chainsafe/lodestar:${{ needs.tag.outputs.tag }}
+      - run: |
+          docker tag chainsafe/lodestar:latest chainsafe/lodestar:${{ needs.tag.outputs.tag }}
+          docker push chainsafe/lodestar:latest
+          docker push chainsafe/lodestar:${{ needs.tag.outputs.tag }}

--- a/scripts/await-release.sh
+++ b/scripts/await-release.sh
@@ -13,7 +13,7 @@ declare CMD_NPM="npm view -j $PACKAGE"
 declare VERSION_LATEST=$($CMD_NPM | jq -r '."dist-tags".latest')
 
 # Usage: scripts/await-release.sh $VERSION $TIMEOUT
-declare VERSION_EXPECTED=$1
+declare VERSION_EXPECTED=$(echo $1 | tr -d 'v')
 declare TIMEOUT=$2
 
 declare TIME=0


### PR DESCRIPTION
**Motivation**

ref #2999 - apparently the release job for docker does not depend on npm yet.

**Description**

renamed "publish" to "npm" and made sure that "docker" depends on "npm"

also fixed the await-release script (trim of the "v" from the version string)

also: docker push requires 1 argument 🙄 