### PR TITLE
Add metrics to LightClientServer

### DIFF
--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -183,6 +183,23 @@ export class LightClientServer {
       finalizedHeader: ssz.phase0.BeaconBlockHeader.defaultValue(),
       finalityBranch: ssz.altair.LightClientUpdate.fields["finalityBranch"].defaultValue(),
     };
+
+    if (metrics) {
+      metrics.lightclientServer.highestSlot.addCollect(() => {
+        if (this.latestHeadUpdate) {
+          metrics.lightclientServer.highestSlot.set(
+            {item: "latest_head_update"},
+            this.latestHeadUpdate.attestedHeader.slot
+          );
+        }
+        if (this.finalized) {
+          metrics.lightclientServer.highestSlot.set(
+            {item: "latest_finalized_update"},
+            this.finalized.attestedHeader.slot
+          );
+        }
+      });
+    }
   }
 
   /**
@@ -211,6 +228,7 @@ export class LightClientServer {
 
     this.onSyncAggregate(syncPeriod, block.body.syncAggregate, signedBlockRoot).catch((e) => {
       this.logger.error("Error onSyncAggregate", {}, e);
+      this.metrics?.lightclientServer.onSyncAggregate.inc({event: "error"});
     });
 
     this.persistPostBlockImportData(block, postState, parentBlockSlot).catch((e) => {
@@ -439,20 +457,22 @@ export class LightClientServer {
     syncAggregate: altair.SyncAggregate,
     signedBlockRoot: Root
   ): Promise<void> {
+    this.metrics?.lightclientServer.onSyncAggregate.inc({event: "processed"});
+
     const signedBlockRootHex = toHexString(signedBlockRoot);
     const attestedData = this.prevHeadData.get(signedBlockRootHex);
     if (!attestedData) {
-      // Check for .size > 0 to prevent erroring always in the first run
-      if (this.prevHeadData.size === 0) {
-        return;
-      } else {
-        throw Error(`attestedData for ${signedBlockRootHex} not available`);
-      }
+      // Log cacheSize since at start this.prevHeadData will be empty
+      this.logger.debug("attestedData not available", {root: signedBlockRootHex, cacheSize: this.prevHeadData.size});
+      this.metrics?.lightclientServer.onSyncAggregate.inc({event: "ignore_no_attested_data"});
+      return;
     }
 
     const attestedPeriod = computeSyncPeriodAtSlot(attestedData.attestedHeader.slot);
     if (syncPeriod !== attestedPeriod) {
-      throw new Error("attested data period different than signature period");
+      this.logger.debug("attested data period different than signature period", {syncPeriod, attestedPeriod});
+      this.metrics?.lightclientServer.onSyncAggregate.inc({event: "ignore_attested_period_diff"});
+      return;
     }
 
     const headerUpdate: routes.lightclient.LightclientOptimisticHeaderUpdate = {
@@ -469,6 +489,7 @@ export class LightClientServer {
     // TODO: Once SyncAggregate are constructed from P2P too, count bits to decide "best"
     if (!this.latestHeadUpdate || attestedData.attestedHeader.slot > this.latestHeadUpdate.attestedHeader.slot) {
       this.latestHeadUpdate = headerUpdate;
+      this.metrics?.lightclientServer.onSyncAggregate.inc({event: "update_latest_head_update"});
     }
 
     if (attestedData.isFinalized) {
@@ -487,6 +508,7 @@ export class LightClientServer {
           finalityBranch: attestedData.finalityBranch,
         };
         this.emitter.emit(ChainEvent.lightclientFinalizedUpdate, this.finalized);
+        this.metrics?.lightclientServer.onSyncAggregate.inc({event: "update_latest_finalized_update"});
       }
     }
 
@@ -505,7 +527,7 @@ export class LightClientServer {
   ): Promise<void> {
     const prevBestUpdate = await this.db.bestPartialLightClientUpdate.get(syncPeriod);
     if (prevBestUpdate && !isBetterUpdate(prevBestUpdate, syncAggregate, attestedData)) {
-      // TODO: Do metrics on how often updates are overwritten
+      this.metrics?.lightclientServer.updateNotBetter.inc();
       return;
     }
 
@@ -539,9 +561,13 @@ export class LightClientServer {
 
     // Count total persisted updates per type. DB metrics don't diff between each type.
     // The frequency of finalized vs non-finalized is critical to debug if finalizedHeader is not available
-    this.metrics?.lightclientServer.persistedUpdates.inc({
-      type: newPartialUpdate.isFinalized ? "finalized" : "non-finalized",
+    this.metrics?.lightclientServer.onSyncAggregate.inc({
+      event: newPartialUpdate.isFinalized ? "store_finalized_update" : "store_nonfinalized_update",
     });
+    this.metrics?.lightclientServer.highestSlot.set(
+      {item: newPartialUpdate.isFinalized ? "best_finalized_update" : "best_nonfinalized_update"},
+      newPartialUpdate.attestedHeader.slot
+    );
   }
 
   private async storeSyncCommittee(

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1004,10 +1004,27 @@ export function createLodestarMetrics(
     },
 
     lightclientServer: {
-      persistedUpdates: register.gauge<"type">({
-        name: "lodestar_lightclient_server_persisted_updates_total",
-        help: "Total number of persisted updates by finalized type",
-        labelNames: ["type"],
+      onSyncAggregate: register.gauge<"event">({
+        name: "lodestar_lightclient_server_on_sync_aggregate_event_total",
+        help: "Total number of relevant events onSyncAggregate fn",
+        labelNames: ["event"],
+      }),
+      highestSlot: register.gauge<"item">({
+        name: "lodestar_lightclient_server_higest_slot",
+        help: "Current highest slot of items stored by LightclientServer",
+        labelNames: ["item"],
+      }),
+      updateNotBetter: register.gauge({
+        name: "lodestar_lightclient_server_event_update_not_better_total",
+        help: "Total number of cache hits in LightclientServer.prevHeadData",
+      }),
+      attestedDataCacheMiss: register.gauge({
+        name: "lodestar_lightclient_server_attested_cache_miss_total",
+        help: "Total number of cache miss in LightclientServer.prevHeadData",
+      }),
+      attestedDataDiffPeriod: register.gauge({
+        name: "lodestar_lightclient_server_attested_data_diff_period_total",
+        help: "Total number of times a syncAggregate is a different period than attested data",
       }),
     },
 


### PR DESCRIPTION
**Motivation**

After running this implementation of the LightClientServer there are many more edge cases than anticipated, throwing too many errors in the logs.

This is bad for UX, as users must not learn to ignore errors. 

**Description**

Instead of throwing, record un-wanted incidents (like attestedData not available) as metrics, and log to debug. We would still have all data available to understand latter under which conditions that happens, which is even better than just throwing errors.

Closes https://github.com/ChainSafe/lodestar/issues/3788