### PR TITLE
Update the weakSubjectivityServerUrl help description

### DIFF
--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -59,7 +59,7 @@ export const beaconExtraOptions: ICliCommandOptions<IBeaconExtraArgs> = {
 
   weakSubjectivityServerUrl: {
     description:
-      "Pass in a custom server from which to fetch weak subjectivity states (if you don't want to use the built-in Lodestar servers).",
+      "Pass in a server hosting Beacon Node APIs from which to fetch weak subjectivity state, required in conjunction with --weakSubjectivitySyncLatest or --weakSubjectivityCheckpoint sync.",
     type: "string",
   },
 };


### PR DESCRIPTION
**Motivation**
A user on discord pointed out that our lodestar cli help still refers to default lodestar urls for weakSubjectivityServerUrl, which we had discontinued.
```
The help text for --weakSubjectivityServerUrl mentions Lodestar default servers, but I don't think those exist, any more. Error: Must set arg --weakSubjectivityServerUrl for network mainnet
```
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR updates the description removing reference to default lodestar urls.
