### PR TITLE
Return peer count

### DIFF
--- a/packages/lodestar/src/api/impl/node/index.ts
+++ b/packages/lodestar/src/api/impl/node/index.ts
@@ -1,6 +1,6 @@
 import {routes} from "@chainsafe/lodestar-api";
 import {createKeypairFromPeerId} from "@chainsafe/discv5";
-import {formatNodePeer} from "./utils";
+import {formatNodePeer, getRevelantConnection} from "./utils";
 import {ApiError} from "../errors";
 import {ApiModules} from "../types";
 import {IApiOptions} from "../../options";
@@ -57,22 +57,22 @@ export function getNodeApi(opts: IApiOptions, {network, sync}: Pick<ApiModules, 
       let disconnecting = 0;
 
       for (const connections of network.getConnectionsByPeer().values()) {
-        for (const connection of connections) {
-          switch (connection.stat.status) {
-            case "open":
-              connected++;
-              break;
-            case "closing":
-              disconnecting++;
-              break;
-            case "closed":
-              disconnected++;
-              break;
-            default:
-              connecting++;
-          }
+        const relevantConnection = getRevelantConnection(connections);
+        switch (relevantConnection?.stat.status) {
+          case "open":
+            connected++;
+            break;
+          case "closing":
+            disconnecting++;
+            break;
+          case "closed":
+            disconnected++;
+            break;
+          default:
+            connecting++;
         }
       }
+
       return {
         data: {
           disconnected,

--- a/packages/lodestar/src/api/impl/node/index.ts
+++ b/packages/lodestar/src/api/impl/node/index.ts
@@ -51,6 +51,7 @@ export function getNodeApi(opts: IApiOptions, {network, sync}: Pick<ApiModules, 
     },
 
     async getPeerCount() {
+      // TODO: Implement disconnect count with on-disk persistence
       let disconnected = 0;
       let connecting = 0;
       let connected = 0;

--- a/packages/lodestar/src/api/impl/node/index.ts
+++ b/packages/lodestar/src/api/impl/node/index.ts
@@ -51,13 +51,34 @@ export function getNodeApi(opts: IApiOptions, {network, sync}: Pick<ApiModules, 
     },
 
     async getPeerCount() {
-      // TODO: Implement
+      let disconnected = 0;
+      let connecting = 0;
+      let connected = 0;
+      let disconnecting = 0;
+
+      for (const connections of network.getConnectionsByPeer().values()) {
+        for (const connection of connections) {
+          switch (connection.stat.status) {
+            case "open":
+              connected++;
+              break;
+            case "closing":
+              disconnecting++;
+              break;
+            case "closed":
+              disconnected++;
+              break;
+            default:
+              connecting++;
+          }
+        }
+      }
       return {
         data: {
-          disconnected: 0,
-          connecting: 0,
-          connected: 0,
-          disconnecting: 0,
+          disconnected,
+          connecting,
+          connected,
+          disconnecting,
         },
       };
     },

--- a/packages/lodestar/src/api/impl/node/utils.ts
+++ b/packages/lodestar/src/api/impl/node/utils.ts
@@ -24,7 +24,7 @@ export function formatNodePeer(peerIdStr: string, connections: Connection[]): ro
  * - Otherwise, the first closing connection
  * - Otherwise, the first closed connection
  */
-function getRevelantConnection(connections: Connection[]): Connection | null {
+export function getRevelantConnection(connections: Connection[]): Connection | null {
   const byStatus = new Map<PeerStatus, Connection>();
   for (const conn of connections) {
     if (conn.stat.status === "open") return conn;

--- a/packages/lodestar/test/unit/api/impl/node/node.test.ts
+++ b/packages/lodestar/test/unit/api/impl/node/node.test.ts
@@ -81,6 +81,47 @@ describe("node api implementation", function () {
     });
   });
 
+  describe("getPeerCount", function () {
+    let peer1: PeerId, peer2: PeerId, peer3: PeerId;
+
+    before(async function () {
+      peer1 = await createPeerId();
+      peer2 = await createPeerId();
+      peer3 = await createPeerId();
+    });
+
+    it("it should return peer count", async function () {
+      const connectionsByPeer = new Map<string, Connection[]>([
+        [peer1.toB58String(), [libp2pConnection(peer1, "open", "outbound")]],
+        [
+          peer2.toB58String(),
+          [libp2pConnection(peer2, "closing", "inbound"), libp2pConnection(peer2, "closing", "inbound")],
+        ],
+        [
+          peer3.toB58String(),
+          [
+            libp2pConnection(peer3, "closed", "inbound"),
+            libp2pConnection(peer3, "closed", "inbound"),
+            libp2pConnection(peer3, "closed", "inbound"),
+          ],
+        ],
+      ]);
+
+      networkStub.getConnectionsByPeer.returns(connectionsByPeer);
+
+      const {data: count} = await api.getPeerCount();
+      expect(count).to.be.deep.equal(
+        {
+          connected: 1,
+          disconnecting: 2,
+          disconnected: 3,
+          connecting: 0,
+        },
+        "getPeerCount incorrect"
+      );
+    });
+  });
+
   describe("getPeers", function () {
     let peer1: PeerId, peer2: PeerId;
 

--- a/packages/lodestar/test/unit/api/impl/node/node.test.ts
+++ b/packages/lodestar/test/unit/api/impl/node/node.test.ts
@@ -113,8 +113,8 @@ describe("node api implementation", function () {
       expect(count).to.be.deep.equal(
         {
           connected: 1,
-          disconnecting: 2,
-          disconnected: 3,
+          disconnecting: 1, // picks most relevant connection to count
+          disconnected: 1, // picks most relevant connection to count
           connecting: 0,
         },
         "getPeerCount incorrect"


### PR DESCRIPTION
**Motivation**

Implements the endpoint to get the peer count which was not implemented before

Closes #3857 

**Steps to test or reproduce**

`curl localhost:9596/eth/v1/node/peer_count` should not return just 0 for all values
