### PR TITLE
Set dependantRoot type to string in api

### DIFF
--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -14,6 +14,8 @@ import {
   ssz,
   UintNum64,
   ValidatorIndex,
+  RootHex,
+  StringType,
 } from "@lodestar/types";
 import {
   RoutesData,
@@ -114,7 +116,7 @@ export type Api = {
   getAttesterDuties(
     epoch: Epoch,
     validatorIndices: ValidatorIndex[]
-  ): Promise<{executionOptimistic: ExecutionOptimistic; data: AttesterDuty[]; dependentRoot: Root}>;
+  ): Promise<{executionOptimistic: ExecutionOptimistic; data: AttesterDuty[]; dependentRoot: RootHex}>;
 
   /**
    * Get block proposers duties
@@ -129,7 +131,7 @@ export type Api = {
    */
   getProposerDuties(
     epoch: Epoch
-  ): Promise<{executionOptimistic: ExecutionOptimistic; data: ProposerDuty[]; dependentRoot: Root}>;
+  ): Promise<{executionOptimistic: ExecutionOptimistic; data: ProposerDuty[]; dependentRoot: RootHex}>;
 
   getSyncCommitteeDuties(
     epoch: number,
@@ -391,13 +393,15 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
 }
 
 export function getReturnTypes(): ReturnTypes<Api> {
+  const rootHexType = new StringType();
+
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   const WithDependentRootExecutionOptimistic = <T>(dataType: Type<T>) =>
     new ContainerType(
       {
         executionOptimistic: ssz.Boolean,
         data: dataType,
-        dependentRoot: ssz.Root,
+        dependentRoot: rootHexType,
       },
       {jsonCase: "eth2"}
     );

--- a/packages/api/test/unit/beacon/testData/validator.ts
+++ b/packages/api/test/unit/beacon/testData/validator.ts
@@ -4,6 +4,7 @@ import {Api} from "../../../../src/beacon/routes/validator.js";
 import {GenericServerTestCases} from "../../../utils/genericServerTest.js";
 
 const ZERO_HASH = Buffer.alloc(32, 0);
+const ZERO_HASH_HEX = "0x" + ZERO_HASH.toString("hex");
 const randaoReveal = Buffer.alloc(96, 1);
 const graffiti = "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2";
 
@@ -23,7 +24,7 @@ export const testData: GenericServerTestCases<Api> = {
           slot: 7,
         },
       ],
