### PR TITLE
Fix interaction between slashings and exits in block production

### DIFF
--- a/packages/lodestar/src/chain/factory/block/body.ts
+++ b/packages/lodestar/src/chain/factory/block/body.ts
@@ -61,8 +61,7 @@ export async function assembleBody(
   //   }
   // }
 
-  const [attesterSlashings, proposerSlashings] = chain.opPool.getSlashings(currentState);
-  const voluntaryExits = chain.opPool.getVoluntaryExits(currentState);
+  const [attesterSlashings, proposerSlashings, voluntaryExits] = chain.opPool.getSlashingsAndExits(currentState);
   const attestations = chain.aggregatedAttestationPool.getAttestationsForBlock(currentState);
   const {eth1Data, deposits} = await chain.eth1.getEth1DataAndDeposits(
     currentState as CachedBeaconState<allForks.BeaconState>

--- a/packages/lodestar/src/chain/opPools/opPool.ts
+++ b/packages/lodestar/src/chain/opPools/opPool.ts
@@ -156,7 +156,7 @@ export class OpPool {
 
       // If there were slashable indices in this slashing
       // Then include the slashing and count the slashable indices
-      if (slashableIndices.size) {
+      if (slashableIndices.size > 0) {
         attesterSlashings.push(attesterSlashing.attesterSlashing);
         for (const index of slashableIndices) {
           toBeSlashedIndices.add(index);

--- a/packages/lodestar/test/unit/chain/factory/block/body.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/block/body.test.ts
@@ -45,12 +45,12 @@ describe("blockAssembly - body", function () {
 
   it("should generate block body", async function () {
     const {chain, opPool, dbStub, aggregatedAttestationPool} = getStubs();
-    opPool.getSlashings.returns([
+    opPool.getSlashingsAndExits.returns([
       [ssz.phase0.AttesterSlashing.defaultValue()],
       [ssz.phase0.ProposerSlashing.defaultValue()],
+      [generateEmptySignedVoluntaryExit()],
     ]);
     aggregatedAttestationPool.getAttestationsForBlock.returns([generateEmptyAttestation()]);
-    opPool.getVoluntaryExits.returns([generateEmptySignedVoluntaryExit()]);
     dbStub.depositDataRoot.getTreeBacked.resolves(ssz.phase0.DepositDataRootList.defaultTreeBacked());
 
     const result = await assembleBody(chain, generateCachedState(), {


### PR DESCRIPTION
**Motivation**

See note in the specs: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/validator.md#voluntary-exits

**Description**

During block production, ensure that no two slashings or voluntary exits refer to the same validator.