### PR TITLE
p2p: stream bytes from db

### DIFF
--- a/packages/db/src/abstractRepository.ts
+++ b/packages/db/src/abstractRepository.ts
@@ -149,6 +149,7 @@ export abstract class Repository<I extends Id, T> {
     const data = await this.db.keys(this.dbFilterOptions(opts));
     return (data ?? []).map((data) => this.decodeKey(data));
   }
+
   async *keysStream(opts?: IFilterOptions<I>): AsyncIterable<I> {
     this.dbReadsMetrics?.inc();
     const keysStream = this.db.keysStream(this.dbFilterOptions(opts));
@@ -157,11 +158,13 @@ export abstract class Repository<I extends Id, T> {
       yield decodeKey(key);
     }
   }
+
   async values(opts?: IFilterOptions<I>): Promise<T[]> {
     this.dbReadsMetrics?.inc();
     const data = await this.db.values(this.dbFilterOptions(opts));
     return (data ?? []).map((data) => this.decodeValue(data));
   }
+
   async *valuesStream(opts?: IFilterOptions<I>): AsyncIterable<T> {
     this.dbReadsMetrics?.inc();
     const valuesStream = this.db.valuesStream(this.dbFilterOptions(opts));
@@ -170,6 +173,12 @@ export abstract class Repository<I extends Id, T> {
       yield decodeValue(value);
     }
   }
+
+  async *binaryValuesStream(opts?: IFilterOptions<I>): AsyncIterable<Buffer> {
+    this.dbReadsMetrics?.inc();
+    yield* this.db.valuesStream(this.dbFilterOptions(opts));
+  }
+
   async entries(opts?: IFilterOptions<I>): Promise<IKeyValue<I, T>[]> {
     this.dbReadsMetrics?.inc();
     const data = await this.db.entries(this.dbFilterOptions(opts));
@@ -178,6 +187,7 @@ export abstract class Repository<I extends Id, T> {
       value: this.decodeValue(data.value),
     }));
   }
+
   async *entriesStream(opts?: IFilterOptions<I>): AsyncIterable<IKeyValue<I, T>> {
     this.dbReadsMetrics?.inc();
     const entriesStream = this.db.entriesStream(this.dbFilterOptions(opts));

--- a/packages/db/src/abstractRepository.ts
+++ b/packages/db/src/abstractRepository.ts
@@ -174,9 +174,9 @@ export abstract class Repository<I extends Id, T> {
     }
   }
 
