### PR TITLE
vc: configure afterBlockDelaySlotFraction for Attestation and SyncCommitteeSignature

### DIFF
--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -122,6 +122,7 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
       abortController,
       doppelgangerProtectionEnabled,
       afterBlockDelaySlotFraction: args.afterBlockDelaySlotFraction,
+      scAfterBlockDelaySlotFraction: args.scAfterBlockDelaySlotFraction,
       valProposerConfig,
     },
     metrics

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -25,6 +25,7 @@ export type IValidatorCliArgs = AccountValidatorArgs &
     force: boolean;
     graffiti: string;
     afterBlockDelaySlotFraction?: number;
+    scAfterBlockDelaySlotFraction?: number;
     suggestedFeeRecipient?: string;
     proposerSettingsFile?: string;
     strictFeeRecipientCheck?: boolean;
@@ -153,7 +154,15 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
 
   afterBlockDelaySlotFraction: {
     hidden: true,
-    description: "Delay before publishing attestations if block comes early, as a fraction of SECONDS_PER_SLOT",
+    description:
+      "Delay before publishing attestations if block comes early, as a fraction of SECONDS_PER_SLOT (value is from 0 inclusive to 1 exclusive)",
+    type: "number",
+  },
+
+  scAfterBlockDelaySlotFraction: {
+    hidden: true,
+    description:
+      "Delay before publishing SyncCommitteeSignature if block comes early, as a fraction of SECONDS_PER_SLOT (value is from 0 inclusive to 1 exclusive)",
     type: "number",
   },
 

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -130,8 +130,8 @@ export class AttestationService {
     // never beyond the 1/3 cutoff time.
     // https://github.com/status-im/nimbus-eth2/blob/7b64c1dce4392731a4a59ee3a36caef2e0a8357a/beacon_chain/validators/validator_duties.nim#L1123
     const msToOneThirdSlot = this.clock.msToSlot(slot + 1 / 3);
-    // Default = 6, which is half of attestation offset
-    const afterBlockDelayMs = (1000 * this.clock.secondsPerSlot) / (this.opts?.afterBlockDelaySlotFraction ?? 6);
+    // Default = 1/6, which is half of attestation offset
+    const afterBlockDelayMs = 1000 * this.clock.secondsPerSlot * (this.opts?.afterBlockDelaySlotFraction ?? 1 / 6);
     await sleep(Math.min(msToOneThirdSlot, afterBlockDelayMs));
 
     this.metrics?.attesterStepCallPublishAttestation.observe(this.clock.secFromSlot(slot + 1 / 3));

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -136,8 +136,9 @@ export class SyncCommitteeService {
     // SyncCommitteeSignature gossip validation.
     const msToOneThirdSlot = this.clock.msToSlot(slot + 1 / 3);
     const afterBlockDelayMs = 1000 * this.clock.secondsPerSlot * (this.opts?.scAfterBlockDelaySlotFraction ?? 0);
-    if (afterBlockDelayMs > 0) {
-      await sleep(Math.min(msToOneThirdSlot, afterBlockDelayMs));
+    const toDelayMs = Math.min(msToOneThirdSlot, afterBlockDelayMs);
+    if (toDelayMs > 0) {
+      await sleep(toDelayMs);
     }
 
     this.metrics?.syncCommitteeStepCallPublishMessage.observe(this.clock.secFromSlot(slot + 1 / 3));

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -12,6 +12,10 @@ import {groupSyncDutiesBySubcommitteeIndex, SubcommitteeDuty} from "./utils.js";
 import {ChainHeaderTracker} from "./chainHeaderTracker.js";
 import {ValidatorEventEmitter} from "./emitter.js";
 
+type SyncCommitteeServiceOpts = {
+  scAfterBlockDelaySlotFraction?: number;
+};
+
 /**
  * Service that sets up and handles validator sync duties.
  */
@@ -26,7 +30,8 @@ export class SyncCommitteeService {
     private readonly validatorStore: ValidatorStore,
     private readonly emitter: ValidatorEventEmitter,
     private readonly chainHeaderTracker: ChainHeaderTracker,
-    private readonly metrics: Metrics | null
+    private readonly metrics: Metrics | null,
+    private readonly opts?: SyncCommitteeServiceOpts
   ) {
     this.dutiesService = new SyncCommitteeDutiesService(config, logger, api, clock, validatorStore, metrics);
 
@@ -125,6 +130,15 @@ export class SyncCommitteeService {
         }
       })
     );
+
+    // by default we want to submit SyncCommitteeSignature asap after we receive block
+    // provide a delay option just in case any client implementation validate the existence of block in
+    // SyncCommitteeSignature gossip validation.
+    const msToOneThirdSlot = this.clock.msToSlot(slot + 1 / 3);
+    const afterBlockDelayMs = 1000 * this.clock.secondsPerSlot * (this.opts?.scAfterBlockDelaySlotFraction ?? 0);
+    if (afterBlockDelayMs > 0) {
+      await sleep(Math.min(msToOneThirdSlot, afterBlockDelayMs));
+    }
 
     this.metrics?.syncCommitteeStepCallPublishMessage.observe(this.clock.secFromSlot(slot + 1 / 3));
 

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -32,6 +32,7 @@ export type ValidatorOptions = {
   processShutdownCallback: ProcessShutdownCallback;
   abortController: AbortController;
   afterBlockDelaySlotFraction?: number;
+  scAfterBlockDelaySlotFraction?: number;
   doppelgangerProtectionEnabled?: boolean;
   closed?: boolean;
   valProposerConfig?: ValidatorProposerConfig;
@@ -129,7 +130,8 @@ export class Validator {
       validatorStore,
       emitter,
       chainHeaderTracker,
-      metrics
+      metrics,
+      {scAfterBlockDelaySlotFraction: opts.scAfterBlockDelaySlotFraction}
     );
 
     this.config = config;


### PR DESCRIPTION
**Motivation**

- A continuation of #4615: add `scAfterBlockDelaySlotFraction` just in case we want to delay the submission of SyncCommitteeSignature (due to some clients validate block in SyncCommitteeSignature gossip validation for example)
- The `afterBlockDelaySlotFraction` is confusing and it's not possible to configure a 0 value (no delay)

**Description**
- Both this param (for SyncCommitteeSignature) and `afterBlockDelaySlotFraction` is configured as a fraction of slot from0 (inclusive) to 1 (exclusive)

Before (not possible to configure 0 value)

```
┌─────────┬──────────────────┬─────────────────────────────┐
│ (index) │ target delay (s) │ afterBlockDelaySlotFraction │
├─────────┼──────────────────┼─────────────────────────────┤
│  bn-0   │       0.1        │             120             │
│  bn-1   │       0.5        │             24              │
│  bn-2   │       0.9        │           13.3333           │
│  bn-3   │       1.3        │           9.2307            │
│  bn-4   │       1.7        │           7.0588            │
└─────────┴──────────────────┴─────────────────────────────┘
```

After (value from 0 to 1)

```
┌─────────┬──────────────────┬─────────────────────────────┐
│ (index) │ target delay (s) │ afterBlockDelaySlotFraction │
├─────────┼──────────────────┼─────────────────────────────┤
│  bn-0   │        0         │              0              │
│  bn-1   │       0.5        │           0.0416            │
│  bn-2   │       0.9        │            0.075            │
│  bn-3   │       1.3        │           0.1083            │
│  bn-4   │       1.7        │           0.1416            │
└─────────┴──────────────────┴─────────────────────────────┘

```
