### PR TITLE
Guard against unsafe numbers

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/epochContext.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochContext.ts
@@ -143,6 +143,8 @@ export function createEpochContext(
   // 1 = 1 unit of EFFECTIVE_BALANCE_INCREMENT
   if (totalActiveBalanceByIncrement < 1) {
     totalActiveBalanceByIncrement = 1;
+  } else if (totalActiveBalanceByIncrement >= Number.MAX_SAFE_INTEGER) {
+    throw Error("totalActiveBalanceByIncrement >= Number.MAX_SAFE_INTEGER. MAX_EFFECTIVE_BALANCE is too low.");
   }
 
   const currentShuffling = computeEpochShuffling(state, currentActiveIndices, currentEpoch);

--- a/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
@@ -193,6 +193,8 @@ export function beforeProcessEpoch<T extends allForks.BeaconState>(state: Cached
 
   if (totalActiveStakeByIncrement < 1) {
     totalActiveStakeByIncrement = 1;
+  } else if (totalActiveStakeByIncrement >= Number.MAX_SAFE_INTEGER) {
+    throw Error("totalActiveStakeByIncrement >= Number.MAX_SAFE_INTEGER. MAX_EFFECTIVE_BALANCE is too low.");
   }
 
   // SPEC: function getBaseRewardPerIncrement()


### PR DESCRIPTION
**Motivation**

https://github.com/ChainSafe/lodestar/pull/3044 could cause us to use numbers in an unsafe way producing consensus failures. This could only happen if the user configures a MAX_EFFECTIVE_BALANCE constant that much lower than the mainnet value.

**Description**

Throw if totalBalanceByIncrement >= Number.MAX_SAFE_INTEGER