### PR TITLE
Model merge Transaction type as Union type

### DIFF
--- a/packages/beacon-state-transition/src/merge/block/processExecutionPayload.ts
+++ b/packages/beacon-state-transition/src/merge/block/processExecutionPayload.ts
@@ -89,6 +89,6 @@ export function processExecutionPayload(
     extraData: payload.extraData,
     baseFeePerGas: payload.baseFeePerGas,
     blockHash: payload.blockHash,
-    transactionsRoot: ssz.merge.Transactions.hashTreeRoot(payload.transactions as List<Uint8Array>),
+    transactionsRoot: ssz.merge.Transactions.hashTreeRoot(payload.transactions as List<merge.Transaction>),
   };
 }

--- a/packages/lodestar/src/chain/validation/block.ts
+++ b/packages/lodestar/src/chain/validation/block.ts
@@ -182,10 +182,10 @@ export async function validateGossipBlock(
   chain.seenBlockProposers.add(blockSlot, proposerIndex);
 }
 
-function getTotalTransactionsSize(transactions: Uint8Array[]): number {
+function getTotalTransactionsSize(transactions: merge.Transaction[]): number {
   let totalSize = 0;
   for (const transaction of transactions) {
-    totalSize += transaction.length;
+    totalSize += transaction.value.length;
   }
   return totalSize;
 }

--- a/packages/lodestar/src/executionEngine/http.ts
+++ b/packages/lodestar/src/executionEngine/http.ts
@@ -249,7 +249,7 @@ export function serializeExecutionPayload(data: merge.ExecutionPayload): Executi
     // TODO: Review big-endian
     baseFeePerGas: bytesToHex(data.baseFeePerGas),
     blockHash: toHexString(data.blockHash),
-    transactions: data.transactions.map(toHexString),
+    transactions: data.transactions.map((tran) => toHexString(tran.value)),
   };
 }
 
@@ -269,6 +269,6 @@ export function parseExecutionPayload(data: ExecutionPayloadRpc): merge.Executio
     // TODO: Review big-endian
     baseFeePerGas: hexToBytes(data.baseFeePerGas),
     blockHash: hexToBytes(data.blockHash),
-    transactions: data.transactions.map(hexToBytes),
+    transactions: data.transactions.map((tran) => ({selector: 0, value: hexToBytes(tran)})),
   };
 }

--- a/packages/types/src/merge/types.ts
+++ b/packages/types/src/merge/types.ts
@@ -3,7 +3,10 @@ import {Root, Bytes32, Number64, ExecutionAddress} from "../primitive/types";
 
 export type OpaqueTransaction = Uint8Array;
 
-export type Transaction = OpaqueTransaction;
+export type Transaction = {
+  selector: number;
+  value: OpaqueTransaction;
+};
 
 type ExecutionPayloadFields = {
   // Execution block header fields


### PR DESCRIPTION
**Motivation**

as stated in https://github.com/ChainSafe/lodestar/pull/3281/files#r720619081 , we want the merge Transaction type to be modeled as 
```typescript
  {
    selector: number;
     value: OpaqueTransaction;
  }
```

**Description**
+ For now, selector is always 0
+ In the future, I think the spec plan to add more transaction type as it stated `Note: The Transaction type is a stub which is not final.`
