### PR TITLE
prefixing lodestar to lodestar metrics, suffixing with a quantifier

### DIFF
--- a/docker/grafana/provisioning/dashboards/lodestar.json
+++ b/docker/grafana/provisioning/dashboards/lodestar.json
@@ -283,7 +283,7 @@
           "pluginVersion": "8.1.5",
           "targets": [
             {
-              "expr": "sum(lodestar_peers_by_direction)",
+              "expr": "sum(lodestar_peers_by_direction_count)",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -919,7 +919,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "lodestar_peers_by_direction",
+              "expr": "lodestar_peers_by_direction_count",
               "hide": false,
               "interval": "",
               "legendFormat": "{{direction}}",
@@ -2309,7 +2309,7 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "rate(unhandeled_promise_rejections[$__rate_interval])",
+              "expr": "rate(lodestar_unhandeled_promise_rejections_total[$__rate_interval])",
               "interval": "",
               "legendFormat": "Errors",
               "refId": "A"
@@ -2758,7 +2758,7 @@
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "sum(delta(validator_monitor_prev_epoch_on_chain_attester_miss[$__rate_interval])) / (sum(delta(validator_monitor_prev_epoch_on_chain_attester_hit[$__rate_interval])) + sum(delta(validator_monitor_prev_epoch_on_chain_attester_miss[$__rate_interval])))",
+              "expr": "sum(delta(validator_monitor_prev_epoch_on_chain_attester_miss_total[$__rate_interval])) / (sum(delta(validator_monitor_prev_epoch_on_chain_attester_hit_total[$__rate_interval])) + sum(delta(validator_monitor_prev_epoch_on_chain_attester_miss_total[$__rate_interval])))",
               "interval": "",
               "legendFormat": "{{index}}",
               "refId": "A"
@@ -2933,7 +2933,7 @@
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "(sum(delta(validator_monitor_prev_epoch_on_chain_head_attester_miss[$__rate_interval])) OR vector(0))\n/\n((sum(delta(validator_monitor_prev_epoch_on_chain_head_attester_hit[$__rate_interval])) OR vector(0))\n+\n(sum(delta(validator_monitor_prev_epoch_on_chain_head_attester_miss[$__rate_interval])) OR vector(0)))",
+              "expr": "(sum(delta(validator_monitor_prev_epoch_on_chain_head_attester_miss_total[$__rate_interval])) OR vector(0))\n/\n((sum(delta(validator_monitor_prev_epoch_on_chain_head_attester_hit_total[$__rate_interval])) OR vector(0))\n+\n(sum(delta(validator_monitor_prev_epoch_on_chain_head_attester_miss_total[$__rate_interval])) OR vector(0)))",
               "interval": "",
               "legendFormat": "{{index}}",
               "refId": "A"
@@ -3019,7 +3019,7 @@
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "sum(delta(validator_monitor_prev_epoch_on_chain_target_attester_miss[$__rate_interval])) /  (sum(delta(validator_monitor_prev_epoch_on_chain_target_attester_hit[$__rate_interval])) + sum(delta(validator_monitor_prev_epoch_on_chain_target_attester_miss[$__rate_interval])))",
+              "expr": "sum(delta(validator_monitor_prev_epoch_on_chain_target_attester_miss_total[$__rate_interval])) /  (sum(delta(validator_monitor_prev_epoch_on_chain_target_attester_hit_total[$__rate_interval])) + sum(delta(validator_monitor_prev_epoch_on_chain_target_attester_miss_total[$__rate_interval])))",
               "interval": "",
               "legendFormat": "{{index}}",
               "refId": "A"
@@ -4323,7 +4323,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(lodestar_bls_thread_pool_batch_retries[$__rate_interval])",
+              "expr": "rate(lodestar_bls_thread_pool_batch_retries_total[$__rate_interval])",
               "interval": "",
               "legendFormat": "pool",
               "refId": "A"
@@ -7206,7 +7206,7 @@
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "delta(lodestar_peer_goodbye_received[$__rate_interval])>0",
+              "expr": "delta(lodestar_peer_goodbye_received_total[$__rate_interval])>0",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -7302,7 +7302,7 @@
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "delta(lodestar_peer_connected[$__rate_interval])>0",
+              "expr": "delta(lodestar_peer_connected_total[$__rate_interval])>0",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -7386,7 +7386,7 @@
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "delta(lodestar_peer_goodbye_sent[$__rate_interval])>0",
+              "expr": "delta(lodestar_peer_goodbye_sent_total[$__rate_interval])>0",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -7482,7 +7482,7 @@
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "delta(lodestar_peer_disconnected[$__rate_interval])>0",
+              "expr": "delta(lodestar_peer_disconnected_total[$__rate_interval])>0",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -7642,7 +7642,7 @@
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "lodestar_peer_connected - lodestar_peer_disconnected - lodestar_peers_by_direction",
+              "expr": "lodestar_peer_connected_total - lodestar_peer_disconnected_total - lodestar_peers_by_direction_count",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 3,
@@ -7713,7 +7713,7 @@
           "pluginVersion": "8.1.4",
           "targets": [
             {
-              "expr": "lodestar_gossip_mesh_peers_by_type{type!~\"beacon_attestation\"}",
+              "expr": "lodestar_gossip_mesh_peers_by_type_count{type!~\"beacon_attestation\"}",
               "format": "time_series",
               "interval": "",
               "legendFormat": "{{type}}",
@@ -7768,7 +7768,7 @@
           "pluginVersion": "8.1.4",
           "targets": [
             {
-              "expr": "lodestar_gossip_mesh_peers_by_beacon_attestation_subnet",
+              "expr": "lodestar_gossip_mesh_peers_by_beacon_attestation_subnet_count",
               "interval": "",
               "legendFormat": "{{subnet}}",
               "refId": "A"
@@ -9197,14 +9197,14 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "rate(state_cache_lookups_total{}[$__rate_interval])",
+              "expr": "rate(lodestar_state_cache_lookups_total{}[$__rate_interval])",
               "interval": "",
               "legendFormat": "total lookups",
               "refId": "A"
             },
             {
               "exemplar": false,
-              "expr": "rate(state_cache_hits_total{}[$__rate_interval])",
+              "expr": "rate(lodestar_state_cache_hits_total{}[$__rate_interval])",
               "hide": false,
               "interval": "",
               "legendFormat": "cache hits",
@@ -9286,14 +9286,14 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "rate(cp_state_cache_lookups_total{}[$__rate_interval])",
+              "expr": "rate(lodestar_cp_state_cache_lookups_total{}[$__rate_interval])",
               "interval": "",
               "legendFormat": "total lookups",
               "refId": "A"
             },
             {
               "exemplar": false,
-              "expr": "rate(cp_state_cache_hits_total{}[$__rate_interval])",
+              "expr": "rate(lodestar_cp_state_cache_hits_total{}[$__rate_interval])",
               "hide": false,
               "interval": "",
               "legendFormat": "cache hits",
@@ -9375,7 +9375,7 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "state_cache_size{}",
+              "expr": "lodestar_state_cache_size{}",
               "interval": "",
               "legendFormat": "states",
               "refId": "A"
@@ -9456,14 +9456,14 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "cp_state_cache_size{}",
+              "expr": "lodestar_cp_state_cache_size{}",
               "interval": "",
               "legendFormat": "states",
               "refId": "A"
             },
             {
               "exemplar": false,
-              "expr": "cp_state_epoch_size",
+              "expr": "lodestar_cp_state_epoch_size",
               "hide": false,
               "interval": "",
               "legendFormat": "epochs",
@@ -9545,14 +9545,14 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "rate(state_cache_adds_total{}[$__rate_interval])",
+              "expr": "rate(lodestar_state_cache_adds_total{}[$__rate_interval])",
               "interval": "",
               "legendFormat": "state cache",
               "refId": "A"
             },
             {
               "exemplar": false,
-              "expr": "rate(cp_state_cache_adds_total{}[$__rate_interval])",
+              "expr": "rate(lodestar_cp_state_cache_adds_total{}[$__rate_interval])",
               "hide": false,
               "interval": "",
               "legendFormat": "checkpointState cache",
@@ -9650,13 +9650,13 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "sum by (entrypoint)(12*rate(regen_fn_call_total[$__rate_interval]))",
+              "expr": "sum by (entrypoint)(12*rate(lodestar_regen_fn_call_total[$__rate_interval]))",
               "interval": "",
               "legendFormat": "{{entrypoint}}",
               "refId": "A"
             }
           ],
-          "title": "Call rate per slot(grouped by entrypoint)",
+          "title": "Call rate per slot (grouped by entrypoint)",
           "type": "timeseries"
         },
         {
@@ -9731,13 +9731,13 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "sum by (caller)(12*rate(regen_fn_call_total[$__rate_interval]))",
+              "expr": "sum by (caller)(12*rate(lodestar_regen_fn_call_total[$__rate_interval]))",
               "interval": "",
               "legendFormat": "{{caller}}",
               "refId": "A"
             }
           ],
-          "title": "Call rate per slot(grouped by caller)",
+          "title": "Call rate per slot (grouped by caller)",
           "type": "timeseries"
         },
         {
@@ -9813,13 +9813,13 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "sum by (entrypoint)(delta(regen_fn_call_duration_sum[$__rate_interval]))/sum by (entrypoint)(delta(regen_fn_call_duration_count[$__rate_interval]))",
+              "expr": "sum by (entrypoint)(delta(lodestar_regen_fn_call_duration_sum[$__rate_interval]))/sum by (entrypoint)(delta(lodestar_regen_fn_call_duration_count[$__rate_interval]))",
               "interval": "",
               "legendFormat": "{{entrypoint}}",
               "refId": "A"
             }
           ],
