### PR TITLE
Fix epoch process effective balance by increment

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
@@ -178,11 +178,11 @@ export function beforeProcessEpoch<T extends allForks.BeaconState>(state: Cached
     }
 
     const active = isActiveValidator(validator, currentEpoch);
+    // We track effectiveBalanceByIncrement as ETH to fit total network balance in a JS number (53 bits)
+    const effectiveBalanceByIncrement = Math.floor(validator.effectiveBalance / EFFECTIVE_BALANCE_INCREMENT);
+    effectiveBalancesByIncrements[i] = effectiveBalanceByIncrement;
     if (active) {
       status.active = true;
-      // We track effectiveBalanceByIncrement as ETH to fit total network balance in a JS number (53 bits)
-      const effectiveBalanceByIncrement = Math.floor(validator.effectiveBalance / EFFECTIVE_BALANCE_INCREMENT);
-      effectiveBalancesByIncrements[i] = effectiveBalanceByIncrement;
       totalActiveStakeByIncrement += effectiveBalanceByIncrement;
     }
 


### PR DESCRIPTION
**Motivation**

Got "invalid state root" when doing epoch transition for prater

**Description**

+ We need to cache effective balance by increment for all validators, not just for active ones

Closes #3066

