### PR TITLE
Disable e2e test eth1 / Eth1MergeBlockTracker

### DIFF
--- a/packages/lodestar/test/e2e/eth1/eth1MergeBlockTracker.test.ts
+++ b/packages/lodestar/test/e2e/eth1/eth1MergeBlockTracker.test.ts
@@ -13,7 +13,10 @@ import {getGoerliRpcUrl} from "../../testParams.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
-describe("eth1 / Eth1MergeBlockTracker", function () {
+// This test is constantly failing. We must unblock PR so this issue is a TODO to debug it and re-enable latter.
+// It's OKAY to disable temporarily since this functionality is tested indirectly by the sim merge tests.
+// See https://github.com/ChainSafe/lodestar/issues/4197
+describe.skip("eth1 / Eth1MergeBlockTracker", function () {
   this.timeout("2 min");
 
   const logger = testLogger();


### PR DESCRIPTION
**Motivation**

This test is constantly failing. We must unblock PR so this issue is a TODO to debug it and re-enable latter.

It's OKAY to disable temporarily since this functionality is tested indirectly by the sim merge tests.

See https://github.com/ChainSafe/lodestar/issues/4197

**Description**

Disable e2e test eth1 / Eth1MergeBlockTracker