### PR TITLE
Re-enable full merge interop tests

### DIFF
--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -57,7 +57,7 @@ jobs:
         working-directory: packages/beacon-node
         env:
           EL_BINARY_DIR: ../../go-ethereum/build/bin
-          EL_SCRIPT_DIR: kiln/geth
+          EL_SCRIPT_DIR: geth
           ENGINE_PORT: 8551
           ETH_PORT: 8545
           TX_SCENARIOS: simple
@@ -76,7 +76,7 @@ jobs:
         working-directory: packages/beacon-node
         env:
           EL_BINARY_DIR: ../../nethermind/src/Nethermind/Nethermind.Runner
-          EL_SCRIPT_DIR: kiln/nethermind
+          EL_SCRIPT_DIR: nethermind
           ENGINE_PORT: 8551
           ETH_PORT: 8545
 

--- a/packages/beacon-node/test/scripts/el-interop/geth/common-setup.sh
+++ b/packages/beacon-node/test/scripts/el-interop/geth/common-setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -x
+
+echo $TTD
+echo $DATA_DIR
+echo $EL_BINARY_DIR
+echo $JWT_SECRET_HEX
+
+echo $scriptDir
+echo $currentDir
+
+
+env TTD=$TTD envsubst < $scriptDir/genesisPre.tmpl > $DATA_DIR/genesis.json
+echo "45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8" > $DATA_DIR/sk.json
+echo "12345678" > $DATA_DIR/password.txt
+pubKey="0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+
+# echo a hex encoded 256 bit secret into a file
+echo $JWT_SECRET_HEX> $DATA_DIR/jwtsecret
+
+$EL_BINARY_DIR/geth --datadir $DATA_DIR init $DATA_DIR/genesis.json
+$EL_BINARY_DIR/geth --datadir $DATA_DIR account import $DATA_DIR/sk.json --password $DATA_DIR/password.txt

--- a/packages/beacon-node/test/scripts/el-interop/geth/genesisPost.tmpl
+++ b/packages/beacon-node/test/scripts/el-interop/geth/genesisPost.tmpl
@@ -1,0 +1,36 @@
+{
+  "config": 
+  {
+  	"chainId":1,
+  	"homesteadBlock":0,
+  	"eip150Block":0,
+  	"eip155Block":0,
+  	"eip158Block":0,
+  	"byzantiumBlock":0,
+  	"constantinopleBlock":0,
+  	"petersburgBlock":0,
+  	"istanbulBlock":0,
+  	"muirGlacierBlock":0,
+  	"berlinBlock":0,
+  	"londonBlock":0,
+  	"clique": {
+  		"period": 5,
+  		"epoch": 30000
+  	},
+  	"terminalTotalDifficulty":${TTD}
+  },
+  "nonce":"0x42",
+  "timestamp":"0x0",
+  "extraData":"0x0000000000000000000000000000000000000000000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "gasLimit":"0x1C9C380",
+  "difficulty":"0x400000000",
+  "mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000",
+  "coinbase":"0x0000000000000000000000000000000000000000",
+  "alloc":{
+  	"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b":{"balance":"0x6d6172697573766477000000"} 
+  },
+  "number":"0x0",
+  "gasUsed":"0x0",
+  "parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000",
+  "baseFeePerGas":"0x7"
+}

--- a/packages/beacon-node/test/scripts/el-interop/geth/genesisPre.tmpl
+++ b/packages/beacon-node/test/scripts/el-interop/geth/genesisPre.tmpl
@@ -1,0 +1,36 @@
+{
+  "config": {
+    "chainId": 1,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "muirGlacierBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
+    "clique": {
+      "period": 5,
+      "epoch": 30000
+    },
+    "terminalTotalDifficulty": ${TTD}
+  },
+  "nonce": "0x42",
+  "timestamp": "0x0",
+  "extraData": "0x0000000000000000000000000000000000000000000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "gasLimit": "0x1c9c380",
+  "difficulty": "0x0",
+  "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "coinbase": "0x0000000000000000000000000000000000000000",
+  "alloc": {
+    "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {"balance": "0x6d6172697573766477000000"}
+  },
+  "number": "0x0",
+  "gasUsed": "0x0",
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "baseFeePerGas": "0x7"
+}

--- a/packages/beacon-node/test/scripts/el-interop/geth/post-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/geth/post-merge.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+
+scriptDir=$(dirname $0)
+currentDir=$(pwd)
+
+. $scriptDir/common-setup.sh
+
+$EL_BINARY_DIR/geth --http -http.api "engine,net,eth,miner" --http.port $ETH_PORT --authrpc.port $ENGINE_PORT --authrpc.jwtsecret $currentDir/$DATA_DIR/jwtsecret --datadir $DATA_DIR --allow-insecure-unlock --unlock $pubKey --password $DATA_DIR/password.txt

