### PR TITLE
Discv5: Do not issue FINDNODES right after the start

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -11,6 +11,7 @@ export interface INetworkArgs {
   "network.localMultiaddrs": string[];
   "network.subscribeAllSubnets": boolean;
   "network.connectToDiscv5Bootnodes": boolean;
+  "network.firstHeartBeatDelayMs": number;
 }
 
 export function parseArgs(args: INetworkArgs): IBeaconNodeOptions["network"] {
@@ -28,6 +29,7 @@ export function parseArgs(args: INetworkArgs): IBeaconNodeOptions["network"] {
     localMultiaddrs: args["network.localMultiaddrs"],
     subscribeAllSubnets: args["network.subscribeAllSubnets"],
     connectToDiscv5Bootnodes: args["network.connectToDiscv5Bootnodes"],
+    firstHeartBeatDelayMs: args["network.firstHeartBeatDelayMs"],
   };
 }
 
@@ -93,6 +95,13 @@ export const options: ICliCommandOptions<INetworkArgs> = {
     type: "boolean",
     description: "Attempt direct connection to discv5 bootnodes from network.discv5.bootEnrs option",
     defaultDescription: String(defaultOptions.network.connectToDiscv5Bootnodes === true),
+    group: "network",
+  },
+
+  "network.firstHeartBeatDelayMs": {
+    type: "number",
+    description: "Delay the 1st heart beat of Peer Manager after starting Discv5",
+    defaultDescription: String(defaultOptions.network.firstHeartBeatDelayMs),
     group: "network",
   },
 };

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -11,7 +11,7 @@ export interface INetworkArgs {
   "network.localMultiaddrs": string[];
   "network.subscribeAllSubnets": boolean;
   "network.connectToDiscv5Bootnodes": boolean;
-  "network.firstHeartBeatDelayMs": number;
+  "network.discv5FirstQueryDelayMs": number;
 }
 
 export function parseArgs(args: INetworkArgs): IBeaconNodeOptions["network"] {
@@ -29,7 +29,7 @@ export function parseArgs(args: INetworkArgs): IBeaconNodeOptions["network"] {
     localMultiaddrs: args["network.localMultiaddrs"],
     subscribeAllSubnets: args["network.subscribeAllSubnets"],
     connectToDiscv5Bootnodes: args["network.connectToDiscv5Bootnodes"],
-    firstHeartBeatDelayMs: args["network.firstHeartBeatDelayMs"],
+    discv5FirstQueryDelayMs: args["network.discv5FirstQueryDelayMs"],
   };
 }
 
@@ -98,10 +98,10 @@ export const options: ICliCommandOptions<INetworkArgs> = {
     group: "network",
   },
 
