### PR TITLE
Fix MESSAGE_DOMAIN_VALID_SNAPPY

### DIFF
--- a/packages/lodestar/src/network/gossip/constants.ts
+++ b/packages/lodestar/src/network/gossip/constants.ts
@@ -7,13 +7,13 @@ import {GossipEncoding} from "./interface";
 export const GOSSIP_MSGID_LENGTH = 20;
 
 /**
- * 4-byte domain for gossip message-id isolation of *invalid* snappy messages
- */
-export const MESSAGE_DOMAIN_VALID_SNAPPY = Buffer.from("00000000", "hex");
-
-/**
  * 4-byte domain for gossip message-id isolation of *valid* snappy messages
  */
-export const MESSAGE_DOMAIN_INVALID_SNAPPY = Buffer.from("01000000", "hex");
+export const MESSAGE_DOMAIN_VALID_SNAPPY = Buffer.from("01000000", "hex");
+
+/**
+ * 4-byte domain for gossip message-id isolation of *invalid* snappy messages
+ */
+export const MESSAGE_DOMAIN_INVALID_SNAPPY = Buffer.from("00000000", "hex");
 
 export const DEFAULT_ENCODING = GossipEncoding.ssz_snappy;


### PR DESCRIPTION
**Motivation**

+ Everytime we receive IHAVE rpc control message and we issue IWANT rpc control message in response, we end up penaltilizing that same peer because that same message id never comes and timeout occurred through gossip tracer
+ Then I found that our messageId function is incorrect due to incorrect MESSAGE_DOMAIN_VALID_SNAPPY defined, it means when subsequent gossip messages come, we can't create a message id that match the one in IHAVE


**Description**

+ Fix MESSAGE_DOMAIN_VALID_SNAPPY
+ Refer to https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md

part of #3084
