### PR TITLE
Publishes Grafana and Prometheus images for monitoring.

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push
+      - name: Build and push lodestar
         run: >
           docker buildx build . --push
           --tag chainsafe/lodestar:next
@@ -130,3 +130,18 @@ jobs:
       # Display history to know byte size of each layer
       # Image is available only because of the previous `docker run` command
       - run: docker image history chainsafe/lodestar:next
+
+      - name: Build and push custom Grafana
+        run: >
+          docker buildx build ./docker/grafana/ --push
+          --file ./docker/grafana/Dockerfile
+          --build-context dashboards=./dashboards
+          --tag chainsafe/lodestar-grafana:next
+          --platform linux/amd64,linux/arm64
+
+      - name: Build and push custom Prometheus
+        run: >
+          docker buildx build ./docker/prometheus/ --push
+          --file ./docker/prometheus/Dockerfile
+          --tag chainsafe/lodestar-prometheus:next
+          --platform linux/amd64,linux/arm64

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -155,3 +155,18 @@ jobs:
       # Display history to know byte size of each layer
       # Image is available only because of the previous `docker run` command
       - run: docker image history chainsafe/lodestar:${{ needs.tag.outputs.tag }}
+
+      - name: Build and push custom Grafana
+        run: >
+          docker buildx build ./docker/grafana/ --push
+          --file ./docker/grafana/Dockerfile
+          --build-context dashboards=./dashboards
+          --tag chainsafe/lodestar-grafana:${{ needs.tag.outputs.tag }}
+          --platform linux/amd64,linux/arm64
+
+      - name: Build and push custom Prometheus
+        run: >
+          docker buildx build ./docker/prometheus/ --push
+          --file ./docker/prometheus/Dockerfile
+          --tag chainsafe/lodestar-prometheus:${{ needs.tag.outputs.tag }}
+          --platform linux/amd64,linux/arm64

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -145,3 +145,18 @@ jobs:
       # Display history to know byte size of each layer
       # Image is available only because of the previous `docker run` command
       - run: docker image history chainsafe/lodestar:${{ needs.tag.outputs.tag }}
+
+      - name: Build and push custom Grafana
+        run: >
+          docker buildx build ./docker/grafana/ --push
+          --file ./docker/grafana/Dockerfile
+          --build-context dashboards=./dashboards
+          --tag chainsafe/lodestar-grafana:${{ needs.tag.outputs.tag }}
+          --platform linux/amd64,linux/arm64
+
+      - name: Build and push custom Prometheus
+        run: >
+          docker buildx build ./docker/prometheus/ --push
+          --file ./docker/prometheus/Dockerfile
+          --tag chainsafe/lodestar-prometheus:${{ needs.tag.outputs.tag }}
+          --platform linux/amd64,linux/arm64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - "3000:3000"
     volumes:
       - "grafana:/var/lib/grafana"
-      - "./dashboards:/dashboards"
+      - "grafana-dashboards:/dashboards"
     environment:
       GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
 
@@ -39,3 +39,4 @@ volumes:
   logs:
   prometheus:
   grafana:
+  grafana-dashboards:

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -27,7 +27,7 @@ services:
     network_mode: host
     volumes:
       - "grafana:/var/lib/grafana"
-      - "../dashboards:/dashboards"
+      - "grafana-dashboards:/dashboards"
     environment:
       # Linux:  http://localhost:9090
       # MacOSX: http://host.docker.internal:9090
@@ -36,3 +36,4 @@ services:
 volumes:
   prometheus:
   grafana:
+  grafana-dashboards:

--- a/docker/grafana/Dockerfile
+++ b/docker/grafana/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.4
+
 # Same version as our ansible deployments, to minimize the diff in the dashboard on export
 FROM grafana/grafana:8.4.2
 
