### PR TITLE
Run epoch transitions always through regen

### DIFF
--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -34,8 +34,8 @@ export class StateRegenerator implements IStateRegenerator {
 
   /**
    * Get the state to run with `block`. May be:
-   * - Exact state at `block.parentRoot`
-   * - State after `block.parentRoot` dialed forward through epoch transition
+   * - If parent is in same epoch -> Exact state at `block.parentRoot`
+   * - If parent is in prev epoch -> State after `block.parentRoot` dialed forward through epoch transition
    */
   async getPreState(
     block: allForks.BeaconBlock,


### PR DESCRIPTION
**Motivation**

PR https://github.com/ChainSafe/lodestar/pull/3221 introduced an edge case that may cause the justified checkpoints state to not be available.

- When syncing a chain segment regen.getPreState() may return a state from the previous epoch if the first slot of the epoch is skipped.
- Then the runStateTransition call in verifyBlock will do the epoch trnsition, and won't cache the checkpoint state.
- Latter when the fork-choice requires the state for the current justified checkpoint it won't be available.

**Description**

Only skip dialing state forward if the parent and block are in the same epoch