### PR TITLE
Support gnosis beacon chain with --network gnosis

### DIFF
--- a/packages/cli/src/networks/gnosis.ts
+++ b/packages/cli/src/networks/gnosis.ts
@@ -1,0 +1,18 @@
+import {gnosisChainConfig} from "@chainsafe/lodestar-config/networks";
+
+export const chainConfig = gnosisChainConfig;
+
+/* eslint-disable max-len */
+
+// eth1.providerUrls suggestion: https://rpc.gnosischain.com
+export const depositContractDeployBlock = 19469077;
+export const genesisFileUrl = null;
+export const bootnodesFileUrl = null;
+
+export const bootEnrs = [
+  // Gnosis Chain Team
+  "enr:-IS4QGmLwm7gFd0L0CEisllrb1op3v-wAGSc7_pwSMGgN3bOS9Fz7m1dWbwuuPHKqeETz9MbhjVuoWk0ohkyRv98kVoBgmlkgnY0gmlwhGjtlgaJc2VjcDI1NmsxoQLMdh0It9fJbuiLydZ9fpF6MRzgNle0vODaDiMqhbC7WIN1ZHCCIyg",
+  "enr:-IS4QFUVG3dvLPCUEI7ycRvFm0Ieg_ITa5tALmJ9LI7dJ6ieT3J4fF9xLRjOoB4ApV-Rjp7HeLKzyTWG1xRdbFBNZPQBgmlkgnY0gmlwhErP5weJc2VjcDI1NmsxoQOBbaJBvx0-w_pyZUhQl9A510Ho2T0grE0K8JevzES99IN1ZHCCIyg",
+  "enr:-Ku4QOQk8V-Hu2gxFzRXmLYIO4AvWDZhoMFwTf3n3DYm_mbsWv0ZitoqiN6JZUUj6Li6e1Jk1w2zFSVHKPMUP1g5tsgBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD5Jd3FAAAAZP__________gmlkgnY0gmlwhC1PTpmJc2VjcDI1NmsxoQL1Ynt5PoA0UOcHa1Rfn98rmnRlLzNuWTePPP4m4qHVroN1ZHCCKvg",
+  "enr:-Ku4QFaTwgoms-EiiRIfHUH3FXprWUFgjHg4UuWvilqoUQtDbmTszVIxUEOwQUmA2qkiP-T9wXjc_rVUuh9cU7WgwbgBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD5Jd3FAAAAZP__________gmlkgnY0gmlwhC0hBmCJc2VjcDI1NmsxoQOpsg1XCrXmCwZKcSTcycLwldoKUMHPUpMEVGeg_EEhuYN1ZHCCKvg",
+];

