### PR TITLE
Remove @chainsafe/abort-controller

### DIFF
--- a/packages/api/test/unit/beacon/events.test.ts
+++ b/packages/api/test/unit/beacon/events.test.ts
@@ -1,5 +1,4 @@
 import {expect} from "chai";
-import {AbortController} from "@chainsafe/abort-controller";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {config} from "@chainsafe/lodestar-config/default";
 import {Api, routesData, EventType, BeaconEvent} from "../../../src/beacon/routes/events.js";

--- a/packages/api/test/unit/client/httpClient.test.ts
+++ b/packages/api/test/unit/client/httpClient.test.ts
@@ -3,7 +3,6 @@ import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
 import fastify, {RouteOptions} from "fastify";
 import {ErrorAborted, TimeoutError} from "@chainsafe/lodestar-utils";
-import {AbortController} from "@chainsafe/abort-controller";
 import {HttpClient, HttpError} from "../../../src/utils/client/index.js";
 
 chai.use(chaiAsPromised);

--- a/packages/lodestar/src/network/reqresp/reqResp.ts
+++ b/packages/lodestar/src/network/reqresp/reqResp.ts
@@ -9,7 +9,6 @@ import {ForkName} from "@chainsafe/lodestar-params";
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {allForks, phase0} from "@chainsafe/lodestar-types";
 import {ILogger} from "@chainsafe/lodestar-utils";
-import {AbortController} from "@chainsafe/abort-controller";
 import {RespStatus, timeoutOptions} from "../../constants/index.js";
 import {IPeerRpcScoreStore} from "../peers/index.js";
 import {MetadataController} from "../metadata.js";

--- a/packages/lodestar/src/network/reqresp/request/index.ts
+++ b/packages/lodestar/src/network/reqresp/request/index.ts
@@ -1,7 +1,6 @@
 import pipe from "it-pipe";
 import PeerId from "peer-id";
 import {Libp2p} from "libp2p/src/connection-manager";
-import {AbortSignal} from "@chainsafe/abort-controller";
 import {IForkDigestContext} from "@chainsafe/lodestar-config";
 import {ErrorAborted, ILogger, withTimeout, TimeoutError} from "@chainsafe/lodestar-utils";
 import {timeoutOptions} from "../../../constants/index.js";

--- a/packages/lodestar/src/network/reqresp/request/responseTimeoutsHandler.ts
+++ b/packages/lodestar/src/network/reqresp/request/responseTimeoutsHandler.ts
@@ -1,5 +1,4 @@
 import pipe from "it-pipe";
-import {AbortController} from "@chainsafe/abort-controller";
 import {timeoutOptions} from "../../../constants/index.js";
 import {abortableSource} from "../../../util/abortableSource.js";
 import {onChunk} from "../utils/index.js";

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -4,7 +4,6 @@
 
 import LibP2p from "libp2p";
 import {Registry} from "prom-client";
-import {AbortController} from "@chainsafe/abort-controller";
 
 import {IBeaconConfig} from "@chainsafe/lodestar-config";
 import {phase0} from "@chainsafe/lodestar-types";

--- a/packages/lodestar/test/e2e/eth1/eth1MergeBlockTracker.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1MergeBlockTracker.test.ts
@@ -1,5 +1,4 @@
 import {expect} from "chai";
-import {AbortController} from "@chainsafe/abort-controller";
 import {IChainConfig} from "@chainsafe/lodestar-config";
 import {sleep} from "@chainsafe/lodestar-utils";
 import {fromHexString} from "@chainsafe/ssz";

--- a/packages/lodestar/test/e2e/eth1/eth1Provider.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1Provider.test.ts
@@ -1,6 +1,5 @@
 import "mocha";
 import {expect} from "chai";
-import {AbortController} from "@chainsafe/abort-controller";
 import {fromHexString} from "@chainsafe/ssz";
 import {Eth1Options} from "../../../src/eth1/options.js";
 import {getTestnetConfig} from "../../utils/testnet.js";

--- a/packages/lodestar/test/e2e/eth1/jsonRpcHttpClient.test.ts
+++ b/packages/lodestar/test/e2e/eth1/jsonRpcHttpClient.test.ts
@@ -2,7 +2,6 @@ import "mocha";
 import http from "node:http";
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
-import {AbortController} from "@chainsafe/abort-controller";
 import {JsonRpcHttpClient} from "../../../src/eth1/provider/jsonRpcHttpClient.js";
 import {getGoerliRpcUrl} from "../../testParams.js";
 import {IRpcPayload} from "../../../src/eth1/interface.js";

--- a/packages/lodestar/test/e2e/network/reqresp.test.ts
+++ b/packages/lodestar/test/e2e/network/reqresp.test.ts
@@ -1,7 +1,6 @@
 import chai, {expect} from "chai";
 import chaiAsPromised from "chai-as-promised";
 import PeerId from "peer-id";
-import {AbortController} from "@chainsafe/abort-controller";
 import {createIBeaconConfig} from "@chainsafe/lodestar-config";
 import {config} from "@chainsafe/lodestar-config/default";
 import {sleep as _sleep} from "@chainsafe/lodestar-utils";

--- a/packages/lodestar/test/unit/api/impl/events/events.test.ts
+++ b/packages/lodestar/test/unit/api/impl/events/events.test.ts
@@ -1,6 +1,5 @@
 import {expect} from "chai";
 import sinon, {SinonStubbedInstance} from "sinon";
-import {AbortController} from "@chainsafe/abort-controller";
 import {routes} from "@chainsafe/lodestar-api";
 import {config} from "@chainsafe/lodestar-config/default";
 import {BeaconChain, ChainEvent, ChainEventEmitter, IBeaconChain} from "../../../../../src/chain/index.js";

--- a/packages/lodestar/test/unit/chain/clock/local.test.ts
+++ b/packages/lodestar/test/unit/chain/clock/local.test.ts
@@ -1,6 +1,5 @@
 import sinon from "sinon";
 import {expect} from "chai";
-import {AbortController} from "@chainsafe/abort-controller";
 import {config} from "@chainsafe/lodestar-config/default";
 
 import {SLOTS_PER_EPOCH} from "@chainsafe/lodestar-params";

--- a/packages/lodestar/test/unit/network/reqresp/request/responseTimeoutsHandler.test.ts
+++ b/packages/lodestar/test/unit/network/reqresp/request/responseTimeoutsHandler.test.ts
@@ -1,6 +1,5 @@
 import all from "it-all";
 import pipe from "it-pipe";
-import {AbortController} from "@chainsafe/abort-controller";
 import {LodestarError, sleep as _sleep} from "@chainsafe/lodestar-utils";
 import {timeoutOptions} from "../../../../../src/constants/index.js";
 import {responseTimeoutsHandler} from "../../../../../src/network/reqresp/request/responseTimeoutsHandler.js";

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -1,5 +1,4 @@
 import sinon from "sinon";
-import {AbortController} from "@chainsafe/abort-controller";
 
 import {CompositeTypeAny, toHexString, TreeView} from "@chainsafe/ssz";
 import {phase0, allForks, UintNum64, Root, Slot, ssz, Uint16, UintBn64} from "@chainsafe/lodestar-types";


### PR DESCRIPTION
**Motivation**

- Since https://github.com/ChainSafe/lodestar/pull/4064 @chainsafe/abort-controller is no longer necessary. But it was not removed from all the source

**Description**

- [x] Remove @chainsafe/abort-controller usage in src
- [ ] Remove from dicv5 to prune from yarn.lock. NOTE: Already removed from discv5 once the dep is bumped should be removed
- [ ] Archive @chainsafe/abort-controller @wemeetagain 