### PR TITLE
Remove rmDir bad implementation

### DIFF
--- a/packages/beacon-node/src/util/file.ts
+++ b/packages/beacon-node/src/util/file.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import path from "node:path";
 import {promisify} from "node:util";
 
 /** Ensure a directory exists */
@@ -23,23 +22,4 @@ export async function writeIfNotExist(filepath: string, bytes: Uint8Array): Prom
     await promisify(fs.writeFile)(filepath, bytes);
     return true;
   }
-}
-
-export function rmDir(dir: string): void {
-  const list = fs.readdirSync(dir);
-  for (let i = 0; i < list.length; i++) {
-    const filename = path.join(dir, list[i]);
-    const stat = fs.statSync(filename);
-
-    if (filename == "." || filename == "..") {
-      // pass these files
-    } else if (stat.isDirectory()) {
-      // rmdir recursively
-      rmDir(filename);
-    } else {
-      // rm fiilename
-      fs.unlinkSync(filename);
-    }
-  }
-  fs.rmdirSync(dir);
 }


### PR DESCRIPTION
**Motivation**

function rmDir() uses fs.syncStat() to determine the ﬁle type. Since this function follows symbolic links it will return the ﬁle type of the target instead of the source. So a symbolic link pointing to a directory will cause rmDir() to break out and delete unwanted ﬁles.

**Description**

This function is not used, so remove rmDir bad implementation