### PR TITLE
Implement optimistic sync post-merge

### DIFF
--- a/packages/lodestar/src/chain/blocks/types.ts
+++ b/packages/lodestar/src/chain/blocks/types.ts
@@ -29,6 +29,10 @@ export type PartiallyVerifiedBlockFlags = FullyVerifiedBlockFlags & {
    * Metadata: `true` if all the signatures including the proposer signature have been verified
    */
   validSignatures?: boolean;
+  /**
+   * From RangeSync module, we won't attest to this block so it's okay to ignore a SYNCING message from execution layer
+   */
+  fromRangeSync?: boolean;
 };
 
 /**

--- a/packages/lodestar/src/chain/errors/blockError.ts
+++ b/packages/lodestar/src/chain/errors/blockError.ts
@@ -57,6 +57,8 @@ export enum BlockErrorCode {
   TRANSACTIONS_TOO_BIG = "BLOCK_ERROR_TRANSACTIONS_TOO_BIG",
   /** Execution engine returned not valid after executePayload() call */
   EXECUTION_PAYLOAD_NOT_VALID = "BLOCK_ERROR_EXECUTION_PAYLOAD_NOT_VALID",
+  /** Execution engine is syncing */
+  EXECUTION_ENGINE_SYNCING = "BLOCK_ERROR_EXECUTION_ENGINE_SYNCING",
 }
 
 export type BlockErrorType =
@@ -89,7 +91,8 @@ export type BlockErrorType =
   | {code: BlockErrorCode.TOO_MUCH_GAS_USED; gasUsed: number; gasLimit: number}
   | {code: BlockErrorCode.SAME_PARENT_HASH; blockHash: RootHex}
   | {code: BlockErrorCode.TRANSACTIONS_TOO_BIG; size: number; max: number}
-  | {code: BlockErrorCode.EXECUTION_PAYLOAD_NOT_VALID};
+  | {code: BlockErrorCode.EXECUTION_PAYLOAD_NOT_VALID}
+  | {code: BlockErrorCode.EXECUTION_ENGINE_SYNCING};
 
 export class BlockGossipError extends GossipActionError<BlockErrorType> {}
 

--- a/packages/lodestar/src/executionEngine/http.ts
+++ b/packages/lodestar/src/executionEngine/http.ts
@@ -67,14 +67,13 @@ export class ExecutionEngineHttp implements IExecutionEngine {
       params: [serializeExecutionPayload(executionPayload)],
     });
 
-    switch (status) {
-      case ExecutePayloadStatus.VALID:
-        return ExecutePayloadStatus.VALID;
-      case ExecutePayloadStatus.INVALID:
-        return ExecutePayloadStatus.INVALID;
-      case ExecutePayloadStatus.SYNCING:
-        return ExecutePayloadStatus.SYNCING;
+    // Validate status is known
+    const statusEnum = ExecutePayloadStatus[status];
+    if (statusEnum === undefined) {
+      throw Error(`Unknown status ${status}`);
     }
+
+    return statusEnum;
   }
 
   /**

--- a/packages/lodestar/src/executionEngine/interface.ts
+++ b/packages/lodestar/src/executionEngine/interface.ts
@@ -4,6 +4,15 @@ import {Bytes32, merge, Root, ExecutionAddress, RootHex} from "@chainsafe/lodest
 // Since we do no processing with this id, we have no need to deserialize it
 export type PayloadId = string;
 
+export enum ExecutePayloadStatus {
+  /** given payload is valid */
+  VALID = "VALID",
+  /** given payload is invalid */
+  INVALID = "INVALID",
+  /** sync process is in progress */
+  SYNCING = "SYNCING",
+}
+
 /**
  * Execution engine represents an abstract protocol to interact with execution clients. Potential transports include:
  * - JSON RPC over network
@@ -20,7 +29,7 @@ export interface IExecutionEngine {
    *
    * Should be called in advance before, after or in parallel to block processing
    */
