### PR TITLE
Implement countNotSeenAttester for OpPool

### DIFF
--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -441,7 +441,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
 
             chain.aggregatedAttestationPool.add(
               signedAggregateAndProof.message.aggregate,
-              indexedAttestation.attestingIndices.length,
+              indexedAttestation.attestingIndices,
               committeeIndices
             );
             const sentPeers = await network.gossip.publishBeaconAggregateAndProof(signedAggregateAndProof);

--- a/packages/lodestar/src/network/gossip/handlers/index.ts
+++ b/packages/lodestar/src/network/gossip/handlers/index.ts
@@ -166,11 +166,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
       metrics?.registerGossipAggregatedAttestation(seenTimestampSec, signedAggregateAndProof, indexedAttestation);
       const aggregatedAttestation = signedAggregateAndProof.message.aggregate;
 
-      chain.aggregatedAttestationPool.add(
-        aggregatedAttestation,
-        indexedAttestation.attestingIndices.length,
-        committeeIndices
-      );
+      chain.aggregatedAttestationPool.add(aggregatedAttestation, indexedAttestation.attestingIndices, committeeIndices);
 
       if (!options.dontSendGossipAttestationsToForkchoice) {
         try {

--- a/packages/lodestar/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/lodestar/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -77,7 +77,7 @@ function getAggregatedAttestationPool(state: CachedBeaconStateAltair): Aggregate
       const committee = state.epochCtx.getBeaconCommittee(slot, committeeIndex);
       // all attestation has full participation so getAttestationsForBlock() has to do a lot of filter
       // aggregate_and_proof messages
-      pool.add(attestation, committee.length, committee);
+      pool.add(attestation, committee, committee);
     }
   }
   return pool;


### PR DESCRIPTION
**Motivation**

Improve performance of aggregated op pool, started from #4034

**Description**

+ Implement `countNotSeenAttester` given committee, attesting indices, seen attesting indices in the same order
+ Clean up some code