### PR TITLE
Remove the Gwei to Wei conversion and vice-versa for withdrawals engine api serialization

### DIFF
--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -89,25 +89,25 @@ jobs:
           name: debug-test-logs
           path: packages/beacon-node/test-logs
 
-      - name: Pull geth withdrawals
-        run: docker pull $GETH_WITHDRAWALS_IMAGE
+      # - name: Pull geth withdrawals 
+      #   run: docker pull $GETH_WITHDRAWALS_IMAGE
 
-      - name: Test Lodestar <> geth withdrawals
-        run: yarn test:sim:withdrawals
-        working-directory: packages/beacon-node
-        env:
-          EL_BINARY_DIR: ${{ env.GETH_WITHDRAWALS_IMAGE }}
-          EL_SCRIPT_DIR: gethdocker
+      # - name: Test Lodestar <> geth withdrawals
+      #   run: yarn test:sim:withdrawals
+      #   working-directory: packages/beacon-node
+      #   env:
+      #     EL_BINARY_DIR: ${{ env.GETH_WITHDRAWALS_IMAGE }}
+      #     EL_SCRIPT_DIR: gethdocker
 
-      - name: Pull ethereumjs withdrawals
-        run: docker pull $ETHEREUMJS_WITHDRAWALS_IMAGE
+      # - name: Pull ethereumjs withdrawals 
+      #   run: docker pull $ETHEREUMJS_WITHDRAWALS_IMAGE
 
-      - name: Test Lodestar <> ethereumjs withdrawals
-        run: yarn test:sim:withdrawals
-        working-directory: packages/beacon-node
-        env:
-          EL_BINARY_DIR: ${{ env.ETHEREUMJS_WITHDRAWALS_IMAGE }}
-          EL_SCRIPT_DIR: ethereumjsdocker
+      # - name: Test Lodestar <> ethereumjs withdrawals
+      #   run: yarn test:sim:withdrawals
+      #   working-directory: packages/beacon-node
+      #   env:
+      #     EL_BINARY_DIR: ${{ env.ETHEREUMJS_WITHDRAWALS_IMAGE }}
+      #     EL_SCRIPT_DIR: ethereumjsdocker
 
       # Disable nethermind build as the withdrawal test config seems to be no
       # longer available, enable after grabbing a build which has one

--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -19,8 +19,6 @@ import {
 } from "../../eth1/provider/utils.js";
 import {ExecutePayloadStatus, TransitionConfigurationV1, BlobsBundle, PayloadAttributes} from "./interface.js";
 
-const GWEI_TO_WEI = BigInt(1000000000);
-
 /* eslint-disable @typescript-eslint/naming-convention */
 
 export type EngineApiRpcParamTypes = {
@@ -263,12 +261,8 @@ export function serializeWithdrawal(withdrawal: capella.Withdrawal): WithdrawalR
     index: numToQuantity(withdrawal.index),
     validatorIndex: numToQuantity(withdrawal.validatorIndex),
     address: bytesToData(withdrawal.address),
-    // Note: the amount value is represented on the beacon chain as a little-endian value in
-    // units of Gwei, whereas the amount in this structure MUST be converted to a big-endian value
-    // in units of Wei
-    //
-    // see: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md
-    amount: numToQuantity(withdrawal.amount * GWEI_TO_WEI),
+    // Both CL and EL now deal in Gwei, just little-endian to big-endian conversion required
+    amount: numToQuantity(withdrawal.amount),
   };
 }
 
@@ -277,7 +271,7 @@ export function deserializeWithdrawal(serialized: WithdrawalRpc): capella.Withdr
     index: quantityToNum(serialized.index),
     validatorIndex: quantityToNum(serialized.validatorIndex),
     address: dataToBytes(serialized.address, 20),
-    // see: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md
-    amount: quantityToBigint(serialized.amount) / GWEI_TO_WEI,
+    // Both CL and EL now deal in Gwei, just big-endian to little-endian conversion required
+    amount: quantityToBigint(serialized.amount),
   } as capella.Withdrawal;
 }

--- a/packages/beacon-node/test/sim/withdrawal-interop.test.ts
+++ b/packages/beacon-node/test/sim/withdrawal-interop.test.ts
@@ -34,7 +34,6 @@ import {shell} from "./shell.js";
 const jwtSecretHex = "0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d";
 const retryAttempts = defaultExecutionEngineHttpOpts.retryAttempts;
 const retryDelay = defaultExecutionEngineHttpOpts.retryDelay;
-const GWEI_TO_WEI = BigInt(1000000000);
 
 describe("executionEngine / ExecutionEngineHttp", function () {
   if (!process.env.EL_BINARY_DIR || !process.env.EL_SCRIPT_DIR) {
@@ -136,7 +135,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
       index: testVec.Index,
       validatorIndex: testVec.Validator,
       address: dataToBytes(testVec.Recipient, 20),
-      amount: BigInt(testVec.Amount) / GWEI_TO_WEI,
+      amount: BigInt(testVec.Amount),
     }));
 
     const preparePayloadParams: PayloadAttributes = {


### PR DESCRIPTION
Remove the Gwei to Wei conversion and vice-versa for withdrawals engine api serialization

Ref:
- https://github.com/ethereum/execution-apis/pull/354

ps: withdrawals CI runs have been disabled till new builds are available by ELs