### PR TITLE
Add dumpDb debug routes

### DIFF
--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -90,6 +90,12 @@ export type Api = {
 
   /** Dump Discv5 Kad values */
   discv5GetKadValues(): Promise<{data: string[]}>;
+
+  /**
+   * Dump level-db entry keys for a given Bucket declared in code, or for all buckets.
+   * @param bucket must be the string name of a bucket entry: `allForks_blockArchive`
+   */
+  dumpDbBucketKeys(bucket?: string): Promise<Record<string, string[]>>;
 };
 
 /**
@@ -111,6 +117,7 @@ export const routesData: RoutesData<Api> = {
   disconnectPeer: {url: "/eth/v1/lodestar/disconnect_peer", method: "POST"},
   getPeers: {url: "/eth/v1/lodestar/peers", method: "GET"},
   discv5GetKadValues: {url: "/eth/v1/debug/discv5-kad-values", method: "GET"},
+  dumpDbBucketKeys: {url: "/eth/v1/debug/dump-db-bucket-keys", method: "GET"},
 };
 
 export type ReqTypes = {
@@ -129,6 +136,7 @@ export type ReqTypes = {
   disconnectPeer: {query: {peerId: string}};
   getPeers: {query: {state?: PeerState[]; direction?: PeerDirection[]}};
   discv5GetKadValues: ReqEmpty;
+  dumpDbBucketKeys: {query: {bucket?: string}};
 };
 
 export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
@@ -168,6 +176,11 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
       schema: {query: {state: Schema.StringArray, direction: Schema.StringArray}},
     },
     discv5GetKadValues: reqEmpty,
+    dumpDbBucketKeys: {
+      writeReq: (bucket) => ({query: {bucket}}),
+      parseReq: ({query}) => [query.bucket],
+      schema: {params: {bucket: Schema.String}},
+    },
   };
 }
 
@@ -185,5 +198,6 @@ export function getReturnTypes(): ReturnTypes<Api> {
     getGossipPeerScoreStats: jsonType("snake"),
     getPeers: jsonType("snake"),
     discv5GetKadValues: jsonType("snake"),
+    dumpDbBucketKeys: sameType(),
   };
 }

--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -95,7 +95,10 @@ export type Api = {
    * Dump level-db entry keys for a given Bucket declared in code, or for all buckets.
    * @param bucket must be the string name of a bucket entry: `allForks_blockArchive`
    */
