### PR TITLE
Add and propogate blockValue to select full or blinded block

### DIFF
--- a/packages/api/src/utils/types.ts
+++ b/packages/api/src/utils/types.ts
@@ -195,6 +195,22 @@ export function WithExecutionOptimistic<T extends {data: unknown}>(
   };
 }
 
+/**
+ * SSZ factory helper to wrap an existing type with `{blockValue: Wei}`
+ */
+export function WithBlockValue<T extends {data: unknown}>(type: TypeJson<T>): TypeJson<T & {blockValue: bigint}> {
+  return {
+    toJson: ({blockValue, ...data}) => ({
+      ...(type.toJson((data as unknown) as T) as Record<string, unknown>),
+      block_value: blockValue.toString(),
+    }),
+    fromJson: ({block_value, ...data}: T & {block_value: string}) => ({
+      ...type.fromJson(data),
+      blockValue: BigInt(block_value),
+    }),
+  };
+}
+
 type JsonCase = "snake" | "constant" | "camel" | "param" | "header" | "pascal" | "dot" | "notransform";
 
 /** Helper to only translate casing */

--- a/packages/api/test/unit/beacon/testData/validator.ts
+++ b/packages/api/test/unit/beacon/testData/validator.ts
@@ -44,15 +44,19 @@ export const testData: GenericServerTestCases<Api> = {
   },
   produceBlock: {
     args: [32000, randaoReveal, graffiti],
-    res: {data: ssz.phase0.BeaconBlock.defaultValue()},
+    res: {data: ssz.phase0.BeaconBlock.defaultValue(), blockValue: ssz.Wei.defaultValue()},
   },
   produceBlockV2: {
     args: [32000, randaoReveal, graffiti],
-    res: {data: ssz.altair.BeaconBlock.defaultValue(), version: ForkName.altair},
+    res: {data: ssz.altair.BeaconBlock.defaultValue(), version: ForkName.altair, blockValue: ssz.Wei.defaultValue()},
   },
   produceBlindedBlock: {
     args: [32000, randaoReveal, graffiti],
-    res: {data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(), version: ForkName.bellatrix},
+    res: {
+      data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(),
+      version: ForkName.bellatrix,
+      blockValue: ssz.Wei.defaultValue(),
+    },
   },
   produceAttestationData: {
     args: [2, 32000],

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -203,13 +203,13 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
       chain.forkChoice.updateHead();
 
       timer = metrics?.blockProductionTime.startTimer();
-      const block = await chain.produceBlindedBlock({
+      const {block, blockValue} = await chain.produceBlindedBlock({
         slot,
         randaoReveal,
         graffiti: toGraffitiBuffer(graffiti || ""),
       });
       metrics?.blockProductionSuccess.inc();
-      return {data: block, version: config.getForkName(block.slot)};
+      return {data: block, version: config.getForkName(block.slot), blockValue};
     } finally {
       if (timer) timer();
     }
@@ -233,14 +233,14 @@ export function getValidatorApi({chain, config, logger, metrics, network, sync}:
       chain.recomputeForkChoiceHead();
 
       timer = metrics?.blockProductionTime.startTimer();
-      const block = await chain.produceBlock({
+      const {block, blockValue} = await chain.produceBlock({
         slot,
         randaoReveal,
         graffiti: toGraffitiBuffer(graffiti || ""),
       });
       metrics?.blockProductionSuccess.inc();
       metrics?.blockProductionNumAggregated.observe(block.body.attestations.length);
-      return {data: block, version: config.getForkName(block.slot)};
+      return {data: block, version: config.getForkName(block.slot), blockValue};
     } finally {
       if (timer) timer();
     }

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -1,4 +1,4 @@
-import {allForks, UintNum64, Root, phase0, Slot, RootHex, Epoch, ValidatorIndex, eip4844} from "@lodestar/types";
+import {allForks, UintNum64, Root, phase0, Slot, RootHex, Epoch, ValidatorIndex, eip4844, Wei} from "@lodestar/types";
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {IBeaconConfig} from "@lodestar/config";
 import {CompositeTypeAny, TreeView, Type} from "@chainsafe/ssz";
@@ -113,8 +113,8 @@ export interface IBeaconChain {
 
   getBlobsSidecar(beaconBlock: eip4844.BeaconBlock): eip4844.BlobsSidecar;
 
-  produceBlock(blockAttributes: BlockAttributes): Promise<allForks.BeaconBlock>;
-  produceBlindedBlock(blockAttributes: BlockAttributes): Promise<allForks.BlindedBeaconBlock>;
+  produceBlock(blockAttributes: BlockAttributes): Promise<{block: allForks.BeaconBlock; blockValue: Wei}>;
+  produceBlindedBlock(blockAttributes: BlockAttributes): Promise<{block: allForks.BlindedBeaconBlock; blockValue: Wei}>;
 
   /** Process a block until complete */
   processBlock(block: BlockInput, opts?: ImportBlockOpts): Promise<void>;

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -1,4 +1,4 @@
-import {allForks, bellatrix, Slot, Root, BLSPubkey, ssz, eip4844} from "@lodestar/types";
+import {allForks, bellatrix, Slot, Root, BLSPubkey, ssz, eip4844, Wei} from "@lodestar/types";
 import {IChainForkConfig} from "@lodestar/config";
 import {getClient, Api as BuilderApi} from "@lodestar/api/builder";
 import {byteArrayEquals, toHexString} from "@chainsafe/ssz";
@@ -57,9 +57,15 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
     slot: Slot,
     parentHash: Root,
     proposerPubKey: BLSPubkey
-  ): Promise<{header: allForks.ExecutionPayloadHeader; blobKzgCommitments?: eip4844.BlobKzgCommitments}> {
+  ): Promise<{
+    header: allForks.ExecutionPayloadHeader;
+    blockValue: Wei;
+    blobKzgCommitments?: eip4844.BlobKzgCommitments;
+  }> {
     const {data: signedBid} = await this.api.getHeader(slot, parentHash, proposerPubKey);
-    return signedBid.message;
+    const {header, value: blockValue} = signedBid.message;
+    const {blobKzgCommitments} = signedBid.message as {blobKzgCommitments?: eip4844.BlobKzgCommitments};
+    return {header, blockValue, blobKzgCommitments};
   }
 
   async submitBlindedBlock(signedBlock: allForks.SignedBlindedBeaconBlock): Promise<allForks.SignedBeaconBlock> {

--- a/packages/beacon-node/src/execution/builder/interface.ts
+++ b/packages/beacon-node/src/execution/builder/interface.ts
@@ -1,4 +1,4 @@
-import {allForks, bellatrix, Root, Slot, BLSPubkey, eip4844} from "@lodestar/types";
+import {allForks, bellatrix, Root, Slot, BLSPubkey, eip4844, Wei} from "@lodestar/types";
 
 export interface IExecutionBuilder {
   /**
@@ -15,7 +15,11 @@ export interface IExecutionBuilder {
     slot: Slot,
     parentHash: Root,
     proposerPubKey: BLSPubkey
-  ): Promise<{header: allForks.ExecutionPayloadHeader; blobKzgCommitments?: eip4844.BlobKzgCommitments}>;
+  ): Promise<{
+    header: allForks.ExecutionPayloadHeader;
+    blockValue: Wei;
+    blobKzgCommitments?: eip4844.BlobKzgCommitments;
+  }>;
   submitBlindedBlock(signedBlock: allForks.SignedBlindedBeaconBlock): Promise<allForks.SignedBeaconBlock>;
   submitBlindedBlockV2(
     signedBlock: allForks.SignedBlindedBeaconBlock

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -1,4 +1,4 @@
-import {RootHex, allForks} from "@lodestar/types";
+import {RootHex, allForks, Wei} from "@lodestar/types";
 import {SLOTS_PER_EPOCH, ForkName, ForkSeq} from "@lodestar/params";
 
 import {ErrorJsonRpcResponse, HttpRpcError} from "../../eth1/provider/jsonRpcHttpClient.js";
@@ -284,7 +284,10 @@ export class ExecutionEngineHttp implements IExecutionEngine {
    * 2. The call MUST be responded with 5: Unavailable payload error if the building process identified by the payloadId doesn't exist.
    * 3. Client software MAY stop the corresponding building process after serving this call.
    */
-  async getPayload(fork: ForkName, payloadId: PayloadId): Promise<allForks.ExecutionPayload> {
+  async getPayload(
+    fork: ForkName,
+    payloadId: PayloadId
+  ): Promise<{executionPayload: allForks.ExecutionPayload; blockValue: Wei}> {
     const method =
       ForkSeq[fork] >= ForkSeq.eip4844
         ? "engine_getPayloadV3"

--- a/packages/beacon-node/src/execution/engine/interface.ts
+++ b/packages/beacon-node/src/execution/engine/interface.ts
@@ -1,6 +1,6 @@
 import {ForkName} from "@lodestar/params";
 import {KZGCommitment, Blob} from "@lodestar/types/eip4844";
-import {RootHex, allForks, capella} from "@lodestar/types";
+import {RootHex, allForks, capella, Wei} from "@lodestar/types";
 
 import {DATA, QUANTITY} from "../../eth1/provider/utils.js";
 import {PayloadIdCache, PayloadId, WithdrawalV1} from "./payloadIdCache.js";
@@ -115,7 +115,10 @@ export interface IExecutionEngine {
    * Required for block producing
    * https://github.com/ethereum/consensus-specs/blob/dev/specs/merge/validator.md#get_payload
    */
-  getPayload(fork: ForkName, payloadId: PayloadId): Promise<allForks.ExecutionPayload>;
+  getPayload(
+    fork: ForkName,
+    payloadId: PayloadId
+  ): Promise<{executionPayload: allForks.ExecutionPayload; blockValue: Wei}>;
 
   /**
    * "After retrieving the execution payload from the execution engine as specified in Bellatrix,

--- a/packages/beacon-node/test/sim/merge-interop.test.ts
+++ b/packages/beacon-node/test/sim/merge-interop.test.ts
@@ -144,7 +144,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
      * curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"engine_getPayloadV1","params":["0xa247243752eb10b4"],"id":67}' http://localhost:8550
      **/
 
-    const payload = await executionEngine.getPayload(ForkName.bellatrix, payloadId);
+    const {executionPayload: payload} = await executionEngine.getPayload(ForkName.bellatrix, payloadId);
     if (TX_SCENARIOS.includes("simple")) {
       if (payload.transactions.length !== 1)
         throw new Error("Expected a simple transaction to be in the fetched payload");

--- a/packages/beacon-node/test/sim/withdrawal-interop.test.ts
+++ b/packages/beacon-node/test/sim/withdrawal-interop.test.ts
@@ -160,7 +160,8 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     if (!payloadId) throw Error("InvalidPayloadId");
 
     // 2. Get the payload
-    const payload = await executionEngine.getPayload(ForkName.capella, payloadId);
+    const payloadAndBlockValue = await executionEngine.getPayload(ForkName.capella, payloadId);
+    const payload = payloadAndBlockValue.executionPayload;
     const blockHash = toHexString(payload.blockHash);
     const expectedBlockHash = "0x64707e5574d14103a7f583e702f09e68ca1eb334e8eb0632a4272efe54f2fc7c";
     if (blockHash !== expectedBlockHash) {

--- a/packages/beacon-node/test/unit/executionEngine/http.test.ts
+++ b/packages/beacon-node/test/unit/executionEngine/http.test.ts
@@ -75,7 +75,8 @@ describe("ExecutionEngine / http", () => {
     };
     returnValue = response;
 
-    const payload = await executionEngine.getPayload(ForkName.bellatrix, "0x0");
+    const payloadAndBlockValue = await executionEngine.getPayload(ForkName.bellatrix, "0x0");
+    const payload = payloadAndBlockValue.executionPayload;
 
     expect(serializeExecutionPayload(ForkName.bellatrix, payload)).to.deep.equal(
       response.result,
@@ -120,7 +121,7 @@ describe("ExecutionEngine / http", () => {
 
     const {status} = await executionEngine.notifyNewPayload(
       ForkName.bellatrix,
-      parseExecutionPayload(ForkName.bellatrix, request.params[0])
+      parseExecutionPayload(ForkName.bellatrix, request.params[0]).executionPayload
     );
 
     expect(status).to.equal("VALID", "Wrong returned execute payload result");

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -1,7 +1,7 @@
 import sinon from "sinon";
 
 import {CompositeTypeAny, toHexString, TreeView} from "@chainsafe/ssz";
-import {phase0, allForks, UintNum64, Root, Slot, ssz, Uint16, UintBn64, RootHex, eip4844} from "@lodestar/types";
+import {phase0, allForks, UintNum64, Root, Slot, ssz, Uint16, UintBn64, RootHex, eip4844, Wei} from "@lodestar/types";
 import {IBeaconConfig} from "@lodestar/config";
 import {BeaconStateAllForks, CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {CheckpointWithHex, IForkChoice, ProtoBlock, ExecutionStatus, AncestorStatus} from "@lodestar/fork-choice";
@@ -173,10 +173,12 @@ export class MockBeaconChain implements IBeaconChain {
     throw Error("Not implemented");
   }
 
-  async produceBlock(_blockAttributes: BlockAttributes): Promise<allForks.BeaconBlock> {
+  async produceBlock(_blockAttributes: BlockAttributes): Promise<{block: allForks.BeaconBlock; blockValue: Wei}> {
     throw Error("Not implemented");
   }
-  async produceBlindedBlock(_blockAttributes: BlockAttributes): Promise<allForks.BlindedBeaconBlock> {
+  async produceBlindedBlock(
+    _blockAttributes: BlockAttributes
+  ): Promise<{block: allForks.BlindedBeaconBlock; blockValue: Wei}> {
     throw Error("Not implemented");
   }
 

--- a/packages/types/src/primitive/sszTypes.ts
+++ b/packages/types/src/primitive/sszTypes.ts
@@ -50,6 +50,7 @@ export const SubcommitteeIndex = UintNum64;
 export const ValidatorIndex = UintNum64;
 export const WithdrawalIndex = UintNum64;
 export const Gwei = UintBn64;
+export const Wei = UintBn256;
 export const Root = new ByteVectorType(32);
 
 export const Version = Bytes4;

--- a/packages/types/src/primitive/types.ts
+++ b/packages/types/src/primitive/types.ts
@@ -30,6 +30,7 @@ export type SubcommitteeIndex = UintNum64;
 export type ValidatorIndex = UintNum64;
 export type WithdrawalIndex = UintNum64;
 export type Gwei = UintBn64;
+export type Wei = UintBn256;
 export type Root = Bytes32;
 export type Version = Bytes4;
 export type DomainType = Bytes4;

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -1,4 +1,4 @@
-import {BLSPubkey, Slot, BLSSignature, allForks, bellatrix, capella, isBlindedBeaconBlock} from "@lodestar/types";
+import {BLSPubkey, Slot, BLSSignature, allForks, bellatrix, capella, isBlindedBeaconBlock, Wei} from "@lodestar/types";
 import {IChainForkConfig} from "@lodestar/config";
 import {ForkName} from "@lodestar/params";
 import {extendError, prettyBytes} from "@lodestar/utils";
@@ -137,14 +137,15 @@ export class BlockProposingService {
     const fullBlock = await fullBlockPromise;
 
     // A metric on the choice between blindedBlock and normal block can be applied
+    // TODO: compare the blockValue that has been obtained in each of full or blinded block
     if (blindedBlock) {
-      const debugLogCtx = {source: "builder"};
+      const debugLogCtx = {source: "builder", blockValue: blindedBlock.blockValue.toString()};
       return {...blindedBlock, debugLogCtx};
     } else {
-      const debugLogCtx = {source: "engine"};
       if (!fullBlock) {
         throw Error("Failed to produce engine or builder block");
       }
+      const debugLogCtx = {source: "engine", blockValue: fullBlock.blockValue.toString()};
       const blockFeeRecipient = (fullBlock.data as bellatrix.BeaconBlock).body.executionPayload?.feeRecipient;
       const feeRecipient = blockFeeRecipient !== undefined ? toHexString(blockFeeRecipient) : undefined;
       if (feeRecipient !== undefined) {
@@ -177,7 +178,7 @@ export class BlockProposingService {
     slot,
     randaoReveal,
     graffiti
-  ): Promise<{data: allForks.BeaconBlock}> => {
+  ): Promise<{data: allForks.BeaconBlock; blockValue: Wei}> => {
     switch (this.config.getForkName(slot)) {
       case ForkName.phase0:
         return this.api.validator.produceBlock(slot, randaoReveal, graffiti);

--- a/packages/validator/test/unit/services/block.test.ts
+++ b/packages/validator/test/unit/services/block.test.ts
@@ -48,7 +48,7 @@ describe("BlockDutiesService", function () {
     const signedBlock = ssz.phase0.SignedBeaconBlock.defaultValue();
     validatorStore.signRandao.resolves(signedBlock.message.body.randaoReveal);
     validatorStore.signBlock.callsFake(async (_, block) => ({message: block, signature: signedBlock.signature}));
-    api.validator.produceBlock.resolves({data: signedBlock.message});
+    api.validator.produceBlock.resolves({data: signedBlock.message, blockValue: ssz.Wei.defaultValue()});
     api.beacon.publishBlock.resolves();
 
     // Trigger block production for slot 1


### PR DESCRIPTION
Since capella onwards, blockValue would also be now available from execution generated payloads, its now feasible to choose between engine or execution on max profit naive strategy.

This PR adds and propogates the same.

TODO: 
- [ ] Compare blockValue and choose between execution and blinded block in validator's block.ts