### PR TITLE
Add connectToDiscv5Bootnodes option

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -27,6 +27,7 @@ export function parseArgs(args: INetworkArgs): IBeaconNodeOptions["network"] {
     bootMultiaddrs: args["network.bootMultiaddrs"],
     localMultiaddrs: args["network.localMultiaddrs"],
     subscribeAllSubnets: args["network.subscribeAllSubnets"],
+    connectToDiscv5Bootnodes: args["network.connectToDiscv5Bootnodes"],
   };
 }
 

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -10,6 +10,7 @@ export interface INetworkArgs {
   "network.bootMultiaddrs": string[];
   "network.localMultiaddrs": string[];
   "network.subscribeAllSubnets": boolean;
+  "network.connectToDiscv5Bootnodes": boolean;
 }
 
 export function parseArgs(args: INetworkArgs): IBeaconNodeOptions["network"] {
@@ -84,6 +85,13 @@ export const options: ICliCommandOptions<INetworkArgs> = {
     type: "boolean",
     description: "Subscribe to all subnets regardless of validator count",
     defaultDescription: String(defaultOptions.network.subscribeAllSubnets === true),
+    group: "network",
+  },
+
+  "network.connectToDiscv5Bootnodes": {
+    type: "boolean",
+    description: "Attempt direct connection to discv5 bootnodes from network.discv5.bootEnrs option",
+    defaultDescription: String(defaultOptions.network.connectToDiscv5Bootnodes === true),
     group: "network",
   },
 };

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -44,6 +44,7 @@ describe("options / beaconNodeOptions", () => {
       "network.bootMultiaddrs": [],
       "network.localMultiaddrs": [],
       "network.subscribeAllSubnets": true,
+      "network.connectToDiscv5Bootnodes": true,
 
       "sync.isSingleNode": true,
       "sync.disableProcessAsChainSegment": true,
@@ -98,6 +99,7 @@ describe("options / beaconNodeOptions", () => {
         bootMultiaddrs: [],
         localMultiaddrs: [],
         subscribeAllSubnets: true,
+        connectToDiscv5Bootnodes: true,
       },
       sync: {
         isSingleNode: true,

--- a/packages/lodestar/src/network/options.ts
+++ b/packages/lodestar/src/network/options.ts
@@ -3,9 +3,10 @@ import {PeerManagerOpts} from "./peers";
 
 export interface INetworkOptions extends PeerManagerOpts {
   localMultiaddrs: string[];
-  bootMultiaddrs: string[];
+  bootMultiaddrs?: string[];
   discv5?: IDiscv5DiscoveryInputOptions;
   subscribeAllSubnets?: boolean;
+  connectToDiscv5Bootnodes?: boolean;
 }
 
 export const defaultDiscv5Options: IDiscv5DiscoveryInputOptions = {


### PR DESCRIPTION
**Motivation**

Necessary in merge interop to connect to bootnodes without having to pass the bootnode's data in a different format

**Description**

- Add connectToDiscv5Bootnodes option
- If true, append parsed bootnode ENRs to bootMultiaddrs