### PR TITLE
Add RootCache performance test

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -110,33 +110,31 @@ export async function importBlock(
   if (!opts.skipImportingAttestations && blockEpoch >= currentEpoch - FORK_CHOICE_ATT_EPOCH_LIMIT) {
     const attestations = block.message.body.attestations;
     const rootCache = new RootCache(postState);
-    const parentSlot = chain.forkChoice.getBlock(block.message.parentRoot)?.slot;
     const invalidAttestationErrorsByCode = new Map<string, {error: Error; count: number}>();
 
     for (const attestation of attestations) {
       try {
         const indexedAttestation = postState.epochCtx.getIndexedAttestation(attestation);
-        const targetEpoch = attestation.data.target.epoch;
+        const {target, slot, beaconBlockRoot} = attestation.data;
 
         const attDataRoot = toHexString(ssz.phase0.AttestationData.hashTreeRoot(indexedAttestation.data));
         chain.seenAggregatedAttestations.add(
-          targetEpoch,
+          target.epoch,
           attDataRoot,
           {aggregationBits: attestation.aggregationBits, trueBitCount: indexedAttestation.attestingIndices.length},
           true
         );
         // Duplicated logic from fork-choice onAttestation validation logic.
         // Attestations outside of this range will be dropped as Errors, so no need to import
-        if (targetEpoch <= currentEpoch && targetEpoch >= currentEpoch - FORK_CHOICE_ATT_EPOCH_LIMIT) {
+        if (target.epoch <= currentEpoch && target.epoch >= currentEpoch - FORK_CHOICE_ATT_EPOCH_LIMIT) {
           chain.forkChoice.onAttestation(indexedAttestation, attDataRoot);
         }
 
         // Note: To avoid slowing down sync, only register attestations within FORK_CHOICE_ATT_EPOCH_LIMIT
         chain.seenBlockAttesters.addIndices(blockEpoch, indexedAttestation.attestingIndices);
 
-        if (parentSlot !== undefined) {
-          chain.metrics?.registerAttestationInBlock(indexedAttestation, parentSlot, rootCache);
-        }
+        const correctHead = ssz.Root.equals(rootCache.getBlockRootAtSlot(slot), beaconBlockRoot);
+        chain.metrics?.registerAttestationInBlock(indexedAttestation, parentBlockSlot, correctHead);
 
         // don't want to log the processed attestations here as there are so many attestations and it takes too much disc space,
         // users may want to keep more log files instead of unnecessary processed attestations log

--- a/packages/beacon-node/src/metrics/validatorMonitor.ts
+++ b/packages/beacon-node/src/metrics/validatorMonitor.ts
@@ -1,9 +1,9 @@
-import {computeEpochAtSlot, IAttesterStatus, parseAttesterFlags, RootCache} from "@lodestar/state-transition";
+import {computeEpochAtSlot, IAttesterStatus, parseAttesterFlags} from "@lodestar/state-transition";
 import {ILogger} from "@lodestar/utils";
 import {allForks} from "@lodestar/types";
 import {IChainForkConfig} from "@lodestar/config";
 import {MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {Epoch, Slot, ValidatorIndex, ssz} from "@lodestar/types";
+import {Epoch, Slot, ValidatorIndex} from "@lodestar/types";
 import {IndexedAttestation, SignedAggregateAndProof} from "@lodestar/types/phase0";
 import {ILodestarMetrics} from "./metrics/lodestar.js";
 
@@ -40,7 +40,7 @@ export interface IValidatorMonitor {
     signedAggregateAndProof: SignedAggregateAndProof,
     indexedAttestation: IndexedAttestation
   ): void;
-  registerAttestationInBlock(indexedAttestation: IndexedAttestation, parentSlot: Slot, rootCache: RootCache): void;
+  registerAttestationInBlock(indexedAttestation: IndexedAttestation, parentSlot: Slot, correctHead: boolean): void;
   scrapeMetrics(slotClock: Slot): void;
 }
 
@@ -380,13 +380,13 @@ export function createValidatorMonitor(
     },
 
     // Register that the `indexed_attestation` was included in a *valid* `BeaconBlock`.
-    registerAttestationInBlock(indexedAttestation, parentSlot, rootCache): void {
+    registerAttestationInBlock(indexedAttestation, parentSlot, correctHead): void {
       const data = indexedAttestation.data;
       // optimal inclusion distance, not to count skipped slots between data.slot and blockSlot
       const inclusionDistance = Math.max(parentSlot - data.slot, 0) + 1;
       const delay = inclusionDistance - MIN_ATTESTATION_INCLUSION_DELAY;
       const epoch = computeEpochAtSlot(data.slot);
-      let correctHead: boolean | null = null;
+
       for (const index of indexedAttestation.attestingIndices) {
         const validator = validators.get(index);
         if (validator) {
@@ -404,9 +404,6 @@ export function createValidatorMonitor(
               summary.attestationMinBlockInclusionDistance = inclusionDistance;
             }
 
-            if (correctHead === null) {
-              correctHead = ssz.Root.equals(rootCache.getBlockRootAtSlot(data.slot), data.beaconBlockRoot);
-            }
             summary.attestationCorrectHead = correctHead;
           });
 

--- a/packages/state-transition/test/perf/util.ts
+++ b/packages/state-transition/test/perf/util.ts
@@ -60,6 +60,7 @@ export const perfStateId = `${numValidators} vs - 7PWei`;
 /** Cache interop secret keys */
 const secretKeyByModIndex = new Map<number, SecretKey>();
 const epoch = 23638;
+export const perfStateEpoch = epoch;
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types
 export function getPubkeys(vc = numValidators) {

--- a/packages/state-transition/test/perf/util/rootCache.test.ts
+++ b/packages/state-transition/test/perf/util/rootCache.test.ts
@@ -1,0 +1,34 @@
+import {itBench} from "@dapplion/benchmark";
+import {generatePerfTestCachedStatePhase0, perfStateId, perfStateEpoch} from "../util.js";
+import {State} from "../types.js";
+import {computeStartSlotAtEpoch, getBlockRootAtSlot, RootCache} from "../../../src/util/index.js";
+
+const slot = computeStartSlotAtEpoch(perfStateEpoch) - 1;
+
+describe("RootCache.getBlockRootAtSlot", () => {
+  itBench<RootCache, RootCache>({
+    id: `RootCache.getBlockRootAtSlot - ${perfStateId}`,
+    before: () => new RootCache(generatePerfTestCachedStatePhase0()),
+    beforeEach: (rootCache) => rootCache,
+    fn: (rootCache) => {
+      for (let i = 0; i <= 100; i++) {
+        rootCache.getBlockRootAtSlot(slot);
+      }
+    },
+    runsFactor: 100,
+  });
+});
+
+describe("RootCache.getBlockRootAtSlot", () => {
+  itBench<State, State>({
+    id: `state getBlockRootAtSlot - ${perfStateId}`,
+    before: () => generatePerfTestCachedStatePhase0() as State,
+    beforeEach: (state) => state,
+    fn: (state) => {
+      for (let i = 0; i <= 100; i++) {
+        getBlockRootAtSlot(state, slot);
+      }
+    },
+    runsFactor: 100,
+  });
+});


### PR DESCRIPTION
**Motivation**

RootCache may become unnecessary after merging SSZ v2.

- From https://github.com/ChainSafe/lodestar/issues/3998

**Description**

- Add performance test for RootCache
- Move RootCache out of registerAttestationInBlock

Locally I get

```
  RootCache.getBlockRootAtSlot
    ✔ RootCache.getBlockRootAtSlot - 250000 vs - 7PWei                 1.164144e+8 ops/s    8.590000 ns/op        -     573120 runs   7.15 s
    ✔ state getBlockRootAtSlot - 250000 vs - 7PWei                        974725.4 ops/s    1.025930 us/op        -       7795 runs   1.47 s
```

RootCache is faster (always will be since it's just a Map.get). But state is somewhat fast too. `1us` * 128 attestations per block is `0.13 ms` of processing time that would be added if we remove the RootCache. @tuyennhv what do you think?