### PR TITLE
update the latest working kintsugi merge EL image/commit targets

### DIFF
--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -3,8 +3,8 @@ name: Sim merge tests
 on: [pull_request, push]
 
 env:
-  GETH_COMMIT: 9a9e416d82b395b1f134eba19490ca130d3de8fe
-  NETHERMIND_COMMIT: 48ea18a48133f91e0e57af8a8120e2a8baceab2e
+  GETH_COMMIT: dfa207dc45e23a14c7d70453d13b6828b2230e5a
+  NETHERMIND_COMMIT: 0aaa60c6b6143d83d5c8c2246426956b0c4abfa2
 
 jobs:
   sim-merge-tests:
@@ -38,7 +38,7 @@ jobs:
       #Install Geth merge interop
       - uses: actions/setup-go@v2
       - name: Clone Geth merge interop branch
-        run: git clone -b merge-devnet-4 https://github.com/g11tech/go-ethereum.git && cd go-ethereum && git reset --hard $GETH_COMMIT && git submodule update --init --recursive
+        run: git clone -b merge-kintsugi https://github.com/g11tech/go-ethereum.git && cd go-ethereum && git reset --hard $GETH_COMMIT && git submodule update --init --recursive
       - name: Build Geth
         run: cd go-ethereum && make
 
@@ -56,7 +56,7 @@ jobs:
         with:
           dotnet-version: '6.0.x'
       - name: Clone Nethermind merge interop branch
-        run: git clone -b themerge_kintsugi_v3 https://github.com/g11tech/nethermind --recursive && cd nethermind && git reset --hard $NETHERMIND_COMMIT && git submodule update --init --recursive
+        run: git clone -b themerge_kintsugi https://github.com/g11tech/nethermind --recursive && cd nethermind && git reset --hard $NETHERMIND_COMMIT && git submodule update --init --recursive
       - name: Build Nethermind
         run: cd nethermind/src/Nethermind && dotnet build Nethermind.sln -c Release
 

--- a/kintsugi/devnets/kintsugi.vars
+++ b/kintsugi/devnets/kintsugi.vars
@@ -1,7 +1,7 @@
 DEVNET_NAME=kintsugi
 
-GETH_IMAGE=parithoshj/geth:merge-d99ac5a
-NETHERMIND_IMAGE=nethermindeth/nethermind:kintsugi_v3_0.1
+GETH_IMAGE=g11tech/geth:kintsugi-dfa207d
+NETHERMIND_IMAGE=nethermindeth/nethermind:kintsugi_0.5
 LODESTAR_IMAGE=chainsafe/lodestar:next
 
 CONFIG_GIT_DIR=kintsugi

--- a/kintsugi/gethdocker/Dockerfile
+++ b/kintsugi/gethdocker/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.17-alpine as builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 
-RUN git clone --depth 1 -b merge-devnet-4 https://github.com/MariusVanDerWijden/go-ethereum.git /go-ethereum
+RUN git clone --depth 1 -b merge-kintsugi https://github.com/MariusVanDerWijden/go-ethereum.git /go-ethereum
 RUN cd /go-ethereum && go run build/ci.go install ./cmd/geth
 
 FROM alpine:latest


### PR DESCRIPTION
**Motivation**
New images and updates have come out for `geth` and `nethermind`. 
This PR updates them to the latest working in the code CI/scripts.