### PR TITLE
Fix readAndGetGitData

### DIFF
--- a/packages/cli/src/util/gitData/index.ts
+++ b/packages/cli/src/util/gitData/index.ts
@@ -20,8 +20,14 @@ export function readAndGetGitData(): GitData {
     return {
       // If the CLI is run from source, prioritze current git data
       // over `.git-data.json` file, which might be stale here.
-      branch: currentGitData.branch ?? persistedGitData.branch ?? "",
-      commit: currentGitData.commit ?? persistedGitData.commit ?? "",
+      branch:
+        currentGitData.branch && currentGitData.branch.length > 0
+          ? currentGitData.branch
+          : persistedGitData.branch ?? "",
+      commit:
+        currentGitData.commit && currentGitData.commit.length > 0
+          ? currentGitData.commit
+          : persistedGitData.commit ?? "",
     };
   } catch (e) {
     return {


### PR DESCRIPTION
**Motivation**

The version in grafana is incorrect for feature branch

**Description**

In case we don't get the current git data, we need to check for empty string to get from `.git-data.json` instead

Closes #4024

**Test result**

<img width="811" alt="Screen Shot 2022-05-17 at 12 42 49" src="https://user-images.githubusercontent.com/10568965/168737499-472e142c-ef15-4855-ab96-709053fd55d2.png">

