### PR TITLE
Update forkchoice using latestValidHash updates from execution engine

### DIFF
--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -68,7 +68,7 @@ export async function processBlocks(
 
     // Fully verify a block to be imported immediately after. Does not produce any side-effects besides adding intermediate
     // states in the state cache through regen.
-    const {postStates, executionStatuses, proposerBalanceDeltas, segmentExecStatus} = await verifyBlocksInEpoch.call(
+    const {postStates, proposerBalanceDeltas, segmentExecStatus} = await verifyBlocksInEpoch.call(
       this,
       parentBlock,
       relevantBlocks,
@@ -77,35 +77,30 @@ export async function processBlocks(
 
     // If segmentExecStatus has lvhForkchoice then, the entire segment should be invalid
     // and we need to further propagate
-    if (segmentExecStatus.invalidSegmentLHV !== undefined) {
-      this.forkChoice.validateLatestHash(segmentExecStatus.invalidSegmentLHV);
-    } else if (segmentExecStatus.mayBeValidTillIndex >= 0) {
-      // Only import blocks if atleast one block was valid
-      const relevantBlocksPostExec = relevantBlocks.slice(0, segmentExecStatus.mayBeValidTillIndex + 1);
-      const fullyVerifiedBlocks = relevantBlocksPostExec.map(
-        (block, i): FullyVerifiedBlock => ({
-          block,
-          postState: postStates[i],
-          parentBlockSlot: parentSlots[i],
-          executionStatus: executionStatuses[i],
-          proposerBalanceDelta: proposerBalanceDeltas[i],
-          // TODO: Make this param mandatory and capture in gossip
-          seenTimestampSec: opts.seenTimestampSec ?? Math.floor(Date.now() / 1000),
-        })
-      );
-
-      for (const fullyVerifiedBlock of fullyVerifiedBlocks) {
-        // No need to sleep(0) here since `importBlock` includes a disk write
-        // TODO: Consider batching importBlock too if it takes significant time
-        await importBlock.call(this, fullyVerifiedBlock, opts);
-      }
-    }
-
-    // If segmentExecStatus has an execError, even if few blocks may be imported
-    // we still need to throw for this segment as it block processor will think
-    // segment imported till end, and will result next into unknown block error
     if (segmentExecStatus.execAborted !== null) {
+      if (segmentExecStatus.invalidSegmentLHV !== undefined) {
+        this.forkChoice.validateLatestHash(segmentExecStatus.invalidSegmentLHV);
+      }
+
       throw segmentExecStatus.execAborted.execError;
+    }
+    const {executionStatuses} = segmentExecStatus;
+    const fullyVerifiedBlocks = relevantBlocks.map(
+      (block, i): FullyVerifiedBlock => ({
+        block,
+        postState: postStates[i],
+        parentBlockSlot: parentSlots[i],
+        executionStatus: executionStatuses[i],
+        proposerBalanceDelta: proposerBalanceDeltas[i],
+        // TODO: Make this param mandatory and capture in gossip
+        seenTimestampSec: opts.seenTimestampSec ?? Math.floor(Date.now() / 1000),
+      })
+    );
+
+    for (const fullyVerifiedBlock of fullyVerifiedBlocks) {
+      // No need to sleep(0) here since `importBlock` includes a disk write
+      // TODO: Consider batching importBlock too if it takes significant time
+      await importBlock.call(this, fullyVerifiedBlock, opts);
     }
   } catch (e) {
     // above functions should only throw BlockError

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -81,9 +81,9 @@ export async function processBlocks(
       if (segmentExecStatus.invalidSegmentLHV !== undefined) {
         this.forkChoice.validateLatestHash(segmentExecStatus.invalidSegmentLHV);
       }
-
       throw segmentExecStatus.execAborted.execError;
     }
+
     const {executionStatuses} = segmentExecStatus;
     const fullyVerifiedBlocks = relevantBlocks.map(
       (block, i): FullyVerifiedBlock => ({

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -1,5 +1,5 @@
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
-import {ExecutionStatus} from "@lodestar/fork-choice";
+import {MaybeValidExecutionStatus} from "@lodestar/fork-choice";
 import {allForks, Slot} from "@lodestar/types";
 
 export type ImportBlockOpts = {
@@ -48,9 +48,10 @@ export type FullyVerifiedBlock = {
   parentBlockSlot: Slot;
   proposerBalanceDelta: number;
   /**
-   * If the execution payload couldnt be verified because of EL syncing status, used in optimistic sync or for merge block
+   * If the execution payload couldnt be verified because of EL syncing status,
+   * used in optimistic sync or for merge block
    */
-  executionStatus: ExecutionStatus;
+  executionStatus: MaybeValidExecutionStatus;
   /** Seen timestamp seconds */
   seenTimestampSec: number;
 };

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -76,7 +76,7 @@ export async function verifyBlocksInEpoch(
       verifyBlocksExecutionPayload(this, parentBlock, blocks, preState0, abortController.signal, opts),
     ]);
 
-    if (segmentExecStatus.mergeBlockFound !== null) {
+    if (segmentExecStatus.execAborted === null && segmentExecStatus.mergeBlockFound !== null) {
       // merge block found and is fully valid = state transition + signatures + execution payload.
       // TODO: Will this banner be logged during syncing?
       logOnPowBlock(this.logger, this.config, segmentExecStatus.mergeBlockFound);

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -1,7 +1,7 @@
 import {CachedBeaconStateAllForks, computeEpochAtSlot} from "@lodestar/state-transition";
 import {allForks, bellatrix} from "@lodestar/types";
 import {toHexString} from "@chainsafe/ssz";
-import {MaybeValidExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
+import {ProtoBlock} from "@lodestar/fork-choice";
 import {IChainForkConfig} from "@lodestar/config";
 import {ILogger} from "@lodestar/utils";
 import {BlockError, BlockErrorCode} from "../errors/index.js";
@@ -32,7 +32,6 @@ export async function verifyBlocksInEpoch(
   opts: BlockProcessOpts & ImportBlockOpts
 ): Promise<{
   postStates: CachedBeaconStateAllForks[];
-  executionStatuses: MaybeValidExecutionStatus[];
   proposerBalanceDeltas: number[];
   segmentExecStatus: SegmentExecStatus;
 }> {
@@ -65,11 +64,7 @@ export async function verifyBlocksInEpoch(
   const abortController = new AbortController();
 
   try {
-    const [
-      {postStates, proposerBalanceDeltas},
-      ,
-      {executionStatuses, mergeBlockFound, segmentExecStatus},
-    ] = await Promise.all([
+    const [{postStates, proposerBalanceDeltas}, , segmentExecStatus] = await Promise.all([
       // Run state transition only
       // TODO: Ensure it yields to allow flushing to workers and engine API
       verifyBlocksStateTransitionOnly(preState0, blocks, this.metrics, abortController.signal, opts),
@@ -81,14 +76,13 @@ export async function verifyBlocksInEpoch(
       verifyBlocksExecutionPayload(this, parentBlock, blocks, preState0, abortController.signal, opts),
     ]);
 
-    logIfSegmentExecError(this.logger, blocks, segmentExecStatus);
-    if (mergeBlockFound !== null) {
+    if (segmentExecStatus.mergeBlockFound !== null) {
       // merge block found and is fully valid = state transition + signatures + execution payload.
       // TODO: Will this banner be logged during syncing?
-      logOnPowBlock(this.logger, this.config, mergeBlockFound);
+      logOnPowBlock(this.logger, this.config, segmentExecStatus.mergeBlockFound);
     }
 
-    return {postStates, executionStatuses, proposerBalanceDeltas, segmentExecStatus};
+    return {postStates, proposerBalanceDeltas, segmentExecStatus};
   } finally {
     abortController.abort();
   }
@@ -105,30 +99,4 @@ function logOnPowBlock(logger: ILogger, config: IChainForkConfig, mergeBlock: be
     executionHash: mergeExecutionHash,
     powHash: mergePowHash,
   });
-}
-
-function logIfSegmentExecError(
-  logger: ILogger,
-  blocks: allForks.SignedBeaconBlock[],
-  segmentExecStatus: SegmentExecStatus
-): void {
-  if (segmentExecStatus.execAborted !== null) {
-    const startSlot = blocks[0].message.slot;
-    const count = blocks.length;
-
-    const failedBlock = blocks[segmentExecStatus.execAborted.blockIndex];
-    const failedSlot = failedBlock.message.slot;
-    const executionPayload = (failedBlock.message.body as bellatrix.BeaconBlockBody).executionPayload;
-    const blockHash = toHexString(executionPayload.blockHash);
-    const blockNumber = executionPayload.blockNumber;
-
-    if (blocks.length > 1) {
-      logger.error("Execution verification failed for a block in segment", {startSlot, count, failedSlot});
-    }
-    logger.error(
-      "Execution Verification failed",
-      {failedSlot, blockNumber, blockHash},
-      segmentExecStatus.execAborted.execError as Error
-    );
-  }
 }

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -372,7 +372,7 @@ function getSegmentErrorResponse(
 
     // If there is no valid in the segment then we have to propagate invalid response
     // in forkchoice as well, also mergeBlockFound has to be null
-    if (lvhFound) {
+    if (!lvhFound) {
       // if the parentBlock is also not the lvh, then we need to propagate this
       // up the forkchoice as parentBlock of the segment is supposed to be in
       // forkchoice.

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -319,7 +319,7 @@ function extractSegmentResponseFromError(
           invalidSegmentLHV = {
             executionStatus: ExecutionStatus.Invalid,
             latestValidExecHash: lvhResponse.latestValidExecHash,
-            invalidateTillBlockHash: parentBlock.blockRoot,
+            invalidateFromBlockHash: parentBlock.blockRoot,
           };
         }
       }
@@ -385,7 +385,7 @@ export async function verifyBlockExecutionPayload(
       const lvhResponse = {
         executionStatus,
         latestValidExecHash: execResult.latestValidHash,
-        invalidateTillBlockHash: toHexString(block.message.parentRoot),
+        invalidateFromBlockHash: toHexString(block.message.parentRoot),
       };
       const execError = new BlockError(block, {
         code: BlockErrorCode.EXECUTION_ENGINE_ERROR,

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -7,7 +7,15 @@ import {
 } from "@lodestar/state-transition";
 import {bellatrix, allForks, Slot} from "@lodestar/types";
 import {toHexString} from "@chainsafe/ssz";
-import {IForkChoice, ExecutionStatus, assertValidTerminalPowBlock, ProtoBlock} from "@lodestar/fork-choice";
+import {
+  IForkChoice,
+  assertValidTerminalPowBlock,
+  ProtoBlock,
+  ExecutionStatus,
+  MaybeValidExecutionStatus,
+  LVHValidResponse,
+  LVHInvalidResponse,
+} from "@lodestar/fork-choice";
 import {IChainForkConfig} from "@lodestar/config";
 import {ErrorAborted, ILogger} from "@lodestar/utils";
 import {IExecutionEngine} from "../../execution/engine/index.js";
@@ -26,6 +34,30 @@ export type VerifyBlockExecutionPayloadModules = {
   config: IChainForkConfig;
 };
 
+type ExecAbortType = {blockIndex: number; execError: BlockError};
+export type SegmentExecStatus =
+  | {
+      mayBeValidTillIndex: number;
+      execAborted: ExecAbortType | null;
+      invalidSegmentLHV: undefined;
+    }
+  | {mayBeValidTillIndex: number; execAborted: ExecAbortType; invalidSegmentLHV: LVHInvalidResponse};
+
+type VerifyExecutionErrorResponse =
+  | {executionStatus: ExecutionStatus.Invalid; lvhResponse: LVHInvalidResponse; execError: BlockError}
+  | {executionStatus: null; execError: BlockError};
+
+type VerifyBlockExecutionResponse =
+  | VerifyExecutionErrorResponse
+  | {executionStatus: ExecutionStatus.Valid; lvhResponse: LVHValidResponse; execError: null}
+  | {executionStatus: ExecutionStatus.Syncing; lvhResponse?: LVHValidResponse; execError: null}
+  | {executionStatus: ExecutionStatus.PreMerge; execError: null};
+
+type VerifySegmentExecutionResponse = {
+  executionStatuses: MaybeValidExecutionStatus[];
+  mergeBlockFound: bellatrix.BeaconBlock | null;
+  segmentExecStatus: SegmentExecStatus;
+};
 /**
  * Verifies 1 or more execution payloads from a linear sequence of blocks.
  *
@@ -38,8 +70,8 @@ export async function verifyBlocksExecutionPayload(
   preState0: CachedBeaconStateAllForks,
   signal: AbortSignal,
   opts: BlockProcessOpts
-): Promise<{executionStatuses: ExecutionStatus[]; mergeBlockFound: bellatrix.BeaconBlock | null}> {
-  const executionStatuses: ExecutionStatus[] = [];
+): Promise<VerifySegmentExecutionResponse> {
+  const executionStatuses: MaybeValidExecutionStatus[] = [];
   let mergeBlockFound: bellatrix.BeaconBlock | null = null;
 
   // Error in the same way as verifyBlocksSanityChecks if empty blocks
@@ -114,14 +146,14 @@ export async function verifyBlocksExecutionPayload(
     parentBlock.executionStatus !== ExecutionStatus.PreMerge ||
     lastBlock.message.slot + opts.safeSlotsToImportOptimistically < currentSlot;
 
-  for (const block of blocks) {
+  for (let blockIndex = 0; blockIndex < blocks.length; blockIndex++) {
+    const block = blocks[blockIndex];
     // If blocks are invalid in consensus the main promise could resolve before this loop ends.
     // In that case stop sending blocks to execution engine
     if (signal.aborted) {
       throw new ErrorAborted("verifyBlockExecutionPayloads");
     }
-
-    const {executionStatus} = await verifyBlockExecutionPayload(
+    const verifyResponse = await verifyBlockExecutionPayload(
       chain,
       block,
       preState0,
@@ -130,9 +162,22 @@ export async function verifyBlocksExecutionPayload(
       currentSlot
     );
 
+    // If execError has happened, then we need to extract the segmentExecStatus and return
+    if (verifyResponse.execError !== null) {
+      return extractSegmentResponseFromError(
+        {verifyResponse, blockIndex},
+        parentBlock,
+        blocks,
+        executionStatuses,
+        mergeBlockFound
+      );
+    }
+
+    // If we are here then its because executionStatus is one of MaybeValidExecutionStatus
+    const {executionStatus} = verifyResponse;
     // It becomes optimistically  safe for following blocks if a post-merge block is deemed fit
-    // for import. If it would not have been safe verifyBlockExecutionPayload would throw error
-    // and we would not be here.
+    // for import. If it would not have been safe verifyBlockExecutionPayload would have
+    // returned execError and loop would have been aborted
     if (executionStatus !== ExecutionStatus.PreMerge) {
       isOptimisticallySafe = true;
     }
@@ -196,14 +241,104 @@ export async function verifyBlocksExecutionPayload(
       }
 
       assertValidTerminalPowBlock(chain.config, mergeBlock, {executionStatus, powBlock, powBlockParent});
-
       // Valid execution payload, but may not be in a valid beacon chain block. Delay printing the POS ACTIVATED banner
       // to the end of the verify block routine, which confirms that this block is fully valid.
       mergeBlockFound = mergeBlock;
     }
   }
 
-  return {executionStatuses, mergeBlockFound};
+  const segmentExecStatus = {mayBeValidTillIndex: blocks.length - 1, execAborted: null} as SegmentExecStatus;
+
+  return {
+    executionStatuses,
+    mergeBlockFound,
+    segmentExecStatus,
+  };
+}
+
+function extractSegmentResponseFromError(
+  {verifyResponse, blockIndex}: {verifyResponse: VerifyExecutionErrorResponse; blockIndex: number},
+  parentBlock: ProtoBlock,
+  blocks: allForks.SignedBeaconBlock[],
+  executionStatuses: MaybeValidExecutionStatus[],
+  mergeBlockFound: bellatrix.BeaconBlock | null
+): VerifySegmentExecutionResponse {
+  const {execError} = verifyResponse;
+
+  if (verifyResponse.executionStatus === null) {
+    const segmentExecStatus = {
+      mayBeValidTillIndex: blockIndex - 1,
+      execAborted: {blockIndex, execError},
+    } as SegmentExecStatus;
+    return {executionStatuses, mergeBlockFound, segmentExecStatus};
+  }
+  // If we had an invalid status we need to inspect up the chain and see if the latestValidExecHash
+  // belong to any of the previous block, if it does then the story stops at that block
+  else {
+    const {lvhResponse} = verifyResponse;
+
+    if (lvhResponse.latestValidExecHash !== null) {
+      let invalidSegmentLHV: LVHInvalidResponse | undefined = undefined;
+      // see if latestValidExecHash belongs to the previous segment of blocks
+      let mayBeValidTillIndex = blockIndex - 1;
+
+      // Lets see if latestValidExecHash is in the parents of this segment
+      //  i) If LVH is 0x00..00, then we will either hit a pre-merge block here
+      //  ii) or a block where LVH is found, so we set mayBeValidTillIndex is
+      //      that block itself
+      //  iii) if not found, then we need to create a invalidSegmentLHV for
+      //       forkchoice if the parentBlock is not pre-merge and its
+      //       execHash doesn't match LVH
+      for (; mayBeValidTillIndex >= 0; mayBeValidTillIndex--) {
+        // if the block is premerge, then stop there, mergeBlockFound has to be null
+        if (executionStatuses[mayBeValidTillIndex] === ExecutionStatus.PreMerge) {
+          mergeBlockFound = null;
+          break;
+        }
+        // ok we found the index in post merge block
+        else if (
+          toHexString(
+            (blocks[mayBeValidTillIndex].message.body as bellatrix.BeaconBlockBody).executionPayload.blockHash
+          ) === lvhResponse.latestValidExecHash
+        ) {
+          break;
+        }
+      }
+
+      // If there is no valid in the segment then we have to propagate invalid response
+      // in forkchoice as well, also mergeBlockFound has to be null
+      if (mayBeValidTillIndex < 0) {
+        mergeBlockFound = null;
+        // if the parentBlock is also not the lvh, then we need to propagate this
+        // up the forkchoice as parentBlock of the segment is supposed to be in
+        // forkchoice.
+        if (
+          parentBlock.executionStatus !== ExecutionStatus.PreMerge &&
+          parentBlock.executionPayloadBlockHash !== lvhResponse.latestValidExecHash
+        ) {
+          invalidSegmentLHV = {
+            executionStatus: ExecutionStatus.Invalid,
+            latestValidExecHash: lvhResponse.latestValidExecHash,
+            invalidateTillBlockHash: parentBlock.blockRoot,
+          };
+        }
+      }
+
+      const segmentExecStatus = {
+        mayBeValidTillIndex,
+        execAborted: {blockIndex, execError},
+        invalidSegmentLHV,
+      } as SegmentExecStatus;
+      return {executionStatuses, mergeBlockFound, segmentExecStatus};
+    } else {
+      // null means only this block is deemed invalid for now
+      const segmentExecStatus = {
+        mayBeValidTillIndex: blockIndex - 1,
+        execAborted: {blockIndex, execError},
+      } as SegmentExecStatus;
+      return {executionStatuses, mergeBlockFound, segmentExecStatus};
+    }
+  }
 }
 
 /**
@@ -216,7 +351,7 @@ export async function verifyBlockExecutionPayload(
   opts: BlockProcessOpts,
   isOptimisticallySafe: boolean,
   currentSlot: Slot
-): Promise<{executionStatus: ExecutionStatus}> {
+): Promise<VerifyBlockExecutionResponse> {
   /** Not null if execution is enabled */
   const executionPayloadEnabled =
     isBellatrixStateType(preState0) &&
@@ -232,30 +367,32 @@ export async function verifyBlockExecutionPayload(
 
   if (!executionPayloadEnabled) {
     // isExecutionEnabled() -> false
-    return {executionStatus: ExecutionStatus.PreMerge};
+    return {executionStatus: ExecutionStatus.PreMerge, execError: null};
   }
 
   // TODO: Handle better notifyNewPayload() returning error is syncing
   const execResult = await chain.executionEngine.notifyNewPayload(executionPayloadEnabled);
 
   switch (execResult.status) {
-    case ExecutePayloadStatus.VALID:
-      chain.forkChoice.validateLatestHash(execResult.latestValidHash, null);
-      return {executionStatus: ExecutionStatus.Valid};
+    case ExecutePayloadStatus.VALID: {
+      const executionStatus: ExecutionStatus.Valid = ExecutionStatus.Valid;
+      const lvhResponse = {executionStatus, latestValidExecHash: execResult.latestValidHash};
+      return {executionStatus, lvhResponse, execError: null};
+    }
 
     case ExecutePayloadStatus.INVALID: {
-      // If the parentRoot is not same as latestValidHash, then the branch from latestValidHash
-      // to parentRoot needs to be invalidated
-      const parentHashHex = toHexString(block.message.parentRoot);
-      chain.forkChoice.validateLatestHash(
-        execResult.latestValidHash,
-        parentHashHex !== execResult.latestValidHash ? parentHashHex : null
-      );
-      throw new BlockError(block, {
+      const executionStatus: ExecutionStatus.Invalid = ExecutionStatus.Invalid;
+      const lvhResponse = {
+        executionStatus,
+        latestValidExecHash: execResult.latestValidHash,
+        invalidateTillBlockHash: toHexString(block.message.parentRoot),
+      };
+      const execError = new BlockError(block, {
         code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
         execStatus: execResult.status,
         errorMessage: execResult.validationError ?? "",
       });
+      return {executionStatus, lvhResponse, execError};
     }
 
     // Accepted and Syncing have the same treatment, as final validation of block is pending
@@ -265,14 +402,15 @@ export async function verifyBlockExecutionPayload(
       // the safeSlotsToImportOptimistically window of current slot, then we can import else
       // we need to throw and not import his block
       if (!isOptimisticallySafe && block.message.slot + opts.safeSlotsToImportOptimistically >= currentSlot) {
-        throw new BlockError(block, {
+        const execError = new BlockError(block, {
           code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
           execStatus: ExecutePayloadStatus.UNSAFE_OPTIMISTIC_STATUS,
           errorMessage: `not safe to import ${execResult.status} payload within ${opts.safeSlotsToImportOptimistically} of currentSlot`,
         });
+        return {executionStatus: null, execError};
       }
 
-      return {executionStatus: ExecutionStatus.Syncing};
+      return {executionStatus: ExecutionStatus.Syncing, execError: null};
     }
 
     // If the block has is not valid, or it referenced an invalid terminal block then the
@@ -294,11 +432,13 @@ export async function verifyBlockExecutionPayload(
 
     case ExecutePayloadStatus.INVALID_BLOCK_HASH:
     case ExecutePayloadStatus.ELERROR:
-    case ExecutePayloadStatus.UNAVAILABLE:
-      throw new BlockError(block, {
+    case ExecutePayloadStatus.UNAVAILABLE: {
+      const execError = new BlockError(block, {
         code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
         execStatus: execResult.status,
         errorMessage: execResult.validationError,
       });
+      return {executionStatus: null, execError};
+    }
   }
 }

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -523,6 +523,12 @@ export class BeaconChain implements IBeaconChain {
     this.logger.verbose("Clock slot", {slot});
 
     // CRITICAL UPDATE
+    try {
+      this.forkChoice.checkSaneForkChoice();
+    } catch (e) {
+      this.logger.error("Critical error in forkChoice, shutting down gracefully", {}, e as Error);
+      process.kill(process.pid, "SIGINT");
+    }
     this.forkChoice.updateTime(slot);
 
     this.metrics?.clockSlot.set(slot);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -14,6 +14,8 @@ import {
 import {IBeaconConfig} from "@lodestar/config";
 import {allForks, UintNum64, Root, phase0, Slot, RootHex, Epoch, ValidatorIndex} from "@lodestar/types";
 import {CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
+import {ProcessShutdownCallback} from "@lodestar/validator";
+
 import {ILogger, toHex} from "@lodestar/utils";
 import {CompositeTypeAny, fromHexString, TreeView, Type} from "@chainsafe/ssz";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
@@ -117,6 +119,7 @@ export class BeaconChain implements IBeaconChain {
 
   private readonly faultInspectionWindow: number;
   private readonly allowedFaults: number;
+  private processShutdownCallback: ProcessShutdownCallback;
 
   constructor(
     opts: IChainOptions,
@@ -124,6 +127,7 @@ export class BeaconChain implements IBeaconChain {
       config,
       db,
       logger,
+      processShutdownCallback,
       clock,
       metrics,
       anchorState,
@@ -134,6 +138,7 @@ export class BeaconChain implements IBeaconChain {
       config: IBeaconConfig;
       db: IBeaconDb;
       logger: ILogger;
+      processShutdownCallback: ProcessShutdownCallback;
       /** Used for testing to supply fake clock */
       clock?: IBeaconClock;
       metrics: IMetrics | null;
@@ -147,6 +152,7 @@ export class BeaconChain implements IBeaconChain {
     this.config = config;
     this.db = db;
     this.logger = logger;
+    this.processShutdownCallback = processShutdownCallback;
     this.metrics = metrics;
     this.genesisTime = anchorState.genesisTime;
     this.anchorStateLatestBlockSlot = anchorState.latestBlockHeader.slot;
@@ -523,11 +529,8 @@ export class BeaconChain implements IBeaconChain {
     this.logger.verbose("Clock slot", {slot});
 
     // CRITICAL UPDATE
-    try {
-      this.forkChoice.checkSaneForkChoice();
-    } catch (e) {
-      this.logger.error("Critical error in forkChoice, shutting down gracefully", {}, e as Error);
-      process.kill(process.pid, "SIGINT");
+    if (this.forkChoice.irrecoverableError) {
+      this.processShutdownCallback(this.forkChoice.irrecoverableError);
     }
     this.forkChoice.updateTime(slot);
 

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -136,15 +136,9 @@ export class ExecutionEngineHttp implements IExecutionEngine {
         return {status, latestValidHash: latestValidHash ?? "0x0", validationError: null};
 
       case ExecutePayloadStatus.INVALID:
-        if (latestValidHash == null) {
-          return {
-            status: ExecutePayloadStatus.ELERROR,
-            latestValidHash: null,
-            validationError: `Invalid null latestValidHash for status=${status}`,
-          };
-        } else {
-          return {status, latestValidHash, validationError};
-        }
+        // As per latest specs if latestValidHash can be null and it would mean only
+        // invalidate this block
+        return {status, latestValidHash, validationError};
 
       case ExecutePayloadStatus.SYNCING:
       case ExecutePayloadStatus.ACCEPTED:

--- a/packages/beacon-node/src/execution/engine/interface.ts
+++ b/packages/beacon-node/src/execution/engine/interface.ts
@@ -28,7 +28,7 @@ export enum ExecutePayloadStatus {
 export type ExecutePayloadResponse =
   | {status: ExecutePayloadStatus.SYNCING | ExecutePayloadStatus.ACCEPTED; latestValidHash: null; validationError: null}
   | {status: ExecutePayloadStatus.VALID; latestValidHash: RootHex; validationError: null}
-  | {status: ExecutePayloadStatus.INVALID; latestValidHash: RootHex; validationError: string | null}
+  | {status: ExecutePayloadStatus.INVALID; latestValidHash: RootHex | null; validationError: string | null}
   | {
       status: ExecutePayloadStatus.INVALID_BLOCK_HASH | ExecutePayloadStatus.ELERROR | ExecutePayloadStatus.UNAVAILABLE;
       latestValidHash: null;

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -7,6 +7,7 @@ import {phase0} from "@lodestar/types";
 import {ILogger} from "@lodestar/utils";
 import {Api} from "@lodestar/api";
 import {BeaconStateAllForks} from "@lodestar/state-transition";
+import {ProcessShutdownCallback} from "@lodestar/validator";
 
 import {IBeaconDb} from "../db/index.js";
 import {INetwork, Network, getReqRespHandlers} from "../network/index.js";
@@ -42,6 +43,7 @@ export interface IBeaconNodeInitModules {
   config: IBeaconConfig;
   db: IBeaconDb;
   logger: ILogger;
+  processShutdownCallback: ProcessShutdownCallback;
   libp2p: LibP2p;
   anchorState: BeaconStateAllForks;
   wsCheckpoint?: phase0.Checkpoint;
@@ -113,6 +115,7 @@ export class BeaconNode {
     config,
     db,
     logger,
+    processShutdownCallback,
     libp2p,
     anchorState,
     wsCheckpoint,
@@ -139,6 +142,7 @@ export class BeaconNode {
       config,
       db,
       logger: logger.child(opts.logger.chain),
+      processShutdownCallback,
       metrics,
       anchorState,
       eth1: initializeEth1ForBlockProduction(opts.eth1, {

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -90,6 +90,8 @@ describe.skip("verify+import blocks - range sync perf test", () => {
           config: state.config,
           db,
           logger,
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          processShutdownCallback: () => {},
           metrics: null,
           anchorState: state,
           eth1: new Eth1ForBlockProductionDisabled(),

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -74,6 +74,8 @@ export const forkChoiceTest: TestRunnerFn<ForkChoiceTestCase, void> = (fork) => 
           config: createIBeaconConfig(config, state.genesisValidatorsRoot),
           db: getStubbedBeaconDb(),
           logger,
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          processShutdownCallback: () => {},
           clock,
           metrics: null,
           anchorState,

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -245,6 +245,7 @@ function mockForkChoice(): IForkChoice {
   const checkpoint: CheckpointWithHex = {epoch: 0, root, rootHex};
 
   return {
+    irrecoverableError: undefined,
     getAncestor: () => rootHex,
     getHeadRoot: () => rootHex,
     getHead: () => block,

--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -99,6 +99,8 @@ export async function getDevBeaconNode(
     config: beaconConfig,
     db,
     logger,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    processShutdownCallback: () => {},
     libp2p,
     anchorState,
     wsCheckpoint: opts.wsCheckpoint,

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -36,7 +36,7 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
   }, logger.info.bind(logger));
 
   logger.info("Lodestar", {network, version, commit});
-  // Callback for beacon to request forced exit, for e.g. in case of irrecoverable 
+  // Callback for beacon to request forced exit, for e.g. in case of irrecoverable
   // forkchoice errors
   const processShutdownCallback: ProcessShutdownCallback = (err) => {
     logger.error("Process shutdown requested", {}, err);

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -34,6 +34,13 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
   }, logger.info.bind(logger));
 
   logger.info("Lodestar", {network, version, commit});
+  // Callback for beacon to request forced exit, for e.g. in case of irrecoverable 
+  // forkchoice errors
+  const processShutdownCallback: ProcessShutdownCallback = (err) => {
+    logger.error("Process shutdown requested", {}, err);
+    process.kill(process.pid, "SIGINT");
+  };
+
   if (ACTIVE_PRESET === PresetName.minimal) logger.info("ACTIVE_PRESET == minimal preset");
 
   // additional metrics registries
@@ -61,6 +68,7 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
       config: beaconConfig,
       db,
       logger,
+      processShutdownCallback,
       libp2p: await createNodeJsLibp2p(peerId, options.network, {peerStoreDir: beaconPaths.peerStoreDir}),
       anchorState,
       wsCheckpoint,

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -6,6 +6,8 @@ import {LevelDbController} from "@lodestar/db";
 import {BeaconNode, BeaconDb, createNodeJsLibp2p} from "@lodestar/beacon-node";
 import {createIBeaconConfig} from "@lodestar/config";
 import {ACTIVE_PRESET, PresetName} from "@lodestar/params";
+import {ProcessShutdownCallback} from "@lodestar/validator";
+
 import {IGlobalArgs, parseBeaconNodeArgs} from "../../options/index.js";
 import {onGracefulShutdown, getCliLogger, mkdir, writeFile} from "../../util/index.js";
 import {BeaconNodeOptions, createPeerId, FileENR, getBeaconConfigFromArgs} from "../../config/index.js";

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -22,7 +22,14 @@ import {computeUnrealizedCheckpoints} from "@lodestar/state-transition/epoch";
 import {IChainConfig, IChainForkConfig} from "@lodestar/config";
 
 import {computeDeltas} from "../protoArray/computeDeltas.js";
-import {HEX_ZERO_HASH, VoteTracker, ProtoBlock, ExecutionStatus} from "../protoArray/interface.js";
+import {
+  HEX_ZERO_HASH,
+  VoteTracker,
+  ProtoBlock,
+  ExecutionStatus,
+  MaybeValidExecutionStatus,
+  LVHExecResponse,
+} from "../protoArray/interface.js";
 import {ProtoArray} from "../protoArray/protoArray.js";
 
 import {ForkChoiceError, ForkChoiceErrorCode, InvalidBlockCode, InvalidAttestationCode} from "./errors.js";
@@ -279,7 +286,7 @@ export class ForkChoice implements IForkChoice {
     state: CachedBeaconStateAllForks,
     blockDelaySec: number,
     currentSlot: Slot,
-    executionStatus: ExecutionStatus
+    executionStatus: MaybeValidExecutionStatus
   ): void {
     const {parentRoot, slot} = block;
     const parentRootHex = toHexString(parentRoot);
@@ -745,14 +752,20 @@ export class ForkChoice implements IForkChoice {
   }
 
   /**
-   * Optimistic sync validate till validated latest hash, invalidate any decendant branch if invalidate till hash provided
-   * TODO: implementation:
-   * 1. verify is_merge_block if the mergeblock has not yet been validated
-   * 2. Throw critical error and exit if a block in finalized chain gets invalidated
+   * Optimistic sync validate till validated latest hash, invalidate any decendant
+   * branch if invalidate till hash provided
+   *
+   * Proxies to protoArray's validateLatestHash and could run extra validations for the
+   * justified's status as well as validate the terminal conditions if terminal block
+   * becomes valid
    */
-  validateLatestHash(_latestValidHash: RootHex, _invalidateTillHash: RootHex | null): void {
-    // Silently ignore for now if all calls were valid
-    return;
+  validateLatestHash(execResponse: LVHExecResponse): void {
+    this.protoArray.validateLatestHash(execResponse, this.fcStore.currentSlot);
+
+    // Call findHead to validate that the forkChoice consensus has not broken down
+    // as it is possible for invalidation to invalidate the entire forkChoice if
+    // the consensus breaks down, which will cause findHead to throw
+    this.protoArray.findHead(this.fcStore.justified.checkpoint.rootHex, this.fcStore.currentSlot);
   }
 
   /**
@@ -792,13 +805,15 @@ export class ForkChoice implements IForkChoice {
     );
   }
 
-  private getPreMergeExecStatus(executionStatus: ExecutionStatus): ExecutionStatus.PreMerge {
+  private getPreMergeExecStatus(executionStatus: MaybeValidExecutionStatus): ExecutionStatus.PreMerge {
     if (executionStatus !== ExecutionStatus.PreMerge)
       throw Error(`Invalid pre-merge execution status: expected: ${ExecutionStatus.PreMerge}, got ${executionStatus}`);
     return executionStatus;
   }
 
-  private getPostMergeExecStatus(executionStatus: ExecutionStatus): ExecutionStatus.Valid | ExecutionStatus.Syncing {
+  private getPostMergeExecStatus(
+    executionStatus: MaybeValidExecutionStatus
+  ): ExecutionStatus.Valid | ExecutionStatus.Syncing {
     if (executionStatus === ExecutionStatus.PreMerge)
       throw Error(
         `Invalid post-merge execution status: expected: ${ExecutionStatus.Syncing} or ${ExecutionStatus.Valid} , got ${executionStatus}`

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -145,6 +145,13 @@ export class ForkChoice implements IForkChoice {
   }
 
   /**
+   * Successful call if no critical errors, else throws
+   */
+  checkSaneForkChoice(): void {
+    this.protoArray.findHead(this.fcStore.justified.checkpoint.rootHex, this.fcStore.currentSlot);
+  }
+
+  /**
    * Get the cached head root
    */
   getHeadRoot(): RootHex {

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -20,6 +20,7 @@ export type CheckpointHexWithBalance = {
 };
 
 export interface IForkChoice {
+  irrecoverableError?: Error;
   /**
    * Returns the block root of an ancestor of `block_root` at the given `slot`. (Note: `slot` refers
    * to the block that is *returned*, not the one that is supplied.)
@@ -159,7 +160,6 @@ export interface IForkChoice {
   /** Find attester dependent root of a block */
   findAttesterDependentRoot(headBlockHash: Root): RootHex | null;
   /** Get critical error from forkChoice */
-  checkSaneForkChoice(): void;
 }
 
 /** Same to the PowBlock but we want RootHex to work with forkchoice conveniently */

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -158,6 +158,8 @@ export interface IForkChoice {
   validateLatestHash(execResponse: LVHExecResponse): void;
   /** Find attester dependent root of a block */
   findAttesterDependentRoot(headBlockHash: Root): RootHex | null;
+  /** Get critical error from forkChoice */
+  checkSaneForkChoice(): void;
 }
 
 /** Same to the PowBlock but we want RootHex to work with forkchoice conveniently */

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -1,7 +1,7 @@
 import {EffectiveBalanceIncrements} from "@lodestar/state-transition";
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {Epoch, Slot, ValidatorIndex, phase0, allForks, Root, RootHex} from "@lodestar/types";
-import {ProtoBlock, ExecutionStatus} from "../protoArray/interface.js";
+import {ProtoBlock, MaybeValidExecutionStatus, LVHExecResponse} from "../protoArray/interface.js";
 import {CheckpointWithHex} from "./store.js";
 
 export type CheckpointHex = {
@@ -70,7 +70,7 @@ export interface IForkChoice {
     state: CachedBeaconStateAllForks,
     blockDelaySec: number,
     currentSlot: Slot,
-    executionStatus: ExecutionStatus
+    executionStatus: MaybeValidExecutionStatus
   ): void;
   /**
    * Register `attestation` with the fork choice DAG so that it may influence future calls to `getHead`.
@@ -155,7 +155,7 @@ export interface IForkChoice {
   /**
    * Optimistic sync validate till validated latest hash, invalidate any decendant branch if invalidated branch decendant provided
    */
-  validateLatestHash(latestValidHash: RootHex, invalidateTillHash: RootHex | null): void;
+  validateLatestHash(execResponse: LVHExecResponse): void;
   /** Find attester dependent root of a block */
   findAttesterDependentRoot(headBlockHash: Root): RootHex | null;
 }

--- a/packages/fork-choice/src/index.ts
+++ b/packages/fork-choice/src/index.ts
@@ -1,5 +1,13 @@
 export {ProtoArray} from "./protoArray/protoArray.js";
-export {ProtoBlock, ProtoNode, ExecutionStatus} from "./protoArray/interface.js";
+export {
+  ProtoBlock,
+  ProtoNode,
+  ExecutionStatus,
+  MaybeValidExecutionStatus,
+  BlockExecution,
+  LVHValidResponse,
+  LVHInvalidResponse,
+} from "./protoArray/interface.js";
 
 export {ForkChoice, ForkChoiceOpts, assertValidTerminalPowBlock} from "./forkChoice/forkChoice.js";
 export {IForkChoice, PowBlockHex} from "./forkChoice/interface.js";

--- a/packages/fork-choice/src/protoArray/errors.ts
+++ b/packages/fork-choice/src/protoArray/errors.ts
@@ -2,6 +2,7 @@ import {Epoch, RootHex} from "@lodestar/types";
 import {LodestarError} from "@lodestar/utils";
 
 export enum LVHExecErrorCode {
+  PreMergeToInvalid = "PreMergeToInvalid",
   ValidToInvalid = "ValidToInvalid",
   InvalidToValid = "InvalidToValid",
 }

--- a/packages/fork-choice/src/protoArray/errors.ts
+++ b/packages/fork-choice/src/protoArray/errors.ts
@@ -1,6 +1,13 @@
 import {Epoch, RootHex} from "@lodestar/types";
 import {LodestarError} from "@lodestar/utils";
 
+export enum LVHExecErrorCode {
+  ValidToInvalid = "ValidToInvalid",
+  InvalidToValid = "InvalidToValid",
+}
+
+export type LVHExecError = {lvhCode: LVHExecErrorCode; blockRoot: RootHex; execHash: RootHex};
+
 export enum ProtoArrayErrorCode {
   FINALIZED_NODE_UNKNOWN = "PROTO_ARRAY_ERROR_FINALIZED_NODE_UNKNOWN",
   JUSTIFIED_NODE_UNKNOWN = "PROTO_ARRAY_ERROR_JUSTIFIED_NODE_UNKNOWN",
@@ -16,6 +23,9 @@ export enum ProtoArrayErrorCode {
   INVALID_DELTA_LEN = "PROTO_ARRAY_ERROR_INVALID_DELTA_LEN",
   REVERTED_FINALIZED_EPOCH = "PROTO_ARRAY_ERROR_REVERTED_FINALIZED_EPOCH",
   INVALID_BEST_NODE = "PROTO_ARRAY_ERROR_INVALID_BEST_NODE",
+  INVALID_BLOCK_EXECUTION_STATUS = "PROTO_ARRAY_INVALID_BLOCK_EXECUTION_STATUS",
+  INVALID_JUSTIFIED_EXECUTION_STATUS = "PROTO_ARRAY_INVALID_JUSTIFIED_EXECUTION_STATUS",
+  INVALID_LVH_EXECUTION_RESPONSE = "PROTO_ARRAY_INVALID_LVH_EXECUTION_RESPONSE",
 }
 
 export type ProtoArrayErrorType =
@@ -40,7 +50,10 @@ export type ProtoArrayErrorType =
       headRoot: RootHex;
       headJustifiedEpoch: Epoch;
       headFinalizedEpoch: Epoch;
-    };
+    }
+  | {code: ProtoArrayErrorCode.INVALID_BLOCK_EXECUTION_STATUS; root: RootHex}
+  | {code: ProtoArrayErrorCode.INVALID_JUSTIFIED_EXECUTION_STATUS; root: RootHex}
+  | ({code: ProtoArrayErrorCode.INVALID_LVH_EXECUTION_RESPONSE} & LVHExecError);
 
 export class ProtoArrayError extends LodestarError<ProtoArrayErrorType> {
   constructor(type: ProtoArrayErrorType) {

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -27,7 +27,7 @@ export type LVHValidResponse = {
 export type LVHInvalidResponse = {
   executionStatus: ExecutionStatus.Invalid;
   latestValidExecHash: RootHex | null;
-  invalidateTillBlockHash: RootHex;
+  invalidateFromBlockHash: RootHex;
 };
 export type LVHExecResponse = LVHValidResponse | LVHInvalidResponse;
 

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -17,10 +17,24 @@ export enum ExecutionStatus {
   Valid = "Valid",
   Syncing = "Syncing",
   PreMerge = "PreMerge",
+  Invalid = "Invalid",
 }
 
-type BlockExecution =
-  | {executionPayloadBlockHash: RootHex; executionStatus: ExecutionStatus.Valid | ExecutionStatus.Syncing}
+export type LVHValidResponse = {
+  executionStatus: ExecutionStatus.Valid;
+  latestValidExecHash: RootHex;
+};
+export type LVHInvalidResponse = {
+  executionStatus: ExecutionStatus.Invalid;
+  latestValidExecHash: RootHex | null;
+  invalidateTillBlockHash: RootHex;
+};
+export type LVHExecResponse = LVHValidResponse | LVHInvalidResponse;
+
+export type MaybeValidExecutionStatus = Exclude<ExecutionStatus, ExecutionStatus.Invalid>;
+
+export type BlockExecution =
+  | {executionPayloadBlockHash: RootHex; executionStatus: Exclude<ExecutionStatus, ExecutionStatus.PreMerge>}
   | {executionPayloadBlockHash: null; executionStatus: ExecutionStatus.PreMerge};
 /**
  * A block that is to be applied to the fork choice

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -323,7 +323,7 @@ export class ProtoArray {
     // propagate till we keep encountering syncing status
     while (nodeIndex !== undefined) {
       const validNode = this.validateNodeByIndex(nodeIndex);
-      if (validNode.executionStatus === ExecutionStatus.PreMerge) {
+      if (validNode.executionStatus !== ExecutionStatus.Syncing) {
         break;
       }
       nodeIndex = validNode.parent;

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -9,7 +9,7 @@ export const DEFAULT_PRUNE_THRESHOLD = 0;
 type ProposerBoost = {root: RootHex; score: number};
 
 const ZERO_HASH = Buffer.alloc(32, 0);
-const ZERO_HASH_HEX = toHexString(ZERO_HASH);
+const ZERO_HASH_HEX = toHexString(Buffer.alloc(32, 0));
 
 export class ProtoArray {
   // Do not attempt to prune the tree unless it has at least this many nodes.

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -440,8 +440,7 @@ export class ProtoArray {
       // Only invalidate if this is post merge, and either parent is invalid or the
       // concensus has failed
       if (parent?.executionStatus === ExecutionStatus.Invalid) {
-        // node should never have pre-merge execution status as its parent is unvalid
-        // still keeping it here for completeness and to record any consensus breakdown
+        // check and flip node status to invalid
         if (node.executionStatus === ExecutionStatus.Valid) {
           // This is a catastrophe, and indicates consensus failure and a non
           // recoverable damage. There is no further processing that can be done.
@@ -456,8 +455,11 @@ export class ProtoArray {
             ...this.lvhError,
           });
         } else {
-          if (node.executionStatus === ExecutionStatus.PreMerge)
+          // node should never have pre-merge execution status as its parent is unvalid
+          // still keeping it here for completeness and to record any consensus breakdown
+          if (node.executionStatus === ExecutionStatus.PreMerge) {
             throw Error("Internal Error in LVH invalidation, pre-merge block has invalid parent");
+          }
           node.executionStatus = ExecutionStatus.Invalid;
           node.bestChild = undefined;
           node.bestDescendant = undefined;
@@ -465,7 +467,7 @@ export class ProtoArray {
       }
     }
 
-    // update the forkchoice
+    // update the forkchoice as the invalidation can change the entire forkchoice DAG
     this.applyScoreChanges({
       deltas: Array.from({length: this.nodes.length}, () => 0),
       proposerBoost: this.previousProposerBoost,

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -322,11 +322,12 @@ export class ProtoArray {
     let nodeIndex: number | undefined = validNodeIndex;
     // propagate till we keep encountering syncing status
     while (nodeIndex !== undefined) {
-      const validNode = this.validateNodeByIndex(nodeIndex);
-      if (validNode.executionStatus !== ExecutionStatus.Syncing) {
+      const node = this.getNodeFromIndex(nodeIndex);
+      if (node.executionStatus === ExecutionStatus.PreMerge || node.executionStatus === ExecutionStatus.Valid) {
         break;
       }
-      nodeIndex = validNode.parent;
+      this.validateNodeByIndex(nodeIndex);
+      nodeIndex = node.parent;
     }
   }
 

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -449,7 +449,7 @@ export class ProtoArray {
    * Follows the best-descendant links to find the best-block (i.e., head-block).
    */
   findHead(justifiedRoot: RootHex, currentSlot: Slot): RootHex {
-    if (this.lvhError !== undefined) {
+    if (!this.lvhError) {
       throw new ProtoArrayError({
         code: ProtoArrayErrorCode.INVALID_LVH_EXECUTION_RESPONSE,
         ...this.lvhError,

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -8,7 +8,6 @@ import {ProtoArrayError, ProtoArrayErrorCode, LVHExecError, LVHExecErrorCode} fr
 export const DEFAULT_PRUNE_THRESHOLD = 0;
 type ProposerBoost = {root: RootHex; score: number};
 
-const ZERO_HASH = Buffer.alloc(32, 0);
 const ZERO_HASH_HEX = toHexString(Buffer.alloc(32, 0));
 
 export class ProtoArray {
@@ -23,7 +22,7 @@ export class ProtoArray {
   indices = new Map<RootHex, number>();
   lvhError?: LVHExecError;
 
-  private previousProposerBoost?: ProposerBoost | null = null;
+  private previousProposerBoost: ProposerBoost | null = null;
 
   constructor({
     pruneThreshold,
@@ -89,7 +88,7 @@ export class ProtoArray {
     currentSlot,
   }: {
     deltas: number[];
-    proposerBoost?: ProposerBoost | null;
+    proposerBoost: ProposerBoost | null;
     justifiedEpoch: Epoch;
     justifiedRoot: RootHex;
     finalizedEpoch: Epoch;
@@ -449,7 +448,7 @@ export class ProtoArray {
    * Follows the best-descendant links to find the best-block (i.e., head-block).
    */
   findHead(justifiedRoot: RootHex, currentSlot: Slot): RootHex {
-    if (!this.lvhError) {
+    if (this.lvhError) {
       throw new ProtoArrayError({
         code: ProtoArrayErrorCode.INVALID_LVH_EXECUTION_RESPONSE,
         ...this.lvhError,

--- a/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
@@ -631,9 +631,9 @@ function collectProtoarrayValidationStatus(fcArray: ProtoArray): ValidationTestC
   for (const fcRoot of fcRoots) {
     const fcNode = fcArray.getNode(fcRoot);
     const bestChild =
-      fcNode?.bestChild !== undefined ? fcArray.getNodeFromIndex(fcNode.bestChild).blockRoot : undefined;
+      fcNode?.bestChild !== undefined ? fcArray["getNodeFromIndex"](fcNode.bestChild).blockRoot : undefined;
     const bestDescendant =
-      fcNode?.bestDescendant !== undefined ? fcArray.getNodeFromIndex(fcNode.bestDescendant).blockRoot : undefined;
+      fcNode?.bestDescendant !== undefined ? fcArray["getNodeFromIndex"](fcNode.bestDescendant).blockRoot : undefined;
     expectedForkChoice.push({
       root: fcRoot,
       bestChild,

--- a/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
@@ -137,7 +137,7 @@ describe("executionStatus / normal updates", () => {
     {
       executionStatus: ExecutionStatus.Invalid,
       latestValidExecHash: "2C",
-      invalidateTillBlockHash: "3C",
+      invalidateFromBlockHash: "3C",
     },
     3
   );
@@ -276,7 +276,7 @@ describe("executionStatus / normal updates", () => {
     {
       executionStatus: ExecutionStatus.Invalid,
       latestValidExecHash: "1A",
-      invalidateTillBlockHash: "3A",
+      invalidateFromBlockHash: "3A",
     },
     3
   );
@@ -361,7 +361,7 @@ describe("executionStatus / invalidate all postmerge chain", () => {
     {
       executionStatus: ExecutionStatus.Invalid,
       latestValidExecHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
-      invalidateTillBlockHash: "3B",
+      invalidateFromBlockHash: "3B",
     },
     3
   );
@@ -514,7 +514,7 @@ describe("executionStatus / poision forkchoice if we invalidate previous valid",
         {
           executionStatus: ExecutionStatus.Invalid,
           latestValidExecHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
-          invalidateTillBlockHash: "3A",
+          invalidateFromBlockHash: "3A",
         },
         3
       )
@@ -551,7 +551,7 @@ describe("executionStatus / poision forkchoice if we validate previous invalid",
     {
       executionStatus: ExecutionStatus.Invalid,
       latestValidExecHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
-      invalidateTillBlockHash: "3B",
+      invalidateFromBlockHash: "3B",
     },
     3
   );

--- a/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
@@ -1,0 +1,645 @@
+import {expect} from "chai";
+import {
+  ProtoBlock,
+  ProtoArray,
+  ExecutionStatus,
+  MaybeValidExecutionStatus,
+  BlockExecution,
+} from "../../../src/index.js";
+import {LVHExecErrorCode} from "../../../src/protoArray/errors.js";
+
+type ValidationTestCase = {
+  root: string;
+  bestChild?: string;
+  bestDescendant?: string;
+  executionStatus: ExecutionStatus | undefined;
+};
+
+type TestBlock = {slot: number; root: string; parent: string; executionStatus: MaybeValidExecutionStatus};
+const blocks: TestBlock[] = [
+  {slot: 1, root: "1A", parent: "0", executionStatus: ExecutionStatus.Syncing},
+  {slot: 2, root: "2A", parent: "1A", executionStatus: ExecutionStatus.Syncing},
+  {slot: 3, root: "3A", parent: "2A", executionStatus: ExecutionStatus.Syncing},
+  {slot: 2, root: "2B", parent: "1A", executionStatus: ExecutionStatus.Syncing},
+  {slot: 2, root: "3B", parent: "2B", executionStatus: ExecutionStatus.Syncing},
+  {slot: 2, root: "2C", parent: "none", executionStatus: ExecutionStatus.Syncing},
+  {slot: 3, root: "3C", parent: "2C", executionStatus: ExecutionStatus.Syncing},
+];
+const fcRoots: string[] = ["0"];
+for (const block of blocks) {
+  fcRoots.push(block.root);
+}
+
+const expectedPreValidationFC: ValidationTestCase[] = [
+  {
+    root: "0",
+    bestChild: "1A",
+    bestDescendant: "3B",
+    executionStatus: ExecutionStatus.PreMerge,
+  },
+  {root: "1A", bestChild: "2B", bestDescendant: "3B", executionStatus: ExecutionStatus.Syncing},
+  {root: "2A", bestChild: "3A", bestDescendant: "3A", executionStatus: ExecutionStatus.Syncing},
+  {root: "3A", bestChild: undefined, bestDescendant: undefined, executionStatus: ExecutionStatus.Syncing},
+  {root: "2B", bestChild: "3B", bestDescendant: "3B", executionStatus: ExecutionStatus.Syncing},
+  {root: "3B", bestChild: undefined, bestDescendant: undefined, executionStatus: ExecutionStatus.Syncing},
+  {root: "2C", bestChild: "3C", bestDescendant: "3C", executionStatus: ExecutionStatus.Syncing},
+  {root: "3C", bestChild: undefined, bestDescendant: undefined, executionStatus: ExecutionStatus.Syncing},
+];
+
+/**
+ * Set up the following forkchoice  (~~ parent not in forkchoice, possibly bogus/NA)
+ *
+ *  0 (PreMerge) <- 1A (Syncing) <- 2A (Syncing) <- 3A (Syncing)
+ *                               ^- 2B (Syncing) <- 3B (Syncing)
+ *                               ~~ 2C (Syncing) <- 3C (Syncing)
+ */
+
+function setupForkChoice(): ProtoArray {
+  const fc = ProtoArray.initialize(
+    {
+      slot: 0,
+      stateRoot: "-",
+      parentRoot: "-",
+      blockRoot: "0",
+
+      justifiedEpoch: 0,
+      justifiedRoot: "-",
+      finalizedEpoch: 0,
+      finalizedRoot: "-",
+
+      ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
+    } as Omit<ProtoBlock, "targetRoot">,
+    0
+  );
+
+  for (const block of blocks) {
+    const executionData = (block.executionStatus === ExecutionStatus.PreMerge
+      ? {executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge}
+      : {executionPayloadBlockHash: block.root, executionStatus: block.executionStatus}) as BlockExecution;
+    fc.onBlock(
+      {
+        slot: block.slot,
+        blockRoot: block.root,
+        parentRoot: block.parent,
+        stateRoot: "-",
+        targetRoot: "-",
+
+        justifiedEpoch: 0,
+        justifiedRoot: "-",
+        finalizedEpoch: 0,
+        finalizedRoot: "-",
+
+        unrealizedJustifiedEpoch: 0,
+        unrealizedJustifiedRoot: "-",
+        unrealizedFinalizedEpoch: 0,
+        unrealizedFinalizedRoot: "-",
+
+        ...executionData,
+      },
+      block.slot
+    );
+  }
+
+  const deltas = Array.from({length: fc.nodes.length}, () => 0);
+  fc.applyScoreChanges({
+    deltas,
+    proposerBoost: null,
+    justifiedEpoch: 0,
+    justifiedRoot: "-",
+    finalizedEpoch: 0,
+    finalizedRoot: "-",
+    currentSlot: 3,
+  });
+  return fc;
+}
+
+describe("executionStatus / normal updates", () => {
+  const fc = setupForkChoice();
+
+  /**
+   *  0 (PreMerge) <- 1A (Syncing) <- 2A (Syncing) <- 3A (Syncing)
+   *                               ^- 2B (Syncing) <- 3B (Syncing)
+   *                               ~~ 2C (Syncing) <- 3C (Syncing)
+   */
+  const preValidation = collectProtoarrayValidationStatus(fc);
+  it("preValidation forkchoice setup should be correct", () => {
+    expect(preValidation).to.be.deep.equal(expectedPreValidationFC);
+  });
+
+  /**
+   * Invalidate 3C with LVH on 2C which stays in Syncing
+   *
+   *  0 (PreMerge) <- 1A (Syncing) <- 2A (Syncing) <- 3A (Syncing)
+   *                               ^- 2B (Syncing) <- 3B (Syncing)
+   *                               ~~ 2C (Syncing) <- 3C (Invalid)
+   */
+  fc.validateLatestHash(
+    {
+      executionStatus: ExecutionStatus.Invalid,
+      latestValidExecHash: "2C",
+      invalidateTillBlockHash: "3C",
+    },
+    3
+  );
+
+  const invalidate3CValidate2CForkChoice = collectProtoarrayValidationStatus(fc);
+  it("correcly invalidate 3C and validate 2C only", () => {
+    expect(invalidate3CValidate2CForkChoice).to.be.deep.equal([
+      {
+        root: "0",
+        bestChild: "1A",
+        bestDescendant: "3B",
+        executionStatus: ExecutionStatus.PreMerge,
+      },
+      {
+        root: "1A",
+        bestChild: "2B",
+        bestDescendant: "3B",
+        executionStatus: "Syncing",
+      },
+      {
+        root: "2A",
+        bestChild: "3A",
+        bestDescendant: "3A",
+        executionStatus: "Syncing",
+      },
+      {
+        root: "3A",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Syncing",
+      },
+      {
+        root: "2B",
+        bestChild: "3B",
+        bestDescendant: "3B",
+        executionStatus: "Syncing",
+      },
+      {
+        root: "3B",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Syncing",
+      },
+      {
+        root: "2C",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Syncing",
+      },
+      {
+        root: "3C",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Invalid",
+      },
+    ]);
+  });
+
+  /**
+   * Validate 3B, 2B, 1A (premerge)
+   *
+   *  0 (PreMerge) <- 1A (Valid)   <- 2A (Syncing) <- 3A (Syncing)
+   *                               ^- 2B (Valid)   <- 3B (Valid)
+   *                               ~~ 2C (Syncing) <- 3C (Invalid)
+   */
+  fc.validateLatestHash(
+    {
+      executionStatus: ExecutionStatus.Valid,
+      latestValidExecHash: "3B",
+    },
+    3
+  );
+  const validate3B2B1A = collectProtoarrayValidationStatus(fc);
+  it("Validate 3B, 2B, 1A", () => {
+    expect(validate3B2B1A).to.be.deep.equal([
+      {
+        root: "0",
+        bestChild: "1A",
+        bestDescendant: "3B",
+        executionStatus: ExecutionStatus.PreMerge,
+      },
+      {
+        root: "1A",
+        bestChild: "2B",
+        bestDescendant: "3B",
+        executionStatus: "Valid",
+      },
+      {
+        root: "2A",
+        bestChild: "3A",
+        bestDescendant: "3A",
+        executionStatus: "Syncing",
+      },
+      {
+        root: "3A",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Syncing",
+      },
+      {
+        root: "2B",
+        bestChild: "3B",
+        bestDescendant: "3B",
+        executionStatus: "Valid",
+      },
+      {
+        root: "3B",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Valid",
+      },
+      {
+        root: "2C",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Syncing",
+      },
+      {
+        root: "3C",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Invalid",
+      },
+    ]);
+  });
+
+  /**
+   * Invalidate 3A, 2A with 2A loosing its bestChild, bestDescendant
+   *
+   *  0 (PreMerge) <- 1A (Valid)   <- 2A (Invalid) <- 3A (Invalid)
+   *                               ^- 2B (Valid)   <- 3B (Valid)
+   *                               ~~ 2C (Syncing) <- 3C (Invalid)
+   */
+
+  fc.validateLatestHash(
+    {
+      executionStatus: ExecutionStatus.Invalid,
+      latestValidExecHash: "1A",
+      invalidateTillBlockHash: "3A",
+    },
+    3
+  );
+  const invalidate3A2A = collectProtoarrayValidationStatus(fc);
+  it("Invalidate 3A, 2A with 2A loosing its bestChild, bestDescendant", () => {
+    expect(invalidate3A2A).to.be.deep.equal([
+      {
+        root: "0",
+        bestChild: "1A",
+        bestDescendant: "3B",
+        executionStatus: ExecutionStatus.PreMerge,
+      },
+      {
+        root: "1A",
+        bestChild: "2B",
+        bestDescendant: "3B",
+        executionStatus: "Valid",
+      },
+      {
+        root: "2A",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Invalid",
+      },
+      {
+        root: "3A",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Invalid",
+      },
+      {
+        root: "2B",
+        bestChild: "3B",
+        bestDescendant: "3B",
+        executionStatus: "Valid",
+      },
+      {
+        root: "3B",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Valid",
+      },
+      {
+        root: "2C",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Syncing",
+      },
+      {
+        root: "3C",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Invalid",
+      },
+    ]);
+  });
+});
+
+describe("executionStatus / invalidate all postmerge chain", () => {
+  const fc = setupForkChoice();
+
+  /**
+   * Set up the following forkchoice  (~~ parent not in forkchoice, possibly bogus/NA)
+   *
+   *  0 (PreMerge) <- 1A (Syncing) <- 2A (Syncing) <- 3A (Syncing)
+   *                               ^- 2B (Syncing) <- 3B (Syncing)
+   *                               ~~ 2C (Syncing) <- 3C (Syncing)
+   */
+  const preValidation = collectProtoarrayValidationStatus(fc);
+  it("preValidation forkchoice setup should be correct", () => {
+    expect(preValidation).to.be.deep.equal(expectedPreValidationFC);
+  });
+
+  /**
+   * All post merge blocks should be invalidated except Cs
+   *
+   *  0 (PreMerge) <- 1A (Invalid) <- 2A (Invalid) <- 3A (Invalid)
+   *                               ^- 2B (Invalid) <- 3B (Invalid)
+   *                               ~~ 2C (Syncing) <- 3C (Syncing)
+   */
+  fc.validateLatestHash(
+    {
+      executionStatus: ExecutionStatus.Invalid,
+      latestValidExecHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+      invalidateTillBlockHash: "3B",
+    },
+    3
+  );
+  const postMergeInvalidated = collectProtoarrayValidationStatus(fc);
+  it("all post merge blocks should be invalidated except Cs", () => {
+    expect(postMergeInvalidated).to.be.deep.equal([
+      {
+        root: "0",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: ExecutionStatus.PreMerge,
+      },
+      {
+        root: "1A",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Invalid",
+      },
+      {
+        root: "2A",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Invalid",
+      },
+      {
+        root: "3A",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Invalid",
+      },
+      {
+        root: "2B",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Invalid",
+      },
+      {
+        root: "3B",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Invalid",
+      },
+      {
+        root: "2C",
+        bestChild: "3C",
+        bestDescendant: "3C",
+        executionStatus: "Syncing",
+      },
+      {
+        root: "3C",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Syncing",
+      },
+    ]);
+  });
+
+  const fcHead = fc.findHead("0", 3);
+  it("pre merge block should be the FC head", () => {
+    expect(fcHead).to.be.equal("0");
+  });
+});
+
+describe("executionStatus / poision forkchoice if we invalidate previous valid", () => {
+  const fc = setupForkChoice();
+
+  /**
+   * Set up the following forkchoice  (~~ parent not in forkchoice, possibly bogus/NA)
+   *
+   *  0 (PreMerge) <- 1A (Syncing) <- 2A (Syncing) <- 3A (Syncing)
+   *                               ^- 2B (Syncing) <- 3B (Syncing)
+   *                               ~~ 2C (Syncing) <- 3C (Syncing)
+   */
+  const preValidation = collectProtoarrayValidationStatus(fc);
+  it("preValidation forkchoice setup should be correct", () => {
+    expect(preValidation).to.be.deep.equal(expectedPreValidationFC);
+  });
+
+  /**
+   * Validate 3B, 2B, 1A (premerge)
+   *
+   *  0 (PreMerge) <- 1A (Valid)   <- 2A (Syncing) <- 3A (Syncing)
+   *                               ^- 2B (Valid)   <- 3B (Valid)
+   *                               ~~ 2C (Syncing) <- 3C (Syncing)
+   */
+  fc.validateLatestHash(
+    {
+      executionStatus: ExecutionStatus.Valid,
+      latestValidExecHash: "3B",
+    },
+    3
+  );
+  const validate3B2B1A = collectProtoarrayValidationStatus(fc);
+  it("Validate 3B, 2B, 1A", () => {
+    expect(validate3B2B1A).to.be.deep.equal([
+      {
+        root: "0",
+        bestChild: "1A",
+        bestDescendant: "3B",
+        executionStatus: ExecutionStatus.PreMerge,
+      },
+      {
+        root: "1A",
+        bestChild: "2B",
+        bestDescendant: "3B",
+        executionStatus: "Valid",
+      },
+      {
+        root: "2A",
+        bestChild: "3A",
+        bestDescendant: "3A",
+        executionStatus: "Syncing",
+      },
+      {
+        root: "3A",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Syncing",
+      },
+      {
+        root: "2B",
+        bestChild: "3B",
+        bestDescendant: "3B",
+        executionStatus: "Valid",
+      },
+      {
+        root: "3B",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Valid",
+      },
+      {
+        root: "2C",
+        bestChild: "3C",
+        bestDescendant: "3C",
+        executionStatus: "Syncing",
+      },
+      {
+        root: "3C",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Syncing",
+      },
+    ]);
+  });
+
+  it("protoarray should be poisioned with a buggy LVH response", () => {
+    expect(() =>
+      fc.validateLatestHash(
+        {
+          executionStatus: ExecutionStatus.Invalid,
+          latestValidExecHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+          invalidateTillBlockHash: "3A",
+        },
+        3
+      )
+    ).to.throw(Error);
+
+    expect(fc.lvhError).to.be.deep.equal({lvhCode: LVHExecErrorCode.ValidToInvalid, blockRoot: "1A", execHash: "1A"});
+    expect(() => fc.findHead("0", 3)).to.throw(Error);
+  });
+});
+
+describe("executionStatus / poision forkchoice if we validate previous invalid", () => {
+  const fc = setupForkChoice();
+
+  /**
+   * Set up the following forkchoice  (~~ parent not in forkchoice, possibly bogus/NA)
+   *
+   *  0 (PreMerge) <- 1A (Syncing) <- 2A (Syncing) <- 3A (Syncing)
+   *                               ^- 2B (Syncing) <- 3B (Syncing)
+   *                               ~~ 2C (Syncing) <- 3C (Syncing)
+   */
+  const preValidation = collectProtoarrayValidationStatus(fc);
+  it("preValidation forkchoice setup should be correct", () => {
+    expect(preValidation).to.be.deep.equal(expectedPreValidationFC);
+  });
+
+  /**
+   * Invalidate 3B, 2B, 1A
+   *
+   *  0 (PreMerge) <- 1A (Invalid) <- 2A (Invalid) <- 3A (Invalid)
+   *                               ^- 2B (Invalid)   <- 3B (Invalid)
+   *                               ~~ 2C (Syncing) <- 3C (Syncing)
+   */
+  fc.validateLatestHash(
+    {
+      executionStatus: ExecutionStatus.Invalid,
+      latestValidExecHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+      invalidateTillBlockHash: "3B",
+    },
+    3
+  );
+  const validate3B2B1A = collectProtoarrayValidationStatus(fc);
+  it("Inalidate 3B, 2B, 1A", () => {
+    expect(validate3B2B1A).to.be.deep.equal([
+      {
+        root: "0",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: ExecutionStatus.PreMerge,
+      },
+      {
+        root: "1A",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Invalid",
+      },
+      {
+        root: "2A",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Invalid",
+      },
+      {
+        root: "3A",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Invalid",
+      },
+      {
+        root: "2B",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Invalid",
+      },
+      {
+        root: "3B",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Invalid",
+      },
+      {
+        root: "2C",
+        bestChild: "3C",
+        bestDescendant: "3C",
+        executionStatus: "Syncing",
+      },
+      {
+        root: "3C",
+        bestChild: undefined,
+        bestDescendant: undefined,
+        executionStatus: "Syncing",
+      },
+    ]);
+  });
+
+  it("protoarray should be poisioned with a buggy LVH response", () => {
+    expect(() =>
+      fc.validateLatestHash(
+        {
+          executionStatus: ExecutionStatus.Valid,
+          latestValidExecHash: "2A",
+        },
+        3
+      )
+    ).to.throw(Error);
+
+    expect(fc.lvhError).to.be.deep.equal({lvhCode: LVHExecErrorCode.InvalidToValid, blockRoot: "2A", execHash: "2A"});
+    expect(() => fc.findHead("0", 3)).to.throw(Error);
+  });
+});
+
+function collectProtoarrayValidationStatus(fcArray: ProtoArray): ValidationTestCase[] {
+  const expectedForkChoice: ValidationTestCase[] = [];
+
+  for (const fcRoot of fcRoots) {
+    const fcNode = fcArray.getNode(fcRoot);
+    const bestChild =
+      fcNode?.bestChild !== undefined ? fcArray.getNodeFromIndex(fcNode.bestChild).blockRoot : undefined;
+    const bestDescendant =
+      fcNode?.bestDescendant !== undefined ? fcArray.getNodeFromIndex(fcNode.bestDescendant).blockRoot : undefined;
+    expectedForkChoice.push({
+      root: fcRoot,
+      bestChild,
+      bestDescendant,
+      executionStatus: fcNode?.executionStatus,
+    });
+  }
+  return expectedForkChoice;
+}


### PR DESCRIPTION
**Motivation**
Post merge, engine can give optimistic `syncing` status on fcU heads which can (should be) eventually resolved into `valid`/`invalid`.
This need to be propagated to forkchoice and remove the consideration of invalids and their descendant from the forkchoice,
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR implements the fcU updates coming from from the execution via latestValidHash

TODO testcases:
- [x] for propagate valid
~~- [ ] verify is_merge_block if the mergeblock has not yet been validated~~ moved to a separate issue as doesn't addressing this may be a bit more evolved, though EL already should have run terminal validations and hence de duping work isn't really necessary.
- [x] for propagate invalid
  - [x] with latest hash found in forkchoice
  - [x] with latesthash  not found in forkchoice

- [x] real life optimistic sync testing against ELs

Closes #3508

Testcases summary:
```shell
  executionStatus / normal updates
    ✔ preValidation forkchoice setup should be correct
    ✔ correcly invalidate 3C and validate 2C only
    ✔ Validate 3B, 2B, 1A
    ✔ Invalidate 3A, 2A with 2A loosing its bestChild, bestDescendant

  executionStatus / invalidate all postmerge chain
    ✔ preValidation forkchoice setup should be correct
    ✔ all post merge blocks should be invalidated except Cs
    ✔ pre merge block should be the FC head

  executionStatus / poision forkchoice if we invalidate previous valid
    ✔ preValidation forkchoice setup should be correct
    ✔ Validate 3B, 2B, 1A
    ✔ protoarray should be poisioned with a buggy LVH response

  executionStatus / poision forkchoice if we validate previous invalid
    ✔ preValidation forkchoice setup should be correct
    ✔ Inalidate 3B, 2B, 1A
    ✔ protoarray should be poisioned with a buggy LVH response


  13 passing (8ms)
```