### PR TITLE
Run sim single node test with Geth catalyst to finality

### DIFF
--- a/packages/beacon-state-transition/src/util/genesis.ts
+++ b/packages/beacon-state-transition/src/util/genesis.ts
@@ -197,7 +197,8 @@ export function initializeBeaconStateFromEth1(
   config: IChainForkConfig,
   eth1BlockHash: Bytes32,
   eth1Timestamp: Number64,
-  deposits: phase0.Deposit[]
+  deposits: phase0.Deposit[],
+  fullDepositDataRootList?: TreeBacked<List<Root>>
 ): TreeBacked<allForks.BeaconState> {
   const state = getGenesisBeaconState(
     // CachedBeaconcState is used for convinience only, we return TreeBacked<allForks.BeaconState> anyway
@@ -211,7 +212,7 @@ export function initializeBeaconStateFromEth1(
   applyEth1BlockHash(state, eth1BlockHash);
 
   // Process deposits
-  const activeValidatorIndices = applyDeposits(config, state, deposits);
+  const activeValidatorIndices = applyDeposits(config, state, deposits, fullDepositDataRootList);
 
   if (GENESIS_SLOT >= config.ALTAIR_FORK_EPOCH) {
     const syncCommittees = getNextSyncCommittee(state, activeValidatorIndices, state.effectiveBalances);

--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -80,7 +80,7 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
       config,
       db,
       logger,
-      await nodeUtils.initDevState(config, db, validatorCount, genesisTime)
+      await nodeUtils.initDevState(config, db, validatorCount, {genesisTime})
     );
   }
   const beaconConfig = createIBeaconConfig(config, anchorState.genesisValidatorsRoot);

--- a/packages/lodestar/src/eth1/eth1MergeBlockTracker.ts
+++ b/packages/lodestar/src/eth1/eth1MergeBlockTracker.ts
@@ -4,7 +4,7 @@ import {Epoch, RootHex} from "@chainsafe/lodestar-types";
 import {ILogger, isErrorAborted, sleep} from "@chainsafe/lodestar-utils";
 import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {IEth1Provider, EthJsonRpcBlockRaw, PowMergeBlock} from "./interface";
-import {hexToBigint, hexToNumber, validateHexRoot} from "./provider/utils";
+import {quantityToNum, quantityToBigint, dataToRootHex} from "./provider/utils";
 
 export enum StatusCode {
   PRE_MERGE = "PRE_MERGE",
@@ -306,13 +306,10 @@ export class Eth1MergeBlockTracker {
 
 export function toPowBlock(block: EthJsonRpcBlockRaw): PowMergeBlock {
   // Validate untrusted data from API
-  validateHexRoot(block.hash);
-  validateHexRoot(block.parentHash);
-
   return {
-    number: hexToNumber(block.number),
-    blockhash: block.hash,
-    parentHash: block.parentHash,
-    totalDifficulty: hexToBigint(block.totalDifficulty),
+    number: quantityToNum(block.number),
+    blockhash: dataToRootHex(block.hash),
+    parentHash: dataToRootHex(block.parentHash),
+    totalDifficulty: quantityToBigint(block.totalDifficulty),
   };
 }

--- a/packages/lodestar/src/eth1/provider/utils.ts
+++ b/packages/lodestar/src/eth1/provider/utils.ts
@@ -1,4 +1,5 @@
 import {RootHex} from "@chainsafe/lodestar-types";
+import {bytesToBigInt, bigIntToBytes} from "@chainsafe/lodestar-utils";
 import {ByteVector, fromHexString, toHexString} from "@chainsafe/ssz";
 import {ErrorParseJson} from "./jsonRpcHttpClient";
 
@@ -74,42 +75,17 @@ export function quantityToBigint(hex: QUANTITY, id = ""): bigint {
  * For compatibility with SSZ type of baseFeePerGas, always return a 32 ByteVector
  */
 export function quantityToBytes(hex: QUANTITY): Uint8Array {
-  if (typeof hex !== "string") {
-    throw new Error("Expected hex string to be a string");
-  }
-  if (hex.startsWith("0x")) {
-    hex = hex.slice(2);
-  }
-
-  // Force pad to 32 bytes
-  const bytes = new Uint8Array(32);
-
-  // Automatically handles special case in Ethereum hex formating where hex values may include a single letter
-  // 0x0, 0x1 are valid values
-  for (let i = 0; i < 32; i++) {
-    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
-  }
-
-  return bytes;
+  const bn = quantityToBigint(hex);
+  return bigIntToBytes(bn, 32, "le");
 }
 
 /**
  * QUANTITY as defined in ethereum execution layer JSON RPC https://eth.wiki/json-rpc/API.
  * Compress a 32 ByteVector into a QUANTITY
  */
-export function bytesToQuantity(bytes: Uint8Array | ByteVector): QUANTITY {
-  const hexWithPrefix = toHexString(bytes);
-  const hex = hexWithPrefix.slice(2);
-
-  // Find the index with a non-zero character
-  let i = 0;
-  for (; i < hex.length; i++) {
-    if (hex[i] !== "0") {
-      break;
-    }
-  }
-
-  return "0x" + hex.slice(i);
+export function bytesToQuantity(bytes: Uint8Array): QUANTITY {
+  const bn = bytesToBigInt(bytes, "le");
+  return numToQuantity(bn);
 }
 
 /**

--- a/packages/lodestar/src/eth1/provider/utils.ts
+++ b/packages/lodestar/src/eth1/provider/utils.ts
@@ -1,7 +1,13 @@
+import {RootHex} from "@chainsafe/lodestar-types";
 import {ByteVector, fromHexString, toHexString} from "@chainsafe/ssz";
 import {ErrorParseJson} from "./jsonRpcHttpClient";
 
 /* eslint-disable @typescript-eslint/naming-convention */
+
+/** QUANTITY as defined in ethereum execution layer JSON RPC https://eth.wiki/json-rpc/API */
+export type QUANTITY = string;
+/** DATA as defined in ethereum execution layer JSON RPC https://eth.wiki/json-rpc/API */
+export type DATA = string;
 
 export const rootHexRegex = /^0x[a-fA-F0-9]{64}$/;
 
@@ -18,41 +24,6 @@ export function isJsonRpcTruncatedError(error: Error): boolean {
   );
 }
 
-/** Safe parser of hex decimal positive integers */
-export function hexToNumber(hex: string, id = ""): number {
-  const num = parseInt(hex, 16);
-  if (isNaN(num) || num < 0) throw Error(`Invalid hex decimal ${id} '${hex}'`);
-  return num;
-}
-
-/** Typesafe fn to convert hex string to bigint. The BigInt constructor param is any */
-export function hexToBigint(hex: string, id = ""): bigint {
-  try {
-    return BigInt(hex);
-  } catch (e) {
-    throw Error(`Invalid hex bigint ${id} '${hex}': ${(e as Error).message}`);
-  }
-}
-
-export function validateHexRoot(hex: string, id = ""): void {
-  if (!rootHexRegex.test(hex)) throw Error(`Invalid hex root ${id} '${hex}'`);
-}
-
-export function hexToBytes(hex: string): Uint8Array {
-  // Handle special case in Ethereum hex formating where hex values may include a single letter
-  // 0x0, 0x1 are valid values
-  if (hex.length === 3 && hex.startsWith("0x")) {
-    hex = "0x0" + hex[2];
-  }
-
-  try {
-    return fromHexString(hex);
-  } catch (e) {
-    (e as Error).message = `Invalid hex string: ${(e as Error).message}`;
-    throw e;
-  }
-}
-
 export function bytesToHex(bytes: Uint8Array | ByteVector): string {
   // Handle special case in Ethereum hex formating where hex values may include a single letter
   // 0x0, 0x1 are valid values
@@ -61,4 +32,122 @@ export function bytesToHex(bytes: Uint8Array | ByteVector): string {
   }
 
   return toHexString(bytes);
+}
+
+/**
+ * QUANTITY as defined in ethereum execution layer JSON RPC https://eth.wiki/json-rpc/API
+ *
+ * When encoding QUANTITIES (integers, numbers): encode as hex, prefix with “0x”, the most compact representation (slight exception: zero should be represented as “0x0”). Examples:
+ * - 0x41 (65 in decimal)
+ * - 0x400 (1024 in decimal)
+ * - WRONG: 0x (should always have at least one digit - zero is “0x0”)
+ * - WRONG: 0x0400 (no leading zeroes allowed)
+ * - WRONG: ff (must be prefixed 0x)
+ */
+export function numToQuantity(num: number | bigint): QUANTITY {
+  return "0x" + num.toString(16);
+}
+
+/**
+ * QUANTITY as defined in ethereum execution layer JSON RPC https://eth.wiki/json-rpc/API
+ */
+export function quantityToNum(hex: QUANTITY, id = ""): number {
+  const num = parseInt(hex, 16);
+  if (isNaN(num) || num < 0) throw Error(`Invalid hex decimal ${id} '${hex}'`);
+  return num;
+}
+
+/**
+ * QUANTITY as defined in ethereum execution layer JSON RPC https://eth.wiki/json-rpc/API.
+ * Typesafe fn to convert hex string to bigint. The BigInt constructor param is any
+ */
+export function quantityToBigint(hex: QUANTITY, id = ""): bigint {
+  try {
+    return BigInt(hex);
+  } catch (e) {
+    throw Error(`Invalid hex bigint ${id} '${hex}': ${(e as Error).message}`);
+  }
+}
+
+/**
+ * QUANTITY as defined in ethereum execution layer JSON RPC https://eth.wiki/json-rpc/API.
+ * For compatibility with SSZ type of baseFeePerGas, always return a 32 ByteVector
+ */
+export function quantityToBytes(hex: QUANTITY): Uint8Array {
+  if (typeof hex !== "string") {
+    throw new Error("Expected hex string to be a string");
+  }
+  if (hex.startsWith("0x")) {
+    hex = hex.slice(2);
+  }
+
+  // Force pad to 32 bytes
+  const bytes = new Uint8Array(32);
+
+  // Automatically handles special case in Ethereum hex formating where hex values may include a single letter
+  // 0x0, 0x1 are valid values
+  for (let i = 0; i < 32; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+
+  return bytes;
+}
+
+/**
+ * QUANTITY as defined in ethereum execution layer JSON RPC https://eth.wiki/json-rpc/API.
+ * Compress a 32 ByteVector into a QUANTITY
+ */
+export function bytesToQuantity(bytes: Uint8Array | ByteVector): QUANTITY {
+  const hexWithPrefix = toHexString(bytes);
+  const hex = hexWithPrefix.slice(2);
+
+  // Find the index with a non-zero character
+  let i = 0;
+  for (; i < hex.length; i++) {
+    if (hex[i] !== "0") {
+      break;
+    }
+  }
+
+  return "0x" + hex.slice(i);
+}
+
+/**
+ * DATA as defined in ethereum execution layer JSON RPC https://eth.wiki/json-rpc/API
+ *
+ * When encoding UNFORMATTED DATA (byte arrays, account addresses, hashes, bytecode arrays): encode as hex, prefix with
+ * “0x”, two hex digits per byte. Examples:
+ *
+ * - 0x41 (size 1, “A”)
+ * - 0x004200 (size 3, “\0B\0”)
+ * - 0x (size 0, “”)
+ * - WRONG: 0xf0f0f (must be even number of digits)
+ * - WRONG: 004200 (must be prefixed 0x)
+ */
+export function bytesToData(bytes: Uint8Array | ByteVector): DATA {
+  return toHexString(bytes);
+}
+
+/**
+ * DATA as defined in ethereum execution layer JSON RPC https://eth.wiki/json-rpc/API
+ */
+export function dataToBytes(hex: DATA, fixedLength?: number): Uint8Array {
+  try {
+    const bytes = fromHexString(hex);
+    if (fixedLength !== undefined && bytes.length !== fixedLength) {
+      throw Error(`Wrong data length ${bytes.length} expected ${fixedLength}`);
+    }
+    return bytes;
+  } catch (e) {
+    (e as Error).message = `Invalid hex string: ${(e as Error).message}`;
+    throw e;
+  }
+}
+
+/**
+ * DATA as defined in ethereum execution layer JSON RPC https://eth.wiki/json-rpc/API
+ */
+export function dataToRootHex(hex: DATA, id = ""): RootHex {
+  if (!rootHexRegex.test(hex)) throw Error(`Invalid hex root ${id} '${hex}'`);
+  return hex;
 }

--- a/packages/lodestar/src/eth1/provider/utils.ts
+++ b/packages/lodestar/src/eth1/provider/utils.ts
@@ -83,8 +83,8 @@ export function quantityToBytes(hex: QUANTITY): Uint8Array {
  * QUANTITY as defined in ethereum execution layer JSON RPC https://eth.wiki/json-rpc/API.
  * Compress a 32 ByteVector into a QUANTITY
  */
-export function bytesToQuantity(bytes: Uint8Array): QUANTITY {
-  const bn = bytesToBigInt(bytes, "le");
+export function bytesToQuantity(bytes: Uint8Array | ByteVector): QUANTITY {
+  const bn = bytesToBigInt(bytes as Uint8Array, "le");
   return numToQuantity(bn);
 }
 

--- a/packages/lodestar/src/node/utils/interop/state.ts
+++ b/packages/lodestar/src/node/utils/interop/state.ts
@@ -1,18 +1,28 @@
 import {List, TreeBacked} from "@chainsafe/ssz";
-import {allForks, phase0, Root} from "@chainsafe/lodestar-types";
+import {allForks, Bytes32, Number64, phase0, Root} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {initializeBeaconStateFromEth1} from "@chainsafe/lodestar-beacon-state-transition";
 
 export const INTEROP_BLOCK_HASH = Buffer.alloc(32, "B");
 export const INTEROP_TIMESTAMP = Math.pow(2, 40);
 
+export type InteropStateOpts = {
+  genesisTime?: number;
+  eth1BlockHash?: Bytes32;
+  eth1Timestamp?: Number64;
+};
+
 export function getInteropState(
   config: IChainForkConfig,
-  depositDataRootList: TreeBacked<List<Root>>,
-  genesisTime: number,
-  deposits: phase0.Deposit[]
+  {
+    genesisTime = Math.floor(Date.now() / 1000),
+    eth1BlockHash = INTEROP_BLOCK_HASH,
+    eth1Timestamp = INTEROP_TIMESTAMP,
+  }: InteropStateOpts,
+  deposits: phase0.Deposit[],
+  fullDepositDataRootList?: TreeBacked<List<Root>>
 ): TreeBacked<allForks.BeaconState> {
-  const state = initializeBeaconStateFromEth1(config, INTEROP_BLOCK_HASH, INTEROP_TIMESTAMP, deposits);
+  const state = initializeBeaconStateFromEth1(config, eth1BlockHash, eth1Timestamp, deposits, fullDepositDataRootList);
   state.genesisTime = genesisTime;
   return state;
 }

--- a/packages/lodestar/src/node/utils/state.ts
+++ b/packages/lodestar/src/node/utils/state.ts
@@ -1,7 +1,7 @@
 import {IBeaconConfig, IChainForkConfig} from "@chainsafe/lodestar-config";
 import {allForks, phase0, ssz} from "@chainsafe/lodestar-types";
 import {interopDeposits} from "./interop/deposits";
-import {getInteropState} from "./interop/state";
+import {getInteropState, InteropStateOpts} from "./interop/state";
 import {mkdirSync, writeFileSync} from "fs";
 import {dirname} from "path";
 import {IBeaconDb} from "../../db";
@@ -11,15 +11,15 @@ export async function initDevState(
   config: IChainForkConfig,
   db: IBeaconDb,
   validatorCount: number,
-  genesisTime?: number
+  interopStateOpts: InteropStateOpts
 ): Promise<TreeBacked<allForks.BeaconState>> {
   const deposits = interopDeposits(config, ssz.phase0.DepositDataRootList.defaultTreeBacked(), validatorCount);
   await storeDeposits(config, db, deposits);
   const state = getInteropState(
     config,
-    await db.depositDataRoot.getTreeBacked(validatorCount - 1),
-    genesisTime || Math.floor(Date.now() / 1000),
-    deposits
+    interopStateOpts,
+    deposits,
+    await db.depositDataRoot.getTreeBacked(validatorCount - 1)
   );
   return state;
 }

--- a/packages/lodestar/test/e2e/eth1/eth1MergeBlockTracker.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1MergeBlockTracker.test.ts
@@ -7,7 +7,7 @@ import {Eth1MergeBlockTracker, StatusCode} from "../../../src/eth1/eth1MergeBloc
 import {Eth1Options} from "../../../src/eth1/options";
 import {testnet} from "../../utils/testnet";
 import {testLogger} from "../../utils/logger";
-import {hexToBigint} from "../../../src/eth1/provider/utils";
+import {quantityToBigint} from "../../../src/eth1/provider/utils";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -43,7 +43,7 @@ describe("eth1 / Eth1MergeBlockTracker", function () {
     if (!latestBlock) throw Error("No latestBlock");
 
     // Set TTD to current totalDifficulty + 1, so the next block is the merge block
-    const terminalTotalDifficulty = hexToBigint(latestBlock.totalDifficulty) + BigInt(1);
+    const terminalTotalDifficulty = quantityToBigint(latestBlock.totalDifficulty) + BigInt(1);
 
     const eth1MergeBlockTracker = new Eth1MergeBlockTracker(
       {
@@ -80,7 +80,7 @@ describe("eth1 / Eth1MergeBlockTracker", function () {
     if (!latestBlock) throw Error("No latestBlock");
 
     // Set TTD to current totalDifficulty + 1, so the previous block is the merge block
-    const terminalTotalDifficulty = hexToBigint(latestBlock.totalDifficulty) - BigInt(1);
+    const terminalTotalDifficulty = quantityToBigint(latestBlock.totalDifficulty) - BigInt(1);
 
     const eth1MergeBlockTracker = new Eth1MergeBlockTracker(
       {

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import os from "os";
 import {AbortController, AbortSignal} from "@chainsafe/abort-controller";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {LogLevel, sleep, TimestampFormatCode} from "@chainsafe/lodestar-utils";
@@ -29,7 +30,8 @@ import {ZERO_HASH} from "../../src/constants";
 describe("executionEngine / ExecutionEngineHttp", function () {
   this.timeout("10min");
 
-  const dataPath = "~/ethereum/taunus";
+  const homeDir = os.homedir();
+  const dataPath = path.join(homeDir, "ethereum/taunus");
   const genesisPath = path.join(dataPath, "genesis.json");
   const jsonRpcPort = 8545;
   const enginePort = 8545;

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -1,11 +1,24 @@
 import fs from "fs";
 import path from "path";
-import {AbortController} from "@chainsafe/abort-controller";
+import {AbortController, AbortSignal} from "@chainsafe/abort-controller";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {LogLevel, sleep, TimestampFormatCode} from "@chainsafe/lodestar-utils";
+import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
+import {IChainConfig} from "@chainsafe/lodestar-config";
+import {phase0} from "@chainsafe/lodestar-types";
 import {hexToNumber} from "../../src/eth1/provider/utils";
 import {ExecutionEngineHttp, parseExecutionPayload} from "../../src/executionEngine/http";
 import {shell} from "./shell";
-import {sleep} from "@chainsafe/lodestar-utils";
+import {ChainEvent} from "../../src/chain";
+import {testLogger, TestLoggerOpts} from "../utils/logger";
+import {logFilesDir} from "./params";
+import {getDevBeaconNode} from "../utils/node/beacon";
+import {RestApiOptions} from "../../src/api";
+import {simTestInfoTracker} from "../utils/node/simTest";
+import {waitForEvent} from "../utils/events/resolver";
+import {getAndInitDevValidators} from "../utils/node/validator";
+import {Eth1Provider} from "../../src";
+import {ZERO_HASH} from "../../src/constants";
 
 // NOTE: Must specify GETH_BINARY_PATH ENV
 // Example:
@@ -20,7 +33,10 @@ describe("executionEngine / ExecutionEngineHttp", function () {
   const genesisPath = path.join(dataPath, "genesis.json");
   const jsonRpcPort = 8545;
   const enginePort = 8545;
+  const jsonRpcUrl = `http://localhost:${jsonRpcPort}`;
+  const engineApiUrl = `http://localhost:${enginePort}`;
 
+  let gensisBlockHash: string;
   let gethProcError: Error | null = null;
   let controller: AbortController;
 
@@ -34,6 +50,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
       throw Error("GETH_BINARY_PATH ENV must be provided");
     }
 
+    await shell(`rm -rf ${dataPath}`);
     fs.mkdirSync(dataPath, {recursive: true});
     writeGenesisJson(genesisPath);
 
@@ -42,7 +59,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     await shell(`${process.env.GETH_BINARY_PATH} --catalyst --datadir "${dataPath}" init "${genesisPath}"`);
 
     controller = new AbortController();
-    shell(`${process.env.GETH_BINARY_PATH} --catalyst --http --ws -http.api "engine,net" --datadir "${dataPath}"`, {
+    shell(`${process.env.GETH_BINARY_PATH} --catalyst --http --ws -http.api "engine,net,eth" --datadir "${dataPath}"`, {
       timeout: 10 * 60 * 1000,
       signal: controller.signal,
     }).catch((e) => {
@@ -50,17 +67,10 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     });
 
     // Wait for Geth to be online
-    for (let i = 0; i < 60; i++) {
-      try {
-        await shell(
-          `curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"net_version","params":[],"id":67}' http://localhost:${jsonRpcPort}`
-        );
-        return; // Done
-      } catch (e) {
-        await sleep(1000, controller.signal);
-      }
-    }
-    throw Error("Geth not online in 60 seconds");
+    await waitForGethOnline(jsonRpcUrl, controller.signal);
+
+    // Fetch genesis block hash
+    gensisBlockHash = await getGenesisBlockHash(jsonRpcUrl, controller.signal);
   });
 
   after("Stop geth", () => {
@@ -73,18 +83,107 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     if (controller) controller.abort();
   });
 
+  /* eslint-disable no-console, @typescript-eslint/naming-convention */
+
+  it("Run for a few blocks", async () => {
+    const validatorClientCount = 1;
+    const validatorsPerClient = 32;
+    const event = ChainEvent.finalized;
+    const altairForkEpoch = 0;
+    const mergeForkEpoch = 0;
+
+    const testParams: Pick<IChainConfig, "SECONDS_PER_SLOT"> = {
+      SECONDS_PER_SLOT: 2,
+    };
+
+    // Should reach justification in 3 epochs max, and finalization in 4 epochs max
+    const expectedEpochsToFinish = 4;
+    // 1 epoch of margin of error
+    const epochsOfMargin = 1;
+    const timeoutSetupMargin = 5 * 1000; // Give extra 5 seconds of margin
+
+    // delay a bit so regular sync sees it's up to date and sync is completed from the beginning
+    const genesisSlotsDelay = 3;
+
+    const timeout =
+      ((epochsOfMargin + expectedEpochsToFinish) * SLOTS_PER_EPOCH + genesisSlotsDelay) *
+      testParams.SECONDS_PER_SLOT *
+      1000;
+
+    this.timeout(timeout + 2 * timeoutSetupMargin);
+
+    const genesisTime = Math.floor(Date.now() / 1000) + genesisSlotsDelay * testParams.SECONDS_PER_SLOT;
+
+    const testLoggerOpts: TestLoggerOpts = {
+      logLevel: LogLevel.info,
+      logFile: `${logFilesDir}/singlethread_singlenode_altair-${altairForkEpoch}_merge-${mergeForkEpoch}_vc-${validatorClientCount}_vs-${validatorsPerClient}_event-${event}.log`,
+      timestampFormat: {
+        format: TimestampFormatCode.EpochSlot,
+        genesisTime,
+        slotsPerEpoch: SLOTS_PER_EPOCH,
+        secondsPerSlot: testParams.SECONDS_PER_SLOT,
+      },
+    };
+    const loggerNodeA = testLogger("Node-A", testLoggerOpts);
+
+    const bn = await getDevBeaconNode({
+      params: {...testParams, ALTAIR_FORK_EPOCH: 0, MERGE_FORK_EPOCH: 0, TERMINAL_TOTAL_DIFFICULTY: BigInt(0)},
+      options: {
+        api: {rest: {enabled: true} as RestApiOptions},
+        sync: {isSingleNode: true},
+        network: {disablePeerDiscovery: true},
+        executionEngine: {urls: [engineApiUrl]},
+      },
+      validatorCount: validatorClientCount * validatorsPerClient,
+      logger: loggerNodeA,
+      genesisTime,
+      eth1BlockHash: fromHexString(gensisBlockHash),
+    });
+
+    const stopInfoTracker = simTestInfoTracker(bn, loggerNodeA);
+
+    const justificationEventListener = waitForEvent<phase0.Checkpoint>(bn.chain.emitter, event, timeout);
+    const validators = await getAndInitDevValidators({
+      node: bn,
+      validatorsPerClient,
+      validatorClientCount,
+      startIndex: 0,
+      // At least one sim test must use the REST API for beacon <-> validator comms
+      useRestApi: true,
+      testLoggerOpts,
+    });
+
+    await Promise.all(validators.map((v) => v.start()));
+
+    try {
+      await justificationEventListener;
+      console.log(`\nGot event ${event}, stopping validators and nodes\n`);
+    } catch (e) {
+      (e as Error).message = `failed to get event: ${event}: ${(e as Error).message}`;
+      throw e;
+    } finally {
+      await Promise.all(validators.map((v) => v.stop()));
+
+      // wait for 1 slot
+      await sleep(1 * bn.config.SECONDS_PER_SLOT * 1000);
+      stopInfoTracker();
+      await bn.close();
+      console.log("\n\nDone\n\n");
+      await sleep(1000);
+    }
+  });
+
   it("Test against real geth", async () => {
     // Assume geth is already running
 
-    const gethUrl = `http://localhost:${enginePort}`;
     const controller = new AbortController();
-    const executionEngine = new ExecutionEngineHttp({urls: [gethUrl]}, controller.signal);
+    const executionEngine = new ExecutionEngineHttp({urls: [engineApiUrl]}, controller.signal);
 
     // 1. Prepare a payload
 
     /**
      * curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"engine_preparePayload","params":[{
-     * "parentHash":"0xa0513a503d5bd6e89a144c3268e5b7e9da9dbf63df125a360e3950a7d0d67131",
+     * "parentHash":gensisBlockHash,
      * "timestamp":"0x5",
      * "random":"0x0000000000000000000000000000000000000000000000000000000000000000",
      * "feeRecipient":"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
@@ -95,7 +194,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
 
     const preparePayloadParams = {
       // Note: this is created with a pre-defined genesis.json
-      parentHash: "0xa0513a503d5bd6e89a144c3268e5b7e9da9dbf63df125a360e3950a7d0d67131",
+      parentHash: gensisBlockHash,
       timestamp: "0x5",
       random: "0x0000000000000000000000000000000000000000000000000000000000000000",
       feeRecipient: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
@@ -121,14 +220,14 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     /**
      * curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"engine_executePayload","params":[{
      * "blockHash":"0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174",
-     * "parentHash":"0xa0513a503d5bd6e89a144c3268e5b7e9da9dbf63df125a360e3950a7d0d67131",
+     * "parentHash":gensisBlockHash,
      * "coinbase":"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
      * "stateRoot":"0xca3149fa9e37db08d1cd49c9061db1002ef1cd58db2210f2115c8c989b2bdf45",
      * "receiptRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
      * "logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
      * "random":"0x0000000000000000000000000000000000000000000000000000000000000000",
      * "blockNumber":"0x1",
-     * "gasLimit":"0x989680",
+     * "gasLimit":"0x1c9c380",
      * "gasUsed":"0x0",
      * "timestamp":"0x5",
      * "extraData":"0x",
@@ -139,7 +238,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
 
     const payloadToTest = parseExecutionPayload({
       blockHash: "0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174",
-      parentHash: "0xa0513a503d5bd6e89a144c3268e5b7e9da9dbf63df125a360e3950a7d0d67131",
+      parentHash: gensisBlockHash,
       coinbase: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
       stateRoot: "0xca3149fa9e37db08d1cd49c9061db1002ef1cd58db2210f2115c8c989b2bdf45",
       receiptRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
@@ -147,7 +246,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
         "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
       random: "0x0000000000000000000000000000000000000000000000000000000000000000",
       blockNumber: "0x1",
-      gasLimit: "0x989680",
+      gasLimit: "0x1c9c380",
       gasUsed: "0x0",
       timestamp: "0x5",
       extraData: "0x",
@@ -209,6 +308,8 @@ describe("executionEngine / ExecutionEngineHttp", function () {
 
 /**
  * From https://notes.ethereum.org/@9AeMAlpyQYaAAyuj47BzRw/rkwW3ceVY
+ *
+ * NOTE: Edited gasLimit to match 30_000_000 value is subsequent block generation
  */
 function writeGenesisJson(filepath: string): void {
   const data = `{
@@ -236,7 +337,7 @@ function writeGenesisJson(filepath: string): void {
   "nonce": "0x42",
   "timestamp": "0x0",
   "extraData": "0x0000000000000000000000000000000000000000000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-  "gasLimit": "0x989680",
+  "gasLimit": "0x1c9c380",
   "difficulty": "0x400000000",
   "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "coinbase": "0x0000000000000000000000000000000000000000",
@@ -249,4 +350,33 @@ function writeGenesisJson(filepath: string): void {
   "baseFeePerGas": "0x7"
 }`;
   fs.writeFileSync(filepath, data);
+}
+
+async function waitForGethOnline(url: string, signal: AbortSignal): Promise<void> {
+  for (let i = 0; i < 60; i++) {
+    try {
+      await shell(
+        `curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"net_version","params":[],"id":67}' ${url}`
+      );
+      return; // Done
+    } catch (e) {
+      await sleep(1000, signal);
+    }
+  }
+  throw Error("Geth not online in 60 seconds");
+}
+
+async function getGenesisBlockHash(url: string, signal: AbortSignal): Promise<string> {
+  const eth1Provider = new Eth1Provider(
+    ({DEPOSIT_CONTRACT_ADDRESS: ZERO_HASH} as Partial<IChainConfig>) as IChainConfig,
+    {providerUrls: [url], enabled: true, depositContractDeployBlock: 0},
+    signal
+  );
+
+  const genesisBlock = await eth1Provider.getBlockByNumber(0);
+  if (!genesisBlock) {
+    throw Error("No genesis block available");
+  }
+
+  return genesisBlock.hash;
 }

--- a/packages/lodestar/test/unit/eth1/hexEncoding.test.ts
+++ b/packages/lodestar/test/unit/eth1/hexEncoding.test.ts
@@ -10,7 +10,13 @@ import {
 
 describe("eth1 / hex encoding", () => {
   describe("QUANTITY", () => {
-    const testCases: {quantity: QUANTITY; bytes: string; num?: number; bigint: bigint}[] = [
+    const testCases: {
+      quantity: QUANTITY;
+      /** SSZ representation in little endian */
+      bytes: string;
+      num?: number;
+      bigint: bigint;
+    }[] = [
       {
         quantity: "0x7",
         bytes: "0700000000000000000000000000000000000000000000000000000000000000",
@@ -24,32 +30,43 @@ describe("eth1 / hex encoding", () => {
         bigint: BigInt(0xff),
       },
       {
-        quantity: "0xffffffffffffffffffffffffffffffff00000000000000000000000000000000",
-        bytes: "ffffffffffffffffffffffffffffffff00000000000000000000000000000000",
-        bigint: BigInt(0xffffffffffffffffffffffffffffffff00000000000000000000000000000000),
+        quantity: "0xff00",
+        bytes: "00ff000000000000000000000000000000000000000000000000000000000000",
+        num: 0xff00,
+        bigint: BigInt(0xff00),
       },
       {
-        quantity: "0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff",
+        quantity: "0xaabb",
+        bytes: "bbaa000000000000000000000000000000000000000000000000000000000000",
+        bigint: BigInt(0xaabb),
+      },
+      {
+        quantity: "0xffffffffffffffffffffffffffffffff",
+        bytes: "ffffffffffffffffffffffffffffffff00000000000000000000000000000000",
+        bigint: BigInt("0xffffffffffffffffffffffffffffffff"),
+      },
+      {
+        quantity: "0xffffffffffffffffffffffffffffffff00000000000000000000000000000000",
         bytes: "00000000000000000000000000000000ffffffffffffffffffffffffffffffff",
-        bigint: BigInt(0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff),
+        bigint: BigInt("0xffffffffffffffffffffffffffffffff00000000000000000000000000000000"),
       },
     ];
 
     for (const {quantity, bytes, num, bigint} of testCases) {
-      it(`${quantity} -> bytes`, () => {
+      it(`quantityToBytes - ${quantity}`, () => {
         expect(Buffer.from(quantityToBytes(quantity)).toString("hex")).to.equal(bytes);
       });
-      it(`${quantity} -> bigint`, () => {
+      it(`quantityToBigint - ${quantity}`, () => {
         expect(quantityToBigint(quantity)).to.equal(bigint);
       });
-      it(`${bytes} -> QUANTITY`, () => {
+      it(`bytesToQuantity - ${bytes}`, () => {
         expect(bytesToQuantity(Buffer.from(bytes, "hex"))).to.equal(quantity);
       });
       if (num !== undefined) {
-        it(`${quantity} -> num`, () => {
+        it(`quantityToNum - ${quantity}`, () => {
           expect(quantityToNum(quantity)).to.equal(num);
         });
-        it(`${num} -> QUANTITY`, () => {
+        it(`numToQuantity - ${num}`, () => {
           expect(numToQuantity(num)).to.equal(quantity);
         });
       }

--- a/packages/lodestar/test/unit/eth1/hexEncoding.test.ts
+++ b/packages/lodestar/test/unit/eth1/hexEncoding.test.ts
@@ -1,0 +1,58 @@
+import {expect} from "chai";
+import {
+  QUANTITY,
+  quantityToBytes,
+  quantityToNum,
+  quantityToBigint,
+  numToQuantity,
+  bytesToQuantity,
+} from "../../../src/eth1/provider/utils";
+
+describe("eth1 / hex encoding", () => {
+  describe("QUANTITY", () => {
+    const testCases: {quantity: QUANTITY; bytes: string; num?: number; bigint: bigint}[] = [
+      {
+        quantity: "0x7",
+        bytes: "0700000000000000000000000000000000000000000000000000000000000000",
+        num: 0x7,
+        bigint: BigInt(0x7),
+      },
+      {
+        quantity: "0xff",
+        bytes: "ff00000000000000000000000000000000000000000000000000000000000000",
+        num: 0xff,
+        bigint: BigInt(0xff),
+      },
+      {
+        quantity: "0xffffffffffffffffffffffffffffffff00000000000000000000000000000000",
+        bytes: "ffffffffffffffffffffffffffffffff00000000000000000000000000000000",
+        bigint: BigInt(0xffffffffffffffffffffffffffffffff00000000000000000000000000000000),
+      },
+      {
+        quantity: "0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff",
+        bytes: "00000000000000000000000000000000ffffffffffffffffffffffffffffffff",
+        bigint: BigInt(0x00000000000000000000000000000000ffffffffffffffffffffffffffffffff),
+      },
+    ];
+
+    for (const {quantity, bytes, num, bigint} of testCases) {
+      it(`${quantity} -> bytes`, () => {
+        expect(Buffer.from(quantityToBytes(quantity)).toString("hex")).to.equal(bytes);
+      });
+      it(`${quantity} -> bigint`, () => {
+        expect(quantityToBigint(quantity)).to.equal(bigint);
+      });
+      it(`${bytes} -> QUANTITY`, () => {
+        expect(bytesToQuantity(Buffer.from(bytes, "hex"))).to.equal(quantity);
+      });
+      if (num !== undefined) {
+        it(`${quantity} -> num`, () => {
+          expect(quantityToNum(quantity)).to.equal(num);
+        });
+        it(`${num} -> QUANTITY`, () => {
+          expect(numToQuantity(num)).to.equal(quantity);
+        });
+      }
+    }
+  });
+});

--- a/packages/lodestar/test/unit/executionEngine/http.test.ts
+++ b/packages/lodestar/test/unit/executionEngine/http.test.ts
@@ -4,7 +4,7 @@ import {fastify} from "fastify";
 import {AbortController} from "@chainsafe/abort-controller";
 import {fromHexString} from "@chainsafe/ssz";
 import {ExecutionEngineHttp, parseExecutionPayload, serializeExecutionPayload} from "../../../src/executionEngine/http";
-import {hexToNumber} from "../../../src/eth1/provider/utils";
+import {dataToBytes, quantityToNum} from "../../../src/eth1/provider/utils";
 
 chai.use(chaiAsPromised);
 
@@ -69,10 +69,10 @@ describe("ExecutionEngine / http", () => {
 
     const param0 = request.params[0];
     const payloadId = await executionEngine.preparePayload(
-      fromHexString(param0.parentHash),
-      hexToNumber(param0.timestamp),
-      fromHexString(param0.random),
-      fromHexString(param0.feeRecipient)
+      dataToBytes(param0.parentHash),
+      quantityToNum(param0.timestamp),
+      dataToBytes(param0.random),
+      dataToBytes(param0.feeRecipient)
     );
 
     expect(payloadId).to.equal(0, "Wrong returned payloadId");
@@ -198,7 +198,7 @@ describe("ExecutionEngine / http", () => {
     const response = {jsonrpc: "2.0", id: 67, error: {code: 5, message: "unknown payload"}};
     returnValue = response;
 
-    await expect(executionEngine.getPayload(hexToNumber(request.params[0]))).to.be.rejectedWith(
+    await expect(executionEngine.getPayload(quantityToNum(request.params[0]))).to.be.rejectedWith(
       "JSON RPC error: unknown payload, engine_getPayload"
     );
   });

--- a/packages/lodestar/test/utils/node/beacon.ts
+++ b/packages/lodestar/test/utils/node/beacon.ts
@@ -15,24 +15,21 @@ import {defaultOptions} from "../../../src/node/options";
 import {BeaconDb} from "../../../src/db";
 import {testLogger} from "../logger";
 import PeerId from "peer-id";
+import {InteropStateOpts} from "../../../src/node/utils/interop/state";
 
-export async function getDevBeaconNode({
-  params,
-  options = {},
-  validatorCount = 8,
-  genesisTime,
-  logger,
-  peerId,
-  peerStoreDir,
-}: {
-  params: Partial<IChainConfig>;
-  options?: RecursivePartial<IBeaconNodeOptions>;
-  validatorCount?: number;
-  genesisTime?: number;
-  logger?: ILogger;
-  peerId?: PeerId;
-  peerStoreDir?: string;
-}): Promise<BeaconNode> {
+export async function getDevBeaconNode(
+  opts: {
+    params: Partial<IChainConfig>;
+    options?: RecursivePartial<IBeaconNodeOptions>;
+    validatorCount?: number;
+    logger?: ILogger;
+    peerId?: PeerId;
+    peerStoreDir?: string;
+  } & InteropStateOpts
+): Promise<BeaconNode> {
+  const {params, validatorCount = 8, peerStoreDir} = opts;
+  let {options = {}, logger, peerId} = opts;
+
   if (!peerId) peerId = await createPeerId();
   const tmpDir = tmp.dirSync({unsafeCleanup: true});
   const config = createIChainForkConfig({...minimalConfig, ...params});
@@ -70,7 +67,7 @@ export async function getDevBeaconNode({
     )
   );
 
-  const anchorState = await initDevState(config, db, validatorCount, genesisTime);
+  const anchorState = await initDevState(config, db, validatorCount, opts);
   const beaconConfig = createIBeaconConfig(config, anchorState.genesisValidatorsRoot);
   return await BeaconNode.init({
     opts: options as IBeaconNodeOptions,


### PR DESCRIPTION
**Motivation**

Part of #3275

**Description**

Run single node test with validators proposing blocks connected to a real Geth node in catalyst mode.

Changes found / done during testing:
- Improve error messages in beacon state transition function for merge
- Allow to customize interop state eth1BlockHash
- Use proper hex encoding for eth1 api, strictly always referring to DATA or QUANTITY

**Pending issues**
- Figure our proper baseFeePerGas encoding. Validator expects a full 32 bytes ByteVector, while the engine API will send a QUANTITY in big endian