### PR TITLE
Filter out files that has data_store in name when resolving keystore path

### DIFF
--- a/packages/cli/src/cmds/validator/keys.ts
+++ b/packages/cli/src/cmds/validator/keys.ts
@@ -12,6 +12,7 @@ import {getAccountPaths} from "../account/paths";
 import {IValidatorCliArgs} from "./options";
 
 const LOCK_FILE_EXT = ".lock";
+const depositDataPattern = new RegExp(/^deposit_data-\d+\.json$/gi);
 
 export async function getSecretKeys(
   args: IValidatorCliArgs & IGlobalArgs
@@ -88,7 +89,7 @@ function resolveKeystorePaths(fileOrDirPath: string): string[] {
   if (fs.lstatSync(fileOrDirPath).isDirectory()) {
     return fs
       .readdirSync(fileOrDirPath)
-      .filter((file) => file.indexOf("deposit_data") === -1 && file.endsWith(".json"))
+      .filter((file) => !depositDataPattern.test(file))
       .map((file) => path.join(fileOrDirPath, file));
   } else {
     return [fileOrDirPath];

--- a/packages/cli/src/cmds/validator/keys.ts
+++ b/packages/cli/src/cmds/validator/keys.ts
@@ -98,9 +98,10 @@ export async function getSecretKeys(
 
 function resolveKeystorePaths(fileOrDirPath: string): string[] {
   if (fs.lstatSync(fileOrDirPath).isDirectory()) {
-    const strings = fs.readdirSync(fileOrDirPath);
-    const strings1 = strings.map((file) => path.join(fileOrDirPath, file));
-    return strings1.filter((filepath) => filepath.endsWith(".json"));
+    return fs
+      .readdirSync(fileOrDirPath)
+      .map((file) => path.join(fileOrDirPath, file))
+      .filter((filepath) => filepath.endsWith(".json"));
   } else {
     return [fileOrDirPath];
   }

--- a/packages/cli/src/cmds/validator/keys.ts
+++ b/packages/cli/src/cmds/validator/keys.ts
@@ -5,14 +5,13 @@ import {SecretKey} from "@chainsafe/bls";
 import {deriveEth2ValidatorKeys, deriveKeyFromMnemonic} from "@chainsafe/bls-keygen";
 import {interopSecretKey} from "@chainsafe/lodestar-beacon-state-transition";
 import {defaultNetwork, IGlobalArgs} from "../../options";
-import {parseRange, stripOffNewlines, warnLogger, YargsError} from "../../util";
+import {parseRange, stripOffNewlines, YargsError} from "../../util";
 import {getLockFile} from "../../util/lockfile";
 import {ValidatorDirManager} from "../../validatorDir";
 import {getAccountPaths} from "../account/paths";
 import {IValidatorCliArgs} from "./options";
 
 const LOCK_FILE_EXT = ".lock";
-const logger = warnLogger();
 
 export async function getSecretKeys(
   args: IValidatorCliArgs & IGlobalArgs
@@ -61,24 +60,12 @@ export async function getSecretKeys(
       lockFile.lockSync(lockFilePath);
     }
 
-    const secretKeysPromise = keystorePaths.map(async (keystorePath) => {
-      try {
-        const keystore = Keystore.parse(fs.readFileSync(keystorePath, "utf8"));
-        return SecretKey.fromBytes(await keystore.decrypt(passphrase));
-      } catch (e) {
-        return Promise.reject(`Failed to parse keystore file: ${keystorePath} with error ${(e as Error).toString()}`);
-      }
-    });
+    const secretKeys = await Promise.all(
+      keystorePaths.map(async (keystorePath) =>
+        SecretKey.fromBytes(await Keystore.parse(fs.readFileSync(keystorePath, "utf8")).decrypt(passphrase))
+      )
+    );
 
-    const results = await Promise.allSettled(secretKeysPromise);
-    const secretKeys: SecretKey[] = [];
-    for (const result of results) {
-      if (result.status !== "rejected") {
-        secretKeys.push(result.value);
-      } else {
-        logger.warn(result.reason);
-      }
-    }
     return {
       secretKeys,
       unlockSecretKeys: () => {
@@ -101,8 +88,8 @@ function resolveKeystorePaths(fileOrDirPath: string): string[] {
   if (fs.lstatSync(fileOrDirPath).isDirectory()) {
     return fs
       .readdirSync(fileOrDirPath)
-      .map((file) => path.join(fileOrDirPath, file))
-      .filter((filepath) => filepath.endsWith(".json"));
+      .filter((file) => file.indexOf("deposit_data") === -1 && file.endsWith(".json"))
+      .map((file) => path.join(fileOrDirPath, file));
   } else {
     return [fileOrDirPath];
   }

--- a/packages/cli/src/cmds/validator/keys.ts
+++ b/packages/cli/src/cmds/validator/keys.ts
@@ -12,6 +12,7 @@ import {getAccountPaths} from "../account/paths";
 import {IValidatorCliArgs} from "./options";
 
 const LOCK_FILE_EXT = ".lock";
+const logger = warnLogger();
 
 export async function getSecretKeys(
   args: IValidatorCliArgs & IGlobalArgs
@@ -75,7 +76,7 @@ export async function getSecretKeys(
       if (result.status !== "rejected") {
         secretKeys.push(result.value);
       } else {
-        warnLogger().warn(result.reason);
+        logger.warn(result.reason);
       }
     }
     return {

--- a/packages/cli/src/cmds/validator/keys.ts
+++ b/packages/cli/src/cmds/validator/keys.ts
@@ -85,7 +85,7 @@ export async function getSecretKeys(
   }
 }
 
-function resolveKeystorePaths(fileOrDirPath: string): string[] {
+export function resolveKeystorePaths(fileOrDirPath: string): string[] {
   if (fs.lstatSync(fileOrDirPath).isDirectory()) {
     return fs
       .readdirSync(fileOrDirPath)

--- a/packages/cli/src/util/logger.ts
+++ b/packages/cli/src/util/logger.ts
@@ -23,10 +23,6 @@ export function errorLogger(): ILogger {
   return new WinstonLogger({level: LogLevel.error});
 }
 
-export function warnLogger(): ILogger {
-  return new WinstonLogger({level: LogLevel.warn});
-}
-
 /**
  * Setup a CLI logger, common for beacon, validator and dev commands
  */

--- a/packages/cli/src/util/logger.ts
+++ b/packages/cli/src/util/logger.ts
@@ -23,6 +23,10 @@ export function errorLogger(): ILogger {
   return new WinstonLogger({level: LogLevel.error});
 }
 
+export function warnLogger(): ILogger {
+  return new WinstonLogger({level: LogLevel.warn});
+}
+
 /**
  * Setup a CLI logger, common for beacon, validator and dev commands
  */

--- a/packages/cli/test/unit/validator/keys.test.ts
+++ b/packages/cli/test/unit/validator/keys.test.ts
@@ -9,16 +9,16 @@ describe("validator / keys / resolveKeystorePaths", () => {
   });
 
   it("should filter out deposite data files", function () {
-    const keystore_filename = "keystore-m_12381_3600_0_0_0-1642090404.json";
-    const deposite_data = "deposit_data-1642090404.json";
+    const keystoreFilename = "keystore-m_12381_3600_0_0_0-1642090404.json";
+    const depositData = "deposit_data-1642090404.json";
 
     sinon.stub(fs, "readdirSync").callsFake(() => {
-      return ([keystore_filename, deposite_data] as unknown) as Dirent[];
+      return ([keystoreFilename, depositData] as unknown) as Dirent[];
     });
 
     const result = resolveKeystorePaths("dir");
     expect(result.length).to.equal(1);
-    expect(result[0]).to.equal(`dir/${keystore_filename}`);
+    expect(result[0]).to.equal(`dir/${keystoreFilename}`);
   });
 
   afterEach(() => {

--- a/packages/cli/test/unit/validator/keys.test.ts
+++ b/packages/cli/test/unit/validator/keys.test.ts
@@ -1,0 +1,27 @@
+import {expect} from "chai";
+import sinon from "sinon";
+import fs, {Dirent, Stats} from "fs";
+import {resolveKeystorePaths} from "../../../src/cmds/validator/keys";
+
+describe("validator / keys / resolveKeystorePaths", () => {
+  beforeEach(() => {
+    sinon.stub(fs, "lstatSync").returns({isDirectory: () => true} as Stats);
+  });
+
+  it("should filter out deposite data files", function () {
+    const keystore_filename = "keystore-m_12381_3600_0_0_0-1642090404.json";
+    const deposite_data = "deposit_data-1642090404.json";
+
+    sinon.stub(fs, "readdirSync").callsFake(() => {
+      return ([keystore_filename, deposite_data] as unknown) as Dirent[];
+    });
+
+    const result = resolveKeystorePaths("dir");
+    expect(result.length).to.equal(1);
+    expect(result[0]).to.equal(`dir/${keystore_filename}`);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+});


### PR DESCRIPTION
**Motivation**

Prevents lodestar from crashing if deposit data files are encountered when resolving keystore path.

**Description**

Filtering out file names that contains deposit_data, when solving keystore path so as to prevent crashing on start up.

Closes #3611

**Steps to test or reproduce**

- Put deposit_data.json files in the /keystores folder.
- Run the validator client with `--importKeystoresPath` flag
- Receive object expected error.
