### PR TITLE
Persist invalid ssz objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ docs/reference/cli.md
 
 # Testnet artifacts
 .lodestar
-genesis.ssz
+*.ssz
 .pyrmont
 packages/lodestar/.tmpdb/
 

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -31,6 +31,7 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
   const beaconPaths = getBeaconPaths(args);
   // TODO: Rename db.name to db.path or db.location
   beaconNodeOptions.set({db: {name: beaconPaths.dbDir}});
+  beaconNodeOptions.set({chain: {persistInvalidSszObjectsDir: beaconPaths.persistInvalidSszObjectsDir}});
   // Add metrics metadata to show versioning + network info in Prometheus + Grafana
   beaconNodeOptions.set({metrics: {metadata: {...gitData, version, network: args.network}}});
 

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -102,6 +102,13 @@ export const beaconPathsOptions: ICliCommandOptions<IBeaconPaths> = {
     type: "string",
   },
 
+  persistInvalidSszObjectsDir: {
+    description: "Directory to persist invalid ssz objects",
+    defaultDescription: defaultBeaconPaths.persistInvalidSszObjectsDir,
+    hidden: true,
+    type: "string",
+  },
+
   configFile: {
     description: "Beacon node configuration file path",
     defaultDescription: defaultBeaconPaths.configFile,

--- a/packages/cli/src/cmds/beacon/paths.ts
+++ b/packages/cli/src/cmds/beacon/paths.ts
@@ -6,6 +6,7 @@ export interface IBeaconPaths {
   beaconDir: string;
   peerStoreDir: string;
   dbDir: string;
+  persistInvalidSszObjectsDir: string;
   configFile: string;
   peerIdFile: string;
   enrFile: string;
@@ -34,6 +35,7 @@ export function getBeaconPaths(
   const rootDir = globalPaths.rootDir;
   const beaconDir = rootDir;
   const dbDir = args.dbDir || path.join(beaconDir, "chain-db");
+  const persistInvalidSszObjectsDir = args.persistInvalidSszObjectsDir || path.join(beaconDir, "invalidSszObjects");
   const peerStoreDir = args.peerStoreDir || path.join(beaconDir, "peerstore");
   const configFile = args.configFile || path.join(beaconDir, "beacon.config.json");
   const peerIdFile = args.peerIdFile || path.join(beaconDir, "peer-id.json");
@@ -44,6 +46,7 @@ export function getBeaconPaths(
     ...globalPaths,
     beaconDir,
     dbDir,
+    persistInvalidSszObjectsDir,
     configFile,
     peerStoreDir,
     peerIdFile,

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -4,12 +4,18 @@ import {ICliCommandOptions} from "../../util";
 export interface IChainArgs {
   "chain.useSingleThreadVerifier": boolean;
   "chain.disableBlsBatchVerify": boolean;
+  "chain.persistInvalidSszObjects": boolean;
+  // this is defined as part of IBeaconPaths
+  // "chain.persistInvalidSszObjectsDir": string;
 }
 
 export function parseArgs(args: IChainArgs): IBeaconNodeOptions["chain"] {
   return {
     useSingleThreadVerifier: args["chain.useSingleThreadVerifier"],
     disableBlsBatchVerify: args["chain.disableBlsBatchVerify"],
+    persistInvalidSszObjects: args["chain.persistInvalidSszObjects"],
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+    persistInvalidSszObjectsDir: undefined as any,
   };
 }
 
@@ -29,6 +35,13 @@ export const options: ICliCommandOptions<IChainArgs> = {
       "Do not use BLS batch verify to validate all block signatures at once. \
 Will double processing times. Use only for debugging purposes.",
     defaultDescription: String(defaultOptions.chain.disableBlsBatchVerify),
+    group: "chain",
+  },
+
+  "chain.persistInvalidSszObjects": {
+    hidden: true,
+    type: "boolean",
+    description: "Persist invalid ssz objects or not for debugging purpose",
     group: "chain",
   },
 };

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -16,6 +16,7 @@ describe("options / beaconNodeOptions", () => {
 
       "chain.useSingleThreadVerifier": true,
       "chain.disableBlsBatchVerify": true,
+      "chain.persistInvalidSszObjects": true,
 
       "eth1.enabled": true,
       "eth1.providerUrl": "http://my.node:8545",
@@ -58,6 +59,7 @@ describe("options / beaconNodeOptions", () => {
       chain: {
         useSingleThreadVerifier: true,
         disableBlsBatchVerify: true,
+        persistInvalidSszObjects: true,
       },
       eth1: {
         enabled: true,

--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -12,10 +12,10 @@ import {
   SYNC_COMMITTEE_SIZE,
   SYNC_COMMITTEE_SUBNET_COUNT,
 } from "@chainsafe/lodestar-params";
-import {allForks, Root, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {allForks, Root, Slot, ValidatorIndex, ssz} from "@chainsafe/lodestar-types";
 import {assembleAttestationData} from "../../../chain/factory/attestation";
 import {assembleBlock} from "../../../chain/factory/block";
-import {AttestationError, AttestationErrorCode} from "../../../chain/errors";
+import {AttestationError, AttestationErrorCode, GossipAction, SyncCommitteeError} from "../../../chain/errors";
 import {validateGossipAggregateAndProof} from "../../../chain/validation";
 import {ZERO_HASH} from "../../../constants";
 import {SyncState} from "../../../sync";
@@ -27,6 +27,7 @@ import {OpSource} from "../../../metrics/validatorMonitor";
 import {computeSubnetForCommitteesAtSlot, getPubkeysForIndices, getSyncComitteeValidatorIndexMap} from "./utils";
 import {ApiModules} from "../types";
 import {RegenCaller} from "../../../chain/regen";
+import {toHexString} from "@chainsafe/ssz";
 
 /**
  * Validator clock may be advanced from beacon's clock. If the validator requests a resource in a
@@ -377,6 +378,14 @@ export function getValidatorApi({
               },
               e
             );
+            if (e instanceof AttestationError && e.action === GossipAction.REJECT) {
+              const archivedPath = chain.persistInvalidSszObject(
+                "signedAggregatedAndProof",
+                ssz.phase0.SignedAggregateAndProof.serialize(signedAggregateAndProof),
+                toHexString(ssz.phase0.SignedAggregateAndProof.hashTreeRoot(signedAggregateAndProof))
+              );
+              logger.debug("The submitted signed aggregate and proof was written to", archivedPath);
+            }
           }
         })
       );
@@ -417,6 +426,14 @@ export function getValidatorApi({
               },
               e
             );
+            if (e instanceof SyncCommitteeError && e.action === GossipAction.REJECT) {
+              const archivedPath = chain.persistInvalidSszObject(
+                "contributionAndProof",
+                ssz.altair.SignedContributionAndProof.serialize(contributionAndProof),
+                toHexString(ssz.altair.SignedContributionAndProof.hashTreeRoot(contributionAndProof))
+              );
+              logger.error("The submitted contribution adn proof was written to", archivedPath);
+            }
           }
         })
       );

--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -432,7 +432,7 @@ export function getValidatorApi({
                 ssz.altair.SignedContributionAndProof.serialize(contributionAndProof),
                 toHexString(ssz.altair.SignedContributionAndProof.hashTreeRoot(contributionAndProof))
               );
-              logger.error("The submitted contribution adn proof was written to", archivedPath);
+              logger.debug("The submitted contribution adn proof was written to", archivedPath);
             }
           }
         })

--- a/packages/lodestar/src/chain/blocks/stateTransition.ts
+++ b/packages/lodestar/src/chain/blocks/stateTransition.ts
@@ -17,6 +17,7 @@ import {ChainEvent, ChainEventEmitter} from "../emitter";
 import {IBlockJob} from "../interface";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {IMetrics} from "../../metrics";
+import {BlockError, BlockErrorCode} from "../errors";
 
 /**
  * Starting at `state.slot`,
@@ -84,12 +85,17 @@ export async function runStateTransition(
     state,
     job.signedBlock,
     {
-      verifyStateRoot: true,
+      verifyStateRoot: false,
       verifyProposer: !job.validSignatures && !job.validProposerSignature,
       verifySignatures: !job.validSignatures,
     },
     metrics
   );
+
+  const blockStateRoot = job.signedBlock.message.stateRoot;
+  if (!ssz.Root.equals(blockStateRoot, postState.tree.root)) {
+    throw new BlockError(job.signedBlock, {code: BlockErrorCode.INVALID_STATE_ROOT, preState, postState});
+  }
 
   const oldHead = forkChoice.getHead();
 

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -2,6 +2,7 @@
  * @module chain
  */
 
+import fs from "fs";
 import {ForkName} from "@chainsafe/lodestar-params";
 import {CachedBeaconState, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
@@ -19,7 +20,7 @@ import {BlockPool, BlockProcessor} from "./blocks";
 import {IBeaconClock, LocalClock} from "./clock";
 import {ChainEventEmitter} from "./emitter";
 import {handleChainEvents} from "./eventHandlers";
-import {IBeaconChain} from "./interface";
+import {IBeaconChain, SSZObjectType} from "./interface";
 import {IChainOptions} from "./options";
 import {IStateRegenerator, QueuedStateRegenerator, RegenCaller} from "./regen";
 import {LodestarForkChoice} from "./forkChoice";
@@ -304,5 +305,24 @@ export class BeaconChain implements IBeaconChain {
       headRoot: head.blockRoot,
       headSlot: head.slot,
     };
+  }
+
+  persistInvalidSszObject(type: SSZObjectType, bytes: Uint8Array, suffix = ""): string | null {
+    if (!this.persistInvalidSszObject) {
+      return null;
+    }
+    const now = new Date();
+    // yyyy-MM-dd
+    const date = now.toISOString().split("T")[0];
+    // by default store to lodestar_archive of current dir
+    const byDate = this.opts.persistInvalidSszObjectsDir
+      ? `${this.opts.persistInvalidSszObjectsDir}/${date}`
+      : `invalidSszObjects/${date}`;
+    if (!fs.existsSync(byDate)) {
+      fs.mkdirSync(byDate, {recursive: true});
+    }
+    const fileName = `${byDate}/${type}_${suffix}_${Date.now()}.ssz`;
+    fs.writeFileSync(fileName, bytes);
+    return fileName;
   }
 }

--- a/packages/lodestar/src/chain/errors/blockError.ts
+++ b/packages/lodestar/src/chain/errors/blockError.ts
@@ -1,5 +1,6 @@
-import {Root, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {allForks, Root, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {LodestarError} from "@chainsafe/lodestar-utils";
+import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 
 import {IBlockJob, IChainSegmentJob} from "../interface";
 import {GossipActionError} from "./gossipValidation";
@@ -58,6 +59,10 @@ export enum BlockErrorCode {
    */
   INVALID_SIGNATURE = "BLOCK_ERROR_INVALID_SIGNATURE",
   /**
+   * Block transition returns invalid state root.
+   */
+  INVALID_STATE_ROOT = "BLOCK_ERROR_INVALID_STATE_ROOT",
+  /**
    * The provided block is from an later slot than its parent.
    */
   BLOCK_IS_NOT_LATER_THAN_PARENT = "BLOCK_ERROR_BLOCK_IS_NOT_LATER_THAN_PARENT",
@@ -97,7 +102,12 @@ export type BlockErrorType =
   | {code: BlockErrorCode.INCORRECT_PROPOSER; blockProposer: ValidatorIndex}
   | {code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID}
   | {code: BlockErrorCode.UNKNOWN_PROPOSER; proposer: ValidatorIndex}
-  | {code: BlockErrorCode.INVALID_SIGNATURE}
+  | {code: BlockErrorCode.INVALID_SIGNATURE; preState: CachedBeaconState<allForks.BeaconState>}
+  | {
+      code: BlockErrorCode.INVALID_STATE_ROOT;
+      preState: CachedBeaconState<allForks.BeaconState>;
+      postState: CachedBeaconState<allForks.BeaconState>;
+    }
   | {code: BlockErrorCode.BLOCK_IS_NOT_LATER_THAN_PARENT; blockSlot: Slot; stateSlot: Slot}
   | {code: BlockErrorCode.NON_LINEAR_PARENT_ROOTS}
   | {code: BlockErrorCode.NON_LINEAR_SLOTS}

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -313,7 +313,8 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
     return;
   }
 
-  this.logger.error("Block error", {slot: err.signedBlock.message.slot}, err);
+  // err type data may contain CachedBeaconState which is too much to log
+  this.logger.error("Block error", {slot: err.signedBlock.message.slot, errCode: err.type.code});
 
   if (err.type.code === BlockErrorCode.FUTURE_SLOT) {
     this.pendingBlocks.addBySlot(err.signedBlock);
@@ -325,5 +326,41 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
   else if (err.type.code === BlockErrorCode.PARENT_UNKNOWN) {
     this.pendingBlocks.addByParent(err.signedBlock);
     await this.db.pendingBlock.add(err.signedBlock);
+  } else if (err.type.code === BlockErrorCode.INVALID_SIGNATURE) {
+    const {signedBlock} = err;
+    const blockSlot = signedBlock.message.slot;
+    const {preState} = err.type;
+    const blockPath = this.persistInvalidSszObject(
+      "signedBlock",
+      this.config.getForkTypes(blockSlot).SignedBeaconBlock.serialize(signedBlock),
+      `${blockSlot}_invalid_signature`
+    );
+    const statePath = this.persistInvalidSszObject("state", preState.serialize(), `${preState.slot}_invalid_signature`);
+    this.logger.debug("Invalid signature block and state were written to disc", {blockPath, statePath});
+  } else if (err.type.code === BlockErrorCode.INVALID_STATE_ROOT) {
+    const {signedBlock} = err;
+    const blockSlot = signedBlock.message.slot;
+    const {preState, postState} = err.type;
+    const invalidRoot = toHexString(postState.hashTreeRoot());
+    const blockPath = this.persistInvalidSszObject(
+      "signedBlock",
+      this.config.getForkTypes(blockSlot).SignedBeaconBlock.serialize(signedBlock),
+      `${blockSlot}_invalid_state_root_${invalidRoot}`
+    );
+    const preStatePath = this.persistInvalidSszObject(
+      "state",
+      preState.serialize(),
+      `${preState.slot}_invalid_state_root_preState_${invalidRoot}`
+    );
+    const postStatePath = this.persistInvalidSszObject(
+      "state",
+      postState.serialize(),
+      `${postState.slot}_invalid_state_root_postState_${invalidRoot}`
+    );
+    this.logger.debug("Invalid signature block and state were written to disc", {
+      blockPath,
+      preStatePath,
+      postStatePath,
+    });
   }
 }

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -119,4 +119,16 @@ export interface IBeaconChain {
   getClockForkDigest(): phase0.ForkDigest;
 
   getStatus(): phase0.Status;
+
+  /** Persist bad items to persistInvalidSszObjectsDir dir, for example invalid state, attestations etc. */
+  persistInvalidSszObject(type: SSZObjectType, bytes: Uint8Array, suffix: string): string | null;
 }
+
+export type SSZObjectType =
+  | "state"
+  | "signedBlock"
+  | "block"
+  | "attestation"
+  | "signedAggregatedAndProof"
+  | "syncCommittee"
+  | "contributionAndProof";

--- a/packages/lodestar/src/chain/options.ts
+++ b/packages/lodestar/src/chain/options.ts
@@ -3,9 +3,13 @@ import {BlockProcessOpts} from "./blocks/process";
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type IChainOptions = BlockProcessOpts & {
   useSingleThreadVerifier?: boolean;
+  persistInvalidSszObjects?: boolean;
+  persistInvalidSszObjectsDir: string;
 };
 
 export const defaultChainOptions: IChainOptions = {
   useSingleThreadVerifier: false,
   disableBlsBatchVerify: false,
+  persistInvalidSszObjects: true,
+  persistInvalidSszObjectsDir: "",
 };

--- a/packages/lodestar/src/network/gossip/handlers/index.ts
+++ b/packages/lodestar/src/network/gossip/handlers/index.ts
@@ -97,7 +97,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules): GossipHandlers 
             config.getForkTypes(slot).SignedBeaconBlock.serialize(signedBlock),
             `gossip_slot_${slot}`
           );
-          logger.error("Error validating gossip block", archivedPath);
+          logger.debug("The invalid gossip block was written to", archivedPath);
         }
 
         throw e;
@@ -146,7 +146,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules): GossipHandlers 
             ssz.phase0.SignedAggregateAndProof.serialize(signedAggregateAndProof),
             toHexString(ssz.phase0.SignedAggregateAndProof.hashTreeRoot(signedAggregateAndProof))
           );
-          logger.error("Error validating gossip aggregate and proof", archivedPath, e);
+          logger.debug("The invalid gossip aggregate and proof was written to", archivedPath, e);
         }
         throw e;
       }
@@ -164,7 +164,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules): GossipHandlers 
             ssz.phase0.Attestation.serialize(attestation),
             toHexString(ssz.phase0.Attestation.hashTreeRoot(attestation))
           );
-          logger.error("Error validating gossip attestation", {archivedPath}, e);
+          logger.debug("The invalid gossip attestation was written to", archivedPath);
         }
         throw e;
       }
