### PR TITLE
Export lodestar package modules

### DIFF
--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -16,6 +16,12 @@
   "exports": {
     ".": {
       "import": "./lib/index.js"
+    },
+    "./chain": {
+      "import": "./lib/chain/index.js"
+    },
+    "./constants": {
+      "import": "./lib/constants/index.js"
     }
   },
   "typesVersions": {

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -17,11 +17,26 @@
     ".": {
       "import": "./lib/index.js"
     },
+    "./api": {
+      "import": "./lib/api/index.js"
+    },
+    "./db": {
+      "import": "./lib/db/index.js"
+    },
     "./chain": {
       "import": "./lib/chain/index.js"
     },
     "./constants": {
       "import": "./lib/constants/index.js"
+    },
+    "./network": {
+      "import": "./lib/network/index.js"
+    },
+    "./node": {
+      "import": "./lib/node/index.js"
+    },
+    "./util": {
+      "import": "./lib/util/index.js"
     }
   },
   "typesVersions": {

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -20,20 +20,32 @@
     "./api": {
       "import": "./lib/api/index.js"
     },
-    "./db": {
-      "import": "./lib/db/index.js"
-    },
     "./chain": {
       "import": "./lib/chain/index.js"
     },
     "./constants": {
       "import": "./lib/constants/index.js"
     },
+    "./db": {
+      "import": "./lib/db/index.js"
+    },
+    "./eth1": {
+      "import": "./lib/eth1/index.js"
+    },
+    "./executionEngine": {
+      "import": "./lib/executionEngine/index.js"
+    },
+    "./metrics": {
+      "import": "./lib/metrics/index.js"
+    },
     "./network": {
       "import": "./lib/network/index.js"
     },
     "./node": {
       "import": "./lib/node/index.js"
+    },
+    "./sync": {
+      "import": "./lib/sync/index.js"
     },
     "./util": {
       "import": "./lib/util/index.js"


### PR DESCRIPTION
**Motivation**

Exports modules in the `lodestar` package so that it can be imported as dependencies in external projects.

**Description**

Adds ESM module exports for some of the `lodestar` modules. I omitted exports for `eth1`, `executionEngine`, `metrics` and `sync` because I don't need to use them, but perhaps for consistency sake they should be added too?

**Steps to test or reproduce**

Exports lodestar modules to fix this error when you try to import, for example, `ChainEvent`:

```
import {ChainEvent} from "@chainsafe/lodestar/lib/chain";
```

Error on `yarn install`:

```
CustomError: ERR_PACKAGE_PATH_NOT_EXPORTED
```