### PR TITLE
Retry network / ReqResp tests

### DIFF
--- a/packages/lodestar/test/e2e/network/gossipsub.test.ts
+++ b/packages/lodestar/test/e2e/network/gossipsub.test.ts
@@ -30,6 +30,7 @@ const opts: INetworkOptions = {
 
 describe("network", function () {
   if (this.timeout() < 15 * 1000) this.timeout(15 * 1000);
+  this.retries(2); // This test fail sometimes, with a 5% rate.
 
   const logger = testLogger();
 

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -34,6 +34,7 @@ const opts: INetworkOptions = {
 
 describe("network", function () {
   if (this.timeout() < 5000) this.timeout(5000);
+  this.retries(2); // This test fail sometimes, with a 5% rate.
 
   const afterEachCallbacks: (() => Promise<void> | void)[] = [];
   afterEach(async () => {

--- a/packages/lodestar/test/e2e/network/reqresp.test.ts
+++ b/packages/lodestar/test/e2e/network/reqresp.test.ts
@@ -31,6 +31,7 @@ chai.use(chaiAsPromised);
 
 describe("network / ReqResp", function () {
   if (this.timeout() < 5000) this.timeout(5000);
+  this.retries(2); // This test fail sometimes, with a 5% rate.
 
   const multiaddr = "/ip4/127.0.0.1/tcp/0";
   const networkOptsDefault: INetworkOptions = {


### PR DESCRIPTION
**Motivation**

e2e tests using libp2p randomly fails, retry since it can be due to unpredictable network side effects. See https://github.com/ChainSafe/lodestar/issues/2715

**Description**

Retry network / ReqResp tests

Closes https://github.com/ChainSafe/lodestar/issues/2715