### PR TITLE
Handle sleep function with negative value

### DIFF
--- a/packages/utils/src/sleep.ts
+++ b/packages/utils/src/sleep.ts
@@ -6,6 +6,8 @@ import {ErrorAborted} from "./errors";
  * On abort throws ErrorAborted
  */
 export async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms < 0) return;
+
   return new Promise((resolve, reject) => {
     if (signal && signal.aborted) return reject(new ErrorAborted());
 

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -48,6 +48,9 @@ export class AttestationService {
   private runAttestationTasks = async (slot: Slot, signal: AbortSignal): Promise<void> => {
     // Fetch info first so a potential delay is absorved by the sleep() below
     const dutiesByCommitteeIndex = groupAttDutiesByCommitteeIndex(this.dutiesService.getDutiesAtSlot(slot));
+    if (dutiesByCommitteeIndex.size === 0) {
+      return;
+    }
 
     // A validator should create and broadcast the attestation to the associated attestation subnet when either
     // (a) the validator has received a valid block from the expected block proposer for the assigned slot or

--- a/packages/validator/src/util/clock.ts
+++ b/packages/validator/src/util/clock.ts
@@ -50,10 +50,13 @@ export class Clock implements IClock {
     this.fns.push({timeItem: TimeItem.Epoch, fn});
   }
 
-  /** Miliseconds from now to a specific slot fraction */
+  /**
+   * Miliseconds from now to a specific slot fraction.
+   * If it's negative, return 0.
+   **/
   msToSlotFraction(slot: Slot, fraction: number): number {
     const timeAt = this.genesisTime + this.config.SECONDS_PER_SLOT * (slot + fraction);
-    return timeAt * 1000 - Date.now();
+    return Math.max(timeAt * 1000 - Date.now(), 0);
   }
 
   /**


### PR DESCRIPTION
**Motivation**

Right now there's a performance issue in contabo node validator with 50 validators, and it passes a negative value to `sleep()` function.

**Description**
+ In the following context of validator AttestationService, the `sleep()` promise should be resolved immediately instead of having to count on `setTimeout()`

```typescript
await Promise.race([sleep(this.clock.msToSlotFraction(slot, 1 / 3), signal), this.waitForBlockSlot(slot)]);
```

Closes #3906 