### PR TITLE
Force usage of Uint8Array.prototype.slice in effectiveBalanceIncrements

### DIFF
--- a/packages/state-transition/src/cache/epochContext.ts
+++ b/packages/state-transition/src/cache/epochContext.ts
@@ -516,8 +516,9 @@ export class EpochContext {
   }
 
   beforeEpochTransition(): void {
-    // Clone before being mutated in processEffectiveBalanceUpdates
-    this.effectiveBalanceIncrements = this.effectiveBalanceIncrements.slice(0);
+    // Clone (copy) before being mutated in processEffectiveBalanceUpdates
+    // NOTE: Force to use Uint8Array.slice (copy) instead of Buffer.call (not copy)
+    this.effectiveBalanceIncrements = Uint8Array.prototype.slice.call(this.effectiveBalanceIncrements, 0);
   }
 
   /**

--- a/packages/state-transition/src/util/balance.ts
+++ b/packages/state-transition/src/util/balance.ts
@@ -56,7 +56,12 @@ export function getEffectiveBalanceIncrementsZeroInactive(
   const validatorCount = justifiedState.validators.length;
   const {effectiveBalanceIncrements} = justifiedState.epochCtx;
   // Slice up to `validatorCount` since it won't be mutated, nor accessed beyond `validatorCount`
-  const effectiveBalanceIncrementsZeroInactive = effectiveBalanceIncrements.slice(0, validatorCount);
+  // NOTE: Force to use Uint8Array.slice (copy) instead of Buffer.call (not copy)
+  const effectiveBalanceIncrementsZeroInactive = Uint8Array.prototype.slice.call(
+    effectiveBalanceIncrements,
+    0,
+    validatorCount
+  );
 
   let j = 0;
   for (let i = 0; i < validatorCount; i++) {


### PR DESCRIPTION
**Motivation**

- See https://github.com/ChainSafe/lodestar/issues/4390

Uint8Array.slice copy while Buffer.slice does not copy. Prevent a future footgun by forcing the former.

**Description**

Closes https://github.com/ChainSafe/lodestar/issues/4390
