### PR TITLE
Move appropriate eip4844 engine endpoints to v3

### DIFF
--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -315,7 +315,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
    */
   async getPayload(fork: ForkName, payloadId: PayloadId): Promise<allForks.ExecutionPayload> {
     const method =
-      ForkSeq[fork] >= ForkSeq.capella
+      ForkSeq[fork] >= ForkSeq.eip4844
         ? "engine_getPayloadV3"
         : ForkSeq[fork] >= ForkSeq.capella
         ? "engine_getPayloadV2"

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -153,7 +153,12 @@ export class ExecutionEngineHttp implements IExecutionEngine {
    * If any of the above fails due to errors unrelated to the normal processing flow of the method, client software MUST respond with an error object.
    */
   async notifyNewPayload(fork: ForkName, executionPayload: allForks.ExecutionPayload): Promise<ExecutePayloadResponse> {
-    const method = ForkSeq[fork] >= ForkSeq.capella ? "engine_newPayloadV2" : "engine_newPayloadV1";
+    const method =
+      ForkSeq[fork] >= ForkSeq.eip4844
+        ? "engine_newPayloadV3"
+        : ForkSeq[fork] >= ForkSeq.capella
+        ? "engine_newPayloadV2"
+        : "engine_newPayloadV1";
     const serializedExecutionPayload = serializeExecutionPayload(fork, executionPayload);
     const {status, latestValidHash, validationError} = await (this.rpcFetchQueue.push({
       method,
@@ -309,7 +314,12 @@ export class ExecutionEngineHttp implements IExecutionEngine {
    * 3. Client software MAY stop the corresponding building process after serving this call.
    */
   async getPayload(fork: ForkName, payloadId: PayloadId): Promise<allForks.ExecutionPayload> {
-    const method = ForkSeq[fork] >= ForkSeq.capella ? "engine_getPayloadV2" : "engine_getPayloadV1";
+    const method =
+      ForkSeq[fork] >= ForkSeq.capella
+        ? "engine_getPayloadV3"
+        : ForkSeq[fork] >= ForkSeq.capella
+        ? "engine_getPayloadV2"
+        : "engine_getPayloadV1";
     const executionPayloadRpc = await this.rpc.fetchWithRetries<
       EngineApiRpcReturnTypes[typeof method],
       EngineApiRpcParamTypes[typeof method]
@@ -374,6 +384,7 @@ type EngineApiRpcParamTypes = {
    */
   engine_newPayloadV1: [ExecutionPayloadRpc];
   engine_newPayloadV2: [ExecutionPayloadRpc];
+  engine_newPayloadV3: [ExecutionPayloadRpc];
   /**
    * 1. Object - Payload validity status with respect to the consensus rules:
    *   - blockHash: DATA, 32 Bytes - block hash value of the payload
@@ -392,6 +403,7 @@ type EngineApiRpcParamTypes = {
    */
   engine_getPayloadV1: [QUANTITY];
   engine_getPayloadV2: [QUANTITY];
+  engine_getPayloadV3: [QUANTITY];
   /**
    * 1. Object - Instance of TransitionConfigurationV1
    */
@@ -417,6 +429,11 @@ type EngineApiRpcReturnTypes = {
     latestValidHash: DATA | null;
     validationError: string | null;
   };
+  engine_newPayloadV3: {
+    status: ExecutePayloadStatus;
+    latestValidHash: DATA | null;
+    validationError: string | null;
+  };
   engine_forkchoiceUpdatedV1: {
     payloadStatus: {status: ForkChoiceUpdateStatus; latestValidHash: DATA | null; validationError: string | null};
     payloadId: QUANTITY | null;
@@ -430,6 +447,7 @@ type EngineApiRpcReturnTypes = {
    */
   engine_getPayloadV1: ExecutionPayloadRpc;
   engine_getPayloadV2: ExecutionPayloadRpc;
+  engine_getPayloadV3: ExecutionPayloadRpc;
   /**
    * Object - Instance of TransitionConfigurationV1
    */


### PR DESCRIPTION
Eip 4844 newpayload/getpayload endpoints have moved to v3

https://github.com/ethereum/execution-apis/blob/ff95a01d34bcf4e0fb945baffc135271d84611c5/src/engine/blob-extension.md#executionpayloadv3