### PR TITLE
Dashboard to show validator_monitor_validators metric

### DIFF
--- a/dashboards/lodestar_debug_gossipsub.json
+++ b/dashboards/lodestar_debug_gossipsub.json
@@ -224,7 +224,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "validator_monitor_validators_total",
+          "expr": "validator_monitor_validators",
           "interval": "",
           "legendFormat": "",
           "refId": "A"

--- a/dashboards/lodestar_multinode.json
+++ b/dashboards/lodestar_multinode.json
@@ -507,7 +507,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "exemplar": false,
-          "expr": "validator_monitor_validators_total",
+          "expr": "validator_monitor_validators",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,

--- a/dashboards/lodestar_summary.json
+++ b/dashboards/lodestar_summary.json
@@ -519,7 +519,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "validator_monitor_validators_total",
+          "expr": "validator_monitor_validators",
           "interval": "",
           "legendFormat": "",
           "refId": "A"

--- a/dashboards/lodestar_validator_monitor.json
+++ b/dashboards/lodestar_validator_monitor.json
@@ -139,17 +139,6 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "validator_monitor_validators_total",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": false,
           "expr": "validator_monitor_validators",
           "hide": false,
           "interval": "",
@@ -1086,7 +1075,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "sum(validator_monitor_prev_epoch_attestations_total)/sum(validator_monitor_validators_total)",
+          "expr": "sum(validator_monitor_prev_epoch_attestations_total)/sum(validator_monitor_validators)",
           "interval": "",
           "legendFormat": "attestations_sent",
           "refId": "A"
@@ -1097,7 +1086,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "sum(validator_monitor_prev_epoch_aggregates_total)/sum(validator_monitor_validators_total)",
+          "expr": "sum(validator_monitor_prev_epoch_aggregates_total)/sum(validator_monitor_validators)",
           "hide": false,
           "interval": "",
           "legendFormat": "aggregates_sent",


### PR DESCRIPTION
**Motivation**

- Grafana dashboard was not able to show connected validators, it said "No Data" instead

**Description**

 - Use `validator_monitor_validators` instead of `validator_monitor_validators_total`
 - See https://github.com/ChainSafe/lodestar/pull/4475/files#diff-61206b531bae1c15627a06074c8d264e9d833f3d8f9b12cb6fa65b5cb845fbdcL623

Closes #4620

