### PR TITLE
Remove delete-tag from rollback in publish workflows

### DIFF
--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -121,7 +121,6 @@ jobs:
         with:
           id: ${{ steps.create_release.outputs.id }}
           tag: ${{ needs.tag.outputs.tag }}
-          delete_orphan_tag: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -111,7 +111,6 @@ jobs:
         with:
           id: ${{ steps.create_release.outputs.id }}
           tag: ${{ needs.tag.outputs.tag }}
-          delete_orphan_tag: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
**Motivation**

In lodestar, tags should only be modified by humans as ways to trigger CI.
Deleting tags is considered harmful.
