### PR TITLE
Improve dependencies cache key

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,6 +25,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "lts/fermium"
+      - name: Node.js version
+        id: node
+        run: echo "::set-output name=v8CppApiVersion::$(node --print "process.versions.modules")"
       - name: Restore dependencies
         uses: actions/cache@master
         id: cache-deps
@@ -32,7 +35,7 @@ jobs:
           path: |
             node_modules
             packages/*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-fermium
+          key: ${{ runner.os }}-${{ steps.node.outputs.v8CppApiVersion }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --ignore-optional && yarn build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "lts/fermium"
+      - name: Node.js version
+        id: node
+        run: echo "::set-output name=v8CppApiVersion::$(node --print "process.versions.modules")"
       - name: Restore dependencies
         uses: actions/cache@master
         id: cache-deps
@@ -20,7 +23,7 @@ jobs:
           path: |
             node_modules
             packages/*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-fermium
+          key: ${{ runner.os }}-${{ steps.node.outputs.v8CppApiVersion }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --ignore-optional && yarn build

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           node-version: "lts/fermium"
           registry-url: "https://registry.npmjs.org"
+      - name: Node.js version
+        id: node
+        run: echo "::set-output name=v8CppApiVersion::$(node --print "process.versions.modules")"
       - name: Restore dependencies
         uses: actions/cache@master
         id: cache-deps
@@ -29,7 +32,7 @@ jobs:
           path: |
             node_modules
             packages/*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-fermium
+          key: ${{ runner.os }}-${{ steps.node.outputs.v8CppApiVersion }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --ignore-optional && yarn build
@@ -37,6 +40,7 @@ jobs:
         run: yarn build
         if: steps.cache-deps.outputs.cache-hit == 'true'
       # </common-build>
+
       - name: Publish to npm registry
         # from-package: Base the latest nightly ref count from NPM registry
         # --no-git-reset: Do not delete code version artifacts so the next step can pick the version

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -25,6 +25,7 @@ jobs:
           fi
         env:
           WEEK: ${{ steps.date.outputs.week }}
+
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -35,6 +36,10 @@ jobs:
         with:
           node-version: "lts/fermium"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Node.js version
+        id: node
+        run: echo "::set-output name=v8CppApiVersion::$(node --print "process.versions.modules")"
       - name: Restore dependencies
         uses: actions/cache@master
         id: cache-deps
@@ -42,7 +47,8 @@ jobs:
           path: |
             node_modules
             packages/*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-fermium
+          key: ${{ runner.os }}-${{ steps.node.outputs.v8CppApiVersion }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}
+
       - name: Bump minor version
         run: |
           node_modules/.bin/lerna version minor --yes \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "lts/fermium"
+      - name: Node.js version
+        id: node
+        run: echo "::set-output name=v8CppApiVersion::$(node --print "process.versions.modules")"
       - name: Restore dependencies
         uses: actions/cache@master
         id: cache-deps
@@ -50,7 +53,7 @@ jobs:
           path: |
             node_modules
             packages/*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-fermium
+          key: ${{ runner.os }}-${{ steps.node.outputs.v8CppApiVersion }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --ignore-optional && yarn build

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -12,6 +12,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "lts/fermium"
+      - name: Node.js version
+        id: node
+        run: echo "::set-output name=v8CppApiVersion::$(node --print "process.versions.modules")"
       - name: Restore dependencies
         uses: actions/cache@master
         id: cache-deps
@@ -19,7 +22,7 @@ jobs:
           path: |
             node_modules
             packages/*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-fermium
+          key: ${{ runner.os }}-${{ steps.node.outputs.v8CppApiVersion }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --ignore-optional && yarn build

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -7,13 +7,17 @@ jobs:
     name: Spec tests
     runs-on: ubuntu-latest
     steps:
+      # As of October 2020, runner has +8GB of free space w/out this script (takes 1m30s to run)
+      # - run: ./scripts/free-disk-space.sh
+
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: "lts/fermium"
-      # As of October 2020, runner has +8GB of free space w/out this script (takes 1m30s to run)
-      # - run: ./scripts/free-disk-space.sh
+      - name: Node.js version
+        id: node
+        run: echo "::set-output name=v8CppApiVersion::$(node --print "process.versions.modules")"
       - name: Restore dependencies
         uses: actions/cache@master
         id: cache-deps
@@ -21,10 +25,10 @@ jobs:
           path: |
             node_modules
             packages/*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-fermium
+          key: ${{ runner.os }}-${{ steps.node.outputs.v8CppApiVersion }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile && yarn build
+        run: yarn install --frozen-lockfile --ignore-optional && yarn build
       - name: Build
         run: yarn build
         if: steps.cache-deps.outputs.cache-hit == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "lts/fermium"
+      - name: Node.js version
+        id: node
+        run: echo "::set-output name=v8CppApiVersion::$(node --print "process.versions.modules")"
       - name: Restore dependencies
         uses: actions/cache@master
         id: cache-deps
@@ -19,7 +22,7 @@ jobs:
           path: |
             node_modules
             packages/*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-ignore-optional-fermium
+          key: ${{ runner.os }}-${{ steps.node.outputs.v8CppApiVersion }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --ignore-optional && yarn build
@@ -27,6 +30,7 @@ jobs:
         run: yarn build
         if: steps.cache-deps.outputs.cache-hit == 'true'
       # </common-build>
+
       - name: Test root binary exists
         run: ./lodestar --version
       - name: Check Types


### PR DESCRIPTION
**Motivation**

Our cache key for dependencies is not good enough for two corner cases:
- package.json is updated but not the yarn.lock
- NodeJS version changes requiring a new build or compiled native addons

**Description**

Closes https://github.com/ChainSafe/lodestar/issues/3170