### PR TITLE
Move Lightclient REST transport to separate class

### DIFF
--- a/packages/cli/src/cmds/lightclient/handler.ts
+++ b/packages/cli/src/cmds/lightclient/handler.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import {getClient} from "@lodestar/api";
 import {Lightclient} from "@lodestar/light-client";
 import {fromHexString} from "@chainsafe/ssz";
+import {LightClientRestTransport} from "@lodestar/light-client/transport";
 import {getBeaconConfigFromArgs} from "../../config/beaconParams.js";
 import {getGlobalPaths} from "../../paths/global.js";
 import {IGlobalArgs} from "../../options/index.js";
@@ -20,12 +21,12 @@ export async function lightclientHandler(args: ILightClientArgs & IGlobalArgs): 
   const client = await Lightclient.initializeFromCheckpointRoot({
     config,
     logger,
-    beaconApiUrl,
     genesisData: {
       genesisTime: Number(genesisData.genesisTime),
       genesisValidatorsRoot: genesisData.genesisValidatorsRoot,
     },
     checkpointRoot: fromHexString(checkpointRoot),
+    transport: new LightClientRestTransport(api),
   });
 
   client.start();

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -25,6 +25,9 @@
     },
     "./spec": {
       "import": "./lib/spec/index.js"
+    },
+    "./transport": {
+      "import": "./lib/transport/index.js"
     }
   },
   "types": "./lib/index.d.ts",
@@ -69,7 +72,8 @@
     "@lodestar/types": "^1.2.1",
     "@lodestar/utils": "^1.2.1",
     "cross-fetch": "^3.1.4",
