### PR TITLE
Group and refactor the wss options

### DIFF
--- a/docs/usage/testnet.md
+++ b/docs/usage/testnet.md
@@ -71,6 +71,23 @@ Jul-09 17:34:54.278 []                 info: Syncing - 3 days left - 3.00 slots/
 
 A young testnet should take a few hours to sync. If you see multiple or consistent errors in the logs, please open a [Github issue](https://github.com/ChainSafe/lodestar/issues/new) or reach out to us in [Discord](https://discord.gg/yjyvFRP). Just by reporting anomalities you are helping accelerate the progress of Eth2.0, thanks for contributing!
 
+### Weak Subjectivity
+
+If you are starting your node from blank db/genesis (or from last saved state in db) in a network which is now far ahead, your node is susceptible to something called "long range attacks".
+[Read Vitalik's illuminating post on the same](https://blog.ethereum.org/2014/11/25/proof-stake-learned-love-weak-subjectivity/)
+
+If you have a synced beacon node handy (your friend's or an infrastructure provider) and a trusted checkpoint you can rely on, you can start off your beacon node in under a minute! And at the same time kicking the "long range attack" in its butt!
+
+Just supply these **extra args** to your beacon node command:
+```bash
+--weakSubjectivity.syncLatest --weakSubjectivity.serverUrl <synced node url> [--weakSubjectivity.checkpoint <trusted checkpoint in root:epoch format>]
+```
+In case you really trust `weakSubjectivity.serverUrl` then you may skip providing `weakSubjectivity.checkpoint`, which will then result into your beacon node syncing and starting off a finalized state from the trusted url.
+
+#### PS
+Please use this option very carefully (and at your own risk), a malicious server url can put you on a wrong chain with the danger of you loosing your funds by social engineering. 
+If possible validate your `weakSubjectivity.checkpoint` from multiple places like different client distributions, or from any other trusted sources. This will highly reduce the risk of starting off on a wrong chain.
+
 ## Run a validator
 
 To start a Lodestar validator run the command:

--- a/docs/usage/testnet.md
+++ b/docs/usage/testnet.md
@@ -80,13 +80,13 @@ If you have a synced beacon node handy (your friend's or an infrastructure provi
 
 Just supply these **extra args** to your beacon node command:
 ```bash
---weakSubjectivity.syncLatest --weakSubjectivity.serverUrl <synced node url> [--weakSubjectivity.checkpoint <trusted checkpoint in root:epoch format>]
+--weakSubjectivitySyncLatest --weakSubjectivityServerUrl <synced node url> [--weakSubjectivityCheckpoint <trusted checkpoint in root:epoch format>]
 ```
-In case you really trust `weakSubjectivity.serverUrl` then you may skip providing `weakSubjectivity.checkpoint`, which will then result into your beacon node syncing and starting off a finalized state from the trusted url.
+In case you really trust `weakSubjectivityServerUrl` then you may skip providing `weakSubjectivityCheckpoint`, which will then result into your beacon node syncing and starting off a finalized state from the trusted url.
 
 #### PS
 Please use this option very carefully (and at your own risk), a malicious server url can put you on a wrong chain with the danger of you loosing your funds by social engineering. 
-If possible validate your `weakSubjectivity.checkpoint` from multiple places like different client distributions, or from any other trusted sources. This will highly reduce the risk of starting off on a wrong chain.
+If possible validate your `weakSubjectivityCheckpoint` from multiple places like different client distributions, or from any other trusted sources. This will highly reduce the risk of starting off on a wrong chain.
 
 ## Run a validator
 

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -12,16 +12,13 @@ import {
 import {IBeaconDb, IBeaconNodeOptions, initStateFromAnchorState, initStateFromEth1} from "@chainsafe/lodestar";
 // eslint-disable-next-line no-restricted-imports
 import {getStateTypeFromBytes} from "@chainsafe/lodestar/lib/util/multifork";
+import {Checkpoint} from "@chainsafe/lodestar-types/phase0";
+
 import {downloadOrLoadFile} from "../../util";
 import {IBeaconArgs} from "./options";
 import {defaultNetwork, IGlobalArgs} from "../../options/globalOptions";
-import {
-  fetchWeakSubjectivityState,
-  getGenesisFileUrl,
-  getCheckpointFromArg,
-  WeakSubjectivityFetchOptions,
-} from "../../networks";
-import {Checkpoint} from "@chainsafe/lodestar-types/phase0";
+import {parseWSSArgs, WSSOptions} from "../../options/wssOptions";
+import {fetchWeakSubjectivityState, getGenesisFileUrl, getCheckpointFromArg} from "../../networks";
 
 function getCheckpointFromState(config: IChainForkConfig, state: allForks.BeaconState): Checkpoint {
   return {
@@ -89,45 +86,10 @@ export async function initBeaconState(
   // fetch the latest state stored in the db
   // this will be used in all cases, if it exists, either used during verification of a weak subjectivity state, or used directly as the anchor state
   const lastDbState = await db.stateArchive.lastValue();
+  const wssOpts = parseWSSArgs(args);
 
-  if (args.weakSubjectivityStateFile) {
-    // weak subjectivity sync from a provided state file:
-    // if a weak subjectivity checkpoint has been provided, it is used for additional verification
-    // otherwise, the state itself is used for verification (not bad, because the trusted state has been explicitly provided)
-    const stateBytes = await downloadOrLoadFile(args.weakSubjectivityStateFile);
-    const wsState = getStateTypeFromBytes(chainForkConfig, stateBytes).createTreeBackedFromBytes(stateBytes);
-    const config = createIBeaconConfig(chainForkConfig, wsState.genesisValidatorsRoot);
-    const store = lastDbState ?? wsState;
-    const checkpoint = args.weakSubjectivityCheckpoint
-      ? getCheckpointFromArg(args.weakSubjectivityCheckpoint)
-      : getCheckpointFromState(config, wsState);
-    return initAndVerifyWeakSubjectivityState(config, db, logger, store, wsState, checkpoint);
-  } else if (args.weakSubjectivitySyncLatest) {
-    // weak subjectivity sync from a state that needs to be fetched:
-    // if a weak subjectivity checkpoint has been provided, it is used to inform which state to download and used for additional verification
-    // otherwise, the 'finalized' state is downloaded and the state itself is used for verification (all trust delegated to the remote beacon node)
-    if (!args.weakSubjectivityServerUrl) {
-      throw Error(`Must set arg --weakSubjectivityServerUrl for network ${args.network}`);
-    }
-    try {
-      // Validate the weakSubjectivityServerUrl and only log the origin to mask the
-      // username password credentials
-      const wssUrl = new URL(args.weakSubjectivityServerUrl);
-      logger.info("Fetching weak subjectivity state", {
-        weakSubjectivityServerUrl: wssUrl.origin,
-      });
-    } catch (e) {
-      logger.error("Invalid", {weakSubjectivityServerUrl: args.weakSubjectivityServerUrl}, e as Error);
-      throw e;
-    }
-
-    const {wsState, wsCheckpoint} = await fetchWeakSubjectivityState(
-      chainForkConfig,
-      args as WeakSubjectivityFetchOptions
-    );
-    const config = createIBeaconConfig(chainForkConfig, wsState.genesisValidatorsRoot);
-    const store = lastDbState ?? wsState;
-    return initAndVerifyWeakSubjectivityState(config, db, logger, store, wsState, wsCheckpoint);
+  if (wssOpts) {
+    return await initFromWSState(lastDbState, wssOpts, chainForkConfig, db, logger);
   } else if (lastDbState) {
     // start the chain from the latest stored state in the db
     const config = createIBeaconConfig(chainForkConfig, lastDbState.genesisValidatorsRoot);
@@ -145,5 +107,52 @@ export async function initBeaconState(
       const anchorState = await initStateFromEth1({config: chainForkConfig, db, logger, opts: options.eth1, signal});
       return {anchorState};
     }
+  }
+}
+
+async function initFromWSState(
+  lastDbState: TreeBacked<allForks.BeaconState> | null,
+  wssOpts: WSSOptions,
+  chainForkConfig: IChainForkConfig,
+  db: IBeaconDb,
+  logger: ILogger
+): Promise<{anchorState: TreeBacked<allForks.BeaconState>; wsCheckpoint?: Checkpoint}> {
+  if (wssOpts.weakSubjectivityStateFile) {
+    // weak subjectivity sync from a provided state file:
+    // if a weak subjectivity checkpoint has been provided, it is used for additional verification
+    // otherwise, the state itself is used for verification (not bad, because the trusted state has been explicitly provided)
+    const {weakSubjectivityStateFile, weakSubjectivityCheckpoint} = wssOpts;
+
+    const stateBytes = await downloadOrLoadFile(weakSubjectivityStateFile);
+    const wsState = getStateTypeFromBytes(chainForkConfig, stateBytes).createTreeBackedFromBytes(stateBytes);
+    const config = createIBeaconConfig(chainForkConfig, wsState.genesisValidatorsRoot);
+    const store = lastDbState ?? wsState;
+    const checkpoint = weakSubjectivityCheckpoint
+      ? getCheckpointFromArg(weakSubjectivityCheckpoint)
+      : getCheckpointFromState(config, wsState);
+    return initAndVerifyWeakSubjectivityState(config, db, logger, store, wsState, checkpoint);
+  } else if (wssOpts.weakSubjectivitySyncLatest) {
+    // weak subjectivity sync from a state that needs to be fetched:
+    // if a weak subjectivity checkpoint has been provided, it is used to inform which state to download and used for additional verification
+    // otherwise, the 'finalized' state is downloaded and the state itself is used for verification (all trust delegated to the remote beacon node)
+    const {weakSubjectivityServerUrl} = wssOpts;
+    try {
+      // Validate the weakSubjectivityServerUrl and only log the origin to mask the
+      // username password credentials
+      const wssUrl = new URL(weakSubjectivityServerUrl);
+      logger.info("Fetching weak subjectivity state", {
+        weakSubjectivityServerUrl: wssUrl.origin,
+      });
+    } catch (e) {
+      logger.error("Invalid", {weakSubjectivityServerUrl}, e as Error);
+      throw e;
+    }
+
+    const {wsState, wsCheckpoint} = await fetchWeakSubjectivityState(chainForkConfig, wssOpts);
+    const config = createIBeaconConfig(chainForkConfig, wsState.genesisValidatorsRoot);
+    const store = lastDbState ?? wsState;
+    return initAndVerifyWeakSubjectivityState(config, db, logger, store, wsState, wsCheckpoint);
+  } else {
+    throw Error("Invalid wss options");
   }
 }

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -1,6 +1,14 @@
 import {Options} from "yargs";
 import {defaultLogLevel, LogLevels} from "@chainsafe/lodestar-utils";
-import {beaconNodeOptions, paramsOptions, IBeaconNodeArgs, IENRArgs, enrOptions} from "../../options";
+import {
+  beaconNodeOptions,
+  paramsOptions,
+  IBeaconNodeArgs,
+  IENRArgs,
+  enrOptions,
+  IWSSArgs,
+  wssOptions,
+} from "../../options";
 import {defaultBeaconPaths, IBeaconPaths} from "./paths";
 import {ICliCommandOptions, ILogArgs} from "../../util";
 
@@ -9,10 +17,6 @@ interface IBeaconExtraArgs {
   discoveryPort?: number;
   forceGenesis?: boolean;
   genesisStateFile?: string;
-  weakSubjectivityStateFile?: string;
-  weakSubjectivityCheckpoint?: string;
-  weakSubjectivityServerUrl?: string;
-  weakSubjectivitySyncLatest?: string;
 }
 
 export const beaconExtraOptions: ICliCommandOptions<IBeaconExtraArgs> = {
@@ -36,30 +40,6 @@ export const beaconExtraOptions: ICliCommandOptions<IBeaconExtraArgs> = {
 
   genesisStateFile: {
     description: "Path or URL to download a genesis state file in ssz-encoded format",
-    type: "string",
-  },
-
-  weakSubjectivityStateFile: {
-    description: "Path or URL to download a weak subjectivity state file in ssz-encoded format",
-    type: "string",
-  },
-
-  weakSubjectivitySyncLatest: {
-    description:
-      "Enable fetching of a weak subjectivity state via --weakSubjectivityServerUrl.  If an argument is provided to --weakSubjectivityCheckpoint, fetch the state at that checkpoint.  Else, fetch the latest finalized state.",
-    type: "boolean",
-    default: false,
-  },
-
-  weakSubjectivityCheckpoint: {
-    description:
-      "Tell the beacon node to fetch a weak subjectivity state at the specified checkpoint. The string arg must be in the form <blockRoot>:<epoch>. For example, 0x1234:100 would ask for the weak subjectivity state at checkpoint of epoch 100 with block root 0x1234.",
-    type: "string",
-  },
-
-  weakSubjectivityServerUrl: {
-    description:
-      "Pass in a server hosting Beacon Node APIs from which to fetch weak subjectivity state, required in conjunction with --weakSubjectivitySyncLatest or --weakSubjectivityCheckpoint sync.",
     type: "string",
   },
 };
@@ -162,7 +142,7 @@ export const beaconPathsOptions: ICliCommandOptions<IBeaconPaths> = {
   },
 };
 
-export type IBeaconArgs = IBeaconExtraArgs & ILogArgs & IBeaconPaths & IBeaconNodeArgs & IENRArgs;
+export type IBeaconArgs = IBeaconExtraArgs & ILogArgs & IBeaconPaths & IBeaconNodeArgs & IENRArgs & IWSSArgs;
 
 export const beaconOptions: {[k: string]: Options} = {
   ...beaconExtraOptions,
@@ -171,4 +151,5 @@ export const beaconOptions: {[k: string]: Options} = {
   ...beaconNodeOptions,
   ...paramsOptions,
   ...enrOptions,
+  ...wssOptions,
 };

--- a/packages/cli/src/options/index.ts
+++ b/packages/cli/src/options/index.ts
@@ -2,3 +2,4 @@ export * from "./beaconNodeOptions";
 export * from "./enrOptions";
 export * from "./globalOptions";
 export * from "./paramsOptions";
+export * from "./wssOptions";

--- a/packages/cli/src/options/wssOptions.ts
+++ b/packages/cli/src/options/wssOptions.ts
@@ -1,0 +1,69 @@
+import {ICliCommandOptions} from "../util";
+
+export type WSSOptions =
+  | {
+      weakSubjectivityStateFile: string;
+      weakSubjectivitySyncLatest: undefined;
+      weakSubjectivityServerUrl: undefined;
+      weakSubjectivityCheckpoint: string | undefined;
+    }
+  | {
+      weakSubjectivityStateFile: undefined;
+      weakSubjectivitySyncLatest: boolean;
+      weakSubjectivityServerUrl: string;
+      weakSubjectivityCheckpoint: string | undefined;
+    };
+export interface IWSSArgs {
+  "wss.weakSubjectivityStateFile": string;
+  "wss.weakSubjectivitySyncLatest": boolean;
+  "wss.weakSubjectivityCheckpoint": string;
+  "wss.weakSubjectivityServerUrl": string;
+}
+
+export function parseWSSArgs(args: IWSSArgs): WSSOptions | null {
+  const {
+    "wss.weakSubjectivityStateFile": weakSubjectivityStateFile,
+    "wss.weakSubjectivitySyncLatest": weakSubjectivitySyncLatest,
+    "wss.weakSubjectivityCheckpoint": weakSubjectivityCheckpoint,
+    "wss.weakSubjectivityServerUrl": weakSubjectivityServerUrl,
+  } = args;
+  if (weakSubjectivityStateFile) {
+    return {weakSubjectivityStateFile, weakSubjectivityCheckpoint} as WSSOptions;
+  } else if (weakSubjectivitySyncLatest) {
+    if (!weakSubjectivityServerUrl) {
+      throw Error("Must set arg --weakSubjectivityServerUrl for wss sync");
+    }
+    return {weakSubjectivitySyncLatest, weakSubjectivityServerUrl, weakSubjectivityCheckpoint} as WSSOptions;
+  } else {
+    return null;
+  }
+}
+
+export const wssOptions: ICliCommandOptions<IWSSArgs> = {
+  "wss.weakSubjectivityStateFile": {
+    description: "Path or URL to download a weak subjectivity state file in ssz-encoded format",
+    type: "string",
+    group: "wss",
+  },
+
+  "wss.weakSubjectivitySyncLatest": {
+    description:
+      "Enable fetching of a weak subjectivity state via --weakSubjectivityServerUrl.  If an argument is provided to --weakSubjectivityCheckpoint, fetch the state at that checkpoint.  Else, fetch the latest finalized state.",
+    type: "boolean",
+    group: "wss",
+  },
+
+  "wss.weakSubjectivityCheckpoint": {
+    description:
+      "Tell the beacon node to fetch a weak subjectivity state at the specified checkpoint. The string arg must be in the form <blockRoot>:<epoch>. For example, 0x1234:100 would ask for the weak subjectivity state at checkpoint of epoch 100 with block root 0x1234.",
+    type: "string",
+    group: "wss",
+  },
+
+  "wss.weakSubjectivityServerUrl": {
+    description:
+      "Pass in a server hosting Beacon Node APIs from which to fetch weak subjectivity state, required in conjunction with --weakSubjectivitySyncLatest or --weakSubjectivityCheckpoint sync.",
+    type: "string",
+    group: "wss",
+  },
+};

--- a/packages/cli/src/options/wssOptions.ts
+++ b/packages/cli/src/options/wssOptions.ts
@@ -14,24 +14,24 @@ export type WSSOptions =
       weakSubjectivityCheckpoint: string | undefined;
     };
 export interface IWSSArgs {
-  "wss.weakSubjectivityStateFile": string;
-  "wss.weakSubjectivitySyncLatest": boolean;
-  "wss.weakSubjectivityCheckpoint": string;
-  "wss.weakSubjectivityServerUrl": string;
+  "weakSubjectivity.stateFile": string;
+  "weakSubjectivity.syncLatest": boolean;
+  "weakSubjectivity.checkpoint": string;
+  "weakSubjectivity.serverUrl": string;
 }
 
 export function parseWSSArgs(args: IWSSArgs): WSSOptions | null {
   const {
-    "wss.weakSubjectivityStateFile": weakSubjectivityStateFile,
-    "wss.weakSubjectivitySyncLatest": weakSubjectivitySyncLatest,
-    "wss.weakSubjectivityCheckpoint": weakSubjectivityCheckpoint,
-    "wss.weakSubjectivityServerUrl": weakSubjectivityServerUrl,
+    "weakSubjectivity.stateFile": weakSubjectivityStateFile,
+    "weakSubjectivity.syncLatest": weakSubjectivitySyncLatest,
+    "weakSubjectivity.checkpoint": weakSubjectivityCheckpoint,
+    "weakSubjectivity.serverUrl": weakSubjectivityServerUrl,
   } = args;
   if (weakSubjectivityStateFile) {
     return {weakSubjectivityStateFile, weakSubjectivityCheckpoint} as WSSOptions;
   } else if (weakSubjectivitySyncLatest) {
     if (!weakSubjectivityServerUrl) {
-      throw Error("Must set arg --weakSubjectivityServerUrl for wss sync");
+      throw Error("Must set arg --weakSubjectivity.serverUrl for wss sync");
     }
     return {weakSubjectivitySyncLatest, weakSubjectivityServerUrl, weakSubjectivityCheckpoint} as WSSOptions;
   } else {
@@ -40,30 +40,30 @@ export function parseWSSArgs(args: IWSSArgs): WSSOptions | null {
 }
 
 export const wssOptions: ICliCommandOptions<IWSSArgs> = {
-  "wss.weakSubjectivityStateFile": {
+  "weakSubjectivity.stateFile": {
     description: "Path or URL to download a weak subjectivity state file in ssz-encoded format",
     type: "string",
-    group: "wss",
+    group: "weakSubjectivity",
   },
 
-  "wss.weakSubjectivitySyncLatest": {
+  "weakSubjectivity.syncLatest": {
     description:
-      "Enable fetching of a weak subjectivity state via --weakSubjectivityServerUrl.  If an argument is provided to --weakSubjectivityCheckpoint, fetch the state at that checkpoint.  Else, fetch the latest finalized state.",
+      "Sync and start from a weak subjectivity state at --weakSubjectivity.checkpoint (if provided, else fetches the latest finalized) via the --weakSubjectivity.serverUrl",
     type: "boolean",
-    group: "wss",
+    group: "weakSubjectivity",
   },
 
-  "wss.weakSubjectivityCheckpoint": {
+  "weakSubjectivity.checkpoint": {
     description:
-      "Tell the beacon node to fetch a weak subjectivity state at the specified checkpoint. The string arg must be in the form <blockRoot>:<epoch>. For example, 0x1234:100 would ask for the weak subjectivity state at checkpoint of epoch 100 with block root 0x1234.",
+      "To fetch and start beacon node off a state at the provided weakSubjectivity checkpoint, to be supplied in <blockRoot>:<epoch> format. For example, 0x1234:100 will sync and start off from the weakSubjectivity state at checkpoint of epoch 100 with block root 0x1234.",
     type: "string",
-    group: "wss",
+    group: "weakSubjectivity",
   },
 
-  "wss.weakSubjectivityServerUrl": {
+  "weakSubjectivity.serverUrl": {
     description:
-      "Pass in a server hosting Beacon Node APIs from which to fetch weak subjectivity state, required in conjunction with --weakSubjectivitySyncLatest or --weakSubjectivityCheckpoint sync.",
+      "Pass in a server url hosting Beacon Node APIs from which to fetch weak subjectivity state, required in conjunction with --weakSubjectivity.syncLatest or --weakSubjectivity.checkpoint.",
     type: "string",
-    group: "wss",
+    group: "weakSubjectivity",
   },
 };

--- a/packages/cli/src/options/wssOptions.ts
+++ b/packages/cli/src/options/wssOptions.ts
@@ -14,24 +14,24 @@ export type WSSOptions =
       weakSubjectivityCheckpoint: string | undefined;
     };
 export interface IWSSArgs {
-  "weakSubjectivity.stateFile": string;
-  "weakSubjectivity.syncLatest": boolean;
-  "weakSubjectivity.checkpoint": string;
-  "weakSubjectivity.serverUrl": string;
+  weakSubjectivityStateFile: string;
+  weakSubjectivitySyncLatest: boolean;
+  weakSubjectivityServerUrl: string;
+  weakSubjectivityCheckpoint: string;
 }
 
 export function parseWSSArgs(args: IWSSArgs): WSSOptions | null {
   const {
-    "weakSubjectivity.stateFile": weakSubjectivityStateFile,
-    "weakSubjectivity.syncLatest": weakSubjectivitySyncLatest,
-    "weakSubjectivity.checkpoint": weakSubjectivityCheckpoint,
-    "weakSubjectivity.serverUrl": weakSubjectivityServerUrl,
+    weakSubjectivityStateFile,
+    weakSubjectivitySyncLatest,
+    weakSubjectivityServerUrl,
+    weakSubjectivityCheckpoint,
   } = args;
   if (weakSubjectivityStateFile) {
     return {weakSubjectivityStateFile, weakSubjectivityCheckpoint} as WSSOptions;
   } else if (weakSubjectivitySyncLatest) {
     if (!weakSubjectivityServerUrl) {
-      throw Error("Must set arg --weakSubjectivity.serverUrl for wss sync");
+      throw Error("Must set arg --weakSubjectivityServerUrl for wss sync");
     }
     return {weakSubjectivitySyncLatest, weakSubjectivityServerUrl, weakSubjectivityCheckpoint} as WSSOptions;
   } else {
@@ -40,29 +40,29 @@ export function parseWSSArgs(args: IWSSArgs): WSSOptions | null {
 }
 
 export const wssOptions: ICliCommandOptions<IWSSArgs> = {
-  "weakSubjectivity.stateFile": {
+  weakSubjectivityStateFile: {
     description: "Path or URL to download a weak subjectivity state file in ssz-encoded format",
     type: "string",
     group: "weakSubjectivity",
   },
 
-  "weakSubjectivity.syncLatest": {
+  weakSubjectivitySyncLatest: {
     description:
-      "Sync and start from a weak subjectivity state at --weakSubjectivity.checkpoint (if provided, else fetches the latest finalized) via the --weakSubjectivity.serverUrl",
+      "Sync and start from a weak subjectivity state at --weakSubjectivityCheckpoint (if provided, else fetches the latest finalized) via the --weakSubjectivityServerUrl",
     type: "boolean",
     group: "weakSubjectivity",
   },
 
-  "weakSubjectivity.checkpoint": {
+  weakSubjectivityServerUrl: {
     description:
-      "To fetch and start beacon node off a state at the provided weakSubjectivity checkpoint, to be supplied in <blockRoot>:<epoch> format. For example, 0x1234:100 will sync and start off from the weakSubjectivity state at checkpoint of epoch 100 with block root 0x1234.",
+      "Pass in a server url hosting Beacon Node APIs from which to fetch weak subjectivity state, required in conjunction with --weakSubjectivitySyncLatest or --weakSubjectivityCheckpoint.",
     type: "string",
     group: "weakSubjectivity",
   },
 
-  "weakSubjectivity.serverUrl": {
+  weakSubjectivityCheckpoint: {
     description:
-      "Pass in a server url hosting Beacon Node APIs from which to fetch weak subjectivity state, required in conjunction with --weakSubjectivity.syncLatest or --weakSubjectivity.checkpoint.",
+      "To fetch and start beacon node off a state at the provided weakSubjectivity checkpoint, to be supplied in <blockRoot>:<epoch> format. For example, 0x1234:100 will sync and start off from the weakSubjectivity state at checkpoint of epoch 100 with block root 0x1234.",
     type: "string",
     group: "weakSubjectivity",
   },


### PR DESCRIPTION
**Motivation**
Weak Subjectivity sync options have become important and needs their own grouping as the main options were getting cluttered.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR refactors the wss cli options and group them in a wss group as wss options are cluttering the main options.
Now they are grouped in the cli help like this:

```
wss
      --wss.weakSubjectivityStateFile   Path or URL to download a weak
                                        subjectivity state file in ssz-encoded
                                        format                          [string]
      --wss.weakSubjectivitySyncLatest  Enable fetching of a weak subjectivity
                                        state via --weakSubjectivityServerUrl.
                                        If an argument is provided to
                                        --weakSubjectivityCheckpoint, fetch the
                                        state at that checkpoint.  Else, fetch
                                        the latest finalized state.    [boolean]
      --wss.weakSubjectivityCheckpoint  Tell the beacon node to fetch a weak
                                        subjectivity state at the specified
                                        checkpoint. The string arg must be in
                                        the form <blockRoot>:<epoch>. For
                                        example, 0x1234:100 would ask for the
                                        weak subjectivity state at checkpoint of
                                        epoch 100 with block root 0x1234.
                                                                        [string]
      --wss.weakSubjectivityServerUrl   Pass in a server hosting Beacon Node
                                        APIs from which to fetch weak
                                        subjectivity state, required in
                                        conjunction with
                                        --weakSubjectivitySyncLatest or
                                        --weakSubjectivityCheckpoint sync.
                                                                        [string]

```