### PR TITLE
Fix no peer issue

### DIFF
--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -119,6 +119,7 @@ export class PeerDiscovery {
         [K in keyof IMetrics["discv5"]]: IDiscv5Metrics[keyof IDiscv5Metrics];
       },
     });
+    opts.discv5.bootEnrs.forEach((bootEnr) => this.discv5.addEnr(bootEnr));
     this.logger.verbose("PeerDiscovery number of bootEnrs", {bootEnrs: opts.discv5.bootEnrs.length});
 
     if (metrics) {

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -119,11 +119,7 @@ export class PeerDiscovery {
         [K in keyof IMetrics["discv5"]]: IDiscv5Metrics[keyof IDiscv5Metrics];
       },
     });
-    this.logger.info("PeerDiscovery number of bootEnr", {bootEnrs: opts.discv5.bootEnrs.length});
-    opts.discv5.bootEnrs.forEach((bootEnr) => {
-      this.discv5.addEnr(bootEnr);
-      this.logger.info("PeerDiscovery", {bootEnr: bootEnr as string});
-    });
+    this.logger.verbose("PeerDiscovery number of bootEnrs", {bootEnrs: opts.discv5.bootEnrs.length});
 
     if (metrics) {
       metrics.discovery.cachedENRsSize.addCollect(() => {

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -119,7 +119,11 @@ export class PeerDiscovery {
         [K in keyof IMetrics["discv5"]]: IDiscv5Metrics[keyof IDiscv5Metrics];
       },
     });
-    opts.discv5.bootEnrs.forEach((bootEnr) => this.discv5.addEnr(bootEnr));
+    this.logger.info("PeerDiscovery number of bootEnr", {bootEnrs: opts.discv5.bootEnrs.length});
+    opts.discv5.bootEnrs.forEach((bootEnr) => {
+      this.discv5.addEnr(bootEnr);
+      this.logger.info("PeerDiscovery", {bootEnr: bootEnr as string});
+    });
 
     if (metrics) {
       metrics.discovery.cachedENRsSize.addCollect(() => {

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -12,7 +12,7 @@ import {ProcessShutdownCallback} from "@lodestar/validator";
 import {IGlobalArgs, parseBeaconNodeArgs} from "../../options/index.js";
 import {BeaconNodeOptions, exportToJSON, FileENR, getBeaconConfigFromArgs} from "../../config/index.js";
 import {onGracefulShutdown, getCliLogger, mkdir, writeFile600Perm} from "../../util/index.js";
-import {getNetworkBootnodes, getNetworkData, readBootnodes} from "../../networks/index.js";
+import {getNetworkBootnodes, getNetworkData, isKnownNetworkName, readBootnodes} from "../../networks/index.js";
 import {getVersionData} from "../../util/version.js";
 import {defaultP2pPort} from "../../options/beaconNodeOptions/network.js";
 import {IBeaconArgs} from "./options.js";
@@ -117,13 +117,13 @@ export async function beaconHandlerInit(args: IBeaconArgs & IGlobalArgs) {
   // Fetch extra bootnodes
   const extraBootnodes = (beaconNodeOptions.get().network?.discv5?.bootEnrs ?? []).concat(
     args.bootnodesFile ? readBootnodes(args.bootnodesFile) : [],
-    args.network ? await getNetworkBootnodes(args.network) : []
+    isKnownNetworkName(network) ? await getNetworkBootnodes(network) : []
   );
   beaconNodeOptions.set({network: {discv5: {bootEnrs: extraBootnodes}}});
 
   // Set known depositContractDeployBlock
-  if (args.network) {
-    const {depositContractDeployBlock} = getNetworkData(args.network);
+  if (isKnownNetworkName(network)) {
+    const {depositContractDeployBlock} = getNetworkData(network);
     beaconNodeOptions.set({eth1: {depositContractDeployBlock}});
   }
 

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -27,6 +27,10 @@ export const networkNames: NetworkName[] = [
   "dev",
 ];
 
+export function isKnownNetworkName(network: string): network is NetworkName {
+  return networkNames.includes(network as NetworkName);
+}
+
 export type WeakSubjectivityFetchOptions = {
   weakSubjectivityServerUrl: string;
   weakSubjectivityCheckpoint?: string;

--- a/packages/cli/test/unit/cmds/beacon.test.ts
+++ b/packages/cli/test/unit/cmds/beacon.test.ts
@@ -27,7 +27,7 @@ describe("cmds / beacon / args handler", () => {
       bootnodesFile,
     });
 
-    expect(options.network.discv5?.bootEnrs?.sort()).to.deep.equal([enr1, enr2]);
+    expect(options.network.discv5?.bootEnrs?.sort().slice(0, 2)).to.deep.equal([enr1, enr2]);
   });
 
   it("Over-write ENR fields", async () => {


### PR DESCRIPTION
**Motivation**

User do not specify mainnnet network expecting lodestar to get boot enrs of mainnet but it turns out we did not, hence it gets stuck

**Description**

- If network is known, pull boot enrs to add to discv5 later
- Print number of bootEnrs in verbose node just in case we see the issue again
- Reproduced and verified in one of our mainnnet nodes

Closes #4657