### PR TITLE
Fix nightly release workflow

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -42,15 +42,32 @@ jobs:
       # </common-build>
 
       - name: Publish to npm registry
-        # from-package: Base the latest nightly ref count from NPM registry
-        # --no-git-reset: Do not delete code version artifacts so the next step can pick the version
-        # --canary: Format version with commit (1.1.0-alpha.0+81e3b443)
-        # --dist-tag next: Make this nightly version installable with `@next`
-        # --preid dev: Tag version with `dev` instead of `alpha`
-        # --force-publish: lerna doesn't want to publish anything otherwise - "lerna success No changed packages to publish"
+        # Just use lerna publish with --canary option. Using 'from-package' ignore other options 
+        # and only compares against the verison in package.json, and skips release if already 
+        # published.
+        #
+        # --no-git-reset: 
+        #   Do not delete code version artifacts so the next step can pick the version
+        #
+        # --canary: 
+        #   Format version with commit (1.1.0-alpha.0+81e3b443). Make sure the previous
+        #   released tags are not lightweight("commit" type), but proper annotated ("tag" type)
+        #   Otherwise the version canary will generate will be from last annotated tag type
+        #   Best way to create such a tag is by using 'git tag -a' or using lerna publish!
+        #
+        # --dist-tag next: 
+        #   Make this nightly version installable with `@next`
+        #
+        # --preid dev: 
+        #   Tag version with `dev` instead of `alpha`
+        #
+        # --force-publish: 
+        #   lerna doesn't want to publish anything otherwise - "lerna success No changed packages 
+        #   to publish"
+        #
         # NOTE: Using --preid dev.$(git rev-parse --short=7 HEAD) results in `0.24.3-dev.3ddb91d.0+3ddb91d`
         run: |
-          node_modules/.bin/lerna publish from-package --yes --no-verify-access \
+          node_modules/.bin/lerna publish --yes --no-verify-access \
           --canary --dist-tag next --no-git-reset --force-publish \
           --preid dev
         env:


### PR DESCRIPTION
**Motivation**
A previous PR https://github.com/ChainSafe/lodestar/pull/3601 which aimed to fix how the nightly `--canary` versions were being tagged, used `from-package` in `lerna publish`. However it was discovered that using `from-package` flag totatly ignore any other options with lerna comparing the published versions against package.json's version.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR restores the original `lerna publish --canary... ` and adds comments as to how to make sure it produces correct publishing tag. 
**Description**
Lerna publish ignores what are called `lightweight` or `commit` tags (do `git for-each-ref refs/tags` to get tag type). It only takes into care the proper `annotated` tags, which can be produced by git tag -a  option, or better through lerna publish. It seems like, the tags post 0.32 are light weight:
```
$ git for-each-ref refs/tags |grep -vE commit
d345c93b9a7afd8eeeb378f51450a90039084dcd tag	refs/tags/v0.13.0
325b1116f97a11f86763a7490c62d5565535875a tag	refs/tags/v0.14.0
f1918f8ca7eeda595225ad00432f68fcfb1134f4 tag	refs/tags/v0.15.0
b3036a20f5f173733574cb00a16aeec96cfd294d tag	refs/tags/v0.16.0
34d1677d0a3eeb0e82579f7c3e40504b19f20aa4 tag	refs/tags/v0.17.0
249ce56e504693e9482348bc4d0b745c9de1a3cb tag	refs/tags/v0.18.0
35f8c997730b3c0101bcf25b805af496014e0b26 tag	refs/tags/v0.19.0
65bbeedb8dbdd9943831847cfcecd2d2911e859f tag	refs/tags/v0.20.0
ead96ad89dd45b3f16ed6552d590452e2c3458a0 tag	refs/tags/v0.21.0
139cf9550c0fa9909c2586d76dd679a9f53e0d80 tag	refs/tags/v0.23.0
b7d8429fab4e59a60acb99bc0d918dc6d4dd4bbd tag	refs/tags/v0.24.0
39142e4573d91497ab0887943bec20f16152b73e tag	refs/tags/v0.24.1
31fdc2c2c7a737bb6e8a4dfa3c166cb9ce3b7634 tag	refs/tags/v0.24.2
dc68d3fcb5ab360b34977d67e74b95200df20138 tag	refs/tags/v0.24.3
7848e77799f2d80948e400206b1f3eb4fbc5444c tag	refs/tags/v0.25.0
ca1c76c9c38c53976efe55025eb3b7617d8ac2f4 tag	refs/tags/v0.25.1
e62779bfa974903561f6ad64ebe1cf6f18c609f3 tag	refs/tags/v0.26.0
3f7f1bb628e79c8ebf7968d92f3f5f346e5be99e tag	refs/tags/v0.27.0
1d791c2197b2f2b85b3a332be6e86f208c798a5a tag	refs/tags/v0.28.0
3228b2966ce3cda8a1ddb937f3bf581782425c3d tag	refs/tags/v0.28.1
a78d0fd62484d0544f6e58367eeeb081265bf454 tag	refs/tags/v0.29.0
4696395abe262b6847ce58cfc84683de8d5a2559 tag	refs/tags/v0.29.1
b6fadd8f0867f8af6e2bd5d2a52b68ab2d65c05e tag	refs/tags/v0.29.2
30ac87b6a73bffccb1b2254789b5990b92222082 tag	refs/tags/v0.29.3
b54d1661713c816e390442c48cd1b4672f06c6d1 tag	refs/tags/v0.30.0
220a13d5c20770a3cb98b32704d418decd2bee2c tag	refs/tags/v0.31.0
f022b80b92fd7e96f75e474615191c94f347451c tag	refs/tags/v0.32.0
```
and lerna publish --canarary gives these tags as 0.32.0 is the last proper annotated tag:
```
deploy@r9core12:/mnt/code/lodestar/master$ yarn lerna publish --canary --force-publish
yarn run v1.22.11
$ lerna publish --canary --force-publish
lerna notice cli v4.0.0
lerna info canary enabled
lerna WARN Yarn's registry proxy is broken, replacing with public npm registry
lerna WARN If you don't have an npm token, you should exit and run `npm login`
lerna WARN force-publish all packages
lerna info Assuming all packages changed

Found 13 packages to publish:
 - @chainsafe/lodestar-api => 0.32.1-alpha.93+94e67f6b6af
 - @chainsafe/lodestar-beacon-state-transition => 0.32.1-alpha.93+94e67f6b6af
 - @chainsafe/lodestar-cli => 0.32.1-alpha.93+94e67f6b6af
 - @chainsafe/lodestar-config => 0.32.1-alpha.93+94e67f6b6af
 - @chainsafe/lodestar-db => 0.32.1-alpha.93+94e67f6b6af
 - @chainsafe/lodestar-fork-choice => 0.32.1-alpha.93+94e67f6b6af
 - @chainsafe/lodestar-light-client => 0.32.1-alpha.93+94e67f6b6af
 - @chainsafe/lodestar => 0.32.1-alpha.93+94e67f6b6af
 - @chainsafe/lodestar-params => 0.32.1-alpha.93+94e67f6b6af
 - @chainsafe/lodestar-spec-test-util => 0.32.1-alpha.93+94e67f6b6af
 - @chainsafe/lodestar-types => 0.32.1-alpha.93+94e67f6b6af
 - @chainsafe/lodestar-utils => 0.32.1-alpha.93+94e67f6b6af
 - @chainsafe/lodestar-validator => 0.32.1-alpha.93+94e67f6b6af
```
So original lerna publish --canary --force-publish will work correctly with the correct tagging.
