### PR TITLE
Offset sync period by ALTAIR_FORK_EPOCH

### DIFF
--- a/packages/beacon-state-transition/src/allForks/util/indexedSyncCommittee.ts
+++ b/packages/beacon-state-transition/src/allForks/util/indexedSyncCommittee.ts
@@ -1,6 +1,7 @@
+import {IChainConfig} from "@chainsafe/lodestar-config";
 import {altair, ssz, allForks, Slot, ValidatorIndex, BLSPubkey} from "@chainsafe/lodestar-types";
 import {TreeBacked, Vector} from "@chainsafe/ssz";
-import {computeSyncPeriodAtSlot} from "../../util/epoch";
+import {computeAbsoluteSyncPeriodAtSlot} from "../../util/epoch";
 import {CachedBeaconState} from "./cachedBeaconState";
 import {PubkeyIndexMap} from "./epochContext";
 
@@ -119,8 +120,8 @@ export function getIndexedSyncCommittee(
   state: CachedBeaconState<allForks.BeaconState> | CachedBeaconState<altair.BeaconState>,
   slot: Slot
 ): IndexedSyncCommittee {
-  const statePeriod = computeSyncPeriodAtSlot(state.slot);
-  const slotPeriod = computeSyncPeriodAtSlot(slot + 1); // See note above for the +1 offset
+  const statePeriod = computeAbsoluteSyncPeriodAtSlot(state.slot);
+  const slotPeriod = computeAbsoluteSyncPeriodAtSlot(slot + 1); // See note above for the +1 offset
   if (slotPeriod === statePeriod) {
     return state.currentSyncCommittee;
   } else if (slotPeriod === statePeriod + 1) {

--- a/packages/beacon-state-transition/src/allForks/util/indexedSyncCommittee.ts
+++ b/packages/beacon-state-transition/src/allForks/util/indexedSyncCommittee.ts
@@ -1,4 +1,3 @@
-import {IChainConfig} from "@chainsafe/lodestar-config";
 import {altair, ssz, allForks, Slot, ValidatorIndex, BLSPubkey} from "@chainsafe/lodestar-types";
 import {TreeBacked, Vector} from "@chainsafe/ssz";
 import {computeAbsoluteSyncPeriodAtSlot} from "../../util/epoch";

--- a/packages/beacon-state-transition/src/util/epoch.ts
+++ b/packages/beacon-state-transition/src/util/epoch.ts
@@ -2,6 +2,7 @@
  * @module chain/stateTransition/util
  */
 
+import {IChainConfig} from "@chainsafe/lodestar-config";
 import {
   EPOCHS_PER_SYNC_COMMITTEE_PERIOD,
   GENESIS_EPOCH,
@@ -52,13 +53,21 @@ export function getPreviousEpoch(state: allForks.BeaconState): Epoch {
 /**
  * Return the sync committee period at slot
  */
-export function computeSyncPeriodAtSlot(slot: Slot): SyncPeriod {
-  return computeSyncPeriodAtEpoch(computeEpochAtSlot(slot));
+export function computeSyncPeriodAtSlot(config: IChainConfig, slot: Slot): SyncPeriod {
+  return computeSyncPeriodAtEpoch(config, computeEpochAtSlot(slot));
 }
 
 /**
  * Return the sync committee period at epoch
  */
-export function computeSyncPeriodAtEpoch(epoch: Epoch): SyncPeriod {
+export function computeSyncPeriodAtEpoch(config: IChainConfig, epoch: Epoch): SyncPeriod {
+  return Math.floor((epoch - config.ALTAIR_FORK_EPOCH) / EPOCHS_PER_SYNC_COMMITTEE_PERIOD);
+}
+
+/**
+ * Return the sync committee period at slot, without offseting for ALTAIR_FORK_EPOCH
+ */
+export function computeAbsoluteSyncPeriodAtSlot(slot: Slot): SyncPeriod {
+  const epoch = computeEpochAtSlot(slot);
   return Math.floor(epoch / EPOCHS_PER_SYNC_COMMITTEE_PERIOD);
 }

--- a/packages/beacon-state-transition/test/perf/dataStructures/arrayish.memory.ts
+++ b/packages/beacon-state-transition/test/perf/dataStructures/arrayish.memory.ts
@@ -156,6 +156,7 @@ for (let i = 0; i < 1e8; i++) {
     const heapUsedM = linearRegression(xs, heapUsed).m;
     const rssM = linearRegression(xs, rss).m;
 
+    // eslint-disable-next-line no-console
     console.log(i, {arrayBuffersM, externalM, heapTotalM, heapUsedM, rssM});
   }
 }

--- a/packages/light-client/src/utils/clock.ts
+++ b/packages/light-client/src/utils/clock.ts
@@ -23,14 +23,22 @@ export function computeEpochAtSlot(slot: Slot): Epoch {
 /**
  * Return the sync committee period at slot
  */
-export function computeSyncPeriodAtSlot(slot: Slot): SyncPeriod {
-  return computeSyncPeriodAtEpoch(computeEpochAtSlot(slot));
+export function computeSyncPeriodAtSlot(config: IChainConfig, slot: Slot): SyncPeriod {
+  return computeSyncPeriodAtEpoch(config, computeEpochAtSlot(slot));
 }
 
 /**
  * Return the sync committee period at epoch
  */
-export function computeSyncPeriodAtEpoch(epoch: Epoch): SyncPeriod {
+export function computeSyncPeriodAtEpoch(config: IChainConfig, epoch: Epoch): SyncPeriod {
+  return Math.floor((epoch - config.ALTAIR_FORK_EPOCH) / EPOCHS_PER_SYNC_COMMITTEE_PERIOD);
+}
+
+/**
+ * Return the sync committee period at slot, without offseting for ALTAIR_FORK_EPOCH
+ */
+export function computeAbsoluteSyncPeriodAtSlot(slot: Slot): SyncPeriod {
+  const epoch = computeEpochAtSlot(slot);
   return Math.floor(epoch / EPOCHS_PER_SYNC_COMMITTEE_PERIOD);
 }
 

--- a/packages/light-client/src/validation.ts
+++ b/packages/light-client/src/validation.ts
@@ -8,11 +8,11 @@ import {
   MIN_SYNC_COMMITTEE_PARTICIPANTS,
   DOMAIN_SYNC_COMMITTEE,
 } from "@chainsafe/lodestar-params";
+import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {isValidMerkleBranch} from "./utils/verifyMerkleBranch";
 import {assertZeroHashes, getParticipantPubkeys, isEmptyHeader} from "./utils/utils";
 import {SyncCommitteeFast} from "./types";
-import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {computeSyncPeriodAtSlot} from "./utils/clock";
+import {computeAbsoluteSyncPeriodAtSlot} from "./utils/clock";
 
 /**
  *
@@ -75,8 +75,8 @@ export function assertValidFinalityProof(update: altair.LightClientUpdate): void
     throw Error("Invalid finality header merkle branch");
   }
 
-  const updatePeriod = computeSyncPeriodAtSlot(update.header.slot);
-  const updateFinalityPeriod = computeSyncPeriodAtSlot(update.finalityHeader.slot);
+  const updatePeriod = computeAbsoluteSyncPeriodAtSlot(update.header.slot);
+  const updateFinalityPeriod = computeAbsoluteSyncPeriodAtSlot(update.finalityHeader.slot);
   if (updateFinalityPeriod !== updatePeriod) {
     throw Error(`finalityHeader period ${updateFinalityPeriod} != header period ${updatePeriod}`);
   }

--- a/packages/light-client/test/naive/update.ts
+++ b/packages/light-client/test/naive/update.ts
@@ -3,7 +3,7 @@ import {altair, Slot} from "@chainsafe/lodestar-types";
 import {LightClientSnapshotFast, LightClientStoreFast} from "../../src/types";
 import {assertValidLightClientUpdate} from "../../src/validation";
 import {deserializeSyncCommittee, isEmptyHeader, sumBits} from "../../src/utils/utils";
-import {computeSyncPeriodAtSlot} from "../../src/utils/clock";
+import {computeSyncPeriodAtSlot, computeAbsoluteSyncPeriodAtSlot} from "../../src/utils/clock";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
 //
@@ -58,7 +58,7 @@ export function processLightClientUpdate(
   const syncCommittee = store.snapshot.nextSyncCommittee;
   assertValidLightClientUpdate(config, syncCommittee, update);
 
-  const syncPeriod = computeSyncPeriodAtSlot(update.header.slot);
+  const syncPeriod = computeSyncPeriodAtSlot(config, update.header.slot);
   const prevBestUpdate = store.bestUpdates.get(syncPeriod);
   if (!prevBestUpdate || isBetterUpdate(prevBestUpdate, update)) {
     store.bestUpdates.set(syncPeriod, update);
@@ -79,7 +79,7 @@ export function processLightClientUpdate(
 
   // Forced best update when the update timeout has elapsed
   else if (currentSlot > store.snapshot.header.slot + updateTimeout) {
-    const prevSyncPeriod = computeSyncPeriodAtSlot(store.snapshot.header.slot);
+    const prevSyncPeriod = computeSyncPeriodAtSlot(config, store.snapshot.header.slot);
     const bestUpdate = store.bestUpdates.get(prevSyncPeriod);
     if (bestUpdate) {
       applyLightClientUpdate(store.snapshot, bestUpdate);
@@ -92,8 +92,8 @@ export function processLightClientUpdate(
  * Spec v1.0.1
  */
 export function applyLightClientUpdate(snapshot: LightClientSnapshotFast, update: altair.LightClientUpdate): void {
-  const snapshotPeriod = computeSyncPeriodAtSlot(snapshot.header.slot);
-  const updatePeriod = computeSyncPeriodAtSlot(update.header.slot);
+  const snapshotPeriod = computeAbsoluteSyncPeriodAtSlot(snapshot.header.slot);
+  const updatePeriod = computeAbsoluteSyncPeriodAtSlot(update.header.slot);
   if (updatePeriod < snapshotPeriod) {
     throw Error("Cannot rollback sync period");
   }

--- a/packages/light-client/test/unit/sync.test.ts
+++ b/packages/light-client/test/unit/sync.test.ts
@@ -1,8 +1,8 @@
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {allForks, phase0, ssz} from "@chainsafe/lodestar-types";
 import {routes, Api} from "@chainsafe/lodestar-api";
-import {chainConfig} from "@chainsafe/lodestar-config/default";
-import {createIBeaconConfig} from "@chainsafe/lodestar-config";
+import {chainConfig as chainConfigDef} from "@chainsafe/lodestar-config/default";
+import {createIBeaconConfig, IChainConfig} from "@chainsafe/lodestar-config";
 import {Lightclient, LightclientEvent} from "../../src";
 import {EventsServerApi, LightclientServerApi, ServerOpts, startServer} from "../lightclientApiServer";
 import {computeLightclientUpdate, computeLightClientSnapshot, getInteropSyncCommittee, testLogger} from "../utils";
@@ -19,6 +19,9 @@ describe("Lightclient sync", () => {
   });
 
   it("Sync lightclient and track head", async () => {
+    const SECONDS_PER_SLOT = 2;
+    const ALTAIR_FORK_EPOCH = 0;
+
     const initialPeriod = 0;
     const targetPeriod = 5;
     const slotsIntoPeriod = 8;
@@ -26,6 +29,8 @@ describe("Lightclient sync", () => {
     const targetSlot = firstHeadSlot + slotsIntoPeriod;
 
     // Genesis data such that targetSlot is at the current clock slot
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const chainConfig: IChainConfig = {...chainConfigDef, SECONDS_PER_SLOT, ALTAIR_FORK_EPOCH};
     const genesisTime = Math.floor(Date.now() / 1000) - chainConfig.SECONDS_PER_SLOT * targetSlot;
     const genesisValidatorsRoot = Buffer.alloc(32, 0xaa);
     const config = createIBeaconConfig(chainConfig, genesisValidatorsRoot);

--- a/packages/lodestar/src/api/impl/beacon/state/utils.ts
+++ b/packages/lodestar/src/api/impl/beacon/state/utils.ts
@@ -4,7 +4,7 @@ import {FAR_FUTURE_EPOCH, GENESIS_SLOT, SLOTS_PER_EPOCH} from "@chainsafe/lodest
 import {
   CachedBeaconState,
   createCachedBeaconState,
-  computeSyncPeriodAtEpoch,
+  computeAbsoluteSyncPeriodAtSlot,
   computeEpochAtSlot,
   isActiveValidator,
 } from "@chainsafe/lodestar-beacon-state-transition";
@@ -149,8 +149,8 @@ export function getSyncCommittees(
   state: allForks.BeaconState | CachedBeaconState<allForks.BeaconState>,
   epoch: Epoch
 ): ValidatorIndex[] {
-  const statePeriod = computeSyncPeriodAtEpoch(computeEpochAtSlot(state.slot));
-  const requestPeriod = computeSyncPeriodAtEpoch(epoch);
+  const statePeriod = computeAbsoluteSyncPeriodAtSlot(computeEpochAtSlot(state.slot));
+  const requestPeriod = computeAbsoluteSyncPeriodAtSlot(epoch);
 
   if ((state as CachedBeaconState<allForks.BeaconState>).epochCtx !== undefined) {
     switch (requestPeriod) {

--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -348,7 +348,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
       // Check that all validatorIndex belong to the state before calling getCommitteeAssignments()
       const pubkeys = getPubkeysForIndices(state.validators, validatorIndices);
       // Ensures `epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD <= current_epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD + 1`
-      const syncComitteeValidatorIndexMap = getSyncComitteeValidatorIndexMap(state, epoch);
+      const syncComitteeValidatorIndexMap = getSyncComitteeValidatorIndexMap(config, state, epoch);
 
       const duties: routes.validator.SyncDuty[] = [];
       for (let i = 0, len = validatorIndices.length; i < len; i++) {

--- a/packages/lodestar/src/api/impl/validator/utils.ts
+++ b/packages/lodestar/src/api/impl/validator/utils.ts
@@ -4,6 +4,7 @@ import {
   computeSlotsSinceEpochStart,
   computeSyncPeriodAtEpoch,
 } from "@chainsafe/lodestar-beacon-state-transition";
+import {IChainConfig} from "@chainsafe/lodestar-config";
 import {ATTESTATION_SUBNET_COUNT} from "@chainsafe/lodestar-params";
 import {
   allForks,
@@ -20,11 +21,12 @@ import {BranchNodeStruct, TreeValue, List} from "@chainsafe/ssz";
 import {ApiError} from "../errors";
 
 export function getSyncComitteeValidatorIndexMap(
+  config: IChainConfig,
   state: allForks.BeaconState | CachedBeaconState<allForks.BeaconState>,
   requestedEpoch: Epoch
 ): Map<ValidatorIndex, number[]> {
-  const statePeriod = computeSyncPeriodAtEpoch(computeEpochAtSlot(state.slot));
-  const requestPeriod = computeSyncPeriodAtEpoch(requestedEpoch);
+  const statePeriod = computeSyncPeriodAtEpoch(config, computeEpochAtSlot(state.slot));
+  const requestPeriod = computeSyncPeriodAtEpoch(config, requestedEpoch);
 
   if ((state as CachedBeaconState<allForks.BeaconState>).epochCtx !== undefined) {
     switch (requestPeriod) {

--- a/packages/lodestar/src/chain/lightClient/index.ts
+++ b/packages/lodestar/src/chain/lightClient/index.ts
@@ -342,8 +342,8 @@ export class LightClientServer {
     }
 
     // Only store next sync committee once per dependant root
-    const parentBlockPeriod = computeSyncPeriodAtSlot(parentBlock.slot);
-    const period = computeSyncPeriodAtSlot(blockSlot);
+    const parentBlockPeriod = computeSyncPeriodAtSlot(this.config, parentBlock.slot);
+    const period = computeSyncPeriodAtSlot(this.config, blockSlot);
     if (parentBlockPeriod < period) {
       // If the parentBlock is in a previous epoch it must be the dependantRoot of this epoch transition
       const dependantRoot = parentBlock.blockRoot;
@@ -363,7 +363,7 @@ export class LightClientServer {
 
     // Store finalized checkpoint data
     const finalizedCheckpoint = postState.finalizedCheckpoint;
-    const finalizedCheckpointPeriod = computeSyncPeriodAtEpoch(finalizedCheckpoint.epoch);
+    const finalizedCheckpointPeriod = computeSyncPeriodAtEpoch(this.config, finalizedCheckpoint.epoch);
     const isFinalized =
       finalizedCheckpointPeriod === period &&
       // Consider the edge case of genesis: Genesis state's finalizedCheckpoint is zero'ed.
@@ -445,7 +445,7 @@ export class LightClientServer {
     syncAggregate: altair.SyncAggregate,
     attestedData: SyncAttestedData
   ): Promise<void> {
-    const period = computeSyncPeriodAtSlot(attestedData.header.slot);
+    const period = computeSyncPeriodAtSlot(this.config, attestedData.header.slot);
     const prevBestUpdate = await this.db.bestPartialLightClientUpdate.get(period);
     if (prevBestUpdate && !isBetterUpdate(prevBestUpdate, syncAggregate, attestedData)) {
       // TODO: Do metrics on how often updates are overwritten

--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -68,7 +68,7 @@ export class SyncCommitteeDutiesService {
    * https://github.com/ethereum/eth2.0-specs/pull/2400
    */
   async getDutiesAtSlot(slot: Slot): Promise<SyncDutyAndProofs[]> {
-    const period = computeSyncPeriodAtSlot(slot + 1); // See note above for the +1 offset
+    const period = computeSyncPeriodAtSlot(this.config, slot + 1); // See note above for the +1 offset
     const duties: SyncDutyAndProofs[] = [];
 
     const dutiesByIndex = this.dutiesByIndexByPeriod.get(period);
@@ -134,7 +134,7 @@ export class SyncCommitteeDutiesService {
       });
     }
 
-    const currentPeriod = computeSyncPeriodAtEpoch(currentEpoch);
+    const currentPeriod = computeSyncPeriodAtEpoch(this.config, currentEpoch);
     const syncCommitteeSubscriptions: routes.validator.SyncCommitteeSubscription[] = [];
 
     // For this and the next period, produce any beacon committee subscriptions.
@@ -186,7 +186,7 @@ export class SyncCommitteeDutiesService {
       throw extendError(e, "Failed to obtain SyncDuties");
     });
     const dependentRoot = syncDuties.dependentRoot;
-    const period = computeSyncPeriodAtEpoch(epoch);
+    const period = computeSyncPeriodAtEpoch(this.config, epoch);
 
     let count = 0;
 
@@ -238,7 +238,7 @@ export class SyncCommitteeDutiesService {
 
   /** Run at least once per period to prune duties map */
   private pruneOldDuties(currentEpoch: Epoch): void {
-    const currentPeriod = computeSyncPeriodAtEpoch(currentEpoch);
+    const currentPeriod = computeSyncPeriodAtEpoch(this.config, currentEpoch);
     for (const period of this.dutiesByIndexByPeriod.keys()) {
       if (period + HISTORICAL_DUTIES_PERIODS < currentPeriod) {
         this.dutiesByIndexByPeriod.delete(period);


### PR DESCRIPTION
**Motivation**

The first sync period for networks with ALTAIR_FORK_EPOCH >> 0 should be sync period 0.

**Description**

- When the sync period is used as a value for indexing, offset by ALTAIR_FORK_EPOCH
- When the sync period is used purely for comparison, don't offset by ALTAIR_FORK_EPOCH