### PR TITLE
Update blst dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
     "@chainsafe/bls": "7.1.1",
     "@chainsafe/bls-keygen": "^0.3.0",
     "@chainsafe/bls-keystore": "^2.0.0",
-    "@chainsafe/blst": "^0.2.4",
+    "@chainsafe/blst": "^0.2.6",
     "@chainsafe/discv5": "^1.4.0",
     "@chainsafe/ssz": "^0.9.2",
     "@libp2p/peer-id-factory": "^1.0.18",

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -71,7 +71,7 @@
     "buffer-xor": "^2.0.2"
   },
   "devDependencies": {
-    "@chainsafe/blst": "^0.2.4",
+    "@chainsafe/blst": "^0.2.6",
     "@types/buffer-xor": "^2.0.0",
     "@types/mockery": "^1.4.29",
     "mockery": "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,10 +469,10 @@
     bls-eth-wasm "^0.4.8"
     randombytes "^2.1.0"
 
-"@chainsafe/blst@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.npmjs.org/@chainsafe/blst/-/blst-0.2.4.tgz"
-  integrity sha512-jjhB4dALUvLdTc2flHE6BEI7KCvXVGevIP8si4OdtERu+Ed+cc6zBsrpLvOySX9pgAMAmAuTnB349AlmRfmR2Q==
+"@chainsafe/blst@^0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-0.2.6.tgz#56f17c82338d62421321dca60250951dd3a7db7a"
+  integrity sha512-7mzE9IRjG0TZKPit83GT4XPSgMnqmMT4AAeUTyTj/IwO4FDPQ3fJVheT6i9LaH3I4Y18oaL68G9j+Uh3mEEAYg==
   dependencies:
     node-fetch "^2.6.1"
     node-gyp "^8.4.0"


### PR DESCRIPTION
Bump from 0.2.4 -> 0.2.6, changelog:
- Bump BLST to latest
- Add support for NodeJS 18 on arm64 + amd64
- Fix issue for MacOS build