### PR TITLE
Use @chainsafe/bls 7.1.1 consistently

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,7 +51,7 @@
   ],
   "dependencies": {
     "@chainsafe/as-sha256": "^0.3.1",
-    "@chainsafe/bls": "7.1.0",
+    "@chainsafe/bls": "7.1.1",
     "@chainsafe/bls-keygen": "^0.3.0",
     "@chainsafe/bls-keystore": "^2.0.0",
     "@chainsafe/blst": "^0.2.4",

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -59,7 +59,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/as-sha256": "^0.3.1",
-    "@chainsafe/bls": "7.1.0",
+    "@chainsafe/bls": "7.1.1",
     "@chainsafe/persistent-merkle-tree": "^0.4.2",
     "@chainsafe/persistent-ts": "^0.19.1",
     "@chainsafe/ssz": "^0.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,15 +455,6 @@
     ethereum-cryptography "^0.1.3"
     uuid "^3.3.3"
 
-"@chainsafe/bls@7.1.0":
-  version "7.1.0"
-  resolved "https://registry.npmjs.org/@chainsafe/bls/-/bls-7.1.0.tgz"
-  integrity sha512-9MR4l8Mc8BAPizo7mqaEBGCUJKzMuqzlvyXA9k8zMhcXZaiZ4wTyAU5BDJJLaMNLAjBVcLT/VSGOWe2O7E8J8A==
-  dependencies:
-    "@chainsafe/bls-keygen" "^0.4.0"
-    bls-eth-wasm "^0.4.8"
-    randombytes "^2.1.0"
-
 "@chainsafe/bls@7.1.1":
   version "7.1.1"
   resolved "https://registry.npmjs.org/@chainsafe/bls/-/bls-7.1.1.tgz"


### PR DESCRIPTION
**Motivation**

We have both bls 7.1.1 and 7.1.0 in our repo, should go with 7.1.1 consistently
