### PR TITLE
Add async lag metric

### DIFF
--- a/packages/lodestar/src/metrics/asyncLag.ts
+++ b/packages/lodestar/src/metrics/asyncLag.ts
@@ -1,0 +1,36 @@
+import {AbortSignal} from "@chainsafe/abort-controller";
+import {isErrorAborted, sleep} from "@chainsafe/lodestar-utils";
+import {ILodestarMetrics} from "./metrics/lodestar";
+
+/**
+ * Track async lag, the difference between when a setTimeout() should execute, and when it actually execute.
+ * Is setTimeout(0, fn) is called at second 0.000s, and fn() is called at 0.053s async lag is 0.053s.
+ * When a node is overloaded with many tasks, such as incoming gossip, REST calls, the event loop fills up
+ * and callbacks take longer to execute. This metrics estimates this lag by sampling the event loop async
+ * delay once per `intervalMs`.
+ *
+ * @param intervalMs How frequently to sample async lag, recommended to set to a "high" value of >= 1sec.
+ */
+export async function trackAsyncLag(metrics: ILodestarMetrics, intervalMs: number, signal: AbortSignal): Promise<void> {
+  try {
+    const intervalSec = intervalMs / 1e3;
+    let prevTimeNs = process.hrtime.bigint();
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      await sleep(intervalMs, signal);
+
+      const newTimeNs = process.hrtime.bigint();
+      const diffSec = Number(newTimeNs - prevTimeNs) / 1e6;
+      metrics.asyncLag.observe(diffSec - intervalSec);
+
+      prevTimeNs = newTimeNs;
+    }
+  } catch (e) {
+    if (isErrorAborted(e)) {
+      return;
+    } else {
+      throw e;
+    }
+  }
+}

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -1,4 +1,3 @@
-import {allForks} from "@chainsafe/lodestar-types";
 import {RegistryMetricCreator} from "../utils/registryMetricCreator";
 import {IMetricsOptions} from "../options";
 
@@ -11,7 +10,7 @@ export type ILodestarMetrics = ReturnType<typeof createLodestarMetrics>;
 export function createLodestarMetrics(
   register: RegistryMetricCreator,
   metadata: IMetricsOptions["metadata"],
-  anchorState?: allForks.BeaconState
+  {genesisTime}: {genesisTime: number}
 ) {
   if (metadata) {
     register.static<"semver" | "branch" | "commit" | "version" | "network">({
@@ -22,14 +21,12 @@ export function createLodestarMetrics(
   }
 
   // Initial static metrics
-  if (anchorState) {
-    register
-      .gauge({
-        name: "lodestar_genesis_time",
-        help: "Genesis time in seconds",
-      })
-      .set(anchorState.genesisTime);
-  }
+  register
+    .gauge({
+      name: "lodestar_genesis_time",
+      help: "Genesis time in seconds",
+    })
+    .set(genesisTime);
 
   return {
     clockSlot: register.gauge({
@@ -674,5 +671,11 @@ export function createLodestarMetrics(
         help: "Total number of precomputing next epoch transition wasted",
       }),
     },
+
+    asyncLag: register.histogram({
+      name: "lodestar_async_lag_seconds",
+      help: "Async lag in seconds",
+      buckets: [0.1, 1, 10],
+    }),
   };
 }

--- a/packages/lodestar/src/metrics/options.ts
+++ b/packages/lodestar/src/metrics/options.ts
@@ -8,14 +8,18 @@ export interface IMetricsOptions {
   serverPort?: number;
   gatewayUrl?: string;
   listenAddr?: string;
+  asyncLagIntervalMs?: number;
+  disabledUnhandledRejectionMetric?: boolean;
   /** Optional metadata to send to Prometheus */
   metadata?: LodestarGitData & {network: string};
 }
 
-export const defaultMetricsOptions: IMetricsOptions = {
+export const defaultMetricsOptions: IMetricsOptions &
+  Required<Pick<IMetricsOptions, "enabled" | "timeout" | "serverPort" | "asyncLagIntervalMs">> = {
   enabled: false,
   timeout: 5000,
   serverPort: 8008,
+  asyncLagIntervalMs: 1000,
 };
 
 export type LodestarGitData = {

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -121,7 +121,10 @@ export class BeaconNode {
     // start db if not already started
     await db.start();
 
-    const metrics = opts.metrics.enabled ? createMetrics(opts.metrics, config, anchorState, metricsRegistries) : null;
+    const genesisTime = anchorState.genesisTime;
+    const metrics = opts.metrics.enabled
+      ? createMetrics(opts.metrics, config, {genesisTime}, signal, metricsRegistries)
+      : null;
     if (metrics) {
       initBeaconMetrics(metrics, anchorState);
     }

--- a/packages/lodestar/test/unit/metrics/utils.ts
+++ b/packages/lodestar/test/unit/metrics/utils.ts
@@ -1,8 +1,8 @@
+import {AbortController} from "@chainsafe/abort-controller";
 import {config} from "@chainsafe/lodestar-config/default";
-import {ssz} from "@chainsafe/lodestar-types";
 import {createMetrics, IMetrics} from "../../../src/metrics";
 
 export function createMetricsTest(): IMetrics {
-  const state = ssz.phase0.BeaconState.defaultValue();
-  return createMetrics({enabled: true, timeout: 12000}, config, state);
+  const controller = new AbortController();
+  return createMetrics({enabled: true, timeout: 12000}, config, {genesisTime: 0}, controller.signal);
 }


### PR DESCRIPTION
**Motivation**

The event loop lag doesn't tell the whole picture of how busy the event loop is. Some tests show that the event loop lag doesn't really correlate with how slow task processing really is.

The metric added in this PR seems to track better bussiness. However, the results should be similar, since `prom-client` uses `setImmediate()`

https://github.com/siimon/prom-client/blob/d00dbd55736595887ae77f1431e4326296e3c5ec/lib/metrics/eventLoopLag.js#L54

![event-loop-final-phases-1400x735](https://user-images.githubusercontent.com/35266934/147292717-79fb7099-0ee6-4a2e-b11c-d61e7bd31fa1.png)


**Description**

Add async lag metric