### PR TITLE
Add option to import keystores in validator CLI

### DIFF
--- a/docker-compose.validator.yml
+++ b/docker-compose.validator.yml
@@ -8,7 +8,7 @@ services:
       - logs:/logs
       - ./keystores:/keystores
     env_file: .env
-    command: validator --rootDir/data --importKeystoresPath /keystores --importKeystoresPassword /keystores/password.txt --server http://beacon_node:9596 --logFile /logs/validator.log --logLevelFile debug --logRotate --logMaxFiles 5
+    command: validator --rootDir /data --importKeystoresPath /keystores --importKeystoresPassword /keystores/password.txt --server http://beacon_node:9596 --logFile /logs/validator.log --logLevelFile debug --logRotate --logMaxFiles 5
     # A validator client requires very little memory. This limit allows to run the validator
     # along with the beacon_node in a 8GB machine and be safe on memory spikes.
     environment:

--- a/docker-compose.validator.yml
+++ b/docker-compose.validator.yml
@@ -7,9 +7,16 @@ services:
       - validator:/data
       - logs:/logs
       - ./keystores:/keystores
-      - ./secrets:/secrets
     env_file: .env
-    command: validator --rootDir /data --keystoresDir /keystores --secretsDir /secrets --server http://beacon_node:9596 --logFile /logs/validator.log --logLevelFile debug --logRotate --logMaxFiles 5
+    command:
+      - validator
+      - --rootDir /data
+      - --importKeystoresPath /keystores
+      - --importKeystoresPassword /keystores/password.txt
+      - --server http://beacon_node:9596
+      - --logFile /logs/validator.log
+      - --logLevelFile debug
+      - --logRotate --logMaxFiles 5
     # A validator client requires very little memory. This limit allows to run the validator
     # along with the beacon_node in a 8GB machine and be safe on memory spikes.
     environment:

--- a/docker-compose.validator.yml
+++ b/docker-compose.validator.yml
@@ -8,15 +8,7 @@ services:
       - logs:/logs
       - ./keystores:/keystores
     env_file: .env
-    command:
-      - validator
-      - --rootDir /data
-      - --importKeystoresPath /keystores
-      - --importKeystoresPassword /keystores/password.txt
-      - --server http://beacon_node:9596
-      - --logFile /logs/validator.log
-      - --logLevelFile debug
-      - --logRotate --logMaxFiles 5
+    command: validator --rootDir/data --importKeystoresPath /keystores --importKeystoresPassword /keystores/password.txt --server http://beacon_node:9596 --logFile /logs/validator.log --logLevelFile debug --logRotate --logMaxFiles 5
     # A validator client requires very little memory. This limit allows to run the validator
     # along with the beacon_node in a 8GB machine and be safe on memory spikes.
     environment:

--- a/packages/cli/src/cmds/validator/keys.ts
+++ b/packages/cli/src/cmds/validator/keys.ts
@@ -41,9 +41,9 @@ export async function getSecretKeys(args: IValidatorCliArgs & IGlobalArgs): Prom
 
     const passphrase = stripOffNewlines(fs.readFileSync(args.importKeystoresPassword, "utf8"));
 
