### PR TITLE
Update pre-merge block proposing logic

### DIFF
--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -180,7 +180,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
 
       timer = metrics?.blockProductionTime.startTimer();
       const block = await assembleBlock(
-        {chain, metrics, logger},
+        {chain, metrics},
         {
           slot,
           randaoReveal,

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -6,7 +6,6 @@ import {CachedBeaconState, allForks} from "@chainsafe/lodestar-beacon-state-tran
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {Bytes32, Bytes96, ExecutionAddress, Root, Slot} from "@chainsafe/lodestar-types";
 import {fromHexString} from "@chainsafe/ssz";
-import {ILogger} from "@chainsafe/lodestar-utils";
 
 import {ZERO_HASH} from "../../../constants";
 import {IMetrics} from "../../../metrics";
@@ -17,11 +16,10 @@ import {RegenCaller} from "../../regen";
 type AssembleBlockModules = {
   chain: IBeaconChain;
   metrics: IMetrics | null;
-  logger?: ILogger | null;
 };
 
 export async function assembleBlock(
-  {chain, metrics, logger}: AssembleBlockModules,
+  {chain, metrics}: AssembleBlockModules,
   {
     randaoReveal,
     graffiti,
@@ -43,19 +41,14 @@ export async function assembleBlock(
     proposerIndex: state.getBeaconProposer(slot),
     parentRoot: parentBlockRoot,
     stateRoot: ZERO_HASH,
-    body: await assembleBody(
-      chain,
-      state,
-      {
-        randaoReveal,
-        graffiti,
-        blockSlot: slot,
-        parentSlot: slot - 1,
-        parentBlockRoot,
-        feeRecipient,
-      },
-      logger
-    ),
+    body: await assembleBody(chain, state, {
+      randaoReveal,
+      graffiti,
+      blockSlot: slot,
+      parentSlot: slot - 1,
+      parentBlockRoot,
+      feeRecipient,
+    }),
   };
 
   block.stateRoot = computeNewStateRoot({config: chain.config, metrics}, state, block);


### PR DESCRIPTION
**Motivation**

Current approach is correct but it logs expected situations to console. This simplification assumes that the `eth1MergeBlockFinder` will log errors if the execution client is missbehaving. This assumption is fine since otherwise our node won't be able to follow the chain

**Description**

Update pre-merge block proposing logic