### PR TITLE
docs: Update nodeJS minimum requirement

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ Make sure to have [Yarn installed](https://classic.yarnpkg.com/en/docs/install).
 
 <!-- prettier-ignore-start -->
 !!! info
-    NodeJS versions < 12 are not supported by Lodestar.
+    NodeJS versions < 16.x are not supported by Lodestar. We currently recommend running NodeJS 16.x.
 <!-- prettier-ignore-end -->
 
 Clone the repo locally.


### PR DESCRIPTION
**Motivation**
From discussion under #4035 

**Description**

Updated documentation to discontinue support for NodeJS <16.x and recommend that we currently use 16.x