### PR TITLE
Cache AgentVersion and PeerData in network globals

### DIFF
--- a/packages/api/src/routes/lodestar.ts
+++ b/packages/api/src/routes/lodestar.ts
@@ -11,6 +11,7 @@ import {
   Schema,
   ArrayOf,
 } from "../utils";
+import {FilterGetPeers, NodePeer, PeerDirection, PeerState} from "./node";
 
 // See /packages/api/src/routes/index.ts for reasoning and instructions to add new routes
 
@@ -53,6 +54,10 @@ export type StateCacheItem = {
   lastRead: number;
 };
 
+export type LodestarNodePeer = NodePeer & {
+  agentVersion: string;
+};
+
 export type Api = {
   /** TODO: description */
   getWtfNode(): Promise<{data: string}>;
@@ -81,6 +86,8 @@ export type Api = {
   connectPeer(peerId: string, multiaddrStrs: string[]): Promise<void>;
   /** Disconnect peer */
   disconnectPeer(peerId: string): Promise<void>;
+  /** Same to node api with new fields */
+  getPeers(filters?: FilterGetPeers): Promise<{data: LodestarNodePeer[]; meta: {count: number}}>;
 
   /** Dump Discv5 Kad values */
   discv5GetKadValues(): Promise<{data: string[]}>;
@@ -103,6 +110,7 @@ export const routesData: RoutesData<Api> = {
   dropStateCache: {url: "/eth/v1/lodestar/drop-state-cache", method: "POST"},
   connectPeer: {url: "/eth/v1/lodestar/connect_peer", method: "POST"},
   disconnectPeer: {url: "/eth/v1/lodestar/disconnect_peer", method: "POST"},
+  getPeers: {url: "/eth/v1/lodestar/peers", method: "GET"},
   discv5GetKadValues: {url: "/eth/v1/debug/discv5-kad-values", method: "GET"},
 };
 
@@ -120,6 +128,7 @@ export type ReqTypes = {
   dropStateCache: ReqEmpty;
   connectPeer: {query: {peerId: string; multiaddr: string[]}};
   disconnectPeer: {query: {peerId: string}};
+  getPeers: {query: {state?: PeerState[]; direction?: PeerDirection[]}};
   discv5GetKadValues: ReqEmpty;
 };
 
@@ -154,6 +163,11 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
       parseReq: ({query}) => [query.peerId],
       schema: {query: {peerId: Schema.StringRequired}},
     },
+    getPeers: {
+      writeReq: (filters) => ({query: filters || {}}),
+      parseReq: ({query}) => [query],
+      schema: {query: {state: Schema.StringArray, direction: Schema.StringArray}},
+    },
     discv5GetKadValues: reqEmpty,
   };
 }
@@ -187,6 +201,7 @@ export function getReturnTypes(): ReturnTypes<Api> {
     getBlockProcessorQueueItems: jsonType(),
     getStateCacheItems: jsonType(),
     getCheckpointStateCacheItems: jsonType(),
+    getPeers: jsonType(),
     discv5GetKadValues: jsonType(),
   };
 }

