### PR TITLE
Fix property merging in publishAttestations attestationNoCommittee

### DIFF
--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -147,7 +147,7 @@ export class AttestationService {
     const currentEpoch = computeEpochAtSlot(slot);
     const signedAttestations: phase0.Attestation[] = [];
 
-    const attestation = {...attestationNoCommittee, committeeIndex};
+    const attestation: phase0.AttestationData = {...attestationNoCommittee, index: committeeIndex};
 
     for (const {duty} of duties) {
       const logCtxValidator = {


### PR DESCRIPTION
**Motivation**

Fixes regression from https://github.com/ChainSafe/lodestar/pull/3917 which prevents validators from attesting if they are in committee != 0.

It's worrying that our sim testing did not catch this issue. @tuyennhv @wemeetagain could it be that since the testnet is so small there is only 1 committee in each slot?

**Description**

Fix property merging in publishAttestations attestationNoCommittee