### PR TITLE
Increase stateCache size to fix headState missing in checkpoint sync start

### DIFF
--- a/packages/beacon-node/src/chain/stateCache/stateContextCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/stateContextCache.ts
@@ -6,7 +6,7 @@ import {IMetrics} from "../../metrics/index.js";
 import {MapTracker} from "./mapMetrics.js";
 import {stateInternalCachePopulated} from "./stateContextCheckpointsCache.js";
 
-const MAX_STATES = 3 * 32;
+const MAX_STATES = 6 * 32;
 
 /**
  * In memory cache of CachedBeaconState


### PR DESCRIPTION
In checkpoint sync start, the stateCache of 3 * 32 caches seem to be not sufficient since generally we start from finalized which is almost 3 epochs behind 
So before bn can sync blocks and generate more states nearer to head, the getHeadState functions seem to be running out of the states.

This PR does a quick-fix for expanding the stateCache's cache to 6 epochs (to give  margin on 3 epochs) so that bns can stay behind 3 epochs + while still trying to find/sync peers.
There could be a better solution, but this is a hotfix to the current issue users might run into.

(see the notifier crossing 96+ skipped slots here since last finalized checkpoint sync comforably without error) 
![image](https://user-images.githubusercontent.com/76567250/189504597-c749cc7f-1ebf-4d95-916c-96a35bf5b9fb.png)

User issue also seems to have resolved.

Closes #4523