### PR TITLE
Spec test production getRewardsPenaltiesDeltas fn only

### DIFF
--- a/packages/beacon-state-transition/src/altair/epoch/index.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/index.ts
@@ -16,7 +16,7 @@ import {processInactivityUpdates} from "./processInactivityUpdates";
 import {processSyncCommitteeUpdates} from "./processSyncCommitteeUpdates";
 
 // For spec tests
-export {getRewardsPenaltiesDeltas, getFlagIndexDeltas, getInactivityPenaltyDeltas} from "./balance";
+export {getRewardsPenaltiesDeltas} from "./balance";
 
 export {
   processInactivityUpdates,


### PR DESCRIPTION
**Motivation**

Spec tests don't test the actual function we use in production getRewardsPenaltiesDeltas() but other implementations only used in spec tests.

**Description**

Test getRewardsPenaltiesDeltas() directly at the cost of losing granularity in case of failures. However, this granularity can be achieved with extra code when debugging.