### PR TITLE
Declare spec tests skipped in preset test runner

### DIFF
--- a/packages/beacon-node/test/spec/presets/index.test.ts
+++ b/packages/beacon-node/test/spec/presets/index.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import {ACTIVE_PRESET} from "@lodestar/params";
 import {RunnerType} from "../utils/types.js";
-import {specTestIterator} from "../utils/specTestIterator.js";
+import {SkipOpts, specTestIterator} from "../utils/specTestIterator.js";
 import {ethereumConsensusSpecsTests} from "../specTestVersioning.js";
 import {epochProcessing} from "./epoch_processing.js";
 import {finality} from "./finality.js";
@@ -16,20 +16,32 @@ import {shuffling} from "./shuffling.js";
 import {sszStatic} from "./ssz_static.js";
 import {transition} from "./transition.js";
 
+// Just disable all capella tests as well and renable when new vectors are released
+// because the latest withdrawals we implemented are a breaking change
+const skipOpts: SkipOpts = {
+  skippedForks: ["eip4844", "capella"],
+  skippedRunners: ["light_client", "sync"],
+  skippedHandlers: ["full_withdrawals", "partial_withdrawals", "bls_to_execution_change", "withdrawals"],
+};
+
 /* eslint-disable @typescript-eslint/naming-convention */
 
-specTestIterator(path.join(ethereumConsensusSpecsTests.outputDir, "tests", ACTIVE_PRESET), {
-  epoch_processing: {type: RunnerType.default, fn: epochProcessing},
-  finality: {type: RunnerType.default, fn: finality},
-  fork: {type: RunnerType.default, fn: fork},
-  fork_choice: {type: RunnerType.default, fn: forkChoiceTest},
-  genesis: {type: RunnerType.default, fn: genesis},
-  merkle: {type: RunnerType.default, fn: merkle},
-  operations: {type: RunnerType.default, fn: operations},
-  random: {type: RunnerType.default, fn: sanityBlocks},
-  rewards: {type: RunnerType.default, fn: rewards},
-  sanity: {type: RunnerType.default, fn: sanity},
-  shuffling: {type: RunnerType.default, fn: shuffling},
-  ssz_static: {type: RunnerType.custom, fn: sszStatic},
-  transition: {type: RunnerType.default, fn: transition},
-});
+specTestIterator(
+  path.join(ethereumConsensusSpecsTests.outputDir, "tests", ACTIVE_PRESET),
+  {
+    epoch_processing: {type: RunnerType.default, fn: epochProcessing},
+    finality: {type: RunnerType.default, fn: finality},
+    fork: {type: RunnerType.default, fn: fork},
+    fork_choice: {type: RunnerType.default, fn: forkChoiceTest},
+    genesis: {type: RunnerType.default, fn: genesis},
+    merkle: {type: RunnerType.default, fn: merkle},
+    operations: {type: RunnerType.default, fn: operations},
+    random: {type: RunnerType.default, fn: sanityBlocks},
+    rewards: {type: RunnerType.default, fn: rewards},
+    sanity: {type: RunnerType.default, fn: sanity},
+    shuffling: {type: RunnerType.default, fn: shuffling},
+    ssz_static: {type: RunnerType.custom, fn: sszStatic},
+    transition: {type: RunnerType.default, fn: transition},
+  },
+  skipOpts
+);


### PR DESCRIPTION
**Motivation**

Currently we declare what spec tests are skipped in an obscure utility. Such a critical decision should be surfaced to the test runner for better clarity.

**Description**

- Declare spec tests skipped in preset test runner