### PR TITLE
Skip checking known participants when publishing ContributionAndProof

### DIFF
--- a/packages/lodestar/src/api/impl/validator/index.ts
+++ b/packages/lodestar/src/api/impl/validator/index.ts
@@ -498,7 +498,8 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
             // TODO: Validate in batch
             const {syncCommitteeParticipants} = await validateSyncCommitteeGossipContributionAndProof(
               chain,
-              contributionAndProof
+              contributionAndProof,
+              true // skip known participants check
             );
             chain.syncContributionAndProofPool.add(contributionAndProof.message, syncCommitteeParticipants);
             await network.gossip.publishContributionAndProof(contributionAndProof);

--- a/packages/lodestar/src/chain/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/aggregateAndProof.ts
@@ -57,14 +57,15 @@ export async function validateGossipAggregateAndProof(
 
   // _[IGNORE]_ A valid aggregate attestation defined by `hash_tree_root(aggregate.data)` whose `aggregation_bits`
   // is a non-strict superset has _not_ already been seen.
-  if (!skipValidationKnownAttesters) {
-    if (chain.seenAggregatedAttestations.isKnown(targetEpoch, attDataRoot, aggregationBits)) {
-      throw new AttestationError(GossipAction.IGNORE, {
-        code: AttestationErrorCode.ATTESTERS_ALREADY_KNOWN,
-        targetEpoch,
-        aggregateRoot: attDataRoot,
-      });
-    }
+  if (
+    !skipValidationKnownAttesters &&
+    chain.seenAggregatedAttestations.isKnown(targetEpoch, attDataRoot, aggregationBits)
+  ) {
+    throw new AttestationError(GossipAction.IGNORE, {
+      code: AttestationErrorCode.ATTESTERS_ALREADY_KNOWN,
+      targetEpoch,
+      aggregateRoot: attDataRoot,
+    });
   }
 
   // [IGNORE] The block being voted for (attestation.data.beacon_block_root) has been seen (via both gossip

--- a/packages/lodestar/src/chain/validation/aggregateAndProof.ts
+++ b/packages/lodestar/src/chain/validation/aggregateAndProof.ts
@@ -47,24 +47,24 @@ export async function validateGossipAggregateAndProof(
   // [IGNORE] The aggregate is the first valid aggregate received for the aggregator with
   // index aggregate_and_proof.aggregator_index for the epoch aggregate.data.target.epoch.
   const aggregatorIndex = aggregateAndProof.aggregatorIndex;
-  if (!skipValidationKnownAttesters) {
-    if (chain.seenAggregators.isKnown(targetEpoch, aggregatorIndex)) {
-      throw new AttestationError(GossipAction.IGNORE, {
-        code: AttestationErrorCode.AGGREGATOR_ALREADY_KNOWN,
-        targetEpoch,
-        aggregatorIndex,
-      });
-    }
+  if (chain.seenAggregators.isKnown(targetEpoch, aggregatorIndex)) {
+    throw new AttestationError(GossipAction.IGNORE, {
+      code: AttestationErrorCode.AGGREGATOR_ALREADY_KNOWN,
+      targetEpoch,
+      aggregatorIndex,
+    });
   }
 
   // _[IGNORE]_ A valid aggregate attestation defined by `hash_tree_root(aggregate.data)` whose `aggregation_bits`
   // is a non-strict superset has _not_ already been seen.
-  if (chain.seenAggregatedAttestations.isKnown(targetEpoch, attDataRoot, aggregationBits)) {
-    throw new AttestationError(GossipAction.IGNORE, {
-      code: AttestationErrorCode.ATTESTERS_ALREADY_KNOWN,
-      targetEpoch,
-      aggregateRoot: attDataRoot,
-    });
+  if (!skipValidationKnownAttesters) {
+    if (chain.seenAggregatedAttestations.isKnown(targetEpoch, attDataRoot, aggregationBits)) {
+      throw new AttestationError(GossipAction.IGNORE, {
+        code: AttestationErrorCode.ATTESTERS_ALREADY_KNOWN,
+        targetEpoch,
+        aggregateRoot: attDataRoot,
+      });
+    }
   }
 
   // [IGNORE] The block being voted for (attestation.data.beacon_block_root) has been seen (via both gossip

--- a/packages/lodestar/src/chain/validation/syncCommitteeContributionAndProof.ts
+++ b/packages/lodestar/src/chain/validation/syncCommitteeContributionAndProof.ts
@@ -15,7 +15,8 @@ import {
  */
 export async function validateSyncCommitteeGossipContributionAndProof(
   chain: IBeaconChain,
-  signedContributionAndProof: altair.SignedContributionAndProof
+  signedContributionAndProof: altair.SignedContributionAndProof,
+  skipValidationKnownParticipants = false
 ): Promise<{syncCommitteeParticipants: number}> {
   const contributionAndProof = signedContributionAndProof.message;
   const {contribution, aggregatorIndex} = contributionAndProof;
@@ -37,10 +38,12 @@ export async function validateSyncCommitteeGossipContributionAndProof(
 
   // _[IGNORE]_ A valid sync committee contribution with equal `slot`, `beacon_block_root` and `subcommittee_index` whose
   // `aggregation_bits` is non-strict superset has _not_ already been seen.
-  if (chain.seenContributionAndProof.participantsKnown(contribution)) {
-    throw new SyncCommitteeError(GossipAction.IGNORE, {
-      code: SyncCommitteeErrorCode.SYNC_COMMITTEE_PARTICIPANTS_ALREADY_KNOWN,
-    });
+  if (!skipValidationKnownParticipants) {
+    if (chain.seenContributionAndProof.participantsKnown(contribution)) {
+      throw new SyncCommitteeError(GossipAction.IGNORE, {
+        code: SyncCommitteeErrorCode.SYNC_COMMITTEE_PARTICIPANTS_ALREADY_KNOWN,
+      });
+    }
   }
 
   // [IGNORE] The sync committee contribution is the first valid contribution received for the aggregator with index

--- a/packages/lodestar/src/chain/validation/syncCommitteeContributionAndProof.ts
+++ b/packages/lodestar/src/chain/validation/syncCommitteeContributionAndProof.ts
@@ -38,12 +38,10 @@ export async function validateSyncCommitteeGossipContributionAndProof(
 
   // _[IGNORE]_ A valid sync committee contribution with equal `slot`, `beacon_block_root` and `subcommittee_index` whose
   // `aggregation_bits` is non-strict superset has _not_ already been seen.
-  if (!skipValidationKnownParticipants) {
-    if (chain.seenContributionAndProof.participantsKnown(contribution)) {
-      throw new SyncCommitteeError(GossipAction.IGNORE, {
-        code: SyncCommitteeErrorCode.SYNC_COMMITTEE_PARTICIPANTS_ALREADY_KNOWN,
-      });
-    }
+  if (!skipValidationKnownParticipants && chain.seenContributionAndProof.participantsKnown(contribution)) {
+    throw new SyncCommitteeError(GossipAction.IGNORE, {
+      code: SyncCommitteeErrorCode.SYNC_COMMITTEE_PARTICIPANTS_ALREADY_KNOWN,
+    });
   }
 
   // [IGNORE] The sync committee contribution is the first valid contribution received for the aggregator with index


### PR DESCRIPTION
**Motivation**

We don't want to check for know participants when publishing ContributionAndProof from api

**Description**

+ Similar to `validateGossipAggregateAndProof`, add `skipValidationKnownParticipants = false` param to `validateSyncCommitteeGossipContributionAndProof`
+ Fix `validateGossipAggregateAndProof`: wrong check on `AGGREGATOR_ALREADY_KNOWN`, should be for `ATTESTERS_ALREADY_KNOWN `



part of #4089