### PR TITLE
Fix typos in variables, comments and metric names

### DIFF
--- a/dashboards/lodestar_debug_gossipsub.json
+++ b/dashboards/lodestar_debug_gossipsub.json
@@ -1270,7 +1270,7 @@
           "type": "timeseries"
         },
         {
-          "description": "Time elappsed between block slot time and the time block received via gossip",
+          "description": "Time elapsed between block slot time and the time block received via gossip",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1347,7 +1347,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": false,
-              "expr": "delta(lodestar_gossip_block_elappsed_time_till_received_sum[$rate_interval])\n/\ndelta(lodestar_gossip_block_elappsed_time_till_received_count[$rate_interval])",
+              "expr": "delta(lodestar_gossip_block_elapsed_time_till_received_sum[$rate_interval])\n/\ndelta(lodestar_gossip_block_elapsed_time_till_received_count[$rate_interval])",
               "interval": "",
               "legendFormat": "till received",
               "refId": "A"
@@ -1358,7 +1358,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": false,
-              "expr": "delta(lodestar_gossip_block_elappsed_time_till_processed_sum[$rate_interval])\n/\ndelta(lodestar_gossip_block_elappsed_time_till_processed_count[$rate_interval])",
+              "expr": "delta(lodestar_gossip_block_elapsed_time_till_processed_sum[$rate_interval])\n/\ndelta(lodestar_gossip_block_elapsed_time_till_processed_count[$rate_interval])",
               "hide": false,
               "interval": "",
               "legendFormat": "till processed",
@@ -7405,7 +7405,7 @@
           },
           "id": 423,
           "options": {
-            "content": "**Detailed stats about RPC recv / sent**\n\n- Big asymetries between recv and sent indicate that our node this node is behaving too differently from its peers. RPC behaviour _should_ be mostly symetrical.\n- As of Apr 2022, Lodestar seem to sends more GRAFTs than receives and receives more PRUNE than it sents. This indicates issues to mantain mesh peers.",
+            "content": "**Detailed stats about RPC recv / sent**\n\n- Big asymmetries between recv and sent indicate that our node this node is behaving too differently from its peers. RPC behaviour _should_ be mostly symmetrical.\n- As of Apr 2022, Lodestar seem to sends more GRAFTs than receives and receives more PRUNE than it sends. This indicates issues to maintain mesh peers.",
             "mode": "markdown"
           },
           "pluginVersion": "8.4.2",

