### PR TITLE
Update the year on the chainsafe cli notice

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,7 +8,7 @@ import {getVersion} from "./util/version";
 const version = getVersion();
 const topBanner = `🌟 Lodestar: TypeScript Implementation of the Ethereum 2.0 Beacon Chain.
   * Version: ${version}
-  * by ChainSafe Systems, 2018-2021`;
+  * by ChainSafe Systems, 2018-2022`;
 const bottomBanner = `📖 For more information, check the CLI reference:
   * https://chainsafe.github.io/lodestar/reference/cli
 


### PR DESCRIPTION
**Motivation**
Observed that the notice being printed on cli has year `2018-2021`.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR updates the same to `2018-2022`
