### PR TITLE
Revert PR 4487: Do not set udp in enr

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -145,7 +145,9 @@ export async function beaconHandlerInit(args: IBeaconArgs & IGlobalArgs) {
 export function overwriteEnrWithCliArgs(enr: ENR, args: IBeaconArgs): void {
   // TODO: Not sure if we should propagate this options to the ENR
   if (args.port != null) enr.tcp = args.port;
-  if (args.port != null) enr.udp = args.port;
+  // TODO: reenable this once we fix the below discv5 issue
+  // See https://github.com/ChainSafe/discv5/issues/201
+  // if (args.port != null) enr.udp = args.port;
   if (args.discoveryPort != null) enr.udp = args.discoveryPort;
 
   if (args["enr.ip"] != null) enr.ip = args["enr.ip"];


### PR DESCRIPTION
**Motivation**

A work around to avoid the external memory issue in discv5, see https://github.com/ChainSafe/discv5/issues/201

**Description**

- Do not set udp in enr
- Need to apply the same thing to unstable

