### PR TITLE
Find more topic peers when subscribeAllSubnets

### DIFF
--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -73,11 +73,10 @@ export class AttnetsService implements IAttnetsService {
     // if subscribeAllSubnets, we act like we have >= ATTESTATION_SUBNET_COUNT validators connecting to this node
     // so that we have enough subnet topic peers
     // see https://github.com/ChainSafe/lodestar/issues/4921
-    const currentSlot = this.chain.clock.currentSlot;
     if (this.opts?.subscribeAllSubnets) {
       const requestedSubnets: RequestedSubnet[] = [];
       for (let subnet = 0; subnet < ATTESTATION_SUBNET_COUNT; subnet++) {
-        requestedSubnets.push({subnet, toSlot: randomSubscriptionSlotLen() + currentSlot});
+        requestedSubnets.push({subnet, toSlot: Infinity});
       }
       return requestedSubnets;
     }

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -70,6 +70,18 @@ export class AttnetsService implements IAttnetsService {
    * Get all active subnets for the hearbeat.
    */
   getActiveSubnets(): RequestedSubnet[] {
+    // if subscribeAllSubnets, we act like we have >= ATTESTATION_SUBNET_COUNT validators connecting to this node
+    // so that we have enough subnet topic peers
+    // see https://github.com/ChainSafe/lodestar/issues/4921
+    const currentSlot = this.chain.clock.currentSlot;
+    if (this.opts?.subscribeAllSubnets) {
+      const requestedSubnets: RequestedSubnet[] = [];
+      for (let subnet = 0; subnet < ATTESTATION_SUBNET_COUNT; subnet++) {
+        requestedSubnets.push({subnet, toSlot: randomSubscriptionSlotLen() + currentSlot});
+      }
+      return requestedSubnets;
+    }
+
     // Omit subscriptionsRandom, not necessary to force the network component to keep peers on that subnets
     return this.committeeSubnets.getActiveTtl(this.chain.clock.currentSlot);
   }


### PR DESCRIPTION
**Motivation**

- If we enable `subscribeAllSubnets` flag, we want the node to have some certain topic/mesh peers in each subnet, but right now we don't actively search for it

**Description**

- If we enable that flag, act like we have `ATTESTATION_SUBNET_COUNT` validators connecting to our node, i.e. actively search for nodes subscribing to requested subnets (which are all subnets in this case)
- This only happens on mainnet, on goerli I think there are a lot of peers subscribing to many/all subnets so it does not happen

Closes #4921