### PR TITLE
Keep at least 10% outbound peers

### DIFF
--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -406,6 +406,7 @@ export class PeerManager {
         const peerData = this.connectedPeers.get(peer.toString());
         return {
           id: peer,
+          direction: peerData?.direction ?? null,
           attnets: peerData?.metadata?.attnets ?? null,
           syncnets: peerData?.metadata?.syncnets ?? null,
           score: this.peerRpcScores.getScore(peer),

--- a/packages/beacon-node/test/perf/network/peers/util/prioritizePeers.test.ts
+++ b/packages/beacon-node/test/perf/network/peers/util/prioritizePeers.test.ts
@@ -91,8 +91,9 @@ describe("prioritizePeers", () => {
          * No peer with no long-lived subnets
          * No peer with bad score
          **/
-        const connectedPeers = seedPeers.map((peer, i) => ({
+        const connectedPeers: Parameters<typeof prioritizePeers>[0] = seedPeers.map((peer, i) => ({
           ...peer,
+          direction: null,
           attnets: getAttnets(
             Array.from({length: Math.floor(attnetPercentage * ATTESTATION_SUBNET_COUNT)}, (_, i) => i)
           ),


### PR DESCRIPTION
**Motivation**

To protect against eclipse attacks always keep some outbound peers. Outbound peers are chosen at random from walking the discv5 DHT, while an attacker can easily direct target_peers worth of nodes to connect to us, such that we only listen to attack nodes. Taking over the discv5 DHT is much more difficult, thus the min ratio of outbound peers.

- See https://github.com/ChainSafe/lodestar/issues/2215

**Description**

- Keep at least 10% outbound peers

Closes https://github.com/ChainSafe/lodestar/issues/2215