### PR TITLE
Shift nethermind merge-interop CI tests to docker based

### DIFF
--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GETH_IMAGE: ethereum/client-go:v1.10.25
-  NETHERMIND_COMMIT: 5b73a2771ed00c6be792fc46f8d5c56333a28b11
+  NETHERMIND_IMAGE: nethermind/nethermind:1.14.3
 
 jobs:
   sim-merge-tests:
@@ -53,21 +53,15 @@ jobs:
           ETH_PORT: 8545
           TX_SCENARIOS: simple
 
-      # Install Nethermind merge interop
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: "6.0.x"
-      - name: Clone Nethermind merge interop branch
-        run: git clone -b master-20-sep-22 https://github.com/g11tech/nethermind --recursive && cd nethermind && git reset --hard $NETHERMIND_COMMIT && git submodule update --init --recursive
-      - name: Build Nethermind
-        run: cd nethermind/src/Nethermind && dotnet build Nethermind.sln -c Release
+      - name: Pull Nethermind
+        run: docker pull $NETHERMIND_IMAGE
 
       - name: Test Lodestar <> Nethermind interop
         run: yarn test:sim:merge-interop
         working-directory: packages/beacon-node
         env:
-          EL_BINARY_DIR: ../../nethermind/src/Nethermind/Nethermind.Runner
-          EL_SCRIPT_DIR: nethermind
+          EL_BINARY_DIR: ${{ env.NETHERMIND_IMAGE }}
+          EL_SCRIPT_DIR: netherminddocker
           ENGINE_PORT: 8551
           ETH_PORT: 8545
 

--- a/packages/beacon-node/test/scripts/el-interop/gethdocker/common-setup.sh
+++ b/packages/beacon-node/test/scripts/el-interop/gethdocker/common-setup.sh
@@ -16,6 +16,9 @@ pubKey="0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
 
 # echo a hex encoded 256 bit secret into a file
 echo $JWT_SECRET_HEX> $DATA_DIR/jwtsecret
+# clear any previous docker dangling docker run
+docker rm -f custom-execution
+rm -rf $DATA_DIR/geth
 
-docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --datadir /data init /data/genesis.json
-docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR  --datadir /data account import --password /data/password.txt /data/sk.json
+docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --name custom-execution -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --datadir /data/geth init /data/genesis.json
+docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --name custom-execution -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR  --datadir /data/geth account import --password /data/password.txt /data/sk.json

--- a/packages/beacon-node/test/scripts/el-interop/gethdocker/post-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/gethdocker/post-merge.sh
@@ -5,4 +5,4 @@ currentDir=$(pwd)
 
 . $scriptDir/common-setup.sh
 
-docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --network host -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --http -http.api "engine,net,eth,miner" --http.port $ETH_PORT --authrpc.port $ENGINE_PORT --authrpc.jwtsecret /data/jwtsecret --allow-insecure-unlock --unlock $pubKey --password /data/password.txt --datadir /data --syncmode full
+docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --name custom-execution --network host -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --http -http.api "engine,net,eth,miner" --http.port $ETH_PORT --authrpc.port $ENGINE_PORT --authrpc.jwtsecret /data/jwtsecret --allow-insecure-unlock --unlock $pubKey --password /data/password.txt --datadir /data/geth --syncmode full

--- a/packages/beacon-node/test/scripts/el-interop/gethdocker/pre-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/gethdocker/pre-merge.sh
@@ -6,4 +6,4 @@ currentDir=$(pwd)
 . $scriptDir/common-setup.sh
 
 # EL_BINARY_DIR refers to the local docker image build from kiln/gethdocker folder
-docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --network host -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --http -http.api "engine,net,eth,miner" --http.port $ETH_PORT --authrpc.port $ENGINE_PORT --authrpc.jwtsecret /data/jwtsecret --allow-insecure-unlock --unlock $pubKey --password /data/password.txt --datadir /data --nodiscover --mine --syncmode full
+docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --name custom-execution --network host -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --http -http.api "engine,net,eth,miner" --http.port $ETH_PORT --authrpc.port $ENGINE_PORT --authrpc.jwtsecret /data/jwtsecret --allow-insecure-unlock --unlock $pubKey --password /data/password.txt --datadir /data/geth --nodiscover --mine --syncmode full

--- a/packages/beacon-node/test/scripts/el-interop/netherminddocker/common-setup.sh
+++ b/packages/beacon-node/test/scripts/el-interop/netherminddocker/common-setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -x
+
+echo $TTD
+echo $DATA_DIR
+echo $EL_BINARY_DIR
+echo $JWT_SECRET_HEX
+
+echo $scriptDir
+echo $currentDir
+
+# echo a hex encoded 256 bit secret into a file
+echo $JWT_SECRET_HEX> $DATA_DIR/jwtsecret
+
+echo "clear any previous docker dangling docker run"
+docker rm -f custom-execution
+rm -rf $DATA_DIR/nethermind

