### PR TITLE
UnknownBlockSync: handle ALREADY_KNOWN error

### DIFF
--- a/packages/lodestar/src/chain/blocks/index.ts
+++ b/packages/lodestar/src/chain/blocks/index.ts
@@ -112,7 +112,7 @@ export async function processChainSegment(
         partiallyVerifiedBlock.ignoreIfKnown &&
         (err.type.code === BlockErrorCode.ALREADY_KNOWN || err.type.code === BlockErrorCode.GENESIS_BLOCK)
       ) {
-        return;
+        continue;
       }
 
       modules.emitter.emit(ChainEvent.errorBlock, err);

--- a/packages/lodestar/src/chain/blocks/types.ts
+++ b/packages/lodestar/src/chain/blocks/types.ts
@@ -6,6 +6,12 @@ export type FullyVerifiedBlockFlags = {
    * TEMP: Review if this is safe, Lighthouse always imports attestations even in finalized sync.
    */
   skipImportingAttestations?: boolean;
+  /**
+   * If error would trigger BlockErrorCode ALREADY_KNOWN or GENESIS_BLOCK, just ignore the block and don't verify nor
+   * import the block and return void | Promise<void>.
+   * Used by range sync and unknown block sync.
+   */
+  ignoreIfKnown?: boolean;
 };
 
 export type PartiallyVerifiedBlockFlags = FullyVerifiedBlockFlags & {

--- a/packages/lodestar/src/sync/range/range.ts
+++ b/packages/lodestar/src/sync/range/range.ts
@@ -11,6 +11,7 @@ import {IMetrics} from "../../metrics";
 import {RangeSyncType, getRangeSyncType} from "../utils/remoteSyncType";
 import {updateChains, shouldRemoveChain} from "./utils";
 import {ChainTarget, SyncChainFns, SyncChain, SyncChainOpts, SyncChainDebugState} from "./chain";
+import {PartiallyVerifiedBlockFlags} from "../../chain/blocks";
 
 export enum RangeSyncEvent {
   completedChain = "RangeSync-completedChain",
@@ -184,7 +185,12 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
   /** Convenience method for `SyncChain` */
   private processChainSegment: SyncChainFns["processChainSegment"] = async (blocks) => {
     // Not trusted, verify signatures
-    const flags = {skipImportingAttestations: true, trusted: false};
+    const flags: PartiallyVerifiedBlockFlags = {
+      // TODO: Review if this is okay, can we prevent some attacks by importing attestations?
+      skipImportingAttestations: true,
+      // Ignores ALREADY_KNOWN or GENESIS_BLOCK errors, and continues with the next block in chain segment
+      ignoreIfKnown: true,
+    };
 
     if (this.opts?.disableProcessAsChainSegment) {
       // Should only be used for debugging or testing

--- a/packages/lodestar/src/sync/unknownBlock.ts
+++ b/packages/lodestar/src/sync/unknownBlock.ts
@@ -166,22 +166,28 @@ export class UnknownBlockSync {
     }
 
     pendingBlock.status = PendingBlockStatus.processing;
-    const res = await wrapError(this.chain.processBlock(pendingBlock.signedBlock));
+    const res = await wrapError(this.chain.processBlock(pendingBlock.signedBlock, {ignoreIfKnown: true}));
     pendingBlock.status = PendingBlockStatus.pending;
 
     if (res.err) this.metrics?.syncUnknownBlock.processedBlocksError.inc(1);
     else this.metrics?.syncUnknownBlock.processedBlocksSuccess.inc(1);
 
-    let isProcessed = false;
-    if (res.err) {
+    if (!res.err) {
+      this.pendingBlocks.delete(pendingBlock.blockRootHex);
+
+      // Send child blocks to the processor
+      for (const descendantBlock of getDescendantBlocks(pendingBlock.blockRootHex, this.pendingBlocks)) {
+        this.processBlock(descendantBlock).catch((e) => {
+          this.logger.error("Unexpect error - processBlock", {}, e);
+        });
+      }
+    } else {
       const errorData = {root: pendingBlock.blockRootHex, slot: pendingBlock.signedBlock.message.slot};
       if (res.err instanceof BlockError) {
         switch (res.err.type.code) {
-          case BlockErrorCode.ALREADY_KNOWN:
-          case BlockErrorCode.GENESIS_BLOCK:
-            // Some race-condition imported the block earlier, that's okay ignore
-            isProcessed = true;
-            break;
+          // This cases are already handled with `{ignoreIfKnown: true}`
+          // case BlockErrorCode.ALREADY_KNOWN:
+          // case BlockErrorCode.GENESIS_BLOCK:
 
           case BlockErrorCode.PARENT_UNKNOWN:
           case BlockErrorCode.PRESTATE_MISSING:
@@ -201,19 +207,6 @@ export class UnknownBlockSync {
       else {
         this.logger.error("Unknown error processing block from unknown parent sync", errorData, res.err);
         pendingBlock.status = PendingBlockStatus.pending;
-      }
-    } else {
-      // no error
-      isProcessed = true;
-    }
-    if (isProcessed) {
-      this.pendingBlocks.delete(pendingBlock.blockRootHex);
-
-      // Send child blocks to the processor
-      for (const descendantBlock of getDescendantBlocks(pendingBlock.blockRootHex, this.pendingBlocks)) {
-        this.processBlock(descendantBlock).catch((e) => {
-          this.logger.error("Unexpect error - processBlock", {}, e);
-        });
       }
     }
   }


### PR DESCRIPTION
**Motivation**

For unknownBlockSync, after processing a block we want to treat ALREADY_KNOWN error as a success so that we can remove the block from pendingBlock array, and continue processing child blocks. 

**Description**

Closes #3236
