### PR TITLE
Handle errors  thrown by EL's executePayload

### DIFF
--- a/packages/lodestar/src/chain/blocks/verifyBlock.ts
+++ b/packages/lodestar/src/chain/blocks/verifyBlock.ts
@@ -169,7 +169,7 @@ export async function verifyBlockStateTransition(
     }
   }
 
-  let executionStatus = ExecutionStatus.PreMerge;
+  let executionStatus: ExecutionStatus;
   if (executionPayloadEnabled) {
     // TODO: Handle better executePayload() returning error is syncing
     const execResult = await chain.executionEngine.executePayload(
@@ -185,6 +185,7 @@ export async function verifyBlockStateTransition(
         executionStatus = ExecutionStatus.Valid;
         chain.forkChoice.validateLatestHash(execResult.latestValidHash, null);
         break; // OK
+
       case ExecutePayloadStatus.INVALID: {
         // If the parentRoot is not same as latestValidHash, then the branch from latestValidHash
         // to parentRoot needs to be invalidated
@@ -198,6 +199,7 @@ export async function verifyBlockStateTransition(
           errorMessage: execResult.validationError ?? "",
         });
       }
+
       case ExecutePayloadStatus.SYNCING: {
         // It's okay to ignore SYNCING status as EL could switch into syncing
         // 1. On intial startup/restart
@@ -264,6 +266,9 @@ export async function verifyBlockStateTransition(
           errorMessage: execResult.validationError,
         });
     }
+  } else {
+    // isExecutionEnabled() -> false
+    executionStatus = ExecutionStatus.PreMerge;
   }
 
   // Check state root matches

--- a/packages/lodestar/src/chain/blocks/verifyBlock.ts
+++ b/packages/lodestar/src/chain/blocks/verifyBlock.ts
@@ -229,7 +229,7 @@ export async function verifyBlockStateTransition(
           block.message.slot + SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY > clockSlot
         ) {
           throw new BlockError(block, {
-            code: BlockErrorCode.EXECUTION_ENGINE_SYNCING,
+            code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
             errorMessage: `not safe to import SYNCING payload within ${SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY} of currentSlot`,
           });
         }
@@ -255,14 +255,9 @@ export async function verifyBlockStateTransition(
       // back. But for now, lets assume other mechanisms like unknown parent block of a future
       // child block will cause it to replay
       case ExecutePayloadStatus.ELERROR:
-        throw new BlockError(block, {
-          code: BlockErrorCode.EXECUTION_ENGINE_ERRORED,
-          errorMessage: execResult.validationError,
-        });
-
       case ExecutePayloadStatus.UNAVAILABLE:
         throw new BlockError(block, {
-          code: BlockErrorCode.EXECUTION_ENGINE_UNAVAILABLE,
+          code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
           errorMessage: execResult.validationError,
         });
     }

