### PR TITLE
Add warnings about starting API on public ip

### DIFF
--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -103,6 +103,9 @@ export class RestApiServer {
     try {
       const address = await this.server.listen(this.opts.port, this.opts.address);
       this.logger.info("Started REST api server", {address});
+      if (this.opts.address === "0.0.0.0") {
+        this.logger.warn("REST api server started on public ip. This is a DoS vector if configured accidentally.");
+      }
     } catch (e) {
       this.logger.error("Error starting REST api server", this.opts, e as Error);
       throw e;

--- a/packages/cli/src/options/beaconNodeOptions/api.ts
+++ b/packages/cli/src/options/beaconNodeOptions/api.ts
@@ -66,7 +66,7 @@ export const options: ICliCommandOptions<IApiArgs> = {
 
   "rest.address": {
     type: "string",
-    description: "Set host for HTTP API",
+    description: "Set host for HTTP API. WARNING: Publicly making this available is a DoS vector.",
     defaultDescription: defaultOptions.api.rest.address,
     group: "api",
   },


### PR DESCRIPTION
**Motivation**

It may be a DoS vector to start the API on a public IP.
Users should be warned against doing this accidentally.

**Description**

- Add cli help warning
- Add log warning