### PR TITLE
Add script based setup to join merge devnet

### DIFF
--- a/kintsugi/devnets/README.md
+++ b/kintsugi/devnets/README.md
@@ -22,7 +22,7 @@ cd kintsugi/devnets
 ###### Script parameters help
 
 1. `dataDir`: Where you want the script and client's configuration data to be setup. Should be non-existent for the first run. (The directory if already present will skip fetching the configuration, assuming it has done previously). You can also clean indivizual directories of CL/EL between the re-runs.
-2. `elClient`: Which EL client you want, currently working with nethermind
+2. `elClient`: Which EL client you want, currently working with `geth` and `nethermind`
 3. `devnetVars`: Contains the configuration specific to a devnet, like images, or urls for EL/CL to interact. Will be updated with new vars.
 4. `dockerWithSudo`(optional): Provide this argument if your docker needs a sudo prefix
 5. `--withTerminal`(optional): Provide the terminal command prefix for CL and EL processes to run in your favourite terminal. You may use an alias or a terminal launching script as long as it waits for the command it runs till ends and then closes.

--- a/kintsugi/devnets/README.md
+++ b/kintsugi/devnets/README.md
@@ -8,11 +8,16 @@ This is a setup to run and join the devnet with a single shell command. This scr
 ###### Just run the script with arguments
 ```bash
 cd kintsugi/devnets
-./setup.sh --dataDir devnet3data --elClient nethermind --devnetVars ./devnet3.vars --dockerWithSudo
+./setup.sh --dataDir devnet3-data --elClient nethermind --devnetVars ./devnet3.vars [--dockerWithSudo --withTerminal "gnome-terminal --disable-factory --"
 ```
 ###### Script parameters help
 
 1. `dataDir`: Where you want the script and client's configuration data to be setup. Should be non-existent for the first run. (The directory if already present will skip fetching the configuration, assuming it has done previously). You can also clean indivizual directories of CL/EL between the re-runs.
 2. `elClient`: Which EL client you want, currently working with nethermind
 3. `devnetVars`: Contains the configuration specific to a devnet, like images, or urls for EL/CL to interact. Will be updated with new vars.
-4. `dockerWithSudo`: provide this argument if your docker needs a sudo prefix
+4. `dockerWithSudo`(optional): Provide this argument if your docker needs a sudo prefix
+5. `--withTerminal`(optional): Provide the terminal command prefix for CL and EL processes to run in your favourite terminal. You may use an alias or a terminal launching script as long as it waits for the command it runs till ends and then closes.
+If not provided, it will launch the docker processes in detached mode.
+6. `--detached`(optional): By default the script will wait for processes and use user input (ctrl +c) to end the processes, however you can pass this option to skip this behavior and just return, for e.g. in case you just want to leave it running.
+
+Only one of `--withTerminal` or `--detached` should be provided.

--- a/kintsugi/devnets/README.md
+++ b/kintsugi/devnets/README.md
@@ -1,0 +1,18 @@
+# Easy script to join the merge devnet(s)
+This is a setup to run and join the devnet with a single shell command. This script will pull the appropriate images and config and spin up the EL client and lodestar.
+###### Requirements
+1. docker
+2. git
+3. A bash shell
+
+###### Just run the script with arguments
+```bash
+cd kintsugi/devnets
+./setup.sh --dataDir devnet3data --elClient nethermind --devnetVars ./devnet3.vars --dockerWithSudo
+```
+###### Script parameters help
+
+1. `dataDir`: Where you want the script and client's configuration data to be setup. Should be non-existent for the first run. (The directory if already present will skip fetching the configuration, assuming it has done previously). You can also clean indivizual directories of CL/EL between the re-runs.
+2. `elClient`: Which EL client you want, currently working with nethermind
+3. `devnetVars`: Contains the configuration specific to a devnet, like images, or urls for EL/CL to interact. Will be updated with new vars.
+4. `dockerWithSudo`: provide this argument if your docker needs a sudo prefix

--- a/kintsugi/devnets/README.md
+++ b/kintsugi/devnets/README.md
@@ -1,5 +1,6 @@
 # Easy script to join the merge devnet(s)
 This is a setup to run and join the devnet with a single shell command. This script will pull the appropriate images and config and spin up the EL client and lodestar.
+
 ###### Requirements
 1. docker
 2. git
@@ -8,25 +9,26 @@ This is a setup to run and join the devnet with a single shell command. This scr
 ###### Just run the script with arguments
 ```bash
 cd kintsugi/devnets
-./setup.sh --dataDir devnet3-data --elClient nethermind --devnetVars ./devnet3.vars [--dockerWithSudo --withTerminal "gnome-terminal --disable-factory --]"
+./setup.sh --dataDir kintsugi-data --elClient geth --devnetVars ./kintsugi.vars [--dockerWithSudo --withTerminal "gnome-terminal --disable-factory --"]
 ```
 
 ###### Example scenarios
 1. Run with separate terminals launched & attached (best for testing in local) : 
