### PR TITLE
Add isSyncing field to API return

### DIFF
--- a/packages/api/src/routes/node.ts
+++ b/packages/api/src/routes/node.ts
@@ -55,6 +55,8 @@ export type SyncingStatus = {
   headSlot: Slot;
   /** How many slots node needs to process to reach head. 0 if synced. */
   syncDistance: Slot;
+  /** Set to true if the node is syncing, false if the node is synced. */
+  isSyncing: boolean;
 };
 
 /**

--- a/packages/api/test/unit/node.test.ts
+++ b/packages/api/test/unit/node.test.ts
@@ -53,7 +53,7 @@ describe("node", () => {
     },
     getSyncingStatus: {
       args: [],
-      res: {data: {headSlot: 1, syncDistance: 2}},
+      res: {data: {headSlot: 1, syncDistance: 2, isSyncing: false}},
     },
     getHealth: {
       args: [],

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -73,11 +73,13 @@ export class BeaconSync implements IBeaconSync {
         return {
           headSlot: headSlot,
           syncDistance: currentSlot - headSlot,
+          isSyncing: true,
         };
       case SyncState.Synced:
         return {
           headSlot: headSlot,
           syncDistance: 0,
+          isSyncing: false,
         };
       default:
         throw new Error("Node is stopped, cannot get sync status");

--- a/packages/lodestar/test/unit/api/impl/node/node.test.ts
+++ b/packages/lodestar/test/unit/api/impl/node/node.test.ts
@@ -146,17 +146,6 @@ describe("node api implementation", function () {
     });
   });
 
-  describe("getSyncStatus", function () {
-    it("success", async function () {
-      syncStub.getSyncStatus.returns({
-        headSlot: 2,
-        syncDistance: 1,
-      });
-      const {data: syncStatus} = await api.getSyncingStatus();
-      expect(syncStatus).to.deep.equal({headSlot: 2, syncDistance: 1});
-    });
-  });
-
   describe("getVersion", function () {
     it("success", async function () {
       const {data} = await api.getNodeVersion();


### PR DESCRIPTION
**Motivation**

Conform to API standard https://github.com/ethereum/beacon-APIs/blob/22b0d759856fbd075d6102a729ab5022914f5945/apis/node/syncing.yaml#L28

**Description**

- Add isSyncing field to API return
