### PR TITLE
Fix pre-genesis getForkInfo

### DIFF
--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -63,7 +63,7 @@ export function createIForkConfig(config: IChainConfig): IForkConfig {
 
     // Fork convenience methods
     getForkInfo(slot: Slot): IForkInfo {
-      const epoch = Math.floor(slot / SLOTS_PER_EPOCH);
+      const epoch = Math.floor(Math.max(slot, 0) / SLOTS_PER_EPOCH);
       // NOTE: forks must be sorted by descending epoch, latest fork first
       for (const fork of forksDescendingEpochOrder) {
         if (epoch >= fork.epoch) return fork;

--- a/packages/config/test/unit/index.test.ts
+++ b/packages/config/test/unit/index.test.ts
@@ -1,7 +1,8 @@
 import {expect} from "chai";
 import {ForkName} from "@lodestar/params";
 import {toHexString} from "@chainsafe/ssz";
-import {config} from "../../src/default.js";
+import {config, chainConfig} from "../../src/default.js";
+import {createIForkConfig} from "../../src/index.js";
 
 describe("forks", () => {
   it("Forks should be in ascending order", () => {
@@ -30,5 +31,11 @@ describe("forks", () => {
       expect(toHexString(fork.prevVersion)).to.equal(toHexString(prevFork.version), `Wrong prevVersion ${fork.name}`);
       expect(fork.prevForkName).to.equal(prevFork.name, `Wrong prevName ${fork.name}`);
     }
+  });
+
+  it("correctly handle pre-genesis", () => {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const postMergeTestnet = createIForkConfig({...chainConfig, ALTAIR_FORK_EPOCH: 0, BELLATRIX_FORK_EPOCH: 0});
+    expect(postMergeTestnet.getForkName(-1)).to.equal(ForkName.bellatrix);
   });
 });


### PR DESCRIPTION
**Motivation**

Bug described in discord:
https://discord.com/channels/593655374469660673/593655641445367808/1053037029925068900
Testnets starting in a non-phase0 fork were affected by incorrect `getForkInfo`

**Description**

`getForkInfo` of a pre-genesis slot should return the forkInfo at genesis