### PR TITLE
Add mev-integration.md to docs navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
       - Local testnet: usage/local.md
       - Validator management: usage/validator-management.md
       - Prometheus & Grafana Setup: usage/prometheus-grafana.md
+      - MEV Builder Integration: usage/mev-integration.md 
   - Reference:
       - Command line: reference/cli.md
   - Libraries: libraries/index.md


### PR DESCRIPTION
**Motivation**

`mev-integration.md` is not listed in the docs navigation.

**Description**

Adding line in navigation to ensure it's accessible from the left hand navigation within our docs.
An addendum to #4329 
