### PR TITLE
Fix random subnet subscription

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -294,6 +294,48 @@ export function createLodestarMetrics(
       buckets: [0.1, 1, 10, 100],
     }),
 
+    attnetsService: {
+      committeeSubnets: register.gauge({
+        name: "lodestar_attnets_service_committee_subnets_total",
+        help: "Count of committee subnets",
+      }),
+      subscriptionsCommittee: register.gauge({
+        name: "lodestar_attnets_service_committee_subscriptions_total",
+        help: "Count of committee subscriptions",
+      }),
+      subscriptionsRandom: register.gauge({
+        name: "lodestar_attnets_service_random_subscriptions_total",
+        help: "Count of random subscriptions",
+      }),
+      subscribeSubnets: register.gauge<"subnet" | "src">({
+        name: "lodestar_attnets_service_subscribe_subnets_total",
+        help: "Count of subscribe_subnets calls",
+        labelNames: ["subnet", "src"],
+      }),
+      unsubscribeSubnets: register.gauge<"subnet" | "src">({
+        name: "lodestar_attnets_service_unsubscribe_subnets_total",
+        help: "Count of unsubscribe_subnets calls",
+        labelNames: ["subnet", "src"],
+      }),
+    },
+
+    syncnetsService: {
+      subscriptionsCommittee: register.gauge({
+        name: "lodestar_syncnets_service_committee_subscriptions_total",
+        help: "Count of syncnet committee subscriptions",
+      }),
+      subscribeSubnets: register.gauge<"subnet">({
+        name: "lodestar_syncnets_service_subscribe_subnets_total",
+        help: "Count of syncnet subscribe_subnets calls",
+        labelNames: ["subnet"],
+      }),
+      unsubscribeSubnets: register.gauge<"subnet">({
+        name: "lodestar_syncnets_service_unsubscribe_subnets_total",
+        help: "Count of syncnet unsubscribe_subnets calls",
+        labelNames: ["subnet"],
+      }),
+    },
+
     regenQueue: {
       length: register.gauge({
         name: "lodestar_regen_queue_length",

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -104,8 +104,8 @@ export class Network implements INetwork {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     void this.gossip.init((libp2p as any).components).catch((e) => this.logger.error(e));
 
-    this.attnetsService = new AttnetsService(config, chain, this.gossip, metadata, logger, opts);
-    this.syncnetsService = new SyncnetsService(config, chain, this.gossip, metadata, logger, opts);
+    this.attnetsService = new AttnetsService(config, chain, this.gossip, metadata, logger, metrics, opts);
+    this.syncnetsService = new SyncnetsService(config, chain, this.gossip, metadata, logger, metrics, opts);
 
     this.peerManager = new PeerManager(
       {

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -192,8 +192,9 @@ export class AttnetsService implements IAttnetsService {
    */
   private unsubscribeExpiredCommitteeSubnets(slot: Slot): void {
     const expired = this.subscriptionsCommittee.getExpired(slot);
-    if (expired.length === 0) return;
-    this.unsubscribeSubnets(expired, slot, SubnetSource.committee);
+    if (expired.length > 0) {
+      this.unsubscribeSubnets(expired, slot, SubnetSource.committee);
+    }
   }
 
   /**
@@ -205,7 +206,9 @@ export class AttnetsService implements IAttnetsService {
     const expired = this.subscriptionsRandom.getExpired(slot);
     const currentSlot = this.chain.clock.currentSlot;
 
-    if (expired.length === 0) return;
+    if (expired.length === 0) {
+      return;
+    }
 
     if (this.knownValidators.size * RANDOM_SUBNETS_PER_VALIDATOR >= ATTESTATION_SUBNET_COUNT) {
       // Optimization: If we have to be subcribed to all subnets, no need to unsubscribe. Just extend the timeout

--- a/packages/beacon-node/src/network/subnets/interface.ts
+++ b/packages/beacon-node/src/network/subnets/interface.ts
@@ -28,7 +28,7 @@ export type ShuffleFn = <T>(arr: T[]) => T[];
 
 export type SubnetsServiceOpts = {
   subscribeAllSubnets?: boolean;
-  // For unit test
+  // For deterministic randomness in unit test after ESM prevents simple import mocking
   randBetweenFn?: RandBetweenFn;
   shuffleFn?: ShuffleFn;
 };

--- a/packages/beacon-node/src/network/subnets/interface.ts
+++ b/packages/beacon-node/src/network/subnets/interface.ts
@@ -23,6 +23,10 @@ export interface IAttnetsService extends ISubnetsService {
   shouldProcess(subnet: number, slot: Slot): boolean;
 }
 
+export type RandBetweenFn = (min: number, max: number) => number;
+
 export type SubnetsServiceOpts = {
   subscribeAllSubnets?: boolean;
+  // For unit test
+  randBetweenFn?: RandBetweenFn;
 };

--- a/packages/beacon-node/src/network/subnets/interface.ts
+++ b/packages/beacon-node/src/network/subnets/interface.ts
@@ -24,9 +24,11 @@ export interface IAttnetsService extends ISubnetsService {
 }
 
 export type RandBetweenFn = (min: number, max: number) => number;
+export type ShuffleFn = <T>(arr: T[]) => T[];
 
 export type SubnetsServiceOpts = {
   subscribeAllSubnets?: boolean;
   // For unit test
   randBetweenFn?: RandBetweenFn;
+  shuffleFn?: ShuffleFn;
 };

--- a/packages/beacon-node/test/unit/network/attestationService.test.ts
+++ b/packages/beacon-node/test/unit/network/attestationService.test.ts
@@ -73,7 +73,7 @@ describe("AttnetsService", function () {
     // load getCurrentSlot first, vscode not able to debug without this
     getCurrentSlot(config, Math.floor(Date.now() / 1000));
     metadata = new MetadataController({}, {config, chain, logger});
-    service = new AttnetsService(config, chain, gossipStub, metadata, logger, {
+    service = new AttnetsService(config, chain, gossipStub, metadata, logger, null, {
       randBetweenFn,
       shuffleFn: shuffleFn as ShuffleFn,
     });


### PR DESCRIPTION
**Motivation**

- Random subscription starts at a random slot in epoch and unsubscribed per `onEpoch` check so there are some inactive slots. This is unexpected because for a node with >= 64 validators we want to always subscribe to all random subnets
- During the inactive slots, a committee subscription may be expired and we unsubscribe the subnet topic
- Due to this change in v1.3.0 #4829 we don't have a chance to rebalance random subscriptions

**Description**

- Check the random subscription per `onSlot` instead of `onEpoch`, do it before committee subscription
- Bring back attnetsService unit test, reproduce the issue in a test case. Since ESM support, there is `ES Modules cannot be stubbed` error so I have to put in `randBetweenFn, shuffleFn` to do the unit test
- Add metrics for future investigation if any issues happen

Closes #4929
