### PR TITLE
v1.1.1: Submit sync committee signatures early

### DIFF
--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -109,6 +109,7 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
       signers,
       doppelgangerProtectionEnabled,
       afterBlockDelaySlotFraction: args.afterBlockDelaySlotFraction,
+      scAfterBlockDelaySlotFraction: args.scAfterBlockDelaySlotFraction,
       valProposerConfig,
     },
     controller.signal,

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -26,6 +26,7 @@ export type IValidatorCliArgs = AccountValidatorArgs &
     force: boolean;
     graffiti: string;
     afterBlockDelaySlotFraction?: number;
+    scAfterBlockDelaySlotFraction?: number;
     suggestedFeeRecipient?: string;
     proposerSettingsFile?: string;
     strictFeeRecipientCheck?: boolean;
@@ -142,7 +143,15 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
 
   afterBlockDelaySlotFraction: {
     hidden: true,
-    description: "Delay before publishing attestations if block comes early, as a fraction of SECONDS_PER_SLOT",
+    description:
+      "Delay before publishing attestations if block comes early, as a fraction of SECONDS_PER_SLOT (value is from 0 inclusive to 1 exclusive)",
+    type: "number",
+  },
+
+  scAfterBlockDelaySlotFraction: {
+    hidden: true,
+    description:
+      "Delay before publishing SyncCommitteeSignature if block comes early, as a fraction of SECONDS_PER_SLOT (value is from 0 inclusive to 1 exclusive)",
     type: "number",
   },
 

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -130,8 +130,8 @@ export class AttestationService {
     // never beyond the 1/3 cutoff time.
     // https://github.com/status-im/nimbus-eth2/blob/7b64c1dce4392731a4a59ee3a36caef2e0a8357a/beacon_chain/validators/validator_duties.nim#L1123
     const msToOneThirdSlot = this.clock.msToSlot(slot + 1 / 3);
-    // Default = 6, which is half of attestation offset
-    const afterBlockDelayMs = (1000 * this.clock.secondsPerSlot) / (this.opts?.afterBlockDelaySlotFraction ?? 6);
+    // Default = 1/6, which is half of attestation offset
+    const afterBlockDelayMs = 1000 * this.clock.secondsPerSlot * (this.opts?.afterBlockDelaySlotFraction ?? 1 / 6);
     await sleep(Math.min(msToOneThirdSlot, afterBlockDelayMs));
 
     this.metrics?.attesterStepCallPublishAttestation.observe(this.clock.secFromSlot(slot + 1 / 3));

--- a/packages/validator/src/services/emitter.ts
+++ b/packages/validator/src/services/emitter.ts
@@ -1,5 +1,6 @@
 import {EventEmitter} from "events";
 import StrictEventEmitter from "strict-event-emitter-types";
+import {Slot} from "@lodestar/types";
 import {HeadEventData} from "./chainHeaderTracker.js";
 
 export enum ValidatorEvent {
@@ -18,4 +19,25 @@ export interface IValidatorEvents {
  */
 export class ValidatorEventEmitter extends (EventEmitter as {
   new (): StrictEventEmitter<EventEmitter, IValidatorEvents>;
-}) {}
+}) {
+  /**
+   * Wait for the first block to come with slot >= provided slot.
+   */
+  async waitForBlockSlot(slot: Slot): Promise<void> {
+    let headListener: (head: HeadEventData) => void;
+
+    const onDone = (): void => {
+      this.off(ValidatorEvent.chainHead, headListener);
+    };
+
+    return new Promise((resolve) => {
+      headListener = (head: HeadEventData): void => {
+        if (head.slot >= slot) {
+          onDone();
+          resolve();
+        }
+      };
+      this.on(ValidatorEvent.chainHead, headListener);
+    });
+  }
+}

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -10,6 +10,7 @@ import {ValidatorStore} from "./validatorStore.js";
 import {SyncCommitteeDutiesService, SyncDutyAndProofs} from "./syncCommitteeDuties.js";
 import {groupSyncDutiesBySubcommitteeIndex, SubcommitteeDuty} from "./utils.js";
 import {ChainHeaderTracker} from "./chainHeaderTracker.js";
+import {ValidatorEventEmitter} from "./emitter.js";
 
 /**
  * Service that sets up and handles validator sync duties.
@@ -23,6 +24,7 @@ export class SyncCommitteeService {
     private readonly api: Api,
     private readonly clock: IClock,
     private readonly validatorStore: ValidatorStore,
+    private readonly emitter: ValidatorEventEmitter,
     private readonly chainHeaderTracker: ChainHeaderTracker,
     private readonly metrics: Metrics | null
   ) {
@@ -49,8 +51,10 @@ export class SyncCommitteeService {
         return;
       }
 
-      // Lighthouse recommends to always wait to 1/3 of the slot, even if the block comes early
-      await sleep(this.clock.msToSlot(slot + 1 / 3), signal);
+      // unlike Attestation, SyncCommitteeSignature could be published asap
+      // especially with lodestar, it's very busy at 1/3 of slot
+      // see https://github.com/ChainSafe/lodestar/issues/4608
+      await Promise.race([sleep(this.clock.msToSlot(slot + 1 / 3), signal), this.emitter.waitForBlockSlot(slot)]);
       this.metrics?.syncCommitteeStepCallProduceMessage.observe(this.clock.secFromSlot(slot + 1 / 3));
 
       // Step 1. Download, sign and publish an `SyncCommitteeMessage` for each validator.

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -125,6 +125,7 @@ export class Validator {
       api,
       clock,
       validatorStore,
+      emitter,
       chainHeaderTracker,
       metrics
     );

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -31,6 +31,7 @@ export type ValidatorOptions = {
   logger: ILogger;
   processShutdownCallback: ProcessShutdownCallback;
   afterBlockDelaySlotFraction?: number;
+  scAfterBlockDelaySlotFraction?: number;
   doppelgangerProtectionEnabled?: boolean;
   closed?: boolean;
   valProposerConfig?: ValidatorProposerConfig;
@@ -127,7 +128,8 @@ export class Validator {
       validatorStore,
       emitter,
       chainHeaderTracker,
-      metrics
+      metrics,
+      {scAfterBlockDelaySlotFraction: opts.scAfterBlockDelaySlotFraction}
     );
 
     this.config = config;

--- a/packages/validator/test/unit/services/syncCommittee.test.ts
+++ b/packages/validator/test/unit/services/syncCommittee.test.ts
@@ -12,6 +12,7 @@ import {getApiClientStub} from "../../utils/apiStub.js";
 import {loggerVc} from "../../utils/logger.js";
 import {ClockMock} from "../../utils/clock.js";
 import {ChainHeaderTracker} from "../../../src/services/chainHeaderTracker.js";
+import {ValidatorEventEmitter} from "../../../src/services/emitter.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -22,6 +23,8 @@ describe("SyncCommitteeService", function () {
   const api = getApiClientStub(sandbox);
   const validatorStore = sinon.createStubInstance(ValidatorStore) as ValidatorStore &
     sinon.SinonStubbedInstance<ValidatorStore>;
+  const emitter = sinon.createStubInstance(ValidatorEventEmitter) as ValidatorEventEmitter &
+    sinon.SinonStubbedInstance<ValidatorEventEmitter>;
   const chainHeaderTracker = sinon.createStubInstance(ChainHeaderTracker) as ChainHeaderTracker &
     sinon.SinonStubbedInstance<ChainHeaderTracker>;
   let pubkeys: Uint8Array[]; // Initialize pubkeys in before() so bls is already initialized
@@ -53,6 +56,7 @@ describe("SyncCommitteeService", function () {
       api,
       clock,
       validatorStore,
+      emitter,
       chainHeaderTracker,
       null
     );


### PR DESCRIPTION
**Motivation**

We want to release v1.1.1 with SyncCommittee improvement

**Description**

- Cherry-pick #4615 from unstable: submit SyncCommitteeSignature asap
- Cherry-pick #4626 from unstable: configure afterBlockDelaySlotFraction for Attestation and SyncCommitteeSignature
