### PR TITLE
More sim tests for merge

### DIFF
--- a/packages/cli/src/cmds/dev/options.ts
+++ b/packages/cli/src/cmds/dev/options.ts
@@ -76,8 +76,8 @@ const externalOptionsOverrides: {[k: string]: Options} = {
     defaultDescription: undefined,
     default: 1,
   },
-  "eth1.enabled": {
-    ...beaconNodeOptions["eth1.enabled"],
+  "eth1.mode": {
+    ...beaconNodeOptions["eth1.mode"],
     defaultDescription: undefined,
     default: false,
   },

--- a/packages/cli/src/options/beaconNodeOptions/eth1.ts
+++ b/packages/cli/src/options/beaconNodeOptions/eth1.ts
@@ -2,7 +2,7 @@ import {defaultOptions, IBeaconNodeOptions} from "@chainsafe/lodestar";
 import {ICliCommandOptions} from "../../util";
 
 export interface IEth1Args {
-  "eth1.enabled": boolean;
+  "eth1.mode": "rpcClient" | "disabled";
   "eth1.providerUrl": string;
   "eth1.providerUrls": string[];
   "eth1.depositContractDeployBlock": number;
@@ -18,7 +18,7 @@ export function parseArgs(args: IEth1Args): IBeaconNodeOptions["eth1"] {
   }
 
   return {
-    enabled: args["eth1.enabled"],
+    mode: args["eth1.mode"],
     providerUrls: providerUrls,
     depositContractDeployBlock: args["eth1.depositContractDeployBlock"],
     disableEth1DepositDataTracker: args["eth1.disableEth1DepositDataTracker"],
@@ -26,10 +26,10 @@ export function parseArgs(args: IEth1Args): IBeaconNodeOptions["eth1"] {
 }
 
 export const options: ICliCommandOptions<IEth1Args> = {
-  "eth1.enabled": {
-    description: "Whether to follow the eth1 chain",
-    type: "boolean",
-    defaultDescription: String(defaultOptions.eth1.enabled),
+  "eth1.mode": {
+    description: "'rpcClient' to follow the eth1 chain, or 'mock' or 'disable'",
+    type: "string",
+    defaultDescription: String(defaultOptions.eth1.mode),
     group: "eth1",
   },
 
@@ -43,7 +43,7 @@ export const options: ICliCommandOptions<IEth1Args> = {
   "eth1.providerUrls": {
     description: "Urls to Eth1 node with enabled rpc",
     type: "array",
-    defaultDescription: defaultOptions.eth1.providerUrls.join(" "),
+    defaultDescription: defaultOptions.eth1.mode === "rpcClient" ? defaultOptions.eth1.providerUrls.join(" ") : "",
     group: "eth1",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/eth1.ts
+++ b/packages/cli/src/options/beaconNodeOptions/eth1.ts
@@ -27,7 +27,7 @@ export function parseArgs(args: IEth1Args): IBeaconNodeOptions["eth1"] {
 
 export const options: ICliCommandOptions<IEth1Args> = {
   "eth1.mode": {
-    description: "'rpcClient' to follow the eth1 chain, or 'mock' or 'disable'",
+    description: "'rpcClient' to follow the eth1 chain, or 'disable'",
     type: "string",
     defaultDescription: String(defaultOptions.eth1.mode),
     group: "eth1",

--- a/packages/cli/test/unit/config/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/config/beaconNodeOptions.test.ts
@@ -1,5 +1,6 @@
 import {expect} from "chai";
-import {defaultOptions} from "@chainsafe/lodestar";
+import {RecursivePartial} from "@chainsafe/lodestar-utils";
+import {defaultOptions, IBeaconNodeOptions} from "@chainsafe/lodestar";
 import {BeaconNodeOptions} from "../../../src/config";
 import {bootEnrs as pyrmontBootEnrs} from "../../../src/networks/pyrmont";
 
@@ -16,8 +17,8 @@ describe("config / beaconNodeOptions", () => {
   });
 
   it("Should return added partial options", () => {
-    const initialPartialOptions = {eth1: {enabled: true}};
-    const editedPartialOptions = {eth1: {enabled: false}};
+    const initialPartialOptions = {eth1: {mode: "rpcClient"}} as RecursivePartial<IBeaconNodeOptions>;
+    const editedPartialOptions = {eth1: {mode: "disabled"}} as RecursivePartial<IBeaconNodeOptions>;
 
     const beaconNodeOptions = new BeaconNodeOptions({
       beaconNodeOptionsCli: initialPartialOptions,

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -18,7 +18,7 @@ describe("options / beaconNodeOptions", () => {
       "chain.disableBlsBatchVerify": true,
       "chain.persistInvalidSszObjects": true,
 
-      "eth1.enabled": true,
+      "eth1.mode": "rpcClient",
       "eth1.providerUrl": "http://my.node:8545",
       "eth1.providerUrls": ["http://my.node:8545"],
       "eth1.depositContractDeployBlock": 1625314,
@@ -66,7 +66,7 @@ describe("options / beaconNodeOptions", () => {
         persistInvalidSszObjects: true,
       },
       eth1: {
-        enabled: true,
+        mode: "rpcClient",
         providerUrls: ["http://my.node:8545"],
         depositContractDeployBlock: 1625314,
         disableEth1DepositDataTracker: true,

--- a/packages/lodestar/src/eth1/eth1DepositDataTracker.ts
+++ b/packages/lodestar/src/eth1/eth1DepositDataTracker.ts
@@ -31,11 +31,15 @@ export type Eth1DepositDataTrackerModules = {
   signal: AbortSignal;
 };
 
+export interface IEth1DepositDataTracker {
+  getEth1DataAndDeposits: (state: CachedBeaconState<allForks.BeaconState>) => Promise<Eth1DataAndDeposits>;
+}
+
 /**
  * Main class handling eth1 data fetching, processing and storing
  * Upon instantiation, starts fetcheing deposits and blocks at regular intervals
  */
-export class Eth1DepositDataTracker {
+export class Eth1DepositDataTracker implements IEth1DepositDataTracker {
   private config: IChainForkConfig;
   private logger: ILogger;
   private signal: AbortSignal;
@@ -224,5 +228,16 @@ export class Eth1DepositDataTracker {
       this.lastProcessedDepositBlockNumber = await this.depositsCache.getHighestDepositEventBlockNumber();
     }
     return this.lastProcessedDepositBlockNumber;
+  }
+}
+
+/** Disabled version of Eth1DepositDataTracker */
+export class Eth1DepositDataTrackerDisabled implements IEth1DepositDataTracker {
+  /**
+   * Returns same eth1Data as in state and no deposits
+   * May produce invalid blocks if deposits have to be added
+   */
+  async getEth1DataAndDeposits(state: CachedBeaconState<allForks.BeaconState>): Promise<Eth1DataAndDeposits> {
+    return {eth1Data: state.eth1Data, deposits: []};
   }
 }

--- a/packages/lodestar/src/eth1/options.ts
+++ b/packages/lodestar/src/eth1/options.ts
@@ -1,12 +1,21 @@
-export type Eth1Options = {
-  enabled: boolean;
-  disableEth1DepositDataTracker?: boolean;
+import {Eth1ProviderMockOpts} from "./provider/eth1Provider/mock";
+
+export type Eth1RpcClient = {
   providerUrls: string[];
+};
+
+export type Eth1OptionsMode =
+  | ({mode: "rpcClient"} & Eth1RpcClient)
+  | ({mode: "mock"} & Eth1ProviderMockOpts)
+  | {mode: "disabled"};
+
+export type Eth1Options = Eth1OptionsMode & {
+  disableEth1DepositDataTracker?: boolean;
   depositContractDeployBlock?: number;
 };
 
 export const defaultEth1Options: Eth1Options = {
-  enabled: true,
+  mode: "rpcClient",
   providerUrls: ["http://localhost:8545"],
   depositContractDeployBlock: 0,
 };

--- a/packages/lodestar/src/eth1/provider/eth1Provider/index.ts
+++ b/packages/lodestar/src/eth1/provider/eth1Provider/index.ts
@@ -41,11 +41,7 @@ export class Eth1Provider implements IEth1Provider {
   private readonly depositContractAddress: string;
   private readonly rpc: JsonRpcHttpClient;
 
-  constructor(
-    config: Pick<IChainConfig, "DEPOSIT_CONTRACT_ADDRESS">,
-    opts: Eth1Options,
-    signal?: AbortSignal
-  ) {
+  constructor(config: Pick<IChainConfig, "DEPOSIT_CONTRACT_ADDRESS">, opts: Eth1Options, signal?: AbortSignal) {
     this.deployBlock = opts.depositContractDeployBlock ?? 0;
     this.depositContractAddress = toHexString(config.DEPOSIT_CONTRACT_ADDRESS);
     if (opts.mode !== "rpcClient") {

--- a/packages/lodestar/src/eth1/provider/eth1Provider/index.ts
+++ b/packages/lodestar/src/eth1/provider/eth1Provider/index.ts
@@ -2,16 +2,16 @@ import {toHexString} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
 import {AbortSignal} from "@chainsafe/abort-controller";
 import {IChainConfig} from "@chainsafe/lodestar-config";
-import {chunkifyInclusiveRange} from "../../util/chunkify";
-import {linspace} from "../../util/numpy";
-import {retry} from "../../util/retry";
-import {depositEventTopics, parseDepositLog} from "../utils/depositContract";
-import {IEth1Provider} from "../interface";
-import {Eth1Options} from "../options";
-import {isValidAddress} from "../../util/address";
-import {EthJsonRpcBlockRaw} from "../interface";
-import {JsonRpcHttpClient} from "./jsonRpcHttpClient";
-import {isJsonRpcTruncatedError, quantityToNum, numToQuantity, dataToBytes} from "./utils";
+import {chunkifyInclusiveRange} from "../../../util/chunkify";
+import {linspace} from "../../../util/numpy";
+import {retry} from "../../../util/retry";
+import {depositEventTopics, parseDepositLog} from "../../utils/depositContract";
+import {IEth1Provider} from "../../interface";
+import {Eth1Options} from "../../options";
+import {isValidAddress} from "../../../util/address";
+import {EthJsonRpcBlockRaw} from "../../interface";
+import {JsonRpcHttpClient} from "../jsonRpcHttpClient";
+import {isJsonRpcTruncatedError, quantityToNum, numToQuantity, dataToBytes} from "../utils";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -43,11 +43,14 @@ export class Eth1Provider implements IEth1Provider {
 
   constructor(
     config: Pick<IChainConfig, "DEPOSIT_CONTRACT_ADDRESS">,
-    opts: Pick<Eth1Options, "depositContractDeployBlock" | "providerUrls">,
+    opts: Eth1Options,
     signal?: AbortSignal
   ) {
     this.deployBlock = opts.depositContractDeployBlock ?? 0;
     this.depositContractAddress = toHexString(config.DEPOSIT_CONTRACT_ADDRESS);
+    if (opts.mode !== "rpcClient") {
+      throw Error("Invalid eth1 mode");
+    }
     this.rpc = new JsonRpcHttpClient(opts.providerUrls, {
       signal,
       // Don't fallback with is truncated error. Throw early and let the retry on this class handle it

--- a/packages/lodestar/src/eth1/provider/eth1Provider/mock.ts
+++ b/packages/lodestar/src/eth1/provider/eth1Provider/mock.ts
@@ -1,0 +1,87 @@
+import {toHexString} from "@chainsafe/ssz";
+import {ZERO_HASH} from "../../../constants";
+import {EthJsonRpcBlockRaw, IEth1Provider} from "../../interface";
+
+export type Eth1ProviderMockOpts = {
+  startDifficulty: number;
+  difficultyIncrement: number;
+  mergeBlockDifficulty: number;
+  mergeBlockHash: string;
+};
+
+const defaultEth1ProviderMockOpts: Eth1ProviderMockOpts = {
+  startDifficulty: 0,
+  difficultyIncrement: 2,
+  mergeBlockDifficulty: 0,
+  mergeBlockHash: toHexString(ZERO_HASH),
+};
+
+export class Eth1ProviderMock implements IEth1Provider {
+  readonly deployBlock = 0;
+  private startDifficulty: number;
+  private difficultyIncrement: number;
+  private mergeBlockDifficulty: number;
+  private mergeBlockHash: string;
+  private blocks: EthJsonRpcBlockRaw[] = [];
+  private blocksByHash = new Map<string, EthJsonRpcBlockRaw>();
+  private latestBlockPointer = 0;
+
+  constructor(opts: Eth1ProviderMockOpts = defaultEth1ProviderMockOpts) {
+    this.startDifficulty = opts.startDifficulty;
+    this.difficultyIncrement = opts.difficultyIncrement;
+    this.mergeBlockDifficulty = opts.mergeBlockDifficulty;
+    this.mergeBlockHash = opts.mergeBlockHash;
+  }
+
+  async getBlockNumber(): Promise<number> {
+    return 0;
+  }
+
+  async getBlockByNumber(blockNumber: number | "latest"): Promise<EthJsonRpcBlockRaw | null> {
+    // On each call simulate that the eth1 chain advances 1 block with +1 totalDifficulty
+    if (blockNumber === "latest") return this.getLatestBlock(this.latestBlockPointer++);
+    return this.blocks[blockNumber];
+  }
+
+  async getBlockByHash(blockHashHex: string): Promise<EthJsonRpcBlockRaw | null> {
+    return this.blocksByHash.get(blockHashHex) ?? null;
+  }
+
+  async getBlocksByNumber(): Promise<never> {
+    throw Error("Not implemented");
+  }
+
+  async getDepositEvents(): Promise<never> {
+    throw Error("Not implemented");
+  }
+
+  async validateContract(): Promise<void> {
+    throw Error("Not implemented");
+  }
+
+  private getLatestBlock(i: number): EthJsonRpcBlockRaw {
+    const totalDifficulty = this.startDifficulty + i * this.difficultyIncrement;
+    const block: EthJsonRpcBlockRaw = {
+      number: toHex(i),
+      hash: this.getBlockHash(i + 1, totalDifficulty),
+      parentHash: toRootHex(i),
+      totalDifficulty: toHex(totalDifficulty),
+      timestamp: "0x0",
+    };
+    this.blocks.push(block);
+    this.blocksByHash.set(block.hash, block);
+    return block;
+  }
+
+  private getBlockHash(i: number, totalDifficulty: number): string {
+    return totalDifficulty === this.mergeBlockDifficulty ? this.mergeBlockHash : toRootHex(i);
+  }
+}
+
+function toHex(num: number | bigint): string {
+  return num < 0 ? "" + num : "0x" + num.toString(16);
+}
+
+export function toRootHex(num: number): string {
+  return "0x" + num.toString(16).padStart(64, "0");
+}

--- a/packages/lodestar/src/executionEngine/mock.ts
+++ b/packages/lodestar/src/executionEngine/mock.ts
@@ -96,7 +96,7 @@ export class ExecutionEngineMock implements IExecutionEngine {
     if (!this.knownBlocks.has(headBlockHash)) {
       throw Error(`Unknown headBlockHash ${headBlockHash}`);
     }
-    if (!this.knownBlocks.has(finalizedBlockHash)) {
+    if (finalizedBlockHash != ZERO_HASH_HEX && !this.knownBlocks.has(finalizedBlockHash)) {
       throw Error(`Unknown finalizedBlockHash ${finalizedBlockHash}`);
     }
 

--- a/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
@@ -32,7 +32,7 @@ describe("eth1 / Eth1Provider", function () {
   this.timeout("2 min");
 
   const eth1Options: Eth1Options = {
-    enabled: true,
+    mode: "rpcClient",
     providerUrls: [testnet.providerUrl],
     depositContractDeployBlock: testnet.depositBlock,
   };

--- a/packages/lodestar/test/e2e/eth1/eth1MergeBlockTracker.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1MergeBlockTracker.test.ts
@@ -18,7 +18,7 @@ describe("eth1 / Eth1MergeBlockTracker", function () {
   const logger = testLogger();
 
   const eth1Options: Eth1Options = {
-    enabled: true,
+    mode: "rpcClient",
     providerUrls: [testnet.providerUrl],
     depositContractDeployBlock: 0,
   };

--- a/packages/lodestar/test/e2e/eth1/eth1Provider.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1Provider.test.ts
@@ -12,7 +12,7 @@ describe("eth1 / Eth1Provider", function () {
   this.timeout("2 min");
 
   const eth1Options: Eth1Options = {
-    enabled: true,
+    mode: "rpcClient",
     providerUrls: [testnet.providerUrl],
     depositContractDeployBlock: 0,
   };

--- a/packages/lodestar/test/e2e/eth1/stream.test.ts
+++ b/packages/lodestar/test/e2e/eth1/stream.test.ts
@@ -18,6 +18,7 @@ describe("Eth1 streams", function () {
     return new Eth1Provider(
       config,
       {
+        mode: "rpcClient",
         providerUrls: [testnet.providerUrl],
         depositContractDeployBlock: testnet.depositBlock,
       },

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -349,7 +349,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
         api: {rest: {enabled: true} as RestApiOptions},
         sync: {isSingleNode: true},
         network: {disablePeerDiscovery: true},
-        eth1: {enabled: true, providerUrls: [jsonRpcUrl]},
+        eth1: {mode: "rpcClient", providerUrls: [jsonRpcUrl]},
         executionEngine: {urls: [engineApiUrl]},
       },
       validatorCount: validatorClientCount * validatorsPerClient,
@@ -400,7 +400,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
 
     // Assertions to make sure the end state is good
     // 1. The proper head is set
-    const rpc = new Eth1Provider({DEPOSIT_CONTRACT_ADDRESS: ZERO_HASH}, {providerUrls: [jsonRpcUrl]});
+    const rpc = new Eth1Provider({DEPOSIT_CONTRACT_ADDRESS: ZERO_HASH}, {mode: "rpcClient", providerUrls: [jsonRpcUrl]});
     const consensusHead = bn.chain.forkChoice.getHead();
     const executionHeadBlockNumber = await rpc.getBlockNumber();
     const executionHeadBlock = await rpc.getBlockByNumber(executionHeadBlockNumber);
@@ -563,7 +563,7 @@ async function isPortInUse(port: number): Promise<boolean> {
 async function getGenesisBlockHash(url: string, signal: AbortSignal): Promise<string> {
   const eth1Provider = new Eth1Provider(
     ({DEPOSIT_CONTRACT_ADDRESS: ZERO_HASH} as Partial<IChainConfig>) as IChainConfig,
-    {providerUrls: [url]},
+    {providerUrls: [url], mode: "rpcClient"},
     signal
   );
 

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -400,7 +400,10 @@ describe("executionEngine / ExecutionEngineHttp", function () {
 
     // Assertions to make sure the end state is good
     // 1. The proper head is set
-    const rpc = new Eth1Provider({DEPOSIT_CONTRACT_ADDRESS: ZERO_HASH}, {mode: "rpcClient", providerUrls: [jsonRpcUrl]});
+    const rpc = new Eth1Provider(
+      {DEPOSIT_CONTRACT_ADDRESS: ZERO_HASH},
+      {mode: "rpcClient", providerUrls: [jsonRpcUrl]}
+    );
     const consensusHead = bn.chain.forkChoice.getHead();
     const executionHeadBlockNumber = await rpc.getBlockNumber();
     const executionHeadBlock = await rpc.getBlockByNumber(executionHeadBlockNumber);

--- a/packages/lodestar/test/sim/singleNodeSingleThread.test.ts
+++ b/packages/lodestar/test/sim/singleNodeSingleThread.test.ts
@@ -1,5 +1,7 @@
+import {expect} from "chai";
 import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
-import {phase0} from "@chainsafe/lodestar-types";
+import {config as minimalConfig} from "@chainsafe/lodestar-config/default";
+import {merge, phase0} from "@chainsafe/lodestar-types";
 import {toHexString} from "@chainsafe/ssz";
 import {getDevBeaconNode} from "../utils/node/beacon";
 import {waitForEvent} from "../utils/events/resolver";
@@ -28,22 +30,57 @@ describe("Run single node single thread interop validators (no eth1) until check
   const validatorClientCount = 1;
   const validatorsPerClient = 32;
 
-  const testCases: {
+  type MergeOption = {
+    ttd: number;
+    mergeBlockDifficulty: number;
+    startDifficulty: number;
+    difficultyIncrement: number;
+  };
+
+  type TestTypeWithOptions = ({testType: "merge"} & MergeOption) | {testType: "phase0"} | {testType: "altair"};
+
+  const testCases: ({
     event: ChainEvent.justified | ChainEvent.finalized;
     altairEpoch: number;
     mergeEpoch: number;
-  }[] = [
+  } & TestTypeWithOptions)[] = [
     // phase0 fork only
-    {event: ChainEvent.finalized, altairEpoch: Infinity, mergeEpoch: Infinity},
+    {testType: "phase0", event: ChainEvent.finalized, altairEpoch: Infinity, mergeEpoch: Infinity},
     // altair fork only
-    {event: ChainEvent.finalized, altairEpoch: 0, mergeEpoch: Infinity},
+    {testType: "altair", event: ChainEvent.finalized, altairEpoch: 0, mergeEpoch: Infinity},
     // altair fork at epoch 2
-    {event: ChainEvent.finalized, altairEpoch: 2, mergeEpoch: Infinity},
-    // merge fork at epoch 0
-    {event: ChainEvent.finalized, altairEpoch: 0, mergeEpoch: 0},
+    {testType: "altair", event: ChainEvent.finalized, altairEpoch: 2, mergeEpoch: Infinity},
+    // merge fork at epoch 0, testType is quite confusing as we don't need ttd params, genesis state automatically mark "isMergeCompleted"
+    // hence no need to detect merge block in this test case
+    {testType: "altair", event: ChainEvent.finalized, altairEpoch: 0, mergeEpoch: 0},
+    // eth1 difficulty of blocks is 0 => -1; 1 => 1; 2 => 3; ...
+    // mergeBlock is block 1 since ttd = 0
+    // merge block is genesis block of execution mock => 1st block included is 1 at block 8
+    {
+      event: ChainEvent.finalized,
+      altairEpoch: 0,
+      mergeEpoch: 1,
+      testType: "merge",
+      ttd: 0,
+      mergeBlockDifficulty: 1,
+      startDifficulty: -1,
+      difficultyIncrement: 2,
+    },
+    // same to the above test with ttd 10, startDifficulty 0, mergeEpoch 2, altairEpoch 1
+    {
+      event: ChainEvent.finalized,
+      altairEpoch: 1,
+      mergeEpoch: 2,
+      testType: "merge",
+      ttd: 10,
+      mergeBlockDifficulty: 10,
+      startDifficulty: 0,
+      difficultyIncrement: 2,
+    },
   ];
 
-  for (const {event, altairEpoch, mergeEpoch} of testCases) {
+  for (const testCase of testCases) {
+    const {event, altairEpoch, mergeEpoch, testType} = testCase;
     it(`singleNode ${validatorClientCount} vc / ${validatorsPerClient} validator > until ${event}, altair ${altairEpoch} merge ${mergeEpoch}`, async function () {
       // Should reach justification in 3 epochs max, and finalization in 4 epochs max
       const expectedEpochsToFinish = event === ChainEvent.justified ? 3 : 4;
@@ -75,12 +112,31 @@ describe("Run single node single thread interop validators (no eth1) until check
       };
       const loggerNodeA = testLogger("Node-A", testLoggerOpts);
 
+      const genesisBlockHash = toHexString(INTEROP_BLOCK_HASH);
       const bn = await getDevBeaconNode({
-        params: {...testParams, ALTAIR_FORK_EPOCH: altairEpoch, MERGE_FORK_EPOCH: mergeEpoch},
+        params: {
+          ...testParams,
+          ALTAIR_FORK_EPOCH: altairEpoch,
+          MERGE_FORK_EPOCH: mergeEpoch,
+          SECONDS_PER_ETH1_BLOCK: 2,
+          TERMINAL_TOTAL_DIFFICULTY:
+            testType === "merge" ? BigInt(testCase.ttd) : minimalConfig.TERMINAL_TOTAL_DIFFICULTY,
+        },
         options: {
           api: {rest: {enabled: true} as RestApiOptions},
           sync: {isSingleNode: true},
-          executionEngine: {mode: "mock", genesisBlockHash: toHexString(INTEROP_BLOCK_HASH)},
+          executionEngine: {mode: "mock", genesisBlockHash},
+          eth1:
+            testType === "merge"
+              ? {
+                  mode: "mock",
+                  startDifficulty: testCase.startDifficulty,
+                  difficultyIncrement: testCase.difficultyIncrement,
+                  disableEth1DepositDataTracker: true,
+                  mergeBlockDifficulty: testCase.mergeBlockDifficulty,
+                  mergeBlockHash: genesisBlockHash,
+                }
+              : {mode: "disabled"},
         },
         validatorCount: validatorClientCount * validatorsPerClient,
         logger: loggerNodeA,
@@ -101,6 +157,46 @@ describe("Run single node single thread interop validators (no eth1) until check
       });
 
       await Promise.all(validators.map((v) => v.start()));
+
+      if (testType === "merge") {
+        // wait for merge block first
+        await waitForEvent<merge.SignedBeaconBlock>(
+          bn.chain.emitter,
+          ChainEvent.block,
+          timeout,
+          (signedBlock: merge.SignedBeaconBlock) => {
+            if (
+              !signedBlock.message.body.executionPayload ||
+              signedBlock.message.body.executionPayload.blockNumber === 0
+            ) {
+              // when mergeBlock is not found, blockNumber in executionPayload is always 0
+              return false;
+            } else {
+              // ExecutionEngineMock: 1st pow block to be included in executionPayload always have blockNumber 1
+              const slotDelta = testCase.mergeEpoch * SLOTS_PER_EPOCH - 1;
+              expect(signedBlock.message.body.executionPayload.blockNumber).to.be.equal(
+                signedBlock.message.slot - slotDelta,
+                "incorrect payload block number"
+              );
+              return true;
+            }
+          }
+        );
+        // confirm merge block
+        const mergeBlockRoot = bn.chain.eth1.getPowBlockAtTotalDifficulty();
+        if (!mergeBlockRoot) throw Error("merge block root not found");
+        const mergeBlock = await bn.chain.eth1.getPowBlock(toHexString(mergeBlockRoot));
+        if (!mergeBlock) throw Error("merge block not found");
+        expect(Number(mergeBlock.totalDifficulty)).to.be.equal(
+          testCase.mergeBlockDifficulty,
+          "merge block totalDifficulty is not correct"
+        );
+        expect(mergeBlock.blockhash).to.be.equal(genesisBlockHash, "merge block hash is not correct");
+        expect(mergeBlock.number).to.be.equal(
+          Math.ceil((testCase.mergeBlockDifficulty - testCase.startDifficulty) / testCase.difficultyIncrement),
+          "merge block number is not correct"
+        );
+      }
 
       try {
         await justificationEventListener;

--- a/packages/lodestar/test/utils/node/beacon.ts
+++ b/packages/lodestar/test/utils/node/beacon.ts
@@ -59,7 +59,7 @@ export async function getDevBeaconNode(
     deepmerge(
       {
         db: {name: tmpDir.name},
-        eth1: {enabled: false},
+        eth1: {mode: "disabled"},
         metrics: {enabled: false},
         network: {disablePeerDiscovery: true},
       } as Partial<IBeaconNodeOptions>,


### PR DESCRIPTION
**Motivation**

Part of #3275 

**Description**

+ Refactor eth1 option to "rpcClient" or "mock" (new) or "disabled"
+ Mock the Eth1Provider with 4 options
```typescript
export type Eth1ProviderMockOpts = {
  startDifficulty: number;
  difficultyIncrement: number;
  mergeBlockDifficulty: number;
  mergeBlockHash: string;
};
```
+ mergeBlockHash is the same to the `genesisBlockHash` option of `ExecutionEngineMock` in order for the mock execution engine to create payload from a known parent hash
+ More tests for merge: MERGE_EPOCH = 1, TERMINAL_TOTAL_DIFFICULTY = 0 and MERGE_EPOCH = 2, TERMINAL_TOTAL_DIFFICULTY = 10 
+ Assertion for the delta/offset between the consensus block slot and the eth1 block number in the payload
+ Assertion for the found merge block