### PR TITLE
Fix compute checkpoint from anchor state

### DIFF
--- a/packages/lodestar/src/chain/initState.ts
+++ b/packages/lodestar/src/chain/initState.ts
@@ -14,6 +14,7 @@ import {allForks, ssz} from "@chainsafe/lodestar-types";
 import {IBeaconConfig, IChainForkConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {toHexString, TreeBacked} from "@chainsafe/ssz";
+import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {GENESIS_SLOT, ZERO_HASH} from "../constants";
 import {IBeaconDb} from "../db";
 import {Eth1Provider} from "../eth1";
@@ -224,7 +225,9 @@ export function computeAnchorCheckpoint(
   return {
     checkpoint: {
       root,
-      epoch: computeEpochAtSlot(anchorState.slot),
+      // the checkpoint epoch = computeEpochAtSlot(anchorState.slot) + 1 if slot is not at epoch boundary
+      // this is similar to a process_slots() call
+      epoch: Math.ceil(anchorState.slot / SLOTS_PER_EPOCH),
     },
     blockHeader,
   };


### PR DESCRIPTION
**Motivation**

+ Not able to sync from a finalized state where slot is not at epoch boundary
+ this is due to the incorrect checkpoint epoch when we initialize forkchoice which leads sync to download blocks before finalized state, hence `BLOCK_ERROR_PARENT_UNKNOWN` error

**Description**
+ when extracting checkpoint from a finalized state and slot is not at epoch boundary, checkpoint epoch is actually `slotEpoch+1`
+ in the issue finalized state slot = 1509951 => checkpoint epoch should be 47186, not 47185


Closes #3380

**Steps to test or reproduce**
+ download `state_1509951.ssz` in the issue
+ `./bin/lodestar beacon --network prater --weakSubjectivityStateFile state_1509951.ssz`