### PR TITLE
Handle missing blocks in onBeaconBlocksByRange

### DIFF
--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -112,6 +112,9 @@ async function getUnfinalizedBlocksAtSlots(
         slot: slots[i],
         bytes: block,
       });
+    } else {
+      // otherwise the returned block is not really a chain segment if it misses a block in the middle
+      throw new ResponseError(RespStatus.RESOURCE_UNAVAILABLE, `No block found for slot ${slots[i]}`);
     }
   }
 

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -107,15 +107,15 @@ async function getUnfinalizedBlocksAtSlots(
 
   for (let i = 0; i < unfinalizedBlocksOrNull.length; i++) {
     const block = unfinalizedBlocksOrNull[i];
-    if (block) {
-      unfinalizedBlocks.push({
-        slot: slots[i],
-        bytes: block,
-      });
-    } else {
+    if (!block) {
       // otherwise the returned block is not really a chain segment if it misses a block in the middle
-      throw new ResponseError(RespStatus.RESOURCE_UNAVAILABLE, `No block found for slot ${slots[i]}`);
+      throw new ResponseError(RespStatus.SERVER_ERROR, `No block found for slot ${slots[i]}`);
     }
+
+    unfinalizedBlocks.push({
+      slot: slots[i],
+      bytes: block,
+    });
   }
 
   return unfinalizedBlocks;

--- a/packages/beacon-node/src/network/reqresp/handlers/blobsSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobsSidecarsByRange.ts
@@ -71,16 +71,18 @@ export async function* onBlobsSidecarsByRange(
         // re-org there's no need to abort the request
         // Spec: https://github.com/ethereum/consensus-specs/blob/a1e46d1ae47dd9d097725801575b46907c12a1f8/specs/eip4844/p2p-interface.md#blobssidecarsbyrange-v1
 
-        const blockBytes = await db.blobsSidecar.getBinary(fromHex(block.blockRoot));
-        if (blockBytes) {
+        const blobsSidecarBytes = await db.blobsSidecar.getBinary(fromHex(block.blockRoot));
+        if (blobsSidecarBytes) {
           yield {
             type: EncodedPayloadType.bytes,
-            bytes: blockBytes,
+            bytes: blobsSidecarBytes,
             contextBytes: {
               type: ContextBytesType.ForkDigest,
               forkSlot: block.slot,
             },
           };
+        } else {
+          throw new ResponseError(RespStatus.RESOURCE_UNAVAILABLE, `No blobsSidecar found for slot ${block.slot}`);
         }
       }
 

--- a/packages/beacon-node/src/network/reqresp/handlers/blobsSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobsSidecarsByRange.ts
@@ -72,18 +72,19 @@ export async function* onBlobsSidecarsByRange(
         // Spec: https://github.com/ethereum/consensus-specs/blob/a1e46d1ae47dd9d097725801575b46907c12a1f8/specs/eip4844/p2p-interface.md#blobssidecarsbyrange-v1
 
         const blobsSidecarBytes = await db.blobsSidecar.getBinary(fromHex(block.blockRoot));
-        if (blobsSidecarBytes) {
-          yield {
-            type: EncodedPayloadType.bytes,
-            bytes: blobsSidecarBytes,
-            contextBytes: {
-              type: ContextBytesType.ForkDigest,
-              forkSlot: block.slot,
-            },
-          };
-        } else {
-          throw new ResponseError(RespStatus.RESOURCE_UNAVAILABLE, `No blobsSidecar found for slot ${block.slot}`);
+        if (!blobsSidecarBytes) {
+          // Handle the same to onBeaconBlocksByRange
+          throw new ResponseError(RespStatus.SERVER_ERROR, `No blobsSidecar found for slot ${block.slot}`);
         }
+
+        yield {
+          type: EncodedPayloadType.bytes,
+          bytes: blobsSidecarBytes,
+          contextBytes: {
+            type: ContextBytesType.ForkDigest,
+            forkSlot: block.slot,
+          },
+        };
       }
 
       // If block is after endSlot, stop iterating


### PR DESCRIPTION
**Motivation**

- The returned data of onBeaconBlocksByRange should be a chain segment, if we miss any blocks, throw Error
- From the discussion in https://github.com/ChainSafe/lodestar/pull/4865#discussion_r1041858081

**Description**

- Handle similarly for `onBlobsSidecarsByRange`
