### PR TITLE
Slow down the dynamic batch size recovery for eth1 deposit tracker

### DIFF
--- a/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts
+++ b/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts
@@ -223,7 +223,11 @@ export class Eth1DepositDataTracker {
     let depositEvents;
     try {
       depositEvents = await this.eth1Provider.getDepositEvents(fromBlock, toBlock);
-      this.eth1GetLogsBatchSizeDynamic = Math.min(MAX_BLOCKS_PER_LOG_QUERY, this.eth1GetLogsBatchSizeDynamic * 2);
+      // Increase the batch size linearly even if we scale down exponentioanlly (half each time)
+      this.eth1GetLogsBatchSizeDynamic = Math.min(
+        MAX_BLOCKS_PER_LOG_QUERY,
+        this.eth1GetLogsBatchSizeDynamic + MIN_BLOCKS_PER_LOG_QUERY
+      );
     } catch (e) {
       if (isJsonRpcTruncatedError(e as Error) || e instanceof TimeoutError) {
         this.eth1GetLogsBatchSizeDynamic = Math.max(
@@ -289,7 +293,11 @@ export class Eth1DepositDataTracker {
     let blocksRaw;
     try {
       blocksRaw = await this.eth1Provider.getBlocksByNumber(fromBlock, toBlock);
-      this.eth1GetBlocksBatchSizeDynamic = Math.min(MAX_BLOCKS_PER_BLOCK_QUERY, this.eth1GetBlocksBatchSizeDynamic * 2);
+      // Increase the batch size linearly even if we scale down exponentioanlly (half each time)
+      this.eth1GetBlocksBatchSizeDynamic = Math.min(
+        MAX_BLOCKS_PER_BLOCK_QUERY,
+        this.eth1GetBlocksBatchSizeDynamic + MIN_BLOCKS_PER_BLOCK_QUERY
+      );
     } catch (e) {
       if (isJsonRpcTruncatedError(e as Error) || e instanceof TimeoutError) {
         this.eth1GetBlocksBatchSizeDynamic = Math.max(

--- a/packages/beacon-node/test/unit/eth1/eth1DepositDataTracker.test.ts
+++ b/packages/beacon-node/test/unit/eth1/eth1DepositDataTracker.test.ts
@@ -61,8 +61,9 @@ describe("Eth1DepositDataTracker", function () {
     expect(expectedSize).to.be.equal(10);
 
     getBlocksByNumberStub.resolves([]);
-    for (let i = 0; i < 10; i++) {
-      expectedSize = Math.min(expectedSize * 2, 1000);
+    // Should take a whole longer to get back to the orignal batch size
+    for (let i = 0; i < 100; i++) {
+      expectedSize = Math.min(expectedSize + 10, 1000);
       await eth1DepositDataTracker["updateBlockCache"](3000);
       expect(eth1DepositDataTracker["eth1GetBlocksBatchSizeDynamic"]).to.be.equal(expectedSize);
     }
@@ -83,8 +84,9 @@ describe("Eth1DepositDataTracker", function () {
     expect(expectedSize).to.be.equal(10);
 
     getDepositEventsStub.resolves([]);
-    for (let i = 0; i < 10; i++) {
-      expectedSize = Math.min(expectedSize * 2, 1000);
+    // Should take a whole longer to get back to the orignal batch size
+    for (let i = 0; i < 100; i++) {
+      expectedSize = Math.min(expectedSize + 10, 1000);
       await eth1DepositDataTracker["updateDepositCache"](3000);
       expect(eth1DepositDataTracker["eth1GetLogsBatchSizeDynamic"]).to.be.equal(expectedSize);
     }


### PR DESCRIPTION
**Motivation**
Rather than increasing the batch size back exponentially (2x on each successful fetch), increase it linearly and slowly to give EL more space to recover when choked (could be doing some internal maintenance for e.g)

This PR slows down the dynamic batch size recovery for eth1 deposit tracker by only incrementing batch size linearly while the decrease is still exponential.