### PR TITLE
Update outdated examples in cli reference

### DIFF
--- a/packages/cli/src/cmds/validator/import.ts
+++ b/packages/cli/src/cmds/validator/import.ts
@@ -20,7 +20,7 @@ Ethereum Foundation utility.",
 
   examples: [
     {
-      command: "account validator import --network prater --keystores $HOME/eth2.0-deposit-cli/validator_keys",
+      command: "validator import --network prater --keystores $HOME/eth2.0-deposit-cli/validator_keys",
       description: "Import validator keystores generated with the Ethereum Foundation Staking Launchpad",
     },
   ],

--- a/packages/cli/src/cmds/validator/slashingProtection/export.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/export.ts
@@ -25,7 +25,7 @@ export const exportCmd: ICliCommand<
 
   examples: [
     {
-      command: "account validator slashing-protection export --network prater --file interchange.json",
+      command: "validator slashing-protection export --network prater --file interchange.json",
       description: "Export an interchange JSON file for all validators in the slashing protection DB",
     },
   ],

--- a/packages/cli/src/cmds/validator/slashingProtection/import.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/import.ts
@@ -26,7 +26,7 @@ export const importCmd: ICliCommand<
 
   examples: [
     {
-      command: "account validator slashing-protection import --network prater --file interchange.json",
+      command: "validator slashing-protection import --network prater --file interchange.json",
       description: "Import an interchange file to the slashing protection DB",
     },
   ],


### PR DESCRIPTION
**Motivation**

The `account` command was deprecated and some of its subcommands moved under `validator`.  This PR updates sections of the documentation to also reflect this changes.