### PR TITLE
Add execution status to notifier on/post bellatrix

### DIFF
--- a/packages/beacon-node/src/node/notifier.ts
+++ b/packages/beacon-node/src/node/notifier.ts
@@ -157,10 +157,15 @@ function getExecutionInfo(
   } else {
     const executionStatusStr = headInfo.executionStatus.toLowerCase();
 
-    if (isBellatrixCachedStateType(headState) && isMergeTransitionComplete(headState)) {
-      return [`execution: ${executionStatusStr}(${prettyBytes(headInfo.executionPayloadBlockHash ?? "empty")})`];
+    // Add execution status to notifier only if head is on/post bellatrix
+    if (isBellatrixCachedStateType(headState)) {
+      if (isMergeTransitionComplete(headState)) {
+        return [`execution: ${executionStatusStr}(${prettyBytes(headInfo.executionPayloadBlockHash ?? "empty")})`];
+      } else {
+        return [`execution: ${executionStatusStr}`];
+      }
     } else {
-      return [`execution: ${executionStatusStr}`];
+      return [];
     }
   }
 }


### PR DESCRIPTION
Right now, we can see `execution: premerge -`, while its a good idea to show it only post bellatrix, and can also act as an indication for the user if lodestar's head is post bellatrix (There can still be time between bellatrix transition and the merge where premerge text transforms into the actual execution status)