### PR TITLE
Remove dev databases if chain starts from scratch

### DIFF
--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -41,6 +41,13 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
   const beaconDbDir = beaconPaths.dbDir;
   const validatorsDbDir = validatorPaths.validatorsDbDir;
 
+  // Remove slashing protection db. Otherwise the validators won't be able to propose nor attest
+  // until the clock reach a higher slot than the previous run of the dev command
+  if (!args.genesisTime) {
+    await promisify(rimraf)(beaconDbDir);
+    await promisify(rimraf)(validatorsDbDir);
+  }
+
   mkdir(beaconDbDir);
   mkdir(validatorsDbDir);
 


### PR DESCRIPTION
**Motivation**

When running dev command again, the db must be whiped out or bad things happens:
- slashing protection db invalidates everything

**Description**

Remove dev databases if no genesisTime option is passed