### PR TITLE
Add CLI flag to read bootnode ENRs from a file

### DIFF
--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -157,7 +157,7 @@ export const beaconPathsOptions: ICliCommandOptions<IBeaconPaths> = {
 
   bootnodesFile: {
     hidden: true,
-    description: "Bootnode ENR file path",
+    description: "Bootnodes file path",
     defaultDescription: defaultBeaconPaths.bootnodesFile,
     type: "string",
   },

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -158,7 +158,6 @@ export const beaconPathsOptions: ICliCommandOptions<IBeaconPaths> = {
   bootnodesFile: {
     hidden: true,
     description: "Bootnodes file path",
-    defaultDescription: defaultBeaconPaths.bootnodesFile,
     type: "string",
   },
 };

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -154,6 +154,13 @@ export const beaconPathsOptions: ICliCommandOptions<IBeaconPaths> = {
     description: "Path to output all logs to a persistent log file",
     type: "string",
   },
+
+  bootnodesFile: {
+    hidden: true,
+    description: "Bootnode ENR file path",
+    defaultDescription: defaultBeaconPaths.bootnodesFile,
+    type: "string",
+  },
 };
 
 export type IBeaconArgs = IBeaconExtraArgs & ILogArgs & IBeaconPaths & IBeaconNodeArgs & IENRArgs;