-    "mitt": "^3.0.0"
+    "mitt": "^3.0.0",
+    "strict-event-emitter-types": "^2.0.0"
   },
   "devDependencies": {
     "uint8arrays": "^4.0.2",

--- a/packages/light-client/src/events.ts
+++ b/packages/light-client/src/events.ts
@@ -1,22 +1,16 @@
 import {phase0} from "@lodestar/types";
 
 export enum LightclientEvent {
-  /**
-   * New head
-   */
-  head = "head",
-  /**
-   * New finalized
-   */
-  finalized = "finalized",
+  lightClientOptimisticUpdate = "light_client_optimistic_update",
+  lightClientFinalityUpdate = "light_client_finality_update",
 }
 
-export type LightclientEvents = {
-  [LightclientEvent.head]: (newHeader: phase0.BeaconBlockHeader) => void;
-  [LightclientEvent.finalized]: (newHeader: phase0.BeaconBlockHeader) => void;
+export type LightclientEmitterEvents = {
+  [LightclientEvent.lightClientOptimisticUpdate]: (newHeader: phase0.BeaconBlockHeader) => void;
+  [LightclientEvent.lightClientFinalityUpdate]: (newHeader: phase0.BeaconBlockHeader) => void;
 };
 
-export type LightclientEmitter = MittEmitter<LightclientEvents>;
+export type LightclientEmitter = MittEmitter<LightclientEmitterEvents>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type MittEmitter<T extends Record<string, (...args: any[]) => void>> = {

--- a/packages/light-client/src/transport/index.ts
+++ b/packages/light-client/src/transport/index.ts
@@ -1,0 +1,2 @@
+export * from "./interface.js";
+export * from "./rest.js";

--- a/packages/light-client/src/transport/interface.ts
+++ b/packages/light-client/src/transport/interface.ts
@@ -1,0 +1,31 @@
+import {altair, SyncPeriod} from "@lodestar/types";
+import {ForkName} from "@lodestar/params";
+
+export interface LightClientTransport {
+  getUpdates(
+    startPeriod: SyncPeriod,
+    count: number
+  ): Promise<
+    {
+      version: ForkName;
+      data: altair.LightClientUpdate;
+    }[]
+  >;
+  /**
+   * Returns the latest optimistic head update available. Clients should use the SSE type `light_client_optimistic_update`
+   * unless to get the very first head update after syncing, or if SSE are not supported by the server.
+   */
+  getOptimisticUpdate(): Promise<{version: ForkName; data: altair.LightClientOptimisticUpdate}>;
+  getFinalityUpdate(): Promise<{version: ForkName; data: altair.LightClientFinalityUpdate}>;
+  /**
+   * Fetch a bootstrapping state with a proof to a trusted block root.
+   * The trusted block root should be fetched with similar means to a weak subjectivity checkpoint.
+   * Only block roots for checkpoints are guaranteed to be available.
+   */
+  getBootstrap(blockRoot: string): Promise<{version: ForkName; data: altair.LightClientBootstrap}>;
+
+  // registers handler for LightClientOptimisticUpdate. This can come either via sse or p2p
+  onOptimisticUpdate(handler: (optimisticUpdate: altair.LightClientOptimisticUpdate) => void): void;
+  // registers handler for LightClientFinalityUpdate. This can come either via sse or p2p
+  onFinalityUpdate(handler: (finalityUpdate: altair.LightClientFinalityUpdate) => void): void;
+}

--- a/packages/light-client/src/transport/rest.ts
+++ b/packages/light-client/src/transport/rest.ts
@@ -1,0 +1,83 @@
+import EventEmitter from "events";
+import StrictEventEmitter from "strict-event-emitter-types";
+import {allForks, altair, SyncPeriod} from "@lodestar/types";
+import {Api, routes} from "@lodestar/api";
+import {ForkName} from "@lodestar/params";
+import {LightClientTransport} from "./interface.js";
+
+export type LightClientRestEvents = {
+  [routes.events.EventType.lightClientFinalityUpdate]: altair.LightClientFinalityUpdate;
+  [routes.events.EventType.lightClientOptimisticUpdate]: altair.LightClientOptimisticUpdate;
+};
+
+type RestEvents = StrictEventEmitter<EventEmitter, LightClientRestEvents>;
+
+export class LightClientRestTransport extends (EventEmitter as {new (): RestEvents}) implements LightClientTransport {
+  private controller = new AbortController();
+  private readonly eventEmitter: StrictEventEmitter<EventEmitter, LightClientRestEvents> = new EventEmitter();
+  private subscribedEventstream = false;
+
+  constructor(private readonly api: Api) {
+    super();
+  }
+
+  getUpdates(
+    startPeriod: SyncPeriod,
+    count: number
+  ): Promise<
+    {
+      version: ForkName;
+      data: altair.LightClientUpdate;
+    }[]
+  > {
+    return this.api.lightclient.getUpdates(startPeriod, count);
+  }
+
+  getOptimisticUpdate(): Promise<{version: ForkName; data: altair.LightClientOptimisticUpdate}> {
+    return this.api.lightclient.getOptimisticUpdate();
+  }
+
+  getFinalityUpdate(): Promise<{version: ForkName; data: altair.LightClientFinalityUpdate}> {
+    return this.api.lightclient.getFinalityUpdate();
+  }
+
+  getBootstrap(blockRoot: string): Promise<{version: ForkName; data: altair.LightClientBootstrap}> {
+    return this.api.lightclient.getBootstrap(blockRoot);
+  }
+
+  fetchBlock(blockRootAsString: string): Promise<{version: ForkName; data: allForks.SignedBeaconBlock}> {
+    return this.api.beacon.getBlockV2(blockRootAsString);
+  }
+
+  onOptimisticUpdate(handler: (optimisticUpdate: altair.LightClientOptimisticUpdate) => void): void {
+    this.subscribeEventstream();
+    this.eventEmitter.on(routes.events.EventType.lightClientOptimisticUpdate, handler);
+  }
+
+  onFinalityUpdate(handler: (finalityUpdate: altair.LightClientFinalityUpdate) => void): void {
+    this.subscribeEventstream();
+    this.eventEmitter.on(routes.events.EventType.lightClientFinalityUpdate, handler);
+  }
+
+  private subscribeEventstream(): void {
+    if (this.subscribedEventstream) {
+      return;
+    }
+
+    this.api.events.eventstream(
+      [routes.events.EventType.lightClientOptimisticUpdate, routes.events.EventType.lightClientFinalityUpdate],
+      this.controller.signal,
+      (event) => {
+        switch (event.type) {
+          case routes.events.EventType.lightClientOptimisticUpdate:
+            this.eventEmitter.emit(routes.events.EventType.lightClientOptimisticUpdate, event.message);
+            break;
+
+          case routes.events.EventType.lightClientFinalityUpdate:
+            this.eventEmitter.emit(routes.events.EventType.lightClientFinalityUpdate, event.message);
+            break;
+        }
+      }
+    );
+  }
+}

--- a/packages/light-client/test/unit/sync.node.test.ts
+++ b/packages/light-client/test/unit/sync.node.test.ts
@@ -23,6 +23,7 @@ import {
 import {startServer, ServerOpts} from "../utils/server.js";
 import {isNode} from "../../src/utils/utils.js";
 import {computeSyncPeriodAtSlot} from "../../src/utils/clock.js";
+import {LightClientRestTransport} from "../../src/transport/rest.js";
 
 const SOME_HASH = Buffer.alloc(32, 0xff);
 


### PR DESCRIPTION
**Motivation**

- PR https://github.com/ChainSafe/lodestar/pull/4819 is blocked on extracting execution engine package

We don't need to wait for that to happen to apply the LightClientTransport pattern now. This PRs moves the REST logic into a separate class.

**Description**

This move is very easy because the existing lightclient implements assumes that transport is REST only. Once we bring p2p, things will get **much** more complex.

Some open questions:
- get proof capability must be dropped from a generic transport since current p2p does not support that
- the p2p transport requires as dependencies: ReqResp, Gossip, discv5, Peer managment, etc.
- the transport instance of p2p requires access to the lightclient state to respond to ResResp requests. This creates a ciruclar dependency that makes the pattern `const lightclient = new Lightclient(lightclientTransportP2p)` very ugly