### PR TITLE
Checkpoint balances cache

### DIFF
--- a/packages/beacon-node/src/chain/balancesCache.ts
+++ b/packages/beacon-node/src/chain/balancesCache.ts
@@ -1,0 +1,55 @@
+import {
+  CachedBeaconStateAllForks,
+  computeStartSlotAtEpoch,
+  EffectiveBalanceIncrements,
+  getBlockRootAtSlot,
+  getEffectiveBalanceIncrementsZeroInactive,
+} from "@lodestar/state-transition";
+import {CheckpointWithHex} from "@lodestar/fork-choice";
+import {Epoch, RootHex} from "@lodestar/types";
+import {toHexString} from "@lodestar/utils";
+
+/**
+ * Cache EffectiveBalanceIncrements of checkpoint blocks
+ */
+export class CheckpointBalancesCache {
+  private readonly balancesByRootByEpoch = new Map<Epoch, Map<RootHex, EffectiveBalanceIncrements>>();
+
+  /**
+   * Inspect the given `state` and determine the root of the block at the first slot of
+   * `state.current_epoch`. If there is not already some entry for the given block root, then
+   * add the effective balances from the `state` to the cache.
+   */
+  processState(blockRootHex: RootHex, state: CachedBeaconStateAllForks): void {
+    const epoch = state.epochCtx.currentShuffling.epoch;
+    const epochBoundarySlot = computeStartSlotAtEpoch(epoch);
+    const epochBoundaryRoot =
+      epochBoundarySlot === state.slot ? blockRootHex : toHexString(getBlockRootAtSlot(state, epochBoundarySlot));
+
+    if (this.balancesByRootByEpoch.get(epoch)?.get(epochBoundaryRoot) === undefined) {
+      // expect to reach this once per epoch
+      let balancesByRoot = this.balancesByRootByEpoch.get(epoch);
+      if (balancesByRoot === undefined) {
+        balancesByRoot = new Map<RootHex, EffectiveBalanceIncrements>();
+        this.balancesByRootByEpoch.set(epoch, balancesByRoot);
+        balancesByRoot.set(epochBoundaryRoot, getEffectiveBalanceIncrementsZeroInactive(state));
+      }
+    }
+  }
+
+  get(checkpoint: CheckpointWithHex): EffectiveBalanceIncrements | undefined {
+    const {rootHex, epoch} = checkpoint;
+    return this.balancesByRootByEpoch.get(epoch)?.get(rootHex);
+  }
+
+  /** Prune is called per finalized checkpoint */
+  prune(finalizedEpoch: Epoch): void {
+    for (const epoch of this.balancesByRootByEpoch.keys()) {
+      if (epoch < finalizedEpoch) {
+        this.balancesByRootByEpoch.delete(epoch);
+      } else {
+        break;
+      }
+    }
+  }
+}

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -1,13 +1,7 @@
-import {altair, allForks, ssz} from "@lodestar/types";
+import {altair, ssz} from "@lodestar/types";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {toHexString} from "@chainsafe/ssz";
-import {
-  CachedBeaconStateAllForks,
-  CachedBeaconStateAltair,
-  computeStartSlotAtEpoch,
-  computeEpochAtSlot,
-  RootCache,
-} from "@lodestar/state-transition";
+import {CachedBeaconStateAltair, computeEpochAtSlot, RootCache} from "@lodestar/state-transition";
 import {IForkChoice, ForkChoiceError, ForkChoiceErrorCode} from "@lodestar/fork-choice";
 import {ILogger} from "@lodestar/utils";
 import {IChainForkConfig} from "@lodestar/config";
@@ -312,90 +306,4 @@ export async function importBlock(chain: ImportBlockModules, fullyVerifiedBlock:
     root: blockRoot,
     delaySec: chain.clock.secFromSlot(block.message.slot),
   });
