### PR TITLE
Optimize backfill sync to efficiently use reqresp fetched block data 

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/sync.ts
+++ b/packages/cli/src/options/beaconNodeOptions/sync.ts
@@ -4,12 +4,14 @@ import {ICliCommandOptions} from "../../util";
 export interface ISyncArgs {
   "sync.isSingleNode": boolean;
   "sync.disableProcessAsChainSegment": boolean;
+  "sync.backfillBatchSize": number;
 }
 
 export function parseArgs(args: ISyncArgs): IBeaconNodeOptions["sync"] {
   return {
     isSingleNode: args["sync.isSingleNode"],
     disableProcessAsChainSegment: args["sync.disableProcessAsChainSegment"],
+    backfillBatchSize: args["sync.backfillBatchSize"],
   };
 }
 
@@ -30,6 +32,14 @@ Use only for local networks with a single node, can be dangerous in regular netw
     description:
       "For RangeSync disable processing batches of blocks at once. Should only be used for debugging or testing.",
     defaultDescription: String(defaultOptions.sync.disableProcessAsChainSegment),
+    group: "sync",
+  },
+
+  "sync.backfillBatchSize": {
+    hidden: true,
+    type: "number",
+    description: "Batch size for backfill sync to sync/process blocks",
+    defaultDescription: String(defaultOptions.sync.backfillBatchSize),
     group: "sync",
   },
 };

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -54,6 +54,7 @@ describe("options / beaconNodeOptions", () => {
       "network.dontSendGossipAttestationsToForkchoice": true,
       "sync.isSingleNode": true,
       "sync.disableProcessAsChainSegment": true,
+      "sync.backfillBatchSize": 34,
     } as IBeaconNodeArgs;
 
     const expectedOptions: RecursivePartial<IBeaconNodeOptions> = {
@@ -117,6 +118,7 @@ describe("options / beaconNodeOptions", () => {
       sync: {
         isSingleNode: true,
         disableProcessAsChainSegment: true,
+        backfillBatchSize: 34,
       },
     };
 

--- a/packages/lodestar/src/network/reqresp/encodingStrategies/index.ts
+++ b/packages/lodestar/src/network/reqresp/encodingStrategies/index.ts
@@ -9,6 +9,7 @@ import {BufferedSource} from "../utils";
 import {readSszSnappyPayload, ISszSnappyOptions} from "./sszSnappy/decode";
 import {writeSszSnappyPayload} from "./sszSnappy/encode";
 
+export {ISszSnappyOptions};
 // For more info about eth2 request/response encoding strategies, see:
 // https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/p2p-interface.md#encoding-strategies
 // Supported encoding strategies:

--- a/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/decode.ts
+++ b/packages/lodestar/src/network/reqresp/encodingStrategies/sszSnappy/decode.ts
@@ -3,12 +3,7 @@ import varint from "varint";
 import {CompositeType} from "@chainsafe/ssz";
 import {MAX_VARINT_BYTES} from "../../../../constants";
 import {BufferedSource} from "../../utils";
-import {
-  RequestOrResponseType,
-  RequestOrIncomingResponseBody,
-  cachedTreeBackedProxyHandler,
-  cachedProxyHandler,
-} from "../../types";
+import {RequestOrResponseType, RequestOrIncomingResponseBody, cachedTreeBackedProxyHandler} from "../../types";
 import {SnappyFramesUncompress} from "./snappyFrames/uncompress";
 import {maxEncodedLen} from "./utils";
 import {SszSnappyError, SszSnappyErrorCode} from "./errors";
@@ -152,10 +147,9 @@ function deserializeSszBody<T extends RequestOrIncomingResponseBody>(
     } else {
       const struct = type.deserialize(bytes);
       if (options?.cacheBytes) {
-        return (new Proxy({struct, bytes}, cachedProxyHandler) as unknown) as T;
-      } else {
-        return struct as T;
+        (struct as T & {bytes: Buffer}).bytes = bytes;
       }
+      return struct as T;
     }
   } catch (e) {
     throw new SszSnappyError({code: SszSnappyErrorCode.DESERIALIZE_ERROR, deserializeError: e as Error});

--- a/packages/lodestar/src/network/reqresp/interface.ts
+++ b/packages/lodestar/src/network/reqresp/interface.ts
@@ -10,6 +10,7 @@ import {INetworkEventBus} from "../events";
 import {ReqRespHandlers} from "./handlers";
 import {IMetrics} from "../../metrics";
 import {RequestTypedContainer} from "./types";
+import {ISszSnappyOptions} from "./request";
 
 export interface IReqResp {
   start(): void;
@@ -20,9 +21,14 @@ export interface IReqResp {
   metadata(peerId: PeerId, fork?: ForkName): Promise<allForks.Metadata>;
   beaconBlocksByRange(
     peerId: PeerId,
-    request: phase0.BeaconBlocksByRangeRequest
+    request: phase0.BeaconBlocksByRangeRequest,
+    options?: Partial<ISszSnappyOptions>
   ): Promise<allForks.SignedBeaconBlock[]>;
-  beaconBlocksByRoot(peerId: PeerId, request: phase0.BeaconBlocksByRootRequest): Promise<allForks.SignedBeaconBlock[]>;
+  beaconBlocksByRoot(
+    peerId: PeerId,
+    request: phase0.BeaconBlocksByRootRequest,
+    options?: Partial<ISszSnappyOptions>
+  ): Promise<allForks.SignedBeaconBlock[]>;
   pruneRateLimiterData(peerId: PeerId): void;
 }
 

--- a/packages/lodestar/src/network/reqresp/request/index.ts
+++ b/packages/lodestar/src/network/reqresp/request/index.ts
@@ -10,7 +10,7 @@ import {Method, Encoding, Protocol, Version, IncomingResponseBody, RequestBody} 
 import {formatProtocolId} from "../utils";
 import {ResponseError} from "../response";
 import {requestEncode} from "../encoders/requestEncode";
-import {responseDecode} from "../encoders/responseDecode";
+import {responseDecode, ISszSnappyOptions} from "../encoders/responseDecode";
 import {Libp2pConnection} from "../interface";
 import {collectResponses} from "./collectResponses";
 import {maxTotalResponseTimeout, responseTimeoutsHandler} from "./responseTimeoutsHandler";
@@ -23,6 +23,7 @@ import {
 } from "./errors";
 
 export {RequestError, RequestErrorCode};
+export {ISszSnappyOptions};
 
 type SendRequestModules = {
   logger: ILogger;
@@ -50,7 +51,7 @@ export async function sendRequest<T extends IncomingResponseBody | IncomingRespo
   requestBody: RequestBody,
   maxResponses: number,
   signal?: AbortSignal,
-  options?: Partial<typeof timeoutOptions>,
+  options?: Partial<typeof timeoutOptions & ISszSnappyOptions>,
   requestId = 0
 ): Promise<T> {
   const {REQUEST_TIMEOUT, DIAL_TIMEOUT} = {...timeoutOptions, ...options};
@@ -136,7 +137,7 @@ export async function sendRequest<T extends IncomingResponseBody | IncomingRespo
         () =>
           pipe(
             stream.source,
-            responseTimeoutsHandler(responseDecode(forkDigestContext, protocol), options),
+            responseTimeoutsHandler(responseDecode(forkDigestContext, protocol, options), options),
             collectResponses(method, maxResponses)
           ),
         maxTotalResponseTimeout(maxResponses, options)

--- a/packages/lodestar/src/network/reqresp/types.ts
+++ b/packages/lodestar/src/network/reqresp/types.ts
@@ -217,3 +217,25 @@ export type ReqRespBlockResponse = {
   bytes: Uint8Array;
   slot: Slot;
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const cachedTreeBackedProxyHandler: any = {
+  get({treeBacked, bytes}: {treeBacked: Record<string, unknown>; bytes: Buffer}, name: string) {
+    if (name === "bytes") {
+      return bytes;
+    } else {
+      return treeBacked[name];
+    }
+  },
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const cachedProxyHandler: any = {
+  get({struct, bytes}: {struct: Record<string, unknown>; bytes: Buffer}, name: string) {
+    if (name === "bytes") {
+      return bytes;
+    } else {
+      return struct[name];
+    }
+  },
+};

--- a/packages/lodestar/src/network/reqresp/types.ts
+++ b/packages/lodestar/src/network/reqresp/types.ts
@@ -228,14 +228,3 @@ export const cachedTreeBackedProxyHandler: any = {
     }
   },
 };
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const cachedProxyHandler: any = {
-  get({struct, bytes}: {struct: Record<string, unknown>; bytes: Buffer}, name: string) {
-    if (name === "bytes") {
-      return bytes;
-    } else {
-      return struct[name];
-    }
-  },
-};

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -169,7 +169,7 @@ export class BeaconNode {
       logger: logger.child(opts.logger.sync),
     });
 
-    const backfillSync = await BackfillSync.init({
+    const backfillSync = await BackfillSync.init(opts.sync, {
       config,
       db,
       chain,

--- a/packages/lodestar/src/sync/options.ts
+++ b/packages/lodestar/src/sync/options.ts
@@ -1,3 +1,6 @@
+import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
+import {EPOCHS_PER_BATCH} from "./constants";
+
 export type SyncOptions = {
   /**
    * Allow node to consider itself synced without being connected to a peer.
@@ -9,7 +12,12 @@ export type SyncOptions = {
    * Should only be used for debugging or testing.
    */
   disableProcessAsChainSegment?: boolean;
-
+  /**
+   * The batch size of slots for backfill sync can attempt to sync/process before yielding
+   * to sync loop. This number can be increased or decreased to make a suitable resource
+   * allocation to backfill sync.
+   */
+  backfillBatchSize?: number;
   /** USE FOR TESTING ONLY. Disable range sync completely */
   disableRangeSync?: boolean;
   /** USE FOR TESTING ONLY. Disable range sync completely */
@@ -19,4 +27,5 @@ export type SyncOptions = {
 export const defaultSyncOptions: SyncOptions = {
   isSingleNode: false,
   disableProcessAsChainSegment: false,
+  backfillBatchSize: EPOCHS_PER_BATCH * SLOTS_PER_EPOCH,
 };

--- a/packages/lodestar/test/unit/sync/backfill/verify.test.ts
+++ b/packages/lodestar/test/unit/sync/backfill/verify.test.ts
@@ -1,5 +1,5 @@
 import {BackfillSyncErrorCode, BackfillSyncError} from "./../../../../src/sync/backfill/errors";
-import {Json} from "@chainsafe/ssz";
+import {Json, TreeBacked} from "@chainsafe/ssz";
 import {createIBeaconConfig} from "@chainsafe/lodestar-config";
 import {config} from "@chainsafe/lodestar-config/default";
 import {phase0, ssz} from "@chainsafe/lodestar-types";
@@ -44,10 +44,12 @@ describe("backfill sync - verify block sequence", function () {
   });
 
   //first 4 mainnet blocks
-  function getBlocks(): phase0.SignedBeaconBlock[] {
+  function getBlocks(): TreeBacked<phase0.SignedBeaconBlock>[] {
     const json = JSON.parse(readFileSync(path.join(__dirname, "./blocks.json"), "utf-8")) as Json[];
     return json.map((b) => {
-      return ssz.phase0.SignedBeaconBlock.fromJson(b, {case: "snake"});
+      return ssz.phase0.SignedBeaconBlock.createTreeBackedFromStruct(
+        ssz.phase0.SignedBeaconBlock.fromJson(b, {case: "snake"})
+      );
     });
   }
 });


### PR DESCRIPTION
**Motivation**
As @tuyennhv pointed out after doing profiler runs, backfill sync could be optimized to use treebacked data from the sync range/block by root.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR changes the following:
- Use treebacked block's hashtree root of the synced block to get its blockroot to verify parent/child relationship in verify block sequence
- Use blockArchive's batch put binary using treebacked block's data
- add a hidden cli option `--sync.backfillBatchSize` to speciify the batch size for backfill sync
**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #3657
