### PR TITLE
Add GENESIS_BASE_FEE_PER_GAS test case for hexEncoding

### DIFF
--- a/packages/lodestar/test/unit/eth1/hexEncoding.test.ts
+++ b/packages/lodestar/test/unit/eth1/hexEncoding.test.ts
@@ -35,6 +35,13 @@ describe("eth1 / hex encoding", () => {
         num: 0xff00,
         bigint: BigInt(0xff00),
       },
+      // GENESIS_BASE_FEE_PER_GAS
+      {
+        quantity: "0x3b9aca00",
+        bytes: "00ca9a3b00000000000000000000000000000000000000000000000000000000",
+        num: 1000000000,
+        bigint: BigInt(1000000000),
+      },
       {
         quantity: "0xaabb",
         bytes: "bbaa000000000000000000000000000000000000000000000000000000000000",


### PR DESCRIPTION
**Motivation**

part of #3275

**Description**

+ add a small test case for `GENESIS_BASE_FEE_PER_GAS` in the spec