### PR TITLE
Handle fork as uppercase in API

### DIFF
--- a/packages/api/src/routes/beacon/block.ts
+++ b/packages/api/src/routes/beacon/block.ts
@@ -159,7 +159,8 @@ export function getReturnTypes(): ReturnTypes<Api> {
 
   return {
     getBlock: ContainerData(ssz.phase0.SignedBeaconBlock),
-    getBlockV2: WithVersion((fork: ForkName) => ssz[fork].SignedBeaconBlock),
+    // Teku returns fork as UPPERCASE
+    getBlockV2: WithVersion((fork: ForkName) => ssz[fork.toLowerCase() as ForkName].SignedBeaconBlock),
     getBlockAttestations: ContainerData(ArrayOf(ssz.phase0.Attestation)),
     getBlockHeader: ContainerData(BeaconHeaderResType),
     getBlockHeaders: ContainerData(ArrayOf(BeaconHeaderResType)),

--- a/packages/api/src/routes/debug.ts
+++ b/packages/api/src/routes/debug.ts
@@ -124,6 +124,9 @@ export function getReturnTypes(): ReturnTypes<Api> {
   return {
     getHeads: ContainerData(ArrayOf(SlotRoot)),
     getState: ContainerData(ssz.phase0.BeaconState),
-    getStateV2: WithVersion((fork: ForkName) => ssz[fork].BeaconState as TypeJson<allForks.BeaconState>),
+    // Teku returns fork as UPPERCASE
+    getStateV2: WithVersion(
+      (fork: ForkName) => ssz[fork.toLowerCase() as ForkName].BeaconState as TypeJson<allForks.BeaconState>
+    ),
   };
 }


### PR DESCRIPTION
**Motivation**

Teku returns fork as UPPERCASE

**Description**

Convert fork to lowercase before using as object index key