### PR TITLE
Fix the merge block found condition while syncing

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -139,6 +139,10 @@ export async function verifyBlocksExecutionPayload(
     executionStatuses.push(executionStatus);
 
     const isMergeTransitionBlock =
+      // If the merge block is found, stop the search as the isMergeTransitionBlockFn condition
+      // will still evalute to true for the following blocks leading to errors (while syncing)
+      // as the preState0 still belongs to the pre state of the first block on segment
+      mergeBlockFound === null &&
       isBellatrixStateType(preState0) &&
       isBellatrixBlockBodyType(block.message.body) &&
       isMergeTransitionBlockFn(preState0, block.message.body);


### PR DESCRIPTION
Since we now eval a segment instead of going block by block, and if there are blocks following the merge block in the segment (most likely to happen while syncing), the current code tries to evaluate even following blocks as a merge block, which leads to errors:

Observed while syncing a goerli node pre-merge to post-merge

This PR fixes the same by discarding merge block eval further if the merge block is already found in segment