### PR TITLE
Implement remote key manager API

### DIFF
--- a/packages/api/src/keymanager/index.ts
+++ b/packages/api/src/keymanager/index.ts
@@ -6,7 +6,18 @@ import * as keymanager from "./client.js";
 
 // NOTE: Don't export server here so it's not bundled to all consumers
 
-export {ImportStatus, DeletionStatus, KeystoreStr, SlashingProtectionData, PubkeyHex, Api} from "./routes.js";
+export {
+  ImportStatus,
+  DeletionStatus,
+  ImportRemoteKeyStatus,
+  DeleteRemoteKeyStatus,
+  ResponseStatus,
+  SignerDefinition,
+  KeystoreStr,
+  SlashingProtectionData,
+  PubkeyHex,
+  Api,
+} from "./routes.js";
 
 type ClientModules = HttpClientModules & {
   config: IChainForkConfig;

--- a/packages/api/test/unit/keymanager/keymanager.test.ts
+++ b/packages/api/test/unit/keymanager/keymanager.test.ts
@@ -1,19 +1,28 @@
 import {config} from "@chainsafe/lodestar-config/default";
-import {Api, DeletionStatus, ImportStatus, ReqTypes} from "../../../src/keymanager/routes.js";
+import {
+  Api,
+  DeleteRemoteKeyStatus,
+  DeletionStatus,
+  ImportRemoteKeyStatus,
+  ImportStatus,
+  ReqTypes,
+} from "../../../src/keymanager/routes.js";
 import {getClient} from "../../../src/keymanager/client.js";
 import {getRoutes} from "../../../src/keymanager/server/index.js";
 import {runGenericServerTest} from "../../utils/genericServerTest.js";
 
 describe("keymanager", () => {
+  // randomly pregenerated pubkey
+  const pubkeyRand =
+    "0x84105a985058fc8740a48bf1ede9d223ef09e8c6b1735ba0a55cf4a9ff2ff92376b778798365e488dab07a652eb04576";
+
   runGenericServerTest<Api, ReqTypes>(config, getClient, getRoutes, {
     listKeys: {
       args: [],
       res: {
         data: [
           {
-            validatingPubkey:
-              // randomly pregenerated pubkey
-              "0x84105a985058fc8740a48bf1ede9d223ef09e8c6b1735ba0a55cf4a9ff2ff92376b778798365e488dab07a652eb04576",
+            validatingPubkey: pubkeyRand,
             derivationPath: "m/12381/3600/0/0/0",
             readonly: false,
           },
@@ -27,6 +36,27 @@ describe("keymanager", () => {
     deleteKeystores: {
       args: [["key1"]],
       res: {data: [{status: DeletionStatus.deleted}], slashingProtection: "slash_protection"},
+    },
+
+    listRemoteKeys: {
+      args: [],
+      res: {
+        data: [
+          {
+            pubkey: pubkeyRand,
+            url: "https://sign.er",
+            readonly: false,
+          },
+        ],
+      },
+    },
+    importRemoteKeys: {
+      args: [[{pubkey: pubkeyRand, url: "https://sign.er"}]],
+      res: {data: [{status: ImportRemoteKeyStatus.imported}]},
+    },
+    deleteRemoteKeys: {
+      args: [["key1"]],
+      res: {data: [{status: DeleteRemoteKeyStatus.deleted}]},
     },
   });
 });

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -1,10 +1,9 @@
 import {LevelDbController} from "@chainsafe/lodestar-db";
 import {SlashingProtection, Validator} from "@chainsafe/lodestar-validator";
-import {SignerType, SignerLocal, SignerRemote, Signer} from "@chainsafe/lodestar-validator";
+import {SignerType, Signer} from "@chainsafe/lodestar-validator";
 import {getMetrics, MetricsRegister} from "@chainsafe/lodestar-validator";
 import {KeymanagerServer, KeymanagerApi} from "@chainsafe/lodestar-keymanager-server";
 import {RegistryMetricCreator, collectNodeJSMetrics, HttpMetricsServer} from "@chainsafe/lodestar";
-import {ILogger} from "@chainsafe/lodestar-utils";
 import {getBeaconConfigFromArgs} from "../../config/index.js";
 import {IGlobalArgs} from "../../options/index.js";
 import {YargsError, getDefaultGraffiti, mkdir, getCliLogger} from "../../util/index.js";
@@ -166,38 +165,5 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
     );
     onGracefulShutdownCbs.push(() => keymanagerServer.close());
     await keymanagerServer.listen();
-  }
-}
-
-/**
- * Log each pubkeys for auditing out keys are loaded from the logs
- */
-function logSigners(logger: ILogger, signers: Signer[]): void {
-  const localSigners: SignerLocal[] = [];
-  const remoteSigners: SignerRemote[] = [];
-
-  for (const signer of signers) {
-    switch (signer.type) {
-      case SignerType.Local:
-        localSigners.push(signer);
-        break;
-      case SignerType.Remote:
-        remoteSigners.push(signer);
-        break;
-    }
-  }
-
-  if (localSigners.length > 0) {
-    logger.info(`Decrypted ${localSigners.length} local keystores`);
-    for (const signer of localSigners) {
-      logger.info(signer.secretKey.toPublicKey().toHex());
-    }
-  }
-
-  for (const {externalSignerUrl, pubkeysHex} of groupExternalSignersByUrl(remoteSigners)) {
-    logger.info(`External signers on URL: ${externalSignerUrl}`);
-    for (const pubkeyHex of pubkeysHex) {
-      logger.info(pubkeyHex);
-    }
   }
 }

--- a/packages/cli/src/cmds/validator/paths.ts
+++ b/packages/cli/src/cmds/validator/paths.ts
@@ -10,6 +10,7 @@ export type AccountPaths = {
   keystoresDir: string;
   secretsDir: string;
   walletsDir: string;
+  remoteKeysDir: string;
 };
 
 /**
@@ -74,11 +75,13 @@ export function getAccountPaths(
   const keystoresDir = args.keystoresDir || path.join(rootDir, "keystores");
   const secretsDir = args.secretsDir || path.join(rootDir, "secrets");
   const walletsDir = args.walletsDir || path.join(rootDir, "wallets");
+  const remoteKeysDir = args.walletsDir || path.join(rootDir, "remoteKeys");
   return {
     ...globalPaths,
     keystoresDir,
     secretsDir,
     walletsDir,
+    remoteKeysDir,
   };
 }
 

--- a/packages/keymanager-server/src/impl.ts
+++ b/packages/keymanager-server/src/impl.ts
@@ -210,8 +210,10 @@ export class KeymanagerApi implements Api {
    */
   async listRemoteKeys(): ReturnType<Api["listRemoteKeys"]> {
     const remoteKeys: SignerDefinition[] = [];
-    for (const signer of this.validator.validatorStore.getSigners()) {
-      if (signer.type === SignerType.Remote) {
+
+    for (const pubkeyHex of this.validator.validatorStore.votingPubkeys()) {
+      const signer = this.validator.validatorStore.getSigner(pubkeyHex);
+      if (signer && signer.type === SignerType.Remote) {
         remoteKeys.push({
           pubkey: signer.pubkeyHex,
           url: signer.externalSignerUrl,

--- a/packages/keymanager-server/src/impl.ts
+++ b/packages/keymanager-server/src/impl.ts
@@ -4,28 +4,41 @@ import bls from "@chainsafe/bls";
 import {Keystore} from "@chainsafe/bls-keystore";
 import {
   Api,
+  DeleteRemoteKeyStatus,
   DeletionStatus,
   ImportStatus,
+  ResponseStatus,
   KeystoreStr,
+  PubkeyHex,
   SlashingProtectionData,
+  SignerDefinition,
+  ImportRemoteKeyStatus,
 } from "@chainsafe/lodestar-api/keymanager";
 import {fromHexString} from "@chainsafe/ssz";
 import {Interchange, SignerType, Validator} from "@chainsafe/lodestar-validator";
-import {PubkeyHex} from "@chainsafe/lodestar-validator/src/types";
 import {lockFilepath, unlockFilepath} from "./util/lockfile.js";
 
-export const KEY_IMPORTED_PREFIX = "key_imported";
+export const KEYSTORE_IMPORTED_PREFIX = "imported_keystore";
+
+export type KeymanagerOpts = {
+  /** Directory to persist imported keystores. Must not be the same as `importedRemoteKeysDirpath` */
+  importedKeystoresDirpath: string;
+  /** Directory to persist imported remote signers. Must not be the same as `importedKeystoresDirpath` */
+  importedRemoteKeysDirpath: string;
+};
 
 export class KeymanagerApi implements Api {
-  constructor(private readonly validator: Validator, private readonly importKeystoresDirpath: string) {
-    if (fs.existsSync(importKeystoresDirpath)) {
-      // Ensure is directory
-      if (!fs.statSync(importKeystoresDirpath).isDirectory()) {
-        throw Error("importKeystoresPath is not a directory");
+  constructor(private readonly validator: Validator, private readonly opts: KeymanagerOpts) {
+    for (const dirpath of [opts.importedKeystoresDirpath, opts.importedRemoteKeysDirpath]) {
+      if (fs.existsSync(dirpath)) {
+        // Ensure is directory
+        if (!fs.statSync(dirpath).isDirectory()) {
+          throw Error(`${dirpath} must be a directory`);
+        }
+      } else {
+        // Or, create empty directory
+        fs.mkdirSync(dirpath, {recursive: true});
       }
-    } else {
-      // Or, create empty directory
-      fs.mkdirSync(importKeystoresDirpath, {recursive: true});
     }
   }
 
@@ -34,15 +47,7 @@ export class KeymanagerApi implements Api {
    *
    * https://github.com/ethereum/keymanager-APIs/blob/0c975dae2ac6053c8245ebdb6a9f27c2f114f407/keymanager-oapi.yaml
    */
-  async listKeys(): Promise<{
-    data: {
-      validatingPubkey: PubkeyHex;
-      /** The derivation path (if present in the imported keystore) */
-      derivationPath?: string;
-      /** The key associated with this pubkey cannot be deleted from the API */
-      readonly?: boolean;
-    }[];
-  }> {
+  async listKeys(): ReturnType<Api["listKeys"]> {
     const pubkeys = this.validator.validatorStore.votingPubkeys();
     return {
       data: pubkeys.map((pubkey) => ({
@@ -70,12 +75,7 @@ export class KeymanagerApi implements Api {
     keystoresStr: KeystoreStr[],
     passwords: string[],
     slashingProtectionStr: SlashingProtectionData
-  ): Promise<{
-    data: {
-      status: ImportStatus;
-      message?: string;
-    }[];
-  }> {
+  ): ReturnType<Api["importKeystores"]> {
     // The arguments to this function is passed in within the body of an HTTP request
     // hence fastify will parse it into an object before this function is called.
     // Even though the slashingProtectionStr is typed as SlashingProtectionData,
@@ -144,15 +144,7 @@ export class KeymanagerApi implements Api {
    *
    * https://github.com/ethereum/keymanager-APIs/blob/0c975dae2ac6053c8245ebdb6a9f27c2f114f407/keymanager-oapi.yaml
    */
-  async deleteKeystores(
-    pubkeysHex: string[]
-  ): Promise<{
-    data: {
-      status: DeletionStatus;
-      message?: string;
-    }[];
-    slashingProtection: SlashingProtectionData;
-  }> {
+  async deleteKeystores(pubkeysHex: PubkeyHex[]): ReturnType<Api["deleteKeystores"]> {
     const deletedKey: boolean[] = [];
     const statuses = new Array<{status: DeletionStatus; message?: string}>(pubkeysHex.length);
 
@@ -213,7 +205,137 @@ export class KeymanagerApi implements Api {
     };
   }
 
-  private getKeystoreFilepath(pubkeyHex: string): string {
-    return path.join(this.importKeystoresDirpath, `${KEY_IMPORTED_PREFIX}_${pubkeyHex}.json`);
+  /**
+   * List all remote validating pubkeys known to this validator client binary
+   */
+  async listRemoteKeys(): ReturnType<Api["listRemoteKeys"]> {
+    const remoteKeys: SignerDefinition[] = [];
+    for (const signer of this.validator.validatorStore.getSigners()) {
+      if (signer.type === SignerType.Remote) {
+        remoteKeys.push({
+          pubkey: signer.pubkeyHex,
+          url: signer.externalSignerUrl,
+          readonly: false,
+        });
+      }
+    }
+
+    return {
+      data: remoteKeys,
+    };
   }
+
+  /**
+   * Import remote keys for the validator client to request duties for
+   */
+  async importRemoteKeys(remoteSigners: SignerDefinition[]): ReturnType<Api["importRemoteKeys"]> {
+    const results = remoteSigners.map(
+      (remoteSigner): ResponseStatus<ImportRemoteKeyStatus> => {
+        // Check if key exists
+        if (this.validator.validatorStore.hasVotingPubkey(remoteSigner.pubkey)) {
+          return {status: ImportRemoteKeyStatus.duplicate};
+        }
+
+        // Else try to add it
+        try {
+          this.validator.validatorStore.addSigner({
+            type: SignerType.Remote,
+            pubkeyHex: remoteSigner.pubkey,
+            externalSignerUrl: remoteSigner.url,
+          });
+
+          const remoteKeyFilepath = this.getRemoteKeyFilepath(remoteSigner.pubkey);
+          writeRemoteSignerDefinition(remoteKeyFilepath, remoteSigner);
+
+          return {status: ImportRemoteKeyStatus.imported};
+        } catch (e) {
+          return {status: ImportRemoteKeyStatus.error, message: (e as Error).message};
+        }
+      }
+    );
+
+    return {
+      data: results,
+    };
+  }
+
+  /**
+   * DELETE must delete all keys from `request.pubkeys` that are known to the validator client and exist in its
+   * persistent storage.
+   * DELETE should never return a 404 response, even if all pubkeys from request.pubkeys have no existing keystores.
+   */
+  async deleteRemoteKeys(pubkeys: PubkeyHex[]): ReturnType<Api["deleteRemoteKeys"]> {
+    const results = pubkeys.map(
+      (pubkey): ResponseStatus<DeleteRemoteKeyStatus> => {
+        // Check if key exists
+        const found = this.validator.validatorStore.removeSigner(pubkey);
+
+        if (!found) {
+          return {status: DeleteRemoteKeyStatus.not_found};
+        }
+
+        try {
+          const remoteKeyFilepath = this.getRemoteKeyFilepath(pubkey);
+          fs.unlinkSync(remoteKeyFilepath);
+
+          return {status: DeleteRemoteKeyStatus.deleted};
+        } catch (e) {
+          // TODO: Consider checking for e.code === "ENOENT" and return not_found
+          // However currently not doing so, because it's an error of inconsistency if a known key is not in disk
+          return {status: DeleteRemoteKeyStatus.error, message: (e as Error).message};
+        }
+      }
+    );
+
+    return {
+      data: results,
+    };
+  }
+
+  private getKeystoreFilepath(pubkeyHex: string): string {
+    return path.join(this.opts.importedKeystoresDirpath, `${KEYSTORE_IMPORTED_PREFIX}_${pubkeyHex}.json`);
+  }
+
+  private getRemoteKeyFilepath(pubkeyHex: string): string {
+    return path.join(this.opts.importedRemoteKeysDirpath, `${pubkeyHex}.json`);
+  }
+}
+
+/**
+ * Read all RemoteSigner definition files from a `importedRemoteKeysDirpath`
+ */
+export function readRemoteSignerDefinitions(dirpath: string): SignerDefinition[] {
+  return fs
+    .readdirSync(dirpath)
+    .filter((filename) => filename.endsWith(".json"))
+    .map((filename) => readRemoteSignerDefinition(path.join(dirpath, filename)));
+}
+
+/**
+ * Validate SignerDefinition from un-trusted disk file.
+ * Performs type validation and re-maps only expected properties.
+ */
+export function readRemoteSignerDefinition(filepath: string): SignerDefinition {
+  const remoteSignerStr = fs.readFileSync(filepath, "utf8");
+  const remoteSignerJson = JSON.parse(remoteSignerStr) as SignerDefinition;
+  if (typeof remoteSignerJson.pubkey !== "string") throw Error(`invalid SignerDefinition.pubkey ${filepath}`);
+  if (typeof remoteSignerJson.url !== "string") throw Error(`invalid SignerDefinition.url ${filepath}`);
+  return {
+    pubkey: remoteSignerJson.pubkey,
+    url: remoteSignerJson.url,
+    readonly: false,
+  };
+}
+
+/**
+ * Re-map all properties to ensure they are defined.
+ * To just write `remoteSigner` is not safe since it may contain extra properties too.
+ */
+export function writeRemoteSignerDefinition(filepath: string, remoteSigner: SignerDefinition): void {
+  const remoteSignerJson: SignerDefinition = {
+    pubkey: remoteSigner.pubkey,
+    url: remoteSigner.url,
+    readonly: false,
+  };
+  fs.writeFileSync(filepath, JSON.stringify(remoteSignerJson));
 }

--- a/packages/lodestar/test/e2e/keymanager/keymanager.test.ts
+++ b/packages/lodestar/test/e2e/keymanager/keymanager.test.ts
@@ -344,7 +344,10 @@ describe("keymanager delete and import test", async function () {
     afterEachCallbacks.push(() => keystoresDir.removeCallback());
     afterEachCallbacks.push(() => tokenDir.removeCallback());
 
-    const keymanagerApi = new KeymanagerApi(validators[0], keystoresDir.name);
+    const keymanagerApi = new KeymanagerApi(validators[0], {
+      importedKeystoresDirpath: keystoresDir.name,
+      importedRemoteKeysDirpath: keystoresDir.name,
+    });
 
     return {config, validators, secretKeys, logger, keymanagerApi, tokenDir: tokenDir.name};
   }
@@ -398,7 +401,10 @@ function createKeymanager(
   config: IBeaconConfig,
   logger: WinstonLogger
 ): KeymanagerServer {
-  const keymanagerApi = new KeymanagerApi(vc, importKeystoresPath);
+  const keymanagerApi = new KeymanagerApi(vc, {
+    importedKeystoresDirpath: importKeystoresPath,
+    importedRemoteKeysDirpath: `${importKeystoresPath}_remotekeys`,
+  });
 
   return new KeymanagerServer(
     {host: "127.0.0.1", port, cors: "*", isAuthEnabled: false, tokenDir: logFilesDir},

--- a/packages/lodestar/test/utils/node/validator.ts
+++ b/packages/lodestar/test/utils/node/validator.ts
@@ -12,6 +12,7 @@ import {
   SignerLocal,
 } from "@chainsafe/lodestar-validator";
 import type {SecretKey} from "@chainsafe/bls/types";
+import {KEYSTORE_IMPORTED_PREFIX} from "@chainsafe/lodestar-keymanager-server";
 import {BeaconNode} from "../../../src/node/index.js";
 import {testLogger, TestLoggerOpts} from "../logger.js";
 import {getLocalSecretKeys} from "../../../../cli/src/cmds/validator/keys.js";
@@ -42,7 +43,8 @@ export async function getAndInitValidatorsWithKeystore({
   };
 }> {
   const keystoreDir = tmp.dirSync({unsafeCleanup: true});
-  const keystoreFile = path.join(`${keystoreDir.name}`, `${keystorePubKey}.json`);
+  // TODO: This hardcoded value is necessary for a keymanager test
+  const keystoreFile = path.join(`${keystoreDir.name}`, `${KEYSTORE_IMPORTED_PREFIX}_${keystorePubKey}.json`);
 
   fs.writeFileSync(keystoreFile, keystoreContent, {encoding: "utf8", flag: "wx"});
 

--- a/packages/lodestar/test/utils/node/validator.ts
+++ b/packages/lodestar/test/utils/node/validator.ts
@@ -12,7 +12,6 @@ import {
   SignerLocal,
 } from "@chainsafe/lodestar-validator";
 import type {SecretKey} from "@chainsafe/bls/types";
-import {KEY_IMPORTED_PREFIX} from "@chainsafe/lodestar-keymanager-server";
 import {BeaconNode} from "../../../src/node/index.js";
 import {testLogger, TestLoggerOpts} from "../logger.js";
 import {getLocalSecretKeys} from "../../../../cli/src/cmds/validator/keys.js";
@@ -43,7 +42,7 @@ export async function getAndInitValidatorsWithKeystore({
   };
 }> {
   const keystoreDir = tmp.dirSync({unsafeCleanup: true});
-  const keystoreFile = path.join(`${keystoreDir.name}`, `${KEY_IMPORTED_PREFIX}_${keystorePubKey}.json`);
+  const keystoreFile = path.join(`${keystoreDir.name}`, `${keystorePubKey}.json`);
 
   fs.writeFileSync(keystoreFile, keystoreContent, {encoding: "utf8", flag: "wx"});
 

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -140,6 +140,10 @@ export class ValidatorStore {
     return this.validators.get(pubkeyHex)?.signer;
   }
 
+  getSigners(): Signer[] {
+    return Array.from(this.validators.values());
+  }
+
   removeSigner(pubkeyHex: PubkeyHex): boolean {
     return this.indicesService.removeForKey(pubkeyHex) || this.validators.delete(pubkeyHex);
   }

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -140,10 +140,6 @@ export class ValidatorStore {
     return this.validators.get(pubkeyHex)?.signer;
   }
 
-  getSigners(): Signer[] {
-    return Array.from(this.validators.values());
-  }
-
   removeSigner(pubkeyHex: PubkeyHex): boolean {
     return this.indicesService.removeForKey(pubkeyHex) || this.validators.delete(pubkeyHex);
   }


### PR DESCRIPTION
**Motivation**

The Keymanager API now has [Remote Key Manager](https://ethereum.github.io/keymanager-APIs/#/Remote%20Key%20Manager) which are set of endpoints for key management of external keys. 

DAppNode requires this API to be implemented to safely manage its interactions with the local web3signer.

**Description**

- [x] Adds required routes to the keymanager API impl and routes declarations
- [x] Wire with validator instance
- [x] Decide in which format to persist remote signer declarations
- [ ] Ensure imported remote signers are consumed after restarting the validator

**Blocked by / related**

- https://github.com/ChainSafe/lodestar/issues/4105
- https://github.com/ChainSafe/lodestar/pull/4104

Closes https://github.com/ChainSafe/lodestar/issues/3886