### PR TITLE
Mask out the infura style wss credentials for the log

### DIFF
--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -108,7 +108,7 @@ export async function initBeaconState(
       // Validate the weakSubjectivityServerUrl and only log the origin to mask the
       // username password credentials
       const wssUrl = new URL(args.weakSubjectivityServerUrl);
-      logger.info("Fetching weak subjectivity state from", {
+      logger.info("Fetching weak subjectivity state", {
         weakSubjectivityServerUrl: wssUrl.origin,
       });
     } catch (e) {

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -104,7 +104,17 @@ export async function initBeaconState(
     if (!args.weakSubjectivityServerUrl) {
       throw Error(`Must set arg --weakSubjectivityServerUrl for network ${args.network}`);
     }
-    logger.info("Fetching weak subjectivity state", {weakSubjectivityServerUrl: args.weakSubjectivityServerUrl});
+    logger.info("Fetching weak subjectivity state,", {
+      // Mask out the wss credentials of the format:
+      //  1. "(http|https)://<alphanumeric>:<alphanumeric>@any.domain.baseurl" =>
+      //     "(http|https)://*****@any.domain.baseurl"
+      //  2. "<alphanumeric>:<alphanumeric>@any.domain.baseurl" =>
+      //     "*****@any.domain.baseurl"
+      weakSubjectivityServerUrl: args.weakSubjectivityServerUrl.replace(
+        /((?<=^)|(?<=\/\/))((\w)+:(\w)+)(?=@([\w\-.])+)/,
+        "*****"
+      ),
+    });
 
     const {wsState, wsCheckpoint} = await fetchWeakSubjectivityState(
       chainForkConfig,

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -104,17 +104,17 @@ export async function initBeaconState(
     if (!args.weakSubjectivityServerUrl) {
       throw Error(`Must set arg --weakSubjectivityServerUrl for network ${args.network}`);
     }
-    logger.info("Fetching weak subjectivity state,", {
-      // Mask out the wss credentials of the format:
-      //  1. "(http|https)://<alphanumeric>:<alphanumeric>@any.domain.baseurl" =>
-      //     "(http|https)://*****@any.domain.baseurl"
-      //  2. "<alphanumeric>:<alphanumeric>@any.domain.baseurl" =>
-      //     "*****@any.domain.baseurl"
-      weakSubjectivityServerUrl: args.weakSubjectivityServerUrl.replace(
-        /((?<=^)|(?<=\/\/))((\w)+:(\w)+)(?=@([\w\-.])+)/,
-        "*****"
-      ),
-    });
+    try {
+      // Validate the weakSubjectivityServerUrl and only log the origin to mask the
+      // username password credentials
+      const wssUrl = new URL(args.weakSubjectivityServerUrl);
+      logger.info("Fetching weak subjectivity state from", {
+        weakSubjectivityServerUrl: wssUrl.origin,
+      });
+    } catch (e) {
+      logger.error("Invalid", {weakSubjectivityServerUrl: args.weakSubjectivityServerUrl}, e as Error);
+      throw e;
+    }
 
     const {wsState, wsCheckpoint} = await fetchWeakSubjectivityState(
       chainForkConfig,


### PR DESCRIPTION
**Motivation**
A user requested to mask out the infura style credentials of the wss url that we log while starting the beacon node.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR  Mask out the wss credentials
New SUCCESS Log:
```
Feb-08 11:14:42.630 []                 info: Fetching weak subjectivity state from weakSubjectivityServerUrl=https://eth2-beacon-prater.infura.io

```

NEW ERROR Log, it still prints the full url string so that the user can validate and see what lodestar cli is picking as the url
```
Feb-08 11:14:15.437 []                error: Invalid weakSubjectivityServerUrl=(real url here..) message=Invalid URL
```
<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #3703

