### PR TITLE
Remove clean pre-build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "clean": "rm -rf ./packages/*/lib ./packages/*/*.tsbuildinfo",
-    "build": "yarn clean && lerna run build",
+    "build": "lerna run build",
     "build:docs": "lerna run build:refdocs && ./scripts/prepare-docs.sh",
     "build:lib:watch": "lerna run build:lib:watch --parallel",
     "build:types:watch": "lerna run build:types:watch --parallel",


### PR DESCRIPTION
**Motivation**

Current root `yarn build` command always cleans up existing lib artifacts. This prevents using incremental builds on the default command

**Description**

- Make default build command not clean
- Build _may_ fail in some cases due to old build files lingering around. In that case run: `yarn clean && yarn build`
- CI runs will produce the same result as they start with no pre-existing lib files