### PR TITLE
Make block proposing flow resilient to errors

### DIFF
--- a/packages/lodestar/src/eth1/eth1DepositDataTracker.ts
+++ b/packages/lodestar/src/eth1/eth1DepositDataTracker.ts
@@ -83,12 +83,18 @@ export class Eth1DepositDataTracker {
    * Requires internal caches to be updated regularly to return good results
    */
   private async getEth1Data(state: allForks.BeaconState): Promise<phase0.Eth1Data> {
-    const eth1VotesToConsider = await getEth1VotesToConsider(
-      this.config,
-      state,
-      this.eth1DataCache.get.bind(this.eth1DataCache)
-    );
-    return pickEth1Vote(state, eth1VotesToConsider);
+    try {
+      const eth1VotesToConsider = await getEth1VotesToConsider(
+        this.config,
+        state,
+        this.eth1DataCache.get.bind(this.eth1DataCache)
+      );
+      return pickEth1Vote(state, eth1VotesToConsider);
+    } catch (e) {
+      // Note: In case there's a DB issue, don't stop a block proposal. Just vote for current eth1Data
+      this.logger.error("CRITICIAL: Error reading valid votes, voting for current eth1Data", {}, e as Error);
+      return state.eth1Data;
+    }
   }
 
   /**
@@ -99,6 +105,11 @@ export class Eth1DepositDataTracker {
     state: CachedBeaconStateAllForks,
     eth1DataVote: phase0.Eth1Data
   ): Promise<phase0.Deposit[]> {
+    // No new deposits have to be included, continue
+    if (eth1DataVote.depositCount === state.eth1DepositIndex) {
+      return [];
+    }
+
     // TODO: Review if this is optimal
     // Convert to view first to hash once and compare hashes
     const eth1DataVoteView = ssz.phase0.Eth1Data.createTreeBackedFromStruct(eth1DataVote);


### PR DESCRIPTION
**Motivation**

Error https://github.com/ChainSafe/lodestar/issues/3700 could have been avoided because this block did not had to include any deposits

**Description**

- Only read deposits from DB if the block needs to include deposits
- If eth1Data vote computation errors, just vote for current eth1Data. This is a tradeoff between chain liveness and stalling the deposit queue.

Closes https://github.com/ChainSafe/lodestar/issues/3700