### PR TITLE
Simplify release process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ In the same day:
 3. The selected commit is tagged as `v0.34.0-beta.0`, released, and published for testing as a Pre-Release
 
 ```
-export TAG=v0.34.0-beta.0 && git tag -a $TAG 9fceb02 -m "$TAG" && git push origin $TAG
+yarn release -t v0.34.0-beta.0 -c 9fceb02
 ```
 
 4. The team creates a PR to bump `master` to the next version (in the example: `v0.35.0`) and continues releasing nightly builds.
@@ -25,7 +25,7 @@ After 3-5 days of testing:
 5. Tag final stable commit as `v0.34.0`, release and publish the stable release. This commit will be in `v0.34.x` branch and may note be on `master` if beta candidate required bug fixes.
 
 ```
-export TAG=v0.34.0 && git tag -a $TAG 9fceb02 -m "$TAG" && git push origin $TAG
+yarn release -t v0.34.0 -c 9fceb02
 ```
 
 ## Pre-Releases

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ In the same day:
 3. The selected commit is tagged as `v0.34.0-beta.0`, released, and published for testing as a Pre-Release
 
 ```
-yarn release -t v0.34.0-beta.0 -c 9fceb02
+yarn release -t v0.34.0-beta.0
 ```
 
 4. The team creates a PR to bump `master` to the next version (in the example: `v0.35.0`) and continues releasing nightly builds.
@@ -25,7 +25,7 @@ After 3-5 days of testing:
 5. Tag final stable commit as `v0.34.0`, release and publish the stable release. This commit will be in `v0.34.x` branch and may note be on `master` if beta candidate required bug fixes.
 
 ```
-yarn release -t v0.34.0 -c 9fceb02
+yarn release -t v0.34.0
 ```
 
 ## Pre-Releases

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "benchmark": "yarn benchmark:files 'packages/*/test/perf/**/*.test.ts'",
     "benchmark:files": "LODESTAR_PRESET=mainnet NODE_OPTIONS=--max-old-space-size=4096 benchmark --config .benchrc.yaml",
     "publish:release": "lerna publish from-package --yes --no-verify-access",
-    "release": "lerna version --no-push --sign-git-commit",
+    "release": "node scripts/release.mjs",
     "postrelease": "git tag -d $(git describe --abbrev=0)",
     "check-readme": "lerna run check-readme"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "benchmark:files": "LODESTAR_PRESET=mainnet NODE_OPTIONS=--max-old-space-size=4096 benchmark --config .benchrc.yaml",
     "publish:release": "lerna publish from-package --yes --no-verify-access",
     "release": "node scripts/release.mjs",
