### PR TITLE
Disable workers for e2e test runs

### DIFF
--- a/packages/beacon-node/test/e2e/api/impl/beacon/state/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/beacon/state/endpoint.test.ts
@@ -42,6 +42,7 @@ describe("lodestar / api / impl / state", function () {
         options: {
           sync: {isSingleNode: true},
           api: {rest: {enabled: true, port: restPort}},
+          chain: {blsVerifyAllMainThread: true},
         },
         validatorCount,
         logger: loggerNodeA,
@@ -76,6 +77,7 @@ describe("lodestar / api / impl / state", function () {
         options: {
           sync: {isSingleNode: true},
           api: {rest: {enabled: true, port: restPort}},
+          chain: {blsVerifyAllMainThread: true},
         },
         validatorCount,
         logger: loggerNodeA,

--- a/packages/beacon-node/test/e2e/api/lodestar/lodestar.test.ts
+++ b/packages/beacon-node/test/e2e/api/lodestar/lodestar.test.ts
@@ -49,6 +49,7 @@ describe("api / impl / validator", function () {
         options: {
           sync: {isSingleNode: true},
           api: {rest: {enabled: true, api: ["lodestar"], port: restPort}},
+          chain: {blsVerifyAllMainThread: true},
         },
         validatorCount,
         logger: loggerNodeA,
@@ -96,6 +97,7 @@ describe("api / impl / validator", function () {
         options: {
           sync: {isSingleNode: true},
           api: {rest: {enabled: true, api: ["lodestar"], port: restPort}},
+          chain: {blsVerifyAllMainThread: true},
         },
         validatorCount,
         logger: loggerNodeA,

--- a/packages/beacon-node/test/e2e/chain/lightclient.test.ts
+++ b/packages/beacon-node/test/e2e/chain/lightclient.test.ts
@@ -73,6 +73,7 @@ describe("chain / lightclient", function () {
         sync: {isSingleNode: true},
         network: {allowPublishToZeroPeers: true},
         api: {rest: {enabled: true, api: ["lightclient"], port: restPort, address: "localhost"}},
+        chain: {blsVerifyAllMainThread: true},
       },
       validatorCount: validatorCount * validatorClientCount,
       genesisTime,

--- a/packages/beacon-node/test/e2e/doppelganger/doppelganger.test.ts
+++ b/packages/beacon-node/test/e2e/doppelganger/doppelganger.test.ts
@@ -56,7 +56,11 @@ describe.skip("doppelganger / doppelganger test", function () {
 
     const bn = await getDevBeaconNode({
       params: beaconParams,
-      options: {sync: {isSingleNode: true}, api: {rest: {enabled: false}}},
+      options: {
+        sync: {isSingleNode: true},
+        api: {rest: {enabled: false}},
+        chain: {blsVerifyAllMainThread: true},
+      },
       validatorCount,
       logger: loggerNodeA,
       genesisTime: config?.genesisTime,

--- a/packages/beacon-node/test/e2e/sync/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/sync/endpoint.test.ts
@@ -40,6 +40,7 @@ describe("lodestar / sync", function () {
         options: {
           sync: {isSingleNode: true},
           api: {rest: {enabled: true, port: restPort}},
+          chain: {blsVerifyAllMainThread: true},
         },
         validatorCount,
         logger: loggerNodeA,

--- a/packages/beacon-node/test/e2e/sync/finalizedSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/finalizedSync.test.ts
@@ -38,7 +38,11 @@ describe("sync / finalized sync", function () {
 
     const bn = await getDevBeaconNode({
       params: beaconParams,
-      options: {sync: {isSingleNode: true}, network: {allowPublishToZeroPeers: true}},
+      options: {
+        sync: {isSingleNode: true},
+        network: {allowPublishToZeroPeers: true},
+        chain: {blsVerifyAllMainThread: true},
+      },
       validatorCount,
       genesisTime,
       logger: loggerNodeA,

--- a/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
@@ -48,7 +48,11 @@ describe("sync / unknown block sync", function () {
 
     const bn = await getDevBeaconNode({
       params: testParams,
-      options: {sync: {isSingleNode: true}, network: {allowPublishToZeroPeers: true}},
+      options: {
+        sync: {isSingleNode: true},
+        network: {allowPublishToZeroPeers: true},
+        chain: {blsVerifyAllMainThread: true},
+      },
       validatorCount,
       logger: loggerNodeA,
     });
@@ -74,7 +78,11 @@ describe("sync / unknown block sync", function () {
 
     const bn2 = await getDevBeaconNode({
       params: testParams,
-      options: {api: {rest: {enabled: false}}, sync: {disableRangeSync: true}},
+      options: {
+        api: {rest: {enabled: false}},
+        sync: {disableRangeSync: true},
+        chain: {blsVerifyAllMainThread: true},
+      },
       validatorCount,
       genesisTime: bn.chain.getHeadState().genesisTime,
       logger: loggerNodeB,

--- a/packages/beacon-node/test/e2e/sync/wss.test.ts
+++ b/packages/beacon-node/test/e2e/sync/wss.test.ts
@@ -60,6 +60,7 @@ describe("Start from WSS", function () {
         },
         sync: {isSingleNode: true},
         network: {allowPublishToZeroPeers: true},
+        chain: {blsVerifyAllMainThread: true},
       },
       validatorCount: 32,
       logger: loggerNodeA,
@@ -99,6 +100,7 @@ describe("Start from WSS", function () {
       options: {
         api: {rest: {enabled: true, port: 9587} as BeaconRestApiServerOpts},
         sync: {isSingleNode: true, backfillBatchSize: 64},
+        chain: {blsVerifyAllMainThread: true},
       },
       validatorCount: 32,
       logger: loggerNodeB,


### PR DESCRIPTION
**Motivation**

- Hopefully mitigates the chance of https://github.com/ChainSafe/lodestar/issues/4145

**Description**

- Disable workers for e2e test runs

We are running way too many Lodestar nodes in e2e tests