### PR TITLE
Remove @chainsafe/abort-controller

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -60,7 +60,6 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/abort-controller": "^3.0.1",
     "@chainsafe/lodestar-config": "^0.37.0",
     "@chainsafe/lodestar-params": "^0.37.0",
     "@chainsafe/lodestar-types": "^0.37.0",

--- a/packages/api/src/client/utils/httpClient.ts
+++ b/packages/api/src/client/utils/httpClient.ts
@@ -1,5 +1,4 @@
 import {fetch} from "cross-fetch";
-import {AbortSignal, AbortController} from "@chainsafe/abort-controller";
 import {ErrorAborted, ILogger, TimeoutError} from "@chainsafe/lodestar-utils";
 import {ReqGeneric, RouteDef} from "../../utils/index.js";
 import {stringifyQuery, urlJoin} from "./format.js";

--- a/packages/api/src/server/events.ts
+++ b/packages/api/src/server/events.ts
@@ -1,4 +1,3 @@
-import {AbortController} from "@chainsafe/abort-controller";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {ServerRoutes} from "./utils/index.js";
 import {Api, ReqTypes, routesData, getEventSerdes} from "../routes/events.js";

--- a/packages/api/test/unit/client/httpClient.test.ts
+++ b/packages/api/test/unit/client/httpClient.test.ts
@@ -1,5 +1,4 @@
 import {ErrorAborted, TimeoutError} from "@chainsafe/lodestar-utils";
-import {AbortController} from "@chainsafe/abort-controller";
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
 import fastify, {RouteOptions} from "fastify";

--- a/packages/api/test/unit/events.test.ts
+++ b/packages/api/test/unit/events.test.ts
@@ -1,4 +1,3 @@
-import {AbortController} from "@chainsafe/abort-controller";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {config} from "@chainsafe/lodestar-config/default";
 import {Api, routesData, EventType, BeaconEvent} from "../../src/routes/events.js";

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,6 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/abort-controller": "^3.0.1",
     "@chainsafe/as-sha256": "^0.3.1",
     "@chainsafe/bls": "7.1.0",
     "@chainsafe/bls-keygen": "^0.3.0",

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -1,5 +1,4 @@
 import {Registry} from "prom-client";
