### PR TITLE
Altair: precalculate nextEpoch total active balance

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/epochContext.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochContext.ts
@@ -33,7 +33,6 @@ import {
   computeStartSlotAtEpoch,
   getChurnLimit,
   getSeed,
-  getTotalBalance,
   isActiveValidator,
   isAggregatorFromCommitteeLength,
   zipIndexesCommitteeBits,
@@ -299,7 +298,7 @@ export function afterProcessEpoch(state: CachedBeaconState<allForks.BeaconState>
   }
 
   if (currEpoch >= epochCtx.config.ALTAIR_FORK_EPOCH) {
-    const totalActiveBalance = getTotalBalance(state, epochCtx.currentShuffling.activeIndices);
+    const totalActiveBalance = epochProcess.nextEpochTotalActiveBalance;
     epochCtx.syncParticipantReward = computeSyncParticipantReward(epochCtx.config, totalActiveBalance);
     epochCtx.syncProposerReward =
       (epochCtx.syncParticipantReward * PROPOSER_WEIGHT) / (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT);

--- a/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
@@ -101,6 +101,7 @@ export interface IEpochProcess {
   balances?: BigUint64Array;
   // to be used for afterProcessEpoch()
   nextEpochShufflingActiveValidatorIndices: ValidatorIndex[];
+  nextEpochTotalActiveBalance: Gwei;
 }
 
 export function beforeProcessEpoch<T extends allForks.BeaconState>(state: CachedBeaconState<T>): IEpochProcess {
@@ -263,7 +264,8 @@ export function beforeProcessEpoch<T extends allForks.BeaconState>(state: Cached
     indicesEligibleForActivation,
     indicesToEject,
     nextEpochShufflingActiveValidatorIndices,
-
+    // to be updated in processEffectiveBalanceUpdates
+    nextEpochTotalActiveBalance: BigInt(0),
     statuses,
     validators,
   };

--- a/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
@@ -99,8 +99,27 @@ export interface IEpochProcess {
   statuses: IAttesterStatus[];
   validators: phase0.Validator[];
   balances?: BigUint64Array;
-  // to be used for afterProcessEpoch()
+  /**
+   * Active validator indices for currentEpoch + 2.
+   * This is only used in `afterProcessEpoch` to compute epoch shuffling, it's not efficient to calculate it at that time
+   * since it requires 1 loop through validator.
+   * | epoch process fn                 | nextEpochTotalActiveBalance action |
+   * | -------------------------------- | ---------------------------------- |
+   * | beforeProcessEpoch               | calculate during the validator loop|
+   * | afterEpochProcess                | read it                            |
+   */
   nextEpochShufflingActiveValidatorIndices: ValidatorIndex[];
+  /**
+   * Altair specific, this is total active balances for the next epoch.
+   * This is only used in `afterProcessEpoch` to compute base reward and sync participant reward.
+   * It's not efficient to calculate it at that time since it requires looping through all active validators,
+   * so we should calculate it during `processEffectiveBalancesUpdate` which gives us updated effective balance.
+   * | epoch process fn                 | nextEpochTotalActiveBalance action |
+   * | -------------------------------- | ---------------------------------- |
+   * | beforeProcessEpoch               | initialize as BigInt(0)            |
+   * | processEffectiveBalancesUpdate   | calculate during the loop          |
+   * | afterEpochProcess                | read it                            |
+   */
   nextEpochTotalActiveBalance: Gwei;
 }
 


### PR DESCRIPTION
**Motivation**

We calculate total active balance for altair in `afterProcessEpoch` while we do some loops during processing epoch

**Description**

Inside `processEffectiveBalanceUpdates`, precalculate next epoch's total active balance if it's altair.