### PR TITLE
Add logs to slashing protection import/export for better UX

### DIFF
--- a/packages/cli/src/cmds/validator/slashingProtection/export.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/export.ts
@@ -2,8 +2,12 @@ import {InterchangeFormatVersion} from "@lodestar/validator";
 import {ICliCommand, writeFile} from "../../../util/index.js";
 import {IGlobalArgs} from "../../../options/index.js";
 import {AccountValidatorArgs} from "../options.js";
-import {ISlashingProtectionArgs} from "./options.js";
+import {getCliLogger, ILogArgs} from "../../../util/index.js";
+import {getBeaconConfigFromArgs} from "../../../config/index.js";
+import {getBeaconPaths} from "../../beacon/paths.js";
+import {getValidatorPaths} from "../paths.js";
 import {getGenesisValidatorsRoot, getSlashingProtection} from "./utils.js";
+import {ISlashingProtectionArgs} from "./options.js";
 
 /* eslint-disable no-console */
 
@@ -11,7 +15,10 @@ interface IExportArgs {
   file: string;
 }
 
-export const exportCmd: ICliCommand<IExportArgs, ISlashingProtectionArgs & AccountValidatorArgs & IGlobalArgs> = {
+export const exportCmd: ICliCommand<
+  IExportArgs,
+  ISlashingProtectionArgs & AccountValidatorArgs & IGlobalArgs & ILogArgs
+> = {
   command: "export",
 
   describe: "Export an interchange file.",
@@ -32,16 +39,32 @@ export const exportCmd: ICliCommand<IExportArgs, ISlashingProtectionArgs & Accou
   },
 
   handler: async (args) => {
-    const genesisValidatorsRoot = await getGenesisValidatorsRoot(args);
-    const slashingProtection = getSlashingProtection(args);
+    const beaconPaths = getBeaconPaths(args);
+    const config = getBeaconConfigFromArgs(args);
+    const logger = getCliLogger(args, beaconPaths, config);
+
+    const {validatorsDbDir: dbPath} = getValidatorPaths(args);
 
     // TODO: Allow format version and pubkeys to be customized with CLI args
     const formatVersion: InterchangeFormatVersion = {version: "4", format: "complete"};
+    logger.info("Exporting the slashing protection logs", {...formatVersion, dbPath});
+
+    const genesisValidatorsRoot = await getGenesisValidatorsRoot(args);
+    const slashingProtection = getSlashingProtection(args);
+
+    logger.verbose("Fetching the pubkeys from the slashingProtection db");
     const pubkeys = await slashingProtection.listPubkeys();
 
-    const interchange = await slashingProtection.exportInterchange(genesisValidatorsRoot, pubkeys, formatVersion);
-    writeFile(args.file, interchange);
+    logger.info("Starting export for pubkeys found", {pubkeys: pubkeys.length});
+    const interchange = await slashingProtection.exportInterchange(
+      genesisValidatorsRoot,
+      pubkeys,
+      formatVersion,
+      logger
+    );
 
-    console.log("Export completed successfully");
+    logger.info("Writing the slashing protection logs", {file: args.file});
+    writeFile(args.file, interchange);
+    logger.verbose("Export completed successfully");
   },
 };

--- a/packages/cli/src/cmds/validator/slashingProtection/import.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/import.ts
@@ -3,8 +3,12 @@ import {Interchange} from "@lodestar/validator";
 import {ICliCommand} from "../../../util/index.js";
 import {IGlobalArgs} from "../../../options/index.js";
 import {AccountValidatorArgs} from "../options.js";
-import {ISlashingProtectionArgs} from "./options.js";
+import {getCliLogger, ILogArgs} from "../../../util/index.js";
+import {getBeaconConfigFromArgs} from "../../../config/index.js";
+import {getBeaconPaths} from "../../beacon/paths.js";
+import {getValidatorPaths} from "../paths.js";
 import {getGenesisValidatorsRoot, getSlashingProtection} from "./utils.js";