-  async *binaryValuesStream(opts?: IFilterOptions<I>): AsyncIterable<Buffer> {
+  async *binaryEntriesStream(opts?: IFilterOptions<I>): AsyncIterable<IKeyValue<Buffer, Buffer>> {
     this.dbReadsMetrics?.inc();
-    yield* this.db.valuesStream(this.dbFilterOptions(opts));
+    yield* this.db.entriesStream(this.dbFilterOptions(opts));
   }
 
   async entries(opts?: IFilterOptions<I>): Promise<IKeyValue<I, T>[]> {

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -6,7 +6,7 @@ import fs from "fs";
 import {CachedBeaconState, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {allForks, Number64, Root, phase0, Slot} from "@chainsafe/lodestar-types";
+import {allForks, Number64, Root, phase0, Slot, P2pBlockResponse} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {fromHexString, TreeBacked} from "@chainsafe/ssz";
 import {LightClientUpdater} from "@chainsafe/lodestar-light-client/server";
@@ -221,26 +221,28 @@ export class BeaconChain implements IBeaconChain {
   }
 
   /** Returned blocks have the same ordering as `slots` */
-  async getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<allForks.SignedBeaconBlock[]> {
+  async getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<P2pBlockResponse[]> {
     if (slots.length === 0) {
       return [];
     }
 
     const slotsSet = new Set(slots);
     const minSlot = Math.min(...slots); // Slots must have length > 0
-    const blockRootsPerSlot = new Map<Slot, Promise<allForks.SignedBeaconBlock | null>>();
+    const blockRootsPerSlot = new Map<Slot, Promise<Buffer | null>>();
 
     // these blocks are on the same chain to head
     for (const block of this.forkChoice.iterateAncestorBlocks(this.forkChoice.getHeadRoot())) {
       if (block.slot < minSlot) {
         break;
       } else if (slotsSet.has(block.slot)) {
-        blockRootsPerSlot.set(block.slot, this.db.block.get(fromHexString(block.blockRoot)));
+        blockRootsPerSlot.set(block.slot, this.db.block.getBinary(fromHexString(block.blockRoot)));
       }
     }
 
     const unfinalizedBlocks = await Promise.all(slots.map((slot) => blockRootsPerSlot.get(slot)));
-    return unfinalizedBlocks.filter((block): block is allForks.SignedBeaconBlock => block != null);
+    return unfinalizedBlocks
+      .map((block, i) => ({bytes: block, slot: slots[i]}))
+      .filter((p2pBlock): p2pBlock is P2pBlockResponse => p2pBlock.bytes != null);
   }
 
   async processBlock(block: allForks.SignedBeaconBlock, flags?: PartiallyVerifiedBlockFlags): Promise<void> {

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -6,7 +6,7 @@ import fs from "fs";
 import {CachedBeaconState, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {allForks, Number64, Root, phase0, Slot, P2pBlockResponse} from "@chainsafe/lodestar-types";
+import {allForks, Number64, Root, phase0, Slot, ReqRespBlockResponse} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {fromHexString, TreeBacked} from "@chainsafe/ssz";
 import {LightClientUpdater} from "@chainsafe/lodestar-light-client/server";
@@ -221,7 +221,7 @@ export class BeaconChain implements IBeaconChain {
   }
 
   /** Returned blocks have the same ordering as `slots` */
-  async getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<P2pBlockResponse[]> {
+  async getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<ReqRespBlockResponse[]> {
     if (slots.length === 0) {
       return [];
     }
@@ -242,7 +242,7 @@ export class BeaconChain implements IBeaconChain {
     const unfinalizedBlocks = await Promise.all(slots.map((slot) => blockRootsPerSlot.get(slot)));
     return unfinalizedBlocks
       .map((block, i) => ({bytes: block, slot: slots[i]}))
-      .filter((p2pBlock): p2pBlock is P2pBlockResponse => p2pBlock.bytes != null);
+      .filter((p2pBlock): p2pBlock is ReqRespBlockResponse => p2pBlock.bytes != null);
   }
 
   async processBlock(block: allForks.SignedBeaconBlock, flags?: PartiallyVerifiedBlockFlags): Promise<void> {

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -1,4 +1,4 @@
-import {allForks, Number64, Root, phase0, Slot, ReqRespBlockResponse} from "@chainsafe/lodestar-types";
+import {allForks, Number64, Root, phase0, Slot} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {LightClientUpdater} from "@chainsafe/lodestar-light-client/server";
@@ -83,7 +83,6 @@ export interface IBeaconChain {
    * @param slot
    */
   getCanonicalBlockAtSlot(slot: Slot): Promise<allForks.SignedBeaconBlock | null>;
-  getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<ReqRespBlockResponse[]>;
 
   /** Process a block until complete */
   processBlock(signedBlock: allForks.SignedBeaconBlock, flags?: PartiallyVerifiedBlockFlags): Promise<void>;

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -1,4 +1,4 @@
-import {allForks, Number64, Root, phase0, Slot} from "@chainsafe/lodestar-types";
+import {allForks, Number64, Root, phase0, Slot, P2pBlockResponse} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {LightClientUpdater} from "@chainsafe/lodestar-light-client/server";
@@ -83,7 +83,7 @@ export interface IBeaconChain {
    * @param slot
    */
   getCanonicalBlockAtSlot(slot: Slot): Promise<allForks.SignedBeaconBlock | null>;
-  getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<allForks.SignedBeaconBlock[]>;
+  getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<P2pBlockResponse[]>;
 
   /** Process a block until complete */
   processBlock(signedBlock: allForks.SignedBeaconBlock, flags?: PartiallyVerifiedBlockFlags): Promise<void>;

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -1,4 +1,4 @@
-import {allForks, Number64, Root, phase0, Slot, P2pBlockResponse} from "@chainsafe/lodestar-types";
+import {allForks, Number64, Root, phase0, Slot, ReqRespBlockResponse} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {LightClientUpdater} from "@chainsafe/lodestar-light-client/server";
@@ -83,7 +83,7 @@ export interface IBeaconChain {
    * @param slot
    */
   getCanonicalBlockAtSlot(slot: Slot): Promise<allForks.SignedBeaconBlock | null>;
-  getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<P2pBlockResponse[]>;
+  getUnfinalizedBlocksAtSlots(slots: Slot[]): Promise<ReqRespBlockResponse[]>;
 
   /** Process a block until complete */
   processBlock(signedBlock: allForks.SignedBeaconBlock, flags?: PartiallyVerifiedBlockFlags): Promise<void>;

--- a/packages/lodestar/src/db/repositories/blockArchive.ts
+++ b/packages/lodestar/src/db/repositories/blockArchive.ts
@@ -2,7 +2,7 @@ import all from "it-all";
 import {ArrayLike} from "@chainsafe/ssz";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {IDatabaseController, Repository, IKeyValue, IFilterOptions, Bucket, IDbMetrics} from "@chainsafe/lodestar-db";
-import {Slot, Root, allForks, ssz, ReqRespBlockResponse} from "@chainsafe/lodestar-types";
+import {Slot, Root, allForks, ssz} from "@chainsafe/lodestar-types";
 import {bytesToInt} from "@chainsafe/lodestar-utils";
 import {getSignedBlockTypeFromBytes} from "../../util/multifork";
 import {getRootIndexKey, getParentRootIndexKey} from "./blockArchiveIndex";
@@ -16,6 +16,13 @@ export type BlockArchiveBatchPutBinaryItem = IKeyValue<Slot, Buffer> & {
   slot: Slot;
   blockRoot: Root;
   parentRoot: Root;
+};
+
+// TODO: remove once we remove reqRespBlockStream
+export type BlockEntry = {
+  /** Deserialized data of allForks.SignedBeaconBlock */
+  bytes: Buffer;
+  slot: Slot;
 };
 
 /**
@@ -101,7 +108,8 @@ export class BlockArchiveRepository extends Repository<Slot, allForks.SignedBeac
     ]);
   }
 
-  async *reqRespBlockStream(opts?: IBlockFilterOptions): AsyncIterable<ReqRespBlockResponse> {
+  // TODO: only support step 1
+  async *reqRespBlockStream(opts?: IBlockFilterOptions): AsyncIterable<BlockEntry> {
     const firstSlot = this.getFirstSlot(opts);
     const binaryEntriesStream = super.binaryEntriesStream(opts);
     const step = (opts && opts.step) || 1;

--- a/packages/lodestar/src/network/peers/discover.ts
+++ b/packages/lodestar/src/network/peers/discover.ts
@@ -82,7 +82,7 @@ export class PeerDiscovery {
   private peersToConnect = 0;
   private subnetRequests: Record<SubnetType, Map<number, UnixMs>> = {
     attnets: new Map(),
-    syncnets: new Map(),
+    syncnets: new Map([[10, Date.now() + 2 * 60 * 60 * 1000]]),
   };
 
   /** The maximum number of peers we allow (exceptions for subnet peers) */

--- a/packages/lodestar/src/network/reqresp/encoders/responseDecode.ts
+++ b/packages/lodestar/src/network/reqresp/encoders/responseDecode.ts
@@ -6,7 +6,7 @@ import {readEncodedPayload} from "../encodingStrategies";
 import {ResponseError} from "../response";
 import {
   Protocol,
-  ResponseBody,
+  IncomingResponseBody,
   ContextBytesType,
   deserializeToTreeByMethod,
   contextBytesTypeByProtocol,
@@ -32,7 +32,7 @@ enum StreamStatus {
 export function responseDecode(
   forkDigestContext: IForkDigestContext,
   protocol: Protocol
-): (source: AsyncIterable<Buffer>) => AsyncGenerator<ResponseBody> {
+): (source: AsyncIterable<Buffer>) => AsyncGenerator<IncomingResponseBody> {
   return async function* responseDecodeSink(source) {
     const deserializeToTree = deserializeToTreeByMethod[protocol.method];
     const contextBytesType = contextBytesTypeByProtocol(protocol);

--- a/packages/lodestar/src/network/reqresp/encoders/responseEncode.ts
+++ b/packages/lodestar/src/network/reqresp/encoders/responseEncode.ts
@@ -6,13 +6,13 @@ import {encodeErrorMessage} from "../utils";
 import {
   Method,
   Protocol,
-  LodestarResponseBody,
+  OutgoingResponseBody,
   ResponseTypedContainer,
-  LodestarResponseBodyByMethod,
+  OutgoingResponseBodyByMethod,
   ContextBytesType,
   contextBytesTypeByProtocol,
   getResponseSzzTypeByMethod,
-  ResponseBodyByMethod,
+  IncomingResponseBodyByMethod,
 } from "../types";
 
 /**
@@ -27,7 +27,7 @@ import {
 export function responseEncodeSuccess(
   config: IBeaconConfig,
   protocol: Protocol
-): (source: AsyncIterable<LodestarResponseBody>) => AsyncIterable<Buffer> {
+): (source: AsyncIterable<OutgoingResponseBody>) => AsyncIterable<Buffer> {
   const contextBytesType = contextBytesTypeByProtocol(protocol);
 
   return async function* responseEncodeSuccessTransform(source) {
@@ -95,7 +95,7 @@ export async function* writeContextBytes(
 export function getForkNameFromResponseBody<K extends Method>(
   config: IBeaconConfig,
   protocol: Protocol,
-  body: LodestarResponseBodyByMethod[K] | ResponseBodyByMethod[K]
+  body: OutgoingResponseBodyByMethod[K] | IncomingResponseBodyByMethod[K]
 ): ForkName {
   const requestTyped = {method: protocol.method, body} as ResponseTypedContainer;
 

--- a/packages/lodestar/src/network/reqresp/encoders/responseEncode.ts
+++ b/packages/lodestar/src/network/reqresp/encoders/responseEncode.ts
@@ -11,8 +11,8 @@ import {
   OutgoingResponseBodyByMethod,
   ContextBytesType,
   contextBytesTypeByProtocol,
-  getResponseSzzTypeByMethod,
   IncomingResponseBodyByMethod,
+  getOutgoingSerializerByMethod,
 } from "../types";
 
 /**
@@ -40,11 +40,8 @@ export function responseEncodeSuccess(
       yield* writeContextBytes(config, contextBytesType, forkName);
 
       // <encoding-dependent-header> | <encoded-payload>
-      const type =
-        protocol.method === Method.BeaconBlocksByRange || protocol.method === Method.BeaconBlocksByRoot
-          ? null
-          : getResponseSzzTypeByMethod(protocol, forkName);
-      yield* writeEncodedPayload(chunk, protocol.encoding, type);
+      const serializer = getOutgoingSerializerByMethod(protocol);
+      yield* writeEncodedPayload(chunk, protocol.encoding, serializer);
     }
   };
 }

--- a/packages/lodestar/src/network/reqresp/encodingStrategies/index.ts
+++ b/packages/lodestar/src/network/reqresp/encodingStrategies/index.ts
@@ -1,4 +1,10 @@
-import {Encoding, RequestOrResponseType, RequestOrIncomingResponseBody, RequestOrOutgoingResponseBody} from "../types";
+import {
+  Encoding,
+  RequestOrResponseType,
+  RequestOrIncomingResponseBody,
+  RequestOrOutgoingResponseBody,
+  OutgoingSerializer,
+} from "../types";
 import {BufferedSource} from "../utils";
 import {readSszSnappyPayload, ISszSnappyOptions} from "./sszSnappy/decode";
 import {writeSszSnappyPayload} from "./sszSnappy/encode";
@@ -31,7 +37,6 @@ export async function readEncodedPayload<T extends RequestOrIncomingResponseBody
 
 /**
  * Yields byte chunks for encoded header and payload as defined in the spec:
- * @param type: null if we use bytes data without having to serialize
  * ```
  * <encoding-dependent-header> | <encoded-payload>
  * ```
@@ -39,11 +44,11 @@ export async function readEncodedPayload<T extends RequestOrIncomingResponseBody
 export async function* writeEncodedPayload<T extends RequestOrOutgoingResponseBody>(
   body: T,
   encoding: Encoding,
-  type: RequestOrResponseType | null
+  serializer: OutgoingSerializer
 ): AsyncGenerator<Buffer> {
   switch (encoding) {
     case Encoding.SSZ_SNAPPY:
-      yield* writeSszSnappyPayload(body, type);
+      yield* writeSszSnappyPayload(body, serializer);
       break;
 
     default:

--- a/packages/lodestar/src/network/reqresp/encodingStrategies/index.ts
+++ b/packages/lodestar/src/network/reqresp/encodingStrategies/index.ts
@@ -1,4 +1,4 @@
-import {Encoding, RequestOrResponseType, RequestOrResponseBody, RequestOrLodestarResponseBody} from "../types";
+import {Encoding, RequestOrResponseType, RequestOrIncomingResponseBody, RequestOrOutgoingResponseBody} from "../types";
 import {BufferedSource} from "../utils";
 import {readSszSnappyPayload, ISszSnappyOptions} from "./sszSnappy/decode";
 import {writeSszSnappyPayload} from "./sszSnappy/encode";
@@ -14,7 +14,7 @@ import {writeSszSnappyPayload} from "./sszSnappy/encode";
  * <encoding-dependent-header> | <encoded-payload>
  * ```
  */
-export async function readEncodedPayload<T extends RequestOrResponseBody>(
+export async function readEncodedPayload<T extends RequestOrIncomingResponseBody>(
   bufferedSource: BufferedSource,
   encoding: Encoding,
   type: RequestOrResponseType,
@@ -36,7 +36,7 @@ export async function readEncodedPayload<T extends RequestOrResponseBody>(
  * <encoding-dependent-header> | <encoded-payload>
  * ```
  */
-export async function* writeEncodedPayload<T extends RequestOrLodestarResponseBody>(
+export async function* writeEncodedPayload<T extends RequestOrOutgoingResponseBody>(
   body: T,
   encoding: Encoding,
   type: RequestOrResponseType | null

--- a/packages/lodestar/src/network/reqresp/encodingStrategies/index.ts
+++ b/packages/lodestar/src/network/reqresp/encodingStrategies/index.ts
@@ -1,4 +1,4 @@
-import {Encoding, RequestOrResponseType, RequestOrResponseBody} from "../types";
+import {Encoding, RequestOrResponseType, RequestOrResponseBody, RequestOrLodestarResponseBody} from "../types";
 import {BufferedSource} from "../utils";
 import {readSszSnappyPayload, ISszSnappyOptions} from "./sszSnappy/decode";
 import {writeSszSnappyPayload} from "./sszSnappy/encode";
@@ -31,14 +31,15 @@ export async function readEncodedPayload<T extends RequestOrResponseBody>(
 
 /**
  * Yields byte chunks for encoded header and payload as defined in the spec:
+ * @param type: null if we use bytes data without having to serialize
  * ```
  * <encoding-dependent-header> | <encoded-payload>
  * ```
  */
-export async function* writeEncodedPayload<T extends RequestOrResponseBody>(
+export async function* writeEncodedPayload<T extends RequestOrLodestarResponseBody>(
   body: T,
   encoding: Encoding,
-  type: RequestOrResponseType
+  type: RequestOrResponseType | null
 ): AsyncGenerator<Buffer> {
   switch (encoding) {
     case Encoding.SSZ_SNAPPY:

--- a/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/decode.ts
+++ b/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/decode.ts
@@ -3,7 +3,7 @@ import varint from "varint";
 import {CompositeType} from "@chainsafe/ssz";
 import {MAX_VARINT_BYTES} from "../../../../constants";
 import {BufferedSource} from "../../utils";
-import {RequestOrResponseType, RequestOrResponseBody} from "../../types";
+import {RequestOrResponseType, RequestOrIncomingResponseBody} from "../../types";
 import {SnappyFramesUncompress} from "./snappyFrames/uncompress";
 import {maxEncodedLen} from "./utils";
 import {SszSnappyError, SszSnappyErrorCode} from "./errors";
@@ -19,7 +19,7 @@ export interface ISszSnappyOptions {
  * <encoding-dependent-header> | <encoded-payload>
  * ```
  */
-export async function readSszSnappyPayload<T extends RequestOrResponseBody>(
+export async function readSszSnappyPayload<T extends RequestOrIncomingResponseBody>(
   bufferedSource: BufferedSource,
   type: RequestOrResponseType,
   options?: ISszSnappyOptions
@@ -130,7 +130,7 @@ async function readSszSnappyBody(bufferedSource: BufferedSource, sszDataLength: 
  * Deseralizes SSZ body.
  * `isSszTree` option allows the SignedBeaconBlock type to be deserialized as a tree
  */
-function deserializeSszBody<T extends RequestOrResponseBody>(
+function deserializeSszBody<T extends RequestOrIncomingResponseBody>(
   bytes: Buffer,
   type: RequestOrResponseType,
   options?: ISszSnappyOptions

--- a/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/encode.ts
+++ b/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/encode.ts
@@ -1,9 +1,9 @@
 import varint from "varint";
 import {source} from "stream-to-it";
 import {createCompressStream} from "@chainsafe/snappy-stream";
-import {RequestOrResponseType, RequestOrLodestarResponseBody} from "../../types";
+import {RequestOrResponseType, RequestOrOutgoingResponseBody} from "../../types";
 import {SszSnappyError, SszSnappyErrorCode} from "./errors";
-import {P2pBlockResponse} from "@chainsafe/lodestar-types";
+import {ReqRespBlockResponse} from "@chainsafe/lodestar-types";
 
 /**
  * ssz_snappy encoding strategy writer.
@@ -13,11 +13,11 @@ import {P2pBlockResponse} from "@chainsafe/lodestar-types";
  * <encoding-dependent-header> | <encoded-payload>
  * ```
  */
-export async function* writeSszSnappyPayload<T extends RequestOrLodestarResponseBody>(
+export async function* writeSszSnappyPayload<T extends RequestOrOutgoingResponseBody>(
   body: T,
   type: RequestOrResponseType | null
 ): AsyncGenerator<Buffer> {
-  const serializedBody = type === null ? (body as P2pBlockResponse).bytes : serializeSszBody(body, type);
+  const serializedBody = type === null ? (body as ReqRespBlockResponse).bytes : serializeSszBody(body, type);
 
   // MUST encode the length of the raw SSZ bytes, encoded as an unsigned protobuf varint
   yield Buffer.from(varint.encode(serializedBody.length));
@@ -40,7 +40,7 @@ function encodeSszSnappy(bytes: Buffer): AsyncGenerator<Buffer> {
 /**
  * Returns SSZ serialized body. Wrapps errors with SszSnappyError.SERIALIZE_ERROR
  */
-function serializeSszBody<T extends RequestOrLodestarResponseBody>(body: T, type: RequestOrResponseType): Buffer {
+function serializeSszBody<T extends RequestOrOutgoingResponseBody>(body: T, type: RequestOrResponseType): Buffer {
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const bytes = type.serialize(body as any);

--- a/packages/lodestar/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/lodestar/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -1,5 +1,5 @@
 import {GENESIS_SLOT, MAX_REQUEST_BLOCKS} from "@chainsafe/lodestar-params";
-import {P2pBlockResponse, phase0} from "@chainsafe/lodestar-types";
+import {ReqRespBlockResponse, phase0} from "@chainsafe/lodestar-types";
 import {IBlockFilterOptions} from "../../../db/repositories";
 import {IBeaconChain} from "../../../chain";
 import {IBeaconDb} from "../../../db";
@@ -12,7 +12,7 @@ export async function* onBeaconBlocksByRange(
   requestBody: phase0.BeaconBlocksByRangeRequest,
   chain: IBeaconChain,
   db: IBeaconDb
-): AsyncIterable<P2pBlockResponse> {
+): AsyncIterable<ReqRespBlockResponse> {
   if (requestBody.step < 1) {
     throw new ResponseError(RespStatus.INVALID_REQUEST, "step < 1");
   }
@@ -28,7 +28,7 @@ export async function* onBeaconBlocksByRange(
     requestBody.count = MAX_REQUEST_BLOCKS;
   }
 
-  const archiveBlocksStream = db.blockArchive.p2pBlockStream({
+  const archiveBlocksStream = db.blockArchive.reqRespBlockStream({
     gte: requestBody.startSlot,
     lt: requestBody.startSlot + requestBody.count * requestBody.step,
     step: requestBody.step,
@@ -37,10 +37,10 @@ export async function* onBeaconBlocksByRange(
 }
 
 export async function* injectRecentBlocks(
-  archiveStream: AsyncIterable<P2pBlockResponse>,
+  archiveStream: AsyncIterable<ReqRespBlockResponse>,
   chain: IBeaconChain,
   request: phase0.BeaconBlocksByRangeRequest
-): AsyncGenerator<P2pBlockResponse> {
+): AsyncGenerator<ReqRespBlockResponse> {
   let totalBlock = 0;
   let slot = -1;
   for await (const p2pBlock of archiveStream) {

--- a/packages/lodestar/src/network/reqresp/handlers/beaconBlocksByRoot.ts
+++ b/packages/lodestar/src/network/reqresp/handlers/beaconBlocksByRoot.ts
@@ -1,7 +1,8 @@
-import {ReqRespBlockResponse, phase0, Slot} from "@chainsafe/lodestar-types";
+import {phase0, Slot} from "@chainsafe/lodestar-types";
 import {IBeaconChain} from "../../../chain";
 import {IBeaconDb} from "../../../db";
 import {getSlotFromBytes} from "../../../util/multifork";
+import {ReqRespBlockResponse} from "../types";
 
 export async function* onBeaconBlocksByRoot(
   requestBody: phase0.BeaconBlocksByRootRequest,

--- a/packages/lodestar/src/network/reqresp/handlers/index.ts
+++ b/packages/lodestar/src/network/reqresp/handlers/index.ts
@@ -1,4 +1,4 @@
-import {allForks, phase0} from "@chainsafe/lodestar-types";
+import {P2pBlockResponse, phase0} from "@chainsafe/lodestar-types";
 import {IBeaconChain} from "../../../chain";
 import {IBeaconDb} from "../../../db";
 import {onBeaconBlocksByRange} from "./beaconBlocksByRange";
@@ -6,8 +6,8 @@ import {onBeaconBlocksByRoot} from "./beaconBlocksByRoot";
 
 export type ReqRespHandlers = {
   onStatus(): AsyncIterable<phase0.Status>;
-  onBeaconBlocksByRange(req: phase0.BeaconBlocksByRangeRequest): AsyncIterable<allForks.SignedBeaconBlock>;
-  onBeaconBlocksByRoot(req: phase0.BeaconBlocksByRootRequest): AsyncIterable<allForks.SignedBeaconBlock>;
+  onBeaconBlocksByRange(req: phase0.BeaconBlocksByRangeRequest): AsyncIterable<P2pBlockResponse>;
+  onBeaconBlocksByRoot(req: phase0.BeaconBlocksByRootRequest): AsyncIterable<P2pBlockResponse>;
 };
 
 /**

--- a/packages/lodestar/src/network/reqresp/handlers/index.ts
+++ b/packages/lodestar/src/network/reqresp/handlers/index.ts
@@ -1,6 +1,7 @@
-import {ReqRespBlockResponse, phase0} from "@chainsafe/lodestar-types";
+import {phase0} from "@chainsafe/lodestar-types";
 import {IBeaconChain} from "../../../chain";
 import {IBeaconDb} from "../../../db";
+import {ReqRespBlockResponse} from "../types";
 import {onBeaconBlocksByRange} from "./beaconBlocksByRange";
 import {onBeaconBlocksByRoot} from "./beaconBlocksByRoot";
 

--- a/packages/lodestar/src/network/reqresp/handlers/index.ts
+++ b/packages/lodestar/src/network/reqresp/handlers/index.ts
@@ -1,4 +1,4 @@
-import {P2pBlockResponse, phase0} from "@chainsafe/lodestar-types";
+import {ReqRespBlockResponse, phase0} from "@chainsafe/lodestar-types";
 import {IBeaconChain} from "../../../chain";
 import {IBeaconDb} from "../../../db";
 import {onBeaconBlocksByRange} from "./beaconBlocksByRange";
@@ -6,8 +6,8 @@ import {onBeaconBlocksByRoot} from "./beaconBlocksByRoot";
 
 export type ReqRespHandlers = {
   onStatus(): AsyncIterable<phase0.Status>;
-  onBeaconBlocksByRange(req: phase0.BeaconBlocksByRangeRequest): AsyncIterable<P2pBlockResponse>;
-  onBeaconBlocksByRoot(req: phase0.BeaconBlocksByRootRequest): AsyncIterable<P2pBlockResponse>;
+  onBeaconBlocksByRange(req: phase0.BeaconBlocksByRangeRequest): AsyncIterable<ReqRespBlockResponse>;
+  onBeaconBlocksByRoot(req: phase0.BeaconBlocksByRootRequest): AsyncIterable<ReqRespBlockResponse>;
 };
 
 /**

--- a/packages/lodestar/src/network/reqresp/reqResp.ts
+++ b/packages/lodestar/src/network/reqresp/reqResp.ts
@@ -27,10 +27,11 @@ import {
   Version,
   Encoding,
   Protocol,
-  ResponseBody,
+  LodestarResponseBody,
   RequestBody,
   RequestTypedContainer,
   protocolsSupported,
+  ResponseBody,
 } from "./types";
 
 export type IReqRespOptions = Partial<typeof timeoutOptions>;
@@ -205,7 +206,11 @@ export class ReqResp implements IReqResp {
     };
   }
 
-  private async *onRequest(protocol: Protocol, requestBody: RequestBody, peerId: PeerId): AsyncIterable<ResponseBody> {
+  private async *onRequest(
+    protocol: Protocol,
+    requestBody: RequestBody,
+    peerId: PeerId
+  ): AsyncIterable<LodestarResponseBody> {
     const requestTyped = {method: protocol.method, body: requestBody} as RequestTypedContainer;
 
     switch (requestTyped.method) {

--- a/packages/lodestar/src/network/reqresp/reqResp.ts
+++ b/packages/lodestar/src/network/reqresp/reqResp.ts
@@ -27,11 +27,11 @@ import {
   Version,
   Encoding,
   Protocol,
-  LodestarResponseBody,
+  OutgoingResponseBody,
   RequestBody,
   RequestTypedContainer,
   protocolsSupported,
-  ResponseBody,
+  IncomingResponseBody,
 } from "./types";
 
 export type IReqRespOptions = Partial<typeof timeoutOptions>;
@@ -133,7 +133,7 @@ export class ReqResp implements IReqResp {
   }
 
   // Helper to reduce code duplication
-  private async sendRequest<T extends ResponseBody | ResponseBody[]>(
+  private async sendRequest<T extends IncomingResponseBody | IncomingResponseBody[]>(
     peerId: PeerId,
     method: Method,
     versions: Version[],
@@ -210,7 +210,7 @@ export class ReqResp implements IReqResp {
     protocol: Protocol,
     requestBody: RequestBody,
     peerId: PeerId
-  ): AsyncIterable<LodestarResponseBody> {
+  ): AsyncIterable<OutgoingResponseBody> {
     const requestTyped = {method: protocol.method, body: requestBody} as RequestTypedContainer;
 
     switch (requestTyped.method) {

--- a/packages/lodestar/src/network/reqresp/request/collectResponses.ts
+++ b/packages/lodestar/src/network/reqresp/request/collectResponses.ts
@@ -1,4 +1,4 @@
-import {Method, isSingleResponseChunkByMethod, ResponseBody} from "../types";
+import {Method, isSingleResponseChunkByMethod, IncomingResponseBody} from "../types";
 import {RequestErrorCode, RequestInternalError} from "./errors";
 
 /**
@@ -8,10 +8,10 @@ import {RequestErrorCode, RequestInternalError} from "./errors";
  * ```
  * Note: `response` has zero or more chunks for SSZ-list responses or exactly one chunk for non-list
  */
-export function collectResponses<T extends ResponseBody | ResponseBody[]>(
+export function collectResponses<T extends IncomingResponseBody | IncomingResponseBody[]>(
   method: Method,
   maxResponses?: number
-): (source: AsyncIterable<ResponseBody>) => Promise<T> {
+): (source: AsyncIterable<IncomingResponseBody>) => Promise<T> {
   return async (source) => {
     if (isSingleResponseChunkByMethod[method]) {
       for await (const response of source) {
@@ -21,7 +21,7 @@ export function collectResponses<T extends ResponseBody | ResponseBody[]>(
     }
 
     // else: zero or more responses
-    const responses: ResponseBody[] = [];
+    const responses: IncomingResponseBody[] = [];
     for await (const response of source) {
       responses.push(response);
 

--- a/packages/lodestar/src/network/reqresp/request/index.ts
+++ b/packages/lodestar/src/network/reqresp/request/index.ts
@@ -6,7 +6,7 @@ import {IForkDigestContext} from "@chainsafe/lodestar-config";
 import {ErrorAborted, ILogger, Context, withTimeout, TimeoutError} from "@chainsafe/lodestar-utils";
 import {timeoutOptions} from "../../../constants";
 import {getAgentVersionFromPeerStore, prettyPrintPeerId} from "../../util";
-import {Method, Encoding, Protocol, Version, ResponseBody, RequestBody} from "../types";
+import {Method, Encoding, Protocol, Version, IncomingResponseBody, RequestBody} from "../types";
 import {formatProtocolId} from "../utils";
 import {ResponseError} from "../response";
 import {requestEncode} from "../encoders/requestEncode";
@@ -41,7 +41,7 @@ type SendRequestModules = {
  *    - Any part of the response_chunk fails validation. Throws a typed error (see `SszSnappyError`)
  *    - The maximum number of requested chunks are read. Does not throw, returns read chunks only.
  */
-export async function sendRequest<T extends ResponseBody | ResponseBody[]>(
+export async function sendRequest<T extends IncomingResponseBody | IncomingResponseBody[]>(
   {logger, forkDigestContext, libp2p}: SendRequestModules,
   peerId: PeerId,
   method: Method,

--- a/packages/lodestar/src/network/reqresp/response/index.ts
+++ b/packages/lodestar/src/network/reqresp/response/index.ts
@@ -6,7 +6,7 @@ import {Context, ILogger, TimeoutError, withTimeout} from "@chainsafe/lodestar-u
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {REQUEST_TIMEOUT, RespStatus} from "../../../constants";
 import {getAgentVersionFromPeerStore, prettyPrintPeerId} from "../../util";
-import {Protocol, RequestBody, ResponseBody} from "../types";
+import {Protocol, RequestBody, LodestarResponseBody} from "../types";
 import {onChunk} from "../utils";
 import {Libp2pStream} from "../interface";
 import {requestDecode} from "../encoders/requestDecode";
@@ -19,7 +19,7 @@ export type PerformRequestHandler = (
   protocol: Protocol,
   requestBody: RequestBody,
   peerId: PeerId
-) => AsyncIterable<ResponseBody>;
+) => AsyncIterable<LodestarResponseBody>;
 
 type HandleRequestModules = {
   config: IBeaconConfig;

--- a/packages/lodestar/src/network/reqresp/response/index.ts
+++ b/packages/lodestar/src/network/reqresp/response/index.ts
@@ -6,7 +6,7 @@ import {Context, ILogger, TimeoutError, withTimeout} from "@chainsafe/lodestar-u
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {REQUEST_TIMEOUT, RespStatus} from "../../../constants";
 import {getAgentVersionFromPeerStore, prettyPrintPeerId} from "../../util";
-import {Protocol, RequestBody, LodestarResponseBody} from "../types";
+import {Protocol, RequestBody, OutgoingResponseBody} from "../types";
 import {onChunk} from "../utils";
 import {Libp2pStream} from "../interface";
 import {requestDecode} from "../encoders/requestDecode";
@@ -19,7 +19,7 @@ export type PerformRequestHandler = (
   protocol: Protocol,
   requestBody: RequestBody,
   peerId: PeerId
-) => AsyncIterable<LodestarResponseBody>;
+) => AsyncIterable<OutgoingResponseBody>;
 
 type HandleRequestModules = {
   config: IBeaconConfig;

--- a/packages/lodestar/src/network/reqresp/types.ts
+++ b/packages/lodestar/src/network/reqresp/types.ts
@@ -1,5 +1,5 @@
 import {ForkName} from "@chainsafe/lodestar-params";
-import {allForks, ReqRespBlockResponse, phase0, ssz} from "@chainsafe/lodestar-types";
+import {allForks, phase0, ssz, Slot} from "@chainsafe/lodestar-types";
 
 export const protocolPrefix = "/eth2/beacon_chain/req";
 
@@ -209,4 +209,11 @@ export const reqRespBlockResponseSerializer = {
   serialize: (chunk: ReqRespBlockResponse): Uint8Array => {
     return chunk.bytes;
   },
+};
+
+/** This type helps response to beacon_block_by_range and beacon_block_by_root more efficiently */
+export type ReqRespBlockResponse = {
+  /** Deserialized data of allForks.SignedBeaconBlock */
+  bytes: Buffer;
+  slot: Slot;
 };

--- a/packages/lodestar/src/network/reqresp/types.ts
+++ b/packages/lodestar/src/network/reqresp/types.ts
@@ -1,5 +1,5 @@
 import {ForkName} from "@chainsafe/lodestar-params";
-import {allForks, P2pBlockResponse, phase0, ssz} from "@chainsafe/lodestar-types";
+import {allForks, ReqRespBlockResponse, phase0, ssz} from "@chainsafe/lodestar-types";
 
 export const protocolPrefix = "/eth2/beacon_chain/req";
 
@@ -150,13 +150,13 @@ type CommonResponseBodyByMethod = {
 
 // Used internally by lodestar to response to beacon_blocks_by_range and beacon_blocks_by_root
 // without having to deserialize and serialize from/to bytes
-export type LodestarResponseBodyByMethod = CommonResponseBodyByMethod & {
-  [Method.BeaconBlocksByRange]: P2pBlockResponse;
-  [Method.BeaconBlocksByRoot]: P2pBlockResponse;
+export type OutgoingResponseBodyByMethod = CommonResponseBodyByMethod & {
+  [Method.BeaconBlocksByRange]: ReqRespBlockResponse;
+  [Method.BeaconBlocksByRoot]: ReqRespBlockResponse;
 };
 
 // p2p protocol in the spec
-export type ResponseBodyByMethod = CommonResponseBodyByMethod & {
+export type IncomingResponseBodyByMethod = CommonResponseBodyByMethod & {
   [Method.BeaconBlocksByRange]: allForks.SignedBeaconBlock;
   [Method.BeaconBlocksByRoot]: allForks.SignedBeaconBlock;
 };
@@ -164,10 +164,10 @@ export type ResponseBodyByMethod = CommonResponseBodyByMethod & {
 // Helper types to generically define the arguments of the encoder functions
 
 export type RequestBody = RequestBodyByMethod[Method];
-export type LodestarResponseBody = LodestarResponseBodyByMethod[Method];
-export type ResponseBody = ResponseBodyByMethod[Method];
-export type RequestOrResponseBody = RequestBody | ResponseBody;
-export type RequestOrLodestarResponseBody = RequestBody | LodestarResponseBody;
+export type OutgoingResponseBody = OutgoingResponseBodyByMethod[Method];
+export type IncomingResponseBody = IncomingResponseBodyByMethod[Method];
+export type RequestOrIncomingResponseBody = RequestBody | IncomingResponseBody;
+export type RequestOrOutgoingResponseBody = RequestBody | OutgoingResponseBody;
 
 export type RequestType = Exclude<ReturnType<typeof getRequestSzzTypeByMethod>, null>;
 export type ResponseType = ReturnType<typeof getResponseSzzTypeByMethod>;
@@ -179,5 +179,5 @@ export type RequestTypedContainer = {
   [K in Method]: {method: K; body: RequestBodyByMethod[K]};
 }[Method];
 export type ResponseTypedContainer = {
-  [K in Method]: {method: K; body: LodestarResponseBodyByMethod[K]};
+  [K in Method]: {method: K; body: OutgoingResponseBodyByMethod[K]};
 }[Method];

--- a/packages/lodestar/src/util/multifork.ts
+++ b/packages/lodestar/src/util/multifork.ts
@@ -1,5 +1,5 @@
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
-import {allForks} from "@chainsafe/lodestar-types";
+import {allForks, Slot} from "@chainsafe/lodestar-types";
 import {bytesToInt} from "@chainsafe/lodestar-utils";
 import {ContainerType} from "@chainsafe/ssz";
 
@@ -39,8 +39,12 @@ export function getSignedBlockTypeFromBytes(
   config: IChainForkConfig,
   bytes: Buffer | Uint8Array
 ): ContainerType<allForks.SignedBeaconBlock> {
-  const slot = bytesToInt(bytes.slice(SLOT_BYTES_POSITION_IN_BLOCK, SLOT_BYTES_POSITION_IN_BLOCK + SLOT_BYTE_COUNT));
+  const slot = getSlotFromBytes(bytes);
   return config.getForkTypes(slot).SignedBeaconBlock;
+}
+
+export function getSlotFromBytes(bytes: Buffer | Uint8Array): Slot {
+  return bytesToInt(bytes.slice(SLOT_BYTES_POSITION_IN_BLOCK, SLOT_BYTES_POSITION_IN_BLOCK + SLOT_BYTE_COUNT));
 }
 
 export function getStateTypeFromBytes(

--- a/packages/lodestar/test/e2e/network/reqresp.test.ts
+++ b/packages/lodestar/test/e2e/network/reqresp.test.ts
@@ -18,7 +18,11 @@ import {MockBeaconChain} from "../../utils/mocks/chain/chain";
 import {createNode} from "../../utils/network";
 import {generateState} from "../../utils/state";
 import {arrToSource, generateEmptySignedBlocks} from "../../unit/network/reqresp/utils";
-import {blocksToP2pBlockResponses, generateEmptyP2pBlockResponse, generateEmptySignedBlock} from "../../utils/block";
+import {
+  blocksToReqRespBlockResponses,
+  generateEmptyReqRespBlockResponse,
+  generateEmptySignedBlock,
+} from "../../utils/block";
 import {expectRejectedWithLodestarError} from "../../utils/errors";
 import {connect, onPeerConnect} from "../../utils/network";
 import {StubbedBeaconDb} from "../../utils/stub";
@@ -179,7 +183,7 @@ describe("network / ReqResp", function () {
 
     const [netA, netB] = await createAndConnectPeers({
       onBeaconBlocksByRange: async function* () {
-        yield* arrToSource(blocksToP2pBlockResponses(blocks));
+        yield* arrToSource(blocksToReqRespBlockResponses(blocks));
       },
     });
 
@@ -215,7 +219,7 @@ describe("network / ReqResp", function () {
 
     const [netA, netB] = await createAndConnectPeers({
       onBeaconBlocksByRange: async function* onRequest() {
-        yield* arrToSource(blocksToP2pBlockResponses(generateEmptySignedBlocks(2)));
+        yield* arrToSource(blocksToReqRespBlockResponses(generateEmptySignedBlocks(2)));
         throw Error(testErrorMessage);
       },
     });
@@ -237,7 +241,7 @@ describe("network / ReqResp", function () {
         onBeaconBlocksByRange: async function* onRequest() {
           // Wait for too long before sending first response chunk
           await sleep(TTFB_TIMEOUT * 10);
-          yield generateEmptyP2pBlockResponse();
+          yield generateEmptyReqRespBlockResponse();
         },
       },
       {TTFB_TIMEOUT}
@@ -258,10 +262,10 @@ describe("network / ReqResp", function () {
     const [netA, netB] = await createAndConnectPeers(
       {
         onBeaconBlocksByRange: async function* onRequest() {
-          yield generateEmptyP2pBlockResponse();
+          yield generateEmptyReqRespBlockResponse();
           // Wait for too long before sending second response chunk
           await sleep(RESP_TIMEOUT * 5);
-          yield generateEmptyP2pBlockResponse();
+          yield generateEmptyReqRespBlockResponse();
         },
       },
       {RESP_TIMEOUT}
@@ -299,7 +303,7 @@ describe("network / ReqResp", function () {
     const [netA, netB] = await createAndConnectPeers(
       {
         onBeaconBlocksByRange: async function* onRequest() {
-          yield generateEmptyP2pBlockResponse();
+          yield generateEmptyReqRespBlockResponse();
           await sleep(100000000);
         },
       },

--- a/packages/lodestar/test/e2e/network/reqresp.test.ts
+++ b/packages/lodestar/test/e2e/network/reqresp.test.ts
@@ -18,7 +18,7 @@ import {MockBeaconChain} from "../../utils/mocks/chain/chain";
 import {createNode} from "../../utils/network";
 import {generateState} from "../../utils/state";
 import {arrToSource, generateEmptySignedBlocks} from "../../unit/network/reqresp/utils";
-import {generateEmptySignedBlock} from "../../utils/block";
+import {blocksToP2pBlockResponses, generateEmptyP2pBlockResponse, generateEmptySignedBlock} from "../../utils/block";
 import {expectRejectedWithLodestarError} from "../../utils/errors";
 import {connect, onPeerConnect} from "../../utils/network";
 import {StubbedBeaconDb} from "../../utils/stub";
@@ -179,7 +179,7 @@ describe("network / ReqResp", function () {
 
     const [netA, netB] = await createAndConnectPeers({
       onBeaconBlocksByRange: async function* () {
-        yield* arrToSource(blocks);
+        yield* arrToSource(blocksToP2pBlockResponses(blocks));
       },
     });
 
@@ -215,7 +215,7 @@ describe("network / ReqResp", function () {
 
     const [netA, netB] = await createAndConnectPeers({
       onBeaconBlocksByRange: async function* onRequest() {
-        yield* arrToSource(generateEmptySignedBlocks(2));
+        yield* arrToSource(blocksToP2pBlockResponses(generateEmptySignedBlocks(2)));
         throw Error(testErrorMessage);
       },
     });
@@ -237,7 +237,7 @@ describe("network / ReqResp", function () {
         onBeaconBlocksByRange: async function* onRequest() {
           // Wait for too long before sending first response chunk
           await sleep(TTFB_TIMEOUT * 10);
-          yield generateEmptySignedBlock();
+          yield generateEmptyP2pBlockResponse();
         },
       },
       {TTFB_TIMEOUT}
@@ -258,10 +258,10 @@ describe("network / ReqResp", function () {
     const [netA, netB] = await createAndConnectPeers(
       {
         onBeaconBlocksByRange: async function* onRequest() {
-          yield generateEmptySignedBlock();
+          yield generateEmptyP2pBlockResponse();
           // Wait for too long before sending second response chunk
           await sleep(RESP_TIMEOUT * 5);
-          yield generateEmptySignedBlock();
+          yield generateEmptyP2pBlockResponse();
         },
       },
       {RESP_TIMEOUT}
@@ -299,7 +299,7 @@ describe("network / ReqResp", function () {
     const [netA, netB] = await createAndConnectPeers(
       {
         onBeaconBlocksByRange: async function* onRequest() {
-          yield generateEmptySignedBlock();
+          yield generateEmptyP2pBlockResponse();
           await sleep(100000000);
         },
       },

--- a/packages/lodestar/test/unit/network/reqresp/encoders/response.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/encoders/response.test.ts
@@ -11,8 +11,8 @@ import {
   Version,
   Encoding,
   Protocol,
-  ResponseBody,
-  LodestarResponseBody,
+  IncomingResponseBody,
+  OutgoingResponseBody,
 } from "../../../../../src/network/reqresp/types";
 import {getResponseSzzTypeByMethod} from "../../../../../src/network/reqresp/types";
 import {SszSnappyError, SszSnappyErrorCode} from "../../../../../src/network/reqresp/encodingStrategies/sszSnappy";
@@ -32,13 +32,13 @@ import {
   sszSnappySignedBeaconBlockPhase0,
   sszSnappySignedBeaconBlockAltair,
 } from "../encodingStrategies/sszSnappy/testData";
-import {blocksToP2pBlockResponses} from "../../../../utils/block";
+import {blocksToReqRespBlockResponses} from "../../../../utils/block";
 import {allForks} from "@chainsafe/lodestar-types";
 
 chai.use(chaiAsPromised);
 
 type ResponseChunk =
-  | {status: RespStatus.SUCCESS; body: ResponseBody}
+  | {status: RespStatus.SUCCESS; body: IncomingResponseBody}
   | {status: Exclude<RespStatus, RespStatus.SUCCESS>; errorMessage: string};
 
 describe("network / reqresp / encoders / response - Success and error cases", () => {
@@ -255,10 +255,10 @@ describe("network / reqresp / encoders / response - Success and error cases", ()
       if (chunk.status === RespStatus.SUCCESS) {
         const lodestarResponseBodies =
           protocol.method === Method.BeaconBlocksByRange || protocol.method === Method.BeaconBlocksByRoot
-            ? blocksToP2pBlockResponses([chunk.body] as allForks.SignedBeaconBlock[], config)
+            ? blocksToReqRespBlockResponses([chunk.body] as allForks.SignedBeaconBlock[], config)
             : [chunk.body];
         yield* pipe(
-          arrToSource(lodestarResponseBodies as LodestarResponseBody[]),
+          arrToSource(lodestarResponseBodies as OutgoingResponseBody[]),
           responseEncodeSuccess(config, protocol)
         );
       } else {
@@ -317,8 +317,8 @@ describe("network / reqresp / encoders / response - Success and error cases", ()
   }
 });
 
-function onlySuccessChunks(responseChunks: ResponseChunk[]): ResponseBody[] {
-  const bodyArr: ResponseBody[] = [];
+function onlySuccessChunks(responseChunks: ResponseChunk[]): IncomingResponseBody[] {
+  const bodyArr: IncomingResponseBody[] = [];
   for (const chunk of responseChunks) {
     if (chunk.status === RespStatus.SUCCESS) bodyArr.push(chunk.body);
   }

--- a/packages/lodestar/test/unit/network/reqresp/encoders/responseTypes.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/encoders/responseTypes.test.ts
@@ -8,22 +8,22 @@ import {
   Method,
   Version,
   Encoding,
-  LodestarResponseBody,
+  OutgoingResponseBody,
   getResponseSzzTypeByMethod,
-  ResponseBodyByMethod,
+  IncomingResponseBodyByMethod,
 } from "../../../../../src/network/reqresp/types";
 import {responseDecode} from "../../../../../src/network/reqresp/encoders/responseDecode";
 import {responseEncodeSuccess} from "../../../../../src/network/reqresp/encoders/responseEncode";
 import {arrToSource, createStatus, generateEmptySignedBlocks} from "../utils";
 import {expectIsEqualSszTypeArr} from "../../../../utils/ssz";
 import {config} from "../../../../utils/config";
-import {blocksToP2pBlockResponses} from "../../../../utils/block";
+import {blocksToReqRespBlockResponses} from "../../../../utils/block";
 
 chai.use(chaiAsPromised);
 
 // Ensure the types from all methods are supported properly
 describe("network / reqresp / encoders / responseTypes", () => {
-  const testCases: {[P in keyof ResponseBodyByMethod]: ResponseBodyByMethod[P][][]} = {
+  const testCases: {[P in keyof IncomingResponseBodyByMethod]: IncomingResponseBodyByMethod[P][][]} = {
     [Method.Status]: [[createStatus()]],
     [Method.Goodbye]: [[BigInt(0)], [BigInt(1)]],
     [Method.Ping]: [[BigInt(0)], [BigInt(1)]],
@@ -44,8 +44,8 @@ describe("network / reqresp / encoders / responseTypes", () => {
       // const responsesChunks = _responsesChunks as LodestarResponseBody[][];
       const lodestarResponseBodies =
         _method === Method.BeaconBlocksByRange || _method === Method.BeaconBlocksByRoot
-          ? responsesChunks.map((chunk) => blocksToP2pBlockResponses(chunk as allForks.SignedBeaconBlock[]))
-          : (responsesChunks as LodestarResponseBody[][]);
+          ? responsesChunks.map((chunk) => blocksToReqRespBlockResponses(chunk as allForks.SignedBeaconBlock[]))
+          : (responsesChunks as OutgoingResponseBody[][]);
 
       const versions =
         method === Method.BeaconBlocksByRange || method === Method.BeaconBlocksByRoot

--- a/packages/lodestar/test/unit/network/reqresp/encodingStrategies/sszSnappy/encode.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/encodingStrategies/sszSnappy/encode.test.ts
@@ -2,7 +2,11 @@ import all from "it-all";
 import pipe from "it-pipe";
 import {allForks, ssz} from "@chainsafe/lodestar-types";
 import {LodestarError} from "@chainsafe/lodestar-utils";
-import {RequestOrIncomingResponseBody, RequestOrResponseType} from "../../../../../../src/network/reqresp/types";
+import {
+  reqRespBlockResponseSerializer,
+  RequestOrIncomingResponseBody,
+  RequestOrResponseType,
+} from "../../../../../../src/network/reqresp/types";
 import {
   SszSnappyError,
   SszSnappyErrorCode,
@@ -28,7 +32,7 @@ describe("network / reqresp / sszSnappy / encode", () => {
         const encodedChunks = await pipe(
           writeSszSnappyPayload(
             body as RequestOrOutgoingResponseBody,
-            type === ssz.phase0.SignedBeaconBlock ? null : type
+            type === ssz.phase0.SignedBeaconBlock ? reqRespBlockResponseSerializer : type
           ),
           all
         );

--- a/packages/lodestar/test/unit/network/reqresp/encodingStrategies/sszSnappy/encode.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/encodingStrategies/sszSnappy/encode.test.ts
@@ -2,7 +2,7 @@ import all from "it-all";
 import pipe from "it-pipe";
 import {allForks, ssz} from "@chainsafe/lodestar-types";
 import {LodestarError} from "@chainsafe/lodestar-utils";
-import {RequestOrResponseBody, RequestOrResponseType} from "../../../../../../src/network/reqresp/types";
+import {RequestOrIncomingResponseBody, RequestOrResponseType} from "../../../../../../src/network/reqresp/types";
 import {
   SszSnappyError,
   SszSnappyErrorCode,
@@ -11,8 +11,8 @@ import {
 import {expectRejectedWithLodestarError} from "../../../../../utils/errors";
 import {expectEqualByteChunks} from "../../utils";
 import {sszSnappyPing, sszSnappyStatus, sszSnappySignedBeaconBlockPhase0} from "./testData";
-import {blocksToP2pBlockResponses} from "../../../../../utils/block";
-import {RequestOrLodestarResponseBody} from "../../../../../../src/network/reqresp/types";
+import {blocksToReqRespBlockResponses} from "../../../../../utils/block";
+import {RequestOrOutgoingResponseBody} from "../../../../../../src/network/reqresp/types";
 
 describe("network / reqresp / sszSnappy / encode", () => {
   describe("Test data vectors (generated in a previous version)", () => {
@@ -23,11 +23,11 @@ describe("network / reqresp / sszSnappy / encode", () => {
       it(id, async () => {
         const body =
           type === ssz.phase0.SignedBeaconBlock
-            ? blocksToP2pBlockResponses([testCase.body] as allForks.SignedBeaconBlock[])[0]
+            ? blocksToReqRespBlockResponses([testCase.body] as allForks.SignedBeaconBlock[])[0]
             : testCase.body;
         const encodedChunks = await pipe(
           writeSszSnappyPayload(
-            body as RequestOrLodestarResponseBody,
+            body as RequestOrOutgoingResponseBody,
             type === ssz.phase0.SignedBeaconBlock ? null : type
           ),
           all
@@ -41,7 +41,7 @@ describe("network / reqresp / sszSnappy / encode", () => {
     const testCases: {
       id: string;
       type: RequestOrResponseType;
-      body: RequestOrResponseBody;
+      body: RequestOrIncomingResponseBody;
       error: LodestarError<any>;
     }[] = [
       {
@@ -58,7 +58,7 @@ describe("network / reqresp / sszSnappy / encode", () => {
     for (const {id, type, body, error} of testCases) {
       it(id, async () => {
         await expectRejectedWithLodestarError(
-          pipe(writeSszSnappyPayload(body as RequestOrLodestarResponseBody, type), all),
+          pipe(writeSszSnappyPayload(body as RequestOrOutgoingResponseBody, type), all),
           error
         );
       });

--- a/packages/lodestar/test/unit/network/reqresp/encodingStrategies/sszSnappy/testData.ts
+++ b/packages/lodestar/test/unit/network/reqresp/encodingStrategies/sszSnappy/testData.ts
@@ -1,11 +1,11 @@
 import {fromHexString, List} from "@chainsafe/ssz";
 import {altair, phase0, ssz} from "@chainsafe/lodestar-types";
-import {RequestOrResponseBody, RequestOrResponseType} from "../../../../../../src/network/reqresp/types";
+import {RequestOrIncomingResponseBody, RequestOrResponseType} from "../../../../../../src/network/reqresp/types";
 
 // This test data generated with code from 'master' at Jan 1st 2021
 // commit: ea3ffab1ffb8093b61a8ebfa4b4432c604c10819
 
-export interface ISszSnappyTestData<T extends RequestOrResponseBody> {
+export interface ISszSnappyTestData<T extends RequestOrIncomingResponseBody> {
   id: string;
   type: RequestOrResponseType;
   body: T;

--- a/packages/lodestar/test/unit/network/reqresp/encodingStrategies/sszSnappy/testData.ts
+++ b/packages/lodestar/test/unit/network/reqresp/encodingStrategies/sszSnappy/testData.ts
@@ -88,8 +88,8 @@ export const sszSnappySignedBeaconBlockAltair: ISszSnappyTestData<altair.SignedB
     },
   },
   chunks: [
-    "0xf803",
-    "0xff060000734e61507059",
+    "0xf803", // length prefix
+    "0xff060000734e61507059", // snappy frames header
     "0x003f0000ee14ab0df8031064000000dafe01007a01000c995f0100010100090105ee70000d700054ee44000d44fe0100fecc0011cc0c400100003e0400fe01008e0100",
   ].map(fromHexString) as Buffer[],
 };

--- a/packages/lodestar/test/unit/network/reqresp/request/collectResponses.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/request/collectResponses.test.ts
@@ -1,17 +1,17 @@
 import {expect} from "chai";
 import {collectResponses} from "../../../../../src/network/reqresp/request/collectResponses";
-import {Method, ResponseBody} from "../../../../../src/network/reqresp/types";
+import {Method, IncomingResponseBody} from "../../../../../src/network/reqresp/types";
 import {arrToSource} from "../utils";
 
 describe("network / reqresp / request / collectResponses", () => {
-  const chunk: ResponseBody = BigInt(1);
+  const chunk: IncomingResponseBody = BigInt(1);
 
   const testCases: {
     id: string;
     method: Method;
     maxResponses?: number;
-    sourceChunks: ResponseBody[];
-    expectedReturn: ResponseBody | ResponseBody[];
+    sourceChunks: IncomingResponseBody[];
+    expectedReturn: IncomingResponseBody | IncomingResponseBody[];
   }[] = [
     {
       id: "Return first chunk only for a single-chunk method",

--- a/packages/lodestar/test/utils/block.ts
+++ b/packages/lodestar/test/utils/block.ts
@@ -1,4 +1,3 @@
-import {ReqRespBlockResponse} from "@chainsafe/lodestar-types";
 import {ssz} from "@chainsafe/lodestar-types";
 import {config as defaultConfig} from "@chainsafe/lodestar-config/default";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
@@ -9,6 +8,7 @@ import {isPlainObject} from "@chainsafe/lodestar-utils";
 import {RecursivePartial} from "@chainsafe/lodestar-utils";
 import deepmerge from "deepmerge";
 import {EMPTY_SIGNATURE, ZERO_HASH} from "../../src/constants";
+import {ReqRespBlockResponse} from "../../src/network/reqresp/types";
 
 export function generateEmptyBlock(): phase0.BeaconBlock {
   return {

--- a/packages/lodestar/test/utils/block.ts
+++ b/packages/lodestar/test/utils/block.ts
@@ -1,4 +1,8 @@
-import {phase0} from "@chainsafe/lodestar-types";
+import {P2pBlockResponse} from "@chainsafe/lodestar-types";
+import {ssz} from "@chainsafe/lodestar-types";
+import {config as defaultConfig} from "@chainsafe/lodestar-config/default";
+import {IChainForkConfig} from "@chainsafe/lodestar-config";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {List} from "@chainsafe/ssz";
 import {IProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {isPlainObject} from "@chainsafe/lodestar-utils";
@@ -34,6 +38,29 @@ export function generateEmptySignedBlock(): phase0.SignedBeaconBlock {
     message: generateEmptyBlock(),
     signature: EMPTY_SIGNATURE,
   };
+}
+
+export function generateEmptyP2pBlockResponse(): P2pBlockResponse {
+  return {
+    slot: 0,
+    bytes: Buffer.from(ssz.phase0.SignedBeaconBlock.serialize(generateEmptySignedBlock())),
+  };
+}
+
+export function blocksToP2pBlockResponses(
+  blocks: allForks.SignedBeaconBlock[],
+  config?: IChainForkConfig
+): P2pBlockResponse[] {
+  return blocks.map((block) => {
+    const slot = block.message.slot;
+    const sszType = config
+      ? config.getForkTypes(slot).SignedBeaconBlock
+      : defaultConfig.getForkTypes(slot).SignedBeaconBlock;
+    return {
+      slot,
+      bytes: Buffer.from(sszType.serialize(block)),
+    };
+  });
 }
 
 export function generateEmptySignedBlockHeader(): phase0.SignedBeaconBlockHeader {

--- a/packages/lodestar/test/utils/block.ts
+++ b/packages/lodestar/test/utils/block.ts
@@ -1,4 +1,4 @@
-import {P2pBlockResponse} from "@chainsafe/lodestar-types";
+import {ReqRespBlockResponse} from "@chainsafe/lodestar-types";
 import {ssz} from "@chainsafe/lodestar-types";
 import {config as defaultConfig} from "@chainsafe/lodestar-config/default";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
@@ -40,17 +40,17 @@ export function generateEmptySignedBlock(): phase0.SignedBeaconBlock {
   };
 }
 
-export function generateEmptyP2pBlockResponse(): P2pBlockResponse {
+export function generateEmptyReqRespBlockResponse(): ReqRespBlockResponse {
   return {
     slot: 0,
     bytes: Buffer.from(ssz.phase0.SignedBeaconBlock.serialize(generateEmptySignedBlock())),
   };
 }
 
-export function blocksToP2pBlockResponses(
+export function blocksToReqRespBlockResponses(
   blocks: allForks.SignedBeaconBlock[],
   config?: IChainForkConfig
-): P2pBlockResponse[] {
+): ReqRespBlockResponse[] {
   return blocks.map((block) => {
     const slot = block.message.slot;
     const sszType = config

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -1,3 +1,4 @@
+import {P2pBlockResponse} from "@chainsafe/lodestar-types";
 import {AbortController} from "@chainsafe/abort-controller";
 import sinon from "sinon";
 
@@ -132,8 +133,12 @@ export class MockBeaconChain implements IBeaconChain {
     return block;
   }
 
-  async getUnfinalizedBlocksAtSlots(slots: Slot[] = []): Promise<allForks.SignedBeaconBlock[]> {
-    return await Promise.all(slots.map(this.getCanonicalBlockAtSlot));
+  async getUnfinalizedBlocksAtSlots(slots: Slot[] = []): Promise<P2pBlockResponse[]> {
+    const blocks = await Promise.all(slots.map(this.getCanonicalBlockAtSlot));
+    return blocks.map((block, i) => ({
+      slot: slots[i],
+      bytes: Buffer.from(ssz.phase0.SignedBeaconBlock.serialize(block)),
+    }));
   }
 
   getGenesisTime(): Number64 {

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -1,4 +1,4 @@
-import {P2pBlockResponse} from "@chainsafe/lodestar-types";
+import {ReqRespBlockResponse} from "@chainsafe/lodestar-types";
 import {AbortController} from "@chainsafe/abort-controller";
 import sinon from "sinon";
 
@@ -133,7 +133,7 @@ export class MockBeaconChain implements IBeaconChain {
     return block;
   }
 
-  async getUnfinalizedBlocksAtSlots(slots: Slot[] = []): Promise<P2pBlockResponse[]> {
+  async getUnfinalizedBlocksAtSlots(slots: Slot[] = []): Promise<ReqRespBlockResponse[]> {
     const blocks = await Promise.all(slots.map(this.getCanonicalBlockAtSlot));
     return blocks.map((block, i) => ({
       slot: slots[i],

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -1,4 +1,3 @@
-import {ReqRespBlockResponse} from "@chainsafe/lodestar-types";
 import {AbortController} from "@chainsafe/abort-controller";
 import sinon from "sinon";
 
@@ -35,6 +34,7 @@ import {
 import {LightClientIniter} from "../../../../src/chain/lightClient";
 import {Eth1ForBlockProductionDisabled} from "../../../../src/eth1";
 import {ExecutionEngineDisabled} from "../../../../src/executionEngine";
+import {ReqRespBlockResponse} from "../../../../src/network/reqresp/types";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -1,3 +1,5 @@
+import {Slot} from "./primitive/types";
+
 export * from "./primitive/types";
 export {ts as phase0} from "./phase0";
 export {ts as altair} from "./altair";
@@ -7,3 +9,10 @@ export {ts as allForks} from "./allForks";
 
 /** Common non-spec type to represent roots as strings */
 export type RootHex = string;
+
+/** This type helps response to beacon_block_by_range and beacon_block_by_root more efficiently */
+export type P2pBlockResponse = {
+  /** Deserialized data of allForks.SignedBeaconBlock */
+  bytes: Buffer;
+  slot: Slot;
+};

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -1,5 +1,3 @@
-import {Slot} from "./primitive/types";
-
 export * from "./primitive/types";
 export {ts as phase0} from "./phase0";
 export {ts as altair} from "./altair";
@@ -9,10 +7,3 @@ export {ts as allForks} from "./allForks";
 
 /** Common non-spec type to represent roots as strings */
 export type RootHex = string;
-
-/** This type helps response to beacon_block_by_range and beacon_block_by_root more efficiently */
-export type ReqRespBlockResponse = {
-  /** Deserialized data of allForks.SignedBeaconBlock */
-  bytes: Buffer;
-  slot: Slot;
-};

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -11,7 +11,7 @@ export {ts as allForks} from "./allForks";
 export type RootHex = string;
 
 /** This type helps response to beacon_block_by_range and beacon_block_by_root more efficiently */
-export type P2pBlockResponse = {
+export type ReqRespBlockResponse = {
   /** Deserialized data of allForks.SignedBeaconBlock */
   bytes: Buffer;
   slot: Slot;


### PR DESCRIPTION
**Motivation**

+ When serving p2p `beacon_blocks_by_range` or `beacon_blocks_by_roots`, it's not necessary to deserialize bytes from db to SignedBeaconBlock struct and serialize it back to bytes before doing ssz snappy and response to the the other node
+ In some cases, it takes 20% of our cpu time and our validators missed chain head root due to that

**Description**

+ No need to convert to temporary `SignedBeaconBlock` objects  for `beacon_blocks_by_range` and `beacon_blocks_by_roots` requests
+ Model `P2pBlockResponse` type which contains slot and bytes data of `SignedBeaconBlock`. We need `slot` because we use it when fetching from db and to determine correct forkdigest for p2p
+ New `LodestarResponseBodyByMethod` type which use `P2pBlockResponse`  for `beacon_blocks_by_range` and `beacon_blocks_by_roots`


Closes #2490
