### PR TITLE
Add spinning up validator from mnemonic on the devnet script

### DIFF
--- a/kiln/devnets/README.md
+++ b/kiln/devnets/README.md
@@ -12,7 +12,7 @@ This is a setup to run and join the devnet with a single shell command. This scr
 
 ```bash
 cd kiln/devnets
-./setup.sh --dataDir kiln-data --elClient geth --devnetVars ./kiln.vars [--dockerWithSudo --withTerminal "gnome-terminal --disable-factory --"]
+./setup.sh --dataDir kiln-data --elClient geth --devnetVars ./kiln.vars [--dockerWithSudo --withTerminal "gnome-terminal --disable-factory --" --withValidator]
 ```
 
 ###### Example scenarios
@@ -35,5 +35,6 @@ You can alternate between `geth` and `nethermind` to experiment with the ELs bei
 5. `--withTerminal`(optional): Provide the terminal command prefix for CL and EL processes to run in your favourite terminal.
    You may use an alias or a terminal launching script as long as it waits for the command it runs till ends and then closes.If not provided, it will launch the docker processes in _in-terminal_ mode.
 6. `--detached`(optional): By default the script will wait for processes and use user input (ctrl +c) to end the processes, however you can pass this option to skip this behavior and just return, for e.g. in case you just want to leave it running.
+7. `--withValidator` (optional): Launch a validator client using `LODESTAR_VALIDATOR_ARGS` as set in the devnet vars file.
 
 Only one of `--withTerminal` or `--detached` should be provided.

--- a/kiln/devnets/kiln.vars
+++ b/kiln/devnets/kiln.vars
@@ -7,7 +7,9 @@ CONFIG_GIT_DIR=kiln
 
 JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
-LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls http://127.0.0.1:8551 --api.rest.enabled --api.rest.host 0.0.0.0"
+LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls http://127.0.0.1:8551 --api.rest.enabled --api.rest.host 0.0.0.0 --api.rest.api '*'"
+
+LODESTAR_VALIDATOR_ARGS='--network kiln  --fromMnemonic "lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow" --mnemonicIndexes 0..5'
 
 NETHERMIND_EXTRA_ARGS="--config kiln --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=1000000000000 --Init.DiagnosticMode=None --JsonRpc.Enabled=true --JsonRpc.Host=0.0.0.0 --JsonRpc.AdditionalRpcUrls \"http://localhost:8545|http;ws|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:8551|http;ws|net;eth;subscribe;engine;web3;client\""
 

--- a/kiln/devnets/parse-args.sh
+++ b/kiln/devnets/parse-args.sh
@@ -27,6 +27,10 @@ while [[ $# -gt 0 ]]; do
       dockerWithSudo=true
       shift # past argument
       ;;
+    --withValidator)
+      withValidator=true
+      shift # past argument
+      ;;
     --detached)
       detached=true
       shift # past argument
@@ -42,6 +46,7 @@ echo "dataDir = $dataDir"
 echo "devnetVars = $devnetVars"
 echo "withTerminal = $withTerminal"
 echo "dockerWithSudo = $dockerWithSudo"
+echo "withValidator = $withValidator"
 echo "detached = $detached"
 
 if [ -n "$withTerminal" ] && [ -n "$detached" ]

--- a/kiln/devnets/setup.sh
+++ b/kiln/devnets/setup.sh
@@ -127,9 +127,9 @@ fi
 valName="$DEVNET_NAME-validator"
 if [ $platform == 'Darwin' ]
 then
-  valCmd="$dockerCmd --name $valName --net=container:$elName -v $currentDir/$dataDir:/data $LODESTAR_IMAGE validator --rootDir /data/lodestar $LODESTAR_VALIDATOR_ARGS"
+  valCmd="$dockerCmd --name $valName --net=container:$elName -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir:/data $LODESTAR_IMAGE validator --rootDir /data/lodestar --paramsFile /config/config.yaml $LODESTAR_VALIDATOR_ARGS"
 else
-  valCmd="$dockerCmd --name $valName --network host -v $currentDir/$dataDir:/data $LODESTAR_IMAGE validator --rootDir /data/lodestar $LODESTAR_VALIDATOR_ARGS"
+  valCmd="$dockerCmd --name $valName --network host -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir:/data $LODESTAR_IMAGE validator --rootDir /data/lodestar --paramsFile /config/config.yaml $LODESTAR_VALIDATOR_ARGS"
 fi;
 
 echo -n $JWT_SECRET > $dataDir/jwtsecret

--- a/kiln/devnets/setup.sh
+++ b/kiln/devnets/setup.sh
@@ -37,15 +37,15 @@ run_cmd(){
   execCmd=$1;
   if [ -n "$detached" ]
   then
-    echo "running: $execCmd"
-    $execCmd
+    echo "running detached: $execCmd"
+    eval "$execCmd"
   else
     if [ -n "$withTerminal" ]
     then
       execCmd="$withTerminal $execCmd"
     fi;
     echo "running: $execCmd &"
-    $execCmd &
+    eval "$execCmd" &
   fi;
 }
 
