### PR TITLE
Validator: validate genesisValidatorsRoot

### DIFF
--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -129,17 +129,18 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
     fs.mkdirSync(dbPath, {recursive: true});
 
     const api = args.server === "memory" ? node.api : args.server;
-    const slashingProtection = new SlashingProtection({
+    const dbOps = {
       config: config,
       controller: new LevelDbController({name: dbPath}, {logger}),
-    });
+    };
+    const slashingProtection = new SlashingProtection(dbOps);
 
     const controller = new AbortController();
     onGracefulShutdownCbs.push(async () => controller.abort());
 
     // Initailize genesis once for all validators
     const validator = await Validator.initializeFromBeaconNode({
-      config,
+      dbOps,
       slashingProtection,
       api,
       logger: logger.child({module: "vali"}),

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -46,15 +46,15 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
   onGracefulShutdownCbs.push(async () => controller.abort());
 
   const api = getClient(config, {baseUrl: args.server});
-  const slashingProtection = new SlashingProtection({
+  const dbOps = {
     config: config,
     controller: new LevelDbController({name: dbPath}, {logger}),
-  });
+  };
+  const slashingProtection = new SlashingProtection(dbOps);
   const validator = await Validator.initializeFromBeaconNode(
-    {config, slashingProtection, api, logger, secretKeys, graffiti},
+    {dbOps, slashingProtection, api, logger, secretKeys, graffiti},
     controller.signal
   );
-
   onGracefulShutdownCbs.push(async () => await validator.stop());
   await validator.start();
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -61,6 +61,7 @@ export enum Bucket {
   altair_lightClientSyncCommitteeProof = 35, // SyncPeriod ->
 
   merge_totalTerminalDifficulty = 40, // Single item -> Uint256
+  validator_metaData = 41,
 }
 
 export enum Key {

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -5,3 +5,4 @@
 export * from "./validator";
 export * from "./genesis";
 export * from "./slashingProtection";
+export * from "./repositories";

--- a/packages/validator/src/repositories/index.ts
+++ b/packages/validator/src/repositories/index.ts
@@ -1,0 +1,1 @@
+export * from "./metaDataRepository";

--- a/packages/validator/src/repositories/metaDataRepository.ts
+++ b/packages/validator/src/repositories/metaDataRepository.ts
@@ -1,0 +1,32 @@
+import {Bucket, encodeKey, IDatabaseApiOptions} from "@chainsafe/lodestar-db";
+import {Root} from "@chainsafe/lodestar-types";
+import {LodestarValidatorDatabaseController} from "../types";
+
+const GENESIS_VALIDATORS_ROOT = Buffer.from("GENESIS_VALIDATORS_ROOT");
+
+/**
+ * Store MetaData of validator.
+ */
+export class MetaDataRepository {
+  protected db: LodestarValidatorDatabaseController;
+  protected bucket = Bucket.validator_metaData;
+
+  constructor(opts: IDatabaseApiOptions) {
+    this.db = opts.controller;
+  }
+
+  async getGenesisValidatorsRoot(): Promise<Root | null> {
+    return this.db.get(this.encodeKey(GENESIS_VALIDATORS_ROOT));
+  }
+
+  async setGenesisValidatorsRoot(genesisValidatorsRoot: Root): Promise<void> {
+    await this.db.put(
+      this.encodeKey(GENESIS_VALIDATORS_ROOT),
+      Buffer.from(genesisValidatorsRoot.valueOf() as Uint8Array)
+    );
+  }
+
+  private encodeKey(key: Buffer): Buffer {
+    return encodeKey(this.bucket, key);
+  }
+}


### PR DESCRIPTION
**Motivation**

+ On some setup, for example Docker, validator db is always fixed at /var/lib/docker/volumes/lodestar_validator/_data/validator-db
+ This makes the ERR_INVALID_ATTESTATION_DOUBLE_VOTE when user switches from one network to another

**Description**

+ Validate and store `genesisValidatorsRoot` when we start validator

Closes #3211
