### PR TITLE
Run fork-choice spec tests against production code

### DIFF
--- a/packages/beacon-node/src/chain/archiver/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiver/archiveBlocks.ts
@@ -1,7 +1,7 @@
 import {fromHexString} from "@chainsafe/ssz";
 import {Epoch, Slot} from "@lodestar/types";
 import {IForkChoice} from "@lodestar/fork-choice";
-import {ILogger} from "@lodestar/utils";
+import {ILogger, toHex} from "@lodestar/utils";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {IBeaconDb} from "../../db/index.js";
@@ -91,7 +91,7 @@ async function migrateBlocksFromHotToColdDb(db: IBeaconDb, blocks: BlockRootSlot
       canonicalBlocks.map(async (block) => {
         const blockBuffer = await db.block.getBinary(block.root);
         if (!blockBuffer) {
-          throw Error(`No block found for slot ${block.slot} root ${block.root}`);
+          throw Error(`No block found for slot ${block.slot} root ${toHex(block.root)}`);
         }
         return {
           key: block.slot,

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -89,7 +89,7 @@ export async function importBlock(chain: ImportBlockModules, fullyVerifiedBlock:
   // current justified checkpoint should be prev epoch or current epoch if it's just updated
   // it should always have epochBalances there bc it's a checkpoint state, ie got through processEpoch
   const prevFinalizedEpoch = chain.forkChoice.getFinalizedCheckpoint().epoch;
-  const blockDelaySec = (Math.floor(Date.now() / 1000) - postState.genesisTime) % chain.config.SECONDS_PER_SLOT;
+  const blockDelaySec = (fullyVerifiedBlock.seenTimestampSec - postState.genesisTime) % chain.config.SECONDS_PER_SLOT;
   const blockRoot = toHexString(chain.config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message));
   // Should compute checkpoint balances before forkchoice.onBlock
   chain.checkpointBalancesCache.processState(blockRoot, postState);

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -84,7 +84,9 @@ export async function processBlock(
       return;
     }
 
-    onBlockError(chain, err);
+    if (!opts.disableOnBlockError) {
+      onBlockError(chain, err);
+    }
 
     throw err;
   }
@@ -130,7 +132,7 @@ export async function processChainSegment(
       // ChainEvent.errorBlock
       if (!(err instanceof BlockError)) {
         chain.logger.error("Non BlockError received", {}, err);
-      } else {
+      } else if (!opts.disableOnBlockError) {
         onBlockError(chain, err);
       }
 

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -38,6 +38,8 @@ export type PartiallyVerifiedBlockFlags = FullyVerifiedBlockFlags & {
    * Verify signatures on main thread or not.
    */
   blsVerifyOnMainThread?: boolean;
+  /** Seen timestamp seconds */
+  seenTimestampSec?: number;
 };
 
 /**
@@ -52,6 +54,8 @@ export type FullyVerifiedBlock = FullyVerifiedBlockFlags & {
    * If the execution payload couldnt be verified because of EL syncing status, used in optimistic sync or for merge block
    */
   executionStatus: ExecutionStatus;
+  /** Seen timestamp seconds */
+  seenTimestampSec: number;
 };
 
 /**

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -62,6 +62,8 @@ export async function verifyBlock(
     skipImportingAttestations: partiallyVerifiedBlock.skipImportingAttestations,
     executionStatus,
     proposerBalanceDiff,
+    // TODO: Make this param mandatory and capture in gossip
+    seenTimestampSec: partiallyVerifiedBlock.seenTimestampSec ?? Math.floor(Date.now() / 1000),
   };
 }
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -199,7 +199,7 @@ export class BeaconChain implements IBeaconChain {
       signal,
     });
 
-    const lightClientServer = new LightClientServer({config, db, metrics, emitter, logger});
+    const lightClientServer = new LightClientServer(opts, {config, db, metrics, emitter, logger});
 
     this.reprocessController = new ReprocessController(this.metrics);
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -117,6 +117,7 @@ export class BeaconChain implements IBeaconChain {
       config,
       db,
       logger,
+      clock,
       metrics,
       anchorState,
       eth1,
@@ -126,6 +127,8 @@ export class BeaconChain implements IBeaconChain {
       config: IBeaconConfig;
       db: IBeaconDb;
       logger: ILogger;
+      /** Used for testing to supply fake clock */
+      clock?: IBeaconClock;
       metrics: IMetrics | null;
       anchorState: BeaconStateAllForks;
       eth1: IEth1ForBlockProduction;
@@ -152,7 +155,7 @@ export class BeaconChain implements IBeaconChain {
       ? new BlsSingleThreadVerifier({metrics})
       : new BlsMultiThreadWorkerPool(opts, {logger, metrics});
 
-    const clock = new LocalClock({config, emitter, genesisTime: this.genesisTime, signal});
+    if (!clock) clock = new LocalClock({config, emitter, genesisTime: this.genesisTime, signal});
     const stateCache = new StateContextCache({metrics});
     const checkpointStateCache = new CheckpointStateCache({metrics});
 

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -2,11 +2,13 @@ import {SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY} from "@lodestar/params";
 import {defaultOptions as defaultValidatorOptions} from "@lodestar/validator";
 import {ArchiverOpts} from "./archiver/index.js";
 import {ForkChoiceOpts} from "./forkChoice/index.js";
+import {LightClientServerOpts} from "./lightClient/index.js";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type IChainOptions = BlockProcessOpts &
   ForkChoiceOpts &
-  ArchiverOpts & {
+  ArchiverOpts &
+  LightClientServerOpts & {
     blsVerifyAllMainThread?: boolean;
     blsVerifyAllMultiThread?: boolean;
     persistInvalidSszObjects?: boolean;

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -30,6 +30,8 @@ export type BlockProcessOpts = {
    * Assert progressive balances the same to EpochProcess
    */
   assertCorrectProgressiveBalances?: boolean;
+  /** Used for fork_choice spec tests */
+  disableOnBlockError?: boolean;
 };
 
 export const defaultChainOptions: IChainOptions = {

--- a/packages/beacon-node/src/execution/engine/mock.ts
+++ b/packages/beacon-node/src/execution/engine/mock.ts
@@ -48,19 +48,6 @@ export class ExecutionEngineMock implements IExecutionEngine {
       timestamp: 0,
       blockNumber: 0,
     });
-
-    this.knownBlocks.set(opts.genesisBlockHash, {
-      blockHash: fromHexString(opts.genesisBlockHash),
-      parentHash: ZERO_HASH,
-      totalDifficulty: BigInt(0),
-    });
-  }
-
-  /**
-   * Non-spec method just to add more known blocks to this mock.
-   */
-  async notifyNewPowBlock(powBlock: bellatrix.PowBlock): Promise<void> {
-    this.knownBlocks.set(toHexString(powBlock.blockHash), powBlock);
   }
 
   /**

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -18,6 +18,7 @@ import {getStubbedBeaconDb} from "../../utils/mocks/db.js";
 import {ClockStopped} from "../../utils/mocks/clock.js";
 import {ZERO_HASH_HEX} from "../../../src/constants/constants.js";
 import {PowMergeBlock} from "../../../src/eth1/interface.js";
+import {assertCorrectProgressiveBalances} from "../config.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -56,6 +57,7 @@ export const forkChoiceTest: TestRunnerFn<ForkChoiceTestCase, void> = (fork) => 
           blsVerifyAllMainThread: true,
           // Do not run any archiver tasks
           disableArchiveOnCheckpoint: false,
+          assertCorrectProgressiveBalances,
         },
         {
           config: createIBeaconConfig(config, state.genesisValidatorsRoot),

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -115,6 +115,7 @@ export const forkChoiceTest: TestRunnerFn<ForkChoiceTestCase, void> = (fork) => 
 
             try {
               await chain.processBlock(signedBlock, {seenTimestampSec: tickTime});
+              if (!isValid) throw Error("Expect error since this is a negative test");
             } catch (e) {
               if (isValid) throw e;
             }

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -56,7 +56,7 @@ export const forkChoiceTest: TestRunnerFn<ForkChoiceTestCase, void> = (fork) => 
           // Do not start workers
           blsVerifyAllMainThread: true,
           // Do not run any archiver tasks
-          disableArchiveOnCheckpoint: false,
+          disableArchiveOnCheckpoint: true,
           assertCorrectProgressiveBalances,
         },
         {

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -60,6 +60,9 @@ export const forkChoiceTest: TestRunnerFn<ForkChoiceTestCase, void> = (fork) => 
           // Since the tests have deep-reorgs attested data is not available often printing lots of error logs.
           // While this function is only called for head blocks, best to disable.
           disableLightClientServerOnImportBlockHead: true,
+          // No need to log BlockErrors, the spec test runner will only log them if not not expected
+          // Otherwise spec tests logs get cluttered with expected errors
+          disableOnBlockError: true,
           assertCorrectProgressiveBalances,
         },
         {
@@ -123,17 +126,22 @@ export const forkChoiceTest: TestRunnerFn<ForkChoiceTestCase, void> = (fork) => 
               if (isValid) throw e;
             }
           }
-          // pow_block step
+
+          // **on_merge_block execution**
+          // Adds PowBlock data which is required for executing on_block(store, block).
+          // The file is located in the same folder (see below). PowBlocks should be used as return values for
+          // get_pow_block(hash: Hash32) -> PowBlock function if hashes match.
           else if (isPowBlock(step)) {
             const powBlock = testcase.powBlocks.get(step.pow_block);
-            logger.debug(`Step ${i}/${stepsLen} pow-block`, {
-              blockHash: powBlock?.blockHash ? toHexString(powBlock.blockHash) : "",
-              parentHash: powBlock?.parentHash ? toHexString(powBlock.parentHash) : "",
+            if (!powBlock) throw Error(`pow_block ${step.pow_block} not found`);
+            logger.debug(`Step ${i}/${stepsLen} pow_block`, {
+              blockHash: toHexString(powBlock.blockHash),
+              parentHash: toHexString(powBlock.parentHash),
             });
-            eth1.setPowBlock(powBlock);
-            if (powBlock) {
-              await executionEngine.notifyNewPowBlock(powBlock);
-            }
+            // Register PowBlock for `get_pow_block(hash: Hash32)` calls in verifyBlock
+            eth1.addPowBlock(powBlock);
+            // Register PowBlock to allow validation in execution engine
+            executionEngine.addPowBlock(powBlock);
           }
 
           // checks step
@@ -351,9 +359,7 @@ class Eth1ForBlockProductionMock implements IEth1ForBlockProduction {
     return this.items.get(powBlockHash) ?? null;
   }
 
-  setPowBlock(powBlock: bellatrix.PowBlock | undefined): void {
-    if (!powBlock) return;
-
+  addPowBlock(powBlock: bellatrix.PowBlock): void {
     this.items.set(toHexString(powBlock.blockHash), {
       // not used by verifyBlock()
       number: 0,

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -57,6 +57,9 @@ export const forkChoiceTest: TestRunnerFn<ForkChoiceTestCase, void> = (fork) => 
           blsVerifyAllMainThread: true,
           // Do not run any archiver tasks
           disableArchiveOnCheckpoint: true,
+          // Since the tests have deep-reorgs attested data is not available often printing lots of error logs.
+          // While this function is only called for head blocks, best to disable.
+          disableLightClientServerOnImportBlockHead: true,
           assertCorrectProgressiveBalances,
         },
         {

--- a/packages/beacon-node/test/spec/utils/types.ts
+++ b/packages/beacon-node/test/spec/utils/types.ts
@@ -11,7 +11,7 @@ export type TestRunnerFn<TestCase, Result> = (
   testHandler: string,
   testSuite: string
 ) => {
-  testFunction: (testCase: TestCase, directoryName: string) => Result;
+  testFunction: (testCase: TestCase, directoryName: string) => Result | Promise<Result>;
   options: Partial<ISpecTestOptions<TestCase, Result>>;
 };
 

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -126,13 +126,16 @@ export class MockBeaconChain implements IBeaconChain {
       metrics: null,
       emitter: this.emitter,
     });
-    this.lightClientServer = new LightClientServer({
-      config: this.config,
-      db: db,
-      metrics: null,
-      emitter: this.emitter,
-      logger,
-    });
+    this.lightClientServer = new LightClientServer(
+      {},
+      {
+        config: this.config,
+        db: db,
+        metrics: null,
+        emitter: this.emitter,
+        logger,
+      }
+    );
     this.reprocessController = new ReprocessController(null);
   }
 

--- a/packages/beacon-node/test/utils/mocks/clock.ts
+++ b/packages/beacon-node/test/utils/mocks/clock.ts
@@ -1,0 +1,59 @@
+import {computeEpochAtSlot} from "@lodestar/state-transition";
+import {Epoch, Slot} from "@lodestar/types";
+import {IBeaconClock} from "../../../src/chain/index.js";
+
+/**
+ * Mock clock that does not progress time unless calling setSlot()
+ */
+export class ClockStopped implements IBeaconClock {
+  constructor(private slot: Slot) {}
+
+  get currentSlot(): Slot {
+    return this.slot;
+  }
+
+  /** If it's too close to next slot, maxCurrentSlot = currentSlot + 1 */
+  get currentSlotWithGossipDisparity(): Slot {
+    return this.slot;
+  }
+
+  get currentEpoch(): Epoch {
+    return computeEpochAtSlot(this.slot);
+  }
+
+  slotWithFutureTolerance(): Slot {
+    return this.slot;
+  }
+  slotWithPastTolerance(): Slot {
+    return this.slot;
+  }
+
+  /**
+   * Check if a slot is current slot given MAXIMUM_GOSSIP_CLOCK_DISPARITY.
+   */
+  isCurrentSlotGivenGossipDisparity(slot: Slot): boolean {
+    return slot === this.slot;
+  }
+
+  /**
+   * Returns a promise that waits until at least `slot` is reached
+   * Resolves when the current slot >= `slot`
+   * Rejects if the clock is aborted
+   */
+  async waitForSlot(): Promise<void> {
+    // Not used
+  }
+
+  /**
+   * Return second from a slot to either toSec or now.
+   */
+  secFromSlot(): number {
+    return 0;
+  }
+
+  // MOCK Methods
+
+  setSlot(slot: Slot): void {
+    this.slot = slot;
+  }
+}

--- a/packages/beacon-node/test/utils/mocks/db.ts
+++ b/packages/beacon-node/test/utils/mocks/db.ts
@@ -1,0 +1,66 @@
+import {IBeaconDb} from "../../../src/db/index.js";
+import {
+  AttesterSlashingRepository,
+  BlockArchiveRepository,
+  BlockRepository,
+  DepositEventRepository,
+  DepositDataRootRepository,
+  Eth1DataRepository,
+  ProposerSlashingRepository,
+  StateArchiveRepository,
+  VoluntaryExitRepository,
+  BestPartialLightClientUpdateRepository,
+  CheckpointHeaderRepository,
+  SyncCommitteeRepository,
+  SyncCommitteeWitnessRepository,
+  BackfilledRanges,
+} from "../../../src/db/repositories/index.js";
+import {PreGenesisState, PreGenesisStateLastProcessedBlock} from "../../../src/db/single/index.js";
+import {createStubInstance} from "../types.js";
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+/**
+ * Stubbed BeaconDb that ignores all DELETE and PUT actions, and returns void on all GET actions
+ */
+export function getStubbedBeaconDb(): IBeaconDb {
+  return {
+    // unfinalized blocks
+    block: createStubInstance(BlockRepository),
+
+    // finalized blocks
+    blockArchive: createStubInstance(BlockArchiveRepository),
+
+    // finalized states
+    stateArchive: createStubInstance(StateArchiveRepository),
+
+    // op pool
+    voluntaryExit: createStubInstance(VoluntaryExitRepository),
+    proposerSlashing: createStubInstance(ProposerSlashingRepository),
+    attesterSlashing: createStubInstance(AttesterSlashingRepository),
+    depositEvent: createStubInstance(DepositEventRepository),
+
+    // eth1 processing
+    preGenesisState: createStubInstance(PreGenesisState),
+    preGenesisStateLastProcessedBlock: createStubInstance(PreGenesisStateLastProcessedBlock),
+
+    // all deposit data roots and merkle tree
+    depositDataRoot: createStubInstance(DepositDataRootRepository),
+    eth1Data: createStubInstance(Eth1DataRepository),
+
+    // lightclient
+    bestPartialLightClientUpdate: createStubInstance(BestPartialLightClientUpdateRepository),
+    checkpointHeader: createStubInstance(CheckpointHeaderRepository),
+    syncCommittee: createStubInstance(SyncCommitteeRepository),
+    syncCommitteeWitness: createStubInstance(SyncCommitteeWitnessRepository),
+
+    backfilledRanges: createStubInstance(BackfilledRanges),
+
+    /** Start the connection to the db instance and open the db store. */
+    async start(): Promise<void> {},
+    /**  Stop the connection to the db instance and close the db store. */
+    async stop(): Promise<void> {},
+    /** To inject metrics after CLI initialization */
+    setMetrics(): void {},
+  };
+}

--- a/packages/spec-test-util/src/single.ts
+++ b/packages/spec-test-util/src/single.ts
@@ -93,7 +93,7 @@ const defaultOptions: ISpecTestOptions<any, any> = {
 export function describeDirectorySpecTest<TestCase extends {meta?: any}, Result>(
   name: string,
   testCaseDirectoryPath: string,
-  testFunction: (testCase: TestCase, directoryName: string) => Result,
+  testFunction: (testCase: TestCase, directoryName: string) => Result | Promise<Result>,
   options: Partial<ISpecTestOptions<TestCase, Result>>
 ): void {
   options = {...defaultOptions, ...options};
@@ -123,11 +123,11 @@ export function loadYamlFile(path: string): Record<string, unknown> {
 function generateTestCase<TestCase extends {meta?: any}, Result>(
   testCaseDirectoryPath: string,
   index: number,
-  testFunction: (...args: any) => Result,
+  testFunction: (...args: any) => Result | Promise<Result>,
   options: ISpecTestOptions<TestCase, Result>
 ): void {
   const name = basename(testCaseDirectoryPath);
-  it(name, function () {
+  it(name, async function () {
     // some tests require to load meta.yaml first in order to know respective ssz types.
     const metaFilePath = join(testCaseDirectoryPath, "meta.yaml");
     let meta: TestCase["meta"] = undefined;
@@ -142,12 +142,12 @@ function generateTestCase<TestCase extends {meta?: any}, Result>(
     }
     if (options.shouldError && options.shouldError(testCase)) {
       try {
-        testFunction(testCase, name);
+        await testFunction(testCase, name);
       } catch (e) {
         return;
       }
     } else {
-      const result = testFunction(testCase, name);
+      const result = await testFunction(testCase, name);
       if (!options.getExpected) throw Error("getExpected is not defined");
       if (!options.expectFunc) throw Error("expectFunc is not defined");
       const expected = options.getExpected(testCase);


### PR DESCRIPTION
**Motivation**

Our current verify / import block flow are quite complex but are not covered by spec tests. Instead the fork-choice spec tests rely on a lot of custom copied code that may differ from production. This is a huge issue as issues may be fixed in the tests but not on production.

**Description**

- Run fork-choice spec tests against production code

Closes https://github.com/ChainSafe/lodestar/issues/3227