--- a/packages/lodestar/src/chain/blocks/verifyBlock.ts
+++ b/packages/lodestar/src/chain/blocks/verifyBlock.ts
@@ -215,10 +215,13 @@ export async function verifyBlockStateTransition(
         //    On kintsugi devnet, this has been observed to cause contiguous proposal failures
         //    as the network is geth dominated, till a non geth node proposes and moves network
         //    forward
-        executionStatus = ExecutionStatus.Syncing;
-        chain.logger.warn("executePayload error-ed, treating the payload optimistic for now", {
-          error: execResult.validationError,
+        // For network/unreachable errors, an optimization can be added to replay these blocks
+        // back. But for now, lets assume other mechanisms like unknown parent block of a future
+        // child block will cause it to replay
+        chain.logger.error("Execution engine api for executePayload failed with error", {
+          validationError: execResult.validationError,
         });
+        throw new BlockError(block, {code: BlockErrorCode.EXECUTION_ENGINE_ERRORED});
     }
   }
 

--- a/packages/lodestar/src/chain/blocks/verifyBlock.ts
+++ b/packages/lodestar/src/chain/blocks/verifyBlock.ts
@@ -221,8 +221,9 @@ export async function verifyBlockStateTransition(
         //    imported.
         const justifiedBlock = chain.forkChoice.getJustifiedBlock();
         const clockSlot = getCurrentSlot(chain.config, postState.genesisTime);
+
         if (
-          justifiedBlock.executionStatus === ExecutionStatus.PreMerge ||
+          justifiedBlock.executionStatus === ExecutionStatus.PreMerge &&
           block.message.slot + SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY > clockSlot
         ) {
           throw new BlockError(block, {

--- a/packages/lodestar/src/chain/errors/blockError.ts
+++ b/packages/lodestar/src/chain/errors/blockError.ts
@@ -59,6 +59,8 @@ export enum BlockErrorCode {
   EXECUTION_PAYLOAD_NOT_VALID = "BLOCK_ERROR_EXECUTION_PAYLOAD_NOT_VALID",
   /** Execution engine is syncing */
   EXECUTION_ENGINE_SYNCING = "BLOCK_ERROR_EXECUTION_ENGINE_SYNCING",
+  /** Execution engine api errored */
+  EXECUTION_ENGINE_ERRORED = "BLOCK_ERROR_EXECUTION_ENGINE_ERRORED",
 }
 
 export type BlockErrorType =
@@ -92,7 +94,8 @@ export type BlockErrorType =
   | {code: BlockErrorCode.SAME_PARENT_HASH; blockHash: RootHex}
   | {code: BlockErrorCode.TRANSACTIONS_TOO_BIG; size: number; max: number}
   | {code: BlockErrorCode.EXECUTION_PAYLOAD_NOT_VALID}
-  | {code: BlockErrorCode.EXECUTION_ENGINE_SYNCING};
+  | {code: BlockErrorCode.EXECUTION_ENGINE_SYNCING}
+  | {code: BlockErrorCode.EXECUTION_ENGINE_ERRORED};
 
 export class BlockGossipError extends GossipActionError<BlockErrorType> {}
 

--- a/packages/lodestar/src/chain/errors/blockError.ts
+++ b/packages/lodestar/src/chain/errors/blockError.ts
@@ -57,6 +57,8 @@ export enum BlockErrorCode {
   TRANSACTIONS_TOO_BIG = "BLOCK_ERROR_TRANSACTIONS_TOO_BIG",
   /** Execution engine returned not valid after executePayload() call */
   EXECUTION_PAYLOAD_NOT_VALID = "BLOCK_ERROR_EXECUTION_PAYLOAD_NOT_VALID",
+  /** Execution engine is unavailable */
+  EXECUTION_ENGINE_UNAVAILABLE = "BLOCK_ERROR_EXECUTION_ENGINE_UNAVAILABLE",
   /** Execution engine is syncing */
   EXECUTION_ENGINE_SYNCING = "BLOCK_ERROR_EXECUTION_ENGINE_SYNCING",
   /** Execution engine api errored */
@@ -94,6 +96,7 @@ export type BlockErrorType =
   | {code: BlockErrorCode.SAME_PARENT_HASH; blockHash: RootHex}
   | {code: BlockErrorCode.TRANSACTIONS_TOO_BIG; size: number; max: number}
   | {code: BlockErrorCode.EXECUTION_PAYLOAD_NOT_VALID}
+  | {code: BlockErrorCode.EXECUTION_ENGINE_UNAVAILABLE}
   | {code: BlockErrorCode.EXECUTION_ENGINE_SYNCING}
   | {code: BlockErrorCode.EXECUTION_ENGINE_ERRORED};
 

--- a/packages/lodestar/src/chain/errors/blockError.ts
+++ b/packages/lodestar/src/chain/errors/blockError.ts
@@ -95,10 +95,10 @@ export type BlockErrorType =
   | {code: BlockErrorCode.TOO_MUCH_GAS_USED; gasUsed: number; gasLimit: number}
   | {code: BlockErrorCode.SAME_PARENT_HASH; blockHash: RootHex}
   | {code: BlockErrorCode.TRANSACTIONS_TOO_BIG; size: number; max: number}
-  | {code: BlockErrorCode.EXECUTION_PAYLOAD_NOT_VALID}
-  | {code: BlockErrorCode.EXECUTION_ENGINE_UNAVAILABLE}
-  | {code: BlockErrorCode.EXECUTION_ENGINE_SYNCING}
-  | {code: BlockErrorCode.EXECUTION_ENGINE_ERRORED};
+  | {code: BlockErrorCode.EXECUTION_PAYLOAD_NOT_VALID; errorMessage: string}
+  | {code: BlockErrorCode.EXECUTION_ENGINE_UNAVAILABLE; errorMessage: string}
+  | {code: BlockErrorCode.EXECUTION_ENGINE_SYNCING; errorMessage: string}
+  | {code: BlockErrorCode.EXECUTION_ENGINE_ERRORED; errorMessage: string};
 
 export class BlockGossipError extends GossipActionError<BlockErrorType> {}
 

--- a/packages/lodestar/src/chain/errors/blockError.ts
+++ b/packages/lodestar/src/chain/errors/blockError.ts
@@ -57,12 +57,8 @@ export enum BlockErrorCode {
   TRANSACTIONS_TOO_BIG = "BLOCK_ERROR_TRANSACTIONS_TOO_BIG",
   /** Execution engine returned not valid after executePayload() call */
   EXECUTION_PAYLOAD_NOT_VALID = "BLOCK_ERROR_EXECUTION_PAYLOAD_NOT_VALID",
-  /** Execution engine is unavailable */
-  EXECUTION_ENGINE_UNAVAILABLE = "BLOCK_ERROR_EXECUTION_ENGINE_UNAVAILABLE",
-  /** Execution engine is syncing */
-  EXECUTION_ENGINE_SYNCING = "BLOCK_ERROR_EXECUTION_ENGINE_SYNCING",
-  /** Execution engine api errored */
-  EXECUTION_ENGINE_ERRORED = "BLOCK_ERROR_EXECUTION_ENGINE_ERRORED",
+  /** Execution engine is unavailable, syncing, or api call errored. Peers must not be downscored on this code */
+  EXECUTION_ENGINE_ERROR = "BLOCK_ERROR_EXECUTION_ERROR",
 }
 
 export type BlockErrorType =
@@ -96,9 +92,7 @@ export type BlockErrorType =
   | {code: BlockErrorCode.SAME_PARENT_HASH; blockHash: RootHex}
   | {code: BlockErrorCode.TRANSACTIONS_TOO_BIG; size: number; max: number}
   | {code: BlockErrorCode.EXECUTION_PAYLOAD_NOT_VALID; errorMessage: string}
-  | {code: BlockErrorCode.EXECUTION_ENGINE_UNAVAILABLE; errorMessage: string}
-  | {code: BlockErrorCode.EXECUTION_ENGINE_SYNCING; errorMessage: string}
-  | {code: BlockErrorCode.EXECUTION_ENGINE_ERRORED; errorMessage: string};
+  | {code: BlockErrorCode.EXECUTION_ENGINE_ERROR; errorMessage: string};
 
 export class BlockGossipError extends GossipActionError<BlockErrorType> {}
 

--- a/packages/lodestar/src/eth1/provider/jsonRpcHttpClient.ts
+++ b/packages/lodestar/src/eth1/provider/jsonRpcHttpClient.ts
@@ -155,8 +155,11 @@ export class JsonRpcHttpClient implements IJsonRpcHttpClient {
 }
 
 function parseRpcResponse<R, P>(res: IRpcResponse<R>, payload: IRpcPayload<P>): R {
-  if (res.result !== undefined) return res.result;
-  throw new ErrorJsonRpcResponse(res, payload);
+  if (res.result !== undefined) {
+    return res.result;
+  } else {
+    throw new ErrorJsonRpcResponse(res, payload);
+  }
 }
 
 /**
@@ -178,6 +181,7 @@ export class ErrorParseJson extends Error {
   }
 }
 
+/** JSON RPC endpoint returned status code == 200, but with error property set */
 export class ErrorJsonRpcResponse<P> extends Error {
   response: IRpcResponseError;
   payload: IRpcPayload<P>;
@@ -197,6 +201,7 @@ export class ErrorJsonRpcResponse<P> extends Error {
   }
 }
 
+/** JSON RPC endpoint returned status code != 200 */
 export class HttpRpcError extends Error {
   constructor(readonly status: number, message: string) {
     super(message);

--- a/packages/lodestar/src/executionEngine/http.ts
+++ b/packages/lodestar/src/executionEngine/http.ts
@@ -78,66 +78,61 @@ export class ExecutionEngineHttp implements IExecutionEngine {
        * If there are errors by EL like connection refused, internal error, they need to be
        * treated seperate from being INVALID. For now, just pass the error upstream.
        */
-      .catch((e: Error) => {
-        let errResponse: EngineApiRpcReturnTypes[typeof method];
+      .catch((e: Error): EngineApiRpcReturnTypes[typeof method] => {
         if (
           e instanceof TimeoutError ||
           e instanceof ErrorAborted ||
           e.message === "Only absolute URLs are supported"
         ) {
-          errResponse = {status: ExecutePayloadStatus.UNAVAILABLE, latestValidHash: null, validationError: e.message};
+          return {status: ExecutePayloadStatus.UNAVAILABLE, latestValidHash: null, validationError: e.message};
         } else {
-          errResponse = {status: ExecutePayloadStatus.ELERROR, latestValidHash: null, validationError: e.message};
+          return {status: ExecutePayloadStatus.ELERROR, latestValidHash: null, validationError: e.message};
         }
-        return errResponse;
       });
-
-    let execResponse: ExecutePayloadResponse;
 
     // Validate status is known
     const statusEnum = ExecutePayloadStatus[status];
     switch (statusEnum) {
       case ExecutePayloadStatus.VALID:
         if (latestValidHash == null) {
-          execResponse = {
+          return {
             status: ExecutePayloadStatus.ELERROR,
             latestValidHash: null,
             validationError: `Invalid null latestValidHash for status=${status}`,
           };
         } else {
-          execResponse = {status: statusEnum, latestValidHash, validationError: null};
+          return {status: statusEnum, latestValidHash, validationError: null};
         }
-        break;
+
       case ExecutePayloadStatus.INVALID:
         if (latestValidHash == null) {
-          execResponse = {
+          return {
             status: ExecutePayloadStatus.ELERROR,
             latestValidHash: null,
             validationError: `Invalid null latestValidHash for status=${status}`,
           };
         } else {
-          execResponse = {status: statusEnum, latestValidHash, validationError};
+          return {status: statusEnum, latestValidHash, validationError};
         }
-        break;
+
       case ExecutePayloadStatus.SYNCING:
-        execResponse = {status: statusEnum, latestValidHash, validationError: null};
-        break;
+        return {status: statusEnum, latestValidHash, validationError: null};
+
       case ExecutePayloadStatus.UNAVAILABLE:
       case ExecutePayloadStatus.ELERROR:
-        execResponse = {
+        return {
           status: statusEnum,
           latestValidHash: null,
           validationError: validationError ?? "Unidentified ELERROR",
         };
-        break;
+
       default:
-        execResponse = {
+        return {
           status: ExecutePayloadStatus.ELERROR,
           latestValidHash: null,
           validationError: `Invalid EL status on executePayload: ${status}`,
         };
     }
-    return execResponse;
   }
 
   /**

--- a/packages/lodestar/src/executionEngine/http.ts
+++ b/packages/lodestar/src/executionEngine/http.ts
@@ -84,6 +84,10 @@ export class ExecutionEngineHttp implements IExecutionEngine {
           errResponse = {status: ExecutePayloadStatus.UNAVAILABLE, latestValidHash: null, validationError: e.message};
         } else if (e instanceof ErrorAborted) {
           errResponse = {status: ExecutePayloadStatus.UNAVAILABLE, latestValidHash: null, validationError: e.message};
+
+          // What would be better way of handling this
+        } else if (e.message === "Only absolute URLs are supported") {
+          errResponse = {status: ExecutePayloadStatus.UNAVAILABLE, latestValidHash: null, validationError: e.message};
         } else {
           errResponse = {status: ExecutePayloadStatus.ELERROR, latestValidHash: null, validationError: e.message};
         }

--- a/packages/lodestar/src/executionEngine/http.ts
+++ b/packages/lodestar/src/executionEngine/http.ts
@@ -80,13 +80,11 @@ export class ExecutionEngineHttp implements IExecutionEngine {
        */
       .catch((e: Error) => {
         let errResponse: EngineApiRpcReturnTypes[typeof method];
-        if (e instanceof TimeoutError) {
-          errResponse = {status: ExecutePayloadStatus.UNAVAILABLE, latestValidHash: null, validationError: e.message};
-        } else if (e instanceof ErrorAborted) {
-          errResponse = {status: ExecutePayloadStatus.UNAVAILABLE, latestValidHash: null, validationError: e.message};
-
-          // What would be better way of handling this
-        } else if (e.message === "Only absolute URLs are supported") {
+        if (
+          e instanceof TimeoutError ||
+          e instanceof ErrorAborted ||
+          e.message === "Only absolute URLs are supported"
+        ) {
           errResponse = {status: ExecutePayloadStatus.UNAVAILABLE, latestValidHash: null, validationError: e.message};
         } else {
           errResponse = {status: ExecutePayloadStatus.ELERROR, latestValidHash: null, validationError: e.message};

--- a/packages/lodestar/src/executionEngine/http.ts
+++ b/packages/lodestar/src/executionEngine/http.ts
@@ -84,8 +84,15 @@ export class ExecutionEngineHttp implements IExecutionEngine {
       });
 
     // Validate status is known
-    const statusEnum = ExecutePayloadStatus[status];
-    switch (statusEnum) {
+    if (!ExecutePayloadStatus[status]) {
+      return {
+        status: ExecutePayloadStatus.ELERROR,
+        latestValidHash: null,
+        validationError: `Invalid EL status on executePayload: ${status}`,
+      };
+    }
+
+    switch (status) {
       case ExecutePayloadStatus.VALID:
         if (latestValidHash == null) {
           return {
@@ -94,7 +101,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
             validationError: `Invalid null latestValidHash for status=${status}`,
           };
         } else {
-          return {status: statusEnum, latestValidHash, validationError: null};
+          return {status, latestValidHash, validationError: null};
         }
 
       case ExecutePayloadStatus.INVALID:
@@ -105,25 +112,18 @@ export class ExecutionEngineHttp implements IExecutionEngine {
             validationError: `Invalid null latestValidHash for status=${status}`,
           };
         } else {
-          return {status: statusEnum, latestValidHash, validationError};
+          return {status, latestValidHash, validationError};
         }
 
       case ExecutePayloadStatus.SYNCING:
-        return {status: statusEnum, latestValidHash, validationError: null};
+        return {status, latestValidHash, validationError: null};
 
       case ExecutePayloadStatus.UNAVAILABLE:
       case ExecutePayloadStatus.ELERROR:
         return {
-          status: statusEnum,
+          status,
           latestValidHash: null,
-          validationError: validationError ?? "Unidentified ELERROR",
-        };
-
-      default:
-        return {
-          status: ExecutePayloadStatus.ELERROR,
-          latestValidHash: null,
-          validationError: `Invalid EL status on executePayload: ${status}`,
+          validationError: validationError ?? "Unknown ELERROR",
         };
     }
   }

--- a/packages/lodestar/src/executionEngine/interface.ts
+++ b/packages/lodestar/src/executionEngine/interface.ts
@@ -13,11 +13,15 @@ export enum ExecutePayloadStatus {
   INVALID = "INVALID",
   /** sync process is in progress */
   SYNCING = "SYNCING",
+  /** EL error */
+  ELERROR = "ELERROR",
 }
 
 export type ExecutePayloadResponse =
-  | {status: ExecutePayloadStatus.SYNCING; latestValidHash: RootHex | null}
-  | {status: ExecutePayloadStatus.VALID | ExecutePayloadStatus.INVALID; latestValidHash: RootHex};
+  | {status: ExecutePayloadStatus.SYNCING; latestValidHash: RootHex | null; validationError: null}
+  | {status: ExecutePayloadStatus.VALID; latestValidHash: RootHex; validationError: null}
+  | {status: ExecutePayloadStatus.INVALID; latestValidHash: RootHex; validationError: string | null}
+  | {status: ExecutePayloadStatus.ELERROR; latestValidHash: null; validationError: string};
 
 export enum ForkChoiceUpdateStatus {
   /** given payload is valid */

--- a/packages/lodestar/src/executionEngine/interface.ts
+++ b/packages/lodestar/src/executionEngine/interface.ts
@@ -15,13 +15,19 @@ export enum ExecutePayloadStatus {
   SYNCING = "SYNCING",
   /** EL error */
   ELERROR = "ELERROR",
+  /** EL unavailable */
+  UNAVAILABLE = "UNAVAILABLE",
 }
 
 export type ExecutePayloadResponse =
   | {status: ExecutePayloadStatus.SYNCING; latestValidHash: RootHex | null; validationError: null}
   | {status: ExecutePayloadStatus.VALID; latestValidHash: RootHex; validationError: null}
   | {status: ExecutePayloadStatus.INVALID; latestValidHash: RootHex; validationError: string | null}
-  | {status: ExecutePayloadStatus.ELERROR; latestValidHash: null; validationError: string};
+  | {
+      status: ExecutePayloadStatus.ELERROR | ExecutePayloadStatus.UNAVAILABLE;
+      latestValidHash: null;
+      validationError: string;
+    };
 
 export enum ForkChoiceUpdateStatus {
   /** given payload is valid */

--- a/packages/lodestar/src/executionEngine/mock.ts
+++ b/packages/lodestar/src/executionEngine/mock.ts
@@ -61,11 +61,15 @@ export class ExecutionEngineMock implements IExecutionEngine {
   async executePayload(executionPayload: merge.ExecutionPayload): Promise<ExecutePayloadResponse> {
     // Only validate that parent is known
     if (!this.knownBlocks.has(toHexString(executionPayload.parentHash))) {
-      return {status: ExecutePayloadStatus.INVALID, latestValidHash: this.headBlockRoot};
+      return {status: ExecutePayloadStatus.INVALID, latestValidHash: this.headBlockRoot, validationError: null};
     }
 
     this.knownBlocks.set(toHexString(executionPayload.blockHash), executionPayload);
-    return {status: ExecutePayloadStatus.VALID, latestValidHash: toHexString(executionPayload.blockHash)};
+    return {
+      status: ExecutePayloadStatus.VALID,
+      latestValidHash: toHexString(executionPayload.blockHash),
+      validationError: null,
+    };
   }
 
   /**

--- a/packages/lodestar/src/network/gossip/handlers/index.ts
+++ b/packages/lodestar/src/network/gossip/handlers/index.ts
@@ -105,6 +105,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules): GossipHandlers 
               case BlockErrorCode.ALREADY_KNOWN:
               case BlockErrorCode.PARENT_UNKNOWN:
               case BlockErrorCode.PRESTATE_MISSING:
+              case BlockErrorCode.EXECUTION_ENGINE_SYNCING:
               case BlockErrorCode.EXECUTION_ENGINE_ERRORED:
                 break;
               default:

--- a/packages/lodestar/src/network/gossip/handlers/index.ts
+++ b/packages/lodestar/src/network/gossip/handlers/index.ts
@@ -105,9 +105,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules): GossipHandlers 
               case BlockErrorCode.ALREADY_KNOWN:
               case BlockErrorCode.PARENT_UNKNOWN:
               case BlockErrorCode.PRESTATE_MISSING:
-              case BlockErrorCode.EXECUTION_ENGINE_UNAVAILABLE:
-              case BlockErrorCode.EXECUTION_ENGINE_SYNCING:
-              case BlockErrorCode.EXECUTION_ENGINE_ERRORED:
+              case BlockErrorCode.EXECUTION_ENGINE_ERROR:
                 break;
               default:
                 network.peerRpcScores.applyAction(

--- a/packages/lodestar/src/network/gossip/handlers/index.ts
+++ b/packages/lodestar/src/network/gossip/handlers/index.ts
@@ -105,6 +105,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules): GossipHandlers 
               case BlockErrorCode.ALREADY_KNOWN:
               case BlockErrorCode.PARENT_UNKNOWN:
               case BlockErrorCode.PRESTATE_MISSING:
+              case BlockErrorCode.EXECUTION_ENGINE_UNAVAILABLE:
               case BlockErrorCode.EXECUTION_ENGINE_SYNCING:
               case BlockErrorCode.EXECUTION_ENGINE_ERRORED:
                 break;

--- a/packages/lodestar/src/network/gossip/handlers/index.ts
+++ b/packages/lodestar/src/network/gossip/handlers/index.ts
@@ -105,6 +105,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules): GossipHandlers 
               case BlockErrorCode.ALREADY_KNOWN:
               case BlockErrorCode.PARENT_UNKNOWN:
               case BlockErrorCode.PRESTATE_MISSING:
+              case BlockErrorCode.EXECUTION_ENGINE_ERRORED:
                 break;
               default:
                 network.peerRpcScores.applyAction(

--- a/packages/lodestar/src/sync/range/batch.ts
+++ b/packages/lodestar/src/sync/range/batch.ts
@@ -172,12 +172,7 @@ export class Batch {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.Processing));
     }
 
-    if (
-      err instanceof ChainSegmentError &&
-      (err.type.code === BlockErrorCode.EXECUTION_ENGINE_UNAVAILABLE ||
-        err.type.code === BlockErrorCode.EXECUTION_ENGINE_SYNCING ||
-        err.type.code === BlockErrorCode.EXECUTION_ENGINE_ERRORED)
-    ) {
+    if (err instanceof ChainSegmentError && err.type.code === BlockErrorCode.EXECUTION_ENGINE_ERROR) {
       this.onExecutionEngineError(this.state.attempt);
     } else {
       this.onProcessingError(this.state.attempt);

--- a/packages/lodestar/src/sync/range/batch.ts
+++ b/packages/lodestar/src/sync/range/batch.ts
@@ -166,7 +166,7 @@ export class Batch {
   /**
    * Processing -> AwaitingProcessing
    */
-  executionNotReady(): void {
+  requeueForProcessing(): void {
     if (this.state.status !== BatchStatus.Processing) {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.Processing));
     }

--- a/packages/lodestar/src/sync/range/chain.ts
+++ b/packages/lodestar/src/sync/range/chain.ts
@@ -429,7 +429,7 @@ export class SyncChain {
       this.triggerBatchProcessor();
     } else {
       this.logger.verbose("Batch process error", {id: this.logId, ...batch.getMetadata()}, res.err);
-      batch.processingError(); // Throws after MAX_BATCH_PROCESSING_ATTEMPTS
+      batch.processingError(res.err); // Throws after MAX_BATCH_PROCESSING_ATTEMPTS
 
       // At least one block was successfully verified and imported, so we can be sure all
       // previous batches are valid and we only need to download the current failed batch.

--- a/packages/lodestar/src/sync/range/chain.ts
+++ b/packages/lodestar/src/sync/range/chain.ts
@@ -271,17 +271,16 @@ export class SyncChain {
       this.status = SyncChainStatus.Error;
       this.logger.verbose("SyncChain Error", {id: this.logId}, e as Error);
 
-      // A batch could not be processed after max retry limit. It's likely that all peers
-      // in this chain are sending invalid batches repeatedly so are either malicious or faulty.
-      // We drop the chain and report all peers.
-      // There are some edge cases with forks that could cause this situation, but it's unlikely.
-      if (e instanceof BatchError && e.type.code === BatchErrorCode.MAX_PROCESSING_ATTEMPTS) {
-        for (const peer of this.peerset.keys()) {
-          this.reportPeer(peer, PeerAction.LowToleranceError, "SyncChainMaxProcessingAttempts");
+      // If a batch exceeds it's retry limit, maybe downscore peers.
+      // shouldDownscoreOnBatchError() functions enforces that all BatchErrorCode values are covered
+      if (e instanceof BatchError) {
+        const shouldReportPeer = shouldReportPeerOnBatchError(e.type.code);
+        if (shouldReportPeer) {
+          for (const peer of this.peerset.keys()) {
+            this.reportPeer(peer, shouldReportPeer.action, shouldReportPeer.reason);
+          }
         }
       }
-
-      // TODO: Should peers be reported for MAX_DOWNLOAD_ATTEMPTS?
 
       throw e;
     }
@@ -479,5 +478,28 @@ export class SyncChain {
     }
 
     this.startEpoch = newStartEpoch;
+  }
+}
+
+/**
+ * Enforces that a report peer action is defined for all BatchErrorCode exhaustively.
+ * If peer should not be downscored, returns null.
+ */
+export function shouldReportPeerOnBatchError(
+  code: BatchErrorCode
+): {action: PeerAction.LowToleranceError; reason: string} | null {
+  switch (code) {
+    // A batch could not be processed after max retry limit. It's likely that all peers
+    // in this chain are sending invalid batches repeatedly so are either malicious or faulty.
+    // We drop the chain and report all peers.
+    // There are some edge cases with forks that could cause this situation, but it's unlikely.
+    case BatchErrorCode.MAX_PROCESSING_ATTEMPTS:
+      return {action: PeerAction.LowToleranceError, reason: "SyncChainMaxProcessingAttempts"};
+
+    // TODO: Should peers be reported for MAX_DOWNLOAD_ATTEMPTS?
+    case BatchErrorCode.WRONG_STATUS:
+    case BatchErrorCode.MAX_DOWNLOAD_ATTEMPTS:
+    case BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS:
+      return null;
   }
 }

--- a/packages/lodestar/src/sync/range/chain.ts
+++ b/packages/lodestar/src/sync/range/chain.ts
@@ -201,10 +201,6 @@ export class SyncChain {
     return toArr(this.batches).map((batch) => batch.getMetadata());
   }
 
-  get startEpochValue(): Epoch {
-    return this.startEpoch;
-  }
-
   get isSyncing(): boolean {
     return this.status === SyncChainStatus.Syncing;
   }

--- a/packages/lodestar/src/sync/unknownBlock.ts
+++ b/packages/lodestar/src/sync/unknownBlock.ts
@@ -189,6 +189,7 @@ export class UnknownBlockSync {
 
           case BlockErrorCode.PARENT_UNKNOWN:
           case BlockErrorCode.PRESTATE_MISSING:
+          case BlockErrorCode.EXECUTION_ENGINE_SYNCING:
           case BlockErrorCode.EXECUTION_ENGINE_ERRORED:
             // Should no happen, mark as pending to try again latter
             this.logger.error("Attempted to process block but its parent was still unknown", errorData, res.err);

--- a/packages/lodestar/src/sync/unknownBlock.ts
+++ b/packages/lodestar/src/sync/unknownBlock.ts
@@ -194,9 +194,7 @@ export class UnknownBlockSync {
             pendingBlock.status = PendingBlockStatus.pending;
             break;
 
-          case BlockErrorCode.EXECUTION_ENGINE_SYNCING:
-          case BlockErrorCode.EXECUTION_ENGINE_ERRORED:
-          case BlockErrorCode.EXECUTION_ENGINE_UNAVAILABLE:
+          case BlockErrorCode.EXECUTION_ENGINE_ERROR:
             // Removing the block(s) without penalizing the peers, hoping for EL to
             // recover on a latter download + verify attempt
             this.removeAllDescendants(pendingBlock);

--- a/packages/lodestar/src/sync/unknownBlock.ts
+++ b/packages/lodestar/src/sync/unknownBlock.ts
@@ -189,6 +189,7 @@ export class UnknownBlockSync {
 
           case BlockErrorCode.PARENT_UNKNOWN:
           case BlockErrorCode.PRESTATE_MISSING:
+          case BlockErrorCode.EXECUTION_ENGINE_ERRORED:
             // Should no happen, mark as pending to try again latter
             this.logger.error("Attempted to process block but its parent was still unknown", errorData, res.err);
             pendingBlock.status = PendingBlockStatus.pending;

--- a/packages/lodestar/test/unit/sync/range/batch.test.ts
+++ b/packages/lodestar/test/unit/sync/range/batch.test.ts
@@ -50,7 +50,7 @@ describe("sync / range / batch", () => {
     expect(blocksToProcess).to.equal(blocksDownloaded, "Blocks to process should be the same downloaded");
 
     // processingError: Processing -> AwaitingDownload
-    batch.processingError();
+    batch.processingError(new Error());
     expect(batch.state.status).to.equal(BatchStatus.AwaitingDownload, "Wrong status on processingError");
 
     // retry download + processing: AwaitingDownload -> Downloading -> AwaitingProcessing -> Processing

--- a/packages/params/src/index.ts
+++ b/packages/params/src/index.ts
@@ -181,3 +181,8 @@ export const NEXT_SYNC_COMMITTEE_GINDEX = 55;
  */
 export const NEXT_SYNC_COMMITTEE_DEPTH = 5;
 export const NEXT_SYNC_COMMITTEE_INDEX = 23;
+
+/**
+ * Optimistic sync
+ */
+export const SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY = 128;


### PR DESCRIPTION
**Motivation**
Currently in kintsugi devnets it has been observed that EL throws error like `internal error`, `invalid merkles` and sometimes `connection refused`. There could be host of other scenarios where EL is not able to respond. This causes block to be treated as invalid in the current handling, leading to downscoring of the peers. 
In a very limited peer scenario, lodestar eventually kicks all peers and goes out of sync unless peerstore is removed.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR 
- tracks the EL operation errors separately on executionEngine level and passes the information upstream. 
- Where these errors are treated in optimistic scenario allowing CL  to move its consensus forward. 
- The user is also logged a `warn` for him to check and take appropriate action/investigation.

and unnecessary/invalid down-scoring of the peer is also prevented.

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #3537
