### PR TITLE
Test UnionType

### DIFF
--- a/packages/types/test/unit/union.test.ts
+++ b/packages/types/test/unit/union.test.ts
@@ -1,0 +1,15 @@
+import {ssz} from "../../src";
+
+describe("union", () => {
+  it("struct hashTreeRoot", () => {
+    const defaultValue = ssz.merge.ExecutionPayload.defaultValue();
+    defaultValue.transactions.push(Buffer.alloc(512, 0));
+    ssz.merge.ExecutionPayload.hashTreeRoot(defaultValue);
+  });
+
+  it("tree hashTreeRoot", () => {
+    const defaultTreeBacked = ssz.merge.ExecutionPayload.defaultTreeBacked();
+    defaultTreeBacked.transactions.push(Buffer.alloc(512, 0));
+    ssz.merge.ExecutionPayload.hashTreeRoot(defaultTreeBacked);
+  });
+});


### PR DESCRIPTION
**Motivation**

Part of #3275, UnionType breaks when transactions are non-empty

**Description**

PR to show errors with UnionType