### PR TITLE
Serialize the fcus in the batch processing of blocks

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -276,7 +276,10 @@ export async function importBlock(
     const safeBlockHash = this.forkChoice.getJustifiedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
     const finalizedBlockHash = this.forkChoice.getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
     if (headBlockHash !== ZERO_HASH_HEX) {
-      this.executionEngine.notifyForkchoiceUpdate(headBlockHash, safeBlockHash, finalizedBlockHash).catch((e) => {
+      // Call and wait on the fcU even though failure of this may not be critical for us to import
+      // ( and hence catch log error). Otherwise this may result in out of order fcU on the execution
+      // engine especially during sync of multiple blocks.
+      await this.executionEngine.notifyForkchoiceUpdate(headBlockHash, safeBlockHash, finalizedBlockHash).catch((e) => {
         this.logger.error("Error pushing notifyForkchoiceUpdate()", {headBlockHash, finalizedBlockHash}, e);
       });
     }


### PR DESCRIPTION
**Motivation**
Since we moved to the batch processing of the blocks, even though we fire fcUs in a particular order, observed that the EL might  receive them in a jumbled manner. This might or mightnot cause interuptions for beacon sync (observed for ethereumjs)

This PR serializes the fcUs by awaiting on the in import block, even if we ignore their failure (since the following fcUs should resolve EL heads) atleast ensuring we don't jumble fcus.
