### PR TITLE
Set libp2p agent version

### DIFF
--- a/packages/beacon-node/src/network/nodejs/bundle.ts
+++ b/packages/beacon-node/src/network/nodejs/bundle.ts
@@ -18,6 +18,7 @@ export interface ILibp2pOptions {
   bootMultiaddrs?: string[];
   maxConnections?: number;
   minConnections?: number;
+  lodestarVersion?: string;
 }
 
 export class NodejsNode extends LibP2p {
@@ -28,6 +29,7 @@ export class NodejsNode extends LibP2p {
         listen: options.addresses.listen,
         announce: options.addresses.announce || [],
       },
+      host: options.lodestarVersion ? {agentVersion: `js-libp2p/lodestar-${options.lodestarVersion}`} : undefined,
       modules: {
         connEncryption: [NOISE],
         transport: [TCP],

--- a/packages/beacon-node/src/network/nodejs/util.ts
+++ b/packages/beacon-node/src/network/nodejs/util.ts
@@ -71,5 +71,6 @@ export async function createNodeJsLibp2p(
     minConnections: networkOpts.targetPeers,
     // If peer discovery is enabled let the default in NodejsNode
     peerDiscovery: disablePeerDiscovery ? [] : undefined,
+    lodestarVersion: networkOpts.version,
   });
 }

--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -9,6 +9,7 @@ export interface INetworkOptions extends PeerManagerOpts, RateLimiterOpts, Gossi
   bootMultiaddrs?: string[];
   subscribeAllSubnets?: boolean;
   connectToDiscv5Bootnodes?: boolean;
+  version?: string;
 }
 
 export const defaultDiscv5Options: IDiscv5DiscoveryInputOptions = {

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -30,6 +30,8 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
   beaconNodeOptions.set({metrics: {metadata: {version, commit, network: args.network}}});
   // Add detailed version string for API node/version endpoint
   beaconNodeOptions.set({api: {version}});
+  // Add simple version string for libp2p agent version
+  beaconNodeOptions.set({network: {version: version.split("/")[0]}});
 
   // ENR setup
   const peerId = await readPeerId(beaconPaths.peerIdFile);


### PR DESCRIPTION
**Motivation**

- See https://github.com/ChainSafe/lodestar/issues/4465

**Description**

Set libp2p agentVersion to Lodestar's version in a way that other clients should be able to parse it. Lighthouse has to match the string before the first `/` to be equal to `js-libp2p` to consider the client to be Lodestar.

- agentVersion before: `js-libp2p/0.32.4`
- agentVersion with this PR: `js-libp2p/lodestar-v1.0.0`

Closes https://github.com/ChainSafe/lodestar/issues/4465