### PR TITLE
Add sepolia to networks defined in light-client package

### DIFF
--- a/packages/light-client/src/networks.ts
+++ b/packages/light-client/src/networks.ts
@@ -4,6 +4,7 @@ enum NetworkName {
   mainnet = "mainnet",
   goerli = "goerli",
   ropsten = "ropsten",
+  sepolia = "sepolia",
 }
 
 export type GenesisDataHex = {
@@ -28,5 +29,9 @@ export const networkGenesis: Record<NetworkName, GenesisDataHex> = {
   [NetworkName.ropsten]: {
     genesisTime: 1653922800,
     genesisValidatorsRoot: "0x44f1e56283ca88b35c789f7f449e52339bc1fefe3a45913a43a6d16edcd33cf1",
+  },
+  [NetworkName.sepolia]: {
+    genesisTime: 1655733600,
+    genesisValidatorsRoot: "0xd8ea171f3c94aea21ebc42a1ed61052acf3f9209c00e4efbaaddac09ed9b8078",
   },
 };


### PR DESCRIPTION
**Motivation**

Needed in other to have sepolia on the light client demo. See https://github.com/ChainSafe/eth2-light-client-demo/issues/46

**Description**

Source of configuration used: https://github.com/eth-clients/sepolia