### PR TITLE
Fetch weakSubjectivityState timeout

### DIFF
--- a/packages/api/src/beacon/client/debug.ts
+++ b/packages/api/src/beacon/client/debug.ts
@@ -2,8 +2,8 @@ import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {Api, ReqTypes, routesData, getReqSerializers, getReturnTypes, StateFormat} from "../routes/debug.js";
 import {IHttpClient, getFetchOptsSerializers, generateGenericJsonClient} from "../../utils/client/index.js";
 
-// As Jul 2022, it takes up to 3 minutes to download states
-const GET_STATE_TIMEOUT_MS = 3 * 60 * 1000;
+// As Jul 2022, it takes up to 3 mins to download states so make this 5 mins for reservation
+const GET_STATE_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
  * REST HTTP client for debug routes

--- a/packages/api/src/beacon/client/debug.ts
+++ b/packages/api/src/beacon/client/debug.ts
@@ -2,6 +2,9 @@ import {IChainForkConfig} from "@chainsafe/lodestar-config";
 import {Api, ReqTypes, routesData, getReqSerializers, getReturnTypes, StateFormat} from "../routes/debug.js";
 import {IHttpClient, getFetchOptsSerializers, generateGenericJsonClient} from "../../utils/client/index.js";
 
+// As Jul 2022, it takes up to 3 minutes to download states
+const GET_STATE_TIMEOUT_MS = 3 * 60 * 1000;
+
 /**
  * REST HTTP client for debug routes
  */
