### PR TITLE
Add support to run validator using deposit cli keystores

### DIFF
--- a/merge-scripts/README.md
+++ b/merge-scripts/README.md
@@ -61,7 +61,7 @@ You can alternate between them (without needing to reset/cleanup) to experiment 
 5. `--withTerminal`(optional): Provide the terminal command prefix for CL and EL processes to run in your favourite terminal.
    You may use an alias or a terminal launching script as long as it waits for the command it runs till ends and then closes.If not provided, it will launch the docker processes in _in-terminal_ mode.
 6. `--detached`(optional): By default the script will wait for processes and use user input (ctrl +c) to end the processes, however you can pass this option to skip this behavior and just return, for e.g. in case you just want to leave it running.
-7. `--withValidator` (optional): Launch a validator client using `LODESTAR_VALIDATOR_ARGS` as set in the devnet vars file.
+7. `--withValidatorKeystore | --withValidatorMnemonic` (optional): Launch a validator client using `LODESTAR_VALIDATOR_KEYSTORE_ARGS` or `LODESTAR_VALIDATOR_MNEMONIC_ARGS` as set in the devnet vars file.
 8. `--justEL | --justCL | --justVC` (optional) : Just launch only EL client or lodestar beacon or lodestar validator at any given time. Gives you more control over the setup.
 9. `--skipImagePull` (optional): Just work with local images, don't try updating them.
 

--- a/merge-scripts/goerlishadow-4.vars
+++ b/merge-scripts/goerlishadow-4.vars
@@ -1,3 +1,15 @@
+# Uncomment the following if you want to start validator with deposit cli keystores
+# Keystores and the pass.txt will be picked from the current dir (mounted as /currentDir in container)
+
+# LODESTAR_VALIDATOR_SECRETS_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
+
+# Comment this if you want to start validators with deposit cli and uncommented above
+
+LODESTAR_VALIDATOR_SECRETS_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
+
+#---------------- Only Modify below if you know what you are doing ----------------
+#----------------------------------------------------------------------------------
+
 DEVNET_NAME=goerlishadow-4
 CONFIG_GIT_DIR=goerli-shadow-fork-4
 NETWORK_ID=5
@@ -12,17 +24,22 @@ BESU_IMAGE=hyperledger/besu:develop
 
 LODESTAR_IMAGE=chainsafe/lodestar:next
 
-LODESTAR_EXTRA_ARGS="--eth1.providerUrls http://127.0.0.1:8545 --execution.urls http://127.0.0.1:8551 --api.rest.enabled --api.rest.host 0.0.0.0 --api.rest.api '*'"
 
-LODESTAR_VALIDATOR_ARGS='--network kiln  --fromMnemonic "lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow" --mnemonicIndexes 0..5'
+LODESTAR_EXTRA_ARGS="--terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
-NETHERMIND_EXTRA_ARGS="--config  goerli_shadowfork --Network.DiscoveryPort=30303 --Network.P2PPort=30303 --Merge.Enabled=true --Merge.TerminalTotalDifficulty=$MERGE_TTD --Init.DiagnosticMode=None --JsonRpc.Enabled=true --JsonRpc.Host=0.0.0.0 --JsonRpc.AdditionalRpcUrls \"http://localhost:8545|http;ws|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:8551|http;ws|net;eth;subscribe;engine;web3;client\""
+# We are using network kiln here but this is just a hack to use mnemonic as lodestar only
+# allows menmonic for non mainnet vals, and there is no explicit goerli shadow fork network.
+# however config.yaml will be picked to apply all the goerli shadow fork params
 
-GETH_EXTRA_ARGS="--http --http.api engine,net,eth,web3 --http.port 8545 --allow-insecure-unlock --http.addr 0.0.0.0 --http.corsdomain \"*\" --http.vhosts \"*\" --authrpc.port=8551 --override.terminaltotaldifficulty=$MERGE_TTD --networkid $NETWORK_ID"
+LODESTAR_VALIDATOR_ARGS="--network kiln $LODESTAR_VAL_FIXED_VARS $LODESTAR_VALIDATOR_SECRETS_ARGS"
 
-ETHEREUMJS_EXTRA_ARGS="--saveReceipts --rpc --rpcport 8545 --ws --rpcEngine --rpcEnginePort=8551 --rpcDebug --loglevel=debug"
+NETHERMIND_EXTRA_ARGS="--config goerli_shadowfork  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 
-BESU_EXTRA_ARGS="--rpc-http-enabled=true --rpc-http-api=ADMIN,CLIQUE,MINER,ETH,NET,DEBUG,TXPOOL,TRACE --rpc-http-host=0.0.0.0 --rpc-http-port=8545 --Xmerge-support=true --engine-rpc-http-port=8551 --rpc-http-cors-origins=\"*\" --host-allowlist=\"*\" --engine-host-allowlist=\"*\" --p2p-enabled=true --engine-jwt-enabled=true --network-id=$NETWORK_ID"
 
