### PR TITLE
Implement forkchoice equivocating validators

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -141,6 +141,15 @@ export async function importBlock(
     }
   }
 
+  for (const slashing of block.message.body.attesterSlashings) {
+    try {
+      // all AttesterSlashings are valid before reaching this
+      this.forkChoice.onAttesterSlashing(slashing);
+    } catch (e) {
+      this.logger.warn("Error processing AttesterSlashing from block", {slot: block.message.slot}, e as Error);
+    }
+  }
+
   // - Write block and state to hot db
   // - Write block and state to snapshot_cache
   if (block.message.slot % SLOTS_PER_EPOCH === 0) {

--- a/packages/beacon-node/src/network/gossip/handlers/index.ts
+++ b/packages/beacon-node/src/network/gossip/handlers/index.ts
@@ -215,6 +215,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
 
       try {
         chain.opPool.insertAttesterSlashing(attesterSlashing);
+        chain.forkChoice.onAttesterSlashing(attesterSlashing);
       } catch (e) {
         logger.error("Error adding attesterSlashing to pool", {}, e as Error);
       }

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -118,6 +118,7 @@ describe("getAttestationsForBlock", () => {
       finalizedCheckpoint: {...finalizedCheckpoint, rootHex: toHexString(finalizedCheckpoint.root)},
       unrealizedFinalizedCheckpoint: {...finalizedCheckpoint, rootHex: toHexString(finalizedCheckpoint.root)},
       justifiedBalancesGetter: () => originalState.epochCtx.effectiveBalanceIncrements,
+      equivocatingIndices: new Set(),
     };
     forkchoice = new ForkChoice(originalState.config, fcStore, protoArray);
   });

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -262,6 +262,7 @@ function mockForkChoice(): IForkChoice {
     getJustifiedCheckpoint: () => checkpoint,
     onBlock: () => {},
     onAttestation: () => {},
+    onAttesterSlashing: () => {},
     getLatestMessage: () => undefined,
     updateTime: () => {},
     getTime: () => 0,

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -556,7 +556,6 @@ export class ForkChoice implements IForkChoice {
   onAttesterSlashing(attesterSlashing: phase0.AttesterSlashing): void {
     // TODO: we already call in in state-transition, find a way not to recompute it again
     const intersectingIndices = getAttesterSlashableIndices(attesterSlashing);
-    // TODO: restore equivocatingIndices upon restart
     intersectingIndices.forEach((validatorIndex) => this.fcStore.equivocatingIndices.add(validatorIndex));
   }
 

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -97,6 +97,14 @@ export interface IForkChoice {
    * will not be run here.
    */
   onAttestation(attestation: phase0.IndexedAttestation, attDataRoot?: string): void;
+  /**
+   * Register attester slashing in order not to consider their votes in `getHead`
+   *
+   * ## Specification
+   *
+   * https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/fork-choice.md#on_attester_slashing
+   */
+  onAttesterSlashing(slashing: phase0.AttesterSlashing): void;
   getLatestMessage(validatorIndex: ValidatorIndex): LatestMessage | undefined;
   /**
    * Call `onTick` for all slots between `fcStore.getCurrentSlot()` and the provided `currentSlot`.

--- a/packages/fork-choice/src/forkChoice/store.ts
+++ b/packages/fork-choice/src/forkChoice/store.ts
@@ -1,5 +1,5 @@
 import {EffectiveBalanceIncrements, CachedBeaconStateAllForks} from "@lodestar/state-transition";
-import {phase0, Slot, RootHex} from "@lodestar/types";
+import {phase0, Slot, RootHex, ValidatorIndex} from "@lodestar/types";
 import {toHexString} from "@chainsafe/ssz";
 import {CheckpointHexWithBalance} from "./interface.js";
 
@@ -43,6 +43,7 @@ export interface IForkChoiceStore {
   finalizedCheckpoint: CheckpointWithHex;
   unrealizedFinalizedCheckpoint: CheckpointWithHex;
   justifiedBalancesGetter: JustifiedBalancesGetter;
+  equivocatingIndices: Set<ValidatorIndex>;
 }
 
 /* eslint-disable @typescript-eslint/naming-convention, @typescript-eslint/member-ordering */
@@ -56,6 +57,7 @@ export class ForkChoiceStore implements IForkChoiceStore {
   unrealizedJustified: CheckpointHexWithBalance;
   private _finalizedCheckpoint: CheckpointWithHex;
   unrealizedFinalizedCheckpoint: CheckpointWithHex;
+  equivocatingIndices = new Set<ValidatorIndex>();
 
   constructor(
     public currentSlot: Slot,

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -156,12 +156,6 @@ export class ProtoArray {
           ? -node.weight
           : deltas[nodeIndex] + currentBoost - previousBoost;
 
-      if (nodeDelta === undefined) {
-        throw new ProtoArrayError({
-          code: ProtoArrayErrorCode.INVALID_NODE_DELTA,
-          index: nodeIndex,
-        });
-      }
       // Apply the delta to the node
       node.weight += nodeDelta;
 

--- a/packages/fork-choice/test/perf/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/perf/forkChoice/forkChoice.test.ts
@@ -58,6 +58,7 @@ describe("ForkChoice", () => {
       finalizedCheckpoint: {epoch: genesisEpoch, root: fromHexString(finalizedRoot), rootHex: finalizedRoot},
       unrealizedFinalizedCheckpoint: {epoch: genesisEpoch, root: fromHexString(finalizedRoot), rootHex: finalizedRoot},
       justifiedBalancesGetter: () => balances,
+      equivocatingIndices: new Set(),
     };
 
     forkchoice = new ForkChoice(config, fcStore, protoArr);

--- a/packages/fork-choice/test/perf/protoArray/computeDeltas.test.ts
+++ b/packages/fork-choice/test/perf/protoArray/computeDeltas.test.ts
@@ -84,7 +84,7 @@ describe("computeDeltas", () => {
       return votes;
     },
     fn: (votes) => {
-      computeDeltas(indices, votes, oldBalances, newBalances);
+      computeDeltas(indices, votes, oldBalances, newBalances, new Set());
     },
   });
 

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -63,6 +63,7 @@ describe("Forkchoice", function () {
     finalizedCheckpoint: {epoch: genesisEpoch, root: fromHexString(finalizedRoot), rootHex: finalizedRoot},
     unrealizedFinalizedCheckpoint: {epoch: genesisEpoch, root: fromHexString(finalizedRoot), rootHex: finalizedRoot},
     justifiedBalancesGetter: () => new Uint8Array([32]),
+    equivocatingIndices: new Set(),
   };
 
   const getParentBlockRoot = (slot: number, skippedSlots: number[] = []): RootHex => {


### PR DESCRIPTION
**Motivation**

We want to disregard equivocating validators, see https://github.com/ethereum/consensus-specs/pull/2845

**Description**

- Handle onAttesterSlashing in forkchoice
- Call it when importing a block or gossip
- Make sure spec tests passed

Closes #4303

**TODO**

- [x] Right now upon restart, we fetch all slashed validators as equivocating indices, need to clarify that => we don't have any attestations initially and node has to resync so `equivocating_indices` should be built up through syncing
- [x] Do we need onProposerSlashing() handler in forkchoice? => no need since that validator could be active for a while and its attestation is still valid, after that when it's not active it's not part of the committee