### PR TITLE
Make slashingProtectionStr optional

### DIFF
--- a/packages/api/src/keymanager/routes.ts
+++ b/packages/api/src/keymanager/routes.ts
@@ -114,7 +114,7 @@ export type Api = {
   importKeystores(
     keystoresStr: KeystoreStr[],
     passwords: string[],
-    slashingProtectionStr: SlashingProtectionData
+    slashingProtectionStr?: SlashingProtectionData
   ): Promise<{
     data: ResponseStatus<ImportStatus>[];
   }>;
@@ -184,7 +184,7 @@ export type ReqTypes = {
     body: {
       keystores: KeystoreStr[];
       passwords: string[];
-      slashingProtection: SlashingProtectionData;
+      slashingProtection?: SlashingProtectionData;
     };
   };
   deleteKeystores: {body: {pubkeys: string[]}};

--- a/packages/cli/src/cmds/validator/keymanager/impl.ts
+++ b/packages/cli/src/cmds/validator/keymanager/impl.ts
@@ -52,15 +52,17 @@ export class KeymanagerApi implements Api {
   async importKeystores(
     keystoresStr: KeystoreStr[],
     passwords: string[],
-    slashingProtectionStr: SlashingProtectionData
+    slashingProtectionStr?: SlashingProtectionData
   ): ReturnType<Api["importKeystores"]> {
-    // The arguments to this function is passed in within the body of an HTTP request
-    // hence fastify will parse it into an object before this function is called.
-    // Even though the slashingProtectionStr is typed as SlashingProtectionData,
-    // at runtime, when the handler for the request is selected, it would see slashingProtectionStr
-    // as an object, hence trying to parse it using JSON.parse won't work. Instead, we cast straight to Interchange
-    const interchange = ensureJSON<Interchange>(slashingProtectionStr);
-    await this.validator.importInterchange(interchange);
+    if (slashingProtectionStr) {
+      // The arguments to this function is passed in within the body of an HTTP request
+      // hence fastify will parse it into an object before this function is called.
+      // Even though the slashingProtectionStr is typed as SlashingProtectionData,
+      // at runtime, when the handler for the request is selected, it would see slashingProtectionStr
+      // as an object, hence trying to parse it using JSON.parse won't work. Instead, we cast straight to Interchange
+      const interchange = ensureJSON<Interchange>(slashingProtectionStr);
+      await this.validator.importInterchange(interchange);
+    }
 
     const statuses: {status: ImportStatus; message?: string}[] = [];
 


### PR DESCRIPTION
**Motivation**

From API spec https://github.com/ethereum/keymanager-APIs/blob/409d7e659a472ae262b9ff443015e2a51746653d/apis/local_keystores.yaml#L59 `slashing_protection` field is optional. However Lodestar server assumes it's always there.

**Description**

Only import slashing_protection data if defined

Closes https://github.com/ChainSafe/lodestar/issues/4295