### PR TITLE
spec-1.1.9 - Rename syncCommitteeAggregate to syncAggregate

### DIFF
--- a/packages/light-client/src/index.ts
+++ b/packages/light-client/src/index.ts
@@ -464,7 +464,7 @@ export class Lightclient {
     const existingNextSyncCommittee = this.syncCommitteeByPeriod.get(nextPeriod);
     const newNextSyncCommitteeStats: LightclientUpdateStats = {
       isFinalized: !isEmptyHeader(update.finalizedHeader),
-      participation: sumBits(update.syncCommitteeAggregate.syncCommitteeBits),
+      participation: sumBits(update.syncAggregate.syncCommitteeBits),
       slot: updateSlot,
     };
 

--- a/packages/light-client/src/validation.ts
+++ b/packages/light-client/src/validation.ts
@@ -47,7 +47,7 @@ export function assertValidLightClientUpdate(
 
   const {attestedHeader} = update;
   const headerBlockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(attestedHeader);
-  assertValidSignedHeader(config, syncCommittee, update.syncCommitteeAggregate, headerBlockRoot, attestedHeader.slot);
+  assertValidSignedHeader(config, syncCommittee, update.syncAggregate, headerBlockRoot, attestedHeader.slot);
 }
 
 /**

--- a/packages/light-client/test/naive/update.ts
+++ b/packages/light-client/test/naive/update.ts
@@ -70,8 +70,8 @@ export function processLightClientUpdate(
   // Note that (2) means that the current light client design needs finality.
   // It may be changed to re-organizable light client design. See the on-going issue eth2.0-specs#2182.
   if (
-    sumBits(update.syncCommitteeAggregate.syncCommitteeBits) * 3 >=
-      update.syncCommitteeAggregate.syncCommitteeBits.length * 2 &&
+    sumBits(update.syncAggregate.syncCommitteeBits) * 3 >=
+      update.syncAggregate.syncCommitteeBits.length * 2 &&
     !isEmptyHeader(update.finalizedHeader)
   ) {
     applyLightClientUpdate(store.snapshot, update);
@@ -115,7 +115,7 @@ export function applyLightClientUpdate(snapshot: LightClientSnapshotFast, update
  */
 export function isBetterUpdate(prevUpdate: altair.LightClientUpdate, newUpdate: altair.LightClientUpdate): boolean {
   return (
-    sumBits(newUpdate.syncCommitteeAggregate.syncCommitteeBits) >=
-    sumBits(prevUpdate.syncCommitteeAggregate.syncCommitteeBits)
+    sumBits(newUpdate.syncAggregate.syncCommitteeBits) >=
+    sumBits(prevUpdate.syncAggregate.syncCommitteeBits)
   );
 }

--- a/packages/light-client/test/naive/update.ts
+++ b/packages/light-client/test/naive/update.ts
@@ -70,8 +70,7 @@ export function processLightClientUpdate(
   // Note that (2) means that the current light client design needs finality.
   // It may be changed to re-organizable light client design. See the on-going issue eth2.0-specs#2182.
   if (
-    sumBits(update.syncAggregate.syncCommitteeBits) * 3 >=
-      update.syncAggregate.syncCommitteeBits.length * 2 &&
+    sumBits(update.syncAggregate.syncCommitteeBits) * 3 >= update.syncAggregate.syncCommitteeBits.length * 2 &&
     !isEmptyHeader(update.finalizedHeader)
   ) {
     applyLightClientUpdate(store.snapshot, update);
@@ -114,8 +113,5 @@ export function applyLightClientUpdate(snapshot: LightClientSnapshotFast, update
  * ```
  */
 export function isBetterUpdate(prevUpdate: altair.LightClientUpdate, newUpdate: altair.LightClientUpdate): boolean {
-  return (
-    sumBits(newUpdate.syncAggregate.syncCommitteeBits) >=
-    sumBits(prevUpdate.syncAggregate.syncCommitteeBits)
-  );
+  return sumBits(newUpdate.syncAggregate.syncCommitteeBits) >= sumBits(prevUpdate.syncAggregate.syncCommitteeBits);
 }

--- a/packages/light-client/test/prepareUpdateNaive.ts
+++ b/packages/light-client/test/prepareUpdateNaive.ts
@@ -107,7 +107,7 @@ export async function prepareUpdateNaive(
     nextSyncCommitteeBranch: nextSyncCommitteeBranch,
     finalizedHeader: finalizedCheckpointBlockHeader,
     finalityBranch: finalityBranch,
-    syncCommitteeAggregate: syncAggregate,
+    syncAggregate,
     forkVersion: syncAttestedForkVersion,
   };
 }

--- a/packages/light-client/test/unit/validation.test.ts
+++ b/packages/light-client/test/unit/validation.test.ts
@@ -81,7 +81,7 @@ describe("validateLightClientUpdate", () => {
       nextSyncCommitteeBranch: nextSyncCommitteeBranch,
       finalizedHeader: finalizedHeader,
       finalityBranch: finalityBranch,
-      syncCommitteeAggregate: syncAggregate,
+      syncAggregate,
       forkVersion,
     };
 

--- a/packages/light-client/test/utils.ts
+++ b/packages/light-client/test/utils.ts
@@ -159,7 +159,7 @@ export function computeLightclientUpdate(config: IBeaconConfig, period: SyncPeri
     nextSyncCommitteeBranch,
     finalizedHeader,
     finalityBranch,
-    syncCommitteeAggregate: syncAggregate,
+    syncAggregate,
     forkVersion,
   };
 }
@@ -258,8 +258,8 @@ export function committeeUpdateToHeadUpdate(
   return {
     attestedHeader: committeeUpdate.attestedHeader,
     syncAggregate: {
-      syncCommitteeBits: committeeUpdate.syncCommitteeAggregate.syncCommitteeBits,
-      syncCommitteeSignature: committeeUpdate.syncCommitteeAggregate.syncCommitteeSignature,
+      syncCommitteeBits: committeeUpdate.syncAggregate.syncCommitteeBits,
+      syncCommitteeSignature: committeeUpdate.syncAggregate.syncCommitteeSignature,
     },
   };
 }

--- a/packages/lodestar/src/chain/lightClient/index.ts
+++ b/packages/lodestar/src/chain/lightClient/index.ts
@@ -282,7 +282,7 @@ export class LightClientServer {
         nextSyncCommitteeBranch: getNextSyncCommitteeBranch(syncCommitteeWitness),
         finalizedHeader: partialUpdate.finalizedHeader,
         finalityBranch: partialUpdate.finalityBranch,
-        syncCommitteeAggregate: partialUpdate.syncCommitteeAggregate,
+        syncAggregate: partialUpdate.syncAggregate,
         forkVersion: this.config.getForkVersion(partialUpdate.attestedHeader.slot),
       };
     } else {
@@ -292,7 +292,7 @@ export class LightClientServer {
         nextSyncCommitteeBranch: getNextSyncCommitteeBranch(syncCommitteeWitness),
         finalizedHeader: this.zero.finalizedHeader,
         finalityBranch: this.zero.finalityBranch,
-        syncCommitteeAggregate: partialUpdate.syncCommitteeAggregate,
+        syncAggregate: partialUpdate.syncAggregate,
         forkVersion: this.config.getForkVersion(partialUpdate.attestedHeader.slot),
       };
     }
@@ -472,11 +472,11 @@ export class LightClientServer {
       ? {
           ...attestedData,
           finalizedHeader: await this.getFinalizedHeader(attestedData.finalizedCheckpoint.root as Uint8Array),
-          syncCommitteeAggregate: syncAggregate,
+          syncAggregate,
         }
       : {
           ...attestedData,
-          syncCommitteeAggregate: syncAggregate,
+          syncAggregate,
         };
 
     await this.db.bestPartialLightClientUpdate.put(period, newPartialUpdate);
@@ -537,7 +537,7 @@ export function isBetterUpdate(
   }
 
   // Higher bit count
-  const prevBitCount = sumBits(prevUpdate.syncCommitteeAggregate.syncCommitteeBits);
+  const prevBitCount = sumBits(prevUpdate.syncAggregate.syncCommitteeBits);
   if (prevBitCount > nextBitCount) return false;
   if (prevBitCount < nextBitCount) return true;
 

--- a/packages/lodestar/src/chain/lightClient/types.ts
+++ b/packages/lodestar/src/chain/lightClient/types.ts
@@ -43,7 +43,7 @@ export type PartialLightClientUpdateFinalized = {
   finalityBranch: Uint8Array[];
   finalizedCheckpoint: phase0.Checkpoint;
   finalizedHeader: phase0.BeaconBlockHeader;
-  syncCommitteeAggregate: altair.SyncAggregate;
+  syncAggregate: altair.SyncAggregate;
 };
 
 export type PartialLightClientUpdateNonFinalized = {
@@ -52,7 +52,7 @@ export type PartialLightClientUpdateNonFinalized = {
   /** Precomputed root to prevent re-hashing */
   blockRoot: Uint8Array;
   // Finalized data
-  syncCommitteeAggregate: altair.SyncAggregate;
+  syncAggregate: altair.SyncAggregate;
 };
 
 export type PartialLightClientUpdate = PartialLightClientUpdateFinalized | PartialLightClientUpdateNonFinalized;

--- a/packages/lodestar/src/db/repositories/lightclientBestPartialUpdate.ts
+++ b/packages/lodestar/src/db/repositories/lightclientBestPartialUpdate.ts
@@ -24,7 +24,7 @@ export class BestPartialLightClientUpdateRepository extends Repository<SyncPerio
       finalityBranch: new VectorType<Uint8Array[]>({length: FINALIZED_ROOT_DEPTH, elementType: ssz.Root}),
       finalizedCheckpoint: ssz.phase0.Checkpoint,
       finalizedHeader: ssz.phase0.BeaconBlockHeader,
-      syncCommitteeAggregate: ssz.altair.SyncAggregate,
+      syncAggregate: ssz.altair.SyncAggregate,
     },
     casingMap: {
       isFinalized: "is_finalized",
@@ -33,7 +33,7 @@ export class BestPartialLightClientUpdateRepository extends Repository<SyncPerio
       finalityBranch: "finality_branch",
       finalizedCheckpoint: "finalized_checkpoint",
       finalizedHeader: "finalized_header",
-      syncCommitteeAggregate: "sync_committee_aggregate",
+      syncAggregate: "sync_aggregate",
     },
   });
 
@@ -43,13 +43,13 @@ export class BestPartialLightClientUpdateRepository extends Repository<SyncPerio
       isFinalized: booleanType,
       attestedHeader: ssz.phase0.BeaconBlockHeader,
       blockRoot: ssz.Root,
-      syncCommitteeAggregate: ssz.altair.SyncAggregate,
+      syncAggregate: ssz.altair.SyncAggregate,
     },
     casingMap: {
       isFinalized: "is_finalized",
       attestedHeader: "attested_header",
       blockRoot: "block_root",
-      syncCommitteeAggregate: "sync_committee_aggregate",
+      syncAggregate: "sync_aggregate",
     },
   });
 

--- a/packages/types/src/altair/sszTypes.ts
+++ b/packages/types/src/altair/sszTypes.ts
@@ -254,7 +254,7 @@ export const LightClientUpdate = new ContainerType<altair.LightClientUpdate>({
     }),
     finalizedHeader: phase0Ssz.BeaconBlockHeader,
     finalityBranch: new VectorType({elementType: Bytes32, length: FINALIZED_ROOT_DEPTH}),
-    syncCommitteeAggregate: SyncAggregate,
+    syncAggregate: SyncAggregate,
     forkVersion: Version,
   },
   casingMap: {
@@ -263,7 +263,7 @@ export const LightClientUpdate = new ContainerType<altair.LightClientUpdate>({
     nextSyncCommitteeBranch: "next_sync_committee_branch",
     finalizedHeader: "finalized_header",
     finalityBranch: "finality_branch",
-    syncCommitteeAggregate: "sync_committee_aggregate",
+    syncAggregate: "sync_aggregate",
     forkVersion: "fork_version",
   },
 });

--- a/packages/types/src/altair/types.ts
+++ b/packages/types/src/altair/types.ts
@@ -100,7 +100,7 @@ export interface LightClientUpdate {
   finalizedHeader: phase0.BeaconBlockHeader;
   finalityBranch: Vector<Bytes32>;
   /** Sync committee aggregate signature */
-  syncCommitteeAggregate: SyncAggregate;
+  syncAggregate: SyncAggregate;
   /** Fork version for the aggregate signature */
   forkVersion: Version;
 }


### PR DESCRIPTION
**Motivation**
[CL spec 1.1.9](https://github.com/ChainSafe/lodestar/issues/3677) renames sync_committee_aggregate to sync_aggregate.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR updates the same in lodestar.
