### PR TITLE
Remove intermediary event ChainEvent.forkChoiceReorg

### DIFF
--- a/packages/beacon-node/src/api/impl/events/index.ts
+++ b/packages/beacon-node/src/api/impl/events/index.ts
@@ -1,5 +1,4 @@
 import {capella} from "@lodestar/types";
-import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {routes} from "@lodestar/api";
 import {toHexString} from "@chainsafe/ssz";
 import {ApiModules} from "../types.js";
@@ -50,18 +49,7 @@ export function getEventsApi({chain, config}: Pick<ApiModules, "chain" | "config
         executionOptimistic: false,
       },
     ],
-    [routes.events.EventType.chainReorg]: (oldHead, newHead, depth, executionOptimistic) => [
-      {
-        depth,
-        epoch: computeEpochAtSlot(newHead.slot),
-        slot: newHead.slot,
-        newHeadBlock: newHead.blockRoot,
-        oldHeadBlock: oldHead.blockRoot,
-        newHeadState: newHead.stateRoot,
-        oldHeadState: oldHead.stateRoot,
-        executionOptimistic,
-      },
-    ],
+    [routes.events.EventType.chainReorg]: (data) => [data],
     [routes.events.EventType.contributionAndProof]: (contributionAndProof) => [contributionAndProof],
     [routes.events.EventType.lightClientOptimisticUpdate]: (headerUpdate) => [headerUpdate],
     [routes.events.EventType.lightClientFinalityUpdate]: (headerUpdate) => [headerUpdate],

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -244,7 +244,16 @@ export async function importBlock(
         newSlot: newHead.slot,
       });
 
-      pendingEvents.push(ChainEvent.forkChoiceReorg, newHead, oldHead, distance, executionOptimistic);
+      pendingEvents.push(ChainEvent.forkChoiceReorg, {
+        depth: distance,
+        epoch: computeEpochAtSlot(newHead.slot),
+        slot: newHead.slot,
+        newHeadBlock: newHead.blockRoot,
+        oldHeadBlock: oldHead.blockRoot,
+        newHeadState: newHead.stateRoot,
+        oldHeadState: oldHead.stateRoot,
+        executionOptimistic,
+      });
 
       this.metrics?.forkChoice.reorg.inc();
       this.metrics?.forkChoice.reorgDistance.observe(distance);

--- a/packages/beacon-node/src/chain/emitter.ts
+++ b/packages/beacon-node/src/chain/emitter.ts
@@ -3,7 +3,7 @@ import StrictEventEmitter from "strict-event-emitter-types";
 
 import {routes} from "@lodestar/api";
 import {phase0, Epoch, Slot, allForks, altair} from "@lodestar/types";
-import {CheckpointWithHex, ProtoBlock} from "@lodestar/fork-choice";
+import {CheckpointWithHex} from "@lodestar/fork-choice";
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 
 /**
@@ -100,6 +100,7 @@ export enum ChainEvent {
 }
 
 export type HeadEventData = routes.events.EventData[routes.events.EventType.head];
+export type ReorgEventData = routes.events.EventData[routes.events.EventType.chainReorg];
 
 export interface IChainEvents {
   [ChainEvent.attestation]: (attestation: phase0.Attestation) => void;
@@ -118,12 +119,7 @@ export interface IChainEvents {
   [ChainEvent.clockEpoch]: (epoch: Epoch) => void;
 
   [ChainEvent.head]: (data: HeadEventData) => void;
-  [ChainEvent.forkChoiceReorg]: (
-    head: ProtoBlock,
-    oldHead: ProtoBlock,
-    depth: number,
-    executionOptimistic: boolean
-  ) => void;
+  [ChainEvent.forkChoiceReorg]: (data: ReorgEventData) => void;
   [ChainEvent.forkChoiceJustified]: (checkpoint: CheckpointWithHex) => void;
   [ChainEvent.forkChoiceFinalized]: (checkpoint: CheckpointWithHex) => void;
 

--- a/packages/beacon-node/test/unit/api/impl/events/events.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/events/events.test.ts
@@ -54,7 +54,7 @@ describe("Events api impl", function () {
 
       const headBlock = generateProtoBlock();
       stateCacheStub.get.withArgs(headBlock.stateRoot).returns(generateCachedState({slot: 1000}));
-      chainEventEmmitter.emit(ChainEvent.forkChoiceReorg, headBlock, headBlock, 2, false);
+      chainEventEmmitter.emit(ChainEvent.attestation, ssz.phase0.Attestation.defaultValue());
       chainEventEmmitter.emit(ChainEvent.head, headEventData);
 
       expect(events).to.have.length(1, "Wrong num of received events");
@@ -132,22 +132,6 @@ describe("Events api impl", function () {
       expect(events).to.have.length(1, "Wrong num of received events");
       expect(events[0].type).to.equal(routes.events.EventType.finalizedCheckpoint);
       expect(events[0].message).to.not.be.null;
-    });
-
-    it("should process chain reorg event", async function () {
-      const events = getEvents([routes.events.EventType.chainReorg]);
-
-      const depth = 3;
-      const oldHead = generateProtoBlock({slot: 4});
-      const newHead = generateProtoBlock({slot: 3});
-      chainEventEmmitter.emit(ChainEvent.forkChoiceReorg, oldHead, newHead, depth, false);
-
-      expect(events).to.have.length(1, "Wrong num of received events");
-      const event = events[0];
-      if (event.type !== routes.events.EventType.chainReorg) throw Error(`Wrong event type ${event.type}`);
-      expect(events[0].type).to.equal(routes.events.EventType.chainReorg);
-      expect(event.message).to.not.be.null;
-      expect(event.message.depth).to.equal(depth, "Wrong depth");
     });
   });
 });


### PR DESCRIPTION
**Motivation**

No need for a different event data, as importBlock can compute the API's style event directly.

**Description**

Remove intermediary event ChainEvent.forkChoiceReorg
