### PR TITLE
Progressively compute target stake

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -158,6 +158,7 @@ export async function verifyBlockStateTransition(
       // if block is trusted don't verify proposer or op signature
       verifyProposer: !useBlsBatchVerify && !validSignatures && !validProposerSignature,
       verifySignatures: !useBlsBatchVerify && !validSignatures,
+      assertCorrectProgressiveBalances: opts.assertCorrectProgressiveBalances,
     },
     chain.metrics
   );

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -24,6 +24,10 @@ export type BlockProcessOpts = {
    * Override SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY
    */
   safeSlotsToImportOptimistically: number;
+  /**
+   * Assert progressive balances the same to EpochProcess
+   */
+  assertCorrectProgressiveBalances?: boolean;
 };
 
 export const defaultChainOptions: IChainOptions = {
@@ -33,4 +37,5 @@ export const defaultChainOptions: IChainOptions = {
   proposerBoostEnabled: true,
   safeSlotsToImportOptimistically: SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY,
   defaultFeeRecipient: defaultValidatorOptions.defaultFeeRecipient,
+  assertCorrectProgressiveBalances: false,
 };

--- a/packages/beacon-node/src/chain/regen/regen.ts
+++ b/packages/beacon-node/src/chain/regen/regen.ts
@@ -222,7 +222,7 @@ async function processSlotsByCheckpoint(
 ): Promise<CachedBeaconStateAllForks> {
   let postState = await processSlotsToNearestCheckpoint(modules, preState, slot);
   if (postState.slot < slot) {
-    postState = processSlots(postState, slot, modules.metrics);
+    postState = processSlots(postState, slot, {}, modules.metrics);
   }
   return postState;
 }
@@ -250,7 +250,7 @@ async function processSlotsToNearestCheckpoint(
     nextEpochSlot <= postSlot;
     nextEpochSlot += SLOTS_PER_EPOCH
   ) {
-    postState = processSlots(postState, nextEpochSlot, metrics);
+    postState = processSlots(postState, nextEpochSlot, {}, metrics);
 
     // Cache state to preserve epoch transition work
     const checkpointState = postState.clone();

--- a/packages/beacon-node/test/spec/config.ts
+++ b/packages/beacon-node/test/spec/config.ts
@@ -1,0 +1,2 @@
+/** When running a spec test through an epoch transition assert correct progressive balances */
+export const assertCorrectProgressiveBalances = true;

--- a/packages/beacon-node/test/spec/presets/epoch_processing.ts
+++ b/packages/beacon-node/test/spec/presets/epoch_processing.ts
@@ -10,6 +10,7 @@ import {createCachedBeaconStateTest} from "../../utils/cachedBeaconState.js";
 import {expectEqualBeaconState, inputTypeSszTreeViewDU} from "../utils/expectEqualBeaconState.js";
 import {getConfig} from "../utils/getConfig.js";
 import {TestRunnerFn} from "../utils/types.js";
+import {assertCorrectProgressiveBalances} from "../config.js";
 
 export type EpochProcessFn = (state: CachedBeaconStateAllForks, epochProcess: EpochProcess) => void;
 
@@ -57,8 +58,7 @@ export const epochProcessing: TestRunnerFn<EpochProcessingTestCase, BeaconStateA
       const stateTB = testcase.pre.clone();
       const state = createCachedBeaconStateTest(stateTB, config);
 
-      const assertCorrectProgressiveBalances = true;
-      const epochProcess = beforeProcessEpoch(state, assertCorrectProgressiveBalances);
+      const epochProcess = beforeProcessEpoch(state, {assertCorrectProgressiveBalances});
       epochProcessFn(state, epochProcess);
       state.commit();
 

--- a/packages/beacon-node/test/spec/presets/epoch_processing.ts
+++ b/packages/beacon-node/test/spec/presets/epoch_processing.ts
@@ -57,7 +57,8 @@ export const epochProcessing: TestRunnerFn<EpochProcessingTestCase, BeaconStateA
       const stateTB = testcase.pre.clone();
       const state = createCachedBeaconStateTest(stateTB, config);
 
-      const epochProcess = beforeProcessEpoch(state);
+      const assertCorrectProgressiveBalances = true;
+      const epochProcess = beforeProcessEpoch(state, assertCorrectProgressiveBalances);
       epochProcessFn(state, epochProcess);
       state.commit();
 

--- a/packages/beacon-node/test/spec/presets/finality.ts
+++ b/packages/beacon-node/test/spec/presets/finality.ts
@@ -20,6 +20,7 @@ export const finality: TestRunnerFn<FinalityTestCase, BeaconStateAllForks> = (fo
           verifyStateRoot: false,
           verifyProposer: verify,
           verifySignatures: verify,
+          assertCorrectProgressiveBalances: true,
         });
       }
 

