### PR TITLE
Implement fast throw-free deserializeEnrSubnets

### DIFF
--- a/packages/lodestar/src/network/peers/utils/enrSubnetsDeserialize.ts
+++ b/packages/lodestar/src/network/peers/utils/enrSubnetsDeserialize.ts
@@ -1,0 +1,26 @@
+import {getUint8ByteToBitBooleanArray, newFilledArray} from "@chainsafe/lodestar-beacon-state-transition";
+import {ATTESTATION_SUBNET_COUNT, SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
+
+export const zeroAttnets = newFilledArray(ATTESTATION_SUBNET_COUNT, false);
+export const zeroSyncnets = newFilledArray(SYNC_COMMITTEE_SUBNET_COUNT, false);
+
+/**
+ * Fast deserialize a BitVector, with pre-cached bool array in `getUint8ByteToBitBooleanArray()`
+ *
+ * Never throw a deserialization error:
+ * - if bytes is too short, it will pad with zeroes
+ * - if bytes is too long, it will ignore the extra values
+ */
+export function deserializeEnrSubnets(bytes: Uint8Array, subnetCount: number): boolean[] {
+  if (subnetCount <= 8) {
+    return getUint8ByteToBitBooleanArray(bytes[0] ?? 0);
+  }
+
+  const boolsArr: boolean[] = [];
+  const byteCount = Math.ceil(subnetCount / 8);
+  for (let i = 0; i < byteCount; i++) {
+    boolsArr.concat(getUint8ByteToBitBooleanArray(bytes[i] ?? 0));
+  }
+
+  return boolsArr;
+}

--- a/packages/lodestar/test/perf/network/peers/enrSubnetsDeserialize.test.ts
+++ b/packages/lodestar/test/perf/network/peers/enrSubnetsDeserialize.test.ts
@@ -1,0 +1,47 @@
+import {itBench} from "@dapplion/benchmark";
+import {SYNC_COMMITTEE_SUBNET_COUNT, ATTESTATION_SUBNET_COUNT} from "@chainsafe/lodestar-params";
+import {ssz} from "@chainsafe/lodestar-types";
+import {expect} from "chai";
+import {deserializeEnrSubnets} from "../../../../src/network/peers/utils/enrSubnetsDeserialize";
+
+/**
+ * Ideally we want to sleep between requests to test the prune.
+ * But adding sinon mock timer here make it impossible to benchmark.
+ */
+describe("network / peers / deserializeEnrSubnets", () => {
+  const attnets = Buffer.from("feffb7f7fdfffefd", "hex");
+  const syncnets = Buffer.from("04", "hex");
+
+  before("Validate constants", () => {
+    expect(ATTESTATION_SUBNET_COUNT).to.equal(64, "ATTESTATION_SUBNET_COUNT changed");
+    expect(SYNC_COMMITTEE_SUBNET_COUNT).to.equal(4, "SYNC_COMMITTEE_SUBNET_COUNT changed");
+  });
+
+  itBench({
+    id: "enrSubnets - fastDeserialize 64 bits",
+    fn: () => {
+      deserializeEnrSubnets(attnets, ATTESTATION_SUBNET_COUNT);
+    },
+  });
+
+  itBench({
+    id: "enrSubnets - ssz BitVector 64 bits",
+    fn: () => {
+      ssz.phase0.AttestationSubnets.deserialize(attnets);
+    },
+  });
+
+  itBench({
+    id: "enrSubnets - fastDeserialize 4 bits",
+    fn: () => {
+      deserializeEnrSubnets(syncnets, SYNC_COMMITTEE_SUBNET_COUNT);
+    },
+  });
+
+  itBench({
+    id: "enrSubnets - ssz BitVector 4 bits",
+    fn: () => {
+      ssz.altair.SyncSubnets.deserialize(syncnets);
+    },
+  });
+});

--- a/packages/lodestar/test/unit/network/peers/utils/enrSubnets.test.ts
+++ b/packages/lodestar/test/unit/network/peers/utils/enrSubnets.test.ts
@@ -1,0 +1,27 @@
+import {SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
+import {ssz} from "@chainsafe/lodestar-types";
+import {expect} from "chai";
+import {deserializeEnrSubnets} from "../../../../../src/network/peers/utils/enrSubnetsDeserialize";
+
+describe("ENR syncnets", () => {
+  const testCases: {bytes: string; bools: boolean[]}[] = [
+    {bytes: "00", bools: [false, false, false, false]},
+    {bytes: "01", bools: [true, false, false, false]},
+    {bytes: "02", bools: [false, true, false, false]},
+    {bytes: "03", bools: [true, true, false, false]},
+    {bytes: "04", bools: [false, false, true, false]},
+    {bytes: "0f", bools: [true, true, true, true]},
+  ];
+
+  for (const {bytes, bools} of testCases) {
+    it(`Deserialize syncnet ${bytes}`, () => {
+      const bytesBuf = Buffer.from(bytes, "hex");
+
+      expect(ssz.altair.SyncSubnets.deserialize(bytesBuf)).to.deep.equal(bools);
+
+      expect(
+        deserializeEnrSubnets(bytesBuf, SYNC_COMMITTEE_SUBNET_COUNT).slice(0, SYNC_COMMITTEE_SUBNET_COUNT)
+      ).to.deep.equal(bools);
+    });
+  }
+});


### PR DESCRIPTION
**Motivation**

See https://github.com/ChainSafe/lodestar/issues/3549

Closes https://github.com/ChainSafe/lodestar/issues/3549

**Description**

- Implement fast throw-free deserializeEnrSubnets
- It's x20 times faster than ssz BitVector implementation since it leverages the pre-computed bool array from `getUint8ByteToBitBooleanArray`