-`./setup.sh --dataDir devnet3data --elClient nethermind --devnetVars ./devnet3.vars --withTerminal "gnome-terminal --disable-factory --" --dockerWithSudo `
-2. Run in terminal attached with logs interleaved (best for testing  in remote shell) : 
-`./setup.sh --dataDir devnet3data --elClient nethermind --devnetVars ./devnet3.vars --dockerWithSudo`
+`./setup.sh --dataDir kintsugi-data --elClient nethermind --devnetVars ./kintsugi.vars --withTerminal "gnome-terminal --disable-factory --" --dockerWithSudo `
+2. Run *in-terminal* attached with logs interleaved (best for testing  in remote shell) : 
+`./setup.sh --dataDir kintsugi-data --elClient nethermind --devnetVars ./kintsugi.vars --dockerWithSudo`
 3. Run detached (best for leaving it to run, typically after testing 1 or 2): 
-`./setup.sh --dataDir devnet3data --elClient nethermind --devnetVars ./devnet3.vars --detached  --dockerWithSudo`
+`./setup.sh --dataDir kintsugi-data --elClient nethermind --devnetVars ./kintsugi.vars --detached  --dockerWithSudo`
+
+You can alternate between `geth` and `nethermind` to experiment with the ELs being out of sync ( and catching up) with `lodestar`.
 
 ###### Script parameters help
-
-1. `dataDir`: Where you want the script and client's configuration data to be setup. Should be non-existent for the first run. (The directory if already present will skip fetching the configuration, assuming it has done previously). You can also clean indivizual directories of CL/EL between the re-runs.
+1. `dataDir`: Where you want the script and client's configuration data to be setup. Should be non-existent one for the first run. (The directory if already present will skip fetching the configuration, assuming it has done previously). You can also clean indivizual directories of CL/EL between the re-runs.
 2. `elClient`: Which EL client you want, currently working with `geth` and `nethermind`
 3. `devnetVars`: Contains the configuration specific to a devnet, like images, or urls for EL/CL to interact. Will be updated with new vars.
 4. `dockerWithSudo`(optional): Provide this argument if your docker needs a sudo prefix
-5. `--withTerminal`(optional): Provide the terminal command prefix for CL and EL processes to run in your favourite terminal. You may use an alias or a terminal launching script as long as it waits for the command it runs till ends and then closes.
-If not provided, it will launch the docker processes in detached mode.
+5. `--withTerminal`(optional): Provide the terminal command prefix for CL and EL processes to run in your favourite terminal. 
+You may use an alias or a terminal launching script as long as it waits for the command it runs till ends and then closes.If not provided, it will launch the docker processes in *in-terminal* mode.
 6. `--detached`(optional): By default the script will wait for processes and use user input (ctrl +c) to end the processes, however you can pass this option to skip this behavior and just return, for e.g. in case you just want to leave it running.
 
 Only one of `--withTerminal` or `--detached` should be provided.

--- a/kintsugi/devnets/README.md
+++ b/kintsugi/devnets/README.md
@@ -8,8 +8,17 @@ This is a setup to run and join the devnet with a single shell command. This scr
 ###### Just run the script with arguments
 ```bash
 cd kintsugi/devnets
-./setup.sh --dataDir devnet3-data --elClient nethermind --devnetVars ./devnet3.vars [--dockerWithSudo --withTerminal "gnome-terminal --disable-factory --"
+./setup.sh --dataDir devnet3-data --elClient nethermind --devnetVars ./devnet3.vars [--dockerWithSudo --withTerminal "gnome-terminal --disable-factory --]"
 ```
+
+###### Example scenarios
+1. Run with separate terminals launched & attached (best for testing in local) : 
+`./setup.sh --dataDir devnet3data --elClient nethermind --devnetVars ./devnet3.vars --withTerminal "gnome-terminal --disable-factory --" --dockerWithSudo `
+2. Run in terminal attached with logs interleaved (best for testing  in remote shell) : 
+`./setup.sh --dataDir devnet3data --elClient nethermind --devnetVars ./devnet3.vars --dockerWithSudo`
+3. Run detached (best for leaving it to run, typically after testing 1 or 2): 
+`./setup.sh --dataDir devnet3data --elClient nethermind --devnetVars ./devnet3.vars --detached  --dockerWithSudo`
+
 ###### Script parameters help
 
 1. `dataDir`: Where you want the script and client's configuration data to be setup. Should be non-existent for the first run. (The directory if already present will skip fetching the configuration, assuming it has done previously). You can also clean indivizual directories of CL/EL between the re-runs.

--- a/kintsugi/devnets/devnet3.vars
+++ b/kintsugi/devnets/devnet3.vars
@@ -1,10 +1,11 @@
 DEVNET_NAME=devnet3
 
