### PR TITLE
Assert equal params with only whitelisted keys

### DIFF
--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -64,7 +64,7 @@ export function assertEqualParams(localConfig: IChainConfig, externalSpecJson: R
   }
 
   if (errors.length > 0) {
-    throw new NotEqualParamsError("Not equal BeaconParams\n" + errors.join("\n"));
+    throw new NotEqualParamsError("Local and remote configs are different\n" + errors.join("\n"));
   }
 }
 

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -20,7 +20,7 @@ type ConfigWithPreset = IChainConfig & BeaconPreset;
  * parameters.
  *
  * So this check only compares a specific list of parameters that are consensus critical, ignoring the rest. Typed
- * config and preset ensure new parameters are leveled critical or ignore, faciliating manteinance of the list.
+ * config and preset ensure new parameters are labeled critical or ignore, facilitating maintenance of the list.
  */
 export function assertEqualParams(localConfig: IChainConfig, externalSpecJson: Record<string, string>): void {
   // Before comparing, add preset which is bundled in api impl config route.

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -173,23 +173,23 @@ function getSpecCriticalParams(localConfig: IChainConfig): Record<keyof ConfigWi
     // # AltairPreset
     /////////////////
 
-    SYNC_COMMITTEE_SIZE: true,
-    EPOCHS_PER_SYNC_COMMITTEE_PERIOD: true,
-    INACTIVITY_PENALTY_QUOTIENT_ALTAIR: true,
-    MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR: true,
-    PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR: true,
+    SYNC_COMMITTEE_SIZE: altairForkRelevant,
+    EPOCHS_PER_SYNC_COMMITTEE_PERIOD: altairForkRelevant,
+    INACTIVITY_PENALTY_QUOTIENT_ALTAIR: altairForkRelevant,
+    MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR: altairForkRelevant,
+    PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR: altairForkRelevant,
     MIN_SYNC_COMMITTEE_PARTICIPANTS: false, // Only relevant for lightclients
     UPDATE_TIMEOUT: false, // Only relevant for lightclients
 
     // # BellatrixPreset
     /////////////////
 
-    INACTIVITY_PENALTY_QUOTIENT_BELLATRIX: true,
-    MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX: true,
-    PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX: true,
-    MAX_BYTES_PER_TRANSACTION: true,
-    MAX_TRANSACTIONS_PER_PAYLOAD: true,
-    BYTES_PER_LOGS_BLOOM: true,
-    MAX_EXTRA_DATA_BYTES: true,
+    INACTIVITY_PENALTY_QUOTIENT_BELLATRIX: bellatrixForkRelevant,
+    MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX: bellatrixForkRelevant,
+    PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX: bellatrixForkRelevant,
+    MAX_BYTES_PER_TRANSACTION: bellatrixForkRelevant,
+    MAX_TRANSACTIONS_PER_PAYLOAD: bellatrixForkRelevant,
+    BYTES_PER_LOGS_BLOOM: bellatrixForkRelevant,
+    MAX_EXTRA_DATA_BYTES: bellatrixForkRelevant,
   };
 }

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -1,25 +1,61 @@
-import {IChainConfig, chainConfigToJson, defaultChainConfig} from "@chainsafe/lodestar-config";
+import {IChainConfig, chainConfigToJson} from "@chainsafe/lodestar-config";
+import {activePreset, BeaconPreset, presetToJson} from "@chainsafe/lodestar-params";
 
 export class NotEqualParamsError extends Error {}
 
