### PR TITLE
Simplify LightclientUpdater.onFinalized

### DIFF
--- a/packages/light-client/src/server/LightClientUpdater.ts
+++ b/packages/light-client/src/server/LightClientUpdater.ts
@@ -169,12 +169,12 @@ export class LightClientUpdater implements ILightClientUpdater {
    */
   async onFinalized(
     checkpoint: phase0.Checkpoint,
-    block: altair.BeaconBlock,
+    blockHeader: phase0.BeaconBlockHeader,
     postState: TreeBacked<altair.BeaconState>
   ): Promise<void> {
     // Pre-compute the nextSyncCommitteeBranch for this checkpoint, it will never change
     await this.db.lightclientFinalizedCheckpoint.put(checkpoint.epoch, {
-      header: toBlockHeader(block),
+      header: blockHeader,
       nextSyncCommittee: postState.nextSyncCommittee,
       // Prove that the `nextSyncCommittee` is included in a finalized state "attested" by the current sync committee
       nextSyncCommitteeBranch: postState.tree.getSingleProof(BigInt(NEXT_SYNC_COMMITTEE_INDEX)),

--- a/packages/light-client/test/lightclientMockServer.ts
+++ b/packages/light-client/test/lightclientMockServer.ts
@@ -1,5 +1,5 @@
 import {FastifyInstance} from "fastify";
-import {computeEpochAtSlot, computeSyncPeriodAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {blockToHeader, computeEpochAtSlot, computeSyncPeriodAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {toHexString, TreeBacked} from "@chainsafe/ssz";
 import {altair, phase0, Epoch, Root, Slot, ssz, SyncPeriod} from "@chainsafe/lodestar-types";
@@ -48,7 +48,7 @@ export class LightclientMockServer {
     state: TreeBacked<altair.BeaconState>;
   }): Promise<void> {
     const {checkpoint, block, state} = initialFinalizedCheckpoint;
-    void this.lightClientUpdater.onFinalized(checkpoint, block, state);
+    void this.lightClientUpdater.onFinalized(checkpoint, blockToHeader(this.config, block), state);
     this.stateRegen.add(state);
     this.blockCache.add(block);
     this.prevState = ssz.altair.BeaconState.createTreeBackedFromStruct(state);
@@ -133,7 +133,7 @@ export class LightclientMockServer {
         // Feed new finalized block and state to the LightClientUpdater
         await this.lightClientUpdater.onFinalized(
           this.finalizedCheckpoint,
-          finalizedData.block,
+          blockToHeader(this.config, finalizedData.block),
           ssz.altair.BeaconState.createTreeBackedFromStruct(finalizedData.state)
         );
       }


### PR DESCRIPTION
**Motivation**

+ On `forkChoiceFinalized` event, LightClientUpdater wants to fetch block and extract block header from there. But the error happened because the block was being moved from `block` db to `blockArchive` db so LightClientUpdater failed to find the block

**Description**

+ We don't need to find block, instead just get the latestBlockHeader from the state

Closes #3360