### PR TITLE
Update discv5 to v0.6.5

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,7 +53,7 @@
     "@chainsafe/bls-keygen": "^0.3.0",
     "@chainsafe/bls-keystore": "2.0.0",
     "@chainsafe/blst": "^0.2.2",
-    "@chainsafe/discv5": "^0.6.4",
+    "@chainsafe/discv5": "^0.6.5",
     "@chainsafe/lodestar": "^0.31.0",
     "@chainsafe/lodestar-api": "^0.31.0",
     "@chainsafe/lodestar-beacon-state-transition": "^0.31.0",

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@chainsafe/abort-controller": "^3.0.1",
     "@chainsafe/bls": "6.0.3",
-    "@chainsafe/discv5": "^0.6.4",
+    "@chainsafe/discv5": "^0.6.5",
     "@chainsafe/libp2p-noise": "4.1.1",
     "@chainsafe/lodestar-api": "^0.31.0",
     "@chainsafe/lodestar-beacon-state-transition": "^0.31.0",

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -136,6 +136,10 @@ export function createLodestarMetrics(
         name: "lodestar_discv5_kad_table_size",
         help: "Total size of the discv5 kad table",
       }),
+      lookupCount: register.gauge({
+        name: "lodestar_discv5_lookup_count",
+        help: "Total count of discv5 lookups",
+      }),
       activeSessionCount: register.gauge({
         name: "lodestar_discv5_active_session_count",
         help: "Count of the discv5 active sessions",

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,10 +447,10 @@
     node-fetch "^2.6.1"
     node-gyp "^7.1.2"
 
-"@chainsafe/discv5@^0.6.4":
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/@chainsafe/discv5/-/discv5-0.6.4.tgz#567b3da1bd0efd573612f3c088fcc68ba96220b9"
-  integrity sha512-98+W2xwBfnHuiOzhT2FzHdWKX5lrdrL+jP5Oz16aQGDJnwagPwhAKtpsuBGCqMfLtbXF2Z6ksP4Q0KFPyTGjeg==
+"@chainsafe/discv5@^0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@chainsafe/discv5/-/discv5-0.6.5.tgz#195005b6d74e42621e40ac9573754f4e91a10dd9"
+  integrity sha512-w+oBg+xKw7PgtN4HLJGLSMsIQLYPJpD7hl4SvmgsIs3Sy+fjtuLyHw8ln56dk50efDX5LOyLq/M60MMopJmFkw==
   dependencies:
     "@chainsafe/abort-controller" "^3.0.1"
     base64url "^3.0.1"


### PR DESCRIPTION
Includes the critical ENR node id cache performance fix