### PR TITLE
Update beacon_aggregate_and_proof gossip scoring params

### DIFF
--- a/packages/lodestar/src/network/gossip/scoringParameters.ts
+++ b/packages/lodestar/src/network/gossip/scoringParameters.ts
@@ -27,6 +27,14 @@ const VOLUNTARY_EXIT_WEIGHT = 0.05;
 const PROPOSER_SLASHING_WEIGHT = 0.05;
 const ATTESTER_SLASHING_WEIGHT = 0.05;
 
+/**
+ * Due to https://github.com/ChainSafe/lodestar/pull/4019
+ * only some first AggregateAndProof messages are accepted, others are ignored.
+ * On Prater, 70% of AggregateAndProof messages are IGNORED due to this reason.
+ * On mainnet, the number is 80%
+ */
+const ACCEPTED_AGGREGATE_AND_PROOF_RATIO = 0.25;
+
 const beaconAttestationSubnetWeight = 1 / ATTESTATION_SUBNET_COUNT;
 const maxPositiveScore =
   (MAX_IN_MESH_SCORE + MAX_FIRST_MESSAGE_DELIVERIES_SCORE) *
@@ -188,7 +196,7 @@ function getAllTopicsScoreParams(
       })
     ] = getTopicScoreParams(config, precomputedParams, {
       topicWeight: BEACON_AGGREGATE_PROOF_WEIGHT,
-      expectedMessageRate: aggregatorsPerslot,
+      expectedMessageRate: aggregatorsPerslot * ACCEPTED_AGGREGATE_AND_PROOF_RATIO,
       firstMessageDecayTime: epochDurationMs,
       meshMessageInfo: {
         decaySlots: SLOTS_PER_EPOCH * 2,

--- a/packages/lodestar/test/unit-mainnet/network/gossip/scoringParameters.test.ts
+++ b/packages/lodestar/test/unit-mainnet/network/gossip/scoringParameters.test.ts
@@ -121,23 +121,29 @@ describe("computeGossipPeerScoreParams", function () {
     expect(params.timeInMeshWeight).closeTo(0.03333, TOLERANCE);
     expect(params.timeInMeshQuantum).to.be.equal(12 * 1000);
     expect(params.timeInMeshCap).to.be.equal(300.0);
-    expect(params.firstMessageDeliveriesWeight).closeTo(0.33509, TOLERANCE);
+    // 0.33509 if not filtering seen attesters
+    expect(params.firstMessageDeliveriesWeight).closeTo(1.340356, TOLERANCE);
     expect(params.firstMessageDeliveriesDecay).closeTo(0.86596, TOLERANCE);
-    expect(params.firstMessageDeliveriesCap).closeTo(119.3712, TOLERANCE);
+    // 119.3712 if not filtering seen attesters
+    expect(params.firstMessageDeliveriesCap).closeTo(29.8428, TOLERANCE);
     expect(params.invalidMessageDeliveriesWeight).closeTo(-215.0, TOLERANCE);
     expect(params.invalidMessageDeliveriesDecay).closeTo(0.99713, TOLERANCE);
 
     // Check message rate penalty params
     expect(params.meshMessageDeliveriesDecay).closeTo(0.930572, TOLERANCE);
-    expect(params.meshMessageDeliveriesCap).closeTo(68.6255, TOLERANCE);
+    // 68.6255 if not filtering seen attesters
+    expect(params.meshMessageDeliveriesCap).closeTo(17.15637, TOLERANCE);
     expect(params.meshMessageDeliveriesActivation).to.be.equal(384 * 1000);
     expect(params.meshMessageDeliveriesWindow).to.be.equal(12 * 1000);
-    expect(params.meshFailurePenaltyWeight).closeTo(-0.73044, TOLERANCE);
+    // -0.73044 if not filtering seen attesters
+    expect(params.meshFailurePenaltyWeight).closeTo(-11.68711, TOLERANCE);
     expect(params.meshFailurePenaltyDecay).closeTo(0.93057, TOLERANCE);
 
     if (penaltiesActive) {
-      expect(params.meshMessageDeliveriesWeight).closeTo(-0.7304, TOLERANCE);
-      expect(params.meshMessageDeliveriesThreshold).closeTo(17.15638, TOLERANCE);
+      // -0.7304 if not filtering seen attesters
+      expect(params.meshMessageDeliveriesWeight).closeTo(-11.68711, TOLERANCE);
+      // 17.15638 if not filtering seen attesters
+      expect(params.meshMessageDeliveriesThreshold).closeTo(4.28909, TOLERANCE);
     } else {
       expect(params.meshMessageDeliveriesWeight).to.be.equal(0.0);
       expect(params.meshMessageDeliveriesThreshold).to.be.equal(0.0);


### PR DESCRIPTION
**Motivation**

After #4019 , we ignore AggregateAndProof gossip messages if all attesters are seen so we need to update respective params.

**Description**

+ As seen in prater and mainnet, 70%-80% messages are filtered so we have less accepted AggregateAndProof messages
+ Detail as below:

|Param|Old value|New value|Note|
|------|----------|----------|----|
| firstMessageDeliveriesWeight|0.33509|4x|p1 (weight * cap) is unchanged|
| firstMessageDeliveriesCap |119.3712 | 1/4 x|p1 (weight * cap) is unchanged|
| meshMessageDeliveriesCap|68.6255 | 1/4 x|less accepted AggregateAndProof messages|
| meshFailurePenaltyWeight|-0.7304|-11.68711|p3b, a little concerned, but this will likely not be applied since threshold is way smaller|
| meshMessageDeliveriesWeight|-0.7304|-11.68711|p3, a little concerned, but this will likely not be applied since threshold is way smaller|
| meshMessageDeliveriesThreshold|17.15638|1/4 x (4.28909)|more relaxed value, hopefully no p3 & p3b penalties are applied|

Closes #4086