### PR TITLE
Inject git commit in docker build

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -120,7 +120,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        run: docker buildx build --push --tag chainsafe/lodestar:next --platform linux/amd64,linux/arm64 --build-arg VERSION=${{ needs.npm.outputs.version }} .
+        run: >
+          docker buildx build . --push
+          --tag chainsafe/lodestar:next
+          --platform linux/amd64,linux/arm64
+          --build-arg COMMIT=$(git rev-parse HEAD)
+
       - run: docker run chainsafe/lodestar:next --help
       # Display history to know byte size of each layer
       # Image is available only because of the previous `docker run` command

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -144,7 +144,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        run: docker buildx build --push --tag chainsafe/lodestar:rc --tag chainsafe/lodestar:${{ needs.tag.outputs.tag }} --platform linux/amd64,linux/arm64 --build-arg VERSION=${{ needs.tag.outputs.tag }} .
+        run: >
+          docker buildx build . --push
+          --tag chainsafe/lodestar:rc
+          --tag chainsafe/lodestar:${{ needs.tag.outputs.tag }}
+          --platform linux/amd64,linux/arm64
+          --build-arg COMMIT=$(git rev-parse HEAD)
+
       - run: docker run chainsafe/lodestar:${{ needs.tag.outputs.tag }} --help
       # Display history to know byte size of each layer
       # Image is available only because of the previous `docker run` command

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -134,7 +134,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        run: docker buildx build --push --tag chainsafe/lodestar:latest --tag chainsafe/lodestar:${{ needs.tag.outputs.tag }} --platform linux/amd64,linux/arm64 --build-arg VERSION=${{ needs.tag.outputs.tag }} .
+        run: >
+          docker buildx build . --push
+          --tag chainsafe/lodestar:latest
+          --tag chainsafe/lodestar:${{ needs.tag.outputs.tag }}
+          --platform linux/amd64,linux/arm64
+          --build-arg COMMIT=$(git rev-parse HEAD)
+
       - run: docker run chainsafe/lodestar:${{ needs.tag.outputs.tag }} --help
       # Display history to know byte size of each layer
       # Image is available only because of the previous `docker run` command

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 # --platform=$BUILDPLATFORM is used build javascript source with host arch
 # Otherwise TS builds on emulated archs and can be extremely slow (+1h)
 FROM --platform=${BUILDPLATFORM:-amd64} node:16-alpine as build_src
+ARG COMMIT
 WORKDIR /usr/app
 RUN apk update && apk add --no-cache g++ make python3 && rm -rf /var/cache/apk/*
 
@@ -15,7 +16,7 @@ RUN yarn install --non-interactive --frozen-lockfile && \
 # a git-data.json file is created by persisting git data at build time. Then,
 # a version string like `v0.35.0-beta.0/HEAD/82219149 (git)` can be shown in
 # the terminal and in the logs; which is very useful to track tests better.
-RUN cd packages/cli && yarn write-git-data
+RUN cd packages/cli && GIT_COMMIT=${COMMIT} yarn write-git-data
 
 
 # Copy built src + node_modules to build native packages for archs different than host.

--- a/packages/cli/src/util/gitData/index.ts
+++ b/packages/cli/src/util/gitData/index.ts
@@ -40,8 +40,8 @@ export function readAndGetGitData(): GitData {
 /** Gets git data containing current branch and commit info from CLI. */
 export function getGitData(): GitData {
   return {
-    branch: getBranch(),
-    commit: getCommit(),
+    branch: process.env.GIT_BRANCH ?? getBranch(),
+    commit: process.env.GIT_COMMIT ?? getCommit(),
   };
 }
 


### PR DESCRIPTION
**Motivation**

git info is not naturally available in the docker context. This PR "injects" the git commit as a build arg to be available in version rendering both in logs and metrics.

**Description**

Closes https://github.com/ChainSafe/lodestar/issues/4464