### PR TITLE
Clean old log files

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -11,8 +11,8 @@ import {ProcessShutdownCallback} from "@lodestar/validator";
 
 import {IGlobalArgs, parseBeaconNodeArgs} from "../../options/index.js";
 import {BeaconNodeOptions, exportToJSON, FileENR, getBeaconConfigFromArgs} from "../../config/index.js";
-import {onGracefulShutdown, getCliLogger, mkdir, writeFile600Perm} from "../../util/index.js";
 import {getNetworkBootnodes, getNetworkData, isKnownNetworkName, readBootnodes} from "../../networks/index.js";
+import {onGracefulShutdown, getCliLogger, mkdir, writeFile600Perm, cleanOldLogFiles} from "../../util/index.js";
 import {getVersionData} from "../../util/version.js";
 import {defaultP2pPort} from "../../options/beaconNodeOptions/network.js";
 import {IBeaconArgs} from "./options.js";
@@ -31,7 +31,16 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
   mkdir(beaconPaths.dbDir);
 
   const abortController = new AbortController();
-  const logger = getCliLogger(args, {defaultLogFilepath: path.join(beaconPaths.dataDir, "beacon.log")}, config);
+  const {logger, logParams} = getCliLogger(
+    args,
+    {defaultLogFilepath: path.join(beaconPaths.dataDir, "beacon.log")},
+    config
+  );
+  try {
+    cleanOldLogFiles(logParams.filename, logParams.rotateMaxFiles);
+  } catch (e) {
+    logger.debug("Not able to delete log files", logParams, e as Error);
+  }
 
   onGracefulShutdown(async () => {
     abortController.abort();

--- a/packages/cli/src/cmds/lightclient/handler.ts
+++ b/packages/cli/src/cmds/lightclient/handler.ts
@@ -13,7 +13,7 @@ export async function lightclientHandler(args: ILightClientArgs & IGlobalArgs): 
   const {config, network} = getBeaconConfigFromArgs(args);
   const globalPaths = getGlobalPaths(args, network);
 
-  const logger = getCliLogger(args, {defaultLogFilepath: path.join(globalPaths.dataDir, "lightclient.log")}, config);
+  const {logger} = getCliLogger(args, {defaultLogFilepath: path.join(globalPaths.dataDir, "lightclient.log")}, config);
   const {beaconApiUrl, checkpointRoot} = args;
   const api = getClient({baseUrl: beaconApiUrl}, {config});
   const {data: genesisData} = await api.beacon.getGenesis();

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -6,7 +6,7 @@ import {getMetrics, MetricsRegister} from "@lodestar/validator";
 import {RegistryMetricCreator, collectNodeJSMetrics, HttpMetricsServer} from "@lodestar/beacon-node";
 import {getBeaconConfigFromArgs} from "../../config/index.js";
 import {IGlobalArgs} from "../../options/index.js";
-import {YargsError, getDefaultGraffiti, mkdir, getCliLogger} from "../../util/index.js";
+import {YargsError, getDefaultGraffiti, mkdir, getCliLogger, cleanOldLogFiles} from "../../util/index.js";
 import {onGracefulShutdown, parseFeeRecipient, parseProposerConfig} from "../../util/index.js";
 import {getVersionData} from "../../util/version.js";
 import {getAccountPaths, getValidatorPaths} from "./paths.js";
@@ -29,7 +29,16 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
   const validatorPaths = getValidatorPaths(args, network);
   const accountPaths = getAccountPaths(args, network);
 
-  const logger = getCliLogger(args, {defaultLogFilepath: path.join(validatorPaths.dataDir, "validator.log")}, config);
+  const {logger, logParams} = getCliLogger(
+    args,
+    {defaultLogFilepath: path.join(validatorPaths.dataDir, "validator.log")},
+    config
+  );
+  try {
+    cleanOldLogFiles(logParams.filename, logParams.rotateMaxFiles);
+  } catch (e) {
+    logger.debug("Not able to delete log files", logParams, e as Error);
+  }
 
   const persistedKeysBackend = new PersistedKeysBackend(accountPaths);
   const valProposerConfig = getProposerConfigFromArgs(args, {persistedKeysBackend, accountPaths});

--- a/packages/cli/src/cmds/validator/slashingProtection/export.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/export.ts
@@ -42,7 +42,11 @@ export const exportCmd: ICliCommand<
     const {config, network} = getBeaconConfigFromArgs(args);
     const validatorPaths = getValidatorPaths(args, network);
     // slashingProtection commands are fast so do not require logFile feature
-    const logger = getCliLogger(args, {defaultLogFilepath: path.join(validatorPaths.dataDir, "validator.log")}, config);
+    const {logger} = getCliLogger(
+      args,
+      {defaultLogFilepath: path.join(validatorPaths.dataDir, "validator.log")},
+      config
+    );
 
     const {validatorsDbDir: dbPath} = getValidatorPaths(args, network);
 

--- a/packages/cli/src/cmds/validator/slashingProtection/import.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/import.ts
@@ -43,7 +43,11 @@ export const importCmd: ICliCommand<
     const {config, network} = getBeaconConfigFromArgs(args);
     const validatorPaths = getValidatorPaths(args, network);
     // slashingProtection commands are fast so do not require logFile feature
-    const logger = getCliLogger(args, {defaultLogFilepath: path.join(validatorPaths.dataDir, "validator.log")}, config);
+    const {logger} = getCliLogger(
+      args,
+      {defaultLogFilepath: path.join(validatorPaths.dataDir, "validator.log")},
+      config
+    );
 
     const {validatorsDbDir: dbPath} = getValidatorPaths(args, network);
 

--- a/packages/cli/test/unit/util/logger.test.ts
+++ b/packages/cli/test/unit/util/logger.test.ts
@@ -1,0 +1,59 @@
+import {expect} from "chai";
+import sinon from "sinon";
+import {shouldDeleteLogFile} from "../../../src/util/logger.js";
+
+describe("shouldDeleteLogFile", function () {
+  const prefix = "beacon";
+  const extension = "log";
+
+  const sandbox = sinon.createSandbox();
+  beforeEach(() => {
+    sandbox.useFakeTimers(new Date("2023-01-01"));
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+  const tcs: {logFile: string; maxFiles: number; now: number; result: boolean}[] = [
+    // missing .log
+    {
+      logFile: "beacon-2022-12-25",
+      maxFiles: 5,
+      now: new Date("2023-01-01").getTime(),
+      result: false,
+    },
+    // close to now
+    {
+      logFile: "beacon-2022-12-28.log",
+      maxFiles: 5,
+      now: new Date("2023-01-01").getTime(),
+      result: false,
+    },
+    // incorrect date format
+    {
+      logFile: "beacon-20225-12-12.log",
+      maxFiles: 5,
+      now: new Date("2023-01-01").getTime(),
+      result: false,
+    },
+    // maxFiles is 10 so close to now
+    {
+      logFile: "beacon-2022-12-25.log",
+      maxFiles: 10,
+      now: new Date("2023-01-01").getTime(),
+      result: false,
+    },
+    {
+      logFile: "beacon-2022-12-25.log",
+      maxFiles: 5,
+      now: new Date("2023-01-01").getTime(),
+      result: true,
+    },
+  ];
+
+  for (const {logFile, maxFiles, result} of tcs) {
+    it(`should ${result ? "" : "not"} delete ${logFile}, maxFiles ${maxFiles}, today ${new Date()}`, () => {
+      expect(shouldDeleteLogFile(prefix, extension, logFile, maxFiles)).to.be.equal(result);
+    });
+  }
+});

--- a/packages/cli/test/unit/util/loggerTransport.test.ts
+++ b/packages/cli/test/unit/util/loggerTransport.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import rimraf from "rimraf";
 import {expect} from "chai";
 import {config} from "@lodestar/config/default";
-import {LodestarError, LogData, LogFormat, logFormats, LogLevel} from "@lodestar/utils";
+import {ILogger, LodestarError, LogData, LogFormat, logFormats, LogLevel} from "@lodestar/utils";
 import {getCliLogger, ILogArgs, LOG_FILE_DISABLE_KEYWORD} from "../../../src/util/logger.js";
 
 describe("winston logger format and options", () => {
@@ -138,13 +138,13 @@ describe("winston transport log to file", () => {
   });
 });
 
-function getCliLoggerTest(logArgs: Partial<ILogArgs>): ReturnType<typeof getCliLogger> {
+function getCliLoggerTest(logArgs: Partial<ILogArgs>): ILogger {
   return getCliLogger(
     {logFile: LOG_FILE_DISABLE_KEYWORD, ...logArgs},
     {defaultLogFilepath: "logger_transport_test.log"},
     config,
     {hideTimestamp: true}
-  );
+  ).logger;
 }
 
 /** Wait for file to exist have some content, then return its contents */


### PR DESCRIPTION
**Motivation**

Lodestar was not able to clean old log files after the node is offline for a while

**Description**
- Clean log files when starting the node based on the file name
- Do it for `beacon` and `validator` cli

Closes #4419
