### PR TITLE
Overhaul blinded types into multi-fork

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -1,7 +1,7 @@
 import {ContainerType} from "@chainsafe/ssz";
 import {ForkName} from "@lodestar/params";
 import {IChainForkConfig} from "@lodestar/config";
-import {phase0, allForks, Slot, Root, ssz, bellatrix, RootHex} from "@lodestar/types";
+import {phase0, allForks, Slot, Root, ssz, RootHex} from "@lodestar/types";
 
 import {
   RoutesData,
@@ -108,7 +108,7 @@ export type Api = {
    * Publish a signed blinded block by submitting it to the mev relay and patching in the block
    * transactions beacon node gets in response.
    */
-  publishBlindedBlock(block: bellatrix.SignedBlindedBeaconBlock): Promise<void>;
+  publishBlindedBlock(block: allForks.SignedBlindedBeaconBlock): Promise<void>;
 };
 
 /**
@@ -156,6 +156,17 @@ export function getReqSerializers(config: IChainForkConfig): ReqSerializers<Api,
     fromJson: (data) => getSignedBeaconBlockType((data as unknown) as allForks.SignedBeaconBlock).fromJson(data),
   };
 
+  const getSignedBlindedBeaconBlockType = (
+    data: allForks.SignedBlindedBeaconBlock
+  ): allForks.AllForksBlindedSSZTypes["SignedBeaconBlock"] =>
+    config.getBlindedForkTypes(data.message.slot).SignedBeaconBlock;
+
+  const AllForksSignedBlindedBeaconBlock: TypeJson<allForks.SignedBlindedBeaconBlock> = {
+    toJson: (data) => getSignedBlindedBeaconBlockType(data).toJson(data),
+    fromJson: (data) =>
+      getSignedBlindedBeaconBlockType((data as unknown) as allForks.SignedBlindedBeaconBlock).fromJson(data),
+  };
+
   return {
     getBlock: blockIdOnlyReq,
     getBlockV2: blockIdOnlyReq,
@@ -168,7 +179,7 @@ export function getReqSerializers(config: IChainForkConfig): ReqSerializers<Api,
     },
     getBlockRoot: blockIdOnlyReq,
     publishBlock: reqOnlyBody(AllForksSignedBeaconBlock, Schema.Object),
-    publishBlindedBlock: reqOnlyBody(ssz.bellatrix.SignedBlindedBeaconBlock, Schema.Object),
+    publishBlindedBlock: reqOnlyBody(AllForksSignedBlindedBeaconBlock, Schema.Object),
   };
 }
 

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -445,7 +445,7 @@ export function getReturnTypes(): ReturnTypes<Api> {
     produceBlockV2: WithVersion((fork: ForkName) => ssz[fork].BeaconBlock),
     produceBlindedBlock: WithVersion((fork: ForkName) => {
       if (fork === ForkName.phase0 || fork === ForkName.altair) {
-        throw Error(`Invalid fork=${fork} for produceBlindedBlock`);
+        throw Error(`No BlindedBlock for fork ${fork} previous to bellatrix`);
       }
       return ssz[fork].BlindedBeaconBlock;
     }),

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -169,7 +169,7 @@ export type Api = {
     slot: Slot,
     randaoReveal: BLSSignature,
     graffiti: string
-  ): Promise<{data: bellatrix.BlindedBeaconBlock; version: ForkName}>;
+  ): Promise<{data: allForks.BlindedBeaconBlock; version: ForkName}>;
 
   /**
    * Produce an attestation data
@@ -443,7 +443,12 @@ export function getReturnTypes(): ReturnTypes<Api> {
     getSyncCommitteeDuties: ContainerDataExecutionOptimistic(ArrayOf(SyncDuty)),
     produceBlock: ContainerData(ssz.phase0.BeaconBlock),
     produceBlockV2: WithVersion((fork: ForkName) => ssz[fork].BeaconBlock),
-    produceBlindedBlock: WithVersion((_fork: ForkName) => ssz.bellatrix.BlindedBeaconBlock),
+    produceBlindedBlock: WithVersion((fork: ForkName) => {
+      if (fork === ForkName.phase0 || fork === ForkName.altair) {
+        throw Error(`Invalid fork=${fork} for produceBlindedBlock`);
+      }
+      return ssz[fork].BlindedBeaconBlock;
+    }),
     produceAttestationData: ContainerData(ssz.phase0.AttestationData),
     produceSyncCommitteeContribution: ContainerData(ssz.altair.SyncCommitteeContribution),
     getAggregatedAttestation: ContainerData(ssz.phase0.Attestation),

--- a/packages/api/src/builder/client.ts
+++ b/packages/api/src/builder/client.ts
@@ -5,8 +5,8 @@ import {Api, ReqTypes, routesData, getReqSerializers, getReturnTypes} from "./ro
 /**
  * REST HTTP client for builder routes
  */
-export function getClient(_config: IChainForkConfig, httpClient: IHttpClient): Api {
-  const reqSerializers = getReqSerializers();
+export function getClient(config: IChainForkConfig, httpClient: IHttpClient): Api {
+  const reqSerializers = getReqSerializers(config);
   const returnTypes = getReturnTypes();
   // All routes return JSON, use a client auto-generator
   return generateGenericJsonClient<Api, ReqTypes>(routesData, reqSerializers, returnTypes, httpClient);

--- a/packages/api/src/builder/routes.ts
+++ b/packages/api/src/builder/routes.ts
@@ -1,6 +1,8 @@
-import {ssz, bellatrix, Slot, Root, BLSPubkey} from "@lodestar/types";
+import {ssz, allForks, bellatrix, Slot, Root, BLSPubkey} from "@lodestar/types";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {ForkName} from "@lodestar/params";
+import {IChainForkConfig} from "@lodestar/config";
+
 import {
   ReturnTypes,
   RoutesData,
@@ -13,6 +15,7 @@ import {
   WithVersion,
 } from "../utils/index.js";
 // See /packages/api/src/routes/index.ts for reasoning and instructions to add new routes
+import {getReqSerializers as getBeaconReqSerializers} from "../beacon/routes/beacon/block.js";
 
 export type Api = {
   status(): Promise<void>;
@@ -23,7 +26,7 @@ export type Api = {
     proposerPubKey: BLSPubkey
   ): Promise<{version: ForkName; data: bellatrix.SignedBuilderBid}>;
   submitBlindedBlock(
-    signedBlock: bellatrix.SignedBlindedBeaconBlock
+    signedBlock: allForks.SignedBlindedBeaconBlock
   ): Promise<{version: ForkName; data: bellatrix.ExecutionPayload}>;
 };
 
@@ -45,7 +48,7 @@ export type ReqTypes = {
   submitBlindedBlock: {body: unknown};
 };
 
-export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
+export function getReqSerializers(config: IChainForkConfig): ReqSerializers<Api, ReqTypes> {
   return {
     status: reqEmpty,
     registerValidator: reqOnlyBody(ArrayOf(ssz.bellatrix.SignedValidatorRegistrationV1), Schema.ObjectArray),
@@ -58,7 +61,7 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
         params: {slot: Schema.UintRequired, parent_hash: Schema.StringRequired, pubkey: Schema.StringRequired},
       },
     },
-    submitBlindedBlock: reqOnlyBody(ssz.bellatrix.SignedBlindedBeaconBlock, Schema.Object),
+    submitBlindedBlock: getBeaconReqSerializers(config)["publishBlindedBlock"],
   };
 }
 

--- a/packages/api/test/unit/beacon/genericServerTest/beacon.test.ts
+++ b/packages/api/test/unit/beacon/genericServerTest/beacon.test.ts
@@ -1,4 +1,4 @@
-import {config} from "@lodestar/config/default";
+import {createIChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {Api, ReqTypes} from "../../../../src/beacon/routes/beacon/index.js";
 import {getClient} from "../../../../src/beacon/client/beacon.js";
 import {getRoutes} from "../../../../src/beacon/server/beacon.js";
@@ -6,7 +6,13 @@ import {runGenericServerTest} from "../../../utils/genericServerTest.js";
 import {testData} from "../testData/beacon.js";
 
 describe("beacon / beacon", () => {
-  runGenericServerTest<Api, ReqTypes>(config, getClient, getRoutes, testData);
+  runGenericServerTest<Api, ReqTypes>(
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    createIChainForkConfig({...defaultChainConfig, ALTAIR_FORK_EPOCH: 1, BELLATRIX_FORK_EPOCH: 2}),
+    getClient,
+    getRoutes,
+    testData
+  );
 
   // TODO: Extra tests to implement maybe
 

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import {fileURLToPath} from "node:url";
 import {expect} from "chai";
-import {config} from "@lodestar/config/default";
+import {createIChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {OpenApiFile} from "../../utils/parseOpenApiSpec.js";
 import {routes} from "../../../src/beacon/index.js";
 import {ReqSerializers} from "../../../src/utils/types.js";
@@ -48,6 +48,8 @@ const getEventsReqSerializers = (): ReqSerializers<routes.events.Api, routes.eve
   },
 });
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const config = createIChainForkConfig({...defaultChainConfig, ALTAIR_FORK_EPOCH: 1, BELLATRIX_FORK_EPOCH: 2});
 const reqSerializers = {
   ...routes.beacon.getReqSerializers(config),
   ...routes.config.getReqSerializers(),

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -1,5 +1,5 @@
 import {ForkName} from "@lodestar/params";
-import {ssz} from "@lodestar/types";
+import {ssz, Slot, allForks} from "@lodestar/types";
 import {toHexString} from "@chainsafe/ssz";
 import {Api, BlockHeaderResponse, ValidatorResponse} from "../../../../src/beacon/routes/beacon/index.js";
 import {GenericServerTestCases} from "../../../utils/genericServerTest.js";
@@ -53,7 +53,7 @@ export const testData: GenericServerTestCases<Api> = {
     res: undefined,
   },
   publishBlindedBlock: {
-    args: [ssz.bellatrix.SignedBlindedBeaconBlock.defaultValue()],
+    args: [getDefaultBlindedBlock(64)],
     res: undefined,
   },
 
@@ -145,3 +145,9 @@ export const testData: GenericServerTestCases<Api> = {
     res: {data: ssz.phase0.Genesis.defaultValue()},
   },
 };
+
+function getDefaultBlindedBlock(slot: Slot): allForks.SignedBlindedBeaconBlock {
+  const block = ssz.bellatrix.SignedBlindedBeaconBlock.defaultValue();
+  block.message.slot = slot;
+  return block;
+}

--- a/packages/api/test/unit/builder/builder.test.ts
+++ b/packages/api/test/unit/builder/builder.test.ts
@@ -1,4 +1,4 @@
-import {config} from "@lodestar/config/default";
+import {createIChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {Api, ReqTypes} from "../../../src/builder/routes.js";
 import {getClient} from "../../../src/builder/client.js";
 import {getRoutes} from "../../../src/builder/server/index.js";
@@ -6,5 +6,11 @@ import {runGenericServerTest} from "../../utils/genericServerTest.js";
 import {testData} from "./testData.js";
 
 describe("builder", () => {
-  runGenericServerTest<Api, ReqTypes>(config, getClient, getRoutes, testData);
+  runGenericServerTest<Api, ReqTypes>(
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    createIChainForkConfig({...defaultChainConfig, ALTAIR_FORK_EPOCH: 0, BELLATRIX_FORK_EPOCH: 0}),
+    getClient,
+    getRoutes,
+    testData
+  );
 });

--- a/packages/api/test/unit/builder/oapiSpec.test.ts
+++ b/packages/api/test/unit/builder/oapiSpec.test.ts
@@ -1,5 +1,7 @@
 import path from "node:path";
 import {fileURLToPath} from "node:url";
+import {config} from "@lodestar/config/default";
+
 import {OpenApiFile} from "../../utils/parseOpenApiSpec.js";
 import {routesData, getReqSerializers, getReturnTypes} from "../../../src/builder/routes.js";
 import {runTestCheckAgainstSpec} from "../../utils/checkAgainstSpec.js";
@@ -20,7 +22,7 @@ const openApiFile: OpenApiFile = {
   version: RegExp(/.*/),
 };
 
-const reqSerializers = getReqSerializers();
+const reqSerializers = getReqSerializers(config);
 const returnTypes = getReturnTypes();
 
 const openApiJson = await fetchOpenApiSpec(openApiFile);

--- a/packages/api/test/unit/builder/oapiSpec.test.ts
+++ b/packages/api/test/unit/builder/oapiSpec.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import {fileURLToPath} from "node:url";
-import {config} from "@lodestar/config/default";
+import {createIChainForkConfig, defaultChainConfig} from "@lodestar/config";
 
 import {OpenApiFile} from "../../utils/parseOpenApiSpec.js";
 import {routesData, getReqSerializers, getReturnTypes} from "../../../src/builder/routes.js";
@@ -22,7 +22,10 @@ const openApiFile: OpenApiFile = {
   version: RegExp(/.*/),
 };
 
-const reqSerializers = getReqSerializers(config);
+const reqSerializers = getReqSerializers(
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  createIChainForkConfig({...defaultChainConfig, ALTAIR_FORK_EPOCH: 0, BELLATRIX_FORK_EPOCH: 0})
+);
 const returnTypes = getReturnTypes();
 
 const openApiJson = await fetchOpenApiSpec(openApiFile);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -12,7 +12,7 @@ import {
   PubkeyIndexMap,
 } from "@lodestar/state-transition";
 import {IBeaconConfig} from "@lodestar/config";
-import {allForks, bellatrix, UintNum64, Root, phase0, Slot, RootHex, Epoch, ValidatorIndex} from "@lodestar/types";
+import {allForks, UintNum64, Root, phase0, Slot, RootHex, Epoch, ValidatorIndex} from "@lodestar/types";
 import {CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {ProcessShutdownCallback} from "@lodestar/validator";
 import {ILogger, toHex} from "@lodestar/utils";
@@ -342,7 +342,7 @@ export class BeaconChain implements IBeaconChain {
     return this.produceBlockWrapper<BlockType.Full>(BlockType.Full, blockAttributes);
   }
 
-  async produceBlindedBlock(blockAttributes: BlockAttributes): Promise<bellatrix.BlindedBeaconBlock> {
+  async produceBlindedBlock(blockAttributes: BlockAttributes): Promise<allForks.BlindedBeaconBlock> {
     return this.produceBlockWrapper<BlockType.Blinded>(BlockType.Blinded, blockAttributes);
   }
 

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -1,4 +1,4 @@
-import {allForks, bellatrix, UintNum64, Root, phase0, Slot, RootHex, Epoch, ValidatorIndex} from "@lodestar/types";
+import {allForks, UintNum64, Root, phase0, Slot, RootHex, Epoch, ValidatorIndex} from "@lodestar/types";
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {IBeaconConfig} from "@lodestar/config";
 import {CompositeTypeAny, TreeView, Type} from "@chainsafe/ssz";
@@ -109,7 +109,7 @@ export interface IBeaconChain {
   getCanonicalBlockAtSlot(slot: Slot): Promise<allForks.SignedBeaconBlock | null>;
 
   produceBlock(blockAttributes: BlockAttributes): Promise<allForks.BeaconBlock>;
-  produceBlindedBlock(blockAttributes: BlockAttributes): Promise<bellatrix.BlindedBeaconBlock>;
+  produceBlindedBlock(blockAttributes: BlockAttributes): Promise<allForks.BlindedBeaconBlock>;
 
   /** Process a block until complete */
   processBlock(block: allForks.SignedBeaconBlock, opts?: ImportBlockOpts): Promise<void>;

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -49,10 +49,10 @@ export enum BlockType {
 }
 export type AssembledBodyType<T extends BlockType> = T extends BlockType.Full
   ? allForks.BeaconBlockBody
-  : bellatrix.BlindedBeaconBlockBody;
+  : allForks.BlindedBeaconBlockBody;
 export type AssembledBlockType<T extends BlockType> = T extends BlockType.Full
   ? allForks.BeaconBlock
-  : bellatrix.BlindedBeaconBlock;
+  : allForks.BlindedBeaconBlock;
 
 export async function produceBlockBody<T extends BlockType>(
   this: BeaconChain,
@@ -133,7 +133,7 @@ export async function produceBlockBody<T extends BlockType>(
       // For MeV boost integration, this is where the execution header will be
       // fetched from the payload id and a blinded block will be produced instead of
       // fullblock for the validator to sign
-      (blockBody as bellatrix.BlindedBeaconBlockBody).executionPayloadHeader = await prepareExecutionPayloadHeader(
+      (blockBody as allForks.BlindedBeaconBlockBody).executionPayloadHeader = await prepareExecutionPayloadHeader(
         this,
         currentState as CachedBeaconStateBellatrix,
         proposerPubKey

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -1,4 +1,4 @@
-import {bellatrix, Slot, Root, BLSPubkey, ssz} from "@lodestar/types";
+import {allForks, bellatrix, Slot, Root, BLSPubkey, ssz} from "@lodestar/types";
 import {IChainForkConfig} from "@lodestar/config";
 import {getClient, Api as BuilderApi} from "@lodestar/api/builder";
 import {byteArrayEquals, toHexString} from "@chainsafe/ssz";
@@ -56,7 +56,7 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
     return executionPayloadHeader;
   }
 
-  async submitBlindedBlock(signedBlock: bellatrix.SignedBlindedBeaconBlock): Promise<bellatrix.SignedBeaconBlock> {
+  async submitBlindedBlock(signedBlock: allForks.SignedBlindedBeaconBlock): Promise<allForks.SignedBeaconBlock> {
     const {data: executionPayload} = await this.api.submitBlindedBlock(signedBlock);
     const expectedTransactionsRoot = signedBlock.message.body.executionPayloadHeader.transactionsRoot;
     const actualTransactionsRoot = ssz.bellatrix.Transactions.hashTreeRoot(executionPayload.transactions);

--- a/packages/beacon-node/src/execution/builder/interface.ts
+++ b/packages/beacon-node/src/execution/builder/interface.ts
@@ -1,4 +1,4 @@
-import {bellatrix, Root, Slot, BLSPubkey} from "@lodestar/types";
+import {allForks, bellatrix, Root, Slot, BLSPubkey} from "@lodestar/types";
 
 export interface IExecutionBuilder {
   /**
@@ -12,5 +12,5 @@ export interface IExecutionBuilder {
   checkStatus(): Promise<void>;
   registerValidator(registrations: bellatrix.SignedValidatorRegistrationV1[]): Promise<void>;
   getHeader(slot: Slot, parentHash: Root, proposerPubKey: BLSPubkey): Promise<bellatrix.ExecutionPayloadHeader>;
-  submitBlindedBlock(signedBlock: bellatrix.SignedBlindedBeaconBlock): Promise<bellatrix.SignedBeaconBlock>;
+  submitBlindedBlock(signedBlock: allForks.SignedBlindedBeaconBlock): Promise<allForks.SignedBeaconBlock>;
 }

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -1,7 +1,7 @@
 import sinon from "sinon";
 
 import {CompositeTypeAny, toHexString, TreeView} from "@chainsafe/ssz";
-import {phase0, allForks, bellatrix, UintNum64, Root, Slot, ssz, Uint16, UintBn64} from "@lodestar/types";
+import {phase0, allForks, UintNum64, Root, Slot, ssz, Uint16, UintBn64} from "@lodestar/types";
 import {IBeaconConfig} from "@lodestar/config";
 import {BeaconStateAllForks, CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {CheckpointWithHex, IForkChoice, ProtoBlock, ExecutionStatus} from "@lodestar/fork-choice";
@@ -180,7 +180,7 @@ export class MockBeaconChain implements IBeaconChain {
   async produceBlock(_blockAttributes: BlockAttributes): Promise<allForks.BeaconBlock> {
     throw Error("Not implemented");
   }
-  async produceBlindedBlock(_blockAttributes: BlockAttributes): Promise<bellatrix.BlindedBeaconBlock> {
+  async produceBlindedBlock(_blockAttributes: BlockAttributes): Promise<allForks.BlindedBeaconBlock> {
     throw Error("Not implemented");
   }
 

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -66,5 +66,12 @@ export function createIForkConfig(config: IChainConfig): IForkConfig {
     getForkTypes(slot: Slot): allForks.AllForksSSZTypes {
       return ssz.allForks[this.getForkName(slot)] as allForks.AllForksSSZTypes;
     },
+    getBlindedForkTypes(slot: Slot): allForks.AllForksBlindedSSZTypes {
+      const forkName = this.getForkName(slot);
+      if (forkName === ForkName.phase0 || forkName === ForkName.altair) {
+        throw Error(`Invalid slot=${slot} fork=${forkName} for blinded fork types`);
+      }
+      return ssz.allForksBlinded[forkName] as allForks.AllForksBlindedSSZTypes;
+    },
   };
 }

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -31,4 +31,6 @@ export interface IForkConfig {
   getForkVersion(slot: Slot): Version;
   /** Get SSZ types by hard-fork */
   getForkTypes(slot: Slot): allForks.AllForksSSZTypes;
+  /** Get blinded SSZ types by hard-fork */
+  getBlindedForkTypes(slot: Slot): allForks.AllForksBlindedSSZTypes;
 }

--- a/packages/state-transition/src/block/processBlockHeader.ts
+++ b/packages/state-transition/src/block/processBlockHeader.ts
@@ -38,10 +38,12 @@ export function processBlockHeader(state: CachedBeaconStateAllForks, block: allF
 
   const blockHeader = blindedOrFullBlockToHeader(state.config, block as allForks.FullOrBlindedBeaconBlock);
   // cache current block as the new latest block
-  // TODO: do we need to ZERO_HASH the stateRoot here??
   state.latestBlockHeader = ssz.phase0.BeaconBlockHeader.toViewDU({
-    ...blockHeader,
+    slot,
+    proposerIndex,
+    parentRoot: block.parentRoot,
     stateRoot: ZERO_HASH,
+    bodyRoot: blockHeader.bodyRoot,
   });
 
   // verify proposer is not slashed. Only once per block, may use the slower read from tree

--- a/packages/state-transition/src/signatureSets/proposer.ts
+++ b/packages/state-transition/src/signatureSets/proposer.ts
@@ -1,5 +1,5 @@
 import {DOMAIN_BEACON_PROPOSER} from "@lodestar/params";
-import {allForks, ssz, isBlindedBeaconBlock} from "@lodestar/types";
+import {allForks, isBlindedBeaconBlock} from "@lodestar/types";
 import {computeSigningRoot} from "../util/index.js";
 import {ISignatureSet, SignatureSetType, verifySignatureSet} from "../util/signatureSets.js";
 import {CachedBeaconStateAllForks} from "../types.js";
@@ -20,7 +20,7 @@ export function getProposerSignatureSet(
   const domain = state.config.getDomain(state.slot, DOMAIN_BEACON_PROPOSER, signedBlock.message.slot);
 
   const blockType = isBlindedBeaconBlock(signedBlock.message)
-    ? ssz.bellatrix.BlindedBeaconBlock
+    ? config.getBlindedForkTypes(signedBlock.message.slot).BeaconBlock
     : config.getForkTypes(signedBlock.message.slot).BeaconBlock;
 
   return {

--- a/packages/state-transition/src/util/blindedBlock.ts
+++ b/packages/state-transition/src/util/blindedBlock.ts
@@ -1,5 +1,5 @@
 import {IChainForkConfig} from "@lodestar/config";
-import {allForks, phase0, Root, ssz, isBlindedBeaconBlock} from "@lodestar/types";
+import {allForks, phase0, Root, isBlindedBeaconBlock} from "@lodestar/types";
 
 export function blindedOrFullBlockHashTreeRoot(
   config: IChainForkConfig,
@@ -7,7 +7,7 @@ export function blindedOrFullBlockHashTreeRoot(
 ): Root {
   return isBlindedBeaconBlock(blindedOrFull)
     ? // Blinded
-      ssz.bellatrix.BlindedBeaconBlock.hashTreeRoot(blindedOrFull)
+      config.getBlindedForkTypes(blindedOrFull.slot).BeaconBlock.hashTreeRoot(blindedOrFull)
     : // Full
       config.getForkTypes(blindedOrFull.slot).BeaconBlock.hashTreeRoot(blindedOrFull);
 }
@@ -18,7 +18,7 @@ export function blindedOrFullBlockToHeader(
 ): phase0.BeaconBlockHeader {
   const bodyRoot = isBlindedBeaconBlock(blindedOrFull)
     ? // Blinded
-      ssz.bellatrix.BlindedBeaconBlockBody.hashTreeRoot(blindedOrFull.body)
+      config.getBlindedForkTypes(blindedOrFull.slot).BeaconBlockBody.hashTreeRoot(blindedOrFull.body)
     : // Full
       config.getForkTypes(blindedOrFull.slot).BeaconBlockBody.hashTreeRoot(blindedOrFull.body);
 

--- a/packages/state-transition/src/util/index.ts
+++ b/packages/state-transition/src/util/index.ts
@@ -21,3 +21,4 @@ export * from "./slot.js";
 export * from "./syncCommittee.js";
 export * from "./validator.js";
 export * from "./weakSubjectivity.js";
+export * from "./blindedBlock.js";

--- a/packages/types/src/allForks/sszTypes.ts
+++ b/packages/types/src/allForks/sszTypes.ts
@@ -29,3 +29,15 @@ export const allForks = {
     Metadata: altair.Metadata,
   },
 };
+
+/**
+ * Index the ssz types that differ by fork
+ * A record of AllForksSSZTypes indexed by fork
+ */
+export const allForksBlinded = {
+  bellatrix: {
+    BeaconBlockBody: bellatrix.BlindedBeaconBlockBody,
+    BeaconBlock: bellatrix.BlindedBeaconBlock,
+    SignedBeaconBlock: bellatrix.SignedBlindedBeaconBlock,
+  },
+};

--- a/packages/types/src/allForks/types.ts
+++ b/packages/types/src/allForks/types.ts
@@ -14,6 +14,21 @@ export type SignedBeaconBlock = phase0.SignedBeaconBlock | altair.SignedBeaconBl
 export type BeaconState = phase0.BeaconState | altair.BeaconState | bellatrix.BeaconState;
 export type Metadata = phase0.Metadata | altair.Metadata;
 
+// These two additional types will also change bellatrix forward
+export type ExecutionPayload = bellatrix.ExecutionPayload;
+export type ExecutionPayloadHeader = bellatrix.ExecutionPayloadHeader;
+
+// Blinded types that will change across forks
+export type BlindedBeaconBlockBody = bellatrix.BlindedBeaconBlockBody;
+export type BlindedBeaconBlock = bellatrix.BlindedBeaconBlock;
+export type SignedBlindedBeaconBlock = bellatrix.SignedBlindedBeaconBlock;
+
+// Full or blinded types
+export type FullOrBlindedExecutionPayload = ExecutionPayload | ExecutionPayloadHeader;
+export type FullOrBlindedBeaconBlockBody = BeaconBlockBody | BlindedBeaconBlockBody;
+export type FullOrBlindedBeaconBlock = BeaconBlock | BlindedBeaconBlock;
+export type FullOrBlindedSignedBeaconBlock = SignedBeaconBlock | SignedBlindedBeaconBlock;
+
 /**
  * Types known to change between forks
  */
@@ -23,6 +38,12 @@ export type AllForksTypes = {
   SignedBeaconBlock: SignedBeaconBlock;
   BeaconState: BeaconState;
   Metadata: Metadata;
+};
+
+export type AllForksBlindedTypes = {
+  BeaconBlockBody: BlindedBeaconBlockBody;
+  BeaconBlock: BlindedBeaconBlock;
+  SignedBeaconBlock: SignedBlindedBeaconBlock;
 };
 
 /**
@@ -70,6 +91,8 @@ export type AllForksSSZTypes = {
   Metadata: AllForksTypeOf<typeof phase0Ssz.Metadata | typeof altairSsz.Metadata>;
 };
 
-export type FullOrBlindedExecutionPayload = bellatrix.ExecutionPayload | bellatrix.ExecutionPayloadHeader;
-export type FullOrBlindedBeaconBlock = BeaconBlock | bellatrix.BlindedBeaconBlock;
-export type FullOrBlindedSignedBeaconBlock = SignedBeaconBlock | bellatrix.SignedBlindedBeaconBlock;
+export type AllForksBlindedSSZTypes = {
+  BeaconBlockBody: AllForksTypeOf<typeof bellatrixSsz.BlindedBeaconBlockBody>;
+  BeaconBlock: AllForksTypeOf<typeof bellatrixSsz.BlindedBeaconBlock>;
+  SignedBeaconBlock: AllForksTypeOf<typeof bellatrixSsz.SignedBlindedBeaconBlock>;
+};

--- a/packages/types/src/sszTypes.ts
+++ b/packages/types/src/sszTypes.ts
@@ -5,3 +5,4 @@ export {ssz as bellatrix} from "./bellatrix/index.js";
 
 import {ssz as allForksSsz} from "./allForks/index.js";
 export const allForks = allForksSsz.allForks;
+export const allForksBlinded = allForksSsz.allForksBlinded;

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -4,6 +4,7 @@ import {
   computeStartSlotAtEpoch,
   computeDomain,
   ZERO_HASH,
+  blindedOrFullBlockHashTreeRoot,
 } from "@lodestar/state-transition";
 import {IBeaconConfig} from "@lodestar/config";
 import {
@@ -38,7 +39,6 @@ import {ISlashingProtection} from "../slashingProtection/index.js";
 import {PubkeyHex} from "../types.js";
 import {externalSignerPostSignature, SignableMessageType, SignableMessage} from "../util/externalSignerClient.js";
 import {Metrics} from "../metrics.js";
-import {blindedOrFullBlockHashTreeRoot} from "../util/blindedBlock.js";
 import {isValidatePubkeyHex} from "../util/format.js";
 import {IndicesService} from "./indices.js";
 import {DoppelgangerService} from "./doppelgangerService.js";

--- a/packages/validator/src/util/externalSignerClient.ts
+++ b/packages/validator/src/util/externalSignerClient.ts
@@ -3,11 +3,10 @@ import {phase0, altair} from "@lodestar/types";
 import {ForkSeq} from "@lodestar/params";
 import {ValidatorRegistrationV1} from "@lodestar/types/bellatrix";
 import {IBeaconConfig} from "@lodestar/config";
-import {computeEpochAtSlot} from "@lodestar/state-transition";
+import {computeEpochAtSlot, blindedOrFullBlockToHeader} from "@lodestar/state-transition";
 import {allForks, Epoch, Root, RootHex, Slot, ssz} from "@lodestar/types";
 import {ContainerType, toHexString, ValueOf} from "@chainsafe/ssz";
 import {PubkeyHex} from "../types.js";
-import {blindedOrFullBlockToHeader} from "./blindedBlock.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 


### PR DESCRIPTION
The blinded types currently used (for dev simplicity) are only of `bellatrix`

This PR overhauls blinded types into multi-fork in preparation for the `capella` hardfork
