### PR TITLE
Fix peer score serialization

### DIFF
--- a/packages/lodestar/src/network/peers/metastore.ts
+++ b/packages/lodestar/src/network/peers/metastore.ts
@@ -45,12 +45,16 @@ export class Libp2pPeerMetadataStore implements IPeerMetadataStore {
       serialize: (v) => Buffer.from(v, "utf8"),
       deserialize: (b) => Buffer.from(b).toString("utf8") as ReqRespEncoding,
     };
+    const floatSerdes: BucketSerdes<number> = {
+      serialize: (f) => Buffer.from(String(f), "utf8"),
+      deserialize: (b) => parseFloat(Buffer.from(b).toString("utf8")),
+    };
 
     this.encoding = this.typedStore("encoding", stringSerdes);
     // Discard existing `metadata` stored values. Store both phase0 and altair Metadata objects as altair
     // Serializing altair.Metadata instead of phase0.Metadata has a cost of just `SYNC_COMMITTEE_SUBNET_COUNT // 8` bytes
     this.metadata = this.typedStore("metadata-altair", metadataV2Serdes);
-    this.rpcScore = this.typedStore("score", number64Serdes);
+    this.rpcScore = this.typedStore("score", floatSerdes);
     this.rpcScoreLastUpdate = this.typedStore("score-last-update", number64Serdes);
   }
 

--- a/packages/lodestar/src/network/reqresp/score.ts
+++ b/packages/lodestar/src/network/reqresp/score.ts
@@ -12,6 +12,14 @@ const libp2pErrorCodes = {
   ERR_UNSUPPORTED_PROTOCOL: "ERR_UNSUPPORTED_PROTOCOL",
 };
 
+/**
+ * Multi stream select error code
+ * https://github.com/multiformats/js-multistream-select/blame/cf4e297b362a43bde2ea117085ceba78cbce1c12/src/select.js#L50
+ */
+const multiStreamSelectErrorCodes = {
+  protocolSelectionFailed: "protocol selection failed",
+};
+
 export function onOutgoingReqRespError(e: Error, method: Method): PeerAction | null {
   if (e instanceof RequestError) {
     switch (e.type.code) {
@@ -25,8 +33,9 @@ export function onOutgoingReqRespError(e: Error, method: Method): PeerAction | n
 
       case RequestErrorCode.DIAL_TIMEOUT:
       case RequestErrorCode.DIAL_ERROR:
-        return PeerAction.LowToleranceError;
-
+        return e.message.includes(multiStreamSelectErrorCodes.protocolSelectionFailed) && method === Method.Ping
+          ? PeerAction.Fatal
+          : PeerAction.LowToleranceError;
       // TODO: Detect SSZDecodeError and return PeerAction.Fatal
 
       case RequestErrorCode.TTFB_TIMEOUT:


### PR DESCRIPTION
**Motivation**

+ When there are a lot of `DIAL_ERROR`, I don't see we say goodbye to peers with "Peer score too low" or "Peer banned"
+ We can't dial some peers with `"protocol selection failed"` and it's still in our connected peer without being banned

**Description**

+ Right now we use `ssz.Number64` type to serialize/deserialize peer score which is float, a peer score of `-20` is serialized and deserialized back as a very big uint64

+ Use a new `floatSerdes` which is similar to `stringSerdes` but we parse float as an extra step

+ If method is `ping` and we get `"protocol selection failed"`, ban the peer immediately

Closes #3517

**Tested in contabo-19**
<img width="768" alt="Screen Shot 2021-12-15 at 15 36 01" src="https://user-images.githubusercontent.com/10568965/146151971-567806bb-3824-4ea1-b9a8-3a362cea3a82.png">
