### PR TITLE
Simplify HttpClient global AbortSignal handling

### DIFF
--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -20,7 +20,7 @@ type ClientModules = HttpClientModules & {
 /**
  * REST HTTP client for all routes
  */
-export function getClient(opts: HttpClientOptions, modules: ClientModules): Api {
+export function getClient(opts: HttpClientOptions, modules: ClientModules): Api & {httpClient: IHttpClient} {
   const {config} = modules;
   const httpClient = modules.httpClient ?? new HttpClient(opts, modules);
 
@@ -33,5 +33,8 @@ export function getClient(opts: HttpClientOptions, modules: ClientModules): Api 
     lodestar: lodestar.getClient(config, httpClient),
     node: node.getClient(config, httpClient),
     validator: validator.getClient(config, httpClient),
+
+    // Extra for access to `IHttpClient.setAbortSignal`
+    httpClient,
   };
 }

--- a/packages/api/test/unit/client/httpClient.test.ts
+++ b/packages/api/test/unit/client/httpClient.test.ts
@@ -158,7 +158,7 @@ describe("httpClient json client", () => {
 
     const controller = new AbortController();
     const signal = controller.signal;
-    const httpClient = new HttpClient({baseUrl, getAbortSignal: () => signal});
+    const httpClient = new HttpClient({baseUrl, signal});
 
     setTimeout(() => controller.abort(), 10);
 


### PR DESCRIPTION
**Motivation**

Simplify how global signals are provided to the HttpClient instance.

- From https://github.com/ChainSafe/lodestar/pull/4107

**Description**

Instead of providing a function to get the global signal everytime, add a method to update the global signal only when necessary. In my opinion it makes consuming the library less awkward, and this complexity is hidden for consumers that don't need to update the signals.