### PR TITLE
Revert "Apply peer action when there are gossip validation errors (#3781)"

### DIFF
--- a/packages/lodestar/src/chain/errors/gossipValidation.ts
+++ b/packages/lodestar/src/chain/errors/gossipValidation.ts
@@ -1,5 +1,4 @@
 import {LodestarError} from "@chainsafe/lodestar-utils";
-import {PeerAction} from "../../network";
 
 export enum GossipAction {
   IGNORE = "IGNORE",
@@ -7,14 +6,10 @@ export enum GossipAction {
 }
 
 export class GossipActionError<T extends {code: string}> extends LodestarError<T> {
-  /** The action at gossipsub side */
   action: GossipAction;
-  /** The action at node side */
-  lodestarAction: PeerAction | null;
 
-  constructor(action: GossipAction, lodestarAction: PeerAction | null, type: T) {
+  constructor(action: GossipAction, type: T) {
     super(type);
     this.action = action;
-    this.lodestarAction = lodestarAction;
   }
 }

--- a/packages/lodestar/src/chain/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/aggregateAndProof.ts
@@ -12,7 +12,6 @@ import {getSelectionProofSignatureSet, getAggregateAndProofSignatureSet} from ".
 import {AttestationError, AttestationErrorCode, GossipAction} from "../errors";
 import {getCommitteeIndices, verifyHeadBlockAndTargetRoot, verifyPropagationSlotRange} from "./attestation";
 import {RegenCaller} from "../regen";
-import {PeerAction} from "../../network/peers";
 
 export async function validateGossipAggregateAndProof(
   chain: IBeaconChain,
@@ -35,9 +34,7 @@ export async function validateGossipAggregateAndProof(
 
   // [REJECT] The attestation's epoch matches its target -- i.e. attestation.data.target.epoch == compute_epoch_at_slot(attestation.data.slot)
   if (targetEpoch !== attEpoch) {
-    throw new AttestationError(GossipAction.REJECT, PeerAction.LowToleranceError, {
-      code: AttestationErrorCode.BAD_TARGET_EPOCH,
-    });
+    throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.BAD_TARGET_EPOCH});
   }
 
   // [IGNORE] aggregate.data.slot is within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
@@ -49,7 +46,7 @@ export async function validateGossipAggregateAndProof(
   // index aggregate_and_proof.aggregator_index for the epoch aggregate.data.target.epoch.
   const aggregatorIndex = aggregateAndProof.aggregatorIndex;
   if (chain.seenAggregators.isKnown(targetEpoch, aggregatorIndex)) {
-    throw new AttestationError(GossipAction.IGNORE, null, {
+    throw new AttestationError(GossipAction.IGNORE, {
       code: AttestationErrorCode.AGGREGATOR_ALREADY_KNOWN,
       targetEpoch,
       aggregatorIndex,
@@ -67,7 +64,7 @@ export async function validateGossipAggregateAndProof(
   const attHeadState = await chain.regen
     .getState(attHeadBlock.stateRoot, RegenCaller.validateGossipAggregateAndProof)
     .catch((e: Error) => {
-      throw new AttestationError(GossipAction.REJECT, null, {
+      throw new AttestationError(GossipAction.REJECT, {
         code: AttestationErrorCode.MISSING_ATTESTATION_HEAD_STATE,
         error: e as Error,
       });
@@ -86,25 +83,19 @@ export async function validateGossipAggregateAndProof(
   // len(get_attesting_indices(state, aggregate.data, aggregate.aggregation_bits)) >= 1.
   if (attestingIndices.length < 1) {
     // missing attestation participants
-    throw new AttestationError(GossipAction.REJECT, PeerAction.LowToleranceError, {
-      code: AttestationErrorCode.EMPTY_AGGREGATION_BITFIELD,
-    });
+    throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.EMPTY_AGGREGATION_BITFIELD});
   }
 
   // [REJECT] aggregate_and_proof.selection_proof selects the validator as an aggregator for the slot
   // -- i.e. is_aggregator(state, aggregate.data.slot, aggregate.data.index, aggregate_and_proof.selection_proof) returns True.
   if (!isAggregatorFromCommitteeLength(committeeIndices.length, aggregateAndProof.selectionProof)) {
-    throw new AttestationError(GossipAction.REJECT, PeerAction.LowToleranceError, {
-      code: AttestationErrorCode.INVALID_AGGREGATOR,
-    });
+    throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.INVALID_AGGREGATOR});
   }
 
   // [REJECT] The aggregator's validator index is within the committee
   // -- i.e. aggregate_and_proof.aggregator_index in get_beacon_committee(state, aggregate.data.slot, aggregate.data.index).
   if (!committeeIndices.includes(aggregateAndProof.aggregatorIndex)) {
-    throw new AttestationError(GossipAction.REJECT, PeerAction.LowToleranceError, {
-      code: AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE,
-    });
+    throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE});
   }
 
   // [REJECT] The aggregate_and_proof.selection_proof is a valid signature of the aggregate.data.slot
@@ -118,16 +109,14 @@ export async function validateGossipAggregateAndProof(
     allForks.getIndexedAttestationSignatureSet(attHeadState, indexedAttestation),
   ];
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {
-    throw new AttestationError(GossipAction.REJECT, PeerAction.LowToleranceError, {
-      code: AttestationErrorCode.INVALID_SIGNATURE,
-    });
+    throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.INVALID_SIGNATURE});
   }
 
   // It's important to double check that the attestation still hasn't been observed, since
   // there can be a race-condition if we receive two attestations at the same time and
   // process them in different threads.
   if (chain.seenAggregators.isKnown(targetEpoch, aggregatorIndex)) {
-    throw new AttestationError(GossipAction.IGNORE, null, {
+    throw new AttestationError(GossipAction.IGNORE, {
       code: AttestationErrorCode.AGGREGATOR_ALREADY_KNOWN,
       targetEpoch,
       aggregatorIndex,

--- a/packages/lodestar/src/chain/validation/attesterSlashing.ts
+++ b/packages/lodestar/src/chain/validation/attesterSlashing.ts
@@ -1,6 +1,5 @@
 import {phase0, allForks, getAttesterSlashableIndices} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconChain} from "..";
-import {PeerAction} from "../../network/peers";
 import {AttesterSlashingError, AttesterSlashingErrorCode, GossipAction} from "../errors";
 
 export async function validateGossipAttesterSlashing(
@@ -13,7 +12,7 @@ export async function validateGossipAttesterSlashing(
   // ), verify if any(attester_slashed_indices.difference(prior_seen_attester_slashed_indices))).
   const intersectingIndices = getAttesterSlashableIndices(attesterSlashing);
   if (chain.opPool.hasSeenAttesterSlashing(intersectingIndices)) {
-    throw new AttesterSlashingError(GossipAction.IGNORE, null, {
+    throw new AttesterSlashingError(GossipAction.IGNORE, {
       code: AttesterSlashingErrorCode.ALREADY_EXISTS,
     });
   }
@@ -25,7 +24,7 @@ export async function validateGossipAttesterSlashing(
     // verifySignature = false, verified in batch below
     allForks.assertValidAttesterSlashing(state, attesterSlashing, false);
   } catch (e) {
-    throw new AttesterSlashingError(GossipAction.REJECT, PeerAction.HighToleranceError, {
+    throw new AttesterSlashingError(GossipAction.REJECT, {
       code: AttesterSlashingErrorCode.INVALID,
       error: e as Error,
     });
@@ -33,7 +32,7 @@ export async function validateGossipAttesterSlashing(
 
   const signatureSets = allForks.getAttesterSlashingSignatureSets(state, attesterSlashing);
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {
-    throw new AttesterSlashingError(GossipAction.REJECT, PeerAction.HighToleranceError, {
+    throw new AttesterSlashingError(GossipAction.REJECT, {
       code: AttesterSlashingErrorCode.INVALID,
       error: Error("Invalid signature"),
     });

--- a/packages/lodestar/src/chain/validation/proposerSlashing.ts
+++ b/packages/lodestar/src/chain/validation/proposerSlashing.ts
@@ -1,6 +1,5 @@
 import {phase0, allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconChain} from "..";
-import {PeerAction} from "../../network/peers";
 import {ProposerSlashingError, ProposerSlashingErrorCode, GossipAction} from "../errors";
 
 export async function validateGossipProposerSlashing(
@@ -10,7 +9,7 @@ export async function validateGossipProposerSlashing(
   // [IGNORE] The proposer slashing is the first valid proposer slashing received for the proposer with index
   // proposer_slashing.signed_header_1.message.proposer_index.
   if (chain.opPool.hasSeenProposerSlashing(proposerSlashing.signedHeader1.message.proposerIndex)) {
-    throw new ProposerSlashingError(GossipAction.IGNORE, null, {
+    throw new ProposerSlashingError(GossipAction.IGNORE, {
       code: ProposerSlashingErrorCode.ALREADY_EXISTS,
     });
   }
@@ -22,7 +21,7 @@ export async function validateGossipProposerSlashing(
     // verifySignature = false, verified in batch below
     allForks.assertValidProposerSlashing(state, proposerSlashing, false);
   } catch (e) {
-    throw new ProposerSlashingError(GossipAction.REJECT, PeerAction.HighToleranceError, {
+    throw new ProposerSlashingError(GossipAction.REJECT, {
       code: ProposerSlashingErrorCode.INVALID,
       error: e as Error,
     });
@@ -30,7 +29,7 @@ export async function validateGossipProposerSlashing(
 
   const signatureSets = allForks.getProposerSlashingSignatureSets(state, proposerSlashing);
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {
-    throw new ProposerSlashingError(GossipAction.REJECT, PeerAction.HighToleranceError, {
+    throw new ProposerSlashingError(GossipAction.REJECT, {
       code: ProposerSlashingErrorCode.INVALID,
       error: Error("Invalid signature"),
     });

--- a/packages/lodestar/src/chain/validation/syncCommitteeContributionAndProof.ts
+++ b/packages/lodestar/src/chain/validation/syncCommitteeContributionAndProof.ts
@@ -9,7 +9,6 @@ import {
   getSyncCommitteeContributionSignatureSet,
   getContributionPubkeys,
 } from "./signatureSets";
-import {PeerAction} from "../../network/peers";
 
 /**
  * Spec v1.1.0-beta.2
@@ -39,7 +38,7 @@ export async function validateSyncCommitteeGossipContributionAndProof(
   // [IGNORE] The sync committee contribution is the first valid contribution received for the aggregator with index
   // contribution_and_proof.aggregator_index for the slot contribution.slot and subcommittee index contribution.subcommittee_index.
   if (chain.seenContributionAndProof.isKnown(slot, subcommitteeIndex, aggregatorIndex)) {
-    throw new SyncCommitteeError(GossipAction.IGNORE, null, {
+    throw new SyncCommitteeError(GossipAction.IGNORE, {
       code: SyncCommitteeErrorCode.SYNC_COMMITTEE_ALREADY_KNOWN,
     });
   }
@@ -47,7 +46,7 @@ export async function validateSyncCommitteeGossipContributionAndProof(
   // [REJECT] The contribution has participants -- that is, any(contribution.aggregation_bits)
   const pubkeys = getContributionPubkeys(headState as CachedBeaconStateAltair, contribution);
   if (!pubkeys.length) {
-    throw new SyncCommitteeError(GossipAction.REJECT, PeerAction.LowToleranceError, {
+    throw new SyncCommitteeError(GossipAction.REJECT, {
       code: SyncCommitteeErrorCode.NO_PARTICIPANT,
     });
   }
@@ -55,7 +54,7 @@ export async function validateSyncCommitteeGossipContributionAndProof(
   // [REJECT] contribution_and_proof.selection_proof selects the validator as an aggregator for the slot --
   // i.e. is_sync_committee_aggregator(contribution_and_proof.selection_proof) returns True.
   if (!isSyncCommitteeAggregator(contributionAndProof.selectionProof)) {
-    throw new SyncCommitteeError(GossipAction.REJECT, PeerAction.LowToleranceError, {
+    throw new SyncCommitteeError(GossipAction.REJECT, {
       code: SyncCommitteeErrorCode.INVALID_AGGREGATOR,
       aggregatorIndex: contributionAndProof.aggregatorIndex,
     });
@@ -79,7 +78,7 @@ export async function validateSyncCommitteeGossipContributionAndProof(
   ];
 
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {
-    throw new SyncCommitteeError(GossipAction.REJECT, PeerAction.LowToleranceError, {
+    throw new SyncCommitteeError(GossipAction.REJECT, {
       code: SyncCommitteeErrorCode.INVALID_SIGNATURE,
     });
   }

--- a/packages/lodestar/src/chain/validation/voluntaryExit.ts
+++ b/packages/lodestar/src/chain/validation/voluntaryExit.ts
@@ -1,6 +1,5 @@
 import {phase0, allForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconChain} from "..";
-import {PeerAction} from "../../network";
 import {VoluntaryExitError, VoluntaryExitErrorCode, GossipAction} from "../errors";
 
 export async function validateGossipVoluntaryExit(
@@ -10,7 +9,7 @@ export async function validateGossipVoluntaryExit(
   // [IGNORE] The voluntary exit is the first valid voluntary exit received for the validator with index
   // signed_voluntary_exit.message.validator_index.
   if (chain.opPool.hasSeenVoluntaryExit(voluntaryExit.message.validatorIndex)) {
-    throw new VoluntaryExitError(GossipAction.IGNORE, null, {
+    throw new VoluntaryExitError(GossipAction.IGNORE, {
       code: VoluntaryExitErrorCode.ALREADY_EXISTS,
     });
   }
@@ -26,17 +25,15 @@ export async function validateGossipVoluntaryExit(
 
   // [REJECT] All of the conditions within process_voluntary_exit pass validation.
   // verifySignature = false, verified in batch below
-  // These errors occur due to a fault in the beacon chain. It is not necessarily
-  // the fault on the peer.
   if (!allForks.isValidVoluntaryExit(state, voluntaryExit, false)) {
-    throw new VoluntaryExitError(GossipAction.REJECT, PeerAction.HighToleranceError, {
+    throw new VoluntaryExitError(GossipAction.REJECT, {
       code: VoluntaryExitErrorCode.INVALID,
     });
   }
 
   const signatureSet = allForks.getVoluntaryExitSignatureSet(state, voluntaryExit);
   if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true}))) {
-    throw new VoluntaryExitError(GossipAction.REJECT, PeerAction.HighToleranceError, {
+    throw new VoluntaryExitError(GossipAction.REJECT, {
       code: VoluntaryExitErrorCode.INVALID_SIGNATURE,
     });
   }

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -42,13 +42,11 @@ import {
   GOSSIP_D_LOW,
 } from "./scoringParameters";
 import {Eth2Context} from "../../chain";
-import {IPeerRpcScoreStore} from "../peers";
 import {computeAllPeersScoreWeights} from "./scoreMetrics";
 
 export interface IGossipsubModules {
   config: IBeaconConfig;
   libp2p: Libp2p;
-  peerRpcScores: IPeerRpcScoreStore;
   logger: ILogger;
   metrics: IMetrics | null;
   signal: AbortSignal;
@@ -105,7 +103,6 @@ export class Eth2Gossipsub extends Gossipsub {
     const {validatorFnsByType, jobQueues} = createValidatorFnsByType(gossipHandlers, {
       config,
       logger,
-      peerRpcScores: modules.peerRpcScores,
       uncompressCache: this.uncompressCache,
       metrics,
       signal,

--- a/packages/lodestar/src/network/gossip/validation/index.ts
+++ b/packages/lodestar/src/network/gossip/validation/index.ts
@@ -18,13 +18,10 @@ import {decodeMessageData, UncompressCache} from "../encoding";
 import {createValidationQueues} from "./queue";
 import {DEFAULT_ENCODING} from "../constants";
 import {getGossipAcceptMetadataByType, GetGossipAcceptMetadataFn} from "./onAccept";
-import {IPeerRpcScoreStore, PeerAction} from "../../peers/score";
-import PeerId from "peer-id";
 
 type ValidatorFnModules = {
   config: IChainForkConfig;
   logger: ILogger;
-  peerRpcScores: IPeerRpcScoreStore;
   metrics: IMetrics | null;
   uncompressCache: UncompressCache;
 };
@@ -81,14 +78,13 @@ function getGossipValidatorFn<K extends GossipType>(
   return async function gossipValidatorFn(topic, gossipMsg, seenTimestampSec) {
     // Define in scope above try {} to be used in catch {} if object was parsed
     let gossipObject;
-    const {data, receivedFrom} = gossipMsg;
     try {
       const encoding = topic.encoding ?? DEFAULT_ENCODING;
 
       // Deserialize object from bytes ONLY after being picked up from the validation queue
       try {
         const sszType = getGossipSSZType(topic);
-        const messageData = decodeMessageData(encoding, data, uncompressCache);
+        const messageData = decodeMessageData(encoding, gossipMsg.data, uncompressCache);
         gossipObject =
           // TODO: Review if it's really necessary to deserialize this as TreeBacked
           topic.type === GossipType.beacon_block || topic.type === GossipType.beacon_aggregate_and_proof
@@ -96,10 +92,10 @@ function getGossipValidatorFn<K extends GossipType>(
             : sszType.deserialize(messageData);
       } catch (e) {
         // TODO: Log the error or do something better with it
-        throw new GossipActionError(GossipAction.REJECT, PeerAction.LowToleranceError, {code: (e as Error).message});
+        throw new GossipActionError(GossipAction.REJECT, {code: (e as Error).message});
       }
 
-      await (gossipHandler as GossipHandlerFn)(gossipObject, topic, receivedFrom, seenTimestampSec);
+      await (gossipHandler as GossipHandlerFn)(gossipObject, topic, gossipMsg.receivedFrom, seenTimestampSec);
 
       const metadata = getGossipObjectAcceptMetadata(config, gossipObject, topic);
       logger.debug(`gossip - ${type} - accept`, metadata);
@@ -108,10 +104,6 @@ function getGossipValidatorFn<K extends GossipType>(
       if (!(e instanceof GossipActionError)) {
         logger.error(`Gossip validation ${type} threw a non-GossipActionError`, {}, e as Error);
         throw new GossipValidationError(ERR_TOPIC_VALIDATOR_IGNORE, (e as Error).message);
-      }
-
-      if (e.lodestarAction) {
-        modules.peerRpcScores.applyAction(PeerId.createFromB58String(receivedFrom), e.lodestarAction);
       }
 
       // If the gossipObject was deserialized include its short metadata with the error data

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -91,7 +91,6 @@ export class Network implements INetwork {
       config,
       libp2p,
       logger,
-      peerRpcScores,
       metrics,
       signal,
       gossipHandlers: gossipHandlers ?? getGossipHandlers({chain, config, logger, network: this, metrics}, opts),

--- a/packages/lodestar/src/network/peers/peerManager.ts
+++ b/packages/lodestar/src/network/peers/peerManager.ts
@@ -361,8 +361,6 @@ export class PeerManager {
     // ban and disconnect peers with bad score, collect rest of healthy peers
     const connectedHealthyPeers: PeerId[] = [];
     for (const peer of connectedPeers) {
-      // to decay score
-      this.peerRpcScores.update(peer);
       switch (this.peerRpcScores.getScoreState(peer)) {
         case ScoreState.Banned:
           void this.goodbyeAndDisconnect(peer, GoodByeReasonCode.BANNED);

--- a/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
+++ b/packages/lodestar/test/unit/network/gossip/gossipsub.test.ts
@@ -1,4 +1,3 @@
-import sinon, {SinonStubbedInstance} from "sinon";
 import {expect, assert} from "chai";
 import Libp2p from "libp2p";
 import {InMessage} from "libp2p-interfaces/src/pubsub";
@@ -18,24 +17,19 @@ import {createNode} from "../../../utils/network";
 import {testLogger} from "../../../utils/logger";
 import {GossipAction, GossipActionError} from "../../../../src/chain/errors";
 import {Eth2Context} from "../../../../src/chain";
-import {IPeerRpcScoreStore, PeerRpcScoreStore} from "../../../../src/network/peers/score";
 
 describe("network / gossip / validation", function () {
   const logger = testLogger();
   const metrics = null;
   const gossipType = GossipType.beacon_block;
-  const sandbox = sinon.createSandbox();
 
   let message: InMessage;
   let topicString: string;
   let libp2p: Libp2p;
   let eth2Context: Eth2Context;
-  let peerRpcScoresStub: IPeerRpcScoreStore & SinonStubbedInstance<PeerRpcScoreStore>;
 
   let controller: AbortController;
   beforeEach(() => {
-    peerRpcScoresStub = sandbox.createStubInstance(PeerRpcScoreStore) as IPeerRpcScoreStore &
-      SinonStubbedInstance<PeerRpcScoreStore>;
     controller = new AbortController();
     eth2Context = {
       activeValidatorCount: 16,
@@ -43,11 +37,7 @@ describe("network / gossip / validation", function () {
       currentSlot: 1000 * SLOTS_PER_EPOCH,
     };
   });
-
-  afterEach(() => {
-    controller.abort();
-    sandbox.restore();
-  });
+  afterEach(() => controller.abort());
 
   beforeEach(async function () {
     const signedBlock = generateEmptySignedBlock();
@@ -65,7 +55,7 @@ describe("network / gossip / validation", function () {
   it("should throw on failed validation", async () => {
     const gossipHandlersPartial: Partial<GossipHandlers> = {
       [gossipType]: async () => {
-        throw new GossipActionError(GossipAction.REJECT, null, {code: "TEST_ERROR"});
+        throw new GossipActionError(GossipAction.REJECT, {code: "TEST_ERROR"});
       },
     };
 
@@ -74,7 +64,6 @@ describe("network / gossip / validation", function () {
       gossipHandlers: gossipHandlersPartial as GossipHandlers,
       logger,
       libp2p,
-      peerRpcScores: peerRpcScoresStub,
       metrics,
       signal: controller.signal,
       eth2Context,
@@ -106,7 +95,6 @@ describe("network / gossip / validation", function () {
       gossipHandlers: gossipHandlersPartial as GossipHandlers,
       logger,
       libp2p,
-      peerRpcScores: peerRpcScoresStub,
       metrics,
       signal: controller.signal,
       eth2Context,


### PR DESCRIPTION
This reverts commit 060918ecf2c8b2c1dbe02ea2ca2100f2efeb2b18.

**Motivation**

There are a lot of missed attestations in v0.35.0-beta.0

**Description**

+ This PR https://github.com/ChainSafe/lodestar/pull/3781 apply peer actions when we receive invalid gossip messages
+ The hypothesis is a node with more long-lived subnets have more chance to send invalid gossip messages to us, and with the PR we'll likely get peers with less long-lived subnets
+ The consequence is we have to search for subnet peers a lot during `PeerManager.heartbeat()`


Closes #3825

**TODO**

- [x] Test this branch on a node with 250 validators => testing on contabo-18
- [x] Test this branch on a node with > 900 validators