### PR TITLE
Enable rc dockerhub publish in await-release script

### DIFF
--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -132,7 +132,7 @@ jobs:
     if: needs.tag.outputs.is_rc == 'true'
     steps:
       - uses: actions/checkout@v2
-      - run: scripts/await-release.sh ${{ needs.tag.outputs.tag }} 900
+      - run: scripts/await-release.sh ${{ needs.tag.outputs.tag }} rc 900
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -122,7 +122,7 @@ jobs:
     if: needs.tag.outputs.is_stable == 'true'
     steps:
       - uses: actions/checkout@v2
-      - run: scripts/await-release.sh ${{ needs.tag.outputs.tag }} 900
+      - run: scripts/await-release.sh ${{ needs.tag.outputs.tag }} latest 900
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/scripts/await-release.sh
+++ b/scripts/await-release.sh
@@ -9,12 +9,13 @@ declare PACKAGE="@chainsafe/lodestar-cli"
 # Using `npm view -j` to get all available versions as JSON
 declare CMD_NPM="npm view -j $PACKAGE"
 
-# Using `jq` to get the latest version
-declare VERSION_LATEST=$($CMD_NPM | jq -r '."dist-tags".latest')
+# Using `jq` to get the dist-tag version
+declare VERSION_LATEST=$($CMD_NPM | jq -r ".\"dist-tags\".$DIST_TAG")
 
 # Usage: scripts/await-release.sh $VERSION $TIMEOUT
 declare VERSION_EXPECTED=$(echo $1 | tr -d 'v')
-declare TIMEOUT=$2
+declare DIST_TAG=$2
+declare TIMEOUT=$3
 
 declare TIME=0
 declare SLEEP=5
@@ -23,7 +24,7 @@ declare SLEEP=5
 ### Note: that this script will already exit here in case everything is fine 
 ###       and only delay in case there is a discrepancy between the versions
 while [[ "$VERSION_EXPECTED" != "$VERSION_LATEST" ]]; do
-    echo "Expected version $VERSION_EXPECTED does not match latest version $VERSION_LATEST in NPM registry. Trying again in $SLEEP..."
+    echo "Expected version $VERSION_EXPECTED does not match $DIST_TAG version $VERSION_LATEST in NPM registry. Trying again in $SLEEP..."
     TIME=$(($TIME+$SLEEP))
 
     # Allow the CI to timeout
@@ -35,5 +36,5 @@ while [[ "$VERSION_EXPECTED" != "$VERSION_LATEST" ]]; do
     
     # Force clean cache before retrying
     npm cache clean --force
-    VERSION_LATEST=$($CMD_NPM | jq -r '."dist-tags".latest')
+    VERSION_LATEST=$($CMD_NPM | jq -r ".\"dist-tags\".$DIST_TAG")
 done


### PR DESCRIPTION
**Motivation**

See https://github.com/ChainSafe/lodestar/runs/6693443871?check_suite_focus=true

The await-release script was hardcoded to check the `latest` dist-tag on npm.

**Description**

Update the await-release script to check a dist-tag determined by script input.
In publish-rc, check the `rc` dist-tag.
In publish-stable, check the `latest` dist-tag.