### PR TITLE
Fix the prepareNextSlot scheduler and add payload metrics

### DIFF
--- a/dashboards/lodestar_general.json
+++ b/dashboards/lodestar_general.json
@@ -14878,7 +14878,7 @@
           },
           "targets": [
             {
-              "exemplar": true,
+              "exemplar": false,
               "expr": "delta(beacon_block_payload_prepare_time_count[$__interval])",
               "interval": "",
               "legendFormat": "fcUs delta",
@@ -15121,7 +15121,7 @@
           },
           "targets": [
             {
-              "exemplar": true,
+              "exemplar": false,
               "expr": "beacon_block_payload_errors_total",
               "interval": "",
               "legendFormat": "errors",

--- a/dashboards/lodestar_general.json
+++ b/dashboards/lodestar_general.json
@@ -14415,15 +14415,17 @@
     },
     {
       "collapsed": true,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 21
       },
       "id": 166,
       "panels": [
         {
+          "datasource": null,
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -14462,7 +14464,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -14523,7 +14526,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 25
+            "y": 22
           },
           "id": 168,
           "options": {
@@ -14558,6 +14561,7 @@
           "type": "timeseries"
         },
         {
+          "datasource": null,
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -14596,7 +14600,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -14612,7 +14617,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 25
+            "y": 22
           },
           "id": 170,
           "options": {
@@ -14636,6 +14641,494 @@
             }
           ],
           "title": "Block production avg time",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 30
+          },
+          "id": 478,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": false,
+              "expr": "delta(beacon_block_payload_prepare_time_sum)/delta(beacon_block_payload_prepare_time_count)",
+              "interval": "",
+              "legendFormat": "avg time",
+              "refId": "A"
+            }
+          ],
+          "title": "Advance prepare fcU time (before slot)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 30
+          },
+          "id": 480,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": false,
+              "expr": "delta(beacon_block_payload_fetched_time_sum)/delta(beacon_block_payload_fetched_time_count)",
+              "interval": "",
+              "legendFormat": "{{prepType}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Payload fetched time (from slot start)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 38
+          },
+          "id": 482,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "delta(beacon_block_payload_prepare_time_count[$__interval])",
+              "interval": "",
+              "legendFormat": "fcUs delta",
+              "refId": "A"
+            }
+          ],
+          "title": "Advance fcU calls",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 38
+          },
+          "id": 484,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": false,
+              "expr": "delta(beacon_block_payload_fetched_time_count[$__interval])",
+              "interval": "",
+              "legendFormat": "{{prepType}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Payload Fetch calls",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 46
+          },
+          "id": 486,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": false,
+              "expr": "beacon_block_payload_empty_total",
+              "interval": "",
+              "legendFormat": "{{prepType}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Empty Payloads",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 46
+          },
+          "id": 488,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "beacon_block_payload_errors_total",
+              "interval": "",
+              "legendFormat": "errors",
+              "refId": "A"
+            }
+          ],
+          "title": "Payload fetch errors",
           "type": "timeseries"
         }
       ],

--- a/packages/beacon-node/src/chain/factory/block/body.ts
+++ b/packages/beacon-node/src/chain/factory/block/body.ts
@@ -22,13 +22,22 @@ import {
   isMergeTransitionComplete,
 } from "@lodestar/state-transition";
 import {IChainForkConfig} from "@lodestar/config";
-import {toHex, ILogger} from "@lodestar/utils";
+import {toHex, ILogger, sleep} from "@lodestar/utils";
 
 import {IBeaconChain} from "../../interface.js";
 import {PayloadId, IExecutionEngine, IExecutionBuilder} from "../../../execution/index.js";
 import {ZERO_HASH, ZERO_HASH_HEX} from "../../../constants/index.js";
 import {IEth1ForBlockProduction} from "../../../eth1/index.js";
 import {numToQuantity} from "../../../eth1/provider/utils.js";
