### PR TITLE
Observe attestation submission after the api called

### DIFF
--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -163,11 +163,10 @@ export class AttestationService {
     const afterBlockDelayMs = (1000 * this.clock.secondsPerSlot) / (this.opts?.afterBlockDelaySlotFraction ?? 6);
     await sleep(Math.min(msToOneThirdSlot, afterBlockDelayMs));
 
-    this.metrics?.attesterStepCallPublishAttestation.observe(this.clock.secFromSlot(slot + 1 / 3));
-
     // Step 2. Publish all `Attestations` in one go
     try {
       await this.api.beacon.submitPoolAttestations(signedAttestations);
+      this.metrics?.attesterStepCallPublishAttestation.observe(this.clock.secFromSlot(slot + 1 / 3));
       this.logger.info("Published attestations", {slot, count: signedAttestations.length});
       this.metrics?.publishedAttestations.inc(signedAttestations.length);
     } catch (e) {


### PR DESCRIPTION
**Motivation**

We want to monitor the delay time from 1/3 slot to the time attestation is published

**Description**

+ as shown in #4009, sometimes beacon node has i/o lag so we'd like to track `attesterStepCallPublishAttestation` metric after the attestation is published

part of #4009

