### PR TITLE
Fix libp2p datastore initialization

### DIFF
--- a/packages/lodestar/src/network/nodejs/util.ts
+++ b/packages/lodestar/src/network/nodejs/util.ts
@@ -59,10 +59,16 @@ export async function createNodeJsLibp2p(
     }
   }
 
+  let datastore: undefined | LevelDatastore = undefined;
+  if (peerStoreDir) {
+    datastore = new LevelDatastore(peerStoreDir);
+    await datastore.open();
+  }
+
   return new NodejsNode({
     peerId,
     addresses: {listen: localMultiaddrs},
-    datastore: peerStoreDir ? new LevelDatastore(peerStoreDir) : undefined,
+    datastore,
     bootMultiaddrs: bootMultiaddrs,
     discv5: network.discv5 || defaultDiscv5Options,
     maxConnections: network.maxPeers,


### PR DESCRIPTION
**Motivation**

To fix this error when starting our node
```
Sep-02 06:07:12.131 []                 info: Initializing beacon state from anchor state slot=2071167, epoch=64723, stateRoot=0x6ffde0580e2dff1b256b1fdf0956744667fa59a3ce57c628759d8aeb4a870fdf
 ✖ TypeError: Cannot read property 'iterator' of undefined
    at LevelDatastore._query (/root/lodestar/node_modules/datastore-level/src/index.js:248:44)
```

**Description**

+ We need to call `LevelDataStore.open()` before using it https://github.com/ipfs/js-datastore-level/blob/28e75881a2aa1eba8fb8098de82f0e68f5a38e34/src/index.js#L77

+ This only happens after we migrate libp2p

part of #3056 
