### PR TITLE
Use consistent RootHex type

### DIFF
--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import {fromHexString, readonlyValues, toHexString} from "@chainsafe/ssz";
 import {SAFE_SLOTS_TO_UPDATE_JUSTIFIED, SLOTS_PER_HISTORICAL_ROOT} from "@chainsafe/lodestar-params";
-import {Slot, ValidatorIndex, phase0, allForks, ssz, BlockRootHex, Epoch} from "@chainsafe/lodestar-types";
+import {Slot, ValidatorIndex, phase0, allForks, ssz, RootHex, Epoch} from "@chainsafe/lodestar-types";
 import {
   computeSlotsSinceEpochStart,
   computeStartSlotAtEpoch,
@@ -796,7 +796,7 @@ export class ForkChoice implements IForkChoice {
   /**
    * Add a validator's latest message to the tracked votes
    */
-  private addLatestMessage(validatorIndex: ValidatorIndex, nextEpoch: Epoch, nextRoot: BlockRootHex): void {
+  private addLatestMessage(validatorIndex: ValidatorIndex, nextEpoch: Epoch, nextRoot: RootHex): void {
     this.synced = false;
     const vote = this.votes[validatorIndex];
     if (!vote) {

--- a/packages/fork-choice/src/protoArray/errors.ts
+++ b/packages/fork-choice/src/protoArray/errors.ts
@@ -1,6 +1,5 @@
-import {Epoch} from "@chainsafe/lodestar-types";
+import {Epoch, RootHex} from "@chainsafe/lodestar-types";
 import {LodestarError} from "@chainsafe/lodestar-utils";
-import {HexRoot} from "./interface";
 
 export enum ProtoArrayErrorCode {
   FINALIZED_NODE_UNKNOWN = "PROTO_ARRAY_ERROR_FINALIZED_NODE_UNKNOWN",
@@ -20,8 +19,8 @@ export enum ProtoArrayErrorCode {
 }
 
 export type ProtoArrayErrorType =
-  | {code: ProtoArrayErrorCode.FINALIZED_NODE_UNKNOWN; root: HexRoot}
-  | {code: ProtoArrayErrorCode.JUSTIFIED_NODE_UNKNOWN; root: HexRoot}
+  | {code: ProtoArrayErrorCode.FINALIZED_NODE_UNKNOWN; root: RootHex}
+  | {code: ProtoArrayErrorCode.JUSTIFIED_NODE_UNKNOWN; root: RootHex}
   | {code: ProtoArrayErrorCode.INVALID_FINALIZED_ROOT_CHANGE}
   | {code: ProtoArrayErrorCode.INVALID_NODE_INDEX; index: number}
   | {code: ProtoArrayErrorCode.INVALID_PARENT_INDEX; index: number}
@@ -35,10 +34,10 @@ export type ProtoArrayErrorType =
   | {code: ProtoArrayErrorCode.REVERTED_FINALIZED_EPOCH; currentFinalizedEpoch: Epoch; newFinalizedEpoch: Epoch}
   | {
       code: ProtoArrayErrorCode.INVALID_BEST_NODE;
-      startRoot: HexRoot;
+      startRoot: RootHex;
       justifiedEpoch: Epoch;
       finalizedEpoch: Epoch;
-      headRoot: HexRoot;
+      headRoot: RootHex;
       headJustifiedEpoch: Epoch;
       headFinalizedEpoch: Epoch;
     };

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -1,18 +1,15 @@
-import {Epoch, Slot} from "@chainsafe/lodestar-types";
+import {Epoch, Slot, RootHex} from "@chainsafe/lodestar-types";
 
-/**
- * HexRoot is a root as a hex string
- * Used for lightweight and easy comparison
- */
-export type HexRoot = string;
+// RootHex is a root as a hex string
+// Used for lightweight and easy comparison
 export const HEX_ZERO_HASH = "0x0000000000000000000000000000000000000000000000000000000000000000";
 
 /**
  * Simplified 'latest message' with previous message
  */
 export interface IVoteTracker {
-  currentRoot: HexRoot;
-  nextRoot: HexRoot;
+  currentRoot: RootHex;
+  nextRoot: RootHex;
   nextEpoch: Epoch;
 }
 
@@ -28,24 +25,24 @@ export interface IProtoBlock {
    * This is useful for upstream fork choice logic.
    */
   slot: Slot;
-  blockRoot: HexRoot;
-  parentRoot: HexRoot;
+  blockRoot: RootHex;
+  parentRoot: RootHex;
   /**
    * The stateRoot is not necessary for ProtoArray either,
    * it also just exists for upstream components (namely attestation verification)
    */
-  stateRoot: HexRoot;
+  stateRoot: RootHex;
   /**
    * The root that would be used for the attestation.data.target.root if a LMD vote was cast for this block.
    *
    * The targetRoot is not necessary for ProtoArray either,
    * it also just exists for upstream components (namely attestation verification)
    */
-  targetRoot: HexRoot;
+  targetRoot: RootHex;
   justifiedEpoch: Epoch;
-  justifiedRoot: HexRoot;
+  justifiedRoot: RootHex;
   finalizedEpoch: Epoch;
-  finalizedRoot: HexRoot;
+  finalizedRoot: RootHex;
 }
 
 /**

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -1,6 +1,6 @@
-import {Epoch, Slot} from "@chainsafe/lodestar-types";
+import {Epoch, Slot, RootHex} from "@chainsafe/lodestar-types";
 
-import {HexRoot, IProtoBlock, IProtoNode, HEX_ZERO_HASH} from "./interface";
+import {IProtoBlock, IProtoNode, HEX_ZERO_HASH} from "./interface";
 import {ProtoArrayError, ProtoArrayErrorCode} from "./errors";
 
 export const DEFAULT_PRUNE_THRESHOLD = 0;
@@ -10,11 +10,11 @@ export class ProtoArray {
   // Small prunes simply waste time
   pruneThreshold: number;
   justifiedEpoch: Epoch;
-  justifiedRoot: HexRoot;
+  justifiedRoot: RootHex;
   finalizedEpoch: Epoch;
-  finalizedRoot: HexRoot;
+  finalizedRoot: RootHex;
   nodes: IProtoNode[];
-  indices: Map<HexRoot, number>;
+  indices: Map<RootHex, number>;
 
   constructor({
     pruneThreshold,
@@ -25,9 +25,9 @@ export class ProtoArray {
   }: {
     pruneThreshold: number;
     justifiedEpoch: Epoch;
-    justifiedRoot: HexRoot;
+    justifiedRoot: RootHex;
     finalizedEpoch: Epoch;
-    finalizedRoot: HexRoot;
+    finalizedRoot: RootHex;
   }) {
     this.pruneThreshold = pruneThreshold;
     this.justifiedEpoch = justifiedEpoch;
@@ -49,13 +49,13 @@ export class ProtoArray {
     finalizedRoot,
   }: {
     slot: Slot;
-    parentRoot: HexRoot;
-    stateRoot: HexRoot;
-    blockRoot: HexRoot;
+    parentRoot: RootHex;
+    stateRoot: RootHex;
+    blockRoot: RootHex;
     justifiedEpoch: Epoch;
-    justifiedRoot: HexRoot;
+    justifiedRoot: RootHex;
     finalizedEpoch: Epoch;
-    finalizedRoot: HexRoot;
+    finalizedRoot: RootHex;
   }): ProtoArray {
     const protoArray = new ProtoArray({
       pruneThreshold: DEFAULT_PRUNE_THRESHOLD,
@@ -104,9 +104,9 @@ export class ProtoArray {
   }: {
     deltas: number[];
     justifiedEpoch: Epoch;
-    justifiedRoot: HexRoot;
+    justifiedRoot: RootHex;
     finalizedEpoch: Epoch;
-    finalizedRoot: HexRoot;
+    finalizedRoot: RootHex;
   }): void {
     if (deltas.length !== this.indices.size) {
       throw new ProtoArrayError({
@@ -212,7 +212,7 @@ export class ProtoArray {
   /**
    * Follows the best-descendant links to find the best-block (i.e., head-block).
    */
-  findHead(justifiedRoot: HexRoot): HexRoot {
+  findHead(justifiedRoot: RootHex): RootHex {
     const justifiedIndex = this.indices.get(justifiedRoot);
     if (justifiedIndex === undefined) {
       throw new ProtoArrayError({
@@ -276,7 +276,7 @@ export class ProtoArray {
    * - The finalized epoch is equal to the current one, but the finalized root is different.
    * - There is some internal error relating to invalid indices inside `this`.
    */
-  maybePrune(finalizedRoot: HexRoot): IProtoBlock[] {
+  maybePrune(finalizedRoot: RootHex): IProtoBlock[] {
     const finalizedIndex = this.indices.get(finalizedRoot);
     if (finalizedIndex === undefined) {
       throw new ProtoArrayError({
@@ -491,7 +491,7 @@ export class ProtoArray {
   /**
    * Iterate from a block root backwards over nodes
    */
-  iterateNodes(blockRoot: HexRoot): IProtoNode[] {
+  iterateNodes(blockRoot: RootHex): IProtoNode[] {
     const startIndex = this.indices.get(blockRoot);
     if (startIndex === undefined) {
       return [];
@@ -524,7 +524,7 @@ export class ProtoArray {
    * iterateNodes is to find ancestor nodes of a blockRoot.
    * this is to find non-ancestor nodes of a blockRoot.
    */
-  iterateNonAncestorNodes(blockRoot: HexRoot): IProtoNode[] {
+  iterateNonAncestorNodes(blockRoot: RootHex): IProtoNode[] {
     const startIndex = this.indices.get(blockRoot);
     if (startIndex === undefined) {
       return [];
@@ -566,7 +566,7 @@ export class ProtoArray {
     return result;
   }
 
-  hasBlock(blockRoot: HexRoot): boolean {
+  hasBlock(blockRoot: RootHex): boolean {
     return this.indices.has(blockRoot);
   }
 
@@ -594,7 +594,7 @@ export class ProtoArray {
     return result;
   }
 
-  getNode(blockRoot: HexRoot): IProtoNode | undefined {
+  getNode(blockRoot: RootHex): IProtoNode | undefined {
     const blockIndex = this.indices.get(blockRoot);
     if (blockIndex === undefined) {
       return undefined;
@@ -602,7 +602,7 @@ export class ProtoArray {
     return this.getNodeByIndex(blockIndex);
   }
 
-  getBlock(blockRoot: HexRoot): IProtoBlock | undefined {
+  getBlock(blockRoot: RootHex): IProtoBlock | undefined {
     const node = this.getNode(blockRoot);
     if (!node) {
       return undefined;
@@ -617,7 +617,7 @@ export class ProtoArray {
    * Always returns `false` if either input roots are unknown.
    * Still returns `true` if `ancestorRoot` === `descendantRoot` (and the roots are known)
    */
-  isDescendant(ancestorRoot: HexRoot, descendantRoot: HexRoot): boolean {
+  isDescendant(ancestorRoot: RootHex, descendantRoot: RootHex): boolean {
     const ancestorNode = this.getNode(ancestorRoot);
     if (!ancestorNode) {
       return false;

--- a/packages/types/src/primitive/types.ts
+++ b/packages/types/src/primitive/types.ts
@@ -35,6 +35,7 @@ export type Domain = Bytes32;
 export type BLSPubkey = Bytes48;
 export type BLSSecretKey = Bytes32;
 export type BLSSignature = Bytes96;
-export type BlockRootHex = string;
-export type AttestationRootHex = string;
 export type ParticipationFlags = Uint8;
+
+/** Common non-spec type to represent roots as strings */
+export type RootHex = string;


### PR DESCRIPTION
**Motivation**

From https://github.com/ChainSafe/lodestar/pull/3118, uses uniform naming for a string that represents a root.

**Description**

Export `RootHex` type from types. Use consistently across monorepo