### PR TITLE
Add unit test for formating in ExecutionEngineHttp

### DIFF
--- a/packages/lodestar/src/eth1/provider/utils.ts
+++ b/packages/lodestar/src/eth1/provider/utils.ts
@@ -1,3 +1,4 @@
+import {ByteVector, fromHexString, toHexString} from "@chainsafe/ssz";
 import {ErrorParseJson} from "./jsonRpcHttpClient";
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -35,4 +36,29 @@ export function hexToBigint(hex: string, id = ""): bigint {
 
 export function validateHexRoot(hex: string, id = ""): void {
   if (!rootHexRegex.test(hex)) throw Error(`Invalid hex root ${id} '${hex}'`);
+}
+
+export function hexToBytes(hex: string): Uint8Array {
+  // Handle special case in Ethereum hex formating where hex values may include a single letter
+  // 0x0, 0x1 are valid values
+  if (hex.length === 3 && hex.startsWith("0x")) {
+    hex = "0x0" + hex[2];
+  }
+
+  try {
+    return fromHexString(hex);
+  } catch (e) {
+    (e as Error).message = `Invalid hex string: ${(e as Error).message}`;
+    throw e;
+  }
+}
+
+export function bytesToHex(bytes: Uint8Array | ByteVector): string {
+  // Handle special case in Ethereum hex formating where hex values may include a single letter
+  // 0x0, 0x1 are valid values
+  if (bytes.length === 1 && bytes[0] <= 0xf) {
+    return "0x" + bytes[0].toString(16);
+  }
+
+  return toHexString(bytes);
 }

--- a/packages/lodestar/test/unit/executionEngine/http.test.ts
+++ b/packages/lodestar/test/unit/executionEngine/http.test.ts
@@ -1,0 +1,224 @@
+import chai, {expect} from "chai";
+import chaiAsPromised from "chai-as-promised";
+import {fastify} from "fastify";
+import {AbortController} from "@chainsafe/abort-controller";
+import {fromHexString} from "@chainsafe/ssz";
+import {ExecutionEngineHttp, parseExecutionPayload, serializeExecutionPayload} from "../../../src/executionEngine/http";
+import {hexToNumber} from "../../../src/eth1/provider/utils";
+
+chai.use(chaiAsPromised);
+
+describe("ExecutionEngine / http", () => {
+  const afterCallbacks: (() => Promise<void> | void)[] = [];
+  after(async () => {
+    while (afterCallbacks.length > 0) {
+      const callback = afterCallbacks.pop();
+      if (callback) await callback();
+    }
+  });
+
+  let executionEngine: ExecutionEngineHttp;
+  let returnValue: unknown = {};
+  let reqJsonRpcPayload: unknown = {};
+
+  before("Prepare server", async () => {
+    const controller = new AbortController();
+    const server = fastify({logger: false});
+
+    server.post("/", async (req) => {
+      reqJsonRpcPayload = req.body;
+      delete (reqJsonRpcPayload as {id?: number}).id;
+      return returnValue;
+    });
+
+    afterCallbacks.push(async () => {
+      controller.abort();
+      await server.close();
+    });
+
+    const baseUrl = await server.listen(0);
+
+    executionEngine = new ExecutionEngineHttp({urls: [baseUrl]}, controller.signal);
+  });
+
+  it("preparePayload", async () => {
+    /**
+     * curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"engine_preparePayload","params":[{
+     * "parentHash":"0xa0513a503d5bd6e89a144c3268e5b7e9da9dbf63df125a360e3950a7d0d67131",
+     * "timestamp":"0x5",
+     * "random":"0x0000000000000000000000000000000000000000000000000000000000000000",
+     * "feeRecipient":"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+     * }],"id":67}' http://localhost:8545
+     *
+     * {"jsonrpc":"2.0","id":67,"result":{"payloadId":"0x0"}}
+     */
+
+    const request = {
+      jsonrpc: "2.0",
+      method: "engine_preparePayload",
+      params: [
+        {
+          parentHash: "0xa0513a503d5bd6e89a144c3268e5b7e9da9dbf63df125a360e3950a7d0d67131",
+          timestamp: "0x5",
+          random: "0x0000000000000000000000000000000000000000000000000000000000000000",
+          feeRecipient: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+        },
+      ],
+    };
+    returnValue = {jsonrpc: "2.0", id: 67, result: {payloadId: "0x0"}};
+
+    const param0 = request.params[0];
+    const payloadId = await executionEngine.preparePayload(
+      fromHexString(param0.parentHash),
+      hexToNumber(param0.timestamp),
+      fromHexString(param0.random),
+      fromHexString(param0.feeRecipient)
+    );
+
+    expect(payloadId).to.equal(0, "Wrong returned payloadId");
+    expect(reqJsonRpcPayload).to.deep.equal(request, "Wrong request JSON RPC payload");
+  });
+
+  it("getPayload", async () => {
+    /**
+     * curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"engine_getPayload","params":["0x0"],"id":67}' http://localhost:8545
+     */
+
+    const request = {jsonrpc: "2.0", method: "engine_getPayload", params: ["0x0"]};
+    const response = {
+      jsonrpc: "2.0",
+      id: 67,
+      result: {
+        blockHash: "0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174",
+        parentHash: "0xa0513a503d5bd6e89a144c3268e5b7e9da9dbf63df125a360e3950a7d0d67131",
+        coinbase: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+        stateRoot: "0xca3149fa9e37db08d1cd49c9061db1002ef1cd58db2210f2115c8c989b2bdf45",
+        receiptRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+        logsBloom:
+          "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        random: "0x0000000000000000000000000000000000000000000000000000000000000000",
+        blockNumber: "0x1",
+        gasLimit: "0x989680",
+        gasUsed: "0x0",
+        timestamp: "0x5",
+        extraData: "0x",
+        baseFeePerGas: "0x7",
+        transactions: [],
+      },
+    };
+    returnValue = response;
+
+    const payload = await executionEngine.getPayload(0);
+
+    expect(serializeExecutionPayload(payload)).to.deep.equal(response.result, "Wrong returned payload");
+    expect(reqJsonRpcPayload).to.deep.equal(request, "Wrong request JSON RPC payload");
+  });
+
+  it("executePayload", async () => {
+    /**
+     * curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"engine_executePayload","params":[{"blockHash":"0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174","parentHash":"0xa0513a503d5bd6e89a144c3268e5b7e9da9dbf63df125a360e3950a7d0d67131","coinbase":"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b","stateRoot":"0xca3149fa9e37db08d1cd49c9061db1002ef1cd58db2210f2115c8c989b2bdf45","receiptRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","random":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x1","gasLimit":"0x989680","gasUsed":"0x0","timestamp":"0x5","extraData":"0x","baseFeePerGas":"0x7","transactions":[]}],"id":67}' http://localhost:8545
+     */
+
+    const request = {
+      jsonrpc: "2.0",
+      method: "engine_executePayload",
+      params: [
+        {
+          blockHash: "0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174",
+          parentHash: "0xa0513a503d5bd6e89a144c3268e5b7e9da9dbf63df125a360e3950a7d0d67131",
+          coinbase: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+          stateRoot: "0xca3149fa9e37db08d1cd49c9061db1002ef1cd58db2210f2115c8c989b2bdf45",
+          receiptRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+          logsBloom:
+            "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          random: "0x0000000000000000000000000000000000000000000000000000000000000000",
+          blockNumber: "0x1",
+          gasLimit: "0x989680",
+          gasUsed: "0x0",
+          timestamp: "0x5",
+          extraData: "0x",
+          baseFeePerGas: "0x7",
+          transactions: [],
+        },
+      ],
+    };
+    returnValue = {jsonrpc: "2.0", id: 67, result: {status: "VALID"}};
+
+    const isValid = await executionEngine.executePayload(parseExecutionPayload(request.params[0]));
+
+    expect(isValid).to.equal(true, "Wrong returned execute payload result");
+    expect(reqJsonRpcPayload).to.deep.equal(request, "Wrong request JSON RPC payload");
+  });
+
+  it("notifyConsensusValidated", async () => {
+    /**
+     * curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"engine_consensusValidated","params":[{"blockHash":"0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174", "status":"VALID"}],"id":67}' http://localhost:8545
+     */
+
+    const request = {
+      jsonrpc: "2.0",
+      method: "engine_consensusValidated",
+      params: [{blockHash: "0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174", status: "VALID"}],
+    };
+    returnValue = {jsonrpc: "2.0", id: 67, result: null};
+
+    await executionEngine.notifyConsensusValidated(fromHexString(request.params[0].blockHash), true);
+
+    expect(reqJsonRpcPayload).to.deep.equal(request, "Wrong request JSON RPC payload");
+  });
+
+  it("notifyForkchoiceUpdate", async () => {
+    /**
+     *  curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"engine_forkchoiceUpdated","params":[{"headBlockHash":"0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174", "finalizedBlockHash":"0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174"}],"id":67}' http://localhost:8545
+     */
+
+    const request = {
+      jsonrpc: "2.0",
+      method: "engine_forkchoiceUpdated",
+      params: [
+        {
+          headBlockHash: "0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174",
+          finalizedBlockHash: "0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174",
+        },
+      ],
+    };
+    returnValue = {jsonrpc: "2.0", id: 67, result: null};
+
+    await executionEngine.notifyForkchoiceUpdate(request.params[0].headBlockHash, request.params[0].finalizedBlockHash);
+
+    expect(reqJsonRpcPayload).to.deep.equal(request, "Wrong request JSON RPC payload");
+  });
+
+  it("error - unknown payload", async () => {
+    /**
+     * curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"engine_getPayload","params":["0x123"],"id":67}' http://localhost:8545
+     */
+
+    const request = {jsonrpc: "2.0", method: "engine_getPayload", params: ["0x123"]};
+    const response = {jsonrpc: "2.0", id: 67, error: {code: 5, message: "unknown payload"}};
+    returnValue = response;
+
+    await expect(executionEngine.getPayload(hexToNumber(request.params[0]))).to.be.rejectedWith(
+      "JSON RPC error: unknown payload, engine_getPayload"
+    );
+  });
+
+  it("error - unknown header", async () => {
+    /**
+     * curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"engine_consensusValidated","params":[{"blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000", "status":"VALID"}],"id":67}' http://localhost:8545
+     */
+
+    const request = {
+      jsonrpc: "2.0",
+      method: "engine_consensusValidated",
+      params: [{blockHash: "0x0000000000000000000000000000000000000000000000000000000000000000", status: "VALID"}],
+      id: 67,
+    };
+    const response = {jsonrpc: "2.0", id: 67, error: {code: 4, message: "unknown header"}};
+    returnValue = response;
+
+    await expect(
+      executionEngine.notifyConsensusValidated(fromHexString(request.params[0].blockHash), true)
+    ).to.be.rejectedWith("JSON RPC error: unknown header, engine_consensusValidated");
+  });
+});


### PR DESCRIPTION
**Motivation**

Part of https://github.com/ChainSafe/lodestar/issues/3275

**Description**

Use test vectors from https://notes.ethereum.org/@9AeMAlpyQYaAAyuj47BzRw/rkwW3ceVY# to unit test the formating of ExecutionEngineHttp 

- Fix parsing of single letter hex strings from eth1 nodes: `0x0`, `0x5` see https://eth.wiki/json-rpc/API#hex-value-encoding