### PR TITLE
prefix light client paths with beacon

### DIFF
--- a/packages/api/src/beacon/routes/lightclient.ts
+++ b/packages/api/src/beacon/routes/lightclient.ts
@@ -60,11 +60,11 @@ export type Api = {
  * Define javascript values for each route
  */
 export const routesData: RoutesData<Api> = {
-  getStateProof: {url: "/eth/v1/light_client/proof/:stateId", method: "GET"},
-  getUpdates: {url: "/eth/v1/light_client/updates", method: "GET"},
-  getOptimisticUpdate: {url: "/eth/v1/light_client/optimistic_update/", method: "GET"},
-  getFinalityUpdate: {url: "/eth/v1/light_client/finality_update/", method: "GET"},
-  getBootstrap: {url: "/eth/v1/light_client/bootstrap/:blockRoot", method: "GET"},
+  getStateProof: {url: "/eth/v1/beacon/light_client/proof/:stateId", method: "GET"},
+  getUpdates: {url: "/eth/v1/beacon/light_client/updates", method: "GET"},
+  getOptimisticUpdate: {url: "/eth/v1/beacon/light_client/optimistic_update/", method: "GET"},
+  getFinalityUpdate: {url: "/eth/v1/beacon/light_client/finality_update/", method: "GET"},
+  getBootstrap: {url: "/eth/v1/beacon/light_client/bootstrap/:blockRoot", method: "GET"},
 };
 
 /* eslint-disable @typescript-eslint/naming-convention */


### PR DESCRIPTION
**Motivation**

In other to further harmonise the REST endpoint for light client, this PR prefixes the paths with `beacon`. That is ` /eth2/v1/light_client to /eth2/v1/beacon/light_client/...`

**Additional context**

Based on the comments [here](https://github.com/ethereum/beacon-APIs/pull/181#issuecomment-1122159034) and [here](https://github.com/ethereum/beacon-APIs/pull/181#issuecomment-1159490403)

Closes #4354