### PR TITLE
BackfillSync: Transform roots with toHexString for logging

### DIFF
--- a/packages/lodestar/src/sync/backfill/backfill.ts
+++ b/packages/lodestar/src/sync/backfill/backfill.ts
@@ -518,15 +518,18 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
 
         // TODO: one can verify the child of wsDbCheckpointBlock is at
         // slot > wsCheckpointHeader
-        wsDbCheckpointBlock.message.slot > this.wsCheckpointHeader.slot
+        wsDbCheckpointBlock.message.slot >= this.wsCheckpointHeader.slot + SLOTS_PER_EPOCH
       )
         // TODO: explode and stop the entire node
         throw new Error(
-          `InvalidWsCheckpoint root=${this.wsCheckpointHeader.root}, epoch=${
+          `InvalidWsCheckpoint root=${toHexString(this.wsCheckpointHeader.root)}, epoch=${
             this.wsCheckpointHeader.slot / SLOTS_PER_EPOCH
           }, ${
             wsDbCheckpointBlock
-              ? "found at epoch=" + Math.floor(wsDbCheckpointBlock?.message.slot / SLOTS_PER_EPOCH)
+              ? "found at epoch=" +
+                Math.floor(wsDbCheckpointBlock?.message.slot / SLOTS_PER_EPOCH) +
+                ", slot=" +
+                wsDbCheckpointBlock.message.slot
               : "not found"
           }`
         );
@@ -584,9 +587,9 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
             } else {
               validSequence = false;
               this.logger.warn(
-                `Invalid backfill sequence: previous finalized or checkpoint block root=${
+                `Invalid backfill sequence: previous finalized or checkpoint block root=${toHexString(
                   this.prevFinalizedCheckpointBlock.root
-                }, slot=${this.prevFinalizedCheckpointBlock.slot} ${
+                )}, slot=${this.prevFinalizedCheckpointBlock.slot} ${
                   prevBackfillCpBlock ? "found at slot=" + prevBackfillCpBlock.message.slot : "not found"
                 }, ignoring the sequence`
               );
@@ -658,7 +661,9 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
 
     if (expectedSlot !== null && anchorBlock.message.slot !== expectedSlot)
       throw Error(
-        `Invalid slot of anchorBlock read from DB with root=${anchorBlockRoot}, expected=${expectedSlot}, actual=${anchorBlock.message.slot}`
+        `Invalid slot of anchorBlock read from DB with root=${toHexString(
+          anchorBlockRoot
+        )}, expected=${expectedSlot}, actual=${anchorBlock.message.slot}`
       );
 
     // If possible, read back till anchorBlock > this.prevFinalizedCheckpointBlock
@@ -686,7 +691,7 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
           throw Error(
             `Invalid root for prevFinalizedCheckpointBlock at slot=${
               this.prevFinalizedCheckpointBlock.slot
-            }, expected=${toHexString(this.prevFinalizedCheckpointBlock.root)}, found=${anchorBlockRoot}`
+            }, expected=${toHexString(this.prevFinalizedCheckpointBlock.root)}, found=${toHexString(anchorBlockRoot)}`
           );
         }
 


### PR DESCRIPTION
**Motivation**
Some of the roots in the backfillsync that were being logged were in raw format, transforming them to hex for better readability and UX. 
<!-- Why is this PR exists? What are the goals of the pull request? -->
- Transforms the roots with toHexString for logging/errors
- Also relaxes/fixes the weak subjectivity checkpoint error validation scenario as the epoch of checkpoint provided could sometimes also be the floor of slot/SLOTS_PER_EPOCH
**Description**
Closes #3640 

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