+import {ISlashingProtectionArgs} from "./options.js";
 
 /* eslint-disable no-console */
 
@@ -12,7 +16,10 @@ interface IImportArgs {
   file: string;
 }
 
-export const importCmd: ICliCommand<IImportArgs, ISlashingProtectionArgs & AccountValidatorArgs & IGlobalArgs> = {
+export const importCmd: ICliCommand<
+  IImportArgs,
+  ISlashingProtectionArgs & AccountValidatorArgs & IGlobalArgs & ILogArgs
+> = {
   command: "import",
 
   describe: "Import an interchange file.",
@@ -33,13 +40,20 @@ export const importCmd: ICliCommand<IImportArgs, ISlashingProtectionArgs & Accou
   },
 
   handler: async (args) => {
+    const beaconPaths = getBeaconPaths(args);
+    const config = getBeaconConfigFromArgs(args);
+    const logger = getCliLogger(args, beaconPaths, config);
+
+    const {validatorsDbDir: dbPath} = getValidatorPaths(args);
+
+    logger.info("Importing the slashing protection logs", {dbPath});
     const genesisValidatorsRoot = await getGenesisValidatorsRoot(args);
     const slashingProtection = getSlashingProtection(args);
 
+    logger.verbose("Reading the slashing protection logs", {file: args.file});
     const importFile = await fs.promises.readFile(args.file, "utf8");
     const importFileJson = JSON.parse(importFile) as Interchange;
-    await slashingProtection.importInterchange(importFileJson, genesisValidatorsRoot);
-
-    console.log("Import completed successfully");
+    await slashingProtection.importInterchange(importFileJson, genesisValidatorsRoot, logger);
+    logger.info("Import completed successfully");
   },
 };

--- a/packages/validator/src/slashingProtection/interface.ts
+++ b/packages/validator/src/slashingProtection/interface.ts
@@ -1,4 +1,5 @@
 import {BLSPubkey, Root} from "@lodestar/types";
+import {ILogger} from "@lodestar/utils";
 import {Interchange, InterchangeFormatVersion} from "./interchange/types.js";
 import {SlashingProtectionBlock, SlashingProtectionAttestation} from "./types.js";
 
@@ -12,10 +13,15 @@ export interface ISlashingProtection {
    */
   checkAndInsertAttestation(pubKey: BLSPubkey, attestation: SlashingProtectionAttestation): Promise<void>;
 
-  importInterchange(interchange: Interchange, genesisValidatorsRoot: Uint8Array | Root): Promise<void>;
+  importInterchange(
+    interchange: Interchange,
+    genesisValidatorsRoot: Uint8Array | Root,
+    logger?: ILogger
+  ): Promise<void>;
   exportInterchange(
     genesisValidatorsRoot: Uint8Array | Root,
     pubkeys: BLSPubkey[],
-    formatVersion: InterchangeFormatVersion
+    formatVersion: InterchangeFormatVersion,
+    logger?: ILogger
   ): Promise<Interchange>;
 }


### PR DESCRIPTION
**Motivation**
The slashing protection import/export could take a long time with user wondering if lodestar got stuck.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR adds better logging to the import/export via winston logger.