-    "postrelease": "git tag -d $(git describe --abbrev=0)",
     "check-readme": "lerna run check-readme"
   },
   "devDependencies": {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -129,6 +129,7 @@ async function lernaVersion(tag, yes) {
     await _lernaVersion({
       cwd: process.cwd(),
       bump: tag,
+      "force-publish": true,
       yes: yes,
     })
   } catch (e) {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,12 +1,15 @@
 import {execSync} from "node:child_process";
+import {readFileSync} from "node:fs";
 import yargs from "yargs";
 import {hideBin} from "yargs/helpers";
 import inquirer from "inquirer";
+import _lernaVersion from "@lerna/version";
 
 // Script to make releasing easier
 // Run with --help to see usage
 
 const cmd = (cmd, opts={}) => execSync(cmd, {encoding: "utf8", stdio: ["pipe", "pipe", "ignore"], ...opts}).trim();
+const exit = (...msg) => { console.log(...msg), process.exit(1) };
 
 const argv = yargs(hideBin(process.argv))
   .usage("Release lodestar")
@@ -23,7 +26,6 @@ const argv = yargs(hideBin(process.argv))
     commit: {
       alias: "c",
       type: "string",
-      default: cmd("git rev-parse --short HEAD"),
       describe: "The commit to tag",
     },
     yes: {
@@ -39,66 +41,126 @@ const argv = yargs(hideBin(process.argv))
   .help()
   .argv;
 
-// Validate the supplied version
-const versionCaptureRegex=/^(v[0-9]+\.[0-9]+)\.[0-9]+(-beta\.[0-9]+)?$/
-const versionMatch = versionCaptureRegex.exec(argv.tag);
-if (versionMatch == null) {
-  console.log(`Tag must match ${versionCaptureRegex}`);
-  process.exit(1);
+const yes = argv.yes;
+const {
+  tag,
+  currentCommit,
+  commit,
+  commitMessage,
+  branch,
+} = getInfo(argv);
+
+console.log("Tag", tag);
+console.log("Checked-out commit", currentCommit);
+console.log("Commit", commit, commitMessage);
+console.log("Branch", branch);
+
+ensureCommitExistsInBranch(commit, branch);
+
+if (!lernaVersionMatchesTag(tag)) {
+  console.log("Lerna-controlled version does not match tag");
+
+  if (commit !== currentCommit) {
+    exit("Cannot continue because the checked-out commit doesn't match the selected commit");
+  }
+  console.log("Deferring to lerna");
+  await lernaVersion(tag, yes);
+} else {
+  await tagAndPush(commit, tag, yes);
 }
 
-const tag = argv.tag;
-const commit = argv.commit;
-const commitMessage = cmd(`git show-branch --no-name ${commit}`);
-// The branch is assumed from the tag
-const branch = `${versionMatch[1]}.x`;
+console.log("Success!");
 
-console.log("Tag", tag)
-console.log("Commit", commit, commitMessage)
-console.log("Branch", branch)
+/////////////////////////////
 
-// Ensure the branch exists
-try {
-  cmd(`git show-branch --no-name ${branch}`);
-} catch (e) {
-  console.log(`Branch ${branch} does not exist`);
-  process.exit(1);
+function getInfo(argv) {
+  // Validate tag version (must be semver-ish)
+  const versionCaptureRegex=/^(v[0-9]+\.[0-9]+)\.[0-9]+(-beta\.[0-9]+)?$/
+  const versionMatch = versionCaptureRegex.exec(argv.tag);
+  if (versionMatch == null) {
+    exit(`Tag must match ${versionCaptureRegex}`);
+  }
+
+  const tag = argv.tag;
+  const currentCommit = cmd("git rev-parse --short HEAD");
+  const commit = argv.commit ?? currentCommit;
+  const commitMessage = cmd(`git show-branch --no-name ${commit}`);
+  // The branch is assumed from the tag
+  const branch = `${versionMatch[1]}.x`;
+
+  return {
+    tag,
+    currentCommit,
+    commit,
+    commitMessage,
+    branch,
+  };
 }
 
-// Ensure the commit exists in the branch (last 10 commits)
-const last10Commits = cmd(`git log --oneline -n 10 ${branch}`);
-const commitMatch = last10Commits.match(commit);
-if (commitMatch == null) {
-  console.log(`Commit ${commit} does not belong to branch ${branch}`);
-  process.exit(1);
-}
+function ensureCommitExistsInBranch(commit, branch) {
+  // Ensure the branch exists
+  try {
+    cmd(`git show-branch --no-name ${branch}`);
+  } catch (e) {
+    exit(`Branch ${branch} does not exist`);
+  }
 
-// Last chance to exit
-if (!argv.yes) {
-  const input = await inquirer.prompt([
-    {
-      name: "yes",
-      type: "confirm",
-      message: "Do you want to proceed?",
-    },
-  ]);
-  if (!input.yes) {
-    process.exit(1);
+  // Ensure the commit exists in the branch (last 10 commits)
+  const last10Commits = cmd(`git log --oneline -n 10 ${branch}`);
+  const commitMatch = last10Commits.match(commit);
+  if (commitMatch == null) {
+    exit(`Commit ${commit} does not belong to branch ${branch}`);
   }
 }
 
-// Perform release actions
-try {
-  const tagCmd = `git tag -a ${tag} ${commit} -m "${tag}"`;
-  console.log(tagCmd);
-  cmd(tagCmd, {stdio: "pipe"});
+function lernaVersionMatchesTag(tag) {
+  // Ensure the lerna.json is at the right version
+  let lernaVersion;
+  try {
+    lernaVersion = JSON.parse(readFileSync("./lerna.json")).version;
+  } catch (e) {
+    exit(`Error fetching/parsing lerna.json: ${e.message}`);
+  }
+  return lernaVersion === tag;
+}
 
-  const pushCmd = `git push origin ${tag}`;
-  console.log(pushCmd);
-  cmd(pushCmd, {stdio: "pipe"});
+async function lernaVersion(tag, yes) {
+  try {
+    await _lernaVersion({
+      cwd: process.cwd(),
+      bump: tag,
+      yes: yes,
+    })
+  } catch (e) {
+    exit((e.message));
+  }
+}
 
-  console.log("Success!");
-} catch (e) {
-  console.log(e.message);
-  process.exit(1);
+async function tagAndPush(commit, tag, yes)  {
+  // Last chance to exit
+  if (!yes) {
+    const input = await inquirer.prompt([
+      {
+        name: "yes",
+        type: "confirm",
+        message: "Do you want to proceed? Continuing will tag and push.",
+      },
+    ]);
+    if (!input.yes) {
+      process.exit(1);
+    }
+  }
+
+  // Perform release actions
+  try {
+    const tagCmd = `git tag -a ${tag} ${commit} -m "${tag}"`;
+    console.log(tagCmd);
+    cmd(tagCmd, {stdio: "pipe"});
+
+    const pushCmd = `git push origin ${tag}`;
+    console.log(pushCmd);
+    cmd(pushCmd, {stdio: "pipe"});
+  } catch (e) {
+    exit(e.message);
+  }
 }

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,104 @@
+import {execSync} from "node:child_process";
+import yargs from "yargs";
+import {hideBin} from "yargs/helpers";
+import inquirer from "inquirer";
+
+// Script to make releasing easier
+// Run with --help to see usage
+
+const cmd = (cmd, opts={}) => execSync(cmd, {encoding: "utf8", stdio: ["pipe", "pipe", "ignore"], ...opts}).trim();
+
+const argv = yargs(hideBin(process.argv))
+  .usage("Release lodestar")
+  .example([
+    ["$0 -t v0.36.0", "Release version 0.36.0 using the current commit"]
+  ])
+  .options({
+    tag: {
+      alias: "t",
+      demandOption: true,
+      type: "string",
+      describe: "The tag to release",
+    },
+    commit: {
+      alias: "c",
+      type: "string",
+      default: cmd("git rev-parse --short HEAD"),
+      describe: "The commit to tag",
+    },
+    yes: {
+      alias: "y",
+      type: "boolean",
+      describe: "Automatic yes to prompts"
+    }
+  })
+  .version("v0.1.0")
+  .alias("v", "version")
+  .alias("h", "help")
+  .strict()
+  .help()
+  .argv;
+
+// Validate the supplied version
+const versionCaptureRegex=/^(v[0-9]+\.[0-9]+)\.[0-9]+(-beta\.[0-9]+)?$/
+const versionMatch = versionCaptureRegex.exec(argv.tag);
+if (versionMatch == null) {
+  console.log(`Tag must match ${versionCaptureRegex}`);
+  process.exit(1);
+}
+
+const tag = argv.tag;
+const commit = argv.commit;
+const commitMessage = cmd(`git show-branch --no-name ${commit}`);
+// The branch is assumed from the tag
+const branch = `${versionMatch[1]}.x`;
+
+console.log("Tag", tag)
+console.log("Commit", commit, commitMessage)
+console.log("Branch", branch)
+
+// Ensure the branch exists
+try {
+  cmd(`git show-branch --no-name ${branch}`);
+} catch (e) {
+  console.log(`Branch ${branch} does not exist`);
+  process.exit(1);
+}
+
+// Ensure the commit exists in the branch (last 10 commits)
+const last10Commits = cmd(`git log --oneline -n 10 ${branch}`);
+const commitMatch = last10Commits.match(commit);
+if (commitMatch == null) {
+  console.log(`Commit ${commit} does not belong to branch ${branch}`);
+  process.exit(1);
+}
+
+// Last chance to exit
+if (!argv.yes) {
+  const input = await inquirer.prompt([
+    {
+      name: "yes",
+      type: "confirm",
+      message: "Do you want to proceed?",
+    },
+  ]);
+  if (!input.yes) {
+    process.exit(1);
+  }
+}
+
+// Perform release actions
+try {
+  const tagCmd = `git tag -a ${tag} ${commit} -m "${tag}"`;
+  console.log(tagCmd);
+  cmd(tagCmd, {stdio: "pipe"});
+
+  const pushCmd = `git push origin ${tag}`;
+  console.log(pushCmd);
+  cmd(pushCmd, {stdio: "pipe"});
+
+  console.log("Success!");
+} catch (e) {
+  console.log(e.message);
+  process.exit(1);
+}


### PR DESCRIPTION
**Motivation**

The release process was slightly error-prone and more tedious than necessary.

**Description**

- Add a release script with basic sanity checking, tagging, and pushing the tag.
- Update RELEASE.md to include usage.

The script automates the steps of "releasing" lodestar.
- optionally, bumping the version in package.jsons
- tag a specific commit
- push the tag to github

It ensures the following sanity checks:
- the tag follows the convention `v#.#.#` or `v#.#.#-beta.#` (eg: `v0.36.1` or `v0.36.1-beta.0`)
- the tag matches an existing branch `v#.#.x`
- the commit exists in the branch `v#.#.x`
- the user is prompted before continuing to the final step
- if the lerna.json matches the tag, the tag and push is performed manually using `git`
- if the lerna.json _doesn't_ match the tag, `lerna version` is used

Common usage:
- If beta release:
  - Checkout version branch (eg: `v0.36.x`)
  - Cherrypick patch commits on top
  - Run release script (eg: `yarn release -t v0.36.1-beta.0`)
- If non-beta release
  - Checkout version branch (eg: `v0.36.x`)
  - Ensure the checked out branch is the one to release
  - Run release script (eg: `yarn release -t v0.36.1`)