--- a/packages/cli/src/cmds/beacon/paths.ts
+++ b/packages/cli/src/cmds/beacon/paths.ts
@@ -11,6 +11,7 @@ export interface IBeaconPaths {
   peerIdFile: string;
   enrFile: string;
   logFile?: string;
+  bootnodesFile?: string;
 }
 
 /**
@@ -41,6 +42,7 @@ export function getBeaconPaths(
   const peerIdFile = args.peerIdFile || path.join(beaconDir, "peer-id.json");
   const enrFile = args.enrFile || path.join(beaconDir, "enr");
   const logFile = args.logFile;
+  const bootnodesFile = args.bootnodesFile;
 
   return {
     ...globalPaths,
@@ -52,6 +54,7 @@ export function getBeaconPaths(
     peerIdFile,
     enrFile,
     logFile,
+    bootnodesFile,
   };
 }
 

--- a/packages/cli/src/cmds/init/handler.ts
+++ b/packages/cli/src/cmds/init/handler.ts
@@ -1,16 +1,8 @@
 import fs from "fs";
-import {
-  BeaconNodeOptions,
-  getBeaconConfigFromArgs,
-  initPeerId,
-  initEnr,
-  readPeerId,
-  readEnr,
-  mergeBeaconNodeOptions,
-} from "../../config";
+import {BeaconNodeOptions, getBeaconConfigFromArgs, initPeerId, initEnr, readPeerId, readEnr} from "../../config";
 import {IGlobalArgs, parseBeaconNodeArgs} from "../../options";
 import {mkdir} from "../../util";
-import {fetchBootnodes, getInjectableBootEnrs} from "../../networks";
+import {fetchBootnodes} from "../../networks";
 import {getBeaconPaths} from "../beacon/paths";
 import {IBeaconArgs} from "../beacon/options";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
@@ -32,16 +24,11 @@ export async function initHandler(args: IBeaconArgs & IGlobalArgs): Promise<Retu
 export async function initializeOptionsAndConfig(args: IBeaconArgs & IGlobalArgs): Promise<ReturnType> {
   const beaconPaths = getBeaconPaths(args);
 
-  const injectableBootEnrs = await getInjectableBootEnrs(beaconPaths.bootnodesFile);
-  // Merge CLI-provided beacon options in order:
-  // - Injected bootnode ENRs if its specified
-  // - Any other options obtained through CLI
-  const beaconNodeOptionsCli = mergeBeaconNodeOptions(injectableBootEnrs, parseBeaconNodeArgs(args));
-
   const beaconNodeOptions = new BeaconNodeOptions({
     network: args.network || "mainnet",
     configFile: beaconPaths.configFile,
-    beaconNodeOptionsCli,
+    bootnodesFile: beaconPaths.bootnodesFile,
+    beaconNodeOptionsCli: parseBeaconNodeArgs(args),
   });
 
   // Auto-setup network

--- a/packages/cli/src/cmds/init/handler.ts
+++ b/packages/cli/src/cmds/init/handler.ts
@@ -44,9 +44,6 @@ export async function initializeOptionsAndConfig(args: IBeaconArgs & IGlobalArgs
     beaconNodeOptionsCli,
   });
 
-  // eslint-disable-next-line no-console
-  console.log(beaconNodeOptions.get()?.network?.discv5?.bootEnrs);
-
   // Auto-setup network
   // Only download files if network.discv5.bootEnrs arg is not specified
   const bOpts = beaconNodeOptions.get();

--- a/packages/cli/src/cmds/init/handler.ts
+++ b/packages/cli/src/cmds/init/handler.ts
@@ -1,8 +1,16 @@
 import fs from "fs";
-import {BeaconNodeOptions, getBeaconConfigFromArgs, initPeerId, initEnr, readPeerId, readEnr} from "../../config";
+import {
+  BeaconNodeOptions,
+  getBeaconConfigFromArgs,
+  initPeerId,
+  initEnr,
+  readPeerId,
+  readEnr,
+  mergeBeaconNodeOptions,
+} from "../../config";
 import {IGlobalArgs, parseBeaconNodeArgs} from "../../options";
 import {mkdir} from "../../util";
-import {fetchBootnodes} from "../../networks";
+import {fetchBootnodes, getInjectableBootEnrs} from "../../networks";
 import {getBeaconPaths} from "../beacon/paths";
 import {IBeaconArgs} from "../beacon/options";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
@@ -23,11 +31,21 @@ export async function initHandler(args: IBeaconArgs & IGlobalArgs): Promise<Retu
 
 export async function initializeOptionsAndConfig(args: IBeaconArgs & IGlobalArgs): Promise<ReturnType> {
   const beaconPaths = getBeaconPaths(args);
+
+  const injectableBootEnrs = await getInjectableBootEnrs(beaconPaths.bootnodesFile);
+  // Merge CLI-provided beacon options in order:
+  // - Injected bootnode ENRs if its specified
+  // - Any other options obtained through CLI
+  const beaconNodeOptionsCli = mergeBeaconNodeOptions(injectableBootEnrs, parseBeaconNodeArgs(args));
+
   const beaconNodeOptions = new BeaconNodeOptions({
     network: args.network || "mainnet",
     configFile: beaconPaths.configFile,
-    beaconNodeOptionsCli: parseBeaconNodeArgs(args),
+    beaconNodeOptionsCli,
   });
+
+  // eslint-disable-next-line no-console
+  console.log(beaconNodeOptions.get()?.network?.discv5?.bootEnrs);
 
   // Auto-setup network
   // Only download files if network.discv5.bootEnrs arg is not specified

--- a/packages/cli/src/config/beaconNodeOptions.ts
+++ b/packages/cli/src/config/beaconNodeOptions.ts
@@ -3,7 +3,7 @@ import {Json} from "@chainsafe/ssz";
 import {defaultOptions, IBeaconNodeOptions} from "@chainsafe/lodestar";
 import {isPlainObject, RecursivePartial} from "@chainsafe/lodestar-utils";
 import {writeFile, readFile} from "../util";
-import {getNetworkBeaconNodeOptions, NetworkName} from "../networks";
+import {getInjectableBootEnrs, getNetworkBeaconNodeOptions, NetworkName} from "../networks";
 
 export class BeaconNodeOptions {
   private beaconNodeOptions: RecursivePartial<IBeaconNodeOptions>;
@@ -17,15 +17,18 @@ export class BeaconNodeOptions {
   constructor({
     network,
     configFile,
+    bootnodesFile,
     beaconNodeOptionsCli,
   }: {
     network?: NetworkName;
     configFile?: string;
+    bootnodesFile?: string;
     beaconNodeOptionsCli: RecursivePartial<IBeaconNodeOptions>;
   }) {
     this.beaconNodeOptions = mergeBeaconNodeOptions(
       network ? getNetworkBeaconNodeOptions(network) : {},
       configFile ? readBeaconNodeOptions(configFile) : {},
+      bootnodesFile ? getInjectableBootEnrs(bootnodesFile) : {},
       beaconNodeOptionsCli
     );
   }

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -79,7 +79,7 @@ export async function fetchBootnodes(network: NetworkName): Promise<string[]> {
 }
 
 /**
- * Reads a list of bootnodes for a network from a file.
+ * Reads and parses a list of bootnodes for a network from a file.
  */
 export async function readBootnodes(bootnodesFilePath: string): Promise<string[]> {
   if (!fs.existsSync(bootnodesFilePath)) {
@@ -94,7 +94,8 @@ export async function readBootnodes(bootnodesFilePath: string): Promise<string[]
 
 /**
  * Parses a file to get a list of bootnodes for a network.
- * Bootnodes file is expected to contain bootnode ENR's concatenated by newlines
+ * Bootnodes file is expected to contain bootnode ENR's concatenated by newlines, or commas for
+ * parsing plaintext, YAML, JSON and/or env files.
  */
 export function parseBootnodesFile(bootnodesFile: string): string[] {
   const enrs = [];
@@ -109,14 +110,10 @@ export function parseBootnodesFile(bootnodesFile: string): string[] {
   return enrs;
 }
 
-export function enrsToNetworkConfig(enrs: string[]): RecursivePartial<IBeaconNodeOptions> {
-  if (enrs.length === 0) {
-    return {};
-  }
-
-  return {network: {discv5: {bootEnrs: enrs}}};
-}
-
+/**
+ * Parses a file to get a list of bootnodes for a network if given a valid path,
+ * and returns the bootnodes in an "injectable" network options format.
+ */
 export async function getInjectableBootEnrs(
   bootnodesFilepath: string | undefined
 ): Promise<RecursivePartial<IBeaconNodeOptions>> {
@@ -124,6 +121,18 @@ export async function getInjectableBootEnrs(
   const injectableBootEnrs = enrsToNetworkConfig(bootEnrs);
 
   return injectableBootEnrs;
+}
+
+/**
+ * Given an array of bootnodes, returns them in an "injectable" format,
+ * or an empty object if given an empty array.
+ */
+export function enrsToNetworkConfig(enrs: string[]): RecursivePartial<IBeaconNodeOptions> {
+  if (enrs.length === 0) {
+    return {};
+  }
+
+  return {network: {discv5: {bootEnrs: enrs}}};
 }
 
 /**

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -8,8 +8,8 @@ import {TreeBacked} from "@chainsafe/ssz";
 import fs from "fs";
 import got from "got";
 import * as mainnet from "./mainnet";
-import * as prater from "./prater";
 import * as pyrmont from "./pyrmont";
+import * as prater from "./prater";
 
 export type NetworkName = "mainnet" | "pyrmont" | "prater" | "dev";
 export const networkNames: NetworkName[] = ["mainnet", "pyrmont", "prater"];

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -82,14 +82,15 @@ export async function fetchBootnodes(network: NetworkName): Promise<string[]> {
  * Reads and parses a list of bootnodes for a network from a file.
  */
 export async function readBootnodes(bootnodesFilePath: string): Promise<string[]> {
-  if (!fs.existsSync(bootnodesFilePath)) {
-    // eslint-disable-next-line no-console
-    console.error("Bootnode file not found. Using default bootnodes.");
-    return [];
-  }
   const bootnodesFile = fs.readFileSync(bootnodesFilePath, "utf8");
 
-  return parseBootnodesFile(bootnodesFile);
+  const bootnodes = parseBootnodesFile(bootnodesFile);
+
+  if (bootnodes.length === 0) {
+    throw new Error(`No bootnodes found on file ${bootnodesFilePath}`);
+  }
+
+  return bootnodes;
 }
 
 /**

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -81,7 +81,7 @@ export async function fetchBootnodes(network: NetworkName): Promise<string[]> {
 /**
  * Reads and parses a list of bootnodes for a network from a file.
  */
-export async function readBootnodes(bootnodesFilePath: string): Promise<string[]> {
+export function readBootnodes(bootnodesFilePath: string): string[] {
   const bootnodesFile = fs.readFileSync(bootnodesFilePath, "utf8");
 
   const bootnodes = parseBootnodesFile(bootnodesFile);
@@ -115,10 +115,8 @@ export function parseBootnodesFile(bootnodesFile: string): string[] {
  * Parses a file to get a list of bootnodes for a network if given a valid path,
  * and returns the bootnodes in an "injectable" network options format.
  */
-export async function getInjectableBootEnrs(
-  bootnodesFilepath: string | undefined
-): Promise<RecursivePartial<IBeaconNodeOptions>> {
-  const bootEnrs = bootnodesFilepath ? await readBootnodes(bootnodesFilepath) : [];
+export function getInjectableBootEnrs(bootnodesFilepath: string): RecursivePartial<IBeaconNodeOptions> {
+  const bootEnrs = readBootnodes(bootnodesFilepath);
   const injectableBootEnrs = enrsToNetworkConfig(bootEnrs);
 
   return injectableBootEnrs;

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -125,14 +125,9 @@ export function getInjectableBootEnrs(bootnodesFilepath: string): RecursiveParti
 }
 
 /**
- * Given an array of bootnodes, returns them in an "injectable" format,
- * or an empty object if given an empty array.
+ * Given an array of bootnodes, returns them in an injectable format
  */
 export function enrsToNetworkConfig(enrs: string[]): RecursivePartial<IBeaconNodeOptions> {
-  if (enrs.length === 0) {
-    return {};
-  }
-
   return {network: {discv5: {bootEnrs: enrs}}};
 }
 

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -102,7 +102,7 @@ export function parseBootnodesFile(bootnodesFile: string): string[] {
   const enrs = [];
   for (const line of bootnodesFile.trim().split(/\r?\n/)) {
     for (const entry of line.split(",")) {
-      if (entry.includes("enr:")) {
+      if (entry.startsWith("enr:")) {
         const parsedEnr = `enr:${entry.split("enr:")[1]}`.replace(/['",[\]{}@.+]+/g, "");
         enrs.push(parsedEnr);
       }

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -102,8 +102,10 @@ export function parseBootnodesFile(bootnodesFile: string): string[] {
   const enrs = [];
   for (const line of bootnodesFile.trim().split(/\r?\n/)) {
     for (const entry of line.split(",")) {
-      if (entry.startsWith("enr:")) {
-        const parsedEnr = `enr:${entry.split("enr:")[1]}`.replace(/['",[\]{}@.+]+/g, "");
+      const sanitizedEntry = entry.replace(/['",[\]{}.]+/g, "").trim();
+
+      if (sanitizedEntry.includes("enr:-")) {
+        const parsedEnr = `enr:-${sanitizedEntry.split("enr:-")[1]}`;
         enrs.push(parsedEnr);
       }
     }

--- a/packages/cli/test/unit/config/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/config/beaconNodeOptions.test.ts
@@ -1,5 +1,4 @@
-import {defaultOptions, IBeaconNodeOptions} from "@chainsafe/lodestar";
-import {RecursivePartial} from "@chainsafe/lodestar-utils";
+import {defaultOptions} from "@chainsafe/lodestar";
 import {expect} from "chai";
 import fs from "fs";
 import path from "path";
@@ -39,14 +38,14 @@ describe("config / beaconNodeOptions", () => {
     const rootDir = testFilesDir;
     const bootnodesFile = path.join(testFilesDir, "bootnodesFile.txt");
     fs.writeFileSync(bootnodesFile, expectedBootEnr);
+
     const beaconPaths = getBeaconPaths({rootDir});
     beaconPaths.bootnodesFile = bootnodesFile;
 
-    const injectableBootEnrs = await getInjectableBootEnrs(beaconPaths.bootnodesFile);
-
     const beaconNodeOptions = new BeaconNodeOptions({
       network: "pyrmont",
-      beaconNodeOptionsCli: injectableBootEnrs,
+      bootnodesFile: beaconPaths.bootnodesFile,
+      beaconNodeOptionsCli: {},
     });
 
     // Asserts only part of the data structure to avoid unnecesary duplicate code
@@ -61,15 +60,14 @@ describe("config / beaconNodeOptions", () => {
     const rootDir = testFilesDir;
     const bootnodesFile = path.join(testFilesDir, "bootnodesFile.txt");
     fs.writeFileSync(bootnodesFile, bootnodesFileContent);
+
     const beaconPaths = getBeaconPaths({rootDir});
     beaconPaths.bootnodesFile = bootnodesFile;
 
-    const injectableBootEnrs = await getInjectableBootEnrs(beaconPaths.bootnodesFile);
-    const beaconNodeOptionsCli = mergeBeaconNodeOptions(injectableBootEnrs, enrsToNetworkConfig([expectedBootEnr]));
-
     const beaconNodeOptions = new BeaconNodeOptions({
       network: "pyrmont",
-      beaconNodeOptionsCli,
+      bootnodesFile: beaconPaths.bootnodesFile,
+      beaconNodeOptionsCli: enrsToNetworkConfig([expectedBootEnr]),
     });
 
     // Asserts only part of the data structure to avoid unnecesary duplicate code
@@ -193,16 +191,6 @@ enr:-Ku4QPp9z1W4tAO8Ber_NQierYaOStqhDqQdOPY3bB3jDgkjcbk6YrEnVYIiCBbTxuar3CzS528d
 });
 
 describe("mergeBeaconNodeOptions", () => {
-  const enrsToNetworkConfig = (enrs: string[]): RecursivePartial<IBeaconNodeOptions> => {
-    return {
-      network: {
-        discv5: {
-          bootEnrs: enrs,
-        },
-      },
-    };
-  };
-
   const testCases: {name: string; networkEnrs: string[]; cliEnrs: string[]; resultEnrs: string[]}[] = [
     {name: "normal case", networkEnrs: ["enr-1", "enr-2", "enr-3"], cliEnrs: ["new-enr"], resultEnrs: ["new-enr"]},
     // TODO: investigate arrayMerge has no effect?

--- a/packages/cli/test/unit/config/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/config/beaconNodeOptions.test.ts
@@ -5,7 +5,7 @@ import fs from "fs";
 import path from "path";
 import {getBeaconPaths} from "../../../src/cmds/beacon/paths";
 import {BeaconNodeOptions, mergeBeaconNodeOptions} from "../../../src/config";
-import {enrsToNetworkConfig, getInjectableBootEnrs} from "../../../src/networks";
+import {enrsToNetworkConfig, getInjectableBootEnrs, parseBootnodesFile} from "../../../src/networks";
 import {bootEnrs as pyrmontBootEnrs} from "../../../src/networks/pyrmont";
 import {testFilesDir} from "../../utils";
 
@@ -86,6 +86,110 @@ describe("config / beaconNodeOptions", () => {
     const options = beaconNodeOptions.getWithDefaults();
     expect(options.eth1).to.deep.equal(defaultOptions.eth1);
   });
+});
+
+describe("config / bootnodes / parsing", () => {
+  const testCases = [
+    {
+      name: "can parse inline JSON input",
+      input: `
+{
+  "enrs": ["enr:-cabfg", "enr:-deadbeef"]
+}
+`,
+      expected: ["enr:-cabfg", "enr:-deadbeef"],
+    },
+    {
+      name: "can parse multiline JSON input",
+      input: `
+{
+  "enrs": 
+    [
+      "enr:-cabfg",
+      "enr:-deadbeef"
+    ]
+}
+`,
+      expected: ["enr:-cabfg", "enr:-deadbeef"],
+    },
+    {
+      name: "Can parse YAML input",
+      input: `
+- "enr:-Iu4QGCUN3RjOLZCab4LLqlOqnnOB9BspIE30Nj5gQGoY00ZXCIW2PCXuGqDLHEPZJK9NO8SFZlKzFF-5rSbTyPqksoBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQJmy_5ZkaIFozyMd3gPygG1lVLQONuTL4C1j_smkZ9WmoN0Y3CCIyiDdWRwgiMo"
+- "enr:-Iu4QCKxIZVqkBMGHOxfeDvY8Yp0V0uq2MQ8wFS2tQGMfQ1YVuER_WeyVmqKawz6H4JE1OVeN52_kJUdZmkuvpyETjMBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQNsaKrbnhjMgAcpHREHrZiCA7sXyEOokOck_1oc3zZMG4N0Y3CCJRyDdWRwgiUc"
+- "enr:-Iu4QN6QRhX7abcUZ6E5eV9-AIUSXpNBSytiSNwG0FGWWifEevi98EDGhoPVt3e82j9KC2H7DiLtDGnj03MMrs707fEBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQL4Lu3nwG5diXILEh3LiAauCrNgtoTJxGZQER33BTDMKoN0Y3CCIyiDdWRwgiMo"
+`,
+      expected: [
+        "enr:-Iu4QGCUN3RjOLZCab4LLqlOqnnOB9BspIE30Nj5gQGoY00ZXCIW2PCXuGqDLHEPZJK9NO8SFZlKzFF-5rSbTyPqksoBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQJmy_5ZkaIFozyMd3gPygG1lVLQONuTL4C1j_smkZ9WmoN0Y3CCIyiDdWRwgiMo",
+        "enr:-Iu4QCKxIZVqkBMGHOxfeDvY8Yp0V0uq2MQ8wFS2tQGMfQ1YVuER_WeyVmqKawz6H4JE1OVeN52_kJUdZmkuvpyETjMBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQNsaKrbnhjMgAcpHREHrZiCA7sXyEOokOck_1oc3zZMG4N0Y3CCJRyDdWRwgiUc",
+        "enr:-Iu4QN6QRhX7abcUZ6E5eV9-AIUSXpNBSytiSNwG0FGWWifEevi98EDGhoPVt3e82j9KC2H7DiLtDGnj03MMrs707fEBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQL4Lu3nwG5diXILEh3LiAauCrNgtoTJxGZQER33BTDMKoN0Y3CCIyiDdWRwgiMo",
+      ],
+    },
+    {
+      name: "Can parse normal txt-file input",
+      input: `
+### Ethereum Node Records
+- "enr:-KG4QOWkRj"
+`,
+      expected: ["enr:-KG4QOWkRj"],
+    },
+    {
+      name: "Can parse plain txt-file input",
+      input: `
+# Eth2 mainnet bootnodes
+# ---------------------------------------
+# 1. Tag nodes with maintainer
+# 2. Keep nodes updated
+# 3. Review PRs: check ENR duplicates, fork-digest, connection.
+
+# Teku team's bootnodes
+enr:-KG4QOtcP9X1FbIMOe17QNMKqDxCpm14jcX5tiOE4_TyMrFqbmhPZHK_ZPG2Gxb1GE2xdtodOfx9-cgvNtxnRyHEmC0ghGV0aDKQ9aX9QgAAAAD__________4JpZIJ2NIJpcIQDE8KdiXNlY3AyNTZrMaEDhpehBDbZjM_L9ek699Y7vhUJ-eAdMyQW_Fil522Y0fODdGNwgiMog3VkcIIjKA
+enr:-KG4QL-eqFoHy0cI31THvtZjpYUu_Jdw_MO7skQRJxY1g5HTN1A0epPCU6vi0gLGUgrzpU-ygeMSS8ewVxDpKfYmxMMGhGV0aDKQtTA_KgAAAAD__________4JpZIJ2NIJpcIQ2_DUbiXNlY3AyNTZrMaED8GJ2vzUqgL6-KD1xalo1CsmY4X1HaDnyl6Y_WayCo9GDdGNwgiMog3VkcIIjKA
+
+# Prylab team's bootnodes
+enr:-Ku4QImhMc1z8yCiNJ1TyUxdcfNucje3BGwEHzodEZUan8PherEo4sF7pPHPSIB1NNuSg5fZy7qFsjmUKs2ea1Whi0EBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQOVphkDqal4QzPMksc5wnpuC3gvSC8AfbFOnZY_On34wIN1ZHCCIyg
+enr:-Ku4QP2xDnEtUXIjzJ_DhlCRN9SN99RYQPJL92TMlSv7U5C1YnYLjwOQHgZIUXw6c-BvRg2Yc2QsZxxoS_pPRVe0yK8Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQMeFF5GrS7UZpAH2Ly84aLK-TyvH-dRo0JM1i8yygH50YN1ZHCCJxA
+enr:-Ku4QPp9z1W4tAO8Ber_NQierYaOStqhDqQdOPY3bB3jDgkjcbk6YrEnVYIiCBbTxuar3CzS528d2iE7TdJsrL-dEKoBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQMw5fqqkw2hHC4F5HZZDPsNmPdB1Gi8JPQK7pRc9XHh-oN1ZHCCKvg
+  `,
+      expected: [
+        "enr:-KG4QOtcP9X1FbIMOe17QNMKqDxCpm14jcX5tiOE4_TyMrFqbmhPZHK_ZPG2Gxb1GE2xdtodOfx9-cgvNtxnRyHEmC0ghGV0aDKQ9aX9QgAAAAD__________4JpZIJ2NIJpcIQDE8KdiXNlY3AyNTZrMaEDhpehBDbZjM_L9ek699Y7vhUJ-eAdMyQW_Fil522Y0fODdGNwgiMog3VkcIIjKA",
+        "enr:-KG4QL-eqFoHy0cI31THvtZjpYUu_Jdw_MO7skQRJxY1g5HTN1A0epPCU6vi0gLGUgrzpU-ygeMSS8ewVxDpKfYmxMMGhGV0aDKQtTA_KgAAAAD__________4JpZIJ2NIJpcIQ2_DUbiXNlY3AyNTZrMaED8GJ2vzUqgL6-KD1xalo1CsmY4X1HaDnyl6Y_WayCo9GDdGNwgiMog3VkcIIjKA",
+        "enr:-Ku4QImhMc1z8yCiNJ1TyUxdcfNucje3BGwEHzodEZUan8PherEo4sF7pPHPSIB1NNuSg5fZy7qFsjmUKs2ea1Whi0EBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQOVphkDqal4QzPMksc5wnpuC3gvSC8AfbFOnZY_On34wIN1ZHCCIyg",
+        "enr:-Ku4QP2xDnEtUXIjzJ_DhlCRN9SN99RYQPJL92TMlSv7U5C1YnYLjwOQHgZIUXw6c-BvRg2Yc2QsZxxoS_pPRVe0yK8Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQMeFF5GrS7UZpAH2Ly84aLK-TyvH-dRo0JM1i8yygH50YN1ZHCCJxA",
+        "enr:-Ku4QPp9z1W4tAO8Ber_NQierYaOStqhDqQdOPY3bB3jDgkjcbk6YrEnVYIiCBbTxuar3CzS528d2iE7TdJsrL-dEKoBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQMw5fqqkw2hHC4F5HZZDPsNmPdB1Gi8JPQK7pRc9XHh-oN1ZHCCKvg",
+      ],
+    },
+    {
+      name: "Can parse YAML input without double quotes",
+      input: `
+- enr:-Iu4QGCUN3RjOLZCab4LLqlOqnnOB9BspIE30Nj5gQGoY00ZXCIW2PCXuGqDLHEPZJK9NO8SFZlKzFF-5rSbTyPqksoBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQJmy_5ZkaIFozyMd3gPygG1lVLQONuTL4C1j_smkZ9WmoN0Y3CCIyiDdWRwgiMo
+- enr:-Iu4QCKxIZVqkBMGHOxfeDvY8Yp0V0uq2MQ8wFS2tQGMfQ1YVuER_WeyVmqKawz6H4JE1OVeN52_kJUdZmkuvpyETjMBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQNsaKrbnhjMgAcpHREHrZiCA7sXyEOokOck_1oc3zZMG4N0Y3CCJRyDdWRwgiUc
+- enr:-Iu4QN6QRhX7abcUZ6E5eV9-AIUSXpNBSytiSNwG0FGWWifEevi98EDGhoPVt3e82j9KC2H7DiLtDGnj03MMrs707fEBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQL4Lu3nwG5diXILEh3LiAauCrNgtoTJxGZQER33BTDMKoN0Y3CCIyiDdWRwgiMo
+  `,
+      expected: [
+        "enr:-Iu4QGCUN3RjOLZCab4LLqlOqnnOB9BspIE30Nj5gQGoY00ZXCIW2PCXuGqDLHEPZJK9NO8SFZlKzFF-5rSbTyPqksoBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQJmy_5ZkaIFozyMd3gPygG1lVLQONuTL4C1j_smkZ9WmoN0Y3CCIyiDdWRwgiMo",
+        "enr:-Iu4QCKxIZVqkBMGHOxfeDvY8Yp0V0uq2MQ8wFS2tQGMfQ1YVuER_WeyVmqKawz6H4JE1OVeN52_kJUdZmkuvpyETjMBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQNsaKrbnhjMgAcpHREHrZiCA7sXyEOokOck_1oc3zZMG4N0Y3CCJRyDdWRwgiUc",
+        "enr:-Iu4QN6QRhX7abcUZ6E5eV9-AIUSXpNBSytiSNwG0FGWWifEevi98EDGhoPVt3e82j9KC2H7DiLtDGnj03MMrs707fEBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQL4Lu3nwG5diXILEh3LiAauCrNgtoTJxGZQER33BTDMKoN0Y3CCIyiDdWRwgiMo",
+      ],
+    },
+    {
+      name: "Can parse .env style input",
+      input: `
+      BOOTNODES=enr:-Iu4QGCUN3RjOLZCab4LLqlOqnnOB9BspIE30Nj5gQGoY00ZXCIW2PCXuGqDLHEPZJK9NO8SFZlKzFF-5rSbTyPqksoBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQJmy_5ZkaIFozyMd3gPygG1lVLQONuTL4C1j_smkZ9WmoN0Y3CCIyiDdWRwgiMo,enr:-Iu4QCKxIZVqkBMGHOxfeDvY8Yp0V0uq2MQ8wFS2tQGMfQ1YVuER_WeyVmqKawz6H4JE1OVeN52_kJUdZmkuvpyETjMBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQNsaKrbnhjMgAcpHREHrZiCA7sXyEOokOck_1oc3zZMG4N0Y3CCJRyDdWRwgiUc,enr:-Iu4QN6QRhX7abcUZ6E5eV9-AIUSXpNBSytiSNwG0FGWWifEevi98EDGhoPVt3e82j9KC2H7DiLtDGnj03MMrs707fEBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQL4Lu3nwG5diXILEh3LiAauCrNgtoTJxGZQER33BTDMKoN0Y3CCIyiDdWRwgiMo
+  `,
+      expected: [
+        "enr:-Iu4QGCUN3RjOLZCab4LLqlOqnnOB9BspIE30Nj5gQGoY00ZXCIW2PCXuGqDLHEPZJK9NO8SFZlKzFF-5rSbTyPqksoBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQJmy_5ZkaIFozyMd3gPygG1lVLQONuTL4C1j_smkZ9WmoN0Y3CCIyiDdWRwgiMo",
+        "enr:-Iu4QCKxIZVqkBMGHOxfeDvY8Yp0V0uq2MQ8wFS2tQGMfQ1YVuER_WeyVmqKawz6H4JE1OVeN52_kJUdZmkuvpyETjMBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQNsaKrbnhjMgAcpHREHrZiCA7sXyEOokOck_1oc3zZMG4N0Y3CCJRyDdWRwgiUc",
+        "enr:-Iu4QN6QRhX7abcUZ6E5eV9-AIUSXpNBSytiSNwG0FGWWifEevi98EDGhoPVt3e82j9KC2H7DiLtDGnj03MMrs707fEBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQL4Lu3nwG5diXILEh3LiAauCrNgtoTJxGZQER33BTDMKoN0Y3CCIyiDdWRwgiMo",
+      ],
+    },
+  ];
+
+  for (const {name, input, expected} of testCases) {
+    it(name, () => {
+      expect(parseBootnodesFile(input)).to.be.deep.equal(expected);
+    });
+  }
 });
 
 describe("mergeBeaconNodeOptions", () => {

--- a/packages/cli/test/unit/config/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/config/beaconNodeOptions.test.ts
@@ -1,8 +1,13 @@
-import {expect} from "chai";
 import {defaultOptions, IBeaconNodeOptions} from "@chainsafe/lodestar";
-import {BeaconNodeOptions, mergeBeaconNodeOptions} from "../../../src/config";
-import {bootEnrs as pyrmontBootEnrs} from "../../../src/networks/pyrmont";
 import {RecursivePartial} from "@chainsafe/lodestar-utils";
+import {expect} from "chai";
+import fs from "fs";
+import path from "path";
+import {getBeaconPaths} from "../../../src/cmds/beacon/paths";
+import {BeaconNodeOptions, mergeBeaconNodeOptions} from "../../../src/config";
+import {enrsToNetworkConfig, getInjectableBootEnrs} from "../../../src/networks";
+import {bootEnrs as pyrmontBootEnrs} from "../../../src/networks/pyrmont";
+import {testFilesDir} from "../../utils";
 
 describe("config / beaconNodeOptions", () => {
   it("Should return pyrmont options", () => {
@@ -27,6 +32,49 @@ describe("config / beaconNodeOptions", () => {
 
     const optionsPartial = beaconNodeOptions.get();
     expect(optionsPartial).to.deep.equal(editedPartialOptions);
+  });
+
+  it("Should return options with injected custom bootnodes", async () => {
+    const expectedBootEnr = "enr:-KG4QOWkRj";
+    const rootDir = testFilesDir;
+    const bootnodesFile = path.join(testFilesDir, "bootnodesFile.txt");
+    fs.writeFileSync(bootnodesFile, expectedBootEnr);
+    const beaconPaths = getBeaconPaths({rootDir});
+    beaconPaths.bootnodesFile = bootnodesFile;
+
+    const injectableBootEnrs = await getInjectableBootEnrs(beaconPaths.bootnodesFile);
+
+    const beaconNodeOptions = new BeaconNodeOptions({
+      network: "pyrmont",
+      beaconNodeOptionsCli: injectableBootEnrs,
+    });
+
+    // Asserts only part of the data structure to avoid unnecesary duplicate code
+    const optionsPartial = beaconNodeOptions.get();
+    expect(optionsPartial?.network?.discv5?.bootEnrs).to.deep.equal([expectedBootEnr]);
+  });
+
+  it("Should return inline, CLI-provided boot ENR even if bootnodes file is provided", async () => {
+    const bootnodesFileContent = "enr:-KG4QOWkRj";
+    const expectedBootEnr = "enr:-W4gMj";
+
+    const rootDir = testFilesDir;
+    const bootnodesFile = path.join(testFilesDir, "bootnodesFile.txt");
+    fs.writeFileSync(bootnodesFile, bootnodesFileContent);
+    const beaconPaths = getBeaconPaths({rootDir});
+    beaconPaths.bootnodesFile = bootnodesFile;
+
+    const injectableBootEnrs = await getInjectableBootEnrs(beaconPaths.bootnodesFile);
+    const beaconNodeOptionsCli = mergeBeaconNodeOptions(injectableBootEnrs, enrsToNetworkConfig([expectedBootEnr]));
+
+    const beaconNodeOptions = new BeaconNodeOptions({
+      network: "pyrmont",
+      beaconNodeOptionsCli,
+    });
+
+    // Asserts only part of the data structure to avoid unnecesary duplicate code
+    const optionsPartial = beaconNodeOptions.get();
+    expect(optionsPartial?.network?.discv5?.bootEnrs).to.deep.equal([expectedBootEnr]);
   });
 
   it("Should return default options", () => {

--- a/packages/cli/test/unit/config/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/config/beaconNodeOptions.test.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import path from "path";
 import {getBeaconPaths} from "../../../src/cmds/beacon/paths";
 import {BeaconNodeOptions, mergeBeaconNodeOptions} from "../../../src/config";
-import {enrsToNetworkConfig, getInjectableBootEnrs, parseBootnodesFile} from "../../../src/networks";
+import {enrsToNetworkConfig, parseBootnodesFile} from "../../../src/networks";
 import {bootEnrs as pyrmontBootEnrs} from "../../../src/networks/pyrmont";
 import {testFilesDir} from "../../utils";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -393,13 +393,6 @@
     "@assemblyscript/loader" "^0.9.2"
     buffer "^5.4.3"
 
-"@chainsafe/bit-utils@0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@chainsafe/bit-utils/-/bit-utils-0.1.6.tgz#f643033340b45a1170c5473e4aab54a7a7b4b9dc"
-  integrity sha512-OYmXKCeItGG52iWR+bqqqUfc1joubkUUCXh6+wACTejGn7qNAawsd9ZHKB9riZWPg1wrKulUn8vecXMe0dk36A==
-  dependencies:
-    assert "^2.0.0"
-
 "@chainsafe/bls-hd-key@^0.2.0":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@chainsafe/bls-hd-key/-/bls-hd-key-0.2.1.tgz#3387a63f36f3cac20276bef40bb16a46294e6724"
@@ -2661,13 +2654,6 @@
   version "15.0.13"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.13.tgz#34f7fec8b389d7f3c1fd08026a5763e072d3c6dc"
   integrity sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
-  dependencies:
-    "@types/yargs-parser" "*"
-
-"@types/yargs@^17.0.2":
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.2.tgz#8fb2e0f4cdc7ab2a1a570106e56533f31225b584"
-  integrity sha512-JhZ+pNdKMfB0rXauaDlrIvm+U7V4m03PPOSVoPS66z8gf+G4Z/UW8UlrVIj2MRQOBzuoEvYtjS0bqYwnpZaS9Q==
   dependencies:
     "@types/yargs-parser" "*"
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this PR exist? What are the goals of the pull request? -->
As commented by @dapplion on #3558, the functionality is there but it's only triggered for known networks, and it's a handy feature to test different bootnodes as well.

**Description**
Adds a CLI flag, `--bootnodesFile`, that if added, parses the bootnodes ENRs from a file. Note that if the more specific CLI flag `--network.discv5.bootEnrs` is provided, the bootnodes will **not** be used as the latter flag is considered of higher priority (subject to discussion).

<!-- A clear and concise general description of the changes of this PR commits -->
As defined in the spec (#3558):
- Adds `bootnodesFile` flag to `beacon/options`
- Parses the flag with the logic in `beacon/paths`
- On the `BeaconNodeOptions` constructor, parses the file (if possible) and merges the injected bootnodes the rest of the config and _before_ any other CLI arguments, so that if the `--network.discv5.bootEnrs` flag is provided, it overrides the bootnode ENR file.
- Adds a parsing function `parseBootnodesFile` which can parse the formats defined in the spec, plus `.env` style files and JSON files, which might have enrs separated by commas. The parsing function takes advantage of the fact that it can remove any symbols not contained in the [URL and filename safe base64 alphabet](https://datatracker.ietf.org/doc/html/rfc4648#section-5).
- Adds corresponding tests as per the spec.

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #3558.

**Steps to test or reproduce**
- Running the tests will test injecting the bootnodes, overriding the injected bootnodes with the `--network.discv5.bootEnrs` argument and the parsing function.
- To use the flag, the simplest way is just to run `lodestar beacon --bootnodesFile path/to/bootnodes`.