### PR TITLE
Remove wtfnode

### DIFF
--- a/packages/api/src/routes/lodestar.ts
+++ b/packages/api/src/routes/lodestar.ts
@@ -58,8 +58,6 @@ export type LodestarNodePeer = NodePeer & {
 };
 
 export type Api = {
-  /** TODO: description */
-  getWtfNode(): Promise<{data: string}>;
   /** Trigger to write a heapdump to disk at `dirpath`. May take > 1min */
   writeHeapdump(dirpath?: string): Promise<{data: {filepath: string}}>;
   /** TODO: description */
@@ -116,7 +114,6 @@ export const routesData: RoutesData<Api> = {
 };
 
 export type ReqTypes = {
-  getWtfNode: ReqEmpty;
   writeHeapdump: {query: {dirpath?: string}};
   getLatestWeakSubjectivityCheckpointEpoch: ReqEmpty;
   getSyncChainsDebugState: ReqEmpty;
@@ -136,7 +133,6 @@ export type ReqTypes = {
 
 export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
   return {
-    getWtfNode: reqEmpty,
     writeHeapdump: {
       writeReq: (dirpath) => ({query: {dirpath}}),
       parseReq: ({query}) => [query.dirpath],
@@ -178,7 +174,6 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
 /* eslint-disable @typescript-eslint/naming-convention */
 export function getReturnTypes(): ReturnTypes<Api> {
   return {
-    getWtfNode: sameType(),
     writeHeapdump: sameType(),
     getLatestWeakSubjectivityCheckpointEpoch: sameType(),
     getSyncChainsDebugState: jsonType("camel"),

--- a/packages/api/src/routes/lodestar.ts
+++ b/packages/api/src/routes/lodestar.ts
@@ -98,7 +98,6 @@ export type Api = {
  * Define javascript values for each route
  */
 export const routesData: RoutesData<Api> = {
-  getWtfNode: {url: "/eth/v1/lodestar/wtfnode", method: "GET"},
   writeHeapdump: {url: "/eth/v1/lodestar/writeheapdump", method: "POST"},
   getLatestWeakSubjectivityCheckpointEpoch: {url: "/eth/v1/lodestar/ws_epoch", method: "GET"},
   getSyncChainsDebugState: {url: "/eth/v1/lodestar/sync-chains-debug-state", method: "GET"},

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -146,8 +146,7 @@
     "snappyjs": "^0.6.0",
     "stream-to-it": "^0.2.0",
     "strict-event-emitter-types": "^2.0.0",
-    "varint": "^6.0.0",
-    "wtfnode": "^0.8.4"
+    "varint": "^6.0.0"
   },
   "devDependencies": {
     "@types/bl": "^5.0.1",

--- a/packages/lodestar/src/api/impl/lodestar/index.ts
+++ b/packages/lodestar/src/api/impl/lodestar/index.ts
@@ -20,29 +20,6 @@ export function getLodestarApi({
   let writingHeapdump = false;
 
   return {
-    /**
-     * Get a wtfnode dump of all active handles
-     * Will only load the wtfnode after the first call, and registers async hooks
-     * and other listeners to the global process instance
-     */
-    async getWtfNode() {
-      // Browser interop
-      if (typeof require !== "function") throw Error("NodeJS only");
-
-      // eslint-disable-next-line
-      const wtfnode = require("wtfnode");
-      const logs: string[] = [];
-      function logger(...args: string[]): void {
-        for (const arg of args) logs.push(arg);
-      }
-      /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
-      wtfnode.setLogger("info", logger);
-      wtfnode.setLogger("warn", logger);
-      wtfnode.setLogger("error", logger);
-      wtfnode.dump();
-      return {data: logs.join("\n")};
-    },
-
     async writeHeapdump(dirpath = ".") {
       // Browser interop
       if (typeof require !== "function") throw Error("NodeJS only");

--- a/yarn.lock
+++ b/yarn.lock
@@ -11778,11 +11778,6 @@ ws@7.2.3:
   resolved "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz"
   integrity sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==
 
-wtfnode@^0.8.4:
-  version "0.8.4"
-  resolved "https://registry.npmjs.org/wtfnode/-/wtfnode-0.8.4.tgz"
-  integrity sha512-64GEKtMt/MUBuAm+8kHqP74ojjafzu00aT0JKsmkIwYmjRQ/odO0yhbzKLm+Z9v1gMla+8dwITRKzTAlHsB+Og==
-
 xml2js@0.4.19:
   version "0.4.19"
   resolved "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz"


### PR DESCRIPTION
**Motivation**

Not a good idea to bundle this capability in production deployments. This tool can be added in specific debugging situations if needed. We haven't need this for +1y tho.

**Description**

Remove wtfnode dependency and route that imports it