### PR TITLE
Use LinkedList for JobItemQueue

### DIFF
--- a/packages/lodestar/src/util/array.ts
+++ b/packages/lodestar/src/util/array.ts
@@ -112,4 +112,17 @@ export class LinkedList<T> {
 
     return arr;
   }
+
+  map<U>(fn: (t: T) => U): U[] {
+    let node = this.head;
+    if (!node) return [];
+
+    const arr: U[] = [];
+    while (node) {
+      arr.push(fn(node.data));
+      node = node.next;
+    }
+
+    return arr;
+  }
 }

--- a/packages/lodestar/src/util/array.ts
+++ b/packages/lodestar/src/util/array.ts
@@ -10,3 +10,106 @@ export function findLastIndex<T>(array: T[], predicate: (value: T) => boolean): 
   }
   return -1;
 }
+
+/**
+ * The node for LinkedList below
+ */
+class Node<T> {
+  data: T;
+  next: Node<T> | null = null;
+  prev: Node<T> | null = null;
+
+  constructor(data: T) {
+    this.data = data;
+  }
+}
+
+/**
+ * We want to use this if we only need push/pop/shift method
+ * without random access.
+ * The shift() method should be cheaper than regular array.
+ */
+export class LinkedList<T> {
+  private _length: number;
+  private head: Node<T> | null;
+  private tail: Node<T> | null;
+
+  constructor() {
+    this._length = 0;
+    this.head = null;
+    this.tail = null;
+  }
+
+  get length(): number {
+    return this._length;
+  }
+
+  push(data: T): void {
+    if (this._length === 0) {
+      this.tail = this.head = new Node(data);
+      this._length++;
+      return;
+    }
+
+    if (!this.head || !this.tail) {
+      // should not happen
+      throw Error("No head or tail");
+    }
+
+    const newTail = new Node(data);
+    this.tail.next = newTail;
+    newTail.prev = this.tail;
+    this.tail = newTail;
+    this._length++;
+  }
+
+  pop(): T | null {
+    const oldTail = this.tail;
+    if (!oldTail) return null;
+    this._length = Math.max(0, this._length - 1);
+
+    if (this._length === 0) {
+      this.head = this.tail = null;
+    } else {
+      this.tail = oldTail.prev;
+      if (this.tail) this.tail.next = null;
+      oldTail.prev = oldTail.next = null;
+    }
+
+    return oldTail.data;
+  }
+
+  shift(): T | null {
+    const oldHead = this.head;
+    if (!oldHead) return null;
+    this._length = Math.max(0, this._length - 1);
+
+    if (this._length === 0) {
+      this.head = this.tail = null;
+    } else {
+      this.head = oldHead.next;
+      if (this.head) this.head.prev = null;
+      oldHead.prev = oldHead.next = null;
+    }
+
+    return oldHead.data;
+  }
+
+  prune(): void {
+    this.head = this.tail = null;
+    this._length = 0;
+  }
+
+  toArray(): T[] {
+    let node = this.head;
+    if (!node) return [];
+
+    const arr: T[] = [];
+    while (node) {
+      arr.push(node.data);
+      node = node.next;
+    }
+
+    return arr;
+  }
+}

--- a/packages/lodestar/src/util/array.ts
+++ b/packages/lodestar/src/util/array.ts
@@ -95,7 +95,7 @@ export class LinkedList<T> {
     return oldHead.data;
   }
 
