### PR TITLE
Get epoch from state cache

### DIFF
--- a/packages/beacon-state-transition/src/altair/epoch/balance.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/balance.ts
@@ -1,4 +1,4 @@
-import {altair, phase0} from "@chainsafe/lodestar-types";
+import {allForks, altair} from "@chainsafe/lodestar-types";
 import {
   EFFECTIVE_BALANCE_INCREMENT,
   INACTIVITY_PENALTY_QUOTIENT_ALTAIR,
@@ -51,7 +51,7 @@ export function getRewardsPenaltiesDeltas(
   const rewards = newZeroedArray(validatorCount);
   const penalties = newZeroedArray(validatorCount);
 
-  const isInInactivityLeakBn = isInInactivityLeak((state as unknown) as phase0.BeaconState);
+  const isInInactivityLeakBn = isInInactivityLeak(state as CachedBeaconState<allForks.BeaconState>);
   // effectiveBalance is multiple of EFFECTIVE_BALANCE_INCREMENT and less than MAX_EFFECTIVE_BALANCE
   // so there are limited values of them like 32000000000, 31000000000, 30000000000
   const rewardPenaltyItemCache = new Map<number, IRewardPenaltyItem>();

--- a/packages/beacon-state-transition/src/altair/epoch/processInactivityUpdates.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processInactivityUpdates.ts
@@ -1,5 +1,5 @@
 import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
-import {altair, Number64, phase0} from "@chainsafe/lodestar-types";
+import {allForks, altair, Number64} from "@chainsafe/lodestar-types";
 import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
 import * as attesterStatusUtil from "../../allForks/util/attesterStatus";
 import {isInInactivityLeak} from "../../util";
@@ -28,7 +28,7 @@ export function processInactivityUpdates(
   const {config, inactivityScores} = state;
   const {INACTIVITY_SCORE_BIAS, INACTIVITY_SCORE_RECOVERY_RATE} = config;
   const {statuses} = epochProcess;
-  const inActivityLeak = isInInactivityLeak((state as unknown) as phase0.BeaconState);
+  const inActivityLeak = isInInactivityLeak(state as CachedBeaconState<allForks.BeaconState>);
 
   // this avoids importing FLAG_ELIGIBLE_ATTESTER inside the for loop, check the compiled code
   const {FLAG_ELIGIBLE_ATTESTER, FLAG_PREV_TARGET_ATTESTER_OR_UNSLASHED, hasMarkers} = attesterStatusUtil;

--- a/packages/beacon-state-transition/src/altair/epoch/processRewardsAndPenalties.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processRewardsAndPenalties.ts
@@ -1,5 +1,4 @@
 import {altair} from "@chainsafe/lodestar-types";
-import {getCurrentEpoch} from "../../util";
 import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
 import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
 import {getRewardsPenaltiesDeltas} from "./balance";
@@ -14,7 +13,7 @@ export function processRewardsAndPenalties(
   state: CachedBeaconState<altair.BeaconState>,
   epochProcess: IEpochProcess
 ): void {
-  if (getCurrentEpoch(state) == GENESIS_EPOCH) {
+  if (state.currentShuffling.epoch == GENESIS_EPOCH) {
     return;
   }
 

--- a/packages/beacon-state-transition/src/altair/upgradeState.ts
+++ b/packages/beacon-state-transition/src/altair/upgradeState.ts
@@ -1,6 +1,6 @@
 import {altair, ParticipationFlags, phase0, ssz, Uint8} from "@chainsafe/lodestar-types";
 import {CachedBeaconState, createCachedBeaconState} from "../allForks/util";
-import {getCurrentEpoch, newZeroedArray} from "../util";
+import {newZeroedArray} from "../util";
 import {List, TreeBacked} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IParticipationStatus} from "../allForks/util/cachedEpochParticipation";
@@ -26,7 +26,7 @@ function upgradeTreeBackedState(
   const nextEpochActiveIndices = state.nextShuffling.activeIndices;
   const stateTB = ssz.phase0.BeaconState.createTreeBacked(state.tree);
   const validatorCount = stateTB.validators.length;
-  const epoch = getCurrentEpoch(stateTB);
+  const epoch = state.currentShuffling.epoch;
   // TODO: Does this preserve the hashing cache? In altair devnets memory spikes on the fork transition
   const postState = ssz.altair.BeaconState.createTreeBacked(stateTB.tree);
   postState.fork = {

--- a/packages/beacon-state-transition/src/merge/block/processExecutionPayload.ts
+++ b/packages/beacon-state-transition/src/merge/block/processExecutionPayload.ts
@@ -2,7 +2,7 @@ import {GAS_LIMIT_DENOMINATOR, MIN_GAS_LIMIT} from "@chainsafe/lodestar-params";
 import {merge, ssz} from "@chainsafe/lodestar-types";
 import {byteArrayEquals, List} from "@chainsafe/ssz";
 import {CachedBeaconState} from "../../allForks";
-import {getCurrentEpoch, getRandaoMix} from "../../util";
+import {getRandaoMix} from "../../util";
 import {ExecutionEngine} from "../executionEngine";
 import {isMergeComplete} from "../utils";
 
@@ -51,7 +51,7 @@ export function processExecutionPayload(
   }
 
   // Verify random
-  if (!byteArrayEquals(payload.random as Uint8Array, getRandaoMix(state, getCurrentEpoch(state)) as Uint8Array)) {
+  if (!byteArrayEquals(payload.random as Uint8Array, getRandaoMix(state, state.currentShuffling.epoch) as Uint8Array)) {
     throw Error("Inconsistent execution payload random");
   }
 

--- a/packages/beacon-state-transition/src/merge/upgradeState.ts
+++ b/packages/beacon-state-transition/src/merge/upgradeState.ts
@@ -1,6 +1,5 @@
 import {altair, merge, ssz} from "@chainsafe/lodestar-types";
 import {CachedBeaconState, createCachedBeaconState} from "../allForks/util";
-import {getCurrentEpoch} from "../util";
 import {TreeBacked} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
@@ -25,7 +24,7 @@ function upgradeTreeBackedState(
   postState.fork = {
     previousVersion: stateTB.fork.currentVersion,
     currentVersion: config.MERGE_FORK_VERSION,
-    epoch: getCurrentEpoch(stateTB),
+    epoch: state.currentShuffling.epoch,
   };
   // Execution-layer
   postState.latestExecutionPayloadHeader = ssz.merge.ExecutionPayloadHeader.defaultTreeBacked();

--- a/packages/beacon-state-transition/src/util/finality.ts
+++ b/packages/beacon-state-transition/src/util/finality.ts
@@ -1,9 +1,9 @@
 import {MIN_EPOCHS_TO_INACTIVITY_PENALTY} from "@chainsafe/lodestar-params";
 import {allForks} from "@chainsafe/lodestar-types";
-import {getPreviousEpoch} from "./epoch";
+import {CachedBeaconState} from "../allForks/util";
 
-export function getFinalityDelay(state: allForks.BeaconState): number {
-  return getPreviousEpoch(state) - state.finalizedCheckpoint.epoch;
+export function getFinalityDelay(state: CachedBeaconState<allForks.BeaconState>): number {
+  return state.previousShuffling.epoch - state.finalizedCheckpoint.epoch;
 }
 
 /**
@@ -12,6 +12,6 @@ export function getFinalityDelay(state: allForks.BeaconState): number {
  * until blocks get finalized again. See here (https://github.com/ethereum/annotated-spec/blob/master/phase0/beacon-chain.md#inactivity-quotient) for what the inactivity leak is, what it's for and how
  * it works.
  */
-export function isInInactivityLeak(state: allForks.BeaconState): boolean {
+export function isInInactivityLeak(state: CachedBeaconState<allForks.BeaconState>): boolean {
   return getFinalityDelay(state) > MIN_EPOCHS_TO_INACTIVITY_PENALTY;
 }


### PR DESCRIPTION
**Motivation**

`getCurrentEpoch and getPreviousEpoch` requires a computation, we should be able to get it directly from `CachedBeaconState` shuffling cache.

**Description**

Avoid using `getCurrentEpoch` and `getPreviousEpoch` whenever possible
