### PR TITLE
Add build if changed script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,7 @@ packages/lodestar/.tmpdb/
 # Git artifacts
 packages/cli/.git-data.json
 
+# Build artifacts
+.last_build_unixsec
+
 temp/

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:lib:watch": "lerna run build:lib:watch --parallel",
     "build:types:watch": "lerna run build:types:watch --parallel",
     "build:watch": "run-p build:lib:watch build:types:watch",
+    "build:ifchanged": "lerna exec -- ../../scripts/build_if_changed.sh",
     "lint": "lerna run lint --no-bail",
     "check-types": "lerna run check-types --no-bail",
     "coverage": "lerna run coverage --no-bail",

--- a/packages/spec-test-runner/package.json
+++ b/packages/spec-test-runner/package.json
@@ -20,6 +20,7 @@
     "lib/**/*.js.map"
   ],
   "scripts": {
+    "build": "exit 0",
     "check-types": "tsc --noEmit",
     "download-spec-tests": "node -r ts-node/register test/downloadTests.ts",
     "check-tests": "mocha test/checkTests.test.ts",

--- a/scripts/build_if_changed.sh
+++ b/scripts/build_if_changed.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Writes the last build time in packages/*/last_build_unixsec
+# Then reads the file and checks if there has been any changes since then
+# If so, do a build
+
+# Exit on errors
+set -e
+
+LAST_BUILD_FILEPATH=.last_build_unixsec
+
+# Check being run from a package directory
+[ ! -d ./src ] && echo "Must be run in a package dir, no src"
+[ ! -f ./package.json ] && echo "Must be run in a package dir, no package.json"
+
+CURRENT_UNIXSEC=$(date +%s)
+
+if [ -f "$LAST_BUILD_FILEPATH" ]; then
+    # Exists
+    LAST_BUILD_UNIXSEC=$(cat $LAST_BUILD_FILEPATH)
+    SINCE_LAST_BUILD_SEC=$(($CURRENT_UNIXSEC - $LAST_BUILD_UNIXSEC))
+    SINCE_LAST_BUILD_MIN=$(($SINCE_LAST_BUILD_SEC / 60 + 1))
+    # Only with DEBUG=true, log math
+    if [ ! -z "$DEBUG" ]; then
+        echo "LAST_BUILD_UNIXSEC: $LAST_BUILD_UNIXSEC SINCE_LAST_BUILD_SEC: $SINCE_LAST_BUILD_SEC SINCE_LAST_BUILD_MIN: $SINCE_LAST_BUILD_MIN"
+    fi
+    
+    CHANGED_FILES=$(find src package.json -cmin -$SINCE_LAST_BUILD_MIN)
+    if [ -z "$CHANGED_FILES" ]; then
+        # Empty, no changes
+        SHOULD_BUILD=false
+    else
+        # Not empty, build
+        SHOULD_BUILD=true
+    fi
+else
+    # Does not exist, always build
+    SHOULD_BUILD=true
+fi
+
+# If there are changes, build
+if [ "$SHOULD_BUILD" = true ]; then
+    # Empty, no changes
+    npm run build
+fi
+
+# Persist current time after a successful build
+echo $CURRENT_UNIXSEC > $LAST_BUILD_FILEPATH
+

--- a/scripts/build_if_changed.sh
+++ b/scripts/build_if_changed.sh
@@ -40,7 +40,6 @@ fi
 
 # If there are changes, build
 if [ "$SHOULD_BUILD" = true ]; then
-    # Empty, no changes
     npm run build
 fi
 


### PR DESCRIPTION
**Motivation**

In some setups I'm building in VPS the build command is run many times when no changes have been done.

The current `yarn build` command blindly nukes the build artifacts and does a build from scratch, which take ~2-3 min

**Description**

- Persist the last time a specific package src was modified
- Check if there has been modifications between that time and now

If there has been no modification running the script over all packages takes 0.5 sec. `find` is very fast.

```
yarn build:ifchanged
```

**Caveats**

- May only work on some UNIX, Linux systems