### PR TITLE
Tag relevant peer

### DIFF
--- a/packages/beacon-node/src/network/nodejs/bundle.ts
+++ b/packages/beacon-node/src/network/nodejs/bundle.ts
@@ -66,8 +66,11 @@ export async function createNodejsLibp2p(options: ILibp2pOptions): Promise<Libp2
       dialTimeout: 30_000,
 
       autoDial: false,
-      // This is the default value, we reject connections based on tcp() option above so this is not important
-      maxConnections: Infinity,
+      // DOCS: the maximum number of connections libp2p is willing to have before it starts disconnecting.
+      // If ConnectionManager.size > maxConnections calls _maybeDisconnectOne() which will sort peers disconnect
+      // the one with the least `_peerValues`. That's a custom peer generalized score that's not used, so it always
+      // has the same value in current Lodestar usage.
+      maxConnections: options.maxConnections,
       // DOCS: the minimum number of connections below which libp2p not activate preemptive disconnections.
       // If ConnectionManager.size < minConnections, it won't prune peers in _maybeDisconnectOne(). If autoDial is
       // off it doesn't have any effect in behaviour.

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -41,6 +41,14 @@ const STATUS_INBOUND_GRACE_PERIOD = 15 * 1000;
 const CHECK_PING_STATUS_INTERVAL = 10 * 1000;
 /** A peer is considered long connection if it's >= 1 day */
 const LONG_PEER_CONNECTION_MS = 24 * 60 * 60 * 1000;
+/**
+ * Tag peer when it's relevant and connecting to our node.
+ * When node has > maxPeer (55), libp2p randomly prune peers if we don't tag peers in use.
+ * See https://github.com/ChainSafe/lodestar/issues/4623#issuecomment-1374447934
+ **/
+const PEER_RELEVANT_TAG = "relevant";
+/** Tag value of PEER_RELEVANT_TAG */
+const PEER_RELEVANT_TAG_VALUE = 100;
 
 /**
  * Relative factor of peers that are allowed to have a negative gossipsub score without penalizing them in lodestar.
@@ -329,7 +337,13 @@ export class PeerManager {
     // Peer is usable, send it to the rangeSync
     // NOTE: Peer may not be connected anymore at this point, potential race condition
     // libp2p.connectionManager.get() returns not null if there's +1 open connections with `peer`
-    if (peerData) peerData.relevantStatus = RelevantPeerStatus.relevant;
+    if (peerData && peerData.relevantStatus !== RelevantPeerStatus.relevant) {
+      this.libp2p.peerStore
+        // ttl = undefined means it's never expired
+        .tagPeer(peer, PEER_RELEVANT_TAG, {ttl: undefined, value: PEER_RELEVANT_TAG_VALUE})
+        .catch((e) => this.logger.verbose("cannot tag peer", {peerId: peer.toString()}, e as Error));
+      peerData.relevantStatus = RelevantPeerStatus.relevant;
+    }
     if (getConnection(this.libp2p.connectionManager, peer.toString())) {
       this.networkEventBus.emit(NetworkEvent.peerConnected, peer, status);
     }
@@ -580,6 +594,9 @@ export class PeerManager {
     this.logger.verbose("peer disconnected", {peer: prettyPrintPeerId(peer), direction, status});
     this.networkEventBus.emit(NetworkEvent.peerDisconnected, peer);
     this.metrics?.peerDisconnectedEvent.inc({direction});
+    this.libp2p.peerStore
+      .unTagPeer(peer, PEER_RELEVANT_TAG)
+      .catch((e) => this.logger.verbose("cannot untag peer", {peerId: peer.toString()}, e as Error));
   };
 
   private async disconnect(peer: PeerId): Promise<void> {


### PR DESCRIPTION
**Motivation**

- When there are many peers (> 55), libp2p randomly delete peer and it makes our peers unstable. See https://github.com/libp2p/js-libp2p/blob/v0.41.0/src/connection-manager/index.ts#L635
- The reason is we don't tag any peers

**Description**

- Tag relevants peers in use, untag when we disconnect peers
- Keep `maxConnections` option in libp2p's connection manager

found it from #4623

**Test result**
- Deployed to feat1 and "Peer connection length` metric improved
<img width="815" alt="Screen Shot 2023-01-10 at 11 15 40" src="https://user-images.githubusercontent.com/10568965/211460657-bf11b321-26eb-4468-8bd2-1e4e9a27c24a.png">

