### PR TITLE
Use web EventSource if available

### DIFF
--- a/packages/api/src/beacon/client/events.ts
+++ b/packages/api/src/beacon/client/events.ts
@@ -1,7 +1,7 @@
-import EventSource from "eventsource";
 import {IChainForkConfig} from "@lodestar/config";
 import {Api, BeaconEvent, routesData, getEventSerdes} from "../routes/events.js";
 import {stringifyQuery} from "../../utils/client/format.js";
+import {getEventSource} from "../../utils/client/eventSource.js";
 
 /**
  * REST HTTP client for events routes
@@ -14,6 +14,8 @@ export function getClient(_config: IChainForkConfig, baseUrl: string): Api {
       const query = stringifyQuery({topics});
       // TODO: Use a proper URL formatter
       const url = `${baseUrl}${routesData.eventstream.url}?${query}`;
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      const EventSource = await getEventSource();
       const eventSource = new EventSource(url);
 
       try {

--- a/packages/api/src/utils/client/eventSource.ts
+++ b/packages/api/src/utils/client/eventSource.ts
@@ -4,6 +4,6 @@ export async function getEventSource(): Promise<typeof EventSource> {
   if (globalThis.EventSource) {
     return EventSource;
   } else {
-    return ((await import("eventsource")) as unknown) as typeof EventSource;
+    return ((await import("eventsource")).default as unknown) as typeof EventSource;
   }
 }

--- a/packages/api/src/utils/client/eventSource.ts
+++ b/packages/api/src/utils/client/eventSource.ts
@@ -1,0 +1,9 @@
+// This function switches between the native web implementation and a nodejs implemnetation
+export async function getEventSource(): Promise<typeof EventSource> {
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+  if (globalThis.EventSource) {
+    return EventSource;
+  } else {
+    return ((await import("eventsource")) as unknown) as typeof EventSource;
+  }
+}


### PR DESCRIPTION
Current implementation of `EventSource`, from package `eventsource`, uses many nodejs imports and apis.
All of that complicates web usage of our api client and is unnecessary since there's a native implementation in-browser.

This PR adds a switch to use the native `EventSource` if it exists.