### PR TITLE
Format libp2p dial errors

### DIFF
--- a/packages/lodestar/src/network/peers/discover.ts
+++ b/packages/lodestar/src/network/peers/discover.ts
@@ -165,6 +165,7 @@ export class PeerDiscovery {
       // Note: `libp2p.dial()` is what libp2p.connectionManager autoDial calls
       // Note: You must listen to the connected events to listen for a successful conn upgrade
       this.libp2p.dial(peer).catch((e: Error) => {
+        formatLibp2pDialError(e);
         this.logger.debug("Error dialing discovered peer", {peer: prettyPrintPeerId(peer)}, e);
       });
     }
@@ -185,3 +186,44 @@ export class PeerDiscovery {
 type Libp2pPeerStore = {
   addressBook: {data: Map<string, void>};
 };
+
+/**
+ * libp2p errors with extremely noisy errors here, which are deeply nested taking 30-50 lines.
+ * Some known erors:
+ * ```
+ * Error: The operation was aborted
+ * Error: stream ended before 1 bytes became available
+ * Error: Error occurred during XX handshake: Error occurred while verifying signed payload: Peer ID doesn't match libp2p public key
+ * ```
+ *
+ * Also the error's message is not properly formated, where the error message in indentated and includes the full stack
+ * ```
+ * {
+ *  emessage: '\n' +
+ *    '    Error: stream ended before 1 bytes became available\n' +
+ *    '        at /home/lion/Code/eth2.0/lodestar/node_modules/it-reader/index.js:37:9\n' +
+ *    '        at runMicrotasks (<anonymous>)\n' +
+ *    '        at decoder (/home/lion/Code/eth2.0/lodestar/node_modules/it-length-prefixed/src/decode.js:113:22)\n' +
+ *    '        at first (/home/lion/Code/eth2.0/lodestar/node_modules/it-first/index.js:11:20)\n' +
+ *    '        at Object.exports.read (/home/lion/Code/eth2.0/lodestar/node_modules/multistream-select/src/multistream.js:31:15)\n' +
+ *    '        at module.exports (/home/lion/Code/eth2.0/lodestar/node_modules/multistream-select/src/select.js:21:19)\n' +
+ *    '        at Upgrader._encryptOutbound (/home/lion/Code/eth2.0/lodestar/node_modules/libp2p/src/upgrader.js:397:36)\n' +
+ *    '        at Upgrader.upgradeOutbound (/home/lion/Code/eth2.0/lodestar/node_modules/libp2p/src/upgrader.js:176:11)\n' +
+ *    '        at ClassIsWrapper.dial (/home/lion/Code/eth2.0/lodestar/node_modules/libp2p-tcp/src/index.js:49:18)'
+ * }
+ * ```
+ *
+ * Tracking issue https://github.com/libp2p/js-libp2p/issues/996
+ */
+function formatLibp2pDialError(e: Error): void {
+  const errorMessage = e.message.trim();
+  e.message = errorMessage.slice(0, errorMessage.indexOf("\n"));
+
+  if (
+    e.message.includes("The operation was aborted") ||
+    e.message.includes("stream ended before 1 bytes became available") ||
+    e.message.includes("The operation was aborted")
+  ) {
+    e.stack === undefined;
+  }
+}


### PR DESCRIPTION
libp2p errors with extremely noisy errors here, which are deeply nested taking 30-50 lines.
Some known erors:
```
Error: The operation was aborted
Error: stream ended before 1 bytes became available
Error: Error occurred during XX handshake: Error occurred while verifying signed payload: Peer ID doesn't match libp2p public key
```
Also the error's message is not properly formated, where the error message in indentated and includes the full stack
```
{
 emessage: '\n' +
   '    Error: stream ended before 1 bytes became available\n' +
   '        at /home/lion/Code/eth2.0/lodestar/node_modules/it-reader/index.js:37:9\n' +
   '        at runMicrotasks (<anonymous>)\n' +
   '        at decoder (/home/lion/Code/eth2.0/lodestar/node_modules/it-length-prefixed/src/decode.js:113:22)\n' +
   '        at first (/home/lion/Code/eth2.0/lodestar/node_modules/it-first/index.js:11:20)\n' +
   '        at Object.exports.read (/home/lion/Code/eth2.0/lodestar/node_modules/multistream-select/src/multistream.js:31:15)\n' +
   '        at module.exports (/home/lion/Code/eth2.0/lodestar/node_modules/multistream-select/src/select.js:21:19)\n' +
   '        at Upgrader._encryptOutbound (/home/lion/Code/eth2.0/lodestar/node_modules/libp2p/src/upgrader.js:397:36)\n' +
   '        at Upgrader.upgradeOutbound (/home/lion/Code/eth2.0/lodestar/node_modules/libp2p/src/upgrader.js:176:11)\n' +
   '        at ClassIsWrapper.dial (/home/lion/Code/eth2.0/lodestar/node_modules/libp2p-tcp/src/index.js:49:18)'
}
```
Tracking issue https://github.com/libp2p/js-libp2p/issues/996