### PR TITLE
Handle attester duties reorg

### DIFF
--- a/packages/beacon-state-transition/src/util/shufflingDecisionRoot.ts
+++ b/packages/beacon-state-transition/src/util/shufflingDecisionRoot.ts
@@ -1,7 +1,7 @@
 import {allForks, Epoch, Root, Slot} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "../allForks/util/cachedBeaconState";
 import {getBlockRootAtSlot} from "./blockRoot";
-import {computeEpochAtSlot, computeStartSlotAtEpoch} from "./epoch";
+import {computeStartSlotAtEpoch} from "./epoch";
 
 /**
  * Returns the block root which decided the proposer shuffling for the current epoch. This root
@@ -10,7 +10,7 @@ import {computeEpochAtSlot, computeStartSlotAtEpoch} from "./epoch";
  * Returns `null` on the one-off scenario where the genesis block decides its own shuffling.
  * It should be set to the latest block applied to this `state` or the genesis block root.
  */
-export function proposerShufflingDecisionRoot(state: allForks.BeaconState): Root | null {
+export function proposerShufflingDecisionRoot(state: CachedBeaconState<allForks.BeaconState>): Root | null {
   const decisionSlot = proposerShufflingDecisionSlot(state);
   if (state.slot == decisionSlot) {
     return null;
@@ -23,9 +23,8 @@ export function proposerShufflingDecisionRoot(state: allForks.BeaconState): Root
  * Returns the slot at which the proposer shuffling was decided. The block root at this slot
  * can be used to key the proposer shuffling for the current epoch.
  */
-function proposerShufflingDecisionSlot(state: allForks.BeaconState): Slot {
-  const epoch = computeEpochAtSlot(state.slot);
-  const startSlot = computeStartSlotAtEpoch(epoch);
+function proposerShufflingDecisionSlot(state: CachedBeaconState<allForks.BeaconState>): Slot {
+  const startSlot = computeStartSlotAtEpoch(state.currentShuffling.epoch);
   return Math.max(startSlot - 1, 0);
 }
 

--- a/packages/lodestar/src/api/impl/events/index.ts
+++ b/packages/lodestar/src/api/impl/events/index.ts
@@ -37,7 +37,7 @@ export function getEventsApi({chain, config}: Pick<ApiModules, "chain" | "config
       }
       const currentEpoch = state.currentShuffling.epoch;
       const [previousDutyDependentRoot, currentDutyDependentRoot] = [currentEpoch - 1, currentEpoch].map((epoch) =>
-        toHexString(getBlockRootAtSlot(state, computeStartSlotAtEpoch(epoch) - 1))
+        toHexString(getBlockRootAtSlot(state, Math.max(computeStartSlotAtEpoch(epoch) - 1, 0)))
       );
       return [
         {

--- a/packages/lodestar/src/api/impl/events/index.ts
+++ b/packages/lodestar/src/api/impl/events/index.ts
@@ -1,11 +1,11 @@
-import {ApiModules} from "../types";
-import {ChainEvent, IChainEvents} from "../../../chain";
-import {routes} from "@chainsafe/lodestar-api";
 import {
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   getBlockRootAtSlot,
 } from "@chainsafe/lodestar-beacon-state-transition";
+import {ApiModules} from "../types";
+import {ChainEvent, IChainEvents} from "../../../chain";
+import {routes} from "@chainsafe/lodestar-api";
 import {ApiError} from "../errors";
 import {toHexString} from "@chainsafe/ssz";
 

--- a/packages/lodestar/src/api/impl/events/index.ts
+++ b/packages/lodestar/src/api/impl/events/index.ts
@@ -1,8 +1,11 @@
 import {ApiModules} from "../types";
 import {ChainEvent, IChainEvents} from "../../../chain";
 import {routes} from "@chainsafe/lodestar-api";
-import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
-import {ZERO_HASH} from "../../../constants";
+import {
+  computeEpochAtSlot,
+  computeStartSlotAtEpoch,
+  getBlockRootAtSlot,
+} from "@chainsafe/lodestar-beacon-state-transition";
 import {ApiError} from "../errors";
 import {toHexString} from "@chainsafe/ssz";
 
@@ -19,8 +22,6 @@ const chainEventMap = {
 };
 
 export function getEventsApi({chain, config}: Pick<ApiModules, "chain" | "config">): routes.events.Api {
-  const ZERO_HASH_HEX = toHexString(ZERO_HASH);
-
   /**
    * Mapping to convert internal `ChainEvents` payload to the API spec events data
    */
@@ -29,17 +30,26 @@ export function getEventsApi({chain, config}: Pick<ApiModules, "chain" | "config
       ...args: Parameters<IChainEvents[typeof chainEventMap[K]]>
     ) => routes.events.EventData[K][];
   } = {
-    [routes.events.EventType.head]: (head) => [
-      {
-        block: head.blockRoot,
-        epochTransition: computeStartSlotAtEpoch(computeEpochAtSlot(head.slot)) === head.slot,
-        slot: head.slot,
-        state: head.stateRoot,
-        // Todo implement
-        previousDutyDependentRoot: ZERO_HASH_HEX,
-        currentDutyDependentRoot: ZERO_HASH_HEX,
-      },
-    ],
+    [routes.events.EventType.head]: (head) => {
+      const state = chain.stateCache.get(head.stateRoot);
+      if (!state) {
+        throw Error("cannot get state for head " + head.stateRoot);
+      }
+      const currentEpoch = state.currentShuffling.epoch;
+      const [previousDutyDependentRoot, currentDutyDependentRoot] = [currentEpoch - 1, currentEpoch].map((epoch) =>
+        toHexString(getBlockRootAtSlot(state, computeStartSlotAtEpoch(epoch) - 1))
+      );
+      return [
+        {
+          block: head.blockRoot,
+          epochTransition: computeStartSlotAtEpoch(computeEpochAtSlot(head.slot)) === head.slot,
+          slot: head.slot,
+          state: head.stateRoot,
+          previousDutyDependentRoot,
+          currentDutyDependentRoot,
+        },
+      ];
+    },
     [routes.events.EventType.block]: (block) => [
       {
         block: toHexString(config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message)),

--- a/packages/lodestar/src/api/impl/events/index.ts
+++ b/packages/lodestar/src/api/impl/events/index.ts
@@ -35,10 +35,12 @@ export function getEventsApi({chain, config}: Pick<ApiModules, "chain" | "config
       if (!state) {
         throw Error("cannot get state for head " + head.stateRoot);
       }
+
       const currentEpoch = state.currentShuffling.epoch;
       const [previousDutyDependentRoot, currentDutyDependentRoot] = [currentEpoch - 1, currentEpoch].map((epoch) =>
         toHexString(getBlockRootAtSlot(state, Math.max(computeStartSlotAtEpoch(epoch) - 1, 0)))
       );
+
       return [
         {
           block: head.blockRoot,

--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -275,6 +275,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
       // May request for an epoch that's in the future
       await waitForNextClosestEpoch();
 
+      // should not compare to headEpoch in order to handle skipped slots
       // Check if the epoch is in the future after waiting for requested slot
       if (epoch > chain.clock.currentEpoch + 1) {
         throw new ApiError(400, "Cannot get duties for epoch more than one ahead");

--- a/packages/lodestar/test/unit/api/impl/events/events.test.ts
+++ b/packages/lodestar/test/unit/api/impl/events/events.test.ts
@@ -42,7 +42,7 @@ describe("Events api impl", function () {
       const events = getEvents([routes.events.EventType.head]);
 
       const headBlock = generateProtoBlock();
-      stateCacheStub.get.withArgs(headBlock.stateRoot).returns(generateCachedState());
+      stateCacheStub.get.withArgs(headBlock.stateRoot).returns(generateCachedState({slot: 1000}));
       chainEventEmmitter.emit(ChainEvent.forkChoiceReorg, headBlock, headBlock, 2);
       chainEventEmmitter.emit(ChainEvent.forkChoiceHead, headBlock);
 
@@ -55,7 +55,7 @@ describe("Events api impl", function () {
       const events = getEvents([routes.events.EventType.head]);
 
       const headBlock = generateProtoBlock();
-      stateCacheStub.get.withArgs(headBlock.stateRoot).returns(generateCachedState());
+      stateCacheStub.get.withArgs(headBlock.stateRoot).returns(generateCachedState({slot: 1000}));
       chainEventEmmitter.emit(ChainEvent.forkChoiceHead, headBlock);
 
       expect(events).to.have.length(1, "Wrong num of received events");

--- a/packages/lodestar/test/unit/api/impl/events/events.test.ts
+++ b/packages/lodestar/test/unit/api/impl/events/events.test.ts
@@ -8,15 +8,19 @@ import {getEventsApi} from "../../../../../src/api/impl/events";
 import {generateProtoBlock, generateEmptySignedBlock, generateSignedBlock} from "../../../../utils/block";
 import {generateAttestation, generateEmptySignedVoluntaryExit} from "../../../../utils/attestation";
 import {generateCachedState} from "../../../../utils/state";
+import {StateContextCache} from "../../../../../src/chain/stateCache";
 
 describe("Events api impl", function () {
   describe("beacon event stream", function () {
     let chainStub: SinonStubbedInstance<IBeaconChain>;
+    let stateCacheStub: SinonStubbedInstance<StateContextCache>;
     let chainEventEmmitter: ChainEventEmitter;
     let api: ReturnType<typeof getEventsApi>;
 
     beforeEach(function () {
       chainStub = sinon.createStubInstance(BeaconChain);
+      stateCacheStub = sinon.createStubInstance(StateContextCache);
+      chainStub.stateCache = (stateCacheStub as unknown) as StateContextCache;
       chainEventEmmitter = new ChainEventEmitter();
       chainStub.emitter = chainEventEmmitter;
       api = getEventsApi({config, chain: chainStub});
@@ -38,6 +42,7 @@ describe("Events api impl", function () {
       const events = getEvents([routes.events.EventType.head]);
 
       const headBlock = generateProtoBlock();
+      stateCacheStub.get.withArgs(headBlock.stateRoot).returns(generateCachedState());
       chainEventEmmitter.emit(ChainEvent.forkChoiceReorg, headBlock, headBlock, 2);
       chainEventEmmitter.emit(ChainEvent.forkChoiceHead, headBlock);
 
@@ -50,6 +55,7 @@ describe("Events api impl", function () {
       const events = getEvents([routes.events.EventType.head]);
 
       const headBlock = generateProtoBlock();
+      stateCacheStub.get.withArgs(headBlock.stateRoot).returns(generateCachedState());
       chainEventEmmitter.emit(ChainEvent.forkChoiceHead, headBlock);
 
       expect(events).to.have.length(1, "Wrong num of received events");

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -9,6 +9,7 @@ import {AttestationDutiesService, AttDutyAndProof} from "./attestationDuties";
 import {groupAttDutiesByCommitteeIndex} from "./utils";
 import {IndicesService} from "./indices";
 import {toHexString} from "@chainsafe/ssz";
+import {ChainHeaderTracker} from "./chainHeaderTracker";
 
 /**
  * Service that sets up and handles validator attester duties.
@@ -21,9 +22,17 @@ export class AttestationService {
     private readonly api: Api,
     private readonly clock: IClock,
     private readonly validatorStore: ValidatorStore,
-    indicesService: IndicesService
+    indicesService: IndicesService,
+    chainHeadTracker: ChainHeaderTracker
   ) {
-    this.dutiesService = new AttestationDutiesService(logger, api, clock, validatorStore, indicesService);
+    this.dutiesService = new AttestationDutiesService(
+      logger,
+      api,
+      clock,
+      validatorStore,
+      indicesService,
+      chainHeadTracker
+    );
 
     // At most every slot, check existing duties from AttestationDutiesService and run tasks
     clock.runEverySlot(this.runAttestationTasks);

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -67,7 +67,6 @@ export class AttestationDutiesService {
   /**
    * If a reorg dependent root comes at a slot other than last slot of epoch
    * just update this.pendingDependentRootByEpoch() and process here
-   * @returns
    */
   private prepareForNextEpoch = async (slot: Slot): Promise<void> => {
     // only interested in last slot of epoch

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -50,11 +50,11 @@ export class AttestationDutiesService {
   getDutiesAtSlot(slot: Slot): AttDutyAndProof[] {
     const epoch = computeEpochAtSlot(slot);
     const duties: AttDutyAndProof[] = [];
-
     const epochDuties = this.dutiesByIndexByEpoch.get(epoch);
     if (epochDuties === undefined) {
       return duties;
     }
+
     for (const validatorDuty of epochDuties.dutiesByIndex.values()) {
       if (validatorDuty.duty.slot === slot) {
         duties.push(validatorDuty);
@@ -73,8 +73,10 @@ export class AttestationDutiesService {
     if ((slot + 1) % SLOTS_PER_EPOCH !== 0) {
       return;
     }
+
     // during the 1 / 3 of epoch, last block of epoch may come
     await sleep(this.clock.msToSlotFraction(slot, 1 / 3));
+
     const nextEpoch = computeEpochAtSlot(slot) + 1;
     const dependentRoot = this.dutiesByIndexByEpoch.get(nextEpoch)?.dependentRoot;
     const pendingDependentRoot = this.pendingDependentRootByEpoch.get(nextEpoch);
@@ -190,6 +192,7 @@ export class AttestationDutiesService {
     const prior = this.dutiesByIndexByEpoch.get(epoch);
     const priorDependentRoot = prior?.dependentRoot;
     const dependentRootChanged = priorDependentRoot !== undefined && priorDependentRoot !== dependentRoot;
+
     if (!prior || dependentRootChanged) {
       const dutiesByIndex = new Map<ValidatorIndex, AttDutyAndProof>();
       for (const duty of relevantDuties) {
@@ -198,6 +201,7 @@ export class AttestationDutiesService {
       }
       this.dutiesByIndexByEpoch.set(epoch, {dependentRoot, dutiesByIndex});
     }
+
     if (prior && dependentRootChanged) {
       this.logger.warn("Attester duties re-org. This may happen from time to time", {
         priorDependentRoot: priorDependentRoot,
@@ -281,7 +285,9 @@ export class AttestationDutiesService {
       oldDependentRoot,
       newDependentRoot,
     };
+
     this.logger.debug("Redownload attester duties", logContext);
+
     await this.pollBeaconAttestersForEpoch(dutyEpoch, this.indicesService.getAllLocalIndices())
       .then(() => {
         this.pendingDependentRootByEpoch.delete(dutyEpoch);

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -189,11 +189,10 @@ export class AttestationDutiesService {
       count: relevantDuties.length,
     });
 
-    const prior = this.dutiesByIndexByEpoch.get(epoch);
-    const priorDependentRoot = prior?.dependentRoot;
+    const priorDependentRoot = this.dutiesByIndexByEpoch.get(epoch)?.dependentRoot;
     const dependentRootChanged = priorDependentRoot !== undefined && priorDependentRoot !== dependentRoot;
 
-    if (!prior || dependentRootChanged) {
+    if (!priorDependentRoot || dependentRootChanged) {
       const dutiesByIndex = new Map<ValidatorIndex, AttDutyAndProof>();
       for (const duty of relevantDuties) {
         const dutyAndProof = await this.getDutyAndProof(duty);
@@ -202,7 +201,7 @@ export class AttestationDutiesService {
       this.dutiesByIndexByEpoch.set(epoch, {dependentRoot, dutiesByIndex});
     }
 
-    if (prior && dependentRootChanged) {
+    if (priorDependentRoot && dependentRootChanged) {
       this.logger.warn("Attester duties re-org. This may happen from time to time", {
         priorDependentRoot: priorDependentRoot,
         dependentRoot: dependentRoot,

--- a/packages/validator/src/services/chainHeaderTracker.ts
+++ b/packages/validator/src/services/chainHeaderTracker.ts
@@ -6,12 +6,17 @@ import {fromHexString} from "@chainsafe/ssz";
 
 const {EventType} = routes.events;
 
+export type SlotRoot = {slot: Slot; root: Root};
+
+type RunEveryFn = (slotRoot: SlotRoot) => Promise<void>;
+
 /**
  * Track the head slot/root using the event stream api "head".
  */
 export class ChainHeaderTracker {
   private headBlockSlot: Slot = GENESIS_SLOT;
   private headBlockRoot: Root | null = null;
+  private readonly fns: RunEveryFn[] = [];
 
   constructor(private readonly logger: ILogger, private readonly api: Api) {}
 
@@ -28,11 +33,18 @@ export class ChainHeaderTracker {
     return null;
   }
 
+  runOnNewHead(fn: RunEveryFn): void {
+    this.fns.push(fn);
+  }
+
   private onHeadUpdate = (event: routes.events.BeaconEvent): void => {
     if (event.type === EventType.head) {
       const {message} = event;
       this.headBlockSlot = message.slot;
       this.headBlockRoot = fromHexString(message.block);
+      for (const fn of this.fns) {
+        void fn({slot: this.headBlockSlot, root: this.headBlockRoot});
+      }
       this.logger.verbose("Found new chain head", {slot: message.slot, blockRoot: message.block});
     }
   };

--- a/packages/validator/src/services/chainHeaderTracker.ts
+++ b/packages/validator/src/services/chainHeaderTracker.ts
@@ -49,12 +49,12 @@ export class ChainHeaderTracker {
       this.headBlockSlot = slot;
       this.headBlockRoot = fromHexString(block);
       for (const fn of this.fns) {
-        void fn({
+        fn({
           slot: this.headBlockSlot,
           head: block,
           previousDutyDependentRoot: previousDutyDependentRoot,
           currentDutyDependentRoot: currentDutyDependentRoot,
-        });
+        }).catch((e) => this.logger.error("Error calling head event handler", e));
       }
       this.logger.verbose("Found new chain head", {
         slot: slot,

--- a/packages/validator/src/services/chainHeaderTracker.ts
+++ b/packages/validator/src/services/chainHeaderTracker.ts
@@ -48,6 +48,7 @@ export class ChainHeaderTracker {
       const {slot, block, previousDutyDependentRoot, currentDutyDependentRoot} = message;
       this.headBlockSlot = slot;
       this.headBlockRoot = fromHexString(block);
+
       for (const fn of this.fns) {
         fn({
           slot: this.headBlockSlot,
@@ -56,6 +57,7 @@ export class ChainHeaderTracker {
           currentDutyDependentRoot: currentDutyDependentRoot,
         }).catch((e) => this.logger.error("Error calling head event handler", e));
       }
+
       this.logger.verbose("Found new chain head", {
         slot: slot,
         head: block,

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -71,7 +71,7 @@ export class Validator {
     this.chainHeaderTracker = new ChainHeaderTracker(logger, api);
     const loggerVc = getLoggerVc(logger, clock);
     new BlockProposingService(config, loggerVc, api, clock, validatorStore, graffiti);
-    new AttestationService(loggerVc, api, clock, validatorStore, indicesService);
+    new AttestationService(loggerVc, api, clock, validatorStore, indicesService, this.chainHeaderTracker);
     new SyncCommitteeService(config, loggerVc, api, clock, validatorStore, this.chainHeaderTracker, indicesService);
 
     this.config = config;

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -13,6 +13,7 @@ import {getApiClientStub} from "../../utils/apiStub";
 import {loggerVc, testLogger} from "../../utils/logger";
 import {ClockMock} from "../../utils/clock";
 import {IndicesService} from "../../../src/services/indices";
+import {ChainHeaderTracker} from "../../../src/services/chainHeaderTracker";
 
 describe("AttestationService", function () {
   const sandbox = sinon.createSandbox();
@@ -22,6 +23,8 @@ describe("AttestationService", function () {
   const api = getApiClientStub(sandbox);
   const validatorStore = sinon.createStubInstance(ValidatorStore) as ValidatorStore &
     sinon.SinonStubbedInstance<ValidatorStore>;
+  const chainHeadTracker = sinon.createStubInstance(ChainHeaderTracker) as ChainHeaderTracker &
+    sinon.SinonStubbedInstance<ChainHeaderTracker>;
   let pubkeys: Uint8Array[]; // Initialize pubkeys in before() so bls is already initialized
 
   before(() => {
@@ -40,7 +43,14 @@ describe("AttestationService", function () {
   it("Should produce, sign, and publish an attestation + aggregate", async () => {
     const clock = new ClockMock();
     const indicesService = new IndicesService(logger, api, validatorStore);
-    const attestationService = new AttestationService(loggerVc, api, clock, validatorStore, indicesService);
+    const attestationService = new AttestationService(
+      loggerVc,
+      api,
+      clock,
+      validatorStore,
+      indicesService,
+      chainHeadTracker
+    );
 
     const attestation = generateEmptyAttestation();
     const aggregate = generateEmptySignedAggregateAndProof();


### PR DESCRIPTION
**Motivation**

+ When getting attester duties for current epoch, we have `notWhileSyncing()` check and it's good but not enough when validator ask for next epoch
+ For example in https://github.com/ChainSafe/lodestar/issues/3211#issuecomment-926320834, head epoch is at 41250 while validator asked for attester duties at epoch 41252, node should throw error instead of returning unreliable duties

**Description**

+ Check requested epoch vs headEpoch (instead of currentEpoch), it should be <=1
+ Closes #3211
