### PR TITLE
Compute score using lodestar score and gossipsub score

### DIFF
--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -96,7 +96,7 @@
     "jwt-simple": "0.5.6",
     "libp2p": "^0.36.2",
     "libp2p-bootstrap": "^0.14.0",
-    "libp2p-gossipsub": "tuyennhv/js-libp2p-gossipsub#6a9965ecf095182c05808f2064f3a63d95ce707c",
+    "libp2p-gossipsub": "tuyennhv/js-libp2p-gossipsub#4b14a2640d23cbe3a8352cb9fd4b9ebb058f61f9",
     "libp2p-mdns": "^0.18.0",
     "libp2p-mplex": "^0.10.5",
     "libp2p-tcp": "^0.17.2",

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -1,7 +1,7 @@
 import Libp2p from "libp2p";
 import Gossipsub from "libp2p-gossipsub";
 import {GossipsubMessage, SignaturePolicy, TopicStr} from "libp2p-gossipsub/src/types";
-import {PeerScore} from "libp2p-gossipsub/src/score";
+import {PeerScore, PeerScoreParams} from "libp2p-gossipsub/src/score";
 import PeerId from "peer-id";
 import {AbortSignal} from "@chainsafe/abort-controller";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
@@ -76,6 +76,7 @@ export type Eth2GossipsubOpts = {
  */
 export class Eth2Gossipsub extends Gossipsub {
   readonly jobQueues: GossipJobQueues;
+  readonly scoreParams: Partial<PeerScoreParams>;
   private readonly config: IBeaconConfig;
   private readonly logger: ILogger;
 
@@ -109,6 +110,7 @@ export class Eth2Gossipsub extends Gossipsub {
       metricsRegister: modules.metrics ? ((modules.metrics.register as unknown) as MetricsRegister) : null,
       metricsTopicStrToLabel: modules.metrics ? getMetricsTopicStrToLabel(modules.config) : undefined,
     });
+    this.scoreParams = scoreParams;
     const {config, logger, metrics, signal, gossipHandlers} = modules;
     this.config = config;
     this.logger = logger;
@@ -145,6 +147,7 @@ export class Eth2Gossipsub extends Gossipsub {
     this.logger.verbose("Publish to topic", {topic: topicStr});
     const sszType = getGossipSSZType(topic);
     const messageData = (sszType.serialize as (object: GossipTypeMap[GossipType]) => Uint8Array)(object);
+    // TODO: log number of sent peers
     await this.publish(topicStr, messageData);
   }
 

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -94,6 +94,7 @@ export class Network implements INetwork {
       {
         libp2p,
         reqResp: this.reqResp,
+        gossip: this.gossip,
         attnetsService: this.attnetsService,
         syncnetsService: this.syncnetsService,
         logger,

--- a/packages/lodestar/src/network/peers/score.ts
+++ b/packages/lodestar/src/network/peers/score.ts
@@ -230,3 +230,31 @@ export class PeerScore {
     }
   }
 }
+
+/**
+ * Utility to update gossipsub score of connected peers
+ */
+export function updateGossipsubScores(
+  peerRpcScores: IPeerRpcScoreStore,
+  gossipsubScores: Map<string, number>,
+  toIgnoreNegativePeers: number
+): void {
+  // sort by gossipsub score desc
+  const sortedPeerIds = Array.from(gossipsubScores.keys()).sort(
+    (a, b) => (gossipsubScores.get(b) ?? 0) - (gossipsubScores.get(a) ?? 0)
+  );
+  for (const peerId of sortedPeerIds) {
+    const gossipsubScore = gossipsubScores.get(peerId);
+    if (gossipsubScore !== undefined) {
+      let ignore = false;
+      if (gossipsubScore < 0 && toIgnoreNegativePeers > 0) {
+        // We ignore the negative score for the best negative peers so that their
+        // gossipsub score can recover without getting disconnected.
+        ignore = true;
+        toIgnoreNegativePeers -= 1;
+      }
+
+      peerRpcScores.updateGossipsubScore(peerId, gossipsubScore, ignore);
+    }
+  }
+}

--- a/packages/lodestar/src/network/peers/score.ts
+++ b/packages/lodestar/src/network/peers/score.ts
@@ -123,7 +123,8 @@ export class PeerRpcScoreStore implements IPeerRpcScoreStore {
   }
 
   updateGossipsubScore(peerId: PeerIdStr, newScore: number, ignore: boolean): void {
-    this.scores.get(peerId)?.updateGossipsubScore(newScore, ignore);
+    const peerScore = this.scores.getOrDefault(peerId);
+    peerScore.updateGossipsubScore(newScore, ignore);
   }
 }
 

