### PR TITLE
Add ropsten network

### DIFF
--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -12,9 +12,10 @@ import got from "got";
 import * as mainnet from "./mainnet";
 import * as prater from "./prater";
 import * as kiln from "./kiln";
+import * as ropsten from "./ropsten";
 
-export type NetworkName = "mainnet" | "prater" | "kiln" | "dev";
-export const networkNames: NetworkName[] = ["mainnet", "prater", "kiln"];
+export type NetworkName = "mainnet" | "prater" | "kiln" | "ropsten" | "dev";
+export const networkNames: NetworkName[] = ["mainnet", "prater", "kiln", "ropsten"];
 
 export type WeakSubjectivityFetchOptions = {
   weakSubjectivityServerUrl: string;
@@ -37,6 +38,8 @@ function getNetworkData(
       return prater;
     case "kiln":
       return kiln;
+    case "ropsten":
+      return ropsten;
     default:
       throw Error(`Network not supported: ${network}`);
   }

--- a/packages/cli/src/networks/ropsten.ts
+++ b/packages/cli/src/networks/ropsten.ts
@@ -1,0 +1,13 @@
+import {ropstenChainConfig} from "@chainsafe/lodestar-config/networks";
+
+export const chainConfig = ropstenChainConfig;
+
+/* eslint-disable max-len */
+
+export const depositContractDeployBlock = 12269949;
+export const genesisFileUrl =
+  "https://raw.githubusercontent.com/eth-clients/merge-testnets/main/ropsten-beacon-chain/genesis.ssz";
+export const bootnodesFileUrl =
+  "https://raw.githubusercontent.com/eth-clients/merge-testnets/main/ropsten-beacon-chain/bootstrap_nodes.txt";
+
+export const bootEnrs = [];

--- a/packages/config/src/chainConfig/networks/ropsten.ts
+++ b/packages/config/src/chainConfig/networks/ropsten.ts
@@ -1,0 +1,44 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import {fromHexString as b} from "@chainsafe/ssz";
+import {IChainConfig} from "../types";
+import {chainConfig as mainnet} from "../presets/mainnet";
+
+/* eslint-disable max-len */
+
+// Ropsten beacon chain config:
+// https://github.com/eth-clients/merge-testnets/blob/main/ropsten-beacon-chain/config.yaml
+
+export const ropstenChainConfig: IChainConfig = {
+  ...mainnet,
+
+  // Genesis
+  // ---------------------------------------------------------------
+  MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 100000,
+  // # Monday, May 30th, 2022 3:00:00 PM +UTC
+  MIN_GENESIS_TIME: 1653318000,
+  GENESIS_FORK_VERSION: b("0x80000069"),
+
+  // Forking
+  // ---------------------------------------------------------------
+  // # Altair
+  ALTAIR_FORK_VERSION: b("0x80000070"),
+  ALTAIR_FORK_EPOCH: 500,
+  // # Merge
+  BELLATRIX_FORK_VERSION: b("0x80000071"),
+  BELLATRIX_FORK_EPOCH: 750,
+  TERMINAL_TOTAL_DIFFICULTY: BigInt(43531756765713534),
+  // # Sharding
+  SHARDING_FORK_VERSION: b("0x03001020"),
+  SHARDING_FORK_EPOCH: Infinity,
+
+  // Fork choice
+  // ---------------------------------------------------------------
+  // 40%
+  PROPOSER_SCORE_BOOST: 40,
+
+  // Deposit contract
+  // ---------------------------------------------------------------
+  DEPOSIT_CHAIN_ID: 3,
+  DEPOSIT_NETWORK_ID: 3,
+  DEPOSIT_CONTRACT_ADDRESS: b("0x6f22fFbC56eFF051aECF839396DD1eD9aD6BBA9D"),
+};

--- a/packages/config/src/networks.ts
+++ b/packages/config/src/networks.ts
@@ -2,12 +2,14 @@ import {IChainConfig} from "./chainConfig";
 import {mainnetChainConfig} from "./chainConfig/networks/mainnet";
 import {praterChainConfig} from "./chainConfig/networks/prater";
 import {kilnChainConfig} from "./chainConfig/networks/kiln";
+import {ropstenChainConfig} from "./chainConfig/networks/ropsten";
 
-export {mainnetChainConfig, praterChainConfig, kilnChainConfig};
+export {mainnetChainConfig, praterChainConfig, kilnChainConfig, ropstenChainConfig};
 
-export type NetworkName = "mainnet" | "prater" | "kiln";
+export type NetworkName = "mainnet" | "prater" | "kiln" | "ropsten";
 export const networksChainConfig: Record<NetworkName, IChainConfig> = {
   mainnet: mainnetChainConfig,
   prater: praterChainConfig,
   kiln: kilnChainConfig,
+  ropsten: ropstenChainConfig,
 };

--- a/packages/light-client/src/networks.ts
+++ b/packages/light-client/src/networks.ts
@@ -4,6 +4,7 @@ enum NetworkName {
   mainnet = "mainnet",
   prater = "prater",
   kiln = "kiln",
+  ropsten = "ropsten",
 }
 
 export type GenesisDataHex = {
@@ -28,5 +29,9 @@ export const networkGenesis: Record<NetworkName, GenesisDataHex> = {
   [NetworkName.kiln]: {
     genesisTime: 1647007500,
     genesisValidatorsRoot: "0x99b09fcd43e5905236c370f184056bec6e6638cfc31a323b304fc4aa789cb4ad",
+  },
+  [NetworkName.ropsten]: {
+    genesisTime: 1653922800,
+    genesisValidatorsRoot: "0x44f1e56283ca88b35c789f7f449e52339bc1fefe3a45913a43a6d16edcd33cf1",
   },
 };


### PR DESCRIPTION
Add ropsten network as per the configs hosted at:
https://github.com/eth-clients/merge-testnets/tree/main/ropsten-beacon-chain
proposer boost at 40%  (for the rest of the code base will be updated with the spec update)
