### PR TITLE
Use as-chacha20poly1305

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -151,10 +151,7 @@
     "uint8arraylist": "^2.3.2",
     "uint8arrays": "^4.0.2",
     "varint": "^6.0.0",
-    "ssz-3": "https://github.com/tuyennhv/ssz.git#tuyen/as-chacha20poly1305-lib",
-    "@stablelib/hkdf": "^1.0.1",
-    "@stablelib/x25519": "^1.0.1",
-    "@stablelib/sha256": "^1.0.1",
+    "@chainsafe/as-chacha20poly1305-2": "https://github.com/tuyennhv/as-chacha20poly1305#tuyen/initial-implementation-dist",
     "xxhash-wasm": "1.0.1"
   },
   "devDependencies": {

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -105,6 +105,7 @@
     "@chainsafe/persistent-merkle-tree": "^0.4.2",
     "@chainsafe/snappy-stream": "5.1.1",
     "@chainsafe/ssz": "^0.9.2",
+    "@chainsafe/as-chacha20poly1305": "^0.1.0",
     "@chainsafe/threads": "^1.10.0",
     "@ethersproject/abi": "^5.0.0",
     "@libp2p/bootstrap": "^2.0.0",
@@ -151,7 +152,6 @@
     "uint8arraylist": "^2.3.2",
     "uint8arrays": "^4.0.2",
     "varint": "^6.0.0",
-    "@chainsafe/as-chacha20poly1305-2": "https://github.com/tuyennhv/as-chacha20poly1305#tuyen/initial-implementation-dist",
     "xxhash-wasm": "1.0.1"
   },
   "devDependencies": {

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -101,7 +101,7 @@
     "@chainsafe/bls": "7.1.1",
     "@chainsafe/discv5": "^1.4.0",
     "@chainsafe/libp2p-gossipsub": "^4.1.1",
-    "@chainsafe/libp2p-noise": "tuyennhv/js-libp2p-noise#tuyen/reuse-decrypt-allocation-dist",
+    "@chainsafe/libp2p-noise": "^10.2.0",
     "@chainsafe/persistent-merkle-tree": "^0.4.2",
     "@chainsafe/snappy-stream": "5.1.1",
     "@chainsafe/ssz": "^0.9.2",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -101,7 +101,7 @@
     "@chainsafe/bls": "7.1.1",
     "@chainsafe/discv5": "^1.4.0",
     "@chainsafe/libp2p-gossipsub": "^4.1.1",
-    "@chainsafe/libp2p-noise": "^8.0.0",
+    "@chainsafe/libp2p-noise": "tuyennhv/js-libp2p-noise#tuyen/reuse-decrypt-allocation-dist",
     "@chainsafe/persistent-merkle-tree": "^0.4.2",
     "@chainsafe/snappy-stream": "5.1.1",
     "@chainsafe/ssz": "^0.9.2",
@@ -151,6 +151,10 @@
     "uint8arraylist": "^2.3.2",
     "uint8arrays": "^4.0.2",
     "varint": "^6.0.0",
+    "ssz-3": "https://github.com/tuyennhv/ssz.git#tuyen/as-chacha20poly1305-lib",
+    "@stablelib/hkdf": "^1.0.1",
+    "@stablelib/x25519": "^1.0.1",
+    "@stablelib/sha256": "^1.0.1",
     "xxhash-wasm": "1.0.1"
   },
   "devDependencies": {

--- a/packages/beacon-node/src/network/nodejs/bundle.ts
+++ b/packages/beacon-node/src/network/nodejs/bundle.ts
@@ -5,7 +5,7 @@ import {Bootstrap} from "@libp2p/bootstrap";
 import {MulticastDNS} from "@libp2p/mdns";
 import {PeerId} from "@libp2p/interface-peer-id";
 import {Datastore} from "interface-datastore";
-import {Noise} from "@chainsafe/libp2p-noise";
+import {createNoise} from "./noise.js";
 
 export interface ILibp2pOptions {
   peerId: PeerId;
@@ -38,7 +38,7 @@ export async function createNodejsLibp2p(options: ILibp2pOptions): Promise<Libp2
       listen: options.addresses.listen,
       announce: options.addresses.announce || [],
     },
-    connectionEncryption: [new Noise()],
+    connectionEncryption: [createNoise()],
     transports: [new TCP()],
     streamMuxers: [new Mplex({maxInboundStreams: 256})],
     peerDiscovery,

--- a/packages/beacon-node/src/network/nodejs/noise.ts
+++ b/packages/beacon-node/src/network/nodejs/noise.ts
@@ -1,23 +1,22 @@
-import {newInstance, ChaCha20Poly1305} from "@chainsafe/as-chacha20poly1305-2";
 import type {ConnectionEncrypter} from "@libp2p/interface-connection-encrypter";
+import {newInstance, ChaCha20Poly1305} from "@chainsafe/as-chacha20poly1305";
 import {ICryptoInterface, noise, stablelib} from "@chainsafe/libp2p-noise";
 import {digest} from "@chainsafe/as-sha256";
 
-type bytes = Uint8Array;
-type bytes32 = Uint8Array;
+type Bytes = Uint8Array;
+type Bytes32 = Uint8Array;
 
 const ctx = newInstance();
 const asImpl = new ChaCha20Poly1305(ctx);
 
 // same to stablelib but we use as-chacha20poly1305 and as-sha256
-// TODO: find a way to reuse the following code
 const lodestarCrypto: ICryptoInterface = {
   ...stablelib,
   hashSHA256(data: Uint8Array): Uint8Array {
     return digest(data);
   },
 
-  chaCha20Poly1305Encrypt(plaintext: Uint8Array, nonce: Uint8Array, ad: Uint8Array, k: bytes32): bytes {
+  chaCha20Poly1305Encrypt(plaintext: Uint8Array, nonce: Uint8Array, ad: Uint8Array, k: Bytes32): Bytes {
     return asImpl.seal(k, nonce, plaintext, ad);
   },
 
@@ -25,9 +24,9 @@ const lodestarCrypto: ICryptoInterface = {
     ciphertext: Uint8Array,
     nonce: Uint8Array,
     ad: Uint8Array,
-    k: bytes32,
+    k: Bytes32,
     dst?: Uint8Array
-  ): bytes | null {
+  ): Bytes | null {
     return asImpl.open(k, nonce, ciphertext, ad, dst);
   },
 };

--- a/packages/beacon-node/src/network/nodejs/noise.ts
+++ b/packages/beacon-node/src/network/nodejs/noise.ts
@@ -1,18 +1,10 @@
-import {HKDF} from "@stablelib/hkdf";
-import * as x25519 from "@stablelib/x25519";
-import {SHA256} from "@stablelib/sha256";
-import {newInstance, ChaCha20Poly1305} from "ssz-3/packages/as-chacha20poly1305/lib/src/index";
+import {newInstance, ChaCha20Poly1305} from "@chainsafe/as-chacha20poly1305-2";
 import type {ConnectionEncrypter} from "@libp2p/interface-connection-encrypter";
-import {ICryptoInterface, noise} from "@chainsafe/libp2p-noise";
+import {ICryptoInterface, noise, stablelib} from "@chainsafe/libp2p-noise";
 import {digest} from "@chainsafe/as-sha256";
 
 type bytes = Uint8Array;
 type bytes32 = Uint8Array;
-type Hkdf = [bytes, bytes, bytes];
-interface KeyPair {
-  publicKey: bytes32;
-  privateKey: bytes32;
-}
 
 const ctx = newInstance();
 const asImpl = new ChaCha20Poly1305(ctx);
@@ -20,42 +12,9 @@ const asImpl = new ChaCha20Poly1305(ctx);
 // same to stablelib but we use as-chacha20poly1305 and as-sha256
 // TODO: find a way to reuse the following code
 const lodestarCrypto: ICryptoInterface = {
+  ...stablelib,
   hashSHA256(data: Uint8Array): Uint8Array {
     return digest(data);
-  },
-
-  getHKDF(ck: bytes32, ikm: Uint8Array): Hkdf {
-    const hkdf = new HKDF(SHA256, ikm, ck);
-    const okmU8Array = hkdf.expand(96);
-    const okm = okmU8Array;
-
-    const k1 = okm.subarray(0, 32);
-    const k2 = okm.subarray(32, 64);
-    const k3 = okm.subarray(64, 96);
-
-    return [k1, k2, k3];
-  },
-
-  generateX25519KeyPair(): KeyPair {
-    const keypair = x25519.generateKeyPair();
-
-    return {
-      publicKey: keypair.publicKey,
-      privateKey: keypair.secretKey,
-    };
-  },
-
-  generateX25519KeyPairFromSeed(seed: Uint8Array): KeyPair {
-    const keypair = x25519.generateKeyPairFromSeed(seed);
-
-    return {
-      publicKey: keypair.publicKey,
-      privateKey: keypair.secretKey,
-    };
-  },
-
-  generateX25519SharedKey(privateKey: Uint8Array, publicKey: Uint8Array): Uint8Array {
-    return x25519.sharedKey(privateKey, publicKey);
   },
 
   chaCha20Poly1305Encrypt(plaintext: Uint8Array, nonce: Uint8Array, ad: Uint8Array, k: bytes32): bytes {

--- a/packages/beacon-node/src/network/nodejs/noise.ts
+++ b/packages/beacon-node/src/network/nodejs/noise.ts
@@ -1,0 +1,79 @@
+import {HKDF} from "@stablelib/hkdf";
+import * as x25519 from "@stablelib/x25519";
+import {SHA256} from "@stablelib/sha256";
+import {newInstance, ChaCha20Poly1305} from "ssz-3/packages/as-chacha20poly1305/lib/src/index";
+import type {ConnectionEncrypter} from "@libp2p/interface-connection-encrypter";
+import {ICryptoInterface, noise} from "@chainsafe/libp2p-noise";
+import {digest} from "@chainsafe/as-sha256";
+
+type bytes = Uint8Array;
+type bytes32 = Uint8Array;
+type Hkdf = [bytes, bytes, bytes];
+interface KeyPair {
+  publicKey: bytes32;
+  privateKey: bytes32;
+}
+
+const ctx = newInstance();
+const asImpl = new ChaCha20Poly1305(ctx);
+
+// same to stablelib but we use as-chacha20poly1305 and as-sha256
+// TODO: find a way to reuse the following code
+const lodestarCrypto: ICryptoInterface = {
+  hashSHA256(data: Uint8Array): Uint8Array {
+    return digest(data);
+  },
+
+  getHKDF(ck: bytes32, ikm: Uint8Array): Hkdf {
+    const hkdf = new HKDF(SHA256, ikm, ck);
+    const okmU8Array = hkdf.expand(96);
+    const okm = okmU8Array;
+
+    const k1 = okm.subarray(0, 32);
+    const k2 = okm.subarray(32, 64);
+    const k3 = okm.subarray(64, 96);
+
+    return [k1, k2, k3];
+  },
+
+  generateX25519KeyPair(): KeyPair {
+    const keypair = x25519.generateKeyPair();
+
+    return {
+      publicKey: keypair.publicKey,
+      privateKey: keypair.secretKey,
+    };
+  },
+
+  generateX25519KeyPairFromSeed(seed: Uint8Array): KeyPair {
+    const keypair = x25519.generateKeyPairFromSeed(seed);
+
+    return {
+      publicKey: keypair.publicKey,
+      privateKey: keypair.secretKey,
+    };
+  },
+
+  generateX25519SharedKey(privateKey: Uint8Array, publicKey: Uint8Array): Uint8Array {
+    return x25519.sharedKey(privateKey, publicKey);
+  },
+
+  chaCha20Poly1305Encrypt(plaintext: Uint8Array, nonce: Uint8Array, ad: Uint8Array, k: bytes32): bytes {
+    return asImpl.seal(k, nonce, plaintext, ad);
+  },
+
+  chaCha20Poly1305Decrypt(
+    ciphertext: Uint8Array,
+    nonce: Uint8Array,
+    ad: Uint8Array,
+    k: bytes32,
+    dst?: Uint8Array
+  ): bytes | null {
+    return asImpl.open(k, nonce, ciphertext, ad, dst);
+  },
+};
+
+export function createNoise(): ConnectionEncrypter {
+  const factory = noise({crypto: lodestarCrypto});
+  return factory() as ConnectionEncrypter;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -548,14 +548,14 @@
     uint8arraylist "^2.3.2"
     uint8arrays "^3.0.0"
 
-"@chainsafe/libp2p-noise@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-noise/-/libp2p-noise-8.0.0.tgz#93118f6872e09517ef50167f05f12aed6d4cc2f2"
-  integrity sha512-APAhb+3eZWHFo+oORG/nUhNTLKgbcTOGeJsnEq//KnjiOjfBDCk4gQmpoSTrLAz1cOTyZ3luSSI4Z+lo2Og7gQ==
+"@chainsafe/libp2p-noise@tuyennhv/js-libp2p-noise#tuyen/reuse-decrypt-allocation-dist":
+  version "10.1.0"
+  resolved "https://codeload.github.com/tuyennhv/js-libp2p-noise/tar.gz/79181207b5bc75b21a990ac2abce2d3b9b21af20"
   dependencies:
     "@libp2p/crypto" "^1.0.0"
-    "@libp2p/interface-connection-encrypter" "^2.0.1"
+    "@libp2p/interface-connection-encrypter" "^3.0.0"
     "@libp2p/interface-keys" "^1.0.2"
+    "@libp2p/interface-metrics" "^4.0.2"
     "@libp2p/interface-peer-id" "^1.0.2"
     "@libp2p/logger" "^2.0.0"
     "@libp2p/peer-id" "^1.1.8"
@@ -568,9 +568,9 @@
     it-pb-stream "^2.0.2"
     it-pipe "^2.0.3"
     it-stream-types "^1.0.4"
-    protons-runtime "^3.1.0"
+    protons-runtime "^4.0.1"
     uint8arraylist "^2.3.2"
-    uint8arrays "^3.1.0"
+    uint8arrays "^4.0.2"
 
 "@chainsafe/persistent-merkle-tree@^0.4.2":
   version "0.4.2"
@@ -1887,6 +1887,15 @@
     it-stream-types "^1.0.4"
     uint8arraylist "^2.1.1"
 
+"@libp2p/interface-connection-encrypter@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-3.0.1.tgz#5a68ce162930b756e8177a88cb807d2937799d32"
+  integrity sha512-KZ/4vuLokv2fNCnEAM5S91t8v5lMWXdYa26v/iGLqLgiH5MXmIGOgLLGdboXNMYM2ZYYCBgEpSHv+ZRbfO524Q==
+  dependencies:
+    "@libp2p/interface-peer-id" "^1.0.0"
+    it-stream-types "^1.0.4"
+    uint8arraylist "^2.1.1"
+
 "@libp2p/interface-connection-manager@^1.1.0", "@libp2p/interface-connection-manager@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@libp2p/interface-connection-manager/-/interface-connection-manager-1.1.1.tgz#6b1e7116d77bf813f5a4d1aa3c2e39c5e00a3a24"
@@ -1948,6 +1957,13 @@
   dependencies:
     "@libp2p/interface-peer-id" "^1.0.0"
     it-stream-types "^1.0.4"
+
+"@libp2p/interface-metrics@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@libp2p/interface-metrics/-/interface-metrics-4.0.2.tgz#329a1602f7844f6a9cf441439001f8e8f8e7dafc"
+  integrity sha512-HON9yXhFaTnQ86tOdE18bFJv71zQdI7xrZJuA6pNUtpsfA+djhqWXv0a4mwEGUP7k4zz3FkH0M9CrrvL0pkBWg==
+  dependencies:
+    "@libp2p/interface-connection" "^3.0.0"
 
 "@libp2p/interface-peer-discovery@^1.0.0", "@libp2p/interface-peer-discovery@^1.0.1":
   version "1.0.1"
@@ -10998,6 +11014,14 @@ protons-runtime@^3.0.1, protons-runtime@^3.1.0:
     protobufjs "^7.0.0"
     uint8arraylist "^2.3.2"
 
+protons-runtime@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/protons-runtime/-/protons-runtime-4.0.1.tgz#bcea3667b6263680e70e2da102f91b3513075374"
+  integrity sha512-SPeV+8TzJAp5UJYPV7vJkLRi08CP0DksxpKK60rcNaZSPkMBQwc0jQrmkHqwc5P0cYbZzKsdYrUBwRrDLrzTfQ==
+  dependencies:
+    protobufjs "^7.0.0"
+    uint8arraylist "^2.3.2"
+
 psl@^1.1.28:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
@@ -12030,6 +12054,10 @@ ssri@^9.0.0, ssri@^9.0.1:
   integrity sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==
   dependencies:
     minipass "^3.1.1"
+
+"ssz-3@https://github.com/tuyennhv/ssz.git#tuyen/as-chacha20poly1305-lib":
+  version "1.0.0"
+  resolved "https://github.com/tuyennhv/ssz.git#9aa9db216934a2a50f2291e904ca0ddc3fecc77a"
 
 stack-trace@0.0.x:
   version "0.0.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -553,9 +553,10 @@
     uint8arraylist "^2.3.2"
     uint8arrays "^3.0.0"
 
-"@chainsafe/libp2p-noise@tuyennhv/js-libp2p-noise#tuyen/reuse-decrypt-allocation-dist":
-  version "10.1.0"
-  resolved "https://codeload.github.com/tuyennhv/js-libp2p-noise/tar.gz/79181207b5bc75b21a990ac2abce2d3b9b21af20"
+"@chainsafe/libp2p-noise@^10.2.0":
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-noise/-/libp2p-noise-10.2.0.tgz#809f7fff8685a1687958fc8f36d314e1d097b6ad"
+  integrity sha512-nXw09UwSE5JCiB5Dte6j0b0Qe+KbtepJvaPz/f5JyxcoyUfLE/t7XWRZAZmcuWBeVWWpOItnK5WmW8uocoiwCQ==
   dependencies:
     "@libp2p/crypto" "^1.0.0"
     "@libp2p/interface-connection-encrypter" "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,6 +404,10 @@
   resolved "https://registry.yarnpkg.com/@balena/dockerignore/-/dockerignore-1.0.2.tgz#9ffe4726915251e8eb69f44ef3547e0da2c03e0d"
   integrity sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==
 
+"@chainsafe/as-chacha20poly1305-2@https://github.com/tuyennhv/as-chacha20poly1305#tuyen/initial-implementation-dist":
+  version "0.1.0"
+  resolved "https://github.com/tuyennhv/as-chacha20poly1305#c11a2715a29371ee1c70b3150c7c43f74a6a8572"
+
 "@chainsafe/as-sha256@^0.3.1":
   version "0.3.1"
   resolved "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz"
@@ -12054,10 +12058,6 @@ ssri@^9.0.0, ssri@^9.0.1:
   integrity sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==
   dependencies:
     minipass "^3.1.1"
-
-"ssz-3@https://github.com/tuyennhv/ssz.git#tuyen/as-chacha20poly1305-lib":
-  version "1.0.0"
-  resolved "https://github.com/tuyennhv/ssz.git#9aa9db216934a2a50f2291e904ca0ddc3fecc77a"
 
 stack-trace@0.0.x:
   version "0.0.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,9 +404,10 @@
   resolved "https://registry.yarnpkg.com/@balena/dockerignore/-/dockerignore-1.0.2.tgz#9ffe4726915251e8eb69f44ef3547e0da2c03e0d"
   integrity sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==
 
-"@chainsafe/as-chacha20poly1305-2@https://github.com/tuyennhv/as-chacha20poly1305#tuyen/initial-implementation-dist":
+"@chainsafe/as-chacha20poly1305@^0.1.0":
   version "0.1.0"
-  resolved "https://github.com/tuyennhv/as-chacha20poly1305#c11a2715a29371ee1c70b3150c7c43f74a6a8572"
+  resolved "https://registry.yarnpkg.com/@chainsafe/as-chacha20poly1305/-/as-chacha20poly1305-0.1.0.tgz#7da6f8796f9b42dac6e830a086d964f1f9189e09"
+  integrity sha512-BpNcL8/lji/GM3+vZ/bgRWqJ1q5kwvTFmGPk7pxm/QQZDbaMI98waOHjEymTjq2JmdD/INdNBFOVSyJofXg7ew==
 
 "@chainsafe/as-sha256@^0.3.1":
   version "0.3.1"


### PR DESCRIPTION
**Motivation**

It takes time for `chacha20poly1305Decrypt` function, on a goerli node of 1000 validators it takes ~10% of cpu time

**Description**

- Switch from `stablelib` to the newly implemented `as-chacha20poly1305`
- In libp2p-noise, reuse encrypted message to avoid another memory allocation, see https://github.com/ChainSafe/js-libp2p-noise/pull/242

Closes #4652

Result after 3 day deployment:

- The new profile showed `chacha20poly1305Decrypt` now takes 3.4% of cpu time with same number of rpc messages received

<img width="1296" alt="Screen Shot 2022-11-21 at 09 52 07" src="https://user-images.githubusercontent.com/10568965/202953083-f8dede6d-3206-4d36-93c8-6f31b6593692.png">

- There are some random differences on the metrics but the main difference regarding this PR is lower cpu time on all nodes (while gc pause time rate is only a bit lower)

<img width="800" alt="Screen Shot 2022-11-21 at 09 55 41" src="https://user-images.githubusercontent.com/10568965/202953528-b663fd7b-0f99-46f8-96c8-8e5252502176.png">

- Number of rpc messages on all nodes are the same (and number of mesh peers too)
<img width="803" alt="Screen Shot 2022-11-21 at 09 58 14" src="https://user-images.githubusercontent.com/10568965/202953809-73e88acb-88a1-4f31-9cf1-18999b6d0550.png">


[1121_lg1k_as-chacha20poly1305.cpuprofile.zip](https://github.com/ChainSafe/lodestar/files/10052621/1121_lg1k_as-chacha20poly1305.cpuprofile.zip)




