### PR TITLE
updating bls to more secure version, all signatures loaded will be checked for being a valid g2 group point

### DIFF
--- a/packages/beacon-state-transition/package.json
+++ b/packages/beacon-state-transition/package.json
@@ -35,7 +35,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/bls": "6.0.1",
+    "@chainsafe/bls": "6.0.3",
     "@chainsafe/lodestar-config": "^0.31.0",
     "@chainsafe/lodestar-params": "^0.31.0",
     "@chainsafe/lodestar-types": "^0.31.0",

--- a/packages/beacon-state-transition/src/util/signatureSets.ts
+++ b/packages/beacon-state-transition/src/util/signatureSets.ts
@@ -22,7 +22,7 @@ export type ISignatureSet =
 
 export function verifySignatureSet(signatureSet: ISignatureSet): boolean {
   // All signatures are not trusted and must be group checked (p2.subgroup_check)
-  const signature = bls.Signature.fromBytes(signatureSet.signature);
+  const signature = bls.Signature.fromBytes(signatureSet.signature, undefined, true);
 
   switch (signatureSet.type) {
     case SignatureSetType.single:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "@chainsafe/abort-controller": "^3.0.1",
-    "@chainsafe/bls": "6.0.1",
+    "@chainsafe/bls": "6.0.3",
     "@chainsafe/bls-keygen": "^0.3.0",
     "@chainsafe/bls-keystore": "2.0.0",
     "@chainsafe/blst": "^0.2.2",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@chainsafe/abort-controller": "^3.0.1",
-    "@chainsafe/bls": "6.0.1",
+    "@chainsafe/bls": "6.0.3",
     "@chainsafe/lodestar-api": "^0.31.0",
     "@chainsafe/lodestar-beacon-state-transition": "^0.31.0",
     "@chainsafe/lodestar-config": "^0.31.0",

--- a/packages/light-client/src/client/validation.ts
+++ b/packages/light-client/src/client/validation.ts
@@ -134,7 +134,7 @@ function isValidBlsAggregate(publicKeys: PublicKey[], message: Uint8Array, signa
 
   let sig: Signature;
   try {
-    sig = Signature.fromBytes(signature);
+    sig = Signature.fromBytes(signature, undefined, true);
   } catch (e) {
     (e as Error).message = `Error deserializing signature: ${(e as Error).message}`;
     throw e;

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@chainsafe/abort-controller": "^3.0.1",
-    "@chainsafe/bls": "6.0.1",
+    "@chainsafe/bls": "6.0.3",
     "@chainsafe/discv5": "^0.6.4",
     "@chainsafe/libp2p-noise": "4.1.1",
     "@chainsafe/lodestar-api": "^0.31.0",

--- a/packages/lodestar/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/lodestar/src/chain/opPools/aggregatedAttestationPool.ts
@@ -334,8 +334,16 @@ export function aggregateInto(
     attestation1.attestingIndices.has(committee[i])
   ) as List<boolean>;
 
-  const signature1 = bls.Signature.fromBytes(attestation1.attestation.signature.valueOf() as Uint8Array);
-  const signature2 = bls.Signature.fromBytes(attestation2.attestation.signature.valueOf() as Uint8Array);
+  const signature1 = bls.Signature.fromBytes(
+    attestation1.attestation.signature.valueOf() as Uint8Array,
+    undefined,
+    true
+  );
+  const signature2 = bls.Signature.fromBytes(
+    attestation2.attestation.signature.valueOf() as Uint8Array,
+    undefined,
+    true
+  );
   attestation1.attestation.signature = bls.Signature.aggregate([signature1, signature2]).toBytes();
 }
 

--- a/packages/lodestar/src/chain/opPools/attestationPool.ts
+++ b/packages/lodestar/src/chain/opPools/attestationPool.ts
@@ -173,7 +173,7 @@ function aggregateAttestationInto(aggregate: AggregateFast, attestation: phase0.
 
   aggregate.signature = Signature.aggregate([
     aggregate.signature,
-    bls.Signature.fromBytes(attestation.signature.valueOf() as Uint8Array),
+    bls.Signature.fromBytes(attestation.signature.valueOf() as Uint8Array, undefined, true),
   ]);
   return InsertOutcome.Aggregated;
 }
@@ -185,7 +185,7 @@ function attestationToAggregate(attestation: phase0.Attestation): AggregateFast 
   return {
     data: attestation.data,
     aggregationBits: Array.from(readonlyValues(attestation.aggregationBits)),
-    signature: bls.Signature.fromBytes(attestation.signature.valueOf() as Uint8Array),
+    signature: bls.Signature.fromBytes(attestation.signature.valueOf() as Uint8Array, undefined, true),
   };
 }
 

--- a/packages/lodestar/src/chain/opPools/syncCommitteeMessagePool.ts
+++ b/packages/lodestar/src/chain/opPools/syncCommitteeMessagePool.ts
@@ -119,7 +119,7 @@ function aggregateSignatureInto(
 
   contribution.signature = Signature.aggregate([
     contribution.signature,
-    bls.Signature.fromBytes(signature.signature.valueOf() as Uint8Array),
+    bls.Signature.fromBytes(signature.signature.valueOf() as Uint8Array, undefined, true),
   ]);
   return InsertOutcome.Aggregated;
 }
@@ -141,6 +141,6 @@ function signatureToAggregate(
     beaconBlockRoot: signature.beaconBlockRoot,
     subCommitteeIndex: subnet,
     aggregationBits,
-    signature: bls.Signature.fromBytes(signature.signature.valueOf() as Uint8Array),
+    signature: bls.Signature.fromBytes(signature.signature.valueOf() as Uint8Array, undefined, true),
   };
 }

--- a/packages/lodestar/src/chain/opPools/syncContributionAndProofPool.ts
+++ b/packages/lodestar/src/chain/opPools/syncContributionAndProofPool.ts
@@ -128,7 +128,11 @@ export function replaceIfBetter(
 
   bestContribution.syncSubCommitteeBits = newSyncSubCommitteeBits;
   bestContribution.numParticipants = newNumParticipants;
-  bestContribution.syncSubCommitteeSignature = bls.Signature.fromBytes(contribution.signature.valueOf() as Uint8Array);
+  bestContribution.syncSubCommitteeSignature = bls.Signature.fromBytes(
+    contribution.signature.valueOf() as Uint8Array,
+    undefined,
+    true
+  );
   return InsertOutcome.NewData;
 }
 
@@ -149,7 +153,7 @@ export function contributionToFast(contribution: altair.SyncCommitteeContributio
   return {
     syncSubCommitteeBits,
     numParticipants,
-    syncSubCommitteeSignature: bls.Signature.fromBytes(contribution.signature.valueOf() as Uint8Array),
+    syncSubCommitteeSignature: bls.Signature.fromBytes(contribution.signature.valueOf() as Uint8Array, undefined, true),
   };
 }
 

--- a/packages/lodestar/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/lodestar/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -121,7 +121,11 @@ describe("MatchingDataAttestationGroup", function () {
     const attestations = attestationGroup.getAttestations();
     expect(attestations.length).to.be.equal(1, "expect exactly 1 aggregated attestation");
     expect(attestations[0].aggregationBits).to.be.deep.equal([true, true, true], "incorrect aggregationBits");
-    const aggregatedSignature = bls.Signature.fromBytes(attestations[0].signature.valueOf() as Uint8Array);
+    const aggregatedSignature = bls.Signature.fromBytes(
+      attestations[0].signature.valueOf() as Uint8Array,
+      undefined,
+      true
+    );
     expect(
       aggregatedSignature.verifyAggregate([sk1.toPublicKey(), sk2.toPublicKey()], attestationDataRoot)
     ).to.be.equal(true, "invalid aggregated signature");
@@ -200,7 +204,11 @@ describe("aggregateInto", function () {
     aggregateInto(attWithIndex1, attWithIndex2, committee);
     expect(attWithIndex1.attestingIndices).to.be.deep.equal(new Set([100, 200]), "invalid aggregated attestingIndices");
     expect(attWithIndex1.attestation.aggregationBits).to.be.deep.equal([true, true], "invalid aggregationBits");
-    const aggregatedSignature = bls.Signature.fromBytes(attWithIndex1.attestation.signature.valueOf() as Uint8Array);
+    const aggregatedSignature = bls.Signature.fromBytes(
+      attWithIndex1.attestation.signature.valueOf() as Uint8Array,
+      undefined,
+      true
+    );
     expect(
       aggregatedSignature.verifyAggregate([sk1.toPublicKey(), sk2.toPublicKey()], attestationDataRoot)
     ).to.be.equal(true, "invalid aggregated signature");

--- a/packages/spec-test-runner/package.json
+++ b/packages/spec-test-runner/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@chainsafe/bit-utils": "0.1.6",
-    "@chainsafe/bls": "6.0.1",
+    "@chainsafe/bls": "6.0.3",
     "@chainsafe/lodestar": "^0.31.0",
     "@chainsafe/lodestar-beacon-state-transition": "^0.31.0",
     "@chainsafe/lodestar-config": "^0.31.0",

--- a/packages/spec-test-runner/test/spec/bls/fast_aggregate_verify.test.ts
+++ b/packages/spec-test-runner/test/spec/bls/fast_aggregate_verify.test.ts
@@ -22,7 +22,7 @@ describeDirectorySpecTest<IAggregateSigsVerifyTestCase, boolean>(
   (testCase) => {
     const {pubkeys, message, signature} = testCase.data.input;
     try {
-      return bls.Signature.fromBytes(fromHexString(signature)).verifyAggregate(
+      return bls.Signature.fromBytes(fromHexString(signature), undefined, true).verifyAggregate(
         pubkeys.map((hex) => bls.PublicKey.fromBytes(fromHexString(hex), CoordType.jacobian, true)),
         fromHexString(message)
       );

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "@chainsafe/abort-controller": "^3.0.1",
-    "@chainsafe/bls": "6.0.1",
+    "@chainsafe/bls": "6.0.3",
     "@chainsafe/lodestar-api": "^0.31.0",
     "@chainsafe/lodestar-beacon-state-transition": "^0.31.0",
     "@chainsafe/lodestar-config": "^0.31.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -430,13 +430,13 @@
     ethereum-cryptography "^0.1.3"
     uuid "^3.3.3"
 
-"@chainsafe/bls@6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/bls/-/bls-6.0.1.tgz#3771182db88e28a6d305c0f4285668d36b5d5da3"
-  integrity sha512-bOyQsjv4H79S7CL4cNX71wY+8lSPcRqou0yNTteMoTCpIOFScFyWqiuUfoBcigHlADbNzoE9SA9pyn02zOSQNw==
+"@chainsafe/bls@6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@chainsafe/bls/-/bls-6.0.3.tgz#fc9154c3192648cec8a117ae0af4dd76ed51bdcb"
+  integrity sha512-+rG9Lpl5intmHQ0aMpVu/O1Tc3OQCgQbvnPiiScMCzdHWie223vjnFhWl8U77mlqJsoh11gME6vfD42TJJMFBA==
   dependencies:
     "@chainsafe/bls-keygen" "^0.3.0"
-    bls-eth-wasm "^0.4.4"
+    bls-eth-wasm "^0.4.8"
     randombytes "^2.1.0"
 
 "@chainsafe/blst@^0.2.2":
@@ -3289,7 +3289,7 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
   integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
 
-bls-eth-wasm@^0.4.4:
+bls-eth-wasm@^0.4.8:
   version "0.4.8"
   resolved "https://registry.yarnpkg.com/bls-eth-wasm/-/bls-eth-wasm-0.4.8.tgz#ad1818fbd1bfb64d8f3e6cd104bd28b96ebaa5f1"
   integrity sha512-ye7+G6KFLb3i9xSrLASAoYqOUK5WLB6XA5DD8Sh0UQpZ3T999ylsYbFdoOJpmvTDuBuMi23Vy8Jm0pn/GF01CA==


### PR DESCRIPTION
…

This PR updates the `@chainsafe/bls` package in `lodestar`, and also explicitly passes validation checks for code readability and easy audit.

**Motivation**
As recommended by @asanso /EF, signatures should be validated for G2 group membership. The `@chainsafe/bls` package was updated to `6.0.3` for the same where signature validation is now done by default.

<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number
#2645
**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