--- a/dashboards/lodestar_networking.json
+++ b/dashboards/lodestar_networking.json
@@ -2430,7 +2430,7 @@
       }
     },
     {
-      "description": "Time elappsed between block slot time and the time block received via gossip",
+      "description": "Time elapsed between block slot time and the time block received via gossip",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2508,7 +2508,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "delta(lodestar_gossip_block_elappsed_time_till_received_sum[$rate_interval])\n/\ndelta(lodestar_gossip_block_elappsed_time_till_received_count[$rate_interval])",
+          "expr": "delta(lodestar_gossip_block_elapsed_time_till_received_sum[$rate_interval])\n/\ndelta(lodestar_gossip_block_elapsed_time_till_received_count[$rate_interval])",
           "interval": "",
           "legendFormat": "till received",
           "refId": "A"
@@ -2519,7 +2519,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "delta(lodestar_gossip_block_elappsed_time_till_processed_sum[$rate_interval])\n/\ndelta(lodestar_gossip_block_elappsed_time_till_processed_count[$rate_interval])",
+          "expr": "delta(lodestar_gossip_block_elapsed_time_till_processed_sum[$rate_interval])\n/\ndelta(lodestar_gossip_block_elapsed_time_till_processed_count[$rate_interval])",
           "hide": false,
           "interval": "",
           "legendFormat": "till processed",
@@ -2542,7 +2542,7 @@
       "type": "timeseries"
     },
     {
-      "description": "Time elappsed between block slot time and the time block received via gossip",
+      "description": "Time elapsed between block slot time and the time block received via gossip",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2620,7 +2620,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "(\n  delta(lodestar_gossip_block_elappsed_time_till_processed_sum[$rate_interval])\n  -\n  delta(lodestar_gossip_block_elappsed_time_till_received_sum[$rate_interval])\n)\n/\ndelta(lodestar_gossip_block_elappsed_time_till_received_count[$rate_interval])",
+          "expr": "(\n  delta(lodestar_gossip_block_elapsed_time_till_processed_sum[$rate_interval])\n  -\n  delta(lodestar_gossip_block_elapsed_time_till_received_sum[$rate_interval])\n)\n/\ndelta(lodestar_gossip_block_elapsed_time_till_received_count[$rate_interval])",
           "interval": "",
           "legendFormat": "processed minus received",
           "refId": "A"

--- a/dashboards/lodestar_vm_host.json
+++ b/dashboards/lodestar_vm_host.json
@@ -928,7 +928,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "rate(lodestar_unhandeled_promise_rejections_total[$rate_interval])",
+          "expr": "rate(lodestar_unhandled_promise_rejections_total[$rate_interval])",
           "interval": "",
           "legendFormat": "Errors",
           "refId": "A"
@@ -1942,7 +1942,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Avaliable"
+                  "options": "Available"
                 },
                 "properties": [
                   {

--- a/packages/beacon-node/src/api/impl/debug/index.ts
+++ b/packages/beacon-node/src/api/impl/debug/index.ts
@@ -1,7 +1,7 @@
 import {routes} from "@lodestar/api";
 import {resolveStateId} from "../beacon/state/utils.js";
 import {ApiModules} from "../types.js";
-import {isOptimsticBlock} from "../../../util/forkChoice.js";
+import {isOptimisticBlock} from "../../../util/forkChoice.js";
 
 export function getDebugApi({chain, config, db}: Pick<ApiModules, "chain" | "config" | "db">): routes.debug.Api {
   return {
@@ -18,7 +18,7 @@ export function getDebugApi({chain, config, db}: Pick<ApiModules, "chain" | "con
         data: heads.map((block) => ({
           slot: block.slot,
           root: block.blockRoot,
-          executionOptimistic: isOptimsticBlock(block),
+          executionOptimistic: isOptimisticBlock(block),
         })),
       };
     },

--- a/packages/beacon-node/src/api/impl/types.ts
+++ b/packages/beacon-node/src/api/impl/types.ts
@@ -8,7 +8,7 @@ import {INetwork} from "../../network/index.js";
 import {IMetrics} from "../../metrics/index.js";
 
 /**
- * PR ensure API follows spec required to include the isOptimstic boolean in many routes.
+ * PR ensure API follows spec required to include the isOptimistic boolean in many routes.
  * To keep the scope of the PR manageable, the PR will only add the flag with proper logic on
  * critical routes. Else it is left as a temporary always false to be implemented next.
  */

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -16,7 +16,7 @@ import {AttestationError, AttestationErrorCode, GossipAction, SyncCommitteeError
 import {validateGossipAggregateAndProof} from "../../../chain/validation/index.js";
 import {ZERO_HASH} from "../../../constants/index.js";
 import {SyncState} from "../../../sync/index.js";
-import {isOptimsticBlock} from "../../../util/forkChoice.js";
+import {isOptimisticBlock} from "../../../util/forkChoice.js";
 import {toGraffitiBuffer} from "../../../util/graffiti.js";
 import {ApiError, NodeIsSyncing} from "../errors.js";
 import {validateSyncCommitteeGossipContributionAndProof} from "../../../chain/validation/syncCommitteeContributionAndProof.js";
@@ -39,7 +39,7 @@ const MAX_API_CLOCK_DISPARITY_MS = 1000;
  * finalized head.
  *
  * TODO: Lighthouse uses 8 for the attack described above. However, 8 kills Lodestar since validators
- * can trigger regen to fast-forward head state 8 epochs to be immediatelly invalidated as sync sets
+ * can trigger regen to fast-forward head state 8 epochs to be immediately invalidated as sync sets
  * a new head. Then the checkpoint state cache grows unbounded with very different states (because
  * they are 8 epochs apart) and causes an OOM. Research a proper solution once regen and the state
  * caches are better.
@@ -248,7 +248,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
       await waitForSlot(slot); // Must never request for a future slot > currentSlot
 
       // This needs a state in the same epoch as `slot` such that state.currentJustifiedCheckpoint is correct.
-      // Note: This may trigger an epoch transition if there skipped slots at the begining of the epoch.
+      // Note: This may trigger an epoch transition if there skipped slots at the beginning of the epoch.
       const headState = chain.getHeadState();
       const headSlot = headState.slot;
       const attEpoch = computeEpochAtSlot(slot);
@@ -354,7 +354,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
       return {
         data: duties,
         dependentRoot: toHex(dependentRoot),
-        executionOptimistic: isOptimsticBlock(head),
+        executionOptimistic: isOptimisticBlock(head),
       };
     },
 
@@ -404,7 +404,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
       return {
         data: duties,
         dependentRoot: toHex(dependentRoot),
-        executionOptimistic: isOptimsticBlock(head),
+        executionOptimistic: isOptimisticBlock(head),
       };
     },
 
@@ -431,7 +431,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
       // May request for an epoch that's in the future
       await waitForNextClosestEpoch();
 
-      // sync committee duties have a lookahead of 1 day. Assuming the validator only requests duties for upcomming
+      // sync committee duties have a lookahead of 1 day. Assuming the validator only requests duties for upcoming
       // epochs, the head state will very likely have the duties available for the requested epoch.
       // Note: does not support requesting past duties
       const head = chain.forkChoice.getHead();
@@ -441,12 +441,12 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
       const pubkeys = getPubkeysForIndices(state.validators, validatorIndices);
       // Ensures `epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD <= current_epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD + 1`
       const syncCommitteeCache = state.epochCtx.getIndexedSyncCommitteeAtEpoch(epoch);
-      const syncComitteeValidatorIndexMap = syncCommitteeCache.validatorIndexMap;
+      const syncCommitteeValidatorIndexMap = syncCommitteeCache.validatorIndexMap;
 
       const duties: routes.validator.SyncDuty[] = [];
       for (let i = 0, len = validatorIndices.length; i < len; i++) {
         const validatorIndex = validatorIndices[i];
-        const validatorSyncCommitteeIndices = syncComitteeValidatorIndexMap.get(validatorIndex);
+        const validatorSyncCommitteeIndices = syncCommitteeValidatorIndexMap.get(validatorIndex);
         if (validatorSyncCommitteeIndices) {
           duties.push({
             pubkey: pubkeys[i],
@@ -458,7 +458,7 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
 
       return {
         data: duties,
-        executionOptimistic: isOptimsticBlock(head),
+        executionOptimistic: isOptimisticBlock(head),
       };
     },
 

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -84,7 +84,7 @@ export class RestApiServer {
     });
 
     server.addHook("onError", async (req, res, err) => {
-      // Don't log ErrorAborted errors, they happen on node shutdown and are not usefull
+      // Don't log ErrorAborted errors, they happen on node shutdown and are not useful
       // Don't log NodeISSyncing errors, they happen very frequently while syncing and the validator polls duties
       if (err instanceof ErrorAborted || err instanceof NodeIsSyncing) return;
 

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -10,7 +10,7 @@ import {
 import {ForkChoiceError, ForkChoiceErrorCode, EpochDifference} from "@lodestar/fork-choice";
 import {ZERO_HASH_HEX} from "../../constants/index.js";
 import {toCheckpointHex} from "../stateCache/index.js";
-import {isOptimsticBlock} from "../../util/forkChoice.js";
+import {isOptimisticBlock} from "../../util/forkChoice.js";
 import {ChainEvent} from "../emitter.js";
 import {REPROCESS_MIN_TIME_TO_NEXT_SLOT_SEC} from "../reprocess.js";
 import {RegenCaller} from "../regen/interface.js";
@@ -212,7 +212,7 @@ export async function importBlock(
       state: newHead.stateRoot,
       previousDutyDependentRoot: this.forkChoice.getDependentRoot(newHead, EpochDifference.previous),
       currentDutyDependentRoot: this.forkChoice.getDependentRoot(newHead, EpochDifference.current),
-      executionOptimistic: isOptimsticBlock(newHead),
+      executionOptimistic: isOptimisticBlock(newHead),
     });
 
     this.metrics?.forkChoice.changedHead.inc();

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -56,7 +56,7 @@ type VerifyBlockExecutionResponse =
 /**
  * Verifies 1 or more execution payloads from a linear sequence of blocks.
  *
- * Since the EL client must be aware of each parent, all payloads must be submited in sequence.
+ * Since the EL client must be aware of each parent, all payloads must be submitted in sequence.
  */
 export async function verifyBlocksExecutionPayload(
   chain: VerifyBlockExecutionPayloadModules,
@@ -77,8 +77,8 @@ export async function verifyBlocksExecutionPayload(
   // For a block with SYNCING status (called optimistic block), it's okay to import with
   // SYNCING status as EL could switch into syncing
   //
-  // 1. On intial startup/restart
-  // 2. When some reorg might have occured and EL doesn't has a parent root
+  // 1. On initial startup/restart
+  // 2. When some reorg might have occurred and EL doesn't has a parent root
   //    (observed on devnets)
   // 3. Because of some unavailable (and potentially invalid) root but there is no way
   //    of knowing if this is invalid/unavailable. For unavailable block, some proposer
@@ -131,7 +131,7 @@ export async function verifyBlocksExecutionPayload(
   //
   //
   // For this segment of blocks:
-  //   We are optimistically safe with respec to this entire block segment if:
+  //   We are optimistically safe with respect to this entire block segment if:
   //    - all the blocks are way behind the current slot
   //    - or we have already imported a post-merge parent of first block of this chain in forkchoice
   const lastBlock = blocks[blocks.length - 1];
@@ -174,7 +174,7 @@ export async function verifyBlocksExecutionPayload(
 
     const isMergeTransitionBlock =
       // If the merge block is found, stop the search as the isMergeTransitionBlockFn condition
-      // will still evalute to true for the following blocks leading to errors (while syncing)
+      // will still evaluate to true for the following blocks leading to errors (while syncing)
       // as the preState0 still belongs to the pre state of the first block on segment
       mergeBlockFound === null &&
       isExecutionStateType(preState0) &&
@@ -321,7 +321,7 @@ export async function verifyBlockExecutionPayload(
     // There can be other reasons for which EL failed some of the observed ones are
     // 1. Connection refused / can't connect to EL port
     // 2. EL Internal Error
-    // 3. Geth sometimes gives invalid merkel root error which means invalid
+    // 3. Geth sometimes gives invalid merkle root error which means invalid
     //    but expects it to be handled in CL as of now. But we should log as warning
     //    and give it as optimistic treatment and expect any other non-geth CL<>EL
     //    combination to reject the invalid block and propose a block.
@@ -373,7 +373,7 @@ function getSegmentErrorResponse(
     // If there is no valid in the segment then we have to propagate invalid response
     // in forkchoice as well if
     //  - if the parentBlock is also not the lvh
-    //  - and parentBlock is not pre merhe
+    //  - and parentBlock is not pre merge
     if (
       !lvhFound &&
       parentBlock.executionStatus !== ExecutionStatus.PreMerge &&

--- a/packages/beacon-node/src/chain/bls/multithread/index.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/index.ts
@@ -32,26 +32,26 @@ export type BlsMultiThreadWorkerPoolOptions = {
  * Split big signature sets into smaller sets so they can be sent to multiple workers.
  *
  * The biggest sets happen during sync, on mainnet batches of 64 blocks have around ~8000 signatures.
- * The latency cost of sending the job to and from the worker is aprox a single sig verification.
+ * The latency cost of sending the job to and from the worker is approx a single sig verification.
  * If you split a big signature into 2, the extra time cost is `(2+2N)/(1+2N)`.
  * For 128, the extra time cost is about 0.3%. No specific reasoning for `128`, it's just good enough.
  */
 const MAX_SIGNATURE_SETS_PER_JOB = 128;
 
 /**
- * If there are more than `MAX_BUFFERED_SIGS` buffered sigs, verify them immediatelly without waiting `MAX_BUFFER_WAIT_MS`.
+ * If there are more than `MAX_BUFFERED_SIGS` buffered sigs, verify them immediately without waiting `MAX_BUFFER_WAIT_MS`.
  *
- * The efficency improvement of batching sets asymptotically reaches x2. However, for batching large sets
+ * The efficiency improvement of batching sets asymptotically reaches x2. However, for batching large sets
  * has more risk in case a signature is invalid, requiring to revalidate all sets in the batch. 32 is sweet
  * point for this tradeoff.
  */
 const MAX_BUFFERED_SIGS = 32;
 /**
  * Gossip objects usually come in bursts. Buffering them for a short period of time allows to increase batching
- * efficieny, at the cost of delaying validation. Unless running in production shows otherwise, it's not critical
+ * efficiency, at the cost of delaying validation. Unless running in production shows otherwise, it's not critical
  * to hold attestations and aggregates for 100ms. Lodestar existing queues may hold those objects for much more anyway.
  *
- * There's no exact reasoning for the `100` miliseconds number. The metric `batchSigsSuccess` should indicate if this
+ * There's no exact reasoning for the `100` milliseconds number. The metric `batchSigsSuccess` should indicate if this
  * value needs revision
  */
 const MAX_BUFFER_WAIT_MS = 100;
@@ -92,7 +92,7 @@ type WorkerDescriptor = {
  * - Complete total outstanding jobs in total minimum time possible.
  *   Will split large signature sets into smaller sets and send to different workers
  * - Reduce the latency cost for small signature sets. In NodeJS 12,14 worker <-> main thread
- *   communiction has very high latency, of around ~5 ms. So package multiple small signature
+ *   communication has very high latency, of around ~5 ms. So package multiple small signature
  *   sets into packages of work and send at once to a worker to distribute the latency cost
  */
 export class BlsMultiThreadWorkerPool implements IBlsVerifier {
@@ -275,7 +275,7 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
       }
 
       // Push job and schedule to call `runJob` in the next macro event loop cycle.
-      // This is usefull to allow batching job submited from a syncronous for loop,
+      // This is useful to allow batching job submitted from a synchronous for loop,
       // and to prevent large stacks since runJob may be called recursively.
       else {
         this.jobs.push(job);
@@ -292,7 +292,7 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
       return;
     }
 
-    // Find iddle worker
+    // Find idle worker
     const worker = this.workers.find((worker) => worker.status.code === WorkerStatusCode.idle);
     if (!worker || worker.status.code !== WorkerStatusCode.idle) {
       return;
@@ -401,7 +401,7 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
   }
 
   /**
-   * Add all buffered jobs to the job queue and potentially run them immediatelly
+   * Add all buffered jobs to the job queue and potentially run them immediately
    */
   private runBufferedJobs = (): void => {
     if (this.bufferedJobs) {

--- a/packages/beacon-node/src/chain/clock/LocalClock.ts
+++ b/packages/beacon-node/src/chain/clock/LocalClock.ts
@@ -152,8 +152,8 @@ export class LocalClock implements IBeaconClock {
   };
 
   private msUntilNextSlot(): number {
-    const miliSecondsPerSlot = this.config.SECONDS_PER_SLOT * 1000;
-    const diffInMiliSeconds = Date.now() - this.genesisTime * 1000;
-    return miliSecondsPerSlot - (diffInMiliSeconds % miliSecondsPerSlot);
+    const milliSecondsPerSlot = this.config.SECONDS_PER_SLOT * 1000;
+    const diffInMilliSeconds = Date.now() - this.genesisTime * 1000;
+    return milliSecondsPerSlot - (diffInMilliSeconds % milliSecondsPerSlot);
   }
 }

--- a/packages/beacon-node/src/chain/errors/lightClientError.ts
+++ b/packages/beacon-node/src/chain/errors/lightClientError.ts
@@ -22,7 +22,7 @@ export class LightClientError extends GossipActionError<LightClientErrorType> {}
 // Errors for the light client server
 
 export enum LightClientServerErrorCode {
-  RESOURCE_UNAVAILABLE = "RESOURCE_UNAVALIABLE",
+  RESOURCE_UNAVAILABLE = "RESOURCE_UNAVAILABLE",
 }
 
 export type LightClientServerErrorType = {code: LightClientServerErrorCode.RESOURCE_UNAVAILABLE};

--- a/packages/beacon-node/src/db/interface.ts
+++ b/packages/beacon-node/src/db/interface.ts
@@ -20,7 +20,7 @@ import {PreGenesisState, PreGenesisStateLastProcessedBlock} from "./single/index
 /**
  * The DB service manages the data layer of the beacon chain
  * The exposed methods do not refer to the underlying data engine,
- * but instead expose relevent beacon chain objects
+ * but instead expose relevant beacon chain objects
  */
 export interface IBeaconDb {
   // unfinalized blocks

--- a/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts
+++ b/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts
@@ -25,10 +25,10 @@ const MIN_BLOCKS_PER_LOG_QUERY = 10;
 const AUTO_UPDATE_PERIOD_MS = 60 * 1000;
 /** Prevent infinite loops */
 const MIN_UPDATE_PERIOD_MS = 1 * 1000;
-/** Miliseconds to wait after getting 429 Too Many Requests */
+/** Milliseconds to wait after getting 429 Too Many Requests */
 const RATE_LIMITED_WAIT_MS = 30 * 1000;
 /** Min time to wait on auto update loop on unknown error */
-const MIN_WAIT_ON_ERORR_MS = 1 * 1000;
+const MIN_WAIT_ON_ERROR_MS = 1 * 1000;
 
 /** Number of blocks to download if the node detects it is lagging behind due to an inaccurate
     relationship between block-number-based follow distance and time-based follow distance. */
@@ -47,7 +47,7 @@ export type Eth1DepositDataTrackerModules = {
 
 /**
  * Main class handling eth1 data fetching, processing and storing
- * Upon instantiation, starts fetcheing deposits and blocks at regular intervals
+ * Upon instantiation, starts fetching deposits and blocks at regular intervals
  */
 export class Eth1DepositDataTracker {
   private config: IChainForkConfig;
@@ -62,9 +62,9 @@ export class Eth1DepositDataTracker {
 
   /** Dynamically adjusted follow distance */
   private eth1FollowDistance: number;
-  /** Dynamically adusted batch size to fetch deposit logs */
+  /** Dynamically adjusted batch size to fetch deposit logs */
   private eth1GetBlocksBatchSizeDynamic = MAX_BLOCKS_PER_BLOCK_QUERY;
-  /** Dynamically adusted batch size to fetch deposit logs */
+  /** Dynamically adjusted batch size to fetch deposit logs */
   private eth1GetLogsBatchSizeDynamic = MAX_BLOCKS_PER_LOG_QUERY;
   private readonly forcedEth1DataVote: phase0.Eth1Data | null;
 
@@ -132,7 +132,7 @@ export class Eth1DepositDataTracker {
       return pickEth1Vote(state, eth1VotesToConsider);
     } catch (e) {
       // Note: In case there's a DB issue, don't stop a block proposal. Just vote for current eth1Data
-      this.logger.error("CRITICIAL: Error reading valid votes, voting for current eth1Data", {}, e as Error);
+      this.logger.error("CRITICAL: Error reading valid votes, voting for current eth1Data", {}, e as Error);
       return state.eth1Data;
     }
   }
@@ -182,7 +182,7 @@ export class Eth1DepositDataTracker {
           await sleep(RATE_LIMITED_WAIT_MS, this.signal);
         } else if (!isErrorAborted(e)) {
           this.logger.error("Error updating eth1 chain cache", {}, e as Error);
-          await sleep(MIN_WAIT_ON_ERORR_MS, this.signal);
+          await sleep(MIN_WAIT_ON_ERROR_MS, this.signal);
         }
 
         this.metrics?.eth1.depositTrackerUpdateErrors.inc(1);
@@ -223,7 +223,7 @@ export class Eth1DepositDataTracker {
     let depositEvents;
     try {
       depositEvents = await this.eth1Provider.getDepositEvents(fromBlock, toBlock);
-      // Increase the batch size linearly even if we scale down exponentioanlly (half each time)
+      // Increase the batch size linearly even if we scale down exponentially (half each time)
       this.eth1GetLogsBatchSizeDynamic = Math.min(
         MAX_BLOCKS_PER_LOG_QUERY,
         this.eth1GetLogsBatchSizeDynamic + MIN_BLOCKS_PER_LOG_QUERY
@@ -293,7 +293,7 @@ export class Eth1DepositDataTracker {
     let blocksRaw;
     try {
       blocksRaw = await this.eth1Provider.getBlocksByNumber(fromBlock, toBlock);
-      // Increase the batch size linearly even if we scale down exponentioanlly (half each time)
+      // Increase the batch size linearly even if we scale down exponentially (half each time)
       this.eth1GetBlocksBatchSizeDynamic = Math.min(
         MAX_BLOCKS_PER_BLOCK_QUERY,
         this.eth1GetBlocksBatchSizeDynamic + MIN_BLOCKS_PER_BLOCK_QUERY

--- a/packages/beacon-node/src/eth1/eth1MergeBlockTracker.ts
+++ b/packages/beacon-node/src/eth1/eth1MergeBlockTracker.ts
@@ -173,7 +173,7 @@ export class Eth1MergeBlockTracker {
     });
 
     const interval = setInterval(() => {
-      // Pre-emptively try to find merge block and cache it if found.
+      // Preemptively try to find merge block and cache it if found.
       // Future callers of getTerminalPowBlock() will re-use the cached found mergeBlock.
       this.getTerminalPowBlockFromEth1().catch((e) => {
         this.logger.error("Error on findMergeBlock", {}, e as Error);
@@ -267,7 +267,7 @@ export class Eth1MergeBlockTracker {
       // For the search below to require more than a few hops, multiple block proposers in a row must fail to detect
       // an existing merge block. Such situation is extremely unlikely, so this search is left un-optimized. Since
       // this class can start eagerly looking for the merge block when not necessary, startPollingMergeBlock() should
-      // only be called when there is certainity that a mergeBlock search is necessary.
+      // only be called when there is certainty that a mergeBlock search is necessary.
 
       // eslint-disable-next-line no-constant-condition
       while (true) {

--- a/packages/beacon-node/src/metrics/metrics.ts
+++ b/packages/beacon-node/src/metrics/metrics.ts
@@ -30,7 +30,7 @@ export function createMetrics(
     validatorMonitor.scrapeMetrics(clockSlot);
   });
   process.on("unhandledRejection", (_error) => {
-    lodestar.unhandeledPromiseRejections.inc();
+    lodestar.unhandledPromiseRejections.inc();
   });
 
   collectNodeJSMetrics(register);

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -93,21 +93,21 @@ export function createLodestarMetrics(
     }),
     peersRequestedToConnect: register.gauge({
       name: "lodestar_peers_requested_total_to_connect",
-      help: "Priorization results total peers count requested to connect",
+      help: "Prioritization results total peers count requested to connect",
     }),
     peersRequestedToDisconnect: register.gauge<"reason">({
       name: "lodestar_peers_requested_total_to_disconnect",
-      help: "Priorization results total peers count requested to disconnect",
+      help: "Prioritization results total peers count requested to disconnect",
       labelNames: ["reason"],
     }),
     peersRequestedSubnetsToQuery: register.gauge<"type">({
       name: "lodestar_peers_requested_total_subnets_to_query",
-      help: "Priorization results total subnets to query and discover peers in",
+      help: "Prioritization results total subnets to query and discover peers in",
       labelNames: ["type"],
     }),
     peersRequestedSubnetsPeerCount: register.gauge<"type">({
       name: "lodestar_peers_requested_total_subnets_peers_count",
-      help: "Priorization results total peers in subnets to query and discover peers in",
+      help: "Prioritization results total peers in subnets to query and discover peers in",
       labelNames: ["type"],
     }),
     peersReportPeerCount: register.gauge<"reason">({
@@ -195,7 +195,7 @@ export function createLodestarMetrics(
     gossipPeer: {
       scoreByThreshold: register.gauge<"threshold">({
         name: "lodestar_gossip_peer_score_by_threshold_count",
-        help: "Gossip peer score by threashold",
+        help: "Gossip peer score by threshold",
         labelNames: ["threshold"],
       }),
       meshPeersByClient: register.gauge<"client">({
@@ -354,7 +354,7 @@ export function createLodestarMetrics(
     apiRest: {
       responseTime: register.histogram<"operationId">({
         name: "lodestar_api_rest_response_time_seconds",
-        help: "REST API time to fullfill a request by operationId",
+        help: "REST API time to fulfill a request by operationId",
         labelNames: ["operationId"],
         // Request times range between 1ms to 100ms in normal conditions. Can get to 1-5 seconds if overloaded
         buckets: [0.01, 0.1, 1],
@@ -572,19 +572,19 @@ export function createLodestarMetrics(
     // Gossip block
     gossipBlock: {
       elapsedTimeTillReceived: register.histogram({
-        name: "lodestar_gossip_block_elappsed_time_till_received",
-        help: "Time elappsed between block slot time and the time block received via gossip",
+        name: "lodestar_gossip_block_elapsed_time_till_received",
+        help: "Time elapsed between block slot time and the time block received via gossip",
         buckets: [0.5, 1, 2, 4, 6, 12],
       }),
       elapsedTimeTillProcessed: register.histogram({
-        name: "lodestar_gossip_block_elappsed_time_till_processed",
-        help: "Time elappsed between block slot time and the time block processed",
+        name: "lodestar_gossip_block_elapsed_time_till_processed",
+        help: "Time elapsed between block slot time and the time block processed",
         buckets: [0.5, 1, 2, 4, 6, 12],
       }),
     },
     elapsedTimeTillBecomeHead: register.histogram({
       name: "lodestar_gossip_block_elapsed_time_till_become_head",
-      help: "Time elappsed between block slot time and the time block becomes head",
+      help: "Time elapsed between block slot time and the time block becomes head",
       buckets: [0.5, 1, 2, 4, 6, 12],
     }),
 
@@ -780,7 +780,7 @@ export function createLodestarMetrics(
         buckets: [0.1, 0.25, 0.5, 1, 2, 5, 10],
       }),
       unaggregatedAttestationSubmittedSentPeers: register.histogram({
-        name: "validator_monitor_unaggregated_attestation_submited_sent_peers_count",
+        name: "validator_monitor_unaggregated_attestation_submitted_sent_peers_count",
         help: "Number of peers that an unaggregated attestation sent to",
         // as of Apr 2022, most of the time we sent to >30 peers per attestations
         // these bucket values just base on that fact to get equal range
@@ -873,7 +873,7 @@ export function createLodestarMetrics(
         help: "Avg min max of all state cache items seconds since last reads",
       }),
       stateClonedCount: register.histogram({
-        name: "lodestar_state_cache_state_cloned_clount",
+        name: "lodestar_state_cache_state_cloned_count",
         help: "Histogram of cloned count per state every time state.clone() is called",
         buckets: [1, 2, 5, 10, 50, 250],
       }),
@@ -913,7 +913,7 @@ export function createLodestarMetrics(
         help: "Avg min max of all state cache items seconds since last reads",
       }),
       stateClonedCount: register.histogram({
-        name: "lodestar_cp_state_cache_state_cloned_clount",
+        name: "lodestar_cp_state_cache_state_cloned_count",
         help: "Histogram of cloned count per state every time state.clone() is called",
         buckets: [1, 2, 5, 10, 50, 250],
       }),
@@ -929,7 +929,7 @@ export function createLodestarMetrics(
         help: "Total number of balances cache requests",
       }),
       misses: register.counter({
-        name: "lodestar_balances_cache_missess_total",
+        name: "lodestar_balances_cache_misses_total",
         help: "Total number of balances cache misses",
       }),
       closestStateResult: register.counter<"stateId">({
@@ -993,9 +993,9 @@ export function createLodestarMetrics(
       help: "regen function total errors",
       labelNames: ["entrypoint", "caller"],
     }),
-    unhandeledPromiseRejections: register.gauge({
-      name: "lodestar_unhandeled_promise_rejections_total",
-      help: "UnhandeledPromiseRejection total count",
+    unhandledPromiseRejections: register.gauge({
+      name: "lodestar_unhandled_promise_rejections_total",
+      help: "UnhandledPromiseRejection total count",
     }),
 
     // Precompute next epoch transition
@@ -1047,7 +1047,7 @@ export function createLodestarMetrics(
         labelNames: ["event"],
       }),
       highestSlot: register.gauge<"item">({
-        name: "lodestar_lightclient_server_higest_slot",
+        name: "lodestar_lightclient_server_highest_slot",
         help: "Current highest slot of items stored by LightclientServer",
         labelNames: ["item"],
       }),

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -403,14 +403,14 @@ export class PeerDiscovery {
 
 /**
  * libp2p errors with extremely noisy errors here, which are deeply nested taking 30-50 lines.
- * Some known erors:
+ * Some known errors:
  * ```
  * Error: The operation was aborted
  * Error: stream ended before 1 bytes became available
  * Error: Error occurred during XX handshake: Error occurred while verifying signed payload: Peer ID doesn't match libp2p public key
  * ```
  *
- * Also the error's message is not properly formated, where the error message in indentated and includes the full stack
+ * Also the error's message is not properly formatted, where the error message is indented and includes the full stack
  * ```
  * {
  *  emessage: '\n' +

--- a/packages/beacon-node/src/network/peers/score.ts
+++ b/packages/beacon-node/src/network/peers/score.ts
@@ -18,10 +18,10 @@ const MAX_SCORE = 100;
 const MIN_SCORE = -100;
 /** Drop score if absolute value is below this threshold */
 const SCORE_THRESHOLD = 1;
-/** The halflife of a peer's score. I.e the number of miliseconds it takes for the score to decay to half its value */
+/** The halflife of a peer's score. I.e the number of milliseconds it takes for the score to decay to half its value */
 const SCORE_HALFLIFE_MS = 10 * 60 * 1000;
 const HALFLIFE_DECAY_MS = -Math.log(2) / SCORE_HALFLIFE_MS;
-/** The number of miliseconds we ban a peer for before their score begins to decay */
+/** The number of milliseconds we ban a peer for before their score begins to decay */
 const BANNED_BEFORE_DECAY_MS = 30 * 60 * 1000;
 /** Limit of entries in the scores map */
 const MAX_ENTRIES = 1000;

--- a/packages/beacon-node/src/sync/constants.ts
+++ b/packages/beacon-node/src/sync/constants.ts
@@ -17,7 +17,7 @@ export const MAX_BATCH_PROCESSING_ATTEMPTS = 3;
  * the block necessary so switch from Finalized sync to Head sync won't be in the fork-choice and range sync would
  * be stuck in a loop downloading the previous epoch to finalized epoch, until we get rate-limited.
  *
- * After Jul2022 during finalized sync the entire epoch of finalized epoch will be downloaded fullfilling the goal
+ * After Jul2022 during finalized sync the entire epoch of finalized epoch will be downloaded fulfilling the goal
  * to switch to Head sync latter. This does not affect performance nor sync speed and just downloads a few extra
  * blocks that would be required by Head sync anyway. However, having an offset of 0 allows to send to the processor
  * blocks that belong to the same epoch, which enables batch verification optimizations.

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -392,7 +392,7 @@ export class SyncChain {
   }
 
   /**
-   * Requests the batch asigned to the given id from a given peer.
+   * Requests the batch assigned to the given id from a given peer.
    */
   private async sendBatch(batch: Batch, peer: PeerId): Promise<void> {
     try {
@@ -409,14 +409,14 @@ export class SyncChain {
         batch.downloadingError(); // Throws after MAX_DOWNLOAD_ATTEMPTS
       }
 
-      // Pre-emptively request more blocks from peers whilst we process current blocks
+      // Preemptively request more blocks from peers whilst we process current blocks
       this.triggerBatchDownloader();
     } catch (e) {
       // bubble the error up to the main async iterable loop
       this.batchProcessor.end(e as Error);
     }
 
-    // Pre-emptively request more blocks from peers whilst we process current blocks
+    // Preemptively request more blocks from peers whilst we process current blocks
     this.triggerBatchDownloader();
   }
 

--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -3,7 +3,7 @@ import {ILogger} from "@lodestar/utils";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {Slot, phase0} from "@lodestar/types";
 import {INetwork, NetworkEvent} from "../network/index.js";
-import {isOptimsticBlock} from "../util/forkChoice.js";
+import {isOptimisticBlock} from "../util/forkChoice.js";
 import {IMetrics} from "../metrics/index.js";
 import {ChainEvent, IBeaconChain} from "../chain/index.js";
 import {GENESIS_SLOT} from "../constants/constants.js";
@@ -92,14 +92,14 @@ export class BeaconSync implements IBeaconSync {
             headSlot: String(head.slot),
             syncDistance: String(currentSlot - head.slot),
             isSyncing: true,
-            isOptimistic: isOptimsticBlock(head),
+            isOptimistic: isOptimisticBlock(head),
           };
         case SyncState.Synced:
           return {
             headSlot: String(head.slot),
             syncDistance: "0",
             isSyncing: false,
-            isOptimistic: isOptimsticBlock(head),
+            isOptimistic: isOptimisticBlock(head),
           };
         default:
           throw new Error("Node is stopped, cannot get sync status");

--- a/packages/beacon-node/src/util/forkChoice.ts
+++ b/packages/beacon-node/src/util/forkChoice.ts
@@ -1,5 +1,5 @@
 import {ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
 
-export function isOptimsticBlock(block: ProtoBlock): boolean {
+export function isOptimisticBlock(block: ProtoBlock): boolean {
   return block.executionStatus === ExecutionStatus.Syncing;
 }

--- a/packages/beacon-node/src/util/queue/options.ts
+++ b/packages/beacon-node/src/util/queue/options.ts
@@ -9,7 +9,7 @@ export type JobQueueOpts = {
   maxLength: number;
   /** Defaults to 1 */
   maxConcurrency?: number;
-  /** Yield to the macro queue every at least every N miliseconds */
+  /** Yield to the macro queue every at least every N milliseconds */
   yieldEveryMs?: number;
   signal: AbortSignal;
   /** Defaults to FIFO */

--- a/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
@@ -67,12 +67,12 @@ describe("chain / bls / multithread queue", function () {
     }
   }
 
-  it("Should verify multiple signatures submited syncronously", async () => {
+  it("Should verify multiple signatures submitted synchronously", async () => {
     // Given the `setTimeout(this.runJob, 0);` all sets should be verified in a single job an worker
     await testManyValidSignatures({sleep: false});
   });
 
-  it("Should verify multiple signatures submited asyncronously", async () => {
+  it("Should verify multiple signatures submitted asynchronously", async () => {
     // Because of the sleep, each sets submitted should be verified in a different job and worker
     await testManyValidSignatures({sleep: true});
   });

--- a/packages/beacon-node/test/memory/testRunnerMemory.ts
+++ b/packages/beacon-node/test/memory/testRunnerMemory.ts
@@ -112,7 +112,7 @@ export function testRunnerMemory<T>(opts: TestRunnerMemoryOpts<T>): number {
       usedMemoryArr.push(usedMemory);
 
       if (usedMemoryArr.length > 1) {
-        // When is a good time to stop a benchmark? A naive answer is after N miliseconds or M runs.
+        // When is a good time to stop a benchmark? A naive answer is after N milliseconds or M runs.
         // This code aims to stop the benchmark when the average fn run time has converged at a value
         // within a given convergence factor. To prevent doing expensive math to often for fast fn,
         // it only takes samples every `sampleEveryMs`. It stores two past values to be able to compute
@@ -124,11 +124,11 @@ export function testRunnerMemory<T>(opts: TestRunnerMemoryOpts<T>): number {
         const b = prevM1;
         const c = m;
 
-        // Aprox linear convergence
+        // Approx linear convergence
         const convergence1 = Math.abs(c - a);
-        // Aprox quadratic convergence
+        // Approx quadratic convergence
         const convergence2 = Math.abs(b - (a + c) / 2);
-        // Take the greater of both to enfore linear and quadratic are below convergeFactor
+        // Take the greater of both to enforce linear and quadratic are below convergeFactor
         const convergence = Math.max(convergence1, convergence2) / a;
 
         // Okay to stop + has converged, stop now

--- a/packages/beacon-node/test/perf/bls/bls.test.ts
+++ b/packages/beacon-node/test/perf/bls/bls.test.ts
@@ -7,7 +7,7 @@ describe("BLS ops", function () {
   type Keypair = {publicKey: PublicKey; secretKey: SecretKey};
   type BlsSet = {publicKey: PublicKey; message: Uint8Array; signature: Signature};
 
-  // Create and cache (on demand) crypto data to bencharmk
+  // Create and cache (on demand) crypto data to benchmark
   const sets = new Map<number, BlsSet>();
   const keypairs = new Map<number, Keypair>();
 

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -44,7 +44,7 @@ describe("getAttestationsForBlock", () => {
     expect(numCurrentEpochParticipation).to.equal(250000, "Wrong numCurrentEpochParticipation");
 
     const {blockHeader, checkpoint} = computeAnchorCheckpoint(originalState.config, originalState);
-    // TODO figure out why getBlockRootAtSlot(originalState, justfifiedSlot) is not the same to justifiedCheckpoint.root
+    // TODO figure out why getBlockRootAtSlot(originalState, justifiedSlot) is not the same to justifiedCheckpoint.root
     const finalizedEpoch = originalState.finalizedCheckpoint.epoch;
     const finalizedCheckpoint = {
       epoch: finalizedEpoch,

--- a/packages/beacon-node/test/rewiremock.ts
+++ b/packages/beacon-node/test/rewiremock.ts
@@ -1,4 +1,4 @@
 // rewiremock.es6.js
 import rewiremock, {overrideEntryPoint} from "rewiremock";
-overrideEntryPoint(module); // this is important. This command is "transfering" this module parent to rewiremock
+overrideEntryPoint(module); // this is important. This command is "transferring" this module parent to rewiremock
 export {rewiremock};

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -41,7 +41,7 @@ describe("sync / range / chain", () => {
       targetEpoch: 0,
     },
     {
-      id: "Simulate sync that must be completed immediatelly",
+      id: "Simulate sync that must be completed immediately",
       startEpoch: 20,
       targetEpoch: 16,
     },

--- a/packages/cli/src/options/beaconNodeOptions/builder.ts
+++ b/packages/cli/src/options/beaconNodeOptions/builder.ts
@@ -34,7 +34,7 @@ export const options: ICliCommandOptions<ExecutionBuilderArgs> = {
   },
 
   "builder.timeout": {
-    description: "Timeout in miliseconds for builder API HTTP client",
+    description: "Timeout in milliseconds for builder API HTTP client",
     type: "number",
     defaultDescription:
       defaultOptions.executionBuilder.mode === "http" ? String(defaultOptions.executionBuilder.timeout) : "",

--- a/packages/cli/src/options/beaconNodeOptions/execution.ts
+++ b/packages/cli/src/options/beaconNodeOptions/execution.ts
@@ -44,7 +44,7 @@ export const options: ICliCommandOptions<ExecutionEngineArgs> = {
   },
 
   "execution.timeout": {
-    description: "Timeout in miliseconds for execution engine API HTTP client",
+    description: "Timeout in milliseconds for execution engine API HTTP client",
     type: "number",
     defaultDescription:
       defaultOptions.executionEngine.mode === "http" ? String(defaultOptions.executionEngine.timeout) : "",

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -80,7 +80,7 @@ export class ForkChoice implements IForkChoice {
 
   // Note: as of Jun 2022 Lodestar metrics show that 100% of the times updateHead() is called, synced = false.
   // Because we are processing attestations from gossip, recomputing scores is always necessary
-  // /** Avoid having to compute detas all the times. */
+  // /** Avoid having to compute deltas all the times. */
   // private synced = false;
 
   /** Cached head */
@@ -201,7 +201,7 @@ export class ForkChoice implements IForkChoice {
       this.fcStore.equivocatingIndices
     );
     /**
-     * The structure in line with deltas to propogate boost up the branch
+     * The structure in line with deltas to propagate boost up the branch
      * starting from the proposerIndex
      */
     let proposerBoost: {root: RootHex; score: number} | null = null;
@@ -247,7 +247,7 @@ export class ForkChoice implements IForkChoice {
   }
 
   /**
-   * An iteration over protoArray to get present slots, to be called pre-emptively
+   * An iteration over protoArray to get present slots, to be called preemptively
    * from prepareNextSlot to prevent delay on produceBlindedBlock
    * @param windowStart is the slot after which (excluding) to provide present slots
    */
@@ -775,7 +775,7 @@ export class ForkChoice implements IForkChoice {
   }
 
   /**
-   * Optimistic sync validate till validated latest hash, invalidate any decendant
+   * Optimistic sync validate till validated latest hash, invalidate any descendant
    * branch if invalidate till hash provided
    *
    * Proxies to protoArray's validateLatestHash and could run extra validations for the
@@ -930,7 +930,7 @@ export class ForkChoice implements IForkChoice {
    * May need the justified balances of:
    * - bestJustified: Already available in `CheckpointHexWithBalance`
    * - unrealizedJustified: Already available in `CheckpointHexWithBalance`
-   * Since this balances are already available the getter is just `() => balances`, without cache iteraction
+   * Since this balances are already available the getter is just `() => balances`, without cache interaction
    */
   private updateCheckpoints(
     stateSlot: Slot,

--- a/packages/fork-choice/src/forkChoice/store.ts
+++ b/packages/fork-choice/src/forkChoice/store.ts
@@ -6,7 +6,7 @@ import {CheckpointHexWithBalance} from "./interface.js";
 /**
  * Stores checkpoints in a hybrid format:
  * - Original checkpoint for fast consumption in Lodestar's side
- * - Root in string hex for fast comparisions inside the fork-choice
+ * - Root in string hex for fast comparisons inside the fork-choice
  */
 export type CheckpointWithHex = phase0.Checkpoint & {rootHex: RootHex};
 

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -246,7 +246,7 @@ export class ProtoArray {
   }
 
   /**
-   * Optimistic sync validate till validated latest hash, invalidate any decendant branch
+   * Optimistic sync validate till validated latest hash, invalidate any descendant branch
    * if invalidate till hash provided. If consensus fails, this will invalidate entire
    * forkChoice which will throw on any call to findHead
    */
@@ -362,7 +362,7 @@ export class ProtoArray {
       const node = this.getNodeFromIndex(nodeIndex);
       const parent = node.parent !== undefined ? this.getNodeByIndex(node.parent) : undefined;
       // Only invalidate if this is post merge, and either parent is invalid or the
-      // concensus has failed
+      // consensus has failed
       if (parent?.executionStatus === ExecutionStatus.Invalid) {
         // check and flip node status to invalid
         this.invalidateNodeByIndex(nodeIndex);

--- a/packages/light-client/src/index.ts
+++ b/packages/light-client/src/index.ts
@@ -99,8 +99,8 @@ type RunStatus =
  *               - known next_sync_committee, signed by current_sync_committee
  *
  * - No need to query for period 0 next_sync_committee until the end of period 0
- * - During most of period 0, current_sync_committe known, next_sync_committee unknown
- * - At the end of period 0, get a sync committe update, and populate period 1's committee
+ * - During most of period 0, current_sync_committee known, next_sync_committee unknown
+ * - At the end of period 0, get a sync committee update, and populate period 1's committee
  *
  * syncCommittees: Map<SyncPeriod, SyncCommittee>, limited to max of 2 items
  */
@@ -167,7 +167,7 @@ export class Lightclient {
     };
   }
 
-  // Embed lightweigth clock. The epoch cycles are handled with `this.runLoop()`
+  // Embed lightweight clock. The epoch cycles are handled with `this.runLoop()`
   get currentSlot(): number {
     return getCurrentSlot(this.config, this.genesisTime);
   }
@@ -185,7 +185,7 @@ export class Lightclient {
     genesisData: GenesisData;
     checkpointRoot: phase0.Checkpoint["root"];
   }): Promise<Lightclient> {
-    // Initialize the BLS implementation. This may requires intializing the WebAssembly instance
+    // Initialize the BLS implementation. This may requires initializing the WebAssembly instance
     // so why it's a an async process. This should be initialized once before any bls operations.
     // This process has to be done manually because of an issue in Karma runner
     // https://github.com/karma-runner/karma/issues/3804
@@ -254,7 +254,7 @@ export class Lightclient {
   }
 
   async sync(fromPeriod: SyncPeriod, toPeriod: SyncPeriod): Promise<void> {
-    // Initialize the BLS implementation. This may requires intializing the WebAssembly instance
+    // Initialize the BLS implementation. This may requires initializing the WebAssembly instance
     // so why it's a an async process. This should be initialized once before any bls operations.
     // This process has to be done manually because of an issue in Karma runner
     // https://github.com/karma-runner/karma/issues/3804
@@ -276,7 +276,7 @@ export class Lightclient {
   }
 
   private async runLoop(): Promise<void> {
-    // Initialize the BLS implementation. This may requires intializing the WebAssembly instance
+    // Initialize the BLS implementation. This may requires initializing the WebAssembly instance
     // so why it's a an async process. This should be initialized once before any bls operations.
     // This process has to be done manually because of an issue in Karma runner
     // https://github.com/karma-runner/karma/issues/3804

--- a/packages/light-client/src/utils/clock.ts
+++ b/packages/light-client/src/utils/clock.ts
@@ -35,11 +35,11 @@ export function computeSyncPeriodAtEpoch(epoch: Epoch): SyncPeriod {
 }
 
 export function timeUntilNextEpoch(config: Pick<IChainConfig, "SECONDS_PER_SLOT">, genesisTime: number): number {
-  const miliSecondsPerEpoch = SLOTS_PER_EPOCH * config.SECONDS_PER_SLOT * 1000;
+  const milliSecondsPerEpoch = SLOTS_PER_EPOCH * config.SECONDS_PER_SLOT * 1000;
   const msFromGenesis = Date.now() - genesisTime * 1000;
   if (msFromGenesis >= 0) {
-    return miliSecondsPerEpoch - (msFromGenesis % miliSecondsPerEpoch);
+    return milliSecondsPerEpoch - (msFromGenesis % milliSecondsPerEpoch);
   } else {
-    return Math.abs(msFromGenesis % miliSecondsPerEpoch);
+    return Math.abs(msFromGenesis % milliSecondsPerEpoch);
   }
 }

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -1,5 +1,5 @@
 /**
- * Fork code name in order of occurance
+ * Fork code name in order of occurrence
  */
 export enum ForkName {
   phase0 = "phase0",
@@ -9,7 +9,7 @@ export enum ForkName {
 }
 
 /**
- * Fork sequence number inorder of occurance
+ * Fork sequence number in order of occurrence
  */
 export enum ForkSeq {
   phase0 = 0,

--- a/packages/params/src/index.ts
+++ b/packages/params/src/index.ts
@@ -124,7 +124,7 @@ export const DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF = Uint8Array.from([8, 0, 0, 0
 export const DOMAIN_CONTRIBUTION_AND_PROOF = Uint8Array.from([9, 0, 0, 0]);
 export const DOMAIN_BLS_TO_EXECUTION_CHANGE = Uint8Array.from([10, 0, 0, 0]);
 
-// Application specfic domains
+// Application specific domains
 
 /**
  * `DOMAIN_APPLICATION_MASK` reserves the rest of the bitspace in `DomainType` for application

--- a/packages/state-transition/src/cache/epochProcess.ts
+++ b/packages/state-transition/src/cache/epochProcess.ts
@@ -32,7 +32,7 @@ export type EpochProcessOpts = {
  * EpochProcess is the parent object of:
  * - Any data-structures not part of the spec'ed BeaconState
  * - Necessary to only compute data once
- * - Only necessary for epoch processing, can be disposed immediatelly
+ * - Only necessary for epoch processing, can be disposed immediately
  * - Not already part of `EpochContext` {@see} {@link EpochContext}
  *
  * EpochProcess speeds up epoch processing as a whole at the cost of more memory temporarily. This is okay since
@@ -89,12 +89,12 @@ export interface EpochProcess {
   indicesToSlash: ValidatorIndex[];
 
   /**
-   * Indices of validators that just joinned and will be eligible for the active queue.
+   * Indices of validators that just joined and will be eligible for the active queue.
    * ```
    * v.activationEligibilityEpoch === FAR_FUTURE_EPOCH && v.effectiveBalance === MAX_EFFECTIVE_BALANCE
    * ```
    * All validators in indicesEligibleForActivationQueue get activationEligibilityEpoch set. So it can only include
-   * validators that have just joinned the registry through a valid full deposit(s).
+   * validators that have just joined the registry through a valid full deposit(s).
    * ```
    * max indicesEligibleForActivationQueue = SLOTS_PER_EPOCH * MAX_DEPOSITS
    * ```
@@ -194,7 +194,7 @@ export function beforeProcessEpoch(state: CachedBeaconStateAllForks, opts?: Epoc
   let totalActiveStakeByIncrement = 0;
 
   // To optimize memory each validator node in `state.validators` is represented with a special node type
-  // `BranchNodeStruct` that represents the data as struct internally. This utility grabs the struct data directrly
+  // `BranchNodeStruct` that represents the data as struct internally. This utility grabs the struct data directly
   // from the nodes without any extra transformation. The returned `validators` array contains native JS objects.
   const validators = state.validators.getAllReadonlyValues();
   const validatorCount = validators.length;

--- a/packages/utils/src/logger/util.ts
+++ b/packages/utils/src/logger/util.ts
@@ -1,7 +1,7 @@
 import {EpochSlotOpts} from "./interface.js";
 
 /**
- * Formats time as: `EPOCH/SLOT_INDEX SECONDS.MILISECONDS
+ * Formats time as: `EPOCH/SLOT_INDEX SECONDS.MILLISECONDS
  */
 export function formatEpochSlotTime(opts: EpochSlotOpts, now = Date.now()): string {
   const nowSec = now / 1000;

--- a/packages/utils/src/retry.ts
+++ b/packages/utils/src/retry.ts
@@ -12,7 +12,7 @@ export type RetryOptions = {
    */
   shouldRetry?: (lastError: Error) => boolean;
   /**
-   * Miliseconds to wait before retrying again
+   * Milliseconds to wait before retrying again
    */
   retryDelay?: number;
 };

--- a/packages/validator/src/metrics.ts
+++ b/packages/validator/src/metrics.ts
@@ -343,7 +343,7 @@ export function getMetrics(register: MetricsRegister, gitData: LodestarGitData) 
     keymanagerApiRest: {
       responseTime: register.histogram<{operationId: string}>({
         name: "vc_keymanager_api_rest_response_time_seconds",
-        help: "REST API time to fullfill a request by operationId",
+        help: "REST API time to fulfill a request by operationId",
         labelNames: ["operationId"],
         // Request times range between 1ms to 100ms in normal conditions. Can get to 1-5 seconds if overloaded
         buckets: [0.01, 0.1, 1],

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -43,7 +43,7 @@ export class AttestationService {
   }
 
   private runAttestationTasks = async (slot: Slot, signal: AbortSignal): Promise<void> => {
-    // Fetch info first so a potential delay is absorved by the sleep() below
+    // Fetch info first so a potential delay is absorbed by the sleep() below
     const duties = this.dutiesService.getDutiesAtSlot(slot);
     if (duties.length === 0) {
       return;

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -148,7 +148,7 @@ export class BlockProposingService {
       const blockFeeRecipient = (fullBlock.data as bellatrix.BeaconBlock).body.executionPayload?.feeRecipient;
       const feeRecipient = blockFeeRecipient !== undefined ? toHexString(blockFeeRecipient) : undefined;
       if (feeRecipient !== undefined) {
-        // In Mev Builder, the feeRecipient could differ and rewards to the feeRecipeint
+        // In Mev Builder, the feeRecipient could differ and rewards to the feeRecipient
         // might be included in the block transactions as indicated by the BuilderBid
         // Address this appropriately in the Mev boost PR
         //

--- a/packages/validator/src/services/blockDuties.ts
+++ b/packages/validator/src/services/blockDuties.ts
@@ -110,7 +110,7 @@ export class BlockDutiesService {
    *
    * This sounds great, but is it safe? Firstly, the additional notification will only contain block
    * producers that were not included in the first notification. This should be safety enough.
-   * However, we also have the slashing protection as a second line of defence. These two factors
+   * However, we also have the slashing protection as a second line of defense. These two factors
    * provide an acceptable level of safety.
    *
    * It's important to note that since there is a 0-epoch look-ahead (i.e., no look-ahead) for block

--- a/packages/validator/src/services/chainHeaderTracker.ts
+++ b/packages/validator/src/services/chainHeaderTracker.ts
@@ -70,7 +70,7 @@ export class ChainHeaderTracker {
       this.logger.verbose("Found new chain head", {
         slot: slot,
         head: block,
-        previouDuty: previousDutyDependentRoot,
+        previousDuty: previousDutyDependentRoot,
         currentDuty: currentDutyDependentRoot,
       });
     }

--- a/packages/validator/src/services/prepareBeaconProposer.ts
+++ b/packages/validator/src/services/prepareBeaconProposer.ts
@@ -13,7 +13,7 @@ const REGISTRATION_CHUNK_SIZE = 512;
  * proposer data (currently `feeRecipient`) so that it can issue advance fcUs to
  * the engine for building execution payload with transactions.
  *
- * This needs to be done every epoch because the BN will cache it atmost for
+ * This needs to be done every epoch because the BN will cache it at most for
  * two epochs.
  */
 export function pollPrepareBeaconProposer(
@@ -62,7 +62,7 @@ export function pollPrepareBeaconProposer(
  * This service is responsible for registering validators with the mev builder as they
  * might prepare and keep ready the execution payloads of just registered validators.
  *
- * This needs to be done every epoch because the builder(s) will cache it atmost for
+ * This needs to be done every epoch because the builder(s) will cache it at most for
  * two epochs.
  */
 export function pollBuilderValidatorRegistration(

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -50,7 +50,7 @@ export class SyncCommitteeService {
         return;
       }
 
-      // Fetch info first so a potential delay is absorved by the sleep() below
+      // Fetch info first so a potential delay is absorbed by the sleep() below
       const dutiesAtSlot = await this.dutiesService.getDutiesAtSlot(slot);
       if (dutiesAtSlot.length === 0) {
         return;
@@ -72,7 +72,7 @@ export class SyncCommitteeService {
       this.metrics?.syncCommitteeStepCallProduceAggregate.observe(this.clock.secFromSlot(slot + 2 / 3));
 
       // await for all so if the Beacon node is overloaded it auto-throttles
-      // TODO: This approach is convervative to reduce the node's load, review
+      // TODO: This approach is conservative to reduce the node's load, review
       const dutiesBySubcommitteeIndex = groupSyncDutiesBySubcommitteeIndex(dutiesAtSlot);
       await Promise.all(
         Array.from(dutiesBySubcommitteeIndex.entries()).map(async ([subcommitteeIndex, duties]) => {

--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -247,7 +247,7 @@ export class SyncCommitteeDutiesService {
 
       // Note: For networks where `state.validators.length < SYNC_COMMITTEE_SIZE` the same validator can appear
       // multiple times in the sync committee. So `routes.validator.SyncDuty` `.validatorSyncCommitteeIndices`
-      // is an array, with all of those apparences.
+      // is an array, with all of those appearances.
       //
       // Validator signs two messages:
       // `SyncCommitteeMessage`:
@@ -255,7 +255,7 @@ export class SyncCommitteeDutiesService {
       //  - Validator signs and publishes only one message regardless of validatorSyncCommitteeIndices length
       // `SyncCommitteeContribution`:
       //  - depends on slot, blockRoot, validatorIndex, and subnet.
-      //  - Validator must sign and publish only one message per subnet MAX. Regarless of validatorSyncCommitteeIndices
+      //  - Validator must sign and publish only one message per subnet MAX. Regardless of validatorSyncCommitteeIndices
       const subnets = syncCommitteeIndicesToSubnets(duty.validatorSyncCommitteeIndices);
 
       // TODO: Enable dependentRoot functionality

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -545,7 +545,7 @@ export class ValidatorStore {
     const feeRecipient = fromHexString(regAttributes.feeRecipient);
     const {gasLimit} = regAttributes;
 
-    const validatorRegistation: bellatrix.ValidatorRegistrationV1 = {
+    const validatorRegistration: bellatrix.ValidatorRegistrationV1 = {
       feeRecipient,
       gasLimit,
       timestamp: Math.floor(Date.now() / 1000),
@@ -554,15 +554,15 @@ export class ValidatorStore {
 
     const signingSlot = 0;
     const domain = computeDomain(DOMAIN_APPLICATION_BUILDER, this.config.GENESIS_FORK_VERSION, ZERO_HASH);
-    const signingRoot = computeSigningRoot(ssz.bellatrix.ValidatorRegistrationV1, validatorRegistation, domain);
+    const signingRoot = computeSigningRoot(ssz.bellatrix.ValidatorRegistrationV1, validatorRegistration, domain);
 
     const signableMessage: SignableMessage = {
       type: SignableMessageType.VALIDATOR_REGISTRATION,
-      data: validatorRegistation,
+      data: validatorRegistration,
     };
 
     return {
-      message: validatorRegistation,
+      message: validatorRegistration,
       signature: await this.getSignature(pubkeyMaybeHex, signingRoot, signingSlot, signableMessage),
     };
   }

--- a/packages/validator/src/slashingProtection/interchange/errors.ts
+++ b/packages/validator/src/slashingProtection/interchange/errors.ts
@@ -10,7 +10,7 @@ export enum InterchangeErrorErrorCode {
 type InterchangeErrorErrorType =
   | {code: InterchangeErrorErrorCode.UNSUPPORTED_FORMAT; format: string}
   | {code: InterchangeErrorErrorCode.UNSUPPORTED_VERSION; version: string}
-  | {code: InterchangeErrorErrorCode.GENESIS_VALIDATOR_MISMATCH; root: Root; extectedRoot: Root};
+  | {code: InterchangeErrorErrorCode.GENESIS_VALIDATOR_MISMATCH; root: Root; expectedRoot: Root};
 
 export class InterchangeError extends LodestarError<InterchangeErrorErrorType> {
   constructor(type: InterchangeErrorErrorType) {

--- a/packages/validator/src/slashingProtection/interchange/parseInterchange.ts
+++ b/packages/validator/src/slashingProtection/interchange/parseInterchange.ts
@@ -18,7 +18,7 @@ export function parseInterchange(interchange: Interchange, expectedGenesisValida
           throw new InterchangeError({
             code: InterchangeErrorErrorCode.GENESIS_VALIDATOR_MISMATCH,
             root: interchangeLodestar.genesisValidatorsRoot,
-            extectedRoot: expectedGenesisValidatorsRoot,
+            expectedRoot: expectedGenesisValidatorsRoot,
           });
         }
         return interchangeLodestar;
@@ -39,7 +39,7 @@ export function parseInterchange(interchange: Interchange, expectedGenesisValida
             throw new InterchangeError({
               code: InterchangeErrorErrorCode.GENESIS_VALIDATOR_MISMATCH,
               root: interchangeLodestar.genesisValidatorsRoot,
-              extectedRoot: expectedGenesisValidatorsRoot,
+              expectedRoot: expectedGenesisValidatorsRoot,
             });
           }
           return interchangeLodestar;

--- a/packages/validator/src/util/clock.ts
+++ b/packages/validator/src/util/clock.ts
@@ -70,7 +70,7 @@ export class Clock implements IClock {
     this.fns.push({timeItem: TimeItem.Epoch, fn});
   }
 
-  /** Miliseconds from now to a specific slot */
+  /** Milliseconds from now to a specific slot */
   msToSlot(slot: Slot): number {
     const timeAt = this.genesisTime + this.config.SECONDS_PER_SLOT * slot;
     return timeAt * 1000 - Date.now();
@@ -88,7 +88,7 @@ export class Clock implements IClock {
    * on an overloaded/latent system rather than overload it even more.
    */
   private async runAtMostEvery(timeItem: TimeItem, signal: AbortSignal, fn: RunEveryFn): Promise<void> {
-    // Run immediatelly first
+    // Run immediately first
     let slot = getCurrentSlot(this.config, this.genesisTime);
     let slotOrEpoch = timeItem === TimeItem.Slot ? slot : computeEpochAtSlot(slot);
     while (!signal.aborted) {
@@ -113,21 +113,21 @@ export class Clock implements IClock {
   }
 
   private timeUntilNext(timeItem: TimeItem): number {
-    const miliSecondsPerSlot = this.config.SECONDS_PER_SLOT * 1000;
+    const milliSecondsPerSlot = this.config.SECONDS_PER_SLOT * 1000;
     const msFromGenesis = Date.now() - this.genesisTime * 1000;
 
     if (timeItem === TimeItem.Slot) {
       if (msFromGenesis >= 0) {
-        return miliSecondsPerSlot - (msFromGenesis % miliSecondsPerSlot);
+        return milliSecondsPerSlot - (msFromGenesis % milliSecondsPerSlot);
       } else {
-        return Math.abs(msFromGenesis % miliSecondsPerSlot);
+        return Math.abs(msFromGenesis % milliSecondsPerSlot);
       }
     } else {
-      const miliSecondsPerEpoch = SLOTS_PER_EPOCH * miliSecondsPerSlot;
+      const milliSecondsPerEpoch = SLOTS_PER_EPOCH * milliSecondsPerSlot;
       if (msFromGenesis >= 0) {
-        return miliSecondsPerEpoch - (msFromGenesis % miliSecondsPerEpoch);
+        return milliSecondsPerEpoch - (msFromGenesis % milliSecondsPerEpoch);
       } else {
-        return Math.abs(msFromGenesis % miliSecondsPerEpoch);
+        return Math.abs(msFromGenesis % milliSecondsPerEpoch);
       }
     }
   }

--- a/packages/validator/test/unit/services/attestationDuties.test.ts
+++ b/packages/validator/test/unit/services/attestationDuties.test.ts
@@ -72,7 +72,7 @@ describe("AttestationDutiesService", function () {
     // Accept all subscriptions
     api.validator.prepareBeaconCommitteeSubnet.resolves();
 
-    // Clock will call runAttesterDutiesTasks() immediatelly
+    // Clock will call runAttesterDutiesTasks() immediately
     const clock = new ClockMock();
     const dutiesService = new AttestationDutiesService(loggerVc, api, clock, validatorStore, chainHeadTracker, null);
 
@@ -139,7 +139,7 @@ describe("AttestationDutiesService", function () {
     // Accept all subscriptions
     api.validator.prepareBeaconCommitteeSubnet.resolves();
 
-    // Clock will call runAttesterDutiesTasks() immediatelly
+    // Clock will call runAttesterDutiesTasks() immediately
     const clock = new ClockMock();
     const dutiesService = new AttestationDutiesService(loggerVc, api, clock, validatorStore, chainHeadTracker, null);
 

--- a/packages/validator/test/unit/services/block.test.ts
+++ b/packages/validator/test/unit/services/block.test.ts
@@ -51,14 +51,14 @@ describe("BlockDutiesService", function () {
     api.validator.produceBlock.resolves({data: signedBlock.message});
     api.beacon.publishBlock.resolves();
 
-    // Triger block production for slot 1
+    // Trigger block production for slot 1
     const notifyBlockProductionFn = blockService["dutiesService"]["notifyBlockProductionFn"];
     notifyBlockProductionFn(1, [pubkeys[0]]);
 
     // Resolve all promises
     await sleep(20, controller.signal);
 
-    // Must have submited the block received on signBlock()
+    // Must have submitted the block received on signBlock()
     expect(api.beacon.publishBlock.callCount).to.equal(1, "publishBlock() must be called once");
     expect(api.beacon.publishBlock.getCall(0).args).to.deep.equal([signedBlock], "wrong publishBlock() args");
   });

--- a/packages/validator/test/unit/services/blockDuties.test.ts
+++ b/packages/validator/test/unit/services/blockDuties.test.ts
@@ -78,7 +78,7 @@ describe("BlockDutiesService", function () {
 
     const notifyBlockProductionFn = sinon.stub(); // Returns void
 
-    // Clock will call runAttesterDutiesTasks() immediatelly
+    // Clock will call runAttesterDutiesTasks() immediately
     const clock = new ClockMock();
     const dutiesService = new BlockDutiesService(loggerVc, api, clock, validatorStore, null, notifyBlockProductionFn);
 

--- a/packages/validator/test/unit/services/doppleganger.test.ts
+++ b/packages/validator/test/unit/services/doppleganger.test.ts
@@ -173,6 +173,6 @@ class ClockMockMsToSlot extends ClockMock {
     await this.tickEpochFns(epoch, signal);
   }
 
-  /** Miliseconds from now to a specific slot */
+  /** Milliseconds from now to a specific slot */
   msToSlot = (_slot: Slot): number => 0;
 }

--- a/packages/validator/test/unit/services/syncCommitteDuties.test.ts
+++ b/packages/validator/test/unit/services/syncCommitteDuties.test.ts
@@ -31,7 +31,7 @@ describe("SyncCommitteeDutiesService", function () {
 
   const altair0Config = createIChainForkConfig({
     ...mainnetConfig,
-    ALTAIR_FORK_EPOCH: 0, // Activate Altair immediatelly
+    ALTAIR_FORK_EPOCH: 0, // Activate Altair immediately
   });
 
   const indices = [4, 100];
@@ -56,12 +56,12 @@ describe("SyncCommitteeDutiesService", function () {
   beforeEach(() => {
     controller = new AbortController();
     // Reply with active validators
-    const validatorReponses = [0, 1].map((i) => ({
+    const validatorResponses = [0, 1].map((i) => ({
       ...defaultValidator,
       index: indices[i],
       validator: {...defaultValidator.validator, pubkey: pubkeys[i]},
     }));
-    api.beacon.getStateValidators.resolves({data: validatorReponses, executionOptimistic: false});
+    api.beacon.getStateValidators.resolves({data: validatorResponses, executionOptimistic: false});
   });
   afterEach(() => controller.abort());
 
@@ -78,7 +78,7 @@ describe("SyncCommitteeDutiesService", function () {
     // Accept all subscriptions
     api.validator.prepareSyncCommitteeSubnets.resolves();
 
-    // Clock will call runAttesterDutiesTasks() immediatelly
+    // Clock will call runAttesterDutiesTasks() immediately
     const clock = new ClockMock();
     const dutiesService = new SyncCommitteeDutiesService(altair0Config, loggerVc, api, clock, validatorStore, null);
 
@@ -150,7 +150,7 @@ describe("SyncCommitteeDutiesService", function () {
       .withArgs(1, sinon.match.any)
       .resolves({data: [duty2], executionOptimistic: false});
 
-    // Clock will call runAttesterDutiesTasks() immediatelly
+    // Clock will call runAttesterDutiesTasks() immediately
     const clock = new ClockMock();
     const dutiesService = new SyncCommitteeDutiesService(altair0Config, loggerVc, api, clock, validatorStore, null);
 
@@ -208,7 +208,7 @@ describe("SyncCommitteeDutiesService", function () {
     // Accept all subscriptions
     api.validator.prepareSyncCommitteeSubnets.resolves();
 
-    // Clock will call runAttesterDutiesTasks() immediatelly
+    // Clock will call runAttesterDutiesTasks() immediately
     const clock = new ClockMock();
     const dutiesService = new SyncCommitteeDutiesService(altair0Config, loggerVc, api, clock, validatorStore, null);
 

--- a/packages/validator/test/unit/services/syncCommittee.test.ts
+++ b/packages/validator/test/unit/services/syncCommittee.test.ts
@@ -32,7 +32,7 @@ describe("SyncCommitteeService", function () {
   const config = createIChainForkConfig({
     ...mainnetConfig,
     SECONDS_PER_SLOT: 1 / 1000, // Make slot time super short: 1 ms
-    ALTAIR_FORK_EPOCH: 0, // Activate Altair immediatelly
+    ALTAIR_FORK_EPOCH: 0, // Activate Altair immediately
   });
 
   before(() => {

--- a/packages/validator/test/unit/utils/clock.test.ts
+++ b/packages/validator/test/unit/utils/clock.test.ts
@@ -28,8 +28,8 @@ describe("util / Clock", function () {
     clock.runEverySlot(onSlot);
     clock.start(controller.signal);
 
-    // Must run once immediatelly
-    expect(onSlot.callCount).to.equal(1, "runEverySlot(cb) must be called immediatelly");
+    // Must run once immediately
+    expect(onSlot.callCount).to.equal(1, "runEverySlot(cb) must be called immediately");
     expect(onSlot.getCall(0).args[0]).to.equal(0, "Wrong arg on runEverySlot(cb) call 0");
 
     await fakeClock.tickAsync(config.SECONDS_PER_SLOT * 1000);
@@ -69,8 +69,8 @@ describe("util / Clock", function () {
     clock.runEveryEpoch(onEpoch);
     clock.start(controller.signal);
 
-    // Must run once immediatelly
-    expect(onEpoch.callCount).to.equal(1, "runEverySlot(cb) must be called immediatelly");
+    // Must run once immediately
+    expect(onEpoch.callCount).to.equal(1, "runEverySlot(cb) must be called immediately");
     expect(onEpoch.getCall(0).args[0]).to.equal(0, "Wrong arg on runEverySlot(cb) call 0");
 
     await fakeClock.tickAsync(config.SECONDS_PER_SLOT * 1000);


### PR DESCRIPTION
**Motivation**

I was reviewing the code and just fixed some typos along the way.

**Description**

This PR fixes typos in variables and comments. I also updated typos in Prometheus metric names in both the code and the dashboard but not sure about other implications as metric names could be considered an external API if there are other consumers of those metrics. If renaming the metrics could be problematic I would rather keep the current names with the typos.