### PR TITLE
Remove all intermediary ChainEvents

### DIFF
--- a/packages/api/src/beacon/routes/events.ts
+++ b/packages/api/src/beacon/routes/events.ts
@@ -5,7 +5,7 @@ import {RouteDef, TypeJson} from "../../utils/index.js";
 
 // See /packages/api/src/routes/index.ts for reasoning and instructions to add new routes
 
-export enum EventType {
+export const enum EventType {
   /**
    * The node has finished processing, resulting in a new head. previous_duty_dependent_root is
    * `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)` and
@@ -34,6 +34,20 @@ export enum EventType {
   /** New or better light client update available */
   lightClientUpdate = "light_client_update",
 }
+
+export const eventTypes: {[K in EventType]: K} = {
+  [EventType.head]: EventType.head,
+  [EventType.block]: EventType.block,
+  [EventType.attestation]: EventType.attestation,
+  [EventType.voluntaryExit]: EventType.voluntaryExit,
+  [EventType.blsToExecutionChange]: EventType.blsToExecutionChange,
+  [EventType.finalizedCheckpoint]: EventType.finalizedCheckpoint,
+  [EventType.chainReorg]: EventType.chainReorg,
+  [EventType.contributionAndProof]: EventType.contributionAndProof,
+  [EventType.lightClientOptimisticUpdate]: EventType.lightClientOptimisticUpdate,
+  [EventType.lightClientFinalityUpdate]: EventType.lightClientFinalityUpdate,
+  [EventType.lightClientUpdate]: EventType.lightClientUpdate,
+};
 
 export type EventData = {
   [EventType.head]: {

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -111,11 +111,11 @@ describe("eventstream event data", () => {
   });
 
   const eventSerdes = routes.events.getEventSerdes();
-  const knownTopics = Object.values(routes.events.EventType) as string[];
+  const knownTopics = new Set<string>(Object.values(routes.events.eventTypes));
 
   for (const [topic, {value}] of Object.entries(eventstreamExamples ?? {})) {
     it(topic, () => {
-      if (!knownTopics.includes(topic)) {
+      if (!knownTopics.has(topic)) {
         throw Error(`topic ${topic} not implemented`);
       }
 

--- a/packages/beacon-node/src/api/impl/events/index.ts
+++ b/packages/beacon-node/src/api/impl/events/index.ts
@@ -1,86 +1,29 @@
-import {capella} from "@lodestar/types";
 import {routes} from "@lodestar/api";
-import {toHexString} from "@chainsafe/ssz";
 import {ApiModules} from "../types.js";
-import {ChainEvent, IChainEvents} from "../../../chain/index.js";
 import {ApiError} from "../errors.js";
 
-/**
- * Mapping of internal `ChainEvents` to API spec events
- */
-const chainEventMap = {
-  [routes.events.EventType.head]: ChainEvent.head as const,
-  [routes.events.EventType.block]: ChainEvent.block as const,
-  [routes.events.EventType.attestation]: ChainEvent.attestation as const,
-  [routes.events.EventType.voluntaryExit]: ChainEvent.block as const,
-  [routes.events.EventType.finalizedCheckpoint]: ChainEvent.finalized as const,
-  [routes.events.EventType.chainReorg]: ChainEvent.forkChoiceReorg as const,
-  [routes.events.EventType.contributionAndProof]: ChainEvent.contributionAndProof as const,
-  [routes.events.EventType.lightClientOptimisticUpdate]: ChainEvent.lightClientOptimisticUpdate as const,
-  [routes.events.EventType.lightClientFinalityUpdate]: ChainEvent.lightClientFinalityUpdate as const,
-  [routes.events.EventType.lightClientUpdate]: ChainEvent.lightClientUpdate as const,
-  [routes.events.EventType.blsToExecutionChange]: ChainEvent.block as const,
-};
-
-export function getEventsApi({chain, config}: Pick<ApiModules, "chain" | "config">): routes.events.Api {
-  /**
-   * Mapping to convert internal `ChainEvents` payload to the API spec events data
-   */
-  const eventDataTransformers: {
-    [K in routes.events.EventType]: (
-      ...args: Parameters<IChainEvents[typeof chainEventMap[K]]>
-    ) => routes.events.EventData[K][];
-  } = {
-    [routes.events.EventType.head]: (data) => [data],
-    [routes.events.EventType.block]: (block, _, executionOptimistic) => [
-      {
-        block: toHexString(config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message)),
-        slot: block.message.slot,
-        executionOptimistic,
-      },
-    ],
-    [routes.events.EventType.attestation]: (attestation) => [attestation],
-    [routes.events.EventType.voluntaryExit]: (block) => Array.from(block.message.body.voluntaryExits),
-    [routes.events.EventType.finalizedCheckpoint]: (checkpoint, state) => [
-      {
-        block: toHexString(checkpoint.root),
-        epoch: checkpoint.epoch,
-        state: toHexString(state.hashTreeRoot()),
-        executionOptimistic: false,
-      },
-    ],
-    [routes.events.EventType.chainReorg]: (data) => [data],
-    [routes.events.EventType.contributionAndProof]: (contributionAndProof) => [contributionAndProof],
-    [routes.events.EventType.lightClientOptimisticUpdate]: (headerUpdate) => [headerUpdate],
-    [routes.events.EventType.lightClientFinalityUpdate]: (headerUpdate) => [headerUpdate],
-    [routes.events.EventType.lightClientUpdate]: (headerUpdate) => [headerUpdate],
-    [routes.events.EventType.blsToExecutionChange]: (block) =>
-      Array.from((block.message.body as capella.BeaconBlockBody).blsToExecutionChanges ?? []),
-  };
+export function getEventsApi({chain}: Pick<ApiModules, "chain" | "config">): routes.events.Api {
+  const validTopics = new Set(Object.values(routes.events.eventTypes));
 
   return {
     eventstream(topics, signal, onEvent) {
       const onAbortFns: (() => void)[] = [];
 
       for (const topic of topics) {
-        const eventDataTransformer = eventDataTransformers[topic];
-        const chainEvent = chainEventMap[topic];
-        if (eventDataTransformer === undefined || !chainEvent) {
+        if (!validTopics.has(topic)) {
           throw new ApiError(400, `Unknown topic ${topic}`);
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const handler = (...args: any[]): void => {
+        const handler = (data: any): void => {
           // TODO: What happens if this handler throws? Does it break the other chain.emitter listeners?
-          const messages = eventDataTransformer(...args);
-          for (const message of messages) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
-            onEvent({type: topic, message: message as any});
-          }
+
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+          onEvent({type: topic, message: data});
         };
 
-        chain.emitter.on(chainEvent, handler);
-        onAbortFns.push(() => chain.emitter.off(chainEvent, handler));
+        chain.emitter.on(topic, handler);
+        onAbortFns.push(() => chain.emitter.off(topic, handler));
       }
 
       signal.addEventListener(

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -1,4 +1,4 @@
-import {altair, ssz} from "@lodestar/types";
+import {altair, capella, ssz} from "@lodestar/types";
 import {MAX_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {toHexString} from "@chainsafe/ssz";
 import {
@@ -7,7 +7,8 @@ import {
   computeStartSlotAtEpoch,
   RootCache,
 } from "@lodestar/state-transition";
-import {ForkChoiceError, ForkChoiceErrorCode, EpochDifference, AncestorStatus} from "@lodestar/fork-choice";
+import {routes} from "@lodestar/api";
+import {ForkChoiceError, ForkChoiceErrorCode, EpochDifference} from "@lodestar/fork-choice";
 import {ZERO_HASH_HEX} from "../../constants/index.js";
 import {toCheckpointHex} from "../stateCache/index.js";
 import {isOptimisticBlock} from "../../util/forkChoice.js";
@@ -130,7 +131,7 @@ export async function importBlock(
         // don't want to log the processed attestations here as there are so many attestations and it takes too much disc space,
         // users may want to keep more log files instead of unnecessary processed attestations log
         // see https://github.com/ChainSafe/lodestar/pull/4032
-        pendingEvents.push(ChainEvent.attestation, attestation);
+        pendingEvents.push(routes.events.EventType.attestation, attestation);
       } catch (e) {
         // a block has a lot of attestations and it may has same error, we don't want to log all of them
         if (e instanceof ForkChoiceError && e.type.code === ForkChoiceErrorCode.INVALID_ATTESTATION) {
@@ -198,7 +199,6 @@ export async function importBlock(
       const justifiedEpoch = justifiedCheckpoint.epoch;
       const preJustifiedEpoch = parentBlockSummary.justifiedEpoch;
       if (justifiedEpoch > preJustifiedEpoch) {
-        this.emitter.emit(ChainEvent.justified, justifiedCheckpoint, checkpointState);
         this.logger.verbose("Checkpoint justified", toCheckpointHex(justifiedCheckpoint));
         this.metrics?.previousJustifiedEpoch.set(checkpointState.previousJustifiedCheckpoint.epoch);
         this.metrics?.currentJustifiedEpoch.set(justifiedCheckpoint.epoch);
@@ -207,7 +207,12 @@ export async function importBlock(
       const finalizedEpoch = finalizedCheckpoint.epoch;
       const preFinalizedEpoch = parentBlockSummary.finalizedEpoch;
       if (finalizedEpoch > preFinalizedEpoch) {
-        this.emitter.emit(ChainEvent.finalized, finalizedCheckpoint, checkpointState);
+        this.emitter.emit(routes.events.EventType.finalizedCheckpoint, {
+          block: toHexString(finalizedCheckpoint.root),
+          epoch: finalizedCheckpoint.epoch,
+          state: toHexString(checkpointState.hashTreeRoot()),
+          executionOptimistic: false,
+        });
         this.logger.verbose("Checkpoint finalized", toCheckpointHex(finalizedCheckpoint));
         this.metrics?.finalizedEpoch.set(finalizedCheckpoint.epoch);
       }
@@ -223,7 +228,7 @@ export async function importBlock(
     // new head
     const executionOptimistic = isOptimisticBlock(newHead);
 
-    pendingEvents.push(ChainEvent.head, {
+    pendingEvents.push(routes.events.EventType.head, {
       block: newHead.blockRoot,
       epochTransition: computeStartSlotAtEpoch(computeEpochAtSlot(newHead.slot)) === newHead.slot,
       slot: newHead.slot,
@@ -232,6 +237,24 @@ export async function importBlock(
       currentDutyDependentRoot: this.forkChoice.getDependentRoot(newHead, EpochDifference.current),
       executionOptimistic,
     });
+
+    const delaySec = this.clock.secFromSlot(newHead.slot);
+    this.logger.verbose("New chain head", {
+      slot: newHead.slot,
+      root: newHead.blockRoot,
+      delaySec,
+    });
+
+    if (this.metrics) {
+      this.metrics.headSlot.set(newHead.slot);
+      // Only track "recent" blocks. Otherwise sync can distort this metrics heavily.
+      // We want to track recent blocks coming from gossip, unknown block sync, and API.
+      if (delaySec < 64 * this.config.SECONDS_PER_SLOT) {
+        this.metrics.elapsedTimeTillBecomeHead.observe(delaySec);
+      }
+    }
+
+    this.onNewHead(newHead);
 
     this.metrics?.forkChoice.changedHead.inc();
 
@@ -248,8 +271,8 @@ export async function importBlock(
         newSlot: newHead.slot,
       });
 
-      pendingEvents.push(ChainEvent.forkChoiceReorg, {
-        depth: ancestorResult.depth,
+      pendingEvents.push(routes.events.EventType.chainReorg, {
+        depth: distance,
         epoch: computeEpochAtSlot(newHead.slot),
         slot: newHead.slot,
         newHeadBlock: newHead.blockRoot,
@@ -361,10 +384,26 @@ export async function importBlock(
 
   // - Send event after everything is done
 
+  // Send block events
+
+  for (const voluntaryExit of block.message.body.voluntaryExits) {
+    this.emitter.emit(routes.events.EventType.voluntaryExit, voluntaryExit);
+  }
+
+  for (const blsToExecutionChange of (block.message.body as capella.BeaconBlockBody).blsToExecutionChanges ?? []) {
+    this.emitter.emit(routes.events.EventType.blsToExecutionChange, blsToExecutionChange);
+  }
+
+  // TODO: Make forkChoice.onBlock return block summary
   const blockSummary = this.forkChoice.getBlock(blockRoot);
-  const executionOptimistic = blockSummary != null && isOptimisticBlock(blockSummary);
+
+  this.emitter.emit(routes.events.EventType.block, {
+    block: toHexString(this.config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message)),
+    slot: block.message.slot,
+    executionOptimistic: blockSummary != null && isOptimisticBlock(blockSummary),
+  });
+
   // Emit all events at once after fully completing importBlock()
-  this.emitter.emit(ChainEvent.block, block, postState, executionOptimistic);
   pendingEvents.emit();
 
   // Register stat metrics about the block after importing it

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -8,7 +8,7 @@ import {
   RootCache,
 } from "@lodestar/state-transition";
 import {routes} from "@lodestar/api";
-import {ForkChoiceError, ForkChoiceErrorCode, EpochDifference} from "@lodestar/fork-choice";
+import {ForkChoiceError, ForkChoiceErrorCode, EpochDifference, AncestorStatus} from "@lodestar/fork-choice";
 import {ZERO_HASH_HEX} from "../../constants/index.js";
 import {toCheckpointHex} from "../stateCache/index.js";
 import {isOptimisticBlock} from "../../util/forkChoice.js";
@@ -272,7 +272,7 @@ export async function importBlock(
       });
 
       pendingEvents.push(routes.events.EventType.chainReorg, {
-        depth: distance,
+        depth: ancestorResult.depth,
         epoch: computeEpochAtSlot(newHead.slot),
         slot: newHead.slot,
         newHeadBlock: newHead.blockRoot,

--- a/packages/beacon-node/src/chain/emitter.ts
+++ b/packages/beacon-node/src/chain/emitter.ts
@@ -2,7 +2,7 @@ import {EventEmitter} from "events";
 import StrictEventEmitter from "strict-event-emitter-types";
 
 import {routes} from "@lodestar/api";
-import {phase0, Epoch, Slot, allForks, altair} from "@lodestar/types";
+import {phase0, Epoch, Slot} from "@lodestar/types";
 import {CheckpointWithHex} from "@lodestar/fork-choice";
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 
@@ -12,24 +12,9 @@ import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
  * Chain events can be broken into several categories:
  * - Clock: the chain's clock is updated
  * - Fork Choice: the chain's fork choice is updated
- * - Processing: the chain processes attestations and blocks, either successfully or with an error
  * - Checkpointing: the chain processes epoch boundaries
  */
-export enum ChainEvent {
-  /**
-   * This event signals that the chain has successfully processed a valid attestation.
-   *
-   * This event is guaranteed to be emitted after every attestation fed to the chain has successfully been passed to the fork choice.
-   */
-  attestation = "attestation",
-  /** The node has received a valid sync committee SignedContributionAndProof (from P2P or API) */
-  contributionAndProof = "contribution_and_proof",
-  /**
-   * This event signals that the chain has successfully processed a valid block.
-   *
-   * This event is guaranteed to be emitted after every block fed to the chain has successfully passed the state transition.
-   */
-  block = "block",
+export const enum ChainEvent {
   /**
    * This event signals that the chain has processed (or reprocessed) a checkpoint.
    *
@@ -37,18 +22,6 @@ export enum ChainEvent {
    * This event is guaranteed to be called after _any_ checkpoint is processed, including skip-slot checkpoints, checkpoints that are formed as a result of processing blocks, etc.
    */
   checkpoint = "checkpoint",
-  /**
-   * This event signals that the chain has processed (or reprocessed) a checkpoint state with an updated justified checkpoint.
-   *
-   * This event is a derivative of the `checkpoint` event. Eg: in cases where the `checkpoint` state has an updated justified checkpoint, this event is triggered.
-   */
-  justified = "justified",
-  /**
-   * This event signals that the chain has processed (or reprocessed) a checkpoint state with an updated finalized checkpoint.
-   *
-   * This event is a derivative of the `checkpoint` event. Eg: in cases where the `checkpoint` state has an updated finalized checkpoint, this event is triggered.
-   */
-  finalized = "finalized",
   /**
    * This event signals the start of a new slot, and that subsequent calls to `clock.currentSlot` will equal `slot`.
    *
@@ -62,18 +35,6 @@ export enum ChainEvent {
    */
   clockEpoch = "clock:epoch",
   /**
-   * This event signals that the fork choice has been updated to a new head.
-   *
-   * This event is guaranteed to be emitted after every sucessfully processed block, if that block updates the head.
-   */
-  head = "forkChoice:head",
-  /**
-   * This event signals that the fork choice has been updated to a new head that is not a descendant of the previous head.
-   *
-   * This event is guaranteed to be emitted after every sucessfully processed block, if that block results results in a reorg.
-   */
-  forkChoiceReorg = "forkChoice:reorg",
-  /**
    * This event signals that the fork choice store has been updated.
    *
    * This event is guaranteed to be triggered whenever the fork choice justified checkpoint is updated. This is either in response to a newly processed block or a new clock tick.
@@ -85,48 +46,23 @@ export enum ChainEvent {
    * This event is guaranteed to be triggered whenever the fork choice justified checkpoint is updated. This is in response to a newly processed block.
    */
   forkChoiceFinalized = "forkChoice:finalized",
-  /**
-   * A new lightclient optimistic header update is available to be broadcasted to connected light-clients
-   */
-  lightClientOptimisticUpdate = "lightclient:header_update",
-  /**
-   * A new lightclient finalized header update is available to be broadcasted to connected light-clients
-   */
-  lightClientFinalityUpdate = "lightclient:finality_update",
-  /**
-   * A new lightclient update is available to be broadcasted to connected light-clients
-   */
-  lightClientUpdate = "lightclient:update",
 }
 
 export type HeadEventData = routes.events.EventData[routes.events.EventType.head];
 export type ReorgEventData = routes.events.EventData[routes.events.EventType.chainReorg];
 
-export interface IChainEvents {
-  [ChainEvent.attestation]: (attestation: phase0.Attestation) => void;
-  [ChainEvent.contributionAndProof]: (contributionAndProof: altair.SignedContributionAndProof) => void;
-  [ChainEvent.block]: (
-    signedBlock: allForks.SignedBeaconBlock,
-    postState: CachedBeaconStateAllForks,
-    executionOptimistic: boolean
-  ) => void;
+// API events are emitted through the same ChainEventEmitter for re-use internally
+type ApiEvents = {[K in routes.events.EventType]: (data: routes.events.EventData[K]) => void};
 
+export type IChainEvents = ApiEvents & {
   [ChainEvent.checkpoint]: (checkpoint: phase0.Checkpoint, state: CachedBeaconStateAllForks) => void;
-  [ChainEvent.justified]: (checkpoint: phase0.Checkpoint, state: CachedBeaconStateAllForks) => void;
-  [ChainEvent.finalized]: (checkpoint: phase0.Checkpoint, state: CachedBeaconStateAllForks) => void;
 
   [ChainEvent.clockSlot]: (slot: Slot) => void;
   [ChainEvent.clockEpoch]: (epoch: Epoch) => void;
 
-  [ChainEvent.head]: (data: HeadEventData) => void;
-  [ChainEvent.forkChoiceReorg]: (data: ReorgEventData) => void;
   [ChainEvent.forkChoiceJustified]: (checkpoint: CheckpointWithHex) => void;
   [ChainEvent.forkChoiceFinalized]: (checkpoint: CheckpointWithHex) => void;
-
-  [ChainEvent.lightClientOptimisticUpdate]: (optimisticUpdate: altair.LightClientOptimisticUpdate) => void;
-  [ChainEvent.lightClientFinalityUpdate]: (finalizedUpdate: altair.LightClientFinalityUpdate) => void;
-  [ChainEvent.lightClientUpdate]: (update: altair.LightClientUpdate) => void;
-}
+};
 
 /**
  * Emits important chain events that occur during normal chain operation.

--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -8,11 +8,12 @@ import {
 } from "@lodestar/state-transition";
 import {isBetterUpdate, toLightClientUpdateSummary, LightClientUpdateSummary} from "@lodestar/light-client/spec";
 import {ILogger, MapDef, pruneSetToMax} from "@lodestar/utils";
+import {routes} from "@lodestar/api";
 import {BitArray, CompositeViewDU, toHexString} from "@chainsafe/ssz";
 import {MIN_SYNC_COMMITTEE_PARTICIPANTS, SYNC_COMMITTEE_SIZE} from "@lodestar/params";
 import {IBeaconDb} from "../../db/index.js";
 import {IMetrics} from "../../metrics/index.js";
-import {ChainEvent, ChainEventEmitter} from "../emitter.js";
+import {ChainEventEmitter} from "../emitter.js";
 import {byteArrayEquals} from "../../util/bytes.js";
 import {ZERO_HASH} from "../../constants/index.js";
 import {LightClientServerError, LightClientServerErrorCode} from "../errors/lightClientError.js";
@@ -484,7 +485,7 @@ export class LightClientServer {
 
     // Emit update
     // Note: Always emit optimistic update even if we have emitted one with higher or equal attested_header.slot
-    this.emitter.emit(ChainEvent.lightClientOptimisticUpdate, headerUpdate);
+    this.emitter.emit(routes.events.EventType.lightClientOptimisticUpdate, headerUpdate);
 
     // Persist latest best update for getLatestHeadUpdate()
     // TODO: Once SyncAggregate are constructed from P2P too, count bits to decide "best"
@@ -513,7 +514,7 @@ export class LightClientServer {
         this.metrics?.lightclientServer.onSyncAggregate.inc({event: "update_latest_finalized_update"});
 
         // Note: Ignores gossip rule to always emit finaly_update with higher finalized_header.slot, for simplicity
-        this.emitter.emit(ChainEvent.lightClientFinalityUpdate, this.finalized);
+        this.emitter.emit(routes.events.EventType.lightClientFinalityUpdate, this.finalized);
       }
     }
 

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -9,6 +9,7 @@ import {ATTESTATION_SUBNET_COUNT, ForkName, ForkSeq, SYNC_COMMITTEE_SUBNET_COUNT
 import {Discv5, ENR} from "@chainsafe/discv5";
 import {computeEpochAtSlot, computeTimeAtSlot} from "@lodestar/state-transition";
 import {altair, eip4844, Epoch, phase0} from "@lodestar/types";
+import {routes} from "@lodestar/api";
 import {IMetrics} from "../metrics/index.js";
 import {ChainEvent, IBeaconChain, IBeaconClock} from "../chain/index.js";
 import {BlockInput, BlockInputType, getBlockInput} from "../chain/blocks/types.js";
@@ -133,16 +134,16 @@ export class Network implements INetwork {
     );
 
     this.chain.emitter.on(ChainEvent.clockEpoch, this.onEpoch);
-    this.chain.emitter.on(ChainEvent.lightClientFinalityUpdate, this.onLightClientFinalityUpdate);
-    this.chain.emitter.on(ChainEvent.lightClientOptimisticUpdate, this.onLightClientOptimisticUpdate);
+    this.chain.emitter.on(routes.events.EventType.lightClientFinalityUpdate, this.onLightClientFinalityUpdate);
+    this.chain.emitter.on(routes.events.EventType.lightClientOptimisticUpdate, this.onLightClientOptimisticUpdate);
     modules.signal.addEventListener("abort", this.close.bind(this), {once: true});
   }
 
   /** Destroy this instance. Can only be called once. */
   close(): void {
     this.chain.emitter.off(ChainEvent.clockEpoch, this.onEpoch);
-    this.chain.emitter.off(ChainEvent.lightClientFinalityUpdate, this.onLightClientFinalityUpdate);
-    this.chain.emitter.off(ChainEvent.lightClientOptimisticUpdate, this.onLightClientOptimisticUpdate);
+    this.chain.emitter.off(routes.events.EventType.lightClientFinalityUpdate, this.onLightClientFinalityUpdate);
+    this.chain.emitter.off(routes.events.EventType.lightClientOptimisticUpdate, this.onLightClientOptimisticUpdate);
   }
 
   async start(): Promise<void> {

--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
 import {createIBeaconConfig, IChainConfig} from "@lodestar/config";
 import {chainConfig as chainConfigDef} from "@lodestar/config/default";
-import {getClient} from "@lodestar/api";
+import {getClient, routes} from "@lodestar/api";
 import {sleep} from "@lodestar/utils";
 import {ForkName, SYNC_COMMITTEE_SIZE} from "@lodestar/params";
 import {Validator} from "@lodestar/validator";
@@ -12,7 +12,6 @@ import {getDevBeaconNode} from "../../../../utils/node/beacon.js";
 import {getAndInitDevValidators} from "../../../../utils/node/validator.js";
 import {BeaconNode} from "../../../../../src/node/nodejs.js";
 import {waitForEvent} from "../../../../utils/events/resolver.js";
-import {ChainEvent} from "../../../../../src/chain/emitter.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 describe("lightclient api", function () {
@@ -97,7 +96,7 @@ describe("lightclient api", function () {
 
   it.skip("getFinalityUpdate()", async function () {
     // TODO: not sure how this causes subsequent tests failed
-    await waitForEvent<phase0.Checkpoint>(bn.chain.emitter, ChainEvent.finalized, 240000);
+    await waitForEvent<phase0.Checkpoint>(bn.chain.emitter, routes.events.EventType.finalizedCheckpoint, 240000);
     await sleep(SECONDS_PER_SLOT * 1000);
     const client = getClient({baseUrl: `http://127.0.0.1:${restPort}`}, {config}).lightclient;
     const {data: update} = await client.getFinalityUpdate();

--- a/packages/beacon-node/test/e2e/chain/lightclient.test.ts
+++ b/packages/beacon-node/test/e2e/chain/lightclient.test.ts
@@ -8,11 +8,11 @@ import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH} from "@lodestar/param
 import {Lightclient} from "@lodestar/light-client";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {LightClientRestTransport} from "@lodestar/light-client/transport";
-import {Api, getClient} from "@lodestar/api";
+import {Api, getClient, routes} from "@lodestar/api";
 import {testLogger, LogLevel, TestLoggerOpts} from "../../utils/logger.js";
 import {getDevBeaconNode} from "../../utils/node/beacon.js";
 import {getAndInitDevValidators} from "../../utils/node/validator.js";
-import {ChainEvent, HeadEventData} from "../../../src/chain/index.js";
+import {HeadEventData} from "../../../src/chain/index.js";
 
 describe("chain / lightclient", function () {
   /**
@@ -107,7 +107,7 @@ describe("chain / lightclient", function () {
     //   - If too far behind error the test
     //   - If beacon node reaches the finality slot, resolve test
     const promiseUntilHead = new Promise<HeadEventData>((resolve) => {
-      bn.chain.emitter.on(ChainEvent.head, async (head) => {
+      bn.chain.emitter.on(routes.events.EventType.head, async (head) => {
         // Wait for the second slot so syncCommitteeWitness is available
         if (head.slot > 2) {
           resolve(head);
@@ -136,7 +136,7 @@ describe("chain / lightclient", function () {
       lightclient.start();
 
       return new Promise<void>((resolve, reject) => {
-        bn.chain.emitter.on(ChainEvent.head, async (head) => {
+        bn.chain.emitter.on(routes.events.EventType.head, async (head) => {
           try {
             // Test fetching proofs
             const {proof, header} = await getHeadStateProof(lightclient, api, [["latestBlockHeader", "bodyRoot"]]);
@@ -167,7 +167,7 @@ describe("chain / lightclient", function () {
     });
 
     const promiseTillFinalization = new Promise<void>((resolve) => {
-      bn.chain.emitter.on(ChainEvent.finalized, (checkpoint) => {
+      bn.chain.emitter.on(routes.events.EventType.finalizedCheckpoint, (checkpoint) => {
         loggerNodeA.info("Node A emitted finalized checkpoint event", {epoch: checkpoint.epoch});
         if (checkpoint.epoch >= finalizedEpochToReach) {
           resolve();

--- a/packages/beacon-node/test/sim/merge-interop.test.ts
+++ b/packages/beacon-node/test/sim/merge-interop.test.ts
@@ -5,6 +5,7 @@ import {isExecutionStateType, isMergeTransitionComplete} from "@lodestar/state-t
 import {LogLevel, sleep, TimestampFormatCode} from "@lodestar/utils";
 import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {IChainConfig} from "@lodestar/config";
+import {routes} from "@lodestar/api";
 import {Epoch} from "@lodestar/types";
 import {ValidatorProposerConfig} from "@lodestar/validator";
 
@@ -239,7 +240,6 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     const {genesisBlockHash, ttd, engineRpcUrl, ethRpcUrl} = elClient;
     const validatorClientCount = 1;
     const validatorsPerClient = 32;
-    const event = ChainEvent.finalized;
 
     const testParams: Pick<IChainConfig, "SECONDS_PER_SLOT"> = {
       SECONDS_PER_SLOT: 2,
@@ -397,11 +397,11 @@ describe("executionEngine / ExecutionEngineHttp", function () {
         }
       });
 
-      bn.chain.emitter.on(ChainEvent.finalized, (checkpoint) => {
+      bn.chain.emitter.on(routes.events.EventType.finalizedCheckpoint, (checkpoint) => {
         // Resolve only if the finalized checkpoint includes execution payload
-        const finalizedBlock = bn.chain.forkChoice.getBlock(checkpoint.root);
+        const finalizedBlock = bn.chain.forkChoice.getBlockHex(checkpoint.block);
         if (finalizedBlock?.executionPayloadBlockHash !== null) {
-          console.log(`\nGot event ${event}, stopping validators and nodes\n`);
+          console.log(`\nGot finalized event, stopping validators and nodes\n`);
           resolve();
         }
       });

--- a/packages/beacon-node/test/unit/api/impl/events/events.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/events/events.test.ts
@@ -3,7 +3,7 @@ import sinon, {SinonStubbedInstance} from "sinon";
 import {routes} from "@lodestar/api";
 import {config} from "@lodestar/config/default";
 import {ssz} from "@lodestar/types";
-import {BeaconChain, ChainEvent, ChainEventEmitter, HeadEventData} from "../../../../../src/chain/index.js";
+import {BeaconChain, ChainEventEmitter, HeadEventData} from "../../../../../src/chain/index.js";
 import {getEventsApi} from "../../../../../src/api/impl/events/index.js";
 import {generateProtoBlock} from "../../../../utils/typeGenerator.js";
 import {generateCachedState} from "../../../../utils/state.js";
@@ -54,83 +54,11 @@ describe("Events api impl", function () {
 
       const headBlock = generateProtoBlock();
       stateCacheStub.get.withArgs(headBlock.stateRoot).returns(generateCachedState({slot: 1000}));
-      chainEventEmmitter.emit(ChainEvent.attestation, ssz.phase0.Attestation.defaultValue());
-      chainEventEmmitter.emit(ChainEvent.head, headEventData);
+      chainEventEmmitter.emit(routes.events.EventType.attestation, ssz.phase0.Attestation.defaultValue());
+      chainEventEmmitter.emit(routes.events.EventType.head, headEventData);
 
       expect(events).to.have.length(1, "Wrong num of received events");
       expect(events[0].type).to.equal(routes.events.EventType.head);
-      expect(events[0].message).to.not.be.null;
-    });
-
-    it("should process head event", async function () {
-      const events = getEvents([routes.events.EventType.head]);
-
-      const headBlock = generateProtoBlock();
-      stateCacheStub.get.withArgs(headBlock.stateRoot).returns(generateCachedState({slot: 1000}));
-      chainEventEmmitter.emit(ChainEvent.head, headEventData);
-
-      expect(events).to.have.length(1, "Wrong num of received events");
-      expect(events[0].type).to.equal(routes.events.EventType.head);
-      expect(events[0].message).to.not.be.null;
-    });
-
-    it("should process block event", async function () {
-      const events = getEvents([routes.events.EventType.block]);
-
-      const block = ssz.phase0.SignedBeaconBlock.defaultValue();
-      chainEventEmmitter.emit(ChainEvent.block, block, null as any, false);
-
-      expect(events).to.have.length(1, "Wrong num of received events");
-      expect(events[0].type).to.equal(routes.events.EventType.block);
-      expect(events[0].message).to.not.be.null;
-    });
-
-    it("should process attestation event", async function () {
-      const events = getEvents([routes.events.EventType.attestation]);
-
-      const attestation = ssz.phase0.Attestation.defaultValue();
-      chainEventEmmitter.emit(ChainEvent.attestation, attestation);
-
-      expect(events).to.have.length(1, "Wrong num of received events");
-      expect(events[0].type).to.equal(routes.events.EventType.attestation);
-      expect(events[0].message).to.equal(attestation);
-    });
-
-    it("should process voluntary exit event", async function () {
-      const events = getEvents([routes.events.EventType.voluntaryExit]);
-
-      const exit = ssz.phase0.SignedVoluntaryExit.defaultValue();
-      const block = ssz.phase0.SignedBeaconBlock.defaultValue();
-      block.message.body.voluntaryExits.push(exit);
-      chainEventEmmitter.emit(ChainEvent.block, block, null as any, false);
-
-      expect(events).to.have.length(1, "Wrong num of received events");
-      expect(events[0].type).to.equal(routes.events.EventType.voluntaryExit);
-      expect(events[0].message).to.equal(exit);
-    });
-
-    it("should process bls to execution change event", async function () {
-      const events = getEvents([routes.events.EventType.blsToExecutionChange]);
-
-      const blsToExecution = ssz.capella.SignedBLSToExecutionChange.defaultValue();
-      const block = ssz.capella.SignedBeaconBlock.defaultValue();
-      block.message.body.blsToExecutionChanges.push(blsToExecution);
-      chainEventEmmitter.emit(ChainEvent.block, block, null as any, false);
-
-      expect(events).to.have.length(1, "Wrong num of received events");
-      expect(events[0].type).to.equal(routes.events.EventType.blsToExecutionChange);
-      expect(events[0].message).to.equal(blsToExecution);
-    });
-
-    it("should process finalized checkpoint event", async function () {
-      const events = getEvents([routes.events.EventType.finalizedCheckpoint]);
-
-      const state = generateCachedState();
-      const checkpoint = state.finalizedCheckpoint;
-      chainEventEmmitter.emit(ChainEvent.finalized, checkpoint, state);
-
-      expect(events).to.have.length(1, "Wrong num of received events");
-      expect(events[0].type).to.equal(routes.events.EventType.finalizedCheckpoint);
       expect(events[0].message).to.not.be.null;
     });
   });

--- a/packages/beacon-node/test/utils/node/simTest.ts
+++ b/packages/beacon-node/test/utils/node/simTest.ts
@@ -9,6 +9,7 @@ import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {allForks, Epoch, Slot} from "@lodestar/types";
 import {Checkpoint} from "@lodestar/types/phase0";
 import {ILogger, mapValues} from "@lodestar/utils";
+import {routes} from "@lodestar/api";
 import {toHexString} from "@chainsafe/ssz";
 import {BeaconNode} from "../../../src/index.js";
 import {ChainEvent, HeadEventData} from "../../../src/chain/index.js";
@@ -72,11 +73,11 @@ export function simTestInfoTracker(bn: BeaconNode, logger: ILogger): () => void 
     logParticipation(lastState);
   }
 
-  bn.chain.emitter.on(ChainEvent.head, onHead);
+  bn.chain.emitter.on(routes.events.EventType.head, onHead);
   bn.chain.emitter.on(ChainEvent.checkpoint, onCheckpoint);
 
   return function stop() {
-    bn.chain.emitter.off(ChainEvent.head, onHead);
+    bn.chain.emitter.off(routes.events.EventType.head, onHead);
     bn.chain.emitter.off(ChainEvent.checkpoint, onCheckpoint);
 
     // Write report


### PR DESCRIPTION
**Motivation**

BeaconNode source emits events meant for the API through intermediary ChainEvents. That's not necessary since the few users of the internal events can just listen to the events defined as in the API.

- Extends https://github.com/ChainSafe/lodestar/pull/4972

**Description**

Remove all intermediary ChainEvents
