### PR TITLE
Skip signature group check after sig verify

### DIFF
--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -19,7 +19,7 @@ import {toHexString} from "@chainsafe/ssz";
 import {IForkChoice, EpochDifference} from "@lodestar/fork-choice";
 import {toHex, MapDef} from "@lodestar/utils";
 import {intersectUint8Arrays, IntersectResult} from "../../util/bitArray.js";
-import {pruneBySlot} from "./utils.js";
+import {pruneBySlot, signatureFromBytesNoCheck} from "./utils.js";
 import {InsertOutcome} from "./types.js";
 
 type DataRootHex = string;
@@ -316,8 +316,8 @@ export function aggregateInto(attestation1: AttestationWithIndex, attestation2: 
   // Merge bits of attestation2 into attestation1
   attestation1.attestation.aggregationBits.mergeOrWith(attestation2.attestation.aggregationBits);
 
-  const signature1 = bls.Signature.fromBytes(attestation1.attestation.signature, undefined, true);
-  const signature2 = bls.Signature.fromBytes(attestation2.attestation.signature, undefined, true);
+  const signature1 = signatureFromBytesNoCheck(attestation1.attestation.signature);
+  const signature2 = signatureFromBytesNoCheck(attestation2.attestation.signature);
   attestation1.attestation.signature = bls.Signature.aggregate([signature1, signature2]).toBytes();
 }
 

--- a/packages/beacon-node/src/chain/opPools/attestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/attestationPool.ts
@@ -4,7 +4,7 @@ import bls from "@chainsafe/bls";
 import {BitArray, toHexString} from "@chainsafe/ssz";
 import {MapDef} from "@lodestar/utils";
 import {InsertOutcome, OpPoolError, OpPoolErrorCode} from "./types.js";
-import {pruneBySlot} from "./utils.js";
+import {pruneBySlot, signatureFromBytesNoCheck} from "./utils.js";
 
 /**
  * The number of slots that will be stored in the pool.
@@ -183,7 +183,7 @@ function aggregateAttestationInto(aggregate: AggregateFast, attestation: phase0.
   aggregate.aggregationBits.set(bitIndex, true);
   aggregate.signature = bls.Signature.aggregate([
     aggregate.signature,
-    bls.Signature.fromBytes(attestation.signature, undefined, true),
+    signatureFromBytesNoCheck(attestation.signature),
   ]);
   return InsertOutcome.Aggregated;
 }
@@ -196,7 +196,7 @@ function attestationToAggregate(attestation: phase0.Attestation): AggregateFast 
     data: attestation.data,
     // clone because it will be mutated
     aggregationBits: attestation.aggregationBits.clone(),
-    signature: bls.Signature.fromBytes(attestation.signature, undefined, true),
+    signature: signatureFromBytesNoCheck(attestation.signature),
   };
 }
 

--- a/packages/beacon-node/src/chain/opPools/syncCommitteeMessagePool.ts
+++ b/packages/beacon-node/src/chain/opPools/syncCommitteeMessagePool.ts
@@ -5,7 +5,7 @@ import {altair, Root, Slot, SubcommitteeIndex} from "@lodestar/types";
 import {BitArray, toHexString} from "@chainsafe/ssz";
 import {MapDef} from "@lodestar/utils";
 import {InsertOutcome, OpPoolError, OpPoolErrorCode} from "./types.js";
-import {pruneBySlot} from "./utils.js";
+import {pruneBySlot, signatureFromBytesNoCheck} from "./utils.js";
 
 /**
  * SyncCommittee signatures are only useful during a single slot according to our peer's clocks
@@ -125,7 +125,7 @@ function aggregateSignatureInto(
   contribution.aggregationBits.set(indexInSubcommittee, true);
   contribution.signature = bls.Signature.aggregate([
     contribution.signature,
-    bls.Signature.fromBytes(signature.signature, undefined, true),
+    signatureFromBytesNoCheck(signature.signature),
   ]);
   return InsertOutcome.Aggregated;
 }
@@ -146,6 +146,6 @@ function signatureToAggregate(
     beaconBlockRoot: signature.beaconBlockRoot,
     subcommitteeIndex: subnet,
     aggregationBits,
-    signature: bls.Signature.fromBytes(signature.signature, undefined, true),
+    signature: signatureFromBytesNoCheck(signature.signature),
   };
 }

--- a/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
@@ -6,7 +6,7 @@ import {G2_POINT_AT_INFINITY} from "@lodestar/state-transition";
 import {BitArray, toHexString} from "@chainsafe/ssz";
 import {MapDef} from "@lodestar/utils";
 import {InsertOutcome, OpPoolError, OpPoolErrorCode} from "./types.js";
-import {pruneBySlot} from "./utils.js";
+import {pruneBySlot, signatureFromBytesNoCheck} from "./utils.js";
 
 /**
  * SyncCommittee aggregates are only useful for the next block they have signed.
@@ -178,7 +178,7 @@ export function aggregate(bestContributionBySubnet: Map<number, SyncContribution
       syncCommitteeBits.uint8Array[byteOffset + i] = bestContribution.syncSubcommitteeBits.uint8Array[i];
     }
 
-    signatures.push(bls.Signature.fromBytes(bestContribution.syncSubcommitteeSignature, undefined, true));
+    signatures.push(signatureFromBytesNoCheck(bestContribution.syncSubcommitteeSignature));
   }
   return {
     syncCommitteeBits,

--- a/packages/beacon-node/src/chain/opPools/utils.ts
+++ b/packages/beacon-node/src/chain/opPools/utils.ts
@@ -1,3 +1,5 @@
+import bls from "@chainsafe/bls";
+import {CoordType, Signature} from "@chainsafe/bls/types";
 import {Slot} from "@lodestar/types";
 
 /**
@@ -19,4 +21,12 @@ export function pruneBySlot(map: Map<Slot, unknown>, slot: Slot, slotsRetained: 
   }
 
   return lowestPermissibleSlot;
+}
+
+/**
+ * De-serialize bytes into Signature.
+ * No need to verify Signature is valid, already run sig-verify = false
+ */
+export function signatureFromBytesNoCheck(signature: Uint8Array): Signature {
+  return bls.Signature.fromBytes(signature, CoordType.affine, false);
 }


### PR DESCRIPTION
**Motivation**

CPU Profile (sorry no link) shows that Lodestar with --subscribe-all-subnets spends ~5% of sig group check on the op pool aggregation logic. Since the signature is already checked to be valid, no need to redo signature validity checks.

**Description**

- Skip signature group check after sig verify

Closes https://github.com/ChainSafe/lodestar/issues/4835
Closes https://github.com/ChainSafe/lodestar/issues/4690