-  "network.firstHeartBeatDelayMs": {
+  "network.discv5FirstQueryDelayMs": {
     type: "number",
     description: "Delay the 1st heart beat of Peer Manager after starting Discv5",
-    defaultDescription: String(defaultOptions.network.firstHeartBeatDelayMs),
+    defaultDescription: String(defaultOptions.network.discv5FirstQueryDelayMs),
     group: "network",
   },
 };

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -45,6 +45,7 @@ describe("options / beaconNodeOptions", () => {
       "network.localMultiaddrs": [],
       "network.subscribeAllSubnets": true,
       "network.connectToDiscv5Bootnodes": true,
+      "network.firstHeartBeatDelayMs": 1000,
 
       "sync.isSingleNode": true,
       "sync.disableProcessAsChainSegment": true,
@@ -100,6 +101,7 @@ describe("options / beaconNodeOptions", () => {
         localMultiaddrs: [],
         subscribeAllSubnets: true,
         connectToDiscv5Bootnodes: true,
+        firstHeartBeatDelayMs: 1000,
       },
       sync: {
         isSingleNode: true,

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -45,7 +45,7 @@ describe("options / beaconNodeOptions", () => {
       "network.localMultiaddrs": [],
       "network.subscribeAllSubnets": true,
       "network.connectToDiscv5Bootnodes": true,
-      "network.firstHeartBeatDelayMs": 1000,
+      "network.discv5FirstQueryDelayMs": 1000,
 
       "sync.isSingleNode": true,
       "sync.disableProcessAsChainSegment": true,
@@ -101,7 +101,7 @@ describe("options / beaconNodeOptions", () => {
         localMultiaddrs: [],
         subscribeAllSubnets: true,
         connectToDiscv5Bootnodes: true,
-        firstHeartBeatDelayMs: 1000,
+        discv5FirstQueryDelayMs: 1000,
       },
       sync: {
         isSingleNode: true,

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -116,6 +116,7 @@ export class Network implements INetwork {
         config,
         peerMetadata,
         peerRpcScores,
+        signal,
         networkEventBus,
       },
       opts

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -116,7 +116,6 @@ export class Network implements INetwork {
         config,
         peerMetadata,
         peerRpcScores,
-        signal,
         networkEventBus,
       },
       opts

--- a/packages/lodestar/src/network/options.ts
+++ b/packages/lodestar/src/network/options.ts
@@ -19,7 +19,7 @@ export const defaultDiscv5Options: IDiscv5DiscoveryInputOptions = {
 export const defaultNetworkOptions: INetworkOptions = {
   maxPeers: 30, // Allow some room above targetPeers for new inbound peers
   targetPeers: 25,
-  firstHeartBeatDelayMs: 1000,
+  discv5FirstQueryDelayMs: 1000,
   localMultiaddrs: ["/ip4/0.0.0.0/tcp/9000"],
   bootMultiaddrs: [],
   discv5: defaultDiscv5Options,

--- a/packages/lodestar/src/network/options.ts
+++ b/packages/lodestar/src/network/options.ts
@@ -19,6 +19,7 @@ export const defaultDiscv5Options: IDiscv5DiscoveryInputOptions = {
 export const defaultNetworkOptions: INetworkOptions = {
   maxPeers: 30, // Allow some room above targetPeers for new inbound peers
   targetPeers: 25,
+  firstHeartBeatDelayMs: 1000,
   localMultiaddrs: ["/ip4/0.0.0.0/tcp/9000"],
   bootMultiaddrs: [],
   discv5: defaultDiscv5Options,

--- a/packages/lodestar/src/network/peers/discover.ts
+++ b/packages/lodestar/src/network/peers/discover.ts
@@ -19,6 +19,7 @@ const MAX_CACHED_ENR_AGE_MS = 5 * 60 * 1000;
 
 export type PeerDiscoveryOpts = {
   maxPeers: number;
+  discv5FirstQueryDelayMs: number;
   discv5: Omit<IDiscv5DiscoveryInputOptions, "metrics" | "searchInterval" | "enabled">;
 };
 
@@ -86,6 +87,8 @@ export class PeerDiscovery {
 
   /** The maximum number of peers we allow (exceptions for subnet peers) */
   private maxPeers: number;
+  private discv5StartMs: number;
+  private discv5FirstQueryDelayMs: number;
 
   constructor(modules: PeerDiscoveryModules, opts: PeerDiscoveryOpts) {
     const {libp2p, peerRpcScores, metrics, logger, config} = modules;
@@ -95,6 +98,8 @@ export class PeerDiscovery {
     this.logger = logger;
     this.config = config;
     this.maxPeers = opts.maxPeers;
+    this.discv5StartMs = 0;
+    this.discv5FirstQueryDelayMs = opts.discv5FirstQueryDelayMs;
 
     this.discv5 = Discv5.create({
       enr: opts.discv5.enr,
@@ -119,6 +124,7 @@ export class PeerDiscovery {
 
   async start(): Promise<void> {
     await this.discv5.start();
+    this.discv5StartMs = Date.now();
     this.discv5.on("discovered", this.onDiscovered);
   }
 
@@ -196,6 +202,10 @@ export class PeerDiscovery {
    * Request to find peers. First, looked at cached peers in peerStore
    */
   private async runFindRandomNodeQuery(): Promise<void> {
+    // Delay the 1st query after starting discv5
+    if (Date.now() - this.discv5StartMs <= this.discv5FirstQueryDelayMs) {
+      return;
+    }
     // Run a general discv5 query if one is not already in progress
     if (this.randomNodeQuery.code === QueryStatusCode.Active) {
       this.metrics?.discovery.findNodeQueryRequests.inc({action: "ignore"});

--- a/packages/lodestar/src/network/peers/discover.ts
+++ b/packages/lodestar/src/network/peers/discover.ts
@@ -203,9 +203,11 @@ export class PeerDiscovery {
    */
   private async runFindRandomNodeQuery(): Promise<void> {
     // Delay the 1st query after starting discv5
+    // See https://github.com/ChainSafe/lodestar/issues/3423
     if (Date.now() - this.discv5StartMs <= this.discv5FirstQueryDelayMs) {
       return;
     }
+
     // Run a general discv5 query if one is not already in progress
     if (this.randomNodeQuery.code === QueryStatusCode.Active) {
       this.metrics?.discovery.findNodeQueryRequests.inc({action: "ignore"});

--- a/packages/lodestar/src/network/peers/peerManager.ts
+++ b/packages/lodestar/src/network/peers/peerManager.ts
@@ -1,9 +1,10 @@
 import LibP2p, {Connection} from "libp2p";
+import {AbortSignal} from "@chainsafe/abort-controller";
 import PeerId from "peer-id";
 import {IDiscv5DiscoveryInputOptions} from "@chainsafe/discv5";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {allForks, altair, phase0} from "@chainsafe/lodestar-types";
-import {ILogger} from "@chainsafe/lodestar-utils";
+import {ILogger, sleep} from "@chainsafe/lodestar-utils";
 import {IBeaconChain} from "../../chain";
 import {GoodByeReasonCode, GOODBYE_KNOWN_CODES, Libp2pEvent} from "../../constants";
 import {IMetrics} from "../../metrics";
@@ -46,6 +47,11 @@ export type PeerManagerOpts = {
   /** The maximum number of peers we allow (exceptions for subnet peers) */
   maxPeers: number;
   /**
+   * Delay the 1st heartbeat after starting discv5
+   * See https://github.com/ChainSafe/lodestar/issues/3423
+   */
+  firstHeartBeatDelayMs: number;
+  /**
    * If null, Don't run discv5 queries, nor connect to cached peers in the peerStore
    */
   discv5: IDiscv5DiscoveryInputOptions | null;
@@ -62,6 +68,7 @@ export type PeerManagerModules = {
   config: IBeaconConfig;
   peerMetadata: Libp2pPeerMetadataStore;
   peerRpcScores: IPeerRpcScoreStore;
+  signal?: AbortSignal;
   networkEventBus: INetworkEventBus;
 };
 
@@ -103,6 +110,7 @@ export class PeerManager {
   private peerRpcScores: IPeerRpcScoreStore;
   /** If null, discovery is disabled */
   private discovery: PeerDiscovery | null;
+  private signal: AbortSignal | undefined;
   private networkEventBus: INetworkEventBus;
 
   // A single map of connected peers with all necessary data to handle PINGs, STATUS, and metrics
@@ -124,6 +132,7 @@ export class PeerManager {
     this.config = modules.config;
     this.peerMetadata = modules.peerMetadata;
     this.peerRpcScores = modules.peerRpcScores;
+    this.signal = modules.signal;
     this.networkEventBus = modules.networkEventBus;
     this.opts = opts;
 
@@ -142,6 +151,7 @@ export class PeerManager {
     this.libp2p.connectionManager.on(Libp2pEvent.peerDisconnect, this.onLibp2pPeerDisconnect);
     this.networkEventBus.on(NetworkEvent.reqRespRequest, this.onRequest);
 
+    await sleep(this.opts.firstHeartBeatDelayMs, this.signal);
     // On start-up will connected to existing peers in libp2p.peerStore, same as autoDial behaviour
     this.heartbeat();
     this.intervals = [

--- a/packages/lodestar/test/e2e/network/gossipsub.test.ts
+++ b/packages/lodestar/test/e2e/network/gossipsub.test.ts
@@ -25,7 +25,7 @@ const opts: INetworkOptions = {
   targetPeers: 1,
   bootMultiaddrs: [],
   localMultiaddrs: [],
-  firstHeartBeatDelayMs: 1,
+  discv5FirstQueryDelayMs: 0,
   discv5: null,
 };
 

--- a/packages/lodestar/test/e2e/network/gossipsub.test.ts
+++ b/packages/lodestar/test/e2e/network/gossipsub.test.ts
@@ -25,6 +25,7 @@ const opts: INetworkOptions = {
   targetPeers: 1,
   bootMultiaddrs: [],
   localMultiaddrs: [],
+  firstHeartBeatDelayMs: 1,
   discv5: null,
 };
 

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -55,7 +55,7 @@ describe("network", function () {
       targetPeers: 1,
       bootMultiaddrs: [],
       localMultiaddrs: [],
-      firstHeartBeatDelayMs: 1,
+      discv5FirstQueryDelayMs: 0,
       discv5: {
         enr,
         bindAddr: bindAddrUdp,

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -55,6 +55,7 @@ describe("network", function () {
       targetPeers: 1,
       bootMultiaddrs: [],
       localMultiaddrs: [],
+      firstHeartBeatDelayMs: 1,
       discv5: {
         enr,
         bindAddr: bindAddrUdp,

--- a/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
@@ -89,7 +89,7 @@ describe("network / peers / PeerManager", function () {
         targetPeers: 30,
         maxPeers: 50,
         discv5: null,
-        firstHeartBeatDelayMs: 1,
+        discv5FirstQueryDelayMs: 0,
       }
     );
     await peerManager.start();

--- a/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
@@ -85,7 +85,12 @@ describe("network / peers / PeerManager", function () {
         attnetsService: mockSubnetsService,
         syncnetsService: mockSubnetsService,
       },
-      {targetPeers: 30, maxPeers: 50, discv5: null}
+      {
+        targetPeers: 30,
+        maxPeers: 50,
+        discv5: null,
+        firstHeartBeatDelayMs: 1,
+      }
     );
     await peerManager.start();
 

--- a/packages/lodestar/test/e2e/network/reqresp.test.ts
+++ b/packages/lodestar/test/e2e/network/reqresp.test.ts
@@ -38,6 +38,7 @@ describe("network / ReqResp", function () {
     targetPeers: 1,
     bootMultiaddrs: [],
     localMultiaddrs: [],
+    firstHeartBeatDelayMs: 1,
     discv5: null,
   };
   const state = generateState();

--- a/packages/lodestar/test/e2e/network/reqresp.test.ts
+++ b/packages/lodestar/test/e2e/network/reqresp.test.ts
@@ -38,7 +38,7 @@ describe("network / ReqResp", function () {
     targetPeers: 1,
     bootMultiaddrs: [],
     localMultiaddrs: [],
-    firstHeartBeatDelayMs: 1,
+    discv5FirstQueryDelayMs: 0,
     discv5: null,
   };
   const state = generateState();


### PR DESCRIPTION
**Motivation**

Sometimes we're not able to send/receive discv5 packets successfully right after it starts. Ideally we should investigate discv5 for that, but I found we all `await` for the discv5 start process correctly.

```
2021-11-11T11:44:03.605Z discv5:service Starting discv5 service with node id a94979c6e3449280c849ddfcde174ddadd3cd4db280193d28743aeeef291a3fb
2021-11-11T11:44:03.605Z discv5:sessionService Starting session service with node id a94979c6e3449280c849ddfcde174ddadd3cd4db280193d28743aeeef291a3fb
2021-11-11T11:44:03.611Z discv5:service Starting a new lookup. Id: 1
```

**Description**

+ Skip doing `FINDNODES` in the 1st heart beat of peer manager

part of #3423
