### PR TITLE
Run forkChoice to get correct head for proposal

### DIFF
--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -951,7 +951,7 @@ export class ForkChoice implements IForkChoice {
   private processAttestationQueue(): void {
     const currentSlot = this.fcStore.currentSlot;
     for (const attestation of this.queuedAttestations.values()) {
-      if (attestation.slot <= currentSlot) {
+      if (attestation.slot < currentSlot) {
         this.queuedAttestations.delete(attestation);
         const {blockRoot, targetEpoch} = attestation;
         const blockRootHex = blockRoot;

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -505,6 +505,7 @@ export class ForkChoice implements IForkChoice {
    * Call `onTick` for all slots between `fcStore.getCurrentSlot()` and the provided `currentSlot`.
    */
   updateTime(currentSlot: Slot): void {
+    if (this.fcStore.currentSlot >= currentSlot) return;
     while (this.fcStore.currentSlot < currentSlot) {
       const previousSlot = this.fcStore.currentSlot;
       // Note: we are relying upon `onTick` to update `fcStore.time` to ensure we don't get stuck in a loop.

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -951,6 +951,7 @@ export class ForkChoice implements IForkChoice {
   private processAttestationQueue(): void {
     const currentSlot = this.fcStore.currentSlot;
     for (const attestation of this.queuedAttestations.values()) {
+      // Delay consideration in the fork choice until their slot is in the past.
       if (attestation.slot < currentSlot) {
         this.queuedAttestations.delete(attestation);
         const {blockRoot, targetEpoch} = attestation;

--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -176,6 +176,12 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
       notWhileSyncing();
       await waitForSlot(slot); // Must never request for a future slot > currentSlot
 
+      // Process the queued attestations in the forkchoice for correct head estimation
+      // forkChoice.updateTime() might have already been called by the onSlot clock
+      // handler, in which case this should just return.
+      chain.forkChoice.updateTime(slot);
+      chain.forkChoice.updateHead();
+
       timer = metrics?.blockProductionTime.startTimer();
       const block = await assembleBlock(
         {chain, metrics},


### PR DESCRIPTION
**Motivation**
[Run forkchoice update pre assembleBlock](https://github.com/ChainSafe/lodestar/issues/4004)
<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**
Runs updateTime and updateHead to process any queued attestations to find the correct head for the proposal slot.
<!-- A clear and concise general description of the changes of this PR commits -->
Context Discussion/specs PR:
https://github.com/ethereum/consensus-specs/pull/2878
https://github.com/ethereum/consensus-specs/pull/2897