### PR TITLE
Use miliseconds in Eth1MergeBlockTracker setInterval

### DIFF
--- a/packages/lodestar/src/eth1/eth1MergeBlockTracker.ts
+++ b/packages/lodestar/src/eth1/eth1MergeBlockTracker.ts
@@ -156,11 +156,15 @@ export class Eth1MergeBlockTracker {
     });
 
     // 2. Subscribe to eth1 blocks and recursively fetch potential POW blocks
-    const intervalPoll = setInterval(() => {
-      this.pollLatestBlock().catch((e) => {
-        if (!isErrorAborted(e)) this.logger.error("Error fetching latest POW block", {}, e);
-      });
-    }, this.config.SECONDS_PER_ETH1_BLOCK);
+    const intervalPoll = setInterval(
+      () => {
+        this.pollLatestBlock().catch((e) => {
+          if (!isErrorAborted(e)) this.logger.error("Error fetching latest POW block", {}, e);
+        });
+      },
+      // Ensure setInterval is at minimum 1 second
+      (this.config.SECONDS_PER_ETH1_BLOCK ?? 1) * 1000
+    );
 
     // 3. Prune roughly every epoch
     const intervalPrune = setInterval(() => {


### PR DESCRIPTION
**Motivation**

Was using seconds as miliseconds causing a very fast loop searching for merge blocks

**Description**

Use miliseconds in Eth1MergeBlockTracker setInterval