### PR TITLE
Fix isValidatePubkeyHex regex

### DIFF
--- a/packages/cli/src/util/format.ts
+++ b/packages/cli/src/util/format.ts
@@ -11,7 +11,7 @@ export function ensure0xPrefix(hex: string): string {
 }
 
 export function isValidatePubkeyHex(pubkeyHex: string): boolean {
-  return /0x[0-9a-fA-F]{96}/.test(pubkeyHex);
+  return /^0x[0-9a-fA-F]{96}$/.test(pubkeyHex);
 }
 
 export function getPubkeyHexFromKeystore(keystore: {pubkey?: string}): string {

--- a/packages/cli/test/unit/util/format.test.ts
+++ b/packages/cli/test/unit/util/format.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import {parseRange} from "../../../src/util/index.js";
+import {isValidatePubkeyHex, parseRange} from "../../../src/util/index.js";
 
 describe("util / format / parseRange", () => {
   const testCases: {range: string; res: number[]}[] = [
@@ -11,6 +11,22 @@ describe("util / format / parseRange", () => {
   for (const {range, res} of testCases) {
     it(range, () => {
       expect(parseRange(range)).to.deep.equal(res);
+    });
+  }
+});
+
+describe("util / format / isValidatePubkeyHex", () => {
+  const testCases: Record<string, boolean> = {
+    "../../malicious_link/0x933ad9491b62059dd065b560d256d8957a8c402cc6e8d8ee7290ae11e8f7329267a8811c397529dac52ae1342ba58c95": false,
+    "0x933ad9491b62059dd065b560d256d8957a8c402cc6e8d8ee7290ae11e8f7329267a8811c397529dac52ae1342ba58c95": true,
+    "0x933ad9491b62059dd065b560d256d8957a8c402cc6e8d8ee7290ae11e8f7329267a8811c397529dac52ae1342ba58c9": false,
+    "0x933ad9491b62059dd065b560d256d8957a8c402cc6e8d8ee7290ae11e8f7329267a8811c397529dac52ae1342ba58c95f": false,
+    "0xaaaaaaaaaaaaaaaaaa": false,
+  };
+
+  for (const [pubkeyHex, isValid] of Object.entries(testCases)) {
+    it(pubkeyHex, () => {
+      expect(isValidatePubkeyHex(pubkeyHex)).equals(isValid);
     });
   }
 });


### PR DESCRIPTION
**Motivation**

Regex isValidatePubkeyHex was too flexible and allow potentially dangerous entries

**Description**

Fix isValidatePubkeyHex regex

Closes #4435 