### PR TITLE
Disable parallel for spec tests

### DIFF
--- a/packages/beacon-node/.mocharc.spec.cjs
+++ b/packages/beacon-node/.mocharc.spec.cjs
@@ -1,14 +1,8 @@
-
 module.exports = {
   colors: true,
   require: ["./test/setupPreset.ts", "./test/setup.ts"],
-  "node-option": [
-    "loader=ts-node/esm"
-  ],
+  "node-option": ["loader=ts-node/esm"],
   timeout: 60_000,
-  // Disable parallel locally for easier debugging
-  parallel: Boolean(process.env.CI),
-  // By default, Mocha’s maximum job count is n – 1, where n is the number of CPU cores
-  // In Github actions the runner has only two cores, so force it to use two
-  jobs: 2,
+  // Do not run tests through workers, it's not proven to be faster than with `jobs: 2`
+  parallel: false,
 };


### PR DESCRIPTION
**Motivation**

Running tests through workers adds additional complexity. Draft PR to test if using parallel mode actually makes tests complete faster

**Description**

- Disable parallel for spec tests