### PR TITLE
Skip verify+import blocks perf test

### DIFF
--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -25,7 +25,7 @@ const slotCount = endSlot - startSlot;
 const timeoutInfura = 300_000;
 const logger = testLogger();
 
-describe("verify+import blocks - range sync perf test", () => {
+describe.skip("verify+import blocks - range sync perf test", () => {
   setBenchOpts({
     yieldEventLoopAfterEach: true, // So SubTree(s)'s WeakRef can be garbage collected https://github.com/nodejs/node/issues/39902
   });


### PR DESCRIPTION
**Motivation**

This perf test timeout almost always, marking CI as red

```
   1) verify+import blocks - range sync perf test
       altair verifyImport mainnet_s3766816:31:
     Error: Timeout of 680000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/runner/work/lodestar/lodestar/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts)
      at listOnTimeout (node:internal/timers:559:17)
      at processTimers (node:internal/timers:502:7)
```

https://github.com/ChainSafe/lodestar/runs/8049373420?check_suite_focus=true#step:9:489

**Description**

Disable temporarily to allow CI to be green, while debug why it timeouts