### PR TITLE
Activate ex-ante fork-choice spec tests

### DIFF
--- a/packages/lodestar/test/spec/allForks/forkChoice.ts
+++ b/packages/lodestar/test/spec/allForks/forkChoice.ts
@@ -49,7 +49,7 @@ const POW_BLOCK_FILE_NAME = "^(pow_block)_([0-9a-zA-Z]+)$";
 const ATTESTATION_FILE_NAME = "^(attestation)_([0-9a-zA-Z])+$";
 
 const logger = testLogger("spec-test");
-export function forkChoiceTest(fork: ForkName, testFolders: string[] = ["get_head", "on_block"]): void {
+export function forkChoiceTest(fork: ForkName, testFolders: string[] = ["get_head", "on_block", "ex_ante"]): void {
   for (const testFolder of testFolders) {
     describeDirectorySpecTest<IForkChoiceTestCase, void>(
       `${ACTIVE_PRESET}/${fork}/fork_choice/${testFolder}`,

--- a/packages/lodestar/test/spec/bellatrix/fork_choice.test.ts
+++ b/packages/lodestar/test/spec/bellatrix/fork_choice.test.ts
@@ -1,4 +1,4 @@
 import {ForkName} from "@chainsafe/lodestar-params";
 import {forkChoiceTest} from "../allForks/forkChoice";
 
-forkChoiceTest(ForkName.bellatrix, ["get_head", "on_block", "on_merge_block"]);
+forkChoiceTest(ForkName.bellatrix, ["get_head", "on_block", "ex_ante", "on_merge_block"]);


### PR DESCRIPTION

<!-- Why is this PR exists? What are the goals of the pull request? -->
Include ex-ante spec tests  in spec test runner for forkchoice.
Closes #3702