### PR TITLE
Provision to enable and specify batchsize for backfill sync (disabled by default)

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/sync.ts
+++ b/packages/cli/src/options/beaconNodeOptions/sync.ts
@@ -4,12 +4,14 @@ import {ICliCommandOptions} from "../../util";
 export interface ISyncArgs {
   "sync.isSingleNode": boolean;
   "sync.disableProcessAsChainSegment": boolean;
+  "sync.backfillBatchSize": number;
 }
 
 export function parseArgs(args: ISyncArgs): IBeaconNodeOptions["sync"] {
   return {
     isSingleNode: args["sync.isSingleNode"],
     disableProcessAsChainSegment: args["sync.disableProcessAsChainSegment"],
+    backfillBatchSize: args["sync.backfillBatchSize"],
   };
 }
 
@@ -30,6 +32,14 @@ Use only for local networks with a single node, can be dangerous in regular netw
     description:
       "For RangeSync disable processing batches of blocks at once. Should only be used for debugging or testing.",
     defaultDescription: String(defaultOptions.sync.disableProcessAsChainSegment),
+    group: "sync",
+  },
+
+  "sync.backfillBatchSize": {
+    hidden: true,
+    type: "number",
+    description: "Batch size for backfill sync to sync/process blocks, set non zero to enable backfill sync",
+    defaultDescription: String(defaultOptions.sync.backfillBatchSize),
     group: "sync",
   },
 };

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -56,6 +56,7 @@ describe("options / beaconNodeOptions", () => {
       "network.dontSendGossipAttestationsToForkchoice": true,
       "sync.isSingleNode": true,
       "sync.disableProcessAsChainSegment": true,
+      "sync.backfillBatchSize": 64,
     } as IBeaconNodeArgs;
 
     const expectedOptions: RecursivePartial<IBeaconNodeOptions> = {
@@ -121,6 +122,7 @@ describe("options / beaconNodeOptions", () => {
       sync: {
         isSingleNode: true,
         disableProcessAsChainSegment: true,
+        backfillBatchSize: 64,
       },
     };
 

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -35,7 +35,7 @@ export interface IBeaconNodeModules {
   chain: IBeaconChain;
   api: Api;
   sync: IBeaconSync;
-  backfillSync: BackfillSync;
+  backfillSync: BackfillSync | null;
   metricsServer?: HttpMetricsServer;
   restApi?: RestApi;
   controller?: AbortController;
@@ -73,7 +73,7 @@ export class BeaconNode {
   api: Api;
   restApi?: RestApi;
   sync: IBeaconSync;
-  backfillSync: BackfillSync;
+  backfillSync: BackfillSync | null;
 
   status: BeaconNodeStatus;
   private controller?: AbortController;
@@ -169,16 +169,19 @@ export class BeaconNode {
       logger: logger.child(opts.logger.sync),
     });
 
-    const backfillSync = await BackfillSync.init({
-      config,
-      db,
-      chain,
-      metrics,
-      network,
-      wsCheckpoint,
-      anchorState,
-      logger: logger.child(opts.logger.sync),
-    });
+    const backfillSync =
+      opts.sync.backfillBatchSize > 0
+        ? await BackfillSync.init(opts.sync, {
+            config,
+            db,
+            chain,
+            metrics,
+            network,
+            wsCheckpoint,
+            anchorState,
+            logger: logger.child(opts.logger.sync),
+          })
+        : null;
 
     const api = getApi(opts.api, {
       config,

--- a/packages/lodestar/src/sync/options.ts
+++ b/packages/lodestar/src/sync/options.ts
@@ -14,9 +14,17 @@ export type SyncOptions = {
   disableRangeSync?: boolean;
   /** USE FOR TESTING ONLY. Disable range sync completely */
   disableUnknownBlockSync?: boolean;
+  /**
+   * The batch size of slots for backfill sync can attempt to sync/process before yielding
+   * to sync loop. This number can be increased or decreased to make a suitable resource
+   * allocation to backfill sync. The default of 0 would mean backfill sync will be skipped
+   */
+  backfillBatchSize: number;
 };
 
 export const defaultSyncOptions: SyncOptions = {
   isSingleNode: false,
   disableProcessAsChainSegment: false,
+  /** By default skip the backfill sync */
+  backfillBatchSize: 0,
 };

--- a/packages/lodestar/test/e2e/sync/wss.test.ts
+++ b/packages/lodestar/test/e2e/sync/wss.test.ts
@@ -108,7 +108,10 @@ describe("Start from WSS", function () {
 
     const bnStartingFromWSS = await getDevBeaconNode({
       params: {...testParams, ALTAIR_FORK_EPOCH: Infinity},
-      options: {api: {rest: {enabled: true, port: 9587} as RestApiOptions}, sync: {isSingleNode: true}},
+      options: {
+        api: {rest: {enabled: true, port: 9587} as RestApiOptions},
+        sync: {isSingleNode: true, backfillBatchSize: 64},
+      },
       validatorCount: 32,
       logger: loggerNodeB,
       genesisTime,
@@ -120,6 +123,7 @@ describe("Start from WSS", function () {
     const head = bn.chain.forkChoice.getHead();
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!head) throw Error("First beacon node has no head block");
+    if (!bnStartingFromWSS.backfillSync) throw Error("Backfill sync not started");
     const waitForSynced = waitForEvent<Slot>(
       bnStartingFromWSS.backfillSync,
       BackfillSyncEvent.completed,


### PR DESCRIPTION
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR provides one with the provision to enable and specify batchsize for backfill sync via providing a non zero number for `sync.backfillBatchSize`. By default this is zero and hence will not start any backfill sync.

This may be later in subsequent PRs set to default as 64 once the optimization issues are resolved.
