### PR TITLE
PayloadId as string

### DIFF
--- a/packages/lodestar/src/chain/factory/block/body.ts
+++ b/packages/lodestar/src/chain/factory/block/body.ts
@@ -3,18 +3,7 @@
  */
 
 import {List} from "@chainsafe/ssz";
-import {
-  Bytes96,
-  Bytes32,
-  phase0,
-  allForks,
-  altair,
-  Root,
-  Slot,
-  ssz,
-  ExecutionAddress,
-  PayloadId,
-} from "@chainsafe/lodestar-types";
+import {Bytes96, Bytes32, phase0, allForks, altair, Root, Slot, ssz, ExecutionAddress} from "@chainsafe/lodestar-types";
 import {
   CachedBeaconState,
   computeEpochAtSlot,
@@ -23,6 +12,7 @@ import {
   merge,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconChain} from "../../interface";
+import {PayloadId} from "../../../executionEngine/interface";
 
 export async function assembleBody(
   chain: IBeaconChain,

--- a/packages/lodestar/src/executionEngine/http.ts
+++ b/packages/lodestar/src/executionEngine/http.ts
@@ -1,5 +1,5 @@
 import {AbortSignal} from "@chainsafe/abort-controller";
-import {Bytes32, merge, Root, ExecutionAddress, PayloadId, RootHex} from "@chainsafe/lodestar-types";
+import {Bytes32, merge, Root, ExecutionAddress, RootHex} from "@chainsafe/lodestar-types";
 import {JsonRpcHttpClient} from "../eth1/provider/jsonRpcHttpClient";
 import {
   bytesToData,
@@ -12,7 +12,7 @@ import {
   QUANTITY,
 } from "../eth1/provider/utils";
 import {IJsonRpcHttpClient} from "../eth1/provider/jsonRpcHttpClient";
-import {IExecutionEngine} from "./interface";
+import {IExecutionEngine, PayloadId} from "./interface";
 import {BYTES_PER_LOGS_BLOOM} from "@chainsafe/lodestar-params";
 
 export type ExecutionEngineHttpOpts = {
@@ -132,7 +132,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
       ],
     });
 
-    return quantityToNum(payloadId);
+    return payloadId;
   }
 
   /**
@@ -149,7 +149,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
       EngineApiRpcParamTypes[typeof method]
     >({
       method,
-      params: [numToQuantity(payloadId)],
+      params: [payloadId],
     });
 
     return parseExecutionPayload(executionPayloadRpc);

--- a/packages/lodestar/src/executionEngine/interface.ts
+++ b/packages/lodestar/src/executionEngine/interface.ts
@@ -1,4 +1,8 @@
-import {Bytes32, merge, Root, ExecutionAddress, PayloadId, RootHex} from "@chainsafe/lodestar-types";
+import {Bytes32, merge, Root, ExecutionAddress, RootHex} from "@chainsafe/lodestar-types";
+
+// An execution engine can produce a payload id anywhere the the uint64 range
+// Since we do no processing with this id, we have no need to deserialize it
+export type PayloadId = string;
 
 /**
  * Execution engine represents an abstract protocol to interact with execution clients. Potential transports include:

--- a/packages/lodestar/src/executionEngine/mock.ts
+++ b/packages/lodestar/src/executionEngine/mock.ts
@@ -1,8 +1,8 @@
 import crypto from "crypto";
-import {Bytes32, merge, Root, ExecutionAddress, PayloadId, RootHex} from "@chainsafe/lodestar-types";
+import {Bytes32, merge, Root, ExecutionAddress, RootHex} from "@chainsafe/lodestar-types";
 import {toHexString} from "@chainsafe/ssz";
 import {ZERO_HASH, ZERO_HASH_HEX} from "../constants";
-import {IExecutionEngine} from "./interface";
+import {IExecutionEngine, PayloadId} from "./interface";
 import {BYTES_PER_LOGS_BLOOM} from "@chainsafe/lodestar-params";
 
 const INTEROP_GAS_LIMIT = 30e6;
@@ -145,7 +145,7 @@ export class ExecutionEngineMock implements IExecutionEngine {
     };
     this.preparingPayloads.set(payloadId, payload);
 
-    return payloadId;
+    return payloadId.toString();
   }
 
   /**
@@ -156,7 +156,7 @@ export class ExecutionEngineMock implements IExecutionEngine {
    * 3. Client software MAY stop the corresponding building process after serving this call.
    */
   async getPayload(payloadId: PayloadId): Promise<merge.ExecutionPayload> {
-    const payload = this.preparingPayloads.get(payloadId);
+    const payload = this.preparingPayloads.get(Number(payloadId));
     if (!payload) {
       throw Error(`Unknown payloadId ${payloadId}`);
     }

--- a/packages/lodestar/test/unit/executionEngine/http.test.ts
+++ b/packages/lodestar/test/unit/executionEngine/http.test.ts
@@ -75,7 +75,7 @@ describe("ExecutionEngine / http", () => {
       dataToBytes(param0.feeRecipient)
     );
 
-    expect(payloadId).to.equal(0, "Wrong returned payloadId");
+    expect(payloadId).to.equal("0x0", "Wrong returned payloadId");
     expect(reqJsonRpcPayload).to.deep.equal(request, "Wrong request JSON RPC payload");
   });
 
@@ -108,7 +108,7 @@ describe("ExecutionEngine / http", () => {
     };
     returnValue = response;
 
-    const payload = await executionEngine.getPayload(0);
+    const payload = await executionEngine.getPayload("0x0");
 
     expect(serializeExecutionPayload(payload)).to.deep.equal(response.result, "Wrong returned payload");
     expect(reqJsonRpcPayload).to.deep.equal(request, "Wrong request JSON RPC payload");
@@ -198,7 +198,7 @@ describe("ExecutionEngine / http", () => {
     const response = {jsonrpc: "2.0", id: 67, error: {code: 5, message: "unknown payload"}};
     returnValue = response;
 
-    await expect(executionEngine.getPayload(quantityToNum(request.params[0]))).to.be.rejectedWith(
+    await expect(executionEngine.getPayload(request.params[0])).to.be.rejectedWith(
       "JSON RPC error: unknown payload, engine_getPayload"
     );
   });

--- a/packages/types/src/primitive/sszTypes.ts
+++ b/packages/types/src/primitive/sszTypes.ts
@@ -44,4 +44,3 @@ export const BLSSignature = Bytes96;
 export const Domain = Bytes32;
 export const ParticipationFlags = Uint8;
 export const ExecutionAddress = Bytes20;
-export const PayloadId = Number64;

--- a/packages/types/src/primitive/types.ts
+++ b/packages/types/src/primitive/types.ts
@@ -37,7 +37,6 @@ export type BLSSecretKey = Bytes32;
 export type BLSSignature = Bytes96;
 export type ParticipationFlags = Uint8;
 export type ExecutionAddress = Bytes20;
-export type PayloadId = Number64;
 
 /** Common non-spec type to represent roots as strings */
 export type RootHex = string;


### PR DESCRIPTION
**Motivation**

Merge interop: found when interoping w besu

**Description**

Besu uses random uint64 payload-ids. We were converting to `number`, which caused the payload id to be off by some...