### PR TITLE
Alias cached beacon state

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,8 @@ jobs:
         run: ./lodestar --version
       - name: Check Types
         run: yarn run check-types
+      - name: README check
+        run: yarn run check-readme
       - name: Lint
         run: yarn lint
       - name: Unit tests
@@ -57,5 +59,3 @@ jobs:
         run: yarn test:e2e
         env:
           GOERLI_RPC_URL: ${{ secrets.GOERLI_RPC_URL!=0 && secrets.GOERLI_RPC_URL || env.GOERLI_RPC_DEFAULT_URL }}
-      - name: README check
-        run: yarn run check-readme

--- a/packages/beacon-state-transition/README.md
+++ b/packages/beacon-state-transition/README.md
@@ -13,12 +13,12 @@ The beacon state transition and state transition utilities
 ## Usage
 
 ```typescript
-import {BeaconStateCachedAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {generateEmptySignedBlock} from "../test/utils/block";
 import {generateState} from "../test/utils/state";
 
 // dummy test state
-const state: BeaconStateCachedAllForks = generateState() as BeaconStateCachedAllForks;
+const state: CachedBeaconStateAllForks = generateState() as CachedBeaconStateAllForks;
 
 // dummy test block
 const block: allForks.SignedBeaconBlock = generateEmptySignedBlock();

--- a/packages/beacon-state-transition/README.md
+++ b/packages/beacon-state-transition/README.md
@@ -13,16 +13,15 @@ The beacon state transition and state transition utilities
 ## Usage
 
 ```typescript
-
-import {CachedBeaconState, stateTransition} from "@chainsafe/lodestar-beacon-state-transition/src/allForks";
+import {BeaconStateCachedAllForks, stateTransition} from "@chainsafe/lodestar-beacon-state-transition/src/allForks";
 import {allForks} from "@chainsafe/lodestar-types";
 import {generateEmptySignedBlock} from "../test/utils/block";
 import {generateState} from "../test/utils/state";
 
 // dummy test state
-const state: CachedBeaconState<allForks.BeaconState> = generateState() as CachedBeaconState<allForks.BeaconState>;
+const state: BeaconStateCachedAllForks = generateState() as BeaconStateCachedAllForks;
 
-// dummy test block 
+// dummy test block
 const block: allForks.SignedBeaconBlock = generateEmptySignedBlock();
 
 let postStateContext: allForks.BeaconState;
@@ -31,7 +30,6 @@ try {
 } catch (e) {
   console.log(e);
 }
-
 ```
 
 ## License

--- a/packages/beacon-state-transition/README.md
+++ b/packages/beacon-state-transition/README.md
@@ -14,7 +14,6 @@ The beacon state transition and state transition utilities
 
 ```typescript
 import {BeaconStateCachedAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
-import {allForks} from "@chainsafe/lodestar-types";
 import {generateEmptySignedBlock} from "../test/utils/block";
 import {generateState} from "../test/utils/state";
 

--- a/packages/beacon-state-transition/README.md
+++ b/packages/beacon-state-transition/README.md
@@ -13,7 +13,7 @@ The beacon state transition and state transition utilities
 ## Usage
 
 ```typescript
-import {BeaconStateCachedAllForks, stateTransition} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {allForks} from "@chainsafe/lodestar-types";
 import {generateEmptySignedBlock} from "../test/utils/block";
 import {generateState} from "../test/utils/state";
@@ -26,7 +26,7 @@ const block: allForks.SignedBeaconBlock = generateEmptySignedBlock();
 
 let postStateContext: allForks.BeaconState;
 try {
-  postStateContext = stateTransition(state, block);
+  postStateContext = allForks.stateTransition(state, block);
 } catch (e) {
   console.log(e);
 }

--- a/packages/beacon-state-transition/README.md
+++ b/packages/beacon-state-transition/README.md
@@ -13,7 +13,7 @@ The beacon state transition and state transition utilities
 ## Usage
 
 ```typescript
-import {BeaconStateCachedAllForks, stateTransition} from "@chainsafe/lodestar-beacon-state-transition/src/allForks";
+import {BeaconStateCachedAllForks, stateTransition} from "@chainsafe/lodestar-beacon-state-transition";
 import {allForks} from "@chainsafe/lodestar-types";
 import {generateEmptySignedBlock} from "../test/utils/block";
 import {generateState} from "../test/utils/state";

--- a/packages/beacon-state-transition/src/allForks/block/initiateValidatorExit.ts
+++ b/packages/beacon-state-transition/src/allForks/block/initiateValidatorExit.ts
@@ -1,6 +1,6 @@
 import {FAR_FUTURE_EPOCH} from "@chainsafe/lodestar-params";
 import {phase0} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAllForks} from "../util";
+import {BeaconStateCachedAllForks} from "../../types";
 
 /**
  * Initiate the exit of the validator with index ``index``.

--- a/packages/beacon-state-transition/src/allForks/block/initiateValidatorExit.ts
+++ b/packages/beacon-state-transition/src/allForks/block/initiateValidatorExit.ts
@@ -1,6 +1,6 @@
 import {FAR_FUTURE_EPOCH} from "@chainsafe/lodestar-params";
-import {allForks, phase0} from "@chainsafe/lodestar-types";
-import {CachedBeaconState} from "../util";
+import {phase0} from "@chainsafe/lodestar-types";
+import {BeaconStateCachedAllForks} from "../util";
 
 /**
  * Initiate the exit of the validator with index ``index``.
@@ -22,10 +22,7 @@ import {CachedBeaconState} from "../util";
  * ```
  * Forcing consumers to pass the SubTree of `validator` directly mitigates this issue.
  */
-export function initiateValidatorExit(
-  state: CachedBeaconState<allForks.BeaconState>,
-  validator: phase0.Validator
-): void {
+export function initiateValidatorExit(state: BeaconStateCachedAllForks, validator: phase0.Validator): void {
   const {config, epochCtx} = state;
 
   // return if validator already initiated exit

--- a/packages/beacon-state-transition/src/allForks/block/initiateValidatorExit.ts
+++ b/packages/beacon-state-transition/src/allForks/block/initiateValidatorExit.ts
@@ -1,6 +1,6 @@
 import {FAR_FUTURE_EPOCH} from "@chainsafe/lodestar-params";
 import {phase0} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 
 /**
  * Initiate the exit of the validator with index ``index``.
@@ -22,7 +22,7 @@ import {BeaconStateCachedAllForks} from "../../types";
  * ```
  * Forcing consumers to pass the SubTree of `validator` directly mitigates this issue.
  */
-export function initiateValidatorExit(state: BeaconStateCachedAllForks, validator: phase0.Validator): void {
+export function initiateValidatorExit(state: CachedBeaconStateAllForks, validator: phase0.Validator): void {
   const {config, epochCtx} = state;
 
   // return if validator already initiated exit

--- a/packages/beacon-state-transition/src/allForks/block/isValidIndexedAttestation.ts
+++ b/packages/beacon-state-transition/src/allForks/block/isValidIndexedAttestation.ts
@@ -1,14 +1,14 @@
 import {readonlyValues} from "@chainsafe/ssz";
 import {MAX_VALIDATORS_PER_COMMITTEE} from "@chainsafe/lodestar-params";
 import {phase0} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 import {verifyIndexedAttestationSignature} from "../signatureSets";
 
 /**
  * Check if `indexedAttestation` has sorted and unique indices and a valid aggregate signature.
  */
 export function isValidIndexedAttestation(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   indexedAttestation: phase0.IndexedAttestation,
   verifySignature = true
 ): boolean {

--- a/packages/beacon-state-transition/src/allForks/block/isValidIndexedAttestation.ts
+++ b/packages/beacon-state-transition/src/allForks/block/isValidIndexedAttestation.ts
@@ -1,14 +1,14 @@
 import {readonlyValues} from "@chainsafe/ssz";
 import {MAX_VALIDATORS_PER_COMMITTEE} from "@chainsafe/lodestar-params";
-import {allForks, phase0} from "@chainsafe/lodestar-types";
-import {CachedBeaconState} from "../util";
+import {phase0} from "@chainsafe/lodestar-types";
+import {BeaconStateCachedAllForks} from "../util";
 import {verifyIndexedAttestationSignature} from "../signatureSets";
 
 /**
  * Check if `indexedAttestation` has sorted and unique indices and a valid aggregate signature.
  */
 export function isValidIndexedAttestation(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   indexedAttestation: phase0.IndexedAttestation,
   verifySignature = true
 ): boolean {

--- a/packages/beacon-state-transition/src/allForks/block/isValidIndexedAttestation.ts
+++ b/packages/beacon-state-transition/src/allForks/block/isValidIndexedAttestation.ts
@@ -1,7 +1,7 @@
 import {readonlyValues} from "@chainsafe/ssz";
 import {MAX_VALIDATORS_PER_COMMITTEE} from "@chainsafe/lodestar-params";
 import {phase0} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAllForks} from "../util";
+import {BeaconStateCachedAllForks} from "../../types";
 import {verifyIndexedAttestationSignature} from "../signatureSets";
 
 /**

--- a/packages/beacon-state-transition/src/allForks/block/processAttesterSlashing.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processAttesterSlashing.ts
@@ -1,8 +1,8 @@
-import {allForks, phase0} from "@chainsafe/lodestar-types";
+import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 
 import {isSlashableValidator, isSlashableAttestationData, getAttesterSlashableIndices} from "../../util";
-import {CachedBeaconState} from "../util";
+import {BeaconStateCachedAllForks} from "../util";
 import {isValidIndexedAttestation} from "./isValidIndexedAttestation";
 import {slashValidatorAllForks} from "./slashValidator";
 
@@ -14,11 +14,11 @@ import {slashValidatorAllForks} from "./slashValidator";
  */
 export function processAttesterSlashing(
   fork: ForkName,
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   attesterSlashing: phase0.AttesterSlashing,
   verifySignatures = true
 ): void {
-  assertValidAttesterSlashing(state as CachedBeaconState<allForks.BeaconState>, attesterSlashing, verifySignatures);
+  assertValidAttesterSlashing(state as BeaconStateCachedAllForks, attesterSlashing, verifySignatures);
 
   const intersectingIndices = getAttesterSlashableIndices(attesterSlashing);
 
@@ -38,7 +38,7 @@ export function processAttesterSlashing(
 }
 
 export function assertValidAttesterSlashing(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   attesterSlashing: phase0.AttesterSlashing,
   verifySignatures = true
 ): void {

--- a/packages/beacon-state-transition/src/allForks/block/processAttesterSlashing.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processAttesterSlashing.ts
@@ -2,7 +2,7 @@ import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 
 import {isSlashableValidator, isSlashableAttestationData, getAttesterSlashableIndices} from "../../util";
-import {BeaconStateCachedAllForks} from "../util";
+import {BeaconStateCachedAllForks} from "../../types";
 import {isValidIndexedAttestation} from "./isValidIndexedAttestation";
 import {slashValidatorAllForks} from "./slashValidator";
 

--- a/packages/beacon-state-transition/src/allForks/block/processAttesterSlashing.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processAttesterSlashing.ts
@@ -2,7 +2,7 @@ import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 
 import {isSlashableValidator, isSlashableAttestationData, getAttesterSlashableIndices} from "../../util";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 import {isValidIndexedAttestation} from "./isValidIndexedAttestation";
 import {slashValidatorAllForks} from "./slashValidator";
 
@@ -14,11 +14,11 @@ import {slashValidatorAllForks} from "./slashValidator";
  */
 export function processAttesterSlashing(
   fork: ForkName,
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   attesterSlashing: phase0.AttesterSlashing,
   verifySignatures = true
 ): void {
-  assertValidAttesterSlashing(state as BeaconStateCachedAllForks, attesterSlashing, verifySignatures);
+  assertValidAttesterSlashing(state as CachedBeaconStateAllForks, attesterSlashing, verifySignatures);
 
   const intersectingIndices = getAttesterSlashableIndices(attesterSlashing);
 
@@ -38,7 +38,7 @@ export function processAttesterSlashing(
 }
 
 export function assertValidAttesterSlashing(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   attesterSlashing: phase0.AttesterSlashing,
   verifySignatures = true
 ): void {

--- a/packages/beacon-state-transition/src/allForks/block/processBlockHeader.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processBlockHeader.ts
@@ -1,6 +1,6 @@
 import {toHexString} from "@chainsafe/ssz";
 import {allForks, ssz} from "@chainsafe/lodestar-types";
-import {CachedBeaconState} from "../util";
+import {BeaconStateCachedAllForks} from "../util";
 import {ZERO_HASH} from "../../constants";
 
 /**
@@ -9,7 +9,7 @@ import {ZERO_HASH} from "../../constants";
  * PERF: Fixed work independent of block contents.
  * NOTE: `block` body root MUST be pre-cached.
  */
-export function processBlockHeader(state: CachedBeaconState<allForks.BeaconState>, block: allForks.BeaconBlock): void {
+export function processBlockHeader(state: BeaconStateCachedAllForks, block: allForks.BeaconBlock): void {
   const slot = state.slot;
   // verify that the slots match
   if (block.slot !== slot) {

--- a/packages/beacon-state-transition/src/allForks/block/processBlockHeader.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processBlockHeader.ts
@@ -1,6 +1,6 @@
 import {toHexString} from "@chainsafe/ssz";
 import {allForks, ssz} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 import {ZERO_HASH} from "../../constants";
 
 /**
@@ -9,7 +9,7 @@ import {ZERO_HASH} from "../../constants";
  * PERF: Fixed work independent of block contents.
  * NOTE: `block` body root MUST be pre-cached.
  */
-export function processBlockHeader(state: BeaconStateCachedAllForks, block: allForks.BeaconBlock): void {
+export function processBlockHeader(state: CachedBeaconStateAllForks, block: allForks.BeaconBlock): void {
   const slot = state.slot;
   // verify that the slots match
   if (block.slot !== slot) {

--- a/packages/beacon-state-transition/src/allForks/block/processBlockHeader.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processBlockHeader.ts
@@ -1,6 +1,6 @@
 import {toHexString} from "@chainsafe/ssz";
 import {allForks, ssz} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAllForks} from "../util";
+import {BeaconStateCachedAllForks} from "../../types";
 import {ZERO_HASH} from "../../constants";
 
 /**

--- a/packages/beacon-state-transition/src/allForks/block/processDeposit.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processDeposit.ts
@@ -12,7 +12,7 @@ import {
 
 import {ZERO_HASH} from "../../constants";
 import {computeDomain, computeSigningRoot, increaseBalance} from "../../util";
-import {BeaconStateCachedAllForks, BeaconStateCachedAltair} from "../../types";
+import {CachedBeaconStateAllForks, CachedBeaconStateAltair} from "../../types";
 
 /**
  * Process a Deposit operation. Potentially adds a new validator to the registry. Mutates the validators and balances
@@ -20,7 +20,7 @@ import {BeaconStateCachedAllForks, BeaconStateCachedAltair} from "../../types";
  *
  * PERF: Work depends on number of Deposit per block. On regular networks the average is 0 / block.
  */
-export function processDeposit(fork: ForkName, state: BeaconStateCachedAllForks, deposit: phase0.Deposit): void {
+export function processDeposit(fork: ForkName, state: CachedBeaconStateAllForks, deposit: phase0.Deposit): void {
   const {config, validators, epochCtx} = state;
   // verify the merkle branch
   if (
@@ -83,7 +83,7 @@ export function processDeposit(fork: ForkName, state: BeaconStateCachedAllForks,
 
     // Forks: altair, bellatrix, and future
     if (fork !== ForkName.phase0) {
-      (state as BeaconStateCachedAltair).inactivityScores.push(0);
+      (state as CachedBeaconStateAltair).inactivityScores.push(0);
     }
 
     // now that there is a new validator, update the epoch context with the new pubkey

--- a/packages/beacon-state-transition/src/allForks/block/processDeposit.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processDeposit.ts
@@ -12,7 +12,7 @@ import {
 
 import {ZERO_HASH} from "../../constants";
 import {computeDomain, computeSigningRoot, increaseBalance} from "../../util";
-import {BeaconStateCachedAllForks, BeaconStateCachedAltair} from "../../allForks/util";
+import {BeaconStateCachedAllForks, BeaconStateCachedAltair} from "../../types";
 
 /**
  * Process a Deposit operation. Potentially adds a new validator to the registry. Mutates the validators and balances

--- a/packages/beacon-state-transition/src/allForks/block/processDeposit.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processDeposit.ts
@@ -1,5 +1,5 @@
 import bls, {CoordType} from "@chainsafe/bls";
-import {allForks, altair, phase0, ssz} from "@chainsafe/lodestar-types";
+import {phase0, ssz} from "@chainsafe/lodestar-types";
 import {verifyMerkleBranch} from "@chainsafe/lodestar-utils";
 import {
   DEPOSIT_CONTRACT_TREE_DEPTH,
@@ -12,7 +12,7 @@ import {
 
 import {ZERO_HASH} from "../../constants";
 import {computeDomain, computeSigningRoot, increaseBalance} from "../../util";
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedAllForks, BeaconStateCachedAltair} from "../../allForks/util";
 
 /**
  * Process a Deposit operation. Potentially adds a new validator to the registry. Mutates the validators and balances
@@ -20,11 +20,7 @@ import {CachedBeaconState} from "../../allForks/util";
  *
  * PERF: Work depends on number of Deposit per block. On regular networks the average is 0 / block.
  */
-export function processDeposit(
-  fork: ForkName,
-  state: CachedBeaconState<allForks.BeaconState>,
-  deposit: phase0.Deposit
-): void {
+export function processDeposit(fork: ForkName, state: BeaconStateCachedAllForks, deposit: phase0.Deposit): void {
   const {config, validators, epochCtx} = state;
   // verify the merkle branch
   if (
@@ -87,7 +83,7 @@ export function processDeposit(
 
     // Forks: altair, bellatrix, and future
     if (fork !== ForkName.phase0) {
-      (state as CachedBeaconState<altair.BeaconState>).inactivityScores.push(0);
+      (state as BeaconStateCachedAltair).inactivityScores.push(0);
     }
 
     // now that there is a new validator, update the epoch context with the new pubkey

--- a/packages/beacon-state-transition/src/allForks/block/processEth1Data.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processEth1Data.ts
@@ -1,7 +1,7 @@
 import {EPOCHS_PER_ETH1_VOTING_PERIOD, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {allForks, phase0, ssz} from "@chainsafe/lodestar-types";
 import {readonlyValues} from "@chainsafe/ssz";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 
 /**
  * Store vote counts for every eth1 block that has votes; if any eth1 block wins majority support within a 1024-slot
@@ -11,7 +11,7 @@ import {BeaconStateCachedAllForks} from "../../types";
  * - Best case: Vote is already decided, zero work. See getNewEth1Data conditions
  * - Worst case: 1023 votes and no majority vote yet.
  */
-export function processEth1Data(state: BeaconStateCachedAllForks, body: allForks.BeaconBlockBody): void {
+export function processEth1Data(state: CachedBeaconStateAllForks, body: allForks.BeaconBlockBody): void {
   const newEth1Data = getNewEth1Data(state, body.eth1Data);
   if (newEth1Data) {
     state.eth1Data = body.eth1Data;
@@ -24,7 +24,7 @@ export function processEth1Data(state: BeaconStateCachedAllForks, body: allForks
  * Returns `newEth1Data` if adding the given `eth1Data` to `state.eth1DataVotes` would
  * result in a change to `state.eth1Data`.
  */
-export function getNewEth1Data(state: BeaconStateCachedAllForks, newEth1Data: phase0.Eth1Data): phase0.Eth1Data | null {
+export function getNewEth1Data(state: CachedBeaconStateAllForks, newEth1Data: phase0.Eth1Data): phase0.Eth1Data | null {
   const SLOTS_PER_ETH1_VOTING_PERIOD = EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH;
 
   // If there are not more than 50% votes, then we do not have to count to find a winner.

--- a/packages/beacon-state-transition/src/allForks/block/processEth1Data.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processEth1Data.ts
@@ -1,8 +1,7 @@
 import {EPOCHS_PER_ETH1_VOTING_PERIOD, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {allForks, phase0, ssz} from "@chainsafe/lodestar-types";
 import {readonlyValues} from "@chainsafe/ssz";
-
-import {CachedBeaconState} from "../util";
+import {BeaconStateCachedAllForks} from "../util";
 
 /**
  * Store vote counts for every eth1 block that has votes; if any eth1 block wins majority support within a 1024-slot
@@ -12,7 +11,7 @@ import {CachedBeaconState} from "../util";
  * - Best case: Vote is already decided, zero work. See getNewEth1Data conditions
  * - Worst case: 1023 votes and no majority vote yet.
  */
-export function processEth1Data(state: CachedBeaconState<allForks.BeaconState>, body: allForks.BeaconBlockBody): void {
+export function processEth1Data(state: BeaconStateCachedAllForks, body: allForks.BeaconBlockBody): void {
   const newEth1Data = getNewEth1Data(state, body.eth1Data);
   if (newEth1Data) {
     state.eth1Data = body.eth1Data;
@@ -25,10 +24,7 @@ export function processEth1Data(state: CachedBeaconState<allForks.BeaconState>, 
  * Returns `newEth1Data` if adding the given `eth1Data` to `state.eth1DataVotes` would
  * result in a change to `state.eth1Data`.
  */
-export function getNewEth1Data(
-  state: CachedBeaconState<allForks.BeaconState>,
-  newEth1Data: phase0.Eth1Data
-): phase0.Eth1Data | null {
+export function getNewEth1Data(state: BeaconStateCachedAllForks, newEth1Data: phase0.Eth1Data): phase0.Eth1Data | null {
   const SLOTS_PER_ETH1_VOTING_PERIOD = EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH;
 
   // If there are not more than 50% votes, then we do not have to count to find a winner.

--- a/packages/beacon-state-transition/src/allForks/block/processEth1Data.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processEth1Data.ts
@@ -1,7 +1,7 @@
 import {EPOCHS_PER_ETH1_VOTING_PERIOD, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {allForks, phase0, ssz} from "@chainsafe/lodestar-types";
 import {readonlyValues} from "@chainsafe/ssz";
-import {BeaconStateCachedAllForks} from "../util";
+import {BeaconStateCachedAllForks} from "../../types";
 
 /**
  * Store vote counts for every eth1 block that has votes; if any eth1 block wins majority support within a 1024-slot

--- a/packages/beacon-state-transition/src/allForks/block/processProposerSlashing.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processProposerSlashing.ts
@@ -1,7 +1,7 @@
-import {allForks, phase0, ssz} from "@chainsafe/lodestar-types";
+import {phase0, ssz} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 import {isSlashableValidator} from "../../util";
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedAllForks} from "../../allForks/util";
 import {getProposerSlashingSignatureSets} from "../../allForks/signatureSets";
 import {slashValidatorAllForks} from "../../allForks/block/slashValidator";
 import {verifySignatureSet} from "../../util/signatureSets";
@@ -14,17 +14,17 @@ import {verifySignatureSet} from "../../util/signatureSets";
  */
 export function processProposerSlashing(
   fork: ForkName,
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   proposerSlashing: phase0.ProposerSlashing,
   verifySignatures = true
 ): void {
-  assertValidProposerSlashing(state as CachedBeaconState<allForks.BeaconState>, proposerSlashing, verifySignatures);
+  assertValidProposerSlashing(state as BeaconStateCachedAllForks, proposerSlashing, verifySignatures);
 
   slashValidatorAllForks(fork, state, proposerSlashing.signedHeader1.message.proposerIndex);
 }
 
 export function assertValidProposerSlashing(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   proposerSlashing: phase0.ProposerSlashing,
   verifySignatures = true
 ): void {
@@ -59,7 +59,7 @@ export function assertValidProposerSlashing(
   // verify signatures
   if (verifySignatures) {
     for (const [i, signatureSet] of getProposerSlashingSignatureSets(
-      state as CachedBeaconState<allForks.BeaconState>,
+      state as BeaconStateCachedAllForks,
       proposerSlashing
     ).entries()) {
       if (!verifySignatureSet(signatureSet)) {

--- a/packages/beacon-state-transition/src/allForks/block/processProposerSlashing.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processProposerSlashing.ts
@@ -1,7 +1,7 @@
 import {phase0, ssz} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 import {isSlashableValidator} from "../../util";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 import {getProposerSlashingSignatureSets} from "../../allForks/signatureSets";
 import {slashValidatorAllForks} from "../../allForks/block/slashValidator";
 import {verifySignatureSet} from "../../util/signatureSets";
@@ -14,17 +14,17 @@ import {verifySignatureSet} from "../../util/signatureSets";
  */
 export function processProposerSlashing(
   fork: ForkName,
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   proposerSlashing: phase0.ProposerSlashing,
   verifySignatures = true
 ): void {
-  assertValidProposerSlashing(state as BeaconStateCachedAllForks, proposerSlashing, verifySignatures);
+  assertValidProposerSlashing(state as CachedBeaconStateAllForks, proposerSlashing, verifySignatures);
 
   slashValidatorAllForks(fork, state, proposerSlashing.signedHeader1.message.proposerIndex);
 }
 
 export function assertValidProposerSlashing(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   proposerSlashing: phase0.ProposerSlashing,
   verifySignatures = true
 ): void {
@@ -59,7 +59,7 @@ export function assertValidProposerSlashing(
   // verify signatures
   if (verifySignatures) {
     for (const [i, signatureSet] of getProposerSlashingSignatureSets(
-      state as BeaconStateCachedAllForks,
+      state as CachedBeaconStateAllForks,
       proposerSlashing
     ).entries()) {
       if (!verifySignatureSet(signatureSet)) {

--- a/packages/beacon-state-transition/src/allForks/block/processProposerSlashing.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processProposerSlashing.ts
@@ -1,7 +1,7 @@
 import {phase0, ssz} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 import {isSlashableValidator} from "../../util";
-import {BeaconStateCachedAllForks} from "../../allForks/util";
+import {BeaconStateCachedAllForks} from "../../types";
 import {getProposerSlashingSignatureSets} from "../../allForks/signatureSets";
 import {slashValidatorAllForks} from "../../allForks/block/slashValidator";
 import {verifySignatureSet} from "../../util/signatureSets";

--- a/packages/beacon-state-transition/src/allForks/block/processRandao.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processRandao.ts
@@ -3,7 +3,7 @@ import {hash} from "@chainsafe/ssz";
 import {allForks} from "@chainsafe/lodestar-types";
 import {getRandaoMix} from "../../util";
 import {verifyRandaoSignature} from "../signatureSets";
-import {BeaconStateCachedAllForks} from "../util";
+import {BeaconStateCachedAllForks} from "../../types";
 import {EPOCHS_PER_HISTORICAL_VECTOR} from "@chainsafe/lodestar-params";
 
 /**

--- a/packages/beacon-state-transition/src/allForks/block/processRandao.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processRandao.ts
@@ -3,7 +3,7 @@ import {hash} from "@chainsafe/ssz";
 import {allForks} from "@chainsafe/lodestar-types";
 import {getRandaoMix} from "../../util";
 import {verifyRandaoSignature} from "../signatureSets";
-import {CachedBeaconState} from "../util";
+import {BeaconStateCachedAllForks} from "../util";
 import {EPOCHS_PER_HISTORICAL_VECTOR} from "@chainsafe/lodestar-params";
 
 /**
@@ -12,7 +12,7 @@ import {EPOCHS_PER_HISTORICAL_VECTOR} from "@chainsafe/lodestar-params";
  * PERF: Fixed work independent of block contents.
  */
 export function processRandao(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   block: allForks.BeaconBlock,
   verifySignature = true
 ): void {
@@ -22,7 +22,7 @@ export function processRandao(
 
   // verify RANDAO reveal
   if (verifySignature) {
-    if (!verifyRandaoSignature(state as CachedBeaconState<allForks.BeaconState>, block)) {
+    if (!verifyRandaoSignature(state as BeaconStateCachedAllForks, block)) {
       throw new Error("RANDAO reveal is an invalid signature");
     }
   }

--- a/packages/beacon-state-transition/src/allForks/block/processRandao.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processRandao.ts
@@ -3,7 +3,7 @@ import {hash} from "@chainsafe/ssz";
 import {allForks} from "@chainsafe/lodestar-types";
 import {getRandaoMix} from "../../util";
 import {verifyRandaoSignature} from "../signatureSets";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 import {EPOCHS_PER_HISTORICAL_VECTOR} from "@chainsafe/lodestar-params";
 
 /**
@@ -12,7 +12,7 @@ import {EPOCHS_PER_HISTORICAL_VECTOR} from "@chainsafe/lodestar-params";
  * PERF: Fixed work independent of block contents.
  */
 export function processRandao(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   block: allForks.BeaconBlock,
   verifySignature = true
 ): void {
@@ -22,7 +22,7 @@ export function processRandao(
 
   // verify RANDAO reveal
   if (verifySignature) {
-    if (!verifyRandaoSignature(state as BeaconStateCachedAllForks, block)) {
+    if (!verifyRandaoSignature(state as CachedBeaconStateAllForks, block)) {
       throw new Error("RANDAO reveal is an invalid signature");
     }
   }

--- a/packages/beacon-state-transition/src/allForks/block/processVoluntaryExit.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processVoluntaryExit.ts
@@ -1,7 +1,7 @@
 import {FAR_FUTURE_EPOCH} from "@chainsafe/lodestar-params";
 import {phase0} from "@chainsafe/lodestar-types";
 import {isActiveValidator} from "../../util";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 import {initiateValidatorExit} from "../../allForks/block";
 import {verifyVoluntaryExitSignature} from "../../allForks/signatureSets";
 
@@ -11,20 +11,20 @@ import {verifyVoluntaryExitSignature} from "../../allForks/signatureSets";
  * PERF: Work depends on number of VoluntaryExit per block. On regular networks the average is 0 / block.
  */
 export function processVoluntaryExitAllForks(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   signedVoluntaryExit: phase0.SignedVoluntaryExit,
   verifySignature = true
 ): void {
-  if (!isValidVoluntaryExit(state as BeaconStateCachedAllForks, signedVoluntaryExit, verifySignature)) {
+  if (!isValidVoluntaryExit(state as CachedBeaconStateAllForks, signedVoluntaryExit, verifySignature)) {
     throw Error("Invalid voluntary exit");
   }
 
   const validator = state.validators[signedVoluntaryExit.message.validatorIndex];
-  initiateValidatorExit(state as BeaconStateCachedAllForks, validator);
+  initiateValidatorExit(state as CachedBeaconStateAllForks, validator);
 }
 
 export function isValidVoluntaryExit(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   signedVoluntaryExit: phase0.SignedVoluntaryExit,
   verifySignature = true
 ): boolean {
@@ -43,6 +43,6 @@ export function isValidVoluntaryExit(
     // verify the validator had been active long enough
     currentEpoch >= validator.activationEpoch + config.SHARD_COMMITTEE_PERIOD &&
     // verify signature
-    (!verifySignature || verifyVoluntaryExitSignature(state as BeaconStateCachedAllForks, signedVoluntaryExit))
+    (!verifySignature || verifyVoluntaryExitSignature(state as CachedBeaconStateAllForks, signedVoluntaryExit))
   );
 }

--- a/packages/beacon-state-transition/src/allForks/block/processVoluntaryExit.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processVoluntaryExit.ts
@@ -1,7 +1,7 @@
 import {FAR_FUTURE_EPOCH} from "@chainsafe/lodestar-params";
-import {allForks, phase0} from "@chainsafe/lodestar-types";
+import {phase0} from "@chainsafe/lodestar-types";
 import {isActiveValidator} from "../../util";
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedAllForks} from "../../allForks/util";
 import {initiateValidatorExit} from "../../allForks/block";
 import {verifyVoluntaryExitSignature} from "../../allForks/signatureSets";
 
@@ -11,20 +11,20 @@ import {verifyVoluntaryExitSignature} from "../../allForks/signatureSets";
  * PERF: Work depends on number of VoluntaryExit per block. On regular networks the average is 0 / block.
  */
 export function processVoluntaryExitAllForks(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   signedVoluntaryExit: phase0.SignedVoluntaryExit,
   verifySignature = true
 ): void {
-  if (!isValidVoluntaryExit(state as CachedBeaconState<allForks.BeaconState>, signedVoluntaryExit, verifySignature)) {
+  if (!isValidVoluntaryExit(state as BeaconStateCachedAllForks, signedVoluntaryExit, verifySignature)) {
     throw Error("Invalid voluntary exit");
   }
 
   const validator = state.validators[signedVoluntaryExit.message.validatorIndex];
-  initiateValidatorExit(state as CachedBeaconState<allForks.BeaconState>, validator);
+  initiateValidatorExit(state as BeaconStateCachedAllForks, validator);
 }
 
 export function isValidVoluntaryExit(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   signedVoluntaryExit: phase0.SignedVoluntaryExit,
   verifySignature = true
 ): boolean {
@@ -43,7 +43,6 @@ export function isValidVoluntaryExit(
     // verify the validator had been active long enough
     currentEpoch >= validator.activationEpoch + config.SHARD_COMMITTEE_PERIOD &&
     // verify signature
-    (!verifySignature ||
-      verifyVoluntaryExitSignature(state as CachedBeaconState<allForks.BeaconState>, signedVoluntaryExit))
+    (!verifySignature || verifyVoluntaryExitSignature(state as BeaconStateCachedAllForks, signedVoluntaryExit))
   );
 }

--- a/packages/beacon-state-transition/src/allForks/block/processVoluntaryExit.ts
+++ b/packages/beacon-state-transition/src/allForks/block/processVoluntaryExit.ts
@@ -1,7 +1,7 @@
 import {FAR_FUTURE_EPOCH} from "@chainsafe/lodestar-params";
 import {phase0} from "@chainsafe/lodestar-types";
 import {isActiveValidator} from "../../util";
-import {BeaconStateCachedAllForks} from "../../allForks/util";
+import {BeaconStateCachedAllForks} from "../../types";
 import {initiateValidatorExit} from "../../allForks/block";
 import {verifyVoluntaryExitSignature} from "../../allForks/signatureSets";
 

--- a/packages/beacon-state-transition/src/allForks/block/slashValidator.ts
+++ b/packages/beacon-state-transition/src/allForks/block/slashValidator.ts
@@ -12,12 +12,12 @@ import {
 } from "@chainsafe/lodestar-params";
 
 import {decreaseBalance, increaseBalance} from "../../util";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 import {initiateValidatorExit} from "./initiateValidatorExit";
 
 export function slashValidatorAllForks(
   fork: ForkName,
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   slashedIndex: ValidatorIndex,
   whistleblowerIndex?: ValidatorIndex
 ): void {
@@ -26,7 +26,7 @@ export function slashValidatorAllForks(
   const validator = state.validators[slashedIndex];
 
   // TODO: Bellatrix initiateValidatorExit validators.update() with the one below
-  initiateValidatorExit(state as BeaconStateCachedAllForks, validator);
+  initiateValidatorExit(state as CachedBeaconStateAllForks, validator);
 
   validator.slashed = true;
   validator.withdrawableEpoch = Math.max(validator.withdrawableEpoch, epoch + EPOCHS_PER_SLASHINGS_VECTOR);

--- a/packages/beacon-state-transition/src/allForks/block/slashValidator.ts
+++ b/packages/beacon-state-transition/src/allForks/block/slashValidator.ts
@@ -1,4 +1,4 @@
-import {allForks, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {ValidatorIndex} from "@chainsafe/lodestar-types";
 import {
   EPOCHS_PER_SLASHINGS_VECTOR,
   ForkName,
@@ -12,12 +12,12 @@ import {
 } from "@chainsafe/lodestar-params";
 
 import {decreaseBalance, increaseBalance} from "../../util";
-import {CachedBeaconState} from "../util";
-import {initiateValidatorExit} from ".";
+import {BeaconStateCachedAllForks} from "../util";
+import {initiateValidatorExit} from "./initiateValidatorExit";
 
 export function slashValidatorAllForks(
   fork: ForkName,
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   slashedIndex: ValidatorIndex,
   whistleblowerIndex?: ValidatorIndex
 ): void {
@@ -26,7 +26,7 @@ export function slashValidatorAllForks(
   const validator = state.validators[slashedIndex];
 
   // TODO: Bellatrix initiateValidatorExit validators.update() with the one below
-  initiateValidatorExit(state as CachedBeaconState<allForks.BeaconState>, validator);
+  initiateValidatorExit(state as BeaconStateCachedAllForks, validator);
 
   validator.slashed = true;
   validator.withdrawableEpoch = Math.max(validator.withdrawableEpoch, epoch + EPOCHS_PER_SLASHINGS_VECTOR);

--- a/packages/beacon-state-transition/src/allForks/block/slashValidator.ts
+++ b/packages/beacon-state-transition/src/allForks/block/slashValidator.ts
@@ -12,7 +12,7 @@ import {
 } from "@chainsafe/lodestar-params";
 
 import {decreaseBalance, increaseBalance} from "../../util";
-import {BeaconStateCachedAllForks} from "../util";
+import {BeaconStateCachedAllForks} from "../../types";
 import {initiateValidatorExit} from "./initiateValidatorExit";
 
 export function slashValidatorAllForks(

--- a/packages/beacon-state-transition/src/allForks/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processEffectiveBalanceUpdates.ts
@@ -5,7 +5,7 @@ import {
   HYSTERESIS_UPWARD_MULTIPLIER,
   MAX_EFFECTIVE_BALANCE,
 } from "@chainsafe/lodestar-params";
-import {IEpochProcess, BeaconStateCachedAllForks} from "../util";
+import {IEpochProcess, BeaconStateCachedAllForks} from "../../types";
 
 /**
  * Update effective balances if validator.balance has changed enough

--- a/packages/beacon-state-transition/src/allForks/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processEffectiveBalanceUpdates.ts
@@ -5,7 +5,7 @@ import {
   HYSTERESIS_UPWARD_MULTIPLIER,
   MAX_EFFECTIVE_BALANCE,
 } from "@chainsafe/lodestar-params";
-import {IEpochProcess, BeaconStateCachedAllForks} from "../../types";
+import {IEpochProcess, CachedBeaconStateAllForks} from "../../types";
 
 /**
  * Update effective balances if validator.balance has changed enough
@@ -17,7 +17,7 @@ import {IEpochProcess, BeaconStateCachedAllForks} from "../../types";
  * - On normal mainnet conditions 0 validators change their effective balance
  * - In case of big innactivity event a medium portion of validators may have their effectiveBalance updated
  */
-export function processEffectiveBalanceUpdates(state: BeaconStateCachedAllForks, epochProcess: IEpochProcess): void {
+export function processEffectiveBalanceUpdates(state: CachedBeaconStateAllForks, epochProcess: IEpochProcess): void {
   const HYSTERESIS_INCREMENT = EFFECTIVE_BALANCE_INCREMENT / HYSTERESIS_QUOTIENT;
   const DOWNWARD_THRESHOLD = HYSTERESIS_INCREMENT * HYSTERESIS_DOWNWARD_MULTIPLIER;
   const UPWARD_THRESHOLD = HYSTERESIS_INCREMENT * HYSTERESIS_UPWARD_MULTIPLIER;

--- a/packages/beacon-state-transition/src/allForks/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processEffectiveBalanceUpdates.ts
@@ -5,8 +5,7 @@ import {
   HYSTERESIS_UPWARD_MULTIPLIER,
   MAX_EFFECTIVE_BALANCE,
 } from "@chainsafe/lodestar-params";
-import {allForks} from "@chainsafe/lodestar-types";
-import {IEpochProcess, CachedBeaconState} from "../util";
+import {IEpochProcess, BeaconStateCachedAllForks} from "../util";
 
 /**
  * Update effective balances if validator.balance has changed enough
@@ -18,10 +17,7 @@ import {IEpochProcess, CachedBeaconState} from "../util";
  * - On normal mainnet conditions 0 validators change their effective balance
  * - In case of big innactivity event a medium portion of validators may have their effectiveBalance updated
  */
-export function processEffectiveBalanceUpdates(
-  state: CachedBeaconState<allForks.BeaconState>,
-  epochProcess: IEpochProcess
-): void {
+export function processEffectiveBalanceUpdates(state: BeaconStateCachedAllForks, epochProcess: IEpochProcess): void {
   const HYSTERESIS_INCREMENT = EFFECTIVE_BALANCE_INCREMENT / HYSTERESIS_QUOTIENT;
   const DOWNWARD_THRESHOLD = HYSTERESIS_INCREMENT * HYSTERESIS_DOWNWARD_MULTIPLIER;
   const UPWARD_THRESHOLD = HYSTERESIS_INCREMENT * HYSTERESIS_UPWARD_MULTIPLIER;

--- a/packages/beacon-state-transition/src/allForks/epoch/processEth1DataReset.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processEth1DataReset.ts
@@ -1,14 +1,14 @@
 import {EPOCHS_PER_ETH1_VOTING_PERIOD} from "@chainsafe/lodestar-params";
 import {phase0} from "@chainsafe/lodestar-types";
 import {List} from "@chainsafe/ssz";
-import {IEpochProcess, BeaconStateCachedAllForks} from "../../types";
+import {IEpochProcess, CachedBeaconStateAllForks} from "../../types";
 
 /**
  * Reset eth1DataVotes tree every `EPOCHS_PER_ETH1_VOTING_PERIOD`.
  *
  * PERF: Almost no (constant) cost
  */
-export function processEth1DataReset(state: BeaconStateCachedAllForks, epochProcess: IEpochProcess): void {
+export function processEth1DataReset(state: CachedBeaconStateAllForks, epochProcess: IEpochProcess): void {
   const nextEpoch = epochProcess.currentEpoch + 1;
 
   // reset eth1 data votes

--- a/packages/beacon-state-transition/src/allForks/epoch/processEth1DataReset.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processEth1DataReset.ts
@@ -1,7 +1,7 @@
 import {EPOCHS_PER_ETH1_VOTING_PERIOD} from "@chainsafe/lodestar-params";
 import {phase0} from "@chainsafe/lodestar-types";
 import {List} from "@chainsafe/ssz";
-import {IEpochProcess, BeaconStateCachedAllForks} from "../util";
+import {IEpochProcess, BeaconStateCachedAllForks} from "../../types";
 
 /**
  * Reset eth1DataVotes tree every `EPOCHS_PER_ETH1_VOTING_PERIOD`.

--- a/packages/beacon-state-transition/src/allForks/epoch/processEth1DataReset.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processEth1DataReset.ts
@@ -1,17 +1,14 @@
 import {EPOCHS_PER_ETH1_VOTING_PERIOD} from "@chainsafe/lodestar-params";
-import {allForks, phase0} from "@chainsafe/lodestar-types";
+import {phase0} from "@chainsafe/lodestar-types";
 import {List} from "@chainsafe/ssz";
-import {IEpochProcess, CachedBeaconState} from "../util";
+import {IEpochProcess, BeaconStateCachedAllForks} from "../util";
 
 /**
  * Reset eth1DataVotes tree every `EPOCHS_PER_ETH1_VOTING_PERIOD`.
  *
  * PERF: Almost no (constant) cost
  */
-export function processEth1DataReset(
-  state: CachedBeaconState<allForks.BeaconState>,
-  epochProcess: IEpochProcess
-): void {
+export function processEth1DataReset(state: BeaconStateCachedAllForks, epochProcess: IEpochProcess): void {
   const nextEpoch = epochProcess.currentEpoch + 1;
 
   // reset eth1 data votes

--- a/packages/beacon-state-transition/src/allForks/epoch/processHistoricalRootsUpdate.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processHistoricalRootsUpdate.ts
@@ -1,7 +1,7 @@
 import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@chainsafe/lodestar-params";
 import {ssz} from "@chainsafe/lodestar-types";
 import {intDiv} from "@chainsafe/lodestar-utils";
-import {IEpochProcess, BeaconStateCachedAllForks} from "../util";
+import {IEpochProcess, BeaconStateCachedAllForks} from "../../types";
 
 /**
  * Persist blockRoots and stateRoots to historicalRoots.

--- a/packages/beacon-state-transition/src/allForks/epoch/processHistoricalRootsUpdate.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processHistoricalRootsUpdate.ts
@@ -1,14 +1,14 @@
 import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@chainsafe/lodestar-params";
 import {ssz} from "@chainsafe/lodestar-types";
 import {intDiv} from "@chainsafe/lodestar-utils";
-import {IEpochProcess, BeaconStateCachedAllForks} from "../../types";
+import {IEpochProcess, CachedBeaconStateAllForks} from "../../types";
 
 /**
  * Persist blockRoots and stateRoots to historicalRoots.
  *
  * PERF: Very low (constant) cost. Most of the HistoricalBatch should already be hashed.
  */
-export function processHistoricalRootsUpdate(state: BeaconStateCachedAllForks, epochProcess: IEpochProcess): void {
+export function processHistoricalRootsUpdate(state: CachedBeaconStateAllForks, epochProcess: IEpochProcess): void {
   const nextEpoch = epochProcess.currentEpoch + 1;
 
   // set historical root accumulator

--- a/packages/beacon-state-transition/src/allForks/epoch/processHistoricalRootsUpdate.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processHistoricalRootsUpdate.ts
@@ -1,17 +1,14 @@
 import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@chainsafe/lodestar-params";
-import {allForks, ssz} from "@chainsafe/lodestar-types";
+import {ssz} from "@chainsafe/lodestar-types";
 import {intDiv} from "@chainsafe/lodestar-utils";
-import {IEpochProcess, CachedBeaconState} from "../util";
+import {IEpochProcess, BeaconStateCachedAllForks} from "../util";
 
 /**
  * Persist blockRoots and stateRoots to historicalRoots.
  *
  * PERF: Very low (constant) cost. Most of the HistoricalBatch should already be hashed.
  */
-export function processHistoricalRootsUpdate(
-  state: CachedBeaconState<allForks.BeaconState>,
-  epochProcess: IEpochProcess
-): void {
+export function processHistoricalRootsUpdate(state: BeaconStateCachedAllForks, epochProcess: IEpochProcess): void {
   const nextEpoch = epochProcess.currentEpoch + 1;
 
   // set historical root accumulator

--- a/packages/beacon-state-transition/src/allForks/epoch/processJustificationAndFinalization.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processJustificationAndFinalization.ts
@@ -1,7 +1,7 @@
 import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
 
 import {getBlockRoot} from "../../util";
-import {BeaconStateCachedAllForks, IEpochProcess} from "../../types";
+import {CachedBeaconStateAllForks, IEpochProcess} from "../../types";
 
 /**
  * Update justified and finalized checkpoints depending on network participation.
@@ -9,7 +9,7 @@ import {BeaconStateCachedAllForks, IEpochProcess} from "../../types";
  * PERF: Very low (constant) cost. Persist small objects to the tree.
  */
 export function processJustificationAndFinalization(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   epochProcess: IEpochProcess
 ): void {
   const previousEpoch = epochProcess.prevEpoch;

--- a/packages/beacon-state-transition/src/allForks/epoch/processJustificationAndFinalization.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processJustificationAndFinalization.ts
@@ -1,8 +1,7 @@
 import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
-import {allForks} from "@chainsafe/lodestar-types";
 
 import {getBlockRoot} from "../../util";
-import {CachedBeaconState, IEpochProcess} from "../util";
+import {BeaconStateCachedAllForks, IEpochProcess} from "../util";
 
 /**
  * Update justified and finalized checkpoints depending on network participation.
@@ -10,7 +9,7 @@ import {CachedBeaconState, IEpochProcess} from "../util";
  * PERF: Very low (constant) cost. Persist small objects to the tree.
  */
 export function processJustificationAndFinalization(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   epochProcess: IEpochProcess
 ): void {
   const previousEpoch = epochProcess.prevEpoch;

--- a/packages/beacon-state-transition/src/allForks/epoch/processJustificationAndFinalization.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processJustificationAndFinalization.ts
@@ -1,7 +1,7 @@
 import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
 
 import {getBlockRoot} from "../../util";
-import {BeaconStateCachedAllForks, IEpochProcess} from "../util";
+import {BeaconStateCachedAllForks, IEpochProcess} from "../../types";
 
 /**
  * Update justified and finalized checkpoints depending on network participation.

--- a/packages/beacon-state-transition/src/allForks/epoch/processRandaoMixesReset.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processRandaoMixesReset.ts
@@ -1,13 +1,13 @@
 import {EPOCHS_PER_HISTORICAL_VECTOR} from "@chainsafe/lodestar-params";
 import {getRandaoMix} from "../../util";
-import {IEpochProcess, BeaconStateCachedAllForks} from "../../types";
+import {IEpochProcess, CachedBeaconStateAllForks} from "../../types";
 
 /**
  * Write next randaoMix
  *
  * PERF: Almost no (constant) cost
  */
-export function processRandaoMixesReset(state: BeaconStateCachedAllForks, epochProcess: IEpochProcess): void {
+export function processRandaoMixesReset(state: CachedBeaconStateAllForks, epochProcess: IEpochProcess): void {
   const currentEpoch = epochProcess.currentEpoch;
   const nextEpoch = currentEpoch + 1;
 

--- a/packages/beacon-state-transition/src/allForks/epoch/processRandaoMixesReset.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processRandaoMixesReset.ts
@@ -1,6 +1,6 @@
 import {EPOCHS_PER_HISTORICAL_VECTOR} from "@chainsafe/lodestar-params";
 import {getRandaoMix} from "../../util";
-import {IEpochProcess, BeaconStateCachedAllForks} from "../util";
+import {IEpochProcess, BeaconStateCachedAllForks} from "../../types";
 
 /**
  * Write next randaoMix

--- a/packages/beacon-state-transition/src/allForks/epoch/processRandaoMixesReset.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processRandaoMixesReset.ts
@@ -1,17 +1,13 @@
 import {EPOCHS_PER_HISTORICAL_VECTOR} from "@chainsafe/lodestar-params";
-import {allForks} from "@chainsafe/lodestar-types";
 import {getRandaoMix} from "../../util";
-import {IEpochProcess, CachedBeaconState} from "../util";
+import {IEpochProcess, BeaconStateCachedAllForks} from "../util";
 
 /**
  * Write next randaoMix
  *
  * PERF: Almost no (constant) cost
  */
-export function processRandaoMixesReset(
-  state: CachedBeaconState<allForks.BeaconState>,
-  epochProcess: IEpochProcess
-): void {
+export function processRandaoMixesReset(state: BeaconStateCachedAllForks, epochProcess: IEpochProcess): void {
   const currentEpoch = epochProcess.currentEpoch;
   const nextEpoch = currentEpoch + 1;
 

--- a/packages/beacon-state-transition/src/allForks/epoch/processRegistryUpdates.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processRegistryUpdates.ts
@@ -1,6 +1,6 @@
 import {computeActivationExitEpoch} from "../../util";
 import {initiateValidatorExit} from "../block";
-import {IEpochProcess, BeaconStateCachedAllForks} from "../../types";
+import {IEpochProcess, CachedBeaconStateAllForks} from "../../types";
 
 /**
  * Update validator registry for validators that activate + exit
@@ -16,7 +16,7 @@ import {IEpochProcess, BeaconStateCachedAllForks} from "../../types";
  *   - indicesEligibleForActivationQueue: 0
  *   - indicesToEject: 0
  */
-export function processRegistryUpdates(state: BeaconStateCachedAllForks, epochProcess: IEpochProcess): void {
+export function processRegistryUpdates(state: CachedBeaconStateAllForks, epochProcess: IEpochProcess): void {
   const {epochCtx} = state;
 
   // Get the validators sub tree once for all the loop

--- a/packages/beacon-state-transition/src/allForks/epoch/processRegistryUpdates.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processRegistryUpdates.ts
@@ -1,6 +1,6 @@
 import {computeActivationExitEpoch} from "../../util";
 import {initiateValidatorExit} from "../block";
-import {IEpochProcess, BeaconStateCachedAllForks} from "../util";
+import {IEpochProcess, BeaconStateCachedAllForks} from "../../types";
 
 /**
  * Update validator registry for validators that activate + exit

--- a/packages/beacon-state-transition/src/allForks/epoch/processRegistryUpdates.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processRegistryUpdates.ts
@@ -1,7 +1,6 @@
-import {allForks} from "@chainsafe/lodestar-types";
 import {computeActivationExitEpoch} from "../../util";
 import {initiateValidatorExit} from "../block";
-import {IEpochProcess, CachedBeaconState} from "../util";
+import {IEpochProcess, BeaconStateCachedAllForks} from "../util";
 
 /**
  * Update validator registry for validators that activate + exit
@@ -17,10 +16,7 @@ import {IEpochProcess, CachedBeaconState} from "../util";
  *   - indicesEligibleForActivationQueue: 0
  *   - indicesToEject: 0
  */
-export function processRegistryUpdates(
-  state: CachedBeaconState<allForks.BeaconState>,
-  epochProcess: IEpochProcess
-): void {
+export function processRegistryUpdates(state: BeaconStateCachedAllForks, epochProcess: IEpochProcess): void {
   const {epochCtx} = state;
 
   // Get the validators sub tree once for all the loop

--- a/packages/beacon-state-transition/src/allForks/epoch/processSlashings.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processSlashings.ts
@@ -1,4 +1,3 @@
-import {allForks} from "@chainsafe/lodestar-types";
 import {bigIntMin} from "@chainsafe/lodestar-utils";
 import {readonlyValues} from "@chainsafe/ssz";
 import {
@@ -10,7 +9,7 @@ import {
 } from "@chainsafe/lodestar-params";
 
 import {decreaseBalance} from "../../util";
-import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedAllForks, IEpochProcess} from "../../allForks/util";
 
 /**
  * Update validator registry for validators that activate + exit
@@ -23,7 +22,7 @@ import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
  */
 export function processSlashingsAllForks(
   fork: ForkName,
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   process: IEpochProcess
 ): void {
   // No need to compute totalSlashings if there no index to slash

--- a/packages/beacon-state-transition/src/allForks/epoch/processSlashings.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processSlashings.ts
@@ -9,7 +9,7 @@ import {
 } from "@chainsafe/lodestar-params";
 
 import {decreaseBalance} from "../../util";
-import {BeaconStateCachedAllForks, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedAllForks, IEpochProcess} from "../../types";
 
 /**
  * Update validator registry for validators that activate + exit

--- a/packages/beacon-state-transition/src/allForks/epoch/processSlashings.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processSlashings.ts
@@ -9,7 +9,7 @@ import {
 } from "@chainsafe/lodestar-params";
 
 import {decreaseBalance} from "../../util";
-import {BeaconStateCachedAllForks, IEpochProcess} from "../../types";
+import {CachedBeaconStateAllForks, IEpochProcess} from "../../types";
 
 /**
  * Update validator registry for validators that activate + exit
@@ -22,7 +22,7 @@ import {BeaconStateCachedAllForks, IEpochProcess} from "../../types";
  */
 export function processSlashingsAllForks(
   fork: ForkName,
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   process: IEpochProcess
 ): void {
   // No need to compute totalSlashings if there no index to slash

--- a/packages/beacon-state-transition/src/allForks/epoch/processSlashingsReset.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processSlashingsReset.ts
@@ -1,5 +1,5 @@
 import {EPOCHS_PER_SLASHINGS_VECTOR} from "@chainsafe/lodestar-params";
-import {IEpochProcess, BeaconStateCachedAllForks} from "../util";
+import {IEpochProcess, BeaconStateCachedAllForks} from "../../types";
 
 /**
  * Reset the next slashings balance accumulator

--- a/packages/beacon-state-transition/src/allForks/epoch/processSlashingsReset.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processSlashingsReset.ts
@@ -1,16 +1,12 @@
 import {EPOCHS_PER_SLASHINGS_VECTOR} from "@chainsafe/lodestar-params";
-import {allForks} from "@chainsafe/lodestar-types";
-import {IEpochProcess, CachedBeaconState} from "../util";
+import {IEpochProcess, BeaconStateCachedAllForks} from "../util";
 
 /**
  * Reset the next slashings balance accumulator
  *
  * PERF: Almost no (constant) cost
  */
-export function processSlashingsReset(
-  state: CachedBeaconState<allForks.BeaconState>,
-  epochProcess: IEpochProcess
-): void {
+export function processSlashingsReset(state: BeaconStateCachedAllForks, epochProcess: IEpochProcess): void {
   const nextEpoch = epochProcess.currentEpoch + 1;
 
   // reset slashings

--- a/packages/beacon-state-transition/src/allForks/epoch/processSlashingsReset.ts
+++ b/packages/beacon-state-transition/src/allForks/epoch/processSlashingsReset.ts
@@ -1,12 +1,12 @@
 import {EPOCHS_PER_SLASHINGS_VECTOR} from "@chainsafe/lodestar-params";
-import {IEpochProcess, BeaconStateCachedAllForks} from "../../types";
+import {IEpochProcess, CachedBeaconStateAllForks} from "../../types";
 
 /**
  * Reset the next slashings balance accumulator
  *
  * PERF: Almost no (constant) cost
  */
-export function processSlashingsReset(state: BeaconStateCachedAllForks, epochProcess: IEpochProcess): void {
+export function processSlashingsReset(state: CachedBeaconStateAllForks, epochProcess: IEpochProcess): void {
   const nextEpoch = epochProcess.currentEpoch + 1;
 
   // reset slashings

--- a/packages/beacon-state-transition/src/allForks/signatureSets/attesterSlashings.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/attesterSlashings.ts
@@ -1,12 +1,12 @@
 import {readonlyValues} from "@chainsafe/ssz";
 import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {ISignatureSet} from "../../util";
-import {CachedBeaconState} from "../util";
+import {BeaconStateCachedAllForks} from "../util";
 import {getIndexedAttestationSignatureSet} from "./indexedAttestation";
 
 /** Get signature sets from a single AttesterSlashing object */
 export function getAttesterSlashingSignatureSets(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   attesterSlashing: phase0.AttesterSlashing
 ): ISignatureSet[] {
   return [attesterSlashing.attestation1, attesterSlashing.attestation2].map((attestation) =>
@@ -16,7 +16,7 @@ export function getAttesterSlashingSignatureSets(
 
 /** Get signature sets from all AttesterSlashing objects in a block */
 export function getAttesterSlashingsSignatureSets(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   signedBlock: allForks.SignedBeaconBlock
 ): ISignatureSet[] {
   return Array.from(readonlyValues(signedBlock.message.body.attesterSlashings), (attesterSlashing) =>

--- a/packages/beacon-state-transition/src/allForks/signatureSets/attesterSlashings.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/attesterSlashings.ts
@@ -1,12 +1,12 @@
 import {readonlyValues} from "@chainsafe/ssz";
 import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {ISignatureSet} from "../../util";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 import {getIndexedAttestationSignatureSet} from "./indexedAttestation";
 
 /** Get signature sets from a single AttesterSlashing object */
 export function getAttesterSlashingSignatureSets(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   attesterSlashing: phase0.AttesterSlashing
 ): ISignatureSet[] {
   return [attesterSlashing.attestation1, attesterSlashing.attestation2].map((attestation) =>
@@ -16,7 +16,7 @@ export function getAttesterSlashingSignatureSets(
 
 /** Get signature sets from all AttesterSlashing objects in a block */
 export function getAttesterSlashingsSignatureSets(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   signedBlock: allForks.SignedBeaconBlock
 ): ISignatureSet[] {
   return Array.from(readonlyValues(signedBlock.message.body.attesterSlashings), (attesterSlashing) =>

--- a/packages/beacon-state-transition/src/allForks/signatureSets/attesterSlashings.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/attesterSlashings.ts
@@ -1,7 +1,7 @@
 import {readonlyValues} from "@chainsafe/ssz";
 import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {ISignatureSet} from "../../util";
-import {BeaconStateCachedAllForks} from "../util";
+import {BeaconStateCachedAllForks} from "../../types";
 import {getIndexedAttestationSignatureSet} from "./indexedAttestation";
 
 /** Get signature sets from a single AttesterSlashing object */

--- a/packages/beacon-state-transition/src/allForks/signatureSets/index.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/index.ts
@@ -1,6 +1,6 @@
 import {allForks, altair} from "@chainsafe/lodestar-types";
 import {computeEpochAtSlot, ISignatureSet} from "../../util";
-import {BeaconStateCachedAllForks, BeaconStateCachedAltair} from "../util";
+import {BeaconStateCachedAllForks, BeaconStateCachedAltair} from "../../types";
 import {getProposerSlashingsSignatureSets} from "./proposerSlashings";
 import {getAttesterSlashingsSignatureSets} from "./attesterSlashings";
 import {getAttestationsSignatureSets} from "./indexedAttestation";

--- a/packages/beacon-state-transition/src/allForks/signatureSets/index.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/index.ts
@@ -1,6 +1,6 @@
 import {allForks, altair} from "@chainsafe/lodestar-types";
 import {computeEpochAtSlot, ISignatureSet} from "../../util";
-import {BeaconStateCachedAllForks, BeaconStateCachedAltair} from "../../types";
+import {CachedBeaconStateAllForks, CachedBeaconStateAltair} from "../../types";
 import {getProposerSlashingsSignatureSets} from "./proposerSlashings";
 import {getAttesterSlashingsSignatureSets} from "./attesterSlashings";
 import {getAttestationsSignatureSets} from "./indexedAttestation";
@@ -21,7 +21,7 @@ export * from "./voluntaryExits";
  * Deposits are not included because they can legally have invalid signatures.
  */
 export function getAllBlockSignatureSets(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   signedBlock: allForks.SignedBeaconBlock
 ): ISignatureSet[] {
   return [getProposerSignatureSet(state, signedBlock), ...getAllBlockSignatureSetsExceptProposer(state, signedBlock)];
@@ -32,7 +32,7 @@ export function getAllBlockSignatureSets(
  * Useful since block proposer signature is verified beforehand on gossip validation
  */
 export function getAllBlockSignatureSetsExceptProposer(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   signedBlock: allForks.SignedBeaconBlock
 ): ISignatureSet[] {
   const signatureSets = [
@@ -46,7 +46,7 @@ export function getAllBlockSignatureSetsExceptProposer(
   // Only after altair fork, validate tSyncCommitteeSignature
   if (computeEpochAtSlot(signedBlock.message.slot) >= state.config.ALTAIR_FORK_EPOCH) {
     const syncCommitteeSignatureSet = getSyncCommitteeSignatureSet(
-      state as BeaconStateCachedAltair,
+      state as CachedBeaconStateAltair,
       (signedBlock as altair.SignedBeaconBlock).message
     );
     // There may be no participants in this syncCommitteeSignature, so it must not be validated

--- a/packages/beacon-state-transition/src/allForks/signatureSets/index.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/index.ts
@@ -1,6 +1,6 @@
 import {allForks, altair} from "@chainsafe/lodestar-types";
 import {computeEpochAtSlot, ISignatureSet} from "../../util";
-import {CachedBeaconState} from "../util";
+import {BeaconStateCachedAllForks, BeaconStateCachedAltair} from "../util";
 import {getProposerSlashingsSignatureSets} from "./proposerSlashings";
 import {getAttesterSlashingsSignatureSets} from "./attesterSlashings";
 import {getAttestationsSignatureSets} from "./indexedAttestation";
@@ -21,7 +21,7 @@ export * from "./voluntaryExits";
  * Deposits are not included because they can legally have invalid signatures.
  */
 export function getAllBlockSignatureSets(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   signedBlock: allForks.SignedBeaconBlock
 ): ISignatureSet[] {
   return [getProposerSignatureSet(state, signedBlock), ...getAllBlockSignatureSetsExceptProposer(state, signedBlock)];
@@ -32,7 +32,7 @@ export function getAllBlockSignatureSets(
  * Useful since block proposer signature is verified beforehand on gossip validation
  */
 export function getAllBlockSignatureSetsExceptProposer(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   signedBlock: allForks.SignedBeaconBlock
 ): ISignatureSet[] {
   const signatureSets = [
@@ -46,7 +46,7 @@ export function getAllBlockSignatureSetsExceptProposer(
   // Only after altair fork, validate tSyncCommitteeSignature
   if (computeEpochAtSlot(signedBlock.message.slot) >= state.config.ALTAIR_FORK_EPOCH) {
     const syncCommitteeSignatureSet = getSyncCommitteeSignatureSet(
-      state as CachedBeaconState<altair.BeaconState>,
+      state as BeaconStateCachedAltair,
       (signedBlock as altair.SignedBeaconBlock).message
     );
     // There may be no participants in this syncCommitteeSignature, so it must not be validated

--- a/packages/beacon-state-transition/src/allForks/signatureSets/indexedAttestation.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/indexedAttestation.ts
@@ -8,10 +8,10 @@ import {
   SignatureSetType,
   verifySignatureSet,
 } from "../../util";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 
 export function verifyIndexedAttestationSignature(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   indexedAttestation: phase0.IndexedAttestation,
   indices?: number[]
 ): boolean {
@@ -19,7 +19,7 @@ export function verifyIndexedAttestationSignature(
 }
 
 export function getAttestationWithIndicesSignatureSet(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   attestation: Pick<phase0.Attestation, "data" | "signature">,
   indices: number[]
 ): ISignatureSet {
@@ -36,7 +36,7 @@ export function getAttestationWithIndicesSignatureSet(
 }
 
 export function getIndexedAttestationSignatureSet(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   indexedAttestation: phase0.IndexedAttestation,
   indices?: number[]
 ): ISignatureSet {
@@ -48,7 +48,7 @@ export function getIndexedAttestationSignatureSet(
 }
 
 export function getAttestationsSignatureSets(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   signedBlock: allForks.SignedBeaconBlock
 ): ISignatureSet[] {
   return Array.from(readonlyValues(signedBlock.message.body.attestations), (attestation) =>

--- a/packages/beacon-state-transition/src/allForks/signatureSets/indexedAttestation.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/indexedAttestation.ts
@@ -8,7 +8,7 @@ import {
   SignatureSetType,
   verifySignatureSet,
 } from "../../util";
-import {BeaconStateCachedAllForks} from "../util";
+import {BeaconStateCachedAllForks} from "../../types";
 
 export function verifyIndexedAttestationSignature(
   state: BeaconStateCachedAllForks,

--- a/packages/beacon-state-transition/src/allForks/signatureSets/indexedAttestation.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/indexedAttestation.ts
@@ -8,10 +8,10 @@ import {
   SignatureSetType,
   verifySignatureSet,
 } from "../../util";
-import {CachedBeaconState} from "../util";
+import {BeaconStateCachedAllForks} from "../util";
 
 export function verifyIndexedAttestationSignature(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   indexedAttestation: phase0.IndexedAttestation,
   indices?: number[]
 ): boolean {
@@ -19,7 +19,7 @@ export function verifyIndexedAttestationSignature(
 }
 
 export function getAttestationWithIndicesSignatureSet(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   attestation: Pick<phase0.Attestation, "data" | "signature">,
   indices: number[]
 ): ISignatureSet {
@@ -36,7 +36,7 @@ export function getAttestationWithIndicesSignatureSet(
 }
 
 export function getIndexedAttestationSignatureSet(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   indexedAttestation: phase0.IndexedAttestation,
   indices?: number[]
 ): ISignatureSet {
@@ -48,7 +48,7 @@ export function getIndexedAttestationSignatureSet(
 }
 
 export function getAttestationsSignatureSets(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   signedBlock: allForks.SignedBeaconBlock
 ): ISignatureSet[] {
   return Array.from(readonlyValues(signedBlock.message.body.attestations), (attestation) =>

--- a/packages/beacon-state-transition/src/allForks/signatureSets/proposer.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/proposer.ts
@@ -2,10 +2,10 @@ import {DOMAIN_BEACON_PROPOSER} from "@chainsafe/lodestar-params";
 import {allForks} from "@chainsafe/lodestar-types";
 import {computeSigningRoot} from "../../util";
 import {ISignatureSet, SignatureSetType, verifySignatureSet} from "../../util/signatureSets";
-import {CachedBeaconState} from "../util";
+import {BeaconStateCachedAllForks} from "../util";
 
 export function verifyProposerSignature(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   signedBlock: allForks.SignedBeaconBlock
 ): boolean {
   const signatureSet = getProposerSignatureSet(state, signedBlock);
@@ -13,7 +13,7 @@ export function verifyProposerSignature(
 }
 
 export function getProposerSignatureSet(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   signedBlock: allForks.SignedBeaconBlock
 ): ISignatureSet {
   const {config, epochCtx} = state;

--- a/packages/beacon-state-transition/src/allForks/signatureSets/proposer.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/proposer.ts
@@ -2,7 +2,7 @@ import {DOMAIN_BEACON_PROPOSER} from "@chainsafe/lodestar-params";
 import {allForks} from "@chainsafe/lodestar-types";
 import {computeSigningRoot} from "../../util";
 import {ISignatureSet, SignatureSetType, verifySignatureSet} from "../../util/signatureSets";
-import {BeaconStateCachedAllForks} from "../util";
+import {BeaconStateCachedAllForks} from "../../types";
 
 export function verifyProposerSignature(
   state: BeaconStateCachedAllForks,

--- a/packages/beacon-state-transition/src/allForks/signatureSets/proposer.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/proposer.ts
@@ -2,10 +2,10 @@ import {DOMAIN_BEACON_PROPOSER} from "@chainsafe/lodestar-params";
 import {allForks} from "@chainsafe/lodestar-types";
 import {computeSigningRoot} from "../../util";
 import {ISignatureSet, SignatureSetType, verifySignatureSet} from "../../util/signatureSets";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 
 export function verifyProposerSignature(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   signedBlock: allForks.SignedBeaconBlock
 ): boolean {
   const signatureSet = getProposerSignatureSet(state, signedBlock);
@@ -13,7 +13,7 @@ export function verifyProposerSignature(
 }
 
 export function getProposerSignatureSet(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   signedBlock: allForks.SignedBeaconBlock
 ): ISignatureSet {
   const {config, epochCtx} = state;

--- a/packages/beacon-state-transition/src/allForks/signatureSets/proposerSlashings.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/proposerSlashings.ts
@@ -2,13 +2,13 @@ import {DOMAIN_BEACON_PROPOSER} from "@chainsafe/lodestar-params";
 import {readonlyValues} from "@chainsafe/ssz";
 import {allForks, phase0, ssz} from "@chainsafe/lodestar-types";
 import {computeSigningRoot, ISignatureSet, SignatureSetType} from "../../util";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 
 /**
  * Extract signatures to allow validating all block signatures at once
  */
 export function getProposerSlashingSignatureSets(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   proposerSlashing: phase0.ProposerSlashing
 ): ISignatureSet[] {
   const {epochCtx} = state;
@@ -30,7 +30,7 @@ export function getProposerSlashingSignatureSets(
 }
 
 export function getProposerSlashingsSignatureSets(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   signedBlock: allForks.SignedBeaconBlock
 ): ISignatureSet[] {
   return Array.from(readonlyValues(signedBlock.message.body.proposerSlashings), (proposerSlashing) =>

--- a/packages/beacon-state-transition/src/allForks/signatureSets/proposerSlashings.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/proposerSlashings.ts
@@ -2,7 +2,7 @@ import {DOMAIN_BEACON_PROPOSER} from "@chainsafe/lodestar-params";
 import {readonlyValues} from "@chainsafe/ssz";
 import {allForks, phase0, ssz} from "@chainsafe/lodestar-types";
 import {computeSigningRoot, ISignatureSet, SignatureSetType} from "../../util";
-import {BeaconStateCachedAllForks} from "../util";
+import {BeaconStateCachedAllForks} from "../../types";
 
 /**
  * Extract signatures to allow validating all block signatures at once

--- a/packages/beacon-state-transition/src/allForks/signatureSets/proposerSlashings.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/proposerSlashings.ts
@@ -2,13 +2,13 @@ import {DOMAIN_BEACON_PROPOSER} from "@chainsafe/lodestar-params";
 import {readonlyValues} from "@chainsafe/ssz";
 import {allForks, phase0, ssz} from "@chainsafe/lodestar-types";
 import {computeSigningRoot, ISignatureSet, SignatureSetType} from "../../util";
-import {CachedBeaconState} from "../util";
+import {BeaconStateCachedAllForks} from "../util";
 
 /**
  * Extract signatures to allow validating all block signatures at once
  */
 export function getProposerSlashingSignatureSets(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   proposerSlashing: phase0.ProposerSlashing
 ): ISignatureSet[] {
   const {epochCtx} = state;
@@ -30,7 +30,7 @@ export function getProposerSlashingSignatureSets(
 }
 
 export function getProposerSlashingsSignatureSets(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   signedBlock: allForks.SignedBeaconBlock
 ): ISignatureSet[] {
   return Array.from(readonlyValues(signedBlock.message.body.proposerSlashings), (proposerSlashing) =>

--- a/packages/beacon-state-transition/src/allForks/signatureSets/randao.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/randao.ts
@@ -1,7 +1,7 @@
 import {DOMAIN_RANDAO} from "@chainsafe/lodestar-params";
 import {allForks, ssz} from "@chainsafe/lodestar-types";
 import {computeEpochAtSlot, computeSigningRoot, ISignatureSet, SignatureSetType, verifySignatureSet} from "../../util";
-import {BeaconStateCachedAllForks} from "../util";
+import {BeaconStateCachedAllForks} from "../../types";
 
 export function verifyRandaoSignature(state: BeaconStateCachedAllForks, block: allForks.BeaconBlock): boolean {
   return verifySignatureSet(getRandaoRevealSignatureSet(state, block));

--- a/packages/beacon-state-transition/src/allForks/signatureSets/randao.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/randao.ts
@@ -1,12 +1,9 @@
 import {DOMAIN_RANDAO} from "@chainsafe/lodestar-params";
 import {allForks, ssz} from "@chainsafe/lodestar-types";
 import {computeEpochAtSlot, computeSigningRoot, ISignatureSet, SignatureSetType, verifySignatureSet} from "../../util";
-import {CachedBeaconState} from "../util";
+import {BeaconStateCachedAllForks} from "../util";
 
-export function verifyRandaoSignature(
-  state: CachedBeaconState<allForks.BeaconState>,
-  block: allForks.BeaconBlock
-): boolean {
+export function verifyRandaoSignature(state: BeaconStateCachedAllForks, block: allForks.BeaconBlock): boolean {
   return verifySignatureSet(getRandaoRevealSignatureSet(state, block));
 }
 
@@ -14,7 +11,7 @@ export function verifyRandaoSignature(
  * Extract signatures to allow validating all block signatures at once
  */
 export function getRandaoRevealSignatureSet(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   block: allForks.BeaconBlock
 ): ISignatureSet {
   const {epochCtx} = state;

--- a/packages/beacon-state-transition/src/allForks/signatureSets/randao.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/randao.ts
@@ -1,9 +1,9 @@
 import {DOMAIN_RANDAO} from "@chainsafe/lodestar-params";
 import {allForks, ssz} from "@chainsafe/lodestar-types";
 import {computeEpochAtSlot, computeSigningRoot, ISignatureSet, SignatureSetType, verifySignatureSet} from "../../util";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 
-export function verifyRandaoSignature(state: BeaconStateCachedAllForks, block: allForks.BeaconBlock): boolean {
+export function verifyRandaoSignature(state: CachedBeaconStateAllForks, block: allForks.BeaconBlock): boolean {
   return verifySignatureSet(getRandaoRevealSignatureSet(state, block));
 }
 
@@ -11,7 +11,7 @@ export function verifyRandaoSignature(state: BeaconStateCachedAllForks, block: a
  * Extract signatures to allow validating all block signatures at once
  */
 export function getRandaoRevealSignatureSet(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   block: allForks.BeaconBlock
 ): ISignatureSet {
   const {epochCtx} = state;

--- a/packages/beacon-state-transition/src/allForks/signatureSets/voluntaryExits.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/voluntaryExits.ts
@@ -8,10 +8,10 @@ import {
   SignatureSetType,
   verifySignatureSet,
 } from "../../util";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 
 export function verifyVoluntaryExitSignature(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   signedVoluntaryExit: phase0.SignedVoluntaryExit
 ): boolean {
   return verifySignatureSet(getVoluntaryExitSignatureSet(state, signedVoluntaryExit));
@@ -21,7 +21,7 @@ export function verifyVoluntaryExitSignature(
  * Extract signatures to allow validating all block signatures at once
  */
 export function getVoluntaryExitSignatureSet(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   signedVoluntaryExit: phase0.SignedVoluntaryExit
 ): ISignatureSet {
   const {epochCtx} = state;
@@ -37,7 +37,7 @@ export function getVoluntaryExitSignatureSet(
 }
 
 export function getVoluntaryExitsSignatureSets(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   signedBlock: allForks.SignedBeaconBlock
 ): ISignatureSet[] {
   return Array.from(readonlyValues(signedBlock.message.body.voluntaryExits), (voluntaryExit) =>

--- a/packages/beacon-state-transition/src/allForks/signatureSets/voluntaryExits.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/voluntaryExits.ts
@@ -8,7 +8,7 @@ import {
   SignatureSetType,
   verifySignatureSet,
 } from "../../util";
-import {BeaconStateCachedAllForks} from "../util";
+import {BeaconStateCachedAllForks} from "../../types";
 
 export function verifyVoluntaryExitSignature(
   state: BeaconStateCachedAllForks,

--- a/packages/beacon-state-transition/src/allForks/signatureSets/voluntaryExits.ts
+++ b/packages/beacon-state-transition/src/allForks/signatureSets/voluntaryExits.ts
@@ -8,10 +8,10 @@ import {
   SignatureSetType,
   verifySignatureSet,
 } from "../../util";
-import {CachedBeaconState} from "../util";
+import {BeaconStateCachedAllForks} from "../util";
 
 export function verifyVoluntaryExitSignature(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   signedVoluntaryExit: phase0.SignedVoluntaryExit
 ): boolean {
   return verifySignatureSet(getVoluntaryExitSignatureSet(state, signedVoluntaryExit));
@@ -21,7 +21,7 @@ export function verifyVoluntaryExitSignature(
  * Extract signatures to allow validating all block signatures at once
  */
 export function getVoluntaryExitSignatureSet(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   signedVoluntaryExit: phase0.SignedVoluntaryExit
 ): ISignatureSet {
   const {epochCtx} = state;
@@ -37,7 +37,7 @@ export function getVoluntaryExitSignatureSet(
 }
 
 export function getVoluntaryExitsSignatureSets(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   signedBlock: allForks.SignedBeaconBlock
 ): ISignatureSet[] {
   return Array.from(readonlyValues(signedBlock.message.body.voluntaryExits), (voluntaryExit) =>

--- a/packages/beacon-state-transition/src/allForks/slot/index.ts
+++ b/packages/beacon-state-transition/src/allForks/slot/index.ts
@@ -1,12 +1,12 @@
-import {allForks, ssz} from "@chainsafe/lodestar-types";
+import {ssz} from "@chainsafe/lodestar-types";
 import {SLOTS_PER_HISTORICAL_ROOT} from "@chainsafe/lodestar-params";
-import {CachedBeaconState} from "../util";
+import {BeaconStateCachedAllForks} from "../util";
 import {ZERO_HASH} from "../../constants";
 
 /**
  * Dial state to next slot. Common for all forks
  */
-export function processSlot(state: CachedBeaconState<allForks.BeaconState>): void {
+export function processSlot(state: BeaconStateCachedAllForks): void {
   const {config} = state;
   const types = config.getForkTypes(state.slot);
 

--- a/packages/beacon-state-transition/src/allForks/slot/index.ts
+++ b/packages/beacon-state-transition/src/allForks/slot/index.ts
@@ -1,12 +1,12 @@
 import {ssz} from "@chainsafe/lodestar-types";
 import {SLOTS_PER_HISTORICAL_ROOT} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 import {ZERO_HASH} from "../../constants";
 
 /**
  * Dial state to next slot. Common for all forks
  */
-export function processSlot(state: BeaconStateCachedAllForks): void {
+export function processSlot(state: CachedBeaconStateAllForks): void {
   const {config} = state;
   const types = config.getForkTypes(state.slot);
 

--- a/packages/beacon-state-transition/src/allForks/slot/index.ts
+++ b/packages/beacon-state-transition/src/allForks/slot/index.ts
@@ -1,6 +1,6 @@
 import {ssz} from "@chainsafe/lodestar-types";
 import {SLOTS_PER_HISTORICAL_ROOT} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedAllForks} from "../util";
+import {BeaconStateCachedAllForks} from "../../types";
 import {ZERO_HASH} from "../../constants";
 
 /**

--- a/packages/beacon-state-transition/src/allForks/stateTransition.ts
+++ b/packages/beacon-state-transition/src/allForks/stateTransition.ts
@@ -7,14 +7,14 @@ import * as bellatrix from "../bellatrix";
 import {IBeaconStateTransitionMetrics} from "../metrics";
 import {verifyProposerSignature} from "./signatureSets";
 import {beforeProcessEpoch, IEpochProcess, afterProcessEpoch} from "./util";
-import {BeaconStateCachedAllForks, BeaconStateCachedPhase0, BeaconStateCachedAltair} from "../types";
+import {CachedBeaconStateAllForks, CachedBeaconStatePhase0, CachedBeaconStateAltair} from "../types";
 import {processSlot} from "./slot";
 import {computeEpochAtSlot} from "../util";
 import {toHexString} from "@chainsafe/ssz";
 
-type StateAllForks = BeaconStateCachedAllForks;
-type StatePhase0 = BeaconStateCachedPhase0;
-type StateAltair = BeaconStateCachedAltair;
+type StateAllForks = CachedBeaconStateAllForks;
+type StatePhase0 = CachedBeaconStatePhase0;
+type StateAltair = CachedBeaconStateAltair;
 
 type ProcessBlockFn = (state: StateAllForks, block: allForks.BeaconBlock, verifySignatures: boolean) => void;
 type ProcessEpochFn = (state: StateAllForks, epochProcess: IEpochProcess) => void;
@@ -37,11 +37,11 @@ const processEpochByFork: Record<ForkName, ProcessEpochFn> = {
  * Implementation Note: follows the optimizations in protolambda's eth2fastspec (https://github.com/protolambda/eth2fastspec)
  */
 export function stateTransition(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   signedBlock: allForks.SignedBeaconBlock,
   options?: {verifyStateRoot?: boolean; verifyProposer?: boolean; verifySignatures?: boolean},
   metrics?: IBeaconStateTransitionMetrics | null
-): BeaconStateCachedAllForks {
+): CachedBeaconStateAllForks {
   const {verifyStateRoot = true, verifyProposer = true} = options || {};
 
   const block = signedBlock.message;
@@ -89,7 +89,7 @@ export function stateTransition(
  * Implementation Note: follows the optimizations in protolambda's eth2fastspec (https://github.com/protolambda/eth2fastspec)
  */
 export function processBlock(
-  postState: BeaconStateCachedAllForks,
+  postState: CachedBeaconStateAllForks,
   block: allForks.BeaconBlock,
   options?: {verifySignatures?: boolean},
   metrics?: IBeaconStateTransitionMetrics | null
@@ -111,10 +111,10 @@ export function processBlock(
  * Implementation Note: follows the optimizations in protolambda's eth2fastspec (https://github.com/protolambda/eth2fastspec)
  */
 export function processSlots(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   slot: Slot,
   metrics?: IBeaconStateTransitionMetrics | null
-): BeaconStateCachedAllForks {
+): CachedBeaconStateAllForks {
   let postState = state.clone();
 
   // Turn caches into a data-structure optimized for fast writes

--- a/packages/beacon-state-transition/src/allForks/stateTransition.ts
+++ b/packages/beacon-state-transition/src/allForks/stateTransition.ts
@@ -6,14 +6,8 @@ import * as altair from "../altair";
 import * as bellatrix from "../bellatrix";
 import {IBeaconStateTransitionMetrics} from "../metrics";
 import {verifyProposerSignature} from "./signatureSets";
-import {
-  beforeProcessEpoch,
-  BeaconStateCachedAllForks,
-  BeaconStateCachedPhase0,
-  BeaconStateCachedAltair,
-  IEpochProcess,
-  afterProcessEpoch,
-} from "./util";
+import {beforeProcessEpoch, IEpochProcess, afterProcessEpoch} from "./util";
+import {BeaconStateCachedAllForks, BeaconStateCachedPhase0, BeaconStateCachedAltair} from "../types";
 import {processSlot} from "./slot";
 import {computeEpochAtSlot} from "../util";
 import {toHexString} from "@chainsafe/ssz";

--- a/packages/beacon-state-transition/src/allForks/stateTransition.ts
+++ b/packages/beacon-state-transition/src/allForks/stateTransition.ts
@@ -6,14 +6,21 @@ import * as altair from "../altair";
 import * as bellatrix from "../bellatrix";
 import {IBeaconStateTransitionMetrics} from "../metrics";
 import {verifyProposerSignature} from "./signatureSets";
-import {beforeProcessEpoch, CachedBeaconState, IEpochProcess, afterProcessEpoch} from "./util";
+import {
+  beforeProcessEpoch,
+  BeaconStateCachedAllForks,
+  BeaconStateCachedPhase0,
+  BeaconStateCachedAltair,
+  IEpochProcess,
+  afterProcessEpoch,
+} from "./util";
 import {processSlot} from "./slot";
 import {computeEpochAtSlot} from "../util";
 import {toHexString} from "@chainsafe/ssz";
 
-type StateAllForks = CachedBeaconState<allForks.BeaconState>;
-type StatePhase0 = CachedBeaconState<phase0.BeaconState>;
-type StateAltair = CachedBeaconState<altair.BeaconState>;
+type StateAllForks = BeaconStateCachedAllForks;
+type StatePhase0 = BeaconStateCachedPhase0;
+type StateAltair = BeaconStateCachedAltair;
 
 type ProcessBlockFn = (state: StateAllForks, block: allForks.BeaconBlock, verifySignatures: boolean) => void;
 type ProcessEpochFn = (state: StateAllForks, epochProcess: IEpochProcess) => void;
@@ -36,11 +43,11 @@ const processEpochByFork: Record<ForkName, ProcessEpochFn> = {
  * Implementation Note: follows the optimizations in protolambda's eth2fastspec (https://github.com/protolambda/eth2fastspec)
  */
 export function stateTransition(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   signedBlock: allForks.SignedBeaconBlock,
   options?: {verifyStateRoot?: boolean; verifyProposer?: boolean; verifySignatures?: boolean},
   metrics?: IBeaconStateTransitionMetrics | null
-): CachedBeaconState<allForks.BeaconState> {
+): BeaconStateCachedAllForks {
   const {verifyStateRoot = true, verifyProposer = true} = options || {};
 
   const block = signedBlock.message;
@@ -88,7 +95,7 @@ export function stateTransition(
  * Implementation Note: follows the optimizations in protolambda's eth2fastspec (https://github.com/protolambda/eth2fastspec)
  */
 export function processBlock(
-  postState: CachedBeaconState<allForks.BeaconState>,
+  postState: BeaconStateCachedAllForks,
   block: allForks.BeaconBlock,
   options?: {verifySignatures?: boolean},
   metrics?: IBeaconStateTransitionMetrics | null
@@ -110,10 +117,10 @@ export function processBlock(
  * Implementation Note: follows the optimizations in protolambda's eth2fastspec (https://github.com/protolambda/eth2fastspec)
  */
 export function processSlots(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   slot: Slot,
   metrics?: IBeaconStateTransitionMetrics | null
-): CachedBeaconState<allForks.BeaconState> {
+): BeaconStateCachedAllForks {
   let postState = state.clone();
 
   // Turn caches into a data-structure optimized for fast writes

--- a/packages/beacon-state-transition/src/allForks/util/cachedBeaconState.ts
+++ b/packages/beacon-state-transition/src/allForks/util/cachedBeaconState.ts
@@ -10,7 +10,7 @@ import {
   readonlyValues,
   TreeBacked,
 } from "@chainsafe/ssz";
-import {allForks, altair, Number64, ParticipationFlags} from "@chainsafe/lodestar-types";
+import {allForks, altair, bellatrix, Number64, ParticipationFlags, phase0} from "@chainsafe/lodestar-types";
 import {createIBeaconConfig, IBeaconConfig, IChainForkConfig} from "@chainsafe/lodestar-config";
 import {Tree} from "@chainsafe/persistent-merkle-tree";
 import {MutableVector} from "@chainsafe/persistent-ts";
@@ -88,6 +88,16 @@ export type CachedBeaconState<T extends allForks.BeaconState> =
     ITreeBacked<T> &
     // Beacon State interface
     T;
+
+export type BeaconStateCachedPhase0 = CachedBeaconState<phase0.BeaconState>;
+export type BeaconStateCachedAltair = CachedBeaconState<altair.BeaconState>;
+export type BeaconStateCachedBellatrix = CachedBeaconState<bellatrix.BeaconState>;
+export type BeaconStateCachedAllForks = CachedBeaconState<allForks.BeaconState>;
+export type BeaconStateCachedAnyFork =
+  | BeaconStateCachedPhase0
+  | BeaconStateCachedAltair
+  | BeaconStateCachedBellatrix
+  | BeaconStateCachedAllForks;
 
 export function createCachedBeaconState<T extends allForks.BeaconState>(
   chainForkConfig: IChainForkConfig,
@@ -357,8 +367,8 @@ export class BeaconStateContext<T extends allForks.BeaconState> {
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export const CachedBeaconStateProxyHandler: ProxyHandler<CachedBeaconState<allForks.BeaconState>> = {
-  get(target: CachedBeaconState<allForks.BeaconState>, key: string): unknown {
+export const CachedBeaconStateProxyHandler: ProxyHandler<BeaconStateCachedAllForks> = {
+  get(target: BeaconStateCachedAllForks, key: string): unknown {
     if (key === "balanceList") {
       return target.balanceList;
     } else if (key === "previousEpochParticipation") {
@@ -382,7 +392,7 @@ export const CachedBeaconStateProxyHandler: ProxyHandler<CachedBeaconState<allFo
     } else if (key in target.epochCtx) {
       return target.epochCtx[key as keyof EpochContext];
     } else if (key in target) {
-      return target[key as keyof CachedBeaconState<allForks.BeaconState>];
+      return target[key as keyof BeaconStateCachedAllForks];
     } else {
       const treeBacked = target.type.createTreeBacked(target.tree);
       if (key in treeBacked) {
@@ -391,7 +401,7 @@ export const CachedBeaconStateProxyHandler: ProxyHandler<CachedBeaconState<allFo
     }
     return undefined;
   },
-  set(target: CachedBeaconState<allForks.BeaconState>, key: string, value: unknown): boolean {
+  set(target: BeaconStateCachedAllForks, key: string, value: unknown): boolean {
     if (key === "validators") {
       throw new Error("Cannot set validators");
     } else if (key === "balanceList" || key === "balances") {

--- a/packages/beacon-state-transition/src/allForks/util/cachedBeaconState.ts
+++ b/packages/beacon-state-transition/src/allForks/util/cachedBeaconState.ts
@@ -10,7 +10,7 @@ import {
   readonlyValues,
   TreeBacked,
 } from "@chainsafe/ssz";
-import {allForks, altair, bellatrix, Number64, ParticipationFlags, phase0} from "@chainsafe/lodestar-types";
+import {allForks, altair, Number64, ParticipationFlags} from "@chainsafe/lodestar-types";
 import {createIBeaconConfig, IBeaconConfig, IChainForkConfig} from "@chainsafe/lodestar-config";
 import {Tree} from "@chainsafe/persistent-merkle-tree";
 import {MutableVector} from "@chainsafe/persistent-ts";
@@ -88,16 +88,6 @@ export type CachedBeaconState<T extends allForks.BeaconState> =
     ITreeBacked<T> &
     // Beacon State interface
     T;
-
-export type BeaconStateCachedPhase0 = CachedBeaconState<phase0.BeaconState>;
-export type BeaconStateCachedAltair = CachedBeaconState<altair.BeaconState>;
-export type BeaconStateCachedBellatrix = CachedBeaconState<bellatrix.BeaconState>;
-export type BeaconStateCachedAllForks = CachedBeaconState<allForks.BeaconState>;
-export type BeaconStateCachedAnyFork =
-  | BeaconStateCachedPhase0
-  | BeaconStateCachedAltair
-  | BeaconStateCachedBellatrix
-  | BeaconStateCachedAllForks;
 
 export function createCachedBeaconState<T extends allForks.BeaconState>(
   chainForkConfig: IChainForkConfig,
@@ -367,8 +357,8 @@ export class BeaconStateContext<T extends allForks.BeaconState> {
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export const CachedBeaconStateProxyHandler: ProxyHandler<BeaconStateCachedAllForks> = {
-  get(target: BeaconStateCachedAllForks, key: string): unknown {
+export const CachedBeaconStateProxyHandler: ProxyHandler<CachedBeaconState<allForks.BeaconState>> = {
+  get(target: CachedBeaconState<allForks.BeaconState>, key: string): unknown {
     if (key === "balanceList") {
       return target.balanceList;
     } else if (key === "previousEpochParticipation") {
@@ -392,7 +382,7 @@ export const CachedBeaconStateProxyHandler: ProxyHandler<BeaconStateCachedAllFor
     } else if (key in target.epochCtx) {
       return target.epochCtx[key as keyof EpochContext];
     } else if (key in target) {
-      return target[key as keyof BeaconStateCachedAllForks];
+      return target[key as keyof CachedBeaconState<allForks.BeaconState>];
     } else {
       const treeBacked = target.type.createTreeBacked(target.tree);
       if (key in treeBacked) {
@@ -401,7 +391,7 @@ export const CachedBeaconStateProxyHandler: ProxyHandler<BeaconStateCachedAllFor
     }
     return undefined;
   },
-  set(target: BeaconStateCachedAllForks, key: string, value: unknown): boolean {
+  set(target: CachedBeaconState<allForks.BeaconState>, key: string, value: unknown): boolean {
     if (key === "validators") {
       throw new Error("Cannot set validators");
     } else if (key === "balanceList" || key === "balances") {

--- a/packages/beacon-state-transition/src/allForks/util/epochContext.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochContext.ts
@@ -40,7 +40,7 @@ import {
 } from "../../util";
 import {computeEpochShuffling, IEpochShuffling} from "./epochShuffling";
 import {computeBaseRewardPerIncrement} from "../../altair/util/misc";
-import {BeaconStateCachedAllForks} from "./cachedBeaconState";
+import {CachedBeaconState} from "./cachedBeaconState";
 import {IEpochProcess} from "./epochProcess";
 
 export type AttesterDuty = {
@@ -312,7 +312,7 @@ export function computeSyncParticipantReward(config: IBeaconConfig, totalActiveB
  * Called to re-use information, such as the shuffling of the next epoch, after transitioning into a
  * new epoch.
  */
-export function afterProcessEpoch(state: BeaconStateCachedAllForks, epochProcess: IEpochProcess): void {
+export function afterProcessEpoch(state: CachedBeaconState<allForks.BeaconState>, epochProcess: IEpochProcess): void {
   const {epochCtx} = state;
   epochCtx.previousShuffling = epochCtx.currentShuffling;
   epochCtx.currentShuffling = epochCtx.nextShuffling;

--- a/packages/beacon-state-transition/src/allForks/util/epochContext.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochContext.ts
@@ -40,7 +40,7 @@ import {
 } from "../../util";
 import {computeEpochShuffling, IEpochShuffling} from "./epochShuffling";
 import {computeBaseRewardPerIncrement} from "../../altair/util/misc";
-import {CachedBeaconState} from "./cachedBeaconState";
+import {BeaconStateCachedAllForks} from "./cachedBeaconState";
 import {IEpochProcess} from "./epochProcess";
 
 export type AttesterDuty = {
@@ -312,7 +312,7 @@ export function computeSyncParticipantReward(config: IBeaconConfig, totalActiveB
  * Called to re-use information, such as the shuffling of the next epoch, after transitioning into a
  * new epoch.
  */
-export function afterProcessEpoch(state: CachedBeaconState<allForks.BeaconState>, epochProcess: IEpochProcess): void {
+export function afterProcessEpoch(state: BeaconStateCachedAllForks, epochProcess: IEpochProcess): void {
   const {epochCtx} = state;
   epochCtx.previousShuffling = epochCtx.currentShuffling;
   epochCtx.currentShuffling = epochCtx.nextShuffling;

--- a/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
@@ -1,4 +1,4 @@
-import {Epoch, ValidatorIndex, allForks} from "@chainsafe/lodestar-types";
+import {Epoch, ValidatorIndex, allForks, phase0} from "@chainsafe/lodestar-types";
 import {intDiv} from "@chainsafe/lodestar-utils";
 import {
   EFFECTIVE_BALANCE_INCREMENT,
@@ -23,7 +23,7 @@ import {
   FLAG_CURR_HEAD_ATTESTER,
 } from "./attesterStatus";
 import {IEpochStakeSummary} from "./epochStakeSummary";
-import {CachedBeaconState, BeaconStateCachedPhase0} from "./cachedBeaconState";
+import {CachedBeaconState} from "./cachedBeaconState";
 import {statusProcessEpoch} from "../../phase0/epoch/processPendingAttestations";
 import {computeBaseRewardPerIncrement} from "../../altair/util/misc";
 import {readonlyValuesListOfLeafNodeStruct} from "@chainsafe/ssz";
@@ -261,19 +261,20 @@ export function beforeProcessEpoch<T extends allForks.BeaconState>(state: Cached
   );
 
   if (forkName === ForkName.phase0) {
+    const statePhase0 = (state as unknown) as CachedBeaconState<phase0.BeaconState>;
     statusProcessEpoch(
-      state,
+      statePhase0,
       statuses,
-      ((state as unknown) as BeaconStateCachedPhase0).previousEpochAttestations,
+      statePhase0.previousEpochAttestations,
       prevEpoch,
       FLAG_PREV_SOURCE_ATTESTER,
       FLAG_PREV_TARGET_ATTESTER,
       FLAG_PREV_HEAD_ATTESTER
     );
     statusProcessEpoch(
-      state,
+      statePhase0,
       statuses,
-      ((state as unknown) as BeaconStateCachedPhase0).currentEpochAttestations,
+      statePhase0.currentEpochAttestations,
       currentEpoch,
       FLAG_CURR_SOURCE_ATTESTER,
       FLAG_CURR_TARGET_ATTESTER,

--- a/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
+++ b/packages/beacon-state-transition/src/allForks/util/epochProcess.ts
@@ -1,4 +1,4 @@
-import {Epoch, ValidatorIndex, phase0, allForks} from "@chainsafe/lodestar-types";
+import {Epoch, ValidatorIndex, allForks} from "@chainsafe/lodestar-types";
 import {intDiv} from "@chainsafe/lodestar-utils";
 import {
   EFFECTIVE_BALANCE_INCREMENT,
@@ -23,7 +23,7 @@ import {
   FLAG_CURR_HEAD_ATTESTER,
 } from "./attesterStatus";
 import {IEpochStakeSummary} from "./epochStakeSummary";
-import {CachedBeaconState} from "./cachedBeaconState";
+import {CachedBeaconState, BeaconStateCachedPhase0} from "./cachedBeaconState";
 import {statusProcessEpoch} from "../../phase0/epoch/processPendingAttestations";
 import {computeBaseRewardPerIncrement} from "../../altair/util/misc";
 import {readonlyValuesListOfLeafNodeStruct} from "@chainsafe/ssz";
@@ -264,7 +264,7 @@ export function beforeProcessEpoch<T extends allForks.BeaconState>(state: Cached
     statusProcessEpoch(
       state,
       statuses,
-      ((state as unknown) as CachedBeaconState<phase0.BeaconState>).previousEpochAttestations,
+      ((state as unknown) as BeaconStateCachedPhase0).previousEpochAttestations,
       prevEpoch,
       FLAG_PREV_SOURCE_ATTESTER,
       FLAG_PREV_TARGET_ATTESTER,
@@ -273,7 +273,7 @@ export function beforeProcessEpoch<T extends allForks.BeaconState>(state: Cached
     statusProcessEpoch(
       state,
       statuses,
-      ((state as unknown) as CachedBeaconState<phase0.BeaconState>).currentEpochAttestations,
+      ((state as unknown) as BeaconStateCachedPhase0).currentEpochAttestations,
       currentEpoch,
       FLAG_CURR_SOURCE_ATTESTER,
       FLAG_CURR_TARGET_ATTESTER,

--- a/packages/beacon-state-transition/src/allForks/util/indexedSyncCommittee.ts
+++ b/packages/beacon-state-transition/src/allForks/util/indexedSyncCommittee.ts
@@ -1,7 +1,7 @@
-import {altair, ssz, Slot, ValidatorIndex, BLSPubkey} from "@chainsafe/lodestar-types";
+import {altair, ssz, Slot, ValidatorIndex, BLSPubkey, allForks} from "@chainsafe/lodestar-types";
 import {TreeBacked, Vector} from "@chainsafe/ssz";
 import {computeSyncPeriodAtSlot} from "../../util/epoch";
-import {BeaconStateCachedAllForks, BeaconStateCachedAltair} from "./cachedBeaconState";
+import {CachedBeaconState} from "./cachedBeaconState";
 import {PubkeyIndexMap} from "./epochContext";
 
 type SyncComitteeValidatorIndexMap = Map<ValidatorIndex, number[]>;
@@ -116,7 +116,7 @@ function computeSyncCommitteeIndices(
  * 100 to 200,then you would actually produce signatures in slot 99 - 199.
  */
 export function getIndexedSyncCommittee(
-  state: BeaconStateCachedAllForks | BeaconStateCachedAltair,
+  state: CachedBeaconState<allForks.BeaconState> | CachedBeaconState<altair.BeaconState>,
   slot: Slot
 ): IndexedSyncCommittee {
   const statePeriod = computeSyncPeriodAtSlot(state.slot);

--- a/packages/beacon-state-transition/src/allForks/util/indexedSyncCommittee.ts
+++ b/packages/beacon-state-transition/src/allForks/util/indexedSyncCommittee.ts
@@ -1,7 +1,7 @@
-import {altair, ssz, allForks, Slot, ValidatorIndex, BLSPubkey} from "@chainsafe/lodestar-types";
+import {altair, ssz, Slot, ValidatorIndex, BLSPubkey} from "@chainsafe/lodestar-types";
 import {TreeBacked, Vector} from "@chainsafe/ssz";
 import {computeSyncPeriodAtSlot} from "../../util/epoch";
-import {CachedBeaconState} from "./cachedBeaconState";
+import {BeaconStateCachedAllForks, BeaconStateCachedAltair} from "./cachedBeaconState";
 import {PubkeyIndexMap} from "./epochContext";
 
 type SyncComitteeValidatorIndexMap = Map<ValidatorIndex, number[]>;
@@ -116,7 +116,7 @@ function computeSyncCommitteeIndices(
  * 100 to 200,then you would actually produce signatures in slot 99 - 199.
  */
 export function getIndexedSyncCommittee(
-  state: CachedBeaconState<allForks.BeaconState> | CachedBeaconState<altair.BeaconState>,
+  state: BeaconStateCachedAllForks | BeaconStateCachedAltair,
   slot: Slot
 ): IndexedSyncCommittee {
   const statePeriod = computeSyncPeriodAtSlot(state.slot);

--- a/packages/beacon-state-transition/src/allForks/util/weakSubjectivity.ts
+++ b/packages/beacon-state-transition/src/allForks/util/weakSubjectivity.ts
@@ -9,7 +9,7 @@ import {allForks, Epoch, Root} from "@chainsafe/lodestar-types";
 import {ssz} from "@chainsafe/lodestar-types";
 import {Checkpoint} from "@chainsafe/lodestar-types/phase0";
 import {toHexString} from "@chainsafe/ssz";
-import {BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAllForks} from "../../types";
 import {
   getActiveValidatorIndices,
   getCurrentEpoch,
@@ -28,7 +28,7 @@ const SAFETY_DECAY = BigInt(10);
  */
 export function getLatestWeakSubjectivityCheckpointEpoch(
   config: IChainForkConfig,
-  state: BeaconStateCachedAllForks
+  state: CachedBeaconStateAllForks
 ): Epoch {
   return state.epochCtx.currentShuffling.epoch - computeWeakSubjectivityPeriodCachedState(config, state);
 }
@@ -43,7 +43,7 @@ export function getLatestWeakSubjectivityCheckpointEpoch(
  */
 export function computeWeakSubjectivityPeriodCachedState(
   config: IChainForkConfig,
-  state: BeaconStateCachedAllForks
+  state: CachedBeaconStateAllForks
 ): number {
   const activeValidatorCount = state.currentShuffling.activeIndices.length;
   return computeWeakSubjectivityPeriodFromConstituents(

--- a/packages/beacon-state-transition/src/allForks/util/weakSubjectivity.ts
+++ b/packages/beacon-state-transition/src/allForks/util/weakSubjectivity.ts
@@ -9,7 +9,7 @@ import {allForks, Epoch, Root} from "@chainsafe/lodestar-types";
 import {ssz} from "@chainsafe/lodestar-types";
 import {Checkpoint} from "@chainsafe/lodestar-types/phase0";
 import {toHexString} from "@chainsafe/ssz";
-import {BeaconStateCachedAllForks} from "./cachedBeaconState";
+import {BeaconStateCachedAllForks} from "../../types";
 import {
   getActiveValidatorIndices,
   getCurrentEpoch,

--- a/packages/beacon-state-transition/src/allForks/util/weakSubjectivity.ts
+++ b/packages/beacon-state-transition/src/allForks/util/weakSubjectivity.ts
@@ -9,7 +9,7 @@ import {allForks, Epoch, Root} from "@chainsafe/lodestar-types";
 import {ssz} from "@chainsafe/lodestar-types";
 import {Checkpoint} from "@chainsafe/lodestar-types/phase0";
 import {toHexString} from "@chainsafe/ssz";
-import {CachedBeaconState} from ".";
+import {BeaconStateCachedAllForks} from "./cachedBeaconState";
 import {
   getActiveValidatorIndices,
   getCurrentEpoch,
@@ -28,7 +28,7 @@ const SAFETY_DECAY = BigInt(10);
  */
 export function getLatestWeakSubjectivityCheckpointEpoch(
   config: IChainForkConfig,
-  state: CachedBeaconState<allForks.BeaconState>
+  state: BeaconStateCachedAllForks
 ): Epoch {
   return state.epochCtx.currentShuffling.epoch - computeWeakSubjectivityPeriodCachedState(config, state);
 }
@@ -43,7 +43,7 @@ export function getLatestWeakSubjectivityCheckpointEpoch(
  */
 export function computeWeakSubjectivityPeriodCachedState(
   config: IChainForkConfig,
-  state: CachedBeaconState<allForks.BeaconState>
+  state: BeaconStateCachedAllForks
 ): number {
   const activeValidatorCount = state.currentShuffling.activeIndices.length;
   return computeWeakSubjectivityPeriodFromConstituents(

--- a/packages/beacon-state-transition/src/altair/block/index.ts
+++ b/packages/beacon-state-transition/src/altair/block/index.ts
@@ -1,6 +1,6 @@
-import {allForks, altair} from "@chainsafe/lodestar-types";
+import {altair} from "@chainsafe/lodestar-types";
 
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../allForks/util";
 import {processBlockHeader, processEth1Data, processRandao} from "../../allForks/block";
 import {processOperations} from "./processOperations";
 import {processAttestations, RootCache} from "./processAttestation";
@@ -21,14 +21,10 @@ export {
   processSyncAggregate,
 };
 
-export function processBlock(
-  state: CachedBeaconState<altair.BeaconState>,
-  block: altair.BeaconBlock,
-  verifySignatures = true
-): void {
-  processBlockHeader(state as CachedBeaconState<allForks.BeaconState>, block);
-  processRandao(state as CachedBeaconState<allForks.BeaconState>, block, verifySignatures);
-  processEth1Data(state as CachedBeaconState<allForks.BeaconState>, block.body);
+export function processBlock(state: BeaconStateCachedAltair, block: altair.BeaconBlock, verifySignatures = true): void {
+  processBlockHeader(state as BeaconStateCachedAllForks, block);
+  processRandao(state as BeaconStateCachedAllForks, block, verifySignatures);
+  processEth1Data(state as BeaconStateCachedAllForks, block.body);
   processOperations(state, block.body, verifySignatures);
   processSyncAggregate(state, block, verifySignatures);
 }

--- a/packages/beacon-state-transition/src/altair/block/index.ts
+++ b/packages/beacon-state-transition/src/altair/block/index.ts
@@ -1,6 +1,6 @@
 import {altair} from "@chainsafe/lodestar-types";
 
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../types";
 import {processBlockHeader, processEth1Data, processRandao} from "../../allForks/block";
 import {processOperations} from "./processOperations";
 import {processAttestations, RootCache} from "./processAttestation";

--- a/packages/beacon-state-transition/src/altair/block/index.ts
+++ b/packages/beacon-state-transition/src/altair/block/index.ts
@@ -1,6 +1,6 @@
 import {altair} from "@chainsafe/lodestar-types";
 
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAltair, CachedBeaconStateAllForks} from "../../types";
 import {processBlockHeader, processEth1Data, processRandao} from "../../allForks/block";
 import {processOperations} from "./processOperations";
 import {processAttestations, RootCache} from "./processAttestation";
@@ -21,10 +21,10 @@ export {
   processSyncAggregate,
 };
 
-export function processBlock(state: BeaconStateCachedAltair, block: altair.BeaconBlock, verifySignatures = true): void {
-  processBlockHeader(state as BeaconStateCachedAllForks, block);
-  processRandao(state as BeaconStateCachedAllForks, block, verifySignatures);
-  processEth1Data(state as BeaconStateCachedAllForks, block.body);
+export function processBlock(state: CachedBeaconStateAltair, block: altair.BeaconBlock, verifySignatures = true): void {
+  processBlockHeader(state as CachedBeaconStateAllForks, block);
+  processRandao(state as CachedBeaconStateAllForks, block, verifySignatures);
+  processEth1Data(state as CachedBeaconStateAllForks, block.body);
   processOperations(state, block.body, verifySignatures);
   processSyncAggregate(state, block, verifySignatures);
 }

--- a/packages/beacon-state-transition/src/altair/block/processAttestation.ts
+++ b/packages/beacon-state-transition/src/altair/block/processAttestation.ts
@@ -1,8 +1,8 @@
-import {allForks, altair, Epoch, phase0, Root, Slot, ssz} from "@chainsafe/lodestar-types";
+import {Epoch, phase0, Root, Slot, ssz} from "@chainsafe/lodestar-types";
 import {intSqrt} from "@chainsafe/lodestar-utils";
 
 import {getBlockRoot, getBlockRootAtSlot, increaseBalance, verifySignatureSet} from "../../util";
-import {CachedBeaconState, EpochContext} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks, EpochContext} from "../../allForks/util";
 import {CachedEpochParticipation, IParticipationStatus} from "../../allForks/util/cachedEpochParticipation";
 import {
   EFFECTIVE_BALANCE_INCREMENT,
@@ -20,14 +20,14 @@ import {getAttestationWithIndicesSignatureSet} from "../../allForks";
 const PROPOSER_REWARD_DOMINATOR = ((WEIGHT_DENOMINATOR - PROPOSER_WEIGHT) * WEIGHT_DENOMINATOR) / PROPOSER_WEIGHT;
 
 export function processAttestations(
-  state: CachedBeaconState<altair.BeaconState>,
+  state: BeaconStateCachedAltair,
   attestations: phase0.Attestation[],
   verifySignature = true
 ): void {
   const {epochCtx} = state;
   const {effectiveBalances} = epochCtx;
   const stateSlot = state.slot;
-  const rootCache = new RootCache(state as CachedBeaconState<allForks.BeaconState>);
+  const rootCache = new RootCache(state as BeaconStateCachedAllForks);
 
   // Process all attestations first and then increase the balance of the proposer once
   let proposerReward = 0;
@@ -36,7 +36,7 @@ export function processAttestations(
   for (const attestation of attestations) {
     const data = attestation.data;
 
-    validateAttestation(state as CachedBeaconState<allForks.BeaconState>, attestation);
+    validateAttestation(state as BeaconStateCachedAllForks, attestation);
 
     // Retrieve the validator indices from the attestation participation bitfield
     const attestingIndices = epochCtx.getAttestingIndices(data, attestation.aggregationBits);
@@ -46,7 +46,7 @@ export function processAttestations(
     // we can verify only that and nothing else.
     if (verifySignature) {
       const sigSet = getAttestationWithIndicesSignatureSet(
-        state as CachedBeaconState<allForks.BeaconState>,
+        state as BeaconStateCachedAllForks,
         attestation,
         attestingIndices
       );
@@ -168,7 +168,7 @@ export class RootCache {
   private readonly blockRootEpochCache = new Map<Epoch, Root>();
   private readonly blockRootSlotCache = new Map<Slot, Root>();
 
-  constructor(private readonly state: CachedBeaconState<allForks.BeaconState>) {
+  constructor(private readonly state: BeaconStateCachedAllForks) {
     this.currentJustifiedCheckpoint = state.currentJustifiedCheckpoint;
     this.previousJustifiedCheckpoint = state.previousJustifiedCheckpoint;
   }

--- a/packages/beacon-state-transition/src/altair/block/processAttestation.ts
+++ b/packages/beacon-state-transition/src/altair/block/processAttestation.ts
@@ -2,7 +2,7 @@ import {Epoch, phase0, Root, Slot, ssz} from "@chainsafe/lodestar-types";
 import {intSqrt} from "@chainsafe/lodestar-utils";
 
 import {getBlockRoot, getBlockRootAtSlot, increaseBalance, verifySignatureSet} from "../../util";
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks, EpochContext} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks, EpochContext} from "../../types";
 import {CachedEpochParticipation, IParticipationStatus} from "../../allForks/util/cachedEpochParticipation";
 import {
   EFFECTIVE_BALANCE_INCREMENT,

--- a/packages/beacon-state-transition/src/altair/block/processAttestation.ts
+++ b/packages/beacon-state-transition/src/altair/block/processAttestation.ts
@@ -2,7 +2,7 @@ import {Epoch, phase0, Root, Slot, ssz} from "@chainsafe/lodestar-types";
 import {intSqrt} from "@chainsafe/lodestar-utils";
 
 import {getBlockRoot, getBlockRootAtSlot, increaseBalance, verifySignatureSet} from "../../util";
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks, EpochContext} from "../../types";
+import {CachedBeaconStateAltair, CachedBeaconStateAllForks, EpochContext} from "../../types";
 import {CachedEpochParticipation, IParticipationStatus} from "../../allForks/util/cachedEpochParticipation";
 import {
   EFFECTIVE_BALANCE_INCREMENT,
@@ -20,14 +20,14 @@ import {getAttestationWithIndicesSignatureSet} from "../../allForks";
 const PROPOSER_REWARD_DOMINATOR = ((WEIGHT_DENOMINATOR - PROPOSER_WEIGHT) * WEIGHT_DENOMINATOR) / PROPOSER_WEIGHT;
 
 export function processAttestations(
-  state: BeaconStateCachedAltair,
+  state: CachedBeaconStateAltair,
   attestations: phase0.Attestation[],
   verifySignature = true
 ): void {
   const {epochCtx} = state;
   const {effectiveBalances} = epochCtx;
   const stateSlot = state.slot;
-  const rootCache = new RootCache(state as BeaconStateCachedAllForks);
+  const rootCache = new RootCache(state as CachedBeaconStateAllForks);
 
   // Process all attestations first and then increase the balance of the proposer once
   let proposerReward = 0;
@@ -36,7 +36,7 @@ export function processAttestations(
   for (const attestation of attestations) {
     const data = attestation.data;
 
-    validateAttestation(state as BeaconStateCachedAllForks, attestation);
+    validateAttestation(state as CachedBeaconStateAllForks, attestation);
 
     // Retrieve the validator indices from the attestation participation bitfield
     const attestingIndices = epochCtx.getAttestingIndices(data, attestation.aggregationBits);
@@ -46,7 +46,7 @@ export function processAttestations(
     // we can verify only that and nothing else.
     if (verifySignature) {
       const sigSet = getAttestationWithIndicesSignatureSet(
-        state as BeaconStateCachedAllForks,
+        state as CachedBeaconStateAllForks,
         attestation,
         attestingIndices
       );
@@ -168,7 +168,7 @@ export class RootCache {
   private readonly blockRootEpochCache = new Map<Epoch, Root>();
   private readonly blockRootSlotCache = new Map<Slot, Root>();
 
-  constructor(private readonly state: BeaconStateCachedAllForks) {
+  constructor(private readonly state: CachedBeaconStateAllForks) {
     this.currentJustifiedCheckpoint = state.currentJustifiedCheckpoint;
     this.previousJustifiedCheckpoint = state.previousJustifiedCheckpoint;
   }

--- a/packages/beacon-state-transition/src/altair/block/processAttesterSlashing.ts
+++ b/packages/beacon-state-transition/src/altair/block/processAttesterSlashing.ts
@@ -1,16 +1,16 @@
-import {allForks, altair, phase0} from "@chainsafe/lodestar-types";
+import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../allForks/util";
 import {processAttesterSlashing as processAttesterSlashingAllForks} from "../../allForks/block";
 
 export function processAttesterSlashing(
-  state: CachedBeaconState<altair.BeaconState>,
+  state: BeaconStateCachedAltair,
   attesterSlashing: phase0.AttesterSlashing,
   verifySignatures = true
 ): void {
   processAttesterSlashingAllForks(
     ForkName.altair,
-    state as CachedBeaconState<allForks.BeaconState>,
+    state as BeaconStateCachedAllForks,
     attesterSlashing,
     verifySignatures
   );

--- a/packages/beacon-state-transition/src/altair/block/processAttesterSlashing.ts
+++ b/packages/beacon-state-transition/src/altair/block/processAttesterSlashing.ts
@@ -1,16 +1,16 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAltair, CachedBeaconStateAllForks} from "../../types";
 import {processAttesterSlashing as processAttesterSlashingAllForks} from "../../allForks/block";
 
 export function processAttesterSlashing(
-  state: BeaconStateCachedAltair,
+  state: CachedBeaconStateAltair,
   attesterSlashing: phase0.AttesterSlashing,
   verifySignatures = true
 ): void {
   processAttesterSlashingAllForks(
     ForkName.altair,
-    state as BeaconStateCachedAllForks,
+    state as CachedBeaconStateAllForks,
     attesterSlashing,
     verifySignatures
   );

--- a/packages/beacon-state-transition/src/altair/block/processAttesterSlashing.ts
+++ b/packages/beacon-state-transition/src/altair/block/processAttesterSlashing.ts
@@ -1,6 +1,6 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../types";
 import {processAttesterSlashing as processAttesterSlashingAllForks} from "../../allForks/block";
 
 export function processAttesterSlashing(

--- a/packages/beacon-state-transition/src/altair/block/processDeposit.ts
+++ b/packages/beacon-state-transition/src/altair/block/processDeposit.ts
@@ -1,7 +1,7 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../types";
 import {processDeposit as processDepositAllForks} from "../../allForks/block";
 
 export function processDeposit(state: BeaconStateCachedAltair, deposit: phase0.Deposit): void {

--- a/packages/beacon-state-transition/src/altair/block/processDeposit.ts
+++ b/packages/beacon-state-transition/src/altair/block/processDeposit.ts
@@ -1,9 +1,9 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAltair, CachedBeaconStateAllForks} from "../../types";
 import {processDeposit as processDepositAllForks} from "../../allForks/block";
 
-export function processDeposit(state: BeaconStateCachedAltair, deposit: phase0.Deposit): void {
-  processDepositAllForks(ForkName.altair, state as BeaconStateCachedAllForks, deposit);
+export function processDeposit(state: CachedBeaconStateAltair, deposit: phase0.Deposit): void {
+  processDepositAllForks(ForkName.altair, state as CachedBeaconStateAllForks, deposit);
 }

--- a/packages/beacon-state-transition/src/altair/block/processDeposit.ts
+++ b/packages/beacon-state-transition/src/altair/block/processDeposit.ts
@@ -1,9 +1,9 @@
-import {allForks, altair, phase0} from "@chainsafe/lodestar-types";
+import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../allForks/util";
 import {processDeposit as processDepositAllForks} from "../../allForks/block";
 
-export function processDeposit(state: CachedBeaconState<altair.BeaconState>, deposit: phase0.Deposit): void {
-  processDepositAllForks(ForkName.altair, state as CachedBeaconState<allForks.BeaconState>, deposit);
+export function processDeposit(state: BeaconStateCachedAltair, deposit: phase0.Deposit): void {
+  processDepositAllForks(ForkName.altair, state as BeaconStateCachedAllForks, deposit);
 }

--- a/packages/beacon-state-transition/src/altair/block/processOperations.ts
+++ b/packages/beacon-state-transition/src/altair/block/processOperations.ts
@@ -1,7 +1,7 @@
 import {readonlyValues} from "@chainsafe/ssz";
 import {altair} from "@chainsafe/lodestar-types";
 
-import {BeaconStateCachedAltair} from "../../allForks/util";
+import {BeaconStateCachedAltair} from "../../types";
 import {processProposerSlashing} from "./processProposerSlashing";
 import {processAttesterSlashing} from "./processAttesterSlashing";
 import {processAttestations} from "./processAttestation";

--- a/packages/beacon-state-transition/src/altair/block/processOperations.ts
+++ b/packages/beacon-state-transition/src/altair/block/processOperations.ts
@@ -1,7 +1,7 @@
 import {readonlyValues} from "@chainsafe/ssz";
 import {altair} from "@chainsafe/lodestar-types";
 
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedAltair} from "../../allForks/util";
 import {processProposerSlashing} from "./processProposerSlashing";
 import {processAttesterSlashing} from "./processAttesterSlashing";
 import {processAttestations} from "./processAttestation";
@@ -10,7 +10,7 @@ import {processVoluntaryExit} from "./processVoluntaryExit";
 import {MAX_DEPOSITS} from "@chainsafe/lodestar-params";
 
 export function processOperations(
-  state: CachedBeaconState<altair.BeaconState>,
+  state: BeaconStateCachedAltair,
   body: altair.BeaconBlockBody,
   verifySignatures = true
 ): void {

--- a/packages/beacon-state-transition/src/altair/block/processOperations.ts
+++ b/packages/beacon-state-transition/src/altair/block/processOperations.ts
@@ -1,7 +1,7 @@
 import {readonlyValues} from "@chainsafe/ssz";
 import {altair} from "@chainsafe/lodestar-types";
 
-import {BeaconStateCachedAltair} from "../../types";
+import {CachedBeaconStateAltair} from "../../types";
 import {processProposerSlashing} from "./processProposerSlashing";
 import {processAttesterSlashing} from "./processAttesterSlashing";
 import {processAttestations} from "./processAttestation";
@@ -10,7 +10,7 @@ import {processVoluntaryExit} from "./processVoluntaryExit";
 import {MAX_DEPOSITS} from "@chainsafe/lodestar-params";
 
 export function processOperations(
-  state: BeaconStateCachedAltair,
+  state: CachedBeaconStateAltair,
   body: altair.BeaconBlockBody,
   verifySignatures = true
 ): void {

--- a/packages/beacon-state-transition/src/altair/block/processProposerSlashing.ts
+++ b/packages/beacon-state-transition/src/altair/block/processProposerSlashing.ts
@@ -1,16 +1,16 @@
-import {allForks, altair, phase0} from "@chainsafe/lodestar-types";
+import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../allForks/util";
 import {processProposerSlashing as processProposerSlashingAllForks} from "../../allForks/block";
 
 export function processProposerSlashing(
-  state: CachedBeaconState<altair.BeaconState>,
+  state: BeaconStateCachedAltair,
   proposerSlashing: phase0.ProposerSlashing,
   verifySignatures = true
 ): void {
   processProposerSlashingAllForks(
     ForkName.altair,
-    state as CachedBeaconState<allForks.BeaconState>,
+    state as BeaconStateCachedAllForks,
     proposerSlashing,
     verifySignatures
   );

--- a/packages/beacon-state-transition/src/altair/block/processProposerSlashing.ts
+++ b/packages/beacon-state-transition/src/altair/block/processProposerSlashing.ts
@@ -1,16 +1,16 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAltair, CachedBeaconStateAllForks} from "../../types";
 import {processProposerSlashing as processProposerSlashingAllForks} from "../../allForks/block";
 
 export function processProposerSlashing(
-  state: BeaconStateCachedAltair,
+  state: CachedBeaconStateAltair,
   proposerSlashing: phase0.ProposerSlashing,
   verifySignatures = true
 ): void {
   processProposerSlashingAllForks(
     ForkName.altair,
-    state as BeaconStateCachedAllForks,
+    state as CachedBeaconStateAllForks,
     proposerSlashing,
     verifySignatures
   );

--- a/packages/beacon-state-transition/src/altair/block/processProposerSlashing.ts
+++ b/packages/beacon-state-transition/src/altair/block/processProposerSlashing.ts
@@ -1,6 +1,6 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../types";
 import {processProposerSlashing as processProposerSlashingAllForks} from "../../allForks/block";
 
 export function processProposerSlashing(

--- a/packages/beacon-state-transition/src/altair/block/processSyncCommittee.ts
+++ b/packages/beacon-state-transition/src/altair/block/processSyncCommittee.ts
@@ -10,11 +10,11 @@ import {
   zipAllIndexesSyncCommitteeBits,
   zipIndexesSyncCommitteeBits,
 } from "../../util";
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedAltair} from "../../allForks/util";
 import {G2_POINT_AT_INFINITY} from "../../constants";
 
 export function processSyncAggregate(
-  state: CachedBeaconState<altair.BeaconState>,
+  state: BeaconStateCachedAltair,
   block: altair.BeaconBlock,
   verifySignatures = true
 ): void {
@@ -43,7 +43,7 @@ export function processSyncAggregate(
 }
 
 export function getSyncCommitteeSignatureSet(
-  state: CachedBeaconState<altair.BeaconState>,
+  state: BeaconStateCachedAltair,
   block: altair.BeaconBlock,
   /** Optional parameter to prevent computing it twice */
   participantIndices?: number[]
@@ -92,19 +92,13 @@ export function getSyncCommitteeSignatureSet(
 }
 
 /** Get participant indices for a sync committee. */
-function getParticipantIndices(
-  state: CachedBeaconState<altair.BeaconState>,
-  syncAggregate: altair.SyncAggregate
-): number[] {
+function getParticipantIndices(state: BeaconStateCachedAltair, syncAggregate: altair.SyncAggregate): number[] {
   const committeeIndices = state.currentSyncCommittee.validatorIndices;
   return zipIndexesSyncCommitteeBits(committeeIndices, syncAggregate.syncCommitteeBits);
 }
 
 /** Return [0] as participant indices and [1] as unparticipant indices for a sync committee. */
-function getParticipantInfo(
-  state: CachedBeaconState<altair.BeaconState>,
-  syncAggregate: altair.SyncAggregate
-): [number[], number[]] {
+function getParticipantInfo(state: BeaconStateCachedAltair, syncAggregate: altair.SyncAggregate): [number[], number[]] {
   const committeeIndices = state.currentSyncCommittee.validatorIndices;
   return zipAllIndexesSyncCommitteeBits(committeeIndices, syncAggregate.syncCommitteeBits);
 }

--- a/packages/beacon-state-transition/src/altair/block/processSyncCommittee.ts
+++ b/packages/beacon-state-transition/src/altair/block/processSyncCommittee.ts
@@ -10,7 +10,7 @@ import {
   zipAllIndexesSyncCommitteeBits,
   zipIndexesSyncCommitteeBits,
 } from "../../util";
-import {BeaconStateCachedAltair} from "../../allForks/util";
+import {BeaconStateCachedAltair} from "../../types";
 import {G2_POINT_AT_INFINITY} from "../../constants";
 
 export function processSyncAggregate(

--- a/packages/beacon-state-transition/src/altair/block/processSyncCommittee.ts
+++ b/packages/beacon-state-transition/src/altair/block/processSyncCommittee.ts
@@ -10,11 +10,11 @@ import {
   zipAllIndexesSyncCommitteeBits,
   zipIndexesSyncCommitteeBits,
 } from "../../util";
-import {BeaconStateCachedAltair} from "../../types";
+import {CachedBeaconStateAltair} from "../../types";
 import {G2_POINT_AT_INFINITY} from "../../constants";
 
 export function processSyncAggregate(
-  state: BeaconStateCachedAltair,
+  state: CachedBeaconStateAltair,
   block: altair.BeaconBlock,
   verifySignatures = true
 ): void {
@@ -43,7 +43,7 @@ export function processSyncAggregate(
 }
 
 export function getSyncCommitteeSignatureSet(
-  state: BeaconStateCachedAltair,
+  state: CachedBeaconStateAltair,
   block: altair.BeaconBlock,
   /** Optional parameter to prevent computing it twice */
   participantIndices?: number[]
@@ -92,13 +92,13 @@ export function getSyncCommitteeSignatureSet(
 }
 
 /** Get participant indices for a sync committee. */
-function getParticipantIndices(state: BeaconStateCachedAltair, syncAggregate: altair.SyncAggregate): number[] {
+function getParticipantIndices(state: CachedBeaconStateAltair, syncAggregate: altair.SyncAggregate): number[] {
   const committeeIndices = state.currentSyncCommittee.validatorIndices;
   return zipIndexesSyncCommitteeBits(committeeIndices, syncAggregate.syncCommitteeBits);
 }
 
 /** Return [0] as participant indices and [1] as unparticipant indices for a sync committee. */
-function getParticipantInfo(state: BeaconStateCachedAltair, syncAggregate: altair.SyncAggregate): [number[], number[]] {
+function getParticipantInfo(state: CachedBeaconStateAltair, syncAggregate: altair.SyncAggregate): [number[], number[]] {
   const committeeIndices = state.currentSyncCommittee.validatorIndices;
   return zipAllIndexesSyncCommitteeBits(committeeIndices, syncAggregate.syncCommitteeBits);
 }

--- a/packages/beacon-state-transition/src/altair/block/processVoluntaryExit.ts
+++ b/packages/beacon-state-transition/src/altair/block/processVoluntaryExit.ts
@@ -1,11 +1,11 @@
-import {allForks, altair, phase0} from "@chainsafe/lodestar-types";
-import {CachedBeaconState} from "../../allForks";
+import {phase0} from "@chainsafe/lodestar-types";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../allForks";
 import {processVoluntaryExitAllForks} from "../../allForks/block";
 
 export function processVoluntaryExit(
-  state: CachedBeaconState<altair.BeaconState>,
+  state: BeaconStateCachedAltair,
   signedVoluntaryExit: phase0.SignedVoluntaryExit,
   verifySignature = true
 ): void {
-  processVoluntaryExitAllForks(state as CachedBeaconState<allForks.BeaconState>, signedVoluntaryExit, verifySignature);
+  processVoluntaryExitAllForks(state as BeaconStateCachedAllForks, signedVoluntaryExit, verifySignature);
 }

--- a/packages/beacon-state-transition/src/altair/block/processVoluntaryExit.ts
+++ b/packages/beacon-state-transition/src/altair/block/processVoluntaryExit.ts
@@ -1,5 +1,5 @@
 import {phase0} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../allForks";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../types";
 import {processVoluntaryExitAllForks} from "../../allForks/block";
 
 export function processVoluntaryExit(

--- a/packages/beacon-state-transition/src/altair/block/processVoluntaryExit.ts
+++ b/packages/beacon-state-transition/src/altair/block/processVoluntaryExit.ts
@@ -1,11 +1,11 @@
 import {phase0} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAltair, CachedBeaconStateAllForks} from "../../types";
 import {processVoluntaryExitAllForks} from "../../allForks/block";
 
 export function processVoluntaryExit(
-  state: BeaconStateCachedAltair,
+  state: CachedBeaconStateAltair,
   signedVoluntaryExit: phase0.SignedVoluntaryExit,
   verifySignature = true
 ): void {
-  processVoluntaryExitAllForks(state as BeaconStateCachedAllForks, signedVoluntaryExit, verifySignature);
+  processVoluntaryExitAllForks(state as CachedBeaconStateAllForks, signedVoluntaryExit, verifySignature);
 }

--- a/packages/beacon-state-transition/src/altair/epoch/balance.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/balance.ts
@@ -1,4 +1,3 @@
-import {allForks, altair} from "@chainsafe/lodestar-types";
 import {
   EFFECTIVE_BALANCE_INCREMENT,
   INACTIVITY_PENALTY_QUOTIENT_ALTAIR,
@@ -11,7 +10,8 @@ import {
   ForkName,
 } from "@chainsafe/lodestar-params";
 import {
-  CachedBeaconState,
+  BeaconStateCachedAltair,
+  BeaconStateCachedAllForks,
   FLAG_ELIGIBLE_ATTESTER,
   FLAG_PREV_HEAD_ATTESTER_OR_UNSLASHED,
   FLAG_PREV_SOURCE_ATTESTER_OR_UNSLASHED,
@@ -44,7 +44,7 @@ interface IRewardPenaltyItem {
  *   - eligibleAttester:   98%
  */
 export function getRewardsPenaltiesDeltas(
-  state: CachedBeaconState<altair.BeaconState>,
+  state: BeaconStateCachedAltair,
   process: IEpochProcess
 ): [number[], number[]] {
   // TODO: Is there a cheaper way to measure length that going to `state.validators`?
@@ -53,7 +53,7 @@ export function getRewardsPenaltiesDeltas(
   const rewards = newZeroedArray(validatorCount);
   const penalties = newZeroedArray(validatorCount);
 
-  const isInInactivityLeakBn = isInInactivityLeak(state as CachedBeaconState<allForks.BeaconState>);
+  const isInInactivityLeakBn = isInInactivityLeak(state as BeaconStateCachedAllForks);
   // effectiveBalance is multiple of EFFECTIVE_BALANCE_INCREMENT and less than MAX_EFFECTIVE_BALANCE
   // so there are limited values of them like 32000000000, 31000000000, 30000000000
   const rewardPenaltyItemCache = new Map<number, IRewardPenaltyItem>();

--- a/packages/beacon-state-transition/src/altair/epoch/balance.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/balance.ts
@@ -9,16 +9,14 @@ import {
   WEIGHT_DENOMINATOR,
   ForkName,
 } from "@chainsafe/lodestar-params";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks, IEpochProcess} from "../../types";
 import {
-  BeaconStateCachedAltair,
-  BeaconStateCachedAllForks,
   FLAG_ELIGIBLE_ATTESTER,
   FLAG_PREV_HEAD_ATTESTER_OR_UNSLASHED,
   FLAG_PREV_SOURCE_ATTESTER_OR_UNSLASHED,
   FLAG_PREV_TARGET_ATTESTER_OR_UNSLASHED,
   hasMarkers,
-  IEpochProcess,
-} from "../../allForks/util";
+} from "../../allForks";
 import {isInInactivityLeak, newZeroedArray} from "../../util";
 
 interface IRewardPenaltyItem {

--- a/packages/beacon-state-transition/src/altair/epoch/balance.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/balance.ts
@@ -9,7 +9,7 @@ import {
   WEIGHT_DENOMINATOR,
   ForkName,
 } from "@chainsafe/lodestar-params";
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks, IEpochProcess} from "../../types";
+import {CachedBeaconStateAltair, CachedBeaconStateAllForks, IEpochProcess} from "../../types";
 import {
   FLAG_ELIGIBLE_ATTESTER,
   FLAG_PREV_HEAD_ATTESTER_OR_UNSLASHED,
@@ -42,7 +42,7 @@ interface IRewardPenaltyItem {
  *   - eligibleAttester:   98%
  */
 export function getRewardsPenaltiesDeltas(
-  state: BeaconStateCachedAltair,
+  state: CachedBeaconStateAltair,
   process: IEpochProcess
 ): [number[], number[]] {
   // TODO: Is there a cheaper way to measure length that going to `state.validators`?
@@ -51,7 +51,7 @@ export function getRewardsPenaltiesDeltas(
   const rewards = newZeroedArray(validatorCount);
   const penalties = newZeroedArray(validatorCount);
 
-  const isInInactivityLeakBn = isInInactivityLeak(state as BeaconStateCachedAllForks);
+  const isInInactivityLeakBn = isInInactivityLeak(state as CachedBeaconStateAllForks);
   // effectiveBalance is multiple of EFFECTIVE_BALANCE_INCREMENT and less than MAX_EFFECTIVE_BALANCE
   // so there are limited values of them like 32000000000, 31000000000, 30000000000
   const rewardPenaltyItemCache = new Map<number, IRewardPenaltyItem>();

--- a/packages/beacon-state-transition/src/altair/epoch/index.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/index.ts
@@ -1,4 +1,4 @@
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks, IEpochProcess} from "../../types";
+import {CachedBeaconStateAltair, CachedBeaconStateAllForks, IEpochProcess} from "../../types";
 import {
   processJustificationAndFinalization,
   processRegistryUpdates,
@@ -25,17 +25,17 @@ export {
   processParticipationFlagUpdates,
 };
 
-export function processEpoch(state: BeaconStateCachedAltair, epochProcess: IEpochProcess): void {
-  processJustificationAndFinalization(state as BeaconStateCachedAllForks, epochProcess);
+export function processEpoch(state: CachedBeaconStateAltair, epochProcess: IEpochProcess): void {
+  processJustificationAndFinalization(state as CachedBeaconStateAllForks, epochProcess);
   processInactivityUpdates(state, epochProcess);
   processRewardsAndPenalties(state, epochProcess);
-  processRegistryUpdates(state as BeaconStateCachedAllForks, epochProcess);
+  processRegistryUpdates(state as CachedBeaconStateAllForks, epochProcess);
   processSlashings(state, epochProcess);
-  processEth1DataReset(state as BeaconStateCachedAllForks, epochProcess);
-  processEffectiveBalanceUpdates(state as BeaconStateCachedAllForks, epochProcess);
-  processSlashingsReset(state as BeaconStateCachedAllForks, epochProcess);
-  processRandaoMixesReset(state as BeaconStateCachedAllForks, epochProcess);
-  processHistoricalRootsUpdate(state as BeaconStateCachedAllForks, epochProcess);
+  processEth1DataReset(state as CachedBeaconStateAllForks, epochProcess);
+  processEffectiveBalanceUpdates(state as CachedBeaconStateAllForks, epochProcess);
+  processSlashingsReset(state as CachedBeaconStateAllForks, epochProcess);
+  processRandaoMixesReset(state as CachedBeaconStateAllForks, epochProcess);
+  processHistoricalRootsUpdate(state as CachedBeaconStateAllForks, epochProcess);
   processParticipationFlagUpdates(state);
   processSyncCommitteeUpdates(state, epochProcess);
 }

--- a/packages/beacon-state-transition/src/altair/epoch/index.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/index.ts
@@ -1,5 +1,4 @@
-import {allForks, altair} from "@chainsafe/lodestar-types";
-import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks, IEpochProcess} from "../../allForks/util";
 import {
   processJustificationAndFinalization,
   processRegistryUpdates,
@@ -26,17 +25,17 @@ export {
   processParticipationFlagUpdates,
 };
 
-export function processEpoch(state: CachedBeaconState<altair.BeaconState>, epochProcess: IEpochProcess): void {
-  processJustificationAndFinalization(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+export function processEpoch(state: BeaconStateCachedAltair, epochProcess: IEpochProcess): void {
+  processJustificationAndFinalization(state as BeaconStateCachedAllForks, epochProcess);
   processInactivityUpdates(state, epochProcess);
   processRewardsAndPenalties(state, epochProcess);
-  processRegistryUpdates(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+  processRegistryUpdates(state as BeaconStateCachedAllForks, epochProcess);
   processSlashings(state, epochProcess);
-  processEth1DataReset(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
-  processEffectiveBalanceUpdates(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
-  processSlashingsReset(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
-  processRandaoMixesReset(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
-  processHistoricalRootsUpdate(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+  processEth1DataReset(state as BeaconStateCachedAllForks, epochProcess);
+  processEffectiveBalanceUpdates(state as BeaconStateCachedAllForks, epochProcess);
+  processSlashingsReset(state as BeaconStateCachedAllForks, epochProcess);
+  processRandaoMixesReset(state as BeaconStateCachedAllForks, epochProcess);
+  processHistoricalRootsUpdate(state as BeaconStateCachedAllForks, epochProcess);
   processParticipationFlagUpdates(state);
   processSyncCommitteeUpdates(state, epochProcess);
 }

--- a/packages/beacon-state-transition/src/altair/epoch/index.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/index.ts
@@ -1,4 +1,4 @@
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks, IEpochProcess} from "../../types";
 import {
   processJustificationAndFinalization,
   processRegistryUpdates,

--- a/packages/beacon-state-transition/src/altair/epoch/processInactivityUpdates.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processInactivityUpdates.ts
@@ -1,6 +1,6 @@
 import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
 import {Number64} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks, IEpochProcess} from "../../types";
 import * as attesterStatusUtil from "../../allForks/util/attesterStatus";
 import {isInInactivityLeak} from "../../util";
 

--- a/packages/beacon-state-transition/src/altair/epoch/processInactivityUpdates.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processInactivityUpdates.ts
@@ -1,6 +1,6 @@
 import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
 import {Number64} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks, IEpochProcess} from "../../types";
+import {CachedBeaconStateAltair, CachedBeaconStateAllForks, IEpochProcess} from "../../types";
 import * as attesterStatusUtil from "../../allForks/util/attesterStatus";
 import {isInInactivityLeak} from "../../util";
 
@@ -18,14 +18,14 @@ import {isInInactivityLeak} from "../../util";
  *
  * TODO: Compute from altair testnet inactivityScores updates on average
  */
-export function processInactivityUpdates(state: BeaconStateCachedAltair, epochProcess: IEpochProcess): void {
+export function processInactivityUpdates(state: CachedBeaconStateAltair, epochProcess: IEpochProcess): void {
   if (state.currentShuffling.epoch === GENESIS_EPOCH) {
     return;
   }
   const {config, inactivityScores} = state;
   const {INACTIVITY_SCORE_BIAS, INACTIVITY_SCORE_RECOVERY_RATE} = config;
   const {statuses} = epochProcess;
-  const inActivityLeak = isInInactivityLeak(state as BeaconStateCachedAllForks);
+  const inActivityLeak = isInInactivityLeak(state as CachedBeaconStateAllForks);
 
   // this avoids importing FLAG_ELIGIBLE_ATTESTER inside the for loop, check the compiled code
   const {FLAG_ELIGIBLE_ATTESTER, FLAG_PREV_TARGET_ATTESTER_OR_UNSLASHED, hasMarkers} = attesterStatusUtil;

--- a/packages/beacon-state-transition/src/altair/epoch/processInactivityUpdates.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processInactivityUpdates.ts
@@ -1,6 +1,6 @@
 import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
-import {allForks, altair, Number64} from "@chainsafe/lodestar-types";
-import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
+import {Number64} from "@chainsafe/lodestar-types";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks, IEpochProcess} from "../../allForks/util";
 import * as attesterStatusUtil from "../../allForks/util/attesterStatus";
 import {isInInactivityLeak} from "../../util";
 
@@ -18,17 +18,14 @@ import {isInInactivityLeak} from "../../util";
  *
  * TODO: Compute from altair testnet inactivityScores updates on average
  */
-export function processInactivityUpdates(
-  state: CachedBeaconState<altair.BeaconState>,
-  epochProcess: IEpochProcess
-): void {
+export function processInactivityUpdates(state: BeaconStateCachedAltair, epochProcess: IEpochProcess): void {
   if (state.currentShuffling.epoch === GENESIS_EPOCH) {
     return;
   }
   const {config, inactivityScores} = state;
   const {INACTIVITY_SCORE_BIAS, INACTIVITY_SCORE_RECOVERY_RATE} = config;
   const {statuses} = epochProcess;
-  const inActivityLeak = isInInactivityLeak(state as CachedBeaconState<allForks.BeaconState>);
+  const inActivityLeak = isInInactivityLeak(state as BeaconStateCachedAllForks);
 
   // this avoids importing FLAG_ELIGIBLE_ATTESTER inside the for loop, check the compiled code
   const {FLAG_ELIGIBLE_ATTESTER, FLAG_PREV_TARGET_ATTESTER_OR_UNSLASHED, hasMarkers} = attesterStatusUtil;

--- a/packages/beacon-state-transition/src/altair/epoch/processParticipationFlagUpdates.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processParticipationFlagUpdates.ts
@@ -1,5 +1,5 @@
 import {PersistentVector} from "@chainsafe/persistent-ts";
-import {BeaconStateCachedAltair} from "../../allForks/util";
+import {BeaconStateCachedAltair} from "../../types";
 
 /**
  * Updates `state.previousEpochParticipation` with precalculated epoch participation. Creates a new empty tree for

--- a/packages/beacon-state-transition/src/altair/epoch/processParticipationFlagUpdates.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processParticipationFlagUpdates.ts
@@ -1,5 +1,5 @@
 import {PersistentVector} from "@chainsafe/persistent-ts";
-import {BeaconStateCachedAltair} from "../../types";
+import {CachedBeaconStateAltair} from "../../types";
 
 /**
  * Updates `state.previousEpochParticipation` with precalculated epoch participation. Creates a new empty tree for
@@ -8,7 +8,7 @@ import {BeaconStateCachedAltair} from "../../types";
  * PERF: Cost = 'proportional' $VALIDATOR_COUNT. Since it updates all of them at once, it will always recreate both
  * trees completely.
  */
-export function processParticipationFlagUpdates(state: BeaconStateCachedAltair): void {
+export function processParticipationFlagUpdates(state: CachedBeaconStateAltair): void {
   state.previousEpochParticipation.updateAllStatus(state.currentEpochParticipation.persistent.vector);
   state.currentEpochParticipation.updateAllStatus(
     PersistentVector.from(

--- a/packages/beacon-state-transition/src/altair/epoch/processParticipationFlagUpdates.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processParticipationFlagUpdates.ts
@@ -1,6 +1,5 @@
-import {altair} from "@chainsafe/lodestar-types";
 import {PersistentVector} from "@chainsafe/persistent-ts";
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedAltair} from "../../allForks/util";
 
 /**
  * Updates `state.previousEpochParticipation` with precalculated epoch participation. Creates a new empty tree for
@@ -9,7 +8,7 @@ import {CachedBeaconState} from "../../allForks/util";
  * PERF: Cost = 'proportional' $VALIDATOR_COUNT. Since it updates all of them at once, it will always recreate both
  * trees completely.
  */
-export function processParticipationFlagUpdates(state: CachedBeaconState<altair.BeaconState>): void {
+export function processParticipationFlagUpdates(state: BeaconStateCachedAltair): void {
   state.previousEpochParticipation.updateAllStatus(state.currentEpochParticipation.persistent.vector);
   state.currentEpochParticipation.updateAllStatus(
     PersistentVector.from(

--- a/packages/beacon-state-transition/src/altair/epoch/processRewardsAndPenalties.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processRewardsAndPenalties.ts
@@ -1,4 +1,4 @@
-import {BeaconStateCachedAltair, IEpochProcess} from "../../types";
+import {CachedBeaconStateAltair, IEpochProcess} from "../../types";
 import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
 import {getRewardsPenaltiesDeltas} from "./balance";
 
@@ -8,7 +8,7 @@ import {getRewardsPenaltiesDeltas} from "./balance";
  * PERF: Cost = 'proportional' to $VALIDATOR_COUNT. Extra work is done per validator the more status flags
  * are true, worst case: FLAG_UNSLASHED + FLAG_ELIGIBLE_ATTESTER + FLAG_PREV_*
  */
-export function processRewardsAndPenalties(state: BeaconStateCachedAltair, epochProcess: IEpochProcess): void {
+export function processRewardsAndPenalties(state: CachedBeaconStateAltair, epochProcess: IEpochProcess): void {
   if (state.currentShuffling.epoch == GENESIS_EPOCH) {
     return;
   }

--- a/packages/beacon-state-transition/src/altair/epoch/processRewardsAndPenalties.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processRewardsAndPenalties.ts
@@ -1,5 +1,4 @@
-import {altair} from "@chainsafe/lodestar-types";
-import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedAltair, IEpochProcess} from "../../allForks/util";
 import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
 import {getRewardsPenaltiesDeltas} from "./balance";
 
@@ -9,10 +8,7 @@ import {getRewardsPenaltiesDeltas} from "./balance";
  * PERF: Cost = 'proportional' to $VALIDATOR_COUNT. Extra work is done per validator the more status flags
  * are true, worst case: FLAG_UNSLASHED + FLAG_ELIGIBLE_ATTESTER + FLAG_PREV_*
  */
-export function processRewardsAndPenalties(
-  state: CachedBeaconState<altair.BeaconState>,
-  epochProcess: IEpochProcess
-): void {
+export function processRewardsAndPenalties(state: BeaconStateCachedAltair, epochProcess: IEpochProcess): void {
   if (state.currentShuffling.epoch == GENESIS_EPOCH) {
     return;
   }

--- a/packages/beacon-state-transition/src/altair/epoch/processRewardsAndPenalties.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processRewardsAndPenalties.ts
@@ -1,4 +1,4 @@
-import {BeaconStateCachedAltair, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedAltair, IEpochProcess} from "../../types";
 import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
 import {getRewardsPenaltiesDeltas} from "./balance";
 

--- a/packages/beacon-state-transition/src/altair/epoch/processSlashings.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processSlashings.ts
@@ -1,5 +1,5 @@
 import {ForkName} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks, IEpochProcess} from "../../types";
 import {processSlashingsAllForks} from "../../allForks/epoch/processSlashings";
 
 export function processSlashings(state: BeaconStateCachedAltair, epochProcess: IEpochProcess): void {

--- a/packages/beacon-state-transition/src/altair/epoch/processSlashings.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processSlashings.ts
@@ -1,8 +1,7 @@
-import {allForks, altair} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedAllForks, IEpochProcess} from "../../allForks/util";
 import {processSlashingsAllForks} from "../../allForks/epoch/processSlashings";
 
-export function processSlashings(state: CachedBeaconState<altair.BeaconState>, epochProcess: IEpochProcess): void {
-  processSlashingsAllForks(ForkName.altair, state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+export function processSlashings(state: BeaconStateCachedAltair, epochProcess: IEpochProcess): void {
+  processSlashingsAllForks(ForkName.altair, state as BeaconStateCachedAllForks, epochProcess);
 }

--- a/packages/beacon-state-transition/src/altair/epoch/processSlashings.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processSlashings.ts
@@ -1,7 +1,7 @@
 import {ForkName} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedAltair, BeaconStateCachedAllForks, IEpochProcess} from "../../types";
+import {CachedBeaconStateAltair, CachedBeaconStateAllForks, IEpochProcess} from "../../types";
 import {processSlashingsAllForks} from "../../allForks/epoch/processSlashings";
 
-export function processSlashings(state: BeaconStateCachedAltair, epochProcess: IEpochProcess): void {
-  processSlashingsAllForks(ForkName.altair, state as BeaconStateCachedAllForks, epochProcess);
+export function processSlashings(state: CachedBeaconStateAltair, epochProcess: IEpochProcess): void {
+  processSlashingsAllForks(ForkName.altair, state as CachedBeaconStateAllForks, epochProcess);
 }

--- a/packages/beacon-state-transition/src/altair/epoch/processSyncCommitteeUpdates.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processSyncCommitteeUpdates.ts
@@ -1,4 +1,4 @@
-import {BeaconStateCachedAltair, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedAltair, IEpochProcess} from "../../types";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD} from "@chainsafe/lodestar-params";
 
 /**

--- a/packages/beacon-state-transition/src/altair/epoch/processSyncCommitteeUpdates.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processSyncCommitteeUpdates.ts
@@ -1,4 +1,4 @@
-import {BeaconStateCachedAltair, IEpochProcess} from "../../types";
+import {CachedBeaconStateAltair, IEpochProcess} from "../../types";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD} from "@chainsafe/lodestar-params";
 
 /**
@@ -7,7 +7,7 @@ import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD} from "@chainsafe/lodestar-params";
  * PERF: Once every `EPOCHS_PER_SYNC_COMMITTEE_PERIOD`, do an expensive operation to compute the next committee.
  * Calculating the next sync committee has a proportional cost to $VALIDATOR_COUNT
  */
-export function processSyncCommitteeUpdates(state: BeaconStateCachedAltair, epochProcess: IEpochProcess): void {
+export function processSyncCommitteeUpdates(state: CachedBeaconStateAltair, epochProcess: IEpochProcess): void {
   const nextEpoch = epochProcess.currentEpoch + 1;
   if (nextEpoch % EPOCHS_PER_SYNC_COMMITTEE_PERIOD === 0) {
     state.rotateSyncCommittee();

--- a/packages/beacon-state-transition/src/altair/epoch/processSyncCommitteeUpdates.ts
+++ b/packages/beacon-state-transition/src/altair/epoch/processSyncCommitteeUpdates.ts
@@ -1,5 +1,4 @@
-import {altair} from "@chainsafe/lodestar-types";
-import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedAltair, IEpochProcess} from "../../allForks/util";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD} from "@chainsafe/lodestar-params";
 
 /**
@@ -8,10 +7,7 @@ import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD} from "@chainsafe/lodestar-params";
  * PERF: Once every `EPOCHS_PER_SYNC_COMMITTEE_PERIOD`, do an expensive operation to compute the next committee.
  * Calculating the next sync committee has a proportional cost to $VALIDATOR_COUNT
  */
-export function processSyncCommitteeUpdates(
-  state: CachedBeaconState<altair.BeaconState>,
-  epochProcess: IEpochProcess
-): void {
+export function processSyncCommitteeUpdates(state: BeaconStateCachedAltair, epochProcess: IEpochProcess): void {
   const nextEpoch = epochProcess.currentEpoch + 1;
   if (nextEpoch % EPOCHS_PER_SYNC_COMMITTEE_PERIOD === 0) {
     state.rotateSyncCommittee();

--- a/packages/beacon-state-transition/src/altair/upgradeState.ts
+++ b/packages/beacon-state-transition/src/altair/upgradeState.ts
@@ -1,5 +1,5 @@
 import {altair, ParticipationFlags, phase0, ssz, Uint8} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedPhase0, BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../types";
+import {CachedBeaconStatePhase0, CachedBeaconStateAltair, CachedBeaconStateAllForks} from "../types";
 import {createCachedBeaconState} from "../allForks";
 import {newZeroedArray} from "../util";
 import {List, TreeBacked} from "@chainsafe/ssz";
@@ -11,7 +11,7 @@ import {getNextSyncCommittee} from "./util/syncCommittee";
 /**
  * Upgrade a state from phase0 to altair.
  */
-export function upgradeState(state: BeaconStateCachedPhase0): BeaconStateCachedAltair {
+export function upgradeState(state: CachedBeaconStatePhase0): CachedBeaconStateAltair {
   const {config} = state;
   const pendingAttesations = Array.from(state.previousEpochAttestations);
   const postTreeBackedState = upgradeTreeBackedState(config, state);
@@ -20,7 +20,7 @@ export function upgradeState(state: BeaconStateCachedPhase0): BeaconStateCachedA
   return postState;
 }
 
-function upgradeTreeBackedState(config: IBeaconConfig, state: BeaconStateCachedPhase0): TreeBacked<altair.BeaconState> {
+function upgradeTreeBackedState(config: IBeaconConfig, state: CachedBeaconStatePhase0): TreeBacked<altair.BeaconState> {
   const nextEpochActiveIndices = state.nextShuffling.activeIndices;
   const stateTB = ssz.phase0.BeaconState.createTreeBacked(state.tree);
   const validatorCount = stateTB.validators.length;
@@ -44,9 +44,9 @@ function upgradeTreeBackedState(config: IBeaconConfig, state: BeaconStateCachedP
 /**
  * Translate_participation in https://github.com/ethereum/eth2.0-specs/blob/dev/specs/altair/fork.md
  */
-function translateParticipation(state: BeaconStateCachedAltair, pendingAttesations: phase0.PendingAttestation[]): void {
+function translateParticipation(state: CachedBeaconStateAltair, pendingAttesations: phase0.PendingAttestation[]): void {
   const {epochCtx} = state;
-  const rootCache = new RootCache(state as BeaconStateCachedAllForks);
+  const rootCache = new RootCache(state as CachedBeaconStateAllForks);
   const epochParticipation = state.previousEpochParticipation;
   for (const attestation of pendingAttesations) {
     const data = attestation.data;

--- a/packages/beacon-state-transition/src/altair/upgradeState.ts
+++ b/packages/beacon-state-transition/src/altair/upgradeState.ts
@@ -1,5 +1,10 @@
-import {allForks, altair, ParticipationFlags, phase0, ssz, Uint8} from "@chainsafe/lodestar-types";
-import {CachedBeaconState, createCachedBeaconState} from "../allForks/util";
+import {altair, ParticipationFlags, phase0, ssz, Uint8} from "@chainsafe/lodestar-types";
+import {
+  BeaconStateCachedPhase0,
+  BeaconStateCachedAltair,
+  BeaconStateCachedAllForks,
+  createCachedBeaconState,
+} from "../allForks/util";
 import {newZeroedArray} from "../util";
 import {List, TreeBacked} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
@@ -10,7 +15,7 @@ import {getNextSyncCommittee} from "./util/syncCommittee";
 /**
  * Upgrade a state from phase0 to altair.
  */
-export function upgradeState(state: CachedBeaconState<phase0.BeaconState>): CachedBeaconState<altair.BeaconState> {
+export function upgradeState(state: BeaconStateCachedPhase0): BeaconStateCachedAltair {
   const {config} = state;
   const pendingAttesations = Array.from(state.previousEpochAttestations);
   const postTreeBackedState = upgradeTreeBackedState(config, state);
@@ -19,10 +24,7 @@ export function upgradeState(state: CachedBeaconState<phase0.BeaconState>): Cach
   return postState;
 }
 
-function upgradeTreeBackedState(
-  config: IBeaconConfig,
-  state: CachedBeaconState<phase0.BeaconState>
-): TreeBacked<altair.BeaconState> {
+function upgradeTreeBackedState(config: IBeaconConfig, state: BeaconStateCachedPhase0): TreeBacked<altair.BeaconState> {
   const nextEpochActiveIndices = state.nextShuffling.activeIndices;
   const stateTB = ssz.phase0.BeaconState.createTreeBacked(state.tree);
   const validatorCount = stateTB.validators.length;
@@ -46,12 +48,9 @@ function upgradeTreeBackedState(
 /**
  * Translate_participation in https://github.com/ethereum/eth2.0-specs/blob/dev/specs/altair/fork.md
  */
-function translateParticipation(
-  state: CachedBeaconState<altair.BeaconState>,
-  pendingAttesations: phase0.PendingAttestation[]
-): void {
+function translateParticipation(state: BeaconStateCachedAltair, pendingAttesations: phase0.PendingAttestation[]): void {
   const {epochCtx} = state;
-  const rootCache = new RootCache(state as CachedBeaconState<allForks.BeaconState>);
+  const rootCache = new RootCache(state as BeaconStateCachedAllForks);
   const epochParticipation = state.previousEpochParticipation;
   for (const attestation of pendingAttesations) {
     const data = attestation.data;

--- a/packages/beacon-state-transition/src/altair/upgradeState.ts
+++ b/packages/beacon-state-transition/src/altair/upgradeState.ts
@@ -1,10 +1,6 @@
 import {altair, ParticipationFlags, phase0, ssz, Uint8} from "@chainsafe/lodestar-types";
-import {
-  BeaconStateCachedPhase0,
-  BeaconStateCachedAltair,
-  BeaconStateCachedAllForks,
-  createCachedBeaconState,
-} from "../allForks/util";
+import {BeaconStateCachedPhase0, BeaconStateCachedAltair, BeaconStateCachedAllForks} from "../types";
+import {createCachedBeaconState} from "../allForks";
 import {newZeroedArray} from "../util";
 import {List, TreeBacked} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";

--- a/packages/beacon-state-transition/src/bellatrix/block/index.ts
+++ b/packages/beacon-state-transition/src/bellatrix/block/index.ts
@@ -1,6 +1,6 @@
-import {allForks, altair, bellatrix} from "@chainsafe/lodestar-types";
+import {bellatrix} from "@chainsafe/lodestar-types";
 
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedBellatrix, BeaconStateCachedAllForks} from "../../allForks/util";
 import {processBlockHeader, processEth1Data, processRandao} from "../../allForks/block";
 import {processOperations} from "./processOperations";
 import {processSyncAggregate} from "../../altair/block/processSyncCommittee";
@@ -13,20 +13,20 @@ import {processProposerSlashing} from "./processProposerSlashing";
 export {processOperations, processAttesterSlashing, processProposerSlashing};
 
 export function processBlock(
-  state: CachedBeaconState<bellatrix.BeaconState>,
+  state: BeaconStateCachedBellatrix,
   block: bellatrix.BeaconBlock,
   verifySignatures = true,
   executionEngine: ExecutionEngine | null
 ): void {
-  processBlockHeader(state as CachedBeaconState<allForks.BeaconState>, block);
+  processBlockHeader(state as BeaconStateCachedAllForks, block);
   // The call to the process_execution_payload must happen before the call to the process_randao as the former depends
   // on the randao_mix computed with the reveal of the previous block.
   if (isExecutionEnabled(state, block.body)) {
     processExecutionPayload(state, block.body.executionPayload, executionEngine);
   }
 
-  processRandao(state as CachedBeaconState<allForks.BeaconState>, block, verifySignatures);
-  processEth1Data(state as CachedBeaconState<allForks.BeaconState>, block.body);
+  processRandao(state as BeaconStateCachedAllForks, block, verifySignatures);
+  processEth1Data(state as BeaconStateCachedAllForks, block.body);
   processOperations(state, block.body, verifySignatures);
-  processSyncAggregate((state as unknown) as CachedBeaconState<altair.BeaconState>, block, verifySignatures);
+  processSyncAggregate((state as unknown) as BeaconStateCachedAltair, block, verifySignatures);
 }

--- a/packages/beacon-state-transition/src/bellatrix/block/index.ts
+++ b/packages/beacon-state-transition/src/bellatrix/block/index.ts
@@ -1,6 +1,6 @@
 import {bellatrix} from "@chainsafe/lodestar-types";
 
-import {BeaconStateCachedAltair, BeaconStateCachedBellatrix, BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAltair, CachedBeaconStateBellatrix, CachedBeaconStateAllForks} from "../../types";
 import {processBlockHeader, processEth1Data, processRandao} from "../../allForks/block";
 import {processOperations} from "./processOperations";
 import {processSyncAggregate} from "../../altair/block/processSyncCommittee";
@@ -13,20 +13,20 @@ import {processProposerSlashing} from "./processProposerSlashing";
 export {processOperations, processAttesterSlashing, processProposerSlashing};
 
 export function processBlock(
-  state: BeaconStateCachedBellatrix,
+  state: CachedBeaconStateBellatrix,
   block: bellatrix.BeaconBlock,
   verifySignatures = true,
   executionEngine: ExecutionEngine | null
 ): void {
-  processBlockHeader(state as BeaconStateCachedAllForks, block);
+  processBlockHeader(state as CachedBeaconStateAllForks, block);
   // The call to the process_execution_payload must happen before the call to the process_randao as the former depends
   // on the randao_mix computed with the reveal of the previous block.
   if (isExecutionEnabled(state, block.body)) {
     processExecutionPayload(state, block.body.executionPayload, executionEngine);
   }
 
-  processRandao(state as BeaconStateCachedAllForks, block, verifySignatures);
-  processEth1Data(state as BeaconStateCachedAllForks, block.body);
+  processRandao(state as CachedBeaconStateAllForks, block, verifySignatures);
+  processEth1Data(state as CachedBeaconStateAllForks, block.body);
   processOperations(state, block.body, verifySignatures);
-  processSyncAggregate((state as unknown) as BeaconStateCachedAltair, block, verifySignatures);
+  processSyncAggregate((state as unknown) as CachedBeaconStateAltair, block, verifySignatures);
 }

--- a/packages/beacon-state-transition/src/bellatrix/block/index.ts
+++ b/packages/beacon-state-transition/src/bellatrix/block/index.ts
@@ -1,6 +1,6 @@
 import {bellatrix} from "@chainsafe/lodestar-types";
 
-import {BeaconStateCachedAltair, BeaconStateCachedBellatrix, BeaconStateCachedAllForks} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedBellatrix, BeaconStateCachedAllForks} from "../../types";
 import {processBlockHeader, processEth1Data, processRandao} from "../../allForks/block";
 import {processOperations} from "./processOperations";
 import {processSyncAggregate} from "../../altair/block/processSyncCommittee";

--- a/packages/beacon-state-transition/src/bellatrix/block/processAttesterSlashing.ts
+++ b/packages/beacon-state-transition/src/bellatrix/block/processAttesterSlashing.ts
@@ -1,6 +1,6 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedBellatrix, BeaconStateCachedAllForks} from "../../allForks/util";
+import {BeaconStateCachedBellatrix, BeaconStateCachedAllForks} from "../../types";
 import {processAttesterSlashing as processAttesterSlashingAllForks} from "../../allForks/block";
 
 export function processAttesterSlashing(

--- a/packages/beacon-state-transition/src/bellatrix/block/processAttesterSlashing.ts
+++ b/packages/beacon-state-transition/src/bellatrix/block/processAttesterSlashing.ts
@@ -1,16 +1,16 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedBellatrix, BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateBellatrix, CachedBeaconStateAllForks} from "../../types";
 import {processAttesterSlashing as processAttesterSlashingAllForks} from "../../allForks/block";
 
 export function processAttesterSlashing(
-  state: BeaconStateCachedBellatrix,
+  state: CachedBeaconStateBellatrix,
   attesterSlashing: phase0.AttesterSlashing,
   verifySignatures = true
 ): void {
   processAttesterSlashingAllForks(
     ForkName.bellatrix,
-    state as BeaconStateCachedAllForks,
+    state as CachedBeaconStateAllForks,
     attesterSlashing,
     verifySignatures
   );

--- a/packages/beacon-state-transition/src/bellatrix/block/processAttesterSlashing.ts
+++ b/packages/beacon-state-transition/src/bellatrix/block/processAttesterSlashing.ts
@@ -1,16 +1,16 @@
-import {allForks, bellatrix, phase0} from "@chainsafe/lodestar-types";
+import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedBellatrix, BeaconStateCachedAllForks} from "../../allForks/util";
 import {processAttesterSlashing as processAttesterSlashingAllForks} from "../../allForks/block";
 
 export function processAttesterSlashing(
-  state: CachedBeaconState<bellatrix.BeaconState>,
+  state: BeaconStateCachedBellatrix,
   attesterSlashing: phase0.AttesterSlashing,
   verifySignatures = true
 ): void {
   processAttesterSlashingAllForks(
     ForkName.bellatrix,
-    state as CachedBeaconState<allForks.BeaconState>,
+    state as BeaconStateCachedAllForks,
     attesterSlashing,
     verifySignatures
   );

--- a/packages/beacon-state-transition/src/bellatrix/block/processExecutionPayload.ts
+++ b/packages/beacon-state-transition/src/bellatrix/block/processExecutionPayload.ts
@@ -1,12 +1,12 @@
 import {bellatrix, ssz} from "@chainsafe/lodestar-types";
 import {byteArrayEquals, List, toHexString} from "@chainsafe/ssz";
-import {CachedBeaconState} from "../../allForks";
+import {BeaconStateCachedBellatrix} from "../../allForks";
 import {getRandaoMix} from "../../util";
 import {ExecutionEngine} from "../executionEngine";
 import {isMergeTransitionComplete} from "../utils";
 
 export function processExecutionPayload(
-  state: CachedBeaconState<bellatrix.BeaconState>,
+  state: BeaconStateCachedBellatrix,
   payload: bellatrix.ExecutionPayload,
   executionEngine: ExecutionEngine | null
 ): void {

--- a/packages/beacon-state-transition/src/bellatrix/block/processExecutionPayload.ts
+++ b/packages/beacon-state-transition/src/bellatrix/block/processExecutionPayload.ts
@@ -1,12 +1,12 @@
 import {bellatrix, ssz} from "@chainsafe/lodestar-types";
 import {byteArrayEquals, List, toHexString} from "@chainsafe/ssz";
-import {BeaconStateCachedBellatrix} from "../../types";
+import {CachedBeaconStateBellatrix} from "../../types";
 import {getRandaoMix} from "../../util";
 import {ExecutionEngine} from "../executionEngine";
 import {isMergeTransitionComplete} from "../utils";
 
 export function processExecutionPayload(
-  state: BeaconStateCachedBellatrix,
+  state: CachedBeaconStateBellatrix,
   payload: bellatrix.ExecutionPayload,
   executionEngine: ExecutionEngine | null
 ): void {

--- a/packages/beacon-state-transition/src/bellatrix/block/processExecutionPayload.ts
+++ b/packages/beacon-state-transition/src/bellatrix/block/processExecutionPayload.ts
@@ -1,6 +1,6 @@
 import {bellatrix, ssz} from "@chainsafe/lodestar-types";
 import {byteArrayEquals, List, toHexString} from "@chainsafe/ssz";
-import {BeaconStateCachedBellatrix} from "../../allForks";
+import {BeaconStateCachedBellatrix} from "../../types";
 import {getRandaoMix} from "../../util";
 import {ExecutionEngine} from "../executionEngine";
 import {isMergeTransitionComplete} from "../utils";

--- a/packages/beacon-state-transition/src/bellatrix/block/processOperations.ts
+++ b/packages/beacon-state-transition/src/bellatrix/block/processOperations.ts
@@ -1,7 +1,7 @@
 import {readonlyValues} from "@chainsafe/ssz";
 import {bellatrix} from "@chainsafe/lodestar-types";
 
-import {BeaconStateCachedAltair, BeaconStateCachedBellatrix, BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateAltair, CachedBeaconStateBellatrix, CachedBeaconStateAllForks} from "../../types";
 import {processProposerSlashing} from "./processProposerSlashing";
 import {processAttesterSlashing} from "./processAttesterSlashing";
 import {processAttestations} from "../../altair/block/processAttestation";
@@ -10,7 +10,7 @@ import {processVoluntaryExit} from "../../altair/block/processVoluntaryExit";
 import {MAX_DEPOSITS} from "@chainsafe/lodestar-params";
 
 export function processOperations(
-  state: BeaconStateCachedBellatrix,
+  state: CachedBeaconStateBellatrix,
   body: bellatrix.BeaconBlockBody,
   verifySignatures = true
 ): void {
@@ -30,17 +30,17 @@ export function processOperations(
   }
 
   processAttestations(
-    (state as BeaconStateCachedAllForks) as BeaconStateCachedAltair,
+    (state as CachedBeaconStateAllForks) as CachedBeaconStateAltair,
     Array.from(readonlyValues(body.attestations)),
     verifySignatures
   );
 
   for (const deposit of readonlyValues(body.deposits)) {
-    processDeposit((state as BeaconStateCachedAllForks) as BeaconStateCachedAltair, deposit);
+    processDeposit((state as CachedBeaconStateAllForks) as CachedBeaconStateAltair, deposit);
   }
   for (const voluntaryExit of readonlyValues(body.voluntaryExits)) {
     processVoluntaryExit(
-      (state as BeaconStateCachedAllForks) as BeaconStateCachedAltair,
+      (state as CachedBeaconStateAllForks) as CachedBeaconStateAltair,
       voluntaryExit,
       verifySignatures
     );

--- a/packages/beacon-state-transition/src/bellatrix/block/processOperations.ts
+++ b/packages/beacon-state-transition/src/bellatrix/block/processOperations.ts
@@ -1,7 +1,7 @@
 import {readonlyValues} from "@chainsafe/ssz";
 import {bellatrix} from "@chainsafe/lodestar-types";
 
-import {BeaconStateCachedAltair, BeaconStateCachedBellatrix, BeaconStateCachedAllForks} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedBellatrix, BeaconStateCachedAllForks} from "../../types";
 import {processProposerSlashing} from "./processProposerSlashing";
 import {processAttesterSlashing} from "./processAttesterSlashing";
 import {processAttestations} from "../../altair/block/processAttestation";

--- a/packages/beacon-state-transition/src/bellatrix/block/processOperations.ts
+++ b/packages/beacon-state-transition/src/bellatrix/block/processOperations.ts
@@ -1,7 +1,7 @@
 import {readonlyValues} from "@chainsafe/ssz";
-import {altair, bellatrix} from "@chainsafe/lodestar-types";
+import {bellatrix} from "@chainsafe/lodestar-types";
 
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedBellatrix, BeaconStateCachedAllForks} from "../../allForks/util";
 import {processProposerSlashing} from "./processProposerSlashing";
 import {processAttesterSlashing} from "./processAttesterSlashing";
 import {processAttestations} from "../../altair/block/processAttestation";
@@ -10,7 +10,7 @@ import {processVoluntaryExit} from "../../altair/block/processVoluntaryExit";
 import {MAX_DEPOSITS} from "@chainsafe/lodestar-params";
 
 export function processOperations(
-  state: CachedBeaconState<bellatrix.BeaconState>,
+  state: BeaconStateCachedBellatrix,
   body: bellatrix.BeaconBlockBody,
   verifySignatures = true
 ): void {
@@ -30,15 +30,19 @@ export function processOperations(
   }
 
   processAttestations(
-    (state as unknown) as CachedBeaconState<altair.BeaconState>,
+    (state as BeaconStateCachedAllForks) as BeaconStateCachedAltair,
     Array.from(readonlyValues(body.attestations)),
     verifySignatures
   );
 
   for (const deposit of readonlyValues(body.deposits)) {
-    processDeposit((state as unknown) as CachedBeaconState<altair.BeaconState>, deposit);
+    processDeposit((state as BeaconStateCachedAllForks) as BeaconStateCachedAltair, deposit);
   }
   for (const voluntaryExit of readonlyValues(body.voluntaryExits)) {
-    processVoluntaryExit((state as unknown) as CachedBeaconState<altair.BeaconState>, voluntaryExit, verifySignatures);
+    processVoluntaryExit(
+      (state as BeaconStateCachedAllForks) as BeaconStateCachedAltair,
+      voluntaryExit,
+      verifySignatures
+    );
   }
 }

--- a/packages/beacon-state-transition/src/bellatrix/block/processProposerSlashing.ts
+++ b/packages/beacon-state-transition/src/bellatrix/block/processProposerSlashing.ts
@@ -1,16 +1,16 @@
-import {allForks, bellatrix, phase0} from "@chainsafe/lodestar-types";
+import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedBellatrix, BeaconStateCachedAllForks} from "../../allForks/util";
 import {processProposerSlashing as processProposerSlashingAllForks} from "../../allForks/block";
 
 export function processProposerSlashing(
-  state: CachedBeaconState<bellatrix.BeaconState>,
+  state: BeaconStateCachedBellatrix,
   proposerSlashing: phase0.ProposerSlashing,
   verifySignatures = true
 ): void {
   processProposerSlashingAllForks(
     ForkName.bellatrix,
-    state as CachedBeaconState<allForks.BeaconState>,
+    state as BeaconStateCachedAllForks,
     proposerSlashing,
     verifySignatures
   );

--- a/packages/beacon-state-transition/src/bellatrix/block/processProposerSlashing.ts
+++ b/packages/beacon-state-transition/src/bellatrix/block/processProposerSlashing.ts
@@ -1,16 +1,16 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedBellatrix, BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStateBellatrix, CachedBeaconStateAllForks} from "../../types";
 import {processProposerSlashing as processProposerSlashingAllForks} from "../../allForks/block";
 
 export function processProposerSlashing(
-  state: BeaconStateCachedBellatrix,
+  state: CachedBeaconStateBellatrix,
   proposerSlashing: phase0.ProposerSlashing,
   verifySignatures = true
 ): void {
   processProposerSlashingAllForks(
     ForkName.bellatrix,
-    state as BeaconStateCachedAllForks,
+    state as CachedBeaconStateAllForks,
     proposerSlashing,
     verifySignatures
   );

--- a/packages/beacon-state-transition/src/bellatrix/block/processProposerSlashing.ts
+++ b/packages/beacon-state-transition/src/bellatrix/block/processProposerSlashing.ts
@@ -1,6 +1,6 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedBellatrix, BeaconStateCachedAllForks} from "../../allForks/util";
+import {BeaconStateCachedBellatrix, BeaconStateCachedAllForks} from "../../types";
 import {processProposerSlashing as processProposerSlashingAllForks} from "../../allForks/block";
 
 export function processProposerSlashing(

--- a/packages/beacon-state-transition/src/bellatrix/epoch/processSlashings.ts
+++ b/packages/beacon-state-transition/src/bellatrix/epoch/processSlashings.ts
@@ -1,8 +1,7 @@
-import {allForks, bellatrix} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedBellatrix, BeaconStateCachedAllForks, IEpochProcess} from "../../allForks/util";
 import {processSlashingsAllForks} from "../../allForks/epoch/processSlashings";
 
-export function processSlashings(state: CachedBeaconState<bellatrix.BeaconState>, epochProcess: IEpochProcess): void {
-  processSlashingsAllForks(ForkName.bellatrix, state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+export function processSlashings(state: BeaconStateCachedBellatrix, epochProcess: IEpochProcess): void {
+  processSlashingsAllForks(ForkName.bellatrix, state as BeaconStateCachedAllForks, epochProcess);
 }

--- a/packages/beacon-state-transition/src/bellatrix/epoch/processSlashings.ts
+++ b/packages/beacon-state-transition/src/bellatrix/epoch/processSlashings.ts
@@ -1,5 +1,5 @@
 import {ForkName} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedBellatrix, BeaconStateCachedAllForks, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedBellatrix, BeaconStateCachedAllForks, IEpochProcess} from "../../types";
 import {processSlashingsAllForks} from "../../allForks/epoch/processSlashings";
 
 export function processSlashings(state: BeaconStateCachedBellatrix, epochProcess: IEpochProcess): void {

--- a/packages/beacon-state-transition/src/bellatrix/epoch/processSlashings.ts
+++ b/packages/beacon-state-transition/src/bellatrix/epoch/processSlashings.ts
@@ -1,7 +1,7 @@
 import {ForkName} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedBellatrix, BeaconStateCachedAllForks, IEpochProcess} from "../../types";
+import {CachedBeaconStateBellatrix, CachedBeaconStateAllForks, IEpochProcess} from "../../types";
 import {processSlashingsAllForks} from "../../allForks/epoch/processSlashings";
 
-export function processSlashings(state: BeaconStateCachedBellatrix, epochProcess: IEpochProcess): void {
-  processSlashingsAllForks(ForkName.bellatrix, state as BeaconStateCachedAllForks, epochProcess);
+export function processSlashings(state: CachedBeaconStateBellatrix, epochProcess: IEpochProcess): void {
+  processSlashingsAllForks(ForkName.bellatrix, state as CachedBeaconStateAllForks, epochProcess);
 }

--- a/packages/beacon-state-transition/src/bellatrix/upgradeState.ts
+++ b/packages/beacon-state-transition/src/bellatrix/upgradeState.ts
@@ -1,13 +1,13 @@
 import {bellatrix, ssz} from "@chainsafe/lodestar-types";
 import {createCachedBeaconState} from "../allForks/util";
-import {BeaconStateCachedAltair, BeaconStateCachedBellatrix} from "../types";
+import {CachedBeaconStateAltair, CachedBeaconStateBellatrix} from "../types";
 import {TreeBacked} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
 /**
  * Upgrade a state from altair to bellatrix.
  */
-export function upgradeState(state: BeaconStateCachedAltair): BeaconStateCachedBellatrix {
+export function upgradeState(state: CachedBeaconStateAltair): CachedBeaconStateBellatrix {
   const {config} = state;
   const postTreeBackedState = upgradeTreeBackedState(config, state);
   // TODO: This seems very sub-optimal, review
@@ -16,7 +16,7 @@ export function upgradeState(state: BeaconStateCachedAltair): BeaconStateCachedB
 
 function upgradeTreeBackedState(
   config: IBeaconConfig,
-  state: BeaconStateCachedAltair
+  state: CachedBeaconStateAltair
 ): TreeBacked<bellatrix.BeaconState> {
   const stateTB = ssz.phase0.BeaconState.createTreeBacked(state.tree);
 

--- a/packages/beacon-state-transition/src/bellatrix/upgradeState.ts
+++ b/packages/beacon-state-transition/src/bellatrix/upgradeState.ts
@@ -1,5 +1,6 @@
 import {bellatrix, ssz} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAltair, BeaconStateCachedBellatrix, createCachedBeaconState} from "../allForks/util";
+import {createCachedBeaconState} from "../allForks/util";
+import {BeaconStateCachedAltair, BeaconStateCachedBellatrix} from "../types";
 import {TreeBacked} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 

--- a/packages/beacon-state-transition/src/bellatrix/upgradeState.ts
+++ b/packages/beacon-state-transition/src/bellatrix/upgradeState.ts
@@ -1,12 +1,12 @@
-import {altair, bellatrix, ssz} from "@chainsafe/lodestar-types";
-import {CachedBeaconState, createCachedBeaconState} from "../allForks/util";
+import {bellatrix, ssz} from "@chainsafe/lodestar-types";
+import {BeaconStateCachedAltair, BeaconStateCachedBellatrix, createCachedBeaconState} from "../allForks/util";
 import {TreeBacked} from "@chainsafe/ssz";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
 /**
  * Upgrade a state from altair to bellatrix.
  */
-export function upgradeState(state: CachedBeaconState<altair.BeaconState>): CachedBeaconState<bellatrix.BeaconState> {
+export function upgradeState(state: BeaconStateCachedAltair): BeaconStateCachedBellatrix {
   const {config} = state;
   const postTreeBackedState = upgradeTreeBackedState(config, state);
   // TODO: This seems very sub-optimal, review
@@ -15,7 +15,7 @@ export function upgradeState(state: CachedBeaconState<altair.BeaconState>): Cach
 
 function upgradeTreeBackedState(
   config: IBeaconConfig,
-  state: CachedBeaconState<altair.BeaconState>
+  state: BeaconStateCachedAltair
 ): TreeBacked<bellatrix.BeaconState> {
   const stateTB = ssz.phase0.BeaconState.createTreeBacked(state.tree);
 

--- a/packages/beacon-state-transition/src/index.ts
+++ b/packages/beacon-state-transition/src/index.ts
@@ -10,4 +10,12 @@ export * as phase0 from "./phase0";
 export * as altair from "./altair";
 export * as bellatrix from "./bellatrix";
 export * as allForks from "./allForks";
-export {CachedBeaconState, createCachedBeaconState} from "./allForks/util/cachedBeaconState";
+export {
+  CachedBeaconState,
+  BeaconStateCachedPhase0,
+  BeaconStateCachedAltair,
+  BeaconStateCachedBellatrix,
+  BeaconStateCachedAllForks,
+  BeaconStateCachedAnyFork,
+  createCachedBeaconState,
+} from "./allForks/util/cachedBeaconState";

--- a/packages/beacon-state-transition/src/index.ts
+++ b/packages/beacon-state-transition/src/index.ts
@@ -13,9 +13,9 @@ export * as allForks from "./allForks";
 export {CachedBeaconState, createCachedBeaconState} from "./allForks/util/cachedBeaconState";
 
 export {
-  BeaconStateCachedPhase0,
-  BeaconStateCachedAltair,
-  BeaconStateCachedBellatrix,
-  BeaconStateCachedAllForks,
-  BeaconStateCachedAnyFork,
+  CachedBeaconStatePhase0,
+  CachedBeaconStateAltair,
+  CachedBeaconStateBellatrix,
+  CachedBeaconStateAllForks,
+  CachedBeaconStateAnyFork,
 } from "./types";

--- a/packages/beacon-state-transition/src/index.ts
+++ b/packages/beacon-state-transition/src/index.ts
@@ -10,12 +10,12 @@ export * as phase0 from "./phase0";
 export * as altair from "./altair";
 export * as bellatrix from "./bellatrix";
 export * as allForks from "./allForks";
+export {CachedBeaconState, createCachedBeaconState} from "./allForks/util/cachedBeaconState";
+
 export {
-  CachedBeaconState,
   BeaconStateCachedPhase0,
   BeaconStateCachedAltair,
   BeaconStateCachedBellatrix,
   BeaconStateCachedAllForks,
   BeaconStateCachedAnyFork,
-  createCachedBeaconState,
-} from "./allForks/util/cachedBeaconState";
+} from "./types";

--- a/packages/beacon-state-transition/src/phase0/block/index.ts
+++ b/packages/beacon-state-transition/src/phase0/block/index.ts
@@ -1,5 +1,5 @@
-import {allForks, phase0} from "@chainsafe/lodestar-types";
-import {CachedBeaconState} from "../../allForks/util";
+import {phase0} from "@chainsafe/lodestar-types";
+import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../allForks/util";
 import {processBlockHeader, processEth1Data, processRandao} from "../../allForks/block";
 import {processOperations} from "./processOperations";
 import {processAttestation, validateAttestation} from "./processAttestation";
@@ -21,13 +21,9 @@ export {
   processVoluntaryExit,
 };
 
-export function processBlock(
-  state: CachedBeaconState<phase0.BeaconState>,
-  block: phase0.BeaconBlock,
-  verifySignatures = true
-): void {
-  processBlockHeader(state as CachedBeaconState<allForks.BeaconState>, block);
-  processRandao(state as CachedBeaconState<allForks.BeaconState>, block, verifySignatures);
-  processEth1Data(state as CachedBeaconState<allForks.BeaconState>, block.body);
+export function processBlock(state: BeaconStateCachedPhase0, block: phase0.BeaconBlock, verifySignatures = true): void {
+  processBlockHeader(state as BeaconStateCachedAllForks, block);
+  processRandao(state as BeaconStateCachedAllForks, block, verifySignatures);
+  processEth1Data(state as BeaconStateCachedAllForks, block.body);
   processOperations(state, block.body, verifySignatures);
 }

--- a/packages/beacon-state-transition/src/phase0/block/index.ts
+++ b/packages/beacon-state-transition/src/phase0/block/index.ts
@@ -1,5 +1,5 @@
 import {phase0} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStatePhase0, CachedBeaconStateAllForks} from "../../types";
 import {processBlockHeader, processEth1Data, processRandao} from "../../allForks/block";
 import {processOperations} from "./processOperations";
 import {processAttestation, validateAttestation} from "./processAttestation";
@@ -21,9 +21,9 @@ export {
   processVoluntaryExit,
 };
 
-export function processBlock(state: BeaconStateCachedPhase0, block: phase0.BeaconBlock, verifySignatures = true): void {
-  processBlockHeader(state as BeaconStateCachedAllForks, block);
-  processRandao(state as BeaconStateCachedAllForks, block, verifySignatures);
-  processEth1Data(state as BeaconStateCachedAllForks, block.body);
+export function processBlock(state: CachedBeaconStatePhase0, block: phase0.BeaconBlock, verifySignatures = true): void {
+  processBlockHeader(state as CachedBeaconStateAllForks, block);
+  processRandao(state as CachedBeaconStateAllForks, block, verifySignatures);
+  processEth1Data(state as CachedBeaconStateAllForks, block.body);
   processOperations(state, block.body, verifySignatures);
 }

--- a/packages/beacon-state-transition/src/phase0/block/index.ts
+++ b/packages/beacon-state-transition/src/phase0/block/index.ts
@@ -1,5 +1,5 @@
 import {phase0} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../allForks/util";
+import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../types";
 import {processBlockHeader, processEth1Data, processRandao} from "../../allForks/block";
 import {processOperations} from "./processOperations";
 import {processAttestation, validateAttestation} from "./processAttestation";

--- a/packages/beacon-state-transition/src/phase0/block/processAttestation.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processAttestation.ts
@@ -1,7 +1,7 @@
 import {phase0, ssz} from "@chainsafe/lodestar-types";
 
 import {computeEpochAtSlot} from "../../util";
-import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../allForks/util";
+import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../types";
 import {isValidIndexedAttestation} from "../../allForks/block";
 import {MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {toHexString} from "@chainsafe/ssz";

--- a/packages/beacon-state-transition/src/phase0/block/processAttestation.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processAttestation.ts
@@ -1,7 +1,7 @@
 import {phase0, ssz} from "@chainsafe/lodestar-types";
 
 import {computeEpochAtSlot} from "../../util";
-import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStatePhase0, CachedBeaconStateAllForks} from "../../types";
 import {isValidIndexedAttestation} from "../../allForks/block";
 import {MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {toHexString} from "@chainsafe/ssz";
@@ -14,7 +14,7 @@ import {toHexString} from "@chainsafe/ssz";
  * true bits on average. See `packages/beacon-state-transition/test/perf/analyzeBlocks.ts`
  */
 export function processAttestation(
-  state: BeaconStateCachedPhase0,
+  state: CachedBeaconStatePhase0,
   attestation: phase0.Attestation,
   verifySignature = true
 ): void {
@@ -22,7 +22,7 @@ export function processAttestation(
   const slot = state.slot;
   const data = attestation.data;
 
-  validateAttestation(state as BeaconStateCachedAllForks, attestation);
+  validateAttestation(state as CachedBeaconStateAllForks, attestation);
 
   const pendingAttestation = ssz.phase0.PendingAttestation.createTreeBackedFromStruct({
     data: data,
@@ -53,7 +53,7 @@ export function processAttestation(
 
   if (
     !isValidIndexedAttestation(
-      state as BeaconStateCachedAllForks,
+      state as CachedBeaconStateAllForks,
       epochCtx.getIndexedAttestation(attestation),
       verifySignature
     )
@@ -62,7 +62,7 @@ export function processAttestation(
   }
 }
 
-export function validateAttestation(state: BeaconStateCachedAllForks, attestation: phase0.Attestation): void {
+export function validateAttestation(state: CachedBeaconStateAllForks, attestation: phase0.Attestation): void {
   const {epochCtx} = state;
   const slot = state.slot;
   const data = attestation.data;

--- a/packages/beacon-state-transition/src/phase0/block/processAttestation.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processAttestation.ts
@@ -1,7 +1,7 @@
-import {allForks, phase0, ssz} from "@chainsafe/lodestar-types";
+import {phase0, ssz} from "@chainsafe/lodestar-types";
 
 import {computeEpochAtSlot} from "../../util";
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../allForks/util";
 import {isValidIndexedAttestation} from "../../allForks/block";
 import {MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {toHexString} from "@chainsafe/ssz";
@@ -14,7 +14,7 @@ import {toHexString} from "@chainsafe/ssz";
  * true bits on average. See `packages/beacon-state-transition/test/perf/analyzeBlocks.ts`
  */
 export function processAttestation(
-  state: CachedBeaconState<phase0.BeaconState>,
+  state: BeaconStateCachedPhase0,
   attestation: phase0.Attestation,
   verifySignature = true
 ): void {
@@ -22,7 +22,7 @@ export function processAttestation(
   const slot = state.slot;
   const data = attestation.data;
 
-  validateAttestation(state as CachedBeaconState<allForks.BeaconState>, attestation);
+  validateAttestation(state as BeaconStateCachedAllForks, attestation);
 
   const pendingAttestation = ssz.phase0.PendingAttestation.createTreeBackedFromStruct({
     data: data,
@@ -53,7 +53,7 @@ export function processAttestation(
 
   if (
     !isValidIndexedAttestation(
-      state as CachedBeaconState<allForks.BeaconState>,
+      state as BeaconStateCachedAllForks,
       epochCtx.getIndexedAttestation(attestation),
       verifySignature
     )
@@ -62,10 +62,7 @@ export function processAttestation(
   }
 }
 
-export function validateAttestation(
-  state: CachedBeaconState<allForks.BeaconState>,
-  attestation: phase0.Attestation
-): void {
+export function validateAttestation(state: BeaconStateCachedAllForks, attestation: phase0.Attestation): void {
   const {epochCtx} = state;
   const slot = state.slot;
   const data = attestation.data;

--- a/packages/beacon-state-transition/src/phase0/block/processAttesterSlashing.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processAttesterSlashing.ts
@@ -1,7 +1,7 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 
-import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../allForks/util";
+import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../types";
 import {processAttesterSlashing as processAttesterSlashingAllForks} from "../../allForks/block";
 
 export function processAttesterSlashing(

--- a/packages/beacon-state-transition/src/phase0/block/processAttesterSlashing.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processAttesterSlashing.ts
@@ -1,17 +1,17 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 
-import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStatePhase0, CachedBeaconStateAllForks} from "../../types";
 import {processAttesterSlashing as processAttesterSlashingAllForks} from "../../allForks/block";
 
 export function processAttesterSlashing(
-  state: BeaconStateCachedPhase0,
+  state: CachedBeaconStatePhase0,
   attesterSlashing: phase0.AttesterSlashing,
   verifySignatures = true
 ): void {
   processAttesterSlashingAllForks(
     ForkName.phase0,
-    state as BeaconStateCachedAllForks,
+    state as CachedBeaconStateAllForks,
     attesterSlashing,
     verifySignatures
   );

--- a/packages/beacon-state-transition/src/phase0/block/processAttesterSlashing.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processAttesterSlashing.ts
@@ -1,17 +1,17 @@
-import {allForks, phase0} from "@chainsafe/lodestar-types";
+import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../allForks/util";
 import {processAttesterSlashing as processAttesterSlashingAllForks} from "../../allForks/block";
 
 export function processAttesterSlashing(
-  state: CachedBeaconState<phase0.BeaconState>,
+  state: BeaconStateCachedPhase0,
   attesterSlashing: phase0.AttesterSlashing,
   verifySignatures = true
 ): void {
   processAttesterSlashingAllForks(
     ForkName.phase0,
-    state as CachedBeaconState<allForks.BeaconState>,
+    state as BeaconStateCachedAllForks,
     attesterSlashing,
     verifySignatures
   );

--- a/packages/beacon-state-transition/src/phase0/block/processDeposit.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processDeposit.ts
@@ -1,7 +1,7 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 
-import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../allForks/util";
+import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../types";
 import {processDeposit as processDepositAllForks} from "../../allForks/block";
 
 export function processDeposit(state: BeaconStateCachedPhase0, deposit: phase0.Deposit): void {

--- a/packages/beacon-state-transition/src/phase0/block/processDeposit.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processDeposit.ts
@@ -1,9 +1,9 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 
-import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStatePhase0, CachedBeaconStateAllForks} from "../../types";
 import {processDeposit as processDepositAllForks} from "../../allForks/block";
 
-export function processDeposit(state: BeaconStateCachedPhase0, deposit: phase0.Deposit): void {
-  processDepositAllForks(ForkName.phase0, state as BeaconStateCachedAllForks, deposit);
+export function processDeposit(state: CachedBeaconStatePhase0, deposit: phase0.Deposit): void {
+  processDepositAllForks(ForkName.phase0, state as CachedBeaconStateAllForks, deposit);
 }

--- a/packages/beacon-state-transition/src/phase0/block/processDeposit.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processDeposit.ts
@@ -1,9 +1,9 @@
-import {allForks, phase0} from "@chainsafe/lodestar-types";
+import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../allForks/util";
 import {processDeposit as processDepositAllForks} from "../../allForks/block";
 
-export function processDeposit(state: CachedBeaconState<phase0.BeaconState>, deposit: phase0.Deposit): void {
-  processDepositAllForks(ForkName.phase0, state as CachedBeaconState<allForks.BeaconState>, deposit);
+export function processDeposit(state: BeaconStateCachedPhase0, deposit: phase0.Deposit): void {
+  processDepositAllForks(ForkName.phase0, state as BeaconStateCachedAllForks, deposit);
 }

--- a/packages/beacon-state-transition/src/phase0/block/processOperations.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processOperations.ts
@@ -2,7 +2,7 @@ import {List, readonlyValues} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
 import {MAX_DEPOSITS} from "@chainsafe/lodestar-params";
 
-import {BeaconStateCachedPhase0} from "../../types";
+import {CachedBeaconStatePhase0} from "../../types";
 import {processProposerSlashing} from "./processProposerSlashing";
 import {processAttesterSlashing} from "./processAttesterSlashing";
 import {processAttestation} from "./processAttestation";
@@ -15,10 +15,10 @@ type Operation =
   | phase0.Attestation
   | phase0.Deposit
   | phase0.VoluntaryExit;
-type OperationFunction = (state: BeaconStateCachedPhase0, op: Operation, verify: boolean) => void;
+type OperationFunction = (state: CachedBeaconStatePhase0, op: Operation, verify: boolean) => void;
 
 export function processOperations(
-  state: BeaconStateCachedPhase0,
+  state: CachedBeaconStatePhase0,
   body: phase0.BeaconBlockBody,
   verifySignatures = true
 ): void {

--- a/packages/beacon-state-transition/src/phase0/block/processOperations.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processOperations.ts
@@ -2,7 +2,7 @@ import {List, readonlyValues} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
 import {MAX_DEPOSITS} from "@chainsafe/lodestar-params";
 
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedPhase0} from "../../allForks/util";
 import {processProposerSlashing} from "./processProposerSlashing";
 import {processAttesterSlashing} from "./processAttesterSlashing";
 import {processAttestation} from "./processAttestation";
@@ -15,10 +15,10 @@ type Operation =
   | phase0.Attestation
   | phase0.Deposit
   | phase0.VoluntaryExit;
-type OperationFunction = (state: CachedBeaconState<phase0.BeaconState>, op: Operation, verify: boolean) => void;
+type OperationFunction = (state: BeaconStateCachedPhase0, op: Operation, verify: boolean) => void;
 
 export function processOperations(
-  state: CachedBeaconState<phase0.BeaconState>,
+  state: BeaconStateCachedPhase0,
   body: phase0.BeaconBlockBody,
   verifySignatures = true
 ): void {

--- a/packages/beacon-state-transition/src/phase0/block/processOperations.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processOperations.ts
@@ -2,7 +2,7 @@ import {List, readonlyValues} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
 import {MAX_DEPOSITS} from "@chainsafe/lodestar-params";
 
-import {BeaconStateCachedPhase0} from "../../allForks/util";
+import {BeaconStateCachedPhase0} from "../../types";
 import {processProposerSlashing} from "./processProposerSlashing";
 import {processAttesterSlashing} from "./processAttesterSlashing";
 import {processAttestation} from "./processAttestation";

--- a/packages/beacon-state-transition/src/phase0/block/processProposerSlashing.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processProposerSlashing.ts
@@ -1,16 +1,16 @@
-import {allForks, phase0} from "@chainsafe/lodestar-types";
+import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../allForks/util";
 import {processProposerSlashing as processProposerSlashingAllForks} from "../../allForks/block";
 
 export function processProposerSlashing(
-  state: CachedBeaconState<phase0.BeaconState>,
+  state: BeaconStateCachedPhase0,
   proposerSlashing: phase0.ProposerSlashing,
   verifySignatures = true
 ): void {
   processProposerSlashingAllForks(
     ForkName.phase0,
-    state as CachedBeaconState<allForks.BeaconState>,
+    state as BeaconStateCachedAllForks,
     proposerSlashing,
     verifySignatures
   );

--- a/packages/beacon-state-transition/src/phase0/block/processProposerSlashing.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processProposerSlashing.ts
@@ -1,6 +1,6 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../allForks/util";
+import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../types";
 import {processProposerSlashing as processProposerSlashingAllForks} from "../../allForks/block";
 
 export function processProposerSlashing(

--- a/packages/beacon-state-transition/src/phase0/block/processProposerSlashing.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processProposerSlashing.ts
@@ -1,16 +1,16 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStatePhase0, CachedBeaconStateAllForks} from "../../types";
 import {processProposerSlashing as processProposerSlashingAllForks} from "../../allForks/block";
 
 export function processProposerSlashing(
-  state: BeaconStateCachedPhase0,
+  state: CachedBeaconStatePhase0,
   proposerSlashing: phase0.ProposerSlashing,
   verifySignatures = true
 ): void {
   processProposerSlashingAllForks(
     ForkName.phase0,
-    state as BeaconStateCachedAllForks,
+    state as CachedBeaconStateAllForks,
     proposerSlashing,
     verifySignatures
   );

--- a/packages/beacon-state-transition/src/phase0/block/processVoluntaryExit.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processVoluntaryExit.ts
@@ -1,5 +1,5 @@
 import {phase0} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../allForks/util";
+import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../types";
 import {processVoluntaryExitAllForks} from "../../allForks/block";
 
 export function processVoluntaryExit(

--- a/packages/beacon-state-transition/src/phase0/block/processVoluntaryExit.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processVoluntaryExit.ts
@@ -1,11 +1,11 @@
 import {phase0} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../types";
+import {CachedBeaconStatePhase0, CachedBeaconStateAllForks} from "../../types";
 import {processVoluntaryExitAllForks} from "../../allForks/block";
 
 export function processVoluntaryExit(
-  state: BeaconStateCachedPhase0,
+  state: CachedBeaconStatePhase0,
   signedVoluntaryExit: phase0.SignedVoluntaryExit,
   verifySignature = true
 ): void {
-  processVoluntaryExitAllForks(state as BeaconStateCachedAllForks, signedVoluntaryExit, verifySignature);
+  processVoluntaryExitAllForks(state as CachedBeaconStateAllForks, signedVoluntaryExit, verifySignature);
 }

--- a/packages/beacon-state-transition/src/phase0/block/processVoluntaryExit.ts
+++ b/packages/beacon-state-transition/src/phase0/block/processVoluntaryExit.ts
@@ -1,11 +1,11 @@
-import {allForks, phase0} from "@chainsafe/lodestar-types";
-import {CachedBeaconState} from "../../allForks/util";
+import {phase0} from "@chainsafe/lodestar-types";
+import {BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../allForks/util";
 import {processVoluntaryExitAllForks} from "../../allForks/block";
 
 export function processVoluntaryExit(
-  state: CachedBeaconState<phase0.BeaconState>,
+  state: BeaconStateCachedPhase0,
   signedVoluntaryExit: phase0.SignedVoluntaryExit,
   verifySignature = true
 ): void {
-  processVoluntaryExitAllForks(state as CachedBeaconState<allForks.BeaconState>, signedVoluntaryExit, verifySignature);
+  processVoluntaryExitAllForks(state as BeaconStateCachedAllForks, signedVoluntaryExit, verifySignature);
 }

--- a/packages/beacon-state-transition/src/phase0/epoch/getAttestationDeltas.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/getAttestationDeltas.ts
@@ -1,7 +1,8 @@
 import {bigIntSqrt} from "@chainsafe/lodestar-utils";
 import {BASE_REWARDS_PER_EPOCH as BASE_REWARDS_PER_EPOCH_CONST} from "../../constants";
 import {newZeroedArray} from "../../util";
-import {IEpochProcess, hasMarkers, BeaconStateCachedPhase0} from "../../allForks/util";
+import {IEpochProcess, BeaconStateCachedPhase0} from "../../types";
+import {hasMarkers} from "../../allForks";
 import {
   BASE_REWARD_FACTOR,
   EFFECTIVE_BALANCE_INCREMENT,

--- a/packages/beacon-state-transition/src/phase0/epoch/getAttestationDeltas.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/getAttestationDeltas.ts
@@ -1,8 +1,7 @@
-import {phase0} from "@chainsafe/lodestar-types";
 import {bigIntSqrt} from "@chainsafe/lodestar-utils";
 import {BASE_REWARDS_PER_EPOCH as BASE_REWARDS_PER_EPOCH_CONST} from "../../constants";
 import {newZeroedArray} from "../../util";
-import {IEpochProcess, hasMarkers, CachedBeaconState} from "../../allForks/util";
+import {IEpochProcess, hasMarkers, BeaconStateCachedPhase0} from "../../allForks/util";
 import {
   BASE_REWARD_FACTOR,
   EFFECTIVE_BALANCE_INCREMENT,
@@ -49,7 +48,7 @@ interface IRewardPenaltyItem {
  *   - eligibleAttester:   98%
  */
 export function getAttestationDeltas(
-  state: CachedBeaconState<phase0.BeaconState>,
+  state: BeaconStateCachedPhase0,
   epochProcess: IEpochProcess
 ): [number[], number[]] {
   const validatorCount = epochProcess.statuses.length;

--- a/packages/beacon-state-transition/src/phase0/epoch/getAttestationDeltas.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/getAttestationDeltas.ts
@@ -1,7 +1,7 @@
 import {bigIntSqrt} from "@chainsafe/lodestar-utils";
 import {BASE_REWARDS_PER_EPOCH as BASE_REWARDS_PER_EPOCH_CONST} from "../../constants";
 import {newZeroedArray} from "../../util";
-import {IEpochProcess, BeaconStateCachedPhase0} from "../../types";
+import {IEpochProcess, CachedBeaconStatePhase0} from "../../types";
 import {hasMarkers} from "../../allForks";
 import {
   BASE_REWARD_FACTOR,
@@ -49,7 +49,7 @@ interface IRewardPenaltyItem {
  *   - eligibleAttester:   98%
  */
 export function getAttestationDeltas(
-  state: BeaconStateCachedPhase0,
+  state: CachedBeaconStatePhase0,
   epochProcess: IEpochProcess
 ): [number[], number[]] {
   const validatorCount = epochProcess.statuses.length;

--- a/packages/beacon-state-transition/src/phase0/epoch/index.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/index.ts
@@ -1,4 +1,4 @@
-import {BeaconStateCachedPhase0, BeaconStateCachedAllForks, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedPhase0, BeaconStateCachedAllForks, IEpochProcess} from "../../types";
 import {
   processJustificationAndFinalization,
   processRegistryUpdates,

--- a/packages/beacon-state-transition/src/phase0/epoch/index.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/index.ts
@@ -1,4 +1,4 @@
-import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedPhase0, BeaconStateCachedAllForks, IEpochProcess} from "../../allForks/util";
 import {
   processJustificationAndFinalization,
   processRegistryUpdates,
@@ -12,20 +12,19 @@ import {processRewardsAndPenalties} from "./processRewardsAndPenalties";
 import {processSlashings} from "./processSlashings";
 import {getAttestationDeltas} from "./getAttestationDeltas";
 import {processParticipationRecordUpdates} from "./processParticipationRecordUpdates";
-import {allForks, phase0} from "@chainsafe/lodestar-types";
 
 export {processRewardsAndPenalties, processSlashings, getAttestationDeltas};
 
-export function processEpoch(state: CachedBeaconState<phase0.BeaconState>, epochProcess: IEpochProcess): void {
-  processJustificationAndFinalization(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+export function processEpoch(state: BeaconStateCachedPhase0, epochProcess: IEpochProcess): void {
+  processJustificationAndFinalization(state as BeaconStateCachedAllForks, epochProcess);
   processRewardsAndPenalties(state, epochProcess);
-  processRegistryUpdates(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+  processRegistryUpdates(state as BeaconStateCachedAllForks, epochProcess);
   processSlashings(state, epochProcess);
   // inline processFinalUpdates() to follow altair and for clarity
-  processEth1DataReset(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
-  processEffectiveBalanceUpdates(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
-  processSlashingsReset(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
-  processRandaoMixesReset(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
-  processHistoricalRootsUpdate(state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+  processEth1DataReset(state as BeaconStateCachedAllForks, epochProcess);
+  processEffectiveBalanceUpdates(state as BeaconStateCachedAllForks, epochProcess);
+  processSlashingsReset(state as BeaconStateCachedAllForks, epochProcess);
+  processRandaoMixesReset(state as BeaconStateCachedAllForks, epochProcess);
+  processHistoricalRootsUpdate(state as BeaconStateCachedAllForks, epochProcess);
   processParticipationRecordUpdates(state);
 }

--- a/packages/beacon-state-transition/src/phase0/epoch/index.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/index.ts
@@ -1,4 +1,4 @@
-import {BeaconStateCachedPhase0, BeaconStateCachedAllForks, IEpochProcess} from "../../types";
+import {CachedBeaconStatePhase0, CachedBeaconStateAllForks, IEpochProcess} from "../../types";
 import {
   processJustificationAndFinalization,
   processRegistryUpdates,
@@ -15,16 +15,16 @@ import {processParticipationRecordUpdates} from "./processParticipationRecordUpd
 
 export {processRewardsAndPenalties, processSlashings, getAttestationDeltas};
 
-export function processEpoch(state: BeaconStateCachedPhase0, epochProcess: IEpochProcess): void {
-  processJustificationAndFinalization(state as BeaconStateCachedAllForks, epochProcess);
+export function processEpoch(state: CachedBeaconStatePhase0, epochProcess: IEpochProcess): void {
+  processJustificationAndFinalization(state as CachedBeaconStateAllForks, epochProcess);
   processRewardsAndPenalties(state, epochProcess);
-  processRegistryUpdates(state as BeaconStateCachedAllForks, epochProcess);
+  processRegistryUpdates(state as CachedBeaconStateAllForks, epochProcess);
   processSlashings(state, epochProcess);
   // inline processFinalUpdates() to follow altair and for clarity
-  processEth1DataReset(state as BeaconStateCachedAllForks, epochProcess);
-  processEffectiveBalanceUpdates(state as BeaconStateCachedAllForks, epochProcess);
-  processSlashingsReset(state as BeaconStateCachedAllForks, epochProcess);
-  processRandaoMixesReset(state as BeaconStateCachedAllForks, epochProcess);
-  processHistoricalRootsUpdate(state as BeaconStateCachedAllForks, epochProcess);
+  processEth1DataReset(state as CachedBeaconStateAllForks, epochProcess);
+  processEffectiveBalanceUpdates(state as CachedBeaconStateAllForks, epochProcess);
+  processSlashingsReset(state as CachedBeaconStateAllForks, epochProcess);
+  processRandaoMixesReset(state as CachedBeaconStateAllForks, epochProcess);
+  processHistoricalRootsUpdate(state as CachedBeaconStateAllForks, epochProcess);
   processParticipationRecordUpdates(state);
 }

--- a/packages/beacon-state-transition/src/phase0/epoch/processParticipationRecordUpdates.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/processParticipationRecordUpdates.ts
@@ -1,12 +1,12 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {List} from "@chainsafe/ssz";
-import {CachedBeaconState} from "../../allForks/util";
+import {BeaconStateCachedPhase0} from "../../allForks/util";
 
 /**
  * PERF: Should have zero cost. It just moves a rootNode from one key to another. Then it creates an empty tree on the
  * previous key
  */
-export function processParticipationRecordUpdates(state: CachedBeaconState<phase0.BeaconState>): void {
+export function processParticipationRecordUpdates(state: BeaconStateCachedPhase0): void {
   // rotate current/previous epoch attestations
   state.previousEpochAttestations = state.currentEpochAttestations;
   state.currentEpochAttestations = ([] as phase0.PendingAttestation[]) as List<phase0.PendingAttestation>;

--- a/packages/beacon-state-transition/src/phase0/epoch/processParticipationRecordUpdates.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/processParticipationRecordUpdates.ts
@@ -1,6 +1,6 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {List} from "@chainsafe/ssz";
-import {BeaconStateCachedPhase0} from "../../allForks/util";
+import {BeaconStateCachedPhase0} from "../../types";
 
 /**
  * PERF: Should have zero cost. It just moves a rootNode from one key to another. Then it creates an empty tree on the

--- a/packages/beacon-state-transition/src/phase0/epoch/processParticipationRecordUpdates.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/processParticipationRecordUpdates.ts
@@ -1,12 +1,12 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {List} from "@chainsafe/ssz";
-import {BeaconStateCachedPhase0} from "../../types";
+import {CachedBeaconStatePhase0} from "../../types";
 
 /**
  * PERF: Should have zero cost. It just moves a rootNode from one key to another. Then it creates an empty tree on the
  * previous key
  */
-export function processParticipationRecordUpdates(state: BeaconStateCachedPhase0): void {
+export function processParticipationRecordUpdates(state: CachedBeaconStatePhase0): void {
   // rotate current/previous epoch attestations
   state.previousEpochAttestations = state.currentEpochAttestations;
   state.currentEpochAttestations = ([] as phase0.PendingAttestation[]) as List<phase0.PendingAttestation>;

--- a/packages/beacon-state-transition/src/phase0/epoch/processPendingAttestations.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/processPendingAttestations.ts
@@ -1,7 +1,7 @@
 import {Epoch, phase0, ssz} from "@chainsafe/lodestar-types";
 import {List, readonlyValues} from "@chainsafe/ssz";
 import {IAttesterStatus} from "../../allForks";
-import {BeaconStateCachedPhase0} from "../../types";
+import {CachedBeaconStatePhase0} from "../../types";
 import {computeStartSlotAtEpoch, getBlockRootAtSlot, zipIndexesCommitteeBits} from "../../util";
 
 /**
@@ -16,7 +16,7 @@ import {computeStartSlotAtEpoch, getBlockRootAtSlot, zipIndexesCommitteeBits} fr
  *   - currentEpochAttestationsBits:  85
  */
 export function statusProcessEpoch(
-  state: BeaconStateCachedPhase0,
+  state: CachedBeaconStatePhase0,
   statuses: IAttesterStatus[],
   attestations: List<phase0.PendingAttestation>,
   epoch: Epoch,

--- a/packages/beacon-state-transition/src/phase0/epoch/processPendingAttestations.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/processPendingAttestations.ts
@@ -1,6 +1,7 @@
-import {allForks, Epoch, phase0, ssz} from "@chainsafe/lodestar-types";
+import {Epoch, phase0, ssz} from "@chainsafe/lodestar-types";
 import {List, readonlyValues} from "@chainsafe/ssz";
-import {CachedBeaconState, IAttesterStatus} from "../../allForks/util";
+import {IAttesterStatus} from "../../allForks";
+import {BeaconStateCachedPhase0} from "../../types";
 import {computeStartSlotAtEpoch, getBlockRootAtSlot, zipIndexesCommitteeBits} from "../../util";
 
 /**
@@ -14,8 +15,8 @@ import {computeStartSlotAtEpoch, getBlockRootAtSlot, zipIndexesCommitteeBits} fr
  *   - previousEpochAttestationsBits: 83
  *   - currentEpochAttestationsBits:  85
  */
-export function statusProcessEpoch<T extends allForks.BeaconState>(
-  state: CachedBeaconState<T>,
+export function statusProcessEpoch(
+  state: BeaconStateCachedPhase0,
   statuses: IAttesterStatus[],
   attestations: List<phase0.PendingAttestation>,
   epoch: Epoch,

--- a/packages/beacon-state-transition/src/phase0/epoch/processRewardsAndPenalties.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/processRewardsAndPenalties.ts
@@ -1,6 +1,6 @@
 import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
 
-import {BeaconStateCachedPhase0, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedPhase0, IEpochProcess} from "../../types";
 import {getAttestationDeltas} from "./getAttestationDeltas";
 
 /**

--- a/packages/beacon-state-transition/src/phase0/epoch/processRewardsAndPenalties.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/processRewardsAndPenalties.ts
@@ -1,6 +1,6 @@
 import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
 
-import {BeaconStateCachedPhase0, IEpochProcess} from "../../types";
+import {CachedBeaconStatePhase0, IEpochProcess} from "../../types";
 import {getAttestationDeltas} from "./getAttestationDeltas";
 
 /**
@@ -9,7 +9,7 @@ import {getAttestationDeltas} from "./getAttestationDeltas";
  * PERF: Cost = 'proportional' to $VALIDATOR_COUNT. Extra work is done per validator the more status flags
  * are true, worst case: FLAG_UNSLASHED + FLAG_ELIGIBLE_ATTESTER + FLAG_PREV_*
  */
-export function processRewardsAndPenalties(state: BeaconStateCachedPhase0, epochProcess: IEpochProcess): void {
+export function processRewardsAndPenalties(state: CachedBeaconStatePhase0, epochProcess: IEpochProcess): void {
   // No rewards are applied at the end of `GENESIS_EPOCH` because rewards are for work done in the previous epoch
   if (epochProcess.currentEpoch === GENESIS_EPOCH) {
     return;

--- a/packages/beacon-state-transition/src/phase0/epoch/processRewardsAndPenalties.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/processRewardsAndPenalties.ts
@@ -1,7 +1,6 @@
 import {GENESIS_EPOCH} from "@chainsafe/lodestar-params";
-import {phase0} from "@chainsafe/lodestar-types";
 
-import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedPhase0, IEpochProcess} from "../../allForks/util";
 import {getAttestationDeltas} from "./getAttestationDeltas";
 
 /**
@@ -10,10 +9,7 @@ import {getAttestationDeltas} from "./getAttestationDeltas";
  * PERF: Cost = 'proportional' to $VALIDATOR_COUNT. Extra work is done per validator the more status flags
  * are true, worst case: FLAG_UNSLASHED + FLAG_ELIGIBLE_ATTESTER + FLAG_PREV_*
  */
-export function processRewardsAndPenalties(
-  state: CachedBeaconState<phase0.BeaconState>,
-  epochProcess: IEpochProcess
-): void {
+export function processRewardsAndPenalties(state: BeaconStateCachedPhase0, epochProcess: IEpochProcess): void {
   // No rewards are applied at the end of `GENESIS_EPOCH` because rewards are for work done in the previous epoch
   if (epochProcess.currentEpoch === GENESIS_EPOCH) {
     return;

--- a/packages/beacon-state-transition/src/phase0/epoch/processSlashings.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/processSlashings.ts
@@ -1,7 +1,7 @@
 import {ForkName} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedPhase0, BeaconStateCachedAllForks, IEpochProcess} from "../../types";
+import {CachedBeaconStatePhase0, CachedBeaconStateAllForks, IEpochProcess} from "../../types";
 import {processSlashingsAllForks} from "../../allForks/epoch/processSlashings";
 
-export function processSlashings(state: BeaconStateCachedPhase0, epochProcess: IEpochProcess): void {
-  processSlashingsAllForks(ForkName.phase0, state as BeaconStateCachedAllForks, epochProcess);
+export function processSlashings(state: CachedBeaconStatePhase0, epochProcess: IEpochProcess): void {
+  processSlashingsAllForks(ForkName.phase0, state as CachedBeaconStateAllForks, epochProcess);
 }

--- a/packages/beacon-state-transition/src/phase0/epoch/processSlashings.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/processSlashings.ts
@@ -1,5 +1,5 @@
 import {ForkName} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedPhase0, BeaconStateCachedAllForks, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedPhase0, BeaconStateCachedAllForks, IEpochProcess} from "../../types";
 import {processSlashingsAllForks} from "../../allForks/epoch/processSlashings";
 
 export function processSlashings(state: BeaconStateCachedPhase0, epochProcess: IEpochProcess): void {

--- a/packages/beacon-state-transition/src/phase0/epoch/processSlashings.ts
+++ b/packages/beacon-state-transition/src/phase0/epoch/processSlashings.ts
@@ -1,8 +1,7 @@
-import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
-import {CachedBeaconState, IEpochProcess} from "../../allForks/util";
+import {BeaconStateCachedPhase0, BeaconStateCachedAllForks, IEpochProcess} from "../../allForks/util";
 import {processSlashingsAllForks} from "../../allForks/epoch/processSlashings";
 
-export function processSlashings(state: CachedBeaconState<phase0.BeaconState>, epochProcess: IEpochProcess): void {
-  processSlashingsAllForks(ForkName.phase0, state as CachedBeaconState<allForks.BeaconState>, epochProcess);
+export function processSlashings(state: BeaconStateCachedPhase0, epochProcess: IEpochProcess): void {
+  processSlashingsAllForks(ForkName.phase0, state as BeaconStateCachedAllForks, epochProcess);
 }

--- a/packages/beacon-state-transition/src/types.ts
+++ b/packages/beacon-state-transition/src/types.ts
@@ -3,12 +3,12 @@ import {CachedBeaconState, EpochContext, IEpochProcess} from "./allForks/util";
 
 export {EpochContext, IEpochProcess};
 
-export type BeaconStateCachedPhase0 = CachedBeaconState<phase0.BeaconState>;
-export type BeaconStateCachedAltair = CachedBeaconState<altair.BeaconState>;
-export type BeaconStateCachedBellatrix = CachedBeaconState<bellatrix.BeaconState>;
-export type BeaconStateCachedAllForks = CachedBeaconState<allForks.BeaconState>;
-export type BeaconStateCachedAnyFork =
-  | BeaconStateCachedPhase0
-  | BeaconStateCachedAltair
-  | BeaconStateCachedBellatrix
-  | BeaconStateCachedAllForks;
+export type CachedBeaconStatePhase0 = CachedBeaconState<phase0.BeaconState>;
+export type CachedBeaconStateAltair = CachedBeaconState<altair.BeaconState>;
+export type CachedBeaconStateBellatrix = CachedBeaconState<bellatrix.BeaconState>;
+export type CachedBeaconStateAllForks = CachedBeaconState<allForks.BeaconState>;
+export type CachedBeaconStateAnyFork =
+  | CachedBeaconStatePhase0
+  | CachedBeaconStateAltair
+  | CachedBeaconStateBellatrix
+  | CachedBeaconStateAllForks;

--- a/packages/beacon-state-transition/src/types.ts
+++ b/packages/beacon-state-transition/src/types.ts
@@ -1,0 +1,14 @@
+import {allForks, altair, bellatrix, phase0} from "@chainsafe/lodestar-types";
+import {CachedBeaconState, EpochContext, IEpochProcess} from "./allForks/util";
+
+export {EpochContext, IEpochProcess};
+
+export type BeaconStateCachedPhase0 = CachedBeaconState<phase0.BeaconState>;
+export type BeaconStateCachedAltair = CachedBeaconState<altair.BeaconState>;
+export type BeaconStateCachedBellatrix = CachedBeaconState<bellatrix.BeaconState>;
+export type BeaconStateCachedAllForks = CachedBeaconState<allForks.BeaconState>;
+export type BeaconStateCachedAnyFork =
+  | BeaconStateCachedPhase0
+  | BeaconStateCachedAltair
+  | BeaconStateCachedBellatrix
+  | BeaconStateCachedAllForks;

--- a/packages/beacon-state-transition/src/util/balance.ts
+++ b/packages/beacon-state-transition/src/util/balance.ts
@@ -5,7 +5,7 @@
 import {EFFECTIVE_BALANCE_INCREMENT} from "@chainsafe/lodestar-params";
 import {allForks, Gwei, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {bigIntMax} from "@chainsafe/lodestar-utils";
-import {BeaconStateCachedAllForks, BeaconStateCachedAltair} from "../allForks";
+import {BeaconStateCachedAllForks, BeaconStateCachedAltair} from "../types";
 
 /**
  * Return the combined effective balance of the [[indices]].

--- a/packages/beacon-state-transition/src/util/balance.ts
+++ b/packages/beacon-state-transition/src/util/balance.ts
@@ -5,7 +5,7 @@
 import {EFFECTIVE_BALANCE_INCREMENT} from "@chainsafe/lodestar-params";
 import {allForks, Gwei, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {bigIntMax} from "@chainsafe/lodestar-utils";
-import {BeaconStateCachedAllForks, BeaconStateCachedAltair} from "../types";
+import {CachedBeaconStateAllForks, CachedBeaconStateAltair} from "../types";
 
 /**
  * Return the combined effective balance of the [[indices]].
@@ -28,7 +28,7 @@ export function getTotalBalance(state: allForks.BeaconState, indices: ValidatorI
  * Increase the balance for a validator with the given ``index`` by ``delta``.
  */
 export function increaseBalance(
-  state: BeaconStateCachedAllForks | BeaconStateCachedAltair,
+  state: CachedBeaconStateAllForks | CachedBeaconStateAltair,
   index: ValidatorIndex,
   delta: number
 ): void {
@@ -42,7 +42,7 @@ export function increaseBalance(
  * Set to ``0`` when underflow.
  */
 export function decreaseBalance(
-  state: BeaconStateCachedAllForks | BeaconStateCachedAltair,
+  state: CachedBeaconStateAllForks | CachedBeaconStateAltair,
   index: ValidatorIndex,
   delta: number
 ): void {
@@ -54,7 +54,7 @@ export function decreaseBalance(
  * This is consumed by forkchoice which based on delta so we return "by increment" (in ether) value,
  * ie [30, 31, 32] instead of [30e9, 31e9, 32e9]
  */
-export function getEffectiveBalances(justifiedState: BeaconStateCachedAllForks): number[] {
+export function getEffectiveBalances(justifiedState: CachedBeaconStateAllForks): number[] {
   const {activeIndices} = justifiedState.currentShuffling;
   // 5x faster than using readonlyValuesListOfLeafNodeStruct
   const count = justifiedState.validators.length;

--- a/packages/beacon-state-transition/src/util/balance.ts
+++ b/packages/beacon-state-transition/src/util/balance.ts
@@ -3,9 +3,9 @@
  */
 
 import {EFFECTIVE_BALANCE_INCREMENT} from "@chainsafe/lodestar-params";
-import {allForks, altair, Gwei, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {allForks, Gwei, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {bigIntMax} from "@chainsafe/lodestar-utils";
-import {CachedBeaconState} from "../allForks";
+import {BeaconStateCachedAllForks, BeaconStateCachedAltair} from "../allForks";
 
 /**
  * Return the combined effective balance of the [[indices]].
@@ -28,7 +28,7 @@ export function getTotalBalance(state: allForks.BeaconState, indices: ValidatorI
  * Increase the balance for a validator with the given ``index`` by ``delta``.
  */
 export function increaseBalance(
-  state: CachedBeaconState<allForks.BeaconState> | CachedBeaconState<altair.BeaconState>,
+  state: BeaconStateCachedAllForks | BeaconStateCachedAltair,
   index: ValidatorIndex,
   delta: number
 ): void {
@@ -42,7 +42,7 @@ export function increaseBalance(
  * Set to ``0`` when underflow.
  */
 export function decreaseBalance(
-  state: CachedBeaconState<allForks.BeaconState> | CachedBeaconState<altair.BeaconState>,
+  state: BeaconStateCachedAllForks | BeaconStateCachedAltair,
   index: ValidatorIndex,
   delta: number
 ): void {
@@ -54,7 +54,7 @@ export function decreaseBalance(
  * This is consumed by forkchoice which based on delta so we return "by increment" (in ether) value,
  * ie [30, 31, 32] instead of [30e9, 31e9, 32e9]
  */
-export function getEffectiveBalances(justifiedState: CachedBeaconState<allForks.BeaconState>): number[] {
+export function getEffectiveBalances(justifiedState: BeaconStateCachedAllForks): number[] {
   const {activeIndices} = justifiedState.currentShuffling;
   // 5x faster than using readonlyValuesListOfLeafNodeStruct
   const count = justifiedState.validators.length;

--- a/packages/beacon-state-transition/src/util/finality.ts
+++ b/packages/beacon-state-transition/src/util/finality.ts
@@ -1,8 +1,7 @@
 import {MIN_EPOCHS_TO_INACTIVITY_PENALTY} from "@chainsafe/lodestar-params";
-import {allForks} from "@chainsafe/lodestar-types";
-import {CachedBeaconState} from "../allForks/util";
+import {BeaconStateCachedAllForks} from "../allForks/util";
 
-export function getFinalityDelay(state: CachedBeaconState<allForks.BeaconState>): number {
+export function getFinalityDelay(state: BeaconStateCachedAllForks): number {
   return state.previousShuffling.epoch - state.finalizedCheckpoint.epoch;
 }
 
@@ -12,6 +11,6 @@ export function getFinalityDelay(state: CachedBeaconState<allForks.BeaconState>)
  * until blocks get finalized again. See here (https://github.com/ethereum/annotated-spec/blob/master/phase0/beacon-chain.md#inactivity-quotient) for what the inactivity leak is, what it's for and how
  * it works.
  */
-export function isInInactivityLeak(state: CachedBeaconState<allForks.BeaconState>): boolean {
+export function isInInactivityLeak(state: BeaconStateCachedAllForks): boolean {
   return getFinalityDelay(state) > MIN_EPOCHS_TO_INACTIVITY_PENALTY;
 }

--- a/packages/beacon-state-transition/src/util/finality.ts
+++ b/packages/beacon-state-transition/src/util/finality.ts
@@ -1,5 +1,5 @@
 import {MIN_EPOCHS_TO_INACTIVITY_PENALTY} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedAllForks} from "../allForks/util";
+import {BeaconStateCachedAllForks} from "../types";
 
 export function getFinalityDelay(state: BeaconStateCachedAllForks): number {
   return state.previousShuffling.epoch - state.finalizedCheckpoint.epoch;

--- a/packages/beacon-state-transition/src/util/finality.ts
+++ b/packages/beacon-state-transition/src/util/finality.ts
@@ -1,7 +1,7 @@
 import {MIN_EPOCHS_TO_INACTIVITY_PENALTY} from "@chainsafe/lodestar-params";
-import {BeaconStateCachedAllForks} from "../types";
+import {CachedBeaconStateAllForks} from "../types";
 
-export function getFinalityDelay(state: BeaconStateCachedAllForks): number {
+export function getFinalityDelay(state: CachedBeaconStateAllForks): number {
   return state.previousShuffling.epoch - state.finalizedCheckpoint.epoch;
 }
 
@@ -11,6 +11,6 @@ export function getFinalityDelay(state: BeaconStateCachedAllForks): number {
  * until blocks get finalized again. See here (https://github.com/ethereum/annotated-spec/blob/master/phase0/beacon-chain.md#inactivity-quotient) for what the inactivity leak is, what it's for and how
  * it works.
  */
-export function isInInactivityLeak(state: BeaconStateCachedAllForks): boolean {
+export function isInInactivityLeak(state: CachedBeaconStateAllForks): boolean {
   return getFinalityDelay(state) > MIN_EPOCHS_TO_INACTIVITY_PENALTY;
 }

--- a/packages/beacon-state-transition/src/util/genesis.ts
+++ b/packages/beacon-state-transition/src/util/genesis.ts
@@ -24,7 +24,8 @@ import {computeEpochAtSlot} from "./epoch";
 import {getActiveValidatorIndices} from "./validator";
 import {getTemporaryBlockHeader} from "./blockRoot";
 import {getNextSyncCommittee} from "../altair/util/syncCommittee";
-import {BeaconStateCachedAllForks, createCachedBeaconState, processDeposit} from "../allForks";
+import {createCachedBeaconState, processDeposit} from "../allForks";
+import {BeaconStateCachedAllForks} from "../types";
 
 // TODO: Refactor to work with non-phase0 genesis state
 

--- a/packages/beacon-state-transition/src/util/genesis.ts
+++ b/packages/beacon-state-transition/src/util/genesis.ts
@@ -24,7 +24,7 @@ import {computeEpochAtSlot} from "./epoch";
 import {getActiveValidatorIndices} from "./validator";
 import {getTemporaryBlockHeader} from "./blockRoot";
 import {getNextSyncCommittee} from "../altair/util/syncCommittee";
-import {CachedBeaconState, createCachedBeaconState, processDeposit} from "../allForks";
+import {BeaconStateCachedAllForks, createCachedBeaconState, processDeposit} from "../allForks";
 
 // TODO: Refactor to work with non-phase0 genesis state
 
@@ -58,7 +58,7 @@ export function getGenesisBeaconState(
   config: IBeaconConfig,
   genesisEth1Data: phase0.Eth1Data,
   latestBlockHeader: phase0.BeaconBlockHeader
-): CachedBeaconState<allForks.BeaconState> {
+): BeaconStateCachedAllForks {
   // Seed RANDAO with Eth1 entropy
   const randaoMixes = Array<Bytes32>(EPOCHS_PER_HISTORICAL_VECTOR).fill(genesisEth1Data.blockHash);
 
@@ -131,7 +131,7 @@ export function applyTimestamp(
  */
 export function applyDeposits(
   config: IChainForkConfig,
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   newDeposits: phase0.Deposit[],
   fullDepositDataRootList?: TreeBacked<List<Root>>
 ): ValidatorIndex[] {

--- a/packages/beacon-state-transition/src/util/genesis.ts
+++ b/packages/beacon-state-transition/src/util/genesis.ts
@@ -25,7 +25,7 @@ import {getActiveValidatorIndices} from "./validator";
 import {getTemporaryBlockHeader} from "./blockRoot";
 import {getNextSyncCommittee} from "../altair/util/syncCommittee";
 import {createCachedBeaconState, processDeposit} from "../allForks";
-import {BeaconStateCachedAllForks} from "../types";
+import {CachedBeaconStateAllForks} from "../types";
 
 // TODO: Refactor to work with non-phase0 genesis state
 
@@ -59,7 +59,7 @@ export function getGenesisBeaconState(
   config: IBeaconConfig,
   genesisEth1Data: phase0.Eth1Data,
   latestBlockHeader: phase0.BeaconBlockHeader
-): BeaconStateCachedAllForks {
+): CachedBeaconStateAllForks {
   // Seed RANDAO with Eth1 entropy
   const randaoMixes = Array<Bytes32>(EPOCHS_PER_HISTORICAL_VECTOR).fill(genesisEth1Data.blockHash);
 
@@ -132,7 +132,7 @@ export function applyTimestamp(
  */
 export function applyDeposits(
   config: IChainForkConfig,
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   newDeposits: phase0.Deposit[],
   fullDepositDataRootList?: TreeBacked<List<Root>>
 ): ValidatorIndex[] {

--- a/packages/beacon-state-transition/src/util/shufflingDecisionRoot.ts
+++ b/packages/beacon-state-transition/src/util/shufflingDecisionRoot.ts
@@ -1,5 +1,5 @@
-import {allForks, Epoch, Root, Slot} from "@chainsafe/lodestar-types";
-import {CachedBeaconState} from "../allForks/util/cachedBeaconState";
+import {Epoch, Root, Slot} from "@chainsafe/lodestar-types";
+import {BeaconStateCachedAllForks} from "../allForks/util/cachedBeaconState";
 import {getBlockRootAtSlot} from "./blockRoot";
 import {computeStartSlotAtEpoch} from "./epoch";
 
@@ -10,7 +10,7 @@ import {computeStartSlotAtEpoch} from "./epoch";
  * Returns `null` on the one-off scenario where the genesis block decides its own shuffling.
  * It should be set to the latest block applied to this `state` or the genesis block root.
  */
-export function proposerShufflingDecisionRoot(state: CachedBeaconState<allForks.BeaconState>): Root | null {
+export function proposerShufflingDecisionRoot(state: BeaconStateCachedAllForks): Root | null {
   const decisionSlot = proposerShufflingDecisionSlot(state);
   if (state.slot == decisionSlot) {
     return null;
@@ -23,7 +23,7 @@ export function proposerShufflingDecisionRoot(state: CachedBeaconState<allForks.
  * Returns the slot at which the proposer shuffling was decided. The block root at this slot
  * can be used to key the proposer shuffling for the current epoch.
  */
-function proposerShufflingDecisionSlot(state: CachedBeaconState<allForks.BeaconState>): Slot {
+function proposerShufflingDecisionSlot(state: BeaconStateCachedAllForks): Slot {
   const startSlot = computeStartSlotAtEpoch(state.currentShuffling.epoch);
   return Math.max(startSlot - 1, 0);
 }
@@ -35,10 +35,7 @@ function proposerShufflingDecisionSlot(state: CachedBeaconState<allForks.BeaconS
  * Returns `null` on the one-off scenario where the genesis block decides its own shuffling.
  * It should be set to the latest block applied to this `state` or the genesis block root.
  */
-export function attesterShufflingDecisionRoot(
-  state: CachedBeaconState<allForks.BeaconState>,
-  requestedEpoch: Epoch
-): Root | null {
+export function attesterShufflingDecisionRoot(state: BeaconStateCachedAllForks, requestedEpoch: Epoch): Root | null {
   const decisionSlot = attesterShufflingDecisionSlot(state, requestedEpoch);
   if (state.slot == decisionSlot) {
     return null;
@@ -51,7 +48,7 @@ export function attesterShufflingDecisionRoot(
  * Returns the slot at which the proposer shuffling was decided. The block root at this slot
  * can be used to key the proposer shuffling for the current epoch.
  */
-function attesterShufflingDecisionSlot(state: CachedBeaconState<allForks.BeaconState>, requestedEpoch: Epoch): Slot {
+function attesterShufflingDecisionSlot(state: BeaconStateCachedAllForks, requestedEpoch: Epoch): Slot {
   const epoch = attesterShufflingDecisionEpoch(state, requestedEpoch);
   const slot = computeStartSlotAtEpoch(epoch);
   return Math.max(slot - 1, 0);
@@ -66,7 +63,7 @@ function attesterShufflingDecisionSlot(state: CachedBeaconState<allForks.BeaconS
  * - `EpochTooLow` when `requestedEpoch` is more than 1 prior to `currentEpoch`.
  * - `EpochTooHigh` when `requestedEpoch` is more than 1 after `currentEpoch`.
  */
-function attesterShufflingDecisionEpoch(state: CachedBeaconState<allForks.BeaconState>, requestedEpoch: Epoch): Epoch {
+function attesterShufflingDecisionEpoch(state: BeaconStateCachedAllForks, requestedEpoch: Epoch): Epoch {
   const currentEpoch = state.currentShuffling.epoch;
   const previouEpoch = state.previousShuffling.epoch;
 

--- a/packages/beacon-state-transition/src/util/shufflingDecisionRoot.ts
+++ b/packages/beacon-state-transition/src/util/shufflingDecisionRoot.ts
@@ -1,5 +1,5 @@
 import {Epoch, Root, Slot} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAllForks} from "../allForks/util/cachedBeaconState";
+import {BeaconStateCachedAllForks} from "../types";
 import {getBlockRootAtSlot} from "./blockRoot";
 import {computeStartSlotAtEpoch} from "./epoch";
 

--- a/packages/beacon-state-transition/src/util/shufflingDecisionRoot.ts
+++ b/packages/beacon-state-transition/src/util/shufflingDecisionRoot.ts
@@ -1,5 +1,5 @@
 import {Epoch, Root, Slot} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAllForks} from "../types";
+import {CachedBeaconStateAllForks} from "../types";
 import {getBlockRootAtSlot} from "./blockRoot";
 import {computeStartSlotAtEpoch} from "./epoch";
 
@@ -10,7 +10,7 @@ import {computeStartSlotAtEpoch} from "./epoch";
  * Returns `null` on the one-off scenario where the genesis block decides its own shuffling.
  * It should be set to the latest block applied to this `state` or the genesis block root.
  */
-export function proposerShufflingDecisionRoot(state: BeaconStateCachedAllForks): Root | null {
+export function proposerShufflingDecisionRoot(state: CachedBeaconStateAllForks): Root | null {
   const decisionSlot = proposerShufflingDecisionSlot(state);
   if (state.slot == decisionSlot) {
     return null;
@@ -23,7 +23,7 @@ export function proposerShufflingDecisionRoot(state: BeaconStateCachedAllForks):
  * Returns the slot at which the proposer shuffling was decided. The block root at this slot
  * can be used to key the proposer shuffling for the current epoch.
  */
-function proposerShufflingDecisionSlot(state: BeaconStateCachedAllForks): Slot {
+function proposerShufflingDecisionSlot(state: CachedBeaconStateAllForks): Slot {
   const startSlot = computeStartSlotAtEpoch(state.currentShuffling.epoch);
   return Math.max(startSlot - 1, 0);
 }
@@ -35,7 +35,7 @@ function proposerShufflingDecisionSlot(state: BeaconStateCachedAllForks): Slot {
  * Returns `null` on the one-off scenario where the genesis block decides its own shuffling.
  * It should be set to the latest block applied to this `state` or the genesis block root.
  */
-export function attesterShufflingDecisionRoot(state: BeaconStateCachedAllForks, requestedEpoch: Epoch): Root | null {
+export function attesterShufflingDecisionRoot(state: CachedBeaconStateAllForks, requestedEpoch: Epoch): Root | null {
   const decisionSlot = attesterShufflingDecisionSlot(state, requestedEpoch);
   if (state.slot == decisionSlot) {
     return null;
@@ -48,7 +48,7 @@ export function attesterShufflingDecisionRoot(state: BeaconStateCachedAllForks, 
  * Returns the slot at which the proposer shuffling was decided. The block root at this slot
  * can be used to key the proposer shuffling for the current epoch.
  */
-function attesterShufflingDecisionSlot(state: BeaconStateCachedAllForks, requestedEpoch: Epoch): Slot {
+function attesterShufflingDecisionSlot(state: CachedBeaconStateAllForks, requestedEpoch: Epoch): Slot {
   const epoch = attesterShufflingDecisionEpoch(state, requestedEpoch);
   const slot = computeStartSlotAtEpoch(epoch);
   return Math.max(slot - 1, 0);
@@ -63,7 +63,7 @@ function attesterShufflingDecisionSlot(state: BeaconStateCachedAllForks, request
  * - `EpochTooLow` when `requestedEpoch` is more than 1 prior to `currentEpoch`.
  * - `EpochTooHigh` when `requestedEpoch` is more than 1 after `currentEpoch`.
  */
-function attesterShufflingDecisionEpoch(state: BeaconStateCachedAllForks, requestedEpoch: Epoch): Epoch {
+function attesterShufflingDecisionEpoch(state: CachedBeaconStateAllForks, requestedEpoch: Epoch): Epoch {
   const currentEpoch = state.currentShuffling.epoch;
   const previouEpoch = state.previousShuffling.epoch;
 

--- a/packages/beacon-state-transition/test/perf/allForks/util/epochContext.test.ts
+++ b/packages/beacon-state-transition/test/perf/allForks/util/epochContext.test.ts
@@ -1,6 +1,6 @@
 import {Epoch} from "@chainsafe/lodestar-types";
 import {itBench} from "@dapplion/benchmark";
-import {computeEpochAtSlot, BeaconStateCachedAllForks} from "../../../../src";
+import {computeEpochAtSlot, CachedBeaconStateAllForks} from "../../../../src";
 import {generatePerfTestCachedStatePhase0, numValidators} from "../../util";
 
 // Current implementation scales very well with number of requested validators
@@ -10,12 +10,12 @@ import {generatePerfTestCachedStatePhase0, numValidators} from "../../util";
 // ✓ getCommitteeAssignments - req 100 vs - 200000 vc                    141.3410 ops/s    7.075087 ms/op        -       1024 runs   7.25 s
 // ✓ getCommitteeAssignments - req 1000 vs - 200000 vc                   124.7096 ops/s    8.018632 ms/op        -       1024 runs   8.25 s
 describe("epochCtx.getCommitteeAssignments", () => {
-  let state: BeaconStateCachedAllForks;
+  let state: CachedBeaconStateAllForks;
   let epoch: Epoch;
 
   before(function () {
     this.timeout(60 * 1000);
-    state = generatePerfTestCachedStatePhase0() as BeaconStateCachedAllForks;
+    state = generatePerfTestCachedStatePhase0() as CachedBeaconStateAllForks;
     epoch = computeEpochAtSlot(state.slot);
 
     // Sanity check to ensure numValidators doesn't go stale

--- a/packages/beacon-state-transition/test/perf/allForks/util/epochContext.test.ts
+++ b/packages/beacon-state-transition/test/perf/allForks/util/epochContext.test.ts
@@ -1,6 +1,6 @@
 import {Epoch} from "@chainsafe/lodestar-types";
 import {itBench} from "@dapplion/benchmark";
-import {allForks, computeEpochAtSlot} from "../../../../src";
+import {computeEpochAtSlot, BeaconStateCachedAllForks} from "../../../../src";
 import {generatePerfTestCachedStatePhase0, numValidators} from "../../util";
 
 // Current implementation scales very well with number of requested validators
@@ -10,12 +10,12 @@ import {generatePerfTestCachedStatePhase0, numValidators} from "../../util";
 // ✓ getCommitteeAssignments - req 100 vs - 200000 vc                    141.3410 ops/s    7.075087 ms/op        -       1024 runs   7.25 s
 // ✓ getCommitteeAssignments - req 1000 vs - 200000 vc                   124.7096 ops/s    8.018632 ms/op        -       1024 runs   8.25 s
 describe("epochCtx.getCommitteeAssignments", () => {
-  let state: allForks.CachedBeaconState<allForks.BeaconState>;
+  let state: BeaconStateCachedAllForks;
   let epoch: Epoch;
 
   before(function () {
     this.timeout(60 * 1000);
-    state = generatePerfTestCachedStatePhase0() as allForks.CachedBeaconState<allForks.BeaconState>;
+    state = generatePerfTestCachedStatePhase0() as BeaconStateCachedAllForks;
     epoch = computeEpochAtSlot(state.slot);
 
     // Sanity check to ensure numValidators doesn't go stale

--- a/packages/beacon-state-transition/test/perf/allForks/util/shufflings.test.ts
+++ b/packages/beacon-state-transition/test/perf/allForks/util/shufflings.test.ts
@@ -1,17 +1,17 @@
 import {itBench} from "@dapplion/benchmark";
 import {Epoch} from "@chainsafe/lodestar-types";
-import {computeEpochAtSlot, BeaconStateCachedAllForks} from "../../../../src";
+import {computeEpochAtSlot, CachedBeaconStateAllForks} from "../../../../src";
 import {computeEpochShuffling, computeProposers} from "../../../../src/allForks";
 import {generatePerfTestCachedStatePhase0, numValidators} from "../../util";
 import {getNextSyncCommittee} from "../../../../src/altair/util/syncCommittee";
 
 describe("epoch shufflings", () => {
-  let state: BeaconStateCachedAllForks;
+  let state: CachedBeaconStateAllForks;
   let nextEpoch: Epoch;
 
   before(function () {
     this.timeout(60 * 1000);
-    state = generatePerfTestCachedStatePhase0() as BeaconStateCachedAllForks;
+    state = generatePerfTestCachedStatePhase0() as CachedBeaconStateAllForks;
     nextEpoch = computeEpochAtSlot(state.slot) + 1;
 
     // Sanity check to ensure numValidators doesn't go stale

--- a/packages/beacon-state-transition/test/perf/allForks/util/shufflings.test.ts
+++ b/packages/beacon-state-transition/test/perf/allForks/util/shufflings.test.ts
@@ -1,17 +1,17 @@
 import {itBench} from "@dapplion/benchmark";
 import {Epoch} from "@chainsafe/lodestar-types";
-import {allForks, computeEpochAtSlot} from "../../../../src";
+import {computeEpochAtSlot, BeaconStateCachedAllForks} from "../../../../src";
 import {computeEpochShuffling, computeProposers} from "../../../../src/allForks";
 import {generatePerfTestCachedStatePhase0, numValidators} from "../../util";
 import {getNextSyncCommittee} from "../../../../src/altair/util/syncCommittee";
 
 describe("epoch shufflings", () => {
-  let state: allForks.CachedBeaconState<allForks.BeaconState>;
+  let state: BeaconStateCachedAllForks;
   let nextEpoch: Epoch;
 
   before(function () {
     this.timeout(60 * 1000);
-    state = generatePerfTestCachedStatePhase0() as allForks.CachedBeaconState<allForks.BeaconState>;
+    state = generatePerfTestCachedStatePhase0() as BeaconStateCachedAllForks;
     nextEpoch = computeEpochAtSlot(state.slot) + 1;
 
     // Sanity check to ensure numValidators doesn't go stale

--- a/packages/beacon-state-transition/test/perf/altair/block/processAttestation.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/block/processAttestation.test.ts
@@ -10,7 +10,7 @@ import {
   SLOTS_PER_EPOCH,
   SYNC_COMMITTEE_SIZE,
 } from "@chainsafe/lodestar-params";
-import {allForks, altair} from "../../../../src";
+import {allForks, altair, BeaconStateCachedAllForks} from "../../../../src";
 import {generatePerfTestCachedStateAltair, perfStateId} from "../../util";
 import {BlockAltairOpts, getBlockAltair} from "../../phase0/block/util";
 import {StateAltair, StateAttestations} from "../../types";
@@ -56,14 +56,14 @@ describe("altair processAttestation", () => {
     itBench<StateAttestations, StateAttestations>({
       id: `altair processAttestation - ${perfStateId} ${id}`,
       before: () => {
-        const state = generatePerfTestCachedStateAltair() as allForks.CachedBeaconState<allForks.BeaconState>;
+        const state = generatePerfTestCachedStateAltair() as BeaconStateCachedAllForks;
         const block = getBlockAltair(state, opts);
         state.hashTreeRoot();
         return {state, attestations: block.message.body.attestations as phase0.Attestation[]};
       },
       beforeEach: ({state, attestations}) => ({state: state.clone(), attestations}),
       fn: ({state, attestations}) => {
-        altair.processAttestations(state as allForks.CachedBeaconState<altair.BeaconState>, attestations, false);
+        altair.processAttestations(state as allForks.BeaconStateCachedAltair, attestations, false);
       },
     });
   }

--- a/packages/beacon-state-transition/test/perf/altair/block/processAttestation.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/block/processAttestation.test.ts
@@ -10,7 +10,7 @@ import {
   SLOTS_PER_EPOCH,
   SYNC_COMMITTEE_SIZE,
 } from "@chainsafe/lodestar-params";
-import {allForks, altair, BeaconStateCachedAllForks} from "../../../../src";
+import {altair, BeaconStateCachedAllForks, BeaconStateCachedAltair} from "../../../../src";
 import {generatePerfTestCachedStateAltair, perfStateId} from "../../util";
 import {BlockAltairOpts, getBlockAltair} from "../../phase0/block/util";
 import {StateAltair, StateAttestations} from "../../types";
@@ -63,7 +63,7 @@ describe("altair processAttestation", () => {
       },
       beforeEach: ({state, attestations}) => ({state: state.clone(), attestations}),
       fn: ({state, attestations}) => {
-        altair.processAttestations(state as allForks.BeaconStateCachedAltair, attestations, false);
+        altair.processAttestations(state as BeaconStateCachedAltair, attestations, false);
       },
     });
   }

--- a/packages/beacon-state-transition/test/perf/altair/block/processAttestation.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/block/processAttestation.test.ts
@@ -10,7 +10,7 @@ import {
   SLOTS_PER_EPOCH,
   SYNC_COMMITTEE_SIZE,
 } from "@chainsafe/lodestar-params";
-import {altair, BeaconStateCachedAllForks, BeaconStateCachedAltair} from "../../../../src";
+import {altair, CachedBeaconStateAllForks, CachedBeaconStateAltair} from "../../../../src";
 import {generatePerfTestCachedStateAltair, perfStateId} from "../../util";
 import {BlockAltairOpts, getBlockAltair} from "../../phase0/block/util";
 import {StateAltair, StateAttestations} from "../../types";
@@ -56,14 +56,14 @@ describe("altair processAttestation", () => {
     itBench<StateAttestations, StateAttestations>({
       id: `altair processAttestation - ${perfStateId} ${id}`,
       before: () => {
-        const state = generatePerfTestCachedStateAltair() as BeaconStateCachedAllForks;
+        const state = generatePerfTestCachedStateAltair() as CachedBeaconStateAllForks;
         const block = getBlockAltair(state, opts);
         state.hashTreeRoot();
         return {state, attestations: block.message.body.attestations as phase0.Attestation[]};
       },
       beforeEach: ({state, attestations}) => ({state: state.clone(), attestations}),
       fn: ({state, attestations}) => {
-        altair.processAttestations(state as BeaconStateCachedAltair, attestations, false);
+        altair.processAttestations(state as CachedBeaconStateAltair, attestations, false);
       },
     });
   }

--- a/packages/beacon-state-transition/test/perf/altair/block/processBlock.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/block/processBlock.test.ts
@@ -9,7 +9,7 @@ import {
   PresetName,
   SYNC_COMMITTEE_SIZE,
 } from "@chainsafe/lodestar-params";
-import {allForks, BeaconStateCachedAllForks} from "../../../../src";
+import {allForks, CachedBeaconStateAllForks} from "../../../../src";
 import {generatePerfTestCachedStateAltair, perfStateId} from "../../util";
 import {BlockAltairOpts, getBlockAltair} from "../../phase0/block/util";
 import {StateBlock} from "../../types";
@@ -102,7 +102,7 @@ describe("altair processBlock", () => {
     itBench<StateBlock, StateBlock>({
       id: `altair processBlock - ${perfStateId} ${id}`,
       before: () => {
-        const state = generatePerfTestCachedStateAltair() as BeaconStateCachedAllForks;
+        const state = generatePerfTestCachedStateAltair() as CachedBeaconStateAllForks;
         const block = getBlockAltair(state, opts);
         state.hashTreeRoot();
         return {state, block};

--- a/packages/beacon-state-transition/test/perf/altair/block/processBlock.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/block/processBlock.test.ts
@@ -9,7 +9,7 @@ import {
   PresetName,
   SYNC_COMMITTEE_SIZE,
 } from "@chainsafe/lodestar-params";
-import {allForks} from "../../../../src";
+import {allForks, BeaconStateCachedAllForks} from "../../../../src";
 import {generatePerfTestCachedStateAltair, perfStateId} from "../../util";
 import {BlockAltairOpts, getBlockAltair} from "../../phase0/block/util";
 import {StateBlock} from "../../types";
@@ -102,7 +102,7 @@ describe("altair processBlock", () => {
     itBench<StateBlock, StateBlock>({
       id: `altair processBlock - ${perfStateId} ${id}`,
       before: () => {
-        const state = generatePerfTestCachedStateAltair() as allForks.CachedBeaconState<allForks.BeaconState>;
+        const state = generatePerfTestCachedStateAltair() as BeaconStateCachedAllForks;
         const block = getBlockAltair(state, opts);
         state.hashTreeRoot();
         return {state, block};

--- a/packages/beacon-state-transition/test/perf/altair/epoch/epoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/epoch/epoch.test.ts
@@ -3,8 +3,8 @@ import {
   allForks,
   altair,
   computeStartSlotAtEpoch,
-  BeaconStateCachedAllForks,
-  BeaconStateCachedAltair,
+  CachedBeaconStateAllForks,
+  CachedBeaconStateAltair,
 } from "../../../../src";
 import {beforeValue, getNetworkCachedState, LazyValue} from "../../util";
 import {StateEpoch} from "../../types";
@@ -27,10 +27,10 @@ describe(`altair processEpoch - ${stateId}`, () => {
   itBench({
     id: `altair processEpoch - ${stateId}`,
     yieldEventLoopAfterEach: true, // So SubTree(s)'s WeakRef can be garbage collected https://github.com/nodejs/node/issues/39902
-    beforeEach: () => stateOg.value.clone() as BeaconStateCachedAllForks,
+    beforeEach: () => stateOg.value.clone() as CachedBeaconStateAllForks,
     fn: (state) => {
       const epochProcess = allForks.beforeProcessEpoch(state);
-      altair.processEpoch(state as BeaconStateCachedAltair, epochProcess);
+      altair.processEpoch(state as CachedBeaconStateAltair, epochProcess);
       allForks.afterProcessEpoch(state, epochProcess);
       // Simulate root computation through the next block to account for changes
       state.hashTreeRoot();
@@ -45,10 +45,10 @@ describe(`altair processEpoch - ${stateId}`, () => {
   });
 });
 
-function benchmarkAltairEpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>, stateId: string): void {
+function benchmarkAltairEpochSteps(stateOg: LazyValue<CachedBeaconStateAllForks>, stateId: string): void {
   const epochProcess = beforeValue(() => allForks.beforeProcessEpoch(stateOg.value));
 
-  // const getPerfState = (): BeaconStateCachedAltair => {
+  // const getPerfState = (): CachedBeaconStateAltair => {
   //   const state = originalState.clone();
   //   state.setStateCachesAsTransient();
   //   return state;
@@ -90,13 +90,13 @@ function benchmarkAltairEpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>
 
   itBench({
     id: `${stateId} - altair processInactivityUpdates`,
-    beforeEach: () => stateOg.value.clone() as BeaconStateCachedAltair,
+    beforeEach: () => stateOg.value.clone() as CachedBeaconStateAltair,
     fn: (state) => altair.processInactivityUpdates(state, epochProcess.value),
   });
 
   itBench({
     id: `${stateId} - altair processRewardsAndPenalties`,
-    beforeEach: () => stateOg.value.clone() as BeaconStateCachedAltair,
+    beforeEach: () => stateOg.value.clone() as CachedBeaconStateAltair,
     fn: (state) => altair.processRewardsAndPenalties(state, epochProcess.value),
   });
 
@@ -110,7 +110,7 @@ function benchmarkAltairEpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>
   // TODO: Needs a better state to test with, current does not include enough actions: 39.985 us/op
   itBench({
     id: `${stateId} - altair processSlashings`,
-    beforeEach: () => stateOg.value.clone() as BeaconStateCachedAltair,
+    beforeEach: () => stateOg.value.clone() as CachedBeaconStateAltair,
     fn: (state) => altair.processSlashings(state, epochProcess.value),
   });
 
@@ -146,14 +146,14 @@ function benchmarkAltairEpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>
 
   itBench({
     id: `${stateId} - altair processParticipationFlagUpdates`,
-    beforeEach: () => stateOg.value.clone() as BeaconStateCachedAltair,
+    beforeEach: () => stateOg.value.clone() as CachedBeaconStateAltair,
     fn: (state) => altair.processParticipationFlagUpdates(state),
   });
 
   itBench({
     id: `${stateId} - altair processSyncCommitteeUpdates`,
     convergeFactor: 1 / 100, // Very unstable make it converge faster
-    beforeEach: () => stateOg.value.clone() as BeaconStateCachedAltair,
+    beforeEach: () => stateOg.value.clone() as CachedBeaconStateAltair,
     fn: (state) => altair.processSyncCommitteeUpdates(state, epochProcess.value),
   });
 
@@ -163,7 +163,7 @@ function benchmarkAltairEpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>
     before: () => {
       const state = stateOg.value.clone();
       const epochProcessAfter = allForks.beforeProcessEpoch(state);
-      altair.processEpoch(state as BeaconStateCachedAltair, epochProcessAfter);
+      altair.processEpoch(state as CachedBeaconStateAltair, epochProcessAfter);
       return {state, epochProcess: epochProcessAfter};
     },
     beforeEach: ({state, epochProcess}) => ({state: state.clone(), epochProcess}),

--- a/packages/beacon-state-transition/test/perf/altair/epoch/epoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/epoch/epoch.test.ts
@@ -1,5 +1,11 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
-import {allForks, altair, CachedBeaconState, computeStartSlotAtEpoch} from "../../../../src";
+import {
+  allForks,
+  altair,
+  computeStartSlotAtEpoch,
+  BeaconStateCachedAllForks,
+  BeaconStateCachedAltair,
+} from "../../../../src";
 import {beforeValue, getNetworkCachedState, LazyValue} from "../../util";
 import {StateEpoch} from "../../types";
 import {altairState} from "../../params";
@@ -21,10 +27,10 @@ describe(`altair processEpoch - ${stateId}`, () => {
   itBench({
     id: `altair processEpoch - ${stateId}`,
     yieldEventLoopAfterEach: true, // So SubTree(s)'s WeakRef can be garbage collected https://github.com/nodejs/node/issues/39902
-    beforeEach: () => stateOg.value.clone() as CachedBeaconState<allForks.BeaconState>,
+    beforeEach: () => stateOg.value.clone() as BeaconStateCachedAllForks,
     fn: (state) => {
       const epochProcess = allForks.beforeProcessEpoch(state);
-      altair.processEpoch(state as CachedBeaconState<altair.BeaconState>, epochProcess);
+      altair.processEpoch(state as BeaconStateCachedAltair, epochProcess);
       allForks.afterProcessEpoch(state, epochProcess);
       // Simulate root computation through the next block to account for changes
       state.hashTreeRoot();
@@ -39,13 +45,10 @@ describe(`altair processEpoch - ${stateId}`, () => {
   });
 });
 
-function benchmarkAltairEpochSteps(
-  stateOg: LazyValue<allForks.CachedBeaconState<allForks.BeaconState>>,
-  stateId: string
-): void {
+function benchmarkAltairEpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>, stateId: string): void {
   const epochProcess = beforeValue(() => allForks.beforeProcessEpoch(stateOg.value));
 
-  // const getPerfState = (): CachedBeaconState<altair.BeaconState> => {
+  // const getPerfState = (): BeaconStateCachedAltair => {
   //   const state = originalState.clone();
   //   state.setStateCachesAsTransient();
   //   return state;
@@ -87,13 +90,13 @@ function benchmarkAltairEpochSteps(
 
   itBench({
     id: `${stateId} - altair processInactivityUpdates`,
-    beforeEach: () => stateOg.value.clone() as allForks.CachedBeaconState<altair.BeaconState>,
+    beforeEach: () => stateOg.value.clone() as allForks.BeaconStateCachedAltair,
     fn: (state) => altair.processInactivityUpdates(state, epochProcess.value),
   });
 
   itBench({
     id: `${stateId} - altair processRewardsAndPenalties`,
-    beforeEach: () => stateOg.value.clone() as allForks.CachedBeaconState<altair.BeaconState>,
+    beforeEach: () => stateOg.value.clone() as allForks.BeaconStateCachedAltair,
     fn: (state) => altair.processRewardsAndPenalties(state, epochProcess.value),
   });
 
@@ -107,7 +110,7 @@ function benchmarkAltairEpochSteps(
   // TODO: Needs a better state to test with, current does not include enough actions: 39.985 us/op
   itBench({
     id: `${stateId} - altair processSlashings`,
-    beforeEach: () => stateOg.value.clone() as allForks.CachedBeaconState<altair.BeaconState>,
+    beforeEach: () => stateOg.value.clone() as allForks.BeaconStateCachedAltair,
     fn: (state) => altair.processSlashings(state, epochProcess.value),
   });
 
@@ -143,14 +146,14 @@ function benchmarkAltairEpochSteps(
 
   itBench({
     id: `${stateId} - altair processParticipationFlagUpdates`,
-    beforeEach: () => stateOg.value.clone() as allForks.CachedBeaconState<altair.BeaconState>,
+    beforeEach: () => stateOg.value.clone() as allForks.BeaconStateCachedAltair,
     fn: (state) => altair.processParticipationFlagUpdates(state),
   });
 
   itBench({
     id: `${stateId} - altair processSyncCommitteeUpdates`,
     convergeFactor: 1 / 100, // Very unstable make it converge faster
-    beforeEach: () => stateOg.value.clone() as allForks.CachedBeaconState<altair.BeaconState>,
+    beforeEach: () => stateOg.value.clone() as allForks.BeaconStateCachedAltair,
     fn: (state) => altair.processSyncCommitteeUpdates(state, epochProcess.value),
   });
 
@@ -160,7 +163,7 @@ function benchmarkAltairEpochSteps(
     before: () => {
       const state = stateOg.value.clone();
       const epochProcessAfter = allForks.beforeProcessEpoch(state);
-      altair.processEpoch(state as CachedBeaconState<altair.BeaconState>, epochProcessAfter);
+      altair.processEpoch(state as BeaconStateCachedAltair, epochProcessAfter);
       return {state, epochProcess: epochProcessAfter};
     },
     beforeEach: ({state, epochProcess}) => ({state: state.clone(), epochProcess}),

--- a/packages/beacon-state-transition/test/perf/altair/epoch/epoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/altair/epoch/epoch.test.ts
@@ -90,13 +90,13 @@ function benchmarkAltairEpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>
 
   itBench({
     id: `${stateId} - altair processInactivityUpdates`,
-    beforeEach: () => stateOg.value.clone() as allForks.BeaconStateCachedAltair,
+    beforeEach: () => stateOg.value.clone() as BeaconStateCachedAltair,
     fn: (state) => altair.processInactivityUpdates(state, epochProcess.value),
   });
 
   itBench({
     id: `${stateId} - altair processRewardsAndPenalties`,
-    beforeEach: () => stateOg.value.clone() as allForks.BeaconStateCachedAltair,
+    beforeEach: () => stateOg.value.clone() as BeaconStateCachedAltair,
     fn: (state) => altair.processRewardsAndPenalties(state, epochProcess.value),
   });
 
@@ -110,7 +110,7 @@ function benchmarkAltairEpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>
   // TODO: Needs a better state to test with, current does not include enough actions: 39.985 us/op
   itBench({
     id: `${stateId} - altair processSlashings`,
-    beforeEach: () => stateOg.value.clone() as allForks.BeaconStateCachedAltair,
+    beforeEach: () => stateOg.value.clone() as BeaconStateCachedAltair,
     fn: (state) => altair.processSlashings(state, epochProcess.value),
   });
 
@@ -146,14 +146,14 @@ function benchmarkAltairEpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>
 
   itBench({
     id: `${stateId} - altair processParticipationFlagUpdates`,
-    beforeEach: () => stateOg.value.clone() as allForks.BeaconStateCachedAltair,
+    beforeEach: () => stateOg.value.clone() as BeaconStateCachedAltair,
     fn: (state) => altair.processParticipationFlagUpdates(state),
   });
 
   itBench({
     id: `${stateId} - altair processSyncCommitteeUpdates`,
     convergeFactor: 1 / 100, // Very unstable make it converge faster
-    beforeEach: () => stateOg.value.clone() as allForks.BeaconStateCachedAltair,
+    beforeEach: () => stateOg.value.clone() as BeaconStateCachedAltair,
     fn: (state) => altair.processSyncCommitteeUpdates(state, epochProcess.value),
   });
 

--- a/packages/beacon-state-transition/test/perf/altair/epoch/util.ts
+++ b/packages/beacon-state-transition/test/perf/altair/epoch/util.ts
@@ -1,6 +1,6 @@
-import {BeaconStateCachedAltair} from "../../../../src";
+import {CachedBeaconStateAltair} from "../../../../src";
 
-export function mutateInactivityScores(state: BeaconStateCachedAltair, factorWithPositive: number): void {
+export function mutateInactivityScores(state: CachedBeaconStateAltair, factorWithPositive: number): void {
   const vc = state.inactivityScores.length;
   for (let i = 0; i < vc; i++) {
     state.inactivityScores[i] = i < vc * factorWithPositive ? 100 : 0;

--- a/packages/beacon-state-transition/test/perf/altair/epoch/util.ts
+++ b/packages/beacon-state-transition/test/perf/altair/epoch/util.ts
@@ -1,7 +1,6 @@
-import {altair} from "../../../../src";
-import {CachedBeaconState} from "../../../../src/allForks";
+import {BeaconStateCachedAltair} from "../../../../src";
 
-export function mutateInactivityScores(state: CachedBeaconState<altair.BeaconState>, factorWithPositive: number): void {
+export function mutateInactivityScores(state: BeaconStateCachedAltair, factorWithPositive: number): void {
   const vc = state.inactivityScores.length;
   for (let i = 0; i < vc; i++) {
     state.inactivityScores[i] = i < vc * factorWithPositive ? 100 : 0;

--- a/packages/beacon-state-transition/test/perf/analyzeEpochs.ts
+++ b/packages/beacon-state-transition/test/perf/analyzeEpochs.ts
@@ -4,7 +4,7 @@ import {getClient} from "@chainsafe/lodestar-api";
 import {config} from "@chainsafe/lodestar-config/default";
 import {NetworkName} from "@chainsafe/lodestar-config/networks";
 import {phase0, ssz} from "@chainsafe/lodestar-types";
-import {allForks, computeEpochAtSlot, computeStartSlotAtEpoch, BeaconStateCachedAllForks} from "../../src";
+import {allForks, computeEpochAtSlot, computeStartSlotAtEpoch, CachedBeaconStateAllForks} from "../../src";
 import {parseAttesterFlags} from "../../lib/allForks";
 import {AttesterFlags} from "../../src/allForks";
 import {Validator} from "../../lib/phase0";
@@ -94,7 +94,7 @@ async function analyzeEpochs(network: NetworkName, fromEpoch?: number): Promise<
     const postState = allForks.createCachedBeaconState(config, stateTB);
 
     const epochProcess = allForks.beforeProcessEpoch(postState);
-    allForks.processSlots(postState as BeaconStateCachedAllForks, nextEpochSlot, null);
+    allForks.processSlots(postState as CachedBeaconStateAllForks, nextEpochSlot, null);
 
     const validatorCount = state.validators.length;
 

--- a/packages/beacon-state-transition/test/perf/analyzeEpochs.ts
+++ b/packages/beacon-state-transition/test/perf/analyzeEpochs.ts
@@ -4,7 +4,7 @@ import {getClient} from "@chainsafe/lodestar-api";
 import {config} from "@chainsafe/lodestar-config/default";
 import {NetworkName} from "@chainsafe/lodestar-config/networks";
 import {phase0, ssz} from "@chainsafe/lodestar-types";
-import {allForks, computeEpochAtSlot, computeStartSlotAtEpoch} from "../../src";
+import {allForks, computeEpochAtSlot, computeStartSlotAtEpoch, BeaconStateCachedAllForks} from "../../src";
 import {parseAttesterFlags} from "../../lib/allForks";
 import {AttesterFlags} from "../../src/allForks";
 import {Validator} from "../../lib/phase0";
@@ -94,7 +94,7 @@ async function analyzeEpochs(network: NetworkName, fromEpoch?: number): Promise<
     const postState = allForks.createCachedBeaconState(config, stateTB);
 
     const epochProcess = allForks.beforeProcessEpoch(postState);
-    allForks.processSlots(postState as allForks.CachedBeaconState<allForks.BeaconState>, nextEpochSlot, null);
+    allForks.processSlots(postState as BeaconStateCachedAllForks, nextEpochSlot, null);
 
     const validatorCount = state.validators.length;
 

--- a/packages/beacon-state-transition/test/perf/phase0/block/processBlock.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/block/processBlock.test.ts
@@ -8,7 +8,7 @@ import {
   MAX_VOLUNTARY_EXITS,
   PresetName,
 } from "@chainsafe/lodestar-params";
-import {allForks, BeaconStateCachedAllForks} from "../../../../src";
+import {allForks, CachedBeaconStateAllForks} from "../../../../src";
 import {generatePerfTestCachedStatePhase0, perfStateId} from "../../util";
 import {BlockOpts, getBlockPhase0} from "./util";
 import {StateBlock} from "../../types";
@@ -101,7 +101,7 @@ describe("phase0 processBlock", () => {
     itBench<StateBlock, StateBlock>({
       id: `phase0 processBlock - ${perfStateId} ${id}`,
       before: () => {
-        const state = generatePerfTestCachedStatePhase0() as BeaconStateCachedAllForks;
+        const state = generatePerfTestCachedStatePhase0() as CachedBeaconStateAllForks;
         const block = getBlockPhase0(state, opts);
         state.hashTreeRoot();
         return {block, state};

--- a/packages/beacon-state-transition/test/perf/phase0/block/processBlock.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/block/processBlock.test.ts
@@ -8,7 +8,7 @@ import {
   MAX_VOLUNTARY_EXITS,
   PresetName,
 } from "@chainsafe/lodestar-params";
-import {allForks} from "../../../../src";
+import {allForks, BeaconStateCachedAllForks} from "../../../../src";
 import {generatePerfTestCachedStatePhase0, perfStateId} from "../../util";
 import {BlockOpts, getBlockPhase0} from "./util";
 import {StateBlock} from "../../types";
@@ -101,7 +101,7 @@ describe("phase0 processBlock", () => {
     itBench<StateBlock, StateBlock>({
       id: `phase0 processBlock - ${perfStateId} ${id}`,
       before: () => {
-        const state = generatePerfTestCachedStatePhase0() as allForks.CachedBeaconState<allForks.BeaconState>;
+        const state = generatePerfTestCachedStatePhase0() as BeaconStateCachedAllForks;
         const block = getBlockPhase0(state, opts);
         state.hashTreeRoot();
         return {block, state};

--- a/packages/beacon-state-transition/test/perf/phase0/block/util.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/block/util.ts
@@ -8,7 +8,7 @@ import {
   computeEpochAtSlot,
   computeSigningRoot,
   ZERO_HASH,
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
 } from "../../../../src";
 import {LeafNode} from "@chainsafe/persistent-merkle-tree";
 import {getBlockRoot, getBlockRootAtSlot} from "../../../../src";
@@ -27,7 +27,7 @@ export type BlockAltairOpts = BlockOpts & {syncCommitteeBitsLen: number};
  * Generate a block that would pass stateTransition with a customizable count of operations
  */
 export function getBlockPhase0(
-  preState: BeaconStateCachedAllForks,
+  preState: CachedBeaconStateAllForks,
   {proposerSlashingLen, attesterSlashingLen, attestationLen, depositsLen, voluntaryExitLen, bitsLen}: BlockOpts
 ): phase0.SignedBeaconBlock {
   const emptySig = Buffer.alloc(96);
@@ -159,9 +159,9 @@ export function getBlockPhase0(
  * Get an altair block.
  * This mutates the input preState as well to mark attestations not seen by the network.
  */
-export function getBlockAltair(preState: BeaconStateCachedAllForks, opts: BlockAltairOpts): altair.SignedBeaconBlock {
+export function getBlockAltair(preState: CachedBeaconStateAllForks, opts: BlockAltairOpts): altair.SignedBeaconBlock {
   const emptySig = Buffer.alloc(96);
-  const phase0Block = getBlockPhase0(preState as BeaconStateCachedAllForks, opts);
+  const phase0Block = getBlockPhase0(preState as CachedBeaconStateAllForks, opts);
   const stateEpoch = computeEpochAtSlot(preState.slot);
   for (const attestation of phase0Block.message.body.attestations) {
     const attEpoch = computeEpochAtSlot(attestation.data.slot);
@@ -195,7 +195,7 @@ export function getBlockAltair(preState: BeaconStateCachedAllForks, opts: BlockA
  * Generate valid deposits with valid signatures and valid merkle proofs.
  * NOTE: Mutates `preState` to add the new `eth1Data.depositRoot`
  */
-function getDeposits(preState: BeaconStateCachedAllForks, count: number): List<phase0.Deposit> {
+function getDeposits(preState: CachedBeaconStateAllForks, count: number): List<phase0.Deposit> {
   const depositRootTree = ssz.phase0.DepositDataRootList.defaultTreeBacked();
   const depositCount = preState.eth1Data.depositCount;
   const withdrawalCredentials = Buffer.alloc(32, 0xee);

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/afterProcessEpoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/afterProcessEpoch.test.ts
@@ -1,5 +1,5 @@
 import {itBench} from "@dapplion/benchmark";
-import {allForks} from "../../../../src";
+import {allForks, BeaconStateCachedAllForks} from "../../../../src";
 import {StateEpoch} from "../../types";
 import {generatePerfTestCachedStatePhase0, perfStateId} from "../../util";
 
@@ -13,7 +13,7 @@ describe("phase0 afterProcessEpoch", () => {
     before: () => {
       const state = generatePerfTestCachedStatePhase0({goBackOneSlot: true});
       const epochProcess = allForks.beforeProcessEpoch(state);
-      return {state: state as allForks.CachedBeaconState<allForks.BeaconState>, epochProcess};
+      return {state: state as BeaconStateCachedAllForks, epochProcess};
     },
     beforeEach: ({state, epochProcess}) => ({state: state.clone(), epochProcess}),
     fn: ({state, epochProcess}) => {

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/afterProcessEpoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/afterProcessEpoch.test.ts
@@ -1,5 +1,5 @@
 import {itBench} from "@dapplion/benchmark";
-import {allForks, BeaconStateCachedAllForks} from "../../../../src";
+import {allForks, CachedBeaconStateAllForks} from "../../../../src";
 import {StateEpoch} from "../../types";
 import {generatePerfTestCachedStatePhase0, perfStateId} from "../../util";
 
@@ -13,7 +13,7 @@ describe("phase0 afterProcessEpoch", () => {
     before: () => {
       const state = generatePerfTestCachedStatePhase0({goBackOneSlot: true});
       const epochProcess = allForks.beforeProcessEpoch(state);
-      return {state: state as BeaconStateCachedAllForks, epochProcess};
+      return {state: state as CachedBeaconStateAllForks, epochProcess};
     },
     beforeEach: ({state, epochProcess}) => ({state: state.clone(), epochProcess}),
     fn: ({state, epochProcess}) => {

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/beforeProcessEpoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/beforeProcessEpoch.test.ts
@@ -1,5 +1,5 @@
 import {itBench} from "@dapplion/benchmark";
-import {allForks, BeaconStateCachedAllForks} from "../../../../src";
+import {allForks, CachedBeaconStateAllForks} from "../../../../src";
 import {State} from "../../types";
 import {generatePerfTestCachedStatePhase0, perfStateId} from "../../util";
 
@@ -12,7 +12,7 @@ describe("phase0 beforeProcessEpoch", () => {
   itBench<State, State>({
     id: `phase0 beforeProcessEpoch - ${perfStateId}`,
     yieldEventLoopAfterEach: true, // So SubTree(s)'s WeakRef can be garbage collected https://github.com/nodejs/node/issues/39902
-    before: () => generatePerfTestCachedStatePhase0({goBackOneSlot: true}) as BeaconStateCachedAllForks,
+    before: () => generatePerfTestCachedStatePhase0({goBackOneSlot: true}) as CachedBeaconStateAllForks,
     beforeEach: (state) => state.clone(),
     fn: (state) => {
       allForks.beforeProcessEpoch(state);

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/beforeProcessEpoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/beforeProcessEpoch.test.ts
@@ -1,5 +1,5 @@
 import {itBench} from "@dapplion/benchmark";
-import {allForks} from "../../../../src";
+import {allForks, BeaconStateCachedAllForks} from "../../../../src";
 import {State} from "../../types";
 import {generatePerfTestCachedStatePhase0, perfStateId} from "../../util";
 
@@ -12,8 +12,7 @@ describe("phase0 beforeProcessEpoch", () => {
   itBench<State, State>({
     id: `phase0 beforeProcessEpoch - ${perfStateId}`,
     yieldEventLoopAfterEach: true, // So SubTree(s)'s WeakRef can be garbage collected https://github.com/nodejs/node/issues/39902
-    before: () =>
-      generatePerfTestCachedStatePhase0({goBackOneSlot: true}) as allForks.CachedBeaconState<allForks.BeaconState>,
+    before: () => generatePerfTestCachedStatePhase0({goBackOneSlot: true}) as BeaconStateCachedAllForks,
     beforeEach: (state) => state.clone(),
     fn: (state) => {
       allForks.beforeProcessEpoch(state);

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.test.ts
@@ -3,8 +3,8 @@ import {
   allForks,
   computeStartSlotAtEpoch,
   phase0,
-  BeaconStateCachedAllForks,
-  BeaconStateCachedPhase0,
+  CachedBeaconStateAllForks,
+  CachedBeaconStatePhase0,
 } from "../../../../src";
 import {beforeValue, getNetworkCachedState, LazyValue} from "../../util";
 import {processParticipationRecordUpdates} from "../../../../src/phase0/epoch/processParticipationRecordUpdates";
@@ -27,10 +27,10 @@ describe(`phase0 processEpoch - ${stateId}`, () => {
 
   itBench({
     id: `phase0 processEpoch - ${stateId}`,
-    beforeEach: () => stateOg.value.clone() as BeaconStateCachedAllForks,
+    beforeEach: () => stateOg.value.clone() as CachedBeaconStateAllForks,
     fn: (state) => {
       const epochProcess = allForks.beforeProcessEpoch(state);
-      phase0.processEpoch(state as BeaconStateCachedPhase0, epochProcess);
+      phase0.processEpoch(state as CachedBeaconStatePhase0, epochProcess);
       allForks.afterProcessEpoch(state, epochProcess);
       // Simulate root computation through the next block to account for changes
       state.hashTreeRoot();
@@ -45,7 +45,7 @@ describe(`phase0 processEpoch - ${stateId}`, () => {
   });
 });
 
-function benchmarkPhase0EpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>, stateId: string): void {
+function benchmarkPhase0EpochSteps(stateOg: LazyValue<CachedBeaconStateAllForks>, stateId: string): void {
   const epochProcess = beforeValue(() => allForks.beforeProcessEpoch(stateOg.value));
 
   // Functions in same order as phase0.processEpoch()
@@ -82,7 +82,7 @@ function benchmarkPhase0EpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>
   // Very expensive 976.40 ms/op good target to optimize
   itBench({
     id: `${stateId} - phase0 processRewardsAndPenalties`,
-    beforeEach: () => stateOg.value.clone() as BeaconStateCachedPhase0,
+    beforeEach: () => stateOg.value.clone() as CachedBeaconStatePhase0,
     fn: (state) => phase0.processRewardsAndPenalties(state, epochProcess.value),
   });
 
@@ -96,7 +96,7 @@ function benchmarkPhase0EpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>
   // TODO: Needs a better state to test with, current does not include enough actions: 39.985 us/op
   itBench({
     id: `${stateId} - phase0 processSlashings`,
-    beforeEach: () => stateOg.value.clone() as BeaconStateCachedPhase0,
+    beforeEach: () => stateOg.value.clone() as CachedBeaconStatePhase0,
     fn: (state) => phase0.processSlashings(state, epochProcess.value),
   });
 
@@ -132,7 +132,7 @@ function benchmarkPhase0EpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>
 
   itBench({
     id: `${stateId} - phase0 processParticipationRecordUpdates`,
-    beforeEach: () => stateOg.value.clone() as BeaconStateCachedPhase0,
+    beforeEach: () => stateOg.value.clone() as CachedBeaconStatePhase0,
     fn: (state) => processParticipationRecordUpdates(state),
   });
 
@@ -142,7 +142,7 @@ function benchmarkPhase0EpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>
     before: () => {
       const state = stateOg.value.clone();
       const epochProcessAfter = allForks.beforeProcessEpoch(state);
-      phase0.processEpoch(state as BeaconStateCachedPhase0, epochProcessAfter);
+      phase0.processEpoch(state as CachedBeaconStatePhase0, epochProcessAfter);
       return {state, epochProcess: epochProcessAfter};
     },
     beforeEach: ({state, epochProcess}) => ({state: state.clone(), epochProcess}),

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.test.ts
@@ -82,7 +82,7 @@ function benchmarkPhase0EpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>
   // Very expensive 976.40 ms/op good target to optimize
   itBench({
     id: `${stateId} - phase0 processRewardsAndPenalties`,
-    beforeEach: () => stateOg.value.clone() as allForks.BeaconStateCachedPhase0,
+    beforeEach: () => stateOg.value.clone() as BeaconStateCachedPhase0,
     fn: (state) => phase0.processRewardsAndPenalties(state, epochProcess.value),
   });
 
@@ -96,7 +96,7 @@ function benchmarkPhase0EpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>
   // TODO: Needs a better state to test with, current does not include enough actions: 39.985 us/op
   itBench({
     id: `${stateId} - phase0 processSlashings`,
-    beforeEach: () => stateOg.value.clone() as allForks.BeaconStateCachedPhase0,
+    beforeEach: () => stateOg.value.clone() as BeaconStateCachedPhase0,
     fn: (state) => phase0.processSlashings(state, epochProcess.value),
   });
 
@@ -132,7 +132,7 @@ function benchmarkPhase0EpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>
 
   itBench({
     id: `${stateId} - phase0 processParticipationRecordUpdates`,
-    beforeEach: () => stateOg.value.clone() as allForks.BeaconStateCachedPhase0,
+    beforeEach: () => stateOg.value.clone() as BeaconStateCachedPhase0,
     fn: (state) => processParticipationRecordUpdates(state),
   });
 

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/epoch.test.ts
@@ -1,5 +1,11 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
-import {allForks, CachedBeaconState, computeStartSlotAtEpoch, phase0} from "../../../../src";
+import {
+  allForks,
+  computeStartSlotAtEpoch,
+  phase0,
+  BeaconStateCachedAllForks,
+  BeaconStateCachedPhase0,
+} from "../../../../src";
 import {beforeValue, getNetworkCachedState, LazyValue} from "../../util";
 import {processParticipationRecordUpdates} from "../../../../src/phase0/epoch/processParticipationRecordUpdates";
 import {StateEpoch} from "../../types";
@@ -21,10 +27,10 @@ describe(`phase0 processEpoch - ${stateId}`, () => {
 
   itBench({
     id: `phase0 processEpoch - ${stateId}`,
-    beforeEach: () => stateOg.value.clone() as CachedBeaconState<allForks.BeaconState>,
+    beforeEach: () => stateOg.value.clone() as BeaconStateCachedAllForks,
     fn: (state) => {
       const epochProcess = allForks.beforeProcessEpoch(state);
-      phase0.processEpoch(state as CachedBeaconState<phase0.BeaconState>, epochProcess);
+      phase0.processEpoch(state as BeaconStateCachedPhase0, epochProcess);
       allForks.afterProcessEpoch(state, epochProcess);
       // Simulate root computation through the next block to account for changes
       state.hashTreeRoot();
@@ -39,10 +45,7 @@ describe(`phase0 processEpoch - ${stateId}`, () => {
   });
 });
 
-function benchmarkPhase0EpochSteps(
-  stateOg: LazyValue<allForks.CachedBeaconState<allForks.BeaconState>>,
-  stateId: string
-): void {
+function benchmarkPhase0EpochSteps(stateOg: LazyValue<BeaconStateCachedAllForks>, stateId: string): void {
   const epochProcess = beforeValue(() => allForks.beforeProcessEpoch(stateOg.value));
 
   // Functions in same order as phase0.processEpoch()
@@ -79,7 +82,7 @@ function benchmarkPhase0EpochSteps(
   // Very expensive 976.40 ms/op good target to optimize
   itBench({
     id: `${stateId} - phase0 processRewardsAndPenalties`,
-    beforeEach: () => stateOg.value.clone() as allForks.CachedBeaconState<phase0.BeaconState>,
+    beforeEach: () => stateOg.value.clone() as allForks.BeaconStateCachedPhase0,
     fn: (state) => phase0.processRewardsAndPenalties(state, epochProcess.value),
   });
 
@@ -93,7 +96,7 @@ function benchmarkPhase0EpochSteps(
   // TODO: Needs a better state to test with, current does not include enough actions: 39.985 us/op
   itBench({
     id: `${stateId} - phase0 processSlashings`,
-    beforeEach: () => stateOg.value.clone() as allForks.CachedBeaconState<phase0.BeaconState>,
+    beforeEach: () => stateOg.value.clone() as allForks.BeaconStateCachedPhase0,
     fn: (state) => phase0.processSlashings(state, epochProcess.value),
   });
 
@@ -129,7 +132,7 @@ function benchmarkPhase0EpochSteps(
 
   itBench({
     id: `${stateId} - phase0 processParticipationRecordUpdates`,
-    beforeEach: () => stateOg.value.clone() as allForks.CachedBeaconState<phase0.BeaconState>,
+    beforeEach: () => stateOg.value.clone() as allForks.BeaconStateCachedPhase0,
     fn: (state) => processParticipationRecordUpdates(state),
   });
 
@@ -139,7 +142,7 @@ function benchmarkPhase0EpochSteps(
     before: () => {
       const state = stateOg.value.clone();
       const epochProcessAfter = allForks.beforeProcessEpoch(state);
-      phase0.processEpoch(state as CachedBeaconState<phase0.BeaconState>, epochProcessAfter);
+      phase0.processEpoch(state as BeaconStateCachedPhase0, epochProcessAfter);
       return {state, epochProcess: epochProcessAfter};
     },
     beforeEach: ({state, epochProcess}) => ({state: state.clone(), epochProcess}),

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/processEffectiveBalanceUpdates.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/processEffectiveBalanceUpdates.test.ts
@@ -1,7 +1,7 @@
 import {itBench} from "@dapplion/benchmark";
 import {ssz} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/default";
-import {allForks, BeaconStateCachedAllForks} from "../../../../src";
+import {allForks, CachedBeaconStateAllForks} from "../../../../src";
 import {beforeProcessEpoch, createCachedBeaconState} from "../../../../src/allForks";
 import {numValidators} from "../../util";
 import {StateEpoch} from "../../types";
@@ -46,7 +46,7 @@ function getEffectiveBalanceTestData(
   vc: number,
   changeRatio: number
 ): {
-  state: BeaconStateCachedAllForks;
+  state: CachedBeaconStateAllForks;
   epochProcess: allForks.IEpochProcess;
 } {
   const stateTree = ssz.phase0.BeaconState.defaultTreeBacked();
@@ -76,7 +76,7 @@ function getEffectiveBalanceTestData(
   epochProcess.balances = balances;
 
   return {
-    state: cachedBeaconState as BeaconStateCachedAllForks,
+    state: cachedBeaconState as CachedBeaconStateAllForks,
     epochProcess: epochProcess,
   };
 }

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/processEffectiveBalanceUpdates.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/processEffectiveBalanceUpdates.test.ts
@@ -1,7 +1,7 @@
 import {itBench} from "@dapplion/benchmark";
 import {ssz} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/default";
-import {allForks} from "../../../../src";
+import {allForks, BeaconStateCachedAllForks} from "../../../../src";
 import {beforeProcessEpoch, createCachedBeaconState} from "../../../../src/allForks";
 import {numValidators} from "../../util";
 import {StateEpoch} from "../../types";
@@ -46,7 +46,7 @@ function getEffectiveBalanceTestData(
   vc: number,
   changeRatio: number
 ): {
-  state: allForks.CachedBeaconState<allForks.BeaconState>;
+  state: BeaconStateCachedAllForks;
   epochProcess: allForks.IEpochProcess;
 } {
   const stateTree = ssz.phase0.BeaconState.defaultTreeBacked();
@@ -76,7 +76,7 @@ function getEffectiveBalanceTestData(
   epochProcess.balances = balances;
 
   return {
-    state: cachedBeaconState as allForks.CachedBeaconState<allForks.BeaconState>,
+    state: cachedBeaconState as BeaconStateCachedAllForks,
     epochProcess: epochProcess,
   };
 }

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/processRegistryUpdates.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/processRegistryUpdates.test.ts
@@ -1,6 +1,5 @@
 import {itBench} from "@dapplion/benchmark";
-import {allForks} from "../../../../src";
-import {beforeProcessEpoch} from "../../../../src/allForks";
+import {allForks, BeaconStateCachedAllForks} from "../../../../src";
 import {generatePerfTestCachedStatePhase0, numValidators} from "../../util";
 import {StateEpoch} from "../../types";
 
@@ -80,18 +79,18 @@ function getRegistryUpdatesTestData(
   vc: number,
   lengths: IndicesLengths
 ): {
-  state: allForks.CachedBeaconState<allForks.BeaconState>;
+  state: BeaconStateCachedAllForks;
   epochProcess: allForks.IEpochProcess;
 } {
   const state = generatePerfTestCachedStatePhase0({goBackOneSlot: true});
-  const epochProcess = beforeProcessEpoch(state);
+  const epochProcess = allForks.beforeProcessEpoch(state);
 
   epochProcess.indicesToEject = linspace(lengths.indicesToEject);
   epochProcess.indicesEligibleForActivationQueue = linspace(lengths.indicesEligibleForActivationQueue);
   epochProcess.indicesEligibleForActivation = linspace(lengths.indicesEligibleForActivation);
 
   return {
-    state: state as allForks.CachedBeaconState<allForks.BeaconState>,
+    state: state as BeaconStateCachedAllForks,
     epochProcess,
   };
 }

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/processRegistryUpdates.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/processRegistryUpdates.test.ts
@@ -1,5 +1,5 @@
 import {itBench} from "@dapplion/benchmark";
-import {allForks, BeaconStateCachedAllForks} from "../../../../src";
+import {allForks, CachedBeaconStateAllForks} from "../../../../src";
 import {generatePerfTestCachedStatePhase0, numValidators} from "../../util";
 import {StateEpoch} from "../../types";
 
@@ -79,7 +79,7 @@ function getRegistryUpdatesTestData(
   vc: number,
   lengths: IndicesLengths
 ): {
-  state: BeaconStateCachedAllForks;
+  state: CachedBeaconStateAllForks;
   epochProcess: allForks.IEpochProcess;
 } {
   const state = generatePerfTestCachedStatePhase0({goBackOneSlot: true});
@@ -90,7 +90,7 @@ function getRegistryUpdatesTestData(
   epochProcess.indicesEligibleForActivation = linspace(lengths.indicesEligibleForActivation);
 
   return {
-    state: state as BeaconStateCachedAllForks,
+    state: state as CachedBeaconStateAllForks,
     epochProcess,
   };
 }

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/processSlashingsAllForks.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/processSlashingsAllForks.test.ts
@@ -1,6 +1,5 @@
 import {itBench} from "@dapplion/benchmark";
-import {allForks, phase0} from "../../../../src";
-import {beforeProcessEpoch} from "../../../../src/allForks";
+import {allForks, phase0, BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../../../src";
 import {generatePerfTestCachedStatePhase0, numValidators} from "../../util";
 import {StateEpoch} from "../../types";
 
@@ -29,8 +28,7 @@ describe("phase0 processSlashings", () => {
       minRuns: 5, // Worst case is very slow
       before: () => getProcessSlashingsTestData(indicesToSlashLen),
       beforeEach: ({state, epochProcess}) => ({state: state.clone(), epochProcess}),
-      fn: ({state, epochProcess}) =>
-        phase0.processSlashings(state as allForks.CachedBeaconState<phase0.BeaconState>, epochProcess),
+      fn: ({state, epochProcess}) => phase0.processSlashings(state as BeaconStateCachedPhase0, epochProcess),
     });
   }
 });
@@ -41,16 +39,16 @@ describe("phase0 processSlashings", () => {
 function getProcessSlashingsTestData(
   indicesToSlashLen: number
 ): {
-  state: allForks.CachedBeaconState<allForks.BeaconState>;
+  state: BeaconStateCachedAllForks;
   epochProcess: allForks.IEpochProcess;
 } {
   const state = generatePerfTestCachedStatePhase0({goBackOneSlot: true});
-  const epochProcess = beforeProcessEpoch(state);
+  const epochProcess = allForks.beforeProcessEpoch(state);
 
   epochProcess.indicesToSlash = linspace(indicesToSlashLen);
 
   return {
-    state: state as allForks.CachedBeaconState<allForks.BeaconState>,
+    state: state as BeaconStateCachedAllForks,
     epochProcess,
   };
 }

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/processSlashingsAllForks.test.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/processSlashingsAllForks.test.ts
@@ -1,5 +1,5 @@
 import {itBench} from "@dapplion/benchmark";
-import {allForks, phase0, BeaconStateCachedPhase0, BeaconStateCachedAllForks} from "../../../../src";
+import {allForks, phase0, CachedBeaconStatePhase0, CachedBeaconStateAllForks} from "../../../../src";
 import {generatePerfTestCachedStatePhase0, numValidators} from "../../util";
 import {StateEpoch} from "../../types";
 
@@ -28,7 +28,7 @@ describe("phase0 processSlashings", () => {
       minRuns: 5, // Worst case is very slow
       before: () => getProcessSlashingsTestData(indicesToSlashLen),
       beforeEach: ({state, epochProcess}) => ({state: state.clone(), epochProcess}),
-      fn: ({state, epochProcess}) => phase0.processSlashings(state as BeaconStateCachedPhase0, epochProcess),
+      fn: ({state, epochProcess}) => phase0.processSlashings(state as CachedBeaconStatePhase0, epochProcess),
     });
   }
 });
@@ -39,7 +39,7 @@ describe("phase0 processSlashings", () => {
 function getProcessSlashingsTestData(
   indicesToSlashLen: number
 ): {
-  state: BeaconStateCachedAllForks;
+  state: CachedBeaconStateAllForks;
   epochProcess: allForks.IEpochProcess;
 } {
   const state = generatePerfTestCachedStatePhase0({goBackOneSlot: true});
@@ -48,7 +48,7 @@ function getProcessSlashingsTestData(
   epochProcess.indicesToSlash = linspace(indicesToSlashLen);
 
   return {
-    state: state as BeaconStateCachedAllForks,
+    state: state as CachedBeaconStateAllForks,
     epochProcess,
   };
 }

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/util.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/util.ts
@@ -1,5 +1,5 @@
 import {AttesterFlags, IAttesterStatus, toAttesterFlags} from "../../../../src/allForks";
-import {BeaconStateCachedPhase0, BeaconStateCachedAltair, IEpochProcess} from "../../../../src/types";
+import {CachedBeaconStatePhase0, CachedBeaconStateAltair, IEpochProcess} from "../../../../src/types";
 
 /**
  * Generate an incomplete IEpochProcess to simulate any network condition relevant to getAttestationDeltas
@@ -7,7 +7,7 @@ import {BeaconStateCachedPhase0, BeaconStateCachedAltair, IEpochProcess} from ".
  * @param flagFactors factor (0,1) of validators that have that flag set to true
  */
 export function generateBalanceDeltasEpochProcess(
-  state: BeaconStateCachedPhase0 | BeaconStateCachedAltair,
+  state: CachedBeaconStatePhase0 | CachedBeaconStateAltair,
   isInInactivityLeak: boolean,
   flagFactors: FlagFactors
 ): IEpochProcess {

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/util.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/util.ts
@@ -1,11 +1,5 @@
-import {
-  AttesterFlags,
-  BeaconStateCachedPhase0,
-  BeaconStateCachedAltair,
-  IAttesterStatus,
-  IEpochProcess,
-  toAttesterFlags,
-} from "../../../../src/allForks";
+import {AttesterFlags, IAttesterStatus, toAttesterFlags} from "../../../../src/allForks";
+import {BeaconStateCachedPhase0, BeaconStateCachedAltair, IEpochProcess} from "../../../../src/types";
 
 /**
  * Generate an incomplete IEpochProcess to simulate any network condition relevant to getAttestationDeltas

--- a/packages/beacon-state-transition/test/perf/phase0/epoch/util.ts
+++ b/packages/beacon-state-transition/test/perf/phase0/epoch/util.ts
@@ -1,7 +1,7 @@
-import {phase0, altair} from "../../../../src";
 import {
   AttesterFlags,
-  CachedBeaconState,
+  BeaconStateCachedPhase0,
+  BeaconStateCachedAltair,
   IAttesterStatus,
   IEpochProcess,
   toAttesterFlags,
@@ -13,7 +13,7 @@ import {
  * @param flagFactors factor (0,1) of validators that have that flag set to true
  */
 export function generateBalanceDeltasEpochProcess(
-  state: CachedBeaconState<phase0.BeaconState> | CachedBeaconState<altair.BeaconState>,
+  state: BeaconStateCachedPhase0 | BeaconStateCachedAltair,
   isInInactivityLeak: boolean,
   flagFactors: FlagFactors
 ): IEpochProcess {

--- a/packages/beacon-state-transition/test/perf/types.ts
+++ b/packages/beacon-state-transition/test/perf/types.ts
@@ -1,15 +1,15 @@
-import {allForks, phase0, BeaconStateCachedAllForks, BeaconStateCachedPhase0, BeaconStateCachedAltair} from "../../src";
+import {allForks, phase0, CachedBeaconStateAllForks, CachedBeaconStatePhase0, CachedBeaconStateAltair} from "../../src";
 import {IEpochProcess} from "../../src/types";
 
 // Type aliases to typesafe itBench() calls
 
-export type State = BeaconStateCachedAllForks;
-export type StateAltair = BeaconStateCachedAltair;
-export type StateBlock = {state: BeaconStateCachedAllForks; block: allForks.SignedBeaconBlock};
+export type State = CachedBeaconStateAllForks;
+export type StateAltair = CachedBeaconStateAltair;
+export type StateBlock = {state: CachedBeaconStateAllForks; block: allForks.SignedBeaconBlock};
 export type StateAttestations = {
-  state: BeaconStateCachedAllForks;
+  state: CachedBeaconStateAllForks;
   attestations: phase0.Attestation[];
 };
-export type StateEpoch = {state: BeaconStateCachedAllForks; epochProcess: IEpochProcess};
-export type StatePhase0Epoch = {state: BeaconStateCachedPhase0; epochProcess: IEpochProcess};
-export type StateAltairEpoch = {state: BeaconStateCachedAltair; epochProcess: IEpochProcess};
+export type StateEpoch = {state: CachedBeaconStateAllForks; epochProcess: IEpochProcess};
+export type StatePhase0Epoch = {state: CachedBeaconStatePhase0; epochProcess: IEpochProcess};
+export type StateAltairEpoch = {state: CachedBeaconStateAltair; epochProcess: IEpochProcess};

--- a/packages/beacon-state-transition/test/perf/types.ts
+++ b/packages/beacon-state-transition/test/perf/types.ts
@@ -1,15 +1,20 @@
 import {allForks, altair, phase0} from "../../src";
-import {IEpochProcess} from "../../src/allForks";
+import {
+  IEpochProcess,
+  BeaconStateCachedAllForks,
+  BeaconStateCachedPhase0,
+  BeaconStateCachedAltair,
+} from "../../src/allForks";
 
 // Type aliases to typesafe itBench() calls
 
-export type State = allForks.CachedBeaconState<allForks.BeaconState>;
-export type StateAltair = allForks.CachedBeaconState<altair.BeaconState>;
-export type StateBlock = {state: allForks.CachedBeaconState<allForks.BeaconState>; block: allForks.SignedBeaconBlock};
+export type State = BeaconStateCachedAllForks;
+export type StateAltair = BeaconStateCachedAltair;
+export type StateBlock = {state: BeaconStateCachedAllForks; block: allForks.SignedBeaconBlock};
 export type StateAttestations = {
-  state: allForks.CachedBeaconState<allForks.BeaconState>;
+  state: BeaconStateCachedAllForks;
   attestations: phase0.Attestation[];
 };
-export type StateEpoch = {state: allForks.CachedBeaconState<allForks.BeaconState>; epochProcess: IEpochProcess};
-export type StatePhase0Epoch = {state: allForks.CachedBeaconState<phase0.BeaconState>; epochProcess: IEpochProcess};
-export type StateAltairEpoch = {state: allForks.CachedBeaconState<altair.BeaconState>; epochProcess: IEpochProcess};
+export type StateEpoch = {state: BeaconStateCachedAllForks; epochProcess: IEpochProcess};
+export type StatePhase0Epoch = {state: BeaconStateCachedPhase0; epochProcess: IEpochProcess};
+export type StateAltairEpoch = {state: BeaconStateCachedAltair; epochProcess: IEpochProcess};

--- a/packages/beacon-state-transition/test/perf/types.ts
+++ b/packages/beacon-state-transition/test/perf/types.ts
@@ -1,10 +1,5 @@
-import {allForks, altair, phase0} from "../../src";
-import {
-  IEpochProcess,
-  BeaconStateCachedAllForks,
-  BeaconStateCachedPhase0,
-  BeaconStateCachedAltair,
-} from "../../src/allForks";
+import {allForks, phase0, BeaconStateCachedAllForks, BeaconStateCachedPhase0, BeaconStateCachedAltair} from "../../src";
+import {IEpochProcess} from "../../src/types";
 
 // Type aliases to typesafe itBench() calls
 

--- a/packages/beacon-state-transition/test/perf/util.ts
+++ b/packages/beacon-state-transition/test/perf/util.ts
@@ -7,7 +7,7 @@ import {fromHexString, List, TreeBacked} from "@chainsafe/ssz";
 import {allForks, interopSecretKey, computeEpochAtSlot, getActiveValidatorIndices} from "../../src";
 import {createIChainForkConfig, IChainForkConfig} from "@chainsafe/lodestar-config";
 import {computeCommitteeCount, createCachedBeaconState, PubkeyIndexMap} from "../../src/allForks";
-import {BeaconStateCachedAllForks, BeaconStateCachedPhase0, BeaconStateCachedAltair} from "../../src/types";
+import {CachedBeaconStateAllForks, CachedBeaconStatePhase0, CachedBeaconStateAltair} from "../../src/types";
 import {profilerLogger} from "../utils/logger";
 import {interopPubkeysCached} from "../utils/interop";
 import {PendingAttestation} from "@chainsafe/lodestar-types/phase0";
@@ -31,12 +31,12 @@ import {testCachePath} from "../cache";
 import {MutableVector} from "@chainsafe/persistent-ts";
 
 let phase0State: TreeBacked<phase0.BeaconState> | null = null;
-let phase0CachedState23637: BeaconStateCachedPhase0 | null = null;
-let phase0CachedState23638: BeaconStateCachedPhase0 | null = null;
+let phase0CachedState23637: CachedBeaconStatePhase0 | null = null;
+let phase0CachedState23638: CachedBeaconStatePhase0 | null = null;
 let phase0SignedBlock: TreeBacked<phase0.SignedBeaconBlock> | null = null;
 let altairState: TreeBacked<altair.BeaconState> | null = null;
-let altairCachedState23637: BeaconStateCachedAltair | null = null;
-let altairCachedState23638: BeaconStateCachedAltair | null = null;
+let altairCachedState23637: CachedBeaconStateAltair | null = null;
+let altairCachedState23638: CachedBeaconStateAltair | null = null;
 const logger = profilerLogger();
 
 /**
@@ -81,7 +81,7 @@ export function getSecretKeyFromIndexCached(validatorIndex: number): SecretKey {
   return sk;
 }
 
-export function generatePerfTestCachedStatePhase0(opts?: {goBackOneSlot: boolean}): BeaconStateCachedPhase0 {
+export function generatePerfTestCachedStatePhase0(opts?: {goBackOneSlot: boolean}): CachedBeaconStatePhase0 {
   // Generate only some publicKeys
   const {pubkeys, pubkeysMod, pubkeysModObj} = getPubkeys();
 
@@ -107,9 +107,9 @@ export function generatePerfTestCachedStatePhase0(opts?: {goBackOneSlot: boolean
   }
   if (!phase0CachedState23638) {
     phase0CachedState23638 = allForks.processSlots(
-      phase0CachedState23637 as BeaconStateCachedAllForks,
+      phase0CachedState23637 as CachedBeaconStateAllForks,
       phase0CachedState23637.slot + 1
-    ) as BeaconStateCachedPhase0;
+    ) as CachedBeaconStatePhase0;
     phase0CachedState23638.slot += 1;
   }
   const resultingState = opts && opts.goBackOneSlot ? phase0CachedState23637 : phase0CachedState23638;
@@ -117,7 +117,7 @@ export function generatePerfTestCachedStatePhase0(opts?: {goBackOneSlot: boolean
   return resultingState.clone();
 }
 
-export function generatePerfTestCachedStateAltair(opts?: {goBackOneSlot: boolean}): BeaconStateCachedAltair {
+export function generatePerfTestCachedStateAltair(opts?: {goBackOneSlot: boolean}): CachedBeaconStateAltair {
   const {pubkeys, pubkeysMod, pubkeysModObj} = getPubkeys();
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const altairConfig = createIChainForkConfig({ALTAIR_FORK_EPOCH: 0});
@@ -144,9 +144,9 @@ export function generatePerfTestCachedStateAltair(opts?: {goBackOneSlot: boolean
   }
   if (!altairCachedState23638) {
     altairCachedState23638 = allForks.processSlots(
-      altairCachedState23637 as BeaconStateCachedAllForks,
+      altairCachedState23637 as CachedBeaconStateAllForks,
       altairCachedState23637.slot + 1
-    ) as BeaconStateCachedAltair;
+    ) as CachedBeaconStateAltair;
     altairCachedState23638.slot += 1;
   }
   const resultingState = opts && opts.goBackOneSlot ? altairCachedState23637 : altairCachedState23638;
@@ -349,7 +349,7 @@ export function generateTestCachedBeaconStateOnlyValidators({
 }: {
   vc: number;
   slot: Slot;
-}): BeaconStateCachedAllForks {
+}): CachedBeaconStateAllForks {
   // Generate only some publicKeys
   const {pubkeys, pubkeysMod, pubkeysModObj} = getPubkeys(vc);
 
@@ -446,7 +446,7 @@ export async function getNetworkCachedState(
   network: NetworkName,
   slot: number,
   timeout?: number
-): Promise<BeaconStateCachedAllForks> {
+): Promise<CachedBeaconStateAllForks> {
   const config = getNetworkConfig(network);
 
   const filepath = path.join(testCachePath, `state_${network}_${slot}.ssz`);

--- a/packages/beacon-state-transition/test/perf/util.ts
+++ b/packages/beacon-state-transition/test/perf/util.ts
@@ -6,7 +6,14 @@ import bls, {CoordType, PublicKey, SecretKey} from "@chainsafe/bls";
 import {fromHexString, List, TreeBacked} from "@chainsafe/ssz";
 import {allForks, interopSecretKey, computeEpochAtSlot, getActiveValidatorIndices} from "../../src";
 import {createIChainForkConfig, IChainForkConfig} from "@chainsafe/lodestar-config";
-import {CachedBeaconState, computeCommitteeCount, createCachedBeaconState, PubkeyIndexMap} from "../../src/allForks";
+import {
+  computeCommitteeCount,
+  createCachedBeaconState,
+  PubkeyIndexMap,
+  BeaconStateCachedAllForks,
+  BeaconStateCachedPhase0,
+  BeaconStateCachedAltair,
+} from "../../src/allForks";
 import {profilerLogger} from "../utils/logger";
 import {interopPubkeysCached} from "../utils/interop";
 import {PendingAttestation} from "@chainsafe/lodestar-types/phase0";
@@ -30,12 +37,12 @@ import {testCachePath} from "../cache";
 import {MutableVector} from "@chainsafe/persistent-ts";
 
 let phase0State: TreeBacked<phase0.BeaconState> | null = null;
-let phase0CachedState23637: allForks.CachedBeaconState<phase0.BeaconState> | null = null;
-let phase0CachedState23638: allForks.CachedBeaconState<phase0.BeaconState> | null = null;
+let phase0CachedState23637: BeaconStateCachedPhase0 | null = null;
+let phase0CachedState23638: BeaconStateCachedPhase0 | null = null;
 let phase0SignedBlock: TreeBacked<phase0.SignedBeaconBlock> | null = null;
 let altairState: TreeBacked<altair.BeaconState> | null = null;
-let altairCachedState23637: allForks.CachedBeaconState<altair.BeaconState> | null = null;
-let altairCachedState23638: allForks.CachedBeaconState<altair.BeaconState> | null = null;
+let altairCachedState23637: BeaconStateCachedAltair | null = null;
+let altairCachedState23638: BeaconStateCachedAltair | null = null;
 const logger = profilerLogger();
 
 /**
@@ -80,9 +87,7 @@ export function getSecretKeyFromIndexCached(validatorIndex: number): SecretKey {
   return sk;
 }
 
-export function generatePerfTestCachedStatePhase0(opts?: {
-  goBackOneSlot: boolean;
-}): allForks.CachedBeaconState<phase0.BeaconState> {
+export function generatePerfTestCachedStatePhase0(opts?: {goBackOneSlot: boolean}): BeaconStateCachedPhase0 {
   // Generate only some publicKeys
   const {pubkeys, pubkeysMod, pubkeysModObj} = getPubkeys();
 
@@ -108,9 +113,9 @@ export function generatePerfTestCachedStatePhase0(opts?: {
   }
   if (!phase0CachedState23638) {
     phase0CachedState23638 = allForks.processSlots(
-      phase0CachedState23637 as allForks.CachedBeaconState<allForks.BeaconState>,
+      phase0CachedState23637 as BeaconStateCachedAllForks,
       phase0CachedState23637.slot + 1
-    ) as allForks.CachedBeaconState<phase0.BeaconState>;
+    ) as BeaconStateCachedPhase0;
     phase0CachedState23638.slot += 1;
   }
   const resultingState = opts && opts.goBackOneSlot ? phase0CachedState23637 : phase0CachedState23638;
@@ -118,9 +123,7 @@ export function generatePerfTestCachedStatePhase0(opts?: {
   return resultingState.clone();
 }
 
-export function generatePerfTestCachedStateAltair(opts?: {
-  goBackOneSlot: boolean;
-}): allForks.CachedBeaconState<altair.BeaconState> {
+export function generatePerfTestCachedStateAltair(opts?: {goBackOneSlot: boolean}): BeaconStateCachedAltair {
   const {pubkeys, pubkeysMod, pubkeysModObj} = getPubkeys();
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const altairConfig = createIChainForkConfig({ALTAIR_FORK_EPOCH: 0});
@@ -147,9 +150,9 @@ export function generatePerfTestCachedStateAltair(opts?: {
   }
   if (!altairCachedState23638) {
     altairCachedState23638 = allForks.processSlots(
-      altairCachedState23637 as allForks.CachedBeaconState<allForks.BeaconState>,
+      altairCachedState23637 as BeaconStateCachedAllForks,
       altairCachedState23637.slot + 1
-    ) as allForks.CachedBeaconState<altair.BeaconState>;
+    ) as BeaconStateCachedAltair;
     altairCachedState23638.slot += 1;
   }
   const resultingState = opts && opts.goBackOneSlot ? altairCachedState23637 : altairCachedState23638;
@@ -352,7 +355,7 @@ export function generateTestCachedBeaconStateOnlyValidators({
 }: {
   vc: number;
   slot: Slot;
-}): allForks.CachedBeaconState<allForks.BeaconState> {
+}): BeaconStateCachedAllForks {
   // Generate only some publicKeys
   const {pubkeys, pubkeysMod, pubkeysModObj} = getPubkeys(vc);
 
@@ -449,7 +452,7 @@ export async function getNetworkCachedState(
   network: NetworkName,
   slot: number,
   timeout?: number
-): Promise<CachedBeaconState<allForks.BeaconState>> {
+): Promise<BeaconStateCachedAllForks> {
   const config = getNetworkConfig(network);
 
   const filepath = path.join(testCachePath, `state_${network}_${slot}.ssz`);

--- a/packages/beacon-state-transition/test/perf/util.ts
+++ b/packages/beacon-state-transition/test/perf/util.ts
@@ -6,14 +6,8 @@ import bls, {CoordType, PublicKey, SecretKey} from "@chainsafe/bls";
 import {fromHexString, List, TreeBacked} from "@chainsafe/ssz";
 import {allForks, interopSecretKey, computeEpochAtSlot, getActiveValidatorIndices} from "../../src";
 import {createIChainForkConfig, IChainForkConfig} from "@chainsafe/lodestar-config";
-import {
-  computeCommitteeCount,
-  createCachedBeaconState,
-  PubkeyIndexMap,
-  BeaconStateCachedAllForks,
-  BeaconStateCachedPhase0,
-  BeaconStateCachedAltair,
-} from "../../src/allForks";
+import {computeCommitteeCount, createCachedBeaconState, PubkeyIndexMap} from "../../src/allForks";
+import {BeaconStateCachedAllForks, BeaconStateCachedPhase0, BeaconStateCachedAltair} from "../../src/types";
 import {profilerLogger} from "../utils/logger";
 import {interopPubkeysCached} from "../utils/interop";
 import {PendingAttestation} from "@chainsafe/lodestar-types/phase0";

--- a/packages/beacon-state-transition/test/unit/util/interface.test.ts
+++ b/packages/beacon-state-transition/test/unit/util/interface.test.ts
@@ -2,14 +2,14 @@ import {config} from "@chainsafe/lodestar-config/default";
 import {ssz} from "@chainsafe/lodestar-types";
 import {fromHexString, List, TreeBacked} from "@chainsafe/ssz";
 import {expect} from "chai";
-import {phase0, BeaconStateCachedPhase0, createCachedBeaconState} from "../../../src";
+import {phase0, CachedBeaconStatePhase0, createCachedBeaconState} from "../../../src";
 import {generateState} from "../../utils/state";
 
 const NUM_VALIDATORS = 1001;
 
 describe("CachedBeaconState", function () {
   let state: TreeBacked<phase0.BeaconState>;
-  let wrappedState: BeaconStateCachedPhase0;
+  let wrappedState: CachedBeaconStatePhase0;
 
   before(function () {
     this.timeout(0);

--- a/packages/beacon-state-transition/test/unit/util/interface.test.ts
+++ b/packages/beacon-state-transition/test/unit/util/interface.test.ts
@@ -2,14 +2,14 @@ import {config} from "@chainsafe/lodestar-config/default";
 import {ssz} from "@chainsafe/lodestar-types";
 import {fromHexString, List, TreeBacked} from "@chainsafe/ssz";
 import {expect} from "chai";
-import {phase0, CachedBeaconState, createCachedBeaconState} from "../../../src";
+import {phase0, BeaconStateCachedPhase0, createCachedBeaconState} from "../../../src";
 import {generateState} from "../../utils/state";
 
 const NUM_VALIDATORS = 1001;
 
 describe("CachedBeaconState", function () {
   let state: TreeBacked<phase0.BeaconState>;
-  let wrappedState: CachedBeaconState<phase0.BeaconState>;
+  let wrappedState: BeaconStateCachedPhase0;
 
   before(function () {
     this.timeout(0);

--- a/packages/beacon-state-transition/test/utils/state.ts
+++ b/packages/beacon-state-transition/test/utils/state.ts
@@ -14,7 +14,7 @@ import {ZERO_HASH} from "../../src/constants";
 import {newZeroedBigIntArray} from "../../src/util";
 
 import {generateEmptyBlock} from "./block";
-import {BeaconStateCachedAllForks, createCachedBeaconState} from "../../src";
+import {CachedBeaconStateAllForks, createCachedBeaconState} from "../../src";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 
 /**
@@ -81,7 +81,7 @@ export function generateState(opts?: TestBeaconState): phase0.BeaconState {
 export function generateCachedState(
   config: IChainForkConfig = minimalConfig,
   opts: TestBeaconState = {}
-): BeaconStateCachedAllForks {
+): CachedBeaconStateAllForks {
   const state = generateState(opts);
   return createCachedBeaconState(config, config.getForkTypes(state.slot).BeaconState.createTreeBackedFromStruct(state));
 }

--- a/packages/beacon-state-transition/test/utils/state.ts
+++ b/packages/beacon-state-transition/test/utils/state.ts
@@ -7,14 +7,14 @@ import {
   GENESIS_SLOT,
   SLOTS_PER_HISTORICAL_ROOT,
 } from "@chainsafe/lodestar-params";
-import {allForks, phase0, ssz} from "@chainsafe/lodestar-types";
+import {phase0, ssz} from "@chainsafe/lodestar-types";
 import {config} from "@chainsafe/lodestar-config/default";
 
 import {ZERO_HASH} from "../../src/constants";
 import {newZeroedBigIntArray} from "../../src/util";
 
 import {generateEmptyBlock} from "./block";
-import {CachedBeaconState, createCachedBeaconState} from "../../src";
+import {BeaconStateCachedAllForks, createCachedBeaconState} from "../../src";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 
 /**
@@ -81,7 +81,7 @@ export function generateState(opts?: TestBeaconState): phase0.BeaconState {
 export function generateCachedState(
   config: IChainForkConfig = minimalConfig,
   opts: TestBeaconState = {}
-): CachedBeaconState<allForks.BeaconState> {
+): BeaconStateCachedAllForks {
   const state = generateState(opts);
   return createCachedBeaconState(config, config.getForkTypes(state.slot).BeaconState.createTreeBackedFromStruct(state));
 }

--- a/packages/fork-choice/test/perf/protoArray/computeDeltas.test.ts
+++ b/packages/fork-choice/test/perf/protoArray/computeDeltas.test.ts
@@ -1,13 +1,13 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
 import {expect} from "chai";
-import {allForks, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {generatePerfTestCachedStateAltair} from "@chainsafe/lodestar-beacon-state-transition/test/perf/util";
 import {IVoteTracker} from "../../../src/protoArray/interface";
 import {computeDeltas} from "../../../src/protoArray/computeDeltas";
 import {computeProposerBoostScoreFromBalances} from "../../../src/forkChoice/forkChoice";
 
 describe("computeDeltas", () => {
-  let originalState: allForks.CachedBeaconState<allForks.BeaconState>;
+  let originalState: BeaconStateCachedAllForks;
   const indices: Map<string, number> = new Map<string, number>();
   const oldBalances: number[] = [];
   const newBalances: number[] = [];
@@ -19,7 +19,7 @@ describe("computeDeltas", () => {
 
     originalState = (generatePerfTestCachedStateAltair({
       goBackOneSlot: true,
-    }) as unknown) as allForks.CachedBeaconState<allForks.BeaconState>;
+    }) as unknown) as BeaconStateCachedAllForks;
     const numPreviousEpochParticipation = originalState.previousEpochParticipation.persistent
       .toArray()
       .filter((part) => part !== undefined && part.timelySource).length;

--- a/packages/fork-choice/test/perf/protoArray/computeDeltas.test.ts
+++ b/packages/fork-choice/test/perf/protoArray/computeDeltas.test.ts
@@ -1,13 +1,13 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
 import {expect} from "chai";
-import {BeaconStateCachedAllForks, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {generatePerfTestCachedStateAltair} from "@chainsafe/lodestar-beacon-state-transition/test/perf/util";
 import {IVoteTracker} from "../../../src/protoArray/interface";
 import {computeDeltas} from "../../../src/protoArray/computeDeltas";
 import {computeProposerBoostScoreFromBalances} from "../../../src/forkChoice/forkChoice";
 
 describe("computeDeltas", () => {
-  let originalState: BeaconStateCachedAllForks;
+  let originalState: CachedBeaconStateAllForks;
   const indices: Map<string, number> = new Map<string, number>();
   const oldBalances: number[] = [];
   const newBalances: number[] = [];
@@ -19,7 +19,7 @@ describe("computeDeltas", () => {
 
     originalState = (generatePerfTestCachedStateAltair({
       goBackOneSlot: true,
-    }) as unknown) as BeaconStateCachedAllForks;
+    }) as unknown) as CachedBeaconStateAllForks;
     const numPreviousEpochParticipation = originalState.previousEpochParticipation.persistent
       .toArray()
       .filter((part) => part !== undefined && part.timelySource).length;

--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -1,6 +1,6 @@
 import {routes} from "@chainsafe/lodestar-api";
 import {
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   computeStartSlotAtEpoch,
   proposerShufflingDecisionRoot,
   attesterShufflingDecisionRoot,
@@ -61,7 +61,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
   let genesisBlockRoot: Root | null = null;
 
   /** Compute and cache the genesis block root */
-  async function getGenesisBlockRoot(state: BeaconStateCachedAllForks): Promise<Root> {
+  async function getGenesisBlockRoot(state: CachedBeaconStateAllForks): Promise<Root> {
     if (!genesisBlockRoot) {
       // Close to genesis the genesis block may not be available in the DB
       if (state.slot < SLOTS_PER_HISTORICAL_ROOT) {

--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -1,6 +1,6 @@
 import {routes} from "@chainsafe/lodestar-api";
 import {
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
   computeStartSlotAtEpoch,
   proposerShufflingDecisionRoot,
   attesterShufflingDecisionRoot,
@@ -14,7 +14,7 @@ import {
   SYNC_COMMITTEE_SIZE,
   SYNC_COMMITTEE_SUBNET_COUNT,
 } from "@chainsafe/lodestar-params";
-import {allForks, Root, Slot, ValidatorIndex, ssz} from "@chainsafe/lodestar-types";
+import {Root, Slot, ValidatorIndex, ssz} from "@chainsafe/lodestar-types";
 import {ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
 
 import {assembleBlock} from "../../../chain/factory/block";
@@ -61,7 +61,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
   let genesisBlockRoot: Root | null = null;
 
   /** Compute and cache the genesis block root */
-  async function getGenesisBlockRoot(state: CachedBeaconState<allForks.BeaconState>): Promise<Root> {
+  async function getGenesisBlockRoot(state: BeaconStateCachedAllForks): Promise<Root> {
     if (!genesisBlockRoot) {
       // Close to genesis the genesis block may not be available in the DB
       if (state.slot < SLOTS_PER_HISTORICAL_ROOT) {

--- a/packages/lodestar/src/api/impl/validator/utils.ts
+++ b/packages/lodestar/src/api/impl/validator/utils.ts
@@ -1,37 +1,28 @@
 import {
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
+  BeaconStateCachedAltair,
   computeEpochAtSlot,
   computeSlotsSinceEpochStart,
   computeSyncPeriodAtEpoch,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {ATTESTATION_SUBNET_COUNT} from "@chainsafe/lodestar-params";
-import {
-  allForks,
-  altair,
-  BLSPubkey,
-  CommitteeIndex,
-  Epoch,
-  phase0,
-  Slot,
-  ssz,
-  ValidatorIndex,
-} from "@chainsafe/lodestar-types";
+import {allForks, BLSPubkey, CommitteeIndex, Epoch, phase0, Slot, ssz, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {BranchNodeStruct, TreeValue, List} from "@chainsafe/ssz";
 import {ApiError} from "../errors";
 
 export function getSyncComitteeValidatorIndexMap(
-  state: allForks.BeaconState | CachedBeaconState<allForks.BeaconState>,
+  state: allForks.BeaconState | BeaconStateCachedAllForks,
   requestedEpoch: Epoch
 ): Map<ValidatorIndex, number[]> {
   const statePeriod = computeSyncPeriodAtEpoch(computeEpochAtSlot(state.slot));
   const requestPeriod = computeSyncPeriodAtEpoch(requestedEpoch);
 
-  if ((state as CachedBeaconState<allForks.BeaconState>).epochCtx !== undefined) {
+  if ((state as BeaconStateCachedAllForks).epochCtx !== undefined) {
     switch (requestPeriod) {
       case statePeriod:
-        return (state as CachedBeaconState<altair.BeaconState>).currentSyncCommittee.validatorIndexMap;
+        return (state as BeaconStateCachedAltair).currentSyncCommittee.validatorIndexMap;
       case statePeriod + 1:
-        return (state as CachedBeaconState<altair.BeaconState>).nextSyncCommittee.validatorIndexMap;
+        return (state as BeaconStateCachedAltair).nextSyncCommittee.validatorIndexMap;
       default:
         throw new ApiError(400, "Epoch out of bounds");
     }

--- a/packages/lodestar/src/api/impl/validator/utils.ts
+++ b/packages/lodestar/src/api/impl/validator/utils.ts
@@ -1,6 +1,6 @@
 import {
-  BeaconStateCachedAllForks,
-  BeaconStateCachedAltair,
+  CachedBeaconStateAllForks,
+  CachedBeaconStateAltair,
   computeEpochAtSlot,
   computeSlotsSinceEpochStart,
   computeSyncPeriodAtEpoch,
@@ -11,18 +11,18 @@ import {BranchNodeStruct, TreeValue, List} from "@chainsafe/ssz";
 import {ApiError} from "../errors";
 
 export function getSyncComitteeValidatorIndexMap(
-  state: allForks.BeaconState | BeaconStateCachedAllForks,
+  state: allForks.BeaconState | CachedBeaconStateAllForks,
   requestedEpoch: Epoch
 ): Map<ValidatorIndex, number[]> {
   const statePeriod = computeSyncPeriodAtEpoch(computeEpochAtSlot(state.slot));
   const requestPeriod = computeSyncPeriodAtEpoch(requestedEpoch);
 
-  if ((state as BeaconStateCachedAllForks).epochCtx !== undefined) {
+  if ((state as CachedBeaconStateAllForks).epochCtx !== undefined) {
     switch (requestPeriod) {
       case statePeriod:
-        return (state as BeaconStateCachedAltair).currentSyncCommittee.validatorIndexMap;
+        return (state as CachedBeaconStateAltair).currentSyncCommittee.validatorIndexMap;
       case statePeriod + 1:
-        return (state as BeaconStateCachedAltair).nextSyncCommittee.validatorIndexMap;
+        return (state as CachedBeaconStateAltair).nextSyncCommittee.validatorIndexMap;
       default:
         throw new ApiError(400, "Epoch out of bounds");
     }

--- a/packages/lodestar/src/chain/blocks/importBlock.ts
+++ b/packages/lodestar/src/chain/blocks/importBlock.ts
@@ -2,7 +2,7 @@ import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {readonlyValues, toHexString} from "@chainsafe/ssz";
 import {allForks} from "@chainsafe/lodestar-types";
 import {
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   computeStartSlotAtEpoch,
   getEffectiveBalances,
   bellatrix,
@@ -271,9 +271,9 @@ export async function importBlock(chain: ImportBlockModules, fullyVerifiedBlock:
  */
 function getStateForJustifiedBalances(
   chain: ImportBlockModules,
-  postState: BeaconStateCachedAllForks,
+  postState: CachedBeaconStateAllForks,
   block: allForks.SignedBeaconBlock
-): BeaconStateCachedAllForks {
+): CachedBeaconStateAllForks {
   const justifiedCheckpoint = postState.currentJustifiedCheckpoint;
   const checkpointHex = toCheckpointHex(justifiedCheckpoint);
   const checkpointSlot = computeStartSlotAtEpoch(checkpointHex.epoch);

--- a/packages/lodestar/src/chain/blocks/importBlock.ts
+++ b/packages/lodestar/src/chain/blocks/importBlock.ts
@@ -2,7 +2,7 @@ import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {readonlyValues, toHexString} from "@chainsafe/ssz";
 import {allForks} from "@chainsafe/lodestar-types";
 import {
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
   computeStartSlotAtEpoch,
   getEffectiveBalances,
   bellatrix,
@@ -271,9 +271,9 @@ export async function importBlock(chain: ImportBlockModules, fullyVerifiedBlock:
  */
 function getStateForJustifiedBalances(
   chain: ImportBlockModules,
-  postState: CachedBeaconState<allForks.BeaconState>,
+  postState: BeaconStateCachedAllForks,
   block: allForks.SignedBeaconBlock
-): CachedBeaconState<allForks.BeaconState> {
+): BeaconStateCachedAllForks {
   const justifiedCheckpoint = postState.currentJustifiedCheckpoint;
   const checkpointHex = toCheckpointHex(justifiedCheckpoint);
   const checkpointSlot = computeStartSlotAtEpoch(checkpointHex.epoch);

--- a/packages/lodestar/src/chain/blocks/types.ts
+++ b/packages/lodestar/src/chain/blocks/types.ts
@@ -1,4 +1,4 @@
-import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {IProtoBlock, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
 import {allForks} from "@chainsafe/lodestar-types";
 
@@ -45,7 +45,7 @@ export type PartiallyVerifiedBlockFlags = FullyVerifiedBlockFlags & {
  */
 export type FullyVerifiedBlock = FullyVerifiedBlockFlags & {
   block: allForks.SignedBeaconBlock;
-  postState: BeaconStateCachedAllForks;
+  postState: CachedBeaconStateAllForks;
   parentBlock: IProtoBlock;
 };
 

--- a/packages/lodestar/src/chain/blocks/types.ts
+++ b/packages/lodestar/src/chain/blocks/types.ts
@@ -1,4 +1,4 @@
-import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {IProtoBlock, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
 import {allForks} from "@chainsafe/lodestar-types";
 
@@ -45,7 +45,7 @@ export type PartiallyVerifiedBlockFlags = FullyVerifiedBlockFlags & {
  */
 export type FullyVerifiedBlock = FullyVerifiedBlockFlags & {
   block: allForks.SignedBeaconBlock;
-  postState: CachedBeaconState<allForks.BeaconState>;
+  postState: BeaconStateCachedAllForks;
   parentBlock: IProtoBlock;
 };
 

--- a/packages/lodestar/src/chain/blocks/utils/checkpoint.ts
+++ b/packages/lodestar/src/chain/blocks/utils/checkpoint.ts
@@ -1,4 +1,4 @@
-import {BeaconStateCachedAllForks, computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks, computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {phase0, ssz} from "@chainsafe/lodestar-types";
 import {ZERO_HASH} from "../../../constants";
@@ -6,7 +6,7 @@ import {ZERO_HASH} from "../../../constants";
 /**
  * Compute a Checkpoint type from `state.latestBlockHeader`
  */
-export function getCheckpointFromState(checkpointState: BeaconStateCachedAllForks): phase0.Checkpoint {
+export function getCheckpointFromState(checkpointState: CachedBeaconStateAllForks): phase0.Checkpoint {
   const config = checkpointState.config;
   const slot = checkpointState.slot;
 

--- a/packages/lodestar/src/chain/blocks/utils/checkpoint.ts
+++ b/packages/lodestar/src/chain/blocks/utils/checkpoint.ts
@@ -1,12 +1,12 @@
-import {CachedBeaconState, computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks, computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
-import {allForks, phase0, ssz} from "@chainsafe/lodestar-types";
+import {phase0, ssz} from "@chainsafe/lodestar-types";
 import {ZERO_HASH} from "../../../constants";
 
 /**
  * Compute a Checkpoint type from `state.latestBlockHeader`
  */
-export function getCheckpointFromState(checkpointState: CachedBeaconState<allForks.BeaconState>): phase0.Checkpoint {
+export function getCheckpointFromState(checkpointState: BeaconStateCachedAllForks): phase0.Checkpoint {
   const config = checkpointState.config;
   const slot = checkpointState.slot;
 

--- a/packages/lodestar/src/chain/blocks/verifyBlock.ts
+++ b/packages/lodestar/src/chain/blocks/verifyBlock.ts
@@ -1,7 +1,7 @@
 import {ssz} from "@chainsafe/lodestar-types";
 import {SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY} from "@chainsafe/lodestar-params";
 import {
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   computeStartSlotAtEpoch,
   allForks,
   bellatrix,
@@ -121,7 +121,7 @@ export async function verifyBlockStateTransition(
   chain: VerifyBlockModules,
   partiallyVerifiedBlock: PartiallyVerifiedBlock,
   opts: BlockProcessOpts
-): Promise<{postState: BeaconStateCachedAllForks; executionStatus: ExecutionStatus}> {
+): Promise<{postState: CachedBeaconStateAllForks; executionStatus: ExecutionStatus}> {
   const {block, validProposerSignature, validSignatures} = partiallyVerifiedBlock;
 
   // TODO: Skip in process chain segment
@@ -162,7 +162,7 @@ export async function verifyBlockStateTransition(
   if (useBlsBatchVerify && !validSignatures) {
     const signatureSets = validProposerSignature
       ? allForks.getAllBlockSignatureSetsExceptProposer(postState, block)
-      : allForks.getAllBlockSignatureSets(postState as BeaconStateCachedAllForks, block);
+      : allForks.getAllBlockSignatureSets(postState as CachedBeaconStateAllForks, block);
 
     if (signatureSets.length > 0 && !(await chain.bls.verifySignatureSets(signatureSets))) {
       throw new BlockError(block, {code: BlockErrorCode.INVALID_SIGNATURE, state: postState});

--- a/packages/lodestar/src/chain/blocks/verifyBlock.ts
+++ b/packages/lodestar/src/chain/blocks/verifyBlock.ts
@@ -1,7 +1,7 @@
 import {ssz} from "@chainsafe/lodestar-types";
 import {SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY} from "@chainsafe/lodestar-params";
 import {
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
   computeStartSlotAtEpoch,
   allForks,
   bellatrix,
@@ -121,7 +121,7 @@ export async function verifyBlockStateTransition(
   chain: VerifyBlockModules,
   partiallyVerifiedBlock: PartiallyVerifiedBlock,
   opts: BlockProcessOpts
-): Promise<{postState: CachedBeaconState<allForks.BeaconState>; executionStatus: ExecutionStatus}> {
+): Promise<{postState: BeaconStateCachedAllForks; executionStatus: ExecutionStatus}> {
   const {block, validProposerSignature, validSignatures} = partiallyVerifiedBlock;
 
   // TODO: Skip in process chain segment
@@ -162,7 +162,7 @@ export async function verifyBlockStateTransition(
   if (useBlsBatchVerify && !validSignatures) {
     const signatureSets = validProposerSignature
       ? allForks.getAllBlockSignatureSetsExceptProposer(postState, block)
-      : allForks.getAllBlockSignatureSets(postState as CachedBeaconState<allForks.BeaconState>, block);
+      : allForks.getAllBlockSignatureSets(postState as BeaconStateCachedAllForks, block);
 
     if (signatureSets.length > 0 && !(await chain.bls.verifySignatureSets(signatureSets))) {
       throw new BlockError(block, {code: BlockErrorCode.INVALID_SIGNATURE, state: postState});

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -3,7 +3,7 @@
  */
 
 import fs from "fs";
-import {BeaconStateCachedAllForks, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {allForks, Number64, Root, phase0, Slot, RootHex} from "@chainsafe/lodestar-types";
@@ -210,7 +210,7 @@ export class BeaconChain implements IBeaconChain {
     return this.genesisTime;
   }
 
-  getHeadState(): BeaconStateCachedAllForks {
+  getHeadState(): CachedBeaconStateAllForks {
     // head state should always exist
     const head = this.forkChoice.getHead();
     const headState =
@@ -219,7 +219,7 @@ export class BeaconChain implements IBeaconChain {
     return headState;
   }
 
-  async getHeadStateAtCurrentEpoch(): Promise<BeaconStateCachedAllForks> {
+  async getHeadStateAtCurrentEpoch(): Promise<CachedBeaconStateAllForks> {
     const currentEpochStartSlot = computeStartSlotAtEpoch(this.clock.currentEpoch);
     const head = this.forkChoice.getHead();
     const bestSlot = currentEpochStartSlot > head.slot ? currentEpochStartSlot : head.slot;

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -3,7 +3,7 @@
  */
 
 import fs from "fs";
-import {CachedBeaconState, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {allForks, Number64, Root, phase0, Slot, RootHex} from "@chainsafe/lodestar-types";
@@ -210,7 +210,7 @@ export class BeaconChain implements IBeaconChain {
     return this.genesisTime;
   }
 
-  getHeadState(): CachedBeaconState<allForks.BeaconState> {
+  getHeadState(): BeaconStateCachedAllForks {
     // head state should always exist
     const head = this.forkChoice.getHead();
     const headState =
@@ -219,7 +219,7 @@ export class BeaconChain implements IBeaconChain {
     return headState;
   }
 
-  async getHeadStateAtCurrentEpoch(): Promise<CachedBeaconState<allForks.BeaconState>> {
+  async getHeadStateAtCurrentEpoch(): Promise<BeaconStateCachedAllForks> {
     const currentEpochStartSlot = computeStartSlotAtEpoch(this.clock.currentEpoch);
     const head = this.forkChoice.getHead();
     const bestSlot = currentEpochStartSlot > head.slot ? currentEpochStartSlot : head.slot;

--- a/packages/lodestar/src/chain/emitter.ts
+++ b/packages/lodestar/src/chain/emitter.ts
@@ -4,7 +4,7 @@ import StrictEventEmitter from "strict-event-emitter-types";
 import {routes} from "@chainsafe/lodestar-api";
 import {phase0, Epoch, Slot, allForks} from "@chainsafe/lodestar-types";
 import {CheckpointWithHex, IProtoBlock} from "@chainsafe/lodestar-fork-choice";
-import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {AttestationError, BlockError} from "./errors";
 
 /**
@@ -104,16 +104,13 @@ export enum ChainEvent {
 
 export interface IChainEvents {
   [ChainEvent.attestation]: (attestation: phase0.Attestation) => void;
-  [ChainEvent.block]: (
-    signedBlock: allForks.SignedBeaconBlock,
-    postState: CachedBeaconState<allForks.BeaconState>
-  ) => void;
+  [ChainEvent.block]: (signedBlock: allForks.SignedBeaconBlock, postState: BeaconStateCachedAllForks) => void;
   [ChainEvent.errorAttestation]: (error: AttestationError) => void;
   [ChainEvent.errorBlock]: (error: BlockError) => void;
 
-  [ChainEvent.checkpoint]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<allForks.BeaconState>) => void;
-  [ChainEvent.justified]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<allForks.BeaconState>) => void;
-  [ChainEvent.finalized]: (checkpoint: phase0.Checkpoint, state: CachedBeaconState<allForks.BeaconState>) => void;
+  [ChainEvent.checkpoint]: (checkpoint: phase0.Checkpoint, state: BeaconStateCachedAllForks) => void;
+  [ChainEvent.justified]: (checkpoint: phase0.Checkpoint, state: BeaconStateCachedAllForks) => void;
+  [ChainEvent.finalized]: (checkpoint: phase0.Checkpoint, state: BeaconStateCachedAllForks) => void;
 
   [ChainEvent.clockSlot]: (slot: Slot) => void;
   [ChainEvent.clockEpoch]: (epoch: Epoch) => void;

--- a/packages/lodestar/src/chain/emitter.ts
+++ b/packages/lodestar/src/chain/emitter.ts
@@ -4,7 +4,7 @@ import StrictEventEmitter from "strict-event-emitter-types";
 import {routes} from "@chainsafe/lodestar-api";
 import {phase0, Epoch, Slot, allForks} from "@chainsafe/lodestar-types";
 import {CheckpointWithHex, IProtoBlock} from "@chainsafe/lodestar-fork-choice";
-import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {AttestationError, BlockError} from "./errors";
 
 /**
@@ -104,13 +104,13 @@ export enum ChainEvent {
 
 export interface IChainEvents {
   [ChainEvent.attestation]: (attestation: phase0.Attestation) => void;
-  [ChainEvent.block]: (signedBlock: allForks.SignedBeaconBlock, postState: BeaconStateCachedAllForks) => void;
+  [ChainEvent.block]: (signedBlock: allForks.SignedBeaconBlock, postState: CachedBeaconStateAllForks) => void;
   [ChainEvent.errorAttestation]: (error: AttestationError) => void;
   [ChainEvent.errorBlock]: (error: BlockError) => void;
 
-  [ChainEvent.checkpoint]: (checkpoint: phase0.Checkpoint, state: BeaconStateCachedAllForks) => void;
-  [ChainEvent.justified]: (checkpoint: phase0.Checkpoint, state: BeaconStateCachedAllForks) => void;
-  [ChainEvent.finalized]: (checkpoint: phase0.Checkpoint, state: BeaconStateCachedAllForks) => void;
+  [ChainEvent.checkpoint]: (checkpoint: phase0.Checkpoint, state: CachedBeaconStateAllForks) => void;
+  [ChainEvent.justified]: (checkpoint: phase0.Checkpoint, state: CachedBeaconStateAllForks) => void;
+  [ChainEvent.finalized]: (checkpoint: phase0.Checkpoint, state: CachedBeaconStateAllForks) => void;
 
   [ChainEvent.clockSlot]: (slot: Slot) => void;
   [ChainEvent.clockEpoch]: (epoch: Epoch) => void;

--- a/packages/lodestar/src/chain/errors/blockError.ts
+++ b/packages/lodestar/src/chain/errors/blockError.ts
@@ -1,6 +1,6 @@
 import {allForks, RootHex, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {LodestarError} from "@chainsafe/lodestar-utils";
-import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {GossipActionError} from "./gossipValidation";
 
 export enum BlockErrorCode {
@@ -74,11 +74,11 @@ export type BlockErrorType =
   | {code: BlockErrorCode.INCORRECT_PROPOSER; proposerIndex: ValidatorIndex}
   | {code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID}
   | {code: BlockErrorCode.UNKNOWN_PROPOSER; proposerIndex: ValidatorIndex}
-  | {code: BlockErrorCode.INVALID_SIGNATURE; state: CachedBeaconState<allForks.BeaconState>}
+  | {code: BlockErrorCode.INVALID_SIGNATURE; state: BeaconStateCachedAllForks}
   | {
       code: BlockErrorCode.INVALID_STATE_ROOT;
-      preState: CachedBeaconState<allForks.BeaconState>;
-      postState: CachedBeaconState<allForks.BeaconState>;
+      preState: BeaconStateCachedAllForks;
+      postState: BeaconStateCachedAllForks;
     }
   | {code: BlockErrorCode.NOT_FINALIZED_DESCENDANT; parentRoot: RootHex}
   | {code: BlockErrorCode.NOT_LATER_THAN_PARENT; parentSlot: Slot; slot: Slot}

--- a/packages/lodestar/src/chain/errors/blockError.ts
+++ b/packages/lodestar/src/chain/errors/blockError.ts
@@ -1,6 +1,6 @@
 import {allForks, RootHex, Slot, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {LodestarError} from "@chainsafe/lodestar-utils";
-import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {GossipActionError} from "./gossipValidation";
 
 export enum BlockErrorCode {
@@ -74,11 +74,11 @@ export type BlockErrorType =
   | {code: BlockErrorCode.INCORRECT_PROPOSER; proposerIndex: ValidatorIndex}
   | {code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID}
   | {code: BlockErrorCode.UNKNOWN_PROPOSER; proposerIndex: ValidatorIndex}
-  | {code: BlockErrorCode.INVALID_SIGNATURE; state: BeaconStateCachedAllForks}
+  | {code: BlockErrorCode.INVALID_SIGNATURE; state: CachedBeaconStateAllForks}
   | {
       code: BlockErrorCode.INVALID_STATE_ROOT;
-      preState: BeaconStateCachedAllForks;
-      postState: BeaconStateCachedAllForks;
+      preState: CachedBeaconStateAllForks;
+      postState: CachedBeaconStateAllForks;
     }
   | {code: BlockErrorCode.NOT_FINALIZED_DESCENDANT; parentRoot: RootHex}
   | {code: BlockErrorCode.NOT_LATER_THAN_PARENT; parentSlot: Slot; slot: Slot}

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -3,7 +3,7 @@ import {toHexString} from "@chainsafe/ssz";
 import {allForks, Epoch, phase0, Slot, ssz, Version} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {CheckpointWithHex, IProtoBlock} from "@chainsafe/lodestar-fork-choice";
-import {CachedBeaconState, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {AttestationError, BlockError, BlockErrorCode} from "./errors";
 import {ChainEvent, IChainEvents} from "./emitter";
 import {BeaconChain} from "./chain";
@@ -99,11 +99,7 @@ export function onForkVersion(this: BeaconChain, version: Version): void {
   this.logger.verbose("New fork version", ssz.Version.toJson(version));
 }
 
-export function onCheckpoint(
-  this: BeaconChain,
-  cp: phase0.Checkpoint,
-  state: CachedBeaconState<allForks.BeaconState>
-): void {
+export function onCheckpoint(this: BeaconChain, cp: phase0.Checkpoint, state: BeaconStateCachedAllForks): void {
   this.logger.verbose("Checkpoint processed", ssz.phase0.Checkpoint.toJson(cp));
 
   this.metrics?.currentValidators.set({status: "active"}, state.currentShuffling.activeIndices.length);
@@ -125,11 +121,7 @@ export function onCheckpoint(
   }
 }
 
-export function onJustified(
-  this: BeaconChain,
-  cp: phase0.Checkpoint,
-  state: CachedBeaconState<allForks.BeaconState>
-): void {
+export function onJustified(this: BeaconChain, cp: phase0.Checkpoint, state: BeaconStateCachedAllForks): void {
   this.logger.verbose("Checkpoint justified", ssz.phase0.Checkpoint.toJson(cp));
   this.metrics?.previousJustifiedEpoch.set(state.previousJustifiedCheckpoint.epoch);
   this.metrics?.currentJustifiedEpoch.set(cp.epoch);
@@ -181,7 +173,7 @@ export function onAttestation(this: BeaconChain, attestation: phase0.Attestation
 export async function onBlock(
   this: BeaconChain,
   block: allForks.SignedBeaconBlock,
-  _postState: CachedBeaconState<allForks.BeaconState>
+  _postState: BeaconStateCachedAllForks
 ): Promise<void> {
   const blockRoot = toHexString(this.config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message));
   const advancedSlot = this.clock.slotWithFutureTolerance(REPROCESS_MIN_TIME_TO_NEXT_SLOT_SEC);

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -3,7 +3,7 @@ import {toHexString} from "@chainsafe/ssz";
 import {allForks, Epoch, phase0, Slot, ssz, Version} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {CheckpointWithHex, IProtoBlock} from "@chainsafe/lodestar-fork-choice";
-import {BeaconStateCachedAllForks, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {AttestationError, BlockError, BlockErrorCode} from "./errors";
 import {ChainEvent, IChainEvents} from "./emitter";
 import {BeaconChain} from "./chain";
@@ -99,7 +99,7 @@ export function onForkVersion(this: BeaconChain, version: Version): void {
   this.logger.verbose("New fork version", ssz.Version.toJson(version));
 }
 
-export function onCheckpoint(this: BeaconChain, cp: phase0.Checkpoint, state: BeaconStateCachedAllForks): void {
+export function onCheckpoint(this: BeaconChain, cp: phase0.Checkpoint, state: CachedBeaconStateAllForks): void {
   this.logger.verbose("Checkpoint processed", ssz.phase0.Checkpoint.toJson(cp));
 
   this.metrics?.currentValidators.set({status: "active"}, state.currentShuffling.activeIndices.length);
@@ -121,7 +121,7 @@ export function onCheckpoint(this: BeaconChain, cp: phase0.Checkpoint, state: Be
   }
 }
 
-export function onJustified(this: BeaconChain, cp: phase0.Checkpoint, state: BeaconStateCachedAllForks): void {
+export function onJustified(this: BeaconChain, cp: phase0.Checkpoint, state: CachedBeaconStateAllForks): void {
   this.logger.verbose("Checkpoint justified", ssz.phase0.Checkpoint.toJson(cp));
   this.metrics?.previousJustifiedEpoch.set(state.previousJustifiedCheckpoint.epoch);
   this.metrics?.currentJustifiedEpoch.set(cp.epoch);
@@ -173,7 +173,7 @@ export function onAttestation(this: BeaconChain, attestation: phase0.Attestation
 export async function onBlock(
   this: BeaconChain,
   block: allForks.SignedBeaconBlock,
-  _postState: BeaconStateCachedAllForks
+  _postState: CachedBeaconStateAllForks
 ): Promise<void> {
   const blockRoot = toHexString(this.config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message));
   const advancedSlot = this.clock.slotWithFutureTolerance(REPROCESS_MIN_TIME_TO_NEXT_SLOT_SEC);

--- a/packages/lodestar/src/chain/factory/block/body.ts
+++ b/packages/lodestar/src/chain/factory/block/body.ts
@@ -16,7 +16,8 @@ import {
   ExecutionAddress,
 } from "@chainsafe/lodestar-types";
 import {
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
+  BeaconStateCachedBellatrix,
   computeEpochAtSlot,
   computeTimeAtSlot,
   getRandaoMix,
@@ -30,7 +31,7 @@ import {ZERO_HASH, ZERO_HASH_HEX} from "../../../constants";
 
 export async function assembleBody(
   chain: IBeaconChain,
-  currentState: CachedBeaconState<allForks.BeaconState>,
+  currentState: BeaconStateCachedAllForks,
   {
     randaoReveal,
     graffiti,
@@ -61,9 +62,7 @@ export async function assembleBody(
 
   const [attesterSlashings, proposerSlashings, voluntaryExits] = chain.opPool.getSlashingsAndExits(currentState);
   const attestations = chain.aggregatedAttestationPool.getAttestationsForBlock(currentState);
-  const {eth1Data, deposits} = await chain.eth1.getEth1DataAndDeposits(
-    currentState as CachedBeaconState<allForks.BeaconState>
-  );
+  const {eth1Data, deposits} = await chain.eth1.getEth1DataAndDeposits(currentState as BeaconStateCachedAllForks);
 
   const blockBody: phase0.BeaconBlockBody = {
     randaoReveal,
@@ -97,7 +96,7 @@ export async function assembleBody(
     const payloadId = await prepareExecutionPayload(
       chain,
       finalizedBlockHash ?? ZERO_HASH_HEX,
-      currentState as CachedBeaconState<bellatrix.BeaconState>,
+      currentState as BeaconStateCachedBellatrix,
       feeRecipient
     );
 
@@ -122,7 +121,7 @@ export async function assembleBody(
 async function prepareExecutionPayload(
   chain: IBeaconChain,
   finalizedBlockHash: RootHex,
-  state: CachedBeaconState<bellatrix.BeaconState>,
+  state: BeaconStateCachedBellatrix,
   suggestedFeeRecipient: ExecutionAddress
 ): Promise<PayloadId | null> {
   // Use different POW block hash parent for block production based on merge status.

--- a/packages/lodestar/src/chain/factory/block/body.ts
+++ b/packages/lodestar/src/chain/factory/block/body.ts
@@ -16,8 +16,8 @@ import {
   ExecutionAddress,
 } from "@chainsafe/lodestar-types";
 import {
-  BeaconStateCachedAllForks,
-  BeaconStateCachedBellatrix,
+  CachedBeaconStateAllForks,
+  CachedBeaconStateBellatrix,
   computeEpochAtSlot,
   computeTimeAtSlot,
   getRandaoMix,
@@ -31,7 +31,7 @@ import {ZERO_HASH, ZERO_HASH_HEX} from "../../../constants";
 
 export async function assembleBody(
   chain: IBeaconChain,
-  currentState: BeaconStateCachedAllForks,
+  currentState: CachedBeaconStateAllForks,
   {
     randaoReveal,
     graffiti,
@@ -62,7 +62,7 @@ export async function assembleBody(
 
   const [attesterSlashings, proposerSlashings, voluntaryExits] = chain.opPool.getSlashingsAndExits(currentState);
   const attestations = chain.aggregatedAttestationPool.getAttestationsForBlock(currentState);
-  const {eth1Data, deposits} = await chain.eth1.getEth1DataAndDeposits(currentState as BeaconStateCachedAllForks);
+  const {eth1Data, deposits} = await chain.eth1.getEth1DataAndDeposits(currentState as CachedBeaconStateAllForks);
 
   const blockBody: phase0.BeaconBlockBody = {
     randaoReveal,
@@ -96,7 +96,7 @@ export async function assembleBody(
     const payloadId = await prepareExecutionPayload(
       chain,
       finalizedBlockHash ?? ZERO_HASH_HEX,
-      currentState as BeaconStateCachedBellatrix,
+      currentState as CachedBeaconStateBellatrix,
       feeRecipient
     );
 
@@ -121,7 +121,7 @@ export async function assembleBody(
 async function prepareExecutionPayload(
   chain: IBeaconChain,
   finalizedBlockHash: RootHex,
-  state: BeaconStateCachedBellatrix,
+  state: CachedBeaconStateBellatrix,
   suggestedFeeRecipient: ExecutionAddress
 ): Promise<PayloadId | null> {
   // Use different POW block hash parent for block production based on merge status.

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -2,7 +2,7 @@
  * @module chain/blockAssembly
  */
 
-import {CachedBeaconState, allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {Bytes32, Bytes96, ExecutionAddress, Root, Slot} from "@chainsafe/lodestar-types";
 import {fromHexString} from "@chainsafe/ssz";
@@ -63,7 +63,7 @@ export async function assembleBlock(
  */
 function computeNewStateRoot(
   {config, metrics}: {config: IChainForkConfig; metrics: IMetrics | null},
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   block: allForks.BeaconBlock
 ): Root {
   const postState = state.clone();

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -2,7 +2,7 @@
  * @module chain/blockAssembly
  */
 
-import {BeaconStateCachedAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {Bytes32, Bytes96, ExecutionAddress, Root, Slot} from "@chainsafe/lodestar-types";
 import {fromHexString} from "@chainsafe/ssz";
@@ -63,7 +63,7 @@ export async function assembleBlock(
  */
 function computeNewStateRoot(
   {config, metrics}: {config: IChainForkConfig; metrics: IMetrics | null},
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   block: allForks.BeaconBlock
 ): Root {
   const postState = state.clone();

--- a/packages/lodestar/src/chain/forkChoice/index.ts
+++ b/packages/lodestar/src/chain/forkChoice/index.ts
@@ -6,7 +6,7 @@ import {toHexString} from "@chainsafe/ssz";
 import {Slot} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {ForkChoice, ProtoArray, ForkChoiceStore, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
-import {getEffectiveBalances, BeaconStateCachedAllForks, bellatrix} from "@chainsafe/lodestar-beacon-state-transition";
+import {getEffectiveBalances, CachedBeaconStateAllForks, bellatrix} from "@chainsafe/lodestar-beacon-state-transition";
 
 import {computeAnchorCheckpoint} from "../initState";
 import {ChainEventEmitter} from "../emitter";
@@ -26,7 +26,7 @@ export function initializeForkChoice(
   config: IChainForkConfig,
   emitter: ChainEventEmitter,
   currentSlot: Slot,
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   proposerBoostEnabled: boolean,
   metrics?: IMetrics | null
 ): ForkChoice {

--- a/packages/lodestar/src/chain/forkChoice/index.ts
+++ b/packages/lodestar/src/chain/forkChoice/index.ts
@@ -3,10 +3,10 @@
  */
 
 import {toHexString} from "@chainsafe/ssz";
-import {allForks, Slot} from "@chainsafe/lodestar-types";
+import {Slot} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {ForkChoice, ProtoArray, ForkChoiceStore, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
-import {getEffectiveBalances, CachedBeaconState, bellatrix} from "@chainsafe/lodestar-beacon-state-transition";
+import {getEffectiveBalances, BeaconStateCachedAllForks, bellatrix} from "@chainsafe/lodestar-beacon-state-transition";
 
 import {computeAnchorCheckpoint} from "../initState";
 import {ChainEventEmitter} from "../emitter";
@@ -26,7 +26,7 @@ export function initializeForkChoice(
   config: IChainForkConfig,
   emitter: ChainEventEmitter,
   currentSlot: Slot,
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   proposerBoostEnabled: boolean,
   metrics?: IMetrics | null
 ): ForkChoice {

--- a/packages/lodestar/src/chain/genesis/genesis.ts
+++ b/packages/lodestar/src/chain/genesis/genesis.ts
@@ -15,7 +15,7 @@ import {
   applyEth1BlockHash,
   isValidGenesisState,
   isValidGenesisValidators,
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
   createCachedBeaconState,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {ILogger} from "@chainsafe/lodestar-utils";
@@ -42,7 +42,7 @@ export interface IGenesisBuilderKwargs {
 
 export class GenesisBuilder implements IGenesisBuilder {
   // Expose state to persist on error
-  state: CachedBeaconState<allForks.BeaconState>;
+  state: BeaconStateCachedAllForks;
   depositTree: TreeBacked<List<Root>>;
   /** Is null if no block has been processed yet */
   lastProcessedBlockNumber: number | null = null;

--- a/packages/lodestar/src/chain/genesis/genesis.ts
+++ b/packages/lodestar/src/chain/genesis/genesis.ts
@@ -15,7 +15,7 @@ import {
   applyEth1BlockHash,
   isValidGenesisState,
   isValidGenesisValidators,
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   createCachedBeaconState,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {ILogger} from "@chainsafe/lodestar-utils";
@@ -42,7 +42,7 @@ export interface IGenesisBuilderKwargs {
 
 export class GenesisBuilder implements IGenesisBuilder {
   // Expose state to persist on error
-  state: BeaconStateCachedAllForks;
+  state: CachedBeaconStateAllForks;
   depositTree: TreeBacked<List<Root>>;
   /** Is null if no block has been processed yet */
   lastProcessedBlockNumber: number | null = null;

--- a/packages/lodestar/src/chain/initState.ts
+++ b/packages/lodestar/src/chain/initState.ts
@@ -8,7 +8,7 @@ import {
   computeEpochAtSlot,
   createCachedBeaconState,
   phase0,
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {allForks, ssz} from "@chainsafe/lodestar-types";
 import {IBeaconConfig, IChainForkConfig} from "@chainsafe/lodestar-config";
@@ -183,7 +183,7 @@ export function restoreStateCaches(
   stateCache: StateContextCache,
   checkpointStateCache: CheckpointStateCache,
   state: TreeBacked<allForks.BeaconState>
-): CachedBeaconState<allForks.BeaconState> {
+): BeaconStateCachedAllForks {
   const {checkpoint} = computeAnchorCheckpoint(config, state);
 
   const cachedBeaconState = createCachedBeaconState(config, state);

--- a/packages/lodestar/src/chain/initState.ts
+++ b/packages/lodestar/src/chain/initState.ts
@@ -8,7 +8,7 @@ import {
   computeEpochAtSlot,
   createCachedBeaconState,
   phase0,
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {allForks, ssz} from "@chainsafe/lodestar-types";
 import {IBeaconConfig, IChainForkConfig} from "@chainsafe/lodestar-config";
@@ -183,7 +183,7 @@ export function restoreStateCaches(
   stateCache: StateContextCache,
   checkpointStateCache: CheckpointStateCache,
   state: TreeBacked<allForks.BeaconState>
-): BeaconStateCachedAllForks {
+): CachedBeaconStateAllForks {
   const {checkpoint} = computeAnchorCheckpoint(config, state);
 
   const cachedBeaconState = createCachedBeaconState(config, state);

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -1,5 +1,5 @@
 import {allForks, Number64, Root, phase0, Slot, RootHex} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
@@ -76,8 +76,8 @@ export interface IBeaconChain {
   persistToDisk(): Promise<void>;
   getGenesisTime(): Number64;
 
-  getHeadState(): BeaconStateCachedAllForks;
-  getHeadStateAtCurrentEpoch(): Promise<BeaconStateCachedAllForks>;
+  getHeadState(): CachedBeaconStateAllForks;
+  getHeadStateAtCurrentEpoch(): Promise<CachedBeaconStateAllForks>;
 
   /**
    * Since we can have multiple parallel chains,

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -1,5 +1,5 @@
 import {allForks, Number64, Root, phase0, Slot, RootHex} from "@chainsafe/lodestar-types";
-import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 
@@ -76,8 +76,8 @@ export interface IBeaconChain {
   persistToDisk(): Promise<void>;
   getGenesisTime(): Number64;
 
-  getHeadState(): CachedBeaconState<allForks.BeaconState>;
-  getHeadStateAtCurrentEpoch(): Promise<CachedBeaconState<allForks.BeaconState>>;
+  getHeadState(): BeaconStateCachedAllForks;
+  getHeadStateAtCurrentEpoch(): Promise<BeaconStateCachedAllForks>;
 
   /**
    * Since we can have multiple parallel chains,

--- a/packages/lodestar/src/chain/lightClient/index.ts
+++ b/packages/lodestar/src/chain/lightClient/index.ts
@@ -1,11 +1,10 @@
 import {altair, phase0, Root, RootHex, Slot, ssz, SyncPeriod} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
   computeSyncPeriodAtEpoch,
   computeSyncPeriodAtSlot,
 } from "@chainsafe/lodestar-beacon-state-transition";
-import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {routes} from "@chainsafe/lodestar-api";
 import {BitVector, toHexString} from "@chainsafe/ssz";
@@ -194,7 +193,7 @@ export class LightClientServer {
    */
   onImportBlock(
     block: altair.BeaconBlock,
-    postState: CachedBeaconState<allForks.BeaconState>,
+    postState: BeaconStateCachedAllForks,
     parentBlock: {blockRoot: RootHex; slot: Slot}
   ): void {
     // What is the syncAggregate signing?
@@ -323,7 +322,7 @@ export class LightClientServer {
 
   private async persistPostBlockImportData(
     block: altair.BeaconBlock,
-    postState: CachedBeaconState<allForks.BeaconState>,
+    postState: BeaconStateCachedAllForks,
     parentBlock: {blockRoot: RootHex; slot: Slot}
   ): Promise<void> {
     const blockSlot = block.slot;

--- a/packages/lodestar/src/chain/lightClient/index.ts
+++ b/packages/lodestar/src/chain/lightClient/index.ts
@@ -1,7 +1,7 @@
 import {altair, phase0, Root, RootHex, Slot, ssz, SyncPeriod} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   computeSyncPeriodAtEpoch,
   computeSyncPeriodAtSlot,
 } from "@chainsafe/lodestar-beacon-state-transition";
@@ -193,7 +193,7 @@ export class LightClientServer {
    */
   onImportBlock(
     block: altair.BeaconBlock,
-    postState: BeaconStateCachedAllForks,
+    postState: CachedBeaconStateAllForks,
     parentBlock: {blockRoot: RootHex; slot: Slot}
   ): void {
     // What is the syncAggregate signing?
@@ -322,7 +322,7 @@ export class LightClientServer {
 
   private async persistPostBlockImportData(
     block: altair.BeaconBlock,
-    postState: BeaconStateCachedAllForks,
+    postState: CachedBeaconStateAllForks,
     parentBlock: {blockRoot: RootHex; slot: Slot}
   ): Promise<void> {
     const blockSlot = block.slot;

--- a/packages/lodestar/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/lodestar/src/chain/opPools/aggregatedAttestationPool.ts
@@ -1,9 +1,11 @@
 import bls from "@chainsafe/bls";
 import {ForkName, MAX_ATTESTATIONS, MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
-import {altair, Epoch, Slot, ssz, ValidatorIndex} from "@chainsafe/lodestar-types";
+import {Epoch, Slot, ssz, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
+  BeaconStateCachedPhase0,
+  BeaconStateCachedAltair,
   computeEpochAtSlot,
   phase0,
   zipIndexesCommitteeBits,
@@ -77,7 +79,7 @@ export class AggregatedAttestationPool {
   /**
    * Get attestations to be included in a block. Returns $MAX_ATTESTATIONS items
    */
-  getAttestationsForBlock(state: CachedBeaconState<allForks.BeaconState>): phase0.Attestation[] {
+  getAttestationsForBlock(state: BeaconStateCachedAllForks): phase0.Attestation[] {
     const stateSlot = state.slot;
     const stateEpoch = state.currentShuffling.epoch;
     const statePrevEpoch = stateEpoch - 1;
@@ -180,9 +182,9 @@ export class AggregatedAttestationPool {
    * As we are close to altair, this is not really important, it's mainly for e2e.
    * The performance is not great due to the different BeaconState data structure to altair.
    */
-  private getParticipationPhase0(state: CachedBeaconState<allForks.BeaconState>): GetParticipationFn {
+  private getParticipationPhase0(state: BeaconStateCachedAllForks): GetParticipationFn {
     // check for phase0 block already
-    const phase0State = state as CachedBeaconState<phase0.BeaconState>;
+    const phase0State = state as BeaconStateCachedPhase0;
     const {epochCtx} = phase0State;
     const stateEpoch = computeEpochAtSlot(state.slot);
 
@@ -203,9 +205,9 @@ export class AggregatedAttestationPool {
    * Attestations are sorted by inclusion distance then number of attesters.
    * Attestations should pass the validation when processing attestations in beacon-state-transition.
    */
-  private getParticipationAltair(state: CachedBeaconState<allForks.BeaconState>): GetParticipationFn {
+  private getParticipationAltair(state: BeaconStateCachedAllForks): GetParticipationFn {
     // check for altair block already
-    const altairState = state as CachedBeaconState<altair.BeaconState>;
+    const altairState = state as BeaconStateCachedAltair;
     const stateEpoch = computeEpochAtSlot(state.slot);
     const previousParticipation = altairState.previousEpochParticipation.persistent.toArray();
     const currentParticipation = altairState.currentEpochParticipation.persistent.toArray();

--- a/packages/lodestar/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/lodestar/src/chain/opPools/aggregatedAttestationPool.ts
@@ -3,9 +3,9 @@ import {ForkName, MAX_ATTESTATIONS, MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_E
 import {Epoch, Slot, ssz, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {
-  BeaconStateCachedAllForks,
-  BeaconStateCachedPhase0,
-  BeaconStateCachedAltair,
+  CachedBeaconStateAllForks,
+  CachedBeaconStatePhase0,
+  CachedBeaconStateAltair,
   computeEpochAtSlot,
   phase0,
   zipIndexesCommitteeBits,
@@ -79,7 +79,7 @@ export class AggregatedAttestationPool {
   /**
    * Get attestations to be included in a block. Returns $MAX_ATTESTATIONS items
    */
-  getAttestationsForBlock(state: BeaconStateCachedAllForks): phase0.Attestation[] {
+  getAttestationsForBlock(state: CachedBeaconStateAllForks): phase0.Attestation[] {
     const stateSlot = state.slot;
     const stateEpoch = state.currentShuffling.epoch;
     const statePrevEpoch = stateEpoch - 1;
@@ -182,9 +182,9 @@ export class AggregatedAttestationPool {
    * As we are close to altair, this is not really important, it's mainly for e2e.
    * The performance is not great due to the different BeaconState data structure to altair.
    */
-  private getParticipationPhase0(state: BeaconStateCachedAllForks): GetParticipationFn {
+  private getParticipationPhase0(state: CachedBeaconStateAllForks): GetParticipationFn {
     // check for phase0 block already
-    const phase0State = state as BeaconStateCachedPhase0;
+    const phase0State = state as CachedBeaconStatePhase0;
     const {epochCtx} = phase0State;
     const stateEpoch = computeEpochAtSlot(state.slot);
 
@@ -205,9 +205,9 @@ export class AggregatedAttestationPool {
    * Attestations are sorted by inclusion distance then number of attesters.
    * Attestations should pass the validation when processing attestations in beacon-state-transition.
    */
-  private getParticipationAltair(state: BeaconStateCachedAllForks): GetParticipationFn {
+  private getParticipationAltair(state: CachedBeaconStateAllForks): GetParticipationFn {
     // check for altair block already
-    const altairState = state as BeaconStateCachedAltair;
+    const altairState = state as CachedBeaconStateAltair;
     const stateEpoch = computeEpochAtSlot(state.slot);
     const previousParticipation = altairState.previousEpochParticipation.persistent.toArray();
     const currentParticipation = altairState.currentEpochParticipation.persistent.toArray();

--- a/packages/lodestar/src/chain/opPools/opPool.ts
+++ b/packages/lodestar/src/chain/opPools/opPool.ts
@@ -1,5 +1,5 @@
 import {
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   computeEpochAtSlot,
   allForks,
   getAttesterSlashableIndices,
@@ -118,7 +118,7 @@ export class OpPool {
    * slashings included earlier in the block.
    */
   getSlashingsAndExits(
-    state: BeaconStateCachedAllForks
+    state: CachedBeaconStateAllForks
   ): [phase0.AttesterSlashing[], phase0.ProposerSlashing[], phase0.SignedVoluntaryExit[]] {
     const stateEpoch = computeEpochAtSlot(state.slot);
     const toBeSlashedIndices = new Set<ValidatorIndex>();

--- a/packages/lodestar/src/chain/opPools/opPool.ts
+++ b/packages/lodestar/src/chain/opPools/opPool.ts
@@ -1,5 +1,5 @@
 import {
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
   computeEpochAtSlot,
   allForks,
   getAttesterSlashableIndices,
@@ -118,7 +118,7 @@ export class OpPool {
    * slashings included earlier in the block.
    */
   getSlashingsAndExits(
-    state: CachedBeaconState<allForks.BeaconState>
+    state: BeaconStateCachedAllForks
   ): [phase0.AttesterSlashing[], phase0.ProposerSlashing[], phase0.SignedVoluntaryExit[]] {
     const stateEpoch = computeEpochAtSlot(state.slot);
     const toBeSlashedIndices = new Set<ValidatorIndex>();

--- a/packages/lodestar/src/chain/regen/interface.ts
+++ b/packages/lodestar/src/chain/regen/interface.ts
@@ -1,5 +1,5 @@
 import {allForks, phase0, Slot, RootHex} from "@chainsafe/lodestar-types";
-import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 
 export enum RegenCaller {
   getDuties = "getDuties",
@@ -28,25 +28,21 @@ export interface IStateRegenerator {
    * Return a valid pre-state for a beacon block
    * This will always return a state in the latest viable epoch
    */
-  getPreState(block: allForks.BeaconBlock, rCaller: RegenCaller): Promise<CachedBeaconState<allForks.BeaconState>>;
+  getPreState(block: allForks.BeaconBlock, rCaller: RegenCaller): Promise<BeaconStateCachedAllForks>;
 
   /**
    * Return a valid checkpoint state
    * This will always return a state with `state.slot % SLOTS_PER_EPOCH === 0`
    */
-  getCheckpointState(cp: phase0.Checkpoint, rCaller: RegenCaller): Promise<CachedBeaconState<allForks.BeaconState>>;
+  getCheckpointState(cp: phase0.Checkpoint, rCaller: RegenCaller): Promise<BeaconStateCachedAllForks>;
 
   /**
    * Return the state of `blockRoot` processed to slot `slot`
    */
-  getBlockSlotState(
-    blockRoot: RootHex,
-    slot: Slot,
-    rCaller: RegenCaller
-  ): Promise<CachedBeaconState<allForks.BeaconState>>;
+  getBlockSlotState(blockRoot: RootHex, slot: Slot, rCaller: RegenCaller): Promise<BeaconStateCachedAllForks>;
 
   /**
    * Return the exact state with `stateRoot`
    */
-  getState(stateRoot: RootHex, rCaller: RegenCaller): Promise<CachedBeaconState<allForks.BeaconState>>;
+  getState(stateRoot: RootHex, rCaller: RegenCaller): Promise<BeaconStateCachedAllForks>;
 }

--- a/packages/lodestar/src/chain/regen/interface.ts
+++ b/packages/lodestar/src/chain/regen/interface.ts
@@ -1,5 +1,5 @@
 import {allForks, phase0, Slot, RootHex} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 
 export enum RegenCaller {
   getDuties = "getDuties",
@@ -28,21 +28,21 @@ export interface IStateRegenerator {
    * Return a valid pre-state for a beacon block
    * This will always return a state in the latest viable epoch
    */
-  getPreState(block: allForks.BeaconBlock, rCaller: RegenCaller): Promise<BeaconStateCachedAllForks>;
+  getPreState(block: allForks.BeaconBlock, rCaller: RegenCaller): Promise<CachedBeaconStateAllForks>;
 
   /**
    * Return a valid checkpoint state
    * This will always return a state with `state.slot % SLOTS_PER_EPOCH === 0`
    */
-  getCheckpointState(cp: phase0.Checkpoint, rCaller: RegenCaller): Promise<BeaconStateCachedAllForks>;
+  getCheckpointState(cp: phase0.Checkpoint, rCaller: RegenCaller): Promise<CachedBeaconStateAllForks>;
 
   /**
    * Return the state of `blockRoot` processed to slot `slot`
    */
-  getBlockSlotState(blockRoot: RootHex, slot: Slot, rCaller: RegenCaller): Promise<BeaconStateCachedAllForks>;
+  getBlockSlotState(blockRoot: RootHex, slot: Slot, rCaller: RegenCaller): Promise<CachedBeaconStateAllForks>;
 
   /**
    * Return the exact state with `stateRoot`
    */
-  getState(stateRoot: RootHex, rCaller: RegenCaller): Promise<BeaconStateCachedAllForks>;
+  getState(stateRoot: RootHex, rCaller: RegenCaller): Promise<CachedBeaconStateAllForks>;
 }

--- a/packages/lodestar/src/chain/regen/queued.ts
+++ b/packages/lodestar/src/chain/regen/queued.ts
@@ -1,7 +1,7 @@
 import {AbortSignal} from "@chainsafe/abort-controller";
 import {phase0, Slot, allForks, RootHex} from "@chainsafe/lodestar-types";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {CachedBeaconState, computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks, computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {CheckpointStateCache, StateContextCache, toCheckpointHex} from "../stateCache";
 import {IMetrics} from "../../metrics";
 import {JobItemQueue} from "../../util/queue";
@@ -26,7 +26,7 @@ export type RegenRequest = RegenRequestByKey[RegenRequestKey];
  * All requests are queued so that only a single state at a time may be regenerated at a time
  */
 export class QueuedStateRegenerator implements IStateRegenerator {
-  readonly jobQueue: JobItemQueue<[RegenRequest], CachedBeaconState<allForks.BeaconState>>;
+  readonly jobQueue: JobItemQueue<[RegenRequest], BeaconStateCachedAllForks>;
   private regen: StateRegenerator;
 
   private forkChoice: IForkChoice;
@@ -36,7 +36,7 @@ export class QueuedStateRegenerator implements IStateRegenerator {
 
   constructor(modules: QueuedStateRegeneratorModules) {
     this.regen = new StateRegenerator(modules);
-    this.jobQueue = new JobItemQueue<[RegenRequest], CachedBeaconState<allForks.BeaconState>>(
+    this.jobQueue = new JobItemQueue<[RegenRequest], BeaconStateCachedAllForks>(
       this.jobQueueProcessor,
       {maxLength: REGEN_QUEUE_MAX_LEN, signal: modules.signal},
       modules.metrics ? modules.metrics.regenQueue : undefined
@@ -51,10 +51,7 @@ export class QueuedStateRegenerator implements IStateRegenerator {
    * Get the state to run with `block`.
    * - State after `block.parentRoot` dialed forward to block.slot
    */
-  async getPreState(
-    block: allForks.BeaconBlock,
-    rCaller: RegenCaller
-  ): Promise<CachedBeaconState<allForks.BeaconState>> {
+  async getPreState(block: allForks.BeaconBlock, rCaller: RegenCaller): Promise<BeaconStateCachedAllForks> {
     this.metrics?.regenFnCallTotal.inc({caller: rCaller, entrypoint: RegenFnName.getPreState});
 
     // First attempt to fetch the state from caches before queueing
@@ -93,10 +90,7 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     return this.jobQueue.push({key: "getPreState", args: [block, rCaller]});
   }
 
-  async getCheckpointState(
-    cp: phase0.Checkpoint,
-    rCaller: RegenCaller
-  ): Promise<CachedBeaconState<allForks.BeaconState>> {
+  async getCheckpointState(cp: phase0.Checkpoint, rCaller: RegenCaller): Promise<BeaconStateCachedAllForks> {
     this.metrics?.regenFnCallTotal.inc({caller: rCaller, entrypoint: RegenFnName.getCheckpointState});
 
     // First attempt to fetch the state from cache before queueing
@@ -110,18 +104,14 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     return this.jobQueue.push({key: "getCheckpointState", args: [cp, rCaller]});
   }
 
-  async getBlockSlotState(
-    blockRoot: RootHex,
-    slot: Slot,
-    rCaller: RegenCaller
-  ): Promise<CachedBeaconState<allForks.BeaconState>> {
+  async getBlockSlotState(blockRoot: RootHex, slot: Slot, rCaller: RegenCaller): Promise<BeaconStateCachedAllForks> {
     this.metrics?.regenFnCallTotal.inc({caller: rCaller, entrypoint: RegenFnName.getBlockSlotState});
 
     // The state is not immediately available in the caches, enqueue the job
     return this.jobQueue.push({key: "getBlockSlotState", args: [blockRoot, slot, rCaller]});
   }
 
-  async getState(stateRoot: RootHex, rCaller: RegenCaller): Promise<CachedBeaconState<allForks.BeaconState>> {
+  async getState(stateRoot: RootHex, rCaller: RegenCaller): Promise<BeaconStateCachedAllForks> {
     this.metrics?.regenFnCallTotal.inc({caller: rCaller, entrypoint: RegenFnName.getState});
 
     // First attempt to fetch the state from cache before queueing
@@ -135,7 +125,7 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     return this.jobQueue.push({key: "getState", args: [stateRoot, rCaller]});
   }
 
-  private jobQueueProcessor = async (regenRequest: RegenRequest): Promise<CachedBeaconState<allForks.BeaconState>> => {
+  private jobQueueProcessor = async (regenRequest: RegenRequest): Promise<BeaconStateCachedAllForks> => {
     const metricsLabels = {
       caller: regenRequest.args[regenRequest.args.length - 1] as RegenCaller,
       entrypoint: regenRequest.key,

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -1,7 +1,7 @@
 import {phase0, Slot, RootHex} from "@chainsafe/lodestar-types";
 import {
   allForks,
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
 } from "@chainsafe/lodestar-beacon-state-transition";
@@ -39,10 +39,7 @@ export class StateRegenerator implements IStateRegenerator {
    * - If parent is in same epoch -> Exact state at `block.parentRoot`
    * - If parent is in prev epoch -> State after `block.parentRoot` dialed forward through epoch transition
    */
-  async getPreState(
-    block: allForks.BeaconBlock,
-    rCaller: RegenCaller
-  ): Promise<CachedBeaconState<allForks.BeaconState>> {
+  async getPreState(block: allForks.BeaconBlock, rCaller: RegenCaller): Promise<BeaconStateCachedAllForks> {
     const parentBlock = this.modules.forkChoice.getBlock(block.parentRoot);
     if (!parentBlock) {
       throw new RegenError({
@@ -70,10 +67,7 @@ export class StateRegenerator implements IStateRegenerator {
   /**
    * Get state after block `cp.root` dialed forward to first slot of `cp.epoch`
    */
-  async getCheckpointState(
-    cp: phase0.Checkpoint,
-    rCaller: RegenCaller
-  ): Promise<CachedBeaconState<allForks.BeaconState>> {
+  async getCheckpointState(cp: phase0.Checkpoint, rCaller: RegenCaller): Promise<BeaconStateCachedAllForks> {
     const checkpointStartSlot = computeStartSlotAtEpoch(cp.epoch);
     return await this.getBlockSlotState(toHexString(cp.root), checkpointStartSlot, rCaller);
   }
@@ -81,11 +75,7 @@ export class StateRegenerator implements IStateRegenerator {
   /**
    * Get state after block `blockRoot` dialed forward to `slot`
    */
-  async getBlockSlotState(
-    blockRoot: RootHex,
-    slot: Slot,
-    rCaller: RegenCaller
-  ): Promise<CachedBeaconState<allForks.BeaconState>> {
+  async getBlockSlotState(blockRoot: RootHex, slot: Slot, rCaller: RegenCaller): Promise<BeaconStateCachedAllForks> {
     const block = this.modules.forkChoice.getBlockHex(blockRoot);
     if (!block) {
       throw new RegenError({
@@ -121,7 +111,7 @@ export class StateRegenerator implements IStateRegenerator {
    * Get state by exact root. If not in cache directly, requires finding the block that references the state from the
    * forkchoice and replaying blocks to get to it.
    */
-  async getState(stateRoot: RootHex, _rCaller: RegenCaller): Promise<CachedBeaconState<allForks.BeaconState>> {
+  async getState(stateRoot: RootHex, _rCaller: RegenCaller): Promise<BeaconStateCachedAllForks> {
     // Trivial case, state at stateRoot is already cached
     const cachedStateCtx = this.modules.stateCache.get(stateRoot);
     if (cachedStateCtx) {
@@ -136,7 +126,7 @@ export class StateRegenerator implements IStateRegenerator {
     // blocks to replay, ordered highest to lowest
     // gets reversed when replayed
     const blocksToReplay = [block];
-    let state: CachedBeaconState<allForks.BeaconState> | null = null;
+    let state: BeaconStateCachedAllForks | null = null;
     for (const b of this.modules.forkChoice.iterateAncestorBlocks(block.parentRoot)) {
       state = this.modules.stateCache.get(b.stateRoot);
       if (state) {
@@ -206,7 +196,7 @@ export class StateRegenerator implements IStateRegenerator {
       }
     }
 
-    return state as CachedBeaconState<allForks.BeaconState>;
+    return state as BeaconStateCachedAllForks;
   }
 
   private findFirstStateBlock(stateRoot: RootHex): IProtoBlock {
@@ -230,9 +220,9 @@ export class StateRegenerator implements IStateRegenerator {
  */
 async function processSlotsByCheckpoint(
   modules: {checkpointStateCache: CheckpointStateCache; metrics: IMetrics | null; emitter: ChainEventEmitter},
-  preState: CachedBeaconState<allForks.BeaconState>,
+  preState: BeaconStateCachedAllForks,
   slot: Slot
-): Promise<CachedBeaconState<allForks.BeaconState>> {
+): Promise<BeaconStateCachedAllForks> {
   let postState = await processSlotsToNearestCheckpoint(modules, preState, slot);
   if (postState.slot < slot) {
     postState = allForks.processSlots(postState, slot, modules.metrics);
@@ -249,9 +239,9 @@ async function processSlotsByCheckpoint(
  */
 async function processSlotsToNearestCheckpoint(
   modules: {checkpointStateCache: CheckpointStateCache; metrics: IMetrics | null; emitter: ChainEventEmitter},
-  preState: CachedBeaconState<allForks.BeaconState>,
+  preState: BeaconStateCachedAllForks,
   slot: Slot
-): Promise<CachedBeaconState<allForks.BeaconState>> {
+): Promise<BeaconStateCachedAllForks> {
   const preSlot = preState.slot;
   const postSlot = slot;
   const preEpoch = computeEpochAtSlot(preSlot);

--- a/packages/lodestar/src/chain/stateCache/stateContextCache.ts
+++ b/packages/lodestar/src/chain/stateCache/stateContextCache.ts
@@ -1,6 +1,6 @@
 import {ByteVector, toHexString} from "@chainsafe/ssz";
 import {Epoch, RootHex} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {routes} from "@chainsafe/lodestar-api";
 import {IMetrics} from "../../metrics";
 import {MapTracker} from "./mapMetrics";
@@ -18,7 +18,7 @@ export class StateContextCache {
    */
   readonly maxStates: number;
 
-  private readonly cache: MapTracker<string, BeaconStateCachedAllForks>;
+  private readonly cache: MapTracker<string, CachedBeaconStateAllForks>;
   /** Epoch -> Set<blockRoot> */
   private readonly epochIndex = new Map<Epoch, Set<string>>();
   private readonly metrics: IMetrics["stateCache"] | null | undefined;
@@ -32,7 +32,7 @@ export class StateContextCache {
     }
   }
 
-  get(rootHex: RootHex): BeaconStateCachedAllForks | null {
+  get(rootHex: RootHex): CachedBeaconStateAllForks | null {
     this.metrics?.lookups.inc();
     const item = this.cache.get(rootHex);
     if (!item) {
@@ -42,7 +42,7 @@ export class StateContextCache {
     return item.clone();
   }
 
-  add(item: BeaconStateCachedAllForks): void {
+  add(item: CachedBeaconStateAllForks): void {
     const key = toHexString(item.hashTreeRoot());
     if (this.cache.get(key)) {
       return;

--- a/packages/lodestar/src/chain/stateCache/stateContextCache.ts
+++ b/packages/lodestar/src/chain/stateCache/stateContextCache.ts
@@ -1,6 +1,6 @@
 import {ByteVector, toHexString} from "@chainsafe/ssz";
-import {Epoch, allForks, RootHex} from "@chainsafe/lodestar-types";
-import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {Epoch, RootHex} from "@chainsafe/lodestar-types";
+import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {routes} from "@chainsafe/lodestar-api";
 import {IMetrics} from "../../metrics";
 import {MapTracker} from "./mapMetrics";
@@ -18,7 +18,7 @@ export class StateContextCache {
    */
   readonly maxStates: number;
 
-  private readonly cache: MapTracker<string, CachedBeaconState<allForks.BeaconState>>;
+  private readonly cache: MapTracker<string, BeaconStateCachedAllForks>;
   /** Epoch -> Set<blockRoot> */
   private readonly epochIndex = new Map<Epoch, Set<string>>();
   private readonly metrics: IMetrics["stateCache"] | null | undefined;
@@ -32,7 +32,7 @@ export class StateContextCache {
     }
   }
 
-  get(rootHex: RootHex): CachedBeaconState<allForks.BeaconState> | null {
+  get(rootHex: RootHex): BeaconStateCachedAllForks | null {
     this.metrics?.lookups.inc();
     const item = this.cache.get(rootHex);
     if (!item) {
@@ -42,7 +42,7 @@ export class StateContextCache {
     return item.clone();
   }
 
-  add(item: CachedBeaconState<allForks.BeaconState>): void {
+  add(item: BeaconStateCachedAllForks): void {
     const key = toHexString(item.hashTreeRoot());
     if (this.cache.get(key)) {
       return;

--- a/packages/lodestar/src/chain/stateCache/stateContextCheckpointsCache.ts
+++ b/packages/lodestar/src/chain/stateCache/stateContextCheckpointsCache.ts
@@ -1,6 +1,6 @@
 import {toHexString} from "@chainsafe/ssz";
 import {phase0, Epoch, RootHex} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {routes} from "@chainsafe/lodestar-api";
 import {IMetrics} from "../../metrics";
 import {MapTracker} from "./mapMetrics";
@@ -16,7 +16,7 @@ const MAX_EPOCHS = 10;
  * Similar API to Repository
  */
 export class CheckpointStateCache {
-  private readonly cache: MapTracker<string, BeaconStateCachedAllForks>;
+  private readonly cache: MapTracker<string, CachedBeaconStateAllForks>;
   /** Epoch -> Set<blockRoot> */
   private readonly epochIndex = new MapDef<Epoch, Set<string>>(() => new Set<string>());
   private readonly metrics: IMetrics["cpStateCache"] | null | undefined;
@@ -32,7 +32,7 @@ export class CheckpointStateCache {
     }
   }
 
-  get(cp: CheckpointHex): BeaconStateCachedAllForks | null {
+  get(cp: CheckpointHex): CachedBeaconStateAllForks | null {
     this.metrics?.lookups.inc();
     const cpKey = toCheckpointKey(cp);
     const item = this.cache.get(cpKey);
@@ -45,7 +45,7 @@ export class CheckpointStateCache {
     return item ? item.clone() : null;
   }
 
-  add(cp: phase0.Checkpoint, item: BeaconStateCachedAllForks): void {
+  add(cp: phase0.Checkpoint, item: CachedBeaconStateAllForks): void {
     const cpHex = toCheckpointHex(cp);
     const key = toCheckpointKey(cpHex);
     if (this.cache.has(key)) {
@@ -59,7 +59,7 @@ export class CheckpointStateCache {
   /**
    * Searches for the latest cached state with a `root`, starting with `epoch` and descending
    */
-  getLatest(rootHex: RootHex, maxEpoch: Epoch): BeaconStateCachedAllForks | null {
+  getLatest(rootHex: RootHex, maxEpoch: Epoch): CachedBeaconStateAllForks | null {
     // sort epochs in descending order, only consider epochs lte `epoch`
     const epochs = Array.from(this.epochIndex.keys())
       .sort((a, b) => b - a)

--- a/packages/lodestar/src/chain/stateCache/stateContextCheckpointsCache.ts
+++ b/packages/lodestar/src/chain/stateCache/stateContextCheckpointsCache.ts
@@ -1,6 +1,6 @@
 import {toHexString} from "@chainsafe/ssz";
-import {phase0, Epoch, allForks, RootHex} from "@chainsafe/lodestar-types";
-import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {phase0, Epoch, RootHex} from "@chainsafe/lodestar-types";
+import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {routes} from "@chainsafe/lodestar-api";
 import {IMetrics} from "../../metrics";
 import {MapTracker} from "./mapMetrics";
@@ -16,7 +16,7 @@ const MAX_EPOCHS = 10;
  * Similar API to Repository
  */
 export class CheckpointStateCache {
-  private readonly cache: MapTracker<string, CachedBeaconState<allForks.BeaconState>>;
+  private readonly cache: MapTracker<string, BeaconStateCachedAllForks>;
   /** Epoch -> Set<blockRoot> */
   private readonly epochIndex = new MapDef<Epoch, Set<string>>(() => new Set<string>());
   private readonly metrics: IMetrics["cpStateCache"] | null | undefined;
@@ -32,7 +32,7 @@ export class CheckpointStateCache {
     }
   }
 
-  get(cp: CheckpointHex): CachedBeaconState<allForks.BeaconState> | null {
+  get(cp: CheckpointHex): BeaconStateCachedAllForks | null {
     this.metrics?.lookups.inc();
     const cpKey = toCheckpointKey(cp);
     const item = this.cache.get(cpKey);
@@ -45,7 +45,7 @@ export class CheckpointStateCache {
     return item ? item.clone() : null;
   }
 
-  add(cp: phase0.Checkpoint, item: CachedBeaconState<allForks.BeaconState>): void {
+  add(cp: phase0.Checkpoint, item: BeaconStateCachedAllForks): void {
     const cpHex = toCheckpointHex(cp);
     const key = toCheckpointKey(cpHex);
     if (this.cache.has(key)) {
@@ -59,7 +59,7 @@ export class CheckpointStateCache {
   /**
    * Searches for the latest cached state with a `root`, starting with `epoch` and descending
    */
-  getLatest(rootHex: RootHex, maxEpoch: Epoch): CachedBeaconState<allForks.BeaconState> | null {
+  getLatest(rootHex: RootHex, maxEpoch: Epoch): BeaconStateCachedAllForks | null {
     // sort epochs in descending order, only consider epochs lte `epoch`
     const epochs = Array.from(this.epochIndex.keys())
       .sort((a, b) => b - a)

--- a/packages/lodestar/src/chain/validation/attestation.ts
+++ b/packages/lodestar/src/chain/validation/attestation.ts
@@ -9,7 +9,7 @@ import {
   getSingleBitIndex,
   AggregationBitsError,
   AggregationBitsErrorCode,
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconChain} from "..";
 import {AttestationError, AttestationErrorCode, GossipAction} from "../errors";
@@ -288,7 +288,7 @@ function verifyAttestationTargetRoot(headBlock: IProtoBlock, targetRoot: Root, a
 }
 
 export function getCommitteeIndices(
-  attestationTargetState: BeaconStateCachedAllForks,
+  attestationTargetState: CachedBeaconStateAllForks,
   attestationSlot: Slot,
   attestationIndex: number
 ): number[] {

--- a/packages/lodestar/src/chain/validation/attestation.ts
+++ b/packages/lodestar/src/chain/validation/attestation.ts
@@ -9,6 +9,7 @@ import {
   getSingleBitIndex,
   AggregationBitsError,
   AggregationBitsErrorCode,
+  BeaconStateCachedAllForks,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconChain} from "..";
 import {AttestationError, AttestationErrorCode, GossipAction} from "../errors";
@@ -287,7 +288,7 @@ function verifyAttestationTargetRoot(headBlock: IProtoBlock, targetRoot: Root, a
 }
 
 export function getCommitteeIndices(
-  attestationTargetState: allForks.CachedBeaconState<allForks.BeaconState>,
+  attestationTargetState: BeaconStateCachedAllForks,
   attestationSlot: Slot,
   attestationIndex: number
 ): number[] {

--- a/packages/lodestar/src/chain/validation/signatureSets/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/signatureSets/aggregateAndProof.ts
@@ -3,7 +3,7 @@ import {ssz} from "@chainsafe/lodestar-types";
 import {Epoch, phase0} from "@chainsafe/lodestar-types";
 import {PublicKey} from "@chainsafe/bls";
 import {
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   computeSigningRoot,
   computeStartSlotAtEpoch,
   ISignatureSet,
@@ -11,7 +11,7 @@ import {
 } from "@chainsafe/lodestar-beacon-state-transition";
 
 export function getAggregateAndProofSignatureSet(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   epoch: Epoch,
   aggregator: PublicKey,
   aggregateAndProof: phase0.SignedAggregateAndProof

--- a/packages/lodestar/src/chain/validation/signatureSets/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/signatureSets/aggregateAndProof.ts
@@ -3,7 +3,7 @@ import {ssz} from "@chainsafe/lodestar-types";
 import {Epoch, phase0} from "@chainsafe/lodestar-types";
 import {PublicKey} from "@chainsafe/bls";
 import {
-  allForks,
+  BeaconStateCachedAllForks,
   computeSigningRoot,
   computeStartSlotAtEpoch,
   ISignatureSet,
@@ -11,7 +11,7 @@ import {
 } from "@chainsafe/lodestar-beacon-state-transition";
 
 export function getAggregateAndProofSignatureSet(
-  state: allForks.CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   epoch: Epoch,
   aggregator: PublicKey,
   aggregateAndProof: phase0.SignedAggregateAndProof

--- a/packages/lodestar/src/chain/validation/signatureSets/contributionAndProof.ts
+++ b/packages/lodestar/src/chain/validation/signatureSets/contributionAndProof.ts
@@ -1,14 +1,14 @@
 import {DOMAIN_CONTRIBUTION_AND_PROOF} from "@chainsafe/lodestar-params";
-import {allForks, altair, ssz} from "@chainsafe/lodestar-types";
+import {altair, ssz} from "@chainsafe/lodestar-types";
 import {
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
   computeSigningRoot,
   ISignatureSet,
   SignatureSetType,
 } from "@chainsafe/lodestar-beacon-state-transition";
 
 export function getContributionAndProofSignatureSet(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   signedContributionAndProof: altair.SignedContributionAndProof
 ): ISignatureSet {
   const {epochCtx} = state;

--- a/packages/lodestar/src/chain/validation/signatureSets/contributionAndProof.ts
+++ b/packages/lodestar/src/chain/validation/signatureSets/contributionAndProof.ts
@@ -1,14 +1,14 @@
 import {DOMAIN_CONTRIBUTION_AND_PROOF} from "@chainsafe/lodestar-params";
 import {altair, ssz} from "@chainsafe/lodestar-types";
 import {
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   computeSigningRoot,
   ISignatureSet,
   SignatureSetType,
 } from "@chainsafe/lodestar-beacon-state-transition";
 
 export function getContributionAndProofSignatureSet(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   signedContributionAndProof: altair.SignedContributionAndProof
 ): ISignatureSet {
   const {epochCtx} = state;

--- a/packages/lodestar/src/chain/validation/signatureSets/selectionProof.ts
+++ b/packages/lodestar/src/chain/validation/signatureSets/selectionProof.ts
@@ -2,14 +2,14 @@ import {DOMAIN_SELECTION_PROOF} from "@chainsafe/lodestar-params";
 import {phase0, Slot, ssz} from "@chainsafe/lodestar-types";
 import {PublicKey} from "@chainsafe/bls";
 import {
-  allForks,
+  BeaconStateCachedAllForks,
   computeSigningRoot,
   ISignatureSet,
   SignatureSetType,
 } from "@chainsafe/lodestar-beacon-state-transition";
 
 export function getSelectionProofSignatureSet(
-  state: allForks.CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   slot: Slot,
   aggregator: PublicKey,
   aggregateAndProof: phase0.SignedAggregateAndProof

--- a/packages/lodestar/src/chain/validation/signatureSets/selectionProof.ts
+++ b/packages/lodestar/src/chain/validation/signatureSets/selectionProof.ts
@@ -2,14 +2,14 @@ import {DOMAIN_SELECTION_PROOF} from "@chainsafe/lodestar-params";
 import {phase0, Slot, ssz} from "@chainsafe/lodestar-types";
 import {PublicKey} from "@chainsafe/bls";
 import {
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   computeSigningRoot,
   ISignatureSet,
   SignatureSetType,
 } from "@chainsafe/lodestar-beacon-state-transition";
 
 export function getSelectionProofSignatureSet(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   slot: Slot,
   aggregator: PublicKey,
   aggregateAndProof: phase0.SignedAggregateAndProof

--- a/packages/lodestar/src/chain/validation/signatureSets/syncCommittee.ts
+++ b/packages/lodestar/src/chain/validation/signatureSets/syncCommittee.ts
@@ -1,14 +1,14 @@
 import {DOMAIN_SYNC_COMMITTEE} from "@chainsafe/lodestar-params";
 import {altair, ssz} from "@chainsafe/lodestar-types";
 import {
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   computeSigningRoot,
   ISignatureSet,
   SignatureSetType,
 } from "@chainsafe/lodestar-beacon-state-transition";
 
 export function getSyncCommitteeSignatureSet(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   syncCommittee: altair.SyncCommitteeMessage
 ): ISignatureSet {
   const domain = state.config.getDomain(DOMAIN_SYNC_COMMITTEE, syncCommittee.slot);

--- a/packages/lodestar/src/chain/validation/signatureSets/syncCommittee.ts
+++ b/packages/lodestar/src/chain/validation/signatureSets/syncCommittee.ts
@@ -1,14 +1,14 @@
 import {DOMAIN_SYNC_COMMITTEE} from "@chainsafe/lodestar-params";
-import {allForks, altair, ssz} from "@chainsafe/lodestar-types";
+import {altair, ssz} from "@chainsafe/lodestar-types";
 import {
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
   computeSigningRoot,
   ISignatureSet,
   SignatureSetType,
 } from "@chainsafe/lodestar-beacon-state-transition";
 
 export function getSyncCommitteeSignatureSet(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   syncCommittee: altair.SyncCommitteeMessage
 ): ISignatureSet {
   const domain = state.config.getDomain(DOMAIN_SYNC_COMMITTEE, syncCommittee.slot);

--- a/packages/lodestar/src/chain/validation/signatureSets/syncCommitteeContribution.ts
+++ b/packages/lodestar/src/chain/validation/signatureSets/syncCommitteeContribution.ts
@@ -4,14 +4,14 @@ import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {DOMAIN_SYNC_COMMITTEE, SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
 import {readonlyValues} from "@chainsafe/ssz";
 import {
-  CachedBeaconState,
+  BeaconStateCachedAltair,
   computeSigningRoot,
   ISignatureSet,
   SignatureSetType,
 } from "@chainsafe/lodestar-beacon-state-transition";
 
 export function getSyncCommitteeContributionSignatureSet(
-  state: CachedBeaconState<altair.BeaconState>,
+  state: BeaconStateCachedAltair,
   contribution: altair.SyncCommitteeContribution,
   pubkeys: PublicKey[]
 ): ISignatureSet {
@@ -30,7 +30,7 @@ export function getSyncCommitteeContributionSignatureSet(
  * - index2pubkey cache
  */
 export function getContributionPubkeys(
-  state: CachedBeaconState<altair.BeaconState>,
+  state: BeaconStateCachedAltair,
   contribution: altair.SyncCommitteeContribution
 ): PublicKey[] {
   const pubkeys: PublicKey[] = [];

--- a/packages/lodestar/src/chain/validation/signatureSets/syncCommitteeContribution.ts
+++ b/packages/lodestar/src/chain/validation/signatureSets/syncCommitteeContribution.ts
@@ -4,14 +4,14 @@ import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {DOMAIN_SYNC_COMMITTEE, SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
 import {readonlyValues} from "@chainsafe/ssz";
 import {
-  BeaconStateCachedAltair,
+  CachedBeaconStateAltair,
   computeSigningRoot,
   ISignatureSet,
   SignatureSetType,
 } from "@chainsafe/lodestar-beacon-state-transition";
 
 export function getSyncCommitteeContributionSignatureSet(
-  state: BeaconStateCachedAltair,
+  state: CachedBeaconStateAltair,
   contribution: altair.SyncCommitteeContribution,
   pubkeys: PublicKey[]
 ): ISignatureSet {
@@ -30,7 +30,7 @@ export function getSyncCommitteeContributionSignatureSet(
  * - index2pubkey cache
  */
 export function getContributionPubkeys(
-  state: BeaconStateCachedAltair,
+  state: CachedBeaconStateAltair,
   contribution: altair.SyncCommitteeContribution
 ): PublicKey[] {
   const pubkeys: PublicKey[] = [];

--- a/packages/lodestar/src/chain/validation/signatureSets/syncCommitteeSelectionProof.ts
+++ b/packages/lodestar/src/chain/validation/signatureSets/syncCommitteeSelectionProof.ts
@@ -1,14 +1,14 @@
 import {DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF} from "@chainsafe/lodestar-params";
-import {allForks, altair, ssz} from "@chainsafe/lodestar-types";
+import {altair, ssz} from "@chainsafe/lodestar-types";
 import {
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
   computeSigningRoot,
   ISignatureSet,
   SignatureSetType,
 } from "@chainsafe/lodestar-beacon-state-transition";
 
 export function getSyncCommitteeSelectionProofSignatureSet(
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   contributionAndProof: altair.ContributionAndProof
 ): ISignatureSet {
   const {epochCtx, config} = state;

--- a/packages/lodestar/src/chain/validation/signatureSets/syncCommitteeSelectionProof.ts
+++ b/packages/lodestar/src/chain/validation/signatureSets/syncCommitteeSelectionProof.ts
@@ -1,14 +1,14 @@
 import {DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF} from "@chainsafe/lodestar-params";
 import {altair, ssz} from "@chainsafe/lodestar-types";
 import {
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   computeSigningRoot,
   ISignatureSet,
   SignatureSetType,
 } from "@chainsafe/lodestar-beacon-state-transition";
 
 export function getSyncCommitteeSelectionProofSignatureSet(
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   contributionAndProof: altair.ContributionAndProof
 ): ISignatureSet {
   const {epochCtx, config} = state;

--- a/packages/lodestar/src/chain/validation/syncCommittee.ts
+++ b/packages/lodestar/src/chain/validation/syncCommittee.ts
@@ -1,4 +1,4 @@
-import {CachedBeaconState, allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
 import {altair} from "@chainsafe/lodestar-types";
 import {GossipAction, SyncCommitteeError, SyncCommitteeErrorCode} from "../errors";
@@ -54,7 +54,7 @@ export async function validateGossipSyncCommittee(
  */
 export async function validateSyncCommitteeSigOnly(
   chain: IBeaconChain,
-  headState: CachedBeaconState<allForks.BeaconState>,
+  headState: BeaconStateCachedAllForks,
   syncCommittee: altair.SyncCommitteeMessage
 ): Promise<void> {
   const signatureSet = getSyncCommitteeSignatureSet(headState, syncCommittee);
@@ -70,7 +70,7 @@ export async function validateSyncCommitteeSigOnly(
  */
 export function validateGossipSyncCommitteeExceptSig(
   chain: IBeaconChain,
-  headState: CachedBeaconState<allForks.BeaconState>,
+  headState: BeaconStateCachedAllForks,
   subnet: number,
   data: Pick<altair.SyncCommitteeMessage, "slot" | "validatorIndex">
 ): IndexInSubCommittee {
@@ -111,7 +111,7 @@ export function validateGossipSyncCommitteeExceptSig(
  * Returns `null` if not part of the sync committee or not part of the given `subnet`
  */
 function getIndexInSubCommittee(
-  headState: CachedBeaconState<allForks.BeaconState>,
+  headState: BeaconStateCachedAllForks,
   subnet: number,
   data: Pick<altair.SyncCommitteeMessage, "slot" | "validatorIndex">
 ): IndexInSubCommittee | null {

--- a/packages/lodestar/src/chain/validation/syncCommittee.ts
+++ b/packages/lodestar/src/chain/validation/syncCommittee.ts
@@ -1,4 +1,4 @@
-import {BeaconStateCachedAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
 import {altair} from "@chainsafe/lodestar-types";
 import {GossipAction, SyncCommitteeError, SyncCommitteeErrorCode} from "../errors";
@@ -54,7 +54,7 @@ export async function validateGossipSyncCommittee(
  */
 export async function validateSyncCommitteeSigOnly(
   chain: IBeaconChain,
-  headState: BeaconStateCachedAllForks,
+  headState: CachedBeaconStateAllForks,
   syncCommittee: altair.SyncCommitteeMessage
 ): Promise<void> {
   const signatureSet = getSyncCommitteeSignatureSet(headState, syncCommittee);
@@ -70,7 +70,7 @@ export async function validateSyncCommitteeSigOnly(
  */
 export function validateGossipSyncCommitteeExceptSig(
   chain: IBeaconChain,
-  headState: BeaconStateCachedAllForks,
+  headState: CachedBeaconStateAllForks,
   subnet: number,
   data: Pick<altair.SyncCommitteeMessage, "slot" | "validatorIndex">
 ): IndexInSubCommittee {
@@ -111,7 +111,7 @@ export function validateGossipSyncCommitteeExceptSig(
  * Returns `null` if not part of the sync committee or not part of the given `subnet`
  */
 function getIndexInSubCommittee(
-  headState: BeaconStateCachedAllForks,
+  headState: CachedBeaconStateAllForks,
   subnet: number,
   data: Pick<altair.SyncCommitteeMessage, "slot" | "validatorIndex">
 ): IndexInSubCommittee | null {

--- a/packages/lodestar/src/chain/validation/syncCommitteeContributionAndProof.ts
+++ b/packages/lodestar/src/chain/validation/syncCommitteeContributionAndProof.ts
@@ -1,4 +1,4 @@
-import {CachedBeaconState, isSyncCommitteeAggregator} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAltair, isSyncCommitteeAggregator} from "@chainsafe/lodestar-beacon-state-transition";
 import {altair} from "@chainsafe/lodestar-types";
 import {GossipAction, SyncCommitteeError, SyncCommitteeErrorCode} from "../errors";
 import {IBeaconChain} from "../interface";
@@ -44,7 +44,7 @@ export async function validateSyncCommitteeGossipContributionAndProof(
   }
 
   // [REJECT] The contribution has participants -- that is, any(contribution.aggregation_bits)
-  const pubkeys = getContributionPubkeys(headState as CachedBeaconState<altair.BeaconState>, contribution);
+  const pubkeys = getContributionPubkeys(headState as BeaconStateCachedAltair, contribution);
   if (!pubkeys.length) {
     throw new SyncCommitteeError(GossipAction.REJECT, {
       code: SyncCommitteeErrorCode.NO_PARTICIPANT,
@@ -74,7 +74,7 @@ export async function validateSyncCommitteeGossipContributionAndProof(
 
     // [REJECT] The aggregate signature is valid for the message beacon_block_root and aggregate pubkey derived from
     // the participation info in aggregation_bits for the subcommittee specified by the contribution.subcommittee_index.
-    getSyncCommitteeContributionSignatureSet(headState as CachedBeaconState<altair.BeaconState>, contribution, pubkeys),
+    getSyncCommitteeContributionSignatureSet(headState as BeaconStateCachedAltair, contribution, pubkeys),
   ];
 
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {

--- a/packages/lodestar/src/chain/validation/syncCommitteeContributionAndProof.ts
+++ b/packages/lodestar/src/chain/validation/syncCommitteeContributionAndProof.ts
@@ -1,4 +1,4 @@
-import {BeaconStateCachedAltair, isSyncCommitteeAggregator} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAltair, isSyncCommitteeAggregator} from "@chainsafe/lodestar-beacon-state-transition";
 import {altair} from "@chainsafe/lodestar-types";
 import {GossipAction, SyncCommitteeError, SyncCommitteeErrorCode} from "../errors";
 import {IBeaconChain} from "../interface";
@@ -44,7 +44,7 @@ export async function validateSyncCommitteeGossipContributionAndProof(
   }
 
   // [REJECT] The contribution has participants -- that is, any(contribution.aggregation_bits)
-  const pubkeys = getContributionPubkeys(headState as BeaconStateCachedAltair, contribution);
+  const pubkeys = getContributionPubkeys(headState as CachedBeaconStateAltair, contribution);
   if (!pubkeys.length) {
     throw new SyncCommitteeError(GossipAction.REJECT, {
       code: SyncCommitteeErrorCode.NO_PARTICIPANT,
@@ -74,7 +74,7 @@ export async function validateSyncCommitteeGossipContributionAndProof(
 
     // [REJECT] The aggregate signature is valid for the message beacon_block_root and aggregate pubkey derived from
     // the participation info in aggregation_bits for the subcommittee specified by the contribution.subcommittee_index.
-    getSyncCommitteeContributionSignatureSet(headState as BeaconStateCachedAltair, contribution, pubkeys),
+    getSyncCommitteeContributionSignatureSet(headState as CachedBeaconStateAltair, contribution, pubkeys),
   ];
 
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {

--- a/packages/lodestar/src/eth1/eth1DepositDataTracker.ts
+++ b/packages/lodestar/src/eth1/eth1DepositDataTracker.ts
@@ -1,6 +1,6 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
-import {CachedBeaconState, allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {ErrorAborted, ILogger, isErrorAborted, sleep} from "@chainsafe/lodestar-utils";
 import {AbortSignal} from "@chainsafe/abort-controller";
 import {IBeaconDb} from "../db";
@@ -72,7 +72,7 @@ export class Eth1DepositDataTracker {
   /**
    * Return eth1Data and deposits ready for block production for a given state
    */
-  async getEth1DataAndDeposits(state: CachedBeaconState<allForks.BeaconState>): Promise<Eth1DataAndDeposits> {
+  async getEth1DataAndDeposits(state: BeaconStateCachedAllForks): Promise<Eth1DataAndDeposits> {
     const eth1Data = await this.getEth1Data(state);
     const deposits = await this.getDeposits(state, eth1Data);
     return {eth1Data, deposits};
@@ -96,7 +96,7 @@ export class Eth1DepositDataTracker {
    * Requires internal caches to be updated regularly to return good results
    */
   private async getDeposits(
-    state: CachedBeaconState<allForks.BeaconState>,
+    state: BeaconStateCachedAllForks,
     eth1DataVote: phase0.Eth1Data
   ): Promise<phase0.Deposit[]> {
     // Eth1 data may change due to the vote included in this block

--- a/packages/lodestar/src/eth1/eth1DepositDataTracker.ts
+++ b/packages/lodestar/src/eth1/eth1DepositDataTracker.ts
@@ -1,6 +1,6 @@
 import {phase0} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
-import {BeaconStateCachedAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {ErrorAborted, ILogger, isErrorAborted, sleep} from "@chainsafe/lodestar-utils";
 import {AbortSignal} from "@chainsafe/abort-controller";
 import {IBeaconDb} from "../db";
@@ -72,7 +72,7 @@ export class Eth1DepositDataTracker {
   /**
    * Return eth1Data and deposits ready for block production for a given state
    */
-  async getEth1DataAndDeposits(state: BeaconStateCachedAllForks): Promise<Eth1DataAndDeposits> {
+  async getEth1DataAndDeposits(state: CachedBeaconStateAllForks): Promise<Eth1DataAndDeposits> {
     const eth1Data = await this.getEth1Data(state);
     const deposits = await this.getDeposits(state, eth1Data);
     return {eth1Data, deposits};
@@ -96,7 +96,7 @@ export class Eth1DepositDataTracker {
    * Requires internal caches to be updated regularly to return good results
    */
   private async getDeposits(
-    state: BeaconStateCachedAllForks,
+    state: CachedBeaconStateAllForks,
     eth1DataVote: phase0.Eth1Data
   ): Promise<phase0.Deposit[]> {
     // Eth1 data may change due to the vote included in this block

--- a/packages/lodestar/src/eth1/index.ts
+++ b/packages/lodestar/src/eth1/index.ts
@@ -1,4 +1,8 @@
-import {CachedBeaconState, computeEpochAtSlot, getCurrentSlot} from "@chainsafe/lodestar-beacon-state-transition";
+import {
+  BeaconStateCachedAllForks,
+  computeEpochAtSlot,
+  getCurrentSlot,
+} from "@chainsafe/lodestar-beacon-state-transition";
 import {allForks, Root} from "@chainsafe/lodestar-types";
 import {bellatrix} from "@chainsafe/lodestar-beacon-state-transition";
 import {fromHexString} from "@chainsafe/ssz";
@@ -77,7 +81,7 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
     this.eth1MergeBlockTracker = new Eth1MergeBlockTracker(modules, eth1Provider);
   }
 
-  async getEth1DataAndDeposits(state: CachedBeaconState<allForks.BeaconState>): Promise<Eth1DataAndDeposits> {
+  async getEth1DataAndDeposits(state: BeaconStateCachedAllForks): Promise<Eth1DataAndDeposits> {
     if (this.eth1DepositDataTracker === null) {
       return {eth1Data: state.eth1Data, deposits: []};
     } else {
@@ -108,7 +112,7 @@ export class Eth1ForBlockProductionDisabled implements IEth1ForBlockProduction {
    * Returns same eth1Data as in state and no deposits
    * May produce invalid blocks if deposits have to be added
    */
-  async getEth1DataAndDeposits(state: CachedBeaconState<allForks.BeaconState>): Promise<Eth1DataAndDeposits> {
+  async getEth1DataAndDeposits(state: BeaconStateCachedAllForks): Promise<Eth1DataAndDeposits> {
     return {eth1Data: state.eth1Data, deposits: []};
   }
 

--- a/packages/lodestar/src/eth1/index.ts
+++ b/packages/lodestar/src/eth1/index.ts
@@ -1,5 +1,5 @@
 import {
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   computeEpochAtSlot,
   getCurrentSlot,
 } from "@chainsafe/lodestar-beacon-state-transition";
@@ -81,7 +81,7 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
     this.eth1MergeBlockTracker = new Eth1MergeBlockTracker(modules, eth1Provider);
   }
 
-  async getEth1DataAndDeposits(state: BeaconStateCachedAllForks): Promise<Eth1DataAndDeposits> {
+  async getEth1DataAndDeposits(state: CachedBeaconStateAllForks): Promise<Eth1DataAndDeposits> {
     if (this.eth1DepositDataTracker === null) {
       return {eth1Data: state.eth1Data, deposits: []};
     } else {
@@ -112,7 +112,7 @@ export class Eth1ForBlockProductionDisabled implements IEth1ForBlockProduction {
    * Returns same eth1Data as in state and no deposits
    * May produce invalid blocks if deposits have to be added
    */
-  async getEth1DataAndDeposits(state: BeaconStateCachedAllForks): Promise<Eth1DataAndDeposits> {
+  async getEth1DataAndDeposits(state: CachedBeaconStateAllForks): Promise<Eth1DataAndDeposits> {
     return {eth1Data: state.eth1Data, deposits: []};
   }
 

--- a/packages/lodestar/src/eth1/interface.ts
+++ b/packages/lodestar/src/eth1/interface.ts
@@ -3,8 +3,8 @@
  */
 
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {allForks, phase0, Root, RootHex} from "@chainsafe/lodestar-types";
-import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {phase0, Root, RootHex} from "@chainsafe/lodestar-types";
+import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 
 export type EthJsonRpcBlockRaw = {
   /** the block number. null when its pending block. `"0x1b4"` */
@@ -41,7 +41,7 @@ export type Eth1DataAndDeposits = {
 };
 
 export interface IEth1ForBlockProduction {
-  getEth1DataAndDeposits(state: CachedBeaconState<allForks.BeaconState>): Promise<Eth1DataAndDeposits>;
+  getEth1DataAndDeposits(state: BeaconStateCachedAllForks): Promise<Eth1DataAndDeposits>;
 
   /** Returns the most recent POW block that satisfies the merge block condition */
   getTerminalPowBlock(): Root | null;

--- a/packages/lodestar/src/eth1/interface.ts
+++ b/packages/lodestar/src/eth1/interface.ts
@@ -4,7 +4,7 @@
 
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {phase0, Root, RootHex} from "@chainsafe/lodestar-types";
-import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 
 export type EthJsonRpcBlockRaw = {
   /** the block number. null when its pending block. `"0x1b4"` */
@@ -41,7 +41,7 @@ export type Eth1DataAndDeposits = {
 };
 
 export interface IEth1ForBlockProduction {
-  getEth1DataAndDeposits(state: BeaconStateCachedAllForks): Promise<Eth1DataAndDeposits>;
+  getEth1DataAndDeposits(state: CachedBeaconStateAllForks): Promise<Eth1DataAndDeposits>;
 
   /** Returns the most recent POW block that satisfies the merge block condition */
   getTerminalPowBlock(): Root | null;

--- a/packages/lodestar/src/sync/backfill/verify.ts
+++ b/packages/lodestar/src/sync/backfill/verify.ts
@@ -1,4 +1,4 @@
-import {allForks, CachedBeaconState, ISignatureSet} from "@chainsafe/lodestar-beacon-state-transition";
+import {allForks, BeaconStateCachedAllForks, ISignatureSet} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Root, allForks as allForkTypes, ssz, Slot} from "@chainsafe/lodestar-types";
 import {GENESIS_SLOT} from "@chainsafe/lodestar-params";
@@ -42,7 +42,7 @@ export function verifyBlockSequence(
 
 export async function verifyBlockProposerSignature(
   bls: IBlsVerifier,
-  state: CachedBeaconState<allForks.BeaconState>,
+  state: BeaconStateCachedAllForks,
   blocks: allForkTypes.SignedBeaconBlock[]
 ): Promise<void> {
   if (blocks.length === 1 && blocks[0].message.slot === GENESIS_SLOT) return;

--- a/packages/lodestar/src/sync/backfill/verify.ts
+++ b/packages/lodestar/src/sync/backfill/verify.ts
@@ -1,4 +1,4 @@
-import {allForks, BeaconStateCachedAllForks, ISignatureSet} from "@chainsafe/lodestar-beacon-state-transition";
+import {allForks, CachedBeaconStateAllForks, ISignatureSet} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Root, allForks as allForkTypes, ssz, Slot} from "@chainsafe/lodestar-types";
 import {GENESIS_SLOT} from "@chainsafe/lodestar-params";
@@ -42,7 +42,7 @@ export function verifyBlockSequence(
 
 export async function verifyBlockProposerSignature(
   bls: IBlsVerifier,
-  state: BeaconStateCachedAllForks,
+  state: CachedBeaconStateAllForks,
   blocks: allForkTypes.SignedBeaconBlock[]
 ): Promise<void> {
   if (blocks.length === 1 && blocks[0].message.slot === GENESIS_SLOT) return;

--- a/packages/lodestar/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/lodestar/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -1,7 +1,7 @@
 import {itBench} from "@dapplion/benchmark";
 import {expect} from "chai";
 import {
-  allForks,
+  BeaconStateCachedAllForks,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   getBlockRootAtSlot,
@@ -16,14 +16,14 @@ import {ssz} from "@chainsafe/lodestar-types";
 // getAttestationsForBlock
 //     ✓ getAttestationsForBlock                                             4.410948 ops/s    226.7086 ms/op        -         64 runs   51.8 s
 describe("getAttestationsForBlock", () => {
-  let originalState: allForks.CachedBeaconState<allForks.BeaconState>;
+  let originalState: BeaconStateCachedAllForks;
 
   before(function () {
     this.timeout(2 * 60 * 1000); // Generating the states for the first time is very slow
 
     originalState = (generatePerfTestCachedStateAltair({
       goBackOneSlot: true,
-    }) as unknown) as allForks.CachedBeaconState<allForks.BeaconState>;
+    }) as unknown) as BeaconStateCachedAllForks;
     const numPreviousEpochParticipation = originalState.previousEpochParticipation.persistent
       .toArray()
       .filter((part) => part.timelySource).length;
@@ -45,9 +45,7 @@ describe("getAttestationsForBlock", () => {
   });
 });
 
-function getAggregatedAttestationPool(
-  state: allForks.CachedBeaconState<allForks.BeaconState>
-): AggregatedAttestationPool {
+function getAggregatedAttestationPool(state: BeaconStateCachedAllForks): AggregatedAttestationPool {
   const pool = new AggregatedAttestationPool();
   for (let epochSlot = 0; epochSlot < SLOTS_PER_EPOCH; epochSlot++) {
     const slot = state.slot - 1 - epochSlot;

--- a/packages/lodestar/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/lodestar/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -1,7 +1,7 @@
 import {itBench} from "@dapplion/benchmark";
 import {expect} from "chai";
 import {
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   getBlockRootAtSlot,
@@ -16,14 +16,14 @@ import {ssz} from "@chainsafe/lodestar-types";
 // getAttestationsForBlock
 //     ✓ getAttestationsForBlock                                             4.410948 ops/s    226.7086 ms/op        -         64 runs   51.8 s
 describe("getAttestationsForBlock", () => {
-  let originalState: BeaconStateCachedAllForks;
+  let originalState: CachedBeaconStateAllForks;
 
   before(function () {
     this.timeout(2 * 60 * 1000); // Generating the states for the first time is very slow
 
     originalState = (generatePerfTestCachedStateAltair({
       goBackOneSlot: true,
-    }) as unknown) as BeaconStateCachedAllForks;
+    }) as unknown) as CachedBeaconStateAllForks;
     const numPreviousEpochParticipation = originalState.previousEpochParticipation.persistent
       .toArray()
       .filter((part) => part.timelySource).length;
@@ -45,7 +45,7 @@ describe("getAttestationsForBlock", () => {
   });
 });
 
-function getAggregatedAttestationPool(state: BeaconStateCachedAllForks): AggregatedAttestationPool {
+function getAggregatedAttestationPool(state: CachedBeaconStateAllForks): AggregatedAttestationPool {
   const pool = new AggregatedAttestationPool();
   for (let epochSlot = 0; epochSlot < SLOTS_PER_EPOCH; epochSlot++) {
     const slot = state.slot - 1 - epochSlot;

--- a/packages/lodestar/test/perf/chain/stateCache/stateContextCheckpointsCache.test.ts
+++ b/packages/lodestar/test/perf/chain/stateCache/stateContextCheckpointsCache.test.ts
@@ -1,13 +1,13 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
-import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
-import {allForks, ssz, phase0} from "@chainsafe/lodestar-types";
+import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {ssz, phase0} from "@chainsafe/lodestar-types";
 import {generateCachedState} from "../../../utils/state";
 import {CheckpointStateCache, toCheckpointHex} from "../../../../src/chain/stateCache";
 
 describe("CheckpointStateCache perf tests", function () {
   setBenchOpts({noThreshold: true});
 
-  let state: CachedBeaconState<allForks.BeaconState>;
+  let state: BeaconStateCachedAllForks;
   let checkpoint: phase0.Checkpoint;
   let checkpointStateCache: CheckpointStateCache;
 

--- a/packages/lodestar/test/perf/chain/stateCache/stateContextCheckpointsCache.test.ts
+++ b/packages/lodestar/test/perf/chain/stateCache/stateContextCheckpointsCache.test.ts
@@ -1,5 +1,5 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
-import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {ssz, phase0} from "@chainsafe/lodestar-types";
 import {generateCachedState} from "../../../utils/state";
 import {CheckpointStateCache, toCheckpointHex} from "../../../../src/chain/stateCache";
@@ -7,7 +7,7 @@ import {CheckpointStateCache, toCheckpointHex} from "../../../../src/chain/state
 describe("CheckpointStateCache perf tests", function () {
   setBenchOpts({noThreshold: true});
 
-  let state: BeaconStateCachedAllForks;
+  let state: CachedBeaconStateAllForks;
   let checkpoint: phase0.Checkpoint;
   let checkpointStateCache: CheckpointStateCache;
 

--- a/packages/lodestar/test/spec/allForks/epochProcessing.ts
+++ b/packages/lodestar/test/spec/allForks/epochProcessing.ts
@@ -1,7 +1,7 @@
 import {join} from "path";
 import fs from "fs";
 
-import {BeaconStateCachedAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util";
 import {ssz} from "@chainsafe/lodestar-types";
 import {TreeBacked} from "@chainsafe/ssz";
@@ -11,7 +11,7 @@ import {expectEqualBeaconState, inputTypeSszTreeBacked} from "../util";
 import {getConfig} from "./util";
 import {IBaseSpecTest} from "../type";
 
-export type EpochProcessFn = (state: BeaconStateCachedAllForks, epochProcess: allForks.IEpochProcess) => void;
+export type EpochProcessFn = (state: CachedBeaconStateAllForks, epochProcess: allForks.IEpochProcess) => void;
 
 type EpochProcessingStateTestCase = IBaseSpecTest & {
   pre: allForks.BeaconState;

--- a/packages/lodestar/test/spec/allForks/epochProcessing.ts
+++ b/packages/lodestar/test/spec/allForks/epochProcessing.ts
@@ -1,7 +1,7 @@
 import {join} from "path";
 import fs from "fs";
 
-import {CachedBeaconState, allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util";
 import {ssz} from "@chainsafe/lodestar-types";
 import {TreeBacked} from "@chainsafe/ssz";
@@ -11,10 +11,7 @@ import {expectEqualBeaconState, inputTypeSszTreeBacked} from "../util";
 import {getConfig} from "./util";
 import {IBaseSpecTest} from "../type";
 
-export type EpochProcessFn = (
-  state: CachedBeaconState<allForks.BeaconState>,
-  epochProcess: allForks.IEpochProcess
-) => void;
+export type EpochProcessFn = (state: BeaconStateCachedAllForks, epochProcess: allForks.IEpochProcess) => void;
 
 type EpochProcessingStateTestCase = IBaseSpecTest & {
   pre: allForks.BeaconState;

--- a/packages/lodestar/test/spec/allForks/finality.ts
+++ b/packages/lodestar/test/spec/allForks/finality.ts
@@ -1,6 +1,6 @@
 import {join} from "path";
 import {TreeBacked} from "@chainsafe/ssz";
-import {BeaconStateCachedAllForks, allForks, altair} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks, allForks, altair} from "@chainsafe/lodestar-beacon-state-transition";
 import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util";
 import {bellatrix, ssz, Uint64} from "@chainsafe/lodestar-types";
 import {ACTIVE_PRESET, ForkName} from "@chainsafe/lodestar-params";
@@ -18,7 +18,7 @@ export function finality(fork: ForkName): void {
       let wrappedState = allForks.createCachedBeaconState(
         getConfig(fork),
         testcase.pre as TreeBacked<allForks.BeaconState>
-      ) as BeaconStateCachedAllForks;
+      ) as CachedBeaconStateAllForks;
       const verify = testcase.meta !== undefined && testcase.meta.blsSetting === BigInt(1);
       for (let i = 0; i < Number(testcase.meta.blocksCount); i++) {
         const signedBlock = testcase[`blocks_${i}`] as bellatrix.SignedBeaconBlock;

--- a/packages/lodestar/test/spec/allForks/finality.ts
+++ b/packages/lodestar/test/spec/allForks/finality.ts
@@ -1,6 +1,6 @@
 import {join} from "path";
 import {TreeBacked} from "@chainsafe/ssz";
-import {CachedBeaconState, allForks, altair} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks, allForks, altair} from "@chainsafe/lodestar-beacon-state-transition";
 import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util";
 import {bellatrix, ssz, Uint64} from "@chainsafe/lodestar-types";
 import {ACTIVE_PRESET, ForkName} from "@chainsafe/lodestar-params";
@@ -18,7 +18,7 @@ export function finality(fork: ForkName): void {
       let wrappedState = allForks.createCachedBeaconState(
         getConfig(fork),
         testcase.pre as TreeBacked<allForks.BeaconState>
-      ) as CachedBeaconState<allForks.BeaconState>;
+      ) as BeaconStateCachedAllForks;
       const verify = testcase.meta !== undefined && testcase.meta.blsSetting === BigInt(1);
       for (let i = 0; i < Number(testcase.meta.blocksCount); i++) {
         const signedBlock = testcase[`blocks_${i}`] as bellatrix.SignedBeaconBlock;

--- a/packages/lodestar/test/spec/allForks/forkChoice.ts
+++ b/packages/lodestar/test/spec/allForks/forkChoice.ts
@@ -5,7 +5,7 @@ import {
   phase0,
   allForks,
   computeEpochAtSlot,
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
   ZERO_HASH,
   getEffectiveBalances,
   computeStartSlotAtEpoch,
@@ -49,7 +49,7 @@ export function forkChoiceTest(fork: ForkName): void {
         const forkchoice = initializeForkChoice(config, emitter, currentSlot, state, true);
 
         const checkpointStateCache = new CheckpointStateCache({});
-        const stateCache = new Map<string, CachedBeaconState<allForks.BeaconState>>();
+        const stateCache = new Map<string, BeaconStateCachedAllForks>();
         cacheState(state, stateCache);
 
         /** This is to track test's tickTime to be used in proposer boost */
@@ -179,12 +179,12 @@ export function forkChoiceTest(fork: ForkName): void {
 }
 
 function runStateTranstion(
-  preState: CachedBeaconState<allForks.BeaconState>,
+  preState: BeaconStateCachedAllForks,
   signedBlock: allForks.SignedBeaconBlock,
   forkchoice: IForkChoice,
   checkpointCache: CheckpointStateCache,
   blockDelaySec: number
-): CachedBeaconState<allForks.BeaconState> {
+): BeaconStateCachedAllForks {
   const preSlot = preState.slot;
   const postSlot = signedBlock.message.slot - 1;
   let preEpoch = computeEpochAtSlot(preSlot);
@@ -235,10 +235,7 @@ function runStateTranstion(
   return postState;
 }
 
-function cacheCheckpointState(
-  checkpointState: CachedBeaconState<allForks.BeaconState>,
-  checkpointCache: CheckpointStateCache
-): void {
+function cacheCheckpointState(checkpointState: BeaconStateCachedAllForks, checkpointCache: CheckpointStateCache): void {
   const config = checkpointState.config;
   const slot = checkpointState.slot;
   if (slot % SLOTS_PER_EPOCH !== 0) {
@@ -255,10 +252,7 @@ function cacheCheckpointState(
   checkpointCache.add(cp, checkpointState);
 }
 
-function cacheState(
-  wrappedState: CachedBeaconState<allForks.BeaconState>,
-  stateCache: Map<string, CachedBeaconState<allForks.BeaconState>>
-): void {
+function cacheState(wrappedState: BeaconStateCachedAllForks, stateCache: Map<string, BeaconStateCachedAllForks>): void {
   const blockHeader = ssz.phase0.BeaconBlockHeader.clone(wrappedState.latestBlockHeader);
   if (ssz.Root.equals(blockHeader.stateRoot, ZERO_HASH)) {
     blockHeader.stateRoot = wrappedState.hashTreeRoot();

--- a/packages/lodestar/test/spec/allForks/forkChoice.ts
+++ b/packages/lodestar/test/spec/allForks/forkChoice.ts
@@ -5,7 +5,7 @@ import {
   phase0,
   allForks,
   computeEpochAtSlot,
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   ZERO_HASH,
   getEffectiveBalances,
   computeStartSlotAtEpoch,
@@ -49,7 +49,7 @@ export function forkChoiceTest(fork: ForkName): void {
         const forkchoice = initializeForkChoice(config, emitter, currentSlot, state, true);
 
         const checkpointStateCache = new CheckpointStateCache({});
-        const stateCache = new Map<string, BeaconStateCachedAllForks>();
+        const stateCache = new Map<string, CachedBeaconStateAllForks>();
         cacheState(state, stateCache);
 
         /** This is to track test's tickTime to be used in proposer boost */
@@ -179,12 +179,12 @@ export function forkChoiceTest(fork: ForkName): void {
 }
 
 function runStateTranstion(
-  preState: BeaconStateCachedAllForks,
+  preState: CachedBeaconStateAllForks,
   signedBlock: allForks.SignedBeaconBlock,
   forkchoice: IForkChoice,
   checkpointCache: CheckpointStateCache,
   blockDelaySec: number
-): BeaconStateCachedAllForks {
+): CachedBeaconStateAllForks {
   const preSlot = preState.slot;
   const postSlot = signedBlock.message.slot - 1;
   let preEpoch = computeEpochAtSlot(preSlot);
@@ -235,7 +235,7 @@ function runStateTranstion(
   return postState;
 }
 
-function cacheCheckpointState(checkpointState: BeaconStateCachedAllForks, checkpointCache: CheckpointStateCache): void {
+function cacheCheckpointState(checkpointState: CachedBeaconStateAllForks, checkpointCache: CheckpointStateCache): void {
   const config = checkpointState.config;
   const slot = checkpointState.slot;
   if (slot % SLOTS_PER_EPOCH !== 0) {
@@ -252,7 +252,7 @@ function cacheCheckpointState(checkpointState: BeaconStateCachedAllForks, checkp
   checkpointCache.add(cp, checkpointState);
 }
 
-function cacheState(wrappedState: BeaconStateCachedAllForks, stateCache: Map<string, BeaconStateCachedAllForks>): void {
+function cacheState(wrappedState: CachedBeaconStateAllForks, stateCache: Map<string, CachedBeaconStateAllForks>): void {
   const blockHeader = ssz.phase0.BeaconBlockHeader.clone(wrappedState.latestBlockHeader);
   if (ssz.Root.equals(blockHeader.stateRoot, ZERO_HASH)) {
     blockHeader.stateRoot = wrappedState.hashTreeRoot();

--- a/packages/lodestar/test/spec/allForks/rewards.ts
+++ b/packages/lodestar/test/spec/allForks/rewards.ts
@@ -37,10 +37,7 @@ export function rewardsPhase0(fork: ForkName): void {
         const config = getConfig(fork);
         const wrappedState = allForks.createCachedBeaconState(config, testcase.pre as TreeBacked<allForks.BeaconState>);
         const epochProcess = allForks.beforeProcessEpoch(wrappedState);
-        return phase0.getAttestationDeltas(
-          wrappedState as allForks.CachedBeaconState<phase0.BeaconState>,
-          epochProcess
-        );
+        return phase0.getAttestationDeltas(wrappedState as allForks.BeaconStateCachedPhase0, epochProcess);
       },
       {
         inputTypes: inputTypeSszTreeBacked,

--- a/packages/lodestar/test/spec/allForks/rewards.ts
+++ b/packages/lodestar/test/spec/allForks/rewards.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import {join} from "path";
 import {expect} from "chai";
 import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util";
-import {altair, phase0, allForks, BeaconStateCachedPhase0} from "@chainsafe/lodestar-beacon-state-transition";
+import {altair, phase0, allForks, CachedBeaconStatePhase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {TreeBacked, VectorType} from "@chainsafe/ssz";
 import {ACTIVE_PRESET, ForkName} from "@chainsafe/lodestar-params";
 import {ssz} from "@chainsafe/lodestar-types";
@@ -37,7 +37,7 @@ export function rewardsPhase0(fork: ForkName): void {
         const config = getConfig(fork);
         const wrappedState = allForks.createCachedBeaconState(config, testcase.pre as TreeBacked<allForks.BeaconState>);
         const epochProcess = allForks.beforeProcessEpoch(wrappedState);
-        return phase0.getAttestationDeltas(wrappedState as BeaconStateCachedPhase0, epochProcess);
+        return phase0.getAttestationDeltas(wrappedState as CachedBeaconStatePhase0, epochProcess);
       },
       {
         inputTypes: inputTypeSszTreeBacked,

--- a/packages/lodestar/test/spec/allForks/rewards.ts
+++ b/packages/lodestar/test/spec/allForks/rewards.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import {join} from "path";
 import {expect} from "chai";
 import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util";
-import {altair, phase0, allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {altair, phase0, allForks, BeaconStateCachedPhase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {TreeBacked, VectorType} from "@chainsafe/ssz";
 import {ACTIVE_PRESET, ForkName} from "@chainsafe/lodestar-params";
 import {ssz} from "@chainsafe/lodestar-types";
@@ -37,7 +37,7 @@ export function rewardsPhase0(fork: ForkName): void {
         const config = getConfig(fork);
         const wrappedState = allForks.createCachedBeaconState(config, testcase.pre as TreeBacked<allForks.BeaconState>);
         const epochProcess = allForks.beforeProcessEpoch(wrappedState);
-        return phase0.getAttestationDeltas(wrappedState as allForks.BeaconStateCachedPhase0, epochProcess);
+        return phase0.getAttestationDeltas(wrappedState as BeaconStateCachedPhase0, epochProcess);
       },
       {
         inputTypes: inputTypeSszTreeBacked,

--- a/packages/lodestar/test/spec/altair/fork.test.ts
+++ b/packages/lodestar/test/spec/altair/fork.test.ts
@@ -14,10 +14,7 @@ describeDirectorySpecTest<IUpgradeStateCase, altair.BeaconState>(
   `${ACTIVE_PRESET}/altair/fork/fork`,
   join(SPEC_TEST_LOCATION, `/tests/${ACTIVE_PRESET}/altair/fork/fork/pyspec_tests`),
   (testcase) => {
-    const phase0State = allForks.createCachedBeaconState<phase0.BeaconState>(
-      config,
-      testcase.pre as TreeBacked<phase0.BeaconState>
-    );
+    const phase0State = allForks.createCachedBeaconState(config, testcase.pre as TreeBacked<phase0.BeaconState>);
     const altairState = altair.upgradeState(phase0State);
     // this test has a random slot so createCachedBeaconState is not able to create indexed sync committee
     const tbAltairState = altairState.type.createTreeBacked(altairState.tree);

--- a/packages/lodestar/test/spec/altair/operations.test.ts
+++ b/packages/lodestar/test/spec/altair/operations.test.ts
@@ -1,4 +1,4 @@
-import {CachedBeaconState, allForks, altair} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks, allForks, altair} from "@chainsafe/lodestar-beacon-state-transition";
 import {phase0, ssz} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 import {IBaseSpecTest} from "../type";
@@ -31,7 +31,7 @@ operations<altair.BeaconState>(ForkName.altair, {
   },
 
   block_header: (state, testCase: IBaseSpecTest & {block: altair.BeaconBlock}) => {
-    allForks.processBlockHeader(state as CachedBeaconState<allForks.BeaconState>, testCase.block);
+    allForks.processBlockHeader(state as BeaconStateCachedAllForks, testCase.block);
   },
 
   deposit: (state, testCase: IBaseSpecTest & {deposit: phase0.Deposit}) => {

--- a/packages/lodestar/test/spec/altair/operations.test.ts
+++ b/packages/lodestar/test/spec/altair/operations.test.ts
@@ -1,4 +1,4 @@
-import {BeaconStateCachedAllForks, allForks, altair} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks, allForks, altair} from "@chainsafe/lodestar-beacon-state-transition";
 import {phase0, ssz} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 import {IBaseSpecTest} from "../type";
@@ -31,7 +31,7 @@ operations<altair.BeaconState>(ForkName.altair, {
   },
 
   block_header: (state, testCase: IBaseSpecTest & {block: altair.BeaconBlock}) => {
-    allForks.processBlockHeader(state as BeaconStateCachedAllForks, testCase.block);
+    allForks.processBlockHeader(state as CachedBeaconStateAllForks, testCase.block);
   },
 
   deposit: (state, testCase: IBaseSpecTest & {deposit: phase0.Deposit}) => {

--- a/packages/lodestar/test/spec/altair/transition.test.ts
+++ b/packages/lodestar/test/spec/altair/transition.test.ts
@@ -18,10 +18,7 @@ describeDirectorySpecTest<ITransitionTestCase, allForks.BeaconState>(
     // testConfig is used here to load forkEpoch from meta.yaml
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const testConfig = createIChainForkConfig({ALTAIR_FORK_EPOCH: Number(forkEpoch)});
-    let wrappedState = allForks.createCachedBeaconState<allForks.BeaconState>(
-      testConfig,
-      testcase.pre as TreeBacked<allForks.BeaconState>
-    );
+    let wrappedState = allForks.createCachedBeaconState(testConfig, testcase.pre as TreeBacked<allForks.BeaconState>);
     for (let i = 0; i < Number(blocksCount); i++) {
       let tbSignedBlock: allForks.SignedBeaconBlock;
       if (i <= forkBlock) {

--- a/packages/lodestar/test/spec/bellatrix/operations.test.ts
+++ b/packages/lodestar/test/spec/bellatrix/operations.test.ts
@@ -1,4 +1,11 @@
-import {CachedBeaconState, allForks, altair, bellatrix} from "@chainsafe/lodestar-beacon-state-transition";
+import {
+  BeaconStateCachedAllForks,
+  BeaconStateCachedAltair,
+  BeaconStateCachedBellatrix,
+  allForks,
+  altair,
+  bellatrix,
+} from "@chainsafe/lodestar-beacon-state-transition";
 import {phase0, ssz} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 import {IBaseSpecTest} from "../type";
@@ -19,12 +26,12 @@ const sync_aggregate: BlockProcessFn<bellatrix.BeaconState> = (
   block.slot = state.slot;
   block.body.syncAggregate = testCase["sync_aggregate"];
 
-  altair.processSyncAggregate((state as unknown) as CachedBeaconState<altair.BeaconState>, block);
+  altair.processSyncAggregate((state as unknown) as BeaconStateCachedAltair, block);
 };
 
 operations<bellatrix.BeaconState>(ForkName.bellatrix, {
   attestation: (state, testCase: IBaseSpecTest & {attestation: phase0.Attestation}) => {
-    altair.processAttestations((state as unknown) as CachedBeaconState<altair.BeaconState>, [testCase.attestation]);
+    altair.processAttestations((state as unknown) as BeaconStateCachedAltair, [testCase.attestation]);
   },
 
   attester_slashing: (state, testCase: IBaseSpecTest & {attester_slashing: phase0.AttesterSlashing}) => {
@@ -33,11 +40,11 @@ operations<bellatrix.BeaconState>(ForkName.bellatrix, {
   },
 
   block_header: (state, testCase: IBaseSpecTest & {block: altair.BeaconBlock}) => {
-    allForks.processBlockHeader(state as CachedBeaconState<allForks.BeaconState>, testCase.block);
+    allForks.processBlockHeader(state as BeaconStateCachedAllForks, testCase.block);
   },
 
   deposit: (state, testCase: IBaseSpecTest & {deposit: phase0.Deposit}) => {
-    altair.processDeposit((state as unknown) as CachedBeaconState<altair.BeaconState>, testCase.deposit);
+    altair.processDeposit((state as unknown) as BeaconStateCachedAltair, testCase.deposit);
   },
 
   proposer_slashing: (state, testCase: IBaseSpecTest & {proposer_slashing: phase0.ProposerSlashing}) => {
@@ -48,19 +55,15 @@ operations<bellatrix.BeaconState>(ForkName.bellatrix, {
   sync_aggregate_random: sync_aggregate,
 
   voluntary_exit: (state, testCase: IBaseSpecTest & {voluntary_exit: phase0.SignedVoluntaryExit}) => {
-    altair.processVoluntaryExit((state as unknown) as CachedBeaconState<altair.BeaconState>, testCase.voluntary_exit);
+    altair.processVoluntaryExit((state as unknown) as BeaconStateCachedAltair, testCase.voluntary_exit);
   },
 
   execution_payload: (
     state,
     testCase: IBaseSpecTest & {execution_payload: bellatrix.ExecutionPayload; execution: {executionValid: boolean}}
   ) => {
-    processExecutionPayload(
-      (state as unknown) as CachedBeaconState<bellatrix.BeaconState>,
-      testCase.execution_payload,
-      {
-        executePayload: () => testCase.execution.executionValid,
-      }
-    );
+    processExecutionPayload((state as unknown) as BeaconStateCachedBellatrix, testCase.execution_payload, {
+      executePayload: () => testCase.execution.executionValid,
+    });
   },
 });

--- a/packages/lodestar/test/spec/bellatrix/operations.test.ts
+++ b/packages/lodestar/test/spec/bellatrix/operations.test.ts
@@ -1,7 +1,7 @@
 import {
-  BeaconStateCachedAllForks,
-  BeaconStateCachedAltair,
-  BeaconStateCachedBellatrix,
+  CachedBeaconStateAllForks,
+  CachedBeaconStateAltair,
+  CachedBeaconStateBellatrix,
   allForks,
   altair,
   bellatrix,
@@ -26,12 +26,12 @@ const sync_aggregate: BlockProcessFn<bellatrix.BeaconState> = (
   block.slot = state.slot;
   block.body.syncAggregate = testCase["sync_aggregate"];
 
-  altair.processSyncAggregate((state as unknown) as BeaconStateCachedAltair, block);
+  altair.processSyncAggregate((state as unknown) as CachedBeaconStateAltair, block);
 };
 
 operations<bellatrix.BeaconState>(ForkName.bellatrix, {
   attestation: (state, testCase: IBaseSpecTest & {attestation: phase0.Attestation}) => {
-    altair.processAttestations((state as unknown) as BeaconStateCachedAltair, [testCase.attestation]);
+    altair.processAttestations((state as unknown) as CachedBeaconStateAltair, [testCase.attestation]);
   },
 
   attester_slashing: (state, testCase: IBaseSpecTest & {attester_slashing: phase0.AttesterSlashing}) => {
@@ -40,11 +40,11 @@ operations<bellatrix.BeaconState>(ForkName.bellatrix, {
   },
 
   block_header: (state, testCase: IBaseSpecTest & {block: altair.BeaconBlock}) => {
-    allForks.processBlockHeader(state as BeaconStateCachedAllForks, testCase.block);
+    allForks.processBlockHeader(state as CachedBeaconStateAllForks, testCase.block);
   },
 
   deposit: (state, testCase: IBaseSpecTest & {deposit: phase0.Deposit}) => {
-    altair.processDeposit((state as unknown) as BeaconStateCachedAltair, testCase.deposit);
+    altair.processDeposit((state as unknown) as CachedBeaconStateAltair, testCase.deposit);
   },
 
   proposer_slashing: (state, testCase: IBaseSpecTest & {proposer_slashing: phase0.ProposerSlashing}) => {
@@ -55,14 +55,14 @@ operations<bellatrix.BeaconState>(ForkName.bellatrix, {
   sync_aggregate_random: sync_aggregate,
 
   voluntary_exit: (state, testCase: IBaseSpecTest & {voluntary_exit: phase0.SignedVoluntaryExit}) => {
-    altair.processVoluntaryExit((state as unknown) as BeaconStateCachedAltair, testCase.voluntary_exit);
+    altair.processVoluntaryExit((state as unknown) as CachedBeaconStateAltair, testCase.voluntary_exit);
   },
 
   execution_payload: (
     state,
     testCase: IBaseSpecTest & {execution_payload: bellatrix.ExecutionPayload; execution: {executionValid: boolean}}
   ) => {
-    processExecutionPayload((state as unknown) as BeaconStateCachedBellatrix, testCase.execution_payload, {
+    processExecutionPayload((state as unknown) as CachedBeaconStateBellatrix, testCase.execution_payload, {
       executePayload: () => testCase.execution.executionValid,
     });
   },

--- a/packages/lodestar/test/spec/phase0/operations.test.ts
+++ b/packages/lodestar/test/spec/phase0/operations.test.ts
@@ -1,4 +1,4 @@
-import {BeaconStateCachedAllForks, allForks, phase0} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks, allForks, phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {ForkName} from "@chainsafe/lodestar-params";
 import {IBaseSpecTest} from "../type";
 import {operations} from "../allForks/operations";
@@ -17,7 +17,7 @@ operations<phase0.BeaconState>(ForkName.phase0, {
   },
 
   block_header: (state, testCase: IBaseSpecTest & {block: phase0.BeaconBlock}) => {
-    allForks.processBlockHeader(state as BeaconStateCachedAllForks, testCase.block);
+    allForks.processBlockHeader(state as CachedBeaconStateAllForks, testCase.block);
   },
 
   deposit: (state, testCase: IBaseSpecTest & {deposit: phase0.Deposit}) => {

--- a/packages/lodestar/test/spec/phase0/operations.test.ts
+++ b/packages/lodestar/test/spec/phase0/operations.test.ts
@@ -1,4 +1,4 @@
-import {CachedBeaconState, allForks, phase0} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks, allForks, phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {ForkName} from "@chainsafe/lodestar-params";
 import {IBaseSpecTest} from "../type";
 import {operations} from "../allForks/operations";
@@ -17,7 +17,7 @@ operations<phase0.BeaconState>(ForkName.phase0, {
   },
 
   block_header: (state, testCase: IBaseSpecTest & {block: phase0.BeaconBlock}) => {
-    allForks.processBlockHeader(state as CachedBeaconState<allForks.BeaconState>, testCase.block);
+    allForks.processBlockHeader(state as BeaconStateCachedAllForks, testCase.block);
   },
 
   deposit: (state, testCase: IBaseSpecTest & {deposit: phase0.Deposit}) => {

--- a/packages/lodestar/test/unit/api/impl/beacon/state/stateValidators.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/state/stateValidators.test.ts
@@ -1,5 +1,5 @@
 import {config} from "@chainsafe/lodestar-config/default";
-import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {List, toHexString} from "@chainsafe/ssz";
 import {expect, use} from "chai";
 import chaiAsPromised from "chai-as-promised";
@@ -53,7 +53,7 @@ describe("beacon api impl - state - validators", function () {
         pubkey2index: ({
           get: () => 0,
         } as unknown) as allForks.PubkeyIndexMap,
-      } as BeaconStateCachedAllForks);
+      } as CachedBeaconStateAllForks);
       const api = getBeaconStateApi({config, db: dbStub, chain: chainStub});
       const {data: validators} = await api.getStateValidators("someState", {indices: [0, 1, 123]});
       expect(validators.length).to.equal(2);
@@ -74,7 +74,7 @@ describe("beacon api impl - state - validators", function () {
           pubkey2index: ({
             get: () => i,
           } as unknown) as allForks.PubkeyIndexMap,
-        } as BeaconStateCachedAllForks);
+        } as CachedBeaconStateAllForks);
       }
       const api = getBeaconStateApi({config, db: dbStub, chain: chainStub});
       const {data: validators} = await api.getStateValidators("someState", {
@@ -93,7 +93,7 @@ describe("beacon api impl - state - validators", function () {
           pubkey2index: ({
             get: () => i,
           } as unknown) as allForks.PubkeyIndexMap,
-        } as BeaconStateCachedAllForks);
+        } as CachedBeaconStateAllForks);
       }
       const api = getBeaconStateApi({config, db: dbStub, chain: chainStub});
       const {data: stateValidators} = await api.getStateValidators("someState", {
@@ -128,7 +128,7 @@ describe("beacon api impl - state - validators", function () {
         pubkey2index: ({
           get: () => undefined,
         } as unknown) as allForks.PubkeyIndexMap,
-      } as BeaconStateCachedAllForks);
+      } as CachedBeaconStateAllForks);
       const api = getBeaconStateApi({config, db: dbStub, chain: chainStub});
       await expect(api.getStateValidator("someState", validatorId1)).to.be.rejectedWith("Validator not found");
     });
@@ -138,7 +138,7 @@ describe("beacon api impl - state - validators", function () {
         pubkey2index: ({
           get: () => 2,
         } as unknown) as allForks.PubkeyIndexMap,
-      } as BeaconStateCachedAllForks);
+      } as CachedBeaconStateAllForks);
       const api = getBeaconStateApi({config, db: dbStub, chain: chainStub});
       expect(await api.getStateValidator("someState", validatorId1)).to.not.be.null;
     });
@@ -157,7 +157,7 @@ describe("beacon api impl - state - validators", function () {
       pubkey2IndexStub.get.withArgs(validatorId2).returns(25);
       chainStub.getHeadState.returns({
         pubkey2index: (pubkey2IndexStub as unknown) as allForks.PubkeyIndexMap,
-      } as BeaconStateCachedAllForks);
+      } as CachedBeaconStateAllForks);
       const api = getBeaconStateApi({config, db: dbStub, chain: chainStub});
       const {data: balances} = await api.getStateValidatorBalances("somestate", [1, 24, validatorId1, validatorId2]);
       expect(balances.length).to.equal(2);

--- a/packages/lodestar/test/unit/api/impl/beacon/state/stateValidators.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/state/stateValidators.test.ts
@@ -1,5 +1,5 @@
 import {config} from "@chainsafe/lodestar-config/default";
-import {CachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {List, toHexString} from "@chainsafe/ssz";
 import {expect, use} from "chai";
 import chaiAsPromised from "chai-as-promised";
@@ -53,7 +53,7 @@ describe("beacon api impl - state - validators", function () {
         pubkey2index: ({
           get: () => 0,
         } as unknown) as allForks.PubkeyIndexMap,
-      } as CachedBeaconState<allForks.BeaconState>);
+      } as BeaconStateCachedAllForks);
       const api = getBeaconStateApi({config, db: dbStub, chain: chainStub});
       const {data: validators} = await api.getStateValidators("someState", {indices: [0, 1, 123]});
       expect(validators.length).to.equal(2);
@@ -74,7 +74,7 @@ describe("beacon api impl - state - validators", function () {
           pubkey2index: ({
             get: () => i,
           } as unknown) as allForks.PubkeyIndexMap,
-        } as CachedBeaconState<allForks.BeaconState>);
+        } as BeaconStateCachedAllForks);
       }
       const api = getBeaconStateApi({config, db: dbStub, chain: chainStub});
       const {data: validators} = await api.getStateValidators("someState", {
@@ -93,7 +93,7 @@ describe("beacon api impl - state - validators", function () {
           pubkey2index: ({
             get: () => i,
           } as unknown) as allForks.PubkeyIndexMap,
-        } as CachedBeaconState<allForks.BeaconState>);
+        } as BeaconStateCachedAllForks);
       }
       const api = getBeaconStateApi({config, db: dbStub, chain: chainStub});
       const {data: stateValidators} = await api.getStateValidators("someState", {
@@ -128,7 +128,7 @@ describe("beacon api impl - state - validators", function () {
         pubkey2index: ({
           get: () => undefined,
         } as unknown) as allForks.PubkeyIndexMap,
-      } as CachedBeaconState<allForks.BeaconState>);
+      } as BeaconStateCachedAllForks);
       const api = getBeaconStateApi({config, db: dbStub, chain: chainStub});
       await expect(api.getStateValidator("someState", validatorId1)).to.be.rejectedWith("Validator not found");
     });
@@ -138,7 +138,7 @@ describe("beacon api impl - state - validators", function () {
         pubkey2index: ({
           get: () => 2,
         } as unknown) as allForks.PubkeyIndexMap,
-      } as CachedBeaconState<allForks.BeaconState>);
+      } as BeaconStateCachedAllForks);
       const api = getBeaconStateApi({config, db: dbStub, chain: chainStub});
       expect(await api.getStateValidator("someState", validatorId1)).to.not.be.null;
     });
@@ -157,7 +157,7 @@ describe("beacon api impl - state - validators", function () {
       pubkey2IndexStub.get.withArgs(validatorId2).returns(25);
       chainStub.getHeadState.returns({
         pubkey2index: (pubkey2IndexStub as unknown) as allForks.PubkeyIndexMap,
-      } as CachedBeaconState<allForks.BeaconState>);
+      } as BeaconStateCachedAllForks);
       const api = getBeaconStateApi({config, db: dbStub, chain: chainStub});
       const {data: balances} = await api.getStateValidatorBalances("somestate", [1, 24, validatorId1, validatorId2]);
       expect(balances.length).to.equal(2);

--- a/packages/lodestar/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/lodestar/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -10,7 +10,7 @@ import {
   computeEpochAtSlot,
   getTemporaryBlockHeader,
   phase0,
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   createCachedBeaconState,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {expect} from "chai";
@@ -37,7 +37,7 @@ describe("LodestarForkChoice", function () {
 
   const hashBlock = (block: phase0.BeaconBlock): string => toHexString(ssz.phase0.BeaconBlock.hashTreeRoot(block));
 
-  let state: BeaconStateCachedAllForks;
+  let state: CachedBeaconStateAllForks;
 
   before(() => {
     state = createCachedBeaconState(config, anchorState);

--- a/packages/lodestar/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/lodestar/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -10,7 +10,7 @@ import {
   computeEpochAtSlot,
   getTemporaryBlockHeader,
   phase0,
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
   createCachedBeaconState,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {expect} from "chai";
@@ -37,7 +37,7 @@ describe("LodestarForkChoice", function () {
 
   const hashBlock = (block: phase0.BeaconBlock): string => toHexString(ssz.phase0.BeaconBlock.hashTreeRoot(block));
 
-  let state: CachedBeaconState<allForks.BeaconState>;
+  let state: BeaconStateCachedAllForks;
 
   before(() => {
     state = createCachedBeaconState(config, anchorState);

--- a/packages/lodestar/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/lodestar/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -1,7 +1,7 @@
 import {bls, SecretKey} from "@chainsafe/bls";
 import {initBLS} from "@chainsafe/lodestar-cli/src/util";
 import {createIChainForkConfig, defaultChainConfig} from "@chainsafe/lodestar-config";
-import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {List} from "@chainsafe/ssz";
 import {expect} from "chai";
@@ -24,7 +24,7 @@ describe("AggregatedAttestationPool", function () {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const config = createIChainForkConfig(Object.assign({}, defaultChainConfig, {ALTAIR_FORK_EPOCH: altairForkEpoch}));
   const originalState = generateCachedState({slot: currentSlot + 1}, config, true);
-  let altairState: allForks.CachedBeaconState<allForks.BeaconState>;
+  let altairState: BeaconStateCachedAllForks;
   const attestation = generateAttestation({data: {slot: currentSlot, target: {epoch: currentEpoch}}});
   const committee = [0, 1, 2, 3];
 

--- a/packages/lodestar/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/lodestar/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -1,7 +1,7 @@
 import {bls, SecretKey} from "@chainsafe/bls";
 import {initBLS} from "@chainsafe/lodestar-cli/src/util";
 import {createIChainForkConfig, defaultChainConfig} from "@chainsafe/lodestar-config";
-import {BeaconStateCachedAllForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {List} from "@chainsafe/ssz";
 import {expect} from "chai";
@@ -24,7 +24,7 @@ describe("AggregatedAttestationPool", function () {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const config = createIChainForkConfig(Object.assign({}, defaultChainConfig, {ALTAIR_FORK_EPOCH: altairForkEpoch}));
   const originalState = generateCachedState({slot: currentSlot + 1}, config, true);
-  let altairState: BeaconStateCachedAllForks;
+  let altairState: CachedBeaconStateAllForks;
   const attestation = generateAttestation({data: {slot: currentSlot, target: {epoch: currentEpoch}}});
   const committee = [0, 1, 2, 3];
 

--- a/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
@@ -4,7 +4,7 @@ import {config} from "@chainsafe/lodestar-config/default";
 import {
   phase0,
   createCachedBeaconState,
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   computeEpochAtSlot,
   computeDomain,
   computeSigningRoot,
@@ -26,7 +26,7 @@ import {createIBeaconConfig} from "@chainsafe/lodestar-config";
 describe("validate voluntary exit", () => {
   const sandbox = sinon.createSandbox();
   let chainStub: StubbedChain;
-  let state: BeaconStateCachedAllForks;
+  let state: CachedBeaconStateAllForks;
   let signedVoluntaryExit: phase0.SignedVoluntaryExit;
   let opPool: OpPool & SinonStubbedInstance<OpPool>;
 

--- a/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
@@ -4,13 +4,13 @@ import {config} from "@chainsafe/lodestar-config/default";
 import {
   phase0,
   createCachedBeaconState,
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
   computeEpochAtSlot,
   computeDomain,
   computeSigningRoot,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {ForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {allForks, ssz} from "@chainsafe/lodestar-types";
+import {ssz} from "@chainsafe/lodestar-types";
 
 import {BeaconChain} from "../../../../src/chain";
 import {StubbedChain} from "../../../utils/stub";
@@ -26,7 +26,7 @@ import {createIBeaconConfig} from "@chainsafe/lodestar-config";
 describe("validate voluntary exit", () => {
   const sandbox = sinon.createSandbox();
   let chainStub: StubbedChain;
-  let state: CachedBeaconState<allForks.BeaconState>;
+  let state: BeaconStateCachedAllForks;
   let signedVoluntaryExit: phase0.SignedVoluntaryExit;
   let opPool: OpPool & SinonStubbedInstance<OpPool>;
 

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -4,7 +4,7 @@ import sinon from "sinon";
 import {toHexString, TreeBacked} from "@chainsafe/ssz";
 import {allForks, Number64, Root, Slot, ssz, Uint16, Uint64} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {CachedBeaconState, createCachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks, createCachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {CheckpointWithHex, IForkChoice, IProtoBlock, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
 
@@ -122,11 +122,11 @@ export class MockBeaconChain implements IBeaconChain {
     this.reprocessController = new ReprocessController(null);
   }
 
-  getHeadState(): CachedBeaconState<allForks.BeaconState> {
+  getHeadState(): BeaconStateCachedAllForks {
     return createCachedBeaconState(this.config, this.state);
   }
 
-  async getHeadStateAtCurrentEpoch(): Promise<CachedBeaconState<allForks.BeaconState>> {
+  async getHeadStateAtCurrentEpoch(): Promise<BeaconStateCachedAllForks> {
     return createCachedBeaconState(this.config, this.state);
   }
 

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -4,7 +4,7 @@ import sinon from "sinon";
 import {toHexString, TreeBacked} from "@chainsafe/ssz";
 import {allForks, Number64, Root, Slot, ssz, Uint16, Uint64} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {BeaconStateCachedAllForks, createCachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks, createCachedBeaconState} from "@chainsafe/lodestar-beacon-state-transition";
 import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {CheckpointWithHex, IForkChoice, IProtoBlock, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
 
@@ -122,11 +122,11 @@ export class MockBeaconChain implements IBeaconChain {
     this.reprocessController = new ReprocessController(null);
   }
 
-  getHeadState(): BeaconStateCachedAllForks {
+  getHeadState(): CachedBeaconStateAllForks {
     return createCachedBeaconState(this.config, this.state);
   }
 
-  async getHeadStateAtCurrentEpoch(): Promise<BeaconStateCachedAllForks> {
+  async getHeadStateAtCurrentEpoch(): Promise<CachedBeaconStateAllForks> {
     return createCachedBeaconState(this.config, this.state);
   }
 

--- a/packages/lodestar/test/utils/node/simTest.ts
+++ b/packages/lodestar/test/utils/node/simTest.ts
@@ -1,4 +1,9 @@
-import {computeEpochAtSlot, computeStartSlotAtEpoch, allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {
+  computeEpochAtSlot,
+  computeStartSlotAtEpoch,
+  allForks,
+  BeaconStateCachedAllForks,
+} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@chainsafe/lodestar-params";
@@ -36,9 +41,9 @@ export function simTestInfoTracker(bn: BeaconNode, logger: ILogger): () => void 
     }
   }
 
-  function logParticipation(state: allForks.CachedBeaconState<allForks.BeaconState>): void {
+  function logParticipation(state: BeaconStateCachedAllForks): void {
     // Compute participation (takes 5ms with 64 validators)
-    // Need a CachedBeaconState<allForks.BeaconState> where (state.slot + 1) % SLOTS_EPOCH == 0
+    // Need a BeaconStateCachedAllForks where (state.slot + 1) % SLOTS_EPOCH == 0
     const epochProcess = allForks.beforeProcessEpoch(state);
     const epoch = computeEpochAtSlot(state.slot);
 

--- a/packages/lodestar/test/utils/node/simTest.ts
+++ b/packages/lodestar/test/utils/node/simTest.ts
@@ -2,7 +2,7 @@ import {
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   allForks,
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IProtoBlock} from "@chainsafe/lodestar-fork-choice";
@@ -41,9 +41,9 @@ export function simTestInfoTracker(bn: BeaconNode, logger: ILogger): () => void 
     }
   }
 
-  function logParticipation(state: BeaconStateCachedAllForks): void {
+  function logParticipation(state: CachedBeaconStateAllForks): void {
     // Compute participation (takes 5ms with 64 validators)
-    // Need a BeaconStateCachedAllForks where (state.slot + 1) % SLOTS_EPOCH == 0
+    // Need a CachedBeaconStateAllForks where (state.slot + 1) % SLOTS_EPOCH == 0
     const epochProcess = allForks.beforeProcessEpoch(state);
     const epoch = computeEpochAtSlot(state.slot);
 

--- a/packages/lodestar/test/utils/state.ts
+++ b/packages/lodestar/test/utils/state.ts
@@ -1,5 +1,5 @@
 import {config as minimalConfig} from "@chainsafe/lodestar-config/default";
-import {BeaconStateCachedAllForks, createCachedBeaconState, phase0} from "@chainsafe/lodestar-beacon-state-transition";
+import {CachedBeaconStateAllForks, createCachedBeaconState, phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {List, TreeBacked} from "@chainsafe/ssz";
 import {allForks, altair, Root, ssz} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
@@ -151,7 +151,7 @@ export function generateCachedState(
   opts: TestBeaconState = {},
   config = minimalConfig,
   isAltair = false
-): BeaconStateCachedAllForks {
+): CachedBeaconStateAllForks {
   const state = generateState(opts, config, isAltair);
   return createCachedBeaconState(config, state);
 }
@@ -163,7 +163,7 @@ export async function generateCachedStateWithPubkeys(
   opts: TestBeaconState = {},
   config = minimalConfig,
   isAltair = false
-): Promise<BeaconStateCachedAllForks> {
+): Promise<CachedBeaconStateAllForks> {
   // somehow this is called in the test but BLS isn't init
   await initBLS();
   const state = generateState(opts, config, isAltair, true);

--- a/packages/lodestar/test/utils/state.ts
+++ b/packages/lodestar/test/utils/state.ts
@@ -1,5 +1,5 @@
 import {config as minimalConfig} from "@chainsafe/lodestar-config/default";
-import {CachedBeaconState, createCachedBeaconState, phase0} from "@chainsafe/lodestar-beacon-state-transition";
+import {BeaconStateCachedAllForks, createCachedBeaconState, phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {List, TreeBacked} from "@chainsafe/ssz";
 import {allForks, altair, Root, ssz} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
@@ -151,7 +151,7 @@ export function generateCachedState(
   opts: TestBeaconState = {},
   config = minimalConfig,
   isAltair = false
-): CachedBeaconState<allForks.BeaconState> {
+): BeaconStateCachedAllForks {
   const state = generateState(opts, config, isAltair);
   return createCachedBeaconState(config, state);
 }
@@ -163,7 +163,7 @@ export async function generateCachedStateWithPubkeys(
   opts: TestBeaconState = {},
   config = minimalConfig,
   isAltair = false
-): Promise<CachedBeaconState<allForks.BeaconState>> {
+): Promise<BeaconStateCachedAllForks> {
   // somehow this is called in the test but BLS isn't init
   await initBLS();
   const state = generateState(opts, config, isAltair, true);

--- a/packages/lodestar/test/utils/validationData/attestation.ts
+++ b/packages/lodestar/test/utils/validationData/attestation.ts
@@ -1,6 +1,5 @@
 import {
-  allForks,
-  CachedBeaconState,
+  BeaconStateCachedAllForks,
   computeEpochAtSlot,
   computeSigningRoot,
   computeStartSlotAtEpoch,
@@ -111,7 +110,7 @@ export function getAttestationValidData(
 
   // Add state to regen
   const regen = ({
-    getState: async () => (state as unknown) as CachedBeaconState<allForks.BeaconState>,
+    getState: async () => (state as unknown) as BeaconStateCachedAllForks,
   } as Partial<IStateRegenerator>) as IStateRegenerator;
 
   const chain = ({

--- a/packages/lodestar/test/utils/validationData/attestation.ts
+++ b/packages/lodestar/test/utils/validationData/attestation.ts
@@ -1,5 +1,5 @@
 import {
-  BeaconStateCachedAllForks,
+  CachedBeaconStateAllForks,
   computeEpochAtSlot,
   computeSigningRoot,
   computeStartSlotAtEpoch,
@@ -110,7 +110,7 @@ export function getAttestationValidData(
 
   // Add state to regen
   const regen = ({
-    getState: async () => (state as unknown) as BeaconStateCachedAllForks,
+    getState: async () => (state as unknown) as CachedBeaconStateAllForks,
   } as Partial<IStateRegenerator>) as IStateRegenerator;
 
   const chain = ({


### PR DESCRIPTION
**Motivation**

The SSZ refactor will change how the state is represented in the entire beacon-state-transition package and by extension almost all of Lodestar. Because now everywhere it's referenced by `CachedBeaconState<T>` the type is too rigid, because the new SSZ version is generic on the SSZ type not the value type.

So attempting to bring the new SSZ changes to the Lodestar monorepo causes an **insane** diff just because of this renames.

So this PR is pre-step that **doesn't change any logic**, but allows a future PR to change the type without causing a massive diff.

Proposed aliases
```ts
type CachedBeaconStatePhase0 = CachedBeaconState<phase0.BeaconState>;
type CachedBeaconStateAltair = CachedBeaconState<altair.BeaconState>;
type CachedBeaconStateBellatrix = CachedBeaconState<bellatrix.BeaconState>;
type CachedBeaconStateAllForks = CachedBeaconState<allForks.BeaconState>;
```

After merging new SSZ version, it's gonna look like this

```ts
type CachedBeaconStatePhase0 = CompositeViewDU<typeof ssz.phase0.BeaconState> & BeaconStateCache;
type CachedBeaconStateAltair = CompositeViewDU<typeof ssz.altair.BeaconState> & BeaconStateCache;
type CachedBeaconStateBellatrix = CompositeViewDU<typeof ssz.bellatrix.BeaconState> & BeaconStateCache;
type CachedBeaconStateAllForks = CompositeViewDU<allForks.AllForksSSZTypes["BeaconState"]> & BeaconStateCache;
```

**Description**

- Alias cached beacon state
- Move types location outside of the allForks dir to allow moving them latter without more insane diffs
