### PR TITLE
Chunkify prepareBeaconCommitteeSubnet() for large request

### DIFF
--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -14,10 +14,12 @@ import {ChainHeaderTracker, HeadEventData} from "./chainHeaderTracker.js";
 const HISTORICAL_DUTIES_EPOCHS = 2;
 
 /**
- * On lodestar test nodes, we can have up to 1k validators per node. On a node with too many validators,
- * it can cause "Request body is too large" issue for http post.
+ * This is to prevent the "Request body is too large" issue for http post.
+ * Typical server accept up to1MB (2 ** 20 bytes) of request body, for example fastify and nginx.
+ * A typical subscription request is 107 bytes in length, make it 120 to buffer.
+ * This number is Math.floor(2 ** 20 / 120)
  **/
-const SUBSCRIPTIONS_PER_REQUEST = 1000;
+const SUBSCRIPTIONS_PER_REQUEST = 8738;
 
 /** Neatly joins the server-generated `AttesterData` with the locally-generated `selectionProof`. */
 export type AttDutyAndProof = {

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -4,7 +4,7 @@ import {computeEpochAtSlot, isAggregatorFromCommitteeLength} from "@lodestar/sta
 import {BLSSignature, Epoch, Slot, ValidatorIndex, RootHex} from "@lodestar/types";
 import {Api, routes} from "@lodestar/api";
 import {toHexString} from "@chainsafe/ssz";
-import {IClock, ILoggerVc} from "../util/index.js";
+import {batchItems, IClock, ILoggerVc} from "../util/index.js";
 import {PubkeyHex} from "../types.js";
 import {Metrics} from "../metrics.js";
 import {ValidatorStore} from "./validatorStore.js";
@@ -12,6 +12,12 @@ import {ChainHeaderTracker, HeadEventData} from "./chainHeaderTracker.js";
 
 /** Only retain `HISTORICAL_DUTIES_EPOCHS` duties prior to the current epoch. */
 const HISTORICAL_DUTIES_EPOCHS = 2;
+
+/**
+ * On lodestar test nodes, we can have up to 1k validators per node. On a node with too many validators,
+ * it can cause "Request body is too large" issue for http post.
+ **/
+const SUBSCRIPTIONS_PER_REQUEST = 1000;
 
 /** Neatly joins the server-generated `AttesterData` with the locally-generated `selectionProof`. */
 export type AttDutyAndProof = {
@@ -184,10 +190,15 @@ export class AttestationDutiesService {
 
     // If there are any subscriptions, push them out to the beacon node.
     if (beaconCommitteeSubscriptions.length > 0) {
-      // TODO: Should log or throw?
-      await this.api.validator.prepareBeaconCommitteeSubnet(beaconCommitteeSubscriptions).catch((e: Error) => {
-        throw extendError(e, "Failed to subscribe to beacon committee subnets");
-      });
+      const subscriptionsBatches = batchItems(beaconCommitteeSubscriptions, {batchSize: SUBSCRIPTIONS_PER_REQUEST});
+      await Promise.all(
+        subscriptionsBatches.map(
+          async (subscriptions) =>
+            await this.api.validator.prepareBeaconCommitteeSubnet(subscriptions).catch((e: Error) => {
+              throw extendError(e, "Failed to subscribe to beacon committee subnets");
+            })
+        )
+      );
     }
   }
 

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -193,14 +193,9 @@ export class AttestationDutiesService {
     // If there are any subscriptions, push them out to the beacon node.
     if (beaconCommitteeSubscriptions.length > 0) {
       const subscriptionsBatches = batchItems(beaconCommitteeSubscriptions, {batchSize: SUBSCRIPTIONS_PER_REQUEST});
-      await Promise.all(
-        subscriptionsBatches.map(
-          async (subscriptions) =>
-            await this.api.validator.prepareBeaconCommitteeSubnet(subscriptions).catch((e: Error) => {
-              throw extendError(e, "Failed to subscribe to beacon committee subnets");
-            })
-        )
-      );
+      await Promise.all(subscriptionsBatches.map(this.api.validator.prepareBeaconCommitteeSubnet)).catch((e: Error) => {
+        throw extendError(e, "Failed to subscribe to beacon committee subnets");
+      });
     }
   }
 


### PR DESCRIPTION
**Motivation**

On a node of 10k validators, it is not able to detect connected validators because `prepareBeaconCommitteeSubnet()` api does not work due to this error:
```
Aug-23 00:00:04.679[]                ^[[31merror^[[39m: Error on poll attesters epoch=116400 Payload Too Large: Request body is too large - Failed to subscribe to beacon committee subnets
Error: Payload Too Large: Request body is too large - Failed to subscribe to beacon committee subnets
    at HttpClient.requestWithBody (file:///usr/src/lodestar/packages/api/src/utils/client/httpClient.ts:121:15)
    at runMicrotasks (<anonymous>)
```

**Description**

- Chunkify the `prepareBeaconCommitteeSubnet` api at validator side
- Since we have nodes with 1k validators for a while, choose `SUBSCRIPTIONS_PER_REQUEST` as 1k

**Test**

<img width="1595" alt="Screen Shot 2022-08-23 at 11 22 22" src="https://user-images.githubusercontent.com/10568965/186069176-9c6654ca-813b-451d-9001-3e1492718a7e.png">

