### PR TITLE
Disable arm64 docker build

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -102,5 +102,5 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - run: docker buildx build --push --tag chainsafe/lodestar:next --platform linux/amd64,linux/arm64 --build-arg VERSION=${{ needs.npm.outputs.version }} .
+      - run: docker buildx build --push --tag chainsafe/lodestar:next --platform linux/amd64 --build-arg VERSION=${{ needs.npm.outputs.version }} .
       - run: docker run chainsafe/lodestar:next --help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,5 +121,5 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - run: docker buildx build --push --tag chainsafe/lodestar:latest --tag chainsafe/lodestar:${{ needs.tag.outputs.tag }} --platform linux/amd64,linux/arm64 --build-arg VERSION=${{ needs.tag.outputs.tag }} .
+      - run: docker buildx build --push --tag chainsafe/lodestar:latest --tag chainsafe/lodestar:${{ needs.tag.outputs.tag }} --platform linux/amd64 --build-arg VERSION=${{ needs.tag.outputs.tag }} .
       - run: docker run chainsafe/lodestar:latest --help


### PR DESCRIPTION
**Motivation**

See https://github.com/ChainSafe/lodestar/runs/5113003430?check_suite_focus=true
and
https://github.com/ChainSafe/blst-ts/issues/51

After #3698 , the docker build is breaking because blst isn't prebuilt for arm64, and the final docker layer doesn't have build tools to build blst itself.

We should first resolve chainsafe/blst-ts#51, then revert this when we're ready.

**Description**

Quick way to resolve the currently breaking docker build, just don't build the arm64 image.