### PR TITLE
Start network before sync

### DIFF
--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -189,6 +189,11 @@ export class BeaconNode {
       reqRespHandlers: getReqRespHandlers({db, chain}),
       signal,
     });
+
+    // Network needs to start before the sync
+    // See https://github.com/ChainSafe/lodestar/issues/4543
+    await network.start();
+
     const sync = new BeaconSync(opts.sync, {
       config,
       db,
@@ -243,8 +248,6 @@ export class BeaconNode {
     if (opts.api.rest.enabled) {
       await restApi.listen();
     }
-
-    await network.start();
 
     void runNodeNotifier({network, chain, sync, config, logger, signal});
 


### PR DESCRIPTION
**Motivation**

Sometimes the sync is too fast and it tries to subscribe to core topics while network is not ready

**Description**

Start network before sync

Closes #4543

