### PR TITLE
Set @chainsafe/flare dependencies to correct version (unstable)

### DIFF
--- a/packages/flare/package.json
+++ b/packages/flare/package.json
@@ -60,10 +60,10 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/lodestar-api": "^0.38.1",
-    "@chainsafe/lodestar-beacon-state-transition": "^0.38.1",
-    "@chainsafe/lodestar-config": "^0.38.1",
-    "@chainsafe/lodestar-types": "^0.38.1",
+    "@chainsafe/lodestar-api": "^0.39.0",
+    "@chainsafe/lodestar-beacon-state-transition": "^0.39.0",
+    "@chainsafe/lodestar-config": "^0.39.0",
+    "@chainsafe/lodestar-types": "^0.39.0",
     "source-map-support": "^0.5.19",
     "yargs": "^16.1.0"
   },


### PR DESCRIPTION
**Motivation**

@chainsafe/flare dependencies are not at the monorepo version. Not sure why this is still happening.

**Description**

Set @chainsafe/flare dependencies to correct version.