### PR TITLE
Deduplicate invalidSszObject files

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -283,8 +283,12 @@ export class BeaconChain implements IBeaconChain {
     if (!fs.existsSync(byDate)) {
       fs.mkdirSync(byDate, {recursive: true});
     }
-    const fileName = `${byDate}/${type}_${suffix}_${Date.now()}.ssz`;
-    fs.writeFileSync(fileName, bytes);
+    const fileName = `${byDate}/${type}_${suffix}.ssz`;
+    // as of Feb 17 2022 there are a lot of duplicate files stored with different date suffixes
+    // remove date suffixes in file name, and check duplicate to avoid redundant persistence
+    if (!fs.existsSync(fileName)) {
+      fs.writeFileSync(fileName, bytes);
+    }
     return fileName;
   }
 }

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -232,14 +232,14 @@ export async function onErrorBlock(this: BeaconChain, err: BlockError): Promise<
     const preStatePath = this.persistInvalidSszObject(
       "state",
       preState.serialize(),
-      `${preState.slot}_invalid_state_root_preState_${invalidRoot}`
+      `${blockSlot}_invalid_state_root_preState_${invalidRoot}`
     );
     const postStatePath = this.persistInvalidSszObject(
       "state",
       postState.serialize(),
-      `${postState.slot}_invalid_state_root_postState_${invalidRoot}`
+      `${blockSlot}_invalid_state_root_postState_${invalidRoot}`
     );
-    this.logger.debug("Invalid signature block and state were written to disc", {
+    this.logger.debug("Invalid state root block and states were written to disc", {
       blockPath,
       preStatePath,
       postStatePath,


### PR DESCRIPTION
**Motivation**

Right now same invalid state root objects are stored in different files with different date suffixes:
```
...
state_2368896_invalid_state_root_preState_0x4dc200dc344c587fcdb0b2bd6bc8c1dd67249c0f4563345ecab67b6b0830d333_1644935390189.ssz
state_2368896_invalid_state_root_preState_0x4dc200dc344c587fcdb0b2bd6bc8c1dd67249c0f4563345ecab67b6b0830d333_1644935499837.ssz
state_2368896_invalid_state_root_preState_0x4dc200dc344c587fcdb0b2bd6bc8c1dd67249c0f4563345ecab67b6b0830d333_1644935608920.ssz
...
```

**Description**

+ Remove the date suffixes as part of file name
+ For invalidStateRoot error, use block slot in file name to group all files together so that it's easier to investigate later
+ Fix the log typo