### PR TITLE
Fix issue 3611

### DIFF
--- a/packages/cli/src/cmds/validator/keys.ts
+++ b/packages/cli/src/cmds/validator/keys.ts
@@ -98,9 +98,10 @@ export async function getSecretKeys(
 
 function resolveKeystorePaths(fileOrDirPath: string): string[] {
   if (fs.lstatSync(fileOrDirPath).isDirectory()) {
-    const strings = fs.readdirSync(fileOrDirPath);
-    const strings1 = strings.map((file) => path.join(fileOrDirPath, file));
-    return strings1.filter((filepath) => filepath.endsWith(".json"));
+    return fs
+      .readdirSync(fileOrDirPath)
+      .map((file) => path.join(fileOrDirPath, file))
+      .filter((filepath) => filepath.endsWith(".json"));
   } else {
     return [fileOrDirPath];
   }

--- a/packages/cli/src/cmds/validator/keys.ts
+++ b/packages/cli/src/cmds/validator/keys.ts
@@ -12,6 +12,7 @@ import {getAccountPaths} from "../account/paths";
 import {IValidatorCliArgs} from "./options";
 
 const LOCK_FILE_EXT = ".lock";
+const logger = warnLogger();
 
 export async function getSecretKeys(
   args: IValidatorCliArgs & IGlobalArgs
@@ -75,7 +76,7 @@ export async function getSecretKeys(
       if (result.status !== "rejected") {
         secretKeys.push(result.value);
       } else {
-        warnLogger().warn(result.reason);
+        logger.warn(result.reason);
       }
     }
     return {

--- a/packages/cli/src/util/logger.ts
+++ b/packages/cli/src/util/logger.ts
@@ -23,6 +23,10 @@ export function errorLogger(): ILogger {
   return new WinstonLogger({level: LogLevel.error});
 }
 
+export function warnLogger(): ILogger {
+  return new WinstonLogger({level: LogLevel.warn});
+}
+
 /**
  * Setup a CLI logger, common for beacon, validator and dev commands
  */


### PR DESCRIPTION
**Motivation**

Prevents lodestar from crashing when there are files that cannot be parsed as a keystore on startup.

**Description**

Have the parsing oppression in a try, so errors can be caught without terminating process.

Closes #3611

**Steps to test or reproduce**

- Put other files, specifically the deposit_data.json files in the /keystores folder.
- Run the validator client
- Receive object expected error.
