### PR TITLE
Move IndicesService inside of ValidatorStore

### DIFF
--- a/packages/keymanager-server/src/impl.ts
+++ b/packages/keymanager-server/src/impl.ts
@@ -82,7 +82,7 @@ export class KeymanagerApi implements Api {
     // at runtime, when the handler for the request is selected, it would see slashingProtectionStr
     // as an object, hence trying to parse it using JSON.parse won't work. Instead, we cast straight to Interchange
     const interchange = (slashingProtectionStr as unknown) as Interchange;
-    await this.validator.validatorStore.importInterchange(interchange);
+    await this.validator.importInterchange(interchange);
 
     const statuses: {status: ImportStatus; message?: string}[] = [];
 
@@ -189,7 +189,7 @@ export class KeymanagerApi implements Api {
 
     const pubkeysBytes = pubkeysHex.map((pubkeyHex) => fromHexString(pubkeyHex));
 
-    const interchangeV5 = await this.validator.validatorStore.exportInterchange(pubkeysBytes, {
+    const interchangeV5 = await this.validator.exportInterchange(pubkeysBytes, {
       version: "5",
     });
 

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -9,7 +9,6 @@ import {Metrics} from "../metrics.js";
 import {ValidatorStore} from "./validatorStore.js";
 import {AttestationDutiesService, AttDutyAndProof} from "./attestationDuties.js";
 import {groupAttDutiesByCommitteeIndex} from "./utils.js";
-import {IndicesService} from "./indices.js";
 import {ChainHeaderTracker, HeadEventData} from "./chainHeaderTracker.js";
 import {ValidatorEvent, ValidatorEventEmitter} from "./emitter.js";
 
@@ -29,20 +28,11 @@ export class AttestationService {
     private readonly clock: IClock,
     private readonly validatorStore: ValidatorStore,
     private readonly emitter: ValidatorEventEmitter,
-    indicesService: IndicesService,
     chainHeadTracker: ChainHeaderTracker,
     private readonly metrics: Metrics | null,
     private readonly opts?: AttestationServiceOpts
   ) {
-    this.dutiesService = new AttestationDutiesService(
-      logger,
-      api,
-      clock,
-      validatorStore,
-      indicesService,
-      chainHeadTracker,
-      metrics
-    );
+    this.dutiesService = new AttestationDutiesService(logger, api, clock, validatorStore, chainHeadTracker, metrics);
 
     // At most every slot, check existing duties from AttestationDutiesService and run tasks
     clock.runEverySlot(this.runAttestationTasks);

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -7,7 +7,6 @@ import {toHexString} from "@chainsafe/ssz";
 import {IClock, ILoggerVc} from "../util/index.js";
 import {PubkeyHex} from "../types.js";
 import {Metrics} from "../metrics.js";
-import {IndicesService} from "./indices.js";
 import {ValidatorStore} from "./validatorStore.js";
 import {ChainHeaderTracker, HeadEventData} from "./chainHeaderTracker.js";
 
@@ -38,7 +37,6 @@ export class AttestationDutiesService {
     private readonly api: Api,
     private clock: IClock,
     private readonly validatorStore: ValidatorStore,
-    private readonly indicesService: IndicesService,
     chainHeadTracker: ChainHeaderTracker,
     private readonly metrics: Metrics | null
   ) {
@@ -117,12 +115,12 @@ export class AttestationDutiesService {
   private runDutiesTasks = async (epoch: Epoch): Promise<void> => {
     await Promise.all([
       // Run pollBeaconAttesters immediately for all known local indices
-      this.pollBeaconAttesters(epoch, this.indicesService.getAllLocalIndices()).catch((e: Error) => {
+      this.pollBeaconAttesters(epoch, this.validatorStore.getAllLocalIndices()).catch((e: Error) => {
         this.logger.error("Error on poll attesters", {epoch}, e);
       }),
 
       // At the same time fetch any remaining unknown validator indices, then poll duties for those newIndices only
-      this.indicesService
+      this.validatorStore
         .pollValidatorIndices()
         .then((newIndices) => this.pollBeaconAttesters(epoch, newIndices))
         .catch((e: Error) => {
@@ -310,7 +308,7 @@ export class AttestationDutiesService {
     const logContext = {dutyEpoch, slot, oldDependentRoot, newDependentRoot};
     this.logger.debug("Redownload attester duties", logContext);
 
-    await this.pollBeaconAttestersForEpoch(dutyEpoch, this.indicesService.getAllLocalIndices())
+    await this.pollBeaconAttestersForEpoch(dutyEpoch, this.validatorStore.getAllLocalIndices())
       .then(() => {
         this.pendingDependentRootByEpoch.delete(dutyEpoch);
       })

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -84,7 +84,7 @@ export class BlockProposingService {
       const blockFeeRecipient = (block.data as bellatrix.BeaconBlock).body.executionPayload?.feeRecipient;
       const feeRecipient = blockFeeRecipient !== undefined ? toHexString(blockFeeRecipient) : undefined;
       if (feeRecipient !== undefined) {
-        const expectedFeeRecipient = this.validatorStore.feeRecipientByValidatorPubkey.getOrDefault(pubkeyHex);
+        const expectedFeeRecipient = this.validatorStore.getFeeRecipient(pubkeyHex);
         // In Mev Builder, the feeRecipeint could differ and rewards to the feeRecipeint
         // might be included in the block transactions as indicated by the BuilderBid
         // Address this appropriately in the Mev boost PR

--- a/packages/validator/src/services/prepareBeaconProposer.ts
+++ b/packages/validator/src/services/prepareBeaconProposer.ts
@@ -2,53 +2,35 @@ import {Epoch} from "@chainsafe/lodestar-types";
 import {Api, routes} from "@chainsafe/lodestar-api";
 
 import {IClock, ILoggerVc} from "../util/index.js";
-import {Metrics} from "../metrics.js";
 import {ValidatorStore} from "./validatorStore.js";
-import {IndicesService} from "./indices.js";
 
 /**
  * This service is responsible for updating the BNs and/or Mev relays with
  * the corresponding feeRecipient suggestion. This should ideally run per epoch
  * but can be run per slot. Lighthouse also uses this to trigger any block
  */
-export class PrepareBeaconProposerService {
-  constructor(
-    private readonly logger: ILoggerVc,
-    private readonly api: Api,
-    private clock: IClock,
-    private readonly validatorStore: ValidatorStore,
-    private readonly indicesService: IndicesService,
-    private readonly metrics: Metrics | null
-  ) {
-    clock.runEveryEpoch(this.prepareBeaconProposer);
-  }
+export function pollPrepareBeaconProposer(
+  logger: ILoggerVc,
+  api: Api,
+  clock: IClock,
+  validatorStore: ValidatorStore
+): void {
+  clock.runEveryEpoch(async function prepareBeaconProposer(epoch: Epoch): Promise<void> {
+    // prepareBeaconProposer is not as time sensitive as attesting.
+    // Poll indices first, then call api.validator.prepareBeaconProposer once
+    await validatorStore.pollValidatorIndices().catch((e: Error) => {
+      logger.error("Error on pollValidatorIndices for prepareBeaconProposer", {epoch}, e);
+    });
 
-  private prepareBeaconProposer = async (epoch: Epoch): Promise<void> => {
-    await Promise.all([
-      // Run prepareBeaconProposer immediately for all known local indices
-      this.api.validator
-        .prepareBeaconProposer(this.getProposerData(this.indicesService.getAllLocalIndices()))
-        .catch((e: Error) => {
-          this.logger.error("Error on prepareBeaconProposer", {epoch}, e);
-        }),
+    const proposerData = validatorStore.getAllLocalIndices().map(
+      (index): routes.validator.ProposerPreparationData => ({
+        validatorIndex: String(index as number),
+        feeRecipient: validatorStore.getFeeRecipientByIndex(index),
+      })
+    );
 
-      // At the same time fetch any remaining unknown validator indices, then poll duties for those newIndices only
-      this.indicesService
-        .pollValidatorIndices()
-        .then((newIndices) => this.api.validator.prepareBeaconProposer(this.getProposerData(newIndices)))
-        .catch((e: Error) => {
-          this.logger.error("Error on poll indices and prepareBeaconProposer", {epoch}, e);
-        }),
-    ]);
-  };
-
-  private getProposerData(indices: number[]): routes.validator.ProposerPreparationData[] {
-    return indices.map((validatorIndex) => ({
-      validatorIndex: validatorIndex.toString(),
-      feeRecipient: this.validatorStore.feeRecipientByValidatorPubkey.getOrDefault(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.indicesService.index2pubkey.get(validatorIndex)!
-      ),
-    }));
-  }
+    await api.validator.prepareBeaconProposer(proposerData).catch((e: Error) => {
+      logger.error("Error on prepareBeaconProposer", {epoch}, e);
+    });
+  });
 }

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -9,7 +9,6 @@ import {Metrics} from "../metrics.js";
 import {ValidatorStore} from "./validatorStore.js";
 import {SyncCommitteeDutiesService, SyncDutyAndProofs} from "./syncCommitteeDuties.js";
 import {groupSyncDutiesBySubcommitteeIndex, SubcommitteeDuty} from "./utils.js";
-import {IndicesService} from "./indices.js";
 import {ChainHeaderTracker} from "./chainHeaderTracker.js";
 
 /**
@@ -25,18 +24,9 @@ export class SyncCommitteeService {
     private readonly clock: IClock,
     private readonly validatorStore: ValidatorStore,
     private readonly chainHeaderTracker: ChainHeaderTracker,
-    indicesService: IndicesService,
     private readonly metrics: Metrics | null
   ) {
-    this.dutiesService = new SyncCommitteeDutiesService(
-      config,
-      logger,
-      api,
-      clock,
-      validatorStore,
-      indicesService,
-      metrics
-    );
+    this.dutiesService = new SyncCommitteeDutiesService(config, logger, api, clock, validatorStore, metrics);
 
     // At most every slot, check existing duties from SyncCommitteeDutiesService and run tasks
     clock.runEverySlot(this.runSyncCommitteeTasks);

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -30,11 +30,11 @@ import {
 } from "@chainsafe/lodestar-types";
 import {BitArray, fromHexString, toHexString} from "@chainsafe/ssz";
 import {routes} from "@chainsafe/lodestar-api";
-import {Interchange, InterchangeFormatVersion, ISlashingProtection} from "../slashingProtection/index.js";
+import {ISlashingProtection} from "../slashingProtection/index.js";
 import {PubkeyHex} from "../types.js";
 import {externalSignerPostSignature} from "../util/externalSignerClient.js";
 import {Metrics} from "../metrics.js";
-import {MapDef} from "../util/map.js";
+import {IndicesService} from "./indices.js";
 
 export enum SignerType {
   Local,
@@ -52,7 +52,8 @@ export type SignerRemote = {
   pubkeyHex: PubkeyHex;
 };
 
-type BLSPubkeyMaybeHex = BLSPubkey | string;
+type BLSPubkeyMaybeHex = BLSPubkey | PubkeyHex;
+type Eth1Address = string;
 
 /**
  * Validator entity capable of producing signatures. Either:
@@ -61,44 +62,86 @@ type BLSPubkeyMaybeHex = BLSPubkey | string;
  */
 export type Signer = SignerLocal | SignerRemote;
 
+type ValidatorData = {
+  signer: Signer;
+  /** feeRecipient for block production, null if not explicitly configured */
+  feeRecipient: Eth1Address | null;
+};
+
 /**
  * Service that sets up and handles validator attester duties.
  */
 export class ValidatorStore {
-  readonly feeRecipientByValidatorPubkey: MapDef<PubkeyHex, string>;
-  private readonly validators = new Map<PubkeyHex, Signer>();
-  private readonly genesisValidatorsRoot: Root;
+  private readonly validators = new Map<PubkeyHex, ValidatorData>();
+  /** Initially true because there are no validators */
+  private pubkeysToDiscover: PubkeyHex[] = [];
 
   constructor(
     private readonly config: IBeaconConfig,
     private readonly slashingProtection: ISlashingProtection,
+    private readonly indicesService: IndicesService,
     private readonly metrics: Metrics | null,
-    signers: Signer[],
-    genesis: phase0.Genesis,
-    defaultFeeRecipient: string
+    initialSigners: Signer[],
+    private readonly defaultFeeRecipient: string
   ) {
-    this.feeRecipientByValidatorPubkey = new MapDef<PubkeyHex, string>(() => defaultFeeRecipient);
-    for (const signer of signers) {
+    for (const signer of initialSigners) {
       this.addSigner(signer);
     }
-
-    this.genesisValidatorsRoot = genesis.genesisValidatorsRoot;
 
     if (metrics) {
       metrics.signers.addCollect(() => metrics.signers.set(this.validators.size));
     }
   }
 
+  /** Return all known indices from the validatorStore pubkeys */
+  getAllLocalIndices(): ValidatorIndex[] {
+    return this.indicesService.getAllLocalIndices();
+  }
+
+  getPubkeyOfIndex(index: ValidatorIndex): PubkeyHex | undefined {
+    return this.indicesService.index2pubkey.get(index);
+  }
+
+  pollValidatorIndices(): Promise<ValidatorIndex[]> {
+    // Consumers will call this function every epoch forever. If everyone has been discovered, skip
+    return this.indicesService.indexCount >= this.validators.size
+      ? Promise.resolve([])
+      : this.indicesService.pollValidatorIndices(Array.from(this.validators.keys()));
+  }
+
+  getFeeRecipient(pubkeyHex: PubkeyHex): string {
+    return this.validators.get(pubkeyHex)?.feeRecipient ?? this.defaultFeeRecipient;
+  }
+
+  getFeeRecipientByIndex(index: ValidatorIndex): string {
+    const pubkey = this.indicesService.index2pubkey.get(index);
+    return pubkey ? this.validators.get(pubkey)?.feeRecipient ?? this.defaultFeeRecipient : this.defaultFeeRecipient;
+  }
+
+  /** Return true if `index` is active part of this validator client */
+  hasValidatorIndex(index: ValidatorIndex): boolean {
+    return this.indicesService.index2pubkey.has(index);
+  }
+
   addSigner(signer: Signer): void {
-    this.validators.set(getSignerPubkeyHex(signer), signer);
+    const pubkey = getSignerPubkeyHex(signer);
+
+    if (!this.validators.has(pubkey)) {
+      this.pubkeysToDiscover.push(pubkey);
+      this.validators.set(pubkey, {
+        signer,
+        // TODO: Allow to customize
+        feeRecipient: null,
+      });
+    }
   }
 
   getSigner(pubkeyHex: PubkeyHex): Signer | undefined {
-    return this.validators.get(pubkeyHex);
+    return this.validators.get(pubkeyHex)?.signer;
   }
 
   removeSigner(pubkeyHex: PubkeyHex): boolean {
-    return this.validators.delete(pubkeyHex);
+    return this.indicesService.removeForKey(pubkeyHex) || this.validators.delete(pubkeyHex);
   }
 
   /** Return true if there is at least 1 pubkey registered */
@@ -112,14 +155,6 @@ export class ValidatorStore {
 
   hasVotingPubkey(pubkeyHex: PubkeyHex): boolean {
     return this.validators.has(pubkeyHex);
-  }
-
-  async importInterchange(interchange: Interchange): Promise<void> {
-    return this.slashingProtection.importInterchange(interchange, this.genesisValidatorsRoot);
-  }
-
-  async exportInterchange(pubkeys: BLSPubkey[], formatVersion: InterchangeFormatVersion): Promise<Interchange> {
-    return this.slashingProtection.exportInterchange(this.genesisValidatorsRoot, pubkeys, formatVersion);
   }
 
   async signBlock(
@@ -294,7 +329,7 @@ export class ValidatorStore {
     // TODO: Refactor indexing to not have to run toHexString() on the pubkey every time
     const pubkeyHex = typeof pubkey === "string" ? pubkey : toHexString(pubkey);
 
-    const signer = this.validators.get(pubkeyHex);
+    const signer = this.validators.get(pubkeyHex)?.signer;
     if (!signer) {
       throw Error(`Validator pubkey ${pubkeyHex} not known`);
     }

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -1,6 +1,5 @@
 import {expect} from "chai";
 import sinon from "sinon";
-import {AbortController} from "@chainsafe/abort-controller";
 import bls from "@chainsafe/bls";
 import {toHexString} from "@chainsafe/ssz";
 import {
@@ -11,15 +10,13 @@ import {AttestationService} from "../../../src/services/attestation.js";
 import {AttDutyAndProof} from "../../../src/services/attestationDuties.js";
 import {ValidatorStore} from "../../../src/services/validatorStore.js";
 import {getApiClientStub} from "../../utils/apiStub.js";
-import {loggerVc, testLogger} from "../../utils/logger.js";
+import {loggerVc} from "../../utils/logger.js";
 import {ClockMock} from "../../utils/clock.js";
-import {IndicesService} from "../../../src/services/indices.js";
 import {ChainHeaderTracker} from "../../../src/services/chainHeaderTracker.js";
 import {ValidatorEventEmitter} from "../../../src/services/emitter.js";
 
 describe("AttestationService", function () {
   const sandbox = sinon.createSandbox();
-  const logger = testLogger();
   const ZERO_HASH = Buffer.alloc(32, 0);
 
   const api = getApiClientStub(sandbox);
@@ -46,14 +43,12 @@ describe("AttestationService", function () {
 
   it("Should produce, sign, and publish an attestation + aggregate", async () => {
     const clock = new ClockMock();
-    const indicesService = new IndicesService(logger, api, validatorStore, null);
     const attestationService = new AttestationService(
       loggerVc,
       api,
       clock,
       validatorStore,
       emitter,
-      indicesService,
       chainHeadTracker,
       null
     );

--- a/packages/validator/test/unit/services/block.test.ts
+++ b/packages/validator/test/unit/services/block.test.ts
@@ -1,6 +1,5 @@
 import {expect} from "chai";
 import sinon from "sinon";
-import {AbortController} from "@chainsafe/abort-controller";
 import bls from "@chainsafe/bls";
 import {toHexString} from "@chainsafe/ssz";
 import {createIChainForkConfig} from "@chainsafe/lodestar-config";

--- a/packages/validator/test/unit/services/blockDuties.test.ts
+++ b/packages/validator/test/unit/services/blockDuties.test.ts
@@ -23,7 +23,7 @@ describe("BlockDutiesService", function () {
   let pubkeys: Uint8Array[]; // Initialize pubkeys in before() so bls is already initialized
 
   before(() => {
-    const secretKeys = [bls.SecretKey.fromBytes(toBufferBE(BigInt(98), 32))];
+    const secretKeys = Array.from({length: 3}, (_, i) => bls.SecretKey.fromBytes(toBufferBE(BigInt(i + 1), 32)));
     pubkeys = secretKeys.map((sk) => sk.toPublicKey().toBytes());
     validatorStore = initValidatorStore(secretKeys, api);
   });

--- a/packages/validator/test/unit/services/blockDuties.test.ts
+++ b/packages/validator/test/unit/services/blockDuties.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 import sinon from "sinon";
-import {AbortController} from "@chainsafe/abort-controller";
+import {toBufferBE} from "bigint-buffer";
 import bls from "@chainsafe/bls";
 import {toHexString} from "@chainsafe/ssz";
 import {Root} from "@chainsafe/lodestar-types";
@@ -10,6 +10,7 @@ import {ValidatorStore} from "../../../src/services/validatorStore.js";
 import {getApiClientStub} from "../../utils/apiStub.js";
 import {loggerVc} from "../../utils/logger.js";
 import {ClockMock} from "../../utils/clock.js";
+import {initValidatorStore} from "../../utils/validatorStore.js";
 
 type ProposerDutiesRes = {dependentRoot: Root; data: routes.validator.ProposerDuty[]};
 
@@ -18,16 +19,13 @@ describe("BlockDutiesService", function () {
   const ZERO_HASH = Buffer.alloc(32, 0);
 
   const api = getApiClientStub(sandbox);
-  const validatorStore = sinon.createStubInstance(ValidatorStore) as ValidatorStore &
-    sinon.SinonStubbedInstance<ValidatorStore>;
+  let validatorStore: ValidatorStore;
   let pubkeys: Uint8Array[]; // Initialize pubkeys in before() so bls is already initialized
 
   before(() => {
-    const secretKeys = Array.from({length: 3}, (_, i) => bls.SecretKey.fromBytes(Buffer.alloc(32, i + 1)));
+    const secretKeys = [bls.SecretKey.fromBytes(toBufferBE(BigInt(98), 32))];
     pubkeys = secretKeys.map((sk) => sk.toPublicKey().toBytes());
-    validatorStore.votingPubkeys.returns(pubkeys.map(toHexString));
-    validatorStore.hasVotingPubkey.returns(true);
-    validatorStore.hasSomeValidators.returns(true);
+    validatorStore = initValidatorStore(secretKeys, api);
   });
 
   let controller: AbortController; // To stop clock

--- a/packages/validator/test/unit/services/indicesService.test.ts
+++ b/packages/validator/test/unit/services/indicesService.test.ts
@@ -3,7 +3,6 @@ import {expect} from "chai";
 import sinon from "sinon";
 import bls from "@chainsafe/bls";
 import {toHexString} from "@chainsafe/ssz";
-import {ValidatorStore} from "../../../src/services/validatorStore.js";
 import {getApiClientStub} from "../../utils/apiStub.js";
 import {testLogger} from "../../utils/logger.js";
 import {IndicesService} from "../../../src/services/indices.js";
@@ -12,8 +11,6 @@ describe("IndicesService", function () {
   const sandbox = sinon.createSandbox();
   const logger = testLogger();
   const api = getApiClientStub(sandbox);
-  const validatorStore = sinon.createStubInstance(ValidatorStore) as ValidatorStore &
-    sinon.SinonStubbedInstance<ValidatorStore>;
 
   let pubkeys: Uint8Array[]; // Initialize pubkeys in before() so bls is already initialized
 
@@ -26,7 +23,7 @@ describe("IndicesService", function () {
   });
 
   it("Should remove pubkey", async function () {
-    const indicesService = new IndicesService(logger, api, validatorStore, null);
+    const indicesService = new IndicesService(logger, api, null);
     const firstValidatorIndex = 0;
     const secondValidatorIndex = 1;
 
@@ -40,7 +37,7 @@ describe("IndicesService", function () {
     indicesService.pubkey2index.set(pubkey2, secondValidatorIndex);
 
     // remove pubkey2
-    indicesService.removeDutiesForKey(pubkey2);
+    indicesService.removeForKey(pubkey2);
 
     expect(Object.fromEntries(indicesService.index2pubkey)).to.deep.equal(
       {

--- a/packages/validator/test/unit/services/syncCommitteDuties.test.ts
+++ b/packages/validator/test/unit/services/syncCommitteDuties.test.ts
@@ -1,7 +1,6 @@
 import {toBufferBE} from "bigint-buffer";
 import {expect} from "chai";
 import sinon from "sinon";
-import {AbortController} from "@chainsafe/abort-controller";
 import bls from "@chainsafe/bls";
 import {toHexString} from "@chainsafe/ssz";
 import {createIChainForkConfig} from "@chainsafe/lodestar-config";
@@ -15,25 +14,25 @@ import {
 } from "../../../src/services/syncCommitteeDuties.js";
 import {ValidatorStore} from "../../../src/services/validatorStore.js";
 import {getApiClientStub} from "../../utils/apiStub.js";
-import {loggerVc, testLogger} from "../../utils/logger.js";
+import {loggerVc} from "../../utils/logger.js";
 import {ClockMock} from "../../utils/clock.js";
-import {IndicesService} from "../../../src/services/indices.js";
+import {initValidatorStore} from "../../utils/validatorStore.js";
 import {syncCommitteeIndicesToSubnets} from "../../../src/services/utils.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
 describe("SyncCommitteeDutiesService", function () {
   const sandbox = sinon.createSandbox();
-  const logger = testLogger();
+
   const ZERO_HASH = Buffer.alloc(32, 0);
   const ZERO_HASH_HEX = toHexString(ZERO_HASH);
 
   const api = getApiClientStub(sandbox);
-  const validatorStore = sinon.createStubInstance(ValidatorStore) as ValidatorStore &
-    sinon.SinonStubbedInstance<ValidatorStore>;
+
+  let validatorStore: ValidatorStore;
   let pubkeys: Uint8Array[]; // Initialize pubkeys in before() so bls is already initialized
 
-  const config = createIChainForkConfig({
+  const altair0Config = createIChainForkConfig({
     ...mainnetConfig,
     ALTAIR_FORK_EPOCH: 0, // Activate Altair immediatelly
   });
@@ -53,10 +52,7 @@ describe("SyncCommitteeDutiesService", function () {
       bls.SecretKey.fromBytes(toBufferBE(BigInt(99), 32)),
     ];
     pubkeys = secretKeys.map((sk) => sk.toPublicKey().toBytes());
-    validatorStore.votingPubkeys.returns(pubkeys.map(toHexString));
-    validatorStore.hasVotingPubkey.returns(true);
-    validatorStore.signAttestationSelectionProof.resolves(ZERO_HASH);
-    validatorStore.signSyncCommitteeSelectionProof.resolves(ZERO_HASH);
+    validatorStore = initValidatorStore(secretKeys, api, altair0Config);
   });
 
   let controller: AbortController; // To stop clock
@@ -87,28 +83,17 @@ describe("SyncCommitteeDutiesService", function () {
 
     // Clock will call runAttesterDutiesTasks() immediatelly
     const clock = new ClockMock();
-    const indicesService = new IndicesService(logger, api, validatorStore, null);
-    const dutiesService = new SyncCommitteeDutiesService(
-      config,
-      loggerVc,
-      api,
-      clock,
-      validatorStore,
-      indicesService,
-      null
-    );
+    const dutiesService = new SyncCommitteeDutiesService(altair0Config, loggerVc, api, clock, validatorStore, null);
 
     // Trigger clock onSlot for slot 0
     await clock.tickEpochFns(0, controller.signal);
 
     // Validator index should be persisted
-    expect(Object.fromEntries(indicesService["pubkey2index"])).to.deep.equal(
-      {
-        [toHexString(pubkeys[0])]: indices[0],
-        [toHexString(pubkeys[1])]: indices[1],
-      },
-      "Wrong dutiesService.indices Map"
-    );
+    // Validator index should be persisted
+    expect(validatorStore.getAllLocalIndices()).to.deep.equal(indices, "Wrong local indices");
+    for (let i = 0; i < indices.length; i++) {
+      expect(validatorStore.getPubkeyOfIndex(indices[i])).equals(toHexString(pubkeys[i]), `Wrong pubkey[${i}]`);
+    }
 
     // Duties for this and next epoch should be persisted
     const dutiesByIndexByPeriodObj = Object.fromEntries(
@@ -166,16 +151,7 @@ describe("SyncCommitteeDutiesService", function () {
 
     // Clock will call runAttesterDutiesTasks() immediatelly
     const clock = new ClockMock();
-    const indicesService = new IndicesService(logger, api, validatorStore, null);
-    const dutiesService = new SyncCommitteeDutiesService(
-      config,
-      loggerVc,
-      api,
-      clock,
-      validatorStore,
-      indicesService,
-      null
-    );
+    const dutiesService = new SyncCommitteeDutiesService(altair0Config, loggerVc, api, clock, validatorStore, null);
 
     // Trigger clock onSlot for slot 0
     await clock.tickEpochFns(0, controller.signal);
@@ -233,16 +209,7 @@ describe("SyncCommitteeDutiesService", function () {
 
     // Clock will call runAttesterDutiesTasks() immediatelly
     const clock = new ClockMock();
-    const indicesService = new IndicesService(logger, api, validatorStore, null);
-    const dutiesService = new SyncCommitteeDutiesService(
-      config,
-      loggerVc,
-      api,
-      clock,
-      validatorStore,
-      indicesService,
-      null
-    );
+    const dutiesService = new SyncCommitteeDutiesService(altair0Config, loggerVc, api, clock, validatorStore, null);
 
     // Trigger clock onSlot for slot 0
     await clock.tickEpochFns(0, controller.signal);

--- a/packages/validator/test/unit/services/syncCommittee.test.ts
+++ b/packages/validator/test/unit/services/syncCommittee.test.ts
@@ -1,6 +1,5 @@
 import {expect} from "chai";
 import sinon from "sinon";
-import {AbortController} from "@chainsafe/abort-controller";
 import bls from "@chainsafe/bls";
 import {toHexString} from "@chainsafe/ssz";
 import {createIChainForkConfig} from "@chainsafe/lodestar-config";
@@ -10,16 +9,14 @@ import {SyncCommitteeService} from "../../../src/services/syncCommittee.js";
 import {SyncDutyAndProofs} from "../../../src/services/syncCommitteeDuties.js";
 import {ValidatorStore} from "../../../src/services/validatorStore.js";
 import {getApiClientStub} from "../../utils/apiStub.js";
-import {loggerVc, testLogger} from "../../utils/logger.js";
+import {loggerVc} from "../../utils/logger.js";
 import {ClockMock} from "../../utils/clock.js";
-import {IndicesService} from "../../../src/services/indices.js";
 import {ChainHeaderTracker} from "../../../src/services/chainHeaderTracker.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
 describe("SyncCommitteeService", function () {
   const sandbox = sinon.createSandbox();
-  const logger = testLogger();
   const ZERO_HASH = Buffer.alloc(32, 0);
 
   const api = getApiClientStub(sandbox);
@@ -50,7 +47,6 @@ describe("SyncCommitteeService", function () {
 
   it("Should produce, sign, and publish a sync committee + contribution", async () => {
     const clock = new ClockMock();
-    const indicesService = new IndicesService(logger, api, validatorStore, null);
     const syncCommitteeService = new SyncCommitteeService(
       config,
       loggerVc,
@@ -58,7 +54,6 @@ describe("SyncCommitteeService", function () {
       clock,
       validatorStore,
       chainHeaderTracker,
-      indicesService,
       null
     );
 

--- a/packages/validator/test/utils/slashingProtectionMock.ts
+++ b/packages/validator/test/utils/slashingProtectionMock.ts
@@ -1,0 +1,19 @@
+import {ISlashingProtection} from "../../src/index.js";
+
+/**
+ * Mock slashing protection that always accepts all messages
+ */
+export class SlashingProtectionMock implements ISlashingProtection {
+  async checkAndInsertBlockProposal(): Promise<void> {
+    //
+  }
+  async checkAndInsertAttestation(): Promise<void> {
+    //
+  }
+  async importInterchange(): Promise<void> {
+    //
+  }
+  async exportInterchange(): Promise<never> {
+    throw Error("disabled");
+  }
+}

--- a/packages/validator/test/utils/validatorStore.ts
+++ b/packages/validator/test/utils/validatorStore.ts
@@ -1,0 +1,37 @@
+import {SecretKey} from "@chainsafe/bls/types";
+import {Api} from "@chainsafe/lodestar-api";
+import {chainConfig} from "@chainsafe/lodestar-config/default";
+import {createIBeaconConfig, IChainConfig} from "@chainsafe/lodestar-config";
+import {Signer, SignerType, ValidatorStore} from "../../src/index.js";
+import {IndicesService} from "../../src/services/indices.js";
+import {testLogger} from "./logger.js";
+import {SlashingProtectionMock} from "./slashingProtectionMock.js";
+
+/**
+ * Initializes an actual ValidatorStore without stubs
+ */
+export function initValidatorStore(
+  secretKeys: SecretKey[],
+  api: Api,
+  customChainConfig: IChainConfig = chainConfig
+): ValidatorStore {
+  const logger = testLogger();
+  const genesisValidatorsRoot = Buffer.alloc(32, 0xdd);
+  const defaultFeeRecipient = "0x0";
+
+  const signers: Signer[] = secretKeys.map((sk) => ({
+    type: SignerType.Local,
+    secretKey: sk,
+  }));
+
+  const metrics = null;
+  const indicesService = new IndicesService(logger, api, metrics);
+  return new ValidatorStore(
+    createIBeaconConfig(customChainConfig, genesisValidatorsRoot),
+    new SlashingProtectionMock(),
+    indicesService,
+    metrics,
+    signers,
+    defaultFeeRecipient
+  );
+}


### PR DESCRIPTION
**Motivation**

- While reviewing https://github.com/ChainSafe/lodestar/pull/3883 I noticed that ValidatorStore, IndicesService and DopplegangerService are unnecessarily complex because they three depend on each other, creating cyclic dependencies.

By moving IndicesService into ValidatorStore things simplify a bunch and would allow for a simpler https://github.com/ChainSafe/lodestar/pull/3883 implementation

**Description**

- Move IndicesService inside of ValidatorStore
- Drop unnecessary stubs in dutiesServices tests
- Make PrepareBeaconProposerService a function since it holds no state