### PR TITLE
Add error handling to exchangeTransitionConfiguration

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -574,7 +574,7 @@ export class BeaconChain implements IBeaconChain {
       // - If there is a missmatch in configuration with Geth, see https://github.com/ethereum/go-ethereum/blob/0016eb7eeeb42568c8c20d0cb560ddfc9a938fad/eth/catalyst/api.go#L301
       this.successfulExchangeTransition = false;
 
-      this.logger.warn("Could not validate transition configuration with execution client", clConfig, elConfigRes.err);
+      this.logger.warn("Could not validate transition configuration with execution client", {}, elConfigRes.err);
     } else {
       // Note: This code is useless when connected to Geth. If there's a configuration mismatch Geth returns an
       // error instead of its own transition configuration, so we can't do this comparision.

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -19,8 +19,10 @@ import {CompositeTypeAny, fromHexString, TreeView, Type} from "@chainsafe/ssz";
 import {GENESIS_EPOCH, ZERO_HASH} from "../constants/index.js";
 import {IBeaconDb} from "../db/index.js";
 import {IMetrics} from "../metrics/index.js";
+import {bytesToData, numToQuantity} from "../eth1/provider/utils.js";
+import {wrapError} from "../util/wrapError.js";
 import {IEth1ForBlockProduction} from "../eth1/index.js";
-import {IExecutionEngine, IExecutionBuilder} from "../execution/index.js";
+import {IExecutionEngine, IExecutionBuilder, TransitionConfigurationV1} from "../execution/index.js";
 import {ensureDir, writeIfNotExist} from "../util/file.js";
 import {CheckpointStateCache, StateContextCache} from "./stateCache/index.js";
 import {BlockProcessor, ImportBlockOpts} from "./blocks/index.js";
@@ -108,6 +110,7 @@ export class BeaconChain implements IBeaconChain {
   protected readonly metrics: IMetrics | null;
   private readonly archiver: Archiver;
   private abortController = new AbortController();
+  private successfulExchangeTransition = false;
 
   constructor(
     opts: IChainOptions,
@@ -488,6 +491,13 @@ export class BeaconChain implements IBeaconChain {
     this.syncCommitteeMessagePool.prune(slot);
     this.seenSyncCommitteeMessages.prune(slot);
     this.reprocessController.onSlot(slot);
+
+    if (isFinite(this.config.BELLATRIX_FORK_EPOCH)) {
+      this.exchangeTransitionConfiguration().catch((e) => {
+        // Should never throw
+        this.logger.error("Error on exchangeTransitionConfiguration", {}, e as Error);
+      });
+    }
   }
 
   private onClockEpoch(epoch: Epoch): void {
@@ -541,6 +551,52 @@ export class BeaconChain implements IBeaconChain {
     const headState = this.stateCache.get(this.forkChoice.getHead().stateRoot);
     if (headState) {
       this.opPool.pruneAll(headState);
+    }
+  }
+
+  /**
+   * perform heart beat for EL lest it logs warning that CL is not connected
+   */
+  private async exchangeTransitionConfiguration(): Promise<void> {
+    const clConfig: TransitionConfigurationV1 = {
+      terminalTotalDifficulty: numToQuantity(this.config.TERMINAL_TOTAL_DIFFICULTY),
+      terminalBlockHash: bytesToData(this.config.TERMINAL_BLOCK_HASH),
+      /** terminalBlockNumber has to be set to zero for now as per specs */
+      terminalBlockNumber: numToQuantity(0),
+    };
+
+    const elConfigRes = await wrapError(this.executionEngine.exchangeTransitionConfigurationV1(clConfig));
+
+    if (elConfigRes.err) {
+      // Note: Will throw an error if:
+      // - EL endpoint is offline, unreachable, port not exposed, etc
+      // - JWT secret is not properly configured
+      // - If there is a missmatch in configuration with Geth, see https://github.com/ethereum/go-ethereum/blob/0016eb7eeeb42568c8c20d0cb560ddfc9a938fad/eth/catalyst/api.go#L301
+      this.successfulExchangeTransition = false;
+
+      this.logger.warn("Could not validate transition configuration with execution client", clConfig, elConfigRes.err);
+    } else {
+      // Note: This code is useless when connected to Geth. If there's a configuration mismatch Geth returns an
+      // error instead of its own transition configuration, so we can't do this comparision.
+      const elConfig = elConfigRes.result;
+      const keysToCheck: (keyof TransitionConfigurationV1)[] = ["terminalTotalDifficulty", "terminalBlockHash"];
+      const errors: string[] = [];
+
+      for (const key of keysToCheck) {
+        if (elConfig[key] !== clConfig[key]) {
+          errors.push(`different ${key} (cl ${clConfig[key]} el ${elConfig[key]})`);
+        }
+      }
+
+      if (errors.length > 0) {
+        this.logger.warn(`Transition configuration mismatch: ${errors.join(", ")}`);
+      } else {
+        // Only log once per successful call
+        if (!this.successfulExchangeTransition) {
+          this.logger.info("Validated transition configuration with execution client", clConfig);
+          this.successfulExchangeTransition = true;
+        }
+      }
     }
   }
 

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -5,7 +5,6 @@ import {Slot} from "@lodestar/types";
 import {ILogger, sleep} from "@lodestar/utils";
 import {GENESIS_SLOT, ZERO_HASH_HEX} from "../constants/constants.js";
 import {IMetrics} from "../metrics/index.js";
-import {bytesToData, numToQuantity} from "../eth1/provider/utils.js";
 import {TransitionConfigurationV1} from "../execution/engine/interface.js";
 import {ChainEvent} from "./emitter.js";
 import {prepareExecutionPayload} from "./factory/block/body.js";
@@ -39,24 +38,10 @@ export class PrepareNextSlotScheduler {
     private readonly signal: AbortSignal
   ) {
     this.chain.emitter.on(ChainEvent.clockSlot, this.prepareForNextSlot);
-    // If the merge is configured
-    if (isFinite(this.config.BELLATRIX_FORK_EPOCH)) {
-      this.transitionConfig = {
-        terminalTotalDifficulty: numToQuantity(this.config.TERMINAL_TOTAL_DIFFICULTY),
-        terminalBlockHash: bytesToData(this.config.TERMINAL_BLOCK_HASH),
-        /** terminalBlockNumber has to be set to zero for now as per specs */
-        terminalBlockNumber: numToQuantity(0),
-      };
-      this.chain.emitter.on(ChainEvent.clockSlot, this.performExchangeTransitionHB);
-    }
-
     this.signal.addEventListener(
       "abort",
       () => {
         this.chain.emitter.off(ChainEvent.clockSlot, this.prepareForNextSlot);
-        if (this.transitionConfig) {
-          this.chain.emitter.off(ChainEvent.clockSlot, this.performExchangeTransitionHB);
-        }
       },
       {once: true}
     );
@@ -152,26 +137,6 @@ export class PrepareNextSlotScheduler {
     } catch (e) {
       this.metrics?.precomputeNextEpochTransition.count.inc({result: "error"}, 1);
       this.logger.error("Failed to run prepareForNextSlot", {nextEpoch, isEpochTransition, prepareSlot}, e as Error);
-    }
-  };
-
-  /**
-   * perform heart beat for EL lest it logs warning that CL is not connected
-   */
-  performExchangeTransitionHB = async (_clockSlot: Slot): Promise<void> => {
-    const transitionConfig = this.transitionConfig;
-    if (transitionConfig) {
-      const elTransitionConfig = await this.chain.executionEngine.exchangeTransitionConfigurationV1(transitionConfig);
-      if (
-        elTransitionConfig.terminalTotalDifficulty !== transitionConfig.terminalTotalDifficulty ||
-        elTransitionConfig.terminalBlockHash !== transitionConfig.terminalBlockHash
-      ) {
-        this.logger.error(
-          `Transition config mismatch, actual=${JSON.stringify(elTransitionConfig)}, expected=${JSON.stringify(
-            transitionConfig
-          )}`
-        );
-      }
     }
   };
 }

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -295,7 +295,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     transitionConfiguration: TransitionConfigurationV1
   ): Promise<TransitionConfigurationV1> {
     const method = "engine_exchangeTransitionConfigurationV1";
-    const exchangeTransitionConfigurationV1Res = await this.rpc.fetchWithRetries<
+    return await this.rpc.fetchWithRetries<
       EngineApiRpcReturnTypes[typeof method],
       EngineApiRpcParamTypes[typeof method]
     >(
@@ -305,7 +305,6 @@ export class ExecutionEngineHttp implements IExecutionEngine {
       },
       exchageTransitionConfigOpts
     );
-    return exchangeTransitionConfigurationV1Res;
   }
 
   async prunePayloadIdCache(): Promise<void> {

--- a/packages/beacon-node/src/execution/engine/mock.ts
+++ b/packages/beacon-node/src/execution/engine/mock.ts
@@ -232,12 +232,8 @@ export class ExecutionEngineMock implements IExecutionEngine {
   async exchangeTransitionConfigurationV1(
     transitionConfiguration: TransitionConfigurationV1
   ): Promise<TransitionConfigurationV1> {
-    const resTransitionConfig = {
-      terminalTotalDifficulty: transitionConfiguration.terminalTotalDifficulty,
-      terminalBlockHash: transitionConfiguration.terminalBlockHash,
-      terminalBlockNumber: transitionConfiguration.terminalBlockNumber,
-    };
-    return resTransitionConfig;
+    // echo same configuration from consensus, which will be considered valid
+    return transitionConfiguration;
   }
 
   /**


### PR DESCRIPTION
**Motivation**

- PR https://github.com/ChainSafe/lodestar/pull/4411 introduced exchangeTransitionConfiguration checks

However it has some issues:

- There is no error handling, and errors are very likely to happen here
- Geth returns an error if there's a mismatch so the comparision code would never be reached
- We should not polute the prepareNextSlot unnecessarily

**Description**

- Add error handling to the exchangeTransitionConfiguration calls
- Log that config is validated once per consecutive success calls
- Move code to BeaconChain

Still I fear this will contribute to our bad error / logging UX.
- How would this look like when the EL node is disconnected?
- For Geth's case, do RPC errors render nice enough to print the value from Geth?