### PR TITLE
Small refactor to merge setup script to use baked in configs for `ropsten`

### DIFF
--- a/kiln/devnets/fixed.vars
+++ b/kiln/devnets/fixed.vars
@@ -1,0 +1,17 @@
+# Data dir will be mounted in /data/lodestar
+LODESTAR_FIXED_VARS="--rootDir /data/lodestar --eth1.providerUrls http://127.0.0.1:8545 --execution.urls http://127.0.0.1:8551 --api.rest.enabled --api.rest.host 0.0.0.0 --api.rest.api '*' --network.connectToDiscv5Bootnodes --network.discv5.enabled true --eth1.enabled true --jwt-secret /data/jwtsecret"
+
+# Data dir will be mounted in /data/lodestar
+LODESTAR_VAL_FIXED_VARS="--rootDir /data/lodestar"
+
+# Data dir will be mounted in /data/nethermind
+NETHERMIND_FIXED_VARS="--datadir /data/nethermind --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Init.DiagnosticMode=None --JsonRpc.Enabled=true --JsonRpc.Host=0.0.0.0 --JsonRpc.AdditionalRpcUrls \"http://localhost:8545|http;ws|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:8551|http;ws|net;eth;subscribe;engine;web3;client\" --JsonRpc.JwtSecretFile /data/jwtsecret"
+
+# Data dir will be mounted in /data/geth
+GETH_FIXED_VARS="--datadir /data/geth --authrpc.jwtsecret /data/jwtsecret --http --http.api engine,net,eth,web3 --http.port 8545 --allow-insecure-unlock --http.addr 0.0.0.0 --http.corsdomain \"*\" --http.vhosts \"*\" --authrpc.port=8551"
+
+# Data dir will be mounted in /data/ethereumjs
+ETHEREUMJS_FIXED_VARS="--saveReceipts --rpc --rpcport 8545 --ws --rpcEngine --rpcEnginePort=8551 --rpcDebug --loglevel=debug"
+
+# Data dir will be mounted in /data/besu
+BESU_FIXED_VARS="--rpc-http-enabled=true --rpc-http-api=ADMIN,CLIQUE,MINER,ETH,NET,DEBUG,TXPOOL,TRACE --rpc-http-host=0.0.0.0 --rpc-http-port=8545 --Xmerge-support=true --engine-rpc-http-port=8551 --rpc-http-cors-origins=\"*\" --host-allowlist=\"*\" --engine-host-allowlist=\"*\" --p2p-enabled=true --engine-jwt-enabled=true"

--- a/kiln/devnets/kiln.vars
+++ b/kiln/devnets/kiln.vars
@@ -12,16 +12,16 @@ BESU_IMAGE=hyperledger/besu:develop
 
 LODESTAR_IMAGE=chainsafe/lodestar:next
 
-LODESTAR_EXTRA_ARGS="--execution.urls http://127.0.0.1:8551 --api.rest.enabled --api.rest.host 0.0.0.0 --api.rest.api '*'"
+LODESTAR_EXTRA_ARGS="--terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
-LODESTAR_VALIDATOR_ARGS='--network kiln  --fromMnemonic "lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow" --mnemonicIndexes 0..5'
+LODESTAR_VALIDATOR_ARGS="--network ropsten --terminal-total-difficulty-override $MERGE_TTD --fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5 $LODESTAR_VAL_FIXED_VARS"
 
-NETHERMIND_EXTRA_ARGS="--config kiln --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=$MERGE_TTD  --Init.DiagnosticMode=None --JsonRpc.Enabled=true --JsonRpc.Host=0.0.0.0 --JsonRpc.AdditionalRpcUrls \"http://localhost:8545|http;ws|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:8551|http;ws|net;eth;subscribe;engine;web3;client\""
+NETHERMIND_EXTRA_ARGS="--config kiln  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 
-GETH_EXTRA_ARGS="--http --http.api engine,net,eth,web3 --http.port 8545 --allow-insecure-unlock --http.addr 0.0.0.0 --http.corsdomain \"*\" --http.vhosts \"*\" --authrpc.port=8551 --override.terminaltotaldifficulty=$MERGE_TTD --networkid $NETWORK_ID"
+GETH_EXTRA_ARGS="--override.terminaltotaldifficulty=$MERGE_TTD --networkid $NETWORK_ID $GETH_FIXED_VARS"
 
