### PR TITLE
Remove unbounded set seenPeers

### DIFF
--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -68,10 +68,6 @@ export function createLodestarMetrics(
       help: "Total number of goodbye sent, labeled by reason",
       labelNames: ["reason"],
     }),
-    peersTotalUniqueConnected: register.gauge({
-      name: "lodestar_peers_total_unique_connected",
-      help: "Total number of unique peers that have had a connection with",
-    }),
     peersRequestedToConnect: register.gauge({
       name: "lodestar_peers_requested_total_to_connect",
       help: "Priorization results total peers count requested to connect",

--- a/packages/lodestar/src/network/peers/peerManager.ts
+++ b/packages/lodestar/src/network/peers/peerManager.ts
@@ -116,8 +116,6 @@ export class PeerManager {
   private opts: PeerManagerOpts;
   private intervals: NodeJS.Timeout[] = [];
 
-  private seenPeers = new Set<string>();
-
   constructor(modules: PeerManagerModules, opts: PeerManagerOpts) {
     this.libp2p = modules.libp2p;
     this.logger = modules.logger;
@@ -477,7 +475,6 @@ export class PeerManager {
     this.logger.verbose("peer connected", {peer: prettyPrintPeerId(peer), direction, status});
     // NOTE: The peerConnect event is not emitted here here, but after asserting peer relevance
     this.metrics?.peerConnectedEvent.inc({direction});
-    this.seenPeers.add(peer.toB58String());
   };
 
   /**
@@ -540,7 +537,6 @@ export class PeerManager {
     }
 
     metrics.peers.set(total);
-    metrics.peersTotalUniqueConnected.set(this.seenPeers.size);
     metrics.peersSync.set(syncPeers);
   }
 }


### PR DESCRIPTION
**Motivation**

PeerManager.seenPeers is an unbounded data structure that tracks all seen peerIds and never gets pruned. From https://github.com/ChainSafe/lodestar/issues/3446 concatenated strings take significant memory so for a long running node seenPeers can take significant memory

**Description**

- Remove unbounded set seenPeers
