### PR TITLE
Throw Error if slot is too far into the future

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -85,9 +85,14 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
   async function waitForSlot(slot: Slot): Promise<void> {
     const slotStartSec = chain.genesisTime + slot * config.SECONDS_PER_SLOT;
     const msToSlot = slotStartSec * 1000 - Date.now();
-    if (msToSlot > 0 && msToSlot < MAX_API_CLOCK_DISPARITY_MS) {
+
+    if (msToSlot > MAX_API_CLOCK_DISPARITY_MS) {
+      throw Error(`Requested slot ${slot} is in the future`);
+    } else if (msToSlot > 0) {
       await chain.clock.waitForSlot(slot);
     }
+
+    // else, clock already in slot or slot is in the past
   }
 
   /**


### PR DESCRIPTION
**Motivation**

Current REST API impl handles only the case where the requested slot is "close enough". Instead it should

- If too far in the future: throw
- If close enough in the future: wait
- else: continue

**Description**

Throw Error if slot is too far into the future

Closes #4432 