### PR TITLE
Prevent peer downscoring on validation error if triggered by execution errors

### DIFF
--- a/packages/lodestar/src/sync/range/batch.ts
+++ b/packages/lodestar/src/sync/range/batch.ts
@@ -182,12 +182,16 @@ export class Batch {
   /**
    * AwaitingValidation -> AwaitingDownload
    */
-  validationError(): void {
+  validationError(err: Error): void {
     if (this.state.status !== BatchStatus.AwaitingValidation) {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.AwaitingValidation));
     }
 
-    this.onProcessingError(this.state.attempt);
+    if (err instanceof ChainSegmentError && err.type.code === BlockErrorCode.EXECUTION_ENGINE_ERROR) {
+      this.onExecutionEngineError(this.state.attempt);
+    } else {
+      this.onProcessingError(this.state.attempt);
+    }
   }
 
   /**

--- a/packages/lodestar/src/sync/range/chain.ts
+++ b/packages/lodestar/src/sync/range/chain.ts
@@ -438,7 +438,7 @@ export class SyncChain {
       for (const pendingBatch of this.batches.values()) {
         if (pendingBatch.startEpoch < batch.startEpoch) {
           this.logger.verbose("Batch validation error", {id: this.logId, ...pendingBatch.getMetadata()});
-          pendingBatch.validationError(); // Throws after MAX_BATCH_PROCESSING_ATTEMPTS
+          pendingBatch.validationError(res.err); // Throws after MAX_BATCH_PROCESSING_ATTEMPTS
         }
       }
     }

--- a/packages/lodestar/test/unit/sync/range/batch.test.ts
+++ b/packages/lodestar/test/unit/sync/range/batch.test.ts
@@ -62,7 +62,7 @@ describe("sync / range / batch", () => {
     expect(batch.state.status).to.equal(BatchStatus.AwaitingValidation, "Wrong status on processingSuccess");
 
     // validationError: AwaitingValidation -> AwaitingDownload
-    batch.validationError();
+    batch.validationError(new Error());
     expect(batch.state.status).to.equal(BatchStatus.AwaitingDownload, "Wrong status on validationError");
 
     // retry download + processing + validation: AwaitingDownload -> Downloading -> AwaitingProcessing -> Processing -> AwaitingValidation


### PR DESCRIPTION

**Motivation**
On further testing, figured out that peers will still getting down scored on execution errors and realized that we also process `validationError` for previous batches.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR also provides the same treatment to `validationError`, helping it discriminate between execution errors and others, so that  `MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS` is thrown instead of `MAX_BATCH_PROCESSING_ATTEMPTS` preventing down-scoring of peers.
Context: merged [PR 3545](https://github.com/ChainSafe/lodestar/pull/3545)
Tested locally on kintsugi devnet :heavy_check_mark: 