-  executePayload(executionPayload: merge.ExecutionPayload): Promise<boolean>;
+  executePayload(executionPayload: merge.ExecutionPayload): Promise<ExecutePayloadStatus>;
 
   /**
    * Signals that the beacon block containing the execution payload is valid with respect to the consensus rule set.

--- a/packages/lodestar/src/executionEngine/mock.ts
+++ b/packages/lodestar/src/executionEngine/mock.ts
@@ -2,7 +2,7 @@ import crypto from "crypto";
 import {Bytes32, merge, Root, ExecutionAddress, RootHex} from "@chainsafe/lodestar-types";
 import {toHexString} from "@chainsafe/ssz";
 import {ZERO_HASH, ZERO_HASH_HEX} from "../constants";
-import {IExecutionEngine, PayloadId} from "./interface";
+import {ExecutePayloadStatus, IExecutionEngine, PayloadId} from "./interface";
 import {BYTES_PER_LOGS_BLOOM} from "@chainsafe/lodestar-params";
 
 const INTEROP_GAS_LIMIT = 30e6;
@@ -54,15 +54,15 @@ export class ExecutionEngineMock implements IExecutionEngine {
    * 6. If the parent block is a PoW block as per EIP-3675 definition, then all missing dependencies of the payload MUST be pulled from the network and validated accordingly. The call MUST be responded according to the validity of the payload and the chain of its ancestors.
    *    If the parent block is a PoS block as per EIP-3675 definition, then the call MAY be responded with SYNCING status and sync process SHOULD be initiated accordingly.
    */
-  async executePayload(executionPayload: merge.ExecutionPayload): Promise<boolean> {
+  async executePayload(executionPayload: merge.ExecutionPayload): Promise<ExecutePayloadStatus> {
     // Only validate that parent is known
     if (!this.knownBlocks.has(toHexString(executionPayload.parentHash))) {
-      return false;
+      return ExecutePayloadStatus.INVALID;
     }
 
     // Append to pending payloads, awaiting notifyConsensusValidated and return valid
     this.pendingPayloads.set(toHexString(executionPayload.blockHash), executionPayload);
-    return true;
+    return ExecutePayloadStatus.VALID;
   }
 
   /**

--- a/packages/lodestar/src/sync/range/range.ts
+++ b/packages/lodestar/src/sync/range/range.ts
@@ -192,6 +192,8 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
       ignoreIfKnown: true,
       // Ignore WOULD_REVERT_FINALIZED_SLOT error, continue with the next block in chain segment
       ignoreIfFinalized: true,
+      // We won't attest to this block so it's okay to ignore a SYNCING message from execution layer
+      fromRangeSync: true,
     };
 
     if (this.opts?.disableProcessAsChainSegment) {

--- a/packages/lodestar/test/unit/executionEngine/http.test.ts
+++ b/packages/lodestar/test/unit/executionEngine/http.test.ts
@@ -144,9 +144,9 @@ describe("ExecutionEngine / http", () => {
     };
     returnValue = {jsonrpc: "2.0", id: 67, result: {status: "VALID"}};
 
-    const isValid = await executionEngine.executePayload(parseExecutionPayload(request.params[0]));
+    const status = await executionEngine.executePayload(parseExecutionPayload(request.params[0]));
 
-    expect(isValid).to.equal(true, "Wrong returned execute payload result");
+    expect(status).to.equal("VALID", "Wrong returned execute payload result");
     expect(reqJsonRpcPayload).to.deep.equal(request, "Wrong request JSON RPC payload");
   });
 


### PR DESCRIPTION
**Motivation**

It's okay to ignore SYNCING status because:
- We MUST verify execution payloads of blocks we attest
- We are NOT REQUIRED to check the execution payload of blocks we don't attest. 

When EL syncs from genesis to a chain post-merge, it doesn't know what the head, CL knows. However, we must verify (complete this fn) and import a block to sync. Since we are syncing we only need to verify consensus and trust that whatever the chain agrees is valid, is valid; no need to verify. When we verify consensus up to the head we notify forkchoice update head and then EL can sync to our head. At that point regular EL sync kicks in and it does verify the execution payload (EL blocks). If after syncing EL gets to an invalid payload or we can prepare payloads on what we consider the head that's a critical error

**Description**

Accept SYNCING status on execution payload verification only when we are syncing