### PR TITLE
Fix typo in updateSyncState

### DIFF
--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -194,7 +194,7 @@ export class BeaconSync implements IBeaconSync {
     if (
       state === SyncState.Synced &&
       !this.network.isSubscribedToGossipCoreTopics() &&
-      this.chain.clock.currentSlot >= MIN_EPOCH_TO_START_GOSSIP
+      this.chain.clock.currentEpoch >= MIN_EPOCH_TO_START_GOSSIP
     ) {
       this.network.subscribeGossipCoreTopics();
       this.metrics?.syncSwitchGossipSubscriptions.inc({action: "subscribed"});


### PR DESCRIPTION
**Motivation**

Typo, comparing clock slot to epoch constant. The impact of this typo was mild, it caused gossip to subscribe to core topics on epoch 0 instead of epoch -1. Only affects new network

**Description**

- Fix typo in updateSyncState