+GETH_EXTRA_ARGS="--override.terminaltotaldifficulty=$MERGE_TTD --networkid $NETWORK_ID $GETH_FIXED_VARS"
+
+ETHEREUMJS_EXTRA_ARGS="$ETHEREUMJS_FIXED_VARS"
+
+BESU_EXTRA_ARGS="--network-id=$NETWORK_ID $BESU_FIXED_VARS"
 
 EXTRA_BOOTNODES=""

--- a/merge-scripts/goerlishadow-4.vars
+++ b/merge-scripts/goerlishadow-4.vars
@@ -1,11 +1,9 @@
-# Uncomment the following if you want to start validator with deposit cli keystores
-# Keystores and the pass.txt will be picked from the current dir (mounted as /currentDir in container)
+LODESTAR_VALIDATOR_KEYSTORE_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
 
-# LODESTAR_VALIDATOR_SECRETS_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
+LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
 
-# Comment this if you want to start validators with deposit cli and uncommented above
-
-LODESTAR_VALIDATOR_SECRETS_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
+# This will be available in /data/jwtsecret
+JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
 #---------------- Only Modify below if you know what you are doing ----------------
 #----------------------------------------------------------------------------------
@@ -14,8 +12,6 @@ DEVNET_NAME=goerlishadow-4
 CONFIG_GIT_DIR=goerli-shadow-fork-4
 NETWORK_ID=5
 MERGE_TTD=9895202
-
-JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
 GETH_IMAGE=parithoshj/geth:master
 NETHERMIND_IMAGE=nethermindeth/nethermind:kiln_shadowfork
@@ -31,7 +27,7 @@ LODESTAR_EXTRA_ARGS="--terminal-total-difficulty-override $MERGE_TTD $LODESTAR_F
 # allows menmonic for non mainnet vals, and there is no explicit goerli shadow fork network.
 # however config.yaml will be picked to apply all the goerli shadow fork params
 
-LODESTAR_VALIDATOR_ARGS="--network kiln $LODESTAR_VAL_FIXED_VARS $LODESTAR_VALIDATOR_SECRETS_ARGS"
+LODESTAR_VALIDATOR_ARGS="--network kiln $LODESTAR_VAL_FIXED_VARS"
 
 NETHERMIND_EXTRA_ARGS="--config goerli_shadowfork  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/goerlishadow-4.vars
+++ b/merge-scripts/goerlishadow-4.vars
@@ -5,6 +5,8 @@ LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb pla
 # This will be available in /data/jwtsecret
 JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
+FEE_RECIPIENT="0xcccccccccccccccccccccccccccccccccccccccc"
+
 #---------------- Only Modify below if you know what you are doing ----------------
 #----------------------------------------------------------------------------------
 
@@ -27,7 +29,7 @@ LODESTAR_EXTRA_ARGS="--terminal-total-difficulty-override $MERGE_TTD $LODESTAR_F
 # allows menmonic for non mainnet vals, and there is no explicit goerli shadow fork network.
 # however config.yaml will be picked to apply all the goerli shadow fork params
 
-LODESTAR_VALIDATOR_ARGS="--network kiln $LODESTAR_VAL_FIXED_VARS"
+LODESTAR_VALIDATOR_ARGS="--network kiln $LODESTAR_VAL_FIXED_VARS --defaultFeeRecipient $FEE_RECIPIENT"
 
 NETHERMIND_EXTRA_ARGS="--config goerli_shadowfork  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/kiln.vars
+++ b/merge-scripts/kiln.vars
@@ -1,11 +1,9 @@
-# Uncomment the following if you want to start validator with deposit cli keystores
-# Keystores and the pass.txt will be picked from the current dir (mounted as /currentDir in container)
+LODESTAR_VALIDATOR_KEYSTORE_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
 
-# LODESTAR_VALIDATOR_SECRETS_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
+LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
 
-# Comment this if you want to start validators with deposit cli and uncommented above
-
-LODESTAR_VALIDATOR_SECRETS_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
+# This will be available in /data/jwtsecret
+JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
 #---------------- Only Modify below if you know what you are doing ----------------
 #----------------------------------------------------------------------------------
@@ -14,8 +12,6 @@ DEVNET_NAME=kiln
 CONFIG_GIT_DIR=kiln
 NETWORK_ID=1337802
 MERGE_TTD=20000000000000
-
-JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
 GETH_IMAGE=ethereum/client-go:latest
 NETHERMIND_IMAGE=nethermind/nethermind:latest
@@ -26,7 +22,7 @@ LODESTAR_IMAGE=chainsafe/lodestar:next
 
 LODESTAR_EXTRA_ARGS="--terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
-LODESTAR_VALIDATOR_ARGS="--network kiln $LODESTAR_VAL_FIXED_VARS $LODESTAR_VALIDATOR_SECRETS_ARGS"
+LODESTAR_VALIDATOR_ARGS="--network kiln $LODESTAR_VAL_FIXED_VARS"
 
 NETHERMIND_EXTRA_ARGS="--config kiln  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/kiln.vars