-}
-
-/**
- * Returns the closest state to postState.currentJustifiedCheckpoint in the same fork as postState
- *
- * From the spec https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/fork-choice.md#get_latest_attesting_balance
- * The state from which to read balances is:
- *
- * ```python
- * state = store.checkpoint_states[store.justified_checkpoint]
- * ```
- *
- * ```python
- * def store_target_checkpoint_state(store: Store, target: Checkpoint) -> None:
- *    # Store target checkpoint state if not yet seen
- *    if target not in store.checkpoint_states:
- *        base_state = copy(store.block_states[target.root])
- *        if base_state.slot < compute_start_slot_at_epoch(target.epoch):
- *            process_slots(base_state, compute_start_slot_at_epoch(target.epoch))
- *        store.checkpoint_states[target] = base_state
- * ```
- *
- * So the state to get justified balances is the post state of `checkpoint.root` dialed forward to the first slot in
- * `checkpoint.epoch` if that block is not in `checkpoint.epoch`.
- */
-function getStateForJustifiedBalances(
-  chain: ImportBlockModules,
-  postState: CachedBeaconStateAllForks,
-  block: allForks.SignedBeaconBlock
-): CachedBeaconStateAllForks {
-  const justifiedCheckpoint = postState.currentJustifiedCheckpoint;
-  const checkpointHex = toCheckpointHex(justifiedCheckpoint);
-  const checkpointSlot = computeStartSlotAtEpoch(checkpointHex.epoch);
-
-  // First, check if the checkpoint block in the checkpoint epoch, by getting the block summary from the fork-choice
-  const checkpointBlock = chain.forkChoice.getBlockHex(checkpointHex.rootHex);
-  if (!checkpointBlock) {
-    // Should never happen
-    return postState;
-  }
-
-  // NOTE: The state of block checkpointHex.rootHex may be prior to the justified checkpoint if it was a skipped slot.
-  if (checkpointBlock.slot >= checkpointSlot) {
-    const checkpointBlockState = chain.stateCache.get(checkpointBlock.stateRoot);
-    if (checkpointBlockState) {
-      return checkpointBlockState;
-    }
-  }
-
-  // If here, the first slot of `checkpoint.epoch` is a skipped slot. Check if the state is in the checkpoint cache.
-  // NOTE: This state and above are correct with the spec.
-  // NOTE: If the first slot of the epoch was skipped and the node is syncing, this state won't be in the cache.
-  const state = chain.checkpointStateCache.get(checkpointHex);
-  if (state) {
-    return state;
-  }
-
-  // If it's not found, then find the oldest state in the same chain as this one
-  // NOTE: If `block.message.parentRoot` is not in the fork-choice, `iterateAncestorBlocks()` returns `[]`
-  // NOTE: This state is not be correct with the spec, it may have extra modifications from multiple blocks.
-  //       However, it's a best effort before triggering an async regen process. In the future this should be fixed
-  //       to use regen and get the correct state.
-  let oldestState = postState;
-  for (const parentBlock of chain.forkChoice.iterateAncestorBlocks(toHexString(block.message.parentRoot))) {
-    // We want at least a state at the slot 0 of checkpoint.epoch
-    if (parentBlock.slot < checkpointSlot) {
-      break;
-    }
-
-    const parentBlockState = chain.stateCache.get(parentBlock.stateRoot);
-    if (parentBlockState) {
-      oldestState = parentBlockState;
-    }
-  }
-
-  // TODO: Use regen to get correct state. Note that making this function async can break the import flow.
-  //       Also note that it can dead lock regen and block processing since both have a concurrency of 1.
-
-  chain.logger.error("State for currentJustifiedCheckpoint not available, using closest state", {
-    checkpointEpoch: checkpointHex.epoch,
-    checkpointRoot: checkpointHex.rootHex,
-    stateSlot: oldestState.slot,
-    stateRoot: toHexString(oldestState.hashTreeRoot()),
-  });
-
-  return oldestState;
 }

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -19,10 +19,6 @@ export type FullyVerifiedBlockFlags = {
    * Used by range sync.
    */
   ignoreIfFinalized?: boolean;
-  /**
-   * If the execution payload couldnt be verified because of EL syncing status, used in optimistic sync or for merge block
-   */
-  executionStatus?: ExecutionStatus;
 };
 
 export type PartiallyVerifiedBlockFlags = FullyVerifiedBlockFlags & {
@@ -52,6 +48,10 @@ export type FullyVerifiedBlock = FullyVerifiedBlockFlags & {
   postState: CachedBeaconStateAllForks;
   parentBlockSlot: Slot;
   proposerBalanceDiff: number;
+  /**
+   * If the execution payload couldnt be verified because of EL syncing status, used in optimistic sync or for merge block
+   */
+  executionStatus: ExecutionStatus;
 };
 
 /**

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -214,6 +214,7 @@ export class BeaconChain implements IBeaconChain {
         seenAggregatedAttestations: this.seenAggregatedAttestations,
         seenBlockAttesters: this.seenBlockAttesters,
         beaconProposerCache: this.beaconProposerCache,
+        checkpointBalancesCache: this.checkpointBalancesCache,
         reprocessController: this.reprocessController,
         emitter,
         config,

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -26,6 +26,7 @@ import {ReprocessController} from "./reprocess.js";
 import {SeenAggregatedAttestations} from "./seenCache/seenAggregateAndProof.js";
 import {BeaconProposerCache, ProposerPreparationData} from "./beaconProposerCache.js";
 import {SeenBlockAttesters} from "./seenCache/seenBlockAttesters.js";
+import {CheckpointBalancesCache} from "./balancesCache.js";
 
 export type Eth2Context = {
   activeValidatorCount: number;
@@ -79,6 +80,7 @@ export interface IBeaconChain {
   readonly seenBlockAttesters: SeenBlockAttesters;
 
   readonly beaconProposerCache: BeaconProposerCache;
+  readonly checkpointBalancesCache: CheckpointBalancesCache;
 
   /** Stop beacon chain processing */
   close(): Promise<void>;

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -886,6 +886,17 @@ export function createLodestarMetrics(
       }),
     },
 
