### PR TITLE
Use attestation head state to validate attestations

### DIFF
--- a/packages/lodestar/src/chain/errors/attestationError.ts
+++ b/packages/lodestar/src/chain/errors/attestationError.ts
@@ -118,9 +118,9 @@ export enum AttestationErrorCode {
    */
   COMMITTEE_INDEX_OUT_OF_RANGE = "ATTESTATION_ERROR_COMMITTEE_INDEX_OUT_OF_RANGE",
   /**
-   * Missing attestation pre-state.
+   * Missing attestation head state
    */
-  MISSING_ATTESTATION_TARGET_STATE = "ATTESTATION_ERROR_MISSING_ATTESTATION_TARGET_STATE",
+  MISSING_ATTESTATION_HEAD_STATE = "ATTESTATION_ERROR_MISSING_ATTESTATION_HEAD_STATE",
   /**
    * Invalid aggregator.
    */
@@ -160,7 +160,7 @@ export type AttestationErrorType =
   | {code: AttestationErrorCode.INVALID_TARGET_ROOT; targetRoot: RootHex; expected: string | null}
   | {code: AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK}
   | {code: AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE; index: number}
-  | {code: AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE; error: Error}
+  | {code: AttestationErrorCode.MISSING_ATTESTATION_HEAD_STATE; error: Error}
   | {code: AttestationErrorCode.INVALID_AGGREGATOR}
   | {code: AttestationErrorCode.INVALID_INDEXED_ATTESTATION};
 

--- a/packages/lodestar/src/chain/validation/attestation.ts
+++ b/packages/lodestar/src/chain/validation/attestation.ts
@@ -72,7 +72,7 @@ export async function validateGossipAttestation(
 
   // [IGNORE] The block being voted for (attestation.data.beacon_block_root) has been seen (via both gossip
   // and non-gossip sources) (a client MAY queue attestations for processing once block is retrieved).
-  verifyHeadBlockAndTargetRoot(chain, attData.beaconBlockRoot, attTarget.root, attEpoch);
+  const attHeadBlock = verifyHeadBlockAndTargetRoot(chain, attData.beaconBlockRoot, attTarget.root, attEpoch);
 
   // [REJECT] The block being voted for (attestation.data.beacon_block_root) passes validation.
   // > Altready check in `verifyHeadBlockAndTargetRoot()`
@@ -85,11 +85,11 @@ export async function validateGossipAttestation(
   //  --i.e. get_ancestor(store, attestation.data.beacon_block_root, compute_start_slot_at_epoch(attestation.data.target.epoch)) == attestation.data.target.root
   // > Altready check in `verifyHeadBlockAndTargetRoot()`
 
-  const attestationTargetState = await chain.regen
-    .getCheckpointState(attTarget, RegenCaller.validateGossipAttestation)
+  const attHeadState = await chain.regen
+    .getState(attHeadBlock.stateRoot, RegenCaller.validateGossipAttestation)
     .catch((e: Error) => {
       throw new AttestationError(GossipAction.REJECT, {
-        code: AttestationErrorCode.MISSING_ATTESTATION_TARGET_STATE,
+        code: AttestationErrorCode.MISSING_ATTESTATION_HEAD_STATE,
         error: e as Error,
       });
     });
@@ -97,7 +97,7 @@ export async function validateGossipAttestation(
   // [REJECT] The committee index is within the expected range
   // -- i.e. data.index < get_committee_count_per_slot(state, data.target.epoch)
   const attIndex = attData.index;
-  const committeeIndices = getCommitteeIndices(attestationTargetState, attSlot, attIndex);
+  const committeeIndices = getCommitteeIndices(attHeadState, attSlot, attIndex);
   const validatorIndex = committeeIndices[bitIndex];
 
   // [REJECT] The number of aggregation bits matches the committee size
@@ -116,7 +116,7 @@ export async function validateGossipAttestation(
   // -- i.e. compute_subnet_for_attestation(committees_per_slot, attestation.data.slot, attestation.data.index) == subnet_id,
   // where committees_per_slot = get_committee_count_per_slot(state, attestation.data.target.epoch),
   // which may be pre-computed along with the committee information for the signature check.
-  const expectedSubnet = computeSubnetForSlot(attestationTargetState, attSlot, attIndex);
+  const expectedSubnet = computeSubnetForSlot(attHeadState, attSlot, attIndex);
   if (subnet !== null && subnet !== expectedSubnet) {
     throw new AttestationError(GossipAction.REJECT, {
       code: AttestationErrorCode.INVALID_SUBNET_ID,
@@ -141,7 +141,7 @@ export async function validateGossipAttestation(
     data: attData,
     signature: attestation.signature,
   };
-  const signatureSet = getIndexedAttestationSignatureSet(attestationTargetState, indexedAttestation);
+  const signatureSet = getIndexedAttestationSignatureSet(attHeadState, indexedAttestation);
   if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true}))) {
     throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.INVALID_SIGNATURE});
   }
@@ -206,9 +206,10 @@ export function verifyHeadBlockAndTargetRoot(
   beaconBlockRoot: Root,
   targetRoot: Root,
   attestationEpoch: Epoch
-): void {
+): IProtoBlock {
   const headBlock = verifyHeadBlockIsKnown(chain, beaconBlockRoot);
   verifyAttestationTargetRoot(headBlock, targetRoot, attestationEpoch);
+  return headBlock;
 }
 
 /**

--- a/packages/lodestar/test/utils/validationData/attestation.ts
+++ b/packages/lodestar/test/utils/validationData/attestation.ts
@@ -107,7 +107,7 @@ export function getAttestationValidData(
 
   // Add state to regen
   const regen = ({
-    getCheckpointState: async () => (state as unknown) as CachedBeaconState<allForks.BeaconState>,
+    getState: async () => (state as unknown) as CachedBeaconState<allForks.BeaconState>,
   } as Partial<IStateRegenerator>) as IStateRegenerator;
 
   const chain = ({


### PR DESCRIPTION
**Motivation**

+ We have multiple epoch transitions per epoch due to the call of `regen.getCheckpointState()` when validating attestation and AggregateAndProof

**Description**

+ The additional epoch transitions come from an out-of-sync node where the headBlockRoot belongs to old epochs

+ The more attestations like that, the more epoch transitions we have. I used to see we have 6-7 epoch transitions in just 2 minutes

+ In all scenarios, using the state at block root yields the same result to the current `getCheckpointState()`, and we don't need any additional epoch transition for it

+ Teku also uses the state at block root for that validation https://github.com/ConsenSys/teku/blob/85af19f4ac8398d62061dbfc77f27281000df6c1/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/AggregateAttestationValidator.java#L103

Closes #3276

**Test Result**

+ Epoch transition shows that there is exactly 1 epoch transition per epoch
<img width="794" alt="Screen Shot 2021-12-17 at 08 53 52" src="https://user-images.githubusercontent.com/10568965/146475826-b194a30e-2826-4e45-93ce-0b6a0d6776f2.png">

+ This shows "process restart" time
<img width="809" alt="Screen Shot 2021-12-17 at 08 57 23" src="https://user-images.githubusercontent.com/10568965/146476258-3247ed0f-62d7-4de9-b01c-1b24ecfa4be7.png">

+ Memory is managed better in a `"subscribeAllSubnets"` node
<img width="799" alt="Screen Shot 2021-12-17 at 08 55 11" src="https://user-images.githubusercontent.com/10568965/146475975-7689da67-9887-419b-9105-300866ad01fe.png">

+ Number of processed attestation/AggregateAndProof gossip messages are the same
<img width="780" alt="Screen Shot 2021-12-17 at 08 58 52" src="https://user-images.githubusercontent.com/10568965/146476383-b863ff86-7545-46f9-b007-8d13056281c9.png">


