### PR TITLE
Use async version of crypto.randomBytes()

### DIFF
--- a/packages/lodestar/src/network/peers/discover.ts
+++ b/packages/lodestar/src/network/peers/discover.ts
@@ -19,6 +19,8 @@ const MAX_CACHED_ENRS = 100;
 /** Max age a cached ENR will be considered for dial */
 const MAX_CACHED_ENR_AGE_MS = 5 * 60 * 1000;
 
+const randomBytesAsync = promisify(crypto.randomBytes);
+
 export type PeerDiscoveryOpts = {
   maxPeers: number;
   discv5FirstQueryDelayMs: number;
@@ -227,8 +229,9 @@ export class PeerDiscovery {
       this.metrics?.discovery.findNodeQueryRequests.inc({action: "start"});
     }
 
-    // async version of crypto.randomBytes
-    const randomNodeId = await promisify(crypto.randomBytes)(64);
+    // Use async version to prevent blocking the event loop
+    // Time to completion of this function is not critical, in case this async call add extra lag
+    const randomNodeId = await randomBytesAsync(64);
     this.randomNodeQuery = {code: QueryStatusCode.Active, count: 0};
     const timer = this.metrics?.discovery.findNodeQueryTime.startTimer();
 


### PR DESCRIPTION
**Motivation**

`crypto.randomBytes()` has both sync and async version, as in the documentation of NodeJS:

```
The crypto.randomBytes() method will not complete until there is sufficient entropy available. This should normally never take longer than a few milliseconds. The only time when generating the random bytes may conceivably block for a longer period of time is right after boot, when the whole system is still low on entropy.
```

**Description**

Switch to async version of `crypto.randomBytes()`

part of #4002