-          "title": "Regen job avg time(grouped by entrypoint)",
+          "title": "Regen job avg time (grouped by entrypoint)",
           "type": "timeseries"
         },
         {
@@ -9895,13 +9895,13 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "sum by (caller)(delta(regen_fn_call_duration_sum[$__rate_interval]))/sum by (caller)(delta(regen_fn_call_duration_count[$__rate_interval]))",
+              "expr": "sum by (caller)(delta(lodestar_regen_fn_call_duration_sum[$__rate_interval]))/sum by (caller)(delta(lodestar_regen_fn_call_duration_count[$__rate_interval]))",
               "interval": "",
               "legendFormat": "{{caller}}",
               "refId": "A"
             }
           ],
-          "title": "Regen job avg time(grouped by caller)",
+          "title": "Regen job avg time (grouped by caller)",
           "type": "timeseries"
         },
         {
@@ -9979,7 +9979,7 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "sum by (entrypoint) (delta(regen_fn_queued_total[$__rate_interval]))/sum by (entrypoint)(delta(regen_fn_call_total[$__rate_interval]))",
+              "expr": "sum by (entrypoint) (delta(lodestar_regen_fn_queued_total[$__rate_interval]))/sum by (entrypoint)(delta(lodestar_regen_fn_call_total[$__rate_interval]))",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -10063,13 +10063,13 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "sum by (caller) (delta(regen_fn_queued_total[$__rate_interval]))/sum by (caller)(delta(regen_fn_call_total[$__rate_interval]))",
+              "expr": "sum by (caller) (delta(lodestar_regen_fn_queued_total[$__rate_interval]))/sum by (caller)(delta(lodestar_regen_fn_call_total[$__rate_interval]))",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
             }
           ],
