### PR TITLE
Replace geth binary in sim merge tests with docker

### DIFF
--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -41,7 +41,7 @@ jobs:
       # </common-build>
 
       - name: Pull Geth
-        run: docker run $GETH_IMAGE --help
+        run: docker pull $GETH_IMAGE
 
       - name: Test Lodestar <> Geth interop
         run: yarn test:sim:merge-interop

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -41,7 +41,7 @@ jobs:
       # </common-build>
 
       - name: Pull Geth
-        run: docker run $GETH_IMAGE
+        run: docker run $GETH_IMAGE --help
 
       - name: Test Lodestar <> Geth interop
         run: yarn test:sim:merge-interop

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  GETH_COMMIT: 511bf8f18801520bf4e0c7e4d098a17d0665bc89
+  GETH_IMAGE: ethereum/client-go:v1.10.25
   NETHERMIND_COMMIT: 5b73a2771ed00c6be792fc46f8d5c56333a28b11
 
 jobs:
@@ -40,21 +40,15 @@ jobs:
         if: steps.cache-deps.outputs.cache-hit == 'true'
       # </common-build>
 
-      # Install Geth merge interop
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.17'
-      - name: Clone Geth merge interop branch
-        run: git clone -b master https://github.com/g11tech/go-ethereum.git && cd go-ethereum && git reset --hard $GETH_COMMIT && git submodule update --init --recursive
-      - name: Build Geth
-        run: cd go-ethereum && make
+      - name: Pull Geth
+        run: docker run $GETH_IMAGE
 
       - name: Test Lodestar <> Geth interop
         run: yarn test:sim:merge-interop
         working-directory: packages/beacon-node
         env:
-          EL_BINARY_DIR: ../../go-ethereum/build/bin
-          EL_SCRIPT_DIR: geth
+          EL_BINARY_DIR: $GETH_IMAGE
+          EL_SCRIPT_DIR: gethdocker
           ENGINE_PORT: 8551
           ETH_PORT: 8545
           TX_SCENARIOS: simple

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -47,7 +47,7 @@ jobs:
         run: yarn test:sim:merge-interop
         working-directory: packages/beacon-node
         env:
-          EL_BINARY_DIR: $GETH_IMAGE
+          EL_BINARY_DIR: ${{ env.GETH_IMAGE }}
           EL_SCRIPT_DIR: gethdocker
           ENGINE_PORT: 8551
           ETH_PORT: 8545

--- a/packages/beacon-node/test/sim/merge-interop.test.ts
+++ b/packages/beacon-node/test/sim/merge-interop.test.ts
@@ -295,7 +295,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     const timeoutSetupMargin = 30 * 1000; // Give extra 30 seconds of margin
 
     // delay a bit so regular sync sees it's up to date and sync is completed from the beginning
-    const genesisSlotsDelay = 30;
+    const genesisSlotsDelay = 5;
 
     const timeout =
       ((epochsOfMargin + expectedEpochsToFinish) * SLOTS_PER_EPOCH + genesisSlotsDelay) *

--- a/packages/beacon-node/test/sim/merge-interop.test.ts
+++ b/packages/beacon-node/test/sim/merge-interop.test.ts
@@ -295,7 +295,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     const timeoutSetupMargin = 30 * 1000; // Give extra 30 seconds of margin
 
     // delay a bit so regular sync sees it's up to date and sync is completed from the beginning
-    const genesisSlotsDelay = 5;
+    const genesisSlotsDelay = 8;
 
     const timeout =
       ((epochsOfMargin + expectedEpochsToFinish) * SLOTS_PER_EPOCH + genesisSlotsDelay) *


### PR DESCRIPTION
Building geth takes time and resources (3-4 minutes of cloning + build), whill pulling geth image is so much easier. This would significantly reduce the merge sim time and will be followed up with nethermind build replacement if success.

geth build time:
![image](https://user-images.githubusercontent.com/76567250/193664618-b1cbde26-eeaf-414f-a42e-dc0dd6418d10.png)
image pull time:
![image](https://user-images.githubusercontent.com/76567250/193668285-1e6623a5-4988-4e69-98b3-d1185e544090.png)

similar for nethermind (will be addressed in a separate PR as docker setup for nethermind needs to be added)