-GETH_IMAGE=parithoshj/geth:merge-9a9e416
+GETH_IMAGE=parithoshj/geth:merge-eb2f01c
 NETHERMIND_IMAGE=nethermindeth/nethermind:kintsugi_v3_0.1
-LODESTAR_IMAGE=parithoshj/lodestar:merge-155311b
+LODESTAR_IMAGE=chainsafe/lodestar:next
 
 CONFIG_GIT_DIR=merge-devnet-3/custom_config_data
 
 NETHERMIND_EXTRA_ARGS="--config kintsugi --Init.WebSocketsEnabled=true --JsonRpc.Enabled=true --JsonRpc.EnabledModules=net,eth,consensus,engine,subscribe,web3 --JsonRpc.Port=8545 --JsonRpc.WebSocketsPort=8546 --JsonRpc.Host=0.0.0.0 --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=5000000000 --Init.DiagnosticMode=None"
 LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls http://127.0.0.1:8545"
+GETH_EXTRA_ARGS="--catalyst --http --http.api engine,net,eth --http.port 8545 --ws --ws.api net,eth,engine --ws.port=8546 --ws.addr 0.0.0.0 --allow-insecure-unlock"

--- a/kintsugi/devnets/devnet3.vars
+++ b/kintsugi/devnets/devnet3.vars
@@ -8,4 +8,4 @@ CONFIG_GIT_DIR=merge-devnet-3/custom_config_data
 
 NETHERMIND_EXTRA_ARGS="--config kintsugi --Init.WebSocketsEnabled=true --JsonRpc.Enabled=true --JsonRpc.EnabledModules=net,eth,consensus,engine,subscribe,web3 --JsonRpc.Port=8545 --JsonRpc.WebSocketsPort=8546 --JsonRpc.Host=0.0.0.0 --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=5000000000 --Init.DiagnosticMode=None"
 LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls http://127.0.0.1:8545"
-GETH_EXTRA_ARGS="--catalyst --http --http.api engine,net,eth --http.port 8545 --ws --ws.api net,eth,engine --ws.port=8546 --ws.addr 0.0.0.0 --allow-insecure-unlock"
+GETH_EXTRA_ARGS="--catalyst --http --http.api engine,net,eth --http.port 8545 --ws --ws.api net,eth,engine --ws.port=8546 --ws.addr 0.0.0.0 --allow-insecure-unlock --networkid 1337602"

--- a/kintsugi/devnets/devnet3.vars
+++ b/kintsugi/devnets/devnet3.vars
@@ -1,0 +1,10 @@
+DEVNET_NAME=devnet3
+
+GETH_IMAGE=parithoshj/geth:merge-9a9e416
+NETHERMIND_IMAGE=nethermindeth/nethermind:kintsugi_v3_0.1
+LODESTAR_IMAGE=parithoshj/lodestar:merge-155311b
+
+CONFIG_GIT_DIR=merge-devnet-3/custom_config_data
+
+NETHERMIND_EXTRA_ARGS="--Init.WebSocketsEnabled=true --JsonRpc.Enabled=true --JsonRpc.EnabledModules=net,eth,consensus,engine,subscribe,web3 --JsonRpc.Port=8545 --JsonRpc.WebSocketsPort=8546 --JsonRpc.Host=0.0.0.0 --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=5000000000 --Init.DiagnosticMode=None"
+LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls http://127.0.0.1:8545"

--- a/kintsugi/devnets/devnet3.vars
+++ b/kintsugi/devnets/devnet3.vars
@@ -2,7 +2,7 @@ DEVNET_NAME=devnet3
 
 GETH_IMAGE=parithoshj/geth:merge-9a9e416
 NETHERMIND_IMAGE=nethermindeth/nethermind:kintsugi_v3_0.1
-LODESTAR_IMAGE=parithoshj/lodestar:merge-155311b
+LODESTAR_IMAGE=chainsafe/lodestar:next
 
 CONFIG_GIT_DIR=merge-devnet-3/custom_config_data
 

--- a/kintsugi/devnets/devnet3.vars
+++ b/kintsugi/devnets/devnet3.vars
@@ -2,9 +2,9 @@ DEVNET_NAME=devnet3
 
 GETH_IMAGE=parithoshj/geth:merge-9a9e416
 NETHERMIND_IMAGE=nethermindeth/nethermind:kintsugi_v3_0.1
-LODESTAR_IMAGE=chainsafe/lodestar:next
+LODESTAR_IMAGE=parithoshj/lodestar:merge-155311b
 
 CONFIG_GIT_DIR=merge-devnet-3/custom_config_data
 
