### PR TITLE
Update Grafana dashboard

### DIFF
--- a/docker/grafana/datasource.local.yml
+++ b/docker/grafana/datasource.local.yml
@@ -5,4 +5,5 @@ datasources:
     type: prometheus
     access: proxy
     url: http://localhost:9090
+    uid: prometheus_local
     isDefault: true

--- a/docker/grafana/datasource.yml
+++ b/docker/grafana/datasource.yml
@@ -5,4 +5,5 @@ datasources:
     type: prometheus
     access: proxy
     url: http://prometheus:9090
+    uid: prometheus_local
     isDefault: true

--- a/docker/grafana/provisioning/dashboards/lodestar.json
+++ b/docker/grafana/provisioning/dashboards/lodestar.json
@@ -77,7 +77,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1645857689467,
+  "iteration": 1645857689470,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -641,7 +641,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "exemplar": true,
+          "exemplar": false,
           "expr": "process_start_time_seconds{scrape_location=\"beacon\"}*1000",
           "instant": false,
           "interval": "",
@@ -1100,7 +1100,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1116,7 +1117,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 2
           },
           "id": 102,
           "options": {
@@ -1210,7 +1211,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1226,7 +1228,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 2
           },
           "id": 172,
           "options": {
@@ -1296,7 +1298,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1312,7 +1315,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 8
           },
           "id": 171,
           "options": {
@@ -1346,7 +1349,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 8
           },
           "id": 99,
           "options": {
@@ -1422,7 +1425,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1505,7 +1509,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1588,7 +1593,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1626,7 +1632,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "process_heap_bytes",
               "interval": "",
               "legendFormat": "",
@@ -1675,7 +1681,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1757,7 +1764,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1840,7 +1848,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1923,7 +1932,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2006,7 +2016,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2105,7 +2116,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2187,7 +2199,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2284,7 +2297,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2404,7 +2418,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2442,7 +2457,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "avg_over_time(scrape_duration_seconds[$__rate_interval])",
               "interval": "",
               "intervalFactor": 1,
@@ -2508,7 +2523,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2562,7 +2578,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "1-up",
               "interval": "",
               "legendFormat": "{{scrape_location}}",
@@ -2613,7 +2629,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2651,7 +2668,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "rate(lodestar_metrics_scrape_seconds_sum[$__rate_interval])/rate(lodestar_metrics_scrape_seconds_count[$__rate_interval])",
               "interval": "",
               "intervalFactor": 1,
@@ -2681,7 +2698,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "rate(lodestar_metrics_scrape_seconds_sum[$__rate_interval])/rate(lodestar_metrics_scrape_seconds_count[$__rate_interval])",
               "interval": "",
               "intervalFactor": 1,
@@ -2730,7 +2747,7 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 7,
+            "h": 8,
             "w": 6,
             "x": 0,
             "y": 5
@@ -2814,7 +2831,7 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 7,
+            "h": 8,
             "w": 6,
             "x": 6,
             "y": 5
@@ -2943,7 +2960,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "avg(\n  delta(validator_monitor_prev_epoch_on_chain_balance_total[$__rate_interval])\n)",
               "interval": "",
               "legendFormat": "aggregates",
@@ -3010,13 +3027,13 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 12
+            "y": 13
           },
           "id": 311,
           "options": {
             "legend": {
               "calcs": [],
-              "displayMode": "list",
+              "displayMode": "hidden",
               "placement": "bottom"
             },
             "tooltip": {
@@ -3033,7 +3050,7 @@
               "exemplar": false,
               "expr": "1-avg(validator_monitor_prev_epoch_on_chain_attester_correct_head_total)",
               "interval": "",
-              "legendFormat": "Percent of correct head attestations",
+              "legendFormat": "ratio",
               "refId": "A"
             }
           ],
@@ -3102,7 +3119,7 @@
           "options": {
             "legend": {
               "calcs": [],
-              "displayMode": "list",
+              "displayMode": "hidden",
               "placement": "bottom"
             },
             "tooltip": {
@@ -3113,9 +3130,14 @@
           "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": false,
               "expr": "avg(validator_monitor_prev_epoch_on_chain_inclusion_distance)",
               "interval": "",
-              "legendFormat": "{{index}}",
+              "legendFormat": "inclusion distance",
               "refId": "A"
             }
           ],
@@ -3179,7 +3201,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 20
+            "y": 21
           },
           "id": 196,
           "options": {
@@ -3201,7 +3223,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "sum(delta(validator_monitor_prev_epoch_on_chain_attester_miss_total[$__rate_interval]))\n/\n(\n  sum(delta(validator_monitor_prev_epoch_on_chain_attester_hit_total[$__rate_interval]))\n  +\n  sum(delta(validator_monitor_prev_epoch_on_chain_attester_miss_total[$__rate_interval]))\n)",
               "interval": "",
               "legendFormat": "attester",
@@ -3212,7 +3234,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "sum(delta(validator_monitor_prev_epoch_on_chain_target_attester_miss_total[$__rate_interval]))\n/\n(\n  sum(delta(validator_monitor_prev_epoch_on_chain_target_attester_hit_total[$__rate_interval]))\n  +\n  sum(delta(validator_monitor_prev_epoch_on_chain_target_attester_miss_total[$__rate_interval]))\n)",
               "hide": false,
               "interval": "",
@@ -3224,7 +3246,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "sum(delta(validator_monitor_prev_epoch_on_chain_head_attester_miss_total[$__rate_interval]))\n/\n(\n  sum(delta(validator_monitor_prev_epoch_on_chain_head_attester_hit_total[$__rate_interval]))\n  +\n  sum(delta(validator_monitor_prev_epoch_on_chain_head_attester_miss_total[$__rate_interval]))\n)",
               "hide": false,
               "interval": "",
@@ -3313,7 +3335,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "sum(delta(validator_monitor_prev_epoch_attestations_min_delay_seconds_sum[$__rate_interval]))\n/\nsum(delta(validator_monitor_prev_epoch_attestations_min_delay_seconds_count[$__rate_interval]))",
               "hide": false,
               "interval": "",
@@ -3325,7 +3347,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "sum(delta(validator_monitor_prev_epoch_aggregates_min_delay_seconds_sum[$__rate_interval]))\n/\nsum(delta(validator_monitor_prev_epoch_aggregates_min_delay_seconds_count[$__rate_interval]))",
               "interval": "",
               "legendFormat": "aggregates",
@@ -3336,7 +3358,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "sum(delta(validator_monitor_prev_epoch_beacon_blocks_min_delay_seconds_sum[$__rate_interval]))\n/\nsum(delta(validator_monitor_prev_epoch_beacon_blocks_min_delay_seconds_count[$__rate_interval]))",
               "hide": false,
               "interval": "",
@@ -3404,7 +3426,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 29
           },
           "id": 204,
           "options": {
@@ -3425,7 +3447,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "sum(validator_monitor_prev_epoch_attestations_total)/sum(validator_monitor_validators_total)",
               "interval": "",
               "legendFormat": "attestations_sent",
@@ -3436,7 +3458,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "avg(validator_monitor_prev_epoch_attestation_block_inclusions_total)",
               "hide": false,
               "interval": "",
@@ -3448,7 +3470,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "avg(validator_monitor_prev_epoch_attestation_aggregate_inclusions_total)",
               "hide": false,
               "interval": "",
@@ -3791,7 +3813,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "rate(lodestar_stfn_epoch_transition_seconds_sum[13m])",
               "interval": "",
               "legendFormat": "process block time",
@@ -3887,7 +3909,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "rate(lodestar_stfn_process_block_seconds_sum[6m])",
               "interval": "",
               "legendFormat": "process block time",
@@ -4080,7 +4102,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "12*rate(lodestar_stfn_process_block_seconds_count[6m])",
               "interval": "",
               "legendFormat": "process block time",
@@ -4930,7 +4952,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "delta(lodestar_bls_thread_pool_latency_to_worker_sum[6m])/delta(lodestar_bls_thread_pool_latency_to_worker_count[6m])",
               "interval": "",
               "legendFormat": "to worker",
@@ -4941,7 +4963,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "delta(lodestar_bls_thread_pool_latency_from_worker_sum[6m])/delta(lodestar_bls_thread_pool_latency_from_worker_count[6m])",
               "hide": false,
               "interval": "",
@@ -5323,7 +5345,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "12*rate(lodestar_block_processor_queue_job_time_seconds_count[6m])",
               "instant": false,
               "interval": "",
@@ -6489,7 +6511,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "12*rate(beacon_fork_choice_requests_total[$__rate_interval])",
               "hide": false,
               "interval": "",
@@ -6765,7 +6787,7 @@
           "options": {
             "legend": {
               "calcs": [],
-              "displayMode": "list",
+              "displayMode": "hidden",
               "placement": "bottom"
             },
             "tooltip": {
@@ -6783,7 +6805,7 @@
               "exemplar": false,
               "expr": "beacon_fork_choice_reorg_total",
               "interval": "",
-              "legendFormat": "",
+              "legendFormat": "reorg count",
               "refId": "A"
             }
           ],
@@ -7394,7 +7416,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "delta(lodestar_gossip_block_elappsed_time_till_processed_sum[$__rate_interval])\n/\ndelta(lodestar_gossip_block_elappsed_time_till_processed_count[$__rate_interval])",
               "hide": false,
               "interval": "",
@@ -8211,7 +8233,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "increase(lodestar_peers_requested_total_to_disconnect[$__rate_interval])",
               "hide": false,
               "interval": "",
@@ -8513,7 +8535,7 @@
               "refId": "A"
             }
           ],
-          "title": "Mesh peers",
+          "title": "Mesh peers count",
           "type": "timeseries"
         },
         {
@@ -8596,7 +8618,7 @@
               "refId": "A"
             }
           ],
-          "title": "Topic peers",
+          "title": "Topic peers count",
           "type": "timeseries"
         },
         {
@@ -8832,7 +8854,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "lodestar_gossip_score_avg_min_max_avg",
               "hide": false,
               "interval": "",
@@ -8844,7 +8866,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "lodestar_gossip_score_avg_min_max_min",
               "hide": false,
               "interval": "",
@@ -8852,7 +8874,7 @@
               "refId": "min"
             }
           ],
