### PR TITLE
Use Uint8Array in all db types

### DIFF
--- a/packages/db/src/abstractRepository.ts
+++ b/packages/db/src/abstractRepository.ts
@@ -11,8 +11,8 @@ export type Id = Uint8Array | string | number | bigint;
 
 /**
  * Repository is a high level kv storage
- * managing a Buffer to Buffer kv database
- * It translates typed keys and values to Buffers required by the underlying database
+ * managing a Uint8rray to Uint8rray kv database
+ * It translates typed keys and values to Uint8rrays required by the underlying database
  *
  * By default, SSZ-encoded values,
  * indexed by root
@@ -46,7 +46,7 @@ export abstract class Repository<I extends Id, T> {
     return this.type.deserialize(data);
   }
 
-  encodeKey(id: I): Buffer {
+  encodeKey(id: I): Uint8Array {
     return _encodeKey(this.bucket, id);
   }
 
@@ -77,7 +77,7 @@ export abstract class Repository<I extends Id, T> {
     await this.db.put(this.encodeKey(id), this.encodeValue(value));
   }
 
-  async putBinary(id: I, value: Buffer): Promise<void> {
+  async putBinary(id: I, value: Uint8Array): Promise<void> {
     this.dbWriteMetrics?.inc();
     await this.db.put(this.encodeKey(id), value);
   }
@@ -110,7 +110,7 @@ export abstract class Repository<I extends Id, T> {
     );
   }
 
-  // Similar to batchPut but we support value as Buffer
+  // Similar to batchPut but we support value as Uint8Array
   async batchPutBinary(items: ArrayLike<IKeyValue<I, Uint8Array>>): Promise<void> {
     this.dbWriteMetrics?.inc();
     await this.db.batchPut(
@@ -251,10 +251,10 @@ export abstract class Repository<I extends Id, T> {
   }
 
   /**
-   * Transforms opts from I to Buffer
+   * Transforms opts from I to Uint8Array
    */
   protected dbFilterOptions(opts?: IFilterOptions<I>): IFilterOptions<Uint8Array> {
-    const _opts: IFilterOptions<Buffer> = {
+    const _opts: IFilterOptions<Uint8Array> = {
       gte: _encodeKey(this.bucket, Buffer.alloc(0)),
       lt: _encodeKey(this.bucket + 1, Buffer.alloc(0)),
     };

--- a/packages/db/src/controller/level.ts
+++ b/packages/db/src/controller/level.ts
@@ -54,9 +54,9 @@ export class LevelDbController implements IDatabaseController<Uint8Array, Uint8A
     await this.db.clear();
   }
 
-  async get(key: Buffer): Promise<Buffer | null> {
+  async get(key: Uint8Array): Promise<Uint8Array | null> {
     try {
-      return (await this.db.get(key)) as Buffer | null;
+      return (await this.db.get(key)) as Uint8Array | null;
     } catch (e) {
       if ((e as NotFoundError).notFound) {
         return null;
@@ -65,47 +65,47 @@ export class LevelDbController implements IDatabaseController<Uint8Array, Uint8A
     }
   }
 
-  async put(key: Buffer, value: Buffer): Promise<void> {
+  async put(key: Uint8Array, value: Uint8Array): Promise<void> {
     await this.db.put(key, value);
   }
 
-  async delete(key: Buffer): Promise<void> {
+  async delete(key: Uint8Array): Promise<void> {
     await this.db.del(key);
   }
 
-  async batchPut(items: IKeyValue<Buffer, Buffer>[]): Promise<void> {
+  async batchPut(items: IKeyValue<Uint8Array, Uint8Array>[]): Promise<void> {
     const batch = this.db.batch();
     for (const item of items) batch.put(item.key, item.value);
     await batch.write();
   }
 
-  async batchDelete(keys: Buffer[]): Promise<void> {
+  async batchDelete(keys: Uint8Array[]): Promise<void> {
     const batch = this.db.batch();
     for (const key of keys) batch.del(key);
     await batch.write();
   }
 
-  keysStream(opts?: IFilterOptions<Buffer>): AsyncGenerator<Buffer> {
+  keysStream(opts?: IFilterOptions<Uint8Array>): AsyncGenerator<Uint8Array> {
     return this.iterator({keys: true, values: false}, (key) => key, opts);
   }
 
-  valuesStream(opts?: IFilterOptions<Buffer>): AsyncGenerator<Buffer> {
+  valuesStream(opts?: IFilterOptions<Uint8Array>): AsyncGenerator<Uint8Array> {
     return this.iterator({keys: false, values: true}, (_key, value) => value, opts);
   }
 
-  entriesStream(opts?: IFilterOptions<Buffer>): AsyncGenerator<IKeyValue<Buffer, Buffer>> {
+  entriesStream(opts?: IFilterOptions<Uint8Array>): AsyncGenerator<IKeyValue<Uint8Array, Uint8Array>> {
     return this.iterator({keys: true, values: true}, (key, value) => ({key, value}), opts);
   }
 
-  async keys(opts?: IFilterOptions<Buffer>): Promise<Buffer[]> {
+  async keys(opts?: IFilterOptions<Uint8Array>): Promise<Uint8Array[]> {
     return all(this.keysStream(opts));
   }
 
-  async values(opts?: IFilterOptions<Buffer>): Promise<Buffer[]> {
+  async values(opts?: IFilterOptions<Uint8Array>): Promise<Uint8Array[]> {
     return all(this.valuesStream(opts));
   }
 
-  async entries(opts?: IFilterOptions<Buffer>): Promise<IKeyValue<Buffer, Buffer>[]> {
+  async entries(opts?: IFilterOptions<Uint8Array>): Promise<IKeyValue<Uint8Array, Uint8Array>[]> {
     return all(this.entriesStream(opts));
   }
 
@@ -120,8 +120,8 @@ export class LevelDbController implements IDatabaseController<Uint8Array, Uint8A
    */
   private async *iterator<T>(
     keysOpts: StreamKeysOpts,
-    getValue: (key: Buffer, value: Buffer) => T,
-    opts?: IFilterOptions<Buffer>
+    getValue: (key: Uint8Array, value: Uint8Array) => T,
+    opts?: IFilterOptions<Uint8Array>
   ): AsyncGenerator<T> {
     // Entries = { keys: true, values: true }
     // Keys =    { keys: true, values: false }
@@ -136,8 +136,8 @@ export class LevelDbController implements IDatabaseController<Uint8Array, Uint8A
 
     try {
       while (true) {
-        const [key, value] = await new Promise<[Buffer, Buffer]>((resolve, reject) => {
-          iterator.next((err, key: Buffer, value: Buffer) => {
+        const [key, value] = await new Promise<[Uint8Array, Uint8Array]>((resolve, reject) => {
+          iterator.next((err, key: Uint8Array, value: Uint8Array) => {
             if (err) reject(err);
             else resolve([key, value]);
           });

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -86,7 +86,7 @@ export const uintLen = 8;
 /**
  * Prepend a bucket to a key
  */
-export function encodeKey(bucket: Bucket, key: Uint8Array | string | number | bigint): Buffer {
+export function encodeKey(bucket: Bucket, key: Uint8Array | string | number | bigint): Uint8Array {
   let buf;
   const prefixLength = BUCKET_LENGTH;
   //all keys are writen with prefixLength offet

--- a/packages/db/test/unit/schema.test.ts
+++ b/packages/db/test/unit/schema.test.ts
@@ -24,7 +24,7 @@ describe("encodeKey", () => {
     it(`should properly encode ${type}`, () => {
       let expected;
       if (type === "Buffer") {
-        expected = Buffer.concat([intToBytes(bucket, BUCKET_LENGTH, "le"), key as Buffer]);
+        expected = Buffer.concat([intToBytes(bucket, BUCKET_LENGTH, "le"), key as Uint8Array]);
       } else if (typeof key === "string") {
         expected = Buffer.concat([intToBytes(bucket, BUCKET_LENGTH, "le"), Buffer.from(key)]);
       } else if (typeof key === "number" || typeof key === "bigint") {

--- a/packages/lodestar/src/db/repositories/blockArchiveIndex.ts
+++ b/packages/lodestar/src/db/repositories/blockArchiveIndex.ts
@@ -23,10 +23,10 @@ export async function deleteParentRootIndex(db: Db, block: allForks.SignedBeacon
   return db.delete(getParentRootIndexKey(block.message.parentRoot));
 }
 
-export function getParentRootIndexKey(parentRoot: Root): Buffer {
+export function getParentRootIndexKey(parentRoot: Root): Uint8Array {
   return encodeKey(Bucket.index_blockArchiveParentRootIndex, parentRoot.valueOf() as Uint8Array);
 }
 
-export function getRootIndexKey(root: Root): Buffer {
+export function getRootIndexKey(root: Root): Uint8Array {
   return encodeKey(Bucket.index_blockArchiveRootIndex, root.valueOf() as Uint8Array);
 }

--- a/packages/lodestar/src/db/repositories/stateArchiveIndex.ts
+++ b/packages/lodestar/src/db/repositories/stateArchiveIndex.ts
@@ -6,6 +6,6 @@ export function storeRootIndex(db: Db, slot: Slot, stateRoot: Root): Promise<voi
   return db.put(getRootIndexKey(stateRoot), intToBytes(slot, 8, "be"));
 }
 
-export function getRootIndexKey(root: Root): Buffer {
+export function getRootIndexKey(root: Root): Uint8Array {
   return encodeKey(Bucket.index_stateArchiveRootIndex, root.valueOf() as Uint8Array);
 }

--- a/packages/validator/src/repositories/metaDataRepository.ts
+++ b/packages/validator/src/repositories/metaDataRepository.ts
@@ -37,7 +37,7 @@ export class MetaDataRepository {
     await this.db.put(this.encodeKey(GENESIS_TIME), Buffer.from(ssz.Uint64.serialize(genesisTime)));
   }
 
-  private encodeKey(key: Buffer): Buffer {
+  private encodeKey(key: Uint8Array): Uint8Array {
     return encodeKey(this.bucket, key);
   }
 }

--- a/packages/validator/src/slashingProtection/attestation/attestationByTargetRepository.ts
+++ b/packages/validator/src/slashingProtection/attestation/attestationByTargetRepository.ts
@@ -61,7 +61,7 @@ export class AttestationByTargetRepository {
     return uniqueVectorArr(keys.map((key) => this.decodeKey(key).pubkey));
   }
 
-  private encodeKey(pubkey: BLSPubkey, targetEpoch: Epoch): Buffer {
+  private encodeKey(pubkey: BLSPubkey, targetEpoch: Epoch): Uint8Array {
     return encodeKey(
       this.bucket,
       Buffer.concat([Buffer.from(pubkey as Uint8Array), intToBytes(BigInt(targetEpoch), uintLen, "be")])

--- a/packages/validator/src/slashingProtection/attestation/attestationLowerBoundRepository.ts
+++ b/packages/validator/src/slashingProtection/attestation/attestationLowerBoundRepository.ts
@@ -43,7 +43,7 @@ export class AttestationLowerBoundRepository {
     await this.db.put(this.encodeKey(pubkey), Buffer.from(this.type.serialize(value)));
   }
 
-  private encodeKey(pubkey: BLSPubkey): Buffer {
+  private encodeKey(pubkey: BLSPubkey): Uint8Array {
     return encodeKey(this.bucket, Buffer.from(pubkey as Uint8Array));
   }
 }

--- a/packages/validator/src/slashingProtection/block/blockBySlotRepository.ts
+++ b/packages/validator/src/slashingProtection/block/blockBySlotRepository.ts
@@ -64,7 +64,7 @@ export class BlockBySlotRepository {
     return uniqueVectorArr(keys.map((key) => this.decodeKey(key).pubkey));
   }
 
-  private encodeKey(pubkey: BLSPubkey, slot: Slot): Buffer {
+  private encodeKey(pubkey: BLSPubkey, slot: Slot): Uint8Array {
     return encodeKey(
       this.bucket,
       Buffer.concat([Buffer.from(pubkey as Uint8Array), intToBytes(BigInt(slot), uintLen, "be")])

--- a/packages/validator/src/slashingProtection/minMaxSurround/distanceStoreRepository.ts
+++ b/packages/validator/src/slashingProtection/minMaxSurround/distanceStoreRepository.ts
@@ -43,7 +43,7 @@ class SpanDistanceRepository {
     );
   }
 
-  private encodeKey(pubkey: BLSPubkey, epoch: Epoch): Buffer {
+  private encodeKey(pubkey: BLSPubkey, epoch: Epoch): Uint8Array {
     return encodeKey(
       this.bucket,
       Buffer.concat([Buffer.from(pubkey as Uint8Array), intToBytes(BigInt(epoch), 8, "be")])


### PR DESCRIPTION
**Motivation**

Current Buffer types cause unnecessary type casting. Since static methods like Buffer.concat accept Uint8Array it's not necessary to type as Buffer.

**Description**

- Use Uint8Array in all db types