### PR TITLE
Fix bootEnrs cli issue

### DIFF
--- a/packages/cli/src/cmds/init/handler.ts
+++ b/packages/cli/src/cmds/init/handler.ts
@@ -30,17 +30,10 @@ export async function initializeOptionsAndConfig(args: IBeaconArgs & IGlobalArgs
   });
 
   // Auto-setup network
-  // Only download files if params file does not exist
+  // Only download files if network.discv5.bootEnrs arg is not specified
   const bOpts = beaconNodeOptions.get();
   const bOptsEnrs = bOpts && bOpts.network && bOpts.network.discv5 && bOpts.network.discv5.bootEnrs;
-  if (
-    args.network &&
-    (!beaconPaths.configFile ||
-      !fs.existsSync(beaconPaths.configFile) ||
-      !beaconPaths.paramsFile ||
-      !fs.existsSync(beaconPaths.paramsFile) ||
-      !(bOptsEnrs && bOptsEnrs.length > 0))
-  ) {
+  if (args.network && !(bOptsEnrs && bOptsEnrs.length > 0)) {
     try {
       const bootEnrs = await fetchBootnodes(args.network);
       beaconNodeOptions.set({network: {discv5: {bootEnrs}}});


### PR DESCRIPTION
**Motivation**

+ When no network is specified, "mainnet" is used
+ In amphora environment, even we specify `network.discv5.bootEnrs` it still gets the bootEnrs from mainnet and discv5 sends lodestar wrong peers all the times

**Description**

+ Only download bootEnrs from the network if cli does not specify its own `network.discv5.bootEnrs` arguments

**Note**
+ There is a TODO found in this PR, will open a separate issue for it.