### PR TITLE
Add skipCreateStateCacheIfAvailable

### DIFF
--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -13,6 +13,7 @@ export type IChainOptions = BlockProcessOpts &
     blsVerifyAllMultiThread?: boolean;
     persistInvalidSszObjects?: boolean;
     persistInvalidSszObjectsDir?: string;
+    skipCreateStateCacheIfAvailable?: boolean;
     defaultFeeRecipient: string;
   };
 

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -83,6 +83,7 @@ describe("verify+import blocks - range sync perf test", () => {
           safeSlotsToImportOptimistically: SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY,
           disableArchiveOnCheckpoint: true,
           defaultFeeRecipient: defaultValidatorOptions.defaultFeeRecipient,
+          skipCreateStateCacheIfAvailable: true,
         },
         {
           config: state.config,

--- a/packages/state-transition/src/cache/stateCache.ts
+++ b/packages/state-transition/src/cache/stateCache.ts
@@ -158,3 +158,12 @@ export function getCachedBeaconState<T extends BeaconStateAllForks>(
 
   return cachedState;
 }
+
+/**
+ * Typeguard to check if a state contains a BeaconStateCache
+ */
+export function isCachedBeaconState<T extends BeaconStateAllForks>(
+  state: T | (T & BeaconStateCache)
+): state is T & BeaconStateCache {
+  return (state as T & BeaconStateCache).epochCtx !== undefined;
+}

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -21,7 +21,7 @@ export {
 } from "./types.js";
 
 // Main state caches
-export {createCachedBeaconState, BeaconStateCache} from "./cache/stateCache.js";
+export {createCachedBeaconState, BeaconStateCache, isCachedBeaconState} from "./cache/stateCache.js";
 export {EpochContext, EpochContextImmutableData, createEmptyEpochContextImmutableData} from "./cache/epochContext.js";
 export {EpochProcess, beforeProcessEpoch} from "./cache/epochProcess.js";
 


### PR DESCRIPTION
**Motivation**

anchorState may already by a CachedBeaconState. If so, don't create the cache again, since deserializing all pubkeys takes ~30 seconds for 350k keys (mainnet 2022Q2). When the BeaconStateCache is created in eth1 genesis builder it may be incorrect. Until we can ensure that it's safe to re-use _ANY_ BeaconStateCache, this option is disabled by default and only used in tests.

**Description**

- use skipCreateStateCacheIfAvailable in perf test for sync 