### PR TITLE
Remove child_process call in gitData before step

### DIFF
--- a/packages/cli/test/unit/util/gitData.test.ts
+++ b/packages/cli/test/unit/util/gitData.test.ts
@@ -1,27 +1,16 @@
 import {expect} from "chai";
-import child_process from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import findUp from "find-up";
 import {gitDataPath, readGitDataFile} from "../../../src/util/gitData/gitDataPath";
 import {getGitData} from "../../../src/util";
 
-const WRITE_GIT_DATA_CMD = "npm run write-git-data";
-
 describe("util / gitData", function () {
-  // In CI, the below before() function takes time
-  this.timeout(3000);
-
-  before(() => {
-    const pkgJsonPath = findUp.sync("package.json", {cwd: __dirname});
-    if (!pkgJsonPath) {
-      throw Error("No package.json found");
-    }
-
-    const pkgJsonDir = path.resolve(path.dirname(pkgJsonPath));
-    child_process.execSync(WRITE_GIT_DATA_CMD, {cwd: pkgJsonDir});
-  });
-
+  // .gitData file is created at build time with the command
+  // ```
+  // npm run write-git-data
+  // ```
+  // If this step fails run that command. This could happen when running tests before building.
   it("gitData file must exist", () => {
     const gitData = readGitDataFile();
 


### PR DESCRIPTION
**Motivation**

gitData is file created at build time that contains the commit and branch of the build.

During https://github.com/ChainSafe/lodestar/pull/3992 experimentation gitData generation was removed from the generic build step. So I added the before() step in the tests to ensure that the file is created with the expected way. However the final version of https://github.com/ChainSafe/lodestar/pull/3992 includes generating gitData on each build. See that PR for reasoning.

If gitData is generated on each build that before() step is useless.

**Description**

The reason is may hang will be probably due to an interactive prompt or some strange interaction of running npm in npm, that takes longer. Instead of keep trying to extend the timeout https://github.com/ChainSafe/lodestar/pull/4026 or debugging, let's just remove this unnecessary source of problems.