### PR TITLE
Deduplicate rateLimitErrors metric

### DIFF
--- a/packages/reqresp/src/metrics.ts
+++ b/packages/reqresp/src/metrics.ts
@@ -101,9 +101,5 @@ export function getMetrics(register: MetricsRegister) {
       name: "beacon_reqresp_dial_errors_total",
       help: "Count total dial errors",
     }),
-    rateLimitErrors: register.gauge({
-      name: "beacon_reqresp_rate_limiter_errors_total",
-      help: "Count rate limiter errors",
-    }),
   };
 }


### PR DESCRIPTION
**Motivation**

Cannot start lodestar, got

```
Error: A metric with the name beacon_reqresp_rate_limiter_errors_total has already been registered.
```

**Description**

Same fix to https://github.com/ChainSafe/lodestar/pull/4808 that happened again after we merge https://github.com/ChainSafe/lodestar/pull/4828
