### PR TITLE
Validate pubkeys args in keymanager API

### DIFF
--- a/packages/cli/src/cmds/validator/keymanager/impl.ts
+++ b/packages/cli/src/cmds/validator/keymanager/impl.ts
@@ -139,6 +139,10 @@ export class KeymanagerApi implements Api {
       try {
         const pubkeyHex = pubkeysHex[i];
 
+        if (!isValidatePubkeyHex(pubkeyHex)) {
+          throw Error(`Invalid pubkey ${pubkeyHex}`);
+        }
+
         // Skip unknown keys or remote signers
         const signer = this.validator.validatorStore.getSigner(pubkeyHex);
         if (signer && signer?.type === SignerType.Local) {
@@ -261,6 +265,10 @@ export class KeymanagerApi implements Api {
     const results = pubkeys.map(
       (pubkeyHex): ResponseStatus<DeleteRemoteKeyStatus> => {
         try {
+          if (!isValidatePubkeyHex(pubkeyHex)) {
+            throw Error(`Invalid pubkey ${pubkeyHex}`);
+          }
+
           const signer = this.validator.validatorStore.getSigner(pubkeyHex);
 
           // Remove key from live local signer


### PR DESCRIPTION
**Motivation**

deleteRemoteKeys() takes a set of public keys as input but does not perform input validation on them. It is advised to perform an explicit input validation on all provided public keys. Having explicit checks will make the code more robust wrt. refactoring.

**Description**

Validate pubkeys args in keymanager API

Closes #4445 