### PR TITLE
Accept the genesis powBlock as terminal in assertValidTerminalPowBlock

### DIFF
--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1237,14 +1237,24 @@ export function assertValidTerminalPowBlock(
 
     const {powBlock, powBlockParent} = preCachedData;
     if (!powBlock) throw Error("onBlock preCachedData must include powBlock");
-    if (!powBlockParent) throw Error("onBlock preCachedData must include powBlockParent");
+    // if powBlock is genesis don't assert powBlockParent
+    if (!powBlockParent && powBlock.parentHash !== HEX_ZERO_HASH)
+      throw Error("onBlock preCachedData must include powBlockParent");
 
     const isTotalDifficultyReached = powBlock.totalDifficulty >= config.TERMINAL_TOTAL_DIFFICULTY;
-    const isParentTotalDifficultyValid = powBlockParent.totalDifficulty < config.TERMINAL_TOTAL_DIFFICULTY;
-    if (!isTotalDifficultyReached || !isParentTotalDifficultyValid)
+    // If we don't have powBlockParent here, powBlock is the genesis and as we would have errored above
+    // we can mark isParentTotalDifficultyValid as valid
+    const isParentTotalDifficultyValid =
+      !powBlockParent || powBlockParent.totalDifficulty < config.TERMINAL_TOTAL_DIFFICULTY;
+    if (!isTotalDifficultyReached) {
       throw Error(
-        `Invalid terminal POW block: total difficulty not reached ${powBlockParent.totalDifficulty} < ${powBlock.totalDifficulty}`
+        `Invalid terminal POW block: total difficulty not reached expected >= ${config.TERMINAL_TOTAL_DIFFICULTY}, actual = ${powBlock.totalDifficulty}`
       );
+    } else if (!isParentTotalDifficultyValid) {
+      throw Error(
+        `Invalid terminal POW block parent: expected < ${config.TERMINAL_TOTAL_DIFFICULTY}, actual = ${powBlockParent.totalDifficulty}`
+      );
+    }
   }
 }
 

--- a/packages/fork-choice/test/unit/forkChoice/utils.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/utils.test.ts
@@ -1,0 +1,74 @@
+import {expect} from "chai";
+import {createIChainForkConfig} from "@lodestar/config";
+import {ssz} from "@lodestar/types";
+import {assertValidTerminalPowBlock, ExecutionStatus} from "../../../src/index.js";
+
+describe("assertValidTerminalPowBlock", function () {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const config = createIChainForkConfig({TERMINAL_TOTAL_DIFFICULTY: BigInt(10)});
+  const block = ssz.bellatrix.BeaconBlock.defaultValue();
+  const executionStatus = ExecutionStatus.Valid;
+  it("should accept ttd >= genesis block as terminal without powBlockParent", function () {
+    const powBlock = {
+      blockHash: "0x" + "ab".repeat(32),
+      // genesis powBlock will have zero parent hash
+      parentHash: "0x" + "00".repeat(32),
+      totalDifficulty: BigInt(10),
+    };
+    expect(() =>
+      assertValidTerminalPowBlock(config, block, {executionStatus, powBlockParent: null, powBlock})
+    ).to.not.throw();
+  });
+
+  it("should require powBlockParent if powBlock not genesis", function () {
+    const powBlock = {
+      blockHash: "0x" + "ab".repeat(32),
+      // genesis powBlock will have non zero parent hash
+      parentHash: "0x" + "01".repeat(32),
+      totalDifficulty: BigInt(10),
+    };
+    expect(() =>
+      assertValidTerminalPowBlock(config, block, {executionStatus, powBlockParent: null, powBlock})
+    ).to.throw();
+  });
+
+  it("should require powBlock >= ttd", function () {
+    const powBlock = {
+      blockHash: "0x" + "ab".repeat(32),
+      // genesis powBlock will have non zero parent hash
+      parentHash: "0x" + "01".repeat(32),
+      totalDifficulty: BigInt(9),
+    };
+    expect(() =>
+      assertValidTerminalPowBlock(config, block, {executionStatus, powBlockParent: powBlock, powBlock})
+    ).to.throw();
+  });
+
+  it("should require powBlockParent < ttd", function () {
+    const powBlock = {
+      blockHash: "0x" + "ab".repeat(32),
+      // genesis powBlock will have non zero parent hash
+      parentHash: "0x" + "01".repeat(32),
+      totalDifficulty: BigInt(10),
+    };
+    expect(() =>
+      assertValidTerminalPowBlock(config, block, {executionStatus, powBlockParent: powBlock, powBlock})
+    ).to.throw();
+  });
+
+  it("should accept powBlockParent < ttd and powBlock >= ttd", function () {
+    const powBlock = {
+      blockHash: "0x" + "ab".repeat(32),
+      // genesis powBlock will have non zero parent hash
+      parentHash: "0x" + "01".repeat(32),
+      totalDifficulty: BigInt(10),
+    };
+    const powBlockParent = {
+      ...powBlock,
+      totalDifficulty: BigInt(9),
+    };
+    expect(() =>
+      assertValidTerminalPowBlock(config, block, {executionStatus, powBlockParent, powBlock})
+    ).to.not.throw();
+  });
+});


### PR DESCRIPTION
In withdrawals devnet testing, the setup is ttd =0, but bellatrix at non zero epoch. This causes us to run assertValidTerminalPowBlock on the EL's genesis block on the merge transition, which fails because we don't have powBlockParent as is hence passed as null in assertValidTerminalPowBlock.

This fix allows a genesis EL block to pass the validations of terminal block