### PR TITLE
Submit API endpoints: verify in batch

### DIFF
--- a/packages/lodestar/src/api/impl/beacon/pool/index.ts
+++ b/packages/lodestar/src/api/impl/beacon/pool/index.ts
@@ -94,9 +94,10 @@ export function getBeaconPoolApi({
           throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.INVALID_SIGNATURE});
         }
         // all are validated
+        const targetEpoch = attTarget.epoch;
         for (const indexedAttestation of indexedAttestations) {
           metrics?.registerUnaggregatedAttestation(OpSource.api, seenTimestampSec, indexedAttestation);
-          chain.seenAttesters.add(attTarget.epoch, indexedAttestation.attestingIndices[0]);
+          chain.seenAttesters.add(targetEpoch, indexedAttestation.attestingIndices[0]);
         }
         for (const [subnet, attestations] of attestationsBySubnet.entries()) {
           await Promise.all(attestations.map((a) => network.gossip.publishBeaconAttestation(a, subnet)));

--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -454,6 +454,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
           })
         );
       } catch (e) {
+        // if one failed validation, this is slower as we verify signatures one by one
         await Promise.all(
           signedAggregateAndProofs.map(async (signedAggregateAndProof, i) => {
             try {
@@ -554,6 +555,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
           })
         );
       } catch (e) {
+        // if one failed validation, this is slower as we verify signatures one by one
         await Promise.all(
           contributionAndProofs.map(async (contributionAndProof, i) => {
             try {


### PR DESCRIPTION
**Motivation**

+ Submitting attestations requires verifying signatures separately and regen same target state

**Description**

+ Regen same target state first
+ Validate all attestations
+ Get all signatures and verify once
+ If one attestation failed, handle separately like what we're doing

part of #3390
