### PR TITLE
Use Uint8Array in db interface

### DIFF
--- a/packages/db/src/abstractRepository.ts
+++ b/packages/db/src/abstractRepository.ts
@@ -1,7 +1,8 @@
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {ArrayLike, Type} from "@chainsafe/ssz";
 import {BUCKET_LENGTH} from ".";
-import {IDatabaseController, IFilterOptions, IKeyValue} from "./controller";
+import {IFilterOptions, IKeyValue} from "./controller";
+import {Db} from "./controller/interface";
 import {DbMetricCounter, IDbMetrics} from "./metrics";
 import {Bucket, encodeKey as _encodeKey} from "./schema";
 import {getBucketNameByValue} from "./util";
@@ -19,7 +20,7 @@ export type Id = Uint8Array | string | number | bigint;
 export abstract class Repository<I extends Id, T> {
   protected config: IChainForkConfig;
 
-  protected db: IDatabaseController<Uint8Array, Uint8Array>;
+  protected db: Db;
 
   protected bucket: Bucket;
 
@@ -28,13 +29,7 @@ export abstract class Repository<I extends Id, T> {
   protected dbReadsMetrics?: ReturnType<DbMetricCounter["labels"]>;
   protected dbWriteMetrics?: ReturnType<DbMetricCounter["labels"]>;
 
-  protected constructor(
-    config: IChainForkConfig,
-    db: IDatabaseController<Uint8Array, Uint8Array>,
-    bucket: Bucket,
-    type: Type<T>,
-    metrics?: IDbMetrics
-  ) {
+  protected constructor(config: IChainForkConfig, db: Db, bucket: Bucket, type: Type<T>, metrics?: IDbMetrics) {
     this.config = config;
     this.db = db;
     this.bucket = bucket;

--- a/packages/db/src/abstractRepository.ts
+++ b/packages/db/src/abstractRepository.ts
@@ -19,7 +19,7 @@ export type Id = Uint8Array | string | number | bigint;
 export abstract class Repository<I extends Id, T> {
   protected config: IChainForkConfig;
 
-  protected db: IDatabaseController<Buffer, Buffer>;
+  protected db: IDatabaseController<Uint8Array, Uint8Array>;
 
   protected bucket: Bucket;
 
@@ -30,7 +30,7 @@ export abstract class Repository<I extends Id, T> {
 
   protected constructor(
     config: IChainForkConfig,
-    db: IDatabaseController<Buffer, Buffer>,
+    db: IDatabaseController<Uint8Array, Uint8Array>,
     bucket: Bucket,
     type: Type<T>,
     metrics?: IDbMetrics
@@ -43,11 +43,11 @@ export abstract class Repository<I extends Id, T> {
     this.dbWriteMetrics = metrics?.dbWrites.labels({bucket: getBucketNameByValue(bucket)});
   }
 
-  encodeValue(value: T): Buffer {
-    return this.type.serialize(value) as Buffer;
+  encodeValue(value: T): Uint8Array {
+    return this.type.serialize(value);
   }
 
-  decodeValue(data: Buffer): T {
+  decodeValue(data: Uint8Array): T {
     return this.type.deserialize(data);
   }
 
@@ -55,8 +55,8 @@ export abstract class Repository<I extends Id, T> {
     return _encodeKey(this.bucket, id);
   }
 
-  decodeKey(key: Buffer): I {
-    return (key.slice(BUCKET_LENGTH) as Uint8Array) as I;
+  decodeKey(key: Uint8Array): I {
+    return key.slice(BUCKET_LENGTH) as I;
   }
 
   async get(id: I): Promise<T | null> {
@@ -66,7 +66,7 @@ export abstract class Repository<I extends Id, T> {
     return this.decodeValue(value);
   }
 
-  async getBinary(id: I): Promise<Buffer | null> {
+  async getBinary(id: I): Promise<Uint8Array | null> {
     this.dbReadsMetrics?.inc();
     const value = await this.db.get(this.encodeKey(id));
     if (!value) return null;
@@ -116,7 +116,7 @@ export abstract class Repository<I extends Id, T> {
   }
 
   // Similar to batchPut but we support value as Buffer
-  async batchPutBinary(items: ArrayLike<IKeyValue<I, Buffer>>): Promise<void> {
+  async batchPutBinary(items: ArrayLike<IKeyValue<I, Uint8Array>>): Promise<void> {
     this.dbWriteMetrics?.inc();
     await this.db.batchPut(
       Array.from({length: items.length}, (_, i) => ({
@@ -174,7 +174,7 @@ export abstract class Repository<I extends Id, T> {
     }
   }
 
-  async *binaryEntriesStream(opts?: IFilterOptions<I>): AsyncIterable<IKeyValue<Buffer, Buffer>> {
+  async *binaryEntriesStream(opts?: IFilterOptions<I>): AsyncIterable<IKeyValue<Uint8Array, Uint8Array>> {
     this.dbReadsMetrics?.inc();
     yield* this.db.entriesStream(this.dbFilterOptions(opts));
   }
@@ -258,7 +258,7 @@ export abstract class Repository<I extends Id, T> {
   /**
    * Transforms opts from I to Buffer
    */
-  protected dbFilterOptions(opts?: IFilterOptions<I>): IFilterOptions<Buffer> {
+  protected dbFilterOptions(opts?: IFilterOptions<I>): IFilterOptions<Uint8Array> {
     const _opts: IFilterOptions<Buffer> = {
       gte: _encodeKey(this.bucket, Buffer.alloc(0)),
       lt: _encodeKey(this.bucket + 1, Buffer.alloc(0)),

--- a/packages/db/src/controller/index.ts
+++ b/packages/db/src/controller/index.ts
@@ -2,5 +2,5 @@
  * @module db/controller
  */
 
-export {IDatabaseController, IFilterOptions, IKeyValue} from "./interface";
+export {Db, IDatabaseController, IFilterOptions, IKeyValue} from "./interface";
 export {LevelDbController} from "./level";

--- a/packages/db/src/controller/interface.ts
+++ b/packages/db/src/controller/interface.ts
@@ -2,6 +2,9 @@
  * @module db/controller
  */
 
+/** Shortcut for Uint8Array based IDatabaseController */
+export type Db = IDatabaseController<Uint8Array, Uint8Array>;
+
 export interface IDatabaseOptions {
   name: string;
 }

--- a/packages/db/src/controller/level.ts
+++ b/packages/db/src/controller/level.ts
@@ -20,7 +20,7 @@ export interface ILevelDBOptions extends IDatabaseOptions {
 /**
  * The LevelDB implementation of DB
  */
-export class LevelDbController implements IDatabaseController<Buffer, Buffer> {
+export class LevelDbController implements IDatabaseController<Uint8Array, Uint8Array> {
   private status = Status.stopped;
   private db: LevelUp;
 

--- a/packages/db/src/databaseService.ts
+++ b/packages/db/src/databaseService.ts
@@ -1,16 +1,16 @@
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
-import {IDatabaseController} from "./controller";
+import {Db} from "./controller";
 import {IDbMetrics} from "./metrics";
 
 export interface IDatabaseApiOptions {
   config: IChainForkConfig;
-  controller: IDatabaseController<Uint8Array, Uint8Array>;
+  controller: Db;
   metrics?: IDbMetrics;
 }
 
 export abstract class DatabaseService {
   protected config: IChainForkConfig;
-  protected db: IDatabaseController<Uint8Array, Uint8Array>;
+  protected db: Db;
 
   protected constructor(opts: IDatabaseApiOptions) {
     this.config = opts.config;

--- a/packages/db/src/databaseService.ts
+++ b/packages/db/src/databaseService.ts
@@ -4,13 +4,13 @@ import {IDbMetrics} from "./metrics";
 
 export interface IDatabaseApiOptions {
   config: IChainForkConfig;
-  controller: IDatabaseController<Buffer, Buffer>;
+  controller: IDatabaseController<Uint8Array, Uint8Array>;
   metrics?: IDbMetrics;
 }
 
 export abstract class DatabaseService {
   protected config: IChainForkConfig;
-  protected db: IDatabaseController<Buffer, Buffer>;
+  protected db: IDatabaseController<Uint8Array, Uint8Array>;
 
   protected constructor(opts: IDatabaseApiOptions) {
     this.config = opts.config;

--- a/packages/lodestar/src/db/repositories/attesterSlashing.ts
+++ b/packages/lodestar/src/db/repositories/attesterSlashing.ts
@@ -1,6 +1,6 @@
 import {phase0, ssz, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
-import {IDatabaseController, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
+import {Db, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
 
 /**
  * AttesterSlashing indexed by root
@@ -9,7 +9,7 @@ import {IDatabaseController, Bucket, Repository, IDbMetrics} from "@chainsafe/lo
  * Removed when included on chain or old
  */
 export class AttesterSlashingRepository extends Repository<Uint8Array, phase0.AttesterSlashing> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     super(config, db, Bucket.phase0_attesterSlashing, ssz.phase0.AttesterSlashing, metrics);
   }
 

--- a/packages/lodestar/src/db/repositories/attesterSlashing.ts
+++ b/packages/lodestar/src/db/repositories/attesterSlashing.ts
@@ -9,7 +9,7 @@ import {IDatabaseController, Bucket, Repository, IDbMetrics} from "@chainsafe/lo
  * Removed when included on chain or old
  */
 export class AttesterSlashingRepository extends Repository<Uint8Array, phase0.AttesterSlashing> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     super(config, db, Bucket.phase0_attesterSlashing, ssz.phase0.AttesterSlashing, metrics);
   }
 

--- a/packages/lodestar/src/db/repositories/bestUpdatePerCommitteePeriod.ts
+++ b/packages/lodestar/src/db/repositories/bestUpdatePerCommitteePeriod.ts
@@ -4,14 +4,14 @@ import {bytesToInt} from "@chainsafe/lodestar-utils";
 import {IDatabaseController, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
 
 export class BestUpdatePerCommitteePeriod extends Repository<SyncPeriod, altair.LightClientUpdate> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     const type = ssz.altair.LightClientUpdate;
     super(config, db, Bucket.altair_bestUpdatePerCommitteePeriod, type, metrics);
   }
 
   // Handle key as SyncPeriod
 
-  decodeKey(data: Buffer): number {
+  decodeKey(data: Uint8Array): number {
     return bytesToInt((super.decodeKey(data) as unknown) as Uint8Array, "be");
   }
 }

--- a/packages/lodestar/src/db/repositories/bestUpdatePerCommitteePeriod.ts
+++ b/packages/lodestar/src/db/repositories/bestUpdatePerCommitteePeriod.ts
@@ -1,10 +1,10 @@
 import {altair, ssz, SyncPeriod} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {bytesToInt} from "@chainsafe/lodestar-utils";
-import {IDatabaseController, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
+import {Db, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
 
 export class BestUpdatePerCommitteePeriod extends Repository<SyncPeriod, altair.LightClientUpdate> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     const type = ssz.altair.LightClientUpdate;
     super(config, db, Bucket.altair_bestUpdatePerCommitteePeriod, type, metrics);
   }

--- a/packages/lodestar/src/db/repositories/block.ts
+++ b/packages/lodestar/src/db/repositories/block.ts
@@ -1,5 +1,5 @@
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
-import {Bucket, IDatabaseController, IDbMetrics, Repository} from "@chainsafe/lodestar-db";
+import {Bucket, Db, IDbMetrics, Repository} from "@chainsafe/lodestar-db";
 import {allForks, ssz} from "@chainsafe/lodestar-types";
 import {getSignedBlockTypeFromBytes} from "../../util/multifork";
 
@@ -9,7 +9,7 @@ import {getSignedBlockTypeFromBytes} from "../../util/multifork";
  * Used to store unfinalized blocks
  */
 export class BlockRepository extends Repository<Uint8Array, allForks.SignedBeaconBlock> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     const type = ssz.phase0.SignedBeaconBlock; // Pick some type but won't be used
     super(config, db, Bucket.allForks_block, type, metrics);
   }

--- a/packages/lodestar/src/db/repositories/block.ts
+++ b/packages/lodestar/src/db/repositories/block.ts
@@ -9,7 +9,7 @@ import {getSignedBlockTypeFromBytes} from "../../util/multifork";
  * Used to store unfinalized blocks
  */
 export class BlockRepository extends Repository<Uint8Array, allForks.SignedBeaconBlock> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     const type = ssz.phase0.SignedBeaconBlock; // Pick some type but won't be used
     super(config, db, Bucket.allForks_block, type, metrics);
   }

--- a/packages/lodestar/src/db/repositories/blockArchive.ts
+++ b/packages/lodestar/src/db/repositories/blockArchive.ts
@@ -1,7 +1,7 @@
 import all from "it-all";
 import {ArrayLike} from "@chainsafe/ssz";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
-import {IDatabaseController, Repository, IKeyValue, IFilterOptions, Bucket, IDbMetrics} from "@chainsafe/lodestar-db";
+import {Db, Repository, IKeyValue, IFilterOptions, Bucket, IDbMetrics} from "@chainsafe/lodestar-db";
 import {Slot, Root, allForks, ssz} from "@chainsafe/lodestar-types";
 import {bytesToInt} from "@chainsafe/lodestar-utils";
 import {getSignedBlockTypeFromBytes} from "../../util/multifork";
@@ -22,7 +22,7 @@ export type BlockArchiveBatchPutBinaryItem = IKeyValue<Slot, Uint8Array> & {
  * Stores finalized blocks. Block slot is identifier.
  */
 export class BlockArchiveRepository extends Repository<Slot, allForks.SignedBeaconBlock> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     const type = ssz.phase0.SignedBeaconBlock; // Pick some type but won't be used
     super(config, db, Bucket.allForks_blockArchive, type, metrics);
   }

--- a/packages/lodestar/src/db/repositories/blockArchive.ts
+++ b/packages/lodestar/src/db/repositories/blockArchive.ts
@@ -11,7 +11,8 @@ import {deleteParentRootIndex, deleteRootIndex, storeParentRootIndex, storeRootI
 export interface IBlockFilterOptions extends IFilterOptions<Slot> {
   step?: number;
 }
-export type BlockArchiveBatchPutBinaryItem = IKeyValue<Slot, Buffer> & {
+
+export type BlockArchiveBatchPutBinaryItem = IKeyValue<Slot, Uint8Array> & {
   slot: Slot;
   blockRoot: Root;
   parentRoot: Root;
@@ -21,18 +22,18 @@ export type BlockArchiveBatchPutBinaryItem = IKeyValue<Slot, Buffer> & {
  * Stores finalized blocks. Block slot is identifier.
  */
 export class BlockArchiveRepository extends Repository<Slot, allForks.SignedBeaconBlock> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     const type = ssz.phase0.SignedBeaconBlock; // Pick some type but won't be used
     super(config, db, Bucket.allForks_blockArchive, type, metrics);
   }
 
   // Overrides for multi-fork
 
-  encodeValue(value: allForks.SignedBeaconBlock): Buffer {
-    return this.config.getForkTypes(value.message.slot).SignedBeaconBlock.serialize(value) as Buffer;
+  encodeValue(value: allForks.SignedBeaconBlock): Uint8Array {
+    return this.config.getForkTypes(value.message.slot).SignedBeaconBlock.serialize(value) as Uint8Array;
   }
 
-  decodeValue(data: Buffer): allForks.SignedBeaconBlock {
+  decodeValue(data: Uint8Array): allForks.SignedBeaconBlock {
     return getSignedBlockTypeFromBytes(this.config, data).deserialize(data);
   }
 
@@ -42,7 +43,7 @@ export class BlockArchiveRepository extends Repository<Slot, allForks.SignedBeac
     return value.message.slot;
   }
 
-  decodeKey(data: Buffer): number {
+  decodeKey(data: Uint8Array): number {
     return bytesToInt((super.decodeKey(data) as unknown) as Uint8Array, "be");
   }
 
@@ -141,7 +142,7 @@ export class BlockArchiveRepository extends Repository<Slot, allForks.SignedBeac
     return this.parseSlot(await this.db.get(getParentRootIndexKey(root)));
   }
 
-  private parseSlot(slotBytes: Buffer | null): Slot | null {
+  private parseSlot(slotBytes: Uint8Array | null): Slot | null {
     if (!slotBytes) return null;
     const slot = bytesToInt(slotBytes, "be");
     // TODO: Is this necessary? How can bytesToInt return a non-integer?

--- a/packages/lodestar/src/db/repositories/blockArchiveIndex.ts
+++ b/packages/lodestar/src/db/repositories/blockArchiveIndex.ts
@@ -4,7 +4,7 @@ import {intToBytes} from "@chainsafe/lodestar-utils";
 import {ContainerType} from "@chainsafe/ssz";
 
 export async function storeRootIndex(
-  db: IDatabaseController<Buffer, Buffer>,
+  db: IDatabaseController<Uint8Array, Uint8Array>,
   slot: Slot,
   blockRoot: Root
 ): Promise<void> {
@@ -12,7 +12,7 @@ export async function storeRootIndex(
 }
 
 export async function storeParentRootIndex(
-  db: IDatabaseController<Buffer, Buffer>,
+  db: IDatabaseController<Uint8Array, Uint8Array>,
   slot: Slot,
   parentRoot: Root
 ): Promise<void> {
@@ -20,7 +20,7 @@ export async function storeParentRootIndex(
 }
 
 export async function deleteRootIndex(
-  db: IDatabaseController<Buffer, Buffer>,
+  db: IDatabaseController<Uint8Array, Uint8Array>,
   blockType: ContainerType<allForks.SignedBeaconBlock>,
   block: allForks.SignedBeaconBlock
 ): Promise<void> {
@@ -28,7 +28,7 @@ export async function deleteRootIndex(
 }
 
 export async function deleteParentRootIndex(
-  db: IDatabaseController<Buffer, Buffer>,
+  db: IDatabaseController<Uint8Array, Uint8Array>,
   block: allForks.SignedBeaconBlock
 ): Promise<void> {
   return db.delete(getParentRootIndexKey(block.message.parentRoot));

--- a/packages/lodestar/src/db/repositories/blockArchiveIndex.ts
+++ b/packages/lodestar/src/db/repositories/blockArchiveIndex.ts
@@ -1,36 +1,25 @@
-import {IDatabaseController, encodeKey, Bucket} from "@chainsafe/lodestar-db";
+import {Db, encodeKey, Bucket} from "@chainsafe/lodestar-db";
 import {Slot, Root, allForks} from "@chainsafe/lodestar-types";
 import {intToBytes} from "@chainsafe/lodestar-utils";
 import {ContainerType} from "@chainsafe/ssz";
 
-export async function storeRootIndex(
-  db: IDatabaseController<Uint8Array, Uint8Array>,
-  slot: Slot,
-  blockRoot: Root
-): Promise<void> {
+export async function storeRootIndex(db: Db, slot: Slot, blockRoot: Root): Promise<void> {
   return db.put(getRootIndexKey(blockRoot), intToBytes(slot, 8, "be"));
 }
 
-export async function storeParentRootIndex(
-  db: IDatabaseController<Uint8Array, Uint8Array>,
-  slot: Slot,
-  parentRoot: Root
-): Promise<void> {
+export async function storeParentRootIndex(db: Db, slot: Slot, parentRoot: Root): Promise<void> {
   return db.put(getParentRootIndexKey(parentRoot), intToBytes(slot, 8, "be"));
 }
 
 export async function deleteRootIndex(
-  db: IDatabaseController<Uint8Array, Uint8Array>,
+  db: Db,
   blockType: ContainerType<allForks.SignedBeaconBlock>,
   block: allForks.SignedBeaconBlock
 ): Promise<void> {
   return db.delete(getRootIndexKey(blockType.fields["message"].hashTreeRoot(block.message)));
 }
 
-export async function deleteParentRootIndex(
-  db: IDatabaseController<Uint8Array, Uint8Array>,
-  block: allForks.SignedBeaconBlock
-): Promise<void> {
+export async function deleteParentRootIndex(db: Db, block: allForks.SignedBeaconBlock): Promise<void> {
   return db.delete(getParentRootIndexKey(block.message.parentRoot));
 }
 

--- a/packages/lodestar/src/db/repositories/depositDataRoot.ts
+++ b/packages/lodestar/src/db/repositories/depositDataRoot.ts
@@ -2,12 +2,12 @@ import {List, readonlyValues, TreeBacked, Vector} from "@chainsafe/ssz";
 import {Root, ssz} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {bytesToInt} from "@chainsafe/lodestar-utils";
-import {IDatabaseController, Bucket, Repository, IKeyValue, IDbMetrics} from "@chainsafe/lodestar-db";
+import {Db, Bucket, Repository, IKeyValue, IDbMetrics} from "@chainsafe/lodestar-db";
 
 export class DepositDataRootRepository extends Repository<number, Root> {
   private depositRootTree?: TreeBacked<List<Root>>;
 
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     super(config, db, Bucket.index_depositDataRoot, ssz.Root, metrics);
   }
 

--- a/packages/lodestar/src/db/repositories/depositDataRoot.ts
+++ b/packages/lodestar/src/db/repositories/depositDataRoot.ts
@@ -7,7 +7,7 @@ import {IDatabaseController, Bucket, Repository, IKeyValue, IDbMetrics} from "@c
 export class DepositDataRootRepository extends Repository<number, Root> {
   private depositRootTree?: TreeBacked<List<Root>>;
 
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     super(config, db, Bucket.index_depositDataRoot, ssz.Root, metrics);
   }
 

--- a/packages/lodestar/src/db/repositories/depositEvent.ts
+++ b/packages/lodestar/src/db/repositories/depositEvent.ts
@@ -1,13 +1,13 @@
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {phase0, ssz} from "@chainsafe/lodestar-types";
-import {IDatabaseController, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
+import {Db, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
 
 /**
  * DepositData indexed by deposit index
  * Removed when included on chain or old
  */
 export class DepositEventRepository extends Repository<number, phase0.DepositEvent> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     super(config, db, Bucket.phase0_depositEvent, ssz.phase0.DepositEvent, metrics);
   }
 

--- a/packages/lodestar/src/db/repositories/depositEvent.ts
+++ b/packages/lodestar/src/db/repositories/depositEvent.ts
@@ -7,7 +7,7 @@ import {IDatabaseController, Bucket, Repository, IDbMetrics} from "@chainsafe/lo
  * Removed when included on chain or old
  */
 export class DepositEventRepository extends Repository<number, phase0.DepositEvent> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     super(config, db, Bucket.phase0_depositEvent, ssz.phase0.DepositEvent, metrics);
   }
 

--- a/packages/lodestar/src/db/repositories/eth1Data.ts
+++ b/packages/lodestar/src/db/repositories/eth1Data.ts
@@ -4,7 +4,7 @@ import {bytesToInt} from "@chainsafe/lodestar-utils";
 import {IDatabaseController, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
 
 export class Eth1DataRepository extends Repository<number, phase0.Eth1DataOrdered> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     super(config, db, Bucket.phase0_eth1Data, ssz.phase0.Eth1DataOrdered, metrics);
   }
 

--- a/packages/lodestar/src/db/repositories/eth1Data.ts
+++ b/packages/lodestar/src/db/repositories/eth1Data.ts
@@ -1,10 +1,10 @@
 import {phase0, ssz} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {bytesToInt} from "@chainsafe/lodestar-utils";
-import {IDatabaseController, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
+import {Db, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
 
 export class Eth1DataRepository extends Repository<number, phase0.Eth1DataOrdered> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     super(config, db, Bucket.phase0_eth1Data, ssz.phase0.Eth1DataOrdered, metrics);
   }
 

--- a/packages/lodestar/src/db/repositories/lightClientInitProof.ts
+++ b/packages/lodestar/src/db/repositories/lightClientInitProof.ts
@@ -4,11 +4,11 @@ import {Bucket, IDatabaseController, IDbMetrics, Repository} from "@chainsafe/lo
 import {Type} from "@chainsafe/ssz";
 
 export class LightClientInitProofRepository extends Repository<Uint8Array, Proof> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     super(config, db, Bucket.altair_lightClientInitProof, (undefined as unknown) as Type<Proof>, metrics);
   }
 
-  encodeValue(value: Proof): Buffer {
+  encodeValue(value: Proof): Uint8Array {
     return Buffer.from(serializeProof(value));
   }
 
@@ -23,11 +23,11 @@ export class LightClientInitProofRepository extends Repository<Uint8Array, Proof
 }
 
 export class LightClientInitProofIndexRepository extends Repository<Uint8Array, boolean> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     super(config, db, Bucket.index_lightClientInitProof, (undefined as unknown) as Type<boolean>, metrics);
   }
 
-  encodeValue(_value: boolean): Buffer {
+  encodeValue(_value: boolean): Uint8Array {
     return Buffer.from([1]);
   }
 
@@ -42,11 +42,11 @@ export class LightClientInitProofIndexRepository extends Repository<Uint8Array, 
 }
 
 export class LightClientSyncCommitteeProofRepository extends Repository<number, Proof> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     super(config, db, Bucket.altair_lightClientSyncCommitteeProof, (undefined as unknown) as Type<Proof>, metrics);
   }
 
-  encodeValue(value: Proof): Buffer {
+  encodeValue(value: Proof): Uint8Array {
     return Buffer.from(serializeProof(value));
   }
 

--- a/packages/lodestar/src/db/repositories/lightClientInitProof.ts
+++ b/packages/lodestar/src/db/repositories/lightClientInitProof.ts
@@ -1,10 +1,10 @@
 import {deserializeProof, Proof, serializeProof} from "@chainsafe/persistent-merkle-tree";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
-import {Bucket, IDatabaseController, IDbMetrics, Repository} from "@chainsafe/lodestar-db";
+import {Bucket, Db, IDbMetrics, Repository} from "@chainsafe/lodestar-db";
 import {Type} from "@chainsafe/ssz";
 
 export class LightClientInitProofRepository extends Repository<Uint8Array, Proof> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     super(config, db, Bucket.altair_lightClientInitProof, (undefined as unknown) as Type<Proof>, metrics);
   }
 
@@ -23,7 +23,7 @@ export class LightClientInitProofRepository extends Repository<Uint8Array, Proof
 }
 
 export class LightClientInitProofIndexRepository extends Repository<Uint8Array, boolean> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     super(config, db, Bucket.index_lightClientInitProof, (undefined as unknown) as Type<boolean>, metrics);
   }
 
@@ -42,7 +42,7 @@ export class LightClientInitProofIndexRepository extends Repository<Uint8Array, 
 }
 
 export class LightClientSyncCommitteeProofRepository extends Repository<number, Proof> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     super(config, db, Bucket.altair_lightClientSyncCommitteeProof, (undefined as unknown) as Type<Proof>, metrics);
   }
 

--- a/packages/lodestar/src/db/repositories/lightclientFinalizedCheckpoint.ts
+++ b/packages/lodestar/src/db/repositories/lightclientFinalizedCheckpoint.ts
@@ -6,7 +6,7 @@ import {FinalizedCheckpointData} from "@chainsafe/lodestar-light-client/server";
 import {ContainerType} from "@chainsafe/ssz";
 
 export class LightclientFinalizedCheckpoint extends Repository<SyncPeriod, FinalizedCheckpointData> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     // Pick<LightClientUpdate, "header" | "nextSyncCommittee" | "nextSyncCommitteeBranch">
     const type = new ContainerType<FinalizedCheckpointData>({
       fields: {
@@ -22,7 +22,7 @@ export class LightclientFinalizedCheckpoint extends Repository<SyncPeriod, Final
 
   // Handle key as SyncPeriod
 
-  decodeKey(data: Buffer): number {
+  decodeKey(data: Uint8Array): number {
     return bytesToInt((super.decodeKey(data) as unknown) as Uint8Array, "be");
   }
 }

--- a/packages/lodestar/src/db/repositories/lightclientFinalizedCheckpoint.ts
+++ b/packages/lodestar/src/db/repositories/lightclientFinalizedCheckpoint.ts
@@ -1,12 +1,12 @@
 import {ssz, SyncPeriod} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {bytesToInt} from "@chainsafe/lodestar-utils";
-import {IDatabaseController, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
+import {Db, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
 import {FinalizedCheckpointData} from "@chainsafe/lodestar-light-client/server";
 import {ContainerType} from "@chainsafe/ssz";
 
 export class LightclientFinalizedCheckpoint extends Repository<SyncPeriod, FinalizedCheckpointData> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     // Pick<LightClientUpdate, "header" | "nextSyncCommittee" | "nextSyncCommitteeBranch">
     const type = new ContainerType<FinalizedCheckpointData>({
       fields: {

--- a/packages/lodestar/src/db/repositories/proposerSlashing.ts
+++ b/packages/lodestar/src/db/repositories/proposerSlashing.ts
@@ -1,9 +1,9 @@
 import {phase0, ssz, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
-import {IDatabaseController, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
+import {Db, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
 
 export class ProposerSlashingRepository extends Repository<ValidatorIndex, phase0.ProposerSlashing> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     super(config, db, Bucket.phase0_proposerSlashing, ssz.phase0.ProposerSlashing, metrics);
   }
 

--- a/packages/lodestar/src/db/repositories/proposerSlashing.ts
+++ b/packages/lodestar/src/db/repositories/proposerSlashing.ts
@@ -3,7 +3,7 @@ import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {IDatabaseController, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
 
 export class ProposerSlashingRepository extends Repository<ValidatorIndex, phase0.ProposerSlashing> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     super(config, db, Bucket.phase0_proposerSlashing, ssz.phase0.ProposerSlashing, metrics);
   }
 

--- a/packages/lodestar/src/db/repositories/stateArchive.ts
+++ b/packages/lodestar/src/db/repositories/stateArchive.ts
@@ -9,7 +9,7 @@ import {getRootIndexKey, storeRootIndex} from "./stateArchiveIndex";
 /* eslint-disable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
 
 export class StateArchiveRepository extends Repository<Slot, TreeBacked<allForks.BeaconState>> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     // Pick some type but won't be used
     const type = (ssz.phase0.BeaconState as unknown) as ContainerType<TreeBacked<allForks.BeaconState>>;
     super(config, db, Bucket.allForks_stateArchive, type, metrics);

--- a/packages/lodestar/src/db/repositories/stateArchive.ts
+++ b/packages/lodestar/src/db/repositories/stateArchive.ts
@@ -2,14 +2,14 @@ import {ContainerType, TreeBacked} from "@chainsafe/ssz";
 import {Epoch, Root, Slot, allForks, ssz} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {bytesToInt} from "@chainsafe/lodestar-utils";
-import {IDatabaseController, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
+import {Db, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
 import {getStateTypeFromBytes} from "../../util/multifork";
 import {getRootIndexKey, storeRootIndex} from "./stateArchiveIndex";
 
 /* eslint-disable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
 
 export class StateArchiveRepository extends Repository<Slot, TreeBacked<allForks.BeaconState>> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     // Pick some type but won't be used
     const type = (ssz.phase0.BeaconState as unknown) as ContainerType<TreeBacked<allForks.BeaconState>>;
     super(config, db, Bucket.allForks_stateArchive, type, metrics);

--- a/packages/lodestar/src/db/repositories/stateArchiveIndex.ts
+++ b/packages/lodestar/src/db/repositories/stateArchiveIndex.ts
@@ -1,12 +1,8 @@
-import {Bucket, encodeKey, IDatabaseController} from "@chainsafe/lodestar-db";
+import {Bucket, encodeKey, Db} from "@chainsafe/lodestar-db";
 import {Root, Slot} from "@chainsafe/lodestar-types";
 import {intToBytes} from "@chainsafe/lodestar-utils";
 
-export function storeRootIndex(
-  db: IDatabaseController<Uint8Array, Uint8Array>,
-  slot: Slot,
-  stateRoot: Root
-): Promise<void> {
+export function storeRootIndex(db: Db, slot: Slot, stateRoot: Root): Promise<void> {
   return db.put(getRootIndexKey(stateRoot), intToBytes(slot, 8, "be"));
 }
 

--- a/packages/lodestar/src/db/repositories/stateArchiveIndex.ts
+++ b/packages/lodestar/src/db/repositories/stateArchiveIndex.ts
@@ -2,7 +2,11 @@ import {Bucket, encodeKey, IDatabaseController} from "@chainsafe/lodestar-db";
 import {Root, Slot} from "@chainsafe/lodestar-types";
 import {intToBytes} from "@chainsafe/lodestar-utils";
 
-export function storeRootIndex(db: IDatabaseController<Buffer, Buffer>, slot: Slot, stateRoot: Root): Promise<void> {
+export function storeRootIndex(
+  db: IDatabaseController<Uint8Array, Uint8Array>,
+  slot: Slot,
+  stateRoot: Root
+): Promise<void> {
   return db.put(getRootIndexKey(stateRoot), intToBytes(slot, 8, "be"));
 }
 

--- a/packages/lodestar/src/db/repositories/voluntaryExit.ts
+++ b/packages/lodestar/src/db/repositories/voluntaryExit.ts
@@ -1,9 +1,9 @@
 import {phase0, ssz, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
-import {IDatabaseController, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
+import {Db, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
 
 export class VoluntaryExitRepository extends Repository<ValidatorIndex, phase0.SignedVoluntaryExit> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     super(config, db, Bucket.phase0_exit, ssz.phase0.SignedVoluntaryExit, metrics);
   }
 

--- a/packages/lodestar/src/db/repositories/voluntaryExit.ts
+++ b/packages/lodestar/src/db/repositories/voluntaryExit.ts
@@ -3,7 +3,7 @@ import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {IDatabaseController, Bucket, Repository, IDbMetrics} from "@chainsafe/lodestar-db";
 
 export class VoluntaryExitRepository extends Repository<ValidatorIndex, phase0.SignedVoluntaryExit> {
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     super(config, db, Bucket.phase0_exit, ssz.phase0.SignedVoluntaryExit, metrics);
   }
 

--- a/packages/lodestar/src/db/single/latestFinalizedUpdate.ts
+++ b/packages/lodestar/src/db/single/latestFinalizedUpdate.ts
@@ -1,16 +1,16 @@
 import {Type} from "@chainsafe/ssz";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {altair, ssz} from "@chainsafe/lodestar-types";
-import {IDatabaseController, Bucket, IDbMetrics} from "@chainsafe/lodestar-db";
+import {Db, Bucket, IDbMetrics} from "@chainsafe/lodestar-db";
 
 export class LatestFinalizedUpdate {
   private readonly bucket = Bucket.altair_latestFinalizedUpdate;
   private readonly key = Buffer.from(new Uint8Array([this.bucket]));
   private readonly type: Type<altair.LightClientUpdate>;
-  private readonly db: IDatabaseController<Uint8Array, Uint8Array>;
+  private readonly db: Db;
   private readonly metrics?: IDbMetrics;
 
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     this.db = db;
     this.type = ssz.altair.LightClientUpdate;
     this.metrics = metrics;

--- a/packages/lodestar/src/db/single/latestFinalizedUpdate.ts
+++ b/packages/lodestar/src/db/single/latestFinalizedUpdate.ts
@@ -7,10 +7,10 @@ export class LatestFinalizedUpdate {
   private readonly bucket = Bucket.altair_latestFinalizedUpdate;
   private readonly key = Buffer.from(new Uint8Array([this.bucket]));
   private readonly type: Type<altair.LightClientUpdate>;
-  private readonly db: IDatabaseController<Buffer, Buffer>;
+  private readonly db: IDatabaseController<Uint8Array, Uint8Array>;
   private readonly metrics?: IDbMetrics;
 
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     this.db = db;
     this.type = ssz.altair.LightClientUpdate;
     this.metrics = metrics;
@@ -18,7 +18,7 @@ export class LatestFinalizedUpdate {
 
   async put(value: altair.LightClientUpdate): Promise<void> {
     this.metrics?.dbWrites.labels({bucket: "altair_latestFinalizedUpdate"}).inc();
-    await this.db.put(this.key, this.type.serialize(value) as Buffer);
+    await this.db.put(this.key, this.type.serialize(value) as Uint8Array);
   }
 
   async get(): Promise<altair.LightClientUpdate | null> {

--- a/packages/lodestar/src/db/single/latestNonFinalizedUpdate.ts
+++ b/packages/lodestar/src/db/single/latestNonFinalizedUpdate.ts
@@ -7,10 +7,10 @@ export class LatestNonFinalizedUpdate {
   private readonly bucket = Bucket.altair_latestNonFinalizedUpdate;
   private readonly key = Buffer.from(new Uint8Array([this.bucket]));
   private readonly type: Type<altair.LightClientUpdate>;
-  private readonly db: IDatabaseController<Buffer, Buffer>;
+  private readonly db: IDatabaseController<Uint8Array, Uint8Array>;
   private readonly metrics?: IDbMetrics;
 
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     this.db = db;
     this.type = ssz.altair.LightClientUpdate;
     this.metrics = metrics;
@@ -18,7 +18,7 @@ export class LatestNonFinalizedUpdate {
 
   async put(value: altair.LightClientUpdate): Promise<void> {
     this.metrics?.dbWrites.labels({bucket: "altair_latestNonFinalizedUpdate"}).inc();
-    await this.db.put(this.key, this.type.serialize(value) as Buffer);
+    await this.db.put(this.key, this.type.serialize(value));
   }
 
   async get(): Promise<altair.LightClientUpdate | null> {

--- a/packages/lodestar/src/db/single/latestNonFinalizedUpdate.ts
+++ b/packages/lodestar/src/db/single/latestNonFinalizedUpdate.ts
@@ -1,16 +1,16 @@
 import {Type} from "@chainsafe/ssz";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {altair, ssz} from "@chainsafe/lodestar-types";
-import {IDatabaseController, Bucket, IDbMetrics} from "@chainsafe/lodestar-db";
+import {Db, Bucket, IDbMetrics} from "@chainsafe/lodestar-db";
 
 export class LatestNonFinalizedUpdate {
   private readonly bucket = Bucket.altair_latestNonFinalizedUpdate;
   private readonly key = Buffer.from(new Uint8Array([this.bucket]));
   private readonly type: Type<altair.LightClientUpdate>;
-  private readonly db: IDatabaseController<Uint8Array, Uint8Array>;
+  private readonly db: Db;
   private readonly metrics?: IDbMetrics;
 
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     this.db = db;
     this.type = ssz.altair.LightClientUpdate;
     this.metrics = metrics;

--- a/packages/lodestar/src/db/single/preGenesisState.ts
+++ b/packages/lodestar/src/db/single/preGenesisState.ts
@@ -7,11 +7,11 @@ import {IDatabaseController, Bucket, IDbMetrics} from "@chainsafe/lodestar-db";
 export class PreGenesisState {
   private readonly config: IChainForkConfig;
   private readonly bucket: Bucket;
-  private readonly db: IDatabaseController<Buffer, Buffer>;
+  private readonly db: IDatabaseController<Uint8Array, Uint8Array>;
   private readonly key: Buffer;
   private readonly metrics?: IDbMetrics;
 
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     this.config = config;
     this.db = db;
     this.bucket = Bucket.phase0_preGenesisState;

--- a/packages/lodestar/src/db/single/preGenesisState.ts
+++ b/packages/lodestar/src/db/single/preGenesisState.ts
@@ -2,16 +2,16 @@ import {TreeBacked, ContainerType} from "@chainsafe/ssz";
 import {GENESIS_SLOT} from "@chainsafe/lodestar-params";
 import {allForks} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
-import {IDatabaseController, Bucket, IDbMetrics} from "@chainsafe/lodestar-db";
+import {Db, Bucket, IDbMetrics} from "@chainsafe/lodestar-db";
 
 export class PreGenesisState {
   private readonly config: IChainForkConfig;
   private readonly bucket: Bucket;
-  private readonly db: IDatabaseController<Uint8Array, Uint8Array>;
+  private readonly db: Db;
   private readonly key: Buffer;
   private readonly metrics?: IDbMetrics;
 
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     this.config = config;
     this.db = db;
     this.bucket = Bucket.phase0_preGenesisState;

--- a/packages/lodestar/src/db/single/preGenesisStateLastProcessedBlock.ts
+++ b/packages/lodestar/src/db/single/preGenesisStateLastProcessedBlock.ts
@@ -1,16 +1,16 @@
 import {NumberUintType} from "@chainsafe/ssz";
 import {ssz} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
-import {IDatabaseController, Bucket, IDbMetrics} from "@chainsafe/lodestar-db";
+import {Db, Bucket, IDbMetrics} from "@chainsafe/lodestar-db";
 
 export class PreGenesisStateLastProcessedBlock {
   private readonly bucket: Bucket;
   private readonly type: NumberUintType;
-  private readonly db: IDatabaseController<Uint8Array, Uint8Array>;
+  private readonly db: Db;
   private readonly key: Buffer;
   private readonly metrics?: IDbMetrics;
 
-  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: Db, metrics?: IDbMetrics) {
     this.db = db;
     this.type = ssz.Number64;
     this.bucket = Bucket.phase0_preGenesisStateLastProcessedBlock;

--- a/packages/lodestar/src/db/single/preGenesisStateLastProcessedBlock.ts
+++ b/packages/lodestar/src/db/single/preGenesisStateLastProcessedBlock.ts
@@ -6,11 +6,11 @@ import {IDatabaseController, Bucket, IDbMetrics} from "@chainsafe/lodestar-db";
 export class PreGenesisStateLastProcessedBlock {
   private readonly bucket: Bucket;
   private readonly type: NumberUintType;
-  private readonly db: IDatabaseController<Buffer, Buffer>;
+  private readonly db: IDatabaseController<Uint8Array, Uint8Array>;
   private readonly key: Buffer;
   private readonly metrics?: IDbMetrics;
 
-  constructor(config: IChainForkConfig, db: IDatabaseController<Buffer, Buffer>, metrics?: IDbMetrics) {
+  constructor(config: IChainForkConfig, db: IDatabaseController<Uint8Array, Uint8Array>, metrics?: IDbMetrics) {
     this.db = db;
     this.type = ssz.Number64;
     this.bucket = Bucket.phase0_preGenesisStateLastProcessedBlock;

--- a/packages/lodestar/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/lodestar/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -110,7 +110,7 @@ async function getUnfinalizedBlocksAtSlots(
 
   const slotsSet = new Set(slots);
   const minSlot = Math.min(...slots); // Slots must have length > 0
-  const blockRootsPerSlot = new Map<Slot, Promise<Buffer | null>>();
+  const blockRootsPerSlot = new Map<Slot, Promise<Uint8Array | null>>();
 
   // these blocks are on the same chain to head
   for (const block of chain.forkChoice.iterateAncestorBlocks(chain.forkChoice.getHeadRoot())) {

--- a/packages/lodestar/src/network/reqresp/handlers/beaconBlocksByRoot.ts
+++ b/packages/lodestar/src/network/reqresp/handlers/beaconBlocksByRoot.ts
@@ -12,7 +12,7 @@ export async function* onBeaconBlocksByRoot(
   for (const blockRoot of requestBody) {
     const root = blockRoot.valueOf() as Uint8Array;
     const summary = chain.forkChoice.getBlock(root);
-    let blockBytes: Buffer | null = null;
+    let blockBytes: Uint8Array | null = null;
 
     // finalized block has summary in forkchoice but it stays in blockArchive db
     if (summary) {

--- a/packages/lodestar/src/network/reqresp/types.ts
+++ b/packages/lodestar/src/network/reqresp/types.ts
@@ -214,6 +214,6 @@ export const reqRespBlockResponseSerializer = {
 /** This type helps response to beacon_block_by_range and beacon_block_by_root more efficiently */
 export type ReqRespBlockResponse = {
   /** Deserialized data of allForks.SignedBeaconBlock */
-  bytes: Buffer;
+  bytes: Uint8Array;
   slot: Slot;
 };

--- a/packages/lodestar/test/unit/db/api/repository.test.ts
+++ b/packages/lodestar/test/unit/db/api/repository.test.ts
@@ -6,7 +6,7 @@ import all from "it-all";
 import {ContainerType} from "@chainsafe/ssz";
 import {Bytes32, ssz} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/default";
-import {IDatabaseController, LevelDbController, Repository, Bucket} from "@chainsafe/lodestar-db";
+import {Db, LevelDbController, Repository, Bucket} from "@chainsafe/lodestar-db";
 
 chai.use(chaiAsPromised);
 
@@ -25,7 +25,7 @@ const TestSSZType = new ContainerType<TestType>({
 });
 
 class TestRepository extends Repository<string, TestType> {
-  constructor(db: IDatabaseController<Uint8Array, Uint8Array>) {
+  constructor(db: Db) {
     super(config, db, Bucket.phase0_depositEvent, TestSSZType);
   }
 }

--- a/packages/lodestar/test/unit/db/api/repository.test.ts
+++ b/packages/lodestar/test/unit/db/api/repository.test.ts
@@ -25,7 +25,7 @@ const TestSSZType = new ContainerType<TestType>({
 });
 
 class TestRepository extends Repository<string, TestType> {
-  constructor(db: IDatabaseController<Buffer, Buffer>) {
+  constructor(db: IDatabaseController<Uint8Array, Uint8Array>) {
     super(config, db, Bucket.phase0_depositEvent, TestSSZType);
   }
 }

--- a/packages/validator/src/slashingProtection/attestation/attestationByTargetRepository.ts
+++ b/packages/validator/src/slashingProtection/attestation/attestationByTargetRepository.ts
@@ -68,7 +68,7 @@ export class AttestationByTargetRepository {
     );
   }
 
-  private decodeKey(key: Buffer): {pubkey: BLSPubkey; targetEpoch: Epoch} {
+  private decodeKey(key: Uint8Array): {pubkey: BLSPubkey; targetEpoch: Epoch} {
     return {
       pubkey: key.slice(DB_PREFIX_LENGTH, DB_PREFIX_LENGTH + blsPubkeyLen),
       targetEpoch: bytesToInt(

--- a/packages/validator/src/slashingProtection/block/blockBySlotRepository.ts
+++ b/packages/validator/src/slashingProtection/block/blockBySlotRepository.ts
@@ -71,7 +71,7 @@ export class BlockBySlotRepository {
     );
   }
 
-  private decodeKey(key: Buffer): {pubkey: BLSPubkey; slot: Slot} {
+  private decodeKey(key: Uint8Array): {pubkey: BLSPubkey; slot: Slot} {
     return {
       pubkey: key.slice(DB_PREFIX_LENGTH, DB_PREFIX_LENGTH + blsPubkeyLen),
       slot: bytesToInt(key.slice(DB_PREFIX_LENGTH, DB_PREFIX_LENGTH + uintLen), "be"),

--- a/packages/validator/src/types.ts
+++ b/packages/validator/src/types.ts
@@ -16,6 +16,6 @@ export type BLSKeypair = {
 
 export type PubkeyHex = string;
 export type LodestarValidatorDatabaseController = Pick<
-  IDatabaseController<Buffer, Buffer>,
+  IDatabaseController<Uint8Array, Uint8Array>,
   "get" | "start" | "values" | "batchPut" | "keys" | "get" | "put"
 >;


### PR DESCRIPTION
**Motivation**

In preparation for https://github.com/ChainSafe/lodestar/pull/3461 the db interface is excesively restrictive requiring Buffer when the underlying db lib needs Uint8Arrays

**Description**

- Use Uint8Array in db interface