### PR TITLE
Updated documentation regarding starting a beacon chain

### DIFF
--- a/docs/usage/testnet.md
+++ b/docs/usage/testnet.md
@@ -17,7 +17,7 @@ To select a known testnet or mainnet, use the `--network` flag. `mainnet` is sel
 If you would like to initialize your beacon node with the basic files required to run on a testnet or mainnet before actually running the node (Especially useful for configuring a new testnet), you can run the following command:
 
 ```bash
-./lodestar beacon init --network $NETWORK_NAME
+./lodestar init --network $NETWORK_NAME
 ```
 
 By default, lodestar stores all configuration and chain data at the path `$XDG_DATA_HOME/lodestar/$NETWORK_NAME`.
@@ -28,6 +28,20 @@ To start a Lodestar beacon run the command:
 
 ```bash
 ./lodestar beacon --network $NETWORK_NAME
+```
+
+This will assume an eth1 client is available at the default location of `localhost:8545`. 
+
+In case eth1 clients are available at different locations, use `--eth1.providerUrls` to specify these locations in the command: 
+
+```bash
+./lodestar beacon --network $NETWORK_NAME --eth1.providerUrls eth1.url1 eth1.url2
+```
+
+It is also possible to start a Lodestar beacon that does not follow the eth1 chain. For this, use the `eth1.enabled` option in the command: 
+
+```bash
+./lodestar beacon --eth1.enabled false --network $NETWORK_NAME
 ```
 
 Immediately you should see confirmation that the node has started


### PR DESCRIPTION
**Motivation**

Some portion of the documentation has since diverged from the current behaviour of the cli. 
This PR updates this outdated part of the documentation.

**Description**

Updated the command listed in the documentation to reflect the fact that `init` is no longer a sub command of `beacon`. Also provided more instructions regarding the location of an eth1 client that the beacon node expects.