--- a/packages/beacon-node/test/scripts/el-interop/geth/pre-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/geth/pre-merge.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+
+scriptDir=$(dirname $0)
+currentDir=$(pwd)
+
+. $scriptDir/common-setup.sh
+
+$EL_BINARY_DIR/geth --http -http.api "engine,net,eth,miner" --http.port $ETH_PORT --authrpc.port $ENGINE_PORT --authrpc.jwtsecret $currentDir/$DATA_DIR/jwtsecret --datadir $DATA_DIR --allow-insecure-unlock --unlock $pubKey --password $DATA_DIR/password.txt --nodiscover --mine

--- a/packages/beacon-node/test/scripts/el-interop/gethdocker/README.md
+++ b/packages/beacon-node/test/scripts/el-interop/gethdocker/README.md
@@ -1,0 +1,15 @@
+# Geth Docker setup for running the sim merge tests on local machine
+
+###### Geth docker image
+Pull the latest `geth` image from the dockerhub
+
+```bash
+docker pull ethereum/client-go:latest
+```
+
+###### Run test scripts
+
+```bash
+cd packages/lodestar
+EL_BINARY_DIR=ethereum/client-go:latest EL_SCRIPT_DIR=gethdocker ETH_PORT=8545 ENGINE_PORT=8551 TX_SCENARIOS=simple yarn mocha test/sim/merge-interop.test.ts
+```

--- a/packages/beacon-node/test/scripts/el-interop/gethdocker/common-setup.sh
+++ b/packages/beacon-node/test/scripts/el-interop/gethdocker/common-setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -x
+
+echo $TTD
+echo $DATA_DIR
+echo $EL_BINARY_DIR
+echo $JWT_SECRET_HEX
+
+echo $scriptDir
+echo $currentDir
+
+
+env TTD=$TTD envsubst < $scriptDir/genesisPre.tmpl > $DATA_DIR/genesis.json
+echo "45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8" > $DATA_DIR/sk.json
+echo "12345678" > $DATA_DIR/password.txt
+pubKey="0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+
+# echo a hex encoded 256 bit secret into a file
+echo $JWT_SECRET_HEX> $DATA_DIR/jwtsecret
+
+docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --datadir /data init /data/genesis.json
+docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR  --datadir /data account import /data/sk.json --password /data/password.txt

--- a/packages/beacon-node/test/scripts/el-interop/gethdocker/genesisPost.tmpl
+++ b/packages/beacon-node/test/scripts/el-interop/gethdocker/genesisPost.tmpl
@@ -1,0 +1,36 @@
+{
+  "config": 
+  {
+  	"chainId":1,
+  	"homesteadBlock":0,
+  	"eip150Block":0,
+  	"eip155Block":0,
+  	"eip158Block":0,
+  	"byzantiumBlock":0,
+  	"constantinopleBlock":0,
+  	"petersburgBlock":0,
+  	"istanbulBlock":0,
+  	"muirGlacierBlock":0,
+  	"berlinBlock":0,
+  	"londonBlock":0,
+  	"clique": {
+  		"period": 5,
+  		"epoch": 30000
+  	},
+  	"terminalTotalDifficulty":${TTD}
+  },
+  "nonce":"0x42",
+  "timestamp":"0x0",
+  "extraData":"0x0000000000000000000000000000000000000000000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "gasLimit":"0x1C9C380",
+  "difficulty":"0x400000000",
+  "mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000",
+  "coinbase":"0x0000000000000000000000000000000000000000",
+  "alloc":{
+  	"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b":{"balance":"0x6d6172697573766477000000"} 
+  },
+  "number":"0x0",
+  "gasUsed":"0x0",
+  "parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000",
+  "baseFeePerGas":"0x7"
+}

--- a/packages/beacon-node/test/scripts/el-interop/gethdocker/genesisPre.tmpl
+++ b/packages/beacon-node/test/scripts/el-interop/gethdocker/genesisPre.tmpl
@@ -1,0 +1,36 @@
+{
+  "config": {
+    "chainId": 1,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "muirGlacierBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
+    "clique": {
+      "period": 5,
+      "epoch": 30000
+    },
+    "terminalTotalDifficulty": ${TTD}
+  },
+  "nonce": "0x42",
+  "timestamp": "0x0",
+  "extraData": "0x0000000000000000000000000000000000000000000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "gasLimit": "0x1c9c380",
+  "difficulty": "0x0",
+  "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "coinbase": "0x0000000000000000000000000000000000000000",
+  "alloc": {
+    "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {"balance": "0x6d6172697573766477000000"}
+  },
+  "number": "0x0",
+  "gasUsed": "0x0",
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "baseFeePerGas": "0x7"
+}

