### PR TITLE
Turn off the import/no-named-as-default-member in tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -182,6 +182,7 @@ module.exports = {
       files: ["**/test/**/*.ts"],
       rules: {
         "import/no-extraneous-dependencies": "off",
+        // Turned off as it floods log with warnings. Underlying issue is not critical so switching off is acceptable
         "import/no-named-as-default-member": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "func-names": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -182,6 +182,7 @@ module.exports = {
       files: ["**/test/**/*.ts"],
       rules: {
         "import/no-extraneous-dependencies": "off",
+        "import/no-named-as-default-member": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "func-names": "off",
       },


### PR DESCRIPTION
**Motivation**

After an upgrade of eslint, it seems the rule got stricter and logs get filled with a wall of warning as shown below:

```
@chainsafe/lodestar:   12:10  warning  Caution: `sinon` also has a named export `createStubInstance`. Check if you meant to write `import {createStubInstance} from 'sinon'` instead  import/no-named-as-default-member
@chainsafe/lodestar: 
@chainsafe/lodestar: ✖ 126 problems (0 errors, 126 warnings)
@chainsafe/lodestar: 

```
This PR disables the rule that leads to these warning in test files. It can be re-enabled and warning fixed in future if it is considered to be important, but for now, removing the wall of log would be nicer.

Closes: #4167 4167