### PR TITLE
Insert SlashingProtectionAttestation after publish successfully

### DIFF
--- a/packages/validator/src/slashingProtection/attestation/index.ts
+++ b/packages/validator/src/slashingProtection/attestation/index.ts
@@ -12,7 +12,7 @@ export {
   InvalidAttestationErrorCode,
 };
 
-enum SafeStatus {
+export enum SafeStatus {
   SAME_DATA = "SAFE_STATUS_SAME_DATA",
   OK = "SAFE_STATUS_OK",
 }
@@ -30,20 +30,6 @@ export class SlashingProtectionAttestationService {
     this.attestationByTarget = signedAttestationDb;
     this.attestationLowerBound = attestationLowerBound;
     this.minMaxSurround = minMaxSurround;
-  }
-
-  /**
-   * Check an attestation for slash safety, and if it is safe, record it in the database
-   * This is the safe, externally-callable interface for checking attestations
-   */
-  async checkAndInsertAttestation(pubKey: BLSPubkey, attestation: SlashingProtectionAttestation): Promise<void> {
-    const safeStatus = await this.checkAttestation(pubKey, attestation);
-
-    if (safeStatus != SafeStatus.SAME_DATA) {
-      await this.insertAttestation(pubKey, attestation);
-    }
-
-    // TODO: Implement safe clean-up of stored attestations
   }
 
   /**

--- a/packages/validator/src/slashingProtection/index.ts
+++ b/packages/validator/src/slashingProtection/index.ts
@@ -5,6 +5,7 @@ import {BlockBySlotRepository, SlashingProtectionBlockService} from "./block";
 import {
   AttestationByTargetRepository,
   AttestationLowerBoundRepository,
+  SafeStatus,
   SlashingProtectionAttestationService,
 } from "./attestation";
 import {ISlashingProtection} from "./interface";
@@ -51,8 +52,12 @@ export class SlashingProtection extends DatabaseService implements ISlashingProt
     await this.blockService.checkAndInsertBlockProposal(pubKey, block);
   }
 
-  async checkAndInsertAttestation(pubKey: BLSPubkey, attestation: SlashingProtectionAttestation): Promise<void> {
-    await this.attestationService.checkAndInsertAttestation(pubKey, attestation);
+  async checkAttestation(pubKey: BLSPubkey, attestation: SlashingProtectionAttestation): Promise<SafeStatus> {
+    return await this.attestationService.checkAttestation(pubKey, attestation);
+  }
+
+  async insertAttestation(pubKey: BLSPubkey, attestation: SlashingProtectionAttestation): Promise<void> {
+    await this.attestationService.insertAttestation(pubKey, attestation);
   }
 
   async importInterchange(interchange: Interchange, genesisValidatorsRoot: Root): Promise<void> {

--- a/packages/validator/src/slashingProtection/interface.ts
+++ b/packages/validator/src/slashingProtection/interface.ts
@@ -1,4 +1,5 @@
 import {BLSPubkey} from "@chainsafe/lodestar-types";
+import {SafeStatus} from "./attestation";
 import {SlashingProtectionBlock, SlashingProtectionAttestation} from "./types";
 
 export interface ISlashingProtection {
@@ -7,7 +8,11 @@ export interface ISlashingProtection {
    */
   checkAndInsertBlockProposal(pubKey: BLSPubkey, block: SlashingProtectionBlock): Promise<void>;
   /**
-   * Check an attestation for slash safety, and if it is safe, record it in the database
+   * Check an attestation for slash safety
    */
-  checkAndInsertAttestation(pubKey: BLSPubkey, attestation: SlashingProtectionAttestation): Promise<void>;
+  checkAttestation(pubKey: BLSPubkey, attestation: SlashingProtectionAttestation): Promise<SafeStatus>;
+  /**
+   * If it is safe, record it in the database
+   */
+  insertAttestation(pubKey: BLSPubkey, attestation: SlashingProtectionAttestation): Promise<void>;
 }

--- a/packages/validator/src/types.ts
+++ b/packages/validator/src/types.ts
@@ -2,8 +2,11 @@
  * @module validator
  */
 import {SecretKey} from "@chainsafe/bls";
-import {BLSPubkey} from "@chainsafe/lodestar-types";
+import {BLSPubkey, phase0} from "@chainsafe/lodestar-types";
 import {IDatabaseController} from "@chainsafe/lodestar-db";
