### PR TITLE
Declare routeId in HTTP client metrics

### DIFF
--- a/packages/lodestar/src/metrics/metrics/lodestar.ts
+++ b/packages/lodestar/src/metrics/metrics/lodestar.ts
@@ -1010,12 +1010,14 @@ export function createLodestarMetrics(
       requestTime: register.histogram<"routeId">({
         name: "lodestar_eth1_http_client_request_time_seconds",
         help: "eth1 JsonHttpClient - histogram or roundtrip request times",
+        labelNames: ["routeId"],
         // Provide max resolution on problematic values around 1 second
         buckets: [0.1, 0.5, 1, 2, 5, 15],
       }),
       requestErrors: register.gauge<"routeId">({
         name: "lodestar_eth1_http_client_request_errors_total",
         help: "eth1 JsonHttpClient - total count of request errors",
+        labelNames: ["routeId"],
       }),
       requestUsedFallbackUrl: register.gauge({
         name: "lodestar_eth1_http_client_request_used_fallback_url_total",
@@ -1035,12 +1037,14 @@ export function createLodestarMetrics(
       requestTime: register.histogram<"routeId">({
         name: "lodestar_execution_engine_http_client_request_time_seconds",
         help: "ExecutionEngineHttp client - histogram or roundtrip request times",
+        labelNames: ["routeId"],
         // Provide max resolution on problematic values around 1 second
         buckets: [0.1, 0.5, 1, 2, 5, 15],
       }),
       requestErrors: register.gauge<"routeId">({
         name: "lodestar_execution_engine_http_client_request_errors_total",
         help: "ExecutionEngineHttp client - total count of request errors",
+        labelNames: ["routeId"],
       }),
       requestUsedFallbackUrl: register.gauge({
         name: "lodestar_execution_engine_http_client_request_used_fallback_url_total",


### PR DESCRIPTION
**Motivation**

Regression introduced probably by https://github.com/ChainSafe/lodestar/pull/4127 which did not add the `labelNames` property in metrics definition. Unfortunately, there no safety guard now to ensure we don't make this mistakes.

**Description**

Declare routeId in HTTP client metrics

Closes https://github.com/ChainSafe/lodestar/issues/4147