### PR TITLE
spec-tests: Use correct fork for state comparisions

### DIFF
--- a/packages/spec-test-runner/test/spec/altair/epoch_processing.test.ts
+++ b/packages/spec-test-runner/test/spec/altair/epoch_processing.test.ts
@@ -6,9 +6,9 @@ import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util";
 import {processParticipationRecordUpdates} from "@chainsafe/lodestar-beacon-state-transition/src/phase0/epoch/processParticipationRecordUpdates";
 import {altair as altairTypes, ssz} from "@chainsafe/lodestar-types";
 import {TreeBacked} from "@chainsafe/ssz";
-import {ACTIVE_PRESET} from "@chainsafe/lodestar-params";
+import {ACTIVE_PRESET, ForkName} from "@chainsafe/lodestar-params";
 import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
-import {expectEqualBeaconStateAltair, inputTypeSszTreeBacked} from "../util";
+import {expectEqualBeaconState, inputTypeSszTreeBacked} from "../util";
 import {IAltairStateTestCase, config} from "./util";
 
 /** Describe with which function to run each directory of tests */
@@ -56,7 +56,7 @@ for (const testDir of fs.readdirSync(rootDir)) {
       },
       getExpected: (testCase) => testCase.post,
       expectFunc: (testCase, expected, actual) => {
-        expectEqualBeaconStateAltair(expected, actual);
+        expectEqualBeaconState(ForkName.altair, expected, actual);
       },
     }
   );

--- a/packages/spec-test-runner/test/spec/altair/fork.test.ts
+++ b/packages/spec-test-runner/test/spec/altair/fork.test.ts
@@ -5,10 +5,10 @@ import {allForks, phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util";
 import {altair} from "@chainsafe/lodestar-beacon-state-transition";
 import {ssz} from "@chainsafe/lodestar-types";
-import {ACTIVE_PRESET} from "@chainsafe/lodestar-params";
+import {ACTIVE_PRESET, ForkName} from "@chainsafe/lodestar-params";
 import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
 import {IBaseSpecTest} from "../type";
-import {expectEqualBeaconStateAltair, inputTypeSszTreeBacked} from "../util";
+import {expectEqualBeaconState, inputTypeSszTreeBacked} from "../util";
 
 describeDirectorySpecTest<IUpgradeStateCase, altair.BeaconState>(
   `${ACTIVE_PRESET}/altair/fork/fork`,
@@ -42,7 +42,7 @@ describeDirectorySpecTest<IUpgradeStateCase, altair.BeaconState>(
     shouldError: (testCase) => !testCase.post,
     getExpected: (testCase) => testCase.post,
     expectFunc: (testCase, expected, actual) => {
-      expectEqualBeaconStateAltair(expected, actual);
+      expectEqualBeaconState(ForkName.altair, expected, actual);
     },
   }
 );

--- a/packages/spec-test-runner/test/spec/altair/operations.test.ts
+++ b/packages/spec-test-runner/test/spec/altair/operations.test.ts
@@ -4,9 +4,9 @@ import {CachedBeaconState, allForks, altair} from "@chainsafe/lodestar-beacon-st
 import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util";
 import {phase0, ssz} from "@chainsafe/lodestar-types";
 import {TreeBacked} from "@chainsafe/ssz";
-import {ACTIVE_PRESET} from "@chainsafe/lodestar-params";
+import {ACTIVE_PRESET, ForkName} from "@chainsafe/lodestar-params";
 import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
-import {expectEqualBeaconStateAltair, inputTypeSszTreeBacked} from "../util";
+import {expectEqualBeaconState, inputTypeSszTreeBacked} from "../util";
 import {IAltairStateTestCase, config} from "./util";
 import {IBaseSpecTest} from "../type";
 
@@ -83,7 +83,7 @@ for (const testDir of fs.readdirSync(rootDir)) {
       shouldError: (testCase) => !testCase.post,
       getExpected: (testCase) => testCase.post,
       expectFunc: (testCase, expected, actual) => {
-        expectEqualBeaconStateAltair(expected, actual);
+        expectEqualBeaconState(ForkName.altair, expected, actual);
       },
     }
   );

--- a/packages/spec-test-runner/test/spec/altair/transition.test.ts
+++ b/packages/spec-test-runner/test/spec/altair/transition.test.ts
@@ -7,7 +7,7 @@ import {ForkName, ACTIVE_PRESET} from "@chainsafe/lodestar-params";
 import {TreeBacked} from "@chainsafe/ssz";
 import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
 import {IBaseSpecTest} from "../type";
-import {expectEqualBeaconStateAltair, inputTypeSszTreeBacked} from "../util";
+import {expectEqualBeaconState, inputTypeSszTreeBacked} from "../util";
 
 describeDirectorySpecTest<ITransitionTestCase, allForks.BeaconState>(
   `${ACTIVE_PRESET}/altair/transition`,
@@ -52,7 +52,7 @@ describeDirectorySpecTest<ITransitionTestCase, allForks.BeaconState>(
     timeout: 10000,
     getExpected: (testCase) => testCase.post,
     expectFunc: (testCase, expected, actual) => {
-      expectEqualBeaconStateAltair(expected, actual);
+      expectEqualBeaconState(ForkName.altair, expected, actual);
     },
   }
 );

