### PR TITLE
Apply peer action when there are gossip validation errors

### DIFF
--- a/packages/lodestar/src/chain/errors/gossipValidation.ts
+++ b/packages/lodestar/src/chain/errors/gossipValidation.ts
@@ -1,4 +1,5 @@
 import {LodestarError} from "@chainsafe/lodestar-utils";
+import {PeerAction} from "../../network";
 
 export enum GossipAction {
   IGNORE = "IGNORE",
@@ -6,10 +7,14 @@ export enum GossipAction {
 }
 
 export class GossipActionError<T extends {code: string}> extends LodestarError<T> {
+  /** The action at gossipsub side */
   action: GossipAction;
+  /** The action at node side */
+  lodestarAction?: PeerAction;
 
-  constructor(action: GossipAction, type: T) {
+  constructor(action: GossipAction, type: T, lodestarAction?: PeerAction) {
     super(type);
     this.action = action;
+    this.lodestarAction = lodestarAction;
   }
 }

--- a/packages/lodestar/src/chain/errors/gossipValidation.ts
+++ b/packages/lodestar/src/chain/errors/gossipValidation.ts
@@ -10,9 +10,9 @@ export class GossipActionError<T extends {code: string}> extends LodestarError<T
   /** The action at gossipsub side */
   action: GossipAction;
   /** The action at node side */
-  lodestarAction?: PeerAction;
+  lodestarAction: PeerAction | null;
 
-  constructor(action: GossipAction, type: T, lodestarAction?: PeerAction) {
+  constructor(action: GossipAction, lodestarAction: PeerAction | null, type: T) {
     super(type);
     this.action = action;
     this.lodestarAction = lodestarAction;

--- a/packages/lodestar/src/chain/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/aggregateAndProof.ts
@@ -12,6 +12,7 @@ import {getSelectionProofSignatureSet, getAggregateAndProofSignatureSet} from ".
 import {AttestationError, AttestationErrorCode, GossipAction} from "../errors";
 import {getCommitteeIndices, verifyHeadBlockAndTargetRoot, verifyPropagationSlotRange} from "./attestation";
 import {RegenCaller} from "../regen";
+import {PeerAction} from "../../network/peers";
 
 export async function validateGossipAggregateAndProof(
   chain: IBeaconChain,
@@ -34,7 +35,11 @@ export async function validateGossipAggregateAndProof(
 
   // [REJECT] The attestation's epoch matches its target -- i.e. attestation.data.target.epoch == compute_epoch_at_slot(attestation.data.slot)
   if (targetEpoch !== attEpoch) {
-    throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.BAD_TARGET_EPOCH});
+    throw new AttestationError(
+      GossipAction.REJECT,
+      {code: AttestationErrorCode.BAD_TARGET_EPOCH},
+      PeerAction.LowToleranceError
+    );
   }
 
   // [IGNORE] aggregate.data.slot is within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
@@ -83,19 +88,31 @@ export async function validateGossipAggregateAndProof(
   // len(get_attesting_indices(state, aggregate.data, aggregate.aggregation_bits)) >= 1.
   if (attestingIndices.length < 1) {
     // missing attestation participants
-    throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.EMPTY_AGGREGATION_BITFIELD});
+    throw new AttestationError(
+      GossipAction.REJECT,
+      {code: AttestationErrorCode.EMPTY_AGGREGATION_BITFIELD},
+      PeerAction.LowToleranceError
+    );
   }
 
   // [REJECT] aggregate_and_proof.selection_proof selects the validator as an aggregator for the slot
   // -- i.e. is_aggregator(state, aggregate.data.slot, aggregate.data.index, aggregate_and_proof.selection_proof) returns True.
   if (!isAggregatorFromCommitteeLength(committeeIndices.length, aggregateAndProof.selectionProof)) {
-    throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.INVALID_AGGREGATOR});
+    throw new AttestationError(
+      GossipAction.REJECT,
+      {code: AttestationErrorCode.INVALID_AGGREGATOR},
+      PeerAction.LowToleranceError
+    );
   }
 
   // [REJECT] The aggregator's validator index is within the committee
   // -- i.e. aggregate_and_proof.aggregator_index in get_beacon_committee(state, aggregate.data.slot, aggregate.data.index).
   if (!committeeIndices.includes(aggregateAndProof.aggregatorIndex)) {
-    throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE});
+    throw new AttestationError(
+      GossipAction.REJECT,
+      {code: AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE},
+      PeerAction.LowToleranceError
+    );
   }
 
   // [REJECT] The aggregate_and_proof.selection_proof is a valid signature of the aggregate.data.slot
