### PR TITLE
Mock validator client

### DIFF
--- a/packages/cli/docsgen/index.ts
+++ b/packages/cli/docsgen/index.ts
@@ -43,7 +43,7 @@ fs.writeFileSync(docsMarkdownPath, docsString);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function cmdToMarkdownSection(cmd: ICliCommand<any>, parentCommand?: string): IMarkdownSection {
   const commandJson = [parentCommand, cmd.command.replace("<command>", "")].filter(Boolean).join(" ");
-  const body = [cmd.describe];
+  const body = [cmd.describe as string];
 
   if (cmd.examples) {
     body.push("**Examples**");
@@ -76,7 +76,10 @@ function cmdToMarkdownSection(cmd: ICliCommand<any>, parentCommand?: string): IM
   return {
     title: `\`${commandJson}\``,
     body,
-    subsections: (cmd.subcommands || []).map((subcmd) => cmdToMarkdownSection(subcmd, commandJson)),
+    subsections: (cmd.subcommands || [])
+      // do not render hidden subcommand
+      .filter((cmd) => cmd.describe !== false)
+      .map((subcmd) => cmdToMarkdownSection(subcmd, commandJson)),
   };
 }
 

--- a/packages/cli/src/cmds/validator/index.ts
+++ b/packages/cli/src/cmds/validator/index.ts
@@ -8,6 +8,7 @@ import {voluntaryExit} from "./voluntaryExit.js";
 import {blsToExecutionChange} from "./blsToExecutionChange.js";
 import {validatorOptions, IValidatorCliArgs} from "./options.js";
 import {validatorHandler} from "./handler.js";
+import {mock} from "./mock.js";
 
 export const validator: ICliCommand<IValidatorCliArgs, IGlobalArgs> = {
   command: "validator",
@@ -22,5 +23,5 @@ export const validator: ICliCommand<IValidatorCliArgs, IGlobalArgs> = {
   ],
   options: validatorOptions,
   handler: validatorHandler,
-  subcommands: [slashingProtection, importCmd, list, voluntaryExit, blsToExecutionChange],
+  subcommands: [slashingProtection, importCmd, list, voluntaryExit, blsToExecutionChange, mock],
 };

--- a/packages/cli/src/cmds/validator/mock.ts
+++ b/packages/cli/src/cmds/validator/mock.ts
@@ -35,8 +35,8 @@ export const mock: ICliCommand<MockValidatorArgs, IGlobalArgs> = {
       description: "The beacon node http url",
       type: "string",
     },
-    // Metrics
 
+    // Metrics
     metrics: {
       type: "boolean",
       description: "Enable the Prometheus metrics HTTP server",
@@ -87,13 +87,12 @@ export const mock: ICliCommand<MockValidatorArgs, IGlobalArgs> = {
     logger.info("Connecting to LevelDB database", {path: validatorPaths.validatorsDbDir});
     const register = args["metrics"] ? new RegistryMetricCreator() : null;
     const metrics = register && getMetrics((register as unknown) as MetricsRegister, {version, commit, network});
+
     if (metrics) {
       collectNodeJSMetrics(register);
-
       const port = args["metrics.port"] ?? validatorMetricsDefaultOptions.port;
       const address = args["metrics.address"] ?? validatorMetricsDefaultOptions.address;
       const metricsServer = new HttpMetricsServer({port, address}, {register, logger});
-
       onGracefulShutdownCbs.push(() => metricsServer.stop());
       await metricsServer.start();
     }

--- a/packages/cli/src/cmds/validator/mock.ts
+++ b/packages/cli/src/cmds/validator/mock.ts
@@ -12,7 +12,7 @@ import {validatorMetricsDefaultOptions} from "./options.js";
 /* eslint-disable no-console */
 
 type MockValidatorArgs = {
-  beaconNode: string;
+  beaconNodes: string;
   metrics?: boolean;
   "metrics.port"?: number;
   "metrics.address"?: string;
@@ -25,13 +25,14 @@ export const mock: ICliCommand<MockValidatorArgs, IGlobalArgs> = {
 
   examples: [
     {
-      command: "validator mock --beaconNode ...",
+      command: "validator mock --beaconNodes ...",
       description: "Run validator mock connecting to a specified beacon node url",
     },
   ],
 
   options: {
-    beaconNode: {
+    // same to validator to simplify deployment
+    beaconNodes: {
       description: "The beacon node http url",
       type: "string",
     },
@@ -100,7 +101,7 @@ export const mock: ICliCommand<MockValidatorArgs, IGlobalArgs> = {
     const mockValidator = await MockValidator.initializeFromBeaconNode(
       {
         config,
-        api: args.beaconNode,
+        api: args.beaconNodes,
         logger,
         abortController,
       },

--- a/packages/cli/src/cmds/validator/mock.ts
+++ b/packages/cli/src/cmds/validator/mock.ts
@@ -1,0 +1,66 @@
+import {setMaxListeners} from "node:events";
+import path from "node:path";
+import {MockValidator} from "@lodestar/validator";
+import {getCliLogger, ICliCommand, onGracefulShutdown} from "../../util/index.js";
+import {IGlobalArgs} from "../../options/index.js";
+import {getBeaconConfigFromArgs} from "../../config/index.js";
+import {getValidatorPaths} from "./paths.js";
+
+/* eslint-disable no-console */
+
+type MockValidatorArgs = {
+  beaconNode: string;
+};
+
+export const mock: ICliCommand<MockValidatorArgs, IGlobalArgs> = {
+  command: "mock",
+  // hide the command
+  describe: false,
+
+  examples: [
+    {
+      command: "validator mock --beaconNode ...",
+      description: "Run validator mock connecting to a specified beacon node url",
+    },
+  ],
+
+  options: {
+    beaconNode: {
+      description: "The beacon node http url",
+      type: "string",
+    },
+  },
+
+  handler: async (args) => {
+    const {config, network} = getBeaconConfigFromArgs(args);
+    const validatorPaths = getValidatorPaths(args, network);
+    const logger = getCliLogger(
+      args,
+      {defaultLogFilepath: path.join(validatorPaths.dataDir, "validator-mock.log")},
+      config
+    );
+
+    // This AbortController interrupts various validators ops: genesis req, clients call, clock etc
+    const abortController = new AbortController();
+
+    // We set infinity for abort controller used for validator operations,
+    // to prevent MaxListenersExceededWarning which get logged when listeners > 10
+    // Since it is perfectly fine to have listeners > 10
+    setMaxListeners(Infinity, abortController.signal);
+
+    const onGracefulShutdownCbs: (() => Promise<void> | void)[] = [];
+    onGracefulShutdown(async () => {
+      for (const cb of onGracefulShutdownCbs) await cb();
+    }, logger.info.bind(logger));
+    onGracefulShutdownCbs.push(async () => abortController.abort());
+
+    const mockValidator = await MockValidator.initializeFromBeaconNode({
+      config,
+      api: args.beaconNode,
+      logger,
+      abortController,
+    });
+
+    onGracefulShutdownCbs.push(() => mockValidator.close());
+  },
+};

--- a/packages/cli/src/util/command.ts
+++ b/packages/cli/src/util/command.ts
@@ -5,7 +5,7 @@ export type ICliCommandOptions<OwnArgs> = Required<{[key in keyof OwnArgs]: Opti
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface ICliCommand<OwnArgs = Record<never, never>, ParentArgs = Record<never, never>, R = any> {
   command: string;
-  describe: string;
+  describe: string | false;
   examples?: {command: string; description: string}[];
   options?: ICliCommandOptions<OwnArgs>;
   // 1st arg: any = free own sub command options

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -1,4 +1,5 @@
 export {Validator, ValidatorOptions} from "./validator.js";
+export {MockValidator} from "./mock.js";
 export {
   ValidatorStore,
   SignerType,

--- a/packages/validator/src/mock.ts
+++ b/packages/validator/src/mock.ts
@@ -110,7 +110,7 @@ export class MockValidator {
   /**
    * Produce attestation data right at 1/3 of slot to monitor I/O lag issue.
    */
-  private async produceAttestationData(slot: Slot): Promise<void> {
+  private produceAttestationData = async (slot: Slot): Promise<void> => {
     await sleep(this.clock.msToSlot(slot + 1 / 3));
     // There should be committee index 0 in all committees
     const committeeIndex = 0;
@@ -119,5 +119,5 @@ export class MockValidator {
       throw extendError(e, "Error producing attestation");
     });
     this.logger.info("Produced attestation successfully", {slot, committeeIndex});
-  }
+  };
 }

--- a/packages/validator/src/mock.ts
+++ b/packages/validator/src/mock.ts
@@ -1,0 +1,122 @@
+import {createIBeaconConfig, IBeaconConfig, IChainForkConfig} from "@lodestar/config";
+import {Genesis} from "@lodestar/types/phase0";
+import {extendError, ILogger, sleep} from "@lodestar/utils";
+import {getClient, Api} from "@lodestar/api";
+import {Slot} from "@lodestar/types";
+import {Clock, IClock} from "./util/clock.js";
+import {waitForGenesis} from "./genesis.js";
+import {assertEqualParams} from "./util/index.js";
+import {ValidatorEventEmitter} from "./services/emitter.js";
+import {Metrics} from "./metrics.js";
+
+export type MockValidatorOptions = {
+  config: IChainForkConfig;
+  api: Api | string | string[];
+  logger: ILogger;
+  abortController: AbortController;
+};
+
+enum Status {
+  running,
+  closed,
+}
+
+/**
+ * A mock validator that consistenly produce attestations right at 1/3 of slot to help monitor the I/O lag issue.
+ */
+export class MockValidator {
+  private readonly config: IBeaconConfig;
+  private readonly api: Api;
+  private readonly clock: IClock;
+  private readonly logger: ILogger;
+  private state: Status;
+  private readonly controller: AbortController;
+
+  constructor(opts: MockValidatorOptions, readonly genesis: Genesis, metrics: Metrics | null = null) {
+    const {logger} = opts;
+    const config = createIBeaconConfig(opts.config, genesis.genesisValidatorsRoot);
+    this.controller = opts.abortController;
+    const clock = new Clock(config, logger, {genesisTime: Number(genesis.genesisTime)});
+
+    let api: Api;
+    if (typeof opts.api === "string" || Array.isArray(opts.api)) {
+      api = getClient(
+        {
+          urls: typeof opts.api === "string" ? [opts.api] : opts.api,
+          // Validator would need the beacon to respond within the slot
+          timeoutMs: config.SECONDS_PER_SLOT * 1000,
+          getAbortSignal: () => this.controller.signal,
+        },
+        {config, logger, metrics: metrics?.restApiClient}
+      );
+    } else {
+      api = opts.api;
+    }
+
+    const emitter = new ValidatorEventEmitter();
+    // Validator event emitter can have more than 10 listeners in a normal course of operation
+    // We set infinity to prevent MaxListenersExceededWarning which get logged when listeners > 10
+    emitter.setMaxListeners(Infinity);
+
+    this.config = config;
+    this.logger = logger;
+    this.api = api;
+    this.clock = clock;
+
+    // "start" the validator
+    this.state = Status.running;
+    this.clock.start(this.controller.signal);
+
+    this.clock.runEverySlot(this.produceAttestationData);
+  }
+
+  get isRunning(): boolean {
+    return this.state === Status.running;
+  }
+
+  /** Waits for genesis and genesis time */
+  static async initializeFromBeaconNode(opts: MockValidatorOptions, metrics?: Metrics | null): Promise<MockValidator> {
+    const {config, logger} = opts;
+
+    let api: Api;
+    if (typeof opts.api === "string" || Array.isArray(opts.api)) {
+      const urls = typeof opts.api === "string" ? [opts.api] : opts.api;
+      // This new api instance can make do with default timeout as a faster timeout is
+      // not necessary since this instance won't be used for validator duties
+      api = getClient({urls, getAbortSignal: () => opts.abortController.signal}, {config, logger});
+    } else {
+      api = opts.api;
+    }
+
+    const genesis = await waitForGenesis(api, opts.logger, opts.abortController.signal);
+    logger.info("Genesis fetched from the beacon node");
+
+    const {data: externalSpecJson} = await api.config.getSpec();
+    assertEqualParams(config, externalSpecJson);
+    logger.info("Verified connected beacon node and validator have same the config");
+
+    return new MockValidator(opts, genesis, metrics);
+  }
+
+  /**
+   * Stops all validator functions.
+   */
+  async close(): Promise<void> {
+    if (this.state === Status.closed) return;
+    this.controller.abort();
+    this.state = Status.closed;
+  }
+
+  /**
+   * Produce attestation data right at 1/3 of slot to monitor I/O lag issue.
+   */
+  private async produceAttestationData(slot: Slot): Promise<void> {
+    await sleep(this.clock.msToSlot(slot + 1 / 3));
+    // There should be committee index 0 in all committees
+    const committeeIndex = 0;
+    await this.api.validator.produceAttestationData(committeeIndex, slot).catch((e: Error) => {
+      throw extendError(e, "Error producing attestation");
+    });
+    this.logger.info("Produced attestation successfully", {slot, committeeIndex});
+  }
+}

--- a/packages/validator/src/mock.ts
+++ b/packages/validator/src/mock.ts
@@ -65,9 +65,8 @@ export class MockValidator {
 
     // "start" the validator
     this.state = Status.running;
-    this.clock.start(this.controller.signal);
-
     this.clock.runEverySlot(this.produceAttestationData);
+    this.clock.start(this.controller.signal);
   }
 
   get isRunning(): boolean {

--- a/packages/validator/src/mock.ts
+++ b/packages/validator/src/mock.ts
@@ -59,7 +59,7 @@ export class MockValidator {
     emitter.setMaxListeners(Infinity);
 
     this.config = config;
-    this.logger = logger;
+    this.logger = logger.child({module: "mock"});
     this.api = api;
     this.clock = clock;
 
@@ -114,6 +114,7 @@ export class MockValidator {
     await sleep(this.clock.msToSlot(slot + 1 / 3));
     // There should be committee index 0 in all committees
     const committeeIndex = 0;
+    this.logger.info("Producing attestation data", {slot, committeeIndex});
     await this.api.validator.produceAttestationData(committeeIndex, slot).catch((e: Error) => {
       throw extendError(e, "Error producing attestation");
     });


### PR DESCRIPTION
**Motivation**

We want to track the I/O lag issue statically

**Description**

- Write a mock vc that produce attestation right at 1/3 of slot
- New sub-command, for example `validator mock --beaconNode http://localhost:9596 --network goerli --metrics true`

part of #4002, #4881