### PR TITLE
Don't error on LightClientServer finalizedHeader not available

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -146,10 +146,7 @@ export class BeaconChain implements IBeaconChain {
       signal,
     });
 
-    const lightClientServer = new LightClientServer(
-      {config, db, emitter, logger},
-      {genesisTime: this.genesisTime, genesisValidatorsRoot: this.genesisValidatorsRoot as Uint8Array}
-    );
+    const lightClientServer = new LightClientServer({config, db, metrics, emitter, logger});
 
     this.reprocessController = new ReprocessController(this.metrics);
 

--- a/packages/lodestar/src/chain/lightClient/index.ts
+++ b/packages/lodestar/src/chain/lightClient/index.ts
@@ -9,6 +9,7 @@ import {ILogger} from "@chainsafe/lodestar-utils";
 import {routes} from "@chainsafe/lodestar-api";
 import {BitVector, toHexString} from "@chainsafe/ssz";
 import {IBeaconDb} from "../../db";
+import {IMetrics} from "../../metrics";
 import {MapDef, pruneSetToMax} from "../../util/map";
 import {ChainEvent, ChainEventEmitter} from "../emitter";
 import {
@@ -40,17 +41,13 @@ type SyncAttestedData = {
     }
 );
 
-type GenesisData = {
-  genesisTime: number;
-  genesisValidatorsRoot: Uint8Array;
-};
-
-interface ILightClientIniterModules {
+type LightClientServerModules = {
   config: IChainForkConfig;
   db: IBeaconDb;
+  metrics: IMetrics | null;
   emitter: ChainEventEmitter;
   logger: ILogger;
-}
+};
 
 const MAX_CACHED_FINALIZED_HEADERS = 3;
 const MAX_PREV_HEAD_DATA = 32;
@@ -158,6 +155,7 @@ const MAX_PREV_HEAD_DATA = 32;
 export class LightClientServer {
   private readonly db: IBeaconDb;
   private readonly config: IChainForkConfig;
+  private readonly metrics: IMetrics | null;
   private readonly emitter: ChainEventEmitter;
   private readonly logger: ILogger;
   private readonly knownSyncCommittee = new MapDef<SyncPeriod, Set<DependantRootHex>>(() => new Set());
@@ -172,11 +170,13 @@ export class LightClientServer {
 
   private readonly zero: Pick<altair.LightClientUpdate, "finalityBranch" | "finalizedHeader">;
 
-  constructor(modules: ILightClientIniterModules, private readonly genesisData: GenesisData) {
-    this.config = modules.config;
-    this.db = modules.db;
-    this.emitter = modules.emitter;
-    this.logger = modules.logger;
+  constructor(modules: LightClientServerModules) {
+    const {config, db, metrics, emitter, logger} = modules;
+    this.config = config;
+    this.db = db;
+    this.metrics = metrics;
+    this.emitter = emitter;
+    this.logger = logger;
 
     this.zero = {
       finalizedHeader: ssz.phase0.BeaconBlockHeader.defaultValue(),
@@ -491,6 +491,12 @@ export class LightClientServer {
       period,
       isFinalized: attestedData.isFinalized,
       participation: sumBits(syncAggregate.syncCommitteeBits) / SYNC_COMMITTEE_SIZE,
+    });
+
+    // Count total persisted updates per type. DB metrics don't diff between each type.
+    // The frequency of finalized vs non-finalized is critical to debug if finalizedHeader is not available
+    this.metrics?.lightclientServer.persistedUpdates.inc({
+      type: newPartialUpdate.isFinalized ? "finalized" : "non-finalized",
     });
   }
 

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -735,5 +735,13 @@ export function createLodestarMetrics(
         help: "Time to wait for unknown block before being rejected",
       }),
     },
+
+    lightclientServer: {
+      persistedUpdates: register.gauge<"type">({
+        name: "lodestar_lightclient_server_persisted_updates_total",
+        help: "Total number of persisted updates by finalized type",
+        labelNames: ["type"],
+      }),
+    },
   };
 }

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -115,10 +115,13 @@ export class MockBeaconChain implements IBeaconChain {
       metrics: null,
       emitter: this.emitter,
     });
-    this.lightClientServer = new LightClientServer(
-      {config: this.config, emitter: this.emitter, logger, db: db},
-      {genesisTime: this.genesisTime, genesisValidatorsRoot: this.genesisValidatorsRoot as Uint8Array}
-    );
+    this.lightClientServer = new LightClientServer({
+      config: this.config,
+      db: db,
+      metrics: null,
+      emitter: this.emitter,
+      logger,
+    });
     this.reprocessController = new ReprocessController(null);
   }
 


### PR DESCRIPTION
**Motivation**

During sync finalizedHeader will not be available since the LightClientServer has never seen that block.

**Description**

Don't error on LightClientServer finalizedHeader not available.

If update if finalized retrieve the previously stored header from DB. Only checkpoint candidates are stored, and not all headers are guaranteed to be available
- If finalizedHeader is available (should be most times) create a finalized update
- If finalizedHeader is not available (happens on startup) create a non-finalized update

Closes https://github.com/ChainSafe/lodestar/issues/3495