### PR TITLE
Issue advance fcU for builing the EL block

### DIFF
--- a/packages/lodestar/src/chain/beaconProposerCache.ts
+++ b/packages/lodestar/src/chain/beaconProposerCache.ts
@@ -30,7 +30,11 @@ export class BeaconProposerCache {
     }
   }
 
-  get(proposerIndex: number | string): string {
+  getOrDefault(proposerIndex: number | string): string {
     return this.feeRecipientByValidatorIndex.getOrDefault(`${proposerIndex}`).feeRecipient;
+  }
+
+  get(proposerIndex: number | string): string | undefined {
+    return this.feeRecipientByValidatorIndex.get(`${proposerIndex}`)?.feeRecipient;
   }
 }

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -199,6 +199,7 @@ export class BeaconChain implements IBeaconChain {
         stateCache,
         checkpointStateCache,
         seenAggregatedAttestations: this.seenAggregatedAttestations,
+        beaconProposerCache: this.beaconProposerCache,
         emitter,
         config,
         logger,

--- a/packages/lodestar/src/executionEngine/disabled.ts
+++ b/packages/lodestar/src/executionEngine/disabled.ts
@@ -1,6 +1,8 @@
-import {IExecutionEngine} from "./interface";
+import {IExecutionEngine, PayloadIdCache} from "./interface";
 
 export class ExecutionEngineDisabled implements IExecutionEngine {
+  readonly payloadIdCache = new PayloadIdCache();
+
   async notifyNewPayload(): Promise<never> {
     throw Error("Execution engine disabled");
   }

--- a/packages/lodestar/src/executionEngine/http.ts
+++ b/packages/lodestar/src/executionEngine/http.ts
@@ -23,6 +23,7 @@ import {
   PayloadAttributes,
   ApiPayloadAttributes,
 } from "./interface";
+import {PayloadIdCache} from "./payloadIdCache";
 
 export type ExecutionEngineHttpOpts = {
   urls: string[];
@@ -56,6 +57,7 @@ export const defaultExecutionEngineHttpOpts: ExecutionEngineHttpOpts = {
  * https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.1/src/engine/interop/specification.md
  */
 export class ExecutionEngineHttp implements IExecutionEngine {
+  readonly payloadIdCache = new PayloadIdCache();
   private readonly rpc: IJsonRpcHttpClient;
 
   constructor(opts: ExecutionEngineHttpOpts, signal: AbortSignal, rpc?: IJsonRpcHttpClient) {
@@ -220,8 +222,16 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     switch (status) {
       case ExecutePayloadStatus.VALID:
         // if payloadAttributes are provided, a valid payloadId is expected
-        if (payloadAttributes && (!payloadId || payloadId === "0x")) {
-          throw Error(`Received invalid payloadId=${payloadId}`);
+        if (apiPayloadAttributes) {
+          if (!payloadId || payloadId === "0x") {
+            throw Error(`Received invalid payloadId=${payloadId}`);
+          }
+
+          this.payloadIdCache.add(
+            {headBlockHash: headBlockHashData, finalizedBlockHash, ...apiPayloadAttributes},
+            payloadId
+          );
+          void this.prunePayloadIdCache();
         }
         return payloadId !== "0x" ? payloadId : null;
 
@@ -270,6 +280,10 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     });
 
     return parseExecutionPayload(executionPayloadRpc);
+  }
+
+  async prunePayloadIdCache(): Promise<void> {
+    this.payloadIdCache.prune();
   }
 }
 

--- a/packages/lodestar/src/executionEngine/interface.ts
+++ b/packages/lodestar/src/executionEngine/interface.ts
@@ -1,10 +1,8 @@
 import {bellatrix, Root, RootHex} from "@chainsafe/lodestar-types";
 
-import {DATA, QUANTITY} from "../eth1/provider/utils";
-// An execution engine can produce a payload id anywhere the the uint64 range
-// Since we do no processing with this id, we have no need to deserialize it
-export type PayloadId = string;
+import {PayloadIdCache, PayloadId, ApiPayloadAttributes} from "./payloadIdCache";
 
+export {PayloadIdCache, PayloadId, ApiPayloadAttributes};
 export enum ExecutePayloadStatus {
   /** given payload is valid */
   VALID = "VALID",
@@ -57,15 +55,6 @@ export type PayloadAttributes = {
   suggestedFeeRecipient: string;
 };
 
-export type ApiPayloadAttributes = {
-  /** QUANTITY, 64 Bits - value for the timestamp field of the new payload */
-  timestamp: QUANTITY;
-  /** DATA, 32 Bytes - value for the prevRandao field of the new payload */
-  prevRandao: DATA;
-  /** DATA, 20 Bytes - suggested value for the coinbase field of the new payload */
-  suggestedFeeRecipient: DATA;
-};
-
 /**
  * Execution engine represents an abstract protocol to interact with execution clients. Potential transports include:
  * - JSON RPC over network
@@ -73,6 +62,7 @@ export type ApiPayloadAttributes = {
  * - Integrated code into the same binary
  */
 export interface IExecutionEngine {
+  payloadIdCache: PayloadIdCache;
   /**
    * A state transition function which applies changes to the self.execution_state.
    * Returns ``True`` iff ``execution_payload`` is valid with respect to ``self.execution_state``.

--- a/packages/lodestar/src/executionEngine/mock.ts
+++ b/packages/lodestar/src/executionEngine/mock.ts
@@ -10,6 +10,7 @@ import {
   IExecutionEngine,
   PayloadId,
   PayloadAttributes,
+  PayloadIdCache,
 } from "./interface";
 
 const INTEROP_GAS_LIMIT = 30e6;
@@ -25,6 +26,7 @@ export class ExecutionEngineMock implements IExecutionEngine {
   // Public state to check if notifyForkchoiceUpdate() is called properly
   headBlockRoot = ZERO_HASH_HEX;
   finalizedBlockRoot = ZERO_HASH_HEX;
+  readonly payloadIdCache = new PayloadIdCache();
 
   private knownBlocks = new Map<RootHex, bellatrix.ExecutionPayload>();
   private preparingPayloads = new Map<number, bellatrix.ExecutionPayload>();

--- a/packages/lodestar/src/executionEngine/payloadIdCache.ts
+++ b/packages/lodestar/src/executionEngine/payloadIdCache.ts
@@ -1,0 +1,46 @@
+import {pruneSetToMax} from "../util/map";
+import {IMetrics} from "../metrics";
+import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
+import {DATA, QUANTITY} from "../eth1/provider/utils";
+
+// Idealy this only need to be set to the max head reorgs number
+const MAX_PAYLOAD_IDS = SLOTS_PER_EPOCH;
+
+// An execution engine can produce a payload id anywhere the the uint64 range
+// Since we do no processing with this id, we have no need to deserialize it
+export type PayloadId = string;
+
+export type ApiPayloadAttributes = {
+  /** QUANTITY, 64 Bits - value for the timestamp field of the new payload */
+  timestamp: QUANTITY;
+  /** DATA, 32 Bytes - value for the prevRandao field of the new payload */
+  prevRandao: DATA;
+  /** DATA, 20 Bytes - suggested value for the coinbase field of the new payload */
+  suggestedFeeRecipient: DATA;
+};
+
+type FcuAttributes = {headBlockHash: DATA; finalizedBlockHash: DATA} & ApiPayloadAttributes;
+
+export class PayloadIdCache {
+  private readonly payloadIdByFcuAttributes = new Map<string, PayloadId>();
+  constructor(private readonly metrics?: IMetrics | null) {}
+
+  getKey({headBlockHash, finalizedBlockHash, timestamp, prevRandao, suggestedFeeRecipient}: FcuAttributes): string {
+    return `${headBlockHash}-${finalizedBlockHash}-${timestamp}-${prevRandao}-${suggestedFeeRecipient}`;
+  }
+
+  add(fcuAttributes: FcuAttributes, payloadId: PayloadId): void {
+    const key = this.getKey(fcuAttributes);
+    this.payloadIdByFcuAttributes.set(key, payloadId);
+  }
+
+  prune(): void {
+    // This is not so optimized function, but could maintain a 2d array may be?
+    pruneSetToMax(this.payloadIdByFcuAttributes, MAX_PAYLOAD_IDS);
+  }
+
+  get(fcuAttributes: FcuAttributes): PayloadId | undefined {
+    const key = this.getKey(fcuAttributes);
+    return this.payloadIdByFcuAttributes.get(key);
+  }
+}


### PR DESCRIPTION
This PR adds the capability to issue advance FcUs using cached beacon proposer data in the engine and cache generated payload ids, which could be picked up while assembling block body in the produceBlock calls.

PS: WIP, and dependent upon https://github.com/ChainSafe/lodestar/pull/3958

TODOS:
- [x] update merge interop tests
 - [x] add check that prepareSlot is the next slot by clock
 - [x] prune payloadIdCache 

Some of the scenario's to issue fcU moved here for allowing this to merge: https://github.com/ChainSafe/lodestar/issues/4054
In these scenarios, since the head prediction might turn out to be wrong, in the produce block call, the previous payload will be not be picked up, but rather an empty payload will be generated by EL which is ok for now as the block proposal will still be successful albeit with the empty payload (current scenario)
 