### PR TITLE
Cleanup test nodes on success and error

### DIFF
--- a/packages/lodestar/test/e2e/sync/wss.test.ts
+++ b/packages/lodestar/test/e2e/sync/wss.test.ts
@@ -1,4 +1,3 @@
-import {assert} from "chai";
 import {GENESIS_SLOT, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {phase0, Slot} from "@chainsafe/lodestar-types";
 import {initBLS} from "@chainsafe/lodestar-cli/src/util";
@@ -26,13 +25,8 @@ describe("Start from WSS", function () {
     await initBLS();
   });
 
-  const afterEachCallbacks: (() => Promise<unknown> | void)[] = [];
-  afterEach(async () => {
-    while (afterEachCallbacks.length > 0) {
-      const callback = afterEachCallbacks.pop();
-      if (callback) await callback();
-    }
-  });
+  const afterEachCallbacks: (() => Promise<unknown> | unknown)[] = [];
+  afterEach(async () => Promise.all(afterEachCallbacks.splice(0, afterEachCallbacks.length)));
 
   it("using another node", async function () {
     // Should reach justification in 3 epochs max, and finalization in 4 epochs max
@@ -133,10 +127,6 @@ describe("Start from WSS", function () {
 
     await connect(bnStartingFromWSS.network as Network, bn.network.peerId, bn.network.localMultiaddrs);
 
-    try {
-      await waitForSynced;
-    } catch (e) {
-      assert.fail("Failed to backfill sync to other node in time");
-    }
+    await waitForSynced;
   });
 });


### PR DESCRIPTION
**Motivation**

e2e or sim tests that run nodes are not cleaning up properly.

current code
```ts
const node = await start()
await runTest(node) // may throw
await node.cleanup()
```

If the test fails resources are not cleanup.

This PR does
```ts
const node = await start()
afterEachCallbacks.push(() => node.cleanup())
await runTest(node) // may throw
```

So whether the test succeeds or fails, clean up step is always called

**Description**

- Cleanup test nodes on success and error