### PR TITLE
Log process block errors

### DIFF
--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -101,11 +101,7 @@ export async function processBlocks(
     if (!(err instanceof BlockError)) {
       this.logger.error("Non BlockError received", {}, err);
     } else if (!opts.disableOnBlockError) {
-      // err type data may contain CachedBeaconState which is too much to log
-      const slimError = new Error();
-      slimError.message = err.message;
-      slimError.stack = err.stack;
-      this.logger.error("Block error", {slot: err.signedBlock.message.slot, errCode: err.type.code}, slimError);
+      this.logger.error("Block error", {slot: err.signedBlock.message.slot}, err);
 
       if (err.type.code === BlockErrorCode.INVALID_SIGNATURE) {
         const {signedBlock} = err;


### PR DESCRIPTION
**Motivation**

One Ropsten node is having issues and is currently offline. Looking at logs I see

```
Aug-15 22:33:53.654[CHAIN]           error: Block error slot=555553, errCode=BLOCK_ERROR_EXECUTION_ERROR BLOCK_ERROR_EXECUTION_ERROR
Error: BLOCK_ERROR_EXECUTION_ERROR
    at verifyBlockExecutionPayload (file:///usr/app/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts:298:13)
    at verifyBlocksExecutionPayload (file:///usr/app/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts:124:31)
    at async Promise.all (index 2)
    at BeaconChain.verifyBlocksInEpoch (file:///usr/app/packages/beacon-node/src/chain/blocks/verifyBlock.ts:67:91)
    at BeaconChain.processBlocks (file:///usr/app/packages/beacon-node/src/chain/blocks/index.ts:71:68)
    at Timeout.JobItemQueue.runJob [as _onTimeout] (file:///usr/app/packages/beacon-node/src/util/queue/itemQueue.ts:92:22)
```

What's happening here what's the error? No clue, because the underlying error message is dropped and it's a property of the error.

BlockError has a custom getMetadata method that prevents the full state from leaking into the logs, so this protection is very counter-productive

**Description**

Log process block errors, without dropping its properties