-NETHERMIND_EXTRA_ARGS="--Init.WebSocketsEnabled=true --JsonRpc.Enabled=true --JsonRpc.EnabledModules=net,eth,consensus,engine,subscribe,web3 --JsonRpc.Port=8545 --JsonRpc.WebSocketsPort=8546 --JsonRpc.Host=0.0.0.0 --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=5000000000 --Init.DiagnosticMode=None"
+NETHERMIND_EXTRA_ARGS="--config kintsugi --Init.WebSocketsEnabled=true --JsonRpc.Enabled=true --JsonRpc.EnabledModules=net,eth,consensus,engine,subscribe,web3 --JsonRpc.Port=8545 --JsonRpc.WebSocketsPort=8546 --JsonRpc.Host=0.0.0.0 --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=5000000000 --Init.DiagnosticMode=None"
 LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls http://127.0.0.1:8545"

--- a/kintsugi/devnets/devnet3.vars
+++ b/kintsugi/devnets/devnet3.vars
@@ -9,3 +9,4 @@ CONFIG_GIT_DIR=merge-devnet-3/custom_config_data
 NETHERMIND_EXTRA_ARGS="--config kintsugi --Init.WebSocketsEnabled=true --JsonRpc.Enabled=true --JsonRpc.EnabledModules=net,eth,consensus,engine,subscribe,web3 --JsonRpc.Port=8545 --JsonRpc.WebSocketsPort=8546 --JsonRpc.Host=0.0.0.0 --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=5000000000 --Init.DiagnosticMode=None"
 LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls http://127.0.0.1:8545"
 GETH_EXTRA_ARGS="--catalyst --http --http.api engine,net,eth --http.port 8545 --ws --ws.api net,eth,engine --ws.port=8546 --ws.addr 0.0.0.0 --allow-insecure-unlock --networkid 1337602"
+GETH_EXTRA_BOOTNODES="enode://984a51c5c9b2f212e9480b0ea811b62e711271c5928bce2c40857643484dc9474410f5002e34aa95ac48d3f58a1e581b25c592ad50cbf50f871791997c36fd8b@137.184.221.12:30303,"

--- a/kintsugi/devnets/devnet3.vars
+++ b/kintsugi/devnets/devnet3.vars
@@ -6,7 +6,7 @@ LODESTAR_IMAGE=chainsafe/lodestar:next
 
 CONFIG_GIT_DIR=merge-devnet-3
 
-LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls http://127.0.0.1:8545"
+LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls http://127.0.0.1:8545 api.rest.enabled: true api.rest.host: 0.0.0.0"
 
 NETHERMIND_EXTRA_ARGS="--config kintsugi --Init.WebSocketsEnabled=true --JsonRpc.Enabled=true --JsonRpc.EnabledModules=net,eth,consensus,engine,subscribe,web3 --JsonRpc.Port=8545 --JsonRpc.WebSocketsPort=8546 --JsonRpc.Host=0.0.0.0 --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=5000000000 --Init.DiagnosticMode=None"
 

--- a/kintsugi/devnets/kintsugi.vars
+++ b/kintsugi/devnets/kintsugi.vars
@@ -6,7 +6,7 @@ LODESTAR_IMAGE=chainsafe/lodestar:next
 
 CONFIG_GIT_DIR=kintsugi
 
-LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls http://127.0.0.1:8545"
+LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls http://127.0.0.1:8545 api.rest.enabled: true api.rest.host: 0.0.0.0"
 
 NETHERMIND_EXTRA_ARGS="--config kintsugi --Init.WebSocketsEnabled=true --JsonRpc.Enabled=true --JsonRpc.EnabledModules=net,eth,consensus,engine,subscribe,web3 --JsonRpc.Port=8545 --JsonRpc.WebSocketsPort=8546 --JsonRpc.Host=0.0.0.0 --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=5000000000 --Init.DiagnosticMode=None"
 

--- a/kintsugi/devnets/kintsugi.vars
+++ b/kintsugi/devnets/kintsugi.vars
@@ -1,6 +1,6 @@
 DEVNET_NAME=kintsugi
 
-GETH_IMAGE=parithoshj/geth:merge-eb2f01c
+GETH_IMAGE=parithoshj/geth:merge-d99ac5a
 NETHERMIND_IMAGE=nethermindeth/nethermind:kintsugi_v3_0.1
 LODESTAR_IMAGE=chainsafe/lodestar:next
 
@@ -12,4 +12,4 @@ NETHERMIND_EXTRA_ARGS="--config kintsugi --Init.WebSocketsEnabled=true --JsonRpc
 
 GETH_EXTRA_ARGS="--catalyst --http --http.api engine,net,eth --http.port 8545 --ws --ws.api net,eth,engine --ws.port=8546 --ws.addr 0.0.0.0 --allow-insecure-unlock --networkid 1337702"
 
-EXTRA_BOOTNODES=
+EXTRA_BOOTNODES="enode://c20047e975f562131d0211b1a36f955b821663bd83a69edd725b221b70db0d01320716dd6a45d87e4e8afc1bc53439ff001212a70be0f1064db65c82d7ebbc9d@161.35.67.221:30303,enode://a0b9d5f4bc6a30b36a40e64762471e79b37700cb7ac6560680f6192e3360d34c689cf97ad3787256939152fe9f2b28e7d74d76119a86fed356f9c76d4c6301cb@161.35.67.200:30303,"

