### PR TITLE
Remove trailing slash from routes declaration

### DIFF
--- a/packages/api/src/routes/lightclient.ts
+++ b/packages/api/src/routes/lightclient.ts
@@ -35,9 +35,9 @@ export type Api = {
  */
 export const routesData: RoutesData<Api> = {
   getStateProof: {url: "/eth/v1/lightclient/proof/:stateId", method: "POST"},
-  getBestUpdates: {url: "/eth/v1/lightclient/best_updates/", method: "GET"},
-  getLatestUpdateFinalized: {url: "/eth/v1/lightclient/latest_update_finalized/", method: "GET"},
-  getLatestUpdateNonFinalized: {url: "/eth/v1/lightclient/latest_update_nonfinalized/", method: "GET"},
+  getBestUpdates: {url: "/eth/v1/lightclient/best_updates", method: "GET"},
+  getLatestUpdateFinalized: {url: "/eth/v1/lightclient/latest_update_finalized", method: "GET"},
+  getLatestUpdateNonFinalized: {url: "/eth/v1/lightclient/latest_update_nonfinalized", method: "GET"},
   getInitProof: {url: "/eth/v1/lightclient/init_proof/:epoch", method: "GET"},
 };
 

--- a/packages/api/src/routes/lodestar.ts
+++ b/packages/api/src/routes/lodestar.ts
@@ -79,15 +79,15 @@ export type Api = {
  * Define javascript values for each route
  */
 export const routesData: RoutesData<Api> = {
-  getWtfNode: {url: "/eth/v1/lodestar/wtfnode/", method: "GET"},
-  writeHeapdump: {url: "/eth/v1/lodestar/writeheapdump/", method: "GET"},
-  getLatestWeakSubjectivityCheckpointEpoch: {url: "/eth/v1/lodestar/ws_epoch/", method: "GET"},
-  getSyncChainsDebugState: {url: "/eth/v1/lodestar/sync-chains-debug-state/", method: "GET"},
+  getWtfNode: {url: "/eth/v1/lodestar/wtfnode", method: "GET"},
+  writeHeapdump: {url: "/eth/v1/lodestar/writeheapdump", method: "GET"},
+  getLatestWeakSubjectivityCheckpointEpoch: {url: "/eth/v1/lodestar/ws_epoch", method: "GET"},
+  getSyncChainsDebugState: {url: "/eth/v1/lodestar/sync-chains-debug-state", method: "GET"},
   getGossipQueueItems: {url: "/eth/v1/lodestar/gossip-queue-items/:gossipType", method: "GET"},
-  getRegenQueueItems: {url: "/eth/v1/lodestar/regen-queue-items/", method: "GET"},
-  getBlockProcessorQueueItems: {url: "/eth/v1/lodestar/block-processor-queue-items/", method: "GET"},
-  getStateCacheItems: {url: "/eth/v1/lodestar/state-cache-items/", method: "GET"},
-  getCheckpointStateCacheItems: {url: "/eth/v1/lodestar/checkpoint-state-cache-items/", method: "GET"},
+  getRegenQueueItems: {url: "/eth/v1/lodestar/regen-queue-items", method: "GET"},
+  getBlockProcessorQueueItems: {url: "/eth/v1/lodestar/block-processor-queue-items", method: "GET"},
+  getStateCacheItems: {url: "/eth/v1/lodestar/state-cache-items", method: "GET"},
+  getCheckpointStateCacheItems: {url: "/eth/v1/lodestar/checkpoint-state-cache-items", method: "GET"},
 };
 
 export type ReqTypes = {


### PR DESCRIPTION
**Motivation**

Otherwise calling the route without the trailing slash causes a 404

```
# curl http://localhost:9596/eth/v1/lodestar/writeheapdump
{"message":"Route GET:/eth/v1/lodestar/writeheapdump not found","error":"Not Found","statusCode":404}
```

**Description**

- Remove trailing slash from routes declaration