### PR TITLE
Lazy aggregation

### DIFF
--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -1,4 +1,5 @@
 import bls from "@chainsafe/bls";
+import {PointFormat} from "@chainsafe/bls/types";
 import {
   ForkName,
   MAX_ATTESTATIONS,
@@ -15,7 +16,7 @@ import {
   computeStartSlotAtEpoch,
   getBlockRootAtSlot,
 } from "@lodestar/state-transition";
-import {toHexString} from "@chainsafe/ssz";
+import {BitArray, toHexString} from "@chainsafe/ssz";
 import {IForkChoice, EpochDifference} from "@lodestar/fork-choice";
 import {toHex, MapDef} from "@lodestar/utils";
 import {intersectUint8Arrays, IntersectResult} from "../../util/bitArray.js";
@@ -24,7 +25,14 @@ import {InsertOutcome} from "./types.js";
 
 type DataRootHex = string;
 
-type AttestationWithScore = {attestation: phase0.Attestation; score: number};
+interface AttestationUnaggregated {
+  data: phase0.AttestationData;
+  aggregationBits: phase0.Attestation["aggregationBits"];
+  /** @see {AggregateFast} for rationale */
+  signatures: Uint8Array[];
+}
+
+type AttestationWithScore = {attestation: AttestationUnaggregated; score: number};
 
 type GetParticipationFn = (epoch: Epoch, committee: number[]) => Set<number> | null;
 
@@ -90,8 +98,9 @@ export class AggregatedAttestationPool {
     }
 
     return attestationGroup.add({
-      attestation,
+      aggregationBits: attestation.aggregationBits,
       trueBitsCount: attestingIndicesCount,
+      signatures: [attestation.signature],
     });
   }
 
