### PR TITLE
Integrate Erigon into merge-script

### DIFF
--- a/merge-scripts/README.md
+++ b/merge-scripts/README.md
@@ -52,6 +52,7 @@ Look for the .vars file in the folder to see what networks are supported. Here a
 2. Nethermind: `--elClient nethermind`
 3. Besu: `--elClient besu`
 4. Ethereumjs: (might sync only small size testnets for now): `--elClient ethereumjs`
+5. Erigon: `--elClient erigon`
 
 You can alternate between them (without needing to reset/cleanup) to experiment with the ELs being out of sync ( and catching up) with `lodestar` via **Optimistic Sync** features.
 

--- a/merge-scripts/fixed.vars
+++ b/merge-scripts/fixed.vars
@@ -17,4 +17,4 @@ ETHEREUMJS_FIXED_VARS="--datadir /data/ethereumjs --gethGenesis /config/genesis.
 BESU_FIXED_VARS="--data-path=/data/besu --engine-jwt-secret=/data/jwtsecret --rpc-http-enabled=true --rpc-http-api=ADMIN,CLIQUE,MINER,ETH,NET,DEBUG,TXPOOL,TRACE --rpc-http-host=0.0.0.0 --rpc-http-port=8545 --engine-rpc-http-port=8551 --rpc-http-cors-origins=\"*\" --host-allowlist=\"*\" --engine-host-allowlist=\"*\" --p2p-enabled=true --engine-jwt-enabled=true"
 
 # Data dir will be mounted in /data/erigon
-ERIGON_FIXED_VARS="--datadir=/data/erigon --http --http.api \"admin,engine,net,eth\" --http.port=8545 --http.corsdomain \"*\" --ws --engine.port=8551 --engine.addr=0.0.0.0 --authrpc.jwtsecret=/data/jwtsecret --allow-insecure-unlock --prune=htrc --batchSize=32m"
+ERIGON_FIXED_VARS="--datadir=/data/erigon --http --http.api \"admin,engine,net,eth\" --http.port=8545 --http.addr 0.0.0.0 --http.corsdomain \"*\" --ws --engine.port=8551 --engine.addr=0.0.0.0 --authrpc.jwtsecret=/data/jwtsecret --allow-insecure-unlock --prune=htrc --batchSize=32m"

--- a/merge-scripts/fixed.vars
+++ b/merge-scripts/fixed.vars
@@ -14,7 +14,7 @@ GETH_FIXED_VARS="--datadir /data/geth --authrpc.jwtsecret /data/jwtsecret --http
 ETHEREUMJS_FIXED_VARS="--datadir /data/ethereumjs --gethGenesis /config/genesis.json --jwt-secret /data/jwtsecret --saveReceipts --rpc --rpcport 8545 --ws --rpcEngine --rpcEnginePort=8551 --rpcDebug --loglevel=debug"
 
 # Data dir will be mounted in /data/besu
-BESU_FIXED_VARS="--data-path=/data/besu --engine-jwt-secret=/data/jwtsecret --rpc-http-enabled=true --rpc-http-api=ADMIN,CLIQUE,MINER,ETH,NET,DEBUG,TXPOOL,TRACE --rpc-http-host=0.0.0.0 --rpc-http-port=8545 --engine-rpc-http-port=8551 --rpc-http-cors-origins=\"*\" --host-allowlist=\"*\" --engine-host-allowlist=\"*\" --p2p-enabled=true --engine-jwt-enabled=true"
+BESU_FIXED_VARS="--data-path=/data/besu --engine-jwt-secret=/data/jwtsecret --rpc-http-enabled=true --rpc-http-api=ADMIN,CLIQUE,MINER,ETH,NET,DEBUG,TXPOOL,TRACE --rpc-http-host=0.0.0.0 --rpc-http-port=8545 --engine-rpc-port=8551 --rpc-http-cors-origins=\"*\" --host-allowlist=\"*\" --engine-host-allowlist=\"*\" --p2p-enabled=true --engine-jwt-enabled=true"
 
 # Data dir will be mounted in /data/erigon
 ERIGON_FIXED_VARS="--datadir=/data/erigon --http --http.api \"admin,engine,net,eth\" --http.port=8545 --http.addr 0.0.0.0 --http.corsdomain \"*\" --ws --engine.port=8551 --engine.addr=0.0.0.0 --authrpc.jwtsecret=/data/jwtsecret --allow-insecure-unlock --prune=htrc --batchSize=32m"

