### PR TITLE
Add strong ref to head state in state cache

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -7,6 +7,7 @@ import {ZERO_HASH_HEX} from "../../constants/index.js";
 import {toCheckpointHex} from "../stateCache/index.js";
 import {ChainEvent} from "../emitter.js";
 import {REPROCESS_MIN_TIME_TO_NEXT_SLOT_SEC} from "../reprocess.js";
+import {RegenCaller} from "../regen/interface.js";
 import type {BeaconChain} from "../chain.js";
 import {FullyVerifiedBlock, ImportBlockOpts} from "./types.js";
 import {PendingEvents} from "./utils/pendingEvents.js";
@@ -215,6 +216,20 @@ export async function importBlock(
       } catch (e) {
         this.logger.error("Error lightClientServer.onImportBlock", {slot: block.message.slot}, e as Error);
       }
+    }
+
+    // Set head state as strong reference
+    const headState =
+      newHead.stateRoot === toHexString(postState.hashTreeRoot()) ? postState : this.stateCache.get(newHead.stateRoot);
+    if (headState) {
+      this.stateCache.setHeadState(headState);
+    } else {
+      // Trigger regen on head change if necessary
+      this.logger.warn("Head state not available, triggering regen", {stateRoot: newHead.stateRoot});
+      this.regen.getState(newHead.stateRoot, RegenCaller.processBlock).then(
+        (headStateRegen) => this.stateCache.setHeadState(headStateRegen),
+        (e) => this.logger.error("Error on head state regen", {}, e)
+      );
     }
   }
 

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -226,6 +226,9 @@ export async function importBlock(
     } else {
       // Trigger regen on head change if necessary
       this.logger.warn("Head state not available, triggering regen", {stateRoot: newHead.stateRoot});
+      // head has changed, so the existing cached head state is no longer useful. Set strong reference to null to free
+      // up memory for regen step below. During regen, node won't be functional but eventually head will be available
+      this.stateCache.setHeadState(null);
       this.regen.getState(newHead.stateRoot, RegenCaller.processBlock).then(
         (headStateRegen) => this.stateCache.setHeadState(headStateRegen),
         (e) => this.logger.error("Error on head state regen", {}, e)

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -193,8 +193,6 @@ export class BeaconChain implements IBeaconChain {
       : new BlsMultiThreadWorkerPool(opts, {logger, metrics});
 
     if (!clock) clock = new LocalClock({config, emitter, genesisTime: this.genesisTime, signal});
-    const stateCache = new StateContextCache({metrics});
-    const checkpointStateCache = new CheckpointStateCache({metrics});
 
     this.seenAggregatedAttestations = new SeenAggregatedAttestations(metrics);
     this.seenContributionAndProof = new SeenContributionAndProof(metrics);
@@ -219,6 +217,9 @@ export class BeaconChain implements IBeaconChain {
     // Persist single global instance of state caches
     this.pubkey2index = cachedState.epochCtx.pubkey2index;
     this.index2pubkey = cachedState.epochCtx.index2pubkey;
+
+    const stateCache = new StateContextCache({metrics}, cachedState);
+    const checkpointStateCache = new CheckpointStateCache({metrics});
 
     const {checkpoint} = computeAnchorCheckpoint(config, anchorState);
     stateCache.add(cachedState);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -218,11 +218,12 @@ export class BeaconChain implements IBeaconChain {
     this.pubkey2index = cachedState.epochCtx.pubkey2index;
     this.index2pubkey = cachedState.epochCtx.index2pubkey;
 
-    const stateCache = new StateContextCache({metrics}, cachedState);
+    const stateCache = new StateContextCache({metrics});
     const checkpointStateCache = new CheckpointStateCache({metrics});
 
     const {checkpoint} = computeAnchorCheckpoint(config, anchorState);
     stateCache.add(cachedState);
+    stateCache.setHeadState(cachedState);
     checkpointStateCache.add(checkpoint, cachedState);
 
     const forkChoice = initializeForkChoice(

--- a/packages/beacon-node/src/chain/regen/interface.ts
+++ b/packages/beacon-node/src/chain/regen/interface.ts
@@ -3,6 +3,7 @@ import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 
 export enum RegenCaller {
   getDuties = "getDuties",
+  processBlock = "processBlock",
   produceBlock = "produceBlock",
   validateGossipBlock = "validateGossipBlock",
   precomputeEpoch = "precomputeEpoch",

--- a/packages/beacon-node/src/chain/stateCache/stateContextCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/stateContextCache.ts
@@ -29,18 +29,13 @@ export class StateContextCache {
    */
   private head: {state: CachedBeaconStateAllForks; stateRoot: RootHex} | null = null;
 
-  constructor(
-    {maxStates = MAX_STATES, metrics}: {maxStates?: number; metrics?: IMetrics | null},
-    initialHeadState: CachedBeaconStateAllForks
-  ) {
+  constructor({maxStates = MAX_STATES, metrics}: {maxStates?: number; metrics?: IMetrics | null}) {
     this.maxStates = maxStates;
     this.cache = new MapTracker(metrics?.stateCache);
     if (metrics) {
       this.metrics = metrics.stateCache;
       metrics.stateCache.size.addCollect(() => metrics.stateCache.size.set(this.cache.size));
     }
-
-    this.head = {state: initialHeadState, stateRoot: toHexString(initialHeadState.hashTreeRoot())};
   }
 
   get(rootHex: RootHex): CachedBeaconStateAllForks | null {

--- a/packages/beacon-node/src/chain/stateCache/stateContextCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/stateContextCache.ts
@@ -23,8 +23,11 @@ export class StateContextCache {
   /** Epoch -> Set<blockRoot> */
   private readonly epochIndex = new Map<Epoch, Set<string>>();
   private readonly metrics: IMetrics["stateCache"] | null | undefined;
-  /** Strong reference to prevent head state from being pruned */
-  private head: {state: CachedBeaconStateAllForks; stateRoot: RootHex};
+  /**
+   * Strong reference to prevent head state from being pruned.
+   * null if head state is being regen and not available at the moment.
+   */
+  private head: {state: CachedBeaconStateAllForks; stateRoot: RootHex} | null = null;
 
   constructor(
     {maxStates = MAX_STATES, metrics}: {maxStates?: number; metrics?: IMetrics | null},
@@ -76,9 +79,13 @@ export class StateContextCache {
     }
   }
 
-  setHeadState(item: CachedBeaconStateAllForks): void {
-    const key = toHexString(item.hashTreeRoot());
-    this.head = {state: item, stateRoot: key};
+  setHeadState(item: CachedBeaconStateAllForks | null): void {
+    if (item) {
+      const key = toHexString(item.hashTreeRoot());
+      this.head = {state: item, stateRoot: key};
+    } else {
+      this.head = null;
+    }
   }
 
   clear(): void {


### PR DESCRIPTION
**Motivation**

StateCache prune logic may drop head state if it gets too old. Also there's no mechanism to regen a head state if it's not available.
- https://github.com/ChainSafe/lodestar/issues/4523

**Description**

- Add strong ref to head state in state cache to prevent pruning
- Trigger regen if head state is not available only in importBlock