-          "title": "Cache miss(grouped by caller)",
+          "title": "Cache miss (grouped by caller)",
           "type": "timeseries"
         },
         {
@@ -10147,13 +10147,13 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "sum by (entrypoint)(rate(regen_fn_total_errors[$__rate_interval]))/sum by (entrypoint)(rate(regen_fn_call_duration_count[$__rate_interval]))",
+              "expr": "sum by (entrypoint)(rate(lodestar_regen_fn_errors_total[$__rate_interval]))/sum by (entrypoint)(rate(lodestar_regen_fn_call_duration_count[$__rate_interval]))",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
             }
           ],
-          "title": "Error rate(grouped by entrypoint)",
+          "title": "Error rate (grouped by entrypoint)",
           "type": "timeseries"
         },
         {
@@ -10231,13 +10231,13 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "sum by (caller)(rate(regen_fn_total_errors[$__rate_interval]))/sum by (caller)(rate(regen_fn_call_duration_count[$__rate_interval]))",
+              "expr": "sum by (caller)(rate(lodestar_regen_fn_errors_total[$__rate_interval]))/sum by (caller)(rate(lodestar_regen_fn_call_duration_count[$__rate_interval]))",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
             }
           ],
-          "title": "Error rate(grouped by caller)",
+          "title": "Error rate (grouped by caller)",
           "type": "timeseries"
         }
       ],
