### PR TITLE
Allow to verify sync committee signatures on any state

### DIFF
--- a/packages/beacon-node/test/spec/presets/operations.ts
+++ b/packages/beacon-node/test/spec/presets/operations.ts
@@ -1,4 +1,9 @@
-import {BeaconStateAllForks, CachedBeaconStateAllForks, CachedBeaconStateBellatrix} from "@lodestar/state-transition";
+import {
+  BeaconStateAllForks,
+  CachedBeaconStateAllForks,
+  CachedBeaconStateBellatrix,
+  getBlockRootAtSlot,
+} from "@lodestar/state-transition";
 import * as blockFns from "@lodestar/state-transition/block";
 import {ssz, phase0, altair, bellatrix} from "@lodestar/types";
 import {InputType} from "@lodestar/spec-test-util";
@@ -19,6 +24,7 @@ const sync_aggregate: BlockProcessFn<CachedBeaconStateAllForks> = (
   // processSyncAggregate() needs the full block to get the slot
   block.slot = state.slot;
   block.body.syncAggregate = ssz.altair.SyncAggregate.toViewDU(testCase["sync_aggregate"]);
+  block.parentRoot = getBlockRootAtSlot(state, Math.max(block.slot, 1) - 1);
 
   blockFns.processSyncAggregate(state, block);
 };


### PR DESCRIPTION
**Motivation**

- From https://github.com/ChainSafe/lodestar/pull/3989

Requires verifying signatures with _any_ states in the same epoch.

**Description**

Allow to verify sync committee signatures on any state

- Get previous block root from block instead of state