-          "title": "Topic peers",
+          "title": "Gossip score avg / min / max",
           "type": "timeseries"
         },
         {
@@ -8951,7 +8973,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "lodestar_gossip_topic_peers_by_type_count{type!~\"beacon_attestation\"}",
               "format": "time_series",
               "interval": "",
@@ -12664,7 +12686,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "12 * rate(lodestar_sync_unknown_block_processed_blocks_success_total[6m])",
               "hide": false,
               "interval": "",
@@ -12676,7 +12698,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "12 * rate(lodestar_sync_unknown_block_downloaded_blocks_success_total[6m])",
               "hide": false,
               "interval": "",
@@ -12773,7 +12795,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "lodestar_sync_unknown_block_known_bad_blocks_size",
               "hide": false,
               "interval": "",
@@ -12901,7 +12923,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "12 * rate(lodestar_sync_unknown_block_downloaded_blocks_error_total[6m])",
               "hide": false,
               "interval": "",
@@ -13327,7 +13349,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "exemplar": true,
+              "exemplar": false,
               "expr": "sum(rate(lodestar_precompute_next_epoch_transition_result_total{result=\"error\"}[13m]))\n/\nsum(rate(lodestar_precompute_next_epoch_transition_result_total[13m]))",
               "hide": false,
               "interval": "",

--- a/docker/grafana/provisioning/dashboards/lodestar.json
+++ b/docker/grafana/provisioning/dashboards/lodestar.json
@@ -1,4 +1,59 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": [],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.4.0-beta1"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph (old)",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -21,8 +76,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
-  "iteration": 1639131826407,
+  "id": null,
+  "iteration": 1645857689467,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -211,7 +266,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "multi"
+          "mode": "multi",
+          "sort": "none"
         }
       },
       "pluginVersion": "7.4.5",
@@ -279,7 +335,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "8.4.0-beta1",
       "targets": [
         {
           "expr": "sum(lodestar_peers_by_direction_count)",
@@ -328,7 +384,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "8.4.0-beta1",
       "targets": [
         {
           "expr": "beacon_head_slot",
@@ -376,7 +432,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "8.4.0-beta1",
       "targets": [
         {
           "expr": "beacon_finalized_epoch",
@@ -424,7 +480,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "8.4.0-beta1",
       "targets": [
         {
           "exemplar": false,
@@ -476,7 +532,7 @@
         "text": {},
         "textMode": "value"
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "8.4.0-beta1",
       "targets": [
         {
           "expr": "rate(process_cpu_user_seconds_total[1m])",
@@ -525,7 +581,7 @@
         "text": {},
         "textMode": "value"
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "8.4.0-beta1",
       "targets": [
         {
           "expr": "process_heap_bytes",
@@ -578,10 +634,15 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "8.4.0-beta1",
       "targets": [
         {
-          "expr": "process_start_time_seconds*1000",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "process_start_time_seconds{scrape_location=\"beacon\"}*1000",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -646,7 +707,7 @@
         "text": {},
         "textMode": "value"
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "8.4.0-beta1",
       "targets": [
         {
           "expr": "lodestar_sync_status",
@@ -701,7 +762,7 @@
         "text": {},
         "textMode": "name"
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "8.4.0-beta1",
       "targets": [
         {
           "expr": "lodestar_version",
@@ -750,7 +811,7 @@
         "text": {},
         "textMode": "name"
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "8.4.0-beta1",
       "targets": [
         {
           "expr": "lodestar_version",
@@ -808,7 +869,7 @@
         "text": {},
         "textMode": "name"
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "8.4.0-beta1",
       "targets": [
         {
           "expr": "nodejs_version_info",
@@ -857,7 +918,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "8.4.0-beta1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -972,7 +1033,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "multi"
+          "mode": "multi",
+          "sort": "none"
         }
       },
       "pluginVersion": "7.4.5",
@@ -1065,7 +1127,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -1174,7 +1237,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -1259,7 +1323,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -1288,7 +1353,7 @@
             "content": "",
             "mode": "markdown"
           },
-          "pluginVersion": "8.2.2",
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
               "exemplar": false,
@@ -1373,7 +1438,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18
+            "y": 3
           },
           "id": 14,
           "options": {
@@ -1384,7 +1449,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -1455,7 +1521,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 18
+            "y": 3
           },
           "id": 16,
           "options": {
@@ -1466,7 +1532,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -1482,10 +1549,6 @@
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "datasource",
-            "uid": "-- Mixed --"
-          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1541,7 +1604,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 26
+            "y": 11
           },
           "id": 44,
           "options": {
@@ -1552,7 +1615,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -1560,8 +1624,9 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${DS_PROMETHEUS}"
               },
+              "exemplar": true,
               "expr": "process_heap_bytes",
               "interval": "",
               "legendFormat": "",
@@ -1572,44 +1637,75 @@
           "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "fill": 1,
-          "fillGradient": 2,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 26
+            "y": 11
           },
-          "hiddenSeries": false,
           "id": 58,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
-            "alertThreshold": true
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
           },
-          "percentage": false,
-          "pluginVersion": "8.2.2",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
               "expr": "rate(nodejs_gc_pause_seconds_total[$__rate_interval])",
@@ -1618,35 +1714,8 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "GC pause time rate",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "percentunit",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
           "fieldConfig": {
@@ -1704,7 +1773,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 34
+            "y": 19
           },
           "id": 60,
           "options": {
@@ -1715,7 +1784,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -1786,7 +1856,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 34
+            "y": 19
           },
           "id": 62,
           "options": {
@@ -1797,7 +1867,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -1868,7 +1939,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 27
           },
           "id": 64,
           "options": {
@@ -1879,7 +1950,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -1966,7 +2038,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 27
           },
           "id": 40,
           "options": {
@@ -1977,7 +2049,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -2048,7 +2121,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 35
           },
           "id": 6,
           "options": {
@@ -2059,7 +2132,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -2075,46 +2149,91 @@
           "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "{instance=\"beacon_node:8008\", job=\"Lodestar\"}": "semi-dark-orange"
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "{instance=\"beacon_node:8008\", job=\"Lodestar\"}"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
           },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "fill": 1,
-          "fillGradient": 2,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 50
+            "y": 35
           },
-          "hiddenSeries": false,
           "id": 42,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
-            "alertThreshold": true
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
           },
-          "percentage": false,
-          "pluginVersion": "8.2.2",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
               "expr": "rate(process_cpu_user_seconds_total[$__rate_interval])",
@@ -2123,35 +2242,8 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "CPU usage % (Lodestar only)",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "percentunit",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "percent",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
           "fieldConfig": {
@@ -2207,7 +2299,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 58
+            "y": 43
           },
           "id": 268,
           "options": {
@@ -2217,7 +2309,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
@@ -2231,6 +2324,31 @@
           ],
           "title": "UnhandledPromiseRejection rate",
           "type": "timeseries"
+        },
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 324,
+          "options": {
+            "content": "",
+            "mode": "markdown"
+          },
+          "pluginVersion": "8.4.0-beta1",
+          "targets": [
+            {
+              "exemplar": false,
+              "expr": "rate(lodestar_unhandeled_promise_rejections_total[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "Errors",
+              "refId": "A"
+            }
+          ],
+          "title": "-",
+          "type": "text"
         }
       ],
       "title": "VM Stats",
@@ -2262,7 +2380,8 @@
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
-                  "tooltip": false
+                  "tooltip": false,
+                  "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
@@ -2271,7 +2390,14 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
@@ -2294,27 +2420,33 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 4
           },
           "id": 48,
           "options": {
             "graph": {},
             "legend": {
               "calcs": [],
-              "displayMode": "hidden",
+              "displayMode": "list",
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
               "expr": "avg_over_time(scrape_duration_seconds[$__rate_interval])",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "",
+              "legendFormat": "{{scrape_location}}",
               "refId": "A"
             }
           ],
@@ -2337,7 +2469,8 @@
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
-                  "tooltip": false
+                  "tooltip": false,
+                  "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
@@ -2346,7 +2479,14 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "decimals": 0,
               "mappings": [
@@ -2400,31 +2540,157 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 4
           },
           "id": 50,
           "options": {
             "graph": {},
             "legend": {
               "calcs": [],
-              "displayMode": "hidden",
+              "displayMode": "list",
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
               "expr": "1-up",
               "interval": "",
-              "legendFormat": "",
+              "legendFormat": "{{scrape_location}}",
               "refId": "A"
             }
           ],
-          "title": "Lodestar prom-client is down",
+          "title": "Is down",
           "type": "timeseries"
+        },
+        {
+          "description": "Prometheus scrape duration measures the total HTTP request time from the caller. This internal scrape time is the total time to collect metrics",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 30,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "id": 322,
+          "options": {
+            "graph": {},
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "7.4.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "rate(lodestar_metrics_scrape_seconds_sum[$__rate_interval])/rate(lodestar_metrics_scrape_seconds_count[$__rate_interval])",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{scrape_location}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Lodestar internal scrape duration",
+          "type": "timeseries"
+        },
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "id": 323,
+          "options": {
+            "content": "",
+            "mode": "markdown"
+          },
+          "pluginVersion": "8.4.0-beta1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "rate(lodestar_metrics_scrape_seconds_sum[$__rate_interval])/rate(lodestar_metrics_scrape_seconds_count[$__rate_interval])",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{scrape_location}}",
+              "refId": "A"
+            }
+          ],
+          "title": "-",
+          "type": "text"
         }
       ],
       "title": "Scrape stats",
@@ -2451,7 +2717,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2464,9 +2731,9 @@
           },
           "gridPos": {
             "h": 7,
-            "w": 12,
+            "w": 6,
             "x": 0,
-            "y": 20
+            "y": 5
           },
           "id": 192,
           "options": {
@@ -2482,7 +2749,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.1.5",
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
               "expr": "validator_monitor_validators_total",
@@ -2495,44 +2762,76 @@
           "type": "stat"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
           "gridPos": {
             "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 20
+            "w": 6,
+            "x": 6,
+            "y": 5
           },
-          "hiddenSeries": false,
           "id": 194,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
-            "alertThreshold": true
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
           },
-          "percentage": false,
-          "pluginVersion": "8.1.5",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
               "expr": "validator_monitor_prev_epoch_attestations_total",
@@ -2541,38 +2840,121 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Validators connected",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "title": "Validators connected (to grab indexes)",
+          "type": "timeseries"
         },
         {
-          "description": "Percent of attestations having correct head",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "__systemRef": "hideSeriesFrom",
+                "matcher": {
+                  "id": "byNames",
+                  "options": {
+                    "mode": "exclude",
+                    "names": ["aggregates"],
+                    "prefix": "All except:",
+                    "readOnly": true
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 5
+          },
+          "id": 326,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.4.0-beta1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "avg(\n  delta(validator_monitor_prev_epoch_on_chain_balance_total[$__rate_interval])\n)",
+              "interval": "",
+              "legendFormat": "aggregates",
+              "refId": "A"
+            }
+          ],
+          "title": "balance delta prev epoch",
+          "type": "timeseries"
+        },
+        {
+          "description": "Percent of attestations having correct head.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2611,7 +2993,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2627,7 +3010,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27
+            "y": 12
           },
           "id": 311,
           "options": {
@@ -2637,97 +3020,25 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "avg(validator_monitor_prev_epoch_on_chain_attester_correct_head_total)",
+              "expr": "1-avg(validator_monitor_prev_epoch_on_chain_attester_correct_head_total)",
               "interval": "",
               "legendFormat": "Percent of correct head attestations",
               "refId": "A"
             }
           ],
-          "title": "Correct Head Percentage",
+          "title": "Wrong head ratio",
           "type": "timeseries"
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 27
-          },
-          "hiddenSeries": false,
-          "id": 198,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.1.5",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "avg(validator_monitor_prev_epoch_on_chain_inclusion_distance)",
-              "interval": "",
-              "legendFormat": "{{index}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Avg inclusion distance",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
         },
         {
           "fieldConfig": {
@@ -2742,6 +3053,88 @@
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 198,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.4.0-beta1",
+          "targets": [
+            {
+              "expr": "avg(validator_monitor_prev_epoch_on_chain_inclusion_distance)",
+              "interval": "",
+              "legendFormat": "{{index}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Avg inclusion distance",
+          "type": "timeseries"
+        },
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 17,
+                "gradientMode": "opacity",
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
@@ -2769,7 +3162,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2785,7 +3179,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 20
           },
           "id": 196,
           "options": {
@@ -2796,22 +3190,53 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "sum(delta(validator_monitor_prev_epoch_on_chain_attester_miss_total[$__rate_interval])) / (sum(delta(validator_monitor_prev_epoch_on_chain_attester_hit_total[$__rate_interval])) + sum(delta(validator_monitor_prev_epoch_on_chain_attester_miss_total[$__rate_interval])))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "sum(delta(validator_monitor_prev_epoch_on_chain_attester_miss_total[$__rate_interval]))\n/\n(\n  sum(delta(validator_monitor_prev_epoch_on_chain_attester_hit_total[$__rate_interval]))\n  +\n  sum(delta(validator_monitor_prev_epoch_on_chain_attester_miss_total[$__rate_interval]))\n)",
               "interval": "",
-              "legendFormat": "{{index}}",
+              "legendFormat": "attester",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "sum(delta(validator_monitor_prev_epoch_on_chain_target_attester_miss_total[$__rate_interval]))\n/\n(\n  sum(delta(validator_monitor_prev_epoch_on_chain_target_attester_hit_total[$__rate_interval]))\n  +\n  sum(delta(validator_monitor_prev_epoch_on_chain_target_attester_miss_total[$__rate_interval]))\n)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "target",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "sum(delta(validator_monitor_prev_epoch_on_chain_head_attester_miss_total[$__rate_interval]))\n/\n(\n  sum(delta(validator_monitor_prev_epoch_on_chain_head_attester_hit_total[$__rate_interval]))\n  +\n  sum(delta(validator_monitor_prev_epoch_on_chain_head_attester_miss_total[$__rate_interval]))\n)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "head",
+              "refId": "C"
             }
           ],
-          "title": "prev epoch ATTESTER miss ratio",
+          "title": "prev epoch miss ratio",
           "type": "timeseries"
         },
         {
+          "description": "Min delay from when the validator should send an object and when it was received",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2825,18 +3250,17 @@
                 "fillOpacity": 10,
                 "gradientMode": "none",
                 "hideFrom": {
-                  "graph": false,
                   "legend": false,
                   "tooltip": false,
                   "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
-                "pointSize": 4,
+                "pointSize": 5,
                 "scaleDistribution": {
                   "type": "linear"
                 },
-                "showPoints": "always",
+                "showPoints": "never",
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2851,7 +3275,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2859,7 +3284,7 @@
                   }
                 ]
               },