-ETHEREUMJS_EXTRA_ARGS="--saveReceipts --rpc --rpcport 8545 --ws --rpcEngine --rpcEnginePort=8551 --rpcDebug --loglevel=debug"
+ETHEREUMJS_EXTRA_ARGS="$ETHEREUMJS_FIXED_VARS"
 
-BESU_EXTRA_ARGS="--rpc-http-enabled=true --rpc-http-api=ADMIN,CLIQUE,MINER,ETH,NET,DEBUG,TXPOOL,TRACE --rpc-http-host=0.0.0.0 --rpc-http-port=8545 --Xmerge-support=true --engine-rpc-http-port=8551 --rpc-http-cors-origins=\"*\" --host-allowlist=\"*\" --engine-host-allowlist=\"*\" --p2p-enabled=true --engine-jwt-enabled=true --network-id=$NETWORK_ID"
+BESU_EXTRA_ARGS="--network-id=$NETWORK_ID $BESU_FIXED_VARS"
 
 EXTRA_BOOTNODES=""

--- a/kiln/devnets/ropsten.vars
+++ b/kiln/devnets/ropsten.vars
@@ -1,8 +1,10 @@
-DEVNET_NAME=mainnet-shadow-fork-5
-CONFIG_GIT_DIR=mainnet-shadow-fork-5
-NETWORK_ID=1
-MERGE_TTD=49407055721335634264064
+DEVNET_NAME=ropsten
+# Empty config git dir will be assumed to be clients having bakedin configs
+CONFIG_GIT_DIR=
+NETWORK_ID=3
+MERGE_TTD=43531756765713534
 
+# This will be available in /data/jwtsecret
 JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
 GETH_IMAGE=parithoshj/geth:master
@@ -12,15 +14,15 @@ BESU_IMAGE=hyperledger/besu:develop
 
 LODESTAR_IMAGE=chainsafe/lodestar:next
 
-LODESTAR_EXTRA_ARGS="--terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
+LODESTAR_EXTRA_ARGS="--network ropsten --terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
 LODESTAR_VALIDATOR_ARGS="--network ropsten --terminal-total-difficulty-override $MERGE_TTD --fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5 $LODESTAR_VAL_FIXED_VARS"
 
-NETHERMIND_EXTRA_ARGS="--config mainnet_shadowfork  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
+NETHERMIND_EXTRA_ARGS="--config ropsten  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 
-GETH_EXTRA_ARGS="--override.terminaltotaldifficulty=$MERGE_TTD --networkid $NETWORK_ID $GETH_FIXED_VARS"
+GETH_EXTRA_ARGS="--ropsten --override.terminaltotaldifficulty=$MERGE_TTD --networkid $NETWORK_ID $GETH_FIXED_VARS"
 
-ETHEREUMJS_EXTRA_ARGS="$ETHEREUMJS_FIXED_VARS"
+ETHEREUMJS_EXTRA_ARGS="--network ropsten $ETHEREUMJS_FIXED_VARS"
 
 BESU_EXTRA_ARGS="--network-id=$NETWORK_ID $BESU_FIXED_VARS"
 


### PR DESCRIPTION
**Motivation**
This PR enables easy setup for `ropsten` network which is expected to have configs baked in rather than picking them up from the EF's github.

Currently working with `geth` for `ropsten` as others have not baked the configs yet.

how to run:

`./setup.sh --dataDir ropsten-data --elClient geth --devnetVars ./ropsten.vars --dockerWithSudo --withTerminal "gnome-terminal --disable-factory --" --withValidator`
