### PR TITLE
Allow specifying proposer metadata per validator pubkey

### DIFF
--- a/packages/beacon-node/test/sim/merge-interop.test.ts
+++ b/packages/beacon-node/test/sim/merge-interop.test.ts
@@ -8,6 +8,7 @@ import {LogLevel, sleep, TimestampFormatCode} from "@lodestar/utils";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {IChainConfig} from "@lodestar/config";
 import {Epoch} from "@lodestar/types";
+import {ValidatorProposerConfig} from "@lodestar/validator";
 
 import {ExecutePayloadStatus} from "../../src/execution/engine/interface.js";
 import {ExecutionEngineHttp} from "../../src/execution/engine/http.js";
@@ -345,6 +346,35 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     });
 
     const stopInfoTracker = simTestInfoTracker(bn, loggerNodeA);
+    const valProposerConfig = {
+      proposerConfig: {
+        "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c": {
+          graffiti: "graffiti",
+          strictFeeRecipientCheck: true,
+          feeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          builder: {
+            enabled: false,
+            gasLimit: 30000000,
+          },
+        },
+        "0xa4855c83d868f772a579133d9f23818008417b743e8447e235d8eb78b1d8f8a9f63f98c551beb7de254400f89592314d": {
+          feeRecipient: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          builder: {
+            enabled: true,
+            gasLimit: 35000000,
+          },
+        },
+      },
+      defaultConfig: {
+        graffiti: "default graffiti",
+        strictFeeRecipientCheck: true,
+        feeRecipient: "0xcccccccccccccccccccccccccccccccccccccccc",
+        builder: {
+          enabled: false,
+          gasLimit: 30000000,
+        },
+      },
+    } as ValidatorProposerConfig;
 
     const {validators} = await getAndInitDevValidators({
       node: bn,
@@ -354,9 +384,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
       // At least one sim test must use the REST API for beacon <-> validator comms
       useRestApi: true,
       testLoggerOpts,
-      suggestedFeeRecipient: "0xcccccccccccccccccccccccccccccccccccccccc",
-      builder: {},
-      // TODO test merge-interop with remote;
+      valProposerConfig,
     });
 
     afterEachCallbacks.push(async function () {

--- a/packages/beacon-node/test/utils/node/validator.ts
+++ b/packages/beacon-node/test/utils/node/validator.ts
@@ -1,7 +1,7 @@
 import tmp from "tmp";
 import {LevelDbController} from "@lodestar/db";
 import {interopSecretKey} from "@lodestar/state-transition";
-import {SlashingProtection, Validator, Signer, SignerType} from "@lodestar/validator";
+import {SlashingProtection, Validator, Signer, SignerType, ValidatorProposerConfig} from "@lodestar/validator";
 import type {SecretKey} from "@chainsafe/bls/types";
 import {BeaconNode} from "../../../src/index.js";
 import {testLogger, TestLoggerOpts} from "../logger.js";
@@ -14,9 +14,8 @@ export async function getAndInitDevValidators({
   useRestApi,
   testLoggerOpts,
   externalSignerUrl,
-  suggestedFeeRecipient,
   doppelgangerProtectionEnabled = false,
-  builder = {},
+  valProposerConfig,
 }: {
   node: BeaconNode;
   validatorsPerClient: number;
@@ -25,9 +24,8 @@ export async function getAndInitDevValidators({
   useRestApi?: boolean;
   testLoggerOpts?: TestLoggerOpts;
   externalSignerUrl?: string;
-  suggestedFeeRecipient?: string;
   doppelgangerProtectionEnabled?: boolean;
-  builder?: {enabled?: boolean};
+  valProposerConfig?: ValidatorProposerConfig;
 }): Promise<{validators: Validator[]; secretKeys: SecretKey[]}> {
   const validators: Promise<Validator>[] = [];
   const secretKeys: SecretKey[] = [];
@@ -70,9 +68,8 @@ export async function getAndInitDevValidators({
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         processShutdownCallback: () => {},
         signers,
-        suggestedFeeRecipient,
         doppelgangerProtectionEnabled,
-        builder,
+        valProposerConfig,
       })
     );
   }

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -27,6 +27,7 @@ export type IValidatorCliArgs = AccountValidatorArgs &
     graffiti: string;
     afterBlockDelaySlotFraction?: number;
     suggestedFeeRecipient?: string;
+    proposerSettingsFile?: string;
     strictFeeRecipientCheck?: boolean;
     doppelgangerProtectionEnabled?: boolean;
     defaultGasLimit?: number;
@@ -143,6 +144,11 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
     hidden: true,
     description: "Delay before publishing attestations if block comes early, as a fraction of SECONDS_PER_SLOT",
     type: "number",
+  },
+
+  proposerSettingsFile: {
+    description: "proposer setting yaml file",
+    type: "string",
   },
 
   suggestedFeeRecipient: {

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -147,7 +147,7 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
   },
 
   proposerSettingsFile: {
-    description: "proposer setting yaml file",
+    description: "A yaml file to specify detailed default and per validator pubkey customized proposer configs. PS: This feature and its format is in alpha and subject to change",
     type: "string",
   },
 

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -147,7 +147,8 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
   },
 
   proposerSettingsFile: {
-    description: "A yaml file to specify detailed default and per validator pubkey customized proposer configs. PS: This feature and its format is in alpha and subject to change",
+    description:
+      "A yaml file to specify detailed default and per validator pubkey customized proposer configs. PS: This feature and its format is in alpha and subject to change",
     type: "string",
   },
 

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -15,3 +15,4 @@ export * from "./stripOffNewlines.js";
 export * from "./types.js";
 export * from "./jwt.js";
 export * from "./feeRecipient.js";
+export * from "./proposerConfig.js";

--- a/packages/cli/src/util/proposerConfig.ts
+++ b/packages/cli/src/util/proposerConfig.ts
@@ -1,0 +1,93 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import {ValidatorProposerConfig} from "@lodestar/validator";
+import {parseFeeRecipient} from "./feeRecipient.js";
+
+import {readFile} from "./file.js";
+
+type ProposerConfig = ValidatorProposerConfig["defaultConfig"];
+
+type ProposerConfigFileSection = {
+  graffiti?: string;
+  strict_fee_recipient_check?: string;
+  fee_recipient?: string;
+  builder?: {
+    // boolean are parse as string by the default schema readFile employs
+    // for js-yaml
+    enabled?: string;
+    gas_limit?: number;
+  };
+};
+
+type ProposerConfigFile = {
+  proposer_config?: {[index: string]: ProposerConfigFileSection};
+  default_config?: ProposerConfigFileSection;
+};
+
+export function parseProposerConfig(
+  configFilePath: string,
+  defaultArgsConfig?: ProposerConfig
+): ValidatorProposerConfig {
+  const configFile = readFile<ProposerConfigFile>(configFilePath, ["yml", "yaml"]);
+  const defaultConfigParsed = parseProposerConfigSection(configFile.default_config || {}, defaultArgsConfig);
+
+  const proposerConfigFile = configFile.proposer_config || {};
+  const proposerConfigParsed: ValidatorProposerConfig["proposerConfig"] = {};
+  for (const pubkeyHex of Object.keys(proposerConfigFile)) {
+    proposerConfigParsed[pubkeyHex] = parseProposerConfigSection(proposerConfigFile[pubkeyHex]);
+  }
+
+  return {
+    proposerConfig: proposerConfigParsed,
+    defaultConfig: defaultConfigParsed,
+  };
+}
+
+function stringtoBool(input: string): boolean {
+  const boolValue = typeof input === "string" ? input === "true" : input;
+  return boolValue;
+}
+
+function parseProposerConfigSection(
+  proposerFileSection: ProposerConfigFileSection,
+  overrideConfig?: ProposerConfig
+): ProposerConfig {
+  const {graffiti, strict_fee_recipient_check, fee_recipient, builder} = proposerFileSection;
+  const {enabled, gas_limit} = builder || {};
+
+  if (graffiti !== undefined && typeof graffiti !== "string") {
+    throw Error("graffiti is not 'string");
+  }
+  if (
+    strict_fee_recipient_check !== undefined &&
+    !(strict_fee_recipient_check === "true" || strict_fee_recipient_check === "false")
+  ) {
+    throw Error("enabled is not set to boolean");
+  }
+  if (fee_recipient !== undefined && typeof fee_recipient !== "string") {
+    throw Error("fee_recipient is not 'string");
+  }
+  if (enabled !== undefined && !(enabled === "true" || enabled === "false")) {
+    throw Error("enabled is not set to boolean");
+  }
+  if (gas_limit !== undefined) {
+    if (typeof gas_limit !== "string") {
+      throw Error("(typeof gas_limit !== 'string') 2 ");
+    }
+    if (Number.isNaN(Number(gas_limit))) {
+      throw Error("(Number.isNaN(Number(gas_limit)) 2");
+    }
+  }
+
+  return {
+    graffiti: overrideConfig?.graffiti ?? graffiti,
+    strictFeeRecipientCheck:
+      overrideConfig?.strictFeeRecipientCheck ??
+      (strict_fee_recipient_check ? stringtoBool(strict_fee_recipient_check) : undefined),
+    feeRecipient: overrideConfig?.feeRecipient ?? (fee_recipient ? parseFeeRecipient(fee_recipient) : undefined),
+    builder: {
+      enabled: overrideConfig?.builder.enabled ?? (enabled ? stringtoBool(enabled) : undefined),
+      gasLimit: overrideConfig?.builder.gasLimit ?? (gas_limit !== undefined ? Number(gas_limit) : undefined),
+    },
+  };
+}

--- a/packages/cli/test/unit/validator/parseProposerConfig.test.ts
+++ b/packages/cli/test/unit/validator/parseProposerConfig.test.ts
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import path from "node:path";
+import {fileURLToPath} from "node:url";
+import {expect} from "chai";
+import {parseProposerConfig} from "../../../src/util/index.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const testValue = {
+  proposerConfig: {
+    "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c": {
+      graffiti: "graffiti",
+      strictFeeRecipientCheck: true,
+      feeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      builder: {
+        enabled: true,
+        gasLimit: 30000000,
+      },
+    },
+    "0xa4855c83d868f772a579133d9f23818008417b743e8447e235d8eb78b1d8f8a9f63f98c551beb7de254400f89592314d": {
+      graffiti: undefined,
+      strictFeeRecipientCheck: undefined,
+      feeRecipient: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      builder: {
+        enabled: true,
+        gasLimit: 35000000,
+      },
+    },
+  },
+  defaultConfig: {
+    graffiti: "default graffiti",
+    strictFeeRecipientCheck: true,
+    feeRecipient: "0xcccccccccccccccccccccccccccccccccccccccc",
+    builder: {
+      enabled: true,
+      gasLimit: 30000000,
+    },
+  },
+};
+
+describe("validator / valid Proposer", () => {
+  it("parse Valid proposer", () => {
+    expect(parseProposerConfig(path.join(__dirname, "./proposerConfigs/validData.yaml"))).to.be.deep.equal(testValue);
+  });
+});
+
+describe("validator / invalid Proposer", () => {
+  it("should throw error", () => {
+    expect(() => parseProposerConfig(path.join(__dirname, "./proposerConfigs/invalidData.yaml"))).to.throw();
+  });
+});

