### PR TITLE
Pass all KeymanagerRestApiServerOpts to RestApiServer

### DIFF
--- a/packages/cli/src/cmds/validator/keymanager/server.ts
+++ b/packages/cli/src/cmds/validator/keymanager/server.ts
@@ -52,7 +52,7 @@ export class KeymanagerRestApiServer extends RestApiServer {
       writeFile600Perm(apiTokenPath, bearerToken, {encoding: "utf8"});
     }
 
-    super({address: opts.address, port: opts.port, cors: opts.cors, bearerToken}, modules);
+    super({...opts, bearerToken}, modules);
 
     // Instantiate and register the keymanager routes
     registerRoutes(this.server, modules.config, modules.api);

--- a/packages/cli/test/e2e/importKeystoresFromApi.test.ts
+++ b/packages/cli/test/e2e/importKeystoresFromApi.test.ts
@@ -37,6 +37,21 @@ describeCliTest("import keystores from api", function ({spawnCli}) {
     },
     data: [],
   };
+
+  /** From multiple tries, 20_000 results in a JSON of ~ 3MB */
+  const SLASHING_PROTECTION_ENTRIES = 20_000;
+  for (let i = 0; i < SLASHING_PROTECTION_ENTRIES; i++) {
+    slashingProtection.data.push({
+      pubkey: "0x" + String(i).padStart(96, "0"),
+      signed_blocks: [],
+      signed_attestations: [],
+    });
+    // // Uncomment to test if size is correct
+    // if (i % 100 === 0) {
+    //   console.log(i, Buffer.from(JSON.stringify(slashingProtection), "utf8").length / 1e6);
+    // }
+  }
+
   const slashingProtectionStr = JSON.stringify(slashingProtection);
 
   itKeymanagerStep("run 'validator' and import remote keys from API", async function (keymanagerClient) {


### PR DESCRIPTION
**Motivation**

- See https://github.com/ChainSafe/lodestar/issues/4530#issuecomment-1312479861

**Description**

- Previous fix https://github.com/ChainSafe/lodestar/pull/4541 failed to pass bodyLimit options to the base class calling fastify.
- This PR adds a test to ensure that 3MB slashing protection files can be imported, and there are no regressions

Closes https://github.com/ChainSafe/lodestar/issues/4530#issuecomment-1312479861