@@ -61,7 +61,9 @@ dockerCmd="$dockerExec run"
 
 if [ -n "$detached" ]
 then 
-  dockerCmd="$dockerCmd --detach"
+  dockerCmd="$dockerCmd --detach --restart unless-stopped"
+else
+  dockerCmd="$dockerCmd --rm"
 fi;
 
 if [ -n "$withTerminal" ]
@@ -86,9 +88,9 @@ then
   fi;
   if [ $platform == 'Darwin' ]
   then
-    elCmd="$dockerCmd --rm --name $elName -v $currentDir/$dataDir:/data $GETH_IMAGE --bootnodes $EXTRA_BOOTNODES$bootNode --datadir /data/geth --authrpc.jwtsecret /data/jwtsecret $GETH_EXTRA_ARGS"
+    elCmd="$dockerCmd --name $elName -v $currentDir/$dataDir:/data $GETH_IMAGE --bootnodes $EXTRA_BOOTNODES$bootNode --datadir /data/geth --authrpc.jwtsecret /data/jwtsecret $GETH_EXTRA_ARGS"
   else
-    elCmd="$dockerCmd --rm --name $elName --network host -v $currentDir/$dataDir:/data $GETH_IMAGE --bootnodes $EXTRA_BOOTNODES$bootNode --datadir /data/geth --authrpc.jwtsecret /data/jwtsecret $GETH_EXTRA_ARGS"
+    elCmd="$dockerCmd --name $elName --network host -v $currentDir/$dataDir:/data $GETH_IMAGE --bootnodes $EXTRA_BOOTNODES$bootNode --datadir /data/geth --authrpc.jwtsecret /data/jwtsecret $GETH_EXTRA_ARGS"
   fi
 elif [ "$elClient" == "nethermind" ] 
 then
@@ -99,9 +101,9 @@ then
 
   if [ $platform == 'Darwin' ]
   then
-    elCmd="$dockerCmd --rm --name $elName -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir:/data $NETHERMIND_IMAGE --datadir /data/nethermind  --Init.ChainSpecPath=/config/nethermind_genesis.json --JsonRpc.JwtSecretFile /data/jwtsecret $NETHERMIND_EXTRA_ARGS --Discovery.Bootnodes $EXTRA_BOOTNODES$bootNode"
+    elCmd="$dockerCmd --name $elName -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir:/data $NETHERMIND_IMAGE --datadir /data/nethermind  --Init.ChainSpecPath=/config/nethermind_genesis.json --JsonRpc.JwtSecretFile /data/jwtsecret $NETHERMIND_EXTRA_ARGS --Discovery.Bootnodes $EXTRA_BOOTNODES$bootNode"
   else
-    elCmd="$dockerCmd --rm --name $elName --network host -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir:/data $NETHERMIND_IMAGE --datadir /data/nethermind  --Init.ChainSpecPath=/config/nethermind_genesis.json --JsonRpc.JwtSecretFile /data/jwtsecret $NETHERMIND_EXTRA_ARGS --Discovery.Bootnodes $EXTRA_BOOTNODES$bootNode"
+    elCmd="$dockerCmd --name $elName --network host -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir:/data $NETHERMIND_IMAGE --datadir /data/nethermind  --Init.ChainSpecPath=/config/nethermind_genesis.json --JsonRpc.JwtSecretFile /data/jwtsecret $NETHERMIND_EXTRA_ARGS --Discovery.Bootnodes $EXTRA_BOOTNODES$bootNode"
   fi
 fi
 
@@ -117,15 +119,24 @@ clName="$DEVNET_NAME-lodestar"
 
 if [ $platform == 'Darwin' ]
 then
-  clCmd="$dockerCmd --rm --name $clName --net=container:$elName -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir:/data $LODESTAR_IMAGE beacon --rootDir /data/lodestar --paramsFile /config/config.yaml --genesisStateFile /config/genesis.ssz --network.connectToDiscv5Bootnodes --network.discv5.enabled true --eth1.enabled true --eth1.depositContractDeployBlock $depositContractDeployBlock  $LODESTAR_EXTRA_ARGS --bootnodesFile /config/boot_enr.yaml --jwt-secret /data/jwtsecret"
+  clCmd="$dockerCmd --name $clName --net=container:$elName -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir:/data $LODESTAR_IMAGE beacon --rootDir /data/lodestar --paramsFile /config/config.yaml --genesisStateFile /config/genesis.ssz --network.connectToDiscv5Bootnodes --network.discv5.enabled true --eth1.enabled true --eth1.depositContractDeployBlock $depositContractDeployBlock  $LODESTAR_EXTRA_ARGS --bootnodesFile /config/boot_enr.yaml --jwt-secret /data/jwtsecret"
 else
