### PR TITLE
Avoid json parsing an expected empty response

### DIFF
--- a/packages/api/src/utils/client/client.ts
+++ b/packages/api/src/utils/client/client.ts
@@ -76,6 +76,9 @@ export function generateGenericJsonClient<
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return returnType.fromJson(res) as ReturnType<Api[keyof Api]>;
       } else {
+        // We need to avoid parsing the response as the servers might just
+        // response status 200 and close the request instead of writing an
+        // empty json response
         await fetchFn.request(fetchOptsSerializer(...args));
       }
     };

--- a/packages/api/src/utils/client/client.ts
+++ b/packages/api/src/utils/client/client.ts
@@ -71,10 +71,12 @@ export function generateGenericJsonClient<
     const returnType = returnTypes[routeId as keyof ReturnTypes<Api>] as TypeJson<any> | null;
 
     return async function request(...args: Parameters<Api[keyof Api]>): Promise<any | void> {
-      const res = await fetchFn.json<unknown>(fetchOptsSerializer(...args));
       if (returnType) {
+        const res = await fetchFn.json<unknown>(fetchOptsSerializer(...args));
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return returnType.fromJson(res) as ReturnType<Api[keyof Api]>;
+      } else {
+        await fetchFn.request(fetchOptsSerializer(...args));
       }
     };
   }) as Api;

--- a/packages/api/src/utils/client/httpClient.ts
+++ b/packages/api/src/utils/client/httpClient.ts
@@ -28,6 +28,7 @@ export type FetchOpts = {
 export interface IHttpClient {
   baseUrl: string;
   json<T>(opts: FetchOpts): Promise<T>;
+  request(opts: FetchOpts): Promise<void>;
   arrayBuffer(opts: FetchOpts): Promise<ArrayBuffer>;
 }
 
@@ -67,14 +68,18 @@ export class HttpClient implements IHttpClient {
   }
 
   async json<T>(opts: FetchOpts): Promise<T> {
-    return await this.request<T>(opts, (res) => res.json() as Promise<T>);
+    return await this.requestWithBody<T>(opts, (res) => res.json() as Promise<T>);
+  }
+
+  async request(opts: FetchOpts): Promise<void> {
+    return await this.requestWithBody<void>(opts, async (_res) => void 0);
   }
 
   async arrayBuffer(opts: FetchOpts): Promise<ArrayBuffer> {
-    return await this.request<ArrayBuffer>(opts, (res) => res.arrayBuffer());
+    return await this.requestWithBody<ArrayBuffer>(opts, (res) => res.arrayBuffer());
   }
 
-  private async request<T>(opts: FetchOpts, getBody: (res: Response) => Promise<T>): Promise<T> {
+  private async requestWithBody<T>(opts: FetchOpts, getBody: (res: Response) => Promise<T>): Promise<T> {
     // Implement fetch timeout
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);


### PR DESCRIPTION
**Motivation**
Sometime servers (builder/other bns like teku) just give `200` response on apis with empty response instead of a valid empty json which causes our api calls to fail even though they have succeeded.

<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR just makes a request for an expected empty return type and hence avoid the issues with parsing the response.
Closes #3991