### PR TITLE
casingMap update for all ssz containers

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -41,7 +41,7 @@
     "@chainsafe/lodestar-types": "^0.31.0",
     "@chainsafe/lodestar-utils": "^0.31.0",
     "@chainsafe/persistent-merkle-tree": "^0.3.7",
-    "@chainsafe/ssz": "^0.8.18",
+    "@chainsafe/ssz": "^0.8.19",
     "cross-fetch": "^3.1.4",
     "eventsource": "^1.1.0",
     "qs": "^6.10.1"

--- a/packages/api/src/routes/beacon/block.ts
+++ b/packages/api/src/routes/beacon/block.ts
@@ -155,6 +155,8 @@ export function getReturnTypes(): ReturnTypes<Api> {
       canonical: ssz.Boolean,
       header: ssz.phase0.SignedBeaconBlockHeader,
     },
+    //from beacon apis
+    expectedCase: "notransform",
   });
 
   return {

--- a/packages/api/src/routes/beacon/state.ts
+++ b/packages/api/src/routes/beacon/state.ts
@@ -232,6 +232,12 @@ export function getReturnTypes(): ReturnTypes<Api> {
       currentJustified: ssz.phase0.Checkpoint,
       finalized: ssz.phase0.Checkpoint,
     },
+    // From beacon apis
+    casingMap: {
+      previousJustified: "previous_justified",
+      currentJustified: "current_justified",
+      finalized: "finalized",
+    },
   });
 
   const ValidatorResponse = new ContainerType<ValidatorResponse>({
@@ -241,6 +247,8 @@ export function getReturnTypes(): ReturnTypes<Api> {
       status: new StringType<ValidatorStatus>(),
       validator: ssz.phase0.Validator,
     },
+    // From beacon apis
+    expectedCase: "notransform",
   });
 
   const ValidatorBalance = new ContainerType<ValidatorBalance>({
@@ -248,6 +256,8 @@ export function getReturnTypes(): ReturnTypes<Api> {
       index: ssz.ValidatorIndex,
       balance: ssz.Number64,
     },
+    // From beacon apis
+    expectedCase: "notransform",
   });
 
   const EpochCommitteeResponse = new ContainerType<EpochCommitteeResponse>({

--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -20,13 +20,7 @@ export const Spec = new ContainerType<ISpec>({
     ...BeaconPreset.fields,
     ...ChainConfig.fields,
   },
-  casingMap: Object.keys({
-    ...BeaconPreset.fields,
-    ...ChainConfig.fields,
-  }).reduce((obj: Record<string, string>, key) => {
-    obj[key] = key;
-    return obj;
-  }, {}),
+  expectedCase: "notransform",
 });
 
 export type Api = {
@@ -75,6 +69,11 @@ export function getReturnTypes(): ReturnTypes<Api> {
     fields: {
       chainId: ssz.Number64,
       address: new ByteVectorType({length: 20}),
+    },
+    // From beacon apis
+    casingMap: {
+      chainId: "chain_id",
+      address: "address",
     },
   });
 

--- a/packages/api/src/routes/debug.ts
+++ b/packages/api/src/routes/debug.ts
@@ -120,6 +120,8 @@ export function getReturnTypes(): ReturnTypes<Api> {
       slot: ssz.Slot,
       root: stringType,
     },
+    // From beacon apis
+    expectedCase: "notransform",
   });
 
   return {

--- a/packages/api/src/routes/events.ts
+++ b/packages/api/src/routes/events.ts
@@ -88,6 +88,15 @@ export function getTypeByEvent(): {[K in EventType]: Type<EventData[K]>} {
         previousDutyDependentRoot: stringType,
         currentDutyDependentRoot: stringType,
       },
+      // From beacon apis eventstream
+      casingMap: {
+        slot: "slot",
+        block: "block",
+        state: "state",
+        epochTransition: "epoch_transition",
+        previousDutyDependentRoot: "previous_duty_dependent_root",
+        currentDutyDependentRoot: "current_duty_dependent_root",
+      },
     }),
 
     [EventType.block]: new ContainerType<EventData[EventType.block]>({
@@ -95,6 +104,8 @@ export function getTypeByEvent(): {[K in EventType]: Type<EventData[K]>} {
         slot: ssz.Slot,
         block: stringType,
       },
+      // From beacon apis eventstream
+      expectedCase: "notransform",
     }),
 
     [EventType.attestation]: ssz.phase0.Attestation,
@@ -106,6 +117,8 @@ export function getTypeByEvent(): {[K in EventType]: Type<EventData[K]>} {
         state: stringType,
         epoch: ssz.Epoch,
       },
+      // From beacon apis eventstream
+      expectedCase: "notransform",
     }),
 
     [EventType.chainReorg]: new ContainerType<EventData[EventType.chainReorg]>({
@@ -117,6 +130,16 @@ export function getTypeByEvent(): {[K in EventType]: Type<EventData[K]>} {
         oldHeadState: stringType,
         newHeadState: stringType,
         epoch: ssz.Epoch,
+      },
+      // From beacon apis eventstream
+      casingMap: {
+        slot: "slot",
+        depth: "depth",
+        oldHeadBlock: "old_head_block",
+        newHeadBlock: "new_head_block",
+        oldHeadState: "old_head_state",
+        newHeadState: "new_head_state",
+        epoch: "epoch",
       },
     }),
   };

--- a/packages/api/src/routes/lodestar.ts
+++ b/packages/api/src/routes/lodestar.ts
@@ -169,6 +169,13 @@ export function getReturnTypes(): ReturnTypes<Api> {
       data: new ByteVectorType({length: 256}),
       addedTimeMs: ssz.Slot,
     },
