### PR TITLE
Export beacon api client

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -20,6 +20,9 @@
     "./beacon": {
       "import": "./lib/beacon/index.js"
     },
+    "./beacon/client": {
+      "import": "./lib/beacon/client/index.js"
+    },
     "./beacon/server": {
       "import": "./lib/beacon/server/index.js"
     },


### PR DESCRIPTION
It's useful (eg: for web use) to have an export that only loads client code