### PR TITLE
Specify lerna exact version for release-nightly workflow

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -55,6 +55,7 @@ jobs:
         # git-data is also correct, since it's generated at build time, before `lerna version` run.
         run: |
           node_modules/.bin/lerna version ${{ steps.version.outputs.version }} \
+          --exact \
           --yes \
           --no-git-tag-version
 


### PR DESCRIPTION
**Motivation**

The generated `package.json` of `lodestar-cli` specified semver, and old commit of lodestar packages were picked because npm thought it's newer version

Specifically, we expect "0.37.0-dev.ef9528aa59" but got "0.37.0-dev.fbfae0c4a0" (the previous commit) becaused we specified "@chainsafe/lodestar": "^0.37.0-dev.ef9528aa59" in `package.json` of lodestar-cli

**Description**
Use "lerna version --exact" to generate the exact version instead of semver

Closes #4048
