### PR TITLE
Use post state for signature verification

### DIFF
--- a/packages/lodestar/src/chain/blocks/verifyBlock.ts
+++ b/packages/lodestar/src/chain/blocks/verifyBlock.ts
@@ -128,11 +128,11 @@ export async function verifyBlockStateTransition(
   // so the attester and proposer shufflings are correct.
   if (useBlsBatchVerify && !validSignatures) {
     const signatureSets = validProposerSignature
-      ? allForks.getAllBlockSignatureSetsExceptProposer(preState, block)
-      : allForks.getAllBlockSignatureSets(preState as CachedBeaconState<allForks.BeaconState>, block);
+      ? allForks.getAllBlockSignatureSetsExceptProposer(postState, block)
+      : allForks.getAllBlockSignatureSets(postState as CachedBeaconState<allForks.BeaconState>, block);
 
     if (signatureSets.length > 0 && !(await chain.bls.verifySignatureSets(signatureSets))) {
-      throw new BlockError(block, {code: BlockErrorCode.INVALID_SIGNATURE, preState});
+      throw new BlockError(block, {code: BlockErrorCode.INVALID_SIGNATURE, state: postState});
     }
   }
 

--- a/packages/lodestar/src/chain/errors/blockError.ts
+++ b/packages/lodestar/src/chain/errors/blockError.ts
@@ -61,7 +61,7 @@ export type BlockErrorType =
   | {code: BlockErrorCode.INCORRECT_PROPOSER; proposerIndex: ValidatorIndex}
   | {code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID}
   | {code: BlockErrorCode.UNKNOWN_PROPOSER; proposerIndex: ValidatorIndex}
-  | {code: BlockErrorCode.INVALID_SIGNATURE; preState: CachedBeaconState<allForks.BeaconState>}
+  | {code: BlockErrorCode.INVALID_SIGNATURE; state: CachedBeaconState<allForks.BeaconState>}
   | {
       code: BlockErrorCode.INVALID_STATE_ROOT;
       preState: CachedBeaconState<allForks.BeaconState>;

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -245,13 +245,13 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
   if (err.type.code === BlockErrorCode.INVALID_SIGNATURE) {
     const {signedBlock} = err;
     const blockSlot = signedBlock.message.slot;
-    const {preState} = err.type;
+    const {state} = err.type;
     const blockPath = this.persistInvalidSszObject(
       "signedBlock",
       this.config.getForkTypes(blockSlot).SignedBeaconBlock.serialize(signedBlock),
       `${blockSlot}_invalid_signature`
     );
-    const statePath = this.persistInvalidSszObject("state", preState.serialize(), `${preState.slot}_invalid_signature`);
+    const statePath = this.persistInvalidSszObject("state", state.serialize(), `${state.slot}_invalid_signature`);
     this.logger.debug("Invalid signature block and state were written to disc", {blockPath, statePath});
   } else if (err.type.code === BlockErrorCode.INVALID_STATE_ROOT) {
     const {signedBlock} = err;


### PR DESCRIPTION
**Motivation**

Fix regression introduced in https://github.com/ChainSafe/lodestar/pull/3221 where the preState is used to verify signatures breaking syncAggregate signature verification

```
Sep-22 12:11:38.549 [SYNC]          verbose: Batch process error id=Finalized, startEpoch=41117, status=Processing code=BLOCK_ERROR_BEACON_CHAIN_ERROR, error={"message":"Can only get block root in the past currentSlot=1315744 slot=1315744"}
Error: Can only get block root in the past currentSlot=1315744 slot=1315744
    at getBlockRootAtSlot (/usr/app/node_modules/@chainsafe/lodestar-beacon-state-transition/src/util/blockRoot.ts:17:11)
    at getSyncCommitteeSignatureSet (/usr/app/node_modules/@chainsafe/lodestar-beacon-state-transition/src/altair/block/processSyncCommittee.ts:67:40)
    at getAllBlockSignatureSetsExceptProposer (/usr/app/node_modules/@chainsafe/lodestar-beacon-state-transition/src/allForks/signatureSets/index.ts:48:67)
    at Object.getAllBlockSignatureSets (/usr/app/node_modules/@chainsafe/lodestar-beacon-state-transition/src/allForks/signatureSets/index.ts:27:59)
    at verifyBlockStateTransition (/usr/app/node_modules/@chainsafe/lodestar/src/chain/blocks/verifyBlock.ts:132:18)
    at verifyBlock (/usr/app/node_modules/@chainsafe/lodestar/src/chain/blocks/verifyBlock.ts:33:10)
    at processBlock (/usr/app/node_modules/@chainsafe/lodestar/src/chain/blocks/index.ts:65:32)
    at processChainSegment (/usr/app/node_modules/@chainsafe/lodestar/src/chain/blocks/index.ts:95:7)
    at Timeout.JobItemQueue.runJob [as _onTimeout] (/usr/app/node_modules/@chainsafe/lodestar/src/util/queue/itemQueue.ts:85:22)
Error: BLOCK_ERROR_BEACON_CHAIN_ERROR
    at processChainSegment (/usr/app/node_modules/@chainsafe/lodestar/src/chain/blocks/index.ts:128:19)
    at Timeout.JobItemQueue.runJob [as _onTimeout] (/usr/app/node_modules/@chainsafe/lodestar/src/util/queue/itemQueue.ts:85:22)
```

**Description**

Use post state for signature verification