### PR TITLE
Force all packages to be versioned for exact

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -55,6 +55,7 @@ jobs:
         # git-data is also correct, since it's generated at build time, before `lerna version` run.
         run: |
           node_modules/.bin/lerna version ${{ steps.version.outputs.version }} \
+          --force-publish \
           --exact \
           --yes \
           --no-git-tag-version


### PR DESCRIPTION
**Motivation**
While using `exact` keywork for lerna version, it doesn't version packages which have no change and hence the install fails.

```bash
npm install @chainsafe/lodestar-cli@0.37.0-dev.7b9cd7f45f
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @chainsafe/lodestar-keymanager-server@0.37.0-dev.7b9cd7f45f.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

```

`--force-publish` is required for all packges
