### PR TITLE
Improve getEffectiveBalances()

### DIFF
--- a/packages/beacon-state-transition/src/util/balance.ts
+++ b/packages/beacon-state-transition/src/util/balance.ts
@@ -53,8 +53,7 @@ export function decreaseBalance(
  * This method is used to get justified balances from a justified state.
  */
 export function getEffectiveBalances(justifiedState: CachedBeaconState<allForks.BeaconState>): number[] {
-  const {currentShuffling} = justifiedState;
-  const {activeIndices} = currentShuffling;
+  const {activeIndices} = justifiedState.currentShuffling;
   // 5x faster than using readonlyValuesListOfLeafNodeStruct
   const effectiveBalances = justifiedState.effectiveBalances.toArray();
   let j = 0;

--- a/packages/beacon-state-transition/test/perf/util/balance.test.ts
+++ b/packages/beacon-state-transition/test/perf/util/balance.test.ts
@@ -1,0 +1,18 @@
+import {itBench} from "@dapplion/benchmark";
+import {generatePerfTestCachedStatePhase0, perfStateId} from "../util";
+import {State} from "../types";
+import {getEffectiveBalances} from "../../../src/util";
+
+describe("getEffectiveBalances", () => {
+  itBench<State, State>({
+    id: `getEffectiveBalances - ${perfStateId}`,
+    before: () => generatePerfTestCachedStatePhase0() as State,
+    beforeEach: (state) => state.clone(),
+    fn: (state) => {
+      for (let i = 0; i <= 100; i++) {
+        getEffectiveBalances(state);
+      }
+    },
+    runsFactor: 100,
+  });
+});

--- a/packages/beacon-state-transition/test/unit/util/balance.test.ts
+++ b/packages/beacon-state-transition/test/unit/util/balance.test.ts
@@ -80,8 +80,11 @@ describe("getEffectiveBalances", () => {
   it("should get correct effective balances", () => {
     const justifiedState = generateCachedState(minimalConfig, {
       validators: [
+        // not active
         ...generateValidators(3, {activation: Infinity, exit: Infinity, balance: 32e9}),
+        // active
         ...generateValidators(4, {activation: 0, exit: Infinity, balance: 32e9}),
+        // not active
         ...generateValidators(5, {activation: Infinity, exit: Infinity, balance: 32e9}),
       ] as List<phase0.Validator>,
     });
@@ -90,8 +93,12 @@ describe("getEffectiveBalances", () => {
     const validators = readonlyValuesListOfLeafNodeStruct(justifiedState.validators);
     for (let i = 0, len = validators.length; i < len; i++) {
       const validator = validators[i];
-      effectiveBalances.push(isActiveValidator(validator, justifiedEpoch) ? validator.effectiveBalance : 0);
+      effectiveBalances.push(
+        isActiveValidator(validator, justifiedEpoch)
+          ? Math.floor(validator.effectiveBalance / EFFECTIVE_BALANCE_INCREMENT)
+          : 0
+      );
     }
-    expect(effectiveBalances).to.be.deep.equal(getEffectiveBalances(justifiedState), "wrong effectiveBalances");
+    expect(getEffectiveBalances(justifiedState)).to.be.deep.equal(effectiveBalances, "wrong effectiveBalances");
   });
 });

--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -103,7 +103,6 @@ export async function runStateTransition(
       const root = toHexString(postState.currentJustifiedCheckpoint.root);
       throw Error(`State not available for justified checkpoint ${epoch} ${root}`);
     }
-    // TODO - PERFORMANCE WARNING - NAIVE CODE
     justifiedBalances = getEffectiveBalances(justifiedState);
   }
   forkChoice.onBlock(job.signedBlock.message, postState, justifiedBalances);


### PR DESCRIPTION
**Motivation**

Looping through persistent-ts is faster than persistent-merkle-tree

**Description**

+ Also we can use `epochCtx.currentShuffling.activeIndices` to know if a validator is active for currentShuffling epoch or not
+ The benchmark showed that it's a 5x improvement