### PR TITLE
Declare locally non-spec'ed type Eth1Block

### DIFF
--- a/packages/lodestar/src/chain/genesis/interface.ts
+++ b/packages/lodestar/src/chain/genesis/interface.ts
@@ -1,10 +1,11 @@
 import {TreeBacked, List} from "@chainsafe/ssz";
-import {allForks, phase0, Root} from "@chainsafe/lodestar-types";
+import {allForks, Root} from "@chainsafe/lodestar-types";
+import {Eth1Block} from "../../eth1/interface";
 
 export interface IGenesisResult {
   state: TreeBacked<allForks.BeaconState>;
   depositTree: TreeBacked<List<Root>>;
-  block: phase0.Eth1Block;
+  block: Eth1Block;
 }
 
 export interface IGenesisBuilder {

--- a/packages/lodestar/src/eth1/eth1DepositsCache.ts
+++ b/packages/lodestar/src/eth1/eth1DepositsCache.ts
@@ -8,6 +8,7 @@ import {getEth1DataForBlocks} from "./utils/eth1Data";
 import {assertConsecutiveDeposits} from "./utils/eth1DepositEvent";
 import {getDepositsWithProofs} from "./utils/deposits";
 import {Eth1Error, Eth1ErrorCode} from "./errors";
+import {Eth1Block} from "./interface";
 
 export class Eth1DepositsCache {
   unsafeAllowDepositDataOverwrite: boolean;
@@ -111,9 +112,9 @@ export class Eth1DepositsCache {
    * @param toBlock
    */
   async getEth1DataForBlocks(
-    blocks: phase0.Eth1Block[],
+    blocks: Eth1Block[],
     lastProcessedDepositBlockNumber: number | null
-  ): Promise<(phase0.Eth1Data & phase0.Eth1Block)[]> {
+  ): Promise<(phase0.Eth1Data & Eth1Block)[]> {
     const highestBlock = blocks[blocks.length - 1]?.blockNumber;
     return await getEth1DataForBlocks(
       blocks,

--- a/packages/lodestar/src/eth1/interface.ts
+++ b/packages/lodestar/src/eth1/interface.ts
@@ -51,6 +51,13 @@ export interface IEth1ForBlockProduction {
   getPowBlock(powBlockHash: string): Promise<PowMergeBlock | null>;
 }
 
+/** Different Eth1Block from phase0.Eth1Block with blockHash */
+export type Eth1Block = {
+  blockHash: Uint8Array;
+  blockNumber: number;
+  timestamp: number;
+};
+
 export type PowMergeBlock = {
   number: number;
   blockhash: RootHex;

--- a/packages/lodestar/src/eth1/provider/eth1Provider.ts
+++ b/packages/lodestar/src/eth1/provider/eth1Provider.ts
@@ -6,7 +6,7 @@ import {chunkifyInclusiveRange} from "../../util/chunkify";
 import {linspace} from "../../util/numpy";
 import {retry} from "../../util/retry";
 import {depositEventTopics, parseDepositLog} from "../utils/depositContract";
-import {IEth1Provider} from "../interface";
+import {Eth1Block, IEth1Provider} from "../interface";
 import {Eth1Options} from "../options";
 import {isValidAddress} from "../../util/address";
 import {EthJsonRpcBlockRaw} from "../interface";
@@ -181,7 +181,7 @@ export class Eth1Provider implements IEth1Provider {
   }
 }
 
-export function parseEth1Block(blockRaw: EthJsonRpcBlockRaw): phase0.Eth1Block {
+export function parseEth1Block(blockRaw: EthJsonRpcBlockRaw): Eth1Block {
   if (typeof blockRaw !== "object") throw Error("block is not an object");
   return {
     blockHash: dataToBytes(blockRaw.hash, 32),

--- a/packages/lodestar/src/eth1/stream.ts
+++ b/packages/lodestar/src/eth1/stream.ts
@@ -3,7 +3,7 @@
  */
 
 import {AbortSignal} from "@chainsafe/abort-controller";
-import {IBatchDepositEvents, IEth1Provider, IEth1StreamParams} from "./interface";
+import {Eth1Block, IBatchDepositEvents, IEth1Provider, IEth1StreamParams} from "./interface";
 import {groupDepositEventsByBlock} from "./utils/groupDepositEventsByBlock";
 import {optimizeNextBlockDiffForGenesis} from "./utils/optimizeNextBlockDiffForGenesis";
 import {sleep} from "@chainsafe/lodestar-utils";
@@ -48,7 +48,7 @@ export async function* getDepositsAndBlockStreamForGenesis(
   provider: IEth1Provider,
   params: IEth1StreamParams,
   signal?: AbortSignal
-): AsyncGenerator<[phase0.DepositEvent[], phase0.Eth1Block]> {
+): AsyncGenerator<[phase0.DepositEvent[], Eth1Block]> {
   fromBlock = Math.max(fromBlock, provider.deployBlock);
   fromBlock = Math.min(fromBlock, await getRemoteFollowBlock(provider, params));
   let toBlock = fromBlock; // First, fetch only the first block

--- a/packages/lodestar/src/eth1/utils/eth1Data.ts
+++ b/packages/lodestar/src/eth1/utils/eth1Data.ts
@@ -3,6 +3,7 @@ import {List, TreeBacked} from "@chainsafe/ssz";
 import {getTreeAtIndex} from "../../util/tree";
 import {binarySearchLte} from "../../util/binarySearch";
 import {Eth1Error, Eth1ErrorCode} from "../errors";
+import {Eth1Block} from "../interface";
 
 type BlockNumber = number;
 
@@ -11,11 +12,11 @@ type BlockNumber = number;
  * eth1 data deposit is inferred from sparse eth1 data obtained from the deposit logs
  */
 export async function getEth1DataForBlocks(
-  blocks: phase0.Eth1Block[],
+  blocks: Eth1Block[],
   depositDescendingStream: AsyncIterable<phase0.DepositEvent>,
   depositRootTree: TreeBacked<List<Root>>,
   lastProcessedDepositBlockNumber: BlockNumber | null
-): Promise<(phase0.Eth1Data & phase0.Eth1Block)[]> {
+): Promise<(phase0.Eth1Data & Eth1Block)[]> {
   // Exclude blocks for which there is no valid eth1 data deposit
   if (lastProcessedDepositBlockNumber !== null) {
     blocks = blocks.filter((block) => block.blockNumber <= lastProcessedDepositBlockNumber);
@@ -38,7 +39,7 @@ export async function getEth1DataForBlocks(
   const depositCounts = depositsByBlockNumber.map((event) => event.index + 1);
   const depositRootByDepositCount = getDepositRootByDepositCount(depositCounts, depositRootTree);
 
-  const eth1Datas: (phase0.Eth1Data & phase0.Eth1Block)[] = [];
+  const eth1Datas: (phase0.Eth1Data & Eth1Block)[] = [];
   for (const block of blocks) {
     const deposit = binarySearchLte(depositsByBlockNumber, block.blockNumber, (event) => event.blockNumber);
     const depositCount = deposit.index + 1;

--- a/packages/lodestar/test/e2e/eth1/eth1Provider.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1Provider.test.ts
@@ -4,9 +4,9 @@ import {AbortController} from "@chainsafe/abort-controller";
 import {Eth1Options} from "../../../src/eth1/options";
 import {getTestnetConfig} from "../../utils/testnet";
 import {fromHexString} from "@chainsafe/ssz";
-import {phase0} from "@chainsafe/lodestar-types";
 import {goerliTestnetDepositEvents} from "../../utils/testnet";
 import {Eth1Provider, parseEth1Block} from "../../../src/eth1/provider/eth1Provider";
+import {Eth1Block} from "../../../src/eth1/interface";
 import {getGoerliRpcUrl} from "../../testParams";
 
 describe("eth1 / Eth1Provider", function () {
@@ -39,7 +39,7 @@ describe("eth1 / Eth1Provider", function () {
   });
 
   it("Should get a specific block by number", async function () {
-    const goerliGenesisBlock: phase0.Eth1Block = {
+    const goerliGenesisBlock: Eth1Block = {
       blockHash: fromHexString("0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a"),
       blockNumber: 0,
       timestamp: 1548854791,
@@ -58,7 +58,7 @@ describe("eth1 / Eth1Provider", function () {
 
   //
 
-  const firstGoerliBlocks: phase0.Eth1Block[] = [
+  const firstGoerliBlocks: Eth1Block[] = [
     [0, 1548854791, "0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a"],
     [1, 1548947453, "0x8f5bab218b6bb34476f51ca588e9f4553a3a7ce5e13a66c660a5283e97e9a85a"],
     [2, 1548947468, "0xe675f1362d82cdd1ec260b16fb046c17f61d8a84808150f5d715ccce775f575e"],

--- a/packages/lodestar/test/unit/eth1/utils/eth1Data.test.ts
+++ b/packages/lodestar/test/unit/eth1/utils/eth1Data.test.ts
@@ -12,17 +12,18 @@ import {
 } from "../../../../src/eth1/utils/eth1Data";
 import {expectRejectedWithLodestarError} from "../../../utils/errors";
 import {Eth1ErrorCode} from "../../../../src/eth1/errors";
+import {Eth1Block} from "../../../../src/eth1/interface";
 
 chai.use(chaiAsPromised);
 
 describe("eth1 / util / getEth1DataForBlocks", function () {
   interface ITestCase {
     id: string;
-    blocks: phase0.Eth1Block[];
+    blocks: Eth1Block[];
     deposits: phase0.DepositEvent[];
     depositRootTree: TreeBacked<List<Root>>;
     lastProcessedDepositBlockNumber: number;
-    expectedEth1Data?: Partial<phase0.Eth1Data & phase0.Eth1Block>[];
+    expectedEth1Data?: Partial<phase0.Eth1Data & Eth1Block>[];
     error?: Eth1ErrorCode;
   }
 
@@ -260,7 +261,7 @@ describe("eth1 / util / getDepositRootByDepositCount", function () {
   }
 });
 
-function getMockBlock({blockNumber}: {blockNumber: number}): phase0.Eth1Block {
+function getMockBlock({blockNumber}: {blockNumber: number}): Eth1Block {
   return {
     blockNumber,
     blockHash: Buffer.alloc(32, blockNumber),

--- a/packages/lodestar/test/unit/eth1/utils/optimizeNextBlockDiffForGenesis.test.ts
+++ b/packages/lodestar/test/unit/eth1/utils/optimizeNextBlockDiffForGenesis.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 import {optimizeNextBlockDiffForGenesis} from "../../../../src/eth1/utils/optimizeNextBlockDiffForGenesis";
-import {phase0} from "@chainsafe/lodestar-types";
+import {Eth1Block} from "../../../../src/eth1/interface";
 
 describe("eth1 / utils / optimizeNextBlockDiffForGenesis", function () {
   it("should return optimized block diff to find genesis time", () => {
@@ -13,7 +13,7 @@ describe("eth1 / utils / optimizeNextBlockDiffForGenesis", function () {
       SECONDS_PER_ETH1_BLOCK: 14,
     };
     const initialTimeDiff = params.GENESIS_DELAY * 2;
-    let lastFetchedBlock: phase0.Eth1Block = {
+    let lastFetchedBlock: Eth1Block = {
       blockHash: Buffer.alloc(32, 0),
       blockNumber: 100000,
       timestamp: params.MIN_GENESIS_TIME - initialTimeDiff,


### PR DESCRIPTION
**Motivation**

Our `phase0.Eth1Block` type is **not** the one spec'ed, which caused a bit of chaos when integrating the new version of SSZ.

**Description**

Re-declare our own version of Eth1Block locally in Lodestar package and leave `phase0.Eth1Block` as a placeholder to be replaced with the spec'ed version.