### PR TITLE
Remove NPM instructions and add disclaimer

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,25 +43,12 @@ Lodestar should now be ready for use:
 ./lodestar --help
 ```
 
-## Install from NPM
+## Install from NPM [redacted]
 
-Install globally
-
-```
-npm install -g @chainsafe/lodestar-cli
-```
-
-or
-
-```
-yarn global add @chainsafe/lodestar-cli
-```
-
-Lodestar should now be ready to use:
-
-```
-lodestar --help
-```
+<!-- prettier-ignore-start -->
+!!! danger
+    For mainnet (production) usage, we only recommend installing with docker due to NPM supply chain attacks, [example here](https://hackaday.com/2021/10/22/supply-chain-attack-npm-library-used-by-facebook-and-others-was-compromised/). [Until a safer installation method has been found](https://github.com/ChainSafe/lodestar/issues/3596), do not use this install method except for experimental purposes.
+<!-- prettier-ignore-end -->
 
 ## Install with docker
 
@@ -69,7 +56,7 @@ The [`chainsafe/lodestar`](https://hub.docker.com/r/chainsafe/lodestar) Docker H
 
 <!-- prettier-ignore-start -->
 !!! info
-    The Docker Hub image in run on CI every dev release on `unstable`
+    The Docker Hub image is run on CI every dev release on `unstable`
 <!-- prettier-ignore-end -->
 
 Ensure you have Docker installed by issuing the command:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,7 +43,7 @@ Lodestar should now be ready for use:
 ./lodestar --help
 ```
 
-## Install from NPM [redacted]
+## Install from NPM [not recommended]
 
 <!-- prettier-ignore-start -->
 !!! danger


### PR DESCRIPTION
**Motivation**

Do not endorse NPM installation due to supply chain attacks addressed in #4113. We must resolve #3596 with #3470 before re-implementing instructions for using NPM.

**Description**

Redacts NPM installation instructions and adds a warning to docs for the reasoning. 
