### PR TITLE
Properly refer to outputs in steps when setting job output

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -44,7 +44,7 @@ jobs:
           echo ::set-output name=tag_commit::$TAG_COMMIT
 
     outputs:
-      is_stable: ${{ steps.release_type.stable_commit == steps.release_type.tag_commit }}
+      is_stable: ${{ steps.release_type.outputs.stable_commit == steps.release_type.outputs.tag_commit }}
       tag: ${{ steps.get_tag.outputs.tag }}
       prev_tag: ${{ steps.get_prev_tag.outputs.prev_tag }}
 


### PR DESCRIPTION
**Motivation**

Fix to the bug where an rc release triggered a stable release.

**Description**

This PR fixes the issue by fixing the syntax used to refer to the outputs from the individual steps.

Closes #4265

PS: Found this tool https://github.com/nektos/act which allows running github actions locally. Can be handy for testing/debugging Github actions.