--- a/packages/beacon-node/test/spec/presets/finality.ts
+++ b/packages/beacon-node/test/spec/presets/finality.ts
@@ -5,6 +5,7 @@ import {createCachedBeaconStateTest} from "../../utils/cachedBeaconState.js";
 import {expectEqualBeaconState, inputTypeSszTreeViewDU} from "../utils/expectEqualBeaconState.js";
 import {shouldVerify, TestRunnerFn} from "../utils/types.js";
 import {getConfig} from "../utils/getConfig.js";
+import {assertCorrectProgressiveBalances} from "../config.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -20,7 +21,7 @@ export const finality: TestRunnerFn<FinalityTestCase, BeaconStateAllForks> = (fo
           verifyStateRoot: false,
           verifyProposer: verify,
           verifySignatures: verify,
-          assertCorrectProgressiveBalances: true,
+          assertCorrectProgressiveBalances,
         });
       }
 

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -39,6 +39,7 @@ import {createCachedBeaconStateTest} from "../../utils/cachedBeaconState.js";
 import {testLogger} from "../../utils/logger.js";
 import {getConfig} from "../utils/getConfig.js";
 import {TestRunnerFn} from "../utils/types.js";
+import {assertCorrectProgressiveBalances} from "../config.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -249,13 +250,12 @@ function runStateTranstion(
   const postSlot = signedBlock.message.slot - 1;
   let preEpoch = computeEpochAtSlot(preSlot);
   let postState = preState.clone();
