### PR TITLE
Reduce default graffiti length

### DIFF
--- a/packages/cli/src/util/graffiti.ts
+++ b/packages/cli/src/util/graffiti.ts
@@ -1,6 +1,6 @@
 import {getVersion} from "./version";
 
-const lodestarPackageName = "ChainSafe/Lodestar";
+const lodestarPackageName = "Lodestar";
 
 /**
  * Computes a default graffiti fetching dynamically the package info.


### PR DESCRIPTION
**Motivation**

Eth2.0 graffiti is trimmed at 32 bytes (32 characters in ASCII encoding). In testnets it contains important versioning information that gets trimmed because the prefix name is too long see:

```
ChainSafe/Lodestar-v0.31.0/maste
```

https://pithos-explorer.ethdevops.io/blocks?q=ChainSafe%2FLodestar-v0.31.0%2Fmaste


**Description**

Reduce default graffiti length