### PR TITLE
exchangeTransitionConfiguration heartbeat implementation

### DIFF
--- a/packages/lodestar/src/executionEngine/index.ts
+++ b/packages/lodestar/src/executionEngine/index.ts
@@ -1,5 +1,5 @@
 import {AbortSignal} from "@chainsafe/abort-controller";
-import {IExecutionEngine} from "./interface";
+import {IExecutionEngine, TransitionConfigOpts} from "./interface";
 import {ExecutionEngineDisabled} from "./disabled";
 import {ExecutionEngineHttp, ExecutionEngineHttpOpts, defaultExecutionEngineHttpOpts} from "./http";
 import {ExecutionEngineMock, ExecutionEngineMockOpts} from "./mock";
@@ -13,7 +13,10 @@ export type ExecutionEngineOpts =
 
 export const defaultExecutionEngineOpts: ExecutionEngineOpts = defaultExecutionEngineHttpOpts;
 
-export function initializeExecutionEngine(opts: ExecutionEngineOpts, signal: AbortSignal): IExecutionEngine {
+export function initializeExecutionEngine(
+  opts: ExecutionEngineOpts & TransitionConfigOpts,
+  signal: AbortSignal
+): IExecutionEngine {
   switch (opts.mode) {
     case "mock":
       return new ExecutionEngineMock(opts);

--- a/packages/lodestar/src/executionEngine/interface.ts
+++ b/packages/lodestar/src/executionEngine/interface.ts
@@ -56,6 +56,20 @@ export type PayloadAttributes = {
   suggestedFeeRecipient: Uint8Array | ByteVector;
 };
 
+export type TransitionConfig = {
+  terminalTotalDifficulty: bigint;
+  terminalBlockHash: Uint8Array | ByteVector;
+  terminalBlockNumber: number;
+};
+
+export type TransitionConfigOpts = {transitionConfig: TransitionConfig; heartBeatInSec?: number};
+
+export type ApiTransitionConfig = {
+  terminalTotalDifficulty: QUANTITY;
+  terminalBlockHash: DATA;
+  terminalBlockNumber: QUANTITY;
+};
+
 export type ApiPayloadAttributes = {
   /** QUANTITY, 64 Bits - value for the timestamp field of the new payload */
   timestamp: QUANTITY;

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -133,6 +133,13 @@ export class BeaconNode {
       initBeaconMetrics(metrics, anchorState);
     }
 
+    const transitionConfig = {
+      terminalTotalDifficulty: config.TERMINAL_TOTAL_DIFFICULTY,
+      terminalBlockHash: config.TERMINAL_BLOCK_HASH,
+      /** terminalBlockNumber has to be set to zero for now as per specs */
+      terminalBlockNumber: 0,
+    };
+
     const chain = new BeaconChain(opts.chain, {
       config,
       db,
@@ -144,7 +151,13 @@ export class BeaconNode {
         {config, db, logger: logger.child(opts.logger.eth1), signal},
         anchorState
       ),
-      executionEngine: initializeExecutionEngine(opts.executionEngine, signal),
+      executionEngine: initializeExecutionEngine(
+        {
+          ...opts.executionEngine,
+          transitionConfig,
+        },
+        signal
+      ),
     });
 
     // Load persisted data from disk to in-memory caches


### PR DESCRIPTION
**Motivation**
Execution engines will now hosts an api to specify and match transition configuration https://github.com/ethereum/execution-apis/pull/172, which is supposed to act as a heatbeat between EL and CL.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR implements and matches the same and aims to implements the heart beat functionality
**Description**
PS: this work is currently WIP and some details/clarifications are awaited. Also this is not the part of Kiln v2 spec.
Part of [Kiln tracker](https://github.com/ChainSafe/lodestar/issues/3731)