-  const assertCorrectProgressiveBalances = true;
   for (
     let nextEpochSlot = computeStartSlotAtEpoch(preEpoch + 1);
     nextEpochSlot <= postSlot;
     nextEpochSlot += SLOTS_PER_EPOCH
   ) {
-    postState = processSlots(postState, nextEpochSlot, null, assertCorrectProgressiveBalances);
+    postState = processSlots(postState, nextEpochSlot, {assertCorrectProgressiveBalances});
     cacheCheckpointState(postState, checkpointCache);
   }
   preEpoch = postState.epochCtx.epoch;

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -249,12 +249,13 @@ function runStateTranstion(
   const postSlot = signedBlock.message.slot - 1;
   let preEpoch = computeEpochAtSlot(preSlot);
   let postState = preState.clone();
+  const assertCorrectProgressiveBalances = true;
   for (
     let nextEpochSlot = computeStartSlotAtEpoch(preEpoch + 1);
     nextEpochSlot <= postSlot;
     nextEpochSlot += SLOTS_PER_EPOCH
   ) {
-    postState = processSlots(postState, nextEpochSlot, null);
+    postState = processSlots(postState, nextEpochSlot, null, assertCorrectProgressiveBalances);
     cacheCheckpointState(postState, checkpointCache);
   }
   preEpoch = postState.epochCtx.epoch;
@@ -262,6 +263,7 @@ function runStateTranstion(
     verifyStateRoot: true,
     verifyProposer: false,
     verifySignatures: false,
+    assertCorrectProgressiveBalances,
   });
   const postEpoch = postState.epochCtx.epoch;
   if (postEpoch > preEpoch) {

--- a/packages/beacon-node/test/spec/presets/rewards.ts
+++ b/packages/beacon-node/test/spec/presets/rewards.ts
@@ -17,7 +17,8 @@ export const rewards: TestRunnerFn<RewardTestCase, Deltas> = (fork) => {
     testFunction: (testcase) => {
       const config = getConfig(fork);
       const wrappedState = createCachedBeaconStateTest(testcase.pre, config);
-      const epochProcess = beforeProcessEpoch(wrappedState);
+      const assertCorrectProgressiveBalances = true;
+      const epochProcess = beforeProcessEpoch(wrappedState, assertCorrectProgressiveBalances);
 
       // To debug this test and get granular results you can tweak inputs to get more granular results
       //

--- a/packages/beacon-node/test/spec/presets/rewards.ts
+++ b/packages/beacon-node/test/spec/presets/rewards.ts
@@ -7,6 +7,7 @@ import {createCachedBeaconStateTest} from "../../utils/cachedBeaconState.js";
 import {inputTypeSszTreeViewDU} from "../utils/expectEqualBeaconState.js";
 import {getConfig} from "../utils/getConfig.js";
 import {TestRunnerFn} from "../utils/types.js";
+import {assertCorrectProgressiveBalances} from "../config.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -17,8 +18,7 @@ export const rewards: TestRunnerFn<RewardTestCase, Deltas> = (fork) => {
     testFunction: (testcase) => {
       const config = getConfig(fork);
       const wrappedState = createCachedBeaconStateTest(testcase.pre, config);
-      const assertCorrectProgressiveBalances = true;
-      const epochProcess = beforeProcessEpoch(wrappedState, assertCorrectProgressiveBalances);
+      const epochProcess = beforeProcessEpoch(wrappedState, {assertCorrectProgressiveBalances});
 
       // To debug this test and get granular results you can tweak inputs to get more granular results
       //

--- a/packages/beacon-node/test/spec/presets/sanity.ts
+++ b/packages/beacon-node/test/spec/presets/sanity.ts
@@ -7,6 +7,7 @@ import {createCachedBeaconStateTest} from "../../utils/cachedBeaconState.js";
 import {expectEqualBeaconState, inputTypeSszTreeViewDU} from "../utils/expectEqualBeaconState.js";
 import {shouldVerify, TestRunnerFn} from "../utils/types.js";
 import {getConfig} from "../utils/getConfig.js";
+import {assertCorrectProgressiveBalances} from "../config.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -26,13 +27,7 @@ const sanitySlots: TestRunnerFn<SanitySlotsTestCase, BeaconStateAllForks> = (for
     testFunction: (testcase) => {
       const stateTB = testcase.pre.clone();
       const state = createCachedBeaconStateTest(stateTB, getConfig(fork));
-      const assertCorrectProgressiveBalances = true;
-      const postState = processSlots(
-        state,
-        state.slot + bnToNum(testcase.slots),
-        null,
-        assertCorrectProgressiveBalances
-      );
+      const postState = processSlots(state, state.slot + bnToNum(testcase.slots), {assertCorrectProgressiveBalances});
       // TODO: May be part of runStateTranstion, necessary to commit again?
       postState.commit();
       return postState;
@@ -65,7 +60,7 @@ export const sanityBlocks: TestRunnerFn<SanityBlocksTestCase, BeaconStateAllFork
           verifyStateRoot: verify,
           verifyProposer: verify,
           verifySignatures: verify,
-          assertCorrectProgressiveBalances: true,
+          assertCorrectProgressiveBalances,
         });
       }
       return wrappedState;

--- a/packages/beacon-node/test/spec/presets/sanity.ts
+++ b/packages/beacon-node/test/spec/presets/sanity.ts
@@ -26,7 +26,8 @@ const sanitySlots: TestRunnerFn<SanitySlotsTestCase, BeaconStateAllForks> = (for
     testFunction: (testcase) => {
       const stateTB = testcase.pre.clone();
       const state = createCachedBeaconStateTest(stateTB, getConfig(fork));
-      const postState = processSlots(state, state.slot + bnToNum(testcase.slots));
+      const assertCorrectProgressiveBalances = true;
+      const postState = processSlots(state, state.slot + bnToNum(testcase.slots), null, assertCorrectProgressiveBalances);
       // TODO: May be part of runStateTranstion, necessary to commit again?
       postState.commit();
       return postState;
@@ -59,6 +60,7 @@ export const sanityBlocks: TestRunnerFn<SanityBlocksTestCase, BeaconStateAllFork
           verifyStateRoot: verify,
           verifyProposer: verify,
           verifySignatures: verify,
+          assertCorrectProgressiveBalances: true,
         });
       }
       return wrappedState;

--- a/packages/beacon-node/test/spec/presets/sanity.ts
+++ b/packages/beacon-node/test/spec/presets/sanity.ts
@@ -27,7 +27,12 @@ const sanitySlots: TestRunnerFn<SanitySlotsTestCase, BeaconStateAllForks> = (for
       const stateTB = testcase.pre.clone();
       const state = createCachedBeaconStateTest(stateTB, getConfig(fork));
       const assertCorrectProgressiveBalances = true;
-      const postState = processSlots(state, state.slot + bnToNum(testcase.slots), null, assertCorrectProgressiveBalances);
+      const postState = processSlots(
+        state,
+        state.slot + bnToNum(testcase.slots),
+        null,
+        assertCorrectProgressiveBalances
+      );
       // TODO: May be part of runStateTranstion, necessary to commit again?
       postState.commit();
       return postState;

--- a/packages/beacon-node/test/spec/presets/transition.ts
+++ b/packages/beacon-node/test/spec/presets/transition.ts
@@ -7,6 +7,7 @@ import {config} from "@lodestar/config/default";
 import {expectEqualBeaconState, inputTypeSszTreeViewDU} from "../utils/expectEqualBeaconState.js";
 import {createCachedBeaconStateTest} from "../../utils/cachedBeaconState.js";
 import {TestRunnerFn} from "../utils/types.js";
+import {assertCorrectProgressiveBalances} from "../config.js";
 import {getPreviousFork} from "./fork.js";
 
 export const transition: TestRunnerFn<TransitionTestCase, BeaconStateAllForks> = (forkNext) => {
@@ -47,7 +48,7 @@ export const transition: TestRunnerFn<TransitionTestCase, BeaconStateAllForks> =
           verifyStateRoot: true,
           verifyProposer: false,
           verifySignatures: false,
-          assertCorrectProgressiveBalances: true,
+          assertCorrectProgressiveBalances,
         });
       }
       return state;

