### PR TITLE
Fix computed db checkpoint for weak subjectivity checks

### DIFF
--- a/packages/beacon-node/src/chain/initState.ts
+++ b/packages/beacon-node/src/chain/initState.ts
@@ -3,12 +3,12 @@ import {
   computeEpochAtSlot,
   BeaconStateAllForks,
   CachedBeaconStateAllForks,
+  computeCheckpointEpochAtStateSlot,
 } from "@lodestar/state-transition";
 import {phase0, allForks, ssz} from "@lodestar/types";
 import {IChainForkConfig} from "@lodestar/config";
 import {ILogger} from "@lodestar/utils";
 import {toHexString} from "@chainsafe/ssz";
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {GENESIS_SLOT, ZERO_HASH} from "../constants/index.js";
 import {IBeaconDb} from "../db/index.js";
 import {Eth1Provider} from "../eth1/index.js";
@@ -223,7 +223,7 @@ export function computeAnchorCheckpoint(
       root,
       // the checkpoint epoch = computeEpochAtSlot(anchorState.slot) + 1 if slot is not at epoch boundary
       // this is similar to a process_slots() call
-      epoch: Math.ceil(anchorState.slot / SLOTS_PER_EPOCH),
+      epoch: computeCheckpointEpochAtStateSlot(anchorState.slot),
     },
     blockHeader,
   };

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -26,7 +26,7 @@ export function getCheckpointFromState(state: BeaconStateAllForks): Checkpoint {
   return {
     // the correct checkpoint is based on state's slot, its latestBlockHeader's slot's epoch can be
     // behind the state
-    epoch: computeCheckpointEpochAtStateSlot(state.slot / SLOTS_PER_EPOCH),
+    epoch: computeCheckpointEpochAtStateSlot(state.slot),
     root: getLatestBlockRoot(state),
   };
 }

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -1,12 +1,7 @@
 import {ssz} from "@lodestar/types";
 import {createIBeaconConfig, IBeaconConfig, IChainForkConfig} from "@lodestar/config";
 import {ILogger} from "@lodestar/utils";
