### PR TITLE
Update the gossip max chunk size to bellatrix specs

### DIFF
--- a/packages/beacon-node/src/constants/network.ts
+++ b/packages/beacon-node/src/constants/network.ts
@@ -42,8 +42,10 @@ export type RpcResponseStatusError = Exclude<RespStatus, RespStatus.SUCCESS>;
 
 /** The maximum allowed size of uncompressed gossip messages. */
 export const GOSSIP_MAX_SIZE = 2 ** 20;
+export const GOSSIP_MAX_SIZE_BELLATRIX = 10 * GOSSIP_MAX_SIZE;
 /** The maximum allowed size of uncompressed req/resp chunked responses. */
 export const MAX_CHUNK_SIZE = 2 ** 20;
+export const MAX_CHUNK_SIZE_BELLATRIX = 10 * MAX_CHUNK_SIZE;
 /** The maximum time to wait for first byte of request response (time-to-first-byte). */
 export const TTFB_TIMEOUT = 5 * 1000; // 5 sec
 /** The maximum time for complete response transfer. */


### PR DESCRIPTION
**Motivation**
The max allowed chunk size for gossip at/post bellatrix are 10x the normal ones to take care of transaction payloads.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR increases the allowed size if bellatrix is configured.  There is "gotcha" in this:
For incoming payloads this isn't an issue however for outgoing payloads pre-merge if we send big chunks they might be rejected by other clients. However sizes greater than even `GOSSIP_MAX_SIZE` aren't likely. 
However an issue has been created for it: https://github.com/ChainSafe/lodestar/issues/4449
**Description**
Closed #3486