--- a/packages/beacon-node/test/spec/presets/transition.ts
+++ b/packages/beacon-node/test/spec/presets/transition.ts
@@ -47,6 +47,7 @@ export const transition: TestRunnerFn<TransitionTestCase, BeaconStateAllForks> =
           verifyStateRoot: true,
           verifyProposer: false,
           verifySignatures: false,
+          assertCorrectProgressiveBalances: true,
         });
       }
       return state;

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -8,6 +8,7 @@ export interface IChainArgs {
   "chain.persistInvalidSszObjects": boolean;
   "chain.proposerBoostEnabled": boolean;
   "chain.defaultFeeRecipient": string;
+  "chain.assertCorrectProgressiveBalances": boolean;
   "safe-slots-to-import-optimistically": number;
   // this is defined as part of IBeaconPaths
   // "chain.persistInvalidSszObjectsDir": string;
@@ -23,6 +24,7 @@ export function parseArgs(args: IChainArgs): IBeaconNodeOptions["chain"] {
     persistInvalidSszObjectsDir: undefined as any,
     proposerBoostEnabled: args["chain.proposerBoostEnabled"],
     defaultFeeRecipient: args["chain.defaultFeeRecipient"],
+    assertCorrectProgressiveBalances: args["chain.assertCorrectProgressiveBalances"],
     safeSlotsToImportOptimistically: args["safe-slots-to-import-optimistically"],
   };
 }
@@ -73,6 +75,12 @@ Will double processing times. Use only for debugging purposes.",
       "Specify fee recipient default for collecting the EL block fees and rewards (a hex string representing 20 bytes address: ^0x[a-fA-F0-9]{40}$) in case validator fails to update for a validator index before calling produceBlock.",
     defaultDescription: defaultOptions.chain.defaultFeeRecipient,
     type: "string",
