### PR TITLE
Trigger block search when receiving unknown block root attestations

### DIFF
--- a/packages/beacon-state-transition/src/allForks/stateTransition.ts
+++ b/packages/beacon-state-transition/src/allForks/stateTransition.ts
@@ -101,11 +101,14 @@ export function processBlock(
   metrics?: IBeaconStateTransitionMetrics | null
 ): void {
   const {verifySignatures = true} = options || {};
-  const fork = postState.config.getForkName(block.slot);
+  const {config, genesisTime} = postState;
+  const fork = config.getForkName(block.slot);
 
   const timer = metrics?.stfnProcessBlock.startTimer();
   try {
     processBlockByFork[fork](postState, block, verifySignatures);
+    const delaySec = Date.now() / 1000 - (genesisTime + block.slot * config.SECONDS_PER_SLOT);
+    metrics?.stfnElappsedTimeTillProcessed.observe(delaySec);
   } finally {
     if (timer) timer();
   }

--- a/packages/beacon-state-transition/src/allForks/stateTransition.ts
+++ b/packages/beacon-state-transition/src/allForks/stateTransition.ts
@@ -108,7 +108,7 @@ export function processBlock(
   try {
     processBlockByFork[fork](postState, block, verifySignatures);
     const delaySec = Date.now() / 1000 - (genesisTime + block.slot * config.SECONDS_PER_SLOT);
-    metrics?.stfnElappsedTimeTillProcessed.observe(delaySec);
+    metrics?.stfnElapsedTimeTillProcessed.observe(delaySec);
   } finally {
     if (timer) timer();
   }

--- a/packages/beacon-state-transition/src/allForks/stateTransition.ts
+++ b/packages/beacon-state-transition/src/allForks/stateTransition.ts
@@ -101,14 +101,11 @@ export function processBlock(
   metrics?: IBeaconStateTransitionMetrics | null
 ): void {
   const {verifySignatures = true} = options || {};
-  const {config, genesisTime} = postState;
-  const fork = config.getForkName(block.slot);
+  const fork = postState.config.getForkName(block.slot);
 
   const timer = metrics?.stfnProcessBlock.startTimer();
   try {
     processBlockByFork[fork](postState, block, verifySignatures);
-    const delaySec = Date.now() / 1000 - (genesisTime + block.slot * config.SECONDS_PER_SLOT);
-    metrics?.stfnElapsedTimeTillProcessed.observe(delaySec);
   } finally {
     if (timer) timer();
   }

--- a/packages/beacon-state-transition/src/metrics.ts
+++ b/packages/beacon-state-transition/src/metrics.ts
@@ -4,9 +4,11 @@ import {IAttesterStatus} from "./util/attesterStatus";
 export interface IBeaconStateTransitionMetrics {
   stfnEpochTransition: IHistogram;
   stfnProcessBlock: IHistogram;
+  stfnElappsedTimeTillProcessed: IHistogram;
   registerValidatorStatuses: (currentEpoch: Epoch, statuses: IAttesterStatus[], balances?: number[]) => void;
 }
 
 interface IHistogram {
   startTimer(): () => void;
+  observe(value: number): void;
 }

--- a/packages/beacon-state-transition/src/metrics.ts
+++ b/packages/beacon-state-transition/src/metrics.ts
@@ -4,7 +4,7 @@ import {IAttesterStatus} from "./util/attesterStatus";
 export interface IBeaconStateTransitionMetrics {
   stfnEpochTransition: IHistogram;
   stfnProcessBlock: IHistogram;
-  stfnElappsedTimeTillProcessed: IHistogram;
+  stfnElapsedTimeTillProcessed: IHistogram;
   registerValidatorStatuses: (currentEpoch: Epoch, statuses: IAttesterStatus[], balances?: number[]) => void;
 }
 

--- a/packages/beacon-state-transition/src/metrics.ts
+++ b/packages/beacon-state-transition/src/metrics.ts
@@ -4,11 +4,9 @@ import {IAttesterStatus} from "./util/attesterStatus";
 export interface IBeaconStateTransitionMetrics {
   stfnEpochTransition: IHistogram;
   stfnProcessBlock: IHistogram;
-  stfnElapsedTimeTillProcessed: IHistogram;
   registerValidatorStatuses: (currentEpoch: Epoch, statuses: IAttesterStatus[], balances?: number[]) => void;
 }
 
 interface IHistogram {
   startTimer(): () => void;
-  observe(value: number): void;
 }

--- a/packages/lodestar/src/api/impl/beacon/blocks/index.ts
+++ b/packages/lodestar/src/api/impl/beacon/blocks/index.ts
@@ -5,6 +5,7 @@ import {computeTimeAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {SLOTS_PER_HISTORICAL_ROOT} from "@chainsafe/lodestar-params";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {BlockSource} from "../../../../chain/blocks/types";
 import {BlockError, BlockErrorCode} from "../../../../chain/errors";
 import {OpSource} from "../../../../metrics/validatorMonitor";
 import {NetworkEvent} from "../../../../network";
@@ -157,7 +158,7 @@ export function getBeaconBlockApi({
         // specification is very clear that this is the desired behaviour.
         network.gossip.publishBeaconBlock(signedBlock),
 
-        chain.processBlock(signedBlock).catch((e) => {
+        chain.processBlock(signedBlock, {source: BlockSource.API}).catch((e) => {
           if (e instanceof BlockError && e.type.code === BlockErrorCode.PARENT_UNKNOWN) {
             network.events.emit(NetworkEvent.unknownBlockParent, signedBlock, network.peerId.toB58String());
           }

--- a/packages/lodestar/src/chain/blocks/importBlock.ts
+++ b/packages/lodestar/src/chain/blocks/importBlock.ts
@@ -237,7 +237,7 @@ export async function importBlock(chain: ImportBlockModules, fullyVerifiedBlock:
   // - Send event after everything is done
 
   // Emit all events at once after fully completing importBlock()
-  chain.emitter.emit(ChainEvent.block, block, postState);
+  chain.emitter.emit(ChainEvent.block, block, postState, fullyVerifiedBlock.source);
   pendingEvents.emit();
 }
 

--- a/packages/lodestar/src/chain/blocks/types.ts
+++ b/packages/lodestar/src/chain/blocks/types.ts
@@ -23,6 +23,10 @@ export type FullyVerifiedBlockFlags = {
    * If the execution payload couldnt be verified because of EL syncing status, used in optimistic sync or for merge block
    */
   executionStatus?: ExecutionStatus;
+  /**
+   * If from RangeSync module, we won't attest to this block so it's okay to ignore a SYNCING message from execution layer
+   */
+  source: BlockSource;
 };
 
 export type PartiallyVerifiedBlockFlags = FullyVerifiedBlockFlags & {
@@ -35,14 +39,20 @@ export type PartiallyVerifiedBlockFlags = FullyVerifiedBlockFlags & {
    */
   validSignatures?: boolean;
   /**
-   * From RangeSync module, we won't attest to this block so it's okay to ignore a SYNCING message from execution layer
-   */
-  fromRangeSync?: boolean;
-  /**
    * Verify signatures on main thread or not.
    */
   blsVerifyOnMainThread?: boolean;
 };
+
+/**
+ * An enum of how a block comes to this node.
+ */
+export enum BlockSource {
+  API = "BLOCK_SOURCE_API",
+  GOSSIP = "BLOCK_SOURCE_GOSSIP",
+  UNKNOWN_BLOCK_SYNC = "BLOCK_SOURCE_UNKNOWN_BLOCK_SYNC",
+  RANGE_SYNC = "BLOCK_SOURCE_RANGE_SYNC",
+}
 
 /**
  * A wrapper around a `SignedBeaconBlock` that indicates that this block is fully verified and ready to import

--- a/packages/lodestar/src/chain/blocks/types.ts
+++ b/packages/lodestar/src/chain/blocks/types.ts
@@ -45,13 +45,13 @@ export type PartiallyVerifiedBlockFlags = FullyVerifiedBlockFlags & {
 };
 
 /**
- * An enum of how a block comes to this node.
+ * An enum of how a block comes to this node, used for metrics as well so value is in snake case.
  */
 export enum BlockSource {
-  API = "BLOCK_SOURCE_API",
-  GOSSIP = "BLOCK_SOURCE_GOSSIP",
-  UNKNOWN_BLOCK_SYNC = "BLOCK_SOURCE_UNKNOWN_BLOCK_SYNC",
-  RANGE_SYNC = "BLOCK_SOURCE_RANGE_SYNC",
+  API = "api",
+  GOSSIP = "gossip",
+  UNKNOWN_BLOCK_SYNC = "unknown_block_sync",
+  RANGE_SYNC = "range_sync",
 }
 
 /**

--- a/packages/lodestar/src/chain/blocks/verifyBlock.ts
+++ b/packages/lodestar/src/chain/blocks/verifyBlock.ts
@@ -52,6 +52,7 @@ export async function verifyBlock(
     parentBlock,
     skipImportingAttestations: partiallyVerifiedBlock.skipImportingAttestations,
     executionStatus,
+    source: partiallyVerifiedBlock.source,
   };
 }
 

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -257,11 +257,11 @@ export class BeaconChain implements IBeaconChain {
     return await this.db.block.get(fromHexString(block.blockRoot));
   }
 
-  async processBlock(block: allForks.SignedBeaconBlock, flags?: PartiallyVerifiedBlockFlags): Promise<void> {
+  async processBlock(block: allForks.SignedBeaconBlock, flags: PartiallyVerifiedBlockFlags): Promise<void> {
     return await this.blockProcessor.processBlockJob({...flags, block});
   }
 
-  async processChainSegment(blocks: allForks.SignedBeaconBlock[], flags?: PartiallyVerifiedBlockFlags): Promise<void> {
+  async processChainSegment(blocks: allForks.SignedBeaconBlock[], flags: PartiallyVerifiedBlockFlags): Promise<void> {
     return await this.blockProcessor.processChainSegment(blocks.map((block) => ({...flags, block})));
   }
 

--- a/packages/lodestar/src/chain/emitter.ts
+++ b/packages/lodestar/src/chain/emitter.ts
@@ -6,6 +6,7 @@ import {phase0, Epoch, Slot, allForks} from "@chainsafe/lodestar-types";
 import {CheckpointWithHex, IProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {AttestationError, BlockError} from "./errors";
+import {BlockSource} from "./blocks/types";
 
 /**
  * Important chain events that occur during normal chain operation.
@@ -108,7 +109,11 @@ export enum ChainEvent {
 
 export interface IChainEvents {
   [ChainEvent.attestation]: (attestation: phase0.Attestation) => void;
-  [ChainEvent.block]: (signedBlock: allForks.SignedBeaconBlock, postState: CachedBeaconStateAllForks) => void;
+  [ChainEvent.block]: (
+    signedBlock: allForks.SignedBeaconBlock,
+    postState: CachedBeaconStateAllForks,
+    source: BlockSource
+  ) => void;
   [ChainEvent.errorAttestation]: (error: AttestationError) => void;
   [ChainEvent.errorBlock]: (error: BlockError) => void;
 

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -192,11 +192,14 @@ export async function onBlock(
   const advancedSlot = this.clock.slotWithFutureTolerance(REPROCESS_MIN_TIME_TO_NEXT_SLOT_SEC);
 
   this.reprocessController.onBlockImported({slot: block.message.slot, root: blockRoot}, advancedSlot);
+  const delaySec = this.clock.secFromSlot(block.message.slot);
+  // block may come from different sources so we want to track a different metric than the gossip one
+  this.metrics?.elapsedTimeTillProcessed.observe(delaySec);
 
   this.logger.verbose("Block processed", {
     slot: block.message.slot,
     root: blockRoot,
-    delaySec: this.clock.secFromSlot(block.message.slot),
+    delaySec,
   });
 }
 

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -87,9 +87,9 @@ export interface IBeaconChain {
   getCanonicalBlockAtSlot(slot: Slot): Promise<allForks.SignedBeaconBlock | null>;
 
   /** Process a block until complete */
-  processBlock(signedBlock: allForks.SignedBeaconBlock, flags?: PartiallyVerifiedBlockFlags): Promise<void>;
+  processBlock(signedBlock: allForks.SignedBeaconBlock, flags: PartiallyVerifiedBlockFlags): Promise<void>;
   /** Process a chain of blocks until complete */
-  processChainSegment(signedBlocks: allForks.SignedBeaconBlock[], flags?: PartiallyVerifiedBlockFlags): Promise<void>;
+  processChainSegment(signedBlocks: allForks.SignedBeaconBlock[], flags: PartiallyVerifiedBlockFlags): Promise<void>;
 
   getStatus(): phase0.Status;
 

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -516,9 +516,9 @@ export function createLodestarMetrics(
         help: "Total number of processed blocks successes in UnknownBlockSync",
         labelNames: ["type"],
       }),
-      elapsedTimeTillProcessed: register.histogram<"type">({
-        name: "lodestar_sync_unknown_block_elapsed_time_till_processed_seconds",
-        help: "Duration from received time until the block is processed",
+      downloadTime: register.histogram<"type">({
+        name: "lodestar_sync_unknown_block_download_time_seconds",
+        help: "Duration from received time until the block is downloaded",
         labelNames: ["type"],
       }),
       slotTimeTillProcessed: register.histogram<"type">({

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -66,6 +66,10 @@ export function createLodestarMetrics(
       name: "lodestar_peers_sync_count",
       help: "Current count of peers useful for sync",
     }),
+    peersRelevant: register.gauge({
+      name: "lodestar_peers_relevant_count",
+      help: "Current count of peers relevant to this node",
+    }),
     peerConnectedEvent: register.gauge<"direction">({
       name: "lodestar_peer_connected_total",
       help: "Total number of peer:connected event, labeled by direction",
@@ -372,6 +376,11 @@ export function createLodestarMetrics(
       help: "Time to process a single block in seconds",
       buckets: [0.1, 1, 10],
     }),
+    stfnElappsedTimeTillProcessed: register.histogram({
+      name: "lodestar_stfn_elappsed_time_until_processed_seconds",
+      help: "Duration from slot time until block is processed in seconds",
+      buckets: [0.1, 1, 10],
+    }),
 
     // BLS verifier thread pool and queue
 
@@ -487,33 +496,49 @@ export function createLodestarMetrics(
     },
 
     syncUnknownBlock: {
-      requests: register.gauge({
+      requests: register.gauge<"type">({
         name: "lodestar_sync_unknown_block_requests_total",
         help: "Total number of unknownBlockParent events or requests",
+        labelNames: ["type"],
       }),
-      pendingBlocks: register.gauge({
+      pendingBlocks: register.gauge<"type">({
         name: "lodestar_sync_unknown_block_pending_blocks_size",
         help: "Current size of UnknownBlockSync pending blocks cache",
+        labelNames: ["type"],
       }),
-      knownBadBlocks: register.gauge({
+      knownBadBlocks: register.gauge<"type">({
         name: "lodestar_sync_unknown_block_known_bad_blocks_size",
         help: "Current size of UnknownBlockSync known bad blocks cache",
+        labelNames: ["type"],
       }),
-      processedBlocksSuccess: register.gauge({
+      processedBlocksSuccess: register.gauge<"type">({
         name: "lodestar_sync_unknown_block_processed_blocks_success_total",
         help: "Total number of processed blocks successes in UnknownBlockSync",
+        labelNames: ["type"],
+      }),
+      elappsedTimeTillProcessed: register.gauge<"type">({
+        name: "lodestar_sync_unknown_block_elappsed_time_till_processed",
+        help: "Duration from received time until the block is processed",
+        labelNames: ["type"],
+      }),
+      slotTimeTillProcessed: register.gauge<"type">({
+        name: "lodestar_sync_unknown_block_slot_time_till_processed",
+        help: "Duration from slot time until the block is processed",
+        labelNames: ["type"],
       }),
       processedBlocksError: register.gauge({
         name: "lodestar_sync_unknown_block_processed_blocks_error_total",
         help: "Total number of processed blocks errors in UnknownBlockSync",
       }),
-      downloadedBlocksSuccess: register.gauge({
+      downloadedBlocksSuccess: register.gauge<"type">({
         name: "lodestar_sync_unknown_block_downloaded_blocks_success_total",
         help: "Total number of downloaded blocks successes in UnknownBlockSync",
+        labelNames: ["type"],
       }),
-      downloadedBlocksError: register.gauge({
+      downloadedBlocksError: register.gauge<"type">({
         name: "lodestar_sync_unknown_block_downloaded_blocks_error_total",
         help: "Total number of downloaded blocks errors in UnknownBlockSync",
+        labelNames: ["type"],
       }),
       removedBlocks: register.gauge({
         name: "lodestar_sync_unknown_block_removed_blocks_total",

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -376,8 +376,8 @@ export function createLodestarMetrics(
       help: "Time to process a single block in seconds",
       buckets: [0.1, 1, 10],
     }),
-    stfnElappsedTimeTillProcessed: register.histogram({
-      name: "lodestar_stfn_elappsed_time_until_processed_seconds",
+    stfnElapsedTimeTillProcessed: register.histogram({
+      name: "lodestar_stfn_elapsed_time_until_processed_seconds",
       help: "Duration from slot time until block is processed in seconds",
       buckets: [0.1, 1, 10],
     }),
@@ -516,13 +516,13 @@ export function createLodestarMetrics(
         help: "Total number of processed blocks successes in UnknownBlockSync",
         labelNames: ["type"],
       }),
-      elappsedTimeTillProcessed: register.gauge<"type">({
-        name: "lodestar_sync_unknown_block_elappsed_time_till_processed",
+      elapsedTimeTillProcessed: register.histogram<"type">({
+        name: "lodestar_sync_unknown_block_elapsed_time_till_processed_seconds",
         help: "Duration from received time until the block is processed",
         labelNames: ["type"],
       }),
-      slotTimeTillProcessed: register.gauge<"type">({
-        name: "lodestar_sync_unknown_block_slot_time_till_processed",
+      slotTimeTillProcessed: register.histogram<"type">({
+        name: "lodestar_sync_unknown_block_slot_time_till_processed_seconds",
         help: "Duration from slot time until the block is processed",
         labelNames: ["type"],
       }),

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -376,11 +376,6 @@ export function createLodestarMetrics(
       help: "Time to process a single block in seconds",
       buckets: [0.1, 1, 10],
     }),
-    stfnElapsedTimeTillProcessed: register.histogram({
-      name: "lodestar_stfn_elapsed_time_until_processed_seconds",
-      help: "Duration from slot time until block is processed in seconds",
-      buckets: [0.1, 1, 10],
-    }),
 
     // BLS verifier thread pool and queue
 
@@ -563,6 +558,12 @@ export function createLodestarMetrics(
       name: "lodestar_gossip_block_elapsed_time_till_become_head",
       help: "Time elappsed between block slot time and the time block becomes head",
       buckets: [0.5, 1, 2, 4, 6, 12],
+    }),
+
+    elapsedTimeTillProcessed: register.histogram({
+      name: "lodestar_elapsed_time_until_processed_seconds",
+      help: "Duration from slot time until block is processed in seconds",
+      buckets: [0.1, 1, 10],
     }),
 
     backfillSync: {

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -496,39 +496,33 @@ export function createLodestarMetrics(
         help: "Total number of unknownBlockParent events or requests",
         labelNames: ["type"],
       }),
-      pendingBlocks: register.gauge<"type">({
+      pendingBlocks: register.gauge({
         name: "lodestar_sync_unknown_block_pending_blocks_size",
         help: "Current size of UnknownBlockSync pending blocks cache",
-        labelNames: ["type"],
       }),
-      knownBadBlocks: register.gauge<"type">({
+      knownBadBlocks: register.gauge({
         name: "lodestar_sync_unknown_block_known_bad_blocks_size",
         help: "Current size of UnknownBlockSync known bad blocks cache",
-        labelNames: ["type"],
       }),
-      processedBlocksSuccess: register.gauge<"type">({
+      processedBlocksSuccess: register.gauge({
         name: "lodestar_sync_unknown_block_processed_blocks_success_total",
         help: "Total number of processed blocks successes in UnknownBlockSync",
-        labelNames: ["type"],
       }),
-      downloadTime: register.histogram<"type">({
+      downloadTime: register.histogram({
         name: "lodestar_sync_unknown_block_download_time_seconds",
         help: "Duration from received time until the block is downloaded",
-        labelNames: ["type"],
       }),
       processedBlocksError: register.gauge({
         name: "lodestar_sync_unknown_block_processed_blocks_error_total",
         help: "Total number of processed blocks errors in UnknownBlockSync",
       }),
-      downloadedBlocksSuccess: register.gauge<"type">({
+      downloadedBlocksSuccess: register.gauge({
         name: "lodestar_sync_unknown_block_downloaded_blocks_success_total",
         help: "Total number of downloaded blocks successes in UnknownBlockSync",
-        labelNames: ["type"],
       }),
-      downloadedBlocksError: register.gauge<"type">({
+      downloadedBlocksError: register.gauge({
         name: "lodestar_sync_unknown_block_downloaded_blocks_error_total",
         help: "Total number of downloaded blocks errors in UnknownBlockSync",
-        labelNames: ["type"],
       }),
       removedBlocks: register.gauge({
         name: "lodestar_sync_unknown_block_removed_blocks_total",

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -516,11 +516,6 @@ export function createLodestarMetrics(
         help: "Duration from received time until the block is downloaded",
         labelNames: ["type"],
       }),
-      slotTimeTillProcessed: register.histogram<"type">({
-        name: "lodestar_sync_unknown_block_slot_time_till_processed_seconds",
-        help: "Duration from slot time until the block is processed",
-        labelNames: ["type"],
-      }),
       processedBlocksError: register.gauge({
         name: "lodestar_sync_unknown_block_processed_blocks_error_total",
         help: "Total number of processed blocks errors in UnknownBlockSync",
@@ -560,10 +555,11 @@ export function createLodestarMetrics(
       buckets: [0.5, 1, 2, 4, 6, 12],
     }),
 
-    elapsedTimeTillProcessed: register.histogram({
+    elapsedTimeTillProcessed: register.histogram<"source">({
       name: "lodestar_elapsed_time_until_processed_seconds",
       help: "Duration from slot time until block is processed in seconds",
       buckets: [0.1, 1, 10],
+      labelNames: ["source"],
     }),
 
     backfillSync: {

--- a/packages/lodestar/src/network/events.ts
+++ b/packages/lodestar/src/network/events.ts
@@ -1,7 +1,7 @@
 import {EventEmitter} from "events";
 import PeerId from "peer-id";
 import StrictEventEmitter from "strict-event-emitter-types";
-import {allForks, phase0} from "@chainsafe/lodestar-types";
+import {allForks, phase0, RootHex} from "@chainsafe/lodestar-types";
 import {RequestTypedContainer} from "./reqresp";
 
 export enum NetworkEvent {
@@ -13,6 +13,7 @@ export enum NetworkEvent {
   gossipHeartbeat = "gossipsub.heartbeat",
   reqRespRequest = "req-resp.request",
   unknownBlockParent = "unknownBlockParent",
+  unknownBlock = "unknownBlock",
 }
 
 export type NetworkEvents = {
@@ -20,6 +21,7 @@ export type NetworkEvents = {
   [NetworkEvent.peerDisconnected]: (peer: PeerId) => void;
   [NetworkEvent.reqRespRequest]: (request: RequestTypedContainer, peer: PeerId) => void;
   [NetworkEvent.unknownBlockParent]: (signedBlock: allForks.SignedBeaconBlock, peerIdStr: string) => void;
+  [NetworkEvent.unknownBlock]: (rootHex: RootHex, peerIdStr: string) => void;
 };
 
 export type INetworkEventBus = StrictEventEmitter<EventEmitter, NetworkEvents>;

--- a/packages/lodestar/src/network/gossip/handlers/index.ts
+++ b/packages/lodestar/src/network/gossip/handlers/index.ts
@@ -29,6 +29,7 @@ import {
 import {INetwork} from "../../interface";
 import {NetworkEvent} from "../../events";
 import {PeerAction} from "../../peers";
+import {BlockSource} from "../../../chain/blocks/types";
 
 /**
  * Gossip handler options as part of network options
@@ -120,7 +121,12 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
       // See https://github.com/ChainSafe/lodestar/issues/3792
       // it's possible that the block is found by unknown block root attestations
       chain
-        .processBlock(signedBlock, {validProposerSignature: true, blsVerifyOnMainThread: true, ignoreIfKnown: true})
+        .processBlock(signedBlock, {
+          validProposerSignature: true,
+          blsVerifyOnMainThread: true,
+          ignoreIfKnown: true,
+          source: BlockSource.GOSSIP,
+        })
         .then(() => {
           // Returns the delay between the start of `block.slot` and `current time`
           const delaySec = chain.clock.secFromSlot(slot);

--- a/packages/lodestar/src/network/interface.ts
+++ b/packages/lodestar/src/network/interface.ts
@@ -31,6 +31,7 @@ export interface INetwork {
   getEnr(): ENR | undefined;
   getConnectionsByPeer(): Map<string, Connection[]>;
   getConnectedPeers(): PeerId[];
+  getSyncedPeers(): PeerId[];
   hasSomeConnectedPeer(): boolean;
   /** Subscribe, search peers, join long-lived attnets */
   prepareBeaconCommitteeSubnet(subscriptions: CommitteeSubscription[]): void;

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -181,6 +181,10 @@ export class Network implements INetwork {
     return this.peerManager.getConnectedPeerIds();
   }
 
+  getSyncedPeers(): PeerId[] {
+    return this.peerManager.getSyncedPeers();
+  }
+
   hasSomeConnectedPeer(): boolean {
     return this.peerManager.hasSomeConnectedPeer();
   }

--- a/packages/lodestar/src/network/peers/peersData.ts
+++ b/packages/lodestar/src/network/peers/peersData.ts
@@ -22,6 +22,9 @@ export type PeerData = {
   agentVersion: string | null;
   agentClient: ClientKind | null;
   encodingPreference: Encoding | null;
+  // similar to our sync,
+  // a peer is considered synced if its head >= currentSlot - SLOTS_PER_EPOCH
+  isSynced: boolean;
 };
 
 /**

--- a/packages/lodestar/src/sync/interface.ts
+++ b/packages/lodestar/src/sync/interface.ts
@@ -80,6 +80,8 @@ export type PendingBlock = {
   | {type: PendingBlockType.UNKNOWN_BLOCK}
 );
 
+export type UnknownParentPendingBlock = PendingBlock & {type: PendingBlockType.UNKNOWN_PARENT};
+
 export enum PendingBlockStatus {
   pending = "pending",
   fetching = "fetching",

--- a/packages/lodestar/src/sync/interface.ts
+++ b/packages/lodestar/src/sync/interface.ts
@@ -2,6 +2,7 @@ import {ILogger} from "@chainsafe/lodestar-utils";
 import {allForks, RootHex, Slot, phase0} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {routes} from "@chainsafe/lodestar-api";
+import PeerId from "peer-id";
 import {INetwork} from "../network";
 import {IBeaconChain} from "../chain";
 import {IMetrics} from "../metrics";
@@ -58,14 +59,27 @@ export interface ISyncModules {
   wsCheckpoint?: phase0.Checkpoint;
 }
 
+export enum PendingBlockType {
+  UNKNOWN_BLOCK = "UNKNOWN_BLOCK",
+  UNKNOWN_PARENT = "UNKNOWN_PARENT",
+}
+
 export type PendingBlock = {
   blockRootHex: RootHex;
-  parentBlockRootHex: RootHex;
-  signedBlock: allForks.SignedBeaconBlock;
   peerIdStrs: Set<string>;
   status: PendingBlockStatus;
   downloadAttempts: number;
-};
+  lastQueriedTimeByPeer: Map<PeerId, number>;
+  receivedTimeSec: number;
+} & (
+  | {
+      type: PendingBlockType.UNKNOWN_PARENT;
+      parentBlockRootHex: RootHex;
+      signedBlock: allForks.SignedBeaconBlock;
+    }
+  | {type: PendingBlockType.UNKNOWN_BLOCK}
+);
+
 export enum PendingBlockStatus {
   pending = "pending",
   fetching = "fetching",

--- a/packages/lodestar/src/sync/interface.ts
+++ b/packages/lodestar/src/sync/interface.ts
@@ -60,30 +60,33 @@ export interface ISyncModules {
 }
 
 export enum PendingBlockType {
-  UNKNOWN_BLOCK = "UNKNOWN_BLOCK",
-  UNKNOWN_PARENT = "UNKNOWN_PARENT",
+  UNKNOWN_BLOCK = "unknown_block",
+  UNKNOWN_PARENT = "unknown_parent",
 }
 
-export type PendingBlock = {
+export enum PendingBlockStatus {
+  toDownload = "toDownload",
+  toProcess = "toProcess",
+}
+
+type PendingBlockMetadata = {
   blockRootHex: RootHex;
   peerIdStrs: Set<string>;
-  status: PendingBlockStatus;
   downloadAttempts: number;
   lastQueriedTimeByPeer: Map<PeerId, number>;
   receivedTimeSec: number;
-} & (
-  | {
-      type: PendingBlockType.UNKNOWN_PARENT;
-      parentBlockRootHex: RootHex;
-      signedBlock: allForks.SignedBeaconBlock;
-    }
-  | {type: PendingBlockType.UNKNOWN_BLOCK}
-);
+};
 
-export type UnknownParentPendingBlock = PendingBlock & {type: PendingBlockType.UNKNOWN_PARENT};
+export type PendingBlockToDownload = PendingBlockMetadata & {
+  status: PendingBlockStatus.toDownload;
+  processing: boolean;
+};
 
-export enum PendingBlockStatus {
-  pending = "pending",
-  fetching = "fetching",
-  processing = "processing",
-}
+export type PendingBlockToProcess = PendingBlockMetadata & {
+  status: PendingBlockStatus.toProcess;
+  processing: boolean;
+  parentBlockRootHex: RootHex;
+  signedBlock: allForks.SignedBeaconBlock;
+};
+
+export type PendingBlock = PendingBlockToDownload | PendingBlockToProcess;

--- a/packages/lodestar/src/sync/range/range.ts
+++ b/packages/lodestar/src/sync/range/range.ts
@@ -12,6 +12,7 @@ import {RangeSyncType, getRangeSyncType, rangeSyncTypes} from "../utils/remoteSy
 import {updateChains} from "./utils";
 import {ChainTarget, SyncChainFns, SyncChain, SyncChainOpts, SyncChainDebugState} from "./chain";
 import {PartiallyVerifiedBlockFlags} from "../../chain/blocks";
+import {BlockSource} from "../../chain/blocks/types";
 
 export enum RangeSyncEvent {
   completedChain = "RangeSync-completedChain",
@@ -200,7 +201,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
       // Ignore WOULD_REVERT_FINALIZED_SLOT error, continue with the next block in chain segment
       ignoreIfFinalized: true,
       // We won't attest to this block so it's okay to ignore a SYNCING message from execution layer
-      fromRangeSync: true,
+      source: BlockSource.RANGE_SYNC,
       // when this runs, syncing is the most important thing and gossip is not likely to run
       // so we can utilize worker threads to verify signatures
       blsVerifyOnMainThread: false,

--- a/packages/lodestar/src/sync/unknownBlock.ts
+++ b/packages/lodestar/src/sync/unknownBlock.ts
@@ -204,7 +204,7 @@ export class UnknownBlockSync {
     if (res.signedBlock !== undefined) {
       this.metrics?.syncUnknownBlock.downloadedBlocksSuccess.inc();
       const {signedBlock, peerIdStr} = res;
-      this.logger.verbose("Successfully download unknown block", logCtx);
+      this.logger.verbose("Successfully download unknown block", {...logCtx, slot: res.signedBlock.message.slot});
       this.metrics?.syncUnknownBlock.downloadTime.observe(downloadSec);
       if (this.chain.forkChoice.hasBlock(signedBlock.message.parentRoot)) {
         // Bingo! Process block. Add to pending blocks anyway for recycle the cache that prevents duplicate processing
@@ -266,6 +266,7 @@ export class UnknownBlockSync {
       this.metrics?.syncUnknownBlock.processedBlocksSuccess.inc();
       this.logger.verbose("Fetched and processed block", {
         root: prettyBytes(blockRootHex),
+        slot: signedBlock.message.slot,
         sinceSlot: this.chain.clock.secFromSlot(signedBlock.message.slot),
         downloadAttempts: pendingBlock.downloadAttempts,
       });

--- a/packages/lodestar/src/sync/utils/pendingBlocksTree.ts
+++ b/packages/lodestar/src/sync/utils/pendingBlocksTree.ts
@@ -1,7 +1,7 @@
 import {RootHex} from "@chainsafe/lodestar-types";
 import {PendingBlockType} from "..";
 import {MapDef} from "../../util/map";
-import {PendingBlock, PendingBlockStatus} from "../interface";
+import {PendingBlock, PendingBlockStatus, UnknownParentPendingBlock} from "../interface";
 
 export function getAllDescendantBlocks(blockRootHex: RootHex, blocks: Map<RootHex, PendingBlock>): PendingBlock[] {
   // Do one pass over all blocks to index by parent
@@ -35,8 +35,11 @@ function addToDescendantBlocks(
 /**
  * Return UNKNOWN_PARENT pending block with the parent hex blockRootHex.
  */
-export function getDescendantBlocks(blockRootHex: RootHex, blocks: Map<RootHex, PendingBlock>): PendingBlock[] {
-  const descendantBlocks: PendingBlock[] = [];
+export function getDescendantBlocks(
+  blockRootHex: RootHex,
+  blocks: Map<RootHex, PendingBlock>
+): UnknownParentPendingBlock[] {
+  const descendantBlocks: UnknownParentPendingBlock[] = [];
 
   for (const block of blocks.values()) {
     if (block.type === PendingBlockType.UNKNOWN_PARENT && block.parentBlockRootHex === blockRootHex) {

--- a/packages/lodestar/src/sync/utils/pendingBlocksTree.ts
+++ b/packages/lodestar/src/sync/utils/pendingBlocksTree.ts
@@ -32,7 +32,7 @@ function addToDescendantBlocks(
 }
 
 /**
- * Return UNKNOWN_PARENT pending block with the parent hex blockRootHex.
+ * Return toProcess blocks with the parent hex blockRootHex.
  */
 export function getDescendantBlocks(
   blockRootHex: RootHex,
@@ -50,11 +50,9 @@ export function getDescendantBlocks(
 }
 
 /**
- * Get pending blocks that do not have a parent. This includes pending blocks:
- * + UNKNOWN_BLOCK
- * + UNKNOWN_PARENT: parent block is not known
+ * Get blocks to download
  */
-export function getLowestPendingUnknownParents(blocks: Map<RootHex, PendingBlock>): PendingBlockToDownload[] {
+export function getBlocksToDownload(blocks: Map<RootHex, PendingBlock>): PendingBlockToDownload[] {
   const blocksToFetch: PendingBlockToDownload[] = [];
 
   for (const block of blocks.values()) {

--- a/packages/lodestar/src/util/wrapError.ts
+++ b/packages/lodestar/src/util/wrapError.ts
@@ -1,4 +1,4 @@
-type Result<T> = {err: null; result: T} | {err: Error};
+export type Result<T> = {err: null; result: T} | {err: Error};
 
 /**
  * Wraps a promise to return either an error or result

--- a/packages/lodestar/test/e2e/sync/unknownBlockSync.test.ts
+++ b/packages/lodestar/test/e2e/sync/unknownBlockSync.test.ts
@@ -11,6 +11,7 @@ import {fromHexString} from "@chainsafe/ssz";
 import {TimestampFormatCode} from "@chainsafe/lodestar-utils";
 import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {BlockError, BlockErrorCode} from "../../../src/chain/errors";
+import {BlockSource} from "../../../src/chain/blocks/types";
 
 describe("sync / unknown block sync", function () {
   const validatorCount = 8;
@@ -91,7 +92,7 @@ describe("sync / unknown block sync", function () {
     );
 
     await connect(bn2.network as Network, bn.network.peerId, bn.network.localMultiaddrs);
-    await bn2.chain.processBlock(head).catch((e) => {
+    await bn2.chain.processBlock(head, {source: BlockSource.UNKNOWN_BLOCK_SYNC}).catch((e) => {
       if (e instanceof BlockError && e.type.code === BlockErrorCode.PARENT_UNKNOWN) {
         // Expected
         bn2.network.events.emit(NetworkEvent.unknownBlockParent, head, bn2.network.peerId.toB58String());

--- a/packages/lodestar/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/lodestar/test/perf/chain/verifyImportBlocks.test.ts
@@ -14,6 +14,7 @@ import {testLogger} from "../../utils/logger";
 import {linspace} from "../../../src/util/numpy";
 import {BeaconDb} from "../../../src";
 import {LevelDbController} from "@chainsafe/lodestar-db";
+import {BlockSource} from "../../../src/chain/blocks/types";
 
 // Define this params in `packages/beacon-state-transition/test/perf/params.ts`
 // to trigger Github actions CI cache
@@ -105,7 +106,7 @@ describe("verify+import blocks - range sync perf test", () => {
         // Ignore WOULD_REVERT_FINALIZED_SLOT error, continue with the next block in chain segment
         ignoreIfFinalized: true,
         // We won't attest to this block so it's okay to ignore a SYNCING message from execution layer
-        fromRangeSync: true,
+        source: BlockSource.RANGE_SYNC,
         // when this runs, syncing is the most important thing and gossip is not likely to run
         // so we can utilize worker threads to verify signatures
         blsVerifyOnMainThread: false,

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/publishBlock.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/publishBlock.test.ts
@@ -8,6 +8,7 @@ import {generateEmptySignedBlock} from "../../../../../utils/block";
 import {allForks} from "@chainsafe/lodestar-types";
 import {BeaconSync} from "../../../../../../src/sync";
 import {setupApiImplTestServer, ApiImplTestModules} from "../../index.test";
+import {BlockSource} from "../../../../../../src/chain/blocks/types";
 
 use(chaiAsPromised);
 
@@ -43,7 +44,7 @@ describe("api - beacon - publishBlock", function () {
 
     syncStub.isSynced.returns(true);
     await expect(blockApi.publishBlock(block)).to.be.fulfilled;
-    expect(chainStub.processBlock.calledOnceWith(block)).to.be.true;
+    expect(chainStub.processBlock.calledOnceWith(block, {source: BlockSource.API})).to.be.true;
     expect(gossipStub.publishBeaconBlock.calledOnceWith(block)).to.be.true;
   });
 });

--- a/packages/lodestar/test/unit/api/impl/events/events.test.ts
+++ b/packages/lodestar/test/unit/api/impl/events/events.test.ts
@@ -9,6 +9,7 @@ import {generateProtoBlock, generateEmptySignedBlock, generateSignedBlock} from 
 import {generateAttestation, generateEmptySignedVoluntaryExit} from "../../../../utils/attestation";
 import {generateCachedState} from "../../../../utils/state";
 import {StateContextCache} from "../../../../../src/chain/stateCache";
+import {BlockSource} from "../../../../../src/chain/blocks/types";
 
 describe("Events api impl", function () {
   describe("beacon event stream", function () {
@@ -67,7 +68,7 @@ describe("Events api impl", function () {
       const events = getEvents([routes.events.EventType.block]);
 
       const block = generateSignedBlock();
-      chainEventEmmitter.emit(ChainEvent.block, block, null as any);
+      chainEventEmmitter.emit(ChainEvent.block, block, null as any, BlockSource.GOSSIP);
 
       expect(events).to.have.length(1, "Wrong num of received events");
       expect(events[0].type).to.equal(routes.events.EventType.block);
@@ -91,7 +92,7 @@ describe("Events api impl", function () {
       const exit = generateEmptySignedVoluntaryExit();
       const block = generateEmptySignedBlock();
       block.message.body.voluntaryExits.push(exit);
-      chainEventEmmitter.emit(ChainEvent.block, block, null as any);
+      chainEventEmmitter.emit(ChainEvent.block, block, null as any, BlockSource.GOSSIP);
 
       expect(events).to.have.length(1, "Wrong num of received events");
       expect(events[0].type).to.equal(routes.events.EventType.voluntaryExit);

--- a/packages/lodestar/test/unit/chain/blocks/verifyBlock.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/verifyBlock.test.ts
@@ -8,6 +8,7 @@ import {LocalClock} from "../../../../src/chain/clock";
 import {BlockErrorCode} from "../../../../src/chain/errors";
 import {allForks, ssz} from "@chainsafe/lodestar-types";
 import {expectThrowsLodestarError} from "../../../utils/errors";
+import {BlockSource} from "../../../../src/chain/blocks/types";
 
 describe("chain / blocks / verifyBlock", function () {
   let forkChoice: SinonStubbedInstance<ForkChoice>;
@@ -30,29 +31,41 @@ describe("chain / blocks / verifyBlock", function () {
 
   it("PARENT_UNKNOWN", function () {
     forkChoice.getBlockHex.returns(null);
-    expectThrowsLodestarError(() => verifyBlockSanityChecks(modules, {block}), BlockErrorCode.PARENT_UNKNOWN);
+    expectThrowsLodestarError(
+      () => verifyBlockSanityChecks(modules, {block, source: BlockSource.GOSSIP}),
+      BlockErrorCode.PARENT_UNKNOWN
+    );
   });
 
   it("GENESIS_BLOCK", function () {
     block.message.slot = 0;
-    expectThrowsLodestarError(() => verifyBlockSanityChecks(modules, {block}), BlockErrorCode.GENESIS_BLOCK);
+    expectThrowsLodestarError(
+      () => verifyBlockSanityChecks(modules, {block, source: BlockSource.GOSSIP}),
+      BlockErrorCode.GENESIS_BLOCK
+    );
   });
 
   it("ALREADY_KNOWN", function () {
     forkChoice.hasBlockHex.returns(true);
-    expectThrowsLodestarError(() => verifyBlockSanityChecks(modules, {block}), BlockErrorCode.ALREADY_KNOWN);
+    expectThrowsLodestarError(
+      () => verifyBlockSanityChecks(modules, {block, source: BlockSource.GOSSIP}),
+      BlockErrorCode.ALREADY_KNOWN
+    );
   });
 
   it("WOULD_REVERT_FINALIZED_SLOT", function () {
     forkChoice.getFinalizedCheckpoint.returns({epoch: 5, root: Buffer.alloc(32), rootHex: ""});
     expectThrowsLodestarError(
-      () => verifyBlockSanityChecks(modules, {block}),
+      () => verifyBlockSanityChecks(modules, {block, source: BlockSource.GOSSIP}),
       BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT
     );
   });
 
   it("FUTURE_SLOT", function () {
     block.message.slot = currentSlot + 1;
-    expectThrowsLodestarError(() => verifyBlockSanityChecks(modules, {block}), BlockErrorCode.FUTURE_SLOT);
+    expectThrowsLodestarError(
+      () => verifyBlockSanityChecks(modules, {block, source: BlockSource.GOSSIP}),
+      BlockErrorCode.FUTURE_SLOT
+    );
   });
 });

--- a/packages/lodestar/test/unit/sync/unknownBlock.test.ts
+++ b/packages/lodestar/test/unit/sync/unknownBlock.test.ts
@@ -47,7 +47,7 @@ describe("sync / UnknownBlockSync", () => {
 
     const network: Partial<INetwork> = {
       events: new NetworkEventBus(),
-      getConnectedPeers: () => [peer],
+      getSyncedPeers: () => [peer],
       reqResp: reqResp as IReqResp,
     };
 

--- a/packages/lodestar/test/unit/sync/unknownBlock.test.ts
+++ b/packages/lodestar/test/unit/sync/unknownBlock.test.ts
@@ -4,7 +4,7 @@ import {ssz} from "@chainsafe/lodestar-types";
 import {notNullish, sleep} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
 import {expect} from "chai";
-import {IBeaconChain} from "../../../src/chain";
+import {IBeaconChain, IBeaconClock} from "../../../src/chain";
 import {INetwork, IReqResp, NetworkEvent, NetworkEventBus} from "../../../src/network";
 import {UnknownBlockSync} from "../../../src/sync/unknownBlock";
 import {testLogger} from "../../utils/logger";
@@ -58,6 +58,7 @@ describe("sync / UnknownBlockSync", () => {
 
     const chain: Partial<IBeaconChain> = {
       forkChoice: forkChoice as IForkChoice,
+      clock: ({secFromSlot: () => 0} as Partial<IBeaconClock>) as IBeaconClock,
       processBlock: async (block) => {
         if (!forkChoice.hasBlock(block.message.parentRoot)) throw Error("Unknown parent");
         // Simluate adding the block to the forkchoice

--- a/packages/lodestar/test/unit/sync/utils/pendingBlocksTree.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/pendingBlocksTree.test.ts
@@ -1,6 +1,6 @@
 import {RootHex} from "@chainsafe/lodestar-types";
 import {expect} from "chai";
-import {PendingBlock, PendingBlockStatus} from "../../../../src/sync";
+import {PendingBlock, PendingBlockStatus, PendingBlockType} from "../../../../src/sync";
 import {
   getAllDescendantBlocks,
   getDescendantBlocks,
@@ -55,6 +55,8 @@ describe("sync / pendingBlocksTree", () => {
         blockRootHex: block.block,
         parentBlockRootHex: block.parent,
         status: PendingBlockStatus.pending,
+        // the tests in this file is not for UNKNOWN_BLOCK type
+        type: PendingBlockType.UNKNOWN_PARENT,
       } as PendingBlock);
     }
 

--- a/packages/lodestar/test/unit/sync/utils/pendingBlocksTree.test.ts
+++ b/packages/lodestar/test/unit/sync/utils/pendingBlocksTree.test.ts
@@ -54,9 +54,9 @@ describe("sync / pendingBlocksTree", () => {
       blocks.set(block.block, {
         blockRootHex: block.block,
         parentBlockRootHex: block.parent,
-        status: PendingBlockStatus.pending,
+        status: PendingBlockStatus.toProcess,
         // the tests in this file is not for UNKNOWN_BLOCK type
-        type: PendingBlockType.UNKNOWN_PARENT,
+        processing: false,
       } as PendingBlock);
     }
 


### PR DESCRIPTION
**Motivation**

+ a missed block is only searched when we receive `PARENT_UNKNOWN` block error while usually we receive unknown block root attestations at previous slot

**Description**

+ Trigger block search when receiving unknown block attestations
+ Refactor Unknown block sync 
  + support both `unknown_block` and `unknown_parent` error
  +  only query synced peers, a synced peer is peer with `head >= current_slot - SLOTS_PER_EPOCH` at the time of exchanging status
  + don't query a peer for unknown block root if we already do that in less than 0.5s
  + only increase block attempt if we have at least 1 attempt to find block root
+ at each slot, there's a race between gossip block and UnknownBlock sync triggered by an unknown block root attestation, whichever comes first is fine to us
+ add related metrics


Closes #3613
Closes #3217

**Test**
This is from a node with `subscribeAllSubnets` flag

<img width="1595" alt="Screen Shot 2022-01-21 at 14 07 22" src="https://user-images.githubusercontent.com/10568965/150482139-b7d64e76-4e52-4de1-b4b9-16c966dfc1b6.png">
