### PR TITLE
Range sync: add ignoreIfFinalized flag

### DIFF
--- a/packages/lodestar/src/chain/blocks/index.ts
+++ b/packages/lodestar/src/chain/blocks/index.ts
@@ -114,6 +114,9 @@ export async function processChainSegment(
       ) {
         continue;
       }
+      if (partiallyVerifiedBlock.ignoreIfFinalized && err.type.code == BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT) {
+        continue;
+      }
 
       modules.emitter.emit(ChainEvent.errorBlock, err);
 

--- a/packages/lodestar/src/chain/blocks/types.ts
+++ b/packages/lodestar/src/chain/blocks/types.ts
@@ -12,6 +12,12 @@ export type FullyVerifiedBlockFlags = {
    * Used by range sync and unknown block sync.
    */
   ignoreIfKnown?: boolean;
+  /**
+   * If error would trigger WOULD_REVERT_FINALIZED_SLOT, it means the block is finalized and we could ignore the block.
+   * Don't import and return void | Promise<void>
+   * Used by range sync.
+   */
+  ignoreIfFinalized?: boolean;
 };
 
 export type PartiallyVerifiedBlockFlags = FullyVerifiedBlockFlags & {

--- a/packages/lodestar/src/sync/range/range.ts
+++ b/packages/lodestar/src/sync/range/range.ts
@@ -190,6 +190,8 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
       skipImportingAttestations: true,
       // Ignores ALREADY_KNOWN or GENESIS_BLOCK errors, and continues with the next block in chain segment
       ignoreIfKnown: true,
+      // Ignore WOULD_REVERT_FINALIZED_SLOT error, continue with the next block in chain segment
+      ignoreIfFinalized: true,
     };
 
     if (this.opts?.disableProcessAsChainSegment) {


### PR DESCRIPTION
**Motivation**

+ In Range Sync, some preFinalized blocks come and it throws error BLOCK_ERROR_PARENT_UNKNOWN
+ The old range sync works by filtering those blocks out before processing remaining blocks

**Description**

+ For range sync, add `isPreFinalized` flags that ignore the error
+ This is not applied for `processBlock`
+ Switch conditions in `verifyBlockSanityChecks`, more specific errors should be checked first

Closes #3240
