### PR TITLE
Do not lookahead for altair duties as the api currently errors pre-altair

### DIFF
--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -15,7 +15,7 @@ import {ValidatorStore} from "./validatorStore";
 /** Only retain `HISTORICAL_DUTIES_PERIODS` duties prior to the current periods. */
 const HISTORICAL_DUTIES_PERIODS = 2;
 /** Epochs prior to `ALTAIR_FORK_EPOCH` to start fetching duties */
-const ALTAIR_FORK_LOOKAHEAD_EPOCHS = 1;
+const ALTAIR_FORK_LOOKAHEAD_EPOCHS = 0;
 /** How many epochs prior from a subscription starting, ask the node to subscribe */
 const SUBSCRIPTIONS_LOOKAHEAD_EPOCHS = 2;
 

--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -14,14 +14,14 @@ import {ValidatorStore} from "./validatorStore";
 
 /** Only retain `HISTORICAL_DUTIES_PERIODS` duties prior to the current periods. */
 const HISTORICAL_DUTIES_PERIODS = 2;
-/** 
- * Epochs prior to `ALTAIR_FORK_EPOCH` to start fetching duties 
- * 
- * UPDATE: Setting it to 0 from 1, because looking ahead caused an "Empty SyncCommitteeCache" 
+/**
+ * Epochs prior to `ALTAIR_FORK_EPOCH` to start fetching duties
+ *
+ * UPDATE: Setting it to 0 from 1, because looking ahead caused an "Empty SyncCommitteeCache"
  * error (https://github.com/ChainSafe/lodestar/issues/3752) as currently the lodestar
  * beacon's pre-altair placeholder object SyncCommitteeCacheEmpty just throws on
  * any getter.
- * This can be updated back to 1, once SyncCommitteeCacheEmpty supports the duties 
+ * This can be updated back to 1, once SyncCommitteeCacheEmpty supports the duties
  * look-ahead. It can also be later turned as a cli param to interface with another
  * client's beacon, which supports look-ahead of duties.
  */

--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -14,7 +14,17 @@ import {ValidatorStore} from "./validatorStore";
 
 /** Only retain `HISTORICAL_DUTIES_PERIODS` duties prior to the current periods. */
 const HISTORICAL_DUTIES_PERIODS = 2;
-/** Epochs prior to `ALTAIR_FORK_EPOCH` to start fetching duties */
+/** 
+ * Epochs prior to `ALTAIR_FORK_EPOCH` to start fetching duties 
+ * 
+ * UPDATE: Setting it to 0 from 1, because looking ahead caused an "Empty SyncCommitteeCache" 
+ * error (https://github.com/ChainSafe/lodestar/issues/3752) as currently the lodestar
+ * beacon's pre-altair placeholder object SyncCommitteeCacheEmpty just throws on
+ * any getter.
+ * This can be updated back to 1, once SyncCommitteeCacheEmpty supports the duties 
+ * look-ahead. It can also be later turned as a cli param to interface with another
+ * client's beacon, which supports look-ahead of duties.
+ */
 const ALTAIR_FORK_LOOKAHEAD_EPOCHS = 0;
 /** How many epochs prior from a subscription starting, ask the node to subscribe */
 const SUBSCRIPTIONS_LOOKAHEAD_EPOCHS = 2;


### PR DESCRIPTION
**Motivation**
We start call `pollSyncCommittees` with a lookahead of 1 in the validator in anticipation of altair fork, but right now lodestar beacon doesn't support look ahead.
```typescript
/** Placeholder object for pre-altair fork */
export class SyncCommitteeCacheEmpty implements SyncCommitteeCache {
  get validatorIndices(): ValidatorIndex[] {
    throw Error("Empty SyncCommitteeCache");
  }

  get validatorIndexMap(): SyncComitteeValidatorIndexMap {
    throw Error("Empty SyncCommitteeCache");
  }
}
```
This results into error
<!-- Why is this PR exists? What are the goals of the pull request? -->
Remove the lookahead in the validator duties for altair
Closes #3752
