### PR TITLE
Use uppercase for `/eth/v1/config/spec`

### DIFF
--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -20,6 +20,13 @@ export const Spec = new ContainerType<ISpec>({
     ...BeaconPreset.fields,
     ...ChainConfig.fields,
   },
+  casingMap: Object.keys({
+    ...BeaconPreset.fields,
+    ...ChainConfig.fields,
+  }).reduce((obj: Record<string, string>, key) => {
+    obj[key] = key;
+    return obj;
+  }, {}),
 });
 
 export type Api = {

--- a/packages/api/test/unit/config.test.ts
+++ b/packages/api/test/unit/config.test.ts
@@ -4,8 +4,15 @@ import {Api, ReqTypes, Spec} from "../../src/routes/config";
 import {getClient} from "../../src/client/config";
 import {getRoutes} from "../../src/server/config";
 import {runGenericServerTest} from "../utils/genericServerTest";
+import {expect} from "chai";
 
 describe("config", () => {
+  it("Spec casing check", function () {
+    const defaultSpec = Spec.defaultValue();
+    const specJson = Spec.toJson(defaultSpec) as Record<string, string>;
+    expect(specJson["SLOTS_PER_EPOCH"] !== undefined).to.be.true;
+  });
+
   runGenericServerTest<Api, ReqTypes>(config, getClient, getRoutes, {
     getDepositContract: {
       args: [],


### PR DESCRIPTION
Currently, the `/eth/v1/config/spec` REST endpoint provides the response
in lowercase snake_case format. However, the specification defines this
to include the spec constants as is, without modifications. This patch
corrects this disparity using a `casingMap` applied to the `Spec` type
to force the constants to be sent in CONSTANT_CASE.
