### PR TITLE
unregisterValidator when removing key from API

### DIFF
--- a/packages/validator/src/services/doppelgangerService.ts
+++ b/packages/validator/src/services/doppelgangerService.ts
@@ -71,6 +71,10 @@ export class DoppelgangerService {
     });
   }
 
+  unregisterValidator(pubkeyHex: PubkeyHex): void {
+    this.doppelgangerStateByPubkey.delete(pubkeyHex);
+  }
+
   getStatus(pubKeyHex: PubkeyHex): DoppelgangerStatus {
     return getStatus(this.doppelgangerStateByPubkey.get(pubKeyHex));
   }

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -151,6 +151,8 @@ export class ValidatorStore {
   }
 
   removeSigner(pubkeyHex: PubkeyHex): boolean {
+    this.doppelgangerService?.unregisterValidator(pubkeyHex);
+
     return this.indicesService.removeForKey(pubkeyHex) || this.validators.delete(pubkeyHex);
   }
 

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -206,7 +206,6 @@ export class Validator {
   }
 
   removeDutiesForKey(pubkey: PubkeyHex): void {
-    this.validatorStore.removeSigner(pubkey);
     this.blockProposingService.removeDutiesForKey(pubkey);
     this.attestationService.removeDutiesForKey(pubkey);
     this.syncCommitteeService.removeDutiesForKey(pubkey);


### PR DESCRIPTION
**Motivation**

In case a public key is removed from the keystore using API, the key is not removed from the map doppelgangerStateByPubkey within the Doppelganger service. This behavior may result in a situation where the validator is killed unintentionally when a mis-
takenly added public key which is already in use by another validator is again removed from the keystore leading to a DoS situation of the validator as the surveillance of the public key within the Doppelganger service is still active.

**Description**

- unregisterValidator when removing key from API
- Remove unnecessary call in removeDutiesForKey(), API calls both validator.removeDutiesForKey() + validator.validatorStore.removeSigner()

Closes #4434