### PR TITLE
Ensure there are 10 epochs max in StateContextCheckpoint

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -133,6 +133,7 @@ export class BeaconChain implements IBeaconChain {
       checkpointStateCache,
       db,
       metrics,
+      emitter,
       signal,
     });
 

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -111,6 +111,7 @@ export class MockBeaconChain implements IBeaconChain {
       checkpointStateCache: this.checkpointStateCache,
       db,
       metrics: null,
+      emitter: this.emitter,
     });
     this.lightClientServer = new LightClientServer(
       {config: this.config, emitter: this.emitter, logger, db: db},


### PR DESCRIPTION
**Motivation**

During non-finality period of prater, sometimes the StateContextCheckpoint contains up to 16 epochs, we want to ensure it's 10 max

**Description**

+ We control that by Checkpoint event but we miss emitting it when checkpoint is at a skipped slot
+ Add it back in regen module


Closes #3583
