### PR TITLE
Fix syncParticipantReward rounding issue

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/epochContext.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochContext.ts
@@ -308,7 +308,7 @@ export function afterProcessEpoch(state: CachedBeaconState<allForks.BeaconState>
     const totalActiveBalanceByIncrement = epochProcess.nextEpochTotalActiveBalanceByIncrement;
     const totalActiveBalance = BigInt(totalActiveBalanceByIncrement) * BigInt(EFFECTIVE_BALANCE_INCREMENT);
     epochCtx.syncParticipantReward = computeSyncParticipantReward(epochCtx.config, totalActiveBalance);
-    epochCtx.syncProposerReward = Number(
+    epochCtx.syncProposerReward = Math.floor(
       (epochCtx.syncParticipantReward * PROPOSER_WEIGHT) / (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT)
     );
 


### PR DESCRIPTION
**Motivation**

This rounding issue was found in random spec tests (altair v1.1.0-beta.3), since that PR is not ready I make the fix a separate one.

**Description**

Use `Math.floor()` to calculate `syncParticipantReward`

This is a follow up PR for #3044 