### PR TITLE
Add startTmpBeaconDb util

### DIFF
--- a/packages/beacon-node/test/e2e/db/api/beacon/repositories/blockArchive.test.ts
+++ b/packages/beacon-node/test/e2e/db/api/beacon/repositories/blockArchive.test.ts
@@ -1,12 +1,12 @@
 import {expect} from "chai";
 import {config} from "@lodestar/config/default";
-import {LevelDbController} from "@lodestar/db";
 import {fromHexString} from "@chainsafe/ssz";
 import {allForks, phase0, ssz} from "@lodestar/types";
 import {BeaconDb} from "../../../../../../src/db/index.js";
 import {generateSignedBlock} from "../../../../../utils/block.js";
 import {testLogger} from "../../../../../utils/logger.js";
 import {BlockArchiveBatchPutBinaryItem} from "../../../../../../src/db/repositories/index.js";
+import {startTmpBeaconDb} from "../../../../../utils/db.js";
 
 describe("BlockArchiveRepository", function () {
   let db: BeaconDb;
@@ -35,11 +35,7 @@ describe("BlockArchiveRepository", function () {
   });
 
   before(async () => {
-    db = new BeaconDb({
-      config,
-      controller: new LevelDbController({name: ".tmpdb"}, {logger}),
-    });
-    await db.start();
+    db = await startTmpBeaconDb(config, logger);
   });
 
   after(async () => {

--- a/packages/beacon-node/test/e2e/interop/genesisState.test.ts
+++ b/packages/beacon-node/test/e2e/interop/genesisState.test.ts
@@ -1,23 +1,19 @@
 import {expect} from "chai";
 import {toHexString} from "@chainsafe/ssz";
-import {LevelDbController} from "@lodestar/db";
 import {config} from "@lodestar/config/default";
 import {ssz} from "@lodestar/types";
 import {BeaconDb} from "../../../src/index.js";
 import {initDevState} from "../../../src/node/utils/state.js";
 import {testLogger} from "../../utils/logger.js";
 import {interopDeposits} from "../../../src/node/utils/interop/deposits.js";
+import {startTmpBeaconDb} from "../../utils/db.js";
 
 describe("interop / initDevState", () => {
   let db: BeaconDb;
   const logger = testLogger();
 
   before(async () => {
-    db = new BeaconDb({
-      config,
-      controller: new LevelDbController({name: ".tmpdb"}, {logger}),
-    });
-    await db.start();
+    db = await startTmpBeaconDb(config, logger);
   });
 
   after(async () => {

--- a/packages/beacon-node/test/utils/db.ts
+++ b/packages/beacon-node/test/utils/db.ts
@@ -1,4 +1,23 @@
-import {IFilterOptions} from "@lodestar/db";
+import child_process from "node:child_process";
+import {IFilterOptions, LevelDbController} from "@lodestar/db";
+import {IChainForkConfig} from "@lodestar/config";
+import {ILogger} from "@lodestar/utils";
+import {BeaconDb} from "../../src/index.js";
+
+export const TEMP_DB_LOCATION = ".tmpdb";
+
+export async function startTmpBeaconDb(config: IChainForkConfig, logger: ILogger): Promise<BeaconDb> {
+  // Clean-up db first
+  child_process.execSync(`rm -rf ${TEMP_DB_LOCATION}`);
+
+  const db = new BeaconDb({
+    config,
+    controller: new LevelDbController({name: TEMP_DB_LOCATION}, {logger}),
+  });
+  await db.start();
+
+  return db;
+}
 
 /**
  * Helper to filter an array with DB IFilterOptions options


### PR DESCRIPTION
**Motivation**

From https://github.com/ChainSafe/lodestar/pull/3989, not having a consistent test db init fn created hard to debug issues

**Description**

Add startTmpBeaconDb util:
- De-duplicate declaration of gitignore path `.tmpdb`. 
- Ensure db is removed before starting