### PR TITLE
Revert "Lodestar gossip queues to wrap processRpcMessage() (#3554)"

### DIFF
--- a/packages/lodestar/src/network/gossip/interface.ts
+++ b/packages/lodestar/src/network/gossip/interface.ts
@@ -118,13 +118,7 @@ export type GossipValidatorFn = (topic: GossipTopic, message: InMessage, seenTim
 
 export type ValidatorFnsByType = {[K in GossipType]: GossipValidatorFn};
 
-export type ProcessRpcMessageTopicFn = (topic: GossipTopic, message: InMessage) => Promise<void>;
-
-export type ProcessRpcMessageFn = (message: InMessage) => Promise<void>;
-
-export type ProcessRpcMessageFnsByType = {[K in GossipType]: ProcessRpcMessageTopicFn};
-
-export type GossipJobQueues = {[K in GossipType]: JobItemQueue<[GossipTopic, InMessage], void>};
+export type GossipJobQueues = {[K in GossipType]: JobItemQueue<[GossipTopic, InMessage, number], void>};
 
 export type GossipHandlerFn = (
   object: GossipTypeMap[GossipType],


### PR DESCRIPTION
This reverts commit fcbc4597cbf4561684363604e2dccfff80ef04ec.

**Motivation**

This reverts #3554. For our gossip queues, we wrapped `processRpcMessage()` instead of `validate()` because we found that `getMsgId()` is not cheap (it also uncompresses the message), it may be called and the message is still dropped in the end.

The down side is that we have different copies of same message in our queue, this leads to `queue.jobs.shift()` functions is called too much, see [#3732](https://github.com/ChainSafe/lodestar/issues/3732#issuecomment-1033431847)

With new gossipsub v0.12, we use `fast_msg_id` function so it resolves the original concerns of #3554 

**Description**
+ Revert #3554: gossip queues to wrap `validate()` instead of `processMessageRpc()`
+ So that only distinct gossip message is included in our gossip queues, duplicate messages are filtered before that time in `processMessageRpc()`
+ If this is approved, this should be merged before #3661 to avoid the conflict

Closes #3691 , #3749 