### PR TITLE
Updated docs for proper syntax on network.localMultiaddrs and eth1Pro…

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/eth1.ts
+++ b/packages/cli/src/options/beaconNodeOptions/eth1.ts
@@ -41,7 +41,7 @@ export const options: ICliCommandOptions<IEth1Args> = {
   "eth1.providerUrls": {
     description: "Urls to Eth1 node with enabled rpc",
     type: "array",
-    defaultDescription: "http://localhost:8545 https://mainnet.infura.io/v3/apiKey",
+    defaultDescription: defaultOptions.eth1.providerUrls.join(" "),
     group: "eth1",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/eth1.ts
+++ b/packages/cli/src/options/beaconNodeOptions/eth1.ts
@@ -41,7 +41,7 @@ export const options: ICliCommandOptions<IEth1Args> = {
   "eth1.providerUrls": {
     description: "Urls to Eth1 node with enabled rpc",
     type: "array",
-    defaultDescription: JSON.stringify(defaultOptions.eth1.providerUrls),
+    defaultDescription: "http://localhost:8545 https://mainnet.infura.io/v3/apiKey",
     group: "eth1",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -76,7 +76,7 @@ export const options: ICliCommandOptions<INetworkArgs> = {
   "network.localMultiaddrs": {
     type: "array",
     description: "Local listening addresses for req/resp and gossip",
-    defaultDescription: JSON.stringify(defaultOptions.network.localMultiaddrs),
+    defaultDescription: "/ip4/0.0.0.0/tcp/9000",
     group: "network",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -76,7 +76,7 @@ export const options: ICliCommandOptions<INetworkArgs> = {
   "network.localMultiaddrs": {
     type: "array",
     description: "Local listening addresses for req/resp and gossip",
-    defaultDescription: "/ip4/0.0.0.0/tcp/9000",
+    defaultDescription: defaultOptions.network.localMultiaddrs.join(" "),
     group: "network",
   },
 


### PR DESCRIPTION
**Motivation**

To help clarify user docs for utilising these cli flags. Fixes #3208 

**Description**

Hard coded the proper syntax to the docs.


