### PR TITLE
Add actionName to all reportAction calls

### DIFF
--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -200,7 +200,7 @@ export class Network implements INetwork {
     this.peerManager.reStatusPeers(peers);
   }
 
-  reportPeer(peer: PeerId, action: PeerAction, actionName?: string): void {
+  reportPeer(peer: PeerId, action: PeerAction, actionName: string): void {
     this.peerRpcScores.applyAction(peer, action, actionName);
   }
 

--- a/packages/beacon-node/src/network/peers/score.ts
+++ b/packages/beacon-node/src/network/peers/score.ts
@@ -79,7 +79,7 @@ type PeerIdStr = string;
 export interface IPeerRpcScoreStore {
   getScore(peer: PeerId): number;
   getScoreState(peer: PeerId): ScoreState;
-  applyAction(peer: PeerId, action: PeerAction, actionName?: string): void;
+  applyAction(peer: PeerId, action: PeerAction, actionName: string): void;
   update(): void;
   updateGossipsubScore(peerId: PeerIdStr, newScore: number, ignore: boolean): void;
 }
@@ -112,7 +112,7 @@ export class PeerRpcScoreStore implements IPeerRpcScoreStore {
     return scoreToState(this.getScore(peer));
   }
 
-  applyAction(peer: PeerId, action: PeerAction, actionName?: string): void {
+  applyAction(peer: PeerId, action: PeerAction, actionName: string): void {
     const peerScore = this.scores.getOrDefault(peer.toB58String());
     peerScore.add(peerActionScore[action]);
 

--- a/packages/beacon-node/src/network/reqresp/score.ts
+++ b/packages/beacon-node/src/network/reqresp/score.ts
@@ -20,36 +20,34 @@ const multiStreamSelectErrorCodes = {
   protocolSelectionFailed: "protocol selection failed",
 };
 
-export function onOutgoingReqRespError(e: Error, method: Method): PeerAction | null {
-  if (e instanceof RequestError) {
-    switch (e.type.code) {
-      case RequestErrorCode.INVALID_REQUEST:
-        return PeerAction.LowToleranceError;
+export function onOutgoingReqRespError(e: RequestError, method: Method): PeerAction | null {
+  switch (e.type.code) {
+    case RequestErrorCode.INVALID_REQUEST:
+      return PeerAction.LowToleranceError;
 
-      case RequestErrorCode.SERVER_ERROR:
-        return PeerAction.MidToleranceError;
-      case RequestErrorCode.UNKNOWN_ERROR_STATUS:
-        return PeerAction.HighToleranceError;
+    case RequestErrorCode.SERVER_ERROR:
+      return PeerAction.MidToleranceError;
+    case RequestErrorCode.UNKNOWN_ERROR_STATUS:
+      return PeerAction.HighToleranceError;
 
-      case RequestErrorCode.DIAL_TIMEOUT:
-      case RequestErrorCode.DIAL_ERROR:
-        return e.message.includes(multiStreamSelectErrorCodes.protocolSelectionFailed) && method === Method.Ping
-          ? PeerAction.Fatal
-          : PeerAction.LowToleranceError;
-      // TODO: Detect SSZDecodeError and return PeerAction.Fatal
+    case RequestErrorCode.DIAL_TIMEOUT:
+    case RequestErrorCode.DIAL_ERROR:
+      return e.message.includes(multiStreamSelectErrorCodes.protocolSelectionFailed) && method === Method.Ping
+        ? PeerAction.Fatal
+        : PeerAction.LowToleranceError;
+    // TODO: Detect SSZDecodeError and return PeerAction.Fatal
 
-      case RequestErrorCode.TTFB_TIMEOUT:
-      case RequestErrorCode.RESP_TIMEOUT:
-        switch (method) {
-          case Method.Ping:
-            return PeerAction.LowToleranceError;
-          case Method.BeaconBlocksByRange:
-          case Method.BeaconBlocksByRoot:
-            return PeerAction.MidToleranceError;
-          default:
-            return null;
-        }
-    }
+    case RequestErrorCode.TTFB_TIMEOUT:
+    case RequestErrorCode.RESP_TIMEOUT:
+      switch (method) {
+        case Method.Ping:
+          return PeerAction.LowToleranceError;
+        case Method.BeaconBlocksByRange:
+        case Method.BeaconBlocksByRoot:
+          return PeerAction.MidToleranceError;
+        default:
+          return null;
+      }
   }
 
   if (e.message.includes(libp2pErrorCodes.ERR_UNSUPPORTED_PROTOCOL)) {

--- a/packages/beacon-node/test/unit/network/peers/score.test.ts
+++ b/packages/beacon-node/test/unit/network/peers/score.test.ts
@@ -6,6 +6,7 @@ import {PeerAction, ScoreState, PeerRpcScoreStore, updateGossipsubScores} from "
 describe("simple block provider score tracking", function () {
   const peer = PeerId.createFromB58String("Qma9T5YraSnpRDZqRR4krcSJabThc8nwZuJV3LercPHufi");
   const MIN_SCORE = -100;
+  const actionName = "test-action";
 
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   function mockStore() {
@@ -30,7 +31,7 @@ describe("simple block provider score tracking", function () {
   for (const [peerAction, times] of timesToBan)
     it(`Should ban peer after ${times} ${peerAction}`, async () => {
       const {scoreStore} = mockStore();
-      for (let i = 0; i < times; i++) scoreStore.applyAction(peer, peerAction);
+      for (let i = 0; i < times; i++) scoreStore.applyAction(peer, peerAction, actionName);
       expect(scoreStore.getScoreState(peer)).to.be.equal(ScoreState.Banned);
     });
 
@@ -55,8 +56,8 @@ describe("simple block provider score tracking", function () {
 
   it("should not go below min score", function () {
     const {scoreStore} = mockStore();
-    scoreStore.applyAction(peer, PeerAction.Fatal);
-    scoreStore.applyAction(peer, PeerAction.Fatal);
+    scoreStore.applyAction(peer, PeerAction.Fatal, actionName);
+    scoreStore.applyAction(peer, PeerAction.Fatal, actionName);
     expect(scoreStore.getScore(peer)).to.be.gte(MIN_SCORE);
   });
 });


### PR DESCRIPTION
**Motivation**

Make sure network reporting metrics always have a label. Otherwise they look like this:

![Screenshot from 2022-08-22 19-03-33](https://user-images.githubusercontent.com/35266934/185978192-23f9b3f0-7f01-4c80-8359-fb1439caf1c1.png)

**Description**

Add actionName to all reportAction calls