-      dependentRoot: ZERO_HASH,
+      dependentRoot: ZERO_HASH_HEX,
     },
   },
   getProposerDuties: {
@@ -31,7 +32,7 @@ export const testData: GenericServerTestCases<Api> = {
     res: {
       executionOptimistic: true,
       data: [{slot: 1, validatorIndex: 2, pubkey: Buffer.alloc(48, 3)}],
-      dependentRoot: ZERO_HASH,
+      dependentRoot: ZERO_HASH_HEX,
     },
   },
   getSyncCommitteeDuties: {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -10,7 +10,7 @@ import {
 import {GENESIS_SLOT, SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT, SYNC_COMMITTEE_SUBNET_SIZE} from "@lodestar/params";
 import {Root, Slot, ValidatorIndex, ssz, Epoch} from "@lodestar/types";
 import {ExecutionStatus} from "@lodestar/fork-choice";
-
+import {toHex} from "@lodestar/utils";
 import {fromHexString} from "@chainsafe/ssz";
 import {AttestationError, AttestationErrorCode, GossipAction, SyncCommitteeError} from "../../../chain/errors/index.js";
 import {validateGossipAggregateAndProof} from "../../../chain/validation/index.js";
@@ -353,7 +353,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
 
       return {
         data: duties,
-        dependentRoot,
+        dependentRoot: toHex(dependentRoot),
         executionOptimistic: isOptimsticBlock(head),
       };
     },
@@ -403,7 +403,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
 
       return {
         data: duties,
-        dependentRoot,
+        dependentRoot: toHex(dependentRoot),
         executionOptimistic: isOptimsticBlock(head),
       };
     },

--- a/packages/cli/test/utils/mockBeaconApiServer.ts
+++ b/packages/cli/test/utils/mockBeaconApiServer.ts
@@ -4,10 +4,10 @@ import {Api, allNamespaces} from "@lodestar/api";
 import {IChainForkConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
 import {ssz} from "@lodestar/types";
-import {fromHex} from "@lodestar/utils";
+import {fromHex, toHex} from "@lodestar/utils";
 import {testLogger} from "../../../beacon-node/test/utils/logger.js";
 
-const ZERO_HASH = Buffer.alloc(32, 0);
+const ZERO_HASH_HEX = toHex(Buffer.alloc(32, 0));
 
 export type MockBeaconApiOpts = {
   genesisValidatorsRoot?: string;
@@ -55,7 +55,7 @@ export function getMockBeaconApiServer(opts: RestApiServerOpts, apiOpts?: MockBe
 
     validator: {
       async getProposerDuties() {
-        return {data: [], dependentRoot: ZERO_HASH, executionOptimistic: false};
+        return {data: [], dependentRoot: ZERO_HASH_HEX, executionOptimistic: false};
       },
       async prepareBeaconProposer() {
         // Do nothing

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -212,17 +212,13 @@ export class AttestationDutiesService {
       throw extendError(e, "Failed to obtain attester duty");
     });
 
-    const dependentRoot = toHexString(attesterDuties.dependentRoot);
+    const {dependentRoot} = attesterDuties;
     const relevantDuties = attesterDuties.data.filter((duty) => {
       const pubkeyHex = toHexString(duty.pubkey);
       return this.validatorStore.hasVotingPubkey(pubkeyHex) && this.validatorStore.isDoppelgangerSafe(pubkeyHex);
     });
 
-    this.logger.debug("Downloaded attester duties", {
-      epoch,
-      dependentRoot,
-      count: relevantDuties.length,
-    });
+    this.logger.debug("Downloaded attester duties", {epoch, dependentRoot, count: relevantDuties.length});
 
     const priorDependentRoot = this.dutiesByIndexByEpoch.get(epoch)?.dependentRoot;
     const dependentRootChanged = priorDependentRoot !== undefined && priorDependentRoot !== dependentRoot;

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -14,10 +14,10 @@ import {loggerVc} from "../../utils/logger.js";
 import {ClockMock} from "../../utils/clock.js";
 import {ChainHeaderTracker} from "../../../src/services/chainHeaderTracker.js";
 import {ValidatorEventEmitter} from "../../../src/services/emitter.js";
+import {ZERO_HASH, ZERO_HASH_HEX} from "../../utils/types.js";
 
 describe("AttestationService", function () {
   const sandbox = sinon.createSandbox();
-  const ZERO_HASH = Buffer.alloc(32, 0);
 
   const api = getApiClientStub(sandbox);
   const validatorStore = sinon.createStubInstance(ValidatorStore) as ValidatorStore &
@@ -72,7 +72,7 @@ describe("AttestationService", function () {
 
     // Return empty replies to duties service
     api.beacon.getStateValidators.resolves({executionOptimistic: false, data: []});
-    api.validator.getAttesterDuties.resolves({dependentRoot: ZERO_HASH, executionOptimistic: false, data: []});
+    api.validator.getAttesterDuties.resolves({dependentRoot: ZERO_HASH_HEX, executionOptimistic: false, data: []});
 
     // Mock duties service to return some duties directly
     attestationService["dutiesService"].getDutiesAtSlot = sinon.stub().returns(duties);

--- a/packages/validator/test/unit/services/attestationDuties.test.ts
+++ b/packages/validator/test/unit/services/attestationDuties.test.ts
@@ -14,10 +14,10 @@ import {loggerVc} from "../../utils/logger.js";
 import {ClockMock} from "../../utils/clock.js";
 import {initValidatorStore} from "../../utils/validatorStore.js";
 import {ChainHeaderTracker} from "../../../src/services/chainHeaderTracker.js";
+import {ZERO_HASH_HEX} from "../../utils/types.js";
 
 describe("AttestationDutiesService", function () {
   const sandbox = sinon.createSandbox();
-  const ZERO_HASH = Buffer.alloc(32, 0);
   const api = getApiClientStub(sandbox);
 
   let validatorStore: ValidatorStore;
@@ -67,7 +67,7 @@ describe("AttestationDutiesService", function () {
       validatorIndex: index,
       pubkey: pubkeys[0],
     };
-    api.validator.getAttesterDuties.resolves({dependentRoot: ZERO_HASH, data: [duty], executionOptimistic: false});
+    api.validator.getAttesterDuties.resolves({dependentRoot: ZERO_HASH_HEX, data: [duty], executionOptimistic: false});
 
     // Accept all subscriptions
     api.validator.prepareBeaconCommitteeSubnet.resolves();
@@ -134,7 +134,7 @@ describe("AttestationDutiesService", function () {
       validatorIndex: index,
       pubkey: pubkeys[0],
     };
-    api.validator.getAttesterDuties.resolves({data: [duty], dependentRoot: ZERO_HASH, executionOptimistic: false});
+    api.validator.getAttesterDuties.resolves({data: [duty], dependentRoot: ZERO_HASH_HEX, executionOptimistic: false});
 
     // Accept all subscriptions
     api.validator.prepareBeaconCommitteeSubnet.resolves();

--- a/packages/validator/test/unit/services/block.test.ts
+++ b/packages/validator/test/unit/services/block.test.ts
@@ -11,10 +11,10 @@ import {ValidatorStore} from "../../../src/services/validatorStore.js";
 import {getApiClientStub} from "../../utils/apiStub.js";
 import {loggerVc} from "../../utils/logger.js";
 import {ClockMock} from "../../utils/clock.js";
+import {ZERO_HASH_HEX} from "../../utils/types.js";
 
 describe("BlockDutiesService", function () {
   const sandbox = sinon.createSandbox();
-  const ZERO_HASH = Buffer.alloc(32, 0);
 
   const api = getApiClientStub(sandbox);
   const validatorStore = sinon.createStubInstance(ValidatorStore) as ValidatorStore &
@@ -37,7 +37,7 @@ describe("BlockDutiesService", function () {
     // Reply with some duties
     const slot = 0; // genesisTime is right now, so test with slot = currentSlot
     api.validator.getProposerDuties.resolves({
-      dependentRoot: ZERO_HASH,
+      dependentRoot: ZERO_HASH_HEX,
       executionOptimistic: false,
       data: [{slot: slot, validatorIndex: 0, pubkey: pubkeys[0]}],
     });

--- a/packages/validator/test/unit/services/blockDuties.test.ts
+++ b/packages/validator/test/unit/services/blockDuties.test.ts
@@ -3,20 +3,21 @@ import sinon from "sinon";
 import {toBufferBE} from "bigint-buffer";
 import bls from "@chainsafe/bls";
 import {toHexString} from "@chainsafe/ssz";
-import {Root} from "@lodestar/types";
+import {RootHex} from "@lodestar/types";
 import {routes} from "@lodestar/api";
+import {toHex} from "@lodestar/utils";
 import {BlockDutiesService} from "../../../src/services/blockDuties.js";
 import {ValidatorStore} from "../../../src/services/validatorStore.js";
 import {getApiClientStub} from "../../utils/apiStub.js";
 import {loggerVc} from "../../utils/logger.js";
 import {ClockMock} from "../../utils/clock.js";
 import {initValidatorStore} from "../../utils/validatorStore.js";
+import {ZERO_HASH_HEX} from "../../utils/types.js";
 
-type ProposerDutiesRes = {dependentRoot: Root; data: routes.validator.ProposerDuty[]};
+type ProposerDutiesRes = {dependentRoot: RootHex; data: routes.validator.ProposerDuty[]};
 
 describe("BlockDutiesService", function () {
   const sandbox = sinon.createSandbox();
-  const ZERO_HASH = Buffer.alloc(32, 0);
 
   const api = getApiClientStub(sandbox);
   let validatorStore: ValidatorStore;
@@ -36,7 +37,7 @@ describe("BlockDutiesService", function () {
     // Reply with some duties
     const slot = 0; // genesisTime is right now, so test with slot = currentSlot
     const duties: ProposerDutiesRes = {
-      dependentRoot: ZERO_HASH,
+      dependentRoot: ZERO_HASH_HEX,
       data: [{slot: slot, validatorIndex: 0, pubkey: pubkeys[0]}],
     };
     api.validator.getProposerDuties.resolves({...duties, executionOptimistic: false});
@@ -65,13 +66,13 @@ describe("BlockDutiesService", function () {
 
   it("Should call notifyBlockProductionFn again on duties re-org", async () => {
     // A re-org will happen at slot 1
-    const DIFF_HASH = Buffer.alloc(32, 1);
+    const dependentRootDiff = toHex(Buffer.alloc(32, 1));
     const dutiesBeforeReorg: ProposerDutiesRes = {
-      dependentRoot: ZERO_HASH,
+      dependentRoot: ZERO_HASH_HEX,
       data: [{slot: 1, validatorIndex: 0, pubkey: pubkeys[0]}],
     };
     const dutiesAfterReorg: ProposerDutiesRes = {
-      dependentRoot: DIFF_HASH,
+      dependentRoot: dependentRootDiff,
       data: [{slot: 1, validatorIndex: 1, pubkey: pubkeys[1]}],
     };
 
@@ -114,7 +115,7 @@ describe("BlockDutiesService", function () {
     // Reply with some duties
     const slot = 0; // genesisTime is right now, so test with slot = currentSlot
     const duties: ProposerDutiesRes = {
-      dependentRoot: ZERO_HASH,
+      dependentRoot: ZERO_HASH_HEX,
       data: [
         {slot: slot, validatorIndex: 0, pubkey: pubkeys[0]},
         {slot: slot, validatorIndex: 1, pubkey: pubkeys[1]},
@@ -123,7 +124,7 @@ describe("BlockDutiesService", function () {
     };
 
     const dutiesRemoved: ProposerDutiesRes = {
-      dependentRoot: ZERO_HASH,
+      dependentRoot: ZERO_HASH_HEX,
       data: [
         {slot: slot, validatorIndex: 1, pubkey: pubkeys[1]},
         {slot: 33, validatorIndex: 2, pubkey: pubkeys[2]},

--- a/packages/validator/test/unit/services/syncCommittee.test.ts
+++ b/packages/validator/test/unit/services/syncCommittee.test.ts
@@ -12,12 +12,12 @@ import {getApiClientStub} from "../../utils/apiStub.js";
 import {loggerVc} from "../../utils/logger.js";
 import {ClockMock} from "../../utils/clock.js";
 import {ChainHeaderTracker} from "../../../src/services/chainHeaderTracker.js";
+import {ZERO_HASH} from "../../utils/types.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
 describe("SyncCommitteeService", function () {
   const sandbox = sinon.createSandbox();
-  const ZERO_HASH = Buffer.alloc(32, 0);
 
   const api = getApiClientStub(sandbox);
   const validatorStore = sinon.createStubInstance(ValidatorStore) as ValidatorStore &

--- a/packages/validator/test/utils/types.ts
+++ b/packages/validator/test/utils/types.ts
@@ -1,4 +1,8 @@
 import {SinonStub} from "sinon";
+import {toHex} from "@lodestar/utils";
+
+export const ZERO_HASH = Buffer.alloc(32, 0);
+export const ZERO_HASH_HEX = toHex(ZERO_HASH);
 
 export type SinonStubFn<T extends (...args: any[]) => any> = T extends (...args: infer TArgs) => infer TReturnValue
   ? SinonStub<TArgs, TReturnValue>


### PR DESCRIPTION
**Motivation**

- spin off from https://github.com/ChainSafe/lodestar/pull/4382

Setting dependant root type to bytes requires unnecessary transformations. And it's something you only do comparisons with

**Description**

- Set dependantRoot type to string in api