--- a/kintsugi/devnets/kintsugi.vars
+++ b/kintsugi/devnets/kintsugi.vars
@@ -1,15 +1,15 @@
-DEVNET_NAME=devnet3
+DEVNET_NAME=kintsugi
 
 GETH_IMAGE=parithoshj/geth:merge-eb2f01c
 NETHERMIND_IMAGE=nethermindeth/nethermind:kintsugi_v3_0.1
 LODESTAR_IMAGE=chainsafe/lodestar:next
 
-CONFIG_GIT_DIR=merge-devnet-3
+CONFIG_GIT_DIR=kintsugi
 
 LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls http://127.0.0.1:8545"
 
 NETHERMIND_EXTRA_ARGS="--config kintsugi --Init.WebSocketsEnabled=true --JsonRpc.Enabled=true --JsonRpc.EnabledModules=net,eth,consensus,engine,subscribe,web3 --JsonRpc.Port=8545 --JsonRpc.WebSocketsPort=8546 --JsonRpc.Host=0.0.0.0 --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=5000000000 --Init.DiagnosticMode=None"
 
-GETH_EXTRA_ARGS="--catalyst --http --http.api engine,net,eth --http.port 8545 --ws --ws.api net,eth,engine --ws.port=8546 --ws.addr 0.0.0.0 --allow-insecure-unlock --networkid 1337602"
+GETH_EXTRA_ARGS="--catalyst --http --http.api engine,net,eth --http.port 8545 --ws --ws.api net,eth,engine --ws.port=8546 --ws.addr 0.0.0.0 --allow-insecure-unlock --networkid 1337702"
 
-EXTRA_BOOTNODES="enode://984a51c5c9b2f212e9480b0ea811b62e711271c5928bce2c40857643484dc9474410f5002e34aa95ac48d3f58a1e581b25c592ad50cbf50f871791997c36fd8b@137.184.221.12:30303,"
+EXTRA_BOOTNODES=

--- a/kintsugi/devnets/parse-args.sh
+++ b/kintsugi/devnets/parse-args.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+  	--elClient)
+      elClient="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --dataDir)
+      dataDir="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --devnetVars)
+      devnetVars="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --dockerWithSudo)
+      dockerWithSudo=true
+      shift # past argument
+      ;;
+    *)    # unknown option
+      shift # past argument
+      ;;
+  esac
+done
+
+echo "elClient = $elClient"
+echo "dataDir = $dataDir"
+echo "devnetVars = $devnetVars"
+echo "dockerWithSudo = $dockerWithSudo"

--- a/kintsugi/devnets/parse-args.sh
+++ b/kintsugi/devnets/parse-args.sh
@@ -18,8 +18,17 @@ while [[ $# -gt 0 ]]; do
       shift # past argument
       shift # past value
       ;;
+    --withTerminal)
+      withTerminal="$2"
+      shift # past argument
+      shift # past value
+      ;;
     --dockerWithSudo)
       dockerWithSudo=true
+      shift # past argument
+      ;;
+    --detached)
+      detached=true
       shift # past argument
       ;;
     *)    # unknown option
@@ -31,4 +40,12 @@ done
 echo "elClient = $elClient"
 echo "dataDir = $dataDir"
 echo "devnetVars = $devnetVars"
+echo "withTerminal = $withTerminal"
 echo "dockerWithSudo = $dockerWithSudo"
+echo "detached = $detached"
+
+if [ -n "$withTerminal" ] && [ -n "$detached" ]
+then
+  echo "Only of of --withTerminal or --detached options should be provided, exiting..."
+  exit;
+fi

--- a/kintsugi/devnets/setup.sh
+++ b/kintsugi/devnets/setup.sh
@@ -20,7 +20,7 @@ then
 fi
 
 
