### PR TITLE
docs: fix use of old arguments and names

### DIFF
--- a/packages/cli/src/cmds/validator/import.ts
+++ b/packages/cli/src/cmds/validator/import.ts
@@ -21,7 +21,7 @@ Ethereum Foundation utility.",
 
   examples: [
     {
-      command: "validator import --network goerli --keystores $HOME/eth2.0-deposit-cli/validator_keys",
+      command: "validator import --network goerli --importKeystores $HOME/staking-deposit-cli/validator_keys",
       description: "Import validator keystores generated with the Ethereum Foundation Staking Launchpad",
     },
   ],

--- a/packages/cli/src/cmds/validator/list.ts
+++ b/packages/cli/src/cmds/validator/list.ts
@@ -14,7 +14,7 @@ export const list: ICliCommand<IValidatorCliArgs, IGlobalArgs, ReturnType> = {
 
   examples: [
     {
-      command: "account validator list",
+      command: "validator list",
       description: "List all validator pubkeys previously imported",
     },
   ],

--- a/packages/cli/src/cmds/validator/signers/importExternalKeystores.ts
+++ b/packages/cli/src/cmds/validator/signers/importExternalKeystores.ts
@@ -51,17 +51,17 @@ export function isVotingKeystore(filename: string): boolean {
   // All formats end with `.json`.
   return (
     filename.endsWith(".json") &&
-    // The eth2.0-deposit-cli tool outputs a deposit_data file in the directory users typically import from.
+    // The staking-deposit-cli tool outputs a deposit_data file in the directory users typically import from.
     // Ignoring that file is very helpful for UX, and it's very unlikely that someone names their keystore that way.
     !/deposit_data-\d+\.json$/gi.test(filename)
-    // Note: Previously this tool only imported the exact naming from the eth2.0-deposit-cli tool.
+    // Note: Previously this tool only imported the exact naming from the staking-deposit-cli tool.
     //       However, that's too restrictive. Guide left here as a reference
     //
-    // The format exported by the `eth2.0-deposit-cli` library.
+    // The format exported by the `staking-deposit-cli` library.
     //
     // Reference to function that generates keystores:
     // eslint-disable-next-line max-len
-    // https://github.com/ethereum/eth2.0-deposit-cli/blob/7cebff15eac299b3b1b090c896dd3410c8463450/eth2deposit/credentials.py#L58-L62
+    // https://github.com/ethereum/staking-deposit-cli/blob/7cebff15eac299b3b1b090c896dd3410c8463450/eth2deposit/credentials.py#L58-L62
     //
     // Since we include the key derivation path of `m/12381/3600/x/0/0` this should only ever match
     // with a voting keystore and never a withdrawal keystore.

--- a/packages/cli/src/cmds/validator/voluntaryExit.ts
+++ b/packages/cli/src/cmds/validator/voluntaryExit.ts
@@ -35,7 +35,7 @@ like to choose for the voluntary exit.",
 
   examples: [
     {
-      command: "account validator voluntary-exit --publicKey 0xF00",
+      command: "validator voluntary-exit --publicKey 0xF00",
       description: "Perform a voluntary exit for the validator who has a public key 0xF00",
     },
   ],


### PR DESCRIPTION
**Motivation**

After completing some work on #4985, I noticed a few things in docs + examples that should be changed/removed. 

**Description**

These are fixed with this PR:

- Some usage of old arguments that we are looking to deprecate (e.g. `validator --keystore`) in relation to keystore imports 
- Docs which still mentioned the old `account validator` CLI in examples which should be removed as part of #3300
- Some references to the old `eth2.0-deposit-cli` have been renamed to the new `staking-deposit-cli`
