### PR TITLE
fill the fields locally that might not be available in the interop spec config api

### DIFF
--- a/packages/api/src/client/config.ts
+++ b/packages/api/src/client/config.ts
@@ -5,9 +5,9 @@ import {Api, ReqTypes, routesData, getReqSerializers, getReturnTypes} from "../r
 /**
  * REST HTTP client for config routes
  */
-export function getClient(_config: IChainForkConfig, httpClient: IHttpClient): Api {
+export function getClient(config: IChainForkConfig, httpClient: IHttpClient): Api {
   const reqSerializers = getReqSerializers();
-  const returnTypes = getReturnTypes();
+  const returnTypes = getReturnTypes(config);
   // All routes return JSON, use a client auto-generator
   return generateGenericJsonClient<Api, ReqTypes>(routesData, reqSerializers, returnTypes, httpClient);
 }

--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -2,17 +2,8 @@ import {IBeaconPreset, BeaconPreset} from "@chainsafe/lodestar-params";
 import {IChainConfig, ChainConfig} from "@chainsafe/lodestar-config";
 import {Bytes32, Number64, phase0, ssz} from "@chainsafe/lodestar-types";
 import {mapValues} from "@chainsafe/lodestar-utils";
-import {ByteVectorType, ContainerType} from "@chainsafe/ssz";
-import {
-  ArrayOf,
-  ContainerData,
-  ReqEmpty,
-  reqEmpty,
-  ReturnTypes,
-  ReqSerializers,
-  RoutesData,
-  withJsonFilled,
-} from "../utils";
+import {ByteVectorType, ContainerType, Json, Type} from "@chainsafe/ssz";
+import {ArrayOf, ContainerData, ReqEmpty, reqEmpty, ReturnTypes, ReqSerializers, RoutesData, TypeJson} from "../utils";
 
 // See /packages/api/src/routes/index.ts for reasoning and instructions to add new routes
 
@@ -70,6 +61,13 @@ export type ReqTypes = {[K in keyof Api]: ReqEmpty};
 
 export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
   return mapValues(routesData, () => reqEmpty);
+}
+
+function withJsonFilled<T>(dataType: Type<T>, fillWith: Json): TypeJson<{data: T}> {
+  return {
+    toJson: ({data}, opts) => ({data: dataType.toJson(data, opts)}),
+    fromJson: ({data}: {data: Json}, opts) => ({data: dataType.fromJson(Object.assign({}, fillWith, data), opts)}),
+  };
 }
 
 /* eslint-disable @typescript-eslint/naming-convention */

--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -3,7 +3,16 @@ import {IChainConfig, ChainConfig} from "@chainsafe/lodestar-config";
 import {Bytes32, Number64, phase0, ssz} from "@chainsafe/lodestar-types";
 import {mapValues} from "@chainsafe/lodestar-utils";
 import {ByteVectorType, ContainerType} from "@chainsafe/ssz";
-import {ArrayOf, ContainerData, ReqEmpty, reqEmpty, ReturnTypes, ReqSerializers, RoutesData} from "../utils";
+import {
+  ArrayOf,
+  ContainerData,
+  ReqEmpty,
+  reqEmpty,
+  ReturnTypes,
+  ReqSerializers,
+  RoutesData,
+  withJsonFilled,
+} from "../utils";
 
 // See /packages/api/src/routes/index.ts for reasoning and instructions to add new routes
 
@@ -64,7 +73,7 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
 }
 
 /* eslint-disable @typescript-eslint/naming-convention */
-export function getReturnTypes(): ReturnTypes<Api> {
+export function getReturnTypes(config: IChainConfig): ReturnTypes<Api> {
   const DepositContract = new ContainerType<DepositContract>({
     fields: {
       chainId: ssz.Number64,
@@ -80,6 +89,6 @@ export function getReturnTypes(): ReturnTypes<Api> {
   return {
     getDepositContract: ContainerData(DepositContract),
     getForkSchedule: ContainerData(ArrayOf(ssz.phase0.Fork)),
-    getSpec: ContainerData(Spec),
+    getSpec: withJsonFilled(Spec, ChainConfig.toJson(config)),
   };
 }

--- a/packages/api/src/utils/types.ts
+++ b/packages/api/src/utils/types.ts
@@ -150,12 +150,3 @@ export function sameType<T>(): TypeJson<T> {
     fromJson: (json) => (json as unknown) as T,
   };
 }
-
-/** Helper to fill missing fields that might not been activated, and thus can be missing
- * especially in interop with other client beacons */
-export function withJsonFilled<T>(dataType: Type<T>, fillWith: Json): TypeJson<{data: T}> {
-  return {
-    toJson: ({data}, opts) => ({data: dataType.toJson(data, opts)}),
-    fromJson: ({data}: {data: Json}, opts) => ({data: dataType.fromJson(Object.assign({}, fillWith, data), opts)}),
-  };
-}

--- a/packages/api/src/utils/types.ts
+++ b/packages/api/src/utils/types.ts
@@ -150,3 +150,12 @@ export function sameType<T>(): TypeJson<T> {
     fromJson: (json) => (json as unknown) as T,
   };
 }
+
+/** Helper to fill missing fields that might not been activated, and thus can be missing
+ * especially in interop with other client beacons */
+export function withJsonFilled<T>(dataType: Type<T>, fillWith: Json): TypeJson<{data: T}> {
+  return {
+    toJson: ({data}, opts) => ({data: dataType.toJson(data, opts)}),
+    fromJson: ({data}: {data: Json}, opts) => ({data: dataType.fromJson(Object.assign({}, fillWith, data), opts)}),
+  };
+}


### PR DESCRIPTION
**Motivation**
When we interop with other clients like lighthouse, their spec api might not have fields that we expect as they might not have been operational, for e.g. those belonging to the merge spec.
By populating those fields in the `--paramsFile` file with appropriate values , this PR allows them to be filled in the spec, and hence let the validator run in an interop fashion.

<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**
Example the current branch of lighthouse doesnt provides: `TERMINAL_TOTAL_DIFFICULTY`, `MERGE_FORK_VERSION`, `SHARDING_FORK_VERSION` ...
defining them in a params config file and using them via `--paramsFile`
![image](https://user-images.githubusercontent.com/76567250/137858751-06a40978-b3e0-45f9-b4d4-068a204a4ca7.png)
allows us to supply those fields to the validator and move forward.

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number
https://github.com/ChainSafe/lodestar/issues/3369
**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
