### PR TITLE
Vc to submit SyncCommitteeSignature on early block

### DIFF
--- a/packages/validator/src/services/emitter.ts
+++ b/packages/validator/src/services/emitter.ts
@@ -1,5 +1,6 @@
 import {EventEmitter} from "events";
 import StrictEventEmitter from "strict-event-emitter-types";
+import {Slot} from "@lodestar/types";
 import {HeadEventData} from "./chainHeaderTracker.js";
 
 export enum ValidatorEvent {
@@ -18,4 +19,25 @@ export interface IValidatorEvents {
  */
 export class ValidatorEventEmitter extends (EventEmitter as {
   new (): StrictEventEmitter<EventEmitter, IValidatorEvents>;
-}) {}
+}) {
+  /**
+   * Wait for the first block to come with slot >= provided slot.
+   */
+  async waitForBlockSlot(slot: Slot): Promise<void> {
+    let headListener: (head: HeadEventData) => void;
+
+    const onDone = (): void => {
+      this.off(ValidatorEvent.chainHead, headListener);
+    };
+
+    return new Promise((resolve) => {
+      headListener = (head: HeadEventData): void => {
+        if (head.slot >= slot) {
+          onDone();
+          resolve();
+        }
+      };
+      this.on(ValidatorEvent.chainHead, headListener);
+    });
+  }
+}

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -10,6 +10,7 @@ import {ValidatorStore} from "./validatorStore.js";
 import {SyncCommitteeDutiesService, SyncDutyAndProofs} from "./syncCommitteeDuties.js";
 import {groupSyncDutiesBySubcommitteeIndex, SubcommitteeDuty} from "./utils.js";
 import {ChainHeaderTracker} from "./chainHeaderTracker.js";
+import {ValidatorEventEmitter} from "./emitter.js";
 
 /**
  * Service that sets up and handles validator sync duties.
@@ -23,6 +24,7 @@ export class SyncCommitteeService {
     private readonly api: Api,
     private readonly clock: IClock,
     private readonly validatorStore: ValidatorStore,
+    private readonly emitter: ValidatorEventEmitter,
     private readonly chainHeaderTracker: ChainHeaderTracker,
     private readonly metrics: Metrics | null
   ) {
@@ -49,8 +51,10 @@ export class SyncCommitteeService {
         return;
       }
 
-      // Lighthouse recommends to always wait to 1/3 of the slot, even if the block comes early
-      await sleep(this.clock.msToSlot(slot + 1 / 3), signal);
+      // unlike Attestation, SyncCommitteeSignature could be published asap
+      // especially with lodestar, it's very busy at 1/3 of slot
+      // see https://github.com/ChainSafe/lodestar/issues/4608
+      await Promise.race([sleep(this.clock.msToSlot(slot + 1 / 3), signal), this.emitter.waitForBlockSlot(slot)]);
       this.metrics?.syncCommitteeStepCallProduceMessage.observe(this.clock.secFromSlot(slot + 1 / 3));
 
       // Step 1. Download, sign and publish an `SyncCommitteeMessage` for each validator.

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -127,6 +127,7 @@ export class Validator {
       api,
       clock,
       validatorStore,
+      emitter,
       chainHeaderTracker,
       metrics
     );

--- a/packages/validator/test/unit/services/syncCommittee.test.ts
+++ b/packages/validator/test/unit/services/syncCommittee.test.ts
@@ -13,6 +13,7 @@ import {loggerVc} from "../../utils/logger.js";
 import {ClockMock} from "../../utils/clock.js";
 import {ChainHeaderTracker} from "../../../src/services/chainHeaderTracker.js";
 import {ZERO_HASH} from "../../utils/types.js";
+import {ValidatorEventEmitter} from "../../../src/services/emitter.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -22,6 +23,8 @@ describe("SyncCommitteeService", function () {
   const api = getApiClientStub(sandbox);
   const validatorStore = sinon.createStubInstance(ValidatorStore) as ValidatorStore &
     sinon.SinonStubbedInstance<ValidatorStore>;
+  const emitter = sinon.createStubInstance(ValidatorEventEmitter) as ValidatorEventEmitter &
+    sinon.SinonStubbedInstance<ValidatorEventEmitter>;
   const chainHeaderTracker = sinon.createStubInstance(ChainHeaderTracker) as ChainHeaderTracker &
     sinon.SinonStubbedInstance<ChainHeaderTracker>;
   let pubkeys: Uint8Array[]; // Initialize pubkeys in before() so bls is already initialized
@@ -53,6 +56,7 @@ describe("SyncCommitteeService", function () {
       api,
       clock,
       validatorStore,
+      emitter,
       chainHeaderTracker,
       null
     );


### PR DESCRIPTION
**Motivation**

We missed a lot of SyncCommitteeMessage because we always submit them at 1/3 of slot which is a very busy time, and we got I/O some lag issue since v1.1.0 (see #4600)

**Description**

Submit SyncCommitteeMessage asap

Closes #4608