+type ConfigWithPreset = IChainConfig & BeaconPreset;
+
+/* eslint-disable @typescript-eslint/naming-convention */
+
 /**
  * Assert localConfig values match externalSpecJson. externalSpecJson may contain more values than localConfig.
+ *
+ * This check ensures that the validator is connected to a beacon node of the exact same network and params.
+ * Otherwise, signatures may be rejected, time may be un-equal and other bugs that are harder to debug caused
+ * by different parameters.
+ *
+ * This check however can't compare the full config as is, since some parameters are not critical to the spec and
+ * can be changed un-expectedly. Also, fork parameters can change un-expectedly, like their _FORK_VERSION or _EPOCH.
+ * Note that the config API endpoint is not precisely specified, so each clients can return a different set of
+ * parameters.
+ *
+ * So this check only compares a specific list of parameters that are consensus critical, ignoring the rest. Typed
+ * config and preset ensure new parameters are leveled critical or ignore, faciliating manteinance of the list.
  */
 export function assertEqualParams(localConfig: IChainConfig, externalSpecJson: Record<string, string>): void {
-  const localConfigJson = chainConfigToJson(localConfig) as Record<string, unknown>;
-
-  const externalSpecJsonWithDefaults = {
-    // fill missing properties in remote config with spec default values
-    ...chainConfigToJson(defaultChainConfig),
-    ...externalSpecJson,
+  // Before comparing, add preset which is bundled in api impl config route.
+  // config and preset must be serialized to JSON for safe comparisions.
+  const localSpecJson = {
+    ...chainConfigToJson(localConfig),
+    ...presetToJson(activePreset),
   };
 
+  // Get list of keys to check, and keys to ignore. Otherwise this function throws for false positives
+  const criticalParams = getSpecCriticalParams(localConfig);
+
+  // Accumulate errors first and print all of them at once
   const errors: string[] = [];
 
-  // Ensure only that the localConfig values match the remote spec
-  for (const key of Object.keys(localConfigJson)) {
-    const localValue = String(localConfigJson[key]).toLocaleLowerCase();
-    const remoteValue = String(externalSpecJsonWithDefaults[key]).toLocaleLowerCase();
+  for (const key of Object.keys(criticalParams) as (keyof typeof criticalParams)[]) {
+    // Ignore non-critical params
+    if (!criticalParams[key]) {
+      continue;
+    }
+
+    // This condition should never be true, but just in case
+    if (localSpecJson[key] === undefined) {
+      errors.push(`${key} not defined in local config`);
+    }
+
+    // All consensus critical keys must be defined, otherwise we can't ensure interoperability
+    if (externalSpecJson[key] === undefined) {
+      errors.push(`${key} not defined in external config`);
+    }
+
+    // Must compare JSON serialized specs, to ensure all strings are rendered in the same way
+    // Must compare as lowercase to ensure checksum addresses and names have same capilatization
+    const localValue = String(localSpecJson[key]).toLocaleLowerCase();
+    const remoteValue = String(externalSpecJson[key]).toLocaleLowerCase();
     if (localValue !== remoteValue) {
       errors.push(`${key} different value: ${localValue} != ${remoteValue}`);
     }
@@ -28,4 +64,132 @@ export function assertEqualParams(localConfig: IChainConfig, externalSpecJson: R
   if (errors.length > 0) {
     throw new NotEqualParamsError("Not equal BeaconParams\n" + errors.join("\n"));
   }
+}
+
+function getSpecCriticalParams(localConfig: IChainConfig): Record<keyof ConfigWithPreset, boolean> {
+  const altairForkRelevant = localConfig.ALTAIR_FORK_EPOCH < Infinity;
+  const bellatrixForkRelevant = localConfig.BELLATRIX_FORK_EPOCH < Infinity;
+  const shardingForkRelevant = localConfig.SHARDING_FORK_EPOCH < Infinity;
+
+  return {
+    // # Config
+    ///////////
+
+    PRESET_BASE: false, // Not relevant, each preset value is checked below
+    TERMINAL_TOTAL_DIFFICULTY: bellatrixForkRelevant,
+    TERMINAL_BLOCK_HASH: bellatrixForkRelevant,
+    TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH: bellatrixForkRelevant,
+
+    // Genesis
+    MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: true,
+    MIN_GENESIS_TIME: true,
+    GENESIS_FORK_VERSION: true,
+    GENESIS_DELAY: true,
+
+    // Forking
+    // Altair
+    ALTAIR_FORK_VERSION: altairForkRelevant,
+    ALTAIR_FORK_EPOCH: altairForkRelevant,
+    // Bellatrix
+    BELLATRIX_FORK_VERSION: bellatrixForkRelevant,
+    BELLATRIX_FORK_EPOCH: bellatrixForkRelevant,
+    // Sharding
+    SHARDING_FORK_VERSION: shardingForkRelevant,
+    SHARDING_FORK_EPOCH: shardingForkRelevant,
+
+    // Time parameters
+    SECONDS_PER_SLOT: true,
+    SECONDS_PER_ETH1_BLOCK: true,
+    MIN_VALIDATOR_WITHDRAWABILITY_DELAY: true,
+    SHARD_COMMITTEE_PERIOD: true,
+    ETH1_FOLLOW_DISTANCE: true,
+
+    // Validator cycle
+    INACTIVITY_SCORE_BIAS: true,
+    INACTIVITY_SCORE_RECOVERY_RATE: true,
+    EJECTION_BALANCE: true,
+    MIN_PER_EPOCH_CHURN_LIMIT: true,
+    CHURN_LIMIT_QUOTIENT: true,
+
+    // Proposer boost
+    PROPOSER_SCORE_BOOST: false, // Ignored as it's changing https://github.com/ethereum/consensus-specs/pull/2895
+
+    // Deposit contract
+    DEPOSIT_CHAIN_ID: false, // Non-critical
+    DEPOSIT_NETWORK_ID: false, // Non-critical
+    DEPOSIT_CONTRACT_ADDRESS: true,
+
+    // # Phase0Preset
+    /////////////////
+
+    MAX_COMMITTEES_PER_SLOT: true,
+    TARGET_COMMITTEE_SIZE: true,
+    MAX_VALIDATORS_PER_COMMITTEE: true,
+
+    SHUFFLE_ROUND_COUNT: true,
+
+    HYSTERESIS_QUOTIENT: true,
+    HYSTERESIS_DOWNWARD_MULTIPLIER: true,
+    HYSTERESIS_UPWARD_MULTIPLIER: true,
+
+    // Fork choice
+    SAFE_SLOTS_TO_UPDATE_JUSTIFIED: true,
+
+    // Gwei Values
+    MIN_DEPOSIT_AMOUNT: true,
+    MAX_EFFECTIVE_BALANCE: true,
+    EFFECTIVE_BALANCE_INCREMENT: true,
+
+    // Time parameters
+    MIN_ATTESTATION_INCLUSION_DELAY: true,
+    SLOTS_PER_EPOCH: true,
+    MIN_SEED_LOOKAHEAD: true,
+    MAX_SEED_LOOKAHEAD: true,
+    EPOCHS_PER_ETH1_VOTING_PERIOD: true,
+    SLOTS_PER_HISTORICAL_ROOT: true,
+    MIN_EPOCHS_TO_INACTIVITY_PENALTY: true,
+
+    // State vector lengths
+    EPOCHS_PER_HISTORICAL_VECTOR: true,
+    EPOCHS_PER_SLASHINGS_VECTOR: true,
+    HISTORICAL_ROOTS_LIMIT: true,
+    VALIDATOR_REGISTRY_LIMIT: true,
+
+    // Reward and penalty quotients
+    BASE_REWARD_FACTOR: true,
+    WHISTLEBLOWER_REWARD_QUOTIENT: true,
+    PROPOSER_REWARD_QUOTIENT: true,
+    INACTIVITY_PENALTY_QUOTIENT: true,
+    MIN_SLASHING_PENALTY_QUOTIENT: true,
+    PROPORTIONAL_SLASHING_MULTIPLIER: true,
+
+    // Max operations per block
+    MAX_PROPOSER_SLASHINGS: true,
+    MAX_ATTESTER_SLASHINGS: true,
+    MAX_ATTESTATIONS: true,
+    MAX_DEPOSITS: true,
+    MAX_VOLUNTARY_EXITS: true,
+
+    // # AltairPreset
+    /////////////////
+
+    SYNC_COMMITTEE_SIZE: true,
+    EPOCHS_PER_SYNC_COMMITTEE_PERIOD: true,
+    INACTIVITY_PENALTY_QUOTIENT_ALTAIR: true,
+    MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR: true,
+    PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR: true,
+    MIN_SYNC_COMMITTEE_PARTICIPANTS: false, // Only relevant for lightclients
+    UPDATE_TIMEOUT: false, // Only relevant for lightclients
+
+    // # BellatrixPreset
+    /////////////////
+
+    INACTIVITY_PENALTY_QUOTIENT_BELLATRIX: true,
+    MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX: true,
+    PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX: true,
+    MAX_BYTES_PER_TRANSACTION: true,
+    MAX_TRANSACTIONS_PER_PAYLOAD: true,
+    BYTES_PER_LOGS_BLOOM: true,
+    MAX_EXTRA_DATA_BYTES: true,
+  };
 }

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -48,16 +48,18 @@ export function assertEqualParams(localConfig: IChainConfig, externalSpecJson: R
     }
 
     // All consensus critical keys must be defined, otherwise we can't ensure interoperability
-    if (externalSpecJson[key] === undefined) {
+    else if (externalSpecJson[key] === undefined) {
       errors.push(`${key} not defined in external config`);
     }
 
     // Must compare JSON serialized specs, to ensure all strings are rendered in the same way
     // Must compare as lowercase to ensure checksum addresses and names have same capilatization
-    const localValue = String(localSpecJson[key]).toLocaleLowerCase();
-    const remoteValue = String(externalSpecJson[key]).toLocaleLowerCase();
-    if (localValue !== remoteValue) {
-      errors.push(`${key} different value: ${localValue} != ${remoteValue}`);
+    else {
+      const localValue = String(localSpecJson[key]).toLocaleLowerCase();
+      const remoteValue = String(externalSpecJson[key]).toLocaleLowerCase();
+      if (localValue !== remoteValue) {
+        errors.push(`${key} different value: ${localValue} != ${remoteValue}`);
+      }
     }
   }
 


### PR DESCRIPTION
**Motivation**

Lodestar validator client asserts that the beacon node is connecting to has the same configuration. This check is very important to exit early in case of misconfiguration. However, in the past it has broke interoperability with other clients due to the checks being too strict on params that are not guaranteed to be the same.

Latest consensus release changed `SHARDING_FORK_VERSION`. We don't know when each client will update this value since it doesn't matter now.

https://github.com/ethereum/consensus-specs/pull/2896/files#diff-fa42a5809dc8042fed427fd9d2d54c2595789c5cad751b03a8d118871285c26fL48

We need a more resilient check that only looks are "relevant" keys, and ignores the ones that are likely to change or not critical for interoperability.

**Description**

Assert equal params with only whitelisted keys.

So this check only compares a specific list of parameters that are consensus critical, ignoring the rest. Typed config and preset ensure new parameters are leveled critical or ignore, facilitating maintenance of the list

Please @g11tech and @dadepo can you ensure that this PR doesn't break interop with other CL clients?