### PR TITLE
Remove postinstall script

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,7 +35,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-fermium
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile --ignore-optional
+        run: yarn install --frozen-lockfile --ignore-optional && yarn build
       - name: Build
         run: yarn build
         if: steps.cache-deps.outputs.cache-hit == 'true'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-fermium
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile --ignore-optional
+        run: yarn install --frozen-lockfile --ignore-optional && yarn build
       - name: Build
         run: yarn build
         if: steps.cache-deps.outputs.cache-hit == 'true'

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -32,7 +32,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-fermium
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile --ignore-optional
+        run: yarn install --frozen-lockfile --ignore-optional && yarn build
       - name: Build
         run: yarn build
         if: steps.cache-deps.outputs.cache-hit == 'true'

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -5,7 +5,7 @@ concurrency:
 
 on:
   schedule:
-    - cron: '23 4 * * WED'
+    - cron: "23 4 * * WED"
 
 jobs:
   prepare:
@@ -49,7 +49,7 @@ jobs:
           --no-git-tag-version --no-push
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile --ignore-optional
+        run: yarn install --frozen-lockfile --ignore-optional && yarn build
       - name: Build
         run: yarn build
         if: steps.cache-deps.outputs.cache-hit == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-fermium
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile --ignore-optional
+        run: yarn install --frozen-lockfile --ignore-optional && yarn build
       - name: Build
         run: yarn build
         if: steps.cache-deps.outputs.cache-hit == 'true'

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -22,7 +22,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-fermium
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile --ignore-optional
+        run: yarn install --frozen-lockfile --ignore-optional && yarn build
       - name: Build
         run: yarn build
         if: steps.cache-deps.outputs.cache-hit == 'true'

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -24,7 +24,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-fermium
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile && yarn build
       - name: Build
         run: yarn build
         if: steps.cache-deps.outputs.cache-hit == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-fermium
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile --ignore-optional
+        run: yarn install --frozen-lockfile --ignore-optional && yarn build
       - name: Build
         run: yarn build
         if: steps.cache-deps.outputs.cache-hit == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 # Getting Started
 
 - Run `lerna bootstrap` or `yarn install` to install dependencies
-- NOTE: By default the spec tests (5GB) will be installed with other dependencies. If you would like to avoid downloading the spec tests, instead run `yarn install --ignore-optional`.
+- Run `yarn build` to build lib from source
 
 # Tests
 

--- a/docker/from_source.Dockerfile
+++ b/docker/from_source.Dockerfile
@@ -28,7 +28,7 @@ COPY package.json yarn.lock ./
 RUN yarn install --non-interactive --frozen-lockfile --ignore-scripts
 
 COPY . .
-RUN yarn install --non-interactive --frozen-lockfile
+RUN yarn install --non-interactive --frozen-lockfile && yarn build
 
 # Copy built src + node_modules to a new layer to prune unnecessary fs
 # Previous layer weights 7.25GB, while this final 488MB (as of Oct 2020)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,7 +50,9 @@ Install globally
 ```
 npm install -g @chainsafe/lodestar-cli
 ```
+
 or
+
 ```
 yarn global add @chainsafe/lodestar-cli
 ```
@@ -75,6 +77,7 @@ Ensure you have Docker installed by issuing the command:
 ```bash
 docker -v
 ```
+
 It should return a non error message such as `Docker version xxxx, build xxxx`.
 
 Pull, run the image and Lodestar should now be ready to use

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "packages/*"
   ],
   "scripts": {
-    "postinstall": "yarn build",
     "clean": "rm -rf ./packages/*/lib ./packages/*/*.tsbuildinfo",
     "build": "yarn clean && lerna run build",
     "build:docs": "lerna run build:typedocs && lerna run build:refdocs && ./scripts/prepare-docs.sh",


### PR DESCRIPTION
**Motivation**

Everytime I install a library or rebuild dependencies after switching node versions, the postinstall script catches me by surprise and triggers a full build of the codebase. This is very annoying personally and would rather have the control to decide when to install and when to build.

**Description**

- Remove postinstall script
- Updated docs with additional instruction
- Update workflows to install && build