### PR TITLE
Fix build:refdocs script in cli package

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prettier": "^2.0.5",
     "sinon": "^9.0.2",
     "supertest": "^4.0.2",
-    "ts-node": "^10.7.0",
+    "ts-node": "^10.9.1",
     "typedoc": "^0.19.2",
     "typedoc-plugin-external-module-name": "^4.0.3",
     "typedoc-plugin-internal-external": "^2.2.0",

--- a/packages/cli/docsgen/index.ts
+++ b/packages/cli/docsgen/index.ts
@@ -90,13 +90,13 @@ function getOptionsTable(options: Record<string, Options>, {showHidden}: {showHi
     return "";
   }
 
+  /* eslint-disable @typescript-eslint/naming-convention */
   return toMarkdownTable(
-    // @ts-ignore
     visibleOptions.map(([key, opt]) => ({
       Option: `\`--${key}\``,
-      Type: opt.type,
-      Description: opt.description,
-      Default: opt.defaultDescription || opt.default || "",
+      Type: opt.type ?? "",
+      Description: opt.description ?? "",
+      Default: String(opt.defaultDescription || opt.default || ""),
     })),
     ["Option", "Type", "Description", "Default"]
   );

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
     "build:lib:watch": "yarn run build:lib --watch",
     "build:typedocs": "typedoc --exclude src/index.ts --out typedocs src",
     "build:types:watch": "yarn run build:types --watch",
-    "build:refdocs": "ts-node --esm ./docsgen docs/cli.md",
+    "build:refdocs": "ts-node --esm ./docsgen/index.ts docs/cli.md",
     "write-git-data": "node lib/util/gitData/writeGitData.js",
     "check-build": "node -e \"(async function() { await import('./lib/index.js') })()\" lodestar --help",
     "check-types": "tsc",

--- a/yarn.lock
+++ b/yarn.lock
@@ -569,6 +569,13 @@
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@dabh/diagnostics@^2.0.2":
   version "2.0.2"
   resolved "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz"
@@ -991,6 +998,24 @@
   version "0.1.3"
   resolved "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
+
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
+  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
+  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@lerna/add@4.0.0":
   version "4.0.0"
@@ -11279,7 +11304,7 @@ truncate-utf8-bytes@^1.0.0:
   dependencies:
     utf8-byte-length "^1.0.1"
 
-ts-node@^10.0.0, ts-node@^10.7.0:
+ts-node@^10.0.0:
   version "10.7.0"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz"
   integrity sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==
@@ -11296,6 +11321,25 @@ ts-node@^10.0.0, ts-node@^10.7.0:
     diff "^4.0.1"
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.0"
+    yn "3.1.1"
+
+ts-node@^10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
 tsconfig-paths@^3.14.1:
@@ -11666,9 +11710,9 @@ uuidv4@^6.1.1:
     "@types/uuid" "8.3.0"
     uuid "8.3.2"
 
-v8-compile-cache-lib@^3.0.0:
+v8-compile-cache-lib@^3.0.0, v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3:


### PR DESCRIPTION
**Motivation**

build:docs script breaks, see example CI https://github.com/ChainSafe/lodestar/runs/7339174005?check_suite_focus=true

```
@chainsafe/lodestar: Error [ERR_LOADER_CHAIN_INCOMPLETE]: "file:///home/runner/work/lodestar/lodestar/node_modules/ts-node/child-loader.mjs 'resolve'" did not call the next hook in its chain and did not explicitly signal a short circuit. If this is intentional, include `shortCircuit: true` in the hook's return.
@chainsafe/lodestar:     at new NodeError (node:internal/errors:387:5)
@chainsafe/lodestar:     at ESMLoader.resolve (node:internal/modules/esm/loader:860:13)
@chainsafe/lodestar:     at async ESMLoader.getModuleJob (node:internal/modules/esm/loader:439:7)
@chainsafe/lodestar:     at async Promise.all (index 0)
@chainsafe/lodestar:     at async ESMLoader.import (node:internal/modules/esm/loader:541:24)
@chainsafe/lodestar:     at async loadESM (node:internal/process/esm_loader:83:5)
@chainsafe/lodestar:     at async handleMainPromise (node:internal/modules/run_main:65:12) {
@chainsafe/lodestar:   code: 'ERR_LOADER_CHAIN_INCOMPLETE'
@chainsafe/lodestar: }
```

After bumping the ts-node version the error is more helpful

```
CustomError: ERR_UNSUPPORTED_DIR_IMPORT /home/lion/Code/eth2.0/lodestar/packages/cli/docsgen /home/lion/Code/eth2.0/lodestar/node_modules/ts-node/dist-raw/runmain-hack.js
```

The issue is that the script `ts-node --esm ./docsgen docs/cli.md` runs against a directory not a script file

**Description**

Run ts-node against script not directory