### PR TITLE
Return detailed version string in node/version route

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -33,6 +33,8 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
   beaconNodeOptions.set({chain: {persistInvalidSszObjectsDir: beaconPaths.persistInvalidSszObjectsDir}});
   // Add metrics metadata to show versioning + network info in Prometheus + Grafana
   beaconNodeOptions.set({metrics: {metadata: {...gitData, version, network: args.network}}});
+  // Add detailed version string for API node/version endpoint
+  beaconNodeOptions.set({api: {version: version}});
 
   // ENR setup
   const peerId = await readPeerId(beaconPaths.peerIdFile);

--- a/packages/lodestar/src/api/impl/api.ts
+++ b/packages/lodestar/src/api/impl/api.ts
@@ -18,7 +18,7 @@ export function getApi(opts: IApiOptions, modules: ApiModules): Api {
     events: getEventsApi(modules),
     lightclient: getLightclientApi(opts, modules),
     lodestar: getLodestarApi(modules),
-    node: getNodeApi(modules),
+    node: getNodeApi(opts, modules),
     validator: getValidatorApi(modules),
   };
 }

--- a/packages/lodestar/src/api/impl/node/index.ts
+++ b/packages/lodestar/src/api/impl/node/index.ts
@@ -3,8 +3,9 @@ import {createKeypairFromPeerId} from "@chainsafe/discv5";
 import {formatNodePeer} from "./utils";
 import {ApiError} from "../errors";
 import {ApiModules} from "../types";
+import {IApiOptions} from "../../options";
 
-export function getNodeApi({network, sync}: Pick<ApiModules, "network" | "sync">): routes.node.Api {
+export function getNodeApi(opts: IApiOptions, {network, sync}: Pick<ApiModules, "network" | "sync">): routes.node.Api {
   return {
     async getNetworkIdentity() {
       const enr = network.getEnr();
@@ -64,7 +65,7 @@ export function getNodeApi({network, sync}: Pick<ApiModules, "network" | "sync">
     async getNodeVersion() {
       return {
         data: {
-          version: `Lodestar/${process.env.npm_package_version || "dev"}`,
+          version: `Lodestar/${opts.version || "dev"}`,
         },
       };
     },

--- a/packages/lodestar/src/api/options.ts
+++ b/packages/lodestar/src/api/options.ts
@@ -3,9 +3,11 @@ import {restApiOptionsDefault, RestApiOptions} from "./rest";
 export interface IApiOptions {
   maxGindicesInProof?: number;
   rest: RestApiOptions;
+  version?: string;
 }
 
 export const defaultApiOptions: IApiOptions = {
   maxGindicesInProof: 512,
   rest: restApiOptionsDefault,
+  version: "dev",
 };

--- a/packages/lodestar/test/unit/api/impl/node/node.test.ts
+++ b/packages/lodestar/test/unit/api/impl/node/node.test.ts
@@ -11,6 +11,7 @@ import {expect, use} from "chai";
 import chaiAsPromised from "chai-as-promised";
 import {Multiaddr} from "multiaddr";
 import {MetadataController} from "../../../../../src/network/metadata";
+import {defaultApiOptions} from "../../../../../src/api/options";
 import {altair} from "@chainsafe/lodestar-types";
 import {PeerStatus, PeerDirection} from "../../../../../src/network";
 import {routes} from "@chainsafe/lodestar-api";
@@ -42,7 +43,7 @@ describe("node api implementation", function () {
   beforeEach(async function () {
     networkStub = sinon.createStubInstance(Network);
     syncStub = sinon.createStubInstance(BeaconSync);
-    api = getNodeApi({network: networkStub, sync: syncStub});
+    api = getNodeApi(defaultApiOptions, {network: networkStub, sync: syncStub});
     peerId = await PeerId.create({keyType: "secp256k1"});
     sinon.stub(networkStub, "peerId").get(() => peerId);
     sinon.stub(networkStub, "localMultiaddrs").get(() => [new Multiaddr("/ip4/127.0.0.1/tcp/36000")]);
@@ -160,7 +161,7 @@ describe("node api implementation", function () {
   describe("getVersion", function () {
     it("success", async function () {
       const {data} = await api.getNodeVersion();
-      expect(data.version.startsWith("Lodestar")).to.be.true;
+      expect(data.version.startsWith("Lodestar"), `data must start with 'Lodestar': ${data.version}`).to.be.true;
     });
   });
 });


### PR DESCRIPTION
**Motivation**

Returned version string from `/eth/v1/node/version` is dev in dockerized setups.

**Description**

- Return detailed version string in node/version route