### PR TITLE
Add metrics for aggregated attestations

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -48,9 +48,10 @@ export function getBeaconPoolApi({
           try {
             const {indexedAttestation, subnet} = await validateGossipAttestation(chain, attestation, null);
 
-            chain.attestationPool.add(attestation);
+            const insertOutcome = chain.attestationPool.add(attestation);
             const sentPeers = await network.gossip.publishBeaconAttestation(attestation, subnet);
             metrics?.submitUnaggregatedAttestation(seenTimestampSec, indexedAttestation, subnet, sentPeers);
+            metrics?.opPool.attestationPoolInsertOutcome.inc({insertOutcome});
           } catch (e) {
             errors.push(e as Error);
             logger.error(

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -628,6 +628,11 @@ export function createLodestarMetrics(
         name: "lodestar_oppool_attestation_pool_size",
         help: "Current size of the AttestationPool = total attestations unique by data and slot",
       }),
+      attestationPoolInsertOutcome: register.counter<"insertOutcome">({
+        name: "lodestar_attestation_pool_insert_outcome_total",
+        help: "Total number of InsertOutcome as a result of adding an attestation in a pool",
+        labelNames: ["insertOutcome"],
+      }),
       attesterSlashingPoolSize: register.gauge({
         name: "lodestar_oppool_attester_slashing_pool_size",
         help: "Current size of the AttesterSlashingPool",

--- a/packages/beacon-node/src/network/gossip/handlers/index.ts
+++ b/packages/beacon-node/src/network/gossip/handlers/index.ts
@@ -194,7 +194,8 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
       }
 
       try {
-        chain.attestationPool.add(attestation);
+        const insertOutcome = chain.attestationPool.add(attestation);
+        metrics?.opPool.attestationPoolInsertOutcome.inc({insertOutcome});
       } catch (e) {
         logger.error("Error adding unaggregated attestation to pool", {subnet}, e as Error);
       }

--- a/packages/validator/src/metrics.ts
+++ b/packages/validator/src/metrics.ts
@@ -169,6 +169,12 @@ export function getMetrics(register: MetricsRegister, gitData: LodestarGitData) 
       help: "Total published aggregates",
     }),
 
+    numParticipantsInAggregate: register.histogram({
+      name: "vc_attestation_service_participants_in_aggregate_total",
+      help: "Number of attestations in the published AggregatedAttestation",
+      buckets: [0, 50, 200, 500],
+    }),
+
     attestaterError: register.gauge<{error: "produce" | "sign" | "publish"}>({
       name: "vc_attestation_service_errors",
       help: "Total errors in AttestationService",

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -175,6 +175,7 @@ export class AttestationService {
       .catch((e: Error) => {
         throw extendError(e, "Error producing aggregateAndProofs");
       });
+    this.metrics?.numParticipantsInAggregate.observe(aggregate.data.aggregationBits.getTrueBitIndexes().length);
 
     const signedAggregateAndProofs: phase0.SignedAggregateAndProof[] = [];
 


### PR DESCRIPTION
**Motivation**

- I want to tweak SLOTS_RETAINED in attestation pools
- See performance of our published aggregated attestations

**Description**

- Add metrics to our attestation pool to see how many attestations are preaggregated
- Add metrics to show number of participations in our published AggregatedAttestation
- Since metrics are the same if I change `SLOTS_RETAINED` to 1, just leave it as is for now

part of #4690

The result shows fewer participations in our AggregatedAttestations than expected, probably because we drop so many unaggregated attestations
<img width="1223" alt="Screen Shot 2022-10-27 at 10 23 26" src="https://user-images.githubusercontent.com/10568965/198183688-72b80b0c-af6f-4216-910d-0f3125a2cf60.png">


