### PR TITLE
Migrate to libp2p-gossipsub 0.14.1

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -135,7 +135,7 @@
     "jwt-simple": "0.5.6",
     "libp2p": "^0.36.2",
     "libp2p-bootstrap": "^0.14.0",
-    "libp2p-gossipsub": "^0.14.0",
+    "libp2p-gossipsub": "^0.14.1",
     "libp2p-mdns": "^0.18.0",
     "libp2p-mplex": "^0.10.5",
     "libp2p-tcp": "^0.17.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8309,10 +8309,10 @@ libp2p-crypto@^0.21.2:
     protobufjs "^6.11.2"
     uint8arrays "^3.0.0"
 
-libp2p-gossipsub@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.14.0.tgz"
-  integrity sha512-70YnK/zwYbAx2xx7CqPROje37AVLAu8OUgWJ3cSMN6AmCVvUMepebXbQvfnDg2+uLkNnnr1huaqHsceN2BYnkQ==
+libp2p-gossipsub@^0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/libp2p-gossipsub/-/libp2p-gossipsub-0.14.1.tgz#d60127574889adf5a40c4b1c0965ccf409faa24c"
+  integrity sha512-z1IzD6MUeJpxAKdvgJuofpPolYxuiEkhO1XcUASfixyl10O+tUPjDrDYwDmmOV+75femnqIOxq62VR1UhUvNdA==
   dependencies:
     "@types/debug" "^4.1.7"
     debug "^4.3.1"


### PR DESCRIPTION
**Motivation**

- Currently lodestar gossip not validated messages, new version of libp2p-gossipsub fixes it

**Description**

- Migrate to libp2p-gossipsub 0.14.1
- See https://github.com/ChainSafe/js-libp2p-gossipsub/pull/328

Closes #4412