### PR TITLE
Remove premature log 'start search pow block'

### DIFF
--- a/packages/beacon-node/src/eth1/eth1MergeBlockTracker.ts
+++ b/packages/beacon-node/src/eth1/eth1MergeBlockTracker.ts
@@ -67,12 +67,6 @@ export class Eth1MergeBlockTracker {
     this.logger = logger;
     this.metrics = metrics;
 
-    // eth1MergeStatus
-    this.logger.info("Starting search for terminal POW block", {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      TERMINAL_TOTAL_DIFFICULTY: this.config.TERMINAL_TOTAL_DIFFICULTY,
-    });
-
     this.status = {code: StatusCode.STOPPED};
 
     signal.addEventListener("abort", () => this.close(), {once: true});


### PR DESCRIPTION
**Motivation**

- From https://github.com/ChainSafe/lodestar/pull/4350 we did not delete this log that is false currently. The search does not start until explicitly called in a function below

**Description**

Remove premature log 'start search pow block'