### PR TITLE
Update light client init proof db

### DIFF
--- a/packages/api/src/routes/lightclient.ts
+++ b/packages/api/src/routes/lightclient.ts
@@ -1,6 +1,6 @@
 import {Path} from "@chainsafe/ssz";
 import {Proof} from "@chainsafe/persistent-merkle-tree";
-import {altair, Epoch, ssz, SyncPeriod} from "@chainsafe/lodestar-types";
+import {altair, ssz, SyncPeriod} from "@chainsafe/lodestar-types";
 import {
   ArrayOf,
   reqEmpty,
@@ -27,7 +27,7 @@ export type Api = {
   /**
    * Fetch a proof needed for light client initialization
    */
-  getInitProof(epoch: Epoch): Promise<{data: Proof}>;
+  getInitProof(blockRoot: string): Promise<{data: Proof}>;
 };
 
 /**
@@ -38,7 +38,7 @@ export const routesData: RoutesData<Api> = {
   getBestUpdates: {url: "/eth/v1/lightclient/best_updates", method: "GET"},
   getLatestUpdateFinalized: {url: "/eth/v1/lightclient/latest_update_finalized", method: "GET"},
   getLatestUpdateNonFinalized: {url: "/eth/v1/lightclient/latest_update_nonfinalized", method: "GET"},
-  getInitProof: {url: "/eth/v1/lightclient/init_proof/:epoch", method: "GET"},
+  getInitProof: {url: "/eth/v1/lightclient/init_proof/:blockRoot", method: "GET"},
 };
 
 export type ReqTypes = {
@@ -46,7 +46,7 @@ export type ReqTypes = {
   getBestUpdates: {query: {from: number; to: number}};
   getLatestUpdateFinalized: ReqEmpty;
   getLatestUpdateNonFinalized: ReqEmpty;
-  getInitProof: {params: {epoch: number}};
+  getInitProof: {params: {blockRoot: string}};
 };
 
 export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
@@ -67,9 +67,9 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
     getLatestUpdateNonFinalized: reqEmpty,
 
     getInitProof: {
-      writeReq: (epoch) => ({params: {epoch}}),
-      parseReq: ({params}) => [params.epoch],
-      schema: {params: {epoch: Schema.UintRequired}},
+      writeReq: (blockRoot) => ({params: {blockRoot}}),
+      parseReq: ({params}) => [params.blockRoot],
+      schema: {params: {blockRoot: Schema.StringRequired}},
     },
   };
 }

--- a/packages/api/test/unit/lightclient.test.ts
+++ b/packages/api/test/unit/lightclient.test.ts
@@ -41,7 +41,7 @@ describe("lightclient", () => {
       res: {data: lightClientUpdate},
     },
     getInitProof: {
-      args: [5],
+      args: ["0x00"],
       res: {
         data: {
           type: ProofType.treeOffset,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -57,8 +57,9 @@ export enum Bucket {
   // TODO: Review if it's really necessary
   altair_lightclientFinalizedCheckpoint = 33, // Epoch -> FinalizedCheckpointData
   // Note: this is the state root for the checkpoint block, NOT necessarily the state root at the epoch boundary
-  altair_lightClientInitProof = 34, // Epoch -> Proof
-  altair_lightClientSyncCommitteeProof = 35, // SyncPeriod ->
+  altair_lightClientInitProof = 34, // Block root -> Proof
+  altair_lightClientSyncCommitteeProof = 35, // SyncPeriod -> Sync Committee Proof
+  index_lightClientInitProof = 36, // Epoch + Block Root -> true
 
   validator_metaData = 41,
 }

--- a/packages/light-client/src/client/index.ts
+++ b/packages/light-client/src/client/index.ts
@@ -69,7 +69,7 @@ export class Lightclient {
     const header = headerResp.data.header.message;
     const stateRoot = header.stateRoot;
 
-    const proof = await api.lightclient.getInitProof(checkpoint.epoch);
+    const proof = await api.lightclient.getInitProof(toHexString(checkpoint.root));
 
     const state = ssz.altair.BeaconState.createTreeBackedFromProof(stateRoot as Uint8Array, proof.data);
     const store: LightClientStoreFast = {

--- a/packages/lodestar/src/api/impl/lightclient/index.ts
+++ b/packages/lodestar/src/api/impl/lightclient/index.ts
@@ -4,7 +4,7 @@ import {resolveStateId} from "../beacon/state/utils";
 import {routes} from "@chainsafe/lodestar-api";
 import {ApiError} from "../errors";
 import {linspace} from "../../../util/numpy";
-import {isCompositeType} from "@chainsafe/ssz";
+import {fromHexString, isCompositeType} from "@chainsafe/ssz";
 import {ProofType} from "@chainsafe/persistent-merkle-tree";
 import {IApiOptions} from "../../options";
 
@@ -73,8 +73,8 @@ export function getLightclientApi(
 
     // Init API
 
-    async getInitProof(epoch) {
-      const proof = await chain.lightClientIniter.getInitProofByEpoch(Number(epoch));
+    async getInitProof(blockRoot) {
+      const proof = await chain.lightClientIniter.getInitProofByBlockRoot(fromHexString(blockRoot));
       if (!proof) {
         throw new ApiError(404, "No init proof available");
       }

--- a/packages/lodestar/src/db/beacon.ts
+++ b/packages/lodestar/src/db/beacon.ts
@@ -18,6 +18,7 @@ import {
   LightclientFinalizedCheckpoint,
   LightClientInitProofRepository,
   LightClientSyncCommitteeProofRepository,
+  LightClientInitProofIndexRepository,
 } from "./repositories";
 import {
   PreGenesisState,
@@ -49,6 +50,7 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
   latestNonFinalizedUpdate: LatestNonFinalizedUpdate;
   lightclientFinalizedCheckpoint: LightclientFinalizedCheckpoint;
   lightClientInitProof: LightClientInitProofRepository;
+  lightClientInitProofIndex: LightClientInitProofIndexRepository;
   lightClientSyncCommitteeProof: LightClientSyncCommitteeProofRepository;
 
   constructor(opts: IDatabaseApiOptions) {
@@ -72,6 +74,7 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
     this.latestNonFinalizedUpdate = new LatestNonFinalizedUpdate(this.config, this.db, this.metrics);
     this.lightclientFinalizedCheckpoint = new LightclientFinalizedCheckpoint(this.config, this.db, this.metrics);
     this.lightClientInitProof = new LightClientInitProofRepository(this.config, this.db, this.metrics);
+    this.lightClientInitProofIndex = new LightClientInitProofIndexRepository(this.config, this.db, this.metrics);
     this.lightClientSyncCommitteeProof = new LightClientSyncCommitteeProofRepository(
       this.config,
       this.db,

--- a/packages/lodestar/src/db/interface.ts
+++ b/packages/lodestar/src/db/interface.ts
@@ -18,6 +18,7 @@ import {
   LightclientFinalizedCheckpoint,
   LightClientInitProofRepository,
   LightClientSyncCommitteeProofRepository,
+  LightClientInitProofIndexRepository,
 } from "./repositories";
 import {
   PreGenesisState,
@@ -63,6 +64,7 @@ export interface IBeaconDb {
   latestNonFinalizedUpdate: LatestNonFinalizedUpdate;
   lightclientFinalizedCheckpoint: LightclientFinalizedCheckpoint;
   lightClientInitProof: LightClientInitProofRepository;
+  lightClientInitProofIndex: LightClientInitProofIndexRepository;
   lightClientSyncCommitteeProof: LightClientSyncCommitteeProofRepository;
 
   /**

--- a/packages/lodestar/src/db/repositories/lightClientInitProof.ts
+++ b/packages/lodestar/src/db/repositories/lightClientInitProof.ts
@@ -3,7 +3,7 @@ import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {Bucket, IDatabaseController, IDbMetrics, Repository} from "@chainsafe/lodestar-db";
 import {Type} from "@chainsafe/ssz";
 
-export class LightClientInitProofRepository extends Repository<number, Proof> {
+export class LightClientInitProofRepository extends Repository<Uint8Array, Proof> {
   constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
     super(config, db, Bucket.altair_lightClientInitProof, (undefined as unknown) as Type<Proof>, metrics);
   }
@@ -17,8 +17,27 @@ export class LightClientInitProofRepository extends Repository<number, Proof> {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  getId(value: Proof): number {
+  getId(value: Proof): Uint8Array {
     throw new Error("Cannot get the db key from a proof");
+  }
+}
+
+export class LightClientInitProofIndexRepository extends Repository<Uint8Array, boolean> {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+    super(config, db, Bucket.index_lightClientInitProof, (undefined as unknown) as Type<boolean>, metrics);
+  }
+
+  encodeValue(_value: boolean): Buffer {
+    return Buffer.from([1]);
+  }
+
+  decodeValue(_data: Uint8Array): boolean {
+    return true;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getId(value: boolean): Uint8Array {
+    throw new Error("Cannot get the db key from a value");
   }
 }
 


### PR DESCRIPTION
**Motivation**

The init proof logic is not as straightforward as it could be. We were fetching the init proof by (checkpoint) epoch, and not by block root. 
The block root is really the primary thing. It expands to the state root, which is used to verify the init proof. No where is the epoch actually needed.

**Description**

Fetch init proof by block root instead of epoch
Store init proof by block root instead of epoch
Store an init proof index ${epoch}${blockRoot} for ease of pruning init proofs
Update existing logic to use above

TODO/discuss: we can now trigger the light client init proof builder with the 'checkpoint' event instead of the 'finalized' event. This may let us be more flexible with our state caches.