+import {IMetrics} from "../../../metrics/index.js";
+
+// Time to provide the EL to generate a payload from new payload id
+const PAYLOAD_GENERATION_TIME_MS = 500;
+enum PayloadPreparationType {
+  Fresh,
+  Cached,
+  Reorged,
+}
 
 export enum BlockType {
   Full,
@@ -42,7 +51,7 @@ export type AssembledBlockType<T extends BlockType> = T extends BlockType.Full
   : bellatrix.BlindedBeaconBlock;
 
 export async function assembleBody<T extends BlockType>(
-  {type, chain, logger}: {type: T; chain: IBeaconChain; logger?: ILogger},
+  {type, chain, logger, metrics}: {type: T; chain: IBeaconChain; logger?: ILogger; metrics?: IMetrics | null},
   currentState: CachedBeaconStateAllForks,
   {
     randaoReveal,
@@ -139,10 +148,29 @@ export async function assembleBody<T extends BlockType>(
           currentState as CachedBeaconStateBellatrix,
           feeRecipient
         );
-        (blockBody as bellatrix.BeaconBlockBody).executionPayload = prepareRes.isPremerge
-          ? ssz.bellatrix.ExecutionPayload.defaultValue()
-          : await chain.executionEngine.getPayload(prepareRes.payloadId);
+        if (prepareRes.isPremerge) {
+          (blockBody as bellatrix.BeaconBlockBody).executionPayload = ssz.bellatrix.ExecutionPayload.defaultValue();
+        } else {
+          const {prepType, payloadId} = prepareRes;
+          if (prepType !== PayloadPreparationType.Cached) {
+            // Wait for 500ms to allow EL to add some txs to the payload
+            // the pitfalls of this have been put forward here, but 500ms delay for block proposal
+            // seems marginal even with unhealthy network
+            //
+            // See: https://discord.com/channels/595666850260713488/892088344438255616/1009882079632314469
+            await sleep(PAYLOAD_GENERATION_TIME_MS);
+          }
+          const payload = await chain.executionEngine.getPayload(payloadId);
+          (blockBody as bellatrix.BeaconBlockBody).executionPayload = payload;
+
+          const fetchTime = Date.now() / 1000 - computeTimeAtSlot(chain.config, blockSlot, chain.genesisTime);
+          metrics?.blockPayload.payloadFetchTime.observe({prepType}, fetchTime);
+          if (payload.transactions.length === 0) {
+            metrics?.blockPayload.emptyPayloads.inc({prepType});
+          }
+        }
       } catch (e) {
+        metrics?.blockPayload.payloadFetchErrors.inc();
         // ok we don't have an execution payload here, so we can assign an empty one
         // if pre-merge
 
@@ -182,7 +210,7 @@ export async function prepareExecutionPayload(
   finalizedBlockHash: RootHex,
   state: CachedBeaconStateBellatrix,
   suggestedFeeRecipient: string
-): Promise<{isPremerge: true} | {isPremerge: false; payloadId: PayloadId}> {
+): Promise<{isPremerge: true} | {isPremerge: false; prepType: PayloadPreparationType; payloadId: PayloadId}> {
   const parentHashRes = await getExecutionPayloadParentHash(chain, state);
   if (parentHashRes.isPremerge) {
     // Return null only if the execution is pre-merge
@@ -204,13 +232,32 @@ export async function prepareExecutionPayload(
   // prepareExecutionPayload will throw error via notifyForkchoiceUpdate if
   // the EL returns Syncing on this request to prepare a payload
   // TODO: Handle only this case, DO NOT put a generic try / catch that discards all errors
-  const payloadId =
-    payloadIdCached ??
-    (await chain.executionEngine.notifyForkchoiceUpdate(toHex(parentHash), safeBlockHash, finalizedBlockHash, {
-      timestamp,
-      prevRandao,
-      suggestedFeeRecipient,
-    }));
+  let payloadId: PayloadId | null;
+  let prepType: PayloadPreparationType;
+
+  if (payloadIdCached) {
+    payloadId = payloadIdCached;
+    prepType = PayloadPreparationType.Cached;
+  } else {
+    // If there was a payload assigned to this timestamp, it would imply that there some sort
+    // of payload reorg, i.e. head, fee recipient or any other fcu param changed
+    if (chain.executionEngine.payloadIdCache.hasPayload({timestamp: numToQuantity(timestamp)})) {
+      prepType = PayloadPreparationType.Reorged;
+    } else {
+      prepType = PayloadPreparationType.Fresh;
+    }
+
+    payloadId = await chain.executionEngine.notifyForkchoiceUpdate(
+      toHex(parentHash),
+      safeBlockHash,
+      finalizedBlockHash,
+      {
+        timestamp,
+        prevRandao,
+        suggestedFeeRecipient,
+      }
+    );
+  }
 
   // Should never happen, notifyForkchoiceUpdate() with payload attributes always
   // returns payloadId
@@ -221,7 +268,7 @@ export async function prepareExecutionPayload(
   // We are only returning payloadId here because prepareExecutionPayload is also called from
   // prepareNextSlot, which is an advance call to execution engine to start building payload
   // Actual payload isn't produced till getPayload is called.
-  return {isPremerge: false, payloadId};
+  return {isPremerge: false, payloadId, prepType};
 }
 
 async function prepareExecutionPayloadHeader(

--- a/packages/beacon-node/src/chain/factory/block/body.ts
+++ b/packages/beacon-node/src/chain/factory/block/body.ts
@@ -34,9 +34,9 @@ import {IMetrics} from "../../../metrics/index.js";
 // Time to provide the EL to generate a payload from new payload id
 const PAYLOAD_GENERATION_TIME_MS = 500;
 enum PayloadPreparationType {
-  Fresh,
-  Cached,
-  Reorged,
+  Fresh = "Fresh",
+  Cached = "Cached",
+  Reorged = "Reorged",
 }
 
 export enum BlockType {
@@ -163,8 +163,8 @@ export async function assembleBody<T extends BlockType>(
           const payload = await chain.executionEngine.getPayload(payloadId);
           (blockBody as bellatrix.BeaconBlockBody).executionPayload = payload;
 
-          const fetchTime = Date.now() / 1000 - computeTimeAtSlot(chain.config, blockSlot, chain.genesisTime);
-          metrics?.blockPayload.payloadFetchTime.observe({prepType}, fetchTime);
+          const fetchedTime = Date.now() / 1000 - computeTimeAtSlot(chain.config, blockSlot, chain.genesisTime);
+          metrics?.blockPayload.payloadFetchedTime.observe({prepType}, fetchedTime);
           if (payload.transactions.length === 0) {
             metrics?.blockPayload.emptyPayloads.inc({prepType});
           }

--- a/packages/beacon-node/src/chain/factory/block/index.ts
+++ b/packages/beacon-node/src/chain/factory/block/index.ts
@@ -40,7 +40,7 @@ export async function assembleBlock<T extends BlockType>(
     proposerIndex,
     parentRoot: parentBlockRoot,
     stateRoot: ZERO_HASH,
-    body: await assembleBody<T>({type, chain, logger}, state, {
+    body: await assembleBody<T>({type, chain, logger, metrics}, state, {
       randaoReveal,
       graffiti,
       blockSlot: slot,

--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -218,7 +218,7 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
         help: "Time for perparing payload in advance",
         buckets: [0.1, 1, 3, 5, 10],
       }),
-      payloadFetchTime: register.histogram<"prepType">({
+      payloadFetchedTime: register.histogram<"prepType">({
         name: "beacon_block_payload_fetched_time",
         help: "Time to fetch the payload from EL",
         labelNames: ["prepType"],

--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -212,5 +212,26 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
       name: "beacon_block_production_successes_total",
       help: "Count of blocks successfully produced",
     }),
+    blockPayload: {
+      payloadAdvancePrepTime: register.histogram({
+        name: "beacon_block_payload_prepare_time",
+        help: "Time for perparing payload in advance",
+        buckets: [0.1, 1, 3, 5, 10],
+      }),
+      payloadFetchTime: register.histogram<"prepType">({
+        name: "beacon_block_payload_fetched_time",
+        help: "Time to fetch the payload from EL",
+        labelNames: ["prepType"],
+      }),
+      emptyPayloads: register.gauge<"prepType">({
+        name: "beacon_block_payload_empty_total",
+        help: "Count of payload with empty transactions",
+        labelNames: ["prepType"],
+      }),
+      payloadFetchErrors: register.gauge({
+        name: "beacon_block_payload_errors_total",
+        help: "Count of errors while fetching payloads",
+      }),
+    },
   };
 }


### PR DESCRIPTION
**Motivation**
Nethermind reported that we were not issuign advance fcU for building payload and hence zero transactions on latest mainnet shadow fork. On debugging it was figured out that the scheduler was wrongly checking the fork on epoch while it should be checking on slot.

<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR fixes the fork check on the slot rather than epoch, as well as add various metrics for block payload production in order to aid debugging.

metrics added to `block production stats`
![image](https://user-images.githubusercontent.com/76567250/185578450-00b99631-38cc-4dcf-8d20-896c4111dcb9.png)