--- a/merge-scripts/fixed.vars
+++ b/merge-scripts/fixed.vars
@@ -16,5 +16,6 @@ ETHEREUMJS_FIXED_VARS="--datadir /data/ethereumjs --gethGenesis /config/genesis.
 # Data dir will be mounted in /data/besu
 BESU_FIXED_VARS="--data-path=/data/besu --engine-jwt-secret=/data/jwtsecret --rpc-http-enabled=true --rpc-http-api=ADMIN,CLIQUE,MINER,ETH,NET,DEBUG,TXPOOL,TRACE --rpc-http-host=0.0.0.0 --rpc-http-port=8545 --engine-rpc-port=8551 --rpc-http-cors-origins=\"*\" --host-allowlist=\"*\" --engine-host-allowlist=\"*\" --p2p-enabled=true --engine-jwt-enabled=true"
 
-# Data dir will be mounted in /data/erigon
-ERIGON_FIXED_VARS="--datadir=/data/erigon --http --http.api \"admin,engine,net,eth\" --http.port=8545 --http.addr 0.0.0.0 --http.corsdomain \"*\" --ws --engine.port=8551 --engine.addr=0.0.0.0 --authrpc.jwtsecret=/data/jwtsecret --allow-insecure-unlock --prune=htrc --batchSize=32m"
+# Data dir will be mounted in /data/erigon, private api addr has been switched off because it collides
+# with lodestar prometheus endpoint. If required make adjustments accordingly
+ERIGON_FIXED_VARS="--datadir=/data/erigon --private.api.addr \"\" --http --http.api \"admin,engine,net,eth\" --http.port=8545 --http.addr 0.0.0.0 --http.corsdomain \"*\" --ws --engine.port=8551 --engine.addr=0.0.0.0 --authrpc.jwtsecret=/data/jwtsecret --allow-insecure-unlock --prune=htrc --batchSize=32m"

--- a/merge-scripts/fixed.vars
+++ b/merge-scripts/fixed.vars
@@ -15,3 +15,6 @@ ETHEREUMJS_FIXED_VARS="--datadir /data/ethereumjs --gethGenesis /config/genesis.
 
 # Data dir will be mounted in /data/besu
 BESU_FIXED_VARS="--data-path=/data/besu --engine-jwt-secret=/data/jwtsecret --rpc-http-enabled=true --rpc-http-api=ADMIN,CLIQUE,MINER,ETH,NET,DEBUG,TXPOOL,TRACE --rpc-http-host=0.0.0.0 --rpc-http-port=8545 --engine-rpc-http-port=8551 --rpc-http-cors-origins=\"*\" --host-allowlist=\"*\" --engine-host-allowlist=\"*\" --p2p-enabled=true --engine-jwt-enabled=true"
+
+# Data dir will be mounted in /data/erigon
+ERIGON_FIXED_VARS="--datadir=/data/erigon --http --http.api \"admin,engine,net,eth\" --http.port=8545 --http.corsdomain \"*\" --ws --engine.port=8551 --engine.addr=0.0.0.0 --authrpc.jwtsecret=/data/jwtsecret --allow-insecure-unlock --prune=htrc --batchSize=32m"

--- a/merge-scripts/goerli.vars
+++ b/merge-scripts/goerli.vars
@@ -20,6 +20,7 @@ GETH_IMAGE=ethereum/client-go:latest
 NETHERMIND_IMAGE=nethermind/nethermind:latest
 ETHEREUMJS_IMAGE=g11tech/ethereumjs:kiln
 BESU_IMAGE=hyperledger/besu:develop
