### PR TITLE
Fix hashing perf test

### DIFF
--- a/packages/beacon-state-transition/test/perf/allForks/hashing.test.ts
+++ b/packages/beacon-state-transition/test/perf/allForks/hashing.test.ts
@@ -14,7 +14,7 @@ describe("BeaconState hashTreeRoot", () => {
   before(function () {
     this.timeout(300_000);
     const {pubkeys} = getPubkeys();
-    stateOg = ssz.phase0.BeaconState.createTreeBacked(generatePerformanceStatePhase0(pubkeys).tree);
+    stateOg = generatePerformanceStatePhase0(pubkeys);
     stateOg.hashTreeRoot();
 
     for (let i = 0; i < vc; i++) indicesShuffled[i] = i;

--- a/packages/beacon-state-transition/test/perf/allForks/hashing.test.ts
+++ b/packages/beacon-state-transition/test/perf/allForks/hashing.test.ts
@@ -14,7 +14,7 @@ describe("BeaconState hashTreeRoot", () => {
   before(function () {
     this.timeout(300_000);
     const {pubkeys} = getPubkeys();
-    stateOg = generatePerformanceStatePhase0(pubkeys);
+    stateOg = ssz.phase0.BeaconState.createTreeBacked(generatePerformanceStatePhase0(pubkeys).tree);
     stateOg.hashTreeRoot();
 
     for (let i = 0; i < vc; i++) indicesShuffled[i] = i;
@@ -35,35 +35,32 @@ describe("BeaconState hashTreeRoot", () => {
 
   // Validator mutations
   for (const count of [1, 32, 512]) {
-    const idxs = indicesShuffled.slice(0, count);
     testCases.push({
       id: `${count} full validator`,
       noTrack: count < 512,
       fn: (state) => {
-        for (const i of idxs) state.validators[i] = validator;
+        for (const i of indicesShuffled.slice(0, count)) state.validators[i] = validator;
       },
     });
   }
 
   for (const count of [1, 32, 512]) {
-    const idxs = indicesShuffled.slice(0, count);
     testCases.push({
       id: `${count} validator.effectiveBalance`,
       noTrack: count < 512,
       fn: (state) => {
-        for (const i of idxs) state.validators[i].effectiveBalance = balance;
+        for (const i of indicesShuffled.slice(0, count)) state.validators[i].effectiveBalance = balance;
       },
     });
   }
 
   // Balance mutations
   for (const count of [1, 32, 512, numValidators]) {
-    const idxs = indicesShuffled.slice(0, count);
     testCases.push({
       id: `${count} balances`,
       noTrack: count < 512,
       fn: (state) => {
-        for (const i of idxs) state.balances[i] = balance;
+        for (const i of indicesShuffled.slice(0, count)) state.balances[i] = balance;
       },
     });
   }

--- a/packages/beacon-state-transition/test/perf/allForks/hashing.test.ts
+++ b/packages/beacon-state-transition/test/perf/allForks/hashing.test.ts
@@ -73,8 +73,9 @@ describe("state hashTreeRoot", () => {
       id: `state hashTreeRoot - ${id}`,
       noThreshold: noTrack,
       beforeEach: () => {
-        fn(stateOg);
-        return stateOg;
+        const state = stateOg.clone();
+        fn(state);
+        return state;
       },
       fn: (state) => {
         state.hashTreeRoot();

--- a/packages/beacon-state-transition/test/perf/allForks/hashing.test.ts
+++ b/packages/beacon-state-transition/test/perf/allForks/hashing.test.ts
@@ -6,7 +6,7 @@ import {unshuffleList} from "../../../src";
 
 // Test cost of hashing state after some modifications
 
-describe("state hashTreeRoot", () => {
+describe("BeaconState hashTreeRoot", () => {
   const vc = numValidators;
   const indicesShuffled: number[] = [];
   let stateOg: TreeBacked<phase0.BeaconState>;
@@ -70,7 +70,7 @@ describe("state hashTreeRoot", () => {
 
   for (const {id, noTrack, fn} of testCases) {
     itBench<TreeBacked<phase0.BeaconState>, TreeBacked<phase0.BeaconState>>({
-      id: `state hashTreeRoot - ${id}`,
+      id: `BeaconState.hashTreeRoot - ${id}`,
       noThreshold: noTrack,
       beforeEach: () => {
         const state = stateOg.clone();


### PR DESCRIPTION
**Motivation**

hashing perf tests results show the same values for all cases. The issue is that the state is not being cloned so the hashing cache is shared between tests.

**Description**

Fix hashing perf test