### PR TITLE
Initialize libp2p with esm module

### DIFF
--- a/packages/lodestar/src/network/nodejs/bundle.mjs
+++ b/packages/lodestar/src/network/nodejs/bundle.mjs
@@ -8,24 +8,9 @@ import Mplex from "libp2p-mplex";
 import {NOISE} from "@chainsafe/libp2p-noise";
 import Bootstrap from "libp2p-bootstrap";
 import MDNS from "libp2p-mdns";
-import PeerId from "peer-id";
-import {Datastore} from "interface-datastore";
-
-export interface ILibp2pOptions {
-  peerId: PeerId;
-  addresses: {
-    listen: string[];
-    announce?: string[];
-  };
-  datastore?: Datastore;
-  peerDiscovery?: (typeof Bootstrap | typeof MDNS)[];
-  bootMultiaddrs?: string[];
-  maxConnections?: number;
-  minConnections?: number;
-}
 
 export class NodejsNode extends LibP2p {
-  constructor(options: ILibp2pOptions) {
+  constructor(options) {
     super({
       peerId: options.peerId,
       addresses: {
@@ -90,7 +75,7 @@ export class NodejsNode extends LibP2p {
           bootstrap: {
             enabled: !!(options.bootMultiaddrs && options.bootMultiaddrs.length),
             interval: 2000,
-            list: (options.bootMultiaddrs || []) as string[],
+            list: (options.bootMultiaddrs || []),
           },
         },
       },

--- a/packages/lodestar/src/network/nodejs/index.ts
+++ b/packages/lodestar/src/network/nodejs/index.ts
@@ -1,5 +1,4 @@
 /**
  * @module network/nodejs
  */
-export * from "./bundle";
 export * from "./util";

--- a/packages/lodestar/src/network/nodejs/util.ts
+++ b/packages/lodestar/src/network/nodejs/util.ts
@@ -3,8 +3,7 @@
  */
 
 import PeerId from "peer-id";
-import LibP2p from "libp2p";
-import {NodejsNode} from "./bundle";
+import type LibP2p from "libp2p";
 import {defaultDiscv5Options, defaultNetworkOptions, INetworkOptions} from "../options";
 import {isLocalMultiAddr, clearMultiaddrUDP} from "..";
 import {ENR} from "@chainsafe/discv5";
@@ -66,6 +65,12 @@ export async function createNodeJsLibp2p(
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const {NodejsNode} = await Function("return import('./bundle.mjs')")();
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
   return new NodejsNode({
     peerId,
     addresses: {listen: localMultiaddrs},

--- a/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
+++ b/packages/lodestar/test/unit/network/nodejs/libp2p.test.ts
@@ -1,6 +1,5 @@
 import {assert} from "chai";
 import {sleep} from "@chainsafe/lodestar-utils";
-import {NodejsNode} from "../../../../src/network/nodejs";
 import {createNode} from "../../../utils/network";
 import {Libp2pEvent} from "../../../../src/constants";
 
@@ -8,7 +7,7 @@ const multiaddr = "/ip4/127.0.0.1/tcp/0";
 
 describe("[network] nodejs libp2p", () => {
   it("can start and stop a node", async () => {
-    const node: NodejsNode = await createNode(multiaddr);
+    const node = await createNode(multiaddr);
     await node.start();
     assert.equal(node.isStarted(), true);
     await node.stop();
@@ -18,8 +17,8 @@ describe("[network] nodejs libp2p", () => {
   it("can connect/disconnect to a peer", async function () {
     this.timeout(5000);
     // setup
-    const nodeA: NodejsNode = await createNode(multiaddr);
-    const nodeB: NodejsNode = await createNode(multiaddr);
+    const nodeA = await createNode(multiaddr);
+    const nodeB = await createNode(multiaddr);
 
     await Promise.all([nodeA.start(), nodeB.start()]);
 

--- a/packages/lodestar/test/utils/network.ts
+++ b/packages/lodestar/test/utils/network.ts
@@ -3,12 +3,17 @@ import {Multiaddr} from "multiaddr";
 import {ATTESTATION_SUBNET_COUNT, SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
 import {BitArray} from "@chainsafe/ssz";
 import {Network} from "../../src/network";
-import {NodejsNode} from "../../src/network/nodejs";
 import {createPeerId} from "../../src/network";
 import {Libp2pEvent} from "../../src/constants";
+import type Libp2p from "libp2p";
 
-export async function createNode(multiaddr: string, inPeerId?: PeerId): Promise<NodejsNode> {
+export async function createNode(multiaddr: string, inPeerId?: PeerId): Promise<Libp2p> {
   const peerId = inPeerId || (await createPeerId());
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const {NodejsNode} = await Function("return import('../../src/network/nodejs/bundle.mjs')")();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
   return new NodejsNode({
     peerId,
     addresses: {listen: [multiaddr]},


### PR DESCRIPTION
**Motivation**

Experiment to see what a minimal code change to support ESM libp2p would look like.

**Description**

Turn the bit of code that initialized a Libp2p instance into an ES Module. Use `await import` to import this.
Typescript tries to transpile `await import` into a `require` so a hack is required to force its hand.