### PR TITLE
config api interoperability with lighthouse

### DIFF
--- a/packages/api/src/client/utils/client.ts
+++ b/packages/api/src/client/utils/client.ts
@@ -72,7 +72,7 @@ export function generateGenericJsonClient<
       const res = await fetchFn.json<Json>(fetchOptsSerializer(...args));
       if (returnType) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return returnType.fromJson(res, jsonOpts) as ReturnType<Api[keyof Api]>;
+        return returnType.fromJson(res, routeDef.jsonOpts || jsonOpts) as ReturnType<Api[keyof Api]>;
       }
     };
   }) as Api;

--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -53,7 +53,7 @@ export type Api = {
 export const routesData: RoutesData<Api> = {
   getDepositContract: {url: "/eth/v1/config/deposit_contract", method: "GET"},
   getForkSchedule: {url: "/eth/v1/config/fork_schedule", method: "GET"},
-  getSpec: {url: "/eth/v1/config/spec", method: "GET"},
+  getSpec: {url: "/eth/v1/config/spec", method: "GET", jsonOpts: {case: "notransform" as const} },
 };
 
 export type ReqTypes = {[K in keyof Api]: ReqEmpty};

--- a/packages/api/src/server/utils/server.ts
+++ b/packages/api/src/server/utils/server.ts
@@ -69,7 +69,7 @@ export function getGenericJsonServer<
         const args: any[] = routeSerdes.parseReq(req as ReqTypes[keyof Api]);
         const data = (await api[routeKey](...args)) as Resolves<Api[keyof Api]>;
         if (returnType) {
-          return returnType.toJson(data, jsonOpts);
+          return returnType.toJson(data, routeDef.jsonOpts ||jsonOpts);
         } else {
           return {};
         }

--- a/packages/api/src/utils/types.ts
+++ b/packages/api/src/utils/types.ts
@@ -25,6 +25,19 @@ export type RouteGroupDefinition<
 export type RouteDef = {
   url: string;
   method: "GET" | "POST";
+  jsonOpts?: {case: 
+    | "lower"
+    | "snake"
+    | "constant"
+    | "camel"
+    | "kebab"
+    | "upper"
+    | "capital"
+    | "header"
+    | "pascal" //Same as squish
+    | "title"
+    | "sentence"
+    | "notransform"};
 };
 
 export type ReqGeneric = {

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -47,7 +47,19 @@ export function mapValues<T extends {[K: string]: any}, R>(
 
 export function objectToExpectedCase<T extends Record<string, unknown> | Record<string, unknown>[]>(
   obj: T,
-  expectedCase: "snake" | "camel" = "camel"
+  expectedCase: 
+    | "lower"
+    | "snake"
+    | "constant"
+    | "camel"
+    | "kebab"
+    | "upper"
+    | "capital"
+    | "header"
+    | "pascal" //Same as squish
+    | "title"
+    | "sentence"
+    | "notransform" = "camel"
 ): T {
   if (Array.isArray(obj)) {
     const newArr: unknown[] = [];


### PR DESCRIPTION
**Motivation**
The goal is to make validator interoperable with lighthouse
The commit is trying to match case of data received from lighthouse beacon node, issue is our beacon servers snake case for config data using jsonopts while lighthouse serves constant case for the spec config data. This PR demos one way to do that.

DEPENDENCY: ssz PR to extend expected case: https://github.com/ChainSafe/ssz/pull/184 to be merged in ssz with ssz released and package version updated.

even after matching case, got this missing data field error in lighthouse data:

![image](https://user-images.githubusercontent.com/76567250/132192700-dd060992-ded2-4576-8330-40c7949d1f83.png)

which basically implies that lighthouse latest stable branch doesn't has the  field. this raises some questions of tracking the version of api.

Also the expectedCase filling of the container data doesn't seem to be the correct approach, because of container nesting like {data:configObj} where data is snake, and configObj is constant case. Ideally if there has to be any case specification of container fields it has to be with the container structure itself (along with fields) and then we don't need to pass any expected case opts.
This needs more discussion and debate.

<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
