### PR TITLE
Add validator option not to submit attestation early

### DIFF
--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -136,7 +136,7 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
       logger,
       signers,
       graffiti,
-      dontSubmitAttestationEarly: args.dontSubmitAttestationEarly,
+      earlyAttestationDelayMs: args.earlyAttestationDelayMs,
     },
     controller.signal,
     metrics

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -129,7 +129,15 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
   // It will wait for genesis, so this promise can be potentially very long
 
   const validator = await Validator.initializeFromBeaconNode(
-    {dbOps, slashingProtection, api: args.server, logger, signers, graffiti},
+    {
+      dbOps,
+      slashingProtection,
+      api: args.server,
+      logger,
+      signers,
+      graffiti,
+      dontSubmitAttestationEarly: args.dontSubmitAttestationEarly,
+    },
     controller.signal,
     metrics
   );

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -136,7 +136,7 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
       logger,
       signers,
       graffiti,
-      earlyAttestationDelayMs: args.earlyAttestationDelayMs,
+      afterBlockDelaySlotFraction: args.afterBlockDelaySlotFraction,
     },
     controller.signal,
     metrics

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -18,7 +18,7 @@ export type IValidatorCliArgs = IAccountValidatorArgs &
     server: string;
     force: boolean;
     graffiti: string;
-    dontSubmitAttestationEarly?: boolean;
+    earlyAttestationDelayMs?: number;
     importKeystoresPath?: string[];
     importKeystoresPassword?: string;
     externalSignerUrl?: string;
@@ -62,10 +62,10 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
     type: "string",
   },
 
