### PR TITLE
Update default.env to current network values

### DIFF
--- a/default.env
+++ b/default.env
@@ -1,5 +1,5 @@
 # To specify a specific network (defaults to mainnet) set this value.
-# Allowed values are: mainnet, gnosis, goerli, ropsten and sepolia. (Source for currently supported networks: /lodestar/packages/cli/src/networks/index.ts#L19)
+# Allowed values are: mainnet, gnosis, goerli, ropsten and sepolia. Source for currently supported networks: https://github.com/ChainSafe/lodestar/blob/unstable/packages/cli/src/networks/index.ts#L19
 LODESTAR_NETWORK=mainnet
 
 # Set a custom admin password to prevent having to signup.

--- a/default.env
+++ b/default.env
@@ -1,5 +1,5 @@
 # To specify a specific network (defaults to mainnet) set this value.
-# Allowed values are: mainnet and pyrmont (others may work, but are deprecated)
+# Allowed values are: mainnet, goerli and sepolia (others may work, but are deprecated)
 LODESTAR_NETWORK=mainnet
 
 # Set a custom admin password to prevent having to signup.

--- a/default.env
+++ b/default.env
@@ -1,5 +1,5 @@
 # To specify a specific network (defaults to mainnet) set this value.
-# Allowed values are: mainnet, goerli and sepolia (others may work, but are deprecated)
+# Allowed values are: mainnet, gnosis, goerli, ropsten and sepolia. (Source for currently supported networks: /lodestar/packages/cli/src/networks/index.ts#L19)
 LODESTAR_NETWORK=mainnet
 
 # Set a custom admin password to prevent having to signup.


### PR DESCRIPTION
**Motivation**

This comment is outdated.

**Description**

This PR changes the comment text to ensure the user understands that `mainnet, `goerli` and `sepolia` are the currently supported networks. Other networks have been deprecated.