### PR TITLE
Add eth1.forcedEth1DataVote hidden flag

### DIFF
--- a/packages/beacon-node/src/eth1/options.ts
+++ b/packages/beacon-node/src/eth1/options.ts
@@ -9,6 +9,11 @@ export type Eth1Options = {
   jwtSecretHex?: string;
   depositContractDeployBlock?: number;
   unsafeAllowDepositDataOverwrite: boolean;
+  /**
+   * Vote for a specific eth1_data regardless of validity and existing votes.
+   * hex encoded ssz serialized Eth1Data type.
+   */
+  forcedEth1DataVote?: string;
 };
 
 export const defaultEth1Options: Eth1Options = {

--- a/packages/cli/src/options/beaconNodeOptions/eth1.ts
+++ b/packages/cli/src/options/beaconNodeOptions/eth1.ts
@@ -10,6 +10,7 @@ export interface IEth1Args {
   "eth1.depositContractDeployBlock": number;
   "eth1.disableEth1DepositDataTracker": boolean;
   "eth1.unsafeAllowDepositDataOverwrite": boolean;
+  "eth1.forcedEth1DataVote": string;
 }
 
 export function parseArgs(args: IEth1Args & Partial<ExecutionEngineArgs>): IBeaconNodeOptions["eth1"] {
@@ -39,6 +40,7 @@ export function parseArgs(args: IEth1Args & Partial<ExecutionEngineArgs>): IBeac
     depositContractDeployBlock: args["eth1.depositContractDeployBlock"],
     disableEth1DepositDataTracker: args["eth1.disableEth1DepositDataTracker"],
     unsafeAllowDepositDataOverwrite: args["eth1.unsafeAllowDepositDataOverwrite"],
+    forcedEth1DataVote: args["eth1.forcedEth1DataVote"],
   };
 }
 
@@ -86,6 +88,13 @@ export const options: ICliCommandOptions<IEth1Args> = {
       "Allow the deposit tracker to overwrite previously fetched and saved deposit event data. Warning!!! This is an unsafe operation, so enable this flag only if you know what you are doing.",
     type: "boolean",
     defaultDescription: String(defaultOptions.eth1.unsafeAllowDepositDataOverwrite),
+    group: "eth1",
+  },
+
+  "eth1.forcedEth1DataVote": {
+    hidden: true,
+    description: "Vote for a specific eth1_data regardless of all conditions. Hex encoded ssz serialized Eth1Data type",
+    type: "string",
     group: "eth1",
   },
 };

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -33,6 +33,8 @@ describe("options / beaconNodeOptions", () => {
       "eth1.depositContractDeployBlock": 1625314,
       "eth1.disableEth1DepositDataTracker": true,
       "eth1.unsafeAllowDepositDataOverwrite": false,
+      "eth1.forcedEth1DataVote":
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 
       "execution.urls": ["http://localhost:8551"],
       "execution.timeout": 12000,
@@ -100,6 +102,8 @@ describe("options / beaconNodeOptions", () => {
         depositContractDeployBlock: 1625314,
         disableEth1DepositDataTracker: true,
         unsafeAllowDepositDataOverwrite: false,
+        forcedEth1DataVote:
+          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
       },
       executionEngine: {
         urls: ["http://localhost:8551"],


### PR DESCRIPTION
**Motivation**

In testnets there has been instances where eth1 data voting gets stuck due to some issue in the logic and client. Specifically in a devnet eth1_data for genesis was stuck with an invalid block hash. To unstuck the voting and move the chain forward it was very useful to intervene with this patch and force one voting period into a hand picked value.

Note: this feature is meant to be exclusively used by experienced core developers under exceptional circumstances

**Description**

Add eth1.forcedEth1DataVote hidden flag