### PR TITLE
Skip PrepareNextSlot scheduler for forkchoice spec tests

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -246,7 +246,10 @@ export class BeaconChain implements IBeaconChain {
     this.lightClientServer = lightClientServer;
 
     this.archiver = new Archiver(db, this, logger, signal, opts);
-    new PrepareNextSlotScheduler(this, this.config, metrics, this.logger, signal);
+    // always run PrepareNextSlotScheduler except for fork_choice spec tests
+    if (!opts?.disablePrepareNextSlot) {
+      new PrepareNextSlotScheduler(this, this.config, metrics, this.logger, signal);
+    }
 
     metrics?.opPool.aggregatedAttestationPoolSize.addCollect(() => this.onScrapeMetrics());
 

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -33,6 +33,8 @@ export type BlockProcessOpts = {
   assertCorrectProgressiveBalances?: boolean;
   /** Used for fork_choice spec tests */
   disableOnBlockError?: boolean;
+  /** Used for fork_choice spec tests */
+  disablePrepareNextSlot?: boolean;
 };
 
 export const defaultChainOptions: IChainOptions = {

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -63,6 +63,9 @@ export const forkChoiceTest: TestRunnerFn<ForkChoiceTestCase, void> = (fork) => 
           // No need to log BlockErrors, the spec test runner will only log them if not not expected
           // Otherwise spec tests logs get cluttered with expected errors
           disableOnBlockError: true,
+          // PrepareNextSlot scheduler is used to precompute epoch transition and prepare for the next payload
+          // we don't use these in fork choice spec tests
+          disablePrepareNextSlot: true,
           assertCorrectProgressiveBalances,
         },
         {


### PR DESCRIPTION
**Motivation**

See a lot of errors thrown from `"PrepareNextSlotScheduler"` when running forkchoice spec tests

**Description**

Add a flag to disable/skip it when running fork_choice spec tests