### PR TITLE
Update nodejs to v16 - gallium

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "lts/fermium"
+          node-version: "lts/gallium"
       - name: Node.js version
         id: node
         run: echo "::set-output name=v8CppApiVersion::$(node --print "process.versions.modules")"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "lts/fermium"
+          node-version: "lts/gallium"
       - name: Node.js version
         id: node
         run: echo "::set-output name=v8CppApiVersion::$(node --print "process.versions.modules")"

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
-          node-version: "lts/fermium"
+          node-version: "lts/gallium"
           registry-url: "https://registry.npmjs.org"
       - name: Node.js version
         id: node

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v2
         with:
-          node-version: "lts/fermium"
+          node-version: "lts/gallium"
           registry-url: "https://registry.npmjs.org"
 
       - name: Node.js version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "lts/fermium"
+          node-version: "lts/gallium"
       - name: Node.js version
         id: node
         run: echo "::set-output name=v8CppApiVersion::$(node --print "process.versions.modules")"

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "lts/fermium"
+          node-version: "lts/gallium"
       - name: Node.js version
         id: node
         run: echo "::set-output name=v8CppApiVersion::$(node --print "process.versions.modules")"

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "lts/fermium"
+          node-version: "lts/gallium"
       - name: Node.js version
         id: node
         run: echo "::set-output name=v8CppApiVersion::$(node --print "process.versions.modules")"

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "lts/fermium"
+          node-version: "lts/gallium"
       - name: Node.js version
         id: node
         run: echo "::set-output name=v8CppApiVersion::$(node --print "process.versions.modules")"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "lts/fermium"
+          node-version: "lts/gallium"
       - name: Node.js version
         id: node
         run: echo "::set-output name=v8CppApiVersion::$(node --print "process.versions.modules")"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine as build
+FROM node:16-alpine as build
 WORKDIR /usr/app
 RUN apk update && apk add --no-cache g++ make python3 && rm -rf /var/cache/apk/*
 
@@ -6,7 +6,7 @@ ARG VERSION=latest
 ENV VERSION=$VERSION
 RUN npm install @chainsafe/lodestar-cli@$VERSION
 
-FROM node:14-alpine
+FROM node:16-alpine
 WORKDIR /usr/app
 COPY --from=build /usr/app .
 

--- a/docker/from_source.Dockerfile
+++ b/docker/from_source.Dockerfile
@@ -19,7 +19,7 @@
 #
 #######################
 
-FROM node:14-alpine as build
+FROM node:16-alpine as build
 WORKDIR /usr/app
 RUN apk update && apk add --no-cache g++ make python3 && rm -rf /var/cache/apk/*
 
@@ -32,7 +32,7 @@ RUN yarn install --non-interactive --frozen-lockfile && yarn build
 
 # Copy built src + node_modules to a new layer to prune unnecessary fs
 # Previous layer weights 7.25GB, while this final 488MB (as of Oct 2020)
-FROM node:14-alpine
+FROM node:16-alpine
 WORKDIR /usr/app
 COPY --from=build /usr/app .
 


### PR DESCRIPTION
**Motivation**

The active LTS is now v16. It could be useful to upgrade our tooling to use v16.
We've seen some internal reports that heap snapshots are more reliable on v16 than v14.

**Description**

Update node v14 -> v16. (fermium -> gallium)