+import {SlashingProtectionAttestation} from "./slashingProtection";
+import {SafeStatus} from "./slashingProtection/attestation";
+import {routes} from "@chainsafe/lodestar-api";
 
 export type GenesisInfo = {
   startTime: number;
@@ -19,3 +22,10 @@ export type LodestarValidatorDatabaseController = Pick<
   IDatabaseController<Buffer, Buffer>,
   "get" | "start" | "values" | "batchPut" | "keys" | "get" | "put"
 >;
+
+export type AttestationSigningResult = {
+  duty: routes.validator.AttesterDuty;
+  attestation: phase0.Attestation;
+  slashingProtection: SlashingProtectionAttestation;
+  safeStatus: SafeStatus;
+};

--- a/packages/validator/test/e2e/slashing-protection-interchange-tests/index.test.ts
+++ b/packages/validator/test/e2e/slashing-protection-interchange-tests/index.test.ts
@@ -49,13 +49,12 @@ describe("slashing-protection custom tests", () => {
     };
     const attestation2: SlashingProtectionAttestation = {
       targetEpoch: attestation1.targetEpoch,
-      sourceEpoch: 999,
+      sourceEpoch: attestation1.sourceEpoch,
       signingRoot: Buffer.alloc(32, 2),
     };
 
-    await slashingProtection.checkAndInsertAttestation(pubkey, attestation1);
-    await expect(slashingProtection.checkAndInsertAttestation(pubkey, attestation2)).to.be.rejectedWith(
-      InvalidAttestationError
-    );
+    await slashingProtection.checkAttestation(pubkey, attestation1);
+    await slashingProtection.insertAttestation(pubkey, attestation1);
+    await expect(slashingProtection.checkAttestation(pubkey, attestation2)).to.be.rejectedWith(InvalidAttestationError);
   });
 });

--- a/packages/validator/test/e2e/slashing-protection-interchange-tests/spec.test.ts
+++ b/packages/validator/test/e2e/slashing-protection-interchange-tests/spec.test.ts
@@ -17,6 +17,7 @@ import {
   SlashingProtectionAttestation,
 } from "../../../src/slashingProtection";
 import {ISlashingProtectionInterchangeTest, SPEC_TEST_LOCATION} from "./params";
+import {SafeStatus} from "../../../src/slashingProtection/attestation";
 
 chai.use(chaiAsPromised);
 
@@ -96,9 +97,12 @@ describe("slashing-protection-interchange-tests", () => {
                 signingRoot: attestationRaw.signing_root ? fromHexString(attestationRaw.signing_root) : ZERO_HASH,
               };
               if (attestationRaw.should_succeed) {
-                await slashingProtection.checkAndInsertAttestation(pubkey, attestation);
+                const safeStatus = await slashingProtection.checkAttestation(pubkey, attestation);
+                if (safeStatus !== SafeStatus.SAME_DATA) {
+                  await slashingProtection.insertAttestation(pubkey, attestation);
+                }
               } else {
-                await expect(slashingProtection.checkAndInsertAttestation(pubkey, attestation)).to.be.rejectedWith(
+                await expect(slashingProtection.checkAttestation(pubkey, attestation)).to.be.rejectedWith(
                   InvalidAttestationError
                 );
               }

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -13,6 +13,7 @@ import {getApiClientStub} from "../../utils/apiStub";
 import {loggerVc, testLogger} from "../../utils/logger";
 import {ClockMock} from "../../utils/clock";
 import {IndicesService} from "../../../src/services/indices";
+import {AttestationSigningResult} from "../../../src/types";
 
 describe("AttestationService", function () {
   const sandbox = sinon.createSandbox();
@@ -74,7 +75,8 @@ describe("AttestationService", function () {
     api.validator.publishAggregateAndProofs.resolves();
 
     // Mock signing service
-    validatorStore.signAttestation.resolves(attestation);
+    validatorStore.signAttestation.resolves({attestation} as AttestationSigningResult);
+    validatorStore.slashingProtectionAttestation.resolves();
     validatorStore.signAggregateAndProof.resolves(aggregate);
 
     // Trigger clock onSlot for slot 0


### PR DESCRIPTION
**Motivation**

+ As shown in https://github.com/ChainSafe/lodestar/issues/3211#issuecomment-925447606 when our node is not stable, attester duties may not be correct
+ But the validator insert SlashingProtectionAttestation right after it signs the attestation
+ Then the validation publish attestation unsucessfully (maybe with an invalid signature error)
+ When the next/correct duties come in same epoch, we got double vote error

**Description**

+ Only insert SlashingProtectionAttestation after we successfully publish attestation

part of #3211 

**TODOs**
- [ ] Determine if a specific attestation failed the validation at api side
- [ ] Consider doing that for block? We may not need it.