+++ b/merge-scripts/kiln.vars
@@ -11,7 +11,7 @@ FEE_RECIPIENT="0xcccccccccccccccccccccccccccccccccccccccc"
 #----------------------------------------------------------------------------------
 
 DEVNET_NAME=kiln
-CONFIG_GIT_DIR=kiln
+CONFIG_GIT_DIR=
 NETWORK_ID=1337802
 MERGE_TTD=20000000000000
 
@@ -22,16 +22,16 @@ BESU_IMAGE=hyperledger/besu:develop
 
 LODESTAR_IMAGE=chainsafe/lodestar:next
 
-LODESTAR_EXTRA_ARGS="--terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
+LODESTAR_EXTRA_ARGS="--network kiln --terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
 LODESTAR_VALIDATOR_ARGS="--network kiln $LODESTAR_VAL_FIXED_VARS --defaultFeeRecipient $FEE_RECIPIENT"
 
 NETHERMIND_EXTRA_ARGS="--config kiln  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 
-GETH_EXTRA_ARGS="--override.terminaltotaldifficulty=$MERGE_TTD --networkid $NETWORK_ID $GETH_FIXED_VARS"
+GETH_EXTRA_ARGS="--kiln --override.terminaltotaldifficulty=$MERGE_TTD --networkid $NETWORK_ID $GETH_FIXED_VARS"
 
 ETHEREUMJS_EXTRA_ARGS="$ETHEREUMJS_FIXED_VARS"
 
-BESU_EXTRA_ARGS="--network-id=$NETWORK_ID $BESU_FIXED_VARS"
+BESU_EXTRA_ARGS="--network=kiln --network-id=$NETWORK_ID $BESU_FIXED_VARS"
 
 EXTRA_BOOTNODES=""

--- a/merge-scripts/kiln.vars
+++ b/merge-scripts/kiln.vars
@@ -5,6 +5,8 @@ LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb pla
 # This will be available in /data/jwtsecret
 JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
+FEE_RECIPIENT="0xcccccccccccccccccccccccccccccccccccccccc"
+
 #---------------- Only Modify below if you know what you are doing ----------------
 #----------------------------------------------------------------------------------
 
@@ -22,7 +24,7 @@ LODESTAR_IMAGE=chainsafe/lodestar:next
 
 LODESTAR_EXTRA_ARGS="--terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
-LODESTAR_VALIDATOR_ARGS="--network kiln $LODESTAR_VAL_FIXED_VARS"
+LODESTAR_VALIDATOR_ARGS="--network kiln $LODESTAR_VAL_FIXED_VARS --defaultFeeRecipient $FEE_RECIPIENT"
 
 NETHERMIND_EXTRA_ARGS="--config kiln  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/kiln.vars
+++ b/merge-scripts/kiln.vars
@@ -1,3 +1,15 @@
+# Uncomment the following if you want to start validator with deposit cli keystores
+# Keystores and the pass.txt will be picked from the current dir (mounted as /currentDir in container)
+
+# LODESTAR_VALIDATOR_SECRETS_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
+
+# Comment this if you want to start validators with deposit cli and uncommented above
+
+LODESTAR_VALIDATOR_SECRETS_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
+
+#---------------- Only Modify below if you know what you are doing ----------------
+#----------------------------------------------------------------------------------
+
 DEVNET_NAME=kiln
 CONFIG_GIT_DIR=kiln
 NETWORK_ID=1337802
@@ -14,7 +26,7 @@ LODESTAR_IMAGE=chainsafe/lodestar:next
 
 LODESTAR_EXTRA_ARGS="--terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
-LODESTAR_VALIDATOR_ARGS="--network ropsten --terminal-total-difficulty-override $MERGE_TTD --fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5 $LODESTAR_VAL_FIXED_VARS"
+LODESTAR_VALIDATOR_ARGS="--network kiln $LODESTAR_VAL_FIXED_VARS $LODESTAR_VALIDATOR_SECRETS_ARGS"
 
 NETHERMIND_EXTRA_ARGS="--config kiln  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/mainnet.vars
+++ b/merge-scripts/mainnet.vars
@@ -1,9 +1,9 @@
-# Start validator with deposit cli keystores
-# Keystores and the pass.txt will be picked from the current dir (mounted as /currentDir in container)
-# Running validatios via mnemonic is not safe (and not available) in mainnet
+LODESTAR_VALIDATOR_KEYSTORE_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
 
-LODESTAR_VALIDATOR_SECRETS_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
+LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
 
+# This will be available in /data/jwtsecret
+JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
 #---------------- Only Modify below if you know what you are doing ----------------
 #----------------------------------------------------------------------------------
@@ -14,8 +14,6 @@ NETWORK_ID=1
 # Merge TTD is placeholder with 2x current total difficulty
 MERGE_TTD=100000000000000000000000
 
-JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
-
 GETH_IMAGE=ethereum/client-go:latest
 NETHERMIND_IMAGE=nethermind/nethermind:latest
 ETHEREUMJS_IMAGE=g11tech/ethereumjs:kiln
@@ -25,7 +23,7 @@ LODESTAR_IMAGE=chainsafe/lodestar:next
 
 LODESTAR_EXTRA_ARGS="--network mainnet --terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
-LODESTAR_VALIDATOR_ARGS="--network mainnet $LODESTAR_VAL_FIXED_VARS $LODESTAR_VALIDATOR_SECRETS_ARGS"
+LODESTAR_VALIDATOR_ARGS="--network mainnet $LODESTAR_VAL_FIXED_VARS"
 
 NETHERMIND_EXTRA_ARGS="--config mainnet  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/mainnet.vars
+++ b/merge-scripts/mainnet.vars
@@ -5,6 +5,8 @@ LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb pla
 # This will be available in /data/jwtsecret
 JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
+FEE_RECIPIENT="0xcccccccccccccccccccccccccccccccccccccccc"
+
 #---------------- Only Modify below if you know what you are doing ----------------
 #----------------------------------------------------------------------------------
 
@@ -23,7 +25,7 @@ LODESTAR_IMAGE=chainsafe/lodestar:next
 
 LODESTAR_EXTRA_ARGS="--network mainnet --terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
-LODESTAR_VALIDATOR_ARGS="--network mainnet $LODESTAR_VAL_FIXED_VARS"
+LODESTAR_VALIDATOR_ARGS="--network mainnet $LODESTAR_VAL_FIXED_VARS --defaultFeeRecipient $FEE_RECIPIENT"
 
 NETHERMIND_EXTRA_ARGS="--config mainnet  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/mainnet.vars
+++ b/merge-scripts/mainnet.vars
@@ -1,3 +1,13 @@
+# Start validator with deposit cli keystores
+# Keystores and the pass.txt will be picked from the current dir (mounted as /currentDir in container)
+# Running validatios via mnemonic is not safe (and not available) in mainnet
+
+LODESTAR_VALIDATOR_SECRETS_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
+
+
+#---------------- Only Modify below if you know what you are doing ----------------
+#----------------------------------------------------------------------------------
+
 DEVNET_NAME=mainnet
 CONFIG_GIT_DIR=
 NETWORK_ID=1
@@ -15,7 +25,7 @@ LODESTAR_IMAGE=chainsafe/lodestar:next
 
 LODESTAR_EXTRA_ARGS="--network mainnet --terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
-LODESTAR_VALIDATOR_ARGS="--network mainnet --fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5 $LODESTAR_VAL_FIXED_VARS"
+LODESTAR_VALIDATOR_ARGS="--network mainnet $LODESTAR_VAL_FIXED_VARS $LODESTAR_VALIDATOR_SECRETS_ARGS"
 
 NETHERMIND_EXTRA_ARGS="--config mainnet  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/mainnetshadow-8.vars
+++ b/merge-scripts/mainnetshadow-8.vars
@@ -1,11 +1,9 @@
-# Uncomment the following if you want to start validator with deposit cli keystores
-# Keystores and the pass.txt will be picked from the current dir (mounted as /currentDir in container)
+LODESTAR_VALIDATOR_KEYSTORE_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
 
-# LODESTAR_VALIDATOR_SECRETS_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
+LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
 
-# Comment this if you want to start validators with deposit cli and uncommented above
-
-LODESTAR_VALIDATOR_SECRETS_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
+# This will be available in /data/jwtsecret
+JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
 #---------------- Only Modify below if you know what you are doing ----------------
 #----------------------------------------------------------------------------------
@@ -14,8 +12,6 @@ DEVNET_NAME=mainnet-shadow-fork-8
 CONFIG_GIT_DIR=mainnet-shadow-fork-8
 NETWORK_ID=1
 MERGE_TTD=53290823313153069154304
-
-JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
 GETH_IMAGE=ethereum/client-go:latest
 NETHERMIND_IMAGE=nethermind/nethermind:latest
@@ -30,7 +26,7 @@ LODESTAR_EXTRA_ARGS="--terminal-total-difficulty-override $MERGE_TTD $LODESTAR_F
 # allows menmonic for non mainnet vals, and there is no explicit mainnet shadow fork network.
 # However config.yaml will be picked to apply all the goerli shadow fork params
 
-LODESTAR_VALIDATOR_ARGS="--network kiln $LODESTAR_VAL_FIXED_VARS $LODESTAR_VALIDATOR_SECRETS_ARGS"
+LODESTAR_VALIDATOR_ARGS="--network kiln $LODESTAR_VAL_FIXED_VARS"
 
 NETHERMIND_EXTRA_ARGS="--config mainnet_shadowfork  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/mainnetshadow-8.vars
+++ b/merge-scripts/mainnetshadow-8.vars
@@ -5,6 +5,8 @@ LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb pla
 # This will be available in /data/jwtsecret
 JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
