### PR TITLE
Add state upgrade to capella and enable spec tests

### DIFF
--- a/packages/beacon-node/test/spec/presets/fork.ts
+++ b/packages/beacon-node/test/spec/presets/fork.ts
@@ -1,4 +1,9 @@
-import {BeaconStateAllForks, CachedBeaconStateAltair, CachedBeaconStatePhase0} from "@lodestar/state-transition";
+import {
+  BeaconStateAllForks,
+  CachedBeaconStateBellatrix,
+  CachedBeaconStateAltair,
+  CachedBeaconStatePhase0,
+} from "@lodestar/state-transition";
 import * as slotFns from "@lodestar/state-transition/slot";
 import {phase0, ssz} from "@lodestar/types";
 import {ForkName} from "@lodestar/params";
@@ -23,7 +28,7 @@ export const fork: TestRunnerFn<ForkStateCase, BeaconStateAllForks> = (forkNext)
         case ForkName.bellatrix:
           return slotFns.upgradeStateToBellatrix(preState as CachedBeaconStateAltair);
         case ForkName.capella:
-          throw Error("capella upgrade not implemented yet");
+          return slotFns.upgradeStateToCapella(preState as CachedBeaconStateBellatrix);
       }
     },
     options: {

--- a/packages/beacon-node/test/spec/specTestVersioning.ts
+++ b/packages/beacon-node/test/spec/specTestVersioning.ts
@@ -15,7 +15,7 @@ import {IDownloadTestsOptions} from "@lodestar/spec-test-util";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const ethereumConsensusSpecsTests: IDownloadTestsOptions = {
-  specVersion: "v1.2.0-rc.3",
+  specVersion: "v1.2.0",
   // Target directory is the host package root: 'packages/*/spec-tests'
   outputDir: path.join(__dirname, "../../spec-tests"),
   specTestsRepoUrl: "https://github.com/ethereum/consensus-spec-tests",

--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -40,10 +40,6 @@ const ARTIFACT_FILENAMES = new Set([
  */
 export function specTestIterator(configDirpath: string, testRunners: Record<string, TestRunner>): void {
   for (const forkStr of readdirSyncSpec(configDirpath)) {
-    // TODO enable capella
-    if (forkStr === "capella") {
-      continue;
-    }
     const fork = ForkName[forkStr as ForkName];
     if (fork === undefined) {
       throw Error(`Unknown fork ${forkStr}`);
@@ -52,7 +48,7 @@ export function specTestIterator(configDirpath: string, testRunners: Record<stri
     const forkDirpath = path.join(configDirpath, fork);
     for (const testRunnerName of readdirSyncSpec(forkDirpath)) {
       // We don't have runner for light client yet
-      if (testRunnerName === "light_client") {
+      if (["light_client", "sync"].includes(testRunnerName)) {
         continue;
       }
       const testRunnerDirpath = path.join(forkDirpath, testRunnerName);

--- a/packages/params/src/presets/mainnet/index.ts
+++ b/packages/params/src/presets/mainnet/index.ts
@@ -4,7 +4,7 @@ import {altair} from "./altair.js";
 import {bellatrix} from "./bellatrix.js";
 import {capella} from "./capella.js";
 
-export const commit = "v1.2.0-rc.3";
+export const commit = "v1.2.0";
 
 export const preset: BeaconPreset = {
   ...phase0,

--- a/packages/params/src/presets/minimal/index.ts
+++ b/packages/params/src/presets/minimal/index.ts
@@ -4,7 +4,7 @@ import {altair} from "./altair.js";
 import {bellatrix} from "./bellatrix.js";
 import {capella} from "./capella.js";
 
-export const commit = "v1.2.0-rc.3";
+export const commit = "v1.2.0";
 
 export const preset: BeaconPreset = {
   ...phase0,

--- a/packages/state-transition/src/block/processDeposit.ts
+++ b/packages/state-transition/src/block/processDeposit.ts
@@ -88,8 +88,9 @@ export function processDeposit(fork: ForkSeq, state: CachedBeaconStateAllForks, 
       (validators as CachedBeaconStateCapella["validators"]).push(
         ssz.capella.Validator.toViewDU({
           ...newValidatorFields,
-          // Very strange that this needs to be set at 0 else statroot mismatches with spec tests blocks,
-          // may be this will get updated later on to a proper epoch or field likely will be junked
+          // Very strange that this needs to be set at 0 rather than FAR_FUTURE_EPOCH else stateRoot mismatches
+          // with spec tests blocks.
+          // May be this will get updated later on to a proper epoch or field likely will be junked
           fullyWithdrawnEpoch: 0,
         })
       );

--- a/packages/state-transition/src/block/processDeposit.ts
+++ b/packages/state-transition/src/block/processDeposit.ts
@@ -72,25 +72,31 @@ export function processDeposit(fork: ForkSeq, state: CachedBeaconStateAllForks, 
 
     // add validator and balance entries
     const effectiveBalance = Math.min(amount - (amount % EFFECTIVE_BALANCE_INCREMENT), MAX_EFFECTIVE_BALANCE);
-    const newValidatorFields = {
-      pubkey,
-      withdrawalCredentials: deposit.data.withdrawalCredentials,
-      activationEligibilityEpoch: FAR_FUTURE_EPOCH,
-      activationEpoch: FAR_FUTURE_EPOCH,
-      exitEpoch: FAR_FUTURE_EPOCH,
-      withdrawableEpoch: FAR_FUTURE_EPOCH,
-      effectiveBalance,
-      slashed: false,
-    };
     if (fork < ForkSeq.capella) {
-      (validators as CachedBeaconStatePhase0["validators"]).push(ssz.phase0.Validator.toViewDU(newValidatorFields));
+      (validators as CachedBeaconStatePhase0["validators"]).push(
+        ssz.phase0.Validator.toViewDU({
+          pubkey,
+          withdrawalCredentials: deposit.data.withdrawalCredentials,
+          activationEligibilityEpoch: FAR_FUTURE_EPOCH,
+          activationEpoch: FAR_FUTURE_EPOCH,
+          exitEpoch: FAR_FUTURE_EPOCH,
+          withdrawableEpoch: FAR_FUTURE_EPOCH,
+          effectiveBalance,
+          slashed: false,
+        })
+      );
     } else {
       (validators as CachedBeaconStateCapella["validators"]).push(
         ssz.capella.Validator.toViewDU({
-          ...newValidatorFields,
-          // Very strange that this needs to be set at 0 rather than FAR_FUTURE_EPOCH else stateRoot mismatches
-          // with spec tests blocks.
-          // May be this will get updated later on to a proper epoch or field likely will be junked
+          pubkey,
+          withdrawalCredentials: deposit.data.withdrawalCredentials,
+          activationEligibilityEpoch: FAR_FUTURE_EPOCH,
+          activationEpoch: FAR_FUTURE_EPOCH,
+          exitEpoch: FAR_FUTURE_EPOCH,
+          withdrawableEpoch: FAR_FUTURE_EPOCH,
+          effectiveBalance,
+          slashed: false,
+          // This field is removed in the latest spec, but is present in 1.2.0 set to 0
           fullyWithdrawnEpoch: 0,
         })
       );

--- a/packages/state-transition/src/block/processDeposit.ts
+++ b/packages/state-transition/src/block/processDeposit.ts
@@ -72,31 +72,25 @@ export function processDeposit(fork: ForkSeq, state: CachedBeaconStateAllForks, 
 
     // add validator and balance entries
     const effectiveBalance = Math.min(amount - (amount % EFFECTIVE_BALANCE_INCREMENT), MAX_EFFECTIVE_BALANCE);
+    const newValidatorFields = {
+      pubkey,
+      withdrawalCredentials: deposit.data.withdrawalCredentials,
+      activationEligibilityEpoch: FAR_FUTURE_EPOCH,
+      activationEpoch: FAR_FUTURE_EPOCH,
+      exitEpoch: FAR_FUTURE_EPOCH,
+      withdrawableEpoch: FAR_FUTURE_EPOCH,
+      effectiveBalance,
+      slashed: false,
+    };
     if (fork < ForkSeq.capella) {
-      (validators as CachedBeaconStatePhase0["validators"]).push(
-        ssz.phase0.Validator.toViewDU({
-          pubkey,
-          withdrawalCredentials: deposit.data.withdrawalCredentials,
-          activationEligibilityEpoch: FAR_FUTURE_EPOCH,
-          activationEpoch: FAR_FUTURE_EPOCH,
-          exitEpoch: FAR_FUTURE_EPOCH,
-          withdrawableEpoch: FAR_FUTURE_EPOCH,
-          effectiveBalance,
-          slashed: false,
-        })
-      );
+      (validators as CachedBeaconStatePhase0["validators"]).push(ssz.phase0.Validator.toViewDU(newValidatorFields));
     } else {
       (validators as CachedBeaconStateCapella["validators"]).push(
         ssz.capella.Validator.toViewDU({
-          pubkey,
-          withdrawalCredentials: deposit.data.withdrawalCredentials,
-          activationEligibilityEpoch: FAR_FUTURE_EPOCH,
-          activationEpoch: FAR_FUTURE_EPOCH,
-          exitEpoch: FAR_FUTURE_EPOCH,
-          withdrawableEpoch: FAR_FUTURE_EPOCH,
-          effectiveBalance,
-          slashed: false,
-          fullyWithdrawnEpoch: FAR_FUTURE_EPOCH,
+          ...newValidatorFields,
+          // Very strange that this needs to be set at 0 else statroot mismatches with spec tests blocks,
+          // may be this will get updated later on to a proper epoch or field likely will be junked
+          fullyWithdrawnEpoch: 0,
         })
       );
     }

--- a/packages/state-transition/src/slot/index.ts
+++ b/packages/state-transition/src/slot/index.ts
@@ -5,6 +5,7 @@ import {ZERO_HASH} from "../constants/index.js";
 
 export {upgradeStateToAltair} from "./upgradeStateToAltair.js";
 export {upgradeStateToBellatrix} from "./upgradeStateToBellatrix.js";
+export {upgradeStateToCapella} from "./upgradeStateToCapella.js";
 
 /**
  * Dial state to next slot. Common for all forks

--- a/packages/state-transition/src/slot/upgradeStateToBellatrix.ts
+++ b/packages/state-transition/src/slot/upgradeStateToBellatrix.ts
@@ -13,7 +13,7 @@ export function upgradeStateToBellatrix(stateAltair: CachedBeaconStateAltair): C
   // An altair BeaconState tree can be safely casted to a bellatrix BeaconState tree because:
   // - All new fields are appended at the end
   //
-  // altair                        | op  | altair
+  // altair                        | op  | bellatrix
   // ----------------------------- | --- | ------------
   // genesis_time                  | -   | genesis_time
   // genesis_validators_root       | -   | genesis_validators_root

--- a/packages/state-transition/src/slot/upgradeStateToCapella.ts
+++ b/packages/state-transition/src/slot/upgradeStateToCapella.ts
@@ -8,13 +8,13 @@ import {getCachedBeaconState} from "../cache/stateCache.js";
 export function upgradeStateToCapella(stateBellatrix: CachedBeaconStateBellatrix): CachedBeaconStateCapella {
   const {config} = stateBellatrix;
 
-  // Get underlying node and cast altair tree to bellatrix tree
+  // Get underlying node and cast bellatrix tree to capella tree
   //
   // An bellatrix BeaconState tree can be safely casted to a capella BeaconState tree because:
   // - Deprecated fields are replaced by new fields at the exact same indexes
   // - All new fields are appended at the end
   //
-  // altair                           | op   | altair
+  // bellatrix                        | op   | capella
   // -------------------------------- | ---- | ------------
   // genesis_time                     | -    | genesis_time
   // genesis_validators_root          | -    | genesis_validators_root
@@ -56,7 +56,8 @@ export function upgradeStateToCapella(stateBellatrix: CachedBeaconStateBellatrix
     epoch: stateBellatrix.epochCtx.epoch,
   });
 
-  // Upgrade the validators
+  // Upgrade the validators, this validator change is not present in latest specs but in 1.2.0
+  // so just set it to 0 and cleanup later
   for (let i = 0; i < stateCapella.validators.length; i++) {
     const validator = stateCapella.validators.get(i);
     validator.fullyWithdrawnEpoch = Infinity;

--- a/packages/state-transition/src/slot/upgradeStateToCapella.ts
+++ b/packages/state-transition/src/slot/upgradeStateToCapella.ts
@@ -1,0 +1,74 @@
+import {ssz} from "@lodestar/types";
+import {CachedBeaconStateBellatrix, CachedBeaconStateCapella} from "../types.js";
+import {getCachedBeaconState} from "../cache/stateCache.js";
+
+/**
+ * Upgrade a state from altair to bellatrix.
+ */
+export function upgradeStateToCapella(stateBellatrix: CachedBeaconStateBellatrix): CachedBeaconStateCapella {
+  const {config} = stateBellatrix;
+
+  // Get underlying node and cast altair tree to bellatrix tree
+  //
+  // An bellatrix BeaconState tree can be safely casted to a capella BeaconState tree because:
+  // - Deprecated fields are replaced by new fields at the exact same indexes
+  // - All new fields are appended at the end
+  //
+  // altair                           | op   | altair
+  // -------------------------------- | ---- | ------------
+  // genesis_time                     | -    | genesis_time
+  // genesis_validators_root          | -    | genesis_validators_root
+  // slot                             | -    | slot
+  // fork                             | -    | fork
+  // latest_block_header              | -    | latest_block_header
+  // block_roots                      | -    | block_roots
+  // state_roots                      | -    | state_roots
+  // historical_roots                 | -    | historical_roots
+  // eth1_data                        | -    | eth1_data
+  // eth1_data_votes                  | -    | eth1_data_votes
+  // eth1_deposit_index               | -    | eth1_deposit_index
+  // validators                       | diff | validators
+  // balances                         | -    | balances
+  // randao_mixes                     | -    | randao_mixes
+  // slashings                        | -    | slashings
+  // previous_epoch_participation     | -    | previous_epoch_participation
+  // current_epoch_participation      | -    | current_epoch_participation
+  // justification_bits               | -    | justification_bits
+  // previous_justified_checkpoint    | -    | previous_justified_checkpoint
+  // current_justified_checkpoint     | -    | current_justified_checkpoint
+  // finalized_checkpoint             | -    | finalized_checkpoint
+  // inactivity_scores                | -    | inactivity_scores
+  // current_sync_committee           | -    | current_sync_committee
+  // next_sync_committee              | -    | next_sync_committee
+  // latest_execution_payload_header  | diff | latest_execution_payload_header
+  // -                                | new  | withdrawal_queue
+  // -                                | new  | next_withdrawal_index
+  // -                                | new  | next_partial_withdrawal_validator_index
+
+  const stateBellatrixNode = ssz.bellatrix.BeaconState.commitViewDU(stateBellatrix);
+  const stateCapellaView = ssz.capella.BeaconState.getViewDU(stateBellatrixNode);
+  // Attach existing BeaconStateCache from stateBellatrix to new stateCapellaView object
+  const stateCapella = getCachedBeaconState(stateCapellaView, stateBellatrix);
+
+  stateCapella.fork = ssz.phase0.Fork.toViewDU({
+    previousVersion: stateBellatrix.fork.currentVersion,
+    currentVersion: config.CAPELLA_FORK_VERSION,
+    epoch: stateBellatrix.epochCtx.epoch,
+  });
+
+  // Upgrade the validators
+  for (let i = 0; i < stateCapella.validators.length; i++) {
+    const validator = stateCapella.validators.get(i);
+    validator.fullyWithdrawnEpoch = Infinity;
+  }
+  // Nothing to do for latestExecutionPayloadHeader as the root is set to 0 by default
+  stateCapella.withdrawalQueue = ssz.capella.WithdrawalQueue.defaultViewDU();
+  // nextWithdrawalIndex and nextPartialWithdrawalValidatorIndex are also set to 0 by default
+
+  // Commit new added fields ViewDU to the root node
+  stateCapella.commit();
+  // Clear cache to ensure the cache of bellatrix fields is not used by new capella fields
+  stateCapella["clearCache"]();
+
+  return stateCapella;
+}

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -67,6 +67,7 @@ export function stateTransition(
 
   // Apply changes to state, must do before hashing. Note: .hashTreeRoot() automatically commits() too
   postState.commit();
+
   // Verify state root
   if (verifyStateRoot) {
     const stateRoot = postState.hashTreeRoot();

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -4,10 +4,15 @@ import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {toHexString} from "@chainsafe/ssz";
 import {IBeaconStateTransitionMetrics} from "./metrics.js";
 import {beforeProcessEpoch, EpochProcessOpts} from "./cache/epochProcess.js";
-import {CachedBeaconStateAllForks, CachedBeaconStatePhase0, CachedBeaconStateAltair} from "./types.js";
+import {
+  CachedBeaconStateAllForks,
+  CachedBeaconStatePhase0,
+  CachedBeaconStateAltair,
+  CachedBeaconStateBellatrix,
+} from "./types.js";
 import {computeEpochAtSlot} from "./util/index.js";
 import {verifyProposerSignature} from "./signatureSets/index.js";
-import {processSlot, upgradeStateToAltair, upgradeStateToBellatrix} from "./slot/index.js";
+import {processSlot, upgradeStateToAltair, upgradeStateToBellatrix, upgradeStateToCapella} from "./slot/index.js";
 import {processBlock} from "./block/index.js";
 import {processEpoch} from "./epoch/index.js";
 
@@ -62,7 +67,6 @@ export function stateTransition(
 
   // Apply changes to state, must do before hashing. Note: .hashTreeRoot() automatically commits() too
   postState.commit();
-
   // Verify state root
   if (verifyStateRoot) {
     const stateRoot = postState.hashTreeRoot();
@@ -144,6 +148,9 @@ function processSlotsWithTransientCache(
       }
       if (stateSlot === config.BELLATRIX_FORK_EPOCH) {
         postState = upgradeStateToBellatrix(postState as CachedBeaconStateAltair) as CachedBeaconStateAllForks;
+      }
+      if (stateSlot === config.CAPELLA_FORK_EPOCH) {
+        postState = upgradeStateToCapella(postState as CachedBeaconStateBellatrix) as CachedBeaconStateAllForks;
       }
     } else {
       postState.slot++;


### PR DESCRIPTION
- Add state upgrade to capella 
- enable spec tests for capella which only has `transition` tests enabled in the spec 1.2.0/rcs versions
- upgrade spec to 1.2.0 from tc
- exclude new `sync` tests as we will need to write spec runners for it, task created

Part of
  -  https://github.com/ChainSafe/lodestar/issues/4680