### PR TITLE
moving el merge commits to more stable config

### DIFF
--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -2,6 +2,10 @@ name: Sim merge tests
 
 on: [pull_request, push]
 
+env:
+  GETH_COMMIT: c65940378e9f96ca7dce2d5c9c3b7260439b01a8
+  NETHERMIND_COMMIT: 8e54f87ce2e36e20a73b73a0e470816b1edc9b92
+
 jobs:
   sim-merge-tests:
     name: Sim merge tests
@@ -34,7 +38,7 @@ jobs:
       #Install Geth merge interop
       - uses: actions/setup-go@v2
       - name: Clone Geth merge interop branch
-        run: git clone -b merge-interop https://github.com/g11tech/go-ethereum.git && cd go-ethereum && git submodule update --init --recursive
+        run: git clone -b merge-interop https://github.com/g11tech/go-ethereum.git && cd go-ethereum && git reset --hard $GETH_COMMIT && git submodule update --init --recursive
       - name: Build Geth
         run: cd go-ethereum && make
 
@@ -52,7 +56,7 @@ jobs:
         with:
           dotnet-version: '5.0.x'
       - name: Clone Nethermind merge interop branch
-        run: git clone -b merge-interop https://github.com/g11tech/nethermind --recursive && cd nethermind && git submodule update --init --recursive
+        run: git clone -b merge-interop https://github.com/g11tech/nethermind --recursive && cd nethermind && git reset --hard $NETHERMIND_COMMIT && git submodule update --init --recursive
       - name: Build Nethermind
         run: cd nethermind/src/Nethermind && dotnet build Nethermind.sln -c Release
 

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -2,10 +2,6 @@ name: Sim merge tests
 
 on: [pull_request, push]
 
-env:
-  GETH_COMMIT: 932939feb6735f4295911063c09b1100aee24cb1
-  NETHERMIND_COMMIT: 8e54f87ce2e36e20a73b73a0e470816b1edc9b92
-
 jobs:
   sim-merge-tests:
     name: Sim merge tests
@@ -38,7 +34,7 @@ jobs:
       #Install Geth merge interop
       - uses: actions/setup-go@v2
       - name: Clone Geth merge interop branch
-        run: git clone -b kintsugi-spec https://github.com/MariusVanDerWijden/go-ethereum.git && cd go-ethereum && git reset --hard $GETH_COMMIT && git submodule update --init --recursive
+        run: git clone -b merge-interop https://github.com/g11tech/go-ethereum.git && cd go-ethereum && git submodule update --init --recursive
       - name: Build Geth
         run: cd go-ethereum && make
 
@@ -56,7 +52,7 @@ jobs:
         with:
           dotnet-version: '5.0.x'
       - name: Clone Nethermind merge interop branch
-        run: git clone -b themerge_kintsugi https://github.com/NethermindEth/nethermind --recursive && cd nethermind && git reset --hard $NETHERMIND_COMMIT && git submodule update --init --recursive
+        run: git clone -b merge-interop https://github.com/g11tech/nethermind --recursive && cd nethermind && git submodule update --init --recursive
       - name: Build Nethermind
         run: cd nethermind/src/Nethermind && dotnet build Nethermind.sln -c Release
 


### PR DESCRIPTION
**Motivation**
The EL teams are frequently re-basing their interop branches, as the merge development is in the early mode. This breaks our CI.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR moves the CI from checkout from the forked repo's branches, which will be updated on the stable update from ELs or will be updated to the EL master code once their merge code stablizes and merges into master.
`merge-interop` branch in the local forked (g11tech's) repo will track and be updated with the interop code from time to time after testing the updated code from ELs.
**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
