### PR TITLE
Remove dependentRoot from getSyncCommitteeDuties

### DIFF
--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -126,10 +126,7 @@ export type Api = {
    */
   getProposerDuties(epoch: Epoch): Promise<{data: ProposerDuty[]; dependentRoot: Root}>;
 
-  getSyncCommitteeDuties(
-    epoch: number,
-    validatorIndices: ValidatorIndex[]
-  ): Promise<{data: SyncDuty[]; dependentRoot: Root}>;
+  getSyncCommitteeDuties(epoch: number, validatorIndices: ValidatorIndex[]): Promise<{data: SyncDuty[]}>;
 
   /**
    * Produce a new block, without signature.
@@ -424,7 +421,7 @@ export function getReturnTypes(): ReturnTypes<Api> {
   return {
     getAttesterDuties: WithDependentRoot(ArrayOf(AttesterDuty)),
     getProposerDuties: WithDependentRoot(ArrayOf(ProposerDuty)),
-    getSyncCommitteeDuties: WithDependentRoot(ArrayOf(SyncDuty)),
+    getSyncCommitteeDuties: ContainerData(ArrayOf(SyncDuty)),
     produceBlock: ContainerData(ssz.phase0.BeaconBlock),
     produceBlockV2: WithVersion((fork: ForkName) => ssz[fork].BeaconBlock),
     produceBlindedBlock: WithVersion((_fork: ForkName) => ssz.bellatrix.BlindedBeaconBlock),

--- a/packages/api/test/unit/beacon/validator.test.ts
+++ b/packages/api/test/unit/beacon/validator.test.ts
@@ -35,7 +35,6 @@ describe("beacon / validator", () => {
       args: [1000, [1, 2, 3]],
       res: {
         data: [{pubkey: Buffer.alloc(48, 1), validatorIndex: 2, validatorSyncCommitteeIndices: [3]}],
-        dependentRoot: ZERO_HASH,
       },
     },
     produceBlock: {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -432,8 +432,6 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
 
       return {
         data: duties,
-        // TODO: Compute a proper dependentRoot for this syncCommittee shuffling
-        dependentRoot: ZERO_HASH,
       };
     },
 

--- a/packages/validator/test/unit/services/syncCommitteDuties.test.ts
+++ b/packages/validator/test/unit/services/syncCommitteDuties.test.ts
@@ -24,9 +24,6 @@ import {syncCommitteeIndicesToSubnets} from "../../../src/services/utils.js";
 describe("SyncCommitteeDutiesService", function () {
   const sandbox = sinon.createSandbox();
 
-  const ZERO_HASH = Buffer.alloc(32, 0);
-  const ZERO_HASH_HEX = toHexString(ZERO_HASH);
-
   const api = getApiClientStub(sandbox);
 
   let validatorStore: ValidatorStore;
@@ -76,7 +73,7 @@ describe("SyncCommitteeDutiesService", function () {
       validatorIndex: indices[0],
       validatorSyncCommitteeIndices: [7],
     };
-    api.validator.getSyncCommitteeDuties.resolves({dependentRoot: ZERO_HASH, data: [duty]});
+    api.validator.getSyncCommitteeDuties.resolves({data: [duty]});
 
     // Accept all subscriptions
     api.validator.prepareSyncCommitteeSubnets.resolves();
@@ -105,8 +102,8 @@ describe("SyncCommitteeDutiesService", function () {
 
     expect(dutiesByIndexByPeriodObj).to.deep.equal(
       {
-        0: {[indices[0]]: {dependentRoot: ZERO_HASH_HEX, duty: toSyncDutySubnet(duty)}},
-        1: {[indices[0]]: {dependentRoot: ZERO_HASH_HEX, duty: toSyncDutySubnet(duty)}},
+        0: {[indices[0]]: {duty: toSyncDutySubnet(duty)}},
+        1: {[indices[0]]: {duty: toSyncDutySubnet(duty)}},
       } as typeof dutiesByIndexByPeriodObj,
       "Wrong dutiesService.dutiesByIndexByPeriod Map"
     );
@@ -134,20 +131,16 @@ describe("SyncCommitteeDutiesService", function () {
       validatorIndex: indices[0],
       validatorSyncCommitteeIndices: [7],
     };
-    api.validator.getSyncCommitteeDuties
-      .withArgs(0, sinon.match.any)
-      .resolves({dependentRoot: ZERO_HASH, data: [duty]});
+    api.validator.getSyncCommitteeDuties.withArgs(0, sinon.match.any).resolves({data: [duty]});
     // sync period 1 should all return empty
-    api.validator.getSyncCommitteeDuties.withArgs(256, sinon.match.any).resolves({dependentRoot: ZERO_HASH, data: []});
-    api.validator.getSyncCommitteeDuties.withArgs(257, sinon.match.any).resolves({dependentRoot: ZERO_HASH, data: []});
+    api.validator.getSyncCommitteeDuties.withArgs(256, sinon.match.any).resolves({data: []});
+    api.validator.getSyncCommitteeDuties.withArgs(257, sinon.match.any).resolves({data: []});
     const duty2: routes.validator.SyncDuty = {
       pubkey: pubkeys[1],
       validatorIndex: indices[1],
       validatorSyncCommitteeIndices: [5],
     };
-    api.validator.getSyncCommitteeDuties
-      .withArgs(1, sinon.match.any)
-      .resolves({dependentRoot: ZERO_HASH, data: [duty2]});
+    api.validator.getSyncCommitteeDuties.withArgs(1, sinon.match.any).resolves({data: [duty2]});
 
     // Clock will call runAttesterDutiesTasks() immediatelly
     const clock = new ClockMock();
@@ -165,7 +158,7 @@ describe("SyncCommitteeDutiesService", function () {
     );
     expect(dutiesByIndexByPeriodObj).to.deep.equal(
       {
-        0: {[indices[0]]: {dependentRoot: ZERO_HASH_HEX, duty: toSyncDutySubnet(duty)}},
+        0: {[indices[0]]: {duty: toSyncDutySubnet(duty)}},
         1: {},
       } as typeof dutiesByIndexByPeriodObj,
       "Wrong dutiesService.dutiesByIndexByPeriod Map"
@@ -181,7 +174,7 @@ describe("SyncCommitteeDutiesService", function () {
     );
     expect(dutiesByIndexByPeriodObj).to.deep.equal(
       {
-        0: {[indices[1]]: {dependentRoot: ZERO_HASH_HEX, duty: toSyncDutySubnet(duty2)}},
+        0: {[indices[1]]: {duty: toSyncDutySubnet(duty2)}},
         1: {},
       } as typeof dutiesByIndexByPeriodObj,
       "Wrong dutiesService.dutiesByIndexByPeriod Map"
@@ -200,9 +193,7 @@ describe("SyncCommitteeDutiesService", function () {
       validatorIndex: indices[1],
       validatorSyncCommitteeIndices: [7],
     };
-    api.validator.getSyncCommitteeDuties
-      .withArgs(sinon.match.any, sinon.match.any)
-      .resolves({dependentRoot: ZERO_HASH, data: [duty1, duty2]});
+    api.validator.getSyncCommitteeDuties.withArgs(sinon.match.any, sinon.match.any).resolves({data: [duty1, duty2]});
 
     // Accept all subscriptions
     api.validator.prepareSyncCommitteeSubnets.resolves();
@@ -225,12 +216,12 @@ describe("SyncCommitteeDutiesService", function () {
     expect(dutiesByIndexByPeriodObj).to.deep.equal(
       {
         0: {
-          [indices[0]]: {dependentRoot: ZERO_HASH_HEX, duty: toSyncDutySubnet(duty1)},
-          [indices[1]]: {dependentRoot: ZERO_HASH_HEX, duty: toSyncDutySubnet(duty2)},
+          [indices[0]]: {duty: toSyncDutySubnet(duty1)},
+          [indices[1]]: {duty: toSyncDutySubnet(duty2)},
         },
         1: {
-          [indices[0]]: {dependentRoot: ZERO_HASH_HEX, duty: toSyncDutySubnet(duty1)},
-          [indices[1]]: {dependentRoot: ZERO_HASH_HEX, duty: toSyncDutySubnet(duty2)},
+          [indices[0]]: {duty: toSyncDutySubnet(duty1)},
+          [indices[1]]: {duty: toSyncDutySubnet(duty2)},
         },
       } as typeof dutiesByIndexByPeriodObj,
       "Wrong dutiesService.dutiesByIndexByPeriod Map"
@@ -247,8 +238,8 @@ describe("SyncCommitteeDutiesService", function () {
     );
     expect(dutiesByIndexByPeriodObjAfterRemoval).to.deep.equal(
       {
-        0: {[indices[1]]: {dependentRoot: ZERO_HASH_HEX, duty: toSyncDutySubnet(duty2)}},
-        1: {[indices[1]]: {dependentRoot: ZERO_HASH_HEX, duty: toSyncDutySubnet(duty2)}},
+        0: {[indices[1]]: {duty: toSyncDutySubnet(duty2)}},
+        1: {[indices[1]]: {duty: toSyncDutySubnet(duty2)}},
       } as typeof dutiesByIndexByPeriodObjAfterRemoval,
       "Wrong dutiesService.dutiesByIndexByPeriod Map"
     );

--- a/packages/validator/test/unit/services/syncCommittee.test.ts
+++ b/packages/validator/test/unit/services/syncCommittee.test.ts
@@ -74,7 +74,7 @@ describe("SyncCommitteeService", function () {
 
     // Return empty replies to duties service
     api.beacon.getStateValidators.resolves({data: []});
-    api.validator.getSyncCommitteeDuties.resolves({dependentRoot: ZERO_HASH, data: []});
+    api.validator.getSyncCommitteeDuties.resolves({data: []});
 
     // Mock duties service to return some duties directly
     syncCommitteeService["dutiesService"].getDutiesAtSlot = sinon.stub().returns(duties);


### PR DESCRIPTION
**Motivation**

Spec https://github.com/ethereum/beacon-APIs/blob/39c9cc35e08f2ef6cfa5b2d5eef57e96065ee080/apis/validator/duties/sync.yaml#L34 

```yaml
            properties:
              execution_optimistic:
                $ref: "../../../beacon-node-oapi.yaml#/components/schemas/ExecutionOptimistic"
              data:
                type: array
                items:
                  $ref: '../../../beacon-node-oapi.yaml#/components/schemas/Altair.SyncDuty'
```

does not specifies dependentRoot for this route. This was probably added as an automatic assumption from attester duties.

Note Lighthouse does not include dependantRoot
https://github.com/sigp/lighthouse/blob/df51a73272489fe154bd10995c96199062b6c3f7/beacon_node/http_api/src/lib.rs#L2152

**Description**

Remove dependentRoot from getSyncCommitteeDuties

Closes https://github.com/ChainSafe/lodestar/issues/4402