### PR TITLE
feat: render named stack traces on ssz type errors

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -285,15 +285,21 @@ export function getReqSerializers(config: ChainForkConfig): ReqSerializers<Api, 
 }
 
 export function getReturnTypes(): ReturnTypes<Api> {
-  const BeaconHeaderResType = new ContainerType({
-    root: ssz.Root,
-    canonical: ssz.Boolean,
-    header: ssz.phase0.SignedBeaconBlockHeader,
-  });
+  const BeaconHeaderResType = ContainerType.named(
+    {
+      root: ssz.Root,
+      canonical: ssz.Boolean,
+      header: ssz.phase0.SignedBeaconBlockHeader,
+    },
+    {typeName: "BeaconHeaderResType", jsonCase: "eth2"}
+  );
 
-  const RootContainer = new ContainerType({
-    root: ssz.Root,
-  });
+  const RootContainer = ContainerType.named(
+    {
+      root: ssz.Root,
+    },
+    {typeName: "RootContainer", jsonCase: "eth2"}
+  );
 
   return {
     getBlock: ContainerData(ssz.phase0.SignedBeaconBlock),

--- a/packages/api/src/beacon/routes/beacon/state.ts
+++ b/packages/api/src/beacon/routes/beacon/state.ts
@@ -295,52 +295,55 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
 }
 
 export function getReturnTypes(): ReturnTypes<Api> {
-  const RootContainer = new ContainerType({
-    root: ssz.Root,
-  });
+  const RootContainer = ContainerType.named(
+    {
+      root: ssz.Root,
+    },
+    {typeName: "RootContainer", jsonCase: "eth2"}
+  );
 
-  const FinalityCheckpoints = new ContainerType(
+  const FinalityCheckpoints = ContainerType.named(
     {
       previousJustified: ssz.phase0.Checkpoint,
       currentJustified: ssz.phase0.Checkpoint,
       finalized: ssz.phase0.Checkpoint,
     },
-    {jsonCase: "eth2"}
+    {typeName: "FinalityCheckpoints", jsonCase: "eth2"}
   );
 
-  const ValidatorResponse = new ContainerType(
+  const ValidatorResponse = ContainerType.named(
     {
       index: ssz.ValidatorIndex,
       balance: ssz.UintNum64,
       status: new StringType<ValidatorStatus>(),
       validator: ssz.phase0.Validator,
     },
-    {jsonCase: "eth2"}
+    {typeName: "ValidatorResponse", jsonCase: "eth2"}
   );
 
-  const ValidatorBalance = new ContainerType(
+  const ValidatorBalance = ContainerType.named(
     {
       index: ssz.ValidatorIndex,
       balance: ssz.UintNum64,
     },
-    {jsonCase: "eth2"}
+    {typeName: "ValidatorBalance", jsonCase: "eth2"}
   );
 
-  const EpochCommitteeResponse = new ContainerType(
+  const EpochCommitteeResponse = ContainerType.named(
     {
       index: ssz.CommitteeIndex,
       slot: ssz.Slot,
       validators: ssz.phase0.CommitteeIndices,
     },
-    {jsonCase: "eth2"}
+    {typeName: "EpochCommitteeResponse", jsonCase: "eth2"}
   );
 
-  const EpochSyncCommitteesResponse = new ContainerType(
+  const EpochSyncCommitteesResponse = ContainerType.named(
     {
       validators: ArrayOf(ssz.ValidatorIndex),
       validatorAggregates: ArrayOf(ArrayOf(ssz.ValidatorIndex)),
     },
-    {jsonCase: "eth2"}
+    {typeName: "EpochSyncCommitteesResponse", jsonCase: "eth2"}
   );
 
   return {

--- a/packages/api/src/beacon/routes/config.ts
+++ b/packages/api/src/beacon/routes/config.ts
@@ -68,12 +68,12 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export function getReturnTypes(): ReturnTypes<Api> {
-  const DepositContract = new ContainerType(
+  const DepositContract = ContainerType.named(
     {
       chainId: ssz.UintNum64,
       address: new ByteVectorType(20),
     },
-    {jsonCase: "eth2"}
+    {typeName: "DepositContract", jsonCase: "eth2"}
   );
 
   return {

--- a/packages/api/src/beacon/routes/debug.ts
+++ b/packages/api/src/beacon/routes/debug.ts
@@ -26,7 +26,7 @@ export type StateFormat = "json" | "ssz";
 export const mimeTypeSSZ = "application/octet-stream";
 
 const stringType = new StringType();
-const protoNodeSszType = new ContainerType(
+const protoNodeSszType = ContainerType.named(
   {
     executionPayloadBlockHash: stringType,
     executionPayloadNumber: ssz.UintNum64,
@@ -49,7 +49,7 @@ const protoNodeSszType = new ContainerType(
     bestChild: stringType,
     bestDescendant: stringType,
   },
-  {jsonCase: "eth2"}
+  {typeName: "ProtoNode", jsonCase: "eth2"}
 );
 
 type ProtoNodeApiType = ValueOf<typeof protoNodeSszType>;
@@ -165,21 +165,21 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
 }
 
 export function getReturnTypes(): ReturnTypes<Api> {
-  const SlotRoot = new ContainerType(
+  const SlotRoot = ContainerType.named(
     {
       slot: ssz.Slot,
       root: stringType,
     },
-    {jsonCase: "eth2"}
+    {typeName: "SlotRoot", jsonCase: "eth2"}
   );
 
-  const SlotRootExecutionOptimistic = new ContainerType(
+  const SlotRootExecutionOptimistic = ContainerType.named(
     {
       slot: ssz.Slot,
       root: stringType,
       executionOptimistic: ssz.Boolean,
     },
-    {jsonCase: "eth2"}
+    {typeName: "SlotRootExecutionOptimistic", jsonCase: "eth2"}
   );
 
   return {

--- a/packages/api/src/beacon/routes/events.ts
+++ b/packages/api/src/beacon/routes/events.ts
@@ -136,7 +136,7 @@ export function getTypeByEvent(config: ChainForkConfig): {[K in EventType]: Type
   };
 
   return {
-    [EventType.head]: new ContainerType(
+    [EventType.head]: ContainerType.named(
       {
         slot: ssz.Slot,
         block: stringType,
@@ -146,33 +146,33 @@ export function getTypeByEvent(config: ChainForkConfig): {[K in EventType]: Type
         currentDutyDependentRoot: stringType,
         executionOptimistic: ssz.Boolean,
       },
-      {jsonCase: "eth2"}
+      {typeName: "EventDataHead", jsonCase: "eth2"}
     ),
 
-    [EventType.block]: new ContainerType(
+    [EventType.block]: ContainerType.named(
       {
         slot: ssz.Slot,
         block: stringType,
         executionOptimistic: ssz.Boolean,
       },
-      {jsonCase: "eth2"}
+      {typeName: "EventDataBlock", jsonCase: "eth2"}
     ),
 
     [EventType.attestation]: ssz.phase0.Attestation,
     [EventType.voluntaryExit]: ssz.phase0.SignedVoluntaryExit,
     [EventType.blsToExecutionChange]: ssz.capella.SignedBLSToExecutionChange,
 
-    [EventType.finalizedCheckpoint]: new ContainerType(
+    [EventType.finalizedCheckpoint]: ContainerType.named(
       {
         block: stringType,
         state: stringType,
         epoch: ssz.Epoch,
         executionOptimistic: ssz.Boolean,
       },
-      {jsonCase: "eth2"}
+      {typeName: "EventDataFinalizedCheckpoint", jsonCase: "eth2"}
     ),
 
-    [EventType.chainReorg]: new ContainerType(
+    [EventType.chainReorg]: ContainerType.named(
       {
         slot: ssz.Slot,
         depth: ssz.UintNum64,
@@ -183,7 +183,7 @@ export function getTypeByEvent(config: ChainForkConfig): {[K in EventType]: Type
         epoch: ssz.Epoch,
         executionOptimistic: ssz.Boolean,
       },
-      {jsonCase: "eth2"}
+      {typeName: "EventDataChainReorg", jsonCase: "eth2"}
     ),
 
     [EventType.contributionAndProof]: ssz.altair.SignedContributionAndProof,

--- a/packages/api/src/beacon/routes/node.ts
+++ b/packages/api/src/beacon/routes/node.ts
@@ -175,7 +175,7 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
 
 export function getReturnTypes(): ReturnTypes<Api> {
   const stringType = new StringType();
-  const NetworkIdentity = new ContainerType(
+  const NetworkIdentity = ContainerType.named(
     {
       peerId: stringType,
       enr: stringType,
@@ -183,17 +183,17 @@ export function getReturnTypes(): ReturnTypes<Api> {
       discoveryAddresses: ArrayOf(stringType),
       metadata: ssz.altair.Metadata,
     },
-    {jsonCase: "eth2"}
+    {typeName: "NetworkIdentity", jsonCase: "eth2"}
   );
 
-  const PeerCount = new ContainerType(
+  const PeerCount = ContainerType.named(
     {
       disconnected: ssz.UintNum64,
       connecting: ssz.UintNum64,
       connected: ssz.UintNum64,
       disconnecting: ssz.UintNum64,
     },
-    {jsonCase: "eth2"}
+    {typeName: "PeerCount", jsonCase: "eth2"}
   );
 
   return {

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -445,27 +445,27 @@ export type ReqTypes = {
   registerValidator: {body: unknown};
 };
 
-const BeaconCommitteeSelection = new ContainerType(
+const BeaconCommitteeSelection = ContainerType.named(
   {
     validatorIndex: ssz.ValidatorIndex,
     slot: ssz.Slot,
     selectionProof: ssz.BLSSignature,
   },
-  {jsonCase: "eth2"}
+  {typeName: "BeaconCommitteeSelection", jsonCase: "eth2"}
 );
 
-const SyncCommitteeSelection = new ContainerType(
+const SyncCommitteeSelection = ContainerType.named(
   {
     validatorIndex: ssz.ValidatorIndex,
     slot: ssz.Slot,
     subcommitteeIndex: ssz.SubcommitteeIndex,
     selectionProof: ssz.BLSSignature,
   },
-  {jsonCase: "eth2"}
+  {typeName: "SyncCommitteeSelection", jsonCase: "eth2"}
 );
 
 export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
-  const BeaconCommitteeSubscription = new ContainerType(
+  const BeaconCommitteeSubscription = ContainerType.named(
     {
       validatorIndex: ssz.ValidatorIndex,
       committeeIndex: ssz.CommitteeIndex,
@@ -473,16 +473,16 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
       slot: ssz.Slot,
       isAggregator: ssz.Boolean,
     },
-    {jsonCase: "eth2"}
+    {typeName: "BeaconCommitteeSubscription", jsonCase: "eth2"}
   );
 
-  const SyncCommitteeSubscription = new ContainerType(
+  const SyncCommitteeSubscription = ContainerType.named(
     {
       validatorIndex: ssz.ValidatorIndex,
       syncCommitteeIndices: ArrayOf(ssz.CommitteeIndex),
       untilEpoch: ssz.Epoch,
     },
-    {jsonCase: "eth2"}
+    {typeName: "SyncCommitteeSubscription", jsonCase: "eth2"}
   );
 
   const produceBlock: ReqSerializers<Api, ReqTypes>["produceBlock"] = {
@@ -591,16 +591,16 @@ export function getReturnTypes(): ReturnTypes<Api> {
 
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   const WithDependentRootExecutionOptimistic = <T>(dataType: Type<T>) =>
-    new ContainerType(
+    ContainerType.named(
       {
         executionOptimistic: ssz.Boolean,
         data: dataType,
         dependentRoot: rootHexType,
       },
-      {jsonCase: "eth2"}
+      {typeName: dataType.typeName + "WithDependentRootExecutionOptimistic", jsonCase: "eth2"}
     );
 
-  const AttesterDuty = new ContainerType(
+  const AttesterDuty = ContainerType.named(
     {
       pubkey: ssz.BLSPubkey,
       validatorIndex: ssz.ValidatorIndex,
@@ -610,25 +610,25 @@ export function getReturnTypes(): ReturnTypes<Api> {
       validatorCommitteeIndex: ssz.UintNum64,
       slot: ssz.Slot,
     },
-    {jsonCase: "eth2"}
+    {typeName: "AttesterDuty", jsonCase: "eth2"}
   );
 
-  const ProposerDuty = new ContainerType(
+  const ProposerDuty = ContainerType.named(
     {
       slot: ssz.Slot,
       validatorIndex: ssz.ValidatorIndex,
       pubkey: ssz.BLSPubkey,
     },
-    {jsonCase: "eth2"}
+    {typeName: "ProposerDuty", jsonCase: "eth2"}
   );
 
-  const SyncDuty = new ContainerType(
+  const SyncDuty = ContainerType.named(
     {
       pubkey: ssz.BLSPubkey,
       validatorIndex: ssz.ValidatorIndex,
       validatorSyncCommitteeIndices: ArrayOf(ssz.UintNum64),
     },
-    {jsonCase: "eth2"}
+    {typeName: "SyncDuty", jsonCase: "eth2"}
   );
 
   return {

--- a/packages/api/src/keymanager/routes.ts
+++ b/packages/api/src/keymanager/routes.ts
@@ -359,12 +359,12 @@ export function getReturnTypes(): ReturnTypes<Api> {
 
     listFeeRecipient: jsonType("snake"),
     getGasLimit: ContainerData(
-      new ContainerType(
+      ContainerType.named(
         {
           pubkey: stringType,
           gasLimit: ssz.UintNum64,
         },
-        {jsonCase: "eth2"}
+        {typeName: "GasLimit", jsonCase: "eth2"}
       )
     ),
   };

--- a/packages/api/src/utils/types.ts
+++ b/packages/api/src/utils/types.ts
@@ -85,9 +85,13 @@ export const reqOnlyBody = <T>(
 /** SSZ factory helper + typed. limit = 1e6 as a big enough random number */
 export function ArrayOf<T>(elementType: Type<T>): ArrayType<Type<T>, unknown, unknown> {
   if (isCompositeType(elementType)) {
-    return new ListCompositeType(elementType, Infinity) as unknown as ArrayType<Type<T>, unknown, unknown>;
+    return ListCompositeType.named(elementType, Infinity, {
+      typeName: elementType.typeName + "List",
+    }) as unknown as ArrayType<Type<T>, unknown, unknown>;
   } else if (isBasicType(elementType)) {
-    return new ListBasicType(elementType, Infinity) as unknown as ArrayType<Type<T>, unknown, unknown>;
+    return ListBasicType.named(elementType, Infinity, {
+      typeName: elementType.typeName + "List",
+    }) as unknown as ArrayType<Type<T>, unknown, unknown>;
   } else {
     throw Error(`Unknown type ${elementType.typeName}`);
   }

--- a/packages/beacon-node/src/db/repositories/blobSidecars.ts
+++ b/packages/beacon-node/src/db/repositories/blobSidecars.ts
@@ -3,7 +3,7 @@ import {Bucket, Db, Repository} from "@lodestar/db";
 import {ssz} from "@lodestar/types";
 import {ValueOf, ContainerType} from "@chainsafe/ssz";
 
-export const blobSidecarsWrapperSsz = new ContainerType(
+export const blobSidecarsWrapperSsz = ContainerType.named(
   {
     blockRoot: ssz.Root,
     slot: ssz.Slot,

--- a/packages/beacon-node/src/util/types.ts
+++ b/packages/beacon-node/src/util/types.ts
@@ -3,7 +3,7 @@ import {ssz} from "@lodestar/types";
 
 // Misc SSZ types used only in the beacon-node package, no need to upstream to types
 
-export const signedBLSToExecutionChangeVersionedType = new ContainerType(
+export const signedBLSToExecutionChangeVersionedType = ContainerType.named(
   {
     // Assumes less than 256 forks, sounds reasonable in our lifetime
     preCapella: ssz.Boolean,

--- a/packages/types/src/altair/sszTypes.ts
+++ b/packages/types/src/altair/sszTypes.ts
@@ -25,26 +25,26 @@ const {
   ParticipationFlags,
 } = primitiveSsz;
 
-export const SyncSubnets = new BitVectorType(SYNC_COMMITTEE_SUBNET_COUNT);
+export const SyncSubnets = BitVectorType.named(SYNC_COMMITTEE_SUBNET_COUNT, {typeName: "SyncSubnets"});
 
-export const Metadata = new ContainerType(
+export const Metadata = ContainerType.named(
   {
     seqNumber: UintBn64,
     attnets: phase0Ssz.AttestationSubnets,
     syncnets: SyncSubnets,
   },
-  {typeName: "Metadata", jsonCase: "eth2"}
+  {typeName: "MetadataAltair", jsonCase: "eth2"}
 );
 
-export const SyncCommittee = new ContainerType(
+export const SyncCommittee = ContainerType.named(
   {
-    pubkeys: new VectorCompositeType(BLSPubkey, SYNC_COMMITTEE_SIZE),
+    pubkeys: VectorCompositeType.named(BLSPubkey, SYNC_COMMITTEE_SIZE, {typeName: "SyncCommitteePubkeys"}),
     aggregatePubkey: BLSPubkey,
   },
   {typeName: "SyncCommittee", jsonCase: "eth2"}
 );
 
-export const SyncCommitteeMessage = new ContainerType(
+export const SyncCommitteeMessage = ContainerType.named(
   {
     slot: Slot,
     beaconBlockRoot: Root,
@@ -54,18 +54,20 @@ export const SyncCommitteeMessage = new ContainerType(
   {typeName: "SyncCommitteeMessage", jsonCase: "eth2"}
 );
 
-export const SyncCommitteeContribution = new ContainerType(
+export const SyncCommitteeContribution = ContainerType.named(
   {
     slot: Slot,
     beaconBlockRoot: Root,
     subcommitteeIndex: SubcommitteeIndex,
-    aggregationBits: new BitVectorType(SYNC_COMMITTEE_SIZE / SYNC_COMMITTEE_SUBNET_COUNT),
+    aggregationBits: BitVectorType.named(SYNC_COMMITTEE_SIZE / SYNC_COMMITTEE_SUBNET_COUNT, {
+      typeName: "AggregationBits",
+    }),
     signature: BLSSignature,
   },
   {typeName: "SyncCommitteeContribution", jsonCase: "eth2"}
 );
 
-export const ContributionAndProof = new ContainerType(
+export const ContributionAndProof = ContainerType.named(
   {
     aggregatorIndex: ValidatorIndex,
     contribution: SyncCommitteeContribution,
@@ -74,7 +76,7 @@ export const ContributionAndProof = new ContainerType(
   {typeName: "ContributionAndProof", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const SignedContributionAndProof = new ContainerType(
+export const SignedContributionAndProof = ContainerType.named(
   {
     message: ContributionAndProof,
     signature: BLSSignature,
@@ -82,7 +84,7 @@ export const SignedContributionAndProof = new ContainerType(
   {typeName: "SignedContributionAndProof", jsonCase: "eth2"}
 );
 
-export const SyncAggregatorSelectionData = new ContainerType(
+export const SyncAggregatorSelectionData = ContainerType.named(
   {
     slot: Slot,
     subcommitteeIndex: SubcommitteeIndex,
@@ -90,9 +92,9 @@ export const SyncAggregatorSelectionData = new ContainerType(
   {typeName: "SyncAggregatorSelectionData", jsonCase: "eth2"}
 );
 
-export const SyncCommitteeBits = new BitVectorType(SYNC_COMMITTEE_SIZE);
+export const SyncCommitteeBits = BitVectorType.named(SYNC_COMMITTEE_SIZE, {typeName: "SyncCommitteeBits"});
 
-export const SyncAggregate = new ContainerType(
+export const SyncAggregate = ContainerType.named(
   {
     syncCommitteeBits: SyncCommitteeBits,
     syncCommitteeSignature: BLSSignature,
@@ -100,15 +102,15 @@ export const SyncAggregate = new ContainerType(
   {typeName: "SyncCommitteeBits", jsonCase: "eth2"}
 );
 
-export const BeaconBlockBody = new ContainerType(
+export const BeaconBlockBody = ContainerType.named(
   {
     ...phase0Ssz.BeaconBlockBody.fields,
     syncAggregate: SyncAggregate,
   },
-  {typeName: "BeaconBlockBody", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BeaconBlockBodyAltair", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const BeaconBlock = new ContainerType(
+export const BeaconBlock = ContainerType.named(
   {
     slot: Slot,
     proposerIndex: ValidatorIndex,
@@ -116,23 +118,27 @@ export const BeaconBlock = new ContainerType(
     stateRoot: Root,
     body: BeaconBlockBody,
   },
-  {typeName: "BeaconBlock", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BeaconBlockAltair", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const SignedBeaconBlock = new ContainerType(
+export const SignedBeaconBlock = ContainerType.named(
   {
     message: BeaconBlock,
     signature: BLSSignature,
   },
-  {typeName: "SignedBeaconBlock", jsonCase: "eth2"}
+  {typeName: "SignedBeaconBlockAltair", jsonCase: "eth2"}
 );
 
-export const EpochParticipation = new ListBasicType(ParticipationFlags, VALIDATOR_REGISTRY_LIMIT);
-export const InactivityScores = new ListBasicType(UintNum64, VALIDATOR_REGISTRY_LIMIT);
+export const EpochParticipation = ListBasicType.named(ParticipationFlags, VALIDATOR_REGISTRY_LIMIT, {
+  typeName: "EpochParticipation",
+});
+export const InactivityScores = ListBasicType.named(UintNum64, VALIDATOR_REGISTRY_LIMIT, {
+  typeName: "InactivityScores",
+});
 
 // we don't reuse phase0.BeaconState fields since we need to replace some keys
 // and we cannot keep order doing that
-export const BeaconState = new ContainerType(
+export const BeaconState = ContainerType.named(
   {
     genesisTime: UintNum64,
     genesisValidatorsRoot: Root,
@@ -142,7 +148,7 @@ export const BeaconState = new ContainerType(
     latestBlockHeader: phase0Ssz.BeaconBlockHeader,
     blockRoots: phase0Ssz.HistoricalBlockRoots,
     stateRoots: phase0Ssz.HistoricalStateRoots,
-    historicalRoots: new ListCompositeType(Root, HISTORICAL_ROOTS_LIMIT),
+    historicalRoots: ListCompositeType.named(Root, HISTORICAL_ROOTS_LIMIT, {typeName: "HistoricalRoots"}),
     // Eth1
     eth1Data: phase0Ssz.Eth1Data,
     eth1DataVotes: phase0Ssz.Eth1DataVotes,
@@ -167,50 +173,54 @@ export const BeaconState = new ContainerType(
     currentSyncCommittee: SyncCommittee,
     nextSyncCommittee: SyncCommittee,
   },
-  {typeName: "BeaconState", jsonCase: "eth2"}
+  {typeName: "BeaconStateAltair", jsonCase: "eth2"}
 );
 
-export const LightClientHeader = new ContainerType(
+export const LightClientHeader = ContainerType.named(
   {
     beacon: phase0Ssz.BeaconBlockHeader,
   },
   {typeName: "LightClientHeader", jsonCase: "eth2"}
 );
 
-export const LightClientBootstrap = new ContainerType(
+export const LightClientBootstrap = ContainerType.named(
   {
     header: LightClientHeader,
     currentSyncCommittee: SyncCommittee,
-    currentSyncCommitteeBranch: new VectorCompositeType(Bytes32, NEXT_SYNC_COMMITTEE_DEPTH),
+    currentSyncCommitteeBranch: VectorCompositeType.named(Bytes32, NEXT_SYNC_COMMITTEE_DEPTH, {
+      typeName: "CurrentSyncCommitteeBranch",
+    }),
   },
   {typeName: "LightClientBootstrap", jsonCase: "eth2"}
 );
 
-export const LightClientUpdate = new ContainerType(
+export const LightClientUpdate = ContainerType.named(
   {
     attestedHeader: LightClientHeader,
     nextSyncCommittee: SyncCommittee,
-    nextSyncCommitteeBranch: new VectorCompositeType(Bytes32, NEXT_SYNC_COMMITTEE_DEPTH),
+    nextSyncCommitteeBranch: VectorCompositeType.named(Bytes32, NEXT_SYNC_COMMITTEE_DEPTH, {
+      typeName: "NextSyncCommitteeBranch",
+    }),
     finalizedHeader: LightClientHeader,
-    finalityBranch: new VectorCompositeType(Bytes32, FINALIZED_ROOT_DEPTH),
+    finalityBranch: VectorCompositeType.named(Bytes32, FINALIZED_ROOT_DEPTH, {typeName: "FinalityBranch"}),
     syncAggregate: SyncAggregate,
     signatureSlot: Slot,
   },
   {typeName: "LightClientUpdate", jsonCase: "eth2"}
 );
 
-export const LightClientFinalityUpdate = new ContainerType(
+export const LightClientFinalityUpdate = ContainerType.named(
   {
     attestedHeader: LightClientHeader,
     finalizedHeader: LightClientHeader,
-    finalityBranch: new VectorCompositeType(Bytes32, FINALIZED_ROOT_DEPTH),
+    finalityBranch: VectorCompositeType.named(Bytes32, FINALIZED_ROOT_DEPTH, {typeName: "FinalityBranch"}),
     syncAggregate: SyncAggregate,
     signatureSlot: Slot,
   },
   {typeName: "LightClientFinalityUpdate", jsonCase: "eth2"}
 );
 
-export const LightClientOptimisticUpdate = new ContainerType(
+export const LightClientOptimisticUpdate = ContainerType.named(
   {
     attestedHeader: LightClientHeader,
     syncAggregate: SyncAggregate,
@@ -219,7 +229,7 @@ export const LightClientOptimisticUpdate = new ContainerType(
   {typeName: "LightClientOptimisticUpdate", jsonCase: "eth2"}
 );
 
-export const LightClientUpdatesByRange = new ContainerType(
+export const LightClientUpdatesByRange = ContainerType.named(
   {
     startPeriod: UintNum64,
     count: UintNum64,
@@ -227,10 +237,12 @@ export const LightClientUpdatesByRange = new ContainerType(
   {typeName: "LightClientUpdatesByRange", jsonCase: "eth2"}
 );
 
-export const LightClientStore = new ContainerType(
+export const LightClientStore = ContainerType.named(
   {
     snapshot: LightClientBootstrap,
-    validUpdates: new ListCompositeType(LightClientUpdate, EPOCHS_PER_SYNC_COMMITTEE_PERIOD * SLOTS_PER_EPOCH),
+    validUpdates: ListCompositeType.named(LightClientUpdate, EPOCHS_PER_SYNC_COMMITTEE_PERIOD * SLOTS_PER_EPOCH, {
+      typeName: "ValidUpdates",
+    }),
   },
   {typeName: "LightClientStore", jsonCase: "eth2"}
 );

--- a/packages/types/src/bellatrix/sszTypes.ts
+++ b/packages/types/src/bellatrix/sszTypes.ts
@@ -34,23 +34,28 @@ export const Transaction = new ByteListType(MAX_BYTES_PER_TRANSACTION);
  *
  * Spec v1.0.1
  */
-export const Transactions = new ListCompositeType(Transaction, MAX_TRANSACTIONS_PER_PAYLOAD);
-
-export const CommonExecutionPayloadType = new ContainerType({
-  parentHash: Root,
-  feeRecipient: ExecutionAddress,
-  stateRoot: Bytes32,
-  receiptsRoot: Bytes32,
-  logsBloom: new ByteVectorType(BYTES_PER_LOGS_BLOOM),
-  prevRandao: Bytes32,
-  blockNumber: UintNum64,
-  gasLimit: UintNum64,
-  gasUsed: UintNum64,
-  timestamp: UintNum64,
-  // TODO: if there is perf issue, consider making ByteListType
-  extraData: new ByteListType(MAX_EXTRA_DATA_BYTES),
-  baseFeePerGas: Uint256,
+export const Transactions = ListCompositeType.named(Transaction, MAX_TRANSACTIONS_PER_PAYLOAD, {
+  typeName: "Transactions",
 });
+
+export const CommonExecutionPayloadType = ContainerType.named(
+  {
+    parentHash: Root,
+    feeRecipient: ExecutionAddress,
+    stateRoot: Bytes32,
+    receiptsRoot: Bytes32,
+    logsBloom: new ByteVectorType(BYTES_PER_LOGS_BLOOM),
+    prevRandao: Bytes32,
+    blockNumber: UintNum64,
+    gasLimit: UintNum64,
+    gasUsed: UintNum64,
+    timestamp: UintNum64,
+    // TODO: if there is perf issue, consider making ByteListType
+    extraData: new ByteListType(MAX_EXTRA_DATA_BYTES),
+    baseFeePerGas: Uint256,
+  },
+  {typeName: "CommonExecutionPayloadType", jsonCase: "eth2"}
+);
 
 const executionPayloadFields = {
   ...CommonExecutionPayloadType.fields,
@@ -58,15 +63,15 @@ const executionPayloadFields = {
   blockHash: Root,
 };
 
-export const ExecutionPayload = new ContainerType(
+export const ExecutionPayload = ContainerType.named(
   {
     ...executionPayloadFields,
     transactions: Transactions,
   },
-  {typeName: "ExecutionPayload", jsonCase: "eth2"}
+  {typeName: "ExecutionPayloadBellatrix", jsonCase: "eth2"}
 );
 
-export const ExecutionPayloadHeader = new ContainerType(
+export const ExecutionPayloadHeader = ContainerType.named(
   {
     ...executionPayloadFields,
     transactionsRoot: Root,
@@ -74,15 +79,15 @@ export const ExecutionPayloadHeader = new ContainerType(
   {typeName: "ExecutionPayloadHeader", jsonCase: "eth2"}
 );
 
-export const BeaconBlockBody = new ContainerType(
+export const BeaconBlockBody = ContainerType.named(
   {
     ...altairSsz.BeaconBlockBody.fields,
     executionPayload: ExecutionPayload,
   },
-  {typeName: "BeaconBlockBody", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BeaconBlockBodyBellatrix", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const BeaconBlock = new ContainerType(
+export const BeaconBlock = ContainerType.named(
   {
     slot: Slot,
     proposerIndex: ValidatorIndex,
@@ -91,18 +96,18 @@ export const BeaconBlock = new ContainerType(
     stateRoot: Root,
     body: BeaconBlockBody,
   },
-  {typeName: "BeaconBlock", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BeaconBlockBellatrix", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const SignedBeaconBlock = new ContainerType(
+export const SignedBeaconBlock = ContainerType.named(
   {
     message: BeaconBlock,
     signature: BLSSignature,
   },
-  {typeName: "SignedBeaconBlock", jsonCase: "eth2"}
+  {typeName: "SignedBeaconBlockBellatrix", jsonCase: "eth2"}
 );
 
-export const PowBlock = new ContainerType(
+export const PowBlock = ContainerType.named(
   {
     blockHash: Root,
     parentHash: Root,
@@ -113,7 +118,7 @@ export const PowBlock = new ContainerType(
 
 // we don't reuse phase0.BeaconState fields since we need to replace some keys
 // and we cannot keep order doing that
-export const BeaconState = new ContainerType(
+export const BeaconState = ContainerType.named(
   {
     genesisTime: UintNum64,
     genesisValidatorsRoot: Root,
@@ -123,7 +128,7 @@ export const BeaconState = new ContainerType(
     latestBlockHeader: phase0Ssz.BeaconBlockHeader,
     blockRoots: phase0Ssz.HistoricalBlockRoots,
     stateRoots: phase0Ssz.HistoricalStateRoots,
-    historicalRoots: new ListCompositeType(Root, HISTORICAL_ROOTS_LIMIT),
+    historicalRoots: ListCompositeType.named(Root, HISTORICAL_ROOTS_LIMIT, {typeName: "HistoricalRoots"}),
     // Eth1
     eth1Data: phase0Ssz.Eth1Data,
     eth1DataVotes: phase0Ssz.Eth1DataVotes,
@@ -150,18 +155,18 @@ export const BeaconState = new ContainerType(
     // Execution
     latestExecutionPayloadHeader: ExecutionPayloadHeader, // [New in Merge]
   },
-  {typeName: "BeaconState", jsonCase: "eth2"}
+  {typeName: "BeaconStateBellatrix", jsonCase: "eth2"}
 );
 
-export const BlindedBeaconBlockBody = new ContainerType(
+export const BlindedBeaconBlockBody = ContainerType.named(
   {
     ...altairSsz.BeaconBlockBody.fields,
     executionPayloadHeader: ExecutionPayloadHeader,
   },
-  {typeName: "BlindedBeaconBlockBody", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BlindedBeaconBlockBodyBellatrix", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const BlindedBeaconBlock = new ContainerType(
+export const BlindedBeaconBlock = ContainerType.named(
   {
     slot: Slot,
     proposerIndex: ValidatorIndex,
@@ -170,18 +175,18 @@ export const BlindedBeaconBlock = new ContainerType(
     stateRoot: Root,
     body: BlindedBeaconBlockBody,
   },
-  {typeName: "BlindedBeaconBlock", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BlindedBeaconBlockBellatrix", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const SignedBlindedBeaconBlock = new ContainerType(
+export const SignedBlindedBeaconBlock = ContainerType.named(
   {
     message: BlindedBeaconBlock,
     signature: BLSSignature,
   },
-  {typeName: "SignedBlindedBeaconBlock", jsonCase: "eth2"}
+  {typeName: "SignedBlindedBeaconBlockBellatrix", jsonCase: "eth2"}
 );
 
-export const ValidatorRegistrationV1 = new ContainerType(
+export const ValidatorRegistrationV1 = ContainerType.named(
   {
     feeRecipient: ExecutionAddress,
     gasLimit: UintNum64,
@@ -191,7 +196,7 @@ export const ValidatorRegistrationV1 = new ContainerType(
   {typeName: "ValidatorRegistrationV1", jsonCase: "eth2"}
 );
 
-export const SignedValidatorRegistrationV1 = new ContainerType(
+export const SignedValidatorRegistrationV1 = ContainerType.named(
   {
     message: ValidatorRegistrationV1,
     signature: BLSSignature,
@@ -199,7 +204,7 @@ export const SignedValidatorRegistrationV1 = new ContainerType(
   {typeName: "SignedValidatorRegistrationV1", jsonCase: "eth2"}
 );
 
-export const BuilderBid = new ContainerType(
+export const BuilderBid = ContainerType.named(
   {
     header: ExecutionPayloadHeader,
     value: Uint256,
@@ -208,7 +213,7 @@ export const BuilderBid = new ContainerType(
   {typeName: "BuilderBid", jsonCase: "eth2"}
 );
 
-export const SignedBuilderBid = new ContainerType(
+export const SignedBuilderBid = ContainerType.named(
   {
     message: BuilderBid,
     signature: BLSSignature,
@@ -217,12 +222,12 @@ export const SignedBuilderBid = new ContainerType(
 );
 
 // PayloadAttributes primarily for SSE event
-export const PayloadAttributes = new ContainerType(
+export const PayloadAttributes = ContainerType.named(
   {timestamp: UintNum64, prevRandao: Bytes32, suggestedFeeRecipient: ExecutionAddress},
   {typeName: "PayloadAttributes", jsonCase: "eth2"}
 );
 
-export const SSEPayloadAttributesCommon = new ContainerType(
+export const SSEPayloadAttributesCommon = ContainerType.named(
   {
     proposerIndex: UintNum64,
     proposalSlot: Slot,
@@ -233,7 +238,7 @@ export const SSEPayloadAttributesCommon = new ContainerType(
   {typeName: "SSEPayloadAttributesCommon", jsonCase: "eth2"}
 );
 
-export const SSEPayloadAttributes = new ContainerType(
+export const SSEPayloadAttributes = ContainerType.named(
   {
     ...SSEPayloadAttributesCommon.fields,
     payloadAttributes: PayloadAttributes,

--- a/packages/types/src/capella/sszTypes.ts
+++ b/packages/types/src/capella/sszTypes.ts
@@ -26,7 +26,7 @@ const {
   Bytes32,
 } = primitiveSsz;
 
-export const Withdrawal = new ContainerType(
+export const Withdrawal = ContainerType.named(
   {
     index: WithdrawalIndex,
     validatorIndex: ValidatorIndex,
@@ -36,7 +36,7 @@ export const Withdrawal = new ContainerType(
   {typeName: "Withdrawal", jsonCase: "eth2"}
 );
 
-export const BLSToExecutionChange = new ContainerType(
+export const BLSToExecutionChange = ContainerType.named(
   {
     validatorIndex: ValidatorIndex,
     fromBlsPubkey: BLSPubkey,
@@ -45,7 +45,7 @@ export const BLSToExecutionChange = new ContainerType(
   {typeName: "BLSToExecutionChange", jsonCase: "eth2"}
 );
 
-export const SignedBLSToExecutionChange = new ContainerType(
+export const SignedBLSToExecutionChange = ContainerType.named(
   {
     message: BLSToExecutionChange,
     signature: BLSSignature,
@@ -53,16 +53,16 @@ export const SignedBLSToExecutionChange = new ContainerType(
   {typeName: "SignedBLSToExecutionChange", jsonCase: "eth2"}
 );
 
-export const Withdrawals = new ListCompositeType(Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD);
-export const ExecutionPayload = new ContainerType(
+export const Withdrawals = ListCompositeType.named(Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD, {typeName: "Withdrawals"});
+export const ExecutionPayload = ContainerType.named(
   {
     ...bellatrixSsz.ExecutionPayload.fields,
     withdrawals: Withdrawals, // New in capella
   },
-  {typeName: "ExecutionPayload", jsonCase: "eth2"}
+  {typeName: "ExecutionPayloadCapella", jsonCase: "eth2"}
 );
 
-export const ExecutionPayloadHeader = new ContainerType(
+export const ExecutionPayloadHeader = ContainerType.named(
   {
     ...bellatrixSsz.ExecutionPayloadHeader.fields,
     withdrawalsRoot: Root, // New in capella
@@ -70,17 +70,19 @@ export const ExecutionPayloadHeader = new ContainerType(
   {typeName: "ExecutionPayloadHeader", jsonCase: "eth2"}
 );
 
-export const BLSToExecutionChanges = new ListCompositeType(SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES);
-export const BeaconBlockBody = new ContainerType(
+export const BLSToExecutionChanges = ListCompositeType.named(SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES, {
+  typeName: "BLSToExecutionChanges",
+});
+export const BeaconBlockBody = ContainerType.named(
   {
     ...altairSsz.BeaconBlockBody.fields,
     executionPayload: ExecutionPayload, // Modified in capella
     blsToExecutionChanges: BLSToExecutionChanges,
   },
-  {typeName: "BeaconBlockBody", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BeaconBlockBodyCapella", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const BeaconBlock = new ContainerType(
+export const BeaconBlock = ContainerType.named(
   {
     slot: Slot,
     proposerIndex: ValidatorIndex,
@@ -89,18 +91,18 @@ export const BeaconBlock = new ContainerType(
     stateRoot: Root,
     body: BeaconBlockBody, // Modified in Capella
   },
-  {typeName: "BeaconBlock", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BeaconBlockCapella", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const SignedBeaconBlock = new ContainerType(
+export const SignedBeaconBlock = ContainerType.named(
   {
     message: BeaconBlock, // Modified in capella
     signature: BLSSignature,
   },
-  {typeName: "SignedBeaconBlock", jsonCase: "eth2"}
+  {typeName: "SignedBeaconBlockCapella", jsonCase: "eth2"}
 );
 
-export const BuilderBid = new ContainerType(
+export const BuilderBid = ContainerType.named(
   {
     header: ExecutionPayloadHeader,
     value: UintBn256,
@@ -109,7 +111,7 @@ export const BuilderBid = new ContainerType(
   {typeName: "BuilderBid", jsonCase: "eth2"}
 );
 
-export const SignedBuilderBid = new ContainerType(
+export const SignedBuilderBid = ContainerType.named(
   {
     message: BuilderBid,
     signature: BLSSignature,
@@ -117,7 +119,7 @@ export const SignedBuilderBid = new ContainerType(
   {typeName: "SignedBuilderBid", jsonCase: "eth2"}
 );
 
-export const HistoricalSummary = new ContainerType(
+export const HistoricalSummary = ContainerType.named(
   {
     blockSummaryRoot: Root,
     stateSummaryRoot: Root,
@@ -127,7 +129,7 @@ export const HistoricalSummary = new ContainerType(
 
 // we don't reuse bellatrix.BeaconState fields since we need to replace some keys
 // and we cannot keep order doing that
-export const BeaconState = new ContainerType(
+export const BeaconState = ContainerType.named(
   {
     genesisTime: UintNum64,
     genesisValidatorsRoot: Root,
@@ -138,7 +140,7 @@ export const BeaconState = new ContainerType(
     blockRoots: phase0Ssz.HistoricalBlockRoots,
     stateRoots: phase0Ssz.HistoricalStateRoots,
     // historical_roots Frozen in Capella, replaced by historical_summaries
-    historicalRoots: new ListCompositeType(Root, HISTORICAL_ROOTS_LIMIT),
+    historicalRoots: ListCompositeType.named(Root, HISTORICAL_ROOTS_LIMIT, {typeName: "HistoricalRoots"}),
     // Eth1
     eth1Data: phase0Ssz.Eth1Data,
     eth1DataVotes: phase0Ssz.Eth1DataVotes,
@@ -168,21 +170,23 @@ export const BeaconState = new ContainerType(
     nextWithdrawalIndex: WithdrawalIndex, // [New in Capella]
     nextWithdrawalValidatorIndex: ValidatorIndex, // [New in Capella]
     // Deep history valid from Capella onwards
-    historicalSummaries: new ListCompositeType(HistoricalSummary, HISTORICAL_ROOTS_LIMIT), // [New in Capella]
+    historicalSummaries: ListCompositeType.named(HistoricalSummary, HISTORICAL_ROOTS_LIMIT, {
+      typeName: "HistoricalSummaries",
+    }), // [New in Capella]
   },
-  {typeName: "BeaconState", jsonCase: "eth2"}
+  {typeName: "BeaconStateCapella", jsonCase: "eth2"}
 );
 
-export const BlindedBeaconBlockBody = new ContainerType(
+export const BlindedBeaconBlockBody = ContainerType.named(
   {
     ...altairSsz.BeaconBlockBody.fields,
     executionPayloadHeader: ExecutionPayloadHeader, // Modified in capella
     blsToExecutionChanges: BLSToExecutionChanges, // New in capella
   },
-  {typeName: "BlindedBeaconBlockBody", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BlindedBeaconBlockBodyCapella", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const BlindedBeaconBlock = new ContainerType(
+export const BlindedBeaconBlock = ContainerType.named(
   {
     slot: Slot,
     proposerIndex: ValidatorIndex,
@@ -191,36 +195,36 @@ export const BlindedBeaconBlock = new ContainerType(
     stateRoot: Root,
     body: BlindedBeaconBlockBody, // Modified in capella
   },
-  {typeName: "BlindedBeaconBlock", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BlindedBeaconBlockCapella", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const SignedBlindedBeaconBlock = new ContainerType(
+export const SignedBlindedBeaconBlock = ContainerType.named(
   {
     message: BlindedBeaconBlock, // Modified in capella
     signature: BLSSignature,
   },
-  {typeName: "SignedBlindedBeaconBlock", jsonCase: "eth2"}
+  {typeName: "SignedBlindedBeaconBlockCapella", jsonCase: "eth2"}
 );
 
-export const LightClientHeader = new ContainerType(
+export const LightClientHeader = ContainerType.named(
   {
     beacon: phase0Ssz.BeaconBlockHeader,
     execution: ExecutionPayloadHeader,
-    executionBranch: new VectorCompositeType(Bytes32, EXECUTION_PAYLOAD_DEPTH),
+    executionBranch: VectorCompositeType.named(Bytes32, EXECUTION_PAYLOAD_DEPTH, {typeName: "ExecutionBranch"}),
   },
-  {typeName: "LightClientHeader", jsonCase: "eth2"}
+  {typeName: "LightClientHeaderCapella", jsonCase: "eth2"}
 );
 
-export const LightClientBootstrap = new ContainerType(
+export const LightClientBootstrap = ContainerType.named(
   {
     header: LightClientHeader,
     currentSyncCommittee: altairSsz.SyncCommittee,
     currentSyncCommitteeBranch: altairSsz.LightClientBootstrap.fields.currentSyncCommitteeBranch,
   },
-  {typeName: "LightClientBootstrap", jsonCase: "eth2"}
+  {typeName: "LightClientBootstrapCapella", jsonCase: "eth2"}
 );
 
-export const LightClientUpdate = new ContainerType(
+export const LightClientUpdate = ContainerType.named(
   {
     attestedHeader: LightClientHeader,
     nextSyncCommittee: altairSsz.SyncCommittee,
@@ -230,10 +234,10 @@ export const LightClientUpdate = new ContainerType(
     syncAggregate: altairSsz.SyncAggregate,
     signatureSlot: Slot,
   },
-  {typeName: "LightClientUpdate", jsonCase: "eth2"}
+  {typeName: "LightClientUpdateCapella", jsonCase: "eth2"}
 );
 
-export const LightClientFinalityUpdate = new ContainerType(
+export const LightClientFinalityUpdate = ContainerType.named(
   {
     attestedHeader: LightClientHeader,
     finalizedHeader: LightClientHeader,
@@ -241,28 +245,30 @@ export const LightClientFinalityUpdate = new ContainerType(
     syncAggregate: altairSsz.SyncAggregate,
     signatureSlot: Slot,
   },
-  {typeName: "LightClientFinalityUpdate", jsonCase: "eth2"}
+  {typeName: "LightClientFinalityUpdateCapella", jsonCase: "eth2"}
 );
 
-export const LightClientOptimisticUpdate = new ContainerType(
+export const LightClientOptimisticUpdate = ContainerType.named(
   {
     attestedHeader: LightClientHeader,
     syncAggregate: altairSsz.SyncAggregate,
     signatureSlot: Slot,
   },
-  {typeName: "LightClientOptimisticUpdate", jsonCase: "eth2"}
+  {typeName: "LightClientOptimisticUpdateCapella", jsonCase: "eth2"}
 );
 
-export const LightClientStore = new ContainerType(
+export const LightClientStore = ContainerType.named(
   {
     snapshot: LightClientBootstrap,
-    validUpdates: new ListCompositeType(LightClientUpdate, EPOCHS_PER_SYNC_COMMITTEE_PERIOD * SLOTS_PER_EPOCH),
+    validUpdates: ListCompositeType.named(LightClientUpdate, EPOCHS_PER_SYNC_COMMITTEE_PERIOD * SLOTS_PER_EPOCH, {
+      typeName: "ValidUpdates",
+    }),
   },
   {typeName: "LightClientStore", jsonCase: "eth2"}
 );
 
 // PayloadAttributes primarily for SSE event
-export const PayloadAttributes = new ContainerType(
+export const PayloadAttributes = ContainerType.named(
   {
     ...bellatrixSsz.PayloadAttributes.fields,
     withdrawals: Withdrawals,
@@ -270,7 +276,7 @@ export const PayloadAttributes = new ContainerType(
   {typeName: "PayloadAttributes", jsonCase: "eth2"}
 );
 
-export const SSEPayloadAttributes = new ContainerType(
+export const SSEPayloadAttributes = ContainerType.named(
   {
     ...bellatrixSsz.SSEPayloadAttributesCommon.fields,
     payloadAttributes: PayloadAttributes,

--- a/packages/types/src/deneb/sszTypes.ts
+++ b/packages/types/src/deneb/sszTypes.ts
@@ -45,11 +45,13 @@ export const KZGProof = Bytes48;
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/beacon-chain.md#custom-types
 
 export const Blob = new ByteVectorType(BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB);
-export const Blobs = new ListCompositeType(Blob, MAX_BLOBS_PER_BLOCK);
+export const Blobs = ListCompositeType.named(Blob, MAX_BLOBS_PER_BLOCK, {typeName: "Blobs"});
 export const BlindedBlob = Bytes32;
-export const BlindedBlobs = new ListCompositeType(BlindedBlob, MAX_BLOBS_PER_BLOCK);
+export const BlindedBlobs = ListCompositeType.named(BlindedBlob, MAX_BLOBS_PER_BLOCK, {typeName: "BlindedBlobs"});
 export const VersionedHash = Bytes32;
-export const BlobKzgCommitments = new ListCompositeType(KZGCommitment, MAX_BLOBS_PER_BLOCK);
+export const BlobKzgCommitments = ListCompositeType.named(KZGCommitment, MAX_BLOBS_PER_BLOCK, {
+  typeName: "BlobKzgCommitments",
+});
 
 // Constants
 
@@ -57,12 +59,12 @@ export const BlobKzgCommitments = new ListCompositeType(KZGCommitment, MAX_BLOBS
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/validator.md
 
 // A polynomial in evaluation form
-export const Polynomial = new ListCompositeType(BLSFieldElement, FIELD_ELEMENTS_PER_BLOB);
+export const Polynomial = ListCompositeType.named(BLSFieldElement, FIELD_ELEMENTS_PER_BLOB, {typeName: "Polynomial"});
 
 // class BlobsAndCommitments(Container):
 //     blobs: List[Blob, MAX_BLOBS_PER_BLOCK]
 //     kzg_commitments: List[KZGCommitment, MAX_BLOBS_PER_BLOCK]
-export const BlobsAndCommitments = new ContainerType(
+export const BlobsAndCommitments = ContainerType.named(
   {
     blobs: Blobs,
     kzgCommitments: BlobKzgCommitments,
@@ -73,7 +75,7 @@ export const BlobsAndCommitments = new ContainerType(
 // class PolynomialAndCommitment(Container):
 //     polynomial: Polynomial
 //     kzg_commitment: KZGCommitment
-export const PolynomialAndCommitment = new ContainerType(
+export const PolynomialAndCommitment = ContainerType.named(
   {
     polynomial: Polynomial,
     kzgCommitment: KZGCommitment,
@@ -84,7 +86,7 @@ export const PolynomialAndCommitment = new ContainerType(
 // ReqResp types
 // =============
 
-export const BlobsSidecarsByRangeRequest = new ContainerType(
+export const BlobsSidecarsByRangeRequest = ContainerType.named(
   {
     startSlot: Slot,
     count: UintNum64,
@@ -92,12 +94,14 @@ export const BlobsSidecarsByRangeRequest = new ContainerType(
   {typeName: "BlobsSidecarsByRangeRequest", jsonCase: "eth2"}
 );
 
-export const BeaconBlockAndBlobsSidecarByRootRequest = new ListCompositeType(Root, MAX_REQUEST_BLOCKS);
+export const BeaconBlockAndBlobsSidecarByRootRequest = ListCompositeType.named(Root, MAX_REQUEST_BLOCKS, {
+  typeName: "BeaconBlockAndBlobsSidecarByRootRequest",
+});
 
 // Beacon Chain types
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/beacon-chain.md#containers
 
-export const ExecutionPayload = new ContainerType(
+export const ExecutionPayload = ContainerType.named(
   {
     ...capellaSsz.ExecutionPayload.fields,
     excessDataGas: UintBn256, // New in DENEB
@@ -105,7 +109,7 @@ export const ExecutionPayload = new ContainerType(
   {typeName: "ExecutionPayload", jsonCase: "eth2"}
 );
 
-export const ExecutionPayloadHeader = new ContainerType(
+export const ExecutionPayloadHeader = ContainerType.named(
   {
     ...capellaSsz.ExecutionPayloadHeader.fields,
     excessDataGas: UintBn256, // New in DENEB
@@ -114,33 +118,33 @@ export const ExecutionPayloadHeader = new ContainerType(
 );
 
 // We have to preserve Fields ordering while changing the type of ExecutionPayload
-export const BeaconBlockBody = new ContainerType(
+export const BeaconBlockBody = ContainerType.named(
   {
     ...altairSsz.BeaconBlockBody.fields,
     executionPayload: ExecutionPayload, // Modified in DENEB
     blsToExecutionChanges: capellaSsz.BeaconBlockBody.fields.blsToExecutionChanges,
     blobKzgCommitments: BlobKzgCommitments, // New in DENEB
   },
-  {typeName: "BeaconBlockBody", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BeaconBlockBodyDeneb", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const BeaconBlock = new ContainerType(
+export const BeaconBlock = ContainerType.named(
   {
     ...capellaSsz.BeaconBlock.fields,
     body: BeaconBlockBody, // Modified in DENEB
   },
-  {typeName: "BeaconBlock", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BeaconBlockDeneb", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const SignedBeaconBlock = new ContainerType(
+export const SignedBeaconBlock = ContainerType.named(
   {
     message: BeaconBlock, // Modified in DENEB
     signature: BLSSignature,
   },
-  {typeName: "SignedBeaconBlock", jsonCase: "eth2"}
+  {typeName: "SignedBeaconBlockDeneb", jsonCase: "eth2"}
 );
 
-export const BlobSidecar = new ContainerType(
+export const BlobSidecar = ContainerType.named(
   {
     blockRoot: Root,
     index: BlobIndex,
@@ -154,18 +158,20 @@ export const BlobSidecar = new ContainerType(
   {typeName: "BlobSidecar", jsonCase: "eth2"}
 );
 
-export const BlobSidecars = new ListCompositeType(BlobSidecar, MAX_BLOBS_PER_BLOCK);
+export const BlobSidecars = ListCompositeType.named(BlobSidecar, MAX_BLOBS_PER_BLOCK, {typeName: "BlobSidecars"});
 
-export const SignedBlobSidecar = new ContainerType(
+export const SignedBlobSidecar = ContainerType.named(
   {
     message: BlobSidecar,
     signature: BLSSignature,
   },
   {typeName: "SignedBlobSidecar", jsonCase: "eth2"}
 );
-export const SignedBlobSidecars = new ListCompositeType(SignedBlobSidecar, MAX_BLOBS_PER_BLOCK);
+export const SignedBlobSidecars = ListCompositeType.named(SignedBlobSidecar, MAX_BLOBS_PER_BLOCK, {
+  typeName: "SignedBlobSidecars",
+});
 
-export const BlindedBlobSidecar = new ContainerType(
+export const BlindedBlobSidecar = ContainerType.named(
   {
     blockRoot: Root,
     index: BlobIndex,
@@ -179,9 +185,11 @@ export const BlindedBlobSidecar = new ContainerType(
   {typeName: "BlindedBlobSidecar", jsonCase: "eth2"}
 );
 
-export const BlindedBlobSidecars = new ListCompositeType(BlindedBlobSidecar, MAX_BLOBS_PER_BLOCK);
+export const BlindedBlobSidecars = ListCompositeType.named(BlindedBlobSidecar, MAX_BLOBS_PER_BLOCK, {
+  typeName: "BlindedBlobSidecars",
+});
 
-export const SignedBlindedBlobSidecar = new ContainerType(
+export const SignedBlindedBlobSidecar = ContainerType.named(
   {
     message: BlindedBlobSidecar,
     signature: BLSSignature,
@@ -189,10 +197,12 @@ export const SignedBlindedBlobSidecar = new ContainerType(
   {typeName: "SignedBlindedBlobSidecar", jsonCase: "eth2"}
 );
 
-export const SignedBlindedBlobSidecars = new ListCompositeType(SignedBlindedBlobSidecar, MAX_BLOBS_PER_BLOCK);
+export const SignedBlindedBlobSidecars = ListCompositeType.named(SignedBlindedBlobSidecar, MAX_BLOBS_PER_BLOCK, {
+  typeName: "SignedBlindedBlobSidecars",
+});
 
 // TODO: replace and cleanup previous types when other parts integrated seamlessly
-export const BlobsSidecar = new ContainerType(
+export const BlobsSidecar = ContainerType.named(
   {
     beaconBlockRoot: Root,
     beaconBlockSlot: Slot,
@@ -202,7 +212,7 @@ export const BlobsSidecar = new ContainerType(
   {typeName: "BlobsSidecar", jsonCase: "eth2"}
 );
 
-export const SignedBeaconBlockAndBlobsSidecar = new ContainerType(
+export const SignedBeaconBlockAndBlobsSidecar = ContainerType.named(
   {
     beaconBlock: SignedBeaconBlock,
     blobsSidecar: BlobsSidecar,
@@ -210,32 +220,32 @@ export const SignedBeaconBlockAndBlobsSidecar = new ContainerType(
   {typeName: "SignedBeaconBlockAndBlobsSidecar", jsonCase: "eth2"}
 );
 
-export const BlindedBeaconBlockBody = new ContainerType(
+export const BlindedBeaconBlockBody = ContainerType.named(
   {
     ...BeaconBlockBody.fields,
     executionPayloadHeader: ExecutionPayloadHeader, // Modified in DENEB
     blobKzgCommitments: BlobKzgCommitments, // New in DENEB
   },
-  {typeName: "BlindedBeaconBlockBody", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BlindedBeaconBlockBodyDeneb", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const BlindedBeaconBlock = new ContainerType(
+export const BlindedBeaconBlock = ContainerType.named(
   {
     ...capellaSsz.BlindedBeaconBlock.fields,
     body: BlindedBeaconBlockBody, // Modified in DENEB
   },
-  {typeName: "BlindedBeaconBlock", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BlindedBeaconBlockDeneb", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const SignedBlindedBeaconBlock = new ContainerType(
+export const SignedBlindedBeaconBlock = ContainerType.named(
   {
     message: BlindedBeaconBlock, // Modified in DENEB
     signature: BLSSignature,
   },
-  {typeName: "SignedBlindedBeaconBlock", jsonCase: "eth2"}
+  {typeName: "SignedBlindedBeaconBlockDeneb", jsonCase: "eth2"}
 );
 
-export const BuilderBid = new ContainerType(
+export const BuilderBid = ContainerType.named(
   {
     header: ExecutionPayloadHeader,
     value: UintBn256,
@@ -245,7 +255,7 @@ export const BuilderBid = new ContainerType(
   {typeName: "BuilderBid", jsonCase: "eth2"}
 );
 
-export const SignedBuilderBid = new ContainerType(
+export const SignedBuilderBid = ContainerType.named(
   {
     message: BuilderBid,
     signature: BLSSignature,
@@ -255,7 +265,7 @@ export const SignedBuilderBid = new ContainerType(
 
 // We don't spread capella.BeaconState fields since we need to replace
 // latestExecutionPayloadHeader and we cannot keep order doing that
-export const BeaconState = new ContainerType(
+export const BeaconState = ContainerType.named(
   {
     genesisTime: UintNum64,
     genesisValidatorsRoot: Root,
@@ -266,7 +276,7 @@ export const BeaconState = new ContainerType(
     blockRoots: phase0Ssz.HistoricalBlockRoots,
     stateRoots: phase0Ssz.HistoricalStateRoots,
     // historical_roots Frozen in Capella, replaced by historical_summaries
-    historicalRoots: new ListCompositeType(Root, HISTORICAL_ROOTS_LIMIT),
+    historicalRoots: ListCompositeType.named(Root, HISTORICAL_ROOTS_LIMIT, {typeName: "HistoricalRoots"}),
     // Eth1
     eth1Data: phase0Ssz.Eth1Data,
     eth1DataVotes: phase0Ssz.Eth1DataVotes,
@@ -298,19 +308,19 @@ export const BeaconState = new ContainerType(
     // Deep history valid from Capella onwards
     historicalSummaries: capellaSsz.BeaconState.fields.historicalSummaries,
   },
-  {typeName: "BeaconState", jsonCase: "eth2"}
+  {typeName: "BeaconStateDeneb", jsonCase: "eth2"}
 );
 
-export const LightClientHeader = new ContainerType(
+export const LightClientHeader = ContainerType.named(
   {
     beacon: phase0Ssz.BeaconBlockHeader,
     execution: ExecutionPayloadHeader,
-    executionBranch: new VectorCompositeType(Bytes32, EXECUTION_PAYLOAD_DEPTH),
+    executionBranch: VectorCompositeType.named(Bytes32, EXECUTION_PAYLOAD_DEPTH, {typeName: "ExecutionBranch"}),
   },
   {typeName: "LightClientHeader", jsonCase: "eth2"}
 );
 
-export const LightClientBootstrap = new ContainerType(
+export const LightClientBootstrap = ContainerType.named(
   {
     header: LightClientHeader,
     currentSyncCommittee: altairSsz.SyncCommittee,
@@ -319,7 +329,7 @@ export const LightClientBootstrap = new ContainerType(
   {typeName: "LightClientBootstrap", jsonCase: "eth2"}
 );
 
-export const LightClientUpdate = new ContainerType(
+export const LightClientUpdate = ContainerType.named(
   {
     attestedHeader: LightClientHeader,
     nextSyncCommittee: altairSsz.SyncCommittee,
@@ -332,7 +342,7 @@ export const LightClientUpdate = new ContainerType(
   {typeName: "LightClientUpdate", jsonCase: "eth2"}
 );
 
-export const LightClientFinalityUpdate = new ContainerType(
+export const LightClientFinalityUpdate = ContainerType.named(
   {
     attestedHeader: LightClientHeader,
     finalizedHeader: LightClientHeader,
@@ -343,7 +353,7 @@ export const LightClientFinalityUpdate = new ContainerType(
   {typeName: "LightClientFinalityUpdate", jsonCase: "eth2"}
 );
 
-export const LightClientOptimisticUpdate = new ContainerType(
+export const LightClientOptimisticUpdate = ContainerType.named(
   {
     attestedHeader: LightClientHeader,
     syncAggregate: altairSsz.SyncAggregate,
@@ -352,10 +362,12 @@ export const LightClientOptimisticUpdate = new ContainerType(
   {typeName: "LightClientOptimisticUpdate", jsonCase: "eth2"}
 );
 
-export const LightClientStore = new ContainerType(
+export const LightClientStore = ContainerType.named(
   {
     snapshot: LightClientBootstrap,
-    validUpdates: new ListCompositeType(LightClientUpdate, EPOCHS_PER_SYNC_COMMITTEE_PERIOD * SLOTS_PER_EPOCH),
+    validUpdates: ListCompositeType.named(LightClientUpdate, EPOCHS_PER_SYNC_COMMITTEE_PERIOD * SLOTS_PER_EPOCH, {
+      typeName: "ValidUpdates",
+    }),
   },
   {typeName: "LightClientStore", jsonCase: "eth2"}
 );

--- a/packages/types/src/phase0/sszTypes.ts
+++ b/packages/types/src/phase0/sszTypes.ts
@@ -51,10 +51,10 @@ const {
 // Misc types
 // ==========
 
-export const AttestationSubnets = new BitVectorType(ATTESTATION_SUBNET_COUNT);
+export const AttestationSubnets = BitVectorType.named(ATTESTATION_SUBNET_COUNT, {typeName: "AttestationSubnets"});
 
 /** BeaconBlockHeader where slot is bounded by the clock, and values above it are invalid */
-export const BeaconBlockHeader = new ContainerType(
+export const BeaconBlockHeader = ContainerType.named(
   {
     slot: Slot,
     proposerIndex: ValidatorIndex,
@@ -66,7 +66,7 @@ export const BeaconBlockHeader = new ContainerType(
 );
 
 /** BeaconBlockHeader where slot is NOT bounded by the clock, i.e. slashings. So slot is a bigint. */
-export const BeaconBlockHeaderBigint = new ContainerType(
+export const BeaconBlockHeaderBigint = ContainerType.named(
   {
     slot: UintBn64,
     proposerIndex: ValidatorIndex,
@@ -74,28 +74,28 @@ export const BeaconBlockHeaderBigint = new ContainerType(
     stateRoot: Root,
     bodyRoot: Root,
   },
-  {typeName: "BeaconBlockHeader", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BeaconBlockHeaderBigint", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const SignedBeaconBlockHeader = new ContainerType(
+export const SignedBeaconBlockHeader = ContainerType.named(
   {
     message: BeaconBlockHeader,
     signature: BLSSignature,
   },
-  {typeName: "SignedBeaconBlockHeader", jsonCase: "eth2"}
+  {typeName: "SignedBeaconBlockHeaderPhase0", jsonCase: "eth2"}
 );
 
 /** Same as `SignedBeaconBlockHeader` but slot is not bounded by the clock and must be a bigint */
-export const SignedBeaconBlockHeaderBigint = new ContainerType(
+export const SignedBeaconBlockHeaderBigint = ContainerType.named(
   {
     message: BeaconBlockHeaderBigint,
     signature: BLSSignature,
   },
-  {typeName: "SignedBeaconBlockHeader", jsonCase: "eth2"}
+  {typeName: "SignedBeaconBlockHeaderBigint", jsonCase: "eth2"}
 );
 
 /** Checkpoint where epoch is bounded by the clock, and values above it are invalid */
-export const Checkpoint = new ContainerType(
+export const Checkpoint = ContainerType.named(
   {
     epoch: Epoch,
     root: Root,
@@ -104,19 +104,21 @@ export const Checkpoint = new ContainerType(
 );
 
 /** Checkpoint where epoch is NOT bounded by the clock, so must be a bigint */
-export const CheckpointBigint = new ContainerType(
+export const CheckpointBigint = ContainerType.named(
   {
     epoch: UintBn64,
     root: Root,
   },
-  {typeName: "Checkpoint", jsonCase: "eth2"}
+  {typeName: "CheckpointBigint", jsonCase: "eth2"}
 );
 
-export const CommitteeBits = new BitListType(MAX_VALIDATORS_PER_COMMITTEE);
+export const CommitteeBits = BitListType.named(MAX_VALIDATORS_PER_COMMITTEE, {typeName: "CommitteeBits"});
 
-export const CommitteeIndices = new ListBasicType(ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE);
+export const CommitteeIndices = ListBasicType.named(ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE, {
+  typeName: "CommitteeIndices",
+});
 
-export const DepositMessage = new ContainerType(
+export const DepositMessage = ContainerType.named(
   {
     pubkey: BLSPubkey,
     withdrawalCredentials: Bytes32,
@@ -125,7 +127,7 @@ export const DepositMessage = new ContainerType(
   {typeName: "DepositMessage", jsonCase: "eth2"}
 );
 
-export const DepositData = new ContainerType(
+export const DepositData = ContainerType.named(
   {
     pubkey: BLSPubkey,
     withdrawalCredentials: Bytes32,
@@ -135,9 +137,11 @@ export const DepositData = new ContainerType(
   {typeName: "DepositData", jsonCase: "eth2"}
 );
 
-export const DepositDataRootList = new ListCompositeType(Root, 2 ** DEPOSIT_CONTRACT_TREE_DEPTH);
+export const DepositDataRootList = ListCompositeType.named(Root, 2 ** DEPOSIT_CONTRACT_TREE_DEPTH, {
+  typeName: "DepositDataRootList",
+});
 
-export const DepositEvent = new ContainerType(
+export const DepositEvent = ContainerType.named(
   {
     depositData: DepositData,
     blockNumber: UintNum64,
@@ -146,7 +150,7 @@ export const DepositEvent = new ContainerType(
   {typeName: "DepositEvent", jsonCase: "eth2"}
 );
 
-export const Eth1Data = new ContainerType(
+export const Eth1Data = ContainerType.named(
   {
     depositRoot: Root,
     depositCount: UintNum64,
@@ -155,9 +159,11 @@ export const Eth1Data = new ContainerType(
   {typeName: "Eth1Data", jsonCase: "eth2"}
 );
 
-export const Eth1DataVotes = new ListCompositeType(Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH);
+export const Eth1DataVotes = ListCompositeType.named(Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH, {
+  typeName: "Eth1DataVotes",
+});
 
-export const Eth1DataOrdered = new ContainerType(
+export const Eth1DataOrdered = ContainerType.named(
   {
     depositRoot: Root,
     depositCount: UintNum64,
@@ -168,7 +174,7 @@ export const Eth1DataOrdered = new ContainerType(
 );
 
 /** Spec'ed but only used in lodestar as a type */
-export const Eth1Block = new ContainerType(
+export const Eth1Block = ContainerType.named(
   {
     timestamp: UintNum64,
     depositRoot: Root,
@@ -177,7 +183,7 @@ export const Eth1Block = new ContainerType(
   {typeName: "Eth1Block", jsonCase: "eth2"}
 );
 
-export const Fork = new ContainerType(
+export const Fork = ContainerType.named(
   {
     previousVersion: Version,
     currentVersion: Version,
@@ -186,7 +192,7 @@ export const Fork = new ContainerType(
   {typeName: "Fork", jsonCase: "eth2"}
 );
 
-export const ForkData = new ContainerType(
+export const ForkData = ContainerType.named(
   {
     currentVersion: Version,
     genesisValidatorsRoot: Root,
@@ -194,7 +200,7 @@ export const ForkData = new ContainerType(
   {typeName: "ForkData", jsonCase: "eth2"}
 );
 
-export const ENRForkID = new ContainerType(
+export const ENRForkID = ContainerType.named(
   {
     forkDigest: ForkDigest,
     nextForkVersion: Version,
@@ -203,10 +209,14 @@ export const ENRForkID = new ContainerType(
   {typeName: "ENRForkID", jsonCase: "eth2"}
 );
 
-export const HistoricalBlockRoots = new VectorCompositeType(Root, SLOTS_PER_HISTORICAL_ROOT);
-export const HistoricalStateRoots = new VectorCompositeType(Root, SLOTS_PER_HISTORICAL_ROOT);
+export const HistoricalBlockRoots = VectorCompositeType.named(Root, SLOTS_PER_HISTORICAL_ROOT, {
+  typeName: "HistoricalBlockRoots",
+});
+export const HistoricalStateRoots = VectorCompositeType.named(Root, SLOTS_PER_HISTORICAL_ROOT, {
+  typeName: "HistoricalStateRoots",
+});
 
-export const HistoricalBatch = new ContainerType(
+export const HistoricalBatch = ContainerType.named(
   {
     blockRoots: HistoricalBlockRoots,
     stateRoots: HistoricalStateRoots,
@@ -218,7 +228,7 @@ export const HistoricalBatch = new ContainerType(
  * Non-spec'ed helper type to allow efficient hashing in epoch transition.
  * This type is like a 'Header' of HistoricalBatch where its fields are hashed.
  */
-export const HistoricalBatchRoots = new ContainerType(
+export const HistoricalBatchRoots = ContainerType.named(
   {
     blockRoots: Root, // Hashed HistoricalBlockRoots
     stateRoots: Root, // Hashed HistoricalStateRoots
@@ -226,7 +236,7 @@ export const HistoricalBatchRoots = new ContainerType(
   {typeName: "HistoricalBatchRoots", jsonCase: "eth2"}
 );
 
-export const ValidatorContainer = new ContainerType(
+export const ValidatorContainer = ContainerType.named(
   {
     pubkey: BLSPubkey,
     withdrawalCredentials: Bytes32,
@@ -240,20 +250,25 @@ export const ValidatorContainer = new ContainerType(
   {typeName: "Validator", jsonCase: "eth2"}
 );
 
-export const ValidatorNodeStruct = new ContainerNodeStructType(ValidatorContainer.fields, ValidatorContainer.opts);
+export const ValidatorNodeStruct = ContainerNodeStructType.named(ValidatorContainer.fields, {
+  ...ValidatorContainer.opts,
+  typeName: "ValidatorNodeStruct",
+});
 // The main Validator type is the 'ContainerNodeStructType' version
 export const Validator = ValidatorNodeStruct;
 
 // Export as stand-alone for direct tree optimizations
-export const Validators = new ListCompositeType(ValidatorNodeStruct, VALIDATOR_REGISTRY_LIMIT);
-export const Balances = new ListBasicType(UintNum64, VALIDATOR_REGISTRY_LIMIT);
-export const RandaoMixes = new VectorCompositeType(Bytes32, EPOCHS_PER_HISTORICAL_VECTOR);
-export const Slashings = new VectorBasicType(Gwei, EPOCHS_PER_SLASHINGS_VECTOR);
-export const JustificationBits = new BitVectorType(JUSTIFICATION_BITS_LENGTH);
+export const Validators = ListCompositeType.named(ValidatorNodeStruct, VALIDATOR_REGISTRY_LIMIT, {
+  typeName: "Validators",
+});
+export const Balances = ListBasicType.named(UintNum64, VALIDATOR_REGISTRY_LIMIT, {typeName: "Balances"});
+export const RandaoMixes = VectorCompositeType.named(Bytes32, EPOCHS_PER_HISTORICAL_VECTOR, {typeName: "RandaoMixes"});
+export const Slashings = VectorBasicType.named(Gwei, EPOCHS_PER_SLASHINGS_VECTOR, {typeName: "Slashings"});
+export const JustificationBits = BitVectorType.named(JUSTIFICATION_BITS_LENGTH, {typeName: "JustificationBits"});
 
 // Misc dependants
 
-export const AttestationData = new ContainerType(
+export const AttestationData = ContainerType.named(
   {
     slot: Slot,
     index: CommitteeIndex,
@@ -265,7 +280,7 @@ export const AttestationData = new ContainerType(
 );
 
 /** Same as `AttestationData` but epoch, slot and index are not bounded and must be a bigint */
-export const AttestationDataBigint = new ContainerType(
+export const AttestationDataBigint = ContainerType.named(
   {
     slot: UintBn64,
     index: UintBn64,
@@ -276,7 +291,7 @@ export const AttestationDataBigint = new ContainerType(
   {typeName: "AttestationData", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const IndexedAttestation = new ContainerType(
+export const IndexedAttestation = ContainerType.named(
   {
     attestingIndices: CommitteeIndices,
     data: AttestationData,
@@ -286,7 +301,7 @@ export const IndexedAttestation = new ContainerType(
 );
 
 /** Same as `IndexedAttestation` but epoch, slot and index are not bounded and must be a bigint */
-export const IndexedAttestationBigint = new ContainerType(
+export const IndexedAttestationBigint = ContainerType.named(
   {
     attestingIndices: CommitteeIndices,
     data: AttestationDataBigint,
@@ -295,7 +310,7 @@ export const IndexedAttestationBigint = new ContainerType(
   {typeName: "IndexedAttestation", jsonCase: "eth2"}
 );
 
-export const PendingAttestation = new ContainerType(
+export const PendingAttestation = ContainerType.named(
   {
     aggregationBits: CommitteeBits,
     data: AttestationData,
@@ -305,7 +320,7 @@ export const PendingAttestation = new ContainerType(
   {typeName: "PendingAttestation", jsonCase: "eth2"}
 );
 
-export const SigningData = new ContainerType(
+export const SigningData = ContainerType.named(
   {
     objectRoot: Root,
     domain: Domain,
@@ -316,7 +331,7 @@ export const SigningData = new ContainerType(
 // Operations types
 // ================
 
-export const Attestation = new ContainerType(
+export const Attestation = ContainerType.named(
   {
     aggregationBits: CommitteeBits,
     data: AttestationData,
@@ -325,7 +340,7 @@ export const Attestation = new ContainerType(
   {typeName: "Attestation", jsonCase: "eth2"}
 );
 
-export const AttesterSlashing = new ContainerType(
+export const AttesterSlashing = ContainerType.named(
   {
     // In state transition, AttesterSlashing attestations are only partially validated. Their slot and epoch could
     // be higher than the clock and the slashing would still be valid. Same applies to attestation data index, which
@@ -336,15 +351,15 @@ export const AttesterSlashing = new ContainerType(
   {typeName: "AttesterSlashing", jsonCase: "eth2"}
 );
 
-export const Deposit = new ContainerType(
+export const Deposit = ContainerType.named(
   {
-    proof: new VectorCompositeType(Bytes32, DEPOSIT_CONTRACT_TREE_DEPTH + 1),
+    proof: VectorCompositeType.named(Bytes32, DEPOSIT_CONTRACT_TREE_DEPTH + 1, {typeName: "DepositProof"}),
     data: DepositData,
   },
   {typeName: "Deposit", jsonCase: "eth2"}
 );
 
-export const ProposerSlashing = new ContainerType(
+export const ProposerSlashing = ContainerType.named(
   {
     // In state transition, ProposerSlashing headers are only partially validated. Their slot could be higher than the
     // clock and the slashing would still be valid. Must use bigint variants to hash correctly to all possible values
@@ -354,7 +369,7 @@ export const ProposerSlashing = new ContainerType(
   {typeName: "ProposerSlashing", jsonCase: "eth2"}
 );
 
-export const VoluntaryExit = new ContainerType(
+export const VoluntaryExit = ContainerType.named(
   {
     epoch: Epoch,
     validatorIndex: ValidatorIndex,
@@ -362,7 +377,7 @@ export const VoluntaryExit = new ContainerType(
   {typeName: "VoluntaryExit", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const SignedVoluntaryExit = new ContainerType(
+export const SignedVoluntaryExit = ContainerType.named(
   {
     message: VoluntaryExit,
     signature: BLSSignature,
@@ -373,21 +388,25 @@ export const SignedVoluntaryExit = new ContainerType(
 // Block types
 // ===========
 
-export const BeaconBlockBody = new ContainerType(
+export const BeaconBlockBody = ContainerType.named(
   {
     randaoReveal: BLSSignature,
     eth1Data: Eth1Data,
     graffiti: Bytes32,
-    proposerSlashings: new ListCompositeType(ProposerSlashing, MAX_PROPOSER_SLASHINGS),
-    attesterSlashings: new ListCompositeType(AttesterSlashing, MAX_ATTESTER_SLASHINGS),
-    attestations: new ListCompositeType(Attestation, MAX_ATTESTATIONS),
-    deposits: new ListCompositeType(Deposit, MAX_DEPOSITS),
-    voluntaryExits: new ListCompositeType(SignedVoluntaryExit, MAX_VOLUNTARY_EXITS),
+    proposerSlashings: ListCompositeType.named(ProposerSlashing, MAX_PROPOSER_SLASHINGS, {
+      typeName: "ProposerSlashings",
+    }),
+    attesterSlashings: ListCompositeType.named(AttesterSlashing, MAX_ATTESTER_SLASHINGS, {
+      typeName: "AttesterSlashings",
+    }),
+    attestations: ListCompositeType.named(Attestation, MAX_ATTESTATIONS, {typeName: "Attestations"}),
+    deposits: ListCompositeType.named(Deposit, MAX_DEPOSITS, {typeName: "Deposits"}),
+    voluntaryExits: ListCompositeType.named(SignedVoluntaryExit, MAX_VOLUNTARY_EXITS, {typeName: "VoluntaryExits"}),
   },
-  {typeName: "BeaconBlockBody", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BeaconBlockBodyPhase0", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const BeaconBlock = new ContainerType(
+export const BeaconBlock = ContainerType.named(
   {
     slot: Slot,
     proposerIndex: ValidatorIndex,
@@ -395,23 +414,25 @@ export const BeaconBlock = new ContainerType(
     stateRoot: Root,
     body: BeaconBlockBody,
   },
-  {typeName: "BeaconBlock", jsonCase: "eth2", cachePermanentRootStruct: true}
+  {typeName: "BeaconBlockPhase0", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const SignedBeaconBlock = new ContainerType(
+export const SignedBeaconBlock = ContainerType.named(
   {
     message: BeaconBlock,
     signature: BLSSignature,
   },
-  {typeName: "SignedBeaconBlock", jsonCase: "eth2"}
+  {typeName: "SignedBeaconBlockPhase0", jsonCase: "eth2"}
 );
 
 // State types
 // ===========
 
-export const EpochAttestations = new ListCompositeType(PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH);
+export const EpochAttestations = ListCompositeType.named(PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH, {
+  typeName: "EpochAttestations",
+});
 
-export const BeaconState = new ContainerType(
+export const BeaconState = ContainerType.named(
   {
     // Misc
     genesisTime: UintNum64,
@@ -422,7 +443,7 @@ export const BeaconState = new ContainerType(
     latestBlockHeader: BeaconBlockHeader,
     blockRoots: HistoricalBlockRoots,
     stateRoots: HistoricalStateRoots,
-    historicalRoots: new ListCompositeType(Root, HISTORICAL_ROOTS_LIMIT),
+    historicalRoots: ListCompositeType.named(Root, HISTORICAL_ROOTS_LIMIT, {typeName: "HistoricalRoots"}),
     // Eth1
     eth1Data: Eth1Data,
     eth1DataVotes: Eth1DataVotes,
@@ -442,13 +463,13 @@ export const BeaconState = new ContainerType(
     currentJustifiedCheckpoint: Checkpoint,
     finalizedCheckpoint: Checkpoint,
   },
-  {typeName: "BeaconState", jsonCase: "eth2"}
+  {typeName: "BeaconStatePhase0", jsonCase: "eth2"}
 );
 
 // Validator types
 // ===============
 
-export const CommitteeAssignment = new ContainerType(
+export const CommitteeAssignment = ContainerType.named(
   {
     validators: CommitteeIndices,
     committeeIndex: CommitteeIndex,
@@ -457,7 +478,7 @@ export const CommitteeAssignment = new ContainerType(
   {typeName: "CommitteeAssignment", jsonCase: "eth2"}
 );
 
-export const AggregateAndProof = new ContainerType(
+export const AggregateAndProof = ContainerType.named(
   {
     aggregatorIndex: ValidatorIndex,
     aggregate: Attestation,
@@ -466,7 +487,7 @@ export const AggregateAndProof = new ContainerType(
   {typeName: "AggregateAndProof", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
-export const SignedAggregateAndProof = new ContainerType(
+export const SignedAggregateAndProof = ContainerType.named(
   {
     message: AggregateAndProof,
     signature: BLSSignature,
@@ -477,7 +498,7 @@ export const SignedAggregateAndProof = new ContainerType(
 // ReqResp types
 // =============
 
-export const Status = new ContainerType(
+export const Status = ContainerType.named(
   {
     forkDigest: ForkDigest,
     finalizedRoot: Root,
@@ -492,7 +513,7 @@ export const Goodbye = UintBn64;
 
 export const Ping = UintBn64;
 
-export const Metadata = new ContainerType(
+export const Metadata = ContainerType.named(
   {
     seqNumber: UintBn64,
     attnets: AttestationSubnets,
@@ -500,7 +521,7 @@ export const Metadata = new ContainerType(
   {typeName: "Metadata", jsonCase: "eth2"}
 );
 
-export const BeaconBlocksByRangeRequest = new ContainerType(
+export const BeaconBlocksByRangeRequest = ContainerType.named(
   {
     startSlot: Slot,
     count: UintNum64,
@@ -509,12 +530,14 @@ export const BeaconBlocksByRangeRequest = new ContainerType(
   {typeName: "BeaconBlocksByRangeRequest", jsonCase: "eth2"}
 );
 
-export const BeaconBlocksByRootRequest = new ListCompositeType(Root, MAX_REQUEST_BLOCKS);
+export const BeaconBlocksByRootRequest = ListCompositeType.named(Root, MAX_REQUEST_BLOCKS, {
+  typeName: "BeaconBlocksByRootRequest",
+});
 
 // Api types
 // =========
 
-export const Genesis = new ContainerType(
+export const Genesis = ContainerType.named(
   {
     genesisValidatorsRoot: Root,
     genesisTime: UintNum64,

--- a/packages/types/test/unit/ensureAllNamed.node.test.ts
+++ b/packages/types/test/unit/ensureAllNamed.node.test.ts
@@ -1,0 +1,33 @@
+import path from "node:path";
+import {fileURLToPath} from "node:url";
+import fs from "node:fs";
+import {ForkName} from "@lodestar/params";
+
+// Global variable __dirname no longer available in ES6 modules.
+// Solutions: https://stackoverflow.com/questions/46745014/alternative-for-dirname-in-node-js-when-using-es6-modules
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe("Ensure all named", () => {
+  // This test is to prevent developers from diverging from the .named() pattern.
+  // Could be achieved with an eslint rule, but this is easier to code with current knowledge.
+  it("Ensure all types use Type.named() instead of new Type()", () => {
+    const forkDirsPath = path.join(__dirname, "../../src");
+    const forkDirs = fs.readdirSync(forkDirsPath);
+
+    if (!forkDirs.includes("phase0")) {
+      throw Error("forkDirs must include at least phase0");
+    }
+
+    for (const forkDir of forkDirs) {
+      if (ForkName[forkDir as ForkName]) {
+        const filepath = path.join(forkDirsPath, forkDir, "sszTypes.ts");
+        const fileSrc = fs.readFileSync(filepath, "utf8");
+        if (fileSrc.includes(" new ")) {
+          throw Error(`${filepath} must use Type.named() syntax, not new Type()`);
+        }
+      }
+    }
+  });
+});
+

--- a/packages/types/test/unit/stackTrace.test.ts
+++ b/packages/types/test/unit/stackTrace.test.ts
@@ -1,0 +1,45 @@
+import {expect} from "chai";
+import {ssz} from "../../src/index.js";
+
+describe("stack traces with proper names", () => {
+  it("Should render stack traces with named properties", () => {
+    const stateEip4844 = ssz.eip4844.BeaconState.defaultValue();
+    const stateEip4844Bytes = ssz.eip4844.BeaconState.serialize(stateEip4844);
+
+    // Force de-serialization failure with the incorrect state type
+    const error = getError(() => ssz.capella.BeaconState.deserialize(stateEip4844Bytes));
+
+    if (!error.stack) {
+      throw Error("no stack trace");
+    }
+
+    // Error: First offset must equal to fixedEnd 376 != 344
+    //   at readVariableOffsets (/home/lion/Code/eth2.0/lodestar/node_modules/@chainsafe/ssz/src/type/container.ts:448:15)
+    //   at ExecutionPayloadHeaderCapellaType.getFieldRanges (/home/lion/Code/eth2.0/lodestar/node_modules/@chainsafe/ssz/src/type/container.ts:399:21)
+    //   at ExecutionPayloadHeaderCapellaType.value_deserializeFromBytes (/home/lion/Code/eth2.0/lodestar/node_modules/@chainsafe/ssz/src/type/container.ts:201:30)
+    //   at BeaconStateCapellaType.value_deserializeFromBytes (/home/lion/Code/eth2.0/lodestar/node_modules/@chainsafe/ssz/src/type/container.ts:208:36)
+    //   at BeaconStateCapellaType.deserialize (/home/lion/Code/eth2.0/lodestar/node_modules/@chainsafe/ssz/src/type/abstract.ts:135:17)
+
+    const stackRows = error.stack
+      .split("\n")
+      .slice(1, 6)
+      .map((row) => row.trim().split(/\s+/)[1]);
+
+    expect(stackRows).deep.equals([
+      "readVariableOffsets",
+      "ExecutionPayloadHeaderCapella.getFieldRanges",
+      "ExecutionPayloadHeaderCapella.value_deserializeFromBytes",
+      "BeaconStateCapella.value_deserializeFromBytes",
+      "BeaconStateCapella.deserialize",
+    ]);
+  });
+});
+
+function getError(fn: () => void): Error {
+  try {
+    fn();
+    throw Error("fn did not throw");
+  } catch (e) {
+    return e as Error;
+  }
+}


### PR DESCRIPTION
**Motivation**

Whenever there's an SSZ error, the stack trace looks like this

```
Error: First offset must equal to fixedEnd 376 != 344
  at readVariableOffsets (/home/lion/Code/eth2.0/lodestar/node_modules/@chainsafe/ssz/src/type/container.ts:448:15)
  at ContainerType.getFieldRanges (/home/lion/Code/eth2.0/lodestar/node_modules/@chainsafe/ssz/src/type/container.ts:399:21)
  at ContainerType.value_deserializeFromBytes (/home/lion/Code/eth2.0/lodestar/node_modules/@chainsafe/ssz/src/type/container.ts:201:30)
  at ContainerType.value_deserializeFromBytes (/home/lion/Code/eth2.0/lodestar/node_modules/@chainsafe/ssz/src/type/container.ts:208:36)
  at ContainerType.deserialize (/home/lion/Code/eth2.0/lodestar/node_modules/@chainsafe/ssz/src/type/abstract.ts:135:17)
```

which sucks because you wonder, which is the offending property? Where should I go look next?

Would be awesome if the stack trace also included the path of what property is causing the error. Previous attempts:
- Add try / catch on every method and concatenate the path of the error, for example: `state.executionPayloadHeader.excessGas`. However this requires adding tons of boilerplate code + has a serious performance penalty.

But what if instead of rendering `ContainerType` in stack trace rows it rendered `BeaconStateCapella`? Well, that's what this PR does

**Description**

The above error renders with this PR like
```
Error: First offset must equal to fixedEnd 376 != 344
  at readVariableOffsets (/home/lion/Code/eth2.0/lodestar/node_modules/@chainsafe/ssz/src/type/container.ts:448:15)
  at ExecutionPayloadHeaderCapellaType.getFieldRanges (/home/lion/Code/eth2.0/lodestar/node_modules/@chainsafe/ssz/src/type/container.ts:399:21)
  at ExecutionPayloadHeaderCapellaType.value_deserializeFromBytes (/home/lion/Code/eth2.0/lodestar/node_modules/@chainsafe/ssz/src/type/container.ts:201:30)
  at BeaconStateCapellaType.value_deserializeFromBytes (/home/lion/Code/eth2.0/lodestar/node_modules/@chainsafe/ssz/src/type/container.ts:208:36)
  at BeaconStateCapellaType.deserialize (/home/lion/Code/eth2.0/lodestar/node_modules/@chainsafe/ssz/src/type/abstract.ts:135:17)
```

Much nicer! The key here is to force JS to pick up a dedicated "object name" for each class instance. I've tried many hacks to do that dynamically but all fail. 
- All engines I've tried consider object.name a read-only immutable property
- They appear to pick the name of the prototype, not of the instance. So if there are multiple instances of ContainerType they will all have the same name
- The only viable option I've found is to declare a new class for each type, so they have a custom name.

Relevant sources on dynamic object names
- https://stackoverflow.com/questions/33605775/es6-dynamic-class-names

**Drawbacks**
- This change will cause all SSZ operations to require one extra hop up the prototype chain. I've not seen that to cause any noticeable performance penalties, and modern engine should cache those paths anyway
- Typescript compilation seems to take the same time, no observed issue there