### PR TITLE
Track stfn state cache misses

### DIFF
--- a/packages/beacon-node/src/chain/stateCache/stateContextCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/stateContextCache.ts
@@ -4,7 +4,6 @@ import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {routes} from "@lodestar/api";
 import {IMetrics} from "../../metrics/index.js";
 import {MapTracker} from "./mapMetrics.js";
-import {stateInternalCachePopulated} from "./stateContextCheckpointsCache.js";
 
 const MAX_STATES = 3 * 32;
 
@@ -51,9 +50,6 @@ export class StateContextCache {
 
     this.metrics?.hits.inc();
     this.metrics?.stateClonedCount.observe(item.clonedCount);
-    if (!stateInternalCachePopulated(item)) {
-      this.metrics?.stateInternalCacheMiss.inc();
-    }
 
     return item;
   }

--- a/packages/beacon-node/src/chain/stateCache/stateContextCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/stateContextCheckpointsCache.ts
@@ -48,9 +48,6 @@ export class CheckpointStateCache {
     }
 
     this.metrics?.stateClonedCount.observe(item.clonedCount);
-    if (!stateInternalCachePopulated(item)) {
-      this.metrics?.stateInternalCacheMiss.inc();
-    }
 
     return item;
   }
@@ -162,16 +159,3 @@ export function toCheckpointHex(checkpoint: phase0.Checkpoint): CheckpointHex {
 export function toCheckpointKey(cp: CheckpointHex): string {
   return `${cp.rootHex}:${cp.epoch}`;
 }
-
-/**
- * Given a CachedBeaconState, check if validators array internal cache is populated.
- * This cache is populated during epoch transition, and should be preserved for performance.
- * If the cache is missing too often, means that our clone strategy is not working well.
- */
-export function stateInternalCachePopulated(state: CachedBeaconStateAllForks): boolean {
-  return ((state.validators as unknown) as ViewDU).nodesPopulated === true;
-}
-
-type ViewDU = {
-  nodesPopulated: boolean;
-};

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -407,6 +407,21 @@ export function createLodestarMetrics(
       // Block processing can take 5-40ms, 100ms max
       buckets: [0.005, 0.01, 0.02, 0.05, 0.1, 1],
     }),
+    stfnBalancesCacheMiss: register.gauge<"source">({
+      name: "lodestar_stfn_balances_nodes_populated_miss_total",
+      help: "Total count state.balances nodesPopulated is not true on stfn",
+      labelNames: ["source"],
+    }),
+    stfnValidatorsNodesPopulatedMiss: register.gauge<"source">({
+      name: "lodestar_stfn_validators_nodes_populated_miss_total",
+      help: "Total count state.validators nodesPopulated is not true on stfn",
+      labelNames: ["source"],
+    }),
+    stfnStateClone: register.gauge<"source">({
+      name: "lodestar_stfn_state_clone_total",
+      help: "Total count of state.clone() calls in stfn",
+      labelNames: ["source"],
+    }),
 
     // BLS verifier thread pool and queue
 
@@ -885,10 +900,6 @@ export function createLodestarMetrics(
         help: "Histogram of cloned count per state every time state.clone() is called",
         buckets: [1, 2, 5, 10, 50, 250],
       }),
-      stateInternalCacheMiss: register.gauge({
-        name: "lodestar_state_cache_state_internal_cache_miss",
-        help: "Retrieved state does not have its internal cache populated",
-      }),
     },
 
     cpStateCache: {
@@ -924,10 +935,6 @@ export function createLodestarMetrics(
         name: "lodestar_cp_state_cache_state_cloned_count",
         help: "Histogram of cloned count per state every time state.clone() is called",
         buckets: [1, 2, 5, 10, 50, 250],
-      }),
-      stateInternalCacheMiss: register.gauge({
-        name: "lodestar_cp_state_cache_state_internal_cache_miss",
-        help: "Retrieved state does not have its internal cache populated",
       }),
     },
 

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -407,7 +407,7 @@ export function createLodestarMetrics(
       // Block processing can take 5-40ms, 100ms max
       buckets: [0.005, 0.01, 0.02, 0.05, 0.1, 1],
     }),
