### PR TITLE
Making comparison between local/remote BeaconParam less error prone. 

### DIFF
--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -92,7 +92,7 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
   onGracefulShutdownCbs.push(async () => controller.abort());
 
   const dbOps = {
-    config: config,
+    config,
     controller: new LevelDbController({name: dbPath}, {logger}),
   };
   const slashingProtection = new SlashingProtection(dbOps);

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -1,12 +1,18 @@
-import {IChainConfig, chainConfigToJson} from "@chainsafe/lodestar-config";
+import {IChainConfig, chainConfigToJson, defaultChainConfig} from "@chainsafe/lodestar-config";
 
 export class NotEqualParamsError extends Error {}
 
 /**
  * Assert localConfig values match externalSpecJson. externalSpecJson may contain more values than localConfig.
  */
-export function assertEqualParams(localConfig: IChainConfig, remoteConfigJson: Record<string, string>): void {
+export function assertEqualParams(localConfig: IChainConfig, externalSpecJson: Record<string, string>): void {
   const localConfigJson = chainConfigToJson(localConfig) as Record<string, unknown>;
+
+  const remoteConfigJson = {
+    // fill missing properties in remote config with spec default values
+    ...chainConfigToJson(defaultChainConfig),
+    ...externalSpecJson,
+  };
 
   const errors: string[] = [];
 

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -18,11 +18,11 @@ export function assertEqualParams(localConfig: IChainConfig, externalSpecJson: R
 
   // Ensure only that the localConfig values match the remote spec
   for (const key of Object.keys(localConfigJson)) {
-    if (
-      (localConfigJson[key] as string)?.toLocaleLowerCase() !==
-      (externalSpecJsonWithDefaults[key] as string)?.toLocaleLowerCase()
-    )
+    const localValue = String(localConfigJson[key]).toLocaleLowerCase();
+    const remoteValue = String(externalSpecJsonWithDefaults[key]).toLocaleLowerCase();
+    if (localValue !== remoteValue) {
       errors.push(`${key} different value: ${localConfigJson[key]} != ${externalSpecJsonWithDefaults[key]}`);
+    }
   }
 
   if (errors.length > 0) {

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -8,7 +8,7 @@ export class NotEqualParamsError extends Error {}
 export function assertEqualParams(localConfig: IChainConfig, externalSpecJson: Record<string, string>): void {
   const localConfigJson = chainConfigToJson(localConfig) as Record<string, unknown>;
 
-  const remoteConfigJson = {
+  const externalSpecJsonWithDefaults = {
     // fill missing properties in remote config with spec default values
     ...chainConfigToJson(defaultChainConfig),
     ...externalSpecJson,
@@ -19,9 +19,10 @@ export function assertEqualParams(localConfig: IChainConfig, externalSpecJson: R
   // Ensure only that the localConfig values match the remote spec
   for (const key of Object.keys(localConfigJson)) {
     if (
-      (localConfigJson[key] as string)?.toLocaleLowerCase() !== (remoteConfigJson[key] as string)?.toLocaleLowerCase()
+      (localConfigJson[key] as string)?.toLocaleLowerCase() !==
+      (externalSpecJsonWithDefaults[key] as string)?.toLocaleLowerCase()
     )
-      errors.push(`${key} different value: ${localConfigJson[key]} != ${remoteConfigJson[key]}`);
+      errors.push(`${key} different value: ${localConfigJson[key]} != ${externalSpecJsonWithDefaults[key]}`);
   }
 
   if (errors.length > 0) {

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -5,16 +5,17 @@ export class NotEqualParamsError extends Error {}
 /**
  * Assert localConfig values match externalSpecJson. externalSpecJson may contain more values than localConfig.
  */
-export function assertEqualParams(localConfig: IChainConfig, externalSpecJson: Record<string, string>): void {
-  const params1Json = chainConfigToJson(localConfig) as Record<string, unknown>;
-  const params2Json = externalSpecJson;
+export function assertEqualParams(localConfig: IChainConfig, remoteConfigJson: Record<string, string>): void {
+  const localConfigJson = chainConfigToJson(localConfig) as Record<string, unknown>;
 
   const errors: string[] = [];
 
   // Ensure only that the localConfig values match the remote spec
-  for (const key of Object.keys(params1Json)) {
-    if (params1Json[key] !== params2Json[key])
-      errors.push(`${key} different value: ${params1Json[key]} != ${params2Json[key]}`);
+  for (const key of Object.keys(localConfigJson)) {
+    if (
+      (localConfigJson[key] as string)?.toLocaleLowerCase() !== (remoteConfigJson[key] as string)?.toLocaleLowerCase()
+    )
+      errors.push(`${key} different value: ${localConfigJson[key]} != ${remoteConfigJson[key]}`);
   }
 
   if (errors.length > 0) {

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -21,7 +21,7 @@ export function assertEqualParams(localConfig: IChainConfig, externalSpecJson: R
     const localValue = String(localConfigJson[key]).toLocaleLowerCase();
     const remoteValue = String(externalSpecJsonWithDefaults[key]).toLocaleLowerCase();
     if (localValue !== remoteValue) {
-      errors.push(`${key} different value: ${localConfigJson[key]} != ${externalSpecJsonWithDefaults[key]}`);
+      errors.push(`${key} different value: ${localValue} != ${remoteValue}`);
     }
   }
 

--- a/packages/validator/test/unit/utils/params.test.ts
+++ b/packages/validator/test/unit/utils/params.test.ts
@@ -1,7 +1,7 @@
 import {chainConfigToJson} from "@chainsafe/lodestar-config";
 import {chainConfig} from "@chainsafe/lodestar-config/default";
 import {expect} from "chai";
-import {assertEqualParams, NotEqualParamsError} from "../../../src/util/params";
+import {assertEqualParams, NotEqualParamsError} from "../../../src/util";
 
 describe("utils / params / assertEqualParams", () => {
   it("default == default", () => {
@@ -17,5 +17,11 @@ describe("utils / params / assertEqualParams", () => {
     const otherConfig = {...chainConfigJson, ALTAIR_FORK_EPOCH: String(chainConfig.ALTAIR_FORK_EPOCH + 1)};
 
     expect(() => assertEqualParams(chainConfig, otherConfig)).to.throw(NotEqualParamsError);
+  });
+
+  it("should fill missing remote values with default and be equal", () => {
+    const chainConfigJson = chainConfigToJson(chainConfig);
+    delete chainConfigJson["DEPOSIT_CONTRACT_ADDRESS"];
+    assertEqualParams(chainConfig, chainConfigJson);
   });
 });


### PR DESCRIPTION
**Motivation**

In issue #3962, it was surfaced that comparison between local/remote BeaconParam fails if:
- local config contains properties that is missing in remote
- difference in case of values. 

**Description**

The PR fills missing properties in remote config with default values specified in the spec before comparison. It also normalises the case of values before comparison.

Closes #3962