-  prune(): void {
+  clear(): void {
     this.head = this.tail = null;
     this._length = 0;
   }

--- a/packages/lodestar/src/util/queue/itemQueue.ts
+++ b/packages/lodestar/src/util/queue/itemQueue.ts
@@ -65,7 +65,7 @@ export class JobItemQueue<Args extends any[], R> {
   }
 
   dropAllJobs = (): void => {
-    this.jobs.prune();
+    this.jobs.clear();
   };
 
   private runJob = async (): Promise<void> => {

--- a/packages/lodestar/test/perf/util/array.test.ts
+++ b/packages/lodestar/test/perf/util/array.test.ts
@@ -1,0 +1,70 @@
+import {itBench} from "@dapplion/benchmark";
+import {LinkedList} from "../../../src/util/array";
+
+/**
+ * 16_000 items: push then shift  - LinkedList is >200x faster than regular array
+ *               push then pop - LinkedList is >10x faster than regular array
+ * 24_000 items: push then shift  - LinkedList is >350x faster than regular array
+ *               push then pop - LinkedList is >10x faster than regular array
+ */
+describe("LinkedList vs Regular Array", () => {
+  const arrayLengths = [16_000, 24_000];
+
+  for (const length of arrayLengths) {
+    itBench({
+      id: `array of ${length} items push then shift`,
+      beforeEach: () => Array.from({length}, (_, i) => i),
+      fn: (arr) => {
+        for (let i = 0; i < 1000; i++) {
+          arr.push(i);
+          arr.shift();
+        }
+      },
+      runsFactor: 1000,
+    });
+
+    itBench({
+      id: `LinkedList of ${length} items push then shift`,
+      beforeEach: () => {
+        const linkedList = new LinkedList<number>();
+        for (let i = 0; i < length; i++) linkedList.push(i);
+        return linkedList;
+      },
+      fn: (arr) => {
+        for (let i = 0; i < 1000; i++) {
+          arr.push(i);
+          arr.shift();
+        }
+      },
+      runsFactor: 1000,
+    });
+
+    itBench({
+      id: `array of ${length} items push then pop`,
+      beforeEach: () => Array.from({length}, (_, i) => i),
+      fn: (arr) => {
+        for (let i = 0; i < 1000; i++) {
+          arr.push(i);
+          arr.pop();
+        }
+      },
+      runsFactor: 1000,
+    });
+
+    itBench({
+      id: `LinkedList of ${length} items push then pop`,
+      beforeEach: () => {
+        const linkedList = new LinkedList<number>();
+        for (let i = 0; i < length; i++) linkedList.push(i);
+        return linkedList;
+      },
+      fn: (arr) => {
+        for (let i = 0; i < 1000; i++) {
+          arr.push(i);
+          arr.pop();
+        }
+      },
+      runsFactor: 1000,
+    });
+  }
+});

--- a/packages/lodestar/test/unit/util/array.test.ts
+++ b/packages/lodestar/test/unit/util/array.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 
-import {findLastIndex} from "../../../src/util/array";
+import {findLastIndex, LinkedList} from "../../../src/util/array";
 
 describe("findLastIndex", () => {
   it("should return the last index that matches a predicate", () => {
@@ -12,5 +12,64 @@ describe("findLastIndex", () => {
   it("should return -1 if there are no matches", () => {
     expect(findLastIndex([1, 3, 5], (n) => n % 2 == 0)).to.eql(-1);
     expect(findLastIndex([1, 2, 3, 4, 5], () => false)).to.eql(-1);
+  });
+});
+
+describe("LinkedList", () => {
+  let list: LinkedList<number>;
+
+  beforeEach(() => {
+    list = new LinkedList<number>();
+  });
+
+  it("pop", () => {
+    expect(list.pop() === null);
+    expect(list.length).to.be.equal(0);
+    let count = 100;
+    for (let i = 0; i < count; i++) list.push(i + 1);
+
+    while (count > 0) {
+      expect(list.length).to.be.equal(count);
+      expect(list.pop()).to.be.equal(count);
+      count--;
+    }
+
+    expect(list.pop() === null);
+    expect(list.length).to.be.equal(0);
+  });
+
+  it("shift", () => {
+    expect(list.shift() === null);
+    expect(list.length).to.be.equal(0);
+    const count = 100;
+    for (let i = 0; i < count; i++) list.push(i);
+
+    for (let i = 0; i < count; i++) {
+      expect(list.length).to.be.equal(count - i);
+      expect(list.shift()).to.be.equal(i);
+    }
+
+    expect(list.shift() === null);
+    expect(list.length).to.be.equal(0);
+  });
+
+  it("toArray", () => {
+    expect(list.toArray()).to.be.deep.equal([]);
+
+    const count = 100;
+    for (let i = 0; i < count; i++) list.push(i);
+
+    expect(list.length).to.be.equal(count);
+    expect(list.toArray()).to.be.deep.equal(Array.from({length: count}, (_, i) => i));
+  });
+
+  it("prune", () => {
+    const count = 100;
+    for (let i = 0; i < count; i++) list.push(i);
+
+    list.prune();
+
+    expect(list.toArray()).to.be.deep.equal([]);
+    expect(list.length).to.be.equal(0);
   });
 });

--- a/packages/lodestar/test/unit/util/array.test.ts
+++ b/packages/lodestar/test/unit/util/array.test.ts
@@ -67,7 +67,7 @@ describe("LinkedList", () => {
     const count = 100;
     for (let i = 0; i < count; i++) list.push(i);
 
-    list.prune();
+    list.clear();
 
     expect(list.toArray()).to.be.deep.equal([]);
     expect(list.length).to.be.equal(0);


### PR DESCRIPTION
**Motivation**

As shown in #3732, it takes up to 17% of cpu time just to do the `array.shift()`

**Description**

+ Since we don't need random access in the `jobs` array, write a LinkedList to improve the performance
+ The benchmark shows that it's way faster to use LinkedList to do shift / push /pop
```
LinkedList vs Regular Array
    ✓ array of 16000 items push then shift                                276390.5 ops/s    3.618070 us/op   x1.140       1017 runs   5.29 s
    ✓ LinkedList of 16000 items push then shift                        7.052684e+7 ops/s    14.17900 ns/op   x0.955       8744 runs   1.73 s
    ✓ array of 16000 items push then pop                                   6606896 ops/s    151.3570 ns/op   x0.947       1720 runs   3.04 s
    ✓ LinkedList of 16000 items push then pop                          7.412898e+7 ops/s    13.49000 ns/op   x1.006       8163 runs   1.82 s
    ✓ array of 24000 items push then shift                                167710.8 ops/s    5.962646 us/op   x0.994        389 runs   3.62 s
    ✓ LinkedList of 24000 items push then shift                        7.102777e+7 ops/s    14.07900 ns/op   x0.914       2824 runs   1.16 s
    ✓ array of 24000 items push then pop                                   4541347 ops/s    220.1990 ns/op   x1.180        525 runs   3.18 s
    ✓ LinkedList of 24000 items push then pop                          7.258474e+7 ops/s    13.77700 ns/op   x1.023       4409 runs   1.65 s
```
part of #3732 
