### PR TITLE
Update sponsor link to bug bounty Gitcoin grant

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: https://gitcoin.co/grants/79/lodestar-eth20-client
+custom: https://gitcoin.co/grants/4571/bug-bounty-funding-for-chainsafes-lodestar-ethereu


### PR DESCRIPTION
Updating the broken sponsor link to point to new Gitcoin bug bounty fund for Lodestar. Closes #3136 
 