-  clCmd="$dockerCmd --rm --name $clName --network host -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir:/data $LODESTAR_IMAGE beacon --rootDir /data/lodestar --paramsFile /config/config.yaml --genesisStateFile /config/genesis.ssz --network.connectToDiscv5Bootnodes --network.discv5.enabled true --eth1.enabled true --eth1.depositContractDeployBlock $depositContractDeployBlock  $LODESTAR_EXTRA_ARGS --bootnodesFile /config/boot_enr.yaml --jwt-secret /data/jwtsecret"
+  clCmd="$dockerCmd --name $clName --network host -v $currentDir/$dataDir/$configGitDir:/config -v $currentDir/$dataDir:/data $LODESTAR_IMAGE beacon --rootDir /data/lodestar --paramsFile /config/config.yaml --genesisStateFile /config/genesis.ssz --network.connectToDiscv5Bootnodes --network.discv5.enabled true --eth1.enabled true --eth1.depositContractDeployBlock $depositContractDeployBlock  $LODESTAR_EXTRA_ARGS --bootnodesFile /config/boot_enr.yaml --jwt-secret /data/jwtsecret"
 fi
+
+valName="$DEVNET_NAME-validator"
+if [ $platform == 'Darwin' ]
+then
+  valCmd="$dockerCmd --name $valName --net=container:$elName -v $currentDir/$dataDir:/data $LODESTAR_IMAGE validator --rootDir /data/lodestar $LODESTAR_VALIDATOR_ARGS"
+else
+  valCmd="$dockerCmd --name $valName --network host -v $currentDir/$dataDir:/data $LODESTAR_IMAGE validator --rootDir /data/lodestar $LODESTAR_VALIDATOR_ARGS"
+fi;
 
 echo -n $JWT_SECRET > $dataDir/jwtsecret
 run_cmd "$elCmd"
 elPid=$!
 echo "elPid= $elPid"
+terminalInfo="elPid= $elPid for $elName"
 
 if [ $platform == 'Darwin' ]
 then
@@ -136,43 +147,59 @@ fi
 run_cmd "$clCmd"
 clPid=$!
 echo "clPid= $clPid"
+terminalInfo="$terminalInfo, clPid= $clPid for $clName"
+
+if [ -n "$withValidator" ]
+then 
+  run_cmd "$valCmd"
+  valPid=$!
+  echo "valPid= $valPid"
+  terminalInfo="$terminalInfo, valPid= $valPid for $elName"
+else 
+   # hack to assign clPid to valPid for joint wait later
+   valPid=$clPid
+fi;
 
 cleanup() {
   echo "cleaning up"
   $dockerExec rm $elName -f
   $dockerExec rm $clName -f
+  $dockerExec rm $valName -f
   elPid=null
   clPid=null
+  valPid=null
 }
 
 trap "echo exit signal recived;cleanup" SIGINT SIGTERM
 
-if [ ! -n "$detached" ] && [ -n "$elPid" ] && [ -n "$clPid" ] 
+if [ ! -n "$detached" ] && [ -n "$elPid" ] && [ -n "$clPid" ] && ([ ! -n "$withValidator" ] || [ -n "$valPid" ] )
 then 
-	echo "launched two terminals for el and cl clients with elPid: $elPid clPid: $clPid"
+	echo "launched terminals for $terminalInfo"
 	echo "you can watch observe the client logs at the respective terminals"
-	echo "use ctl + c on any of these three (including this) terminals to stop the process"
+	echo "use ctl + c on any of these (including this) terminals to stop the process"
 	echo "waiting ..."
 	if [ $platform == 'Darwin' ]
 	then # macOs ships with an old version of bash with wait that does not have the -n flag
 	  wait $elPid
 	  wait $clPid
+    wait $valPid
 	else
-	  wait -n $elPid $clPid
+	  wait -n  $elPid $clPid $valPid 
 	fi
   echo "one of the el or cl process exited, stopping and cleanup"
 	cleanup
 fi;
 
-if [ ! -n "$detached" ] && [ -n "$elPid$clPid" ]
+# if its not detached and is here, it means one of the processes exited/didn't launch
+if [ ! -n "$detached" ] && [ -n "$elPid$clPid$valPid" ]
 then
-	echo "one of the el or cl processes didn't launch properly"
+	echo "one of the processes didn't launch properly"
 	cleanup
 fi;
 
 if [ -n "$detached" ]
-then 
-  echo "launched detached docker containers: $elName, $clName"
+then  
+  echo "launched detached containers: $terminalInfo"
 else 
   echo "exiting ..."
 fi;


### PR DESCRIPTION
**Motivation**
Allow anyone to spin up validator fast on the kiln testnet using mnemonic.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR updates the setup scripts for anyone to participate in the testnet validation process using mnemonic from which deposits have been made to the deposit contract.
**Description**
- `--withValidator` (optional): Launch a validator client using `LODESTAR_VALIDATOR_ARGS` as set in the devnet vars file.

Example args to be set in the devnet vars file for .e.g
```
LODESTAR_VALIDATOR_ARGS='--network kiln  --fromMnemonic "lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow" --mnemonicIndexes 0..5
```