@@ -5,11 +7,12 @@ FROM grafana/grafana:8.4.2
 COPY datasource.yml /etc/grafana/provisioning/datasources/datasource.yml
 # Note: Dashboard as linked via a bind volume
 COPY dashboard.yml /etc/grafana/provisioning/dashboards/dashboard.yml
+# copy over some reasonable default dashboards, user can mount a volume over top of it
+COPY --from=dashboards . /dashboards/
+VOLUME /dashboards
 
-# Set GF_SECURITY_ADMIN_PASSWORD=your-password to the root .env file
-ARG GF_SECURITY_ADMIN_PASSWORD
-ENV GF_SECURITY_ADMIN_USER=admin \
-  GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD}
+ENV GF_SECURITY_ADMIN_USER=admin
+ENV GF_SECURITY_ADMIN_PASSWORD=admin
 
 # Modified datasource to work with a network_mode: host
 ENV PROMETHEUS_URL=http://prometheus:9090

--- a/docker/prometheus/Dockerfile
+++ b/docker/prometheus/Dockerfile
@@ -1,16 +1,16 @@
 FROM prom/prometheus:latest
 
 COPY prometheus.yml /etc/prometheus/prometheus.yml
+COPY entrypoint.sh /prometheus/entrypoint.sh
 
 # Modified datasource to work with a network_mode: host
 # Docker DNS: "beacon_node:8008"
 # net host: "localhost:8008"
 # MacOSX: "host.docker.internal:8008"
-ARG BEACON_URL
-ARG VC_URL
-RUN sed -i 's/#BEACON_URL/'"$BEACON_URL"'/' /etc/prometheus/prometheus.yml
-RUN sed -i 's/#VC_URL/'"$VC_URL"'/' /etc/prometheus/prometheus.yml
-RUN cat /etc/prometheus/prometheus.yml
+ENV BEACON_URL='beacon_node:8008'
+ENV VC_URL='validator'
+
+ENTRYPOINT ["/prometheus/entrypoint.sh"]
 
 CMD [ \
   "--config.file=/etc/prometheus/prometheus.yml", \

--- a/docker/prometheus/entrypoint.sh
+++ b/docker/prometheus/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+sed -i 's/#BEACON_URL/'"$BEACON_URL"'/' /etc/prometheus/prometheus.yml
+sed -i 's/#VC_URL/'"$VC_URL"'/' /etc/prometheus/prometheus.yml
+cat /etc/prometheus/prometheus.yml
+exec /bin/prometheus $*


### PR DESCRIPTION
**Motivation**

I run lodestar in a fully dockerized environment and it is non-trivial to add grafana/prometheus at the moment.  This is because configuration of these two images is done at build time rather than runtime, and they aren't published anywhere.  As a user, if I want to add monitoring to my docker hosted Lodestar instance I would need to:
1. clone this repository somewhere
2. setup some configuration in .env files and such
3. docker build
4. docker publish
5. go to my production environment and add new entries for each.

After this change, I can skip to step 5.

**Description**

Prometheus only supports configuration by file, so in order to support runtime configuration via environment we have to switch over to using an entrypoint script. `exec` will make it so `/bin/prometheus` will take over PID 1, which ensures that signals get processed correctly. I picked some reasonable defaults for BEACON_URL and VC_URL, but I'm happy to change them to whatever.

Grafana requires building with a second context because the dashboards folder is outside of the docker folder. This requires a relatively up-to-date version of docker and I'm *hoping* GitHub actions supports it. Users should be able to mount a volume of their choosing targeting `/dashboards` if they want their own dashboards to be retained on top of the default set.

Grafana build was setting the admin password at build time, but that should be set at runtime. I set the default password to `admin` under the assumption that the user will have to go out of their way to expose the service and hopefully they'll change the password when they do.  😬

I added two new build/push steps to each of the GitHub action workflows that follow the tagging convention of `chainsafe/lodestar`. I suspect some other name will be desired like `chainsafe/lodestar-grafana` and I'm happy to change it to whatever.