### PR TITLE
Correct Aggregate Inclusion metric

### DIFF
--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -439,8 +439,9 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
           try {
             // TODO: Validate in batch
             const {indexedAttestation, committeeIndices} = await validateGossipAggregateAndProof(
-              chain,
-              signedAggregateAndProof
+              {chain, metrics},
+              signedAggregateAndProof,
+              seenTimestampSec
             );
 
             chain.aggregatedAttestationPool.add(

--- a/packages/lodestar/src/metrics/validatorMonitor.ts
+++ b/packages/lodestar/src/metrics/validatorMonitor.ts
@@ -112,7 +112,7 @@ type EpochSummary = {
   /** The delay between when the attestation should have been produced and when it was observed. */
   attestationMinDelay: Seconds | null;
   /** The number of times a validators attestation was seen in an aggregate. */
-  attestationAggregateIncusions: number;
+  attestationAggregateInclusions: number;
   /** The number of times a validators attestation was seen in a block. */
   attestationBlockInclusions: number;
   /** The minimum observed inclusion distance for an attestation for this epoch.. */
@@ -137,7 +137,7 @@ function withEpochSummary(validator: MonitoredValidator, epoch: Epoch, fn: (summ
     summary = {
       attestations: 0,
       attestationMinDelay: null,
-      attestationAggregateIncusions: 0,
+      attestationAggregateInclusions: 0,
       attestationBlockInclusions: 0,
       attestationMinBlockInclusionDistance: null,
       blocks: 0,
@@ -370,7 +370,7 @@ export function createValidatorMonitor(
           metrics.validatorMonitor.attestationInAggregateTotal.inc({src, index});
           metrics.validatorMonitor.attestationInAggregateDelaySeconds.observe({src, index}, delaySec);
           withEpochSummary(validator, epoch, (summary) => {
-            summary.attestationAggregateIncusions += 1;
+            summary.attestationAggregateInclusions += 1;
           });
           logger.debug("Local validator attestation is included in AggregatedAndProof", {
             validatorIndex: validator.index,
@@ -457,7 +457,7 @@ export function createValidatorMonitor(
           metrics.validatorMonitor.prevEpochAttestationsMinDelaySeconds.observe({index}, summary.attestationMinDelay);
         metrics.validatorMonitor.prevEpochAttestationAggregateInclusions.set(
           {index},
-          summary.attestationAggregateIncusions
+          summary.attestationAggregateInclusions
         );
         metrics.validatorMonitor.prevEpochAttestationBlockInclusions.set({index}, summary.attestationBlockInclusions);
         if (summary.attestationMinBlockInclusionDistance !== null) {

--- a/packages/lodestar/test/perf/chain/validation/aggregateAndProof.test.ts
+++ b/packages/lodestar/test/perf/chain/validation/aggregateAndProof.test.ts
@@ -13,6 +13,7 @@ describe("validate gossip signedAggregateAndProof", () => {
   });
 
   const aggStruct = signedAggregateAndProof;
+  const seenTimestampSec = Date.now() / 1000;
 
   for (const [id, agg] of Object.entries({struct: aggStruct})) {
     itBench({
@@ -22,7 +23,7 @@ describe("validate gossip signedAggregateAndProof", () => {
         chain.seenAggregatedAttestations["aggregateRootsByEpoch"].clear();
       },
       fn: async () => {
-        await validateGossipAggregateAndProof(chain, agg);
+        await validateGossipAggregateAndProof({chain}, agg, seenTimestampSec);
       },
     });
   }

--- a/packages/lodestar/test/unit/chain/validation/aggregateAndProof.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/aggregateAndProof.test.ts
@@ -40,7 +40,7 @@ describe("chain / validation / aggregateAndProof", () => {
   it("Valid", async () => {
     const {chain, signedAggregateAndProof} = getValidData({});
 
-    await validateGossipAggregateAndProof(chain, signedAggregateAndProof);
+    await validateGossipAggregateAndProof({chain}, signedAggregateAndProof, Date.now() / 1000);
   });
 
   it("BAD_TARGET_EPOCH", async () => {
@@ -170,6 +170,9 @@ describe("chain / validation / aggregateAndProof", () => {
     signedAggregateAndProof: phase0.SignedAggregateAndProof,
     errorCode: AttestationErrorCode
   ): Promise<void> {
-    await expectRejectedWithLodestarError(validateGossipAggregateAndProof(chain, signedAggregateAndProof), errorCode);
+    await expectRejectedWithLodestarError(
+      validateGossipAggregateAndProof({chain}, signedAggregateAndProof, Date.now() / 1000),
+      errorCode
+    );
   }
 });


### PR DESCRIPTION
**Motivation**

Due to #4019, Aggregate Inclusion metric dropped. We want to get it back to the previous state.

<img width="1242" alt="Screen Shot 2022-05-29 at 15 23 21" src="https://user-images.githubusercontent.com/10568965/170859068-28567975-d051-4fe7-ae7c-feb9c46fbbd3.png">


**Description**

+ Call the metric before the `chain.seenAggregatedAttestations.isKnown()` check, about 70% of AggregateAndProof gossip messages were caught by that
