### PR TITLE
Use clock epoch to compute ENR forkDigest

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -3,11 +3,10 @@
  */
 
 import fs from "fs";
-import {ForkName} from "@chainsafe/lodestar-params";
 import {CachedBeaconState, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {allForks, ForkDigest, Number64, Root, phase0, Slot} from "@chainsafe/lodestar-types";
+import {allForks, Number64, Root, phase0, Slot} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {fromHexString, TreeBacked} from "@chainsafe/ssz";
 import {LightClientUpdater} from "@chainsafe/lodestar-light-client/server";
@@ -248,19 +247,6 @@ export class BeaconChain implements IBeaconChain {
 
   async processChainSegment(blocks: allForks.SignedBeaconBlock[], flags?: PartiallyVerifiedBlockFlags): Promise<void> {
     return await this.blockProcessor.processChainSegment(blocks.map((block) => ({...flags, block})));
-  }
-
-  getHeadForkName(): ForkName {
-    return this.config.getForkName(this.forkChoice.getHead().slot);
-  }
-  getClockForkName(): ForkName {
-    return this.config.getForkName(this.clock.currentSlot);
-  }
-  getHeadForkDigest(): ForkDigest {
-    return this.config.forkName2ForkDigest(this.getHeadForkName());
-  }
-  getClockForkDigest(): ForkDigest {
-    return this.config.forkName2ForkDigest(this.getClockForkName());
   }
 
   getStatus(): phase0.Status {

--- a/packages/lodestar/src/chain/emitter.ts
+++ b/packages/lodestar/src/chain/emitter.ts
@@ -1,8 +1,7 @@
 import {EventEmitter} from "events";
 import StrictEventEmitter from "strict-event-emitter-types";
 
-import {ForkName} from "@chainsafe/lodestar-params";
-import {phase0, Epoch, Slot, Version, allForks} from "@chainsafe/lodestar-types";
+import {phase0, Epoch, Slot, allForks} from "@chainsafe/lodestar-types";
 import {CheckpointWithHex, IProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {AttestationError, BlockError} from "./errors";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
@@ -48,12 +47,6 @@ export enum ChainEvent {
    * This event is a derivative of the `checkpoint` event. Eg: in cases where the `checkpoint` state has an updated finalized checkpoint, this event is triggered.
    */
   finalized = "finalized",
-  /**
-   * This event signals that the chain has reached a new fork version.
-   *
-   * This event is guaranteed to be triggered after processing any block or checkpoint that updates the `state.fork.currentVersion` as a result of processing.
-   */
-  forkVersion = "forkVersion",
   /**
    * This event signals the start of a new slot, and that subsequent calls to `clock.currentSlot` will equal `slot`.
    *
@@ -116,7 +109,6 @@ export interface IChainEvents {
   [ChainEvent.checkpoint]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<allForks.BeaconState>) => void;
   [ChainEvent.justified]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<allForks.BeaconState>) => void;
   [ChainEvent.finalized]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<allForks.BeaconState>) => void;
-  [ChainEvent.forkVersion]: (version: Version, fork: ForkName) => void;
 
   [ChainEvent.clockSlot]: (slot: Slot) => void;
   [ChainEvent.clockEpoch]: (epoch: Epoch) => void;

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -54,7 +54,6 @@ export function handleChainEvents(this: BeaconChain, signal: AbortSignal): void 
     [ChainEvent.forkChoiceHead]: onForkChoiceHead,
     [ChainEvent.forkChoiceJustified]: onForkChoiceJustified,
     [ChainEvent.forkChoiceReorg]: onForkChoiceReorg,
-    [ChainEvent.forkVersion]: onForkVersion,
     [ChainEvent.justified]: onJustified,
   };
 

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -1,4 +1,3 @@
-import {ForkName} from "@chainsafe/lodestar-params";
 import {allForks, Number64, Root, phase0, Slot} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
@@ -90,15 +89,6 @@ export interface IBeaconChain {
   processBlock(signedBlock: allForks.SignedBeaconBlock, flags?: PartiallyVerifiedBlockFlags): Promise<void>;
   /** Process a chain of blocks until complete */
   processChainSegment(signedBlocks: allForks.SignedBeaconBlock[], flags?: PartiallyVerifiedBlockFlags): Promise<void>;
-
-  /** Get the ForkName from the head state */
-  getHeadForkName(): ForkName;
-  /** Get the ForkName from the current slot */
-  getClockForkName(): ForkName;
-  /** Get ForkDigest from the head state */
-  getHeadForkDigest(): phase0.ForkDigest;
-  /** Get ForkDigest from the current slot */
-  getClockForkDigest(): phase0.ForkDigest;
 
   getStatus(): phase0.Status;
 

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -146,7 +146,6 @@ export class Network implements INetwork {
     // Must goodbye and disconnect before stopping libp2p
     await this.peerManager.goodbyeAndDisconnectAllPeers();
     this.peerManager.stop();
-    this.metadata.stop();
     this.gossip.stop();
     this.reqResp.stop();
     this.attnetsService.stop();
@@ -264,6 +263,12 @@ export class Network implements INetwork {
           if (this.isSubscribedToGossipCoreTopics()) this.subscribeCoreTopicsAtFork(nextFork);
           this.attnetsService.subscribeSubnetsToNextFork(nextFork);
           this.syncnetsService.subscribeSubnetsToNextFork(nextFork);
+        }
+
+        // On fork transition
+        if (epoch === forkEpoch) {
+          // updateEth2Field() MUST be called with clock epoch, onEpoch event is emitted in response to clock events
+          this.metadata.updateEth2Field(epoch);
         }
 
         // After fork transition

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -2,7 +2,7 @@ import {AbortController} from "@chainsafe/abort-controller";
 import sinon from "sinon";
 
 import {toHexString, TreeBacked} from "@chainsafe/ssz";
-import {allForks, ForkDigest, Number64, Root, Slot, ssz, Uint16, Uint64} from "@chainsafe/lodestar-types";
+import {allForks, Number64, Root, Slot, ssz, Uint16, Uint64} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {CachedBeaconState, createCachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
@@ -17,7 +17,6 @@ import {LocalClock} from "../../../../src/chain/clock";
 import {IStateRegenerator, StateRegenerator} from "../../../../src/chain/regen";
 import {StubbedBeaconDb} from "../../stub";
 import {IBlsVerifier, BlsSingleThreadVerifier} from "../../../../src/chain/bls";
-import {ForkName} from "@chainsafe/lodestar-params";
 import {AttestationPool} from "../../../../src/chain/opPools/attestationPool";
 import {
   SeenAggregators,
@@ -140,19 +139,6 @@ export class MockBeaconChain implements IBeaconChain {
     return await Promise.all(slots.map(this.getCanonicalBlockAtSlot));
   }
 
-  getHeadForkDigest(): ForkDigest {
-    return ssz.ForkDigest.defaultValue();
-  }
-  getClockForkDigest(): ForkDigest {
-    return ssz.ForkDigest.defaultValue();
-  }
-  getHeadForkName(): ForkName {
-    return ForkName.phase0;
-  }
-  getClockForkName(): ForkName {
-    return ForkName.phase0;
-  }
-
   getGenesisTime(): Number64 {
     return Math.floor(Date.now() / 1000);
   }
@@ -170,7 +156,7 @@ export class MockBeaconChain implements IBeaconChain {
 
   getStatus(): phase0.Status {
     return {
-      forkDigest: this.getHeadForkDigest(),
+      forkDigest: Buffer.alloc(4),
       finalizedRoot: Buffer.alloc(32),
       finalizedEpoch: 0,
       headRoot: Buffer.alloc(32),


### PR DESCRIPTION
**Motivation**

We are having peering issues in merge interop hacknet v2. Upon inspection we realize that our ENR is wrong, and differs from most peers.

**Description**

- Use clock epoch to compute ENR forkDigest

From spec:

> fork_digest is compute_fork_digest(current_fork_version, genesis_validators_root) where
> - current_fork_version is the fork version at the node's current epoch defined by the wall-clock time (not necessarily the epoch to which the node is sync)
> - genesis_validators_root is the static Root found in state.genesis_validators_root

