### PR TITLE
Fix the eth1 tracker poll loop when the blocks are slow

### DIFF
--- a/packages/lodestar/src/eth1/eth1DepositDataTracker.ts
+++ b/packages/lodestar/src/eth1/eth1DepositDataTracker.ts
@@ -305,10 +305,15 @@ export class Eth1DepositDataTracker {
       return true;
     } else {
       // Blocks are slower than expected, reduce eth1FollowDistance. Limit min CATCHUP_MIN_FOLLOW_DISTANCE
-      const delta = ETH1_FOLLOW_DISTANCE_DELTA_IF_SLOW;
-      this.eth1FollowDistance = Math.max(this.eth1FollowDistance - delta, ETH_MIN_FOLLOW_DISTANCE);
+      const delta =
+        this.eth1FollowDistance -
+        Math.max(this.eth1FollowDistance - ETH1_FOLLOW_DISTANCE_DELTA_IF_SLOW, ETH_MIN_FOLLOW_DISTANCE);
+      this.eth1FollowDistance = this.eth1FollowDistance - delta;
 
-      return false;
+      // Even if the blocks are slow, when we are all caught up as there is no
+      // further possibility to reduce follow distance, we need to call it quits
+      // for now, else it leads to an incessant poll on the EL
+      return delta === 0;
     }
   }
 


### PR DESCRIPTION
On ropsten nethermind deployment, it was noticed that the eth1 tracker was continuously polling it. The reason being since the blocks were slow (at some point in sync history) and none of the dowloaded blocks were crossing the `remoteFollowBlockTimestamp`, we reached minimum possible `eth1FollowDistance` but kept returning false to `updateBlockCache` leading to another round of block fetches (and so on...)

This PR fixes that if blocks are slow and we are already at minimum `eth1FollowDistance`, i.e. `delta` is `0`, we return that we are all *caught up* for now (leading to the normal slow poll)