### PR TITLE
Disable libp2p metrics

### DIFF
--- a/packages/beacon-node/src/network/nodejs/bundle.ts
+++ b/packages/beacon-node/src/network/nodejs/bundle.ts
@@ -43,7 +43,7 @@ export async function createNodejsLibp2p(options: ILibp2pOptions): Promise<Libp2
     streamMuxers: [new Mplex({maxInboundStreams: 256})],
     peerDiscovery,
     metrics: {
-      enabled: Boolean(options.metrics),
+      enabled: false,
     },
     connectionManager: {
       // dialer config

--- a/packages/beacon-node/src/network/nodejs/bundle.ts
+++ b/packages/beacon-node/src/network/nodejs/bundle.ts
@@ -43,6 +43,8 @@ export async function createNodejsLibp2p(options: ILibp2pOptions): Promise<Libp2
     streamMuxers: [new Mplex({maxInboundStreams: 256})],
     peerDiscovery,
     metrics: {
+      // temporarily disable since there is a performance issue with it
+      // see https://github.com/ChainSafe/lodestar/issues/4698
       enabled: false,
     },
     connectionManager: {


### PR DESCRIPTION
**Motivation**

- Reduce `gc` run time since libp2p metrics has a performance issue, see https://github.com/ChainSafe/lodestar/issues/4698
- Unblock v1.2.0

**Description**

Disable libp2p metrics

part of #4698

**Test**
- novc

<img width="1221" alt="Screen Shot 2022-10-28 at 17 42 22" src="https://user-images.githubusercontent.com/10568965/198568971-c2321488-bb49-4deb-9db0-762804fc457b.png">

- sm1v

<img width="1241" alt="Screen Shot 2022-10-28 at 17 42 57" src="https://user-images.githubusercontent.com/10568965/198569073-c29756a9-cf8c-46e4-a4be-8c5b53fee768.png">

- md16

<img width="1251" alt="Screen Shot 2022-10-28 at 17 43 23" src="https://user-images.githubusercontent.com/10568965/198569145-648668ca-b7cc-4b96-a889-32be7f434d25.png">

- lg1k

<img width="1337" alt="Screen Shot 2022-10-28 at 17 43 53" src="https://user-images.githubusercontent.com/10568965/198569238-8d004c42-b565-4136-bd35-c535b7973b1d.png">
