### PR TITLE
Handle merge block fetch error

### DIFF
--- a/packages/lodestar/src/chain/blocks/verifyBlock.ts
+++ b/packages/lodestar/src/chain/blocks/verifyBlock.ts
@@ -296,8 +296,8 @@ export async function verifyBlockStateTransition(
     if (isMergeTransitionBlock) {
       const mergeBlock = block.message as bellatrix.BeaconBlock;
       const powBlockRootHex = toHexString(mergeBlock.body.executionPayload.parentHash);
-      const powBlock = await chain.eth1.getPowBlock(powBlockRootHex);
-      const powBlockParent = powBlock && (await chain.eth1.getPowBlock(powBlock.parentHash));
+      const powBlock = await chain.eth1.getPowBlock(powBlockRootHex).catch((_error) => null);
+      const powBlockParent = powBlock && (await chain.eth1.getPowBlock(powBlock.parentHash).catch((_error) => null));
 
       assertValidTerminalPowBlock(chain.config, mergeBlock, {executionStatus, powBlock, powBlockParent});
     }

--- a/packages/lodestar/src/chain/blocks/verifyBlock.ts
+++ b/packages/lodestar/src/chain/blocks/verifyBlock.ts
@@ -295,9 +295,32 @@ export async function verifyBlockStateTransition(
     //     in import block
     if (isMergeTransitionBlock) {
       const mergeBlock = block.message as bellatrix.BeaconBlock;
+      const mergeBlockHash = toHexString(
+        chain.config.getForkTypes(mergeBlock.slot).BeaconBlock.hashTreeRoot(mergeBlock)
+      );
       const powBlockRootHex = toHexString(mergeBlock.body.executionPayload.parentHash);
-      const powBlock = await chain.eth1.getPowBlock(powBlockRootHex).catch((_error) => null);
-      const powBlockParent = powBlock && (await chain.eth1.getPowBlock(powBlock.parentHash).catch((_error) => null));
+      const powBlock = await chain.eth1.getPowBlock(powBlockRootHex).catch((error) => {
+        // Lets just warn the user here, errors if any will be reported on
+        // `assertValidTerminalPowBlock` checks
+        chain.logger.warn(
+          "Error fetching terminal PoW block referred in the merge transition block",
+          {powBlockHash: powBlockRootHex, mergeBlockHash},
+          error
+        );
+        return null;
+      });
+      const powBlockParent =
+        powBlock &&
+        (await chain.eth1.getPowBlock(powBlock.parentHash).catch((error) => {
+          // Lets just warn the user here, errors if any will be reported on
+          // `assertValidTerminalPowBlock` checks
+          chain.logger.warn(
+            "Error fetching parent of the terminal PoW block referred in the merge transition block",
+            {powBlockParentHash: powBlock.parentHash, powBlock: powBlockRootHex, mergeBlockHash},
+            error
+          );
+          return null;
+        }));
 
       assertValidTerminalPowBlock(chain.config, mergeBlock, {executionStatus, powBlock, powBlockParent});
     }


### PR DESCRIPTION
**Motivation**
The merge block fetch (`getBlockByHash`) can error and stop the CL from syncing past merge transition point unless the corresponding EL also syncs upto the merge transition block.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR ignores the merge pow block fetch error for preparing data to run `assertValidTerminalPowBlock` validations on `isMergeTransitionBlock`. 
This fix will allow lodestar to keep syncing and importing the blocks even if the respective EL is behind the merge transition point or doesn't has the corresponding merge block (provided the validations pass as per `assertValidTerminalPowBlock` logic)