### PR TITLE
Bump spec tests version to v1.3.0-alpha.1

### DIFF
--- a/packages/beacon-node/test/spec/specTestVersioning.ts
+++ b/packages/beacon-node/test/spec/specTestVersioning.ts
@@ -15,7 +15,7 @@ import {IDownloadTestsOptions} from "@lodestar/spec-test-util";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const ethereumConsensusSpecsTests: IDownloadTestsOptions = {
-  specVersion: "v1.3.0-alpha.0",
+  specVersion: "v1.3.0-alpha.1",
   // Target directory is the host package root: 'packages/*/spec-tests'
   outputDir: path.join(__dirname, "../../spec-tests"),
   specTestsRepoUrl: "https://github.com/ethereum/consensus-spec-tests",

--- a/packages/params/src/index.ts
+++ b/packages/params/src/index.ts
@@ -84,10 +84,6 @@ export const {
   BYTES_PER_LOGS_BLOOM,
   MAX_EXTRA_DATA_BYTES,
 
-  // TODO CAPELLA: Remove the bottom ones after the new spec test vectors are released
-  MAX_PARTIAL_WITHDRAWALS_PER_EPOCH,
-  WITHDRAWAL_QUEUE_LIMIT,
-
   MAX_BLS_TO_EXECUTION_CHANGES,
   MAX_WITHDRAWALS_PER_PAYLOAD,
 

--- a/packages/params/src/interface/capella.ts
+++ b/packages/params/src/interface/capella.ts
@@ -1,9 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 export type CapellaPreset = {
-  // TODO CAPELLA: Remove these two when new spec tests are released
-  MAX_PARTIAL_WITHDRAWALS_PER_EPOCH: number;
-  WITHDRAWAL_QUEUE_LIMIT: number;
-
   MAX_BLS_TO_EXECUTION_CHANGES: number;
   MAX_WITHDRAWALS_PER_PAYLOAD: number;
 };

--- a/packages/params/src/presets/mainnet/capella.ts
+++ b/packages/params/src/presets/mainnet/capella.ts
@@ -2,10 +2,6 @@ import {CapellaPreset} from "../../interface/capella.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export const capella: CapellaPreset = {
-  // TODO CAPELLA: Remove these two when new spec tests vectors are released
-  MAX_PARTIAL_WITHDRAWALS_PER_EPOCH: 256,
-  WITHDRAWAL_QUEUE_LIMIT: 1099511627776,
-
   MAX_BLS_TO_EXECUTION_CHANGES: 16,
   MAX_WITHDRAWALS_PER_PAYLOAD: 16,
 };

--- a/packages/params/src/presets/mainnet/index.ts
+++ b/packages/params/src/presets/mainnet/index.ts
@@ -5,7 +5,7 @@ import {bellatrix} from "./bellatrix.js";
 import {capella} from "./capella.js";
 import {eip4844} from "./eip4844.js";
 
-export const commit = "v1.3.0-alpha.0";
+export const commit = "v1.3.0-alpha.1";
 
 export const preset: BeaconPreset = {
   ...phase0,

--- a/packages/params/src/presets/minimal/capella.ts
+++ b/packages/params/src/presets/minimal/capella.ts
@@ -2,11 +2,7 @@ import {CapellaPreset} from "../../interface/capella.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export const capella: CapellaPreset = {
-  // TODO CAPELLA: Remove these two when we move to the new spec vectors
-  MAX_PARTIAL_WITHDRAWALS_PER_EPOCH: 16,
-  WITHDRAWAL_QUEUE_LIMIT: 1099511627776,
-
   MAX_BLS_TO_EXECUTION_CHANGES: 16,
   // Change this to 4 when new spec test vectors are released
-  MAX_WITHDRAWALS_PER_PAYLOAD: 8,
+  MAX_WITHDRAWALS_PER_PAYLOAD: 4,
 };

--- a/packages/params/src/presets/minimal/index.ts
+++ b/packages/params/src/presets/minimal/index.ts
@@ -5,7 +5,7 @@ import {bellatrix} from "./bellatrix.js";
 import {capella} from "./capella.js";
 import {eip4844} from "./eip4844.js";
 
-export const commit = "v1.3.0-alpha.0";
+export const commit = "v1.3.0-alpha.1";
 
 export const preset: BeaconPreset = {
   ...phase0,

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -207,10 +207,6 @@ function getSpecCriticalParams(localConfig: IChainConfig): Record<keyof ConfigWi
 
     // # CapellaPreset
     /////////////////
-    // TODO CAPELLA: Remove them on when new spec tests for without queue withdrawals are
-    // released
-    MAX_PARTIAL_WITHDRAWALS_PER_EPOCH: capellaForkRelevant,
-    WITHDRAWAL_QUEUE_LIMIT: capellaForkRelevant,
     MAX_BLS_TO_EXECUTION_CHANGES: capellaForkRelevant,
     MAX_WITHDRAWALS_PER_PAYLOAD: capellaForkRelevant,
 


### PR DESCRIPTION
**Motivation**

- See for full changelog https://github.com/ethereum/consensus-specs/releases/tag/v1.3.0-alpha.1

**Description**

- Bump spec tests version to v1.3.0-alpha.1