### PR TITLE
Fix aggregatorsPerslot when calculating topic score params

### DIFF
--- a/packages/lodestar/src/network/gossip/scoringParameters.ts
+++ b/packages/lodestar/src/network/gossip/scoringParameters.ts
@@ -289,8 +289,9 @@ function expectedAggregatorCountPerSlot(
   const largeCommitteeAggregatorPerEpoch = Math.floor((largerCommiteeeSize / moduloLarger) * largeCommitteesPerEpoch);
 
   return {
-    aggregatorsPerslot: Math.floor(
-      (smallCommitteeAggregatorPerEpoch + largeCommitteeAggregatorPerEpoch) / SLOTS_PER_EPOCH
+    aggregatorsPerslot: Math.max(
+      1,
+      Math.floor((smallCommitteeAggregatorPerEpoch + largeCommitteeAggregatorPerEpoch) / SLOTS_PER_EPOCH)
     ),
     committeesPerSlot,
   };


### PR DESCRIPTION
**Motivation**

+ Not able to start dev network because estimated aggregators per slot is 0 when calculating topic score params

**Description**

+ estimated `aggregatorsPerSlot` should be at least 1

Closes #3342