### PR TITLE
Remove ssz as dependency to lodestar-utils

### DIFF
--- a/packages/lodestar/src/node/notifier.ts
+++ b/packages/lodestar/src/node/notifier.ts
@@ -53,7 +53,7 @@ export async function runNodeNotifier({
       const headInfo = chain.forkChoice.getHead();
       const headState = chain.getHeadState();
       const finalizedEpoch = headState.finalizedCheckpoint.epoch;
-      const finalizedRoot = headState.finalizedCheckpoint.root;
+      const finalizedRoot = headState.finalizedCheckpoint.root.valueOf() as Uint8Array;
       const headSlot = headInfo.slot;
       timeSeries.addPoint(headSlot, Date.now());
 

--- a/packages/lodestar/test/utils/errors.ts
+++ b/packages/lodestar/test/utils/errors.ts
@@ -51,7 +51,7 @@ export function expectLodestarError<T extends {code: string}>(err1: LodestarErro
 
 export function getErrorMetadata<T extends {code: string}>(err: LodestarError<T> | Error | Json): Json {
   if (err instanceof LodestarError) {
-    return mapValues(err.getMetadata(), (value) => getErrorMetadata(value));
+    return mapValues(err.getMetadata(), (value) => getErrorMetadata(value as any));
   } else if (err instanceof Error) {
     return err.message;
   } else {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -37,9 +37,10 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/abort-controller": "^3.0.1",
-    "@chainsafe/ssz": "^0.8.20",
+    "@chainsafe/as-sha256": "^0.2.4",
     "any-signal": "2.1.2",
     "bigint-buffer": "^1.1.5",
+    "case": "^1.6.3",
     "chalk": "^4.1.2",
     "js-yaml": "^3.13.1",
     "winston": "^3.3.3",

--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -2,6 +2,18 @@ import {toBufferLE, toBigIntLE, toBufferBE, toBigIntBE} from "bigint-buffer";
 
 type Endianness = "le" | "be";
 
+const hexByByte: string[] = [];
+export function toHexString(bytes: Uint8Array): string {
+  let hex = "0x";
+  for (const byte of bytes) {
+    if (!hexByByte[byte]) {
+      hexByByte[byte] = byte < 16 ? "0" + byte.toString(16) : byte.toString(16);
+    }
+    hex += hexByByte[byte];
+  }
+  return hex;
+}
+
 /**
  * Return a byte array from a number or BigInt
  */

--- a/packages/utils/src/errors.ts
+++ b/packages/utils/src/errors.ts
@@ -1,5 +1,3 @@
-import {Json} from "@chainsafe/ssz";
-
 /**
  * Generic Lodestar error with attached metadata
  */
@@ -10,14 +8,14 @@ export class LodestarError<T extends {code: string}> extends Error {
     this.type = type;
   }
 
-  getMetadata(): {[key: string]: Json} {
+  getMetadata(): Record<string, unknown> {
     return this.type;
   }
 
   /**
    * Get the metadata and the stacktrace for the error.
    */
-  toObject(): {[key: string]: Json} {
+  toObject(): Record<string, unknown> {
     return {
       // Ignore message since it's just type.code
       ...this.getMetadata(),

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -1,10 +1,10 @@
-import {ByteVector, toHexString} from "@chainsafe/ssz";
+import {toHexString} from "./bytes";
 
 /**
  * Format bytes as `0x1234…1234`
  * 4 bytes can represent 4294967296 values, so the chance of collision is low
  */
-export function prettyBytes(root: Uint8Array | ByteVector | string): string {
+export function prettyBytes(root: Uint8Array | string): string {
   const str = typeof root === "string" ? root : toHexString(root);
   return `${str.slice(0, 6)}…${str.slice(-4)}`;
 }

--- a/packages/utils/src/json.ts
+++ b/packages/utils/src/json.ts
@@ -1,10 +1,10 @@
-import {Json, toHexString} from "@chainsafe/ssz";
+import {toHexString} from "./bytes";
 import {LodestarError} from "./errors";
 import {mapValues} from "./objects";
 
 export const CIRCULAR_REFERENCE_TAG = "CIRCULAR_REFERENCE";
 
-export function toJson(arg: unknown, refs = new WeakMap()): Json {
+export function toJson(arg: unknown, refs = new WeakMap()): unknown {
   switch (typeof arg) {
     case "bigint":
     case "symbol":
@@ -32,11 +32,11 @@ export function toJson(arg: unknown, refs = new WeakMap()): Json {
     case "undefined":
     case "boolean":
     default:
-      return arg as Json;
+      return arg;
   }
 }
 
-export function toString(json: Json, nested = false): string {
+export function toString(json: unknown, nested = false): string {
   switch (typeof json) {
     case "object": {
       if (nested) return JSONStringifyCircular(json);
@@ -55,7 +55,7 @@ export function toString(json: Json, nested = false): string {
   }
 }
 
-function errorToObject(err: Error): Json {
+function errorToObject(err: Error): Record<string, unknown> {
   return {
     message: err.message,
     ...(err.stack ? {stack: err.stack} : {}),

--- a/packages/utils/src/logger/format.ts
+++ b/packages/utils/src/logger/format.ts
@@ -1,4 +1,3 @@
-import {Json} from "@chainsafe/ssz";
 import {format} from "winston";
 import {toJson, toString} from "../json";
 import {Context, ILoggerOptions, TimestampFormatCode} from "./interface";
@@ -61,7 +60,7 @@ function jsonLogFormat(opts: ILoggerOptions): Format {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     format((_info) => {
       const info = _info as IWinstonInfoArg;
-      info.context = toJson(info.context);
+      info.context = toJson(info.context) as Context;
       info.error = (toJson(info.error) as unknown) as Error;
       return info;
     })(),
@@ -117,7 +116,7 @@ export function printStackTraceLast(context?: Context | Error): string {
  * Mutates the `json` argument deleting all 'stack' properties.
  * `json` argument must not contain circular properties, which should be guaranteed by `toJson()`
  */
-export function extractStackTraceFromJson(json: Json, stackTraces: string[] = []): string[] {
+export function extractStackTraceFromJson(json: unknown, stackTraces: string[] = []): string[] {
   if (typeof json === "object" && json !== null && !Array.isArray(json)) {
     let stack: string | null = null;
     for (const [key, value] of Object.entries(json)) {
@@ -125,7 +124,7 @@ export function extractStackTraceFromJson(json: Json, stackTraces: string[] = []
         stack = value;
         delete ((json as unknown) as Error)[key];
       } else {
-        extractStackTraceFromJson(value as Json, stackTraces);
+        extractStackTraceFromJson(value, stackTraces);
       }
     }
     // Push stack trace last so nested errors come first

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -1,7 +1,33 @@
-// eslint-disable-next-line no-restricted-imports
-import {toExpectedCase} from "@chainsafe/ssz/lib/util/json";
+import Case from "case";
 
 /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
+
+export type KeyCase =
+  | "snake"
+  | "constant"
+  | "camel"
+  | "param"
+  | "header"
+  | "pascal" //Same as squish
+  | "dot"
+  | "notransform";
+
+export function toExpectedCase(
+  value: string,
+  expectedCase: KeyCase = "camel",
+  customCasingMap?: Record<string, string>
+): string {
+  if (expectedCase === "notransform") return value;
+  if (customCasingMap && customCasingMap[value]) return customCasingMap[value];
+  switch (expectedCase) {
+    case "param":
+      return Case.kebab(value);
+    case "dot":
+      return Case.lower(value, ".", true);
+    default:
+      return Case[expectedCase](value);
+  }
+}
 
 function isObjectObject(val: unknown): boolean {
   return val != null && typeof val === "object" && Array.isArray(val) === false;

--- a/packages/utils/src/verifyMerkleBranch.ts
+++ b/packages/utils/src/verifyMerkleBranch.ts
@@ -1,5 +1,8 @@
-import {intDiv} from "./math";
-import {hash} from "@chainsafe/ssz";
+import SHA256 from "@chainsafe/as-sha256";
+
+export function hash(...inputs: Uint8Array[]): Uint8Array {
+  return SHA256.digest(Buffer.concat(inputs));
+}
 
 /**
  * Verify that the given ``leaf`` is on the merkle branch ``proof``
@@ -14,10 +17,10 @@ export function verifyMerkleBranch(
 ): boolean {
   let value = leaf;
   for (let i = 0; i < depth; i++) {
-    if (intDiv(index, 2 ** i) % 2) {
-      value = hash(Buffer.concat([proof[i], value]));
+    if (Math.floor(index / 2 ** i) % 2) {
+      value = SHA256.digest64(Buffer.concat([proof[i], value]));
     } else {
-      value = hash(Buffer.concat([value, proof[i]]));
+      value = SHA256.digest64(Buffer.concat([value, proof[i]]));
     }
   }
   return Buffer.from(value).equals(root);


### PR DESCRIPTION
**Motivation**

SSZ needs to import lodestar-utils as dev dependency which causes circular dependency problems when SSZ changes significantly, for example with https://github.com/ChainSafe/ssz/pull/223

SSZ is really not a required dependency to lodestar-utils which should have minimal dependencies

**Description**

Remove ssz as dependency to lodestar-utils