### PR TITLE
Validator: log full validator root hex for debug context

### DIFF
--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -53,12 +53,13 @@ export class BlockProposingService {
     try {
       const randaoReveal = await this.validatorStore.signRandao(pubkey, slot);
       const graffiti = this.graffiti || "";
+      const debugLogCtx = {...logCtx, validator: pubkeyHex};
 
-      this.logger.debug("Producing block", logCtx);
+      this.logger.debug("Producing block", debugLogCtx);
       const block = await this.produceBlock(slot, randaoReveal, graffiti).catch((e: Error) => {
         throw extendError(e, "Failed to produce block");
       });
-      this.logger.debug("Produced block", logCtx);
+      this.logger.debug("Produced block", debugLogCtx);
 
       const signedBlock = await this.validatorStore.signBlock(pubkey, block.data, slot);
       await this.api.beacon.publishBlock(signedBlock).catch((e: Error) => {

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -1,7 +1,7 @@
 import {AbortSignal} from "@chainsafe/abort-controller";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {Slot, CommitteeIndex, altair, Root} from "@chainsafe/lodestar-types";
-import {prettyBytes, sleep} from "@chainsafe/lodestar-utils";
+import {sleep} from "@chainsafe/lodestar-utils";
 import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {Api} from "@chainsafe/lodestar-api";
 import {IClock, extendError, ILoggerVc} from "../util";
@@ -103,7 +103,7 @@ export class SyncCommitteeService {
     const signatures: altair.SyncCommitteeMessage[] = [];
 
     for (const {duty} of duties) {
-      const logCtxValidator = {...logCtx, validator: prettyBytes(duty.pubkey)};
+      const logCtxValidator = {...logCtx, validatorIndex: duty.validatorIndex};
       try {
         signatures.push(
           await this.validatorStore.signSyncCommitteeSignature(duty.pubkey, duty.validatorIndex, slot, blockRoot)
@@ -159,7 +159,7 @@ export class SyncCommitteeService {
     const signedContributions: altair.SignedContributionAndProof[] = [];
 
     for (const {duty, selectionProof} of duties) {
-      const logCtxValidator = {...logCtx, validator: prettyBytes(duty.pubkey)};
+      const logCtxValidator = {...logCtx, validatorIndex: duty.validatorIndex};
       try {
         // Produce signed contributions only for validators that are subscribed aggregators.
         if (selectionProof !== null) {


### PR DESCRIPTION
**Motivation**

To debug an issue in validator, it's hard to get validator index from `prettyBytes()`

**Description**

+ For debug context, log full validator root hex
+ For info context, keep `prettyBytes()`/short root hex

from #3211 
