### PR TITLE
Improve processInactivityUpdates

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/cachedInactivityScoreList.ts
+++ b/packages/beacon-state-transition/src/allForks/util/cachedInactivityScoreList.ts
@@ -32,6 +32,13 @@ export class CachedInactivityScoreList implements List<Number64> {
     this.type.tree_setProperty(this.tree, index, value);
   }
 
+  setMultiple(newValues: Map<number, Number64>): void {
+    // TODO: based on newValues.size to determine we build the tree from scratch or not
+    for (const [index, value] of newValues.entries()) {
+      this.set(index, value);
+    }
+  }
+
   push(value: Number64): number {
     this.persistent.push(value);
     return this.type.tree_push(this.tree, value);

--- a/packages/beacon-state-transition/src/altair/epoch/processInactivityUpdates.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processInactivityUpdates.ts
@@ -1,7 +1,7 @@
 import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
 import {altair, Number64, phase0} from "@chainsafe/lodestar-types";
-import {CachedBeaconState, hasMarkers, IEpochProcess} from "../../allForks/util";
-import * as constants from "../../allForks/util/attesterStatus";
+import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
+import * as attesterStatusUtil from "../../allForks/util/attesterStatus";
 import {isInInactivityLeak} from "../../util";
 
 /**
@@ -31,14 +31,13 @@ export function processInactivityUpdates(
   const inActivityLeak = isInInactivityLeak((state as unknown) as phase0.BeaconState);
 
   // this avoids importing FLAG_ELIGIBLE_ATTESTER inside the for loop, check the compiled code
-  const {FLAG_ELIGIBLE_ATTESTER, FLAG_PREV_TARGET_ATTESTER_OR_UNSLASHED} = constants;
-  const hasMarkersFn = hasMarkers;
+  const {FLAG_ELIGIBLE_ATTESTER, FLAG_PREV_TARGET_ATTESTER_OR_UNSLASHED, hasMarkers} = attesterStatusUtil;
   const newValues = new Map<number, Number64>();
   inactivityScores.forEach(function processInactivityScore(inactivityScore, i) {
     const status = statuses[i];
-    if (hasMarkersFn(status.flags, FLAG_ELIGIBLE_ATTESTER)) {
+    if (hasMarkers(status.flags, FLAG_ELIGIBLE_ATTESTER)) {
       const prevInactivityScore = inactivityScore;
-      if (hasMarkersFn(status.flags, FLAG_PREV_TARGET_ATTESTER_OR_UNSLASHED)) {
+      if (hasMarkers(status.flags, FLAG_PREV_TARGET_ATTESTER_OR_UNSLASHED)) {
         inactivityScore -= Math.min(1, inactivityScore);
       } else {
         inactivityScore += Number(INACTIVITY_SCORE_BIAS);

--- a/packages/beacon-state-transition/test/perf/altair/epoch/processInactivityUpdates.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/epoch/processInactivityUpdates.test.ts
@@ -1,4 +1,4 @@
-import {itBench, setBenchOpts} from "@dapplion/benchmark";
+import {itBench} from "@dapplion/benchmark";
 import {altair} from "../../../../src";
 import {FlagFactors, generateBalanceDeltasEpochProcess} from "../../phase0/epoch/util";
 import {StateAltairEpoch} from "../../types";
@@ -21,10 +21,6 @@ import {mutateInactivityScores} from "./util";
 
 describe("altair processInactivityUpdates", () => {
   const vc = numValidators;
-  setBenchOpts({
-    maxMs: 60 * 1000,
-    minMs: 50 * 1000,
-  });
 
   const testCases: {id: string; isInInactivityLeak: boolean; flagFactors: FlagFactors; factorWithPositive: number}[] = [
     {

--- a/packages/beacon-state-transition/test/perf/altair/epoch/processInactivityUpdates.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/epoch/processInactivityUpdates.test.ts
@@ -1,4 +1,4 @@
-import {itBench} from "@dapplion/benchmark";
+import {itBench, setBenchOpts} from "@dapplion/benchmark";
 import {altair} from "../../../../src";
 import {FlagFactors, generateBalanceDeltasEpochProcess} from "../../phase0/epoch/util";
 import {StateAltairEpoch} from "../../types";
@@ -21,6 +21,10 @@ import {mutateInactivityScores} from "./util";
 
 describe("altair processInactivityUpdates", () => {
   const vc = numValidators;
+  setBenchOpts({
+    maxMs: 60 * 1000,
+    minMs: 50 * 1000,
+  });
 
   const testCases: {id: string; isInInactivityLeak: boolean; flagFactors: FlagFactors; factorWithPositive: number}[] = [
     {


### PR DESCRIPTION
**Motivation**

+ `processInactivityUpdates` is slow and almost equal to `processRewardsAndPenalties` even we don't update anything
+ the profile is shown in #3173

**Description**

1. Loop through the persistent-ts array
2. New method `setMultiple` so that we go through the proxy only 1 time. We'll enhance `setMultiple` in another PR to build the whole tree from scratch if we have to update so many values.
3. Avoid importing functions/constants from other modules inside for loop

This gives 5x-7x improvement when I run altair and 3x in the performance test. Note that the improvement #3 gives only 10% speed increasement but we can apply same strategy for other functions 

resolves issue 1 of #3173