--- a/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
@@ -5,7 +5,7 @@ import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/default";
 import {IReqResp, ReqRespMethod} from "../../../../src/network/reqresp";
 import {PeerRpcScoreStore, PeerManager} from "../../../../src/network/peers";
-import {NetworkEvent, NetworkEventBus} from "../../../../src/network";
+import {Eth2Gossipsub, NetworkEvent, NetworkEventBus} from "../../../../src/network";
 import {createNode, getAttnets, getSyncnets} from "../../../utils/network";
 import {MockBeaconChain} from "../../../utils/mocks/chain/chain";
 import {generateEmptySignedBlock} from "../../../utils/block";
@@ -82,6 +82,7 @@ describe("network / peers / PeerManager", function () {
         networkEventBus,
         attnetsService: mockSubnetsService,
         syncnetsService: mockSubnetsService,
+        gossip: ({getScore: () => 0, scoreParams: {decayInterval: 1000}} as unknown) as Eth2Gossipsub,
       },
       {
         targetPeers: 30,

--- a/packages/lodestar/test/unit/network/peers/score.test.ts
+++ b/packages/lodestar/test/unit/network/peers/score.test.ts
@@ -8,7 +8,9 @@ describe("simple block provider score tracking", function () {
 
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   function mockStore() {
-    return {scoreStore: new PeerRpcScoreStore()};
+    const scoreStore = new PeerRpcScoreStore();
+    const peerScores = scoreStore["scores"];
+    return {scoreStore, peerScores};
   }
 
   it("Should return default score, without any previous action", function () {
@@ -40,9 +42,12 @@ describe("simple block provider score tracking", function () {
   ];
   for (const [minScore, timeToDecay] of decayTimes)
     it(`Should decay MIN_SCORE to ${minScore} after ${timeToDecay} ms`, () => {
-      const {scoreStore} = mockStore();
-      scoreStore["scores"].set(peer.toB58String(), MIN_SCORE);
-      scoreStore["lastUpdate"].set(peer.toB58String(), Date.now() - timeToDecay * factorForJsBadMath);
+      const {scoreStore, peerScores} = mockStore();
+      const peerScore = peerScores.get(peer.toB58String());
+      if (peerScore) {
+        peerScore["lastUpdate"] = Date.now() - timeToDecay * factorForJsBadMath;
+        peerScore["lodestarScore"] = MIN_SCORE;
+      }
       scoreStore.update();
       expect(scoreStore.getScore(peer)).to.be.greaterThan(minScore);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7172,9 +7172,9 @@ libp2p-crypto@^0.21.2:
     protobufjs "^6.11.2"
     uint8arrays "^3.0.0"
 
-libp2p-gossipsub@tuyennhv/js-libp2p-gossipsub#6a9965ecf095182c05808f2064f3a63d95ce707c:
+libp2p-gossipsub@tuyennhv/js-libp2p-gossipsub#4b14a2640d23cbe3a8352cb9fd4b9ebb058f61f9:
   version "0.13.1"
-  resolved "https://codeload.github.com/tuyennhv/js-libp2p-gossipsub/tar.gz/6a9965ecf095182c05808f2064f3a63d95ce707c"
+  resolved "https://codeload.github.com/tuyennhv/js-libp2p-gossipsub/tar.gz/4b14a2640d23cbe3a8352cb9fd4b9ebb058f61f9"
   dependencies:
     "@types/debug" "^4.1.7"
     debug "^4.3.1"


### PR DESCRIPTION
**Motivation**

Some gossipsub peers' behavior is so bad that we'd like to disconnect them before others

**Description**

+ Compute final score using both lodestar score and gossipsub score
+ Lodestar score is decayed periodically
+ Pull scores from gossipsub periodically to update `PeerRpcScoreStore`
+ When we disconnect peers we choose peers with worse score (already existing feature), so this helps disconnect bad behavior gossip peers
