### PR TITLE
Don't track unstable LinkedList benchmark

### DIFF
--- a/packages/lodestar/test/perf/util/array.test.ts
+++ b/packages/lodestar/test/perf/util/array.test.ts
@@ -1,4 +1,4 @@
-import {itBench} from "@dapplion/benchmark";
+import {itBench, setBenchOpts} from "@dapplion/benchmark";
 import {LinkedList} from "../../../src/util/array";
 
 /**
@@ -8,6 +8,8 @@ import {LinkedList} from "../../../src/util/array";
  *               push then pop - LinkedList is >10x faster than regular array
  */
 describe("LinkedList vs Regular Array", () => {
+  setBenchOpts({noThreshold: true});
+
   const arrayLengths = [16_000, 24_000];
 
   for (const length of arrayLengths) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2363,7 +2363,7 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/jwt-simple@^0.5.33":
+"@types/jwt-simple@0.5.33":
   version "0.5.33"
   resolved "https://registry.yarnpkg.com/@types/jwt-simple/-/jwt-simple-0.5.33.tgz#fb839cabe81437954f7d0cd01760ad8096ec526e"
   integrity sha1-+4Ocq+gUN5VPfQzQF2CtgJbsUm4=


### PR DESCRIPTION
**Motivation**

We got the results of the data-structure performance, which is already implemented. Disable since it's failing CI builds

**Description**

Don't track unstable LinkedList benchmark