### PR TITLE
Fix publish stable workflow

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Determine release type
         id: release_type
         run: |
-          STABLE_COMMIT=$(git log --pretty="%h" -n 1 stable)
+          STABLE_COMMIT=$(git log --pretty="%h" -n 1 refs/remotes/origin/stable)
           TAG_COMMIT=$(git log --pretty="%h" -n 1 $GITHUB_REF)
           echo ::set-output name=stable_commit::$STABLE_COMMIT
           echo ::set-output name=tag_commit::$TAG_COMMIT


### PR DESCRIPTION
See https://github.com/ChainSafe/lodestar/actions/runs/2457085743

```
Run STABLE_COMMIT=$(git log --pretty="%h" -n 1 stable)
fatal: ambiguous argument 'stable': unknown revision or path not in the working tree.
```