### PR TITLE
Cache syncCommittee contribution participant count

### DIFF
--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -500,8 +500,11 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
         contributionAndProofs.map(async (contributionAndProof, i) => {
           try {
             // TODO: Validate in batch
-            await validateSyncCommitteeGossipContributionAndProof(chain, contributionAndProof);
-            chain.syncContributionAndProofPool.add(contributionAndProof.message);
+            const {syncCommitteeParticipants} = await validateSyncCommitteeGossipContributionAndProof(
+              chain,
+              contributionAndProof
+            );
+            chain.syncContributionAndProofPool.add(contributionAndProof.message, syncCommitteeParticipants);
             await network.gossip.publishContributionAndProof(contributionAndProof);
           } catch (e) {
             errors.push(e as Error);

--- a/packages/lodestar/src/chain/validation/syncCommitteeContributionAndProof.ts
+++ b/packages/lodestar/src/chain/validation/syncCommitteeContributionAndProof.ts
@@ -16,7 +16,7 @@ import {
 export async function validateSyncCommitteeGossipContributionAndProof(
   chain: IBeaconChain,
   signedContributionAndProof: altair.SignedContributionAndProof
-): Promise<void> {
+): Promise<{syncCommitteeParticipants: number}> {
   const contributionAndProof = signedContributionAndProof.message;
   const {contribution, aggregatorIndex} = contributionAndProof;
   const {subcommitteeIndex, slot} = contribution;
@@ -85,4 +85,6 @@ export async function validateSyncCommitteeGossipContributionAndProof(
 
   // no need to add to seenSyncCommittteeContributionCache here, gossip handler will do that
   chain.seenContributionAndProof.add(slot, subcommitteeIndex, aggregatorIndex);
+
+  return {syncCommitteeParticipants: pubkeys.length};
 }

--- a/packages/lodestar/test/utils/contributionAndProof.ts
+++ b/packages/lodestar/test/utils/contributionAndProof.ts
@@ -1,4 +1,5 @@
 import {EMPTY_SIGNATURE} from "@chainsafe/lodestar-beacon-state-transition";
+import {SYNC_COMMITTEE_SUBNET_SIZE} from "@chainsafe/lodestar-params";
 import {altair} from "@chainsafe/lodestar-types";
 import {isPlainObject, RecursivePartial} from "@chainsafe/lodestar-utils";
 import {fromHexString, List} from "@chainsafe/ssz";
@@ -6,7 +7,7 @@ import deepmerge from "deepmerge";
 
 export function generateEmptyContribution(): altair.SyncCommitteeContribution {
   return {
-    aggregationBits: Array.from({length: 64}, () => false) as List<boolean>,
+    aggregationBits: Array.from({length: SYNC_COMMITTEE_SUBNET_SIZE}, () => false) as List<boolean>,
     beaconBlockRoot: Buffer.alloc(32),
     signature: fromHexString(
       "99cb82bc69b4111d1a828963f0316ec9aa38c4e9e041a8afec86cd20dfe9a590999845bf01d4689f3bbe3df54e48695e081f1216027b577c7fccf6ab0a4fcc75faf8009c6b55e518478139f604f542d138ae3bc34bad01ee6002006d64c4ff82"


### PR DESCRIPTION
**Motivation**

Our current syncCommittee contribution opPool has the simple rules of:
- Replace existing contribution if the new one has more participants

This logic is okay, but the implementation does unnecessary work:
- De-serialize Signature for aggregation, before it's really necessary
- Recompute participation count when it's already computed in validation

**Description**

- Cache syncCommittee contribution participant count. Return validation artifact similar to what's done now with aggregates