+FEE_RECIPIENT="0xcccccccccccccccccccccccccccccccccccccccc"
+
 #---------------- Only Modify below if you know what you are doing ----------------
 #----------------------------------------------------------------------------------
 
@@ -26,7 +28,7 @@ LODESTAR_EXTRA_ARGS="--terminal-total-difficulty-override $MERGE_TTD $LODESTAR_F
 # allows menmonic for non mainnet vals, and there is no explicit mainnet shadow fork network.
 # However config.yaml will be picked to apply all the goerli shadow fork params
 
-LODESTAR_VALIDATOR_ARGS="--network kiln $LODESTAR_VAL_FIXED_VARS"
+LODESTAR_VALIDATOR_ARGS="--network kiln $LODESTAR_VAL_FIXED_VARS --defaultFeeRecipient $FEE_RECIPIENT"
 
 NETHERMIND_EXTRA_ARGS="--config mainnet_shadowfork  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/mainnetshadow-8.vars
+++ b/merge-scripts/mainnetshadow-8.vars
@@ -1,3 +1,15 @@
+# Uncomment the following if you want to start validator with deposit cli keystores
+# Keystores and the pass.txt will be picked from the current dir (mounted as /currentDir in container)
+
+# LODESTAR_VALIDATOR_SECRETS_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
+
+# Comment this if you want to start validators with deposit cli and uncommented above
+
+LODESTAR_VALIDATOR_SECRETS_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
+
+#---------------- Only Modify below if you know what you are doing ----------------
+#----------------------------------------------------------------------------------
+
 DEVNET_NAME=mainnet-shadow-fork-8
 CONFIG_GIT_DIR=mainnet-shadow-fork-8
 NETWORK_ID=1
@@ -14,7 +26,11 @@ LODESTAR_IMAGE=chainsafe/lodestar:next
 
 LODESTAR_EXTRA_ARGS="--terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
-LODESTAR_VALIDATOR_ARGS="--network ropsten --fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5 $LODESTAR_VAL_FIXED_VARS"
+# We are using network kiln here but this is just a hack to use mnemonic as lodestar only
+# allows menmonic for non mainnet vals, and there is no explicit mainnet shadow fork network.
+# However config.yaml will be picked to apply all the goerli shadow fork params
+
+LODESTAR_VALIDATOR_ARGS="--network kiln $LODESTAR_VAL_FIXED_VARS $LODESTAR_VALIDATOR_SECRETS_ARGS"
 
 NETHERMIND_EXTRA_ARGS="--config mainnet_shadowfork  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/parse-args.sh
+++ b/merge-scripts/parse-args.sh
@@ -27,8 +27,12 @@ while [[ $# -gt 0 ]]; do
       dockerWithSudo=true
       shift # past argument
       ;;
-    --withValidator)
-      withValidator=true
+    --withValidatorMnemonic)
+      withValidatorMnemonic=true
+      shift # past argument
+      ;;
+    --withValidatorKeystore)
+      withValidatorKeystore=true
       shift # past argument
       ;;
     --justEL)
@@ -57,28 +61,18 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# key won't ever get assigned in while loop if there is no arg, in that case print usage
+if [[ ! -n "$key" ]];
+then
+  echo "usage: ./setup.sh --dataDir <data dir> --elClient <geth | nethermind | ethereumjs | besu> --devetVars <devnet vars file> [--dockerWithSudo --withTerminal \"gnome-terminal --disable-factory --\"]"
+  echo "example: ./setup.sh --dataDir kiln-data --elClient nethermind --devnetVars ./kiln.vars --dockerWithSudo --withTerminal \"gnome-terminal --disable-factory --\""
+  echo "Note: if running on macOS where gnome-terminal is not available, remove the gnome-terminal related flags."
+  echo "example: ./setup.sh --dataDir kiln-data --elClient geth --devnetVars ./kiln.vars"
+  exit;
+fi;
+
 echo "elClient = $elClient"
 echo "dataDir = $dataDir"
 echo "devnetVars = $devnetVars"
 echo "withTerminal = $withTerminal"
 echo "dockerWithSudo = $dockerWithSudo"
-echo "withValidator = $withValidator"
-echo "detached = $detached"
-
-if [ -n "$withTerminal" ] && [ -n "$detached" ]
-then
-  echo "Only of of --withTerminal or --detached options should be provided, exiting..."
-  exit;
-fi
-
-if [ -n "$withValidator" ] && ( [ -n "$justEL" ] || [ -n "$justEL" ] || [ -n "$justEL" ] )
-then
-  echo "--withValidator can not be just with --justEL or --justCL or --justVC. Try using only --justVC."
-  exit;
-fi;
-
-if [ -n "$justEL" ] && ( [ -n "$justCL" ] || [ -n "$justVC" ]  ) || [ -n "$justCL" ] && ( [ -n "$justEL" ] || [ -n "$justVC" ]  ) || [ -n "$justVC" ] && ( [ -n "$justEL" ] || [ -n "$justCL" ]  )
-then
-  echo "only one of --justEL, --justCL or --justVC can be used at a time. You can however start another (parallel) run(s) to spin them up separately."
-  exit;
-fi

