### PR TITLE
Use protobufjs with libp2p-gossipsub

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -103,7 +103,7 @@
     "@chainsafe/as-sha256": "^0.3.1",
     "@chainsafe/bls": "7.1.1",
     "@chainsafe/discv5": "^1.1.1",
-    "@chainsafe/libp2p-gossipsub": "^3.1.0",
+    "@chainsafe/libp2p-gossipsub": "https://github.com/tuyennhv/js-libp2p-gossipsub.git#tuyen/protobufjs",
     "@chainsafe/libp2p-noise": "7.0.1",
     "@lodestar/api": "^0.39.0",
     "@lodestar/state-transition": "^0.39.0",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -103,7 +103,7 @@
     "@chainsafe/as-sha256": "^0.3.1",
     "@chainsafe/bls": "7.1.1",
     "@chainsafe/discv5": "^1.1.1",
-    "@chainsafe/libp2p-gossipsub": "https://github.com/tuyennhv/js-libp2p-gossipsub.git#tuyen/protobufjs",
+    "@chainsafe/libp2p-gossipsub": "git+https://github.com/tuyennhv/js-libp2p-gossipsub.git#tuyen/protobufjs",
     "@chainsafe/libp2p-noise": "7.0.1",
     "@lodestar/api": "^0.39.0",
     "@lodestar/state-transition": "^0.39.0",

--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -11,7 +11,7 @@ import {GossipTopicCache} from "./topic.js";
  * The function used to generate a gossipsub message id
  * We use the first 8 bytes of SHA256(data) for content addressing
  */
-export function fastMsgIdFn(rpcMsg: RPC.Message): string {
+export function fastMsgIdFn(rpcMsg: RPC.IMessage): string {
   if (rpcMsg.data) {
     return Buffer.from(digest(rpcMsg.data)).slice(0, 8).toString("hex");
   } else {

--- a/packages/beacon-node/tsconfig.build.json
+++ b/packages/beacon-node/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "compilerOptions": {
     "outDir": "lib",
+    "checkJs": false,
     "typeRoots": ["../../node_modules/@types", "./node_modules/@types", "../../types"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -520,9 +520,9 @@
   optionalDependencies:
     "@node-rs/crc32" "1.1.0"
 
-"@chainsafe/libp2p-gossipsub@https://github.com/tuyennhv/js-libp2p-gossipsub.git#tuyen/protobufjs":
+"@chainsafe/libp2p-gossipsub@git+https://github.com/tuyennhv/js-libp2p-gossipsub.git#tuyen/protobufjs":
   version "3.3.0"
-  resolved "https://github.com/tuyennhv/js-libp2p-gossipsub.git#b2c2751b2a899ddf4142b0de2b84fe80148f501e"
+  resolved "git+https://github.com/tuyennhv/js-libp2p-gossipsub.git#7c49b3ca7ffc3beb2d6d907d544f0e4ec0990c39"
   dependencies:
     "@libp2p/components" "^2.0.0"
     "@libp2p/crypto" "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -520,10 +520,9 @@
   optionalDependencies:
     "@node-rs/crc32" "1.1.0"
 
-"@chainsafe/libp2p-gossipsub@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-3.1.0.tgz#7855302c6c370016ceb1b8c88afd2971042a09fd"
-  integrity sha512-N8vO5QG5tHqEPYPtDHOYEXE0MK3BPkIR80thx7KtCqeNOzR4B5l94XlSN2YzytTTg6tvjbR4ZGqFLoTocMRxBg==
+"@chainsafe/libp2p-gossipsub@https://github.com/tuyennhv/js-libp2p-gossipsub.git#tuyen/protobufjs":
+  version "3.3.0"
+  resolved "https://github.com/tuyennhv/js-libp2p-gossipsub.git#b2c2751b2a899ddf4142b0de2b84fe80148f501e"
   dependencies:
     "@libp2p/components" "^2.0.0"
     "@libp2p/crypto" "^1.0.0"
@@ -541,12 +540,11 @@
     abortable-iterator "^4.0.2"
     denque "^1.5.0"
     err-code "^3.0.1"
-    iso-random-stream "^2.0.2"
     it-length-prefixed "^7.0.1"
     it-pipe "^2.0.3"
     it-pushable "^3.0.0"
     multiformats "^9.6.4"
-    protons-runtime "^1.0.4"
+    protobufjs "^6.11.2"
     uint8arrays "^3.0.0"
 
 "@chainsafe/libp2p-noise@7.0.1":
@@ -7423,14 +7421,6 @@ iso-random-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-2.0.0.tgz"
   integrity sha512-lGuIu104KfBV9ubYTSaE3GeAr6I69iggXxBHbTBc5u/XKlwlWl0LCytnkIZissaKqvxablwRD9B3ktVnmIUnEg==
-  dependencies:
-    events "^3.3.0"
-    readable-stream "^3.4.0"
-
-iso-random-stream@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-2.0.2.tgz"
-  integrity sha512-yJvs+Nnelic1L2vH2JzWvvPQFA4r7kSTnpST/+LkAQjSz0hos2oqLD+qIVi9Qk38Hoe7mNDt3j0S27R58MVjLQ==
   dependencies:
     events "^3.3.0"
     readable-stream "^3.4.0"


### PR DESCRIPTION
**Motivation**

Try https://github.com/ChainSafe/js-libp2p-gossipsub/pull/310 before gossipsub-js is released

**Description**

Deployed to:
- ct-vpsm-dev-3
- hz-ax41-dev-3
