### PR TITLE
JobItemQueue: only run job on push if there're free slots

### DIFF
--- a/packages/lodestar/src/util/queue/itemQueue.ts
+++ b/packages/lodestar/src/util/queue/itemQueue.ts
@@ -56,7 +56,9 @@ export class JobItemQueue<Args extends any[], R> {
 
     return new Promise<R>((resolve, reject) => {
       this.jobs.push({args, resolve, reject, addedTimeMs: Date.now()});
-      setTimeout(this.runJob, 0);
+      if (this.runningJobs < this.opts.maxConcurrency) {
+        setTimeout(this.runJob, 0);
+      }
     });
   }
 


### PR DESCRIPTION
**Motivation**

If there are `maxConcurrency` running jobs and we push more jobs to the queue, we don't have to trigger `runJob` on push. Jobs will be triggered to run from the current running jobs.

**Description**

```ts
if (this.runningJobs < this.opts.maxConcurrency) {
        setTimeout(this.runJob, 0);
      }
```
