### PR TITLE
Do not check for know attesters when publishing AggregateAndProof

### DIFF
--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -440,7 +440,8 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
             // TODO: Validate in batch
             const {indexedAttestation, committeeIndices} = await validateGossipAggregateAndProof(
               chain,
-              signedAggregateAndProof
+              signedAggregateAndProof,
+              false // bypass known attesters check
             );
 
             chain.aggregatedAttestationPool.add(

--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -441,7 +441,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
             const {indexedAttestation, committeeIndices} = await validateGossipAggregateAndProof(
               chain,
               signedAggregateAndProof,
-              false // bypass known attesters check
+              true // skip known attesters check
             );
 
             chain.aggregatedAttestationPool.add(

--- a/packages/lodestar/src/chain/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/aggregateAndProof.ts
@@ -15,7 +15,7 @@ import {getCommitteeIndices, verifyHeadBlockAndTargetRoot, verifyPropagationSlot
 export async function validateGossipAggregateAndProof(
   chain: IBeaconChain,
   signedAggregateAndProof: phase0.SignedAggregateAndProof,
-  validateKnownAttesters: boolean = true,
+  skipValidationKnownAttesters = false
 ): Promise<{indexedAttestation: phase0.IndexedAttestation; committeeIndices: ValidatorIndex[]}> {
   // Do checks in this order:
   // - do early checks (w/o indexed attestation)
@@ -47,7 +47,7 @@ export async function validateGossipAggregateAndProof(
   // [IGNORE] The aggregate is the first valid aggregate received for the aggregator with
   // index aggregate_and_proof.aggregator_index for the epoch aggregate.data.target.epoch.
   const aggregatorIndex = aggregateAndProof.aggregatorIndex;
-  if (validateKnownAttesters) {
+  if (!skipValidationKnownAttesters) {
     if (chain.seenAggregators.isKnown(targetEpoch, aggregatorIndex)) {
       throw new AttestationError(GossipAction.IGNORE, {
         code: AttestationErrorCode.AGGREGATOR_ALREADY_KNOWN,

--- a/packages/lodestar/src/chain/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/aggregateAndProof.ts
@@ -14,7 +14,8 @@ import {getCommitteeIndices, verifyHeadBlockAndTargetRoot, verifyPropagationSlot
 
 export async function validateGossipAggregateAndProof(
   chain: IBeaconChain,
-  signedAggregateAndProof: phase0.SignedAggregateAndProof
+  signedAggregateAndProof: phase0.SignedAggregateAndProof,
+  validateKnownAttesters: boolean = true,
 ): Promise<{indexedAttestation: phase0.IndexedAttestation; committeeIndices: ValidatorIndex[]}> {
   // Do checks in this order:
   // - do early checks (w/o indexed attestation)
@@ -46,12 +47,14 @@ export async function validateGossipAggregateAndProof(
   // [IGNORE] The aggregate is the first valid aggregate received for the aggregator with
   // index aggregate_and_proof.aggregator_index for the epoch aggregate.data.target.epoch.
   const aggregatorIndex = aggregateAndProof.aggregatorIndex;
-  if (chain.seenAggregators.isKnown(targetEpoch, aggregatorIndex)) {
-    throw new AttestationError(GossipAction.IGNORE, {
-      code: AttestationErrorCode.AGGREGATOR_ALREADY_KNOWN,
-      targetEpoch,
-      aggregatorIndex,
-    });
+  if (validateKnownAttesters) {
+    if (chain.seenAggregators.isKnown(targetEpoch, aggregatorIndex)) {
+      throw new AttestationError(GossipAction.IGNORE, {
+        code: AttestationErrorCode.AGGREGATOR_ALREADY_KNOWN,
+        targetEpoch,
+        aggregatorIndex,
+      });
+    }
   }
 
   // _[IGNORE]_ A valid aggregate attestation defined by `hash_tree_root(aggregate.data)` whose `aggregation_bits`


### PR DESCRIPTION
**Motivation**

Fix ropsten error
```
Error publishing aggregateAndProofs slot=3542, index=20 Internal Server Error: ATTESTATION_ERROR_ATTESTERS_ALREADY_KNOWN
Error: Internal Server Error: ATTESTATION_ERROR_ATTESTERS_ALREADY_KNOWN
```

**Description**

Due to #4019, we filter a lot of AggregateAndProof with known attesters. We should not have that check at api side.

Closes #4089
