### PR TITLE
Default afterBlockDelaySlotFraction to 0

### DIFF
--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -135,9 +135,11 @@ export class AttestationService {
     // never beyond the 1/3 cutoff time.
     // https://github.com/status-im/nimbus-eth2/blob/7b64c1dce4392731a4a59ee3a36caef2e0a8357a/beacon_chain/validators/validator_duties.nim#L1123
     const msToOneThirdSlot = this.clock.msToSlot(slot + 1 / 3);
-    // Default = 1/6, which is half of attestation offset
-    const afterBlockDelayMs = 1000 * this.clock.secondsPerSlot * (this.opts?.afterBlockDelaySlotFraction ?? 1 / 6);
-    await sleep(Math.min(msToOneThirdSlot, afterBlockDelayMs));
+    // submitting attestations asap to avoid busy time at around 1/3 of slot
+    const afterBlockDelayMs = 1000 * this.clock.secondsPerSlot * (this.opts?.afterBlockDelaySlotFraction ?? 0);
+    if (afterBlockDelayMs > 0) {
+      await sleep(Math.min(msToOneThirdSlot, afterBlockDelayMs));
+    }
 
     this.metrics?.attesterStepCallPublishAttestation.observe(this.clock.secFromSlot(slot + 1 / 3));
 

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -17,6 +17,15 @@ type AttestationServiceOpts = {
 };
 
 /**
+ * Previously, submitting attestations too early may cause some attestations missed (because some clients may not queue attestations, and
+ * sent peers are few) so it was configured as 1/6. See https://github.com/ChainSafe/lodestar/issues/3943
+ *
+ * As of Nov 2022, it's proved that submitting attestations asap is better as it avoids busy time of node at around 1/3 of slot (and could be
+ * because sent peers are better than before). See https://github.com/ChainSafe/lodestar/issues/4600#issuecomment-1321546586
+ */
+const DEFAULT_AFTER_BLOCK_DELAY_SLOT_FRACTION = 0;
+
+/**
  * Service that sets up and handles validator attester duties.
  */
 export class AttestationService {
@@ -136,10 +145,11 @@ export class AttestationService {
     // https://github.com/status-im/nimbus-eth2/blob/7b64c1dce4392731a4a59ee3a36caef2e0a8357a/beacon_chain/validators/validator_duties.nim#L1123
     const msToOneThirdSlot = this.clock.msToSlot(slot + 1 / 3);
     // submitting attestations asap to avoid busy time at around 1/3 of slot
-    const afterBlockDelayMs = 1000 * this.clock.secondsPerSlot * (this.opts?.afterBlockDelaySlotFraction ?? 0);
-    if (afterBlockDelayMs > 0) {
-      await sleep(Math.min(msToOneThirdSlot, afterBlockDelayMs));
-    }
+    const afterBlockDelayMs =
+      1000 *
+      this.clock.secondsPerSlot *
+      (this.opts?.afterBlockDelaySlotFraction ?? DEFAULT_AFTER_BLOCK_DELAY_SLOT_FRACTION);
+    await sleep(Math.min(msToOneThirdSlot, afterBlockDelayMs));
 
     this.metrics?.attesterStepCallPublishAttestation.observe(this.clock.secFromSlot(slot + 1 / 3));
 


### PR DESCRIPTION
**Motivation**

It's been a while since we test the `afterBlockDelaySlotFraction=0` on mainnet nodes, the result is good so we should apply that by default to benefit everybody.

**Description**

- By default set `afterBlockDelaySlotFraction` as 0 instead of 1/6 slot

Closes #4600
