### PR TITLE
Fix beacon/states/validator endpoint

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -185,9 +185,11 @@ export function filterStateValidatorsByStatus(
   for (const validator of validatorsArr) {
     const validatorStatus = getValidatorStatus(validator, currentEpoch);
 
-    const validatorIndex = getStateValidatorIndex(validator.pubkey, state, pubkey2index);
-    if (validatorIndex !== undefined && statusSet.has(validatorStatus)) {
-      responses.push(toValidatorResponse(validatorIndex, validator, state.balances.get(validatorIndex), currentEpoch));
+    const resp = getStateValidatorIndex(validator.pubkey, state, pubkey2index);
+    if (resp.valid && statusSet.has(validatorStatus)) {
+      responses.push(
+        toValidatorResponse(resp.validatorIndex, validator, state.balances.get(resp.validatorIndex), currentEpoch)
+      );
     }
   }
   return responses;
@@ -234,22 +236,42 @@ async function getFinalizedState(
   return state;
 }
 
+type StateValidatorIndexResponse = {valid: true; validatorIndex: number} | {valid: false; code: number; reason: string};
+
 export function getStateValidatorIndex(
   id: routes.beacon.ValidatorId | BLSPubkey,
   state: BeaconStateAllForks,
   pubkey2index: PubkeyIndexMap
-): number | undefined {
+): StateValidatorIndexResponse {
   let validatorIndex: ValidatorIndex | undefined;
-  if (typeof id === "number") {
-    if (state.validators.length > id) {
-      validatorIndex = id;
-    }
-  } else {
-    validatorIndex = pubkey2index.get(id) ?? undefined;
-    // validator added later than given stateId
-    if (validatorIndex !== undefined && validatorIndex >= state.validators.length) {
-      validatorIndex = undefined;
+  if (typeof id === "string") {
+    if (id.startsWith("0x")) {
+      // mutate `id` and fallthrough to below
+      try {
+        id = fromHexString(id);
+      } catch (e) {
+        return {valid: false, code: 400, reason: "Invalid pubkey hex encoding"};
+      }
+    } else {
+      validatorIndex = Number(id);
+      // validator is invalid or added later than given stateId
+      if (!Number.isSafeInteger(validatorIndex)) {
+        return {valid: false, code: 400, reason: "Invalid validator index"};
+      }
+      if (validatorIndex >= state.validators.length) {
+        return {valid: false, code: 404, reason: "Validator index from future state"};
+      }
+      return {valid: true, validatorIndex};
     }
   }
-  return validatorIndex;
+
+  // typeof id === Uint8Array
+  validatorIndex = pubkey2index.get(id as BLSPubkey);
+  if (validatorIndex === undefined) {
+    return {valid: false, code: 404, reason: "Validator pubkey not found in state"};
+  }
+  if (validatorIndex >= state.validators.length) {
+    return {valid: false, code: 404, reason: "Validator pubkey from future state"};
+  }
+  return {valid: true, validatorIndex};
 }

--- a/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
@@ -5,11 +5,15 @@ import {phase0} from "@lodestar/types";
 import {config} from "@lodestar/config/default";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {toHexString} from "@chainsafe/ssz";
-import {resolveStateId, getValidatorStatus} from "../../../../../../src/api/impl/beacon/state/utils.js";
+import {
+  resolveStateId,
+  getValidatorStatus,
+  getStateValidatorIndex,
+} from "../../../../../../src/api/impl/beacon/state/utils.js";
 import {IBeaconChain} from "../../../../../../src/chain/index.js";
 import {PERSIST_STATE_EVERY_EPOCHS} from "../../../../../../src/chain/archiver/archiveStates.js";
 import {generateProtoBlock} from "../../../../../utils/block.js";
-import {generateCachedState, generateState} from "../../../../../utils/state.js";
+import {generateCachedState, generateCachedStateWithPubkeys, generateState} from "../../../../../utils/state.js";
 import {StubbedBeaconDb} from "../../../../../utils/stub/index.js";
 
 use(chaiAsPromised);
@@ -213,6 +217,49 @@ describe("beacon state api utils", function () {
         getValidatorStatus(validator, currentEpoch);
       } catch (error) {
         expect(error).to.have.property("message", "ValidatorStatus unknown");
+      }
+    });
+  });
+
+  describe("getStateValidatorIndex", async function () {
+    const state = await generateCachedStateWithPubkeys({}, config, true);
+    const pubkey2index = state.epochCtx.pubkey2index;
+
+    it("should return valid: false on invalid input", () => {
+      expect(getStateValidatorIndex("foo", state, pubkey2index).valid, "invalid validator id number").to.equal(false);
+      expect(getStateValidatorIndex("0xfoo", state, pubkey2index).valid, "invalid hex").to.equal(false);
+    });
+
+    it("should return valid: false on validator indices / pubkeys not in the state", () => {
+      expect(
+        getStateValidatorIndex(String(state.validators.length), state, pubkey2index).valid,
+        "validator id not in state"
+      ).to.equal(false);
+      expect(getStateValidatorIndex("0xabcd", state, pubkey2index).valid, "validator pubkey not in state").to.equal(
+        false
+      );
+    });
+
+    it("should return valid: true on validator indices / pubkeys in the state", () => {
+      const index = state.validators.length - 1;
+      const resp1 = getStateValidatorIndex(String(index), state, pubkey2index);
+      if (resp1.valid) {
+        expect(resp1.validatorIndex).to.equal(index);
+      } else {
+        expect.fail("validator index should be found - validator index input");
+      }
+      const pubkey = state.validators.get(index).pubkey;
+      const resp2 = getStateValidatorIndex(pubkey, state, pubkey2index);
+      if (resp2.valid) {
+        expect(resp2.validatorIndex).to.equal(index);
+      } else {
+        expect.fail("validator index should be found - Uint8Array input");
+      }
+      const resp3 = getStateValidatorIndex(toHexString(pubkey), state, pubkey2index);
+      if (resp3.valid) {
+        expect(resp3.validatorIndex).to.equal(index);
+      } else {
+        expect.fail("validator index should be found - Uint8Array input");
       }
     });
   });


### PR DESCRIPTION
**Motivation**

Resolves #4731 

**Description**

Refactor `getStateValidatorIndex` to properly handle inputs required of it and to return more information in failure cases.