### PR TITLE
Reduce heap memory

### DIFF
--- a/packages/beacon-node/test/memory/stateTransitionMemTest.ts
+++ b/packages/beacon-node/test/memory/stateTransitionMemTest.ts
@@ -1,0 +1,50 @@
+import fs from "fs";
+import {createIBeaconConfig, createIChainForkConfig} from "@lodestar/config";
+import {praterChainConfig as chainConfig} from "@lodestar/config/networks";
+import {stateTransition, createCachedBeaconState, PubkeyIndexMap} from "@lodestar/state-transition";
+import {StateContextCache} from "../../src/chain/stateCache/stateContextCache.js";
+
+global.gc?.();
+const cache = new StateContextCache({metrics: null});
+
+const config = createIChainForkConfig(chainConfig);
+
+const path = "/Users/tuyennguyen/tuyen/memTest";
+
+const firstState = config.getForkTypes(3628800).BeaconState.deserializeToViewDU(fs.readFileSync(`${path}/state_3628800.ssz`));
+
+// similar to chain.ts
+let state = createCachedBeaconState(firstState, {
+  config: createIBeaconConfig(config, firstState.genesisValidatorsRoot),
+  pubkey2index: new PubkeyIndexMap(),
+  index2pubkey: [],
+});
+
+cache.add(state);
+
+// const altairState = state as BeaconStateAltair;
+// console.log("@@@ sync committee", altairState.currentSyncCommittee);
+
+for (let n = 0; n < 7; n++) {
+  for (let i = 0; i < 10; i++) {
+    // skip 3628800
+    if (n === 0 && i === 0) continue;
+    const blockFilePath = `${path}/block_36288${n}${i}.json`;
+    if (fs.existsSync(blockFilePath)) {
+      const blockBytes = fs.readFileSync(blockFilePath);
+      const str = new TextDecoder().decode(blockBytes);
+      const json = JSON.parse(str);
+      const signedBlock = config.getForkTypes((json.data.message.slot as unknown) as number).SignedBeaconBlock.fromJson(json.data);
+      state = stateTransition(state, signedBlock, {
+        verifyProposer: false,
+        verifySignatures: false,
+        verifyStateRoot: true,
+      });
+      cache.add(state);
+      console.log("@@@ successfully process block", signedBlock.message.slot, "cache size", cache.size);
+    }
+  }
+}
+
+const memoryUsage = process.memoryUsage();
+console.log("@@@ memory used in MB:", memoryUsage.heapTotal / 1e6);

