### PR TITLE
Fix getCanonicalBlockSummaryAtSlot at future slot

### DIFF
--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -621,7 +621,11 @@ export class ForkChoice implements IForkChoice {
   }
 
   getCanonicalBlockAtSlot(slot: Slot): IProtoBlock | null {
-    if (slot >= this.head.slot) {
+    if (slot > this.head.slot) {
+      return null;
+    }
+
+    if (slot === this.head.slot) {
       return this.head;
     }
 


### PR DESCRIPTION
**Motivation**

`getCanonicalBlockSummaryAtSlot` should return the block summary _at_ the slot and never return a block summary at a different slot.

**Description**

Resolves https://github.com/ChainSafe/lodestar/issues/3332