--- a/packages/cli/test/unit/validator/proposerConfigs/invalidData.yaml
+++ b/packages/cli/test/unit/validator/proposerConfigs/invalidData.yaml
@@ -1,0 +1,20 @@
+proposer_config:
+  '0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c':
+    graffiti: 123
+    strict_fee_recipient_check: "true"
+    fee_recipient: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    builder:
+      enabled: true
+      gas_limit: "30000000"
+  '0xa4855c83d868f772a579133d9f23818008417b743e8447e235d8eb78b1d8f8a9f63f98c551beb7de254400f89592314d':
+    fee_recipient: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    builder:
+      enabled: "true"
+      gas_limit: "35000000"
+default_config:
+  graffiti: 'default graffiti'
+  strict_fee_recipient_check: true
+  fee_recipient: '0xcccccccccccccccccccccccccccccccccccccccc'
+  builder:
+    enabled: true
+    gas_limit: "30000000"

--- a/packages/cli/test/unit/validator/proposerConfigs/validData.yaml
+++ b/packages/cli/test/unit/validator/proposerConfigs/validData.yaml
@@ -1,0 +1,20 @@
+proposer_config:
+  '0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c':
+    graffiti: 'graffiti'
+    strict_fee_recipient_check: true
+    fee_recipient: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    builder:
+      enabled: true
+      gas_limit: "30000000"
+  '0xa4855c83d868f772a579133d9f23818008417b743e8447e235d8eb78b1d8f8a9f63f98c551beb7de254400f89592314d':
+    fee_recipient: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    builder:
+      enabled: "true"
+      gas_limit: "35000000"
+default_config:
+  graffiti: 'default graffiti'
+  strict_fee_recipient_check: "true"
+  fee_recipient: '0xcccccccccccccccccccccccccccccccccccccccc'
+  builder:
+    enabled: true
+    gas_limit: "30000000"

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -1,5 +1,13 @@
-export {Validator, ValidatorOptions, defaultOptions} from "./validator.js";
-export {ValidatorStore, SignerType, Signer, SignerLocal, SignerRemote} from "./services/validatorStore.js";
+export {Validator, ValidatorOptions} from "./validator.js";
+export {
+  ValidatorStore,
+  SignerType,
+  Signer,
+  SignerLocal,
+  SignerRemote,
+  ValidatorProposerConfig,
+  defaultOptions,
+} from "./services/validatorStore.js";
 export {waitForGenesis} from "./genesis.js";
 export {getMetrics, Metrics, MetricsRegister} from "./metrics.js";
 // For CLI to read genesisValidatorsRoot