-  dontSubmitAttestationEarly: {
-    description: "Wait for 1/3 of slot to submit attestation, by default submit attestation early if possible",
-    type: "boolean",
-    default: false,
+  earlyAttestationDelayMs: {
+    hidden: true,
+    description: "Delay early attestation in millisecond",
+    type: "number",
   },
 
   importKeystoresPath: {

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -18,6 +18,7 @@ export type IValidatorCliArgs = IAccountValidatorArgs &
     server: string;
     force: boolean;
     graffiti: string;
+    dontSubmitAttestationEarly?: boolean;
     importKeystoresPath?: string[];
     importKeystoresPassword?: string;
     externalSignerUrl?: string;
@@ -59,6 +60,12 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
     description: "Specify your custom graffiti to be included in blocks (plain UTF8 text, 32 characters max)",
     // Don't use a default here since it should be computed only if necessary by getDefaultGraffiti()
     type: "string",
+  },
+
+  dontSubmitAttestationEarly: {
+    description: "Wait for 1/3 of slot to submit attestation, by default submit attestation early if possible",
+    type: "boolean",
+    default: false,
   },
 
   importKeystoresPath: {

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -18,7 +18,7 @@ export type IValidatorCliArgs = IAccountValidatorArgs &
     server: string;
     force: boolean;
     graffiti: string;
-    earlyAttestationDelayMs?: number;
+    afterBlockDelaySlotFraction?: number;
     importKeystoresPath?: string[];
     importKeystoresPassword?: string;
     externalSignerUrl?: string;
@@ -62,9 +62,9 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
     type: "string",
   },
 
-  earlyAttestationDelayMs: {
+  afterBlockDelaySlotFraction: {
     hidden: true,
-    description: "Delay early attestation in millisecond",
+    description: "Delay before publishing attestations if block comes early, as a fraction of SECONDS_PER_SLOT",
     type: "number",
   },
 

--- a/packages/utils/src/sleep.ts
+++ b/packages/utils/src/sleep.ts
@@ -6,7 +6,9 @@ import {ErrorAborted} from "./errors";
  * On abort throws ErrorAborted
  */
 export async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  if (ms < 0) return;
+  if (ms <= 0) {
+    return;
+  }
 
   return new Promise((resolve, reject) => {
     if (signal && signal.aborted) return reject(new ErrorAborted());

--- a/packages/utils/test/unit/sleep.test.ts
+++ b/packages/utils/test/unit/sleep.test.ts
@@ -29,6 +29,6 @@ describe("sleep", function () {
     controller.abort();
     expect(controller.signal.aborted, "Signal should already be aborted").to.be.true;
 
-    await expect(sleep(0, controller.signal)).to.rejectedWith(ErrorAborted);
+    await expect(sleep(10, controller.signal)).to.rejectedWith(ErrorAborted);
   });
 });

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -14,10 +14,9 @@ import {ValidatorEvent, ValidatorEventEmitter} from "./emitter";
 import {PubkeyHex} from "../types";
 import {Metrics} from "../metrics";
 
-/**
- * As experiment by Nimbus, a delay of 2000ms is necessary to avoid an attestation to be missed.
- */
-const DEFAULT_EARLY_ATTESTATION_DELAY_MS = 2000;
+type AttestationServiceOpts = {
+  afterBlockDelaySlotFraction?: number;
+};
 
 /**
  * Service that sets up and handles validator attester duties.
@@ -34,7 +33,7 @@ export class AttestationService {
     indicesService: IndicesService,
     chainHeadTracker: ChainHeaderTracker,
     private readonly metrics: Metrics | null,
-    private earlyAttestationDelayMs = DEFAULT_EARLY_ATTESTATION_DELAY_MS
+    private readonly opts?: AttestationServiceOpts
   ) {
     this.dutiesService = new AttestationDutiesService(
       logger,
@@ -154,31 +153,27 @@ export class AttestationService {
       })
     );
 
+    // signAndPublishAttestations() may be called before the 1/3 cutoff time if the block was received early.
+    // If we produced the block or we got the block sooner than our peers, our attestations can be dropped because
+    // they reach our peers before the block. To prevent that, we wait 2 extra seconds AFTER block arrival, but
+    // never beyond the 1/3 cutoff time.
+    // https://github.com/status-im/nimbus-eth2/blob/7b64c1dce4392731a4a59ee3a36caef2e0a8357a/beacon_chain/validators/validator_duties.nim#L1123
+    const msToOneThirdSlot = this.clock.msToSlot(slot + 1 / 3);
+    // Default = 6, which is half of attestation offset
+    const afterBlockDelayMs = (1000 * this.clock.secondsPerSlot) / (this.opts?.afterBlockDelaySlotFraction ?? 6);
+    await sleep(Math.min(msToOneThirdSlot, afterBlockDelayMs));
+
+    this.metrics?.attesterStepCallPublishAttestation.observe(this.clock.secFromSlot(slot + 1 / 3));
+
     // Step 2. Publish all `Attestations` in one go
-    if (signedAttestations.length > 0) {
-      try {
-        const msToOneThirdSlot = this.clock.msToSlot(slot + 1 / 3);
-        const signedAttestationTime = Date.now();
-        // as monitored in hetzner nodes, most of the time we're before 1/3 of slot at this time
-        // i.e. msToOneThirdSlot > 0
-        if (msToOneThirdSlot > 0) {
-          // for early attestations, wait until now + 2000ms, or 1/3 of slot, whichever comes first
-          await sleep(Math.min(msToOneThirdSlot, this.earlyAttestationDelayMs));
-        }
-        this.metrics?.attesterStepCallPublishAttestation.observe(this.clock.secFromSlot(slot + 1 / 3));
-        await this.api.beacon.submitPoolAttestations(signedAttestations);
-        const delayMs = Date.now() - signedAttestationTime;
-        this.logger.info("Published attestations", {
-          slot,
-          count: signedAttestations.length,
-          delayMs,
-        });
-        this.metrics?.publishedAttestations.inc(signedAttestations.length);
-      } catch (e) {
-        // Note: metric counts only 1 since we don't know how many signedAttestations are invalid
-        this.metrics?.attestaterError.inc({error: "publish"});
-        this.logger.error("Error publishing attestations", {slot}, e as Error);
-      }
+    try {
+      await this.api.beacon.submitPoolAttestations(signedAttestations);
+      this.logger.info("Published attestations", {slot, count: signedAttestations.length});
+      this.metrics?.publishedAttestations.inc(signedAttestations.length);
+    } catch (e) {
+      // Note: metric counts only 1 since we don't know how many signedAttestations are invalid
+      this.metrics?.attestaterError.inc({error: "publish"});
+      this.logger.error("Error publishing attestations", {slot}, e as Error);
     }
   }
 

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -10,6 +10,10 @@ import {BlockDutiesService, GENESIS_SLOT} from "./blockDuties";
 import {PubkeyHex} from "../types";
 import {Metrics} from "../metrics";
 
+type BlockProposingServiceOpts = {
+  graffiti?: string;
+};
+
 /**
  * Service that sets up and handles validator block proposal duties.
  */
@@ -23,7 +27,7 @@ export class BlockProposingService {
     private readonly clock: IClock,
     private readonly validatorStore: ValidatorStore,
     private readonly metrics: Metrics | null,
-    private readonly graffiti?: string
+    private readonly opts: BlockProposingServiceOpts
   ) {
     this.dutiesService = new BlockDutiesService(
       logger,
@@ -66,7 +70,7 @@ export class BlockProposingService {
     // Wrap with try catch here to re-use `logCtx`
     try {
       const randaoReveal = await this.validatorStore.signRandao(pubkey, slot);
-      const graffiti = this.graffiti || "";
+      const graffiti = this.opts.graffiti || "";
       const debugLogCtx = {...logCtx, validator: pubkeyHex};
 
       this.logger.debug("Producing block", debugLogCtx);

--- a/packages/validator/src/util/clock.ts
+++ b/packages/validator/src/util/clock.ts
@@ -9,6 +9,7 @@ type RunEveryFn = (slot: Slot, signal: AbortSignal) => Promise<void>;
 
 export interface IClock {
   readonly genesisTime: number;
+  readonly secondsPerSlot: number;
   start(signal: AbortSignal): void;
   runEverySlot(fn: (slot: Slot, signal: AbortSignal) => Promise<void>): void;
   runEveryEpoch(fn: (epoch: Epoch, signal: AbortSignal) => Promise<void>): void;
@@ -23,12 +24,14 @@ export enum TimeItem {
 
 export class Clock implements IClock {
   readonly genesisTime: number;
+  readonly secondsPerSlot: number;
   private readonly config: IChainForkConfig;
   private readonly logger: ILogger;
   private readonly fns: {timeItem: TimeItem; fn: RunEveryFn}[] = [];
 
   constructor(config: IChainForkConfig, logger: ILogger, opts: {genesisTime: number}) {
     this.genesisTime = opts.genesisTime;
+    this.secondsPerSlot = config.SECONDS_PER_SLOT;
     this.config = config;
     this.logger = logger;
   }

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -28,6 +28,7 @@ export type ValidatorOptions = {
   api: Api | string;
   signers: Signer[];
   logger: ILogger;
+  dontSubmitAttestationEarly?: boolean;
   graffiti?: string;
 };
 
@@ -60,7 +61,7 @@ export class Validator {
   private state: State = {status: Status.stopped};
 
   constructor(opts: ValidatorOptions, readonly genesis: Genesis, metrics: Metrics | null = null) {
-    const {dbOps, logger, slashingProtection, signers, graffiti} = opts;
+    const {dbOps, logger, slashingProtection, signers, graffiti, dontSubmitAttestationEarly} = opts;
     const config = createIBeaconConfig(dbOps.config, genesis.genesisValidatorsRoot);
 
     const api =
@@ -101,7 +102,8 @@ export class Validator {
       this.emitter,
       this.indicesService,
       this.chainHeaderTracker,
-      metrics
+      metrics,
+      dontSubmitAttestationEarly
     );
 
     this.syncCommitteeService = new SyncCommitteeService(

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -28,7 +28,7 @@ export type ValidatorOptions = {
   api: Api | string;
   signers: Signer[];
   logger: ILogger;
-  dontSubmitAttestationEarly?: boolean;
+  earlyAttestationDelayMs?: number;
   graffiti?: string;
 };
 
@@ -61,7 +61,7 @@ export class Validator {
   private state: State = {status: Status.stopped};
 
   constructor(opts: ValidatorOptions, readonly genesis: Genesis, metrics: Metrics | null = null) {
-    const {dbOps, logger, slashingProtection, signers, graffiti, dontSubmitAttestationEarly} = opts;
+    const {dbOps, logger, slashingProtection, signers, graffiti, earlyAttestationDelayMs} = opts;
     const config = createIBeaconConfig(dbOps.config, genesis.genesisValidatorsRoot);
 
     const api =
@@ -103,7 +103,7 @@ export class Validator {
       this.indicesService,
       this.chainHeaderTracker,
       metrics,
-      dontSubmitAttestationEarly
+      earlyAttestationDelayMs
     );
 
     this.syncCommitteeService = new SyncCommitteeService(

--- a/packages/validator/test/unit/services/block.test.ts
+++ b/packages/validator/test/unit/services/block.test.ts
@@ -48,7 +48,7 @@ describe("BlockDutiesService", function () {
     api.validator.getProposerDuties.resolves(duties);
 
     const clock = new ClockMock();
-    const blockService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, null);
+    const blockService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, null, {});
 
     const signedBlock = generateEmptySignedBlock();
     validatorStore.signRandao.resolves(signedBlock.message.body.randaoReveal);

--- a/packages/validator/test/utils/clock.ts
+++ b/packages/validator/test/utils/clock.ts
@@ -6,6 +6,7 @@ type RunEveryFn = (slot: Slot, signal: AbortSignal) => Promise<void>;
 
 export class ClockMock implements IClock {
   readonly genesisTime = 0;
+  readonly secondsPerSlot = 12;
 
   private readonly everySlot: RunEveryFn[] = [];
   private readonly everyEpoch: RunEveryFn[] = [];


### PR DESCRIPTION
**Motivation**

As monitored in hetzner-c0, there are 2 missed attestations with:
+ correct head
+ sent peers is 2  or 8
+ delaySec is around -1.5

It's possible that the missed attestations were because we submit them too early, and peers ignore them (maybe due to unknown block root?). Note that lighthouse does not submit attestations early at this time

**Description**

Add an option to submit attestations right at 1/3 of slot so that we can test in mainnet nodes

part of #3943 
