### PR TITLE
Assert correct head in merge interop tests

### DIFF
--- a/packages/lodestar/src/eth1/eth1DepositDataTracker.ts
+++ b/packages/lodestar/src/eth1/eth1DepositDataTracker.ts
@@ -1,7 +1,7 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {CachedBeaconState, allForks} from "@chainsafe/lodestar-beacon-state-transition";
-import {ErrorAborted, ILogger, sleep} from "@chainsafe/lodestar-utils";
+import {ErrorAborted, ILogger, isErrorAborted, sleep} from "@chainsafe/lodestar-utils";
 import {AbortSignal} from "@chainsafe/abort-controller";
 import {IBeaconDb} from "../db";
 import {Eth1DepositsCache} from "./eth1DepositsCache";
@@ -124,7 +124,7 @@ export class Eth1DepositDataTracker {
         if (e instanceof HttpRpcError && e.status === 429) {
           this.logger.debug("Eth1 provider rate limited", {}, e);
           await sleep(RATE_LIMITED_WAIT_MS, this.signal);
-        } else {
+        } else if (!isErrorAborted(e)) {
           this.logger.error("Error updating eth1 chain cache", {}, e as Error);
           await sleep(MIN_WAIT_ON_ERORR_MS, this.signal);
         }

--- a/packages/lodestar/src/eth1/options.ts
+++ b/packages/lodestar/src/eth1/options.ts
@@ -1,7 +1,7 @@
 export type Eth1Options = {
   enabled: boolean;
   providerUrls: string[];
-  depositContractDeployBlock: number;
+  depositContractDeployBlock?: number;
 };
 
 export const defaultEth1Options: Eth1Options = {

--- a/packages/lodestar/src/eth1/provider/eth1Provider.ts
+++ b/packages/lodestar/src/eth1/provider/eth1Provider.ts
@@ -41,8 +41,12 @@ export class Eth1Provider implements IEth1Provider {
   private readonly depositContractAddress: string;
   private readonly rpc: JsonRpcHttpClient;
 
-  constructor(config: IChainConfig, opts: Eth1Options, signal: AbortSignal) {
-    this.deployBlock = opts.depositContractDeployBlock;
+  constructor(
+    config: Pick<IChainConfig, "DEPOSIT_CONTRACT_ADDRESS">,
+    opts: Pick<Eth1Options, "depositContractDeployBlock" | "providerUrls">,
+    signal?: AbortSignal
+  ) {
+    this.deployBlock = opts.depositContractDeployBlock ?? 0;
     this.depositContractAddress = toHexString(config.DEPOSIT_CONTRACT_ADDRESS);
     this.rpc = new JsonRpcHttpClient(opts.providerUrls, {
       signal,

--- a/packages/lodestar/src/eth1/provider/jsonRpcHttpClient.ts
+++ b/packages/lodestar/src/eth1/provider/jsonRpcHttpClient.ts
@@ -34,8 +34,8 @@ export class JsonRpcHttpClient implements IJsonRpcHttpClient {
 
   constructor(
     private readonly urls: string[],
-    private readonly opts: {
-      signal: AbortSignal;
+    private readonly opts?: {
+      signal?: AbortSignal;
       timeout?: number;
       /** If returns true, do not fallback to other urls and throw early */
       shouldNotFallback?: (error: Error) => boolean;
@@ -81,7 +81,7 @@ export class JsonRpcHttpClient implements IJsonRpcHttpClient {
       try {
         return await this.fetchJsonOneUrl(url, json, opts);
       } catch (e) {
-        if (this.opts.shouldNotFallback?.(e as Error)) {
+        if (this.opts?.shouldNotFallback?.(e as Error)) {
           throw e;
         }
 
@@ -112,11 +112,11 @@ export class JsonRpcHttpClient implements IJsonRpcHttpClient {
     const controller = new AbortController();
     const timeout = setTimeout(() => {
       controller.abort();
-    }, opts?.timeout ?? this.opts.timeout ?? REQUEST_TIMEOUT);
+    }, opts?.timeout ?? this.opts?.timeout ?? REQUEST_TIMEOUT);
 
     const onParentSignalAbort = (): void => controller.abort();
 
-    if (this.opts.signal) {
+    if (this.opts?.signal) {
       this.opts.signal.addEventListener("abort", onParentSignalAbort, {once: true});
     }
 
@@ -128,7 +128,7 @@ export class JsonRpcHttpClient implements IJsonRpcHttpClient {
         signal: controller.signal,
       }).finally(() => {
         clearTimeout(timeout);
-        this.opts.signal?.removeEventListener("abort", onParentSignalAbort);
+        this.opts?.signal?.removeEventListener("abort", onParentSignalAbort);
       });
 
       const body = await res.text();
@@ -142,7 +142,7 @@ export class JsonRpcHttpClient implements IJsonRpcHttpClient {
     } catch (e) {
       if (controller.signal.aborted) {
         // controller will abort on both parent signal abort + timeout of this specific request
-        if (this.opts.signal.aborted) {
+        if (this.opts?.signal?.aborted) {
           throw new ErrorAborted("request");
         } else {
           throw new TimeoutError("request");

--- a/packages/lodestar/test/e2e/eth1/eth1MergeBlockTracker.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1MergeBlockTracker.test.ts
@@ -8,6 +8,7 @@ import {Eth1Options} from "../../../src/eth1/options";
 import {testnet} from "../../utils/testnet";
 import {testLogger} from "../../utils/logger";
 import {quantityToBigint} from "../../../src/eth1/provider/utils";
+import {ZERO_HASH} from "../../../src/constants";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -31,14 +32,14 @@ describe("eth1 / Eth1MergeBlockTracker", function () {
       TERMINAL_TOTAL_DIFFICULTY: ttd,
     } as Partial<IChainConfig>) as IChainConfig;
   }
-  const configNoTtd = getConfig(BigInt(0));
+  const eth1Config = {DEPOSIT_CONTRACT_ADDRESS: ZERO_HASH};
 
   let controller: AbortController;
   beforeEach(() => (controller = new AbortController()));
   afterEach(() => controller.abort());
 
   it("Should find merge block polling future 'latest' blocks", async () => {
-    const eth1Provider = new Eth1Provider(configNoTtd, eth1Options, controller.signal);
+    const eth1Provider = new Eth1Provider(eth1Config, eth1Options, controller.signal);
     const latestBlock = await eth1Provider.getBlockByNumber("latest");
     if (!latestBlock) throw Error("No latestBlock");
 
@@ -75,7 +76,7 @@ describe("eth1 / Eth1MergeBlockTracker", function () {
   });
 
   it("Should find merge block fetching past blocks", async () => {
-    const eth1Provider = new Eth1Provider(configNoTtd, eth1Options, controller.signal);
+    const eth1Provider = new Eth1Provider(eth1Config, eth1Options, controller.signal);
     const latestBlock = await eth1Provider.getBlockByNumber("latest");
     if (!latestBlock) throw Error("No latestBlock");
 

--- a/packages/lodestar/test/e2e/eth1/stream.test.ts
+++ b/packages/lodestar/test/e2e/eth1/stream.test.ts
@@ -18,7 +18,6 @@ describe("Eth1 streams", function () {
     return new Eth1Provider(
       config,
       {
-        enabled: true,
         providerUrls: [testnet.providerUrl],
         depositContractDeployBlock: testnet.depositBlock,
       },

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -395,6 +395,8 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     });
 
     // Stop chain and un-subscribe events so the execution engine won't update it's head
+    // Allow some time to broadcast finalized events and complete the importBlock routine
+    await sleep(500);
     await bn.close();
 
     // Assertions to make sure the end state is good

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -68,11 +68,11 @@ describe("executionEngine / ExecutionEngineHttp", function () {
 
     gethProc.stdout.on("data", (chunk) => {
       const str = Buffer.from(chunk).toString("utf8");
-      process.stdout.write(`GETH: ${str}`); // str already contains a new line. console.log adds a new line
+      process.stdout.write(`GETH ${gethProc.pid}: ${str}`); // str already contains a new line. console.log adds a new line
     });
     gethProc.stderr.on("data", (chunk) => {
       const str = Buffer.from(chunk).toString("utf8");
-      process.stderr.write(`GETH: ${str}`); // str already contains a new line. console.log adds a new line
+      process.stderr.write(`GETH ${gethProc.pid}: ${str}`); // str already contains a new line. console.log adds a new line
     });
 
     gethProc.on("exit", (code) => {
@@ -89,6 +89,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
 
       // Wait for the P2P to be offline
       await waitForGethOffline();
+      console.log("Geth successfully killed!");
     });
   }
 
@@ -276,17 +277,18 @@ describe("executionEngine / ExecutionEngineHttp", function () {
   });
 
   it("Post-merge, run for a few blocks", async function () {
+    console.log("\n\nPost-merge, run for a few blocks\n\n");
     const {genesisBlockHash} = await runGethPostMerge();
     await runNodeWithGeth.bind(this)({
       genesisBlockHash,
       mergeEpoch: 0,
       ttd: BigInt(0),
-      testName: "pre-merge",
+      testName: "post-merge",
     });
   });
 
   it("Pre-merge, run for a few blocks", async function () {
-    console.log("Merge test!");
+    console.log("\n\nPre-merge, run for a few blocks\n\n");
     const {genesisBlockHash} = await runGethPreMerge();
     await runNodeWithGeth.bind(this)({
       genesisBlockHash,

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -70,12 +70,12 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     gethProc.stdout.on("data", (chunk) => {
       const str = Buffer.from(chunk).toString("utf8");
       stdoutStr += str;
-      console.log(`GETH: ${str}`);
+      process.stdout.write(`GETH: ${str}`); // str already contains a new line. console.log adds a new line
     });
     gethProc.stderr.on("data", (chunk) => {
       const str = Buffer.from(chunk).toString("utf8");
       stderrStr += str;
-      console.log(`GETH: ${str}`);
+      process.stderr.write(`GETH: ${str}`); // str already contains a new line. console.log adds a new line
     });
 
     gethProc.on("exit", (code) => {

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -68,10 +68,14 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     let stderrStr = "";
 
     gethProc.stdout.on("data", (chunk) => {
-      stdoutStr += Buffer.from(chunk).toString("hex");
+      const str = Buffer.from(chunk).toString("utf8");
+      stdoutStr += str;
+      console.log(`GETH: ${str}`);
     });
     gethProc.stderr.on("data", (chunk) => {
-      stderrStr += Buffer.from(chunk).toString("hex");
+      const str = Buffer.from(chunk).toString("utf8");
+      stderrStr += str;
+      console.log(`GETH: ${str}`);
     });
 
     gethProc.on("exit", (code) => {

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -544,7 +544,7 @@ async function isPortInUse(port: number): Promise<boolean> {
 async function getGenesisBlockHash(url: string, signal: AbortSignal): Promise<string> {
   const eth1Provider = new Eth1Provider(
     ({DEPOSIT_CONTRACT_ADDRESS: ZERO_HASH} as Partial<IChainConfig>) as IChainConfig,
-    {providerUrls: [url], enabled: true, depositContractDeployBlock: 0},
+    {providerUrls: [url]},
     signal
   );
 

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -396,8 +396,9 @@ describe("executionEngine / ExecutionEngineHttp", function () {
 
     // Stop chain and un-subscribe events so the execution engine won't update it's head
     // Allow some time to broadcast finalized events and complete the importBlock routine
-    await sleep(500);
+    await Promise.all(validators.map((v) => v.stop()));
     await bn.close();
+    await sleep(500);
 
     // Assertions to make sure the end state is good
     // 1. The proper head is set

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -1,7 +1,6 @@
 import fs from "fs";
 import path from "path";
 import net from "net";
-import os from "os";
 import {spawn} from "child_process";
 import {Context} from "mocha";
 import {AbortController, AbortSignal} from "@chainsafe/abort-controller";

--- a/packages/validator/src/util/clock.ts
+++ b/packages/validator/src/util/clock.ts
@@ -67,7 +67,9 @@ export class Clock implements IClock {
     let slotOrEpoch = timeItem === TimeItem.Slot ? slot : computeEpochAtSlot(slot);
     while (!signal.aborted) {
       // Must catch fn() to ensure `sleep()` is awaited both for resolve and reject
-      await fn(slotOrEpoch, signal).catch((e: Error) => this.logger.error("Error on runEvery fn", {}, e));
+      await fn(slotOrEpoch, signal).catch((e: Error) => {
+        if (!isErrorAborted(e)) this.logger.error("Error on runEvery fn", {}, e);
+      });
 
       try {
         await sleep(this.timeUntilNext(timeItem), signal);


### PR DESCRIPTION
**Motivation**

We can check if the Geth head is correct after completing the merge with existing JSON RPC methods.

**Description**

- Assert correct head in merge interop tests
- Request only necessary options in Eth1Provider
- Remove unnecessary options in Eth1Provider