### PR TITLE
Add light client finalized update route

### DIFF
--- a/packages/api/src/routes/events.ts
+++ b/packages/api/src/routes/events.ts
@@ -9,6 +9,13 @@ export type LightclientHeaderUpdate = {
   attestedHeader: phase0.BeaconBlockHeader;
 };
 
+export type LightclientFinalizedUpdate = {
+  attestedHeader: phase0.BeaconBlockHeader;
+  finalizedHeader: phase0.BeaconBlockHeader;
+  finalityBranch: Uint8Array[];
+  syncAggregate: altair.SyncAggregate;
+};
+
 export enum EventType {
   /**
    * The node has finished processing, resulting in a new head. previous_duty_dependent_root is

--- a/packages/api/src/routes/events.ts
+++ b/packages/api/src/routes/events.ts
@@ -1,5 +1,6 @@
 import {Epoch, phase0, Slot, ssz, StringType, RootHex, altair, UintNum64} from "@chainsafe/lodestar-types";
-import {ContainerType, Type} from "@chainsafe/ssz";
+import {ContainerType, Type, VectorCompositeType} from "@chainsafe/ssz";
+import {FINALIZED_ROOT_DEPTH} from "@chainsafe/lodestar-params";
 import {RouteDef, TypeJson} from "../utils";
 
 // See /packages/api/src/routes/index.ts for reasoning and instructions to add new routes
@@ -36,6 +37,8 @@ export enum EventType {
   chainReorg = "chain_reorg",
   /** New or better header update available */
   lightclientHeaderUpdate = "lightclient_header_update",
+  /** New or better finalized update available */
+  lightclientFinalizedUpdate = "lightclient_finalized_update",
 }
 
 export type EventData = {
@@ -61,6 +64,7 @@ export type EventData = {
     epoch: Epoch;
   };
   [EventType.lightclientHeaderUpdate]: LightclientHeaderUpdate;
+  [EventType.lightclientFinalizedUpdate]: LightclientFinalizedUpdate;
 };
 
 export type BeaconEvent = {[K in EventType]: {type: K; message: EventData[K]}}[EventType];
@@ -143,6 +147,15 @@ export function getTypeByEvent(): {[K in EventType]: Type<EventData[K]>} {
       {
         syncAggregate: ssz.altair.SyncAggregate,
         attestedHeader: ssz.phase0.BeaconBlockHeader,
+      },
+      {jsonCase: "eth2"}
+    ),
+    [EventType.lightclientFinalizedUpdate]: new ContainerType(
+      {
+        attestedHeader: ssz.phase0.BeaconBlockHeader,
+        finalizedHeader: ssz.phase0.BeaconBlockHeader,
+        finalityBranch: new VectorCompositeType(ssz.Bytes32, FINALIZED_ROOT_DEPTH),
+        syncAggregate: ssz.altair.SyncAggregate,
       },
       {jsonCase: "eth2"}
     ),

