### PR TITLE
Improve UnknownBlock sync

### DIFF
--- a/packages/lodestar/src/sync/unknownBlock.ts
+++ b/packages/lodestar/src/sync/unknownBlock.ts
@@ -146,7 +146,14 @@ export class UnknownBlockSync {
       } else if (parentSlot <= finalizedSlot) {
         // the common ancestor of the downloading chain and canonical chain should be at least the finalized slot and
         // we should found it through forkchoice. If not, we should penalize all peers sending us this block chain
-        this.logger.error("Downloaded block parent is before finalized slot", {finalizedSlot, parentSlot});
+        // 0 - 1 - ... - n - finalizedSlot
+        //                \
+        //                parent 1 - parent 2 - ... - unknownParent block
+        this.logger.error("Downloaded block parent is before finalized slot", {
+          finalizedSlot,
+          parentSlot,
+          parentRoot: toHexString(this.config.getForkTypes(parentSlot).BeaconBlock.hashTreeRoot(signedBlock.message)),
+        });
         this.removeAndDownscoreAllDescendants(block);
       } else {
         this.onUnknownBlock(signedBlock, peerIdStr);

--- a/packages/lodestar/test/unit/sync/unknownBlock.test.ts
+++ b/packages/lodestar/test/unit/sync/unknownBlock.test.ts
@@ -1,11 +1,11 @@
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/default";
-import {IForkChoice} from "@chainsafe/lodestar-fork-choice";
+import {IForkChoice, IProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {ssz} from "@chainsafe/lodestar-types";
 import {notNullish, sleep} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
 import {IBeaconChain} from "../../../src/chain/index.js";
-import {INetwork, IReqResp, NetworkEvent, NetworkEventBus} from "../../../src/network/index.js";
+import {INetwork, IReqResp, NetworkEvent, NetworkEventBus, PeerAction} from "../../../src/network/index.js";
 import {UnknownBlockSync} from "../../../src/sync/unknownBlock.js";
 import {testLogger} from "../../utils/logger.js";
 import {getValidPeerId} from "../../utils/peer.js";
@@ -13,71 +13,90 @@ import {getValidPeerId} from "../../utils/peer.js";
 describe("sync / UnknownBlockSync", () => {
   const logger = testLogger();
 
-  it("fetch and process multiple unknown block parents", async () => {
-    const peer = getValidPeerId();
-    const peerIdStr = peer.toB58String();
-    const blockA = ssz.phase0.SignedBeaconBlock.defaultValue();
-    const blockB = ssz.phase0.SignedBeaconBlock.defaultValue();
-    const blockC = ssz.phase0.SignedBeaconBlock.defaultValue();
-    blockA.message.slot = 1;
-    blockB.message.slot = 2;
-    blockC.message.slot = 3;
-    const blockRoot0 = Buffer.alloc(32, 0x00);
-    const blockRootA = ssz.phase0.BeaconBlock.hashTreeRoot(blockA.message);
-    blockB.message.parentRoot = blockRootA;
-    const blockRootB = ssz.phase0.BeaconBlock.hashTreeRoot(blockB.message);
-    blockC.message.parentRoot = blockRootB;
-    const blockRootC = ssz.phase0.BeaconBlock.hashTreeRoot(blockC.message);
-    const blockRootHex0 = toHexString(blockRoot0);
-    const blockRootHexA = toHexString(blockRootA);
-    const blockRootHexB = toHexString(blockRootB);
-    const blockRootHexC = toHexString(blockRootC);
+  const testCases: {id: string; finalizedSlot: number; reportPeer: boolean}[] = [
+    {id: "fetch and process multiple unknown block parents", finalizedSlot: 0, reportPeer: false},
+    {id: "downloaded parent is before finalized slot", finalizedSlot: 2, reportPeer: true},
+  ];
 
-    const blocksByRoot = new Map([
-      [blockRootHexA, blockA],
-      [blockRootHexB, blockB],
-    ]);
+  for (const {id, finalizedSlot, reportPeer} of testCases) {
+    it(id, async () => {
+      const peer = getValidPeerId();
+      const peerIdStr = peer.toB58String();
+      const blockA = ssz.phase0.SignedBeaconBlock.defaultValue();
+      const blockB = ssz.phase0.SignedBeaconBlock.defaultValue();
+      const blockC = ssz.phase0.SignedBeaconBlock.defaultValue();
+      blockA.message.slot = 1;
+      blockB.message.slot = 2;
+      blockC.message.slot = 3;
+      const blockRoot0 = Buffer.alloc(32, 0x00);
+      const blockRootA = ssz.phase0.BeaconBlock.hashTreeRoot(blockA.message);
+      blockB.message.parentRoot = blockRootA;
+      const blockRootB = ssz.phase0.BeaconBlock.hashTreeRoot(blockB.message);
+      blockC.message.parentRoot = blockRootB;
+      const blockRootC = ssz.phase0.BeaconBlock.hashTreeRoot(blockC.message);
+      const blockRootHex0 = toHexString(blockRoot0);
+      const blockRootHexA = toHexString(blockRootA);
+      const blockRootHexB = toHexString(blockRootB);
+      const blockRootHexC = toHexString(blockRootC);
 
-    const reqResp: Partial<IReqResp> = {
-      beaconBlocksByRoot: async (_peer, roots) =>
-        Array.from(roots)
-          .map((root) => blocksByRoot.get(toHexString(root)))
-          .filter(notNullish),
-    };
+      const blocksByRoot = new Map([
+        [blockRootHexA, blockA],
+        [blockRootHexB, blockB],
+      ]);
 
-    const network: Partial<INetwork> = {
-      events: new NetworkEventBus(),
-      getConnectedPeers: () => [peer],
-      reqResp: reqResp as IReqResp,
-    };
+      const reqResp: Partial<IReqResp> = {
+        beaconBlocksByRoot: async (_peer, roots) =>
+          Array.from(roots)
+            .map((root) => blocksByRoot.get(toHexString(root)))
+            .filter(notNullish),
+      };
 
-    const forkChoiceKnownRoots = new Set([blockRootHex0]);
-    const forkChoice: Pick<IForkChoice, "hasBlock"> = {
-      hasBlock: (root) => forkChoiceKnownRoots.has(toHexString(root)),
-    };
+      let reportPeerResolveFn: (value: Parameters<INetwork["reportPeer"]>) => void;
+      const reportPeerPromise = new Promise<Parameters<INetwork["reportPeer"]>>((r) => (reportPeerResolveFn = r));
 
-    const chain: Partial<IBeaconChain> = {
-      forkChoice: forkChoice as IForkChoice,
-      processBlock: async (block) => {
-        if (!forkChoice.hasBlock(block.message.parentRoot)) throw Error("Unknown parent");
-        // Simluate adding the block to the forkchoice
-        const blockRootHex = toHexString(ssz.phase0.BeaconBlock.hashTreeRoot(block.message));
-        forkChoiceKnownRoots.add(blockRootHex);
-      },
-    };
+      const network: Partial<INetwork> = {
+        events: new NetworkEventBus(),
+        getConnectedPeers: () => [peer],
+        reqResp: reqResp as IReqResp,
+        reportPeer: (peerId, action, actionName) => reportPeerResolveFn([peerId, action, actionName]),
+      };
 
-    new UnknownBlockSync(config, network as INetwork, chain as IBeaconChain, logger, null);
-    network.events?.emit(NetworkEvent.unknownBlockParent, blockC, peerIdStr);
+      const forkChoiceKnownRoots = new Set([blockRootHex0]);
+      const forkChoice: Pick<IForkChoice, "hasBlock" | "getFinalizedBlock"> = {
+        hasBlock: (root) => forkChoiceKnownRoots.has(toHexString(root)),
+        getFinalizedBlock: () => ({slot: finalizedSlot} as IProtoBlock),
+      };
 
-    // Wait for all blocks to be in ForkChoice store
-    while (forkChoiceKnownRoots.size < 3) {
-      await sleep(10);
-    }
+      const chain: Partial<IBeaconChain> = {
+        forkChoice: forkChoice as IForkChoice,
+        processBlock: async (block) => {
+          if (!forkChoice.hasBlock(block.message.parentRoot)) throw Error("Unknown parent");
+          // Simluate adding the block to the forkchoice
+          const blockRootHex = toHexString(ssz.phase0.BeaconBlock.hashTreeRoot(block.message));
+          forkChoiceKnownRoots.add(blockRootHex);
+        },
+      };
 
-    // After completing the sync, all blocks should be in the ForkChoice
-    expect(Array.from(forkChoiceKnownRoots.values())).to.deep.equal(
-      [blockRootHex0, blockRootHexA, blockRootHexB, blockRootHexC],
-      "Wrong blocks in mock ForkChoice"
-    );
-  });
+      new UnknownBlockSync(config, network as INetwork, chain as IBeaconChain, logger, null);
+      network.events?.emit(NetworkEvent.unknownBlockParent, blockC, peerIdStr);
+
+      if (reportPeer) {
+        const err = await reportPeerPromise;
+        expect(err[0].toB58String()).equal(peerIdStr);
+        expect([err[1], err[2]]).to.be.deep.equal([PeerAction.LowToleranceError, "BadBlockByRoot"]);
+      } else {
+        // happy path
+        // Wait for all blocks to be in ForkChoice store
+        while (forkChoiceKnownRoots.size < 3) {
+          await sleep(10);
+        }
+
+        // After completing the sync, all blocks should be in the ForkChoice
+        expect(Array.from(forkChoiceKnownRoots.values())).to.deep.equal(
+          [blockRootHex0, blockRootHexA, blockRootHexB, blockRootHexC],
+          "Wrong blocks in mock ForkChoice"
+        );
+      }
+    });
+  }
 });


### PR DESCRIPTION
**Motivation**

UnknownBlock sync keep downloading blocks if the parent is unknown, we should have some conditions to stop this

**Description**

UnknownBlock sync: We should only download non-finalized blocks, penalize peers if downloaded blocks is before our finalized slot because it means that the chain we're downloading is conflicting to our finalized chain

For example

```
0 - 1 - ... - n  -  finalizedSlot
               \
                \
               parent 1 - parent 2 - ... - unknownParent block
```