--- a/packages/lodestar/src/network/globals.ts
+++ b/packages/lodestar/src/network/globals.ts
@@ -34,6 +34,10 @@ export type PeerData = {
 export class NetworkGlobals {
   readonly connectedPeers = new Map<PeerIdStr, PeerData>();
 
+  getAgentVersion(peerIdStr: string): string {
+    return this.connectedPeers.get(peerIdStr)?.agentVersion ?? "NA";
+  }
+
   getPeerKind(peerIdStr: string): ClientKind {
     return this.connectedPeers.get(peerIdStr)?.agentClient ?? ClientKind.Unknown;
   }

--- a/packages/lodestar/src/network/interface.ts
+++ b/packages/lodestar/src/network/interface.ts
@@ -52,6 +52,7 @@ export interface INetwork {
   // Debug
   connectToPeer(peer: PeerId, multiaddr: Multiaddr[]): Promise<void>;
   disconnectPeer(peer: PeerId): Promise<void>;
+  getAgentVersion(peerIdStr: string): string;
 }
 
 export type PeerDirection = Connection["stat"]["direction"];

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -24,6 +24,7 @@ import {PeerManager} from "./peers/peerManager";
 import {IPeerRpcScoreStore, PeerAction, PeerRpcScoreStore} from "./peers";
 import {INetworkEventBus, NetworkEventBus} from "./events";
 import {AttnetsService, SyncnetsService, CommitteeSubscription} from "./subnets";
+import {NetworkGlobals} from "./globals";
 
 interface INetworkModules {
   config: IBeaconConfig;
@@ -62,6 +63,7 @@ export class Network implements INetwork {
     this.config = config;
     this.clock = chain.clock;
     this.chain = chain;
+    const networkGlobals = new NetworkGlobals();
     const networkEventBus = new NetworkEventBus();
     const metadata = new MetadataController({}, {config, chain, logger});
     const peerRpcScores = new PeerRpcScoreStore();
@@ -69,7 +71,7 @@ export class Network implements INetwork {
     this.metadata = metadata;
     this.peerRpcScores = peerRpcScores;
     this.reqResp = new ReqResp(
-      {config, libp2p, reqRespHandlers, metadata, peerRpcScores, logger, networkEventBus, metrics},
+      {config, libp2p, reqRespHandlers, metadata, peerRpcScores, logger, networkEventBus, metrics, networkGlobals},
       opts
     );
 
@@ -102,6 +104,7 @@ export class Network implements INetwork {
         config,
         peerRpcScores,
         networkEventBus,
+        networkGlobals,
       },
       opts
     );

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -46,6 +46,7 @@ export class Network implements INetwork {
   gossip: Eth2Gossipsub;
   metadata: MetadataController;
   private readonly peerRpcScores: IPeerRpcScoreStore;
+  private readonly networkGlobals: NetworkGlobals;
 
   private readonly peerManager: PeerManager;
   private readonly libp2p: LibP2p;
@@ -63,7 +64,7 @@ export class Network implements INetwork {
     this.config = config;
     this.clock = chain.clock;
     this.chain = chain;
-    const networkGlobals = new NetworkGlobals();
+    this.networkGlobals = new NetworkGlobals();
     const networkEventBus = new NetworkEventBus();
     const metadata = new MetadataController({}, {config, chain, logger});
     const peerRpcScores = new PeerRpcScoreStore();
@@ -71,7 +72,17 @@ export class Network implements INetwork {
     this.metadata = metadata;
     this.peerRpcScores = peerRpcScores;
     this.reqResp = new ReqResp(
-      {config, libp2p, reqRespHandlers, metadata, peerRpcScores, logger, networkEventBus, metrics, networkGlobals},
+      {
+        config,
+        libp2p,
+        reqRespHandlers,
+        metadata,
+        peerRpcScores,
+        logger,
+        networkEventBus,
+        metrics,
+        networkGlobals: this.networkGlobals,
+      },
       opts
     );
 
@@ -104,7 +115,7 @@ export class Network implements INetwork {
         config,
         peerRpcScores,
         networkEventBus,
-        networkGlobals,
+        networkGlobals: this.networkGlobals,
       },
       opts
     );
@@ -237,6 +248,10 @@ export class Network implements INetwork {
 
   async disconnectPeer(peer: PeerId): Promise<void> {
     await this.libp2p.hangUp(peer);
+  }
+
+  getAgentVersion(peerIdStr: string): string {
+    return this.networkGlobals.getAgentVersion(peerIdStr);
   }
 
   /**

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -24,7 +24,7 @@ import {PeerManager} from "./peers/peerManager";
 import {IPeerRpcScoreStore, PeerAction, PeerRpcScoreStore} from "./peers";
 import {INetworkEventBus, NetworkEventBus} from "./events";
 import {AttnetsService, SyncnetsService, CommitteeSubscription} from "./subnets";
-import {NetworkGlobals} from "./globals";
+import {PeersData} from "./peers/peersData";
 
 interface INetworkModules {
   config: IBeaconConfig;
@@ -46,7 +46,7 @@ export class Network implements INetwork {
   gossip: Eth2Gossipsub;
   metadata: MetadataController;
   private readonly peerRpcScores: IPeerRpcScoreStore;
-  private readonly networkGlobals: NetworkGlobals;
+  private readonly peersData: PeersData;
 
   private readonly peerManager: PeerManager;
   private readonly libp2p: LibP2p;
@@ -64,7 +64,7 @@ export class Network implements INetwork {
     this.config = config;
     this.clock = chain.clock;
     this.chain = chain;
-    this.networkGlobals = new NetworkGlobals();
+    this.peersData = new PeersData();
     const networkEventBus = new NetworkEventBus();
     const metadata = new MetadataController({}, {config, chain, logger});
     const peerRpcScores = new PeerRpcScoreStore();
@@ -81,7 +81,7 @@ export class Network implements INetwork {
         logger,
         networkEventBus,
         metrics,
-        networkGlobals: this.networkGlobals,
+        peersData: this.peersData,
       },
       opts
     );
@@ -115,7 +115,7 @@ export class Network implements INetwork {
         config,
         peerRpcScores,
         networkEventBus,
-        networkGlobals: this.networkGlobals,
+        peersData: this.peersData,
       },
       opts
     );
@@ -251,7 +251,7 @@ export class Network implements INetwork {
   }
 
   getAgentVersion(peerIdStr: string): string {
-    return this.networkGlobals.getAgentVersion(peerIdStr);
+    return this.peersData.getAgentVersion(peerIdStr);
   }
 
   /**

--- a/packages/lodestar/src/network/peers/peerManager.ts
+++ b/packages/lodestar/src/network/peers/peerManager.ts
@@ -477,7 +477,7 @@ export class PeerManager {
    * Registers a peer as connected. The `direction` parameter determines if the peer is being
    * dialed or connecting to us.
    */
-  private onLibp2pPeerConnect = (libp2pConnection: Connection): void => {
+  private onLibp2pPeerConnect = async (libp2pConnection: Connection): Promise<void> => {
     const {direction, status} = libp2pConnection.stat;
     const peer = libp2pConnection.remotePeer;
 
@@ -509,7 +509,7 @@ export class PeerManager {
 
       // AgentVersion was set in libp2p handler of 'peer:connect' event
       // we register our handler after libp2p so this data should be available
-      const agentVersionBytes = this.libp2p.peerStore.metadataBook.getValue(peerData.peerId, "AgentVersion");
+      const agentVersionBytes = await this.libp2p.peerStore.metadataBook.getValue(peerData.peerId, "AgentVersion");
       if (agentVersionBytes) {
         const agentVersion = new TextDecoder().decode(agentVersionBytes) || "N/A";
         peerData.agentVersion = agentVersion;

--- a/packages/lodestar/src/network/peers/peerManager.ts
+++ b/packages/lodestar/src/network/peers/peerManager.ts
@@ -10,7 +10,7 @@ import {IMetrics} from "../../metrics";
 import {NetworkEvent, INetworkEventBus} from "../events";
 import {IReqResp, ReqRespMethod, RequestTypedContainer} from "../reqresp";
 import {prettyPrintPeerId} from "../util";
-import {NetworkGlobals, PeerData} from "../globals";
+import {PeersData, PeerData} from "./peersData";
 import {ISubnetsService} from "../subnets";
 import {PeerDiscovery, SubnetDiscvQueryMs} from "./discover";
 import {IPeerRpcScoreStore, ScoreState} from "./score";
@@ -72,7 +72,7 @@ export type PeerManagerModules = {
   config: IBeaconConfig;
   peerRpcScores: IPeerRpcScoreStore;
   networkEventBus: INetworkEventBus;
-  networkGlobals: NetworkGlobals;
+  peersData: PeersData;
 };
 
 type PeerIdStr = string;
@@ -122,7 +122,7 @@ export class PeerManager {
     this.config = modules.config;
     this.peerRpcScores = modules.peerRpcScores;
     this.networkEventBus = modules.networkEventBus;
-    this.connectedPeers = modules.networkGlobals.connectedPeers;
+    this.connectedPeers = modules.peersData.connectedPeers;
     this.opts = opts;
 
     // opts.discv5 === null, discovery is disabled
@@ -568,7 +568,6 @@ export class PeerManager {
   private async runPeerCountMetrics(metrics: IMetrics): Promise<void> {
     let total = 0;
 
-    // TODO: Should we use here `this.connectedPeers`?
     const peersByDirection = new Map<string, number>();
     const peersByClient = new Map<string, number>();
     for (const connections of this.libp2p.connectionManager.connections.values()) {

--- a/packages/lodestar/src/network/peers/peersData.ts
+++ b/packages/lodestar/src/network/peers/peersData.ts
@@ -1,7 +1,7 @@
 import {altair} from "@chainsafe/lodestar-types";
 import PeerId from "peer-id";
-import {ClientKind} from "./peers/client";
-import {Encoding} from "./reqresp/types";
+import {ClientKind} from "./client";
+import {Encoding} from "../reqresp/types";
 
 type PeerIdStr = string;
 
@@ -31,7 +31,7 @@ export type PeerData = {
  *
  * The pruning and bounding of this class is handled by the PeerManager
  */
-export class NetworkGlobals {
+export class PeersData {
   readonly connectedPeers = new Map<PeerIdStr, PeerData>();
 
   getAgentVersion(peerIdStr: string): string {

--- a/packages/lodestar/src/network/reqresp/interface.ts
+++ b/packages/lodestar/src/network/reqresp/interface.ts
@@ -7,6 +7,7 @@ import {ILogger} from "@chainsafe/lodestar-utils";
 import {IPeerRpcScoreStore} from "../peers";
 import {MetadataController} from "../metadata";
 import {INetworkEventBus} from "../events";
+import {NetworkGlobals} from "../globals";
 import {ReqRespHandlers} from "./handlers";
 import {IMetrics} from "../../metrics";
 import {RequestTypedContainer} from "./types";
@@ -29,6 +30,7 @@ export interface IReqResp {
 export interface IReqRespModules {
   config: IBeaconConfig;
   libp2p: LibP2p;
+  networkGlobals: NetworkGlobals;
   logger: ILogger;
   metadata: MetadataController;
   reqRespHandlers: ReqRespHandlers;

--- a/packages/lodestar/src/network/reqresp/interface.ts
+++ b/packages/lodestar/src/network/reqresp/interface.ts
@@ -7,7 +7,7 @@ import {ILogger} from "@chainsafe/lodestar-utils";
 import {IPeerRpcScoreStore} from "../peers";
 import {MetadataController} from "../metadata";
 import {INetworkEventBus} from "../events";
-import {NetworkGlobals} from "../globals";
+import {PeersData} from "../peers/peersData";
 import {ReqRespHandlers} from "./handlers";
 import {IMetrics} from "../../metrics";
 import {RequestTypedContainer} from "./types";
@@ -30,7 +30,7 @@ export interface IReqResp {
 export interface IReqRespModules {
   config: IBeaconConfig;
   libp2p: LibP2p;
-  networkGlobals: NetworkGlobals;
+  peersData: PeersData;
   logger: ILogger;
   metadata: MetadataController;
   reqRespHandlers: ReqRespHandlers;

--- a/packages/lodestar/src/network/reqresp/request/index.ts
+++ b/packages/lodestar/src/network/reqresp/request/index.ts
@@ -5,7 +5,8 @@ import {Libp2p} from "libp2p/src/connection-manager";
 import {IForkDigestContext} from "@chainsafe/lodestar-config";
 import {ErrorAborted, ILogger, withTimeout, TimeoutError} from "@chainsafe/lodestar-utils";
 import {timeoutOptions} from "../../../constants";
-import {getClientFromPeerStore, prettyPrintPeerId} from "../../util";
+import {prettyPrintPeerId} from "../../util";
+import {NetworkGlobals} from "../../globals";
 import {Method, Encoding, Protocol, Version, IncomingResponseBody, RequestBody} from "../types";
 import {formatProtocolId, renderRequestBody} from "../utils";
 import {ResponseError} from "../response";
@@ -28,6 +29,7 @@ type SendRequestModules = {
   logger: ILogger;
   forkDigestContext: IForkDigestContext;
   libp2p: Libp2p;
+  networkGlobals: NetworkGlobals;
 };
 
 /**
@@ -42,7 +44,7 @@ type SendRequestModules = {
  *    - The maximum number of requested chunks are read. Does not throw, returns read chunks only.
  */
 export async function sendRequest<T extends IncomingResponseBody | IncomingResponseBody[]>(
-  {logger, forkDigestContext, libp2p}: SendRequestModules,
+  {logger, forkDigestContext, libp2p, networkGlobals}: SendRequestModules,
   peerId: PeerId,
   method: Method,
   encoding: Encoding,
@@ -55,7 +57,7 @@ export async function sendRequest<T extends IncomingResponseBody | IncomingRespo
 ): Promise<T> {
   const {REQUEST_TIMEOUT, DIAL_TIMEOUT} = {...timeoutOptions, ...options};
   const peer = prettyPrintPeerId(peerId);
-  const client = await getClientFromPeerStore(peerId, libp2p.peerStore.metadataBook);
+  const client = networkGlobals.getPeerKind(peerId.toB58String());
   const logCtx = {method, encoding, client, peer, requestId};
 
   if (signal?.aborted) {

--- a/packages/lodestar/src/network/reqresp/request/index.ts
+++ b/packages/lodestar/src/network/reqresp/request/index.ts
@@ -6,7 +6,7 @@ import {IForkDigestContext} from "@chainsafe/lodestar-config";
 import {ErrorAborted, ILogger, withTimeout, TimeoutError} from "@chainsafe/lodestar-utils";
 import {timeoutOptions} from "../../../constants";
 import {prettyPrintPeerId} from "../../util";
-import {NetworkGlobals} from "../../globals";
+import {PeersData} from "../../peers/peersData";
 import {Method, Encoding, Protocol, Version, IncomingResponseBody, RequestBody} from "../types";
 import {formatProtocolId, renderRequestBody} from "../utils";
 import {ResponseError} from "../response";
@@ -29,7 +29,7 @@ type SendRequestModules = {
   logger: ILogger;
   forkDigestContext: IForkDigestContext;
   libp2p: Libp2p;
-  networkGlobals: NetworkGlobals;
+  peersData: PeersData;
 };
 
 /**
@@ -44,7 +44,7 @@ type SendRequestModules = {
  *    - The maximum number of requested chunks are read. Does not throw, returns read chunks only.
  */
 export async function sendRequest<T extends IncomingResponseBody | IncomingResponseBody[]>(
-  {logger, forkDigestContext, libp2p, networkGlobals}: SendRequestModules,
+  {logger, forkDigestContext, libp2p, peersData}: SendRequestModules,
   peerId: PeerId,
   method: Method,
   encoding: Encoding,
@@ -57,7 +57,7 @@ export async function sendRequest<T extends IncomingResponseBody | IncomingRespo
 ): Promise<T> {
   const {REQUEST_TIMEOUT, DIAL_TIMEOUT} = {...timeoutOptions, ...options};
   const peer = prettyPrintPeerId(peerId);
-  const client = networkGlobals.getPeerKind(peerId.toB58String());
+  const client = peersData.getPeerKind(peerId.toB58String());
   const logCtx = {method, encoding, client, peer, requestId};
 
   if (signal?.aborted) {

--- a/packages/lodestar/src/network/reqresp/response/index.ts
+++ b/packages/lodestar/src/network/reqresp/response/index.ts
@@ -5,7 +5,7 @@ import {ILogger, TimeoutError, withTimeout} from "@chainsafe/lodestar-utils";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {REQUEST_TIMEOUT, RespStatus} from "../../../constants";
 import {prettyPrintPeerId} from "../../util";
-import {NetworkGlobals} from "../../globals";
+import {PeersData} from "../../peers/peersData";
 import {Protocol, RequestBody, OutgoingResponseBody} from "../types";
 import {renderRequestBody} from "../utils";
 import {Libp2pStream} from "../interface";
@@ -24,7 +24,7 @@ export type PerformRequestHandler = (
 type HandleRequestModules = {
   config: IBeaconConfig;
   logger: ILogger;
-  networkGlobals: NetworkGlobals;
+  peersData: PeersData;
 };
 
 /**
@@ -38,7 +38,7 @@ type HandleRequestModules = {
  * 4b. On error, encode and write an error `<response_chunk>` and stop
  */
 export async function handleRequest(
-  {config, logger, networkGlobals}: HandleRequestModules,
+  {config, logger, peersData: peersData}: HandleRequestModules,
   performRequestHandler: PerformRequestHandler,
   stream: Libp2pStream,
   peerId: PeerId,
@@ -46,7 +46,7 @@ export async function handleRequest(
   signal?: AbortSignal,
   requestId = 0
 ): Promise<void> {
-  const client = networkGlobals.getPeerKind(peerId.toB58String());
+  const client = peersData.getPeerKind(peerId.toB58String());
   const logCtx = {method: protocol.method, client, peer: prettyPrintPeerId(peerId), requestId};
 
   let responseError: Error | null = null;

--- a/packages/lodestar/src/network/reqresp/response/index.ts
+++ b/packages/lodestar/src/network/reqresp/response/index.ts
@@ -1,11 +1,11 @@
 import PeerId from "peer-id";
 import pipe from "it-pipe";
 import {AbortSignal} from "@chainsafe/abort-controller";
-import {Libp2p} from "libp2p/src/connection-manager";
 import {ILogger, TimeoutError, withTimeout} from "@chainsafe/lodestar-utils";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {REQUEST_TIMEOUT, RespStatus} from "../../../constants";
-import {getClientFromPeerStore, prettyPrintPeerId} from "../../util";
+import {prettyPrintPeerId} from "../../util";
+import {NetworkGlobals} from "../../globals";
 import {Protocol, RequestBody, OutgoingResponseBody} from "../types";
 import {renderRequestBody} from "../utils";
 import {Libp2pStream} from "../interface";
@@ -24,7 +24,7 @@ export type PerformRequestHandler = (
 type HandleRequestModules = {
   config: IBeaconConfig;
   logger: ILogger;
-  libp2p: Libp2p;
+  networkGlobals: NetworkGlobals;
 };
 
 /**
@@ -38,7 +38,7 @@ type HandleRequestModules = {
  * 4b. On error, encode and write an error `<response_chunk>` and stop
  */
 export async function handleRequest(
-  {config, logger, libp2p}: HandleRequestModules,
+  {config, logger, networkGlobals}: HandleRequestModules,
   performRequestHandler: PerformRequestHandler,
   stream: Libp2pStream,
   peerId: PeerId,
@@ -46,7 +46,7 @@ export async function handleRequest(
   signal?: AbortSignal,
   requestId = 0
 ): Promise<void> {
-  const client = await getClientFromPeerStore(peerId, libp2p.peerStore.metadataBook);
+  const client = networkGlobals.getPeerKind(peerId.toB58String());
   const logCtx = {method: protocol.method, client, peer: prettyPrintPeerId(peerId), requestId};
 
   let responseError: Error | null = null;

--- a/packages/lodestar/src/network/util.ts
+++ b/packages/lodestar/src/network/util.ts
@@ -7,8 +7,6 @@ import PeerId from "peer-id";
 import {Multiaddr} from "multiaddr";
 import {networkInterfaces} from "node:os";
 import {ENR} from "@chainsafe/discv5";
-import {MetadataBook} from "libp2p/src/peer-store/types";
-import {clientFromAgentVersion, ClientKind} from "./peers/client";
 
 // peers
 
@@ -68,13 +66,4 @@ export function clearMultiaddrUDP(enr: ENR): void {
 export function prettyPrintPeerId(peerId: PeerId): string {
   const id = peerId.toB58String();
   return `${id.substr(0, 2)}...${id.substr(id.length - 6, id.length)}`;
-}
-
-export async function getClientFromPeerStore(peerId: PeerId, metadataBook: MetadataBook): Promise<ClientKind> {
-  const agentVersion = await getAgentVersionFromPeerStore(peerId, metadataBook);
-  return clientFromAgentVersion(agentVersion);
-}
-
-export async function getAgentVersionFromPeerStore(peerId: PeerId, metadataBook: MetadataBook): Promise<string> {
-  return new TextDecoder().decode(await metadataBook.getValue(peerId, "AgentVersion")) || "N/A";
 }

--- a/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
@@ -6,6 +6,7 @@ import {config} from "@chainsafe/lodestar-config/default";
 import {IReqResp, ReqRespMethod} from "../../../../src/network/reqresp";
 import {PeerRpcScoreStore, PeerManager} from "../../../../src/network/peers";
 import {NetworkEvent, NetworkEventBus} from "../../../../src/network";
+import {NetworkGlobals} from "../../../../src/network/globals";
 import {createNode, getAttnets, getSyncnets} from "../../../utils/network";
 import {MockBeaconChain} from "../../../utils/mocks/chain/chain";
 import {generateEmptySignedBlock} from "../../../utils/block";
@@ -82,6 +83,7 @@ describe("network / peers / PeerManager", function () {
         networkEventBus,
         attnetsService: mockSubnetsService,
         syncnetsService: mockSubnetsService,
+        networkGlobals: new NetworkGlobals(),
       },
       {
         targetPeers: 30,

--- a/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
@@ -6,7 +6,7 @@ import {config} from "@chainsafe/lodestar-config/default";
 import {IReqResp, ReqRespMethod} from "../../../../src/network/reqresp";
 import {PeerRpcScoreStore, PeerManager} from "../../../../src/network/peers";
 import {NetworkEvent, NetworkEventBus} from "../../../../src/network";
-import {NetworkGlobals} from "../../../../src/network/globals";
+import {PeersData} from "../../../../src/network/peers/peersData";
 import {createNode, getAttnets, getSyncnets} from "../../../utils/network";
 import {MockBeaconChain} from "../../../utils/mocks/chain/chain";
 import {generateEmptySignedBlock} from "../../../utils/block";
@@ -83,7 +83,7 @@ describe("network / peers / PeerManager", function () {
         networkEventBus,
         attnetsService: mockSubnetsService,
         syncnetsService: mockSubnetsService,
-        networkGlobals: new NetworkGlobals(),
+        peersData: new PeersData(),
       },
       {
         targetPeers: 30,

--- a/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
@@ -114,7 +114,7 @@ describe("network / peers / PeerManager", function () {
     const {reqResp, networkEventBus, peerManager} = await mockModules();
 
     // Simulate connection so that PeerManager persists the metadata response
-    peerManager["onLibp2pPeerConnect"]({
+    await peerManager["onLibp2pPeerConnect"]({
       stat: {direction: "inbound", status: "open"},
       remotePeer: peerId1,
     } as Connection);

--- a/packages/lodestar/test/unit/network/reqresp/response/index.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/response/index.test.ts
@@ -5,12 +5,12 @@ import {LodestarError} from "@chainsafe/lodestar-utils";
 import {RespStatus} from "../../../../../src/constants";
 import {Method, Encoding, Version} from "../../../../../src/network/reqresp/types";
 import {handleRequest, PerformRequestHandler} from "../../../../../src/network/reqresp/response";
+import {NetworkGlobals} from "../../../../../src/network/globals";
 import {expectRejectedWithLodestarError} from "../../../../utils/errors";
 import {expectEqualByteChunks, MockLibP2pStream} from "../utils";
 import {sszSnappyPing} from "../encodingStrategies/sszSnappy/testData";
 import {testLogger} from "../../../../utils/logger";
 import {getValidPeerId} from "../../../../utils/peer";
-import {createNode} from "../../../../utils/network";
 import {config} from "../../../../utils/config";
 
 chai.use(chaiAsPromised);
@@ -18,8 +18,7 @@ chai.use(chaiAsPromised);
 describe("network / reqresp / response / handleRequest", async () => {
   const logger = testLogger();
   const peerId = getValidPeerId();
-  const multiaddr = "/ip4/127.0.0.1/tcp/0";
-  const libp2p = await createNode(multiaddr);
+  const networkGlobals = new NetworkGlobals();
 
   let controller: AbortController;
   beforeEach(() => (controller = new AbortController()));
@@ -74,7 +73,7 @@ describe("network / reqresp / response / handleRequest", async () => {
       const stream = new MockLibP2pStream(requestChunks);
 
       const resultPromise = handleRequest(
-        {config, logger, libp2p},
+        {config, logger, networkGlobals},
         performRequestHandler,
         stream,
         peerId,

--- a/packages/lodestar/test/unit/network/reqresp/response/index.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/response/index.test.ts
@@ -5,7 +5,7 @@ import {LodestarError} from "@chainsafe/lodestar-utils";
 import {RespStatus} from "../../../../../src/constants";
 import {Method, Encoding, Version} from "../../../../../src/network/reqresp/types";
 import {handleRequest, PerformRequestHandler} from "../../../../../src/network/reqresp/response";
-import {NetworkGlobals} from "../../../../../src/network/globals";
+import {PeersData} from "../../../../../src/network/peers/peersData";
 import {expectRejectedWithLodestarError} from "../../../../utils/errors";
 import {expectEqualByteChunks, MockLibP2pStream} from "../utils";
 import {sszSnappyPing} from "../encodingStrategies/sszSnappy/testData";
@@ -18,7 +18,7 @@ chai.use(chaiAsPromised);
 describe("network / reqresp / response / handleRequest", async () => {
   const logger = testLogger();
   const peerId = getValidPeerId();
-  const networkGlobals = new NetworkGlobals();
+  const peersData = new PeersData();
 
   let controller: AbortController;
   beforeEach(() => (controller = new AbortController()));
@@ -73,7 +73,7 @@ describe("network / reqresp / response / handleRequest", async () => {
       const stream = new MockLibP2pStream(requestChunks);
 
       const resultPromise = handleRequest(
-        {config, logger, networkGlobals},
+        {config, logger, peersData: peersData},
         performRequestHandler,
         stream,
         peerId,

--- a/packages/lodestar/test/unit/network/util.test.ts
+++ b/packages/lodestar/test/unit/network/util.test.ts
@@ -1,14 +1,12 @@
-import PeerId from "peer-id";
 import {Multiaddr} from "multiaddr";
 import {expect} from "chai";
-import {fromHexString} from "@chainsafe/ssz";
 import {config} from "@chainsafe/lodestar-config/default";
 import {ForkName} from "@chainsafe/lodestar-params";
 import {createEnr, createPeerId} from "@chainsafe/lodestar-cli/src/config";
 import {Method, Version, Encoding} from "../../../src/network/reqresp/types";
 import {defaultNetworkOptions} from "../../../src/network/options";
 import {formatProtocolId, parseProtocolId} from "../../../src/network/reqresp/utils";
-import {createNodeJsLibp2p, getAgentVersionFromPeerStore, isLocalMultiAddr} from "../../../src/network";
+import {createNodeJsLibp2p, isLocalMultiAddr} from "../../../src/network";
 import {getCurrentAndNextFork} from "../../../src/network/forks";
 
 describe("Test isLocalMultiAddr", () => {
@@ -53,49 +51,6 @@ describe("ReqResp protocolID parse / render", () => {
       expect(parseProtocolId(protocolId)).to.deep.equal({method, version, encoding});
     });
   }
-});
-
-describe("getAgentVersionFromPeerStore", () => {
-  it("should get the peer's AgentVersion", async function () {
-    this.timeout(0);
-    const peerId = await createPeerId();
-    const libp2p = await createNodeJsLibp2p(
-      peerId,
-      {
-        discv5: {
-          enabled: false,
-          enr: createEnr(peerId),
-          bindAddr: "/ip4/127.0.0.1/udp/0",
-          bootEnrs: [],
-        },
-        localMultiaddrs: ["/ip4/127.0.0.1/tcp/0"],
-        targetPeers: defaultNetworkOptions.targetPeers,
-        maxPeers: defaultNetworkOptions.maxPeers,
-      },
-      {disablePeerDiscovery: true}
-    );
-
-    const testAgentVersion = fromHexString("0x1234");
-    const numPeers = 200;
-    const peers: PeerId[] = [];
-
-    // Write peers to peerStore
-    for (let i = 0; i < numPeers; i++) {
-      const peerId = await createPeerId();
-      await libp2p.peerStore.metadataBook.setValue(peerId, "AgentVersion", testAgentVersion);
-      peers.push(peerId);
-    }
-
-    // start the benchmark
-    const start = Date.now();
-    for (const peer of peers) {
-      const version = await getAgentVersionFromPeerStore(peer, libp2p.peerStore.metadataBook);
-      expect(version).to.be.equal(new TextDecoder().decode(testAgentVersion));
-    }
-    const timeDiff = Date.now() - start;
-    // eslint-disable-next-line no-console
-    console.log(`getAgentVersionFromPeerStore x${numPeers}: ${timeDiff} ms`);
-  });
 });
 
 describe("getCurrentAndNextFork", function () {


### PR DESCRIPTION
**Motivation**

Currently we read AgentVersion and ClientKind from the peerstore everytime it's needed. In the libp2p bump https://github.com/ChainSafe/lodestar/pull/3661 this can trigger disk reads. This data is not necessary to persist besides the lifetime of the peer.

This PR extends https://github.com/ChainSafe/lodestar/pull/3838 adding agentVersion and clientKind to the ephemeral data attached to connected peers, which is dropped on disconnection.

In the future we should do a PR upstream to libp2p to emit the response of the identity protocol to prevent having to poll agentVersions from the peerstore

**Description**

- Cache AgentVersion and PeerData in network globals
- Move encodingPreference to PeerData