### PR TITLE
Add SignedAggregateAndProof root to gossip validation accept metadata

### DIFF
--- a/packages/lodestar/src/network/gossip/validation/onAccept.ts
+++ b/packages/lodestar/src/network/gossip/validation/onAccept.ts
@@ -1,6 +1,6 @@
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
-import { ssz } from "@chainsafe/lodestar-types";
-import { prettyBytes } from "@chainsafe/lodestar-utils";
+import {ssz} from "@chainsafe/lodestar-types";
+import {prettyBytes} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
 import {GossipType, GossipTypeMap, GossipTopicTypeMap} from "../interface";
 

--- a/packages/lodestar/src/network/gossip/validation/onAccept.ts
+++ b/packages/lodestar/src/network/gossip/validation/onAccept.ts
@@ -1,4 +1,6 @@
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
+import { ssz } from "@chainsafe/lodestar-types";
+import { prettyBytes } from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
 import {GossipType, GossipTypeMap, GossipTopicTypeMap} from "../interface";
 
@@ -29,6 +31,7 @@ export const getGossipAcceptMetadataByType: GetGossipAcceptMetadataFns = {
     return {
       slot: data.slot,
       index: data.index,
+      root: prettyBytes(ssz.phase0.SignedAggregateAndProof.hashTreeRoot(aggregateAndProof)),
     };
   },
   [GossipType.beacon_attestation]: (config, attestation, topic) => ({


### PR DESCRIPTION
**Motivation**

Different nodes show different subsets of invalid signature SignedAggregateAndProof messages

**Description**

+ Add SignedAggregateAndProof pretty bytes root to the below log:
```
Dec-24 14:11:13.820 [NETWORK]         ^[[34mdebug^[[39m: gossip - beacon_aggregate_and_proof - accept slot=198        5152, index=39
```

+ I'd like to do same investigation for `Attestation` and `sync_committee_contribution_and_proof` but worry that additional `hashTreeRoot()` calls would make the performance worse (ssz v2 could help?). Printing root for SignedAggregateAndProof is not an issue because it's a TreeBacked.

part of #3555

