### PR TITLE
Modify gossipsub params following consensus spec v1.1.10

### DIFF
--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -94,6 +94,8 @@ export class Eth2Gossipsub extends Gossipsub {
 
     const scoreParams = computeGossipPeerScoreParams(modules);
 
+    const heartbeatInterval = 0.7 * 1000;
+
     // Gossipsub parameters defined here:
     // https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md#the-gossip-domain-gossipsub
     super(modules.libp2p, {
@@ -104,6 +106,11 @@ export class Eth2Gossipsub extends Gossipsub {
       Dlo: GOSSIP_D_LOW,
       Dhi: GOSSIP_D_HIGH,
       Dlazy: 6,
+      heartbeatInterval,
+      fanoutTTL: 60 * 1000,
+      mcacheLength: 6,
+      mcacheGossip: 3,
+      seenTTL: 550 * heartbeatInterval,
       scoreParams,
       scoreThresholds: gossipScoreThresholds,
       // the default in gossipsub is 3s is not enough since lodestar suffers from I/O lag

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -39,6 +39,8 @@ import {PeersData} from "../peers/peersData";
 import {ClientKind} from "../peers/client";
 
 /* eslint-disable @typescript-eslint/naming-convention */
+/** As specified in https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md */
+const GOSSIPSUB_HEARTBEAT_INTERVAL = 0.7 * 1000;
 
 // TODO: Export this type
 type GossipsubEvents = {
@@ -94,8 +96,6 @@ export class Eth2Gossipsub extends Gossipsub {
 
     const scoreParams = computeGossipPeerScoreParams(modules);
 
-    const heartbeatInterval = 0.7 * 1000;
-
     // Gossipsub parameters defined here:
     // https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md#the-gossip-domain-gossipsub
     super(modules.libp2p, {
@@ -106,11 +106,11 @@ export class Eth2Gossipsub extends Gossipsub {
       Dlo: GOSSIP_D_LOW,
       Dhi: GOSSIP_D_HIGH,
       Dlazy: 6,
-      heartbeatInterval,
+      heartbeatInterval: GOSSIPSUB_HEARTBEAT_INTERVAL,
       fanoutTTL: 60 * 1000,
       mcacheLength: 6,
       mcacheGossip: 3,
-      seenTTL: 550 * heartbeatInterval,
+      seenTTL: 550 * GOSSIPSUB_HEARTBEAT_INTERVAL,
       scoreParams,
       scoreThresholds: gossipScoreThresholds,
       // the default in gossipsub is 3s is not enough since lodestar suffers from I/O lag


### PR DESCRIPTION
**Motivation**

Strictly follow consensus spec v1.1.10

**Description**

+ D params: same
+ heartbeatInterval: change from 1s to 0.7s
+ fanoutTTL: same
+ mcacheLength: change from 5 to 6
+ mcacheGossip: same
+ seenTTL: change from 5 minutes to 6.4 minutes (550 hearbeatInterval)

Closes #3865

**TODO**
- [x] Test on feature group