### PR TITLE
Track BlsToExecutionChange fork signature instead of head's fork

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -99,11 +99,14 @@ export function getBeaconPoolApi({
     async submitPoolBlsToExecutionChange(blsToExecutionChanges) {
       const errors: Error[] = [];
 
+      // TODO CAPELLA: Which fork should assume to validate submitted execution changes?
+      const signatureFork = chain.config.getForkName(chain.clock.currentSlot);
+
       await Promise.all(
         blsToExecutionChanges.map(async (blsToExecutionChange, i) => {
           try {
-            const {signatureEpoch} = await validateBlsToExecutionChange(chain, blsToExecutionChange);
-            chain.opPool.insertBlsToExecutionChange(blsToExecutionChange, signatureEpoch);
+            await validateBlsToExecutionChange(chain, blsToExecutionChange, signatureFork);
+            chain.opPool.insertBlsToExecutionChange(blsToExecutionChange, signatureFork);
             await network.gossip.publishBlsToExecutionChange(blsToExecutionChange);
           } catch (e) {
             errors.push(e as Error);

--- a/packages/beacon-node/src/chain/opPools/utils.ts
+++ b/packages/beacon-node/src/chain/opPools/utils.ts
@@ -1,7 +1,7 @@
 import bls from "@chainsafe/bls";
 import {CoordType, Signature} from "@chainsafe/bls/types";
 import {BLS_WITHDRAWAL_PREFIX} from "@lodestar/params";
-import {CachedBeaconStateCapella, computeEpochAtSlot} from "@lodestar/state-transition";
+import {CachedBeaconStateCapella} from "@lodestar/state-transition";
 import {Slot} from "@lodestar/types";
 import {SignedBLSToExecutionChangeVersioned} from "../../util/types.js";
 
@@ -63,7 +63,7 @@ export function isValidBlsToExecutionChangeForBlockInclusion(
   //    the fork it was valid, is still the current fork
   //
   // TODO CAPELLA: Ensure that the fork at witch the signature was verified is the same as the state's fork
-  if (signedBLSToExecutionChange.signatureEpoch !== computeEpochAtSlot(state.slot)) {
+  if (signedBLSToExecutionChange.signatureForkSeq !== state.config.getForkSeq(state.slot)) {
     return false;
   }
 

--- a/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
+++ b/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
@@ -1,17 +1,19 @@
-import {capella, Epoch} from "@lodestar/types";
+import {capella} from "@lodestar/types";
 import {
   isValidBlsToExecutionChange,
   getBlsToExecutionChangeSignatureSet,
   CachedBeaconStateCapella,
-  computeEpochAtSlot,
+  computeStartSlotAtEpoch,
 } from "@lodestar/state-transition";
+import {ForkName} from "@lodestar/params";
 import {IBeaconChain} from "..";
 import {BlsToExecutionChangeError, BlsToExecutionChangeErrorCode, GossipAction} from "../errors/index.js";
 
 export async function validateBlsToExecutionChange(
   chain: IBeaconChain,
-  blsToExecutionChange: capella.SignedBLSToExecutionChange
-): Promise<{signatureEpoch: Epoch}> {
+  blsToExecutionChange: capella.SignedBLSToExecutionChange,
+  signatureFork: ForkName
+): Promise<void> {
   // [IGNORE] The blsToExecutionChange is the first valid blsToExecutionChange received for the validator with index
   // signedBLSToExecutionChange.message.validatorIndex.
   if (chain.opPool.hasSeenBlsToExecutionChange(blsToExecutionChange.message.validatorIndex)) {
@@ -21,7 +23,10 @@ export async function validateBlsToExecutionChange(
   }
 
   // validate bls to executionChange
-  const state = await chain.getHeadStateAtCurrentEpoch();
+  // NOTE: No need to advance head state since the signature's fork is handled with `broadcastedOnFork`,
+  // and chanes relevant to `isValidBlsToExecutionChange()` happen only on processBlock(), not processEpoch()
+  const state = chain.getHeadState();
+  const {config} = state;
 
   // [REJECT] All of the conditions within process_bls_to_execution_change pass validation.
   // verifySignature = false, verified in batch below
@@ -32,12 +37,12 @@ export async function validateBlsToExecutionChange(
     });
   }
 
-  const signatureSet = getBlsToExecutionChangeSignatureSet(state, blsToExecutionChange);
+  const signatureSlot = computeStartSlotAtEpoch(config.forks[signatureFork].epoch);
+
+  const signatureSet = getBlsToExecutionChangeSignatureSet(config, signatureSlot, blsToExecutionChange);
   if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true}))) {
     throw new BlsToExecutionChangeError(GossipAction.REJECT, {
       code: BlsToExecutionChangeErrorCode.INVALID_SIGNATURE,
     });
   }
-
-  return {signatureEpoch: computeEpochAtSlot(state.slot)};
 }

--- a/packages/beacon-node/src/network/gossip/handlers/index.ts
+++ b/packages/beacon-node/src/network/gossip/handlers/index.ts
@@ -345,13 +345,13 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
     [GossipType.light_client_optimistic_update]: async (lightClientOptimisticUpdate) => {
       validateLightClientOptimisticUpdate(config, chain, lightClientOptimisticUpdate);
     },
-    [GossipType.bls_to_execution_change]: async (blsToExecutionChange) => {
-      // validate ?? - to do assuming returning true
-      const {signatureEpoch} = await validateBlsToExecutionChange(chain, blsToExecutionChange);
+
+    [GossipType.bls_to_execution_change]: async (blsToExecutionChange, topic) => {
+      await validateBlsToExecutionChange(chain, blsToExecutionChange, topic.fork);
 
       // Handler
       try {
-        chain.opPool.insertBlsToExecutionChange(blsToExecutionChange, signatureEpoch);
+        chain.opPool.insertBlsToExecutionChange(blsToExecutionChange, topic.fork);
       } catch (e) {
         logger.error("Error adding blsToExecutionChange to pool", {}, e as Error);
       }

--- a/packages/beacon-node/src/util/types.ts
+++ b/packages/beacon-node/src/util/types.ts
@@ -6,8 +6,9 @@ import {ssz} from "@lodestar/types";
 export type SignedBLSToExecutionChangeVersioned = ValueOf<typeof signedBLSToExecutionChangeVersionedType>;
 export const signedBLSToExecutionChangeVersionedType = new ContainerType(
   {
+    // Assumes less than 256 forks, sounds reasonable in our lifetime
+    signatureForkSeq: ssz.Uint8,
     data: ssz.capella.SignedBLSToExecutionChange,
-    signatureEpoch: ssz.Epoch,
   },
   {jsonCase: "eth2", typeName: "SignedBLSToExecutionChangeVersionedType"}
 );

--- a/packages/beacon-node/test/unit/chain/validation/blsToExecutionChange.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/blsToExecutionChange.test.ts
@@ -78,6 +78,8 @@ describe("validate bls to execution change", () => {
   const _state = generateState(stateEmpty, config);
   const state = createCachedBeaconStateTest(_state, createIBeaconConfig(config, _state.genesisValidatorsRoot));
 
+  const signatureFork = config.getForkName(state.slot);
+
   // Gen a valid blsToExecutionChange for first val
   const blsToExecutionChange = {
     validatorIndex: 0,
@@ -116,13 +118,13 @@ describe("validate bls to execution change", () => {
     opPool.hasSeenBlsToExecutionChange.returns(true);
 
     await expectRejectedWithLodestarError(
-      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
+      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid, signatureFork),
       BlsToExecutionChangeErrorCode.ALREADY_EXISTS
     );
   });
 
   it("should return valid blsToExecutionChange ", async () => {
-    await validateBlsToExecutionChange(chainStub, signedBlsToExecChange);
+    await validateBlsToExecutionChange(chainStub, signedBlsToExecChange, signatureFork);
   });
 
   it("should return invalid bls to execution Change - invalid validatorIndex", async () => {
@@ -136,7 +138,7 @@ describe("validate bls to execution change", () => {
     };
 
     await expectRejectedWithLodestarError(
-      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
+      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid, signatureFork),
       BlsToExecutionChangeErrorCode.INVALID
     );
   });
@@ -151,7 +153,7 @@ describe("validate bls to execution change", () => {
     };
 
     await expectRejectedWithLodestarError(
-      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
+      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid, signatureFork),
       BlsToExecutionChangeErrorCode.INVALID
     );
   });
@@ -167,7 +169,7 @@ describe("validate bls to execution change", () => {
     };
 
     await expectRejectedWithLodestarError(
-      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
+      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid, signatureFork),
       BlsToExecutionChangeErrorCode.INVALID
     );
   });
@@ -183,7 +185,7 @@ describe("validate bls to execution change", () => {
     };
 
     await expectRejectedWithLodestarError(
-      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
+      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid, signatureFork),
       BlsToExecutionChangeErrorCode.INVALID
     );
   });

--- a/packages/beacon-node/test/unit/chain/validation/blsToExecutionChange.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/blsToExecutionChange.test.ts
@@ -99,7 +99,7 @@ describe("validate bls to execution change", () => {
     chainStub.forkChoice = sandbox.createStubInstance(ForkChoice);
     opPool = sandbox.createStubInstance(OpPool) as OpPool & SinonStubbedInstance<OpPool>;
     (chainStub as {opPool: OpPool}).opPool = opPool;
-    chainStub.getHeadStateAtCurrentEpoch.resolves(state);
+    chainStub.getHeadState.returns(state);
     // TODO: Use actual BLS verification
     chainStub.bls = new BlsVerifierMock(true);
   });

--- a/packages/state-transition/src/signatureSets/blsToExecutionChange.ts
+++ b/packages/state-transition/src/signatureSets/blsToExecutionChange.ts
@@ -1,5 +1,6 @@
 import {DOMAIN_BLS_TO_EXECUTION_CHANGE} from "@lodestar/params";
-import {capella, ssz} from "@lodestar/types";
+import {capella, Slot, ssz} from "@lodestar/types";
+import {IBeaconConfig} from "@lodestar/config";
 import bls from "@chainsafe/bls";
 import {CoordType} from "@chainsafe/bls/types";
 
@@ -10,17 +11,18 @@ export function verifyBlsToExecutionChangeSignature(
   state: CachedBeaconStateAllForks,
   signedBLSToExecutionChange: capella.SignedBLSToExecutionChange
 ): boolean {
-  return verifySignatureSet(getBlsToExecutionChangeSignatureSet(state, signedBLSToExecutionChange));
+  return verifySignatureSet(getBlsToExecutionChangeSignatureSet(state.config, state.slot, signedBLSToExecutionChange));
 }
 
 /**
  * Extract signatures to allow validating all block signatures at once
  */
 export function getBlsToExecutionChangeSignatureSet(
-  state: CachedBeaconStateAllForks,
+  config: IBeaconConfig,
+  signatureSlot: Slot,
   signedBLSToExecutionChange: capella.SignedBLSToExecutionChange
 ): ISignatureSet {
-  const domain = state.config.getDomain(state.slot, DOMAIN_BLS_TO_EXECUTION_CHANGE);
+  const domain = config.getDomain(signatureSlot, DOMAIN_BLS_TO_EXECUTION_CHANGE);
 
   return {
     type: SignatureSetType.single,
@@ -33,10 +35,11 @@ export function getBlsToExecutionChangeSignatureSet(
 }
 
 export function getBlsToExecutionChangeSignatureSets(
-  state: CachedBeaconStateAllForks,
+  config: IBeaconConfig,
+  signatureSlot: Slot,
   signedBlock: capella.SignedBeaconBlock
 ): ISignatureSet[] {
   return signedBlock.message.body.blsToExecutionChanges.map((blsToExecutionChange) =>
-    getBlsToExecutionChangeSignatureSet(state, blsToExecutionChange)
+    getBlsToExecutionChangeSignatureSet(config, signatureSlot, blsToExecutionChange)
   );
 }

--- a/packages/state-transition/src/signatureSets/index.ts
+++ b/packages/state-transition/src/signatureSets/index.ts
@@ -1,7 +1,7 @@
 import {ForkSeq} from "@lodestar/params";
 import {allForks, altair, capella} from "@lodestar/types";
 import {ISignatureSet} from "../util/index.js";
-import {CachedBeaconStateAllForks, CachedBeaconStateAltair, CachedBeaconStateCapella} from "../types.js";
+import {CachedBeaconStateAllForks, CachedBeaconStateAltair} from "../types.js";
 import {getSyncCommitteeSignatureSet} from "../block/processSyncCommittee.js";
 import {getProposerSlashingsSignatureSets} from "./proposerSlashings.js";
 import {getAttesterSlashingsSignatureSets} from "./attesterSlashings.js";
@@ -61,7 +61,8 @@ export function getBlockSignatureSets(
   // only after capella fork
   if (fork >= ForkSeq.capella) {
     const blsToExecutionChangeSignatureSets = getBlsToExecutionChangeSignatureSets(
-      state as CachedBeaconStateCapella,
+      state.config,
+      state.slot,
       signedBlock as capella.SignedBeaconBlock
     );
     if (blsToExecutionChangeSignatureSets.length > 0) {


### PR DESCRIPTION
**Motivation**

- After reviewing https://github.com/ChainSafe/lodestar/pull/4923 we should not assume the head's fork is correct but instead use the "submitted fork" as correct

**Description**

@g11tech Let's sit on this one for some hours to ensure it feels right.

- Track BlsToExecutionChange fork signature instead of head's fork
- TODO: beacon API should provide with what fork that message was signed