### PR TITLE
Make it possible to run devnet setup script on macOS

### DIFF
--- a/kiln/devnets/devnet3.vars
+++ b/kiln/devnets/devnet3.vars
@@ -10,6 +10,6 @@ LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls 
 
 NETHERMIND_EXTRA_ARGS="--config kintsugi --Init.WebSocketsEnabled=true --JsonRpc.Enabled=true --JsonRpc.EnabledModules=net,eth,consensus,engine,subscribe,web3 --JsonRpc.Port=8545 --JsonRpc.WebSocketsPort=8546 --JsonRpc.Host=0.0.0.0 --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=5000000000 --Init.DiagnosticMode=None"
 
-GETH_EXTRA_ARGS="--catalyst --http --http.api engine,net,eth --http.port 8545 --ws --ws.api net,eth,engine --ws.port=8546 --ws.addr 0.0.0.0 --allow-insecure-unlock --networkid 1337602"
+GETH_EXTRA_ARGS="--catalyst --http --http.api engine,net,eth --http.port 8545 --ws --ws.api net,eth,engine --ws.port=8546 --ws.addr 0.0.0.0 --allow-insecure-unlock --networkid 1337602 --http.addr 0.0.0.0"
 
 EXTRA_BOOTNODES="enode://984a51c5c9b2f212e9480b0ea811b62e711271c5928bce2c40857643484dc9474410f5002e34aa95ac48d3f58a1e581b25c592ad50cbf50f871791997c36fd8b@137.184.221.12:30303,"

--- a/kiln/devnets/devnet4.vars
+++ b/kiln/devnets/devnet4.vars
@@ -10,6 +10,6 @@ LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls 
 
 NETHERMIND_EXTRA_ARGS="--config kiln --Init.WebSocketsEnabled=true --JsonRpc.Enabled=true --JsonRpc.EnabledModules=net,eth,consensus,engine,subscribe,web3 --JsonRpc.Port=8545 --JsonRpc.WebSocketsPort=8546 --JsonRpc.Host=0.0.0.0 --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=5000000000 --Init.DiagnosticMode=None"
 
-GETH_EXTRA_ARGS="--http --http.api engine,net,eth --http.port 8545 --ws --ws.api net,eth,engine --ws.port=8546 --ws.addr 0.0.0.0 --allow-insecure-unlock --networkid 1337752"
+GETH_EXTRA_ARGS="--http --http.api engine,net,eth --http.port 8545 --ws --ws.api net,eth,engine --ws.port=8546 --ws.addr 0.0.0.0 --allow-insecure-unlock --networkid 1337752 --http.addr 0.0.0.0"
 
 EXTRA_BOOTNODES=""

--- a/kiln/devnets/devnet4.vars
+++ b/kiln/devnets/devnet4.vars
@@ -2,7 +2,7 @@ DEVNET_NAME=devnet4
 
 GETH_IMAGE=parithoshj/geth:merge-8f408a2
 NETHERMIND_IMAGE=nethermindeth/nethermind:kiln_0.1
-LODESTAR_IMAGE=chainsafe/lodestar:next
+LODESTAR_IMAGE=g11tech/lodestar:kilnv1
 
 CONFIG_GIT_DIR=merge-devnet-4
 

--- a/kiln/devnets/kintsugi.vars
+++ b/kiln/devnets/kintsugi.vars
@@ -10,6 +10,6 @@ LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls 
 
 NETHERMIND_EXTRA_ARGS="--config kintsugi --Init.WebSocketsEnabled=true --JsonRpc.Enabled=true --JsonRpc.EnabledModules=net,eth,consensus,engine,subscribe,web3 --JsonRpc.Port=8545 --JsonRpc.WebSocketsPort=8546 --JsonRpc.Host=0.0.0.0 --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=5000000000 --Init.DiagnosticMode=None"
 
-GETH_EXTRA_ARGS="--catalyst --http --http.api engine,net,eth --http.port 8545 --ws --ws.api net,eth,engine --ws.port=8546 --ws.addr 0.0.0.0 --allow-insecure-unlock --networkid 1337702"
+GETH_EXTRA_ARGS="--catalyst --http --http.api engine,net,eth --http.port 8545 --ws --ws.api net,eth,engine --ws.port=8546 --ws.addr 0.0.0.0 --allow-insecure-unlock --networkid 1337702 --http.addr 0.0.0.0"
 
 EXTRA_BOOTNODES="enode://c20047e975f562131d0211b1a36f955b821663bd83a69edd725b221b70db0d01320716dd6a45d87e4e8afc1bc53439ff001212a70be0f1064db65c82d7ebbc9d@161.35.67.221:30303,enode://a0b9d5f4bc6a30b36a40e64762471e79b37700cb7ac6560680f6192e3360d34c689cf97ad3787256939152fe9f2b28e7d74d76119a86fed356f9c76d4c6301cb@161.35.67.200:30303,"


### PR DESCRIPTION
**Motivation**

There are slight differences between the docker api on linux and macOS. 
The current devnet setup script assumes linux and hence the start up script does not work on macOs.
This PR updates the startup script making it possible to also use the startup script on a macOS 