-              "unit": "percentunit"
+              "unit": "s"
             },
             "overrides": []
           },
@@ -2867,30 +3292,59 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 21
           },
-          "id": 202,
+          "id": 325,
           "options": {
-            "graph": {},
             "legend": {
               "calcs": [],
               "displayMode": "list",
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "multi",
+              "sort": "none"
             }
           },
-          "pluginVersion": "7.4.5",
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
-              "expr": "sum(delta(validator_monitor_prev_epoch_on_chain_target_attester_miss_total[$__rate_interval])) /  (sum(delta(validator_monitor_prev_epoch_on_chain_target_attester_hit_total[$__rate_interval])) + sum(delta(validator_monitor_prev_epoch_on_chain_target_attester_miss_total[$__rate_interval])))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "sum(delta(validator_monitor_prev_epoch_attestations_min_delay_seconds_sum[$__rate_interval]))\n/\nsum(delta(validator_monitor_prev_epoch_attestations_min_delay_seconds_count[$__rate_interval]))",
+              "hide": false,
               "interval": "",
-              "legendFormat": "{{index}}",
-              "refId": "A"
+              "legendFormat": "attestations",
+              "refId": "Attestations"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "sum(delta(validator_monitor_prev_epoch_aggregates_min_delay_seconds_sum[$__rate_interval]))\n/\nsum(delta(validator_monitor_prev_epoch_aggregates_min_delay_seconds_count[$__rate_interval]))",
+              "interval": "",
+              "legendFormat": "aggregates",
+              "refId": "Aggregates"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "sum(delta(validator_monitor_prev_epoch_beacon_blocks_min_delay_seconds_sum[$__rate_interval]))\n/\nsum(delta(validator_monitor_prev_epoch_beacon_blocks_min_delay_seconds_count[$__rate_interval]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "Blocks"
             }
           ],
-          "title": "prev epoch TARGET miss ratio",
+          "title": "Prev epoch min delay",
           "type": "timeseries"
         },
         {
@@ -2904,21 +3358,21 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
+                "fillOpacity": 8,
+                "gradientMode": "opacity",
                 "hideFrom": {
-                  "graph": false,
                   "legend": false,
                   "tooltip": false,
                   "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
-                "pointSize": 4,
+                "pointSize": 5,
                 "scaleDistribution": {
-                  "type": "linear"
+                  "log": 2,
+                  "type": "log"
                 },
-                "showPoints": "always",
+                "showPoints": "never",
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2933,7 +3387,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2941,7 +3396,7 @@
                   }
                 ]
               },
-              "unit": "percentunit"
+              "unit": "short"
             },
             "overrides": []
           },
@@ -2949,77 +3404,132 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 28
           },
-          "id": 200,
+          "id": 204,
           "options": {
-            "graph": {},
             "legend": {
               "calcs": [],
               "displayMode": "list",
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "multi",
+              "sort": "none"
             }
           },
-          "pluginVersion": "7.4.5",
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
-              "expr": "(sum(delta(validator_monitor_prev_epoch_on_chain_head_attester_miss_total[$__rate_interval])) OR vector(0))\n/\n((sum(delta(validator_monitor_prev_epoch_on_chain_head_attester_hit_total[$__rate_interval])) OR vector(0))\n+\n(sum(delta(validator_monitor_prev_epoch_on_chain_head_attester_miss_total[$__rate_interval])) OR vector(0)))",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "sum(validator_monitor_prev_epoch_attestations_total)/sum(validator_monitor_validators_total)",
               "interval": "",
-              "legendFormat": "{{index}}",
+              "legendFormat": "attestations_sent",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "avg(validator_monitor_prev_epoch_attestation_block_inclusions_total)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "block_inclusions",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "avg(validator_monitor_prev_epoch_attestation_aggregate_inclusions_total)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "aggregate_inclusions",
+              "refId": "C"
             }
           ],
-          "title": "prev epoch HEAD miss ratio",
+          "title": "Attestations per epoch per validator",
           "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "fieldConfig": {
             "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
               "unit": "none"
             },
             "overrides": []
           },
-          "fill": 1,
-          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 29
           },
-          "hiddenSeries": false,
           "id": 206,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
-            "alertThreshold": true
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
           },
-          "percentage": false,
-          "pluginVersion": "8.1.5",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
               "expr": "sum(validator_monitor_prev_epoch_aggregates_total)/sum(validator_monitor_validators_total)",
@@ -3028,118 +3538,8 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Aggregates per epoch per validator",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "none",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "fieldConfig": {
-            "defaults": {
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 51
-          },
-          "hiddenSeries": false,
-          "id": 204,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.1.5",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(validator_monitor_prev_epoch_attestations_total)/sum(validator_monitor_validators_total)",
-              "interval": "",
-              "legendFormat": "{{index}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Attestations per epoch per validator",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "title": "Validator monitor",
@@ -3214,7 +3614,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -3288,7 +3689,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -3345,7 +3747,23 @@
               },
               "unit": "percentunit"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "process block time"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 8,
@@ -3362,13 +3780,19 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "rate(lodestar_stfn_epoch_transition_seconds_sum[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "rate(lodestar_stfn_epoch_transition_seconds_sum[13m])",
               "interval": "",
               "legendFormat": "process block time",
               "refId": "A"
@@ -3419,7 +3843,23 @@
               },
               "unit": "percentunit"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "process block time"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 8,
@@ -3436,13 +3876,19 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "rate(lodestar_stfn_process_block_seconds_sum[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "rate(lodestar_stfn_process_block_seconds_sum[6m])",
               "interval": "",
               "legendFormat": "process block time",
               "refId": "A"
@@ -3487,13 +3933,30 @@
                 }
               },
               "mappings": [],
+              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": []
               },
               "unit": "none"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "number of epoch transition"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 8,
@@ -3510,20 +3973,25 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "lodestar_stfn_epoch_transition_seconds_count",
+              "expr": "384 * rate(lodestar_stfn_epoch_transition_seconds_count[13m])",
               "interval": "",
               "legendFormat": "number of epoch transition",
               "refId": "A"
             }
           ],
-          "title": "Epoch transition count",
+          "title": "Epoch transitions / epoch",
           "type": "timeseries"
         },
         {
@@ -3568,7 +4036,23 @@
               },
               "unit": "none"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "process block time"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 8,
@@ -3585,13 +4069,19 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "12*rate(lodestar_stfn_process_block_seconds_count[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "12*rate(lodestar_stfn_process_block_seconds_count[6m])",
               "interval": "",
               "legendFormat": "process block time",
               "refId": "A"
