### PR TITLE
Consider state slot in getDomain

### DIFF
--- a/packages/beacon-node/src/chain/validation/signatureSets/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/aggregateAndProof.ts
@@ -17,7 +17,7 @@ export function getAggregateAndProofSignatureSet(
   aggregateAndProof: phase0.SignedAggregateAndProof
 ): ISignatureSet {
   const slot = computeStartSlotAtEpoch(epoch);
-  const aggregatorDomain = state.config.getDomain(DOMAIN_AGGREGATE_AND_PROOF, slot);
+  const aggregatorDomain = state.config.getDomain(state.slot, DOMAIN_AGGREGATE_AND_PROOF, slot);
   const signingRoot = computeSigningRoot(ssz.phase0.AggregateAndProof, aggregateAndProof.message, aggregatorDomain);
 
   return {

--- a/packages/beacon-node/src/chain/validation/signatureSets/contributionAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/contributionAndProof.ts
@@ -13,6 +13,7 @@ export function getContributionAndProofSignatureSet(
 ): ISignatureSet {
   const {epochCtx} = state;
   const domain = state.config.getDomain(
+    state.slot,
     DOMAIN_CONTRIBUTION_AND_PROOF,
     signedContributionAndProof.message.contribution.slot
   );

--- a/packages/beacon-node/src/chain/validation/signatureSets/selectionProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/selectionProof.ts
@@ -14,7 +14,7 @@ export function getSelectionProofSignatureSet(
   aggregator: PublicKey,
   aggregateAndProof: phase0.SignedAggregateAndProof
 ): ISignatureSet {
-  const selectionProofDomain = state.config.getDomain(DOMAIN_SELECTION_PROOF, slot);
+  const selectionProofDomain = state.config.getDomain(state.slot, DOMAIN_SELECTION_PROOF, slot);
 
   return {
     type: SignatureSetType.single,

--- a/packages/beacon-node/src/chain/validation/signatureSets/syncCommittee.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/syncCommittee.ts
@@ -11,7 +11,7 @@ export function getSyncCommitteeSignatureSet(
   state: CachedBeaconStateAllForks,
   syncCommittee: altair.SyncCommitteeMessage
 ): ISignatureSet {
-  const domain = state.config.getDomain(DOMAIN_SYNC_COMMITTEE, syncCommittee.slot);
+  const domain = state.config.getDomain(state.slot, DOMAIN_SYNC_COMMITTEE, syncCommittee.slot);
 
   return {
     type: SignatureSetType.single,

--- a/packages/beacon-node/src/chain/validation/signatureSets/syncCommitteeContribution.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/syncCommitteeContribution.ts
@@ -8,7 +8,7 @@ export function getSyncCommitteeContributionSignatureSet(
   contribution: altair.SyncCommitteeContribution,
   pubkeys: PublicKey[]
 ): ISignatureSet {
-  const domain = state.config.getDomain(DOMAIN_SYNC_COMMITTEE, contribution.slot);
+  const domain = state.config.getDomain(state.slot, DOMAIN_SYNC_COMMITTEE, contribution.slot);
   return {
     type: SignatureSetType.aggregate,
     pubkeys,

--- a/packages/beacon-node/src/chain/validation/signatureSets/syncCommitteeSelectionProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/syncCommitteeSelectionProof.ts
@@ -13,7 +13,7 @@ export function getSyncCommitteeSelectionProofSignatureSet(
 ): ISignatureSet {
   const {epochCtx, config} = state;
   const slot = contributionAndProof.contribution.slot;
-  const domain = config.getDomain(DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF, slot);
+  const domain = config.getDomain(state.slot, DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF, slot);
   const signingData: altair.SyncAggregatorSelectionData = {
     slot,
     subcommitteeIndex: contributionAndProof.contribution.subcommitteeIndex,

--- a/packages/beacon-node/test/spec/presets/operations.ts
+++ b/packages/beacon-node/test/spec/presets/operations.ts
@@ -91,7 +91,9 @@ export const operations: TestRunnerFn<OperationsTestCase, BeaconStateAllForks> =
   return {
     testFunction: (testcase) => {
       const state = testcase.pre.clone();
-      const cachedState = createCachedBeaconStateTest(state, getConfig(fork));
+      const epoch = (state.fork as phase0.Fork).epoch;
+      const cachedState = createCachedBeaconStateTest(state, getConfig(fork, epoch));
+
       operationFn(cachedState, testcase);
       state.commit();
       return state;
@@ -116,9 +118,6 @@ export const operations: TestRunnerFn<OperationsTestCase, BeaconStateAllForks> =
       getExpected: (testCase) => testCase.post,
       expectFunc: (testCase, expected, actual) => {
         expectEqualBeaconState(fork, expected, actual);
-      },
-      shouldSkip: (_testcase, name, _index) => {
-        return !name.includes("voluntary_exit_with_previous_fork_version_is_before_fork_epoch__valid");
       },
     },
   };

--- a/packages/beacon-node/test/spec/presets/operations.ts
+++ b/packages/beacon-node/test/spec/presets/operations.ts
@@ -118,7 +118,7 @@ export const operations: TestRunnerFn<OperationsTestCase, BeaconStateAllForks> =
         expectEqualBeaconState(fork, expected, actual);
       },
       shouldSkip: (_testcase, name, _index) => {
-        return name.includes("voluntary_exit_with_previous_fork_version_is_before_fork_epoch__valid");
+        return !name.includes("voluntary_exit_with_previous_fork_version_is_before_fork_epoch__valid");
       },
     },
   };

--- a/packages/beacon-node/test/spec/utils/getConfig.ts
+++ b/packages/beacon-node/test/spec/utils/getConfig.ts
@@ -4,16 +4,16 @@ import {IChainForkConfig, createIChainForkConfig} from "@lodestar/config";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
-export function getConfig(fork: ForkName): IChainForkConfig {
+export function getConfig(fork: ForkName, forkEpoch = 0): IChainForkConfig {
   switch (fork) {
     case ForkName.phase0:
       return config;
     case ForkName.altair:
-      return createIChainForkConfig({ALTAIR_FORK_EPOCH: 0});
+      return createIChainForkConfig({ALTAIR_FORK_EPOCH: forkEpoch});
     case ForkName.bellatrix:
       return createIChainForkConfig({
         ALTAIR_FORK_EPOCH: 0,
-        BELLATRIX_FORK_EPOCH: 0,
+        BELLATRIX_FORK_EPOCH: forkEpoch,
       });
   }
 }

--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -58,7 +58,7 @@ export function specTestIterator(configName: string, testRunners: Record<string,
     const forkDirpath = path.join(configDirpath, fork);
     for (const testRunnerName of readdirSyncSpec(forkDirpath)) {
       // We don't have runner for light client yet
-      if (testRunnerName !== "operations") {
+      if (testRunnerName === "light_client") {
         continue;
       }
       const testRunnerDirpath = path.join(forkDirpath, testRunnerName);

--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -58,7 +58,7 @@ export function specTestIterator(configName: string, testRunners: Record<string,
     const forkDirpath = path.join(configDirpath, fork);
     for (const testRunnerName of readdirSyncSpec(forkDirpath)) {
       // We don't have runner for light client yet
-      if (testRunnerName === "light_client") {
+      if (testRunnerName !== "operations") {
         continue;
       }
       const testRunnerDirpath = path.join(forkDirpath, testRunnerName);

--- a/packages/beacon-node/test/unit/network/fork.test.ts
+++ b/packages/beacon-node/test/unit/network/fork.test.ts
@@ -18,18 +18,21 @@ function getForkConfig({
       seq: ForkSeq.phase0,
       epoch: phase0,
       version: Buffer.from([0, 0, 0, 0]),
+      prevForkName: ForkName.phase0,
     },
     altair: {
       name: ForkName.altair,
       seq: ForkSeq.altair,
       epoch: altair,
       version: Buffer.from([0, 0, 0, 1]),
+      prevForkName: ForkName.phase0,
     },
     bellatrix: {
       name: ForkName.bellatrix,
       seq: ForkSeq.bellatrix,
       epoch: bellatrix,
       version: Buffer.from([0, 0, 0, 2]),
+      prevForkName: ForkName.altair,
     },
   };
   const forksAscendingEpochOrder = Object.values(forks);

--- a/packages/beacon-node/test/utils/validationData/aggregateAndProof.ts
+++ b/packages/beacon-node/test/utils/validationData/aggregateAndProof.ts
@@ -30,7 +30,7 @@ export function getAggregateAndProofValidData(
   (chain as {seenAggregators: IBeaconChain["seenAggregators"]}).seenAggregators = new SeenAggregators();
 
   const aggregatorIndex = validatorIndex;
-  const proofDomain = state.config.getDomain(DOMAIN_SELECTION_PROOF, attSlot);
+  const proofDomain = state.config.getDomain(state.slot, DOMAIN_SELECTION_PROOF, attSlot);
   const proofSigningRoot = computeSigningRoot(ssz.Slot, attSlot, proofDomain);
 
   const aggregateAndProof: phase0.AggregateAndProof = {
@@ -39,7 +39,7 @@ export function getAggregateAndProofValidData(
     selectionProof: signCached(sk, proofSigningRoot),
   };
 
-  const aggDomain = state.config.getDomain(DOMAIN_AGGREGATE_AND_PROOF, attSlot);
+  const aggDomain = state.config.getDomain(state.slot, DOMAIN_AGGREGATE_AND_PROOF, attSlot);
   const aggSigningRoot = computeSigningRoot(ssz.phase0.AggregateAndProof, aggregateAndProof, aggDomain);
 
   const signedAggregateAndProof: phase0.SignedAggregateAndProof = {

--- a/packages/beacon-node/test/utils/validationData/attestation.ts
+++ b/packages/beacon-node/test/utils/validationData/attestation.ts
@@ -93,7 +93,7 @@ export function getAttestationValidData(
   };
 
   const slot = computeStartSlotAtEpoch(attestationData.target.epoch);
-  const domain = state.config.getDomain(DOMAIN_BEACON_ATTESTER, slot);
+  const domain = state.config.getDomain(state.slot, DOMAIN_BEACON_ATTESTER, slot);
   const signingRoot = computeSigningRoot(ssz.phase0.AttestationData, attestationData, domain);
   const sk = getSecretKeyFromIndexCached(validatorIndex);
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -112,8 +112,6 @@ import {config as chainConfig} from "@lodestar/config/default";
 let genesisValidatorsRoot: Uint8Array = new Uint8Array();
 
 const config: IBeaconConfig = createIBeaconConfig(chainConfig, genesisValidatorsRoot);
-
-const domain = config.getDomain(DOMAIN_DEPOSIT, GENESIS_SLOT);
 ```
 
 ## License

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -11,18 +11,22 @@ export function createIForkConfig(config: IChainConfig): IForkConfig {
     seq: ForkSeq.phase0,
     epoch: GENESIS_EPOCH,
     version: config.GENESIS_FORK_VERSION,
+    // Will never be used
+    prevForkName: ForkName.phase0,
   };
   const altair = {
     name: ForkName.altair,
     seq: ForkSeq.altair,
     epoch: config.ALTAIR_FORK_EPOCH,
     version: config.ALTAIR_FORK_VERSION,
+    prevForkName: ForkName.phase0,
   };
   const bellatrix = {
     name: ForkName.bellatrix,
     seq: ForkSeq.bellatrix,
     epoch: config.BELLATRIX_FORK_EPOCH,
     version: config.BELLATRIX_FORK_VERSION,
+    prevForkName: ForkName.altair,
   };
 
   /** Forks in order order of occurence, `phase0` first */

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -7,6 +7,7 @@ export interface IForkInfo {
   seq: ForkSeq;
   epoch: Epoch;
   version: Version;
+  prevForkName: ForkName;
 }
 
 /**

--- a/packages/config/src/genesisConfig/types.ts
+++ b/packages/config/src/genesisConfig/types.ts
@@ -11,5 +11,10 @@ export interface IForkDigestContext {
 }
 
 export interface ICachedGenesis extends IForkDigestContext {
-  getDomain(domainType: DomainType, slot: Slot): Uint8Array;
+  /**
+   * Return the signature domain (fork version concatenated with domain type) of a message.
+   *
+   * Note: The configured fork schedule is always used rather than on-chain fork schedule.
+   */
+  getDomain(stateSlot: Slot, domainType: DomainType, messageSlot?: Slot): Uint8Array;
 }

--- a/packages/flare/src/cmds/selfSlashAttester.ts
+++ b/packages/flare/src/cmds/selfSlashAttester.ts
@@ -145,7 +145,7 @@ function signAttestationDataBigint(
   data: phase0.AttestationDataBigint
 ): Uint8Array {
   const slot = Number(data.slot as bigint);
-  const proposerDomain = config.getDomain(DOMAIN_BEACON_ATTESTER, slot);
+  const proposerDomain = config.getDomain(slot, DOMAIN_BEACON_ATTESTER);
   const signingRoot = computeSigningRoot(ssz.phase0.AttestationDataBigint, data, proposerDomain);
 
   const sigs = sks.map((sk) => sk.sign(signingRoot));

--- a/packages/flare/src/cmds/selfSlashProposer.ts
+++ b/packages/flare/src/cmds/selfSlashProposer.ts
@@ -135,7 +135,7 @@ export async function selfSlashProposerHandler(args: SelfSlashArgs): Promise<voi
 
 function signHeaderBigint(config: IBeaconConfig, sk: SecretKey, header: phase0.BeaconBlockHeaderBigint): Uint8Array {
   const slot = Number(header.slot as bigint);
-  const proposerDomain = config.getDomain(DOMAIN_BEACON_PROPOSER, slot);
+  const proposerDomain = config.getDomain(slot, DOMAIN_BEACON_PROPOSER);
   const signingRoot = computeSigningRoot(ssz.phase0.BeaconBlockHeaderBigint, header, proposerDomain);
   return sk.sign(signingRoot).toBytes();
 }

--- a/packages/light-client/src/validation.ts
+++ b/packages/light-client/src/validation.ts
@@ -154,7 +154,7 @@ export function assertValidSignedHeader(
 
   const signingRoot = ssz.phase0.SigningData.hashTreeRoot({
     objectRoot: signedHeaderRoot,
-    domain: config.getDomain(DOMAIN_SYNC_COMMITTEE, signedHeaderSlot),
+    domain: config.getDomain(signedHeaderSlot, DOMAIN_SYNC_COMMITTEE),
   });
 
   if (!isValidBlsAggregate(participantPubkeys, signingRoot, syncAggregate.syncCommitteeSignature)) {

--- a/packages/light-client/test/utils/utils.ts
+++ b/packages/light-client/test/utils/utils.ts
@@ -48,7 +48,7 @@ export function getSyncAggregateSigningRoot(
   config: IBeaconConfig,
   syncAttestedBlockHeader: phase0.BeaconBlockHeader
 ): Uint8Array {
-  const domain = config.getDomain(DOMAIN_SYNC_COMMITTEE, syncAttestedBlockHeader.slot);
+  const domain = config.getDomain(syncAttestedBlockHeader.slot, DOMAIN_SYNC_COMMITTEE);
   return computeSigningRoot(ssz.phase0.BeaconBlockHeader, syncAttestedBlockHeader, domain);
 }
 

--- a/packages/state-transition/src/block/processSyncCommittee.ts
+++ b/packages/state-transition/src/block/processSyncCommittee.ts
@@ -88,7 +88,7 @@ export function getSyncCommitteeSignatureSet(
     }
   }
 
-  const domain = state.config.getDomain(DOMAIN_SYNC_COMMITTEE, previousSlot);
+  const domain = state.config.getDomain(state.slot, DOMAIN_SYNC_COMMITTEE, previousSlot);
 
   return {
     type: SignatureSetType.aggregate,

--- a/packages/state-transition/src/signatureSets/attesterSlashings.ts
+++ b/packages/state-transition/src/signatureSets/attesterSlashings.ts
@@ -29,7 +29,7 @@ export function getIndexedAttestationBigintSignatureSet(
 ): ISignatureSet {
   const {index2pubkey} = state.epochCtx;
   const slot = computeStartSlotAtEpoch(Number(indexedAttestation.data.target.epoch as bigint));
-  const domain = state.config.getDomain(DOMAIN_BEACON_ATTESTER, slot);
+  const domain = state.config.getDomain(state.slot, DOMAIN_BEACON_ATTESTER, slot);
 
   return {
     type: SignatureSetType.aggregate,

--- a/packages/state-transition/src/signatureSets/indexedAttestation.ts
+++ b/packages/state-transition/src/signatureSets/indexedAttestation.ts
@@ -10,7 +10,7 @@ export function getAttestationWithIndicesSignatureSet(
 ): ISignatureSet {
   const {epochCtx} = state;
   const slot = computeStartSlotAtEpoch(attestation.data.target.epoch);
-  const domain = state.config.getDomain(DOMAIN_BEACON_ATTESTER, slot);
+  const domain = state.config.getDomain(state.slot, DOMAIN_BEACON_ATTESTER, slot);
 
   return {
     type: SignatureSetType.aggregate,

--- a/packages/state-transition/src/signatureSets/proposer.ts
+++ b/packages/state-transition/src/signatureSets/proposer.ts
@@ -17,7 +17,7 @@ export function getProposerSignatureSet(
   signedBlock: allForks.FullOrBlindedSignedBeaconBlock
 ): ISignatureSet {
   const {config, epochCtx} = state;
-  const domain = state.config.getDomain(DOMAIN_BEACON_PROPOSER, signedBlock.message.slot);
+  const domain = state.config.getDomain(state.slot, DOMAIN_BEACON_PROPOSER, signedBlock.message.slot);
 
   const blockType = isBlindedBeaconBlock(signedBlock.message)
     ? ssz.bellatrix.BlindedBeaconBlock

--- a/packages/state-transition/src/signatureSets/proposerSlashings.ts
+++ b/packages/state-transition/src/signatureSets/proposerSlashings.ts
@@ -17,7 +17,11 @@ export function getProposerSlashingSignatureSets(
   // clock and the slashing would still be valid. Must use bigint variants to hash correctly to all possible values
   return [proposerSlashing.signedHeader1, proposerSlashing.signedHeader2].map(
     (signedHeader): ISignatureSet => {
-      const domain = state.config.getDomain(DOMAIN_BEACON_PROPOSER, Number(signedHeader.message.slot as bigint));
+      const domain = state.config.getDomain(
+        state.slot,
+        DOMAIN_BEACON_PROPOSER,
+        Number(signedHeader.message.slot as bigint)
+      );
 
       return {
         type: SignatureSetType.single,

--- a/packages/state-transition/src/signatureSets/randao.ts
+++ b/packages/state-transition/src/signatureSets/randao.ts
@@ -23,7 +23,7 @@ export function getRandaoRevealSignatureSet(
   const {epochCtx} = state;
   // should not get epoch from epochCtx
   const epoch = computeEpochAtSlot(block.slot);
-  const domain = state.config.getDomain(DOMAIN_RANDAO, block.slot);
+  const domain = state.config.getDomain(state.slot, DOMAIN_RANDAO, block.slot);
 
   return {
     type: SignatureSetType.single,

--- a/packages/state-transition/src/signatureSets/voluntaryExits.ts
+++ b/packages/state-transition/src/signatureSets/voluntaryExits.ts
@@ -25,7 +25,7 @@ export function getVoluntaryExitSignatureSet(
 ): ISignatureSet {
   const {epochCtx} = state;
   const slot = computeStartSlotAtEpoch(signedVoluntaryExit.message.epoch);
-  const domain = state.config.getDomain(DOMAIN_VOLUNTARY_EXIT, slot);
+  const domain = state.config.getDomain(state.slot, DOMAIN_VOLUNTARY_EXIT, slot);
 
   return {
     type: SignatureSetType.single,

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -182,7 +182,7 @@ export class ValidatorStore {
     // Duties are filtered before-hard by doppelganger-safe, this assert should never throw
     this.assertDoppelgangerSafe(pubkey);
 
-    const proposerDomain = this.config.getDomain(DOMAIN_BEACON_PROPOSER, blindedOrFull.slot);
+    const proposerDomain = this.config.getDomain(currentSlot, DOMAIN_BEACON_PROPOSER, blindedOrFull.slot);
     const blockType =
       (blindedOrFull.body as bellatrix.BlindedBeaconBlockBody).executionPayloadHeader !== undefined
         ? ssz.bellatrix.BlindedBeaconBlock
@@ -202,7 +202,7 @@ export class ValidatorStore {
 
   async signRandao(pubkey: BLSPubkey, slot: Slot): Promise<BLSSignature> {
     const epoch = computeEpochAtSlot(slot);
-    const randaoDomain = this.config.getDomain(DOMAIN_RANDAO, slot);
+    const randaoDomain = this.config.getDomain(slot, DOMAIN_RANDAO);
     const randaoSigningRoot = computeSigningRoot(ssz.Epoch, epoch, randaoDomain);
 
     return await this.getSignature(pubkey, randaoSigningRoot);
@@ -225,7 +225,7 @@ export class ValidatorStore {
 
     this.validateAttestationDuty(duty, attestationData);
     const slot = computeStartSlotAtEpoch(attestationData.target.epoch);
-    const domain = this.config.getDomain(DOMAIN_BEACON_ATTESTER, slot);
+    const domain = this.config.getDomain(slot, DOMAIN_BEACON_ATTESTER);
     const signingRoot = computeSigningRoot(ssz.phase0.AttestationData, attestationData, domain);
 
     try {
@@ -259,7 +259,7 @@ export class ValidatorStore {
       selectionProof,
     };
 
-    const domain = this.config.getDomain(DOMAIN_AGGREGATE_AND_PROOF, aggregate.data.slot);
+    const domain = this.config.getDomain(duty.slot, DOMAIN_AGGREGATE_AND_PROOF);
     const signingRoot = computeSigningRoot(ssz.phase0.AggregateAndProof, aggregateAndProof, domain);
 
     return {
@@ -274,7 +274,7 @@ export class ValidatorStore {
     slot: Slot,
     beaconBlockRoot: Root
   ): Promise<altair.SyncCommitteeMessage> {
-    const domain = this.config.getDomain(DOMAIN_SYNC_COMMITTEE, slot);
+    const domain = this.config.getDomain(slot, DOMAIN_SYNC_COMMITTEE);
     const signingRoot = computeSigningRoot(ssz.Root, beaconBlockRoot, domain);
 
     return {
@@ -296,7 +296,7 @@ export class ValidatorStore {
       selectionProof,
     };
 
-    const domain = this.config.getDomain(DOMAIN_CONTRIBUTION_AND_PROOF, contribution.slot);
+    const domain = this.config.getDomain(contribution.slot, DOMAIN_CONTRIBUTION_AND_PROOF);
     const signingRoot = computeSigningRoot(ssz.altair.ContributionAndProof, contributionAndProof, domain);
 
     return {
@@ -306,7 +306,7 @@ export class ValidatorStore {
   }
 
   async signAttestationSelectionProof(pubkey: BLSPubkeyMaybeHex, slot: Slot): Promise<BLSSignature> {
-    const domain = this.config.getDomain(DOMAIN_SELECTION_PROOF, slot);
+    const domain = this.config.getDomain(slot, DOMAIN_SELECTION_PROOF);
     const signingRoot = computeSigningRoot(ssz.Slot, slot, domain);
 
     return await this.getSignature(pubkey, signingRoot);
@@ -317,7 +317,7 @@ export class ValidatorStore {
     slot: Slot,
     subcommitteeIndex: number
   ): Promise<BLSSignature> {
-    const domain = this.config.getDomain(DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF, slot);
+    const domain = this.config.getDomain(slot, DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF);
     const signingData: altair.SyncAggregatorSelectionData = {
       slot,
       subcommitteeIndex,
@@ -333,7 +333,7 @@ export class ValidatorStore {
     validatorIndex: number,
     exitEpoch: Epoch
   ): Promise<phase0.SignedVoluntaryExit> {
-    const domain = this.config.getDomain(DOMAIN_VOLUNTARY_EXIT, computeStartSlotAtEpoch(exitEpoch));
+    const domain = this.config.getDomain(computeStartSlotAtEpoch(exitEpoch), DOMAIN_VOLUNTARY_EXIT);
 
     const voluntaryExit: phase0.VoluntaryExit = {epoch: exitEpoch, validatorIndex};
     const signingRoot = computeSigningRoot(ssz.phase0.VoluntaryExit, voluntaryExit, domain);

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -182,7 +182,7 @@ export class ValidatorStore {
     // Duties are filtered before-hard by doppelganger-safe, this assert should never throw
     this.assertDoppelgangerSafe(pubkey);
 
-    const proposerDomain = this.config.getDomain(currentSlot, DOMAIN_BEACON_PROPOSER, blindedOrFull.slot);
+    const proposerDomain = this.config.getDomain(blindedOrFull.slot, DOMAIN_BEACON_PROPOSER, blindedOrFull.slot);
     const blockType =
       (blindedOrFull.body as bellatrix.BlindedBeaconBlockBody).executionPayloadHeader !== undefined
         ? ssz.bellatrix.BlindedBeaconBlock


### PR DESCRIPTION
Resolves https://github.com/ChainSafe/lodestar/issues/4428

Add a `stateSlot: Slot` parameter to `getDomain`. This matches the ergonomics of the consensus function.
Note: `getDomain` still relies on the configured fork schedule rather than the on-chain fork schedule (`state.fork`)