### PR TITLE
Replace usage of chai assertion to.be.$value_name

### DIFF
--- a/packages/beacon-node/test/e2e/db/api/beacon/repositories/blockArchive.test.ts
+++ b/packages/beacon-node/test/e2e/db/api/beacon/repositories/blockArchive.test.ts
@@ -68,7 +68,7 @@ describe("BlockArchiveRepository", function () {
 
     // make sure they are the same except for slot
     savedBlock2.message.slot = sampleBlock.message.slot;
-    expect(ssz.phase0.SignedBeaconBlock.equals(savedBlock1, savedBlock2)).to.be.true;
+    expect(ssz.phase0.SignedBeaconBlock.equals(savedBlock1, savedBlock2)).to.equal(true);
   });
 
   it("batchPutBinary should be faster than batchPut", async () => {

--- a/packages/beacon-node/test/unit/api/impl/beacon/blocks/getBlockHeaders.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/blocks/getBlockHeaders.test.ts
@@ -40,10 +40,10 @@ describe("api - beacon - getBlockHeaders", function () {
     expect(blockHeaders).to.not.be.null;
     expect(blockHeaders.length).to.be.equal(2);
     expect(blockHeaders.filter((header) => header.canonical).length).to.be.equal(1);
-    expect(server.forkChoiceStub.getHead.calledOnce).to.be.true;
-    expect(server.chainStub.getCanonicalBlockAtSlot.calledOnce).to.be.true;
-    expect(server.forkChoiceStub.getBlockSummariesAtSlot.calledOnce).to.be.true;
-    expect(server.dbStub.block.get.calledOnce).to.be.true;
+    expect(server.forkChoiceStub.getHead.calledOnce).to.equal(true);
+    expect(server.chainStub.getCanonicalBlockAtSlot.calledOnce).to.equal(true);
+    expect(server.forkChoiceStub.getBlockSummariesAtSlot.calledOnce).to.equal(true);
+    expect(server.dbStub.block.get.calledOnce).to.equal(true);
   });
 
   it("future slot", async function () {
@@ -58,7 +58,7 @@ describe("api - beacon - getBlockHeaders", function () {
     server.forkChoiceStub.getBlockSummariesAtSlot.withArgs(0).returns([]);
     const {data: blockHeaders} = await server.blockApi.getBlockHeaders({slot: 0});
     expect(blockHeaders.length).to.be.equal(1);
-    expect(blockHeaders[0].canonical).to.be.true;
+    expect(blockHeaders[0].canonical).to.equal(true);
   });
 
   it("skip slot", async function () {

--- a/packages/beacon-node/test/unit/api/impl/beacon/blocks/publishBlock.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/blocks/publishBlock.test.ts
@@ -42,7 +42,7 @@ describe("api - beacon - publishBlock", function () {
 
     syncStub.isSynced.returns(true);
     await expect(blockApi.publishBlock(block)).to.be.fulfilled;
-    expect(chainStub.processBlock.calledOnceWith(block)).to.be.true;
-    expect(gossipStub.publishBeaconBlock.calledOnceWith(block)).to.be.true;
+    expect(chainStub.processBlock.calledOnceWith(block)).to.equal(true);
+    expect(gossipStub.publishBeaconBlock.calledOnceWith(block)).to.equal(true);
   });
 });

--- a/packages/beacon-node/test/unit/api/impl/beacon/blocks/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/blocks/utils.test.ts
@@ -59,14 +59,14 @@ describe("block api utils", function () {
 
     it("should resolve genesis", async function () {
       await resolveBlockId(forkChoiceStub, dbStub, "genesis").catch(() => {});
-      expect(dbStub.blockArchive.get.withArgs(GENESIS_SLOT).calledOnce).to.be.true;
+      expect(dbStub.blockArchive.get.withArgs(GENESIS_SLOT).calledOnce).to.equal(true);
     });
 
     it("should resolve finalized", async function () {
       const expected = 0;
       forkChoiceStub.getFinalizedBlock.returns(expectedSummary);
       await resolveBlockId(forkChoiceStub, dbStub, "finalized").catch(() => {});
-      expect(dbStub.blockArchive.get.withArgs(expected).calledOnce).to.be.true;
+      expect(dbStub.blockArchive.get.withArgs(expected).calledOnce).to.equal(true);
     });
 
     it("should resolve finalized block root", async function () {
@@ -74,14 +74,14 @@ describe("block api utils", function () {
       forkChoiceStub.getFinalizedBlock.returns(expectedSummary);
       dbStub.blockArchive.getByRoot.withArgs(bufferEqualsMatcher(expectedBuffer)).resolves(null);
       await resolveBlockId(forkChoiceStub, dbStub, toHexString(expectedBuffer)).catch(() => {});
-      expect(dbStub.blockArchive.get.withArgs(expectedSummary.slot).calledOnce).to.be.true;
+      expect(dbStub.blockArchive.get.withArgs(expectedSummary.slot).calledOnce).to.equal(true);
     });
 
     it("should resolve non finalized block root", async function () {
       forkChoiceStub.getBlock.returns(null);
       dbStub.block.get.withArgs(bufferEqualsMatcher(expectedBuffer)).resolves(generateEmptySignedBlock());
       await resolveBlockId(forkChoiceStub, dbStub, toHexString(expectedBuffer)).catch(() => {});
-      expect(dbStub.blockArchive.getByRoot.withArgs(bufferEqualsMatcher(expectedBuffer)).calledOnce).to.be.true;
+      expect(dbStub.blockArchive.getByRoot.withArgs(bufferEqualsMatcher(expectedBuffer)).calledOnce).to.equal(true);
     });
 
     it("should resolve non finalized slot", async function () {
@@ -90,14 +90,14 @@ describe("block api utils", function () {
         blockRoot: expectedRootHex,
       });
       await resolveBlockId(forkChoiceStub, dbStub, "2").catch(() => {});
-      expect(forkChoiceStub.getCanonicalBlockAtSlot.withArgs(2).calledOnce).to.be.true;
+      expect(forkChoiceStub.getCanonicalBlockAtSlot.withArgs(2).calledOnce).to.equal(true);
     });
 
     it("should resolve finalized slot", async function () {
       forkChoiceStub.getCanonicalBlockAtSlot.withArgs(2).returns(null);
       await resolveBlockId(forkChoiceStub, dbStub, "2").catch(() => {});
-      expect(forkChoiceStub.getCanonicalBlockAtSlot.withArgs(2).calledOnce).to.be.true;
-      expect(dbStub.blockArchive.get.withArgs(2).calledOnce).to.be.true;
+      expect(forkChoiceStub.getCanonicalBlockAtSlot.withArgs(2).calledOnce).to.equal(true);
+      expect(dbStub.blockArchive.get.withArgs(2).calledOnce).to.equal(true);
     });
 
     it("should trow on invalid", async function () {

--- a/packages/beacon-node/test/unit/api/impl/beacon/pool/pool.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/pool/pool.test.ts
@@ -102,13 +102,13 @@ describe.skip("beacon pool api impl", function () {
     it("should broadcast", async function () {
       validateGossipAttesterSlashing.resolves();
       await poolApi.submitPoolAttesterSlashing(atterterSlashing);
-      expect(gossipStub.publishAttesterSlashing.calledOnceWithExactly(atterterSlashing)).to.be.true;
+      expect(gossipStub.publishAttesterSlashing.calledOnceWithExactly(atterterSlashing)).to.equal(true);
     });
 
     it("should not broadcast", async function () {
       validateGossipAttesterSlashing.throws(new Error("unit test error"));
       await poolApi.submitPoolAttesterSlashing(atterterSlashing).catch(() => ({}));
-      expect(gossipStub.publishAttesterSlashing.calledOnce).to.be.false;
+      expect(gossipStub.publishAttesterSlashing.calledOnce).to.equal(false);
     });
   });
 
@@ -121,13 +121,13 @@ describe.skip("beacon pool api impl", function () {
     it("should broadcast", async function () {
       validateGossipProposerSlashing.resolves();
       await poolApi.submitPoolProposerSlashing(proposerSlashing);
-      expect(gossipStub.publishProposerSlashing.calledOnceWithExactly(proposerSlashing)).to.be.true;
+      expect(gossipStub.publishProposerSlashing.calledOnceWithExactly(proposerSlashing)).to.equal(true);
     });
 
     it("should not broadcast", async function () {
       validateGossipProposerSlashing.throws(new Error("unit test error"));
       await poolApi.submitPoolProposerSlashing(proposerSlashing).catch(() => ({}));
-      expect(gossipStub.publishProposerSlashing.calledOnce).to.be.false;
+      expect(gossipStub.publishProposerSlashing.calledOnce).to.equal(false);
     });
   });
 
@@ -137,13 +137,13 @@ describe.skip("beacon pool api impl", function () {
     it("should broadcast", async function () {
       validateVoluntaryExit.resolves();
       await poolApi.submitPoolVoluntaryExit(voluntaryExit);
-      expect(gossipStub.publishVoluntaryExit.calledOnceWithExactly(voluntaryExit)).to.be.true;
+      expect(gossipStub.publishVoluntaryExit.calledOnceWithExactly(voluntaryExit)).to.equal(true);
     });
 
     it("should not broadcast", async function () {
       validateVoluntaryExit.throws(new Error("unit test error"));
       await poolApi.submitPoolVoluntaryExit(voluntaryExit).catch(() => ({}));
-      expect(gossipStub.publishVoluntaryExit.calledOnce).to.be.false;
+      expect(gossipStub.publishVoluntaryExit.calledOnce).to.equal(false);
     });
   });
 });

--- a/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
@@ -29,8 +29,8 @@ describe("beacon state api utils", function () {
 
       const state = await resolveStateId(config, chainStub, dbStub, "head");
       expect(state).to.not.be.null;
-      expect(getHead.calledOnce).to.be.true;
-      expect(get.calledOnce).to.be.true;
+      expect(getHead.calledOnce).to.equal(true);
+      expect(get.calledOnce).to.equal(true);
     });
 
     it("resolve finalized state id - success", async function () {
@@ -43,8 +43,8 @@ describe("beacon state api utils", function () {
 
       const state = await resolveStateId(config, chainStub, dbStub, "finalized");
       expect(state).to.not.be.null;
-      expect(getFinalizedBlock.calledOnce).to.be.true;
-      expect(get.calledOnce).to.be.true;
+      expect(getFinalizedBlock.calledOnce).to.equal(true);
+      expect(get.calledOnce).to.equal(true);
     });
 
     it("resolve justified state id - success", async function () {
@@ -57,8 +57,8 @@ describe("beacon state api utils", function () {
 
       const state = await resolveStateId(config, chainStub, dbStub, "justified");
       expect(state).to.not.be.null;
-      expect(getJustifiedBlock.calledOnce).to.be.true;
-      expect(get.calledOnce).to.be.true;
+      expect(getJustifiedBlock.calledOnce).to.equal(true);
+      expect(get.calledOnce).to.equal(true);
     });
 
     it("resolve state by root", async function () {
@@ -67,7 +67,7 @@ describe("beacon state api utils", function () {
 
       const state = await resolveStateId(config, chainStub, dbStub, otherRoot);
       expect(state).to.not.be.null;
-      expect(get.calledOnce).to.be.true;
+      expect(get.calledOnce).to.equal(true);
     });
 
     it("resolve state by slot", async function () {
@@ -83,7 +83,7 @@ describe("beacon state api utils", function () {
 
       const state = await resolveStateId(config, chainStub, dbStub, "123");
       expect(state).to.not.be.null;
-      expect(getCanonicalBlockAtSlot.withArgs(123).calledOnce).to.be.true;
+      expect(getCanonicalBlockAtSlot.withArgs(123).calledOnce).to.equal(true);
     });
 
     it("resolve state on unarchived finalized slot", async function () {

--- a/packages/beacon-node/test/unit/api/impl/node/node.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/node/node.test.ts
@@ -66,8 +66,8 @@ describe("node api implementation", function () {
         },
       } as MetadataController;
       const {data: identity} = await api.getNetworkIdentity();
-      expect(identity.peerId.startsWith("16")).to.be.true;
-      expect(identity.enr.startsWith("enr:-")).to.be.true;
+      expect(identity.peerId.startsWith("16")).to.equal(true);
+      expect(identity.enr.startsWith("enr:-")).to.equal(true);
       expect(identity.discoveryAddresses.length).to.equal(1);
       expect(identity.discoveryAddresses[0]).to.equal("/ip4/127.0.0.1/tcp/36001");
       expect(identity.p2pAddresses.length).to.equal(1);
@@ -192,7 +192,7 @@ describe("node api implementation", function () {
   describe("getVersion", function () {
     it("success", async function () {
       const {data} = await api.getNodeVersion();
-      expect(data.version.startsWith("Lodestar"), `data must start with 'Lodestar': ${data.version}`).to.be.true;
+      expect(data.version.startsWith("Lodestar"), `data must start with 'Lodestar': ${data.version}`).to.equal(true);
     });
   });
 });

--- a/packages/beacon-node/test/unit/api/impl/validator/duties/proposer.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/duties/proposer.test.ts
@@ -78,8 +78,10 @@ describe("get proposers api impl", function () {
     const {data: result} = await api.getProposerDuties(1);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(result.length).to.be.equal(SLOTS_PER_EPOCH, "result should be equals to slots per epoch");
-    expect(stubGetNextBeaconProposer.called, "stubGetBeaconProposer function should not have been called").to.be.true;
-    expect(stubGetBeaconProposer.called, "stubGetBeaconProposer function should have been called").to.be.false;
+    expect(stubGetNextBeaconProposer.called, "stubGetBeaconProposer function should not have been called").to.equal(
+      true
+    );
+    expect(stubGetBeaconProposer.called, "stubGetBeaconProposer function should have been called").to.equal(false);
   });
 
   it("should have different proposer for current and next epoch", async function () {

--- a/packages/beacon-node/test/unit/chain/archive/blockArchiver.test.ts
+++ b/packages/beacon-node/test/unit/chain/archive/blockArchiver.test.ts
@@ -53,7 +53,7 @@ describe("block archiver task", function () {
       dbStub.block.batchDelete.calledWith(
         [blocks[4], blocks[3], blocks[1], blocks[0]].map((summary) => fromHexString(summary.blockRoot))
       )
-    ).to.be.true;
+    ).to.equal(true);
     // delete non canonical blocks
     expect(dbStub.block.batchDelete.calledWith([blocks[2]].map((summary) => fromHexString(summary.blockRoot)))).to.be
       .true;

--- a/packages/beacon-node/test/unit/chain/clock/local.test.ts
+++ b/packages/beacon-node/test/unit/chain/clock/local.test.ts
@@ -34,16 +34,16 @@ describe("LocalClock", function () {
     const spy = sinon.spy();
     emitter.on(ChainEvent.clockSlot, spy);
     sandbox.clock.tick(config.SECONDS_PER_SLOT * 1000);
-    expect(spy.calledOnce).to.be.true;
-    expect(spy.calledWith(clock.currentSlot)).to.be.true;
+    expect(spy.calledOnce).to.equal(true);
+    expect(spy.calledWith(clock.currentSlot)).to.equal(true);
   });
 
   it("Should notify on new epoch", function () {
     const spy = sinon.spy();
     emitter.on(ChainEvent.clockEpoch, spy);
     sandbox.clock.tick(SLOTS_PER_EPOCH * config.SECONDS_PER_SLOT * 1000);
-    expect(spy.calledOnce).to.be.true;
-    expect(spy.calledWith(clock.currentEpoch)).to.be.true;
+    expect(spy.calledOnce).to.equal(true);
+    expect(spy.calledWith(clock.currentEpoch)).to.equal(true);
   });
 
   describe("currentSlotWithGossipDisparity", () => {
@@ -63,7 +63,7 @@ describe("LocalClock", function () {
       expect(
         clock.isCurrentSlotGivenGossipDisparity(currentSlot),
         "isCurrentSlotGivenGossipDisparity is not correct for current slot"
-      ).to.be.true;
+      ).to.equal(true);
     });
 
     it("should accept next slot if it's too close to next slot", () => {
@@ -71,12 +71,12 @@ describe("LocalClock", function () {
       expect(
         clock.isCurrentSlotGivenGossipDisparity(nextSlot),
         "current slot could NOT be next slot if it's far away from next slot"
-      ).to.be.false;
+      ).to.equal(false);
       sandbox.clock.tick(config.SECONDS_PER_SLOT * 1000 - (MAXIMUM_GOSSIP_CLOCK_DISPARITY - 50));
       expect(
         clock.isCurrentSlotGivenGossipDisparity(nextSlot),
         "current slot could be next slot if it's too close to next slot"
-      ).to.be.true;
+      ).to.equal(true);
     });
 
     it("should accept previous slot if it's just passed current slot", () => {
@@ -85,12 +85,12 @@ describe("LocalClock", function () {
       expect(
         clock.isCurrentSlotGivenGossipDisparity(previousSlot),
         "current slot could be previous slot if it's just passed to a slot"
-      ).to.be.true;
+      ).to.equal(true);
       sandbox.clock.tick(100);
       expect(
         clock.isCurrentSlotGivenGossipDisparity(previousSlot),
         "current slot could NOT be previous slot if it's far away from previous slot"
-      ).to.be.false;
+      ).to.equal(false);
     });
   });
 });

--- a/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -87,7 +87,7 @@ describe("LodestarForkChoice", function () {
       const parentBlockHex = ssz.phase0.BeaconBlock.hashTreeRoot(parentBlock.message);
       const orphanedBlockHex = ssz.phase0.BeaconBlock.hashTreeRoot(orphanedBlock.message);
       // forkchoice tie-break condition is based on root hex
-      expect(orphanedBlockHex > parentBlockHex).to.be.true;
+      expect(orphanedBlockHex > parentBlockHex).to.equal(true);
       const currentSlot = childBlock.message.slot;
       forkChoice.updateTime(currentSlot);
 
@@ -174,8 +174,8 @@ describe("LodestarForkChoice", function () {
       );
       expect(forkChoice.getBlockHex(hashBlock(block08.message))).to.be.not.null;
       expect(forkChoice.getBlockHex(hashBlock(block12.message))).to.be.not.null;
-      expect(forkChoice.hasBlockHex(hashBlock(block08.message))).to.be.true;
-      expect(forkChoice.hasBlockHex(hashBlock(block12.message))).to.be.true;
+      expect(forkChoice.hasBlockHex(hashBlock(block08.message))).to.equal(true);
+      expect(forkChoice.hasBlockHex(hashBlock(block12.message))).to.equal(true);
       forkChoice.onBlock(block32.message, state32, blockDelaySec, currentSlot, executionStatus);
       forkChoice.prune(hashBlock(block16.message));
       expect(forkChoice.getAllAncestorBlocks(hashBlock(block16.message)).length).to.be.equal(
@@ -186,10 +186,10 @@ describe("LodestarForkChoice", function () {
         2,
         "getAllAncestorBlocks should return 2 blocks"
       );
-      expect(forkChoice.getBlockHex(hashBlock(block08.message))).to.be.null;
-      expect(forkChoice.getBlockHex(hashBlock(block12.message))).to.be.null;
-      expect(forkChoice.hasBlockHex(hashBlock(block08.message))).to.be.false;
-      expect(forkChoice.hasBlockHex(hashBlock(block12.message))).to.be.false;
+      expect(forkChoice.getBlockHex(hashBlock(block08.message))).to.equal(null);
+      expect(forkChoice.getBlockHex(hashBlock(block12.message))).to.equal(null);
+      expect(forkChoice.hasBlockHex(hashBlock(block08.message))).to.equal(false);
+      expect(forkChoice.hasBlockHex(hashBlock(block12.message))).to.equal(false);
     });
 
     /**

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -79,7 +79,7 @@ describe("AggregatedAttestationPool", function () {
       expect(
         forkchoiceStub.findAttesterDependentRoot.calledOnce,
         "forkchoice should be called to check pivot block"
-      ).to.be.true;
+      ).to.equal(true);
     });
   }
 
@@ -92,7 +92,7 @@ describe("AggregatedAttestationPool", function () {
       [],
       "no attestation since incorrect source"
     );
-    expect(forkchoiceStub.iterateAncestorBlocks.calledOnce, "forkchoice should not be called").to.be.false;
+    expect(forkchoiceStub.iterateAncestorBlocks.calledOnce, "forkchoice should not be called").to.equal(false);
   });
 
   it("incompatible shuffling - incorrect pivot block root", function () {

--- a/packages/beacon-node/test/unit/chain/opPools/syncCommitteeContribution.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/syncCommitteeContribution.test.ts
@@ -37,7 +37,7 @@ describe("chain / opPools / SyncContributionAndProofPool", function () {
     });
     cache.add(newContributionAndProof, syncCommitteeParticipants);
     const aggregate = cache.getAggregate(slot, beaconBlockRoot);
-    expect(ssz.altair.SyncAggregate.equals(aggregate, ssz.altair.SyncAggregate.defaultValue())).to.be.false;
+    expect(ssz.altair.SyncAggregate.equals(aggregate, ssz.altair.SyncAggregate.defaultValue())).to.equal(false);
     // TODO Test it's correct. Modify the contributions above so they have 1 bit set to true
     expect(aggregate.syncCommitteeBits.bitLen).to.be.equal(32);
   });

--- a/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
+++ b/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
@@ -66,7 +66,7 @@ describe("PrepareNextSlot scheduler", () => {
   it("pre bellatrix - should not run due to not last slot of epoch", async () => {
     getForkSeqStub.returns(ForkSeq.phase0);
     await scheduler.prepareForNextSlot(3);
-    expect(forkChoiceStub.updateHead.called).to.be.false;
+    expect(forkChoiceStub.updateHead.called).to.equal(false);
   });
 
   it("pre bellatrix - should skip, headSlot is more than 1 epoch to prepare slot", async () => {
@@ -76,8 +76,8 @@ describe("PrepareNextSlot scheduler", () => {
       scheduler.prepareForNextSlot(2 * SLOTS_PER_EPOCH - 1),
       sandbox.clock.tickAsync((config.SECONDS_PER_SLOT * 1000 * 2) / 3),
     ]);
-    expect(forkChoiceStub.updateHead.called, "expect forkChoice.updateHead to be called").to.be.true;
-    expect(regenStub.getBlockSlotState.called, "expect regen.getBlockSlotState not to be called").to.be.false;
+    expect(forkChoiceStub.updateHead.called, "expect forkChoice.updateHead to be called").to.equal(true);
+    expect(regenStub.getBlockSlotState.called, "expect regen.getBlockSlotState not to be called").to.equal(false);
   });
 
   it("pre bellatrix - should run regen.getBlockSlotState", async () => {
@@ -88,22 +88,22 @@ describe("PrepareNextSlot scheduler", () => {
       scheduler.prepareForNextSlot(SLOTS_PER_EPOCH - 1),
       sandbox.clock.tickAsync((config.SECONDS_PER_SLOT * 1000 * 2) / 3),
     ]);
-    expect(forkChoiceStub.updateHead.called, "expect forkChoice.updateHead to be called").to.be.true;
-    expect(regenStub.getBlockSlotState.called, "expect regen.getBlockSlotState to be called").to.be.true;
+    expect(forkChoiceStub.updateHead.called, "expect forkChoice.updateHead to be called").to.equal(true);
+    expect(regenStub.getBlockSlotState.called, "expect regen.getBlockSlotState to be called").to.equal(true);
   });
 
   it("pre bellatrix - should handle regen.getBlockSlotState error", async () => {
     getForkSeqStub.returns(ForkSeq.phase0);
     forkChoiceStub.updateHead.returns({slot: SLOTS_PER_EPOCH - 1} as ProtoBlock);
     regenStub.getBlockSlotState.rejects("Unit test error");
-    expect(loggerStub.error.calledOnce).to.be.false;
+    expect(loggerStub.error.calledOnce).to.equal(false);
     await Promise.all([
       scheduler.prepareForNextSlot(SLOTS_PER_EPOCH - 1),
       sandbox.clock.tickAsync((config.SECONDS_PER_SLOT * 1000 * 2) / 3),
     ]);
-    expect(forkChoiceStub.updateHead.called, "expect forkChoice.updateHead to be called").to.be.true;
-    expect(regenStub.getBlockSlotState.called, "expect regen.getBlockSlotState to be called").to.be.true;
-    expect(loggerStub.error.calledOnce, "expect log error on rejected regen.getBlockSlotState").to.be.true;
+    expect(forkChoiceStub.updateHead.called, "expect forkChoice.updateHead to be called").to.equal(true);
+    expect(regenStub.getBlockSlotState.called, "expect regen.getBlockSlotState to be called").to.equal(true);
+    expect(loggerStub.error.calledOnce, "expect log error on rejected regen.getBlockSlotState").to.equal(true);
   });
 
   it("bellatrix - should skip, headSlot is more than 1 epoch to prepare slot", async () => {
@@ -113,8 +113,8 @@ describe("PrepareNextSlot scheduler", () => {
       scheduler.prepareForNextSlot(2 * SLOTS_PER_EPOCH - 1),
       sandbox.clock.tickAsync((config.SECONDS_PER_SLOT * 1000 * 2) / 3),
     ]);
-    expect(forkChoiceStub.updateHead.called, "expect forkChoice.updateHead to be called").to.be.true;
-    expect(regenStub.getBlockSlotState.called, "expect regen.getBlockSlotState not to be called").to.be.false;
+    expect(forkChoiceStub.updateHead.called, "expect forkChoice.updateHead to be called").to.equal(true);
+    expect(regenStub.getBlockSlotState.called, "expect regen.getBlockSlotState not to be called").to.equal(false);
   });
 
   it("bellatrix - should skip, no block proposer", async () => {
@@ -126,8 +126,8 @@ describe("PrepareNextSlot scheduler", () => {
       scheduler.prepareForNextSlot(SLOTS_PER_EPOCH - 1),
       sandbox.clock.tickAsync((config.SECONDS_PER_SLOT * 1000 * 2) / 3),
     ]);
-    expect(forkChoiceStub.updateHead.called, "expect forkChoice.updateHead to be called").to.be.true;
-    expect(regenStub.getBlockSlotState.called, "expect regen.getBlockSlotState to be called").to.be.true;
+    expect(forkChoiceStub.updateHead.called, "expect forkChoice.updateHead to be called").to.equal(true);
+    expect(regenStub.getBlockSlotState.called, "expect regen.getBlockSlotState to be called").to.equal(true);
   });
 
   it("bellatrix - should prepare payload", async () => {
@@ -145,10 +145,12 @@ describe("PrepareNextSlot scheduler", () => {
       sandbox.clock.tickAsync((config.SECONDS_PER_SLOT * 1000 * 2) / 3),
     ]);
 
-    expect(forkChoiceStub.updateHead.called, "expect forkChoice.updateHead to be called").to.be.true;
-    expect(regenStub.getBlockSlotState.called, "expect regen.getBlockSlotState to be called").to.be.true;
-    expect(forkChoiceStub.getJustifiedBlock.called, "expect forkChoice.getJustifiedBlock to be called").to.be.true;
-    expect(forkChoiceStub.getFinalizedBlock.called, "expect forkChoice.getFinalizedBlock to be called").to.be.true;
-    expect(executionEngineStub.notifyForkchoiceUpdate.calledOnce, "expect CL call notifyForkchoiceUpdate").to.be.true;
+    expect(forkChoiceStub.updateHead.called, "expect forkChoice.updateHead to be called").to.equal(true);
+    expect(regenStub.getBlockSlotState.called, "expect regen.getBlockSlotState to be called").to.equal(true);
+    expect(forkChoiceStub.getJustifiedBlock.called, "expect forkChoice.getJustifiedBlock to be called").to.equal(true);
+    expect(forkChoiceStub.getFinalizedBlock.called, "expect forkChoice.getFinalizedBlock to be called").to.equal(true);
+    expect(executionEngineStub.notifyForkchoiceUpdate.calledOnce, "expect CL call notifyForkchoiceUpdate").to.equal(
+      true
+    );
   });
 });

--- a/packages/beacon-node/test/unit/db/api/repositories/blockArchive.test.ts
+++ b/packages/beacon-node/test/unit/db/api/repositories/blockArchive.test.ts
@@ -118,13 +118,13 @@ describe("block archive repository", function () {
         encodeKey(Bucket.index_blockArchiveRootIndex, ssz.phase0.BeaconBlock.hashTreeRoot(block.message)),
         intToBytes(block.message.slot, 8, "be")
       ).calledOnce
-    ).to.be.true;
+    ).to.equal(true);
     expect(
       spy.withArgs(
         encodeKey(Bucket.index_blockArchiveParentRootIndex, block.message.parentRoot),
         intToBytes(block.message.slot, 8, "be")
       ).calledOnce
-    ).to.be.true;
+    ).to.equal(true);
   });
 
   it("should store indexes when block batch", async function () {
@@ -136,13 +136,13 @@ describe("block archive repository", function () {
         encodeKey(Bucket.index_blockArchiveRootIndex, ssz.phase0.BeaconBlock.hashTreeRoot(blocks[0].message)),
         intToBytes(blocks[0].message.slot, 8, "be")
       ).calledTwice
-    ).to.be.true;
+    ).to.equal(true);
     expect(
       spy.withArgs(
         encodeKey(Bucket.index_blockArchiveParentRootIndex, blocks[0].message.parentRoot),
         intToBytes(blocks[0].message.slot, 8, "be")
       ).calledTwice
-    ).to.be.true;
+    ).to.equal(true);
   });
 
   it("should get slot by root", async function () {
@@ -157,7 +157,7 @@ describe("block archive repository", function () {
     await blockArchive.add(block);
     const retrieved = await blockArchive.getByRoot(ssz.phase0.BeaconBlock.hashTreeRoot(block.message));
     if (!retrieved) throw Error("getByRoot returned null");
-    expect(ssz.phase0.SignedBeaconBlock.equals(retrieved, block)).to.be.true;
+    expect(ssz.phase0.SignedBeaconBlock.equals(retrieved, block)).to.equal(true);
   });
 
   it("should get slot by parent root", async function () {
@@ -172,6 +172,6 @@ describe("block archive repository", function () {
     await blockArchive.add(block);
     const retrieved = await blockArchive.getByParentRoot(block.message.parentRoot);
     if (!retrieved) throw Error("getByRoot returned null");
-    expect(ssz.phase0.SignedBeaconBlock.equals(retrieved, block)).to.be.true;
+    expect(ssz.phase0.SignedBeaconBlock.equals(retrieved, block)).to.equal(true);
   });
 });

--- a/packages/beacon-node/test/unit/db/api/repository.test.ts
+++ b/packages/beacon-node/test/unit/db/api/repository.test.ts
@@ -43,46 +43,46 @@ describe("database repository", function () {
     controller.get.resolves(TestSSZType.serialize(item) as Buffer);
     const result = await repository.get("id");
     expect(result).to.be.deep.equal(item);
-    expect(controller.get.calledOnce).to.be.true;
+    expect(controller.get.calledOnce).to.equal(true);
   });
 
   it("should return null if item not found", async function () {
     controller.get.resolves(null);
     const result = await repository.get("id");
     expect(result).to.be.deep.equal(null);
-    expect(controller.get.calledOnce).to.be.true;
+    expect(controller.get.calledOnce).to.equal(true);
   });
 
   it("should return true if item exists", async function () {
     const item = {bool: true, bytes: Buffer.alloc(32)};
     controller.get.resolves(TestSSZType.serialize(item) as Buffer);
     const result = await repository.has("id");
-    expect(result).to.be.true;
-    expect(controller.get.calledOnce).to.be.true;
+    expect(result).to.equal(true);
+    expect(controller.get.calledOnce).to.equal(true);
   });
 
   it("should return false if item doesnt exists", async function () {
     controller.get.resolves(null);
     const result = await repository.has("id");
-    expect(result).to.be.false;
-    expect(controller.get.calledOnce).to.be.true;
+    expect(result).to.equal(false);
+    expect(controller.get.calledOnce).to.equal(true);
   });
 
   it("should store with hashTreeRoot as id", async function () {
     const item = {bool: true, bytes: Buffer.alloc(32)};
     await expect(repository.add(item)).to.not.be.rejected;
-    expect(controller.put.calledOnce).to.be.true;
+    expect(controller.put.calledOnce).to.equal(true);
   });
 
   it("should store with given id", async function () {
     const item = {bool: true, bytes: Buffer.alloc(32)};
     await expect(repository.put("1", item)).to.not.be.rejected;
-    expect(controller.put.calledOnce).to.be.true;
+    expect(controller.put.calledOnce).to.equal(true);
   });
 
   it("should delete", async function () {
     await expect(repository.delete("1")).to.not.be.rejected;
-    expect(controller.delete.calledOnce).to.be.true;
+    expect(controller.delete.calledOnce).to.equal(true);
   });
 
   it("should return all items", async function () {
@@ -92,12 +92,12 @@ describe("database repository", function () {
     controller.values.resolves(items as Buffer[]);
     const result = await repository.values();
     expect(result).to.be.deep.equal([item, item, item]);
-    expect(controller.values.calledOnce).to.be.true;
+    expect(controller.values.calledOnce).to.equal(true);
   });
 
   it("should return range of items", async function () {
     await repository.values({gt: "a", lt: "b"});
-    expect(controller.values.calledOnce).to.be.true;
+    expect(controller.values.calledOnce).to.equal(true);
   });
 
   it("should delete given items", async function () {

--- a/packages/beacon-node/test/unit/eth1/utils/deposits.test.ts
+++ b/packages/beacon-node/test/unit/eth1/utils/deposits.test.ts
@@ -143,7 +143,7 @@ describe("eth1 / util / deposits", function () {
             eth1Data.depositRoot
           ),
           `Wrong merkle proof on deposit ${index}`
-        ).to.be.true;
+        ).to.equal(true);
       }
     });
   });

--- a/packages/beacon-node/test/unit/network/attestationService.test.ts
+++ b/packages/beacon-node/test/unit/network/attestationService.test.ts
@@ -81,24 +81,24 @@ describe.skip("AttnetsService", function () {
 
   it("should not subscribe when there is no active validator", () => {
     chain.emitter.emit(ChainEvent.clockSlot, 1);
-    expect(gossipStub.subscribeTopic.called).to.be.false;
+    expect(gossipStub.subscribeTopic.called).to.equal(false);
   });
 
   it.skip("should subscribe to RANDOM_SUBNETS_PER_VALIDATOR per 1 validator", () => {
     randomUtil.withArgs(0, ATTESTATION_SUBNET_COUNT).returns(30);
     randomUtil.withArgs(0, ATTESTATION_SUBNET_COUNT - 1).returns(40);
     service.addCommitteeSubscriptions([subscription]);
-    expect(gossipStub.subscribeTopic.calledOnce).to.be.true;
+    expect(gossipStub.subscribeTopic.calledOnce).to.equal(true);
     expect(metadata.seqNumber).to.be.equal(BigInt(1));
     // subscribe with a different validator
     subscription.validatorIndex = 2022;
     service.addCommitteeSubscriptions([subscription]);
-    expect(gossipStub.subscribeTopic.calledTwice).to.be.true;
+    expect(gossipStub.subscribeTopic.calledTwice).to.equal(true);
     expect(metadata.seqNumber).to.be.equal(BigInt(2));
     // subscribe with same validator
     subscription.validatorIndex = 2021;
     service.addCommitteeSubscriptions([subscription]);
-    expect(gossipStub.subscribeTopic.calledTwice).to.be.true;
+    expect(gossipStub.subscribeTopic.calledTwice).to.equal(true);
     expect(metadata.seqNumber).to.be.equal(BigInt(2));
   });
 
@@ -107,14 +107,14 @@ describe.skip("AttnetsService", function () {
     expect(metadata.seqNumber).to.be.equal(BigInt(1));
     expect(EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION * SLOTS_PER_EPOCH).to.be.gt(150);
     sandbox.clock.tick(150 * SLOTS_PER_EPOCH * SECONDS_PER_SLOT * 1000);
-    expect(gossipStub.unsubscribeTopic.called).to.be.true;
+    expect(gossipStub.unsubscribeTopic.called).to.equal(true);
     // subscribe then unsubscribe
     expect(metadata.seqNumber).to.be.equal(BigInt(2));
   });
 
   it.skip("should change subnet subscription after 2*EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION", async () => {
     service.addCommitteeSubscriptions([subscription]);
-    expect(gossipStub.subscribeTopic.calledOnce).to.be.true;
+    expect(gossipStub.subscribeTopic.calledOnce).to.equal(true);
     expect(metadata.seqNumber).to.be.equal(BigInt(1));
     for (let numEpoch = 0; numEpoch < 2 * EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION; numEpoch++) {
       // avoid known validator expiry
@@ -122,7 +122,7 @@ describe.skip("AttnetsService", function () {
       sandbox.clock.tick(SLOTS_PER_EPOCH * SECONDS_PER_SLOT * 1000);
     }
     // may call 2 times, 1 for committee subnet, 1 for random subnet
-    expect(gossipStub.unsubscribeTopic.called).to.be.true;
+    expect(gossipStub.unsubscribeTopic.called).to.equal(true);
     // subscribe then unsubscribe then subscribe again
     expect(metadata.seqNumber).to.be.equal(BigInt(3));
   });
@@ -161,11 +161,11 @@ describe.skip("AttnetsService", function () {
     service.addCommitteeSubscriptions([aggregatorSubscription]);
     expect(service.getActiveSubnets()).to.be.deep.equal([COMMITTEE_SUBNET_SUBSCRIPTION]);
     // committee subnet is same to random subnet
-    expect(gossipStub.subscribeTopic.calledOnce).to.be.true;
+    expect(gossipStub.subscribeTopic.calledOnce).to.equal(true);
     expect(metadata.seqNumber).to.be.equal(BigInt(1));
     // pass through subscription slot
     sandbox.clock.tick((aggregatorSubscription.slot + 2) * SECONDS_PER_SLOT * 1000);
     // don't unsubscribe bc random subnet is still there
-    expect(gossipStub.unsubscribeTopic.called).to.be.false;
+    expect(gossipStub.unsubscribeTopic.called).to.equal(false);
   });
 });

--- a/packages/beacon-node/test/unit/network/peers/datastore.test.ts
+++ b/packages/beacon-node/test/unit/network/peers/datastore.test.ts
@@ -21,9 +21,9 @@ describe("Eth2PeerDataStore", () => {
 
   it("should persist to db after threshold put", async () => {
     await eth2Datastore.put(new Key("k1"), Buffer.from("1"));
-    expect(dbDatastoreStub.batch.calledOnce).to.be.false;
+    expect(dbDatastoreStub.batch.calledOnce).to.equal(false);
     await eth2Datastore.put(new Key("k2"), Buffer.from("2"));
-    expect(dbDatastoreStub.batch.calledOnce).to.be.true;
+    expect(dbDatastoreStub.batch.calledOnce).to.equal(true);
   });
 
   it("should persist to db the oldest item after max", async () => {
@@ -35,38 +35,38 @@ describe("Eth2PeerDataStore", () => {
     // 2nd, not call dbDatastoreStub.put yet
     await eth2Datastore.put(new Key("k2"), Buffer.from("2"));
     expect(await eth2Datastore.get(new Key("k1"))).to.be.deep.equal(Buffer.from("1"));
-    expect(dbDatastoreStub.put.calledOnce).to.be.false;
+    expect(dbDatastoreStub.put.calledOnce).to.equal(false);
     // 3rd item, not call dbDatastoreStub.put yet
     await eth2Datastore.put(new Key("k3"), Buffer.from("3"));
     expect(await eth2Datastore.get(new Key("k3"))).to.be.deep.equal(Buffer.from("3"));
-    expect(dbDatastoreStub.put.calledOnce).to.be.false;
+    expect(dbDatastoreStub.put.calledOnce).to.equal(false);
 
     // 4th item, should evict 1st item since it's oldest
     await eth2Datastore.put(new Key("k4"), Buffer.from("4"));
     expect(await eth2Datastore.get(new Key("k4"))).to.be.deep.equal(Buffer.from("4"));
-    expect(dbDatastoreStub.put.calledOnceWith(new Key("k1"), Buffer.from("1"))).to.be.true;
+    expect(dbDatastoreStub.put.calledOnceWith(new Key("k1"), Buffer.from("1"))).to.equal(true);
 
     // still able to get k1 from datastore
-    expect(dbDatastoreStub.get.calledOnce).to.be.false;
+    expect(dbDatastoreStub.get.calledOnce).to.equal(false);
     dbDatastoreStub.get.resolves(Buffer.from("1"));
     expect(await eth2Datastore.get(new Key("k1"))).to.be.deep.equal(Buffer.from("1"));
-    expect(dbDatastoreStub.get.calledOnce).to.be.true;
+    expect(dbDatastoreStub.get.calledOnce).to.equal(true);
 
     // access k1 again, should not query db
     expect(await eth2Datastore.get(new Key("k1"))).to.be.deep.equal(Buffer.from("1"));
-    expect(dbDatastoreStub.get.calledOnce).to.be.true;
-    expect(dbDatastoreStub.get.calledTwice).to.be.false;
+    expect(dbDatastoreStub.get.calledOnce).to.equal(true);
+    expect(dbDatastoreStub.get.calledTwice).to.equal(false);
   });
 
   it("should put to memory cache if item was found from db", async () => {
     dbDatastoreStub.get.resolves(Buffer.from("1"));
     // query db for the first time
     expect(await eth2Datastore.get(new Key("k1"))).to.be.deep.equal(Buffer.from("1"));
-    expect(dbDatastoreStub.get.calledOnce).to.be.true;
+    expect(dbDatastoreStub.get.calledOnce).to.equal(true);
 
     // this time it should not query from db
     expect(await eth2Datastore.get(new Key("k1"))).to.be.deep.equal(Buffer.from("1"));
-    expect(dbDatastoreStub.get.calledOnce).to.be.true;
-    expect(dbDatastoreStub.get.calledTwice).to.be.false;
+    expect(dbDatastoreStub.get.calledOnce).to.equal(true);
+    expect(dbDatastoreStub.get.calledTwice).to.equal(false);
   });
 });

--- a/packages/beacon-node/test/unit/network/peers/score.test.ts
+++ b/packages/beacon-node/test/unit/network/peers/score.test.ts
@@ -80,11 +80,11 @@ describe("updateGossipsubScores", function () {
       ]),
       2
     );
-    expect(peerRpcScoresStub.updateGossipsubScore.calledWith("a", 10, false)).to.be.true;
+    expect(peerRpcScoresStub.updateGossipsubScore.calledWith("a", 10, false)).to.equal(true);
     // should ignore b d since they are 2 biggest negative scores
-    expect(peerRpcScoresStub.updateGossipsubScore.calledWith("b", -10, true)).to.be.true;
-    expect(peerRpcScoresStub.updateGossipsubScore.calledWith("d", -5, true)).to.be.true;
+    expect(peerRpcScoresStub.updateGossipsubScore.calledWith("b", -10, true)).to.equal(true);
+    expect(peerRpcScoresStub.updateGossipsubScore.calledWith("d", -5, true)).to.equal(true);
     // should not ignore c as it's lowest negative scores
-    expect(peerRpcScoresStub.updateGossipsubScore.calledWith("c", -20, false)).to.be.true;
+    expect(peerRpcScoresStub.updateGossipsubScore.calledWith("c", -20, false)).to.equal(true);
   });
 });

--- a/packages/beacon-node/test/unit/network/reqresp/encodingStrategies/sszSnappy/snappy-frames/uncompress.test.ts
+++ b/packages/beacon-node/test/unit/network/reqresp/encodingStrategies/sszSnappy/snappy-frames/uncompress.test.ts
@@ -50,6 +50,6 @@ describe("snappy frames uncompress", function () {
   it("should return null if not enough data", function () {
     const decompress = new SnappyFramesUncompress();
 
-    expect(decompress.uncompress(Buffer.alloc(3, 1))).to.be.null;
+    expect(decompress.uncompress(Buffer.alloc(3, 1))).to.equal(null);
   });
 });

--- a/packages/beacon-node/test/unit/network/reqresp/response/rateLimiter.test.ts
+++ b/packages/beacon-node/test/unit/network/reqresp/response/rateLimiter.test.ts
@@ -39,23 +39,23 @@ describe("ResponseRateLimiter", () => {
     const peerId = await PeerId.create();
     const requestTyped = {method: Method.Ping, body: BigInt(1)} as RequestTypedContainer;
     for (let i = 0; i < defaultNetworkOptions.requestCountPeerLimit; i++) {
-      expect(inboundRateLimiter.allowRequest(peerId, requestTyped)).to.be.true;
+      expect(inboundRateLimiter.allowRequest(peerId, requestTyped)).to.equal(true);
     }
     const peerId2 = await PeerId.create();
     // it's ok to request blocks for another peer
-    expect(inboundRateLimiter.allowRequest(peerId2, requestTyped)).to.be.true;
-    expect(peerRpcScoresStub.applyAction.calledOnce).to.be.false;
+    expect(inboundRateLimiter.allowRequest(peerId2, requestTyped)).to.equal(true);
+    expect(peerRpcScoresStub.applyAction.calledOnce).to.equal(false);
     // not ok for the same peer id as it reached the limit
-    expect(inboundRateLimiter.allowRequest(peerId, requestTyped)).to.be.false;
+    expect(inboundRateLimiter.allowRequest(peerId, requestTyped)).to.equal(false);
     // this peer id abuses us
     expect(
       peerRpcScoresStub.applyAction.calledOnceWith(peerId, PeerAction.Fatal, sinon.match.any),
       "peer1 is banned due to requestCountPeerLimit"
-    ).to.be.true;
+    ).to.equal(true);
 
     sandbox.clock.tick(60 * 1000);
     // try again after timeout
-    expect(inboundRateLimiter.allowRequest(peerId, requestTyped)).to.be.true;
+    expect(inboundRateLimiter.allowRequest(peerId, requestTyped)).to.equal(true);
   });
 
   /**
@@ -70,16 +70,16 @@ describe("ResponseRateLimiter", () => {
     const blockCount = Math.floor(defaultNetworkOptions.blockCountTotalLimit / 2);
     const requestTyped = {method: Method.BeaconBlocksByRange, body: {count: blockCount}} as RequestTypedContainer;
     for (let i = 0; i < 2; i++) {
-      expect(inboundRateLimiter.allowRequest(await PeerId.create(), requestTyped)).to.be.true;
+      expect(inboundRateLimiter.allowRequest(await PeerId.create(), requestTyped)).to.equal(true);
     }
 
     const oneBlockRequestTyped = {method: Method.BeaconBlocksByRoot, body: [Buffer.alloc(32)]} as RequestTypedContainer;
-    expect(inboundRateLimiter.allowRequest(await PeerId.create(), oneBlockRequestTyped)).to.be.false;
-    expect(peerRpcScoresStub.applyAction.calledOnce).to.be.false;
+    expect(inboundRateLimiter.allowRequest(await PeerId.create(), oneBlockRequestTyped)).to.equal(false);
+    expect(peerRpcScoresStub.applyAction.calledOnce).to.equal(false);
 
     sandbox.clock.tick(60 * 1000);
     // try again after timeout
-    expect(inboundRateLimiter.allowRequest(await PeerId.create(), oneBlockRequestTyped)).to.be.true;
+    expect(inboundRateLimiter.allowRequest(await PeerId.create(), oneBlockRequestTyped)).to.equal(true);
   });
 
   /**
@@ -96,23 +96,23 @@ describe("ResponseRateLimiter", () => {
     const requestTyped = {method: Method.BeaconBlocksByRange, body: {count: blockCount}} as RequestTypedContainer;
     const peerId = await PeerId.create();
     for (let i = 0; i < 2; i++) {
-      expect(inboundRateLimiter.allowRequest(peerId, requestTyped)).to.be.true;
+      expect(inboundRateLimiter.allowRequest(peerId, requestTyped)).to.equal(true);
     }
     const peerId2 = await PeerId.create();
     const oneBlockRequestTyped = {method: Method.BeaconBlocksByRoot, body: [Buffer.alloc(32)]} as RequestTypedContainer;
     // it's ok to request blocks for another peer
-    expect(inboundRateLimiter.allowRequest(peerId2, oneBlockRequestTyped)).to.be.true;
+    expect(inboundRateLimiter.allowRequest(peerId2, oneBlockRequestTyped)).to.equal(true);
     // not ok for the same peer id as it reached the limit
-    expect(inboundRateLimiter.allowRequest(peerId, oneBlockRequestTyped)).to.be.false;
+    expect(inboundRateLimiter.allowRequest(peerId, oneBlockRequestTyped)).to.equal(false);
     // this peer id abuses us
     expect(
       peerRpcScoresStub.applyAction.calledOnceWith(peerId, PeerAction.Fatal, sinon.match.any),
       "peer1 is banned due to blockCountPeerLimit"
-    ).to.be.true;
+    ).to.equal(true);
 
     sandbox.clock.tick(60 * 1000);
     // try again after timeout
-    expect(inboundRateLimiter.allowRequest(peerId, oneBlockRequestTyped)).to.be.true;
+    expect(inboundRateLimiter.allowRequest(peerId, oneBlockRequestTyped)).to.equal(true);
   });
 
   it("should remove rate tracker for disconnected peers", async () => {
@@ -120,14 +120,14 @@ describe("ResponseRateLimiter", () => {
     const pruneStub = sandbox.stub(inboundRateLimiter, "pruneByPeerIdStr" as keyof InboundRateLimiter);
     inboundRateLimiter.start();
     const requestTyped = {method: Method.Ping, body: BigInt(1)} as RequestTypedContainer;
-    expect(inboundRateLimiter.allowRequest(peerId, requestTyped)).to.be.true;
+    expect(inboundRateLimiter.allowRequest(peerId, requestTyped)).to.equal(true);
 
     // no request is made in 5 minutes
     sandbox.clock.tick(5 * 60 * 1000);
-    expect(pruneStub.calledOnce).to.be.false;
+    expect(pruneStub.calledOnce).to.equal(false);
     // wait for 5 more minutes for the timer to run
     sandbox.clock.tick(5 * 60 * 1000);
-    expect(pruneStub.calledOnce, "prune is not called").to.be.true;
+    expect(pruneStub.calledOnce, "prune is not called").to.equal(true);
   });
 
   it.skip("rateLimiter memory usage", async function () {

--- a/packages/beacon-node/test/unit/network/util.test.ts
+++ b/packages/beacon-node/test/unit/network/util.test.ts
@@ -17,12 +17,12 @@ async function createPeerId(): Promise<PeerId> {
 describe("Test isLocalMultiAddr", () => {
   it("should return true for 127.0.0.1", () => {
     const multi0 = new Multiaddr("/ip4/127.0.0.1/udp/30303");
-    expect(isLocalMultiAddr(multi0)).to.be.true;
+    expect(isLocalMultiAddr(multi0)).to.equal(true);
   });
 
   it("should return false for 0.0.0.0", () => {
     const multi0 = new Multiaddr("/ip4/0.0.0.0/udp/30303");
-    expect(isLocalMultiAddr(multi0)).to.be.false;
+    expect(isLocalMultiAddr(multi0)).to.equal(false);
   });
 });
 

--- a/packages/beacon-node/test/unit/util/address.test.ts
+++ b/packages/beacon-node/test/unit/util/address.test.ts
@@ -4,13 +4,13 @@ import {isValidAddress} from "../../../src/util/address.js";
 
 describe("Eth address helper", () => {
   it("should be valid address", () => {
-    expect(isValidAddress("0x0000000000000000000000000000000000000000")).to.be.true;
-    expect(isValidAddress("0x1C2D4a6b0e85e802952968d2DFBA985f2F5f339d")).to.be.true;
+    expect(isValidAddress("0x0000000000000000000000000000000000000000")).to.equal(true);
+    expect(isValidAddress("0x1C2D4a6b0e85e802952968d2DFBA985f2F5f339d")).to.equal(true);
   });
 
   it("should not be valid address", () => {
-    expect(isValidAddress("0x00")).to.be.false;
-    expect(isValidAddress("TPB")).to.be.false;
-    expect(isValidAddress(null as any)).to.be.false;
+    expect(isValidAddress("0x00")).to.equal(false);
+    expect(isValidAddress("TPB")).to.equal(false);
+    expect(isValidAddress(null as any)).to.equal(false);
   });
 });

--- a/packages/beacon-node/test/unit/util/file.test.ts
+++ b/packages/beacon-node/test/unit/util/file.test.ts
@@ -9,9 +9,9 @@ describe("file util", function () {
 
   describe("ensureDir", function () {
     it("create dir if not exists", async () => {
-      expect(fs.existsSync(dirPath), `${dirPath} should not exist`).to.be.false;
+      expect(fs.existsSync(dirPath), `${dirPath} should not exist`).to.equal(false);
       await ensureDir(dirPath);
-      expect(fs.existsSync(dirPath), `${dirPath} should exist`).to.be.true;
+      expect(fs.existsSync(dirPath), `${dirPath} should exist`).to.equal(true);
       fs.rmdirSync(dirPath);
     });
   });
@@ -28,8 +28,8 @@ describe("file util", function () {
     });
 
     it("write to a non-existed file", async () => {
-      expect(fs.existsSync(filePath)).to.be.false;
-      expect(await writeIfNotExist(filePath, data)).to.be.true;
+      expect(fs.existsSync(filePath)).to.equal(false);
+      expect(await writeIfNotExist(filePath, data)).to.equal(true);
       const bytes = fs.readFileSync(filePath);
       expect(new Uint8Array(bytes)).to.be.deep.equals(data);
 
@@ -39,7 +39,7 @@ describe("file util", function () {
 
     it("write to an existing file", async () => {
       fs.writeFileSync(filePath, new Uint8Array([3, 4]));
-      expect(await writeIfNotExist(filePath, data)).to.be.false;
+      expect(await writeIfNotExist(filePath, data)).to.equal(false);
       const bytes = fs.readFileSync(filePath);
       expect(new Uint8Array(bytes)).not.to.be.deep.equals(data);
 

--- a/packages/cli/test/unit/config/fileEnr.test.ts
+++ b/packages/cli/test/unit/config/fileEnr.test.ts
@@ -28,9 +28,9 @@ describe("fileENR", function () {
     const enr = FileENR.initFromFile(enrFilePath, peerId);
     const newValue = new Uint8Array(55);
     enr.set("tcp", newValue);
-    expect(existsSync(enrFilePath), `ENR does not exist at ${enrFilePath}`).to.be.true;
+    expect(existsSync(enrFilePath), `ENR does not exist at ${enrFilePath}`).to.equal(true);
     const updatedEnr = FileENR.initFromFile(enrFilePath, peerId);
     expect(updatedEnr.get("tcp")).to.not.be.undefined;
-    expect(toHexString(updatedEnr.get("tcp") as Uint8Array) === toHexString(newValue)).to.be.true;
+    expect(toHexString(updatedEnr.get("tcp") as Uint8Array) === toHexString(newValue)).to.equal(true);
   });
 });

--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -28,7 +28,7 @@ describe("LevelDB controller", () => {
     await db.put(key, value);
     expect(await db.get(key)).to.be.deep.equal(value);
     await db.delete(key);
-    expect(await db.get(key)).to.be.null;
+    expect(await db.get(key)).to.equal(null);
   });
 
   it("test batchPut", async () => {

--- a/packages/utils/test/unit/objects.test.ts
+++ b/packages/utils/test/unit/objects.test.ts
@@ -3,17 +3,17 @@ import {isPlainObject, objectToExpectedCase} from "../../src/index.js";
 
 describe("Objects helper", () => {
   it("should be plain object", () => {
-    expect(isPlainObject(Object.create({}))).to.be.true;
-    expect(isPlainObject(Object.create(Object.create(Object.prototype)))).to.be.true;
-    expect(isPlainObject({foo: "bar"})).to.be.true;
-    expect(isPlainObject({})).to.be.true;
+    expect(isPlainObject(Object.create({}))).to.equal(true);
+    expect(isPlainObject(Object.create(Object.create(Object.prototype)))).to.equal(true);
+    expect(isPlainObject({foo: "bar"})).to.equal(true);
+    expect(isPlainObject({})).to.equal(true);
   });
 
   it("should not be plain object", () => {
-    expect(isPlainObject(1)).to.be.false;
-    expect(isPlainObject(["foo", "bar"])).to.be.false;
-    expect(isPlainObject([])).to.be.false;
-    expect(isPlainObject(null)).to.be.false;
+    expect(isPlainObject(1)).to.equal(false);
+    expect(isPlainObject(["foo", "bar"])).to.equal(false);
+    expect(isPlainObject([])).to.equal(false);
+    expect(isPlainObject(null)).to.equal(false);
   });
 });
 

--- a/packages/utils/test/unit/promise.test.ts
+++ b/packages/utils/test/unit/promise.test.ts
@@ -17,9 +17,9 @@ describe("callFnWhenAwait util", function () {
     const stub = sandbox.stub();
     const result = await Promise.all([callFnWhenAwait(p, stub, 2 * 1000), sandbox.clock.tickAsync(5000)]);
     expect(result[0]).to.be.equal("done");
-    expect(stub.calledTwice).to.be.true;
+    expect(stub.calledTwice).to.equal(true);
     await sandbox.clock.tickAsync(5000);
-    expect(stub.calledTwice).to.be.true;
+    expect(stub.calledTwice).to.equal(true);
   });
 
   it("should throw error", async () => {
@@ -30,7 +30,7 @@ describe("callFnWhenAwait util", function () {
       expect.fail("should throw error here");
     } catch (e) {
       expect((e as Error).message).to.be.equal("done");
-      expect(stub.calledTwice).to.be.true;
+      expect(stub.calledTwice).to.equal(true);
     }
   });
 });

--- a/packages/utils/test/unit/sleep.test.ts
+++ b/packages/utils/test/unit/sleep.test.ts
@@ -26,7 +26,7 @@ describe("sleep", function () {
     const controller = new AbortController();
 
     controller.abort();
-    expect(controller.signal.aborted, "Signal should already be aborted").to.be.true;
+    expect(controller.signal.aborted, "Signal should already be aborted").to.equal(true);
 
     await expect(sleep(0, controller.signal)).to.rejectedWith(ErrorAborted);
   });

--- a/packages/utils/test/unit/timeout.test.ts
+++ b/packages/utils/test/unit/timeout.test.ts
@@ -69,7 +69,7 @@ describe("withTimeout", function () {
     const controller = new AbortController();
 
     controller.abort();
-    expect(controller.signal.aborted, "Signal should already be aborted").to.be.true;
+    expect(controller.signal.aborted, "Signal should already be aborted").to.equal(true);
 
     await expect(withTimeout(() => pause(shortTimeoutMs, data), shortTimeoutMs, controller.signal)).to.rejectedWith(
       ErrorAborted


### PR DESCRIPTION
**Motivation**

- See https://github.com/ChainSafe/js-libp2p-gossipsub/issues/238

**Description**

Replace usage of chai assertion to.be.$value_name