### PR TITLE
Remove I prefix for fork-choice types

### DIFF
--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -1,7 +1,7 @@
 import {EffectiveBalanceIncrements} from "@chainsafe/lodestar-beacon-state-transition";
 import {BeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {Epoch, Slot, ValidatorIndex, phase0, allForks, Root, RootHex} from "@chainsafe/lodestar-types";
-import {IProtoBlock, ExecutionStatus} from "../protoArray/interface.js";
+import {ProtoBlock, ExecutionStatus} from "../protoArray/interface.js";
 import {CheckpointWithHex} from "./store.js";
 
 export type CheckpointHex = {
@@ -31,12 +31,12 @@ export interface IForkChoice {
    * https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/fork-choice.md#get_head
    */
   getHeadRoot(): RootHex;
-  getHead(): IProtoBlock;
-  updateHead(): IProtoBlock;
+  getHead(): ProtoBlock;
+  updateHead(): ProtoBlock;
   /**
    * Retrieves all possible chain heads (leaves of fork choice tree).
    */
-  getHeads(): IProtoBlock[];
+  getHeads(): ProtoBlock[];
   getFinalizedCheckpoint(): CheckpointWithHex;
   getJustifiedCheckpoint(): CheckpointWithHex;
   /**
@@ -78,7 +78,7 @@ export interface IForkChoice {
    * will not be run here.
    */
   onAttestation(attestation: phase0.IndexedAttestation, attDataRoot?: string): void;
-  getLatestMessage(validatorIndex: ValidatorIndex): ILatestMessage | undefined;
+  getLatestMessage(validatorIndex: ValidatorIndex): LatestMessage | undefined;
   /**
    * Call `onTick` for all slots between `fcStore.getCurrentSlot()` and the provided `currentSlot`.
    */
@@ -94,12 +94,12 @@ export interface IForkChoice {
   hasBlock(blockRoot: Root): boolean;
   hasBlockHex(blockRoot: RootHex): boolean;
   /**
-   * Returns a `IProtoBlock` if the block is known **and** a descendant of the finalized root.
+   * Returns a `ProtoBlock` if the block is known **and** a descendant of the finalized root.
    */
-  getBlock(blockRoot: Root): IProtoBlock | null;
-  getBlockHex(blockRoot: RootHex): IProtoBlock | null;
-  getFinalizedBlock(): IProtoBlock;
-  getJustifiedBlock(): IProtoBlock;
+  getBlock(blockRoot: Root): ProtoBlock | null;
+  getBlockHex(blockRoot: RootHex): ProtoBlock | null;
+  getFinalizedBlock(): ProtoBlock;
+  getJustifiedBlock(): ProtoBlock;
   /**
    * Return `true` if `block_root` is equal to the finalized root, or a known descendant of it.
    */
@@ -114,26 +114,26 @@ export interface IForkChoice {
   /**
    * Prune items up to a finalized root.
    */
-  prune(finalizedRoot: RootHex): IProtoBlock[];
+  prune(finalizedRoot: RootHex): ProtoBlock[];
   setPruneThreshold(threshold: number): void;
   /**
    * Iterates backwards through ancestor block summaries, starting from a block root
    */
-  iterateAncestorBlocks(blockRoot: RootHex): IterableIterator<IProtoBlock>;
-  getAllAncestorBlocks(blockRoot: RootHex): IProtoBlock[];
+  iterateAncestorBlocks(blockRoot: RootHex): IterableIterator<ProtoBlock>;
+  getAllAncestorBlocks(blockRoot: RootHex): ProtoBlock[];
   /**
    * The same to iterateAncestorBlocks but this gets non-ancestor nodes instead of ancestor nodes.
    */
-  getAllNonAncestorBlocks(blockRoot: RootHex): IProtoBlock[];
-  getCanonicalBlockAtSlot(slot: Slot): IProtoBlock | null;
+  getAllNonAncestorBlocks(blockRoot: RootHex): ProtoBlock[];
+  getCanonicalBlockAtSlot(slot: Slot): ProtoBlock | null;
   /**
    * Iterates forwards through block summaries, exact order is not guaranteed
    */
-  forwarditerateAncestorBlocks(): IProtoBlock[];
-  getBlockSummariesByParentRoot(parentRoot: RootHex): IProtoBlock[];
-  getBlockSummariesAtSlot(slot: Slot): IProtoBlock[];
+  forwarditerateAncestorBlocks(): ProtoBlock[];
+  getBlockSummariesByParentRoot(parentRoot: RootHex): ProtoBlock[];
+  getBlockSummariesAtSlot(slot: Slot): ProtoBlock[];
   /** Returns the distance of common ancestor of nodes to newNode. Returns null if newNode is descendant of prevNode */
-  getCommonAncestorDistance(prevBlock: IProtoBlock, newBlock: IProtoBlock): number | null;
+  getCommonAncestorDistance(prevBlock: ProtoBlock, newBlock: ProtoBlock): number | null;
   /**
    * Optimistic sync validate till validated latest hash, invalidate any decendant branch if invalidated branch decendant provided
    */
@@ -155,18 +155,18 @@ export type OnBlockPrecachedData = {
   executionStatus?: ExecutionStatus;
 };
 
-export interface ILatestMessage {
+export type LatestMessage = {
   epoch: Epoch;
   root: RootHex;
-}
+};
 
 /**
  * Used for queuing attestations from the current slot. Only contains the minimum necessary
  * information about the attestation.
  */
-export interface IQueuedAttestation {
+export type QueuedAttestation = {
   slot: Slot;
   attestingIndices: ValidatorIndex[];
   blockRoot: RootHex;
   targetEpoch: Epoch;
-}
+};

--- a/packages/fork-choice/src/index.ts
+++ b/packages/fork-choice/src/index.ts
@@ -1,14 +1,8 @@
 export {ProtoArray} from "./protoArray/protoArray.js";
-export {IProtoBlock, IProtoNode, ExecutionStatus} from "./protoArray/interface.js";
+export {ProtoBlock, ProtoNode, ExecutionStatus} from "./protoArray/interface.js";
 
 export {ForkChoice, assertValidTerminalPowBlock} from "./forkChoice/forkChoice.js";
-export {
-  IForkChoice,
-  OnBlockPrecachedData,
-  PowBlockHex,
-  ILatestMessage,
-  IQueuedAttestation,
-} from "./forkChoice/interface.js";
+export {IForkChoice, OnBlockPrecachedData, PowBlockHex} from "./forkChoice/interface.js";
 export {ForkChoiceStore, IForkChoiceStore, CheckpointWithHex} from "./forkChoice/store.js";
 export {
   InvalidAttestation,

--- a/packages/fork-choice/src/protoArray/computeDeltas.ts
+++ b/packages/fork-choice/src/protoArray/computeDeltas.ts
@@ -1,5 +1,5 @@
 import {EffectiveBalanceIncrements} from "@chainsafe/lodestar-beacon-state-transition";
-import {IVoteTracker, HEX_ZERO_HASH} from "./interface.js";
+import {VoteTracker, HEX_ZERO_HASH} from "./interface.js";
 import {ProtoArrayError, ProtoArrayErrorCode} from "./errors.js";
 
 /**
@@ -13,7 +13,7 @@ import {ProtoArrayError, ProtoArrayErrorCode} from "./errors.js";
  */
 export function computeDeltas(
   indices: Map<string, number>,
-  votes: IVoteTracker[],
+  votes: VoteTracker[],
   oldBalances: EffectiveBalanceIncrements,
   newBalances: EffectiveBalanceIncrements
 ): number[] {

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -7,11 +7,11 @@ export const HEX_ZERO_HASH = "0x000000000000000000000000000000000000000000000000
 /**
  * Simplified 'latest message' with previous message
  */
-export interface IVoteTracker {
+export type VoteTracker = {
   currentRoot: RootHex;
   nextRoot: RootHex;
   nextEpoch: Epoch;
-}
+};
 
 export enum ExecutionStatus {
   Valid = "Valid",
@@ -28,7 +28,7 @@ type BlockExecution =
  * A simplified version of BeaconBlock
  */
 
-export type IProtoBlock = BlockExecution & {
+export type ProtoBlock = BlockExecution & {
   /**
    * The slot is not necessary for ProtoArray,
    * it just exists so external components can easily query the block slot.
@@ -60,7 +60,7 @@ export type IProtoBlock = BlockExecution & {
  * A block root with additional metadata required to form a DAG
  * with vote weights and best blocks stored as metadata
  */
-export type IProtoNode = IProtoBlock & {
+export type ProtoNode = ProtoBlock & {
   parent?: number;
   weight: number;
   bestChild?: number;

--- a/packages/fork-choice/test/perf/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/perf/forkChoice/forkChoice.test.ts
@@ -5,7 +5,7 @@ import {ATTESTATION_SUBNET_COUNT} from "@chainsafe/lodestar-params";
 import {getEffectiveBalanceIncrementsZeroed} from "@chainsafe/lodestar-beacon-state-transition";
 import {ssz} from "@chainsafe/lodestar-types";
 import {fromHexString} from "@chainsafe/ssz";
-import {ExecutionStatus, ForkChoice, IForkChoiceStore, IProtoBlock, ProtoArray} from "../../../src/index.js";
+import {ExecutionStatus, ForkChoice, IForkChoiceStore, ProtoBlock, ProtoArray} from "../../../src/index.js";
 
 describe("ForkChoice", () => {
   let forkchoice: ForkChoice;
@@ -35,7 +35,7 @@ describe("ForkChoice", () => {
 
       executionPayloadBlockHash: null,
       executionStatus: ExecutionStatus.PreMerge,
-    } as Omit<IProtoBlock, "targetRoot">);
+    } as Omit<ProtoBlock, "targetRoot">);
 
     const fcStore: IForkChoiceStore = {
       currentSlot: genesisSlot,
@@ -50,7 +50,7 @@ describe("ForkChoice", () => {
     // assume there are 64 unfinalized blocks, this number does not make a difference in term of performance
     for (let i = 1; i < 64; i++) {
       const blockRoot = i < 10 ? blockRootPrefix + "0" + i : blockRootPrefix + i;
-      const block: IProtoBlock = {
+      const block: ProtoBlock = {
         slot: genesisSlot + i,
         blockRoot,
         parentRoot: parentBlockRoot,

--- a/packages/fork-choice/test/perf/protoArray/computeDeltas.test.ts
+++ b/packages/fork-choice/test/perf/protoArray/computeDeltas.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {TIMELY_SOURCE_FLAG_INDEX} from "@chainsafe/lodestar-params";
 import {generatePerfTestCachedStateAltair} from "../../../../beacon-state-transition/test/perf/util.js";
-import {IVoteTracker} from "../../../src/protoArray/interface.js";
+import {VoteTracker} from "../../../src/protoArray/interface.js";
 import {computeDeltas} from "../../../src/protoArray/computeDeltas.js";
 import {computeProposerBoostScoreFromBalances} from "../../../src/forkChoice/forkChoice.js";
 
@@ -63,7 +63,7 @@ describe("computeDeltas", () => {
   itBench({
     id: "computeDeltas",
     beforeEach: () => {
-      const votes: IVoteTracker[] = [];
+      const votes: VoteTracker[] = [];
       const epoch = originalState.epochCtx.currentShuffling.epoch;
       const committee = originalState.epochCtx.getBeaconCommittee(computeStartSlotAtEpoch(epoch), 0);
       for (let i = 0; i < 250000; i++) {

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/default";
 import {fromHexString} from "@chainsafe/ssz";
 import {getEffectiveBalanceIncrementsZeroed} from "@chainsafe/lodestar-beacon-state-transition";
-import {ForkChoice, IForkChoiceStore, IProtoBlock, ProtoArray, ExecutionStatus} from "../../../src/index.js";
+import {ForkChoice, IForkChoiceStore, ProtoBlock, ProtoArray, ExecutionStatus} from "../../../src/index.js";
 
 describe("Forkchoice", function () {
   const genesisSlot = 0;
@@ -27,10 +27,10 @@ describe("Forkchoice", function () {
 
     executionPayloadBlockHash: null,
     executionStatus: ExecutionStatus.PreMerge,
-  } as Omit<IProtoBlock, "targetRoot">);
+  } as Omit<ProtoBlock, "targetRoot">);
 
   // Add block that is a finalized descendant.
-  const block: IProtoBlock = {
+  const block: ProtoBlock = {
     slot: genesisSlot + 1,
     blockRoot: finalizedDesc,
     parentRoot: finalizedRoot,

--- a/packages/lodestar/src/chain/blocks/types.ts
+++ b/packages/lodestar/src/chain/blocks/types.ts
@@ -1,5 +1,5 @@
 import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
-import {IProtoBlock, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
+import {ProtoBlock, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
 import {allForks} from "@chainsafe/lodestar-types";
 
 export type FullyVerifiedBlockFlags = {
@@ -50,7 +50,7 @@ export type PartiallyVerifiedBlockFlags = FullyVerifiedBlockFlags & {
 export type FullyVerifiedBlock = FullyVerifiedBlockFlags & {
   block: allForks.SignedBeaconBlock;
   postState: CachedBeaconStateAllForks;
-  parentBlock: IProtoBlock;
+  parentBlock: ProtoBlock;
 };
 
 /**

--- a/packages/lodestar/src/chain/blocks/verifyBlock.ts
+++ b/packages/lodestar/src/chain/blocks/verifyBlock.ts
@@ -11,7 +11,7 @@ import {
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {bellatrix} from "@chainsafe/lodestar-types";
 import {toHexString} from "@chainsafe/ssz";
-import {IForkChoice, IProtoBlock, ExecutionStatus, assertValidTerminalPowBlock} from "@chainsafe/lodestar-fork-choice";
+import {IForkChoice, ProtoBlock, ExecutionStatus, assertValidTerminalPowBlock} from "@chainsafe/lodestar-fork-choice";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {ILogger} from "@chainsafe/lodestar-utils";
 import {IMetrics} from "../../metrics/index.js";
@@ -76,7 +76,7 @@ export async function verifyBlock(
 export function verifyBlockSanityChecks(
   chain: VerifyBlockModules,
   partiallyVerifiedBlock: PartiallyVerifiedBlock
-): IProtoBlock {
+): ProtoBlock {
   const {block} = partiallyVerifiedBlock;
   const blockSlot = block.message.slot;
 

--- a/packages/lodestar/src/chain/emitter.ts
+++ b/packages/lodestar/src/chain/emitter.ts
@@ -3,7 +3,7 @@ import StrictEventEmitter from "strict-event-emitter-types";
 
 import {routes} from "@chainsafe/lodestar-api";
 import {phase0, Epoch, Slot, allForks} from "@chainsafe/lodestar-types";
-import {CheckpointWithHex, IProtoBlock} from "@chainsafe/lodestar-fork-choice";
+import {CheckpointWithHex, ProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
 import {AttestationError, BlockError} from "./errors/index.js";
 
@@ -119,8 +119,8 @@ export interface IChainEvents {
   [ChainEvent.clockSlot]: (slot: Slot) => void;
   [ChainEvent.clockEpoch]: (epoch: Epoch) => void;
 
-  [ChainEvent.forkChoiceHead]: (head: IProtoBlock) => void;
-  [ChainEvent.forkChoiceReorg]: (head: IProtoBlock, oldHead: IProtoBlock, depth: number) => void;
+  [ChainEvent.forkChoiceHead]: (head: ProtoBlock) => void;
+  [ChainEvent.forkChoiceReorg]: (head: ProtoBlock, oldHead: ProtoBlock, depth: number) => void;
   [ChainEvent.forkChoiceJustified]: (checkpoint: CheckpointWithHex) => void;
   [ChainEvent.forkChoiceFinalized]: (checkpoint: CheckpointWithHex) => void;
 

--- a/packages/lodestar/src/chain/eventHandlers.ts
+++ b/packages/lodestar/src/chain/eventHandlers.ts
@@ -1,7 +1,7 @@
 import {toHexString} from "@chainsafe/ssz";
 import {allForks, Epoch, phase0, Slot, Version} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
-import {CheckpointWithHex, IProtoBlock} from "@chainsafe/lodestar-fork-choice";
+import {CheckpointWithHex, ProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {CachedBeaconStateAllForks, computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {AttestationError, BlockError, BlockErrorCode} from "./errors/index.js";
 import {ChainEvent, IChainEvents} from "./emitter.js";
@@ -151,7 +151,7 @@ export async function onForkChoiceFinalized(this: BeaconChain, cp: CheckpointWit
   }
 }
 
-export function onForkChoiceHead(this: BeaconChain, head: IProtoBlock): void {
+export function onForkChoiceHead(this: BeaconChain, head: ProtoBlock): void {
   const delaySec = this.clock.secFromSlot(head.slot);
   this.logger.verbose("New chain head", {
     headSlot: head.slot,
@@ -171,7 +171,7 @@ export function onForkChoiceHead(this: BeaconChain, head: IProtoBlock): void {
   }
 }
 
-export function onForkChoiceReorg(this: BeaconChain, head: IProtoBlock, oldHead: IProtoBlock, depth: number): void {
+export function onForkChoiceReorg(this: BeaconChain, head: ProtoBlock, oldHead: ProtoBlock, depth: number): void {
   this.logger.verbose("Chain reorg", {
     depth,
     previousHead: oldHead.blockRoot,

--- a/packages/lodestar/src/chain/regen/regen.ts
+++ b/packages/lodestar/src/chain/regen/regen.ts
@@ -7,7 +7,7 @@ import {
   stateTransition,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
-import {IForkChoice, IProtoBlock} from "@chainsafe/lodestar-fork-choice";
+import {IForkChoice, ProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
@@ -196,7 +196,7 @@ export class StateRegenerator implements IStateRegenerator {
     return state;
   }
 
-  private findFirstStateBlock(stateRoot: RootHex): IProtoBlock {
+  private findFirstStateBlock(stateRoot: RootHex): ProtoBlock {
     for (const block of this.modules.forkChoice.forwarditerateAncestorBlocks()) {
       if (block !== undefined) {
         return block;

--- a/packages/lodestar/src/chain/validation/attestation.ts
+++ b/packages/lodestar/src/chain/validation/attestation.ts
@@ -1,5 +1,5 @@
 import {phase0, Epoch, Root, Slot} from "@chainsafe/lodestar-types";
-import {IProtoBlock} from "@chainsafe/lodestar-fork-choice";
+import {ProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {ATTESTATION_SUBNET_COUNT, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {toHexString} from "@chainsafe/ssz";
 import {
@@ -199,7 +199,7 @@ export function verifyHeadBlockAndTargetRoot(
   beaconBlockRoot: Root,
   targetRoot: Root,
   attestationEpoch: Epoch
-): IProtoBlock {
+): ProtoBlock {
   const headBlock = verifyHeadBlockIsKnown(chain, beaconBlockRoot);
   verifyAttestationTargetRoot(headBlock, targetRoot, attestationEpoch);
   return headBlock;
@@ -217,7 +217,7 @@ export function verifyHeadBlockAndTargetRoot(
  * it's still fine to ignore here because there's no need for us to handle attestations that are
  * already finalized.
  */
-function verifyHeadBlockIsKnown(chain: IBeaconChain, beaconBlockRoot: Root): IProtoBlock {
+function verifyHeadBlockIsKnown(chain: IBeaconChain, beaconBlockRoot: Root): ProtoBlock {
   // TODO (LH): Enforce a maximum skip distance for unaggregated attestations.
 
   const headBlock = chain.forkChoice.getBlock(beaconBlockRoot);
@@ -235,7 +235,7 @@ function verifyHeadBlockIsKnown(chain: IBeaconChain, beaconBlockRoot: Root): IPr
  * Verifies that the `attestation.data.target.root` is indeed the target root of the block at
  * `attestation.data.beacon_block_root`.
  */
-function verifyAttestationTargetRoot(headBlock: IProtoBlock, targetRoot: Root, attestationEpoch: Epoch): void {
+function verifyAttestationTargetRoot(headBlock: ProtoBlock, targetRoot: Root, attestationEpoch: Epoch): void {
   // Check the attestation target root.
   const headBlockEpoch = computeEpochAtSlot(headBlock.slot);
 

--- a/packages/lodestar/test/e2e/chain/lightclient.test.ts
+++ b/packages/lodestar/test/e2e/chain/lightclient.test.ts
@@ -5,7 +5,7 @@ import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {TimestampFormatCode} from "@chainsafe/lodestar-utils";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {Lightclient} from "@chainsafe/lodestar-light-client";
-import {IProtoBlock} from "@chainsafe/lodestar-fork-choice";
+import {ProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {computeStartSlotAtEpoch} from "@chainsafe/lodestar-beacon-state-transition";
 import {testLogger, LogLevel, TestLoggerOpts} from "../../utils/logger.js";
 import {getDevBeaconNode} from "../../utils/node/beacon.js";
@@ -103,7 +103,7 @@ describe("chain / lightclient", function () {
     // 4. On every new beacon node head, check that the lightclient is following closely
     //   - If too far behind error the test
     //   - If beacon node reaches the finality slot, resolve test
-    const promiseUntilHead = new Promise<IProtoBlock>((resolve) => {
+    const promiseUntilHead = new Promise<ProtoBlock>((resolve) => {
       bn.chain.emitter.on(ChainEvent.forkChoiceHead, async (head) => {
         // Wait for the second slot so syncCommitteeWitness is available
         if (head.slot > 2) {

--- a/packages/lodestar/test/unit/api/impl/beacon/blocks/utils.test.ts
+++ b/packages/lodestar/test/unit/api/impl/beacon/blocks/utils.test.ts
@@ -1,7 +1,7 @@
 import {SinonStubbedInstance} from "sinon";
 import {expect, use} from "chai";
 import chaiAsPromised from "chai-as-promised";
-import {ForkChoice, IProtoBlock, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
+import {ForkChoice, ProtoBlock, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
 import {toHexString} from "@chainsafe/ssz";
 import {resolveBlockId} from "../../../../../../src/api/impl/beacon/blocks/utils.js";
 import {generateEmptySignedBlock, generateProtoBlock} from "../../../../../utils/block.js";
@@ -21,7 +21,7 @@ describe("block api utils", function () {
     let server: ApiImplTestModules;
     let expectedBuffer: Buffer;
     let expectedRootHex: string;
-    let expectedSummary: IProtoBlock;
+    let expectedSummary: ProtoBlock;
 
     before(function () {
       expectedBuffer = Buffer.alloc(32, 2);

--- a/packages/lodestar/test/unit/api/impl/validator/produceAttestationData.test.ts
+++ b/packages/lodestar/test/unit/api/impl/validator/produceAttestationData.test.ts
@@ -2,7 +2,7 @@ import sinon, {SinonStubbedInstance} from "sinon";
 import chaiAsPromised from "chai-as-promised";
 import {use, expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/default";
-import {IProtoBlock} from "@chainsafe/lodestar-fork-choice";
+import {ProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {IBeaconSync, SyncState} from "../../../../../src/sync/interface.js";
 import {ApiModules} from "../../../../../src/api/impl/types.js";
 import {getValidatorApi} from "../../../../../src/api/impl/validator/index.js";
@@ -38,7 +38,7 @@ describe("api - validator - produceAttestationData", function () {
     const headSlot = 0;
     server.chainStub.clock = {currentSlot} as LocalClock;
     sinon.replaceGetter(syncStub, "state", () => SyncState.SyncingFinalized);
-    server.forkChoiceStub.getHead.returns({slot: headSlot} as IProtoBlock);
+    server.forkChoiceStub.getHead.returns({slot: headSlot} as ProtoBlock);
 
     // Should not allow any call to validator API
     const api = getValidatorApi(modules);

--- a/packages/lodestar/test/unit/chain/blocks/verifyBlock.test.ts
+++ b/packages/lodestar/test/unit/chain/blocks/verifyBlock.test.ts
@@ -1,7 +1,7 @@
 import sinon, {SinonStubbedInstance} from "sinon";
 
 import {config} from "@chainsafe/lodestar-config/default";
-import {ForkChoice, IProtoBlock} from "@chainsafe/lodestar-fork-choice";
+import {ForkChoice, ProtoBlock} from "@chainsafe/lodestar-fork-choice";
 
 import {allForks, ssz} from "@chainsafe/lodestar-types";
 import {verifyBlockSanityChecks, VerifyBlockModules} from "../../../../src/chain/blocks/verifyBlock.js";
@@ -25,7 +25,7 @@ describe("chain / blocks / verifyBlock", function () {
     clock = {currentSlot} as LocalClock;
     modules = ({config, forkChoice, clock} as Partial<VerifyBlockModules>) as VerifyBlockModules;
     // On first call, parentRoot is known
-    forkChoice.getBlockHex.returns({} as IProtoBlock);
+    forkChoice.getBlockHex.returns({} as ProtoBlock);
   });
 
   it("PARENT_UNKNOWN", function () {

--- a/packages/lodestar/test/unit/chain/precomputeNextEpochTransition.test.ts
+++ b/packages/lodestar/test/unit/chain/precomputeNextEpochTransition.test.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
 import sinon, {SinonStubbedInstance} from "sinon";
 import {config} from "@chainsafe/lodestar-config/default";
-import {ForkChoice, IProtoBlock} from "@chainsafe/lodestar-fork-choice";
+import {ForkChoice, ProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {WinstonLogger} from "@chainsafe/lodestar-utils";
 import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";
 import {BeaconChain, ChainEventEmitter} from "../../../src/chain/index.js";
@@ -51,7 +51,7 @@ describe("PrecomputeEpochScheduler", () => {
   });
 
   it("should skip, headSlot is less than clock slot", async () => {
-    forkChoiceStub.getHead.returns({slot: SLOTS_PER_EPOCH - 2} as IProtoBlock);
+    forkChoiceStub.getHead.returns({slot: SLOTS_PER_EPOCH - 2} as ProtoBlock);
     await Promise.all([
       preComputeScheduler.prepareForNextEpoch(SLOTS_PER_EPOCH - 1),
       sandbox.clock.tickAsync((config.SECONDS_PER_SLOT * 1000 * 2) / 3),
@@ -61,7 +61,7 @@ describe("PrecomputeEpochScheduler", () => {
   });
 
   it("should run regen.getBlockSlotState", async () => {
-    forkChoiceStub.getHead.returns({slot: SLOTS_PER_EPOCH - 1} as IProtoBlock);
+    forkChoiceStub.getHead.returns({slot: SLOTS_PER_EPOCH - 1} as ProtoBlock);
     regenStub.getBlockSlotState.resolves();
     await Promise.all([
       preComputeScheduler.prepareForNextEpoch(SLOTS_PER_EPOCH - 1),
@@ -72,7 +72,7 @@ describe("PrecomputeEpochScheduler", () => {
   });
 
   it("should handle regen.getBlockSlotState error", async () => {
-    forkChoiceStub.getHead.returns({slot: SLOTS_PER_EPOCH - 1} as IProtoBlock);
+    forkChoiceStub.getHead.returns({slot: SLOTS_PER_EPOCH - 1} as ProtoBlock);
     regenStub.getBlockSlotState.rejects("Unit test error");
     expect(loggerStub.error.calledOnce).to.be.false;
     await Promise.all([

--- a/packages/lodestar/test/unit/chain/validation/block.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/block.test.ts
@@ -1,6 +1,6 @@
 import sinon, {SinonStubbedInstance} from "sinon";
 import {config} from "@chainsafe/lodestar-config/default";
-import {ForkChoice, IProtoBlock} from "@chainsafe/lodestar-fork-choice";
+import {ForkChoice, ProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {allForks, ssz} from "@chainsafe/lodestar-types";
 import {ForkName} from "@chainsafe/lodestar-params";
 import {BeaconChain, IBeaconChain} from "../../../../src/chain/index.js";
@@ -71,7 +71,7 @@ describe("gossip block validation", function () {
 
   it("ALREADY_KNOWN", async function () {
     // Make the fork choice return a block summary for the proposed block
-    forkChoice.getBlockHex.returns({} as IProtoBlock);
+    forkChoice.getBlockHex.returns({} as ProtoBlock);
 
     await expectRejectedWithLodestarError(
       validateGossipBlock(config, chain, job, ForkName.phase0),
@@ -105,7 +105,7 @@ describe("gossip block validation", function () {
     // Return not known for proposed block
     forkChoice.getBlockHex.onCall(0).returns(null);
     // Returned parent block is latter than proposed block
-    forkChoice.getBlockHex.onCall(1).returns({slot: clockSlot + 1} as IProtoBlock);
+    forkChoice.getBlockHex.onCall(1).returns({slot: clockSlot + 1} as ProtoBlock);
 
     await expectRejectedWithLodestarError(
       validateGossipBlock(config, chain, job, ForkName.phase0),
@@ -117,7 +117,7 @@ describe("gossip block validation", function () {
     // Return not known for proposed block
     forkChoice.getBlockHex.onCall(0).returns(null);
     // Returned parent block is latter than proposed block
-    forkChoice.getBlockHex.onCall(1).returns({slot: clockSlot - 1} as IProtoBlock);
+    forkChoice.getBlockHex.onCall(1).returns({slot: clockSlot - 1} as ProtoBlock);
     // Regen not able to get the parent block state
     regen.getBlockSlotState.rejects();
 
@@ -131,7 +131,7 @@ describe("gossip block validation", function () {
     // Return not known for proposed block
     forkChoice.getBlockHex.onCall(0).returns(null);
     // Returned parent block is latter than proposed block
-    forkChoice.getBlockHex.onCall(1).returns({slot: clockSlot - 1} as IProtoBlock);
+    forkChoice.getBlockHex.onCall(1).returns({slot: clockSlot - 1} as ProtoBlock);
     // Regen returns some state
     regen.getBlockSlotState.resolves(generateCachedState());
     // BLS signature verifier returns invalid
@@ -147,7 +147,7 @@ describe("gossip block validation", function () {
     // Return not known for proposed block
     forkChoice.getBlockHex.onCall(0).returns(null);
     // Returned parent block is latter than proposed block
-    forkChoice.getBlockHex.onCall(1).returns({slot: clockSlot - 1} as IProtoBlock);
+    forkChoice.getBlockHex.onCall(1).returns({slot: clockSlot - 1} as ProtoBlock);
     // Regen returns some state
     const state = generateCachedState();
     regen.getBlockSlotState.resolves(state);
@@ -166,7 +166,7 @@ describe("gossip block validation", function () {
     // Return not known for proposed block
     forkChoice.getBlockHex.onCall(0).returns(null);
     // Returned parent block is latter than proposed block
-    forkChoice.getBlockHex.onCall(1).returns({slot: clockSlot - 1} as IProtoBlock);
+    forkChoice.getBlockHex.onCall(1).returns({slot: clockSlot - 1} as ProtoBlock);
     // Regen returns some state
     const state = generateCachedState();
     regen.getBlockSlotState.resolves(state);

--- a/packages/lodestar/test/unit/sync/unknownBlock.test.ts
+++ b/packages/lodestar/test/unit/sync/unknownBlock.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 import {config} from "@chainsafe/lodestar-config/default";
-import {IForkChoice, IProtoBlock} from "@chainsafe/lodestar-fork-choice";
+import {IForkChoice, ProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {ssz} from "@chainsafe/lodestar-types";
 import {notNullish, sleep} from "@chainsafe/lodestar-utils";
 import {toHexString} from "@chainsafe/ssz";
@@ -64,7 +64,7 @@ describe("sync / UnknownBlockSync", () => {
       const forkChoiceKnownRoots = new Set([blockRootHex0]);
       const forkChoice: Pick<IForkChoice, "hasBlock" | "getFinalizedBlock"> = {
         hasBlock: (root) => forkChoiceKnownRoots.has(toHexString(root)),
-        getFinalizedBlock: () => ({slot: finalizedSlot} as IProtoBlock),
+        getFinalizedBlock: () => ({slot: finalizedSlot} as ProtoBlock),
       };
 
       const chain: Partial<IBeaconChain> = {

--- a/packages/lodestar/test/utils/block.ts
+++ b/packages/lodestar/test/utils/block.ts
@@ -3,7 +3,7 @@ import {ssz} from "@chainsafe/lodestar-types";
 import {config as defaultConfig} from "@chainsafe/lodestar-config/default";
 import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {allForks, phase0} from "@chainsafe/lodestar-types";
-import {IProtoBlock, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
+import {ProtoBlock, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
 import {isPlainObject} from "@chainsafe/lodestar-utils";
 import {RecursivePartial} from "@chainsafe/lodestar-utils";
 import {EMPTY_SIGNATURE, ZERO_HASH} from "../../src/constants/index.js";
@@ -100,7 +100,7 @@ export function generateSignedBlock(
   );
 }
 
-export function generateEmptyProtoBlock(): IProtoBlock {
+export function generateEmptyProtoBlock(): ProtoBlock {
   const rootHex = "0x" + "00".repeat(32);
   return {
     slot: 0,
@@ -118,8 +118,8 @@ export function generateEmptyProtoBlock(): IProtoBlock {
   };
 }
 
-export function generateProtoBlock(overrides: RecursivePartial<IProtoBlock> = {}): IProtoBlock {
-  return deepmerge<IProtoBlock, RecursivePartial<IProtoBlock>>(generateEmptyProtoBlock(), overrides, {
+export function generateProtoBlock(overrides: RecursivePartial<ProtoBlock> = {}): ProtoBlock {
+  return deepmerge<ProtoBlock, RecursivePartial<ProtoBlock>>(generateEmptyProtoBlock(), overrides, {
     isMergeableObject: isPlainObject,
   });
 }

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -5,7 +5,7 @@ import {CompositeTypeAny, toHexString, TreeView} from "@chainsafe/ssz";
 import {phase0, allForks, UintNum64, Root, Slot, ssz, Uint16, UintBn64} from "@chainsafe/lodestar-types";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {BeaconStateAllForks, CachedBeaconStateAllForks} from "@chainsafe/lodestar-beacon-state-transition";
-import {CheckpointWithHex, IForkChoice, IProtoBlock, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
+import {CheckpointWithHex, IForkChoice, ProtoBlock, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
 import {defaultDefaultFeeRecipient} from "@chainsafe/lodestar-validator";
 
 import {ChainEventEmitter, IBeaconChain} from "../../../../src/chain/index.js";
@@ -194,7 +194,7 @@ export class MockBeaconChain implements IBeaconChain {
 function mockForkChoice(): IForkChoice {
   const root = ssz.Root.defaultValue() as Uint8Array;
   const rootHex = toHexString(root);
-  const block: IProtoBlock = {
+  const block: ProtoBlock = {
     slot: 0,
     blockRoot: rootHex,
     parentRoot: rootHex,

--- a/packages/lodestar/test/utils/node/simTest.ts
+++ b/packages/lodestar/test/utils/node/simTest.ts
@@ -5,7 +5,7 @@ import {
   beforeProcessEpoch,
 } from "@chainsafe/lodestar-beacon-state-transition";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {IProtoBlock} from "@chainsafe/lodestar-fork-choice";
+import {ProtoBlock} from "@chainsafe/lodestar-fork-choice";
 import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@chainsafe/lodestar-params";
 import {allForks, Epoch, Slot} from "@chainsafe/lodestar-types";
 import {Checkpoint} from "@chainsafe/lodestar-types/phase0";
@@ -26,7 +26,7 @@ export function simTestInfoTracker(bn: BeaconNode, logger: ILogger): () => void 
   const prevParticipationPerEpoch = new Map<Epoch, number>();
   const currParticipationPerEpoch = new Map<Epoch, number>();
 
-  async function onHead(head: IProtoBlock): Promise<void> {
+  async function onHead(head: ProtoBlock): Promise<void> {
     const slot = head.slot;
 
     // For each block

--- a/packages/lodestar/test/utils/validationData/attestation.ts
+++ b/packages/lodestar/test/utils/validationData/attestation.ts
@@ -3,7 +3,7 @@ import {
   computeSigningRoot,
   computeStartSlotAtEpoch,
 } from "@chainsafe/lodestar-beacon-state-transition";
-import {IProtoBlock, IForkChoice, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
+import {ProtoBlock, IForkChoice, ExecutionStatus} from "@chainsafe/lodestar-fork-choice";
 import {DOMAIN_BEACON_ATTESTER} from "@chainsafe/lodestar-params";
 import {phase0, Slot, ssz} from "@chainsafe/lodestar-types";
 import {BitArray, toHexString} from "@chainsafe/ssz";
@@ -50,7 +50,7 @@ export function getAttestationValidData(
   const clock = new ClockStatic(currentSlot);
 
   // Add block to forkChoice
-  const headBlock: IProtoBlock = {
+  const headBlock: ProtoBlock = {
     slot: attSlot,
     blockRoot: toHexString(beaconBlockRoot),
     parentRoot: ZERO_HASH_HEX,


### PR DESCRIPTION
**Motivation**

- See https://github.com/ChainSafe/lodestar/pull/3900

**Description**

Run search and replace for
```
IVoteTracker -> VoteTracker
IQueuedAttestation -> QueuedAttestation
ILatestMessage -> LatestMessage
IProtoBlock -> ProtoBlock
IProtoNode -> ProtoNode
```