### PR TITLE
Ensure BLSToExecutionChange block inclusions are safe

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -102,8 +102,8 @@ export function getBeaconPoolApi({
       await Promise.all(
         blsToExecutionChanges.map(async (blsToExecutionChange, i) => {
           try {
-            await validateBlsToExecutionChange(chain, blsToExecutionChange);
-            chain.opPool.insertBlsToExecutionChange(blsToExecutionChange);
+            const {signatureEpoch} = await validateBlsToExecutionChange(chain, blsToExecutionChange);
+            chain.opPool.insertBlsToExecutionChange(blsToExecutionChange, signatureEpoch);
             await network.gossip.publishBlsToExecutionChange(blsToExecutionChange);
           } catch (e) {
             errors.push(e as Error);

--- a/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
+++ b/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
@@ -1,8 +1,9 @@
-import {capella} from "@lodestar/types";
+import {capella, Epoch} from "@lodestar/types";
 import {
   isValidBlsToExecutionChange,
   getBlsToExecutionChangeSignatureSet,
   CachedBeaconStateCapella,
+  computeEpochAtSlot,
 } from "@lodestar/state-transition";
 import {IBeaconChain} from "..";
 import {BlsToExecutionChangeError, BlsToExecutionChangeErrorCode, GossipAction} from "../errors/index.js";
@@ -10,7 +11,7 @@ import {BlsToExecutionChangeError, BlsToExecutionChangeErrorCode, GossipAction} 
 export async function validateBlsToExecutionChange(
   chain: IBeaconChain,
   blsToExecutionChange: capella.SignedBLSToExecutionChange
-): Promise<void> {
+): Promise<{signatureEpoch: Epoch}> {
   // [IGNORE] The blsToExecutionChange is the first valid blsToExecutionChange received for the validator with index
   // signedBLSToExecutionChange.message.validatorIndex.
   if (chain.opPool.hasSeenBlsToExecutionChange(blsToExecutionChange.message.validatorIndex)) {
@@ -37,4 +38,6 @@ export async function validateBlsToExecutionChange(
       code: BlsToExecutionChangeErrorCode.INVALID_SIGNATURE,
     });
   }
+
+  return {signatureEpoch: computeEpochAtSlot(state.slot)};
 }

--- a/packages/beacon-node/src/db/repositories/blsToExecutionChange.ts
+++ b/packages/beacon-node/src/db/repositories/blsToExecutionChange.ts
@@ -1,13 +1,14 @@
-import {capella, ssz, ValidatorIndex} from "@lodestar/types";
+import {ValidatorIndex} from "@lodestar/types";
 import {IChainForkConfig} from "@lodestar/config";
 import {Db, Bucket, Repository} from "@lodestar/db";
+import {SignedBLSToExecutionChangeVersioned, signedBLSToExecutionChangeVersionedType} from "../../util/types.js";
 
-export class BLSToExecutionChangeRepository extends Repository<ValidatorIndex, capella.SignedBLSToExecutionChange> {
+export class BLSToExecutionChangeRepository extends Repository<ValidatorIndex, SignedBLSToExecutionChangeVersioned> {
   constructor(config: IChainForkConfig, db: Db) {
-    super(config, db, Bucket.capella_blsToExecutionChange, ssz.capella.SignedBLSToExecutionChange);
+    super(config, db, Bucket.capella_blsToExecutionChange, signedBLSToExecutionChangeVersionedType);
   }
 
-  getId(value: capella.SignedBLSToExecutionChange): ValidatorIndex {
-    return value.message.validatorIndex;
+  getId(value: SignedBLSToExecutionChangeVersioned): ValidatorIndex {
+    return value.data.message.validatorIndex;
   }
 }

--- a/packages/beacon-node/src/network/gossip/handlers/index.ts
+++ b/packages/beacon-node/src/network/gossip/handlers/index.ts
@@ -347,11 +347,11 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
     },
     [GossipType.bls_to_execution_change]: async (blsToExecutionChange) => {
       // validate ?? - to do assuming returning true
-      await validateBlsToExecutionChange(chain, blsToExecutionChange);
+      const {signatureEpoch} = await validateBlsToExecutionChange(chain, blsToExecutionChange);
 
       // Handler
       try {
-        chain.opPool.insertBlsToExecutionChange(blsToExecutionChange);
+        chain.opPool.insertBlsToExecutionChange(blsToExecutionChange, signatureEpoch);
       } catch (e) {
         logger.error("Error adding blsToExecutionChange to pool", {}, e as Error);
       }

--- a/packages/beacon-node/src/util/types.ts
+++ b/packages/beacon-node/src/util/types.ts
@@ -1,0 +1,13 @@
+import {ContainerType, ValueOf} from "@chainsafe/ssz";
+import {ssz} from "@lodestar/types";
+
+// Misc SSZ types used only in the beacon-node package, no need to upstream to types
+
+export type SignedBLSToExecutionChangeVersioned = ValueOf<typeof signedBLSToExecutionChangeVersionedType>;
+export const signedBLSToExecutionChangeVersionedType = new ContainerType(
+  {
+    data: ssz.capella.SignedBLSToExecutionChange,
+    signatureEpoch: ssz.Epoch,
+  },
+  {jsonCase: "eth2", typeName: "SignedBLSToExecutionChangeVersionedType"}
+);


### PR DESCRIPTION
**Motivation**

BLSToExecutionChange on block processed are expected to have a signature domain at the state's epoch. Since we don't want to re-validate the BLS signature on block inclusion from the op-pool, we must track for what epoch that object was valid.

See related proposal to allow changes through multiple forks: https://github.com/ethereum/consensus-specs/pull/3168

**Description**

- Append `signature_epoch` to data structure.
- Prune on clock fork advance
