### PR TITLE
Process recent attestations in head sync

### DIFF
--- a/packages/lodestar/src/sync/range/chain.ts
+++ b/packages/lodestar/src/sync/range/chain.ts
@@ -35,7 +35,7 @@ export type SyncChainFns = {
    * Must return if ALL blocks are processed successfully
    * If SOME blocks are processed must throw BlockProcessorError()
    */
-  processChainSegment: (blocks: allForks.SignedBeaconBlock[]) => Promise<void>;
+  processChainSegment: (blocks: allForks.SignedBeaconBlock[], syncType: RangeSyncType) => Promise<void>;
   /** Must download blocks, and validate their range */
   downloadBeaconBlocksByRange: (
     peer: PeerId,
@@ -414,7 +414,7 @@ export class SyncChain {
     const blocks = batch.startProcessing();
 
     // wrapError ensures to never call both batch success() and batch error()
-    const res = await wrapError(this.processChainSegment(blocks));
+    const res = await wrapError(this.processChainSegment(blocks, this.syncType));
 
     if (!res.err) {
       batch.processingSuccess();

--- a/packages/lodestar/src/sync/range/range.ts
+++ b/packages/lodestar/src/sync/range/range.ts
@@ -183,11 +183,13 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
   }
 
   /** Convenience method for `SyncChain` */
-  private processChainSegment: SyncChainFns["processChainSegment"] = async (blocks) => {
+  private processChainSegment: SyncChainFns["processChainSegment"] = async (blocks, syncType) => {
     // Not trusted, verify signatures
     const flags: PartiallyVerifiedBlockFlags = {
+      // Only skip importing attestations for finalized sync. For head sync attestation are valuable.
+      // Importing attestations also triggers a head update, see https://github.com/ChainSafe/lodestar/issues/3804
       // TODO: Review if this is okay, can we prevent some attacks by importing attestations?
-      skipImportingAttestations: true,
+      skipImportingAttestations: syncType === RangeSyncType.Finalized,
       // Ignores ALREADY_KNOWN or GENESIS_BLOCK errors, and continues with the next block in chain segment
       ignoreIfKnown: true,
       // Ignore WOULD_REVERT_FINALIZED_SLOT error, continue with the next block in chain segment


### PR DESCRIPTION
**Motivation**

When completing a sync the blocks within the current and past epoch contain attestations that are useful to the fork-choice. We should process those.

Part of https://github.com/ChainSafe/lodestar/issues/3804

**Description**

- Process recent attestations in head sync, only if block and attestation are within range