### PR TITLE
Use python3 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:14-alpine as build
 WORKDIR /usr/app
-RUN apk update && apk add --no-cache g++ make python && rm -rf /var/cache/apk/*
+RUN apk update && apk add --no-cache g++ make python3 && rm -rf /var/cache/apk/*
 
 ARG VERSION=latest
 ENV VERSION=$VERSION

--- a/docker/from_source.Dockerfile
+++ b/docker/from_source.Dockerfile
@@ -21,7 +21,7 @@
 
 FROM node:14-alpine as build
 WORKDIR /usr/app
-RUN apk update && apk add --no-cache g++ make python && rm -rf /var/cache/apk/*
+RUN apk update && apk add --no-cache g++ make python3 && rm -rf /var/cache/apk/*
 
 # Installs all deps in the root yarn.lock, which are most of them. To cache before copying the src
 COPY package.json yarn.lock ./


### PR DESCRIPTION
**Motivation**

Latest `node:14-alpine` image does not have python in its repository

```
Step 3/12 : RUN apk update && apk add --no-cache g++ make python && rm -rf /var/cache/apk/*
 ---> Running in 8d16596188aa
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
v3.14.2-127-g0195433b93 [https://dl-cdn.alpinelinux.org/alpine/v3.14/main]
v3.14.2-120-g90167408c8 [https://dl-cdn.alpinelinux.org/alpine/v3.14/community]
OK: 14943 distinct packages available
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
ERROR: unable to select packages:
  python (no such package):
    required by: world[python]
The command '/bin/sh -c apk update && apk add --no-cache g++ make python && rm -rf /var/cache/apk/*' returned a non-zero code: 1
```

**Description**

- Use python3 in Dockerfile