### PR TITLE
forward sync with wsCheckpoint

### DIFF
--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -30,6 +30,7 @@ export interface IForkChoice {
    */
   getHeadRoot(): RootHex;
   getHead(): IProtoBlock;
+  wsCheckpointFoundAndValidated(): boolean;
   updateHead(): IProtoBlock;
   /**
    * Retrieves all possible chain heads (leaves of fork choice tree).

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -91,6 +91,7 @@ export class BeaconChain implements IBeaconChain {
       db,
       logger,
       metrics,
+      wsCheckpoint,
       anchorState,
       eth1,
       executionEngine,
@@ -99,6 +100,7 @@ export class BeaconChain implements IBeaconChain {
       db: IBeaconDb;
       logger: ILogger;
       metrics: IMetrics | null;
+      wsCheckpoint?: phase0.Checkpoint | null;
       anchorState: TreeBacked<allForks.BeaconState>;
       eth1: IEth1ForBlockProduction;
       executionEngine: IExecutionEngine;
@@ -125,7 +127,7 @@ export class BeaconChain implements IBeaconChain {
     const stateCache = new StateContextCache({metrics});
     const checkpointStateCache = new CheckpointStateCache({metrics});
     const cachedState = restoreStateCaches(config, stateCache, checkpointStateCache, anchorState);
-    const forkChoice = initializeForkChoice(config, emitter, clock.currentSlot, cachedState, metrics);
+    const forkChoice = initializeForkChoice(config, emitter, clock.currentSlot, cachedState, wsCheckpoint, metrics);
     const regen = new QueuedStateRegenerator({
       config,
       forkChoice,

--- a/packages/lodestar/src/chain/forkChoice/index.ts
+++ b/packages/lodestar/src/chain/forkChoice/index.ts
@@ -3,7 +3,7 @@
  */
 
 import {toHexString} from "@chainsafe/ssz";
-import {allForks, Slot} from "@chainsafe/lodestar-types";
+import {allForks, Slot, phase0} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {ForkChoice, ProtoArray, ForkChoiceStore, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
 import {getEffectiveBalances, CachedBeaconState, merge} from "@chainsafe/lodestar-beacon-state-transition";
@@ -26,6 +26,7 @@ export function initializeForkChoice(
   emitter: ChainEventEmitter,
   currentSlot: Slot,
   state: CachedBeaconState<allForks.BeaconState>,
+  wsCheckpoint?: phase0.Checkpoint | null,
   metrics?: IMetrics | null
 ): ForkChoice {
   const {blockHeader, checkpoint} = computeAnchorCheckpoint(config, state);
@@ -69,6 +70,7 @@ export function initializeForkChoice(
     }),
 
     justifiedBalances,
+    wsCheckpoint,
     metrics
   );
 }

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -138,6 +138,7 @@ export class BeaconNode {
       db,
       logger: logger.child(opts.logger.chain),
       metrics,
+      wsCheckpoint,
       anchorState,
       eth1: initializeEth1ForBlockProduction(
         opts.eth1,
@@ -234,7 +235,7 @@ export class BeaconNode {
     if (this.status === BeaconNodeStatus.started) {
       this.status = BeaconNodeStatus.closing;
       this.sync.close();
-      this.backfillSync?.close();
+      this.backfillSync.close();
       await this.network.stop();
       if (this.metricsServer) await this.metricsServer.stop();
       if (this.restApi) await this.restApi.close();

--- a/packages/lodestar/src/sync/sync.ts
+++ b/packages/lodestar/src/sync/sync.ts
@@ -104,6 +104,8 @@ export class BeaconSync implements IBeaconSync {
       (currentSlot < 0 ||
         // head is behind clock but close enough with some tolerance
         (headSlot <= currentSlot && headSlot >= currentSlot - this.slotImportTolerance)) &&
+      // If a checkpoint was set, it should have been found
+      this.chain.forkChoice.wsCheckpointFoundAndValidated() &&
       // Ensure there at least one connected peer to not claim synced if has no peers
       // Allow to bypass this conditions for local networks with a single node
       (this.opts.isSingleNode || this.network.hasSomeConnectedPeer())

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -193,6 +193,7 @@ function mockForkChoice(): IForkChoice {
     getAncestor: () => rootHex,
     getHeadRoot: () => rootHex,
     getHead: () => block,
+    wsCheckpointFoundAndValidated: () => true,
     updateHead: () => block,
     getHeads: () => [block],
     getFinalizedCheckpoint: () => checkpoint,


### PR DESCRIPTION
**Motivation**
Currently lodestar only provides starting sync from a `wsCheckpoint` (if wsCheckpoint is ahead of db state)  by syncing state from `weakSubjectivityServerUrl`.
<!-- Why is this PR exists? What are the goals of the pull request? -->

This PR enables forward sync anchored in future by `wsCheckpoint` (while starting from DB/genesis), which basically validates finding `wsCheckpoint` as a finalized checkpoint as the chain syncs forward. 

However if a `weakSubjectivityServerUrl` is also provided, then lodestar will just use that url to fetch state and again sync from  wsCheckpoint and validate wsCheckpoint connecting to genesis in a backfill sync.


**Description**
example usage:
`./lodestar beacon --network prater --rootDir /data  --weakSubjectivityCheckpoint 0xbff6ef213be7c53b0181b2daf7ed68fe1ca29eebed04bf7ef46166c51fdcea55:65429`

This will result in the following successful log output (after it syncs past the wsCheckpoint epoch  65429 as a finalized checkpoint):
`Jan-08 09:58:22.913 [CHAIN]            info: wsCheckpoint found and validated as finalized root=0xbff6ef213be7c53b0181b2daf7ed68fe1ca29eebed04bf7ef46166c51fdcea55, epoch=65429`

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #3385