### PR TITLE
Fix iteration order in onBlobsSidecarsByRange

### DIFF
--- a/packages/beacon-node/src/network/reqresp/handlers/blobsSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobsSidecarsByRange.ts
@@ -61,7 +61,9 @@ export async function* onBlobsSidecarsByRange(
     const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot);
 
     // Iterate head chain with ascending block numbers
-    for (const block of headChain) {
+    for (let i = headChain.length - 1; i >= 0; i--) {
+      const block = headChain[i];
+
       // Must include only blocks in the range requested
       if (block.slot >= startSlot && block.slot < endSlot) {
         // Note: Here the forkChoice head may change due to a re-org, so the headChain reflects the cannonical chain


### PR DESCRIPTION
**Motivation**

- Fix bug from https://github.com/ChainSafe/lodestar/pull/4865 noted by @tuyennhv  at https://github.com/ChainSafe/lodestar/pull/4865/files#r1041824795

**Description**

- Fix iteration order in onBlobsSidecarsByRange