### PR TITLE
Update the proposer boost percentage to 40%

### DIFF
--- a/packages/config/src/chainConfig/networks/ropsten.ts
+++ b/packages/config/src/chainConfig/networks/ropsten.ts
@@ -31,11 +31,6 @@ export const ropstenChainConfig: IChainConfig = {
   SHARDING_FORK_VERSION: b("0x03001020"),
   SHARDING_FORK_EPOCH: Infinity,
 
-  // Fork choice
-  // ---------------------------------------------------------------
-  // 40%
-  PROPOSER_SCORE_BOOST: 40,
-
   // Deposit contract
   // ---------------------------------------------------------------
   DEPOSIT_CHAIN_ID: 3,

--- a/packages/config/src/chainConfig/presets/mainnet.ts
+++ b/packages/config/src/chainConfig/presets/mainnet.ts
@@ -64,7 +64,7 @@ export const chainConfig: IChainConfig = {
   MIN_PER_EPOCH_CHURN_LIMIT: 4,
   // 2**16 (= 65,536)
   CHURN_LIMIT_QUOTIENT: 65536,
-  PROPOSER_SCORE_BOOST: 70,
+  PROPOSER_SCORE_BOOST: 40,
 
   // Deposit contract
   // ---------------------------------------------------------------

--- a/packages/config/src/chainConfig/presets/minimal.ts
+++ b/packages/config/src/chainConfig/presets/minimal.ts
@@ -64,7 +64,7 @@ export const chainConfig: IChainConfig = {
   MIN_PER_EPOCH_CHURN_LIMIT: 4,
   // [customized] scale queue churn at much lower validator counts for testing
   CHURN_LIMIT_QUOTIENT: 32,
-  PROPOSER_SCORE_BOOST: 70,
+  PROPOSER_SCORE_BOOST: 40,
 
   // Deposit contract
   // ---------------------------------------------------------------


### PR DESCRIPTION
**Motivation**
https://github.com/ethereum/consensus-specs/pull/2895
<!-- Why is this PR exists? What are the goals of the pull request? -->
Update proposer boost to 40% by default, and remove override in the ropsten config.
