### PR TITLE
Split RestApiServer into a base class

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/api.ts
+++ b/packages/cli/src/options/beaconNodeOptions/api.ts
@@ -19,7 +19,7 @@ export function parseArgs(args: IApiArgs): IBeaconNodeOptions["api"] {
       api: args["api.rest.api"] as IBeaconNodeOptions["api"]["rest"]["api"],
       cors: args["api.rest.cors"],
       enabled: args["api.rest.enabled"],
-      host: args["api.rest.host"],
+      address: args["api.rest.host"],
       port: args["api.rest.port"],
     },
   };
@@ -65,7 +65,7 @@ export const options: ICliCommandOptions<IApiArgs> = {
   "api.rest.host": {
     type: "string",
     description: "Set host for HTTP API",
-    defaultDescription: defaultOptions.api.rest.host,
+    defaultDescription: defaultOptions.api.rest.address,
     group: "api",
   },
 

--- a/packages/lodestar/package.json
+++ b/packages/lodestar/package.json
@@ -127,6 +127,7 @@
     "datastore-level": "^6.0.2",
     "deepmerge": "^3.2.0",
     "fastify": "3.15.1",
+    "fastify-bearer-auth": "6.1.0",
     "fastify-cors": "^6.0.1",
     "gc-stats": "^1.4.0",
     "interface-datastore": "^5.1.2",

--- a/packages/lodestar/src/api/options.ts
+++ b/packages/lodestar/src/api/options.ts
@@ -1,13 +1,13 @@
-import {restApiOptionsDefault, RestApiOptions} from "./rest/index.js";
+import {beaconRestApiServerOpts, BeaconRestApiServerOpts} from "./rest/index.js";
 
 export interface IApiOptions {
   maxGindicesInProof?: number;
-  rest: RestApiOptions;
+  rest: BeaconRestApiServerOpts;
   version?: string;
 }
 
 export const defaultApiOptions: IApiOptions = {
   maxGindicesInProof: 512,
-  rest: restApiOptionsDefault,
+  rest: beaconRestApiServerOpts,
   version: "dev",
 };

--- a/packages/lodestar/src/api/rest/activeSockets.ts
+++ b/packages/lodestar/src/api/rest/activeSockets.ts
@@ -2,7 +2,7 @@ import http, {Server} from "node:http";
 import {Socket} from "node:net";
 import {IGauge} from "../../metrics/index.js";
 
-type SocketMetrics = {
+export type SocketMetrics = {
   activeSockets: IGauge;
   socketsBytesRead: IGauge;
   socketsBytesWritten: IGauge;

--- a/packages/lodestar/src/api/rest/base.ts
+++ b/packages/lodestar/src/api/rest/base.ts
@@ -1,0 +1,128 @@
+import querystring from "querystring";
+import fastify, {FastifyError, FastifyInstance} from "fastify";
+import fastifyCors from "fastify-cors";
+import bearerAuthPlugin from "fastify-bearer-auth";
+import {RouteConfig} from "@chainsafe/lodestar-api/beacon/server";
+import {ErrorAborted, ILogger} from "@chainsafe/lodestar-utils";
+import {IGauge, IHistogram} from "../../metrics/index.js";
+import {ApiError, NodeIsSyncing} from "../impl/errors.js";
+import {HttpActiveSocketsTracker, SocketMetrics} from "./activeSockets.js";
+
+export type RestApiServerOpts = {
+  port: number;
+  cors?: string;
+  address?: string;
+  bearerToken?: string;
+};
+
+export type RestApiServerModules = {
+  logger: ILogger;
+  metrics: RestApiServerMetrics | null;
+};
+
+export type RestApiServerMetrics = SocketMetrics & {
+  requests: IGauge<"operationId">;
+  responseTime: IHistogram<"operationId">;
+  errors: IGauge<"operationId">;
+};
+
+/**
+ * REST API powered by `fastify` server.
+ */
+export class RestApiServer {
+  protected readonly server: FastifyInstance;
+  protected readonly logger: ILogger;
+  private readonly activeSockets: HttpActiveSocketsTracker;
+
+  constructor(private readonly opts: RestApiServerOpts, modules: RestApiServerModules) {
+    // Apply opts defaults
+    const {logger, metrics} = modules;
+
+    const server = fastify({
+      logger: false,
+      ajv: {customOptions: {coerceTypes: "array"}},
+      querystringParser: querystring.parse,
+    });
+
+    this.activeSockets = new HttpActiveSocketsTracker(server.server, metrics);
+
+    // To parse our ApiError -> statusCode
+    server.setErrorHandler((err, req, res) => {
+      if ((err as FastifyError).validation) {
+        void res.status(400).send((err as FastifyError).validation);
+      } else {
+        // Convert our custom ApiError into status code
+        const statusCode = err instanceof ApiError ? err.statusCode : 500;
+        void res.status(statusCode).send(err);
+      }
+    });
+
+    if (opts.cors) {
+      void server.register(fastifyCors, {origin: opts.cors});
+    }
+
+    if (opts.bearerToken) {
+      void server.register(bearerAuthPlugin, {keys: new Set([opts.bearerToken])});
+    }
+
+    // Log all incoming request to debug (before parsing). TODO: Should we hook latter in the lifecycle? https://www.fastify.io/docs/latest/Lifecycle/
+    // Note: Must be an async method so fastify can continue the release lifecycle. Otherwise we must call done() or the request stalls
+    server.addHook("onRequest", async (req, res) => {
+      const {operationId} = res.context.config as RouteConfig;
+      this.logger.debug(`Req ${req.id} ${req.ip} ${operationId}`);
+      metrics?.requests.inc({operationId});
+    });
+
+    // Log after response
+    server.addHook("onResponse", async (req, res) => {
+      const {operationId} = res.context.config as RouteConfig;
+      this.logger.debug(`Res ${req.id} ${operationId} - ${res.raw.statusCode}`);
+      metrics?.responseTime.observe({operationId}, res.getResponseTime() / 1000);
+    });
+
+    server.addHook("onError", async (req, res, err) => {
+      // Don't log ErrorAborted errors, they happen on node shutdown and are not usefull
+      // Don't log NodeISSyncing errors, they happen very frequently while syncing and the validator polls duties
+      if (err instanceof ErrorAborted || err instanceof NodeIsSyncing) return;
+
+      const {operationId} = res.context.config as RouteConfig;
+      this.logger.error(`Req ${req.id} ${operationId} error`, {}, err);
+      metrics?.errors.inc({operationId});
+    });
+
+    this.server = server;
+    this.logger = logger;
+  }
+
+  /**
+   * Start the REST API server.
+   */
+  async listen(): Promise<void> {
+    try {
+      const address = await this.server.listen(this.opts.port, this.opts.address);
+      this.logger.info("Started REST api server", {address});
+    } catch (e) {
+      this.logger.error("Error starting REST api server", this.opts, e as Error);
+      throw e;
+    }
+  }
+
+  /**
+   * Close the server instance and terminate all existing connections.
+   */
+  async close(): Promise<void> {
+    // In NodeJS land calling close() only causes new connections to be rejected.
+    // Existing connections can prevent .close() from resolving for potentially forever.
+    // In Lodestar case when the BeaconNode wants to close we will just abruptly terminate
+    // all existing connections for a fast shutdown.
+    // Inspired by https://github.com/gajus/http-terminator/
+    this.activeSockets.destroyAll();
+
+    await this.server.close();
+  }
+
+  /** For child classes to override */
+  protected shouldIgnoreError(_err: Error): boolean {
+    return false;
+  }
+}

--- a/packages/lodestar/src/api/rest/index.ts
+++ b/packages/lodestar/src/api/rest/index.ts
@@ -1,136 +1,51 @@
-import querystring from "querystring";
-import fastify, {FastifyError, FastifyInstance} from "fastify";
-import fastifyCors from "fastify-cors";
 import {Api} from "@chainsafe/lodestar-api";
-import {registerRoutes, RouteConfig} from "@chainsafe/lodestar-api/beacon/server";
+import {registerRoutes} from "@chainsafe/lodestar-api/beacon/server";
 import {ErrorAborted, ILogger} from "@chainsafe/lodestar-utils";
-import {IBeaconConfig} from "@chainsafe/lodestar-config";
-import {IMetrics} from "../../metrics/index.js";
-import {ApiError, NodeIsSyncing} from "../impl/errors.js";
-import {HttpActiveSocketsTracker} from "./activeSockets.js";
+import {IChainForkConfig} from "@chainsafe/lodestar-config";
+import {NodeIsSyncing} from "../impl/errors.js";
+import {RestApiServer, RestApiServerModules, RestApiServerMetrics} from "./base.js";
 export {allNamespaces} from "@chainsafe/lodestar-api";
 
-export type RestApiOptions = {
+export type BeaconRestApiServerOpts = {
   enabled: boolean;
   api: (keyof Api)[];
-  host: string;
-  cors: string;
   port: number;
+  cors?: string;
+  address?: string;
 };
 
-export const restApiOptionsDefault: RestApiOptions = {
+export const beaconRestApiServerOpts: BeaconRestApiServerOpts = {
   enabled: true,
   // ApiNamespace "debug" is not turned on by default
   api: ["beacon", "config", "events", "node", "validator"],
-  host: "127.0.0.1",
+  address: "127.0.0.1",
   port: 9596,
   cors: "*",
 };
 
-export interface IRestApiModules {
-  config: IBeaconConfig;
+export type BeaconRestApiServerModules = RestApiServerModules & {
+  config: IChainForkConfig;
   logger: ILogger;
   api: Api;
-  metrics: IMetrics | null;
-}
+  metrics: RestApiServerMetrics | null;
+};
 
 /**
  * REST API powered by `fastify` server.
  */
-export class RestApi {
-  private readonly opts: RestApiOptions;
-  private readonly server: FastifyInstance;
-  private readonly logger: ILogger;
-  private readonly activeSockets: HttpActiveSocketsTracker;
+export class BeaconRestApiServer extends RestApiServer {
+  constructor(optsArg: Partial<BeaconRestApiServerOpts>, modules: BeaconRestApiServerModules) {
+    const opts = {...beaconRestApiServerOpts, ...optsArg};
 
-  constructor(optsArg: Partial<RestApiOptions>, modules: IRestApiModules) {
-    // Apply opts defaults
-    const opts = {...restApiOptionsDefault, ...optsArg};
-    const {config, logger, api, metrics} = modules;
-
-    const server = fastify({
-      logger: false,
-      ajv: {customOptions: {coerceTypes: "array"}},
-      querystringParser: querystring.parse,
-    });
-
-    this.activeSockets = new HttpActiveSocketsTracker(server.server, metrics ? metrics.apiRest : null);
+    super(opts, modules);
 
     // Instantiate and register the routes with matching namespace in `opts.api`
-    registerRoutes(server, config, api, opts.api);
-
-    // To parse our ApiError -> statusCode
-    server.setErrorHandler((err, req, res) => {
-      if ((err as FastifyError).validation) {
-        void res.status(400).send((err as FastifyError).validation);
-      } else {
-        // Convert our custom ApiError into status code
-        const statusCode = err instanceof ApiError ? err.statusCode : 500;
-        void res.status(statusCode).send(err);
-      }
-    });
-
-    if (opts.cors) {
-      void server.register(fastifyCors, {origin: opts.cors});
-    }
-
-    // Log all incoming request to debug (before parsing). TODO: Should we hook latter in the lifecycle? https://www.fastify.io/docs/latest/Lifecycle/
-    // Note: Must be an async method so fastify can continue the release lifecycle. Otherwise we must call done() or the request stalls
-    server.addHook("onRequest", async (req, res) => {
-      const {operationId} = res.context.config as RouteConfig;
-      this.logger.debug(`Req ${req.id} ${req.ip} ${operationId}`);
-      metrics?.apiRest.requests.inc({operationId});
-    });
-
-    // Log after response
-    server.addHook("onResponse", async (req, res) => {
-      const {operationId} = res.context.config as RouteConfig;
-      this.logger.debug(`Res ${req.id} ${operationId} - ${res.raw.statusCode}`);
-      metrics?.apiRest.responseTime.observe({operationId}, res.getResponseTime() / 1000);
-    });
-
-    server.addHook("onError", async (req, res, err) => {
-      // Don't log ErrorAborted errors, they happen on node shutdown and are not usefull
-      // Don't log NodeISSyncing errors, they happen very frequently while syncing and the validator polls duties
-      if (err instanceof ErrorAborted || err instanceof NodeIsSyncing) return;
-
-      const {operationId} = res.context.config as RouteConfig;
-      this.logger.error(`Req ${req.id} ${operationId} error`, {}, err);
-      metrics?.apiRest.errors.inc({operationId});
-    });
-
-    this.opts = opts;
-    this.server = server;
-    this.logger = logger;
+    registerRoutes(this.server, modules.config, modules.api, opts.api);
   }
 
-  /**
-   * Start the REST API server.
-   */
-  async listen(): Promise<void> {
-    // TODO: Consider if necessary. The consumer could just not call this function
-    if (!this.opts.enabled) return;
-
-    try {
-      const address = await this.server.listen(this.opts.port, this.opts.host);
-      this.logger.info("Started REST api server", {address, namespaces: this.opts.api.join(",")});
-    } catch (e) {
-      this.logger.error("Error starting REST api server", {host: this.opts.host, port: this.opts.port}, e as Error);
-      throw e;
-    }
-  }
-
-  /**
-   * Close the server instance and terminate all existing connections.
-   */
-  async close(): Promise<void> {
-    // In NodeJS land calling close() only causes new connections to be rejected.
-    // Existing connections can prevent .close() from resolving for potentially forever.
-    // In Lodestar case when the BeaconNode wants to close we will just abruptly terminate
-    // all existing connections for a fast shutdown.
-    // Inspired by https://github.com/gajus/http-terminator/
-    this.activeSockets.destroyAll();
-
-    await this.server.close();
+  protected shouldIgnoreError(err: Error): boolean {
+    // Don't log ErrorAborted errors, they happen on node shutdown and are not usefull
+    // Don't log NodeISSyncing errors, they happen very frequently while syncing and the validator polls duties
+    return err instanceof ErrorAborted || err instanceof NodeIsSyncing;
   }
 }

--- a/packages/lodestar/src/node/nodejs.ts
+++ b/packages/lodestar/src/node/nodejs.ts
@@ -17,7 +17,7 @@ import {BeaconSync, IBeaconSync} from "../sync/index.js";
 import {BackfillSync} from "../sync/backfill/index.js";
 import {BeaconChain, IBeaconChain, initBeaconMetrics} from "../chain/index.js";
 import {createMetrics, IMetrics, HttpMetricsServer} from "../metrics/index.js";
-import {getApi, RestApi} from "../api/index.js";
+import {getApi, BeaconRestApiServer} from "../api/index.js";
 import {initializeExecutionEngine} from "../executionEngine/index.js";
 import {initializeEth1ForBlockProduction} from "../eth1/index.js";
 import {IBeaconNodeOptions} from "./options.js";
@@ -36,7 +36,7 @@ export interface IBeaconNodeModules {
   sync: IBeaconSync;
   backfillSync: BackfillSync | null;
   metricsServer?: HttpMetricsServer;
-  restApi?: RestApi;
+  restApi?: BeaconRestApiServer;
   controller?: AbortController;
 }
 
@@ -70,7 +70,7 @@ export class BeaconNode {
   network: INetwork;
   chain: IBeaconChain;
   api: Api;
-  restApi?: RestApi;
+  restApi?: BeaconRestApiServer;
   sync: IBeaconSync;
   backfillSync: BackfillSync | null;
 
@@ -203,11 +203,11 @@ export class BeaconNode {
       await metricsServer.start();
     }
 
-    const restApi = new RestApi(opts.api.rest, {
+    const restApi = new BeaconRestApiServer(opts.api.rest, {
       config,
       logger: logger.child(opts.logger.api),
       api,
-      metrics,
+      metrics: metrics ? metrics.apiRest : null,
     });
     if (opts.api.rest.enabled) {
       await restApi.listen();


### PR DESCRIPTION
**Motivation**

Spin-off PR from https://github.com/ChainSafe/lodestar/pull/4201

Modularize our REST API server class to be used for both beacon and keymanager servers

**Description**

Split RestApiServer into a base class