@@ -3626,7 +4116,7 @@
             "content": "Verifies signature sets in a thread pool of workers. Must ensure that signatures are verified fast and efficiently.",
             "mode": "markdown"
           },
-          "pluginVersion": "8.0.6",
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
               "expr": "rate(lodestar_bls_thread_pool_time_seconds_sum[$__rate_interval])",
@@ -3639,51 +4129,77 @@
           "type": "text"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "description": "Utilization rate = total CPU time per worker per second. Graph is stacked. This ratios should be high since BLS verification is the limiting factor in the node's throughput.",
           "fieldConfig": {
             "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
               "unit": "percentunit"
             },
             "overrides": []
           },
-          "fill": 1,
-          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
             "y": 10
           },
-          "hiddenSeries": false,
           "id": 94,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
-            "alertThreshold": true
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
           },
-          "percentage": false,
-          "pluginVersion": "8.0.6",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
               "expr": "rate(lodestar_bls_thread_pool_time_seconds_sum[$__rate_interval])",
@@ -3692,35 +4208,8 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "BLS thread pool - utilization rate",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "percentunit",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
           "description": "Raw throughput of the thread pool. How many individual signature sets are successfully validated per second",
@@ -3763,7 +4252,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3790,7 +4280,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             },
             "tooltipOptions": {
               "mode": "multi"
@@ -3849,7 +4340,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3876,7 +4368,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             },
             "tooltipOptions": {
               "mode": "multi"
@@ -3935,7 +4428,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -3962,7 +4456,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             },
             "tooltipOptions": {
               "mode": "multi"
@@ -4021,7 +4516,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4048,7 +4544,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             },
             "tooltipOptions": {
               "mode": "multi"
@@ -4107,7 +4604,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4134,7 +4632,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             },
             "tooltipOptions": {
               "mode": "multi"
@@ -4153,51 +4652,93 @@
           "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "description": "How many signature set batches fail per second. On failure all signatures in the batch have to be verified twice, so this number should be very low to make the optimization worth it.",
           "fieldConfig": {
             "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
               "unit": "none"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "pool"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
           },
-          "fill": 1,
-          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
             "y": 34
           },
-          "hiddenSeries": false,
           "id": 152,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
-            "alertThreshold": true
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
           },
-          "percentage": false,
-          "pluginVersion": "8.0.6",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
               "expr": "rate(lodestar_bls_thread_pool_batch_retries_total[$__rate_interval])",
@@ -4206,82 +4747,97 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "BLS thread pool - batch retries / sec",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "none",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "description": "How many individual signature sets are invalid vs (valid + invalid). We don't control this number since peers may send us invalid signatures. This number should be very low since we should ban bad peers. If it's too high the batch optimization may not be worth it.",
           "fieldConfig": {
             "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
               "unit": "percentunit"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "pool"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
           },
-          "fill": 1,
-          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
             "y": 34
           },
-          "hiddenSeries": false,
           "id": 153,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
-            "alertThreshold": true
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
           },
-          "percentage": false,
-          "pluginVersion": "8.0.6",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
               "expr": "delta(lodestar_bls_thread_pool_error_jobs_signature_sets_count[$__rate_interval])/(delta(lodestar_bls_thread_pool_success_jobs_signature_sets_count[$__rate_interval])+delta(lodestar_bls_thread_pool_error_jobs_signature_sets_count[$__rate_interval]))",
@@ -4290,35 +4846,8 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "BLS thread pool - sig error rate",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "percentunit",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
           "description": "Async time from sending a message to the worker and the worker receiving it.",
@@ -4344,7 +4873,8 @@
                 "lineWidth": 1,
                 "pointSize": 5,
                 "scaleDistribution": {
-                  "type": "linear"
+                  "log": 2,
+                  "type": "log"
                 },
                 "showPoints": "never",
                 "spanNulls": false,
@@ -4361,7 +4891,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4374,7 +4905,7 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 6,
+            "h": 8,
             "w": 12,
             "x": 0,
             "y": 42
@@ -4384,23 +4915,41 @@
             "graph": {},
             "legend": {
               "calcs": [],
-              "displayMode": "hidden",
+              "displayMode": "list",
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "delta(lodestar_bls_thread_pool_latency_to_worker_sum[$__rate_interval])/delta(lodestar_bls_thread_pool_latency_to_worker_count[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "delta(lodestar_bls_thread_pool_latency_to_worker_sum[6m])/delta(lodestar_bls_thread_pool_latency_to_worker_count[6m])",
               "interval": "",
-              "legendFormat": "pool",
-              "refId": "A"
+              "legendFormat": "to worker",
+              "refId": "to worker"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "delta(lodestar_bls_thread_pool_latency_from_worker_sum[6m])/delta(lodestar_bls_thread_pool_latency_from_worker_count[6m])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "from worker",
+              "refId": "from worker"
             }
           ],
-          "title": "BLS worker pool - to worker latency",
+          "title": "BLS worker pool - to from worker latency",
           "type": "timeseries"
         },
         {
@@ -4444,7 +4993,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4457,7 +5007,7 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 6,
+            "h": 8,
             "w": 12,
             "x": 12,
             "y": 42
@@ -4471,7 +5021,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -4487,87 +5038,29 @@
           "type": "timeseries"
         },
         {
-          "description": "Async time sending a message from a worker to the main thread and it receiving it.",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 23,
-                "gradientMode": "opacity",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
+          "description": "",
           "gridPos": {
-            "h": 6,
+            "h": 7,
             "w": 12,
             "x": 0,
-            "y": 48
+            "y": 50
           },
-          "id": 149,
+          "id": 327,
           "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "hidden",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "multi"
-            }
+            "content": "",
+            "mode": "markdown"
           },
-          "pluginVersion": "7.4.5",
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
-              "expr": "delta(lodestar_bls_thread_pool_latency_from_worker_sum[$__rate_interval])/delta(lodestar_bls_thread_pool_latency_from_worker_count[$__rate_interval])",
+              "expr": "delta(lodestar_bls_thread_pool_sig_sets_started_total[$__rate_interval])/(delta(lodestar_bls_thread_pool_jobs_started_total[$__rate_interval])>0)",
               "interval": "",
               "legendFormat": "pool",
               "refId": "A"
             }
           ],
-          "title": "BLS worker pool - from worker latency",
-          "type": "timeseries"
+          "title": "-",
+          "type": "text"
         },
         {
           "description": "Average signatures per set. This number is decided by the time of object submitted to the pool:\n- Sync blocks: 128\n- Aggregates: 3\n- Attestations: 1",
@@ -4610,7 +5103,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4623,10 +5117,10 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 6,
+            "h": 7,
             "w": 12,
             "x": 12,
-            "y": 48
+            "y": 50
           },
           "id": 98,
           "options": {
@@ -4637,7 +5131,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -4667,56 +5162,76 @@
       "id": 25,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "fieldConfig": {
             "defaults": {
-              "color": {},
-              "custom": {},
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
-                "steps": []
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
               },
               "unit": "percentunit"
             },
             "overrides": []
           },
-          "fill": 1,
-          "fillGradient": 1,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 8
           },
-          "hiddenSeries": false,
           "id": 26,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
-            "alertThreshold": true
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
           },
-          "percentage": false,
-          "pluginVersion": "7.4.5",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
               "expr": "rate(lodestar_block_processor_queue_job_time_seconds_sum[$__rate_interval])",
@@ -4726,35 +5241,8 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Block processor queue - Utilization rate",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "percentunit",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
           "fieldConfig": {
@@ -4772,7 +5260,8 @@
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
-                  "tooltip": false
+                  "tooltip": false,
+                  "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
@@ -4781,14 +5270,22 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": false
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4804,7 +5301,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 22
+            "y": 8
           },
           "id": 81,
           "options": {
@@ -4815,13 +5312,19 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
           "targets": [
             {
-              "expr": "12*rate(lodestar_block_processor_queue_job_time_seconds_count[$__rate_interval])",
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "12*rate(lodestar_block_processor_queue_job_time_seconds_count[6m])",
               "instant": false,
               "interval": "",
               "legendFormat": "block_processor",
@@ -4847,7 +5350,8 @@
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
-                  "tooltip": false
+                  "tooltip": false,
+                  "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 2,
@@ -4856,14 +5360,22 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": false
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4879,7 +5391,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 30
+            "y": 16
           },
           "id": 100,
           "options": {
@@ -4890,7 +5402,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -4922,7 +5435,8 @@
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
-                  "tooltip": false
+                  "tooltip": false,
+                  "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 2,
@@ -4931,14 +5445,22 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": false
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4954,7 +5476,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 30
+            "y": 16
           },
           "id": 126,
           "options": {
@@ -4965,7 +5487,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -4997,7 +5520,8 @@
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
-                  "tooltip": false
+                  "tooltip": false,
+                  "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 2,
@@ -5006,14 +5530,22 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": false
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5029,7 +5561,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 24
           },
           "id": 127,
           "options": {
@@ -5040,7 +5572,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -5072,7 +5605,8 @@
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
-                  "tooltip": false
+                  "tooltip": false,
+                  "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
@@ -5081,14 +5615,22 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5104,7 +5646,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 38
+            "y": 24
           },
           "id": 128,
           "options": {
@@ -5115,7 +5657,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -5161,7 +5704,8 @@
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
-                  "tooltip": false
+                  "tooltip": false,
+                  "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
@@ -5170,14 +5714,22 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": false
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5193,7 +5745,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 9
           },
           "id": 113,
           "options": {
@@ -5204,7 +5756,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -5235,7 +5788,8 @@
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
-                  "tooltip": false
+                  "tooltip": false,
+                  "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
@@ -5244,14 +5798,22 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": false
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5267,7 +5829,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 9
           },
           "id": 114,
           "options": {
@@ -5278,7 +5840,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -5309,7 +5872,8 @@
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
-                  "tooltip": false
+                  "tooltip": false,
+                  "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
@@ -5318,14 +5882,22 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": false
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5341,7 +5913,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 31
+            "y": 17
           },
           "id": 115,
           "options": {
@@ -5352,7 +5924,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -5383,7 +5956,8 @@
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
-                  "tooltip": false
+                  "tooltip": false,
+                  "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
@@ -5392,14 +5966,22 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": false
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5415,7 +5997,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 31
+            "y": 17
           },
           "id": 116,
           "options": {
@@ -5426,7 +6008,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -5457,7 +6040,8 @@
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
-                  "tooltip": false
+                  "tooltip": false,
+                  "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
@@ -5466,14 +6050,22 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5489,7 +6081,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 39
+            "y": 25
           },
           "id": 112,
           "options": {
@@ -5500,7 +6092,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -5531,7 +6124,8 @@
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
-                  "tooltip": false
+                  "tooltip": false,
+                  "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
@@ -5540,14 +6134,22 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5563,7 +6165,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 39
+            "y": 25
           },
           "id": 117,
           "options": {
@@ -5574,7 +6176,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -5615,6 +6218,92 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
+                "fillOpacity": 28,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 130,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            },
+            "tooltipOptions": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": false,
+              "expr": "delta(beacon_fork_choice_find_head_seconds_sum[$__rate_interval])/delta(beacon_fork_choice_find_head_seconds_count[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "find head",
+              "refId": "A"
+            }
+          ],
+          "title": "updateHead() avg time",
+          "type": "timeseries"
+        },
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
                 "hideFrom": {
@@ -5631,33 +6320,54 @@
                 },
                 "showPoints": "auto",
                 "spanNulls": false,
