### PR TITLE
Optimize fork-choice iterators

### DIFF
--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -107,13 +107,17 @@ export interface IForkChoice {
   prune(finalizedRoot: phase0.Root): IBlockSummary[];
   setPruneThreshold(threshold: number): void;
   /**
-   * Iterates backwards through block summaries, starting from a block root
+   * Iterates backwards through ancestor block summaries, starting from a block root
    */
-  iterateBlockSummaries(blockRoot: phase0.Root): IBlockSummary[];
+  iterateAncestorBlocks(blockRoot: phase0.Root): IterableIterator<IBlockSummary>;
   /**
-   * The same to iterateBlockSummaries but this gets non-ancestor nodes instead of ancestor nodes.
+   * Returns all ancestor blocks backwards, starting from a block root
    */
-  iterateNonAncestors(blockRoot: phase0.Root): IBlockSummary[];
+  getAllAncestorBlocks(blockRoot: phase0.Root): IBlockSummary[];
+  /**
+   * The same to getAllAncestorBlocks but this gets non-ancestor nodes instead of ancestor nodes.
+   */
+  getAllNonAncestorBlocks(blockRoot: phase0.Root): IBlockSummary[];
   getCanonicalBlockSummaryAtSlot(slot: Slot): IBlockSummary | null;
   /**
    * Iterates forwards through block summaries, exact order is not guaranteed
@@ -121,6 +125,8 @@ export interface IForkChoice {
   forwardIterateBlockSummaries(): IBlockSummary[];
   getBlockSummariesByParentRoot(parentRoot: phase0.Root): IBlockSummary[];
   getBlockSummariesAtSlot(slot: Slot): IBlockSummary[];
+  /** Returns the distance of common ancestor of nodes to newNode. Returns null if newNode is descendant of prevNode */
+  getCommonAncestorDistance(prevBlock: IBlockSummary, newBlock: IBlockSummary): number | null;
 }
 
 export interface ILatestMessage {

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -44,7 +44,7 @@ describe("Forkchoice", function () {
     bestJustifiedCheckpoint: {root: fromHexString(finalizedRoot), epoch: genesisEpoch},
   };
 
-  it("iterateBlockSummaries", function () {
+  it("getAllAncestorBlocks", function () {
     protoArr.onBlock(block);
     const forkchoice = new ForkChoice({
       config,
@@ -53,8 +53,8 @@ describe("Forkchoice", function () {
       queuedAttestations: new Set(),
       justifiedBalances: [],
     });
-    const summaries = forkchoice.iterateBlockSummaries(fromHexString(finalizedDesc));
-    // there are 2 blocks in protoArray but iterateBlockSummaries should only return non-finalized blocks
+    const summaries = forkchoice.getAllAncestorBlocks(fromHexString(finalizedDesc));
+    // there are 2 blocks in protoArray but getAllAncestorBlocks should only return non-finalized blocks
     expect(summaries.length).to.be.equals(1, "should not return the finalized block");
     expect(summaries[0]).to.be.deep.equals(toBlockSummary(block), "the block summary is not correct");
   });

--- a/packages/lodestar/src/chain/archiver/archiveBlocks.ts
+++ b/packages/lodestar/src/chain/archiver/archiveBlocks.ts
@@ -20,10 +20,10 @@ export async function archiveBlocks(
   finalized: phase0.Checkpoint
 ): Promise<void> {
   // Use fork choice to determine the blocks to archive and delete
-  const allCanonicalSummaries = forkChoice.iterateBlockSummaries(finalized.root);
-  // 1st block in iterateBlockSummaries() is the finalized block itself
+  const allCanonicalSummaries = forkChoice.getAllAncestorBlocks(finalized.root);
+  // 1st block in getAllAncestorBlocks() is the finalized block itself
   // we move it to blockArchive but forkchoice still have it to check next onBlock calls
-  // the next iterateBlockSummaries call does not return this block
+  // the next getAllAncestorBlocks call does not return this block
   let i = 0;
   // this number of blocks per chunk is tested in e2e test blockArchive.test.ts
   const BATCH_SIZE = 1000;
@@ -65,7 +65,7 @@ export async function archiveBlocks(
 
   // deleteNonCanonicalBlocks
   // loop through forkchoice single time
-  const nonCanonicalSummaries = forkChoice.iterateNonAncestors(finalized.root);
+  const nonCanonicalSummaries = forkChoice.getAllNonAncestorBlocks(finalized.root);
   if (nonCanonicalSummaries && nonCanonicalSummaries.length > 0) {
     await db.block.batchDelete(nonCanonicalSummaries.map((summary) => summary.blockRoot));
     logger.verbose("deleteNonCanonicalBlocks", {

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -220,7 +220,7 @@ export class BeaconChain implements IBeaconChain {
     const blockRootsPerSlot = new Map<Slot, Promise<allForks.SignedBeaconBlock | null>>();
 
     // these blocks are on the same chain to head
-    for (const summary of this.forkChoice.iterateBlockSummaries(this.forkChoice.getHeadRoot())) {
+    for (const summary of this.forkChoice.getAllAncestorBlocks(this.forkChoice.getHeadRoot())) {
       if (slotsSet.has(summary.slot)) {
         blockRootsPerSlot.set(summary.slot, this.db.block.get(summary.blockRoot));
       }

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -162,7 +162,7 @@ export class StateRegenerator implements IStateRegenerator {
     // gets reversed when replayed
     const blocksToReplay = [block];
     let state: CachedBeaconState<allForks.BeaconState> | null = null;
-    for (const b of this.forkChoice.iterateBlockSummaries(block.parentRoot)) {
+    for (const b of this.forkChoice.iterateAncestorBlocks(block.parentRoot)) {
       state = this.stateCache.get(b.stateRoot);
       if (state) {
         break;

--- a/packages/lodestar/test/unit/chain/archive/blockArchiver.test.ts
+++ b/packages/lodestar/test/unit/chain/archive/blockArchiver.test.ts
@@ -29,8 +29,8 @@ describe("block archiver task", function () {
     );
     const canonicalBlocks = [blocks[4], blocks[3], blocks[1], blocks[0]];
     const nonCanonicalBlocks = [blocks[2]];
-    forkChoiceStub.iterateBlockSummaries.returns(canonicalBlocks);
-    forkChoiceStub.iterateNonAncestors.returns(nonCanonicalBlocks);
+    forkChoiceStub.getAllAncestorBlocks.returns(canonicalBlocks);
+    forkChoiceStub.getAllNonAncestorBlocks.returns(nonCanonicalBlocks);
     await archiveBlocks(dbStub, forkChoiceStub, logger, {epoch: 5, root: ZERO_HASH});
     expect(
       dbStub.blockArchive.batchPutBinary.calledWith(

--- a/packages/lodestar/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/lodestar/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -142,13 +142,13 @@ describe("LodestarForkChoice", function () {
       forkChoice.onBlock(block20.message, state20, justifiedBalances);
       forkChoice.onBlock(block24.message, state24, justifiedBalances);
       forkChoice.onBlock(block28.message, state28, justifiedBalances);
-      expect(forkChoice.iterateBlockSummaries(ssz.phase0.BeaconBlock.hashTreeRoot(block16.message)).length).to.be.equal(
+      expect(forkChoice.getAllAncestorBlocks(ssz.phase0.BeaconBlock.hashTreeRoot(block16.message)).length).to.be.equal(
         3,
-        "iterateBlockSummaries should return 3 blocks"
+        "getAllAncestorBlocks should return 3 blocks"
       );
-      expect(forkChoice.iterateBlockSummaries(ssz.phase0.BeaconBlock.hashTreeRoot(block24.message)).length).to.be.equal(
+      expect(forkChoice.getAllAncestorBlocks(ssz.phase0.BeaconBlock.hashTreeRoot(block24.message)).length).to.be.equal(
         5,
-        "iterateBlockSummaries should return 5 blocks"
+        "getAllAncestorBlocks should return 5 blocks"
       );
       expect(forkChoice.getBlock(ssz.phase0.BeaconBlock.hashTreeRoot(block08.message))).to.be.not.null;
       expect(forkChoice.getBlock(ssz.phase0.BeaconBlock.hashTreeRoot(block12.message))).to.be.not.null;
@@ -156,13 +156,13 @@ describe("LodestarForkChoice", function () {
       expect(forkChoice.hasBlock(ssz.phase0.BeaconBlock.hashTreeRoot(block12.message))).to.be.true;
       forkChoice.onBlock(block32.message, state32, justifiedBalances);
       forkChoice.prune(ssz.phase0.BeaconBlock.hashTreeRoot(block16.message));
-      expect(forkChoice.iterateBlockSummaries(ssz.phase0.BeaconBlock.hashTreeRoot(block16.message)).length).to.be.equal(
+      expect(forkChoice.getAllAncestorBlocks(ssz.phase0.BeaconBlock.hashTreeRoot(block16.message)).length).to.be.equal(
         0,
-        "iterateBlockSummaries should not return finalized block"
+        "getAllAncestorBlocks should not return finalized block"
       );
-      expect(forkChoice.iterateBlockSummaries(ssz.phase0.BeaconBlock.hashTreeRoot(block24.message)).length).to.be.equal(
+      expect(forkChoice.getAllAncestorBlocks(ssz.phase0.BeaconBlock.hashTreeRoot(block24.message)).length).to.be.equal(
         2,
-        "iterateBlockSummaries should return 2 blocks"
+        "getAllAncestorBlocks should return 2 blocks"
       );
       expect(forkChoice.getBlock(ssz.phase0.BeaconBlock.hashTreeRoot(block08.message))).to.be.null;
       expect(forkChoice.getBlock(ssz.phase0.BeaconBlock.hashTreeRoot(block12.message))).to.be.null;
@@ -175,7 +175,7 @@ describe("LodestarForkChoice", function () {
      *                     \
      *                       parent (34) - child (35)
      */
-    it("iterateNonAncestors - should get non ancestor nodes", () => {
+    it("getAllNonAncestorBlocks - should get non ancestor nodes", () => {
       const {blockHeader} = computeAnchorCheckpoint(config, anchorState);
       const finalizedRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(blockHeader);
       const targetBlock = generateSignedBlock({message: {slot: 32}});
@@ -200,8 +200,8 @@ describe("LodestarForkChoice", function () {
           (summary) =>
             summary.slot < childBlock.message.slot && !forkChoice.isDescendant(summary.blockRoot, childBlockRoot)
         );
-      // compare to iterateNonAncestors api
-      expect(forkChoice.iterateNonAncestors(childBlockRoot)).to.be.deep.equal(nonCanonicalSummaries);
+      // compare to getAllNonAncestorBlocks api
+      expect(forkChoice.getAllNonAncestorBlocks(childBlockRoot)).to.be.deep.equal(nonCanonicalSummaries);
     });
   });
 });

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -219,11 +219,13 @@ function mockForkChoice(): IForkChoice {
     isDescendant: () => true,
     prune: () => [blockSummary],
     setPruneThreshold: () => {},
-    iterateBlockSummaries: () => [blockSummary],
-    iterateNonAncestors: () => [blockSummary],
+    iterateAncestorBlocks: function* () {},
+    getAllAncestorBlocks: () => [blockSummary],
+    getAllNonAncestorBlocks: () => [blockSummary],
     getCanonicalBlockSummaryAtSlot: () => blockSummary,
     forwardIterateBlockSummaries: () => [blockSummary],
     getBlockSummariesByParentRoot: () => [blockSummary],
     getBlockSummariesAtSlot: () => [blockSummary],
+    getCommonAncestorDistance: () => null,
   };
 }


### PR DESCRIPTION
**Motivation**

ForkChoice iterates over the proto array in suboptimal ways.

**Description**

- Update methods that iterate over nodes to walk through the minimum number of nodes possible.
- https://github.com/ChainSafe/lodestar/pull/3118 will address reducing unnecessary transformations from hex to bytes

Closes https://github.com/ChainSafe/lodestar/issues/3105