### PR TITLE
Apply preset to ENV from CLI args

### DIFF
--- a/packages/cli/src/applyPreset.ts
+++ b/packages/cli/src/applyPreset.ts
@@ -1,0 +1,54 @@
+// MUST import this file first before anything and not import any Lodestar code
+const network = valueOfArg("network");
+const preset = valueOfArg("preset");
+
+// Apply preset flag if present
+if (preset) {
+  process.env.LODESTAR_PRESET = preset;
+}
+
+// Translate network to preset
+else if (network) {
+  if (network === "dev") {
+    process.env.LODESTAR_PRESET = "minimal";
+  } else if (network === "gnosis") {
+    process.env.LODESTAR_PRESET = "gnosis";
+  }
+}
+
+// If running dev top level command `$ lodestar dev`, apply minimal
+else if (process.argv[2] === "dev") {
+  process.env.LODESTAR_PRESET = "minimal";
+  process.env.LODESTAR_NETWORK = "dev";
+}
+
+/**
+ * Valid syntax
+ * - `--preset minimal`
+ * - `--preset=minimal`
+ */
+function valueOfArg(argName: string): string | null {
+  // Syntax `--preset minimal`
+  // process.argv = ["--preset", "minimal"];
+
+  {
+    const index = process.argv.indexOf(`--${argName}`);
+    if (index > -1) {
+      return process.argv[index + 1] ?? "";
+    }
+  }
+
+  // Syntax `--preset=minimal`
+  {
+    const prefix = `--${argName}=`;
+    const item = process.argv.find((arg) => arg.startsWith(prefix));
+    if (item) {
+      return item.slice(prefix.length);
+    }
+  }
+
+  return null;
+}
+
+// Add empty export to make this a module
+export {};

--- a/packages/cli/src/applyPreset.ts
+++ b/packages/cli/src/applyPreset.ts
@@ -1,4 +1,17 @@
-// MUST import this file first before anything and not import any Lodestar code
+// MUST import this file first before anything and not import any Lodestar code.
+//
+// ## Rationale
+//
+// Lodestar implemented PRESET / CONFIG separation to allow importing types and preset constants directly
+// see https://github.com/ChainSafe/lodestar/pull/2585
+//
+// However this prevents dynamic configuration changes which is exactly what the CLI required before.
+// - The dev command can't apply the minimal preset dynamically
+// - `--network gnosis` can't apply a different preset dynamically
+//
+// Running this file allows us to keep a static export strategy while NOT requiring users to
+// set LODESTAR_PRESET manually every time.
+
 const network = valueOfArg("network");
 const preset = valueOfArg("preset");
 

--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -33,9 +33,8 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
   const enrArgs = parseEnrArgs(args);
   overwriteEnrWithCliArgs(enr, enrArgs, beaconNodeOptions.getWithDefaults());
 
-  // Custom paths different than regular beacon, validator paths
-  // network="dev" will store all data in separate dir than other networks
-  args.network = "dev";
+  // Note: defaults to network "dev", to all paths are custom and don't conflict with networks.
+  // Flag --reset cleans up the custom dirs on dev stop
   const beaconPaths = getBeaconPaths(args);
   const validatorPaths = getValidatorPaths(args);
   const beaconDbDir = beaconPaths.dbDir;

--- a/packages/cli/src/cmds/dev/options.ts
+++ b/packages/cli/src/cmds/dev/options.ts
@@ -1,9 +1,10 @@
 import {Options} from "yargs";
 import {ICliCommandOptions} from "../../util/index.js";
 import {beaconOptions, IBeaconArgs} from "../beacon/options.js";
-import {beaconNodeOptions} from "../../options/index.js";
-import {IValidatorCliArgs, validatorOptions} from "../validator/options.js";
+import {NetworkName} from "../../networks/index.js";
+import {beaconNodeOptions, globalOptions} from "../../options/index.js";
 import {KeymanagerArgs, keymanagerOptions} from "../../options/keymanagerOptions.js";
