### PR TITLE
Fix deserializeEnrSubnets

### DIFF
--- a/packages/lodestar/src/network/peers/utils/enrSubnetsDeserialize.ts
+++ b/packages/lodestar/src/network/peers/utils/enrSubnetsDeserialize.ts
@@ -17,10 +17,10 @@ export function deserializeEnrSubnets(bytes: Uint8Array, subnetCount: number): b
     return getUint8ByteToBitBooleanArray(bytes[0] ?? 0);
   }
 
-  const boolsArr: boolean[] = [];
+  let boolsArr: boolean[] = [];
   const byteCount = Math.ceil(subnetCount / 8);
   for (let i = 0; i < byteCount; i++) {
-    boolsArr.concat(getUint8ByteToBitBooleanArray(bytes[i] ?? 0));
+    boolsArr = boolsArr.concat(getUint8ByteToBitBooleanArray(bytes[i] ?? 0));
   }
 
   return boolsArr;

--- a/packages/lodestar/test/unit/network/peers/utils/enrSubnets.test.ts
+++ b/packages/lodestar/test/unit/network/peers/utils/enrSubnets.test.ts
@@ -6,7 +6,7 @@ import {expect} from "chai";
 import {deserializeEnrSubnets} from "../../../../../src/network/peers/utils/enrSubnetsDeserialize";
 
 describe("ENR syncnets", () => {
-  const testCases: {bytes: string; bools: boolean[]}[] = [
+  const syncnetTestCases: {bytes: string; bools: boolean[]}[] = [
     {bytes: "00", bools: [false, false, false, false]},
     {bytes: "01", bools: [true, false, false, false]},
     {bytes: "02", bools: [false, true, false, false]},
@@ -15,7 +15,7 @@ describe("ENR syncnets", () => {
     {bytes: "0f", bools: [true, true, true, true]},
   ];
 
-  for (const {bytes, bools} of testCases) {
+  for (const {bytes, bools} of syncnetTestCases) {
     it(`Deserialize syncnet ${bytes}`, () => {
       const bytesBuf = Buffer.from(bytes, "hex");
 
@@ -25,6 +25,90 @@ describe("ENR syncnets", () => {
 
       expect(
         deserializeEnrSubnets(bytesBuf, SYNC_COMMITTEE_SUBNET_COUNT).slice(0, SYNC_COMMITTEE_SUBNET_COUNT)
+      ).to.deep.equal(bools);
+    });
+  }
+
+  // ATTESTATION_SUBNET_COUNT = 64 is too much for unit test, make it 16
+  const ATTESTATION_SUBNET_COUNT = 16;
+  const attnetTestCases: {bytes: string; bools: boolean[]}[] = [
+    {
+      bytes: "1111",
+      bools: [
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+      ],
+    },
+    {
+      bytes: "2222",
+      bools: [
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+      ],
+    },
+    {
+      bytes: "3333",
+      bools: [true, true, false, false, true, true, false, false, true, true, false, false, true, true, false, false],
+    },
+    {
+      bytes: "4444",
+      bools: [
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+      ],
+    },
+    {
+      bytes: "ffff",
+      bools: [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true],
+    },
+  ];
+  for (const {bytes, bools} of attnetTestCases) {
+    const bytesBuf = Buffer.from(bytes, "hex");
+    it(`Deserialize attnet ${bytes}`, () => {
+      expect(
+        deserializeEnrSubnets(bytesBuf, ATTESTATION_SUBNET_COUNT).slice(0, ATTESTATION_SUBNET_COUNT)
       ).to.deep.equal(bools);
     });
   }


### PR DESCRIPTION
**Motivation**

Lodestar node is not able to connect to an attestation subnet peer because `deserializeEnrSubnets` always return an empty array

**Description**

Fix `deserializeEnrSubnets`

closes #3940 
