### PR TITLE
weak subjecitivity checks

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/weakSubjectivity.ts
+++ b/packages/beacon-state-transition/src/allForks/util/weakSubjectivity.ts
@@ -10,7 +10,14 @@ import {ssz} from "@chainsafe/lodestar-types";
 import {Checkpoint} from "@chainsafe/lodestar-types/phase0";
 import {toHexString} from "@chainsafe/ssz";
 import {CachedBeaconState} from ".";
-import {getActiveValidatorIndices, getCurrentEpoch, computeEpochAtSlot, ZERO_HASH, getChurnLimit} from "../..";
+import {
+  getActiveValidatorIndices,
+  getCurrentEpoch,
+  computeEpochAtSlot,
+  ZERO_HASH,
+  getChurnLimit,
+  getCurrentSlot,
+} from "../..";
 
 export const ETH_TO_GWEI = 10 ** 9;
 const SAFETY_DECAY = BigInt(10);
@@ -109,7 +116,6 @@ export function getLatestBlockRoot(config: IChainForkConfig, state: allForks.Bea
 
 export function isWithinWeakSubjectivityPeriod(
   config: IBeaconConfig,
-  store: allForks.BeaconState,
   wsState: allForks.BeaconState,
   wsCheckpoint: Checkpoint
 ): boolean {
@@ -124,6 +130,6 @@ export function isWithinWeakSubjectivityPeriod(
     throw new Error(`Epochs do not match.  expected=${wsCheckpoint.epoch}, actual=${wsStateEpoch}`);
   }
   const wsPeriod = computeWeakSubjectivityPeriod(config, wsState);
-  const currentEpoch = getCurrentEpoch(store);
-  return currentEpoch <= wsStateEpoch + wsPeriod;
+  const clockEpoch = computeEpochAtSlot(getCurrentSlot(config, wsState.genesisTime));
+  return clockEpoch <= wsStateEpoch + wsPeriod;
 }

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -55,7 +55,7 @@ async function initAndVerifyWeakSubjectivityState(
   if (store.slot > wsState.slot) {
     anchorState = store;
     anchorCheckpoint = getCheckpointFromState(config, store);
-    logger.info("Db state is ahead of the provided checkpoint state, using the same to initialize the beacon chain");
+    logger.verbose("Db state is ahead of the provided checkpoint state, using the db state to initialize the beacon chain");
   }
 
   if (!allForks.isWithinWeakSubjectivityPeriod(config, anchorState, anchorCheckpoint)) {

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -48,7 +48,7 @@ async function initAndVerifyWeakSubjectivityState(
       "Db state and checkpoint state are not compatible, either clear the db or verify your checkpoint source"
     );
   }
-  
+
   if (!allForks.isWithinWeakSubjectivityPeriod(config, wsState, wsCheckpoint)) {
     throw new Error("Fetched weak subjectivity checkpoint not within weak subjectivity period.");
   }

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -55,7 +55,9 @@ async function initAndVerifyWeakSubjectivityState(
   if (store.slot > wsState.slot) {
     anchorState = store;
     anchorCheckpoint = getCheckpointFromState(config, store);
-    logger.verbose("Db state is ahead of the provided checkpoint state, using the db state to initialize the beacon chain");
+    logger.verbose(
+      "Db state is ahead of the provided checkpoint state, using the db state to initialize the beacon chain"
+    );
   }
 
   if (!allForks.isWithinWeakSubjectivityPeriod(config, anchorState, anchorCheckpoint)) {


### PR DESCRIPTION
**Motivation**

<!-- Why is this PR exists? What are the goals of the pull request? -->
The aim of the PR is to rectify weak subjectivity checks:
- [x] while intializing if DB's finalized is ahead of the provided anchor states finalized (though wssStateFile), use the db's finalized as anchor state instead of again starting from the wss checkpoint  
- [x] add a simpler check on wss's subjectivity period of the anchor state w.r.t. the clockSlot while initializing the chain
**Description**

UPDATE:
previous resolution of making the wss check on the head when chain syncs to synced state for the first time was deemed overkill, so reverted that and replaced with the initialization time `clockEpoch` check.
<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->
example error of providing an checkpoint wss subjectivity period behind the `clockEpoch`
![image](https://user-images.githubusercontent.com/76567250/139575240-b8c1d308-8be2-4517-bab4-b225d2fe7004.png)

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number
partially closes #3385
**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