+    // Custom type, not in the consensus specs
+    casingMap: {
+      topic: "topic",
+      receivedFrom: "received_from",
+      data: "data",
+      addedTimeMs: "added_time_ms",
+    },
   });
 
   return {

--- a/packages/api/src/routes/node.ts
+++ b/packages/api/src/routes/node.ts
@@ -171,6 +171,14 @@ export function getReturnTypes(): ReturnTypes<Api> {
       discoveryAddresses: ArrayOf(stringType),
       metadata: ssz.altair.Metadata,
     },
+    // From beacon apis
+    casingMap: {
+      peerId: "peer_id",
+      enr: "enr",
+      p2pAddresses: "p2p_addresses",
+      discoveryAddresses: "discovery_addresses",
+      metadata: "metadata",
+    },
   });
 
   return {

--- a/packages/api/src/routes/validator.ts
+++ b/packages/api/src/routes/validator.ts
@@ -246,6 +246,14 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
       slot: ssz.Slot,
       isAggregator: ssz.Boolean,
     },
+    // From beacon apis
+    casingMap: {
+      validatorIndex: "validator_index",
+      committeeIndex: "committee_index",
+      committeesAtSlot: "committees_at_slot",
+      slot: "slot",
+      isAggregator: "is_aggregator",
+    },
   });
 
   const SyncCommitteeSubscription = new ContainerType<SyncCommitteeSubscription>({
@@ -253,6 +261,12 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
       validatorIndex: ssz.ValidatorIndex,
       syncCommitteeIndices: ArrayOf(ssz.CommitteeIndex),
       untilEpoch: ssz.Epoch,
+    },
+    // From beacon apis
+    casingMap: {
+      validatorIndex: "validator_index",
+      syncCommitteeIndices: "sync_committee_indices",
+      untilEpoch: "until_epoch",
     },
   });
 
@@ -349,6 +363,16 @@ export function getReturnTypes(): ReturnTypes<Api> {
       validatorCommitteeIndex: ssz.Number64,
       slot: ssz.Slot,
     },
+    // From beacon apis
+    casingMap: {
+      pubkey: "pubkey",
+      validatorIndex: "validator_index",
+      committeeIndex: "committee_index",
+      committeeLength: "committee_length",
+      committeesAtSlot: "committees_at_slot",
+      validatorCommitteeIndex: "validator_committee_index",
+      slot: "slot",
+    },
   });
 
   const ProposerDuty = new ContainerType<ProposerDuty>({
@@ -357,6 +381,12 @@ export function getReturnTypes(): ReturnTypes<Api> {
       validatorIndex: ssz.ValidatorIndex,
       pubkey: ssz.BLSPubkey,
     },
+    // From beacon apis
+    casingMap: {
+      slot: "slot",
+      validatorIndex: "validator_index",
+      pubkey: "pubkey",
+    },
   });
 
   const SyncDuty = new ContainerType<SyncDuty>({
@@ -364,6 +394,12 @@ export function getReturnTypes(): ReturnTypes<Api> {
       pubkey: ssz.BLSPubkey,
       validatorIndex: ssz.ValidatorIndex,
       validatorSyncCommitteeIndices: ArrayOf(ssz.Number64),
+    },
+    // From beacon apis
+    casingMap: {
+      pubkey: "pubkey",
+      validatorIndex: "validator_index",
+      validatorSyncCommitteeIndices: "validator_sync_committee_indices",
     },
   });
 

