### PR TITLE
Publish exact dependencies for nighly release

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -64,12 +64,16 @@ jobs:
         # --force-publish: 
         #   lerna doesn't want to publish anything otherwise - "lerna success No changed packages 
         #   to publish"
+        # --exact
+        #   lerna will link the dependencies of monorepo packages without ^ operator as npm 
+        #   is apparently bad at resolving ^ dependencies of the canary versions. For e.g
+        #   @chainsafe/lodestar-cli@^0.34.0-dev.4 resolves to => 0.34.0
         #
         # NOTE: Using --preid dev.$(git rev-parse --short=7 HEAD) results in `0.24.3-dev.3ddb91d.0+3ddb91d`
         run: |
           node_modules/.bin/lerna publish --yes --no-verify-access \
           --canary --dist-tag next --no-git-reset --force-publish \
-          --preid dev
+          --preid dev --exact
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Get version


### PR DESCRIPTION
**Motivation**
npm install is not able to resolve the dev versioned dependencies specified with `^` operator for e.g. `@chainsafe/lodestar-config@^0.34.0-dev.4` resolves to => `0.34.0` when `npm install @chainsafe/lodestar-cli@^0.34.0-dev.4` is done.
<!-- Why is this PR exists? What are the goals of the pull request? -->
On a bit of digging through on internet, people have tried using `--exact` version in lerna publish to make npm resolve the exact package.  Hopefully this fixes the dependency resolution in the install, and wll fix the nightly build

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #3676

