### PR TITLE
Benchmark proxy cost

### DIFF
--- a/packages/beacon-state-transition/test/perf/misc/proxy.test.ts
+++ b/packages/beacon-state-transition/test/perf/misc/proxy.test.ts
@@ -1,0 +1,46 @@
+import {itBench} from "@dapplion/benchmark";
+import {expect} from "chai";
+
+describe("Proxy cost", () => {
+  const n = 100_000;
+  const array: number[] = [];
+  for (let i = 0; i < n; i++) {
+    array.push(i);
+  }
+
+  const arrayWithProxy = new Proxy(array, {
+    get(target, p) {
+      if (p === "length") {
+        return target.length;
+      } else {
+        return target[(p as unknown) as number];
+      }
+    },
+  });
+
+  const wrappedArray = {
+    array,
+    get(i: number) {
+      return this.array[i];
+    },
+  };
+
+  it("Check is correct", () => {
+    for (const i of [0, 1, Math.floor(n / 2)]) {
+      expect(array[i]).to.equal(i, `Wrong value array[${i}]`);
+      expect(arrayWithProxy[i]).to.equal(i, `Wrong value arrayWithProxy[${i}]`);
+    }
+  });
+
+  itBench(`regular array get ${n} times`, () => {
+    for (let i = 0; i < n; i++) array[i];
+  });
+
+  itBench(`wrappedArray get ${n} times`, () => {
+    for (let i = 0; i < n; i++) wrappedArray.get(i);
+  });
+
+  itBench(`arrayWithProxy get ${n} times`, () => {
+    for (let i = 0; i < n; i++) arrayWithProxy[i];
+  });
+});


### PR DESCRIPTION
**Motivation**

We use Proxy for TreeBacked values. What's the cost of getting properties through it?

**Description**

A lot! Getting an array property through a proxy is x180 times slower than using a regular array. We should consider a different approach for performance reasons:

```
  Proxy cost
    ✓ Check is correct
    ✓ regular array get 100000 times                                      6901.740 ops/s    144.8910 us/op   x0.998      30730 runs   4.54 s
    ✓ wrappedArray get 100000 times                                       15244.60 ops/s    65.59700 us/op   x0.993       6316 runs  0.505 s
    ✓ arrayWithProxy get 100000 times                                     36.63105 ops/s    27.29925 ms/op   x0.908         17 runs  0.969 s
```