### PR TITLE
Use last data point to determine nodejs version from metrics

### DIFF
--- a/dashboards/lodestar_debug_gossipsub.json
+++ b/dashboards/lodestar_debug_gossipsub.json
@@ -454,6 +454,7 @@
       "targets": [
         {
           "expr": "nodejs_version_info",
+          "instant": true,
           "interval": "",
           "legendFormat": "{{version}}",
           "refId": "A"

--- a/dashboards/lodestar_summary.json
+++ b/dashboards/lodestar_summary.json
@@ -933,6 +933,7 @@
           },
           "exemplar": false,
           "expr": "nodejs_version_info{scrape_location=\"beacon\"}",
+          "instant": true,
           "interval": "",
           "legendFormat": "{{version}}",
           "refId": "A"

--- a/dashboards/lodestar_validator_client.json
+++ b/dashboards/lodestar_validator_client.json
@@ -329,6 +329,7 @@
           },
           "exemplar": false,
           "expr": "nodejs_version_info{scrape_location=\"validator\"}",
+          "instant": true,
           "interval": "",
           "legendFormat": "{{version}}",
           "refId": "A"


### PR DESCRIPTION
**Motivation**

By default Grafana sends PromQL queries to `query_range` API. Setting `instant` to `true` means that the `query` API is used instead which is more efficient as it only returns a single data point (end of time range). This ensures that always the current nodejs version is shown and makes the metric more robust in case the version changed during the selected time range due to a Lodestar update.

**Description**

Adds `instant` to `true` to all dashboards metrics which use the  `nodejs_version_info` expression to display the nodejs version.