--- a/packages/validator/src/services/prepareBeaconProposer.ts
+++ b/packages/validator/src/services/prepareBeaconProposer.ts
@@ -1,7 +1,6 @@
 import {Epoch, bellatrix} from "@lodestar/types";
 import {Api, routes} from "@lodestar/api";
 import {IBeaconConfig} from "@lodestar/config";
-import {fromHexString} from "@chainsafe/ssz";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 
 import {IClock, ILoggerVc, batchItems} from "../util/index.js";
@@ -84,28 +83,34 @@ export function pollBuilderValidatorRegistration(
     await validatorStore.pollValidatorIndices().catch((e: Error) => {
       logger.error("Error on pollValidatorIndices for prepareBeaconProposer", {epoch}, e);
     });
+    const pubkeyHexes = validatorStore
+      .getAllLocalIndices()
+      .map((index) => validatorStore.getPubkeyOfIndex(index))
+      .filter((pubkeyHex) => pubkeyHex !== undefined && validatorStore.isBuilderEnabled(pubkeyHex));
 
-    const indicesChunks = batchItems(validatorStore.getAllLocalIndices(), {batchSize: REGISTRATION_CHUNK_SIZE});
+    if (pubkeyHexes.length > 0) {
+      const pubkeyHexesChunks = batchItems(pubkeyHexes, {batchSize: REGISTRATION_CHUNK_SIZE});
 
-    for (const indices of indicesChunks) {
-      try {
-        const registrations = await Promise.all(
-          indices.map(
-            (index): Promise<bellatrix.SignedValidatorRegistrationV1> => {
-              const pubkeyHex = validatorStore.getPubkeyOfIndex(index);
-              if (!pubkeyHex) throw Error(`Pubkey lookup failure for index=${index}`);
-              const feeRecipient = validatorStore.getFeeRecipient(pubkeyHex);
-              return validatorStore.signValidatorRegistration(
-                fromHexString(pubkeyHex),
-                fromHexString(feeRecipient),
-                slot
-              );
-            }
-          )
-        );
-        await api.validator.registerValidator(registrations);
-      } catch (e) {
-        logger.error("Failed to register validator registrations with builder", {epoch}, e as Error);
+      for (const pubkeyHexes of pubkeyHexesChunks) {
+        try {
+          const registrations = await Promise.all(
+            pubkeyHexes.map(
+              (pubkeyHex): Promise<bellatrix.SignedValidatorRegistrationV1> => {
+                // Just to make typescript happy as it can't figure out we have filtered
+                // undefined pubkeys above
+                if (pubkeyHex === undefined) {
+                  throw Error("All undefined pubkeys should have been filtered out");
+                }
+                const feeRecipient = validatorStore.getFeeRecipient(pubkeyHex);
+                const gasLimit = validatorStore.getGasLimit(pubkeyHex);
+                return validatorStore.signValidatorRegistration(pubkeyHex, {feeRecipient, gasLimit}, slot);
+              }
+            )
+          );
+          await api.validator.registerValidator(registrations);
+        } catch (e) {
+          logger.error("Failed to register validator registrations with builder", {epoch}, e as Error);
+        }
       }
     }
   }

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -97,7 +97,7 @@ type ValidatorData = ProposerConfig & {
 };
 
 export const defaultOptions = {
-  defaultFeeRecipient: "0x0000000000000000000000000000000000000000",
+  suggestedFeeRecipient: "0x0000000000000000000000000000000000000000",
   defaultGasLimit: 30_000_000,
 };
 
@@ -123,7 +123,7 @@ export class ValidatorStore {
     this.defaultProposerConfig = {
       graffiti: defaultConfig.graffiti ?? "",
       strictFeeRecipientCheck: defaultConfig.strictFeeRecipientCheck ?? false,
-      feeRecipient: defaultConfig.feeRecipient ?? defaultOptions.defaultFeeRecipient,
+      feeRecipient: defaultConfig.feeRecipient ?? defaultOptions.suggestedFeeRecipient,
       builder: {
         enabled: defaultConfig.builder?.enabled ?? false,
         gasLimit: defaultConfig.builder?.gasLimit ?? defaultOptions.defaultGasLimit,

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -31,7 +31,6 @@ import {
   Slot,
   ssz,
   ValidatorIndex,
-  ExecutionAddress,
 } from "@lodestar/types";
 import {BitArray, fromHexString, toHexString} from "@chainsafe/ssz";
 import {routes} from "@lodestar/api";
@@ -41,6 +40,9 @@ import {externalSignerPostSignature} from "../util/externalSignerClient.js";
 import {Metrics} from "../metrics.js";
 import {IndicesService} from "./indices.js";
 import {DoppelgangerService} from "./doppelgangerService.js";
+
+type BLSPubkeyMaybeHex = BLSPubkey | PubkeyHex;
+type Eth1Address = string;
 
 export enum SignerType {
   Local,
@@ -58,8 +60,30 @@ export type SignerRemote = {
   pubkey: PubkeyHex;
 };
 
-type BLSPubkeyMaybeHex = BLSPubkey | PubkeyHex;
-type Eth1Address = string;
+type DefaultProposerConfig = {
+  graffiti: string;
+  strictFeeRecipientCheck: boolean;
+  feeRecipient: Eth1Address;
+  builder: {
+    enabled: boolean;
+    gasLimit: number;
+  };
+};
+
+export type ProposerConfig = {
+  graffiti?: string;
+  strictFeeRecipientCheck?: boolean;
+  feeRecipient?: Eth1Address;
+  builder: {
+    enabled?: boolean;
+    gasLimit?: number;
+  };
+};
+
+export type ValidatorProposerConfig = {
+  proposerConfig: {[index: PubkeyHex]: ProposerConfig};
+  defaultConfig: ProposerConfig;
+};
 
 /**
  * Validator entity capable of producing signatures. Either:
@@ -68,10 +92,13 @@ type Eth1Address = string;
  */
 export type Signer = SignerLocal | SignerRemote;
 
-type ValidatorData = {
+type ValidatorData = ProposerConfig & {
   signer: Signer;
-  /** feeRecipient for block production, null if not explicitly configured */
-  feeRecipient: Eth1Address | null;
+};
+
+export const defaultOptions = {
+  defaultFeeRecipient: "0x0000000000000000000000000000000000000000",
+  defaultGasLimit: 30_000_000,
 };
 
 /**
@@ -81,6 +108,7 @@ export class ValidatorStore {
   private readonly validators = new Map<PubkeyHex, ValidatorData>();
   /** Initially true because there are no validators */
   private pubkeysToDiscover: PubkeyHex[] = [];
+  private readonly defaultProposerConfig: DefaultProposerConfig;
 
   constructor(
     private readonly config: IBeaconConfig,
@@ -89,11 +117,21 @@ export class ValidatorStore {
     private readonly doppelgangerService: DoppelgangerService | null,
     private readonly metrics: Metrics | null,
     initialSigners: Signer[],
-    private readonly suggestedFeeRecipient: string,
-    private readonly gasLimit: number
+    valProposerConfig: ValidatorProposerConfig = {defaultConfig: {builder: {}}, proposerConfig: {}}
   ) {
+    const defaultConfig = valProposerConfig.defaultConfig;
+    this.defaultProposerConfig = {
+      graffiti: defaultConfig.graffiti ?? "",
+      strictFeeRecipientCheck: defaultConfig.strictFeeRecipientCheck ?? false,
+      feeRecipient: defaultConfig.feeRecipient ?? defaultOptions.defaultFeeRecipient,
+      builder: {
+        enabled: defaultConfig.builder?.enabled ?? false,
+        gasLimit: defaultConfig.builder?.gasLimit ?? defaultOptions.defaultGasLimit,
+      },
+    };
+
     for (const signer of initialSigners) {
-      this.addSigner(signer);
+      this.addSigner(signer, valProposerConfig);
     }
 
     if (metrics) {
@@ -117,13 +155,35 @@ export class ValidatorStore {
       : this.indicesService.pollValidatorIndices(Array.from(this.validators.keys()));
   }
 
-  getFeeRecipient(pubkeyHex: PubkeyHex): string {
-    return this.validators.get(pubkeyHex)?.feeRecipient ?? this.suggestedFeeRecipient;
+  getFeeRecipient(pubkeyHex: PubkeyHex): Eth1Address {
+    return this.validators.get(pubkeyHex)?.feeRecipient ?? this.defaultProposerConfig.feeRecipient;
   }
 
-  getFeeRecipientByIndex(index: ValidatorIndex): string {
+  getFeeRecipientByIndex(index: ValidatorIndex): Eth1Address {
     const pubkey = this.indicesService.index2pubkey.get(index);
-    return (pubkey && this.validators.get(pubkey)?.feeRecipient) ?? this.suggestedFeeRecipient;
+    return pubkey ? this.getFeeRecipient(pubkey) : this.defaultProposerConfig.feeRecipient;
+  }
+
+  getGraffiti(pubkeyHex: PubkeyHex): string {
+    return this.validators.get(pubkeyHex)?.graffiti ?? this.defaultProposerConfig.graffiti;
+  }
+
+  isBuilderEnabled(pubkeyHex: PubkeyHex): boolean {
+    return (this.validators.get(pubkeyHex)?.builder || {}).enabled ?? this.defaultProposerConfig?.builder.enabled;
+  }
+
+  strictFeeRecipientCheck(pubkeyHex: PubkeyHex): boolean {
+    return (
+      this.validators.get(pubkeyHex)?.strictFeeRecipientCheck ?? this.defaultProposerConfig?.strictFeeRecipientCheck
+    );
+  }
+
+  getGasLimit(pubkeyHex: PubkeyHex): number {
+    return (
+      (this.validators.get(pubkeyHex)?.builder || {}).gasLimit ??
+      this.defaultProposerConfig?.builder.gasLimit ??
+      defaultOptions.defaultGasLimit
+    );
   }
 
   /** Return true if `index` is active part of this validator client */
@@ -131,15 +191,15 @@ export class ValidatorStore {
     return this.indicesService.index2pubkey.has(index);
   }
 
-  addSigner(signer: Signer): void {
+  addSigner(signer: Signer, valProposerConfig?: ValidatorProposerConfig): void {
     const pubkey = getSignerPubkeyHex(signer);
+    const proposerConfig = (valProposerConfig?.proposerConfig ?? {})[pubkey] ?? {};
 
     if (!this.validators.has(pubkey)) {
       this.pubkeysToDiscover.push(pubkey);
       this.validators.set(pubkey, {
         signer,
-        // TODO: Allow to customize
-        feeRecipient: null,
+        ...proposerConfig,
       });
 
       this.doppelgangerService?.registerValidator(pubkey);
@@ -350,11 +410,14 @@ export class ValidatorStore {
   }
 
   async signValidatorRegistration(
-    pubkey: BLSPubkey,
-    feeRecipient: ExecutionAddress,
+    pubkeyMaybeHex: BLSPubkeyMaybeHex,
+    regAttributes: {feeRecipient: Eth1Address; gasLimit: number},
     _slot: Slot
   ): Promise<bellatrix.SignedValidatorRegistrationV1> {
-    const gasLimit = this.gasLimit;
+    const pubkey = typeof pubkeyMaybeHex === "string" ? fromHexString(pubkeyMaybeHex) : pubkeyMaybeHex;
+    const feeRecipient = fromHexString(regAttributes.feeRecipient);
+    const {gasLimit} = regAttributes;
+
     const timestamp = Math.floor(Date.now() / 1000);
     const validatorRegistation: bellatrix.ValidatorRegistrationV1 = {
       feeRecipient,

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -17,16 +17,11 @@ import {Interchange, InterchangeFormatVersion, ISlashingProtection} from "./slas
 import {assertEqualParams, getLoggerVc, NotEqualParamsError} from "./util/index.js";
 import {ChainHeaderTracker} from "./services/chainHeaderTracker.js";
 import {ValidatorEventEmitter} from "./services/emitter.js";
-import {ValidatorStore, Signer} from "./services/validatorStore.js";
+import {ValidatorStore, Signer, ValidatorProposerConfig} from "./services/validatorStore.js";
 import {ProcessShutdownCallback, PubkeyHex} from "./types.js";
 import {Metrics} from "./metrics.js";
 import {MetaDataRepository} from "./repositories/metaDataRepository.js";
 import {DoppelgangerService} from "./services/doppelgangerService.js";
-
-export const defaultOptions = {
-  suggestedFeeRecipient: "0x0000000000000000000000000000000000000000",
-  defaultGasLimit: 30_000_000,
-};
 
 export type ValidatorOptions = {
   slashingProtection: ISlashingProtection;
@@ -36,13 +31,9 @@ export type ValidatorOptions = {
   logger: ILogger;
   processShutdownCallback: ProcessShutdownCallback;
   afterBlockDelaySlotFraction?: number;
-  graffiti?: string;
-  suggestedFeeRecipient?: string;
-  strictFeeRecipientCheck?: boolean;
   doppelgangerProtectionEnabled?: boolean;
   closed?: boolean;
-  gasLimit?: number;
-  builder: {enabled?: boolean};
+  valProposerConfig?: ValidatorProposerConfig;
 };
 
 // TODO: Extend the timeout, and let it be customizable
@@ -72,17 +63,7 @@ export class Validator {
   private readonly controller: AbortController;
 
   constructor(opts: ValidatorOptions, readonly genesis: Genesis, metrics: Metrics | null = null) {
-    const {
-      dbOps,
-      logger,
-      slashingProtection,
-      signers,
-      graffiti,
-      suggestedFeeRecipient,
-      strictFeeRecipientCheck,
-      gasLimit,
-      builder,
-    } = opts;
+    const {dbOps, logger, slashingProtection, signers, valProposerConfig} = opts;
     const config = createIBeaconConfig(dbOps.config, genesis.genesisValidatorsRoot);
     this.controller = new AbortController();
     const clock = new Clock(config, logger, {genesisTime: Number(genesis.genesisTime)});
@@ -105,6 +86,7 @@ export class Validator {
     const doppelgangerService = opts.doppelgangerProtectionEnabled
       ? new DoppelgangerService(logger, clock, api, indicesService, opts.processShutdownCallback, metrics)
       : null;
+
     const validatorStore = new ValidatorStore(
       config,
       slashingProtection,
@@ -112,13 +94,10 @@ export class Validator {
       doppelgangerService,
       metrics,
       signers,
-      suggestedFeeRecipient ?? defaultOptions.suggestedFeeRecipient,
-      gasLimit ?? defaultOptions.defaultGasLimit
+      valProposerConfig
     );
     pollPrepareBeaconProposer(config, loggerVc, api, clock, validatorStore, metrics);
-    if (builder.enabled) {
-      pollBuilderValidatorRegistration(config, loggerVc, api, clock, validatorStore, metrics);
-    }
+    pollBuilderValidatorRegistration(config, loggerVc, api, clock, validatorStore, metrics);
 
     const emitter = new ValidatorEventEmitter();
     // Validator event emitter can have more than 10 listeners in a normal course of operation
@@ -127,11 +106,7 @@ export class Validator {
 
     const chainHeaderTracker = new ChainHeaderTracker(logger, api, emitter);
 
-    this.blockProposingService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, metrics, {
-      graffiti,
-      strictFeeRecipientCheck,
-      builder,
-    });
+    this.blockProposingService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, metrics);
 
     this.attestationService = new AttestationService(
       loggerVc,

--- a/packages/validator/test/unit/services/block.test.ts
+++ b/packages/validator/test/unit/services/block.test.ts
@@ -43,7 +43,7 @@ describe("BlockDutiesService", function () {
     });
 
     const clock = new ClockMock();
-    const blockService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, null, {builder: {}});
+    const blockService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, null);
 
     const signedBlock = generateEmptySignedBlock();
     validatorStore.signRandao.resolves(signedBlock.message.body.randaoReveal);

--- a/packages/validator/test/unit/validatorStore.test.ts
+++ b/packages/validator/test/unit/validatorStore.test.ts
@@ -1,0 +1,84 @@
+import {toBufferBE} from "bigint-buffer";
+import {expect} from "chai";
+import sinon from "sinon";
+import {chainConfig} from "@lodestar/config/default";
+import bls from "@chainsafe/bls";
+import {toHexString} from "@chainsafe/ssz";
+import {ValidatorStore} from "../../src/services/validatorStore.js";
+import {getApiClientStub} from "../utils/apiStub.js";
+import {initValidatorStore} from "../utils/validatorStore.js";
+import {ValidatorProposerConfig} from "../../src/services/validatorStore.js";
+
+describe("ValidatorStore", function () {
+  const sandbox = sinon.createSandbox();
+  const api = getApiClientStub(sandbox);
+
+  let validatorStore: ValidatorStore;
+
+  let pubkeys: Uint8Array[]; // Initialize pubkeys in before() so bls is already initialized
+  let valProposerConfig: ValidatorProposerConfig;
+
+  before(() => {
+    const secretKeys = Array.from({length: 3}, (_, i) => bls.SecretKey.fromBytes(toBufferBE(BigInt(i + 1), 32)));
+    pubkeys = secretKeys.map((sk) => sk.toPublicKey().toBytes());
+
+    valProposerConfig = {
+      proposerConfig: {
+        [toHexString(pubkeys[0])]: {
+          graffiti: "graffiti",
+          strictFeeRecipientCheck: true,
+          feeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          builder: {
+            enabled: false,
+            gasLimit: 30000000,
+          },
+        },
+      },
+      defaultConfig: {
+        graffiti: "default graffiti",
+        strictFeeRecipientCheck: false,
+        feeRecipient: "0xcccccccccccccccccccccccccccccccccccccccc",
+        builder: {
+          enabled: true,
+          gasLimit: 35000000,
+        },
+      },
+    };
+
+    validatorStore = initValidatorStore(secretKeys, api, chainConfig, valProposerConfig);
+  });
+
+  it("Should validate graffiti,feeRecipient etc. from valProposerConfig and ValidatorStore", async function () {
+    //pubkeys[0] values
+    expect(validatorStore.getGraffiti(toHexString(pubkeys[0]))).to.be.equal(
+      valProposerConfig.proposerConfig[toHexString(pubkeys[0])].graffiti
+    );
+    expect(validatorStore.getFeeRecipient(toHexString(pubkeys[0]))).to.be.equal(
+      valProposerConfig.proposerConfig[toHexString(pubkeys[0])].feeRecipient
+    );
+    expect(validatorStore.isBuilderEnabled(toHexString(pubkeys[0]))).to.be.equal(
+      valProposerConfig.proposerConfig[toHexString(pubkeys[0])].builder.enabled
+    );
+    expect(validatorStore.strictFeeRecipientCheck(toHexString(pubkeys[0]))).to.be.equal(
+      valProposerConfig.proposerConfig[toHexString(pubkeys[0])].strictFeeRecipientCheck
+    );
+    expect(validatorStore.getGasLimit(toHexString(pubkeys[0]))).to.be.equal(
+      valProposerConfig.proposerConfig[toHexString(pubkeys[0])].builder.gasLimit
+    );
+
+    // default values
+    expect(validatorStore.getGraffiti(toHexString(pubkeys[1]))).to.be.equal(valProposerConfig.defaultConfig.graffiti);
+    expect(validatorStore.getFeeRecipient(toHexString(pubkeys[1]))).to.be.equal(
+      valProposerConfig.defaultConfig.feeRecipient
+    );
+    expect(validatorStore.isBuilderEnabled(toHexString(pubkeys[1]))).to.be.equal(
+      valProposerConfig.defaultConfig.builder.enabled
+    );
+    expect(validatorStore.strictFeeRecipientCheck(toHexString(pubkeys[1]))).to.be.equal(
+      valProposerConfig.defaultConfig.strictFeeRecipientCheck
+    );
+    expect(validatorStore.getGasLimit(toHexString(pubkeys[1]))).to.be.equal(
+      valProposerConfig.defaultConfig.builder.gasLimit
+    );
+  });
+});

--- a/packages/validator/test/utils/validatorStore.ts
+++ b/packages/validator/test/utils/validatorStore.ts
@@ -4,6 +4,7 @@ import {chainConfig} from "@lodestar/config/default";
 import {createIBeaconConfig, IChainConfig} from "@lodestar/config";
 import {Signer, SignerType, ValidatorStore} from "../../src/index.js";
 import {IndicesService} from "../../src/services/indices.js";
+import {ValidatorProposerConfig} from "../../src/services/validatorStore.js";
 import {testLogger} from "./logger.js";
 import {SlashingProtectionMock} from "./slashingProtectionMock.js";
 
@@ -13,12 +14,11 @@ import {SlashingProtectionMock} from "./slashingProtectionMock.js";
 export function initValidatorStore(
   secretKeys: SecretKey[],
   api: Api,
-  customChainConfig: IChainConfig = chainConfig
+  customChainConfig: IChainConfig = chainConfig,
+  valProposerConfig: ValidatorProposerConfig = {defaultConfig: {builder: {}}, proposerConfig: {}}
 ): ValidatorStore {
   const logger = testLogger();
   const genesisValidatorsRoot = Buffer.alloc(32, 0xdd);
-  const suggestedFeeRecipient = "0x0";
-  const defaultGasLimit = 10000;
 
   const signers: Signer[] = secretKeys.map((sk) => ({
     type: SignerType.Local,
@@ -34,7 +34,6 @@ export function initValidatorStore(
     null,
     metrics,
     signers,
-    suggestedFeeRecipient,
-    defaultGasLimit
+    valProposerConfig
   );
 }


### PR DESCRIPTION
**Motivation**
Right now our validator client only support default configgurations for fee recipient and builder params
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR allows one to specify the proposer metadata per validator pubkey via `proposerSettingsFile` arg for validator with such file format (https://docs.prylabs.network/docs/execution-node/fee-recipient#fee-recipient-json-config-file )
Enhanced it with `graffiti` and `strict_fee_recipient_check` (our custom option of allowing user to enforce fee recipient check for the engine block) options as well to allow full control to the user for the proposer data associated with a pubkey/default
```typescript
proposer_config:
  '0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c':
    graffiti: 'graffiti'
    strict_fee_recipient_check: false
    fee_recipient: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
    builder:
      enabled: true
      gas_limit: "30000000"
  '0xa4855c83d868f772a579133d9f23818008417b743e8447e235d8eb78b1d8f8a9f63f98c551beb7de254400f89592314d':
    fee_recipient: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
    builder:
      enabled: "true"
      gas_limit: "35000000"
default_config:
  graffiti: 'default graffiti'
  strict_fee_recipient_check: true
  fee_recipient: '0xcccccccccccccccccccccccccccccccccccccccc'
  builder:
    enabled: true
    gas_limit: "30000000"
```
Reference to file format discussion which seems to be proposing similar format: https://github.com/ethereum/builder-specs/pull/41/files
Closes #4490