### PR TITLE
Add scrape_location as default label to beacon and validator metrics

### DIFF
--- a/packages/beacon-node/src/metrics/metrics.ts
+++ b/packages/beacon-node/src/metrics/metrics.ts
@@ -33,6 +33,9 @@ export function createMetrics(
     lodestar.unhandledPromiseRejections.inc();
   });
 
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  register.setDefaultLabels({scrape_location: "beacon"});
+
   collectNodeJSMetrics(register);
 
   // Merge external registries

--- a/packages/beacon-node/test/unit/metrics/beacon.test.ts
+++ b/packages/beacon-node/test/unit/metrics/beacon.test.ts
@@ -12,10 +12,10 @@ describe("BeaconMetrics", () => {
     expect(metricsAsText).to.not.equal("");
 
     // check updating beacon-specific metrics
-    await expect(metrics.register.getSingleMetricAsString("libp2p_peers")).eventually.include("libp2p_peers 0");
+    await expect(metrics.register.getSingleMetricAsString("libp2p_peers")).eventually.match(/libp2p_peers({.+})? 0/);
     metrics.peers.set(1);
-    await expect(metrics.register.getSingleMetricAsString("libp2p_peers")).eventually.include("libp2p_peers 1");
+    await expect(metrics.register.getSingleMetricAsString("libp2p_peers")).eventually.match(/libp2p_peers({.+})? 1/);
     metrics.peers.set(20);
-    await expect(metrics.register.getSingleMetricAsString("libp2p_peers")).eventually.include("libp2p_peers 20");
+    await expect(metrics.register.getSingleMetricAsString("libp2p_peers")).eventually.match(/libp2p_peers({.+})? 20/);
   });
 });

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -99,6 +99,9 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
   // Collect NodeJS metrics defined in the Lodestar repo
 
   if (metrics) {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    register.setDefaultLabels({scrape_location: "validator"});
+
     collectNodeJSMetrics(register);
 
     const port = args["metrics.port"] ?? validatorMetricsDefaultOptions.port;


### PR DESCRIPTION
**Motivation**

Fixes metrics that use the `scrape_location` label and makes it independent from the deployment configuration i.e. it should not be required to set this label in prometheus configuration file which is currently also not the case, e.g. see [eth-docker lodestar jobs](https://github.com/eth-educators/eth-docker/blob/main/prometheus/ls-prom.yml).

**Description**

Adds the `scrape_location` as default label to beacon and validator node. See [prom-client default labels](https://github.com/siimon/prom-client#default-labels-segmented-by-registry) for more details about default labels.

Closes #4809
