### PR TITLE
Run lint across all packages at once

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:types:watch": "lerna run build:types:watch --parallel",
     "build:watch": "run-p build:lib:watch build:types:watch",
     "build:ifchanged": "lerna exec -- ../../scripts/build_if_changed.sh",
-    "lint": "lerna run lint --no-bail",
+    "lint": "eslint --color --ext .ts packages/*/src packages/*/test",
     "check-build": "lerna run check-build",
     "check-types": "lerna run check-types --no-bail",
     "coverage": "lerna run coverage --no-bail",


### PR DESCRIPTION
**Motivation**

If we run lint on the entire monorepo in one command you will find errors faster.
- See https://github.com/ChainSafe/lodestar/pull/2988

*before*
```
// Package A
✓ A1 Ok
x A2 Error

// Package B
✓ B1 Ok
x B2 Error
```
*after this PR*
```
✓ A1 Ok
✓ B1 Ok
x A2 Error
x B2 Error
```


**Description**

Run lint across all packages at once