### PR TITLE
Fix block processor regressions

### DIFF
--- a/packages/fork-choice/src/index.ts
+++ b/packages/fork-choice/src/index.ts
@@ -2,7 +2,7 @@ export {ProtoArray} from "./protoArray/protoArray";
 export {IProtoBlock, IProtoNode} from "./protoArray/interface";
 
 export {ForkChoice} from "./forkChoice/forkChoice";
-export {IForkChoice} from "./forkChoice/interface";
+export {IForkChoice, OnBlockPrecachedData, PowBlock, ILatestMessage, IQueuedAttestation} from "./forkChoice/interface";
 export {ForkChoiceStore, IForkChoiceStore, CheckpointWithHex} from "./forkChoice/store";
 export {ITransitionStore} from "./forkChoice/transitionStore";
 export {InvalidAttestation, InvalidAttestationCode, InvalidBlock, InvalidBlockCode} from "./forkChoice/errors";

--- a/packages/lodestar/src/chain/blocks/importBlock.ts
+++ b/packages/lodestar/src/chain/blocks/importBlock.ts
@@ -1,8 +1,7 @@
 import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
-import {readonlyValues, toHexString} from "@chainsafe/ssz";
-import {phase0} from "@chainsafe/lodestar-types";
+import {readonlyValues} from "@chainsafe/ssz";
 import {getEffectiveBalances} from "@chainsafe/lodestar-beacon-state-transition";
-import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
+import {IForkChoice, OnBlockPrecachedData} from "@chainsafe/lodestar-fork-choice";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {IMetrics} from "../../metrics";
@@ -66,17 +65,24 @@ export async function importBlock(chain: ImportBlockModules, fullyVerifiedBlock:
   // current justified checkpoint should be prev epoch or current epoch if it's just updated
   // it should always have epochBalances there bc it's a checkpoint state, ie got through processEpoch
   const justifiedCheckpoint = postState.currentJustifiedCheckpoint;
-  const shouldUpdateJustifiedBalances = justifiedCheckpoint.epoch > chain.forkChoice.getJustifiedCheckpoint().epoch;
-  const justifiedBalances = shouldUpdateJustifiedBalances
-    ? getJustifiedBalancesSync(chain.checkpointStateCache, justifiedCheckpoint)
-    : undefined;
+  const onBlockPrecachedData: OnBlockPrecachedData = {};
+  if (justifiedCheckpoint.epoch > chain.forkChoice.getJustifiedCheckpoint().epoch) {
+    const checkpointHex = toCheckpointHex(justifiedCheckpoint);
+    const state = chain.checkpointStateCache.get(checkpointHex);
+    if (state) {
+      onBlockPrecachedData.justifiedBalances = getEffectiveBalances(state);
+    } else {
+      // TODO: Use regen to get the justified state. Send the block to the forkChoice immediately, and the balances
+      // latter in case regen takes too much time.
+      chain.logger.error("State not available for justified checkpoint", checkpointHex);
+    }
+  }
 
-  chain.forkChoice.onBlock(block.message, postState, {
-    justifiedBalances,
-    // TODO: Figure out how to fetch for merge
-    powBlock: undefined,
-    powBlockParent: undefined,
-  });
+  // TODO: Figure out how to fetch for merge
+  //  powBlock: undefined,
+  //  powBlockParent: undefined,
+
+  chain.forkChoice.onBlock(block.message, postState, onBlockPrecachedData);
 
   // - Register state and block to the validator monitor
   // TODO
@@ -143,20 +149,4 @@ export async function importBlock(chain: ImportBlockModules, fullyVerifiedBlock:
   // Emit all events at once after fully completing importBlock()
   chain.emitter.emit(ChainEvent.block, block, postState);
   pendingEvents.emit();
-}
-
-function getJustifiedBalancesSync(
-  checkpointStateCache: CheckpointStateCache,
-  justifiedCheckpoint: phase0.Checkpoint
-): number[] | undefined {
-  const checkpointHex = toCheckpointHex(justifiedCheckpoint);
-  const state = checkpointStateCache.get(checkpointHex);
-  if (state) {
-    return getEffectiveBalances(state);
-  } else {
-    // TODO: Use regen to get the justified state. Send the block to the forkChoice immediately, and the balances
-    // latter in case regen takes too much time.
-    const cpStr = `${checkpointHex.rootHex}:${checkpointHex.epoch}`;
-    throw Error(`State not available for justified checkpoint ${cpStr}`);
-  }
 }

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -240,7 +240,10 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
   }
 
   // err type data may contain CachedBeaconState which is too much to log
-  this.logger.error("Block error", {slot: err.signedBlock.message.slot, errCode: err.type.code});
+  const slimError = new Error();
+  slimError.message = err.message;
+  slimError.stack = err.stack;
+  this.logger.error("Block error", {slot: err.signedBlock.message.slot, errCode: err.type.code}, err);
 
   if (err.type.code === BlockErrorCode.INVALID_SIGNATURE) {
     const {signedBlock} = err;


### PR DESCRIPTION
**Motivation**

Current master may get stuck during finalized sync

**Description**

Fix two regressions introduced by https://github.com/ChainSafe/lodestar/pull/3221 
- Interpolation of a root type that causes a TypeError
https://github.com/ChainSafe/lodestar/blob/0d7121fa38e5fd58250d87542357ca5a41f3d63f/packages/lodestar/src/chain/blocks/importBlock.ts#L77
- During sync justifiedBalances may not be available which completely stall sync. Change a hard error for a log.error. Future work should investigate better mitigation techniques