### PR TITLE
Remove keymanager-server dep from cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,7 +61,6 @@
     "@chainsafe/lodestar-beacon-state-transition": "^0.39.0",
     "@chainsafe/lodestar-config": "^0.39.0",
     "@chainsafe/lodestar-db": "^0.39.0",
-    "@chainsafe/lodestar-keymanager-server": "^0.39.0",
     "@chainsafe/lodestar-light-client": "^0.39.0",
     "@chainsafe/lodestar-params": "^0.39.0",
     "@chainsafe/lodestar-types": "^0.39.0",


### PR DESCRIPTION
**Motivation**

This dependency was introduced back when merging stable into unstable here https://github.com/ChainSafe/lodestar/commit/138225fed450b623ffce8131b96c51807733a481

**Description**

Remove keymanager-server dep from cli