### PR TITLE
Add nodesource for nodejs source installl

### DIFF
--- a/docs/install/source.md
+++ b/docs/install/source.md
@@ -5,6 +5,9 @@ Make sure to have [Yarn installed](https://classic.yarnpkg.com/en/docs/install).
 <!-- prettier-ignore-start -->
 !!! info
     NodeJS versions older than the current LTS are not supported by Lodestar. We recommend running the latest Node LTS.
+
+!!! note
+    Node Version Manager (NVM) will only install NodeJS for use with the active user. If you intend on setting up Lodestar to run under another user, we recommend using [Nodesource's source for NodeJS](https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions) so you can install NodeJS globally.
 <!-- prettier-ignore-end -->
 
 Clone the repo locally.


### PR DESCRIPTION
**Motivation**

Users trying to build Lodestar from source may run into issues using NVM if they're looking to run Lodestar as another user.

**Description**

This PR will add to documentation that we recommend Nodesource's NodeJS installation if a user intends to install Lodestar from source for a user other than the active profile.

<img width="798" alt="Screenshot 2023-01-13 at 4 26 15 PM" src="https://user-images.githubusercontent.com/58080811/212437256-336ec833-51c8-45e0-99f6-9d6f05a0693c.png">

