### PR TITLE
Another fix for publish rc

### DIFF
--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -1,4 +1,4 @@
-name: Publish release
+name: Publish release candidate
 
 # only one can tun at a time
 concurrency: cd-publish-rc

--- a/scripts/release/assert_valid_rc.sh
+++ b/scripts/release/assert_valid_rc.sh
@@ -20,7 +20,7 @@ else
 fi
 
 # assert it exists in branch
-HEAD_COMMIT=$(git rev-parse refs/heads/$RC_BRANCH)
+HEAD_COMMIT=$(git rev-parse refs/remotes/origin/$RC_BRANCH)
 git merge-base --is-ancestor $COMMIT $HEAD_COMMIT
 
 # success


### PR DESCRIPTION
**Motivation**

#4096 added a bash script which broke in CI. The script checks the that the commit at the rc tag is an ancestor of the head of the rc branch. But the command to get the head commit of the rc branch erroneously assumed that the branch had already been checked out. Which is not the case in CI.

**Description**
Update the script to check against the remote's rc branch, which should always exist in CI.