### PR TITLE
Duplicate actions in the CI pipeline

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -1,6 +1,9 @@
 name: Browser tests
 
-on: [pull_request, push]
+on: 
+  pull_request:
+    types: [opened, reopened]
+  push:
 
 jobs:
   tests-main:

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -1,9 +1,11 @@
 name: Browser tests
 
 on: 
-  pull_request:
-    types: [opened, reopened]
   push:
+    # We intentionally don't run push on feature branches. See PR for rational. 
+    branches: [unstable, stable]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   tests-main:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,6 +1,9 @@
 name: E2E tests
 
-on: [pull_request, push]
+on: 
+  pull_request:
+    types: [opened, reopened]
+  push:
 
 env:
   GOERLI_RPC_DEFAULT_URL: https://goerli.infura.io/v3/84842078b09946638c03157f83405213

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,9 +1,11 @@
 name: E2E tests
 
 on: 
-  pull_request:
-    types: [opened, reopened]
   push:
+    # We intentionally don't run push on feature branches. See PR for rational. 
+    branches: [unstable, stable]
+  pull_request:
+  workflow_dispatch:
 
 env:
   GOERLI_RPC_DEFAULT_URL: https://goerli.infura.io/v3/84842078b09946638c03157f83405213

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -1,9 +1,11 @@
 name: Sim merge tests
 
 on: 
-  pull_request:
-    types: [opened, reopened]
   push:
+    # We intentionally don't run push on feature branches. See PR for rational. 
+    branches: [unstable, stable]
+  pull_request:
+  workflow_dispatch:
 
 env:
   GETH_COMMIT: be9742721f56eb8bb7ebf4f6a03fb01b13a05408

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -1,6 +1,9 @@
 name: Sim merge tests
 
-on: [pull_request, push]
+on: 
+  pull_request:
+    types: [opened, reopened]
+  push:
 
 env:
   GETH_COMMIT: be9742721f56eb8bb7ebf4f6a03fb01b13a05408

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -1,6 +1,9 @@
 name: Sim tests
 
-on: [pull_request, push]
+on: 
+  pull_request:
+    types: [opened, reopened]
+  push:
 
 jobs:
   tests-sim:

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -1,9 +1,11 @@
 name: Sim tests
 
 on: 
-  pull_request:
-    types: [opened, reopened]
   push:
+    # We intentionally don't run push on feature branches. See PR for rational. 
+    branches: [unstable, stable]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   tests-sim:

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -1,6 +1,9 @@
 name: Spec tests
 
-on: [pull_request, push]
+on: 
+  pull_request:
+    types: [opened, reopened]
+  push:
 
 jobs:
   tests-spec:

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -1,9 +1,11 @@
 name: Spec tests
 
 on: 
-  pull_request:
-    types: [opened, reopened]
   push:
+    # We intentionally don't run push on feature branches. See PR for rational. 
+    branches: [unstable, stable]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   tests-spec:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Tests
 
-on: [pull_request, push]
+on: 
+  pull_request:
+    types: [opened, reopened]
+  push:
 
 jobs:
   tests-main:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,11 @@
 name: Tests
 
 on: 
-  pull_request:
-    types: [opened, reopened]
   push:
+    # We intentionally don't run push on feature branches. See PR for rational. 
+    branches: [unstable, stable]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   tests-main:


### PR DESCRIPTION
**Motivation**

We want to optimize the CI workflow to have quick developer feedback. 


**Description**

We need to run flow on pushing changes to stable/unstable branches. As long as the tests are passing after merging the branch it's not important for us if these passes on local branch or not. If required to run tests for the some branches which don't have a PR, you can use the manual trigger. 

Closes #4535


