### PR TITLE
Consistent use of RootHex in notifyForkchoiceUpdate

### DIFF
--- a/packages/beacon-node/src/chain/factory/block/body.ts
+++ b/packages/beacon-node/src/chain/factory/block/body.ts
@@ -190,7 +190,7 @@ export async function prepareExecutionPayload(
       prevRandao: toHex(prevRandao),
       suggestedFeeRecipient,
     }) ??
-    (await chain.executionEngine.notifyForkchoiceUpdate(parentHash, safeBlockHash, finalizedBlockHash, {
+    (await chain.executionEngine.notifyForkchoiceUpdate(toHex(parentHash), safeBlockHash, finalizedBlockHash, {
       timestamp,
       prevRandao,
       suggestedFeeRecipient,

--- a/packages/beacon-node/src/execution/engine/interface.ts
+++ b/packages/beacon-node/src/execution/engine/interface.ts
@@ -1,4 +1,4 @@
-import {bellatrix, Root, RootHex} from "@lodestar/types";
+import {bellatrix, RootHex} from "@lodestar/types";
 import {PayloadIdCache, PayloadId, ApiPayloadAttributes} from "./payloadIdCache.js";
 
 export {PayloadIdCache, PayloadId, ApiPayloadAttributes};
@@ -79,7 +79,7 @@ export interface IExecutionEngine {
    * Should be called in response to fork-choice head and finalized events
    */
   notifyForkchoiceUpdate(
-    headBlockHash: Root | RootHex,
+    headBlockHash: RootHex,
     safeBlockHash: RootHex,
     finalizedBlockHash: RootHex,
     payloadAttributes?: PayloadAttributes

--- a/packages/beacon-node/src/execution/engine/mock.ts
+++ b/packages/beacon-node/src/execution/engine/mock.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import {bellatrix, RootHex, Root} from "@lodestar/types";
+import {bellatrix, RootHex} from "@lodestar/types";
 import {toHexString, fromHexString} from "@chainsafe/ssz";
 import {BYTES_PER_LOGS_BLOOM} from "@lodestar/params";
 import {ZERO_HASH, ZERO_HASH_HEX} from "../../constants/index.js";
@@ -81,23 +81,22 @@ export class ExecutionEngineMock implements IExecutionEngine {
    * 2. Client software MUST respond with 4: Unknown block error if the payload identified by either the headBlockHash or the finalizedBlockHash is unknown.
    */
   async notifyForkchoiceUpdate(
-    headBlockHash: Root,
+    headBlockHash: RootHex,
     safeBlockHash: RootHex,
     finalizedBlockHash: RootHex,
     payloadAttributes?: PayloadAttributes
   ): Promise<PayloadId> {
-    const headBlockHashHex = toHexString(headBlockHash);
-    if (!this.knownBlocks.has(headBlockHashHex)) {
-      throw Error(`Unknown headBlockHash ${headBlockHashHex}`);
+    if (!this.knownBlocks.has(headBlockHash)) {
+      throw Error(`Unknown headBlockHash ${headBlockHash}`);
     }
     if (!this.knownBlocks.has(finalizedBlockHash)) {
       throw Error(`Unknown finalizedBlockHash ${finalizedBlockHash}`);
     }
 
-    this.headBlockRoot = headBlockHashHex;
+    this.headBlockRoot = headBlockHash;
     this.finalizedBlockRoot = finalizedBlockHash;
 
-    const parentHashHex = headBlockHashHex;
+    const parentHashHex = headBlockHash;
     const parentPayload = this.knownBlocks.get(parentHashHex);
     if (!parentPayload) {
       throw Error(`Unknown parentHash ${parentHashHex}`);
@@ -107,7 +106,7 @@ export class ExecutionEngineMock implements IExecutionEngine {
 
     const payloadId = this.payloadId++;
     const payload: bellatrix.ExecutionPayload = {
-      parentHash: headBlockHash,
+      parentHash: fromHexString(headBlockHash),
       feeRecipient: fromHexString(payloadAttributes.suggestedFeeRecipient),
       stateRoot: crypto.randomBytes(32),
       receiptsRoot: crypto.randomBytes(32),


### PR DESCRIPTION
**Motivation**

No necessary to support a mix of `Root` and `Root | RooHex` of parameters in `notifyForkchoiceUpdate()`

This caused an type issue not guarded by Typescript:
- An interface defines method `fn(arg: Root | RootHex)`
- An implementer class uses `fn(arg: RootHex)`, which compiles fine
- Then `fn()` is called with `RootHex` = TypeError

**Description**

Consistent use of RootHex in notifyForkchoiceUpdate