### PR TITLE
BN<>VC interop: Export the active preset to fill missing preset for spec api

### DIFF
--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -1,4 +1,4 @@
-import {IBeaconPreset, BeaconPreset} from "@chainsafe/lodestar-params";
+import {IBeaconPreset, BeaconPreset, activePreset} from "@chainsafe/lodestar-params";
 import {IChainConfig, ChainConfig} from "@chainsafe/lodestar-config";
 import {Bytes32, Number64, phase0, ssz} from "@chainsafe/lodestar-types";
 import {mapValues} from "@chainsafe/lodestar-utils";
@@ -87,6 +87,6 @@ export function getReturnTypes(config: IChainConfig): ReturnTypes<Api> {
   return {
     getDepositContract: ContainerData(DepositContract),
     getForkSchedule: ContainerData(ArrayOf(ssz.phase0.Fork)),
-    getSpec: withJsonFilled(Spec, ChainConfig.toJson(config)),
+    getSpec: withJsonFilled(Spec, Spec.toJson({...config, ...activePreset})),
   };
 }

--- a/packages/params/src/index.ts
+++ b/packages/params/src/index.ts
@@ -25,6 +25,7 @@ presetStatus.frozen = true;
  */
 export const ACTIVE_PRESET: PresetName =
   userSelectedPreset || PresetName[process?.env?.LODESTAR_PRESET as PresetName] || PresetName.mainnet;
+export const activePreset = presets[ACTIVE_PRESET];
 
 // These variables must be exported individually and explicitly
 // in order to be accessible as top-level exports


### PR DESCRIPTION
**Motivation**
This PR addresses lodestar validator interop with the other clients (LH)
- [x] As now merge related fields are present in the preset, this PR also picks the active preset to fill for missing fields in the interop spec api.
- [x] Tested that no additional params need to be specified in the `--paramsFile`, since default activiation of merge (and other forks like sharding) via `MERGE_EPOCH` is set to far future and hence shouldn't interfere with the operation of validator if the spec api don't have those fields. This addresses the need to have a better UX as desired in https://github.com/ChainSafe/lodestar/issues/3437

Tested against Lighthouse BN :heavy_check_mark: 

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #3437