### PR TITLE
Bump gossipsub to 0.13.2

### DIFF
--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -96,7 +96,7 @@
     "jwt-simple": "0.5.6",
     "libp2p": "^0.36.2",
     "libp2p-bootstrap": "^0.14.0",
-    "libp2p-gossipsub": "^0.13.0",
+    "libp2p-gossipsub": "^0.13.2",
     "libp2p-interfaces": "^4.0.4",
     "libp2p-mdns": "^0.18.0",
     "libp2p-mplex": "^0.10.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7164,10 +7164,10 @@ libp2p-crypto@^0.21.2:
     protobufjs "^6.11.2"
     uint8arrays "^3.0.0"
 
-libp2p-gossipsub@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/libp2p-gossipsub/-/libp2p-gossipsub-0.13.0.tgz#a70db85139c62d7a8ad273be3ba01d1c9f338f7b"
-  integrity sha512-xy2jRZGmJpjy++Di6f1admtjve8Fx0z5l8NISTQS282egwbRMmTPE6/UeYktb6hNGAgtSTIwXdHjXmMOiTarFA==
+libp2p-gossipsub@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/libp2p-gossipsub/-/libp2p-gossipsub-0.13.2.tgz#3a21d3556f8fb832d8659fdfee118b43da2ba3e7"
+  integrity sha512-r2i+GM5m58IDSIMP/9fv3L0/3V2Bci3NsVnlWEyxptcpUcUt7Dif5FN1lsiFPIkCtjks+OmhWPQmMM/7J/a6Rg==
   dependencies:
     "@types/debug" "^4.1.7"
     debug "^4.3.1"


### PR DESCRIPTION
Upstream fix in floodpublish logic that may affect attestation propagation