### PR TITLE
Cache head state in BeaconChain instance

### DIFF
--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -245,6 +245,23 @@ export class ForkChoice implements IForkChoice {
     return this.fcStore.bestJustifiedCheckpoint;
   }
 
+  // TODO: Optimize
+  /** Returns the distance to the common ancestor, or null if descendants */
+  commonAncestorDistance(prevBlock: IBlockSummary, newBlock: IBlockSummary): null | number {
+    const prevRoot = prevBlock.blockRoot;
+    const newRoot = newBlock.blockRoot;
+
+    if (this.isDescendant(prevRoot, newRoot)) {
+      return null;
+    }
+
+    // chain reorg
+    const oldHeadHistory = this.iterateBlockSummaries(prevRoot);
+    const headHistory = this.iterateBlockSummaries(newRoot);
+    const firstAncestor = headHistory.find((summary) => oldHeadHistory.includes(summary));
+    return prevBlock.slot - (firstAncestor?.slot ?? newBlock.slot);
+  }
+
   /**
    * Add `block` to the fork choice DAG.
    *

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -121,6 +121,7 @@ export interface IForkChoice {
   forwardIterateBlockSummaries(): IBlockSummary[];
   getBlockSummariesByParentRoot(parentRoot: phase0.Root): IBlockSummary[];
   getBlockSummariesAtSlot(slot: Slot): IBlockSummary[];
+  commonAncestorDistance(prevBlock: IBlockSummary, newBlock: IBlockSummary): null | number;
 }
 
 export interface ILatestMessage {

--- a/packages/lodestar/src/chain/blocks/validate.ts
+++ b/packages/lodestar/src/chain/blocks/validate.ts
@@ -1,18 +1,15 @@
 import {computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {IBlockJob} from "../interface";
+import {BlockError, BlockErrorCode} from "../errors";
+import {IBeaconClock} from "../clock";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 
-import {IBlockJob} from "../interface";
-import {IBeaconClock} from "../clock";
-import {BlockError, BlockErrorCode} from "../errors";
-
-export type BlockValidateModules = {
-  config: IChainForkConfig;
-  forkChoice: IForkChoice;
-  clock: IBeaconClock;
-};
-
-export function validateBlock({config, forkChoice, clock}: BlockValidateModules, job: IBlockJob): void {
+export function validateBlock(
+  modules: {config: IChainForkConfig; forkChoice: IForkChoice; clock: IBeaconClock},
+  job: IBlockJob
+): void {
+  const {config, forkChoice, clock} = modules;
   const block = job.signedBlock;
 
   try {

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -15,6 +15,8 @@ import {AttestationPool, SyncCommitteeMessagePool, SyncContributionAndProofPool}
 import {IForkDigestContext} from "../util/forkDigestContext";
 import {LightClientIniter} from "./lightClient";
 import {AggregatedAttestationPool} from "./opPools/aggregatedAttestationPool";
+import {IMetrics} from "../metrics";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
 export interface IProcessBlock {
   /**
@@ -51,6 +53,8 @@ export interface IBlockJob extends IProcessBlock {
 export interface IBeaconChain {
   readonly genesisTime: Number64;
   readonly genesisValidatorsRoot: Root;
+  readonly metrics: IMetrics | null;
+  readonly config: IBeaconConfig;
 
   bls: IBlsVerifier;
   forkChoice: IForkChoice;
@@ -81,6 +85,8 @@ export interface IBeaconChain {
   persistToDisk(): Promise<void>;
   getGenesisTime(): Number64;
 
+  /** Run fork-choice and may change head. If so get head state from regen */
+  updateHead(): void;
   getHeadState(): CachedBeaconState<allForks.BeaconState>;
   getHeadStateAtCurrentEpoch(): Promise<CachedBeaconState<allForks.BeaconState>>;
   getHeadStateAtCurrentSlot(): Promise<CachedBeaconState<allForks.BeaconState>>;

--- a/packages/lodestar/test/unit/chain/blocks/process.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/process.test.ts
@@ -3,7 +3,7 @@ import sinon, {SinonStubbedInstance} from "sinon";
 
 import {ForkChoice} from "@chainsafe/lodestar-fork-choice";
 
-import {ChainEventEmitter} from "../../../../src/chain";
+import {ChainEventEmitter, IBeaconChain} from "../../../../src/chain";
 import {BlockError, BlockErrorCode} from "../../../../src/chain/errors";
 import {CheckpointStateCache} from "../../../../src/chain/stateCache";
 import {processBlock} from "../../../../src/chain/blocks/process";
@@ -38,7 +38,11 @@ describe("processBlock", function () {
     const job = getNewBlockJob(signedBlock);
     forkChoice.hasBlock.returns(false);
     try {
-      await processBlock({forkChoice, checkpointStateCache, regen, emitter, bls, metrics}, job);
+      await processBlock(
+        ({forkChoice, checkpointStateCache, regen, emitter, bls, metrics} as Partial<IBeaconChain>) as IBeaconChain,
+        {},
+        job
+      );
       expect.fail("block should throw");
     } catch (e) {
       expect((e as BlockError).type.code).to.equal(BlockErrorCode.PARENT_UNKNOWN);
@@ -52,7 +56,11 @@ describe("processBlock", function () {
     forkChoice.hasBlock.returns(true);
     regen.getPreState.rejects(new RegenError({code: RegenErrorCode.STATE_TRANSITION_ERROR, error: new Error()}));
     try {
-      await processBlock({forkChoice, checkpointStateCache, regen, emitter, bls, metrics}, job);
+      await processBlock(
+        ({forkChoice, checkpointStateCache, regen, emitter, bls, metrics} as Partial<IBeaconChain>) as IBeaconChain,
+        {},
+        job
+      );
       expect.fail("block should throw");
     } catch (e) {
       expect((e as BlockError).type.code).to.equal(BlockErrorCode.PRESTATE_MISSING);


### PR DESCRIPTION
**Motivation**

As a previous step to having a state cache with WeakRefs, the head state must be strongly held somewhere. This PR implements and approach inspired by Lighthouse, where the canonical head state is kept in the BeaconChain class

**Description**

- Keep head state in BeaconChain class
- Required changing the API of all processors and regen to get be able to call `chain.updateHead()` inside the state transition fn runner