-                "stacking": {},
-                "thresholdsStyle": {}
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
                     "value": 80
                   }
                 ]
-              },
-              "unit": "s"
+              }
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "beacon_fork_choice_errors_total{group=\"beta\", instance=\"contabo-13\", job=\"beacon\", scrape_location=\"beacon\"}"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 0,
-            "y": 24
+            "x": 12,
+            "y": 10
           },
-          "id": 130,
+          "id": 140,
           "options": {
             "legend": {
               "calcs": [],
@@ -5665,7 +6375,98 @@
               "placement": "bottom"
             },
             "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            },
+            "tooltipOptions": {
               "mode": "single"
+            }
+          },
+          "pluginVersion": "8.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": false,
+              "expr": "beacon_fork_choice_errors_total",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "updateHead() errors",
+          "type": "timeseries"
+        },
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 132,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
             },
             "tooltipOptions": {
               "mode": "single"
@@ -5673,14 +6474,30 @@
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "delta(beacon_fork_choice_find_head_seconds_sum[$__rate_interval])/delta(beacon_fork_choice_find_head_seconds_count[$__rate_interval])",
+              "expr": "12*rate(beacon_fork_choice_find_head_seconds_count[$__rate_interval])",
               "interval": "",
-              "legendFormat": "find head",
+              "legendFormat": "updateHead runs (non-cached)",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "12*rate(beacon_fork_choice_requests_total[$__rate_interval])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "updateHead calls",
+              "refId": "B"
             }
           ],
-          "title": "find head avg time (seconds)",
+          "title": "updateHead() calls / slot",
           "type": "timeseries"
         },
         {
@@ -5694,8 +6511,8 @@
                 "axisPlacement": "left",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 24,
-                "gradientMode": "hue",
+                "fillOpacity": 20,
+                "gradientMode": "opacity",
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
@@ -5713,18 +6530,25 @@
                 },
                 "showPoints": "never",
                 "spanNulls": false,
-                "stacking": {},
-                "thresholdsStyle": {}
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
-              }
+              },
+              "unit": "percentunit"
             },
             "overrides": [
               {
@@ -5748,7 +6572,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 24
+            "y": 18
           },
           "id": 138,
           "options": {
@@ -5758,7 +6582,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             },
             "tooltipOptions": {
               "mode": "single"
@@ -5767,23 +6592,31 @@
           "pluginVersion": "8.0.0",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "delta(beacon_fork_choice_changed_head_total[$__rate_interval])",
+              "expr": "rate(beacon_fork_choice_changed_head_total[6m])/rate(beacon_fork_choice_requests_total[6m])",
               "hide": false,
               "interval": "",
               "legendFormat": "Changed Heads",
               "refId": "A"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "delta(beacon_fork_choice_requests_total[$__rate_interval])",
+              "expr": "",
               "hide": false,
               "interval": "",
               "legendFormat": "Total Requests",
               "refId": "B"
             }
           ],
-          "title": "Total findHead Requests vs changed heads",
+          "title": "ratio of updateHead() calls that change head",
           "type": "timeseries"
         },
         {
@@ -5797,8 +6630,8 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
+                "fillOpacity": 22,
+                "gradientMode": "opacity",
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
@@ -5813,172 +6646,21 @@
                 },
                 "showPoints": "auto",
                 "spanNulls": false,
-                "stacking": {},
-                "thresholdsStyle": {}
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 32
-          },
-          "id": 132,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "hidden",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
-          },
-          "targets": [
-            {
-              "exemplar": false,
-              "expr": "12*rate(beacon_fork_choice_find_head_seconds_count[$__rate_interval])",
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "find head / slot",
-          "type": "timeseries"
-        },
-        {
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {},
-                "thresholdsStyle": {}
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 32
-          },
-          "id": 140,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "8.0.0",
-          "targets": [
-            {
-              "exemplar": false,
-              "expr": "beacon_fork_choice_errors_total",
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "Fork Choice Errors",
-          "type": "timeseries"
-        },
-        {
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {},
-                "thresholdsStyle": {}
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -5990,7 +6672,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 40
+            "y": 26
           },
           "id": 146,
           "options": {
@@ -6000,7 +6682,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             },
             "tooltipOptions": {
               "mode": "single"
@@ -6015,7 +6698,7 @@
               "refId": "A"
             }
           ],
-          "title": "find head utilization rate",
+          "title": "updateHead() utilization rate",
           "type": "timeseries"
         },
         {
@@ -6023,15 +6706,45 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "mode": "palette-classic"
               },
-              "custom": {},
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
               "mappings": [],
+              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6044,27 +6757,29 @@
           },
           "gridPos": {
             "h": 8,
-            "w": 3,
+            "w": 12,
             "x": 12,
-            "y": 40
+            "y": 26
           },
           "id": 144,
           "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": ["lastNotNull"],
-              "fields": "",
-              "values": false
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
             },
-            "text": {},
-            "textMode": "auto"
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
           },
-          "pluginVersion": "7.4.5",
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
               "expr": "beacon_fork_choice_reorg_total",
               "interval": "",
@@ -6073,7 +6788,7 @@
             }
           ],
           "title": "Reorgs",
-          "type": "stat"
+          "type": "timeseries"
         }
       ],
       "title": "Fork-Choice Stats",
@@ -6106,7 +6821,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 26
+            "y": 11
           },
           "hiddenSeries": false,
           "id": 77,
@@ -6126,7 +6841,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.2.2",
+          "pluginVersion": "8.4.0-beta1",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -6189,7 +6904,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 26
+            "y": 11
           },
           "hiddenSeries": false,
           "id": 80,
@@ -6209,7 +6924,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.2.2",
+          "pluginVersion": "8.4.0-beta1",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -6272,7 +6987,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 34
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 79,
@@ -6292,7 +7007,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.2.2",
+          "pluginVersion": "8.4.0-beta1",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -6365,14 +7080,22 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": false
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6388,7 +7111,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 34
+            "y": 19
           },
           "id": 78,
           "options": {
@@ -6399,7 +7122,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -6431,7 +7155,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 27
           },
           "hiddenSeries": false,
           "id": 82,
@@ -6451,7 +7175,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.2.2",
+          "pluginVersion": "8.4.0-beta1",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -6515,7 +7239,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 27
           },
           "hiddenSeries": false,
           "id": 88,
@@ -6535,7 +7259,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.2.2",
+          "pluginVersion": "8.4.0-beta1",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -6580,6 +7304,194 @@
           "yaxis": {
             "align": false
           }
+        },
+        {
+          "description": "Time elappsed between block slot time and the time block received via gossip",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "log": 2,
+                  "type": "log"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 35
+          },
+          "id": 244,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": false,
+              "expr": "delta(lodestar_gossip_block_elappsed_time_till_received_sum[$__rate_interval])\n/\ndelta(lodestar_gossip_block_elappsed_time_till_received_count[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "till received",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "delta(lodestar_gossip_block_elappsed_time_till_processed_sum[$__rate_interval])\n/\ndelta(lodestar_gossip_block_elappsed_time_till_processed_count[$__rate_interval])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "till processed",
+              "refId": "B"
+            }
+          ],
+          "title": "Gossip Block Received Delay",
+          "type": "timeseries"
+        },
+        {
+          "description": "Time elappsed between block slot time and the time block received via gossip",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "log": 2,
+                  "type": "log"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 35
+          },
+          "id": 333,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": false,
+              "expr": "(\n  delta(lodestar_gossip_block_elappsed_time_till_processed_sum[$__rate_interval])\n  -\n  delta(lodestar_gossip_block_elappsed_time_till_received_sum[$__rate_interval])\n)\n/\ndelta(lodestar_gossip_block_elappsed_time_till_received_count[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "processed minus received",
+              "refId": "A"
+            }
+          ],
+          "title": "Gossip Block process time",
+          "type": "timeseries"
         }
       ],
       "title": "Gossip validation queues",
@@ -6602,12 +7514,6 @@
           "dashes": false,
           "fieldConfig": {
             "defaults": {
-              "color": {},
-              "custom": {},
-              "thresholds": {
-                "mode": "absolute",
-                "steps": []
-              },
               "unit": "s"
             },
             "overrides": []
@@ -6618,7 +7524,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 84,
@@ -6638,7 +7544,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.5",
+          "pluginVersion": "8.4.0-beta1",
           "pointradius": 0.5,
           "points": true,
           "renderer": "flot",
@@ -6690,19 +7596,13 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 1,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 50
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 87,
@@ -6722,7 +7622,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.5",
+          "pluginVersion": "8.4.0-beta1",
           "pointradius": 0.5,
           "points": true,
           "renderer": "flot",
@@ -6823,7 +7723,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6839,7 +7740,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 13
           },
           "id": 30,
           "options": {
@@ -6850,7 +7751,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -6907,7 +7809,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6939,7 +7842,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 13
           },
           "id": 34,
           "options": {
@@ -6950,7 +7853,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -7011,7 +7915,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -7027,7 +7932,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 36
+            "y": 21
           },
           "id": 32,
           "options": {
@@ -7038,7 +7943,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -7095,7 +8001,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -7127,7 +8034,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 36
+            "y": 21
           },
           "id": 36,
           "options": {
@@ -7138,7 +8045,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -7156,174 +8064,6 @@
           "type": "timeseries"
         },
         {
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 20,
-                "gradientMode": "opacity",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 12,
-            "x": 0,
-            "y": 44
-          },
-          "id": 37,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "hidden",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "multi"
-            }
-          },
-          "pluginVersion": "7.4.5",
-          "targets": [
-            {
-              "expr": "lodestar_peers_total_unique_connected",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 3,
-              "legendFormat": "peers",
-              "refId": "A"
-            }
-          ],
-          "title": "Total unique peers connected to",
-          "type": "timeseries"
-        },
-        {
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 20,
-                "gradientMode": "opacity",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 12,
-            "x": 12,
-            "y": 44
-          },
-          "id": 38,
-          "options": {
-            "graph": {},
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "multi"
-            }
-          },
-          "pluginVersion": "7.4.5",
-          "targets": [
-            {
-              "expr": "lodestar_peer_connected_total - lodestar_peer_disconnected_total - lodestar_peers_by_direction_count",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 3,
-              "legendFormat": "{{direction}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Peer connect events offset (must be 0-1)",
-          "type": "timeseries"
-        },
-        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
@@ -7340,179 +8080,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 50
-          },
-          "hiddenSeries": false,
-          "id": 294,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.2.2",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": false,
-              "expr": "increase(lodestar_peers_requested_total_to_connect[$__rate_interval])",
-              "interval": "",
-              "legendFormat": "ENR count",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Requested peers to connect",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:430",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:431",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 50
-          },
-          "hiddenSeries": false,
-          "id": 295,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.2.2",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": false,
-              "expr": "increase(lodestar_peers_requested_total_to_disconnect[$__rate_interval])",
-              "interval": "",
-              "legendFormat": "ENR count",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Requested peers to disconnect",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:430",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:431",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 57
+            "y": 29
           },
           "hiddenSeries": false,
           "id": 296,
