### PR TITLE
Add res headers to raw response in sse handler

### DIFF
--- a/packages/api/src/server/events.ts
+++ b/packages/api/src/server/events.ts
@@ -17,6 +17,12 @@ export function getRoutes(config: IChainForkConfig, api: Api): ServerRoutes<Api,
         const controller = new AbortController();
 
         try {
+          // Add injected headers from other pluggins. This is required for fastify-cors for example
+          // From: https://github.com/NodeFactoryIo/fastify-sse-v2/blob/b1686a979fbf655fb9936c0560294a0c094734d4/src/plugin.ts
+          Object.entries(res.getHeaders()).forEach(([key, value]) => {
+            if (value !== undefined) res.raw.setHeader(key, value);
+          });
+
           res.raw.setHeader("Content-Type", "text/event-stream");
           res.raw.setHeader("Cache-Control", "no-cache,no-transform");
           res.raw.setHeader("Connection", "keep-alive");


### PR DESCRIPTION
**Motivation**

Add injected headers from other plugins. This is required for fastify-cors for example.
From: https://github.com/NodeFactoryIo/fastify-sse-v2/blob/b1686a979fbf655fb9936c0560294a0c094734d4/src/plugin.ts

**Description**

- Add res headers to raw response in sse handler

Fixes https://github.com/ChainSafe/lodestar/issues/2712 

I've tested it locally and without this fix #2712 is still an issue