### PR TITLE
Add gossip topic peers metrics

### DIFF
--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -69,21 +69,40 @@ export function createLodestarMetrics(
       help: "Total number of unique peers that have had a connection with",
     }),
 
-    gossipMeshPeersByType: register.gauge<"type" | "fork">({
-      name: "lodestar_gossip_mesh_peers_by_type_count",
-      help: "Number of connected mesh peers per gossip type",
-      labelNames: ["type", "fork"],
-    }),
-    gossipMeshPeersByBeaconAttestationSubnet: register.gauge<"subnet" | "fork">({
-      name: "lodestar_gossip_mesh_peers_by_beacon_attestation_subnet_count",
-      help: "Number of connected mesh peers per beacon attestation subnet",
-      labelNames: ["subnet", "fork"],
-    }),
-    gossipMeshPeersBySyncCommitteeSubnet: register.gauge<"subnet" | "fork">({
-      name: "lodestar_gossip_mesh_peers_by_sync_committee_subnet_count",
-      help: "Number of connected mesh peers per sync committee subnet",
-      labelNames: ["subnet", "fork"],
-    }),
+    gossipMesh: {
+      peersByType: register.gauge<"type" | "fork">({
+        name: "lodestar_gossip_mesh_peers_by_type_count",
+        help: "Number of connected mesh peers per gossip type",
+        labelNames: ["type", "fork"],
+      }),
+      peersByBeaconAttestationSubnet: register.gauge<"subnet" | "fork">({
+        name: "lodestar_gossip_mesh_peers_by_beacon_attestation_subnet_count",
+        help: "Number of connected mesh peers per beacon attestation subnet",
+        labelNames: ["subnet", "fork"],
+      }),
+      peersBySyncCommitteeSubnet: register.gauge<"subnet" | "fork">({
+        name: "lodestar_gossip_mesh_peers_by_sync_committee_subnet_count",
+        help: "Number of connected mesh peers per sync committee subnet",
+        labelNames: ["subnet", "fork"],
+      }),
+    },
+    gossipTopic: {
+      peersByType: register.gauge<"type" | "fork">({
+        name: "lodestar_gossip_topic_peers_by_type_count",
+        help: "Number of connected topic peers per gossip type",
+        labelNames: ["type", "fork"],
+      }),
+      peersByBeaconAttestationSubnet: register.gauge<"subnet" | "fork">({
+        name: "lodestar_gossip_topic_peers_by_beacon_attestation_subnet_count",
+        help: "Number of connected topic peers per beacon attestation subnet",
+        labelNames: ["subnet", "fork"],
+      }),
+      peersBySyncCommitteeSubnet: register.gauge<"subnet" | "fork">({
+        name: "lodestar_gossip_topic_peers_by_sync_committee_subnet_count",
+        help: "Number of connected topic peers per sync committee subnet",
+        labelNames: ["subnet", "fork"],
+      }),
+    },
 
     gossipValidationAccept: register.gauge<"topic">({
       name: "lodestar_gossip_validation_accept_total",

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -110,7 +110,7 @@ export class Eth2Gossipsub extends Gossipsub {
     this.jobQueues = jobQueues;
 
     if (metrics) {
-      metrics.gossipMeshPeersByType.addCollect(() => this.onScrapeMetrics(metrics));
+      metrics.gossipMesh.peersByType.addCollect(() => this.onScrapeMetrics(metrics));
     }
   }
 
@@ -385,45 +385,50 @@ export class Eth2Gossipsub extends Gossipsub {
   }
 
   private onScrapeMetrics(metrics: IMetrics): void {
-    // Pre-aggregate results by fork so we can fill the remaining metrics with 0
-    const peersByTypeByFork = new Map2d<ForkName, GossipType, number>();
-    const peersByBeaconAttSubnetByFork = new Map2dArr<ForkName, number>();
-    const peersByBeaconSyncSubnetByFork = new Map2dArr<ForkName, number>();
+    for (const {peersMap, metricsGossip} of [
+      {peersMap: this.mesh, metricsGossip: metrics.gossipMesh},
+      {peersMap: this.topics, metricsGossip: metrics.gossipTopic},
+    ]) {
+      // Pre-aggregate results by fork so we can fill the remaining metrics with 0
+      const peersByTypeByFork = new Map2d<ForkName, GossipType, number>();
+      const peersByBeaconAttSubnetByFork = new Map2dArr<ForkName, number>();
+      const peersByBeaconSyncSubnetByFork = new Map2dArr<ForkName, number>();
 
-    // loop through all mesh entries, count each set size
-    for (const [topicString, peers] of this.mesh.entries()) {
-      // Ignore topics with 0 peers. May prevent overriding after a fork
-      if (peers.size === 0) continue;
+      // loop through all mesh entries, count each set size
+      for (const [topicString, peers] of peersMap) {
+        // Ignore topics with 0 peers. May prevent overriding after a fork
+        if (peers.size === 0) continue;
 
-      const topic = this.gossipTopicCache.getTopic(topicString);
-      if (topic.type === GossipType.beacon_attestation) {
-        peersByBeaconAttSubnetByFork.set(topic.fork, topic.subnet, peers.size);
-      } else if (topic.type === GossipType.sync_committee) {
-        peersByBeaconSyncSubnetByFork.set(topic.fork, topic.subnet, peers.size);
-      } else {
-        peersByTypeByFork.set(topic.fork, topic.type, peers.size);
+        const topic = this.gossipTopicCache.getTopic(topicString);
+        if (topic.type === GossipType.beacon_attestation) {
+          peersByBeaconAttSubnetByFork.set(topic.fork, topic.subnet, peers.size);
+        } else if (topic.type === GossipType.sync_committee) {
+          peersByBeaconSyncSubnetByFork.set(topic.fork, topic.subnet, peers.size);
+        } else {
+          peersByTypeByFork.set(topic.fork, topic.type, peers.size);
+        }
       }
-    }
 
-    // beacon attestation mesh gets counted separately so we can track mesh peers by subnet
-    // zero out all gossip type & subnet choices, so the dashboard will register them
-    for (const [fork, peersByType] of peersByTypeByFork.map.entries()) {
-      for (const type of Object.values(GossipType)) {
-        metrics.gossipMeshPeersByType.set({fork, type}, peersByType.get(type) ?? 0);
+      // beacon attestation mesh gets counted separately so we can track mesh peers by subnet
+      // zero out all gossip type & subnet choices, so the dashboard will register them
+      for (const [fork, peersByType] of peersByTypeByFork.map) {
+        for (const type of Object.values(GossipType)) {
+          metricsGossip.peersByType.set({fork, type}, peersByType.get(type) ?? 0);
+        }
       }
-    }
-    for (const [fork, peersByBeaconAttSubnet2] of peersByBeaconAttSubnetByFork.map.entries()) {
-      for (let subnet = 0; subnet < ATTESTATION_SUBNET_COUNT; subnet++) {
-        metrics.gossipMeshPeersByBeaconAttestationSubnet.set(
-          {fork, subnet: attSubnetLabel(subnet)},
-          peersByBeaconAttSubnet2[subnet] ?? 0
-        );
+      for (const [fork, peersByBeaconAttSubnet] of peersByBeaconAttSubnetByFork.map) {
+        for (let subnet = 0; subnet < ATTESTATION_SUBNET_COUNT; subnet++) {
+          metricsGossip.peersByBeaconAttestationSubnet.set(
+            {fork, subnet: attSubnetLabel(subnet)},
+            peersByBeaconAttSubnet[subnet] ?? 0
+          );
+        }
       }
-    }
-    for (const [fork, peersByBeaconSyncSubnet2] of peersByBeaconSyncSubnetByFork.map.entries()) {
-      for (let subnet = 0; subnet < SYNC_COMMITTEE_SUBNET_COUNT; subnet++) {
-        // SYNC_COMMITTEE_SUBNET_COUNT is < 9, no need to prepend a 0 to the label
-        metrics.gossipMeshPeersBySyncCommitteeSubnet.set({fork, subnet}, peersByBeaconSyncSubnet2[subnet] ?? 0);
+      for (const [fork, peersByBeaconSyncSubnet] of peersByBeaconSyncSubnetByFork.map) {
+        for (let subnet = 0; subnet < SYNC_COMMITTEE_SUBNET_COUNT; subnet++) {
+          // SYNC_COMMITTEE_SUBNET_COUNT is < 9, no need to prepend a 0 to the label
+          metricsGossip.peersBySyncCommitteeSubnet.set({fork, subnet}, peersByBeaconSyncSubnet[subnet] ?? 0);
+        }
       }
     }
   }


### PR DESCRIPTION
**Motivation**

Currently we only register mesh peers (from `gossip.mesh`). It's very important to know about peers in each topic too (from `gossip.topics`).

**Description**

Duplicate gossip peers metrics for mesh and topics