### PR TITLE
adding support for passing a passphrase file to account validator import

### DIFF
--- a/packages/cli/src/cmds/account/cmds/validator/import.ts
+++ b/packages/cli/src/cmds/account/cmds/validator/import.ts
@@ -22,6 +22,7 @@ import {IGlobalArgs} from "../../../../options";
 interface IValidatorImportArgs {
   keystore?: string;
   directory?: string;
+  passphraseFile?: string;
 }
 
 export const importCmd: ICliCommand<IValidatorImportArgs, IAccountValidatorArgs & IGlobalArgs> = {
@@ -62,11 +63,18 @@ has the '.json' extension will be attempted to be imported.",
       conflicts: ["keystore"],
       type: "string",
     },
+
+    passphraseFile: {
+      description: "Path to a file that contains password that protects the keystore.",
+      describe: "Path to a file that contains password that protects the keystore.",
+      type: "string",
+    },
   },
 
   handler: async (args) => {
     const singleKeystorePath = args.keystore;
     const directoryPath = args.directory;
+    const passphraseFile = args.passphraseFile;
     const {keystoresDir, secretsDir} = getAccountPaths(args);
 
     const keystorePaths = singleKeystorePath
@@ -117,7 +125,7 @@ has the '.json' extension will be attempted to be imported.",
   - Public key: ${pubkey}
   - UUID: ${uuid}`);
 
-      const passphrase = await getKeystorePassphrase(keystore, passphrasePaths);
+      const passphrase = await getKeystorePassphrase(keystore, passphrasePaths, passphraseFile);
       fs.mkdirSync(secretsDir, {recursive: true});
       fs.mkdirSync(dir, {recursive: true});
       fs.writeFileSync(path.join(dir, VOTING_KEYSTORE_FILE), keystore.stringify());
@@ -145,11 +153,17 @@ has the '.json' extension will be attempted to be imported.",
  * Fetches the passphrase of an imported Kestore
  *
  * Paths that may contain valid passphrases
+ * @param keystore
  * @param passphrasePaths ["secrets/0x12341234"]
+ * @param passphraseFile
  */
-async function getKeystorePassphrase(keystore: Keystore, passphrasePaths: string[]): Promise<string> {
-  // First, try to find a passphrase file in the provided directory
-  const passphraseFile = passphrasePaths.find((filepath) => filepath.endsWith(keystore.pubkey));
+async function getKeystorePassphrase(
+  keystore: Keystore,
+  passphrasePaths: string[],
+  passphraseFile?: string
+): Promise<string> {
+  // First, try to use a passphrase file if provided, if not, find a passphrase file in the provided directory
+  passphraseFile = passphraseFile ?? passphrasePaths.find((filepath) => filepath.endsWith(keystore.pubkey));
   if (passphraseFile) {
     const passphrase = fs.readFileSync(passphraseFile, "utf8");
     try {


### PR DESCRIPTION
**Motivation**

There is a need to have `account validator import` to be non interactive.

**Description**

Added support for the command `account validator import` to accept a password as a file path, which will be used instead of interactively prompting for password during the import

Also as part of this PR, reviewed other `account` commands and confirmed that the interactive ones have options that makes them non interactive:

- `account recover` is interactive, but if not, if `--mnemonicInputPath` is passed. 
- `account validator voluntary-exit` is interactive but not, if `--publicKey` is passed.  

Closes #3688