--- a/merge-scripts/ropsten.vars
+++ b/merge-scripts/ropsten.vars
@@ -5,6 +5,8 @@ LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb pla
 # This will be available in /data/jwtsecret
 JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
+FEE_RECIPIENT="0xcccccccccccccccccccccccccccccccccccccccc"
+
 #---------------- Only Modify below if you know what you are doing ----------------
 #----------------------------------------------------------------------------------
 
@@ -25,7 +27,7 @@ LODESTAR_IMAGE=chainsafe/lodestar:next
 
 LODESTAR_EXTRA_ARGS="--network ropsten --terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
-LODESTAR_VALIDATOR_ARGS="--network ropsten $LODESTAR_VAL_FIXED_VARS"
+LODESTAR_VALIDATOR_ARGS="--network ropsten $LODESTAR_VAL_FIXED_VARS --defaultFeeRecipient $FEE_RECIPIENT"
 
 NETHERMIND_EXTRA_ARGS="--config ropsten  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/ropsten.vars
+++ b/merge-scripts/ropsten.vars
@@ -1,3 +1,15 @@
+# Uncomment the following if you want to start validator with deposit cli keystores
+# Keystores and the pass.txt will be picked from the current dir (mounted as /currentDir in container)
+
+# LODESTAR_VALIDATOR_SECRETS_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
+
+# Comment this if you want to start validators with deposit cli and uncommented above
+
+LODESTAR_VALIDATOR_SECRETS_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
+
+#---------------- Only Modify below if you know what you are doing ----------------
+#----------------------------------------------------------------------------------
+
 DEVNET_NAME=ropsten
 # Empty config git dir will be assumed to be clients having bakedin configs
 CONFIG_GIT_DIR=
@@ -16,7 +28,7 @@ LODESTAR_IMAGE=chainsafe/lodestar:next
 
 LODESTAR_EXTRA_ARGS="--network ropsten --terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
-LODESTAR_VALIDATOR_ARGS="--network ropsten --terminal-total-difficulty-override $MERGE_TTD --fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5 $LODESTAR_VAL_FIXED_VARS"
+LODESTAR_VALIDATOR_ARGS="--network ropsten $LODESTAR_VAL_FIXED_VARS $LODESTAR_VALIDATOR_SECRETS_ARGS"
 
 NETHERMIND_EXTRA_ARGS="--config ropsten  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/ropsten.vars
+++ b/merge-scripts/ropsten.vars
@@ -1,11 +1,9 @@
-# Uncomment the following if you want to start validator with deposit cli keystores
-# Keystores and the pass.txt will be picked from the current dir (mounted as /currentDir in container)
+LODESTAR_VALIDATOR_KEYSTORE_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
 
-# LODESTAR_VALIDATOR_SECRETS_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
+LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
 
-# Comment this if you want to start validators with deposit cli and uncommented above
-
-LODESTAR_VALIDATOR_SECRETS_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
+# This will be available in /data/jwtsecret
+JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
 #---------------- Only Modify below if you know what you are doing ----------------
 #----------------------------------------------------------------------------------
@@ -17,7 +15,6 @@ NETWORK_ID=3
 MERGE_TTD=50000000000000000
 
 # This will be available in /data/jwtsecret
-JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
 GETH_IMAGE=ethereum/client-go:latest
 NETHERMIND_IMAGE=nethermind/nethermind:latest
@@ -28,7 +25,7 @@ LODESTAR_IMAGE=chainsafe/lodestar:next
 
 LODESTAR_EXTRA_ARGS="--network ropsten --terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
-LODESTAR_VALIDATOR_ARGS="--network ropsten $LODESTAR_VAL_FIXED_VARS $LODESTAR_VALIDATOR_SECRETS_ARGS"
+LODESTAR_VALIDATOR_ARGS="--network ropsten $LODESTAR_VAL_FIXED_VARS"
 
 NETHERMIND_EXTRA_ARGS="--config ropsten  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/sepolia.vars
+++ b/merge-scripts/sepolia.vars
@@ -1,11 +1,9 @@
-# Uncomment the following if you want to start validator with deposit cli keystores
-# Keystores and the pass.txt will be picked from the current dir (mounted as /currentDir in container)
+LODESTAR_VALIDATOR_KEYSTORE_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
 
-# LODESTAR_VALIDATOR_SECRETS_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
+LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
 
-# Comment this if you want to start validators with deposit cli and uncommented above
-
-LODESTAR_VALIDATOR_SECRETS_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
+# This will be available in /data/jwtsecret
+JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
 #---------------- Only Modify below if you know what you are doing ----------------
 #----------------------------------------------------------------------------------
