### PR TITLE
Prevent circular dependencies with eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -112,6 +112,9 @@ module.exports = {
     //if --fix is run it messes imports like /lib/presets/minimal & /lib/presets/mainnet
     "import/no-duplicates": "off",
     "import/no-relative-packages": "error",
+    // 'import/no-cycle' is expensive computationally, consider restricting its `maxdepth`
+    // See https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-cycle.md#maxdepth
+    "import/no-cycle": "error",
     "node/no-deprecated-api": "error",
     "new-parens": "error",
     "no-caller": "error",


### PR DESCRIPTION
**Motivation**

'import/no-cycle' is expensive computationally, consider restricting its `maxdepth`

See https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-cycle.md#maxdepth

A lint run in master currently takes `Done in 121.30s.` in Github Actions (from https://github.com/ChainSafe/lodestar/runs/5137987474?check_suite_focus=true#step:13:38)

In this PR for a failed run it took `in 137.5s` so the extra time is okay :+1: 

**Description**

Prevent circular dependencies with eslint