### PR TITLE
Bump level db to 8.0.0

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -43,11 +43,7 @@
     "@lodestar/utils": "^1.0.0",
     "@types/levelup": "^4.3.3",
     "it-all": "^1.0.2",
-    "level": "^7.0.0",
-    "levelup": "^5.0.1"
+    "level": "^8.0.0"
   },
-  "devDependencies": {
-    "@types/level": "^6.0.0",
-    "@types/leveldown": "^4.0.3"
-  }
+  "devDependencies": {}
 }

--- a/packages/db/src/controller/level.ts
+++ b/packages/db/src/controller/level.ts
@@ -75,7 +75,7 @@ export class LevelDbController implements IDatabaseController<Uint8Array, Uint8A
       this.metrics?.dbReadItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
       return (await this.db.get(key)) as Uint8Array | null;
     } catch (e) {
-      if ((e as NotFoundError).notFound) {
+      if ((e as LevelDbError).code === "LEVEL_NOT_FOUND") {
         return null;
       }
       throw e;
@@ -184,7 +184,4 @@ export class LevelDbController implements IDatabaseController<Uint8Array, Uint8A
 }
 
 /** From https://www.npmjs.com/package/level */
-type NotFoundError = {
-  notFound: true;
-  type: "NotFoundError";
-};
+type LevelDbError = {code: "LEVEL_NOT_FOUND"};

--- a/packages/db/src/controller/level.ts
+++ b/packages/db/src/controller/level.ts
@@ -100,18 +100,14 @@ export class LevelDbController implements IDatabaseController<Uint8Array, Uint8A
     this.metrics?.dbWriteReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
     this.metrics?.dbWriteItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, items.length);
 
-    const batch = this.db.batch();
-    for (const item of items) batch.put(item.key, item.value);
-    return batch.write();
+    return this.db.batch(items.map((item) => ({type: "put", key: item.key, value: item.value})));
   }
 
   batchDelete(keys: Uint8Array[], opts?: DbReqOpts): Promise<void> {
     this.metrics?.dbWriteReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
     this.metrics?.dbWriteItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, keys.length);
 
