### PR TITLE
Use debug level when passing gossip attestations to forkchoice error

### DIFF
--- a/packages/lodestar/src/network/gossip/handlers/index.ts
+++ b/packages/lodestar/src/network/gossip/handlers/index.ts
@@ -173,8 +173,8 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
         try {
           chain.forkChoice.onAttestation(indexedAttestation);
         } catch (e) {
-          logger.error(
-            "Error adding aggregated attestation to forkchoice",
+          logger.debug(
+            "Error adding gossip aggregated attestation to forkchoice",
             {slot: aggregatedAttestation.data.slot},
             e as Error
           );
@@ -218,7 +218,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
         try {
           chain.forkChoice.onAttestation(indexedAttestation);
         } catch (e) {
-          logger.error("Error adding unaggregated attestation to forkchoice", {subnet}, e as Error);
+          logger.debug("Error adding gossip unaggregated attestation to forkchoice", {subnet}, e as Error);
         }
       }
     },


### PR DESCRIPTION
**Motivation**

When passing gossip attestations to forkchoice and there are error, it does not affect the functionality while it's logged as `logger.error`, switch to using `logger.debug()` so that we can investigate further if needed

**Description**

Closes #3665