### PR TITLE
Reduce max old space size to 4096

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN /usr/app/node_modules/.bin/lodestar --help
 # NodeJS applications have a default memory limit of 2.5GB.
 # This limit is bit tight for a Prater node, it is recommended to raise the limit
 # since memory may spike during certain network conditions.
-ENV NODE_OPTIONS=--max_old_space_size=6144
+ENV NODE_OPTIONS=--max-old-space-size=4096
 
 ENTRYPOINT ["node", "/usr/app/node_modules/.bin/lodestar"]

--- a/amphora/m3/docker-compose.yml
+++ b/amphora/m3/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     # This limit is bit tight for a Prater node, it is recommended to raise the limit
     # since memory may spike during certain network conditions.
     environment:
-      NODE_OPTIONS: --max_old_space_size=6144
+      NODE_OPTIONS: --max-old-space-size=4096
       LODESTAR_PRESET: minimal
 
   geth:

--- a/docker-compose.validator.yml
+++ b/docker-compose.validator.yml
@@ -12,7 +12,7 @@ services:
     # A validator client requires very little memory. This limit allows to run the validator
     # along with the beacon_node in a 8GB machine and be safe on memory spikes.
     environment:
-      NODE_OPTIONS: --max_old_space_size=2048
+      NODE_OPTIONS: --max-old-space-size=2048
 
 volumes:
   validator:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     # This limit is bit tight for a Prater node, it is recommended to raise the limit
     # since memory may spike during certain network conditions.
     environment:
-      NODE_OPTIONS: --max_old_space_size=6144
+      NODE_OPTIONS: --max-old-space-size=4096
 
   prometheus:
     build: docker/prometheus

--- a/docker/from_source.Dockerfile
+++ b/docker/from_source.Dockerfile
@@ -39,6 +39,6 @@ COPY --from=build /usr/app .
 # NodeJS applications have a default memory limit of 2.5GB.
 # This limit is bit tight for a Prater node, it is recommended to raise the limit
 # since memory may spike during certain network conditions.
-ENV NODE_OPTIONS=--max_old_space_size=6144
+ENV NODE_OPTIONS=--max-old-space-size=4096
 
 ENTRYPOINT ["node", "./packages/cli/bin/lodestar"]

--- a/lodestar
+++ b/lodestar
@@ -4,4 +4,4 @@
 #
 # ./lodestar.sh beacon --network prater
 
-node --trace-deprecation --max-old-space-size=6144 ./packages/cli/bin/lodestar "$@"
+node --trace-deprecation --max-old-space-size=4096 ./packages/cli/bin/lodestar "$@"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:spec-fast": "lerna run test:spec-fast --no-bail",
     "test:spec-main": "lerna run test:spec-main --no-bail",
     "benchmark": "yarn benchmark:files 'packages/*/test/perf/**/*.test.ts'",
-    "benchmark:files": "LODESTAR_PRESET=mainnet NODE_OPTIONS=--max_old_space_size=4096 benchmark --config .benchrc.yaml",
+    "benchmark:files": "LODESTAR_PRESET=mainnet NODE_OPTIONS=--max-old-space-size=4096 benchmark --config .benchrc.yaml",
     "publish:release": "lerna publish from-package --yes --no-verify-access",
     "release": "lerna version --no-push --sign-git-commit",
     "postrelease": "git tag -d $(git describe --abbrev=0)",


### PR DESCRIPTION
**Motivation**

There's a 1.5GB difference between total process memory and the heap used old-space-size. Current old-space-size value of 6000 causes machines with 8GB of ram to never OOM but stall.

Part of https://github.com/ChainSafe/lodestar/issues/3515

**Description**

Reduce max old space size to 4096.

- Testing shows that old space size oscillates between 1.5GB and 2GB. A 4GB wide safety margin
- Machines with 8GB will OOM when there's memory issues

![Screenshot from 2021-12-13 17-59-25](https://user-images.githubusercontent.com/35266934/145862753-ccb21de0-e793-4f76-a145-62371f3d33d0.png)