### PR TITLE
Add vc bn fallback

### DIFF
--- a/packages/api/.mocharc.yaml
+++ b/packages/api/.mocharc.yaml
@@ -2,5 +2,7 @@ colors: true
 timeout: 2000
 exit: true
 extension: ["ts"]
+require:
+  - ./test/setup.ts
 node-option:
   - "loader=ts-node/esm"

--- a/packages/api/src/utils/client/httpClient.ts
+++ b/packages/api/src/utils/client/httpClient.ts
@@ -96,6 +96,10 @@ export class HttpClient implements IHttpClient {
       }
     }
 
+    if (this.urlOpts.length === 0) {
+      throw Error("Must set at least 1 URL in HttpClient opts");
+    }
+
     this.globalTimeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.getAbortSignal = opts.getAbortSignal;
     this.fetch = opts.fetch ?? fetch;

--- a/packages/api/src/utils/client/httpClient.ts
+++ b/packages/api/src/utils/client/httpClient.ts
@@ -113,6 +113,14 @@ export class HttpClient implements IHttpClient {
     this.fetch = opts.fetch ?? fetch;
     this.metrics = metrics ?? null;
     this.logger = logger ?? null;
+
+    if (metrics) {
+      metrics.urlsScore.addCollect(() => {
+        for (let i = 0; i < this.urlsScore.length; i++) {
+          metrics.urlsScore.set({urlIndex: i}, this.urlsScore[i]);
+        }
+      });
+    }
   }
 
   async json<T>(opts: FetchOpts): Promise<T> {

--- a/packages/api/src/utils/client/httpClient.ts
+++ b/packages/api/src/utils/client/httpClient.ts
@@ -117,6 +117,11 @@ export class HttpClient implements IHttpClient {
   }
 
   private async requestWithBodyWithRetries<T>(opts: FetchOpts, getBody: (res: Response) => Promise<T>): Promise<T> {
+    // Early return when no fallback URLs are setup
+    if (this.urlOpts.length === 1) {
+      return this.requestWithBody(this.urlOpts[0], opts, getBody);
+    }
+
     return new Promise<T>((resolve, reject) => {
       let requestCount = 0;
       let errorCount = 0;

--- a/packages/api/src/utils/client/metrics.ts
+++ b/packages/api/src/utils/client/metrics.ts
@@ -1,6 +1,7 @@
 export type Metrics = {
   requestTime: IHistogram<"routeId">;
   requestErrors: IGauge<"routeId">;
+  requestToFallbacks: IGauge<"routeId">;
 };
 
 type LabelValues<T extends string> = Partial<Record<T, string | number>>;

--- a/packages/api/src/utils/client/metrics.ts
+++ b/packages/api/src/utils/client/metrics.ts
@@ -2,9 +2,11 @@ export type Metrics = {
   requestTime: IHistogram<"routeId">;
   requestErrors: IGauge<"routeId">;
   requestToFallbacks: IGauge<"routeId">;
+  urlsScore: IGauge<"urlIndex">;
 };
 
 type LabelValues<T extends string> = Partial<Record<T, string | number>>;
+type CollectFn<T extends string> = (metric: IGauge<T>) => void;
 
 export interface IGauge<T extends string> {
   /**
@@ -32,6 +34,8 @@ export interface IGauge<T extends string> {
    * @param value The value to set
    */
   set(value: number): void;
+
+  addCollect(collectFn: CollectFn<T>): void;
 }
 
 export interface IHistogram<T extends string> {

--- a/packages/api/test/setup.ts
+++ b/packages/api/test/setup.ts
@@ -1,0 +1,6 @@
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import sinonChai from "sinon-chai";
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);

--- a/packages/api/test/unit/client/httpClientFallback.test.ts
+++ b/packages/api/test/unit/client/httpClientFallback.test.ts
@@ -1,0 +1,120 @@
+import Sinon from "sinon";
+import {expect} from "chai";
+import {HttpClient} from "../../../src/utils/client/index.js";
+
+describe("httpClient fallback", () => {
+  const testRoute = {url: "/test-route", method: "GET" as const};
+  const DEBUG_LOGS = Boolean(process.env.DEBUG);
+
+  // Using fetchSub instead of actually setting up servers because there are some strange
+  // race conditions, where the server stub doesn't count the call in time before the test is over.
+  const fetchStub = Sinon.stub<[string], ReturnType<typeof fetch>>();
+
+  let httpClient: HttpClient;
+
+  const serverCount = 3;
+  const baseUrls: string[] = [];
+  for (let i = 0; i < serverCount; i++) {
+    baseUrls.push(`http://127.0.0.1:${18000 + i}`);
+  }
+
+  const serverErrors = new Map<number, boolean>();
+
+  // With baseURLs above find the server index associated with that URL
+  function getServerIndex(url: string): number {
+    const i = baseUrls.findIndex((baseUrl) => url.startsWith(baseUrl));
+    if (i < 0) {
+      throw Error(`fetch called with unknown url ${url}`);
+    }
+    return i;
+  }
+
+  // Create fresh HttpClient with new internal state
+  beforeEach(() => {
+    httpClient = new HttpClient({
+      baseUrl: "",
+      urls: baseUrls.map((baseUrl) => ({baseUrl})),
+      fetch: fetchStub as typeof fetch,
+    });
+
+    fetchStub.callsFake(async (url) => {
+      // Simulate network delay
+      await new Promise((r) => setTimeout(r, 10));
+      const i = getServerIndex(url);
+      if (serverErrors.get(i)) {
+        throw Error(`test_error_server_${i}`);
+      } else {
+        return {ok: true} as Response;
+      }
+    });
+  });
+
+  afterEach(() => {
+    fetchStub.reset();
+    serverErrors.clear();
+  });
+
+  // Compares the call count of all server on a request, prints the diff as "1,1,0" == "1,0,0"
+  function assertServerCallCount(step: number, expectedCallCounts: number[]): void {
+    const callCounts: number[] = [];
+    for (let i = 0; i < serverCount; i++) callCounts[i] = 0;
+    for (const call of fetchStub.getCalls()) {
+      callCounts[getServerIndex(call.args[0])]++;
+    }
+
+    expect(callCounts.join(",")).equals(expectedCallCounts.join(","), `step ${step} - callCounts`);
+
+    fetchStub.resetHistory();
+
+    // eslint-disable-next-line no-console
+    if (DEBUG_LOGS) console.log("completed assertions step", step);
+  }
+
+  async function requestTestRoute(): Promise<void> {
+    await httpClient.request(testRoute);
+  }
+
+  it("Should only call server 0", async () => {
+    await requestTestRoute();
+    assertServerCallCount(0, [1, 0, 0]);
+  });
+
+  it("server 0 throws, so call next healthy, server 1", async () => {
+    serverErrors.set(0, true);
+    await requestTestRoute();
+    assertServerCallCount(0, [1, 1, 0]);
+  });
+
+  it("server 1 also throws, so call next healthy server 2", async () => {
+    serverErrors.set(0, true);
+    serverErrors.set(1, true);
+    await requestTestRoute();
+    assertServerCallCount(0, [1, 1, 1]);
+  });
+
+  it("servers 0,1 recently errored, so call 0,1,2 until healthy", async () => {
+    // servers 0,1 errors
+    serverErrors.set(0, true);
+    serverErrors.set(1, true);
+    await requestTestRoute();
+    assertServerCallCount(0, [1, 1, 1]);
+
+    // servers 0,1 recently errored, so call 0,1,2 until healthy
+    serverErrors.set(0, false);
+    serverErrors.set(1, false);
+    await requestTestRoute();
+    assertServerCallCount(1, [1, 1, 1]);
+    await requestTestRoute();
+    assertServerCallCount(2, [1, 1, 1]);
+    await requestTestRoute();
+    assertServerCallCount(3, [1, 0, 0]);
+  });
+
+  it("all URLs fail, expect error from the last server", async () => {
+    serverErrors.set(0, true);
+    serverErrors.set(1, true);
+    serverErrors.set(2, true);
+    await expect(requestTestRoute()).rejectedWith("test_error_server_2");
+    assertServerCallCount(0, [1, 1, 1]);
+  });
+});

--- a/packages/api/test/unit/client/httpClientOptions.test.ts
+++ b/packages/api/test/unit/client/httpClientOptions.test.ts
@@ -10,10 +10,22 @@ describe("HTTPClient options", () => {
   it("Single root baseUrl option", () => {
     const httpClient = new HttpClient({baseUrl: baseUrl1, bearerToken: bearerToken1});
 
-    expect(httpClient["urlsOpts"]).deep.equals([{baseUrl: baseUrl1, bearerToken: bearerToken1, timeoutMs: undefined}]);
+    expect(httpClient["urlsOpts"]).deep.equals([{baseUrl: baseUrl1, bearerToken: bearerToken1}]);
   });
 
-  it("Multiple urls option", () => {
+  it("Multiple urls option with common bearerToken", () => {
+    const httpClient = new HttpClient({
+      urls: [baseUrl1, baseUrl2],
+      bearerToken: bearerToken1,
+    });
+
+    expect(httpClient["urlsOpts"]).deep.equals([
+      {baseUrl: baseUrl1, bearerToken: bearerToken1},
+      {baseUrl: baseUrl2, bearerToken: bearerToken1},
+    ]);
+  });
+
+  it("Multiple urls as object option", () => {
     const httpClient = new HttpClient({
       urls: [
         {baseUrl: baseUrl1, bearerToken: bearerToken1},
@@ -35,7 +47,7 @@ describe("HTTPClient options", () => {
     });
 
     expect(httpClient["urlsOpts"]).deep.equals([
-      {baseUrl: baseUrl1, bearerToken: bearerToken1, timeoutMs: undefined},
+      {baseUrl: baseUrl1, bearerToken: bearerToken1},
       {baseUrl: baseUrl2, bearerToken: bearerToken2},
     ]);
   });
@@ -51,7 +63,7 @@ describe("HTTPClient options", () => {
       ],
     });
     expect(httpClient["urlsOpts"]).deep.equals([
-      {baseUrl: baseUrl1, bearerToken: bearerToken1, timeoutMs: undefined},
+      {baseUrl: baseUrl1, bearerToken: bearerToken1},
       {baseUrl: baseUrl2, bearerToken: bearerToken2},
     ]);
   });

--- a/packages/api/test/unit/client/httpClientOptions.test.ts
+++ b/packages/api/test/unit/client/httpClientOptions.test.ts
@@ -1,0 +1,58 @@
+import {expect} from "chai";
+import {HttpClient} from "../../../src/index.js";
+
+describe("HTTPClient options", () => {
+  const baseUrl1 = "http://url-1";
+  const baseUrl2 = "http://url-2";
+  const bearerToken1 = "token-1";
+  const bearerToken2 = "token-2";
+
+  it("Single root baseUrl option", () => {
+    const httpClient = new HttpClient({baseUrl: baseUrl1, bearerToken: bearerToken1});
+
+    expect(httpClient["urlsOpts"]).deep.equals([{baseUrl: baseUrl1, bearerToken: bearerToken1, timeoutMs: undefined}]);
+  });
+
+  it("Multiple urls option", () => {
+    const httpClient = new HttpClient({
+      urls: [
+        {baseUrl: baseUrl1, bearerToken: bearerToken1},
+        {baseUrl: baseUrl2, bearerToken: bearerToken2},
+      ],
+    });
+
+    expect(httpClient["urlsOpts"]).deep.equals([
+      {baseUrl: baseUrl1, bearerToken: bearerToken1},
+      {baseUrl: baseUrl2, bearerToken: bearerToken2},
+    ]);
+  });
+
+  it("baseUrl and urls option", () => {
+    const httpClient = new HttpClient({
+      baseUrl: baseUrl1,
+      bearerToken: bearerToken1,
+      urls: [{baseUrl: baseUrl2, bearerToken: bearerToken2}],
+    });
+
+    expect(httpClient["urlsOpts"]).deep.equals([
+      {baseUrl: baseUrl1, bearerToken: bearerToken1, timeoutMs: undefined},
+      {baseUrl: baseUrl2, bearerToken: bearerToken2},
+    ]);
+  });
+
+  it("de-duplicate urls", () => {
+    const httpClient = new HttpClient({
+      baseUrl: baseUrl1,
+      bearerToken: bearerToken1,
+      urls: [
+        {baseUrl: baseUrl2, bearerToken: bearerToken2},
+        {baseUrl: baseUrl1, bearerToken: bearerToken1},
+        {baseUrl: baseUrl2, bearerToken: bearerToken2},
+      ],
+    });
+    expect(httpClient["urlsOpts"]).deep.equals([
+      {baseUrl: baseUrl1, bearerToken: bearerToken1, timeoutMs: undefined},
+      {baseUrl: baseUrl2, bearerToken: bearerToken2},
+    ]);
+  });
+});

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -116,7 +116,7 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
     {
       dbOps,
       slashingProtection,
-      api: args.server,
+      api: args.beaconNodes,
       logger,
       processShutdownCallback,
       signers,

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -17,11 +17,14 @@ export const validatorMetricsDefaultOptions = {
   address: "127.0.0.1",
 };
 
+// Defined as variable to not set yargs.default to an array
+export const DEFAULT_BEACON_NODE_URL = "";
+
 export type IValidatorCliArgs = AccountValidatorArgs &
   KeymanagerArgs &
   ILogArgs & {
     validatorsDbDir?: string;
-    server: string;
+    beaconNodes: string[];
     force: boolean;
     graffiti: string;
     afterBlockDelaySlotFraction?: number;
@@ -135,10 +138,15 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
     type: "string",
   },
 
-  server: {
-    description: "Address to connect to BeaconNode",
-    default: "http://127.0.0.1:9596",
-    type: "string",
+  beaconNodes: {
+    description: "Addresses to connect to BeaconNode",
+    default: ["http://127.0.0.1:9596"],
+    type: "array",
+    string: true,
+    coerce: (urls: string[]): string[] =>
+      // Parse ["url1,url2"] to ["url1", "url2"]
+      urls.map((item) => item.split(",")).flat(1),
+    alias: ["server"], // for backwards compatibility
   },
 
   force: {

--- a/packages/cli/src/cmds/validator/slashingProtection/options.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/options.ts
@@ -1,12 +1,12 @@
 import {ICliCommandOptions} from "../../../util/index.js";
 import {IValidatorCliArgs, validatorOptions} from "../options.js";
 
-export type ISlashingProtectionArgs = Pick<IValidatorCliArgs, "server"> & {
+export type ISlashingProtectionArgs = Pick<IValidatorCliArgs, "beaconNodes"> & {
   force?: boolean;
 };
 
 export const slashingProtectionOptions: ICliCommandOptions<ISlashingProtectionArgs> = {
-  server: validatorOptions.server,
+  beaconNodes: validatorOptions.beaconNodes,
 
   force: {
     description: "If genesisValidatorsRoot can't be fetched from the Beacon node, use a zero hash",

--- a/packages/cli/src/cmds/validator/slashingProtection/utils.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/utils.ts
@@ -36,7 +36,7 @@ export function getSlashingProtection(
  * Returns genesisValidatorsRoot from validator API client.
  */
 export async function getGenesisValidatorsRoot(args: IGlobalArgs & ISlashingProtectionArgs): Promise<Root> {
-  const server = args.server;
+  const server = args.beaconNodes[0];
 
   const networkGenesis = genesisData[args.network as NetworkName];
   if (networkGenesis !== undefined) {

--- a/packages/cli/src/cmds/validator/voluntaryExit.ts
+++ b/packages/cli/src/cmds/validator/voluntaryExit.ts
@@ -69,7 +69,7 @@ like to choose for the voluntary exit.",
     // Fetch genesisValidatorsRoot always from beacon node
     // Do not use known networks cache, it defaults to mainnet for devnets
     const {config: chainForkConfig, network} = getBeaconConfigFromArgs(args);
-    const client = getClient({baseUrl: args.server}, {config: chainForkConfig});
+    const client = getClient({urls: args.beaconNodes}, {config: chainForkConfig});
     const {genesisValidatorsRoot, genesisTime} = (await client.beacon.getGenesis()).data;
     const config = createIBeaconConfig(chainForkConfig, genesisValidatorsRoot);
 

--- a/packages/validator/src/metrics.ts
+++ b/packages/validator/src/metrics.ts
@@ -326,6 +326,12 @@ export function getMetrics(register: MetricsRegister, gitData: LodestarGitData) 
         help: "Total count of requests to fallback URLs on REST API by routeId",
         labelNames: ["routeId"],
       }),
+
+      urlsScore: register.gauge<{urlIndex: string}>({
+        name: "vc_rest_api_client_urls_score",
+        help: "Current score of REST API URLs by url index",
+        labelNames: ["urlIndex"],
+      }),
     },
 
     keymanagerApiRest: {

--- a/packages/validator/src/metrics.ts
+++ b/packages/validator/src/metrics.ts
@@ -320,6 +320,12 @@ export function getMetrics(register: MetricsRegister, gitData: LodestarGitData) 
         help: "Total count of errors on REST API client requests by routeId",
         labelNames: ["routeId"],
       }),
+
+      requestToFallbacks: register.gauge<{routeId: string}>({
+        name: "vc_rest_api_client_request_to_fallbacks_total",
+        help: "Total count of requests to fallback URLs on REST API by routeId",
+        labelNames: ["routeId"],
+      }),
     },
 
     keymanagerApiRest: {

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -73,14 +73,11 @@ export class Validator {
 
     let api: Api;
     if (typeof opts.api === "string" || Array.isArray(opts.api)) {
-      const urls = typeof opts.api === "string" ? [opts.api] : opts.api;
-      const urlOpts = urls.map((url) => ({baseUrl: url}));
       // This new api instance can make do with default timeout as a faster timeout is
       // not necessary since this instance won't be used for validator duties
       api = getClient(
         {
-          baseUrl: urls[0],
-          urls: urlOpts,
+          urls: typeof opts.api === "string" ? [opts.api] : opts.api,
           // Validator would need the beacon to respond within the slot
           timeoutMs: config.SECONDS_PER_SLOT * 1000,
           getAbortSignal: () => this.controller.signal,
@@ -176,13 +173,9 @@ export class Validator {
     let api: Api;
     if (typeof opts.api === "string" || Array.isArray(opts.api)) {
       const urls = typeof opts.api === "string" ? [opts.api] : opts.api;
-      const urlOpts = urls.map((url) => ({baseUrl: url}));
       // This new api instance can make do with default timeout as a faster timeout is
       // not necessary since this instance won't be used for validator duties
-      api = getClient(
-        {baseUrl: urls[0], urls: urlOpts, getAbortSignal: () => opts.abortController.signal},
-        {config, logger}
-      );
+      api = getClient({urls, getAbortSignal: () => opts.abortController.signal}, {config, logger});
     } else {
       api = opts.api;
     }

--- a/packages/validator/test/utils/apiStub.ts
+++ b/packages/validator/test/utils/apiStub.ts
@@ -5,7 +5,7 @@ import {config} from "@lodestar/config/default";
 export function getApiClientStub(
   sandbox: SinonSandbox = sinon
 ): Api & {[K in keyof Api]: sinon.SinonStubbedInstance<Api[K]>} {
-  const api = getClient({baseUrl: ""}, {config});
+  const api = getClient({baseUrl: "http://localhost:9596"}, {config});
 
   return {
     beacon: sandbox.stub(api.beacon),


### PR DESCRIPTION
**Motivation**

- See https://github.com/ChainSafe/lodestar/issues/4337

**Description**

A good vc bn fallback must fulfill these goals
- if first server is stable and responding do not query fallbacks
- if first server errors, retry that same request on fallbacks
- until first server is shown to be reliable again, contact all servers

This behaviour is not simple, so classic patterns like Promise.all() or for try catch are not enough.

The solution of this PR appears complex, but that's what's needed to achieve the goals above. Please check the inline comments for pointers on the logic.

A unit tests proves that it works, but I haven't tested yet on a deployed beacon node.

Closes https://github.com/ChainSafe/lodestar/issues/4337
