### PR TITLE
Add ability to update the fee recipient for execution via beacon and/or validator defaults

### DIFF
--- a/packages/api/src/routes/validator.ts
+++ b/packages/api/src/routes/validator.ts
@@ -13,6 +13,7 @@ import {
   ssz,
   UintNum64,
   ValidatorIndex,
+  ExecutionAddress,
 } from "@chainsafe/lodestar-types";
 import {
   RoutesData,
@@ -42,6 +43,11 @@ export type SyncCommitteeSubscription = {
   validatorIndex: ValidatorIndex;
   syncCommitteeIndices: number[];
   untilEpoch: Epoch;
+};
+
+export type ProposerPreparationData = {
+  validatorIndex: ValidatorIndex;
+  feeRecipient: ExecutionAddress;
 };
 
 export type ProposerDuty = {
@@ -197,6 +203,8 @@ export type Api = {
   prepareBeaconCommitteeSubnet(subscriptions: BeaconCommitteeSubscription[]): Promise<void>;
 
   prepareSyncCommitteeSubnets(subscriptions: SyncCommitteeSubscription[]): Promise<void>;
+
+  prepareBeaconProposer(proposers: ProposerPreparationData[]): Promise<void>;
 };
 
 /**
@@ -215,6 +223,7 @@ export const routesData: RoutesData<Api> = {
   publishContributionAndProofs: {url: "/eth/v1/validator/contribution_and_proofs", method: "POST"},
   prepareBeaconCommitteeSubnet: {url: "/eth/v1/validator/beacon_committee_subscriptions", method: "POST"},
   prepareSyncCommitteeSubnets: {url: "/eth/v1/validator/sync_committee_subscriptions", method: "POST"},
+  prepareBeaconProposer: {url: "/eth/v1/validator/prepare_beacon_proposer", method: "POST"},
 };
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -231,6 +240,7 @@ export type ReqTypes = {
   publishContributionAndProofs: {body: unknown};
   prepareBeaconCommitteeSubnet: {body: unknown};
   prepareSyncCommitteeSubnets: {body: unknown};
+  prepareBeaconProposer: {body: unknown};
 };
 
 export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
@@ -250,6 +260,14 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
       validatorIndex: ssz.ValidatorIndex,
       syncCommitteeIndices: ArrayOf(ssz.CommitteeIndex),
       untilEpoch: ssz.Epoch,
+    },
+    {jsonCase: "eth2"}
+  );
+
+  const ProposerPreparationData = new ContainerType(
+    {
+      validatorIndex: ssz.ValidatorIndex,
+      feeRecipient: ssz.ExecutionAddress,
     },
     {jsonCase: "eth2"}
   );
@@ -330,6 +348,7 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
     publishContributionAndProofs: reqOnlyBody(ArrayOf(ssz.altair.SignedContributionAndProof), Schema.ObjectArray),
     prepareBeaconCommitteeSubnet: reqOnlyBody(ArrayOf(BeaconCommitteeSubscription), Schema.ObjectArray),
     prepareSyncCommitteeSubnets: reqOnlyBody(ArrayOf(SyncCommitteeSubscription), Schema.ObjectArray),
+    prepareBeaconProposer: reqOnlyBody(ArrayOf(ProposerPreparationData), Schema.ObjectArray),
   };
 }
 

--- a/packages/api/src/routes/validator.ts
+++ b/packages/api/src/routes/validator.ts
@@ -45,6 +45,10 @@ export type SyncCommitteeSubscription = {
   untilEpoch: Epoch;
 };
 
+/**
+ * The types used here are string instead of ssz based because the use of proposer data
+ * is just validator --> beacon json api call for `beaconProposerCache` cache update.
+ */
 export type ProposerPreparationData = {
   validatorIndex: string;
   feeRecipient: string;

--- a/packages/api/test/unit/validator.test.ts
+++ b/packages/api/test/unit/validator.test.ts
@@ -74,6 +74,10 @@ describe("validator", () => {
       args: [[{validatorIndex: 1, syncCommitteeIndices: [2], untilEpoch: 3}]],
       res: undefined,
     },
+    prepareBeaconProposer: {
+      args: [[{validatorIndex: 1, feeRecipient: new Uint8Array(20)}]],
+      res: undefined,
+    },
   });
 
   // TODO: Extra tests to implement maybe

--- a/packages/api/test/unit/validator.test.ts
+++ b/packages/api/test/unit/validator.test.ts
@@ -75,7 +75,7 @@ describe("validator", () => {
       res: undefined,
     },
     prepareBeaconProposer: {
-      args: [[{validatorIndex: 1, feeRecipient: new Uint8Array(20)}]],
+      args: [[{validatorIndex: "1", feeRecipient: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"}]],
       res: undefined,
     },
   });

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -11,7 +11,7 @@ import {onGracefulShutdown, parseFeeRecipient} from "../../util";
 import {getVersionData} from "../../util/version";
 import {getBeaconPaths} from "../beacon/paths";
 import {getValidatorPaths} from "./paths";
-import {IValidatorCliArgs, validatorMetricsDefaultOptions, defaultDefaultSuggestedFeeRecipient} from "./options";
+import {IValidatorCliArgs, validatorMetricsDefaultOptions, defaultDefaultFeeRecipient} from "./options";
 import {getLocalSecretKeys, getExternalSigners, groupExternalSignersByUrl} from "./keys";
 
 /**
@@ -21,9 +21,7 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
   await initBLS();
 
   const graffiti = args.graffiti || getDefaultGraffiti();
-  const defaultSuggestedFeeRecipient = parseFeeRecipient(
-    args.defaultSuggestedFeeRecipient ?? defaultDefaultSuggestedFeeRecipient
-  );
+  const defaultFeeRecipient = parseFeeRecipient(args.defaultFeeRecipient ?? defaultDefaultFeeRecipient);
 
   const validatorPaths = getValidatorPaths(args);
   const beaconPaths = getBeaconPaths(args);
@@ -132,7 +130,7 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
       signers,
       graffiti,
       afterBlockDelaySlotFraction: args.afterBlockDelaySlotFraction,
-      defaultSuggestedFeeRecipient,
+      defaultFeeRecipient,
     },
     controller.signal,
     metrics

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -7,11 +7,11 @@ import {RegistryMetricCreator, collectNodeJSMetrics, HttpMetricsServer} from "@c
 import {getBeaconConfigFromArgs} from "../../config";
 import {IGlobalArgs} from "../../options";
 import {YargsError, getDefaultGraffiti, initBLS, mkdir, getCliLogger} from "../../util";
-import {onGracefulShutdown} from "../../util";
+import {onGracefulShutdown, parseFeeRecipient} from "../../util";
 import {getVersionData} from "../../util/version";
 import {getBeaconPaths} from "../beacon/paths";
 import {getValidatorPaths} from "./paths";
-import {IValidatorCliArgs, validatorMetricsDefaultOptions} from "./options";
+import {IValidatorCliArgs, validatorMetricsDefaultOptions, defaultDefaultSuggestedFeeRecipient} from "./options";
 import {getLocalSecretKeys, getExternalSigners, groupExternalSignersByUrl} from "./keys";
 
 /**
@@ -21,6 +21,9 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
   await initBLS();
 
   const graffiti = args.graffiti || getDefaultGraffiti();
+  const defaultSuggestedFeeRecipient = parseFeeRecipient(
+    args.defaultSuggestedFeeRecipient ?? defaultDefaultSuggestedFeeRecipient
+  );
 
   const validatorPaths = getValidatorPaths(args);
   const beaconPaths = getBeaconPaths(args);
@@ -129,6 +132,7 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
       signers,
       graffiti,
       afterBlockDelaySlotFraction: args.afterBlockDelaySlotFraction,
+      defaultSuggestedFeeRecipient,
     },
     controller.signal,
     metrics

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -1,17 +1,18 @@
+import {defaultOptions} from "@chainsafe/lodestar";
 import {ICliCommandOptions, ILogArgs} from "../../util";
 import {defaultValidatorPaths} from "./paths";
 import {accountValidatorOptions, IAccountValidatorArgs} from "../account/cmds/validator/options";
 import {logOptions, beaconPathsOptions} from "../beacon/options";
 import {IBeaconPaths} from "../beacon/paths";
 import {KeymanagerArgs, keymanagerOptions} from "../../options/keymanagerOptions";
-import {defaultDefaultSuggestedFeeRecipient} from "@chainsafe/lodestar";
 
-export {defaultDefaultSuggestedFeeRecipient};
 export const validatorMetricsDefaultOptions = {
   enabled: false,
   port: 5064,
   address: "127.0.0.1",
 };
+
+export const defaultDefaultFeeRecipient = defaultOptions.chain.defaultFeeRecipient;
 
 export type IValidatorCliArgs = IAccountValidatorArgs &
   ILogArgs & {
@@ -21,7 +22,7 @@ export type IValidatorCliArgs = IAccountValidatorArgs &
     force: boolean;
     graffiti: string;
     afterBlockDelaySlotFraction?: number;
-    defaultSuggestedFeeRecipient?: string;
+    defaultFeeRecipient?: string;
 
     importKeystoresPath?: string[];
     importKeystoresPassword?: string;
@@ -72,10 +73,10 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
     type: "number",
   },
 
-  defaultSuggestedFeeRecipient: {
+  defaultFeeRecipient: {
     description:
       "Specify fee recipient default for collecting the EL block fees and rewards (a hex string representing 20 bytes address: ^0x[a-fA-F0-9]{40}$). It would be possible (WIP) to override this per validator key using config or keymanager API.",
-    default: defaultDefaultSuggestedFeeRecipient,
+    defaultDescription: defaultDefaultFeeRecipient,
     type: "string",
   },
 

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -4,7 +4,9 @@ import {accountValidatorOptions, IAccountValidatorArgs} from "../account/cmds/va
 import {logOptions, beaconPathsOptions} from "../beacon/options";
 import {IBeaconPaths} from "../beacon/paths";
 import {KeymanagerArgs, keymanagerOptions} from "../../options/keymanagerOptions";
+import {defaultDefaultSuggestedFeeRecipient} from "@chainsafe/lodestar";
 
+export {defaultDefaultSuggestedFeeRecipient};
 export const validatorMetricsDefaultOptions = {
   enabled: false,
   port: 5064,
@@ -19,6 +21,8 @@ export type IValidatorCliArgs = IAccountValidatorArgs &
     force: boolean;
     graffiti: string;
     afterBlockDelaySlotFraction?: number;
+    defaultSuggestedFeeRecipient?: string;
+
     importKeystoresPath?: string[];
     importKeystoresPassword?: string;
     externalSignerUrl?: string;
@@ -66,6 +70,13 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
     hidden: true,
     description: "Delay before publishing attestations if block comes early, as a fraction of SECONDS_PER_SLOT",
     type: "number",
+  },
+
+  defaultSuggestedFeeRecipient: {
+    description:
+      "Specify fee recipient default for collecting the EL block fees and rewards (a hex string representing 20 bytes address: ^0x[a-fA-F0-9]{40}$). It would be possible (WIP) to override this per validator key using config or keymanager API.",
+    default: defaultDefaultSuggestedFeeRecipient,
+    type: "string",
   },
 
   importKeystoresPath: {

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -23,6 +23,7 @@ export type IValidatorCliArgs = IAccountValidatorArgs &
     graffiti: string;
     afterBlockDelaySlotFraction?: number;
     defaultFeeRecipient?: string;
+    strictFeeRecipientCheck?: boolean;
 
     importKeystoresPath?: string[];
     importKeystoresPassword?: string;
@@ -78,6 +79,11 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
       "Specify fee recipient default for collecting the EL block fees and rewards (a hex string representing 20 bytes address: ^0x[a-fA-F0-9]{40}$). It would be possible (WIP) to override this per validator key using config or keymanager API.",
     defaultDescription: defaultDefaultFeeRecipient,
     type: "string",
+  },
+
+  strictFeeRecipientCheck: {
+    description: "Enable strict checking of the validator's feeRecipient with the one returned by engine",
+    type: "boolean",
   },
 
   importKeystoresPath: {

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -7,6 +7,7 @@ export interface IChainArgs {
   "chain.disableBlsBatchVerify": boolean;
   "chain.persistInvalidSszObjects": boolean;
   "chain.proposerBoostEnabled": boolean;
+  "chain.defaultFeeRecipient": string;
   "safe-slots-to-import-optimistically": number;
   // this is defined as part of IBeaconPaths
   // "chain.persistInvalidSszObjectsDir": string;
@@ -21,6 +22,7 @@ export function parseArgs(args: IChainArgs): IBeaconNodeOptions["chain"] {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
     persistInvalidSszObjectsDir: undefined as any,
     proposerBoostEnabled: args["chain.proposerBoostEnabled"],
+    defaultFeeRecipient: args["chain.defaultFeeRecipient"],
     safeSlotsToImportOptimistically: args["safe-slots-to-import-optimistically"],
   };
 }
@@ -63,6 +65,14 @@ Will double processing times. Use only for debugging purposes.",
     type: "boolean",
     description: "Enable proposer boost to reward a timely block",
     defaultDescription: String(defaultOptions.chain.proposerBoostEnabled),
+    group: "chain",
+  },
+
+  "chain.defaultFeeRecipient": {
+    description:
+      "Specify fee recipient default for collecting the EL block fees and rewards (a hex string representing 20 bytes address: ^0x[a-fA-F0-9]{40}$) in case validator fails to update for a validator index before calling produceBlock.",
+    defaultDescription: defaultOptions.chain.defaultFeeRecipient,
+    type: "string",
     group: "chain",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/execution.ts
+++ b/packages/cli/src/options/beaconNodeOptions/execution.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs";
 import {defaultOptions, IBeaconNodeOptions} from "@chainsafe/lodestar";
-import {ICliCommandOptions, extractJwtHexSecret} from "../../util";
+import {ICliCommandOptions, extractJwtHexSecret, parseFeeRecipientHex} from "../../util";
 
 export type ExecutionEngineArgs = {
   "execution.urls": string[];
   "execution.timeout": number;
+  defaultSuggestedFeeRecipient?: string;
   "jwt-secret"?: string;
 };
 
@@ -12,8 +13,20 @@ export function parseArgs(args: ExecutionEngineArgs): IBeaconNodeOptions["execut
   return {
     urls: args["execution.urls"],
     timeout: args["execution.timeout"],
+    /**
+     * jwtSecret is parsed as hex instead of bytes because the merge with defaults
+     * in beaconOptions messes up the bytes array as as index => value object
+     */
     jwtSecretHex: args["jwt-secret"]
       ? extractJwtHexSecret(fs.readFileSync(args["jwt-secret"], "utf-8").trim())
+      : undefined,
+    /**
+     * defaultSuggestedFeeRecipient is parsed as hex instead of ExecutionAddress
+     * bytes because the merge with defaults in beaconOptions messes up the bytes
+     * array as index => value object
+     */
+    defaultSuggestedFeeRecipientHex: args["defaultSuggestedFeeRecipient"]
+      ? parseFeeRecipientHex(args["defaultSuggestedFeeRecipient"])
       : undefined,
   };
 }
@@ -38,6 +51,17 @@ export const options: ICliCommandOptions<ExecutionEngineArgs> = {
   "jwt-secret": {
     description:
       "File path to a shared hex-encoded jwt secret which will be used to generate and bundle HS256 encoded jwt tokens for authentication with the EL client's rpc server hosting engine apis. Secret to be exactly same as the one used by the corresponding EL client.",
+    type: "string",
+    group: "execution",
+  },
+
+  defaultSuggestedFeeRecipient: {
+    description:
+      "Specify fee recipient default for collecting the EL block fees and rewards (a hex string representing 20 bytes address: ^0x[a-fA-F0-9]{40}$) in case validator fails to update for a validator index before calling produceBlock.",
+    default:
+      defaultOptions.executionEngine.mode === "http"
+        ? String(defaultOptions.executionEngine.defaultSuggestedFeeRecipientHex)
+        : "",
     type: "string",
     group: "execution",
   },

--- a/packages/cli/src/options/beaconNodeOptions/execution.ts
+++ b/packages/cli/src/options/beaconNodeOptions/execution.ts
@@ -1,11 +1,10 @@
 import fs from "node:fs";
 import {defaultOptions, IBeaconNodeOptions} from "@chainsafe/lodestar";
-import {ICliCommandOptions, extractJwtHexSecret, parseFeeRecipientHex} from "../../util";
+import {ICliCommandOptions, extractJwtHexSecret} from "../../util";
 
 export type ExecutionEngineArgs = {
   "execution.urls": string[];
   "execution.timeout": number;
-  defaultSuggestedFeeRecipient?: string;
   "jwt-secret"?: string;
 };
 
@@ -19,14 +18,6 @@ export function parseArgs(args: ExecutionEngineArgs): IBeaconNodeOptions["execut
      */
     jwtSecretHex: args["jwt-secret"]
       ? extractJwtHexSecret(fs.readFileSync(args["jwt-secret"], "utf-8").trim())
-      : undefined,
-    /**
-     * defaultSuggestedFeeRecipient is parsed as hex instead of ExecutionAddress
-     * bytes because the merge with defaults in beaconOptions messes up the bytes
-     * array as index => value object
-     */
-    defaultSuggestedFeeRecipientHex: args["defaultSuggestedFeeRecipient"]
-      ? parseFeeRecipientHex(args["defaultSuggestedFeeRecipient"])
       : undefined,
   };
 }
@@ -51,17 +42,6 @@ export const options: ICliCommandOptions<ExecutionEngineArgs> = {
   "jwt-secret": {
     description:
       "File path to a shared hex-encoded jwt secret which will be used to generate and bundle HS256 encoded jwt tokens for authentication with the EL client's rpc server hosting engine apis. Secret to be exactly same as the one used by the corresponding EL client.",
-    type: "string",
-    group: "execution",
-  },
-
-  defaultSuggestedFeeRecipient: {
-    description:
-      "Specify fee recipient default for collecting the EL block fees and rewards (a hex string representing 20 bytes address: ^0x[a-fA-F0-9]{40}$) in case validator fails to update for a validator index before calling produceBlock.",
-    default:
-      defaultOptions.executionEngine.mode === "http"
-        ? String(defaultOptions.executionEngine.defaultSuggestedFeeRecipientHex)
-        : "",
     type: "string",
     group: "execution",
   },

--- a/packages/cli/src/util/feeRecipient.ts
+++ b/packages/cli/src/util/feeRecipient.ts
@@ -1,0 +1,16 @@
+import {ExecutionAddress} from "@chainsafe/lodestar-types";
+import {fromHex} from "@chainsafe/lodestar-utils";
+
+export function parseFeeRecipientHex(feeRecipientHexString: string): string {
+  const hexPattern = new RegExp(/^(0x|0X)(?<feeRecipientString>[a-fA-F0-9]{40})$/, "g");
+  const feeRecipientStringMatch = hexPattern.exec(feeRecipientHexString);
+  const feeRecipientString = feeRecipientStringMatch?.groups?.feeRecipientString;
+  if (feeRecipientString === undefined)
+    throw Error(`Invalid feeRecipient= ${feeRecipientHexString}, expected format: ^0x[a-fA-F0-9]{40}$`);
+  return feeRecipientString;
+}
+
+export function parseFeeRecipient(feeRecipientHexString: string): ExecutionAddress {
+  const feeRecipientHex = parseFeeRecipientHex(feeRecipientHexString);
+  return fromHex(feeRecipientHex);
+}

--- a/packages/cli/src/util/feeRecipient.ts
+++ b/packages/cli/src/util/feeRecipient.ts
@@ -1,16 +1,9 @@
 import {ExecutionAddress} from "@chainsafe/lodestar-types";
 import {fromHex} from "@chainsafe/lodestar-utils";
 
-export function parseFeeRecipientHex(feeRecipientHexString: string): string {
-  const hexPattern = new RegExp(/^(0x|0X)(?<feeRecipientString>[a-fA-F0-9]{40})$/, "g");
-  const feeRecipientStringMatch = hexPattern.exec(feeRecipientHexString);
-  const feeRecipientString = feeRecipientStringMatch?.groups?.feeRecipientString;
-  if (feeRecipientString === undefined)
-    throw Error(`Invalid feeRecipient= ${feeRecipientHexString}, expected format: ^0x[a-fA-F0-9]{40}$`);
-  return feeRecipientString;
-}
-
-export function parseFeeRecipient(feeRecipientHexString: string): ExecutionAddress {
-  const feeRecipientHex = parseFeeRecipientHex(feeRecipientHexString);
-  return fromHex(feeRecipientHex);
+export function parseFeeRecipient(feeRecipientHex: string): ExecutionAddress {
+  if (!/^0x[a-fA-F0-9]{40}$/i.test(feeRecipientHex)) {
+    throw Error(`Invalid feeRecipient= ${feeRecipientHex}, expected format: ^0x[a-fA-F0-9]{40}$`);
+  }
+  return fromHex(feeRecipientHex.toLowerCase());
 }

--- a/packages/cli/src/util/feeRecipient.ts
+++ b/packages/cli/src/util/feeRecipient.ts
@@ -1,9 +1,6 @@
-import {ExecutionAddress} from "@chainsafe/lodestar-types";
-import {fromHex} from "@chainsafe/lodestar-utils";
-
-export function parseFeeRecipient(feeRecipientHex: string): ExecutionAddress {
+export function parseFeeRecipient(feeRecipientHex: string): string {
   if (!/^0x[a-fA-F0-9]{40}$/i.test(feeRecipientHex)) {
     throw Error(`Invalid feeRecipient= ${feeRecipientHex}, expected format: ^0x[a-fA-F0-9]{40}$`);
   }
-  return fromHex(feeRecipientHex.toLowerCase());
+  return feeRecipientHex.toLowerCase();
 }

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -17,3 +17,4 @@ export * from "./stripOffNewlines";
 export * from "./types";
 export * from "./bls";
 export * from "./jwt";
+export * from "./feeRecipient";

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -21,6 +21,7 @@ describe("options / beaconNodeOptions", () => {
       "chain.disableBlsBatchVerify": true,
       "chain.persistInvalidSszObjects": true,
       "chain.proposerBoostEnabled": false,
+      "chain.defaultFeeRecipient": "0xafa3f8684e54059998bc3a7b0d2b0da075154d66",
       "safe-slots-to-import-optimistically": 256,
 
       "eth1.enabled": true,
@@ -79,6 +80,7 @@ describe("options / beaconNodeOptions", () => {
         persistInvalidSszObjects: true,
         proposerBoostEnabled: false,
         safeSlotsToImportOptimistically: 256,
+        defaultFeeRecipient: "0xafa3f8684e54059998bc3a7b0d2b0da075154d66",
       },
       eth1: {
         enabled: true,

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -21,7 +21,7 @@ describe("options / beaconNodeOptions", () => {
       "chain.disableBlsBatchVerify": true,
       "chain.persistInvalidSszObjects": true,
       "chain.proposerBoostEnabled": false,
-      "chain.defaultFeeRecipient": "0xafa3f8684e54059998bc3a7b0d2b0da075154d66",
+      "chain.defaultFeeRecipient": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "safe-slots-to-import-optimistically": 256,
 
       "eth1.enabled": true,
@@ -80,7 +80,7 @@ describe("options / beaconNodeOptions", () => {
         persistInvalidSszObjects: true,
         proposerBoostEnabled: false,
         safeSlotsToImportOptimistically: 256,
-        defaultFeeRecipient: "0xafa3f8684e54059998bc3a7b0d2b0da075154d66",
+        defaultFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       },
       eth1: {
         enabled: true,

--- a/packages/cli/test/unit/validator/options.test.ts
+++ b/packages/cli/test/unit/validator/options.test.ts
@@ -4,7 +4,7 @@ import {parseFeeRecipient} from "../../../src/util";
 const feeRecipient = Buffer.from(Array.from({length: 20}, () => Math.round(Math.random() * 255)));
 const feeRecipientString = feeRecipient.toString("hex");
 
-describe("parseFeeRecipient", () => {
+describe("validator / parseFeeRecipient", () => {
   const testCases: string[] = [`0x${feeRecipientString}`, `0X${feeRecipientString}`];
   for (const testCase of testCases) {
     it(`parse ${testCase}`, () => {
@@ -13,7 +13,7 @@ describe("parseFeeRecipient", () => {
   }
 });
 
-describe("invalid feeRecipient", () => {
+describe("validator / invalid feeRecipient", () => {
   const testCases: string[] = [
     feeRecipientString,
     `X0${feeRecipientString}`,

--- a/packages/cli/test/unit/validator/options.test.ts
+++ b/packages/cli/test/unit/validator/options.test.ts
@@ -8,7 +8,7 @@ describe("validator / parseFeeRecipient", () => {
   const testCases: string[] = [`0x${feeRecipientString}`, `0X${feeRecipientString}`];
   for (const testCase of testCases) {
     it(`parse ${testCase}`, () => {
-      expect(feeRecipient).to.be.deep.equal(parseFeeRecipient(testCase));
+      expect(`0x${feeRecipientString}`).to.be.deep.equal(parseFeeRecipient(testCase));
     });
   }
 });

--- a/packages/cli/test/unit/validator/options.test.ts
+++ b/packages/cli/test/unit/validator/options.test.ts
@@ -1,0 +1,28 @@
+import {expect} from "chai";
+import {parseFeeRecipient} from "../../../src/util";
+
+const feeRecipient = Buffer.from(Array.from({length: 20}, () => Math.round(Math.random() * 255)));
+const feeRecipientString = feeRecipient.toString("hex");
+
+describe("parseFeeRecipient", () => {
+  const testCases: string[] = [`0x${feeRecipientString}`, `0X${feeRecipientString}`];
+  for (const testCase of testCases) {
+    it(`parse ${testCase}`, () => {
+      expect(feeRecipient).to.be.deep.equal(parseFeeRecipient(testCase));
+    });
+  }
+});
+
+describe("invalid feeRecipient", () => {
+  const testCases: string[] = [
+    feeRecipientString,
+    `X0${feeRecipientString}`,
+    `0x${feeRecipientString}13`,
+    `0x${feeRecipientString.substr(0, 38)}`,
+  ];
+  for (const testCase of testCases) {
+    it(`should error on ${testCase}`, () => {
+      expect(() => parseFeeRecipient(testCase)).to.throw();
+    });
+  }
+});

--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -584,7 +584,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
     },
 
     async prepareBeaconProposer(proposers) {
-      await chain.executionEngine.updateProposerPreparation(chain.clock.currentEpoch, proposers);
+      await chain.updateBeaconProposerData(chain.clock.currentEpoch, proposers);
     },
   };
 }

--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -183,8 +183,6 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
           slot,
           randaoReveal,
           graffiti: toGraffitiBuffer(graffiti || ""),
-          // TODO - TEMP
-          feeRecipient: Buffer.alloc(20, 0),
         }
       );
       metrics?.blockProductionSuccess.inc();
@@ -583,6 +581,10 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
       }
 
       network.prepareSyncCommitteeSubnets(subs);
+    },
+
+    async prepareBeaconProposer(proposers) {
+      await chain.executionEngine.updateProposerPreparation(chain.clock.currentEpoch, proposers);
     },
   };
 }

--- a/packages/lodestar/src/chain/beaconProposerCache.ts
+++ b/packages/lodestar/src/chain/beaconProposerCache.ts
@@ -1,12 +1,11 @@
 import {MapDef} from "../util/map";
 import {Epoch} from "@chainsafe/lodestar-types";
 import {IMetrics} from "../metrics";
+import {routes} from "@chainsafe/lodestar-api";
 
 const PROPOSER_PRESERVE_EPOCHS = 2;
-export type ProposerPreparationData = {
-  validatorIndex: string;
-  feeRecipient: string;
-};
+
+export type ProposerPreparationData = routes.validator.ProposerPreparationData;
 
 export class BeaconProposerCache {
   private readonly feeRecipientByValidatorIndex: MapDef<string, {epoch: Epoch; feeRecipient: string}>;

--- a/packages/lodestar/src/chain/beaconProposerCache.ts
+++ b/packages/lodestar/src/chain/beaconProposerCache.ts
@@ -1,0 +1,37 @@
+import {MapDef} from "../util/map";
+import {Epoch} from "@chainsafe/lodestar-types";
+import {IMetrics} from "../metrics";
+
+const PROPOSER_PRESERVE_EPOCHS = 2;
+export type ProposerPreparationData = {
+  validatorIndex: string;
+  feeRecipient: string;
+};
+
+export class BeaconProposerCache {
+  private readonly feeRecipientByValidatorIndex: MapDef<string, {epoch: Epoch; feeRecipient: string}>;
+  constructor(opts: {defaultFeeRecipient: string}, private readonly metrics?: IMetrics | null) {
+    this.feeRecipientByValidatorIndex = new MapDef<string, {epoch: Epoch; feeRecipient: string}>(() => ({
+      epoch: 0,
+      feeRecipient: opts.defaultFeeRecipient,
+    }));
+  }
+
+  add(epoch: Epoch, {validatorIndex, feeRecipient}: ProposerPreparationData): void {
+    this.feeRecipientByValidatorIndex.set(validatorIndex, {epoch, feeRecipient});
+  }
+
+  prune(epoch: Epoch): void {
+    // This is not so optimized function, but could maintain a 2d array may be?
+    for (const [validatorIndex, feeRecipientEntry] of this.feeRecipientByValidatorIndex.entries()) {
+      // We only retain an entry for PROPOSER_PRESERVE_EPOCHS epochs
+      if (feeRecipientEntry.epoch + PROPOSER_PRESERVE_EPOCHS > epoch) {
+        this.feeRecipientByValidatorIndex.delete(validatorIndex);
+      }
+    }
+  }
+
+  get(proposerIndex: number | string): string {
+    return this.feeRecipientByValidatorIndex.getOrDefault(`${proposerIndex}`).feeRecipient;
+  }
+}

--- a/packages/lodestar/src/chain/beaconProposerCache.ts
+++ b/packages/lodestar/src/chain/beaconProposerCache.ts
@@ -25,7 +25,7 @@ export class BeaconProposerCache {
     // This is not so optimized function, but could maintain a 2d array may be?
     for (const [validatorIndex, feeRecipientEntry] of this.feeRecipientByValidatorIndex.entries()) {
       // We only retain an entry for PROPOSER_PRESERVE_EPOCHS epochs
-      if (feeRecipientEntry.epoch + PROPOSER_PRESERVE_EPOCHS > epoch) {
+      if (feeRecipientEntry.epoch + PROPOSER_PRESERVE_EPOCHS < epoch) {
         this.feeRecipientByValidatorIndex.delete(validatorIndex);
       }
     }

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -13,18 +13,8 @@ import {
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {
-  allForks,
-  UintNum64,
-  Root,
-  phase0,
-  Slot,
-  RootHex,
-  ValidatorIndex,
-  ExecutionAddress,
-  Epoch,
-} from "@chainsafe/lodestar-types";
-import {ILogger, fromHex} from "@chainsafe/lodestar-utils";
+import {allForks, UintNum64, Root, phase0, Slot, RootHex, Epoch} from "@chainsafe/lodestar-types";
+import {ILogger} from "@chainsafe/lodestar-utils";
 import {fromHexString} from "@chainsafe/ssz";
 import {AbortController} from "@chainsafe/abort-controller";
 import {GENESIS_EPOCH, ZERO_HASH} from "../constants";
@@ -102,7 +92,7 @@ export class BeaconChain implements IBeaconChain {
   readonly pubkey2index: PubkeyIndexMap;
   readonly index2pubkey: Index2PubkeyCache;
 
-  readonly beaconProposerCache: MapDef<ValidatorIndex, {epoch: Epoch; feeRecipient: ExecutionAddress}>;
+  readonly beaconProposerCache: MapDef<string, {epoch: Epoch; feeRecipient: string}>;
 
   protected readonly blockProcessor: BlockProcessor;
   protected readonly db: IBeaconDb;
@@ -161,9 +151,9 @@ export class BeaconChain implements IBeaconChain {
     this.pubkey2index = new PubkeyIndexMap();
     this.index2pubkey = [];
 
-    this.beaconProposerCache = new MapDef<ValidatorIndex, {epoch: Epoch; feeRecipient: ExecutionAddress}>(() => ({
+    this.beaconProposerCache = new MapDef<string, {epoch: Epoch; feeRecipient: string}>(() => ({
       epoch: 0,
-      feeRecipient: fromHex(opts.defaultFeeRecipient),
+      feeRecipient: opts.defaultFeeRecipient,
     }));
 
     // Restore state caches

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -13,8 +13,18 @@ import {
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
-import {allForks, UintNum64, Root, phase0, Slot, RootHex} from "@chainsafe/lodestar-types";
-import {ILogger} from "@chainsafe/lodestar-utils";
+import {
+  allForks,
+  UintNum64,
+  Root,
+  phase0,
+  Slot,
+  RootHex,
+  ValidatorIndex,
+  ExecutionAddress,
+  Epoch,
+} from "@chainsafe/lodestar-types";
+import {ILogger, fromHex} from "@chainsafe/lodestar-utils";
 import {fromHexString} from "@chainsafe/ssz";
 import {AbortController} from "@chainsafe/abort-controller";
 import {GENESIS_EPOCH, ZERO_HASH} from "../constants";
@@ -25,7 +35,7 @@ import {BlockProcessor, PartiallyVerifiedBlockFlags} from "./blocks";
 import {IBeaconClock, LocalClock} from "./clock";
 import {ChainEventEmitter} from "./emitter";
 import {handleChainEvents} from "./eventHandlers";
-import {IBeaconChain, SSZObjectType} from "./interface";
+import {IBeaconChain, SSZObjectType, ProposerPreparationData} from "./interface";
 import {IChainOptions} from "./options";
 import {IStateRegenerator, QueuedStateRegenerator, RegenCaller} from "./regen";
 import {initializeForkChoice} from "./forkChoice";
@@ -52,6 +62,7 @@ import {IExecutionEngine} from "../executionEngine";
 import {PrecomputeNextEpochTransitionScheduler} from "./precomputeNextEpochTransition";
 import {ReprocessController} from "./reprocess";
 import {SeenAggregatedAttestations} from "./seenCache/seenAggregateAndProof";
+import {MapDef} from "../util/map";
 
 export class BeaconChain implements IBeaconChain {
   readonly genesisTime: UintNum64;
@@ -90,6 +101,8 @@ export class BeaconChain implements IBeaconChain {
   // Global state caches
   readonly pubkey2index: PubkeyIndexMap;
   readonly index2pubkey: Index2PubkeyCache;
+
+  readonly beaconProposerCache: MapDef<ValidatorIndex, {epoch: Epoch; feeRecipient: ExecutionAddress}>;
 
   protected readonly blockProcessor: BlockProcessor;
   protected readonly db: IBeaconDb;
@@ -147,6 +160,11 @@ export class BeaconChain implements IBeaconChain {
     // Initialize single global instance of state caches
     this.pubkey2index = new PubkeyIndexMap();
     this.index2pubkey = [];
+
+    this.beaconProposerCache = new MapDef<ValidatorIndex, {epoch: Epoch; feeRecipient: ExecutionAddress}>(() => ({
+      epoch: 0,
+      feeRecipient: fromHex(opts.defaultFeeRecipient),
+    }));
 
     // Restore state caches
     const cachedState = createCachedBeaconState(anchorState, {
@@ -315,5 +333,11 @@ export class BeaconChain implements IBeaconChain {
       fs.writeFileSync(fileName, bytes);
     }
     return fileName;
+  }
+
+  async updateBeaconProposerData(epoch: Epoch, proposers: ProposerPreparationData[]): Promise<void> {
+    proposers.forEach(({validatorIndex, feeRecipient}) => {
+      this.beaconProposerCache.set(validatorIndex, {epoch, feeRecipient});
+    });
   }
 }

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -97,6 +97,7 @@ export function onClockEpoch(this: BeaconChain, currentEpoch: Epoch): void {
   this.seenAttesters.prune(currentEpoch);
   this.seenAggregators.prune(currentEpoch);
   this.seenAggregatedAttestations.prune(currentEpoch);
+  this.beaconProposerCache.prune(currentEpoch);
 }
 
 export function onForkVersion(this: BeaconChain, version: Version): void {

--- a/packages/lodestar/src/chain/factory/block/body.ts
+++ b/packages/lodestar/src/chain/factory/block/body.ts
@@ -13,6 +13,7 @@ import {
   Slot,
   ssz,
   ExecutionAddress,
+  ValidatorIndex,
 } from "@chainsafe/lodestar-types";
 import {
   CachedBeaconStateAllForks,
@@ -37,14 +38,14 @@ export async function assembleBody(
     blockSlot,
     parentSlot,
     parentBlockRoot,
-    feeRecipient,
+    proposerIndex,
   }: {
     randaoReveal: Bytes96;
     graffiti: Bytes32;
     blockSlot: Slot;
     parentSlot: Slot;
     parentBlockRoot: Root;
-    feeRecipient: ExecutionAddress;
+    proposerIndex: ValidatorIndex;
   }
 ): Promise<allForks.BeaconBlockBody> {
   // TODO:
@@ -89,9 +90,21 @@ export async function assembleBody(
     // - Call prepareExecutionPayload again if parameters change
 
     const finalizedBlockHash = chain.forkChoice.getFinalizedBlock().executionPayloadBlockHash;
+    const feeRecipient = chain.executionEngine.proposers.getOrDefault(proposerIndex).feeRecipient;
 
     // prepareExecutionPayload will throw error via notifyForkchoiceUpdate if
     // the EL returns Syncing on this request to prepare a payload
+    //
+    // TODO:
+    // The payloadId should be extracted from the ones cached in the execution engine
+    // by the advance firing of the fcU. If no entry in the cache is available then
+    // continue with the usual firing, but this will most likely not generate a full
+    // block. However some timing consideration can be done here to bundle some time
+    // for the same.
+    //
+    // For MeV boost integration as well, this is where the execution header will be
+    // fetched from the payload id and a blinded block will be produced instead of
+    // fullblock for the validator to sign
     const payloadId = await prepareExecutionPayload(
       chain,
       finalizedBlockHash ?? ZERO_HASH_HEX,

--- a/packages/lodestar/src/chain/factory/block/body.ts
+++ b/packages/lodestar/src/chain/factory/block/body.ts
@@ -12,7 +12,6 @@ import {
   RootHex,
   Slot,
   ssz,
-  ExecutionAddress,
   ValidatorIndex,
 } from "@chainsafe/lodestar-types";
 import {
@@ -90,7 +89,7 @@ export async function assembleBody(
     // - Call prepareExecutionPayload again if parameters change
 
     const finalizedBlockHash = chain.forkChoice.getFinalizedBlock().executionPayloadBlockHash;
-    const feeRecipient = chain.beaconProposerCache.getOrDefault(proposerIndex).feeRecipient;
+    const feeRecipient = chain.beaconProposerCache.getOrDefault(`${proposerIndex}`).feeRecipient;
 
     // prepareExecutionPayload will throw error via notifyForkchoiceUpdate if
     // the EL returns Syncing on this request to prepare a payload
@@ -134,7 +133,7 @@ async function prepareExecutionPayload(
   chain: IBeaconChain,
   finalizedBlockHash: RootHex,
   state: CachedBeaconStateBellatrix,
-  suggestedFeeRecipient: ExecutionAddress
+  suggestedFeeRecipient: string
 ): Promise<PayloadId | null> {
   // Use different POW block hash parent for block production based on merge status.
   // Returned value of null == using an empty ExecutionPayload value

--- a/packages/lodestar/src/chain/factory/block/body.ts
+++ b/packages/lodestar/src/chain/factory/block/body.ts
@@ -89,7 +89,7 @@ export async function assembleBody(
     // - Call prepareExecutionPayload again if parameters change
 
     const finalizedBlockHash = chain.forkChoice.getFinalizedBlock().executionPayloadBlockHash;
-    const feeRecipient = chain.beaconProposerCache.getOrDefault(`${proposerIndex}`).feeRecipient;
+    const feeRecipient = chain.beaconProposerCache.get(proposerIndex);
 
     // prepareExecutionPayload will throw error via notifyForkchoiceUpdate if
     // the EL returns Syncing on this request to prepare a payload

--- a/packages/lodestar/src/chain/factory/block/body.ts
+++ b/packages/lodestar/src/chain/factory/block/body.ts
@@ -90,7 +90,7 @@ export async function assembleBody(
     // - Call prepareExecutionPayload again if parameters change
 
     const finalizedBlockHash = chain.forkChoice.getFinalizedBlock().executionPayloadBlockHash;
-    const feeRecipient = chain.executionEngine.proposers.getOrDefault(proposerIndex).feeRecipient;
+    const feeRecipient = chain.beaconProposerCache.getOrDefault(proposerIndex).feeRecipient;
 
     // prepareExecutionPayload will throw error via notifyForkchoiceUpdate if
     // the EL returns Syncing on this request to prepare a payload

--- a/packages/lodestar/src/chain/factory/block/index.ts
+++ b/packages/lodestar/src/chain/factory/block/index.ts
@@ -3,7 +3,7 @@
  */
 
 import {CachedBeaconStateAllForks, allForks} from "@chainsafe/lodestar-beacon-state-transition";
-import {Bytes32, Bytes96, ExecutionAddress, Root, Slot} from "@chainsafe/lodestar-types";
+import {Bytes32, Bytes96, Root, Slot} from "@chainsafe/lodestar-types";
 import {fromHexString} from "@chainsafe/ssz";
 
 import {ZERO_HASH} from "../../../constants";
@@ -23,21 +23,20 @@ export async function assembleBlock(
     randaoReveal,
     graffiti,
     slot,
-    feeRecipient,
   }: {
     randaoReveal: Bytes96;
     graffiti: Bytes32;
     slot: Slot;
-    feeRecipient: ExecutionAddress;
   }
 ): Promise<allForks.BeaconBlock> {
   const head = chain.forkChoice.getHead();
   const state = await chain.regen.getBlockSlotState(head.blockRoot, slot, RegenCaller.produceBlock);
   const parentBlockRoot = fromHexString(head.blockRoot);
+  const proposerIndex = state.epochCtx.getBeaconProposer(slot);
 
   const block: allForks.BeaconBlock = {
     slot,
-    proposerIndex: state.epochCtx.getBeaconProposer(slot),
+    proposerIndex,
     parentRoot: parentBlockRoot,
     stateRoot: ZERO_HASH,
     body: await assembleBody(chain, state, {
@@ -46,7 +45,7 @@ export async function assembleBlock(
       blockSlot: slot,
       parentSlot: slot - 1,
       parentBlockRoot,
-      feeRecipient,
+      proposerIndex,
     }),
   };
 

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -23,7 +23,7 @@ import {AggregatedAttestationPool} from "./opPools/aggregatedAttestationPool";
 import {PartiallyVerifiedBlockFlags} from "./blocks/types";
 import {ReprocessController} from "./reprocess";
 import {SeenAggregatedAttestations} from "./seenCache/seenAggregateAndProof";
-import {MapDef} from "../util/map";
+import {BeaconProposerCache, ProposerPreparationData} from "./beaconProposerCache";
 
 export type Eth2Context = {
   activeValidatorCount: number;
@@ -31,10 +31,7 @@ export type Eth2Context = {
   currentEpoch: number;
 };
 
-export type ProposerPreparationData = {
-  validatorIndex: string;
-  feeRecipient: string;
-};
+export {ProposerPreparationData};
 
 /**
  * The IBeaconChain service deals with processing incoming blocks, advancing a state transition
@@ -76,7 +73,7 @@ export interface IBeaconChain {
   readonly seenSyncCommitteeMessages: SeenSyncCommitteeMessages;
   readonly seenContributionAndProof: SeenContributionAndProof;
 
-  readonly beaconProposerCache: MapDef<string, {epoch: Epoch; feeRecipient: string}>;
+  readonly beaconProposerCache: BeaconProposerCache;
 
   /** Stop beacon chain processing */
   close(): void;

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -1,4 +1,14 @@
-import {allForks, UintNum64, Root, phase0, Slot, RootHex} from "@chainsafe/lodestar-types";
+import {
+  allForks,
+  UintNum64,
+  Root,
+  phase0,
+  Slot,
+  RootHex,
+  ValidatorIndex,
+  ExecutionAddress,
+  Epoch,
+} from "@chainsafe/lodestar-types";
 import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
@@ -23,11 +33,17 @@ import {AggregatedAttestationPool} from "./opPools/aggregatedAttestationPool";
 import {PartiallyVerifiedBlockFlags} from "./blocks/types";
 import {ReprocessController} from "./reprocess";
 import {SeenAggregatedAttestations} from "./seenCache/seenAggregateAndProof";
+import {MapDef} from "../util/map";
 
 export type Eth2Context = {
   activeValidatorCount: number;
   currentSlot: number;
   currentEpoch: number;
+};
+
+export type ProposerPreparationData = {
+  validatorIndex: ValidatorIndex;
+  feeRecipient: ExecutionAddress;
 };
 
 /**
@@ -70,6 +86,8 @@ export interface IBeaconChain {
   readonly seenSyncCommitteeMessages: SeenSyncCommitteeMessages;
   readonly seenContributionAndProof: SeenContributionAndProof;
 
+  readonly beaconProposerCache: MapDef<ValidatorIndex, {epoch: Epoch; feeRecipient: ExecutionAddress}>;
+
   /** Stop beacon chain processing */
   close(): void;
   /** Populate in-memory caches with persisted data. Call at least once on startup */
@@ -99,6 +117,8 @@ export interface IBeaconChain {
 
   /** Persist bad items to persistInvalidSszObjectsDir dir, for example invalid state, attestations etc. */
   persistInvalidSszObject(type: SSZObjectType, bytes: Uint8Array, suffix: string): string | null;
+
+  updateBeaconProposerData(epoch: Epoch, proposers: ProposerPreparationData[]): Promise<void>;
 }
 
 export type SSZObjectType =

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -1,14 +1,4 @@
-import {
-  allForks,
-  UintNum64,
-  Root,
-  phase0,
-  Slot,
-  RootHex,
-  ValidatorIndex,
-  ExecutionAddress,
-  Epoch,
-} from "@chainsafe/lodestar-types";
+import {allForks, UintNum64, Root, phase0, Slot, RootHex, Epoch} from "@chainsafe/lodestar-types";
 import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
@@ -42,8 +32,8 @@ export type Eth2Context = {
 };
 
 export type ProposerPreparationData = {
-  validatorIndex: ValidatorIndex;
-  feeRecipient: ExecutionAddress;
+  validatorIndex: string;
+  feeRecipient: string;
 };
 
 /**
@@ -86,7 +76,7 @@ export interface IBeaconChain {
   readonly seenSyncCommitteeMessages: SeenSyncCommitteeMessages;
   readonly seenContributionAndProof: SeenContributionAndProof;
 
-  readonly beaconProposerCache: MapDef<ValidatorIndex, {epoch: Epoch; feeRecipient: ExecutionAddress}>;
+  readonly beaconProposerCache: MapDef<string, {epoch: Epoch; feeRecipient: string}>;
 
   /** Stop beacon chain processing */
   close(): void;

--- a/packages/lodestar/src/chain/options.ts
+++ b/packages/lodestar/src/chain/options.ts
@@ -1,4 +1,6 @@
 import {SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY} from "@chainsafe/lodestar-params";
+import {defaultDefaultFeeRecipient} from "@chainsafe/lodestar-validator";
+
 import {ArchiverOpts} from "./archiver";
 import {ForkChoiceOpts} from "./forkChoice";
 
@@ -24,8 +26,6 @@ export type BlockProcessOpts = {
    */
   safeSlotsToImportOptimistically: number;
 };
-
-export const defaultDefaultFeeRecipient = "0x0000000000000000000000000000000000000000";
 
 export const defaultChainOptions: IChainOptions = {
   blsVerifyAllMainThread: false,

--- a/packages/lodestar/src/chain/options.ts
+++ b/packages/lodestar/src/chain/options.ts
@@ -10,6 +10,7 @@ export type IChainOptions = BlockProcessOpts &
     blsVerifyAllMultiThread?: boolean;
     persistInvalidSszObjects?: boolean;
     persistInvalidSszObjectsDir?: string;
+    defaultFeeRecipient: string;
   };
 
 export type BlockProcessOpts = {
@@ -24,6 +25,8 @@ export type BlockProcessOpts = {
   safeSlotsToImportOptimistically: number;
 };
 
+export const defaultDefaultFeeRecipient = "0x0000000000000000000000000000000000000000";
+
 export const defaultChainOptions: IChainOptions = {
   blsVerifyAllMainThread: false,
   blsVerifyAllMultiThread: false,
@@ -32,4 +35,5 @@ export const defaultChainOptions: IChainOptions = {
   persistInvalidSszObjectsDir: "",
   proposerBoostEnabled: true,
   safeSlotsToImportOptimistically: SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY,
+  defaultFeeRecipient: defaultDefaultFeeRecipient,
 };

--- a/packages/lodestar/src/executionEngine/disabled.ts
+++ b/packages/lodestar/src/executionEngine/disabled.ts
@@ -1,13 +1,6 @@
-import {ValidatorIndex, Epoch, ExecutionAddress} from "@chainsafe/lodestar-types";
-import {MapDef} from "../util/map";
 import {IExecutionEngine} from "./interface";
 
 export class ExecutionEngineDisabled implements IExecutionEngine {
-  readonly proposers = new MapDef<ValidatorIndex, {epoch: Epoch; feeRecipient: ExecutionAddress}>(() => ({
-    epoch: 0,
-    feeRecipient: Buffer.alloc(20, 0),
-  }));
-
   async notifyNewPayload(): Promise<never> {
     throw Error("Execution engine disabled");
   }
@@ -17,10 +10,6 @@ export class ExecutionEngineDisabled implements IExecutionEngine {
   }
 
   async getPayload(): Promise<never> {
-    throw Error("Execution engine disabled");
-  }
-
-  async updateProposerPreparation(): Promise<never> {
     throw Error("Execution engine disabled");
   }
 }

--- a/packages/lodestar/src/executionEngine/disabled.ts
+++ b/packages/lodestar/src/executionEngine/disabled.ts
@@ -1,6 +1,13 @@
+import {ValidatorIndex, Epoch, ExecutionAddress} from "@chainsafe/lodestar-types";
+import {MapDef} from "../util/map";
 import {IExecutionEngine} from "./interface";
 
 export class ExecutionEngineDisabled implements IExecutionEngine {
+  readonly proposers = new MapDef<ValidatorIndex, {epoch: Epoch; feeRecipient: ExecutionAddress}>(() => ({
+    epoch: 0,
+    feeRecipient: Buffer.alloc(20, 0),
+  }));
+
   async notifyNewPayload(): Promise<never> {
     throw Error("Execution engine disabled");
   }
@@ -10,6 +17,10 @@ export class ExecutionEngineDisabled implements IExecutionEngine {
   }
 
   async getPayload(): Promise<never> {
+    throw Error("Execution engine disabled");
+  }
+
+  async updateProposerPreparation(): Promise<never> {
     throw Error("Execution engine disabled");
   }
 }

--- a/packages/lodestar/src/executionEngine/http.ts
+++ b/packages/lodestar/src/executionEngine/http.ts
@@ -1,5 +1,5 @@
 import {AbortSignal} from "@chainsafe/abort-controller";
-import {bellatrix, RootHex, Root} from "@chainsafe/lodestar-types";
+import {bellatrix, RootHex, Root, Epoch, ExecutionAddress, ValidatorIndex} from "@chainsafe/lodestar-types";
 import {BYTES_PER_LOGS_BLOOM} from "@chainsafe/lodestar-params";
 import {fromHex} from "@chainsafe/lodestar-utils";
 
@@ -22,7 +22,9 @@ import {
   PayloadId,
   PayloadAttributes,
   ApiPayloadAttributes,
+  ProposerPreparationData,
 } from "./interface";
+import {MapDef} from "../util/map";
 
 export type ExecutionEngineHttpOpts = {
   urls: string[];
@@ -34,8 +36,10 @@ export type ExecutionEngineHttpOpts = {
    * +-5 seconds interval.
    */
   jwtSecretHex?: string;
+  defaultSuggestedFeeRecipientHex?: string;
 };
 
+export const defaultDefaultSuggestedFeeRecipient = "0x0000000000000000000000000000000000000000";
 export const defaultExecutionEngineHttpOpts: ExecutionEngineHttpOpts = {
   /**
    * By default ELs host engine api on an auth protected 8551 port, would need a jwt secret to be
@@ -44,6 +48,7 @@ export const defaultExecutionEngineHttpOpts: ExecutionEngineHttpOpts = {
    */
   urls: ["http://localhost:8551"],
   timeout: 12000,
+  defaultSuggestedFeeRecipientHex: defaultDefaultSuggestedFeeRecipient,
 };
 
 /**
@@ -56,9 +61,15 @@ export const defaultExecutionEngineHttpOpts: ExecutionEngineHttpOpts = {
  * https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.1/src/engine/interop/specification.md
  */
 export class ExecutionEngineHttp implements IExecutionEngine {
+  readonly proposers: MapDef<ValidatorIndex, {epoch: Epoch; feeRecipient: ExecutionAddress}>;
   private readonly rpc: IJsonRpcHttpClient;
 
   constructor(opts: ExecutionEngineHttpOpts, signal: AbortSignal, rpc?: IJsonRpcHttpClient) {
+    const feeRecipient = fromHex(opts.defaultSuggestedFeeRecipientHex ?? defaultDefaultSuggestedFeeRecipient);
+    this.proposers = new MapDef<ValidatorIndex, {epoch: Epoch; feeRecipient: ExecutionAddress}>(() => ({
+      epoch: 0,
+      feeRecipient,
+    }));
     this.rpc =
       rpc ??
       new JsonRpcHttpClient(opts.urls, {
@@ -270,6 +281,12 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     });
 
     return parseExecutionPayload(executionPayloadRpc);
+  }
+
+  async updateProposerPreparation(epoch: Epoch, proposers: ProposerPreparationData[]): Promise<void> {
+    proposers.forEach(({validatorIndex, feeRecipient}) => {
+      this.proposers.set(validatorIndex, {epoch, feeRecipient});
+    });
   }
 }
 

--- a/packages/lodestar/src/executionEngine/http.ts
+++ b/packages/lodestar/src/executionEngine/http.ts
@@ -200,7 +200,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
       ? {
           timestamp: numToQuantity(payloadAttributes.timestamp),
           prevRandao: bytesToData(payloadAttributes.prevRandao),
-          suggestedFeeRecipient: bytesToData(payloadAttributes.suggestedFeeRecipient),
+          suggestedFeeRecipient: payloadAttributes.suggestedFeeRecipient,
         }
       : undefined;
 

--- a/packages/lodestar/src/executionEngine/index.ts
+++ b/packages/lodestar/src/executionEngine/index.ts
@@ -1,10 +1,21 @@
 import {AbortSignal} from "@chainsafe/abort-controller";
 import {IExecutionEngine} from "./interface";
 import {ExecutionEngineDisabled} from "./disabled";
-import {ExecutionEngineHttp, ExecutionEngineHttpOpts, defaultExecutionEngineHttpOpts} from "./http";
+import {
+  ExecutionEngineHttp,
+  ExecutionEngineHttpOpts,
+  defaultExecutionEngineHttpOpts,
+  defaultDefaultSuggestedFeeRecipient,
+} from "./http";
 import {ExecutionEngineMock, ExecutionEngineMockOpts} from "./mock";
 
-export {IExecutionEngine, ExecutionEngineHttp, ExecutionEngineDisabled, ExecutionEngineMock};
+export {
+  IExecutionEngine,
+  ExecutionEngineHttp,
+  ExecutionEngineDisabled,
+  ExecutionEngineMock,
+  defaultDefaultSuggestedFeeRecipient,
+};
 
 export type ExecutionEngineOpts =
   | ({mode?: "http"} & ExecutionEngineHttpOpts)

--- a/packages/lodestar/src/executionEngine/index.ts
+++ b/packages/lodestar/src/executionEngine/index.ts
@@ -1,21 +1,10 @@
 import {AbortSignal} from "@chainsafe/abort-controller";
 import {IExecutionEngine} from "./interface";
 import {ExecutionEngineDisabled} from "./disabled";
-import {
-  ExecutionEngineHttp,
-  ExecutionEngineHttpOpts,
-  defaultExecutionEngineHttpOpts,
-  defaultDefaultSuggestedFeeRecipient,
-} from "./http";
+import {ExecutionEngineHttp, ExecutionEngineHttpOpts, defaultExecutionEngineHttpOpts} from "./http";
 import {ExecutionEngineMock, ExecutionEngineMockOpts} from "./mock";
 
-export {
-  IExecutionEngine,
-  ExecutionEngineHttp,
-  ExecutionEngineDisabled,
-  ExecutionEngineMock,
-  defaultDefaultSuggestedFeeRecipient,
-};
+export {IExecutionEngine, ExecutionEngineHttp, ExecutionEngineDisabled, ExecutionEngineMock};
 
 export type ExecutionEngineOpts =
   | ({mode?: "http"} & ExecutionEngineHttpOpts)

--- a/packages/lodestar/src/executionEngine/interface.ts
+++ b/packages/lodestar/src/executionEngine/interface.ts
@@ -1,4 +1,5 @@
-import {bellatrix, Root, RootHex} from "@chainsafe/lodestar-types";
+import {bellatrix, Root, RootHex, ValidatorIndex, Epoch, ExecutionAddress} from "@chainsafe/lodestar-types";
+import {MapDef} from "../util/map";
 
 import {DATA, QUANTITY} from "../eth1/provider/utils";
 // An execution engine can produce a payload id anywhere the the uint64 range
@@ -63,6 +64,11 @@ export type ApiPayloadAttributes = {
   /** DATA, 20 Bytes - suggested value for the coinbase field of the new payload */
   suggestedFeeRecipient: DATA;
 };
+
+export type ProposerPreparationData = {
+  validatorIndex: ValidatorIndex;
+  feeRecipient: ExecutionAddress;
+};
 /**
  * Execution engine represents an abstract protocol to interact with execution clients. Potential transports include:
  * - JSON RPC over network
@@ -70,6 +76,7 @@ export type ApiPayloadAttributes = {
  * - Integrated code into the same binary
  */
 export interface IExecutionEngine {
+  proposers: MapDef<ValidatorIndex, {epoch: Epoch; feeRecipient: ExecutionAddress}>;
   /**
    * A state transition function which applies changes to the self.execution_state.
    * Returns ``True`` iff ``execution_payload`` is valid with respect to ``self.execution_state``.
@@ -107,4 +114,6 @@ export interface IExecutionEngine {
    * https://github.com/ethereum/consensus-specs/blob/dev/specs/merge/validator.md#get_payload
    */
   getPayload(payloadId: PayloadId): Promise<bellatrix.ExecutionPayload>;
+
+  updateProposerPreparation(currentEpoch: Epoch, proposers: ProposerPreparationData[]): Promise<void>;
 }

--- a/packages/lodestar/src/executionEngine/interface.ts
+++ b/packages/lodestar/src/executionEngine/interface.ts
@@ -1,5 +1,4 @@
-import {bellatrix, Root, RootHex, ValidatorIndex, Epoch, ExecutionAddress} from "@chainsafe/lodestar-types";
-import {MapDef} from "../util/map";
+import {bellatrix, Root, RootHex} from "@chainsafe/lodestar-types";
 
 import {DATA, QUANTITY} from "../eth1/provider/utils";
 // An execution engine can produce a payload id anywhere the the uint64 range
@@ -65,10 +64,6 @@ export type ApiPayloadAttributes = {
   suggestedFeeRecipient: DATA;
 };
 
-export type ProposerPreparationData = {
-  validatorIndex: ValidatorIndex;
-  feeRecipient: ExecutionAddress;
-};
 /**
  * Execution engine represents an abstract protocol to interact with execution clients. Potential transports include:
  * - JSON RPC over network
@@ -76,7 +71,6 @@ export type ProposerPreparationData = {
  * - Integrated code into the same binary
  */
 export interface IExecutionEngine {
-  proposers: MapDef<ValidatorIndex, {epoch: Epoch; feeRecipient: ExecutionAddress}>;
   /**
    * A state transition function which applies changes to the self.execution_state.
    * Returns ``True`` iff ``execution_payload`` is valid with respect to ``self.execution_state``.
@@ -114,6 +108,4 @@ export interface IExecutionEngine {
    * https://github.com/ethereum/consensus-specs/blob/dev/specs/merge/validator.md#get_payload
    */
   getPayload(payloadId: PayloadId): Promise<bellatrix.ExecutionPayload>;
-
-  updateProposerPreparation(currentEpoch: Epoch, proposers: ProposerPreparationData[]): Promise<void>;
 }

--- a/packages/lodestar/src/executionEngine/interface.ts
+++ b/packages/lodestar/src/executionEngine/interface.ts
@@ -52,7 +52,9 @@ export type ForkChoiceUpdateStatus =
 export type PayloadAttributes = {
   timestamp: number;
   prevRandao: Uint8Array;
-  suggestedFeeRecipient: Uint8Array;
+  // DATA is anyway a hex string, so we can just track it as a hex string to
+  // avoid any conversions
+  suggestedFeeRecipient: string;
 };
 
 export type ApiPayloadAttributes = {

--- a/packages/lodestar/src/executionEngine/mock.ts
+++ b/packages/lodestar/src/executionEngine/mock.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import {bellatrix, RootHex, Root} from "@chainsafe/lodestar-types";
-import {toHexString} from "@chainsafe/ssz";
+import {toHexString, fromHexString} from "@chainsafe/ssz";
 import {BYTES_PER_LOGS_BLOOM} from "@chainsafe/lodestar-params";
 
 import {ZERO_HASH, ZERO_HASH_HEX} from "../constants";
@@ -107,7 +107,7 @@ export class ExecutionEngineMock implements IExecutionEngine {
     const payloadId = this.payloadId++;
     const payload: bellatrix.ExecutionPayload = {
       parentHash: headBlockHash,
-      feeRecipient: payloadAttributes.suggestedFeeRecipient,
+      feeRecipient: fromHexString(payloadAttributes.suggestedFeeRecipient),
       stateRoot: crypto.randomBytes(32),
       receiptsRoot: crypto.randomBytes(32),
       logsBloom: crypto.randomBytes(BYTES_PER_LOGS_BLOOM),

--- a/packages/lodestar/src/executionEngine/mock.ts
+++ b/packages/lodestar/src/executionEngine/mock.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import {bellatrix, RootHex, Root, Epoch, ValidatorIndex, ExecutionAddress} from "@chainsafe/lodestar-types";
+import {bellatrix, RootHex, Root} from "@chainsafe/lodestar-types";
 import {toHexString} from "@chainsafe/ssz";
 import {BYTES_PER_LOGS_BLOOM} from "@chainsafe/lodestar-params";
 
@@ -10,9 +10,7 @@ import {
   IExecutionEngine,
   PayloadId,
   PayloadAttributes,
-  ProposerPreparationData,
 } from "./interface";
-import {MapDef} from "../util/map";
 
 const INTEROP_GAS_LIMIT = 30e6;
 
@@ -27,17 +25,12 @@ export class ExecutionEngineMock implements IExecutionEngine {
   // Public state to check if notifyForkchoiceUpdate() is called properly
   headBlockRoot = ZERO_HASH_HEX;
   finalizedBlockRoot = ZERO_HASH_HEX;
-  readonly proposers: MapDef<ValidatorIndex, {epoch: Epoch; feeRecipient: ExecutionAddress}>;
 
   private knownBlocks = new Map<RootHex, bellatrix.ExecutionPayload>();
   private preparingPayloads = new Map<number, bellatrix.ExecutionPayload>();
   private payloadId = 0;
 
   constructor(opts: ExecutionEngineMockOpts) {
-    this.proposers = new MapDef<ValidatorIndex, {epoch: Epoch; feeRecipient: ExecutionAddress}>(() => ({
-      epoch: 0,
-      feeRecipient: Buffer.alloc(20, 0),
-    }));
     this.knownBlocks.set(opts.genesisBlockHash, {
       parentHash: ZERO_HASH,
       feeRecipient: Buffer.alloc(20, 0),
@@ -148,9 +141,5 @@ export class ExecutionEngineMock implements IExecutionEngine {
     }
     this.preparingPayloads.delete(payloadIdNbr);
     return payload;
-  }
-
-  async updateProposerPreparation(_epoch: Epoch, _proposers: ProposerPreparationData[]): Promise<void> {
-    return;
   }
 }

--- a/packages/lodestar/src/node/options.ts
+++ b/packages/lodestar/src/node/options.ts
@@ -10,9 +10,10 @@ import {defaultLoggerOptions, IBeaconLoggerOptions} from "./loggerOptions";
 import {defaultMetricsOptions, MetricsOptions} from "../metrics/options";
 import {defaultNetworkOptions, INetworkOptions} from "../network/options";
 import {defaultSyncOptions, SyncOptions} from "../sync/options";
-import {defaultExecutionEngineOpts, ExecutionEngineOpts} from "../executionEngine";
+import {defaultExecutionEngineOpts, ExecutionEngineOpts, defaultDefaultSuggestedFeeRecipient} from "../executionEngine";
 // Re-export so the CLI doesn't need to depend on lodestar-api
 export {allNamespaces} from "../api/rest/index";
+export {defaultDefaultSuggestedFeeRecipient};
 
 export interface IBeaconNodeOptions {
   api: IApiOptions;

--- a/packages/lodestar/src/node/options.ts
+++ b/packages/lodestar/src/node/options.ts
@@ -10,10 +10,9 @@ import {defaultLoggerOptions, IBeaconLoggerOptions} from "./loggerOptions";
 import {defaultMetricsOptions, MetricsOptions} from "../metrics/options";
 import {defaultNetworkOptions, INetworkOptions} from "../network/options";
 import {defaultSyncOptions, SyncOptions} from "../sync/options";
-import {defaultExecutionEngineOpts, ExecutionEngineOpts, defaultDefaultSuggestedFeeRecipient} from "../executionEngine";
+import {defaultExecutionEngineOpts, ExecutionEngineOpts} from "../executionEngine";
 // Re-export so the CLI doesn't need to depend on lodestar-api
 export {allNamespaces} from "../api/rest/index";
-export {defaultDefaultSuggestedFeeRecipient};
 
 export interface IBeaconNodeOptions {
   api: IApiOptions;

--- a/packages/lodestar/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/lodestar/test/perf/chain/verifyImportBlocks.test.ts
@@ -14,6 +14,7 @@ import {testLogger} from "../../utils/logger";
 import {linspace} from "../../../src/util/numpy";
 import {BeaconDb} from "../../../src";
 import {LevelDbController} from "@chainsafe/lodestar-db";
+import {defaultDefaultFeeRecipient} from "../../../src/chain/options";
 
 // Define this params in `packages/beacon-state-transition/test/perf/params.ts`
 // to trigger Github actions CI cache
@@ -80,6 +81,7 @@ describe("verify+import blocks - range sync perf test", () => {
           proposerBoostEnabled: true,
           safeSlotsToImportOptimistically: SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY,
           disableArchiveOnCheckpoint: true,
+          defaultFeeRecipient: defaultDefaultFeeRecipient,
         },
         {
           config: state.config,

--- a/packages/lodestar/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/lodestar/test/perf/chain/verifyImportBlocks.test.ts
@@ -7,14 +7,15 @@ import {
 import {rangeSyncTest} from "@chainsafe/lodestar-beacon-state-transition/test/perf/params";
 import {config} from "@chainsafe/lodestar-config/default";
 import {SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
+import {LevelDbController} from "@chainsafe/lodestar-db";
+import {defaultDefaultFeeRecipient} from "@chainsafe/lodestar-validator";
+
 import {BeaconChain} from "../../../src/chain";
 import {ExecutionEngineDisabled} from "../../../src/executionEngine";
 import {Eth1ForBlockProductionDisabled} from "../../../src/eth1";
 import {testLogger} from "../../utils/logger";
 import {linspace} from "../../../src/util/numpy";
 import {BeaconDb} from "../../../src";
-import {LevelDbController} from "@chainsafe/lodestar-db";
-import {defaultDefaultFeeRecipient} from "../../../src/chain/options";
 
 // Define this params in `packages/beacon-state-transition/test/perf/params.ts`
 // to trigger Github actions CI cache

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -170,7 +170,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
       // Note: this is created with a pre-defined genesis.json
       timestamp: quantityToNum("0x5"),
       prevRandao: dataToBytes("0x0000000000000000000000000000000000000000000000000000000000000000"),
-      suggestedFeeRecipient: dataToBytes("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"),
+      suggestedFeeRecipient: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
     };
 
     const finalizedBlockHash = "0x0000000000000000000000000000000000000000000000000000000000000000";

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -147,13 +147,13 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     if (TX_SCENARIOS.includes("simple")) {
       await sendTransaction(jsonRpcUrl, {
         from: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
-        to: "0xafa3f8684e54059998bc3a7b0d2b0da075154d66",
+        to: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         gas: "0x76c0",
         gasPrice: "0x9184e72a000",
         value: "0x9184e72a",
       });
 
-      const balance = await getBalance(jsonRpcUrl, "0xafa3f8684e54059998bc3a7b0d2b0da075154d66");
+      const balance = await getBalance(jsonRpcUrl, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
       if (balance != "0x0") throw new Error("Invalid Balance: " + balance);
     }
 
@@ -192,7 +192,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     if (TX_SCENARIOS.includes("simple")) {
       if (payload.transactions.length !== 1)
         throw new Error("Expected a simple transaction to be in the fetched payload");
-      const balance = await getBalance(jsonRpcUrl, "0xafa3f8684e54059998bc3a7b0d2b0da075154d66");
+      const balance = await getBalance(jsonRpcUrl, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
       if (balance != "0x0") throw new Error("Invalid Balance: " + balance);
     }
 
@@ -215,7 +215,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     await executionEngine.notifyForkchoiceUpdate(bytesToData(payload.blockHash), genesisBlockHash);
 
     if (TX_SCENARIOS.includes("simple")) {
-      const balance = await getBalance(jsonRpcUrl, "0xafa3f8684e54059998bc3a7b0d2b0da075154d66");
+      const balance = await getBalance(jsonRpcUrl, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
       if (balance !== "0x9184e72a") throw new Error("Invalid Balance");
     }
 
@@ -359,7 +359,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
       // If bellatrixEpoch > 0, this is the case of pre-merge transaction submission on EL pow
       await sendTransaction(jsonRpcUrl, {
         from: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
-        to: "0xafa3f8684e54059998bc3a7b0d2b0da075154d66",
+        to: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         gas: "0x76c0",
         gasPrice: "0x9184e72a000",
         value: "0x9184e72a",
@@ -374,7 +374,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
           // If bellatrixEpoch > 0, this is the case of pre-merge transaction confirmation on EL pow
           case 2:
             if (TX_SCENARIOS.includes("simple")) {
-              const balance = await getBalance(jsonRpcUrl, "0xafa3f8684e54059998bc3a7b0d2b0da075154d66");
+              const balance = await getBalance(jsonRpcUrl, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
               if (balance !== "0x9184e72a") reject("Invalid Balance");
             }
             break;
@@ -390,7 +390,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
             if (TX_SCENARIOS.includes("simple")) {
               await sendTransaction(jsonRpcUrl, {
                 from: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
-                to: "0xafa3f8684e54059998bc3a7b0d2b0da075154d66",
+                to: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 gas: "0x76c0",
                 gasPrice: "0x9184e72a000",
                 value: "0x9184e72a",
@@ -439,7 +439,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     }
 
     if (TX_SCENARIOS.includes("simple")) {
-      const balance = await getBalance(jsonRpcUrl, "0xafa3f8684e54059998bc3a7b0d2b0da075154d66");
+      const balance = await getBalance(jsonRpcUrl, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
       // 0x12309ce54 = 2 * 0x9184e72a
       if (balance !== "0x12309ce54") throw Error("Invalid Balance");
     }

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -324,6 +324,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
         // Now eth deposit/merge tracker methods directly available on engine endpoints
         eth1: {enabled: true, providerUrls: [engineApiUrl], jwtSecretHex},
         executionEngine: {urls: [engineApiUrl], jwtSecretHex},
+        chain: {defaultFeeRecipient: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
       },
       validatorCount: validatorClientCount * validatorsPerClient,
       logger: loggerNodeA,
@@ -346,6 +347,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
       // At least one sim test must use the REST API for beacon <-> validator comms
       useRestApi: true,
       testLoggerOpts,
+      defaultFeeRecipient: "0xcccccccccccccccccccccccccccccccccccccccc",
       // TODO test merge-interop with remote;
     });
 
@@ -418,6 +420,10 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     await Promise.all(validators.map((v) => v.stop()));
     await bn.close();
     await sleep(500);
+
+    if (bn.chain.beaconProposerCache.get(1) !== "0xcccccccccccccccccccccccccccccccccccccccc") {
+      throw Error("Invalid feeRecipient set at BN");
+    }
 
     // Assertions to make sure the end state is good
     // 1. The proper head is set

--- a/packages/lodestar/test/unit/chain/beaconProposerCache.ts
+++ b/packages/lodestar/test/unit/chain/beaconProposerCache.ts
@@ -1,0 +1,37 @@
+import {expect} from "chai";
+import {BeaconProposerCache} from "../../../src/chain/beaconProposerCache";
+
+const defaultFeeRecipient = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+describe("BeaconProposerCache", function () {
+  let cache: BeaconProposerCache;
+
+  beforeEach(function () {
+    // max 2 items
+    cache = new BeaconProposerCache({defaultFeeRecipient});
+    cache.add(1, {validatorIndex: "23", feeRecipient: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"});
+    cache.add(3, {validatorIndex: "43", feeRecipient: "0xcccccccccccccccccccccccccccccccccccccccc"});
+  });
+
+  it("get default", function () {
+    expect(cache.get("32")).to.be.equal("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  });
+
+  it("get what has been set", function () {
+    expect(cache.get("23")).to.be.equal("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+  });
+
+  it("override and get latest", function () {
+    cache.add(5, {validatorIndex: "23", feeRecipient: "0xdddddddddddddddddddddddddddddddddddddddd"});
+    expect(cache.get("23")).to.be.equal("0xdddddddddddddddddddddddddddddddddddddddd");
+  });
+
+  it("prune", function () {
+    cache.prune(4);
+
+    // Default for what has been pruned
+    expect(cache.get("23")).to.be.equal("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+    // Original for what hasn't been pruned
+    expect(cache.get("43")).to.be.equal("0xcccccccccccccccccccccccccccccccccccccccc");
+  });
+});

--- a/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/block/blockAssembly.test.ts
@@ -64,7 +64,6 @@ describe("block assembly", function () {
         randaoReveal: Buffer.alloc(96, 0),
         graffiti: Buffer.alloc(32, 0),
         slot: 1,
-        feeRecipient: Buffer.alloc(20, 0),
       }
     );
     expect(result).to.not.be.null;

--- a/packages/lodestar/test/unit/chain/factory/block/body.test.ts
+++ b/packages/lodestar/test/unit/chain/factory/block/body.test.ts
@@ -59,7 +59,7 @@ describe("blockAssembly - body", function () {
       blockSlot: 1,
       parentSlot: 0,
       parentBlockRoot: Buffer.alloc(32, 0),
-      feeRecipient: Buffer.alloc(20, 0),
+      proposerIndex: 1000,
     });
     expect(result).to.not.be.null;
     expect(result.randaoReveal.length).to.be.equal(96);

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -7,6 +7,7 @@ import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {BeaconStateAllForks, CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {CheckpointWithHex, IForkChoice, IProtoBlock, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
+import {defaultDefaultFeeRecipient} from "@chainsafe/lodestar-validator";
 
 import {ChainEventEmitter, IBeaconChain} from "../../../../src/chain";
 import {IBeaconClock} from "../../../../src/chain/clock/interface";
@@ -38,7 +39,6 @@ import {testLogger} from "../../logger";
 import {ReprocessController} from "../../../../src/chain/reprocess";
 import {createCachedBeaconStateTest} from "@chainsafe/lodestar-beacon-state-transition/test/utils/state";
 import {SeenAggregatedAttestations} from "../../../../src/chain/seenCache/seenAggregateAndProof";
-import {defaultDefaultFeeRecipient} from "../../../../src/chain/options";
 import {BeaconProposerCache} from "../../../../src/chain/beaconProposerCache";
 
 /* eslint-disable @typescript-eslint/no-empty-function */

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -2,7 +2,7 @@ import {AbortController} from "@chainsafe/abort-controller";
 import sinon from "sinon";
 
 import {toHexString} from "@chainsafe/ssz";
-import {allForks, UintNum64, Root, Slot, ssz, Uint16, UintBn64, Epoch} from "@chainsafe/lodestar-types";
+import {allForks, UintNum64, Root, Slot, ssz, Uint16, UintBn64} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {BeaconStateAllForks, CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
@@ -39,7 +39,7 @@ import {ReprocessController} from "../../../../src/chain/reprocess";
 import {createCachedBeaconStateTest} from "@chainsafe/lodestar-beacon-state-transition/test/utils/state";
 import {SeenAggregatedAttestations} from "../../../../src/chain/seenCache/seenAggregateAndProof";
 import {defaultDefaultFeeRecipient} from "../../../../src/chain/options";
-import {MapDef} from "../../../../src/util/map";
+import {BeaconProposerCache} from "../../../../src/chain/beaconProposerCache";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 
@@ -86,10 +86,7 @@ export class MockBeaconChain implements IBeaconChain {
   readonly seenSyncCommitteeMessages = new SeenSyncCommitteeMessages();
   readonly seenContributionAndProof = new SeenContributionAndProof(null);
 
-  readonly beaconProposerCache = new MapDef<string, {epoch: Epoch; feeRecipient: string}>(() => ({
-    epoch: 0,
-    feeRecipient: defaultDefaultFeeRecipient,
-  }));
+  readonly beaconProposerCache = new BeaconProposerCache({defaultFeeRecipient: defaultDefaultFeeRecipient});
 
   private state: BeaconStateAllForks;
   private abortController: AbortController;

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -2,23 +2,11 @@ import {AbortController} from "@chainsafe/abort-controller";
 import sinon from "sinon";
 
 import {toHexString} from "@chainsafe/ssz";
-import {
-  allForks,
-  UintNum64,
-  Root,
-  Slot,
-  ssz,
-  Uint16,
-  UintBn64,
-  ValidatorIndex,
-  Epoch,
-  ExecutionAddress,
-} from "@chainsafe/lodestar-types";
+import {allForks, UintNum64, Root, Slot, ssz, Uint16, UintBn64, Epoch} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {BeaconStateAllForks, CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {CheckpointWithHex, IForkChoice, IProtoBlock, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
-import {fromHex} from "@chainsafe/lodestar-utils";
 
 import {ChainEventEmitter, IBeaconChain} from "../../../../src/chain";
 import {IBeaconClock} from "../../../../src/chain/clock/interface";
@@ -98,9 +86,9 @@ export class MockBeaconChain implements IBeaconChain {
   readonly seenSyncCommitteeMessages = new SeenSyncCommitteeMessages();
   readonly seenContributionAndProof = new SeenContributionAndProof(null);
 
-  readonly beaconProposerCache = new MapDef<ValidatorIndex, {epoch: Epoch; feeRecipient: ExecutionAddress}>(() => ({
+  readonly beaconProposerCache = new MapDef<string, {epoch: Epoch; feeRecipient: string}>(() => ({
     epoch: 0,
-    feeRecipient: fromHex(defaultDefaultFeeRecipient),
+    feeRecipient: defaultDefaultFeeRecipient,
   }));
 
   private state: BeaconStateAllForks;

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -2,11 +2,23 @@ import {AbortController} from "@chainsafe/abort-controller";
 import sinon from "sinon";
 
 import {toHexString} from "@chainsafe/ssz";
-import {allForks, UintNum64, Root, Slot, ssz, Uint16, UintBn64} from "@chainsafe/lodestar-types";
+import {
+  allForks,
+  UintNum64,
+  Root,
+  Slot,
+  ssz,
+  Uint16,
+  UintBn64,
+  ValidatorIndex,
+  Epoch,
+  ExecutionAddress,
+} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {BeaconStateAllForks, CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {phase0} from "@chainsafe/lodestar-beacon-state-transition";
 import {CheckpointWithHex, IForkChoice, IProtoBlock, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
+import {fromHex} from "@chainsafe/lodestar-utils";
 
 import {ChainEventEmitter, IBeaconChain} from "../../../../src/chain";
 import {IBeaconClock} from "../../../../src/chain/clock/interface";
@@ -38,6 +50,8 @@ import {testLogger} from "../../logger";
 import {ReprocessController} from "../../../../src/chain/reprocess";
 import {createCachedBeaconStateTest} from "@chainsafe/lodestar-beacon-state-transition/test/utils/state";
 import {SeenAggregatedAttestations} from "../../../../src/chain/seenCache/seenAggregateAndProof";
+import {defaultDefaultFeeRecipient} from "../../../../src/chain/options";
+import {MapDef} from "../../../../src/util/map";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 
@@ -83,6 +97,11 @@ export class MockBeaconChain implements IBeaconChain {
   readonly seenBlockProposers = new SeenBlockProposers();
   readonly seenSyncCommitteeMessages = new SeenSyncCommitteeMessages();
   readonly seenContributionAndProof = new SeenContributionAndProof(null);
+
+  readonly beaconProposerCache = new MapDef<ValidatorIndex, {epoch: Epoch; feeRecipient: ExecutionAddress}>(() => ({
+    epoch: 0,
+    feeRecipient: fromHex(defaultDefaultFeeRecipient),
+  }));
 
   private state: BeaconStateAllForks;
   private abortController: AbortController;
@@ -178,6 +197,8 @@ export class MockBeaconChain implements IBeaconChain {
   persistInvalidSszObject(): string | null {
     return null;
   }
+
+  async updateBeaconProposerData(): Promise<void> {}
 }
 
 function mockForkChoice(): IForkChoice {

--- a/packages/lodestar/test/utils/node/validator.ts
+++ b/packages/lodestar/test/utils/node/validator.ts
@@ -117,6 +117,7 @@ export async function getAndInitDevValidators({
   useRestApi,
   testLoggerOpts,
   externalSignerUrl,
+  defaultFeeRecipient,
 }: {
   node: BeaconNode;
   validatorsPerClient: number;
@@ -125,6 +126,7 @@ export async function getAndInitDevValidators({
   useRestApi?: boolean;
   testLoggerOpts?: TestLoggerOpts;
   externalSignerUrl?: string;
+  defaultFeeRecipient?: string;
 }): Promise<{validators: Validator[]; secretKeys: SecretKey[]}> {
   const validators: Promise<Validator>[] = [];
   const secretKeys: SecretKey[] = [];
@@ -165,6 +167,7 @@ export async function getAndInitDevValidators({
         slashingProtection,
         logger,
         signers,
+        defaultFeeRecipient,
       })
     );
   }

--- a/packages/lodestar/test/utils/node/validator.ts
+++ b/packages/lodestar/test/utils/node/validator.ts
@@ -11,13 +11,15 @@ import {
   ISlashingProtection,
   SignerLocal,
 } from "@chainsafe/lodestar-validator";
-import {BeaconNode} from "../../../src/node";
-import {testLogger, TestLoggerOpts} from "../logger";
+
 import {SecretKey} from "@chainsafe/bls";
 import {getLocalSecretKeys} from "@chainsafe/lodestar-cli/src/cmds/validator/keys";
 import {IValidatorCliArgs} from "@chainsafe/lodestar-cli/src/cmds/validator/options";
 import {IGlobalArgs} from "@chainsafe/lodestar-cli/src/options";
 import {KEY_IMPORTED_PREFIX} from "@chainsafe/lodestar-keymanager-server";
+
+import {BeaconNode} from "../../../src/node";
+import {testLogger, TestLoggerOpts} from "../logger";
 
 export async function getAndInitValidatorsWithKeystore({
   node,

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -2,7 +2,7 @@
  * @module validator
  */
 
-export {Validator, ValidatorOptions} from "./validator";
+export {Validator, ValidatorOptions, defaultDefaultFeeRecipient} from "./validator";
 export {ValidatorStore, SignerType, Signer, SignerLocal, SignerRemote} from "./services/validatorStore";
 export {waitForGenesis} from "./genesis";
 export {getMetrics, Metrics, MetricsRegister} from "./metrics";

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -12,6 +12,7 @@ import {Metrics} from "../metrics";
 
 type BlockProposingServiceOpts = {
   graffiti?: string;
+  strictFeeRecipientCheck?: boolean;
 };
 
 /**
@@ -87,7 +88,16 @@ export class BlockProposingService {
         // In Mev Builder, the feeRecipeint could differ and rewards to the feeRecipeint
         // might be included in the block transactions as indicated by the BuilderBid
         // Address this appropriately in the Mev boost PR
-        if (feeRecipient !== expectedFeeRecipient) {
+        //
+        // Even for engine, there isn't any clarity as of now how to proceed with the
+        // the divergence of feeRecipient, the argument being that the bn <> engine setup
+        // has implied trust and are user-agents of the same entity.
+        // A better approach would be to have engine also provide something akin to BuilderBid
+        //
+        // The following conversation in the interop R&D channel can provide some context
+        // https://discord.com/channels/595666850260713488/892088344438255616/978374892678426695
+        // For now providing a strick check flag to enable disable this
+        if (feeRecipient !== expectedFeeRecipient && this.opts.strictFeeRecipientCheck) {
           throw Error(`Invalid feeRecipient=${feeRecipient}, expected=${expectedFeeRecipient}`);
         }
       }

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -80,7 +80,7 @@ export class BlockProposingService {
         this.metrics?.blockProposingErrors.inc({error: "produce"});
         throw extendError(e, "Failed to produce block");
       });
-      const blockFeeRecipient = (block.data as bellatrix.BeaconBlock).body?.executionPayload.feeRecipient;
+      const blockFeeRecipient = (block.data as bellatrix.BeaconBlock).body.executionPayload?.feeRecipient;
       const feeRecipient = blockFeeRecipient !== undefined ? toHexString(blockFeeRecipient) : undefined;
       this.logger.debug("Produced block", {...debugLogCtx, feeRecipient});
       this.metrics?.blocksProduced.inc();

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -82,6 +82,15 @@ export class BlockProposingService {
       });
       const blockFeeRecipient = (block.data as bellatrix.BeaconBlock).body.executionPayload?.feeRecipient;
       const feeRecipient = blockFeeRecipient !== undefined ? toHexString(blockFeeRecipient) : undefined;
+      if (feeRecipient !== undefined) {
+        const expectedFeeRecipient = this.validatorStore.feeRecipientByValidatorPubkey.getOrDefault(pubkeyHex);
+        // In Mev Builder, the feeRecipeint could differ and rewards to the feeRecipeint
+        // might be included in the block transactions as indicated by the BuilderBid
+        // Address this appropriately in the Mev boost PR
+        if (feeRecipient !== expectedFeeRecipient) {
+          throw Error(`Invalid feeRecipient=${feeRecipient}, expected=${expectedFeeRecipient}`);
+        }
+      }
       this.logger.debug("Produced block", {...debugLogCtx, feeRecipient});
       this.metrics?.blocksProduced.inc();
 

--- a/packages/validator/src/services/prepareBeaconProposer.ts
+++ b/packages/validator/src/services/prepareBeaconProposer.ts
@@ -1,15 +1,10 @@
 import {Epoch} from "@chainsafe/lodestar-types";
-import {Api} from "@chainsafe/lodestar-api";
+import {Api, routes} from "@chainsafe/lodestar-api";
 
 import {ValidatorStore} from "./validatorStore";
 import {IndicesService} from "./indices";
 import {IClock, ILoggerVc} from "../util";
 import {Metrics} from "../metrics";
-
-type ProposerPreparationData = {
-  validatorIndex: string;
-  feeRecipient: string;
-};
 
 /**
  * This service is responsible for updating the BNs and/or Mev relays with
@@ -22,7 +17,6 @@ export class PrepareBeaconProposerService {
     private readonly api: Api,
     private clock: IClock,
     private readonly validatorStore: ValidatorStore,
-    private readonly defaultFeeRecipient: string,
     private readonly indicesService: IndicesService,
     private readonly metrics: Metrics | null
   ) {
@@ -48,10 +42,13 @@ export class PrepareBeaconProposerService {
     ]);
   };
 
-  private getProposerData(indices: number[]): ProposerPreparationData[] {
+  private getProposerData(indices: number[]): routes.validator.ProposerPreparationData[] {
     return indices.map((validatorIndex) => ({
       validatorIndex: validatorIndex.toString(),
-      feeRecipient: this.defaultFeeRecipient,
+      feeRecipient: this.validatorStore.feeRecipientByValidatorPubkey.getOrDefault(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.indicesService.index2pubkey.get(validatorIndex)!
+      ),
     }));
   }
 }

--- a/packages/validator/src/services/prepareBeaconProposer.ts
+++ b/packages/validator/src/services/prepareBeaconProposer.ts
@@ -1,0 +1,54 @@
+import {ValidatorIndex, ExecutionAddress, Epoch} from "@chainsafe/lodestar-types";
+import {Api} from "@chainsafe/lodestar-api";
+
+import {ValidatorStore} from "./validatorStore";
+import {IndicesService} from "./indices";
+import {IClock, ILoggerVc} from "../util";
+import {Metrics} from "../metrics";
+
+type ProposerPreparationData = {
+  validatorIndex: ValidatorIndex;
+  feeRecipient: ExecutionAddress;
+};
+
+/**
+ * This service is responsible for updating the BNs and/or Mev relays with
+ * the corresponding feeRecipient suggestion. This should ideally run per epoch
+ * but can be run per slot. Lighthouse also uses this to trigger any block
+ */
+export class PrepareBeaconProposerService {
+  constructor(
+    private readonly logger: ILoggerVc,
+    private readonly api: Api,
+    private clock: IClock,
+    private readonly validatorStore: ValidatorStore,
+    private readonly defaultSuggestedFeeRecipient: ExecutionAddress,
+    private readonly indicesService: IndicesService,
+    private readonly metrics: Metrics | null
+  ) {
+    clock.runEverySlot(this.prepareBeaconProposer);
+  }
+
+  private prepareBeaconProposer = async (epoch: Epoch): Promise<void> => {
+    await Promise.all([
+      // Run prepareBeaconProposer immediately for all known local indices
+      this.api.validator
+        .prepareBeaconProposer(this.getProposerData(this.indicesService.getAllLocalIndices()))
+        .catch((e: Error) => {
+          this.logger.error("Error on prepareBeaconProposer", {epoch}, e);
+        }),
+
+      // At the same time fetch any remaining unknown validator indices, then poll duties for those newIndices only
+      this.indicesService
+        .pollValidatorIndices()
+        .then((newIndices) => this.api.validator.prepareBeaconProposer(this.getProposerData(newIndices)))
+        .catch((e: Error) => {
+          this.logger.error("Error on poll indices and prepareBeaconProposer", {epoch}, e);
+        }),
+    ]);
+  };
+
+  private getProposerData(indices: number[]): ProposerPreparationData[] {
+    return indices.map((validatorIndex) => ({validatorIndex, feeRecipient: this.defaultSuggestedFeeRecipient}));
+  }
+}

--- a/packages/validator/src/services/prepareBeaconProposer.ts
+++ b/packages/validator/src/services/prepareBeaconProposer.ts
@@ -1,4 +1,4 @@
-import {ValidatorIndex, ExecutionAddress, Epoch} from "@chainsafe/lodestar-types";
+import {Epoch} from "@chainsafe/lodestar-types";
 import {Api} from "@chainsafe/lodestar-api";
 
 import {ValidatorStore} from "./validatorStore";
@@ -7,8 +7,8 @@ import {IClock, ILoggerVc} from "../util";
 import {Metrics} from "../metrics";
 
 type ProposerPreparationData = {
-  validatorIndex: ValidatorIndex;
-  feeRecipient: ExecutionAddress;
+  validatorIndex: string;
+  feeRecipient: string;
 };
 
 /**
@@ -22,7 +22,7 @@ export class PrepareBeaconProposerService {
     private readonly api: Api,
     private clock: IClock,
     private readonly validatorStore: ValidatorStore,
-    private readonly defaultFeeRecipient: ExecutionAddress,
+    private readonly defaultFeeRecipient: string,
     private readonly indicesService: IndicesService,
     private readonly metrics: Metrics | null
   ) {
@@ -49,6 +49,9 @@ export class PrepareBeaconProposerService {
   };
 
   private getProposerData(indices: number[]): ProposerPreparationData[] {
-    return indices.map((validatorIndex) => ({validatorIndex, feeRecipient: this.defaultFeeRecipient}));
+    return indices.map((validatorIndex) => ({
+      validatorIndex: validatorIndex.toString(),
+      feeRecipient: this.defaultFeeRecipient,
+    }));
   }
 }

--- a/packages/validator/src/services/prepareBeaconProposer.ts
+++ b/packages/validator/src/services/prepareBeaconProposer.ts
@@ -22,11 +22,11 @@ export class PrepareBeaconProposerService {
     private readonly api: Api,
     private clock: IClock,
     private readonly validatorStore: ValidatorStore,
-    private readonly defaultSuggestedFeeRecipient: ExecutionAddress,
+    private readonly defaultFeeRecipient: ExecutionAddress,
     private readonly indicesService: IndicesService,
     private readonly metrics: Metrics | null
   ) {
-    clock.runEverySlot(this.prepareBeaconProposer);
+    clock.runEveryEpoch(this.prepareBeaconProposer);
   }
 
   private prepareBeaconProposer = async (epoch: Epoch): Promise<void> => {
@@ -49,6 +49,6 @@ export class PrepareBeaconProposerService {
   };
 
   private getProposerData(indices: number[]): ProposerPreparationData[] {
-    return indices.map((validatorIndex) => ({validatorIndex, feeRecipient: this.defaultSuggestedFeeRecipient}));
+    return indices.map((validatorIndex) => ({validatorIndex, feeRecipient: this.defaultFeeRecipient}));
   }
 }

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -34,6 +34,7 @@ import {Interchange, InterchangeFormatVersion, ISlashingProtection} from "../sla
 import {PubkeyHex} from "../types";
 import {externalSignerPostSignature} from "../util/externalSignerClient";
 import {Metrics} from "../metrics";
+import {MapDef} from "../util/map";
 
 export enum SignerType {
   Local,
@@ -62,6 +63,7 @@ export type Signer = SignerLocal | SignerRemote;
  * Service that sets up and handles validator attester duties.
  */
 export class ValidatorStore {
+  readonly feeRecipientByValidatorPubkey: MapDef<PubkeyHex, string>;
   private readonly validators = new Map<PubkeyHex, Signer>();
   private readonly genesisValidatorsRoot: Root;
 
@@ -70,8 +72,10 @@ export class ValidatorStore {
     private readonly slashingProtection: ISlashingProtection,
     private readonly metrics: Metrics | null,
     signers: Signer[],
-    genesis: phase0.Genesis
+    genesis: phase0.Genesis,
+    defaultFeeRecipient: string
   ) {
+    this.feeRecipientByValidatorPubkey = new MapDef<PubkeyHex, string>(() => defaultFeeRecipient);
     for (const signer of signers) {
       this.addSigner(signer);
     }

--- a/packages/validator/src/util/map.ts
+++ b/packages/validator/src/util/map.ts
@@ -1,0 +1,14 @@
+export class MapDef<K, V> extends Map<K, V> {
+  constructor(private readonly getDefault: () => V) {
+    super();
+  }
+
+  getOrDefault(key: K): V {
+    let value = super.get(key);
+    if (value === undefined) {
+      value = this.getDefault();
+      this.set(key, value);
+    }
+    return value;
+  }
+}

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -31,7 +31,7 @@ export type ValidatorOptions = {
   logger: ILogger;
   afterBlockDelaySlotFraction?: number;
   graffiti?: string;
-  defaultSuggestedFeeRecipient?: ExecutionAddress;
+  defaultFeeRecipient?: ExecutionAddress;
 };
 
 // TODO: Extend the timeout, and let it be customizable
@@ -64,7 +64,7 @@ export class Validator {
   private state: State = {status: Status.stopped};
 
   constructor(opts: ValidatorOptions, readonly genesis: Genesis, metrics: Metrics | null = null) {
-    const {dbOps, logger, slashingProtection, signers, graffiti, defaultSuggestedFeeRecipient} = opts;
+    const {dbOps, logger, slashingProtection, signers, graffiti, defaultFeeRecipient} = opts;
     const config = createIBeaconConfig(dbOps.config, genesis.genesisValidatorsRoot);
 
     const api =
@@ -114,13 +114,13 @@ export class Validator {
       metrics
     );
 
-    this.prepareBeaconProposerService = defaultSuggestedFeeRecipient
+    this.prepareBeaconProposerService = defaultFeeRecipient
       ? new PrepareBeaconProposerService(
           loggerVc,
           api,
           clock,
           validatorStore,
-          defaultSuggestedFeeRecipient,
+          defaultFeeRecipient,
           indicesService,
           metrics
         )

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -35,6 +35,7 @@ export type ValidatorOptions = {
   afterBlockDelaySlotFraction?: number;
   graffiti?: string;
   defaultFeeRecipient?: string;
+  strictFeeRecipientCheck?: boolean;
 };
 
 // TODO: Extend the timeout, and let it be customizable
@@ -67,7 +68,7 @@ export class Validator {
   private state: State = {status: Status.stopped};
 
   constructor(opts: ValidatorOptions, readonly genesis: Genesis, metrics: Metrics | null = null) {
-    const {dbOps, logger, slashingProtection, signers, graffiti, defaultFeeRecipient} = opts;
+    const {dbOps, logger, slashingProtection, signers, graffiti, defaultFeeRecipient, strictFeeRecipientCheck} = opts;
     const config = createIBeaconConfig(dbOps.config, genesis.genesisValidatorsRoot);
 
     const api =
@@ -99,6 +100,7 @@ export class Validator {
 
     this.blockProposingService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, metrics, {
       graffiti,
+      strictFeeRecipientCheck,
     });
 
     this.attestationService = new AttestationService(

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -1,6 +1,6 @@
 import {AbortController, AbortSignal} from "@chainsafe/abort-controller";
 import {IDatabaseApiOptions} from "@chainsafe/lodestar-db";
-import {ssz, ExecutionAddress} from "@chainsafe/lodestar-types";
+import {ssz} from "@chainsafe/lodestar-types";
 import {createIBeaconConfig, IBeaconConfig} from "@chainsafe/lodestar-config";
 import {Genesis} from "@chainsafe/lodestar-types/phase0";
 import {ILogger} from "@chainsafe/lodestar-utils";
@@ -31,7 +31,7 @@ export type ValidatorOptions = {
   logger: ILogger;
   afterBlockDelaySlotFraction?: number;
   graffiti?: string;
-  defaultFeeRecipient?: ExecutionAddress;
+  defaultFeeRecipient?: string;
 };
 
 // TODO: Extend the timeout, and let it be customizable


### PR DESCRIPTION
**Motivation**
Post `merge`, a `suggestedFeeRecipient` needs to be supplied per validator index while proposing blocks.

<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR adds the capability to supply a **default** `suggestedFeeRecipient` for 

- a validator process   (could be overridden per validator in a later PR via config or keymanager api)
- as well as for a BN in case the the proposer data is not updated for a validator

and to enable beacon node to maintain and use the updated/registered `suggestedFeeRecipient` while instantiating the block building corresponding to the validator index.

TODOs
- [x] BeaconProposerCache tests
- [x] merge interop beacon default fee recipient check
- [x] merge interop validator default fee recipient check

Closes #3693