### PR TITLE
Skip waitForSlot pre-genesis

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -83,6 +83,10 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
    * Prevents the validator from getting errors from the API if the clock is a bit advanced
    */
   async function waitForSlot(slot: Slot): Promise<void> {
+    if (slot <= 0) {
+      return;
+    }
+
     const slotStartSec = chain.genesisTime + slot * config.SECONDS_PER_SLOT;
     const msToSlot = slotStartSec * 1000 - Date.now();
 


### PR DESCRIPTION
**Motivation**

Prevent many errors pre-genesis

```
@lodestar/beacon-node: Eph -1/7 0.003[NODE-A NODE-A API] error: Req req-p getProposerDuties error  Requested slot 0 is in the future
@lodestar/beacon-node: Error: Requested slot 0 is in the future
@lodestar/beacon-node:     at waitForSlot (file:///home/runner/work/lodestar/lodestar/packages/beacon-node/src/api/impl/validator/index.ts:90:13)
@lodestar/beacon-node:     at Object.getProposerDuties (file:///home/runner/work/lodestar/lodestar/packages/beacon-node/src/api/impl/validator/index.ts:305:13)
@lodestar/beacon-node:     at Object.handler (file:///home/runner/work/lodestar/lodestar/packages/api/src/utils/server/genericJsonServer.ts:39:41)
@lodestar/beacon-node:     at preHandlerCallback (/home/runner/work/lodestar/lodestar/node_modules/fastify/lib/handleRequest.js:124:28)
@lodestar/beacon-node:     at preValidationCallback (/home/runner/work/lodestar/lodestar/node_modules/fastify/lib/handleRequest.js:107:5)
@lodestar/beacon-node:     at handler (/home/runner/work/lodestar/lodestar/node_modules/fastify/lib/handleRequest.js:70:7)
@lodestar/beacon-node:     at handleRequest (/home/runner/work/lodestar/lodestar/node_modules/fastify/lib/handleRequest.js:18:5)
@lodestar/beacon-node:     at runPreParsing (/home/runner/work/lodestar/lodestar/node_modules/fastify/lib/route.js:422:5)
@lodestar/beacon-node:     at next (/home/runner/work/lodestar/lodestar/node_modules/fastify/lib/hooks.js:158:7)
@lodestar/beacon-node:     at handleResolve (/home/runner/work/lodestar/lodestar/node_modules/fastify/lib/hooks.js:175:5)
@lodestar/beacon-node:     at runMicrotasks (<anonymous>)
@lodestar/beacon-node:     at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

**Description**

- Skip waitForSlot pre-genesis