### PR TITLE
Don't store future blocks

### DIFF
--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -322,14 +322,9 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
   // err type data may contain CachedBeaconState which is too much to log
   this.logger.error("Block error", {slot: err.signedBlock.message.slot, errCode: err.type.code});
 
-  if (err.type.code === BlockErrorCode.FUTURE_SLOT) {
-    this.pendingBlocks.addBySlot(err.signedBlock);
-    await this.db.pendingBlock.add(err.signedBlock);
-  }
-
   // add to pendingBlocks first which is not await
   // this is to process a block range
-  else if (err.type.code === BlockErrorCode.PARENT_UNKNOWN) {
+  if (err.type.code === BlockErrorCode.PARENT_UNKNOWN) {
     this.pendingBlocks.addByParent(err.signedBlock);
     await this.db.pendingBlock.add(err.signedBlock);
   } else if (err.type.code === BlockErrorCode.INVALID_SIGNATURE) {

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -104,28 +104,6 @@ export async function onClockSlot(this: BeaconChain, slot: Slot): Promise<void> 
   this.aggregatedAttestationPool.prune(slot);
   this.syncCommitteeMessagePool.prune(slot);
   this.seenSyncCommitteeMessages.prune(slot);
-
-  await Promise.all(
-    this.pendingBlocks.getBySlot(slot).map(async (root) => {
-      const pendingBlock = await this.db.pendingBlock.get(root);
-      if (pendingBlock) {
-        this.pendingBlocks.remove(pendingBlock);
-        await this.db.pendingBlock.delete(root);
-        return this.blockProcessor.processBlockJob({
-          signedBlock: pendingBlock,
-          reprocess: false,
-          prefinalized: false,
-          validSignatures: false,
-          validProposerSignature: false,
-        });
-      }
-    })
-  );
-
-  this.logger.debug("Block pools: ", {
-    pendingBlocks: this.pendingBlocks.getTotalPendingBlocks(),
-    currentSlot: this.clock.currentSlot,
-  });
 }
 
 export function onClockEpoch(this: BeaconChain, currentEpoch: Epoch): void {

--- a/packages/lodestar/test/unit/chain/blocks/pool.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/pool.test.ts
@@ -17,7 +17,7 @@ describe("BlockPool", function () {
     const ancestorRoot = firstBlock.message.parentRoot;
     const secondBlock = ssz.phase0.SignedBeaconBlock.defaultValue();
     secondBlock.message.parentRoot = ssz.phase0.BeaconBlock.hashTreeRoot(firstBlock.message);
-    pool.addBySlot(firstBlock);
+    pool.addByParent(firstBlock);
     pool.addByParent(secondBlock);
     const root = pool.getMissingAncestor(ssz.phase0.BeaconBlock.hashTreeRoot(secondBlock.message));
     expect(ssz.Root.equals(ancestorRoot, root)).to.be.true;


### PR DESCRIPTION
**Motivation**

We already check gossip disparity when asserting correct slot. It's not useful for us to keep future blocks.

**Description**

Don't store future blocks