--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -33,7 +33,7 @@ export function processAttestationsAltair(
   verifySignature = true
 ): void {
   const {epochCtx} = state;
-  const {effectiveBalanceIncrements} = epochCtx;
+  const {effectiveBalanceIncrements, slashedArr} = epochCtx;
   const stateSlot = state.slot;
   const rootCache = new RootCache(state);
   const currentEpoch = epochCtx.epoch;
@@ -96,8 +96,7 @@ export function processAttestationsAltair(
       // TODO: describe issue. Compute progressive target balances
       // When processing each attestation, increase the cummulative target balance. Only applies post-altair
       if ((flagsNewSet & TIMELY_TARGET) === TIMELY_TARGET) {
-        const validator = state.validators.get(index);
-        if (!validator.slashed) {
+        if (!slashedArr.get(index)) {
           if (inCurrentEpoch) {
             epochCtx.currentTargetUnslashedBalanceIncrements += effectiveBalanceIncrements[index];
           } else {

--- a/packages/state-transition/src/block/slashValidator.ts
+++ b/packages/state-transition/src/block/slashValidator.ts
@@ -34,6 +34,7 @@ export function slashValidator(
   initiateValidatorExit(state, validator);
 
   validator.slashed = true;
+  epochCtx.slashedArr.set(slashedIndex, true);
   validator.withdrawableEpoch = Math.max(validator.withdrawableEpoch, epoch + EPOCHS_PER_SLASHINGS_VECTOR);
 
   const {effectiveBalance} = validator;

--- a/packages/state-transition/src/util/lazyBitArray.ts
+++ b/packages/state-transition/src/util/lazyBitArray.ts
@@ -8,6 +8,7 @@ export class LazyBitArray {
   constructor(private bitArray: BitArray) {}
 
   set(bitIndex: number, bit: boolean): void {
+    // only clone on the first set()
     if (!this.isDirty) {
       this.isDirty = true;
       this.bitArray = this.bitArray.clone();
@@ -19,7 +20,10 @@ export class LazyBitArray {
     return this.bitArray.get(bitIndex);
   }
 
-  clone(): LazyBitArray {
+  clone(forceClone = false): LazyBitArray {
+    if (forceClone) {
+      this.bitArray = this.bitArray.clone();
+    }
     // the real clone only happens on the 1st set
     return new LazyBitArray(this.bitArray);
   }

--- a/packages/state-transition/src/util/lazyBitArray.ts
+++ b/packages/state-transition/src/util/lazyBitArray.ts
@@ -4,8 +4,11 @@ import {BitArray} from "@chainsafe/ssz";
  * Same to BitArray but it only so a copy on the 1st set to save memory.
  */
 export class LazyBitArray {
-  private isDirty = false;
-  constructor(private bitArray: BitArray) {}
+  isDirty = false;
+  bitArray: BitArray;
+  constructor(bitArray: BitArray) {
+    this.bitArray = bitArray;
+  }
 
   set(bitIndex: number, bit: boolean): void {
     // only clone on the first set()

--- a/packages/state-transition/src/util/lazyBitArray.ts
+++ b/packages/state-transition/src/util/lazyBitArray.ts
@@ -1,0 +1,69 @@
+import {BitArray} from "@chainsafe/ssz";
+
+/**
+ * Same to BitArray but it only so a copy on the 1st set to save memory.
+ */
+export class LazyBitArray {
+  private isDirty = false;
+  constructor(private bitArray: BitArray) {}
+
+  set(bitIndex: number, bit: boolean): void {
+    if (!this.isDirty) {
+      this.isDirty = true;
+      this.bitArray = this.bitArray.clone();
+    }
+    this.bitArray.set(bitIndex, bit);
+  }
+
+  get(bitIndex: number): boolean {
+    return this.bitArray.get(bitIndex);
+  }
+
+  clone(): LazyBitArray {
+    // the real clone only happens on the 1st set
+    return new LazyBitArray(this.bitArray);
+  }
+}
+
+/**
+ * Util class to build LazyBitArray.
+ */
+export class LazyBitArrayBuilder {
+  private byte = 0;
+  private bytes: Uint8Array;
+  constructor(private bitLength: number) {
+    this.bytes = new Uint8Array(Math.ceil(bitLength / 8));
+  }
+
+  append(i: number, value: boolean): void {
+    if (value === true) {
+      this.byte += 2 ** (i % 8);
+    }
+
+    if ((i + 1) % 8 === 0) {
+      this.bytes[Math.floor(i / 8)] = this.byte;
+      this.byte = 0;
+    }
+  }
+
+  build(): LazyBitArray {
+    if (this.byte !== 0) {
+      const lastIndex = Math.floor((this.bitLength - 1) / 8);
+      this.bytes[lastIndex] = this.byte;
+    }
+    return new LazyBitArray(new BitArray(this.bytes, this.bitLength));
+  }
+}
+
+/**
+ * Return LazyBitArray from an array of boolean
+ */
+export function buildLazyBitArray(arr: boolean[]): LazyBitArray {
+  const builder = new LazyBitArrayBuilder(arr.length);
+
+  for (let i = 0; i < arr.length; i++) {
+    builder.append(i, arr[i]);
+  }
+
+  return builder.build();
+}

--- a/packages/state-transition/test/perf/util/lazyBitArray.test.ts
+++ b/packages/state-transition/test/perf/util/lazyBitArray.test.ts
@@ -1,0 +1,79 @@
+import {itBench, setBenchOpts} from "@dapplion/benchmark";
+import {buildLazyBitArray} from "../../../src/util/lazyBitArray.js";
+
+/**
+ * As of Aug 2022, LaziBitArray vs boolean[]:
+ * - ~1.5x slower to read
+ * - ~5x slower to write
+ * - ~60x faster to clone
+ */
+describe("LazyBitArray vs. boolean[]", function () {
+  setBenchOpts({noThreshold: true});
+
+  const length = 400_000;
+
+  itBench({
+    id: `random read boolean[] ${length} bits`,
+    beforeEach: () => Array.from({length}, () => true),
+    fn: (arr) => {
+      for (let i = 0; i < length; i++) {
+        arr[i];
+      }
+    },
+    runsFactor: 1000,
+  });
+
+  itBench({
+    id: `random read LazyBitArray ${length} bits`,
+    beforeEach: () => {
+      const bits = Array.from({length}, () => true);
+      return buildLazyBitArray(bits);
+    },
+    fn: (arr) => {
+      for (let i = 0; i < length; i++) {
+        arr.get(i);
+      }
+    },
+    runsFactor: 1000,
+  });
+
+  itBench({
+    id: `random write boolean[] ${length} bits`,
+    beforeEach: () => Array.from({length}, () => false),
+    fn: (arr) => {
+      for (let i = 0; i < length; i++) {
+        arr[i] = true;
+      }
+    },
+    runsFactor: 1000,
+  });
+
+  itBench({
+    id: `random write LazyBitArray ${length} bits`,
+    beforeEach: () => buildLazyBitArray(Array.from({length}, () => false)),
+    fn: (arr) => {
+      for (let i = 0; i < length; i++) {
+        arr.set(i, true);
+      }
+    },
+    runsFactor: 1000,
+  });
+
+  itBench({
+    id: `clone boolean ${length} bits`,
+    beforeEach: () => Array.from({length}, () => true),
+    fn: (arr) => {
+      arr.slice();
+    },
+    runsFactor: 1000,
+  });
+
+  itBench({
+    id: `clone LazyBitArray ${length} bits`,
+    beforeEach: () => buildLazyBitArray(Array.from({length}, () => true)),
+    fn: (arr) => {
+      arr.clone(true);
+    },
+    runsFactor: 1000,
+  });
+});

--- a/packages/state-transition/test/unit/util/lazyBitArray.test.ts
+++ b/packages/state-transition/test/unit/util/lazyBitArray.test.ts
@@ -1,0 +1,22 @@
+import {expect} from "chai";
+import {buildLazyBitArray} from "../../../src/util/lazyBitArray.js";
+
+describe("LazyBitArray creation", function () {
+  const testCases: {name: string; booleanArr: boolean[]}[] = [
+    {name: "all true", booleanArr: Array.from({length: 19}, () => true)},
+    {name: "all false", booleanArr: Array.from({length: 19}, () => false)},
+    {name: "true every 2 bits", booleanArr: Array.from({length: 19}, (_, i) => i % 2 === 0)},
+    {name: "true every 3 bits", booleanArr: Array.from({length: 19}, (_, i) => i % 3 === 0)},
+    {name: "true every 4 bits", booleanArr: Array.from({length: 19}, (_, i) => i % 4 === 0)},
+    {name: "true every 5 bits", booleanArr: Array.from({length: 19}, (_, i) => i % 5 === 0)},
+  ];
+
+  for (const {name, booleanArr} of testCases) {
+    it(name, () => {
+      const bitArray = buildLazyBitArray(booleanArr);
+      for (let i = 0; i < booleanArr.length; i++) {
+        expect(bitArray.get(i)).to.be.equal(booleanArr[i], `incorrect bit ${i}`);
+      }
+    });
+  }
+});


### PR DESCRIPTION
**Motivation**

This PR #4294 causes the memory to increased a lot, the reason is we access `state.validators.get()` on every indexed attestations (20_000 times per block), see https://github.com/ChainSafe/lodestar/issues/4397#issuecomment-1212652592

**Description**

- Cache `slashed` property of validator in EpochContext, clone at every block only if needed
- The performance between BitArray vs boolean[]:
  - On read: 1.5x slower
  - On write: 5x slower
  - On clone: 60x faster

Pick BitArray because we mostly read (20_000 per block) and rarely write (max 16 + 2 = 18 slashed validators per block). Although the read is slower than boolean[], it should be faster than tree backed traversal, and the `clone()` is great

- Also wrap it in a class called `LazyBitArray` which only clone the BitArray on the first set. So on a block with no slashed validators (most of the time), we even don't need to do a `clone()` on every block, only build the `slashedArr` at epoch transition

Closes #4397

**Test**
- [x] The memory test shows it consumed 0-30MB more than v0.41.0 (vs ~500MB in the case of v0.42.0, or unstable)
- [ ] Deploy and test on a prater node