### PR TITLE
Expose util modules from the light-client package

### DIFF
--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -13,7 +13,17 @@
   },
   "version": "0.38.1",
   "type": "module",
-  "exports": "./lib/index.js",
+  "exports": {
+    ".": {
+      "import": "./lib/index.js"
+    },
+    "./utils": {
+      "import": "./lib/utils/index.js"
+    },
+    "./networks": {
+      "import": "./lib/networks.js"
+    }
+  },
   "types": "./lib/index.d.ts",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/light-client/src/utils/index.ts
+++ b/packages/light-client/src/utils/index.ts
@@ -1,0 +1,7 @@
+export * from "./chunkify.js";
+export * from "./clock.js";
+export * from "./domain.js";
+export * from "./logger.js";
+export * from "./update.js";
+export * from "./utils.js";
+export * from "./verifyMerkleBranch.js";


### PR DESCRIPTION
**Motivation**

While upgrading lodestar dependencies in our light client demo, it became obvious that import statements like:

```
import {computeSyncPeriodAtSlot} from "@chainsafe/lodestar-light-client/lib/utils/clock"
```

No longer work due to move to esm.


**Description**

Exposes this modules by exporting them in package.json

Closes #4227

