### PR TITLE
Remove hardcoded infura links from codebase

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,5 +45,7 @@ jobs:
         run: yarn coverage
       - name: E2e tests
         run: yarn test:e2e
+        env:
+          GOERLI_RPC_URL: ${{ secrets.GOERLI_RPC_URL }}
       - name: README check
         run: yarn run check-readme

--- a/packages/beacon-state-transition/test/perf/analyzeBlocks.ts
+++ b/packages/beacon-state-transition/test/perf/analyzeBlocks.ts
@@ -1,5 +1,6 @@
 import {getClient} from "@chainsafe/lodestar-api";
 import {config} from "@chainsafe/lodestar-config/default";
+import {getInfuraBeaconUrl} from "./infura";
 
 // Analyze how eth2 blocks are in a target network to prepare accurate performance states and blocks
 
@@ -15,10 +16,7 @@ import {config} from "@chainsafe/lodestar-config/default";
 // aggregationBitsAvg: 87.88991645944512
 
 const network = "mainnet";
-const INFURA_CREDENTIALS = "1sla4tyOFn0bB1ohyCKaH2sLmHu:b8cdb9d881039fd04fe982a5ec57b0b8";
-const baseUrl = `https://${INFURA_CREDENTIALS}@eth2-beacon-${network}.infura.io`;
-
-const client = getClient(config, {baseUrl});
+const client = getClient(config, {baseUrl: getInfuraBeaconUrl(network)});
 
 async function run(): Promise<void> {
   const {data: headBlock} = await client.beacon.getBlockHeader("head");

--- a/packages/beacon-state-transition/test/perf/infura.ts
+++ b/packages/beacon-state-transition/test/perf/infura.ts
@@ -1,5 +1,10 @@
-const INFURA_CREDENTIALS = "1sla4tyOFn0bB1ohyCKaH2sLmHu:b8cdb9d881039fd04fe982a5ec57b0b8";
+import {NetworkName} from "@chainsafe/lodestar-config/networks";
 
-export function getInfuraUrl(network: "mainnet" | "pyrmont" | "prater"): string {
-  return `https://${INFURA_CREDENTIALS}@eth2-beacon-${network}.infura.io`;
+export function getInfuraBeaconUrl(network: NetworkName): string {
+  const INFURA_ETH2_CREDENTIALS = process.env.INFURA_ETH2_CREDENTIALS;
+  if (!INFURA_ETH2_CREDENTIALS) {
+    throw Error("Must set ENV INFURA_ETH2_CREDENTIALS");
+  }
+
+  return `https://${INFURA_ETH2_CREDENTIALS}@eth2-beacon-${network}.infura.io`;
 }

--- a/packages/beacon-state-transition/test/perf/util.ts
+++ b/packages/beacon-state-transition/test/perf/util.ts
@@ -25,7 +25,7 @@ import {
 import {NetworkName, networksChainConfig} from "@chainsafe/lodestar-config/networks";
 import {getClient} from "@chainsafe/lodestar-api";
 import {getNextSyncCommittee} from "../../src/altair/util/syncCommittee";
-import {getInfuraUrl} from "./infura";
+import {getInfuraBeaconUrl} from "./infura";
 import {testCachePath} from "../cache";
 import {MutableVector} from "@chainsafe/persistent-ts";
 
@@ -457,7 +457,7 @@ export async function getNetworkCachedState(
   if (fs.existsSync(filepath)) {
     stateSsz = fs.readFileSync(filepath);
   } else {
-    const client = getClient(config, {baseUrl: getInfuraUrl(network), timeoutMs: timeout ?? 300_000});
+    const client = getClient(config, {baseUrl: getInfuraBeaconUrl(network), timeoutMs: timeout ?? 300_000});
     stateSsz =
       computeEpochAtSlot(slot) < config.ALTAIR_FORK_EPOCH
         ? await client.debug.getState(String(slot), "ssz")

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -10,7 +10,7 @@ import {getStateTypeFromBytes} from "@chainsafe/lodestar/lib/util/multifork";
 import {downloadOrLoadFile} from "../../util";
 import {IBeaconArgs} from "./options";
 import {defaultNetwork, IGlobalArgs} from "../../options/globalOptions";
-import {fetchWeakSubjectivityState, getGenesisFileUrl, getInfuraBeaconUrl, infuraNetworks} from "../../networks";
+import {fetchWeakSubjectivityState, getGenesisFileUrl} from "../../networks";
 import {Checkpoint} from "@chainsafe/lodestar-types/phase0";
 import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 
@@ -104,11 +104,9 @@ export async function initBeaconState(
     // weak subjectivity sync from a state that needs to be fetched:
     // if a weak subjectivity checkpoint has been provided, it is used to inform which state to download and used for additional verification
     // otherwise, the 'finalized' state is downloaded and the state itself is used for verification (all trust delegated to the remote beacon node)
-    const remoteBeaconUrl = args.weakSubjectivityServerUrl || getInfuraBeaconUrl(args.network);
+    const remoteBeaconUrl = args.weakSubjectivityServerUrl;
     if (!remoteBeaconUrl) {
-      throw new Error(
-        `Missing weak subjectivity server URL.  Use either a custom URL via --weakSubjectivityServerUrl or use one of these options for --network: ${infuraNetworks.toString()}`
-      );
+      throw Error(`Must set arg --weakSubjectivityServerUrl for network ${args.network}`);
     }
 
     let stateId = "finalized";

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -12,8 +12,6 @@ import * as prater from "./prater";
 
 export type NetworkName = "mainnet" | "pyrmont" | "prater" | "dev";
 export const networkNames: NetworkName[] = ["mainnet", "pyrmont", "prater"];
-/** Networks that infura supports */
-export const infuraNetworks: NetworkName[] = ["mainnet", "pyrmont", "prater"];
 
 function getNetworkData(
   network: NetworkName
@@ -36,27 +34,14 @@ function getNetworkData(
   }
 }
 
-export function getEth1ProviderUrl(networkId: number): string {
-  switch (networkId) {
-    case 1:
-      return "https://mainnet.infura.io/v3/84842078b09946638c03157f83405213";
-    case 5:
-      return "https://goerli.infura.io/v3/84842078b09946638c03157f83405213";
-    default:
-      throw Error(`Eth1 network not supported: ${networkId}`);
-  }
-}
-
 export function getNetworkBeaconParams(network: NetworkName): IChainConfig {
   return getNetworkData(network).chainConfig;
 }
 
 export function getNetworkBeaconNodeOptions(network: NetworkName): RecursivePartial<IBeaconNodeOptions> {
-  const {depositContractDeployBlock, bootEnrs, chainConfig} = getNetworkData(network);
-  const networkId = parseInt(String(chainConfig.DEPOSIT_NETWORK_ID || 1), 10);
+  const {depositContractDeployBlock, bootEnrs} = getNetworkData(network);
   return {
     eth1: {
-      providerUrls: [getEth1ProviderUrl(networkId)],
       depositContractDeployBlock,
     },
     network: {
@@ -90,16 +75,6 @@ export async function fetchBootnodes(network: NetworkName): Promise<string[]> {
     if (line.includes("enr:")) enrs.push("enr:" + line.split("enr:")[1]);
   }
   return enrs;
-}
-
-// TODO these URLs are from a local infura account.  switch with a ChainSafe account when available
-const INFURA_CREDENTIALS = "1sla4tyOFn0bB1ohyCKaH2sLmHu:b8cdb9d881039fd04fe982a5ec57b0b8";
-
-export function getInfuraBeaconUrl(network: NetworkName): string | undefined {
-  if (infuraNetworks.includes(network)) {
-    return `https://${INFURA_CREDENTIALS}@eth2-beacon-${network}.infura.io`;
-  }
-  return undefined;
 }
 
 /**

--- a/packages/light-client/test/getGenesisData.ts
+++ b/packages/light-client/test/getGenesisData.ts
@@ -1,20 +1,21 @@
 import {getClient} from "@chainsafe/lodestar-api";
 import {config} from "@chainsafe/lodestar-config/default";
+import {getInfuraBeaconUrl} from "@chainsafe/lodestar-beacon-state-transition/test/perf/infura";
+import {NetworkName} from "@chainsafe/lodestar-config/networks";
 
 // To populate packages/light-client/src/networks.ts
 //
 // ```
-// ./node_modules/.bin/ts-node test/getGenesisData.ts
+// INFURA_ETH2_CREDENTIALS=<user>:<secret> ./node_modules/.bin/ts-node test/getGenesisData.ts
 // ```
 
 /* eslint-disable no-console */
 
-const networksInInfura = ["mainnet", "prater", "pyrmont"];
-const INFURA_CREDENTIALS = "1sla4tyOFn0bB1ohyCKaH2sLmHu:b8cdb9d881039fd04fe982a5ec57b0b8";
+const networksInInfura: NetworkName[] = ["mainnet", "prater", "pyrmont"];
 
 async function getGenesisData(): Promise<void> {
   for (const network of networksInInfura) {
-    const baseUrl = `https://${INFURA_CREDENTIALS}@eth2-beacon-${network}.infura.io`;
+    const baseUrl = getInfuraBeaconUrl(network);
     const api = getClient(config, {baseUrl});
     const {data: genesis} = await api.beacon.getGenesis();
     console.log(network, {

--- a/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
@@ -9,7 +9,7 @@ import {LevelDbController} from "@chainsafe/lodestar-db";
 
 import {Eth1ForBlockProduction} from "../../../src/eth1";
 import {Eth1Options} from "../../../src/eth1/options";
-import {getTestnetConfig, testnet} from "../../utils/testnet";
+import {getTestnetConfig, medallaTestnetConfig} from "../../utils/testnet";
 import {testLogger} from "../../utils/logger";
 import {BeaconDb} from "../../../src/db";
 import {generateState} from "../../utils/state";
@@ -17,6 +17,7 @@ import {fromHexString, List, toHexString} from "@chainsafe/ssz";
 import {Root, ssz} from "@chainsafe/lodestar-types";
 import {createCachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {Eth1Provider} from "../../../src/eth1/provider/eth1Provider";
+import {getGoerliRpcUrl} from "../../testParams";
 
 const dbLocation = "./.__testdb";
 
@@ -31,16 +32,10 @@ const pyrmontDepositsDataRoot = [
 describe("eth1 / Eth1Provider", function () {
   this.timeout("2 min");
 
-  const eth1Options: Eth1Options = {
-    enabled: true,
-    providerUrls: [testnet.providerUrl],
-    depositContractDeployBlock: testnet.depositBlock,
-  };
   const controller = new AbortController();
 
   const config = getTestnetConfig();
   const logger = testLogger();
-  const eth1Provider = new Eth1Provider(config, eth1Options, controller.signal);
 
   let db: BeaconDb;
   let dbController: LevelDbController;
@@ -67,6 +62,13 @@ describe("eth1 / Eth1Provider", function () {
   });
 
   it("Should fetch real Pyrmont eth1 data for block proposing", async function () {
+    const eth1Options: Eth1Options = {
+      enabled: true,
+      providerUrls: [getGoerliRpcUrl()],
+      depositContractDeployBlock: medallaTestnetConfig.depositBlock,
+    };
+    const eth1Provider = new Eth1Provider(config, eth1Options, controller.signal);
+
     const eth1ForBlockProduction = new Eth1ForBlockProduction(eth1Options, {
       config,
       db,

--- a/packages/lodestar/test/e2e/eth1/eth1MergeBlockTracker.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1MergeBlockTracker.test.ts
@@ -6,10 +6,10 @@ import {expect} from "chai";
 import {Eth1Provider, IEth1Provider} from "../../../src";
 import {Eth1MergeBlockTracker, StatusCode} from "../../../src/eth1/eth1MergeBlockTracker";
 import {Eth1Options} from "../../../src/eth1/options";
-import {testnet} from "../../utils/testnet";
 import {testLogger} from "../../utils/logger";
 import {quantityToBigint} from "../../../src/eth1/provider/utils";
 import {ZERO_HASH} from "../../../src/constants";
+import {getGoerliRpcUrl} from "../../testParams";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -17,12 +17,6 @@ describe("eth1 / Eth1MergeBlockTracker", function () {
   this.timeout("2 min");
 
   const logger = testLogger();
-
-  const eth1Options: Eth1Options = {
-    enabled: true,
-    providerUrls: [testnet.providerUrl],
-    depositContractDeployBlock: 0,
-  };
 
   function getConfig(ttd: bigint): IChainConfig {
     return ({
@@ -35,6 +29,16 @@ describe("eth1 / Eth1MergeBlockTracker", function () {
     } as Partial<IChainConfig>) as IChainConfig;
   }
   const eth1Config = {DEPOSIT_CONTRACT_ADDRESS: ZERO_HASH};
+
+  // Compute lazily since getGoerliRpcUrl() throws if GOERLI_RPC_URL is not set
+  let eth1Options: Eth1Options;
+  before("Get eth1Options", () => {
+    eth1Options = {
+      enabled: true,
+      providerUrls: [getGoerliRpcUrl()],
+      depositContractDeployBlock: 0,
+    };
+  });
 
   let controller: AbortController;
   beforeEach(() => (controller = new AbortController()));

--- a/packages/lodestar/test/e2e/eth1/eth1Provider.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1Provider.test.ts
@@ -2,27 +2,29 @@ import "mocha";
 import {expect} from "chai";
 import {AbortController} from "@chainsafe/abort-controller";
 import {Eth1Options} from "../../../src/eth1/options";
-import {getTestnetConfig, testnet} from "../../utils/testnet";
+import {getTestnetConfig} from "../../utils/testnet";
 import {fromHexString} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
 import {goerliTestnetDepositEvents} from "../../utils/testnet";
 import {Eth1Provider, parseEth1Block} from "../../../src/eth1/provider/eth1Provider";
+import {getGoerliRpcUrl} from "../../testParams";
 
 describe("eth1 / Eth1Provider", function () {
   this.timeout("2 min");
-
-  const eth1Options: Eth1Options = {
-    enabled: true,
-    providerUrls: [testnet.providerUrl],
-    depositContractDeployBlock: 0,
-  };
 
   let controller: AbortController;
   beforeEach(() => (controller = new AbortController()));
   afterEach(() => controller.abort());
 
   const config = getTestnetConfig();
+
+  // Compute lazily since getGoerliRpcUrl() throws if GOERLI_RPC_URL is not set
   function getEth1Provider(): Eth1Provider {
+    const eth1Options: Eth1Options = {
+      enabled: true,
+      providerUrls: [getGoerliRpcUrl()],
+      depositContractDeployBlock: 0,
+    };
     return new Eth1Provider(config, eth1Options, controller.signal);
   }
 

--- a/packages/lodestar/test/e2e/eth1/jsonRpcHttpClient.test.ts
+++ b/packages/lodestar/test/e2e/eth1/jsonRpcHttpClient.test.ts
@@ -4,7 +4,7 @@ import chaiAsPromised from "chai-as-promised";
 import http from "http";
 import {AbortController} from "@chainsafe/abort-controller";
 import {JsonRpcHttpClient} from "../../../src/eth1/provider/jsonRpcHttpClient";
-import {goerliRpcUrl} from "../../testParams";
+import {getGoerliRpcUrl} from "../../testParams";
 import {IRpcPayload} from "../../../src/eth1/interface";
 
 chai.use(chaiAsPromised);
@@ -142,7 +142,7 @@ describe("eth1 / jsonRpcHttpClient", function () {
         );
       }
 
-      if (!url) url = goerliRpcUrl;
+      if (!url) url = getGoerliRpcUrl();
       if (!payload) payload = {method: "no-method", params: []};
 
       const controller = new AbortController();

--- a/packages/lodestar/test/e2e/eth1/stream.test.ts
+++ b/packages/lodestar/test/e2e/eth1/stream.test.ts
@@ -1,9 +1,11 @@
 import "mocha";
 import {expect} from "chai";
 import {AbortController} from "@chainsafe/abort-controller";
-import {getTestnetConfig, testnet} from "../../utils/testnet";
+import {getTestnetConfig, medallaTestnetConfig} from "../../utils/testnet";
 import {getDepositsStream, getDepositsAndBlockStreamForGenesis} from "../../../src/eth1/stream";
 import {Eth1Provider} from "../../../src/eth1/provider/eth1Provider";
+import {getGoerliRpcUrl} from "../../testParams";
+import {Eth1Options} from "../../../src/eth1/options";
 
 describe("Eth1 streams", function () {
   this.timeout("2 min");
@@ -14,15 +16,14 @@ describe("Eth1 streams", function () {
 
   const config = getTestnetConfig();
 
+  // Compute lazily since getGoerliRpcUrl() throws if GOERLI_RPC_URL is not set
   function getEth1Provider(): Eth1Provider {
-    return new Eth1Provider(
-      config,
-      {
-        providerUrls: [testnet.providerUrl],
-        depositContractDeployBlock: testnet.depositBlock,
-      },
-      controller.signal
-    );
+    const eth1Options: Eth1Options = {
+      enabled: true,
+      providerUrls: [getGoerliRpcUrl()],
+      depositContractDeployBlock: 0,
+    };
+    return new Eth1Provider(config, eth1Options, controller.signal);
   }
 
   const maxBlocksPerPoll = 1000;
@@ -31,7 +32,7 @@ describe("Eth1 streams", function () {
 
   it(`Should fetch ${depositsToFetch} deposits with getDepositsStream`, async function () {
     const depositsStream = getDepositsStream(
-      testnet.blockWithDepositActivity,
+      medallaTestnetConfig.blockWithDepositActivity,
       getEth1Provider(),
       eth1Params,
       controller.signal
@@ -50,7 +51,7 @@ describe("Eth1 streams", function () {
 
   it(`Should fetch ${depositsToFetch} deposits with getDepositsAndBlockStreamForGenesis`, async function () {
     const stream = getDepositsAndBlockStreamForGenesis(
-      testnet.blockWithDepositActivity,
+      medallaTestnetConfig.blockWithDepositActivity,
       getEth1Provider(),
       eth1Params,
       controller.signal

--- a/packages/lodestar/test/testParams.ts
+++ b/packages/lodestar/test/testParams.ts
@@ -1,4 +1,10 @@
-export const mainnetRpcUrl =
-  process.env.MAINNET_RPC_URL || "https://mainnet.infura.io/v3/84842078b09946638c03157f83405213";
+export function getGoerliRpcUrl(): string {
+  const {GOERLI_RPC_URL} = process.env;
+  if (!GOERLI_RPC_URL) {
+    throw Error("Must set ENV GOERLI_RPC_URL");
+  }
+  return GOERLI_RPC_URL;
+}
+
 export const goerliRpcUrl =
   process.env.GOERLI_RPC_URL || "https://goerli.infura.io/v3/84842078b09946638c03157f83405213";

--- a/packages/lodestar/test/utils/testnet.ts
+++ b/packages/lodestar/test/utils/testnet.ts
@@ -1,12 +1,10 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {createIChainForkConfig, IChainForkConfig} from "@chainsafe/lodestar-config";
 import {chainConfig} from "@chainsafe/lodestar-config/default";
-import {goerliRpcUrl} from "../testParams";
 import {fromHexString} from "@chainsafe/ssz";
 
 /** Generic testnet data taken from the Medalla testnet  */
-export const testnet = {
-  providerUrl: goerliRpcUrl,
+export const medallaTestnetConfig = {
   depositBlock: 3085928,
   // Optimized blocks for quick testing
   blockWithDepositActivity: 3124889,


### PR DESCRIPTION
**Motivation**

Historically for convenience Lodestar has hardcoded Infura URLs and credentials so the eth1 node doesn't have to be setup. Preparing for the merge and better practices this URLs have to be removed

**WARNING!**: Setups relying on this auto-filled URLs will need to provide an eth1 endpoint of their own after the next release

**Description**

- Remove hardcoded infura links from codebase