### PR TITLE
Add debug routes to drop state

### DIFF
--- a/packages/api/src/routes/lodestar.ts
+++ b/packages/api/src/routes/lodestar.ts
@@ -73,6 +73,10 @@ export type Api = {
   getStateCacheItems(): Promise<StateCacheItem[]>;
   /** Dump a summary of the states in the CheckpointStateCache */
   getCheckpointStateCacheItems(): Promise<StateCacheItem[]>;
+  /** Run GC with `global.gc()` */
+  runGC(): Promise<void>;
+  /** Drop all states in the state cache */
+  dropStateCache(): Promise<void>;
 };
 
 /**
@@ -80,7 +84,7 @@ export type Api = {
  */
 export const routesData: RoutesData<Api> = {
   getWtfNode: {url: "/eth/v1/lodestar/wtfnode", method: "GET"},
-  writeHeapdump: {url: "/eth/v1/lodestar/writeheapdump", method: "GET"},
+  writeHeapdump: {url: "/eth/v1/lodestar/writeheapdump", method: "POST"},
   getLatestWeakSubjectivityCheckpointEpoch: {url: "/eth/v1/lodestar/ws_epoch", method: "GET"},
   getSyncChainsDebugState: {url: "/eth/v1/lodestar/sync-chains-debug-state", method: "GET"},
   getGossipQueueItems: {url: "/eth/v1/lodestar/gossip-queue-items/:gossipType", method: "GET"},
@@ -88,6 +92,8 @@ export const routesData: RoutesData<Api> = {
   getBlockProcessorQueueItems: {url: "/eth/v1/lodestar/block-processor-queue-items", method: "GET"},
   getStateCacheItems: {url: "/eth/v1/lodestar/state-cache-items", method: "GET"},
   getCheckpointStateCacheItems: {url: "/eth/v1/lodestar/checkpoint-state-cache-items", method: "GET"},
+  runGC: {url: "/eth/v1/lodestar/gc", method: "POST"},
+  dropStateCache: {url: "/eth/v1/lodestar/drop-state-cache", method: "POST"},
 };
 
 export type ReqTypes = {
@@ -100,6 +106,8 @@ export type ReqTypes = {
   getBlockProcessorQueueItems: ReqEmpty;
   getStateCacheItems: ReqEmpty;
   getCheckpointStateCacheItems: ReqEmpty;
+  runGC: ReqEmpty;
+  dropStateCache: ReqEmpty;
 };
 
 export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
@@ -121,6 +129,8 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
     getBlockProcessorQueueItems: reqEmpty,
     getStateCacheItems: reqEmpty,
     getCheckpointStateCacheItems: reqEmpty,
+    runGC: reqEmpty,
+    dropStateCache: reqEmpty,
   };
 }
 

--- a/packages/lodestar/src/api/impl/lodestar/index.ts
+++ b/packages/lodestar/src/api/impl/lodestar/index.ts
@@ -127,6 +127,16 @@ export function getLodestarApi({
     async getCheckpointStateCacheItems() {
       return (chain as BeaconChain)["checkpointStateCache"].dumpSummary();
     },
+
+    async runGC() {
+      if (!global.gc) throw Error("You must expose GC running the Node.js process with 'node --expose_gc'");
+      global.gc();
+    },
+
+    async dropStateCache() {
+      chain.stateCache.clear();
+      chain.checkpointStateCache.clear();
+    },
   };
 }
 

--- a/packages/lodestar/src/chain/stateCache/stateContextCache.ts
+++ b/packages/lodestar/src/chain/stateCache/stateContextCache.ts
@@ -70,6 +70,7 @@ export class StateContextCache {
 
   clear(): void {
     this.cache.clear();
+    this.epochIndex.clear();
   }
 
   get size(): number {


### PR DESCRIPTION
**Motivation**

To debug an occasional OOM issue in altair this routes will help me fence the issue by doing experimental debug tests in production nodes.

Note: this routes are never enabled by default and are meant to be used for debugging only.

**Description**

Add routes:
- `/eth/v1/lodestar/gc`: Run GC with `global.gc()`
- `/eth/v1/lodestar/drop-state-cache`: Drop all states in the state cache