--- a/packages/api/src/routes/lightclient.ts
+++ b/packages/api/src/routes/lightclient.ts
@@ -46,7 +46,6 @@ export type Api = {
    * Returns the latest best head update available. Clients should use the SSE type `lightclient_header_update`
    * unless to get the very first head update after syncing, or if SSE are not supported by the server.
    */
-  getHeadUpdate(): Promise<{data: LightclientHeaderUpdate}>;
   getLatestHeadUpdate(): Promise<{data: LightclientHeaderUpdate}>;
   getLatestFinalizedHeadUpdate(): Promise<{data: LightclientFinalizedUpdate}>;
   /**
@@ -63,7 +62,6 @@ export type Api = {
 export const routesData: RoutesData<Api> = {
   getStateProof: {url: "/eth/v1/lightclient/proof/:stateId", method: "GET"},
   getCommitteeUpdates: {url: "/eth/v1/lightclient/committee_updates", method: "GET"},
-  getHeadUpdate: {url: "/eth/v1/lightclient/head_update/", method: "GET"},
   getLatestHeadUpdate: {url: "/eth/v1/lightclient/latest_head_update/", method: "GET"},
   getLatestFinalizedHeadUpdate: {url: "/eth/v1/lightclient/latest_finalized_head_update/", method: "GET"},
   getSnapshot: {url: "/eth/v1/lightclient/snapshot/:blockRoot", method: "GET"},
@@ -72,7 +70,6 @@ export const routesData: RoutesData<Api> = {
 export type ReqTypes = {
   getStateProof: {params: {stateId: string}; query: {paths: string[]}};
   getCommitteeUpdates: {query: {from: number; to: number}};
-  getHeadUpdate: ReqEmpty;
   getLatestHeadUpdate: ReqEmpty;
   getLatestFinalizedHeadUpdate: ReqEmpty;
   getSnapshot: {params: {blockRoot: string}};
@@ -92,7 +89,6 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
       schema: {query: {from: Schema.UintRequired, to: Schema.UintRequired}},
     },
 
-    getHeadUpdate: reqEmpty,
     getLatestHeadUpdate: reqEmpty,
     getLatestFinalizedHeadUpdate: reqEmpty,
 
@@ -136,7 +132,6 @@ export function getReturnTypes(): ReturnTypes<Api> {
     // Just sent the proof JSON as-is
     getStateProof: sameType(),
     getCommitteeUpdates: ContainerData(ArrayOf(ssz.altair.LightClientUpdate)),
-    getHeadUpdate: ContainerData(lightclientHeaderUpdate),
     getLatestHeadUpdate: ContainerData(lightclientHeaderUpdate),
     getLatestFinalizedHeadUpdate: ContainerData(lightclientFinalizedUpdate),
     getSnapshot: ContainerData(lightclientSnapshotWithProofType),

--- a/packages/api/src/routes/lightclient.ts
+++ b/packages/api/src/routes/lightclient.ts
@@ -48,7 +48,7 @@ export type Api = {
    */
   getHeadUpdate(): Promise<{data: LightclientHeaderUpdate}>;
   getLatestHeadUpdate(): Promise<{data: LightclientHeaderUpdate}>;
-  getFinalizedHeadUpdate(): Promise<{data: LightclientFinalizedUpdate}>;
+  getLatestFinalizedHeadUpdate(): Promise<{data: LightclientFinalizedUpdate}>;
   /**
    * Fetch a snapshot with a proof to a trusted block root.
    * The trusted block root should be fetched with similar means to a weak subjectivity checkpoint.
@@ -65,7 +65,7 @@ export const routesData: RoutesData<Api> = {
   getCommitteeUpdates: {url: "/eth/v1/lightclient/committee_updates", method: "GET"},
   getHeadUpdate: {url: "/eth/v1/lightclient/head_update/", method: "GET"},
   getLatestHeadUpdate: {url: "/eth/v1/lightclient/latest_head_update/", method: "GET"},
-  getFinalizedHeadUpdate: {url: "/eth/v1/lightclient/finalized_head_update/", method: "GET"},
+  getLatestFinalizedHeadUpdate: {url: "/eth/v1/lightclient/latest_finalized_head_update/", method: "GET"},
   getSnapshot: {url: "/eth/v1/lightclient/snapshot/:blockRoot", method: "GET"},
 };
 
@@ -74,7 +74,7 @@ export type ReqTypes = {
   getCommitteeUpdates: {query: {from: number; to: number}};
   getHeadUpdate: ReqEmpty;
   getLatestHeadUpdate: ReqEmpty;
-  getFinalizedHeadUpdate: ReqEmpty;
+  getLatestFinalizedHeadUpdate: ReqEmpty;
   getSnapshot: {params: {blockRoot: string}};
 };
 
@@ -94,7 +94,7 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
 
     getHeadUpdate: reqEmpty,
     getLatestHeadUpdate: reqEmpty,
-    getFinalizedHeadUpdate: reqEmpty,
+    getLatestFinalizedHeadUpdate: reqEmpty,
 
     getSnapshot: {
       writeReq: (blockRoot) => ({params: {blockRoot}}),
@@ -138,7 +138,7 @@ export function getReturnTypes(): ReturnTypes<Api> {
     getCommitteeUpdates: ContainerData(ArrayOf(ssz.altair.LightClientUpdate)),
     getHeadUpdate: ContainerData(lightclientHeaderUpdate),
     getLatestHeadUpdate: ContainerData(lightclientHeaderUpdate),
-    getFinalizedHeadUpdate: ContainerData(lightclientFinalizedUpdate),
+    getLatestFinalizedHeadUpdate: ContainerData(lightclientFinalizedUpdate),
     getSnapshot: ContainerData(lightclientSnapshotWithProofType),
   };
 }

--- a/packages/api/test/unit/lightclient.test.ts
+++ b/packages/api/test/unit/lightclient.test.ts
@@ -43,9 +43,20 @@ describe("lightclient", () => {
       args: [1, 2],
       res: {data: [lightClientUpdate]},
     },
-    getHeadUpdate: {
+    getLatestHeadUpdate: {
       args: [],
       res: {data: {syncAggregate, attestedHeader: header}},
+    },
+    getLatestFinalizedHeadUpdate: {
+      args: [],
+      res: {
+        data: {
+          syncAggregate,
+          attestedHeader: header,
+          finalizedHeader: lightClientUpdate.finalizedHeader,
+          finalityBranch: lightClientUpdate.finalityBranch,
+        },
+      },
     },
     getSnapshot: {
       args: [toHexString(root)],

--- a/packages/light-client/src/events.ts
+++ b/packages/light-client/src/events.ts
@@ -6,6 +6,10 @@ export enum LightclientEvent {
    */
   head = "head",
   /**
+   * New finalized
+   */
+  finalized = "finalized",
+  /**
    * Stored nextSyncCommittee from an update at period `period`.
    * Note: the SyncCommittee is stored for `period + 1`.
    */
@@ -14,6 +18,7 @@ export enum LightclientEvent {
 
 export type LightclientEvents = {
   [LightclientEvent.head]: (newHeader: phase0.BeaconBlockHeader) => void;
+  [LightclientEvent.finalized]: (newHeader: phase0.BeaconBlockHeader) => void;
   [LightclientEvent.committee]: (updatePeriod: SyncPeriod) => void;
 };
 

--- a/packages/light-client/src/index.ts
+++ b/packages/light-client/src/index.ts
@@ -284,10 +284,10 @@ export class Lightclient {
         // Fetch latest head to prevent a potential 12 seconds lag between syncing and getting the first head,
         // Don't retry, this is a non-critical UX improvement
         try {
-          const {data: latestHeadUpdate} = await this.api.lightclient.getHeadUpdate();
+          const {data: latestHeadUpdate} = await this.api.lightclient.getLatestHeadUpdate();
           this.processHeaderUpdate(latestHeadUpdate);
         } catch (e) {
-          this.logger.error("Error fetching getHeadUpdate", {currentPeriod}, e as Error);
+          this.logger.error("Error fetching getLatestHeadUpdate", {currentPeriod}, e as Error);
         }
       }
 
@@ -298,7 +298,7 @@ export class Lightclient {
         this.logger.debug("Started tracking the head");
 
         // Subscribe to head updates over SSE
-        // TODO: Use polling for getHeadUpdate() is SSE is unavailable
+        // TODO: Use polling for getLatestHeadUpdate() is SSE is unavailable
         this.api.events.eventstream([routes.events.EventType.lightclientHeaderUpdate], controller.signal, this.onSSE);
       }
 

--- a/packages/light-client/src/index.ts
+++ b/packages/light-client/src/index.ts
@@ -484,7 +484,7 @@ export class Lightclient {
           prevHeadRoot: prevFinalized.blockRoot,
         });
       }
