### PR TITLE
Lightclient e2e: increase validator client

### DIFF
--- a/packages/lodestar/test/e2e/chain/lightclient.test.ts
+++ b/packages/lodestar/test/e2e/chain/lightclient.test.ts
@@ -20,6 +20,7 @@ describe("chain / lightclient", function () {
    */
   const maxLcHeadTrackingDiffSlots = 4;
   const validatorCount = 8;
+  const validatorClientCount = 4;
   const targetSyncCommittee = 3;
   /** N sync committee periods + 1 epoch of margin */
   const finalizedEpochToReach = targetSyncCommittee * EPOCHS_PER_SYNC_COMMITTEE_PERIOD + 1;
@@ -72,7 +73,7 @@ describe("chain / lightclient", function () {
         network: {allowPublishToZeroPeers: true},
         api: {rest: {enabled: true, api: ["lightclient"], port: restPort}},
       },
-      validatorCount,
+      validatorCount: validatorCount * validatorClientCount,
       genesisTime,
       logger: loggerNodeA,
     });
@@ -84,7 +85,7 @@ describe("chain / lightclient", function () {
     const {validators} = await getAndInitDevValidators({
       node: bn,
       validatorsPerClient: validatorCount,
-      validatorClientCount: 1,
+      validatorClientCount,
       startIndex: 0,
       useRestApi: false,
       testLoggerOpts: {...testLoggerOpts, logLevel: LogLevel.error},

--- a/packages/lodestar/test/utils/node/validator.ts
+++ b/packages/lodestar/test/utils/node/validator.ts
@@ -127,8 +127,8 @@ export async function getAndInitDevValidators({
   const validators: Promise<Validator>[] = [];
   const secretKeys: SecretKey[] = [];
 
-  for (let i = 0; i < validatorClientCount; i++) {
-    const startIndexVc = startIndex + i * validatorClientCount;
+  for (let clientIndex = 0; clientIndex < validatorClientCount; clientIndex++) {
+    const startIndexVc = startIndex + clientIndex * validatorsPerClient;
     const endIndex = startIndexVc + validatorsPerClient - 1;
     const logger = testLogger(`Vali ${startIndexVc}-${endIndex}`, testLoggerOpts);
     const tmpDir = tmp.dirSync({unsafeCleanup: true});


### PR DESCRIPTION
**Motivation**

+ There is lightclient sync error `Sync committee has not sufficient participants` sometimes, increasing validator clients should mitigate it
+ Fix `getAndInitDevValidators()` util

**Description**

+ `SYNC_COMMITTEE_SIZE` is 32 but the test only has 8 validators, so we increase validator client to 4
+ It also help mitigate `Sync committee has not sufficient participants` issue

Closes #3994

