### PR TITLE
Assert tag in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Get tag
         id: get_tag
         run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
+      - name: Assert tag name is valid
+        id: assert_tag
+        run: node scripts/assert_tag.mjs
+        env:
+          TAG: ${{ steps.get_tag.outputs.tag }}
       - name: Get previous tag
         id: get_prev_tag
         run: node scripts/get_prev_tag.js

--- a/scripts/assert_tag.mjs
+++ b/scripts/assert_tag.mjs
@@ -1,0 +1,16 @@
+
+/**
+ * Assert tag version (must be semver-ish)
+ *   release.mjs passes tagParam
+ *   In CI, tagParam is undefined, get from proces.env instead
+ */
+export function assertTag(tagParam) {
+  const tag = tagParam || process.env.TAG;
+  const versionCaptureRegex=/^(v[0-9]+\.[0-9]+)\.[0-9]+(-beta\.[0-9]+)?$/
+  const versionMatch = versionCaptureRegex.exec(tag);
+  if (versionMatch == null) {
+    console.log(`Tag must match ${versionCaptureRegex}`);
+    process.exit(1);
+  }
+  return versionMatch;
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -4,6 +4,7 @@ import yargs from "yargs";
 import {hideBin} from "yargs/helpers";
 import inquirer from "inquirer";
 import _lernaVersion from "@lerna/version";
+import {assertTag} from "./assert_tag.mjs";
 
 // Script to make releasing easier
 // Run with --help to see usage
@@ -74,12 +75,8 @@ console.log("Success!");
 /////////////////////////////
 
 function getInfo(argv) {
-  // Validate tag version (must be semver-ish)
-  const versionCaptureRegex=/^(v[0-9]+\.[0-9]+)\.[0-9]+(-beta\.[0-9]+)?$/
-  const versionMatch = versionCaptureRegex.exec(argv.tag);
-  if (versionMatch == null) {
-    exit(`Tag must match ${versionCaptureRegex}`);
-  }
+  const versionMatch = assertTag(argv.tag);
+  // versionMatch should be valid now
 
   const tag = argv.tag;
   const currentCommit = cmd("git rev-parse --short HEAD");


### PR DESCRIPTION
**Motivation**

An unintended release was created because I missed `--no-git-tag-version` param when I try `lerna version` command locally

**Description**

- Release workflow should assert tag version
- Create `assert-tag.mjs` to be used for both release workflow and `release.mjs` script

Closes #4050