### PR TITLE
Reprocess unknown block root attestations

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -6,7 +6,7 @@ import fs from "fs";
 import {CachedBeaconState, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {allForks, Number64, Root, phase0, Slot} from "@chainsafe/lodestar-types";
+import {allForks, Number64, Root, phase0, Slot, RootHex} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {fromHexString, TreeBacked} from "@chainsafe/ssz";
 import {AbortController} from "@chainsafe/abort-controller";
@@ -43,6 +43,7 @@ import {Archiver} from "./archiver";
 import {IEth1ForBlockProduction} from "../eth1";
 import {IExecutionEngine} from "../executionEngine";
 import {PrecomputeNextEpochTransitionScheduler} from "./precomputeNextEpochTransition";
+import {ReprocessController} from "./reprocess";
 
 export class BeaconChain implements IBeaconChain {
   readonly genesisTime: Number64;
@@ -61,6 +62,7 @@ export class BeaconChain implements IBeaconChain {
   checkpointStateCache: CheckpointStateCache;
   regen: IStateRegenerator;
   readonly lightClientServer: LightClientServer;
+  readonly reprocessController: ReprocessController;
 
   // Ops pool
   readonly attestationPool = new AttestationPool();
@@ -141,6 +143,8 @@ export class BeaconChain implements IBeaconChain {
       {config, db, emitter, logger},
       {genesisTime: this.genesisTime, genesisValidatorsRoot: this.genesisValidatorsRoot as Uint8Array}
     );
+
+    this.reprocessController = new ReprocessController(this.metrics);
 
     this.blockProcessor = new BlockProcessor(
       {
@@ -250,6 +254,15 @@ export class BeaconChain implements IBeaconChain {
       headRoot: fromHexString(head.blockRoot),
       headSlot: head.slot,
     };
+  }
+
+  /**
+   * Returns Promise that resolves either on block found or once 1 slot passes.
+   * Used to handle unknown block root for both unaggregated and aggregated attestations.
+   * @returns true if blockFound
+   */
+  waitForBlockOfAttestation(slot: Slot, root: RootHex): Promise<boolean> {
+    return this.reprocessController.waitForBlockOfAttestation(slot, root);
   }
 
   persistInvalidSszObject(type: SSZObjectType, bytes: Uint8Array, suffix = ""): string | null {

--- a/packages/lodestar/src/chain/errors/attestationError.ts
+++ b/packages/lodestar/src/chain/errors/attestationError.ts
@@ -141,7 +141,7 @@ export type AttestationErrorType =
   | {code: AttestationErrorCode.ATTESTATION_ALREADY_KNOWN; targetEpoch: Epoch; validatorIndex: number}
   | {code: AttestationErrorCode.AGGREGATOR_ALREADY_KNOWN; targetEpoch: Epoch; aggregatorIndex: number}
   | {code: AttestationErrorCode.AGGREGATOR_INDEX_TOO_HIGH; aggregatorIndex: ValidatorIndex}
-  | {code: AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT; root: Uint8Array}
+  | {code: AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT; root: RootHex}
   | {code: AttestationErrorCode.BAD_TARGET_EPOCH}
   | {code: AttestationErrorCode.HEAD_NOT_TARGET_DESCENDANT}
   | {code: AttestationErrorCode.UNKNOWN_TARGET_ROOT; root: Uint8Array}

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -1,4 +1,4 @@
-import {allForks, Number64, Root, phase0, Slot} from "@chainsafe/lodestar-types";
+import {allForks, Number64, Root, phase0, Slot, RootHex} from "@chainsafe/lodestar-types";
 import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
@@ -21,6 +21,7 @@ import {AttestationPool, OpPool, SyncCommitteeMessagePool, SyncContributionAndPr
 import {LightClientServer} from "./lightClient";
 import {AggregatedAttestationPool} from "./opPools/aggregatedAttestationPool";
 import {PartiallyVerifiedBlockFlags} from "./blocks/types";
+import {ReprocessController} from "./reprocess";
 
 export type Eth2Context = {
   activeValidatorCount: number;
@@ -51,6 +52,7 @@ export interface IBeaconChain {
   checkpointStateCache: CheckpointStateCache;
   regen: IStateRegenerator;
   readonly lightClientServer: LightClientServer;
+  readonly reprocessController: ReprocessController;
 
   // Ops pool
   readonly attestationPool: AttestationPool;
@@ -91,6 +93,8 @@ export interface IBeaconChain {
   processChainSegment(signedBlocks: allForks.SignedBeaconBlock[], flags?: PartiallyVerifiedBlockFlags): Promise<void>;
 
   getStatus(): phase0.Status;
+
+  waitForBlockOfAttestation(slot: Slot, root: RootHex): Promise<boolean>;
 
   /** Persist bad items to persistInvalidSszObjectsDir dir, for example invalid state, attestations etc. */
   persistInvalidSszObject(type: SSZObjectType, bytes: Uint8Array, suffix: string): string | null;

--- a/packages/lodestar/src/chain/reprocess.ts
+++ b/packages/lodestar/src/chain/reprocess.ts
@@ -1,0 +1,159 @@
+import {Slot, RootHex} from "@chainsafe/lodestar-types";
+import {IMetrics} from "../metrics";
+import {MapDef} from "../util/map";
+
+/**
+ * To prevent our node from having to reprocess while struggling to sync,
+ * we only want to reprocess attestations if block reaches our node before this time.
+ */
+export const REPROCESS_MIN_TIME_TO_NEXT_SLOT_SEC = 2;
+
+/**
+ * Reprocess status for metrics
+ */
+enum ReprocessStatus {
+  /**
+   * There are too many attestations that have unknown block root.
+   */
+  reached_limit = "reached_limit",
+  /**
+   * The awaiting attestation is pruned per clock slot.
+   */
+  expired = "expired",
+}
+
+type AwaitingAttestationPromise = {
+  resolve: (foundBlock: boolean) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  promise: Promise<boolean>;
+  // there are multiple subnet/aggregated attestations waiting for same promise
+  awaitingAttestationsCount: number;
+  // we only resolve to true or false to make the code simpler so no need to keep reject here
+  addedTimeMs: number;
+};
+
+// How many attestations (aggregate + unaggregate) we keep before new ones get dropped.
+const MAXIMUM_QUEUED_ATTESTATIONS = 16_384;
+
+type SlotRoot = {slot: Slot; root: RootHex};
+
+/**
+ * Some attestations may reach our node before the voted block, so we manage a cache to reprocess them
+ * when the block come.
+ * (n)                                               (n + 1)
+ *  |----------------|----------------|----------|------|
+ *                   |                |          |
+ *                  att           agg att        |
+ *                                              block
+ * Since the gossip handler has to return validation result to js-libp2p-gossipsub, this class should not
+ * reprocess attestations, it should control when the attestations are ready to reprocess instead.
+ */
+export class ReprocessController {
+  private readonly awaitingPromisesByRootBySlot: MapDef<Slot, Map<RootHex, AwaitingAttestationPromise>>;
+  private awaitingPromisesCount = 0;
+
+  constructor(private readonly metrics: IMetrics | null) {
+    this.awaitingPromisesByRootBySlot = new MapDef(() => new Map<RootHex, AwaitingAttestationPromise>());
+  }
+
+  /**
+   * Returns Promise that resolves either on block found or once 1 slot passes.
+   * Used to handle unknown block root for both unaggregated and aggregated attestations.
+   * @returns true if blockFound
+   */
+  waitForBlockOfAttestation(slot: Slot, root: RootHex): Promise<boolean> {
+    this.metrics?.reprocessAttestations.total.inc();
+
+    if (this.awaitingPromisesCount >= MAXIMUM_QUEUED_ATTESTATIONS) {
+      this.metrics?.reprocessAttestations.reject.inc({reason: ReprocessStatus.reached_limit});
+      return Promise.resolve(false);
+    }
+
+    this.awaitingPromisesCount++;
+    const awaitingPromisesByRoot = this.awaitingPromisesByRootBySlot.getOrDefault(slot);
+    const promiseCached = awaitingPromisesByRoot.get(root);
+    if (promiseCached) {
+      promiseCached.awaitingAttestationsCount++;
+      return promiseCached.promise;
+    }
+
+    // Capture both the promise and its callbacks.
+    // It is not spec'ed but in tests in Firefox and NodeJS the promise constructor is run immediately
+    let resolve: AwaitingAttestationPromise["resolve"] | null = null;
+    const promise = new Promise<boolean>((resolveCB) => {
+      resolve = resolveCB;
+    });
+
+    if (resolve === null) {
+      throw Error("Promise Constructor was not executed immediately");
+    }
+
+    awaitingPromisesByRoot.set(root, {
+      promise,
+      awaitingAttestationsCount: 1,
+      resolve,
+      addedTimeMs: Date.now(),
+    });
+
+    return promise;
+  }
+
+  /**
+   * It's important to make sure our node is synced before we reprocess,
+   * it means the processed slot is same to clock slot
+   * Note that we want to use clock advanced by REPROCESS_MIN_TIME_TO_NEXT_SLOT instead of
+   * clockSlot because we want to make sure our node is healthy while reprocessing attestations.
+   * If a block reach our node 1s before the next slot, for example, then probably node
+   * is struggling and we don't want to reprocess anything at that time.
+   */
+  onBlockImported({slot: blockSlot, root}: SlotRoot, advancedSlot: Slot): void {
+    // we are probably resyncing, don't want to reprocess attestations here
+    if (blockSlot < advancedSlot) return;
+
+    // resolve all related promises
+    const awaitingPromisesBySlot = this.awaitingPromisesByRootBySlot.getOrDefault(blockSlot);
+    const awaitingPromise = awaitingPromisesBySlot.get(root);
+    if (awaitingPromise) {
+      const {resolve, addedTimeMs, awaitingAttestationsCount} = awaitingPromise;
+      resolve(true);
+      this.awaitingPromisesCount -= awaitingAttestationsCount;
+      this.metrics?.reprocessAttestations.resolve.inc(awaitingAttestationsCount);
+      this.metrics?.reprocessAttestations.waitTimeBeforeResolve.set((Date.now() - addedTimeMs) / 1000);
+    }
+
+    // prune
+    awaitingPromisesBySlot.delete(root);
+  }
+
+  /**
+   * It's important to make sure our node is synced before reprocessing attestations,
+   * it means clockSlot is the same to last processed block's slot, and we don't reprocess
+   * attestations of old slots.
+   * So we reject and prune all old awaiting promises per clock slot.
+   * @param clockSlot
+   */
+  onSlot(clockSlot: Slot): void {
+    const now = Date.now();
+
+    for (const [key, awaitingPromisesByRoot] of this.awaitingPromisesByRootBySlot.entries()) {
+      if (key < clockSlot) {
+        // reject all related promises
+        for (const awaitingPromise of awaitingPromisesByRoot.values()) {
+          const {resolve, addedTimeMs} = awaitingPromise;
+          resolve(false);
+          this.metrics?.reprocessAttestations.waitTimeBeforeReject.set((now - addedTimeMs) / 1000);
+          this.metrics?.reprocessAttestations.reject.inc({reason: ReprocessStatus.expired});
+        }
+
+        // prune
+        this.awaitingPromisesByRootBySlot.delete(key);
+      } else {
+        break;
+      }
+    }
+
+    // in theory there are maybe some awaiting promises waiting for a slot > clockSlot
+    // in reality this never happens so reseting awaitingPromisesCount to 0 to make it simple
+    this.awaitingPromisesCount = 0;
+  }
+}

--- a/packages/lodestar/src/chain/validation/attestation.ts
+++ b/packages/lodestar/src/chain/validation/attestation.ts
@@ -231,7 +231,7 @@ function verifyHeadBlockIsKnown(chain: IBeaconChain, beaconBlockRoot: Root): IPr
   if (headBlock === null) {
     throw new AttestationError(GossipAction.IGNORE, {
       code: AttestationErrorCode.UNKNOWN_BEACON_BLOCK_ROOT,
-      root: beaconBlockRoot.valueOf() as Uint8Array,
+      root: toHexString(beaconBlockRoot.valueOf() as typeof beaconBlockRoot),
     });
   }
 

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -710,5 +710,30 @@ export function createLodestarMetrics(
         help: "Total number of precomputing next epoch transition wasted",
       }),
     },
+
+    // reprocess attestations
+    reprocessAttestations: {
+      total: register.gauge({
+        name: "lodestar_reprocess_attestations_total",
+        help: "Total number of attestations waiting to reprocess",
+      }),
+      resolve: register.gauge({
+        name: "lodestar_reprocess_attestations_resolve_total",
+        help: "Total number of attestations are reprocessed",
+      }),
+      waitTimeBeforeResolve: register.gauge({
+        name: "lodestar_reprocess_attestations_wait_time_resolve_seconds",
+        help: "Time to wait for unknown block in seconds",
+      }),
+      reject: register.gauge<"reason">({
+        name: "lodestar_reprocess_attestations_reject_total",
+        help: "Total number of attestations are rejected to reprocess",
+        labelNames: ["reason"],
+      }),
+      waitTimeBeforeReject: register.gauge<"reason">({
+        name: "lodestar_reprocess_attestations_wait_time_reject_seconds",
+        help: "Time to wait for unknown block before being rejected",
+      }),
+    },
   };
 }

--- a/packages/lodestar/src/network/gossip/handlers/index.ts
+++ b/packages/lodestar/src/network/gossip/handlers/index.ts
@@ -154,18 +154,19 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
       }
 
       // Handler
+      const {indexedAttestation, committeeIndices} = validationResult;
       metrics?.registerAggregatedAttestation(
         OpSource.gossip,
         seenTimestampSec,
         signedAggregateAndProof,
-        validationResult.indexedAttestation
+        indexedAttestation
       );
       const aggregatedAttestation = signedAggregateAndProof.message.aggregate;
 
       chain.aggregatedAttestationPool.add(
         aggregatedAttestation,
-        validationResult.indexedAttestation.attestingIndices as ValidatorIndex[],
-        validationResult.committeeIndices
+        indexedAttestation.attestingIndices as ValidatorIndex[],
+        committeeIndices
       );
 
       if (!options.dontSendGossipAttestationsToForkchoice) {
@@ -197,9 +198,9 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
         throw e;
       }
 
-      metrics?.registerUnaggregatedAttestation(OpSource.gossip, seenTimestampSec, validationResult.indexedAttestation);
-
       // Handler
+      const {indexedAttestation} = validationResult;
+      metrics?.registerUnaggregatedAttestation(OpSource.gossip, seenTimestampSec, indexedAttestation);
 
       // Node may be subscribe to extra subnets (long-lived random subnets). For those, validate the messages
       // but don't import them, to save CPU and RAM

--- a/packages/lodestar/src/network/gossip/validation/queue.ts
+++ b/packages/lodestar/src/network/gossip/validation/queue.ts
@@ -10,9 +10,10 @@ import {GossipJobQueues, GossipTopic, GossipType, ProcessRpcMessageFn} from "../
  */
 const gossipQueueOpts: {[K in GossipType]: Pick<JobQueueOpts, "maxLength" | "type" | "maxConcurrency">} = {
   [GossipType.beacon_block]: {maxLength: 1024, type: QueueType.FIFO},
-  // this is different from lighthouse's, there are more gossip aggregate_and_proof than gossip block
-  [GossipType.beacon_aggregate_and_proof]: {maxLength: 4096, type: QueueType.LIFO, maxConcurrency: 16},
-  [GossipType.beacon_attestation]: {maxLength: 16384, type: QueueType.LIFO, maxConcurrency: 64},
+  // lighthoue has aggregate_queue 4096 and unknown_block_aggregate_queue 1024, we use single queue
+  [GossipType.beacon_aggregate_and_proof]: {maxLength: 5120, type: QueueType.LIFO, maxConcurrency: 16},
+  // lighthouse has attestation_queue 16384 and unknown_block_attestation_queue 8192, we use single queue
+  [GossipType.beacon_attestation]: {maxLength: 24576, type: QueueType.LIFO, maxConcurrency: 64},
   [GossipType.voluntary_exit]: {maxLength: 4096, type: QueueType.FIFO},
   [GossipType.proposer_slashing]: {maxLength: 4096, type: QueueType.FIFO},
   [GossipType.attester_slashing]: {maxLength: 4096, type: QueueType.FIFO},

--- a/packages/lodestar/test/unit/chain/reprocess.test.ts
+++ b/packages/lodestar/test/unit/chain/reprocess.test.ts
@@ -1,0 +1,37 @@
+import {expect} from "chai";
+import {ReprocessController} from "../../../src/chain/reprocess";
+
+describe("ReprocessController", function () {
+  let controller: ReprocessController;
+
+  beforeEach(() => {
+    controller = new ReprocessController(null);
+  });
+
+  it("Block not found after 1 slot - returns false", async () => {
+    const promise = controller.waitForBlockOfAttestation(100, "A");
+    controller.onSlot(101);
+    expect(await promise).to.be.equal(false);
+  });
+
+  it("Block found too late - returns false", async () => {
+    const promise = controller.waitForBlockOfAttestation(100, "A");
+    controller.onBlockImported({slot: 100, root: "A"}, 101);
+    controller.onSlot(101);
+    expect(await promise).to.be.equal(false);
+  });
+
+  it("Too many promises - returns false", async () => {
+    for (let i = 0; i < 16_384; i++) {
+      void controller.waitForBlockOfAttestation(100, "A");
+    }
+    const promise = controller.waitForBlockOfAttestation(100, "A");
+    expect(await promise).to.be.equal(false);
+  });
+
+  it("Block comes on time - returns true", async () => {
+    const promise = controller.waitForBlockOfAttestation(100, "A");
+    controller.onBlockImported({slot: 100, root: "A"}, 100);
+    expect(await promise).to.be.equal(true);
+  });
+});

--- a/packages/lodestar/test/unit/util/wrapError.test.ts
+++ b/packages/lodestar/test/unit/util/wrapError.test.ts
@@ -1,0 +1,32 @@
+import {expect} from "chai";
+import {wrapError} from "../../../src/util/wrapError";
+
+describe("util / wrapError", () => {
+  const error = Error("test-error");
+  async function throwNoAwait(shouldThrow: boolean): Promise<boolean> {
+    if (shouldThrow) throw error;
+    else return true;
+  }
+
+  async function throwAwait(shouldThrow: boolean): Promise<boolean> {
+    await new Promise((r) => setTimeout(r, 0));
+    if (shouldThrow) throw error;
+    else return true;
+  }
+
+  it("Handle error and result with throwNoAwait", async () => {
+    const resErr = await wrapError(throwNoAwait(true));
+    const resOk = await wrapError(throwNoAwait(false));
+
+    expect(resErr).to.deep.equal({err: error}, "Wrong resErr");
+    expect(resOk).to.deep.equal({err: null, result: true}, "Wrong resOk");
+  });
+
+  it("Handle error and result with throwAwait", async () => {
+    const resErr = await wrapError(throwAwait(true));
+    const resOk = await wrapError(throwAwait(false));
+
+    expect(resErr).to.deep.equal({err: error}, "Wrong resErr");
+    expect(resOk).to.deep.equal({err: null, result: true}, "Wrong resOk");
+  });
+});

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -35,6 +35,7 @@ import {Eth1ForBlockProductionDisabled} from "../../../../src/eth1";
 import {ExecutionEngineDisabled} from "../../../../src/executionEngine";
 import {ReqRespBlockResponse} from "../../../../src/network/reqresp/types";
 import {testLogger} from "../../logger";
+import {ReprocessController} from "../../../../src/chain/reprocess";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 
@@ -64,6 +65,7 @@ export class MockBeaconChain implements IBeaconChain {
   regen: IStateRegenerator;
   emitter: ChainEventEmitter;
   lightClientServer: LightClientServer;
+  reprocessController: ReprocessController;
 
   // Ops pool
   readonly attestationPool = new AttestationPool();
@@ -117,6 +119,7 @@ export class MockBeaconChain implements IBeaconChain {
       {config: this.config, emitter: this.emitter, logger, db: db},
       {genesisTime: this.genesisTime, genesisValidatorsRoot: this.genesisValidatorsRoot as Uint8Array}
     );
+    this.reprocessController = new ReprocessController(null);
   }
 
   getHeadState(): CachedBeaconState<allForks.BeaconState> {
@@ -164,6 +167,10 @@ export class MockBeaconChain implements IBeaconChain {
       headRoot: Buffer.alloc(32),
       headSlot: 0,
     };
+  }
+
+  async waitForBlockOfAttestation(): Promise<boolean> {
+    return false;
   }
 
   persistInvalidSszObject(): string | null {

--- a/packages/lodestar/test/utils/validationData/attestation.ts
+++ b/packages/lodestar/test/utils/validationData/attestation.ts
@@ -72,6 +72,10 @@ export function getAttestationValidData(
       if (!ssz.Root.equals(root, beaconBlockRoot)) return null;
       return headBlock;
     },
+    getBlockHex: (rootHex) => {
+      if (rootHex !== toHexString(beaconBlockRoot)) return null;
+      return headBlock;
+    },
   } as Partial<IForkChoice>) as IForkChoice;
 
   const committeeIndices = state.getBeaconCommittee(attSlot, attIndex);
@@ -117,6 +121,7 @@ export function getAttestationValidData(
     regen,
     seenAttesters: new SeenAttesters(),
     bls: new BlsSingleThreadVerifier(),
+    waitForBlockOfAttestation: () => Promise.resolve(false),
   } as Partial<IBeaconChain>) as IBeaconChain;
 
   return {chain, attestation, subnet, validatorIndex};


### PR DESCRIPTION
**Motivation**

Right now when attestations come before the block, we ignore attestations. We should follow other clients to queue and reprocess those attestations when the block becomes known. This:
+ May help us with the missing attestation issue #3527, right now we swallow unknown block root attestations
+ Potentially increase gossip peer score after we propagating those attestations

**Description**
Since we used to have performance issue with this `reprocess` work, the approach is quite conservative

+ New `ReprocessController` to wait for the block, add awaiting promises to `awaitingPromisesByRootBySlot`
+ Prune `awaitingPromisesByRootBySlot` per clock slot since we don't want to reprocess old slot attestations
+ If block comes right close to next slot, do not reprocess as the node may be struggling to resync, see `REPROCESS_MIN_TIME_TO_NEXT_SLOT_SEC` constant
+ New related metrics for this reprocess work

Closes #3560

**Some considerations**
+ Ideally we should have 1 separate queue for reprocess work but since we have to hook to the life cycle of `js-libp2p-gossipsub`, I do this reprocess in the gossip handler
+ I increase attestation & AggregateAndProof gossip queue since we use single queue for this reprocess and Lighthouse has 2 separate queues, does this make sense? The test does not show any differences if I increase this

**Test**

~~I don't see any big differences with the metrics, except for the peer count with `subscribeAllSubnets` flag~~ => peer count is the same after running 2 instances for 9 days. Although total attestations reprocessed per slot is only around 20 - 60/slot, the total attestations accepted is a big difference after I leave 2 instances (contabo 19 vs cotabo 20) for 9 days
<img width="1249" alt="Screen Shot 2022-01-13 at 10 15 24" src="https://user-images.githubusercontent.com/10568965/149259654-0f09c76b-3adc-4a7e-a35c-a26aef9fd515.png">


+ Master: Gossip aggregate and proofs accepted per slot
<img width="1280" alt="Screen Shot 2022-01-13 at 09 52 48" src="https://user-images.githubusercontent.com/10568965/149257402-89dfc4f5-1df6-4d16-b3a7-57b9abc97ad2.png">

+ This branch:  Gossip aggregate and proofs accepted per slot is higher
<img width="1240" alt="Screen Shot 2022-01-13 at 09 53 31" src="https://user-images.githubusercontent.com/10568965/149257456-ae04c3fb-c13c-4e4b-957c-c9a6851aef07.png">

+ Master: Gossip beacon attestations accepted per slot
<img width="1300" alt="Screen Shot 2022-01-13 at 09 58 50" src="https://user-images.githubusercontent.com/10568965/149257954-c37601c3-a921-4eea-90a2-edd5b7753f05.png">

+ This branch: Gossip beacon attestations accepted per slot is higher
<img width="1268" alt="Screen Shot 2022-01-13 at 09 59 12" src="https://user-images.githubusercontent.com/10568965/149258006-26c6778d-e1bb-4f75-b8a0-e60cf9135183.png">


