### PR TITLE
Adjust currentTargetUnslashedBalanceIncrements if effectiveBalance is changed

### DIFF
--- a/packages/beacon-state-transition/src/cache/epochProcess.ts
+++ b/packages/beacon-state-transition/src/cache/epochProcess.ts
@@ -407,8 +407,6 @@ export function beforeProcessEpoch(state: CachedBeaconStateAllForks): EpochProce
   if (prevTargetUnslStake < 1) prevTargetUnslStake = 1;
   if (prevHeadUnslStake < 1) prevHeadUnslStake = 1;
   if (currTargetUnslStake < 1) currTargetUnslStake = 1;
-  if (epochCtx.currentTargetUnslashedBalanceIncrements < 1) epochCtx.currentTargetUnslashedBalanceIncrements = 1;
-  if (epochCtx.previousTargetUnslashedBalanceIncrements < 1) epochCtx.previousTargetUnslashedBalanceIncrements = 1;
 
   return {
     prevEpoch,

--- a/packages/beacon-state-transition/src/cache/epochProcess.ts
+++ b/packages/beacon-state-transition/src/cache/epochProcess.ts
@@ -407,6 +407,8 @@ export function beforeProcessEpoch(state: CachedBeaconStateAllForks): EpochProce
   if (prevTargetUnslStake < 1) prevTargetUnslStake = 1;
   if (prevHeadUnslStake < 1) prevHeadUnslStake = 1;
   if (currTargetUnslStake < 1) currTargetUnslStake = 1;
+  if (epochCtx.currentTargetUnslashedBalanceIncrements < 1) epochCtx.currentTargetUnslashedBalanceIncrements = 1;
+  if (epochCtx.previousTargetUnslashedBalanceIncrements < 1) epochCtx.previousTargetUnslashedBalanceIncrements = 1;
 
   return {
     prevEpoch,

--- a/packages/beacon-state-transition/src/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/beacon-state-transition/src/epoch/processEffectiveBalanceUpdates.ts
@@ -1,11 +1,16 @@
 import {
   EFFECTIVE_BALANCE_INCREMENT,
+  ForkSeq,
   HYSTERESIS_DOWNWARD_MULTIPLIER,
   HYSTERESIS_QUOTIENT,
   HYSTERESIS_UPWARD_MULTIPLIER,
   MAX_EFFECTIVE_BALANCE,
+  TIMELY_TARGET_FLAG_INDEX,
 } from "@chainsafe/lodestar-params";
-import {EpochProcess, CachedBeaconStateAllForks} from "../types.js";
+import {EpochProcess, CachedBeaconStateAllForks, BeaconStateAltair} from "../types.js";
+
+/** Same to https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.5/specs/altair/beacon-chain.md#has_flag */
+const TIMELY_TARGET = 1 << TIMELY_TARGET_FLAG_INDEX;
 
 /**
  * Update effective balances if validator.balance has changed enough
@@ -23,6 +28,7 @@ export function processEffectiveBalanceUpdates(state: CachedBeaconStateAllForks,
   const UPWARD_THRESHOLD = HYSTERESIS_INCREMENT * HYSTERESIS_UPWARD_MULTIPLIER;
   const {validators, epochCtx} = state;
   const {effectiveBalanceIncrements} = epochCtx;
+  const forkSeq = epochCtx.config.getForkSeq(state.slot);
   let nextEpochTotalActiveBalanceByIncrement = 0;
 
   // update effective balances with hysteresis
@@ -49,7 +55,17 @@ export function processEffectiveBalanceUpdates(state: CachedBeaconStateAllForks,
       // Should happen rarely, so it's fine to update the tree
       validators.get(i).effectiveBalance = effectiveBalance;
       // Also update the fast cached version
-      effectiveBalanceIncrement = Math.floor(effectiveBalance / EFFECTIVE_BALANCE_INCREMENT);
+      const newEffectiveBalanceIncrement = Math.floor(effectiveBalance / EFFECTIVE_BALANCE_INCREMENT);
+      const deltaEffectiveBalanceIncrement = newEffectiveBalanceIncrement - effectiveBalanceIncrement;
+      if (forkSeq > ForkSeq.phase0) {
+        const currentParticipation = (state as BeaconStateAltair).currentEpochParticipation.getAll();
+        if ((currentParticipation[i] & TIMELY_TARGET) === TIMELY_TARGET) {
+          // currentTargetUnslashedBalanceIncrements is transfered to previousTargetUnslashedBalanceIncrements in afterEpochProcess
+          // at epoch transition of next epoch (in EpochProcess), prevTargetUnslStake is calculated based on newEffectiveBalanceIncrement
+          epochCtx.currentTargetUnslashedBalanceIncrements += deltaEffectiveBalanceIncrement;
+        }
+      }
+      effectiveBalanceIncrement = newEffectiveBalanceIncrement;
       effectiveBalanceIncrements[i] = effectiveBalanceIncrement;
     }
 

--- a/packages/beacon-state-transition/src/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/beacon-state-transition/src/epoch/processEffectiveBalanceUpdates.ts
@@ -59,10 +59,17 @@ export function processEffectiveBalanceUpdates(state: CachedBeaconStateAllForks,
       const deltaEffectiveBalanceIncrement = newEffectiveBalanceIncrement - effectiveBalanceIncrement;
       if (forkSeq > ForkSeq.phase0) {
         const currentParticipation = (state as BeaconStateAltair).currentEpochParticipation.getAll();
+        // currentTargetUnslashedBalanceIncrements is transfered to previousTargetUnslashedBalanceIncrements in afterEpochProcess
+        // at epoch transition of next epoch (in EpochProcess), prevTargetUnslStake is calculated based on newEffectiveBalanceIncrement
         if ((currentParticipation[i] & TIMELY_TARGET) === TIMELY_TARGET) {
-          // currentTargetUnslashedBalanceIncrements is transfered to previousTargetUnslashedBalanceIncrements in afterEpochProcess
-          // at epoch transition of next epoch (in EpochProcess), prevTargetUnslStake is calculated based on newEffectiveBalanceIncrement
           epochCtx.currentTargetUnslashedBalanceIncrements += deltaEffectiveBalanceIncrement;
+        }
+
+        // previousTargetUnslashedBalanceIncrements is also used after this (in slashValidators())
+        // it needs to go with the new effectiveBalance as well
+        const previousParticipation = (state as BeaconStateAltair).previousEpochParticipation.getAll();
+        if ((previousParticipation[i] & TIMELY_TARGET) === TIMELY_TARGET) {
+          epochCtx.previousTargetUnslashedBalanceIncrements += deltaEffectiveBalanceIncrement;
         }
       }
       effectiveBalanceIncrement = newEffectiveBalanceIncrement;

--- a/packages/beacon-state-transition/src/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/beacon-state-transition/src/epoch/processEffectiveBalanceUpdates.ts
@@ -53,7 +53,8 @@ export function processEffectiveBalanceUpdates(state: CachedBeaconStateAllForks,
       effectiveBalance = Math.min(balance - (balance % EFFECTIVE_BALANCE_INCREMENT), MAX_EFFECTIVE_BALANCE);
       // Update the state tree
       // Should happen rarely, so it's fine to update the tree
-      validators.get(i).effectiveBalance = effectiveBalance;
+      const validator = validators.get(i);
+      validator.effectiveBalance = effectiveBalance;
       // Also update the fast cached version
       const newEffectiveBalanceIncrement = Math.floor(effectiveBalance / EFFECTIVE_BALANCE_INCREMENT);
       const deltaEffectiveBalanceIncrement = newEffectiveBalanceIncrement - effectiveBalanceIncrement;
@@ -61,14 +62,14 @@ export function processEffectiveBalanceUpdates(state: CachedBeaconStateAllForks,
         const currentParticipation = (state as BeaconStateAltair).currentEpochParticipation.getAll();
         // currentTargetUnslashedBalanceIncrements is transfered to previousTargetUnslashedBalanceIncrements in afterEpochProcess
         // at epoch transition of next epoch (in EpochProcess), prevTargetUnslStake is calculated based on newEffectiveBalanceIncrement
-        if ((currentParticipation[i] & TIMELY_TARGET) === TIMELY_TARGET) {
+        if (!validator.slashed && (currentParticipation[i] & TIMELY_TARGET) === TIMELY_TARGET) {
           epochCtx.currentTargetUnslashedBalanceIncrements += deltaEffectiveBalanceIncrement;
         }
 
         // previousTargetUnslashedBalanceIncrements is also used after this (in slashValidators())
         // it needs to go with the new effectiveBalance as well
         const previousParticipation = (state as BeaconStateAltair).previousEpochParticipation.getAll();
-        if ((previousParticipation[i] & TIMELY_TARGET) === TIMELY_TARGET) {
+        if (!validator.slashed && (previousParticipation[i] & TIMELY_TARGET) === TIMELY_TARGET) {
           epochCtx.previousTargetUnslashedBalanceIncrements += deltaEffectiveBalanceIncrement;
         }
       }

--- a/packages/beacon-state-transition/src/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/beacon-state-transition/src/epoch/processEffectiveBalanceUpdates.ts
@@ -59,17 +59,16 @@ export function processEffectiveBalanceUpdates(state: CachedBeaconStateAllForks,
       const newEffectiveBalanceIncrement = Math.floor(effectiveBalance / EFFECTIVE_BALANCE_INCREMENT);
       const deltaEffectiveBalanceIncrement = newEffectiveBalanceIncrement - effectiveBalanceIncrement;
       if (forkSeq > ForkSeq.phase0) {
-        const currentParticipation = (state as BeaconStateAltair).currentEpochParticipation.getAll();
+        const altairState = state as BeaconStateAltair;
         // currentTargetUnslashedBalanceIncrements is transfered to previousTargetUnslashedBalanceIncrements in afterEpochProcess
         // at epoch transition of next epoch (in EpochProcess), prevTargetUnslStake is calculated based on newEffectiveBalanceIncrement
-        if (!validator.slashed && (currentParticipation[i] & TIMELY_TARGET) === TIMELY_TARGET) {
+        if (!validator.slashed && (altairState.currentEpochParticipation.get(i) & TIMELY_TARGET) === TIMELY_TARGET) {
           epochCtx.currentTargetUnslashedBalanceIncrements += deltaEffectiveBalanceIncrement;
         }
 
         // previousTargetUnslashedBalanceIncrements is also used after this (in slashValidators())
         // it needs to go with the new effectiveBalance as well
-        const previousParticipation = (state as BeaconStateAltair).previousEpochParticipation.getAll();
-        if (!validator.slashed && (previousParticipation[i] & TIMELY_TARGET) === TIMELY_TARGET) {
+        if (!validator.slashed && (altairState.previousEpochParticipation.get(i) & TIMELY_TARGET) === TIMELY_TARGET) {
           epochCtx.previousTargetUnslashedBalanceIncrements += deltaEffectiveBalanceIncrement;
         }
       }


### PR DESCRIPTION
**Motivation**

+ Fix this error

```
Jun-29 04:22:54.602[CHAIN]           error: Block error slot=1176512, errCode=BLOCK_ERROR_PRESTATE_MISSING error=previousTargetUnslashedBalanceIncrements is wrong, expect 6214032, got 6214033,current epoch 36765
```

+ Note that the difference is only 1 so I think it's due to the incorrect `effectiveBalance` of one of validators

**Description**

+ `previousTargetUnslashedBalanceIncrements` may went with the effectiveBalance of previous epoch while `prevTargetUnslStake` in EpochProcess always go with the current epoch's effectiveBalance

+ Adjust `currentTargetUnslashedBalanceIncrements` in `processEffectiveBalance()` before transfer it to `previousTargetUnslashedBalanceIncrements` in `afterEpochProcess`
