### PR TITLE
backfill: Use batchable mode when verifying signature sets

### DIFF
--- a/packages/lodestar/src/sync/backfill/verify.ts
+++ b/packages/lodestar/src/sync/backfill/verify.ts
@@ -52,7 +52,7 @@ export async function verifyBlockProposerSignature(
     return sigs;
   }, []);
 
-  if (!(await bls.verifySignatureSets(signatures))) {
+  if (!(await bls.verifySignatureSets(signatures, {batchable: true}))) {
     throw new BackfillSyncError({code: BackfillSyncErrorCode.INVALID_SIGNATURE});
   }
 }


### PR DESCRIPTION
**Motivation**

We don't want backfill sync to take a lot of resources

**Description**

Use `{batchable: true}` when verify signature sets for backfill