-mkdir $dataDir && mkdir $dataDir/lodestar && mkdir $dataDir/$elClient && cd $dataDir && git init && git remote add -f origin $setupConfigUrl && git config core.sparseCheckout true && echo "$configGitDir/*" >> .git/info/sparse-checkout && git pull --depth=1 origin master && cd $currentDir
+mkdir $dataDir && mkdir $dataDir/lodestar && mkdir $dataDir/geth && mkdir $dataDir/nethermind && cd $dataDir && git init && git remote add -f origin $setupConfigUrl && git config core.sparseCheckout true && echo "$configGitDir/*" >> .git/info/sparse-checkout && git pull --depth=1 origin master && cd $currentDir
 
 run_cmd(){
   execCmd=$1;
@@ -61,8 +61,14 @@ fi;
 if [ "$elClient" == "geth" ]
 then
   echo "gethImage: $GETH_IMAGE"
-  echo "Client geth not supported, please try another, exiting ..."
-  exit;
+  elName="$DEVNET_NAME-geth"
+  if [ ! -n "$(ls -A $dataDir/geth)" ]
+  then 
+    echo "setting up geth directory"
+    $dockerExec run --rm -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir/geth:/data $GETH_IMAGE --catalyst --datadir /data init /config/genesis.json
+  fi;
+  bootNode=$(cat $dataDir/$configGitDir/el_bootnode.txt)
+  elCmd="$dockerCmd --rm --name $elName --network host -v $currentDir/$dataDir/geth:/data $GETH_IMAGE --bootnodes $bootNode --datadir /data $GETH_EXTRA_ARGS"
 elif [ "$elClient" == "nethermind" ] 
 then
   echo "nethermindImage: $NETHERMIND_IMAGE"

--- a/kintsugi/devnets/setup.sh
+++ b/kintsugi/devnets/setup.sh
@@ -68,7 +68,7 @@ then
     $dockerExec run --rm -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir/geth:/data $GETH_IMAGE --catalyst --datadir /data init /config/genesis.json
   fi;
   bootNode=$(cat $dataDir/$configGitDir/el_bootnode.txt)
-  elCmd="$dockerCmd --rm --name $elName --network host -v $currentDir/$dataDir/geth:/data $GETH_IMAGE --bootnodes $bootNode --datadir /data $GETH_EXTRA_ARGS"
+  elCmd="$dockerCmd --rm --name $elName --network host -v $currentDir/$dataDir/geth:/data $GETH_IMAGE --bootnodes $GETH_EXTRA_BOOTNODES$bootNode --datadir /data $GETH_EXTRA_ARGS"
 elif [ "$elClient" == "nethermind" ] 
 then
   echo "nethermindImage: $NETHERMIND_IMAGE"

--- a/kintsugi/devnets/setup.sh
+++ b/kintsugi/devnets/setup.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -e
+
+source parse-args.sh
+source ./devnet3.vars
+
+currentDir=$(pwd)
+setupConfigUrl=https://github.com/parithosh/consensus-deployment-ansible.git
+
+configGitDir=$CONFIG_GIT_DIR
+
+gethImage=$GETH_IMAGE
+nethermindImage=$NETHERMIND_IMAGE
+lodestarImage=$LODESTAR_IMAGE
+
+if [ ! -n "$dataDir" ] || [ ! -n "$devnetVars" ] || ([ "$elClient" != "geth" ] && [ "$elClient" != "nethermind" ]) 
+then
+  echo "usage: ./setup.sh --dataDir <data dir> --elClient <geth | nethermind> --devetVars <devnet vars file> --dockerWithSudo (if your docker comands require sudo)"
+  echo "example: ./setup.sh --dataDir devnet3data --elClient nethermind --devnetVars ./devnet3.vars"
+  exit;
+fi
+
+if [ -n "$dockerWithSudo" ]
+then 
+  dockerCmd="sudo docker"
+else 
+  dockerCmd="docker"
+fi;
+
+mkdir $dataDir && mkdir $dataDir/lodestar && mkdir $dataDir/$elClient && cd $dataDir && git init && git remote add -f origin $setupConfigUrl && git config core.sparseCheckout true && echo "$configGitDir/*" >> .git/info/sparse-checkout && git pull --depth=1 origin master && cd $currentDir
+
+
+bootEnr=$(cat $dataDir/$configGitDir/bootstrap_nodes.txt)
+
+
+if [ "$elClient" == "geth" ]
+then
+  echo "gethImage: $gethImage"  
+elif [ "$elClient" == "nethermind" ] 
+then
+  echo "nethermindImage: $nethermindImage"
+  elName="$DEVNET_NAME-nethermind"
+  elCmd="$dockerCmd run --rm --name $elName -it --network host -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir/nethermind:/data $nethermindImage --datadir /data --config kintsugi  --Init.ChainSpecPath=/config/nethermind_genesis.json $NETHERMIND_EXTRA_ARGS"
+fi
+
+echo "lodestarImage: $lodestarImage"
+
+echo "running: $elCmd"
+gnome-terminal --disable-factory -- $elCmd &
+elPid=$!
+
+echo "elPid= $elPid"
+
+
+
+clName="$DEVNET_NAME-lodestar"
+clCmd="$dockerCmd run --rm --name $clName -it --network host -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir/lodestar:/data $lodestarImage beacon --rootDir /data --paramsFile /config/config.yaml --genesisStateFile /config/genesis.ssz --network.discv5.bootEnrs $bootEnr --network.connectToDiscv5Bootnodes --network.discv5.enabled true --eth1.enabled true --eth1.disableEth1DepositDataTracker true $LODESTAR_EXTRA_ARGS"
+
+echo "running: $clCmd"
+gnome-terminal --disable-factory -- $clCmd &
+clPid=$!
+
+echo "clPid= $clPid"
+
+cleanup() {
+  echo "cleaning up"
+  $dockerCmd rm $elName -f
+  $dockerCmd rm $clName -f
+  elPid=null
+  clPid=null
+  # Our cleanup code goes here
+}
+
+trap "echo exit signal recived;cleanup" SIGINT SIGTERM
+
+if [ -n "$elPid" ] && [ -n "$clPid" ] 
+then 
+	echo "launched two terminals for el and cl clients with elPid: $elPid clPid: $clPid"
+	echo "you can watch observe the client logs at the respective terminals"
+	echo "use ctl + c on any of these three (including this) terminals to stop the process"
+	echo "waiting ..."
+	wait -n $elPid $clPid
+	cleanup
+fi;
+
+if [ -n "$elPid$clPid" ]
+then
+	echo "one of the el or cl process exited, stopping and cleanup"
+	cleanup
+fi;

--- a/kintsugi/devnets/setup.sh
+++ b/kintsugi/devnets/setup.sh
@@ -2,10 +2,10 @@
 # set -e
 
 source parse-args.sh
-source ./devnet3.vars
+source $devnetVars
 
 currentDir=$(pwd)
-setupConfigUrl=https://github.com/parithosh/consensus-deployment-ansible.git
+setupConfigUrl=https://github.com/eth-clients/merge-testnets.git
 
 configGitDir=$CONFIG_GIT_DIR
 
@@ -15,12 +15,21 @@ nethermindImage=$NETHERMIND_IMAGE
 if [ ! -n "$dataDir" ] || [ ! -n "$devnetVars" ] || ([ "$elClient" != "geth" ] && [ "$elClient" != "nethermind" ]) 
 then
   echo "usage: ./setup.sh --dataDir <data dir> --elClient <geth | nethermind> --devetVars <devnet vars file> [--dockerWithSudo --withTerminal \"gnome-terminal --disable-factory --\"]"
-  echo "example: ./setup.sh --dataDir devnet3data --elClient nethermind --devnetVars ./devnet3.vars --dockerWithSudo --withTerminal \"gnome-terminal --disable-factory --\""
+  echo "example: ./setup.sh --dataDir kintsugi-data --elClient nethermind --devnetVars ./kintsugi.vars --dockerWithSudo --withTerminal \"gnome-terminal --disable-factory --\""
   exit;
 fi
 
 
-mkdir $dataDir && mkdir $dataDir/lodestar && mkdir $dataDir/geth && mkdir $dataDir/nethermind && cd $dataDir && git init && git remote add -f origin $setupConfigUrl && git config core.sparseCheckout true && echo "$configGitDir/*" >> .git/info/sparse-checkout && git pull --depth=1 origin master && cd $currentDir
+mkdir $dataDir && mkdir $dataDir/lodestar && mkdir $dataDir/geth && mkdir $dataDir/nethermind && cd $dataDir && git init && git remote add -f origin $setupConfigUrl && git config core.sparseCheckout true && echo "$configGitDir/*" >> .git/info/sparse-checkout && git pull --depth=1 origin main && cd $currentDir
+
+if [ ! -n "$(ls -A $dataDir/$configGitDir)" ] || [ ! -n "$(ls -A $dataDir/$configGitDir/genesis.json)" ] || [ ! -n "$(ls -A $dataDir/$configGitDir/genesis.ssz)" ] || [ ! -n "$(ls -A $dataDir/$configGitDir/nethermind_genesis.json)" ] || [ ! -n "$(ls -A $dataDir/$configGitDir/el_bootnode.txt)" ] || [ ! -n "$(ls -A $dataDir/$configGitDir/bootstrap_nodes.txt)" ]
+then
+  echo "Configuration directory not setup properly, remove the data directory and run again."
+  echo "exiting ..."
+  exit;
+else 
+  echo "Configuration discovered!"
+fi;
 
 run_cmd(){
   execCmd=$1;
@@ -58,33 +67,38 @@ then
   dockerCmd="$dockerCmd -it" 
 fi;
 
+
+bootNode=$(cat $dataDir/$configGitDir/el_bootnode.txt)
 if [ "$elClient" == "geth" ]
 then
   echo "gethImage: $GETH_IMAGE"
+  $dockerExec pull $GETH_IMAGE
   elName="$DEVNET_NAME-geth"
   if [ ! -n "$(ls -A $dataDir/geth)" ]
   then 
     echo "setting up geth directory"
     $dockerExec run --rm -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir/geth:/data $GETH_IMAGE --catalyst --datadir /data init /config/genesis.json
   fi;
-  bootNode=$(cat $dataDir/$configGitDir/el_bootnode.txt)
-  elCmd="$dockerCmd --rm --name $elName --network host -v $currentDir/$dataDir/geth:/data $GETH_IMAGE --bootnodes $GETH_EXTRA_BOOTNODES$bootNode --datadir /data $GETH_EXTRA_ARGS"
+  elCmd="$dockerCmd --rm --name $elName --network host -v $currentDir/$dataDir/geth:/data $GETH_IMAGE --bootnodes $EXTRA_BOOTNODES$bootNode --datadir /data $GETH_EXTRA_ARGS"
 elif [ "$elClient" == "nethermind" ] 
 then
   echo "nethermindImage: $NETHERMIND_IMAGE"
+  $dockerExec pull $NETHERMIND_IMAGE
   elName="$DEVNET_NAME-nethermind"
-  elCmd="$dockerCmd --rm --name $elName --network host -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir/nethermind:/data $NETHERMIND_IMAGE --datadir /data  --Init.ChainSpecPath=/config/nethermind_genesis.json $NETHERMIND_EXTRA_ARGS"
+  elCmd="$dockerCmd --rm --name $elName --network host -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir/nethermind:/data $NETHERMIND_IMAGE --datadir /data  --Init.ChainSpecPath=/config/nethermind_genesis.json $NETHERMIND_EXTRA_ARGS --Discovery.Bootnodes $EXTRA_BOOTNODES$bootNode"
 fi
+
+echo "lodestarImage: $LODESTAR_IMAGE"
+$dockerExec pull $LODESTAR_IMAGE
+bootEnr=$(cat $dataDir/$configGitDir/bootstrap_nodes.txt)
+clName="$DEVNET_NAME-lodestar"
+clCmd="$dockerCmd --rm --name $clName --network host -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir/lodestar:/data $LODESTAR_IMAGE beacon --rootDir /data --paramsFile /config/config.yaml --genesisStateFile /config/genesis.ssz --network.discv5.bootEnrs $bootEnr --network.connectToDiscv5Bootnodes --network.discv5.enabled true --eth1.enabled true --eth1.disableEth1DepositDataTracker true $LODESTAR_EXTRA_ARGS"
+
 
 run_cmd "$elCmd"
 elPid=$!
 echo "elPid= $elPid"
 
-
-echo "lodestarImage: $LODESTAR_IMAGE"
-bootEnr=$(cat $dataDir/$configGitDir/bootstrap_nodes.txt)
-clName="$DEVNET_NAME-lodestar"
-clCmd="$dockerCmd --rm --name $clName --network host -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir/lodestar:/data $LODESTAR_IMAGE beacon --rootDir /data --paramsFile /config/config.yaml --genesisStateFile /config/genesis.ssz --network.discv5.bootEnrs $bootEnr --network.connectToDiscv5Bootnodes --network.discv5.enabled true --eth1.enabled true --eth1.disableEth1DepositDataTracker true $LODESTAR_EXTRA_ARGS"
 
 run_cmd "$clCmd"
 clPid=$!


### PR DESCRIPTION
# Easy script to join the merge devnet(s)
This is a setup to run and join the devnet with a single shell command. This script will pull the appropriate images and config and spin up the EL client and lodestar.

###### Requirements
1. docker
2. git
3. A bash shell

###### Just run the script with arguments
```bash
cd kintsugi/devnets
./setup.sh --dataDir kintsugi-data --elClient geth --devnetVars ./kintsugi.vars [--dockerWithSudo --withTerminal "gnome-terminal --disable-factory --"]
```

###### Example scenarios
1. Run with separate terminals launched & attached (best for testing in local) : 
`./setup.sh --dataDir kintsugi-data --elClient nethermind --devnetVars ./kintsugi.vars --withTerminal "gnome-terminal --disable-factory --" --dockerWithSudo `
2. Run *in-terminal* attached with logs interleaved (best for testing  in remote shell) : 
`./setup.sh --dataDir kintsugi-data --elClient nethermind --devnetVars ./kintsugi.vars --dockerWithSudo`
3. Run detached (best for leaving it to run, typically after testing 1 or 2): 
`./setup.sh --dataDir kintsugi-data --elClient nethermind --devnetVars ./kintsugi.vars --detached  --dockerWithSudo`

You can alternate between `geth` and `nethermind` to experiment with the ELs being out of sync ( and catching up) with `lodestar`.

###### Script parameters help
1. `dataDir`: Where you want the script and client's configuration data to be setup. Should be non-existent one for the first run. (The directory if already present will skip fetching the configuration, assuming it has done previously). You can also clean indivizual directories of CL/EL between the re-runs.
2. `elClient`: Which EL client you want, currently working with `geth` and `nethermind`
3. `devnetVars`: Contains the configuration specific to a devnet, like images, or urls for EL/CL to interact. Will be updated with new vars.
4. `dockerWithSudo`(optional): Provide this argument if your docker needs a sudo prefix
5. `--withTerminal`(optional): Provide the terminal command prefix for CL and EL processes to run in your favourite terminal. 
You may use an alias or a terminal launching script as long as it waits for the command it runs till ends and then closes.If not provided, it will launch the docker processes in *in-terminal* mode.
6. `--detached`(optional): By default the script will wait for processes and use user input (ctrl +c) to end the processes, however you can pass this option to skip this behavior and just return, for e.g. in case you just want to leave it running.

Only one of `--withTerminal` or `--detached` should be provided.