@@ -151,10 +160,16 @@ export class AggregatedAttestationPool {
         // The committeeCountPerSlot can be precomputed once per slot
 
         attestationsByScore.push(
-          ...attestationGroup.getAttestationsForBlock(participation).map((attestation) => ({
-            attestation: attestation.attestation,
-            score: attestation.notSeenAttesterCount / (stateSlot - slot),
-          }))
+          ...attestationGroup.getAttestationsForBlock(participation).map(
+            (attestation): AttestationWithScore => ({
+              attestation: {
+                data: attestationGroup.data,
+                aggregationBits: attestation.attestation.aggregationBits,
+                signatures: attestation.attestation.signatures,
+              },
+              score: attestation.notSeenAttesterCount / (stateSlot - slot),
+            })
+          )
         );
 
         // Stop accumulating attestations there are enough that may have good scoring
@@ -167,7 +182,7 @@ export class AggregatedAttestationPool {
     return attestationsByScore
       .sort((a, b) => b.score - a.score)
       .slice(0, MAX_ATTESTATIONS)
-      .map((attestation) => attestation.attestation);
+      .map((attestation): phase0.Attestation => toAggregatedAttestation(attestation.attestation));
   }
 
   /**
@@ -196,12 +211,13 @@ export class AggregatedAttestationPool {
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 interface AttestationWithIndex {
-  attestation: phase0.Attestation;
+  aggregationBits: BitArray;
+  signatures: Uint8Array[];
   trueBitsCount: number;
 }
 
 type AttestationNonParticipant = {
-  attestation: phase0.Attestation;
+  attestation: AttestationWithIndex;
   // this is <= attestingIndices.count since some attesters may be seen by the chain
   // this is only updated and used in removeBySeenValidators function
   notSeenAttesterCount: number;
@@ -229,12 +245,12 @@ export class MatchingDataAttestationGroup {
    * If it's a superset of an existing attestation, remove the existing attestation and add new.
    */
   add(attestation: AttestationWithIndex): InsertOutcome {
-    const newBits = attestation.attestation.aggregationBits;
+    const newBits = attestation.aggregationBits;
 
     const indicesToRemove = [];
 
     for (const [i, prevAttestation] of this.attestations.entries()) {
-      const prevBits = prevAttestation.attestation.aggregationBits;
+      const prevBits = prevAttestation.aggregationBits;
 
       switch (intersectUint8Arrays(newBits.uint8Array, prevBits.uint8Array)) {
         case IntersectResult.Subset:
@@ -285,7 +301,7 @@ export class MatchingDataAttestationGroup {
       committeeSeenAttesting[i] = seenAttestingIndices.has(this.committee[i]);
     }
 
-    for (const {attestation} of this.attestations) {
+    for (const attestation of this.attestations) {
       const {aggregationBits} = attestation;
       let notSeenAttesterCount = 0;
 
@@ -308,17 +324,31 @@ export class MatchingDataAttestationGroup {
 
   /** Get attestations for API. */
   getAttestations(): phase0.Attestation[] {
-    return this.attestations.map((attestation) => attestation.attestation);
+    return this.attestations.map(
+      ({aggregationBits, signatures}): phase0.Attestation =>
+        toAggregatedAttestation({data: this.data, aggregationBits, signatures})
+    );
   }
+}
+
+export function toAggregatedAttestation(attestation: AttestationUnaggregated): phase0.Attestation {
+  return {
+    data: attestation.data,
+    aggregationBits: attestation.aggregationBits,
+    signature: bls.Signature.aggregate(
+      // No need to validate Signature again since it has already been validated ------- false
+      attestation.signatures.map((signature) => signatureFromBytesNoCheck(signature))
+    ).toBytes(PointFormat.compressed),
+  };
 }
 
 export function aggregateInto(attestation1: AttestationWithIndex, attestation2: AttestationWithIndex): void {
   // Merge bits of attestation2 into attestation1
-  attestation1.attestation.aggregationBits.mergeOrWith(attestation2.attestation.aggregationBits);
+  attestation1.aggregationBits.mergeOrWith(attestation2.aggregationBits);
 
-  const signature1 = signatureFromBytesNoCheck(attestation1.attestation.signature);
-  const signature2 = signatureFromBytesNoCheck(attestation2.attestation.signature);
-  attestation1.attestation.signature = bls.Signature.aggregate([signature1, signature2]).toBytes();
+  for (const signature of attestation2.signatures) {
+    attestation1.signatures.push(signature);
+  }
 }
 
 /**

--- a/packages/beacon-node/src/chain/opPools/attestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/attestationPool.ts
@@ -1,5 +1,5 @@
 import {phase0, Slot, Root, ssz} from "@lodestar/types";
-import {PointFormat, Signature} from "@chainsafe/bls/types";
+import {PointFormat} from "@chainsafe/bls/types";
 import bls from "@chainsafe/bls";
 import {BitArray, toHexString} from "@chainsafe/ssz";
 import {MapDef} from "@lodestar/utils";
@@ -25,7 +25,17 @@ const MAX_ATTESTATIONS_PER_SLOT = 16_384;
 type AggregateFast = {
   data: phase0.Attestation["data"];
   aggregationBits: BitArray;
-  signature: Signature;
+  /**
+   * Two potential strategies to pre-aggregate attestation signatures:
+   * - Aggregate new signature into existing aggregate on .add(). More memory efficient as only 1 signature
+   *   is kept per aggregate. However, the eager aggregation may be useless if the connected validator ends up
+   *   not being an aggregator. bls.Signature.fromBytes() is not free, thus the aggregation may be done around
+   *   the 1/3 of the slot which is a very busy period.
+   * - Defer aggregation until getAggregate(). Consumes more memory but prevents extra work by only doing the
+   *   aggregation if the connected validator is an aggregator. The aggregation is done during 2/3 of the slot
+   *   which is a less busy time than 1/3 of the slot.
+   */
+  signatures: Uint8Array[];
 };
 
 /** Hex string of DataRoot `TODO` */
@@ -181,10 +191,7 @@ function aggregateAttestationInto(aggregate: AggregateFast, attestation: phase0.
   }
 
   aggregate.aggregationBits.set(bitIndex, true);
-  aggregate.signature = bls.Signature.aggregate([
-    aggregate.signature,
-    signatureFromBytesNoCheck(attestation.signature),
-  ]);
+  aggregate.signatures.push(attestation.signature);
   return InsertOutcome.Aggregated;
 }
 
@@ -196,7 +203,7 @@ function attestationToAggregate(attestation: phase0.Attestation): AggregateFast 
     data: attestation.data,
     // clone because it will be mutated
     aggregationBits: attestation.aggregationBits.clone(),
-    signature: signatureFromBytesNoCheck(attestation.signature),
+    signatures: [attestation.signature],
   };
 }
 
@@ -207,6 +214,9 @@ function fastToAttestation(aggFast: AggregateFast): phase0.Attestation {
   return {
     data: aggFast.data,
     aggregationBits: aggFast.aggregationBits,
-    signature: aggFast.signature.toBytes(PointFormat.compressed),
+    signature: bls.Signature.aggregate(
+      // No need to validate Signature again since it has already been validated --------------- false
+      aggFast.signatures.map((signature) => signatureFromBytesNoCheck(signature))
+    ).toBytes(PointFormat.compressed),
   };
 }

--- a/packages/beacon-node/src/chain/opPools/attestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/attestationPool.ts
@@ -220,7 +220,7 @@ function attestationToAggregate(attestation: phase0.Attestation): AggregateFast 
 function fastToAttestation(aggFast: AggregateFast): phase0.Attestation {
   if (aggFast.aggregatedAttestation) return aggFast.aggregatedAttestation;
 
-  return {
+  aggFast.aggregatedAttestation = {
     data: aggFast.data,
     aggregationBits: aggFast.aggregationBits,
     signature: bls.Signature.aggregate(
@@ -228,4 +228,6 @@ function fastToAttestation(aggFast: AggregateFast): phase0.Attestation {
       aggFast.signatures.map((signature) => signatureFromBytesNoCheck(signature))
     ).toBytes(PointFormat.compressed),
   };
+
+  return aggFast.aggregatedAttestation;
 }

--- a/packages/beacon-node/test/perf/bls/bls.test.ts
+++ b/packages/beacon-node/test/perf/bls/bls.test.ts
@@ -1,4 +1,3 @@
-import crypto from "crypto";
 import {itBench} from "@dapplion/benchmark";
 import bls from "@chainsafe/bls";
 import {CoordType, PointFormat, PublicKey, SecretKey, Signature} from "@chainsafe/bls/types";

--- a/packages/beacon-node/test/unit/chain/opPools/attestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/attestationPool.test.ts
@@ -1,0 +1,72 @@
+import {expect} from "chai";
+import bls from "@chainsafe/bls";
+import {phase0, ssz} from "@lodestar/types";
+import {PointFormat} from "@chainsafe/bls/types";
+import {BitArray} from "@chainsafe/ssz";
+import {AttestationPool} from "../../../../lib/chain/opPools/attestationPool.js";
+import {generateAttestation} from "../../../utils/attestation.js";
+import {InsertOutcome} from "../../../../src/chain/opPools/types.js";
+
+describe("chain / opPools / attestationPool", function () {
+  let pool: AttestationPool;
+  const index = 2;
+  const beaconBlockRoot = Buffer.alloc(32, 1);
+  const slot = 10;
+  let attestation: phase0.Attestation;
+  const participantIndex = 1;
+
+  before(() => {
+    const sk = bls.SecretKey.fromBytes(Buffer.alloc(32, 1));
+    attestation = generateAttestation({
+      data: {
+        slot,
+        beaconBlockRoot,
+        index,
+      },
+    });
+    attestation.aggregationBits = new BitArray(new Uint8Array([0]), 8);
+    attestation.aggregationBits.set(participantIndex, true);
+    attestation.signature = sk
+      .sign(ssz.phase0.AttestationData.hashTreeRoot(attestation.data))
+      .toBytes(PointFormat.compressed);
+  });
+
+  beforeEach(() => {
+    pool = new AttestationPool();
+    pool.add(attestation);
+  });
+
+  it("should return the cached aggregated attestation", () => {
+    const aggregated = pool.getAggregate(slot, ssz.phase0.AttestationData.hashTreeRoot(attestation.data));
+    expect(aggregated).to.be.not.null;
+    expect(pool.getAggregate(slot, ssz.phase0.AttestationData.hashTreeRoot(attestation.data))).to.be.equal(aggregated);
+  });
+
+  it("should return new aggregated attestation", () => {
+    const firstAggregated = pool.getAggregate(slot, ssz.phase0.AttestationData.hashTreeRoot(attestation.data));
+    expect(firstAggregated).to.be.not.null;
+    const sk2 = bls.SecretKey.fromBytes(Buffer.alloc(32, 2));
+    const attestation2 = generateAttestation({
+      data: {
+        slot,
+        beaconBlockRoot,
+        index,
+      },
+    });
+    attestation2.aggregationBits = new BitArray(new Uint8Array([0]), 8);
+    const participantIndex2 = 2;
+    attestation2.aggregationBits.set(participantIndex2, true);
+    attestation2.signature = sk2
+      .sign(ssz.phase0.AttestationData.hashTreeRoot(attestation2.data))
+      .toBytes(PointFormat.compressed);
+    const outcome = pool.add(attestation2);
+
+    expect(outcome).to.be.equal(InsertOutcome.Aggregated);
+    const aggregated = pool.getAggregate(slot, ssz.phase0.AttestationData.hashTreeRoot(attestation.data));
+    expect(aggregated).to.be.not.equal(firstAggregated);
+    expect(ssz.phase0.AttestationData.equals(aggregated.data, attestation.data)).to.be.true;
+    for (const i of [participantIndex, participantIndex2]) {
+      expect(aggregated.aggregationBits.get(i)).to.be.true;
+    }
+  });
+});

--- a/packages/beacon-node/test/unit/chain/opPools/syncCommittee.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/syncCommittee.test.ts
@@ -28,9 +28,21 @@ describe("chain / opPools / SyncCommitteeMessagePool", function () {
     cache.add(subcommitteeIndex, syncCommittee, indexInSubcommittee);
   });
 
-  it("should preaggregate SyncCommitteeContribution", () => {
-    let contribution = cache.getContribution(subcommitteeIndex, syncCommittee.slot, syncCommittee.beaconBlockRoot);
+  it("should return the cached contribution", () => {
+    const contribution = cache.getContribution(subcommitteeIndex, syncCommittee.slot, syncCommittee.beaconBlockRoot);
     expect(contribution).to.be.not.null;
+    expect(cache.getContribution(subcommitteeIndex, syncCommittee.slot, syncCommittee.beaconBlockRoot)).to.be.equal(
+      contribution
+    );
+  });
+
+  it("should aggregate new SyncCommitteeContribution", () => {
+    const firstContribution = cache.getContribution(
+      subcommitteeIndex,
+      syncCommittee.slot,
+      syncCommittee.beaconBlockRoot
+    );
+    expect(firstContribution).to.be.not.null;
     const newSecretKey = bls.SecretKey.fromBytes(Buffer.alloc(32, 2));
     const newSyncCommittee = generateSyncCommitteeSignature({
       slot: syncCommittee.slot,
@@ -41,8 +53,9 @@ describe("chain / opPools / SyncCommitteeMessagePool", function () {
     });
     const newIndicesInSubSyncCommittee = [1];
     cache.add(subcommitteeIndex, newSyncCommittee, newIndicesInSubSyncCommittee[0]);
-    contribution = cache.getContribution(subcommitteeIndex, syncCommittee.slot, syncCommittee.beaconBlockRoot);
+    const contribution = cache.getContribution(subcommitteeIndex, syncCommittee.slot, syncCommittee.beaconBlockRoot);
     expect(contribution).to.be.not.null;
+    expect(contribution).to.be.not.equal(firstContribution);
     if (contribution) {
       expect(contribution.slot).to.be.equal(syncCommittee.slot);
       expect(toHexString(contribution.beaconBlockRoot)).to.be.equal(toHexString(syncCommittee.beaconBlockRoot));


### PR DESCRIPTION
**Motivation**

- For attestation pools, right now we do preaggregation which has `fromBytes()` performance issue and the aggregated attestations may not be used if no connected validator is an aggregator.

**Description**

- Attestation pool:
  - Do aggregation only once getAggregate() is called
  - Cached the aggregated attestations because there could be up to 16 aggregators per committee
- Aggregated Attestation pool: only do aggregation when we call `getAttestationsForBlock`
- Add benchmark for `bls.Signature.aggregate`

Closes #4690