### PR TITLE
gossip attestation validation: handle no committee error

### DIFF
--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -85,18 +85,7 @@ export async function validateGossipAggregateAndProof(
       });
     });
 
-  let committeeIndices: number[];
-  try {
-    committeeIndices = getCommitteeIndices(attHeadState, attSlot, attIndex);
-  } catch (e) {
-    // this may come from an out-of-synced node, the spec did not define it so should not REJECT
-    // see https://github.com/ChainSafe/lodestar/issues/4396
-    throw new AttestationError(GossipAction.IGNORE, {
-      code: AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX,
-      index: attIndex,
-      slot: attSlot,
-    });
-  }
+  const committeeIndices: number[] = getCommitteeIndices(attHeadState, attSlot, attIndex);
 
   const attestingIndices = aggregate.aggregationBits.intersectValues(committeeIndices);
   const indexedAttestation: phase0.IndexedAttestation = {

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -89,7 +89,9 @@ export async function validateGossipAggregateAndProof(
   try {
     committeeIndices = getCommitteeIndices(attHeadState, attSlot, attIndex);
   } catch (e) {
-    throw new AttestationError(GossipAction.REJECT, {
+    // this may come from an out-of-synced node, the spec did not define it so should not REJECT
+    // see https://github.com/ChainSafe/lodestar/issues/4396
+    throw new AttestationError(GossipAction.IGNORE, {
       code: AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX,
       index: attIndex,
       slot: attSlot,

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -88,7 +88,17 @@ export async function validateGossipAttestation(
   // [REJECT] The committee index is within the expected range
   // -- i.e. data.index < get_committee_count_per_slot(state, data.target.epoch)
   const attIndex = attData.index;
-  const committeeIndices = getCommitteeIndices(attHeadState, attSlot, attIndex);
+  let committeeIndices: number[];
+  try {
+    committeeIndices = getCommitteeIndices(attHeadState, attSlot, attIndex);
+  } catch (e) {
+    throw new AttestationError(GossipAction.REJECT, {
+      code: AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX,
+      index: attIndex,
+      slot: attSlot,
+    });
+  }
+
   const validatorIndex = committeeIndices[bitIndex];
 
   // [REJECT] The number of aggregation bits matches the committee size

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -88,18 +88,7 @@ export async function validateGossipAttestation(
   // [REJECT] The committee index is within the expected range
   // -- i.e. data.index < get_committee_count_per_slot(state, data.target.epoch)
   const attIndex = attData.index;
-  let committeeIndices: number[];
-  try {
-    committeeIndices = getCommitteeIndices(attHeadState, attSlot, attIndex);
-  } catch (e) {
-    // this may come from an out-of-synced node, the spec did not define it so should not REJECT
-    // see https://github.com/ChainSafe/lodestar/issues/4396
-    throw new AttestationError(GossipAction.IGNORE, {
-      code: AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX,
-      index: attIndex,
-      slot: attSlot,
-    });
-  }
+  const committeeIndices = getCommitteeIndices(attHeadState, attSlot, attIndex);
 
   const validatorIndex = committeeIndices[bitIndex];
 
@@ -296,7 +285,18 @@ export function getCommitteeIndices(
   attestationSlot: Slot,
   attestationIndex: number
 ): number[] {
-  const {committees} = attestationTargetState.epochCtx.getShufflingAtSlot(attestationSlot);
+  const shuffling = attestationTargetState.epochCtx.getShufflingAtSlotOrNull(attestationSlot);
+  if (shuffling === null) {
+    // this may come from an out-of-synced node, the spec did not define it so should not REJECT
+    // see https://github.com/ChainSafe/lodestar/issues/4396
+    throw new AttestationError(GossipAction.IGNORE, {
+      code: AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX,
+      index: attestationIndex,
+      slot: attestationSlot,
+    });
+  }
+
+  const {committees} = shuffling;
   const slotCommittees = committees[attestationSlot % SLOTS_PER_EPOCH];
 
   if (attestationIndex >= slotCommittees.length) {

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -92,7 +92,9 @@ export async function validateGossipAttestation(
   try {
     committeeIndices = getCommitteeIndices(attHeadState, attSlot, attIndex);
   } catch (e) {
-    throw new AttestationError(GossipAction.REJECT, {
+    // this may come from an out-of-synced node, the spec did not define it so should not REJECT
+    // see https://github.com/ChainSafe/lodestar/issues/4396
+    throw new AttestationError(GossipAction.IGNORE, {
       code: AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX,
       index: attIndex,
       slot: attSlot,

--- a/packages/beacon-node/src/network/gossip/validation/index.ts
+++ b/packages/beacon-node/src/network/gossip/validation/index.ts
@@ -88,7 +88,8 @@ function getGossipValidatorFn<K extends GossipType>(
       return MessageAcceptance.Accept;
     } catch (e) {
       if (!(e instanceof GossipActionError)) {
-        logger.error(`Gossip validation ${type} threw a non-GossipActionError`, {}, e as Error);
+        // not deserve to log error here, it looks too dangerous to users
+        logger.debug(`Gossip validation ${type} threw a non-GossipActionError`, {}, e as Error);
         return MessageAcceptance.Ignore;
       }
 

--- a/packages/state-transition/src/cache/epochContext.ts
+++ b/packages/state-transition/src/cache/epochContext.ts
@@ -709,7 +709,21 @@ export class EpochContext {
     return this.getShufflingAtEpoch(epoch);
   }
 
+  getShufflingAtSlotOrNull(slot: Slot): IEpochShuffling | null {
+    const epoch = computeEpochAtSlot(slot);
+    return this.getShufflingAtEpochOrNull(epoch);
+  }
+
   getShufflingAtEpoch(epoch: Epoch): IEpochShuffling {
+    const shuffling = this.getShufflingAtEpochOrNull(epoch);
+    if (shuffling === null) {
+      throw new Error(`Requesting slot committee out of range epoch: ${epoch} current: ${this.currentShuffling.epoch}`);
+    }
+
+    return shuffling;
+  }
+
+  getShufflingAtEpochOrNull(epoch: Epoch): IEpochShuffling | null {
     if (epoch === this.previousShuffling.epoch) {
       return this.previousShuffling;
     } else if (epoch === this.currentShuffling.epoch) {
@@ -717,7 +731,7 @@ export class EpochContext {
     } else if (epoch === this.nextShuffling.epoch) {
       return this.nextShuffling;
     } else {
-      throw new Error(`Requesting slot committee out of range epoch: ${epoch} current: ${this.currentShuffling.epoch}`);
+      return null;
     }
   }
 


### PR DESCRIPTION
**Motivation**

When an attestation came from an out of synced node, our logs look like:
```
Aug-11 02:29:41.278[NETWORK]         error: Gossip validation beacon_attestation threw a non-GossipActionError  Requesting slot committee out of range epoch: 113742 current: 113740
Error: Requesting slot committee out of range epoch: 113742 current: 113740
    at EpochContext.getShufflingAtEpoch (file:///usr/app/node_modules/@lodestar/state-transition/src/cache/epochContext.ts:720:13)
    at EpochContext.getShufflingAtSlot (file:///usr/app/node_modules/@lodestar/state-transition/src/cache/epochContext.ts:709:17)
    at getCommitteeIndices (file:///usr/app/node_modules/@lodestar/beacon-node/src/chain/validation/attestation.ts:287:56)
    at validateGossipAttestation (file:///usr/app/node_modules/@lodestar/beacon-node/src/chain/validation/attestation.ts:91:28)
    at runMicrotasks (<anonymous>)
```
Two issues here:
- the log look dangerous to the user
- we did not handle no committee error well, and we treated this case as `IGNORE` instead of `REJECT`

**Description**

- Handle the no committee scenario in gossip attestation/aggregateAndProof validation: return `REJECT` to gossipsub
- Correct log level just in case we got non-attestation errors

Closes #4396
