### PR TITLE
Remove gossip validation result log

### DIFF
--- a/packages/lodestar/src/network/gossip/validation/onAccept.ts
+++ b/packages/lodestar/src/network/gossip/validation/onAccept.ts
@@ -1,5 +1,4 @@
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
-import {toHexString} from "@chainsafe/ssz";
 import {GossipType, GossipTypeMap, GossipTopicTypeMap} from "../interface";
 
 export type GetGossipAcceptMetadataFn = (
@@ -13,48 +12,4 @@ export type GetGossipAcceptMetadataFns = {
     object: GossipTypeMap[K],
     topic: GossipTopicTypeMap[K]
   ) => Record<string, string | number>;
-};
-
-/**
- * Return succint but meaningful data about accepted gossip objects.
- * This data is logged at the debug level extremely frequently so it must be short.
- */
-export const getGossipAcceptMetadataByType: GetGossipAcceptMetadataFns = {
-  [GossipType.beacon_block]: (config, signedBlock) => ({
-    slot: signedBlock.message.slot,
-    root: toHexString(config.getForkTypes(signedBlock.message.slot).BeaconBlock.hashTreeRoot(signedBlock.message)),
-  }),
-  [GossipType.beacon_aggregate_and_proof]: (config, aggregateAndProof) => {
-    const {data} = aggregateAndProof.message.aggregate;
-    return {
-      slot: data.slot,
-      index: data.index,
-    };
-  },
-  [GossipType.beacon_attestation]: (config, attestation, topic) => ({
-    slot: attestation.data.slot,
-    subnet: topic.subnet,
-    index: attestation.data.index,
-  }),
-  [GossipType.voluntary_exit]: (config, voluntaryExit) => ({
-    validatorIndex: voluntaryExit.message.validatorIndex,
-  }),
-  [GossipType.proposer_slashing]: (config, proposerSlashing) => ({
-    proposerIndex: proposerSlashing.signedHeader1.message.proposerIndex,
-  }),
-  [GossipType.attester_slashing]: (config, attesterSlashing) => ({
-    slot1: attesterSlashing.attestation1.data.slot,
-    slot2: attesterSlashing.attestation2.data.slot,
-  }),
-  [GossipType.sync_committee_contribution_and_proof]: (config, contributionAndProof) => {
-    const {contribution} = contributionAndProof.message;
-    return {
-      slot: contribution.slot,
-      index: contribution.subcommitteeIndex,
-    };
-  },
-  [GossipType.sync_committee]: (config, syncCommitteeSignature, topic) => ({
-    slot: syncCommitteeSignature.slot,
-    subnet: topic.subnet,
-  }),
 };


### PR DESCRIPTION
**Motivation**

+ The gossipsub result does not bring any value, especially after the new gossipsub gets merged, and we have a lot of nice metrics over there
+ It's hard to locate other logs, for example the attestation journey of validators
+ The log file is quite big right now, it's 4GB per day

**Description**

+ Remove gossip result log
