### PR TITLE
GC non pruned states

### DIFF
--- a/packages/beacon-node/src/chain/archiver/archiveStates.ts
+++ b/packages/beacon-node/src/chain/archiver/archiveStates.ts
@@ -1,5 +1,7 @@
 import {ILogger} from "@lodestar/utils";
-import {computeEpochAtSlot} from "@lodestar/state-transition";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {Slot, Epoch} from "@lodestar/types";
+import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {CheckpointWithHex} from "@lodestar/fork-choice";
 import {IBeaconDb} from "../../db/index.js";
 import {CheckpointStateCache} from "../stateCache/index.js";
@@ -45,14 +47,20 @@ export class StatesArchiver {
     if (finalized.epoch - lastStoredEpoch > PERSIST_TEMP_STATE_EVERY_EPOCHS) {
       await this.archiveState(finalized);
 
-      const storedEpochs = await this.db.stateArchive.keys({
-        lt: finalized.epoch,
-        // Only check the current and previous intervals
-        gte: Math.max(0, (Math.floor(finalized.epoch / PERSIST_STATE_EVERY_EPOCHS) - 1) * PERSIST_STATE_EVERY_EPOCHS),
+      // Only check the current and previous intervals
+      const minEpoch = Math.max(
+        0,
+        (Math.floor(finalized.epoch / PERSIST_STATE_EVERY_EPOCHS) - 1) * PERSIST_STATE_EVERY_EPOCHS
+      );
+
+      const storedStateSlots = await this.db.stateArchive.keys({
+        lt: computeStartSlotAtEpoch(finalized.epoch),
+        gte: computeStartSlotAtEpoch(minEpoch),
       });
-      const statesToDelete = computeEpochsToDelete(storedEpochs, PERSIST_STATE_EVERY_EPOCHS);
-      if (statesToDelete.length > 0) {
-        await this.db.stateArchive.batchDelete(statesToDelete);
+
+      const statesSlotsToDelete = computeStateSlotsToDelete(storedStateSlots, PERSIST_STATE_EVERY_EPOCHS);
+      if (statesSlotsToDelete.length > 0) {
+        await this.db.stateArchive.batchDelete(statesSlotsToDelete);
       }
     }
   }
@@ -73,19 +81,39 @@ export class StatesArchiver {
 }
 
 /**
+ * Garbage collection run once at process start to delete any extra states not pruned from previous runs
+ */
+export async function gcFinalizedStates(db: IBeaconDb, logger: ILogger, finalizedStateSlot: Slot): Promise<void> {
+  const storedStateSlots = await db.stateArchive.keys({lt: finalizedStateSlot});
+
+  const statesSlotsToDelete = computeStateSlotsToDelete(storedStateSlots, PERSIST_STATE_EVERY_EPOCHS);
+  if (statesSlotsToDelete.length > 0) {
+    await db.stateArchive.batchDelete(statesSlotsToDelete);
+  }
+
+  if (statesSlotsToDelete.length > 0) {
+    logger.info(`Pruned ${statesSlotsToDelete.length} finalized states`, {slots: statesSlotsToDelete.join(",")});
+  } else {
+    logger.verbose("Did not prune any existing finalized states");
+  }
+}
+
+/**
  * Keeps first epoch per interval of persistEveryEpochs, deletes the rest
  */
-export function computeEpochsToDelete(storedEpochs: number[], persistEveryEpochs: number): number[] {
-  const epochBuckets = new Set<number>();
-  const toDelete = new Set<number>();
-  for (const epoch of storedEpochs) {
-    const epochBucket = epoch - (epoch % persistEveryEpochs);
-    if (epochBuckets.has(epochBucket)) {
-      toDelete.add(epoch);
+export function computeStateSlotsToDelete(storedStateSlots: Slot[], persistEveryEpochs: Epoch): Slot[] {
+  const persistEverySlots = persistEveryEpochs * SLOTS_PER_EPOCH;
+  const intervalsWithStates = new Set<number>();
+  const stateSlotsToDelete = new Set<number>();
+
+  for (const slot of storedStateSlots) {
+    const interval = Math.floor(slot / persistEverySlots);
+    if (intervalsWithStates.has(interval)) {
+      stateSlotsToDelete.add(slot);
     } else {
-      epochBuckets.add(epochBucket);
+      intervalsWithStates.add(interval);
     }
   }
 
-  return Array.from(toDelete.values());
+  return Array.from(stateSlotsToDelete.values());
 }

--- a/packages/beacon-node/test/unit/chain/archive/stateArchiver.test.ts
+++ b/packages/beacon-node/test/unit/chain/archive/stateArchiver.test.ts
@@ -1,42 +1,46 @@
 import {expect} from "chai";
-import {computeEpochsToDelete} from "../../../../src/chain/archiver/archiveStates.js";
+import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
+import {computeStateSlotsToDelete} from "../../../../src/chain/archiver/archiveStates.js";
 
 describe("state archiver task", () => {
-  describe("computeEpochsToDelete", () => {
+  describe("computeStateSlotsToDelete", () => {
     const testCases: {
       id: string;
       storedEpochs: number[];
-      persistEveryEpochs?: number;
-      toDelete: number[];
+      persistEveryEpochs: number;
+      epochsToDelete: number[];
     }[] = [
       {
         id: "Empty",
         storedEpochs: [],
-        toDelete: [],
+        persistEveryEpochs: 8,
+        epochsToDelete: [],
       },
       {
         id: "Equally spaced, delete x%8 != 0",
         storedEpochs: [0, 2, 4, 6, 8, 10, 12, 14, 16],
         persistEveryEpochs: 8,
-        toDelete: [2, 4, 6, 10, 12, 14],
+        epochsToDelete: [2, 4, 6, 10, 12, 14],
       },
       {
         id: "Equally spaced with offset",
         storedEpochs: [0, 3, 5, 7, 9, 11, 13, 15, 17],
         persistEveryEpochs: 8,
-        toDelete: [3, 5, 7, 11, 13, 15],
+        epochsToDelete: [3, 5, 7, 11, 13, 15],
       },
       {
         id: "Edge case with offset that causes a very large gap between epochs",
         storedEpochs: [7, 8, 23, 24],
         persistEveryEpochs: 8,
-        toDelete: [],
+        epochsToDelete: [],
       },
     ];
 
-    for (const {id, storedEpochs, persistEveryEpochs, toDelete} of testCases) {
+    for (const {id, storedEpochs, persistEveryEpochs, epochsToDelete} of testCases) {
       it(id, () => {
-        expect(computeEpochsToDelete(storedEpochs, persistEveryEpochs ?? 1024)).to.deep.equal(toDelete);
+        const storedStateSlots = storedEpochs.map((epoch) => computeStartSlotAtEpoch(epoch));
+        const stateSlotsToDelete = epochsToDelete.map((epoch) => computeStartSlotAtEpoch(epoch));
+        expect(computeStateSlotsToDelete(storedStateSlots, persistEveryEpochs)).to.deep.equal(stateSlotsToDelete);
       });
     }
   });

--- a/packages/db/src/abstractRepository.ts
+++ b/packages/db/src/abstractRepository.ts
@@ -8,6 +8,11 @@ import {getBucketNameByValue} from "./util.js";
 
 export type Id = Uint8Array | string | number | bigint;
 
+export type RangeOpts<I> = {
+  from?: I;
+  to?: I;
+};
+
 /**
  * Repository is a high level kv storage
  * managing a Uint8Array to Uint8Array kv database
@@ -25,6 +30,9 @@ export abstract class Repository<I extends Id, T> {
   private readonly bucketId: string;
   private readonly dbReqOpts: DbReqOpts;
 
+  private readonly minKey: Uint8Array;
+  private readonly maxKey: Uint8Array;
+
   protected type: Type<T>;
 
   protected constructor(config: IChainForkConfig, db: Db, bucket: Bucket, type: Type<T>) {
@@ -34,6 +42,8 @@ export abstract class Repository<I extends Id, T> {
     this.bucketId = getBucketNameByValue(bucket);
     this.dbReqOpts = {bucketId: this.bucketId};
     this.type = type;
+    this.minKey = _encodeKey(bucket, Buffer.alloc(0));
+    this.maxKey = _encodeKey(bucket + 1, Buffer.alloc(0));
   }
 
   encodeValue(value: T): Uint8Array {
@@ -236,6 +246,23 @@ export abstract class Repository<I extends Id, T> {
       return null;
     }
     return entries[0];
+  }
+
+  compactRange(range?: RangeOpts<I>): Promise<void> {
+    const {from, to} = this.serializeRange(range);
+    return this.db.compactRange(from, to);
+  }
+
+  approximateSize(range?: RangeOpts<I>): Promise<number> {
+    const {from, to} = this.serializeRange(range);
+    return this.db.approximateSize(from, to);
+  }
+
+  protected serializeRange(range: RangeOpts<I> | undefined): {from: Uint8Array; to: Uint8Array} {
+    return {
+      from: range?.from !== undefined ? this.encodeKey(range.from) : this.minKey,
+      to: range?.to !== undefined ? this.encodeKey(range.to) : this.maxKey,
+    };
   }
 
   /**

--- a/packages/db/src/controller/interface.ts
+++ b/packages/db/src/controller/interface.ts
@@ -58,4 +58,7 @@ export interface IDatabaseController<K, V> {
 
   entriesStream(opts?: IFilterOptions<K>): AsyncIterable<IKeyValue<K, V>>;
   entries(opts?: IFilterOptions<K>): Promise<IKeyValue<K, V>[]>;
+
+  approximateSize(start: Uint8Array, end: Uint8Array): Promise<number>;
+  compactRange(start: Uint8Array, end: Uint8Array): Promise<void>;
 }


### PR DESCRIPTION
**Motivation**

- PR https://github.com/ChainSafe/lodestar/pull/4508 fixes an issue where Lodestar stores more states than necessary. 

For Prater/Goerli nodes running for a few months that extra space accounted for 50GB / 120GB of db data pre-pruning.

I would be nice to automatically prune the existing states since it's very cheap and reliable to detect the non-pruned states.

**Description**

Once on start-up, read the archive_states bucket keys to check if there are states that should be pruned. If there are:
- Remove them all in batches
- Trigger compactRange on archive_states bucket. If this is not done the total db size does not decrease. See for details on some experiments https://github.com/ChainSafe/lodestar/issues/4515

_marking as draft as test of this branch has caused issues in nodes, still unknown_

```
Sep-07 14:02:22.367[eth1]            error: Error updating eth1 chain cache  Database is not open
Error: Database is not open
    at ClassicLevel.values (/usr/src/lodestar/node_modules/abstract-level/abstract-level.js:726:13)
    at LevelDbController.values (file:///usr/src/lodestar/packages/db/src/controller/level.ts:134:36)
    at DepositEventRepository.values (file:///usr/src/lodestar/packages/db/src/abstractRepository.ts:161:32)
    at DepositEventRepository.lastValue (file:///usr/src/lodestar/packages/db/src/abstractRepository.ts:226:31)
    at Eth1DepositsCache.add (file:///usr/src/lodestar/packages/beacon-node/src/eth1/eth1DepositsCache.ts:44:48)
    at Eth1DepositDataTracker.updateDepositCache (file:///usr/src/lodestar/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts:211:30)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at Eth1DepositDataTracker.update (file:///usr/src/lodestar/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts:191:33)
    at Eth1DepositDataTracker.runAutoUpdate (file:///usr/src/lodestar/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts:154:29)
```

From https://github.com/ChainSafe/lodestar/pull/4508#issuecomment-1239311911