### PR TITLE
Goerli shadowfork 4 config update

### DIFF
--- a/kiln/devnets/goerlishadow-4.vars
+++ b/kiln/devnets/goerlishadow-4.vars
@@ -1,0 +1,21 @@
+DEVNET_NAME=goerlishadow-4
+
+GETH_IMAGE=parithoshj/geth:master
+NETHERMIND_IMAGE=nethermindeth/nethermind:kiln_0.12
+ETHEREUMJS_IMAGE=g11tech/ethereumjs:kiln
+LODESTAR_IMAGE=chainsafe/lodestar:next
+CONFIG_GIT_DIR=goerli-shadow-fork-4
+
+JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
+
+LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls http://127.0.0.1:8551 --api.rest.enabled --api.rest.host 0.0.0.0 --api.rest.api '*'"
+
+LODESTAR_VALIDATOR_ARGS='--network kiln  --fromMnemonic "lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow" --mnemonicIndexes 0..5'
+
+NETHERMIND_EXTRA_ARGS="--config  goerli_shadowfork --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=9891031 --Init.DiagnosticMode=None --JsonRpc.Enabled=true --JsonRpc.Host=0.0.0.0 --JsonRpc.AdditionalRpcUrls \"http://localhost:8545|http;ws|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:8551|http;ws|net;eth;subscribe;engine;web3;client\""
+
+GETH_EXTRA_ARGS="--http --http.api engine,net,eth,web3 --http.port 8545 --allow-insecure-unlock --http.addr 0.0.0.0 --http.corsdomain \"*\" --http.vhosts \"*\" --authrpc.port=8551 --networkid 1"
+
+ETHEREUMJS_EXTRA_ARGS="--saveReceipts --rpc --rpcport 8545 --ws --rpcEngine --rpcEnginePort=8551 --rpcDebug --loglevel=debug"
+
+EXTRA_BOOTNODES=""

--- a/kiln/devnets/goerlishadow-4.vars
+++ b/kiln/devnets/goerlishadow-4.vars
@@ -14,7 +14,7 @@ LODESTAR_VALIDATOR_ARGS='--network kiln  --fromMnemonic "lens risk clerk foot ve
 
 NETHERMIND_EXTRA_ARGS="--config  goerli_shadowfork --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=9891031 --Init.DiagnosticMode=None --JsonRpc.Enabled=true --JsonRpc.Host=0.0.0.0 --JsonRpc.AdditionalRpcUrls \"http://localhost:8545|http;ws|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:8551|http;ws|net;eth;subscribe;engine;web3;client\""
 
-GETH_EXTRA_ARGS="--http --http.api engine,net,eth,web3 --http.port 8545 --allow-insecure-unlock --http.addr 0.0.0.0 --http.corsdomain \"*\" --http.vhosts \"*\" --authrpc.port=8551 --networkid 1"
+GETH_EXTRA_ARGS="--http --http.api engine,net,eth,web3 --http.port 8545 --allow-insecure-unlock --http.addr 0.0.0.0 --http.corsdomain \"*\" --http.vhosts \"*\" --authrpc.port=8551 --networkid 5"
 
 ETHEREUMJS_EXTRA_ARGS="--saveReceipts --rpc --rpcport 8545 --ws --rpcEngine --rpcEnginePort=8551 --rpcDebug --loglevel=debug"
 

--- a/kiln/devnets/goerlishadow-4.vars
+++ b/kiln/devnets/goerlishadow-4.vars
@@ -1,7 +1,7 @@
 DEVNET_NAME=goerlishadow-4
 
 GETH_IMAGE=parithoshj/geth:master
-NETHERMIND_IMAGE=nethermindeth/nethermind:kiln_0.12
+NETHERMIND_IMAGE=nethermindeth/nethermind:kiln_shadowfork
 ETHEREUMJS_IMAGE=g11tech/ethereumjs:kiln
 LODESTAR_IMAGE=chainsafe/lodestar:next
 CONFIG_GIT_DIR=goerli-shadow-fork-4


### PR DESCRIPTION
Add Goerli shadow fork 4 config for merge testnets in our easy setup file based on new configs released here:
https://github.com/eth-clients/merge-testnets/tree/main/goerli-shadow-fork-4

usage:

`cd kiln/devnets`
`./setup.sh --dataDir goerli4-data --elClient nethermind --devnetVars ./goerlishadow-4.vars --dockerWithSudo --withTerminal "gnome-terminal --disable-factory --"`
