### PR TITLE
fix: change eth1 withdrawal prefix from 0 to 1

### DIFF
--- a/packages/params/src/index.ts
+++ b/packages/params/src/index.ts
@@ -87,7 +87,7 @@ export const JUSTIFICATION_BITS_LENGTH = 4;
 // Withdrawal prefixes
 
 export const BLS_WITHDRAWAL_PREFIX = Uint8Array.from([0]);
-export const ETH1_ADDRESS_WITHDRAWAL_PREFIX = Uint8Array.from([0]);
+export const ETH1_ADDRESS_WITHDRAWAL_PREFIX = Uint8Array.from([1]);
 
 // Domain types
 


### PR DESCRIPTION
**Motivation**

Fix a value error in the `params` package.

Closes #3366