### PR TITLE
Throw a more informative error on invalid keystore

### DIFF
--- a/packages/cli/src/cmds/validator/keys.ts
+++ b/packages/cli/src/cmds/validator/keys.ts
@@ -60,9 +60,10 @@ export async function getLocalSecretKeys(
 
     const secretKeys = await Promise.all(
       keystorePaths.map(async (keystorePath) => {
+        const keystoreStr = fs.readFileSync(keystorePath, "utf8");
         let keystore;
         try {
-          keystore = Keystore.parse(fs.readFileSync(keystorePath, "utf8"));
+          keystore = Keystore.parse(keystoreStr);
         } catch (e) {
           throw new Error(`Error parsing keystore at ${keystorePath}: ${(e as Error).message}`);
         }

--- a/packages/cli/src/cmds/validator/keys.ts
+++ b/packages/cli/src/cmds/validator/keys.ts
@@ -61,12 +61,15 @@ export async function getLocalSecretKeys(
     const secretKeys = await Promise.all(
       keystorePaths.map(async (keystorePath) => {
         const keystoreStr = fs.readFileSync(keystorePath, "utf8");
+
         let keystore;
         try {
           keystore = Keystore.parse(keystoreStr);
         } catch (e) {
-          throw new Error(`Error parsing keystore at ${keystorePath}: ${(e as Error).message}`);
+          (e as Error).message = `Error parsing keystore at ${keystorePath}: ${(e as Error).message}`;
+          throw e;
         }
+
         return SecretKey.fromBytes(await keystore.decrypt(passphrase));
       })
     );

--- a/packages/cli/src/cmds/validator/keys.ts
+++ b/packages/cli/src/cmds/validator/keys.ts
@@ -64,7 +64,7 @@ export async function getLocalSecretKeys(
         try {
           keystore = Keystore.parse(fs.readFileSync(keystorePath, "utf8"));
         } catch (e) {
-          throw new Error("Invalid keystore at " + keystorePath);
+          throw new Error("Error parsing keystore at " + keystorePath + ": " + (e as Error).message);
         }
         return SecretKey.fromBytes(await keystore.decrypt(passphrase));
       })

--- a/packages/cli/src/cmds/validator/keys.ts
+++ b/packages/cli/src/cmds/validator/keys.ts
@@ -59,9 +59,15 @@ export async function getLocalSecretKeys(
     }
 
     const secretKeys = await Promise.all(
-      keystorePaths.map(async (keystorePath) =>
-        SecretKey.fromBytes(await Keystore.parse(fs.readFileSync(keystorePath, "utf8")).decrypt(passphrase))
-      )
+      keystorePaths.map(async (keystorePath) => {
+        let keystore;
+        try {
+          keystore = Keystore.parse(fs.readFileSync(keystorePath, "utf8"));
+        } catch (e) {
+          throw new Error("Invalid keystore at " + keystorePath);
+        }
+        return SecretKey.fromBytes(await keystore.decrypt(passphrase));
+      })
     );
 
     return {

--- a/packages/cli/src/cmds/validator/keys.ts
+++ b/packages/cli/src/cmds/validator/keys.ts
@@ -64,7 +64,7 @@ export async function getLocalSecretKeys(
         try {
           keystore = Keystore.parse(fs.readFileSync(keystorePath, "utf8"));
         } catch (e) {
-          throw new Error("Error parsing keystore at " + keystorePath + ": " + (e as Error).message);
+          throw new Error(`Error parsing keystore at ${keystorePath}: ${(e as Error).message}`);
         }
         return SecretKey.fromBytes(await keystore.decrypt(passphrase));
       })


### PR DESCRIPTION
**Motivation**

Seen in the private lodestar chat:

Has anyone ever seen this validator error before?
```
May-16 14:13:11.239[]                 info: Lodestar version=v0.34.0-beta.0/HEAD/+183/28e2c74c (git), network=prater
 ✖ SyntaxError: Unexpected token p in JSON at position 0
    at JSON.parse (<anonymous>)
    at Function.parse (/usr/app/node_modules/@chainsafe/bls-keystore/lib/class.js:53:41)
    at /usr/app/node_modules/@chainsafe/lodestar-cli/src/cmds/validator/keys.ts:63:44
    at Array.map (<anonymous>)
    at getLocalSecretKeys (/usr/app/node_modules/@chainsafe/lodestar-cli/src/cmds/validator/keys.ts:62:21)
    at Object.validatorHandler [as handler] (/usr/app/node_modules/@chainsafe/lodestar-cli/src/cmds/validator/handler.ts:68:68)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

This error isn't very informative, but its due to an invalid keystore being loaded.

**Description**

This PR catches errors parsing a keystore, and throws an error with the keystore path
