### PR TITLE
Update the ping time for inboud and outbound

### DIFF
--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -31,8 +31,8 @@ import {
 /** heartbeat performs regular updates such as updating reputations and performing discovery requests */
 const HEARTBEAT_INTERVAL_MS = 30 * 1000;
 /** The time in seconds between PING events. We do not send a ping if the other peer has PING'd us */
-const PING_INTERVAL_INBOUND_MS = 4 * 60 * 1000 - 11 * 1000; // Offset to not ping when outbound reqs
-const PING_INTERVAL_OUTBOUND_MS = 4 * 60 * 1000;
+const PING_INTERVAL_INBOUND_MS = 15 * 1000; // Offset to not ping when outbound reqs
+const PING_INTERVAL_OUTBOUND_MS = 20 * 1000;
 /** The time in seconds between re-status's peers. */
 const STATUS_INTERVAL_MS = 5 * 60 * 1000;
 /** Expect a STATUS request from on inbound peer for some time. Afterwards the node does a request */


### PR DESCRIPTION
**Motivation**

Avoid socket timeout if the node tries to load with higher genesis delay. 

**Description**

Here are some stats from this change extracted for last **24 hours** and drawn over **1h interval**.

**nogroup-ctvpss-0 - current branch**
<img width="1354" alt="image" src="https://user-images.githubusercontent.com/112468/199948044-d0b77181-132a-4903-8926-67781dc572b6.png">

**nogroup-ctvpss-1 - current branch**
<img width="1354" alt="image" src="https://user-images.githubusercontent.com/112468/199948153-63cb7938-3018-4713-b06f-8719a452a9d6.png">

**nogroup-ctvpss-2 - unstable**
<img width="1354" alt="image" src="https://user-images.githubusercontent.com/112468/199948315-40bfbd78-f0c4-4002-9c69-93c9e95131fd.png">

**nogroup-ctvpss-3 - unstable**
<img width="1354" alt="image" src="https://user-images.githubusercontent.com/112468/199948443-d3c88f1f-9496-4c41-b803-eda2044e38dc.png">

Closes  #4645 

**Steps to test or reproduce**
Run tests 