### PR TITLE
Fix state cache dump API types

### DIFF
--- a/packages/api/src/routes/lodestar.ts
+++ b/packages/api/src/routes/lodestar.ts
@@ -1,4 +1,4 @@
-import {Epoch, Slot, ssz} from "@chainsafe/lodestar-types";
+import {Epoch, RootHex, Slot, ssz} from "@chainsafe/lodestar-types";
 import {ByteVectorType, ContainerType, Json} from "@chainsafe/ssz";
 import {
   jsonType,
@@ -47,7 +47,7 @@ export type BlockProcessorQueueItem = {
 
 export type StateCacheItem = {
   slot: Slot;
-  root: Uint8Array;
+  root: RootHex;
   /** Total number of reads */
   reads: number;
   /** Unix timestamp (ms) of the last read */
@@ -136,13 +136,6 @@ export function getReturnTypes(): ReturnTypes<Api> {
     },
   });
 
-  const StateCacheItem = new ContainerType<StateCacheItem>({
-    fields: {
-      slot: ssz.Slot,
-      root: ssz.Root,
-    },
-  });
-
   return {
     getWtfNode: sameType(),
     writeHeapdump: sameType(),
@@ -151,7 +144,7 @@ export function getReturnTypes(): ReturnTypes<Api> {
     getGossipQueueItems: ArrayOf(GossipQueueItem),
     getRegenQueueItems: jsonType(),
     getBlockProcessorQueueItems: jsonType(),
-    getStateCacheItems: ArrayOf(StateCacheItem),
-    getCheckpointStateCacheItems: ArrayOf(StateCacheItem),
+    getStateCacheItems: jsonType(),
+    getCheckpointStateCacheItems: jsonType(),
   };
 }

--- a/packages/lodestar/src/chain/stateCache/stateContextCache.ts
+++ b/packages/lodestar/src/chain/stateCache/stateContextCache.ts
@@ -1,6 +1,7 @@
 import {ByteVector, toHexString} from "@chainsafe/ssz";
 import {Epoch, allForks} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {routes} from "@chainsafe/lodestar-api";
 import {IMetrics} from "../../metrics";
 import {MapTracker} from "./mapMetrics";
 
@@ -109,10 +110,10 @@ export class StateContextCache {
   }
 
   /** ONLY FOR DEBUGGING PURPOSES. For lodestar debug API */
-  dumpSummary(): {slot: number; root: Uint8Array; reads: number; lastRead: number}[] {
+  dumpSummary(): routes.lodestar.StateCacheItem[] {
     return Array.from(this.cache.entries()).map(([key, state]) => ({
       slot: state.slot,
-      root: state.hashTreeRoot(),
+      root: toHexString(state.hashTreeRoot()),
       reads: this.cache.readCount.get(key) ?? 0,
       lastRead: this.cache.lastRead.get(key) ?? 0,
     }));

--- a/packages/lodestar/src/chain/stateCache/stateContextCheckpointsCache.ts
+++ b/packages/lodestar/src/chain/stateCache/stateContextCheckpointsCache.ts
@@ -1,6 +1,7 @@
 import {toHexString} from "@chainsafe/ssz";
 import {phase0, Epoch, allForks} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {routes} from "@chainsafe/lodestar-api";
 import {IMetrics} from "../../metrics";
 import {MapTracker} from "./mapMetrics";
 
@@ -112,10 +113,10 @@ export class CheckpointStateCache {
   }
 
   /** ONLY FOR DEBUGGING PURPOSES. For lodestar debug API */
-  dumpSummary(): {slot: number; root: Uint8Array; reads: number; lastRead: number}[] {
+  dumpSummary(): routes.lodestar.StateCacheItem[] {
     return Array.from(this.cache.entries()).map(([key, state]) => ({
       slot: state.slot,
-      root: state.hashTreeRoot(),
+      root: toHexString(state.hashTreeRoot()),
       reads: this.cache.readCount.get(key) ?? 0,
       lastRead: this.cache.lastRead.get(key) ?? 0,
     }));


### PR DESCRIPTION
**Motivation**

Return type for state cache dump routes is missing extra properties 
```ts
reads: number;
lastRead: number;
```

https://github.com/ChainSafe/lodestar/blob/7beccf0128c94d9e1720d4e844a53035ff4975ea/packages/api/src/routes/lodestar.ts#L149-L154

**Description**

Use automatic return type generator `jsonType()`