### PR TITLE
Bugfix: don't throw error if finalized state not found for backfill ranges while archiving state

### DIFF
--- a/packages/lodestar/src/chain/archiver/archiveStates.ts
+++ b/packages/lodestar/src/chain/archiver/archiveStates.ts
@@ -49,15 +49,14 @@ export class StatesArchiver {
 
     // Mark the sequence in backfill db from finalized slot till anchor slot as filled
     const finalizedState = this.checkpointStateCache.get(finalized);
-    if (!finalizedState) {
-      throw Error("No state in cache for finalized checkpoint state epoch #" + finalized.epoch);
-    }
-    await this.db.backfilledRanges.put(finalizedState.slot, anchorSlot);
+    if (finalizedState) {
+      await this.db.backfilledRanges.put(finalizedState.slot, anchorSlot);
 
-    // Clear previously marked sequence till anchorSlot, without touching backfill sync
-    // process sequence which are at <=anchorSlot i.e. clear >anchorSlot and < currentSlot
-    const filteredSeqs = await this.db.backfilledRanges.keys({gt: anchorSlot, lt: finalizedState.slot});
-    await this.db.backfilledRanges.batchDelete(filteredSeqs);
+      // Clear previously marked sequence till anchorSlot, without touching backfill sync
+      // process sequence which are at <=anchorSlot i.e. clear >anchorSlot and < currentSlot
+      const filteredSeqs = await this.db.backfilledRanges.keys({gt: anchorSlot, lt: finalizedState.slot});
+      await this.db.backfilledRanges.batchDelete(filteredSeqs);
+    }
 
     if (finalized.epoch - lastStoredEpoch > PERSIST_TEMP_STATE_EVERY_EPOCHS) {
       await this.archiveState(finalized);

--- a/packages/lodestar/src/chain/archiver/index.ts
+++ b/packages/lodestar/src/chain/archiver/index.ts
@@ -75,7 +75,7 @@ export class Archiver {
       this.chain.stateCache.deleteAllBeforeEpoch(finalizedEpoch);
       // tasks rely on extended fork choice
       this.chain.forkChoice.prune(finalized.rootHex);
-      void this.updateBackfillRange(finalized);
+      await this.updateBackfillRange(finalized);
 
       this.logger.verbose("Finish processing finalized checkpoint", {epoch: finalizedEpoch});
     } catch (e) {

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -110,7 +110,7 @@ export class BeaconChain implements IBeaconChain {
     this.logger = logger;
     this.metrics = metrics;
     this.genesisTime = anchorState.genesisTime;
-    this.anchorSlot = anchorState.slot;
+    this.anchorSlot = anchorState.latestBlockHeader.slot;
     this.genesisValidatorsRoot = anchorState.genesisValidatorsRoot.valueOf() as Uint8Array;
     this.eth1 = eth1;
     this.executionEngine = executionEngine;

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -51,7 +51,7 @@ export class BeaconChain implements IBeaconChain {
   readonly executionEngine: IExecutionEngine;
   // Expose config for convenience in modularized functions
   readonly config: IBeaconConfig;
-  readonly anchorSlot: Slot;
+  readonly anchorStateLatestBlockSlot: Slot;
 
   bls: IBlsVerifier;
   forkChoice: IForkChoice;
@@ -110,7 +110,7 @@ export class BeaconChain implements IBeaconChain {
     this.logger = logger;
     this.metrics = metrics;
     this.genesisTime = anchorState.genesisTime;
-    this.anchorSlot = anchorState.latestBlockHeader.slot;
+    this.anchorStateLatestBlockSlot = anchorState.latestBlockHeader.slot;
     this.genesisValidatorsRoot = anchorState.genesisValidatorsRoot.valueOf() as Uint8Array;
     this.eth1 = eth1;
     this.executionEngine = executionEngine;

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -41,7 +41,7 @@ export interface IBeaconChain {
   readonly config: IBeaconConfig;
 
   /** The initial slot that the chain is started with */
-  readonly anchorSlot: Slot;
+  readonly anchorStateLatestBlockSlot: Slot;
 
   bls: IBlsVerifier;
   forkChoice: IForkChoice;

--- a/packages/lodestar/src/chain/stateCache/stateContextCache.ts
+++ b/packages/lodestar/src/chain/stateCache/stateContextCache.ts
@@ -102,7 +102,7 @@ export class StateContextCache {
   /**
    * Prune per finalized epoch.
    */
-  async deleteAllBeforeEpoch(finalizedEpoch: Epoch): Promise<void> {
+  deleteAllBeforeEpoch(finalizedEpoch: Epoch): void {
     for (const epoch of this.epochIndex.keys()) {
       if (epoch < finalizedEpoch) {
         this.deleteAllEpochItems(epoch);

--- a/packages/lodestar/src/chain/stateCache/stateContextCheckpointsCache.ts
+++ b/packages/lodestar/src/chain/stateCache/stateContextCheckpointsCache.ts
@@ -83,7 +83,7 @@ export class CheckpointStateCache {
     return previousHits;
   }
 
-  pruneFinalized(finalizedEpoch: Epoch): void {
+  async pruneFinalized(finalizedEpoch: Epoch): Promise<void> {
     for (const epoch of this.epochIndex.keys()) {
       if (epoch < finalizedEpoch) {
         this.deleteAllEpochItems(epoch);

--- a/packages/lodestar/src/chain/stateCache/stateContextCheckpointsCache.ts
+++ b/packages/lodestar/src/chain/stateCache/stateContextCheckpointsCache.ts
@@ -83,7 +83,7 @@ export class CheckpointStateCache {
     return previousHits;
   }
 
-  async pruneFinalized(finalizedEpoch: Epoch): Promise<void> {
+  pruneFinalized(finalizedEpoch: Epoch): void {
     for (const epoch of this.epochIndex.keys()) {
       if (epoch < finalizedEpoch) {
         this.deleteAllEpochItems(epoch);

--- a/packages/lodestar/src/sync/backfill/backfill.ts
+++ b/packages/lodestar/src/sync/backfill/backfill.ts
@@ -231,16 +231,18 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
     const {config, anchorState, db, wsCheckpoint, logger} = modules;
 
     const {checkpoint: anchorCp} = computeAnchorCheckpoint(config, anchorState);
+    const anchorSlot = anchorState.latestBlockHeader.slot;
     const syncAnchor = {
       anchorBlock: null,
       anchorBlockRoot: anchorCp.root,
-      anchorSlot: anchorState.slot,
+      anchorSlot,
       lastBackSyncedBlock: null,
     };
     const backfillStartFromSlot = anchorState.slot;
     modules.logger.info("BackfillSync - initializing from Checkpoint", {
       root: toHexString(anchorCp.root),
       epoch: anchorCp.epoch,
+      slot: anchorSlot,
     });
 
     // Load the previous written to slot for the key  backfillStartFromSlot
@@ -252,7 +254,7 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
       ? {root: wsCheckpoint.root, slot: wsCheckpoint.epoch * SLOTS_PER_EPOCH}
       : null;
     // Load a previous finalized or wsCheckpoint slot from DB below anchorSlot
-    const prevFinalizedCheckpointBlock = await extractPreviousFinOrWsCheckpoint(config, db, anchorState.slot, logger);
+    const prevFinalizedCheckpointBlock = await extractPreviousFinOrWsCheckpoint(config, db, anchorSlot, logger);
 
     return new this(
       {

--- a/packages/lodestar/src/sync/backfill/backfill.ts
+++ b/packages/lodestar/src/sync/backfill/backfill.ts
@@ -542,7 +542,6 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
 
     const filteredSeqs = await this.db.backfilledRanges.entries({
       gte: lastBackSyncedSlot,
-      lte: this.backfillStartFromSlot,
     });
 
     if (filteredSeqs.length > 0) {
@@ -627,7 +626,9 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
 
     if (filteredSeqs.length > 0) {
       await this.db.backfilledRanges.batchDelete(
-        filteredSeqs.filter((entry) => entry.key !== this.backfillStartFromSlot).map((entry) => entry.key)
+        // Only delete < backfillStartFromSlot, the keys greater than this would be cleaned
+        // up by the archival process of forward sync
+        filteredSeqs.filter((entry) => entry.key < this.backfillStartFromSlot).map((entry) => entry.key)
       );
     }
 

--- a/packages/lodestar/test/unit/chain/stateCache/stateContextCache.test.ts
+++ b/packages/lodestar/test/unit/chain/stateCache/stateContextCache.test.ts
@@ -43,8 +43,8 @@ describe("StateContextCache", function () {
     expect(cache.get(toHexString(key2)), "must have key2").to.be.not.undefined;
   });
 
-  it("should deleteAllBeforeEpoch", async function () {
-    await cache.deleteAllBeforeEpoch(2);
+  it("should deleteAllBeforeEpoch", function () {
+    cache.deleteAllBeforeEpoch(2);
     expect(cache.size).to.be.equal(0, "size must be 0 after delete all");
   });
 });

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -52,7 +52,7 @@ export class MockBeaconChain implements IBeaconChain {
   readonly eth1 = new Eth1ForBlockProductionDisabled();
   readonly executionEngine = new ExecutionEngineDisabled();
   readonly config: IBeaconConfig;
-  readonly anchorSlot: Slot;
+  readonly anchorStateLatestBlockSlot: Slot;
 
   readonly bls: IBlsVerifier;
   forkChoice: IForkChoice;
@@ -90,7 +90,7 @@ export class MockBeaconChain implements IBeaconChain {
     this.chainId = chainId || 0;
     this.networkId = networkId || BigInt(0);
     this.state = state;
-    this.anchorSlot = state.slot;
+    this.anchorStateLatestBlockSlot = state.latestBlockHeader.slot;
     this.config = config;
     this.emitter = new ChainEventEmitter();
     this.abortController = new AbortController();


### PR DESCRIPTION
**Motivation**
In the backfill sync, in the archival process, updating backfill ranges required finalized slot. On not finding, it was made to error which messed up with the hot db to cold db movement of the blocks. This was observed in kintsugi network:
```
Jan-08 18:18:30.000 []                 info: Syncing - 8.5 hours left - 5.44 slots/s - slot: 167167 (skipped 165688) - head: 1479 0x81d0…f181 - execution: valid(0x32d6…a73e) - finalized: 0x5738…e489:43 - peers: 14
Jan-08 18:18:33.008 [CHAIN]           error: State for currentJustifiedCheckpoint not available, using closest state checkpointEpoch=46, checkpointRoot=0xdaf0940d9a9bc2bdf88ffd11b237104587290ccd5cb06441c6a2e96b447aec1f, stateSlot=1475, stateRoot=0x3ad08611a1a61a4431c3258f6a86e990ed3d0bbe746fb3f666d8ff8be6e3bd15
Jan-08 18:18:35.142 [CHAIN]           error: Error processing finalized checkpoint epoch=46 message=No state in cache for finalized checkpoint state epoch #46
Error: No state in cache for finalized checkpoint state epoch #46
    at StatesArchiver.maybeArchiveState (/usr/app/packages/lodestar/s
```
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR fixes the issue by not throwing, as updating backfill ranges on a missed finalized state is not a critical as it will get updated next time around the archival happens. PR changes `throw` to an positive `if` scenario for updating backfill ranges.

