### PR TITLE
Add option to attach beacon node to globalThis

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -85,6 +85,8 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
       metricsRegistries,
     });
 
+    if (args.attachToGlobalThis) ((globalThis as unknown) as {bn: BeaconNode}).bn = node;
+
     abortController.signal.addEventListener("abort", () => node.close(), {once: true});
   } catch (e) {
     await db.stop();

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -142,7 +142,22 @@ export const beaconPathsOptions: ICliCommandOptions<IBeaconPaths> = {
   },
 };
 
-export type IBeaconArgs = IBeaconExtraArgs & ILogArgs & IBeaconPaths & IBeaconNodeArgs & IENRArgs & IWSSArgs;
+export type DebugArgs = {attachToGlobalThis: boolean};
+export const debugOptions: ICliCommandOptions<DebugArgs> = {
+  attachToGlobalThis: {
+    hidden: true,
+    description: "Attach the beacon node to `globalThis`. Useful to inspect a running beacon node.",
+    type: "boolean",
+  },
+};
+
+export type IBeaconArgs = IBeaconExtraArgs &
+  ILogArgs &
+  IBeaconPaths &
+  IBeaconNodeArgs &
+  IENRArgs &
+  IWSSArgs &
+  DebugArgs;
 
 export const beaconOptions: {[k: string]: Options} = {
   ...beaconExtraOptions,
@@ -152,4 +167,5 @@ export const beaconOptions: {[k: string]: Options} = {
   ...paramsOptions,
   ...enrOptions,
   ...wssOptions,
+  ...debugOptions,
 };


### PR DESCRIPTION
**Motivation**

It can be useful to inspect a running beacon node for debugging purposes.

**Description**

Add a hidden cli option `--attachToGlobalThis` which attaches the beacon node to `globalThis.bn`