### PR TITLE
Increase default timeout of api instances except for validator duties

### DIFF
--- a/packages/api/src/client/utils/httpClient.ts
+++ b/packages/api/src/client/utils/httpClient.ts
@@ -50,7 +50,7 @@ export class HttpClient implements IHttpClient {
   constructor(opts: HttpClientOptions) {
     this.baseUrl = opts.baseUrl;
     // A higher default timeout, validator will sets its own shorter timeoutMs
-    this.timeoutMs = opts.timeoutMs ?? 40000;
+    this.timeoutMs = opts.timeoutMs ?? 60_000;
     this.getAbortSignal = opts.getAbortSignal;
     this.fetch = opts.fetch ?? fetch;
   }

--- a/packages/api/src/client/utils/httpClient.ts
+++ b/packages/api/src/client/utils/httpClient.ts
@@ -49,7 +49,8 @@ export class HttpClient implements IHttpClient {
    */
   constructor(opts: HttpClientOptions) {
     this.baseUrl = opts.baseUrl;
-    this.timeoutMs = opts.timeoutMs ?? 12000;
+    // A higher default timeout, validator will sets its own shorter timeoutMs
+    this.timeoutMs = opts.timeoutMs ?? 40000;
     this.getAbortSignal = opts.getAbortSignal;
     this.fetch = opts.fetch ?? fetch;
   }

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -61,6 +61,7 @@ export class Validator {
       typeof opts.api === "string"
         ? getClient(config, {
             baseUrl: opts.api,
+            // Validator would need the beacon to respond within the slot
             timeoutMs: config.SECONDS_PER_SLOT * 1000,
             getAbortSignal: this.getAbortSignal,
           })
@@ -88,7 +89,9 @@ export class Validator {
     const {config} = opts.dbOps;
     const api =
       typeof opts.api === "string"
-        ? getClient(config, {baseUrl: opts.api, timeoutMs: 12000, getAbortSignal: () => signal})
+        ? // This new api instance can make do with default timeout as a faster timeout is
+          // not necessary since this instance won't be used for validator duties
+          getClient(config, {baseUrl: opts.api, getAbortSignal: () => signal})
         : opts.api;
 
     const genesis = await waitForGenesis(api, opts.logger, signal);


### PR DESCRIPTION
**Motivation**
A user reported over discord that lodestar was timing out doing a wss state fetch from infura. On a bit of digging through, figured out that lodestar uses timeout of 12 seconds, which is fine for validator calling beacon api, but could be relaxed else where, as discussed with @dapplion [here on discord](https://discord.com/channels/593655374469660673/593655641445367808/937360994710204456)
<!-- Why is this PR exists? What are the goals of the pull request? -->
**Description**
This PR raises the default  api timeout from 12 seconds to 40 seconds, which should be a comfortable range for downloading the mainnet sync state and adds couple of comments to enure/highlight validator using a strict 1 slot timeout.
