### PR TITLE
Benchmark cost of a throw

### DIFF
--- a/packages/lodestar/test/perf/misc/throw.test.ts
+++ b/packages/lodestar/test/perf/misc/throw.test.ts
@@ -1,0 +1,51 @@
+import {itBench} from "@dapplion/benchmark";
+
+describe("misc / throw vs return", () => {
+  const count = 10000;
+
+  type Status = {code: string; value: number};
+
+  function statusReturn(i: number): Status {
+    return {
+      code: "OK",
+      value: i,
+    };
+  }
+
+  class ErrorStatus extends Error implements Status {
+    constructor(readonly code: string, readonly value: number) {
+      super(code);
+    }
+  }
+
+  function statusThrow(i: number): never {
+    throw new ErrorStatus("OK", i);
+  }
+
+  itBench({
+    id: `Return object ${count} times`,
+    noThreshold: true,
+    runsFactor: count,
+    fn: () => {
+      for (let i = 0; i < count; i++) {
+        const res = statusReturn(i);
+        res.code;
+      }
+    },
+  });
+
+  itBench({
+    id: `Throw Error ${count} times`,
+    noThreshold: true,
+    runsFactor: count,
+    fn: () => {
+      for (let i = 0; i < count; i++) {
+        try {
+          statusThrow(i);
+        } catch (e) {
+          (e as Status).code;
+        }
+      }
+    },
+  });
+});


### PR DESCRIPTION
**Motivation**

We use a throw + catch pattern in gossip validation, which is a relatively hot path in our application. This benchmark shows that throw + catch is x1000 more expensive than just returning objects. We should refactor gossip validation to return objects instead of throwing in most cases.

**Description**

- Benchmark cost of a throw
