### PR TITLE
Add config/fork_schedule API implementation

### DIFF
--- a/packages/lodestar/src/api/impl/config/index.ts
+++ b/packages/lodestar/src/api/impl/config/index.ts
@@ -14,8 +14,13 @@ export function getConfigApi({config}: Pick<ApiModules, "config">): routes.confi
   });
   return {
     async getForkSchedule() {
-      // @TODO: implement the actual fork schedule data get from config params once marin's altair PRs have been merged
-      return {data: []};
+      const forkInfos = Object.values(config.forks);
+      const forks = forkInfos.map((fi, ix) => ({
+        previousVersion: ix === 0 ? fi.version : forkInfos[ix - 1].version,
+        currentVersion: fi.version,
+        epoch: fi.epoch,
+      }));
+      return {data: forks};
     },
 
     async getDepositContract() {

--- a/packages/lodestar/test/unit/api/impl/config/config.test.ts
+++ b/packages/lodestar/test/unit/api/impl/config/config.test.ts
@@ -14,9 +14,8 @@ describe("config api implementation", function () {
 
   describe("getForkSchedule", function () {
     it("should get known scheduled forks", async function () {
-      // @TODO: implement the actual fork schedule data get from config params once marin's altair PRs have been merged
       const {data: forkSchedule} = await api.getForkSchedule();
-      expect(forkSchedule.length).to.equal(0);
+      expect(forkSchedule.length).to.equal(Object.keys(config.forks).length);
     });
   });
 


### PR DESCRIPTION
**Motivation**

Querying amphora nodes, noticed empty response for `config/fork_schedule`

**Description**

Simple implementation of config/fork_schedule.
Since we already store fork info in a sorted object, this is very straightforward.