### PR TITLE
Track beacon health from vc

### DIFF
--- a/packages/validator/src/metrics.ts
+++ b/packages/validator/src/metrics.ts
@@ -3,6 +3,14 @@ export enum MessageSource {
   publish = "publish",
 }
 
+export enum BeaconHealth {
+  READY = 0,
+  SYNCING = 1,
+  NOT_INITIALIZED_OR_ISSUES = 2,
+  UNKNOWN = 3,
+  ERROR = 4,
+}
+
 type LabelsGeneric = Record<string, string | undefined>;
 type CollectFn<Labels extends LabelsGeneric> = (metric: Gauge<Labels>) => void;
 
@@ -312,6 +320,11 @@ export function getMetrics(register: MetricsRegister, gitData: LodestarGitData) 
 
     // REST API client
 
+    beaconHealth: register.gauge({
+      name: "vc_beacon_health",
+      help: `Current health status of the beacon(s) the validator is connected too. ${renderEnumNumeric(BeaconHealth)}`,
+    }),
+
     restApiClient: {
       requestTime: register.histogram<{routeId: string}>({
         name: "vc_rest_api_client_request_time_seconds",
@@ -408,4 +421,16 @@ export function getMetrics(register: MetricsRegister, gitData: LodestarGitData) 
       }),
     },
   };
+}
+
+export function renderEnumNumeric(obj: Record<string, unknown>): string {
+  const out: string[] = [];
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value === "number") {
+      out.push(`${key}=${value}`);
+    }
+  }
+
+  return out.join(", ");
 }

--- a/packages/validator/test/unit/utils/metrics.test.ts
+++ b/packages/validator/test/unit/utils/metrics.test.ts
@@ -1,0 +1,10 @@
+import {expect} from "chai";
+import {BeaconHealth, renderEnumNumeric} from "../../../src/metrics.js";
+
+describe("renderEnumNumeric", () => {
+  it("BeaconHealth", () => {
+    expect(renderEnumNumeric(BeaconHealth)).equals(
+      "READY=0, SYNCING=1, NOT_INITIALIZED_OR_ISSUES=2, UNKNOWN=3, ERROR=4"
+    );
+  });
+});


### PR DESCRIPTION
**Motivation**

- See https://github.com/ChainSafe/lodestar/issues/4637

**Description**

Adds metric `vc_beacon_health` to track the health of the "current" connected beacon node. Note that retry logic of the multi-endpoint REST client apply, but should represent the current URL that the validator client is attempting to pull duties from. 

Performance wise, for the beacon node serving a GET /node/health request is practically free. This PR could be implemented too by inspecting errors from existing API calls to duties. However depending on the lifecycle of imported keys the validator behavior is not constant. Having a constant every slot poll ensure that the metric `vc_beacon_health` accurately reflects the status of the beacon node.

Closes https://github.com/ChainSafe/lodestar/issues/4637
