### PR TITLE
Remove unnecessary dependency from flare

### DIFF
--- a/packages/flare/package.json
+++ b/packages/flare/package.json
@@ -60,7 +60,6 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/lodestar": "^0.37.0",
     "@chainsafe/lodestar-api": "^0.37.0",
     "@chainsafe/lodestar-beacon-state-transition": "^0.37.0",
     "@chainsafe/lodestar-config": "^0.37.0",


### PR DESCRIPTION
**Motivation**

When doing `npx @chainsafe/flare` more things than necessary are installed

**Description**

Remove unnecessary dependency from flare