### PR TITLE
Reject yarn lock changes from external contributors

### DIFF
--- a/.github/workflows/scripts/reject_yarn_lock_changes.sh
+++ b/.github/workflows/scripts/reject_yarn_lock_changes.sh
@@ -1,0 +1,19 @@
+# yarn.lock can be easily modified to plant a backdoor. A regular yarn.lock diff is never audited.
+# Article below details the risks and ease of implementation.
+# See https://dev.to/kozlovzxc/injecting-backdoors-to-npm-packages-a0k
+#
+# This script will exit 1 if yarn.lock was modified.
+# A Github action should only run this script for non-high trust contributors.
+# TODO: Mechanism to allow changes once the yarn.lock changes have been audited by the team
+
+
+# From https://stackoverflow.com/questions/10641361/get-all-files-that-have-been-modified-in-git-branch
+MERGE_BASE=$(git merge-base $GITHUB_REF master)
+CHANGED_FILES=$(git diff --name-only $GITHUB_REF $MERGE_BASE)
+
+
+if [[ $CHANGED_FILES == *"yarn.lock"* ]]; then
+  AUTHOR_EMAIL=$(git show -s --format='%ae' $GITHUB_REF)
+  echo "yarn.lock modified by external contributor $AUTHOR_EMAIL"
+  exit 1
+fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,16 @@ jobs:
           path: packages/validator/spec-tests
           key: spec-test-data-${{ hashFiles('packages/validator/test/spec/params.ts') }}
 
+      # Misc sanity checks
       - name: Lint Grafana Dashboard
         run: yarn validate-gdash
       - name: Test root binary exists
         run: ./lodestar --version
+      - name: Reject yarn.lock changes
+        run: .github/workflows/scripts/reject_yarn_lock_changes.sh
+        # Run only on forks
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+
       - name: Check Types
         run: yarn run check-types
       - name: README check


### PR DESCRIPTION
**Motivation**

yarn.lock can be easily modified to plant a backdoor. A regular yarn.lock diff is never audited. Article below details the risks and ease of implementation. See https://dev.to/kozlovzxc/injecting-backdoors-to-npm-packages-a0k


**Description**

This script will exit 1 if yarn.lock was modified. A Github action should only run this script for non-high trust contributors.

TODO: Mechanism to allow changes once the yarn.lock changes have been audited by the team