@@ -226,7 +226,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules): GossipHandlers 
             ssz.altair.SignedContributionAndProof.serialize(contributionAndProof),
             toHexString(ssz.altair.SignedContributionAndProof.hashTreeRoot(contributionAndProof))
           );
-          logger.error("Error validating gossip contribution and proof", archivedPath, e);
+          logger.debug("The invalid gossip contribution and proof was written to", archivedPath);
         }
         throw e;
       }
@@ -251,7 +251,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules): GossipHandlers 
             ssz.altair.SyncCommitteeMessage.serialize(syncCommittee),
             toHexString(ssz.altair.SyncCommitteeMessage.hashTreeRoot(syncCommittee))
           );
-          logger.error("Error validating gossip sync committee", archivedPath, e);
+          logger.debug("The invalid gossip sync committee was written to", archivedPath);
         }
         throw e;
       }

--- a/packages/lodestar/src/network/gossip/handlers/index.ts
+++ b/packages/lodestar/src/network/gossip/handlers/index.ts
@@ -1,11 +1,18 @@
+import {toHexString} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {ValidatorIndex} from "@chainsafe/lodestar-types";
+import {phase0, ssz, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {ILogger, prettyBytes} from "@chainsafe/lodestar-utils";
 import {IMetrics} from "../../../metrics";
 import {OpSource} from "../../../metrics/validatorMonitor";
 import {IBeaconDb} from "../../../db";
 import {IBeaconChain} from "../../../chain";
-import {BlockErrorCode, BlockGossipError} from "../../../chain/errors";
+import {
+  AttestationError,
+  BlockErrorCode,
+  BlockGossipError,
+  GossipAction,
+  SyncCommitteeError,
+} from "../../../chain/errors";
 import {GossipTopicMap, GossipType, GossipTypeMap} from "../interface";
 import {
   validateGossipAggregateAndProof,
@@ -84,6 +91,13 @@ export function getGossipHandlers(modules: ValidatorFnsModules): GossipHandlers 
         ) {
           logger.debug("Gossip block has error", {slot, root: blockHex, code: e.type.code});
           chain.receiveBlock(signedBlock);
+        } else if (e instanceof BlockGossipError && e.action === GossipAction.REJECT) {
+          const archivedPath = chain.persistInvalidSszObject(
+            "signedBlock",
+            config.getForkTypes(slot).SignedBeaconBlock.serialize(signedBlock),
+            `gossip_slot_${slot}`
+          );
+          logger.error("Error validating gossip block", archivedPath);
         }
 
         throw e;
@@ -93,43 +107,67 @@ export function getGossipHandlers(modules: ValidatorFnsModules): GossipHandlers 
     [GossipType.beacon_aggregate_and_proof]: async (signedAggregateAndProof) => {
       const seenTimestampSec = Date.now() / 1000;
 
-      const {indexedAttestation, committeeIndices} = await validateGossipAggregateAndProof(
-        chain,
-        signedAggregateAndProof
-      );
+      try {
+        const {indexedAttestation, committeeIndices} = await validateGossipAggregateAndProof(
+          chain,
+          signedAggregateAndProof
+        );
 
-      metrics?.registerAggregatedAttestation(
-        OpSource.gossip,
-        seenTimestampSec,
-        signedAggregateAndProof,
-        indexedAttestation
-      );
+        metrics?.registerAggregatedAttestation(
+          OpSource.gossip,
+          seenTimestampSec,
+          signedAggregateAndProof,
+          indexedAttestation
+        );
 
-      // TODO: Add DoS resistant pending attestation pool
-      // switch (e.type.code) {
-      //   case AttestationErrorCode.FUTURE_SLOT:
-      //     chain.pendingAttestations.putBySlot(e.type.attestationSlot, attestation);
-      //     break;
-      //   case AttestationErrorCode.UNKNOWN_TARGET_ROOT:
-      //   case AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT:
-      //     chain.pendingAttestations.putByBlock(e.type.root, attestation);
-      //     break;
-      // }
+        // TODO: Add DoS resistant pending attestation pool
+        // switch (e.type.code) {
+        //   case AttestationErrorCode.FUTURE_SLOT:
+        //     chain.pendingAttestations.putBySlot(e.type.attestationSlot, attestation);
+        //     break;
+        //   case AttestationErrorCode.UNKNOWN_TARGET_ROOT:
+        //   case AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT:
+        //     chain.pendingAttestations.putByBlock(e.type.root, attestation);
+        //     break;
+        // }
 
-      // Handler
-      const aggregatedAttestation = signedAggregateAndProof.message.aggregate;
+        // Handler
+        const aggregatedAttestation = signedAggregateAndProof.message.aggregate;
 
-      chain.aggregatedAttestationPool.add(
-        aggregatedAttestation,
-        indexedAttestation.attestingIndices as ValidatorIndex[],
-        committeeIndices
-      );
+        chain.aggregatedAttestationPool.add(
+          aggregatedAttestation,
+          indexedAttestation.attestingIndices as ValidatorIndex[],
+          committeeIndices
+        );
+      } catch (e) {
+        if (e instanceof AttestationError && e.action === GossipAction.REJECT) {
+          const archivedPath = chain.persistInvalidSszObject(
+            "signedAggregatedAndProof",
+            ssz.phase0.SignedAggregateAndProof.serialize(signedAggregateAndProof),
+            toHexString(ssz.phase0.SignedAggregateAndProof.hashTreeRoot(signedAggregateAndProof))
+          );
+          logger.error("Error validating gossip aggregate and proof", archivedPath, e);
+        }
+        throw e;
+      }
     },
 
     [GossipType.beacon_attestation]: async (attestation, {subnet}) => {
       const seenTimestampSec = Date.now() / 1000;
-
-      const {indexedAttestation} = await validateGossipAttestation(chain, attestation, subnet);
+      let indexedAttestation: phase0.IndexedAttestation | undefined = undefined;
+      try {
+        indexedAttestation = (await validateGossipAttestation(chain, attestation, subnet)).indexedAttestation;
+      } catch (e) {
+        if (e instanceof AttestationError && e.action === GossipAction.REJECT) {
+          const archivedPath = chain.persistInvalidSszObject(
+            "attestation",
+            ssz.phase0.Attestation.serialize(attestation),
+            toHexString(ssz.phase0.Attestation.hashTreeRoot(attestation))
+          );
+          logger.error("Error validating gossip attestation", {archivedPath}, e);
+        }
+        throw e;
+      }
 
       metrics?.registerUnaggregatedAttestation(OpSource.gossip, seenTimestampSec, indexedAttestation);
 
@@ -179,7 +217,19 @@ export function getGossipHandlers(modules: ValidatorFnsModules): GossipHandlers 
     },
 
     [GossipType.sync_committee_contribution_and_proof]: async (contributionAndProof) => {
-      await validateSyncCommitteeGossipContributionAndProof(chain, contributionAndProof);
+      try {
+        await validateSyncCommitteeGossipContributionAndProof(chain, contributionAndProof);
+      } catch (e) {
+        if (e instanceof SyncCommitteeError && e.action === GossipAction.REJECT) {
+          const archivedPath = chain.persistInvalidSszObject(
+            "contributionAndProof",
+            ssz.altair.SignedContributionAndProof.serialize(contributionAndProof),
+            toHexString(ssz.altair.SignedContributionAndProof.hashTreeRoot(contributionAndProof))
+          );
+          logger.error("Error validating gossip contribution and proof", archivedPath, e);
+        }
+        throw e;
+      }
 
       // Handler
 
@@ -191,7 +241,20 @@ export function getGossipHandlers(modules: ValidatorFnsModules): GossipHandlers 
     },
 
     [GossipType.sync_committee]: async (syncCommittee, {subnet}) => {
-      const {indexInSubCommittee} = await validateGossipSyncCommittee(chain, syncCommittee, subnet);
+      let indexInSubCommittee = 0;
+      try {
+        indexInSubCommittee = (await validateGossipSyncCommittee(chain, syncCommittee, subnet)).indexInSubCommittee;
+      } catch (e) {
+        if (e instanceof SyncCommitteeError && e.action === GossipAction.REJECT) {
+          const archivedPath = chain.persistInvalidSszObject(
+            "syncCommittee",
+            ssz.altair.SyncCommitteeMessage.serialize(syncCommittee),
+            toHexString(ssz.altair.SyncCommitteeMessage.hashTreeRoot(syncCommittee))
+          );
+          logger.error("Error validating gossip sync committee", archivedPath, e);
+        }
+        throw e;
+      }
 
       // Handler
 

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -199,6 +199,10 @@ export class MockBeaconChain implements IBeaconChain {
       headSlot: 0,
     };
   }
+
+  persistInvalidSszObject(): string | null {
+    return null;
+  }
 }
 
 function mockForkChoice(): IForkChoice {


### PR DESCRIPTION
**Motivation**

+ When "Invalid state root" issue happen inside our state transition, there is no way to investigate. We should be able to persist the preState/block/postState and investigate
+ Teku always persist error items, it's really convenient for us to do the same so that does not take time to reproduce/investigate the issue

**Description**

+ New "archiveItem" function in our util, call it when error in our api/gossip/state transition. For invalid gossip message, we only persist if its a "REJECT" action
+ Since `archiveItem` stays in util so that we can call it either from lodestar or beacon-state-transition, I make LODESTAR_ARCHIVE_DIR environment variable for the parent dir, set it with new "archiveDir" option
+ Although it takes time to serialize items, we don't do that frequently so hopefully it does not have performance issue
+ Persist by date, something like `/Users/tuyennguyen/.local/share/lodestar/prater/archive/2021-09-03/state_invalid_weak_subjectivity_1630662789679.ssz`

part of #3066
