### PR TITLE
Show github branch in grafana dashboard if using ansible with lodestar_github_tag

### DIFF
--- a/packages/cli/src/util/gitData/index.ts
+++ b/packages/cli/src/util/gitData/index.ts
@@ -68,7 +68,7 @@ export function readLodestarGitData(): GitData {
     }
 
     return {
-      semver: gitData?.semver || "N/A",
+      semver: gitData?.semver,
       branch: gitData?.branch || "N/A",
       commit: gitData?.commit || "N/A",
       numCommits: gitData?.numCommits || "",

--- a/packages/cli/src/util/version.ts
+++ b/packages/cli/src/util/version.ts
@@ -28,17 +28,15 @@ const defaultReleaseTrack = ReleaseTrack.alpha;
  */
 export function getVersion(): string {
   const gitData: GitData = readLodestarGitData();
-  const semver: string | undefined = gitData.semver;
+  let semver: string | undefined = gitData.semver;
   const numCommits: string | undefined = gitData.numCommits;
   const commitSlice: string | undefined = gitData.commit?.slice(0, 8);
 
-  // Fall back to/assume local package version if git is unavailable
-  if (!semver || semver.includes("N/A")) {
-    return `v${getLocalVersion()} (${ReleaseTrack.npm})`;
-  }
+  // ansible github branch deployment returns no semver
+  semver = semver ?? `v${getLocalVersion()}`;
 
-  // If these values are empty/undefined, we assume tag release.
-  if (!commitSlice || !numCommits || numCommits === "") {
+  // Tag release has numCommits as "0"
+  if (!commitSlice || numCommits === "0") {
     return `${semver} (${defaultReleaseTrack})`;
   }
 


### PR DESCRIPTION
**Motivation**

+ Using ansible with "lodestar_github_tag", it always show the current local version, which is "v0.35.0 (npm)"
+ The code assumes if no "semver", there is no git but actually there is git and we can get github branch in this case

**Description**
+ Show github branch

<img width="808" alt="Screen Shot 2022-02-10 at 14 53 07" src="https://user-images.githubusercontent.com/10568965/153361898-dbcbd237-d864-471f-ad76-2fbfe5a44da9.png">

+ Note that with feature branch, we can't get "numCommit" but it should be fine with master