### PR TITLE
Fix docker image history used tag

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -123,4 +123,5 @@ jobs:
         run: docker buildx build --push --tag chainsafe/lodestar:next --platform linux/amd64,linux/arm64 --build-arg VERSION=${{ needs.npm.outputs.version }} .
       - run: docker run chainsafe/lodestar:next --help
       # Display history to know byte size of each layer
+      # Image is available only because of the previous `docker run` command
       - run: docker image history chainsafe/lodestar:next

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -147,4 +147,5 @@ jobs:
         run: docker buildx build --push --tag chainsafe/lodestar:rc --tag chainsafe/lodestar:${{ needs.tag.outputs.tag }} --platform linux/amd64,linux/arm64 --build-arg VERSION=${{ needs.tag.outputs.tag }} .
       - run: docker run chainsafe/lodestar:${{ needs.tag.outputs.tag }} --help
       # Display history to know byte size of each layer
-      - run: docker image history chainsafe/lodestar:rc
+      # Image is available only because of the previous `docker run` command
+      - run: docker image history chainsafe/lodestar:${{ needs.tag.outputs.tag }}

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -137,4 +137,5 @@ jobs:
         run: docker buildx build --push --tag chainsafe/lodestar:latest --tag chainsafe/lodestar:${{ needs.tag.outputs.tag }} --platform linux/amd64,linux/arm64 --build-arg VERSION=${{ needs.tag.outputs.tag }} .
       - run: docker run chainsafe/lodestar:${{ needs.tag.outputs.tag }} --help
       # Display history to know byte size of each layer
-      - run: docker image history chainsafe/lodestar:latest
+      # Image is available only because of the previous `docker run` command
+      - run: docker image history chainsafe/lodestar:${{ needs.tag.outputs.tag }}


### PR DESCRIPTION
**Motivation**

Fixes a regression introduced in https://github.com/ChainSafe/lodestar/pull/4369

**Description**

When using docker buildx --push images are not available in the docker cache. In our workflow we do `docker run` to test the image running, so only that specific tag will be available