### PR TITLE
EIP-4844: Add blobsSidecar db repos

### DIFF
--- a/packages/beacon-node/src/db/beacon.ts
+++ b/packages/beacon-node/src/db/beacon.ts
@@ -15,12 +15,16 @@ import {
   SyncCommitteeRepository,
   SyncCommitteeWitnessRepository,
   BackfilledRanges,
+  BlobsSidecarRepository,
+  BlobsSidecarArchiveRepository,
 } from "./repositories/index.js";
 import {PreGenesisState, PreGenesisStateLastProcessedBlock} from "./single/index.js";
 
 export class BeaconDb extends DatabaseService implements IBeaconDb {
   block: BlockRepository;
+  blobsSidecar: BlobsSidecarRepository;
   blockArchive: BlockArchiveRepository;
+  blobsSidecarArchive: BlobsSidecarArchiveRepository;
   stateArchive: StateArchiveRepository;
 
   voluntaryExit: VoluntaryExitRepository;
@@ -46,7 +50,9 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
 
     // Warning: If code is ever run in the constructor, must change this stub to not extend 'packages/beacon-node/test/utils/stub/beaconDb.ts' -
     this.block = new BlockRepository(this.config, this.db);
+    this.blobsSidecar = new BlobsSidecarRepository(this.config, this.db);
     this.blockArchive = new BlockArchiveRepository(this.config, this.db);
+    this.blobsSidecarArchive = new BlobsSidecarArchiveRepository(this.config, this.db);
     this.stateArchive = new StateArchiveRepository(this.config, this.db);
     this.voluntaryExit = new VoluntaryExitRepository(this.config, this.db);
     this.proposerSlashing = new ProposerSlashingRepository(this.config, this.db);

--- a/packages/beacon-node/src/db/interface.ts
+++ b/packages/beacon-node/src/db/interface.ts
@@ -14,6 +14,8 @@ import {
   SyncCommitteeRepository,
   SyncCommitteeWitnessRepository,
   BackfilledRanges,
+  BlobsSidecarRepository,
+  BlobsSidecarArchiveRepository,
 } from "./repositories/index.js";
 import {PreGenesisState, PreGenesisStateLastProcessedBlock} from "./single/index.js";
 
@@ -25,9 +27,11 @@ import {PreGenesisState, PreGenesisStateLastProcessedBlock} from "./single/index
 export interface IBeaconDb {
   // unfinalized blocks
   block: BlockRepository;
+  blobsSidecar: BlobsSidecarRepository;
 
   // finalized blocks
   blockArchive: BlockArchiveRepository;
+  blobsSidecarArchive: BlobsSidecarArchiveRepository;
 
   // finalized states
   stateArchive: StateArchiveRepository;

--- a/packages/beacon-node/src/db/repositories/blobsSidecar.ts
+++ b/packages/beacon-node/src/db/repositories/blobsSidecar.ts
@@ -1,0 +1,21 @@
+import {IChainForkConfig} from "@lodestar/config";
+import {Bucket, Db, Repository} from "@lodestar/db";
+import {eip4844, ssz} from "@lodestar/types";
+
+/**
+ * BlobsSidecar by block root (= hash_tree_root(SignedBeaconBlockAndBlobsSidecar.beacon_block.message))
+ *
+ * Used to store unfinalized BlobsSidecar
+ */
+export class BlobsSidecarRepository extends Repository<Uint8Array, eip4844.BlobsSidecar> {
+  constructor(config: IChainForkConfig, db: Db) {
+    super(config, db, Bucket.allForks_blobsSidecar, ssz.eip4844.BlobsSidecar);
+  }
+
+  /**
+   * Id is hashTreeRoot of unsigned BeaconBlock
+   */
+  getId(value: eip4844.BlobsSidecar): Uint8Array {
+    return value.beaconBlockRoot;
+  }
+}

--- a/packages/beacon-node/src/db/repositories/blobsSidecarArchive.ts
+++ b/packages/beacon-node/src/db/repositories/blobsSidecarArchive.ts
@@ -1,0 +1,33 @@
+import {IChainForkConfig} from "@lodestar/config";
+import {Db, Repository, IKeyValue, IFilterOptions, Bucket} from "@lodestar/db";
+import {Slot, Root, ssz, eip4844} from "@lodestar/types";
+import {bytesToInt} from "@lodestar/utils";
+
+export interface IBlockFilterOptions extends IFilterOptions<Slot> {
+  step?: number;
+}
+
+export type BlockArchiveBatchPutBinaryItem = IKeyValue<Slot, Uint8Array> & {
+  slot: Slot;
+  blockRoot: Root;
+  parentRoot: Root;
+};
+
+/**
+ * Stores finalized blocks. Block slot is identifier.
+ */
+export class BlobsSidecarArchiveRepository extends Repository<Slot, eip4844.BlobsSidecar> {
+  constructor(config: IChainForkConfig, db: Db) {
+    super(config, db, Bucket.allForks_blobsSidecarArchive, ssz.eip4844.BlobsSidecar);
+  }
+
+  // Handle key as slot
+
+  getId(value: eip4844.BlobsSidecar): Slot {
+    return value.beaconBlockSlot;
+  }
+
+  decodeKey(data: Uint8Array): number {
+    return bytesToInt((super.decodeKey(data) as unknown) as Uint8Array, "be");
+  }
+}

--- a/packages/beacon-node/src/db/repositories/index.ts
+++ b/packages/beacon-node/src/db/repositories/index.ts
@@ -1,3 +1,5 @@
+export {BlobsSidecarRepository} from "./blobsSidecar.js";
+export {BlobsSidecarArchiveRepository} from "./blobsSidecarArchive.js";
 export {BlockRepository} from "./block.js";
 export {BlockArchiveBatchPutBinaryItem, BlockArchiveRepository, IBlockFilterOptions} from "./blockArchive.js";
 export {StateArchiveRepository} from "./stateArchive.js";

--- a/packages/beacon-node/test/utils/mocks/db.ts
+++ b/packages/beacon-node/test/utils/mocks/db.ts
@@ -14,6 +14,8 @@ import {
   SyncCommitteeRepository,
   SyncCommitteeWitnessRepository,
   BackfilledRanges,
+  BlobsSidecarRepository,
+  BlobsSidecarArchiveRepository,
 } from "../../../src/db/repositories/index.js";
 import {PreGenesisState, PreGenesisStateLastProcessedBlock} from "../../../src/db/single/index.js";
 import {createStubInstance} from "../types.js";
@@ -27,9 +29,11 @@ export function getStubbedBeaconDb(): IBeaconDb {
   return {
     // unfinalized blocks
     block: createStubInstance(BlockRepository),
+    blobsSidecar: createStubInstance(BlobsSidecarRepository),
 
     // finalized blocks
     blockArchive: createStubInstance(BlockArchiveRepository),
+    blobsSidecarArchive: createStubInstance(BlobsSidecarArchiveRepository),
 
     // finalized states
     stateArchive: createStubInstance(StateArchiveRepository),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -46,6 +46,9 @@ export enum Bucket {
 
   index_stateArchiveRootIndex = 26, // State Root -> slot
 
+  allForks_blobsSidecar = 27, // EIP-4844 BeaconBlockRoot -> BlobsSidecar
+  allForks_blobsSidecarArchive = 28, // EIP-4844 BeaconBlockSlot -> BlobsSidecar
+
   // Lightclient server
   // altair_bestUpdatePerCommitteePeriod = 30, // DEPRECATED on v0.32.0
   // altair_latestFinalizedUpdate = 31, // DEPRECATED on v0.32.0


### PR DESCRIPTION
**Motivation**

- From https://github.com/ChainSafe/lodestar/pull/4774

**Description**

BlobsSidecar have to be stored, served and prune with identical logic to blocks. So this two new repos mimic existing for blocks. See https://github.com/ChainSafe/lodestar/pull/4774 for how this repos will be used specifically