-    const keystorePaths = fs.lstatSync(args.importKeystoresPath).isDirectory()
-      ? fs.readdirSync(args.importKeystoresPath)
-      : [args.importKeystoresPath];
+    const keystorePaths = args.importKeystoresPath
+      .map((filepath) => (fs.lstatSync(filepath).isDirectory() ? fs.readdirSync(filepath) : [filepath]))
+      .flat(1);
 
     return await Promise.all(
       keystorePaths.map(async (keystorePath) =>

--- a/packages/cli/src/cmds/validator/keys.ts
+++ b/packages/cli/src/cmds/validator/keys.ts
@@ -1,8 +1,10 @@
+import fs from "fs";
+import {Keystore} from "@chainsafe/bls-keystore";
 import {SecretKey} from "@chainsafe/bls";
 import {deriveEth2ValidatorKeys, deriveKeyFromMnemonic} from "@chainsafe/bls-keygen";
 import {interopSecretKey} from "@chainsafe/lodestar-beacon-state-transition";
 import {defaultNetwork, IGlobalArgs} from "../../options";
-import {parseRange, YargsError} from "../../util";
+import {parseRange, stripOffNewlines, YargsError} from "../../util";
 import {ValidatorDirManager} from "../../validatorDir";
 import {getAccountPaths} from "../account/paths";
 import {IValidatorCliArgs} from "./options";
@@ -29,6 +31,25 @@ export async function getSecretKeys(args: IValidatorCliArgs & IGlobalArgs): Prom
   else if (args.interopIndexes) {
     const indexes = parseRange(args.interopIndexes);
     return indexes.map((index) => interopSecretKey(index));
+  }
+
+  // Import JSON keystores and run
+  else if (args.importKeystoresPath) {
+    if (!args.importKeystoresPassword) {
+      throw new YargsError("Must specify importKeystoresPassword with importKeystoresPath");
+    }
+
+    const passphrase = stripOffNewlines(fs.readFileSync(args.importKeystoresPassword, "utf8"));
+
+    const keystorePaths = fs.lstatSync(args.importKeystoresPath).isDirectory()
+      ? fs.readdirSync(args.importKeystoresPath)
+      : [args.importKeystoresPath];
+
+    return await Promise.all(
+      keystorePaths.map(async (keystorePath) =>
+        SecretKey.fromBytes(await Keystore.parse(fs.readFileSync(keystorePath, "utf8")).decrypt(passphrase))
+      )
+    );
   }
 
   // Read keys from local account manager

--- a/packages/cli/src/cmds/validator/keys.ts
+++ b/packages/cli/src/cmds/validator/keys.ts
@@ -43,7 +43,8 @@ export async function getSecretKeys(args: IValidatorCliArgs & IGlobalArgs): Prom
 
     const keystorePaths = args.importKeystoresPath
       .map((filepath) => (fs.lstatSync(filepath).isDirectory() ? fs.readdirSync(filepath) : [filepath]))
-      .flat(1);
+      .flat(1)
+      .filter((filepath) => filepath.endsWith(".json"));
 
     return await Promise.all(
       keystorePaths.map(async (keystorePath) =>

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -10,7 +10,7 @@ export type IValidatorCliArgs = IAccountValidatorArgs &
     server: string;
     force: boolean;
     graffiti: string;
-    importKeystoresPath?: string;
+    importKeystoresPath?: string[];
     importKeystoresPassword?: string;
     interopIndexes?: string;
     fromMnemonic?: string;
@@ -47,12 +47,14 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
   },
 
   importKeystoresPath: {
-    description: "Directory or single filepath to validator keystores, i.e. Launchpad validators",
-    type: "string",
+    description: "Path(s) to a directory or single filepath to validator keystores, i.e. Launchpad validators",
+    defaultDescription: "./keystores/*.json",
+    type: "array",
   },
 
   importKeystoresPassword: {
     description: "Path to a file with password to decrypt all keystores from importKeystoresPath option",
+    defaultDescription: "./password.txt",
     type: "string",
   },
 

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -10,6 +10,8 @@ export type IValidatorCliArgs = IAccountValidatorArgs &
     server: string;
     force: boolean;
     graffiti: string;
+    importKeystoresPath?: string;
+    importKeystoresPassword?: string;
     interopIndexes?: string;
     fromMnemonic?: string;
     mnemonicIndexes?: string;
@@ -41,6 +43,16 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
   graffiti: {
     description: "Specify your custom graffiti to be included in blocks (plain UTF8 text, 32 characters max)",
     // Don't use a default here since it should be computed only if necessary by getDefaultGraffiti()
+    type: "string",
+  },
+
+  importKeystoresPath: {
+    description: "Directory or single filepath to validator keystores, i.e. Launchpad validators",
+    type: "string",
+  },
+
+  importKeystoresPassword: {
+    description: "Path to a file with password to decrypt all keystores from importKeystoresPath option",
     type: "string",
   },
 


### PR DESCRIPTION
**Motivation**

To easily import validators without requiring a previous step

**Description**

Adds flags `--importKeystoresPath` and `--importKeystoresPassword` which trigger decrypting the keys from them automatically

```
lodestar validator --importKeystoresPath ./keystores --importKeystoresPassword ./password.txt
```