### PR TITLE
Fix response casing for complaince with beacon-apis

### DIFF
--- a/packages/api/src/routes/node.ts
+++ b/packages/api/src/routes/node.ts
@@ -180,11 +180,11 @@ export function getReturnTypes(): ReturnTypes<Api> {
     getNetworkIdentity: ContainerData(NetworkIdentity),
     // All these types don't contain any BigInt nor Buffer instances.
     // Use jsonType() to translate the casing in a generic way.
-    getPeers: jsonType("camel"),
-    getPeer: jsonType("camel"),
-    getPeerCount: jsonType("camel"),
-    getNodeVersion: jsonType("camel"),
-    getSyncingStatus: jsonType("camel"),
+    getPeers: jsonType("snake"),
+    getPeer: jsonType("snake"),
+    getPeerCount: jsonType("snake"),
+    getNodeVersion: jsonType("snake"),
+    getSyncingStatus: jsonType("snake"),
     getHealth: sameType(),
   };
 }

--- a/packages/api/src/routes/validator.ts
+++ b/packages/api/src/routes/validator.ts
@@ -335,7 +335,8 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
 
 export function getReturnTypes(): ReturnTypes<Api> {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  const WithDependentRoot = <T>(dataType: Type<T>) => new ContainerType({data: dataType, dependentRoot: ssz.Root});
+  const WithDependentRoot = <T>(dataType: Type<T>) =>
+    new ContainerType({data: dataType, dependentRoot: ssz.Root}, {jsonCase: "snake"});
 
   const AttesterDuty = new ContainerType(
     {


### PR DESCRIPTION
**Motivation**
Dhruv from Obol network wanted to operate the lodestar validator against infura beacon node (most likely prysm or lighthouse).
However the validator fails on casing conversion.
<!-- Why is this PR exists? What are the goals of the pull request? -->
To make the casing of response complaint with the beacon-Apis spec.