### PR TITLE
More logs when forkchoice reorg

### DIFF
--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -173,7 +173,15 @@ export function onForkChoiceHead(this: BeaconChain, head: IProtoBlock): void {
 }
 
 export function onForkChoiceReorg(this: BeaconChain, head: IProtoBlock, oldHead: IProtoBlock, depth: number): void {
-  this.logger.verbose("Chain reorg", {depth});
+  this.logger.verbose("Chain reorg", {
+    depth,
+    previousHead: oldHead.blockRoot,
+    previousHeadParent: oldHead.parentRoot,
+    previousSlot: oldHead.slot,
+    newHead: head.blockRoot,
+    newHeadParent: head.parentRoot,
+    newSlot: head.slot,
+  });
 }
 
 export function onAttestation(this: BeaconChain, attestation: phase0.Attestation): void {


### PR DESCRIPTION
**Motivation**

Forkchoice reorg rarely happens so we'd like to be as detailed as we can. An example log from lighthouse:
```
Beacon chain re-org                    
reorg_distance: 8,
new_slot: 3887074, 
new_head: 0x9c2a567eee0491b7d72e6dc4121f5425c3555553af0d3edcbb2978351cf8c441, 
new_head_parent: 0x1468af1a109a1bad928d4c9fab48bba66320afa4d7fd50533c4b637b15ed50e8, 
previous_slot: 3887081, 
previous_head: 0x2fb24231bf49c8dfa636615971c898f27a11a89c057814ce3ca8d0861fc78d9d,
```

**Description**

Add more infor to "Chain reorg" log