+ERIGON_IMAGE=parithoshj/erigon:devel-fb9f193
 
 LODESTAR_IMAGE=chainsafe/lodestar:next
 
@@ -34,5 +35,7 @@ GETH_EXTRA_ARGS="--goerli --override.terminaltotaldifficulty=$MERGE_TTD --networ
 ETHEREUMJS_EXTRA_ARGS="--network goerli $ETHEREUMJS_FIXED_VARS"
 
 BESU_EXTRA_ARGS="--network=goerli --network-id=$NETWORK_ID $BESU_FIXED_VARS"
+
+ERIGON_EXTRA_ARGS="--chain goerli --networkid=$NETWORK_ID --override.terminaltotaldifficulty=$MERGE_TTD $ERIGON_FIXED_VARS"
 
 EXTRA_BOOTNODES=""

--- a/merge-scripts/goerli.vars
+++ b/merge-scripts/goerli.vars
@@ -36,6 +36,6 @@ ETHEREUMJS_EXTRA_ARGS="--network goerli $ETHEREUMJS_FIXED_VARS"
 
 BESU_EXTRA_ARGS="--network=goerli --network-id=$NETWORK_ID $BESU_FIXED_VARS"
 
-ERIGON_EXTRA_ARGS="--chain goerli --networkid=$NETWORK_ID --override.terminaltotaldifficulty=$MERGE_TTD $ERIGON_FIXED_VARS"
+ERIGON_EXTRA_ARGS="erigon --chain=goerli --networkid=$NETWORK_ID --override.terminaltotaldifficulty=$MERGE_TTD $ERIGON_FIXED_VARS"
 
 EXTRA_BOOTNODES=""

--- a/merge-scripts/kiln.vars
+++ b/merge-scripts/kiln.vars
@@ -19,6 +19,7 @@ GETH_IMAGE=ethereum/client-go:latest
 NETHERMIND_IMAGE=nethermind/nethermind:latest
 ETHEREUMJS_IMAGE=g11tech/ethereumjs:kiln
 BESU_IMAGE=hyperledger/besu:develop
+ERIGON_IMAGE=parithoshj/erigon:devel-fb9f193
 
 LODESTAR_IMAGE=chainsafe/lodestar:next
 
@@ -33,5 +34,7 @@ GETH_EXTRA_ARGS="--kiln --override.terminaltotaldifficulty=$MERGE_TTD --networki
 ETHEREUMJS_EXTRA_ARGS="$ETHEREUMJS_FIXED_VARS"
 
 BESU_EXTRA_ARGS="--network=kiln --network-id=$NETWORK_ID $BESU_FIXED_VARS"
+
+ERIGON_EXTRA_ARGS="erigon --chain=goerli --networkid=$NETWORK_ID --override.terminaltotaldifficulty=$MERGE_TTD $ERIGON_FIXED_VARS"
 
 EXTRA_BOOTNODES=""

--- a/merge-scripts/mainnet.vars
+++ b/merge-scripts/mainnet.vars
@@ -20,6 +20,7 @@ GETH_IMAGE=ethereum/client-go:latest
 NETHERMIND_IMAGE=nethermind/nethermind:latest
 ETHEREUMJS_IMAGE=g11tech/ethereumjs:kiln
 BESU_IMAGE=hyperledger/besu:develop
+ERIGON_IMAGE=parithoshj/erigon:devel-fb9f193
 
 LODESTAR_IMAGE=chainsafe/lodestar:next
 
@@ -34,5 +35,7 @@ GETH_EXTRA_ARGS="--mainnet --override.terminaltotaldifficulty=$MERGE_TTD --netwo
 ETHEREUMJS_EXTRA_ARGS="$ETHEREUMJS_FIXED_VARS"
 
 BESU_EXTRA_ARGS="--network-id=$NETWORK_ID $BESU_FIXED_VARS"
