### PR TITLE
Generalize filename regex for voting keys.

### DIFF
--- a/packages/cli/src/util/recursivelyFind.ts
+++ b/packages/cli/src/util/recursivelyFind.ts
@@ -49,7 +49,7 @@ export function isVotingKeystore(filename: string): boolean {
       // Key derivation path reference:
       //
       // https://eips.ethereum.org/EIPS/eip-2334
-      /keystore-m_12381_3600_[0-9]+_0_0-[0-9]+.json/.test(filename))
+      /keystore[\w-]*.json/.test(filename))
   );
 }
 

--- a/packages/cli/test/unit/validator/keys.test.ts
+++ b/packages/cli/test/unit/validator/keys.test.ts
@@ -2,13 +2,14 @@ import {expect} from "chai";
 import sinon from "sinon";
 import fs, {Dirent, Stats} from "node:fs";
 import {resolveKeystorePaths} from "../../../src/cmds/validator/keys";
+import {isVotingKeystore} from "../../../src/util";
 
 describe("validator / keys / resolveKeystorePaths", () => {
   beforeEach(() => {
     sinon.stub(fs, "lstatSync").returns({isDirectory: () => true} as Stats);
   });
 
-  it("should filter out deposite data files", function () {
+  it("should filter out deposit data files", function () {
     const keystoreFilename = "keystore-m_12381_3600_0_0_0-1642090404.json";
     const depositData = "deposit_data-1642090404.json";
 
@@ -19,6 +20,16 @@ describe("validator / keys / resolveKeystorePaths", () => {
     const result = resolveKeystorePaths("dir");
     expect(result.length).to.equal(1);
     expect(result[0]).to.equal(`dir/${keystoreFilename}`);
+  });
+
+  it("should read key voting files with accepted file names", function () {
+    const keystoreFilenames = ["keystore-m_12381_3600_0_0_0-1642090404.json", "keystore-0.json", "keystore.json"];
+
+    sinon.stub(fs, "readdirSync").callsFake(() => {
+      return ([keystoreFilenames] as unknown) as Dirent[];
+    });
+
+    expect(keystoreFilenames.every(isVotingKeystore)).to.equal(true, "should read voting keystore file");
   });
 
   afterEach(() => {


### PR DESCRIPTION
**Motivation**

Lodestar expects filename for key files to match the format exported by the eth2.0-deposit-cli library, even though the documentation states file name which contains 'keystore' and has the '.json' extension will be attempted to be imported.

This PR updates the behaviour to match what is documented.

Closes #3941