### PR TITLE
Dont track getEffectiveBalanceIncrementsZeroInactive perf test

### DIFF
--- a/packages/state-transition/test/perf/util/balance.test.ts
+++ b/packages/state-transition/test/perf/util/balance.test.ts
@@ -6,6 +6,7 @@ import {getEffectiveBalanceIncrementsZeroInactive} from "../../../src/util/index
 describe("getEffectiveBalanceIncrementsZeroInactive", () => {
   itBench<State, State>({
     id: `getEffectiveBalanceIncrementsZeroInactive - ${perfStateId}`,
+    noThreshold: true,
     before: () => generatePerfTestCachedStatePhase0() as State,
     beforeEach: (state) => state.clone(),
     fn: (state) => {


### PR DESCRIPTION
**Motivation**

This performance test is very unstable in CI, triggering many false positives. See https://github.com/ChainSafe/lodestar/pull/4366#issuecomment-1206326540

**Description**

Dont track getEffectiveBalanceIncrementsZeroInactive perf test