### PR TITLE
Log attestation's journey published by local validators

### DIFF
--- a/packages/lodestar/src/api/impl/beacon/pool/index.ts
+++ b/packages/lodestar/src/api/impl/beacon/pool/index.ts
@@ -42,6 +42,7 @@ export function getBeaconPoolApi({
     },
 
     async submitPoolAttestations(attestations) {
+      const seenTimestampSec = Date.now() / 1000;
       const errors: Error[] = [];
 
       await Promise.all(
@@ -51,7 +52,7 @@ export function getBeaconPoolApi({
 
             chain.attestationPool.add(attestation);
             const sentPeers = await network.gossip.publishBeaconAttestation(attestation, subnet);
-            metrics?.submitUnaggregatedAttestation(indexedAttestation, subnet, sentPeers);
+            metrics?.submitUnaggregatedAttestation(seenTimestampSec, indexedAttestation, subnet, sentPeers);
           } catch (e) {
             errors.push(e as Error);
             logger.error(

--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -423,6 +423,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
     async publishAggregateAndProofs(signedAggregateAndProofs) {
       notWhileSyncing();
 
+      const seenTimestampSec = Date.now() / 1000;
       const errors: Error[] = [];
 
       await Promise.all(
@@ -440,7 +441,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
               committeeIndices
             );
             const sentPeers = await network.gossip.publishBeaconAggregateAndProof(signedAggregateAndProof);
-            metrics?.submitAggregatedAttestation(indexedAttestation, sentPeers);
+            metrics?.submitAggregatedAttestation(seenTimestampSec, indexedAttestation, sentPeers);
           } catch (e) {
             if (e instanceof AttestationError && e.type.code === AttestationErrorCode.AGGREGATOR_ALREADY_KNOWN) {
               logger.debug("Ignoring known signedAggregateAndProof");

--- a/packages/lodestar/src/metrics/metrics.ts
+++ b/packages/lodestar/src/metrics/metrics.ts
@@ -1,6 +1,7 @@
 /**
  * @module metrics
  */
+import {ILogger} from "@chainsafe/lodestar-utils";
 import {BeaconStateAllForks, getCurrentSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {collectDefaultMetrics, Counter, Metric, Registry} from "prom-client";
@@ -18,14 +19,15 @@ export function createMetrics(
   opts: IMetricsOptions,
   config: IChainForkConfig,
   anchorState: BeaconStateAllForks,
-  externalRegistries: Registry[] = []
+  logger: ILogger,
+  externalRegistries: Registry[] = [],
 ): IMetrics {
   const register = new RegistryMetricCreator();
   const beacon = createBeaconMetrics(register);
   const lodestar = createLodestarMetrics(register, opts.metadata, anchorState);
 
   const genesisTime = anchorState.genesisTime;
-  const validatorMonitor = createValidatorMonitor(lodestar, config, genesisTime);
+  const validatorMonitor = createValidatorMonitor(lodestar, config, genesisTime, logger);
   // Register a single collect() function to run all validatorMonitor metrics
   lodestar.validatorMonitor.validatorsTotal.addCollect(() => {
     const clockSlot = getCurrentSlot(config, genesisTime);

--- a/packages/lodestar/src/metrics/metrics.ts
+++ b/packages/lodestar/src/metrics/metrics.ts
@@ -20,7 +20,7 @@ export function createMetrics(
   config: IChainForkConfig,
   anchorState: BeaconStateAllForks,
   logger: ILogger,
-  externalRegistries: Registry[] = [],
+  externalRegistries: Registry[] = []
 ): IMetrics {
   const register = new RegistryMetricCreator();
   const beacon = createBeaconMetrics(register);

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -644,6 +644,12 @@ export function createLodestarMetrics(
         labelNames: ["index", "src"],
         buckets: [0.1, 1],
       }),
+      unaggregatedAttestationSubmittedSentPeers: register.histogram<"index">({
+        name: "validator_monitor_unaggregated_attestation_submited_sent_peers_total",
+        help: "Number of unaggregated attestations submitted by local validator that has no subnet peers",
+        labelNames: ["index"],
+        buckets: [0, 2, 5, 10],
+      }),
       aggregatedAttestationTotal: register.gauge<"index" | "src">({
         name: "validator_monitor_aggregated_attestation_total",
         help: "Number of aggregated attestations seen",

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -659,6 +659,9 @@ export function createLodestarMetrics(
         name: "validator_monitor_unaggregated_attestation_submited_sent_peers_count",
         help: "Number of peers that an unaggregated attestation sent to",
         labelNames: ["index"],
+        // as of Apr 2022, most of the time we sent to >30 peers per attestations
+        // these bucket values just base on that fact to get equal range
+        // refine if we want more reasonable values
         buckets: [0, 10, 20, 30],
       }),
       aggregatedAttestationTotal: register.gauge<"index" | "src">({

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -542,12 +542,23 @@ export function createLodestarMetrics(
       }),
       prevEpochOnChainAttesterHit: register.gauge<"index">({
         name: "validator_monitor_prev_epoch_on_chain_attester_hit_total",
-        help: "Incremented if the validator is flagged as a previous epoch attester during per epoch processing",
+        help: "Incremented if validator's submitted attestation is included in some blocks",
         labelNames: ["index"],
       }),
       prevEpochOnChainAttesterMiss: register.gauge<"index">({
         name: "validator_monitor_prev_epoch_on_chain_attester_miss_total",
-        help: "Incremented if the validator is not flagged as a previous epoch attester during per epoch processing",
+        help: "Incremented if validator's submitted attestation is not included in any blocks",
+        labelNames: ["index"],
+      }),
+      prevEpochOnChainSourceAttesterHit: register.gauge<"index">({
+        name: "validator_monitor_prev_epoch_on_chain_source_attester_hit_total",
+        help: "Incremented if the validator is flagged as a previous epoch source attester during per epoch processing",
+        labelNames: ["index"],
+      }),
+      prevEpochOnChainSourceAttesterMiss: register.gauge<"index">({
+        name: "validator_monitor_prev_epoch_on_chain_source_attester_miss_total",
+        help:
+          "Incremented if the validator is not flagged as a previous epoch source attester during per epoch processing",
         labelNames: ["index"],
       }),
       prevEpochOnChainHeadAttesterHit: register.gauge<"index">({

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -656,10 +656,10 @@ export function createLodestarMetrics(
         buckets: [0.1, 1],
       }),
       unaggregatedAttestationSubmittedSentPeers: register.histogram<"index">({
-        name: "validator_monitor_unaggregated_attestation_submited_sent_peers_total",
-        help: "Number of unaggregated attestations submitted by local validator that has no subnet peers",
+        name: "validator_monitor_unaggregated_attestation_submited_sent_peers_count",
+        help: "Number of peers that an unaggregated attestation sent to",
         labelNames: ["index"],
-        buckets: [0, 2, 5, 10],
+        buckets: [0, 10, 20, 30],
       }),
       aggregatedAttestationTotal: register.gauge<"index" | "src">({
         name: "validator_monitor_aggregated_attestation_total",

--- a/packages/lodestar/src/metrics/validatorMonitor.ts
+++ b/packages/lodestar/src/metrics/validatorMonitor.ts
@@ -208,10 +208,10 @@ export function createValidatorMonitor(
         let failedAttestation = false;
 
         if (summary.isPrevSourceAttester) {
-          metrics.validatorMonitor.prevEpochOnChainAttesterHit.inc({index});
+          metrics.validatorMonitor.prevEpochOnChainSourceAttesterHit.inc({index});
         } else {
           failedAttestation = true;
-          metrics.validatorMonitor.prevEpochOnChainAttesterMiss.inc({index});
+          metrics.validatorMonitor.prevEpochOnChainSourceAttesterMiss.inc({index});
         }
         if (summary.isPrevHeadAttester) {
           metrics.validatorMonitor.prevEpochOnChainHeadAttesterHit.inc({index});
@@ -255,6 +255,9 @@ export function createValidatorMonitor(
 
         if (inclusionDistance !== null) {
           metrics.validatorMonitor.prevEpochOnChainInclusionDistance.set({index}, inclusionDistance);
+          metrics.validatorMonitor.prevEpochOnChainAttesterHit.inc({index});
+        } else {
+          metrics.validatorMonitor.prevEpochOnChainAttesterMiss.inc({index});
         }
 
         const balance = balances && balances[index];

--- a/packages/lodestar/src/metrics/validatorMonitor.ts
+++ b/packages/lodestar/src/metrics/validatorMonitor.ts
@@ -229,10 +229,11 @@ export function createValidatorMonitor(
         if (failedAttestation) {
           logger.verbose("Failed attestation in previous epoch", {
             validatorIndex: index,
-            currentEpoch,
+            prevEpoch: currentEpoch - 1,
             isPrevSourceAttester: summary.isPrevSourceAttester,
             isPrevHeadAttester: summary.isPrevHeadAttester,
             isPrevTargetAttester: summary.isPrevTargetAttester,
+            inclusionDistance: summary.inclusionDistance,
           });
         }
 

--- a/packages/lodestar/src/metrics/validatorMonitor.ts
+++ b/packages/lodestar/src/metrics/validatorMonitor.ts
@@ -278,7 +278,7 @@ export function createValidatorMonitor(
     submitUnaggregatedAttestation(indexedAttestation, subnet, sentPeers) {
       const data = indexedAttestation.data;
       // Returns the duration between when the attestation `data` could be produced (1/3rd through the slot) and `seenTimestamp`.
-      const delaySec = Math.floor(Date.now() / 1000) - (genesisTime + (data.slot + 1 / 3) * config.SECONDS_PER_SLOT);
+      const delaySec = Date.now() / 1000 - (genesisTime + (data.slot + 1 / 3) * config.SECONDS_PER_SLOT);
       for (const index of indexedAttestation.attestingIndices) {
         const validator = validators.get(index);
         if (validator) {
@@ -321,7 +321,7 @@ export function createValidatorMonitor(
     submitAggregatedAttestation(indexedAttestation, sentPeers) {
       const data = indexedAttestation.data;
       // Returns the duration between when a `AggregateAndproof` with `data` could be produced (2/3rd through the slot) and `seenTimestamp`.
-      const delaySec = Math.floor(Date.now() / 1000) - (genesisTime + (data.slot + 2 / 3) * config.SECONDS_PER_SLOT);
+      const delaySec = Date.now() / 1000 - (genesisTime + (data.slot + 2 / 3) * config.SECONDS_PER_SLOT);
 
       for (const index of indexedAttestation.attestingIndices) {
         const validator = validators.get(index);

--- a/packages/lodestar/src/metrics/validatorMonitor.ts
+++ b/packages/lodestar/src/metrics/validatorMonitor.ts
@@ -226,17 +226,6 @@ export function createValidatorMonitor(
           metrics.validatorMonitor.prevEpochOnChainTargetAttesterMiss.inc({index});
         }
 
-        if (failedAttestation) {
-          logger.verbose("Failed attestation in previous epoch", {
-            validatorIndex: index,
-            prevEpoch: currentEpoch - 1,
-            isPrevSourceAttester: summary.isPrevSourceAttester,
-            isPrevHeadAttester: summary.isPrevHeadAttester,
-            isPrevTargetAttester: summary.isPrevTargetAttester,
-            inclusionDistance: summary.inclusionDistance,
-          });
-        }
-
         const prevEpochSummary = monitoredValidator.summaries.get(previousEpoch);
         const attestationCorrectHead = prevEpochSummary?.attestationCorrectHead;
         if (attestationCorrectHead !== null && attestationCorrectHead !== undefined) {
@@ -263,6 +252,18 @@ export function createValidatorMonitor(
         const balance = balances && balances[index];
         if (balance !== undefined) {
           metrics.validatorMonitor.prevEpochOnChainBalance.set({index}, balance);
+        }
+
+        if (failedAttestation) {
+          logger.verbose("Failed attestation in previous epoch", {
+            validatorIndex: index,
+            prevEpoch: currentEpoch - 1,
+            isPrevSourceAttester: summary.isPrevSourceAttester,
+            isPrevHeadAttester: summary.isPrevHeadAttester,
+            isPrevTargetAttester: summary.isPrevTargetAttester,
+            // inclusionDistance is not available in summary since altair
+            inclusionDistance,
+          });
         }
       }
     },

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -148,12 +148,13 @@ export class Eth2Gossipsub extends Gossipsub {
   /**
    * Publish a `GossipObject` on a `GossipTopic`
    */
-  async publishObject<K extends GossipType>(topic: GossipTopicMap[K], object: GossipTypeMap[K]): Promise<void> {
+  async publishObject<K extends GossipType>(topic: GossipTopicMap[K], object: GossipTypeMap[K]): Promise<number> {
     const topicStr = this.getGossipTopicString(topic);
     const sszType = getGossipSSZType(topic);
     const messageData = (sszType.serialize as (object: GossipTypeMap[GossipType]) => Uint8Array)(object);
     const sentPeers = await this.publish(topicStr, messageData);
     this.logger.verbose("Publish to topic", {topic: topicStr, sentPeers});
+    return sentPeers;
   }
 
   /**
@@ -182,17 +183,17 @@ export class Eth2Gossipsub extends Gossipsub {
     await this.publishObject<GossipType.beacon_block>({type: GossipType.beacon_block, fork}, signedBlock);
   }
 
-  async publishBeaconAggregateAndProof(aggregateAndProof: phase0.SignedAggregateAndProof): Promise<void> {
+  async publishBeaconAggregateAndProof(aggregateAndProof: phase0.SignedAggregateAndProof): Promise<number> {
     const fork = this.config.getForkName(aggregateAndProof.message.aggregate.data.slot);
-    await this.publishObject<GossipType.beacon_aggregate_and_proof>(
+    return await this.publishObject<GossipType.beacon_aggregate_and_proof>(
       {type: GossipType.beacon_aggregate_and_proof, fork},
       aggregateAndProof
     );
   }
 
-  async publishBeaconAttestation(attestation: phase0.Attestation, subnet: number): Promise<void> {
+  async publishBeaconAttestation(attestation: phase0.Attestation, subnet: number): Promise<number> {
     const fork = this.config.getForkName(attestation.data.slot);
-    await this.publishObject<GossipType.beacon_attestation>(
+    return await this.publishObject<GossipType.beacon_attestation>(
       {type: GossipType.beacon_attestation, fork, subnet},
       attestation
     );

--- a/packages/lodestar/src/network/gossip/handlers/index.ts
+++ b/packages/lodestar/src/network/gossip/handlers/index.ts
@@ -161,12 +161,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
 
       // Handler
       const {indexedAttestation, committeeIndices} = validationResult;
-      metrics?.registerAggregatedAttestation(
-        OpSource.gossip,
-        seenTimestampSec,
-        signedAggregateAndProof,
-        indexedAttestation
-      );
+      metrics?.registerGossipAggregatedAttestation(seenTimestampSec, signedAggregateAndProof, indexedAttestation);
       const aggregatedAttestation = signedAggregateAndProof.message.aggregate;
 
       chain.aggregatedAttestationPool.add(
@@ -206,7 +201,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
 
       // Handler
       const {indexedAttestation} = validationResult;
-      metrics?.registerUnaggregatedAttestation(OpSource.gossip, seenTimestampSec, indexedAttestation);
+      metrics?.registerGossipUnaggregatedAttestation(seenTimestampSec, indexedAttestation);
 
       // Node may be subscribe to extra subnets (long-lived random subnets). For those, validate the messages
       // but don't import them, to save CPU and RAM

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -128,7 +128,9 @@ export class BeaconNode {
     // start db if not already started
     await db.start();
 
-    const metrics = opts.metrics.enabled ? createMetrics(opts.metrics, config, anchorState, metricsRegistries) : null;
+    const metrics = opts.metrics.enabled
+      ? createMetrics(opts.metrics, config, anchorState, logger.child({module: "VMON"}), metricsRegistries)
+      : null;
     if (metrics) {
       initBeaconMetrics(metrics, anchorState);
     }

--- a/packages/lodestar/test/unit/metrics/utils.ts
+++ b/packages/lodestar/test/unit/metrics/utils.ts
@@ -1,8 +1,10 @@
 import {config} from "@chainsafe/lodestar-config/default";
 import {ssz} from "@chainsafe/lodestar-types";
+import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {createMetrics, IMetrics} from "../../../src/metrics";
 
 export function createMetricsTest(): IMetrics {
   const state = ssz.phase0.BeaconState.defaultViewDU();
-  return createMetrics({enabled: true, timeout: 12000}, config, state);
+  const logger = new WinstonLogger();
+  return createMetrics({enabled: true, timeout: 12000}, config, state, logger);
 }


### PR DESCRIPTION
**Motivation**

We want to debug #3527 - missing attestations in mainnet

**Description**

+ Log attestation when it's published to topic and included in AggregateAndProof

+ Don't log when we receive gossip block because I think it's not worth to do so considering the performance to scan through all indices of aggregate and proofs, @dapplion let me know if there's a cheap way to do it. Once an attestation is included in AggregateAndProof, it's likely it's included in upcoming blocks.

part of #3527
