### PR TITLE
Fix notifyConsensusValidated

### DIFF
--- a/packages/lodestar/src/chain/blocks/verifyBlock.ts
+++ b/packages/lodestar/src/chain/blocks/verifyBlock.ts
@@ -178,7 +178,7 @@ export async function verifyBlockStateTransition(
   } catch (e) {
     // Notify of consensus invalid block to execution client
     if (executionPayloadEnabled)
-      chain.executionEngine.notifyConsensusValidated(executionPayloadEnabled.blockHash, true).catch((e) => {
+      chain.executionEngine.notifyConsensusValidated(executionPayloadEnabled.blockHash, false).catch((e) => {
         chain.logger.error("Error on notifyConsensusValidated", {valid: false}, e);
       });
 

--- a/packages/lodestar/src/executionEngine/mock.ts
+++ b/packages/lodestar/src/executionEngine/mock.ts
@@ -156,10 +156,12 @@ export class ExecutionEngineMock implements IExecutionEngine {
    * 3. Client software MAY stop the corresponding building process after serving this call.
    */
   async getPayload(payloadId: PayloadId): Promise<merge.ExecutionPayload> {
-    const payload = this.preparingPayloads.get(Number(payloadId));
+    const payloadIdNbr = Number(payloadId);
+    const payload = this.preparingPayloads.get(payloadIdNbr);
     if (!payload) {
       throw Error(`Unknown payloadId ${payloadId}`);
     }
+    this.preparingPayloads.delete(payloadIdNbr);
     return payload;
   }
 }


### PR DESCRIPTION
**Motivation**

+ part of #3275

**Description**

+ when we failed to get through state transition, we want to `notifyConsensusValidated` as `false` to execution engine
+ also in executionEngine mock, delete from `preparingPayloads` in `getPayload()` as we don't need that anymore after this method