### PR TITLE
Fix write heap dump in libp2p esm branch

### DIFF
--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -21,8 +21,6 @@ export function getLodestarApi({
 
   return {
     async writeHeapdump(dirpath = ".") {
-      // Browser interop
-      if (typeof require !== "function") throw Error("NodeJS only");
 
       if (writingHeapdump) {
         throw Error("Already writing heapdump");

--- a/packages/config/src/chainConfig/networks/prater.ts
+++ b/packages/config/src/chainConfig/networks/prater.ts
@@ -26,7 +26,7 @@ export const praterChainConfig: IChainConfig = {
   ALTAIR_FORK_EPOCH: 36660,
   // Bellatrix
   BELLATRIX_FORK_VERSION: b("0x02001020"),
-  BELLATRIX_FORK_EPOCH: Infinity,
+  BELLATRIX_FORK_EPOCH: 112260,
   // Sharding
   SHARDING_FORK_VERSION: b("0x03001020"),
   SHARDING_FORK_EPOCH: Infinity,


### PR DESCRIPTION
**Motivation**

- Get heapsnapshot in libp2p-esm branch

**Description**

- Remove unnecessary `require` check
- Correct bellatrix epoch to get through deserialization issue
