### PR TITLE
Implement standard keymanager API - review

### DIFF
--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -105,9 +105,16 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
   await validator.start();
 
   // Start keymanager API backend
-  // Only if keymanagerEnabled flag is set to true and at least one keystore path is supplied
-  const firstImportKeystorePath = args.importKeystoresPath?.[0];
-  if (args.keymanagerEnabled && firstImportKeystorePath) {
+  // Only if keymanagerEnabled flag is set to true
+  if (args.keymanagerEnabled) {
+    if (!args.importKeystoresPath || args.importKeystoresPath.length === 0) {
+      throw new YargsError("For keymanagerEnabled must set importKeystoresPath to at least 1 path");
+    }
+
+    // Use the first path in importKeystoresPath as directory to write keystores
+    // KeymanagerApi must ensure that the path is a directory and not a file
+    const firstImportKeystorePath = args.importKeystoresPath[0];
+
     const keymanagerApi = new KeymanagerApi(logger, validator, firstImportKeystorePath);
 
     const keymanagerServer = new KeymanagerServer(

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -115,7 +115,7 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
     // KeymanagerApi must ensure that the path is a directory and not a file
     const firstImportKeystorePath = args.importKeystoresPath[0];
 
-    const keymanagerApi = new KeymanagerApi(logger, validator, firstImportKeystorePath);
+    const keymanagerApi = new KeymanagerApi(validator, firstImportKeystorePath);
 
     const keymanagerServer = new KeymanagerServer(
       {

--- a/packages/cli/src/validatorDir/ValidatorDir.ts
+++ b/packages/cli/src/validatorDir/ValidatorDir.ts
@@ -3,14 +3,13 @@ import path from "node:path";
 import bls, {SecretKey} from "@chainsafe/bls";
 import {Keystore} from "@chainsafe/bls-keystore";
 import {phase0} from "@chainsafe/lodestar-types";
-import {getLockFile} from "@chainsafe/lodestar-keymanager-server";
+import {lockFilepath, unlockFilepath} from "@chainsafe/lodestar-keymanager-server";
 import {YargsError, readValidatorPassphrase} from "../util";
 import {decodeEth1TxData} from "../depositContract/depositData";
 import {add0xPrefix} from "../util/format";
 import {
   VOTING_KEYSTORE_FILE,
   WITHDRAWAL_KEYSTORE_FILE,
-  LOCK_FILE,
   ETH1_DEPOSIT_DATA_FILE,
   ETH1_DEPOSIT_AMOUNT_FILE,
   ETH1_DEPOSIT_TX_HASH_FILE,
@@ -50,23 +49,21 @@ export interface IEth1DepositData {
  * ```
  */
 export class ValidatorDir {
-  dir: string;
-  private lockfilePath: string;
+  private readonly dirpath: string;
 
   /**
    * Open `dir`, creating a lockfile to prevent concurrent access.
    * Errors if there is a filesystem error or if a lockfile already exists
-   * @param dir
    */
   constructor(baseDir: string, pubkey: string, options?: IValidatorDirOptions) {
-    this.dir = path.join(baseDir, add0xPrefix(pubkey));
-    this.lockfilePath = path.join(this.dir, LOCK_FILE);
+    this.dirpath = path.join(baseDir, add0xPrefix(pubkey));
 
-    if (!fs.existsSync(this.dir)) throw new YargsError(`Validator directory ${this.dir} does not exist`);
+    if (!fs.existsSync(this.dirpath)) {
+      throw new YargsError(`Validator directory ${this.dirpath} does not exist`);
+    }
 
-    const lockFile = getLockFile();
     try {
-      lockFile.lockSync(this.lockfilePath);
+      lockFilepath(this.dirpath);
     } catch (e) {
       if (options && options.force) {
         // Ignore error, maybe log?
@@ -80,7 +77,7 @@ export class ValidatorDir {
    * Removes the lockfile associated with this validator dir
    */
   close(): void {
-    getLockFile().unlockSync(this.lockfilePath);
+    unlockFilepath(this.dirpath);
   }
 
   /**
@@ -91,7 +88,7 @@ export class ValidatorDir {
    * @param secretsDir
    */
   async votingKeypair(secretsDir: string): Promise<SecretKey> {
-    const keystorePath = path.join(this.dir, VOTING_KEYSTORE_FILE);
+    const keystorePath = path.join(this.dirpath, VOTING_KEYSTORE_FILE);
     return await this.unlockKeypair(keystorePath, secretsDir);
   }
 
@@ -103,7 +100,7 @@ export class ValidatorDir {
    * @param secretsDir
    */
   async withdrawalKeypair(secretsDir: string): Promise<SecretKey> {
-    const keystorePath = path.join(this.dir, WITHDRAWAL_KEYSTORE_FILE);
+    const keystorePath = path.join(this.dirpath, WITHDRAWAL_KEYSTORE_FILE);
     return await this.unlockKeypair(keystorePath, secretsDir);
   }
 
@@ -127,14 +124,14 @@ export class ValidatorDir {
    * when relying upon this value.
    */
   eth1DepositTxHashExists(): boolean {
-    return fs.existsSync(path.join(this.dir, ETH1_DEPOSIT_TX_HASH_FILE));
+    return fs.existsSync(path.join(this.dirpath, ETH1_DEPOSIT_TX_HASH_FILE));
   }
 
   /**
    * Saves the `tx_hash` to a file in `this.dir`.
    */
   saveEth1DepositTxHash(txHash: string): void {
-    const filepath = path.join(this.dir, ETH1_DEPOSIT_TX_HASH_FILE);
+    const filepath = path.join(this.dirpath, ETH1_DEPOSIT_TX_HASH_FILE);
 
     if (fs.existsSync(filepath)) throw new YargsError(`ETH1_DEPOSIT_TX_HASH_FILE ${filepath} already exists`);
 
@@ -146,8 +143,8 @@ export class ValidatorDir {
    * submitting an Eth1 deposit.
    */
   eth1DepositData(): IEth1DepositData {
-    const depositDataPath = path.join(this.dir, ETH1_DEPOSIT_DATA_FILE);
-    const depositAmountPath = path.join(this.dir, ETH1_DEPOSIT_AMOUNT_FILE);
+    const depositDataPath = path.join(this.dirpath, ETH1_DEPOSIT_DATA_FILE);
+    const depositAmountPath = path.join(this.dirpath, ETH1_DEPOSIT_AMOUNT_FILE);
     const depositDataRlp = fs.readFileSync(depositDataPath, "utf8");
     const depositAmount = fs.readFileSync(depositAmountPath, "utf8");
 

--- a/packages/cli/src/validatorDir/paths.ts
+++ b/packages/cli/src/validatorDir/paths.ts
@@ -6,10 +6,6 @@ export const WITHDRAWAL_KEYSTORE_FILE = "withdrawal-keystore.json";
 export const ETH1_DEPOSIT_DATA_FILE = "eth1-deposit-data.rlp";
 export const ETH1_DEPOSIT_AMOUNT_FILE = "eth1-deposit-gwei.txt";
 export const ETH1_DEPOSIT_TX_HASH_FILE = "eth1-deposit-tx-hash.txt";
-/**
- * The file used for indicating if a directory is in-use by another process.
- */
-export const LOCK_FILE = ".lock";
 
 // Dynamic paths computed from the validator pubkey
 

--- a/packages/keymanager-server/src/impl.ts
+++ b/packages/keymanager-server/src/impl.ts
@@ -60,9 +60,9 @@ export class KeymanagerApi implements Api {
    * Users SHOULD send slashing_protection data associated with the imported pubkeys. MUST follow the format defined in
    * EIP-3076: Slashing Protection Interchange Format.
    *
-   * @param keystores JSON-encoded keystore files generated with the Launchpad
+   * @param keystoresStr JSON-encoded keystore files generated with the Launchpad
    * @param passwords Passwords to unlock imported keystore files. `passwords[i]` must unlock `keystores[i]`
-   * @param slashingProtection Slashing protection data for some of the keys of `keystores`
+   * @param slashingProtectionStr Slashing protection data for some of the keys of `keystores`
    * @returns Status result of each `request.keystores` with same length and order of `request.keystores`
    *
    * https://github.com/ethereum/keymanager-APIs/blob/0c975dae2ac6053c8245ebdb6a9f27c2f114f407/keymanager-oapi.yaml
@@ -77,7 +77,7 @@ export class KeymanagerApi implements Api {
       message?: string;
     }[];
   }> {
-    const interchange = (slashingProtectionStr as unknown) as Interchange;
+    const interchange = JSON.parse(slashingProtectionStr) as Interchange;
     await this.validator.validatorStore.importInterchange(interchange);
 
     const statuses: {status: ImportStatus; message?: string}[] = [];
@@ -134,7 +134,7 @@ export class KeymanagerApi implements Api {
    * Slashing protection data must only be returned for keys from `request.pubkeys` for which a
    * `deleted` or `not_active` status is returned.
    *
-   * @param pubkeys List of public keys to delete.
+   * @param pubkeysHex List of public keys to delete.
    * @returns Deletion status of all keys in `request.pubkeys` in the same order.
    *
    * https://github.com/ethereum/keymanager-APIs/blob/0c975dae2ac6053c8245ebdb6a9f27c2f114f407/keymanager-oapi.yaml

--- a/packages/keymanager-server/src/impl.ts
+++ b/packages/keymanager-server/src/impl.ts
@@ -18,20 +18,17 @@ import {LOCK_FILE_EXT, getLockFile} from "./util/lockfile";
 export const KEY_IMPORTED_PREFIX = "key_imported";
 
 export class KeymanagerApi implements Api {
-  constructor(
-    private readonly logger: ILogger,
-    private readonly validator: Validator,
-    private readonly importKeystoresPath: string
-  ) {}
-
-  getKeystorePathInfoForKey = (pubkey: string): {keystoreFilePath: string; lockFilePath: string} => {
-    const keystoreFilename = `${KEY_IMPORTED_PREFIX}_${pubkey}.json`;
-    const keystoreFilePath = path.join(this.importKeystoresPath, keystoreFilename);
-    return {
-      keystoreFilePath,
-      lockFilePath: `${keystoreFilePath}${LOCK_FILE_EXT}`,
-    };
-  };
+  constructor(private readonly validator: Validator, private readonly importKeystoresPath: string) {
+    if (fs.existsSync(importKeystoresPath)) {
+      // Ensure is directory
+      if (!fs.statSync(importKeystoresPath).isDirectory()) {
+        throw Error("importKeystoresPath is not a directory");
+      }
+    } else {
+      // Or, create empty directory
+      fs.mkdirSync(importKeystoresPath, {recursive: true});
+    }
+  }
 
   /**
    * List all validating pubkeys known to and decrypted by this keymanager binary

--- a/packages/keymanager-server/src/impl.ts
+++ b/packages/keymanager-server/src/impl.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import {SecretKey} from "@chainsafe/bls";
 import {Keystore} from "@chainsafe/bls-keystore";
 import {
@@ -16,15 +17,15 @@ import {lockFilepath, unlockFilepath} from "./util/lockfile";
 export const KEY_IMPORTED_PREFIX = "key_imported";
 
 export class KeymanagerApi implements Api {
-  constructor(private readonly validator: Validator, private readonly importKeystoresPath: string) {
-    if (fs.existsSync(importKeystoresPath)) {
+  constructor(private readonly validator: Validator, private readonly importKeystoresDirpath: string) {
+    if (fs.existsSync(importKeystoresDirpath)) {
       // Ensure is directory
-      if (!fs.statSync(importKeystoresPath).isDirectory()) {
+      if (!fs.statSync(importKeystoresDirpath).isDirectory()) {
         throw Error("importKeystoresPath is not a directory");
       }
     } else {
       // Or, create empty directory
-      fs.mkdirSync(importKeystoresPath, {recursive: true});
+      fs.mkdirSync(importKeystoresDirpath, {recursive: true});
     }
   }
 
@@ -208,6 +209,6 @@ export class KeymanagerApi implements Api {
   }
 
   private getKeystoreFilepath(pubkeyHex: string): string {
-    return `${KEY_IMPORTED_PREFIX}_${pubkeyHex}.json`;
+    return path.join(this.importKeystoresDirpath, `${KEY_IMPORTED_PREFIX}_${pubkeyHex}.json`);
   }
 }

--- a/packages/keymanager-server/src/impl.ts
+++ b/packages/keymanager-server/src/impl.ts
@@ -76,7 +76,12 @@ export class KeymanagerApi implements Api {
       message?: string;
     }[];
   }> {
-    const interchange = JSON.parse(slashingProtectionStr) as Interchange;
+    // The arguments to this function is passed in within the body of an HTTP request
+    // hence fastify will parse it into an object before this function is called.
+    // Even though the slashingProtectionStr is typed as SlashingProtectionData,
+    // at runtime, when the handler for the request is selected, it would see slashingProtectionStr
+    // as an object, hence trying to parse it using JSON.parse won't work. Instead, we cast straight to Interchange
+    const interchange = (slashingProtectionStr as unknown) as Interchange;
     await this.validator.validatorStore.importInterchange(interchange);
 
     const statuses: {status: ImportStatus; message?: string}[] = [];

--- a/packages/keymanager-server/src/server.ts
+++ b/packages/keymanager-server/src/server.ts
@@ -47,9 +47,12 @@ export class KeymanagerServer {
 
   constructor(optsArg: Partial<RestApiOptions>, modules: IRestApiModules) {
     this.logger = modules.logger;
+
     // Apply opts defaults
     const opts = {
       ...restApiOptionsDefault,
+      // optsArg is a Partial type, any of its properties can be undefined. If port is set to undefined,
+      // it overrides the default port value in restApiOptionsDefault to be undefined.
       ...Object.fromEntries(Object.entries(optsArg).filter(([_, v]) => v != null)),
     };
 

--- a/packages/keymanager-server/src/util/lockfile.ts
+++ b/packages/keymanager-server/src/util/lockfile.ts
@@ -27,9 +27,7 @@ function getLockFile(): Lockfile {
  * @param filepath File to lock, i.e. `keystore_0001.json`
  */
 export function lockFilepath(filepath: string): void {
-  const lf = getLockFile();
-
-  lf.lockSync(getLockFilepath(filepath));
+  getLockFile().lockSync(getLockFilepath(filepath));
 }
 
 /**
@@ -37,9 +35,7 @@ export function lockFilepath(filepath: string): void {
  * @param filepath File to unlock, i.e. `keystore_0001.json`
  */
 export function unlockFilepath(filepath: string): void {
-  const lf = getLockFile();
-
   // Does not throw if the lock file is already deleted
   // https://github.com/npm/lockfile/blob/6590779867ee9bdc5dbebddc962640759892bb91/lockfile.js#L68
-  lf.unlockSync(getLockFilepath(filepath));
+  getLockFile().unlockSync(getLockFilepath(filepath));
 }

--- a/packages/keymanager-server/src/util/lockfile.ts
+++ b/packages/keymanager-server/src/util/lockfile.ts
@@ -5,15 +5,42 @@ type Lockfile = {
 
 let lockFile: Lockfile | null = null;
 export const LOCK_FILE_EXT = ".lock";
+
+export function getLockFilepath(filepath: string): string {
+  return `${filepath}.lock`;
+}
+
 /**
  * When lockfile it's required it registers listeners to process
  * Since it's only used by the validator client, require lazily to not pollute
  * beacon_node client context
  */
-export function getLockFile(): Lockfile {
+function getLockFile(): Lockfile {
   if (!lockFile) {
     // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
     lockFile = require("lockfile") as Lockfile;
   }
   return lockFile;
+}
+
+/**
+ * Creates a .lock file for `filepath`, argument passed must not be the lock path
+ * @param filepath File to lock, i.e. `keystore_0001.json`
+ */
+export function lockFilepath(filepath: string): void {
+  const lf = getLockFile();
+
+  lf.lockSync(getLockFilepath(filepath));
+}
+
+/**
+ * Deletes a .lock file for `filepath`, argument passed must not be the lock path
+ * @param filepath File to unlock, i.e. `keystore_0001.json`
+ */
+export function unlockFilepath(filepath: string): void {
+  const lf = getLockFile();
+
+  // Does not throw if the lock file is already deleted
+  // https://github.com/npm/lockfile/blob/6590779867ee9bdc5dbebddc962640759892bb91/lockfile.js#L68
+  lf.unlockSync(getLockFilepath(filepath));
 }

--- a/packages/keymanager-server/src/util/lockfile.ts
+++ b/packages/keymanager-server/src/util/lockfile.ts
@@ -4,9 +4,8 @@ type Lockfile = {
 };
 
 let lockFile: Lockfile | null = null;
-export const LOCK_FILE_EXT = ".lock";
 
-export function getLockFilepath(filepath: string): string {
+function getLockFilepath(filepath: string): string {
   return `${filepath}.lock`;
 }
 

--- a/packages/lodestar/test/e2e/keymanager/keymanager.test.ts
+++ b/packages/lodestar/test/e2e/keymanager/keymanager.test.ts
@@ -339,26 +339,25 @@ describe("keymanager delete and import test", async function () {
 
     afterEachCallbacks.push(() => Promise.all(validators.map((validator) => validator.stop())));
 
-    const keymanagerApi = new KeymanagerApi(validators[0], "/test/path");
-
-    const tokenDir = tmp.dirSync({unsafeCleanup: true});
+    const keystoresDir = tmp.dirSync({unsafeCleanup: true, prefix: "keystores"});
+    const tokenDir = tmp.dirSync({unsafeCleanup: true, prefix: "token"});
+    afterEachCallbacks.push(() => keystoresDir.removeCallback());
     afterEachCallbacks.push(() => tokenDir.removeCallback());
+
+    const keymanagerApi = new KeymanagerApi(validators[0], keystoresDir.name);
 
     return {config, validators, secretKeys, logger, keymanagerApi, tokenDir: tokenDir.name};
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   async function prepareTestSingleKeymanagerClient(opts?: PrepareTestOpts) {
-    const {config, secretKeys, logger, keymanagerApi} = await prepareTestSingleKeymanagerApi(opts);
+    const {config, secretKeys, logger, keymanagerApi, tokenDir} = await prepareTestSingleKeymanagerApi(opts);
 
     const kmPort = 10003;
 
-    const tokenDir = tmp.dirSync({unsafeCleanup: true});
-    afterEachCallbacks.push(() => tokenDir.removeCallback());
-
     // by default auth is on
     const keymanagerServer = new KeymanagerServer(
-      {host: "127.0.0.1", port: kmPort, cors: "*", tokenDir: tokenDir.name},
+      {host: "127.0.0.1", port: kmPort, cors: "*", tokenDir},
       {config, logger, api: keymanagerApi}
     );
 

--- a/packages/lodestar/test/e2e/keymanager/keymanager.test.ts
+++ b/packages/lodestar/test/e2e/keymanager/keymanager.test.ts
@@ -224,7 +224,7 @@ describe("keymanager delete and import test", async function () {
   });
 
   it("should not delete external signers", async function () {
-    const {client, secretKeys} = await prepareTestSingleKeymanagerClient({useRemoteSigner: true});
+    const {client, secretKeys} = await prepareTestSingleKeymanagerClient({useRemoteSigner: true, isAuthEnabled: false});
 
     expect((await client.listKeys()).data).to.be.deep.equal(
       [
@@ -306,7 +306,7 @@ describe("keymanager delete and import test", async function () {
     );
   });
 
-  type PrepareTestOpts = {useRemoteSigner?: boolean};
+  type PrepareTestOpts = {useRemoteSigner?: boolean; isAuthEnabled?: boolean};
 
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   async function prepareTestSingleKeymanagerApi(opts?: PrepareTestOpts) {
@@ -357,7 +357,7 @@ describe("keymanager delete and import test", async function () {
 
     // by default auth is on
     const keymanagerServer = new KeymanagerServer(
-      {host: "127.0.0.1", port: kmPort, cors: "*", tokenDir},
+      {host: "127.0.0.1", port: kmPort, cors: "*", tokenDir, isAuthEnabled: opts?.isAuthEnabled ?? true},
       {config, logger, api: keymanagerApi}
     );
 


### PR DESCRIPTION
**Motivation**

Post-merge review of https://github.com/ChainSafe/lodestar/pull/3522

**Description**

Fixes some potential issues:
- Improve CLI options, if keymanager is enabled require importKeystorePath
- [Explain KeymanagerServer opts merging](https://github.com/ChainSafe/lodestar/commit/f11081e69eefdb875fc593aa0355462df01199e5)
- [Ensure importKeystoresPath is a directory](https://github.com/ChainSafe/lodestar/commit/87d9bfb4725d9036802accdb643c3f6c3a342f81)
- [Parse slashingProtectionStr to JSON](https://github.com/ChainSafe/lodestar/commit/77c7fb183fce9b1bf93cb1732572e2afaf6ee307) @dadepo how could this work before? If the import should require a JSON
- [Improve keystore lock logic](https://github.com/ChainSafe/lodestar/commit/1b92d71af1c797261e6c9c8d81f0d6d8208bc762) define the path logic concatenation in a single place