### PR TITLE
Customize fastify bodyLimit

### DIFF
--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -13,6 +13,7 @@ export type RestApiServerOpts = {
   cors?: string;
   address?: string;
   bearerToken?: string;
+  bodyLimit?: number;
 };
 
 export type RestApiServerModules = {
@@ -42,6 +43,7 @@ export class RestApiServer {
       logger: false,
       ajv: {customOptions: {coerceTypes: "array"}},
       querystringParser: querystring.parse,
+      bodyLimit: opts.bodyLimit,
     });
 
     this.activeSockets = new HttpActiveSocketsTracker(server.server, metrics);

--- a/packages/beacon-node/src/api/rest/index.ts
+++ b/packages/beacon-node/src/api/rest/index.ts
@@ -3,15 +3,12 @@ import {registerRoutes} from "@lodestar/api/beacon/server";
 import {ErrorAborted, ILogger} from "@lodestar/utils";
 import {IChainForkConfig} from "@lodestar/config";
 import {NodeIsSyncing} from "../impl/errors.js";
-import {RestApiServer, RestApiServerModules, RestApiServerMetrics} from "./base.js";
+import {RestApiServer, RestApiServerModules, RestApiServerMetrics, RestApiServerOpts} from "./base.js";
 export {allNamespaces} from "@lodestar/api";
 
-export type BeaconRestApiServerOpts = {
+export type BeaconRestApiServerOpts = Omit<RestApiServerOpts, "bearerToken"> & {
   enabled: boolean;
   api: (keyof Api)[];
-  port: number;
-  cors?: string;
-  address?: string;
 };
 
 export const beaconRestApiServerOpts: BeaconRestApiServerOpts = {
@@ -21,6 +18,8 @@ export const beaconRestApiServerOpts: BeaconRestApiServerOpts = {
   address: "127.0.0.1",
   port: 9596,
   cors: "*",
+  // beacon -> validator API is trusted, and for large amounts of keys the payload is multi-MB
+  bodyLimit: 10 * 1024 * 1024, // 10MB
 };
 
 export type BeaconRestApiServerModules = RestApiServerModules & {

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -146,6 +146,7 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
         port: args["keymanager.port"],
         cors: args["keymanager.cors"],
         isAuthEnabled: args["keymanager.authEnabled"],
+        bodyLimit: args["keymanager.bodyLimit"],
         tokenDir: dbPath,
       },
       {config, logger, api: keymanagerApi, metrics: metrics ? metrics.keymanagerApiRest : null}

--- a/packages/cli/src/cmds/validator/keymanager/server.ts
+++ b/packages/cli/src/cmds/validator/keymanager/server.ts
@@ -17,6 +17,8 @@ export const keymanagerRestApiServerOptsDefault: KeymanagerRestApiServerOpts = {
   port: 5062,
   cors: "*",
   isAuthEnabled: true,
+  // Slashing protection DB has been reported to be 3MB https://github.com/ChainSafe/lodestar/issues/4530
+  bodyLimit: 20 * 1024 * 1024, // 20MB
 };
 
 export type KeymanagerRestApiServerModules = RestApiServerModules & {

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -56,6 +56,7 @@ export type KeymanagerArgs = {
   "keymanager.port"?: number;
   "keymanager.address"?: string;
   "keymanager.cors"?: string;
+  "keymanager.bodyLimit"?: number;
 };
 
 export const keymanagerOptions: ICliCommandOptions<KeymanagerArgs> = {
@@ -88,6 +89,11 @@ export const keymanagerOptions: ICliCommandOptions<KeymanagerArgs> = {
     description: "Configures the Access-Control-Allow-Origin CORS header for keymanager API",
     defaultDescription: keymanagerRestApiServerOptsDefault.cors,
     group: "keymanager",
+  },
+  "keymanager.bodyLimit": {
+    hidden: true,
+    type: "number",
+    description: "Defines the maximum payload, in bytes, the server is allowed to accept",
   },
 };
 

--- a/packages/cli/src/options/beaconNodeOptions/api.ts
+++ b/packages/cli/src/options/beaconNodeOptions/api.ts
@@ -10,6 +10,7 @@ export interface IApiArgs {
   rest: boolean;
   "rest.address": string;
   "rest.port": number;
+  "rest.bodyLimit": number;
 }
 
 export function parseArgs(args: IApiArgs): IBeaconNodeOptions["api"] {
@@ -21,6 +22,7 @@ export function parseArgs(args: IApiArgs): IBeaconNodeOptions["api"] {
       enabled: args["rest"],
       address: args["rest.address"],
       port: args["rest.port"],
+      bodyLimit: args["rest.bodyLimit"],
     },
   };
 }
@@ -74,5 +76,10 @@ export const options: ICliCommandOptions<IApiArgs> = {
     description: "Set port for HTTP API",
     defaultDescription: String(defaultOptions.api.rest.port),
     group: "api",
+  },
+  "rest.bodyLimit": {
+    hidden: true,
+    type: "number",
+    description: "Defines the maximum payload, in bytes, the server is allowed to accept",
   },
 };

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -15,6 +15,7 @@ describe("options / beaconNodeOptions", () => {
       rest: true,
       "rest.address": "127.0.0.1",
       "rest.port": 7654,
+      "rest.bodyLimit": 30e6,
 
       "chain.blsVerifyAllMultiThread": true,
       "chain.blsVerifyAllMainThread": true,
@@ -82,6 +83,7 @@ describe("options / beaconNodeOptions", () => {
           enabled: true,
           address: "127.0.0.1",
           port: 7654,
+          bodyLimit: 30e6,
         },
       },
       chain: {


### PR DESCRIPTION
**Motivation**

- See https://github.com/ChainSafe/lodestar/issues/4530

**Description**

Sets API body limit to (arbitrary) large enough values:
- keymanager API bodylimit = 20 MB
- beacon API bodylimit = 10 MB

Closes https://github.com/ChainSafe/lodestar/issues/4530