### PR TITLE
Disable @typescript-eslint/member-ordering

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,7 @@ module.exports = {
           {
             pattern: "@lodestar/**",
             group: "internal",
-          }
+          },
         ],
         pathGroupsExcludedImportTypes: ["builtin"],
       },
@@ -84,7 +84,7 @@ module.exports = {
     ],
     "@typescript-eslint/func-call-spacing": "error",
     // TODO after upgrading es-lint, member-ordering is now leading to lint errors. Set to warning now and fix in another PR
-    "@typescript-eslint/member-ordering": "warn",
+    "@typescript-eslint/member-ordering": "off",
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-require-imports": "error",
     "@typescript-eslint/no-unused-vars": [


### PR DESCRIPTION
**Motivation**

I don't see any strong reason to follow this rule, when we sometimes want to order and mix methods getters to ease understanding of complex classes.

**Description**

- Disable @typescript-eslint/member-ordering