### PR TITLE
Lodestar gossip queues to wrap processRpcMessage()

### DIFF
--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -12,25 +12,25 @@ import {computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transiti
 
 import {IMetrics} from "../../metrics";
 import {
-  GossipJobQueues,
   GossipTopic,
   GossipTopicMap,
   GossipType,
   GossipTypeMap,
   ValidatorFnsByType,
   GossipHandlers,
+  ProcessRpcMessageFnsByType,
+  GossipJobQueues,
 } from "./interface";
 import {getGossipSSZType, GossipTopicCache, stringifyGossipTopic} from "./topic";
 import {computeMsgId, encodeMessageData, UncompressCache} from "./encoding";
 import {DEFAULT_ENCODING} from "./constants";
 import {GossipValidationError} from "./errors";
 import {GOSSIP_MAX_SIZE} from "../../constants";
-import {createValidatorFnsByType} from "./validation";
+import {createProcessRpcMessageFnsByType, createValidatorFnsByType} from "./validation";
 import {Map2d, Map2dArr} from "../../util/map";
 import pipe from "it-pipe";
 import PeerStreams from "libp2p-interfaces/src/pubsub/peer-streams";
 import BufferList from "bl";
-// import {RPC} from "libp2p-interfaces/src/pubsub/message/rpc";
 import {RPC} from "libp2p-gossipsub/src/message/rpc";
 import {normalizeInRpcMessage} from "libp2p-interfaces/src/pubsub/utils";
 
@@ -77,6 +77,8 @@ export class Eth2Gossipsub extends Gossipsub {
   private readonly msgIdCache = new WeakMap<InMessage, Uint8Array>();
 
   private readonly validatorFnsByType: ValidatorFnsByType;
+  // this wraps processRpcMessage() function in lodestar gossip queues
+  private readonly processRpcMessageFnsByType: ProcessRpcMessageFnsByType;
 
   constructor(modules: IGossipsubModules) {
     // Gossipsub parameters defined here:
@@ -99,14 +101,19 @@ export class Eth2Gossipsub extends Gossipsub {
     // Note: We use the validator functions as handlers. No handler will be registered to gossipsub.
     // libp2p-js layer will emit the message to an EventEmitter that won't be listened by anyone.
     // TODO: Force to ensure there's a validatorFunction attached to every received topic.
-    const {validatorFnsByType, jobQueues} = createValidatorFnsByType(gossipHandlers, {
+    this.validatorFnsByType = createValidatorFnsByType(gossipHandlers, {
       config,
       logger,
       uncompressCache: this.uncompressCache,
       metrics,
       signal,
     });
-    this.validatorFnsByType = validatorFnsByType;
+    const {processRpcMessagesFnByType, jobQueues} = createProcessRpcMessageFnsByType(
+      super._processRpcMessage.bind(this),
+      signal,
+      metrics
+    );
+    this.processRpcMessageFnsByType = processRpcMessagesFnByType;
     this.jobQueues = jobQueues;
 
     if (metrics) {
@@ -221,9 +228,27 @@ export class Eth2Gossipsub extends Gossipsub {
   // }
 
   /**
+   * Extend super._processRpcMessage() to wrap its logic in queue,
+   * this is the entry point for lodestar gossip queue implementation.
+   */
+  async _processRpcMessage(message: InMessage): Promise<void> {
+    // messages must have a single topicID
+    const topicStr = Array.isArray(message.topicIDs) ? message.topicIDs[0] : undefined;
+    if (!topicStr) {
+      // no need to send this to a queue
+      // the validate() function will handle message error
+      return super.validate(message);
+    }
+
+    // Execute the _processRpcMessage in a queue
+    const topic = this.gossipTopicCache.getTopic(topicStr);
+    await this.processRpcMessageFnsByType[topic.type](topic, message);
+  }
+
+  /**
    * @override https://github.com/ChainSafe/js-libp2p-gossipsub/blob/3c3c46595f65823fcd7900ed716f43f76c6b355c/ts/index.ts#L436
    * @override https://github.com/libp2p/js-libp2p-interfaces/blob/ff3bd10704a4c166ce63135747e3736915b0be8d/src/pubsub/index.js#L513
-   * Note: this does not call super. All logic is re-implemented below
+   * Note: this executes in queues and does not call super. All logic is re-implemented below
    */
   async validate(message: InMessage): Promise<void> {
     try {

--- a/packages/lodestar/src/network/gossip/interface.ts
+++ b/packages/lodestar/src/network/gossip/interface.ts
@@ -118,7 +118,13 @@ export type GossipValidatorFn = (topic: GossipTopic, message: InMessage, seenTim
 
 export type ValidatorFnsByType = {[K in GossipType]: GossipValidatorFn};
 
-export type GossipJobQueues = {[K in GossipType]: JobItemQueue<[GossipTopic, InMessage, number], void>};
+export type ProcessRpcMessageTopicFn = (topic: GossipTopic, message: InMessage) => Promise<void>;
+
+export type ProcessRpcMessageFn = (message: InMessage) => Promise<void>;
+
+export type ProcessRpcMessageFnsByType = {[K in GossipType]: ProcessRpcMessageTopicFn};
+
+export type GossipJobQueues = {[K in GossipType]: JobItemQueue<[GossipTopic, InMessage], void>};
 
 export type GossipHandlerFn = (
   object: GossipTypeMap[GossipType],

--- a/packages/lodestar/src/network/gossip/validation/index.ts
+++ b/packages/lodestar/src/network/gossip/validation/index.ts
@@ -1,4 +1,5 @@
 import {ERR_TOPIC_VALIDATOR_IGNORE, ERR_TOPIC_VALIDATOR_REJECT} from "libp2p-gossipsub/src/constants";
+import {InMessage} from "libp2p-interfaces/src/pubsub";
 import {AbortSignal} from "@chainsafe/abort-controller";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {Json} from "@chainsafe/ssz";
@@ -14,15 +15,14 @@ import {
   ProcessRpcMessageFn,
   GossipTopic,
   ProcessRpcMessageFnsByType,
+  GossipJobQueues,
 } from "../interface";
 import {GossipValidationError} from "../errors";
 import {GossipActionError, GossipAction} from "../../../chain/errors";
 import {decodeMessageData, UncompressCache} from "../encoding";
 import {DEFAULT_ENCODING} from "../constants";
 import {getGossipAcceptMetadataByType, GetGossipAcceptMetadataFn} from "./onAccept";
-import {GossipJobQueues} from "..";
 import {createProcessRpcMessageQueues} from "./queue";
-import {InMessage} from "libp2p-interfaces/src/pubsub";
 
 type ValidatorFnModules = {
   config: IChainForkConfig;

--- a/packages/lodestar/src/network/gossip/validation/queue.ts
+++ b/packages/lodestar/src/network/gossip/validation/queue.ts
@@ -3,7 +3,7 @@ import {InMessage} from "libp2p-interfaces/src/pubsub";
 import {mapValues} from "@chainsafe/lodestar-utils";
 import {IMetrics} from "../../../metrics";
 import {JobItemQueue, JobQueueOpts, QueueType} from "../../../util/queue";
-import {GossipJobQueues, GossipTopic, GossipType, ValidatorFnsByType} from "../interface";
+import {GossipJobQueues, GossipTopic, GossipType, ProcessRpcMessageFn} from "../interface";
 
 /**
  * Numbers from https://github.com/sigp/lighthouse/blob/b34a79dc0b02e04441ba01fd0f304d1e203d877d/beacon_node/network/src/beacon_processor/mod.rs#L69
@@ -21,10 +21,10 @@ const gossipQueueOpts: {[K in GossipType]: Pick<JobQueueOpts, "maxLength" | "typ
 };
 
 /**
- * Wraps a GossipValidatorFn with a queue, to limit the processing of gossip objects by type.
+ * Wraps a _processRpcMessage() function with a queue, to limit the processing of gossip objects by type.
  *
  * A queue here is essential to protect against DOS attacks, where a peer may send many messages at once.
- * Queues also protect the node against overloading. If the node gets bussy with an expensive epoch transition,
+ * Queues also protect the node against overloading. If the node gets busy with an expensive epoch transition,
  * it may buffer too many gossip objects causing an Out of memory (OOM) error. With a queue the node will reject
  * new objects to fit its current throughput.
  *
@@ -36,15 +36,14 @@ const gossipQueueOpts: {[K in GossipType]: Pick<JobQueueOpts, "maxLength" | "typ
  * By topic is too specific, so by type groups all similar objects in the same queue. All in the same won't allow
  * to customize different queue behaviours per object type (see `gossipQueueOpts`).
  */
-export function createValidationQueues(
-  gossipValidatorFns: ValidatorFnsByType,
+export function createProcessRpcMessageQueues(
+  processRpcMsgFn: ProcessRpcMessageFn,
   signal: AbortSignal,
   metrics: IMetrics | null
 ): GossipJobQueues {
   return mapValues(gossipQueueOpts, (opts, type) => {
-    const gossipValidatorFn = gossipValidatorFns[type];
-    return new JobItemQueue<[GossipTopic, InMessage, number], void>(
-      (topic, message, seenTimestampsMs) => gossipValidatorFn(topic, message, seenTimestampsMs),
+    return new JobItemQueue<[GossipTopic, InMessage], void>(
+      (topic, message) => processRpcMsgFn(message),
       {signal, ...opts},
       metrics
         ? {


### PR DESCRIPTION
**Motivation**

+ When we subscribe to all subnets (or the node have so many connected validators), we waste time uncompressing messages, getting message id and drop it in the end

**Description**

+ Lodestar gossip queues to wrap processRpcMessage() function instead of validate() function

Closes #3553 

**Test Result with subscribeAllSubnets flag**
This shows significant improvement with `subscribeAllSubnets` flag and 2 contabo nodes (contabo-19/master vs contabo-20/this-branch)

+ Master cannot maintain a good number of peer
<img width="791" alt="Screen Shot 2021-12-27 at 16 57 09" src="https://user-images.githubusercontent.com/10568965/147460172-88465206-e88d-4640-8744-3b68f0187c6c.png">

+ This branch can
<img width="810" alt="Screen Shot 2021-12-27 at 16 57 35" src="https://user-images.githubusercontent.com/10568965/147460225-20ed1cf3-c2db-4334-9541-5720583a6715.png">

+ Master can process up to 1024 attestation messages
<img width="801" alt="Screen Shot 2021-12-27 at 16 58 58" src="https://user-images.githubusercontent.com/10568965/147460380-107da1aa-85e7-4751-94de-79b475897a7f.png">

+ This branch can process 4x number of messages
<img width="787" alt="Screen Shot 2021-12-27 at 16 59 36" src="https://user-images.githubusercontent.com/10568965/147460467-e968990f-ea88-42f6-97c9-3c0a31ba5e9e.png">

+ Master: gossip block is delayed a lot and node uses UnknownBlock sync frequently
<img width="816" alt="Screen Shot 2021-12-27 at 17 01 07" src="https://user-images.githubusercontent.com/10568965/147460621-839c0944-4a2a-4f63-b847-9246608b4ec3.png">

+ This branch: gossip block is delayed mostly <= 10s (40s 1 time), UnknownBlock sync is not used
<img width="776" alt="Screen Shot 2021-12-27 at 17 02 00" src="https://user-images.githubusercontent.com/10568965/147460748-689e3be3-26f1-4aed-a152-7e4c951728fa.png">
