### PR TITLE
Install c-kzg optionally

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,8 @@ jobs:
       # </common-build>
 
       # Only install c-kzg if required. See https://github.com/ChainSafe/lodestar/pull/4888
-      - run: yarn add c-kzg
-        working-directory: packages/beacon-node
+      # Install in workspace root, else there are weird type errors with NodeJS types
+      - run: yarn add --ignore-workspace-root-check c-kzg
 
       # Cache validator slashing protection data tests
       - name: Restore spec tests cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
         if: steps.cache-deps.outputs.cache-hit == 'true'
       # </common-build>
 
+      # Only install c-kzg if required. See https://github.com/ChainSafe/lodestar/pull/4888
+      - run: yarn install c-kzg
+
       # Cache validator slashing protection data tests
       - name: Restore spec tests cache
         uses: actions/cache@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       # </common-build>
 
       # Only install c-kzg if required. See https://github.com/ChainSafe/lodestar/pull/4888
-      - run: yarn install c-kzg
+      - run: yarn add c-kzg
 
       # Cache validator slashing protection data tests
       - name: Restore spec tests cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
 
       # Only install c-kzg if required. See https://github.com/ChainSafe/lodestar/pull/4888
       - run: yarn add c-kzg
+        working-directory: packages/beacon-node
 
       # Cache validator slashing protection data tests
       - name: Restore spec tests cache

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -133,7 +133,6 @@
     "@multiformats/multiaddr": "^11.0.0",
     "@types/datastore-level": "^3.0.0",
     "buffer-xor": "^2.0.2",
-    "c-kzg": "^1.0.7",
     "cross-fetch": "^3.1.4",
     "datastore-core": "^8.0.1",
     "datastore-level": "^9.0.1",
@@ -156,6 +155,9 @@
     "uint8arrays": "^4.0.2",
     "varint": "^6.0.0",
     "xxhash-wasm": "1.0.1"
