### PR TITLE
Merge getBlockSignatureSets fns into one

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -5,8 +5,7 @@ import {
   isBellatrixBlockBodyType,
   isMergeTransitionBlock as isMergeTransitionBlockFn,
   isExecutionEnabled,
-  getAllBlockSignatureSetsExceptProposer,
-  getAllBlockSignatureSets,
+  getBlockSignatureSets,
   stateTransition,
 } from "@lodestar/state-transition";
 import {bellatrix} from "@lodestar/types";
@@ -176,9 +175,9 @@ export async function verifyBlockStateTransition(
   // NOTE: If in the future multiple blocks signatures are verified at once, all blocks must be in the same epoch
   // so the attester and proposer shufflings are correct.
   if (useBlsBatchVerify && !validSignatures) {
-    const signatureSets = validProposerSignature
-      ? getAllBlockSignatureSetsExceptProposer(postState, block)
-      : getAllBlockSignatureSets(postState, block);
+    const signatureSets = getBlockSignatureSets(postState, block, {
+      skipProposerSignature: validProposerSignature,
+    });
 
     if (
       signatureSets.length > 0 &&

--- a/packages/state-transition/src/signatureSets/index.ts
+++ b/packages/state-transition/src/signatureSets/index.ts
@@ -20,20 +20,13 @@ export * from "./voluntaryExits.js";
  * Includes all signatures on the block (except the deposit signatures) for verification.
  * Deposits are not included because they can legally have invalid signatures.
  */
-export function getAllBlockSignatureSets(
+export function getBlockSignatureSets(
   state: CachedBeaconStateAllForks,
-  signedBlock: allForks.SignedBeaconBlock
-): ISignatureSet[] {
-  return [getProposerSignatureSet(state, signedBlock), ...getAllBlockSignatureSetsExceptProposer(state, signedBlock)];
-}
-
-/**
- * Includes all signatures on the block (except the deposit signatures) for verification.
- * Useful since block proposer signature is verified beforehand on gossip validation
- */
-export function getAllBlockSignatureSetsExceptProposer(
-  state: CachedBeaconStateAllForks,
-  signedBlock: allForks.SignedBeaconBlock
+  signedBlock: allForks.SignedBeaconBlock,
+  opts?: {
+    /** Useful since block proposer signature is verified beforehand on gossip validation */
+    skipProposerSignature?: boolean;
+  }
 ): ISignatureSet[] {
   const signatureSets = [
     getRandaoRevealSignatureSet(state, signedBlock.message),
@@ -42,6 +35,10 @@ export function getAllBlockSignatureSetsExceptProposer(
     ...getAttestationsSignatureSets(state, signedBlock),
     ...getVoluntaryExitsSignatureSets(state, signedBlock),
   ];
+
+  if (!opts?.skipProposerSignature) {
+    signatureSets.push(getProposerSignatureSet(state, signedBlock));
+  }
 
   // Only after altair fork, validate tSyncCommitteeSignature
   if (computeEpochAtSlot(signedBlock.message.slot) >= state.config.ALTAIR_FORK_EPOCH) {

--- a/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
+++ b/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
@@ -6,7 +6,7 @@ import {phase0, ValidatorIndex, BLSSignature} from "@lodestar/types";
 import {FAR_FUTURE_EPOCH, MAX_EFFECTIVE_BALANCE} from "@lodestar/params";
 import {BitArray} from "@chainsafe/ssz";
 import {ZERO_HASH} from "../../../src/constants/index.js";
-import {getAllBlockSignatureSets} from "../../../src/signatureSets/index.js";
+import {getBlockSignatureSets} from "../../../src/signatureSets/index.js";
 import {generateCachedState} from "../../utils/state.js";
 import {generateValidators} from "../../utils/validator.js";
 
@@ -63,7 +63,7 @@ describe("signatureSets", () => {
 
     const state = generateCachedState(config, {validators});
 
-    const signatureSets = getAllBlockSignatureSets(state, signedBlock);
+    const signatureSets = getBlockSignatureSets(state, signedBlock);
     expect(signatureSets.length).to.equal(
       // block signature
       1 +


### PR DESCRIPTION
**Motivation**

Cosmetic change from https://github.com/ChainSafe/lodestar/pull/3989. Having two functions `getAllBlockSignatureSetsExceptProposer()` and `getAllBlockSignatureSets()` is redundant

**Description**

Merge `getAllBlockSignatureSetsExceptProposer()` and `getAllBlockSignatureSets()` into `getBlockSignatureSets` with options