### PR TITLE
Fix the network fork subscription

### DIFF
--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -19,10 +19,13 @@ export function createIForkConfig(config: IChainConfig): IForkConfig {
   const forks = {phase0, altair, bellatrix};
 
   // Prevents allocating an array on every getForkInfo() call
+  const forksAscendingEpochOrder = Object.values(forks);
   const forksDescendingEpochOrder = Object.values(forks).reverse();
 
   return {
     forks,
+    forksAscendingEpochOrder,
+    forksDescendingEpochOrder,
 
     // Fork convenience methods
     getForkInfo(slot: Slot): IForkInfo {

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -14,6 +14,9 @@ export interface IForkInfo {
 export interface IForkConfig {
   /** Forks in order order of occurence, `phase0` first */
   forks: {[K in ForkName]: IForkInfo};
+  forksAscendingEpochOrder: IForkInfo[];
+  forksDescendingEpochOrder: IForkInfo[];
+
   /** Get the hard-fork info for the active fork at `slot` */
   getForkInfo(slot: Slot): IForkInfo;
 

--- a/packages/lodestar/src/network/forks.ts
+++ b/packages/lodestar/src/network/forks.ts
@@ -13,45 +13,43 @@ import {Epoch} from "@chainsafe/lodestar-types";
  * |----------|----------|----------|----------|
  * 0        fork-2      fork      fork+2       oo
  * ```
+ *
+ * It the fork epochs are very close to each other there may more than two active at once
+ *
+ * ```
+ *   f0    f0   f0    f0   f0    -
+ *   -     fa   fa    fa   fa    fa   -
+ *   -     -    fb    fb   fb    fb   fb
+ *
+ *     forka-2    forka      forka+2
+ * |     |          |          |
+ * |----------|----------|----------|----------|
+ * 0        forkb-2    forkb      forkb+2      oo
+ * ```
  */
 export const FORK_EPOCH_LOOKAHEAD = 2;
 
 /**
  * Return the list of `ForkName`s meant to be active at `epoch`
+ * @see FORK_EPOCH_LOOKAHEAD for details on when forks are considered 'active'
  */
 export function getActiveForks(config: IChainForkConfig, epoch: Epoch): ForkName[] {
-  // Compute prev and next fork shifted, so next fork is still next at forkEpoch + FORK_EPOCH_LOOKAHEAD
   const activeForks: ForkName[] = [];
-  // A sliding point to evaluate active forks with FORK_EPOCH_LOOKAHEAD windows
-  let evalAtEpoch: Epoch | null = epoch - FORK_EPOCH_LOOKAHEAD - 1;
-  do {
-    const forks = getCurrentAndNextFork(config, evalAtEpoch);
-    if (!forks.nextFork) {
-      activeForks.push(forks.currentFork.name);
-      evalAtEpoch = null;
-    } else {
-      const prevFork = forks.currentFork.name;
-      const forkEpoch = forks.nextFork.epoch;
+  const forks = config.forksAscendingEpochOrder;
 
-      // way before fork
-      if (epoch < forkEpoch - FORK_EPOCH_LOOKAHEAD) {
-        activeForks.push(prevFork);
-        // No more need to slide and check, just exit
-        evalAtEpoch = null;
-      } else {
-        if (epoch <= forkEpoch + FORK_EPOCH_LOOKAHEAD) {
-          // The previous fork is relevant
-          activeForks.push(prevFork);
-        }
+  for (let i = 0; i < forks.length; i++) {
+    const currForkEpoch = forks[i].epoch;
+    const nextForkEpoch = i >= forks.length - 1 ? Infinity : forks[i + 1].epoch;
 
-        if (epoch >= forkEpoch - FORK_EPOCH_LOOKAHEAD) {
-          evalAtEpoch = forkEpoch;
-        } else {
-          evalAtEpoch = null;
-        }
-      }
+    // Edge case: If multiple forks start at the same epoch, only consider the latest one
+    if (currForkEpoch === nextForkEpoch) {
+      continue;
     }
-  } while (evalAtEpoch !== null);
+
+    if (epoch >= currForkEpoch - FORK_EPOCH_LOOKAHEAD && epoch <= nextForkEpoch + FORK_EPOCH_LOOKAHEAD) {
+      activeForks.push(forks[i].name);
+    }
+  }
 
   return activeForks;
 }
@@ -63,14 +61,18 @@ export function getCurrentAndNextFork(
   config: IChainForkConfig,
   epoch: Epoch
 ): {currentFork: IForkInfo; nextFork: IForkInfo | undefined} {
-  if (epoch < 0) epoch = 0;
+  if (epoch < 0) {
+    epoch = 0;
+  }
+
   // NOTE: forks are sorted by ascending epoch, phase0 first
-  const forks = Object.values(config.forks);
+  const forks = config.forksAscendingEpochOrder;
   let currentForkIdx = -1;
   // findLastIndex
   for (let i = 0; i < forks.length; i++) {
     if (epoch >= forks[i].epoch) currentForkIdx = i;
   }
+
   let nextForkIdx = currentForkIdx + 1;
   const hasNextFork = forks[nextForkIdx] !== undefined && forks[nextForkIdx].epoch !== Infinity;
   // Keep moving the needle of nextForkIdx if there the higher fork also exists on same epoch
@@ -82,6 +84,7 @@ export function getCurrentAndNextFork(
       if (forks[i].epoch === forks[nextForkIdx].epoch) nextForkIdx = i;
     }
   }
+
   return {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     currentFork: forks[currentForkIdx] || forks[0],

--- a/packages/lodestar/src/network/forks.ts
+++ b/packages/lodestar/src/network/forks.ts
@@ -21,23 +21,39 @@ export const FORK_EPOCH_LOOKAHEAD = 2;
  */
 export function getActiveForks(config: IChainForkConfig, epoch: Epoch): ForkName[] {
   // Compute prev and next fork shifted, so next fork is still next at forkEpoch + FORK_EPOCH_LOOKAHEAD
-  const forks = getCurrentAndNextFork(config, epoch - FORK_EPOCH_LOOKAHEAD - 1);
+  const activeForks: ForkName[] = [];
+  // A sliding point to evaluate active forks with FORK_EPOCH_LOOKAHEAD windows
+  let evalAtEpoch: Epoch | null = epoch - FORK_EPOCH_LOOKAHEAD - 1;
+  do {
+    const forks = getCurrentAndNextFork(config, evalAtEpoch);
+    if (!forks.nextFork) {
+      activeForks.push(forks.currentFork.name);
+      evalAtEpoch = null;
+    } else {
+      const prevFork = forks.currentFork.name;
+      const forkEpoch = forks.nextFork.epoch;
 
-  // Before fork is scheduled
-  if (!forks.nextFork) {
-    return [forks.currentFork.name];
-  }
+      // way before fork
+      if (epoch < forkEpoch - FORK_EPOCH_LOOKAHEAD) {
+        activeForks.push(prevFork);
+        // No more need to slide and check, just exit
+        evalAtEpoch = null;
+      } else {
+        if (epoch <= forkEpoch + FORK_EPOCH_LOOKAHEAD) {
+          // The previous fork is relevant
+          activeForks.push(prevFork);
+        }
 
-  const prevFork = forks.currentFork.name;
-  const nextFork = forks.nextFork.name;
-  const forkEpoch = forks.nextFork.epoch;
+        if (epoch >= forkEpoch - FORK_EPOCH_LOOKAHEAD) {
+          evalAtEpoch = forkEpoch;
+        } else {
+          evalAtEpoch = null;
+        }
+      }
+    }
+  } while (evalAtEpoch !== null);
 
-  // Way before fork
-  if (epoch < forkEpoch - FORK_EPOCH_LOOKAHEAD) return [prevFork];
-  // Way after fork
-  if (epoch > forkEpoch + FORK_EPOCH_LOOKAHEAD) return [nextFork];
-  // During fork transition
-  return [prevFork, nextFork];
+  return activeForks;
 }
 
 /**
@@ -55,8 +71,17 @@ export function getCurrentAndNextFork(
   for (let i = 0; i < forks.length; i++) {
     if (epoch >= forks[i].epoch) currentForkIdx = i;
   }
-  const nextForkIdx = currentForkIdx + 1;
+  let nextForkIdx = currentForkIdx + 1;
   const hasNextFork = forks[nextForkIdx] !== undefined && forks[nextForkIdx].epoch !== Infinity;
+  // Keep moving the needle of nextForkIdx if there the higher fork also exists on same epoch
+  // for e.g. altair and bellatrix are on same epoch 6, next fork should be bellatrix
+  if (hasNextFork) {
+    for (let i = nextForkIdx + 1; i < forks.length; i++) {
+      // If the fork's epoch is same as nextForkIdx (which is not equal to infinity),
+      // update nextForkIdx to the same
+      if (forks[i].epoch === forks[nextForkIdx].epoch) nextForkIdx = i;
+    }
+  }
   return {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     currentFork: forks[currentForkIdx] || forks[0],

--- a/packages/lodestar/src/network/gossip/scoringParameters.ts
+++ b/packages/lodestar/src/network/gossip/scoringParameters.ts
@@ -5,7 +5,7 @@ import {ATTESTATION_SUBNET_COUNT, SLOTS_PER_EPOCH, TARGET_AGGREGATORS_PER_COMMIT
 import {PeerScoreThresholds} from "libp2p-gossipsub/src/score";
 import {defaultTopicScoreParams, PeerScoreParams, TopicScoreParams} from "libp2p-gossipsub/src/score/peer-score-params";
 import {Eth2Context} from "../../chain";
-import {FORK_EPOCH_LOOKAHEAD, getCurrentAndNextFork} from "../forks";
+import {getActiveForks} from "../forks";
 import {IGossipsubModules} from "./gossipsub";
 import {GossipType} from "./interface";
 import {stringifyGossipTopic} from "./topic";
@@ -111,11 +111,10 @@ function getAllTopicsScoreParams(
 ): Record<string, TopicScoreParams> {
   const {epochDurationMs, slotDurationMs} = precomputedParams;
   const epoch = eth2Context.currentEpoch;
-  const {currentFork, nextFork} = getCurrentAndNextFork(config, epoch - FORK_EPOCH_LOOKAHEAD - 1);
   const topicsParams: Record<string, TopicScoreParams> = {};
-  const forks = nextFork ? [currentFork, nextFork] : [currentFork];
+  const forks = getActiveForks(config, epoch);
   const beaconAttestationSubnetWeight = 1 / ATTESTATION_SUBNET_COUNT;
-  for (const fork of forks.map((fork) => fork.name)) {
+  for (const fork of forks) {
     //first all fixed topics
     topicsParams[
       stringifyGossipTopic(config, {

--- a/packages/lodestar/test/unit/network/fork.test.ts
+++ b/packages/lodestar/test/unit/network/fork.test.ts
@@ -3,281 +3,115 @@ import {ForkName} from "@chainsafe/lodestar-params";
 import {IBeaconConfig, IForkInfo} from "@chainsafe/lodestar-config";
 import {getCurrentAndNextFork, getActiveForks} from "../../../src/network/forks";
 
-describe("network / fork: phase0: 0, altair: 0, bellatrix: Infinity", () => {
+function getForkConfig({
+  phase0,
+  altair,
+  bellatrix,
+}: {
+  phase0: number;
+  altair: number;
+  bellatrix: number;
+}): IBeaconConfig {
   const forks: Record<ForkName, IForkInfo> = {
     phase0: {
       name: ForkName.phase0,
-      epoch: 0,
+      epoch: phase0,
       version: Buffer.from([0, 0, 0, 0]),
     },
     altair: {
       name: ForkName.altair,
-      epoch: 0,
+      epoch: altair,
       version: Buffer.from([0, 0, 0, 1]),
     },
     bellatrix: {
       name: ForkName.bellatrix,
-      epoch: Infinity,
+      epoch: bellatrix,
       version: Buffer.from([0, 0, 0, 2]),
     },
   };
-  const forkConfig = {forks} as IBeaconConfig;
-  it("should return altair on epoch -1, getActiveForks: altair", () => {
-    expect(getCurrentAndNextFork(forkConfig, -1)).to.deep.equal({
-      currentFork: forks[ForkName.altair],
-      nextFork: undefined,
-    });
-    expect(getActiveForks(forkConfig, -1)).to.deep.equal(["altair"]);
-  });
-  it("should return altair on epoch 0, getActiveForks: altair", () => {
-    expect(getCurrentAndNextFork(forkConfig, 0)).to.deep.equal({
-      currentFork: forks[ForkName.altair],
-      nextFork: undefined,
-    });
-    expect(getActiveForks(forkConfig, -1)).to.deep.equal(["altair"]);
-  });
-  it("should return altair on epoch 1, getActiveForks: altair", () => {
-    expect(getCurrentAndNextFork(forkConfig, 1)).to.deep.equal({
-      currentFork: forks[ForkName.altair],
-      nextFork: undefined,
-    });
-    expect(getActiveForks(forkConfig, -1)).to.deep.equal(["altair"]);
-  });
-});
+  return {forks} as IBeaconConfig;
+}
 
-describe("network / fork: phase0: 0, altair: 0, bellatrix: 0", () => {
-  const forks: Record<ForkName, IForkInfo> = {
-    phase0: {
-      name: ForkName.phase0,
-      epoch: 0,
-      version: Buffer.from([0, 0, 0, 0]),
-    },
-    altair: {
-      name: ForkName.altair,
-      epoch: 0,
-      version: Buffer.from([0, 0, 0, 1]),
-    },
-    bellatrix: {
-      name: ForkName.bellatrix,
-      epoch: 0,
-      version: Buffer.from([0, 0, 0, 2]),
-    },
-  };
-  const forkConfig = {forks} as IBeaconConfig;
-  it("should return bellatrix on epoch -1, getActiveForks: bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, -1)).to.deep.equal({
-      currentFork: forks[ForkName.bellatrix],
-      nextFork: undefined,
-    });
-    expect(getActiveForks(forkConfig, -1)).to.deep.equal(["bellatrix"]);
-  });
-  it("should return bellatrix on epoch 0, getActiveForks: bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, 0)).to.deep.equal({
-      currentFork: forks[ForkName.bellatrix],
-      nextFork: undefined,
-    });
-    expect(getActiveForks(forkConfig, 0)).to.deep.equal(["bellatrix"]);
-  });
-});
+const testScenarios = [
+  {
+    phase0: 0,
+    altair: 0,
+    bellatrix: Infinity,
+    testCases: [
+      {epoch: -1, currentFork: "altair", nextFork: undefined, activeForks: ["altair"]},
+      {epoch: 0, currentFork: "altair", nextFork: undefined, activeForks: ["altair"]},
+      {epoch: 1, currentFork: "altair", nextFork: undefined, activeForks: ["altair"]},
+    ],
+  },
+  {
+    phase0: 0,
+    altair: 0,
+    bellatrix: 0,
+    testCases: [
+      {epoch: -1, currentFork: "bellatrix", nextFork: undefined, activeForks: ["bellatrix"]},
+      {epoch: 0, currentFork: "bellatrix", nextFork: undefined, activeForks: ["bellatrix"]},
+      {epoch: 1, currentFork: "bellatrix", nextFork: undefined, activeForks: ["bellatrix"]},
+    ],
+  },
+  {
+    phase0: 0,
+    altair: 1,
+    bellatrix: 1,
+    testCases: [
+      {epoch: -1, currentFork: "phase0", nextFork: "bellatrix", activeForks: ["phase0", "bellatrix"]},
+      {epoch: 2, currentFork: "bellatrix", nextFork: undefined, activeForks: ["phase0", "bellatrix"]},
+      {epoch: 3, currentFork: "bellatrix", nextFork: undefined, activeForks: ["phase0", "bellatrix"]},
+      {epoch: 4, currentFork: "bellatrix", nextFork: undefined, activeForks: ["bellatrix"]},
+    ],
+  },
+  {
+    phase0: 0,
+    altair: 1,
+    bellatrix: 2,
+    testCases: [
+      {epoch: -1, currentFork: "phase0", nextFork: "altair", activeForks: ["phase0", "altair"]},
+      {epoch: 0, currentFork: "phase0", nextFork: "altair", activeForks: ["phase0", "altair", "bellatrix"]},
+      {epoch: 1, currentFork: "altair", nextFork: "bellatrix", activeForks: ["phase0", "altair", "bellatrix"]},
+      {epoch: 2, currentFork: "bellatrix", nextFork: undefined, activeForks: ["phase0", "altair", "bellatrix"]},
+      {epoch: 3, currentFork: "bellatrix", nextFork: undefined, activeForks: ["phase0", "altair", "bellatrix"]},
+      {epoch: 4, currentFork: "bellatrix", nextFork: undefined, activeForks: ["altair", "bellatrix"]},
+      {epoch: 5, currentFork: "bellatrix", nextFork: undefined, activeForks: ["bellatrix"]},
+    ],
+  },
+  {
+    phase0: 0,
+    altair: 5,
+    bellatrix: 10,
+    testCases: [
+      {epoch: -1, currentFork: "phase0", nextFork: "altair", activeForks: ["phase0"]},
+      {epoch: 3, currentFork: "phase0", nextFork: "altair", activeForks: ["phase0", "altair"]},
+      {epoch: 7, currentFork: "altair", nextFork: "bellatrix", activeForks: ["phase0", "altair"]},
+      {epoch: 8, currentFork: "altair", nextFork: "bellatrix", activeForks: ["altair", "bellatrix"]},
+      {epoch: 11, currentFork: "bellatrix", nextFork: undefined, activeForks: ["altair", "bellatrix"]},
+      {epoch: 12, currentFork: "bellatrix", nextFork: undefined, activeForks: ["altair", "bellatrix"]},
+      {epoch: 13, currentFork: "bellatrix", nextFork: undefined, activeForks: ["bellatrix"]},
+    ],
+  },
+];
 
-describe("network / fork: phase0: 0, altair: 1, bellatrix: 1", () => {
-  const forks: Record<ForkName, IForkInfo> = {
-    phase0: {
-      name: ForkName.phase0,
-      epoch: 0,
-      version: Buffer.from([0, 0, 0, 0]),
-    },
-    altair: {
-      name: ForkName.altair,
-      epoch: 1,
-      version: Buffer.from([0, 0, 0, 1]),
-    },
-    bellatrix: {
-      name: ForkName.bellatrix,
-      epoch: 1,
-      version: Buffer.from([0, 0, 0, 2]),
-    },
-  };
-  const forkConfig = {forks} as IBeaconConfig;
-  it("should return phase0,bellatrix  on epoch -1, getActiveForks: phase0, bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, -1)).to.deep.equal({
-      currentFork: forks[ForkName.phase0],
-      nextFork: forks[ForkName.bellatrix],
-    });
-    expect(getActiveForks(forkConfig, -1)).to.deep.equal(["phase0", "bellatrix"]);
-  });
-  it("should return phase0,bellatrix  on epoch 0, getActiveForks: phase0, bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, 0)).to.deep.equal({
-      currentFork: forks[ForkName.phase0],
-      nextFork: forks[ForkName.bellatrix],
-    });
-    expect(getActiveForks(forkConfig, 0)).to.deep.equal(["phase0", "bellatrix"]);
-  });
-  it("should return bellatrix on epoch 2, getActiveForks: phase0, bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, 2)).to.deep.equal({
-      currentFork: forks[ForkName.bellatrix],
-      nextFork: undefined,
-    });
-    expect(getActiveForks(forkConfig, 2)).to.deep.equal(["phase0", "bellatrix"]);
-  });
-  it("should return bellatrix on epoch 3, getActiveForks: phase0,bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, 3)).to.deep.equal({
-      currentFork: forks[ForkName.bellatrix],
-      nextFork: undefined,
-    });
-    expect(getActiveForks(forkConfig, 3)).to.deep.equal(["phase0", "bellatrix"]);
-  });
-  it("should return bellatrix on epoch 4, getActiveForks: bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, 4)).to.deep.equal({
-      currentFork: forks[ForkName.bellatrix],
-      nextFork: undefined,
-    });
-    expect(getActiveForks(forkConfig, 4)).to.deep.equal(["bellatrix"]);
-  });
-});
+for (const testScenario of testScenarios) {
+  const {phase0, altair, bellatrix, testCases} = testScenario;
 
-describe("network / fork: phase0: 0, altair: 1, bellatrix: 2", () => {
-  const forks: Record<ForkName, IForkInfo> = {
-    phase0: {
-      name: ForkName.phase0,
-      epoch: 0,
-      version: Buffer.from([0, 0, 0, 0]),
-    },
-    altair: {
-      name: ForkName.altair,
-      epoch: 1,
-      version: Buffer.from([0, 0, 0, 1]),
-    },
-    bellatrix: {
-      name: ForkName.bellatrix,
-      epoch: 2,
-      version: Buffer.from([0, 0, 0, 2]),
-    },
-  };
-  const forkConfig = {forks} as IBeaconConfig;
-  it("should return phase0,altair  on epoch -1, getActiveForks: phase0, altair", () => {
-    expect(getCurrentAndNextFork(forkConfig, -1)).to.deep.equal({
-      currentFork: forks[ForkName.phase0],
-      nextFork: forks[ForkName.altair],
-    });
-    expect(getActiveForks(forkConfig, -1)).to.deep.equal(["phase0", "altair"]);
+  describe(`network / fork: phase0: ${phase0}, altair: ${altair}, bellatrix: ${bellatrix}`, () => {
+    const forkConfig = getForkConfig({phase0, altair, bellatrix});
+    const forks = forkConfig.forks;
+    for (const testCase of testCases) {
+      const {epoch, currentFork, nextFork, activeForks} = testCase;
+      it(` on epoch ${epoch} should return ${JSON.stringify({
+        currentFork,
+        nextFork,
+      })}, getActiveForks: ${activeForks}`, () => {
+        expect(getCurrentAndNextFork(forkConfig, epoch)).to.deep.equal({
+          currentFork: forks[currentFork as ForkName],
+          nextFork: (nextFork && forks[nextFork as ForkName]) ?? undefined,
+        });
+        expect(getActiveForks(forkConfig, epoch)).to.deep.equal(activeForks);
+      });
+    }
   });
-  it("should return phase0,altair  on epoch 0, getActiveForks: phase0, altair, bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, 0)).to.deep.equal({
-      currentFork: forks[ForkName.phase0],
-      nextFork: forks[ForkName.altair],
-    });
-    expect(getActiveForks(forkConfig, 0)).to.deep.equal(["phase0", "altair", "bellatrix"]);
-  });
-  it("should return altair,bellatrix on epoch 1, getActiveForks: phase0, altair, bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, 1)).to.deep.equal({
-      currentFork: forks[ForkName.altair],
-      nextFork: forks[ForkName.bellatrix],
-    });
-    expect(getActiveForks(forkConfig, 1)).to.deep.equal(["phase0", "altair", "bellatrix"]);
-  });
-  it("should return bellatrix on epoch 2, getActiveForks: phase0, altair, bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, 2)).to.deep.equal({
-      currentFork: forks[ForkName.bellatrix],
-      nextFork: undefined,
-    });
-    expect(getActiveForks(forkConfig, 2)).to.deep.equal(["phase0", "altair", "bellatrix"]);
-  });
-  it("should return bellatrix on epoch 3, getActiveForks: phase0, altair, bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, 3)).to.deep.equal({
-      currentFork: forks[ForkName.bellatrix],
-      nextFork: undefined,
-    });
-    expect(getActiveForks(forkConfig, 3)).to.deep.equal(["phase0", "altair", "bellatrix"]);
-  });
-  it("should return bellatrix on epoch 4, getActiveForks: altair, bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, 4)).to.deep.equal({
-      currentFork: forks[ForkName.bellatrix],
-      nextFork: undefined,
-    });
-    expect(getActiveForks(forkConfig, 4)).to.deep.equal(["altair", "bellatrix"]);
-  });
-  it("should return bellatrix on epoch 5, getActiveForks: bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, 5)).to.deep.equal({
-      currentFork: forks[ForkName.bellatrix],
-      nextFork: undefined,
-    });
-    expect(getActiveForks(forkConfig, 5)).to.deep.equal(["bellatrix"]);
-  });
-});
-
-describe("network / fork: phase0: 0, altair: 5, bellatrix: 10", () => {
-  const forks: Record<ForkName, IForkInfo> = {
-    phase0: {
-      name: ForkName.phase0,
-      epoch: 0,
-      version: Buffer.from([0, 0, 0, 0]),
-    },
-    altair: {
-      name: ForkName.altair,
-      epoch: 5,
-      version: Buffer.from([0, 0, 0, 1]),
-    },
-    bellatrix: {
-      name: ForkName.bellatrix,
-      epoch: 10,
-      version: Buffer.from([0, 0, 0, 2]),
-    },
-  };
-  const forkConfig = {forks} as IBeaconConfig;
-  it("should return phase0,altair  on epoch -1, getActiveForks: phase0", () => {
-    expect(getCurrentAndNextFork(forkConfig, -1)).to.deep.equal({
-      currentFork: forks[ForkName.phase0],
-      nextFork: forks[ForkName.altair],
-    });
-    expect(getActiveForks(forkConfig, -1)).to.deep.equal(["phase0"]);
-  });
-
-  it("should return phase0,altair  on epoch 3, getActiveForks: phase0,altair", () => {
-    expect(getCurrentAndNextFork(forkConfig, 3)).to.deep.equal({
-      currentFork: forks[ForkName.phase0],
-      nextFork: forks[ForkName.altair],
-    });
-    expect(getActiveForks(forkConfig, 3)).to.deep.equal(["phase0", "altair"]);
-  });
-
-  it("should return altair,bellatrix  on epoch 7, getActiveForks: phase0,altair", () => {
-    expect(getCurrentAndNextFork(forkConfig, 7)).to.deep.equal({
-      currentFork: forks[ForkName.altair],
-      nextFork: forks[ForkName.bellatrix],
-    });
-    expect(getActiveForks(forkConfig, 7)).to.deep.equal(["phase0", "altair"]);
-  });
-
-  it("should return altair,bellatrix  on epoch 8, getActiveForks: altair,bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, 8)).to.deep.equal({
-      currentFork: forks[ForkName.altair],
-      nextFork: forks[ForkName.bellatrix],
-    });
-    expect(getActiveForks(forkConfig, 8)).to.deep.equal(["altair", "bellatrix"]);
-  });
-
-  it("should return bellatrix  on epoch 11, getActiveForks: altair,bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, 11)).to.deep.equal({
-      currentFork: forks[ForkName.bellatrix],
-      nextFork: undefined,
-    });
-    expect(getActiveForks(forkConfig, 11)).to.deep.equal(["altair", "bellatrix"]);
-  });
-
-  it("should return bellatrix  on epoch 12, getActiveForks: altair,bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, 12)).to.deep.equal({
-      currentFork: forks[ForkName.bellatrix],
-      nextFork: undefined,
-    });
-    expect(getActiveForks(forkConfig, 12)).to.deep.equal(["altair", "bellatrix"]);
-  });
-
-  it("should return bellatrix  on epoch 13, getActiveForks: bellatrix", () => {
-    expect(getCurrentAndNextFork(forkConfig, 13)).to.deep.equal({
-      currentFork: forks[ForkName.bellatrix],
-      nextFork: undefined,
-    });
-    expect(getActiveForks(forkConfig, 13)).to.deep.equal(["bellatrix"]);
-  });
-});
+}

--- a/packages/lodestar/test/unit/network/fork.test.ts
+++ b/packages/lodestar/test/unit/network/fork.test.ts
@@ -29,7 +29,9 @@ function getForkConfig({
       version: Buffer.from([0, 0, 0, 2]),
     },
   };
-  return {forks} as IBeaconConfig;
+  const forksAscendingEpochOrder = Object.values(forks);
+  const forksDescendingEpochOrder = Object.values(forks).reverse();
+  return {forks, forksAscendingEpochOrder, forksDescendingEpochOrder} as IBeaconConfig;
 }
 
 const testScenarios = [

--- a/packages/lodestar/test/unit/network/fork.test.ts
+++ b/packages/lodestar/test/unit/network/fork.test.ts
@@ -1,9 +1,9 @@
 import {expect} from "chai";
 import {ForkName} from "@chainsafe/lodestar-params";
 import {IBeaconConfig, IForkInfo} from "@chainsafe/lodestar-config";
-import {getCurrentAndNextFork} from "../../../src/network/forks";
+import {getCurrentAndNextFork, getActiveForks} from "../../../src/network/forks";
 
-describe("network / fork", () => {
+describe("network / fork: phase0: 0, altair: 0, bellatrix: Infinity", () => {
   const forks: Record<ForkName, IForkInfo> = {
     phase0: {
       name: ForkName.phase0,
@@ -21,17 +21,263 @@ describe("network / fork", () => {
       version: Buffer.from([0, 0, 0, 2]),
     },
   };
-  const altairEpoch0 = {forks} as IBeaconConfig;
-  it("should return altair on epoch -1", () => {
-    expect(getCurrentAndNextFork(altairEpoch0, -1)).to.deep.equal({
+  const forkConfig = {forks} as IBeaconConfig;
+  it("should return altair on epoch -1, getActiveForks: altair", () => {
+    expect(getCurrentAndNextFork(forkConfig, -1)).to.deep.equal({
       currentFork: forks[ForkName.altair],
       nextFork: undefined,
     });
+    expect(getActiveForks(forkConfig, -1)).to.deep.equal(["altair"]);
   });
-  it("should return altair on epoch 0", () => {
-    expect(getCurrentAndNextFork(altairEpoch0, 0)).to.deep.equal({
+  it("should return altair on epoch 0, getActiveForks: altair", () => {
+    expect(getCurrentAndNextFork(forkConfig, 0)).to.deep.equal({
       currentFork: forks[ForkName.altair],
       nextFork: undefined,
     });
+    expect(getActiveForks(forkConfig, -1)).to.deep.equal(["altair"]);
+  });
+  it("should return altair on epoch 1, getActiveForks: altair", () => {
+    expect(getCurrentAndNextFork(forkConfig, 1)).to.deep.equal({
+      currentFork: forks[ForkName.altair],
+      nextFork: undefined,
+    });
+    expect(getActiveForks(forkConfig, -1)).to.deep.equal(["altair"]);
+  });
+});
+
+describe("network / fork: phase0: 0, altair: 0, bellatrix: 0", () => {
+  const forks: Record<ForkName, IForkInfo> = {
+    phase0: {
+      name: ForkName.phase0,
+      epoch: 0,
+      version: Buffer.from([0, 0, 0, 0]),
+    },
+    altair: {
+      name: ForkName.altair,
+      epoch: 0,
+      version: Buffer.from([0, 0, 0, 1]),
+    },
+    bellatrix: {
+      name: ForkName.bellatrix,
+      epoch: 0,
+      version: Buffer.from([0, 0, 0, 2]),
+    },
+  };
+  const forkConfig = {forks} as IBeaconConfig;
+  it("should return bellatrix on epoch -1, getActiveForks: bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, -1)).to.deep.equal({
+      currentFork: forks[ForkName.bellatrix],
+      nextFork: undefined,
+    });
+    expect(getActiveForks(forkConfig, -1)).to.deep.equal(["bellatrix"]);
+  });
+  it("should return bellatrix on epoch 0, getActiveForks: bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, 0)).to.deep.equal({
+      currentFork: forks[ForkName.bellatrix],
+      nextFork: undefined,
+    });
+    expect(getActiveForks(forkConfig, 0)).to.deep.equal(["bellatrix"]);
+  });
+});
+
+describe("network / fork: phase0: 0, altair: 1, bellatrix: 1", () => {
+  const forks: Record<ForkName, IForkInfo> = {
+    phase0: {
+      name: ForkName.phase0,
+      epoch: 0,
+      version: Buffer.from([0, 0, 0, 0]),
+    },
+    altair: {
+      name: ForkName.altair,
+      epoch: 1,
+      version: Buffer.from([0, 0, 0, 1]),
+    },
+    bellatrix: {
+      name: ForkName.bellatrix,
+      epoch: 1,
+      version: Buffer.from([0, 0, 0, 2]),
+    },
+  };
+  const forkConfig = {forks} as IBeaconConfig;
+  it("should return phase0,bellatrix  on epoch -1, getActiveForks: phase0, bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, -1)).to.deep.equal({
+      currentFork: forks[ForkName.phase0],
+      nextFork: forks[ForkName.bellatrix],
+    });
+    expect(getActiveForks(forkConfig, -1)).to.deep.equal(["phase0", "bellatrix"]);
+  });
+  it("should return phase0,bellatrix  on epoch 0, getActiveForks: phase0, bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, 0)).to.deep.equal({
+      currentFork: forks[ForkName.phase0],
+      nextFork: forks[ForkName.bellatrix],
+    });
+    expect(getActiveForks(forkConfig, 0)).to.deep.equal(["phase0", "bellatrix"]);
+  });
+  it("should return bellatrix on epoch 2, getActiveForks: phase0, bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, 2)).to.deep.equal({
+      currentFork: forks[ForkName.bellatrix],
+      nextFork: undefined,
+    });
+    expect(getActiveForks(forkConfig, 2)).to.deep.equal(["phase0", "bellatrix"]);
+  });
+  it("should return bellatrix on epoch 3, getActiveForks: phase0,bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, 3)).to.deep.equal({
+      currentFork: forks[ForkName.bellatrix],
+      nextFork: undefined,
+    });
+    expect(getActiveForks(forkConfig, 3)).to.deep.equal(["phase0", "bellatrix"]);
+  });
+  it("should return bellatrix on epoch 4, getActiveForks: bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, 4)).to.deep.equal({
+      currentFork: forks[ForkName.bellatrix],
+      nextFork: undefined,
+    });
+    expect(getActiveForks(forkConfig, 4)).to.deep.equal(["bellatrix"]);
+  });
+});
+
+describe("network / fork: phase0: 0, altair: 1, bellatrix: 2", () => {
+  const forks: Record<ForkName, IForkInfo> = {
+    phase0: {
+      name: ForkName.phase0,
+      epoch: 0,
+      version: Buffer.from([0, 0, 0, 0]),
+    },
+    altair: {
+      name: ForkName.altair,
+      epoch: 1,
+      version: Buffer.from([0, 0, 0, 1]),
+    },
+    bellatrix: {
+      name: ForkName.bellatrix,
+      epoch: 2,
+      version: Buffer.from([0, 0, 0, 2]),
+    },
+  };
+  const forkConfig = {forks} as IBeaconConfig;
+  it("should return phase0,altair  on epoch -1, getActiveForks: phase0, altair", () => {
+    expect(getCurrentAndNextFork(forkConfig, -1)).to.deep.equal({
+      currentFork: forks[ForkName.phase0],
+      nextFork: forks[ForkName.altair],
+    });
+    expect(getActiveForks(forkConfig, -1)).to.deep.equal(["phase0", "altair"]);
+  });
+  it("should return phase0,altair  on epoch 0, getActiveForks: phase0, altair, bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, 0)).to.deep.equal({
+      currentFork: forks[ForkName.phase0],
+      nextFork: forks[ForkName.altair],
+    });
+    expect(getActiveForks(forkConfig, 0)).to.deep.equal(["phase0", "altair", "bellatrix"]);
+  });
+  it("should return altair,bellatrix on epoch 1, getActiveForks: phase0, altair, bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, 1)).to.deep.equal({
+      currentFork: forks[ForkName.altair],
+      nextFork: forks[ForkName.bellatrix],
+    });
+    expect(getActiveForks(forkConfig, 1)).to.deep.equal(["phase0", "altair", "bellatrix"]);
+  });
+  it("should return bellatrix on epoch 2, getActiveForks: phase0, altair, bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, 2)).to.deep.equal({
+      currentFork: forks[ForkName.bellatrix],
+      nextFork: undefined,
+    });
+    expect(getActiveForks(forkConfig, 2)).to.deep.equal(["phase0", "altair", "bellatrix"]);
+  });
+  it("should return bellatrix on epoch 3, getActiveForks: phase0, altair, bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, 3)).to.deep.equal({
+      currentFork: forks[ForkName.bellatrix],
+      nextFork: undefined,
+    });
+    expect(getActiveForks(forkConfig, 3)).to.deep.equal(["phase0", "altair", "bellatrix"]);
+  });
+  it("should return bellatrix on epoch 4, getActiveForks: altair, bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, 4)).to.deep.equal({
+      currentFork: forks[ForkName.bellatrix],
+      nextFork: undefined,
+    });
+    expect(getActiveForks(forkConfig, 4)).to.deep.equal(["altair", "bellatrix"]);
+  });
+  it("should return bellatrix on epoch 5, getActiveForks: bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, 5)).to.deep.equal({
+      currentFork: forks[ForkName.bellatrix],
+      nextFork: undefined,
+    });
+    expect(getActiveForks(forkConfig, 5)).to.deep.equal(["bellatrix"]);
+  });
+});
+
+describe("network / fork: phase0: 0, altair: 5, bellatrix: 10", () => {
+  const forks: Record<ForkName, IForkInfo> = {
+    phase0: {
+      name: ForkName.phase0,
+      epoch: 0,
+      version: Buffer.from([0, 0, 0, 0]),
+    },
+    altair: {
+      name: ForkName.altair,
+      epoch: 5,
+      version: Buffer.from([0, 0, 0, 1]),
+    },
+    bellatrix: {
+      name: ForkName.bellatrix,
+      epoch: 10,
+      version: Buffer.from([0, 0, 0, 2]),
+    },
+  };
+  const forkConfig = {forks} as IBeaconConfig;
+  it("should return phase0,altair  on epoch -1, getActiveForks: phase0", () => {
+    expect(getCurrentAndNextFork(forkConfig, -1)).to.deep.equal({
+      currentFork: forks[ForkName.phase0],
+      nextFork: forks[ForkName.altair],
+    });
+    expect(getActiveForks(forkConfig, -1)).to.deep.equal(["phase0"]);
+  });
+
+  it("should return phase0,altair  on epoch 3, getActiveForks: phase0,altair", () => {
+    expect(getCurrentAndNextFork(forkConfig, 3)).to.deep.equal({
+      currentFork: forks[ForkName.phase0],
+      nextFork: forks[ForkName.altair],
+    });
+    expect(getActiveForks(forkConfig, 3)).to.deep.equal(["phase0", "altair"]);
+  });
+
+  it("should return altair,bellatrix  on epoch 7, getActiveForks: phase0,altair", () => {
+    expect(getCurrentAndNextFork(forkConfig, 7)).to.deep.equal({
+      currentFork: forks[ForkName.altair],
+      nextFork: forks[ForkName.bellatrix],
+    });
+    expect(getActiveForks(forkConfig, 7)).to.deep.equal(["phase0", "altair"]);
+  });
+
+  it("should return altair,bellatrix  on epoch 8, getActiveForks: altair,bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, 8)).to.deep.equal({
+      currentFork: forks[ForkName.altair],
+      nextFork: forks[ForkName.bellatrix],
+    });
+    expect(getActiveForks(forkConfig, 8)).to.deep.equal(["altair", "bellatrix"]);
+  });
+
+  it("should return bellatrix  on epoch 11, getActiveForks: altair,bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, 11)).to.deep.equal({
+      currentFork: forks[ForkName.bellatrix],
+      nextFork: undefined,
+    });
+    expect(getActiveForks(forkConfig, 11)).to.deep.equal(["altair", "bellatrix"]);
+  });
+
+  it("should return bellatrix  on epoch 12, getActiveForks: altair,bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, 12)).to.deep.equal({
+      currentFork: forks[ForkName.bellatrix],
+      nextFork: undefined,
+    });
+    expect(getActiveForks(forkConfig, 12)).to.deep.equal(["altair", "bellatrix"]);
+  });
+
+  it("should return bellatrix  on epoch 13, getActiveForks: bellatrix", () => {
+    expect(getCurrentAndNextFork(forkConfig, 13)).to.deep.equal({
+      currentFork: forks[ForkName.bellatrix],
+      nextFork: undefined,
+    });
+    expect(getActiveForks(forkConfig, 13)).to.deep.equal(["bellatrix"]);
   });
 });


### PR DESCRIPTION
**Motivation**
If the forks (phase0,altair,bellatrix) are lined up close together, like 0,1,2 then the subscription to the fork bellatrix doesn't happen at all, at fork 0 (when bellatrix should be subscribed), the getActiveForks gives phase0 and altair only.
This issue surfaced in the Kurtosis merge testnet runs, as diagnosed here: https://github.com/ChainSafe/lodestar/issues/3639
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR fixes 
- the implementation of getActiveForks to provide all the active forks instead of just current and next, so now it will give phase0,altair,bellatrix as well. 
- refactors the onEpoch of the network to iterate through activeForks and subscribe/unsubscribe.
- Added tests for some scenarios for current, next and total active forks:
```
 network / fork: phase0: 0, altair: 0, bellatrix: Infinity
    ✓ should return altair on epoch -1, getActiveForks: altair
    ✓ should return altair on epoch 0, getActiveForks: altair
    ✓ should return altair on epoch 1, getActiveForks: altair

  network / fork: phase0: 0, altair: 0, bellatrix: 0
    ✓ should return bellatrix on epoch -1, getActiveForks: bellatrix
    ✓ should return bellatrix on epoch 0, getActiveForks: bellatrix

  network / fork: phase0: 0, altair: 1, bellatrix: 1
    ✓ should return phase0,bellatrix  on epoch -1, getActiveForks: phase0, bellatrix
    ✓ should return phase0,bellatrix  on epoch 0, getActiveForks: phase0, bellatrix
    ✓ should return bellatrix on epoch 2, getActiveForks: phase0, bellatrix
    ✓ should return bellatrix on epoch 3, getActiveForks: phase0,bellatrix
    ✓ should return bellatrix on epoch 4, getActiveForks: bellatrix

  network / fork: phase0: 0, altair: 1, bellatrix: 2
    ✓ should return phase0,altair  on epoch -1, getActiveForks: phase0, altair
    ✓ should return phase0,altair  on epoch 0, getActiveForks: phase0, altair, bellatrix
    ✓ should return altair,bellatrix on epoch 1, getActiveForks: phase0, altair, bellatrix
    ✓ should return bellatrix on epoch 2, getActiveForks: phase0, altair, bellatrix
    ✓ should return bellatrix on epoch 3, getActiveForks: phase0, altair, bellatrix
    ✓ should return bellatrix on epoch 4, getActiveForks: altair, bellatrix
    ✓ should return bellatrix on epoch 5, getActiveForks: bellatrix

  network / fork: phase0: 0, altair: 5, bellatrix: 10
    ✓ should return phase0,altair  on epoch -1, getActiveForks: phase0
    ✓ should return phase0,altair  on epoch 3, getActiveForks: phase0,altair
    ✓ should return altair,bellatrix  on epoch 7, getActiveForks: phase0,altair
    ✓ should return altair,bellatrix  on epoch 8, getActiveForks: altair,bellatrix
    ✓ should return bellatrix  on epoch 11, getActiveForks: altair,bellatrix
    ✓ should return bellatrix  on epoch 12, getActiveForks: altair,bellatrix
    ✓ should return bellatrix  on epoch 13, getActiveForks: bellatrix


  24 passing (19ms)

```


<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #3639 
