### PR TITLE
DIsable libp2p nat

### DIFF
--- a/packages/lodestar/src/network/nodejs/bundle.ts
+++ b/packages/lodestar/src/network/nodejs/bundle.ts
@@ -62,6 +62,11 @@ export class NodejsNode extends LibP2p {
         threshold: 10,
       },
       config: {
+        nat: {
+          // libp2p usage of nat-api is broken as shown in this issue. https://github.com/ChainSafe/lodestar/issues/2996
+          // Also, unnsolicited usage of UPnP is not great, and should be customizable with flags
+          enabled: false,
+        },
         relay: {
           enabled: false,
           hop: {


### PR DESCRIPTION
**Motivation**

See https://github.com/ChainSafe/lodestar/issues/2996 and https://github.com/libp2p/js-libp2p/issues/1158

**Description**

Disable libp2p Nat manager (at least) temporarily

> @dapplion : Could you desbribe what the nat manager does besides opening ports with upnp?
> @achingbrain : Nothing much - if they have announce addresses configured they can disable it through config - https://github.com/libp2p/js-libp2p/blob/master/doc/CONFIGURATION.md#configuring-the-nat-manager
> @achingbrain : I’m AFK so it’s a bit hard for me to dig through the history but I think they need libp2p 0.35 to get Nat-api with the fix
> @dapplion : Got it, will disable for now and consider re-enabling once we bump libp2p

Closes https://github.com/ChainSafe/lodestar/issues/2996