### PR TITLE
Process gossip block asap

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -338,8 +338,7 @@ export async function importBlock(
   }, 0);
 
   if (opts.seenTimestampSec !== undefined) {
-    const delaySec = this.clock.secFromSlot(block.message.slot, opts.seenTimestampSec);
-    const recvToImportedBlock = this.clock.secFromSlot(block.message.slot, Date.now() / 1000) - delaySec;
+    const recvToImportedBlock = Date.now() / 1000 - opts.seenTimestampSec;
     this.metrics?.gossipBlock.receivedToBlockImport.observe(recvToImportedBlock);
     this.logger.verbose("Imported block", {slot: block.message.slot, recvToImportedBlock});
   }

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -26,7 +26,7 @@ export class BlockProcessor {
       (job, importOpts) => {
         return processBlocks.call(chain, job, {...opts, ...importOpts});
       },
-      {maxLength: QUEUE_MAX_LENGTH, signal},
+      {maxLength: QUEUE_MAX_LENGTH, noYieldIfOneItem: true, signal},
       metrics?.blockProcessorQueue ?? undefined
     );
   }

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -67,16 +67,30 @@ export async function verifyBlocksInEpoch(
   const abortController = new AbortController();
 
   try {
-    const [{postStates, proposerBalanceDeltas}, , segmentExecStatus] = await Promise.all([
+    const [segmentExecStatus, {postStates, proposerBalanceDeltas}] = await Promise.all([
+      // Execution payloads
+      verifyBlocksExecutionPayload(
+        {...this, metrics: this.metrics},
+        parentBlock,
+        blocks,
+        preState0,
+        abortController.signal,
+        opts
+      ),
       // Run state transition only
       // TODO: Ensure it yields to allow flushing to workers and engine API
-      verifyBlocksStateTransitionOnly(preState0, blocksImport, this.metrics, abortController.signal, opts),
+      verifyBlocksStateTransitionOnly(
+        preState0,
+        blocksImport,
+        this.logger,
+        this.metrics,
+        this.clock,
+        abortController.signal,
+        opts
+      ),
 
       // All signatures at once
-      verifyBlocksSignatures(this.bls, preState0, blocks, opts),
-
-      // Execution payloads
-      verifyBlocksExecutionPayload(this, parentBlock, blocks, preState0, abortController.signal, opts),
+      verifyBlocksSignatures(this.bls, this.clock, this.logger, this.metrics, preState0, blocks, opts),
     ]);
 
     if (segmentExecStatus.execAborted === null && segmentExecStatus.mergeBlockFound !== null) {

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -69,28 +69,13 @@ export async function verifyBlocksInEpoch(
   try {
     const [segmentExecStatus, {postStates, proposerBalanceDeltas}] = await Promise.all([
       // Execution payloads
-      verifyBlocksExecutionPayload(
-        {...this, metrics: this.metrics},
-        parentBlock,
-        blocks,
-        preState0,
-        abortController.signal,
-        opts
-      ),
+      verifyBlocksExecutionPayload(this, parentBlock, blocks, preState0, abortController.signal, opts),
       // Run state transition only
       // TODO: Ensure it yields to allow flushing to workers and engine API
-      verifyBlocksStateTransitionOnly(
-        preState0,
-        blocksImport,
-        this.logger,
-        this.metrics,
-        this.clock,
-        abortController.signal,
-        opts
-      ),
+      verifyBlocksStateTransitionOnly(preState0, blocksImport, this.logger, this.metrics, abortController.signal, opts),
 
       // All signatures at once
-      verifyBlocksSignatures(this.bls, this.clock, this.logger, this.metrics, preState0, blocks, opts),
+      verifyBlocksSignatures(this.bls, this.logger, this.metrics, preState0, blocks, opts),
     ]);
 
     if (segmentExecStatus.execAborted === null && segmentExecStatus.mergeBlockFound !== null) {

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -24,12 +24,15 @@ import {IBeaconClock} from "../clock/index.js";
 import {BlockProcessOpts} from "../options.js";
 import {ExecutePayloadStatus} from "../../execution/engine/interface.js";
 import {IEth1ForBlockProduction} from "../../eth1/index.js";
+import {IMetrics} from "../../metrics/metrics.js";
+import {ImportBlockOpts} from "./types.js";
 
 export type VerifyBlockExecutionPayloadModules = {
   eth1: IEth1ForBlockProduction;
   executionEngine: IExecutionEngine;
   clock: IBeaconClock;
   logger: ILogger;
+  metrics: IMetrics | null;
   forkChoice: IForkChoice;
   config: IChainForkConfig;
 };
@@ -64,7 +67,7 @@ export async function verifyBlocksExecutionPayload(
   blocks: allForks.SignedBeaconBlock[],
   preState0: CachedBeaconStateAllForks,
   signal: AbortSignal,
-  opts: BlockProcessOpts
+  opts: BlockProcessOpts & ImportBlockOpts
 ): Promise<SegmentExecStatus> {
   const executionStatuses: MaybeValidExecutionStatus[] = [];
   let mergeBlockFound: bellatrix.BeaconBlock | null = null;
@@ -234,6 +237,16 @@ export async function verifyBlocksExecutionPayload(
       // to the end of the verify block routine, which confirms that this block is fully valid.
       mergeBlockFound = mergeBlock;
     }
+  }
+
+  if (blocks.length === 1 && opts.seenTimestampSec !== undefined) {
+    const delaySec = chain.clock.secFromSlot(blocks[0].message.slot, opts.seenTimestampSec);
+    const recvToVerifiedExecPayload = chain.clock.secFromSlot(blocks[0].message.slot, Date.now() / 1000) - delaySec;
+    chain.metrics?.gossipBlock.receivedToExecutionPayloadVerification.observe(recvToVerifiedExecPayload);
+    chain.logger.verbose("Verified execution payload", {
+      slot: blocks[0].message.slot,
+      recvToVerifiedExecPayload,
+    });
   }
 
   return {

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -240,8 +240,7 @@ export async function verifyBlocksExecutionPayload(
   }
 
   if (blocks.length === 1 && opts.seenTimestampSec !== undefined) {
-    const delaySec = chain.clock.secFromSlot(blocks[0].message.slot, opts.seenTimestampSec);
-    const recvToVerifiedExecPayload = chain.clock.secFromSlot(blocks[0].message.slot, Date.now() / 1000) - delaySec;
+    const recvToVerifiedExecPayload = Date.now() / 1000 - opts.seenTimestampSec;
     chain.metrics?.gossipBlock.receivedToExecutionPayloadVerification.observe(recvToVerifiedExecPayload);
     chain.logger.verbose("Verified execution payload", {
       slot: blocks[0].message.slot,

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
@@ -3,7 +3,6 @@ import {allForks} from "@lodestar/types";
 import {ILogger, sleep} from "@lodestar/utils";
 import {IMetrics} from "../../metrics/metrics.js";
 import {IBlsVerifier} from "../bls/index.js";
-import {IBeaconClock} from "../clock/interface.js";
 import {BlockError, BlockErrorCode} from "../errors/blockError.js";
 import {ImportBlockOpts} from "./types.js";
 
@@ -16,7 +15,6 @@ import {ImportBlockOpts} from "./types.js";
  */
 export async function verifyBlocksSignatures(
   bls: IBlsVerifier,
-  clock: IBeaconClock,
   logger: ILogger,
   metrics: IMetrics | null,
   preState0: CachedBeaconStateAllForks,
@@ -49,8 +47,7 @@ export async function verifyBlocksSignatures(
   }
 
   if (blocks.length === 1 && opts.seenTimestampSec !== undefined) {
-    const delaySec = clock.secFromSlot(blocks[0].message.slot, opts.seenTimestampSec);
-    const recvToSigVer = clock.secFromSlot(blocks[0].message.slot, Date.now() / 1000) - delaySec;
+    const recvToSigVer = Date.now() / 1000 - opts.seenTimestampSec;
     metrics?.gossipBlock.receivedToSignaturesVerification.observe(recvToSigVer);
     logger.verbose("Verified block signatures", {slot: blocks[0].message.slot, recvToSigVer});
   }

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -1,10 +1,11 @@
 import {CachedBeaconStateAllForks, stateTransition} from "@lodestar/state-transition";
-import {ErrorAborted, sleep} from "@lodestar/utils";
+import {ErrorAborted, ILogger, sleep} from "@lodestar/utils";
 import {IMetrics} from "../../metrics/index.js";
 import {BlockError, BlockErrorCode} from "../errors/index.js";
 import {BlockProcessOpts} from "../options.js";
 import {byteArrayEquals} from "../../util/bytes.js";
 import {BlockInput, ImportBlockOpts} from "./types.js";
+import {IBeaconClock} from "../clock/index.js";
 
 /**
  * Verifies 1 or more blocks are fully valid running the full state transition; from a linear sequence of blocks.
@@ -17,7 +18,9 @@ import {BlockInput, ImportBlockOpts} from "./types.js";
 export async function verifyBlocksStateTransitionOnly(
   preState0: CachedBeaconStateAllForks,
   blocks: BlockInput[],
+  logger: ILogger,
   metrics: IMetrics | null,
+  clock: IBeaconClock,
   signal: AbortSignal,
   opts: BlockProcessOpts & ImportBlockOpts
 ): Promise<{postStates: CachedBeaconStateAllForks[]; proposerBalanceDeltas: number[]}> {
@@ -72,6 +75,13 @@ export async function verifyBlocksStateTransitionOnly(
     if (i < blocks.length - 1) {
       await sleep(0);
     }
+  }
+
+  if (blocks.length === 1 && opts.seenTimestampSec !== undefined) {
+    const delaySec = clock.secFromSlot(blocks[0].message.slot, opts.seenTimestampSec);
+    const recvToTransition = clock.secFromSlot(blocks[0].message.slot, Date.now() / 1000) - delaySec;
+    metrics?.gossipBlock.receivedToStateTransition.observe(recvToTransition);
+    logger.verbose("Transitioned gossip block", {slot: blocks[0].message.slot, recvToTransition});
   }
 
   return {postStates, proposerBalanceDeltas};

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -5,7 +5,6 @@ import {BlockError, BlockErrorCode} from "../errors/index.js";
 import {BlockProcessOpts} from "../options.js";
 import {byteArrayEquals} from "../../util/bytes.js";
 import {BlockInput, ImportBlockOpts} from "./types.js";
-import {IBeaconClock} from "../clock/index.js";
 
 /**
  * Verifies 1 or more blocks are fully valid running the full state transition; from a linear sequence of blocks.
@@ -20,7 +19,6 @@ export async function verifyBlocksStateTransitionOnly(
   blocks: BlockInput[],
   logger: ILogger,
   metrics: IMetrics | null,
-  clock: IBeaconClock,
   signal: AbortSignal,
   opts: BlockProcessOpts & ImportBlockOpts
 ): Promise<{postStates: CachedBeaconStateAllForks[]; proposerBalanceDeltas: number[]}> {
@@ -78,10 +76,10 @@ export async function verifyBlocksStateTransitionOnly(
   }
 
   if (blocks.length === 1 && opts.seenTimestampSec !== undefined) {
-    const delaySec = clock.secFromSlot(blocks[0].message.slot, opts.seenTimestampSec);
-    const recvToTransition = clock.secFromSlot(blocks[0].message.slot, Date.now() / 1000) - delaySec;
+    const slot = blocks[0].block.message.slot;
+    const recvToTransition = Date.now() / 1000 - opts.seenTimestampSec;
     metrics?.gossipBlock.receivedToStateTransition.observe(recvToTransition);
-    logger.verbose("Transitioned gossip block", {slot: blocks[0].message.slot, recvToTransition});
+    logger.verbose("Transitioned gossip block", {slot, recvToTransition});
   }
 
   return {postStates, proposerBalanceDeltas};

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -73,6 +73,7 @@ export class BeaconChain implements IBeaconChain {
   // Expose config for convenience in modularized functions
   readonly config: IBeaconConfig;
   readonly logger: ILogger;
+  readonly metrics: IMetrics | null;
 
   readonly anchorStateLatestBlockSlot: Slot;
 
@@ -113,7 +114,6 @@ export class BeaconChain implements IBeaconChain {
 
   protected readonly blockProcessor: BlockProcessor;
   protected readonly db: IBeaconDb;
-  protected readonly metrics: IMetrics | null;
   private readonly archiver: Archiver;
   private abortController = new AbortController();
   private successfulExchangeTransition = false;

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -7,6 +7,7 @@ import {ILogger} from "@lodestar/utils";
 import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {IEth1ForBlockProduction} from "../eth1/index.js";
 import {IExecutionEngine, IExecutionBuilder} from "../execution/index.js";
+import {IMetrics} from "../metrics/metrics.js";
 import {IBeaconClock} from "./clock/interface.js";
 import {ChainEventEmitter} from "./emitter.js";
 import {IStateRegenerator} from "./regen/index.js";
@@ -53,6 +54,7 @@ export interface IBeaconChain {
   // Expose config for convenience in modularized functions
   readonly config: IBeaconConfig;
   readonly logger: ILogger;
+  readonly metrics: IMetrics | null;
 
   /** The initial slot that the chain is started with */
   readonly anchorStateLatestBlockSlot: Slot;

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -122,7 +122,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     });
     this.rpcFetchQueue = new JobItemQueue<[EngineRequest], EngineResponse>(
       this.jobQueueProcessor,
-      {maxLength: QUEUE_MAX_LENGTH, maxConcurrency: 1, signal},
+      {maxLength: QUEUE_MAX_LENGTH, maxConcurrency: 1, noYieldIfOneItem: true, signal},
       metrics?.engineHttpProcessorQueue
     );
   }

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -612,27 +612,27 @@ export function createLodestarMetrics(
       receivedToGossipValidate: register.histogram({
         name: "lodestar_gossip_block_received_to_gossip_validate",
         help: "Time elapsed between block received and block validated",
-        buckets: [0.2, 0.5, 1, 1.5, 2, 4],
+        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
       }),
       receivedToStateTransition: register.histogram({
         name: "lodestar_gossip_block_received_to_state_transition",
         help: "Time elapsed between block received and block state transition",
-        buckets: [0.2, 0.5, 1, 1.5, 2, 4],
+        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
       }),
       receivedToSignaturesVerification: register.histogram({
         name: "lodestar_gossip_block_received_to_signatures_verification",
         help: "Time elapsed between block received and block signatures verification",
-        buckets: [0.2, 0.5, 1, 1.5, 2, 4],
+        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
       }),
       receivedToExecutionPayloadVerification: register.histogram({
         name: "lodestar_gossip_block_received_to_execution_payload_verification",
         help: "Time elapsed between block received and execution payload verification",
-        buckets: [0.2, 0.5, 1, 1.5, 2, 4],
+        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
       }),
       receivedToBlockImport: register.histogram({
         name: "lodestar_gossip_block_received_to_block_import",
         help: "Time elapsed between block received and block import",
-        buckets: [0.2, 0.5, 1, 1.5, 2, 4],
+        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
       }),
     },
     elapsedTimeTillBecomeHead: register.histogram({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -609,6 +609,31 @@ export function createLodestarMetrics(
         help: "Time elapsed between block slot time and the time block processed",
         buckets: [0.5, 1, 2, 4, 6, 12],
       }),
+      receivedToGossipValidate: register.histogram({
+        name: "lodestar_gossip_block_received_to_gossip_validate",
+        help: "Time elapsed between block received and block validated",
+        buckets: [0.2, 0.5, 1, 1.5, 2, 4],
+      }),
+      receivedToStateTransition: register.histogram({
+        name: "lodestar_gossip_block_received_to_state_transition",
+        help: "Time elapsed between block received and block state transition",
+        buckets: [0.2, 0.5, 1, 1.5, 2, 4],
+      }),
+      receivedToSignaturesVerification: register.histogram({
+        name: "lodestar_gossip_block_received_to_signatures_verification",
+        help: "Time elapsed between block received and block signatures verification",
+        buckets: [0.2, 0.5, 1, 1.5, 2, 4],
+      }),
+      receivedToExecutionPayloadVerification: register.histogram({
+        name: "lodestar_gossip_block_received_to_execution_payload_verification",
+        help: "Time elapsed between block received and execution payload verification",
+        buckets: [0.2, 0.5, 1, 1.5, 2, 4],
+      }),
+      receivedToBlockImport: register.histogram({
+        name: "lodestar_gossip_block_received_to_block_import",
+        help: "Time elapsed between block received and block import",
+        buckets: [0.2, 0.5, 1, 1.5, 2, 4],
+      }),
     },
     elapsedTimeTillBecomeHead: register.histogram({
       name: "lodestar_gossip_block_elapsed_time_till_become_head",

--- a/packages/beacon-node/src/network/gossip/handlers/index.ts
+++ b/packages/beacon-node/src/network/gossip/handlers/index.ts
@@ -81,7 +81,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
       const forkTypes = config.getForkTypes(slot);
       const blockHex = prettyBytes(forkTypes.BeaconBlock.hashTreeRoot(signedBlock.message));
       const delaySec = chain.clock.secFromSlot(slot, seenTimestampSec);
-      const recvToVal = chain.clock.secFromSlot(slot, Date.now() / 1000) - delaySec;
+      const recvToVal = Date.now() / 1000 - seenTimestampSec;
       metrics?.gossipBlock.receivedToGossipValidate.observe(recvToVal);
       logger.verbose("Received gossip block", {
         slot: slot,

--- a/packages/beacon-node/src/network/gossip/handlers/index.ts
+++ b/packages/beacon-node/src/network/gossip/handlers/index.ts
@@ -81,12 +81,15 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
       const forkTypes = config.getForkTypes(slot);
       const blockHex = prettyBytes(forkTypes.BeaconBlock.hashTreeRoot(signedBlock.message));
       const delaySec = chain.clock.secFromSlot(slot, seenTimestampSec);
+      const recvToVal = chain.clock.secFromSlot(slot, Date.now() / 1000) - delaySec;
+      metrics?.gossipBlock.receivedToGossipValidate.observe(recvToVal);
       logger.verbose("Received gossip block", {
         slot: slot,
         root: blockHex,
         curentSlot: chain.clock.currentSlot,
         peerId: peerIdStr,
         delaySec,
+        recvToVal,
       });
 
       // TODO EIP-4844: Will throw an error for blocks post EIP-4844
@@ -121,7 +124,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
       // otherwise we can't utilize bls thread pool capacity and Gossip Job Wait Time can't be kept low consistently.
       // See https://github.com/ChainSafe/lodestar/issues/3792
       chain
-        .processBlock(blockInput, {validProposerSignature: true, blsVerifyOnMainThread: true})
+        .processBlock(blockInput, {validProposerSignature: true, blsVerifyOnMainThread: true, seenTimestampSec})
         .then(() => {
           // Returns the delay between the start of `block.slot` and `current time`
           const delaySec = chain.clock.secFromSlot(slot);

--- a/packages/beacon-node/src/network/gossip/validation/queue.ts
+++ b/packages/beacon-node/src/network/gossip/validation/queue.ts
@@ -6,8 +6,11 @@ import {GossipJobQueues, GossipType, GossipValidatorFn, ResolvedType, ValidatorF
 /**
  * Numbers from https://github.com/sigp/lighthouse/blob/b34a79dc0b02e04441ba01fd0f304d1e203d877d/beacon_node/network/src/beacon_processor/mod.rs#L69
  */
-const gossipQueueOpts: {[K in GossipType]: Pick<JobQueueOpts, "maxLength" | "type" | "maxConcurrency">} = {
-  [GossipType.beacon_block]: {maxLength: 1024, type: QueueType.FIFO},
+const gossipQueueOpts: {
+  [K in GossipType]: Pick<JobQueueOpts, "maxLength" | "type" | "maxConcurrency" | "noYieldIfOneItem">;
+} = {
+  // validation gossip block asap
+  [GossipType.beacon_block]: {maxLength: 1024, type: QueueType.FIFO, noYieldIfOneItem: true},
   // lighthoue has aggregate_queue 4096 and unknown_block_aggregate_queue 1024, we use single queue
   [GossipType.beacon_aggregate_and_proof]: {maxLength: 5120, type: QueueType.LIFO, maxConcurrency: 16},
   // lighthouse has attestation_queue 16384 and unknown_block_attestation_queue 8192, we use single queue

--- a/packages/beacon-node/src/util/queue/itemQueue.ts
+++ b/packages/beacon-node/src/util/queue/itemQueue.ts
@@ -56,7 +56,9 @@ export class JobItemQueue<Args extends any[], R> {
 
     return new Promise<R>((resolve, reject) => {
       this.jobs.push({args, resolve, reject, addedTimeMs: Date.now()});
-      if (this.runningJobs < this.opts.maxConcurrency) {
+      if (this.jobs.length === 1 && this.opts.noYieldIfOneItem) {
+        void this.runJob();
+      } else if (this.runningJobs < this.opts.maxConcurrency) {
         setTimeout(this.runJob, 0);
       }
     });

--- a/packages/beacon-node/src/util/queue/options.ts
+++ b/packages/beacon-node/src/util/queue/options.ts
@@ -14,6 +14,8 @@ export type JobQueueOpts = {
   signal: AbortSignal;
   /** Defaults to FIFO */
   type?: QueueType;
+  /**By default yield per push()*/
+  noYieldIfOneItem?: boolean;
 };
 
 export interface IQueueMetrics {
@@ -24,8 +26,11 @@ export interface IQueueMetrics {
   jobWaitTime: IHistogram;
 }
 
-export const defaultQueueOpts: Required<Pick<JobQueueOpts, "maxConcurrency" | "yieldEveryMs" | "type">> = {
+export const defaultQueueOpts: Required<
+  Pick<JobQueueOpts, "maxConcurrency" | "yieldEveryMs" | "type" | "noYieldIfOneItem">
+> = {
   maxConcurrency: 1,
   yieldEveryMs: 50,
   type: QueueType.FIFO,
+  noYieldIfOneItem: false,
 };

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -62,6 +62,7 @@ export class MockBeaconChain implements IBeaconChain {
   readonly executionEngine = new ExecutionEngineDisabled();
   readonly config: IBeaconConfig;
   readonly logger: ILogger;
+  readonly metrics = null;
   readonly opts: IChainOptions = {
     persistInvalidSszObjectsDir: "",
     proposerBoostEnabled: false,


### PR DESCRIPTION
**Motivation**

There are wrong head votes and missed attestations due to processing gossip blocks end in > 1/3 of slot. There are 2 reasons for it:
- There are some delays when we put block jobs in our queues (see Job Wait Time metrics in https://github.com/ChainSafe/lodestar/issues/4789#issuecomment-1336970334)
- `notifyNewPayload` engine api job time some times > 1s or 2s or even 5s => we can only track this time => see #4859

**Description**

- Add option to process job immediately if there is only 1 job at a time to reduce Job Wait Time
- Apply that to 3 queues: Block Gossip Validation queue, Block Processor queue, Execution Engine queue
- Add some more logs and metrics to track timing of each task when we process block since `seenTimestampSec`


Closes #4789

**Test result on feat1 mainnet node**

- Gossip Validation Job Wait Time >1s ratio

<img width="1286" alt="Screen Shot 2022-12-06 at 10 45 33" src="https://user-images.githubusercontent.com/10568965/205807872-7ef7f219-fe16-4d80-b338-19cdd81b3704.png">

- Block Processor Job Wait Time >1s ratio

<img width="1293" alt="Screen Shot 2022-12-06 at 10 46 07" src="https://user-images.githubusercontent.com/10568965/205807943-ae7a98dc-87ad-4f5d-bcab-f1f049afe4c6.png">

- Execution Engine Job wait time >1s ratio

<img width="1296" alt="Screen Shot 2022-12-06 at 10 46 37" src="https://user-images.githubusercontent.com/10568965/205808009-7152078d-7c56-48f0-b9b1-37f57ba7aab0.png">


- Block Process Time >1s ratio

<img width="1346" alt="Screen Shot 2022-12-06 at 10 44 50" src="https://user-images.githubusercontent.com/10568965/205807808-0bac57bf-63a9-46ac-9d82-2db4be984b3c.png">


