### PR TITLE
Stop running CI for node v18 until #4145

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [16, 18]
+        node: [16]
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v2


### PR DESCRIPTION
**Motivation**

- Stop running CI for node 18 until https://github.com/ChainSafe/lodestar/issues/4145 is resolved.

CI failure rate is very high and it's extremely annoying.

**Description**

Stop running CI for node v18 until #4145