### PR TITLE
Avoid scanning archived block db with huge step

### DIFF
--- a/packages/lodestar/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/lodestar/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -35,11 +35,9 @@ export async function* onBeaconBlocksByRange(
   let archivedBlocksStream: AsyncIterable<ReqRespBlockResponse>;
 
   if (step > 1) {
-    let slot = startSlot;
     const slots = [];
-    while (slot < lt) {
+    for (let slot = startSlot; slot < lt; slot += step) {
       slots.push(slot);
-      slot += step;
     }
     archivedBlocksStream = getFinalizedBlocksAtSlots(slots, db);
   } else {


### PR DESCRIPTION
**Motivation**

+ Regarding `reqRespBlockStream` api in `blockArhchive.ts`: We may have to scan the whole archived block db if the `step` is huge

**Description**

+ Remove `reqRespBlockStream`
+ If `step > 1` get archived block by slots
+ If `step = 1`, get blocks stream from db
+ If `step < 1`, throw error (already implemented)

Closes #1983