--- a/packages/beacon-node/test/scripts/el-interop/gethdocker/post-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/gethdocker/post-merge.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+
+scriptDir=$(dirname $0)
+currentDir=$(pwd)
+
+. $scriptDir/common-setup.sh
+
+docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --network host -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --http -http.api "engine,net,eth,miner" --http.port $ETH_PORT --authrpc.port $ENGINE_PORT --authrpc.jwtsecret /data/jwtsecret --allow-insecure-unlock --unlock $pubKey --password /data/password.txt --datadir /data

--- a/packages/beacon-node/test/scripts/el-interop/gethdocker/pre-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/gethdocker/pre-merge.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+
+scriptDir=$(dirname $0)
+currentDir=$(pwd)
+
+. $scriptDir/common-setup.sh
+
+# EL_BINARY_DIR refers to the local docker image build from kiln/gethdocker folder
+docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --network host -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --http -http.api "engine,net,eth,miner" --http.port $ETH_PORT --authrpc.port $ENGINE_PORT --authrpc.jwtsecret /data/jwtsecret --allow-insecure-unlock --unlock $pubKey --password /data/password.txt --datadir /data --nodiscover --mine

--- a/packages/beacon-node/test/scripts/el-interop/nethermind/common-setup.sh
+++ b/packages/beacon-node/test/scripts/el-interop/nethermind/common-setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -x
+
+# echo a hex encoded 256 bit secret into a file
+echo $JWT_SECRET_HEX> $DATA_DIR/jwtsecret

--- a/packages/beacon-node/test/scripts/el-interop/nethermind/post-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/nethermind/post-merge.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+
+scriptDir=$(dirname $0)
+currentDir=$(pwd)
+
+. $scriptDir/common-setup.sh
+
+cd $EL_BINARY_DIR
+dotnet run -c Release -- --config themerge_kiln_testvectors --Merge.TerminalTotalDifficulty $TTD --JsonRpc.JwtSecretFile $currentDir/$DATA_DIR/jwtsecret --JsonRpc.Enabled true --JsonRpc.Host 0.0.0.0 --JsonRpc.AdditionalRpcUrls "http://localhost:$ETH_PORT|http|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:$ENGINE_PORT|http|eth;engine"

--- a/packages/beacon-node/test/scripts/el-interop/nethermind/pre-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/nethermind/pre-merge.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+
+scriptDir=$(dirname $0)
+currentDir=$(pwd)
+
+. $scriptDir/common-setup.sh
+
+cd $EL_BINARY_DIR
+dotnet run -c Release -- --config themerge_kiln_m2 --Merge.TerminalTotalDifficulty $TTD --JsonRpc.JwtSecretFile $currentDir/$DATA_DIR/jwtsecret --Merge.Enabled true  --Init.DiagnosticMode=None --JsonRpc.Enabled true --JsonRpc.Host 0.0.0.0 --JsonRpc.AdditionalRpcUrls "http://localhost:$ETH_PORT|http|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:$ENGINE_PORT|http|eth;engine"

--- a/packages/beacon-node/test/sim/merge-interop.test.ts
+++ b/packages/beacon-node/test/sim/merge-interop.test.ts
@@ -36,7 +36,7 @@ import {shell} from "./shell.js";
 // Example:
 // ```
 // $ EL_BINARY_DIR=/home/lion/Code/eth2.0/merge-interop/go-ethereum/build/bin \
-//   EL_SCRIPT_DIR=kiln/geth ETH_PORT=8545 ENGINE_PORT=8551 TX_SCENARIOS=simple \
+//   EL_SCRIPT_DIR=geth ETH_PORT=8545 ENGINE_PORT=8551 TX_SCENARIOS=simple \
 //   ../../node_modules/.bin/mocha test/sim/merge.test.ts
 // ```
 
@@ -50,7 +50,7 @@ const jwtSecretHex = "0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7
 const retryAttempts = defaultExecutionEngineHttpOpts.retryAttempts;
 const retryDelay = defaultExecutionEngineHttpOpts.retryDelay;
 
-describe.skip("executionEngine / ExecutionEngineHttp", function () {
+describe("executionEngine / ExecutionEngineHttp", function () {
   this.timeout("10min");
 
   const dataPath = fs.mkdtempSync("lodestar-test-merge-interop");
@@ -129,7 +129,7 @@ describe.skip("executionEngine / ExecutionEngineHttp", function () {
     fs.mkdirSync(dataPath, {recursive: true});
 
     startELProcess({
-      runScriptPath: `../../${process.env.EL_SCRIPT_DIR}/${elScript}`,
+      runScriptPath: `./test/scripts/el-interop/${process.env.EL_SCRIPT_DIR}/${elScript}`,
       TTD: `${ttd}`,
       DATA_DIR: dataPath,
     });


### PR DESCRIPTION
**Motivation**
PR https://github.com/ChainSafe/lodestar/pull/4451 mistakenly deleted the kiln merge scripts folder assuming it belonged to network kiln. however it was used to test merge interop scenarios.
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR re-locates those scripts to the more appropriate place and renables the full merge interop tests.