@@ -109,7 +126,11 @@ export async function validateGossipAggregateAndProof(
     allForks.getIndexedAttestationSignatureSet(attHeadState, indexedAttestation),
   ];
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {
-    throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.INVALID_SIGNATURE});
+    throw new AttestationError(
+      GossipAction.REJECT,
+      {code: AttestationErrorCode.INVALID_SIGNATURE},
+      PeerAction.LowToleranceError
+    );
   }
 
   // It's important to double check that the attestation still hasn't been observed, since

--- a/packages/lodestar/src/chain/validation/attesterSlashing.ts
+++ b/packages/lodestar/src/chain/validation/attesterSlashing.ts
@@ -13,7 +13,7 @@ export async function validateGossipAttesterSlashing(
   // ), verify if any(attester_slashed_indices.difference(prior_seen_attester_slashed_indices))).
   const intersectingIndices = getAttesterSlashableIndices(attesterSlashing);
   if (chain.opPool.hasSeenAttesterSlashing(intersectingIndices)) {
-    throw new AttesterSlashingError(GossipAction.IGNORE, {
+    throw new AttesterSlashingError(GossipAction.IGNORE, null, {
       code: AttesterSlashingErrorCode.ALREADY_EXISTS,
     });
   }
@@ -25,25 +25,17 @@ export async function validateGossipAttesterSlashing(
     // verifySignature = false, verified in batch below
     allForks.assertValidAttesterSlashing(state, attesterSlashing, false);
   } catch (e) {
-    throw new AttesterSlashingError(
-      GossipAction.REJECT,
-      {
-        code: AttesterSlashingErrorCode.INVALID,
-        error: e as Error,
-      },
-      PeerAction.HighToleranceError
-    );
+    throw new AttesterSlashingError(GossipAction.REJECT, PeerAction.HighToleranceError, {
+      code: AttesterSlashingErrorCode.INVALID,
+      error: e as Error,
+    });
   }
 
   const signatureSets = allForks.getAttesterSlashingSignatureSets(state, attesterSlashing);
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {
-    throw new AttesterSlashingError(
-      GossipAction.REJECT,
-      {
-        code: AttesterSlashingErrorCode.INVALID,
-        error: Error("Invalid signature"),
-      },
-      PeerAction.HighToleranceError
-    );
+    throw new AttesterSlashingError(GossipAction.REJECT, PeerAction.HighToleranceError, {
+      code: AttesterSlashingErrorCode.INVALID,
+      error: Error("Invalid signature"),
+    });
   }
 }

--- a/packages/lodestar/src/chain/validation/attesterSlashing.ts
+++ b/packages/lodestar/src/chain/validation/attesterSlashing.ts
@@ -1,5 +1,6 @@
 import {phase0, allForks, getAttesterSlashableIndices} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconChain} from "..";
+import {PeerAction} from "../../network/peers";
 import {AttesterSlashingError, AttesterSlashingErrorCode, GossipAction} from "../errors";
 
 export async function validateGossipAttesterSlashing(
@@ -24,17 +25,25 @@ export async function validateGossipAttesterSlashing(
     // verifySignature = false, verified in batch below
     allForks.assertValidAttesterSlashing(state, attesterSlashing, false);
   } catch (e) {
-    throw new AttesterSlashingError(GossipAction.REJECT, {
-      code: AttesterSlashingErrorCode.INVALID,
-      error: e as Error,
-    });
+    throw new AttesterSlashingError(
+      GossipAction.REJECT,
+      {
+        code: AttesterSlashingErrorCode.INVALID,
+        error: e as Error,
+      },
+      PeerAction.HighToleranceError
+    );
   }
 
   const signatureSets = allForks.getAttesterSlashingSignatureSets(state, attesterSlashing);
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {
-    throw new AttesterSlashingError(GossipAction.REJECT, {
-      code: AttesterSlashingErrorCode.INVALID,
-      error: Error("Invalid signature"),
-    });
+    throw new AttesterSlashingError(
+      GossipAction.REJECT,
+      {
+        code: AttesterSlashingErrorCode.INVALID,
+        error: Error("Invalid signature"),
+      },
+      PeerAction.HighToleranceError
+    );
   }
 }

--- a/packages/lodestar/src/chain/validation/block.ts
+++ b/packages/lodestar/src/chain/validation/block.ts
@@ -24,15 +24,11 @@ export async function validateGossipBlock(
   // appropriate slot).
   const currentSlotWithGossipDisparity = chain.clock.currentSlotWithGossipDisparity;
   if (currentSlotWithGossipDisparity < blockSlot) {
-    throw new BlockGossipError(
-      GossipAction.IGNORE,
-      {
-        code: BlockErrorCode.FUTURE_SLOT,
-        currentSlot: currentSlotWithGossipDisparity,
-        blockSlot,
-      },
-      PeerAction.LowToleranceError
-    );
+    throw new BlockGossipError(GossipAction.IGNORE, PeerAction.LowToleranceError, {
+      code: BlockErrorCode.FUTURE_SLOT,
+      currentSlot: currentSlotWithGossipDisparity,
+      blockSlot,
+    });
   }
 
   // [IGNORE] The block is from a slot greater than the latest finalized slot -- i.e. validate that
@@ -40,15 +36,11 @@ export async function validateGossipBlock(
   const finalizedCheckpoint = chain.forkChoice.getFinalizedCheckpoint();
   const finalizedSlot = computeStartSlotAtEpoch(finalizedCheckpoint.epoch);
   if (blockSlot <= finalizedSlot) {
-    throw new BlockGossipError(
-      GossipAction.IGNORE,
-      {
-        code: BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT,
-        blockSlot,
-        finalizedSlot,
-      },
-      PeerAction.LowToleranceError
-    );
+    throw new BlockGossipError(GossipAction.IGNORE, PeerAction.LowToleranceError, {
+      code: BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT,
+      blockSlot,
+      finalizedSlot,
+    });
   }
 
   // Check if the block is already known. We know it is post-finalization, so it is sufficient to check the fork choice.
@@ -59,7 +51,7 @@ export async function validateGossipBlock(
   // already know this block.
   const blockRoot = toHexString(config.getForkTypes(blockSlot).BeaconBlock.hashTreeRoot(block));
   if (chain.forkChoice.getBlockHex(blockRoot) !== null) {
-    throw new BlockGossipError(GossipAction.IGNORE, {code: BlockErrorCode.ALREADY_KNOWN, root: blockRoot});
+    throw new BlockGossipError(GossipAction.IGNORE, null, {code: BlockErrorCode.ALREADY_KNOWN, root: blockRoot});
   }
 
   // No need to check for badBlock
@@ -68,7 +60,7 @@ export async function validateGossipBlock(
   // [IGNORE] The block is the first block with valid signature received for the proposer for the slot, signed_beacon_block.message.slot.
   const proposerIndex = block.proposerIndex;
   if (chain.seenBlockProposers.isKnown(blockSlot, proposerIndex)) {
-    throw new BlockGossipError(GossipAction.IGNORE, {code: BlockErrorCode.REPEAT_PROPOSAL, proposerIndex});
+    throw new BlockGossipError(GossipAction.IGNORE, null, {code: BlockErrorCode.REPEAT_PROPOSAL, proposerIndex});
   }
 
   // [REJECT] The current finalized_checkpoint is an ancestor of block -- i.e.
@@ -86,20 +78,16 @@ export async function validateGossipBlock(
     //    descend from the finalized root.
     // (Non-Lighthouse): Since we prune all blocks non-descendant from finalized checking the `db.block` database won't be useful to guard
     // against known bad fork blocks, so we throw PARENT_UNKNOWN for cases (1) and (2)
-    throw new BlockGossipError(GossipAction.IGNORE, {code: BlockErrorCode.PARENT_UNKNOWN, parentRoot});
+    throw new BlockGossipError(GossipAction.IGNORE, null, {code: BlockErrorCode.PARENT_UNKNOWN, parentRoot});
   }
 
   // [REJECT] The block is from a higher slot than its parent.
   if (parentBlock.slot >= blockSlot) {
-    throw new BlockGossipError(
-      GossipAction.IGNORE,
-      {
-        code: BlockErrorCode.NOT_LATER_THAN_PARENT,
-        parentSlot: parentBlock.slot,
-        slot: blockSlot,
-      },
-      PeerAction.LowToleranceError
-    );
+    throw new BlockGossipError(GossipAction.IGNORE, PeerAction.LowToleranceError, {
+      code: BlockErrorCode.NOT_LATER_THAN_PARENT,
+      parentSlot: parentBlock.slot,
+      slot: blockSlot,
+    });
   }
 
   // getBlockSlotState also checks for whether the current finalized checkpoint is an ancestor of the block.
@@ -110,7 +98,7 @@ export async function validateGossipBlock(
   const blockState = await chain.regen
     .getBlockSlotState(parentRoot, blockSlot, RegenCaller.validateGossipBlock)
     .catch(() => {
-      throw new BlockGossipError(GossipAction.IGNORE, {code: BlockErrorCode.PARENT_UNKNOWN, parentRoot});
+      throw new BlockGossipError(GossipAction.IGNORE, null, {code: BlockErrorCode.PARENT_UNKNOWN, parentRoot});
     });
 
   // Extra conditions for merge fork blocks
@@ -122,15 +110,11 @@ export async function validateGossipBlock(
     if (bellatrix.isBellatrixStateType(blockState) && bellatrix.isExecutionEnabled(blockState, block.body)) {
       const expectedTimestamp = computeTimeAtSlot(config, blockSlot, chain.genesisTime);
       if (executionPayload.timestamp !== expectedTimestamp) {
-        throw new BlockGossipError(
-          GossipAction.REJECT,
-          {
-            code: BlockErrorCode.INCORRECT_TIMESTAMP,
-            timestamp: executionPayload.timestamp,
-            expectedTimestamp,
-          },
-          PeerAction.LowToleranceError
-        );
+        throw new BlockGossipError(GossipAction.REJECT, PeerAction.LowToleranceError, {
+          code: BlockErrorCode.INCORRECT_TIMESTAMP,
+          timestamp: executionPayload.timestamp,
+          expectedTimestamp,
+        });
       }
     }
   }
@@ -139,11 +123,9 @@ export async function validateGossipBlock(
   const signatureSet = allForks.getProposerSignatureSet(blockState, signedBlock);
   // Don't batch so verification is not delayed
   if (!(await chain.bls.verifySignatureSets([signatureSet]))) {
-    throw new BlockGossipError(
-      GossipAction.REJECT,
-      {code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID},
-      PeerAction.LowToleranceError
-    );
+    throw new BlockGossipError(GossipAction.REJECT, PeerAction.LowToleranceError, {
+      code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID,
+    });
   }
 
   // [REJECT] The block is proposed by the expected proposer_index for the block's slot in the context of the current
@@ -151,16 +133,15 @@ export async function validateGossipBlock(
   // shuffling, the block MAY be queued for later processing while proposers for the block's branch are calculated --
   // in such a case do not REJECT, instead IGNORE this message.
   if (blockState.epochCtx.getBeaconProposer(blockSlot) !== proposerIndex) {
-    throw new BlockGossipError(
-      GossipAction.REJECT,
-      {code: BlockErrorCode.INCORRECT_PROPOSER, proposerIndex},
-      PeerAction.LowToleranceError
-    );
+    throw new BlockGossipError(GossipAction.REJECT, PeerAction.LowToleranceError, {
+      code: BlockErrorCode.INCORRECT_PROPOSER,
+      proposerIndex,
+    });
   }
 
   // Check again in case there two blocks are processed concurrently
   if (chain.seenBlockProposers.isKnown(blockSlot, proposerIndex)) {
-    throw new BlockGossipError(GossipAction.IGNORE, {code: BlockErrorCode.REPEAT_PROPOSAL, proposerIndex});
+    throw new BlockGossipError(GossipAction.IGNORE, null, {code: BlockErrorCode.REPEAT_PROPOSAL, proposerIndex});
   }
 
   // Simple implementation of a pending block queue. Keeping the block here recycles the queue logic, and keeps the

--- a/packages/lodestar/src/chain/validation/proposerSlashing.ts
+++ b/packages/lodestar/src/chain/validation/proposerSlashing.ts
@@ -1,5 +1,6 @@
 import {phase0, allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconChain} from "..";
+import {PeerAction} from "../../network/peers";
 import {ProposerSlashingError, ProposerSlashingErrorCode, GossipAction} from "../errors";
 
 export async function validateGossipProposerSlashing(
@@ -21,17 +22,25 @@ export async function validateGossipProposerSlashing(
     // verifySignature = false, verified in batch below
     allForks.assertValidProposerSlashing(state, proposerSlashing, false);
   } catch (e) {
-    throw new ProposerSlashingError(GossipAction.REJECT, {
-      code: ProposerSlashingErrorCode.INVALID,
-      error: e as Error,
-    });
+    throw new ProposerSlashingError(
+      GossipAction.REJECT,
+      {
+        code: ProposerSlashingErrorCode.INVALID,
+        error: e as Error,
+      },
+      PeerAction.HighToleranceError
+    );
   }
 
   const signatureSets = allForks.getProposerSlashingSignatureSets(state, proposerSlashing);
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {
-    throw new ProposerSlashingError(GossipAction.REJECT, {
-      code: ProposerSlashingErrorCode.INVALID,
-      error: Error("Invalid signature"),
-    });
+    throw new ProposerSlashingError(
+      GossipAction.REJECT,
+      {
+        code: ProposerSlashingErrorCode.INVALID,
+        error: Error("Invalid signature"),
+      },
+      PeerAction.HighToleranceError
+    );
   }
 }

--- a/packages/lodestar/src/chain/validation/proposerSlashing.ts
+++ b/packages/lodestar/src/chain/validation/proposerSlashing.ts
@@ -10,7 +10,7 @@ export async function validateGossipProposerSlashing(
   // [IGNORE] The proposer slashing is the first valid proposer slashing received for the proposer with index
   // proposer_slashing.signed_header_1.message.proposer_index.
   if (chain.opPool.hasSeenProposerSlashing(proposerSlashing.signedHeader1.message.proposerIndex)) {
-    throw new ProposerSlashingError(GossipAction.IGNORE, {
+    throw new ProposerSlashingError(GossipAction.IGNORE, null, {
       code: ProposerSlashingErrorCode.ALREADY_EXISTS,
     });
   }
@@ -22,25 +22,17 @@ export async function validateGossipProposerSlashing(
     // verifySignature = false, verified in batch below
     allForks.assertValidProposerSlashing(state, proposerSlashing, false);
   } catch (e) {
-    throw new ProposerSlashingError(
-      GossipAction.REJECT,
-      {
-        code: ProposerSlashingErrorCode.INVALID,
-        error: e as Error,
-      },
-      PeerAction.HighToleranceError
-    );
+    throw new ProposerSlashingError(GossipAction.REJECT, PeerAction.HighToleranceError, {
+      code: ProposerSlashingErrorCode.INVALID,
+      error: e as Error,
+    });
   }
 
   const signatureSets = allForks.getProposerSlashingSignatureSets(state, proposerSlashing);
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {
-    throw new ProposerSlashingError(
-      GossipAction.REJECT,
-      {
-        code: ProposerSlashingErrorCode.INVALID,
-        error: Error("Invalid signature"),
-      },
-      PeerAction.HighToleranceError
-    );
+    throw new ProposerSlashingError(GossipAction.REJECT, PeerAction.HighToleranceError, {
+      code: ProposerSlashingErrorCode.INVALID,
+      error: Error("Invalid signature"),
+    });
   }
 }

--- a/packages/lodestar/src/chain/validation/syncCommittee.ts
+++ b/packages/lodestar/src/chain/validation/syncCommittee.ts
@@ -32,7 +32,7 @@ export async function validateGossipSyncCommittee(
   // [IGNORE] There has been no other valid sync committee signature for the declared slot for the validator referenced
   // by sync_committee_signature.validator_index.
   if (chain.seenSyncCommitteeMessages.isKnown(slot, subnet, validatorIndex)) {
-    throw new SyncCommitteeError(GossipAction.IGNORE, {
+    throw new SyncCommitteeError(GossipAction.IGNORE, null, {
       code: SyncCommitteeErrorCode.SYNC_COMMITTEE_ALREADY_KNOWN,
     });
   }
@@ -60,13 +60,9 @@ export async function validateSyncCommitteeSigOnly(
 ): Promise<void> {
   const signatureSet = getSyncCommitteeSignatureSet(headState, syncCommittee);
   if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true}))) {
-    throw new SyncCommitteeError(
-      GossipAction.REJECT,
-      {
-        code: SyncCommitteeErrorCode.INVALID_SIGNATURE,
-      },
-      PeerAction.LowToleranceError
-    );
+    throw new SyncCommitteeError(GossipAction.REJECT, PeerAction.LowToleranceError, {
+      code: SyncCommitteeErrorCode.INVALID_SIGNATURE,
+    });
   }
 }
 
@@ -84,7 +80,7 @@ export function validateGossipSyncCommitteeExceptSig(
   // (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
   // don't apply any peer actions for now
   if (!chain.clock.isCurrentSlotGivenGossipDisparity(slot)) {
-    throw new SyncCommitteeError(GossipAction.IGNORE, {
+    throw new SyncCommitteeError(GossipAction.IGNORE, null, {
       code: SyncCommitteeErrorCode.NOT_CURRENT_SLOT,
       currentSlot: chain.clock.currentSlot,
       slot,
@@ -93,28 +89,20 @@ export function validateGossipSyncCommitteeExceptSig(
 
   // [REJECT] The subcommittee index is in the allowed range, i.e. contribution.subcommittee_index < SYNC_COMMITTEE_SUBNET_COUNT.
   if (subnet >= SYNC_COMMITTEE_SUBNET_COUNT) {
-    throw new SyncCommitteeError(
-      GossipAction.REJECT,
-      {
-        code: SyncCommitteeErrorCode.INVALID_SUBCOMMITTEE_INDEX,
-        subcommitteeIndex: subnet,
-      },
-      PeerAction.LowToleranceError
-    );
+    throw new SyncCommitteeError(GossipAction.REJECT, PeerAction.LowToleranceError, {
+      code: SyncCommitteeErrorCode.INVALID_SUBCOMMITTEE_INDEX,
+      subcommitteeIndex: subnet,
+    });
   }
 
   // [REJECT] The subnet_id is valid for the given validator, i.e. subnet_id in compute_subnets_for_sync_committee(state, sync_committee_signature.validator_index).
   // Note this validation implies the validator is part of the broader current sync committee along with the correct subcommittee.
   const indexInSubcommittee = getIndexInSubcommittee(headState, subnet, data);
   if (indexInSubcommittee === null) {
-    throw new SyncCommitteeError(
-      GossipAction.REJECT,
-      {
-        code: SyncCommitteeErrorCode.VALIDATOR_NOT_IN_SYNC_COMMITTEE,
-        validatorIndex,
-      },
-      PeerAction.LowToleranceError
-    );
+    throw new SyncCommitteeError(GossipAction.REJECT, PeerAction.LowToleranceError, {
+      code: SyncCommitteeErrorCode.VALIDATOR_NOT_IN_SYNC_COMMITTEE,
+      validatorIndex,
+    });
   }
 
   return indexInSubcommittee;

--- a/packages/lodestar/src/chain/validation/voluntaryExit.ts
+++ b/packages/lodestar/src/chain/validation/voluntaryExit.ts
@@ -10,7 +10,7 @@ export async function validateGossipVoluntaryExit(
   // [IGNORE] The voluntary exit is the first valid voluntary exit received for the validator with index
   // signed_voluntary_exit.message.validator_index.
   if (chain.opPool.hasSeenVoluntaryExit(voluntaryExit.message.validatorIndex)) {
-    throw new VoluntaryExitError(GossipAction.IGNORE, {
+    throw new VoluntaryExitError(GossipAction.IGNORE, null, {
       code: VoluntaryExitErrorCode.ALREADY_EXISTS,
     });
   }
@@ -29,23 +29,15 @@ export async function validateGossipVoluntaryExit(
   // These errors occur due to a fault in the beacon chain. It is not necessarily
   // the fault on the peer.
   if (!allForks.isValidVoluntaryExit(state, voluntaryExit, false)) {
-    throw new VoluntaryExitError(
-      GossipAction.REJECT,
-      {
-        code: VoluntaryExitErrorCode.INVALID,
-      },
-      PeerAction.HighToleranceError
-    );
+    throw new VoluntaryExitError(GossipAction.REJECT, PeerAction.HighToleranceError, {
+      code: VoluntaryExitErrorCode.INVALID,
+    });
   }
 
   const signatureSet = allForks.getVoluntaryExitSignatureSet(state, voluntaryExit);
   if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true}))) {
-    throw new VoluntaryExitError(
-      GossipAction.REJECT,
-      {
-        code: VoluntaryExitErrorCode.INVALID_SIGNATURE,
-      },
-      PeerAction.HighToleranceError
-    );
+    throw new VoluntaryExitError(GossipAction.REJECT, PeerAction.HighToleranceError, {
+      code: VoluntaryExitErrorCode.INVALID_SIGNATURE,
+    });
   }
 }

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -42,10 +42,12 @@ import {
   GOSSIP_D_LOW,
 } from "./scoringParameters";
 import {Eth2Context} from "../../chain";
+import {IPeerRpcScoreStore} from "../peers";
 
 export interface IGossipsubModules {
   config: IBeaconConfig;
   libp2p: Libp2p;
+  peerRpcScores: IPeerRpcScoreStore;
   logger: ILogger;
   metrics: IMetrics | null;
   signal: AbortSignal;
@@ -102,6 +104,7 @@ export class Eth2Gossipsub extends Gossipsub {
     const {validatorFnsByType, jobQueues} = createValidatorFnsByType(gossipHandlers, {
       config,
       logger,
+      peerRpcScores: modules.peerRpcScores,
       uncompressCache: this.uncompressCache,
       metrics,
       signal,

--- a/packages/lodestar/src/network/gossip/validation/index.ts
+++ b/packages/lodestar/src/network/gossip/validation/index.ts
@@ -18,7 +18,7 @@ import {decodeMessageData, UncompressCache} from "../encoding";
 import {createValidationQueues} from "./queue";
 import {DEFAULT_ENCODING} from "../constants";
 import {getGossipAcceptMetadataByType, GetGossipAcceptMetadataFn} from "./onAccept";
-import {IPeerRpcScoreStore} from "../../peers/score";
+import {IPeerRpcScoreStore, PeerAction} from "../../peers/score";
 import PeerId from "peer-id";
 
 type ValidatorFnModules = {
@@ -96,7 +96,7 @@ function getGossipValidatorFn<K extends GossipType>(
             : sszType.deserialize(messageData);
       } catch (e) {
         // TODO: Log the error or do something better with it
-        throw new GossipActionError(GossipAction.REJECT, {code: (e as Error).message});
+        throw new GossipActionError(GossipAction.REJECT, PeerAction.LowToleranceError, {code: (e as Error).message});
       }
 
       await (gossipHandler as GossipHandlerFn)(gossipObject, topic, receivedFrom, seenTimestampSec);

--- a/packages/lodestar/src/network/gossip/validation/index.ts
+++ b/packages/lodestar/src/network/gossip/validation/index.ts
@@ -18,10 +18,13 @@ import {decodeMessageData, UncompressCache} from "../encoding";
 import {createValidationQueues} from "./queue";
 import {DEFAULT_ENCODING} from "../constants";
 import {getGossipAcceptMetadataByType, GetGossipAcceptMetadataFn} from "./onAccept";
+import {IPeerRpcScoreStore} from "../../peers/score";
+import PeerId from "peer-id";
 
 type ValidatorFnModules = {
   config: IChainForkConfig;
   logger: ILogger;
+  peerRpcScores: IPeerRpcScoreStore;
   metrics: IMetrics | null;
   uncompressCache: UncompressCache;
 };
@@ -78,13 +81,14 @@ function getGossipValidatorFn<K extends GossipType>(
   return async function gossipValidatorFn(topic, gossipMsg, seenTimestampSec) {
     // Define in scope above try {} to be used in catch {} if object was parsed
     let gossipObject;
+    const {data, receivedFrom} = gossipMsg;
     try {
       const encoding = topic.encoding ?? DEFAULT_ENCODING;
 
       // Deserialize object from bytes ONLY after being picked up from the validation queue
       try {
         const sszType = getGossipSSZType(topic);
-        const messageData = decodeMessageData(encoding, gossipMsg.data, uncompressCache);
+        const messageData = decodeMessageData(encoding, data, uncompressCache);
         gossipObject =
           // TODO: Review if it's really necessary to deserialize this as TreeBacked
           topic.type === GossipType.beacon_block || topic.type === GossipType.beacon_aggregate_and_proof
@@ -95,7 +99,7 @@ function getGossipValidatorFn<K extends GossipType>(
         throw new GossipActionError(GossipAction.REJECT, {code: (e as Error).message});
       }
 
-      await (gossipHandler as GossipHandlerFn)(gossipObject, topic, gossipMsg.receivedFrom, seenTimestampSec);
+      await (gossipHandler as GossipHandlerFn)(gossipObject, topic, receivedFrom, seenTimestampSec);
 
       const metadata = getGossipObjectAcceptMetadata(config, gossipObject, topic);
       logger.debug(`gossip - ${type} - accept`, metadata);
@@ -104,6 +108,10 @@ function getGossipValidatorFn<K extends GossipType>(
       if (!(e instanceof GossipActionError)) {
         logger.error(`Gossip validation ${type} threw a non-GossipActionError`, {}, e as Error);
         throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE, (e as Error).message);
+      }
+
+      if (e.lodestarAction) {
+        modules.peerRpcScores.applyAction(PeerId.createFromB58String(receivedFrom), e.lodestarAction);
       }
 
       // If the gossipObject was deserialized include its short metadata with the error data

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -91,6 +91,7 @@ export class Network implements INetwork {
       config,
       libp2p,
       logger,
+      peerRpcScores,
       metrics,
       signal,
       gossipHandlers: gossipHandlers ?? getGossipHandlers({chain, config, logger, network: this, metrics}, opts),

--- a/packages/lodestar/src/network/peers/peerManager.ts
+++ b/packages/lodestar/src/network/peers/peerManager.ts
@@ -361,6 +361,8 @@ export class PeerManager {
     // ban and disconnect peers with bad score, collect rest of healthy peers
     const connectedHealthyPeers: PeerId[] = [];
     for (const peer of connectedPeers) {
+      // to decay score
+      this.peerRpcScores.update(peer);
       switch (this.peerRpcScores.getScoreState(peer)) {
         case ScoreState.Banned:
           void this.goodbyeAndDisconnect(peer, GoodByeReasonCode.BANNED);

--- a/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
@@ -1,3 +1,4 @@
+import sinon, {SinonStubbedInstance} from "sinon";
 import {expect, assert} from "chai";
 import Libp2p from "libp2p";
 import {InMessage} from "libp2p-interfaces/src/pubsub";
@@ -17,19 +18,24 @@ import {createNode} from "../../../utils/network";
 import {testLogger} from "../../../utils/logger";
 import {GossipAction, GossipActionError} from "../../../../src/chain/errors";
 import {Eth2Context} from "../../../../src/chain";
+import {IPeerRpcScoreStore, PeerRpcScoreStore} from "../../../../src/network/peers/score";
 
 describe("network / gossip / validation", function () {
   const logger = testLogger();
   const metrics = null;
   const gossipType = GossipType.beacon_block;
+  const sandbox = sinon.createSandbox();
 
   let message: InMessage;
   let topicString: string;
   let libp2p: Libp2p;
   let eth2Context: Eth2Context;
+  let peerRpcScoresStub: IPeerRpcScoreStore & SinonStubbedInstance<PeerRpcScoreStore>;
 
   let controller: AbortController;
   beforeEach(() => {
+    peerRpcScoresStub = sandbox.createStubInstance(PeerRpcScoreStore) as IPeerRpcScoreStore &
+      SinonStubbedInstance<PeerRpcScoreStore>;
     controller = new AbortController();
     eth2Context = {
       activeValidatorCount: 16,
@@ -37,7 +43,11 @@ describe("network / gossip / validation", function () {
       currentSlot: 1000 * SLOTS_PER_EPOCH,
     };
   });
-  afterEach(() => controller.abort());
+
+  afterEach(() => {
+    controller.abort();
+    sandbox.restore();
+  });
 
   beforeEach(async function () {
     const signedBlock = generateEmptySignedBlock();
@@ -64,6 +74,7 @@ describe("network / gossip / validation", function () {
       gossipHandlers: gossipHandlersPartial as GossipHandlers,
       logger,
       libp2p,
+      peerRpcScores: peerRpcScoresStub,
       metrics,
       signal: controller.signal,
       eth2Context,
@@ -95,6 +106,7 @@ describe("network / gossip / validation", function () {
       gossipHandlers: gossipHandlersPartial as GossipHandlers,
       logger,
       libp2p,
+      peerRpcScores: peerRpcScoresStub,
       metrics,
       signal: controller.signal,
       eth2Context,

--- a/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
@@ -65,7 +65,7 @@ describe("network / gossip / validation", function () {
   it("should throw on failed validation", async () => {
     const gossipHandlersPartial: Partial<GossipHandlers> = {
       [gossipType]: async () => {
-        throw new GossipActionError(GossipAction.REJECT, {code: "TEST_ERROR"});
+        throw new GossipActionError(GossipAction.REJECT, null, {code: "TEST_ERROR"});
       },
     };
 


### PR DESCRIPTION
**Motivation**

+ if a node keeps receiving invalid messages from another node, right now it only decreases gossip score of peer, we also should decrease score at lodestar side, and in the end disconnect the peer

**Description**

+ Decay score in PeerManager hearbeat (we missed that)
+ GossipError now has PeerAction, based on that we'll penalizing peer at lodestar side when errors happen, refer to lighthouse implementation https://github.com/sigp/lighthouse/blob/c3a793fd73a3b11b130b82032904d39c952869e4/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs#L1339

Closes #3772
