### PR TITLE
Don't precompute epoch transition at pre genesis

### DIFF
--- a/packages/lodestar/src/chain/precomputeNextEpochTransition.ts
+++ b/packages/lodestar/src/chain/precomputeNextEpochTransition.ts
@@ -49,6 +49,8 @@ export class PrecomputeNextEpochTransitionScheduler {
 
     const {slot: headSlot, blockRoot} = this.chain.forkChoice.getHead();
     const nextEpoch = computeEpochAtSlot(clockSlot) + 1;
+    // Don't want to pre compute epoch transition at pre genesis
+    if (nextEpoch <= 0) return;
     // node may be syncing or out of synced
     if (headSlot < clockSlot) {
       this.metrics?.precomputeNextEpochTransition.count.inc({result: "skip"}, 1);


### PR DESCRIPTION
**Motivation**

Fix this error when running kinsugi at pregenesis:

```
ec-16 11:03:26.004 [CHAIN]           error: Failed to precompute epoch transition -19 message=REGEN_ERROR_SLOT_BEFORE_BLOCK_SLOT
Error: REGEN_ERROR_SLOT_BEFORE_BLOCK_SLOT
    at StateRegenerator.getBlockSlotState (/usr/app/node_modules/@chainsafe/lodestar/src/chain/regen/regen.ts:96:13)
    at JobItemQueue.QueuedStateRegenerator.jobQueueProcessor [as itemProcessor] (/usr/app/node_modules/@chainsafe/lodestar/src/chain/regen/queued.ts:152:35)
    at Timeout.JobItemQueue.runJob [as _onTimeout] (/usr/app/node_modules/@chainsafe/lodestar/src/util/queue/itemQueue.ts:85:33)
    at listOnTimeout (node:internal/timers:557:17)
    at processTimers (node:internal/timers:500:7)
```
