### PR TITLE
Extend timeout for gitData unit test

### DIFF
--- a/packages/cli/test/unit/util/gitData.test.ts
+++ b/packages/cli/test/unit/util/gitData.test.ts
@@ -8,7 +8,10 @@ import {getGitData} from "../../../src/util";
 
 const WRITE_GIT_DATA_CMD = "npm run write-git-data";
 
-describe("util / gitData", () => {
+describe("util / gitData", function () {
+  // In CI, the below before() function takes time
+  this.timeout(3000);
+
   before(() => {
     const pkgJsonPath = findUp.sync("package.json", {cwd: __dirname});
     if (!pkgJsonPath) {


### PR DESCRIPTION
**Motivation**

Fix timeout error in `gitData` unit test

**Description**
+ The `before()` block writes `.git-data.json` in a child process so it takes time
+ Increase timeout to 3000

Closes #4023
