### PR TITLE
Add network.gossipsubAwaitHandler option

### DIFF
--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -58,6 +58,7 @@ export type Eth2GossipsubOpts = {
   gossipsubD?: number;
   gossipsubDLow?: number;
   gossipsubDHigh?: number;
+  gossipsubAwaitHandler?: boolean;
 };
 
 /**
@@ -108,6 +109,10 @@ export class Eth2Gossipsub extends GossipSub {
       seenTTL: 550 * GOSSIPSUB_HEARTBEAT_INTERVAL,
       scoreParams,
       scoreThresholds: gossipScoreThresholds,
+      // For a single stream, await processing each RPC before processing the next
+      awaitRpcHandler: opts.gossipsubAwaitHandler,
+      // For a single RPC, await processing each message before processing the next
+      awaitRpcMessageHandler: opts.gossipsubAwaitHandler,
       // the default in gossipsub is 3s is not enough since lodestar suffers from I/O lag
       gossipsubIWantFollowupMs: 12 * 1000, // 12s
       fastMsgIdFn: fastMsgIdFn,

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -24,6 +24,7 @@ export interface INetworkArgs {
   "network.gossipsubD": number;
   "network.gossipsubDLow": number;
   "network.gossipsubDHigh": number;
+  "network.gossipsubAwaitHandler": boolean;
 }
 
 export function parseArgs(args: INetworkArgs): IBeaconNodeOptions["network"] {
@@ -55,6 +56,7 @@ export function parseArgs(args: INetworkArgs): IBeaconNodeOptions["network"] {
     gossipsubD: args["network.gossipsubD"],
     gossipsubDLow: args["network.gossipsubDLow"],
     gossipsubDHigh: args["network.gossipsubDHigh"],
+    gossipsubAwaitHandler: args["network.gossipsubAwaitHandler"],
   };
 }
 
@@ -202,6 +204,12 @@ export const options: ICliCommandOptions<INetworkArgs> = {
     hidden: true,
     type: "number",
     description: "Gossipsub D param high",
+    group: "network",
+  },
+
+  "network.gossipsubAwaitHandler": {
+    hidden: true,
+    type: "boolean",
     group: "network",
   },
 };

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -71,6 +71,7 @@ describe("options / beaconNodeOptions", () => {
       "network.gossipsubD": 4,
       "network.gossipsubDLow": 2,
       "network.gossipsubDHigh": 6,
+      "network.gossipsubAwaitHandler": true,
 
       "sync.isSingleNode": true,
       "sync.disableProcessAsChainSegment": true,
@@ -149,6 +150,7 @@ describe("options / beaconNodeOptions", () => {
         gossipsubD: 4,
         gossipsubDLow: 2,
         gossipsubDHigh: 6,
+        gossipsubAwaitHandler: true,
       },
       sync: {
         isSingleNode: true,


### PR DESCRIPTION
**Motivation**

Gossipsub RPC processing is async. Not awaiting may cause the node to get overloaded without allowing TCP backpressure to kick in.

**Description**

Add option to test awaiting each packet in stream processing.
