### PR TITLE
Prevent MaxListenersExceededWarning observed in validator's abort controller

### DIFF
--- a/packages/beacon-node/test/utils/node/validator.ts
+++ b/packages/beacon-node/test/utils/node/validator.ts
@@ -31,8 +31,8 @@ export async function getAndInitDevValidators({
   const validators: Promise<Validator>[] = [];
   const secretKeys: SecretKey[] = [];
   const abortControllers: ValidatorAbortController = {
-    genesisInit: new AbortController(),
-    validatorOps: new AbortController(),
+    genesisReqController: new AbortController(),
+    validatorOpsController: new AbortController(),
   };
 
   for (let clientIndex = 0; clientIndex < validatorClientCount; clientIndex++) {

--- a/packages/beacon-node/test/utils/node/validator.ts
+++ b/packages/beacon-node/test/utils/node/validator.ts
@@ -3,7 +3,6 @@ import {LevelDbController} from "@lodestar/db";
 import {interopSecretKey} from "@lodestar/state-transition";
 import {SlashingProtection, Validator, Signer, SignerType, ValidatorProposerConfig} from "@lodestar/validator";
 import type {SecretKey} from "@chainsafe/bls/types";
-import {ValidatorAbortController} from "@lodestar/validator";
 import {BeaconNode} from "../../../src/index.js";
 import {testLogger, TestLoggerOpts} from "../logger.js";
 
@@ -30,10 +29,7 @@ export async function getAndInitDevValidators({
 }): Promise<{validators: Validator[]; secretKeys: SecretKey[]}> {
   const validators: Promise<Validator>[] = [];
   const secretKeys: SecretKey[] = [];
-  const abortControllers: ValidatorAbortController = {
-    genesisReqController: new AbortController(),
-    validatorOpsController: new AbortController(),
-  };
+  const abortController = new AbortController();
 
   for (let clientIndex = 0; clientIndex < validatorClientCount; clientIndex++) {
     const startIndexVc = startIndex + clientIndex * validatorsPerClient;
@@ -72,7 +68,7 @@ export async function getAndInitDevValidators({
         logger,
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         processShutdownCallback: () => {},
-        abortControllers,
+        abortController,
         signers,
         doppelgangerProtectionEnabled,
         valProposerConfig,

--- a/packages/beacon-node/test/utils/node/validator.ts
+++ b/packages/beacon-node/test/utils/node/validator.ts
@@ -3,6 +3,7 @@ import {LevelDbController} from "@lodestar/db";
 import {interopSecretKey} from "@lodestar/state-transition";
 import {SlashingProtection, Validator, Signer, SignerType, ValidatorProposerConfig} from "@lodestar/validator";
 import type {SecretKey} from "@chainsafe/bls/types";
+import {ValidatorAbortController} from "@lodestar/validator";
 import {BeaconNode} from "../../../src/index.js";
 import {testLogger, TestLoggerOpts} from "../logger.js";
 
@@ -29,6 +30,10 @@ export async function getAndInitDevValidators({
 }): Promise<{validators: Validator[]; secretKeys: SecretKey[]}> {
   const validators: Promise<Validator>[] = [];
   const secretKeys: SecretKey[] = [];
+  const abortControllers: ValidatorAbortController = {
+    genesisInit: new AbortController(),
+    validatorOps: new AbortController(),
+  };
 
   for (let clientIndex = 0; clientIndex < validatorClientCount; clientIndex++) {
     const startIndexVc = startIndex + clientIndex * validatorsPerClient;
@@ -67,6 +72,7 @@ export async function getAndInitDevValidators({
         logger,
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         processShutdownCallback: () => {},
+        abortControllers,
         signers,
         doppelgangerProtectionEnabled,
         valProposerConfig,

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -69,17 +69,17 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
 
   const abortControllers: ValidatorAbortController = {
     // This AbortController interrupts the sleep() calls when waiting for genesis
-    genesisInit: new AbortController(),
+    genesisReqController: new AbortController(),
     // This AbortController interrupts the validators ops: clients call, clock etc
-    validatorOps: new AbortController(),
+    validatorOpsController: new AbortController(),
   };
 
   // We set infinity for abort controller used for validator operations,
   // to prevent MaxListenersExceededWarning which get logged when listeners > 10
   // Since it is perfectly fine to have listeners > 10
-  setMaxListeners(Infinity, abortControllers.validatorOps.signal);
+  setMaxListeners(Infinity, abortControllers.validatorOpsController.signal);
 
-  onGracefulShutdownCbs.push(async () => abortControllers.genesisInit.abort());
+  onGracefulShutdownCbs.push(async () => abortControllers.genesisReqController.abort());
 
   const dbOps = {
     config,

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -1,4 +1,4 @@
-export {Validator, ValidatorOptions} from "./validator.js";
+export {Validator, ValidatorOptions, ValidatorAbortController} from "./validator.js";
 export {
   ValidatorStore,
   SignerType,

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -1,4 +1,4 @@
-export {Validator, ValidatorOptions, ValidatorAbortController} from "./validator.js";
+export {Validator, ValidatorOptions} from "./validator.js";
 export {
   ValidatorStore,
   SignerType,

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -23,8 +23,6 @@ import {Metrics} from "./metrics.js";
 import {MetaDataRepository} from "./repositories/metaDataRepository.js";
 import {DoppelgangerService} from "./services/doppelgangerService.js";
 
-export type ValidatorAbortController = {genesisReqController: AbortController; validatorOpsController: AbortController};
-
 export type ValidatorOptions = {
   slashingProtection: ISlashingProtection;
   dbOps: IDatabaseApiOptions;
@@ -32,7 +30,7 @@ export type ValidatorOptions = {
   signers: Signer[];
   logger: ILogger;
   processShutdownCallback: ProcessShutdownCallback;
-  abortControllers: ValidatorAbortController;
+  abortController: AbortController;
   afterBlockDelaySlotFraction?: number;
   doppelgangerProtectionEnabled?: boolean;
   closed?: boolean;
@@ -68,7 +66,7 @@ export class Validator {
   constructor(opts: ValidatorOptions, readonly genesis: Genesis, metrics: Metrics | null = null) {
     const {dbOps, logger, slashingProtection, signers, valProposerConfig} = opts;
     const config = createIBeaconConfig(dbOps.config, genesis.genesisValidatorsRoot);
-    this.controller = opts.abortControllers.validatorOpsController;
+    this.controller = opts.abortController;
     const clock = new Clock(config, logger, {genesisTime: Number(genesis.genesisTime)});
     const loggerVc = getLoggerVc(logger, clock);
 
@@ -167,13 +165,10 @@ export class Validator {
       typeof opts.api === "string"
         ? // This new api instance can make do with default timeout as a faster timeout is
           // not necessary since this instance won't be used for validator duties
-          getClient(
-            {baseUrl: opts.api, getAbortSignal: () => opts.abortControllers.genesisReqController.signal},
-            {config, logger}
-          )
+          getClient({baseUrl: opts.api, getAbortSignal: () => opts.abortController.signal}, {config, logger})
         : opts.api;
 
-    const genesis = await waitForGenesis(api, opts.logger, opts.abortControllers.genesisReqController.signal);
+    const genesis = await waitForGenesis(api, opts.logger, opts.abortController.signal);
     logger.info("Genesis available");
 
     const {data: externalSpecJson} = await api.config.getSpec();

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -23,6 +23,8 @@ import {Metrics} from "./metrics.js";
 import {MetaDataRepository} from "./repositories/metaDataRepository.js";
 import {DoppelgangerService} from "./services/doppelgangerService.js";
 
+export type ValidatorAbortController = {genesisInit: AbortController; validatorOps: AbortController};
+
 export type ValidatorOptions = {
   slashingProtection: ISlashingProtection;
   dbOps: IDatabaseApiOptions;
@@ -30,6 +32,7 @@ export type ValidatorOptions = {
   signers: Signer[];
   logger: ILogger;
   processShutdownCallback: ProcessShutdownCallback;
+  abortControllers: ValidatorAbortController;
   afterBlockDelaySlotFraction?: number;
   doppelgangerProtectionEnabled?: boolean;
   closed?: boolean;
@@ -65,7 +68,7 @@ export class Validator {
   constructor(opts: ValidatorOptions, readonly genesis: Genesis, metrics: Metrics | null = null) {
     const {dbOps, logger, slashingProtection, signers, valProposerConfig} = opts;
     const config = createIBeaconConfig(dbOps.config, genesis.genesisValidatorsRoot);
-    this.controller = new AbortController();
+    this.controller = opts.abortControllers.validatorOps;
     const clock = new Clock(config, logger, {genesisTime: Number(genesis.genesisTime)});
     const loggerVc = getLoggerVc(logger, clock);
 
@@ -157,21 +160,20 @@ export class Validator {
   }
 
   /** Waits for genesis and genesis time */
-  static async initializeFromBeaconNode(
-    opts: ValidatorOptions,
-    signal?: AbortSignal,
-    metrics?: Metrics | null
-  ): Promise<Validator> {
+  static async initializeFromBeaconNode(opts: ValidatorOptions, metrics?: Metrics | null): Promise<Validator> {
     const {config} = opts.dbOps;
     const {logger} = opts;
     const api =
       typeof opts.api === "string"
         ? // This new api instance can make do with default timeout as a faster timeout is
           // not necessary since this instance won't be used for validator duties
-          getClient({baseUrl: opts.api, getAbortSignal: () => signal}, {config, logger})
+          getClient(
+            {baseUrl: opts.api, getAbortSignal: () => opts.abortControllers.genesisInit.signal},
+            {config, logger}
+          )
         : opts.api;
 
-    const genesis = await waitForGenesis(api, opts.logger, signal);
+    const genesis = await waitForGenesis(api, opts.logger, opts.abortControllers.genesisInit.signal);
     logger.info("Genesis available");
 
     const {data: externalSpecJson} = await api.config.getSpec();


### PR DESCRIPTION
**Motivation**

See https://github.com/ChainSafe/lodestar/issues/3569 and # https://github.com/ChainSafe/lodestar/issues/4394 for bug report

**Description**

While running the validator client I noticed the following lines in the log:

```
Sep-06 11:51:38.076[]                 info: Genesis available
Sep-06 11:51:38.084[]                 info: Verified node and validator have same config
Sep-06 11:51:38.084[]                 info: Verified node and validator have same genesisValidatorRoot
Sep-06 11:51:38.133[]                 info: Discovered new validators count=3
(node:46338) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]. Use events.setMaxListeners() to increase limit
    at AbortSignal.[kNewListener] (node:internal/event_target:426:17)
    at AbortSignal.[kNewListener] (node:internal/abort_controller:173:24)
    at AbortSignal.addEventListener (node:internal/event_target:535:23)
    at file:///Users/dadepoaderemi/Documents/work/testing_remote_signer/lodestar/packages/utils/src/sleep.ts:26:24
    at new Promise (<anonymous>)
    at sleep (file:///Users/dadepoaderemi/Documents/work/testing_remote_signer/lodestar/packages/utils/src/sleep.ts:12:10)
    at Clock.runAtMostEvery (file:///Users/dadepoaderemi/Documents/work/testing_remote_signer/lodestar/packages/validator/src/util/clock.ts:101:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

This PR prevents this by setting the max event listener for the abort controller that trigger the log to infinity.

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

resolves #3569 
resolves #4394
