### PR TITLE
Fix getting validator from state by index

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -240,12 +240,14 @@ export function getStateValidatorIndex(
   pubkey2index: PubkeyIndexMap
 ): number | undefined {
   let validatorIndex: ValidatorIndex | undefined;
-  if (typeof id === "number") {
-    if (state.validators.length > id) {
-      validatorIndex = id;
+  if (!(id as string).startsWith("0x")) {
+    // validator index (0, 1, 2, ...) is used as id
+    const idInt = parseInt(id as string);
+    if (state.validators.length > idInt) {
+      validatorIndex = idInt;
     }
   } else {
-    validatorIndex = pubkey2index.get(id) ?? undefined;
+    validatorIndex = pubkey2index.get(id as string) ?? undefined;
     // validator added later than given stateId
     if (validatorIndex !== undefined && validatorIndex >= state.validators.length) {
       validatorIndex = undefined;


### PR DESCRIPTION
**Motivation**

Getting the validator from state by index is currently broken as the code assumes that value is a `number` but it is a `string` instead. This means that at the moment it is only possible to get a specific validator from state by using the hex encoded public key.

**Description**

The solution implemented in this PR is not a proper fix but rather a quick workaround. The main issue is that the [validator id](https://github.com/ChainSafe/lodestar/blob/unstable/packages/api/src/beacon/routes/beacon/state.ts#L16) can either be a `string` or `number` but this seems to be wrong at least when looking at the [Beacon Node API spec](https://ethereum.github.io/beacon-APIs/#/Beacon/getStateValidator). The validator index in the json response `data.index` should be a `string` but currently a number is return, see [test assertion](https://github.com/ChainSafe/lodestar/blob/unstable/packages/beacon-node/test/e2e/api/impl/beacon/state/endpoint.test.ts#L63). I think a proper fix would be to update the type of the validator id to be a `string` but this requires a few more changes in the code.

Closes #4731
