### PR TITLE
Fix local testnet link in README files

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -37,7 +37,7 @@ You will need to go over the [specification](https://github.com/ethereum/eth2.0-
 ## Getting started
 
 - Follow the [installation guide](https://chainsafe.github.io/lodestar/installation) to install Lodestar.
-- Quickly try out the whole stack by [starting a local testnet](https://chainsafe.github.io/lodestar/usage).
+- Quickly try out the whole stack by [starting a local testnet](https://chainsafe.github.io/lodestar/usage/local).
 - View the [typedoc code docs](https://chainsafe.github.io/lodestar/packages).
 
 ## Contributors

--- a/packages/light-client/README.md
+++ b/packages/light-client/README.md
@@ -19,7 +19,7 @@ You will need to go over the [specification](https://github.com/ethereum/eth2.0-
 ## Getting started
 
 - Follow the [installation guide](https://chainsafe.github.io/lodestar/installation) to install Lodestar.
-- Quickly try out the whole stack by [starting a local testnet](https://chainsafe.github.io/lodestar/usage).
+- Quickly try out the whole stack by [starting a local testnet](https://chainsafe.github.io/lodestar/usage/local).
 - View the [typedoc code docs](https://chainsafe.github.io/lodestar/packages).
 
 ## Contributors


### PR DESCRIPTION
This corrects a couple outdated links for starting a local testnet.
Previous link https://chainsafe.github.io/lodestar/usage was outdated.
It has been split up across pages for public and local testnets.