@@ -14,9 +12,6 @@ DEVNET_NAME=sepolia
 CONFIG_GIT_DIR=
 NETWORK_ID=11155111
 MERGE_TTD=17000000000000000
-
-# This will be available in /data/jwtsecret
-JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
 GETH_IMAGE=ethereum/client-go:latest
 NETHERMIND_IMAGE=nethermind/nethermind:latest
@@ -27,7 +22,7 @@ LODESTAR_IMAGE=chainsafe/lodestar:next
 
 LODESTAR_EXTRA_ARGS="--network sepolia --terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
-LODESTAR_VALIDATOR_ARGS="--network sepolia $LODESTAR_VAL_FIXED_VARS $LODESTAR_VALIDATOR_SECRETS_ARGS"
+LODESTAR_VALIDATOR_ARGS="--network sepolia $LODESTAR_VAL_FIXED_VARS"
 
 NETHERMIND_EXTRA_ARGS="--config sepolia  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/sepolia.vars
+++ b/merge-scripts/sepolia.vars
@@ -1,3 +1,14 @@
+# Uncomment the following if you want to start validator with deposit cli keystores
+# Keystores and the pass.txt will be picked from the current dir (mounted as /currentDir in container)
+
+# LODESTAR_VALIDATOR_SECRETS_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
+
+# Comment this if you want to start validators with deposit cli and uncommented above
+
+LODESTAR_VALIDATOR_SECRETS_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
+
+#---------------- Only Modify below if you know what you are doing ----------------
+#----------------------------------------------------------------------------------
 DEVNET_NAME=sepolia
 # Empty config git dir will be assumed to be clients having bakedin configs
 CONFIG_GIT_DIR=
@@ -16,7 +27,7 @@ LODESTAR_IMAGE=chainsafe/lodestar:next
 
 LODESTAR_EXTRA_ARGS="--network sepolia --terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
-LODESTAR_VALIDATOR_ARGS="--network sepolia --terminal-total-difficulty-override $MERGE_TTD --fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5 $LODESTAR_VAL_FIXED_VARS"
+LODESTAR_VALIDATOR_ARGS="--network sepolia $LODESTAR_VAL_FIXED_VARS $LODESTAR_VALIDATOR_SECRETS_ARGS"
 
 NETHERMIND_EXTRA_ARGS="--config sepolia  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/sepolia.vars
+++ b/merge-scripts/sepolia.vars
@@ -5,6 +5,8 @@ LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb pla
 # This will be available in /data/jwtsecret
 JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
 
+FEE_RECIPIENT="0xcccccccccccccccccccccccccccccccccccccccc"
+
 #---------------- Only Modify below if you know what you are doing ----------------
 #----------------------------------------------------------------------------------
 DEVNET_NAME=sepolia
@@ -22,7 +24,7 @@ LODESTAR_IMAGE=chainsafe/lodestar:next
 
 LODESTAR_EXTRA_ARGS="--network sepolia --terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
 
-LODESTAR_VALIDATOR_ARGS="--network sepolia $LODESTAR_VAL_FIXED_VARS"
+LODESTAR_VALIDATOR_ARGS="--network sepolia $LODESTAR_VAL_FIXED_VARS --defaultFeeRecipient $FEE_RECIPIENT"
 
 NETHERMIND_EXTRA_ARGS="--config sepolia  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
 

--- a/merge-scripts/setup.sh
+++ b/merge-scripts/setup.sh
@@ -215,7 +215,8 @@ fi;
 clCmd="$clCmd $LODESTAR_EXTRA_ARGS"
 
 valName="$DEVNET_NAME-validator"
-valCmd="$dockerCmd --name $valName $clDockerNetwork -v $currentDir/$dataDir:/data"
+# we are additionally mounting current dir to /currentDir if anyone wants to provide keystores
+valCmd="$dockerCmd --name $valName $clDockerNetwork -v $currentDir:/currentDir -v $currentDir/$dataDir:/data"
 # mount and use config
 if [ -n "$configGitDir" ]
 then

--- a/merge-scripts/setup.sh
+++ b/merge-scripts/setup.sh
@@ -3,7 +3,13 @@
 
 source parse-args.sh
 source "./fixed.vars"
+if [ ! -n "$devnetVars" ] 
+then
+  echo "You need to specify the corresponding network.vars file, for e.g. kiln.vars, exiting ..."
+  exit;
+fi;
 source $devnetVars
+source validate.sh
 
 currentDir=$(pwd)
 setupConfigUrl=https://github.com/eth-clients/merge-testnets.git
@@ -12,15 +18,6 @@ configGitDir=$CONFIG_GIT_DIR
 
 gethImage=$GETH_IMAGE
 nethermindImage=$NETHERMIND_IMAGE
