### PR TITLE
Fix peer id log

### DIFF
--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -364,7 +364,7 @@ export class Eth2Gossipsub extends Gossipsub {
     const seenTimestampSec = Date.now() / 1000;
 
     // Puts object in queue, validates, then processes
-    this.validatorFnsByType[topic.type](topic, msg, propagationSource.toString(), seenTimestampSec)
+    this.validatorFnsByType[topic.type](topic, msg, propagationSource.toB58String(), seenTimestampSec)
       .then((acceptance) => {
         this.reportMessageValidationResult(msgId, propagationSource, acceptance);
       })


### PR DESCRIPTION
**Motivation**
The peer id logged is incorrect when lodestar receives a gossip block

```
Received gossip block slot=3977407, root=0x7bc6…52f8, curentSlot=3977407, peerId=bafzaajiiaijcca2szy2eje5bz2y6w4mucwv3pe7gi33p2b3a3z5u2qszjzt6eqnzxq, delaySec=2.4609999656677246
```

**Description**

- We should use `peerId.toB58String()` api

part of #4596 
