### PR TITLE
execution engine fcU call refinement

### DIFF
--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -293,7 +293,7 @@ export class BeaconChain implements IBeaconChain {
 
   async notifyForkchoiceUpdate(): Promise<void> {
     const head = this.forkChoice.getHead();
-    if (head.executionStatus != ExecutionStatus.PreMerge) {
+    if (head.executionStatus !== ExecutionStatus.PreMerge) {
       const headBlockHash = this.forkChoice.getHead().executionPayloadBlockHash;
       const finalizedBlockHash = this.forkChoice.getFinalizedBlock().executionPayloadBlockHash;
       if (headBlockHash !== null && headBlockHash !== ZERO_HASH_HEX) {

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -297,9 +297,11 @@ export class BeaconChain implements IBeaconChain {
       const headBlockHash = this.forkChoice.getHead().executionPayloadBlockHash;
       const finalizedBlockHash = this.forkChoice.getFinalizedBlock().executionPayloadBlockHash;
       if (headBlockHash !== null && headBlockHash !== ZERO_HASH_HEX) {
-        this.executionEngine.notifyForkchoiceUpdate(headBlockHash, finalizedBlockHash ?? ZERO_HASH_HEX).catch((e) => {
-          this.logger.error("Error pushing notifyForkchoiceUpdate()", {headBlockHash, finalizedBlockHash}, e);
-        });
+        await this.executionEngine
+          .notifyForkchoiceUpdate(headBlockHash, finalizedBlockHash ?? ZERO_HASH_HEX)
+          .catch((e) => {
+            this.logger.error("Error pushing notifyForkchoiceUpdate()", {headBlockHash, finalizedBlockHash}, e);
+          });
       }
     }
   }

--- a/packages/lodestar/src/chain/forkChoice/index.ts
+++ b/packages/lodestar/src/chain/forkChoice/index.ts
@@ -16,7 +16,6 @@ import {computeAnchorCheckpoint} from "../initState";
 import {ChainEventEmitter} from "../emitter";
 import {IMetrics} from "../../metrics";
 import {ChainEvent} from "../emitter";
-import {GENESIS_SLOT} from "../../constants";
 
 export type ForkChoiceOpts = {
   terminalTotalDifficulty?: bigint;
@@ -69,7 +68,9 @@ export function initializeForkChoice(
       ...(bellatrix.isBellatrixStateType(state) && bellatrix.isMergeTransitionComplete(state)
         ? {
             executionPayloadBlockHash: toHexString(state.latestExecutionPayloadHeader.blockHash),
-            executionStatus: blockHeader.slot === GENESIS_SLOT ? ExecutionStatus.Valid : ExecutionStatus.Syncing,
+            // The state used to initialize the beacon node, can be assumed to have a Valid execution
+            // head (https://github.com/ethereum/consensus-specs/blob/dev/sync/optimistic.md#checkpoint-sync-weak-subjectivity-sync)
+            executionStatus: ExecutionStatus.Valid,
           }
         : {executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge}),
     }),

--- a/packages/lodestar/src/chain/forkChoice/index.ts
+++ b/packages/lodestar/src/chain/forkChoice/index.ts
@@ -68,8 +68,8 @@ export function initializeForkChoice(
       ...(bellatrix.isBellatrixStateType(state) && bellatrix.isMergeTransitionComplete(state)
         ? {
             executionPayloadBlockHash: toHexString(state.latestExecutionPayloadHeader.blockHash),
-            // The state used to initialize the beacon node, can be assumed to have a Valid execution
-            // head (https://github.com/ethereum/consensus-specs/blob/dev/sync/optimistic.md#checkpoint-sync-weak-subjectivity-sync)
+            // The state used to initialize the beacon node, can be assumed to have a Valid execution head
+            // (https://github.com/ethereum/consensus-specs/blob/dev/sync/optimistic.md#checkpoint-sync-weak-subjectivity-sync)
             executionStatus: ExecutionStatus.Valid,
           }
         : {executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge}),

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -98,6 +98,9 @@ export interface IBeaconChain {
 
   /** Persist bad items to persistInvalidSszObjectsDir dir, for example invalid state, attestations etc. */
   persistInvalidSszObject(type: SSZObjectType, bytes: Uint8Array, suffix: string): string | null;
+
+  /** Notify execution engine about the head of the forkChoice via fcU api of execution engine */
+  notifyForkchoiceUpdate(): Promise<void>;
 }
 
 export type SSZObjectType =

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -146,8 +146,8 @@ export class BeaconNode {
       ),
       executionEngine: initializeExecutionEngine(opts.executionEngine, signal),
     });
-    // Issue a notifyForkchoiceUpdate to the execution engine so that it may start its backfill
-    // sync if need to
+    // Issue a notifyForkchoiceUpdate to the execution engine so that EL may start its backfill
+    // sync (beacon sync) if it needs to.
     await chain.notifyForkchoiceUpdate();
 
     // Load persisted data from disk to in-memory caches

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -146,6 +146,9 @@ export class BeaconNode {
       ),
       executionEngine: initializeExecutionEngine(opts.executionEngine, signal),
     });
+    // Issue a notifyForkchoiceUpdate to the execution engine so that it may start its backfill
+    // sync if need to
+    await chain.notifyForkchoiceUpdate();
 
     // Load persisted data from disk to in-memory caches
     await chain.loadFromDisk();

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -179,6 +179,10 @@ export class MockBeaconChain implements IBeaconChain {
   persistInvalidSszObject(): string | null {
     return null;
   }
+
+  async notifyForkchoiceUpdate(): Promise<void> {
+    return;
+  }
 }
 
 function mockForkChoice(): IForkChoice {


### PR DESCRIPTION
**Motivation**
Nethermind(@MarekM25) reported it does not get an fcU event on starting from a weak subjectivity state while the lighthouse apparently does.
<!-- Why is this PR exists? What are the goals of the pull request? -->
When the beacon starts from a weak subjectivity state or from a saved DB state it now sends fcU event to the execution engine so that it can start syncing.
