### PR TITLE
Queue future attestations instead of throwing error

### DIFF
--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -804,17 +804,6 @@ export class ForkChoice implements IForkChoice {
       });
     }
 
-    if (this.fcStore.currentSlot < slot + 1) {
-      throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.INVALID_ATTESTATION,
-        err: {
-          code: InvalidAttestationCode.FUTURE_SLOT,
-          attestationSlot: slot,
-          latestPermissibleSlot: this.fcStore.currentSlot - 1,
-        },
-      });
-    }
-
     // Attestation target must be for a known block.
     //
     // We do not delay the block for later processing to reduce complexity and DoS attack


### PR DESCRIPTION
**Motivation**

There are a lot of error like this after we pass gossip attestations to forkchoice

```
Jan-17 09:31:23.920 [NETWORK]         error: Error adding aggregated attestation to forkchoice slot=2158356 code=FORKCHOICE_ERROR_INVALID_ATTESTATION, err={"code":"FUTURE_SLOT","attestationSlot":2158356,"latestPermissibleSlot":2158355}
Error: FORKCHOICE_ERROR_INVALID_ATTESTATION
```

**Description**

+ It's designed to queue attestations for future reprocess instead of throwing error as in the spec:
```
  # Attestations can only affect the fork choice of subsequent slots.
    # Delay consideration in the fork choice until their slot is in the past.
```
and our impl https://github.com/ChainSafe/lodestar/blob/c581c18a0fd2f9db867c4f9852651bea64c51e4a/packages/fork-choice/src/forkChoice/forkChoice.ts#L434

+ Other clients, like lighthouse does not throw that error too.
+ Tested successfully in contabo-20

Closes #3631
