### PR TITLE
LightClientServer only import block if its new head

### DIFF
--- a/packages/lodestar/src/chain/lightClient/index.ts
+++ b/packages/lodestar/src/chain/lightClient/index.ts
@@ -186,11 +186,11 @@ export class LightClientServer {
   }
 
   /**
-   * Call after importing a block, having the postState available in memory for proof generation.
+   * Call after importing a block head, having the postState available in memory for proof generation.
    * - Persist state witness
    * - Use block's syncAggregate
    */
-  onImportBlock(
+  onImportBlockHead(
     block: altair.BeaconBlock,
     postState: CachedBeaconStateAltair,
     parentBlock: {blockRoot: RootHex; slot: Slot}


### PR DESCRIPTION
**Motivation**

A block maybe imported to LightClientServer but it's not part of canonical chain in the end

**Description**
Only import block if it's new head

Closes #3932
