### PR TITLE
Set lodestar version in agent version

### DIFF
--- a/packages/beacon-node/src/network/nodejs/bundle.ts
+++ b/packages/beacon-node/src/network/nodejs/bundle.ts
@@ -19,6 +19,7 @@ export interface ILibp2pOptions {
   maxConnections?: number;
   minConnections?: number;
   metrics?: boolean;
+  lodestarVersion?: string;
 }
 
 export async function createNodejsLibp2p(options: ILibp2pOptions): Promise<Libp2p> {
@@ -82,6 +83,12 @@ export async function createNodejsLibp2p(options: ILibp2pOptions): Promise<Libp2
       autoRelay: {
         enabled: false,
         maxListeners: 0,
+      },
+    },
+
+    identify: {
+      host: {
+        agentVersion: options.lodestarVersion ? `lodestar/${options.lodestarVersion}` : "lodestar",
       },
     },
   });

--- a/packages/beacon-node/src/network/nodejs/util.ts
+++ b/packages/beacon-node/src/network/nodejs/util.ts
@@ -73,5 +73,6 @@ export async function createNodeJsLibp2p(
     // If peer discovery is enabled let the default in NodejsNode
     peerDiscovery: disablePeerDiscovery ? [] : undefined,
     metrics: nodeJsLibp2pOpts.metrics,
+    lodestarVersion: networkOpts.version,
   });
 }

--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -9,6 +9,7 @@ export interface INetworkOptions extends PeerManagerOpts, RateLimiterOpts, Gossi
   bootMultiaddrs?: string[];
   subscribeAllSubnets?: boolean;
   connectToDiscv5Bootnodes?: boolean;
+  version?: string;
 }
 
 export const defaultDiscv5Options: IDiscv5DiscoveryInputOptions = {

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -140,6 +140,8 @@ export async function beaconHandlerInit(args: IBeaconArgs & IGlobalArgs) {
 
   // Inject ENR to beacon options
   beaconNodeOptions.set({network: {discv5: {enr: fileENR, enrUpdate: !enr.ip && !enr.ip6}}});
+  // Add simple version string for libp2p agent version
+  beaconNodeOptions.set({network: {version: version.split("/")[0]}});
 
   // Render final options
   const options = beaconNodeOptions.getWithDefaults();


### PR DESCRIPTION
**Motivation**

- See https://github.com/ChainSafe/lodestar/issues/4465

Most clients have already changed their agent string to lodestar

**Description**

- Set lodestar version in agent version

Closes https://github.com/ChainSafe/lodestar/issues/4465