-  dumpDbBucketKeys(bucket?: string): Promise<Record<string, string[]>>;
+  dumpDbBucketKeys(bucket: string): Promise<string[]>;
+
+  /** Return all entries in the StateArchive index with bucket index_stateArchiveRootIndex */
+  dumpDbStateIndex(): Promise<{root: RootHex; slot: Slot}[]>;
 };
 
 /**
@@ -117,7 +120,8 @@ export const routesData: RoutesData<Api> = {
   disconnectPeer: {url: "/eth/v1/lodestar/disconnect_peer", method: "POST"},
   getPeers: {url: "/eth/v1/lodestar/peers", method: "GET"},
   discv5GetKadValues: {url: "/eth/v1/debug/discv5-kad-values", method: "GET"},
-  dumpDbBucketKeys: {url: "/eth/v1/debug/dump-db-bucket-keys", method: "GET"},
+  dumpDbBucketKeys: {url: "/eth/v1/debug/dump-db-bucket-keys/:bucket", method: "GET"},
+  dumpDbStateIndex: {url: "/eth/v1/debug/dump-db-state-index", method: "GET"},
 };
 
 export type ReqTypes = {
@@ -136,7 +140,8 @@ export type ReqTypes = {
   disconnectPeer: {query: {peerId: string}};
   getPeers: {query: {state?: PeerState[]; direction?: PeerDirection[]}};
   discv5GetKadValues: ReqEmpty;
-  dumpDbBucketKeys: {query: {bucket?: string}};
+  dumpDbBucketKeys: {params: {bucket: string}};
+  dumpDbStateIndex: ReqEmpty;
 };
 
 export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
@@ -177,10 +182,11 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
     },
     discv5GetKadValues: reqEmpty,
     dumpDbBucketKeys: {
-      writeReq: (bucket) => ({query: {bucket}}),
-      parseReq: ({query}) => [query.bucket],
+      writeReq: (bucket) => ({params: {bucket}}),
+      parseReq: ({params}) => [params.bucket],
       schema: {params: {bucket: Schema.String}},
     },
+    dumpDbStateIndex: reqEmpty,
   };
 }
 
@@ -199,5 +205,6 @@ export function getReturnTypes(): ReturnTypes<Api> {
     getPeers: jsonType("snake"),
     discv5GetKadValues: jsonType("snake"),
     dumpDbBucketKeys: sameType(),
+    dumpDbStateIndex: sameType(),
   };
 }

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -1,6 +1,8 @@
 import PeerId from "peer-id";
 import {Multiaddr} from "multiaddr";
 import {routes} from "@lodestar/api";
+import {Bucket, Repository} from "@lodestar/db";
+import {toHex} from "@lodestar/utils";
 import {getLatestWeakSubjectivityCheckpointEpoch} from "@lodestar/state-transition";
 import {toHexString} from "@chainsafe/ssz";
 import {IChainForkConfig} from "@lodestar/config";
@@ -8,15 +10,17 @@ import {ssz} from "@lodestar/types";
 import {BeaconChain} from "../../../chain/index.js";
 import {QueuedStateRegenerator, RegenRequest} from "../../../chain/regen/index.js";
 import {GossipType} from "../../../network/index.js";
+import {IBeaconDb} from "../../../db/interface.js";
 import {ApiModules} from "../types.js";
 import {formatNodePeer} from "../node/utils.js";
 
 export function getLodestarApi({
   chain,
   config,
+  db,
   network,
   sync,
-}: Pick<ApiModules, "chain" | "config" | "network" | "sync">): routes.lodestar.Api {
+}: Pick<ApiModules, "chain" | "config" | "db" | "network" | "sync">): routes.lodestar.Api {
   let writingHeapdump = false;
 
   return {
@@ -153,6 +157,37 @@ export function getLodestarApi({
         data: network.discv5?.kadValues().map((enr) => enr.encodeTxt()) ?? [],
       };
     },
+
+    async dumpDbBucketKeys(bucketReq?) {
+      const keysByBucket: Record<string, string[]> = {};
+
+      // Find requested repo and return keys from that one
+      if (bucketReq) {
+        for (const repo of Object.values(db) as IBeaconDb[keyof IBeaconDb][]) {
+          if (repo instanceof Repository) {
+            const bucket = (repo as RepositoryAny)["bucket"];
+            if (bucket === bucket || Bucket[bucket] === bucketReq) {
+              keysByBucket[Bucket[bucket]] = stringifyKeys(await repo.keys());
+              return keysByBucket;
+            }
+          }
+        }
+
+        throw Error(`Unknown Bucket '${bucketReq}' available: ${Object.keys(Bucket).join(", ")}`);
+      }
+
+      // Return keys from all repos
+      else {
+        for (const repo of Object.values(db) as IBeaconDb[keyof IBeaconDb][]) {
+          if (repo instanceof Repository) {
+            const bucket = (repo as RepositoryAny)["bucket"];
+            keysByBucket[Bucket[bucket]] = stringifyKeys(await repo.keys());
+          }
+        }
+
+        return keysByBucket;
+      }
+    },
   };
 }
 
@@ -180,4 +215,17 @@ function regenRequestToJson(config: IChainForkConfig, regenRequest: RegenRequest
         root: regenRequest.args[0],
       };
   }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type RepositoryAny = Repository<any, any>;
+
+function stringifyKeys(keys: (Uint8Array | number | string)[]): string[] {
+  return keys.map((key) => {
+    if (key instanceof Uint8Array) {
+      return toHex(key);
+    } else {
+      return `${key}`;
+    }
+  });
 }

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -158,35 +158,21 @@ export function getLodestarApi({
       };
     },
 
-    async dumpDbBucketKeys(bucketReq?) {
-      const keysByBucket: Record<string, string[]> = {};
-
-      // Find requested repo and return keys from that one
-      if (bucketReq) {
-        for (const repo of Object.values(db) as IBeaconDb[keyof IBeaconDb][]) {
-          if (repo instanceof Repository) {
-            const bucket = (repo as RepositoryAny)["bucket"];
-            if (bucket === bucket || Bucket[bucket] === bucketReq) {
-              keysByBucket[Bucket[bucket]] = stringifyKeys(await repo.keys());
-              return keysByBucket;
-            }
+    async dumpDbBucketKeys(bucketReq) {
+      for (const repo of Object.values(db) as IBeaconDb[keyof IBeaconDb][]) {
+        if (repo instanceof Repository) {
+          const bucket = (repo as RepositoryAny)["bucket"];
+          if (bucket === bucket || Bucket[bucket] === bucketReq) {
+            return stringifyKeys(await repo.keys());
           }
         }
-
-        throw Error(`Unknown Bucket '${bucketReq}' available: ${Object.keys(Bucket).join(", ")}`);
       }
 
-      // Return keys from all repos
-      else {
-        for (const repo of Object.values(db) as IBeaconDb[keyof IBeaconDb][]) {
-          if (repo instanceof Repository) {
-            const bucket = (repo as RepositoryAny)["bucket"];
-            keysByBucket[Bucket[bucket]] = stringifyKeys(await repo.keys());
-          }
-        }
+      throw Error(`Unknown Bucket '${bucketReq}' available: ${Object.keys(Bucket).join(", ")}`);
+    },
 
-        return keysByBucket;
-      }
+    async dumpDbStateIndex() {
+      return db.stateArchive.dumpRootIndexEntries();
     },
   };
 }


### PR DESCRIPTION
**Motivation**

Useful tools (not enabled by default) to debug db state and retained keys.

- Allowed me to confirm this issue https://github.com/ChainSafe/lodestar/issues/4417

**Description**

Add routes:
- dumpDbBucketKeys: Dump level-db entry keys for a given Bucket declared in code, or for all buckets.
- dumpDbStateIndex: Return all entries in the StateArchive index with bucket index_stateArchiveRootIndex