### PR TITLE
[DNM] Demo throwing AttestationError performance

### DIFF
--- a/packages/lodestar/test/perf/chain/validation/attestation.test.ts
+++ b/packages/lodestar/test/perf/chain/validation/attestation.test.ts
@@ -4,6 +4,7 @@ import {validateGossipAttestation} from "../../../../src/chain/validation";
 import {generateTestCachedBeaconStateOnlyValidators} from "@chainsafe/lodestar-beacon-state-transition/test/perf/util";
 import {getAttestationValidData} from "../../../utils/validationData/attestation";
 import {AttestationError, AttestationErrorCode, GossipAction} from "../../../../src/chain/errors";
+import {ZERO_HASH} from "../../../../src/constants";
 
 describe("validate gossip attestation", () => {
   const vc = 64;
@@ -30,43 +31,41 @@ describe("validate gossip attestation", () => {
 
 describe.only("test throw AttestationError vs object", () => {
   itBench({
-    id: "AttestationError",
+    id: "AttestationError x1000",
+    runsFactor: 1000,
     fn: async () => {
       for (let i = 0; i < 1000; i++) {
         try {
-          await throwAttestationError(true);
+          await throwAttestationError();
         } catch (e) {}
       }
-    }
+    },
   });
 
   itBench({
-    id: "Object",
+    id: "Object x1000",
+    runsFactor: 1000,
     fn: async () => {
       for (let i = 0; i < 1000; i++) {
         try {
-          await throwObject(true);
+          await throwObject();
         } catch (e) {}
       }
-    }
+    },
   });
 });
 
-async function throwAttestationError(b: boolean): Promise<void> {
-  if (b) {
-    throw new AttestationError(GossipAction.IGNORE, {
-      code: AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT,
-      root: Buffer.alloc(32),
-    });
-  }
+async function throwAttestationError(): Promise<void> {
+  throw new AttestationError(GossipAction.IGNORE, {
+    code: AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT,
+    root: ZERO_HASH,
+  });
 }
 
-async function throwObject(b: boolean): Promise<void> {
-  if (b) {
-    throw {
-      action: GossipAction.IGNORE,
-      code: AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT,
-      root: Buffer.alloc(32),
-    };
-  }
+async function throwObject(): Promise<void> {
+  throw {
+    action: GossipAction.IGNORE,
+    code: AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT,
+    root: ZERO_HASH,
+  };
 }

--- a/packages/lodestar/test/perf/chain/validation/attestation.test.ts
+++ b/packages/lodestar/test/perf/chain/validation/attestation.test.ts
@@ -31,10 +31,10 @@ describe("validate gossip attestation", () => {
 describe.only("test throw AttestationError vs object", () => {
   itBench({
     id: "AttestationError",
-    fn: () => {
+    fn: async () => {
       for (let i = 0; i < 1000; i++) {
         try {
-          throwAttestationError(true);
+          await throwAttestationError(true);
         } catch (e) {}
       }
     }
@@ -42,17 +42,17 @@ describe.only("test throw AttestationError vs object", () => {
 
   itBench({
     id: "Object",
-    fn: () => {
+    fn: async () => {
       for (let i = 0; i < 1000; i++) {
         try {
-          throwErrorCode(true);
+          await throwObject(true);
         } catch (e) {}
       }
     }
   });
 });
 
-function throwAttestationError(b: boolean): void {
+async function throwAttestationError(b: boolean): Promise<void> {
   if (b) {
     throw new AttestationError(GossipAction.IGNORE, {
       code: AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT,
@@ -61,7 +61,7 @@ function throwAttestationError(b: boolean): void {
   }
 }
 
-function throwErrorCode(b: boolean): void {
+async function throwObject(b: boolean): Promise<void> {
   if (b) {
     throw {
       action: GossipAction.IGNORE,

--- a/packages/lodestar/test/perf/chain/validation/attestation.test.ts
+++ b/packages/lodestar/test/perf/chain/validation/attestation.test.ts
@@ -3,6 +3,7 @@ import {ssz} from "@chainsafe/lodestar-types";
 import {validateGossipAttestation} from "../../../../src/chain/validation";
 import {generateTestCachedBeaconStateOnlyValidators} from "@chainsafe/lodestar-beacon-state-transition/test/perf/util";
 import {getAttestationValidData} from "../../../utils/validationData/attestation";
+import {AttestationError, AttestationErrorCode, GossipAction} from "../../../../src/chain/errors";
 
 describe("validate gossip attestation", () => {
   const vc = 64;
@@ -26,3 +27,46 @@ describe("validate gossip attestation", () => {
     });
   }
 });
+
+describe.only("test throw AttestationError vs object", () => {
+  itBench({
+    id: "AttestationError",
+    fn: () => {
+      for (let i = 0; i < 1000; i++) {
+        try {
+          throwAttestationError(true);
+        } catch (e) {}
+      }
+    }
+  });
+
+  itBench({
+    id: "Object",
+    fn: () => {
+      for (let i = 0; i < 1000; i++) {
+        try {
+          throwErrorCode(true);
+        } catch (e) {}
+      }
+    }
+  });
+});
+
+function throwAttestationError(b: boolean): void {
+  if (b) {
+    throw new AttestationError(GossipAction.IGNORE, {
+      code: AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT,
+      root: Buffer.alloc(32),
+    });
+  }
+}
+
+function throwErrorCode(b: boolean): void {
+  if (b) {
+    throw {
+      action: GossipAction.IGNORE,
+      code: AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT,
+      root: Buffer.alloc(32),
+    };
+  }
+}


### PR DESCRIPTION
**Motivation**

This profile with `--subscribeAllSubnets` flag shows that creating AttestationError takes 4% of the cpu time
<img width="1490" alt="Screen Shot 2021-11-20 at 16 38 10" src="https://user-images.githubusercontent.com/10568965/142721821-ece08a31-5c82-4d2b-9d82-3881b8aa9167.png">

**Description**

Throwing a regular object could improve the speed 500%:
```
test throw AttestationError vs object
    ✓ AttestationError                                                    115.3952 ops/s    8.665875 ms/op        -        197 runs   2.21 s
    ✓ Object                                                              578.6963 ops/s    1.728022 ms/op        -        410 runs   1.21 s

```
+ found from #3416
+ this is another option to improve performance compared to #3402
