### PR TITLE
Remove reference to sharding information page

### DIFF
--- a/packages/beacon-node/README.md
+++ b/packages/beacon-node/README.md
@@ -13,7 +13,7 @@
 
 ## What you need
 
-You will need to go over the [specification](https://github.com/ethereum/consensus-specs). You will also need to have a [basic understanding of sharding](https://github.com/ethereum/wiki/wiki/Sharding-FAQs).
+You will need to go over the [specification](https://github.com/ethereum/consensus-specs).
 
 ## Getting started
 

--- a/packages/light-client/README.md
+++ b/packages/light-client/README.md
@@ -14,7 +14,7 @@
 
 ## What you need
 
-You will need to go over the [specification](https://github.com/ethereum/consensus-specs). You will also need to have a [basic understanding of sharding](https://github.com/ethereum/wiki/wiki/Sharding-FAQs).
+You will need to go over the [specification](https://github.com/ethereum/consensus-specs).
 
 ## Getting started
 


### PR DESCRIPTION
**Motivation**

The Ethereum wiki has been archived for a while.
Sharding information can now be found on the Ethereum website.

**Description**

This PR updates the link to the sharding information page.
