### PR TITLE
Do not set udp to enr

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -149,7 +149,8 @@ export async function beaconHandlerInit(args: IBeaconArgs & IGlobalArgs) {
 export function overwriteEnrWithCliArgs(enr: ENR, args: IBeaconArgs): void {
   // TODO: Not sure if we should propagate this options to the ENR
   if (args.port != null) enr.tcp = args.port;
-  if (args.port != null) enr.udp = args.port;
+  // test discv5 without handling FIND_NODES request
+  // if (args.port != null) enr.udp = args.port;
   if (args.discoveryPort != null) enr.udp = args.discoveryPort;
 
   if (args["enr.ip"] != null) enr.ip = args["enr.ip"];


### PR DESCRIPTION
**Motivation**

Fix external memory issue, it turns out it has the same root cause to https://github.com/ChainSafe/lodestar/pull/4579

**Description**

- Do not set udp to enr so that our node do not have to serve `FIND_NODES` request. This is a work around, the real fix should be in discv5, see this candidate to fix https://github.com/ChainSafe/discv5/pull/202

- External memory has been great for 3 days, on feat1 sm1v:
<img width="791" alt="Screen Shot 2022-09-23 at 17 46 01" src="https://user-images.githubusercontent.com/10568965/191944701-3ba9e6e3-5b84-46fe-9cc4-b361c03243f2.png">

- On feat1 novc
<img width="785" alt="Screen Shot 2022-09-23 at 17 46 39" src="https://user-images.githubusercontent.com/10568965/191944769-882263bf-f58d-407b-9488-9437c6b96d6e.png">
