### PR TITLE
Implement `--safe-slots-to-import-optimistically` cli config option for optimistic sync

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -6,6 +6,7 @@ export interface IChainArgs {
   "chain.disableBlsBatchVerify": boolean;
   "chain.persistInvalidSszObjects": boolean;
   "chain.proposerBoostEnabled": boolean;
+  "safe-slots-to-import-optimistically": number;
   // this is defined as part of IBeaconPaths
   // "chain.persistInvalidSszObjectsDir": string;
 }
@@ -18,6 +19,7 @@ export function parseArgs(args: IChainArgs): IBeaconNodeOptions["chain"] {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
     persistInvalidSszObjectsDir: undefined as any,
     proposerBoostEnabled: args["chain.proposerBoostEnabled"],
+    safeSlotsToImportOptimistically: args["safe-slots-to-import-optimistically"],
   };
 }
 
@@ -51,6 +53,15 @@ Will double processing times. Use only for debugging purposes.",
     type: "boolean",
     description: "Enable proposer boost to reward a timely block",
     defaultDescription: String(defaultOptions.chain.proposerBoostEnabled),
+    group: "chain",
+  },
+
+  "safe-slots-to-import-optimistically": {
+    hidden: true,
+    type: "number",
+    description:
+      "Slots from current (clock) slot till which its safe to import a block optimistically if the merge is not justified yet.",
+    defaultDescription: String(defaultOptions.chain.safeSlotsToImportOptimistically),
     group: "chain",
   },
 };

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -18,6 +18,7 @@ describe("options / beaconNodeOptions", () => {
       "chain.disableBlsBatchVerify": true,
       "chain.persistInvalidSszObjects": true,
       "chain.proposerBoostEnabled": false,
+      "safe-slots-to-import-optimistically": 256,
 
       "eth1.enabled": true,
       "eth1.providerUrl": "http://my.node:8545",
@@ -73,6 +74,7 @@ describe("options / beaconNodeOptions", () => {
         disableBlsBatchVerify: true,
         persistInvalidSszObjects: true,
         proposerBoostEnabled: false,
+        safeSlotsToImportOptimistically: 256,
       },
       eth1: {
         enabled: true,

--- a/packages/lodestar/src/chain/blocks/verifyBlock.ts
+++ b/packages/lodestar/src/chain/blocks/verifyBlock.ts
@@ -1,5 +1,4 @@
 import {ssz} from "@chainsafe/lodestar-types";
-import {SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY} from "@chainsafe/lodestar-params";
 import {
   CachedBeaconStateAllForks,
   computeStartSlotAtEpoch,
@@ -235,11 +234,11 @@ export async function verifyBlockStateTransition(
 
         if (
           justifiedBlock.executionStatus === ExecutionStatus.PreMerge &&
-          block.message.slot + SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY > clockSlot
+          block.message.slot + opts.safeSlotsToImportOptimistically > clockSlot
         ) {
           throw new BlockError(block, {
             code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
-            errorMessage: `not safe to import not yet validated payload within ${SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY} of currentSlot, status=${execResult.status}`,
+            errorMessage: `not safe to import not yet validated payload within ${opts.safeSlotsToImportOptimistically} of currentSlot, status=${execResult.status}`,
           });
         }
 

--- a/packages/lodestar/src/chain/options.ts
+++ b/packages/lodestar/src/chain/options.ts
@@ -1,3 +1,4 @@
+import {SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY} from "@chainsafe/lodestar-params";
 import {ForkChoiceOpts} from "./forkChoice";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -14,6 +15,10 @@ export type BlockProcessOpts = {
    * Will double processing times. Use only for debugging purposes.
    */
   disableBlsBatchVerify?: boolean;
+  /**
+   * Override SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY
+   */
+  safeSlotsToImportOptimistically: number;
 };
 
 export const defaultChainOptions: IChainOptions = {
@@ -22,4 +27,5 @@ export const defaultChainOptions: IChainOptions = {
   persistInvalidSszObjects: true,
   persistInvalidSszObjectsDir: "",
   proposerBoostEnabled: false,
+  safeSlotsToImportOptimistically: SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY,
 };


### PR DESCRIPTION
**Motivation**
In optimistic sync, at the time of merge, there is a possibility that an unavailable `terminal` PoW can cause liveness failure of the chain (as all beacon nodes and their corresponding ELs which will process merge block will go into syncing mode). See #3622 for more details/references.
The solution was to provide for a range in which a beacon node will note accept optimistic execution payloads via a constant `SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY` = 128 slots if the merge has not been `justified` yet. 

However if such a non available terminal situation arises, a dynamic configuration of this might be required depending on the scenario, and has been recommended in spec to be configurable
https://github.com/ethereum/consensus-specs/blob/dev/sync/optimistic.md?plain=1#L218-L225

<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR provides for a user to specify this value via a cli param if he wants to overwrite the default SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY.
<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #3622