+
+ERIGON_EXTRA_ARGS="erigon --chain=mainnet --networkid=$NETWORK_ID --override.terminaltotaldifficulty=$MERGE_TTD $ERIGON_FIXED_VARS"
 
 EXTRA_BOOTNODES=""

--- a/merge-scripts/parse-args.sh
+++ b/merge-scripts/parse-args.sh
@@ -64,7 +64,7 @@ done
 # key won't ever get assigned in while loop if there is no arg, in that case print usage
 if [[ ! -n "$key" ]];
 then
-  echo "usage: ./setup.sh --dataDir <data dir> --elClient <geth | nethermind | ethereumjs | besu> --devetVars <devnet vars file> [--dockerWithSudo --withTerminal \"gnome-terminal --disable-factory --\"]"
+  echo "usage: ./setup.sh --dataDir <data dir> --elClient <geth | nethermind | ethereumjs | besu | erigon> --devetVars <devnet vars file> [--dockerWithSudo --withTerminal \"gnome-terminal --disable-factory --\"]"
   echo "example: ./setup.sh --dataDir kiln-data --elClient nethermind --devnetVars ./kiln.vars --dockerWithSudo --withTerminal \"gnome-terminal --disable-factory --\""
   echo "Note: if running on macOS where gnome-terminal is not available, remove the gnome-terminal related flags."
   echo "example: ./setup.sh --dataDir kiln-data --elClient geth --devnetVars ./kiln.vars"

--- a/merge-scripts/ropsten.vars
+++ b/merge-scripts/ropsten.vars
@@ -22,6 +22,7 @@ GETH_IMAGE=ethereum/client-go:latest
 NETHERMIND_IMAGE=nethermind/nethermind:latest
 ETHEREUMJS_IMAGE=g11tech/ethereumjs:kiln
 BESU_IMAGE=hyperledger/besu:develop
+ERIGON_IMAGE=parithoshj/erigon:devel-fb9f193
 
 LODESTAR_IMAGE=chainsafe/lodestar:next
 
@@ -36,5 +37,7 @@ GETH_EXTRA_ARGS="--ropsten --override.terminaltotaldifficulty=$MERGE_TTD --netwo
 ETHEREUMJS_EXTRA_ARGS="--network ropsten $ETHEREUMJS_FIXED_VARS"
 
 BESU_EXTRA_ARGS="--network=ropsten --network-id=$NETWORK_ID $BESU_FIXED_VARS"
+
+ERIGON_EXTRA_ARGS="erigon --chain=ropsten --networkid=$NETWORK_ID --override.terminaltotaldifficulty=$MERGE_TTD $ERIGON_FIXED_VARS"
 
 EXTRA_BOOTNODES=""

--- a/merge-scripts/sepolia.vars
+++ b/merge-scripts/sepolia.vars
@@ -19,6 +19,7 @@ GETH_IMAGE=ethereum/client-go:latest
 NETHERMIND_IMAGE=nethermind/nethermind:latest
 ETHEREUMJS_IMAGE=g11tech/ethereumjs:kiln
 BESU_IMAGE=hyperledger/besu:develop
+ERIGON_IMAGE=parithoshj/erigon:devel-fb9f193
 
 LODESTAR_IMAGE=chainsafe/lodestar:next
 
@@ -33,5 +34,7 @@ GETH_EXTRA_ARGS="--sepolia --override.terminaltotaldifficulty=$MERGE_TTD --netwo
 ETHEREUMJS_EXTRA_ARGS="--network sepolia $ETHEREUMJS_FIXED_VARS"
 
 BESU_EXTRA_ARGS="--network=sepolia --network-id=$NETWORK_ID $BESU_FIXED_VARS"
+
+ERIGON_EXTRA_ARGS="erigon --chain=sepolia --networkid=$NETWORK_ID --override.terminaltotaldifficulty=$MERGE_TTD $ERIGON_FIXED_VARS"
 
 EXTRA_BOOTNODES=""

