### PR TITLE
Skip genesis fetch on slashing protection import/export for known networks

### DIFF
--- a/packages/cli/src/cmds/validator/slashingProtection/options.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/options.ts
@@ -3,6 +3,7 @@ import {IValidatorCliArgs, validatorOptions} from "../options.js";
 
 export type ISlashingProtectionArgs = Pick<IValidatorCliArgs, "server"> & {
   force?: boolean;
+  fetchCustomGenesis?: boolean;
 };
 
 export const slashingProtectionOptions: ICliCommandOptions<ISlashingProtectionArgs> = {
@@ -10,6 +11,10 @@ export const slashingProtectionOptions: ICliCommandOptions<ISlashingProtectionAr
 
   force: {
     description: "If genesisValidatorsRoot can't be fetched from the Beacon node, use a zero hash",
+    type: "boolean",
+  },
+  fetchCustomGenesis: {
+    description: "Fetch genesisValidatorsRoot from beacon node for custom network",
     type: "boolean",
   },
 };


### PR DESCRIPTION
Only fetch the genesis for slashing protection import/export if unknown network or forced via  a flag `fetchCustomGenesis` (for e.g. for shadow forks)


Closes #4259