### PR TITLE
Parse remote key's pubkeys into format expected by validator store.

### DIFF
--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -1,5 +1,5 @@
 import {defaultOptions} from "@lodestar/validator";
-import {ICliCommandOptions, ILogArgs} from "../../util/index.js";
+import {ensure0xPrefix, ICliCommandOptions, ILogArgs} from "../../util/index.js";
 import {logOptions, beaconPathsOptions} from "../beacon/options.js";
 import {IBeaconPaths} from "../beacon/paths.js";
 import {keymanagerRestApiServerOptsDefault} from "./keymanager/server.js";
@@ -210,9 +210,13 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
     description:
       "List of validator public keys used by an external signer. May also provide a single string a comma separated public keys",
     type: "array",
+    string: true, // Ensures the pubkey string is not automatically converted to numbers
     coerce: (pubkeys: string[]): string[] =>
       // Parse ["0x11,0x22"] to ["0x11", "0x22"]
-      pubkeys.map((item) => item.split(",")).flat(1),
+      pubkeys
+        .map((item) => item.split(","))
+        .flat(1)
+        .map(ensure0xPrefix),
     group: "externalSignerUrl",
   },
 

--- a/packages/cli/src/util/format.ts
+++ b/packages/cli/src/util/format.ts
@@ -5,14 +5,6 @@ import {fromHexString} from "@chainsafe/ssz";
 /**
  * 0x prefix a string if not prefixed already
  */
-export function add0xPrefix(hex: string): string {
-  if (!hex.startsWith("0x")) {
-    return `0x${hex}`;
-  } else {
-    return hex;
-  }
-}
-
 export function ensure0xPrefix(hex: string): string {
   if (!hex.startsWith("0x")) hex = `0x${hex}`;
   return hex;


### PR DESCRIPTION
**Motivation**

Pubkeys passed via the `externalSigner.pubkeys`, flag, if prefixed by `0x` leads to parsing error. (See https://github.com/ChainSafe/lodestar/issues/3817), if not prefixed  with`0x` the validator client runs alright, but it is not picked for validator duties since the validator store expects known pubkeys to be prefixed with `0x`.

**Description**

Prevents parsing error if pubkeys with `0x` prefix is passed in. If not prefixed, ensures that the pubkey is prefixed with `0x`

Closes #3817
Closes #4367
