### PR TITLE
Use the correct api version for wss sync

### DIFF
--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -151,11 +151,12 @@ export async function fetchWeakSubjectivityState(
       wsCheckpoint = getCheckpointFromArg(weakSubjectivityCheckpoint);
     } else {
       wsCheckpoint = await fetchFinalizedCheckpoint(
-        `${weakSubjectivityServerUrl}/eth/v1/beacon/states/finalized/finality_checkpoints`
+        `${weakSubjectivityServerUrl}/eth/v1/beacon/states/head/finality_checkpoints`
       );
     }
     const stateSlot = wsCheckpoint.epoch * SLOTS_PER_EPOCH;
     const apiVersion = config.getForkName(stateSlot) === ForkName.phase0 ? "v1" : "v2";
+
     const response = await got(`${weakSubjectivityServerUrl}/eth/${apiVersion}/debug/beacon/states/${stateSlot}`, {
       headers: {accept: "application/octet-stream"},
     });
@@ -172,11 +173,12 @@ export async function fetchWeakSubjectivityState(
  */
 async function fetchFinalizedCheckpoint(url: string): Promise<Checkpoint> {
   try {
+    const response = await got(url).json();
     const {
       data: {
         finalized: {epoch, root},
       },
-    } = (await got(url).json()) as {data: {finalized: {epoch: string; root: string}}};
+    } = response as {data: {finalized: {epoch: string; root: string}}};
     if (epoch === undefined || root === undefined) {
       throw Error(`Invalid fetch of finalized checkpoint from url=${url}`);
     }

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -1,7 +1,7 @@
 import {IBeaconNodeOptions} from "@chainsafe/lodestar";
 import {IChainConfig, IChainForkConfig} from "@chainsafe/lodestar-config";
-import {allForks} from "@chainsafe/lodestar-types";
-import {RecursivePartial} from "@chainsafe/lodestar-utils";
+import {allForks, phase0} from "@chainsafe/lodestar-types";
+import {RecursivePartial, fromHex} from "@chainsafe/lodestar-utils";
 // eslint-disable-next-line no-restricted-imports
 import {getStateTypeFromBytes} from "@chainsafe/lodestar/lib/util/multifork";
 import {TreeBacked} from "@chainsafe/ssz";
@@ -142,6 +142,25 @@ export async function fetchWeakSubjectivityState(
     const response = await got(url, {headers: {accept: "application/octet-stream"}});
     const stateBytes = response.rawBody;
     return getStateTypeFromBytes(config, stateBytes).createTreeBackedFromBytes(stateBytes);
+  } catch (e) {
+    throw new Error("Unable to fetch weak subjectivity state: " + (e as Error).message);
+  }
+}
+
+/**
+ * Fetch a checkpoint from a remote beacon node
+ */
+export async function fetchFinalizedCheckpoint(url: string): Promise<phase0.Checkpoint> {
+  try {
+    const {
+      data: {
+        finalized: {epoch, root},
+      },
+    } = (await got(url).json()) as {data: {finalized: {epoch: string; root: string}}};
+    if (epoch === undefined || root === undefined) {
+      throw Error(`Invalid fetch of finalized checkpoint from url=${url}`);
+    }
+    return {epoch: parseInt(epoch), root: fromHex(root)} as phase0.Checkpoint;
   } catch (e) {
     throw new Error("Unable to fetch weak subjectivity state: " + (e as Error).message);
   }

--- a/packages/lodestar/test/e2e/sync/wss.test.ts
+++ b/packages/lodestar/test/e2e/sync/wss.test.ts
@@ -15,7 +15,6 @@ import {connect} from "../../utils/network";
 import {Network} from "../../../src/network";
 import {BackfillSyncEvent} from "../../../src/sync/backfill";
 import {TimestampFormatCode} from "@chainsafe/lodestar-utils";
-import {computeEpochAtSlot, allForks} from "@chainsafe/lodestar-beacon-state-transition";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 describe("Start from WSS", function () {
@@ -102,14 +101,9 @@ describe("Start from WSS", function () {
       throw e;
     }
 
-    const url = "http://127.0.0.1:9596/eth/v1/debug/beacon/states/finalized";
-
-    loggerNodeB.important("Fetching weak subjectivity state from " + url);
-    const wsState = await fetchWeakSubjectivityState(config, url);
-    const wsCheckpoint = {
-      epoch: computeEpochAtSlot(wsState.latestBlockHeader.slot),
-      root: allForks.getLatestBlockRoot(config, wsState),
-    };
+    const weakSubjectivityServerUrl="http://127.0.0.1:9596";
+    loggerNodeB.important("Fetching weak subjectivity state ",{weakSubjectivityServerUrl});
+    const {wsState,wsCheckpoint} = await fetchWeakSubjectivityState(config, {weakSubjectivityServerUrl});
     loggerNodeB.important("Fetched wss state");
 
     const bnStartingFromWSS = await getDevBeaconNode({

--- a/packages/lodestar/test/e2e/sync/wss.test.ts
+++ b/packages/lodestar/test/e2e/sync/wss.test.ts
@@ -101,9 +101,9 @@ describe("Start from WSS", function () {
       throw e;
     }
 
-    const weakSubjectivityServerUrl="http://127.0.0.1:9596";
-    loggerNodeB.important("Fetching weak subjectivity state ",{weakSubjectivityServerUrl});
-    const {wsState,wsCheckpoint} = await fetchWeakSubjectivityState(config, {weakSubjectivityServerUrl});
+    const weakSubjectivityServerUrl = "http://127.0.0.1:9596";
+    loggerNodeB.important("Fetching weak subjectivity state ", {weakSubjectivityServerUrl});
+    const {wsState, wsCheckpoint} = await fetchWeakSubjectivityState(config, {weakSubjectivityServerUrl});
     loggerNodeB.important("Fetched wss state");
 
     const bnStartingFromWSS = await getDevBeaconNode({


### PR DESCRIPTION
**Motivation**
To do the wss sync, we only use v1 to fetch the state, but post phase0 this end point may only be available in v2.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR determines which end point (v1/v2) to use based upon the epoch of the checkpoint at which to fetch the state.

