### PR TITLE
Enforce the MAX_REQUEST_LIGHT_CLIENT_UPDATES limit

### DIFF
--- a/packages/beacon-node/src/api/impl/lightclient/index.ts
+++ b/packages/beacon-node/src/api/impl/lightclient/index.ts
@@ -1,6 +1,7 @@
 import {routes} from "@lodestar/api";
 import {fromHexString} from "@chainsafe/ssz";
 import {ProofType, Tree} from "@chainsafe/persistent-merkle-tree";
+import {SyncPeriod} from "@lodestar/types";
 import {ApiModules} from "../types.js";
 import {resolveStateId} from "../beacon/state/utils.js";
 import {IApiOptions} from "../../options.js";
@@ -42,9 +43,8 @@ export function getLightclientApi(
     },
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    async getUpdates(start_period, count) {
-      const periods = Array.from({length: count}, (_ignored, i) => i + start_period);
-      const updates = await Promise.all(periods.map((period) => chain.lightClientServer.getUpdates(period)));
+    async getUpdates(startPeriod: SyncPeriod, count: number) {
+      const updates = await chain.lightClientServer.getUpdates(startPeriod, count);
       return {data: updates};
     },
 

--- a/packages/params/src/index.ts
+++ b/packages/params/src/index.ts
@@ -197,6 +197,7 @@ export const NEXT_SYNC_COMMITTEE_GINDEX = 55;
  */
 export const NEXT_SYNC_COMMITTEE_DEPTH = 5;
 export const NEXT_SYNC_COMMITTEE_INDEX = 23;
+export const MAX_REQUEST_LIGHT_CLIENT_UPDATES = 128;
 
 /**
  * Optimistic sync


### PR DESCRIPTION
**Motivation**

In the specification there is a requirement that results returned from `/eth/v1/beacon/light_client/updates` do not exceed `MAX_REQUEST_LIGHT_CLIENT_UPDATES`.

closes #4633 