+import {IValidatorCliArgs, validatorOptions} from "../validator/options.js";
 
 type IDevOwnArgs = {
   genesisEth1Hash?: string;
@@ -68,6 +69,13 @@ const devOwnOptions: ICliCommandOptions<IDevOwnArgs> = {
  * Note: use beaconNodeOptions and globalOptions to make sure option key is correct
  */
 const externalOptionsOverrides: {[k: string]: Options} = {
+  // Custom paths different than regular beacon, validator paths
+  // network="dev" will store all data in separate dir than other networks
+  network: {
+    ...globalOptions.network,
+    default: "dev" as NetworkName,
+  },
+
   "sync.isSingleNode": {
     ...beaconNodeOptions["sync.isSingleNode"],
     defaultDescription: undefined,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+// MUST import first to apply preset from args
+import "./applyPreset.js";
 import {YargsError} from "./util/index.js";
 import {getLodestarCli, yarg} from "./cli.js";
 import "source-map-support/register.js";

--- a/packages/cli/src/networks/dev.ts
+++ b/packages/cli/src/networks/dev.ts
@@ -1,0 +1,8 @@
+export {minimalChainConfig as chainConfig} from "@chainsafe/lodestar-config/presets";
+
+/* eslint-disable max-len */
+
+export const depositContractDeployBlock = 0;
+export const genesisFileUrl = null;
+export const bootnodesFileUrl = null;
+export const bootEnrs = [];

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -8,12 +8,21 @@ import {Checkpoint} from "@chainsafe/lodestar-types/phase0";
 import {RecursivePartial, fromHex} from "@chainsafe/lodestar-utils";
 import {BeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import * as mainnet from "./mainnet.js";
+import * as dev from "./dev.js";
 import * as prater from "./prater.js";
 import * as kiln from "./kiln.js";
 import * as ropsten from "./ropsten.js";
 
-export type NetworkName = "mainnet" | "prater" | "kiln" | "ropsten" | "dev";
-export const networkNames: NetworkName[] = ["mainnet", "prater", "kiln", "ropsten"];
+export type NetworkName = "mainnet" | "dev" | "prater" | "kiln" | "ropsten";
+export const networkNames: NetworkName[] = [
+  "mainnet",
+  "prater",
+  "kiln",
+  "ropsten",
+
+  // Leave always as last network. The order matters for the --help printout
+  "dev",
+];
 
 export type WeakSubjectivityFetchOptions = {
   weakSubjectivityServerUrl: string;
@@ -26,12 +35,14 @@ function getNetworkData(
   chainConfig: IChainConfig;
   depositContractDeployBlock: number;
   genesisFileUrl: string | null;
-  bootnodesFileUrl: string;
+  bootnodesFileUrl: string | null;
   bootEnrs: string[];
 } {
   switch (network) {
     case "mainnet":
       return mainnet;
+    case "dev":
+      return dev;
     case "prater":
       return prater;
     case "kiln":
@@ -75,6 +86,10 @@ export function getGenesisFileUrl(network: NetworkName): string | null {
  */
 export async function fetchBootnodes(network: NetworkName): Promise<string[]> {
   const bootnodesFileUrl = getNetworkData(network).bootnodesFileUrl;
+  if (bootnodesFileUrl === null) {
+    return [];
+  }
+
   const bootnodesFile = await got.get(bootnodesFileUrl).text();
 
   const enrs: string[] = [];


### PR DESCRIPTION
**Motivation**

Lodestar implemented PRESET / CONFIG separation to allow importing types and preset constants directly, see https://github.com/ChainSafe/lodestar/pull/2585.

However this prevents dynamic configuration changes which is exactly what the CLI required before.
- The dev command can't apply the minimal preset dynamically
- `--network gnosis` can't apply a different preset dynamically

..but fear no more!

**Description**

In CLI index first thing before importing anything else:
- With a bare-bones CLI parser (Note: it has **duplicated logic**, but it's lesser of two evils) check --network and --preset
- If --preset is set, apply to LODESTAR_PRESET
- If --network is set, map to LODESTAR_PRESET
- if dev command apply minimal

This PR adds a new network `dev` which makes everything simpler to reason about.

**NOTE: this solution only applies to CLI usage. Programmatic usage must still manually set the LODESTAR_PRESET env**

Closes https://github.com/ChainSafe/lodestar/issues/3695