### PR TITLE
Add from-package to lerna publish command in release-nightly.yml

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -50,7 +50,7 @@ jobs:
         # --force-publish: lerna doesn't want to publish anything otherwise - "lerna success No changed packages to publish"
         # NOTE: Using --preid dev.$(git rev-parse --short=7 HEAD) results in `0.24.3-dev.3ddb91d.0+3ddb91d`
         run: |
-          node_modules/.bin/lerna publish --yes --no-verify-access \
+          node_modules/.bin/lerna publish from-package --yes --no-verify-access \
           --canary --dist-tag next --no-git-reset --force-publish \
           --preid dev
         env:


### PR DESCRIPTION
**Motivation**

+ package.json specifies "0.34.0" but lerna released with "0.32.1-dev.70+758a958aec"

**Description**
+ Refer to https://www.npmjs.com/package/@lerna/publish for documentation
+ I see in the comment we specify to release with `from-package` but don't see it in the command so add it here
