### PR TITLE
Log error if there is no discv5 kad value

### DIFF
--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -120,7 +120,12 @@ export class PeerDiscovery {
       },
     });
     opts.discv5.bootEnrs.forEach((bootEnr) => this.discv5.addEnr(bootEnr));
-    this.logger.verbose("PeerDiscovery number of bootEnrs", {bootEnrs: opts.discv5.bootEnrs.length});
+    const numBootEnrs = opts.discv5.bootEnrs.length;
+    if (numBootEnrs === 0) {
+      this.logger.error("PeerDiscovery: discv5 has no boot enr");
+    } else {
+      this.logger.verbose("PeerDiscovery: number of bootEnrs", {bootEnrs: numBootEnrs});
+    }
 
     if (metrics) {
       metrics.discovery.cachedENRsSize.addCollect(() => {


### PR DESCRIPTION
**Motivation**
- discv5 can't fetch enrs if there is no kad value
- See https://github.com/ChainSafe/lodestar/issues/4657#issuecomment-1366335998

**Description**

Add a check and log error if there is no kad value

part of #4657
