### PR TITLE
Trigger release with tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         id: get_prev_tag
         run: node scripts/get_prev_tag.js
         env:
-          CURRENT_TAG: ${{ steps.tag.outputs.tagname }}
+          CURRENT_TAG: ${{ steps.tag.outputs.tag }}
           IGNORE_PATTERN: beta
     outputs:
       is_beta: ${{ contains(github.ref, 'beta') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ concurrency: cd-release
 on:
   push:
     tags:
+      - v*
 
 jobs:
   tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,13 @@ name: Release
 # only one can tun at a time
 concurrency: cd-release
 
+# See for rationale https://github.com/ChainSafe/lodestar/issues/3036#issuecomment-976956044
+# When a stable release is proposed, a testing period of N days starts
+# - Tag current master to v0.33.0-beta.0
+# - Bump master to v0.34.0
 on:
   push:
-    branches:
-      - "master"
+    tags:
 
 jobs:
   tag:
@@ -15,28 +18,27 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Get latest tag
-        id: get-latest-tag
-        uses: actions-ecosystem/action-get-latest-tag@v1
-        with:
-          with_initial_version: false
-      - name: Create tag
-        id: tag
-        uses: butlerlogic/action-autotag@1.1.2
-        with:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          root: "packages/lodestar" # lerna doesn't update version root package.json and this action cannot read from lerna.json
-          tag_prefix: "v"
+      - name: Get tag
+        id: get_tag
+        run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
+      - name: Get previous tag
+        id: get_prev_tag
+        run: node scripts/get_prev_tag.js
+        env:
+          CURRENT_TAG: ${{ steps.tag.outputs.tagname }}
+          IGNORE_PATTERN: beta
     outputs:
+      is_beta: ${{ contains(github.ref, 'beta') }}
       tag: ${{ steps.tag.outputs.tagname }}
-      previous_tag: ${{ steps.get-latest-tag.outputs.tag }}
-      version: ${{ steps.tag.outputs.version }}
+      prev_tag: ${{ steps.get_prev_tag.outputs.prev_tag }}
+      version: ${{ steps.get_version.outputs.version }}
 
   npm:
     name: Publish to NPM Registry
     runs-on: ubuntu-latest
     needs: tag
-    if: needs.tag.outputs.tag != ''
+    # Skip creating a release for beta releases (for now)
+    if: needs.tag.outputs.is_beta != 'true'
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v2
@@ -75,7 +77,7 @@ jobs:
           compareLink: "true"
           filterByMilestone: "false"
           unreleased: "false"
-          sinceTag: "${{ needs.tag.outputs.previous_tag }}"
+          sinceTag: "${{ needs.tag.outputs.prev_tag }}"
           maxIssues: "0"
           stripGeneratorNotice: "true"
           excludeLabels: "meta-excludefromchangelog"
@@ -115,7 +117,7 @@ jobs:
     name: Publish to Docker Hub
     runs-on: ubuntu-latest
     needs: [tag, npm]
-    if: needs.tag.outputs.tag != ''
+    if: needs.tag.outputs.is_beta != 'true'
     steps:
       - uses: actions/checkout@v2
       - run: scripts/await-release.sh ${{ needs.tag.outputs.tag }} 900

--- a/scripts/get_prev_tag.js
+++ b/scripts/get_prev_tag.js
@@ -1,0 +1,44 @@
+/* eslint-disable no-console,
+  @typescript-eslint/explicit-function-return-type,
+  @typescript-eslint/no-var-requires,
+  @typescript-eslint/no-require-imports */
+
+// Script used in .github/workflows/release.yml to get the previous tag
+// to generate a changelog from 'prev_tag' to 'tag'
+// Returns the most recent tag that:
+// - is not equal to CURRENT_TAG
+// - does not contain IGNORE_PATTERN
+//
+// Outputs to output.prev_tag
+
+const {exec} = require("child_process");
+const {promisify} = require("util");
+
+async function run() {
+  const {CURRENT_TAG, IGNORE_PATTERN} = process.env;
+  if (!CURRENT_TAG) throw Error("CURRENT_TAG must be defined");
+  if (!IGNORE_PATTERN) throw Error("IGNORE_PATTERN must be defined");
+
+  const {stdout} = await promisify(exec)("git tag --sort=-version:refname");
+  // Returns sorted list of tags
+  // v0.32.0
+  // v0.31.0
+  // v0.30.0
+  // v0.29.3
+
+  // Pick the first tag that doesn't match current tag
+  const tags = stdout.trim().split("\n");
+  for (const tag of tags) {
+    if (tag !== CURRENT_TAG && !tag.includes(IGNORE_PATTERN)) {
+      console.log(`echo ::set-output name=prev_tag::${tag}`);
+      return;
+    }
+  }
+
+  throw Error("No tag found");
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
**Motivation**

Modifies current release github action to follow https://github.com/ChainSafe/lodestar/issues/3036#issuecomment-976956044

**Description**

- Don't trigger release on package.json bump
- Trigger release on tag push if doesn't include 'beta'
- Get previous tag with new script