### PR TITLE
Cleanup disabledWithdrawals option

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -35,7 +35,7 @@ export async function verifyBlocksStateTransitionOnly(
   const proposerBalanceDeltas: number[] = [];
 
   for (let i = 0; i < blocks.length; i++) {
-    const {validProposerSignature, validSignatures, disabledWithdrawals} = opts;
+    const {validProposerSignature, validSignatures} = opts;
     const {block} = blocks[i];
     const preState = i === 0 ? preState0 : postStates[i - 1];
 
@@ -61,7 +61,6 @@ export async function verifyBlocksStateTransitionOnly(
         // if block is trusted don't verify proposer or op signature
         verifyProposer: !useBlsBatchVerify && !validSignatures && !validProposerSignature,
         verifySignatures: !useBlsBatchVerify && !validSignatures,
-        disabledWithdrawals,
       },
       metrics
     );

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -49,8 +49,6 @@ export type BlockProcessOpts = {
    * will still issue fcU for block proposal
    */
   disableImportExecutionFcU?: boolean;
-  // TODO EIP-4844: to test without capella
-  disabledWithdrawals?: boolean;
 };
 
 export const defaultChainOptions: IChainOptions = {

--- a/packages/state-transition/src/block/index.ts
+++ b/packages/state-transition/src/block/index.ts
@@ -45,7 +45,7 @@ export function processBlock(
     const fullOrBlindedPayload = getFullOrBlindedPayload(block);
     // TODO EIP-4844: Allow to disable withdrawals for interop testing
     // https://github.com/ethereum/consensus-specs/blob/b62c9e877990242d63aa17a2a59a49bc649a2f2e/specs/eip4844/beacon-chain.md#disabling-withdrawals
-    if (fork >= ForkSeq.capella && !opts?.disabledWithdrawals) {
+    if (fork >= ForkSeq.capella) {
       processWithdrawals(
         state as CachedBeaconStateCapella,
         fullOrBlindedPayload as capella.FullOrBlindedExecutionPayload

--- a/packages/state-transition/src/block/processOperations.ts
+++ b/packages/state-transition/src/block/processOperations.ts
@@ -49,7 +49,7 @@ export function processOperations(
     processVoluntaryExit(state, voluntaryExit, opts.verifySignatures);
   }
 
-  if (fork >= ForkSeq.capella && !opts?.disabledWithdrawals) {
+  if (fork >= ForkSeq.capella) {
     for (const blsToExecutionChange of (body as capella.BeaconBlockBody).blsToExecutionChanges) {
       processBlsToExecutionChange(state as CachedBeaconStateCapella, blsToExecutionChange);
     }

--- a/packages/state-transition/src/block/types.ts
+++ b/packages/state-transition/src/block/types.ts
@@ -1,4 +1,3 @@
 export interface ProcessBlockOpts {
   verifySignatures?: boolean;
-  disabledWithdrawals?: boolean;
 }


### PR DESCRIPTION
As a consequence of updating the spec to `v1.3.0-rc.0` in 
- https://github.com/ChainSafe/lodestar/pull/4974

eip4844 is now with withdrawals activated and hence the option of disabledWithdrawals isn't relavant anymore. 
