### PR TITLE
Handle getPayload response with blockValue

### DIFF
--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -446,8 +446,8 @@ type EngineApiRpcReturnTypes = {
    * payloadId | Error: QUANTITY, 64 Bits - Identifier of the payload building process
    */
   engine_getPayloadV1: ExecutionPayloadRpc;
-  engine_getPayloadV2: {executionPayload: ExecutionPayloadRpc; blockValue: QUANTITY};
-  engine_getPayloadV3: {executionPayload: ExecutionPayloadRpc; blockValue: QUANTITY};
+  engine_getPayloadV2: ExecutionPayloadRpcWithBlockValue;
+  engine_getPayloadV3: ExecutionPayloadRpcWithBlockValue;
   /**
    * Object - Instance of TransitionConfigurationV1
    */


### PR DESCRIPTION
Some execution engines have started providing the the getpayload response as {blockValue, executionPayload) on/post capella and all execution engines will move over to it
 - https://github.com/ethereum/execution-apis/pull/314/files

This PR provides for a robust way to deal with those who have moved and those who haven't post capella onwatds