### PR TITLE
Migrate to prom-client 14.1.0

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -142,7 +142,7 @@
     "it-pipe": "^2.0.4",
     "jwt-simple": "0.5.6",
     "libp2p": "0.39.2",
-    "prom-client": "^13.2.0",
+    "prom-client": "^14.1.0",
     "prometheus-gc-stats": "^0.6.3",
     "snappyjs": "^0.7.0",
     "stream-to-it": "^0.2.0",

--- a/packages/beacon-node/src/metrics/metrics.ts
+++ b/packages/beacon-node/src/metrics/metrics.ts
@@ -37,11 +37,7 @@ export function createMetrics(
 
   // Merge external registries
   for (const externalRegister of externalRegistries) {
-    // Wrong types, does not return a promise
-    const metrics = (externalRegister.getMetricsAsArray() as unknown) as Resolves<
-      typeof externalRegister.getMetricsAsArray
-    >;
-    for (const metric of metrics) {
+    for (const metric of externalRegister.getMetricsAsArray()) {
       register.registerMetric((metric as unknown) as Metric<string>);
     }
   }
@@ -67,6 +63,3 @@ export function collectNodeJSMetrics(register: Registry): void {
   // - nodejs_gc_reclaimed_bytes_total: The number of bytes GC has freed
   gcStats(register)();
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Resolves<F extends (...args: any[]) => Promise<any>> = F extends (...args: any[]) => Promise<infer T> ? T : never;

--- a/packages/beacon-node/test/unit/metrics/beacon.test.ts
+++ b/packages/beacon-node/test/unit/metrics/beacon.test.ts
@@ -4,7 +4,7 @@ import {createMetricsTest} from "./utils.js";
 describe("BeaconMetrics", () => {
   it("updated metrics should be reflected in the register", async () => {
     const metrics = createMetricsTest();
-    const metricsAsArray = await metrics.register.getMetricsAsArray();
+    const metricsAsArray = metrics.register.getMetricsAsArray();
     const metricsAsText = await metrics.register.metrics();
 
     // basic assumptions

--- a/packages/beacon-node/test/unit/metrics/metrics.test.ts
+++ b/packages/beacon-node/test/unit/metrics/metrics.test.ts
@@ -4,7 +4,7 @@ import {createMetricsTest} from "./utils.js";
 describe("Metrics", () => {
   it("should get default metrics from register", async () => {
     const metrics = createMetricsTest();
-    const metricsAsArray = await metrics.register.getMetricsAsArray();
+    const metricsAsArray = metrics.register.getMetricsAsArray();
     const metricsAsText = await metrics.register.metrics();
     expect(metricsAsArray.length).to.be.gt(0);
     expect(metricsAsText).to.not.equal("");

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -81,7 +81,7 @@
     "lockfile": "^1.0.4",
     "lodash": "^4.17.15",
     "peer-id": "^0.15.3",
-    "prom-client": "^14.0.1",
+    "prom-client": "^14.1.0",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.19",
     "uint8arrays": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11037,17 +11037,10 @@ progress@^2.0.3:
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-prom-client@^13.2.0:
-  version "13.2.0"
-  resolved "https://registry.npmjs.org/prom-client/-/prom-client-13.2.0.tgz"
-  integrity sha512-wGr5mlNNdRNzEhRYXgboUU2LxHWIojxscJKmtG3R8f4/KiWqyYgXTLHs0+Ted7tG3zFT7pgHJbtomzZ1L0ARaQ==
-  dependencies:
-    tdigest "^0.1.1"
-
-prom-client@^14.0.1:
-  version "14.0.1"
-  resolved "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz"
-  integrity sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==
+prom-client@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.1.0.tgz#049609859483d900844924df740722c76ed1fdbb"
+  integrity sha512-iFWCchQmi4170omLpFXbzz62SQTmPhtBL35v0qGEVRHKcqIeiexaoYeP0vfZTujxEq3tA87iqOdRbC9svS1B9A==
   dependencies:
     tdigest "^0.1.1"
 


### PR DESCRIPTION
**Motivation**

Improve `gauge.inc()` performance, see https://github.com/ChainSafe/js-libp2p-gossipsub/issues/275

**Description**

Update to prom-client 14.1.0

part of https://github.com/ChainSafe/js-libp2p-gossipsub/issues/275
