### PR TITLE
Allow genesis PoW block to reach TTD

### DIFF
--- a/packages/lodestar/src/eth1/eth1MergeBlockTracker.ts
+++ b/packages/lodestar/src/eth1/eth1MergeBlockTracker.ts
@@ -289,6 +289,12 @@ export class Eth1MergeBlockTracker {
     // Check if this block is already visited
 
     while (block.totalDifficulty >= this.config.TERMINAL_TOTAL_DIFFICULTY) {
+      if (block.parentHash === ZERO_HASH_HEX) {
+        // Allow genesis block to reach TTD
+        // https://github.com/ethereum/consensus-specs/pull/2719
+        return this.setTerminalPowBlock(block);
+      }
+
       const parent = await this.getPowBlock(block.parentHash);
       // Unknown parent
       if (!parent) {


### PR DESCRIPTION
**Motivation**
It was discovered that the current logic of discovering terminal block fails if the PoW chain starts from genesis > TTD as its parent doesn't exists. This was corrected as part of spec 1.1.6: https://github.com/ethereum/consensus-specs/pull/2719
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR updates the terminal block finding logic to allow accepting genesis block for TTD.
<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #3483, Partially #3410

