### PR TITLE
Fix heap memory issue when processing attestations for altair

### DIFF
--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -96,7 +96,7 @@ export function processAttestationsAltair(
       // TODO: describe issue. Compute progressive target balances
       // When processing each attestation, increase the cummulative target balance. Only applies post-altair
       if ((flagsNewSet & TIMELY_TARGET) === TIMELY_TARGET) {
-        const validator = state.validators.get(index);
+        const validator = state.validators.getReadonly(index);
         if (!validator.slashed) {
           if (inCurrentEpoch) {
             epochCtx.currentTargetUnslashedBalanceIncrements += effectiveBalanceIncrements[index];


### PR DESCRIPTION
**Motivation**

This PR #4294 causes the memory to increased a lot, the reason is we access `state.validators.get()` on every indexed attestations (20_000 times per block), see https://github.com/ChainSafe/lodestar/issues/4397#issuecomment-1212652592

**Description**

- As instructed by @dapplion , use `state.validators.getReadOnly()` instead of `state.validators.get()`
- Confirmed by the test posted in the issue

Closes #4397

