### PR TITLE
Do not duplicate forkchoice.onAttestation() errors

### DIFF
--- a/packages/fork-choice/src/index.ts
+++ b/packages/fork-choice/src/index.ts
@@ -10,6 +10,13 @@ export {
   IQueuedAttestation,
 } from "./forkChoice/interface";
 export {ForkChoiceStore, IForkChoiceStore, CheckpointWithHex} from "./forkChoice/store";
-export {InvalidAttestation, InvalidAttestationCode, InvalidBlock, InvalidBlockCode} from "./forkChoice/errors";
+export {
+  InvalidAttestation,
+  InvalidAttestationCode,
+  InvalidBlock,
+  InvalidBlockCode,
+  ForkChoiceError,
+  ForkChoiceErrorCode,
+} from "./forkChoice/errors";
 
 export {IForkChoiceMetrics} from "./metrics";

--- a/packages/lodestar/src/chain/blocks/importBlock.ts
+++ b/packages/lodestar/src/chain/blocks/importBlock.ts
@@ -139,15 +139,13 @@ export async function importBlock(chain: ImportBlockModules, fullyVerifiedBlock:
       } catch (e) {
         // a block has a lot of attestations and it may has same error, we don't want to log all of them
         if (e instanceof ForkChoiceError && e.type.code === ForkChoiceErrorCode.INVALID_ATTESTATION) {
-          let errWithCount = invalidAttestationErrorsByCode.get(e.type.err.code) as
-            | {error: Error; count: number}
-            | undefined;
+          let errWithCount = invalidAttestationErrorsByCode.get(e.type.err.code);
           if (errWithCount === undefined) {
             errWithCount = {error: e as Error, count: 1};
+            invalidAttestationErrorsByCode.set(e.type.err.code, errWithCount);
           } else {
             errWithCount.count++;
           }
-          invalidAttestationErrorsByCode.set(e.type.err.code, errWithCount);
         } else {
           // always log other errors
           chain.logger.warn("Error processing attestation from block", {slot: block.message.slot}, e as Error);

--- a/packages/lodestar/src/chain/blocks/importBlock.ts
+++ b/packages/lodestar/src/chain/blocks/importBlock.ts
@@ -9,7 +9,13 @@ import {
   altair,
   computeEpochAtSlot,
 } from "@chainsafe/lodestar-beacon-state-transition";
-import {IForkChoice, OnBlockPrecachedData, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
+import {
+  IForkChoice,
+  OnBlockPrecachedData,
+  ExecutionStatus,
+  ForkChoiceError,
+  ForkChoiceErrorCode,
+} from "@chainsafe/lodestar-fork-choice";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {IMetrics} from "../../metrics";
@@ -24,6 +30,7 @@ import {LightClientServer} from "../lightClient";
 import {getCheckpointFromState} from "./utils/checkpoint";
 import {PendingEvents} from "./utils/pendingEvents";
 import {FullyVerifiedBlock} from "./types";
+// import {ForkChoiceError, ForkChoiceErrorCode} from "@chainsafe/lodestar-fork-choice/lib/forkChoice/errors";
 
 export type ImportBlockModules = {
   db: IBeaconDb;
@@ -119,6 +126,8 @@ export async function importBlock(chain: ImportBlockModules, fullyVerifiedBlock:
     const attestations = Array.from(readonlyValues(block.message.body.attestations));
     const rootCache = new altair.RootCache(postState);
     const parentSlot = chain.forkChoice.getBlock(block.message.parentRoot)?.slot;
+    const invalidAttestationErrorsByCode = new Map<string, {error: Error; count: number}>();
+
     for (const attestation of attestations) {
       try {
         const indexedAttestation = postState.epochCtx.getIndexedAttestation(attestation);
@@ -128,8 +137,30 @@ export async function importBlock(chain: ImportBlockModules, fullyVerifiedBlock:
         }
         pendingEvents.push(ChainEvent.attestation, attestation);
       } catch (e) {
-        chain.logger.error("Error processing attestation from block", {slot: block.message.slot}, e as Error);
+        // a block has a lot of attestations and it may has same error, we don't want to log all of them
+        if (e instanceof ForkChoiceError && e.type.code === ForkChoiceErrorCode.INVALID_ATTESTATION) {
+          let errWithCount = invalidAttestationErrorsByCode.get(e.type.err.code) as
+            | {error: Error; count: number}
+            | undefined;
+          if (errWithCount === undefined) {
+            errWithCount = {error: e as Error, count: 1};
+          } else {
+            errWithCount.count++;
+          }
+          invalidAttestationErrorsByCode.set(e.type.err.code, errWithCount);
+        } else {
+          // always log other errors
+          chain.logger.warn("Error processing attestation from block", {slot: block.message.slot}, e as Error);
+        }
       }
+    }
+
+    for (const {error, count} of invalidAttestationErrorsByCode.values()) {
+      chain.logger.warn(
+        "Error processing attestations from block",
+        {slot: block.message.slot, erroredAttestations: count},
+        error
+      );
     }
   }
 


### PR DESCRIPTION
**Motivation**

In Kintsugi, there are a lot of duplicate errorred attestations in same block like this:

```
Jan-04 17:21:11.909 [CHAIN]           ^[[31merror^[[39m: Error processing attestation from block slot=138066 code=FORKCHOICE_ERROR_INVALID_ATTESTATION, err={"code        ":"UNKNOWN_HEAD_BLOCK","beaconBlockRoot":"0x64535ff2cc85ecaaf73c44b1b35f1e084fae6702eb507e375fb104136756bdb9"}
2357023 Error: FORKCHOICE_ERROR_INVALID_ATTESTATION
2357024     at ForkChoice.validateOnAttestation (/usr/app/node_modules/@chainsafe/lodestar-fork-choice/src/forkChoice/forkChoice.ts:826:13)
2357025     at ForkChoice.onAttestation (/usr/app/node_modules/@chainsafe/lodestar-fork-choice/src/forkChoice/forkChoice.ts:427:10)
2357026     at importBlock (/usr/app/node_modules/@chainsafe/lodestar/src/chain/blocks/importBlock.ts:125:26)
2357027     at processBlock (/usr/app/node_modules/@chainsafe/lodestar/src/chain/blocks/index.ts:65:22)
2357028     at runMicrotasks (<anonymous>)
2357029     at processTicksAndRejections (node:internal/process/task_queues:96:5)
2357030     at JobItemQueue.runJob (/usr/app/node_modules/@chainsafe/lodestar/src/util/queue/itemQueue.ts:85:22)
2357031 Jan-04 17:21:11.910 [CHAIN]           ^[[31merror^[[39m: Error processing attestation from block slot=138066 code=FORKCHOICE_ERROR_INVALID_ATTESTATION, err={"code        ":"UNKNOWN_HEAD_BLOCK","beaconBlockRoot":"0x64535ff2cc85ecaaf73c44b1b35f1e084fae6702eb507e375fb104136756bdb9"}
2357032 Error: FORKCHOICE_ERROR_INVALID_ATTESTATION
2357033     at ForkChoice.validateOnAttestation (/usr/app/node_modules/@chainsafe/lodestar-fork-choice/src/forkChoice/forkChoice.ts:826:13)
2357034     at ForkChoice.onAttestation (/usr/app/node_modules/@chainsafe/lodestar-fork-choice/src/forkChoice/forkChoice.ts:427:10)
2357035     at importBlock (/usr/app/node_modules/@chainsafe/lodestar/src/chain/blocks/importBlock.ts:125:26)
2357036     at processBlock (/usr/app/node_modules/@chainsafe/lodestar/src/chain/blocks/index.ts:65:22)
2357037     at runMicrotasks (<anonymous>)
2357038     at processTicksAndRejections (node:internal/process/task_queues:96:5)
2357039     at JobItemQueue.runJob (/usr/app/node_modules/@chainsafe/lodestar/src/util/queue/itemQueue.ts:85:22)
```

That happens when we import a block with a lot of errorred attestations of the same type

**Description**

+ That error does not affect the functionality, we still import that block in the end so it's more suitable for a `log.warn` instead
+ It's redundant to show a lot of duplicate errors like that in same block, we should log it once per code and number of attestations that have the same error instead
