### PR TITLE
More log for gossip and req/resp

### DIFF
--- a/packages/lodestar/src/network/gossip/handlers/index.ts
+++ b/packages/lodestar/src/network/gossip/handlers/index.ts
@@ -62,6 +62,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules): GossipHandlers 
         slot: slot,
         root: blockHex,
         curentSlot: chain.clock.currentSlot,
+        peerId: peerIdStr,
       });
 
       try {

--- a/packages/lodestar/src/network/reqresp/request/index.ts
+++ b/packages/lodestar/src/network/reqresp/request/index.ts
@@ -152,7 +152,8 @@ export async function sendRequest<T extends ResponseBody | ResponseBody[]>(
       // NOTE: Only log once per request to verbose, intermediate steps to debug
       // NOTE: Do not log the response, logs get extremely cluttered
       // NOTE: add double space after "Req  " to align log with the "Resp " log
-      logger.verbose("Req  done", logCtx);
+      const numResponse = Array.isArray(responses) ? responses.length : 1;
+      logger.verbose("Req  done", {...logCtx, numResponse});
 
       return responses as T;
     } finally {


### PR DESCRIPTION
**Motivation**

+ Our lodestar-nethermind node received a bad gossip block that we want to know which peer we received it from
+ For beacon_blocks_by_range we want to know how many blocks we received

