### PR TITLE
Remove requirement to prefix interface with I

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,8 +40,6 @@ module.exports = {
       //classes and types must be in PascalCase
       {selector: ["typeLike", "enum"], format: ["PascalCase"]},
       {selector: "enumMember", format: null},
-      //interface must start with I
-      {selector: "interface", format: ["PascalCase"], prefix: ["I"]},
       //ignore rule for quoted stuff
       {
         selector: [


### PR DESCRIPTION
**Motivation**

In multiple team calls it has been agreed that the rule to prefix all interfaces with `I` is not productive. While the idea is good it has forced us through the project lifespan to prefix multiple interfaces with `I` when it was not really necessary. The team can manually request to prefix with `I` when appropriate.

**Description**

- Remove requirement to prefix interface with I