### PR TITLE
Enable keymanager API spec tests

### DIFF
--- a/packages/api/src/keymanager/routes.ts
+++ b/packages/api/src/keymanager/routes.ts
@@ -1,4 +1,15 @@
-import {ReturnTypes, RoutesData, Schema, reqEmpty, ReqSerializers, ReqEmpty, jsonType} from "../utils/index.js";
+import {ContainerType} from "@chainsafe/ssz";
+import {ssz, stringType} from "@lodestar/types";
+import {
+  ReturnTypes,
+  RoutesData,
+  Schema,
+  reqEmpty,
+  ReqSerializers,
+  ReqEmpty,
+  jsonType,
+  ContainerData,
+} from "../utils/index.js";
 
 export enum ImportStatus {
   /** Keystore successfully decrypted and imported to keymanager permanent storage */
@@ -237,7 +248,7 @@ export type ReqTypes = {
   deleteFeeRecipient: {params: {pubkey: string}};
 
   getGasLimit: {params: {pubkey: string}};
-  setGasLimit: {params: {pubkey: string}; body: {gas_limit: string | number}};
+  setGasLimit: {params: {pubkey: string}; body: {gas_limit: string}};
   deleteGasLimit: {params: {pubkey: string}};
 };
 
@@ -298,7 +309,7 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
       },
     },
     setGasLimit: {
-      writeReq: (pubkey, gas_limit) => ({params: {pubkey}, body: {gas_limit}}),
+      writeReq: (pubkey, gasLimit) => ({params: {pubkey}, body: {gas_limit: gasLimit.toString(10)}}),
       parseReq: ({params: {pubkey}, body: {gas_limit}}) => [pubkey, parseGasLimit(gas_limit)],
       schema: {
         params: {pubkey: Schema.StringRequired},
@@ -327,7 +338,15 @@ export function getReturnTypes(): ReturnTypes<Api> {
     deleteRemoteKeys: jsonType("snake"),
 
     listFeeRecipient: jsonType("snake"),
-    getGasLimit: jsonType("snake"),
+    getGasLimit: ContainerData(
+      new ContainerType(
+        {
+          pubkey: stringType,
+          gasLimit: ssz.UintNum64,
+        },
+        {jsonCase: "eth2"}
+      )
+    ),
   };
 }
 

--- a/packages/api/test/unit/keymanager/oapiSpec.test.ts
+++ b/packages/api/test/unit/keymanager/oapiSpec.test.ts
@@ -11,20 +11,16 @@ import {testData} from "./testData.js";
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const skip = true;
-const version = "v1.0.0-alpha";
-const commit = "e718c8503b1c65b9b9bd9a4f8f37da9f0001850c";
+const version = "v1.0.0";
 const openApiFile: OpenApiFile = {
-  url: `https://github.com/ethereum/keymanager-APIs/blob/${commit}/keymanager-oapi.yaml`,
+  url: `https://github.com/ethereum/keymanager-APIs/releases/download/${version}/keymanager-oapi.json`,
   filepath: path.join(__dirname, "../../../oapi-schemas/builder-oapi.json"),
   version: RegExp(version),
 };
 
 // TODO: un-skip in follow-up PR, this PR only adds basic infra for spec testing
-if (!skip) {
-  const reqSerializers = getReqSerializers();
-  const returnTypes = getReturnTypes();
+const reqSerializers = getReqSerializers();
+const returnTypes = getReturnTypes();
 
-  const openApiJson = await fetchOpenApiSpec(openApiFile);
-  runTestCheckAgainstSpec(openApiJson, routesData, reqSerializers, returnTypes, testData);
-}
+const openApiJson = await fetchOpenApiSpec(openApiFile);
+runTestCheckAgainstSpec(openApiJson, routesData, reqSerializers, returnTypes, testData);

--- a/packages/api/test/utils/fetchOpenApiSpec.ts
+++ b/packages/api/test/utils/fetchOpenApiSpec.ts
@@ -19,7 +19,13 @@ export async function fetchOpenApiSpec(openApiFile: OpenApiFile): Promise<OpenAp
   const openApiStr = await fetch(openApiFile.url).then((res) => res.text());
 
   // Parse before writting to ensure it's proper JSON
-  const openApiJson = JSON.parse(openApiStr) as OpenApiJson;
+  let openApiJson: OpenApiJson;
+  try {
+    openApiJson = JSON.parse(openApiStr) as OpenApiJson;
+  } catch (e) {
+    console.log(openApiStr);
+    throw e;
+  }
 
   fs.mkdirSync(path.dirname(openApiFile.filepath), {recursive: true});
   fs.writeFileSync(openApiFile.filepath, openApiStr);

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,4 +3,4 @@ export * as ssz from "./sszTypes.js";
 // Typeguards
 export * from "./utils/typeguards.js";
 // String type
-export {StringType} from "./utils/StringType.js";
+export {StringType, stringType} from "./utils/StringType.js";

--- a/packages/types/src/utils/StringType.ts
+++ b/packages/types/src/utils/StringType.ts
@@ -53,3 +53,5 @@ export class StringType<T extends string = string> extends BasicType<T> {
     return value;
   }
 }
+
+export const stringType = new StringType();


### PR DESCRIPTION
**Motivation**

Ensure keymanager API complies with JSON schema from OpenAPI spec

**Description**

- Enable tests with latest release
- Fix serialization bug where gas_limit must be rendered as a string

Closes https://github.com/ChainSafe/lodestar/issues/4497