### PR TITLE
check for bellatrix block in `maybeIssueNextProposerEngineFcU`

### DIFF
--- a/packages/lodestar/src/chain/blocks/importBlock.ts
+++ b/packages/lodestar/src/chain/blocks/importBlock.ts
@@ -268,8 +268,9 @@ async function maybeIssueNextProposerEngineFcU(
   state: CachedBeaconStateAllForks
 ): Promise<PayloadId | null> {
   const prepareSlot = state.slot + 1;
+  const prepareEpoch = computeEpochAtSlot(prepareSlot);
   // No need to try building block if we are not synced
-  if (prepareSlot > chain.clock.currentSlot + 1) {
+  if (prepareSlot !== chain.clock.currentSlot + 1 || prepareEpoch < chain.config.BELLATRIX_FORK_EPOCH) {
     return null;
   }
   const prepareState = allForks.processSlots(state, prepareSlot);


### PR DESCRIPTION
**Motivation**
Only do `prepareSlot` proposer computation/checks post bellatrix to avoid side effects for mainnet till this is better optimized.
<!-- Why is this PR exists? What are the goals of the pull request? -->
Checks the prepareSlot against bellatrix epoch in config.