### PR TITLE
Track gossipValidationError metrics by specific error code

### DIFF
--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -254,6 +254,11 @@ export function createLodestarMetrics(
       help: "Count of total gossip validation reject",
       labelNames: ["topic"],
     }),
+    gossipValidationError: register.gauge<"topic" | "error">({
+      name: "lodestar_gossip_validation_error_total",
+      help: "Count of total gossip validation errors detailed",
+      labelNames: ["topic", "error"],
+    }),
 
     gossipValidationQueueLength: register.gauge<"topic">({
       name: "lodestar_gossip_validation_queue_length",

--- a/packages/lodestar/src/network/gossip/validation/index.ts
+++ b/packages/lodestar/src/network/gossip/validation/index.ts
@@ -101,6 +101,10 @@ function getGossipValidatorFn<K extends GossipType>(
       const metadata = gossipObject && getGossipObjectAcceptMetadata(config, gossipObject, topic);
       const errorData = {...metadata, ...e.getMetadata()};
 
+      // Metrics on specific error reason
+      // Note: LodestarError.code are bounded pre-declared error messages, not from arbitrary error.message
+      metrics?.gossipValidationError.inc({topic: type, error: (e as GossipActionError<{code: string}>).type.code});
+
       switch (e.action) {
         case GossipAction.IGNORE:
           logger.debug(`gossip - ${type} - ignore`, errorData);


### PR DESCRIPTION
**Motivation**

Current metrics show that we are penalizing peer heavily with [P4 penalties](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#p-invalid-messages). We need more visibility into why exactly this messages are invalid.

**Description**

- Track gossipValidationError metrics by specific error code.

Note: LodestarError.code are bounded pre-declared error messages, not from arbitrary error.message