--- a/packages/cli/src/networks/gnosis.ts
+++ b/packages/cli/src/networks/gnosis.ts
@@ -1,6 +1,4 @@
-import {gnosisChainConfig} from "@chainsafe/lodestar-config/networks";
-
-export const chainConfig = gnosisChainConfig;
+export {gnosisChainConfig as chainConfig} from "@chainsafe/lodestar-config/networks";
 
 /* eslint-disable max-len */
 

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -9,13 +9,15 @@ import {RecursivePartial, fromHex} from "@chainsafe/lodestar-utils";
 import {BeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import * as mainnet from "./mainnet.js";
 import * as dev from "./dev.js";
+import * as gnosis from "./gnosis.js";
 import * as prater from "./prater.js";
 import * as kiln from "./kiln.js";
 import * as ropsten from "./ropsten.js";
 
-export type NetworkName = "mainnet" | "dev" | "prater" | "kiln" | "ropsten";
+export type NetworkName = "mainnet" | "dev" | "gnosis" | "prater" | "kiln" | "ropsten";
 export const networkNames: NetworkName[] = [
   "mainnet",
+  "gnosis",
   "prater",
   "kiln",
   "ropsten",
@@ -43,6 +45,8 @@ function getNetworkData(
       return mainnet;
     case "dev":
       return dev;
+    case "gnosis":
+      return gnosis;
     case "prater":
       return prater;
     case "kiln":

--- a/packages/config/src/chainConfig/networks/gnosis.ts
+++ b/packages/config/src/chainConfig/networks/gnosis.ts
@@ -1,0 +1,40 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import {fromHexString as b} from "@chainsafe/ssz";
+import {PresetName} from "@chainsafe/lodestar-params";
+import {IChainConfig} from "../types.js";
+import {chainConfig as mainnet} from "../presets/mainnet.js";
+
+/* eslint-disable max-len */
+
+export const gnosisChainConfig: IChainConfig = {
+  ...mainnet,
+
+  // NOTE: Only add diff values
+  PRESET_BASE: PresetName.gnosis,
+
+  SECONDS_PER_SLOT: 5,
+  SECONDS_PER_ETH1_BLOCK: 6,
+  ETH1_FOLLOW_DISTANCE: 1024,
+  CHURN_LIMIT_QUOTIENT: 4096,
+
+  // Ethereum Goerli testnet
+  DEPOSIT_CHAIN_ID: 100,
+  DEPOSIT_NETWORK_ID: 100,
+  DEPOSIT_CONTRACT_ADDRESS: b("0x0b98057ea310f4d31f2a452b414647007d1645d9"),
+
+  // Dec 8, 2021, 13:00 UTC
+  MIN_GENESIS_TIME: 1638968400,
+  MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 4096,
+  GENESIS_FORK_VERSION: b("0x00000064"),
+  GENESIS_DELAY: 6000,
+
+  // Forking
+  ALTAIR_FORK_VERSION: b("0x01000064"),
+  ALTAIR_FORK_EPOCH: 512,
+  // Bellatrix
+  BELLATRIX_FORK_VERSION: b("0x02000064"),
+  BELLATRIX_FORK_EPOCH: Infinity,
+  // Sharding
+  SHARDING_FORK_VERSION: b("0x03000064"),
+  SHARDING_FORK_EPOCH: Infinity,
+};

--- a/packages/config/src/networks.ts
+++ b/packages/config/src/networks.ts
@@ -1,14 +1,16 @@
 import {IChainConfig} from "./chainConfig/index.js";
 import {mainnetChainConfig} from "./chainConfig/networks/mainnet.js";
+import {gnosisChainConfig} from "./chainConfig/networks/gnosis.js";
 import {praterChainConfig} from "./chainConfig/networks/prater.js";
 import {kilnChainConfig} from "./chainConfig/networks/kiln.js";
 import {ropstenChainConfig} from "./chainConfig/networks/ropsten.js";
 
-export {mainnetChainConfig, praterChainConfig, kilnChainConfig, ropstenChainConfig};
+export {mainnetChainConfig, gnosisChainConfig, praterChainConfig, kilnChainConfig, ropstenChainConfig};
 
-export type NetworkName = "mainnet" | "prater" | "kiln" | "ropsten";
+export type NetworkName = "mainnet" | "gnosis" | "prater" | "kiln" | "ropsten";
 export const networksChainConfig: Record<NetworkName, IChainConfig> = {
   mainnet: mainnetChainConfig,
+  gnosis: gnosisChainConfig,
   prater: praterChainConfig,
   kiln: kilnChainConfig,
   ropsten: ropstenChainConfig,

--- a/packages/params/src/index.ts
+++ b/packages/params/src/index.ts
@@ -1,6 +1,7 @@
 import {PresetName} from "./presetName.js";
 import {preset as mainnet} from "./presets/mainnet/index.js";
 import {preset as minimal} from "./presets/minimal/index.js";
+import {preset as gnosis} from "./presets/gnosis/index.js";
 import {presetStatus} from "./presetStatus.js";
 import {userSelectedPreset} from "./setPreset.js";
 
@@ -12,6 +13,7 @@ export {PresetName};
 const presets = {
   [PresetName.mainnet]: mainnet,
   [PresetName.minimal]: minimal,
+  [PresetName.gnosis]: gnosis,
 };
 
 // Once this file is imported, freeze the preset so calling setActivePreset() will throw an error

--- a/packages/params/src/presetName.ts
+++ b/packages/params/src/presetName.ts
@@ -1,4 +1,5 @@
 export enum PresetName {
   mainnet = "mainnet",
   minimal = "minimal",
+  gnosis = "gnosis",
 }

--- a/packages/params/src/presets/gnosis/index.ts
+++ b/packages/params/src/presets/gnosis/index.ts
@@ -1,0 +1,19 @@
+import {BeaconPreset} from "../../interface/index.js";
+import {preset as presetMainnet} from "../mainnet/index.js";
+
+// Note: 1.0.0 has no meaning and is a placeholder
+export const commit = "v1.0.0";
+
+/* eslint-disable @typescript-eslint/naming-convention */
+export const preset: BeaconPreset = {
+  ...presetMainnet,
+
+  /// NOTE: Only add diff values
+
+  // phase0
+  BASE_REWARD_FACTOR: 25,
+  SLOTS_PER_EPOCH: 16,
+
+  // altair
+  EPOCHS_PER_SYNC_COMMITTEE_PERIOD: 512,
+};

--- a/packages/params/test/unit/activePreset.test.ts
+++ b/packages/params/test/unit/activePreset.test.ts
@@ -1,6 +1,7 @@
 import {expect} from "chai";
 import {preset as mainnetParams} from "../../src/presets/mainnet/index.js";
 import {preset as minimalParams} from "../../src/presets/minimal/index.js";
+import {preset as gnosisParams} from "../../src/presets/gnosis/index.js";
 import {ACTIVE_PRESET, PresetName} from "../../src/index.js";
 import {setActivePreset} from "../../src/setPreset.js";
 import {setActivePreset as setActivePresetLib} from "../../src/setPreset.js";
@@ -10,6 +11,7 @@ describe("active preset", async () => {
   const params = {
     [PresetName.mainnet]: mainnetParams,
     [PresetName.minimal]: minimalParams,
+    [PresetName.gnosis]: gnosisParams,
   };
 
   it("Active preset should be set to the correct value", () => {


### PR DESCRIPTION
**Motivation**

Support Gnosis beacon chain with a new preset and config

**Description**

Gnosis beacon chain has changed some preset values that we don't expected to be changed. Thus requires https://github.com/ChainSafe/lodestar/pull/4136 to auto-load a specific preset at runtime for the config to be compatible.

**Note**: Any programmatic use of Lodestar libraries still require setting `LODESTAR_PRESET=gnosis` to work properly.