### PR TITLE
Remove ChainEvent.forkChoiceHead event

### DIFF
--- a/packages/beacon-node/src/api/impl/events/index.ts
+++ b/packages/beacon-node/src/api/impl/events/index.ts
@@ -1,16 +1,15 @@
-import {computeEpochAtSlot, computeStartSlotAtEpoch, getBlockRootAtSlot} from "@lodestar/state-transition";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {routes} from "@lodestar/api";
 import {toHexString} from "@chainsafe/ssz";
 import {ApiModules, IS_OPTIMISTIC_TEMP} from "../types.js";
 import {ChainEvent, IChainEvents} from "../../../chain/index.js";
 import {ApiError} from "../errors.js";
-import {isOptimsticBlock} from "../../../util/forkChoice.js";
 
 /**
  * Mapping of internal `ChainEvents` to API spec events
  */
 const chainEventMap = {
-  [routes.events.EventType.head]: ChainEvent.forkChoiceHead as const,
+  [routes.events.EventType.head]: ChainEvent.head as const,
   [routes.events.EventType.block]: ChainEvent.block as const,
   [routes.events.EventType.attestation]: ChainEvent.attestation as const,
   [routes.events.EventType.voluntaryExit]: ChainEvent.block as const,
@@ -30,29 +29,7 @@ export function getEventsApi({chain, config}: Pick<ApiModules, "chain" | "config
       ...args: Parameters<IChainEvents[typeof chainEventMap[K]]>
     ) => routes.events.EventData[K][];
   } = {
-    [routes.events.EventType.head]: (head) => {
-      const state = chain.stateCache.get(head.stateRoot);
-      if (!state) {
-        throw Error("cannot get state for head " + head.stateRoot);
-      }
-
-      const currentEpoch = state.epochCtx.epoch;
-      const [previousDutyDependentRoot, currentDutyDependentRoot] = [currentEpoch - 1, currentEpoch].map((epoch) =>
-        toHexString(getBlockRootAtSlot(state, Math.max(computeStartSlotAtEpoch(epoch) - 1, 0)))
-      );
-
-      return [
-        {
-          block: head.blockRoot,
-          epochTransition: computeStartSlotAtEpoch(computeEpochAtSlot(head.slot)) === head.slot,
-          slot: head.slot,
-          state: head.stateRoot,
-          previousDutyDependentRoot,
-          currentDutyDependentRoot,
-          executionOptimistic: isOptimsticBlock(head),
-        },
-      ];
-    },
+    [routes.events.EventType.head]: (data) => [data],
     [routes.events.EventType.block]: (block) => [
       {
         block: toHexString(config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message)),

--- a/packages/beacon-node/src/chain/emitter.ts
+++ b/packages/beacon-node/src/chain/emitter.ts
@@ -66,7 +66,7 @@ export enum ChainEvent {
    *
    * This event is guaranteed to be emitted after every sucessfully processed block, if that block updates the head.
    */
-  forkChoiceHead = "forkChoice:head",
+  head = "forkChoice:head",
   /**
    * This event signals that the fork choice has been updated to a new head that is not a descendant of the previous head.
    *
@@ -95,6 +95,8 @@ export enum ChainEvent {
   lightclientFinalizedUpdate = "lightclient:finalized_update",
 }
 
+export type HeadEventData = routes.events.EventData[routes.events.EventType.head];
+
 export interface IChainEvents {
   [ChainEvent.attestation]: (attestation: phase0.Attestation) => void;
   [ChainEvent.contributionAndProof]: (contributionAndProof: altair.SignedContributionAndProof) => void;
@@ -107,7 +109,7 @@ export interface IChainEvents {
   [ChainEvent.clockSlot]: (slot: Slot) => void;
   [ChainEvent.clockEpoch]: (epoch: Epoch) => void;
 
-  [ChainEvent.forkChoiceHead]: (head: ProtoBlock) => void;
+  [ChainEvent.head]: (data: HeadEventData) => void;
   [ChainEvent.forkChoiceReorg]: (head: ProtoBlock, oldHead: ProtoBlock, depth: number) => void;
   [ChainEvent.forkChoiceJustified]: (checkpoint: CheckpointWithHex) => void;
   [ChainEvent.forkChoiceFinalized]: (checkpoint: CheckpointWithHex) => void;

--- a/packages/beacon-node/test/utils/node/simTest.ts
+++ b/packages/beacon-node/test/utils/node/simTest.ts
@@ -5,14 +5,13 @@ import {
   beforeProcessEpoch,
 } from "@lodestar/state-transition";
 import {IBeaconConfig} from "@lodestar/config";
-import {ProtoBlock} from "@lodestar/fork-choice";
 import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {allForks, Epoch, Slot} from "@lodestar/types";
 import {Checkpoint} from "@lodestar/types/phase0";
 import {ILogger, mapValues} from "@lodestar/utils";
 import {toHexString} from "@chainsafe/ssz";
 import {BeaconNode} from "../../../src/index.js";
-import {ChainEvent} from "../../../src/chain/index.js";
+import {ChainEvent, HeadEventData} from "../../../src/chain/index.js";
 import {linspace} from "../../../src/util/numpy.js";
 import {RegenCaller} from "../../../src/chain/regen/index.js";
 
@@ -26,7 +25,7 @@ export function simTestInfoTracker(bn: BeaconNode, logger: ILogger): () => void 
   const prevParticipationPerEpoch = new Map<Epoch, number>();
   const currParticipationPerEpoch = new Map<Epoch, number>();
 
-  async function onHead(head: ProtoBlock): Promise<void> {
+  async function onHead(head: HeadEventData): Promise<void> {
     const slot = head.slot;
 
     // For each block
@@ -73,11 +72,11 @@ export function simTestInfoTracker(bn: BeaconNode, logger: ILogger): () => void 
     logParticipation(lastState);
   }
 
-  bn.chain.emitter.on(ChainEvent.forkChoiceHead, onHead);
+  bn.chain.emitter.on(ChainEvent.head, onHead);
   bn.chain.emitter.on(ChainEvent.checkpoint, onCheckpoint);
 
   return function stop() {
-    bn.chain.emitter.off(ChainEvent.forkChoiceHead, onHead);
+    bn.chain.emitter.off(ChainEvent.head, onHead);
     bn.chain.emitter.off(ChainEvent.checkpoint, onCheckpoint);
 
     // Write report


### PR DESCRIPTION
**Motivation**

It's unnecessary to have this intermediary event between what the eventstream requires and where it's emitted. Splitting sensitive code like this has been a source of inconsistencies and bugs in the past. In the case for example it hide away this really ugly code

```ts
      const state = chain.stateCache.get(head.stateRoot);
      if (!state) {
        throw Error("cannot get state for head " + head.stateRoot);
      }

      const currentEpoch = state.epochCtx.epoch;
      const [previousDutyDependentRoot, currentDutyDependentRoot] = [currentEpoch - 1, currentEpoch].map((epoch) =>
        toHexString(getBlockRootAtSlot(state, Math.max(computeStartSlotAtEpoch(epoch) - 1, 0)))
      );
```

This code forces dangerous assumptions:
- When is the forkchoice:head event emitted? Is it emitted BEFORE or AFTER storing the state in the cache?
- Is there always a state available for the head? If not, under what circumstances? If it's not available should the event be delayed?

**Description**

- Remove intermediary head event
- Move event data logic into sequential importBlock flow