### PR TITLE
Prune logic when we have too many peers

### DIFF
--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -114,6 +114,13 @@ export function createLodestarMetrics(
       help: "network.reportPeer count by reason",
       labelNames: ["reason"],
     }),
+    peerManager: {
+      heartbeatDuration: register.histogram({
+        name: "lodestar_discovery_find_node_query_time_seconds",
+        help: "Time to complete a find node query in seconds in seconds",
+        buckets: [0.001, 0.01, 0.1, 1],
+      }),
+    },
 
     discovery: {
       peersToConnect: register.gauge({

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -94,9 +94,10 @@ export function createLodestarMetrics(
       name: "lodestar_peers_requested_total_to_connect",
       help: "Priorization results total peers count requested to connect",
     }),
-    peersRequestedToDisconnect: register.gauge({
+    peersRequestedToDisconnect: register.gauge<"reason">({
       name: "lodestar_peers_requested_total_to_disconnect",
       help: "Priorization results total peers count requested to disconnect",
+      labelNames: ["reason"],
     }),
     peersRequestedSubnetsToQuery: register.gauge<"type">({
       name: "lodestar_peers_requested_total_subnets_to_query",

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -49,9 +49,10 @@ export function createLodestarMetrics(
       help: "number of peers, labeled by client",
       labelNames: ["client"],
     }),
-    peerLongLivedSubnets: register.avgMinMax({
-      name: "lodestar_peer_long_lived_subnets_avg_min_max",
-      help: "Avg min max of amount of long lived subnets of peers",
+    peerLongLivedAttnets: register.histogram({
+      name: "lodestar_peer_long_lived_attnets_count",
+      help: "Histogram of current count of long lived attnets of connected peers",
+      buckets: [0, 4, 16, 32, 64],
     }),
     peerScore: register.avgMinMax({
       name: "lodestar_peer_score_avg_min_max",

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -117,8 +117,8 @@ export function createLodestarMetrics(
     }),
     peerManager: {
       heartbeatDuration: register.histogram({
-        name: "lodestar_discovery_find_node_query_time_seconds",
-        help: "Time to complete a find node query in seconds in seconds",
+        name: "lodestar_peer_manager_heartbeat_duration_seconds",
+        help: "Peer manager heartbeat function duration in seconds",
         buckets: [0.001, 0.01, 0.1, 1],
       }),
     },

--- a/packages/lodestar/src/network/peers/peerManager.ts
+++ b/packages/lodestar/src/network/peers/peerManager.ts
@@ -46,9 +46,6 @@ const LONG_PEER_CONNECTION_MS = 24 * 60 * 60 * 1000;
  */
 const ALLOWED_NEGATIVE_GOSSIPSUB_FACTOR = 0.1;
 
-const attnetsZero = BitArray.fromBitLen(ATTESTATION_SUBNET_COUNT);
-const syncnetsZero = BitArray.fromBitLen(SYNC_COMMITTEE_SUBNET_COUNT);
-
 // TODO:
 // maxPeers and targetPeers should be dynamic on the num of validators connected
 // The Node should compute a recomended value every interval and log a warning
@@ -405,10 +402,8 @@ export class PeerManager {
         const peerData = this.connectedPeers.get(peer.toB58String());
         return {
           id: peer,
-          attnets: peerData?.metadata?.attnets ?? attnetsZero,
-          syncnets: peerData?.metadata?.syncnets ?? syncnetsZero,
-          attnetsTrueBitIndices: peerData?.metadata?.attnets.getTrueBitIndexes() ?? [],
-          syncnetsTrueBitIndices: peerData?.metadata?.syncnets.getTrueBitIndexes() ?? [],
+          attnets: peerData?.metadata?.attnets ?? null,
+          syncnets: peerData?.metadata?.syncnets ?? null,
           score: this.peerRpcScores.getScore(peer),
         };
       }),

--- a/packages/lodestar/src/network/peers/peerManager.ts
+++ b/packages/lodestar/src/network/peers/peerManager.ts
@@ -614,10 +614,13 @@ export class PeerManager {
 
     const peersByDirection = new Map<string, number>();
     const peersByClient = new Map<string, number>();
-    const longLivedSubnets: number[] = [];
+    const longLivedAttnets: number[] = [];
     const scores: number[] = [];
     const connSecs: number[] = [];
     const now = Date.now();
+
+    // peerLongLivedAttnets metric is a count
+    metrics.peerLongLivedAttnets.reset();
 
     for (const connections of this.libp2p.connectionManager.connections.values()) {
       const openCnx = connections.find((cnx) => cnx.stat.status === "open");
@@ -630,7 +633,7 @@ export class PeerManager {
         peersByClient.set(client, 1 + (peersByClient.get(client) ?? 0));
 
         const attnets = peerData?.metadata?.attnets;
-        longLivedSubnets.push(attnets ? attnets.getTrueBitIndexes().length : 0);
+        longLivedAttnets.push(attnets ? attnets.getTrueBitIndexes().length : 0);
 
         scores.push(this.peerRpcScores.getScore(peerId));
         connSecs.push(Math.floor((now - openCnx.stat.timeline.open) / 1000));
@@ -655,8 +658,9 @@ export class PeerManager {
 
     metrics.peers.set(total);
     metrics.peersSync.set(syncPeers);
-    metrics.peerLongLivedSubnets.set(longLivedSubnets);
     metrics.peerScore.set(scores);
     metrics.peerConnectionLength.set(connSecs);
+    // TODO: Optimize doing observe in batch
+    for (const count of longLivedAttnets) metrics.peerLongLivedAttnets.observe(count);
   }
 }

--- a/packages/lodestar/src/network/peers/peerManager.ts
+++ b/packages/lodestar/src/network/peers/peerManager.ts
@@ -414,7 +414,9 @@ export class PeerManager {
     );
 
     // Register results to metrics
-    this.metrics?.peersRequestedToDisconnect.inc(peersToDisconnect.length);
+    for (const [reason, peers] of peersToDisconnect) {
+      this.metrics?.peersRequestedToDisconnect.inc({reason}, peers.length);
+    }
     this.metrics?.peersRequestedToConnect.inc(peersToConnect);
 
     const queriesMerged: SubnetDiscvQueryMs[] = [];
@@ -447,7 +449,7 @@ export class PeerManager {
       }
     }
 
-    for (const peer of peersToDisconnect) {
+    for (const peer of Array.from(peersToDisconnect.values()).flat()) {
       void this.goodbyeAndDisconnect(peer, GoodByeReasonCode.TOO_MANY_PEERS);
     }
 

--- a/packages/lodestar/src/network/peers/utils/prioritizePeers.ts
+++ b/packages/lodestar/src/network/peers/utils/prioritizePeers.ts
@@ -4,9 +4,27 @@ import {shuffle} from "../../../util/shuffle";
 import {sortBy} from "../../../util/sortBy";
 import {SubnetType} from "../../metadata";
 import {RequestedSubnet} from "./subnetMap";
+import {ATTESTATION_SUBNET_COUNT} from "@chainsafe/lodestar-params";
+import {MapDef} from "../../../util/map";
 
 /** Target number of peers we'd like to have connected to a given long-lived subnet */
 const MAX_TARGET_SUBNET_PEERS = 6;
+/** Minimal number of peers we'd like to have connected to a given long-lived subnet */
+const MIN_TARGET_SUBNET_PEERS = 2;
+
+/**
+ * This is used in the pruning logic. We avoid pruning peers on sync-committees if doing so would
+ * lower our peer count below this number. Instead we favour a non-uniform distribution of subnet
+ * peers.
+ */
+const MIN_SYNC_COMMITTEE_PEERS = 2;
+
+/**
+ * Lighthouse has this value as 0. However, as monitored in Lodestar mainnet node, the max score is 0
+ * and average score is -0.5 to 0 so we want this value to be a little bit more relaxed
+ */
+const LOW_SCORE_TO_PRUNE_IF_TOO_MANY_PEERS = -2;
+
 /**
  * Instead of attempting to connect the exact amount necessary this will overshoot a little since the success
  * rate of outgoing connections is low, <33%. If we try to connect exactly `targetPeers - connectedPeerCount` the
@@ -16,6 +34,13 @@ const PEERS_TO_CONNECT_OVERSHOOT_FACTOR = 3;
 
 type SubnetDiscvQuery = {subnet: number; toSlot: number; maxPeersToDiscover: number};
 
+type PeerInfo = {
+  id: PeerId;
+  attnets: phase0.AttestationSubnets | null;
+  syncnets: altair.SyncSubnets | null;
+  score: number;
+};
+
 /**
  * Prioritize which peers to disconect and which to connect. Conditions:
  * - Reach `targetPeers`
@@ -24,12 +49,7 @@ type SubnetDiscvQuery = {subnet: number; toSlot: number; maxPeersToDiscover: num
  * - Prioritize peers with good score
  */
 export function prioritizePeers(
-  connectedPeers: {
-    id: PeerId;
-    attnets: phase0.AttestationSubnets | null;
-    syncnets: altair.SyncSubnets | null;
-    score: number;
-  }[],
+  connectedPeers: PeerInfo[],
   activeAttnets: RequestedSubnet[],
   activeSyncnets: RequestedSubnet[],
   {targetPeers, maxPeers}: {targetPeers: number; maxPeers: number}
@@ -40,36 +60,59 @@ export function prioritizePeers(
   syncnetQueries: SubnetDiscvQuery[];
 } {
   let peersToConnect = 0;
-  const peersToDisconnect: PeerId[] = [];
+  const peersToDisconnect = new Set<PeerId>();
   const attnetQueries: SubnetDiscvQuery[] = [];
   const syncnetQueries: SubnetDiscvQuery[] = [];
+  const attnetTruebitIndices = new Map<PeerInfo, number[]>();
+  const syncnetTruebitIndices = new Map<PeerInfo, number[]>();
 
   // To filter out peers that are part of 1+ attnets of interest from possible disconnection
-  const peerHasDuty = new Map<string, boolean>();
+  const peerHasDuty = new Map<PeerInfo, boolean>();
+  // Dynamically compute MIN_TARGET_SUBNET_PEERS <= TARGET_PEERS_PER_SUBNET <= MAX_TARGET_SUBNET_PEERS
+  // TODO: see if we need to tweak this logic as lighthouse always requires MAX_TARGET_SUBNET_PEERS
+  const targetPeersPerAttnetSubnet = Math.min(
+    MAX_TARGET_SUBNET_PEERS,
+    maxPeers,
+    Math.max(MIN_TARGET_SUBNET_PEERS, Math.floor(maxPeers / activeAttnets.length))
+  );
+  const targetPeersPerSyncnetSubnet = Math.min(
+    MAX_TARGET_SUBNET_PEERS,
+    maxPeers,
+    Math.max(MIN_TARGET_SUBNET_PEERS, Math.floor(maxPeers / activeSyncnets.length))
+  );
 
-  for (const {subnets, subnetKey, queries} of [
-    {subnets: activeAttnets, subnetKey: SubnetType.attnets, queries: attnetQueries},
-    {subnets: activeSyncnets, subnetKey: SubnetType.syncnets, queries: syncnetQueries},
+  for (const {subnets, subnetKey, queries, bitIndicesByPeer, targetPeersPerSubnet} of [
+    {
+      subnets: activeAttnets,
+      subnetKey: SubnetType.attnets,
+      queries: attnetQueries,
+      bitIndicesByPeer: attnetTruebitIndices,
+      targetPeersPerSubnet: targetPeersPerAttnetSubnet,
+    },
+    {
+      subnets: activeSyncnets,
+      subnetKey: SubnetType.syncnets,
+      queries: syncnetQueries,
+      bitIndicesByPeer: syncnetTruebitIndices,
+      targetPeersPerSubnet: targetPeersPerSyncnetSubnet,
+    },
   ]) {
-    // Dynamically compute 1 <= TARGET_PEERS_PER_SUBNET <= MAX_TARGET_SUBNET_PEERS
-    const targetPeersPerSubnet = Math.min(MAX_TARGET_SUBNET_PEERS, Math.max(1, Math.floor(maxPeers / subnets.length)));
-
     if (subnets.length > 0) {
       /** Map of peers per subnet, peer may be in multiple arrays */
       const peersPerSubnet = new Map<number, number>();
 
       for (const peer of connectedPeers) {
         let hasDuty = false;
+        const bitIndices = peer[subnetKey]?.getTrueBitIndexes() ?? [];
+        bitIndicesByPeer.set(peer, bitIndices);
         for (const {subnet} of subnets) {
-          const subnetBitArray = peer[subnetKey];
-          // TODO: Review performance
-          if (subnetBitArray && subnetBitArray.get(subnet) === true) {
+          if (bitIndices.includes(subnet)) {
             hasDuty = true;
             peersPerSubnet.set(subnet, 1 + (peersPerSubnet.get(subnet) ?? 0));
           }
         }
         if (hasDuty) {
-          peerHasDuty.set(peer.id.toB58String(), true);
+          peerHasDuty.set(peer, true);
         }
       }
 
@@ -96,26 +139,197 @@ export function prioritizePeers(
       maxPeers - connectedPeerCount
     );
   } else if (connectedPeerCount > targetPeers) {
-    // Too much peers, disconnect worst
-
-    // Current peer sorting:
-    // - All connected with no future duty, sorted by score (worst first) (ties broken random)
-
-    // TODO: Priotize peers for disconection better, don't just filter by duty but
-    // reduce their probability of being disconected, mantaining `targetPeersPerSubnet`
-
-    const connectedPeersWithoutDuty = connectedPeers.filter((peer) => !peerHasDuty.get(peer.id.toB58String()));
-    // sort from least score to high
-    const worstPeers = sortBy(shuffle(connectedPeersWithoutDuty), (peer) => peer.score);
-    for (const peer of worstPeers.slice(0, connectedPeerCount - targetPeers)) {
-      peersToDisconnect.push(peer.id);
-    }
+    pruneExcessPeers({
+      connectedPeers,
+      attnetTruebitIndices,
+      syncnetTruebitIndices,
+      peerHasDuty,
+      targetPeers,
+      targetPeersPerAttnetSubnet,
+      activeAttnets,
+      peersToDisconnect,
+    });
   }
 
   return {
     peersToConnect,
-    peersToDisconnect,
+    peersToDisconnect: Array.from(peersToDisconnect),
     attnetQueries,
     syncnetQueries,
   };
+}
+
+/**
+ * Remove excess peers back down to our target values.
+ * 1. Remove worst scoring peers
+ * 2. Remove peers that are not subscribed to a subnet (they have less value)
+ * 3. Remove peers that we have many on any particular subnet
+ *   - Only consider removing peers on subnet that has > MAX_TARGET_SUBNET_PEERS to be safe
+ *   - If we have a choice, do not remove peer that would drop us below targetPeersPerAttnetSubnet
+ *   - If we have a choice, do not remove peer that would drop us below MIN_SYNC_COMMITTEE_PEERS
+ *
+ * Although the logic looks complicated, we'd prune 5 peers max per heartbeat based on the mainnet config.
+ */
+function pruneExcessPeers({
+  connectedPeers,
+  attnetTruebitIndices,
+  syncnetTruebitIndices,
+  peerHasDuty,
+  targetPeers,
+  targetPeersPerAttnetSubnet,
+  activeAttnets,
+  peersToDisconnect,
+}: {
+  connectedPeers: PeerInfo[];
+  attnetTruebitIndices: Map<PeerInfo, number[]>;
+  syncnetTruebitIndices: Map<PeerInfo, number[]>;
+  peerHasDuty: Map<PeerInfo, boolean>;
+  targetPeers: number;
+  targetPeersPerAttnetSubnet: number;
+  activeAttnets: RequestedSubnet[];
+  peersToDisconnect: Set<PeerId>;
+}): void {
+  const connectedPeerCount = connectedPeers.length;
+  const connectedPeersWithoutDuty = connectedPeers.filter((peer) => !peerHasDuty.get(peer));
+  // sort from least score to high
+  const worstPeers = sortBy(shuffle(connectedPeersWithoutDuty), (peer) => peer.score);
+
+  // Remove peers that have score < LOW_SCORE_TO_PRUNE_IF_TOO_MANY_PEERS or not have long lived subnet
+  for (const peer of worstPeers) {
+    const hasLongLivedSubnet =
+      (attnetTruebitIndices.get(peer)?.length ?? 0) > 0 || (syncnetTruebitIndices.get(peer)?.length ?? 0) > 0;
+    if (
+      (!hasLongLivedSubnet || peer.score < LOW_SCORE_TO_PRUNE_IF_TOO_MANY_PEERS) &&
+      peersToDisconnect.size < connectedPeerCount - targetPeers
+    ) {
+      peersToDisconnect.add(peer.id);
+    }
+  }
+
+  // Remove peers that are too grouped on any given subnet
+  if (peersToDisconnect.size < connectedPeerCount - targetPeers) {
+    // PeerInfo array by attestation subnet
+    const subnetToPeers = new MapDef<number, PeerInfo[]>(() => []);
+    // number of peers per long lived sync committee
+    const syncCommitteePeerCount = new MapDef<number, number>(() => 0);
+    // no need to create peerToSyncCommittee, use syncnetTruebitIndices
+
+    // populate the above variables
+    for (const peer of connectedPeers) {
+      if (peersToDisconnect.has(peer.id)) {
+        continue;
+      }
+      for (const subnet of attnetTruebitIndices.get(peer) ?? []) {
+        subnetToPeers.getOrDefault(subnet).push(peer);
+      }
+      for (const subnet of syncnetTruebitIndices.get(peer) ?? []) {
+        syncCommitteePeerCount.set(subnet, 1 + syncCommitteePeerCount.getOrDefault(subnet));
+      }
+    }
+
+    while (peersToDisconnect.size < connectedPeerCount - targetPeers) {
+      let maxPeersSubnet: number | null = null;
+      let maxPeerCountPerSubnet = -1;
+      // find subnet that has the most peers and > MAX_TARGET_SUBNET_PEERS
+      // prater has up to 15-20 peers per subnet at most
+      // however mainnet has up to 6-10 peers per subnet at most
+      for (const [subnet, peers] of subnetToPeers) {
+        if (peers.length > Math.min(targetPeers, MAX_TARGET_SUBNET_PEERS) && peers.length > maxPeerCountPerSubnet) {
+          maxPeersSubnet = subnet;
+          maxPeerCountPerSubnet = peers.length;
+        }
+      }
+
+      // peers are NOT too grouped on any given subnet, finish this function
+      if (maxPeersSubnet === null) break;
+      const peersOnMostGroupedSubnet = subnetToPeers.get(maxPeersSubnet);
+      if (peersOnMostGroupedSubnet === undefined) break;
+
+      const removedPeer = findPeerToRemove(
+        subnetToPeers,
+        syncCommitteePeerCount,
+        peersOnMostGroupedSubnet,
+        attnetTruebitIndices,
+        syncnetTruebitIndices,
+        targetPeersPerAttnetSubnet,
+        activeAttnets
+      );
+
+      // If we have successfully found a candidate peer to prune, prune it,
+      // otherwise all peers on this subnet should not be removed.
+      // In this case, we remove all peers from the pruning logic and try another subnet.
+      if (removedPeer != null) {
+        // recalculate variables
+        for (const peers of subnetToPeers.values()) {
+          const index = peers.findIndex((peer) => peer === removedPeer);
+          if (index >= 0) peers.splice(index, 1);
+        }
+        const knownSyncCommittees = syncnetTruebitIndices.get(removedPeer);
+        if (knownSyncCommittees) {
+          for (const syncCommittee of knownSyncCommittees) {
+            syncCommitteePeerCount.set(
+              syncCommittee,
+              Math.max(syncCommitteePeerCount.getOrDefault(syncCommittee) - 1, 0)
+            );
+          }
+        }
+
+        peersToDisconnect.add(removedPeer.id);
+      } else {
+        // should continue with the 2nd biggest maxPeersSubnet
+        subnetToPeers.delete(maxPeersSubnet);
+      }
+    }
+  }
+}
+
+/**
+ * Find peers to remove from the current maxPeersSubnet.
+ * In the long term, this logic will help us gradually find peers with more long lived subnet.
+ * Return null if we should not remove any peer on the most grouped subnet.
+ */
+function findPeerToRemove(
+  subnetToPeers: Map<number, PeerInfo[]>,
+  syncCommitteePeerCount: Map<number, number>,
+  peersOnMostGroupedSubnet: PeerInfo[],
+  attnetTruebitIndices: Map<PeerInfo, number[]>,
+  syncnetTruebitIndices: Map<PeerInfo, number[]>,
+  targetPeersPerAttnetSubnet: number,
+  activeAttnets: RequestedSubnet[]
+): PeerInfo | null {
+  const peersOnSubnet = sortBy(peersOnMostGroupedSubnet, (peer) => attnetTruebitIndices.get(peer)?.length ?? 0);
+  let removedPeer: PeerInfo | null = null;
+  for (const candidatePeer of peersOnSubnet) {
+    // new logic of lodestar
+    const attnetIndices = attnetTruebitIndices.get(candidatePeer) ?? [];
+    if (attnetIndices.length > 0) {
+      const requestedSubnets = activeAttnets.map((activeAttnet) => activeAttnet.subnet);
+      let minAttnetCount = ATTESTATION_SUBNET_COUNT;
+      for (const subnet of requestedSubnets) {
+        const numSubnetPeers = subnetToPeers.get(subnet)?.length;
+        if (attnetIndices.includes(subnet) && numSubnetPeers !== undefined && numSubnetPeers < minAttnetCount) {
+          minAttnetCount = numSubnetPeers;
+        }
+      }
+      // shouldn't remove this peer because it drops us below targetPeersPerAttnetSubnet
+      if (minAttnetCount <= targetPeersPerAttnetSubnet) continue;
+    }
+
+    // same logic to lighthouse
+    const syncnetIndices = syncnetTruebitIndices.get(candidatePeer) ?? [];
+    // The peer is subscribed to some long-lived sync-committees
+    if (syncnetIndices.length > 0) {
+      const minSubnetCount = Math.min(...syncnetIndices.map((subnet) => syncCommitteePeerCount.get(subnet) ?? 0));
+      // If the minimum count is our target or lower, we
+      // shouldn't remove this peer, because it drops us lower
+      // than our target
+      if (minSubnetCount <= MIN_SYNC_COMMITTEE_PEERS) continue;
+    }
+
+    // ok, found a peer to remove
+    removedPeer = candidatePeer;
+    break;
+  }
+
+  return removedPeer;
 }

--- a/packages/lodestar/test/perf/network/peers/util/prioritizePeers.test.ts
+++ b/packages/lodestar/test/perf/network/peers/util/prioritizePeers.test.ts
@@ -82,7 +82,7 @@ describe("prioritizePeers", () => {
     syncnetPercentage,
   } of testCases) {
     itBench({
-      id: `prioritizePeers lowestScore ${lowestScore} highestScore ${highestScore} attnetPercentage ${attnetPercentage}, syncnetPercentage ${syncnetPercentage} requestedAttnets ${requestedAttnets.count}, requestedSyncNets ${requestedSyncNets.count}`,
+      id: `prioritizePeers score ${lowestScore}:${highestScore} att ${requestedAttnets.count}-${attnetPercentage} sync ${requestedSyncNets.count}-${syncnetPercentage}`,
       beforeEach: () => {
         /**
          * Percentage of active attnet per peer starting from 0.

--- a/packages/lodestar/test/perf/network/peers/util/prioritizePeers.test.ts
+++ b/packages/lodestar/test/perf/network/peers/util/prioritizePeers.test.ts
@@ -1,0 +1,120 @@
+import {ATTESTATION_SUBNET_COUNT, SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
+import {altair, phase0} from "@chainsafe/lodestar-types";
+import {itBench} from "@dapplion/benchmark";
+import PeerId from "peer-id";
+import {defaultNetworkOptions} from "../../../../../src/network/options";
+import {prioritizePeers, RequestedSubnet} from "../../../../../src/network/peers/utils";
+import {getAttnets, getSyncnets} from "../../../../utils/network";
+
+describe("prioritizePeers", () => {
+  const seedPeers: {id: PeerId; attnets: phase0.AttestationSubnets; syncnets: altair.SyncSubnets; score: number}[] = [];
+
+  before(function () {
+    for (let i = 0; i < defaultNetworkOptions.maxPeers; i++) {
+      const peer = new PeerId(Buffer.from(`peer-${i}`));
+      peer.toB58String = () => `peer-${i}`;
+      seedPeers.push({
+        id: peer,
+        attnets: getAttnets([]),
+        syncnets: getSyncnets([]),
+        // to be populated later
+        score: 0,
+      });
+    }
+  });
+
+  const testCases: {
+    lowestScore: number;
+    highestScore: number;
+    requestedAttnets: {start: number; count: number};
+    requestedSyncNets: {start: number; count: number};
+    attnetPercentage: number;
+    syncnetPercentage: number;
+  }[] = [
+    {
+      lowestScore: -10,
+      highestScore: 0,
+      requestedAttnets: {start: 0, count: 32},
+      requestedSyncNets: {start: 0, count: 2},
+      attnetPercentage: 0.1,
+      syncnetPercentage: 0,
+    },
+    {
+      lowestScore: 0,
+      highestScore: 0,
+      requestedAttnets: {start: 0, count: 32},
+      requestedSyncNets: {start: 0, count: 2},
+      attnetPercentage: 0.25,
+      syncnetPercentage: 0.25,
+    },
+    {
+      lowestScore: 0,
+      highestScore: 0,
+      requestedAttnets: {start: 32, count: 32},
+      requestedSyncNets: {start: 0, count: 2},
+      attnetPercentage: 0.5,
+      syncnetPercentage: 0.5,
+    },
+    {
+      lowestScore: 0,
+      highestScore: 0,
+      requestedAttnets: {start: 0, count: 64},
+      requestedSyncNets: {start: 0, count: 4},
+      attnetPercentage: 0.75,
+      syncnetPercentage: 0.75,
+    },
+    {
+      lowestScore: 0,
+      highestScore: 0,
+      requestedAttnets: {start: 0, count: 64},
+      requestedSyncNets: {start: 0, count: 4},
+      attnetPercentage: 1,
+      syncnetPercentage: 1,
+    },
+  ];
+
+  for (const {
+    lowestScore,
+    highestScore,
+    requestedAttnets,
+    requestedSyncNets,
+    attnetPercentage,
+    syncnetPercentage,
+  } of testCases) {
+    itBench({
+      id: `prioritizePeers lowestScore ${lowestScore} highestScore ${highestScore} attnetPercentage ${attnetPercentage}, syncnetPercentage ${syncnetPercentage} requestedAttnets ${requestedAttnets.count}, requestedSyncNets ${requestedSyncNets.count}`,
+      beforeEach: () => {
+        /**
+         * Percentage of active attnet per peer starting from 0.
+         * The worse prune scenario is when we have too many subnet peers that's too grouped in some subnets
+         * No peer with no long-lived subnets
+         * No peer with bad score
+         **/
+        const connectedPeers = seedPeers.map((peer, i) => ({
+          ...peer,
+          attnets: getAttnets(
+            Array.from({length: Math.floor(attnetPercentage * ATTESTATION_SUBNET_COUNT)}, (_, i) => i)
+          ),
+          syncnets: getSyncnets(
+            Array.from({length: Math.floor(syncnetPercentage * SYNC_COMMITTEE_SUBNET_COUNT)}, (_, i) => i)
+          ),
+          score: lowestScore + ((highestScore - lowestScore) * i) / defaultNetworkOptions.maxPeers,
+        }));
+
+        const attnets: RequestedSubnet[] = [];
+        for (let i = 0; i < requestedAttnets.count; i++) {
+          attnets.push({subnet: requestedAttnets.start + i, toSlot: 1_000_000});
+        }
+
+        const syncnets: RequestedSubnet[] = [];
+        for (let i = 0; i < requestedSyncNets.count; i++) {
+          syncnets.push({subnet: requestedSyncNets.start + i, toSlot: 1_000_000});
+        }
+        return {connectedPeers, attnets, syncnets};
+      },
+      fn: ({connectedPeers, attnets, syncnets}) => {
+        prioritizePeers(connectedPeers, attnets, syncnets, defaultNetworkOptions);
+      },
+    });
+  }
+});

--- a/packages/lodestar/test/unit/network/peers/priorization.test.ts
+++ b/packages/lodestar/test/unit/network/peers/priorization.test.ts
@@ -24,6 +24,7 @@ describe("network / peers / priorization", () => {
     activeAttnets: number[];
     activeSyncnets: number[];
     opts: {targetPeers: number; maxPeers: number};
+    targetSubnetPeers: number;
     expectedResult: Result;
   }[] = [
     {
@@ -38,6 +39,7 @@ describe("network / peers / priorization", () => {
         attnetQueries: [{subnet: 3, maxPeersToDiscover: 1, toSlot: 0}],
         syncnetQueries: [],
       },
+      targetSubnetPeers: 1,
     },
     {
       id: "Don't request a subnet query when enough peers are connected to it",
@@ -51,6 +53,7 @@ describe("network / peers / priorization", () => {
         attnetQueries: [],
         syncnetQueries: [],
       },
+      targetSubnetPeers: 1,
     },
     {
       id: "Disconnect low score peers without duty",
@@ -74,6 +77,7 @@ describe("network / peers / priorization", () => {
         attnetQueries: [],
         syncnetQueries: [],
       },
+      targetSubnetPeers: 1,
     },
     {
       id: "Disconnect no long-lived-subnet peers without duty",
@@ -97,6 +101,7 @@ describe("network / peers / priorization", () => {
         attnetQueries: [],
         syncnetQueries: [],
       },
+      targetSubnetPeers: 1,
     },
     {
       id: "Disconnect no-duty peers that's too grouped in a subnet",
@@ -124,6 +129,7 @@ describe("network / peers / priorization", () => {
         attnetQueries: [],
         syncnetQueries: [],
       },
+      targetSubnetPeers: 1,
     },
     {
       id: "Disconnect no-duty peers that's too grouped in a subnet - ignore maxPeersSubnet",
@@ -154,6 +160,7 @@ describe("network / peers / priorization", () => {
         attnetQueries: [],
         syncnetQueries: [],
       },
+      targetSubnetPeers: 1,
     },
     {
       id: "Complete example: Disconnect peers and request a subnet query",
@@ -178,17 +185,32 @@ describe("network / peers / priorization", () => {
           })
         ),
         peersToConnect: 0,
-        attnetQueries: [{subnet: 3, maxPeersToDiscover: 2, toSlot: 0}],
+        attnetQueries: [{subnet: 3, maxPeersToDiscover: 1, toSlot: 0}],
         syncnetQueries: [],
       },
+      targetSubnetPeers: 2,
     },
 
     // TODO: Add a test case with syncnets priorization
   ];
 
-  for (const {id, connectedPeers, activeAttnets, activeSyncnets, opts, expectedResult} of testCases) {
+  for (const {
+    id,
+    connectedPeers,
+    activeAttnets,
+    activeSyncnets,
+    opts,
+    expectedResult,
+    targetSubnetPeers,
+  } of testCases) {
     it(id, () => {
-      const result = prioritizePeers(connectedPeers, toReqSubnet(activeAttnets), toReqSubnet(activeSyncnets), opts);
+      const result = prioritizePeers(
+        connectedPeers,
+        toReqSubnet(activeAttnets),
+        toReqSubnet(activeSyncnets),
+        opts,
+        targetSubnetPeers
+      );
       expect(cleanResult(result)).to.deep.equal(cleanResult(expectedResult));
     });
   }

--- a/packages/lodestar/test/unit/network/peers/priorization.test.ts
+++ b/packages/lodestar/test/unit/network/peers/priorization.test.ts
@@ -68,11 +68,9 @@ describe("network / peers / priorization", () => {
       opts: {targetPeers: 1, maxPeers: 1},
       expectedResult: {
         // Peers sorted by score, excluding with future duties
-        peersToDisconnect: new Map<string, PeerId[]>(
-          Object.entries({
-            [ExcessPeerDisconnectReason.LOW_SCORE]: [peers[3], peers[2], peers[1]],
-          })
-        ),
+        peersToDisconnect: new Map<ExcessPeerDisconnectReason, PeerId[]>([
+          [ExcessPeerDisconnectReason.LOW_SCORE, [peers[3], peers[2], peers[1]]],
+        ]),
         peersToConnect: 0,
         attnetQueries: [],
         syncnetQueries: [],
@@ -92,11 +90,9 @@ describe("network / peers / priorization", () => {
       opts: {targetPeers: 1, maxPeers: 1},
       expectedResult: {
         // Peers sorted by score, excluding with future duties
-        peersToDisconnect: new Map<string, PeerId[]>(
-          Object.entries({
-            [ExcessPeerDisconnectReason.NO_LONG_LIVED_SUBNET]: [peers[3], peers[2], peers[1]],
-          })
-        ),
+        peersToDisconnect: new Map<ExcessPeerDisconnectReason, PeerId[]>([
+          [ExcessPeerDisconnectReason.NO_LONG_LIVED_SUBNET, [peers[3], peers[2], peers[1]]],
+        ]),
         peersToConnect: 0,
         attnetQueries: [],
         syncnetQueries: [],
@@ -120,11 +116,9 @@ describe("network / peers / priorization", () => {
       opts: {targetPeers: 1, maxPeers: 1},
       expectedResult: {
         // Peers sorted by long lived subnets
-        peersToDisconnect: new Map<string, PeerId[]>(
-          Object.entries({
-            [ExcessPeerDisconnectReason.TOO_GROUPED_SUBNET]: [peers[3], peers[2], peers[1]],
-          })
-        ),
+        peersToDisconnect: new Map<ExcessPeerDisconnectReason, PeerId[]>([
+          [ExcessPeerDisconnectReason.TOO_GROUPED_SUBNET, [peers[3], peers[2], peers[1]]],
+        ]),
         peersToConnect: 0,
         attnetQueries: [],
         syncnetQueries: [],
@@ -151,11 +145,9 @@ describe("network / peers / priorization", () => {
       opts: {targetPeers: 1, maxPeers: 1},
       expectedResult: {
         // Peers sorted by long lived subnets
-        peersToDisconnect: new Map<string, PeerId[]>(
-          Object.entries({
-            [ExcessPeerDisconnectReason.TOO_GROUPED_SUBNET]: [peers[3]],
-          })
-        ),
+        peersToDisconnect: new Map<ExcessPeerDisconnectReason, PeerId[]>([
+          [ExcessPeerDisconnectReason.TOO_GROUPED_SUBNET, [peers[3]]],
+        ]),
         peersToConnect: 0,
         attnetQueries: [],
         syncnetQueries: [],
@@ -179,11 +171,9 @@ describe("network / peers / priorization", () => {
       opts: {targetPeers: 6, maxPeers: 6},
       expectedResult: {
         // Peers sorted by score, excluding with future duties
-        peersToDisconnect: new Map<string, PeerId[]>(
-          Object.entries({
-            [ExcessPeerDisconnectReason.LOW_SCORE]: [peers[5], peers[3]],
-          })
-        ),
+        peersToDisconnect: new Map<ExcessPeerDisconnectReason, PeerId[]>([
+          [ExcessPeerDisconnectReason.LOW_SCORE, [peers[5], peers[3]]],
+        ]),
         peersToConnect: 0,
         attnetQueries: [{subnet: 3, maxPeersToDiscover: 1, toSlot: 0}],
         syncnetQueries: [],

--- a/packages/lodestar/test/unit/network/peers/priorization.test.ts
+++ b/packages/lodestar/test/unit/network/peers/priorization.test.ts
@@ -193,14 +193,14 @@ describe("network / peers / priorization", () => {
     });
   }
 
-  function cleanResult(res: Result): Omit<Result, "peersToDisconnect"> & {peersToDisconnect: Map<string, string[]>} {
-    const toCleanResult = (peersToDisconnect: Map<string, PeerId[]>): Map<string, string[]> => {
-      const result = new Map<string, string[]>();
+  function cleanResult(res: Result): Omit<Result, "peersToDisconnect"> & {peersToDisconnect: string[]} {
+    const toCleanResult = (peersToDisconnect: Map<string, PeerId[]>): string[] => {
+      const result: string[] = [];
       for (const [reason, peers] of peersToDisconnect) {
-        result.set(
-          reason,
-          peers.map((peer) => peer.toB58String())
-        );
+        if (peers.length > 0) {
+          result.push(reason);
+        }
+        result.push(...peers.map((peer) => peer.toB58String()));
       }
       return result;
     };


### PR DESCRIPTION
**Motivation**

Right now when we have too many peers, we remove peers based on worse scored no-duty peers
+ We lack subnet peers
+ We have peers that have 0 long lived subnet
+ We want to continuously improve the long lived subnets of peer and balance the peer distribution per subnet

**Description**
Implement the prune logic when we have too many peers
- Remove peers that are not subscribed to a subnet and have no duties (they have less value)
- Remove worst scored no-duty peers
- Remove peers that we have many on any particular subne
  - Only consider removing peers on subnet that has > MAX_TARGET_SUBNET_PEERS to be safe
  - Do not remove peer that would drop us below targetPeersPerAttnetSubnet
  - Do not remove peer that would drop us below MIN_SYNC_COMMITTEE_PEERS
  - Choose peers that have less long lived subnet to remove first
 
Some other modification:
 - Number of peers per requested subnet is changed from 1 to 2
 - Due to the real score of lodestar node in mainnet, maxScore is 0 so we don't want to just remove peers with score < 0, I defined `LOW_SCORE_TO_PRUNE_IF_TOO_MANY_PEERS` constant for it, right now make it -2

closes #3940 