eg (validator pubkeys here are for kiln testnet)
### Import
```typescript
./lodestar  validator  slashing-protection import --network kiln  --rootDir /root/kiln-data/lodestar/vals495-499  --file /root/kiln-data/lodestar/spexport.json --logLevel debug
Jul-07 12:56:18.416[]                 info: Importing the slashing protection logs dbPath=/root/kiln-data/lodestar/vals495-499/validator-db
Jul-07 12:56:18.519[]              verbose: Reading the slashing protection logs file=/root/kiln-data/lodestar/spexport.json
Jul-07 12:56:19.725[]                 info: Importing logs for Validator 0x828ee58143149640384f4ddeb7fe5baa8a311ed62aa453c17c13d0c48183a36e7e74b5e26859e029705b284ff390c2bc
Jul-07 12:56:26.613[]                 info: Importing logs for Validator 0x91a09c0e67732124d3d3b51ba4b4c97f39c0b2d72b02b45d8e3f314af73d934629e66a59cb71b14c8bbe8d3722f1639f
Jul-07 12:56:34.423[]                 info: Importing logs for Validator 0xa1ee3fc1accae609c27d8edf316a45d477a24e471f73d42ec872933a5e3f92ade868c4920c4c4f613e1103d45f3ffd94
Jul-07 12:56:41.149[]                 info: Importing logs for Validator 0xa5e6aeaf0b8359854ca6de3dab48bcc1c953167a1e2c7c9c4ddbf2edcced724f21014e19e2c97ee217aaaeb1a7859320
Jul-07 12:56:48.895[]                 info: Importing logs for Validator 0xb8ab94e1f599e9afefd2e17a6e4f9cc22a3a280eb49341a5c4a5309ae60b19679eb45b5f92b75ec331d8eb49bb5f5c9d
Jul-07 12:56:57.420[]                 info: Importing logs for Validator 0x47454e455349535f54494d45
Jul-07 12:56:57.422[]                 info: Importing logs for Validator 0x47454e455349535f56414c494441544f52535f524f4f54
Jul-07 12:56:57.423[]                 info: Import completed successfully
```
### export
```typescript
./lodestar  validator  slashing-protection export --network kiln  --rootDir /root/kiln-data/lodestar/vals495-499  --file /root/kiln-data/lodestar/spexport.json --logLevel debug
Jul-07 12:44:11.752[]                 info: Extracting the slashing protection logs version=4, format=complete, dbPath=/root/kiln-data/lodestar/vals495-499/validator-db, file=/root/kiln-data/lodestar/spexport.json
Jul-07 12:44:11.851[]              verbose: Fetching the pubkeys from the slashingProtection db
Jul-07 12:44:21.076[]                 info: Starting export for pubkeys found pubkeys=7
Jul-07 12:44:21.077[]                 info: Exporting logs for Validator 0x828ee58143149640384f4ddeb7fe5baa8a311ed62aa453c17c13d0c48183a36e7e74b5e26859e029705b284ff390c2bc
Jul-07 12:44:21.400[]                 info: Exporting logs for Validator 0x91a09c0e67732124d3d3b51ba4b4c97f39c0b2d72b02b45d8e3f314af73d934629e66a59cb71b14c8bbe8d3722f1639f
Jul-07 12:44:21.640[]                 info: Exporting logs for Validator 0xa1ee3fc1accae609c27d8edf316a45d477a24e471f73d42ec872933a5e3f92ade868c4920c4c4f613e1103d45f3ffd94
Jul-07 12:44:21.898[]                 info: Exporting logs for Validator 0xa5e6aeaf0b8359854ca6de3dab48bcc1c953167a1e2c7c9c4ddbf2edcced724f21014e19e2c97ee217aaaeb1a7859320
Jul-07 12:44:22.210[]                 info: Exporting logs for Validator 0xb8ab94e1f599e9afefd2e17a6e4f9cc22a3a280eb49341a5c4a5309ae60b19679eb45b5f92b75ec331d8eb49bb5f5c9d
Jul-07 12:44:22.505[]                 info: Exporting logs for Validator 0x47454e455349535f54494d45
Jul-07 12:44:22.540[]                 info: Exporting logs for Validator 0x47454e455349535f56414c494441544f52535f524f4f54
Jul-07 12:44:22.545[]                debug: Serializing Interchange
Jul-07 12:44:23.751[]                 info: Exporting the the slashing protection logs to file
Jul-07 12:44:24.219[]              verbose: Export completed successfully
```
Closes #4184