### PR TITLE
Make PeerId ephemeral by default

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -9,7 +9,7 @@ import {ACTIVE_PRESET, PresetName} from "@chainsafe/lodestar-params";
 import {IGlobalArgs} from "../../options";
 import {parseEnrArgs} from "../../options/enrOptions";
 import {initBLS, onGracefulShutdown, getCliLogger} from "../../util";
-import {FileENR, overwriteEnrWithCliArgs, readPeerId} from "../../config";
+import {FileENR, overwriteEnrWithCliArgs} from "../../config";
 import {initializeOptionsAndConfig, persistOptionsAndConfig} from "../init/handler";
 import {IBeaconArgs} from "./options";
 import {getBeaconPaths} from "./paths";
@@ -23,7 +23,7 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
   await initBLS();
 
   const {beaconNodeOptions, config} = await initializeOptionsAndConfig(args);
-  await persistOptionsAndConfig(args);
+  const {peerId} = await persistOptionsAndConfig(args);
 
   const version = getVersion();
   const gitData = getVersionGitData();
@@ -37,7 +37,6 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
   beaconNodeOptions.set({api: {version: version}});
 
   // ENR setup
-  const peerId = await readPeerId(beaconPaths.peerIdFile);
   const enr = FileENR.initFromFile(beaconPaths.enrFile, peerId);
   const enrArgs = parseEnrArgs(args);
   overwriteEnrWithCliArgs(enr, enrArgs, beaconNodeOptions.getWithDefaults());

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -17,6 +17,7 @@ interface IBeaconExtraArgs {
   discoveryPort?: number;
   forceGenesis?: boolean;
   genesisStateFile?: string;
+  peerIdPersist?: boolean;
 }
 
 export const beaconExtraOptions: ICliCommandOptions<IBeaconExtraArgs> = {
@@ -41,6 +42,11 @@ export const beaconExtraOptions: ICliCommandOptions<IBeaconExtraArgs> = {
   genesisStateFile: {
     description: "Path or URL to download a genesis state file in ssz-encoded format",
     type: "string",
+  },
+
+  peerIdPersist: {
+    description: "Persist PeerID across sessions. If not set the node will create a new PeerID on each run",
+    type: "boolean",
   },
 };
 

--- a/packages/cli/src/cmds/init/handler.ts
+++ b/packages/cli/src/cmds/init/handler.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import PeerId from "peer-id";
 import {BeaconNodeOptions, getBeaconConfigFromArgs, initPeerId, initEnr, readPeerId, readEnr} from "../../config";
 import {IGlobalArgs, parseBeaconNodeArgs} from "../../options";
 import {mkdir} from "../../util";
@@ -63,7 +64,7 @@ export async function initializeOptionsAndConfig(args: IBeaconArgs & IGlobalArgs
 /**
  * Write options and configs to disk
  */
-export async function persistOptionsAndConfig(args: IBeaconArgs & IGlobalArgs): Promise<void> {
+export async function persistOptionsAndConfig(args: IBeaconArgs & IGlobalArgs): Promise<{peerId: PeerId}> {
   const beaconPaths = getBeaconPaths(args);
 
   // initialize directories
@@ -71,8 +72,8 @@ export async function persistOptionsAndConfig(args: IBeaconArgs & IGlobalArgs): 
   mkdir(beaconPaths.beaconDir);
   mkdir(beaconPaths.dbDir);
 
-  // Initialize peerId if does not exist
-  if (!fs.existsSync(beaconPaths.peerIdFile)) {
+  // Initialize peerId if does not exist OR if persist is not set
+  if (!fs.existsSync(beaconPaths.peerIdFile) || !args.peerIdPersist) {
     await initPeerId(beaconPaths.peerIdFile);
   }
 
@@ -89,4 +90,6 @@ export async function persistOptionsAndConfig(args: IBeaconArgs & IGlobalArgs): 
       initEnr(beaconPaths.enrFile, peerId);
     }
   }
+
+  return {peerId};
 }


### PR DESCRIPTION
**Motivation**

We suspect our node tends to get down-scored by peers. While issues like https://github.com/ChainSafe/lodestar/issues/3811 are being worked on, it's an okay strategy to clear the PeerId on each process session. AFAIK Nimbus also does this for privacy reasons.

**Description**

- Make PeerId ephemeral by default.

- Add flag `--peerIdPersist` to re-use an existing PeerId in disk