### PR TITLE
Do not use peer_id to index API response

### DIFF
--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -33,11 +33,17 @@ export type GossipQueueItem = {
 };
 
 export type PeerScoreStat = {
+  peerId: string;
   lodestarScore: number;
   gossipScore: number;
   ignoreNegativeGossipScore: boolean;
   score: number;
   lastUpdate: number;
+};
+
+export type GossipPeerScoreStat = {
+  peerId: string;
+  // + Other un-typed options
 };
 
 export type RegenQueueItem = {
@@ -83,9 +89,9 @@ export type Api = {
   /** Dump a summary of the states in the CheckpointStateCache */
   getCheckpointStateCacheItems(): Promise<StateCacheItem[]>;
   /** Dump peer gossip stats by peer */
-  getGossipPeerScoreStats(): Promise<Record<string, unknown>>;
+  getGossipPeerScoreStats(): Promise<GossipPeerScoreStat[]>;
   /** Dump lodestar score stats by peer */
-  getLodestarPeerScoreStats(): Promise<Record<string, PeerScoreStat>>;
+  getLodestarPeerScoreStats(): Promise<PeerScoreStat[]>;
   /** Run GC with `global.gc()` */
   runGC(): Promise<void>;
   /** Drop all states in the state cache */

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -105,7 +105,7 @@ export function getLodestarApi({
     },
 
     async getGossipPeerScoreStats() {
-      return network.gossip.dumpPeerScoreStats();
+      return Object.entries(network.gossip.dumpPeerScoreStats()).map(([peerId, stats]) => ({peerId, ...stats}));
     },
 
     async getLodestarPeerScoreStats() {

--- a/packages/beacon-node/src/network/peers/score.ts
+++ b/packages/beacon-node/src/network/peers/score.ts
@@ -79,7 +79,7 @@ type PeerIdStr = string;
 export interface IPeerRpcScoreStore {
   getScore(peer: PeerId): number;
   getScoreState(peer: PeerId): ScoreState;
-  dumpPeerScoreStats(): Record<PeerIdStr, PeerScoreStat>;
+  dumpPeerScoreStats(): PeerScoreStats;
   applyAction(peer: PeerId, action: PeerAction, actionName: string): void;
   update(): void;
   updateGossipsubScore(peerId: PeerIdStr, newScore: number, ignore: boolean): void;
@@ -88,6 +88,8 @@ export interface IPeerRpcScoreStore {
 export interface IPeerRpcScoreStoreModules {
   metrics: IMetrics | null;
 }
+
+export type PeerScoreStats = ({peerId: PeerIdStr} & PeerScoreStat)[];
 
 export type PeerScoreStat = {
   lodestarScore: number;
@@ -121,12 +123,8 @@ export class PeerRpcScoreStore implements IPeerRpcScoreStore {
     return scoreToState(this.getScore(peer));
   }
 
-  dumpPeerScoreStats(): Record<PeerIdStr, PeerScoreStat> {
-    const peerStats: Record<PeerIdStr, PeerScoreStat> = {};
-    for (const [peerId, peerScore] of this.scores.entries()) {
-      peerStats[peerId] = peerScore.getStat();
-    }
-    return peerStats;
+  dumpPeerScoreStats(): PeerScoreStats {
+    return Array.from(this.scores.entries()).map(([peerId, peerScore]) => ({peerId, ...peerScore.getStat()}));
   }
 
   applyAction(peer: PeerId, action: PeerAction, actionName: string): void {


### PR DESCRIPTION
**Motivation**

- Fix to https://github.com/ChainSafe/lodestar/pull/4904

Using the peer_id in base58 as key renders poorly

```
curl http://localhost:9596/eth/v1/lodestar/lodestar-peer-score-stats
{"16_uiu2_h_am_c_xkwg_y_ckw_ww_xegyoj_xs8q_kq_bm_pmrajh_d_s3d_vu2o_c_w8n_z":{"lodestar_score":-3.9147850488702933,"gossip_score":0,"ignore_negative_gossip_score":false,"score":-3.9147850488702933,"last_update":1670902395574},"16_uiu2_h_am_sn_av8x_jn3_vgbw4_agtx9x_xw5_w9f4_h_vj8_f_twx_ye_ek_s_n8_to":{"lodestar_score":-1.9578086420665635,"gossip_score":0,"ignore_negative_gossip_score":false,"score":-1.9578086420665635,"last_update":1670902395574}
```

**Description**

- Do not use peer_id to index API response, instead return an array with object with property `peer_id`