### PR TITLE
Add keystores folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage/**
 beaconchain
 lodestar-config.toml
 keys/
+keystores/
 test-db
 yarn-error.log
 package-lock.json


### PR DESCRIPTION
**Motivation**

`keystores` folder is used during [local testing](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#beacon-node-and-validator) and should not be tracked in git

**Description**

adds `keystores` folder to `.gitignore` file

