### PR TITLE
Remove peer penalization even on INVALID execution status

### DIFF
--- a/packages/lodestar/src/chain/blocks/verifyBlock.ts
+++ b/packages/lodestar/src/chain/blocks/verifyBlock.ts
@@ -194,17 +194,11 @@ export async function verifyBlockStateTransition(
           parentHashHex !== execResult.latestValidHash ? parentHashHex : null
         );
         throw new BlockError(block, {
-          code: BlockErrorCode.EXECUTION_PAYLOAD_NOT_VALID,
+          code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
+          execStatus: execResult.status,
           errorMessage: execResult.validationError ?? "",
         });
       }
-
-      case ExecutePayloadStatus.INVALID_BLOCK_HASH:
-      case ExecutePayloadStatus.INVALID_TERMINAL_BLOCK:
-        throw new BlockError(block, {
-          code: BlockErrorCode.EXECUTION_PAYLOAD_NOT_VALID,
-          errorMessage: execResult.validationError,
-        });
 
       // Accepted and Syncing have the same treatment, as final validation of block is pending
       case ExecutePayloadStatus.ACCEPTED:
@@ -238,7 +232,8 @@ export async function verifyBlockStateTransition(
         ) {
           throw new BlockError(block, {
             code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
-            errorMessage: `not safe to import not yet validated payload within ${opts.safeSlotsToImportOptimistically} of currentSlot, status=${execResult.status}`,
+            execStatus: ExecutePayloadStatus.UNSAFE_OPTIMISTIC_STATUS,
+            errorMessage: `not safe to import ${execResult.status} payload within ${opts.safeSlotsToImportOptimistically} of currentSlot, status=${execResult.status}`,
           });
         }
 
@@ -246,7 +241,10 @@ export async function verifyBlockStateTransition(
         break;
       }
 
-      // There can be many reasons for which EL failed some of the observed ones are
+      // If the block has is not valid, or it referenced an invalid terminal block then the
+      // block is invalid, however it has no bearing on any forkChoice cleanup
+      //
+      // There can be other reasons for which EL failed some of the observed ones are
       // 1. Connection refused / can't connect to EL port
       // 2. EL Internal Error
       // 3. Geth sometimes gives invalid merkel root error which means invalid
@@ -259,10 +257,14 @@ export async function verifyBlockStateTransition(
       // For network/unreachable errors, an optimization can be added to replay these blocks
       // back. But for now, lets assume other mechanisms like unknown parent block of a future
       // child block will cause it to replay
+
+      case ExecutePayloadStatus.INVALID_BLOCK_HASH:
+      case ExecutePayloadStatus.INVALID_TERMINAL_BLOCK:
       case ExecutePayloadStatus.ELERROR:
       case ExecutePayloadStatus.UNAVAILABLE:
         throw new BlockError(block, {
           code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
+          execStatus: execResult.status,
           errorMessage: execResult.validationError,
         });
     }

--- a/packages/lodestar/src/chain/errors/blockError.ts
+++ b/packages/lodestar/src/chain/errors/blockError.ts
@@ -2,6 +2,7 @@ import {allForks, RootHex, Slot, ValidatorIndex} from "@chainsafe/lodestar-types
 import {LodestarError} from "@chainsafe/lodestar-utils";
 import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {GossipActionError} from "./gossipValidation";
+import {ExecutePayloadStatus} from "../../executionEngine/interface";
 
 export enum BlockErrorCode {
   /** The prestate cannot be fetched */
@@ -55,11 +56,14 @@ export enum BlockErrorCode {
   SAME_PARENT_HASH = "BLOCK_ERROR_SAME_PARENT_HASH",
   /** Total size of executionPayload.transactions exceed a sane limit to prevent DOS attacks */
   TRANSACTIONS_TOO_BIG = "BLOCK_ERROR_TRANSACTIONS_TOO_BIG",
-  /** Execution engine returned not valid after notifyNewPayload() call */
-  EXECUTION_PAYLOAD_NOT_VALID = "BLOCK_ERROR_EXECUTION_PAYLOAD_NOT_VALID",
   /** Execution engine is unavailable, syncing, or api call errored. Peers must not be downscored on this code */
   EXECUTION_ENGINE_ERROR = "BLOCK_ERROR_EXECUTION_ERROR",
 }
+
+type ExecutionErrorStatus = Exclude<
+  ExecutePayloadStatus,
+  ExecutePayloadStatus.VALID | ExecutePayloadStatus.ACCEPTED | ExecutePayloadStatus.SYNCING
+>;
 
 export type BlockErrorType =
   | {code: BlockErrorCode.PRESTATE_MISSING; error: Error}
@@ -91,8 +95,7 @@ export type BlockErrorType =
   | {code: BlockErrorCode.TOO_MUCH_GAS_USED; gasUsed: number; gasLimit: number}
   | {code: BlockErrorCode.SAME_PARENT_HASH; blockHash: RootHex}
   | {code: BlockErrorCode.TRANSACTIONS_TOO_BIG; size: number; max: number}
-  | {code: BlockErrorCode.EXECUTION_PAYLOAD_NOT_VALID; errorMessage: string}
-  | {code: BlockErrorCode.EXECUTION_ENGINE_ERROR; errorMessage: string};
+  | {code: BlockErrorCode.EXECUTION_ENGINE_ERROR; execStatus: ExecutionErrorStatus; errorMessage: string};
 
 export class BlockGossipError extends GossipActionError<BlockErrorType> {}
 

--- a/packages/lodestar/src/executionEngine/interface.ts
+++ b/packages/lodestar/src/executionEngine/interface.ts
@@ -26,6 +26,8 @@ export enum ExecutePayloadStatus {
   ELERROR = "ELERROR",
   /** EL unavailable */
   UNAVAILABLE = "UNAVAILABLE",
+  /** EL replied with SYNCING or ACCEPTED when its not safe to import optimistic blocks */
+  UNSAFE_OPTIMISTIC_STATUS = "UNSAFE_OPTIMISTIC_STATUS",
 }
 
 export type ExecutePayloadResponse =


### PR DESCRIPTION
**Motivation**
As per the optimistic sync spec, 
https://github.com/ethereum/consensus-specs/pull/2770/files#diff-2b75236a9ab74fc85d4ce0967032deeea2faad9b1eafd93ac2b327c4d0d30cf2R117-R124
even INVALID shouldn't downscore the peers as it might cause network split because of the faulty ELs. 
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR now treats the INVALIDs same as other execution errors and throws `EXECUTION_ENGINE_ERROR` , which isn't meant to downscore the peers.
**Description**
Part of https://github.com/ChainSafe/lodestar/issues/3731