--- a/packages/spec-test-runner/test/spec/phase0/epoch_processing.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/epoch_processing.test.ts
@@ -6,9 +6,9 @@ import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util";
 import {processParticipationRecordUpdates} from "@chainsafe/lodestar-beacon-state-transition/src/phase0/epoch/processParticipationRecordUpdates";
 import {ssz} from "@chainsafe/lodestar-types";
 import {TreeBacked} from "@chainsafe/ssz";
-import {ACTIVE_PRESET, PresetName} from "@chainsafe/lodestar-params";
+import {ACTIVE_PRESET, ForkName, PresetName} from "@chainsafe/lodestar-params";
 import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
-import {expectEqualBeaconStateAltair, inputTypeSszTreeBacked} from "../util";
+import {expectEqualBeaconState, inputTypeSszTreeBacked} from "../util";
 import {IPhase0StateTestCase, config} from "./util";
 
 /** Describe with which function to run each directory of tests */
@@ -53,7 +53,7 @@ for (const testDir of fs.readdirSync(rootDir)) {
       },
       getExpected: (testCase) => testCase.post,
       expectFunc: (testCase, expected, actual) => {
-        expectEqualBeaconStateAltair(expected, actual);
+        expectEqualBeaconState(ForkName.phase0, expected, actual);
       },
       shouldSkip: (testCase, n) =>
         // TODO: All the tests below fail with the same error

--- a/packages/spec-test-runner/test/spec/phase0/operations.test.ts
+++ b/packages/spec-test-runner/test/spec/phase0/operations.test.ts
@@ -4,9 +4,9 @@ import {CachedBeaconState, allForks, phase0} from "@chainsafe/lodestar-beacon-st
 import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util";
 import {ssz} from "@chainsafe/lodestar-types";
 import {TreeBacked} from "@chainsafe/ssz";
-import {ACTIVE_PRESET} from "@chainsafe/lodestar-params";
+import {ACTIVE_PRESET, ForkName} from "@chainsafe/lodestar-params";
 import {SPEC_TEST_LOCATION} from "../../utils/specTestCases";
-import {expectEqualBeaconStateAltair, inputTypeSszTreeBacked} from "../util";
+import {expectEqualBeaconState, inputTypeSszTreeBacked} from "../util";
 import {IPhase0StateTestCase, config} from "./util";
 import {IBaseSpecTest} from "../type";
 
@@ -72,7 +72,7 @@ for (const testDir of fs.readdirSync(rootDir)) {
       shouldError: (testCase) => !testCase.post,
       getExpected: (testCase) => testCase.post,
       expectFunc: (testCase, expected, actual) => {
-        expectEqualBeaconStateAltair(expected, actual);
+        expectEqualBeaconState(ForkName.phase0, expected, actual);
       },
     }
   );

--- a/packages/spec-test-runner/test/spec/util.ts
+++ b/packages/spec-test-runner/test/spec/util.ts
@@ -1,23 +1,8 @@
 import {expect} from "chai";
-import {allForks, altair, phase0, ssz} from "@chainsafe/lodestar-types";
+import {allForks, ssz} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 import {InputType} from "@chainsafe/lodestar-spec-test-util";
-
-/** Compare each field in BeaconState to help debug failed test easier. */
-export function expectEqualBeaconStatePhase0(expected: phase0.BeaconState, actual: phase0.BeaconState): void {
-  if (!ssz.phase0.BeaconState.equals(actual, expected)) {
-    expect(ssz.phase0.BeaconState.toJson(actual)).to.deep.equal(ssz.phase0.BeaconState.toJson(expected));
-    throw Error("Wrong state");
-  }
-}
-
-/** Compare each field in BeaconState to help debug failed test easier. */
-export function expectEqualBeaconStateAltair(expected: altair.BeaconState, actual: altair.BeaconState): void {
-  if (!ssz.altair.BeaconState.equals(actual, expected)) {
-    expect(ssz.altair.BeaconState.toJson(actual)).to.deep.equal(ssz.altair.BeaconState.toJson(expected));
-    throw Error("Wrong state");
-  }
-}
+import {ContainerType} from "@chainsafe/ssz";
 
 /** Compare each field in BeaconState to help debug failed test easier. */
 export function expectEqualBeaconState(
@@ -25,11 +10,10 @@ export function expectEqualBeaconState(
   expected: allForks.BeaconState,
   actual: allForks.BeaconState
 ): void {
-  switch (fork) {
-    case ForkName.phase0:
-      return expectEqualBeaconStatePhase0(expected as phase0.BeaconState, actual as phase0.BeaconState);
-    case ForkName.altair:
-      return expectEqualBeaconStateAltair(expected as altair.BeaconState, actual as altair.BeaconState);
+  const stateType = ssz[fork].BeaconState as ContainerType<allForks.BeaconState>;
+  if (!stateType.equals(actual, expected)) {
+    expect(stateType.toJson(actual)).to.deep.equal(stateType.toJson(expected));
+    throw Error("Wrong state");
   }
 }
 


### PR DESCRIPTION
**Motivation**

phase0 spec tests are using the altair BeaconState type

**Description**

Use fork variable to pick correct BeaconState type