### PR TITLE
Revert the reqresp rate limit error metric

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -95,14 +95,6 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
       buckets: [1, 2, 3, 5, 7, 10, 20, 30, 50, 100],
     }),
 
-    reqResp: {
-      rateLimitErrors: register.gauge<"method">({
-        name: "beacon_reqresp_rate_limiter_errors_total",
-        help: "Count rate limiter errors",
-        labelNames: ["method"],
-      }),
-    },
-
     blockProductionTime: register.histogram({
       name: "beacon_block_production_seconds",
       help: "Full runtime of block production",

--- a/packages/reqresp/src/metrics.ts
+++ b/packages/reqresp/src/metrics.ts
@@ -101,5 +101,9 @@ export function getMetrics(register: MetricsRegister) {
       name: "beacon_reqresp_dial_errors_total",
       help: "Count total dial errors",
     }),
+    rateLimitErrors: register.gauge({
+      name: "beacon_reqresp_rate_limiter_errors_total",
+      help: "Count rate limiter errors",
+    }),
   };
 }


### PR DESCRIPTION
**Motivation**

Metrics related to the rate limiter should stay in `reqresp` package. 

**Description**

Revert the change made earlier and keep the metric in `reqresp` package


**Steps to test or reproduce**
Run all tests. 