### PR TITLE
Do not pass kzg proof in doBeaconBlocksMaybeBlobsByRange

### DIFF
--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -12,7 +12,6 @@ import {altair, eip4844, Epoch, phase0} from "@lodestar/types";
 import {IMetrics} from "../metrics/index.js";
 import {ChainEvent, IBeaconChain, IBeaconClock} from "../chain/index.js";
 import {BlockInput, BlockInputType, getBlockInput} from "../chain/blocks/types.js";
-import {ckzg} from "../util/kzg.js";
 import {INetworkOptions} from "./options.js";
 import {INetwork} from "./interface.js";
 import {ReqRespBeaconNode, ReqRespHandlers, doBeaconBlocksMaybeBlobsByRange} from "./reqresp/index.js";
@@ -235,14 +234,7 @@ export class Network implements INetwork {
     peerId: PeerId,
     request: phase0.BeaconBlocksByRangeRequest
   ): Promise<BlockInput[]> {
-    return doBeaconBlocksMaybeBlobsByRange(
-      this.config,
-      this.reqResp,
-      peerId,
-      request,
-      this.clock.currentEpoch,
-      ckzg.computeAggregateKzgProof([])
-    );
+    return doBeaconBlocksMaybeBlobsByRange(this.config, this.reqResp, peerId, request, this.clock.currentEpoch);
   }
 
   async beaconBlocksMaybeBlobsByRoot(peerId: PeerId, request: phase0.BeaconBlocksByRootRequest): Promise<BlockInput[]> {

--- a/packages/beacon-node/src/network/reqresp/doBeaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/doBeaconBlocksMaybeBlobsByRange.ts
@@ -5,6 +5,7 @@ import {ForkSeq} from "@lodestar/params";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 
 import {BlockInput, getBlockInput} from "../../chain/blocks/types.js";
+import {ckzg} from "../../util/kzg.js";
 import {IReqRespBeaconNode} from "./interface.js";
 
 export async function doBeaconBlocksMaybeBlobsByRange(
@@ -12,9 +13,7 @@ export async function doBeaconBlocksMaybeBlobsByRange(
   reqResp: IReqRespBeaconNode,
   peerId: PeerId,
   request: phase0.BeaconBlocksByRangeRequest,
-  currentEpoch: Epoch,
-  // To make test life easy without loading ckzg
-  emptyKzgAggregatedProof: eip4844.BlobsSidecar["kzgAggregatedProof"]
+  currentEpoch: Epoch
 ): Promise<BlockInput[]> {
   // TODO EIP-4844: Assumes all blocks in the same epoch
   // TODO EIP-4844: Ensure all blocks are in the same epoch
@@ -32,6 +31,8 @@ export async function doBeaconBlocksMaybeBlobsByRange(
     const blockInputs: BlockInput[] = [];
     let blobSideCarIndex = 0;
     let lastMatchedSlot = -1;
+
+    const emptyKzgAggregatedProof = ckzg.computeAggregateKzgProof([]);
 
     // Match blobSideCar with the block as some blocks would have no blobs and hence
     // would be omitted from the response. If there are any inconsitencies in the

--- a/packages/beacon-node/src/util/kzg.ts
+++ b/packages/beacon-node/src/util/kzg.ts
@@ -67,9 +67,13 @@ export function loadEthereumTrustedSetup(): void {
     try {
       // in unit tests, calling loadTrustedSetup() twice has error so we have to free and retry
       ckzg.loadTrustedSetup(TRUSTED_SETUP_TXT_FILEPATH);
-    } catch (_) {
-      ckzg.freeTrustedSetup();
-      ckzg.loadTrustedSetup(TRUSTED_SETUP_TXT_FILEPATH);
+    } catch (e) {
+      if ((e as Error).message === "Call freeTrustedSetup before loading a new trusted setup.") {
+        ckzg.freeTrustedSetup();
+        ckzg.loadTrustedSetup(TRUSTED_SETUP_TXT_FILEPATH);
+      } else {
+        throw e;
+      }
     }
   } catch (e) {
     (e as Error).message = `Error loading trusted setup ${TRUSTED_SETUP_JSON_FILEPATH}: ${(e as Error).message}`;

--- a/packages/beacon-node/test/unit/network/doBeaconBlocksMaybeBlobsByRange.test.ts
+++ b/packages/beacon-node/test/unit/network/doBeaconBlocksMaybeBlobsByRange.test.ts
@@ -8,17 +8,17 @@ import {doBeaconBlocksMaybeBlobsByRange, ReqRespBeaconNode} from "../../../src/n
 import {BlockInputType} from "../../../src/chain/blocks/types.js";
 import {ckzg, initCKZG, loadEthereumTrustedSetup} from "../../../src/util/kzg.js";
 
-describe("doBeaconBlocksMaybeBlobsByRange", function () {
-  const sandbox = sinon.createSandbox();
-  const reqResp = sandbox.createStubInstance(ReqRespBeaconNode) as SinonStubbedInstance<ReqRespBeaconNode> &
-    ReqRespBeaconNode;
-  const peerId = peerIdFromString("Qma9T5YraSnpRDZqRR4krcSJabThc8nwZuJV3LercPHufi");
-
+describe("doBeaconBlocksMaybeBlobsByRange", () => {
   before(async function () {
     this.timeout(10000); // Loading trusted setup is slow
     await initCKZG();
     loadEthereumTrustedSetup();
   });
+
+  const sandbox = sinon.createSandbox();
+  const reqResp = sandbox.createStubInstance(ReqRespBeaconNode) as SinonStubbedInstance<ReqRespBeaconNode> &
+    ReqRespBeaconNode;
+  const peerId = peerIdFromString("Qma9T5YraSnpRDZqRR4krcSJabThc8nwZuJV3LercPHufi");
 
   /* eslint-disable @typescript-eslint/naming-convention */
   const chainConfig = createIChainForkConfig({
@@ -31,7 +31,6 @@ describe("doBeaconBlocksMaybeBlobsByRange", function () {
   const genesisValidatorsRoot = Buffer.alloc(32, 0xaa);
   const config = createIBeaconConfig(chainConfig, genesisValidatorsRoot);
   const rangeRequest = ssz.phase0.BeaconBlocksByRangeRequest.defaultValue();
-  const emptyKzgAggregatedProof = ckzg.computeAggregateKzgProof([]);
 
   const block1 = ssz.eip4844.SignedBeaconBlock.defaultValue();
   block1.message.slot = 1;
@@ -61,7 +60,7 @@ describe("doBeaconBlocksMaybeBlobsByRange", function () {
       const blobsSidecars = blocksWithBlobs
         .map(([_block, blobs]) => blobs as eip4844.BlobsSidecar)
         .filter((blobs) => blobs !== undefined);
-
+      const emptyKzgAggregatedProof = ckzg.computeAggregateKzgProof([]);
       const expectedResponse = blocksWithBlobs.map(([block, blobsSidecar]) => {
         const blobs =
           blobsSidecar !== undefined


### PR DESCRIPTION
**Motivation**

- We don't want to always load c-kzg as we're not at EIP-4844 yet, this library may not work on some platform
- Fix this error

```
Dec-28 03:40:47.306[sync]          ^[[36mverbose^[[39m: Batch download error id=Finalized, startEpoch=144782, status=Downloading c-kzg library not loaded
Error: c-kzg library not loaded
    at Object.ckzgNotLoaded (file:///usr/app/packages/beacon-node/src/util/kzg.ts:12:9)
    at Network.beaconBlocksMaybeBlobsByRange (file:///usr/app/packages/beacon-node/src/network/network.ts:237:12)
    at SyncChain.RangeSync.downloadBeaconBlocksByRange (file:///usr/app/packages/beacon-node/src/sync/range/range.ts:201:31)
    at SyncChain.sendBatch (file:///usr/app/packages/beacon-node/src/sync/range/chain.ts:400:40)
    at SyncChain.requestBatches (file:///usr/app/packages/beacon-node/src/sync/range/chain.ts:344:19)
    at SyncChain.triggerBatchDownloader (file:///usr/app/packages/beacon-node/src/sync/range/chain.ts:318:12)
    at SyncChain.sendBatch (file:///usr/app/packages/beacon-node/src/sync/range/chain.ts:411:12)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

**Description**

- Do not pass emptyKzgAggregatedProof in doBeaconBlocksMaybeBlobsByRange
Closes #4955
