### PR TITLE
Add more state cache metrics

### DIFF
--- a/packages/api/src/routes/lodestar.ts
+++ b/packages/api/src/routes/lodestar.ts
@@ -48,6 +48,10 @@ export type BlockProcessorQueueItem = {
 export type StateCacheItem = {
   slot: Slot;
   root: Uint8Array;
+  /** Total number of reads */
+  reads: number;
+  /** Unix timestamp (ms) of the last read */
+  lastRead: number;
 };
 
 export type Api = {

--- a/packages/lodestar/src/api/impl/lodestar/index.ts
+++ b/packages/lodestar/src/api/impl/lodestar/index.ts
@@ -121,19 +121,11 @@ export function getLodestarApi({
     },
 
     async getStateCacheItems() {
-      const states = (chain as BeaconChain)["stateCache"]["cache"].values();
-      return Array.from(states).map((state) => ({
-        slot: state.slot,
-        root: state.hashTreeRoot(),
-      }));
+      return (chain as BeaconChain)["stateCache"].dumpSummary();
     },
 
     async getCheckpointStateCacheItems() {
-      const states = (chain as BeaconChain)["checkpointStateCache"]["cache"].values();
-      return Array.from(states).map((state) => ({
-        slot: state.slot,
-        root: state.hashTreeRoot(),
-      }));
+      return (chain as BeaconChain)["checkpointStateCache"].dumpSummary();
     },
   };
 }

--- a/packages/lodestar/src/chain/stateCache/mapMetrics.ts
+++ b/packages/lodestar/src/chain/stateCache/mapMetrics.ts
@@ -1,0 +1,52 @@
+import {IAvgMinMax} from "../../metrics";
+
+type MapTrackerMetrics = {
+  reads: IAvgMinMax;
+  secondsSinceLastRead: IAvgMinMax;
+};
+
+export class MapTracker<K, V> extends Map<K, V> {
+  /** Tracks the number of reads each entry in the cache gets for metrics */
+  readonly readCount = new Map<K, number>();
+  /** Tracks the last time a state was read from the cache */
+  readonly lastRead = new Map<K, number>();
+
+  constructor(metrics?: MapTrackerMetrics) {
+    super();
+    if (metrics) {
+      metrics.reads.addGetValuesFn(() => Array.from(this.readCount.values()));
+      metrics.secondsSinceLastRead.addGetValuesFn(() => {
+        const now = Date.now();
+        const secondsSinceLastRead: number[] = [];
+        for (const lastRead of this.lastRead.values()) {
+          secondsSinceLastRead.push((now - lastRead) / 1000);
+        }
+        return secondsSinceLastRead;
+      });
+    }
+  }
+
+  get(key: K): V | undefined {
+    const value = super.get(key);
+    if (value !== undefined) {
+      this.readCount.set(key, 1 + (this.readCount.get(key) ?? 0));
+      this.lastRead.set(key, Date.now());
+    }
+    return value;
+  }
+
+  delete(key: K): boolean {
+    const deleted = super.delete(key);
+    if (deleted) {
+      this.readCount.delete(key);
+      this.lastRead.delete(key);
+    }
+    return deleted;
+  }
+
+  clear(): void {
+    super.clear();
+    this.readCount.clear();
+    this.lastRead.clear();
+  }
+}

--- a/packages/lodestar/src/chain/stateCache/stateContextCache.ts
+++ b/packages/lodestar/src/chain/stateCache/stateContextCache.ts
@@ -2,8 +2,9 @@ import {ByteVector, toHexString} from "@chainsafe/ssz";
 import {Epoch, allForks} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {IMetrics} from "../../metrics";
+import {MapTracker} from "./mapMetrics";
 
-const MAX_STATES = 96;
+const MAX_STATES = 3 * 32;
 /**
  * In memory cache of CachedBeaconState
  *
@@ -13,28 +14,29 @@ export class StateContextCache {
   /**
    * Max number of states allowed in the cache
    */
-  maxStates: number;
+  readonly maxStates: number;
 
-  private cache = new Map<string, CachedBeaconState<allForks.BeaconState>>();
+  private readonly cache: MapTracker<string, CachedBeaconState<allForks.BeaconState>>;
   /** Epoch -> Set<blockRoot> */
-  private epochIndex = new Map<Epoch, Set<string>>();
-  private metrics: IMetrics | null | undefined;
+  private readonly epochIndex = new Map<Epoch, Set<string>>();
+  private readonly metrics: IMetrics["stateCache"] | null | undefined;
 
   constructor({maxStates = MAX_STATES, metrics}: {maxStates?: number; metrics?: IMetrics | null}) {
     this.maxStates = maxStates;
+    this.cache = new MapTracker(metrics?.stateCache);
     if (metrics) {
-      this.metrics = metrics;
-      metrics.stateCacheSize.addCollect(() => metrics.stateCacheSize.set(this.cache.size));
+      this.metrics = metrics.stateCache;
+      metrics.stateCache.size.addCollect(() => metrics.stateCache.size.set(this.cache.size));
     }
   }
 
   get(root: ByteVector): CachedBeaconState<allForks.BeaconState> | null {
-    this.metrics?.stateCacheLookups.inc();
+    this.metrics?.lookups.inc();
     const item = this.cache.get(toHexString(root));
     if (!item) {
       return null;
     }
-    this.metrics?.stateCacheHits.inc();
+    this.metrics?.hits.inc();
     return item.clone();
   }
 
@@ -43,7 +45,7 @@ export class StateContextCache {
     if (this.cache.get(key)) {
       return;
     }
-    this.metrics?.stateCacheAdds.inc();
+    this.metrics?.adds.inc();
     this.cache.set(key, item.clone());
     const epoch = item.epochCtx.currentShuffling.epoch;
     const blockRoots = this.epochIndex.get(epoch);
@@ -104,6 +106,16 @@ export class StateContextCache {
         this.deleteAllEpochItems(epoch);
       }
     }
+  }
+
+  /** ONLY FOR DEBUGGING PURPOSES. For lodestar debug API */
+  dumpSummary(): {slot: number; root: Uint8Array; reads: number; lastRead: number}[] {
+    return Array.from(this.cache.entries()).map(([key, state]) => ({
+      slot: state.slot,
+      root: state.hashTreeRoot(),
+      reads: this.cache.readCount.get(key) ?? 0,
+      lastRead: this.cache.lastRead.get(key) ?? 0,
+    }));
   }
 
   private deleteAllEpochItems(epoch: Epoch): void {

--- a/packages/lodestar/src/metrics/interface.ts
+++ b/packages/lodestar/src/metrics/interface.ts
@@ -5,3 +5,8 @@ export type IGauge<T extends string = string> = Pick<Gauge<T>, "inc" | "set"> & 
 };
 
 export type IHistogram<T extends string = string> = Pick<Histogram<T>, "observe" | "startTimer">;