@@ -7532,7 +8100,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.2.2",
+          "pluginVersion": "8.4.0-beta1",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -7598,7 +8166,109 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 57
+            "y": 29
+          },
+          "hiddenSeries": false,
+          "id": 294,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.4.0-beta1",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": false,
+              "expr": "increase(lodestar_peers_requested_total_to_connect[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "to connect",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "increase(lodestar_peers_requested_total_to_disconnect[$__rate_interval])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "to disconnect",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Requested peers to connect and disconnect",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:430",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:431",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 36
           },
           "hiddenSeries": false,
           "id": 297,
@@ -7618,7 +8288,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.2.2",
+          "pluginVersion": "8.4.0-beta1",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -7666,6 +8336,92 @@
           "yaxis": {
             "align": false
           }
+        },
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 36
+          },
+          "id": 38,
+          "options": {
+            "graph": {},
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "7.4.5",
+          "targets": [
+            {
+              "expr": "lodestar_peer_connected_total - lodestar_peer_disconnected_total - lodestar_peers_by_direction_count",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 3,
+              "legendFormat": "{{direction}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Peer connect events offset (must be 0-1)",
+          "type": "timeseries"
         }
       ],
       "title": "Peer stats",
@@ -7685,15 +8441,43 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
-              "min": 0.01,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "semi-dark-green"
+                    "color": "semi-dark-green",
+                    "value": null
                   }
                 ]
               }
@@ -7701,26 +8485,27 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 7,
+            "h": 8,
             "w": 12,
             "x": 0,
-            "y": 29
+            "y": 14
           },
-          "id": 68,
+          "id": 328,
           "options": {
-            "displayMode": "lcd",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": ["last"],
-              "fields": "",
-              "values": false
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
             },
-            "showUnfilled": true,
-            "text": {}
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
           },
           "pluginVersion": "8.2.2",
           "targets": [
             {
+              "exemplar": false,
               "expr": "lodestar_gossip_mesh_peers_by_type_count{type!~\"beacon_attestation\"}",
               "format": "time_series",
               "interval": "",
@@ -7728,8 +8513,8 @@
               "refId": "A"
             }
           ],
-          "title": "Mesh Peers per Topic",
-          "type": "bargauge"
+          "title": "Mesh peers",
+          "type": "timeseries"
         },
         {
           "fieldConfig": {
@@ -7770,7 +8555,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "semi-dark-green"
+                    "color": "semi-dark-green",
+                    "value": null
                   }
                 ]
               }
@@ -7778,10 +8564,10 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 7,
+            "h": 8,
             "w": 12,
             "x": 12,
-            "y": 29
+            "y": 14
           },
           "id": 298,
           "options": {
@@ -7791,13 +8577,325 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
+              "expr": "lodestar_gossip_topic_peers_by_type_count{type!~\"beacon_attestation\"}",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "{{type}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Topic peers",
+          "type": "timeseries"
+        },
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "semi-dark-green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 22
+          },
+          "id": 330,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": false,
+              "expr": "lodestar_gossip_peer_score_by_threshold_count",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "{{threshold}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Peer count per gossip score threshold",
+          "type": "timeseries"
+        },
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "semi-dark-green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "max"
+                },
+                "properties": [
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "avg"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 12
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "avg"
+                },
+                "properties": [
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "min"
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 12
+                  },
+                  {
+                    "id": "custom.gradientMode",
+                    "value": "opacity"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "super-light-green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "min"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 22
+          },
+          "id": 331,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": false,
+              "expr": "lodestar_gossip_score_avg_min_max_max",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "max",
+              "refId": "max"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "lodestar_gossip_score_avg_min_max_avg",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "avg",
+              "refId": "avg"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "lodestar_gossip_score_avg_min_max_min",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "min",
+              "refId": "min"
+            }
+          ],
+          "title": "Topic peers",
+          "type": "timeseries"
+        },
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0.01,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "semi-dark-green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 31
+          },
+          "id": 68,
+          "options": {
+            "displayMode": "lcd",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": ["last"],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "8.4.0-beta1",
+          "targets": [
+            {
               "expr": "lodestar_gossip_mesh_peers_by_type_count{type!~\"beacon_attestation\"}",
               "format": "time_series",
               "interval": "",
@@ -7805,8 +8903,64 @@
               "refId": "A"
             }
           ],
-          "title": "Mesh Peers per Topic",
-          "type": "timeseries"
+          "title": "Mesh peers",
+          "type": "bargauge"
+        },
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0.01,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "semi-dark-green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 31
+          },
+          "id": 329,
+          "options": {
+            "displayMode": "lcd",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": ["last"],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "8.4.0-beta1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "lodestar_gossip_topic_peers_by_type_count{type!~\"beacon_attestation\"}",
+              "format": "time_series",
+              "interval": "",
+              "legendFormat": "{{type}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Topic peers",
+          "type": "bargauge"
         },
         {
           "fieldConfig": {
@@ -7821,7 +8975,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "semi-dark-green"
+                    "color": "semi-dark-green",
+                    "value": null
                   }
                 ]
               }
@@ -7846,7 +9001,7 @@
             "showUnfilled": true,
             "text": {}
           },
-          "pluginVersion": "8.2.2",
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
               "exemplar": false,
@@ -7872,7 +9027,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "semi-dark-green"
+                    "color": "semi-dark-green",
+                    "value": null
                   }
                 ]
               }
@@ -7897,7 +9053,7 @@
             "showUnfilled": true,
             "text": {}
           },
-          "pluginVersion": "8.2.2",
+          "pluginVersion": "8.4.0-beta1",
           "targets": [
             {
               "exemplar": false,
@@ -7949,7 +9105,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "semi-dark-green"
+                    "color": "semi-dark-green",
+                    "value": null
                   }
                 ]
               }
@@ -7970,7 +9127,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
@@ -8025,7 +9183,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "semi-dark-green"
+                    "color": "semi-dark-green",
+                    "value": null
                   }
                 ]
               }
@@ -8046,7 +9205,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
@@ -8116,7 +9276,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -8132,7 +9293,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 30
+            "y": 15
           },
           "id": 286,
           "options": {
@@ -8142,7 +9303,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
@@ -8180,7 +9342,8 @@
                 "lineWidth": 1,
                 "pointSize": 5,
                 "scaleDistribution": {
-                  "type": "linear"
+                  "log": 2,
+                  "type": "log"
                 },
                 "showPoints": "never",
                 "spanNulls": true,
@@ -8198,7 +9361,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -8245,7 +9409,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 30
+            "y": 15
           },
           "id": 287,
           "options": {
@@ -8255,7 +9419,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
@@ -8311,7 +9476,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -8327,7 +9493,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 23
           },
           "id": 302,
           "options": {
@@ -8337,7 +9503,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
@@ -8393,7 +9560,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -8409,7 +9577,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 38
+            "y": 23
           },
           "id": 303,
           "options": {
@@ -8419,7 +9587,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
@@ -8475,7 +9644,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -8491,7 +9661,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 29
           },
           "id": 291,
           "options": {
@@ -8501,7 +9671,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
@@ -8557,7 +9728,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -8573,7 +9745,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 44
+            "y": 29
           },
           "id": 289,
           "options": {
@@ -8583,7 +9755,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
@@ -8639,7 +9812,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -8678,7 +9852,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 35
           },
           "id": 293,
           "options": {
@@ -8688,7 +9862,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
@@ -8744,7 +9919,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -8760,7 +9936,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 50
+            "y": 35
           },
           "id": 292,
           "options": {
@@ -8770,7 +9946,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
@@ -8826,7 +10003,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -8842,7 +10020,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 56
+            "y": 41
           },
           "id": 240,
           "options": {
@@ -8852,7 +10030,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
@@ -8907,7 +10086,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -8923,7 +10103,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 56
+            "y": 41
           },
           "id": 242,
           "options": {
@@ -8933,7 +10113,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
@@ -8988,7 +10169,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9004,7 +10186,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 64
+            "y": 49
           },
           "id": 238,
           "options": {
@@ -9014,7 +10196,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
@@ -9069,7 +10252,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9085,7 +10269,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 64
+            "y": 49
           },
           "id": 236,
           "options": {
@@ -9095,7 +10279,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
@@ -9150,7 +10335,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9166,7 +10352,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 72
+            "y": 57
           },
           "id": 288,
           "options": {
@@ -9176,7 +10362,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
@@ -9232,7 +10419,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9248,7 +10436,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 72
+            "y": 57
           },
           "id": 290,
           "options": {
@@ -9258,7 +10446,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "8.2.2",
@@ -9304,7 +10493,8 @@
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
-                  "tooltip": false
+                  "tooltip": false,
+                  "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
@@ -9314,14 +10504,22 @@
                   "type": "log"
                 },
                 "showPoints": "never",
