### PR TITLE
Enforce usage of node:* protocol with eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -98,7 +98,7 @@ module.exports = {
         allowNullableBoolean: true,
         allowNullableString: true,
         allowAny: true,
-      }
+      },
     ],
     "import/no-extraneous-dependencies": [
       "error",
@@ -126,7 +126,19 @@ module.exports = {
     "prefer-const": "error",
     quotes: ["error", "double"],
     semi: "off",
-    "no-restricted-imports": ["error", {patterns: ["../lib/*", "@chainsafe/*/lib/*"]}],
+    "no-restricted-imports": [
+      "error",
+      {
+        patterns: ["../lib/*", "@chainsafe/*/lib/*"],
+        paths: [
+          {name: "fs", message: "Please use node:fs instead."},
+          {name: "path", message: "Please use node:path instead."},
+          {name: "crypto", message: "Please use node:crypto instead."},
+          {name: "url", message: "Please use node:url instead."},
+          {name: "os", message: "Please use node:os instead."},
+        ],
+      },
+    ],
     // Force to add names to all functions to ease CPU profiling
     "func-names": ["error", "always"],
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -131,11 +131,16 @@ module.exports = {
       {
         patterns: ["../lib/*", "@chainsafe/*/lib/*"],
         paths: [
-          {name: "fs", message: "Please use node:fs instead."},
-          {name: "path", message: "Please use node:path instead."},
+          {name: "child_process", message: "Please use node:child_process instead."},
           {name: "crypto", message: "Please use node:crypto instead."},
-          {name: "url", message: "Please use node:url instead."},
+          {name: "fs", message: "Please use node:fs instead."},
+          {name: "http", message: "Please use node:http instead."},
+          {name: "net", message: "Please use node:net instead."},
           {name: "os", message: "Please use node:os instead."},
+          {name: "path", message: "Please use node:path instead."},
+          {name: "stream", message: "Please use node:stream instead."},
+          {name: "util", message: "Please use node:util instead."},
+          {name: "url", message: "Please use node:url instead."},
         ],
       },
     ],
@@ -146,7 +151,18 @@ module.exports = {
     "no-only-tests/no-only-tests": "error",
   },
   settings: {
-    "import/core-modules": ["node:fs", "node:path"],
+    "import/core-modules": [
+      "node:child_process",
+      "node:crypto",
+      "node:fs",
+      "node:http",
+      "node:net",
+      "node:os",
+      "node:path",
+      "node:stream",
+      "node:util",
+      "node:url",
+    ],
   },
   overrides: [
     {

--- a/packages/api/test/unit/client/httpClient.test.ts
+++ b/packages/api/test/unit/client/httpClient.test.ts
@@ -3,7 +3,7 @@ import {AbortController} from "@chainsafe/abort-controller";
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
 import fastify, {RouteOptions} from "fastify";
-import {IncomingMessage} from "http";
+import {IncomingMessage} from "node:http";
 import {HttpClient, HttpError} from "../../../src/client/utils";
 
 chai.use(chaiAsPromised);

--- a/packages/beacon-state-transition/test/unit/signatureSets/signatureSets.test.ts
+++ b/packages/beacon-state-transition/test/unit/signatureSets/signatureSets.test.ts
@@ -1,4 +1,4 @@
-import crypto from "crypto";
+import crypto from "node:crypto";
 import bls from "@chainsafe/bls";
 import {BitList, List, TreeBacked} from "@chainsafe/ssz";
 import {config} from "@chainsafe/lodestar-config/default";

--- a/packages/beacon-state-transition/test/utils/block.ts
+++ b/packages/beacon-state-transition/test/utils/block.ts
@@ -1,4 +1,4 @@
-import crypto from "crypto";
+import crypto from "node:crypto";
 import {List} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
 import {ZERO_HASH} from "../../src/constants";

--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import {promisify} from "util";
+import {promisify} from "node:util";
 import rimraf from "rimraf";
 import path from "node:path";
 import {fromHexString} from "@chainsafe/ssz";

--- a/packages/cli/src/paths/rootDir.ts
+++ b/packages/cli/src/paths/rootDir.ts
@@ -1,4 +1,4 @@
-import os from "os";
+import os from "node:os";
 import path from "node:path";
 import {NetworkName} from "../networks";
 

--- a/packages/cli/src/util/file.ts
+++ b/packages/cli/src/util/file.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import stream from "stream";
-import {promisify} from "util";
+import stream from "node:stream";
+import {promisify} from "node:util";
 import got from "got";
 import {load, dump, FAILSAFE_SCHEMA, Schema, Type} from "js-yaml";
 import {Json} from "@chainsafe/ssz";

--- a/packages/cli/src/util/gitData/index.ts
+++ b/packages/cli/src/util/gitData/index.ts
@@ -1,4 +1,4 @@
-import {execSync} from "child_process";
+import {execSync} from "node:child_process";
 
 /**
  * This file is created in the build step and is distributed through NPM

--- a/packages/cli/src/util/randomPassword.ts
+++ b/packages/cli/src/util/randomPassword.ts
@@ -1,4 +1,4 @@
-import crypto from "crypto";
+import crypto from "node:crypto";
 
 const DEFAULT_PASSWORD_LEN = 48;
 

--- a/packages/lodestar/src/api/rest/index.ts
+++ b/packages/lodestar/src/api/rest/index.ts
@@ -1,7 +1,7 @@
 import fastify, {FastifyError, FastifyInstance} from "fastify";
 import fastifyCors from "fastify-cors";
 import querystring from "querystring";
-import {IncomingMessage} from "http";
+import {IncomingMessage} from "node:http";
 import {Api} from "@chainsafe/lodestar-api";
 import {registerRoutes, RouteConfig} from "@chainsafe/lodestar-api/server";
 import {ErrorAborted, ILogger} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/src/chain/bls/multithread/utils.ts
+++ b/packages/lodestar/src/chain/bls/multithread/utils.ts
@@ -28,7 +28,7 @@ export function getDefaultPoolSize(): number {
 
   if (typeof require !== "undefined") {
     // eslint-disable-next-line
-    return require("os").cpus().length;
+    return require("node:os").cpus().length;
   }
 
   return 8;

--- a/packages/lodestar/src/executionEngine/mock.ts
+++ b/packages/lodestar/src/executionEngine/mock.ts
@@ -1,4 +1,4 @@
-import crypto from "crypto";
+import crypto from "node:crypto";
 import {bellatrix, RootHex, Root} from "@chainsafe/lodestar-types";
 import {toHexString} from "@chainsafe/ssz";
 import {ZERO_HASH, ZERO_HASH_HEX} from "../constants";

--- a/packages/lodestar/src/metrics/server/http.ts
+++ b/packages/lodestar/src/metrics/server/http.ts
@@ -1,7 +1,7 @@
 /**
  * @module metrics/server
  */
-import http from "http";
+import http from "node:http";
 import {createHttpTerminator, HttpTerminator} from "http-terminator";
 import {Registry} from "prom-client";
 import {ILogger} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/src/network/peers/discover.ts
+++ b/packages/lodestar/src/network/peers/discover.ts
@@ -1,7 +1,7 @@
 import LibP2p from "libp2p";
 import PeerId from "peer-id";
 import {Multiaddr} from "multiaddr";
-import crypto from "crypto";
+import crypto from "node:crypto";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {Discv5, ENR, IDiscv5Metrics, IDiscv5DiscoveryInputOptions} from "@chainsafe/discv5";

--- a/packages/lodestar/src/network/util.ts
+++ b/packages/lodestar/src/network/util.ts
@@ -5,7 +5,7 @@
 
 import PeerId from "peer-id";
 import {Multiaddr} from "multiaddr";
-import {networkInterfaces} from "os";
+import {networkInterfaces} from "node:os";
 import {ENR} from "@chainsafe/discv5";
 import MetadataBook from "libp2p/src/peer-store/metadata-book";
 import {clientFromAgentVersion, ClientKind} from "./peers/client";

--- a/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import "mocha";
 import {expect} from "chai";
-import {promisify} from "util";
+import {promisify} from "node:util";
 import leveldown from "leveldown";
 import {AbortController} from "@chainsafe/abort-controller";
 import {sleep} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/test/e2e/eth1/jsonRpcHttpClient.test.ts
+++ b/packages/lodestar/test/e2e/eth1/jsonRpcHttpClient.test.ts
@@ -1,7 +1,7 @@
 import "mocha";
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
-import http from "http";
+import http from "node:http";
 import {AbortController} from "@chainsafe/abort-controller";
 import {JsonRpcHttpClient} from "../../../src/eth1/provider/jsonRpcHttpClient";
 import {getGoerliRpcUrl} from "../../testParams";

--- a/packages/lodestar/test/memory/bytesHex.ts
+++ b/packages/lodestar/test/memory/bytesHex.ts
@@ -1,5 +1,5 @@
 import {toHexString} from "@chainsafe/ssz";
-import crypto from "crypto";
+import crypto from "node:crypto";
 import {testRunnerMemory} from "./testRunnerMemory";
 
 // Results in Linux Dec 2021

--- a/packages/lodestar/test/memory/pubkeysToIndex.ts
+++ b/packages/lodestar/test/memory/pubkeysToIndex.ts
@@ -1,5 +1,5 @@
 import {toHexString} from "@chainsafe/ssz";
-import crypto from "crypto";
+import crypto from "node:crypto";
 import {testRunnerMemory} from "./testRunnerMemory";
 
 // Results in Linux Jan 2022

--- a/packages/lodestar/test/perf/misc/bytesHex.test.ts
+++ b/packages/lodestar/test/perf/misc/bytesHex.test.ts
@@ -1,4 +1,4 @@
-import crypto from "crypto";
+import crypto from "node:crypto";
 import {itBench} from "@dapplion/benchmark";
 import {toHexString} from "@chainsafe/ssz";
 

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
-import net from "net";
-import {spawn} from "child_process";
+import net from "node:net";
+import {spawn} from "node:child_process";
 import {Context} from "mocha";
 import {AbortController, AbortSignal} from "@chainsafe/abort-controller";
 import {fromHexString} from "@chainsafe/ssz";

--- a/packages/lodestar/test/sim/multiNodeMultiThread.test.ts
+++ b/packages/lodestar/test/sim/multiNodeMultiThread.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import os from "os";
+import os from "node:os";
 import {Worker} from "worker_threads";
 import {phase0} from "@chainsafe/lodestar-types";
 import {toHexString} from "@chainsafe/ssz";

--- a/packages/lodestar/test/sim/shell.ts
+++ b/packages/lodestar/test/sim/shell.ts
@@ -1,4 +1,4 @@
-import childProcess from "child_process";
+import childProcess from "node:child_process";
 import {AbortSignal} from "@chainsafe/abort-controller";
 
 /**

--- a/packages/lodestar/test/utils/attestation.ts
+++ b/packages/lodestar/test/utils/attestation.ts
@@ -1,6 +1,6 @@
 import {List} from "@chainsafe/ssz";
 import {CommitteeIndex, Epoch, Slot, phase0} from "@chainsafe/lodestar-types";
-import crypto from "crypto";
+import crypto from "node:crypto";
 import deepmerge from "deepmerge";
 import {isPlainObject} from "@chainsafe/lodestar-utils";
 import {RecursivePartial} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/types/snappy-stream/index.d.ts
+++ b/packages/lodestar/types/snappy-stream/index.d.ts
@@ -1,5 +1,5 @@
 declare module "@chainsafe/snappy-stream" {
-  import {Transform} from "stream";
+  import {Transform} from "node:stream";
 
   export function createUncompressStream(opts?: {asBuffer?: boolean}): Transform;
   export function createCompressStream(): Transform;

--- a/packages/lodestar/types/stream-to-it/index.d.ts
+++ b/packages/lodestar/types/stream-to-it/index.d.ts
@@ -1,4 +1,4 @@
 declare module "stream-to-it" {
-  import {Readable} from "stream";
+  import {Readable} from "node:stream";
   export function source<T = Buffer | string>(readable: Readable): AsyncGenerator<T>;
 }

--- a/packages/params/test/e2e/setPreset.test.ts
+++ b/packages/params/test/e2e/setPreset.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
-import util from "util";
-import * as child from "child_process";
+import util from "node:util";
+import child from "node:child_process";
 import {expect, use} from "chai";
 import chaiAsPromised from "chai-as-promised";
 

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -4,8 +4,8 @@ import path from "node:path";
 import rimraf from "rimraf";
 import axios from "axios";
 import tar from "tar";
-import stream from "stream";
-import {promisify} from "util";
+import stream from "node:stream";
+import {promisify} from "node:util";
 import retry from "async-retry";
 
 export type TestToDownload = "general" | "mainnet" | "minimal";

--- a/packages/utils/src/logger/interface.ts
+++ b/packages/utils/src/logger/interface.ts
@@ -2,7 +2,7 @@
  * @module logger
  */
 
-import {Writable} from "stream";
+import {Writable} from "node:stream";
 
 export enum LogLevel {
   error = "error",

--- a/packages/utils/src/logger/winston.ts
+++ b/packages/utils/src/logger/winston.ts
@@ -6,7 +6,7 @@ import {createLogger, Logger} from "winston";
 import {Context, defaultLogLevel, ILogger, ILoggerOptions, LogLevel, logLevelNum} from "./interface";
 import chalk from "chalk";
 import {getFormat} from "./format";
-import {Writable} from "stream";
+import {Writable} from "node:stream";
 import {TransportOpts, TransportType, fromTransportOpts} from "./transport";
 
 const defaultTransportOpts: TransportOpts = {type: TransportType.console};

--- a/packages/utils/test/unit/logger/winston.test.ts
+++ b/packages/utils/test/unit/logger/winston.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import rimraf from "rimraf";
-import {Writable} from "stream";
+import {Writable} from "node:stream";
 import {expect} from "chai";
 import {Context, LodestarError, LogFormat, logFormats, LogLevel, sleep, WinstonLogger} from "../../../src";
 import {TransportType} from "../../../src/logger/transport";

--- a/scripts/generate_changelog_simple.js
+++ b/scripts/generate_changelog_simple.js
@@ -6,7 +6,7 @@
 no-console
 */
 
-const {execSync} = require("child_process");
+const {execSync} = require("node:child_process");
 const fs = require("node:fs");
 
 // Docs

--- a/scripts/get_prev_tag.js
+++ b/scripts/get_prev_tag.js
@@ -11,8 +11,8 @@
 //
 // Outputs to output.prev_tag
 
-const {exec} = require("child_process");
-const {promisify} = require("util");
+const {exec} = require("node:child_process");
+const {promisify} = require("node:util");
 
 async function run() {
   const {CURRENT_TAG, IGNORE_PATTERN} = process.env;


### PR DESCRIPTION
**Motivation**

Enforce https://github.com/ChainSafe/lodestar/pull/3667 to not import from `"fs"` by mistake (I just did)

**Description**

- [Enforce usage of node protocol with eslint](https://github.com/ChainSafe/lodestar/commit/bc317c07d086eab604b31058c880df487cf160a5)
- Extend to all modules that we currently use in Lodestar