### PR TITLE
Modify error message for getAncestorAtSlot

### DIFF
--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -652,7 +652,7 @@ export class ProtoArray {
         return parentNode;
       }
     }
-    throw Error("slot less than finalized block");
+    throw Error(`cannot get ancestor for block ${node.blockRoot} at slot ${slot}`);
   }
 
   private getNodeFromIndex(index: number): IProtoNode {


### PR DESCRIPTION
**Motivation**

The error "slot less than finalized block" is kind of misleading and missing specific information

**Description**

Change to `cannot get ancestor for block ${node.blockRoot} at slot ${slot}`

part of #3243
