### PR TITLE
Use genesis fork version for signing and verifying `BLSToExecutionChange`

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -1,6 +1,6 @@
 import {routes} from "@lodestar/api";
 import {Epoch, ssz} from "@lodestar/types";
-import {SYNC_COMMITTEE_SUBNET_SIZE} from "@lodestar/params";
+import {SYNC_COMMITTEE_SUBNET_SIZE, ForkName} from "@lodestar/params";
 import {validateGossipAttestation} from "../../../../chain/validation/index.js";
 import {validateGossipAttesterSlashing} from "../../../../chain/validation/attesterSlashing.js";
 import {validateGossipProposerSlashing} from "../../../../chain/validation/proposerSlashing.js";
@@ -99,8 +99,8 @@ export function getBeaconPoolApi({
     async submitPoolBlsToExecutionChange(blsToExecutionChanges) {
       const errors: Error[] = [];
 
-      // TODO CAPELLA: Which fork should assume to validate submitted execution changes?
-      const signatureFork = chain.config.getForkName(chain.clock.currentSlot);
+      // Fork to validate submitted execution changes: phase0 which picks GENESIS_FORK_VERSION
+      const signatureFork = ForkName.phase0;
 
       await Promise.all(
         blsToExecutionChanges.map(async (blsToExecutionChange, i) => {

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -105,7 +105,7 @@ export function getBeaconPoolApi({
       await Promise.all(
         blsToExecutionChanges.map(async (blsToExecutionChange, i) => {
           try {
-            await validateBlsToExecutionChange(chain, blsToExecutionChange, signatureFork);
+            await validateBlsToExecutionChange(chain, blsToExecutionChange);
             chain.opPool.insertBlsToExecutionChange(blsToExecutionChange, signatureFork);
             await network.gossip.publishBlsToExecutionChange(blsToExecutionChange);
           } catch (e) {

--- a/packages/beacon-node/src/chain/opPools/opPool.ts
+++ b/packages/beacon-node/src/chain/opPools/opPool.ts
@@ -350,15 +350,7 @@ export class OpPool {
     headState: CachedBeaconStateAllForks,
     finalizedState: CachedBeaconStateAllForks | null
   ): void {
-    const headStateFork = headState.config.getForkSeq(headState.slot);
-
     for (const [key, blsToExecutionChange] of this.blsToExecutionChanges.entries()) {
-      // TODO CAPELLA: Current spec only allows to verify changes from the same fork
-      // https://github.com/ethereum/consensus-specs/pull/3168
-      if (blsToExecutionChange.signatureForkSeq < headStateFork) {
-        this.blsToExecutionChanges.delete(key);
-      }
-
       // TODO CAPELLA: We need the finalizedState to safely prune BlsToExecutionChanges. Finalized state may not be
       // available in the cache, so it can be null. Once there's a head only prunning strategy, change
       if (finalizedState !== null) {

--- a/packages/beacon-node/src/chain/opPools/utils.ts
+++ b/packages/beacon-node/src/chain/opPools/utils.ts
@@ -57,15 +57,6 @@ export function isValidBlsToExecutionChangeForBlockInclusion(
 
   // 3. assert validator.withdrawal_credentials[1:] == hash(address_change.from_bls_pubkey)[1:]:
   //    If valid before will always be valid in the future, no need to check
-  //
-  // 4. assert bls.Verify(address_change.from_bls_pubkey, signing_root, signed_address_change.signature):
-  //    May become invalid in the future if the fork changes. No need to check the full BLS signature, but check that
-  //    the fork it was valid, is still the current fork
-  //
-  // TODO CAPELLA: Ensure that the fork at witch the signature was verified is the same as the state's fork
-  if (signedBLSToExecutionChange.signatureForkSeq !== state.config.getForkSeq(state.slot)) {
-    return false;
-  }
 
   return true;
 }

--- a/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
+++ b/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
@@ -3,16 +3,13 @@ import {
   isValidBlsToExecutionChange,
   getBlsToExecutionChangeSignatureSet,
   CachedBeaconStateCapella,
-  computeStartSlotAtEpoch,
 } from "@lodestar/state-transition";
-import {ForkName} from "@lodestar/params";
 import {IBeaconChain} from "..";
 import {BlsToExecutionChangeError, BlsToExecutionChangeErrorCode, GossipAction} from "../errors/index.js";
 
 export async function validateBlsToExecutionChange(
   chain: IBeaconChain,
-  blsToExecutionChange: capella.SignedBLSToExecutionChange,
-  signatureFork: ForkName
+  blsToExecutionChange: capella.SignedBLSToExecutionChange
 ): Promise<void> {
   // [IGNORE] The blsToExecutionChange is the first valid blsToExecutionChange received for the validator with index
   // signedBLSToExecutionChange.message.validatorIndex.
@@ -37,9 +34,7 @@ export async function validateBlsToExecutionChange(
     });
   }
 
-  const signatureSlot = computeStartSlotAtEpoch(config.forks[signatureFork].epoch);
-
-  const signatureSet = getBlsToExecutionChangeSignatureSet(config, signatureSlot, blsToExecutionChange);
+  const signatureSet = getBlsToExecutionChangeSignatureSet(config, blsToExecutionChange);
   if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true}))) {
     throw new BlsToExecutionChangeError(GossipAction.REJECT, {
       code: BlsToExecutionChangeErrorCode.INVALID_SIGNATURE,

--- a/packages/beacon-node/src/network/gossip/handlers/index.ts
+++ b/packages/beacon-node/src/network/gossip/handlers/index.ts
@@ -346,12 +346,13 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
       validateLightClientOptimisticUpdate(config, chain, lightClientOptimisticUpdate);
     },
 
-    [GossipType.bls_to_execution_change]: async (blsToExecutionChange, topic) => {
-      await validateBlsToExecutionChange(chain, blsToExecutionChange, topic.fork);
+    // blsToExecutionChange is to be generated and validated against GENESIS_FORK_VERSION
+    [GossipType.bls_to_execution_change]: async (blsToExecutionChange, _topic) => {
+      await validateBlsToExecutionChange(chain, blsToExecutionChange, ForkName.phase0);
 
       // Handler
       try {
-        chain.opPool.insertBlsToExecutionChange(blsToExecutionChange, topic.fork);
+        chain.opPool.insertBlsToExecutionChange(blsToExecutionChange, ForkName.phase0);
       } catch (e) {
         logger.error("Error adding blsToExecutionChange to pool", {}, e as Error);
       }

--- a/packages/beacon-node/src/network/gossip/handlers/index.ts
+++ b/packages/beacon-node/src/network/gossip/handlers/index.ts
@@ -348,7 +348,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
 
     // blsToExecutionChange is to be generated and validated against GENESIS_FORK_VERSION
     [GossipType.bls_to_execution_change]: async (blsToExecutionChange, _topic) => {
-      await validateBlsToExecutionChange(chain, blsToExecutionChange, ForkName.phase0);
+      await validateBlsToExecutionChange(chain, blsToExecutionChange);
 
       // Handler
       try {

--- a/packages/beacon-node/test/spec/presets/index.test.ts
+++ b/packages/beacon-node/test/spec/presets/index.test.ts
@@ -65,6 +65,9 @@ specTestIterator(
     ssz_static: {
       type: RunnerType.custom,
       fn: sszStatic([
+        // The LightClient types are disabled momentarily as there is LightClientHeader introduced
+        // in this spec release and is being addressed in separate PR which will fix and
+        // reenable all these types
         "LightClientHeader",
         "LightClientUpdate",
         "LightClientFinalityUpdate",

--- a/packages/beacon-node/test/spec/presets/index.test.ts
+++ b/packages/beacon-node/test/spec/presets/index.test.ts
@@ -62,7 +62,7 @@ specTestIterator(
     rewards: {type: RunnerType.default, fn: rewards},
     sanity: {type: RunnerType.default, fn: sanity},
     shuffling: {type: RunnerType.default, fn: shuffling},
-    ssz_static: {type: RunnerType.custom, fn: sszStatic()},
+    ssz_static: {type: RunnerType.custom, fn: sszStatic(["LightClientHeader"])},
     sync: {type: RunnerType.default, fn: forkChoiceTest({onlyPredefinedResponses: true})},
     transition: {
       type: RunnerType.default,

--- a/packages/beacon-node/test/spec/presets/index.test.ts
+++ b/packages/beacon-node/test/spec/presets/index.test.ts
@@ -62,7 +62,16 @@ specTestIterator(
     rewards: {type: RunnerType.default, fn: rewards},
     sanity: {type: RunnerType.default, fn: sanity},
     shuffling: {type: RunnerType.default, fn: shuffling},
-    ssz_static: {type: RunnerType.custom, fn: sszStatic(["LightClientHeader"])},
+    ssz_static: {
+      type: RunnerType.custom,
+      fn: sszStatic([
+        "LightClientHeader",
+        "LightClientUpdate",
+        "LightClientFinalityUpdate",
+        "LightClientBootstrap",
+        "LightClientOptimisticUpdate",
+      ]),
+    },
     sync: {type: RunnerType.default, fn: forkChoiceTest({onlyPredefinedResponses: true})},
     transition: {
       type: RunnerType.default,

--- a/packages/beacon-node/test/spec/specTestVersioning.ts
+++ b/packages/beacon-node/test/spec/specTestVersioning.ts
@@ -15,7 +15,7 @@ import {IDownloadTestsOptions} from "@lodestar/spec-test-util";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const ethereumConsensusSpecsTests: IDownloadTestsOptions = {
-  specVersion: "v1.3.0-rc.0",
+  specVersion: "v1.3.0-rc.1",
   // Target directory is the host package root: 'packages/*/spec-tests'
   outputDir: path.join(__dirname, "../../spec-tests"),
   specTestsRepoUrl: "https://github.com/ethereum/consensus-spec-tests",

--- a/packages/beacon-node/test/unit/chain/validation/blsToExecutionChange.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/blsToExecutionChange.test.ts
@@ -10,6 +10,7 @@ import {
   DOMAIN_BLS_TO_EXECUTION_CHANGE,
   FAR_FUTURE_EPOCH,
   SLOTS_PER_EPOCH,
+  ForkName,
 } from "@lodestar/params";
 import bls from "@chainsafe/bls";
 import {PointFormat} from "@chainsafe/bls/types";
@@ -78,7 +79,7 @@ describe("validate bls to execution change", () => {
   const _state = generateState(stateEmpty, config);
   const state = createCachedBeaconStateTest(_state, createIBeaconConfig(config, _state.genesisValidatorsRoot));
 
-  const signatureFork = config.getForkName(state.slot);
+  const signatureFork = ForkName.phase0;
 
   // Gen a valid blsToExecutionChange for first val
   const blsToExecutionChange = {

--- a/packages/beacon-node/test/unit/chain/validation/blsToExecutionChange.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/blsToExecutionChange.test.ts
@@ -35,7 +35,7 @@ describe("validate bls to execution change", () => {
 
   const stateEmpty = ssz.phase0.BeaconState.defaultValue();
   // Validator has to be active for long enough
-  stateEmpty.slot = config.SHARD_COMMITTEE_PERIOD * SLOTS_PER_EPOCH;
+  stateEmpty.slot = defaultConfig.SHARD_COMMITTEE_PERIOD * SLOTS_PER_EPOCH;
   // A withdrawal key which we will keep same on the two vals we generate
   const wsk = bls.SecretKey.fromKeygen();
 
@@ -76,11 +76,9 @@ describe("validate bls to execution change", () => {
   stateEmpty.validators[1] = validatorTwo;
 
   // Generate the state
+  const _state = generateState(stateEmpty, defaultConfig);
   const config = createIBeaconConfig(defaultConfig, _state.genesisValidatorsRoot);
-  const _state = generateState(stateEmpty, config);
   const state = createCachedBeaconStateTest(_state, config);
-
-  const signatureFork = ForkName.phase0;
 
   // Gen a valid blsToExecutionChange for first val
   const blsToExecutionChange = {

--- a/packages/cli/src/cmds/validator/blsToExecutionChange.ts
+++ b/packages/cli/src/cmds/validator/blsToExecutionChange.ts
@@ -1,4 +1,4 @@
-import {computeSigningRoot, getCurrentSlot} from "@lodestar/state-transition";
+import {computeSigningRoot} from "@lodestar/state-transition";
 import {DOMAIN_BLS_TO_EXECUTION_CHANGE} from "@lodestar/params";
 import {createIBeaconConfig} from "@lodestar/config";
 import {ssz, capella} from "@lodestar/types";
@@ -59,7 +59,6 @@ like to choose for BLS To Execution Change.",
     // submitting the signed message
     const {config: chainForkConfig} = getBeaconConfigFromArgs(args);
     const client = getClient({urls: args.beaconNodes}, {config: chainForkConfig});
-    const {genesisValidatorsRoot, genesisTime} = (await client.beacon.getGenesis()).data;
     const config = createIBeaconConfig(chainForkConfig, genesisValidatorsRoot);
 
     const {data: stateValidators} = await client.beacon.getStateValidators("head", {id: [publicKey]});
@@ -77,8 +76,7 @@ like to choose for BLS To Execution Change.",
       toExecutionAddress: fromHexString(args.toExecutionAddress),
     };
 
-    const currentSlot = getCurrentSlot(config, genesisTime);
-    const domain = config.getDomain(currentSlot, DOMAIN_BLS_TO_EXECUTION_CHANGE);
+    const domain = config.getDomainAtFork(signatureFork, DOMAIN_BLS_TO_EXECUTION_CHANGE);
     const signingRoot = computeSigningRoot(ssz.capella.BLSToExecutionChange, blsToExecutionChange, domain);
     const signedBLSToExecutionChange = {
       message: blsToExecutionChange,

--- a/packages/cli/src/cmds/validator/blsToExecutionChange.ts
+++ b/packages/cli/src/cmds/validator/blsToExecutionChange.ts
@@ -1,5 +1,5 @@
 import {computeSigningRoot} from "@lodestar/state-transition";
-import {DOMAIN_BLS_TO_EXECUTION_CHANGE} from "@lodestar/params";
+import {DOMAIN_BLS_TO_EXECUTION_CHANGE, ForkName} from "@lodestar/params";
 import {createIBeaconConfig} from "@lodestar/config";
 import {ssz, capella} from "@lodestar/types";
 import {getClient} from "@lodestar/api";
@@ -77,6 +77,7 @@ like to choose for BLS To Execution Change.",
       toExecutionAddress: fromHexString(args.toExecutionAddress),
     };
 
+    const signatureFork = ForkName.phase0;
     const domain = config.getDomainAtFork(signatureFork, DOMAIN_BLS_TO_EXECUTION_CHANGE);
     const signingRoot = computeSigningRoot(ssz.capella.BLSToExecutionChange, blsToExecutionChange, domain);
     const signedBLSToExecutionChange = {

--- a/packages/cli/src/cmds/validator/blsToExecutionChange.ts
+++ b/packages/cli/src/cmds/validator/blsToExecutionChange.ts
@@ -59,6 +59,7 @@ like to choose for BLS To Execution Change.",
     // submitting the signed message
     const {config: chainForkConfig} = getBeaconConfigFromArgs(args);
     const client = getClient({urls: args.beaconNodes}, {config: chainForkConfig});
+    const {genesisValidatorsRoot} = (await client.beacon.getGenesis()).data;
     const config = createIBeaconConfig(chainForkConfig, genesisValidatorsRoot);
 
     const {data: stateValidators} = await client.beacon.getStateValidators("head", {id: [publicKey]});

--- a/packages/config/src/genesisConfig/index.ts
+++ b/packages/config/src/genesisConfig/index.ts
@@ -57,8 +57,9 @@ export function createICachedGenesis(chainForkConfig: IChainForkConfig, genesisV
 
     getDomainAtFork(forkName: ForkName, domainType: DomainType): Uint8Array {
       // For some of the messages, irrespective of which slot they are signed
-      // they need to use a fixed fork name even if other forks are scheduled
+      // they need to use a fixed fork version even if other forks are scheduled
       // at the same fork.
+      //
       // For e.g. BLSToExecutionChange has to be signed using GENESIS_FORK_VERSION
       // corresponding to phase0
       const forkInfo = chainForkConfig.forks[forkName];

--- a/packages/config/src/genesisConfig/types.ts
+++ b/packages/config/src/genesisConfig/types.ts
@@ -17,6 +17,10 @@ export interface ICachedGenesis extends IForkDigestContext {
    * Note: The configured fork schedule is always used rather than on-chain fork schedule.
    */
   getDomain(stateSlot: Slot, domainType: DomainType, messageSlot?: Slot): Uint8Array;
+  /**
+   * Return the signature domain corresponding to a particular fork version
+   */
+  getDomainAtFork(forkName: ForkName, domainType: DomainType): Uint8Array;
 
   readonly genesisValidatorsRoot: Root;
 }

--- a/packages/state-transition/src/signatureSets/blsToExecutionChange.ts
+++ b/packages/state-transition/src/signatureSets/blsToExecutionChange.ts
@@ -1,5 +1,5 @@
-import {DOMAIN_BLS_TO_EXECUTION_CHANGE} from "@lodestar/params";
-import {capella, Slot, ssz} from "@lodestar/types";
+import {DOMAIN_BLS_TO_EXECUTION_CHANGE, ForkName} from "@lodestar/params";
+import {capella, ssz} from "@lodestar/types";
 import {IBeaconConfig} from "@lodestar/config";
 import bls from "@chainsafe/bls";
 import {CoordType} from "@chainsafe/bls/types";
@@ -11,7 +11,7 @@ export function verifyBlsToExecutionChangeSignature(
   state: CachedBeaconStateAllForks,
   signedBLSToExecutionChange: capella.SignedBLSToExecutionChange
 ): boolean {
-  return verifySignatureSet(getBlsToExecutionChangeSignatureSet(state.config, state.slot, signedBLSToExecutionChange));
+  return verifySignatureSet(getBlsToExecutionChangeSignatureSet(state.config, signedBLSToExecutionChange));
 }
 
 /**
@@ -19,10 +19,11 @@ export function verifyBlsToExecutionChangeSignature(
  */
 export function getBlsToExecutionChangeSignatureSet(
   config: IBeaconConfig,
-  signatureSlot: Slot,
   signedBLSToExecutionChange: capella.SignedBLSToExecutionChange
 ): ISignatureSet {
-  const domain = config.getDomain(signatureSlot, DOMAIN_BLS_TO_EXECUTION_CHANGE);
+  // signatureFork for signing domain is fixed
+  const signatureFork = ForkName.phase0;
+  const domain = config.getDomainAtFork(signatureFork, DOMAIN_BLS_TO_EXECUTION_CHANGE);
 
   return {
     type: SignatureSetType.single,
@@ -36,10 +37,9 @@ export function getBlsToExecutionChangeSignatureSet(
 
 export function getBlsToExecutionChangeSignatureSets(
   config: IBeaconConfig,
-  signatureSlot: Slot,
   signedBlock: capella.SignedBeaconBlock
 ): ISignatureSet[] {
   return signedBlock.message.body.blsToExecutionChanges.map((blsToExecutionChange) =>
-    getBlsToExecutionChangeSignatureSet(config, signatureSlot, blsToExecutionChange)
+    getBlsToExecutionChangeSignatureSet(config, blsToExecutionChange)
   );
 }

--- a/packages/state-transition/src/signatureSets/index.ts
+++ b/packages/state-transition/src/signatureSets/index.ts
@@ -62,7 +62,6 @@ export function getBlockSignatureSets(
   if (fork >= ForkSeq.capella) {
     const blsToExecutionChangeSignatureSets = getBlsToExecutionChangeSignatureSets(
       state.config,
-      state.slot,
       signedBlock as capella.SignedBeaconBlock
     );
     if (blsToExecutionChangeSignatureSets.length > 0) {


### PR DESCRIPTION
Use genesis fork version for signing and verifying withdrawals
ref:
- https://github.com/ethereum/consensus-specs/pull/3206