### PR TITLE
Fix duplicate metrics

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -127,7 +127,7 @@
     "@lodestar/types": "^1.2.1",
     "@lodestar/utils": "^1.2.1",
     "@lodestar/validator": "^1.2.1",
-    "@lodestar/reqresp": "^0.1.0",
+    "@lodestar/reqresp": "^1.2.1",
     "@multiformats/multiaddr": "^11.0.0",
     "@types/datastore-level": "^3.0.0",
     "buffer-xor": "^2.0.2",

--- a/packages/reqresp/package.json
+++ b/packages/reqresp/package.json
@@ -20,9 +20,6 @@
     "./messages": {
       "import": "./lib/messages/index.js"
     },
-    "./rate_limiter": {
-      "import": "./lib/rate_limiter/index.js"
-    },
     "./utils": {
       "import": "./lib/utils/index.js"
     }

--- a/packages/reqresp/src/metrics.ts
+++ b/packages/reqresp/src/metrics.ts
@@ -101,10 +101,5 @@ export function getMetrics(register: MetricsRegister) {
       name: "beacon_reqresp_dial_errors_total",
       help: "Count total dial errors",
     }),
-    rateLimitErrors: register.gauge<"tracker">({
-      name: "beacon_reqresp_rate_limiter_errors_total",
-      help: "Count rate limiter errors",
-      labelNames: ["tracker"],
-    }),
   };
 }


### PR DESCRIPTION
**Motivation**

Node is not able to start due to this error
```
Nov-24 14:31:31.368[]                 info: Initializing beacon from a valid db state slot=5159328, epoch=161229, stateRoot=0x360b07c5efdbc3020d9e9d76c704a78590446b4f755a005cf61e459f7bdd04bc, isWithinWeakSubjectivityPeriod=true
 ✖ Error: A metric with the name beacon_reqresp_rate_limiter_errors_total has already been registered.
    at RegistryMetricCreator.registerMetric (/Users/tuyennguyen/Projects/workshop/lodestar/node_modules/prom-client/lib/registry.js:80:10)
    at new Metric (/Users/tuyennguyen/Projects/workshop/lodestar/node_modules/prom-client/lib/metric.js:48:13)
    at new Gauge (/Users/tuyennguyen/Projects/workshop/lodestar/node_modules/prom-client/lib/gauge.js:20:1)
    at new GaugeExtra (file:///Users/tuyennguyen/Projects/workshop/lodestar/packages/beacon-node/src/metrics/utils/gauge.ts:16:5)
    at RegistryMetricCreator.gauge (file:///Users/tuyennguyen/Projects/workshop/lodestar/packages/beacon-node/src/metrics/utils/registryMetricCreator.ts:14:12)
    at getMetrics (file:///Users/tuyennguyen/Projects/workshop/lodestar/packages/beacon-node/node_modules/@lodestar/reqresp/src/metrics.ts:104:31)
    at new ReqResp (file:///Users/tuyennguyen/Projects/workshop/lodestar/packages/beacon-node/node_modules/@lodestar/reqresp/src/ReqResp.ts:49:46)
    at new ReqRespBeaconNode (file:///Users/tuyennguyen/Projects/workshop/lodestar/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts:79:5)
    at new Network (file:///Users/tuyennguyen/Projects/workshop/lodestar/packages/beacon-node/src/network/network.ts:74:20)
    at Function.init (file:///Users/tuyennguyen/Projects/workshop/lodestar/packages/beacon-node/src/node/nodejs.ts:185:21)
```

**Description**

- Remove redundant metric in `reqresp` package
- Correct version of `reqresp` package in `beacon-node

Closes #4805
