### PR TITLE
CL spec 1.1.6: Rename merge transition fields

### DIFF
--- a/packages/beacon-state-transition/src/merge/block/processExecutionPayload.ts
+++ b/packages/beacon-state-transition/src/merge/block/processExecutionPayload.ts
@@ -3,7 +3,7 @@ import {byteArrayEquals, List, toHexString} from "@chainsafe/ssz";
 import {CachedBeaconState} from "../../allForks";
 import {getRandaoMix} from "../../util";
 import {ExecutionEngine} from "../executionEngine";
-import {isMergeComplete} from "../utils";
+import {isMergeTransitionComplete} from "../utils";
 
 export function processExecutionPayload(
   state: CachedBeaconState<merge.BeaconState>,
@@ -12,7 +12,7 @@ export function processExecutionPayload(
 ): void {
   // Verify consistency of the parent hash, block number, base fee per gas and gas limit
   // with respect to the previous execution payload header
-  if (isMergeComplete(state)) {
+  if (isMergeTransitionComplete(state)) {
     const {latestExecutionPayloadHeader} = state;
     if (!byteArrayEquals(payload.parentHash as Uint8Array, latestExecutionPayloadHeader.blockHash as Uint8Array)) {
       throw Error(

--- a/packages/beacon-state-transition/src/merge/utils.ts
+++ b/packages/beacon-state-transition/src/merge/utils.ts
@@ -6,7 +6,7 @@ import {allForks, merge, ssz} from "@chainsafe/lodestar-types";
  */
 export function isExecutionEnabled(state: merge.BeaconState, body: merge.BeaconBlockBody): boolean {
   return (
-    isMergeComplete(state) ||
+    isMergeTransitionComplete(state) ||
     !ssz.merge.ExecutionPayload.equals(body.executionPayload, ssz.merge.ExecutionPayload.defaultValue())
   );
 }
@@ -15,9 +15,9 @@ export function isExecutionEnabled(state: merge.BeaconState, body: merge.BeaconB
  * Merge block is the SINGLE block that transitions from POW to POS.
  * state has no execution data AND this block has execution data
  */
-export function isMergeBlock(state: merge.BeaconState, body: merge.BeaconBlockBody): boolean {
+export function isMergeTransitionBlock(state: merge.BeaconState, body: merge.BeaconBlockBody): boolean {
   return (
-    !isMergeComplete(state) &&
+    !isMergeTransitionComplete(state) &&
     !ssz.merge.ExecutionPayload.equals(body.executionPayload, ssz.merge.ExecutionPayload.defaultValue())
   );
 }
@@ -26,7 +26,7 @@ export function isMergeBlock(state: merge.BeaconState, body: merge.BeaconBlockBo
  * Merge is complete when the state includes execution layer data:
  * state.latestExecutionPayloadHeader NOT EMPTY
  */
-export function isMergeComplete(state: merge.BeaconState): boolean {
+export function isMergeTransitionComplete(state: merge.BeaconState): boolean {
   return !ssz.merge.ExecutionPayloadHeader.equals(
     state.latestExecutionPayloadHeader,
     ssz.merge.ExecutionPayloadHeader.defaultTreeBacked()

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -296,8 +296,10 @@ export class ForkChoice implements IForkChoice {
     }
 
     if (
-      preCachedData?.isMergeBlock ||
-      (merge.isMergeStateType(state) && merge.isMergeBlockBodyType(block.body) && merge.isMergeBlock(state, block.body))
+      preCachedData?.isMergeTransitionBlock ||
+      (merge.isMergeStateType(state) &&
+        merge.isMergeBlockBodyType(block.body) &&
+        merge.isMergeTransitionBlock(state, block.body))
     )
       assertValidTerminalPowBlock(this.config, (block as unknown) as merge.BeaconBlock, preCachedData);
 

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -165,7 +165,7 @@ export type OnBlockPrecachedData = {
   /**
    * Optimistic sync fields
    */
-  isMergeBlock?: boolean;
+  isMergeTransitionBlock?: boolean;
   executionStatus?: ExecutionStatus;
 };
 

--- a/packages/lodestar/src/chain/blocks/importBlock.ts
+++ b/packages/lodestar/src/chain/blocks/importBlock.ts
@@ -95,7 +95,7 @@ export async function importBlock(chain: ImportBlockModules, fullyVerifiedBlock:
   if (
     merge.isMergeStateType(postState) &&
     merge.isMergeBlockBodyType(block.message.body) &&
-    merge.isMergeBlock(postState, block.message.body)
+    merge.isMergeTransitionBlock(postState, block.message.body)
   ) {
     // pow_block = get_pow_block(block.body.execution_payload.parent_hash)
     const powBlockRootHex = toHexString(block.message.body.executionPayload.parentHash);
@@ -108,7 +108,7 @@ export async function importBlock(chain: ImportBlockModules, fullyVerifiedBlock:
       throw Error(`merge block parent's parent POW block not found ${powBlock.parentHash}`);
     onBlockPrecachedData.powBlock = powBlock;
     onBlockPrecachedData.powBlockParent = powBlockParent;
-    onBlockPrecachedData.isMergeBlock = true;
+    onBlockPrecachedData.isMergeTransitionBlock = true;
   }
 
   const prevFinalizedEpoch = chain.forkChoice.getFinalizedCheckpoint().epoch;

--- a/packages/lodestar/src/chain/factory/block/body.ts
+++ b/packages/lodestar/src/chain/factory/block/body.ts
@@ -128,7 +128,7 @@ async function prepareExecutionPayload(
   // Use different POW block hash parent for block production based on merge status.
   // Returned value of null == using an empty ExecutionPayload value
   let parentHash: Root;
-  if (!merge.isMergeComplete(state)) {
+  if (!merge.isMergeTransitionComplete(state)) {
     if (
       !ssz.Root.equals(chain.config.TERMINAL_BLOCK_HASH, ZERO_HASH) &&
       getCurrentEpoch(state) < chain.config.TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH

--- a/packages/lodestar/src/chain/forkChoice/index.ts
+++ b/packages/lodestar/src/chain/forkChoice/index.ts
@@ -60,7 +60,7 @@ export function initializeForkChoice(
       finalizedEpoch: finalizedCheckpoint.epoch,
       finalizedRoot: toHexString(finalizedCheckpoint.root),
 
-      ...(merge.isMergeStateType(state) && merge.isMergeComplete(state)
+      ...(merge.isMergeStateType(state) && merge.isMergeTransitionComplete(state)
         ? {
             executionPayloadBlockHash: toHexString(state.latestExecutionPayloadHeader.blockHash),
             executionStatus: blockHeader.slot === GENESIS_SLOT ? ExecutionStatus.Valid : ExecutionStatus.Syncing,

--- a/packages/lodestar/src/eth1/eth1MergeBlockTracker.ts
+++ b/packages/lodestar/src/eth1/eth1MergeBlockTracker.ts
@@ -35,7 +35,7 @@ export type Eth1MergeBlockTrackerModules = {
   logger: ILogger;
   signal: AbortSignal;
   clockEpoch: Epoch;
-  isMergeComplete: boolean;
+  isMergeTransitionComplete: boolean;
 };
 
 /**
@@ -57,7 +57,7 @@ export class Eth1MergeBlockTracker {
   private readonly intervals: NodeJS.Timeout[] = [];
 
   constructor(
-    {config, logger, signal, clockEpoch, isMergeComplete}: Eth1MergeBlockTrackerModules,
+    {config, logger, signal, clockEpoch, isMergeTransitionComplete}: Eth1MergeBlockTrackerModules,
     private readonly eth1Provider: IEth1Provider
   ) {
     this.config = config;
@@ -65,7 +65,7 @@ export class Eth1MergeBlockTracker {
     this.signal = signal;
 
     // If merge has already happened, disable
-    if (isMergeComplete) {
+    if (isMergeTransitionComplete) {
       this.status = StatusCode.POST_MERGE;
       return;
     }

--- a/packages/lodestar/src/eth1/index.ts
+++ b/packages/lodestar/src/eth1/index.ts
@@ -53,7 +53,7 @@ export function initializeEth1ForBlockProduction(
       logger: modules.logger,
       signal: modules.signal,
       clockEpoch: computeEpochAtSlot(getCurrentSlot(modules.config, anchorState.genesisTime)),
-      isMergeComplete: merge.isMergeStateType(anchorState) && merge.isMergeComplete(anchorState),
+      isMergeTransitionComplete: merge.isMergeStateType(anchorState) && merge.isMergeTransitionComplete(anchorState),
     });
   } else {
     return new Eth1ForBlockProductionDisabled();

--- a/packages/lodestar/src/node/notifier.ts
+++ b/packages/lodestar/src/node/notifier.ts
@@ -60,8 +60,8 @@ export async function runNodeNotifier({
       const peersRow = `peers: ${connectedPeerCount}`;
       const finalizedCheckpointRow = `finalized: ${prettyBytes(finalizedRoot)}:${finalizedEpoch}`;
       const headRow = `head: ${headInfo.slot} ${prettyBytes(headInfo.blockRoot)}`;
-      const isMergeComplete = merge.isMergeStateType(headState) && merge.isMergeComplete(headState);
-      const mergeInfo = isMergeComplete
+      const isMergeTransitionComplete = merge.isMergeStateType(headState) && merge.isMergeTransitionComplete(headState);
+      const mergeInfo = isMergeTransitionComplete
         ? [
             `execution: ${headInfo.executionStatus.toLowerCase()}(${prettyBytes(
               headInfo.executionPayloadBlockHash ?? "empty"

--- a/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
@@ -76,7 +76,7 @@ describe("eth1 / Eth1Provider", function () {
       signal: controller.signal,
       eth1Provider,
       clockEpoch: 0,
-      isMergeComplete: false,
+      isMergeTransitionComplete: false,
     });
 
     // Resolves when Eth1ForBlockProduction has fetched both blocks and deposits

--- a/packages/lodestar/test/e2e/eth1/eth1MergeBlockTracker.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1MergeBlockTracker.test.ts
@@ -57,7 +57,7 @@ describe("eth1 / Eth1MergeBlockTracker", function () {
         logger,
         signal: controller.signal,
         clockEpoch: 0,
-        isMergeComplete: false,
+        isMergeTransitionComplete: false,
       },
       eth1Provider as IEth1Provider
     );
@@ -94,7 +94,7 @@ describe("eth1 / Eth1MergeBlockTracker", function () {
         logger,
         signal: controller.signal,
         clockEpoch: 0,
-        isMergeComplete: false,
+        isMergeTransitionComplete: false,
       },
       eth1Provider as IEth1Provider
     );
@@ -131,7 +131,7 @@ describe("eth1 / Eth1MergeBlockTracker", function () {
         logger,
         signal: controller.signal,
         clockEpoch: 0,
-        isMergeComplete: false,
+        isMergeTransitionComplete: false,
       },
       eth1Provider as IEth1Provider
     );

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -365,8 +365,8 @@ describe("executionEngine / ExecutionEngineHttp", function () {
           // By this slot, ttd should be reached and merge complete
           case Number(ttd) + 3: {
             const headState = bn.chain.getHeadState();
-            const isMergeComplete = merge.isMergeStateType(headState) && merge.isMergeComplete(headState);
-            if (!isMergeComplete) reject("Merge not completed");
+            const isMergeTransitionComplete = merge.isMergeStateType(headState) && merge.isMergeTransitionComplete(headState);
+            if (!isMergeTransitionComplete) reject("Merge not completed");
 
             // Send another tx post-merge, total amount in destination account should be double after this is included in chain
             if (TX_SCENARIOS.includes("simple")) {

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -365,7 +365,8 @@ describe("executionEngine / ExecutionEngineHttp", function () {
           // By this slot, ttd should be reached and merge complete
           case Number(ttd) + 3: {
             const headState = bn.chain.getHeadState();
-            const isMergeTransitionComplete = merge.isMergeStateType(headState) && merge.isMergeTransitionComplete(headState);
+            const isMergeTransitionComplete =
+              merge.isMergeStateType(headState) && merge.isMergeTransitionComplete(headState);
             if (!isMergeTransitionComplete) reject("Merge not completed");
 
             // Send another tx post-merge, total amount in destination account should be double after this is included in chain

--- a/packages/lodestar/test/unit/eth1/eth1MergeBlockTracker.test.ts
+++ b/packages/lodestar/test/unit/eth1/eth1MergeBlockTracker.test.ts
@@ -66,7 +66,7 @@ describe("eth1 / Eth1MergeBlockTracker", () => {
         logger,
         signal: controller.signal,
         clockEpoch: 0,
-        isMergeComplete: false,
+        isMergeTransitionComplete: false,
       },
       eth1Provider as IEth1Provider
     );
@@ -137,7 +137,7 @@ describe("eth1 / Eth1MergeBlockTracker", () => {
         logger,
         signal: controller.signal,
         clockEpoch: 0,
-        isMergeComplete: false,
+        isMergeTransitionComplete: false,
       },
       eth1Provider as IEth1Provider
     );
@@ -210,7 +210,7 @@ describe("eth1 / Eth1MergeBlockTracker", () => {
         logger,
         signal: controller.signal,
         clockEpoch: 0,
-        isMergeComplete: false,
+        isMergeTransitionComplete: false,
       },
       eth1Provider as IEth1Provider
     );


### PR DESCRIPTION
**Motivation**
As part of CL spec 1.1.6 (https://github.com/ethereum/consensus-specs/pull/2738) , two fields were renamed for better clarity:
- is_merge_complete -> is_merge_transition_complete
- is_merge_block -> is_merge_transition_block


<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR implements those renaming in lodestar
