### PR TITLE
SSZ static spec tests for merge

### DIFF
--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -16,7 +16,7 @@ import {ProtoArray} from "../protoArray/protoArray";
 
 import {IForkChoiceMetrics} from "../metrics";
 import {ForkChoiceError, ForkChoiceErrorCode, InvalidBlockCode, InvalidAttestationCode} from "./errors";
-import {IForkChoice, ILatestMessage, IQueuedAttestation, OnBlockPrecachedData, PowBlock} from "./interface";
+import {IForkChoice, ILatestMessage, IQueuedAttestation, OnBlockPrecachedData, PowBlockHex} from "./interface";
 import {IForkChoiceStore, CheckpointWithHex, toCheckpointWithHex, equalCheckpointWithHex} from "./store";
 
 /* eslint-disable max-len */
@@ -910,7 +910,7 @@ export class ForkChoice implements IForkChoice {
   }
 }
 
-function isValidTerminalPowBlock(config: IChainConfig, block: PowBlock, parent: PowBlock): boolean {
+function isValidTerminalPowBlock(config: IChainConfig, block: PowBlockHex, parent: PowBlockHex): boolean {
   const isTotalDifficultyReached = block.totalDifficulty >= config.TERMINAL_TOTAL_DIFFICULTY;
   const isParentTotalDifficultyValid = parent.totalDifficulty < config.TERMINAL_TOTAL_DIFFICULTY;
   return isTotalDifficultyReached && isParentTotalDifficultyValid;

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -134,7 +134,8 @@ export interface IForkChoice {
   getCommonAncestorDistance(prevBlock: IProtoBlock, newBlock: IProtoBlock): number | null;
 }
 
-export type PowBlock = {
+/** Same to the PowBlock but we want RootHex to work with forkchoice conveniently */
+export type PowBlockHex = {
   blockhash: RootHex;
   parentHash: RootHex;
   totalDifficulty: bigint;
@@ -149,14 +150,14 @@ export type OnBlockPrecachedData = {
    * powBlock = getPowBlock((block as merge.BeaconBlock).body.executionPayload.parentHash)
    * ```
    */
-  powBlock?: PowBlock;
+  powBlock?: PowBlockHex;
   /**
    * POW chain block's block parent, from getPowBlock() `eth_getBlockByHash` JSON RPC endpoint
    * ```ts
    * const powParent = getPowBlock(powBlock.parentHash);
    * ```
    */
-  powBlockParent?: PowBlock;
+  powBlockParent?: PowBlockHex;
 };
 
 export interface ILatestMessage {

--- a/packages/fork-choice/src/index.ts
+++ b/packages/fork-choice/src/index.ts
@@ -2,7 +2,13 @@ export {ProtoArray} from "./protoArray/protoArray";
 export {IProtoBlock, IProtoNode} from "./protoArray/interface";
 
 export {ForkChoice} from "./forkChoice/forkChoice";
-export {IForkChoice, OnBlockPrecachedData, PowBlock, ILatestMessage, IQueuedAttestation} from "./forkChoice/interface";
+export {
+  IForkChoice,
+  OnBlockPrecachedData,
+  PowBlockHex,
+  ILatestMessage,
+  IQueuedAttestation,
+} from "./forkChoice/interface";
 export {ForkChoiceStore, IForkChoiceStore, CheckpointWithHex} from "./forkChoice/store";
 export {InvalidAttestation, InvalidAttestationCode, InvalidBlock, InvalidBlockCode} from "./forkChoice/errors";
 

--- a/packages/spec-test-runner/test/spec/allForks/ssz_static.ts
+++ b/packages/spec-test-runner/test/spec/allForks/ssz_static.ts
@@ -24,7 +24,7 @@ const extraTypes = {
 };
 
 export function sszStatic(fork: ForkName): void {
-  const rootDir = path.join(SPEC_TEST_LOCATION, `tests/${ACTIVE_PRESET}/phase0/ssz_static`);
+  const rootDir = path.join(SPEC_TEST_LOCATION, `tests/${ACTIVE_PRESET}/${fork}/ssz_static`);
   for (const typeName of fs.readdirSync(rootDir)) {
     const type =
       (ssz[fork] as Types)[typeName] ||

--- a/packages/types/src/merge/sszTypes.ts
+++ b/packages/types/src/merge/sszTypes.ts
@@ -23,6 +23,7 @@ import {ssz as phase0Ssz, ts as phase0} from "../phase0";
 import {ssz as altairSsz} from "../altair";
 import * as merge from "./types";
 import {LazyVariable} from "../utils/lazyVar";
+import {Uint256} from "../primitive/sszTypes";
 
 const {Bytes20, Bytes32, Number64, Slot, ValidatorIndex, Root, BLSSignature, Uint8} = primitiveSsz;
 
@@ -136,6 +137,15 @@ export const SignedBeaconBlock = new ContainerType<merge.SignedBeaconBlock>({
   fields: {
     message: BeaconBlock,
     signature: BLSSignature,
+  },
+});
+
+export const PowBlock = new ContainerType<merge.BeaconState>({
+  fields: {
+    blockHash: Root,
+    parentHash: Root,
+    totalDifficulty: Uint256,
+    difficulty: Uint256,
   },
 });
 

--- a/packages/types/src/merge/types.ts
+++ b/packages/types/src/merge/types.ts
@@ -46,3 +46,10 @@ export interface SignedBeaconBlock extends altair.SignedBeaconBlock {
 export interface BeaconState extends altair.BeaconState {
   latestExecutionPayloadHeader: ExecutionPayloadHeader;
 }
+
+export type PowBlock = {
+  blockHash: Root;
+  parentHash: Root;
+  totalDifficulty: bigint;
+  difficulty: bigint;
+};


### PR DESCRIPTION
**Motivation**

We miss merge type because we always scan through "phase0" folder

**Description**

+ Remove the "phase0" hard coded value
+ Move `PowBlock` to the common "types" package as the ssz static test needs it

Closes #3282
