### PR TITLE
Fix Error: bytes is not iterable

### DIFF
--- a/packages/lodestar/src/api/impl/debug/index.ts
+++ b/packages/lodestar/src/api/impl/debug/index.ts
@@ -25,7 +25,7 @@ export function getDebugApi({
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
         return state.serialize() as any;
       } else {
-        return {data: state};
+        return {data: state.toValue()};
       }
     },
 
@@ -36,7 +36,7 @@ export function getDebugApi({
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
         return state.serialize() as any;
       } else {
-        return {data: state, version: config.getForkName(state.slot)};
+        return {data: state.toValue(), version: config.getForkName(state.slot)};
       }
     },
 

--- a/packages/lodestar/test/unit/api/impl/debug/index.test.ts
+++ b/packages/lodestar/test/unit/api/impl/debug/index.test.ts
@@ -1,4 +1,6 @@
 import {config} from "@chainsafe/lodestar-config/default";
+import {config as minimalConfig} from "@chainsafe/lodestar-config/default";
+import {altair, phase0, ssz} from "@chainsafe/lodestar-types";
 import {ZERO_HASH} from "@chainsafe/lodestar-beacon-state-transition";
 import {ForkChoice, IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {toHexString} from "@chainsafe/ssz";
@@ -48,5 +50,17 @@ describe("api - debug - beacon", function () {
     resolveStateIdStub.resolves(generateState());
     const {data: state} = await debugApi.getState("something");
     expect(state).to.not.be.null;
+  });
+
+  it("getState - should be able to convert to json", async function () {
+    resolveStateIdStub.resolves(generateState());
+    const {data: state} = await debugApi.getState("something");
+    expect(() => ssz.phase0.BeaconState.toJson(state as phase0.BeaconState)).to.not.throw();
+  });
+
+  it("getStateV2 - should be able to convert to json", async function () {
+    resolveStateIdStub.resolves(generateState({}, minimalConfig, true));
+    const {data: state} = await debugApi.getStateV2("something");
+    expect(() => ssz.altair.BeaconState.toJson(state as altair.BeaconState)).to.not.throw();
   });
 });


### PR DESCRIPTION
**Motivation**

Got `Error: bytes is not iterable` when downloading json state

**Description**

+ SSZ Container `toJson()` only works with value, not DU object
+ Maybe we need to fix in ssz too?

Closes #3934 #3872
