### PR TITLE
Added typeVersions and also exported a needed type

### DIFF
--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -25,6 +25,15 @@
     }
   },
   "types": "./lib/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "*",
+        "lib/*",
+        "lib/*/index"
+      ]
+    }
+  },
   "files": [
     "lib/**/*.d.ts",
     "lib/**/*.js",

--- a/packages/light-client/src/index.ts
+++ b/packages/light-client/src/index.ts
@@ -24,8 +24,9 @@ import {GenesisData} from "./networks.js";
 import {getLcLoggerConsole, ILcLogger} from "./utils/logger.js";
 import {computeSyncPeriodAtEpoch, computeSyncPeriodAtSlot, computeEpochAtSlot} from "./utils/clock.js";
 
-// Re-export event types
+// Re-export types
 export {LightclientEvent} from "./events.js";
+export {SyncCommitteeFast} from "./types.js";
 
 export type LightclientInitArgs = {
   config: IChainForkConfig;


### PR DESCRIPTION
**Motivation**

Importing using the subpath leads to compile errors. For example as seen [here](https://github.com/ChainSafe/eth2-light-client-demo/runs/7186999427?check_suite_focus=true) 

.The error is probably due to the `typeVersions` being missing.

**Description**

Adding missing `typeVersions`