### PR TITLE
Fix headState does not exist

### DIFF
--- a/packages/beacon-node/src/chain/stateCache/stateContextCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/stateContextCache.ts
@@ -39,13 +39,9 @@ export class StateContextCache {
 
   get(rootHex: RootHex): CachedBeaconStateAllForks | null {
     this.metrics?.lookups.inc();
-    const item = this.cache.get(rootHex);
+    const item = this.head?.stateRoot === rootHex ? this.head.state : this.cache.get(rootHex);
     if (!item) {
       return null;
-    }
-
-    if (this.head?.stateRoot === rootHex) {
-      return this.head.state;
     }
 
     this.metrics?.hits.inc();


### PR DESCRIPTION
**Motivation**

We have head state strong reference but it does not work if head state is not in the cache

**Description**

- In `StateContextCache.get` check/get from head state strong ref first before the cache

Closes #4700 
