### PR TITLE
Use state dialed to attestation target epoch

### DIFF
--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -76,14 +76,25 @@ export async function validateGossipAggregateAndProof(
   // -- i.e. get_ancestor(store, aggregate.data.beacon_block_root, compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)) == store.finalized_checkpoint.root
   // > Altready check in `chain.forkChoice.hasBlock(attestation.data.beaconBlockRoot)`
 
-  const attHeadState = await chain.regen
-    .getState(attHeadBlock.stateRoot, RegenCaller.validateGossipAggregateAndProof)
-    .catch((e: Error) => {
-      throw new AttestationError(GossipAction.REJECT, {
-        code: AttestationErrorCode.MISSING_ATTESTATION_HEAD_STATE,
-        error: e as Error,
-      });
-    });
+  // TODO: Must be a state in the same chain as attHeadBlock, but dialed to target.epoch
+  const attHeadState =
+    computeEpochAtSlot(attHeadBlock.slot) < attEpoch
+      ? await chain.regen
+          .getCheckpointState(attTarget, RegenCaller.validateGossipAggregateAndProof)
+          .catch((e: Error) => {
+            throw new AttestationError(GossipAction.REJECT, {
+              code: AttestationErrorCode.MISSING_ATTESTATION_HEAD_STATE,
+              error: e as Error,
+            });
+          })
+      : await chain.regen
+          .getState(attHeadBlock.stateRoot, RegenCaller.validateGossipAggregateAndProof)
+          .catch((e: Error) => {
+            throw new AttestationError(GossipAction.REJECT, {
+              code: AttestationErrorCode.MISSING_ATTESTATION_HEAD_STATE,
+              error: e as Error,
+            });
+          });
 
   const committeeIndices: number[] = getCommitteeIndices(attHeadState, attSlot, attIndex);
 

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -76,14 +76,21 @@ export async function validateGossipAttestation(
   //  --i.e. get_ancestor(store, attestation.data.beacon_block_root, compute_start_slot_at_epoch(attestation.data.target.epoch)) == attestation.data.target.root
   // > Altready check in `verifyHeadBlockAndTargetRoot()`
 
-  const attHeadState = await chain.regen
-    .getState(attHeadBlock.stateRoot, RegenCaller.validateGossipAttestation)
-    .catch((e: Error) => {
-      throw new AttestationError(GossipAction.REJECT, {
-        code: AttestationErrorCode.MISSING_ATTESTATION_HEAD_STATE,
-        error: e as Error,
-      });
-    });
+  // TODO: Must be a state in the same chain as attHeadBlock, but dialed to target.epoch
+  const attHeadState =
+    computeEpochAtSlot(attHeadBlock.slot) < attEpoch
+      ? await chain.regen.getCheckpointState(attTarget, RegenCaller.validateGossipAttestation).catch((e: Error) => {
+          throw new AttestationError(GossipAction.REJECT, {
+            code: AttestationErrorCode.MISSING_ATTESTATION_HEAD_STATE,
+            error: e as Error,
+          });
+        })
+      : await chain.regen.getState(attHeadBlock.stateRoot, RegenCaller.validateGossipAttestation).catch((e: Error) => {
+          throw new AttestationError(GossipAction.REJECT, {
+            code: AttestationErrorCode.MISSING_ATTESTATION_HEAD_STATE,
+            error: e as Error,
+          });
+        });
 
   // [REJECT] The committee index is within the expected range
   // -- i.e. data.index < get_committee_count_per_slot(state, data.target.epoch)


### PR DESCRIPTION
**Motivation**

- Testing https://github.com/ChainSafe/lodestar/pull/4774 found a bug where the state fetched for attestation verification is not dialed to attestation target

In practice this can only affect attestation verification if there's a full epoch of missed slots, or the first slot of a new fork is missed. It showed up in testing because a block processing error caused the first block of eip-4844 fork to be missed.

**Description**

- Use state dialed to attestation target epoch