### PR TITLE
Assert tag == local package.json version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,11 @@ jobs:
         env:
           CURRENT_TAG: ${{ steps.get_tag.outputs.tag }}
           IGNORE_PATTERN: beta
+
+      - name: Assert tag == package.json version
+        run: .github/workflows/scripts/assert-same-package-version.sh
+        env:
+          TAG: ${{ steps.get_tag.outputs.tag }}
     outputs:
       is_beta: ${{ contains(github.ref, 'beta') }}
       tag: ${{ steps.get_tag.outputs.tag }}

--- a/.github/workflows/scripts/assert-same-package-version.sh
+++ b/.github/workflows/scripts/assert-same-package-version.sh
@@ -1,0 +1,19 @@
+# Our current release strategy does not gurantee that the tagged commit
+# has the same version in the package.json.
+# 
+# If that's not the case, no version will be published to NPM and a faulty image will be published to dockerhub
+
+LOCAL_VERSION=$(jq -r .version lerna.json)
+
+if [ -z "$TAG" ]; then
+  echo "ENV TAG is empty"
+  exit 1
+fi
+
+if [[ $TAG == *"$LOCAL_VERSION"* ]]; then
+  echo "TAG $TAG includes LOCAL_VERSION $LOCAL_VERSION"
+  exit 0
+else
+  echo "TAG $TAG does not include LOCAL_VERSION $LOCAL_VERSION"
+  exit 1
+fi

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ export TAG=v0.34.0-beta.0 && git tag -a $TAG 9fceb02 -m "$TAG" && git push origi
 4. The team creates a PR to bump `master` to the next version (in the example: `v0.35.0`) and continues releasing nightly builds.
 
 ```
-lerna version minor --no-git-tag-version
+lerna version minor --no-git-tag-version --force-publish
 ```
 
 After 3-5 days of testing:
@@ -25,7 +25,7 @@ After 3-5 days of testing:
 5. Tag final stable commit as `v0.34.0`, release and publish the stable release. This commit will be in `v0.34.x` branch and may note be on `master` if beta candidate required bug fixes.
 
 ```
-export TAG=v0.34.0 git && tag -a $TAG 9fceb02 -m "$TAG" && git push origin $TAG
+export TAG=v0.34.0 && git tag -a $TAG 9fceb02 -m "$TAG" && git push origin $TAG
 ```
 
 ## Pre-Releases


### PR DESCRIPTION
**Motivation**

When releasing v0.34.1 it failed because the local package.json version had not been bumped. The root cause is that this version doesn't follow our RELEASE.md guidelines. However this script `.github/workflows/scripts/assert-same-package-version.sh` ensures that no faulty Github release is published.

**Description**

- Assert tag == local package.json version
- [Fix RELEASE instructions](https://github.com/ChainSafe/lodestar/commit/a1eb36eb6ec1db453cb961e1e1498989cad6ee0c)