+    group: "chain",
+  },
+
+  "chain.assertCorrectProgressiveBalances": {
+    description: "Enable asserting the progressive balances",
+    type: "boolean",
     group: "chain",
   },
 

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -22,6 +22,7 @@ describe("options / beaconNodeOptions", () => {
       "chain.persistInvalidSszObjects": true,
       "chain.proposerBoostEnabled": false,
       "chain.defaultFeeRecipient": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "chain.assertCorrectProgressiveBalances": true,
       "safe-slots-to-import-optimistically": 256,
 
       "eth1.enabled": true,
@@ -85,6 +86,7 @@ describe("options / beaconNodeOptions", () => {
         proposerBoostEnabled: false,
         safeSlotsToImportOptimistically: 256,
         defaultFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        assertCorrectProgressiveBalances: true,
       },
       eth1: {
         enabled: true,

--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -93,7 +93,7 @@ export function processAttestationsAltair(
         totalBalanceIncrementsWithWeight += effectiveBalanceIncrements[index] * totalWeight;
       }
 
-      // Unrealized checkpoints issue pull-up tips N+1: Compute progressive target balances
+      // TODO: describe issue. Compute progressive target balances
       // When processing each attestation, increase the cummulative target balance. Only applies post-altair
       if ((flagsNewSet & TIMELY_TARGET) === TIMELY_TARGET) {
         const validator = state.validators.get(index);

--- a/packages/state-transition/src/block/slashValidator.ts
+++ b/packages/state-transition/src/block/slashValidator.ts
@@ -65,7 +65,7 @@ export function slashValidator(
     increaseBalance(state, whistleblowerIndex, whistleblowerReward - proposerReward);
   }
 
-  // Unrealized checkpoints issue pull-up tips N+1: Compute progressive target balances
+  // TODO: describe issue. Compute progressive target balances
   // if a validator is slashed, lookup their participation and remove from the cumulative values
   if (fork >= ForkSeq.altair) {
     const {previousEpochParticipation, currentEpochParticipation} = state as CachedBeaconStateAltair;

--- a/packages/state-transition/src/cache/epochContext.ts
+++ b/packages/state-transition/src/cache/epochContext.ts
@@ -364,7 +364,7 @@ export class EpochContext {
       exitQueueChurn = 0;
     }
 
-    // Unrealized checkpoints issue pull-up tips N+1: Compute progressive target balances
+    // TODO: describe issue. Compute progressive target balances
     // Compute balances from zero, note this state could be mid-epoch so target balances != 0
     let previousTargetUnslashedBalanceIncrements = 0;
     let currentTargetUnslashedBalanceIncrements = 0;

--- a/packages/state-transition/src/cache/epochProcess.ts
+++ b/packages/state-transition/src/cache/epochProcess.ts
@@ -163,7 +163,10 @@ export interface EpochProcess {
   isActiveNextEpoch: boolean[];
 }
 
-export function beforeProcessEpoch(state: CachedBeaconStateAllForks): EpochProcess {
+export function beforeProcessEpoch(
+  state: CachedBeaconStateAllForks,
+  assertCorrectProgressiveBalances = false
+): EpochProcess {
   const {config, epochCtx} = state;
   const forkName = config.getForkName(state.slot);
   const currentEpoch = epochCtx.currentShuffling.epoch;
@@ -370,29 +373,29 @@ export function beforeProcessEpoch(state: CachedBeaconStateAllForks): EpochProce
     }
   }
 
-  // Unrealized checkpoints issue pull-up tips N+1: To compute progressive target balances
-  if (forkName !== ForkName.phase0) {
-    // TODO, ensure that spec tests run through this
-    if (epochCtx.currentTargetUnslashedBalanceIncrements !== currTargetUnslStake) {
-      throw Error(
-        "currentTargetUnslashedBalanceIncrements is wrong, expect " +
-          currTargetUnslStake +
-          ", got " +
-          epochCtx.currentTargetUnslashedBalanceIncrements +
-          ",current epoch " +
-          epochCtx.currentShuffling.epoch
-      );
-    }
-    // TODO, ensure that spec tests run through this
-    if (epochCtx.previousTargetUnslashedBalanceIncrements !== prevTargetUnslStake) {
-      throw Error(
-        "previousTargetUnslashedBalanceIncrements is wrong, expect " +
-          prevTargetUnslStake +
-          ", got " +
-          epochCtx.previousTargetUnslashedBalanceIncrements +
-          ",current epoch " +
-          epochCtx.currentShuffling.epoch
-      );
+  if (assertCorrectProgressiveBalances) {
+    // Unrealized checkpoints issue pull-up tips N+1: To compute progressive target balances
+    if (forkName !== ForkName.phase0) {
+      if (epochCtx.currentTargetUnslashedBalanceIncrements !== currTargetUnslStake) {
+        throw Error(
+          "currentTargetUnslashedBalanceIncrements is wrong, expect " +
+            currTargetUnslStake +
+            ", got " +
+            epochCtx.currentTargetUnslashedBalanceIncrements +
+            ",current epoch " +
+            epochCtx.currentShuffling.epoch
+        );
+      }
+      if (epochCtx.previousTargetUnslashedBalanceIncrements !== prevTargetUnslStake) {
+        throw Error(
+          "previousTargetUnslashedBalanceIncrements is wrong, expect " +
+            prevTargetUnslStake +
+            ", got " +
+            epochCtx.previousTargetUnslashedBalanceIncrements +
+            ",current epoch " +
+            epochCtx.currentShuffling.epoch
+        );
+      }
     }
   }
 

--- a/packages/state-transition/src/cache/epochProcess.ts
+++ b/packages/state-transition/src/cache/epochProcess.ts
@@ -369,6 +369,33 @@ export function beforeProcessEpoch(state: CachedBeaconStateAllForks): EpochProce
       currTargetUnslStake += effectiveBalanceByIncrement;
     }
   }
+
+  // Unrealized checkpoints issue pull-up tips N+1: To compute progressive target balances
+  if (forkName !== ForkName.phase0) {
+    // TODO, ensure that spec tests run through this
+    if (epochCtx.currentTargetUnslashedBalanceIncrements !== currTargetUnslStake) {
+      throw Error(
+        "currentTargetUnslashedBalanceIncrements is wrong, expect " +
+          currTargetUnslStake +
+          ", got " +
+          epochCtx.currentTargetUnslashedBalanceIncrements +
+          ",current epoch " +
+          epochCtx.currentShuffling.epoch
+      );
+    }
+    // TODO, ensure that spec tests run through this
+    if (epochCtx.previousTargetUnslashedBalanceIncrements !== prevTargetUnslStake) {
+      throw Error(
+        "previousTargetUnslashedBalanceIncrements is wrong, expect " +
+          prevTargetUnslStake +
+          ", got " +
+          epochCtx.previousTargetUnslashedBalanceIncrements +
+          ",current epoch " +
+          epochCtx.currentShuffling.epoch
+      );
+    }
+  }
+
   // As per spec of `get_total_balance`:
   // EFFECTIVE_BALANCE_INCREMENT Gwei minimum to avoid divisions by zero.
   // Math safe up to ~10B ETH, afterwhich this overflows uint64.

--- a/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
@@ -1,12 +1,16 @@
 import {
   EFFECTIVE_BALANCE_INCREMENT,
+  ForkSeq,
   HYSTERESIS_DOWNWARD_MULTIPLIER,
   HYSTERESIS_QUOTIENT,
   HYSTERESIS_UPWARD_MULTIPLIER,
   MAX_EFFECTIVE_BALANCE,
+  TIMELY_TARGET_FLAG_INDEX,
 } from "@lodestar/params";
-import {EpochProcess, CachedBeaconStateAllForks} from "../types.js";
+import {EpochProcess, CachedBeaconStateAllForks, BeaconStateAltair} from "../types.js";
 
+/** Same to https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.5/specs/altair/beacon-chain.md#has_flag */
+const TIMELY_TARGET = 1 << TIMELY_TARGET_FLAG_INDEX;
 /**
  * Update effective balances if validator.balance has changed enough
  *
@@ -23,6 +27,7 @@ export function processEffectiveBalanceUpdates(state: CachedBeaconStateAllForks,
   const UPWARD_THRESHOLD = HYSTERESIS_INCREMENT * HYSTERESIS_UPWARD_MULTIPLIER;
   const {validators, epochCtx} = state;
   const {effectiveBalanceIncrements} = epochCtx;
+  const forkSeq = epochCtx.config.getForkSeq(state.slot);
   let nextEpochTotalActiveBalanceByIncrement = 0;
 
   // update effective balances with hysteresis
@@ -47,9 +52,29 @@ export function processEffectiveBalanceUpdates(state: CachedBeaconStateAllForks,
       effectiveBalance = Math.min(balance - (balance % EFFECTIVE_BALANCE_INCREMENT), MAX_EFFECTIVE_BALANCE);
       // Update the state tree
       // Should happen rarely, so it's fine to update the tree
-      validators.get(i).effectiveBalance = effectiveBalance;
+      const validator = validators.get(i);
+      validator.effectiveBalance = effectiveBalance;
       // Also update the fast cached version
-      effectiveBalanceIncrement = Math.floor(effectiveBalance / EFFECTIVE_BALANCE_INCREMENT);
+      const newEffectiveBalanceIncrement = Math.floor(effectiveBalance / EFFECTIVE_BALANCE_INCREMENT);
+
+      // Unrealized checkpoints issue pull-up tips N+1: Compute progressive target balances
+      // Must update target balances for consistency, see comments below
+      if (forkSeq >= ForkSeq.altair) {
+        const deltaEffectiveBalanceIncrement = newEffectiveBalanceIncrement - effectiveBalanceIncrement;
+        const {previousEpochParticipation, currentEpochParticipation} = state as BeaconStateAltair;
+
+        if (!validator.slashed && (previousEpochParticipation.get(i) & TIMELY_TARGET) === TIMELY_TARGET) {
+          epochCtx.previousTargetUnslashedBalanceIncrements += deltaEffectiveBalanceIncrement;
+        }
+
+        // currentTargetUnslashedBalanceIncrements is transfered to previousTargetUnslashedBalanceIncrements in afterEpochProcess
+        // at epoch transition of next epoch (in EpochProcess), prevTargetUnslStake is calculated based on newEffectiveBalanceIncrement
+        if (!validator.slashed && (currentEpochParticipation.get(i) & TIMELY_TARGET) === TIMELY_TARGET) {
+          epochCtx.currentTargetUnslashedBalanceIncrements += deltaEffectiveBalanceIncrement;
+        }
+      }
+
+      effectiveBalanceIncrement = newEffectiveBalanceIncrement;
       effectiveBalanceIncrements[i] = effectiveBalanceIncrement;
     }
 

--- a/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
@@ -57,7 +57,7 @@ export function processEffectiveBalanceUpdates(state: CachedBeaconStateAllForks,
       // Also update the fast cached version
       const newEffectiveBalanceIncrement = Math.floor(effectiveBalance / EFFECTIVE_BALANCE_INCREMENT);
 
-      // Unrealized checkpoints issue pull-up tips N+1: Compute progressive target balances
+      // TODO: describe issue. Compute progressive target balances
       // Must update target balances for consistency, see comments below
       if (forkSeq >= ForkSeq.altair) {
         const deltaEffectiveBalanceIncrement = newEffectiveBalanceIncrement - effectiveBalanceIncrement;

--- a/packages/state-transition/src/slot/upgradeStateToAltair.ts
+++ b/packages/state-transition/src/slot/upgradeStateToAltair.ts
@@ -92,7 +92,7 @@ export function upgradeStateToAltair(statePhase0: CachedBeaconStatePhase0): Cach
   //       internals. If the cache is not cleared, consuming the ViewDU instance could break in strange ways.
   stateAltair["clearCache"]();
 
-  // Unrealized checkpoints issue pull-up tips N+1: Compute progressive target balances
+  // TODO: describe issue. Compute progressive target balances
   //
   // Note: in EpochContext.afterProcessEpoch previousTargetUnslashedBalanceIncrements is overwritten,
   //       currentTargetUnslashedBalanceIncrements is rotated to previousTargetUnslashedBalanceIncrements

--- a/packages/state-transition/src/slot/upgradeStateToAltair.ts
+++ b/packages/state-transition/src/slot/upgradeStateToAltair.ts
@@ -3,6 +3,7 @@ import {CompositeViewDU} from "@chainsafe/ssz";
 import {CachedBeaconStatePhase0, CachedBeaconStateAltair} from "../types.js";
 import {newZeroedArray, RootCache} from "../util/index.js";
 import {getNextSyncCommittee} from "../util/syncCommittee.js";
+import {sumTargetUnslashedBalanceIncrements} from "../util/targetUnslashedBalance.js";
 import {getCachedBeaconState} from "../cache/stateCache.js";
 import {getAttestationParticipationStatus} from "../block/processAttestationsAltair.js";
 
@@ -104,6 +105,7 @@ function translateParticipation(
   const {epochCtx} = state;
   const rootCache = new RootCache(state);
   const epochParticipation = state.previousEpochParticipation;
+  const previousEpoch = epochCtx.currentShuffling.epoch - 1;
 
   for (const attestation of pendingAttesations.getAllReadonly()) {
     const data = attestation.data;
@@ -122,4 +124,22 @@ function translateParticipation(
       epochParticipation.set(index, attestationFlags);
     }
   }
+
+  // Unrealized checkpoints issue pull-up tips N+1: Compute progressive target balances
+  //
+  // Note: in EpochContext.afterProcessEpoch previousTargetUnslashedBalanceIncrements is overwritten,
+  //       currentTargetUnslashedBalanceIncrements is rotated to previousTargetUnslashedBalanceIncrements
+  //
+  // Here target balance is computed in full, which is slightly less performant than doing so in the loop
+  // above but gurantees consistency with EpochContext.createFromState(). Note execution order below:
+  // ```
+  // processEpoch()
+  // epochCtx.afterProcessEpoch()
+  // if (...) upgradeStateToAltair()
+  // ```
+  epochCtx.previousTargetUnslashedBalanceIncrements = sumTargetUnslashedBalanceIncrements(
+    state.previousEpochParticipation.getAll(),
+    previousEpoch,
+    state.validators.getAllReadonlyValues()
+  );
 }

--- a/packages/state-transition/src/util/targetUnslashedBalance.ts
+++ b/packages/state-transition/src/util/targetUnslashedBalance.ts
@@ -6,7 +6,7 @@ import {isActiveValidator} from "./validator.js";
 const TIMELY_TARGET = 1 << TIMELY_TARGET_FLAG_INDEX;
 
 /**
- * Unrealized checkpoints issue pull-up tips N+1: Compute progressive target balances
+ * TODO: describe issue. Compute progressive target balances
  * Compute balances from zero, note this state could be mid-epoch so target balances != 0
  * @param participation from `state.previousEpochParticipation.getAll()`
  * @param epoch either currentEpoch or previousEpoch

--- a/packages/state-transition/src/util/targetUnslashedBalance.ts
+++ b/packages/state-transition/src/util/targetUnslashedBalance.ts
@@ -1,0 +1,30 @@
+import {EFFECTIVE_BALANCE_INCREMENT, TIMELY_TARGET_FLAG_INDEX} from "@lodestar/params";
+import {Epoch, phase0} from "@lodestar/types";
+import {isActiveValidator} from "./validator.js";
+
+/** Same to https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.5/specs/altair/beacon-chain.md#has_flag */
+const TIMELY_TARGET = 1 << TIMELY_TARGET_FLAG_INDEX;
+
+/**
+ * Unrealized checkpoints issue pull-up tips N+1: Compute progressive target balances
+ * Compute balances from zero, note this state could be mid-epoch so target balances != 0
+ * @param participation from `state.previousEpochParticipation.getAll()`
+ * @param epoch either currentEpoch or previousEpoch
+ * @param validators from `state.validators.getAllReadonlyValues()`
+ */
+export function sumTargetUnslashedBalanceIncrements(
+  participation: number[],
+  epoch: Epoch,
+  validators: phase0.Validator[]
+): number {
+  let total = 0;
+  for (let i = 0; i < participation.length; i++) {
+    if ((participation[i] & TIMELY_TARGET) === TIMELY_TARGET) {
+      const validator = validators[i];
+      if (isActiveValidator(validator, epoch) && !validator.slashed) {
+        total += Math.floor(validator.effectiveBalance / EFFECTIVE_BALANCE_INCREMENT);
+      }
+    }
+  }
+  return total;
+}

--- a/packages/state-transition/test/perf/analyzeEpochs.ts
+++ b/packages/state-transition/test/perf/analyzeEpochs.ts
@@ -96,7 +96,7 @@ async function analyzeEpochs(network: NetworkName, fromEpoch?: number): Promise<
     const postState = createCachedBeaconStateTest(stateTB, config);
 
     const epochProcess = beforeProcessEpoch(postState);
-    processSlots(postState, nextEpochSlot, null);
+    processSlots(postState, nextEpochSlot);
 
     const validatorCount = state.validators.length;
 


### PR DESCRIPTION
**Motivation**

Research into computing target stake progressively to compute participation through an epoch instead of at the end of epoch.

**Description**

+ Add `currentTargetUnslashedBalanceIncrements, previoustTargetUnslashedBalanceIncrements` and compute it per block processing
+ Add assertion in `beforeEpochProcess`, by default do the assertion in spec tests
+ Also add cli flag to do the assertion, which allow us to sync from genesis and test