### PR TITLE
terminal pow overriding args

### DIFF
--- a/packages/cli/src/config/beaconParams.ts
+++ b/packages/cli/src/config/beaconParams.ts
@@ -10,7 +10,7 @@ import {writeFile, readFile} from "../util";
 import {getNetworkBeaconParams, NetworkName} from "../networks";
 import {getGlobalPaths, IGlobalPaths} from "../paths/global";
 import {IBeaconParamsUnparsed} from "./types";
-import {parseBeaconParamsArgs} from "../options";
+import {parseBeaconParamsArgs, parseTerminalPowArgs, ITerminalPowArgs} from "../options";
 
 type IBeaconParamsCliArgs = {
   network?: NetworkName;
@@ -39,7 +39,10 @@ export function getBeaconParamsFromArgs(args: IBeaconParamsCliArgs): IChainConfi
   return getBeaconParams({
     network: args.network,
     paramsFile: getGlobalPaths(args).paramsFile,
-    additionalParamsCli: parseBeaconParamsArgs(args as Record<string, string | number>),
+    additionalParamsCli: {
+      ...parseBeaconParamsArgs(args as Record<string, string | number>),
+      ...parseTerminalPowArgs(args as ITerminalPowArgs),
+    },
   });
 }
 

--- a/packages/cli/src/options/paramsOptions.ts
+++ b/packages/cli/src/options/paramsOptions.ts
@@ -55,7 +55,7 @@ export function parseTerminalPowArgs(args: ITerminalPowArgs): IBeaconParamsUnpar
   return parsedArgs;
 }
 
-export const paramsOptions: ICliCommandOptions<ITerminalPowArgs> = {
+export const paramsOptions: ICliCommandOptions<IParamsArgs> = {
   ...paramsOptionsByName,
 
   "terminal-total-difficulty-override": {

--- a/packages/cli/src/options/paramsOptions.ts
+++ b/packages/cli/src/options/paramsOptions.ts
@@ -1,12 +1,18 @@
 import {Options} from "yargs";
 import {IBeaconParamsUnparsed} from "../config/types";
-import {ObjectKeys} from "../util";
+import {ObjectKeys, ICliCommandOptions} from "../util";
 import {ChainConfig, IChainConfig} from "@chainsafe/lodestar-config";
 
 // No options are statically declared
 // If an arbitraty key notation is used, it removes typesafety on most of this CLI arg parsing code.
 // Params will be parsed from an args object assuming to contain the required keys
-export type IParamsArgs = Record<never, never>;
+
+export type ITerminalPowArgs = {
+  "terminal-total-difficulty-override"?: string;
+  "terminal-block-hash-override"?: string;
+  "terminal-block-hash-epoch-override"?: string;
+};
+export type IParamsArgs = Record<never, never> & ITerminalPowArgs;
 
 const getArgKey = (key: keyof IBeaconParamsUnparsed): string => `params.${key}`;
 
@@ -21,7 +27,7 @@ export function parseBeaconParamsArgs(args: Record<string, string | number>): IB
   );
 }
 
-export const paramsOptions = ((ObjectKeys(ChainConfig.fields) as unknown) as (keyof IChainConfig)[]).reduce(
+const paramsOptionsByName = ((ObjectKeys(ChainConfig.fields) as unknown) as (keyof IChainConfig)[]).reduce(
   (options: Record<string, Options>, key): Record<string, Options> => ({
     ...options,
     [getArgKey(key)]: {
@@ -32,3 +38,38 @@ export const paramsOptions = ((ObjectKeys(ChainConfig.fields) as unknown) as (ke
   }),
   {}
 );
+
+const terminalArgsToParamsMap: {[K in keyof ITerminalPowArgs]: keyof IChainConfig} = {
+  "terminal-total-difficulty-override": "TERMINAL_TOTAL_DIFFICULTY",
+  "terminal-block-hash-override": "TERMINAL_BLOCK_HASH",
+  "terminal-block-hash-epoch-override": "TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH",
+};
+
+export function parseTerminalPowArgs(args: ITerminalPowArgs): IBeaconParamsUnparsed {
+  const parsedArgs = ObjectKeys(terminalArgsToParamsMap).reduce((beaconParams: Partial<IBeaconParamsUnparsed>, key) => {
+    const paramOption = terminalArgsToParamsMap[key];
+    const value = args[key];
+    if (paramOption != null && value != null) beaconParams[paramOption] = value;
+    return beaconParams;
+  }, {});
+  return parsedArgs;
+}
+
+export const paramsOptions: ICliCommandOptions<ITerminalPowArgs> = {
+  ...paramsOptionsByName,
+
+  "terminal-total-difficulty-override": {
+    description: "Terminal PoW block TTD override",
+    type: "string",
+  },
+
+  "terminal-block-hash-override": {
+    description: "Terminal PoW block hash override",
+    type: "string",
+  },
+
+  "terminal-block-hash-epoch-override": {
+    description: "Terminal PoW block hash override activation epoch",
+    type: "string",
+  },
+};


### PR DESCRIPTION
**Motivation**
The consensus-spec provides for the option of overiding the following terminal pow params
- terminal-total-difficulty-override
- terminal-block-hash-override
- terminal-block-hash-epoch-override

this PR enables the same.
Closes #3479