-    stfnBalancesCacheMiss: register.gauge<"source">({
+    stfnBalancesNodesPopulatedMiss: register.gauge<"source">({
       name: "lodestar_stfn_balances_nodes_populated_miss_total",
       help: "Total count state.balances nodesPopulated is not true on stfn",
       labelNames: ["source"],
@@ -421,6 +421,11 @@ export function createLodestarMetrics(
       name: "lodestar_stfn_state_clone_total",
       help: "Total count of state.clone() calls in stfn",
       labelNames: ["source"],
+    }),
+    stfnStateClonedCount: register.histogram({
+      name: "lodestar_stfn_state_cloned_count",
+      help: "Histogram of cloned count per state every time state.clone() is called",
+      buckets: [1, 2, 5, 10, 50, 250],
     }),
 
     // BLS verifier thread pool and queue

--- a/packages/state-transition/src/metrics.ts
+++ b/packages/state-transition/src/metrics.ts
@@ -1,12 +1,49 @@
 import {Epoch} from "@lodestar/types";
+import {CachedBeaconStateAllForks} from "./types.js";
 import {IAttesterStatus} from "./util/attesterStatus.js";
 
 export interface IBeaconStateTransitionMetrics {
   stfnEpochTransition: IHistogram;
   stfnProcessBlock: IHistogram;
+  stfnBalancesNodesPopulatedMiss: IGauge<"source">;
+  stfnValidatorsNodesPopulatedMiss: IGauge<"source">;
+  stfnStateClone: IGauge<"source">;
+  stfnStateClonedCount: IHistogram;
   registerValidatorStatuses: (currentEpoch: Epoch, statuses: IAttesterStatus[], balances?: number[]) => void;
 }
 
-interface IHistogram {
+type LabelValues<T extends string> = Partial<Record<T, string | number>>;
+
+interface IHistogram<T extends string = string> {
   startTimer(): () => void;
+
+  observe(value: number): void;
+  observe(labels: LabelValues<T>, values: number): void;
+  observe(arg1: LabelValues<T> | number, arg2?: number): void;
+}
+
+interface IGauge<T extends string = string> {
+  inc(value?: number): void;
+  inc(labels: LabelValues<T>, value?: number): void;
+  inc(arg1?: LabelValues<T> | number, arg2?: number): void;
+}
+
+export function onStateCloneMetrics(
+  state: CachedBeaconStateAllForks,
+  metrics: IBeaconStateTransitionMetrics,
+  source: "stateTransition" | "processSlots"
+): void {
+  metrics.stfnStateClone.inc({source});
+  metrics.stfnStateClonedCount.observe(state.clonedCount);
+
+  if (!state.balances["nodesPopulated"]) {
+    metrics.stfnBalancesNodesPopulatedMiss.inc({source});
+  }
+
+  // Given a CachedBeaconState, check if validators array internal cache is populated.
+  // This cache is populated during epoch transition, and should be preserved for performance.
+  // If the cache is missing too often, means that our clone strategy is not working well.
+  if (!state.validators["nodesPopulated"]) {
+    metrics.stfnValidatorsNodesPopulatedMiss.inc({source});
+  }
 }

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -2,7 +2,7 @@
 import {allForks, Slot, ssz} from "@lodestar/types";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {toHexString} from "@chainsafe/ssz";
-import {IBeaconStateTransitionMetrics} from "./metrics.js";
+import {IBeaconStateTransitionMetrics, onStateCloneMetrics} from "./metrics.js";
 import {beforeProcessEpoch, EpochProcessOpts} from "./cache/epochProcess.js";
 import {
   CachedBeaconStateAllForks,
@@ -40,6 +40,10 @@ export function stateTransition(
 
   // .clone() before mutating state in state transition
   let postState = state.clone();
+
+  if (metrics) {
+    onStateCloneMetrics(postState, metrics, "stateTransition");
+  }
 
   // State is already a ViewDU, which won't commit changes. Equivalent to .setStateCachesAsTransient()
   // postState.setStateCachesAsTransient();
@@ -96,6 +100,10 @@ export function processSlots(
 ): CachedBeaconStateAllForks {
   // .clone() before mutating state in state transition
   let postState = state.clone();
+
+  if (metrics) {
+    onStateCloneMetrics(postState, metrics, "processSlots");
+  }
 
   // State is already a ViewDU, which won't commit changes. Equivalent to .setStateCachesAsTransient()
   // postState.setStateCachesAsTransient();


### PR DESCRIPTION
**Motivation**

- Need to understand how often ssz TreeViewDU caches are populated allowing for fast tree traversal, for https://github.com/ChainSafe/lodestar/pull/4792

**Description**

- Track stfn state cache misses before running state transition, instead of on every state cache get.