### PR TITLE
Moves Prometheus entrypoint to a non-volume directory.

### DIFF
--- a/docker/prometheus/Dockerfile
+++ b/docker/prometheus/Dockerfile
@@ -1,8 +1,8 @@
 FROM prom/prometheus:latest
 
 COPY prometheus.yml /etc/prometheus/prometheus.yml
-COPY --chown=nobody:nobody entrypoint.sh /prometheus/entrypoint.sh
-RUN chmod +x /prometheus/entrypoint.sh
+COPY --chown=nobody:nobody entrypoint.sh /etc/prometheus/entrypoint.sh
+RUN chmod +x /etc/prometheus/entrypoint.sh
 
 # Modified datasource to work with a network_mode: host
 # Docker DNS: "beacon_node:8008"
@@ -10,8 +10,9 @@ RUN chmod +x /prometheus/entrypoint.sh
 # MacOSX: "host.docker.internal:8008"
 ENV BEACON_URL='beacon_node:8008'
 ENV VC_URL='validator'
+VOLUME /prometheus
 
-ENTRYPOINT ["/prometheus/entrypoint.sh"]
+ENTRYPOINT ["/etc/prometheus/entrypoint.sh"]
 
 CMD [ \
   "--config.file=/etc/prometheus/prometheus.yml", \


### PR DESCRIPTION
Putting the entrypoint script in `/prometheus` caused problems with updating the docker image as the entrypoint was written to the volume when it was first created and then wouldn't be overwritten by future images.  Moving the entrypoint script into a non-mounted location avoids this problem.

I also added a VOLUME line to make it clear to anyone reading the dockerfile that `/prometheus` is intended to be a mounted volume, which may also help some tools auto-discover volumes and I think docker may even automatically create a volume when the image is run (not sure on the last).  Generally speaking, I believe it is a good practice to flag intended mount points in the Dockerfile.

Note: Things will work without this change, but if the entrypoint.sh file ever changes in a future image users will have a bad time when updating to the new image from an old one so ideally this should happen sooner rather than later (ideally before a lot of people start using this published image).