### PR TITLE
Use snake case in REST APIs

### DIFF
--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -176,14 +176,14 @@ export function getReturnTypes(): ReturnTypes<Api> {
   return {
     writeHeapdump: sameType(),
     getLatestWeakSubjectivityCheckpointEpoch: sameType(),
-    getSyncChainsDebugState: jsonType("camel"),
-    getGossipQueueItems: jsonType("camel"),
-    getRegenQueueItems: jsonType("camel"),
-    getBlockProcessorQueueItems: jsonType("camel"),
-    getStateCacheItems: jsonType("camel"),
-    getCheckpointStateCacheItems: jsonType("camel"),
-    getGossipPeerScoreStats: jsonType("camel"),
-    getPeers: jsonType("camel"),
-    discv5GetKadValues: jsonType("camel"),
+    getSyncChainsDebugState: jsonType("snake"),
+    getGossipQueueItems: jsonType("snake"),
+    getRegenQueueItems: jsonType("snake"),
+    getBlockProcessorQueueItems: jsonType("snake"),
+    getStateCacheItems: jsonType("snake"),
+    getCheckpointStateCacheItems: jsonType("snake"),
+    getGossipPeerScoreStats: jsonType("snake"),
+    getPeers: jsonType("snake"),
+    discv5GetKadValues: jsonType("snake"),
   };
 }

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -431,6 +431,6 @@ export function getReturnTypes(): ReturnTypes<Api> {
     produceAttestationData: ContainerData(ssz.phase0.AttestationData),
     produceSyncCommitteeContribution: ContainerData(ssz.altair.SyncCommitteeContribution),
     getAggregatedAttestation: ContainerData(ssz.phase0.Attestation),
-    getLiveness: jsonType("camel"),
+    getLiveness: jsonType("snake"),
   };
 }

--- a/packages/api/src/keymanager/routes.ts
+++ b/packages/api/src/keymanager/routes.ts
@@ -231,12 +231,12 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
 /* eslint-disable @typescript-eslint/naming-convention */
 export function getReturnTypes(): ReturnTypes<Api> {
   return {
-    listKeys: jsonType("camel"),
-    importKeystores: jsonType("camel"),
-    deleteKeystores: jsonType("camel"),
+    listKeys: jsonType("snake"),
+    importKeystores: jsonType("snake"),
+    deleteKeystores: jsonType("snake"),
 
-    listRemoteKeys: jsonType("camel"),
-    importRemoteKeys: jsonType("camel"),
-    deleteRemoteKeys: jsonType("camel"),
+    listRemoteKeys: jsonType("snake"),
+    importRemoteKeys: jsonType("snake"),
+    deleteRemoteKeys: jsonType("snake"),
   };
 }


### PR DESCRIPTION
**Motivation**

`jsonType()` expects the API consumer's case as parameter, not the in-app case. Use snake as required by the spec of beacon and keymanager API, and good default for Lodestar's debug API.

Our integration tests did not catch this issue because both the API client and API itself expect the wrong case.

**Description**

Use snake in REST APIs.

- Note marking as breaking as beacon -> validator comms for doppleganger will break if not updated at once. This is okay IMO since this feature is not critical and is not enabled by default.

Closes https://github.com/ChainSafe/lodestar/issues/4370
Closes https://github.com/ChainSafe/lodestar/issues/4381
