### PR TITLE
Remove peer overrides from dev command defaults

### DIFF
--- a/packages/cli/src/cmds/dev/options.ts
+++ b/packages/cli/src/cmds/dev/options.ts
@@ -74,16 +74,6 @@ const externalOptionsOverrides: Partial<Record<"network" | keyof typeof beaconNo
     defaultDescription: undefined,
     default: true,
   },
-  "network.maxPeers": {
-    ...beaconNodeOptions["network.maxPeers"],
-    defaultDescription: undefined,
-    default: 1,
-  },
-  targetPeers: {
-    ...beaconNodeOptions["targetPeers"],
-    defaultDescription: undefined,
-    default: 1,
-  },
   eth1: {
     ...beaconNodeOptions["eth1"],
     defaultDescription: undefined,


### PR DESCRIPTION
Running lodestar in dev network with default args was not allowing to connect the second lodestar bn to connect to the bootnode.

the reason is the peer restrictions in the oveeride of the defaults, which doesn't really make any sense to restrict nodes to connect to dev network. 
This PR removes the overrides
Closes #4662