+  },
+  "peerDependencies": {
+    "c-kzg": "^1.0.7"
   },
   "devDependencies": {
     "@types/bl": "^5.0.1",

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import {computeAggregateKzgProof} from "c-kzg";
 import {
   BeaconStateAllForks,
   CachedBeaconStateAllForks,
@@ -25,6 +24,7 @@ import {IBeaconDb} from "../db/index.js";
 import {IMetrics} from "../metrics/index.js";
 import {bytesToData, numToQuantity} from "../eth1/provider/utils.js";
 import {wrapError} from "../util/wrapError.js";
+import {ckzg} from "../util/kzg.js";
 import {IEth1ForBlockProduction} from "../eth1/index.js";
 import {IExecutionEngine, IExecutionBuilder, TransitionConfigurationV1} from "../execution/index.js";
 import {ensureDir, writeIfNotExist} from "../util/file.js";
@@ -399,7 +399,7 @@ export class BeaconChain implements IBeaconChain {
         beaconBlockRoot: this.config.getForkTypes(block.slot).BeaconBlock.hashTreeRoot(block),
         beaconBlockSlot: block.slot,
         blobs: blobs.blobs,
-        kzgAggregatedProof: computeAggregateKzgProof(blobs.blobs),
+        kzgAggregatedProof: ckzg.computeAggregateKzgProof(blobs.blobs),
       });
       pruneSetToMax(
         this.producedBlobsSidecarCache,

--- a/packages/beacon-node/src/chain/produceBlock/validateBlobsAndKzgCommitments.ts
+++ b/packages/beacon-node/src/chain/produceBlock/validateBlobsAndKzgCommitments.ts
@@ -1,9 +1,9 @@
-import {blobToKzgCommitment} from "c-kzg";
 import {verifyKzgCommitmentsAgainstTransactions} from "@lodestar/state-transition";
 import {allForks, eip4844} from "@lodestar/types";
 import {toHex} from "@lodestar/utils";
 import {BlobsBundle} from "../../execution/index.js";
 import {byteArrayEquals} from "../../util/bytes.js";
+import {ckzg} from "../../util/kzg.js";
 
 /**
  * Optionally sanity-check that the KZG commitments match the versioned hashes in the transactions
@@ -18,7 +18,7 @@ export function validateBlobsAndKzgCommitments(payload: allForks.ExecutionPayloa
   }
 
   for (let i = 0; i < blobsBundle.blobs.length; i++) {
-    const kzg = blobToKzgCommitment(blobsBundle.blobs[i]) as eip4844.KZGCommitment;
+    const kzg = ckzg.blobToKzgCommitment(blobsBundle.blobs[i]) as eip4844.KZGCommitment;
     if (!byteArrayEquals(kzg, blobsBundle.kzgs[i])) {
       throw Error(`Wrong KZG[${i}] ${toHex(blobsBundle.kzgs[i])} expected ${toHex(kzg)}`);
     }

--- a/packages/beacon-node/src/chain/validation/blobsSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/blobsSidecar.ts
@@ -1,13 +1,13 @@
-import {BYTES_PER_FIELD_ELEMENT, verifyAggregateKzgProof} from "c-kzg";
 import bls from "@chainsafe/bls";
 import {CoordType} from "@chainsafe/bls/types";
 import {eip4844, Root, ssz} from "@lodestar/types";
 import {bytesToBigInt} from "@lodestar/utils";
-import {FIELD_ELEMENTS_PER_BLOB} from "@lodestar/params";
+import {BYTES_PER_FIELD_ELEMENT, FIELD_ELEMENTS_PER_BLOB} from "@lodestar/params";
 import {verifyKzgCommitmentsAgainstTransactions} from "@lodestar/state-transition";
 import {BlobsSidecarError, BlobsSidecarErrorCode} from "../errors/blobsSidecarError.js";
 import {GossipAction} from "../errors/gossipValidation.js";
 import {byteArrayEquals} from "../../util/bytes.js";
+import {ckzg} from "../../util/kzg.js";
 
 const BLS_MODULUS = BigInt("52435875175126190479447740508185965837690552500527637822603658699938581184513");
 
@@ -104,7 +104,7 @@ export function validateBlobsSidecar(
     // assert verify_aggregate_kzg_proof(blobs, expected_kzg_commitments, kzg_aggregated_proof)
     let isProofValid: boolean;
     try {
-      isProofValid = verifyAggregateKzgProof(blobs, expectedKzgCommitments, kzgAggregatedProof);
+      isProofValid = ckzg.verifyAggregateKzgProof(blobs, expectedKzgCommitments, kzgAggregatedProof);
     } catch (e) {
       // TODO EIP-4844: TEMP Nov17: May always throw error -- we need to fix Geth's KZG to match C-KZG and the trusted setup used here
       (e as Error).message = `Error on verifyAggregateKzgProof: ${(e as Error).message}`;

--- a/packages/beacon-node/src/execution/engine/mock.ts
+++ b/packages/beacon-node/src/execution/engine/mock.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import {blobToKzgCommitment, BYTES_PER_FIELD_ELEMENT, FIELD_ELEMENTS_PER_BLOB} from "c-kzg";
 import {
   kzgCommitmentToVersionedHash,
   OPAQUE_TX_BLOB_VERSIONED_HASHES_OFFSET,
@@ -7,8 +6,9 @@ import {
 } from "@lodestar/state-transition";
 import {allForks, bellatrix, eip4844, RootHex, ssz} from "@lodestar/types";
 import {fromHex, toHex} from "@lodestar/utils";
-import {BLOB_TX_TYPE, ForkName, ForkSeq} from "@lodestar/params";
+import {BYTES_PER_FIELD_ELEMENT, FIELD_ELEMENTS_PER_BLOB, BLOB_TX_TYPE, ForkName, ForkSeq} from "@lodestar/params";
 import {ZERO_HASH_HEX} from "../../constants/index.js";
+import {ckzg} from "../../util/kzg.js";
 import {
   ExecutePayloadStatus,
   ExecutePayloadResponse,
@@ -226,7 +226,7 @@ export class ExecutionEngineMock implements IExecutionEngine {
         const eip4844TxCount = Math.round(2 * Math.random());
         for (let i = 0; i < eip4844TxCount; i++) {
           const blob = generateRandomBlob();
-          const kzg = blobToKzgCommitment(blob);
+          const kzg = ckzg.blobToKzgCommitment(blob);
           executionPayload.transactions.push(transactionForKzgCommitment(kzg));
           kzgs.push(kzg);
           blobs.push(blob);

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -18,7 +18,7 @@ import {createMetrics, IMetrics, HttpMetricsServer} from "../metrics/index.js";
 import {getApi, BeaconRestApiServer} from "../api/index.js";
 import {initializeExecutionEngine, initializeExecutionBuilder} from "../execution/index.js";
 import {initializeEth1ForBlockProduction} from "../eth1/index.js";
-import {loadEthereumTrustedSetup} from "../util/kzg.js";
+import {initCKZG, loadEthereumTrustedSetup} from "../util/kzg.js";
 import {createLibp2pMetrics} from "../metrics/metrics/libp2p.js";
 import {IBeaconNodeOptions} from "./options.js";
 import {runNodeNotifier} from "./notifier.js";
@@ -144,6 +144,9 @@ export class BeaconNode {
 
     // TODO EIP-4844, where is the best place to do this?
     if (config.EIP4844_FORK_EPOCH < Infinity) {
+      // TODO EIP-4844: "c-kzg" is not installed by default, so if the library is not installed this will throw
+      // See "Not able to build lodestar from source" https://github.com/ChainSafe/lodestar/issues/4886
+      await initCKZG();
       loadEthereumTrustedSetup();
     }
 

--- a/packages/beacon-node/src/util/kzg.ts
+++ b/packages/beacon-node/src/util/kzg.ts
@@ -6,7 +6,7 @@ import {fromHex, toHex} from "@lodestar/utils";
 /* eslint-disable @typescript-eslint/naming-convention */
 
 // "c-kzg" has hardcoded the mainnet value, do not use params
-const FIELD_ELEMENTS_PER_BLOB_MAINNET = 4096;
+export const FIELD_ELEMENTS_PER_BLOB_MAINNET = 4096;
 
 function ckzgNotLoaded(): never {
   throw Error("c-kzg library not loaded");

--- a/packages/beacon-node/src/util/kzg.ts
+++ b/packages/beacon-node/src/util/kzg.ts
@@ -2,7 +2,11 @@ import path from "node:path";
 import fs from "node:fs";
 import {fileURLToPath} from "node:url";
 import {fromHex, toHex} from "@lodestar/utils";
-import {FIELD_ELEMENTS_PER_BLOB} from "@lodestar/params";
+
+/* eslint-disable @typescript-eslint/naming-convention */
+
+// "c-kzg" has hardcoded the mainnet value, do not use params
+const FIELD_ELEMENTS_PER_BLOB_MAINNET = 4096;
 
 function ckzgNotLoaded(): never {
   throw Error("c-kzg library not loaded");
@@ -35,7 +39,7 @@ const TRUSTED_SETUP_TXT_FILEPATH = path.join(__dirname, "../../trusted_setup.txt
 const POINT_COUNT_BYTES = 4;
 const G1POINT_BYTES = 48;
 const G2POINT_BYTES = 96;
-const G1POINT_COUNT = FIELD_ELEMENTS_PER_BLOB;
+const G1POINT_COUNT = FIELD_ELEMENTS_PER_BLOB_MAINNET;
 const G2POINT_COUNT = 65;
 const TOTAL_SIZE = 2 * POINT_COUNT_BYTES + G1POINT_BYTES * G1POINT_COUNT + G2POINT_BYTES * G2POINT_COUNT;
 
@@ -121,12 +125,13 @@ export function trustedSetupBinToJson(bytes: TrustedSetupBin): TrustedSetupJSON 
 }
 
 export function trustedSetupJsonToTxt(data: TrustedSetupJSON): TrustedSetupTXT {
-  let out = `${FIELD_ELEMENTS_PER_BLOB}\n65\n`;
-
-  for (const p of data.setup_G1) out += strip0xPrefix(p) + "\n";
-  for (const p of data.setup_G2) out += strip0xPrefix(p) + "\n";
-
-  return out;
+  return [
+    // ↵
+    G1POINT_COUNT,
+    G2POINT_COUNT,
+    ...data.setup_G1.map(strip0xPrefix),
+    ...data.setup_G2.map(strip0xPrefix),
+  ].join("\n");
 }
 
 function strip0xPrefix(hex: string): string {

--- a/packages/beacon-node/src/util/kzg.ts
+++ b/packages/beacon-node/src/util/kzg.ts
@@ -44,8 +44,10 @@ const G2POINT_COUNT = 65;
 const TOTAL_SIZE = 2 * POINT_COUNT_BYTES + G1POINT_BYTES * G1POINT_COUNT + G2POINT_BYTES * G2POINT_COUNT;
 
 export async function initCKZG(): Promise<void> {
-  // eslint-disable-next-line import/no-extraneous-dependencies
-  ckzg = await import("c-kzg");
+  /* eslint-disable import/no-extraneous-dependencies, @typescript-eslint/ban-ts-comment */
+  // @ts-ignore
+  ckzg = (await import("c-kzg")) as typeof ckzg;
+  /* eslint-enable import/no-extraneous-dependencies, @typescript-eslint/ban-ts-comment */
 }
 
 /**

--- a/packages/beacon-node/test/unit/util/kzg.test.ts
+++ b/packages/beacon-node/test/unit/util/kzg.test.ts
@@ -1,12 +1,12 @@
 import {expect} from "chai";
 import {bellatrix, eip4844, ssz} from "@lodestar/types";
-import {BLOB_TX_TYPE, BYTES_PER_FIELD_ELEMENT, FIELD_ELEMENTS_PER_BLOB} from "@lodestar/params";
+import {BLOB_TX_TYPE, BYTES_PER_FIELD_ELEMENT} from "@lodestar/params";
 import {
   kzgCommitmentToVersionedHash,
   OPAQUE_TX_BLOB_VERSIONED_HASHES_OFFSET,
   OPAQUE_TX_MESSAGE_OFFSET,
 } from "@lodestar/state-transition";
-import {loadEthereumTrustedSetup, initCKZG, ckzg} from "../../../src/util/kzg.js";
+import {loadEthereumTrustedSetup, initCKZG, ckzg, FIELD_ELEMENTS_PER_BLOB_MAINNET} from "../../../src/util/kzg.js";
 import {validateBlobsSidecar, validateGossipBlobsSidecar} from "../../../src/chain/validation/blobsSidecar.js";
 
 describe("C-KZG", () => {
@@ -80,9 +80,9 @@ function transactionForKzgCommitment(kzgCommitment: eip4844.KZGCommitment): bell
  * Generate random blob of sequential integers such that each element is < BLS_MODULUS
  */
 function generateRandomBlob(): eip4844.Blob {
-  const blob = new Uint8Array(FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT);
+  const blob = new Uint8Array(FIELD_ELEMENTS_PER_BLOB_MAINNET * BYTES_PER_FIELD_ELEMENT);
   const dv = new DataView(blob.buffer, blob.byteOffset, blob.byteLength);
-  for (let i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
+  for (let i = 0; i < FIELD_ELEMENTS_PER_BLOB_MAINNET; i++) {
     dv.setUint32(i * BYTES_PER_FIELD_ELEMENT, i);
   }
   return blob;

--- a/packages/beacon-node/test/unit/util/kzg.test.ts
+++ b/packages/beacon-node/test/unit/util/kzg.test.ts
@@ -1,30 +1,19 @@
 import {expect} from "chai";
-import {
-  freeTrustedSetup,
-  blobToKzgCommitment,
-  computeAggregateKzgProof,
-  verifyAggregateKzgProof,
-  BYTES_PER_FIELD_ELEMENT,
-  FIELD_ELEMENTS_PER_BLOB,
-} from "c-kzg";
 import {bellatrix, eip4844, ssz} from "@lodestar/types";
-import {BLOB_TX_TYPE} from "@lodestar/params";
+import {BLOB_TX_TYPE, BYTES_PER_FIELD_ELEMENT, FIELD_ELEMENTS_PER_BLOB} from "@lodestar/params";
 import {
   kzgCommitmentToVersionedHash,
   OPAQUE_TX_BLOB_VERSIONED_HASHES_OFFSET,
   OPAQUE_TX_MESSAGE_OFFSET,
 } from "@lodestar/state-transition";
-import {loadEthereumTrustedSetup} from "../../../src/util/kzg.js";
+import {loadEthereumTrustedSetup, initCKZG, ckzg} from "../../../src/util/kzg.js";
 import {validateBlobsSidecar, validateGossipBlobsSidecar} from "../../../src/chain/validation/blobsSidecar.js";
 
 describe("C-KZG", () => {
   before(async function () {
     this.timeout(10000); // Loading trusted setup is slow
+    await initCKZG();
     loadEthereumTrustedSetup();
-  });
-
-  after(() => {
-    freeTrustedSetup();
   });
 
   it("computes the correct commitments and aggregate proofs from blobs", () => {
@@ -32,15 +21,15 @@ describe("C-KZG", () => {
     // Apply this example to the test data
     // ====================
     const blobs = new Array(2).fill(0).map(generateRandomBlob);
-    const commitments = blobs.map(blobToKzgCommitment);
-    const proof = computeAggregateKzgProof(blobs);
-    expect(verifyAggregateKzgProof(blobs, commitments, proof)).to.equal(true);
+    const commitments = blobs.map((blob) => ckzg.blobToKzgCommitment(blob));
+    const proof = ckzg.computeAggregateKzgProof(blobs);
+    expect(ckzg.verifyAggregateKzgProof(blobs, commitments, proof)).to.equal(true);
   });
 
   it("BlobsSidecar", () => {
     const slot = 0;
     const blobs = [generateRandomBlob(), generateRandomBlob()];
-    const kzgCommitments = blobs.map(blobToKzgCommitment);
+    const kzgCommitments = blobs.map((blob) => ckzg.blobToKzgCommitment(blob));
 
     const signedBeaconBlock = ssz.eip4844.SignedBeaconBlock.defaultValue();
     for (const kzgCommitment of kzgCommitments) {
@@ -53,7 +42,7 @@ describe("C-KZG", () => {
       beaconBlockRoot,
       beaconBlockSlot: 0,
       blobs,
-      kzgAggregatedProof: computeAggregateKzgProof(blobs),
+      kzgAggregatedProof: ckzg.computeAggregateKzgProof(blobs),
     };
 
     // Full validation


### PR DESCRIPTION
**Motivation**

- c-kzg library does not feature any pre-builds and is quite untested through multiple platforms. See https://github.com/ChainSafe/lodestar/issues/4886

I think we should not install by default on unstable to prevent usability issues until the library bindings are hardened

**Description**

- Install c-kzg optionally

Closes #4886