### PR TITLE
sleep(0) must yield event loop

### DIFF
--- a/packages/utils/src/sleep.ts
+++ b/packages/utils/src/sleep.ts
@@ -6,7 +6,7 @@ import {ErrorAborted} from "./errors";
  * On abort throws ErrorAborted
  */
 export async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  if (ms <= 0) {
+  if (ms < 0) {
     return;
   }
 

--- a/packages/utils/test/unit/sleep.test.ts
+++ b/packages/utils/test/unit/sleep.test.ts
@@ -29,6 +29,41 @@ describe("sleep", function () {
     controller.abort();
     expect(controller.signal.aborted, "Signal should already be aborted").to.be.true;
 
-    await expect(sleep(10, controller.signal)).to.rejectedWith(ErrorAborted);
+    await expect(sleep(0, controller.signal)).to.rejectedWith(ErrorAborted);
+  });
+
+  it("sleep 0 must tick the event loop", async () => {
+    enum Step {
+      beforeSleep = "beforeSleep",
+      afterSleep = "afterSleep",
+      setTimeout0 = "setTimeout0",
+    }
+
+    const steps: Step[] = [];
+
+    setTimeout(() => {
+      steps.push(Step.setTimeout0);
+    }, 0);
+
+    steps.push(Step.beforeSleep);
+    await sleep(0);
+    steps.push(Step.afterSleep);
+
+    // Manual sleep to wait 2 ticks
+    for (let i = 0; i < 2; i++) {
+      await new Promise((r) => setTimeout(r, 0));
+    }
+
+    expect(steps).to.deep.equal(
+      [
+        // Sync execution
+        Step.beforeSleep,
+        // Next tick, first registered callback
+        Step.setTimeout0,
+        // Next tick, second registered callback
+        Step.afterSleep,
+      ],
+      "Wrong steps"
+    );
   });
 });


### PR DESCRIPTION
**Motivation**

Fix a regression introduced in https://github.com/ChainSafe/lodestar/pull/3944 which changed how sleep(0) behaves

```diff
-  if (ms < 0) return;
+  if (ms <= 0) {
+    return;
+  }
```

**Description**

- sleep(0) must yield event loop
- Add unit test to guarantee correct behaviour
