### PR TITLE
Delete redundant sync committee duties

### DIFF
--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -187,20 +187,21 @@ export class SyncCommitteeDutiesService {
     });
     const dependentRoot = syncDuties.dependentRoot;
     const period = computeSyncPeriodAtEpoch(epoch);
+    let dutiesByIndex = this.dutiesByIndexByPeriod.get(period);
+    if (!dutiesByIndex) {
+      dutiesByIndex = new Map<ValidatorIndex, DutyAtPeriod>();
+      this.dutiesByIndexByPeriod.set(period, dutiesByIndex);
+    }
+    const redundantDutiedValidatorIndices = new Set(dutiesByIndex.keys());
 
     let count = 0;
 
     for (const duty of syncDuties.data) {
-      if (!this.indicesService.hasValidatorIndex(duty.validatorIndex)) {
+      const {validatorIndex} = duty;
+      if (!this.indicesService.hasValidatorIndex(validatorIndex)) {
         continue;
       }
       count++;
-
-      let dutiesByIndex = this.dutiesByIndexByPeriod.get(period);
-      if (!dutiesByIndex) {
-        dutiesByIndex = new Map<ValidatorIndex, DutyAtPeriod>();
-        this.dutiesByIndexByPeriod.set(period, dutiesByIndex);
-      }
 
       // TODO: Enable dependentRoot functionality
       // Meanwhile just overwrite them, since the latest duty will be older and less likely to re-org
@@ -211,10 +212,22 @@ export class SyncCommitteeDutiesService {
       // - The dependent root has changed, signalling a re-org.
 
       // Using `alreadyWarnedReorg` avoids excessive logs.
-      dutiesByIndex.set(duty.validatorIndex, {dependentRoot, duty});
+      dutiesByIndex.set(validatorIndex, {dependentRoot, duty});
+      redundantDutiedValidatorIndices.delete(validatorIndex);
     }
 
-    this.logger.debug("Downloaded SyncDuties", {epoch, dependentRoot: toHexString(dependentRoot), count});
+    // these could be redundant duties due to the state of next period query reorged
+    // see https://github.com/ChainSafe/lodestar/issues/3572
+    for (const validatorIndex of redundantDutiedValidatorIndices) {
+      dutiesByIndex.delete(validatorIndex);
+    }
+
+    this.logger.debug("Downloaded SyncDuties", {
+      epoch,
+      dependentRoot: toHexString(dependentRoot),
+      count,
+      deletedIndices: Array.from(redundantDutiedValidatorIndices).join(","),
+    });
   }
 
   private async getSelectionProofs(slot: Slot, duty: routes.validator.SyncDuty): Promise<SyncSelectionProof[]> {

--- a/packages/validator/test/unit/services/syncCommitteDuties.test.ts
+++ b/packages/validator/test/unit/services/syncCommitteDuties.test.ts
@@ -32,17 +32,20 @@ describe("SyncCommitteeDutiesService", function () {
     ALTAIR_FORK_EPOCH: 0, // Activate Altair immediatelly
   });
 
-  const index = 4;
+  const indices = [4, 100];
   // Sample validator
   const defaultValidator: routes.beacon.ValidatorResponse = {
-    index,
+    index: indices[0],
     balance: 32e9,
     status: "active",
     validator: ssz.phase0.Validator.defaultValue(),
   };
 
   before(() => {
-    const secretKeys = [bls.SecretKey.fromBytes(toBufferBE(BigInt(98), 32))];
+    const secretKeys = [
+      bls.SecretKey.fromBytes(toBufferBE(BigInt(98), 32)),
+      bls.SecretKey.fromBytes(toBufferBE(BigInt(99), 32)),
+    ];
     pubkeys = secretKeys.map((sk) => sk.toPublicKey().toBytes());
     validatorStore.votingPubkeys.returns(pubkeys);
     validatorStore.hasVotingPubkey.returns(true);
@@ -51,23 +54,24 @@ describe("SyncCommitteeDutiesService", function () {
   });
 
   let controller: AbortController; // To stop clock
-  beforeEach(() => (controller = new AbortController()));
+  beforeEach(() => {
+    controller = new AbortController();
+    // Reply with active validators
+    const validatorReponses = [0, 1].map((i) => ({
+      ...defaultValidator,
+      index: indices[i],
+      validator: {...defaultValidator.validator, pubkey: pubkeys[i]},
+    }));
+    api.beacon.getStateValidators.resolves({data: validatorReponses});
+  });
   afterEach(() => controller.abort());
 
   it("Should fetch indexes and duties", async function () {
-    // Reply with an active validator that has an index
-    const validatorResponse = {
-      ...defaultValidator,
-      index,
-      validator: {...defaultValidator.validator, pubkey: pubkeys[0]},
-    };
-    api.beacon.getStateValidators.resolves({data: [validatorResponse]});
-
     // Reply with some duties
     const slot = 1;
     const duty: routes.validator.SyncDuty = {
       pubkey: pubkeys[0],
-      validatorIndex: index,
+      validatorIndex: indices[0],
       validatorSyncCommitteeIndices: [7],
     };
     api.validator.getSyncCommitteeDuties.resolves({dependentRoot: ZERO_HASH, data: [duty]});
@@ -85,7 +89,10 @@ describe("SyncCommitteeDutiesService", function () {
 
     // Validator index should be persisted
     expect(Object.fromEntries(indicesService["pubkey2index"])).to.deep.equal(
-      {[toHexString(pubkeys[0])]: index},
+      {
+        [toHexString(pubkeys[0])]: indices[0],
+        [toHexString(pubkeys[1])]: indices[1],
+      },
       "Wrong dutiesService.indices Map"
     );
 
@@ -98,8 +105,8 @@ describe("SyncCommitteeDutiesService", function () {
     );
     expect(dutiesByIndexByPeriodObj).to.deep.equal(
       {
-        0: {[index]: {dependentRoot: ZERO_HASH, duty}},
-        1: {[index]: {dependentRoot: ZERO_HASH, duty}},
+        0: {[indices[0]]: {dependentRoot: ZERO_HASH, duty}},
+        1: {[indices[0]]: {dependentRoot: ZERO_HASH, duty}},
       },
       "Wrong dutiesService.dutiesByIndexByPeriod Map"
     );
@@ -112,6 +119,71 @@ describe("SyncCommitteeDutiesService", function () {
     expect(api.validator.prepareSyncCommitteeSubnets.callCount).to.equal(
       1,
       "prepareSyncCommitteeSubnets() must be called once after getting the duties"
+    );
+  });
+
+  /**
+   * Reproduce https://github.com/ChainSafe/lodestar/issues/3572
+   */
+  it("should remove redundant duties", async function () {
+    // Reply with some duties
+    const duty: routes.validator.SyncDuty = {
+      pubkey: pubkeys[0],
+      validatorIndex: indices[0],
+      validatorSyncCommitteeIndices: [7],
+    };
+    api.validator.getSyncCommitteeDuties
+      .withArgs(0, sinon.match.any)
+      .resolves({dependentRoot: ZERO_HASH, data: [duty]});
+    // sync period 1 should all return empty
+    api.validator.getSyncCommitteeDuties.withArgs(256, sinon.match.any).resolves({dependentRoot: ZERO_HASH, data: []});
+    api.validator.getSyncCommitteeDuties.withArgs(257, sinon.match.any).resolves({dependentRoot: ZERO_HASH, data: []});
+    const duty2: routes.validator.SyncDuty = {
+      pubkey: pubkeys[1],
+      validatorIndex: indices[1],
+      validatorSyncCommitteeIndices: [5],
+    };
+    api.validator.getSyncCommitteeDuties
+      .withArgs(1, sinon.match.any)
+      .resolves({dependentRoot: ZERO_HASH, data: [duty2]});
+
+    // Clock will call runAttesterDutiesTasks() immediatelly
+    const clock = new ClockMock();
+    const indicesService = new IndicesService(logger, api, validatorStore);
+    const dutiesService = new SyncCommitteeDutiesService(config, loggerVc, api, clock, validatorStore, indicesService);
+
+    // Trigger clock onSlot for slot 0
+    await clock.tickEpochFns(0, controller.signal);
+
+    // Duties for this and next epoch should be persisted
+    let dutiesByIndexByPeriodObj = Object.fromEntries(
+      Array.from(dutiesService["dutiesByIndexByPeriod"].entries()).map(([period, dutiesByIndex]) => [
+        period,
+        Object.fromEntries(dutiesByIndex),
+      ])
+    );
+    expect(dutiesByIndexByPeriodObj).to.deep.equal(
+      {
+        0: {[indices[0]]: {dependentRoot: ZERO_HASH, duty}},
+        1: {},
+      },
+      "Wrong dutiesService.dutiesByIndexByPeriod Map"
+    );
+
+    await clock.tickEpochFns(1, controller.signal);
+
+    dutiesByIndexByPeriodObj = Object.fromEntries(
+      Array.from(dutiesService["dutiesByIndexByPeriod"].entries()).map(([period, dutiesByIndex]) => [
+        period,
+        Object.fromEntries(dutiesByIndex),
+      ])
+    );
+    expect(dutiesByIndexByPeriodObj).to.deep.equal(
+      {
+        0: {[indices[1]]: {dependentRoot: ZERO_HASH, duty: duty2}},
+        1: {},
+      },
+      "Wrong dutiesService.dutiesByIndexByPeriod Map"
     );
   });
 });


### PR DESCRIPTION
**Motivation**

+ There are redundant sync committee duties because we keep merging it to our map. 
+ For example query1 returns `[period_n]: [validator1, validator2, validator3]`
+ query2 returns `[period_n]: [validator2, validator3, validator4]`
=> we should delete validator1 out of our duties, and overwrite duties for validator2, validator3, add new duties for validator4

**Description**

+ When next duties query returned, check for redundant duties and delete

Closes #3572
