### PR TITLE
Add goerli TTD to merge-script

### DIFF
--- a/merge-scripts/README.md
+++ b/merge-scripts/README.md
@@ -6,6 +6,8 @@ This script is borne out of need to simplify putting together the various moving
 
 So just give it a go and fire away your merge setup command!
 
+A comprehensive setup guide on how to use this merge script can be found here: https://hackmd.io/@philknows/rJegZyH9q
+
 ### Supported Networks
 
 Look for the .vars file in the folder to see what networks are supported. Here are a few examples

--- a/merge-scripts/README.md
+++ b/merge-scripts/README.md
@@ -13,7 +13,8 @@ Look for the .vars file in the folder to see what networks are supported. Here a
 1. Kiln Network ( soon to be deprecated ): `--devnetVars ./kiln.vars`
 2. Ropsten Network: `--devnetVars ./ropsten.vars`
 3. Sepolia Network: `--devnetVars ./sepolia.vars`
-4. Mainnet Shadow fork 9: `--devnetVars ./mainnetshadow-9.vars`
+4. Goerli Network: `--devnetVars ./goerli.vars`
+5. Mainnet Shadow fork 9: `--devnetVars ./mainnetshadow-9.vars`
 
 #### And the much awaited Mainnet merge!
 
@@ -29,17 +30,17 @@ Comming soon! but you can start prepping your nodes with `--devnetVars mainnet.v
 
 ```bash
 cd merge-scripts
-./setup.sh --dataDir kiln-data --elClient geth --devnetVars ./kiln.vars [--dockerWithSudo --withTerminal "gnome-terminal --disable-factory --" --withValidator]
+./setup.sh --dataDir goerli-data --elClient nethermind --devnetVars ./goerli.vars [--dockerWithSudo --withTerminal "gnome-terminal --disable-factory --" --withValidator]
 ```
 
 ### Example scenarios
 
 1. Run with separate terminals launched & attached (best for testing in local) :
-   `./setup.sh --dataDir kiln-data --elClient nethermind --devnetVars ./kiln.vars --withTerminal "gnome-terminal --disable-factory --" --dockerWithSudo `
+   `./setup.sh --dataDir goerli-data --elClient nethermind --devnetVars ./goerli.vars --withTerminal "gnome-terminal --disable-factory --" --dockerWithSudo `
 2. Run _in-terminal_ attached with logs interleaved (best for testing in remote shell) :
-   `./setup.sh --dataDir kiln-data --elClient nethermind --devnetVars ./kiln.vars --dockerWithSudo`
+   `./setup.sh --dataDir goerli-data --elClient nethermind --devnetVars ./goerli.vars --dockerWithSudo`
 3. Run detached (best for leaving it to run, typically after testing 1 or 2):
-   `./setup.sh --dataDir kiln-data --elClient nethermind --devnetVars ./kiln.vars --detached --dockerWithSudo`
+   `./setup.sh --dataDir goerli-data --elClient nethermind --devnetVars ./goerli.vars --detached --dockerWithSudo`
 
 ### Supported EL clients
 

--- a/merge-scripts/goerli.vars
+++ b/merge-scripts/goerli.vars
@@ -1,0 +1,38 @@
+LODESTAR_VALIDATOR_KEYSTORE_ARGS="--importKeystoresPath /currentDir/keystores --importKeystoresPassword /currentDir/pass.txt"
+
+LODESTAR_VALIDATOR_MNEMONIC_ARGS="--fromMnemonic \"lens risk clerk foot verb planet drill roof boost aim salt omit celery tube list permit motor obvious flash demise churn hold wave hollow\" --mnemonicIndexes 0..5"
+
+# This will be available in /data/jwtsecret
+JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
+
+FEE_RECIPIENT="0xcccccccccccccccccccccccccccccccccccccccc"
+
+#---------------- Only Modify below if you know what you are doing ----------------
+#----------------------------------------------------------------------------------
+
+DEVNET_NAME=goerli
+# Empty config git dir will be assumed to be clients having bakedin configs
+CONFIG_GIT_DIR=
+NETWORK_ID=5
+MERGE_TTD=10790000
+
+GETH_IMAGE=ethereum/client-go:latest
+NETHERMIND_IMAGE=nethermind/nethermind:latest
+ETHEREUMJS_IMAGE=g11tech/ethereumjs:kiln
+BESU_IMAGE=hyperledger/besu:develop
+
+LODESTAR_IMAGE=chainsafe/lodestar:next
+
+LODESTAR_EXTRA_ARGS="--network goerli --terminal-total-difficulty-override $MERGE_TTD $LODESTAR_FIXED_VARS"
+
+LODESTAR_VALIDATOR_ARGS="--network goerli $LODESTAR_VAL_FIXED_VARS --defaultFeeRecipient $FEE_RECIPIENT"
+
+NETHERMIND_EXTRA_ARGS="--config goerli  --Merge.TerminalTotalDifficulty=$MERGE_TTD $NETHERMIND_FIXED_VARS"
+
+GETH_EXTRA_ARGS="--goerli --override.terminaltotaldifficulty=$MERGE_TTD --networkid $NETWORK_ID $GETH_FIXED_VARS"
+
+ETHEREUMJS_EXTRA_ARGS="--network goerli $ETHEREUMJS_FIXED_VARS"
+
+BESU_EXTRA_ARGS="--network=goerli --network-id=$NETWORK_ID $BESU_FIXED_VARS"
+
+EXTRA_BOOTNODES=""


### PR DESCRIPTION
**Motivation**

To have a default config file for Goerli merge for the merge-script.

**Description**

Sets parameters required for goerli merge on the merge-script. Updates readme with goerli defaults.
Conforms with proposed TTD of `10790000` referenced here: https://github.com/ethereum/execution-specs/pull/563

Closes #4304 

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
