### PR TITLE
inspecting lodestar.json with regexp to invalidate use of exemplar

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
         if: steps.cache-deps.outputs.cache-hit == 'true'
       # </common-build>
 
+
+      - name: Grafana Dashboard
+        run: yarn validate-gdash
       - name: Test root binary exists
         run: ./lodestar --version
       - name: Check Types

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       # </common-build>
 
 
-      - name: Grafana Dashboard
+      - name: Lint Grafana Dashboard
         run: yarn validate-gdash
       - name: Test root binary exists
         run: ./lodestar --version

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "publish:release": "lerna publish from-package --yes --no-verify-access",
     "release": "lerna version --no-push --sign-git-commit",
     "postrelease": "git tag -d $(git describe --abbrev=0)",
-    "check-readme": "lerna run check-readme"
+    "check-readme": "lerna run check-readme",
+    "validate-gdash": "node scripts/validate-grafana-dashboard.js"
   },
   "devDependencies": {
     "@dapplion/benchmark": "^0.2.2",

--- a/scripts/validate-grafana-dashboard.js
+++ b/scripts/validate-grafana-dashboard.js
@@ -1,0 +1,6 @@
+let lodestarDash = require("../docker/grafana/provisioning/dashboards/lodestar.json");
+lodestarDash = JSON.stringify(lodestarDash); //get everything in the same line
+
+//match something like exemplar : true
+const matches = lodestarDash.match(/(exemplar)(\s)*(["])?(\s)*:(\s)*(["])?(\s)*true/gi);
+if (matches && matches.length > 0) throw new Error("ExemplarQueryNotSupported");


### PR DESCRIPTION
**Motivation**
since some of the grafana panels were showing 404 not found on using the exemplar, it was decided to avoid exemplar query use as we don't use the feature at all. however exemplar is turned on by default while creating new query.
This PR adds the check for the same.
<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number
#3117
**Steps to test or reproduce**

example of github checks failing (mock test):

![image](https://user-images.githubusercontent.com/76567250/133622319-a41f32a2-f516-4520-b179-929eabfe0e03.png)

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
