### PR TITLE
Run spec tests v1.2.0-rc.1

### DIFF
--- a/packages/lodestar/test/spec/specTestVersioning.ts
+++ b/packages/lodestar/test/spec/specTestVersioning.ts
@@ -14,6 +14,6 @@ import {fileURLToPath} from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const SPEC_TEST_REPO_URL = "https://github.com/ethereum/consensus-spec-tests";
-export const SPEC_TEST_VERSION = "v1.1.10";
+export const SPEC_TEST_VERSION = "v1.2.0-rc.1";
 // Target directory is the host package root: 'packages/*/spec-tests'
 export const SPEC_TEST_LOCATION = path.join(__dirname, "../../spec-tests");

--- a/packages/lodestar/test/spec/utils/specTestIterator.ts
+++ b/packages/lodestar/test/spec/utils/specTestIterator.ts
@@ -48,6 +48,13 @@ export function specTestIterator(configName: string, testRunners: Record<string,
   for (const forkStr of readdirSyncSpec(configDirpath)) {
     const fork = ForkName[forkStr as ForkName];
     if (fork === undefined) {
+      if (forkStr === "capella") {
+        it("capella fork disabled, and prevents passing tests", () => {
+          throw Error("capella fork disabled, and prevents passing tests");
+        });
+        continue;
+      }
+
       throw Error(`Unknown fork ${forkStr}`);
     }
 


### PR DESCRIPTION
**Motivation**

Start preparing to support v1.2.0.

**Description**

 Lodestar is missing
- [ ] fork-choice equivocations
- [ ] handle large withdrawable epoch