### PR TITLE
More conservative inbound stream count

### DIFF
--- a/packages/beacon-node/src/network/nodejs/bundle.ts
+++ b/packages/beacon-node/src/network/nodejs/bundle.ts
@@ -40,7 +40,7 @@ export async function createNodejsLibp2p(options: ILibp2pOptions): Promise<Libp2
     },
     connectionEncryption: [new Noise()],
     transports: [new TCP()],
-    streamMuxers: [new Mplex()],
+    streamMuxers: [new Mplex({maxInboundStreams: 256})],
     peerDiscovery,
     metrics: {
       enabled: Boolean(options.metrics),


### PR DESCRIPTION
**Motivation**

We can be more conservative than the default.
Default: 1024
Now: 256