### PR TITLE
Run optimistic sync spec tests

### DIFF
--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -11,7 +11,7 @@ import {importBlock} from "./importBlock.js";
 import {assertLinearChainSegment} from "./utils/chainSegment.js";
 import {BlockInput, FullyVerifiedBlock, ImportBlockOpts} from "./types.js";
 import {verifyBlocksSanityChecks} from "./verifyBlocksSanityChecks.js";
-export {ImportBlockOpts} from "./types.js";
+export {ImportBlockOpts, AttestationImportOpt} from "./types.js";
 
 const QUEUE_MAX_LENGTH = 256;
 

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -56,11 +56,16 @@ export const getBlockInput = {
   },
 };
 
+export enum AttestationImportOpt {
+  Skip,
+  Force,
+}
+
 export type ImportBlockOpts = {
   /**
    * TEMP: Review if this is safe, Lighthouse always imports attestations even in finalized sync.
    */
-  skipImportingAttestations?: boolean;
+  importAttestations?: AttestationImportOpt;
   /**
    * If error would trigger BlockErrorCode ALREADY_KNOWN or GENESIS_BLOCK, just ignore the block and don't verify nor
    * import the block and return void | Promise<void>.

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -1,11 +1,11 @@
 import {computeEpochAtSlot, isExecutionStateType, computeTimeAtSlot} from "@lodestar/state-transition";
 import {IChainForkConfig} from "@lodestar/config";
-import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkSeq, SLOTS_PER_EPOCH, ForkExecution} from "@lodestar/params";
 import {Slot} from "@lodestar/types";
 import {ILogger, sleep} from "@lodestar/utils";
 import {GENESIS_SLOT, ZERO_HASH_HEX} from "../constants/constants.js";
 import {IMetrics} from "../metrics/index.js";
-import {ForkExecution, TransitionConfigurationV1} from "../execution/engine/interface.js";
+import {TransitionConfigurationV1} from "../execution/engine/interface.js";
 import {ChainEvent} from "./emitter.js";
 import {prepareExecutionPayload} from "./produceBlock/produceBlockBody.js";
 import {IBeaconChain} from "./interface.js";

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -26,17 +26,11 @@ import {
   getExpectedWithdrawals,
 } from "@lodestar/state-transition";
 import {IChainForkConfig} from "@lodestar/config";
-import {ForkName, ForkSeq} from "@lodestar/params";
+import {ForkName, ForkSeq, ForkExecution} from "@lodestar/params";
 import {toHex, sleep} from "@lodestar/utils";
 
 import type {BeaconChain} from "../chain.js";
-import {
-  PayloadId,
-  IExecutionEngine,
-  IExecutionBuilder,
-  PayloadAttributes,
-  ForkExecution,
-} from "../../execution/index.js";
+import {PayloadId, IExecutionEngine, IExecutionBuilder, PayloadAttributes} from "../../execution/index.js";
 import {ZERO_HASH, ZERO_HASH_HEX} from "../../constants/index.js";
 import {IEth1ForBlockProduction} from "../../eth1/index.js";
 import {numToQuantity} from "../../eth1/provider/utils.js";
@@ -342,7 +336,6 @@ export async function prepareExecutionPayload(
     }
 
     const attributes: PayloadAttributes = {
-      fork,
       timestamp,
       prevRandao,
       suggestedFeeRecipient,

--- a/packages/beacon-node/src/execution/engine/interface.ts
+++ b/packages/beacon-node/src/execution/engine/interface.ts
@@ -3,10 +3,9 @@ import {KZGCommitment, Blob} from "@lodestar/types/eip4844";
 import {RootHex, allForks, capella} from "@lodestar/types";
 
 import {DATA, QUANTITY} from "../../eth1/provider/utils.js";
-import {PayloadIdCache, PayloadId, ApiPayloadAttributes, WithdrawalV1} from "./payloadIdCache.js";
+import {PayloadIdCache, PayloadId, WithdrawalV1} from "./payloadIdCache.js";
 
-export type ForkExecution = ForkName.bellatrix | ForkName.capella | ForkName.eip4844;
-export {PayloadIdCache, PayloadId, ApiPayloadAttributes, WithdrawalV1};
+export {PayloadIdCache, PayloadId, WithdrawalV1};
 
 export enum ExecutePayloadStatus {
   /** given payload is valid */
@@ -51,8 +50,6 @@ export type PayloadAttributes = {
   // DATA is anyway a hex string, so we can just track it as a hex string to
   // avoid any conversions
   suggestedFeeRecipient: string;
-  // Not spec'ed, to know the type of the payload
-  fork: ForkExecution;
   withdrawals?: capella.Withdrawal[];
 };
 

--- a/packages/beacon-node/src/execution/engine/mock.ts
+++ b/packages/beacon-node/src/execution/engine/mock.ts
@@ -4,27 +4,39 @@ import {
   OPAQUE_TX_BLOB_VERSIONED_HASHES_OFFSET,
   OPAQUE_TX_MESSAGE_OFFSET,
 } from "@lodestar/state-transition";
-import {allForks, bellatrix, eip4844, RootHex, ssz} from "@lodestar/types";
+import {bellatrix, eip4844, RootHex, ssz} from "@lodestar/types";
 import {fromHex, toHex} from "@lodestar/utils";
-import {BYTES_PER_FIELD_ELEMENT, FIELD_ELEMENTS_PER_BLOB, BLOB_TX_TYPE, ForkName, ForkSeq} from "@lodestar/params";
+import {
+  BYTES_PER_FIELD_ELEMENT,
+  FIELD_ELEMENTS_PER_BLOB,
+  BLOB_TX_TYPE,
+  ForkSeq,
+  ForkExecution,
+  ForkName,
+} from "@lodestar/params";
 import {ZERO_HASH_HEX} from "../../constants/index.js";
 import {ckzg} from "../../util/kzg.js";
+import {quantityToNum} from "../../eth1/provider/utils.js";
 import {
-  ExecutePayloadStatus,
-  ExecutePayloadResponse,
-  IExecutionEngine,
-  PayloadId,
-  PayloadAttributes,
-  PayloadIdCache,
-  TransitionConfigurationV1,
-  BlobsBundle,
-} from "./interface.js";
+  EngineApiRpcParamTypes,
+  EngineApiRpcReturnTypes,
+  deserializePayloadAttributes,
+  PayloadStatus,
+  serializeBlobsBundle,
+  serializeExecutionPayload,
+  ExecutionPayloadRpc,
+  BlobsBundleRpc,
+} from "./types.js";
+import {ExecutePayloadStatus, PayloadIdCache} from "./interface.js";
+import {IJsonRpcBackend} from "./utils.js";
 
 const INTEROP_GAS_LIMIT = 30e6;
 const PRUNE_PAYLOAD_ID_AFTER_MS = 5000;
 
 export type ExecutionEngineMockOpts = {
   genesisBlockHash: string;
+  capellaForkTimestamp?: number;
+  eip4844ForkTimestamp?: number;
 };
 
 type ExecutionBlock = {
@@ -37,14 +49,14 @@ type ExecutionBlock = {
 const TX_TYPE_EIP1559 = 2;
 
 type PreparedPayload = {
-  executionPayload: allForks.ExecutionPayload;
-  blobsBundle: BlobsBundle;
+  executionPayload: ExecutionPayloadRpc;
+  blobsBundle: BlobsBundleRpc;
 };
 
 /**
  * Mock ExecutionEngine for fast prototyping and unit testing
  */
-export class ExecutionEngineMock implements IExecutionEngine {
+export class ExecutionEngineMockBackend implements IJsonRpcBackend {
   // Public state to check if notifyForkchoiceUpdate() is called properly
   headBlockHash = ZERO_HASH_HEX;
   safeBlockHash = ZERO_HASH_HEX;
@@ -57,26 +69,70 @@ export class ExecutionEngineMock implements IExecutionEngine {
   private readonly preparingPayloads = new Map<number, PreparedPayload>();
   private readonly payloadsForDeletion = new Map<number, number>();
 
+  private readonly predefinedPayloadStatuses = new Map<RootHex, PayloadStatus>();
+
   private payloadId = 0;
 
-  constructor(opts: ExecutionEngineMockOpts) {
+  readonly handlers: {
+    [K in keyof EngineApiRpcParamTypes]: (...args: EngineApiRpcParamTypes[K]) => EngineApiRpcReturnTypes[K];
+  };
+
+  constructor(private readonly opts: ExecutionEngineMockOpts) {
     this.validBlocks.set(opts.genesisBlockHash, {
       parentHash: ZERO_HASH_HEX,
       blockHash: ZERO_HASH_HEX,
       timestamp: 0,
       blockNumber: 0,
     });
+
+    this.handlers = {
+      /* eslint-disable @typescript-eslint/naming-convention */
+      engine_newPayloadV1: this.notifyNewPayload.bind(this),
+      engine_newPayloadV2: this.notifyNewPayload.bind(this),
+      engine_newPayloadV3: this.notifyNewPayload.bind(this),
+      engine_forkchoiceUpdatedV1: this.notifyForkchoiceUpdate.bind(this),
+      engine_forkchoiceUpdatedV2: this.notifyForkchoiceUpdate.bind(this),
+      engine_getPayloadV1: this.getPayload.bind(this),
+      engine_getPayloadV2: this.getPayload.bind(this),
+      engine_getPayloadV3: this.getPayload.bind(this),
+      engine_exchangeTransitionConfigurationV1: this.exchangeTransitionConfigurationV1.bind(this),
+      engine_getBlobsBundleV1: this.getBlobsBundle.bind(this),
+    };
+  }
+
+  /**
+   * Mock manipulator to add more known blocks to this mock.
+   */
+  addPowBlock(powBlock: bellatrix.PowBlock): void {
+    this.validBlocks.set(toHex(powBlock.blockHash), {
+      parentHash: toHex(powBlock.parentHash),
+      blockHash: toHex(powBlock.blockHash),
+      timestamp: 0,
+      blockNumber: 0,
+    });
+  }
+
+  /**
+   * Mock manipulator to add predefined responses before execution engine client calls
+   */
+  addPredefinedPayloadStatus(blockHash: RootHex, payloadStatus: PayloadStatus): void {
+    this.predefinedPayloadStatuses.set(blockHash, payloadStatus);
   }
 
   /**
    * `engine_newPayloadV1`
    */
-  async notifyNewPayload(
-    _fork: ForkName,
-    executionPayload: bellatrix.ExecutionPayload
-  ): Promise<ExecutePayloadResponse> {
-    const blockHash = toHex(executionPayload.blockHash);
-    const parentHash = toHex(executionPayload.parentHash);
+  private notifyNewPayload(
+    executionPayloadRpc: EngineApiRpcParamTypes["engine_newPayloadV1"][0]
+  ): EngineApiRpcReturnTypes["engine_newPayloadV1"] {
+    const blockHash = executionPayloadRpc.blockHash;
+    const parentHash = executionPayloadRpc.parentHash;
+
+    // For optimistic sync spec tests, allow to define responses ahead of time
+    const predefinedResponse = this.predefinedPayloadStatuses.get(blockHash);
+    if (predefinedResponse) {
+      return predefinedResponse;
+    }
 
     // 1. Client software MUST validate blockHash value as being equivalent to Keccak256(RLP(ExecutionBlockHeader)),
     //    where ExecutionBlockHeader is the execution layer block header (the former PoW block header structure).
@@ -111,8 +167,8 @@ export class ExecutionEngineMock implements IExecutionEngine {
     this.validBlocks.set(blockHash, {
       parentHash,
       blockHash,
-      timestamp: executionPayload.timestamp,
-      blockNumber: executionPayload.blockNumber,
+      timestamp: quantityToNum(executionPayloadRpc.timestamp),
+      blockNumber: quantityToNum(executionPayloadRpc.blockNumber),
     });
 
     // IF the payload has been fully validated while processing the call
@@ -124,13 +180,21 @@ export class ExecutionEngineMock implements IExecutionEngine {
   /**
    * `engine_forkchoiceUpdatedV1`
    */
-  async notifyForkchoiceUpdate(
-    _fork: ForkName,
-    headBlockHash: RootHex,
-    safeBlockHash: RootHex,
-    finalizedBlockHash: RootHex,
-    payloadAttributes?: PayloadAttributes
-  ): Promise<PayloadId | null> {
+  private notifyForkchoiceUpdate(
+    forkChoiceData: EngineApiRpcParamTypes["engine_forkchoiceUpdatedV1"][0],
+    payloadAttributesRpc: EngineApiRpcParamTypes["engine_forkchoiceUpdatedV1"][1]
+  ): EngineApiRpcReturnTypes["engine_forkchoiceUpdatedV1"] {
+    const {headBlockHash, safeBlockHash, finalizedBlockHash} = forkChoiceData;
+
+    // For optimistic sync spec tests, allow to define responses ahead of time
+    const predefinedResponse = this.predefinedPayloadStatuses.get(headBlockHash);
+    if (predefinedResponse) {
+      return {
+        payloadStatus: predefinedResponse,
+        payloadId: null,
+      };
+    }
+
     // 1. Client software MAY initiate a sync process if forkchoiceState.headBlockHash references an unknown payload or
     //    a payload that can't be validated because data that are requisite for the validation is missing. The sync
     //    process is specified in the Sync section.
@@ -163,8 +227,10 @@ export class ExecutionEngineMock implements IExecutionEngine {
       // RETURN {payloadStatus: {status: SYNCING, latestValidHash: null, validationError: null}, payloadId: null}
       //
       // > TODO: Implement
-
-      throw Error(`Unknown headBlock ${headBlockHash}`);
+      return {
+        payloadStatus: {status: ExecutePayloadStatus.SYNCING, latestValidHash: null, validationError: null},
+        payloadId: null,
+      };
     }
 
     // 5. Client software MUST update its forkchoice state if payloads referenced by forkchoiceState.headBlockHash and
@@ -182,7 +248,9 @@ export class ExecutionEngineMock implements IExecutionEngine {
     //
     // > N/A: Mock does not track the chain dag
 
-    if (payloadAttributes) {
+    if (payloadAttributesRpc) {
+      const payloadAttributes = deserializePayloadAttributes(payloadAttributesRpc);
+
       // 7. Client software MUST ensure that payloadAttributes.timestamp is greater than timestamp of a block referenced
       //    by forkchoiceState.headBlockHash. If this condition isn't held client software MUST respond with
       //   `-38003: Invalid payload attributes` and MUST NOT begin a payload build process.
@@ -197,7 +265,8 @@ export class ExecutionEngineMock implements IExecutionEngine {
       const payloadId = this.payloadId++;
 
       // Generate empty payload first to be correct with respect to fork
-      const executionPayload = ssz[payloadAttributes.fork].ExecutionPayload.defaultValue();
+      const fork = this.timestampToFork(payloadAttributes.timestamp);
+      const executionPayload = ssz[fork].ExecutionPayload.defaultValue();
 
       // Make executionPayload valid
       executionPayload.parentHash = fromHex(headBlockHash);
@@ -222,7 +291,7 @@ export class ExecutionEngineMock implements IExecutionEngine {
       const blobs: eip4844.Blob[] = [];
 
       // if post eip4844, add between 0 and 2 blob transactions
-      if (ForkSeq[payloadAttributes.fork] >= ForkSeq.eip4844) {
+      if (ForkSeq[fork] >= ForkSeq.eip4844) {
         const eip4844TxCount = Math.round(2 * Math.random());
         for (let i = 0; i < eip4844TxCount; i++) {
           const blob = generateRandomBlob();
@@ -234,24 +303,30 @@ export class ExecutionEngineMock implements IExecutionEngine {
       }
 
       this.preparingPayloads.set(payloadId, {
-        executionPayload,
-        blobsBundle: {
+        executionPayload: serializeExecutionPayload(fork, executionPayload),
+        blobsBundle: serializeBlobsBundle({
           blockHash: toHex(executionPayload.blockHash),
           kzgs,
           blobs,
-        },
+        }),
       });
 
       // IF the payload is deemed VALID and the build process has begun
       // {payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: buildProcessId}
-      return String(payloadId as number);
+      return {
+        payloadStatus: {status: ExecutePayloadStatus.VALID, latestValidHash: null, validationError: null},
+        payloadId: String(payloadId as number),
+      };
     }
 
     // Don't start build process
     else {
       // IF the payload is deemed VALID and a build process hasn't been started
       // {payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: null}
-      return null;
+      return {
+        payloadStatus: {status: ExecutePayloadStatus.VALID, latestValidHash: null, validationError: null},
+        payloadId: null,
+      };
     }
   }
 
@@ -262,7 +337,9 @@ export class ExecutionEngineMock implements IExecutionEngine {
    * 2. The call MUST be responded with 5: Unavailable payload error if the building process identified by the payloadId doesn't exist.
    * 3. Client software MAY stop the corresponding building process after serving this call.
    */
-  async getPayload(_fork: ForkName, payloadId: PayloadId): Promise<bellatrix.ExecutionPayload> {
+  private getPayload(
+    payloadId: EngineApiRpcParamTypes["engine_getPayloadV1"][0]
+  ): EngineApiRpcReturnTypes["engine_getPayloadV1"] {
     // 1. Given the payloadId client software MUST return the most recent version of the payload that is available in
     //    the corresponding build process at the time of receiving the call.
     const payloadIdNbr = Number(payloadId);
@@ -288,7 +365,9 @@ export class ExecutionEngineMock implements IExecutionEngine {
     return payload.executionPayload;
   }
 
-  async getBlobsBundle(payloadId: PayloadId): Promise<BlobsBundle> {
+  private getBlobsBundle(
+    payloadId: EngineApiRpcParamTypes["engine_getBlobsBundleV1"][0]
+  ): EngineApiRpcReturnTypes["engine_getBlobsBundleV1"] {
     const payloadIdNbr = Number(payloadId);
     const payload = this.preparingPayloads.get(payloadIdNbr);
 
@@ -299,23 +378,17 @@ export class ExecutionEngineMock implements IExecutionEngine {
     return payload.blobsBundle;
   }
 
-  async exchangeTransitionConfigurationV1(
-    transitionConfiguration: TransitionConfigurationV1
-  ): Promise<TransitionConfigurationV1> {
+  private exchangeTransitionConfigurationV1(
+    transitionConfiguration: EngineApiRpcParamTypes["engine_exchangeTransitionConfigurationV1"][0]
+  ): EngineApiRpcReturnTypes["engine_exchangeTransitionConfigurationV1"] {
     // echo same configuration from consensus, which will be considered valid
     return transitionConfiguration;
   }
 
-  /**
-   * Non-spec method just to add more known blocks to this mock.
-   */
-  addPowBlock(powBlock: bellatrix.PowBlock): void {
-    this.validBlocks.set(toHex(powBlock.blockHash), {
-      parentHash: toHex(powBlock.parentHash),
-      blockHash: toHex(powBlock.blockHash),
-      timestamp: 0,
-      blockNumber: 0,
-    });
+  private timestampToFork(timestamp: number): ForkExecution {
+    if (timestamp > (this.opts.eip4844ForkTimestamp ?? Infinity)) return ForkName.eip4844;
+    if (timestamp > (this.opts.capellaForkTimestamp ?? Infinity)) return ForkName.capella;
+    return ForkName.bellatrix;
   }
 }
 

--- a/packages/beacon-node/src/execution/engine/mock.ts
+++ b/packages/beacon-node/src/execution/engine/mock.ts
@@ -35,6 +35,7 @@ const PRUNE_PAYLOAD_ID_AFTER_MS = 5000;
 
 export type ExecutionEngineMockOpts = {
   genesisBlockHash: string;
+  onlyPredefinedResponses?: boolean;
   capellaForkTimestamp?: number;
   eip4844ForkTimestamp?: number;
 };
@@ -132,6 +133,8 @@ export class ExecutionEngineMockBackend implements IJsonRpcBackend {
     const predefinedResponse = this.predefinedPayloadStatuses.get(blockHash);
     if (predefinedResponse) {
       return predefinedResponse;
+    } else if (this.opts.onlyPredefinedResponses) {
+      throw Error(`No predefined response for blockHash ${blockHash}`);
     }
 
     // 1. Client software MUST validate blockHash value as being equivalent to Keccak256(RLP(ExecutionBlockHeader)),
@@ -193,6 +196,8 @@ export class ExecutionEngineMockBackend implements IJsonRpcBackend {
         payloadStatus: predefinedResponse,
         payloadId: null,
       };
+    } else if (this.opts.onlyPredefinedResponses) {
+      throw Error(`No predefined response for headBlockHash ${headBlockHash}`);
     }
 
     // 1. Client software MAY initiate a sync process if forkchoiceState.headBlockHash references an unknown payload or

--- a/packages/beacon-node/src/execution/engine/payloadIdCache.ts
+++ b/packages/beacon-node/src/execution/engine/payloadIdCache.ts
@@ -2,6 +2,7 @@ import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {pruneSetToMax} from "@lodestar/utils";
 import {IMetrics} from "../../metrics/index.js";
 import {DATA, QUANTITY} from "../../eth1/provider/utils.js";
+import {PayloadAttributesRpc} from "./types.js";
 
 // Idealy this only need to be set to the max head reorgs number
 const MAX_PAYLOAD_IDS = SLOTS_PER_EPOCH;
@@ -17,17 +18,7 @@ export type WithdrawalV1 = {
   amount: QUANTITY;
 };
 
-export type ApiPayloadAttributes = {
-  /** QUANTITY, 64 Bits - value for the timestamp field of the new payload */
-  timestamp: QUANTITY;
-  /** DATA, 32 Bytes - value for the prevRandao field of the new payload */
-  prevRandao: DATA;
-  /** DATA, 20 Bytes - suggested value for the coinbase field of the new payload */
-  suggestedFeeRecipient: DATA;
-  withdrawals?: WithdrawalV1[];
-};
-
-type FcuAttributes = {headBlockHash: DATA; finalizedBlockHash: DATA} & Omit<ApiPayloadAttributes, "withdrawals">;
+type FcuAttributes = {headBlockHash: DATA; finalizedBlockHash: DATA} & Omit<PayloadAttributesRpc, "withdrawals">;
 
 export class PayloadIdCache {
   private readonly payloadIdByFcuAttributes = new Map<string, {payloadId: PayloadId; fullKey: string}>();

--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -1,0 +1,283 @@
+import {allForks, capella, eip4844} from "@lodestar/types";
+import {
+  BYTES_PER_LOGS_BLOOM,
+  FIELD_ELEMENTS_PER_BLOB,
+  BYTES_PER_FIELD_ELEMENT,
+  ForkName,
+  ForkSeq,
+} from "@lodestar/params";
+
+import {
+  bytesToData,
+  numToQuantity,
+  dataToBytes,
+  quantityToNum,
+  DATA,
+  QUANTITY,
+  quantityToBigint,
+  dataToRootHex,
+} from "../../eth1/provider/utils.js";
+import {ExecutePayloadStatus, TransitionConfigurationV1, BlobsBundle, PayloadAttributes} from "./interface.js";
+
+const GWEI_TO_WEI = BigInt(1000000000);
+
+/* eslint-disable @typescript-eslint/naming-convention */
+
+export type EngineApiRpcParamTypes = {
+  /**
+   * 1. Object - Instance of ExecutionPayload
+   */
+  engine_newPayloadV1: [ExecutionPayloadRpc];
+  engine_newPayloadV2: [ExecutionPayloadRpc];
+  engine_newPayloadV3: [ExecutionPayloadRpc];
+  /**
+   * 1. Object - Payload validity status with respect to the consensus rules:
+   *   - blockHash: DATA, 32 Bytes - block hash value of the payload
+   *   - status: String: VALID|INVALID - result of the payload validation with respect to the proof-of-stake consensus rules
+   */
+  engine_forkchoiceUpdatedV1: [
+    forkChoiceData: {headBlockHash: DATA; safeBlockHash: DATA; finalizedBlockHash: DATA},
+    payloadAttributes?: PayloadAttributesRpc
+  ];
+  engine_forkchoiceUpdatedV2: [
+    forkChoiceData: {headBlockHash: DATA; safeBlockHash: DATA; finalizedBlockHash: DATA},
+    payloadAttributes?: PayloadAttributesRpc
+  ];
+  /**
+   * 1. payloadId: QUANTITY, 64 Bits - Identifier of the payload building process
+   */
+  engine_getPayloadV1: [QUANTITY];
+  engine_getPayloadV2: [QUANTITY];
+  engine_getPayloadV3: [QUANTITY];
+  /**
+   * 1. Object - Instance of TransitionConfigurationV1
+   */
+  engine_exchangeTransitionConfigurationV1: [TransitionConfigurationV1];
+  /**
+   * 1. payloadId: QUANTITY, 64 Bits - Identifier of the payload building process
+   */
+  engine_getBlobsBundleV1: [QUANTITY];
+};
+
+export type PayloadStatus = {
+  status: ExecutePayloadStatus;
+  latestValidHash: DATA | null;
+  validationError: string | null;
+};
+
+export type EngineApiRpcReturnTypes = {
+  /**
+   * Object - Response object:
+   * - status: String - the result of the payload execution:
+   */
+  engine_newPayloadV1: PayloadStatus;
+  engine_newPayloadV2: PayloadStatus;
+  engine_newPayloadV3: PayloadStatus;
+  engine_forkchoiceUpdatedV1: {
+    payloadStatus: PayloadStatus;
+    payloadId: QUANTITY | null;
+  };
+  engine_forkchoiceUpdatedV2: {
+    payloadStatus: PayloadStatus;
+    payloadId: QUANTITY | null;
+  };
+  /**
+   * payloadId | Error: QUANTITY, 64 Bits - Identifier of the payload building process
+   */
+  engine_getPayloadV1: ExecutionPayloadRpc;
+  engine_getPayloadV2: ExecutionPayloadResponseV2;
+  engine_getPayloadV3: ExecutionPayloadResponseV2;
+  /**
+   * Object - Instance of TransitionConfigurationV1
+   */
+  engine_exchangeTransitionConfigurationV1: TransitionConfigurationV1;
+
+  engine_getBlobsBundleV1: BlobsBundleRpc;
+};
+
+type ExecutionPayloadRpcWithBlockValue = {executionPayload: ExecutionPayloadRpc; blockValue: QUANTITY};
+type ExecutionPayloadResponseV2 = ExecutionPayloadRpc | ExecutionPayloadRpcWithBlockValue;
+
+export type ExecutionPayloadRpc = {
+  parentHash: DATA; // 32 bytes
+  feeRecipient: DATA; // 20 bytes
+  stateRoot: DATA; // 32 bytes
+  receiptsRoot: DATA; // 32 bytes
+  logsBloom: DATA; // 256 bytes
+  prevRandao: DATA; // 32 bytes
+  blockNumber: QUANTITY;
+  gasLimit: QUANTITY;
+  gasUsed: QUANTITY;
+  timestamp: QUANTITY;
+  extraData: DATA; // 0 to 32 bytes
+  baseFeePerGas: QUANTITY;
+  blockHash: DATA; // 32 bytes
+  transactions: DATA[];
+  withdrawals?: WithdrawalRpc[]; // Capella hardfork
+  excessDataGas?: QUANTITY; // EIP-4844
+};
+
+export type WithdrawalRpc = {
+  index: QUANTITY;
+  validatorIndex: QUANTITY;
+  address: DATA;
+  amount: QUANTITY;
+};
+
+export type PayloadAttributesRpc = {
+  /** QUANTITY, 64 Bits - value for the timestamp field of the new payload */
+  timestamp: QUANTITY;
+  /** DATA, 32 Bytes - value for the prevRandao field of the new payload */
+  prevRandao: DATA;
+  /** DATA, 20 Bytes - suggested value for the coinbase field of the new payload */
+  suggestedFeeRecipient: DATA;
+  withdrawals?: WithdrawalRpc[];
+};
+
+export interface BlobsBundleRpc {
+  blockHash: DATA; // 32 Bytes
+  kzgs: DATA[]; // each 48 bytes
+  blobs: DATA[]; // each 4096 * 32 = 131072 bytes
+}
+
+export function serializeExecutionPayload(fork: ForkName, data: allForks.ExecutionPayload): ExecutionPayloadRpc {
+  const payload: ExecutionPayloadRpc = {
+    parentHash: bytesToData(data.parentHash),
+    feeRecipient: bytesToData(data.feeRecipient),
+    stateRoot: bytesToData(data.stateRoot),
+    receiptsRoot: bytesToData(data.receiptsRoot),
+    logsBloom: bytesToData(data.logsBloom),
+    prevRandao: bytesToData(data.prevRandao),
+    blockNumber: numToQuantity(data.blockNumber),
+    gasLimit: numToQuantity(data.gasLimit),
+    gasUsed: numToQuantity(data.gasUsed),
+    timestamp: numToQuantity(data.timestamp),
+    extraData: bytesToData(data.extraData),
+    baseFeePerGas: numToQuantity(data.baseFeePerGas),
+    blockHash: bytesToData(data.blockHash),
+    transactions: data.transactions.map((tran) => bytesToData(tran)),
+  };
+
+  // Capella adds withdrawals to the ExecutionPayload
+  if (ForkSeq[fork] >= ForkSeq.capella) {
+    const {withdrawals} = data as capella.ExecutionPayload;
+    payload.withdrawals = withdrawals.map(serializeWithdrawal);
+  }
+
+  // EIP-4844 adds excessDataGas to the ExecutionPayload
+  if ((data as eip4844.ExecutionPayload).excessDataGas !== undefined) {
+    payload.excessDataGas = numToQuantity((data as eip4844.ExecutionPayload).excessDataGas);
+  }
+
+  return payload;
+}
+
+export function hasBlockValue(response: ExecutionPayloadResponseV2): response is ExecutionPayloadRpcWithBlockValue {
+  return (response as ExecutionPayloadRpcWithBlockValue).blockValue !== undefined;
+}
+
+export function parseExecutionPayload(fork: ForkName, response: ExecutionPayloadResponseV2): allForks.ExecutionPayload {
+  const data: ExecutionPayloadRpc = hasBlockValue(response) ? response.executionPayload : response;
+
+  const payload = {
+    parentHash: dataToBytes(data.parentHash, 32),
+    feeRecipient: dataToBytes(data.feeRecipient, 20),
+    stateRoot: dataToBytes(data.stateRoot, 32),
+    receiptsRoot: dataToBytes(data.receiptsRoot, 32),
+    logsBloom: dataToBytes(data.logsBloom, BYTES_PER_LOGS_BLOOM),
+    prevRandao: dataToBytes(data.prevRandao, 32),
+    blockNumber: quantityToNum(data.blockNumber),
+    gasLimit: quantityToNum(data.gasLimit),
+    gasUsed: quantityToNum(data.gasUsed),
+    timestamp: quantityToNum(data.timestamp),
+    extraData: dataToBytes(data.extraData, null),
+    baseFeePerGas: quantityToBigint(data.baseFeePerGas),
+    blockHash: dataToBytes(data.blockHash, 32),
+    transactions: data.transactions.map((tran) => dataToBytes(tran, null)),
+  };
+
+  if (ForkSeq[fork] >= ForkSeq.capella) {
+    const {withdrawals} = data;
+    // Geth can also reply with null
+    if (withdrawals == null) {
+      throw Error(
+        `withdrawals missing for ${fork} >= capella executionPayload number=${payload.blockNumber} hash=${data.blockHash}`
+      );
+    }
+    (payload as capella.ExecutionPayload).withdrawals = withdrawals.map((w) => deserializeWithdrawal(w));
+  }
+
+  // EIP-4844 adds excessDataGas to the ExecutionPayload
+  if (ForkSeq[fork] >= ForkSeq.eip4844) {
+    if (data.excessDataGas == null) {
+      throw Error(
+        `excessDataGas missing for ${fork} >= eip4844 executionPayload number=${payload.blockNumber} hash=${data.blockHash}`
+      );
+    }
+    (payload as eip4844.ExecutionPayload).excessDataGas = quantityToBigint(data.excessDataGas);
+  }
+
+  return payload;
+}
+
+export function serializePayloadAttributes(data: PayloadAttributes): PayloadAttributesRpc {
+  return {
+    timestamp: numToQuantity(data.timestamp),
+    prevRandao: bytesToData(data.prevRandao),
+    suggestedFeeRecipient: data.suggestedFeeRecipient,
+    withdrawals: data.withdrawals?.map(serializeWithdrawal),
+  };
+}
+
+export function deserializePayloadAttributes(data: PayloadAttributesRpc): PayloadAttributes {
+  return {
+    timestamp: quantityToNum(data.timestamp),
+    prevRandao: dataToBytes(data.prevRandao, 32),
+    // DATA is anyway a hex string, so we can just track it as a hex string to
+    // avoid any conversions
+    suggestedFeeRecipient: data.suggestedFeeRecipient,
+    withdrawals: data.withdrawals?.map((withdrawal) => deserializeWithdrawal(withdrawal)),
+  };
+}
+
+export function parseBlobsBundle(data: BlobsBundleRpc): BlobsBundle {
+  return {
+    // NOTE: Keep as hex, since it's only used for equality downstream
+    blockHash: dataToRootHex(data.blockHash),
+    // As of Nov 17th 2022 according to Dan's tests Geth returns null if no blobs in block
+    kzgs: (data.kzgs ?? []).map((kzg) => dataToBytes(kzg, 48)),
+    blobs: (data.blobs ?? []).map((blob) => dataToBytes(blob, BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB)),
+  };
+}
+
+export function serializeBlobsBundle(data: BlobsBundle): BlobsBundleRpc {
+  return {
+    blockHash: dataToRootHex(data.blockHash),
+    kzgs: data.kzgs.map((kzg) => bytesToData(kzg)),
+    blobs: data.blobs.map((blob) => bytesToData(blob)),
+  };
+}
+
+export function serializeWithdrawal(withdrawal: capella.Withdrawal): WithdrawalRpc {
+  return {
+    index: numToQuantity(withdrawal.index),
+    validatorIndex: numToQuantity(withdrawal.validatorIndex),
+    address: bytesToData(withdrawal.address),
+    // Note: the amount value is represented on the beacon chain as a little-endian value in
+    // units of Gwei, whereas the amount in this structure MUST be converted to a big-endian value
+    // in units of Wei
+    //
+    // see: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md
+    amount: numToQuantity(withdrawal.amount * GWEI_TO_WEI),
+  };
+}
+
+export function deserializeWithdrawal(serialized: WithdrawalRpc): capella.Withdrawal {
+  return {
+    index: quantityToNum(serialized.index),
+    validatorIndex: quantityToNum(serialized.validatorIndex),
+    address: dataToBytes(serialized.address, 20),
+    // see: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md
+    amount: quantityToBigint(serialized.amount) / GWEI_TO_WEI,
+  } as capella.Withdrawal;
+}

--- a/packages/beacon-node/src/execution/engine/utils.ts
+++ b/packages/beacon-node/src/execution/engine/utils.ts
@@ -16,7 +16,7 @@ export class ExecutionEngineMockJsonRpcClient implements IJsonRpcHttpClient {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return handler(payload.params as any) as R;
+    return handler(...(payload.params as any[])) as R;
   }
 
   fetchWithRetries<R, P = IJson[]>(payload: IRpcPayload<P>): Promise<R> {

--- a/packages/beacon-node/src/execution/engine/utils.ts
+++ b/packages/beacon-node/src/execution/engine/utils.ts
@@ -1,0 +1,29 @@
+import {IJson, IRpcPayload} from "../../eth1/interface.js";
+import {IJsonRpcHttpClient} from "../../eth1/provider/jsonRpcHttpClient.js";
+
+export interface IJsonRpcBackend {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly handlers: Record<string, (...args: any[]) => any>;
+}
+
+export class ExecutionEngineMockJsonRpcClient implements IJsonRpcHttpClient {
+  constructor(private readonly backend: IJsonRpcBackend) {}
+
+  async fetch<R, P = IJson[]>(payload: IRpcPayload<P>): Promise<R> {
+    const handler = this.backend.handlers[payload.method];
+    if (handler === undefined) {
+      throw Error(`Unknown method ${payload.method}`);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return handler(payload.params as any) as R;
+  }
+
+  fetchWithRetries<R, P = IJson[]>(payload: IRpcPayload<P>): Promise<R> {
+    return this.fetch(payload);
+  }
+
+  fetchBatch<R>(rpcPayloadArr: IRpcPayload<IJson[]>[]): Promise<R[]> {
+    return Promise.all(rpcPayloadArr.map((payload) => this.fetch<R>(payload)));
+  }
+}

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -9,7 +9,7 @@ import {IBeaconChain} from "../../chain/index.js";
 import {INetwork} from "../../network/index.js";
 import {IMetrics} from "../../metrics/index.js";
 import {RangeSyncType, rangeSyncTypes, getRangeSyncTarget} from "../utils/remoteSyncType.js";
-import {ImportBlockOpts} from "../../chain/blocks/index.js";
+import {ImportBlockOpts, AttestationImportOpt} from "../../chain/blocks/index.js";
 import {updateChains} from "./utils/index.js";
 import {ChainTarget, SyncChainFns, SyncChain, SyncChainDebugState} from "./chain.js";
 
@@ -176,7 +176,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
       // Only skip importing attestations for finalized sync. For head sync attestation are valuable.
       // Importing attestations also triggers a head update, see https://github.com/ChainSafe/lodestar/issues/3804
       // TODO: Review if this is okay, can we prevent some attacks by importing attestations?
-      skipImportingAttestations: syncType === RangeSyncType.Finalized,
+      importAttestations: syncType === RangeSyncType.Finalized ? AttestationImportOpt.Skip : undefined,
       // Ignores ALREADY_KNOWN or GENESIS_BLOCK errors, and continues with the next block in chain segment
       ignoreIfKnown: true,
       // Ignore WOULD_REVERT_FINALIZED_SLOT error, continue with the next block in chain segment

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -16,7 +16,7 @@ import {Eth1ForBlockProductionDisabled} from "../../../src/eth1/index.js";
 import {testLogger} from "../../utils/logger.js";
 import {linspace} from "../../../src/util/numpy.js";
 import {BeaconDb} from "../../../src/index.js";
-import {getBlockInput} from "../../../src/chain/blocks/types.js";
+import {getBlockInput, AttestationImportOpt} from "../../../src/chain/blocks/types.js";
 
 // Define this params in `packages/state-transition/test/perf/params.ts`
 // to trigger Github actions CI cache
@@ -112,7 +112,7 @@ describe.skip("verify+import blocks - range sync perf test", () => {
         // Only skip importing attestations for finalized sync. For head sync attestation are valuable.
         // Importing attestations also triggers a head update, see https://github.com/ChainSafe/lodestar/issues/3804
         // TODO: Review if this is okay, can we prevent some attacks by importing attestations?
-        skipImportingAttestations: true,
+        importAttestations: AttestationImportOpt.Skip,
         // Ignores ALREADY_KNOWN or GENESIS_BLOCK errors, and continues with the next block in chain segment
         ignoreIfKnown: true,
         // Ignore WOULD_REVERT_FINALIZED_SLOT error, continue with the next block in chain segment

--- a/packages/beacon-node/test/sim/merge-interop.test.ts
+++ b/packages/beacon-node/test/sim/merge-interop.test.ts
@@ -9,7 +9,7 @@ import {Epoch} from "@lodestar/types";
 import {ValidatorProposerConfig} from "@lodestar/validator";
 
 import {ExecutePayloadStatus, PayloadAttributes} from "../../src/execution/engine/interface.js";
-import {ExecutionEngineHttp} from "../../src/execution/engine/http.js";
+import {initializeExecutionEngine} from "../../src/execution/index.js";
 import {ChainEvent} from "../../src/chain/index.js";
 import {testLogger, TestLoggerOpts} from "../utils/logger.js";
 import {getDevBeaconNode} from "../utils/node/beacon.js";
@@ -107,8 +107,8 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     }
 
     //const controller = new AbortController();
-    const executionEngine = new ExecutionEngineHttp(
-      {urls: [engineRpcUrl], jwtSecretHex, retryAttempts, retryDelay},
+    const executionEngine = initializeExecutionEngine(
+      {mode: "http", urls: [engineRpcUrl], jwtSecretHex, retryAttempts, retryDelay},
       {signal: controller.signal}
     );
 
@@ -123,7 +123,6 @@ describe("executionEngine / ExecutionEngineHttp", function () {
       timestamp: quantityToNum("0x5"),
       prevRandao: dataToBytes("0x0000000000000000000000000000000000000000000000000000000000000000", 32),
       suggestedFeeRecipient: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
-      fork: ForkName.bellatrix,
     };
 
     const finalizedBlockHash = "0x0000000000000000000000000000000000000000000000000000000000000000";

--- a/packages/beacon-node/test/sim/withdrawal-interop.test.ts
+++ b/packages/beacon-node/test/sim/withdrawal-interop.test.ts
@@ -8,7 +8,7 @@ import {Epoch, capella} from "@lodestar/types";
 import {ValidatorProposerConfig} from "@lodestar/validator";
 
 import {ExecutePayloadStatus, PayloadAttributes} from "../../src/execution/engine/interface.js";
-import {ExecutionEngineHttp} from "../../src/execution/engine/http.js";
+import {initializeExecutionEngine} from "../../src/execution/index.js";
 import {ChainEvent} from "../../src/chain/index.js";
 import {testLogger, TestLoggerOpts} from "../utils/logger.js";
 import {getDevBeaconNode} from "../utils/node/beacon.js";
@@ -79,8 +79,8 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     console.log({genesisBlockHash});
 
     //const controller = new AbortController();
-    const executionEngine = new ExecutionEngineHttp(
-      {urls: [engineRpcUrl], jwtSecretHex, retryAttempts, retryDelay},
+    const executionEngine = initializeExecutionEngine(
+      {mode: "http", urls: [engineRpcUrl], jwtSecretHex, retryAttempts, retryDelay},
       {signal: controller.signal}
     );
 
@@ -143,7 +143,6 @@ describe("executionEngine / ExecutionEngineHttp", function () {
       prevRandao: dataToBytes("0xff00000000000000000000000000000000000000000000000000000000000000", 32),
       suggestedFeeRecipient: "0xaa00000000000000000000000000000000000000",
       withdrawals,
-      fork: ForkName.capella,
     };
     const finalizedBlockHash = "0xfe950635b1bd2a416ff6283b0bbd30176e1b1125ad06fa729da9f3f4c1c61710";
 

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -37,7 +37,9 @@ const ATTESTER_SLASHING_FILE_NAME = "^(attester_slashing)_([0-9a-zA-Z])+$";
 
 const logger = testLogger("spec-test");
 
-export const forkChoiceTest: TestRunnerFn<ForkChoiceTestCase, void> = (fork) => {
+export const forkChoiceTest = (opts: {onlyPredefinedResponses: boolean}): TestRunnerFn<ForkChoiceTestCase, void> => (
+  fork
+) => {
   return {
     testFunction: async (testcase) => {
       const {steps, anchorState} = testcase;
@@ -50,6 +52,7 @@ export const forkChoiceTest: TestRunnerFn<ForkChoiceTestCase, void> = (fork) => 
       const clock = new ClockStopped(currentSlot);
       const eth1 = new Eth1ForBlockProductionMock();
       const executionEngineBackend = new ExecutionEngineMockBackend({
+        onlyPredefinedResponses: opts.onlyPredefinedResponses,
         genesisBlockHash: isExecutionStateType(anchorState)
           ? toHexString(anchorState.latestExecutionPayloadHeader.blockHash)
           : ZERO_HASH_HEX,
@@ -141,6 +144,7 @@ export const forkChoiceTest: TestRunnerFn<ForkChoiceTestCase, void> = (fork) => 
               .BeaconBlock.hashTreeRoot(signedBlock.message);
             logger.debug(`Step ${i}/${stepsLen} block`, {
               slot,
+              id: step.block,
               root: toHexString(blockRoot),
               parentRoot: toHexString(signedBlock.message.parentRoot),
               isValid,

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -199,8 +199,10 @@ export const forkChoiceTest: TestRunnerFn<ForkChoiceTestCase, void> = (fork) => 
             const proposerBootRoot = (chain.forkChoice as ForkChoice).getProposerBoostRoot();
 
             if (step.checks.head !== undefined) {
-              expect(head.slot).to.be.equal(bnToNum(step.checks.head.slot), `Invalid head slot at step ${i}`);
-              expect(head.blockRoot).to.be.equal(step.checks.head.root, `Invalid head root at step ${i}`);
+              expect({slot: head.slot, root: head.blockRoot}).deep.equals(
+                {slot: bnToNum(step.checks.head.slot), root: step.checks.head.root},
+                `Invalid head at step ${i}`
+              );
             }
             if (step.checks.proposer_boost_root !== undefined) {
               expect(proposerBootRoot).to.be.equal(

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -19,7 +19,7 @@ import {ExecutionEngineMockBackend} from "../../../src/execution/engine/mock.js"
 import {defaultChainOptions} from "../../../src/chain/options.js";
 import {getStubbedBeaconDb} from "../../utils/mocks/db.js";
 import {ClockStopped} from "../../utils/mocks/clock.js";
-import {getBlockInput} from "../../../src/chain/blocks/types.js";
+import {getBlockInput, AttestationImportOpt} from "../../../src/chain/blocks/types.js";
 import {ZERO_HASH_HEX} from "../../../src/constants/constants.js";
 import {PowMergeBlock} from "../../../src/eth1/interface.js";
 import {assertCorrectProgressiveBalances} from "../config.js";
@@ -156,7 +156,11 @@ export const forkChoiceTest = (opts: {onlyPredefinedResponses: boolean}): TestRu
                 : getBlockInput.postEIP4844OldBlobs(config, signedBlock);
 
             try {
-              await chain.processBlock(blockImport, {seenTimestampSec: tickTime, validBlobsSidecar: true});
+              await chain.processBlock(blockImport, {
+                seenTimestampSec: tickTime,
+                validBlobsSidecar: true,
+                importAttestations: AttestationImportOpt.Force,
+              });
               if (!isValid) throw Error("Expect error since this is a negative test");
             } catch (e) {
               if (isValid) throw e;

--- a/packages/beacon-node/test/spec/presets/index.test.ts
+++ b/packages/beacon-node/test/spec/presets/index.test.ts
@@ -21,7 +21,7 @@ import {transition} from "./transition.js";
 // because the latest withdrawals we implemented are a breaking change
 const skipOpts: SkipOpts = {
   skippedForks: [],
-  skippedRunners: ["sync"],
+  skippedRunners: [],
   skippedHandlers: ["full_withdrawals", "partial_withdrawals", "bls_to_execution_change", "withdrawals"],
 };
 
@@ -51,6 +51,7 @@ specTestIterator(
         "LightClientOptimisticUpdate",
       ]),
     },
+    sync: {type: RunnerType.default, fn: forkChoiceTest},
     transition: {type: RunnerType.default, fn: transition},
   },
   skipOpts

--- a/packages/beacon-node/test/spec/presets/index.test.ts
+++ b/packages/beacon-node/test/spec/presets/index.test.ts
@@ -33,7 +33,7 @@ specTestIterator(
     epoch_processing: {type: RunnerType.default, fn: epochProcessing(["invalid_large_withdrawable_epoch"])},
     finality: {type: RunnerType.default, fn: finality},
     fork: {type: RunnerType.default, fn: fork},
-    fork_choice: {type: RunnerType.default, fn: forkChoiceTest},
+    fork_choice: {type: RunnerType.default, fn: forkChoiceTest({onlyPredefinedResponses: false})},
     genesis: {type: RunnerType.default, fn: genesis},
     light_client: {type: RunnerType.default, fn: lightClient},
     merkle: {type: RunnerType.default, fn: merkle},
@@ -51,7 +51,7 @@ specTestIterator(
         "LightClientOptimisticUpdate",
       ]),
     },
-    sync: {type: RunnerType.default, fn: forkChoiceTest},
+    sync: {type: RunnerType.default, fn: forkChoiceTest({onlyPredefinedResponses: true})},
     transition: {type: RunnerType.default, fn: transition},
   },
   skipOpts

--- a/packages/beacon-node/test/unit/executionEngine/http.test.ts
+++ b/packages/beacon-node/test/unit/executionEngine/http.test.ts
@@ -1,12 +1,9 @@
 import {expect} from "chai";
 import {fastify} from "fastify";
 import {ForkName} from "@lodestar/params";
-import {
-  ExecutionEngineHttp,
-  parseExecutionPayload,
-  serializeExecutionPayload,
-  defaultExecutionEngineHttpOpts,
-} from "../../../src/execution/engine/http.js";
+import {defaultExecutionEngineHttpOpts} from "../../../src/execution/engine/http.js";
+import {IExecutionEngine, initializeExecutionEngine} from "../../../src/execution/index.js";
+import {parseExecutionPayload, serializeExecutionPayload} from "../../../src/execution/engine/types.js";
 
 describe("ExecutionEngine / http", () => {
   const afterCallbacks: (() => Promise<void> | void)[] = [];
@@ -17,7 +14,7 @@ describe("ExecutionEngine / http", () => {
     }
   });
 
-  let executionEngine: ExecutionEngineHttp;
+  let executionEngine: IExecutionEngine;
   let returnValue: unknown = {};
   let reqJsonRpcPayload: unknown = {};
 
@@ -38,8 +35,9 @@ describe("ExecutionEngine / http", () => {
 
     const baseUrl = await server.listen(0);
 
-    executionEngine = new ExecutionEngineHttp(
+    executionEngine = initializeExecutionEngine(
       {
+        mode: "http",
         urls: [baseUrl],
         retryAttempts: defaultExecutionEngineHttpOpts.retryAttempts,
         retryDelay: defaultExecutionEngineHttpOpts.retryDelay,

--- a/packages/beacon-node/test/unit/executionEngine/httpRetry.test.ts
+++ b/packages/beacon-node/test/unit/executionEngine/httpRetry.test.ts
@@ -3,9 +3,9 @@ import {fastify} from "fastify";
 import {ForkName} from "@lodestar/params";
 import {fromHexString} from "@chainsafe/ssz";
 
-import {ExecutionEngineHttp, defaultExecutionEngineHttpOpts} from "../../../src/execution/engine/http.js";
+import {defaultExecutionEngineHttpOpts} from "../../../src/execution/engine/http.js";
 import {bytesToData, numToQuantity} from "../../../src/eth1/provider/utils.js";
-import {PayloadAttributes} from "../../../src/execution/index.js";
+import {IExecutionEngine, initializeExecutionEngine, PayloadAttributes} from "../../../src/execution/index.js";
 
 describe("ExecutionEngine / http ", () => {
   const afterCallbacks: (() => Promise<void> | void)[] = [];
@@ -16,7 +16,7 @@ describe("ExecutionEngine / http ", () => {
     }
   });
 
-  let executionEngine: ExecutionEngineHttp;
+  let executionEngine: IExecutionEngine;
   let returnValue: unknown = {};
   let reqJsonRpcPayload: unknown = {};
   let baseUrl: string;
@@ -45,8 +45,9 @@ describe("ExecutionEngine / http ", () => {
 
     baseUrl = await server.listen(0);
 
-    executionEngine = new ExecutionEngineHttp(
+    executionEngine = initializeExecutionEngine(
       {
+        mode: "http",
         urls: [baseUrl],
         retryAttempts: defaultExecutionEngineHttpOpts.retryAttempts,
         retryDelay: defaultExecutionEngineHttpOpts.retryDelay,
@@ -100,7 +101,6 @@ describe("ExecutionEngine / http ", () => {
         timestamp: 1647036763,
         prevRandao: fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000"),
         suggestedFeeRecipient: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
-        fork: ForkName.bellatrix,
       };
 
       const request = {

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -96,7 +96,7 @@ export interface IForkChoice {
    * The supplied `attestation` **must** pass the `in_valid_indexed_attestation` function as it
    * will not be run here.
    */
-  onAttestation(attestation: phase0.IndexedAttestation, attDataRoot?: string): void;
+  onAttestation(attestation: phase0.IndexedAttestation, attDataRoot?: string, forceImport?: boolean): void;
   /**
    * Register attester slashing in order not to consider their votes in `getHead`
    *

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -19,3 +19,5 @@ export enum ForkSeq {
   capella = 3,
   eip4844 = 4,
 }
+
+export type ForkExecution = ForkName.bellatrix | ForkName.capella | ForkName.eip4844;

--- a/packages/params/src/index.ts
+++ b/packages/params/src/index.ts
@@ -6,7 +6,7 @@ import {presetStatus} from "./presetStatus.js";
 import {userSelectedPreset, userOverrides} from "./setPreset.js";
 
 export {BeaconPreset} from "./interface.js";
-export {ForkName, ForkSeq} from "./forkName.js";
+export {ForkName, ForkSeq, ForkExecution} from "./forkName.js";
 export {presetToJson} from "./json.js";
 export {PresetName};
 


### PR DESCRIPTION
**Motivation**

Last remaining item we were not running for spec tests. The `sync` spec tests use the same runner as the `fork_choice` tests but with optimistic sync. It requires to inject execution engine replies ahead of submitting blocks.

**Description**

- Refactor execution engine mock to allow modifying its backend and inject responses, while re-using our production-path logic to manage status responses

to use the mock execution backend with this PR:

```ts
const executionEngineBackend = new ExecutionEngineMockBackend({genesisBlockHash: "some-hash"});
const executionEngine = getExecutionEngineFromBackend(executionEngineBackend, {signal});
// Pass `executionEngine` as module to BeaconChain

// Latter in the test
executionEngineBackend.addPowBlock(powBlock);
executionEngineBackend.addPredefinedPayloadStatus(step.block_hash, step.payload_status);
```
