### PR TITLE
Remove @types/jwt-simple package

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -156,7 +156,6 @@
     "@types/bl": "^5.0.1",
     "@types/eventsource": "^1.1.5",
     "@types/it-all": "^1.0.0",
-    "@types/jwt-simple": "0.5.33",
     "@types/leveldown": "^4.0.2",
     "@types/prometheus-gc-stats": "^0.6.1",
     "@types/supertest": "^2.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3325,11 +3325,6 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/jwt-simple@0.5.33":
-  version "0.5.33"
-  resolved "https://registry.npmjs.org/@types/jwt-simple/-/jwt-simple-0.5.33.tgz"
-  integrity sha1-+4Ocq+gUN5VPfQzQF2CtgJbsUm4=
-
 "@types/keyv@*":
   version "3.1.1"
   resolved "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz"


### PR DESCRIPTION
**Motivation**

This PR removes an obsolete package which speeds up the installation and reduces the dependency graph.

**Description**

`jwt-simple` contains built-in TypeScript declarations which are more
accurate than the types provided by the `@types/jwt-simple` package.

[built-in](https://github.com/hokaccha/node-jwt-simple/blob/master/index.d.ts) vs. [types package](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f7ec78508c6797e42f87a4390735bc2c650a1bfd/types/jwt-simple/index.d.ts)