### PR TITLE
Add discv5 metrics to grafana dashboard

### DIFF
--- a/docker/grafana/provisioning/dashboards/lodestar.json
+++ b/docker/grafana/provisioning/dashboards/lodestar.json
@@ -7675,6 +7675,491 @@
         "x": 0,
         "y": 29
       },
+      "id": 232,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 30
+          },
+          "hiddenSeries": false,
+          "id": 238,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "lodestar_discv5_connected_peer_count",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Connected Peer Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 30
+          },
+          "hiddenSeries": false,
+          "id": 236,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "lodestar_discv5_active_session_count",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Active Session Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 38
+          },
+          "hiddenSeries": false,
+          "id": 240,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "lodestar_discv5_sent_message_count",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Sent Message Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 38
+          },
+          "hiddenSeries": false,
+          "id": 242,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "lodestar_discv5_rcvd_message_count",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Received Message Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 46
+          },
+          "hiddenSeries": false,
+          "id": 234,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "lodestar_discv5_kad_table_size",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "KAD Table Size",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Discv5",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
       "id": 164,
       "panels": [
         {

--- a/docker/grafana/provisioning/dashboards/lodestar.json
+++ b/docker/grafana/provisioning/dashboards/lodestar.json
@@ -7912,7 +7912,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "lodestar_discv5_sent_message_count",
+              "expr": "rate(lodestar_discv5_sent_message_count[$__rate_interval])",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -8006,7 +8006,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "lodestar_discv5_rcvd_message_count",
+              "expr": "rate(lodestar_discv5_rcvd_message_count[$__rate_interval])",
               "interval": "",
               "legendFormat": "",
               "refId": "A"

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -4,7 +4,7 @@ import {ErrorAborted} from "@chainsafe/lodestar-utils";
 import {LevelDbController} from "@chainsafe/lodestar-db";
 import {BeaconNode, BeaconDb, createNodeJsLibp2p} from "@chainsafe/lodestar";
 // eslint-disable-next-line no-restricted-imports
-import {createDbMetrics} from "@chainsafe/lodestar/lib/metrics";
+import {createDbMetrics, createDiscv5Metrics} from "@chainsafe/lodestar/lib/metrics";
 import {createIBeaconConfig} from "@chainsafe/lodestar-config";
 
 import {IGlobalArgs} from "../../options";
@@ -54,11 +54,15 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
   logger.info("Lodestar", {version: version, network: args.network});
 
   let dbMetrics: null | ReturnType<typeof createDbMetrics> = null;
+  let discv5Metrics: null | ReturnType<typeof createDiscv5Metrics> = null;
   // additional metrics registries
   const metricsRegistries = [];
   if (options.metrics.enabled) {
     dbMetrics = createDbMetrics();
-    metricsRegistries.push(dbMetrics.registry);
+    discv5Metrics = createDiscv5Metrics();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    options.network.discv5!.metrics = discv5Metrics.metrics;
+    metricsRegistries.push(dbMetrics.registry, discv5Metrics.registry);
   }
   const db = new BeaconDb({
     config,

--- a/packages/lodestar/src/metrics/metrics.ts
+++ b/packages/lodestar/src/metrics/metrics.ts
@@ -12,7 +12,7 @@ import {createLodestarMetrics, ILodestarMetrics} from "./metrics/lodestar";
 import {IMetricsOptions} from "./options";
 import {RegistryMetricCreator} from "./utils/registryMetricCreator";
 import {createValidatorMonitor, IValidatorMonitor} from "./validatorMonitor";
-import { IDiscv5Metrics } from "@chainsafe/discv5";
+import {IDiscv5Metrics} from "@chainsafe/discv5";
 
 export type IMetrics = IBeaconMetrics & ILodestarMetrics & IValidatorMonitor & {register: Registry};
 

--- a/packages/lodestar/src/metrics/metrics.ts
+++ b/packages/lodestar/src/metrics/metrics.ts
@@ -85,10 +85,12 @@ export function createDiscv5Metrics(): {metrics: IDiscv5Metrics; registry: Regis
     sentMessageCount: new Gauge<"type">({
       name: "lodestar_discv5_sent_message_count",
       help: "Count of the discv5 messages sent by message type",
+      labelNames: ["type"],
     }) as Gauge<"type"> & {collect(): void},
     rcvdMessageCount: new Gauge<"type">({
       name: "lodestar_discv5_rcvd_message_count",
       help: "Count of the discv5 messages received by message type",
+      labelNames: ["type"],
     }) as Gauge<"type"> & {collect(): void},
   };
   const registry = new Registry();

--- a/packages/lodestar/src/metrics/metrics.ts
+++ b/packages/lodestar/src/metrics/metrics.ts
@@ -4,7 +4,7 @@
 import {getCurrentSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {allForks} from "@chainsafe/lodestar-types";
-import {collectDefaultMetrics, Counter, Registry} from "prom-client";
+import {collectDefaultMetrics, Counter, Gauge, Registry} from "prom-client";
 import gcStats from "prometheus-gc-stats";
 import {DbMetricLabels, IDbMetrics} from "@chainsafe/lodestar-db";
 import {createBeaconMetrics, IBeaconMetrics} from "./metrics/beacon";
@@ -12,6 +12,7 @@ import {createLodestarMetrics, ILodestarMetrics} from "./metrics/lodestar";
 import {IMetricsOptions} from "./options";
 import {RegistryMetricCreator} from "./utils/registryMetricCreator";
 import {createValidatorMonitor, IValidatorMonitor} from "./validatorMonitor";
+import { IDiscv5Metrics } from "@chainsafe/discv5";
 
 export type IMetrics = IBeaconMetrics & ILodestarMetrics & IValidatorMonitor & {register: Registry};
 
@@ -64,5 +65,33 @@ export function createDbMetrics(): {metrics: IDbMetrics; registry: Registry} {
   const registry = new Registry();
   registry.registerMetric(metrics.dbReads);
   registry.registerMetric(metrics.dbWrites);
+  return {metrics, registry};
+}
+
+export function createDiscv5Metrics(): {metrics: IDiscv5Metrics; registry: Registry} {
+  const metrics = {
+    kadTableSize: new Gauge({
+      name: "lodestar_discv5_kad_table_size",
+      help: "Total size of the discv5 kad table",
+    }) as Gauge<string> & {collect(): void},
+    activeSessionCount: new Gauge({
+      name: "lodestar_discv5_active_session_count",
+      help: "Count of the discv5 active sessions",
+    }) as Gauge<string> & {collect(): void},
+    connectedPeerCount: new Gauge({
+      name: "lodestar_discv5_connected_peer_count",
+      help: "Count of the discv5 connected peers",
+    }) as Gauge<string> & {collect(): void},
+    sentMessageCount: new Gauge<"type">({
+      name: "lodestar_discv5_sent_message_count",
+      help: "Count of the discv5 messages sent by message type",
+    }) as Gauge<"type"> & {collect(): void},
+    rcvdMessageCount: new Gauge<"type">({
+      name: "lodestar_discv5_rcvd_message_count",
+      help: "Count of the discv5 messages received by message type",
+    }) as Gauge<"type"> & {collect(): void},
+  };
+  const registry = new Registry();
+  Object.keys(metrics).forEach((metricName) => registry.registerMetric(metrics[metricName as keyof typeof metrics]));
   return {metrics, registry};
 }

--- a/packages/lodestar/src/network/nodejs/bundle.ts
+++ b/packages/lodestar/src/network/nodejs/bundle.ts
@@ -9,7 +9,7 @@ import {NOISE} from "@chainsafe/libp2p-noise";
 import Bootstrap from "libp2p-bootstrap";
 import MDNS from "libp2p-mdns";
 import PeerId from "peer-id";
-import {ENRInput, Discv5Discovery} from "@chainsafe/discv5";
+import {ENRInput, Discv5Discovery, IDiscv5Metrics} from "@chainsafe/discv5";
 import {Datastore} from "interface-datastore";
 
 export interface ILibp2pOptions {
@@ -24,6 +24,7 @@ export interface ILibp2pOptions {
     bindAddr: string;
     enr: ENRInput;
     bootEnrs?: ENRInput[];
+    metrics?: IDiscv5Metrics;
   };
   peerDiscovery?: (typeof Bootstrap | typeof MDNS | typeof Discv5Discovery)[];
   bootMultiaddrs?: string[];
@@ -86,6 +87,7 @@ export class NodejsNode extends LibP2p {
             enr: options.discv5.enr,
             bindAddr: options.discv5.bindAddr,
             bootEnrs: options.discv5.bootEnrs || [],
+            metrics: options.discv5.metrics,
           },
         },
       },


### PR DESCRIPTION
**Motivation**
See #3041 

**Description**

Feeds metrics from lodestar into discv5 when metrics are enabled
Adds current discv5 metrics to grafana dashboard under a "Discv5" row