-                "spanNulls": true
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9337,7 +10535,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 30
+            "y": 16
           },
           "id": 160,
           "options": {
@@ -9348,7 +10546,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -9379,7 +10578,8 @@
                 "hideFrom": {
                   "graph": false,
                   "legend": false,
-                  "tooltip": false
+                  "tooltip": false,
+                  "viz": false
                 },
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
@@ -9389,14 +10589,22 @@
                   "type": "log"
                 },
                 "showPoints": "never",
-                "spanNulls": true
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9412,7 +10620,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 30
+            "y": 16
           },
           "id": 162,
           "options": {
@@ -9423,7 +10631,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.4.5",
@@ -9491,7 +10700,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9552,7 +10762,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16
+            "y": 17
           },
           "id": 168,
           "options": {
@@ -9562,7 +10772,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
@@ -9624,7 +10835,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9640,17 +10852,18 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16
+            "y": 17
           },
           "id": 170,
           "options": {
             "legend": {
               "calcs": [],
-              "displayMode": "list",
+              "displayMode": "hidden",
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
@@ -9719,88 +10932,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 1
-          },
-          "id": 182,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single"
-            }
-          },
-          "targets": [
-            {
-              "exemplar": false,
-              "expr": "delta(beacon_reqresp_incoming_requests_error_total[$__rate_interval])/(delta(beacon_reqresp_incoming_requests_total[$__rate_interval])>0)",
-              "interval": "",
-              "legendFormat": "{{method}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Incoming requests error rate",
-          "type": "timeseries"
-        },
-        {
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "graph": false,
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9814,8 +10947,8 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 12,
-            "y": 1
+            "x": 0,
+            "y": 18
           },
           "id": 180,
           "options": {
@@ -9825,7 +10958,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
@@ -9880,7 +11014,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9895,8 +11030,8 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 0,
-            "y": 9
+            "x": 12,
+            "y": 18
           },
           "id": 176,
           "options": {
@@ -9906,7 +11041,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
@@ -9961,7 +11097,91 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 182,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": false,
+              "expr": "delta(beacon_reqresp_incoming_requests_error_total[$__rate_interval])/(delta(beacon_reqresp_incoming_requests_total[$__rate_interval])>0)",
+              "interval": "",
+              "legendFormat": "{{method}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Incoming requests error rate",
+          "type": "timeseries"
+        },
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9977,7 +11197,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 9
+            "y": 26
           },
           "id": 178,
           "options": {
@@ -9987,7 +11207,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
@@ -10042,14 +11263,16 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
                     "value": 80
                   }
                 ]
-              }
+              },
+              "unit": "percentunit"
             },
             "overrides": []
           },
@@ -10057,7 +11280,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 34
           },
           "id": 184,
           "options": {
@@ -10067,7 +11290,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
@@ -10087,14 +11311,14 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 34
           },
           "id": 186,
           "options": {
             "content": "",
             "mode": "markdown"
           },
-          "pluginVersion": "8.0.6",
+          "pluginVersion": "8.4.0-beta1",
           "title": "-",
           "type": "text"
         }
@@ -10151,7 +11375,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -10166,7 +11391,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 34
+            "y": 19
           },
           "id": 216,
           "options": {
@@ -10176,7 +11401,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
@@ -10238,7 +11464,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -10253,7 +11480,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 34
+            "y": 19
           },
           "id": 217,
           "options": {
@@ -10263,7 +11490,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
@@ -10325,7 +11553,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -10340,7 +11569,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 27
           },
           "id": 219,
           "options": {
@@ -10350,7 +11579,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
@@ -10404,7 +11634,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -10419,7 +11650,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 27
           },
           "id": 220,
           "options": {
@@ -10429,7 +11660,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
@@ -10491,7 +11723,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -10504,9 +11737,9 @@
           },
           "gridPos": {
             "h": 8,
-            "w": 24,
+            "w": 12,
             "x": 0,
-            "y": 50
+            "y": 35
           },
           "id": 222,
           "options": {
@@ -10516,27 +11749,110 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "rate(lodestar_state_cache_adds_total{}[$__rate_interval])",
+              "expr": "12 * rate(lodestar_state_cache_adds_total{}[6m])",
               "interval": "",
               "legendFormat": "state cache",
               "refId": "A"
+            }
+          ],
+          "title": "stateCache add() calls / slot",
+          "type": "timeseries"
+        },
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
             },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 35
+          },
+          "id": 332,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "rate(lodestar_cp_state_cache_adds_total{}[$__rate_interval])",
+              "expr": "32 * 12 * rate(lodestar_cp_state_cache_adds_total{}[6m])",
               "hide": false,
               "interval": "",
               "legendFormat": "checkpointState cache",
               "refId": "B"
             }
           ],
-          "title": "cached state add(s)",
+          "title": "checkpointStateCache add() calls / epoch",
           "type": "timeseries"
         }
       ],
@@ -10593,7 +11909,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -10608,7 +11925,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 20
           },
           "id": 273,
           "options": {
@@ -10618,13 +11935,18 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "sum by (entrypoint)(12*rate(lodestar_regen_fn_call_total[$__rate_interval]))",
+              "expr": "sum by (entrypoint) (\n  12 * rate(lodestar_regen_fn_call_total[$__rate_interval])\n)",
               "interval": "",
               "legendFormat": "{{entrypoint}}",
               "refId": "A"
@@ -10672,7 +11994,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -10687,7 +12010,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 20
           },
           "id": 275,
           "options": {
@@ -10697,13 +12020,18 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "sum by (caller)(12*rate(lodestar_regen_fn_call_total[$__rate_interval]))",
+              "expr": "sum by (caller)(\n  12 * rate(lodestar_regen_fn_call_total[$__rate_interval])\n)",
               "interval": "",
               "legendFormat": "{{caller}}",
               "refId": "A"
@@ -10751,7 +12079,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -10767,7 +12096,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 28
           },
           "id": 277,
           "options": {
@@ -10777,13 +12106,18 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "sum by (entrypoint)(delta(lodestar_regen_fn_call_duration_sum[$__rate_interval]))/sum by (entrypoint)(delta(lodestar_regen_fn_call_duration_count[$__rate_interval]))",
+              "expr": "sum by (entrypoint) (\n  delta(lodestar_regen_fn_call_duration_sum[$__rate_interval])\n)\n/\nsum by (entrypoint) (\n  delta(lodestar_regen_fn_call_duration_count[$__rate_interval])\n)",
               "interval": "",
               "legendFormat": "{{entrypoint}}",
               "refId": "A"
@@ -10831,7 +12165,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -10847,7 +12182,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 28
           },
           "id": 279,
           "options": {
@@ -10857,13 +12192,18 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "sum by (caller)(delta(lodestar_regen_fn_call_duration_sum[$__rate_interval]))/sum by (caller)(delta(lodestar_regen_fn_call_duration_count[$__rate_interval]))",
+              "expr": "sum by (caller) (\n  delta(lodestar_regen_fn_call_duration_sum[$__rate_interval])\n)\n/\nsum by (caller) (\n  delta(lodestar_regen_fn_call_duration_count[$__rate_interval])\n)",
               "interval": "",
               "legendFormat": "{{caller}}",
               "refId": "A"
@@ -10913,7 +12253,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -10929,7 +12270,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 36
           },
           "id": 281,
           "options": {
@@ -10939,13 +12280,18 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "sum by (entrypoint) (delta(lodestar_regen_fn_queued_total[$__rate_interval]))/sum by (entrypoint)(delta(lodestar_regen_fn_call_total[$__rate_interval]))",
+              "expr": "sum by (entrypoint) (\n  delta(lodestar_regen_fn_queued_total[$__rate_interval])\n)\n/\nsum by (entrypoint) (\n  delta(lodestar_regen_fn_call_total[$__rate_interval])\n)",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -10995,7 +12341,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -11011,7 +12358,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 36
           },
           "id": 282,
           "options": {
@@ -11021,13 +12368,18 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "sum by (caller) (delta(lodestar_regen_fn_queued_total[$__rate_interval]))/sum by (caller)(delta(lodestar_regen_fn_call_total[$__rate_interval]))",
+              "expr": "sum by (caller) (\n  delta(lodestar_regen_fn_queued_total[$__rate_interval])\n)\n/\nsum by (caller) (\n  delta(lodestar_regen_fn_call_total[$__rate_interval])\n)",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -11077,7 +12429,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -11093,7 +12446,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 59
+            "y": 44
           },
           "id": 284,
           "options": {
@@ -11103,13 +12456,18 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "sum by (entrypoint)(rate(lodestar_regen_fn_errors_total[$__rate_interval]))/sum by (entrypoint)(rate(lodestar_regen_fn_call_duration_count[$__rate_interval]))",
+              "expr": "sum by (entrypoint) (\n  rate(lodestar_regen_fn_errors_total[$__rate_interval])\n)\n/\nsum by (entrypoint) (\n  rate(lodestar_regen_fn_call_duration_count[$__rate_interval])\n)",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -11159,7 +12517,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -11175,7 +12534,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 59
+            "y": 44
           },
           "id": 285,
           "options": {
@@ -11185,13 +12544,18 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "sum by (caller)(rate(lodestar_regen_fn_errors_total[$__rate_interval]))/sum by (caller)(rate(lodestar_regen_fn_call_duration_count[$__rate_interval]))",
+              "expr": "sum by (caller) (\n  rate(lodestar_regen_fn_errors_total[$__rate_interval])\n)\n/\nsum by (caller) (\n  rate(lodestar_regen_fn_call_duration_count[$__rate_interval])\n)",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -11211,182 +12575,6 @@
         "w": 24,
         "x": 0,
         "y": 35
-      },
-      "id": 246,
-      "panels": [
-        {
-          "description": "Time elappsed between block slot time and the time block received via gossip",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 21
-          },
-          "id": 244,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single"
-            }
-          },
-          "targets": [
-            {
-              "exemplar": false,
-              "expr": "delta(lodestar_gossip_block_elappsed_time_till_received_sum[$__rate_interval])/delta(lodestar_gossip_block_elappsed_time_till_received_count[$__rate_interval])",
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "Gossip Block Received Delay",
-          "type": "timeseries"
-        },
-        {
-          "description": "Time elappsed between block slot time and the time block processed",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 21
-          },
-          "id": 248,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single"
-            }
-          },
-          "targets": [
-            {
-              "exemplar": false,
-              "expr": "delta(lodestar_gossip_block_elappsed_time_till_processed_sum[$__rate_interval])/delta(lodestar_gossip_block_elappsed_time_till_processed_count[$__rate_interval])",
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "Gossip Block Processed Delay",
-          "type": "timeseries"
-        }
-      ],
-      "title": "Gossip Block",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 36
       },
       "id": 252,
       "panels": [
@@ -11429,7 +12617,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -11444,7 +12633,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 69
+            "y": 21
           },
           "id": 250,
           "options": {
@@ -11454,19 +12643,48 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "lodestar_sync_unknown_block_requests_total",
+              "expr": "12 * rate(lodestar_sync_unknown_block_requests_total[6m])",
               "interval": "",
-              "legendFormat": "",
+              "legendFormat": "requests",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "12 * rate(lodestar_sync_unknown_block_processed_blocks_success_total[6m])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "processed",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "12 * rate(lodestar_sync_unknown_block_downloaded_blocks_success_total[6m])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "downloaded",
+              "refId": "C"
             }
           ],