-import {AbortController} from "@chainsafe/abort-controller";
 import {ErrorAborted} from "@chainsafe/lodestar-utils";
 import {LevelDbController} from "@chainsafe/lodestar-db";
 import {BeaconNode, BeaconDb, createNodeJsLibp2p} from "@chainsafe/lodestar";

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {ssz} from "@chainsafe/lodestar-types";
 import {createIBeaconConfig, IBeaconConfig, IChainForkConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils";

--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -3,7 +3,6 @@ import {promisify} from "node:util";
 import rimraf from "rimraf";
 import path from "node:path";
 import {fromHexString} from "@chainsafe/ssz";
-import {AbortController} from "@chainsafe/abort-controller";
 import {GENESIS_SLOT} from "@chainsafe/lodestar-params";
 import {BeaconNode, BeaconDb, initStateFromAnchorState, createNodeJsLibp2p, nodeUtils} from "@chainsafe/lodestar";
 import {SlashingProtection, Validator, SignerType} from "@chainsafe/lodestar-validator";

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -1,4 +1,3 @@
-import {AbortController} from "@chainsafe/abort-controller";
 import {LevelDbController} from "@chainsafe/lodestar-db";
 import {SignerType, Signer, SlashingProtection, Validator} from "@chainsafe/lodestar-validator";
 import {getMetrics, MetricsRegister} from "@chainsafe/lodestar-validator";

--- a/packages/keymanager-server/package.json
+++ b/packages/keymanager-server/package.json
@@ -45,7 +45,6 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/abort-controller": "^3.0.1",
     "@chainsafe/bls": "7.1.0",
     "@chainsafe/bls-keystore": "^2.0.0",
     "@chainsafe/lodestar-api": "^0.37.0",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -38,7 +38,6 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/abort-controller": "^3.0.1",
     "@chainsafe/bls": "7.1.1",
     "@chainsafe/lodestar-api": "^0.37.0",
     "@chainsafe/lodestar-config": "^0.37.0",

--- a/packages/light-client/src/index.ts
+++ b/packages/light-client/src/index.ts
@@ -1,5 +1,4 @@
 import mitt from "mitt";
-import {AbortController} from "@chainsafe/abort-controller";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {getClient, Api, routes} from "@chainsafe/lodestar-api";
 import {altair, phase0, RootHex, ssz, SyncPeriod} from "@chainsafe/lodestar-types";

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -67,7 +67,6 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/abort-controller": "^3.0.1",
     "@chainsafe/as-sha256": "^0.3.1",
     "@chainsafe/bls": "7.1.1",
     "@chainsafe/discv5": "^0.7.1",

--- a/packages/lodestar/src/chain/archiver/index.ts
+++ b/packages/lodestar/src/chain/archiver/index.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {ILogger} from "@chainsafe/lodestar-utils";
 
 import {IBeaconDb} from "../../db/index.js";

--- a/packages/lodestar/src/chain/blocks/index.ts
+++ b/packages/lodestar/src/chain/blocks/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {allForks} from "@chainsafe/lodestar-types";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {ChainEvent} from "../emitter.js";

--- a/packages/lodestar/src/chain/bls/multithread/index.ts
+++ b/packages/lodestar/src/chain/bls/multithread/index.ts
@@ -6,7 +6,6 @@ import {spawn, Worker} from "@chainsafe/threads";
 // @ts-ignore
 // eslint-disable-next-line
 self = undefined;
-import {AbortSignal} from "@chainsafe/abort-controller";
 import bls from "@chainsafe/bls";
 import {Implementation, PointFormat} from "@chainsafe/bls/types";
 import {ILogger} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -16,7 +16,6 @@ import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {allForks, UintNum64, Root, phase0, Slot, RootHex, Epoch} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {fromHexString} from "@chainsafe/ssz";
-import {AbortController} from "@chainsafe/abort-controller";
 import {GENESIS_EPOCH, ZERO_HASH} from "../constants/index.js";
 import {IBeaconDb} from "../db/index.js";
 import {CheckpointStateCache, StateContextCache} from "./stateCache/index.js";

--- a/packages/lodestar/src/chain/clock/LocalClock.ts
+++ b/packages/lodestar/src/chain/clock/LocalClock.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {Epoch, Slot} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {ErrorAborted} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {toHexString} from "@chainsafe/ssz";
 import {allForks, Epoch, phase0, Slot, Version} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/src/chain/genesis/genesis.ts
+++ b/packages/lodestar/src/chain/genesis/genesis.ts
@@ -6,7 +6,6 @@ import {GENESIS_EPOCH, GENESIS_SLOT} from "@chainsafe/lodestar-params";
 import {phase0, ssz} from "@chainsafe/lodestar-types";
 import {IBeaconConfig, IChainForkConfig} from "@chainsafe/lodestar-config";
 import {toGindex, Tree} from "@chainsafe/persistent-merkle-tree";
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {
   getTemporaryBlockHeader,
   getGenesisBeaconState,

--- a/packages/lodestar/src/chain/initState.ts
+++ b/packages/lodestar/src/chain/initState.ts
@@ -2,7 +2,6 @@
  * @module chain
  */
 
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {
   blockToHeader,
   computeEpochAtSlot,

--- a/packages/lodestar/src/chain/precomputeNextEpochTransition.ts
+++ b/packages/lodestar/src/chain/precomputeNextEpochTransition.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";

--- a/packages/lodestar/src/chain/regen/queued.ts
+++ b/packages/lodestar/src/chain/regen/queued.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {phase0, Slot, allForks, RootHex} from "@chainsafe/lodestar-types";
 import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
 import {CachedBeaconStateAllForks, computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";

--- a/packages/lodestar/src/eth1/eth1DepositDataTracker.ts
+++ b/packages/lodestar/src/eth1/eth1DepositDataTracker.ts
@@ -2,7 +2,6 @@ import {phase0, ssz} from "@chainsafe/lodestar-types";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {allForks, BeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {ErrorAborted, ILogger, isErrorAborted, sleep} from "@chainsafe/lodestar-utils";
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {IBeaconDb} from "../db/index.js";
 import {Eth1DepositsCache} from "./eth1DepositsCache.js";
 import {Eth1DataCache} from "./eth1DataCache.js";

--- a/packages/lodestar/src/eth1/eth1MergeBlockTracker.ts
+++ b/packages/lodestar/src/eth1/eth1MergeBlockTracker.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {IChainConfig} from "@chainsafe/lodestar-config";
 import {Epoch, RootHex} from "@chainsafe/lodestar-types";
 import {ILogger, isErrorAborted, sleep} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/src/eth1/provider/eth1Provider.ts
+++ b/packages/lodestar/src/eth1/provider/eth1Provider.ts
@@ -1,6 +1,5 @@
 import {toHexString} from "@chainsafe/ssz";
 import {phase0} from "@chainsafe/lodestar-types";
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {IChainConfig} from "@chainsafe/lodestar-config";
 import {fromHex} from "@chainsafe/lodestar-utils";
 

--- a/packages/lodestar/src/eth1/provider/jsonRpcHttpClient.ts
+++ b/packages/lodestar/src/eth1/provider/jsonRpcHttpClient.ts
@@ -1,7 +1,6 @@
 // Uses cross-fetch for browser + NodeJS cross compatibility
 // Note: isomorphic-fetch is not well mantained and does not support abort signals
 import fetch from "cross-fetch";
-import {AbortController, AbortSignal} from "@chainsafe/abort-controller";
 
 import {ErrorAborted, TimeoutError} from "@chainsafe/lodestar-utils";
 import {IJson, IRpcPayload, ReqOpts} from "../interface.js";

--- a/packages/lodestar/src/eth1/stream.ts
+++ b/packages/lodestar/src/eth1/stream.ts
@@ -2,7 +2,6 @@
  * @module eth1
  */
 
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {Eth1Block, IBatchDepositEvents, IEth1Provider, IEth1StreamParams} from "./interface.js";
 import {groupDepositEventsByBlock} from "./utils/groupDepositEventsByBlock.js";
 import {optimizeNextBlockDiffForGenesis} from "./utils/optimizeNextBlockDiffForGenesis.js";

--- a/packages/lodestar/src/executionEngine/http.ts
+++ b/packages/lodestar/src/executionEngine/http.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {bellatrix, RootHex, Root} from "@chainsafe/lodestar-types";
 import {BYTES_PER_LOGS_BLOOM} from "@chainsafe/lodestar-params";
 import {fromHex} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/src/executionEngine/index.ts
+++ b/packages/lodestar/src/executionEngine/index.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {IExecutionEngine} from "./interface.js";
 import {ExecutionEngineDisabled} from "./disabled.js";
 import {ExecutionEngineHttp, ExecutionEngineHttpOpts, defaultExecutionEngineHttpOpts} from "./http.js";

--- a/packages/lodestar/src/network/gossip/gossipsub.ts
+++ b/packages/lodestar/src/network/gossip/gossipsub.ts
@@ -6,7 +6,6 @@ const Gossipsub = ((GossipsubDefault as unknown) as {default: unknown}).default 
 import {GossipsubMessage, SignaturePolicy, TopicStr} from "libp2p-gossipsub/src/types.js";
 import {PeerScore, PeerScoreParams} from "libp2p-gossipsub/src/score/index.js";
 import PeerId from "peer-id";
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ATTESTATION_SUBNET_COUNT, ForkName, SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";
 import {allForks, altair, phase0} from "@chainsafe/lodestar-types";

--- a/packages/lodestar/src/network/gossip/validation/index.ts
+++ b/packages/lodestar/src/network/gossip/validation/index.ts
@@ -1,5 +1,4 @@
 import {MessageAcceptance} from "libp2p-gossipsub/src/types.js";
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {ILogger, mapValues} from "@chainsafe/lodestar-utils";
 import {IMetrics} from "../../../metrics/index.js";

--- a/packages/lodestar/src/network/gossip/validation/queue.ts
+++ b/packages/lodestar/src/network/gossip/validation/queue.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {mapValues} from "@chainsafe/lodestar-utils";
 import {IMetrics} from "../../../metrics/index.js";
 import {JobItemQueue, JobQueueOpts, QueueType} from "../../../util/queue/index.js";

--- a/packages/lodestar/src/network/network.ts
+++ b/packages/lodestar/src/network/network.ts
@@ -5,7 +5,6 @@
 import LibP2p, {Connection} from "libp2p";
 import PeerId from "peer-id";
 import {Multiaddr} from "multiaddr";
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {ATTESTATION_SUBNET_COUNT, ForkName, SYNC_COMMITTEE_SUBNET_COUNT} from "@chainsafe/lodestar-params";

--- a/packages/lodestar/src/network/reqresp/reqResp.ts
+++ b/packages/lodestar/src/network/reqresp/reqResp.ts
@@ -7,7 +7,6 @@ import {ForkName} from "@chainsafe/lodestar-params";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
-import {AbortController} from "@chainsafe/abort-controller";
 import LibP2p from "libp2p";
 import PeerId from "peer-id";
 import {RespStatus, timeoutOptions} from "../../constants/index.js";

--- a/packages/lodestar/src/network/reqresp/request/index.ts
+++ b/packages/lodestar/src/network/reqresp/request/index.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import pipe from "it-pipe";
 import PeerId from "peer-id";
 import {Libp2p} from "libp2p/src/connection-manager";

--- a/packages/lodestar/src/network/reqresp/request/responseTimeoutsHandler.ts
+++ b/packages/lodestar/src/network/reqresp/request/responseTimeoutsHandler.ts
@@ -1,4 +1,3 @@
-import {AbortController} from "@chainsafe/abort-controller";
 import pipe from "it-pipe";
 import {timeoutOptions} from "../../../constants/index.js";
 import {abortableSource} from "../../../util/abortableSource.js";

--- a/packages/lodestar/src/network/reqresp/response/index.ts
+++ b/packages/lodestar/src/network/reqresp/response/index.ts
@@ -1,6 +1,5 @@
 import PeerId from "peer-id";
 import pipe from "it-pipe";
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {ILogger, TimeoutError, withTimeout} from "@chainsafe/lodestar-utils";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {REQUEST_TIMEOUT, RespStatus} from "../../../constants/index.js";

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -2,7 +2,6 @@
  * @module node
  */
 
-import {AbortController} from "@chainsafe/abort-controller";
 import LibP2p from "libp2p";
 import {Registry} from "prom-client";
 

--- a/packages/lodestar/src/node/notifier.ts
+++ b/packages/lodestar/src/node/notifier.ts
@@ -1,6 +1,5 @@
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {ErrorAborted, ILogger, sleep, prettyBytes} from "@chainsafe/lodestar-utils";
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {computeEpochAtSlot, bellatrix} from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconChain} from "../chain/index.js";

--- a/packages/lodestar/src/sync/backfill/backfill.ts
+++ b/packages/lodestar/src/sync/backfill/backfill.ts
@@ -7,7 +7,6 @@ import {IBeaconConfig, IChainForkConfig} from "@chainsafe/lodestar-config";
 import {phase0, Root, Slot, allForks, ssz} from "@chainsafe/lodestar-types";
 import {ErrorAborted, ILogger, sleep} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
-import {AbortSignal} from "@chainsafe/abort-controller";
 
 import {IBeaconChain} from "../../chain/index.js";
 import {GENESIS_SLOT, ZERO_HASH} from "../../constants/index.js";

--- a/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
@@ -1,6 +1,5 @@
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
-import {AbortController} from "@chainsafe/abort-controller";
 import bls from "@chainsafe/bls";
 import {ISignatureSet, SignatureSetType} from "@chainsafe/lodestar-beacon-state-transition";
 import {BlsMultiThreadWorkerPool} from "../../../../src/chain/bls/multithread/index.js";

--- a/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1ForBlockProduction.test.ts
@@ -3,7 +3,6 @@ import "mocha";
 import {expect} from "chai";
 import {promisify} from "node:util";
 import leveldown from "leveldown";
-import {AbortController} from "@chainsafe/abort-controller";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {LevelDbController} from "@chainsafe/lodestar-db";
 

--- a/packages/lodestar/test/e2e/eth1/eth1MergeBlockTracker.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1MergeBlockTracker.test.ts
@@ -1,4 +1,3 @@
-import {AbortController} from "@chainsafe/abort-controller";
 import {IChainConfig} from "@chainsafe/lodestar-config";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {fromHexString} from "@chainsafe/ssz";

--- a/packages/lodestar/test/e2e/eth1/eth1Provider.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1Provider.test.ts
@@ -1,6 +1,5 @@
 import "mocha";
 import {expect} from "chai";
-import {AbortController} from "@chainsafe/abort-controller";
 import {Eth1Options} from "../../../src/eth1/options.js";
 import {getTestnetConfig} from "../../utils/testnet.js";
 import {fromHexString} from "@chainsafe/ssz";

--- a/packages/lodestar/test/e2e/eth1/jsonRpcHttpClient.test.ts
+++ b/packages/lodestar/test/e2e/eth1/jsonRpcHttpClient.test.ts
@@ -2,7 +2,6 @@ import "mocha";
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
 import http from "node:http";
-import {AbortController} from "@chainsafe/abort-controller";
 import {JsonRpcHttpClient} from "../../../src/eth1/provider/jsonRpcHttpClient.js";
 import {getGoerliRpcUrl} from "../../testParams.js";
 import {IRpcPayload} from "../../../src/eth1/interface.js";

--- a/packages/lodestar/test/e2e/eth1/stream.test.ts
+++ b/packages/lodestar/test/e2e/eth1/stream.test.ts
@@ -1,6 +1,5 @@
 import "mocha";
 import {expect} from "chai";
-import {AbortController} from "@chainsafe/abort-controller";
 import {getTestnetConfig, medallaTestnetConfig} from "../../utils/testnet.js";
 import {getDepositsStream, getDepositsAndBlockStreamForGenesis} from "../../../src/eth1/stream.js";
 import {Eth1Provider} from "../../../src/eth1/provider/eth1Provider.js";

--- a/packages/lodestar/test/e2e/network/gossipsub.test.ts
+++ b/packages/lodestar/test/e2e/network/gossipsub.test.ts
@@ -1,6 +1,5 @@
 import sinon from "sinon";
 import {expect} from "chai";
-import {AbortController} from "@chainsafe/abort-controller";
 import {createIBeaconConfig} from "@chainsafe/lodestar-config";
 import {config} from "@chainsafe/lodestar-config/default";
 import {phase0, ssz} from "@chainsafe/lodestar-types";

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -1,6 +1,5 @@
 import sinon from "sinon";
 import {expect} from "chai";
-import {AbortController} from "@chainsafe/abort-controller";
 
 import PeerId from "peer-id";
 import {ENR} from "@chainsafe/discv5";

--- a/packages/lodestar/test/e2e/network/reqresp.test.ts
+++ b/packages/lodestar/test/e2e/network/reqresp.test.ts
@@ -1,6 +1,5 @@
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
-import {AbortController} from "@chainsafe/abort-controller";
 import PeerId from "peer-id";
 import {createIBeaconConfig} from "@chainsafe/lodestar-config";
 import {config} from "@chainsafe/lodestar-config/default";

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import net from "node:net";
 import {spawn} from "node:child_process";
 import {Context} from "mocha";
-import {AbortController, AbortSignal} from "@chainsafe/abort-controller";
 import {fromHexString} from "@chainsafe/ssz";
 import {LogLevel, sleep, TimestampFormatCode} from "@chainsafe/lodestar-utils";
 import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";

--- a/packages/lodestar/test/sim/shell.ts
+++ b/packages/lodestar/test/sim/shell.ts
@@ -1,5 +1,4 @@
 import childProcess from "node:child_process";
-import {AbortSignal} from "@chainsafe/abort-controller";
 
 /**
  * If timeout is greater than 0, the parent will send the signal

--- a/packages/lodestar/test/unit/api/impl/events/events.test.ts
+++ b/packages/lodestar/test/unit/api/impl/events/events.test.ts
@@ -1,4 +1,3 @@
-import {AbortController} from "@chainsafe/abort-controller";
 import {expect} from "chai";
 import sinon, {SinonStubbedInstance} from "sinon";
 import {routes} from "@chainsafe/lodestar-api";

--- a/packages/lodestar/test/unit/chain/clock/local.test.ts
+++ b/packages/lodestar/test/unit/chain/clock/local.test.ts
@@ -1,5 +1,4 @@
 import sinon from "sinon";
-import {AbortController} from "@chainsafe/abort-controller";
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/default";
 

--- a/packages/lodestar/test/unit/chain/genesis/genesis.test.ts
+++ b/packages/lodestar/test/unit/chain/genesis/genesis.test.ts
@@ -13,7 +13,6 @@ import {
 import {ValidatorIndex, phase0, ssz} from "@chainsafe/lodestar-types";
 import {ErrorAborted} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
-import {AbortController} from "@chainsafe/abort-controller";
 import {GenesisBuilder} from "../../../../src/chain/genesis/genesis.js";
 import {testLogger} from "../../../utils/logger.js";
 import {ZERO_HASH_HEX} from "../../../../src/constants/index.js";

--- a/packages/lodestar/test/unit/chain/precomputeNextEpochTransition.test.ts
+++ b/packages/lodestar/test/unit/chain/precomputeNextEpochTransition.test.ts
@@ -1,5 +1,4 @@
 import {config} from "@chainsafe/lodestar-config/default";
-import {AbortController} from "@chainsafe/abort-controller";
 import {ForkChoice, IProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {expect} from "chai";

--- a/packages/lodestar/test/unit/eth1/eth1MergeBlockTracker.test.ts
+++ b/packages/lodestar/test/unit/eth1/eth1MergeBlockTracker.test.ts
@@ -1,4 +1,3 @@
-import {AbortController} from "@chainsafe/abort-controller";
 import {IChainConfig} from "@chainsafe/lodestar-config";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";

--- a/packages/lodestar/test/unit/executionEngine/http.test.ts
+++ b/packages/lodestar/test/unit/executionEngine/http.test.ts
@@ -1,7 +1,6 @@
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
 import {fastify} from "fastify";
-import {AbortController} from "@chainsafe/abort-controller";
 import {
   ExecutionEngineHttp,
   parseExecutionPayload,

--- a/packages/lodestar/test/unit/network/reqresp/request/responseTimeoutsHandler.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/request/responseTimeoutsHandler.test.ts
@@ -1,4 +1,3 @@
-import {AbortController} from "@chainsafe/abort-controller";
 import all from "it-all";
 import pipe from "it-pipe";
 import {LodestarError, sleep as _sleep} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/test/unit/network/reqresp/response/index.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/response/index.test.ts
@@ -1,6 +1,5 @@
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
-import {AbortController} from "@chainsafe/abort-controller";
 import {LodestarError} from "@chainsafe/lodestar-utils";
 import {RespStatus} from "../../../../../src/constants/index.js";
 import {Method, Encoding, Version} from "../../../../../src/network/reqresp/types.js";

--- a/packages/lodestar/test/unit/util/queue.test.ts
+++ b/packages/lodestar/test/unit/util/queue.test.ts
@@ -1,5 +1,4 @@
 import {sleep} from "@chainsafe/lodestar-utils";
-import {AbortController} from "@chainsafe/abort-controller";
 import {expect} from "chai";
 
 import {JobFnQueue, QueueError, QueueErrorCode, QueueType} from "../../../src/util/queue/index.js";

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -1,4 +1,3 @@
-import {AbortController} from "@chainsafe/abort-controller";
 import sinon from "sinon";
 
 import {toHexString} from "@chainsafe/ssz";

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -38,7 +38,6 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/abort-controller": "^3.0.1",
     "@chainsafe/as-sha256": "^0.3.1",
     "any-signal": "2.1.2",
     "bigint-buffer": "^1.1.5",

--- a/packages/utils/src/sleep.ts
+++ b/packages/utils/src/sleep.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {ErrorAborted} from "./errors.js";
 
 /**

--- a/packages/utils/src/timeout.ts
+++ b/packages/utils/src/timeout.ts
@@ -1,4 +1,3 @@
-import {AbortSignal, AbortController} from "@chainsafe/abort-controller";
 import {anySignal} from "any-signal";
 import {TimeoutError} from "./errors.js";
 import {sleep} from "./sleep.js";

--- a/packages/utils/test/unit/sleep.test.ts
+++ b/packages/utils/test/unit/sleep.test.ts
@@ -1,6 +1,5 @@
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
-import {AbortController} from "@chainsafe/abort-controller";
 import {sleep} from "../../src/sleep.js";
 import {ErrorAborted} from "../../src/errors.js";
 

--- a/packages/utils/test/unit/timeout.test.ts
+++ b/packages/utils/test/unit/timeout.test.ts
@@ -1,6 +1,5 @@
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
-import {AbortController} from "@chainsafe/abort-controller";
 import {withTimeout} from "../../src/timeout.js";
 import {ErrorAborted, TimeoutError} from "../../src/errors.js";
 

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -48,7 +48,6 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/abort-controller": "^3.0.1",
     "@chainsafe/bls": "7.1.1",
     "@chainsafe/lodestar-api": "^0.37.0",
     "@chainsafe/lodestar-beacon-state-transition": "^0.37.0",

--- a/packages/validator/src/genesis.ts
+++ b/packages/validator/src/genesis.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {Genesis} from "@chainsafe/lodestar-types/phase0";
 import {ILogger, sleep} from "@chainsafe/lodestar-utils";
 import {Api} from "@chainsafe/lodestar-api";

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {phase0, Slot, ssz} from "@chainsafe/lodestar-types";
 import {computeEpochAtSlot} from "@chainsafe/lodestar-beacon-state-transition";
 import {extendError, sleep} from "@chainsafe/lodestar-utils";

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {Slot, CommitteeIndex, altair, Root} from "@chainsafe/lodestar-types";
 import {extendError, sleep} from "@chainsafe/lodestar-utils";

--- a/packages/validator/src/util/clock.ts
+++ b/packages/validator/src/util/clock.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {ErrorAborted, ILogger, isErrorAborted, sleep} from "@chainsafe/lodestar-utils";
 import {GENESIS_SLOT, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -1,4 +1,3 @@
-import {AbortController, AbortSignal} from "@chainsafe/abort-controller";
 import {IDatabaseApiOptions} from "@chainsafe/lodestar-db";
 import {ssz} from "@chainsafe/lodestar-types";
 import {createIBeaconConfig, IBeaconConfig} from "@chainsafe/lodestar-config";

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -1,4 +1,3 @@
-import {AbortController} from "@chainsafe/abort-controller";
 import {expect} from "chai";
 import sinon from "sinon";
 import bls from "@chainsafe/bls";

--- a/packages/validator/test/unit/services/attestationDuties.test.ts
+++ b/packages/validator/test/unit/services/attestationDuties.test.ts
@@ -1,4 +1,3 @@
-import {AbortController} from "@chainsafe/abort-controller";
 import {toBufferBE} from "bigint-buffer";
 import {expect} from "chai";
 import sinon from "sinon";

--- a/packages/validator/test/unit/services/block.test.ts
+++ b/packages/validator/test/unit/services/block.test.ts
@@ -1,4 +1,3 @@
-import {AbortController} from "@chainsafe/abort-controller";
 import {expect} from "chai";
 import sinon from "sinon";
 import bls from "@chainsafe/bls";

--- a/packages/validator/test/unit/services/blockDuties.test.ts
+++ b/packages/validator/test/unit/services/blockDuties.test.ts
@@ -1,4 +1,3 @@
-import {AbortController} from "@chainsafe/abort-controller";
 import {expect} from "chai";
 import sinon from "sinon";
 import bls from "@chainsafe/bls";

--- a/packages/validator/test/unit/services/syncCommitteDuties.test.ts
+++ b/packages/validator/test/unit/services/syncCommitteDuties.test.ts
@@ -1,4 +1,3 @@
-import {AbortController} from "@chainsafe/abort-controller";
 import {toBufferBE} from "bigint-buffer";
 import {expect} from "chai";
 import sinon from "sinon";

--- a/packages/validator/test/unit/services/syncCommittee.test.ts
+++ b/packages/validator/test/unit/services/syncCommittee.test.ts
@@ -1,4 +1,3 @@
-import {AbortController} from "@chainsafe/abort-controller";
 import {expect} from "chai";
 import sinon from "sinon";
 import bls from "@chainsafe/bls";

--- a/packages/validator/test/unit/utils/clock.test.ts
+++ b/packages/validator/test/unit/utils/clock.test.ts
@@ -1,6 +1,5 @@
 import sinon from "sinon";
 import {expect} from "chai";
-import {AbortController} from "@chainsafe/abort-controller";
 import {config} from "@chainsafe/lodestar-config/default";
 import {Clock, getCurrentSlotAround} from "../../../src/util/clock.js";
 import {testLogger} from "../../utils/logger.js";

--- a/packages/validator/test/utils/clock.ts
+++ b/packages/validator/test/utils/clock.ts
@@ -1,4 +1,3 @@
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {Epoch, Slot} from "@chainsafe/lodestar-types";
 import {IClock} from "../../src/util/index.js";
 


### PR DESCRIPTION
**Motivation**

Since we're now using node 16, we don't need our own implementation of AbortController

**Description**

Remove the dependency