### PR TITLE
github: fix publish tag variable

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -51,7 +51,6 @@ jobs:
           --preid dev
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Get version
         id: version
         run: |
@@ -72,5 +71,5 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - run: docker build --tag chainsafe/lodestar:next --build-arg VERSION=${{ needs.publish.outputs.version }} .
+      - run: docker build --tag chainsafe/lodestar:next --build-arg VERSION=${{ needs.npm.outputs.version }} .
       - run: docker push chainsafe/lodestar:next

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-
       - name: Get latest tag
+        id: get-latest-tag
         uses: actions-ecosystem/action-get-latest-tag@v1
         with:
           with_initial_version: false
-        id: get-latest-tag
-
       - name: Create tag
         id: tag
         uses: butlerlogic/action-autotag@1.1.2
@@ -98,7 +96,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      #in case of failure
+      # In case of failure
       - name: Rollback on failure
         if: failure()
         uses: author/action-rollback@9ec72a6af74774e00343c6de3e946b0901c23013
@@ -112,7 +110,7 @@ jobs:
   docker:
     name: Publish to Docker Hub
     runs-on: ubuntu-latest
-    needs: npm
+    needs: [tag, npm]
     if: needs.tag.outputs.tag != ''
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
**Motivation**

I broke the tag variable when renaming the workflows. 🤦🏼 

**Description**

The jobs depend on `docker` <- `npm` <- `tag`, so I implied that `tag` would be available for `docker`, which is not. `docker` now depends on both `tag, npm`...