### PR TITLE
Add pending `bellatrix/fork` and  `bellatrix/transition` spec test scenarios runner

### DIFF
--- a/packages/beacon-state-transition/src/allForks/stateTransition.ts
+++ b/packages/beacon-state-transition/src/allForks/stateTransition.ts
@@ -18,6 +18,7 @@ type StateAltair = CachedBeaconStateAltair;
 
 type ProcessBlockFn = (state: StateAllForks, block: allForks.BeaconBlock, verifySignatures: boolean) => void;
 type ProcessEpochFn = (state: StateAllForks, epochProcess: IEpochProcess) => void;
+type UpgradeStateFn = (state: StateAllForks) => StateAllForks;
 
 const processBlockByFork: Record<ForkName, ProcessBlockFn> = {
   [ForkName.phase0]: phase0.processBlock as ProcessBlockFn,
@@ -31,6 +32,12 @@ const processEpochByFork: Record<ForkName, ProcessEpochFn> = {
   [ForkName.bellatrix]: altair.processEpoch as ProcessEpochFn,
 };
 
+export const upgradeStateByFork: Record<ForkName, UpgradeStateFn> = {
+  // Dummy placeholder Fn for phase0
+  [ForkName.phase0]: ((x) => x) as UpgradeStateFn,
+  [ForkName.altair]: altair.upgradeState as UpgradeStateFn,
+  [ForkName.bellatrix]: bellatrix.upgradeState as UpgradeStateFn,
+};
 // Multifork capable state transition
 
 /**

--- a/packages/lodestar/test/spec/allForks/fork.ts
+++ b/packages/lodestar/test/spec/allForks/fork.ts
@@ -14,10 +14,6 @@ export function fork<
   PreBeaconState extends phase0.BeaconState | altair.BeaconState,
   PostBeaconState extends altair.BeaconState | bellatrix.BeaconState
 >(pre: ForkName, fork: ForkName): void {
-  interface IUpgradeStateCase extends IBaseSpecTest {
-    pre: allForks.BeaconState;
-    post: allForks.BeaconState;
-  }
   describeDirectorySpecTest<IUpgradeStateCase, allForks.BeaconState>(
     `${ACTIVE_PRESET}/${fork}/fork/fork`,
     join(SPEC_TEST_LOCATION, `/tests/${ACTIVE_PRESET}/${fork}/fork/fork/pyspec_tests`),
@@ -52,4 +48,9 @@ export function fork<
       },
     }
   );
+
+  interface IUpgradeStateCase extends IBaseSpecTest {
+    pre: PreBeaconState;
+    post: PostBeaconState;
+  }
 }

--- a/packages/lodestar/test/spec/allForks/fork.ts
+++ b/packages/lodestar/test/spec/allForks/fork.ts
@@ -1,0 +1,55 @@
+import {join} from "node:path";
+import {TreeBacked} from "@chainsafe/ssz";
+import {config} from "@chainsafe/lodestar-config/default";
+import {allForks, CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util";
+import {phase0, altair, bellatrix} from "@chainsafe/lodestar-beacon-state-transition";
+import {ssz} from "@chainsafe/lodestar-types";
+import {ACTIVE_PRESET, ForkName} from "@chainsafe/lodestar-params";
+import {SPEC_TEST_LOCATION} from "../specTestVersioning";
+import {IBaseSpecTest} from "../type";
+import {expectEqualBeaconState, inputTypeSszTreeBacked} from "../util";
+
+export function fork<
+  PreBeaconState extends phase0.BeaconState | altair.BeaconState,
+  PostBeaconState extends altair.BeaconState | bellatrix.BeaconState
+>(pre: ForkName, fork: ForkName): void {
+  interface IUpgradeStateCase extends IBaseSpecTest {
+    pre: allForks.BeaconState;
+    post: allForks.BeaconState;
+  }
+  describeDirectorySpecTest<IUpgradeStateCase, allForks.BeaconState>(
+    `${ACTIVE_PRESET}/${fork}/fork/fork`,
+    join(SPEC_TEST_LOCATION, `/tests/${ACTIVE_PRESET}/${fork}/fork/fork/pyspec_tests`),
+    (testcase) => {
+      const preState = allForks.createCachedBeaconState(config, testcase.pre as TreeBacked<PreBeaconState>);
+      const postState = allForks.upgradeStateByFork[fork]((preState as unknown) as CachedBeaconStateAllForks);
+
+      // this test has a random slot so createCachedBeaconState is not able to create indexed sync committee
+      const tbPostState = (postState.type.createTreeBacked(postState.tree) as unknown) as TreeBacked<PostBeaconState>;
+      postState.currentSyncCommittee = allForks.convertToIndexedSyncCommittee(
+        tbPostState.currentSyncCommittee as TreeBacked<altair.SyncCommittee>,
+        postState.pubkey2index
+      );
+      postState.nextSyncCommittee = allForks.convertToIndexedSyncCommittee(
+        tbPostState.nextSyncCommittee as TreeBacked<altair.SyncCommittee>,
+        postState.pubkey2index
+      );
+      return postState;
+    },
+    {
+      inputTypes: inputTypeSszTreeBacked,
+      sszTypes: {
+        pre: ssz[pre].BeaconState,
+        post: ssz[fork].BeaconState,
+      },
+
+      timeout: 10000,
+      shouldError: (testCase) => testCase.post === undefined,
+      getExpected: (testCase) => testCase.post,
+      expectFunc: (testCase, expected, actual) => {
+        expectEqualBeaconState(fork, expected, actual);
+      },
+    }
+  );
+}

--- a/packages/lodestar/test/spec/altair/fork.test.ts
+++ b/packages/lodestar/test/spec/altair/fork.test.ts
@@ -1,50 +1,5 @@
-import {join} from "node:path";
-import {TreeBacked} from "@chainsafe/ssz";
-import {config} from "@chainsafe/lodestar-config/default";
-import {allForks, phase0} from "@chainsafe/lodestar-beacon-state-transition";
-import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util";
-import {altair} from "@chainsafe/lodestar-beacon-state-transition";
-import {ssz} from "@chainsafe/lodestar-types";
-import {ACTIVE_PRESET, ForkName} from "@chainsafe/lodestar-params";
-import {SPEC_TEST_LOCATION} from "../specTestVersioning";
-import {IBaseSpecTest} from "../type";
-import {expectEqualBeaconState, inputTypeSszTreeBacked} from "../util";
+import {phase0, altair} from "@chainsafe/lodestar-types";
+import {ForkName} from "@chainsafe/lodestar-params";
+import {fork} from "../allForks/fork";
 
-describeDirectorySpecTest<IUpgradeStateCase, altair.BeaconState>(
-  `${ACTIVE_PRESET}/altair/fork/fork`,
-  join(SPEC_TEST_LOCATION, `/tests/${ACTIVE_PRESET}/altair/fork/fork/pyspec_tests`),
-  (testcase) => {
-    const phase0State = allForks.createCachedBeaconState(config, testcase.pre as TreeBacked<phase0.BeaconState>);
-    const altairState = altair.upgradeState(phase0State);
-    // this test has a random slot so createCachedBeaconState is not able to create indexed sync committee
-    const tbAltairState = altairState.type.createTreeBacked(altairState.tree);
-    altairState.currentSyncCommittee = allForks.convertToIndexedSyncCommittee(
-      tbAltairState.currentSyncCommittee as TreeBacked<altair.SyncCommittee>,
-      altairState.pubkey2index
-    );
-    altairState.nextSyncCommittee = allForks.convertToIndexedSyncCommittee(
-      tbAltairState.nextSyncCommittee as TreeBacked<altair.SyncCommittee>,
-      altairState.pubkey2index
-    );
-    return altairState;
-  },
-  {
-    inputTypes: inputTypeSszTreeBacked,
-    sszTypes: {
-      pre: ssz.phase0.BeaconState,
-      post: ssz.altair.BeaconState,
-    },
-
-    timeout: 10000,
-    shouldError: (testCase) => testCase.post === undefined,
-    getExpected: (testCase) => testCase.post,
-    expectFunc: (testCase, expected, actual) => {
-      expectEqualBeaconState(ForkName.altair, expected, actual);
-    },
-  }
-);
-
-interface IUpgradeStateCase extends IBaseSpecTest {
-  pre: phase0.BeaconState;
-  post: altair.BeaconState;
-}
+fork<phase0.BeaconState, altair.BeaconState>(ForkName.phase0, ForkName.altair);

--- a/packages/lodestar/test/spec/bellatrix/fork.test.ts
+++ b/packages/lodestar/test/spec/bellatrix/fork.test.ts
@@ -1,52 +1,5 @@
-import {join} from "node:path";
-import {TreeBacked} from "@chainsafe/ssz";
-import {config} from "@chainsafe/lodestar-config/default";
-import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
-import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util";
-import {altair, bellatrix} from "@chainsafe/lodestar-beacon-state-transition";
-import {ssz} from "@chainsafe/lodestar-types";
-import {ACTIVE_PRESET, ForkName} from "@chainsafe/lodestar-params";
-import {SPEC_TEST_LOCATION} from "../specTestVersioning";
-import {IBaseSpecTest} from "../type";
-import {expectEqualBeaconState, inputTypeSszTreeBacked} from "../util";
+import {altair, bellatrix} from "@chainsafe/lodestar-types";
+import {ForkName} from "@chainsafe/lodestar-params";
+import {fork} from "../allForks/fork";
 
-describeDirectorySpecTest<IUpgradeStateCase, bellatrix.BeaconState>(
-  `${ACTIVE_PRESET}/bellatrix/fork/fork`,
-  join(SPEC_TEST_LOCATION, `/tests/${ACTIVE_PRESET}/bellatrix/fork/fork/pyspec_tests`),
-  (testcase) => {
-    const altairState = allForks.createCachedBeaconState(config, testcase.pre as TreeBacked<altair.BeaconState>);
-    const bellatrixState = bellatrix.upgradeState(altairState);
-
-    // See altair/fork.test.ts for why we have to explicity set treebacked currentSyncCommittee
-    // and nextSyncCommittee
-    const tbBellatrixState = bellatrixState.type.createTreeBacked(bellatrixState.tree);
-    bellatrixState.currentSyncCommittee = allForks.convertToIndexedSyncCommittee(
-      tbBellatrixState.currentSyncCommittee as TreeBacked<altair.SyncCommittee>,
-      bellatrixState.pubkey2index
-    );
-    bellatrixState.nextSyncCommittee = allForks.convertToIndexedSyncCommittee(
-      tbBellatrixState.nextSyncCommittee as TreeBacked<altair.SyncCommittee>,
-      bellatrixState.pubkey2index
-    );
-    return bellatrixState;
-  },
-  {
-    inputTypes: inputTypeSszTreeBacked,
-    sszTypes: {
-      pre: ssz.altair.BeaconState,
-      post: ssz.bellatrix.BeaconState,
-    },
-
-    timeout: 10000,
-    shouldError: (testCase) => testCase.post === undefined,
-    getExpected: (testCase) => testCase.post,
-    expectFunc: (testCase, expected, actual) => {
-      expectEqualBeaconState(ForkName.bellatrix, expected, actual);
-    },
-  }
-);
-
-interface IUpgradeStateCase extends IBaseSpecTest {
-  pre: altair.BeaconState;
-  post: bellatrix.BeaconState;
-}
+fork<altair.BeaconState, bellatrix.BeaconState>(ForkName.altair, ForkName.bellatrix);

--- a/packages/lodestar/test/spec/bellatrix/fork.test.ts
+++ b/packages/lodestar/test/spec/bellatrix/fork.test.ts
@@ -1,0 +1,52 @@
+import {join} from "node:path";
+import {TreeBacked} from "@chainsafe/ssz";
+import {config} from "@chainsafe/lodestar-config/default";
+import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util";
+import {altair, bellatrix} from "@chainsafe/lodestar-beacon-state-transition";
+import {ssz} from "@chainsafe/lodestar-types";
+import {ACTIVE_PRESET, ForkName} from "@chainsafe/lodestar-params";
+import {SPEC_TEST_LOCATION} from "../specTestVersioning";
+import {IBaseSpecTest} from "../type";
+import {expectEqualBeaconState, inputTypeSszTreeBacked} from "../util";
+
+describeDirectorySpecTest<IUpgradeStateCase, bellatrix.BeaconState>(
+  `${ACTIVE_PRESET}/bellatrix/fork/fork`,
+  join(SPEC_TEST_LOCATION, `/tests/${ACTIVE_PRESET}/bellatrix/fork/fork/pyspec_tests`),
+  (testcase) => {
+    const altairState = allForks.createCachedBeaconState(config, testcase.pre as TreeBacked<altair.BeaconState>);
+    const bellatrixState = bellatrix.upgradeState(altairState);
+
+    // See altair/fork.test.ts for why we have to explicity set treebacked currentSyncCommittee
+    // and nextSyncCommittee
+    const tbBellatrixState = bellatrixState.type.createTreeBacked(bellatrixState.tree);
+    bellatrixState.currentSyncCommittee = allForks.convertToIndexedSyncCommittee(
+      tbBellatrixState.currentSyncCommittee as TreeBacked<altair.SyncCommittee>,
+      bellatrixState.pubkey2index
+    );
+    bellatrixState.nextSyncCommittee = allForks.convertToIndexedSyncCommittee(
+      tbBellatrixState.nextSyncCommittee as TreeBacked<altair.SyncCommittee>,
+      bellatrixState.pubkey2index
+    );
+    return bellatrixState;
+  },
+  {
+    inputTypes: inputTypeSszTreeBacked,
+    sszTypes: {
+      pre: ssz.altair.BeaconState,
+      post: ssz.bellatrix.BeaconState,
+    },
+
+    timeout: 10000,
+    shouldError: (testCase) => testCase.post === undefined,
+    getExpected: (testCase) => testCase.post,
+    expectFunc: (testCase, expected, actual) => {
+      expectEqualBeaconState(ForkName.bellatrix, expected, actual);
+    },
+  }
+);
+
+interface IUpgradeStateCase extends IBaseSpecTest {
+  pre: altair.BeaconState;
+  post: bellatrix.BeaconState;
+}

--- a/packages/lodestar/test/spec/bellatrix/transition.test.ts
+++ b/packages/lodestar/test/spec/bellatrix/transition.test.ts
@@ -1,0 +1,85 @@
+import {join} from "node:path";
+import {allForks} from "@chainsafe/lodestar-beacon-state-transition";
+import {altair, Uint64, Epoch, ssz, bellatrix} from "@chainsafe/lodestar-types";
+import {describeDirectorySpecTest} from "@chainsafe/lodestar-spec-test-util";
+import {createIChainForkConfig} from "@chainsafe/lodestar-config";
+import {ForkName, ACTIVE_PRESET} from "@chainsafe/lodestar-params";
+import {TreeBacked} from "@chainsafe/ssz";
+import {SPEC_TEST_LOCATION} from "../specTestVersioning";
+import {IBaseSpecTest} from "../type";
+import {expectEqualBeaconState, inputTypeSszTreeBacked} from "../util";
+
+describeDirectorySpecTest<ITransitionTestCase, allForks.BeaconState>(
+  `${ACTIVE_PRESET}/bellatrix/transition`,
+  join(SPEC_TEST_LOCATION, `/tests/${ACTIVE_PRESET}/bellatrix/transition/core/pyspec_tests`),
+  (testcase) => {
+    const meta = testcase.meta;
+    const {forkEpoch, blocksCount, forkBlock} = meta;
+    // testConfig is used here to load forkEpoch from meta.yaml
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const testConfig = createIChainForkConfig({ALTAIR_FORK_EPOCH: 0, BELLATRIX_FORK_EPOCH: Number(forkEpoch)});
+    let wrappedState = allForks.createCachedBeaconState(testConfig, testcase.pre as TreeBacked<allForks.BeaconState>);
+    for (let i = 0; i < Number(blocksCount); i++) {
+      let tbSignedBlock: allForks.SignedBeaconBlock;
+      if (i <= forkBlock) {
+        const signedBlock = testcase[`blocks_${i}`] as altair.SignedBeaconBlock;
+        tbSignedBlock = ssz.altair.SignedBeaconBlock.createTreeBackedFromStruct(signedBlock);
+      } else {
+        const signedBlock = testcase[`blocks_${i}`] as bellatrix.SignedBeaconBlock;
+        tbSignedBlock = ssz.bellatrix.SignedBeaconBlock.createTreeBackedFromStruct(signedBlock);
+      }
+      wrappedState = allForks.stateTransition(wrappedState, tbSignedBlock, {
+        verifyStateRoot: true,
+        verifyProposer: false,
+        verifySignatures: false,
+      });
+    }
+    return wrappedState;
+  },
+  {
+    inputTypes: inputTypeSszTreeBacked,
+    getSszTypes: (meta: ITransitionTestCase["meta"]) => {
+      return {
+        pre: ssz.altair.BeaconState,
+        post: ssz.bellatrix.BeaconState,
+        ...generateBlocksSZZTypeMapping(meta),
+      };
+    },
+    shouldError: (testCase) => testCase.post === undefined,
+    timeout: 10000,
+    getExpected: (testCase) => testCase.post,
+    expectFunc: (testCase, expected, actual) => {
+      expectEqualBeaconState(ForkName.altair, expected, actual);
+    },
+  }
+);
+
+type BlocksSZZTypeMapping = Record<string, typeof ssz[ForkName]["SignedBeaconBlock"]>;
+
+/**
+ * https://github.com/ethereum/eth2.0-specs/tree/v1.1.0-alpha.5/tests/formats/transition
+ */
+function generateBlocksSZZTypeMapping(meta: ITransitionTestCase["meta"]): BlocksSZZTypeMapping {
+  if (meta === undefined) {
+    throw new Error("No meta data found");
+  }
+  const blocksMapping: BlocksSZZTypeMapping = {};
+  // The fork_block is the index in the test data of the last block of the initial fork.
+  for (let i = 0; i < meta.blocksCount; i++) {
+    blocksMapping[`blocks_${i}`] = i <= meta.forkBlock ? ssz.altair.SignedBeaconBlock : ssz.bellatrix.SignedBeaconBlock;
+  }
+  return blocksMapping;
+}
+
+interface ITransitionTestCase extends IBaseSpecTest {
+  [k: string]: bellatrix.SignedBeaconBlock | unknown | null | undefined;
+  meta: {
+    postFork: ForkName;
+    forkEpoch: Epoch;
+    forkBlock: Uint64;
+    blocksCount: Uint64;
+    blsSetting?: BigInt;
+  };
+  pre: altair.BeaconState;
+  post: bellatrix.BeaconState;
+}


### PR DESCRIPTION
**Motivation**
Additonal `bellatrix/fork` tests were added in 1.1.8 for which a placeholder file was added till the actual runner could be added.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR adds the runner for `bellatrix/fork` on the lines of `altair/fork` runner.

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #3541


Example RUN results:
```
$ /usr/app/node_modules/.bin/mocha --config .mocharc.spec.yml test/spec/bellatrix/fork.test.ts


  minimal/bellatrix/fork/fork
    ✓ bellatrix_fork_random_0 (55ms)
    ✓ bellatrix_fork_random_1 (42ms)
    ✓ bellatrix_fork_random_2 (56ms)
    ✓ bellatrix_fork_random_3
    ✓ bellatrix_fork_random_large_validator_set (42ms)
    ✓ bellatrix_fork_random_low_balances
    ✓ bellatrix_fork_random_misc_balances
    ✓ fork_base_state
    ✓ fork_many_next_epoch
    ✓ fork_next_epoch
    ✓ fork_next_epoch_with_block
    ✓ fork_random_large_validator_set
    ✓ fork_random_low_balances
    ✓ fork_random_misc_balances


  14 passing (2s)

 /usr/app/node_modules/.bin/mocha --config .mocharc.spec.yml test/spec/bellatrix/transition.test.ts


  minimal/bellatrix/transition
    ✓ normal_transition (178ms)
    ✓ sample_transition (86ms)
    ✓ transition_missing_first_post_block (68ms)
    ✓ transition_missing_last_pre_fork_block (52ms)
    ✓ transition_only_blocks_post_fork
    ✓ transition_with_activation_at_fork_epoch
    ✓ transition_with_attester_slashing_right_after_fork
    ✓ transition_with_attester_slashing_right_before_fork
    ✓ transition_with_deposit_right_after_fork (75ms)
    ✓ transition_with_deposit_right_before_fork (81ms)
    ✓ transition_with_finality (93ms)
    ✓ transition_with_leaking_at_fork
    ✓ transition_with_leaking_pre_fork
    ✓ transition_with_no_attestations_until_after_fork (70ms)
    ✓ transition_with_non_empty_activation_queue
    ✓ transition_with_one_fourth_exiting_validators_exit_at_fork
    ✓ transition_with_one_fourth_exiting_validators_exit_post_fork
    ✓ transition_with_one_fourth_slashed_active_validators_pre_fork
    ✓ transition_with_proposer_slashing_right_after_fork
    ✓ transition_with_proposer_slashing_right_before_fork
    ✓ transition_with_random_half_participation (89ms)
    ✓ transition_with_random_three_quarters_participation (65ms)
    ✓ transition_with_voluntary_exit_right_after_fork
    ✓ transition_with_voluntary_exit_right_before_fork


  24 passing (3s)

```
