### PR TITLE
Use justified blocks execution payload hash as safeBlockHash in engine fcU

### DIFF
--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -3,8 +3,8 @@ name: Sim merge tests
 on: [pull_request, push]
 
 env:
-  GETH_COMMIT: bb5633c5ee3975ce016636066ec790054ec469e4
-  NETHERMIND_COMMIT: 00b50532543824dbac65e8b7ab09484e44992c27
+  GETH_COMMIT: be9742721f56eb8bb7ebf4f6a03fb01b13a05408
+  NETHERMIND_COMMIT: 82f331a3e7ff21712a5f839e0a62ba7c16110e44
 
 jobs:
   sim-merge-tests:
@@ -59,7 +59,7 @@ jobs:
         with:
           dotnet-version: "6.0.x"
       - name: Clone Nethermind merge interop branch
-        run: git clone -b kiln https://github.com/g11tech/nethermind --recursive && cd nethermind && git reset --hard $NETHERMIND_COMMIT && git submodule update --init --recursive
+        run: git clone -b kiln-rebased https://github.com/g11tech/nethermind --recursive && cd nethermind && git reset --hard $NETHERMIND_COMMIT && git submodule update --init --recursive
       - name: Build Nethermind
         run: cd nethermind/src/Nethermind && dotnet build Nethermind.sln -c Release
 

--- a/packages/lodestar/src/chain/blocks/importBlock.ts
+++ b/packages/lodestar/src/chain/blocks/importBlock.ts
@@ -237,9 +237,10 @@ export async function importBlock(chain: ImportBlockModules, fullyVerifiedBlock:
        * the current finalized block does not contain any execution payload at all (pre MERGE_EPOCH) or if it contains a
        * zero block hash (pre TTD)
        */
+      const safeBlockHash = chain.forkChoice.getJustifiedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
       const finalizedBlockHash = chain.forkChoice.getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
       if (headBlockHash !== ZERO_HASH_HEX) {
-        chain.executionEngine.notifyForkchoiceUpdate(headBlockHash, finalizedBlockHash).catch((e) => {
+        chain.executionEngine.notifyForkchoiceUpdate(headBlockHash, safeBlockHash, finalizedBlockHash).catch((e) => {
           chain.logger.error("Error pushing notifyForkchoiceUpdate()", {headBlockHash, finalizedBlockHash}, e);
         });
       }
@@ -284,8 +285,9 @@ async function maybeIssueNextProposerEngineFcU(
       const proposerIndex = prepareState.epochCtx.getBeaconProposer(prepareSlot);
       const feeRecipient = chain.beaconProposerCache.get(proposerIndex);
       if (feeRecipient) {
+        const safeBlockHash = chain.forkChoice.getJustifiedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
         const finalizedBlockHash = chain.forkChoice.getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
-        return prepareExecutionPayload(chain, finalizedBlockHash, prepareState, feeRecipient);
+        return prepareExecutionPayload(chain, safeBlockHash, finalizedBlockHash, prepareState, feeRecipient);
       }
     } catch (e) {
       chain.logger.error("Error on issuing next proposer engine fcU", {}, e as Error);

--- a/packages/lodestar/src/executionEngine/http.ts
+++ b/packages/lodestar/src/executionEngine/http.ts
@@ -192,6 +192,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
    */
   async notifyForkchoiceUpdate(
     headBlockHash: Root | RootHex,
+    safeBlockHash: RootHex,
     finalizedBlockHash: RootHex,
     payloadAttributes?: PayloadAttributes
   ): Promise<PayloadId | null> {
@@ -212,10 +213,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
       payloadId,
     } = await this.rpc.fetch<EngineApiRpcReturnTypes[typeof method], EngineApiRpcParamTypes[typeof method]>({
       method,
-      params: [
-        {headBlockHash: headBlockHashData, safeBlockHash: headBlockHashData, finalizedBlockHash},
-        apiPayloadAttributes,
-      ],
+      params: [{headBlockHash: headBlockHashData, safeBlockHash, finalizedBlockHash}, apiPayloadAttributes],
     });
 
     switch (status) {

--- a/packages/lodestar/src/executionEngine/interface.ts
+++ b/packages/lodestar/src/executionEngine/interface.ts
@@ -88,6 +88,7 @@ export interface IExecutionEngine {
    */
   notifyForkchoiceUpdate(
     headBlockHash: Root | RootHex,
+    safeBlockHash: RootHex,
     finalizedBlockHash: RootHex,
     payloadAttributes?: PayloadAttributes
   ): Promise<PayloadId | null>;

--- a/packages/lodestar/src/executionEngine/mock.ts
+++ b/packages/lodestar/src/executionEngine/mock.ts
@@ -82,6 +82,7 @@ export class ExecutionEngineMock implements IExecutionEngine {
    */
   async notifyForkchoiceUpdate(
     headBlockHash: Root,
+    safeBlockHash: RootHex,
     finalizedBlockHash: RootHex,
     payloadAttributes?: PayloadAttributes
   ): Promise<PayloadId> {

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -213,7 +213,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
      * curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"engine_forkchoiceUpdatedV1","params":[{"headBlockHash":"0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858", "safeBlockHash":"0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858", "finalizedBlockHash":"0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a"}, null],"id":67}' http://localhost:8550
      **/
 
-    await executionEngine.notifyForkchoiceUpdate(bytesToData(payload.blockHash), genesisBlockHash);
+    await executionEngine.notifyForkchoiceUpdate(bytesToData(payload.blockHash), genesisBlockHash, genesisBlockHash);
 
     if (TX_SCENARIOS.includes("simple")) {
       const balance = await getBalance(jsonRpcUrl, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");

--- a/packages/lodestar/test/sim/merge-interop.test.ts
+++ b/packages/lodestar/test/sim/merge-interop.test.ts
@@ -176,6 +176,8 @@ describe("executionEngine / ExecutionEngineHttp", function () {
 
     const payloadId = await executionEngine.notifyForkchoiceUpdate(
       genesisBlockHash,
+      //use finalizedBlockHash as safeBlockHash
+      finalizedBlockHash,
       finalizedBlockHash,
       preparePayloadParams
     );

--- a/packages/lodestar/test/unit/executionEngine/http.test.ts
+++ b/packages/lodestar/test/unit/executionEngine/http.test.ts
@@ -140,6 +140,7 @@ describe("ExecutionEngine / http", () => {
 
     await executionEngine.notifyForkchoiceUpdate(
       forkChoiceHeadData.headBlockHash,
+      forkChoiceHeadData.safeBlockHash,
       forkChoiceHeadData.finalizedBlockHash
     );
 


### PR DESCRIPTION
The specs (v1.2.0 rc) have been updated on what to pass as `safeBlockHash` in engine fcU call (https://github.com/ethereum/consensus-specs/pull/2876/files, https://github.com/ethereum/consensus-specs/pull/2851/files, https://github.com/ethereum/consensus-specs/pull/2858/files)
**Motivation**
This PR implements the same in lodestar and does some comment cleanup.