### PR TITLE
Add configuration for kintsugi network

### DIFF
--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -10,9 +10,10 @@ import got from "got";
 import * as mainnet from "./mainnet";
 import * as pyrmont from "./pyrmont";
 import * as prater from "./prater";
+import * as kintsugi from "./kintsugi";
 
-export type NetworkName = "mainnet" | "pyrmont" | "prater" | "dev";
-export const networkNames: NetworkName[] = ["mainnet", "pyrmont", "prater"];
+export type NetworkName = "mainnet" | "pyrmont" | "prater" | "kintsugi" | "dev";
+export const networkNames: NetworkName[] = ["mainnet", "pyrmont", "prater", "kintsugi"];
 
 function getNetworkData(
   network: NetworkName
@@ -30,6 +31,8 @@ function getNetworkData(
       return pyrmont;
     case "prater":
       return prater;
+    case "kintsugi":
+      return kintsugi;
     default:
       throw Error(`Network not supported: ${network}`);
   }

--- a/packages/cli/src/networks/kintsugi.ts
+++ b/packages/cli/src/networks/kintsugi.ts
@@ -1,0 +1,12 @@
+import {kintsugiChainConfig} from "@chainsafe/lodestar-config/networks";
+
+export const chainConfig = kintsugiChainConfig;
+
+/* eslint-disable max-len */
+
+export const depositContractDeployBlock = 0;
+export const genesisFileUrl = "https://raw.githubusercontent.com/eth-clients/merge-testnets/main/kintsugi/genesis.ssz";
+export const bootnodesFileUrl =
+  "https://raw.githubusercontent.com/eth-clients/merge-testnets/main/kintsugi/bootstrap_nodes.txt";
+
+export const bootEnrs = [];

--- a/packages/config/src/chainConfig/networks/kintsugi.ts
+++ b/packages/config/src/chainConfig/networks/kintsugi.ts
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import {fromHexString as b} from "@chainsafe/ssz";
+import {IChainConfig} from "../types";
+import {chainConfig as mainnet} from "../presets/mainnet";
+
+/* eslint-disable max-len */
+
+export const kintsugiChainConfig: IChainConfig = {
+  ...mainnet,
+
+  MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 72100,
+  // Dec 16th, 2021, 13:00 UTC
+  MIN_GENESIS_TIME: 1639659600,
+  // Gensis fork
+  GENESIS_FORK_VERSION: b("0x60000069"),
+  // 300 seconds (5 min)
+  GENESIS_DELAY: 300,
+
+  // Forking
+  ALTAIR_FORK_VERSION: b("0x61000070"),
+  ALTAIR_FORK_EPOCH: 10,
+  // Bellatrix
+  BELLATRIX_FORK_VERSION: b("0x62000071"),
+  BELLATRIX_FORK_EPOCH: 20,
+  TERMINAL_TOTAL_DIFFICULTY: BigInt(5000000000),
+  // Sharding
+  SHARDING_FORK_VERSION: b("0x03000000"),
+  SHARDING_FORK_EPOCH: Infinity,
+
+  // Time parameters
+  // ---------------------------------------------------------------
+  // 16 blocks is ~190s
+  ETH1_FOLLOW_DISTANCE: 16,
+
+  // Deposit contract
+  // ---------------------------------------------------------------
+  // Custom Ethereum testnet
+  DEPOSIT_CHAIN_ID: 1337702,
+  DEPOSIT_NETWORK_ID: 1337702,
+  DEPOSIT_CONTRACT_ADDRESS: b("0x4242424242424242424242424242424242424242"),
+};

--- a/packages/config/src/networks.ts
+++ b/packages/config/src/networks.ts
@@ -2,12 +2,14 @@ import {IChainConfig} from "./chainConfig";
 import {mainnetChainConfig} from "./chainConfig/networks/mainnet";
 import {pyrmontChainConfig} from "./chainConfig/networks/pyrmont";
 import {praterChainConfig} from "./chainConfig/networks/prater";
+import {kintsugiChainConfig} from "./chainConfig/networks/kintsugi";
 
-export {mainnetChainConfig, pyrmontChainConfig, praterChainConfig};
+export {mainnetChainConfig, pyrmontChainConfig, praterChainConfig, kintsugiChainConfig};
 
-export type NetworkName = "mainnet" | "pyrmont" | "prater";
+export type NetworkName = "mainnet" | "pyrmont" | "prater" | "kintsugi";
 export const networksChainConfig: Record<NetworkName, IChainConfig> = {
   mainnet: mainnetChainConfig,
   pyrmont: pyrmontChainConfig,
   prater: praterChainConfig,
+  kintsugi: kintsugiChainConfig,
 };


### PR DESCRIPTION
**Motivation**
Final step of Kintsugi testnet milestone is for individual teams to bundle the kintsugi configuration in their clients. 
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR adds the kintsugi network configuration available on the fly  via `--network kintsugi` flag. It will also require an kintsufi enabled EL in tandem which can be specified via `--execution.urls <EL url>` for e.g. ``--execution.urls http://localhost:8545``

Tested locally for successful kintsugi network runs
<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #3620