-          "title": "Total Requests",
+          "title": "Actions / slot",
           "type": "timeseries"
         },
         {
@@ -11508,7 +12726,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -11523,108 +12742,46 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 69
+            "y": 21
           },
           "id": 254,
           "options": {
             "legend": {
               "calcs": [],
-              "displayMode": "list",
+              "displayMode": "hidden",
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
               "expr": "lodestar_sync_unknown_block_pending_blocks_size",
               "interval": "",
-              "legendFormat": "",
+              "legendFormat": "pending blocks",
               "refId": "A"
-            }
-          ],
-          "title": "Pending Blocks",
-          "type": "timeseries"
-        },
-        {
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
             },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 77
-          },
-          "id": 256,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single"
-            }
-          },
-          "targets": [
             {
-              "exemplar": false,
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
               "expr": "lodestar_sync_unknown_block_known_bad_blocks_size",
+              "hide": false,
               "interval": "",
-              "legendFormat": "",
-              "refId": "A"
+              "legendFormat": "known bad blocks",
+              "refId": "B"
             }
           ],
-          "title": "Bad Blocks",
+          "title": "Blocks cache size",
           "type": "timeseries"
         },
         {
@@ -11666,7 +12823,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -11675,92 +12833,44 @@
                 ]
               }
             },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 77
-          },
-          "id": 258,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single"
-            }
-          },
-          "targets": [
-            {
-              "exemplar": false,
-              "expr": "lodestar_sync_unknown_block_processed_blocks_success_total",
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "Processed Blocks",
-          "type": "timeseries"
-        },
-        {
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "process errors"
                 },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
+                "properties": [
                   {
-                    "color": "green"
-                  },
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "download errors"
+                },
+                "properties": [
                   {
-                    "color": "red",
-                    "value": 80
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
                   }
                 ]
               }
-            },
-            "overrides": []
+            ]
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 85
+            "y": 29
           },
           "id": 260,
           "options": {
@@ -11770,19 +12880,36 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "lodestar_sync_unknown_block_processed_blocks_error_total",
+              "expr": "12 * rate(lodestar_sync_unknown_block_processed_blocks_error_total[6m])",
               "interval": "",
-              "legendFormat": "",
+              "legendFormat": "process errors",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "12 * rate(lodestar_sync_unknown_block_downloaded_blocks_error_total[6m])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "download errors",
+              "refId": "B"
             }
           ],
-          "title": "Processed Errors",
+          "title": "Errors / slot",
           "type": "timeseries"
         },
         {
@@ -11824,7 +12951,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -11839,187 +12967,34 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 85
-          },
-          "id": 262,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single"
-            }
-          },
-          "targets": [
-            {
-              "exemplar": false,
-              "expr": "lodestar_sync_unknown_block_downloaded_blocks_success_total",
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "Download Success",
-          "type": "timeseries"
-        },
-        {
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 93
-          },
-          "id": 264,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single"
-            }
-          },
-          "targets": [
-            {
-              "exemplar": false,
-              "expr": "lodestar_sync_unknown_block_downloaded_blocks_error_total",
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "title": "Download Errors",
-          "type": "timeseries"
-        },
-        {
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 93
+            "y": 29
           },
           "id": 266,
           "options": {
             "legend": {
               "calcs": [],
-              "displayMode": "list",
+              "displayMode": "hidden",
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "lodestar_sync_unknown_block_removed_blocks_total",
+              "expr": "12 * rate(lodestar_sync_unknown_block_removed_blocks_total[6m])",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
             }
           ],
-          "title": "Removed Bad Blocks",
+          "title": "Removed bad blocks / slot",
           "type": "timeseries"
         }
       ],
@@ -12032,7 +13007,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 36
       },
       "id": 309,
       "panels": [
@@ -12075,7 +13050,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -12121,7 +13097,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 22
           },
           "id": 305,
           "options": {
@@ -12131,13 +13107,18 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "rate(lodestar_precompute_next_epoch_transition_result_total[$__rate_interval])",
+              "expr": "32*12 * rate(lodestar_precompute_next_epoch_transition_result_total[13m])",
               "interval": "",
               "legendFormat": "{{result}}",
               "refId": "A"
@@ -12186,7 +13167,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -12217,7 +13199,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 38
+            "y": 22
           },
           "id": 307,
           "options": {
@@ -12227,20 +13209,29 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "multi"
+              "mode": "multi",
+              "sort": "none"
             }
           },
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "rate(lodestar_precompute_next_epoch_transition_hits_total[$__rate_interval])",
+              "expr": "rate(lodestar_precompute_next_epoch_transition_hits_total[6m])",
               "interval": "",
               "legendFormat": "Cache Hit Count",
               "refId": "A"
             },
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
-              "expr": "rate(lodestar_precompute_next_epoch_transition_waste_total[$__rate_interval])",
+              "expr": "rate(lodestar_precompute_next_epoch_transition_waste_total[6m])",
               "hide": false,
               "interval": "",
               "legendFormat": "Waste Count",
@@ -12249,6 +13240,188 @@
           ],
           "title": "Hit vs Waste",
           "type": "timeseries"
+        },
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 30
+          },
+          "id": 335,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": false,
+              "expr": "sum(rate(lodestar_precompute_next_epoch_transition_result_total{result=\"skip\"}[13m]))\n/\nsum(rate(lodestar_precompute_next_epoch_transition_result_total[13m]))",
+              "interval": "",
+              "legendFormat": "skip rate",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": true,
+              "expr": "sum(rate(lodestar_precompute_next_epoch_transition_result_total{result=\"error\"}[13m]))\n/\nsum(rate(lodestar_precompute_next_epoch_transition_result_total[13m]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "error rate",
+              "refId": "B"
+            }
+          ],
+          "title": "Skip rate + error rate",
+          "type": "timeseries"
+        },
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 30
+          },
+          "id": 334,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": false,
+              "expr": "32*12 * sum(rate(lodestar_precompute_next_epoch_transition_result_total[13m]))",
+              "interval": "",
+              "legendFormat": "{{result}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Runs / epoch",
+          "type": "timeseries"
         }
       ],
       "title": "Precompute Epoch Transition",
@@ -12256,17 +13429,15 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 37
       },
       "id": 313,
       "panels": [
         {
-          "datasource": null,
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -12349,7 +13520,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 39
+            "y": 23
           },
           "id": 315,
           "options": {
@@ -12359,7 +13530,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
@@ -12375,7 +13547,6 @@
           "type": "timeseries"
         },
         {
-          "datasource": null,
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -12446,7 +13617,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 39
+            "y": 23
           },
           "id": 317,
           "options": {
@@ -12456,7 +13627,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
@@ -12480,7 +13652,6 @@
           "type": "timeseries"
         },
         {
-          "datasource": null,
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -12537,7 +13708,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 47
+            "y": 31
           },
           "id": 319,
           "options": {
@@ -12547,7 +13718,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
@@ -12563,7 +13735,6 @@
           "type": "timeseries"
         },
         {
-          "datasource": null,
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -12618,7 +13789,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 47
+            "y": 31
           },
           "id": 321,
           "options": {
@@ -12628,7 +13799,8 @@
               "placement": "bottom"
             },
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "targets": [
@@ -12649,7 +13821,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 33,
+  "schemaVersion": 35,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -12657,12 +13829,12 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
+          "uid": "prometheus_local"
         },
         "filters": [
           {
             "condition": "",
-            "key": "job",
+            "key": "instance",
             "operator": "=",
             "value": "contabo-1"
           }
@@ -12675,7 +13847,7 @@
     ]
   },
   "time": {
-    "from": "now-12h",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {


### PR DESCRIPTION
**Motivation**

Add missing charts and improve existing charts for better clarify. See https://github.com/ChainSafe/lodestar/issues/3778

**Description**

Summary of changes

### Scrape stats

Added internal scrape time chart

![Screenshot from 2022-02-26 14-56-58](https://user-images.githubusercontent.com/35266934/155838058-98bbda52-49ce-412e-9f92-9cfc9b35f65d.png)

### Validator monitor

- Add balance delta chart
- Inverse correct head ratio to match miss ratio chart below
- Add delay time chart
- Add attestation seen ratios to track progress

![Screenshot from 2022-02-26 14-58-41](https://user-images.githubusercontent.com/35266934/155838074-f9f9e7cb-da3f-4649-92a2-6e5ee2d792ac.png)
![Screenshot from 2022-02-26 14-58-56](https://user-images.githubusercontent.com/35266934/155838095-4a53c260-1321-417c-861a-bfba1b050852.png)

### Fork-choice

Re-order

![Screenshot from 2022-02-26 14-59-55](https://user-images.githubusercontent.com/35266934/155838132-9e2e856a-f11f-4c62-8ba3-d2222690e822.png)

### Gossip stats

- Move block delay charts into gossip row
- Add gossip score charts
- Add gossip per count time series charts, both mesh and topic

![Screenshot from 2022-02-26 15-00-21](https://user-images.githubusercontent.com/35266934/155838152-78403f56-b1e6-471a-8c73-fbe8fa782aec.png)

![Screenshot from 2022-02-26 15-01-42](https://user-images.githubusercontent.com/35266934/155838171-811626fb-3f16-4642-b6ba-7a7f4ac2caa5.png)

### Unknown block sync

- Merge charts and re-order

![Screenshot from 2022-02-26 15-02-22](https://user-images.githubusercontent.com/35266934/155838201-c93b0c95-5543-4737-8800-963d8c28bf28.png)

### Precompute epoch transition

- Merge charts and re-order

![Screenshot from 2022-02-26 15-02-38](https://user-images.githubusercontent.com/35266934/155838269-e520148a-2993-4b73-9a50-4a840ce252c5.png)












Closes https://github.com/ChainSafe/lodestar/issues/3778