### PR TITLE
Add and heartbeat to engine exchangeTransitionConfigurationV1 method

### DIFF
--- a/packages/beacon-node/src/execution/engine/disabled.ts
+++ b/packages/beacon-node/src/execution/engine/disabled.ts
@@ -14,4 +14,7 @@ export class ExecutionEngineDisabled implements IExecutionEngine {
   async getPayload(): Promise<never> {
     throw Error("Execution engine disabled");
   }
+  async exchangeTransitionConfigurationV1(): Promise<never> {
+    throw Error("Execution engine disabled");
+  }
 }

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -22,6 +22,7 @@ import {
   PayloadId,
   PayloadAttributes,
   ApiPayloadAttributes,
+  TransitionConfigurationV1,
 } from "./interface.js";
 import {PayloadIdCache} from "./payloadIdCache.js";
 
@@ -60,6 +61,7 @@ export const defaultExecutionEngineHttpOpts: ExecutionEngineHttpOpts = {
 const notifyNewPayloadOpts: ReqOpts = {routeId: "notifyNewPayload"};
 const forkchoiceUpdatedV1Opts: ReqOpts = {routeId: "forkchoiceUpdated"};
 const getPayloadOpts: ReqOpts = {routeId: "getPayload"};
+const exchageTransitionConfigOpts: ReqOpts = {routeId: "exchangeTransitionConfiguration"};
 
 /**
  * based on Ethereum JSON-RPC API and inherits the following properties of this standard:
@@ -283,6 +285,29 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     return parseExecutionPayload(executionPayloadRpc);
   }
 
+  /**
+   * `engine_exchangeTransitionConfigurationV1`
+   *
+   * An api method for EL<>CL transition config matching and heartbeat
+   */
+
+  async exchangeTransitionConfigurationV1(
+    transitionConfiguration: TransitionConfigurationV1
+  ): Promise<TransitionConfigurationV1> {
+    const method = "engine_exchangeTransitionConfigurationV1";
+    const exchangeTransitionConfigurationV1Res = await this.rpc.fetchWithRetries<
+      EngineApiRpcReturnTypes[typeof method],
+      EngineApiRpcParamTypes[typeof method]
+    >(
+      {
+        method,
+        params: [transitionConfiguration],
+      },
+      exchageTransitionConfigOpts
+    );
+    return exchangeTransitionConfigurationV1Res;
+  }
+
   async prunePayloadIdCache(): Promise<void> {
     this.payloadIdCache.prune();
   }
@@ -308,6 +333,10 @@ type EngineApiRpcParamTypes = {
    * 1. payloadId: QUANTITY, 64 Bits - Identifier of the payload building process
    */
   engine_getPayloadV1: [QUANTITY];
+  /**
+   * 1. Object - Instance of TransitionConfigurationV1
+   */
+  engine_exchangeTransitionConfigurationV1: [TransitionConfigurationV1];
 };
 
 type EngineApiRpcReturnTypes = {
@@ -328,6 +357,10 @@ type EngineApiRpcReturnTypes = {
    * payloadId | Error: QUANTITY, 64 Bits - Identifier of the payload building process
    */
   engine_getPayloadV1: ExecutionPayloadRpc;
+  /**
+   * Object - Instance of TransitionConfigurationV1
+   */
+  engine_exchangeTransitionConfigurationV1: TransitionConfigurationV1;
 };
 
 type ExecutionPayloadRpc = {

--- a/packages/beacon-node/src/execution/engine/interface.ts
+++ b/packages/beacon-node/src/execution/engine/interface.ts
@@ -1,4 +1,5 @@
 import {bellatrix, RootHex} from "@lodestar/types";
+import {DATA, QUANTITY} from "../../eth1/provider/utils.js";
 import {PayloadIdCache, PayloadId, ApiPayloadAttributes} from "./payloadIdCache.js";
 
 export {PayloadIdCache, PayloadId, ApiPayloadAttributes};
@@ -47,6 +48,12 @@ export type PayloadAttributes = {
   suggestedFeeRecipient: string;
 };
 
+export type TransitionConfigurationV1 = {
+  terminalTotalDifficulty: QUANTITY;
+  terminalBlockHash: DATA;
+  terminalBlockNumber: QUANTITY;
+};
+
 /**
  * Execution engine represents an abstract protocol to interact with execution clients. Potential transports include:
  * - JSON RPC over network
@@ -93,4 +100,8 @@ export interface IExecutionEngine {
    * https://github.com/ethereum/consensus-specs/blob/dev/specs/merge/validator.md#get_payload
    */
   getPayload(payloadId: PayloadId): Promise<bellatrix.ExecutionPayload>;
+
+  exchangeTransitionConfigurationV1(
+    transitionConfiguration: TransitionConfigurationV1
+  ): Promise<TransitionConfigurationV1>;
 }

--- a/packages/beacon-node/src/execution/engine/mock.ts
+++ b/packages/beacon-node/src/execution/engine/mock.ts
@@ -10,6 +10,7 @@ import {
   PayloadId,
   PayloadAttributes,
   PayloadIdCache,
+  TransitionConfigurationV1,
 } from "./interface.js";
 const INTEROP_GAS_LIMIT = 30e6;
 
@@ -226,6 +227,17 @@ export class ExecutionEngineMock implements IExecutionEngine {
     this.preparingPayloads.delete(payloadIdNbr);
 
     return payload;
+  }
+
+  async exchangeTransitionConfigurationV1(
+    transitionConfiguration: TransitionConfigurationV1
+  ): Promise<TransitionConfigurationV1> {
+    const resTransitionConfig = {
+      terminalTotalDifficulty: transitionConfiguration.terminalTotalDifficulty,
+      terminalBlockHash: transitionConfiguration.terminalBlockHash,
+      terminalBlockNumber: transitionConfiguration.terminalBlockNumber,
+    };
+    return resTransitionConfig;
   }
 
   /**


### PR DESCRIPTION
**Motivation**
Engine expects every now and then a call to exchange transition config otherwise it warns the users as 
```
WARN [08-14|10:16:25.522] Post-merge network, but no beacon client seen. Please launch one to follow the chain! 
WARN [08-14|10:16:55.526] Post-merge network, but no beacon client seen. Please launch one to follow the chain! 
``` 
even if the requests are going at the engine endpoint

<!-- Why is this PR exists? What are the goals of the pull request? -->
Add and heartbeat to engine exchangeTransitionConfigurationV1 method to notify and match merge params with the EL.

On this PR, the EL stops complaining about the CL not being connected, manually tested and verified. (and gives this warning once lodestar is stopped, so as to confirm it saw CL connection/heartbeat: 
```
WARN [08-14|10:27:25.603] Previously seen beacon client is offline. Please ensure it is operational to follow the chain!
```
Closes #4364