### PR TITLE
Fix flare dependencies

### DIFF
--- a/packages/flare/package.json
+++ b/packages/flare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/flare",
-  "version": "0.37.0",
+  "version": "0.38.1",
   "description": "Beacon chain debugging tool",
   "author": "ChainSafe Systems",
   "license": "Apache-2.0",
@@ -60,10 +60,10 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/lodestar-api": "^0.37.0",
-    "@chainsafe/lodestar-beacon-state-transition": "^0.37.0",
-    "@chainsafe/lodestar-config": "^0.37.0",
-    "@chainsafe/lodestar-types": "^0.37.0",
+    "@chainsafe/lodestar-api": "^0.38.1",
+    "@chainsafe/lodestar-beacon-state-transition": "^0.38.1",
+    "@chainsafe/lodestar-config": "^0.38.1",
+    "@chainsafe/lodestar-types": "^0.38.1",
     "source-map-support": "^0.5.19",
     "yargs": "^16.1.0"
   },


### PR DESCRIPTION
**Motivation**

Flare dependencies are out of date

**Description**

- Correct its dependencies
- @wemeetagain I think we got these out of date dependencies from day one, once we fix this it should be ok the next time we increase version

<img width="1602" alt="Screen Shot 2022-06-24 at 15 59 13" src="https://user-images.githubusercontent.com/10568965/175501573-6d8e4cc3-314e-4ba0-be5e-3e76efd580c6.png">


Closes #4186