### PR TITLE
Add JSON RPC client metrics

### DIFF
--- a/packages/api/src/client/utils/metrics.ts
+++ b/packages/api/src/client/utils/metrics.ts
@@ -1,6 +1,6 @@
 export type Metrics = {
   requestTime: IHistogram<"routeId">;
-  errors: IGauge<"routeId">;
+  requestErrors: IGauge<"routeId">;
 };
 
 type LabelValues<T extends string> = Partial<Record<T, string | number>>;

--- a/packages/lodestar/src/eth1/index.ts
+++ b/packages/lodestar/src/eth1/index.ts
@@ -74,7 +74,8 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
     opts: Eth1Options,
     modules: Eth1DepositDataTrackerModules & Eth1MergeBlockTrackerModules & {eth1Provider?: IEth1Provider}
   ) {
-    const eth1Provider = modules.eth1Provider || new Eth1Provider(modules.config, opts, modules.signal);
+    const eth1Provider =
+      modules.eth1Provider || new Eth1Provider(modules.config, opts, modules.signal, modules.metrics?.eth1HttpClient);
 
     this.eth1DepositDataTracker = opts.disableEth1DepositDataTracker
       ? null

--- a/packages/lodestar/src/eth1/interface.ts
+++ b/packages/lodestar/src/eth1/interface.ts
@@ -91,4 +91,6 @@ export interface IRpcPayload<P = IJson[]> {
 
 export type ReqOpts = {
   timeout?: number;
+  // To label request metrics
+  routeId?: string;
 };

--- a/packages/lodestar/src/eth1/interface.ts
+++ b/packages/lodestar/src/eth1/interface.ts
@@ -88,9 +88,3 @@ export interface IRpcPayload<P = IJson[]> {
   method: string;
   params: P;
 }
-
-export type ReqOpts = {
-  timeout?: number;
-  // To label request metrics
-  routeId?: string;
-};

--- a/packages/lodestar/src/eth1/provider/eth1Provider.ts
+++ b/packages/lodestar/src/eth1/provider/eth1Provider.ts
@@ -11,7 +11,7 @@ import {Eth1Block, IEth1Provider} from "../interface.js";
 import {Eth1Options} from "../options.js";
 import {isValidAddress} from "../../util/address.js";
 import {EthJsonRpcBlockRaw} from "../interface.js";
-import {JsonRpcHttpClient} from "./jsonRpcHttpClient.js";
+import {JsonRpcHttpClient, JsonRpcHttpClientMetrics} from "./jsonRpcHttpClient.js";
 import {isJsonRpcTruncatedError, quantityToNum, numToQuantity, dataToBytes} from "./utils.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -45,7 +45,8 @@ export class Eth1Provider implements IEth1Provider {
   constructor(
     config: Pick<IChainConfig, "DEPOSIT_CONTRACT_ADDRESS">,
     opts: Pick<Eth1Options, "depositContractDeployBlock" | "providerUrls" | "jwtSecretHex">,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    metrics?: JsonRpcHttpClientMetrics | null
   ) {
     this.deployBlock = opts.depositContractDeployBlock ?? 0;
     this.depositContractAddress = toHexString(config.DEPOSIT_CONTRACT_ADDRESS);
@@ -54,6 +55,7 @@ export class Eth1Provider implements IEth1Provider {
       // Don't fallback with is truncated error. Throw early and let the retry on this class handle it
       shouldNotFallback: isJsonRpcTruncatedError,
       jwtSecret: opts.jwtSecretHex ? fromHex(opts.jwtSecretHex) : undefined,
+      metrics: metrics,
     });
   }
 

--- a/packages/lodestar/src/eth1/provider/jsonRpcHttpClient.ts
+++ b/packages/lodestar/src/eth1/provider/jsonRpcHttpClient.ts
@@ -4,7 +4,7 @@ import fetch from "cross-fetch";
 
 import {ErrorAborted, TimeoutError} from "@chainsafe/lodestar-utils";
 import {IGauge, IHistogram} from "../../metrics/interface.js";
-import {IJson, IRpcPayload, ReqOpts} from "../interface.js";
+import {IJson, IRpcPayload} from "../interface.js";
 import {encodeJwtToken} from "./jwt.js";
 /**
  * Limits the amount of response text printed with RPC or parsing errors
@@ -24,6 +24,12 @@ interface IRpcResponseError {
     message: string; // "The method eth_none does not exist/is not available"
   };
 }
+
+export type ReqOpts = {
+  timeout?: number;
+  // To label request metrics
+  routeId?: string;
+};
 
 export type JsonRpcHttpClientMetrics = {
   requestTime: IHistogram<"routeId">;
@@ -155,7 +161,8 @@ export class JsonRpcHttpClient implements IJsonRpcHttpClient {
     const onParentSignalAbort = (): void => controller.abort();
     this.opts?.signal?.addEventListener("abort", onParentSignalAbort, {once: true});
 
-    const routeId = opts?.routeId; // TODO: Should default to "unknown"?
+    // Default to "unknown" to prevent mixing metrics with others.
+    const routeId = opts?.routeId ?? "unknown";
     const timer = this.metrics?.requestTime.startTimer({routeId});
     this.activeRequests++;
 

--- a/packages/lodestar/src/executionEngine/http.ts
+++ b/packages/lodestar/src/executionEngine/http.ts
@@ -13,6 +13,7 @@ import {
   quantityToBigint,
 } from "../eth1/provider/utils.js";
 import {IJsonRpcHttpClient} from "../eth1/provider/jsonRpcHttpClient.js";
+import {IMetrics} from "../metrics/index.js";
 import {
   ExecutePayloadStatus,
   ExecutePayloadResponse,
@@ -59,14 +60,13 @@ export class ExecutionEngineHttp implements IExecutionEngine {
   readonly payloadIdCache = new PayloadIdCache();
   private readonly rpc: IJsonRpcHttpClient;
 
-  constructor(opts: ExecutionEngineHttpOpts, signal: AbortSignal, rpc?: IJsonRpcHttpClient) {
-    this.rpc =
-      rpc ??
-      new JsonRpcHttpClient(opts.urls, {
-        signal,
-        timeout: opts.timeout,
-        jwtSecret: opts.jwtSecretHex ? fromHex(opts.jwtSecretHex) : undefined,
-      });
+  constructor(opts: ExecutionEngineHttpOpts, signal: AbortSignal, metrics?: IMetrics | null) {
+    this.rpc = new JsonRpcHttpClient(opts.urls, {
+      signal,
+      timeout: opts.timeout,
+      jwtSecret: opts.jwtSecretHex ? fromHex(opts.jwtSecretHex) : undefined,
+      metrics: metrics?.executionEnginerHttpClient,
+    });
   }
 
   /**

--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -960,5 +960,55 @@ export function createLodestarMetrics(
         help: "Eth1 dynamic follow distance changed by the deposit tracker if blocks are slow",
       }),
     },
+
+    eth1HttpClient: {
+      requestTime: register.histogram<"routeId">({
+        name: "lodestar_eth1_http_client_request_time_seconds",
+        help: "eth1 JsonHttpClient - histogram or roundtrip request times",
+        // Provide max resolution on problematic values around 1 second
+        buckets: [0.1, 0.5, 1, 2, 5, 15],
+      }),
+      requestErrors: register.gauge<"routeId">({
+        name: "lodestar_eth1_http_client_request_errors_total",
+        help: "eth1 JsonHttpClient - total count of request errors",
+      }),
+      requestUsedFallbackUrl: register.gauge({
+        name: "lodestar_eth1_http_client_request_used_fallback_url_total",
+        help: "eth1 JsonHttpClient - total count of requests on fallback url(s)",
+      }),
+      activeRequests: register.gauge({
+        name: "lodestar_eth1_http_client_active_requests",
+        help: "eth1 JsonHttpClient - current count of active requests",
+      }),
+      configUrlsCount: register.gauge({
+        name: "lodestar_eth1_http_client_config_urls_count",
+        help: "eth1 JsonHttpClient - static config urls count",
+      }),
+    },
+
+    executionEnginerHttpClient: {
+      requestTime: register.histogram<"routeId">({
+        name: "lodestar_execution_engine_http_client_request_time_seconds",
+        help: "ExecutionEngineHttp client - histogram or roundtrip request times",
+        // Provide max resolution on problematic values around 1 second
+        buckets: [0.1, 0.5, 1, 2, 5, 15],
+      }),
+      requestErrors: register.gauge<"routeId">({
+        name: "lodestar_execution_engine_http_client_request_errors_total",
+        help: "ExecutionEngineHttp client - total count of request errors",
+      }),
+      requestUsedFallbackUrl: register.gauge({
+        name: "lodestar_execution_engine_http_client_request_used_fallback_url_total",
+        help: "ExecutionEngineHttp client - total count of requests on fallback url(s)",
+      }),
+      activeRequests: register.gauge({
+        name: "lodestar_execution_engine_http_client_active_requests",
+        help: "ExecutionEngineHttp client - current count of active requests",
+      }),
+      configUrlsCount: register.gauge({
+        name: "lodestar_execution_engine_http_client_config_urls_count",
+        help: "ExecutionEngineHttp client - static config urls count",
+      }),
+    },
   };
 }

--- a/packages/validator/src/metrics.ts
+++ b/packages/validator/src/metrics.ts
@@ -311,9 +311,9 @@ export function getMetrics(register: MetricsRegister, gitData: LodestarGitData) 
         buckets: [0.01, 0.1, 1, 5],
       }),
 
-      errors: register.gauge<{routeId: string}>({
-        name: "vc_rest_api_client_errors_total",
-        help: "Total count of errors calling the REST API client by routeId",
+      requestErrors: register.gauge<{routeId: string}>({
+        name: "vc_rest_api_client_request_errors_total",
+        help: "Total count of errors on REST API client requests by routeId",
         labelNames: ["routeId"],
       }),
     },


### PR DESCRIPTION
**Motivation**

- More metrics https://github.com/ChainSafe/lodestar/issues/2468

**Description**

Add JSON RPC client metrics

Apply to both execution engine client, and "previous" eth1 client