### PR TITLE
msgIdFn: use Buffer.subarray()

### DIFF
--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -13,7 +13,7 @@ import {GossipTopicCache} from "./topic.js";
  */
 export function fastMsgIdFn(rpcMsg: RPC.IMessage): string {
   if (rpcMsg.data) {
-    return Buffer.from(digest(rpcMsg.data)).slice(0, 8).toString("hex");
+    return Buffer.from(digest(rpcMsg.data)).subarray(0, 8).toString("hex");
   } else {
     return "0000000000000000";
   }
@@ -53,7 +53,7 @@ export function msgIdFn(gossipTopicCache: GossipTopicCache, msg: GossipsubMessag
     }
   }
 
-  return Buffer.from(digest(Buffer.concat(vec))).slice(0, 20);
+  return Buffer.from(digest(Buffer.concat(vec))).subarray(0, 20);
 }
 
 export class DataTransformSnappy {

--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -53,7 +53,7 @@ export function msgIdFn(gossipTopicCache: GossipTopicCache, msg: GossipsubMessag
     }
   }
 
-  return digest(Buffer.concat(vec)).slice(0, 20);
+  return Buffer.from(digest(Buffer.concat(vec))).slice(0, 20);
 }
 
 export class DataTransformSnappy {

--- a/packages/beacon-node/src/util/multifork.ts
+++ b/packages/beacon-node/src/util/multifork.ts
@@ -43,13 +43,13 @@ export function getSignedBlockTypeFromBytes(
 }
 
 export function getSlotFromBytes(bytes: Buffer | Uint8Array): Slot {
-  return bytesToInt(bytes.slice(SLOT_BYTES_POSITION_IN_BLOCK, SLOT_BYTES_POSITION_IN_BLOCK + SLOT_BYTE_COUNT));
+  return bytesToInt(bytes.subarray(SLOT_BYTES_POSITION_IN_BLOCK, SLOT_BYTES_POSITION_IN_BLOCK + SLOT_BYTE_COUNT));
 }
 
 export function getStateTypeFromBytes(
   config: IChainForkConfig,
   bytes: Buffer | Uint8Array
 ): allForks.AllForksSSZTypes["BeaconState"] {
-  const slot = bytesToInt(bytes.slice(SLOT_BYTES_POSITION_IN_STATE, SLOT_BYTES_POSITION_IN_STATE + SLOT_BYTE_COUNT));
+  const slot = bytesToInt(bytes.subarray(SLOT_BYTES_POSITION_IN_STATE, SLOT_BYTES_POSITION_IN_STATE + SLOT_BYTE_COUNT));
   return config.getForkTypes(slot).BeaconState;
 }


### PR DESCRIPTION
**Motivation**

`Buffer.slice()` only create a view of the Buffer instead of creating a copy so we should use it instead of `Uint8Array.slice()`

**Description**

- Use `Buffer.slice()` in `msgIdFn` function like other places