+
+export type IAvgMinMax = {
+  addGetValuesFn(getValuesFn: () => number[]): void;
+  set(values: number[]): void;
+};

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -404,44 +404,66 @@ export function createLodestarMetrics(
         labelNames: ["index", "src"],
       }),
     },
-    //regen metrics
-    stateCacheLookups: register.gauge({
-      name: "state_cache_lookups_total",
-      help: "Number of cache lookup",
-    }),
-    stateCacheHits: register.gauge({
-      name: "state_cache_hits_total",
-      help: "Number of total cache hits",
-    }),
-    stateCacheAdds: register.gauge({
-      name: "state_cache_adds_total",
-      help: "Number of items added in state cache",
-    }),
-    stateCacheSize: register.gauge({
-      name: "state_cache_size",
-      help: "State cache size",
-    }),
 
-    cpStateCacheLookups: register.gauge({
-      name: "cp_state_cache_lookups_total",
-      help: "Number of checkpoint cache lookup",
-    }),
-    cpStateCacheHits: register.gauge({
-      name: "cp_state_cache_hits_total",
-      help: "Number of checkpoint cache hits",
-    }),
-    cpStateCacheAdds: register.gauge({
-      name: "cp_state_cache_adds_total",
-      help: "Number of items added in checkpoint state cache",
-    }),
-    cpStateCacheSize: register.gauge({
-      name: "cp_state_cache_size",
-      help: "Checkpoint state cache size",
-    }),
-    cpStateEpochSize: register.gauge({
-      name: "cp_state_epoch_size",
-      help: "Checkpoint state cache size",
-    }),
+    // regen metrics
+
+    stateCache: {
+      lookups: register.gauge({
+        name: "state_cache_lookups_total",
+        help: "Number of cache lookup",
+      }),
+      hits: register.gauge({
+        name: "state_cache_hits_total",
+        help: "Number of total cache hits",
+      }),
+      adds: register.gauge({
+        name: "state_cache_adds_total",
+        help: "Number of items added in state cache",
+      }),
+      size: register.gauge({
+        name: "state_cache_size",
+        help: "State cache size",
+      }),
+      reads: register.avgMinMax({
+        name: "state_cache_reads",
+        help: "Avg min max of all state cache items total read count",
+      }),
+      secondsSinceLastRead: register.avgMinMax({
+        name: "state_cache_seconds_since_last_read",
+        help: "Avg min max of all state cache items seconds since last reads",
+      }),
+    },
+
+    cpStateCache: {
+      lookups: register.gauge({
+        name: "cp_state_cache_lookups_total",
+        help: "Number of checkpoint cache lookup",
+      }),
+      hits: register.gauge({
+        name: "cp_state_cache_hits_total",
+        help: "Number of checkpoint cache hits",
+      }),
+      adds: register.gauge({
+        name: "cp_state_cache_adds_total",
+        help: "Number of items added in checkpoint state cache",
+      }),
+      size: register.gauge({
+        name: "cp_state_cache_size",
+        help: "Checkpoint state cache size",
+      }),
+      epochSize: register.gauge({
+        name: "cp_state_epoch_size",
+        help: "Checkpoint state cache size",
+      }),
+      reads: register.avgMinMax({
+        name: "cp_state_epoch_reads",
+        help: "Avg min max of all state cache items total read count",
+      }),
+      secondsSinceLastRead: register.avgMinMax({
+        name: "cp_state_epoch_seconds_since_last_read",
+        help: "Avg min max of all state cache items seconds since last reads",
+      }),
+    },
 
     regenFnCallTotal: register.gauge<"entrypoint" | "caller">({
       name: "regen_fn_call_total",

--- a/packages/lodestar/src/metrics/utils/avgMinMax.ts
+++ b/packages/lodestar/src/metrics/utils/avgMinMax.ts
@@ -1,0 +1,69 @@
+import {GaugeConfiguration} from "prom-client";
+import {GaugeExtra} from "./gauge";
+
+type GetValuesFn = () => number[];
+
+/**
+ * Special non-standard "Histogram" that captures the avg, min and max of values
+ */
+export class AvgMinMax<T extends string> {
+  private readonly avg: GaugeExtra<string>;
+  private readonly min: GaugeExtra<string>;
+  private readonly max: GaugeExtra<string>;
+
+  private getValuesFn: GetValuesFn | null = null;
+
+  constructor(configuration: GaugeConfiguration<T>) {
+    this.avg = new GaugeExtra({...configuration, name: `${configuration.name}_avg`});
+    this.min = new GaugeExtra({...configuration, name: `${configuration.name}_min`});
+    this.max = new GaugeExtra({...configuration, name: `${configuration.name}_max`});
+  }
+
+  addGetValuesFn(getValuesFn: GetValuesFn): void {
+    if (this.getValuesFn === null) {
+      this.getValuesFn = getValuesFn;
+
+      this.avg.addCollect(this.onCollect);
+    } else {
+      throw Error("Already registered a getValuesFn");
+    }
+  }
+
+  set(values: number[]): void {
+    const {avg, min, max} = getStats(values);
+    this.avg.set(avg);
+    this.min.set(min);
+    this.max.set(max);
+  }
+
+  private onCollect = (): void => {
+    if (this.getValuesFn !== null) {
+      this.set(this.getValuesFn());
+    }
+  };
+}
+
+type ArrStatistics = {
+  avg: number;
+  min: number;
+  max: number;
+};
+
+function getStats(values: number[]): ArrStatistics {
+  if (values.length < 1) {
+    return {avg: 0, min: 0, max: 0};
+  }
+
+  let min = values[0];
+  let max = values[0];
+  let total = values[0];
+
+  for (let i = 1; i < values.length; i++) {
+    const val = values[i];
+    if (val < min) min = val;
+    if (val > max) max = val;
+    total += val;
+  }
+
+  return {avg: total / values.length, min, max};
+}

--- a/packages/lodestar/src/metrics/utils/registryMetricCreator.ts
+++ b/packages/lodestar/src/metrics/utils/registryMetricCreator.ts
@@ -1,4 +1,5 @@
 import {Gauge, GaugeConfiguration, Registry, HistogramConfiguration} from "prom-client";
+import {AvgMinMax} from "./avgMinMax";
 import {GaugeExtra} from "./gauge";
 import {HistogramExtra} from "./histogram";
 
@@ -15,6 +16,10 @@ export class RegistryMetricCreator extends Registry {
 
   histogram<T extends string>(configuration: HistogramConfiguration<T>): HistogramExtra<T> {
     return new HistogramExtra<T>({...configuration, registers: [this]});
+  }
+
+  avgMinMax<T extends string>(configuration: GaugeConfiguration<T>): AvgMinMax<T> {
+    return new AvgMinMax<T>({...configuration, registers: [this]});
   }
 
   /** Static metric to send string-based data such as versions, config params, etc */


### PR DESCRIPTION
**Motivation**

To understand our cache strategy and behavior better I would like to know:
- How often are specific states read?
- When are these states read?
- How useful are old states?



**Description**

To answer this questions I've extended the cache data structure to register the total count of reads per cache item + the last timestamp it was read.

Expose the data in two ways:
- API: Dump the read count + last read for each cache item
- Metrics: Track avg, min, max of total read counts + time since last read

A new metric class `AvgMinMax` acts as a sort of histogram on demand that only tracks those three statistics, instead of multiple precentiles. The plan is to render it as bands, see https://grafana.com/blog/2021/02/10/how-the-new-time-series-panel-brings-major-performance-improvements-and-new-visualization-features-to-grafana-7.4/

![Screenshot from 2021-08-28 16-19-14](https://user-images.githubusercontent.com/35266934/131220976-852e9ab3-932a-4526-b3c7-b818a5f450a6.png)

![Screenshot from 2021-08-28 16-33-08](https://user-images.githubusercontent.com/35266934/131221420-04bfbb57-4241-4bb6-bb14-ff589969c3d2.png)
