### PR TITLE
Keep states in cache as WeakRef

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -135,6 +135,11 @@ export class BeaconChain implements IBeaconChain {
       metrics,
       signal,
     });
+
+    // On start, the initial anchor state is added to the state cache + the forkchoice.
+    // Since this state and its block is the only one in the forkchoice, it becomes the head.
+    regen.setHead(forkChoice.getHead(), cachedState);
+
     this.blockProcessor = new BlockProcessor(
       {
         clock,
@@ -194,10 +199,8 @@ export class BeaconChain implements IBeaconChain {
 
   getHeadState(): CachedBeaconState<allForks.BeaconState> {
     // head state should always exist
-    const head = this.forkChoice.getHead();
-    const headState =
-      this.checkpointStateCache.getLatest(head.blockRoot, Infinity) || this.stateCache.get(head.stateRoot);
-    if (!headState) throw Error("headState does not exist");
+    const headState = this.regen.getHeadState();
+    if (!headState) throw Error("headState not available");
     return headState;
   }
 

--- a/packages/lodestar/src/chain/regen/errors.ts
+++ b/packages/lodestar/src/chain/regen/errors.ts
@@ -14,7 +14,7 @@ export type RegenErrorType =
   | {code: RegenErrorCode.BLOCK_NOT_IN_FORKCHOICE; blockRoot: RootHex | Root}
   | {code: RegenErrorCode.STATE_NOT_IN_FORKCHOICE; stateRoot: RootHex | Root}
   | {code: RegenErrorCode.SLOT_BEFORE_BLOCK_SLOT; slot: Slot; blockSlot: Slot}
-  | {code: RegenErrorCode.NO_SEED_STATE}
+  | {code: RegenErrorCode.NO_SEED_STATE; slot: Slot; blockRoot: RootHex}
   | {code: RegenErrorCode.TOO_MANY_BLOCK_PROCESSED; stateRoot: RootHex | Root}
   | {code: RegenErrorCode.BLOCK_NOT_IN_DB; blockRoot: RootHex | Root}
   | {code: RegenErrorCode.STATE_TRANSITION_ERROR; error: Error};

--- a/packages/lodestar/src/chain/regen/interface.ts
+++ b/packages/lodestar/src/chain/regen/interface.ts
@@ -1,5 +1,6 @@
 import {allForks, phase0, Slot, RootHex} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {IProtoBlock} from "@chainsafe/lodestar-fork-choice";
 
 export enum RegenCaller {
   getDuties = "getDuties",
@@ -11,6 +12,7 @@ export enum RegenCaller {
   validateGossipAggregateAndProof = "validateGossipAggregateAndProof",
   validateGossipAttestation = "validateGossipAttestation",
   onForkChoiceFinalized = "onForkChoiceFinalized",
+  regenHeadState = "regenHeadState",
 }
 
 export enum RegenFnName {
@@ -20,10 +22,15 @@ export enum RegenFnName {
   getCheckpointState = "getCheckpointState",
 }
 
+export interface IStateRegenerator extends IStateRegeneratorInternal {
+  getHeadState(): CachedBeaconState<allForks.BeaconState> | null;
+  setHead(head: IProtoBlock, potentialHeadState?: CachedBeaconState<allForks.BeaconState>): void;
+}
+
 /**
  * Regenerates states that have already been processed by the fork choice
  */
-export interface IStateRegenerator {
+export interface IStateRegeneratorInternal {
   /**
    * Return a valid pre-state for a beacon block
    * This will always return a state in the latest viable epoch

--- a/packages/lodestar/src/chain/regen/queued.ts
+++ b/packages/lodestar/src/chain/regen/queued.ts
@@ -5,7 +5,7 @@ import {CachedBeaconState, computeEpochAtSlot} from "@chainsafe/lodestar-beacon-
 import {CheckpointStateCache, StateContextCache, toCheckpointHex} from "../stateCache";
 import {IMetrics} from "../../metrics";
 import {JobItemQueue} from "../../util/queue";
-import {IStateRegeneratorInternal, RegenCaller, RegenFnName} from "./interface";
+import {IStateRegeneratorInternal, IStateRegenerator, RegenCaller, RegenFnName} from "./interface";
 import {StateRegenerator, RegenModules} from "./regen";
 import {RegenError, RegenErrorCode} from "./errors";
 import {toHexString} from "@chainsafe/ssz";
@@ -25,7 +25,7 @@ export type RegenRequest = RegenRequestByKey[RegenRequestKey];
  *
  * All requests are queued so that only a single state at a time may be regenerated at a time
  */
-export class QueuedStateRegenerator implements IStateRegeneratorInternal {
+export class QueuedStateRegenerator implements IStateRegenerator {
   readonly jobQueue: JobItemQueue<[RegenRequest], CachedBeaconState<allForks.BeaconState>>;
   private regen: StateRegenerator;
 

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -153,6 +153,8 @@ export class StateRegenerator implements IStateRegeneratorInternal {
     if (state === null) {
       throw new RegenError({
         code: RegenErrorCode.NO_SEED_STATE,
+        slot: block.slot,
+        blockRoot: block.blockRoot,
       });
     }
 

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -13,7 +13,7 @@ import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {IMetrics} from "../../metrics";
 import {IBeaconDb} from "../../db";
 import {CheckpointStateCache, StateContextCache} from "../stateCache";
-import {IStateRegenerator, RegenCaller} from "./interface";
+import {IStateRegeneratorInternal, RegenCaller} from "./interface";
 import {RegenError, RegenErrorCode} from "./errors";
 import {getCheckpointFromState} from "../blocks/utils/checkpoint";
 
@@ -29,7 +29,7 @@ export type RegenModules = {
 /**
  * Regenerates states that have already been processed by the fork choice
  */
-export class StateRegenerator implements IStateRegenerator {
+export class StateRegenerator implements IStateRegeneratorInternal {
   constructor(private readonly modules: RegenModules) {}
 
   /**

--- a/packages/lodestar/src/chain/stateCache/mapMetrics.ts
+++ b/packages/lodestar/src/chain/stateCache/mapMetrics.ts
@@ -5,14 +5,15 @@ type MapTrackerMetrics = {
   secondsSinceLastRead: IAvgMinMax;
 };
 
-export class MapTracker<K, V> extends Map<K, V> {
+// eslint-disable-next-line @typescript-eslint/ban-types
+export class MapTrackerWeakRef<K, V extends object> {
+  readonly values = new Map<K, WeakRef<V>>();
   /** Tracks the number of reads each entry in the cache gets for metrics */
   readonly readCount = new Map<K, number>();
   /** Tracks the last time a state was read from the cache */
   readonly lastRead = new Map<K, number>();
 
   constructor(metrics?: MapTrackerMetrics) {
-    super();
     if (metrics) {
       metrics.reads.addGetValuesFn(() => Array.from(this.readCount.values()));
       metrics.secondsSinceLastRead.addGetValuesFn(() => {
@@ -26,17 +27,34 @@ export class MapTracker<K, V> extends Map<K, V> {
     }
   }
 
+  get size(): number {
+    return this.values.size;
+  }
+
   get(key: K): V | undefined {
-    const value = super.get(key);
-    if (value !== undefined) {
-      this.readCount.set(key, 1 + (this.readCount.get(key) ?? 0));
-      this.lastRead.set(key, Date.now());
+    const valueWeakRef = this.values.get(key);
+    if (valueWeakRef === undefined) {
+      return undefined;
     }
+
+    const value = valueWeakRef.deref();
+    // Clean GC'ed references
+    if (value === undefined) {
+      this.delete(key);
+      return undefined;
+    }
+
+    this.readCount.set(key, 1 + (this.readCount.get(key) ?? 0));
+    this.lastRead.set(key, Date.now());
     return value;
   }
 
+  set(key: K, value: V): void {
+    this.values.set(key, new WeakRef(value));
+  }
+
   delete(key: K): boolean {
-    const deleted = super.delete(key);
+    const deleted = this.values.delete(key);
     if (deleted) {
       this.readCount.delete(key);
       this.lastRead.delete(key);
@@ -44,8 +62,25 @@ export class MapTracker<K, V> extends Map<K, V> {
     return deleted;
   }
 
+  has(key: K): boolean {
+    return this.values.has(key);
+  }
+
+  keys(): IterableIterator<K> {
+    return this.values.keys();
+  }
+
+  *entries(): IterableIterator<[K, V]> {
+    for (const [key, weakRef] of this.values.entries()) {
+      const value = weakRef.deref();
+      if (value) {
+        yield [key, value];
+      }
+    }
+  }
+
   clear(): void {
-    super.clear();
+    this.values.clear();
     this.readCount.clear();
     this.lastRead.clear();
   }

--- a/packages/lodestar/src/chain/stateCache/stateContextCache.ts
+++ b/packages/lodestar/src/chain/stateCache/stateContextCache.ts
@@ -3,7 +3,7 @@ import {Epoch, allForks, RootHex} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {routes} from "@chainsafe/lodestar-api";
 import {IMetrics} from "../../metrics";
-import {MapTracker} from "./mapMetrics";
+import {MapTrackerWeakRef} from "./mapMetrics";
 
 const MAX_STATES = 3 * 32;
 
@@ -18,14 +18,14 @@ export class StateContextCache {
    */
   readonly maxStates: number;
 
-  private readonly cache: MapTracker<string, CachedBeaconState<allForks.BeaconState>>;
+  private readonly cache: MapTrackerWeakRef<string, CachedBeaconState<allForks.BeaconState>>;
   /** Epoch -> Set<blockRoot> */
   private readonly epochIndex = new Map<Epoch, Set<string>>();
   private readonly metrics: IMetrics["stateCache"] | null | undefined;
 
   constructor({maxStates = MAX_STATES, metrics}: {maxStates?: number; metrics?: IMetrics | null}) {
     this.maxStates = maxStates;
-    this.cache = new MapTracker(metrics?.stateCache);
+    this.cache = new MapTrackerWeakRef(metrics?.stateCache);
     if (metrics) {
       this.metrics = metrics.stateCache;
       metrics.stateCache.size.addCollect(() => metrics.stateCache.size.set(this.cache.size));

--- a/packages/lodestar/src/chain/stateCache/stateContextCheckpointsCache.ts
+++ b/packages/lodestar/src/chain/stateCache/stateContextCheckpointsCache.ts
@@ -3,7 +3,7 @@ import {phase0, Epoch, allForks, RootHex} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {routes} from "@chainsafe/lodestar-api";
 import {IMetrics} from "../../metrics";
-import {MapTracker} from "./mapMetrics";
+import {MapTrackerWeakRef} from "./mapMetrics";
 import {MapDef} from "../../util/map";
 
 type CheckpointHex = {epoch: Epoch; rootHex: RootHex};
@@ -16,7 +16,7 @@ const MAX_EPOCHS = 10;
  * Similar API to Repository
  */
 export class CheckpointStateCache {
-  private readonly cache: MapTracker<string, CachedBeaconState<allForks.BeaconState>>;
+  private readonly cache: MapTrackerWeakRef<string, CachedBeaconState<allForks.BeaconState>>;
   /** Epoch -> Set<blockRoot> */
   private readonly epochIndex = new MapDef<Epoch, Set<string>>(() => new Set<string>());
   private readonly metrics: IMetrics["cpStateCache"] | null | undefined;
@@ -24,7 +24,7 @@ export class CheckpointStateCache {
   private preComputedCheckpointHits: number | null = null;
 
   constructor({metrics}: {metrics?: IMetrics | null}) {
-    this.cache = new MapTracker(metrics?.cpStateCache);
+    this.cache = new MapTrackerWeakRef(metrics?.cpStateCache);
     if (metrics) {
       this.metrics = metrics.cpStateCache;
       metrics.cpStateCache.size.addCollect(() => metrics.cpStateCache.size.set(this.cache.size));

--- a/packages/lodestar/test/perf/weakrefOrder.ts
+++ b/packages/lodestar/test/perf/weakrefOrder.ts
@@ -1,0 +1,93 @@
+/**
+ * This script test NodeJS behaviour to decide which WeakRefs to GC.
+ * For both v14 and v16 NodeJS strictly GCs WeakRefs by order of creation, regardless of usage.
+ *
+ * This script creates 350MB arrays and inserts then into a Map wrapped with a WeakRef.
+ * If deref() values 0 and 1 to check if usage delays GC. However running this script yields
+ *
+ * ```
+ * 0 - heapUsed 127.859328 MB
+ * Used 0
+ * 1 - heapUsed 473.8622 MB
+ * Used 0
+ * Used 1
+ * 2 - heapUsed 589.052368 MB
+ * Used 0
+ * Used 1
+ * 3 - heapUsed 875.18052 MB
+ * Used 0
+ * Used 1
+ * 4 - heapUsed 1161.331344 MB
+ * expired 0
+ * expired 1
+ * expired 2
+ * 5 - heapUsed 359.572248 MB
+ * 6 - heapUsed 645.6928 MB
+ * 7 - heapUsed 931.81108 MB
+ * 8 - heapUsed 1217.929616 MB
+ * 9 - heapUsed 1504.047864 MB
+ * 10 - heapUsed 1790.1756 MB
+ * expired 3
+ * expired 4
+ * expired 5
+ * expired 6
+ * expired 7
+ * expired 8
+ * ```
+ */
+/* eslint-disable no-console */
+async function testFn(): Promise<void> {
+  const weakRefs = new Map<number, WeakRef<number[]>>();
+
+  for (let i = 0; i < 1000; i++) {
+    const heapUsedMB = process.memoryUsage().heapUsed / 1e6;
+    console.log(`${i} - heapUsed ${heapUsedMB} MB`);
+    const largeObj = getLargeObject();
+    const newWeakRef = new WeakRef(largeObj);
+    weakRefs.set(i, newWeakRef);
+
+    // Must yield to the macro queue to allow creating an actual WeakRef
+    // Using setTimeout(r, 0) results in a much latter GC of WeakRefs
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Use some refs to test if they are deleted latter
+    useRefs(weakRefs, [0, 1]);
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Check which weakRefs have expired
+    checkRefs(weakRefs);
+    // MUST yield after .deref() or the strong refs are not dropped causing OOM
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+function useRefs(weakRefs: Map<number, WeakRef<number[]>>, idxs: number[]): void {
+  for (const idx of idxs) {
+    const val = weakRefs.get(idx)?.deref();
+    if (val) console.log(`Used ${idx}`);
+  }
+}
+
+function checkRefs(weakRefs: Map<number, WeakRef<number[]>>): void {
+  // Check which weakRefs have expired
+  for (const [idx, weakRef] of weakRefs) {
+    const value = weakRef.deref();
+    if (value === undefined) {
+      weakRefs.delete(idx);
+      console.log(`GC'ed ${idx}`);
+    }
+  }
+}
+
+function getLargeObject(): number[] {
+  const arr: number[] = [];
+  for (let i = 0; i < 1e7; i++) {
+    arr.push(i);
+  }
+  return arr;
+}
+
+testFn().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
@@ -11,7 +11,7 @@ import {BeaconChain} from "../../../../../src/chain";
 import {LocalClock} from "../../../../../src/chain/clock";
 import {assembleBlock} from "../../../../../src/chain/factory/block";
 import * as blockBodyAssembly from "../../../../../src/chain/factory/block/body";
-import {StateRegenerator} from "../../../../../src/chain/regen";
+import {QueuedStateRegenerator} from "../../../../../src/chain/regen";
 import {Eth1ForBlockProduction} from "../../../../../src/eth1";
 import {generateProtoBlock, generateEmptyBlock} from "../../../../utils/block";
 import {generateCachedState} from "../../../../utils/state";
@@ -24,7 +24,7 @@ describe("block assembly", function () {
   let assembleBodyStub: SinonStubFn<typeof blockBodyAssembly["assembleBody"]>,
     chainStub: StubbedChain,
     forkChoiceStub: SinonStubbedInstance<ForkChoice>,
-    regenStub: SinonStubbedInstance<StateRegenerator>,
+    regenStub: SinonStubbedInstance<QueuedStateRegenerator>,
     processBlockStub: SinonStubFn<typeof processBlock["processBlock"]>,
     beaconDB: StubbedBeaconDb;
 
@@ -35,7 +35,7 @@ describe("block assembly", function () {
     chainStub = sandbox.createStubInstance(BeaconChain) as StubbedChain;
     forkChoiceStub = chainStub.forkChoice = sandbox.createStubInstance(ForkChoice);
     chainStub.clock = sandbox.createStubInstance(LocalClock);
-    regenStub = chainStub.regen = sandbox.createStubInstance(StateRegenerator);
+    regenStub = chainStub.regen = sandbox.createStubInstance(QueuedStateRegenerator);
 
     beaconDB = new StubbedBeaconDb();
   });

--- a/packages/lodestar/test/unit/chain/precomputeNextEpochTransition.test.ts
+++ b/packages/lodestar/test/unit/chain/precomputeNextEpochTransition.test.ts
@@ -8,7 +8,7 @@ import sinon, {SinonStubbedInstance} from "sinon";
 import {BeaconChain, ChainEventEmitter} from "../../../src/chain";
 import {LocalClock} from "../../../src/chain/clock";
 import {PrecomputeNextEpochTransitionScheduler} from "../../../src/chain/precomputeNextEpochTransition";
-import {StateRegenerator} from "../../../src/chain/regen";
+import {QueuedStateRegenerator} from "../../../src/chain/regen";
 
 describe("PrecomputeEpochScheduler", () => {
   const sandbox = sinon.createSandbox();
@@ -16,7 +16,7 @@ describe("PrecomputeEpochScheduler", () => {
 
   let preComputeScheduler: PrecomputeNextEpochTransitionScheduler;
   let forkChoiceStub: SinonStubbedInstance<ForkChoice> & ForkChoice;
-  let regenStub: SinonStubbedInstance<StateRegenerator> & StateRegenerator;
+  let regenStub: SinonStubbedInstance<QueuedStateRegenerator> & QueuedStateRegenerator;
   let loggerStub: SinonStubbedInstance<WinstonLogger> & WinstonLogger;
 
   beforeEach(() => {
@@ -29,8 +29,8 @@ describe("PrecomputeEpochScheduler", () => {
     const emitterStub = sandbox.createStubInstance(ChainEventEmitter) as SinonStubbedInstance<ChainEventEmitter> &
       ChainEventEmitter;
     chainStub.emitter = emitterStub;
-    regenStub = sandbox.createStubInstance(StateRegenerator) as SinonStubbedInstance<StateRegenerator> &
-      StateRegenerator;
+    regenStub = sandbox.createStubInstance(QueuedStateRegenerator) as SinonStubbedInstance<QueuedStateRegenerator> &
+      QueuedStateRegenerator;
     chainStub.regen = regenStub;
     loggerStub = sandbox.createStubInstance(WinstonLogger) as SinonStubbedInstance<WinstonLogger> & WinstonLogger;
     preComputeScheduler = new PrecomputeNextEpochTransitionScheduler(

--- a/packages/lodestar/test/unit/chain/validation/block.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/block.test.ts
@@ -3,7 +3,7 @@ import {config} from "@chainsafe/lodestar-config/default";
 import {ForkChoice, IProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {BeaconChain, IBeaconChain} from "../../../../src/chain";
 import {LocalClock} from "../../../../src/chain/clock";
-import {StateRegenerator} from "../../../../src/chain/regen";
+import {QueuedStateRegenerator} from "../../../../src/chain/regen";
 import {validateGossipBlock} from "../../../../src/chain/validation";
 import {generateCachedState} from "../../../utils/state";
 import {BlockErrorCode} from "../../../../src/chain/errors";
@@ -17,7 +17,7 @@ import {ForkName} from "@chainsafe/lodestar-params";
 describe("gossip block validation", function () {
   let chain: SinonStubbedInstance<IBeaconChain>;
   let forkChoice: SinonStubbedInstance<ForkChoice>;
-  let regen: SinonStubbedInstance<StateRegenerator>;
+  let regen: SinonStubbedInstance<QueuedStateRegenerator>;
   let verifySignature: SinonStubFn<() => Promise<boolean>>;
   let job: allForks.SignedBeaconBlock;
   const proposerIndex = 0;
@@ -33,7 +33,7 @@ describe("gossip block validation", function () {
     forkChoice = sinon.createStubInstance(ForkChoice);
     forkChoice.getBlockHex.returns(null);
     chain.forkChoice = forkChoice;
-    regen = chain.regen = sinon.createStubInstance(StateRegenerator);
+    regen = chain.regen = sinon.createStubInstance(QueuedStateRegenerator);
 
     verifySignature = sinon.stub();
     verifySignature.resolves(true);

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -14,7 +14,7 @@ import {IBeaconClock} from "../../../../src/chain/clock/interface";
 import {generateEmptySignedBlock} from "../../block";
 import {CheckpointStateCache, StateContextCache} from "../../../../src/chain/stateCache";
 import {LocalClock} from "../../../../src/chain/clock";
-import {IStateRegenerator, StateRegenerator} from "../../../../src/chain/regen";
+import {IStateRegenerator, QueuedStateRegenerator} from "../../../../src/chain/regen";
 import {StubbedBeaconDb} from "../../stub";
 import {IBlsVerifier, BlsSingleThreadVerifier} from "../../../../src/chain/bls";
 import {AttestationPool} from "../../../../src/chain/opPools/attestationPool";
@@ -101,13 +101,14 @@ export class MockBeaconChain implements IBeaconChain {
     this.stateCache = new StateContextCache({});
     this.checkpointStateCache = new CheckpointStateCache({});
     const db = new StubbedBeaconDb();
-    this.regen = new StateRegenerator({
+    this.regen = new QueuedStateRegenerator({
       config: this.config,
       forkChoice: this.forkChoice,
       stateCache: this.stateCache,
       checkpointStateCache: this.checkpointStateCache,
       db,
       metrics: null,
+      signal: this.abortController.signal,
     });
     this.lightclientUpdater = new LightClientUpdater(db);
     this.lightClientIniter = new LightClientIniter({

--- a/packages/lodestar/test/utils/stub/beaconDb.ts
+++ b/packages/lodestar/test/utils/stub/beaconDb.ts
@@ -1,5 +1,4 @@
 import {SinonStubbedInstance} from "sinon";
-import {LevelDbController} from "@chainsafe/lodestar-db";
 
 import {BeaconDb} from "../../../src/db";
 import {
@@ -17,8 +16,6 @@ import {config as minimalConfig} from "@chainsafe/lodestar-config/default";
 import {createStubInstance} from "../types";
 
 export class StubbedBeaconDb extends BeaconDb {
-  db!: SinonStubbedInstance<LevelDbController>;
-
   block: SinonStubbedInstance<BlockRepository> & BlockRepository;
   blockArchive: SinonStubbedInstance<BlockArchiveRepository> & BlockArchiveRepository;
   stateArchive: SinonStubbedInstance<StateArchiveRepository> & StateArchiveRepository;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es2019",
+    "target": "esnext",
     "module": "commonjs",
     "pretty": true,
-    "lib": ["es2020", "esnext.bigint", "es2020.string", "es2020.symbol.wellknown"],
+    "lib": ["esnext", "esnext.bigint", "es2020.string", "es2020.symbol.wellknown"],
 
     "strict": true,
     "sourceMap": true,


### PR DESCRIPTION
**Motivation**

Lodestar has suffered serious memory issues when the state cache grows unbounded due to some bug (for example https://github.com/ChainSafe/lodestar/issues/3171)

The problem is that the state caches are unbounded memory wise. Current state cache design only limits by state count. In normal conditions that's good enough thanks to high structural sharing. However if the states are too different it will cause an out of memory (OOM) exception.

**Description**

Keep all states but the head as WeakRefs. NodeJS will garbage collect (GC) the oldest WeakRefs when the app's memory is considered too high.

Script `packages/lodestar/test/perf/weakrefOrder.ts` demonstrates the behavior of WeakRef (tested in NodeJS v14 and v16).
- WeakRef are GC'ed strictly by creation order
- For a WeakRef to become GC-able the macro queue must tick at least once
- After calling `WeakRef.deref()`, for that WeakRef to become GC-able the macro queue must tick at least once