--- a/packages/beacon-node/test/scripts/el-interop/netherminddocker/post-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/netherminddocker/post-merge.sh
@@ -5,4 +5,4 @@ currentDir=$(pwd)
 
 . $scriptDir/common-setup.sh
 
-docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --network host --name custom-execution -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --datadir /data/nethermind --config themerge_kiln_testvectors --Merge.TerminalTotalDifficulty $TTD --JsonRpc.JwtSecretFile /data/jwtsecret --JsonRpc.Enabled true --JsonRpc.Host 0.0.0.0 --JsonRpc.AdditionalRpcUrls "http://localhost:$ETH_PORT|http|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:$ENGINE_PORT|http|eth;engine" --Sync.SnapSync false
+docker run --rm --network host --name custom-execution -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --datadir /data/nethermind --config themerge_kiln_testvectors --Merge.TerminalTotalDifficulty $TTD --JsonRpc.JwtSecretFile /data/jwtsecret --JsonRpc.Enabled true --JsonRpc.Host 0.0.0.0 --JsonRpc.AdditionalRpcUrls "http://localhost:$ETH_PORT|http|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:$ENGINE_PORT|http|eth;engine" --Sync.SnapSync false

--- a/packages/beacon-node/test/scripts/el-interop/netherminddocker/post-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/netherminddocker/post-merge.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+
+scriptDir=$(dirname $0)
+currentDir=$(pwd)
+
+. $scriptDir/common-setup.sh
+
+docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --network host --name custom-execution -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --datadir /data/nethermind --config themerge_kiln_testvectors --Merge.TerminalTotalDifficulty $TTD --JsonRpc.JwtSecretFile /data/jwtsecret --JsonRpc.Enabled true --JsonRpc.Host 0.0.0.0 --JsonRpc.AdditionalRpcUrls "http://localhost:$ETH_PORT|http|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:$ENGINE_PORT|http|eth;engine" --Sync.SnapSync false

--- a/packages/beacon-node/test/scripts/el-interop/netherminddocker/pre-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/netherminddocker/pre-merge.sh
@@ -7,4 +7,4 @@ currentDir=$(pwd)
 
 echo "sleeping for 10 seconds..."
 
-docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --network host --name custom-execution -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --datadir /data/nethermind --config themerge_kiln_m2 --Merge.TerminalTotalDifficulty $TTD --JsonRpc.JwtSecretFile /data/jwtsecret --Merge.Enabled true  --Init.DiagnosticMode=None --JsonRpc.Enabled true --JsonRpc.Host 0.0.0.0 --JsonRpc.AdditionalRpcUrls "http://localhost:$ETH_PORT|http|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:$ENGINE_PORT|http|eth;engine" --Sync.SnapSync false
+docker run --rm --network host --name custom-execution -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --datadir /data/nethermind --config themerge_kiln_m2 --Merge.TerminalTotalDifficulty $TTD --JsonRpc.JwtSecretFile /data/jwtsecret --Merge.Enabled true  --Init.DiagnosticMode=None --JsonRpc.Enabled true --JsonRpc.Host 0.0.0.0 --JsonRpc.AdditionalRpcUrls "http://localhost:$ETH_PORT|http|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:$ENGINE_PORT|http|eth;engine" --Sync.SnapSync false

--- a/packages/beacon-node/test/scripts/el-interop/netherminddocker/pre-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/netherminddocker/pre-merge.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -x
+
+scriptDir=$(dirname $0)
+currentDir=$(pwd)
+
+. $scriptDir/common-setup.sh
+
+echo "sleeping for 10 seconds..."
+
+docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --network host --name custom-execution -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --datadir /data/nethermind --config themerge_kiln_m2 --Merge.TerminalTotalDifficulty $TTD --JsonRpc.JwtSecretFile /data/jwtsecret --Merge.Enabled true  --Init.DiagnosticMode=None --JsonRpc.Enabled true --JsonRpc.Host 0.0.0.0 --JsonRpc.AdditionalRpcUrls "http://localhost:$ETH_PORT|http|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:$ENGINE_PORT|http|eth;engine" --Sync.SnapSync false

--- a/packages/beacon-node/test/sim/merge-interop.test.ts
+++ b/packages/beacon-node/test/sim/merge-interop.test.ts
@@ -63,7 +63,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
   const engineApiUrl = `http://localhost:${enginePort}`;
 
   after(async () => {
-    await shell(`rm -rf ${dataPath}`);
+    await shell(`sudo rm -rf ${dataPath}`);
   });
 
   const afterEachCallbacks: (() => Promise<void> | void)[] = [];

--- a/packages/beacon-node/test/sim/merge-interop.test.ts
+++ b/packages/beacon-node/test/sim/merge-interop.test.ts
@@ -126,7 +126,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
       );
     }
 
-    await shell(`rm -rf ${dataPath}`);
+    await shell(`sudo rm -rf ${dataPath}`);
     fs.mkdirSync(dataPath, {recursive: true});
 
     startELProcess({


### PR DESCRIPTION

Skip building nethermind in the CI  for merge-interop and directly use nethermind docker build as with the `geth`, saves time and resources.
