### PR TITLE
Fetch genesisValidatorsRoot from cached metadata value

### DIFF
--- a/packages/cli/src/cmds/validator/slashingProtection/export.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/export.ts
@@ -49,8 +49,13 @@ export const exportCmd: ICliCommand<
     const formatVersion: InterchangeFormatVersion = {version: "4", format: "complete"};
     logger.info("Exporting the slashing protection logs", {...formatVersion, dbPath});
 
-    const genesisValidatorsRoot = await getGenesisValidatorsRoot(args);
-    const slashingProtection = getSlashingProtection(args);
+    const {slashingProtection, metadata} = getSlashingProtection(args);
+
+    // When exporting validator DB should already have genesisValidatorsRoot persisted.
+    // For legacy node and general fallback, fetch from:
+    // - known genesis data from existing network
+    // - else fetch from beacon node
+    const genesisValidatorsRoot = (await metadata.getGenesisValidatorsRoot()) ?? (await getGenesisValidatorsRoot(args));
 
     logger.verbose("Fetching the pubkeys from the slashingProtection db");
     const pubkeys = await slashingProtection.listPubkeys();

--- a/packages/cli/src/cmds/validator/slashingProtection/import.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/import.ts
@@ -47,13 +47,20 @@ export const importCmd: ICliCommand<
     const {validatorsDbDir: dbPath} = getValidatorPaths(args);
 
     logger.info("Importing the slashing protection logs", {dbPath});
-    const genesisValidatorsRoot = await getGenesisValidatorsRoot(args);
-    const slashingProtection = getSlashingProtection(args);
+
+    const {slashingProtection, metadata} = getSlashingProtection(args);
+
+    // Fetch genesisValidatorsRoot from:
+    // - existing cached in validator DB
+    // - known genesis data from existing network
+    // - else fetch from beacon node
+    const genesisValidatorsRoot = (await metadata.getGenesisValidatorsRoot()) ?? (await getGenesisValidatorsRoot(args));
 
     logger.verbose("Reading the slashing protection logs", {file: args.file});
-    const importFile = await fs.promises.readFile(args.file, "utf8");
-    const importFileJson = JSON.parse(importFile) as Interchange;
-    await slashingProtection.importInterchange(importFileJson, genesisValidatorsRoot, logger);
+    const interchangeStr = await fs.promises.readFile(args.file, "utf8");
+    const interchangeJson = JSON.parse(interchangeStr) as Interchange;
+
+    await slashingProtection.importInterchange(interchangeJson, genesisValidatorsRoot, logger);
     logger.info("Import completed successfully");
   },
 };

--- a/packages/cli/src/cmds/validator/slashingProtection/utils.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/utils.ts
@@ -2,8 +2,8 @@ import {Root} from "@lodestar/types";
 import {getClient} from "@lodestar/api";
 import {fromHex} from "@lodestar/utils";
 import {genesisData, NetworkName} from "@lodestar/config/networks";
-import {SlashingProtection} from "@lodestar/validator";
-import {LevelDbController} from "@lodestar/db";
+import {SlashingProtection, MetaDataRepository} from "@lodestar/validator";
+import {IDatabaseApiOptions, LevelDbController} from "@lodestar/db";
 import {YargsError} from "../../../util/index.js";
 import {IGlobalArgs} from "../../../options/index.js";
 import {getValidatorPaths} from "../paths.js";
@@ -14,15 +14,23 @@ import {ISlashingProtectionArgs} from "./options.js";
 /**
  * Returns a new SlashingProtection object instance based on global args.
  */
-export function getSlashingProtection(args: IGlobalArgs): SlashingProtection {
+export function getSlashingProtection(
+  args: IGlobalArgs
+): {slashingProtection: SlashingProtection; metadata: MetaDataRepository} {
   const validatorPaths = getValidatorPaths(args);
   const dbPath = validatorPaths.validatorsDbDir;
   const config = getBeaconConfigFromArgs(args);
   const logger = errorLogger();
-  return new SlashingProtection({
+
+  const dbOpts: IDatabaseApiOptions = {
     config,
     controller: new LevelDbController({name: dbPath}, {logger}),
-  });
+  };
+
+  return {
+    slashingProtection: new SlashingProtection(dbOpts),
+    metadata: new MetaDataRepository(dbOpts),
+  };
 }
 
 /**

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -2,6 +2,8 @@ export {Validator, ValidatorOptions, defaultOptions} from "./validator.js";
 export {ValidatorStore, SignerType, Signer, SignerLocal, SignerRemote} from "./services/validatorStore.js";
 export {waitForGenesis} from "./genesis.js";
 export {getMetrics, Metrics, MetricsRegister} from "./metrics.js";
+// For CLI to read genesisValidatorsRoot
+export {MetaDataRepository} from "./repositories/index.js";
 
 // Remote signer client
 export {


### PR DESCRIPTION
**Motivation**

- Further improvement on https://github.com/ChainSafe/lodestar/pull/4480

**Description**

When exporting data from validator DB it should already include the genesisValidatorRoot of that specific DB. So let's use that instead of fetching from the beacon node.