-import {
-  computeEpochAtSlot,
-  getLatestBlockRoot,
-  isWithinWeakSubjectivityPeriod,
-  BeaconStateAllForks,
-} from "@lodestar/state-transition";
+import {getLatestBlockRoot, isWithinWeakSubjectivityPeriod, BeaconStateAllForks} from "@lodestar/state-transition";
 import {
   IBeaconDb,
   IBeaconNodeOptions,
@@ -15,6 +10,7 @@ import {
   getStateTypeFromBytes,
 } from "@lodestar/beacon-node";
 import {Checkpoint} from "@lodestar/types/phase0";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
 
 import {downloadOrLoadFile} from "../../util/index.js";
 import {defaultNetwork, IGlobalArgs} from "../../options/globalOptions.js";
@@ -23,7 +19,9 @@ import {IBeaconArgs} from "./options.js";
 
 export function getCheckpointFromState(state: BeaconStateAllForks): Checkpoint {
   return {
-    epoch: computeEpochAtSlot(state.latestBlockHeader.slot),
+    // the correct checkpoint is based on state's slot, its latestBlockHeader's slot's epoch can be
+    // behind the state
+    epoch: Math.ceil(state.slot / SLOTS_PER_EPOCH),
     root: getLatestBlockRoot(state),
   };
 }

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -15,7 +15,6 @@ import {
   getStateTypeFromBytes,
 } from "@lodestar/beacon-node";
 import {Checkpoint} from "@lodestar/types/phase0";
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
 
 import {downloadOrLoadFile} from "../../util/index.js";
 import {defaultNetwork, IGlobalArgs} from "../../options/globalOptions.js";

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -1,7 +1,12 @@
 import {ssz} from "@lodestar/types";
 import {createIBeaconConfig, IBeaconConfig, IChainForkConfig} from "@lodestar/config";
 import {ILogger} from "@lodestar/utils";
-import {getLatestBlockRoot, isWithinWeakSubjectivityPeriod, BeaconStateAllForks} from "@lodestar/state-transition";
+import {
+  getLatestBlockRoot,
+  isWithinWeakSubjectivityPeriod,
+  BeaconStateAllForks,
+  computeCheckpointEpochAtStateSlot,
+} from "@lodestar/state-transition";
 import {
   IBeaconDb,
   IBeaconNodeOptions,
@@ -21,7 +26,7 @@ export function getCheckpointFromState(state: BeaconStateAllForks): Checkpoint {
   return {
     // the correct checkpoint is based on state's slot, its latestBlockHeader's slot's epoch can be
     // behind the state
-    epoch: Math.ceil(state.slot / SLOTS_PER_EPOCH),
+    epoch: computeCheckpointEpochAtStateSlot(state.slot / SLOTS_PER_EPOCH),
     root: getLatestBlockRoot(state),
   };
 }

--- a/packages/state-transition/src/util/epoch.ts
+++ b/packages/state-transition/src/util/epoch.ts
@@ -9,6 +9,16 @@ export function computeEpochAtSlot(slot: Slot): Epoch {
 }
 
 /**
+ * Return the epoch at the state slot for purposes of checkpoint.
+ * Ideally this slot % SLOTS_PER_EPOCH === 0, but just to handle the improbable case of
+ * non boundary slot, using ceil so that the state's latestBlockHeader would always
+ * lie before this epooch
+ */
+export function computeCheckpointEpochAtStateSlot(slot: Slot): Epoch {
+  return Math.ceil(slot / SLOTS_PER_EPOCH);
+}
+
+/**
  * Return the starting slot of the given epoch.
  */
 export function computeStartSlotAtEpoch(epoch: Epoch): Slot {

--- a/packages/state-transition/src/util/weakSubjectivity.ts
+++ b/packages/state-transition/src/util/weakSubjectivity.ts
@@ -6,7 +6,7 @@ import {Checkpoint} from "@lodestar/types/phase0";
 import {toHexString} from "@chainsafe/ssz";
 import {ZERO_HASH} from "../constants/constants.js";
 import {CachedBeaconStateAllForks, BeaconStateAllForks} from "../types.js";
-import {computeEpochAtSlot, getCurrentEpoch} from "./epoch.js";
+import {computeEpochAtSlot, getCurrentEpoch, computeCheckpointEpochAtStateSlot} from "./epoch.js";
 import {getCurrentSlot} from "./slot.js";
 import {getActiveValidatorIndices, getChurnLimit} from "./validator.js";
 
@@ -111,7 +111,7 @@ export function isWithinWeakSubjectivityPeriod(
   wsState: BeaconStateAllForks,
   wsCheckpoint: Checkpoint
 ): boolean {
-  const wsStateEpoch = Math.ceil(wsState.slot / SLOTS_PER_EPOCH);
+  const wsStateEpoch = computeCheckpointEpochAtStateSlot(wsState.slot);
   const blockRoot = getLatestBlockRoot(wsState);
   if (!ssz.Root.equals(blockRoot, wsCheckpoint.root)) {
     throw new Error(

--- a/packages/state-transition/src/util/weakSubjectivity.ts
+++ b/packages/state-transition/src/util/weakSubjectivity.ts
@@ -111,7 +111,7 @@ export function isWithinWeakSubjectivityPeriod(
   wsState: BeaconStateAllForks,
   wsCheckpoint: Checkpoint
 ): boolean {
-  const wsStateEpoch = computeEpochAtSlot(wsState.slot);
+  const wsStateEpoch = Math.ceil(wsState.slot / SLOTS_PER_EPOCH);
   const blockRoot = getLatestBlockRoot(wsState);
   if (!ssz.Root.equals(blockRoot, wsCheckpoint.root)) {
     throw new Error(


### PR DESCRIPTION
**Motivation**
The checkpoint computed from db state for weak subjetcivity checks is wrongly based on its latestBlockHeader's slot's epoch
which causes a mismatch while comparing epochs in `isWithinWeakSubjectivityPeriod` and can cause a restarted node to be stuck if the last state written's latestBlockHeader's slot doesn't align

This PR fixes the calculation of a state's checkpoint epoch