@@ -18,7 +21,10 @@ export function getClient(_config: IChainForkConfig, httpClient: IHttpClient): A
 
     async getState(stateId: string, format?: StateFormat) {
       if (format === "ssz") {
-        const buffer = await httpClient.arrayBuffer(fetchOptsSerializers.getState(stateId, format));
+        const buffer = await httpClient.arrayBuffer({
+          ...fetchOptsSerializers.getState(stateId, format),
+          timeoutMs: GET_STATE_TIMEOUT_MS,
+        });
         // Casting to any otherwise Typescript doesn't like the multi-type return
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
         return new Uint8Array(buffer) as any;
@@ -28,7 +34,10 @@ export function getClient(_config: IChainForkConfig, httpClient: IHttpClient): A
     },
     async getStateV2(stateId: string, format?: StateFormat) {
       if (format === "ssz") {
-        const buffer = await httpClient.arrayBuffer(fetchOptsSerializers.getStateV2(stateId, format));
+        const buffer = await httpClient.arrayBuffer({
+          ...fetchOptsSerializers.getStateV2(stateId, format),
+          timeoutMs: GET_STATE_TIMEOUT_MS,
+        });
         // Casting to any otherwise Typescript doesn't like the multi-type return
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
         return new Uint8Array(buffer) as any;

--- a/packages/api/src/utils/client/httpClient.ts
+++ b/packages/api/src/utils/client/httpClient.ts
@@ -23,6 +23,7 @@ export type FetchOpts = {
   headers?: ReqGeneric["headers"];
   /** Optional, for metrics */
   routeId?: string;
+  timeoutMs?: number;
 };
 
 export interface IHttpClient {
@@ -85,7 +86,7 @@ export class HttpClient implements IHttpClient {
   private async requestWithBody<T>(opts: FetchOpts, getBody: (res: Response) => Promise<T>): Promise<T> {
     // Implement fetch timeout
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    const timeout = setTimeout(() => controller.abort(), opts.timeoutMs ?? this.timeoutMs);
 
     // Attach global signal to this request's controller
     const onGlobalSignalAbort = controller.abort.bind(controller);

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -150,7 +150,7 @@ async function initFromWSState(
       throw e;
     }
 
-    const {wsState, wsCheckpoint} = await fetchWeakSubjectivityState(chainForkConfig, wssOpts);
+    const {wsState, wsCheckpoint} = await fetchWeakSubjectivityState(chainForkConfig, logger, wssOpts);
     const config = createIBeaconConfig(chainForkConfig, wsState.genesisValidatorsRoot);
     const store = lastDbState ?? wsState;
     return initAndVerifyWeakSubjectivityState(config, db, logger, store, wsState, wsCheckpoint);

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -185,8 +185,6 @@ export async function fetchWeakSubjectivityState(
       wsCheckpoint = finalized;
     }
     const stateSlot = wsCheckpoint.epoch * SLOTS_PER_EPOCH;
-    // TODO: timeout param for api? or only increase timeout for getState
-    // const timeout = 3 * 60 * 1000;
     const getStatePromise =
       config.getForkName(stateSlot) === ForkName.phase0
         ? api.debug.getState(`${stateSlot}`, "ssz")

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -198,6 +198,8 @@ export async function fetchWeakSubjectivityState(
       GET_STATE_LOG_INTERVAL
     );
 
+    logger.info("Download completed");
+
     return {wsState: getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes), wsCheckpoint};
   } catch (e) {
     throw new Error(

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -33,6 +33,9 @@ export type WeakSubjectivityFetchOptions = {
   weakSubjectivityCheckpoint?: string;
 };
 
+// log to screen every 30s when downloading state from a lodestar node
+const GET_STATE_LOG_INTERVAL = 30 * 1000;
+
 function getNetworkData(
   network: NetworkName
 ): {
@@ -192,7 +195,7 @@ export async function fetchWeakSubjectivityState(
     const stateBytes = await callFnWhenAwait(
       getStatePromise,
       () => logger.info("Download in progress, please wait ..."),
-      30 * 1000
+      GET_STATE_LOG_INTERVAL
     );
 
     return {wsState: getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes), wsCheckpoint};

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -200,7 +200,11 @@ export async function fetchWeakSubjectivityState(
 
     return {wsState: getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes), wsCheckpoint};
   } catch (e) {
-    throw new Error("Unable to fetch weak subjectivity state: " + (e as Error).message);
+    throw new Error(
+      "Unable to fetch weak subjectivity state: " +
+        (e as Error).message +
+        ". Consider downloading the state manually using debug api and use --weakSubjectivityStateFile option."
+    );
   }
 }
 

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -192,7 +192,7 @@ export async function fetchWeakSubjectivityState(
 
     const stateBytes = await callFnWhenAwait(
       getStatePromise,
-      () => logger.info("Download in progress, please wait ..."),
+      () => logger.info("Download in progress, please wait..."),
       GET_STATE_LOG_INTERVAL
     );
 
@@ -203,7 +203,7 @@ export async function fetchWeakSubjectivityState(
     throw new Error(
       "Unable to fetch weak subjectivity state: " +
         (e as Error).message +
-        ". Consider downloading the state manually using debug api and use --weakSubjectivityStateFile option."
+        ". Consider downloading a state manually and using the --weakSubjectivityStateFile option."
     );
   }
 }

--- a/packages/lodestar/test/e2e/sync/wss.test.ts
+++ b/packages/lodestar/test/e2e/sync/wss.test.ts
@@ -91,7 +91,7 @@ describe("Start from WSS", function () {
 
     const weakSubjectivityServerUrl = "http://127.0.0.1:19596";
     loggerNodeB.important("Fetching weak subjectivity state ", {weakSubjectivityServerUrl});
-    const {wsState, wsCheckpoint} = await fetchWeakSubjectivityState(config, {weakSubjectivityServerUrl});
+    const {wsState, wsCheckpoint} = await fetchWeakSubjectivityState(config, loggerNodeB, {weakSubjectivityServerUrl});
     loggerNodeB.important("Fetched wss state");
 
     const bnStartingFromWSS = await getDevBeaconNode({

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -13,3 +13,4 @@ export * from "./sort.js";
 export * from "./timeout.js";
 export {RecursivePartial, bnToNum} from "./types.js";
 export * from "./verifyMerkleBranch.js";
+export * from "./promise.js";

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -12,13 +12,13 @@ export async function callFnWhenAwait<T>(
   const logFn = async (): Promise<undefined> => {
     while (t === undefined) {
       await sleep(interval);
-      fn();
+      if (t === undefined) fn();
     }
     return undefined;
   };
 
   t = await Promise.race([p, logFn()]);
-  // should not happen
+  // should not happen since p doesn not resolve to undefined
   if (t === undefined) {
     throw new Error("Unexpected error: Timeout");
   }

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -1,0 +1,26 @@
+import {sleep} from "./sleep.js";
+
+/**
+ * While promise t is not finished, call function `fn` per `interval`
+ */
+export async function callFnWhenAwait<T>(
+  p: Promise<NonNullable<T>>,
+  fn: () => void,
+  interval: number
+): Promise<NonNullable<T>> {
+  let t: NonNullable<T> | undefined = undefined;
+  const logFn = async (): Promise<undefined> => {
+    while (t === undefined) {
+      await sleep(interval);
+      fn();
+    }
+    return undefined;
+  };
+
+  t = await Promise.race([p, logFn()]);
+  // should not happen
+  if (t === undefined) {
+    throw new Error("Unexpected error: Timeout");
+  }
+  return t;
+}

--- a/packages/utils/test/unit/promise.test.ts
+++ b/packages/utils/test/unit/promise.test.ts
@@ -1,0 +1,34 @@
+import {expect} from "chai";
+import sinon from "sinon";
+import {callFnWhenAwait} from "../../src/promise.js";
+
+describe("callFnWhenAwait util", function () {
+  const sandbox = sinon.createSandbox();
+  beforeEach(() => {
+    sandbox.useFakeTimers();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should call function while awaing for promise", async () => {
+    const p = new Promise<string>((resolve) => setTimeout(() => resolve("done"), 5 * 1000));
+    const stub = sandbox.stub();
+    const result = await Promise.all([callFnWhenAwait(p, stub, 2 * 1000), sandbox.clock.tickAsync(5000)]);
+    expect(result[0]).to.be.equal("done");
+    expect(stub.calledTwice).to.be.true;
+  });
+
+  it("should throw error", async () => {
+    const stub = sandbox.stub();
+    const p = new Promise<string>((_, reject) => setTimeout(() => reject(new Error("done")), 5 * 1000));
+    try {
+      await Promise.all([callFnWhenAwait(p, stub, 2 * 1000), sandbox.clock.tickAsync(5000)]);
+      expect.fail("should throw error here");
+    } catch (e) {
+      expect((e as Error).message).to.be.equal("done");
+      expect(stub.calledTwice).to.be.true;
+    }
+  });
+});

--- a/packages/utils/test/unit/promise.test.ts
+++ b/packages/utils/test/unit/promise.test.ts
@@ -18,6 +18,8 @@ describe("callFnWhenAwait util", function () {
     const result = await Promise.all([callFnWhenAwait(p, stub, 2 * 1000), sandbox.clock.tickAsync(5000)]);
     expect(result[0]).to.be.equal("done");
     expect(stub.calledTwice).to.be.true;
+    await sandbox.clock.tickAsync(5000);
+    expect(stub.calledTwice).to.be.true;
   });
 
   it("should throw error", async () => {


### PR DESCRIPTION
**Motivation**

It may take up to 3m to download a weaksubjectivity state, see https://github.com/ChainSafe/lodestar/issues/4190#issuecomment-1173486780

**Description**

+ Extend timeout for `getState()` client api to 3m
+ Periodically log "Download in progress" per 30s
+ Add "Download completed" log
+ If it fails to download, instruct user to download the state manually in the error message

Closes #4190

**Test**

```
Jul-05 15:22:42.543[]                 info: Fetching weak subjectivity state weakSubjectivityServerUrl=https://eth2-beacon-prater.infura.io

Jul-05 15:23:13.695[]                 info: Download in progress, please wait ...
Jul-05 15:23:43.696[]                 info: Download in progress, please wait ...
Jul-05 15:23:49.662[]                 info: Download completed

Jul-05 15:23:58.612[]                 info: Initializing beacon state from anchor state slot=3375040, epoch=105470, stateRoot=0x2e6950f96e6adbbdb227dbcf4224d7d11df2c846a43e04971c3a08bc30c9a4e8
```