### PR TITLE
Remove invalid terminal block execution scenario

### DIFF
--- a/packages/lodestar/src/chain/blocks/verifyBlock.ts
+++ b/packages/lodestar/src/chain/blocks/verifyBlock.ts
@@ -270,7 +270,6 @@ export async function verifyBlockStateTransition(
       // child block will cause it to replay
 
       case ExecutePayloadStatus.INVALID_BLOCK_HASH:
-      case ExecutePayloadStatus.INVALID_TERMINAL_BLOCK:
       case ExecutePayloadStatus.ELERROR:
       case ExecutePayloadStatus.UNAVAILABLE:
         throw new BlockError(block, {

--- a/packages/lodestar/src/executionEngine/http.ts
+++ b/packages/lodestar/src/executionEngine/http.ts
@@ -140,7 +140,6 @@ export class ExecutionEngineHttp implements IExecutionEngine {
         return {status, latestValidHash: null, validationError: null};
 
       case ExecutePayloadStatus.INVALID_BLOCK_HASH:
-      case ExecutePayloadStatus.INVALID_TERMINAL_BLOCK:
         return {status, latestValidHash: null, validationError: validationError ?? "Malformed block"};
 
       case ExecutePayloadStatus.UNAVAILABLE:
@@ -247,13 +246,6 @@ export class ExecutionEngineHttp implements IExecutionEngine {
           `Invalid ${payloadAttributes ? "prepare payload" : "forkchoice request"}, validationError=${
             validationError ?? ""
           }`
-        );
-
-      case ExecutePayloadStatus.INVALID_TERMINAL_BLOCK:
-        throw Error(
-          `Invalid terminal block for ${
-            payloadAttributes ? "prepare payload" : "forkchoice request"
-          }, validationError=${validationError ?? ""}`
         );
 
       default:

--- a/packages/lodestar/src/executionEngine/interface.ts
+++ b/packages/lodestar/src/executionEngine/interface.ts
@@ -17,8 +17,6 @@ export enum ExecutePayloadStatus {
   ACCEPTED = "ACCEPTED",
   /** blockHash is invalid */
   INVALID_BLOCK_HASH = "INVALID_BLOCK_HASH",
-  /** invalid terminal block */
-  INVALID_TERMINAL_BLOCK = "INVALID_TERMINAL_BLOCK",
   /** EL error */
   ELERROR = "ELERROR",
   /** EL unavailable */
@@ -32,11 +30,7 @@ export type ExecutePayloadResponse =
   | {status: ExecutePayloadStatus.VALID; latestValidHash: RootHex; validationError: null}
   | {status: ExecutePayloadStatus.INVALID; latestValidHash: RootHex; validationError: string | null}
   | {
-      status:
-        | ExecutePayloadStatus.INVALID_BLOCK_HASH
-        | ExecutePayloadStatus.INVALID_TERMINAL_BLOCK
-        | ExecutePayloadStatus.ELERROR
-        | ExecutePayloadStatus.UNAVAILABLE;
+      status: ExecutePayloadStatus.INVALID_BLOCK_HASH | ExecutePayloadStatus.ELERROR | ExecutePayloadStatus.UNAVAILABLE;
       latestValidHash: null;
       validationError: string;
     };
@@ -44,8 +38,7 @@ export type ExecutePayloadResponse =
 export type ForkChoiceUpdateStatus =
   | ExecutePayloadStatus.VALID
   | ExecutePayloadStatus.INVALID
-  | ExecutePayloadStatus.SYNCING
-  | ExecutePayloadStatus.INVALID_TERMINAL_BLOCK;
+  | ExecutePayloadStatus.SYNCING;
 
 export type PayloadAttributes = {
   timestamp: number;


### PR DESCRIPTION
**Motivation**
Now the invalid terminal block errors from execution will come as normal INVALID errors
<!-- Why is this PR exists? What are the goals of the pull request? -->
Context:

https://github.com/ethereum/consensus-specs/pull/2891