### PR TITLE
Revert "Call deliverMessage before gossip queue (#3812)"

### DIFF
--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -230,11 +230,6 @@ export class Eth2Gossipsub extends Gossipsub {
    */
   async validate(message: InMessage): Promise<void> {
     try {
-      // Resolve IWANT promise before sending message to the queue. Attestations and aggregates can remain in the
-      // validation queue for > 1 min. Metrics show that peers are severly penalized with P7 due to broken promises,
-      // which they fullfil but _publish() is not called in time.
-      await this.gossipTracer.deliverMessage(message);
-
       // messages must have a single topicID
       const topicStr = Array.isArray(message.topicIDs) ? message.topicIDs[0] : undefined;
 


### PR DESCRIPTION
This reverts commit 4b62955343be8d77d327703488041a3527fdd39c.

**Motivation**

PR https://github.com/ChainSafe/lodestar/pull/3812 introduces an idea to improve gossip scores by reducing the P7 penality overloaded nodes apply to all peers.

This behavior was not properly tested in networks for a while and was merged prematurely. Our nightly deployment showed that indeed P7 penalties were no longer applied and gossip scores improved greatly. However the validator performance of the validators was extremely worse. Better scores correlated with worse validator performance

![Screenshot from 2022-03-01 12-25-42](https://user-images.githubusercontent.com/35266934/156161985-af25aa86-69e8-48a1-9f47-cf862ad515fd.png)

Metrics show that after merging #3812 at 22:00 in the chart, inclusion in aggregates and blocks drops a lot. Also, we receive way less gossip messages with less throughput that usual without dropping any objects.

![Screenshot from 2022-03-01 08-22-31](https://user-images.githubusercontent.com/35266934/156162136-e2ab8cf4-2a57-45e6-8c87-409fffdf7bb7.png)

![Screenshot from 2022-03-01 08-23-15](https://user-images.githubusercontent.com/35266934/156162288-e45f26ef-4cb5-40af-9cfd-7fcd9154405c.png)

Reverting while we investigate more

**Description**

Revert "Call deliverMessage before gossip queue (#3812)"