### PR TITLE
Update default file options to save debug level log

### DIFF
--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -76,7 +76,10 @@ export const logOptions: ICliCommandOptions<ILogArgs> = {
   },
 
   logFileDailyRotate: {
-    description: `Daily rotate log files, set to an integer to limit the file count, else defaults to ${defaultLogMaxFiles}`,
+    description:
+      "Daily rotate log files, set to an integer to limit the file count, set to 0(zero) to disable rotation",
+    defaultDescription: defaultLogMaxFiles.toString(),
+    default: defaultLogMaxFiles,
     type: "number",
   },
 
@@ -139,7 +142,8 @@ export const beaconPathsOptions: ICliCommandOptions<IBeaconPaths> = {
   },
 
   logFile: {
-    description: "Path to output all logs to a persistent log file",
+    description: "Path to output all logs to a persistent log file, use 'none' to disable",
+    defaultDescription: defaultBeaconPaths.logFile,
     type: "string",
   },
 };

--- a/packages/cli/src/cmds/beacon/paths.ts
+++ b/packages/cli/src/cmds/beacon/paths.ts
@@ -19,7 +19,8 @@ export interface IBeaconPaths {
  *     ├── beacon.config.json
  *     ├── peer-id.json
  *     ├── enr
- *     └── chain-db
+ *     ├── chain-db
+ *     └── beacon.log
  * ```
  */
 // Using Pick<IGlobalArgs, "dataDir"> make changes in IGlobalArgs throw a type error here
@@ -32,10 +33,10 @@ export function getBeaconPaths(
 
   const dataDir = globalPaths.dataDir;
   const beaconDir = dataDir;
-  const dbDir = args.dbDir || path.join(beaconDir, "chain-db");
-  const persistInvalidSszObjectsDir = args.persistInvalidSszObjectsDir || path.join(beaconDir, "invalidSszObjects");
-  const peerStoreDir = args.peerStoreDir || path.join(beaconDir, "peerstore");
-  const logFile = args.logFile;
+  const dbDir = args.dbDir ?? path.join(beaconDir, "chain-db");
+  const persistInvalidSszObjectsDir = args.persistInvalidSszObjectsDir ?? path.join(beaconDir, "invalidSszObjects");
+  const peerStoreDir = args.peerStoreDir ?? path.join(beaconDir, "peerstore");
+  const logFile = args.logFile?.trim() !== "none" ? args.logFile ?? path.join(dataDir, "beacon.log") : undefined;
 
   return {
     ...globalPaths,

--- a/packages/cli/src/cmds/lightclient/handler.ts
+++ b/packages/cli/src/cmds/lightclient/handler.ts
@@ -6,12 +6,15 @@ import {IGlobalArgs} from "../../options/index.js";
 import {getCliLogger} from "../../util/index.js";
 import {getBeaconPaths} from "../beacon/paths.js";
 import {ILightClientArgs} from "./options.js";
+import {getLightclientPaths} from "./paths.js";
 
 export async function lightclientHandler(args: ILightClientArgs & IGlobalArgs): Promise<void> {
   const {config, network} = getBeaconConfigFromArgs(args);
 
   const beaconPaths = getBeaconPaths(args, network);
-  const logger = getCliLogger(args, beaconPaths, config);
+  const lightclientPaths = getLightclientPaths(args, network);
+
+  const logger = getCliLogger(args, {...beaconPaths, logFile: lightclientPaths.logFile}, config);
   const {beaconApiUrl, checkpointRoot} = args;
   const api = getClient({baseUrl: beaconApiUrl}, {config});
   const {data: genesisData} = await api.beacon.getGenesis();

--- a/packages/cli/src/cmds/lightclient/paths.ts
+++ b/packages/cli/src/cmds/lightclient/paths.ts
@@ -1,0 +1,27 @@
+import path from "node:path";
+import {IGlobalArgs} from "../../options/index.js";
+import {getGlobalPaths} from "../../paths/global.js";
+
+export type ILightclientPaths = {
+  logFile?: string;
+};
+
+export function getLightclientPaths(
+  args: Pick<IGlobalArgs, "dataDir"> & ILightclientPaths,
+  network: string
+): ILightclientPaths {
+  // Compute global paths first
+  const globalPaths = getGlobalPaths(args, network);
+
+  const dataDir = globalPaths.dataDir;
+  const logFile = args.logFile?.trim() !== "none" ? args.logFile ?? path.join(dataDir, "lightclient.log") : undefined;
+
+  return {
+    logFile,
+  };
+}
+
+/**
+ * Constructs representations of the path structure to show in command's description
+ */
+export const defaultLightclientPaths = getLightclientPaths({dataDir: "$dataDir"}, "$network");

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -29,7 +29,7 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
   const beaconPaths = getBeaconPaths(args, network);
   const validatorPaths = getValidatorPaths(args, network);
 
-  const logger = getCliLogger(args, beaconPaths, config);
+  const logger = getCliLogger(args, {...beaconPaths, logFile: validatorPaths.logFile}, config);
 
   const {version, commit} = getVersionData();
   logger.info("Lodestar", {network, version, commit});

--- a/packages/cli/src/cmds/validator/paths.ts
+++ b/packages/cli/src/cmds/validator/paths.ts
@@ -4,6 +4,7 @@ import {IGlobalPaths, getGlobalPaths} from "../../paths/global.js";
 
 export type IValidatorPaths = {
   validatorsDbDir: string;
+  logFile?: string;
 };
 
 export type AccountPaths = {
@@ -29,10 +30,13 @@ export function getValidatorPaths(
   const globalPaths = getGlobalPaths(args, network);
 
   const dataDir = globalPaths.dataDir;
-  const validatorsDbDir = args.validatorsDbDir || path.join(dataDir, "validator-db");
+  const validatorsDbDir = args.validatorsDbDir ?? path.join(dataDir, "validator-db");
+  const logFile = args.logFile?.trim() !== "none" ? args.logFile ?? path.join(dataDir, "validator.log") : undefined;
+
   return {
     ...globalPaths,
     validatorsDbDir,
+    logFile,
   };
 }
 

--- a/packages/cli/src/cmds/validator/slashingProtection/export.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/export.ts
@@ -8,6 +8,7 @@ import {getBeaconPaths} from "../../beacon/paths.js";
 import {getValidatorPaths} from "../paths.js";
 import {getGenesisValidatorsRoot, getSlashingProtection} from "./utils.js";
 import {ISlashingProtectionArgs} from "./options.js";
+import {getSlashingProtectionPaths} from "./paths.js";
 
 /* eslint-disable no-console */
 
@@ -40,8 +41,10 @@ export const exportCmd: ICliCommand<
 
   handler: async (args) => {
     const {config, network} = getBeaconConfigFromArgs(args);
+
     const beaconPaths = getBeaconPaths(args, network);
-    const logger = getCliLogger(args, beaconPaths, config);
+    const {logFile} = getSlashingProtectionPaths(args, network, "export-");
+    const logger = getCliLogger(args, {...beaconPaths, logFile}, config);
 
     const {validatorsDbDir: dbPath} = getValidatorPaths(args, network);
 

--- a/packages/cli/src/cmds/validator/slashingProtection/import.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/import.ts
@@ -9,6 +9,7 @@ import {getBeaconPaths} from "../../beacon/paths.js";
 import {getValidatorPaths} from "../paths.js";
 import {getGenesisValidatorsRoot, getSlashingProtection} from "./utils.js";
 import {ISlashingProtectionArgs} from "./options.js";
+import {getSlashingProtectionPaths} from "./paths.js";
 
 /* eslint-disable no-console */
 
@@ -42,7 +43,8 @@ export const importCmd: ICliCommand<
   handler: async (args) => {
     const {config, network} = getBeaconConfigFromArgs(args);
     const beaconPaths = getBeaconPaths(args, network);
-    const logger = getCliLogger(args, beaconPaths, config);
+    const {logFile} = getSlashingProtectionPaths(args, network, "export-");
+    const logger = getCliLogger(args, {...beaconPaths, logFile}, config);
 
     const {validatorsDbDir: dbPath} = getValidatorPaths(args, network);
 

--- a/packages/cli/src/cmds/validator/slashingProtection/paths.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/paths.ts
@@ -1,0 +1,35 @@
+import path from "node:path";
+import {IGlobalArgs} from "../../../options/index.js";
+import {getGlobalPaths} from "../../../paths/global.js";
+
+export type ISlashingProtectionPaths = {
+  logFile?: string;
+};
+
+export function getSlashingProtectionPaths(
+  args: Pick<IGlobalArgs, "dataDir"> & ISlashingProtectionPaths,
+  network: string,
+  defaultFilePrefix = ""
+): ISlashingProtectionPaths {
+  // Compute global paths first
+  const globalPaths = getGlobalPaths(args, network);
+
+  const dataDir = globalPaths.dataDir;
+  const logFile =
+    args.logFile?.trim() !== "none"
+      ? args.logFile ?? path.join(dataDir, `${defaultFilePrefix}slashing-protection.log`)
+      : undefined;
+
+  return {
+    logFile,
+  };
+}
+
+/**
+ * Constructs representations of the path structure to show in command's description
+ */
+export const defaultSlashingProtectionPaths = getSlashingProtectionPaths(
+  {dataDir: "$dataDir"},
+  "$network",
+  "(import|export)-"
+);

--- a/packages/cli/src/util/logger.ts
+++ b/packages/cli/src/util/logger.ts
@@ -63,18 +63,18 @@ export function getCliLogger(
     // args = {
     //   logFileDailyRotate: undefined,
     // }
-    const rotate = "logFileDailyRotate" in args;
+    const rotateMaxFiles = args.logFileDailyRotate ?? 0;
     const filename = paths.logFile;
 
     transports.push(
-      rotate
+      rotateMaxFiles > 0
         ? new DailyRotateFile({
             level: args.logFileLevel,
             //insert the date pattern in filename before the file extension.
             filename: filename.replace(/\.(?=[^.]*$)|$/, "-%DATE%$&"),
             datePattern: "YYYY-MM-DD",
             handleExceptions: true,
-            maxFiles: args.logFileDailyRotate ?? defaultLogMaxFiles,
+            maxFiles: rotateMaxFiles,
             auditFile: path.join(path.dirname(filename), ".log_rotate_audit.json"),
           })
         : new winston.transports.File({


### PR DESCRIPTION
This PR updates the default file options to always debug log with log rotation set.

To disable log, now one has to pass `--logFile none` and to disable log rotation one has to pass `--logRotateFiles 0`.

Closes #4527