@@ -10329,7 +10329,7 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "delta(gossip_block_elappsed_time_till_received_sum[$__rate_interval])/delta(gossip_block_elappsed_time_till_received_count[$__rate_interval])",
+              "expr": "delta(lodestar_gossip_block_elappsed_time_till_received_sum[$__rate_interval])/delta(lodestar_gossip_block_elappsed_time_till_received_count[$__rate_interval])",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -10412,7 +10412,7 @@
           "targets": [
             {
               "exemplar": false,
-              "expr": "delta(gossip_block_elappsed_time_till_processed_sum[$__rate_interval])/delta(gossip_block_elappsed_time_till_processed_count[$__rate_interval])",
+              "expr": "delta(lodestar_gossip_block_elappsed_time_till_processed_sum[$__rate_interval])/delta(lodestar_gossip_block_elappsed_time_till_processed_count[$__rate_interval])",
               "interval": "",
               "legendFormat": "",
               "refId": "A"

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -40,28 +40,28 @@ export function createLodestarMetrics(
     // Peers
 
     peersByDirection: register.gauge<"direction">({
-      name: "lodestar_peers_by_direction",
+      name: "lodestar_peers_by_direction_count",
       help: "number of peers, labeled by direction",
       labelNames: ["direction"],
     }),
     peerConnectedEvent: register.gauge<"direction">({
-      name: "lodestar_peer_connected",
-      help: "Number of peer:connected event, labeled by direction",
+      name: "lodestar_peer_connected_total",
+      help: "Total number of peer:connected event, labeled by direction",
       labelNames: ["direction"],
     }),
     peerDisconnectedEvent: register.gauge<"direction">({
-      name: "lodestar_peer_disconnected",
-      help: "Number of peer:disconnected event, labeled by direction",
+      name: "lodestar_peer_disconnected_total",
+      help: "Total number of peer:disconnected event, labeled by direction",
       labelNames: ["direction"],
     }),
     peerGoodbyeReceived: register.gauge<"reason">({
-      name: "lodestar_peer_goodbye_received",
-      help: "Number of goodbye received, labeled by reason",
+      name: "lodestar_peer_goodbye_received_total",
+      help: "Total number of goodbye received, labeled by reason",
       labelNames: ["reason"],
     }),
     peerGoodbyeSent: register.gauge<"reason">({
-      name: "lodestar_peer_goodbye_sent",
-      help: "Number of goodbye sent, labeled by reason",
+      name: "lodestar_peer_goodbye_sent_total",
+      help: "Total number of goodbye sent, labeled by reason",
       labelNames: ["reason"],
     }),
     peersTotalUniqueConnected: register.gauge({
@@ -70,33 +70,33 @@ export function createLodestarMetrics(
     }),
 
     gossipMeshPeersByType: register.gauge<"type" | "fork">({
-      name: "lodestar_gossip_mesh_peers_by_type",
+      name: "lodestar_gossip_mesh_peers_by_type_count",
       help: "Number of connected mesh peers per gossip type",
       labelNames: ["type", "fork"],
     }),
     gossipMeshPeersByBeaconAttestationSubnet: register.gauge<"subnet" | "fork">({
-      name: "lodestar_gossip_mesh_peers_by_beacon_attestation_subnet",
+      name: "lodestar_gossip_mesh_peers_by_beacon_attestation_subnet_count",
       help: "Number of connected mesh peers per beacon attestation subnet",
       labelNames: ["subnet", "fork"],
     }),
     gossipMeshPeersBySyncCommitteeSubnet: register.gauge<"subnet" | "fork">({
-      name: "lodestar_gossip_mesh_peers_by_sync_committee_subnet",
+      name: "lodestar_gossip_mesh_peers_by_sync_committee_subnet_count",
       help: "Number of connected mesh peers per sync committee subnet",
       labelNames: ["subnet", "fork"],
     }),
 
     gossipValidationAccept: register.gauge<"topic">({
-      name: "lodestar_gossip_validation_accept",
+      name: "lodestar_gossip_validation_accept_total",
       help: "Count of total gossip validation accept",
       labelNames: ["topic"],
     }),
     gossipValidationIgnore: register.gauge<"topic">({
-      name: "lodestar_gossip_validation_ignore",
+      name: "lodestar_gossip_validation_ignore_total",
       help: "Count of total gossip validation ignore",
       labelNames: ["topic"],
     }),
     gossipValidationReject: register.gauge<"topic">({
-      name: "lodestar_gossip_validation_reject",
+      name: "lodestar_gossip_validation_reject_total",
       help: "Count of total gossip validation reject",
       labelNames: ["topic"],
     }),
@@ -224,7 +224,7 @@ export function createLodestarMetrics(
       }),
       // Re-verifying a batch means doing double work. This number must be very low or it can be a waste of CPU resources
       batchRetries: register.gauge({
-        name: "lodestar_bls_thread_pool_batch_retries",
+        name: "lodestar_bls_thread_pool_batch_retries_total",
         help: "Count of total batches that failed and had to be verified again.",
       }),
       // To count how many sigs are being validated with the optimization of batching them
@@ -248,7 +248,7 @@ export function createLodestarMetrics(
     // Sync
 
     syncChainsStarted: register.gauge<"syncType">({
-      name: "lodestar_sync_chains_started",
+      name: "lodestar_sync_chains_started_total",
       help: "Total number of sync chains started events, labeled by syncType",
       labelNames: ["syncType"],
     }),
@@ -294,12 +294,12 @@ export function createLodestarMetrics(
     // Gossip block
     gossipBlock: {
       elappsedTimeTillReceived: register.histogram({
-        name: "gossip_block_elappsed_time_till_received",
+        name: "lodestar_gossip_block_elappsed_time_till_received",
         help: "Time elappsed between block slot time and the time block received via gossip",
         buckets: [0.1, 1, 10],
       }),
       elappsedTimeTillProcessed: register.histogram({
-        name: "gossip_block_elappsed_time_till_processed",
+        name: "lodestar_gossip_block_elappsed_time_till_processed",
         help: "Time elappsed between block slot time and the time block processed",
         buckets: [0.1, 1, 10],
       }),
@@ -317,33 +317,33 @@ export function createLodestarMetrics(
       // Validator Monitor Metrics (per-epoch summaries)
 
       prevEpochOnChainAttesterHit: register.gauge<"index">({
-        name: "validator_monitor_prev_epoch_on_chain_attester_hit",
+        name: "validator_monitor_prev_epoch_on_chain_attester_hit_total",
         help: "Incremented if the validator is flagged as a previous epoch attester during per epoch processing",
         labelNames: ["index"],
       }),
       prevEpochOnChainAttesterMiss: register.gauge<"index">({
-        name: "validator_monitor_prev_epoch_on_chain_attester_miss",
+        name: "validator_monitor_prev_epoch_on_chain_attester_miss_total",
         help: "Incremented if the validator is not flagged as a previous epoch attester during per epoch processing",
         labelNames: ["index"],
       }),
       prevEpochOnChainHeadAttesterHit: register.gauge<"index">({
-        name: "validator_monitor_prev_epoch_on_chain_head_attester_hit",
+        name: "validator_monitor_prev_epoch_on_chain_head_attester_hit_total",
         help: "Incremented if the validator is flagged as a previous epoch head attester during per epoch processing",
         labelNames: ["index"],
       }),
       prevEpochOnChainHeadAttesterMiss: register.gauge<"index">({
-        name: "validator_monitor_prev_epoch_on_chain_head_attester_miss",
+        name: "validator_monitor_prev_epoch_on_chain_head_attester_miss_total",
         help:
           "Incremented if the validator is not flagged as a previous epoch head attester during per epoch processing",
         labelNames: ["index"],
       }),
       prevEpochOnChainTargetAttesterHit: register.gauge<"index">({
-        name: "validator_monitor_prev_epoch_on_chain_target_attester_hit",
+        name: "validator_monitor_prev_epoch_on_chain_target_attester_hit_total",
         help: "Incremented if the validator is flagged as a previous epoch target attester during per epoch processing",
         labelNames: ["index"],
       }),
       prevEpochOnChainTargetAttesterMiss: register.gauge<"index">({
-        name: "validator_monitor_prev_epoch_on_chain_target_attester_miss",
+        name: "validator_monitor_prev_epoch_on_chain_target_attester_miss_total",
         help:
           "Incremented if the validator is not flagged as a previous epoch target attester during per epoch processing",
         labelNames: ["index"],
@@ -364,12 +364,12 @@ export function createLodestarMetrics(
         labelNames: ["index"],
       }),
       prevEpochAttestationAggregateInclusions: register.gauge<"index">({
-        name: "validator_monitor_prev_epoch_attestation_aggregate_inclusions",
+        name: "validator_monitor_prev_epoch_attestation_aggregate_inclusions_total",
         help: "The count of times an attestation was seen inside an aggregate",
         labelNames: ["index"],
       }),
       prevEpochAttestationBlockInclusions: register.gauge<"index">({
-        name: "validator_monitor_prev_epoch_attestation_block_inclusions",
+        name: "validator_monitor_prev_epoch_attestation_block_inclusions_total",
         help: "The count of times an attestation was seen inside a block",
         labelNames: ["index"],
       }),
@@ -443,7 +443,7 @@ export function createLodestarMetrics(
       }),
       beaconBlockTotal: register.gauge<"index" | "src">({
         name: "validator_monitor_beacon_block_total",
-        help: "Number of beacon blocks seen",
+        help: "Total number of beacon blocks seen",
         labelNames: ["index", "src"],
       }),
       beaconBlockDelaySeconds: register.histogram<"index" | "src">({
@@ -457,86 +457,86 @@ export function createLodestarMetrics(
 
     stateCache: {
       lookups: register.gauge({
-        name: "state_cache_lookups_total",
-        help: "Number of cache lookup",
+        name: "lodestar_state_cache_lookups_total",
+        help: "Total number of cache lookup",
       }),
       hits: register.gauge({
-        name: "state_cache_hits_total",
-        help: "Number of total cache hits",
+        name: "lodestar_state_cache_hits_total",
+        help: "Total number of cache hits",
       }),
       adds: register.gauge({
-        name: "state_cache_adds_total",
-        help: "Number of items added in state cache",
+        name: "lodestar_state_cache_adds_total",
+        help: "Total number of items added in state cache",
       }),
       size: register.gauge({
-        name: "state_cache_size",
+        name: "lodestar_state_cache_size",
         help: "State cache size",
       }),
       reads: register.avgMinMax({
-        name: "state_cache_reads",
+        name: "lodestar_state_cache_reads",
         help: "Avg min max of all state cache items total read count",
       }),
       secondsSinceLastRead: register.avgMinMax({
-        name: "state_cache_seconds_since_last_read",
+        name: "lodestar_state_cache_seconds_since_last_read",
         help: "Avg min max of all state cache items seconds since last reads",
       }),
     },
 
     cpStateCache: {
       lookups: register.gauge({
-        name: "cp_state_cache_lookups_total",
-        help: "Number of checkpoint cache lookup",
+        name: "lodestar_cp_state_cache_lookups_total",
+        help: "Total number of checkpoint cache lookup",
       }),
       hits: register.gauge({
-        name: "cp_state_cache_hits_total",
-        help: "Number of checkpoint cache hits",
+        name: "lodestar_cp_state_cache_hits_total",
+        help: "Total number of checkpoint cache hits",
       }),
       adds: register.gauge({
-        name: "cp_state_cache_adds_total",
-        help: "Number of items added in checkpoint state cache",
+        name: "lodestar_cp_state_cache_adds_total",
+        help: "Total number of items added in checkpoint state cache",
       }),
       size: register.gauge({
-        name: "cp_state_cache_size",
+        name: "lodestar_cp_state_cache_size",
         help: "Checkpoint state cache size",
       }),
       epochSize: register.gauge({
-        name: "cp_state_epoch_size",
+        name: "lodestar_cp_state_epoch_size",
         help: "Checkpoint state cache size",
       }),
       reads: register.avgMinMax({
-        name: "cp_state_epoch_reads",
+        name: "lodestar_cp_state_epoch_reads",
         help: "Avg min max of all state cache items total read count",
       }),
       secondsSinceLastRead: register.avgMinMax({
-        name: "cp_state_epoch_seconds_since_last_read",
+        name: "lodestar_cp_state_epoch_seconds_since_last_read",
         help: "Avg min max of all state cache items seconds since last reads",
       }),
     },
 
     regenFnCallTotal: register.gauge<"entrypoint" | "caller">({
-      name: "regen_fn_call_total",
-      help: "Number of calls for regen functions",
+      name: "lodestar_regen_fn_call_total",
+      help: "Total number of calls for regen functions",
       labelNames: ["entrypoint", "caller"],
     }),
     regenFnQueuedTotal: register.gauge<"entrypoint" | "caller">({
-      name: "regen_fn_queued_total",
-      help: "Number of calls queued for regen functions",
+      name: "lodestar_regen_fn_queued_total",
+      help: "Total number of calls queued for regen functions",
       labelNames: ["entrypoint", "caller"],
     }),
     regenFnCallDuration: register.histogram<"entrypoint" | "caller">({
-      name: "regen_fn_call_duration",
+      name: "lodestar_regen_fn_call_duration",
       help: "regen function duration",
       labelNames: ["entrypoint", "caller"],
       buckets: [0.1, 1, 10, 100],
     }),
     regenFnTotalErrors: register.gauge<"entrypoint" | "caller">({
-      name: "regen_fn_total_errors",
+      name: "lodestar_regen_fn_errors_total",
       help: "regen function total errors",
       labelNames: ["entrypoint", "caller"],
     }),
     unhandeledPromiseRejections: register.gauge({
-      name: "unhandeled_promise_rejections",
-      help: "UnhandeledPromiseRejection count",
+      name: "lodestar_unhandeled_promise_rejections_total",
+      help: "UnhandeledPromiseRejection total count",
     }),
   };
 }


### PR DESCRIPTION
**Motivation**
1. This PR prefixed lodestar metrics name with `lodestar_..` and if a quantifier is missing in gauge metrics like `..._count` or `..._total`, adds that quantifier.
2. changes in lodestar.json dashboard metrics expressions for the same
3. Fixes some styling issues in the regenFn panel titles
<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #3399

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
