### PR TITLE
Fix bounded peersToConnect variable

### DIFF
--- a/packages/lodestar/src/network/peers/discover.ts
+++ b/packages/lodestar/src/network/peers/discover.ts
@@ -357,6 +357,8 @@ export class PeerDiscovery {
    * Peers that have been returned by discovery requests are dialed here if they are suitable.
    */
   private async dialPeer(cachedPeer: CachedENR): Promise<void> {
+    this.peersToConnect = Math.max(this.peersToConnect - 1, 0);
+
     const {peerId, multiaddrTCP} = cachedPeer;
 
     // Must add the multiaddrs array to the address book before dialing
@@ -374,7 +376,6 @@ export class PeerDiscovery {
     // Note: You must listen to the connected events to listen for a successful conn upgrade
     try {
       await this.libp2p.dial(peerId);
-      this.peersToConnect = Math.max(this.peersToConnect - 1, 0);
       timer?.({status: "success"});
       this.logger.debug("Dialed discovered peer", {peer: peerIdShort});
     } catch (e) {

--- a/packages/lodestar/src/network/peers/discover.ts
+++ b/packages/lodestar/src/network/peers/discover.ts
@@ -357,6 +357,12 @@ export class PeerDiscovery {
    * Peers that have been returned by discovery requests are dialed here if they are suitable.
    */
   private async dialPeer(cachedPeer: CachedENR): Promise<void> {
+    // we dial a peer when:
+    // - this.peersToConnect > 0
+    // - or the peer subscribes to a subnet that we want
+    // If this.peersToConnect is 3 while we need to dial 5 subnet peers, in that case we want this.peersToConnect
+    // to be 0 instead of a negative value. The next heartbeat may increase this.peersToConnect again if some dials
+    // are not successful.
     this.peersToConnect = Math.max(this.peersToConnect - 1, 0);
 
     const {peerId, multiaddrTCP} = cachedPeer;

--- a/packages/lodestar/src/network/peers/discover.ts
+++ b/packages/lodestar/src/network/peers/discover.ts
@@ -357,8 +357,6 @@ export class PeerDiscovery {
    * Peers that have been returned by discovery requests are dialed here if they are suitable.
    */
   private async dialPeer(cachedPeer: CachedENR): Promise<void> {
-    this.peersToConnect--;
-
     const {peerId, multiaddrTCP} = cachedPeer;
 
     // Must add the multiaddrs array to the address book before dialing
@@ -376,7 +374,7 @@ export class PeerDiscovery {
     // Note: You must listen to the connected events to listen for a successful conn upgrade
     try {
       await this.libp2p.dial(peerId);
-
+      this.peersToConnect = Math.max(this.peersToConnect - 1, 0);
       timer?.({status: "success"});
       this.logger.debug("Dialed discovered peer", {peer: peerIdShort});
     } catch (e) {


### PR DESCRIPTION
**Motivation**

The `peersToConnect` variable in PeerDiscovery is not bounded and becomes negative most of the time

<img width="969" alt="Screen Shot 2022-04-28 at 10 05 49" src="https://user-images.githubusercontent.com/10568965/165668527-f0d56a5f-55fd-415a-b468-2a217091a7e4.png">

**Description**

Make it min 0.

part of #3940
