### PR TITLE
Remove balanceList proxy

### DIFF
--- a/packages/beacon-state-transition/src/allForks/block/processDeposit.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processDeposit.ts
@@ -78,7 +78,7 @@ export function processDeposit(
       effectiveBalance,
       slashed: false,
     });
-    state.balances.push(Number(amount));
+    state.balanceList.push(Number(amount));
     epochCtx.effectiveBalances.push(effectiveBalance);
 
     // add participation caches

--- a/packages/beacon-state-transition/src/allForks/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processEffectiveBalanceUpdates.ts
@@ -32,7 +32,8 @@ export function processEffectiveBalanceUpdates(
   // update effective balances with hysteresis
   if (!epochProcess.balances) {
     // only do this for genesis epoch, or spec test
-    epochProcess.balances = Array.from({length: state.balances.length}, (_, i) => state.balances[i]);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    epochProcess.balances = Array.from({length: state.balanceList.length}, (_, i) => state.balanceList.get(i)!);
   }
 
   for (let i = 0, len = epochProcess.balances.length; i < len; i++) {

--- a/packages/beacon-state-transition/src/allForks/util/balanceList.ts
+++ b/packages/beacon-state-transition/src/allForks/util/balanceList.ts
@@ -1,8 +1,8 @@
-import {List, Number64ListType, TreeBacked} from "@chainsafe/ssz";
+import {List, Number64ListType} from "@chainsafe/ssz";
 import {Tree} from "@chainsafe/persistent-merkle-tree";
 
 /**
- * Manage balances of BeaconState.
+ * Manage balances of BeaconState, use this instead of state.balances
  */
 export class BalanceList implements List<number> {
   [index: number]: number;
@@ -66,27 +66,3 @@ export class BalanceList implements List<number> {
     return -1;
   }
 }
-
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export const CachedBalanceListProxyHandler: ProxyHandler<BalanceList> = {
-  get(target: BalanceList, key: PropertyKey): unknown {
-    if (!Number.isNaN(Number(String(key)))) {
-      return target.get(key as number);
-    } else if (target[key as keyof BalanceList]) {
-      return target[key as keyof BalanceList];
-    } else {
-      const treeBacked = target.type.createTreeBacked(target.tree);
-      if (key in treeBacked) {
-        return treeBacked[key as keyof TreeBacked<List<number>>];
-      }
-      return undefined;
-    }
-  },
-  set(target: BalanceList, key: PropertyKey, value: number): boolean {
-    if (!Number.isNaN(Number(key))) {
-      target.set(key as number, value);
-      return true;
-    }
-    return false;
-  },
-};

--- a/packages/beacon-state-transition/src/allForks/util/balanceList.ts
+++ b/packages/beacon-state-transition/src/allForks/util/balanceList.ts
@@ -1,11 +1,10 @@
-import {List, Number64ListType} from "@chainsafe/ssz";
+import {Number64ListType} from "@chainsafe/ssz";
 import {Tree} from "@chainsafe/persistent-merkle-tree";
 
 /**
  * Manage balances of BeaconState, use this instead of state.balances
  */
-export class BalanceList implements List<number> {
-  [index: number]: number;
+export class BalanceList {
   tree: Tree;
   type: Number64ListType;
 

--- a/packages/beacon-state-transition/src/altair/block/processSyncCommittee.ts
+++ b/packages/beacon-state-transition/src/altair/block/processSyncCommittee.ts
@@ -39,7 +39,7 @@ export function processSyncAggregate(
   for (const unparticipantIndex of unparticipantIndices) {
     accumulateDelta(deltaByIndex, unparticipantIndex, -syncParticipantReward);
   }
-  state.balances.applyDeltaInBatch(deltaByIndex);
+  state.balanceList.applyDeltaInBatch(deltaByIndex);
 }
 
 export function getSyncCommitteeSignatureSet(

--- a/packages/beacon-state-transition/src/altair/epoch/processRewardsAndPenalties.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processRewardsAndPenalties.ts
@@ -23,7 +23,7 @@ export function processRewardsAndPenalties(
   // important: do not change state one balance at a time
   // set them all at once, constructing the tree in one go
   // cache the balances array, too
-  epochProcess.balances = state.balances.updateAll(deltas);
+  epochProcess.balances = state.balanceList.updateAll(deltas);
 }
 
 // // naive version, leave here for debugging purposes

--- a/packages/beacon-state-transition/src/phase0/epoch/processRewardsAndPenalties.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/processRewardsAndPenalties.ts
@@ -23,5 +23,5 @@ export function processRewardsAndPenalties(
   // important: do not change state one balance at a time
   // set them all at once, constructing the tree in one go
   // cache the balances array, too
-  epochProcess.balances = state.balances.updateAll(deltas);
+  epochProcess.balances = state.balanceList.updateAll(deltas);
 }

--- a/packages/beacon-state-transition/src/util/balance.ts
+++ b/packages/beacon-state-transition/src/util/balance.ts
@@ -33,7 +33,7 @@ export function increaseBalance(
   delta: number
 ): void {
   // TODO: Inline this
-  state.balances.applyDelta(index, delta);
+  state.balanceList.applyDelta(index, delta);
 }
 
 /**
@@ -46,7 +46,7 @@ export function decreaseBalance(
   index: ValidatorIndex,
   delta: number
 ): void {
-  state.balances.applyDelta(index, -delta);
+  state.balanceList.applyDelta(index, -delta);
 }
 
 /**

--- a/packages/beacon-state-transition/src/util/genesis.ts
+++ b/packages/beacon-state-transition/src/util/genesis.ts
@@ -161,7 +161,8 @@ export function applyDeposits(
   const validatorLength = state.validators.length;
   for (let index = 0; index < validatorLength; index++) {
     const validator = state.validators[index];
-    const balance = state.balances[index];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const balance = state.balanceList.get(index)!;
     const effectiveBalance = Math.min(balance - (balance % EFFECTIVE_BALANCE_INCREMENT), MAX_EFFECTIVE_BALANCE);
     validator.effectiveBalance = effectiveBalance;
     state.effectiveBalances.set(index, effectiveBalance);

--- a/packages/beacon-state-transition/test/unit/util/balance.test.ts
+++ b/packages/beacon-state-transition/test/unit/util/balance.test.ts
@@ -43,12 +43,13 @@ describe("getTotalBalance", () => {
 describe("increaseBalance", () => {
   it("should add to a validators balance", () => {
     const state = generateCachedState();
+
     state.validators.push(generateValidators(1)[0]);
-    state.balances.push(0);
+    state.balanceList.push(0);
     const delta = 5;
     for (let i = 1; i < 10; i++) {
       increaseBalance(state, 0, delta);
-      assert(state.balances[0] === delta * i);
+      expect(state.balanceList.get(0)).to.be.equal(delta * i);
     }
   });
 });
@@ -58,21 +59,21 @@ describe("decreaseBalance", () => {
     const state = generateCachedState();
     state.validators.push(generateValidators(1)[0]);
     const initial = 100;
-    state.balances.push(initial);
+    state.balanceList.push(initial);
     const delta = 5;
     for (let i = 1; i < 10; i++) {
       decreaseBalance(state, 0, delta);
-      assert(state.balances[0] === initial - delta * i);
+      expect(state.balanceList.get(0)).to.be.equal(initial - delta * i);
     }
   });
   it("should not make a validators balance < 0", () => {
     const state = generateCachedState();
     state.validators.push(generateValidators(1)[0]);
     const initial = 10;
-    state.balances.push(initial);
+    state.balanceList.push(initial);
     const delta = 11;
     decreaseBalance(state, 0, delta);
-    assert(state.balances[0] === 0);
+    expect(state.balanceList.get(0)).to.be.equal(0);
   });
 });
 


### PR DESCRIPTION
**Motivation**

+ Most of the time we use direct method of `BalanceList` so we don't need proxy
+ Performance of proxy is a concern, see #3109

**Description**
+ Remove BalanceList proxy
+ So BalanceList does not conform to List interface anymore, I have to make a separate property `balanceList` vs `balances`. Using `balances` would go through the CachedBeaconState proxy but let's only use `balanceList` instead of `balances` from now on.

it's not really convenient since BeaconState has `balances` in its interface but we always use `balanceList` in CachedBeaconState from this PR, please let me know your ideas @wemeetagain @dapplion 