### PR TITLE
Enable specifying bootnodes cli arg as comma separated values

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -27,17 +27,13 @@ export function parseArgs(args: INetworkArgs): IBeaconNodeOptions["network"] {
   const listenAddress = args.listenAddress || defaultListenAddress;
   const udpPort = args.discoveryPort ?? args.port ?? defaultP2pPort;
   const tcpPort = args.port ?? defaultP2pPort;
-  // Each bootnode entry could be comma separated, just deserialize it into a single array
-  // as comma separated entries are generally most friendly in ansible kind of setups, i.e.
-  // [ "en1", "en2,en3" ] => [ 'en1', 'en2', 'en3' ]
-  const bootnodes = (args["bootnodes"] ?? []).reduce((acc: string[], elem: string) => acc.concat(elem.split(",")), []);
 
   return {
     discv5: {
       enabled: args["discv5"] ?? true,
       bindAddr: `/ip4/${listenAddress}/udp/${udpPort}`,
       // TODO: Okay to set to empty array?
-      bootEnrs: bootnodes,
+      bootEnrs: args["bootnodes"] ?? [],
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
       enr: undefined as any,
     },
@@ -92,6 +88,10 @@ export const options: ICliCommandOptions<INetworkArgs> = {
     description: "Bootnodes for discv5 discovery",
     defaultDescription: JSON.stringify((defaultOptions.network.discv5 || {}).bootEnrs || []),
     group: "network",
+    // Each bootnode entry could be comma separated, just deserialize it into a single array
+    // as comma separated entries are generally most friendly in ansible kind of setups, i.e.
+    // [ "en1", "en2,en3" ] => [ 'en1', 'en2', 'en3' ]
+    coerce: (args: string[]) => args.map((item) => item.split(",")).flat(1),
   },
 
   targetPeers: {

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -27,13 +27,17 @@ export function parseArgs(args: INetworkArgs): IBeaconNodeOptions["network"] {
   const listenAddress = args.listenAddress || defaultListenAddress;
   const udpPort = args.discoveryPort ?? args.port ?? defaultP2pPort;
   const tcpPort = args.port ?? defaultP2pPort;
+  // Each bootnode entry could be comma separated, just deserialize it into a single array
+  // as comma separated entries are generally most friendly in ansible kind of setups, i.e.
+  // [ "en1", "en2,en3" ] => [ 'en1', 'en2', 'en3' ]
+  const bootnodes = (args["bootnodes"] ?? []).reduce((acc: string[], elem: string) => acc.concat(elem.split(",")), []);
 
   return {
     discv5: {
       enabled: args["discv5"] ?? true,
       bindAddr: `/ip4/${listenAddress}/udp/${udpPort}`,
       // TODO: Okay to set to empty array?
-      bootEnrs: args["bootnodes"] ?? [],
+      bootEnrs: bootnodes,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
       enr: undefined as any,
     },

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -56,7 +56,7 @@ describe("options / beaconNodeOptions", () => {
       listenAddress: "127.0.0.1",
       port: 9001,
       discoveryPort: 9002,
-      bootnodes: ["enr:-somedata"],
+      bootnodes: ["enr:-somedata", "enr:-somedata1,enr:-somedata2"],
       targetPeers: 25,
       subscribeAllSubnets: true,
       "network.maxPeers": 30,
@@ -129,7 +129,7 @@ describe("options / beaconNodeOptions", () => {
         discv5: {
           enabled: true,
           bindAddr: "/ip4/127.0.0.1/udp/9002",
-          bootEnrs: ["enr:-somedata"],
+          bootEnrs: ["enr:-somedata", "enr:-somedata1", "enr:-somedata2"],
         },
         maxPeers: 30,
         targetPeers: 25,

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -56,7 +56,7 @@ describe("options / beaconNodeOptions", () => {
       listenAddress: "127.0.0.1",
       port: 9001,
       discoveryPort: 9002,
-      bootnodes: ["enr:-somedata", "enr:-somedata1,enr:-somedata2"],
+      bootnodes: ["enr:-somedata"],
       targetPeers: 25,
       subscribeAllSubnets: true,
       "network.maxPeers": 30,
@@ -129,7 +129,7 @@ describe("options / beaconNodeOptions", () => {
         discv5: {
           enabled: true,
           bindAddr: "/ip4/127.0.0.1/udp/9002",
-          bootEnrs: ["enr:-somedata", "enr:-somedata1", "enr:-somedata2"],
+          bootEnrs: ["enr:-somedata"],
         },
         maxPeers: 30,
         targetPeers: 25,


### PR DESCRIPTION
**Motivation**
Pari's ansible uses comma separated bootnodes and he endeavour to use them in a custom devnet failed as we don't accept bootnodes as comma separated,
<!-- Why is this PR exists? What are the goals of the pull request? -->
This PR enables providing the bootnodes as comma separated arg value
