### PR TITLE
Cache selectionProofs

### DIFF
--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -230,11 +230,11 @@ export class ValidatorStore {
     };
   }
 
-  async signAttestationSelectionProof(pubkey: BLSPubkey, slot: Slot): Promise<BLSSignature> {
+  async signAttestationSelectionProof(pubkeyHex: PubkeyHex, slot: Slot): Promise<BLSSignature> {
     const domain = this.config.getDomain(DOMAIN_SELECTION_PROOF, slot);
     const signingRoot = computeSigningRoot(ssz.Slot, slot, domain);
 
-    return await this.getSignature(pubkey, signingRoot);
+    return await this.getSignature(pubkeyHex, signingRoot);
   }
 
   async signSyncCommitteeSelectionProof(

--- a/packages/validator/test/unit/services/attestationDuties.test.ts
+++ b/packages/validator/test/unit/services/attestationDuties.test.ts
@@ -115,6 +115,12 @@ describe("AttestationDutiesService", function () {
       },
       "Wrong dutiesService.attesters Map at next epoch"
     );
+    expect(Object.fromEntries(dutiesService["selectionProofs"].get(duty.slot) || new Map())).to.deep.equal(
+      {
+        [toHexString(pubkeys[0])]: ZERO_HASH,
+      },
+      "Wrong dutiesService.selectionProofs"
+    );
 
     expect(dutiesService.getDutiesAtSlot(slot)).to.deep.equal(
       [{duty, selectionProof: null}],
@@ -180,11 +186,23 @@ describe("AttestationDutiesService", function () {
       },
       "Wrong dutiesService.attesters Map at current epoch"
     );
+
+    expect(Object.fromEntries(dutiesService["selectionProofs"].get(duty.slot) || new Map())).to.deep.equal(
+      {
+        [toHexString(pubkeys[0])]: ZERO_HASH,
+      },
+      "Wrong dutiesService.selectionProofs at current epoch"
+    );
+
     // then remove
     dutiesService.removeDutiesForKey(toHexString(pubkeys[0]));
     expect(Object.fromEntries(dutiesService["dutiesByIndexByEpoch"])).to.deep.equal(
       {},
       "Wrong dutiesService.attesters Map at current epoch after removal"
+    );
+    expect(Object.fromEntries(dutiesService["selectionProofs"])).to.deep.equal(
+      {},
+      "Wrong dutiesService.selectionProofs at current epoch after removal"
     );
   });
 });


### PR DESCRIPTION
**Motivation**

+ For each validator, we create selection proof twice for the same slot.
+ We want to avoid this since it takes 10% of validator time in a contabo node of 50 connected validators

**Description**

Cache selection proof by pubkey hex by slot, prune it per epoch

part of #3895 