### PR TITLE
propogating skipped block logic to processblock as well and debug logging on block skip

### DIFF
--- a/packages/lodestar/src/chain/emitter.ts
+++ b/packages/lodestar/src/chain/emitter.ts
@@ -102,6 +102,12 @@ export enum ChainEvent {
    * This event is guaranteed to be triggered after any block fed to the chain fails at any stage of processing.
    */
   errorBlock = "error:block",
+  /**
+   * This event signals that the chain has skipped or ignored a block when it erroed while processing.
+   *
+   * This event is guaranteed to be triggered after any block fed to the chain fails block processing and is deemed not to be relevant to the chain as per sync configuration.
+   */
+  skippedBlock = "skip:block",
 }
 
 export interface IChainEvents {
@@ -112,6 +118,7 @@ export interface IChainEvents {
   ) => void;
   [ChainEvent.errorAttestation]: (error: AttestationError) => void;
   [ChainEvent.errorBlock]: (error: BlockError) => void;
+  [ChainEvent.skippedBlock]: (error: BlockError) => void;
 
   [ChainEvent.checkpoint]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<allForks.BeaconState>) => void;
   [ChainEvent.justified]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<allForks.BeaconState>) => void;

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -50,6 +50,7 @@ export function handleChainEvents(this: BeaconChain, signal: AbortSignal): void 
     [ChainEvent.clockSlot]: onClockSlot,
     [ChainEvent.errorAttestation]: onErrorAttestation,
     [ChainEvent.errorBlock]: onErrorBlock,
+    [ChainEvent.skippedBlock]: onSkippedBlock,
     [ChainEvent.finalized]: onFinalized,
     [ChainEvent.forkChoiceFinalized]: onForkChoiceFinalized,
     [ChainEvent.forkChoiceHead]: onForkChoiceHead,
@@ -282,4 +283,13 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
       postStatePath,
     });
   }
+}
+
+export async function onSkippedBlock(this: BeaconChain, err: BlockError): Promise<void> {
+  if (!(err instanceof BlockError)) {
+    this.logger.error("Non BlockError received", {}, err);
+    return;
+  }
+
+  this.logger.debug("Block skipped", {slot: err.signedBlock.message.slot, errCode: err.type.code});
 }


### PR DESCRIPTION

**Motivation**
This PR makes the block skip logic same on processBlock and processChainSegment, plus adds debug logs on block skip
<!-- Why is this PR exists? What are the goals of the pull request? -->

context: https://github.com/ChainSafe/lodestar/pull/3245#discussion_r716029538

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
