### PR TITLE
Improve updating participation status to tree

### DIFF
--- a/packages/beacon-state-transition/src/altair/block/processAttestation.ts
+++ b/packages/beacon-state-transition/src/altair/block/processAttestation.ts
@@ -3,7 +3,7 @@ import {intSqrt} from "@chainsafe/lodestar-utils";
 
 import {getBlockRoot, getBlockRootAtSlot, increaseBalance, verifySignatureSet} from "../../util";
 import {CachedBeaconState, EpochContext} from "../../allForks/util";
-import {IParticipationStatus} from "../../allForks/util/cachedEpochParticipation";
+import {CachedEpochParticipation, IParticipationStatus} from "../../allForks/util/cachedEpochParticipation";
 import {
   EFFECTIVE_BALANCE_INCREMENT,
   MIN_ATTESTATION_INCLUSION_DELAY,
@@ -31,6 +31,8 @@ export function processAttestations(
 
   // Process all attestations first and then increase the balance of the proposer once
   let proposerReward = 0;
+  const previousEpochStatuses = new Map<number, IParticipationStatus>();
+  const currentEpochStatuses = new Map<number, IParticipationStatus>();
   for (const attestation of attestations) {
     const data = attestation.data;
 
@@ -57,6 +59,8 @@ export function processAttestations(
       data.target.epoch === epochCtx.currentShuffling.epoch
         ? state.currentEpochParticipation
         : state.previousEpochParticipation;
+    const epochStatuses =
+      data.target.epoch === epochCtx.currentShuffling.epoch ? currentEpochStatuses : previousEpochStatuses;
 
     const {timelySource, timelyTarget, timelyHead} = getAttestationParticipationStatus(
       data,
@@ -69,13 +73,17 @@ export function processAttestations(
     // In epoch processing, this participation info is used to calculate balance updates
     let totalBalancesWithWeight = 0;
     for (const index of attestingIndices) {
-      const status = epochParticipation.getStatus(index) as IParticipationStatus;
+      const status = epochStatuses.get(index) || (epochParticipation.getStatus(index) as IParticipationStatus);
       const newStatus = {
         timelySource: status.timelySource || timelySource,
         timelyTarget: status.timelyTarget || timelyTarget,
         timelyHead: status.timelyHead || timelyHead,
       };
-      epochParticipation.setStatus(index, newStatus);
+      // For normal block, > 90% of attestations belong to current epoch
+      // At epoch boundary, 100% of attestations belong to previous epoch
+      // so we want to update the participation flag tree in batch
+      epochStatuses.set(index, newStatus);
+      // epochParticipation.setStatus(index, newStatus);
       /**
        * Spec:
        * baseReward = state.validators[index].effectiveBalance / EFFECTIVE_BALANCE_INCREMENT * baseRewardPerIncrement;
@@ -97,6 +105,16 @@ export function processAttestations(
     const proposerRewardNumerator = totalIncrements * state.baseRewardPerIncrement;
     proposerReward += Math.floor(proposerRewardNumerator / PROPOSER_REWARD_DOMINATOR);
   }
+  updateEpochParticipants(
+    previousEpochStatuses,
+    state.previousEpochParticipation,
+    epochCtx.previousShuffling.activeIndices.length
+  );
+  updateEpochParticipants(
+    currentEpochStatuses,
+    state.currentEpochParticipation,
+    epochCtx.currentShuffling.activeIndices.length
+  );
 
   increaseBalance(state, epochCtx.getBeaconProposer(state.slot), proposerReward);
 }
@@ -171,5 +189,25 @@ export class RootCache {
       this.blockRootSlotCache.set(slot, root);
     }
     return root;
+  }
+}
+
+export function updateEpochParticipants(
+  epochStatuses: Map<number, IParticipationStatus>,
+  epochParticipation: CachedEpochParticipation,
+  numActiveValidators: number
+): void {
+  // all active validators are attesters, there are 32 slots per epoch
+  // if 1/2 of that or more are updated status, do that in batch, see the benchmark for more details
+  if (epochStatuses.size >= numActiveValidators / (2 * SLOTS_PER_EPOCH)) {
+    const transientVector = epochParticipation.persistent.asTransient();
+    for (const [index, status] of epochStatuses.entries()) {
+      transientVector.set(index, status);
+    }
+    epochParticipation.updateAllStatus(transientVector.vector);
+  } else {
+    for (const [index, status] of epochStatuses.entries()) {
+      epochParticipation.setStatus(index, status);
+    }
   }
 }

--- a/packages/beacon-state-transition/test/perf/altair/block/processAttestation.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/block/processAttestation.test.ts
@@ -1,0 +1,151 @@
+import {itBench} from "@dapplion/benchmark";
+import {
+  ACTIVE_PRESET,
+  MAX_ATTESTATIONS,
+  MAX_ATTESTER_SLASHINGS,
+  MAX_DEPOSITS,
+  MAX_PROPOSER_SLASHINGS,
+  MAX_VOLUNTARY_EXITS,
+  PresetName,
+  SLOTS_PER_EPOCH,
+  SYNC_COMMITTEE_SIZE,
+} from "@chainsafe/lodestar-params";
+import {allForks, altair} from "../../../../src";
+import {generatePerfTestCachedStateAltair, perfStateId} from "../../util";
+import {BlockAltairOpts, getBlockAltair} from "../../phase0/block/util";
+import {StateAltair, StateAttestations} from "../../types";
+import {phase0} from "@chainsafe/lodestar-types";
+import {IParticipationStatus} from "../../../../src/allForks/util/cachedEpochParticipation";
+import {updateEpochParticipants} from "../../../../src/altair/block/processAttestation";
+
+// Most of the cost of processAttestation in altair is for updating participation flag tree
+describe("altair processAttestation", () => {
+  if (ACTIVE_PRESET !== PresetName.mainnet) {
+    throw Error(`ACTIVE_PRESET ${ACTIVE_PRESET} must be mainnet`);
+  }
+
+  const testCases: {id: string; opts: BlockAltairOpts}[] = [
+    {
+      id: "normalcase",
+      opts: {
+        proposerSlashingLen: 0,
+        attesterSlashingLen: 0,
+        attestationLen: 90,
+        depositsLen: 0,
+        voluntaryExitLen: 0,
+        bitsLen: 90,
+        // TODO: There's no data yet on how full syncCommittee will be. Assume same ratio of attestations
+        syncCommitteeBitsLen: Math.round(SYNC_COMMITTEE_SIZE * 0.7),
+      },
+    },
+    {
+      id: "worstcase",
+      opts: {
+        proposerSlashingLen: MAX_PROPOSER_SLASHINGS,
+        attesterSlashingLen: MAX_ATTESTER_SLASHINGS,
+        attestationLen: MAX_ATTESTATIONS,
+        depositsLen: MAX_DEPOSITS,
+        voluntaryExitLen: MAX_VOLUNTARY_EXITS,
+        bitsLen: 128,
+        syncCommitteeBitsLen: SYNC_COMMITTEE_SIZE,
+      },
+    },
+  ];
+
+  for (const {id, opts} of testCases) {
+    itBench<StateAttestations, StateAttestations>({
+      id: `altair processAttestation - ${perfStateId} ${id}`,
+      before: () => {
+        const state = generatePerfTestCachedStateAltair() as allForks.CachedBeaconState<allForks.BeaconState>;
+        const block = getBlockAltair(state, opts);
+        state.hashTreeRoot();
+        return {state, attestations: block.message.body.attestations as phase0.Attestation[]};
+      },
+      beforeEach: ({state, attestations}) => ({state: state.clone(), attestations}),
+      fn: ({state, attestations}) => {
+        altair.processAttestations(state as allForks.CachedBeaconState<altair.BeaconState>, attestations, false);
+      },
+    });
+  }
+});
+
+describe("altair processAttestation - CachedEpochParticipation.setStatus", () => {
+  if (ACTIVE_PRESET !== PresetName.mainnet) {
+    throw Error(`ACTIVE_PRESET ${ACTIVE_PRESET} must be mainnet`);
+  }
+
+  const testCases: {name: string; ratio: number}[] = [
+    {name: "1/6 committees", ratio: 1 / 6},
+    {name: "1/3 committees", ratio: 1 / 3},
+    {name: "1/2 committees", ratio: 1 / 2},
+    {name: "2/3 committees", ratio: 2 / 3},
+    {name: "4/5 committees", ratio: 4 / 5},
+    {name: "100% committees", ratio: 1},
+  ];
+  for (const {name, ratio} of testCases) {
+    itBench<StateAltair, StateAltair>({
+      id: `altair processAttestation - setStatus - ${name} join`,
+      before: () => {
+        const state = generatePerfTestCachedStateAltair();
+        state.hashTreeRoot();
+        return state;
+      },
+      beforeEach: (state) => state.clone(),
+      fn: (state) => {
+        const {currentEpochParticipation} = state;
+        const numAttesters = Math.floor((state.currentShuffling.activeIndices.length * ratio) / SLOTS_PER_EPOCH);
+        // just get committees of slot 10
+        let count = 0;
+        for (const committees of state.currentShuffling.committees[10]) {
+          for (const committee of committees) {
+            currentEpochParticipation.setStatus(committee, {timelyHead: true, timelySource: true, timelyTarget: true});
+            count++;
+            if (count >= numAttesters) break;
+          }
+        }
+      },
+    });
+  }
+
+  for (const {name, ratio} of testCases) {
+    itBench<StateAltair, StateAltair>({
+      id: `altair processAttestation - updateEpochParticipants - ${name} join`,
+      before: () => {
+        const state = generatePerfTestCachedStateAltair();
+        state.hashTreeRoot();
+        return state;
+      },
+      beforeEach: (state) => state.clone(),
+      fn: (state) => {
+        const {currentEpochParticipation} = state;
+        const numAttesters = Math.floor((state.currentShuffling.activeIndices.length * ratio) / SLOTS_PER_EPOCH);
+        // just get committees of slot 10
+        let count = 0;
+        const epochStatuses = new Map<number, IParticipationStatus>();
+        for (const committees of state.currentShuffling.committees[10]) {
+          for (const committee of committees) {
+            // currentEpochParticipation.setStatus(committee, {timelyHead: true, timelySource: true, timelyTarget: true});
+            epochStatuses.set(committee, {timelyHead: true, timelySource: true, timelyTarget: true});
+            count++;
+            if (count >= numAttesters) break;
+          }
+        }
+        updateEpochParticipants(epochStatuses, currentEpochParticipation, state.currentShuffling.activeIndices.length);
+      },
+    });
+  }
+
+  itBench<StateAltair, StateAltair>({
+    id: "altair processAttestation - updateAllStatus",
+    before: () => {
+      const state = generatePerfTestCachedStateAltair();
+      state.hashTreeRoot();
+      return state;
+    },
+    beforeEach: (state) => state.clone(),
+    fn: (state) => {
+      const {currentEpochParticipation} = state;
+      currentEpochParticipation.updateAllStatus(currentEpochParticipation.persistent.vector);
+    },
+  });
+});

--- a/packages/beacon-state-transition/test/perf/types.ts
+++ b/packages/beacon-state-transition/test/perf/types.ts
@@ -6,6 +6,10 @@ import {IEpochProcess} from "../../src/allForks";
 export type State = allForks.CachedBeaconState<allForks.BeaconState>;
 export type StateAltair = allForks.CachedBeaconState<altair.BeaconState>;
 export type StateBlock = {state: allForks.CachedBeaconState<allForks.BeaconState>; block: allForks.SignedBeaconBlock};
+export type StateAttestations = {
+  state: allForks.CachedBeaconState<allForks.BeaconState>;
+  attestations: phase0.Attestation[];
+};
 export type StateEpoch = {state: allForks.CachedBeaconState<allForks.BeaconState>; epochProcess: IEpochProcess};
 export type StatePhase0Epoch = {state: allForks.CachedBeaconState<phase0.BeaconState>; epochProcess: IEpochProcess};
 export type StateAltairEpoch = {state: allForks.CachedBeaconState<altair.BeaconState>; epochProcess: IEpochProcess};


### PR DESCRIPTION
**Motivation**

+ For attestations included in a block, there are a lot of duplicated validators there and we keep updating them to tree separately

**Description**

+ New performance test shows that if there are >= 1/2 committees are included in a block, it's better to rebuild the whole participation flag tree
+ altair block processing is 40% faster now, we need it in order to produce attestation data faster (the next work for this issue)

part of #3084