--- a/merge-scripts/setup.sh
+++ b/merge-scripts/setup.sh
@@ -20,7 +20,7 @@ gethImage=$GETH_IMAGE
 nethermindImage=$NETHERMIND_IMAGE
 
 
-mkdir $dataDir && mkdir $dataDir/lodestar && mkdir $dataDir/geth && mkdir $dataDir/nethermind && mkdir $dataDir/ethereumjs && mkdir $dataDir/besu
+mkdir $dataDir && mkdir $dataDir/lodestar && mkdir $dataDir/geth && mkdir $dataDir/nethermind && mkdir $dataDir/ethereumjs && mkdir $dataDir/besu && mkdir $dataDir/erigon
 
 if [ -n "$configGitDir" ]
 then
@@ -122,6 +122,9 @@ then
     elif [ "$elClient" == "besu" ]
     then
       $dockerExec pull $BESU_IMAGE
+    elif [ "$elClient" == "erigon" ]
+    then
+      $dockerExec pull $ERIGON_IMAGE
     fi;
   fi;
 
@@ -189,6 +192,19 @@ then
     elCmd="$elCmd $BESU_IMAGE"
   fi;
   elCmd="$elCmd $BESU_EXTRA_ARGS"
+elif [ "$elClient" == "erigon" ] 
+then
+  echo "erigonImage: $ERIGON_IMAGE"
+
+  elName="$DEVNET_NAME-erigon"
+  elCmd="$dockerCmd --name $elName $elDockerNetwork -v $currentDir/$dataDir:/data"
+  if [ -n "$configGitDir" ]
+  then
+    elCmd="$elCmd -v $currentDir/$dataDir/$configGitDir:/config  $ERIGON_IMAGE --bootnodes=$EXTRA_BOOTNODES$bootNode"
+  else
+    elCmd="$elCmd $ERIGON_IMAGE"
+  fi;
+  elCmd="$elCmd $ERIGON_EXTRA_ARGS"
 fi
 
 echo "lodestarImage: $LODESTAR_IMAGE"

--- a/merge-scripts/validate.sh
+++ b/merge-scripts/validate.sh
@@ -66,9 +66,9 @@ then
 fi;
 
 
-if [ -n "$justCL" ] && [ -n "$justVC" ]  && ([ "$elClient" != "geth" ] && [ "$elClient" != "nethermind" ] && [ "$elClient" != "ethereumjs" ] && [ "$elClient" != "besu" ]) 
+if [ -n "$justCL" ] && [ -n "$justVC" ]  && ([ "$elClient" != "geth" ] && [ "$elClient" != "nethermind" ] && [ "$elClient" != "ethereumjs" ] && [ "$elClient" != "besu" ] && [ "$elClient" != "erigon" ]) 
 then
-  echo "To run EL client you need to provide one of --elClient <geth | nethermind | ethereumjs | besu>, exiting ...";
+  echo "To run EL client you need to provide one of --elClient <geth | nethermind | ethereumjs | besu | erigon>, exiting ...";
   exit;
 fi
 


### PR DESCRIPTION
**Motivation**

We currently support Geth, Nethermind and Besu for execution clients in our merge script. This PR adds the final EL client for maximum coverage and ensuring compatibility of Lodestar to maximize client diversity.

**Description**

This PR integrates the standard args and default parameters required to start Erigon alongside Lodestar.

Note that by default, Erigon has private gRPC connections located at port 9090 which may conflict with Prometheus if trying to plug in our metrics, and hence has been turned off. If you need this, you can enable this at a different port, or make the appropriate adjustments to lodestar Prometheus configurations.

For e.g.
You can reconfig Erigon with `--private.api.addr=127.0.0.1:9090` in `fixed.vars`

Also includes an update to a deprecating flag for Besu's authenticated RPC port.

Closes #4285 