### PR TITLE
Use clock state to validate voluntaryExits

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/epochContext.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochContext.ts
@@ -57,9 +57,11 @@ export type AttesterDuty = {
   slot: Slot;
 };
 
+export type Index2PubkeyCache = PublicKey[];
+
 export type EpochContextOpts = {
   pubkey2index?: PubkeyIndexMap;
-  index2pubkey?: PublicKey[];
+  index2pubkey?: Index2PubkeyCache;
   skipSyncPubkeys?: boolean;
 };
 
@@ -98,7 +100,7 @@ export function createEpochContext(
   opts?: EpochContextOpts
 ): EpochContext {
   const pubkey2index = opts?.pubkey2index || new PubkeyIndexMap();
-  const index2pubkey = opts?.index2pubkey || ([] as PublicKey[]);
+  const index2pubkey = opts?.index2pubkey || ([] as Index2PubkeyCache);
   if (!opts?.skipSyncPubkeys) {
     syncPubkeys(state, pubkey2index, index2pubkey);
   }
@@ -227,7 +229,7 @@ export function createEpochContext(
 export function syncPubkeys(
   state: allForks.BeaconState,
   pubkey2index: PubkeyIndexMap,
-  index2pubkey: PublicKey[]
+  index2pubkey: Index2PubkeyCache
 ): void {
   const currentCount = pubkey2index.size;
   if (currentCount !== index2pubkey.length) {
@@ -344,7 +346,7 @@ export function afterProcessEpoch(state: CachedBeaconState<allForks.BeaconState>
 interface IEpochContextData {
   config: IBeaconConfig;
   pubkey2index: PubkeyIndexMap;
-  index2pubkey: PublicKey[];
+  index2pubkey: Index2PubkeyCache;
   proposers: number[];
   previousShuffling: IEpochShuffling;
   currentShuffling: IEpochShuffling;
@@ -385,7 +387,7 @@ export class EpochContext {
    *
    * $VALIDATOR_COUNT x BLST deserialized pubkey (Jacobian coordinates)
    */
-  index2pubkey: PublicKey[];
+  index2pubkey: Index2PubkeyCache;
   /**
    * Indexes of the block proposers for the current epoch.
    *

--- a/packages/lodestar/src/chain/regen/interface.ts
+++ b/packages/lodestar/src/chain/regen/interface.ts
@@ -10,7 +10,6 @@ export enum RegenCaller {
   processBlocksInEpoch = "processBlocksInEpoch",
   validateGossipAggregateAndProof = "validateGossipAggregateAndProof",
   validateGossipAttestation = "validateGossipAttestation",
-  validateGossipVoluntaryExit = "validateGossipVoluntaryExit",
   onForkChoiceFinalized = "onForkChoiceFinalized",
 }
 

--- a/packages/lodestar/src/chain/validation/voluntaryExit.ts
+++ b/packages/lodestar/src/chain/validation/voluntaryExit.ts
@@ -18,10 +18,10 @@ export async function validateGossipVoluntaryExit(
   //
   // The only condtion that is time sensitive and may require a non-head state is
   // -> Validator is active && validator has not initiated exit
-  // The voluntaryExit.epoch must be in the past so using the head state may evaluate the
-  // validator's status in the future, compared to using a state at epoch voluntaryExit.epoch
-  // Unless there's a clear need to use a non-head state, will use the head state as its cheap.
-  const state = chain.getHeadState();
+  // The voluntaryExit.epoch must be in the past but the validator's status may change in recent epochs.
+  // We dial the head state to the current epoch to get the current status of the validator. This is
+  // relevant on periods of many skipped slots.
+  const state = await chain.getHeadStateAtCurrentEpoch();
 
   try {
     // verifySignature = false, verified in batch below

--- a/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
@@ -68,9 +68,9 @@ describe("validate voluntary exit", () => {
   beforeEach(() => {
     chainStub = sandbox.createStubInstance(BeaconChain) as StubbedChain;
     chainStub.forkChoice = sandbox.createStubInstance(ForkChoice);
+    chainStub.getHeadStateAtCurrentEpoch.resolves(state);
     // TODO: Use actual BLS verification
     chainStub.bls = {verifySignatureSets: async () => true};
-    chainStub.getHeadState.returns(state);
     dbStub = new StubbedBeaconDb(sandbox);
     dbStub.voluntaryExit.has.resolves(false);
   });

--- a/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
@@ -1,4 +1,4 @@
-import sinon, {SinonStubbedInstance} from "sinon";
+import sinon from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/default";
 import {
@@ -13,7 +13,6 @@ import {ForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {allForks, ssz} from "@chainsafe/lodestar-types";
 
 import {BeaconChain} from "../../../../src/chain";
-import {StateRegenerator} from "../../../../src/chain/regen";
 import {StubbedBeaconDb, StubbedChain} from "../../../utils/stub";
 import {generateState} from "../../../utils/state";
 import {validateGossipVoluntaryExit} from "../../../../src/chain/validation/voluntaryExit";
@@ -27,7 +26,6 @@ describe("validate voluntary exit", () => {
   const sandbox = sinon.createSandbox();
   let dbStub: StubbedBeaconDb;
   let chainStub: StubbedChain;
-  let regenStub: SinonStubbedInstance<StateRegenerator>;
   let state: CachedBeaconState<allForks.BeaconState>;
   let signedVoluntaryExit: phase0.SignedVoluntaryExit;
 
@@ -72,8 +70,7 @@ describe("validate voluntary exit", () => {
     chainStub.forkChoice = sandbox.createStubInstance(ForkChoice);
     // TODO: Use actual BLS verification
     chainStub.bls = {verifySignatureSets: async () => true};
-    regenStub = chainStub.regen = sandbox.createStubInstance(StateRegenerator);
-    regenStub.getCheckpointState.resolves(state);
+    chainStub.getHeadState.returns(state);
     dbStub = new StubbedBeaconDb(sandbox);
     dbStub.voluntaryExit.has.resolves(false);
   });


### PR DESCRIPTION
What state should the voluntaryExit validate against?


The only condtion that is time sensitive and may require a non-head state is
- Validator is active && validator has not initiated exit

The voluntaryExit.epoch must be in the past so using the head state may evaluate the validator's status in the future, compared to using a state at epoch voluntaryExit.epoch. Unless there's a clear need to use a non-head state, will use the head state as its cheap.