-    const batch = this.db.batch();
-    for (const key of keys) batch.del(key);
-    return batch.write();
+    return this.db.batch(keys.map((key) => ({type: "del", key: key})));
   }
 
   keysStream(opts: IFilterOptions<Uint8Array> = {}): AsyncIterable<Uint8Array> {

--- a/packages/db/src/controller/level.ts
+++ b/packages/db/src/controller/level.ts
@@ -1,6 +1,6 @@
-import {LevelUp} from "levelup";
-import level from "level";
-import all from "it-all";
+import {Level} from "level";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import type {ClassicLevel} from "classic-level";
 import {ILogger} from "@lodestar/utils";
 import {DbReqOpts, IDatabaseController, IDatabaseOptions, IFilterOptions, IKeyValue} from "./interface.js";
 import {ILevelDbControllerMetrics} from "./metrics.js";
@@ -10,8 +10,10 @@ enum Status {
   stopped = "stopped",
 }
 
+type LevelNodeJS = ClassicLevel<Uint8Array, Uint8Array>;
+
 export interface ILevelDBOptions extends IDatabaseOptions {
-  db?: LevelUp;
+  db?: Level<Uint8Array, Uint8Array>;
 }
 
 export type LevelDbControllerModules = {
@@ -26,7 +28,7 @@ const BUCKET_ID_UNKNOWN = "unknown";
  */
 export class LevelDbController implements IDatabaseController<Uint8Array, Uint8Array> {
   private status = Status.stopped;
-  private db: LevelUp;
+  private db: Level<Uint8Array, Uint8Array>;
 
   private readonly opts: ILevelDBOptions;
   private readonly logger: ILogger;
@@ -36,8 +38,7 @@ export class LevelDbController implements IDatabaseController<Uint8Array, Uint8A
     this.opts = opts;
     this.logger = logger;
     this.metrics = metrics ?? null;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-    this.db = opts.db || level(opts.name || "beaconchain", {keyEncoding: "binary", valueEncoding: "binary"});
+    this.db = opts.db || new Level(opts.name || "beaconchain", {keyEncoding: "binary", valueEncoding: "binary"});
   }
 
   async start(): Promise<void> {
@@ -81,128 +82,110 @@ export class LevelDbController implements IDatabaseController<Uint8Array, Uint8A
     }
   }
 
-  async put(key: Uint8Array, value: Uint8Array, opts?: DbReqOpts): Promise<void> {
+  put(key: Uint8Array, value: Uint8Array, opts?: DbReqOpts): Promise<void> {
     this.metrics?.dbWriteReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
     this.metrics?.dbWriteItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
 
-    await this.db.put(key, value);
+    return this.db.put(key, value);
   }
 
-  async delete(key: Uint8Array, opts?: DbReqOpts): Promise<void> {
+  delete(key: Uint8Array, opts?: DbReqOpts): Promise<void> {
     this.metrics?.dbWriteReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
     this.metrics?.dbWriteItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
 
-    await this.db.del(key);
+    return this.db.del(key);
   }
 
-  async batchPut(items: IKeyValue<Uint8Array, Uint8Array>[], opts?: DbReqOpts): Promise<void> {
+  batchPut(items: IKeyValue<Uint8Array, Uint8Array>[], opts?: DbReqOpts): Promise<void> {
     this.metrics?.dbWriteReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
     this.metrics?.dbWriteItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, items.length);
 
     const batch = this.db.batch();
     for (const item of items) batch.put(item.key, item.value);
-    await batch.write();
+    return batch.write();
   }
 
-  async batchDelete(keys: Uint8Array[], opts?: DbReqOpts): Promise<void> {
+  batchDelete(keys: Uint8Array[], opts?: DbReqOpts): Promise<void> {
     this.metrics?.dbWriteReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
     this.metrics?.dbWriteItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, keys.length);
 
     const batch = this.db.batch();
     for (const key of keys) batch.del(key);
-    await batch.write();
+    return batch.write();
   }
 
-  keysStream(opts?: IFilterOptions<Uint8Array>): AsyncGenerator<Uint8Array> {
-    return this.iterator({keys: true, values: false}, (key) => key, opts);
+  keysStream(opts: IFilterOptions<Uint8Array> = {}): AsyncIterable<Uint8Array> {
+    return this.metricsIterator(this.db.keys(opts), (key) => key, opts.bucketId ?? BUCKET_ID_UNKNOWN);
   }
 
-  valuesStream(opts?: IFilterOptions<Uint8Array>): AsyncGenerator<Uint8Array> {
-    return this.iterator({keys: false, values: true}, (_key, value) => value, opts);
+  valuesStream(opts: IFilterOptions<Uint8Array> = {}): AsyncIterable<Uint8Array> {
+    return this.metricsIterator(this.db.values(opts), (value) => value, opts.bucketId ?? BUCKET_ID_UNKNOWN);
   }
 
-  entriesStream(opts?: IFilterOptions<Uint8Array>): AsyncGenerator<IKeyValue<Uint8Array, Uint8Array>> {
-    return this.iterator({keys: true, values: true}, (key, value) => ({key, value}), opts);
+  entriesStream(opts: IFilterOptions<Uint8Array> = {}): AsyncIterable<IKeyValue<Uint8Array, Uint8Array>> {
+    return this.metricsIterator(
+      this.db.iterator(opts),
+      (entry) => ({key: entry[0], value: entry[1]}),
+      opts.bucketId ?? BUCKET_ID_UNKNOWN
+    );
   }
 
-  async keys(opts?: IFilterOptions<Uint8Array>): Promise<Uint8Array[]> {
-    return all(this.keysStream(opts));
+  keys(opts: IFilterOptions<Uint8Array> = {}): Promise<Uint8Array[]> {
+    return this.metricsAll(this.db.keys(opts).all(), opts.bucketId ?? BUCKET_ID_UNKNOWN);
   }
 
-  async values(opts?: IFilterOptions<Uint8Array>): Promise<Uint8Array[]> {
-    return all(this.valuesStream(opts));
+  values(opts: IFilterOptions<Uint8Array> = {}): Promise<Uint8Array[]> {
+    return this.metricsAll(this.db.values(opts).all(), opts.bucketId ?? BUCKET_ID_UNKNOWN);
   }
 
-  async entries(opts?: IFilterOptions<Uint8Array>): Promise<IKeyValue<Uint8Array, Uint8Array>[]> {
-    return all(this.entriesStream(opts));
+  async entries(opts: IFilterOptions<Uint8Array> = {}): Promise<IKeyValue<Uint8Array, Uint8Array>[]> {
+    const entries = await this.metricsAll(this.db.iterator(opts).all(), opts.bucketId ?? BUCKET_ID_UNKNOWN);
+    return entries.map((entry) => ({key: entry[0], value: entry[1]}));
   }
 
   /**
-   * Turn an abstract-leveldown iterator into an AsyncGenerator.
-   * Replaces https://github.com/Level/iterator-stream
-   *
-   * How to use:
-   * - Entries = { keys: true, values: true }
-   * - Keys =    { keys: true, values: false }
-   * - Values =  { keys: false, values: true }
+   * Get the approximate number of bytes of file system space used by the range [start..end).
+   * The result might not include recently written data.
    */
-  private async *iterator<T>(
-    keysOpts: StreamKeysOpts,
-    getValue: (key: Uint8Array, value: Uint8Array) => T,
-    opts?: IFilterOptions<Uint8Array>
-  ): AsyncGenerator<T> {
-    this.metrics?.dbWriteReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+  approximateSize(start: Uint8Array, end: Uint8Array): Promise<number> {
+    return (this.db as LevelNodeJS).approximateSize(start, end);
+  }
+
+  /**
+   * Manually trigger a database compaction in the range [start..end].
+   */
+  compactRange(start: Uint8Array, end: Uint8Array): Promise<void> {
+    return (this.db as LevelNodeJS).compactRange(start, end);
+  }
+
+  /** Capture metrics for db.iterator, db.keys, db.values .all() calls */
+  private async metricsAll<T>(promise: Promise<T[]>, bucket: string): Promise<T[]> {
+    this.metrics?.dbWriteReq.inc({bucket}, 1);
+    const items = await promise;
+    this.metrics?.dbWriteItems.inc({bucket}, items.length);
+    return items;
+  }
+
+  /** Capture metrics for db.iterator, db.keys, db.values AsyncIterable calls */
+  private async *metricsIterator<T, K>(
+    iterator: AsyncIterable<T>,
+    getValue: (item: T) => K,
+    bucket: string
+  ): AsyncIterable<K> {
+    this.metrics?.dbWriteReq.inc({bucket}, 1);
+
     let itemsRead = 0;
 
-    // Entries = { keys: true, values: true }
-    // Keys =    { keys: true, values: false }
-    // Values =  { keys: false, values: true }
+    for await (const item of iterator) {
+      // Count metrics after done condition
+      itemsRead++;
 
-    const iterator = this.db.iterator({
-      ...opts,
-      ...keysOpts,
-      // TODO: Test if this is necessary. It's in https://github.com/Level/iterator-stream but may be stale
-      limit: opts?.limit ?? -1,
-    });
-
-    try {
-      while (true) {
-        const [key, value] = await new Promise<[Uint8Array, Uint8Array]>((resolve, reject) => {
-          iterator.next((err, key: Uint8Array, value: Uint8Array) => {
-            if (err) reject(err);
-            else resolve([key, value]);
-          });
-        });
-
-        // Source code justification of why this condition implies the stream is done
-        // https://github.com/Level/level-js/blob/e2253839a62fa969de50e9114279763228959d40/iterator.js#L123
-        if (key === undefined && value === undefined) {
-          return; // Done
-        }
-
-        // Count metrics after done condition
-        itemsRead++;
-
-        yield getValue(key, value);
-      }
-    } finally {
-      this.metrics?.dbWriteItems.inc(itemsRead);
-
-      // TODO: Should we await here?
-      await new Promise<void>((resolve, reject) => {
-        iterator.end((err) => {
-          if (err) reject(err);
-          else resolve();
-        });
-      });
+      yield getValue(item);
     }
+
+    this.metrics?.dbWriteItems.inc({bucket}, itemsRead);
   }
 }
-
-type StreamKeysOpts = {
-  keys: boolean;
-  values: boolean;
-};
 
 /** From https://www.npmjs.com/package/level */
 type NotFoundError = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2471,14 +2471,6 @@
   dependencies:
     "@types/ms" "*"
 
-"@types/encoding-down@*":
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/@types/encoding-down/-/encoding-down-5.0.0.tgz"
-  integrity sha512-G0MlS/+/U2RIQLcSEhhAcoMrXw3hXUCFSKbhbeEljoKMra2kq+NPX6tfOveSWQLX2hJXBo+YrvKgAGe+tFL1Aw==
-  dependencies:
-    "@types/abstract-leveldown" "*"
-    "@types/level-codec" "*"
-
 "@types/eslint-scope@^3.7.3":
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.4.tgz#37fc1223f0786c39627068a12e94d6e6fc61de16"
@@ -2582,45 +2574,15 @@
   dependencies:
     "@types/node" "*"
 
-"@types/level-codec@*":
-  version "9.0.0"
-  resolved "https://registry.npmjs.org/@types/level-codec/-/level-codec-9.0.0.tgz"
-  integrity sha512-SWYkVJylo1dqblkhrr7UtmsQh4wdZA9bV1y3QJSywMPSqGfW0p1w37N1EayZtKbg1dGReIIQEEOtxk4wZvGrWQ==
-
 "@types/level-errors@*":
   version "3.0.0"
   resolved "https://registry.npmjs.org/@types/level-errors/-/level-errors-3.0.0.tgz"
   integrity sha512-/lMtoq/Cf/2DVOm6zE6ORyOM+3ZVm/BvzEZVxUhf6bgh8ZHglXlBqxbxSlJeVp8FCbD3IVvk/VbsaNmDjrQvqQ==
 
-"@types/level@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/@types/level/-/level-6.0.0.tgz"
-  integrity sha512-NjaUpukKfCvnV4Wk0jUaodFi2/66HxgpYghc2aV8iP+zk2NMt/9ps1eVlifqOU/+eLzMlDIY69NWkbPaAstukQ==
-  dependencies:
-    "@types/abstract-leveldown" "*"
-    "@types/encoding-down" "*"
-    "@types/levelup" "*"
-
 "@types/leveldown@^4.0.2":
   version "4.0.2"
   resolved "https://registry.npmjs.org/@types/leveldown/-/leveldown-4.0.2.tgz"
   integrity sha512-VW6QbUnPb5yLbUBcXEh93lFNphyxkBul7Ae41OCgROd76WfLM3qzAbuzErx1LtsTqwcNlbavTr9rWXHCiGVF8A==
-  dependencies:
-    "@types/abstract-leveldown" "*"
-    "@types/node" "*"
-
-"@types/leveldown@^4.0.3":
-  version "4.0.3"
-  resolved "https://registry.npmjs.org/@types/leveldown/-/leveldown-4.0.3.tgz"
-  integrity sha512-fzIXOuUCSZQKkRadWhURwu6mMYbfqi/nRDA+yBwz8kj7AK/L7L//u6A0MqSv0gsilzo7N/5+FlZOx8G6m03EVQ==
-  dependencies:
-    "@types/abstract-leveldown" "*"
-    "@types/node" "*"
-
-"@types/levelup@*":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@types/levelup/-/levelup-4.3.0.tgz"
-  integrity sha512-h82BoajhjU/zwLoM4BUBX/SCodCFi1ae/ZlFOYh5Z4GbHeaXj9H709fF1LYl/StrK8KSwnJOeMRPo9lnC6sz4w==
   dependencies:
     "@types/abstract-leveldown" "*"
     "@types/node" "*"
@@ -3141,6 +3103,19 @@ abortable-iterator@^3.0.0:
   integrity sha512-7KqcPPnMhfot4GrEjK51zesS4Ye/lUCHBgYt3oRxIlU24HO3mVxBwEo9niNyfHqoWKqWLuZTc3zErNomdHA+ag==
   dependencies:
     get-iterator "^1.0.2"
+
+abstract-level@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/abstract-level/-/abstract-level-1.0.3.tgz#78a67d3d84da55ee15201486ab44c09560070741"
+  integrity sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==
+  dependencies:
+    buffer "^6.0.3"
+    catering "^2.1.0"
+    is-buffer "^2.0.5"
+    level-supports "^4.0.0"
+    level-transcoder "^1.0.1"
+    module-error "^1.0.1"
+    queue-microtask "^1.2.3"
 
 abstract-leveldown@^7.0.0:
   version "7.0.0"
@@ -3801,6 +3776,16 @@ brorand@^1.0.1, brorand@^1.1.0:
   resolved "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
+browser-level@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/browser-level/-/browser-level-1.0.1.tgz#36e8c3183d0fe1c405239792faaab5f315871011"
+  integrity sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==
+  dependencies:
+    abstract-level "^1.0.2"
+    catering "^2.1.1"
+    module-error "^1.0.2"
+    run-parallel-limit "^1.1.0"
+
 browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz"
@@ -4170,6 +4155,11 @@ catering@^2.0.0:
   resolved "https://registry.npmjs.org/catering/-/catering-2.0.0.tgz"
   integrity sha512-aD/WmxhGwUGsVPrj8C80vH7C7GphJilYVSdudoV4u16XdrLF7CVyfBmENsc4tLTVsJJzCRid8GbwJ7mcPLee6Q==
 
+catering@^2.1.0, catering@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/catering/-/catering-2.1.1.tgz#66acba06ed5ee28d5286133982a927de9a04b510"
+  integrity sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==
+
 chai-as-promised@^7.1.1:
   version "7.1.1"
   resolved "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz"
@@ -4286,6 +4276,17 @@ class-is@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz"
   integrity sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==
+
+classic-level@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/classic-level/-/classic-level-1.2.0.tgz#2d52bdec8e7a27f534e67fdeb890abef3e643c27"
+  integrity sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==
+  dependencies:
+    abstract-level "^1.0.2"
+    catering "^2.1.0"
+    module-error "^1.0.1"
+    napi-macros "~2.0.0"
+    node-gyp-build "^4.3.0"
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -8164,6 +8165,19 @@ level-supports@^2.0.0:
   resolved "https://registry.npmjs.org/level-supports/-/level-supports-2.0.0.tgz"
   integrity sha512-8UJgzo1pvWP1wq80ZlkL19fPeK7tlyy0sBY90+2pj0x/kvzHCoLDWyuFJJMrsTn33oc7hbMkS3SkjCxMRPHWaw==
 
+level-supports@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/level-supports/-/level-supports-4.0.1.tgz#431546f9d81f10ff0fea0e74533a0e875c08c66a"
+  integrity sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==
+
+level-transcoder@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/level-transcoder/-/level-transcoder-1.0.1.tgz#f8cef5990c4f1283d4c86d949e73631b0bc8ba9c"
+  integrity sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==
+  dependencies:
+    buffer "^6.0.3"
+    module-error "^1.0.1"
+
 level@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/level/-/level-7.0.0.tgz"
@@ -8172,6 +8186,14 @@ level@^7.0.0:
     level-js "^6.0.0"
     level-packager "^6.0.0"
     leveldown "^6.0.0"
+
+level@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/level/-/level-8.0.0.tgz#41b4c515dabe28212a3e881b61c161ffead14394"
+  integrity sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==
+  dependencies:
+    browser-level "^1.0.1"
+    classic-level "^1.2.0"
 
 leveldown@^6.0.0:
   version "6.0.0"
@@ -8186,18 +8208,6 @@ levelup@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/levelup/-/levelup-5.0.0.tgz"
   integrity sha512-P4IKS4J17b6dzm8iI8Irv5gvOlrqJv04Lrpq1rAgZvjR2IsVSjbXQQo1LoK/PJuouxepLE8CTIiKGmHQYZnneA==
-  dependencies:
-    catering "^2.0.0"
-    deferred-leveldown "^6.0.0"
-    level-errors "^3.0.0"
-    level-iterator-stream "^5.0.0"
-    level-supports "^2.0.0"
-    queue-microtask "^1.2.3"
-
-levelup@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/levelup/-/levelup-5.0.1.tgz"
-  integrity sha512-MJvQgBRQmB+E5+d6Qbxqm05N4U9NzOxGNhXx0rR8maRBwmVuVV+m4IV3N4HzZJW8JwiJ0jj92RZaytcD+Hr1CA==
   dependencies:
     catering "^2.0.0"
     deferred-leveldown "^6.0.0"
@@ -9193,6 +9203,11 @@ modify-values@^1.0.0:
   resolved "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+module-error@^1.0.1, module-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/module-error/-/module-error-1.0.2.tgz#8d1a48897ca883f47a45816d4fb3e3c6ba404d86"
+  integrity sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==
+
 moment@^2.11.2:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
@@ -9450,6 +9465,11 @@ node-gyp-build@^4.2.0, node-gyp-build@~4.2.1:
   version "4.2.3"
   resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz"
   integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
+
+node-gyp-build@^4.3.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.5.0.tgz#7a64eefa0b21112f89f58379da128ac177f20e40"
+  integrity sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==
 
 node-gyp@^5.0.2:
   version "5.1.1"
@@ -10752,7 +10772,7 @@ querystring@0.2.0:
   resolved "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-queue-microtask@^1.1.2, queue-microtask@^1.2.3:
+queue-microtask@^1.1.2, queue-microtask@^1.2.2, queue-microtask@^1.2.3:
   version "1.2.3"
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
@@ -11254,6 +11274,13 @@ run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
+
+run-parallel-limit@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz#be80e936f5768623a38a963262d6bef8ff11e7ba"
+  integrity sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==
+  dependencies:
+    queue-microtask "^1.2.2"
 
 run-parallel@^1.1.9:
   version "1.1.10"


### PR DESCRIPTION
**Motivation**

- Testing https://github.com/ChainSafe/lodestar/pull/4508 discovered level has a new version 8.0.0 which includes types, a proper iterator and other goodies.

**Description**

- Bump level to 8.0.0
- Drop custom wrapper code for the iterator
- Use existing .keys() and .values() methods where possible

Functionality should be equivalent, only less wanky code to mantain