### PR TITLE
publish block fix for validator interoperability with lighthouse beacon

### DIFF
--- a/packages/api/src/routes/validator.ts
+++ b/packages/api/src/routes/validator.ts
@@ -123,11 +123,7 @@ export type Api = {
    * @returns any Success response
    * @throws ApiError
    */
-  produceBlock(
-    slot: Slot,
-    randaoReveal: BLSSignature,
-    graffiti: string
-  ): Promise<{data: allForks.BeaconBlock; version: ForkName}>;
+  produceBlock(slot: Slot, randaoReveal: BLSSignature, graffiti: string): Promise<{data: allForks.BeaconBlock}>;
 
   /**
    * Requests a beacon node to produce a valid block, which can then be signed by a validator.
@@ -403,14 +399,12 @@ export function getReturnTypes(): ReturnTypes<Api> {
     },
   });
 
-  const produceBlock: ReturnTypes<Api>["produceBlock"] = WithVersion((fork: ForkName) => ssz[fork].BeaconBlock);
-
   return {
     getAttesterDuties: WithDependentRoot(ArrayOf(AttesterDuty)),
     getProposerDuties: WithDependentRoot(ArrayOf(ProposerDuty)),
     getSyncCommitteeDuties: WithDependentRoot(ArrayOf(SyncDuty)),
-    produceBlock: produceBlock,
-    produceBlockV2: produceBlock,
+    produceBlock: ContainerData(ssz.phase0.BeaconBlock),
+    produceBlockV2: WithVersion((fork: ForkName) => ssz[fork].BeaconBlock),
     produceAttestationData: ContainerData(ssz.phase0.AttestationData),
     produceSyncCommitteeContribution: ContainerData(ssz.altair.SyncCommitteeContribution),
     getAggregatedAttestation: ContainerData(ssz.phase0.Attestation),

--- a/packages/api/src/utils/types.ts
+++ b/packages/api/src/utils/types.ts
@@ -128,10 +128,15 @@ export function WithVersion<T>(getType: (fork: ForkName) => TypeJson<T>): TypeJs
       data: getType(version || ForkName.phase0).toJson(data, opts),
       version,
     }),
-    fromJson: ({data, version}: {data: Json; version: string}, opts) => ({
-      data: getType((version as ForkName) || ForkName.phase0).fromJson(data, opts),
-      version: version as ForkName,
-    }),
+    fromJson: ({data, version}: {data: Json; version: string}, opts) => {
+      // Un-safe external data, validate version is known ForkName value
+      if (!ForkName[version as ForkName]) throw Error(`Invalid version ${version}`);
+
+      return {
+        data: getType(version as ForkName).fromJson(data, opts),
+        version: version as ForkName,
+      };
+    },
   };
 }
 

--- a/packages/api/src/utils/types.ts
+++ b/packages/api/src/utils/types.ts
@@ -125,11 +125,11 @@ export function ContainerData<T>(dataType: Type<T>): ContainerType<{data: T}> {
 export function WithVersion<T>(getType: (fork: ForkName) => TypeJson<T>): TypeJson<{data: T; version: ForkName}> {
   return {
     toJson: ({data, version}, opts) => ({
-      data: getType(version).toJson(data, opts),
+      data: getType(version || ForkName.phase0).toJson(data, opts),
       version,
     }),
     fromJson: ({data, version}: {data: Json; version: string}, opts) => ({
-      data: getType(version as ForkName).fromJson(data, opts),
+      data: getType((version as ForkName) || ForkName.phase0).fromJson(data, opts),
       version: version as ForkName,
     }),
   };

--- a/packages/api/test/unit/validator.test.ts
+++ b/packages/api/test/unit/validator.test.ts
@@ -40,7 +40,7 @@ describe("validator", () => {
     },
     produceBlock: {
       args: [32000, Buffer.alloc(96, 1), "graffiti"],
-      res: {data: ssz.phase0.BeaconBlock.defaultValue(), version: ForkName.phase0},
+      res: {data: ssz.phase0.BeaconBlock.defaultValue()},
     },
     produceBlockV2: {
       args: [32000, Buffer.alloc(96, 1), "graffiti"],

--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -133,7 +133,11 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
     }
   }
 
-  const produceBlock: routes.validator.Api["produceBlock"] = async function produceBlock(slot, randaoReveal, graffiti) {
+  const produceBlock: routes.validator.Api["produceBlockV2"] = async function produceBlock(
+    slot,
+    randaoReveal,
+    graffiti
+  ) {
     let timer;
     metrics?.blockProductionRequests.inc();
     try {

--- a/packages/validator/test/unit/services/block.test.ts
+++ b/packages/validator/test/unit/services/block.test.ts
@@ -7,7 +7,6 @@ import {config as mainnetConfig} from "@chainsafe/lodestar-config/default";
 import {Root} from "@chainsafe/lodestar-types";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {routes} from "@chainsafe/lodestar-api";
-import {ForkName} from "@chainsafe/lodestar-params";
 import {generateEmptySignedBlock} from "@chainsafe/lodestar/test/utils/block";
 import {BlockProposingService} from "../../../src/services/block";
 import {ValidatorStore} from "../../../src/services/validatorStore";
@@ -53,7 +52,7 @@ describe("BlockDutiesService", function () {
     const signedBlock = generateEmptySignedBlock();
     validatorStore.signRandao.resolves(signedBlock.message.body.randaoReveal);
     validatorStore.signBlock.callsFake(async (_, block) => ({message: block, signature: signedBlock.signature}));
-    api.validator.produceBlock.resolves({data: signedBlock.message, version: ForkName.phase0});
+    api.validator.produceBlock.resolves({data: signedBlock.message});
     api.beacon.publishBlock.resolves();
 
     // Triger block production for slot 1


### PR DESCRIPTION
**Motivation**
This is to make the lodestar validator interop with lighthouse beacon

<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**
The lodestar validator was throwing errors on the `produceBlock` api response as documented in isssue: #3370 . 

~~Reason was that the lodestar validator assumes the version  information (`phase0`, `altair`) availability in response which was not being provided by lighthouse beacon as its not the part of the spec. This PR adds the ability to extract the version from the slot to get the version.~~

making `WithVersion` back compatible with pre altair `v1/produceBlock` call
<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->
The `publishBlock` api is now being properly consumed and the validator is able to produce blocks.
![image](https://user-images.githubusercontent.com/76567250/137723903-7d1f5592-f75d-4aa7-aab4-10d9cd563344.png)

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number
#3370

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