-
-if [ ! -n "$dataDir" ] || [ ! -n "$devnetVars" ] || ([ "$elClient" != "geth" ] && [ "$elClient" != "nethermind" ] && [ "$elClient" != "ethereumjs" ] && [ "$elClient" != "besu" ]) 
-then
-  echo "usage: ./setup.sh --dataDir <data dir> --elClient <geth | nethermind | ethereumjs | besu> --devetVars <devnet vars file> [--dockerWithSudo --withTerminal \"gnome-terminal --disable-factory --\"]"
-  echo "example: ./setup.sh --dataDir kiln-data --elClient nethermind --devnetVars ./kiln.vars --dockerWithSudo --withTerminal \"gnome-terminal --disable-factory --\""
-  echo "Note: if running on macOS where gnome-terminal is not available, remove the gnome-terminal related flags."
-  echo "example: ./setup.sh --dataDir kiln-data --elClient geth --devnetVars ./kiln.vars"
-  exit;
-fi
 
 
 mkdir $dataDir && mkdir $dataDir/lodestar && mkdir $dataDir/geth && mkdir $dataDir/nethermind && mkdir $dataDir/ethereumjs && mkdir $dataDir/besu
@@ -224,7 +221,7 @@ then
 else
   valCmd="$valCmd $LODESTAR_IMAGE validator"
 fi;
-valCmd="$valCmd $LODESTAR_VALIDATOR_ARGS"
+valCmd="$valCmd $LODESTAR_VALIDATOR_ARGS $validatorKeyArgs"
 
 echo -n $JWT_SECRET > $dataDir/jwtsecret
 terminalInfo=""

--- a/merge-scripts/validate.sh
+++ b/merge-scripts/validate.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+if [ -n "$withValidatorMnemonic" ] && [ -n "$withValidatorKeystore" ]
+then
+  echo "Only of of --withValidatorMnemonic or --withValidatorKeystore options should be provided, exiting..."
+  exit;
+fi
+if [ -n "$withValidatorMnemonic" ]
+then
+  withValidator="withValidatorMnemonic";
+  validatorKeyArgs="$LODESTAR_VALIDATOR_MNEMONIC_ARGS"
+  if [ ! -n "$validatorKeyArgs" ]
+  then
+    echo "To run validator with mnemonic, you need to set LODESTAR_VALIDATOR_MNEMONIC_ARGS"
+    exit;
+  fi;
+fi;
+
+if [ -n "$withValidatorKeystore" ]
+then
+  withValidator="withValidatorKeystore";
+  validatorKeyArgs="$LODESTAR_VALIDATOR_KEYSTORE_ARGS"
+  if [ ! -n "$validatorKeyArgs" ]
+  then
+    echo "To run validator with keystores, you need to set LODESTAR_VALIDATOR_KEYSTORE_ARGS"
+    exit;
+  fi;
+fi;
+
+if [ -n "$justVC" ] && [ ! -n "$withValidator" ]
+then
+  echo "To run validator, you need to provide either one of --withValidatorMnemonic or --withValidatorKeystore, exiting..."
+  exit;
+fi;
+
+echo "withValidator = $withValidator, $validatorKeyArgs"
+echo "detached = $detached"
+
+if [ -n "$withTerminal" ] && [ -n "$detached" ]
+then
+  echo "Only of of --withTerminal or --detached options should be provided, exiting..."
+  exit;
+fi
+
+if [ -n "$withValidator" ] && ( [ -n "$justEL" ] || [ -n "$justEL" ] || [ -n "$justEL" ] )
+then
+  echo "--withValidator can not be just with --justEL or --justCL or --justVC. Try using only --justVC."
+  exit;
+fi;
+
+if [ -n "$justEL" ] && ( [ -n "$justCL" ] || [ -n "$justVC" ]  ) || [ -n "$justCL" ] && ( [ -n "$justEL" ] || [ -n "$justVC" ]  ) || [ -n "$justVC" ] && ( [ -n "$justEL" ] || [ -n "$justCL" ]  )
+then
+  echo "only one of --justEL, --justCL or --justVC can be used at a time. You can however start another (parallel) run(s) to spin them up separately."
+  exit;
+fi
+
+if [ ! -n "$dataDir" ]
+then
+  echo "Please provide a data directory. If you are running fresh, the dataDir should be non existant for setup to configure it properly, exiting...";
+  exit;
+fi;
+
+
+if [ -n "$justCL" ] && [ -n "$justVC" ]  && ([ "$elClient" != "geth" ] && [ "$elClient" != "nethermind" ] && [ "$elClient" != "ethereumjs" ] && [ "$elClient" != "besu" ]) 
+then
+  echo "To run EL client you need to provide one of --elClient <geth | nethermind | ethereumjs | besu>, exiting ...";
+  exit;
+fi
+
+if [ ! -n "$JWT_SECRET" ]
+then
+  echo "You need to provide a file containing 32 bytes JWT_SECRET in hex format, exiting ..."
+  exit;
+fi;


### PR DESCRIPTION
**Motivation**
Currently in our merge scripts we only support mnemonic for validator key/secret derivation.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR provides the ability to run validator via importing the deposit cli keystores

cc: @philknows (Please test out and approve if this works)