### PR TITLE
Produce block: filter out incompatible shuffling attestations

### DIFF
--- a/packages/beacon-node/src/chain/factory/block/body.ts
+++ b/packages/beacon-node/src/chain/factory/block/body.ts
@@ -75,7 +75,7 @@ export async function assembleBody<T extends BlockType>(
   // }
 
   const [attesterSlashings, proposerSlashings, voluntaryExits] = chain.opPool.getSlashingsAndExits(currentState);
-  const attestations = chain.aggregatedAttestationPool.getAttestationsForBlock(currentState);
+  const attestations = chain.aggregatedAttestationPool.getAttestationsForBlock(chain.forkChoice, currentState);
   const {eth1Data, deposits} = await chain.eth1.getEth1DataAndDeposits(currentState);
 
   const blockBody: phase0.BeaconBlockBody = {

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -12,8 +12,11 @@ import {
   CachedBeaconStatePhase0,
   CachedBeaconStateAltair,
   computeEpochAtSlot,
+  computeStartSlotAtEpoch,
+  getBlockRootAtSlot,
 } from "@lodestar/state-transition";
 import {toHexString} from "@chainsafe/ssz";
+import {IForkChoice} from "@lodestar/fork-choice";
 import {MapDef} from "../../util/map.js";
 import {intersectUint8Arrays, IntersectResult} from "../../util/bitArray.js";
 import {pruneBySlot} from "./utils.js";
@@ -102,7 +105,7 @@ export class AggregatedAttestationPool {
   /**
    * Get attestations to be included in a block. Returns $MAX_ATTESTATIONS items
    */
-  getAttestationsForBlock(state: CachedBeaconStateAllForks): phase0.Attestation[] {
+  getAttestationsForBlock(forkChoice: IForkChoice, state: CachedBeaconStateAllForks): phase0.Attestation[] {
     const stateSlot = state.slot;
     const stateEpoch = state.epochCtx.epoch;
     const statePrevEpoch = stateEpoch - 1;
@@ -112,7 +115,6 @@ export class AggregatedAttestationPool {
     const attestationsByScore: AttestationWithScore[] = [];
 
     const slots = Array.from(this.attestationGroupByDataHashBySlot.keys()).sort((a, b) => b - a);
-    const {previousJustifiedCheckpoint, currentJustifiedCheckpoint} = state;
     slot: for (const slot of slots) {
       const attestationGroupByDataHash = this.attestationGroupByDataHashBySlot.get(slot);
       // should not happen
@@ -132,14 +134,7 @@ export class AggregatedAttestationPool {
 
       const attestationGroups = Array.from(attestationGroupByDataHash.values());
       for (const attestationGroup of attestationGroups) {
-        if (
-          !isValidAttestationData(
-            stateEpoch,
-            previousJustifiedCheckpoint,
-            currentJustifiedCheckpoint,
-            attestationGroup.data
-          )
-        ) {
+        if (!isValidAttestationData(forkChoice, state, attestationGroup.data)) {
           continue;
         }
         const participation = getParticipation(epoch, attestationGroup.committee);
@@ -403,23 +398,56 @@ export function extractParticipation(
 }
 
 /**
- * The state transition accepts incorrect target and head attestations.
- * We only need to validate the source checkpoint.
+ * Do those validations:
+ *   - Validate the source checkpoint
+ *   - Since we validated attestation's signature in gossip validation function,
+ *     we only need to validate the shuffling of attestation
+ *     is compatible to this state.
+ *     (see https://github.com/ChainSafe/lodestar/issues/4333)
  * @returns
  */
 export function isValidAttestationData(
-  currentEpoch: Epoch,
-  previousJustifiedCheckpoint: phase0.Checkpoint,
-  currentJustifiedCheckpoint: phase0.Checkpoint,
+  forkChoice: IForkChoice,
+  state: CachedBeaconStateAllForks,
   data: phase0.AttestationData
 ): boolean {
+  const {previousJustifiedCheckpoint, currentJustifiedCheckpoint} = state;
   let justifiedCheckpoint;
-  if (data.target.epoch === currentEpoch) {
+  const stateEpoch = state.epochCtx.epoch;
+  const targetEpoch = data.target.epoch;
+
+  if (targetEpoch === stateEpoch) {
     justifiedCheckpoint = currentJustifiedCheckpoint;
-  } else {
+  } else if (targetEpoch === stateEpoch - 1) {
     justifiedCheckpoint = previousJustifiedCheckpoint;
+  } else {
+    return false;
   }
-  return ssz.phase0.Checkpoint.equals(data.source, justifiedCheckpoint);
+
+  if (!ssz.phase0.Checkpoint.equals(data.source, justifiedCheckpoint)) return false;
+
+  // Shuffling can't have changed if we're in the first few epochs
+  if (stateEpoch < 2) {
+    return true;
+  }
+  // Otherwise the shuffling is determined by the block at the end of the target epoch
+  // minus the shuffling lookahead (usually 2). We call this the "pivot".
+  const pivotSlot = computeStartSlotAtEpoch(targetEpoch - 1) - 1;
+  const statePivotBlockRoot = toHexString(getBlockRootAtSlot(state, pivotSlot));
+
+  // Use fork choice's view of the block DAG to quickly evaluate whether the attestation's
+  // pivot block is the same as the current state's pivot block. If it is, then the
+  // attestation's shuffling is the same as the current state's.
+  // To account for skipped slots, find the first block at *or before* the pivot slot.
+  let pivotBlockRoot = "";
+  for (const protoBlock of forkChoice.iterateAncestorBlocks(toHexString(data.beaconBlockRoot))) {
+    if (protoBlock.slot <= pivotSlot) {
+      pivotBlockRoot = protoBlock.blockRoot;
+      break;
+    }
+  }
+
+  return pivotBlockRoot === statePivotBlockRoot;
 }
 
 function flagIsTimelySource(flag: number): boolean {

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -439,14 +439,7 @@ export function isValidAttestationData(
   // pivot block is the same as the current state's pivot block. If it is, then the
   // attestation's shuffling is the same as the current state's.
   // To account for skipped slots, find the first block at *or before* the pivot slot.
-  let pivotBlockRoot = "";
-  for (const protoBlock of forkChoice.iterateAncestorBlocks(toHexString(data.beaconBlockRoot))) {
-    if (protoBlock.slot <= pivotSlot) {
-      pivotBlockRoot = protoBlock.blockRoot;
-      break;
-    }
-  }
-
+  const pivotBlockRoot = forkChoice.findAttesterDependentRoot(data.beaconBlockRoot);
   return pivotBlockRoot === statePivotBlockRoot;
 }
 

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -266,6 +266,7 @@ function mockForkChoice(): IForkChoice {
     getBlockSummariesAtSlot: () => [block],
     getCommonAncestorDistance: () => null,
     validateLatestHash: () => {},
+    findAttesterDependentRoot: () => block.blockRoot,
   };
 }
 

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -155,6 +155,8 @@ export interface IForkChoice {
    * Optimistic sync validate till validated latest hash, invalidate any decendant branch if invalidated branch decendant provided
    */
   validateLatestHash(latestValidHash: RootHex, invalidateTillHash: RootHex | null): void;
+  /** Find attester dependent root of a block */
+  findAttesterDependentRoot(headBlockHash: Root): RootHex | null;
 }
 
 /** Same to the PowBlock but we want RootHex to work with forkchoice conveniently */

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -1,6 +1,9 @@
 import {expect} from "chai";
 import {config} from "@lodestar/config/default";
 import {fromHexString} from "@chainsafe/ssz";
+import {RootHex} from "@lodestar/types";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {ForkChoice, IForkChoiceStore, ProtoBlock, ProtoArray, ExecutionStatus} from "../../../src/index.js";
 
 describe("Forkchoice", function () {
@@ -8,52 +11,36 @@ describe("Forkchoice", function () {
   const genesisEpoch = 0;
   const genesisRoot = "0x0000000000000000000000000000000000000000000000000000000000000000";
 
-  const stateRoot = "0xb021a96da54dd89dfafc0e8817e23fe708f5746e924855f49b3f978133c3ac6a";
+  // missing 2 last chars
+  const stateRootPrefix = "0xb021a96da54dd89dfafc0e8817e23fe708f5746e924855f49b3f978133c3ac";
   const finalizedRoot = "0x86d2ebb56a21be95b9036f4596ff4feaa336acf5fd8739cf39f5d58955b1295b";
   const parentRoot = "0x853d08094d83f1db67159144db54ec0c882eb9715184c4bde8f4191c926a1671";
-  const finalizedDesc = "0x37487efdbfbeeb82d7d35c6eb96438c4576f645b0f4c0386184592abab4b1736";
+  // missing 2 last chars
+  const blockRootPrefix = "0x37487efdbfbeeb82d7d35c6eb96438c4576f645b0f4c0386184592abab4b17";
+  let protoArr: ProtoArray;
 
-  const protoArr = ProtoArray.initialize(
-    {
-      slot: genesisSlot,
-      stateRoot,
-      parentRoot,
-      blockRoot: finalizedRoot,
+  beforeEach(() => {
+    protoArr = ProtoArray.initialize(
+      {
+        slot: genesisSlot,
+        stateRoot: getStateRoot(genesisSlot),
+        parentRoot,
+        blockRoot: finalizedRoot,
 
-      justifiedEpoch: genesisEpoch,
-      justifiedRoot: genesisRoot,
-      finalizedEpoch: genesisEpoch,
-      finalizedRoot: genesisRoot,
+        justifiedEpoch: genesisEpoch,
+        justifiedRoot: genesisRoot,
+        finalizedEpoch: genesisEpoch,
+        finalizedRoot: genesisRoot,
 
-      executionPayloadBlockHash: null,
-      executionStatus: ExecutionStatus.PreMerge,
-    } as Omit<ProtoBlock, "targetRoot">,
-    genesisSlot
-  );
-
-  // Add block that is a finalized descendant.
-  const block: ProtoBlock = {
-    slot: genesisSlot + 1,
-    blockRoot: finalizedDesc,
-    parentRoot: finalizedRoot,
-    stateRoot,
-    targetRoot: finalizedRoot,
-
-    justifiedEpoch: genesisEpoch,
-    justifiedRoot: genesisRoot,
-    finalizedEpoch: genesisEpoch,
-    finalizedRoot: genesisRoot,
-    unrealizedJustifiedEpoch: genesisEpoch,
-    unrealizedJustifiedRoot: genesisRoot,
-    unrealizedFinalizedEpoch: genesisEpoch,
-    unrealizedFinalizedRoot: genesisRoot,
-
-    executionPayloadBlockHash: null,
-    executionStatus: ExecutionStatus.PreMerge,
-  };
+        executionPayloadBlockHash: null,
+        executionStatus: ExecutionStatus.PreMerge,
+      } as Omit<ProtoBlock, "targetRoot">,
+      genesisSlot
+    );
+  });
 
   const fcStore: IForkChoiceStore = {
-    currentSlot: block.slot,
+    currentSlot: genesisSlot + 1,
     justified: {
       checkpoint: {epoch: genesisEpoch, root: fromHexString(finalizedRoot), rootHex: finalizedRoot},
       balances: new Uint8Array([32]),
@@ -71,12 +58,99 @@ describe("Forkchoice", function () {
     justifiedBalancesGetter: () => new Uint8Array([32]),
   };
 
+  const getBlockRoot = (slot: number): RootHex => {
+    if (slot === genesisSlot) return finalizedRoot;
+    return blockRootPrefix + (slot < 10 ? "0" + slot : slot);
+  };
+
+  const getStateRoot = (slot: number): RootHex => {
+    return stateRootPrefix + (slot < 10 ? "0" + slot : slot);
+  };
+
+  const getParentBlockRoot = (slot: number, skippedSlots: number[] = []): RootHex => {
+    slot -= 1;
+    while (slot >= 0) {
+      if (!skippedSlots.includes(slot)) return getBlockRoot(slot);
+      slot -= 1;
+    }
+    throw Error("Not found parent slot for slot" + slot);
+  };
+
+  const getTargetRoot = (slot: number, skippedSlots: number[] = []): RootHex => {
+    let targetSlot = computeEpochAtSlot(slot) * SLOTS_PER_EPOCH;
+    if (targetSlot === genesisSlot) return finalizedRoot;
+    while (targetSlot > 0) {
+      if (!skippedSlots.includes(targetSlot)) return getBlockRoot(targetSlot);
+      targetSlot -= 1;
+    }
+    throw Error("Not found target slot for slot " + slot);
+  };
+
+  const getBlock = (slot: number, skippedSlots: number[] = []): ProtoBlock => {
+    return {
+      slot,
+      blockRoot: getBlockRoot(slot),
+      parentRoot: getParentBlockRoot(slot, skippedSlots),
+      stateRoot: getStateRoot(slot),
+      targetRoot: getTargetRoot(slot, skippedSlots),
+
+      justifiedEpoch: genesisEpoch,
+      justifiedRoot: genesisRoot,
+      finalizedEpoch: genesisEpoch,
+      finalizedRoot: genesisRoot,
+      unrealizedJustifiedEpoch: genesisEpoch,
+      unrealizedJustifiedRoot: genesisRoot,
+      unrealizedFinalizedEpoch: genesisEpoch,
+      unrealizedFinalizedRoot: genesisRoot,
+
+      executionPayloadBlockHash: null,
+      executionStatus: ExecutionStatus.PreMerge,
+    };
+  };
+
+  const populateProtoArray = (tillSlot: number, skippedSlots: number[] = []): void => {
+    for (let slot = genesisSlot + 1; slot <= tillSlot; slot++) {
+      if (!skippedSlots.includes(slot)) {
+        const block = getBlock(slot, skippedSlots);
+        protoArr.onBlock(block, block.slot);
+      }
+    }
+  };
+
   it("getAllAncestorBlocks", function () {
+    // Add block that is a finalized descendant.
+    const block = getBlock(genesisSlot + 1);
     protoArr.onBlock(block, block.slot);
     const forkchoice = new ForkChoice(config, fcStore, protoArr);
-    const summaries = forkchoice.getAllAncestorBlocks(finalizedDesc);
+    const summaries = forkchoice.getAllAncestorBlocks(getBlockRoot(genesisSlot + 1));
     // there are 2 blocks in protoArray but iterateAncestorBlocks should only return non-finalized blocks
     expect(summaries.length).to.be.equals(1, "should not return the finalized block");
     expect(summaries[0]).to.be.deep.include(block, "the block summary is not correct");
   });
+
+  const dependentRootTestCases = [
+    {name: "no skipped lot", skippedSlots: [], pivotSlot: 31},
+    {name: "skipped pivot slot 31", skippedSlots: [31], pivotSlot: 30},
+    {name: "skipped pivot slot 31, 30", skippedSlots: [31, 30], pivotSlot: 29},
+    {name: "skipped slot 33 to 64", skippedSlots: Array.from({length: 32}, (_, i) => i + 33), pivotSlot: 31},
+    {name: "skipped slot 32 to 64", skippedSlots: Array.from({length: 33}, (_, i) => i + 32), pivotSlot: 31},
+    {name: "skipped slot 31 to 64", skippedSlots: Array.from({length: 34}, (_, i) => i + 31), pivotSlot: 30},
+    {name: "skipped slot 30 to 64", skippedSlots: Array.from({length: 35}, (_, i) => i + 30), pivotSlot: 29},
+  ];
+
+  for (const {name, skippedSlots, pivotSlot} of dependentRootTestCases) {
+    it(`findAttesterDependentRoot - ${name}`, () => {
+      const slot = 2 * 32 + 5;
+      populateProtoArray(slot, skippedSlots);
+      const forkchoice = new ForkChoice(config, fcStore, protoArr);
+      const blockRoot = getBlockRoot(slot);
+      const pivotRoot = getBlockRoot(pivotSlot);
+      expect(forkchoice.findAttesterDependentRoot(fromHexString(blockRoot))).to.be.equal(
+        pivotRoot,
+        "incorrect attester dependent root"
+      );
+    });
+  }
+
+  // TODO: more unit tests for other apis
 });


### PR DESCRIPTION
**Motivation**

Lodestar includes incompatible shuffling attestations when producing a block, see https://github.com/ChainSafe/lodestar/issues/4333#issuecomment-1191471214

**Description**

+ Filter out incompatible shuffling attestations based on forkchoice and attester dependent root in state
+ Refer to lighthouse's implementation: https://github.com/sigp/lighthouse/blob/21dec6f603edd53ad8d2372941c77ab8098d3b5a/beacon_node/beacon_chain/src/beacon_chain.rs#L1933

Closes #4333

**TODOs**

- [x] Deploy to a node
- [x] Issue curl to produce blocks, make sure there are enough attestations returned