### PR TITLE
Upgrade to spec 1.1.6 sans proposer boost

### DIFF
--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -17,7 +17,7 @@ import {ProtoArray} from "../protoArray/protoArray";
 import {IForkChoiceMetrics} from "../metrics";
 import {ForkChoiceError, ForkChoiceErrorCode, InvalidBlockCode, InvalidAttestationCode} from "./errors";
 import {IForkChoice, ILatestMessage, IQueuedAttestation, OnBlockPrecachedData} from "./interface";
-import {IForkChoiceStore, CheckpointWithHex, toCheckpointWithHex, equalCheckpointWithHex} from "./store";
+import {IForkChoiceStore, CheckpointWithHex, toCheckpointWithHex} from "./store";
 
 /* eslint-disable max-len */
 
@@ -329,19 +329,8 @@ export class ForkChoice implements IForkChoice {
     // Update finalized checkpoint.
     if (finalizedCheckpoint.epoch > this.fcStore.finalizedCheckpoint.epoch) {
       this.fcStore.finalizedCheckpoint = toCheckpointWithHex(finalizedCheckpoint);
+      shouldUpdateJustified = true;
       this.synced = false;
-
-      if (
-        // If checkpoints are not equal
-        (!equalCheckpointWithHex(this.fcStore.justifiedCheckpoint, currentJustifiedCheckpoint) &&
-          stateJustifiedEpoch > this.fcStore.justifiedCheckpoint.epoch) ||
-        this.getAncestor(
-          this.fcStore.justifiedCheckpoint.rootHex,
-          computeStartSlotAtEpoch(this.fcStore.finalizedCheckpoint.epoch)
-        ) !== this.fcStore.finalizedCheckpoint.rootHex
-      ) {
-        shouldUpdateJustified = true;
-      }
     }
 
     // This needs to be performed after finalized checkpoint has been updated

--- a/packages/lodestar/test/spec/allForks/forkChoice.ts
+++ b/packages/lodestar/test/spec/allForks/forkChoice.ts
@@ -157,6 +157,11 @@ export function forkChoiceTest(fork: ForkName): void {
         timeout: 10000,
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         expectFunc: () => {},
+        shouldSkip: (_testCase, name, _index) => {
+          const ignoreTestsWithKeywords = ["proposer_boost"];
+          const ignoreTest = ignoreTestsWithKeywords.reduce((acc, kword) => acc || name.includes(kword), false);
+          return ignoreTest;
+        },
       }
     );
   }

--- a/packages/lodestar/test/spec/specTestVersioning.ts
+++ b/packages/lodestar/test/spec/specTestVersioning.ts
@@ -8,6 +8,6 @@ import path from "path";
 // The contents of this file MUST include the URL, version and target path, and nothing else.
 
 export const SPEC_TEST_REPO_URL = "https://github.com/ethereum/consensus-spec-tests";
-export const SPEC_TEST_VERSION = "v1.1.5";
+export const SPEC_TEST_VERSION = "v1.1.6";
 // Target directory is the host package root: 'packages/*/spec-tests'
 export const SPEC_TEST_LOCATION = path.join(__dirname, "../../spec-tests");

--- a/packages/types/src/merge/sszTypes.ts
+++ b/packages/types/src/merge/sszTypes.ts
@@ -157,13 +157,11 @@ export const PowBlock = new ContainerType<merge.PowBlock>({
     blockHash: Root,
     parentHash: Root,
     totalDifficulty: Uint256,
-    difficulty: Uint256,
   },
   casingMap: {
     blockHash: "block_hash",
     parentHash: "parent_hash",
     totalDifficulty: "total_difficulty",
-    difficulty: "difficulty",
   },
 });
 

--- a/packages/types/src/merge/types.ts
+++ b/packages/types/src/merge/types.ts
@@ -49,5 +49,4 @@ export type PowBlock = {
   blockHash: Root;
   parentHash: Root;
   totalDifficulty: bigint;
-  difficulty: bigint;
 };


### PR DESCRIPTION
**Motivation**
Spec 1.1.6 has following changes pending apart from proposer boost
<!-- Why is this PR exists? What are the goals of the pull request? -->
- removing difficulty field
- atomic updated of finalized and justified in forkchoice
**Description**

Details
- This PR tackles the above two points. 
- Adds a placeholder test file for `merge/transition` tests to be added as separate PR: tracked here: https://github.com/ChainSafe/lodestar/issues/3541
- Proposer boot will be addressed in a separate PR and right now will be opt-in via flag : draft PR wip : https://github.com/ChainSafe/lodestar/pull/3540 

Part of https://github.com/ChainSafe/lodestar/issues/3483