-      this.logger.info("Head updated", {
+      this.logger.info("Finalized updated", {
         slot: finalizedHeader.slot,
         root: finalizedBlockRootHex,
       });

--- a/packages/light-client/src/validation.ts
+++ b/packages/light-client/src/validation.ts
@@ -9,6 +9,8 @@ import {
   DOMAIN_SYNC_COMMITTEE,
 } from "@chainsafe/lodestar-params";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
+import {routes} from "@chainsafe/lodestar-api";
+
 import {isValidMerkleBranch} from "./utils/verifyMerkleBranch";
 import {assertZeroHashes, getParticipantPubkeys, isEmptyHeader} from "./utils/utils";
 import {SyncCommitteeFast} from "./types";
@@ -62,7 +64,7 @@ export function assertValidLightClientUpdate(
  *
  * Where `hashTreeRoot(state) == update.finalityHeader.stateRoot`
  */
-export function assertValidFinalityProof(update: altair.LightClientUpdate): void {
+export function assertValidFinalityProof(update: routes.lightclient.LightclientFinalizedUpdate): void {
   if (
     !isValidMerkleBranch(
       ssz.phase0.BeaconBlockHeader.hashTreeRoot(update.finalizedHeader),

--- a/packages/light-client/test/lightclientApiServer.ts
+++ b/packages/light-client/test/lightclientApiServer.ts
@@ -44,6 +44,7 @@ export class LightclientServerApi implements routes.lightclient.Api {
   readonly updates = new Map<SyncPeriod, altair.LightClientUpdate>();
   readonly snapshots = new Map<RootHex, routes.lightclient.LightclientSnapshotWithProof>();
   latestHeadUpdate: routes.lightclient.LightclientHeaderUpdate | null = null;
+  finalized: routes.lightclient.LightclientFinalizedUpdate | null = null;
 
   async getStateProof(stateId: string, paths: JsonPath[]): Promise<{data: Proof}> {
     const state = this.states.get(stateId);
@@ -62,9 +63,14 @@ export class LightclientServerApi implements routes.lightclient.Api {
     return {data: updates};
   }
 
-  async getHeadUpdate(): Promise<{data: routes.lightclient.LightclientHeaderUpdate}> {
+  async getLatestHeadUpdate(): Promise<{data: routes.lightclient.LightclientHeaderUpdate}> {
     if (!this.latestHeadUpdate) throw Error("No latest head update");
     return {data: this.latestHeadUpdate};
+  }
+
+  async getLatestFinalizedHeadUpdate(): Promise<{data: routes.lightclient.LightclientFinalizedUpdate}> {
+    if (!this.finalized) throw Error("No finalized head update");
+    return {data: this.finalized};
   }
 
   async getSnapshot(blockRoot: string): Promise<{data: routes.lightclient.LightclientSnapshotWithProof}> {

--- a/packages/light-client/test/unit/sync.test.ts
+++ b/packages/light-client/test/unit/sync.test.ts
@@ -64,7 +64,7 @@ describe("Lightclient sync", () => {
       lightclientServerApi.updates.set(period, committeeUpdate);
     }
 
-    // So the first call to getHeadUpdate() doesn't error, store the latest snapshot as latest header update
+    // So the first call to getLatestHeadUpdate() doesn't error, store the latest snapshot as latest header update
     lightclientServerApi.latestHeadUpdate = committeeUpdateToHeadUpdate(lastInMap(lightclientServerApi.updates));
 
     // Initilize from snapshot

--- a/packages/light-client/test/unit/sync.test.ts
+++ b/packages/light-client/test/unit/sync.test.ts
@@ -11,7 +11,8 @@ import {
   computeLightClientSnapshot,
   getInteropSyncCommittee,
   testLogger,
-  committeeUpdateToHeadUpdate,
+  committeeUpdateToLatestHeadUpdate,
+  committeeUpdateToLatestFinalizedHeadUpdate,
   lastInMap,
 } from "../utils";
 import {toHexString} from "@chainsafe/ssz";
@@ -65,7 +66,10 @@ describe("Lightclient sync", () => {
     }
 
     // So the first call to getLatestHeadUpdate() doesn't error, store the latest snapshot as latest header update
-    lightclientServerApi.latestHeadUpdate = committeeUpdateToHeadUpdate(lastInMap(lightclientServerApi.updates));
+    lightclientServerApi.latestHeadUpdate = committeeUpdateToLatestHeadUpdate(lastInMap(lightclientServerApi.updates));
+    lightclientServerApi.finalized = committeeUpdateToLatestFinalizedHeadUpdate(
+      lastInMap(lightclientServerApi.updates)
+    );
 
     // Initilize from snapshot
     const lightclient = await Lightclient.initializeFromCheckpointRoot({

--- a/packages/light-client/test/utils.ts
+++ b/packages/light-client/test/utils.ts
@@ -252,11 +252,25 @@ export function computeMerkleBranch(
   return {root: value, proof};
 }
 
-export function committeeUpdateToHeadUpdate(
+export function committeeUpdateToLatestHeadUpdate(
   committeeUpdate: altair.LightClientUpdate
 ): routes.lightclient.LightclientHeaderUpdate {
   return {
     attestedHeader: committeeUpdate.attestedHeader,
+    syncAggregate: {
+      syncCommitteeBits: committeeUpdate.syncAggregate.syncCommitteeBits,
+      syncCommitteeSignature: committeeUpdate.syncAggregate.syncCommitteeSignature,
+    },
+  };
+}
+
+export function committeeUpdateToLatestFinalizedHeadUpdate(
+  committeeUpdate: altair.LightClientUpdate
+): routes.lightclient.LightclientFinalizedUpdate {
+  return {
+    attestedHeader: committeeUpdate.attestedHeader,
+    finalizedHeader: committeeUpdate.finalizedHeader,
+    finalityBranch: committeeUpdate.finalityBranch,
     syncAggregate: {
       syncCommitteeBits: committeeUpdate.syncAggregate.syncCommitteeBits,
       syncCommitteeSignature: committeeUpdate.syncAggregate.syncCommitteeSignature,

--- a/packages/lodestar/src/api/impl/events/index.ts
+++ b/packages/lodestar/src/api/impl/events/index.ts
@@ -20,6 +20,7 @@ const chainEventMap = {
   [routes.events.EventType.finalizedCheckpoint]: ChainEvent.finalized as const,
   [routes.events.EventType.chainReorg]: ChainEvent.forkChoiceReorg as const,
   [routes.events.EventType.lightclientHeaderUpdate]: ChainEvent.lightclientHeaderUpdate as const,
+  [routes.events.EventType.lightclientFinalizedUpdate]: ChainEvent.lightclientFinalizedUpdate as const,
 };
 
 export function getEventsApi({chain, config}: Pick<ApiModules, "chain" | "config">): routes.events.Api {
@@ -80,6 +81,7 @@ export function getEventsApi({chain, config}: Pick<ApiModules, "chain" | "config
       },
     ],
     [routes.events.EventType.lightclientHeaderUpdate]: (headerUpdate) => [headerUpdate],
+    [routes.events.EventType.lightclientFinalizedUpdate]: (headerUpdate) => [headerUpdate],
   };
 
   return {

--- a/packages/lodestar/src/api/impl/lightclient/index.ts
+++ b/packages/lodestar/src/api/impl/lightclient/index.ts
@@ -56,7 +56,7 @@ export function getLightclientApi(
       return {data: await chain.lightClientServer.getLatestHeadUpdate()};
     },
 
-    async getFinalizedHeadUpdate() {
+    async getLatestFinalizedHeadUpdate() {
       return {data: await chain.lightClientServer.getFinalizedHeadUpdate()};
     },
 

--- a/packages/lodestar/src/api/impl/lightclient/index.ts
+++ b/packages/lodestar/src/api/impl/lightclient/index.ts
@@ -49,7 +49,15 @@ export function getLightclientApi(
     },
 
     async getHeadUpdate() {
-      return {data: await chain.lightClientServer.getHeadUpdate()};
+      return {data: await chain.lightClientServer.getLatestHeadUpdate()};
+    },
+
+    async getLatestHeadUpdate() {
+      return {data: await chain.lightClientServer.getLatestHeadUpdate()};
+    },
+
+    async getFinalizedHeadUpdate() {
+      return {data: await chain.lightClientServer.getFinalizedHeadUpdate()};
     },
 
     async getSnapshot(blockRoot) {

--- a/packages/lodestar/src/api/impl/lightclient/index.ts
+++ b/packages/lodestar/src/api/impl/lightclient/index.ts
@@ -48,16 +48,12 @@ export function getLightclientApi(
       return {data: updates};
     },
 
-    async getHeadUpdate() {
-      return {data: await chain.lightClientServer.getLatestHeadUpdate()};
-    },
-
     async getLatestHeadUpdate() {
       return {data: await chain.lightClientServer.getLatestHeadUpdate()};
     },
 
     async getLatestFinalizedHeadUpdate() {
-      return {data: await chain.lightClientServer.getFinalizedHeadUpdate()};
+      return {data: await chain.lightClientServer.getLatestFinalizedHeadUpdate()};
     },
 
     async getSnapshot(blockRoot) {

--- a/packages/lodestar/src/chain/emitter.ts
+++ b/packages/lodestar/src/chain/emitter.ts
@@ -100,6 +100,7 @@ export enum ChainEvent {
    * A new lightclient header update is available to be broadcasted to connected light-clients
    */
   lightclientHeaderUpdate = "lightclient:header_update",
+  lightclientFinalizedUpdate = "lightclient:finalized_update",
 }
 
 export interface IChainEvents {
@@ -121,6 +122,7 @@ export interface IChainEvents {
   [ChainEvent.forkChoiceFinalized]: (checkpoint: CheckpointWithHex) => void;
 
   [ChainEvent.lightclientHeaderUpdate]: (headerUpdate: routes.events.LightclientHeaderUpdate) => void;
+  [ChainEvent.lightclientFinalizedUpdate]: (finalizedUpdate: routes.events.LightclientFinalizedUpdate) => void;
 }
 
 /**

--- a/packages/lodestar/src/chain/emitter.ts
+++ b/packages/lodestar/src/chain/emitter.ts
@@ -100,6 +100,9 @@ export enum ChainEvent {
    * A new lightclient header update is available to be broadcasted to connected light-clients
    */
   lightclientHeaderUpdate = "lightclient:header_update",
+  /**
+   * A new lightclient finalized header update is available to be broadcasted to connected light-clients
+   */
   lightclientFinalizedUpdate = "lightclient:finalized_update",
 }
 

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -54,6 +54,8 @@ export function handleChainEvents(this: BeaconChain, signal: AbortSignal): void 
     [ChainEvent.justified]: onJustified,
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     [ChainEvent.lightclientHeaderUpdate]: () => {},
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    [ChainEvent.lightclientFinalizedUpdate]: () => {},
   };
 
   const emitter = this.emitter;

--- a/packages/lodestar/src/chain/lightClient/index.ts
+++ b/packages/lodestar/src/chain/lightClient/index.ts
@@ -169,6 +169,10 @@ export class LightClientServer {
   private latestHeadUpdate: routes.lightclient.LightclientHeaderUpdate | null = null;
 
   private readonly zero: Pick<altair.LightClientUpdate, "finalityBranch" | "finalizedHeader">;
+  private finalized?: Pick<
+    altair.LightClientUpdate,
+    "finalityBranch" | "finalizedHeader" | "attestedHeader" | "syncAggregate"
+  >;
 
   constructor(modules: LightClientServerModules) {
     const {config, db, metrics, emitter, logger} = modules;
@@ -300,11 +304,19 @@ export class LightClientServer {
    * API ROUTE to poll LightclientHeaderUpdate.
    * Clients should use the SSE type `lightclient_header_update` if available
    */
-  async getHeadUpdate(): Promise<routes.lightclient.LightclientHeaderUpdate> {
+  async getLatestHeadUpdate(): Promise<routes.lightclient.LightclientHeaderUpdate> {
     if (this.latestHeadUpdate === null) {
       throw Error("No latest header update available");
     }
     return this.latestHeadUpdate;
+  }
+
+  async getFinalizedHeadUpdate(): Promise<routes.lightclient.LightclientFinalizedUpdate> {
+    // Signature data
+    if (this.finalized == null) {
+      throw Error("No latest header update available");
+    }
+    return this.finalized;
   }
 
   /**
@@ -445,6 +457,25 @@ export class LightClientServer {
     // TODO: Once SyncAggregate are constructed from P2P too, count bits to decide "best"
     if (!this.latestHeadUpdate || attestedData.attestedHeader.slot > this.latestHeadUpdate.attestedHeader.slot) {
       this.latestHeadUpdate = headerUpdate;
+    }
+
+    if (attestedData.isFinalized) {
+      const finalizedCheckpointRoot = attestedData.finalizedCheckpoint.root as Uint8Array;
+      const finalizedHeader = await this.getFinalizedHeader(finalizedCheckpointRoot);
+      if (
+        finalizedHeader &&
+        (!this.finalized ||
+          finalizedHeader.slot > this.finalized.finalizedHeader.slot ||
+          sumBits(syncAggregate.syncCommitteeBits) > sumBits(this.finalized.syncAggregate.syncCommitteeBits))
+      ) {
+        this.finalized = {
+          attestedHeader: attestedData.attestedHeader,
+          finalizedHeader,
+          syncAggregate,
+          finalityBranch: attestedData.finalityBranch,
+        };
+        this.emitter.emit(ChainEvent.lightclientFinalizedUpdate, this.finalized);
+      }
     }
 
     // Check if this update is better, otherwise ignore

--- a/packages/lodestar/src/chain/lightClient/index.ts
+++ b/packages/lodestar/src/chain/lightClient/index.ts
@@ -169,10 +169,7 @@ export class LightClientServer {
   private latestHeadUpdate: routes.lightclient.LightclientHeaderUpdate | null = null;
 
   private readonly zero: Pick<altair.LightClientUpdate, "finalityBranch" | "finalizedHeader">;
-  private finalized?: Pick<
-    altair.LightClientUpdate,
-    "finalityBranch" | "finalizedHeader" | "attestedHeader" | "syncAggregate"
-  >;
+  private finalized: routes.lightclient.LightclientFinalizedUpdate | null = null;
 
   constructor(modules: LightClientServerModules) {
     const {config, db, metrics, emitter, logger} = modules;
@@ -311,9 +308,9 @@ export class LightClientServer {
     return this.latestHeadUpdate;
   }
 
-  async getFinalizedHeadUpdate(): Promise<routes.lightclient.LightclientFinalizedUpdate> {
+  async getLatestFinalizedHeadUpdate(): Promise<routes.lightclient.LightclientFinalizedUpdate> {
     // Signature data
-    if (this.finalized == null) {
+    if (this.finalized === null) {
       throw Error("No latest header update available");
     }
     return this.finalized;
@@ -453,7 +450,7 @@ export class LightClientServer {
     // - After a new update has INCREMENT_THRESHOLD == 32 bits more than the previous emitted threshold
     this.emitter.emit(ChainEvent.lightclientHeaderUpdate, headerUpdate);
 
-    // Persist latest best update for getHeadUpdate()
+    // Persist latest best update for getLatestHeadUpdate()
     // TODO: Once SyncAggregate are constructed from P2P too, count bits to decide "best"
     if (!this.latestHeadUpdate || attestedData.attestedHeader.slot > this.latestHeadUpdate.attestedHeader.slot) {
       this.latestHeadUpdate = headerUpdate;


### PR DESCRIPTION
**Motivation**
Currently light client header update route/event provides the latest headers to the light clients, which can be used to check if the transactions have been included/mined in the blockchain head.
But second part of client would require is the confirmation of that, currently in eth1 land done by having `N`(for e.g. 12 for mainnet eth) confirmations, but post merge will be driven by the `finalization` of the checkpoints.

<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR aims to provide those finalized updates (likely 1 per epoch) to the light clients so that they can marry/proof it with EL (eth1) data, and confirm/release funds.
A finalized update is updated/evented when
- Finalized slot has moved forward
- A better finalized update is generated with more sync_aggregate bits.

TODOS:
- ~~[ ] More comments~~
- [x] Test cases to asset validity of finalized update 
- [x] Refactoring based on feedback