+    balancesCache: {
+      hits: register.counter({
+        name: "lodestar_balances_cache_hits_total",
+        help: "Total number of balances cache hits",
+      }),
+      misses: register.counter({
+        name: "lodestar_balances_cache_missess_total",
+        help: "Total number of balances cache misses",
+      }),
+    },
+
     seenCache: {
       aggregatedAttestations: {
         superSetCheckTotal: register.histogram({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -887,13 +887,18 @@ export function createLodestarMetrics(
     },
 
     balancesCache: {
-      hits: register.counter({
-        name: "lodestar_balances_cache_hits_total",
-        help: "Total number of balances cache hits",
+      requests: register.counter({
+        name: "lodestar_balances_cache_requests_total",
+        help: "Total number of balances cache requests",
       }),
       misses: register.counter({
         name: "lodestar_balances_cache_missess_total",
         help: "Total number of balances cache misses",
+      }),
+      closestStateResult: register.counter<"stateId">({
+        name: "lodestar_balances_cache_closest_state_result_total",
+        help: "Total number of stateIds returned as closest justified balances state by id",
+        labelNames: ["stateId"],
       }),
     },
 

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -268,7 +268,6 @@ function runStateTranstion(
     cacheCheckpointState(postState, checkpointCache);
   }
   // same logic like in state transition https://github.com/ChainSafe/lodestar/blob/f6778740075fe2b75edf94d1db0b5691039cb500/packages/lodestar/src/chain/blocks/stateTransition.ts#L101
-  let justifiedBalances: EffectiveBalanceIncrements | undefined;
   const checkpointHex = toCheckpointHex(postState.currentJustifiedCheckpoint);
   const justifiedState = checkpointCache.get(checkpointHex);
   if (
@@ -280,7 +279,6 @@ function runStateTranstion(
       const cachedCps = checkpointCache.dumpCheckpointKeys().join(", ");
       throw Error(`No justifiedState for checkpoint ${checkpointHexKey}. Available: ${cachedCps}`);
     }
-    justifiedBalances = getEffectiveBalanceIncrementsZeroInactive(justifiedState);
   }
 
   const executionStatus =

--- a/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -8,7 +8,6 @@ import {
   getTemporaryBlockHeader,
   CachedBeaconStateAllForks,
   getEffectiveBalanceIncrementsZeroed,
-  BeaconStateAllForks,
   processSlots,
 } from "@lodestar/state-transition";
 import {toHexString} from "@chainsafe/ssz";
@@ -20,19 +19,22 @@ import {generateValidators} from "../../../utils/validator.js";
 
 describe("LodestarForkChoice", function () {
   let forkChoice: ForkChoice;
-  const anchorState = generateState(
-    {
-      slot: 0,
-      validators: generateValidators(3, {
-        effectiveBalance: MAX_EFFECTIVE_BALANCE,
-        activationEpoch: 0,
-        exitEpoch: FAR_FUTURE_EPOCH,
-        withdrawableEpoch: FAR_FUTURE_EPOCH,
-      }),
-      balances: Array.from({length: 3}, () => 0),
-      // Jan 01 2020
-      genesisTime: 1577836800,
-    },
+  const anchorState = createCachedBeaconStateTest(
+    generateState(
+      {
+        slot: 0,
+        validators: generateValidators(3, {
+          effectiveBalance: MAX_EFFECTIVE_BALANCE,
+          activationEpoch: 0,
+          exitEpoch: FAR_FUTURE_EPOCH,
+          withdrawableEpoch: FAR_FUTURE_EPOCH,
+        }),
+        balances: Array.from({length: 3}, () => 0),
+        // Jan 01 2020
+        genesisTime: 1577836800,
+      },
+      config
+    ),
     config
   );
 
@@ -223,7 +225,10 @@ describe("LodestarForkChoice", function () {
 });
 
 // lightweight state transtion function for this test
-function runStateTransition(preState: BeaconStateAllForks, signedBlock: phase0.SignedBeaconBlock): BeaconStateAllForks {
+function runStateTransition(
+  preState: CachedBeaconStateAllForks,
+  signedBlock: phase0.SignedBeaconBlock
+): CachedBeaconStateAllForks {
   // Clone state because process slots and block are not pure
   const postState = preState.clone();
   // Process slots (including those with no blocks) since block
@@ -237,9 +242,9 @@ function runStateTransition(preState: BeaconStateAllForks, signedBlock: phase0.S
 
 // create a child block/state from a parent block/state and a provided slot
 function makeChild(
-  parent: {block: phase0.SignedBeaconBlock; state: BeaconStateAllForks},
+  parent: {block: phase0.SignedBeaconBlock; state: CachedBeaconStateAllForks},
   slot: Slot
-): {block: phase0.SignedBeaconBlock; state: BeaconStateAllForks} {
+): {block: phase0.SignedBeaconBlock; state: CachedBeaconStateAllForks} {
   const childBlock = generateSignedBlock({message: {slot}});
   const parentRoot = ssz.phase0.BeaconBlock.hashTreeRoot(parent.block.message);
   childBlock.message.parentRoot = parentRoot;

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -242,16 +242,17 @@ function mockForkChoice(): IForkChoice {
     isDescendant: () => true,
     prune: () => [block],
     setPruneThreshold: () => {},
-    iterateAncestorBlocks: function* () {
-      yield block;
-    },
+    iterateAncestorBlocks: emptyGenerator,
     getAllAncestorBlocks: () => [block],
     getAllNonAncestorBlocks: () => [block],
     getCanonicalBlockAtSlot: () => block,
     forwarditerateAncestorBlocks: () => [block],
+    forwardIterateDescendants: emptyGenerator,
     getBlockSummariesByParentRoot: () => [block],
     getBlockSummariesAtSlot: () => [block],
     getCommonAncestorDistance: () => null,
     validateLatestHash: () => {},
   };
 }
+
+function* emptyGenerator<T>(): IterableIterator<T> {}

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -39,6 +39,7 @@ import {createCachedBeaconStateTest} from "../../../../../state-transition/test/
 import {SeenAggregatedAttestations} from "../../../../src/chain/seenCache/seenAggregateAndProof.js";
 import {SeenBlockAttesters} from "../../../../src/chain/seenCache/seenBlockAttesters.js";
 import {BeaconProposerCache} from "../../../../src/chain/beaconProposerCache.js";
+import {CheckpointBalancesCache} from "../../../../src/chain/balancesCache.js";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 
@@ -89,6 +90,7 @@ export class MockBeaconChain implements IBeaconChain {
   readonly beaconProposerCache = new BeaconProposerCache({
     defaultFeeRecipient: defaultValidatorOptions.defaultFeeRecipient,
   });
+  readonly checkpointBalancesCache = new CheckpointBalancesCache();
 
   private state: BeaconStateAllForks;
   private abortController: AbortController;

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -629,6 +629,26 @@ export class ForkChoice implements IForkChoice {
     return this.protoArray.nodes;
   }
 
+  *forwardIterateDescendants(blockRoot: RootHex): IterableIterator<ProtoBlock> {
+    const rootsInChain = new Set([blockRoot]);
+
+    const blockIndex = this.protoArray.indices.get(blockRoot);
+    if (blockIndex === undefined) {
+      throw new ForkChoiceError({
+        code: ForkChoiceErrorCode.MISSING_PROTO_ARRAY_BLOCK,
+        root: blockRoot,
+      });
+    }
+
+    for (let i = blockIndex + 1; i < this.protoArray.nodes.length; i++) {
+      const node = this.protoArray.nodes[i];
+      if (rootsInChain.has(node.parentRoot)) {
+        rootsInChain.add(node.blockRoot);
+        yield node;
+      }
+    }
+  }
+
   /** Very expensive function, iterates the entire ProtoArray. TODO: Is this function even necessary? */
   getBlockSummariesByParentRoot(parentRoot: RootHex): ProtoBlock[] {
     return this.protoArray.nodes.filter((node) => node.parentRoot === parentRoot);

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -356,7 +356,6 @@ export class ForkChoice implements IForkChoice {
     // null = not providing pre-computed justified balances, may trigger .justifiedBalancesGetter()
     this.updateCheckpoints(state.slot, justifiedCheckpoint, finalizedCheckpoint, null);
 
-
     const targetSlot = computeStartSlotAtEpoch(computeEpochAtSlot(slot));
     const targetRoot = slot === targetSlot ? blockRoot : state.blockRoots.get(targetSlot % SLOTS_PER_HISTORICAL_ROOT);
 

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -9,6 +9,18 @@ export type CheckpointHex = {
   root: RootHex;
 };
 
+export type CheckpointsWithHex = {
+  justifiedCheckpoint: CheckpointWithHex;
+  finalizedCheckpoint: CheckpointWithHex;
+};
+
+export type CheckpointHexWithBalance = {
+  checkpoint: CheckpointWithHex;
+  balances: EffectiveBalanceIncrements;
+};
+
+export type JustifiedBalancesGetter = (checkpoint: CheckpointWithHex) => EffectiveBalanceIncrements;
+
 export interface IForkChoice {
   /**
    * Returns the block root of an ancestor of `block_root` at the given `slot`. (Note: `slot` refers
@@ -54,11 +66,13 @@ export interface IForkChoice {
    * ## Notes:
    *
    * The supplied block **must** pass the `state_transition` function as it will not be run here.
-   *
-   * `preCachedData` includes data necessary for validation included in the spec but some data is
-   * pre-fetched in advance to keep the fork-choice fully syncronous
    */
-  onBlock(block: allForks.BeaconBlock, state: BeaconStateAllForks, preCachedData?: OnBlockPrecachedData): void;
+  onBlock(
+    block: allForks.BeaconBlock,
+    state: BeaconStateAllForks,
+    blockDelaySec: number,
+    executionStatus: ExecutionStatus
+  ): void;
   /**
    * Register `attestation` with the fork choice DAG so that it may influence future calls to `getHead`.
    *
@@ -145,14 +159,6 @@ export type PowBlockHex = {
   blockHash: RootHex;
   parentHash: RootHex;
   totalDifficulty: bigint;
-};
-
-export type OnBlockPrecachedData = {
-  /** `justifiedBalances` balances of justified state which is updated synchronously. */
-  justifiedBalances?: EffectiveBalanceIncrements;
-  /** Time in seconds when the block was received */
-  blockDelaySec: number;
-  executionStatus?: ExecutionStatus;
 };
 
 export type LatestMessage = {

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -141,9 +141,13 @@ export interface IForkChoice {
   getAllNonAncestorBlocks(blockRoot: RootHex): ProtoBlock[];
   getCanonicalBlockAtSlot(slot: Slot): ProtoBlock | null;
   /**
-   * Iterates forwards through block summaries, exact order is not guaranteed
+   * Returns all ProtoBlock known to fork-choice. Must not mutated the returned array
    */
   forwarditerateAncestorBlocks(): ProtoBlock[];
+  /**
+   * Iterates forward descendants of blockRoot. Does not yield blockRoot itself
+   */
+  forwardIterateDescendants(blockRoot: RootHex): IterableIterator<ProtoBlock>;
   getBlockSummariesByParentRoot(parentRoot: RootHex): ProtoBlock[];
   getBlockSummariesAtSlot(slot: Slot): ProtoBlock[];
   /** Returns the distance of common ancestor of nodes to newNode. Returns null if newNode is descendant of prevNode */

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -1,5 +1,5 @@
 import {EffectiveBalanceIncrements} from "@lodestar/state-transition";
-import {BeaconStateAllForks} from "@lodestar/state-transition";
+import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {Epoch, Slot, ValidatorIndex, phase0, allForks, Root, RootHex} from "@lodestar/types";
 import {ProtoBlock, ExecutionStatus} from "../protoArray/interface.js";
 import {CheckpointWithHex} from "./store.js";
@@ -18,8 +18,6 @@ export type CheckpointHexWithBalance = {
   checkpoint: CheckpointWithHex;
   balances: EffectiveBalanceIncrements;
 };
-
-export type JustifiedBalancesGetter = (checkpoint: CheckpointWithHex) => EffectiveBalanceIncrements;
 
 export interface IForkChoice {
   /**
@@ -69,7 +67,7 @@ export interface IForkChoice {
    */
   onBlock(
     block: allForks.BeaconBlock,
-    state: BeaconStateAllForks,
+    state: CachedBeaconStateAllForks,
     blockDelaySec: number,
     executionStatus: ExecutionStatus
   ): void;

--- a/packages/fork-choice/src/forkChoice/store.ts
+++ b/packages/fork-choice/src/forkChoice/store.ts
@@ -1,5 +1,7 @@
+import {EffectiveBalanceIncrements} from "@lodestar/state-transition";
 import {phase0, Slot, RootHex} from "@lodestar/types";
 import {toHexString} from "@chainsafe/ssz";
+import {CheckpointHexWithBalance, JustifiedBalancesGetter} from "./interface.js";
 
 /**
  * Stores checkpoints in a hybrid format:
@@ -22,9 +24,10 @@ export type CheckpointWithHex = phase0.Checkpoint & {rootHex: RootHex};
  */
 export interface IForkChoiceStore {
   currentSlot: Slot;
-  justifiedCheckpoint: CheckpointWithHex;
+  justified: CheckpointHexWithBalance;
+  bestJustified: CheckpointHexWithBalance;
   finalizedCheckpoint: CheckpointWithHex;
-  bestJustifiedCheckpoint: CheckpointWithHex;
+  justifiedBalancesGetter: JustifiedBalancesGetter;
 }
 
 /* eslint-disable @typescript-eslint/naming-convention, @typescript-eslint/member-ordering */
@@ -33,32 +36,39 @@ export interface IForkChoiceStore {
  * IForkChoiceStore implementer which emits forkChoice events on updated justified and finalized checkpoints.
  */
 export class ForkChoiceStore implements IForkChoiceStore {
-  bestJustifiedCheckpoint: CheckpointWithHex;
-  private _justifiedCheckpoint: CheckpointWithHex;
+  private _justified: CheckpointHexWithBalance;
+  bestJustified: CheckpointHexWithBalance;
   private _finalizedCheckpoint: CheckpointWithHex;
 
   constructor(
     public currentSlot: Slot,
     justifiedCheckpoint: phase0.Checkpoint,
     finalizedCheckpoint: phase0.Checkpoint,
+    justifiedBalances: EffectiveBalanceIncrements,
+    public justifiedBalancesGetter: JustifiedBalancesGetter,
     private readonly events?: {
       onJustified: (cp: CheckpointWithHex) => void;
       onFinalized: (cp: CheckpointWithHex) => void;
     }
   ) {
-    this._justifiedCheckpoint = toCheckpointWithHex(justifiedCheckpoint);
+    const justified: CheckpointHexWithBalance = {
+      checkpoint: toCheckpointWithHex(justifiedCheckpoint),
+      balances: justifiedBalances,
+    };
+    this._justified = justified;
+    this.bestJustified = justified;
     this._finalizedCheckpoint = toCheckpointWithHex(finalizedCheckpoint);
-    this.bestJustifiedCheckpoint = this._justifiedCheckpoint;
   }
 
-  get justifiedCheckpoint(): CheckpointWithHex {
-    return this._justifiedCheckpoint;
+  get justified(): CheckpointHexWithBalance {
+    return this._justified;
   }
-  set justifiedCheckpoint(checkpoint: CheckpointWithHex) {
-    const cp = toCheckpointWithHex(checkpoint);
-    this._justifiedCheckpoint = cp;
-    this.events?.onJustified(cp);
+
+  set justified(justified: CheckpointHexWithBalance) {
+    this._justified = justified;
+    this.events?.onJustified(justified.checkpoint);
   }
+
   get finalizedCheckpoint(): CheckpointWithHex {
     return this._finalizedCheckpoint;
   }

--- a/packages/fork-choice/src/index.ts
+++ b/packages/fork-choice/src/index.ts
@@ -2,7 +2,7 @@ export {ProtoArray} from "./protoArray/protoArray.js";
 export {ProtoBlock, ProtoNode, ExecutionStatus} from "./protoArray/interface.js";
 
 export {ForkChoice, assertValidTerminalPowBlock} from "./forkChoice/forkChoice.js";
-export {IForkChoice, OnBlockPrecachedData, PowBlockHex} from "./forkChoice/interface.js";
+export {IForkChoice, PowBlockHex, JustifiedBalancesGetter} from "./forkChoice/interface.js";
 export {ForkChoiceStore, IForkChoiceStore, CheckpointWithHex} from "./forkChoice/store.js";
 export {
   InvalidAttestation,

--- a/packages/fork-choice/src/index.ts
+++ b/packages/fork-choice/src/index.ts
@@ -2,8 +2,8 @@ export {ProtoArray} from "./protoArray/protoArray.js";
 export {ProtoBlock, ProtoNode, ExecutionStatus} from "./protoArray/interface.js";
 
 export {ForkChoice, assertValidTerminalPowBlock} from "./forkChoice/forkChoice.js";
-export {IForkChoice, PowBlockHex, JustifiedBalancesGetter} from "./forkChoice/interface.js";
-export {ForkChoiceStore, IForkChoiceStore, CheckpointWithHex} from "./forkChoice/store.js";
+export {IForkChoice, PowBlockHex} from "./forkChoice/interface.js";
+export {ForkChoiceStore, IForkChoiceStore, CheckpointWithHex, JustifiedBalancesGetter} from "./forkChoice/store.js";
 export {
   InvalidAttestation,
   InvalidAttestationCode,

--- a/packages/fork-choice/test/perf/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/perf/forkChoice/forkChoice.test.ts
@@ -52,7 +52,7 @@ describe("ForkChoice", () => {
       justifiedBalancesGetter: () => balances,
     };
 
-    forkchoice = new ForkChoice(config, fcStore, protoArr,false);
+    forkchoice = new ForkChoice(config, fcStore, protoArr, false);
 
     let parentBlockRoot = finalizedRoot;
     for (let i = 1; i < numBlocks; i++) {

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -1,7 +1,6 @@
 import {expect} from "chai";
 import {config} from "@lodestar/config/default";
 import {fromHexString} from "@chainsafe/ssz";
-import {getEffectiveBalanceIncrementsZeroed} from "@lodestar/state-transition";
 import {ForkChoice, IForkChoiceStore, ProtoBlock, ProtoArray, ExecutionStatus} from "../../../src/index.js";
 
 describe("Forkchoice", function () {
@@ -48,14 +47,21 @@ describe("Forkchoice", function () {
 
   const fcStore: IForkChoiceStore = {
     currentSlot: block.slot,
-    justifiedCheckpoint: {epoch: genesisEpoch, root: fromHexString(finalizedRoot), rootHex: finalizedRoot},
+    justified: {
+      checkpoint: {epoch: genesisEpoch, root: fromHexString(finalizedRoot), rootHex: finalizedRoot},
+      balances: new Uint8Array([32]),
+    },
+    bestJustified: {
+      checkpoint: {epoch: genesisEpoch, root: fromHexString(finalizedRoot), rootHex: finalizedRoot},
+      balances: new Uint8Array([32]),
+    },
     finalizedCheckpoint: {epoch: genesisEpoch, root: fromHexString(finalizedRoot), rootHex: finalizedRoot},
-    bestJustifiedCheckpoint: {epoch: genesisEpoch, root: fromHexString(finalizedRoot), rootHex: finalizedRoot},
+    justifiedBalancesGetter: () => new Uint8Array([32]),
   };
 
   it("getAllAncestorBlocks", function () {
     protoArr.onBlock(block);
-    const forkchoice = new ForkChoice(config, fcStore, protoArr, getEffectiveBalanceIncrementsZeroed(0), false);
+    const forkchoice = new ForkChoice(config, fcStore, protoArr, false);
     const summaries = forkchoice.getAllAncestorBlocks(finalizedDesc);
     // there are 2 blocks in protoArray but iterateAncestorBlocks should only return non-finalized blocks
     expect(summaries.length).to.be.equals(1, "should not return the finalized block");


### PR DESCRIPTION
**Motivation**

Right now whenever we provide a justified checkpoint to forkchoice, we provide balances too but forkchoice may switch justified checkpoint so we want to provide a way to cache balances from checkpoints

**Description**

- Implement a CheckpointBalancesCache, provide checkpoint balances per block process
- Implement `justifiedBalancesGetter` function:
  - Get from the cache first
  - If not find the closest state to checkpoint and extract balances from there
