### PR TITLE
Await workers temination on stop

### DIFF
--- a/packages/lodestar/src/chain/bls/interface.ts
+++ b/packages/lodestar/src/chain/bls/interface.ts
@@ -40,4 +40,7 @@ export interface IBlsVerifier {
    * Signature checks above could be done here for convienence as well
    */
   verifySignatureSets(sets: ISignatureSet[], opts?: VerifySignatureOpts): Promise<boolean>;
+
+  /** For multithread pool awaits terminating all workers */
+  close(): Promise<void>;
 }

--- a/packages/lodestar/src/chain/bls/singleThread.ts
+++ b/packages/lodestar/src/chain/bls/singleThread.ts
@@ -27,4 +27,8 @@ export class BlsSingleThreadVerifier implements IBlsVerifier {
       if (timer) timer();
     }
   }
+
+  async close(): Promise<void> {
+    // nothing to do
+  }
 }

--- a/packages/lodestar/src/chain/chain.ts
+++ b/packages/lodestar/src/chain/chain.ts
@@ -138,7 +138,7 @@ export class BeaconChain implements IBeaconChain {
     // by default, verify signatures on both main threads and worker threads
     const bls = opts.blsVerifyAllMainThread
       ? new BlsSingleThreadVerifier({metrics})
-      : new BlsMultiThreadWorkerPool(opts, {logger, metrics, signal: this.abortController.signal});
+      : new BlsMultiThreadWorkerPool(opts, {logger, metrics});
 
     const clock = new LocalClock({config, emitter, genesisTime: this.genesisTime, signal});
     const stateCache = new StateContextCache({metrics});
@@ -226,10 +226,11 @@ export class BeaconChain implements IBeaconChain {
     metrics?.opPool.aggregatedAttestationPoolSize.addCollect(() => this.onScrapeMetrics());
   }
 
-  close(): void {
+  async close(): Promise<void> {
     this.abortController.abort();
     this.stateCache.clear();
     this.checkpointStateCache.clear();
+    await this.bls.close();
   }
 
   /** Populate in-memory caches with persisted data. Call at least once on startup */

--- a/packages/lodestar/src/chain/interface.ts
+++ b/packages/lodestar/src/chain/interface.ts
@@ -77,7 +77,7 @@ export interface IBeaconChain {
   readonly beaconProposerCache: BeaconProposerCache;
 
   /** Stop beacon chain processing */
-  close(): void;
+  close(): Promise<void>;
   /** Populate in-memory caches with persisted data. Call at least once on startup */
   loadFromDisk(): Promise<void>;
   /** Persist in-memory data to the DB. Call at least once before stopping the process */

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -247,7 +247,7 @@ export class BeaconNode {
       if (this.restApi) await this.restApi.close();
 
       await this.chain.persistToDisk();
-      this.chain.close();
+      await this.chain.close();
       await this.db.stop();
       if (this.controller) this.controller.abort();
       this.status = BeaconNodeStatus.closed;

--- a/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/lodestar/test/e2e/chain/bls/multithread.test.ts
@@ -41,7 +41,7 @@ describe("chain / bls / multithread queue", function () {
   });
 
   async function initializePool(): Promise<BlsMultiThreadWorkerPool> {
-    const pool = new BlsMultiThreadWorkerPool({}, {logger, metrics: null, signal: controller.signal});
+    const pool = new BlsMultiThreadWorkerPool({}, {logger, metrics: null});
     // await terminating all workers
     afterEachCallbacks.push(() => pool.close());
     // Wait until initialized

--- a/packages/lodestar/test/e2e/network/gossipsub.test.ts
+++ b/packages/lodestar/test/e2e/network/gossipsub.test.ts
@@ -80,7 +80,7 @@ describe("gossipsub", function () {
     await Promise.all([netA.start(), netB.start()]);
 
     afterEachCallbacks.push(async () => {
-      chain.close();
+      await chain.close();
       controller.abort();
       await Promise.all([netA.stop(), netB.stop()]);
       sinon.restore();

--- a/packages/lodestar/test/e2e/network/network.test.ts
+++ b/packages/lodestar/test/e2e/network/network.test.ts
@@ -105,7 +105,7 @@ describe("network", function () {
     await network.start();
 
     afterEachCallbacks.push(async () => {
-      chain.close();
+      await chain.close();
       controller.abort();
       await network.stop();
       sinon.restore();

--- a/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/lodestar/test/e2e/network/peers/peerManager.test.ts
@@ -54,7 +54,7 @@ describe("network / peers / PeerManager", function () {
     const libp2p = await createNode("/ip4/127.0.0.1/tcp/0");
 
     afterEachCallbacks.push(async () => {
-      chain.close();
+      await chain.close();
       await libp2p.stop();
     });
 

--- a/packages/lodestar/test/e2e/network/reqresp.test.ts
+++ b/packages/lodestar/test/e2e/network/reqresp.test.ts
@@ -107,7 +107,7 @@ describe("network / ReqResp", function () {
     await connected;
 
     afterEachCallbacks.push(async () => {
-      chain.close();
+      await chain.close();
       controller.abort();
       await Promise.all([netA.stop(), netB.stop()]);
     });

--- a/packages/lodestar/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/lodestar/test/perf/chain/verifyImportBlocks.test.ts
@@ -116,7 +116,7 @@ describe("verify+import blocks - range sync perf test", () => {
         // so we can utilize worker threads to verify signatures
         blsVerifyOnMainThread: false,
       });
-      chain.close();
+      await chain.close();
     },
   });
 });

--- a/packages/lodestar/test/unit/chain/validation/attesterSlashing.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/attesterSlashing.test.ts
@@ -10,6 +10,7 @@ import {validateGossipAttesterSlashing} from "../../../../src/chain/validation/a
 import {AttesterSlashingErrorCode} from "../../../../src/chain/errors/attesterSlashingError.js";
 import {OpPool} from "../../../../src/chain/opPools/index.js";
 import {expectRejectedWithLodestarError} from "../../../utils/errors.js";
+import {BlsVerifierMock} from "../../../utils/mocks/bls.js";
 
 describe("GossipMessageValidator", () => {
   const sandbox = sinon.createSandbox();
@@ -19,7 +20,7 @@ describe("GossipMessageValidator", () => {
   beforeEach(() => {
     chainStub = sandbox.createStubInstance(BeaconChain) as StubbedChain;
     chainStub.forkChoice = sandbox.createStubInstance(ForkChoice);
-    chainStub.bls = {verifySignatureSets: async () => true};
+    chainStub.bls = new BlsVerifierMock(true);
     opPool = sandbox.createStubInstance(OpPool) as OpPool & SinonStubbedInstance<OpPool>;
     (chainStub as {opPool: OpPool}).opPool = opPool;
 

--- a/packages/lodestar/test/unit/chain/validation/block.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/block.test.ts
@@ -37,7 +37,7 @@ describe("gossip block validation", function () {
 
     verifySignature = sinon.stub();
     verifySignature.resolves(true);
-    chain.bls = {verifySignatureSets: verifySignature};
+    chain.bls = {verifySignatureSets: verifySignature, close: () => Promise.resolve()};
 
     forkChoice.getFinalizedCheckpoint.returns({epoch: 0, root: ZERO_HASH, rootHex: ""});
 

--- a/packages/lodestar/test/unit/chain/validation/contributionAndProof.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/contributionAndProof.test.ts
@@ -15,6 +15,7 @@ import * as syncCommitteeUtils from "../../../../../beacon-state-transition/src/
 import {SinonStubFn} from "../../../utils/types.js";
 import {generateCachedStateWithPubkeys} from "../../../utils/state.js";
 import {SeenContributionAndProof} from "../../../../src/chain/seenCache/index.js";
+import {BlsVerifierMock} from "../../../utils/mocks/bls.js";
 
 // https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/p2p-interface.md
 // TODO remove stub
@@ -151,7 +152,7 @@ describe.skip("Sync Committee Contribution And Proof validation", function () {
     isSyncCommitteeAggregatorStub.returns(true);
     const headState = await generateCachedStateWithPubkeys({slot: currentSlot}, config, true);
     chain.getHeadState.returns(headState);
-    chain.bls = {verifySignatureSets: async () => false};
+    chain.bls = new BlsVerifierMock(false);
     await expectRejectedWithLodestarError(
       validateSyncCommitteeGossipContributionAndProof(chain, signedContributionAndProof),
       SyncCommitteeErrorCode.INVALID_SIGNATURE

--- a/packages/lodestar/test/unit/chain/validation/proposerSlashing.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/proposerSlashing.test.ts
@@ -10,6 +10,7 @@ import {ProposerSlashingErrorCode} from "../../../../src/chain/errors/proposerSl
 import {validateGossipProposerSlashing} from "../../../../src/chain/validation/proposerSlashing.js";
 import {OpPool} from "../../../../src/chain/opPools/index.js";
 import {expectRejectedWithLodestarError} from "../../../utils/errors.js";
+import {BlsVerifierMock} from "../../../utils/mocks/bls.js";
 
 describe("validate proposer slashing", () => {
   const sandbox = sinon.createSandbox();
@@ -19,7 +20,7 @@ describe("validate proposer slashing", () => {
   beforeEach(() => {
     chainStub = sandbox.createStubInstance(BeaconChain) as StubbedChain;
     chainStub.forkChoice = sandbox.createStubInstance(ForkChoice);
-    chainStub.bls = {verifySignatureSets: async () => true};
+    chainStub.bls = new BlsVerifierMock(true);
     opPool = sandbox.createStubInstance(OpPool) as OpPool & SinonStubbedInstance<OpPool>;
     (chainStub as {opPool: OpPool}).opPool = opPool;
 

--- a/packages/lodestar/test/unit/chain/validation/syncCommittee.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/syncCommittee.test.ts
@@ -11,6 +11,7 @@ import {expectRejectedWithLodestarError} from "../../../utils/errors.js";
 import {generateCachedState} from "../../../utils/state.js";
 import {generateSyncCommitteeSignature} from "../../../utils/syncCommittee.js";
 import {SeenSyncCommitteeMessages} from "../../../../src/chain/seenCache/index.js";
+import {BlsVerifierMock} from "../../../utils/mocks/bls.js";
 
 // https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/p2p-interface.md
 describe("Sync Committee Signature validation", function () {
@@ -107,7 +108,7 @@ describe("Sync Committee Signature validation", function () {
     const headState = generateCachedState({slot: currentSlot}, config, true);
 
     chain.getHeadState.returns(headState);
-    chain.bls = {verifySignatureSets: async () => false};
+    chain.bls = new BlsVerifierMock(false);
     await expectRejectedWithLodestarError(
       validateGossipSyncCommittee(chain, syncCommittee, 0),
       SyncCommitteeErrorCode.INVALID_SIGNATURE

--- a/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
+++ b/packages/lodestar/test/unit/chain/validation/voluntaryExit.test.ts
@@ -22,6 +22,7 @@ import {VoluntaryExitErrorCode} from "../../../../src/chain/errors/voluntaryExit
 import {OpPool} from "../../../../src/chain/opPools/index.js";
 import {expectRejectedWithLodestarError} from "../../../utils/errors.js";
 import {createCachedBeaconStateTest} from "../../../utils/cachedBeaconState.js";
+import {BlsVerifierMock} from "../../../utils/mocks/bls.js";
 
 describe("validate voluntary exit", () => {
   const sandbox = sinon.createSandbox();
@@ -74,7 +75,7 @@ describe("validate voluntary exit", () => {
     (chainStub as {opPool: OpPool}).opPool = opPool;
     chainStub.getHeadStateAtCurrentEpoch.resolves(state);
     // TODO: Use actual BLS verification
-    chainStub.bls = {verifySignatureSets: async () => true};
+    chainStub.bls = new BlsVerifierMock(true);
   });
 
   afterEach(() => {

--- a/packages/lodestar/test/utils/mocks/bls.ts
+++ b/packages/lodestar/test/utils/mocks/bls.ts
@@ -1,0 +1,13 @@
+import {IBlsVerifier} from "../../../src/chain/bls/index.js";
+
+export class BlsVerifierMock implements IBlsVerifier {
+  constructor(private readonly isValidResult: boolean) {}
+
+  async verifySignatureSets(): Promise<boolean> {
+    return this.isValidResult;
+  }
+
+  async close(): Promise<void> {
+    //
+  }
+}

--- a/packages/lodestar/test/utils/mocks/chain/chain.ts
+++ b/packages/lodestar/test/utils/mocks/chain/chain.ts
@@ -159,7 +159,7 @@ export class MockBeaconChain implements IBeaconChain {
   async processBlock(): Promise<void> {}
   async processChainSegment(): Promise<void> {}
 
-  close(): void {
+  async close(): Promise<void> {
     this.abortController.abort();
   }
 


### PR DESCRIPTION
**Motivation**

There are many seg faults occurring in our CI. Most of them suggest to come from the multi-threaded workers.

One suspicious practice that we have is to not await worker termination. BeaconNode consumer just aborts an AbortController which immediately returns and gives the impression downstream that everything is cleaned up and finished.

**Description**

Await workers temination on stop

**NOTE: I have no evidence to support that this change has anything to do with the motivation above**

Even it does not help directly on test stability, it makes sense to await this specific step given that workers are resource intensive.