### PR TITLE
Ignore ssz deserialize INVALID_VARINT_BYTES_COUNT unit test

### DIFF
--- a/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/decode.ts
+++ b/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/decode.ts
@@ -44,8 +44,9 @@ async function readSszSnappyHeader(bufferedSource: BufferedSource, type: Request
     const sszDataLength = varint.decode(buffer.slice());
 
     // MUST validate: the unsigned protobuf varint used for the length-prefix MUST not be longer than 10 bytes
+    // Check for varintBytes > 0 to guard against NaN, or 0 values
     const varintBytes = varint.decode.bytes;
-    if (varintBytes > MAX_VARINT_BYTES) {
+    if (varintBytes > MAX_VARINT_BYTES || !(varintBytes > 0)) {
       throw new SszSnappyError({code: SszSnappyErrorCode.INVALID_VARINT_BYTES_COUNT, bytes: varintBytes});
     }
     buffer.consume(varintBytes);

--- a/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/decode.ts
+++ b/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/decode.ts
@@ -41,7 +41,16 @@ async function readSszSnappyHeader(bufferedSource: BufferedSource, type: Request
       continue;
     }
 
-    const sszDataLength = varint.decode(buffer.slice());
+    // Use Number.MAX_SAFE_INTEGER to guard against this check https://github.com/chrisdickinson/varint/pull/20
+    // On varint v6 if the number is > Number.MAX_SAFE_INTEGER `varint.decode` throws.
+    // Since MAX_VARINT_BYTES = 10, this will always be the case for the condition below.
+    // The check for MAX_VARINT_BYTES is kept for completeness
+    let sszDataLength: number;
+    try {
+      sszDataLength = varint.decode(buffer.slice());
+    } catch (e) {
+      throw new SszSnappyError({code: SszSnappyErrorCode.INVALID_VARINT_BYTES_COUNT, bytes: Infinity});
+    }
 
     // MUST validate: the unsigned protobuf varint used for the length-prefix MUST not be longer than 10 bytes
     // Check for varintBytes > 0 to guard against NaN, or 0 values

--- a/packages/lodestar/test/unit/network/reqresp/encodingStrategies/sszSnappy/decode.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/encodingStrategies/sszSnappy/decode.test.ts
@@ -34,13 +34,13 @@ describe("network / reqresp / sszSnappy / decode", () => {
       error: SszSnappyErrorCode;
       chunks: Buffer[];
     }[] = [
-      // this does not work with varint 6
-      // {
-      //   id: "if it takes more than 10 bytes for varint",
-      //   type: ssz.phase0.Status,
-      //   error: SszSnappyErrorCode.INVALID_VARINT_BYTES_COUNT,
-      //   chunks: [Buffer.from(varint.encode(99999999999999999999999))],
-      // },
+      {
+        id: "if it takes more than 10 bytes for varint",
+        type: ssz.phase0.Status,
+        error: SszSnappyErrorCode.INVALID_VARINT_BYTES_COUNT,
+        // Use Number.MAX_SAFE_INTEGER to guard against this check https://github.com/chrisdickinson/varint/pull/20
+        chunks: [Buffer.from(varint.encode(Number.MAX_SAFE_INTEGER - 1))],
+      },
       {
         id: "if failed ssz size bound validation",
         type: ssz.phase0.Status,

--- a/packages/lodestar/test/unit/network/reqresp/encodingStrategies/sszSnappy/decode.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/encodingStrategies/sszSnappy/decode.test.ts
@@ -38,8 +38,8 @@ describe("network / reqresp / sszSnappy / decode", () => {
         id: "if it takes more than 10 bytes for varint",
         type: ssz.phase0.Status,
         error: SszSnappyErrorCode.INVALID_VARINT_BYTES_COUNT,
-        // Use Number.MAX_SAFE_INTEGER to guard against this check https://github.com/chrisdickinson/varint/pull/20
-        chunks: [Buffer.from(varint.encode(Number.MAX_SAFE_INTEGER - 1))],
+        // Used varint@5.0.2 to generated this hex payload because of https://github.com/chrisdickinson/varint/pull/20
+        chunks: [Buffer.from("80808080808080808080808010", "hex")],
       },
       {
         id: "if failed ssz size bound validation",

--- a/packages/lodestar/test/unit/network/reqresp/encodingStrategies/sszSnappy/decode.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/encodingStrategies/sszSnappy/decode.test.ts
@@ -34,12 +34,13 @@ describe("network / reqresp / sszSnappy / decode", () => {
       error: SszSnappyErrorCode;
       chunks: Buffer[];
     }[] = [
-      {
-        id: "if it takes more than 10 bytes for varint",
-        type: ssz.phase0.Status,
-        error: SszSnappyErrorCode.INVALID_VARINT_BYTES_COUNT,
-        chunks: [Buffer.from(varint.encode(99999999999999999999999))],
-      },
+      // this does not work with varint 6
+      // {
+      //   id: "if it takes more than 10 bytes for varint",
+      //   type: ssz.phase0.Status,
+      //   error: SszSnappyErrorCode.INVALID_VARINT_BYTES_COUNT,
+      //   chunks: [Buffer.from(varint.encode(99999999999999999999999))],
+      // },
       {
         id: "if failed ssz size bound validation",
         type: ssz.phase0.Status,


### PR DESCRIPTION
**Motivation**
+ Fix broken build on master due to varint upgrade from version 5 to 6
+ Got unit test failed due to varint upgrade from version 5 to 6, refer to https://github.com/chrisdickinson/varint/pull/20

**Description**
+ varint6 encode only support up to Number.MAX_SAFE_INTEGER
+ not able to create a test data to decode like `[Buffer.concat([Buffer.alloc(10, 128), Buffer.alloc(1, 0)])]`, got "Could not decode varint" due to the above PR

I have to ignore the failed unit test for now, @wemeetagain please let me know if there's any ways to get this unit test back again

