### PR TITLE
Update release.md to remove devops tasks and include local backup strategy

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -200,14 +200,13 @@ This section is to guide the Release Manager tasked with the next version releas
 - If there are `rc.x` hot fixes, push to branch and increment the `rc.x` version.
 - Team members conduct Release Candidate Metrics Review
 - A Lodestar team member must mark the release candidate as safe, after personally reviewing and / or testing it
+- Backup `stable` and `unstable` branches locally for restoration incase of accidental use of the incorrect merge method
 - Temporarily enable "Allow merge commits" under the Lodestar repository settings
 - Release Manager can now complete Step 4: Merge release candidate.
 - Disable "Allow merge commits" under the Lodestar repository settings
 - Complete Step 5: Tag stable release
 - Double check that Github release is correct and inform the Project Manager of completion
-- Update lodestar_dockerhub_tag in production repository
-- Deploy new stable release to `stable` group of servers
-- Confirm attestations and monitor for any issues
+- Project Manager to follow up with Devops updating both `bn` and `vc` stable servers
 
 ## Alternatives considered
 


### PR DESCRIPTION
**Motivation**

Improve the RELEASE.md release manager checklist from lessons learned up to v1.1.0 release.

**Description**

This PR is to update the Release manager checklist to remove tasks specified for the PM + Devops. It only serves as a reminder, but not an action item for the release manager. Also includes a strategy of backing up local `stable` and `unstable` branches before merging incase of using the wrong merge strategy.