--- a/packages/api/src/utils/types.ts
+++ b/packages/api/src/utils/types.ts
@@ -112,7 +112,7 @@ export function ArrayOf<T>(elementType: Type<T>, limit = 1e6): ListType<T[]> {
  * ```
  */
 export function ContainerData<T>(dataType: Type<T>): ContainerType<{data: T}> {
-  return new ContainerType({fields: {data: dataType}});
+  return new ContainerType({fields: {data: dataType}, expectedCase: "notransform"});
 }
 
 /**

--- a/packages/beacon-state-transition/package.json
+++ b/packages/beacon-state-transition/package.json
@@ -42,7 +42,7 @@
     "@chainsafe/lodestar-utils": "^0.31.0",
     "@chainsafe/persistent-merkle-tree": "^0.3.7",
     "@chainsafe/persistent-ts": "^0.19.1",
-    "@chainsafe/ssz": "^0.8.18",
+    "@chainsafe/ssz": "^0.8.19",
     "bigint-buffer": "^1.1.5",
     "buffer-xor": "^2.0.2"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,7 +63,7 @@
     "@chainsafe/lodestar-types": "^0.31.0",
     "@chainsafe/lodestar-utils": "^0.31.0",
     "@chainsafe/lodestar-validator": "^0.31.0",
-    "@chainsafe/ssz": "^0.8.18",
+    "@chainsafe/ssz": "^0.8.19",
     "@types/lockfile": "^1.0.1",
     "bip39": "^3.0.2",
     "deepmerge": "^4.2.2",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -44,6 +44,6 @@
   "dependencies": {
     "@chainsafe/lodestar-params": "^0.31.0",
     "@chainsafe/lodestar-types": "^0.31.0",
-    "@chainsafe/ssz": "^0.8.18"
+    "@chainsafe/ssz": "^0.8.19"
   }
 }

--- a/packages/config/src/chainConfig/sszTypes.ts
+++ b/packages/config/src/chainConfig/sszTypes.ts
@@ -50,4 +50,6 @@ export const ChainConfig = new ContainerType<IChainConfig>({
     DEPOSIT_NETWORK_ID: ssz.Number64,
     DEPOSIT_CONTRACT_ADDRESS: ByteVector20,
   },
+  // Expected and container fields are the same here
+  expectedCase: "notransform",
 });

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@chainsafe/lodestar-config": "^0.31.0",
     "@chainsafe/lodestar-utils": "^0.31.0",
-    "@chainsafe/ssz": "^0.8.18",
+    "@chainsafe/ssz": "^0.8.19",
     "@types/levelup": "^4.3.3",
     "it-all": "^1.0.2",
     "level": "^7.0.0",

--- a/packages/fork-choice/package.json
+++ b/packages/fork-choice/package.json
@@ -42,7 +42,7 @@
     "@chainsafe/lodestar-params": "^0.31.0",
     "@chainsafe/lodestar-types": "^0.31.0",
     "@chainsafe/lodestar-utils": "^0.31.0",
-    "@chainsafe/ssz": "^0.8.18"
+    "@chainsafe/ssz": "^0.8.19"
   },
   "keywords": [
     "ethereum",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -44,7 +44,7 @@
     "@chainsafe/lodestar-types": "^0.31.0",
     "@chainsafe/lodestar-utils": "^0.31.0",
     "@chainsafe/persistent-merkle-tree": "^0.3.7",
-    "@chainsafe/ssz": "^0.8.18",
+    "@chainsafe/ssz": "^0.8.19",
     "cross-fetch": "^3.1.4",
     "mitt": "^3.0.0"
   },

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -61,7 +61,7 @@
     "@chainsafe/lodestar-validator": "^0.31.0",
     "@chainsafe/persistent-merkle-tree": "^0.3.7",
     "@chainsafe/snappy-stream": "5.0.0",
-    "@chainsafe/ssz": "^0.8.18",
+    "@chainsafe/ssz": "^0.8.19",
     "@ethersproject/abi": "^5.0.0",
     "@types/datastore-level": "^3.0.0",
     "bl": "^5.0.0",

--- a/packages/lodestar/src/db/repositories/lightclientFinalizedCheckpoint.ts
+++ b/packages/lodestar/src/db/repositories/lightclientFinalizedCheckpoint.ts
@@ -14,6 +14,8 @@ export class LightclientFinalizedCheckpoint extends Repository<SyncPeriod, Final
         nextSyncCommittee: ssz.altair.LightClientUpdate.getPropertyType("nextSyncCommittee"),
         nextSyncCommitteeBranch: ssz.altair.LightClientUpdate.getPropertyType("nextSyncCommitteeBranch"),
       },
+      // Custom type, subset of LightClientUpdate
+      casingMap: ssz.altair.LightClientUpdate.casingMap,
     });
     super(config, db, Bucket.altair_lightclientFinalizedCheckpoint, type, metrics);
   }

--- a/packages/params/package.json
+++ b/packages/params/package.json
@@ -43,7 +43,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/ssz": "^0.8.18"
+    "@chainsafe/ssz": "^0.8.19"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.3",

--- a/packages/params/src/preset/altair/ssz.ts
+++ b/packages/params/src/preset/altair/ssz.ts
@@ -14,4 +14,6 @@ export const AltairPreset = new ContainerType<IAltairPreset>({
     MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR: Number64,
     PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR: Number64,
   },
+  // Expected and container fields are the same here
+  expectedCase: "notransform",
 });

--- a/packages/params/src/preset/phase0/ssz.ts
+++ b/packages/params/src/preset/phase0/ssz.ts
@@ -55,4 +55,6 @@ export const Phase0Preset = new ContainerType<IPhase0Preset>({
     MAX_DEPOSITS: Number64,
     MAX_VOLUNTARY_EXITS: Number64,
   },
+  // Expected and container fields are the same here
+  expectedCase: "notransform",
 });

--- a/packages/params/src/preset/ssz.ts
+++ b/packages/params/src/preset/ssz.ts
@@ -11,4 +11,5 @@ export const BeaconPreset = new ContainerType<IBeaconPreset>({
     ...Phase0Preset.fields,
     ...AltairPreset.fields,
   },
+  expectedCase: "notransform",
 });

--- a/packages/spec-test-runner/package.json
+++ b/packages/spec-test-runner/package.json
@@ -50,7 +50,7 @@
     "@chainsafe/lodestar-types": "^0.31.0",
     "@chainsafe/lodestar-utils": "^0.31.0",
     "@chainsafe/lodestar-validator": "^0.31.0",
-    "@chainsafe/ssz": "^0.8.18",
+    "@chainsafe/ssz": "^0.8.19",
     "@chainsafe/persistent-merkle-tree": "^0.3.7",
     "@types/yargs": "^17.0.2"
   },

--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "@chainsafe/lodestar-utils": "^0.31.0",
-    "@chainsafe/ssz": "^0.8.18",
+    "@chainsafe/ssz": "^0.8.19",
     "async-retry": "^1.3.3",
     "axios": "^0.21.0",
     "chai": "^4.2.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -36,7 +36,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/lodestar-params": "^0.31.0",
-    "@chainsafe/ssz": "^0.8.18"
+    "@chainsafe/ssz": "^0.8.19"
   },
   "keywords": [
     "ethereum",

--- a/packages/types/src/altair/sszTypes.ts
+++ b/packages/types/src/altair/sszTypes.ts
@@ -22,7 +22,6 @@ import * as altair from "./types";
 const {
   Bytes32,
   Number64,
-  Uint64,
   Slot,
   SubCommitteeIndex,
   ValidatorIndex,
@@ -46,9 +45,13 @@ export const SyncSubnets = new BitVectorType({
 
 export const Metadata = new ContainerType<altair.Metadata>({
   fields: {
-    seqNumber: Uint64,
-    attnets: phase0Ssz.AttestationSubnets,
+    ...phase0Ssz.Metadata.fields,
     syncnets: SyncSubnets,
+  },
+  // New keys are strictly appended, phase0 key order is preserved
+  casingMap: {
+    ...phase0Ssz.Metadata.casingMap,
+    syncnets: "syncnets",
   },
 });
 
@@ -56,6 +59,10 @@ export const SyncCommittee = new ContainerType<altair.SyncCommittee>({
   fields: {
     pubkeys: new VectorType({elementType: BLSPubkey, length: SYNC_COMMITTEE_SIZE}),
     aggregatePubkey: BLSPubkey,
+  },
+  casingMap: {
+    pubkeys: "pubkeys",
+    aggregatePubkey: "aggregate_pubkey",
   },
 });
 
@@ -65,6 +72,12 @@ export const SyncCommitteeMessage = new ContainerType<altair.SyncCommitteeMessag
     beaconBlockRoot: Root,
     validatorIndex: ValidatorIndex,
     signature: BLSSignature,
+  },
+  casingMap: {
+    slot: "slot",
+    beaconBlockRoot: "beacon_block_root",
+    validatorIndex: "validator_index",
+    signature: "signature",
   },
 });
 
@@ -76,6 +89,13 @@ export const SyncCommitteeContribution = new ContainerType<altair.SyncCommitteeC
     aggregationBits: new BitVectorType({length: SYNC_COMMITTEE_SIZE / SYNC_COMMITTEE_SUBNET_COUNT}),
     signature: BLSSignature,
   },
+  casingMap: {
+    slot: "slot",
+    beaconBlockRoot: "beacon_block_root",
+    subCommitteeIndex: "subcommittee_index",
+    aggregationBits: "aggregation_bits",
+    signature: "signature",
+  },
 });
 
 export const ContributionAndProof = new ContainerType<altair.ContributionAndProof>({
@@ -84,6 +104,11 @@ export const ContributionAndProof = new ContainerType<altair.ContributionAndProo
     contribution: SyncCommitteeContribution,
     selectionProof: BLSSignature,
   },
+  casingMap: {
+    aggregatorIndex: "aggregator_index",
+    contribution: "contribution",
+    selectionProof: "selection_proof",
+  },
 });
 
 export const SignedContributionAndProof = new ContainerType<altair.SignedContributionAndProof>({
@@ -91,12 +116,17 @@ export const SignedContributionAndProof = new ContainerType<altair.SignedContrib
     message: ContributionAndProof,
     signature: BLSSignature,
   },
+  expectedCase: "notransform",
 });
 
 export const SyncAggregatorSelectionData = new ContainerType<altair.SyncAggregatorSelectionData>({
   fields: {
     slot: Slot,
     subCommitteeIndex: SubCommitteeIndex,
+  },
+  casingMap: {
+    slot: "slot",
+    subCommitteeIndex: "subcommittee_index",
   },
 });
 
@@ -108,6 +138,10 @@ export const SyncAggregate = new ContainerType<altair.SyncAggregate>({
   fields: {
     syncCommitteeBits: SyncCommitteeBits,
     syncCommitteeSignature: BLSSignature,
+  },
+  casingMap: {
+    syncCommitteeBits: "sync_committee_bits",
+    syncCommitteeSignature: "sync_committee_signature",
   },
 });
 
@@ -127,12 +161,17 @@ export const HistoricalBatch = new ContainerType<phase0Types.HistoricalBatch>({
     blockRoots: HistoricalBlockRoots,
     stateRoots: HistoricalStateRoots,
   },
+  casingMap: phase0Ssz.HistoricalBatch.casingMap,
 });
 
 export const BeaconBlockBody = new ContainerType<altair.BeaconBlockBody>({
   fields: {
     ...phase0Ssz.BeaconBlockBody.fields,
     syncAggregate: SyncAggregate,
+  },
+  casingMap: {
+    ...phase0Ssz.BeaconBlockBody.casingMap,
+    syncAggregate: "sync_aggregate",
   },
 });
 
@@ -145,6 +184,7 @@ export const BeaconBlock = new ContainerType<altair.BeaconBlock>({
     stateRoot: new RootType({expandedType: () => typesRef.get().BeaconState}),
     body: BeaconBlockBody,
   },
+  casingMap: phase0Ssz.BeaconBlock.casingMap,
 });
 
 export const SignedBeaconBlock = new ContainerType<altair.SignedBeaconBlock>({
@@ -152,6 +192,7 @@ export const SignedBeaconBlock = new ContainerType<altair.SignedBeaconBlock>({
     message: BeaconBlock,
     signature: BLSSignature,
   },
+  expectedCase: "notransform",
 });
 
 export const EpochParticipation = new ListType({elementType: ParticipationFlags, limit: VALIDATOR_REGISTRY_LIMIT});
@@ -197,6 +238,12 @@ export const BeaconState = new ContainerType<altair.BeaconState>({
     currentSyncCommittee: SyncCommittee,
     nextSyncCommittee: SyncCommittee,
   },
+  casingMap: {
+    ...phase0Ssz.BeaconState.casingMap,
+    inactivityScores: "inactivity_scores",
+    currentSyncCommittee: "current_sync_committee",
+    nextSyncCommittee: "next_sync_committee",
+  },
 });
 
 export const LightClientSnapshot = new ContainerType<altair.LightClientSnapshot>({
@@ -204,6 +251,11 @@ export const LightClientSnapshot = new ContainerType<altair.LightClientSnapshot>
     header: phase0Ssz.BeaconBlockHeader,
     nextSyncCommittee: SyncCommittee,
     currentSyncCommittee: SyncCommittee,
+  },
+  casingMap: {
+    header: "header",
+    nextSyncCommittee: "next_sync_committee",
+    currentSyncCommittee: "current_sync_committee",
   },
 });
 
@@ -221,6 +273,16 @@ export const LightClientUpdate = new ContainerType<altair.LightClientUpdate>({
     syncCommitteeSignature: BLSSignature,
     forkVersion: Version,
   },
+  casingMap: {
+    header: "header",
+    nextSyncCommittee: "next_sync_committee",
+    nextSyncCommitteeBranch: "next_sync_committee_branch",
+    finalityHeader: "finality_header",
+    finalityBranch: "finality_branch",
+    syncCommitteeBits: "sync_committee_bits",
+    syncCommitteeSignature: "sync_committee_signature",
+    forkVersion: "fork_version",
+  },
 });
 
 export const LightClientStore = new ContainerType<altair.LightClientStore>({
@@ -230,6 +292,10 @@ export const LightClientStore = new ContainerType<altair.LightClientStore>({
       elementType: LightClientUpdate,
       limit: EPOCHS_PER_SYNC_COMMITTEE_PERIOD * SLOTS_PER_EPOCH,
     }),
+  },
+  casingMap: {
+    snapshot: "snapshot",
+    validUpdates: "valid_updates",
   },
 });
 

--- a/packages/types/src/merge/sszTypes.ts
+++ b/packages/types/src/merge/sszTypes.ts
@@ -68,6 +68,21 @@ const executionPayloadFields = {
   // Extra payload fields
   blockHash: Root,
 };
+const executionPayloadCasingMap = {
+  parentHash: "parent_hash",
+  coinbase: "coinbase",
+  stateRoot: "state_root",
+  receiptRoot: "receipt_root",
+  logsBloom: "logs_bloom",
+  random: "random",
+  blockNumber: "block_number",
+  gasLimit: "gas_limit",
+  gasUsed: "gas_used",
+  timestamp: "timestamp",
+  extraData: "extra_data",
+  baseFeePerGas: "base_fee_per_gas",
+  blockHash: "block_hash",
+};
 
 /**
  * ```python
@@ -97,6 +112,10 @@ export const ExecutionPayload = new ContainerType<merge.ExecutionPayload>({
     ...executionPayloadFields,
     transactions: Transactions,
   },
+  casingMap: {
+    ...executionPayloadCasingMap,
+    transactions: "transactions",
+  },
 });
 
 /**
@@ -113,12 +132,20 @@ export const ExecutionPayloadHeader = new ContainerType<merge.ExecutionPayloadHe
     ...executionPayloadFields,
     transactionsRoot: Root,
   },
+  casingMap: {
+    ...executionPayloadCasingMap,
+    transactionsRoot: "transactions_root",
+  },
 });
 
 export const BeaconBlockBody = new ContainerType<merge.BeaconBlockBody>({
   fields: {
     ...altairSsz.BeaconBlockBody.fields,
     executionPayload: ExecutionPayload,
+  },
+  casingMap: {
+    ...altairSsz.BeaconBlockBody.casingMap,
+    executionPayload: "execution_payload",
   },
 });
 
@@ -131,6 +158,7 @@ export const BeaconBlock = new ContainerType<merge.BeaconBlock>({
     stateRoot: new RootType({expandedType: () => typesRef.get().BeaconState}),
     body: BeaconBlockBody,
   },
+  casingMap: altairSsz.BeaconBlock.casingMap,
 });
 
 export const SignedBeaconBlock = new ContainerType<merge.SignedBeaconBlock>({
@@ -138,14 +166,21 @@ export const SignedBeaconBlock = new ContainerType<merge.SignedBeaconBlock>({
     message: BeaconBlock,
     signature: BLSSignature,
   },
+  expectedCase: "notransform",
 });
 
-export const PowBlock = new ContainerType<merge.BeaconState>({
+export const PowBlock = new ContainerType<merge.PowBlock>({
   fields: {
     blockHash: Root,
     parentHash: Root,
     totalDifficulty: Uint256,
     difficulty: Uint256,
+  },
+  casingMap: {
+    blockHash: "block_hash",
+    parentHash: "parent_hash",
+    totalDifficulty: "total_difficulty",
+    difficulty: "difficulty",
   },
 });
 
@@ -165,6 +200,7 @@ export const HistoricalBatch = new ContainerType<phase0.HistoricalBatch>({
     blockRoots: HistoricalBlockRoots,
     stateRoots: HistoricalStateRoots,
   },
+  casingMap: phase0Ssz.HistoricalBatch.casingMap,
 });
 
 // we don't reuse phase0.BeaconState fields since we need to replace some keys
@@ -208,6 +244,10 @@ export const BeaconState = new ContainerType<merge.BeaconState>({
     nextSyncCommittee: altairSsz.SyncCommittee,
     // Execution
     latestExecutionPayloadHeader: ExecutionPayloadHeader, // [New in Merge]
+  },
+  casingMap: {
+    ...altairSsz.BeaconState.casingMap,
+    latestExecutionPayloadHeader: "latest_execution_payload_header",
   },
 });
 

--- a/packages/types/src/phase0/sszTypes.ts
+++ b/packages/types/src/phase0/sszTypes.ts
@@ -71,6 +71,13 @@ export const BeaconBlockHeader = new ContainerType<phase0.BeaconBlockHeader>({
     stateRoot: Root,
     bodyRoot: Root,
   },
+  casingMap: {
+    slot: "slot",
+    proposerIndex: "proposer_index",
+    parentRoot: "parent_root",
+    stateRoot: "state_root",
+    bodyRoot: "body_root",
+  },
 });
 
 export const SignedBeaconBlockHeader = new ContainerType<phase0.SignedBeaconBlockHeader>({
@@ -78,6 +85,7 @@ export const SignedBeaconBlockHeader = new ContainerType<phase0.SignedBeaconBloc
     message: BeaconBlockHeader,
     signature: BLSSignature,
   },
+  expectedCase: "notransform",
 });
 
 export const Checkpoint = new ContainerType<phase0.Checkpoint>({
@@ -85,6 +93,7 @@ export const Checkpoint = new ContainerType<phase0.Checkpoint>({
     epoch: Epoch,
     root: Root,
   },
+  expectedCase: "notransform",
 });
 
 export const CommitteeBits = new BitListType({
@@ -102,14 +111,22 @@ export const DepositMessage = new ContainerType<phase0.DepositMessage>({
     withdrawalCredentials: Bytes32,
     amount: Number64,
   },
+  casingMap: {
+    pubkey: "pubkey",
+    withdrawalCredentials: "withdrawal_credentials",
+    amount: "amount",
+  },
 });
 
 export const DepositData = new ContainerType<phase0.DepositData>({
   fields: {
-    pubkey: BLSPubkey,
-    withdrawalCredentials: Bytes32,
-    amount: Number64,
+    // Fields order is strickly preserved
+    ...DepositMessage.fields,
     signature: BLSSignature,
+  },
+  casingMap: {
+    ...DepositMessage.casingMap,
+    signature: "signature",
   },
 });
 
@@ -124,6 +141,12 @@ export const DepositEvent = new ContainerType<phase0.DepositEvent>({
     blockNumber: Number64,
     index: Number64,
   },
+  // Custom type, not in the consensus specs
+  casingMap: {
+    depositData: "deposit_data",
+    blockNumber: "block_number",
+    index: "index",
+  },
 });
 
 export const Eth1Data = new ContainerType<phase0.Eth1Data>({
@@ -131,6 +154,11 @@ export const Eth1Data = new ContainerType<phase0.Eth1Data>({
     depositRoot: Root,
     depositCount: Number64,
     blockHash: Bytes32,
+  },
+  casingMap: {
+    depositRoot: "deposit_root",
+    depositCount: "deposit_count",
+    blockHash: "block_hash",
   },
 });
 
@@ -141,10 +169,14 @@ export const Eth1DataVotes = new ListType({
 
 export const Eth1DataOrdered = new ContainerType<phase0.Eth1DataOrdered>({
   fields: {
-    depositRoot: Root,
-    depositCount: Number64,
-    blockHash: Bytes32,
+    // Fields order is strickly preserved
+    ...Eth1Data.fields,
     blockNumber: Number64,
+  },
+  // Custom type, not in the consensus specs
+  casingMap: {
+    ...Eth1Data.casingMap,
+    blockNumber: "block_number",
   },
 });
 
@@ -154,12 +186,21 @@ export const Fork = new ContainerType<phase0.Fork>({
     currentVersion: Version,
     epoch: Epoch,
   },
+  casingMap: {
+    previousVersion: "previous_version",
+    currentVersion: "current_version",
+    epoch: "epoch",
+  },
 });
 
 export const ForkData = new ContainerType<phase0.ForkData>({
   fields: {
     currentVersion: Version,
     genesisValidatorsRoot: Root,
+  },
+  casingMap: {
+    currentVersion: "current_version",
+    genesisValidatorsRoot: "genesis_validators_root",
   },
 });
 
@@ -168,6 +209,11 @@ export const ENRForkID = new ContainerType<phase0.ENRForkID>({
     forkDigest: ForkDigest,
     nextForkVersion: Version,
     nextForkEpoch: Epoch,
+  },
+  casingMap: {
+    forkDigest: "fork_digest",
+    nextForkVersion: "next_fork_version",
+    nextForkEpoch: "next_fork_epoch",
   },
 });
 
@@ -186,6 +232,10 @@ export const HistoricalBatch = new ContainerType<phase0.HistoricalBatch>({
     blockRoots: HistoricalBlockRoots,
     stateRoots: HistoricalStateRoots,
   },
+  casingMap: {
+    blockRoots: "block_roots",
+    stateRoots: "state_roots",
+  },
 });
 
 export const Validator = new ContainerLeafNodeStructType<phase0.Validator>({
@@ -198,6 +248,16 @@ export const Validator = new ContainerLeafNodeStructType<phase0.Validator>({
     activationEpoch: Epoch,
     exitEpoch: Epoch,
     withdrawableEpoch: Epoch,
+  },
+  casingMap: {
+    pubkey: "pubkey",
+    withdrawalCredentials: "withdrawal_credentials",
+    effectiveBalance: "effective_balance",
+    slashed: "slashed",
+    activationEligibilityEpoch: "activation_eligibility_epoch",
+    activationEpoch: "activation_epoch",
+    exitEpoch: "exit_epoch",
+    withdrawableEpoch: "withdrawable_epoch",
   },
 });
 
@@ -218,6 +278,13 @@ export const AttestationData = new ContainerType<phase0.AttestationData>({
     source: Checkpoint,
     target: Checkpoint,
   },
+  casingMap: {
+    slot: "slot",
+    index: "index",
+    beaconBlockRoot: "beacon_block_root",
+    source: "source",
+    target: "target",
+  },
 });
 
 export const IndexedAttestation = new ContainerType<phase0.IndexedAttestation>({
@@ -225,6 +292,11 @@ export const IndexedAttestation = new ContainerType<phase0.IndexedAttestation>({
     attestingIndices: CommitteeIndices,
     data: AttestationData,
     signature: BLSSignature,
+  },
+  casingMap: {
+    attestingIndices: "attesting_indices",
+    data: "data",
+    signature: "signature",
   },
 });
 
@@ -235,12 +307,22 @@ export const PendingAttestation = new ContainerType<phase0.PendingAttestation>({
     inclusionDelay: Slot,
     proposerIndex: ValidatorIndex,
   },
+  casingMap: {
+    aggregationBits: "aggregation_bits",
+    data: "data",
+    inclusionDelay: "inclusion_delay",
+    proposerIndex: "proposer_index",
+  },
 });
 
 export const SigningData = new ContainerType<phase0.SigningData>({
   fields: {
     objectRoot: Root,
     domain: Domain,
+  },
+  casingMap: {
+    objectRoot: "object_root",
+    domain: "domain",
   },
 });
 
@@ -252,6 +334,11 @@ export const Attestation = new ContainerType<phase0.Attestation>({
     aggregationBits: CommitteeBits,
     data: AttestationData,
     signature: BLSSignature,
+  },
+  casingMap: {
+    aggregationBits: "aggregation_bits",
+    data: "data",
+    signature: "signature",
   },
 });
 
@@ -272,6 +359,7 @@ export const Deposit = new ContainerType<phase0.Deposit>({
     proof: new VectorType({elementType: Bytes32, length: DEPOSIT_CONTRACT_TREE_DEPTH + 1}),
     data: DepositData,
   },
+  expectedCase: "notransform",
 });
 
 export const ProposerSlashing = new ContainerType<phase0.ProposerSlashing>({
@@ -291,6 +379,10 @@ export const VoluntaryExit = new ContainerType<phase0.VoluntaryExit>({
     epoch: Epoch,
     validatorIndex: ValidatorIndex,
   },
+  casingMap: {
+    epoch: "epoch",
+    validatorIndex: "validator_index",
+  },
 });
 
 export const SignedVoluntaryExit = new ContainerType<phase0.SignedVoluntaryExit>({
@@ -298,6 +390,7 @@ export const SignedVoluntaryExit = new ContainerType<phase0.SignedVoluntaryExit>
     message: VoluntaryExit,
     signature: BLSSignature,
   },
+  expectedCase: "notransform",
 });
 
 // Block types
@@ -314,6 +407,16 @@ export const BeaconBlockBody = new ContainerType<phase0.BeaconBlockBody>({
     deposits: new ListType({elementType: Deposit, limit: MAX_DEPOSITS}),
     voluntaryExits: new ListType({elementType: SignedVoluntaryExit, limit: MAX_VOLUNTARY_EXITS}),
   },
+  casingMap: {
+    randaoReveal: "randao_reveal",
+    eth1Data: "eth1_data",
+    graffiti: "graffiti",
+    proposerSlashings: "proposer_slashings",
+    attesterSlashings: "attester_slashings",
+    attestations: "attestations",
+    deposits: "deposits",
+    voluntaryExits: "voluntary_exits",
+  },
 });
 
 export const BeaconBlock = new ContainerType<phase0.BeaconBlock>({
@@ -324,6 +427,13 @@ export const BeaconBlock = new ContainerType<phase0.BeaconBlock>({
     stateRoot: new RootType({expandedType: () => typesRef.get().BeaconState}),
     body: BeaconBlockBody,
   },
+  casingMap: {
+    slot: "slot",
+    proposerIndex: "proposer_index",
+    parentRoot: "parent_root",
+    stateRoot: "state_root",
+    body: "body",
+  },
 });
 
 export const SignedBeaconBlock = new ContainerType<phase0.SignedBeaconBlock>({
@@ -331,6 +441,7 @@ export const SignedBeaconBlock = new ContainerType<phase0.SignedBeaconBlock>({
     message: BeaconBlock,
     signature: BLSSignature,
   },
+  expectedCase: "notransform",
 });
 
 // State types
@@ -375,6 +486,29 @@ export const BeaconState = new ContainerType<phase0.BeaconState>({
     currentJustifiedCheckpoint: Checkpoint,
     finalizedCheckpoint: Checkpoint,
   },
+  casingMap: {
+    genesisTime: "genesis_time",
+    genesisValidatorsRoot: "genesis_validators_root",
+    slot: "slot",
+    fork: "fork",
+    latestBlockHeader: "latest_block_header",
+    blockRoots: "block_roots",
+    stateRoots: "state_roots",
+    historicalRoots: "historical_roots",
+    eth1Data: "eth1_data",
+    eth1DataVotes: "eth1_data_votes",
+    eth1DepositIndex: "eth1_deposit_index",
+    validators: "validators",
+    balances: "balances",
+    randaoMixes: "randao_mixes",
+    slashings: "slashings",
+    previousEpochAttestations: "previous_epoch_attestations",
+    currentEpochAttestations: "current_epoch_attestations",
+    justificationBits: "justification_bits",
+    previousJustifiedCheckpoint: "previous_justified_checkpoint",
+    currentJustifiedCheckpoint: "current_justified_checkpoint",
+    finalizedCheckpoint: "finalized_checkpoint",
+  },
 });
 
 // Validator types
@@ -386,6 +520,12 @@ export const CommitteeAssignment = new ContainerType<phase0.CommitteeAssignment>
     committeeIndex: CommitteeIndex,
     slot: Slot,
   },
+  // Custom type, not in the consensus specs
+  casingMap: {
+    validators: "validators",
+    committeeIndex: "committee_index",
+    slot: "slot",
+  },
 });
 
 export const AggregateAndProof = new ContainerType<phase0.AggregateAndProof>({
@@ -394,6 +534,11 @@ export const AggregateAndProof = new ContainerType<phase0.AggregateAndProof>({
     aggregate: Attestation,
     selectionProof: BLSSignature,
   },
+  casingMap: {
+    aggregatorIndex: "aggregator_index",
+    aggregate: "aggregate",
+    selectionProof: "selection_proof",
+  },
 });
 
 export const SignedAggregateAndProof = new ContainerType<phase0.SignedAggregateAndProof>({
@@ -401,6 +546,7 @@ export const SignedAggregateAndProof = new ContainerType<phase0.SignedAggregateA
     message: AggregateAndProof,
     signature: BLSSignature,
   },
+  expectedCase: "notransform",
 });
 
 // ReqResp types
@@ -414,6 +560,13 @@ export const Status = new ContainerType<phase0.Status>({
     headRoot: Root,
     headSlot: Slot,
   },
+  casingMap: {
+    forkDigest: "fork_digest",
+    finalizedRoot: "finalized_root",
+    finalizedEpoch: "finalized_epoch",
+    headRoot: "head_root",
+    headSlot: "head_slot",
+  },
 });
 
 export const Goodbye = Uint64;
@@ -425,6 +578,10 @@ export const Metadata = new ContainerType<phase0.Metadata>({
     seqNumber: Uint64,
     attnets: AttestationSubnets,
   },
+  casingMap: {
+    seqNumber: "seq_number",
+    attnets: "attnets",
+  },
 });
 
 export const BeaconBlocksByRangeRequest = new ContainerType<phase0.BeaconBlocksByRangeRequest>({
@@ -432,6 +589,11 @@ export const BeaconBlocksByRangeRequest = new ContainerType<phase0.BeaconBlocksB
     startSlot: Slot,
     count: Number64,
     step: Number64,
+  },
+  casingMap: {
+    startSlot: "start_slot",
+    count: "count",
+    step: "step",
   },
 });
 
@@ -445,6 +607,12 @@ export const Genesis = new ContainerType<phase0.Genesis>({
     genesisValidatorsRoot: Root,
     genesisTime: Uint64,
     genesisForkVersion: Version,
+  },
+  // From beacon-apis
+  casingMap: {
+    genesisValidatorsRoot: "genesis_validators_root",
+    genesisTime: "genesis_time",
+    genesisForkVersion: "genesis_fork_version",
   },
 });
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -37,7 +37,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/abort-controller": "^3.0.1",
-    "@chainsafe/ssz": "^0.8.18",
+    "@chainsafe/ssz": "^0.8.19",
     "any-signal": "2.1.2",
     "bigint-buffer": "^1.1.5",
     "chalk": "^4.1.2",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -54,7 +54,7 @@
     "@chainsafe/lodestar-params": "^0.31.0",
     "@chainsafe/lodestar-types": "^0.31.0",
     "@chainsafe/lodestar-utils": "^0.31.0",
-    "@chainsafe/ssz": "^0.8.18",
+    "@chainsafe/ssz": "^0.8.19",
     "bigint-buffer": "^1.1.5"
   },
   "devDependencies": {

--- a/packages/validator/src/slashingProtection/attestation/attestationByTargetRepository.ts
+++ b/packages/validator/src/slashingProtection/attestation/attestationByTargetRepository.ts
@@ -24,6 +24,12 @@ export class AttestationByTargetRepository {
         targetEpoch: ssz.Epoch,
         signingRoot: ssz.Root,
       },
+      // Custom type, not in the consensus specs
+      casingMap: {
+        sourceEpoch: "source_epoch",
+        targetEpoch: "target_epoch",
+        signingRoot: "signing_root",
+      },
     });
   }
 

--- a/packages/validator/src/slashingProtection/attestation/attestationLowerBoundRepository.ts
+++ b/packages/validator/src/slashingProtection/attestation/attestationLowerBoundRepository.ts
@@ -26,6 +26,11 @@ export class AttestationLowerBoundRepository {
         minSourceEpoch: ssz.Epoch,
         minTargetEpoch: ssz.Epoch,
       },
+      // Custom type, not in the consensus specs
+      casingMap: {
+        minSourceEpoch: "min_source_epoch",
+        minTargetEpoch: "min_target_epoch",
+      },
     });
   }
 

--- a/packages/validator/src/slashingProtection/block/blockBySlotRepository.ts
+++ b/packages/validator/src/slashingProtection/block/blockBySlotRepository.ts
@@ -23,6 +23,11 @@ export class BlockBySlotRepository {
         slot: ssz.Slot,
         signingRoot: ssz.Root,
       },
+      // Custom type, not in the consensus specs
+      casingMap: {
+        slot: "slot",
+        signingRoot: "signing_root",
+      },
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -520,10 +520,10 @@
     buffer-from "^1.1.1"
     snappy "^6.3.5"
 
-"@chainsafe/ssz@^0.8.18":
-  version "0.8.18"
-  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.8.18.tgz#b281b5fde4b4ef31763e3e1d92555f396622a808"
-  integrity sha512-7efoXZOlDnWl5DpgcgJQPNudoAIHJkcKIhQWFElrmcTFqaoUZtdYsFoXTkXgsIqC0w7yGMp3wUtqGIopoj9C0w==
+"@chainsafe/ssz@^0.8.19":
+  version "0.8.19"
+  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.8.19.tgz#a502143cbc88a417b1722ea669a82fd2f3e3a10f"
+  integrity sha512-TtUDcI2LPHs5VF5i5yIBmxqp1t07eAFv7cAC7ObOz76cA8xowuWtgJVT7lAoXKSyyQlJaz2EQTBpw5NV8CZyUg==
   dependencies:
     "@chainsafe/as-sha256" "^0.2.4"
     "@chainsafe/persistent-merkle-tree" "^0.3.7"


### PR DESCRIPTION
**Motivation**
This PR adds casingMap to all the ssz containers both for the reasons of
1. Being verbose in stating the matching of container fields to the field names in specs expected in data apis and not leaving to doubt the library based conversion
2. casingMap speeds up the case conversion in toJson/fromJson by skipping the actual case conversion call
3. corrected case conversion of `subCommitteeIndex` to the `subcommittee_index` as specified in spec. earlier  the case conversion library  was  **erroneously** converting it to `sub_committee_index` potentially leading to errors and bad performance.
4. The `PowBlock` ssz type has been corrected to `merge.PowBlock`. earlier it was `merge.BeaconState`. 


<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**
This PR labels if the container casing is from beacon apis or custom made (there are couple of the custom fields). Rest were all found and matched from the consensus specs.

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number
#3336
**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
