### PR TITLE
Clean up getStateValidator endpoints sim test

### DIFF
--- a/packages/cli/test/sim/endpoints.test.ts
+++ b/packages/cli/test/sim/endpoints.test.ts
@@ -92,12 +92,11 @@ await env.tracker.assert(
 await env.tracker.assert(
   "should return the validator when getStateValidator is called with the validator index",
   async () => {
-    const validatorIndex = "0";
+    const validatorIndex = 0;
 
     const response = await node.api.beacon.getStateValidator("head", validatorIndex);
 
-    // TODO: the index in data should be a string instead of an integer
-    expect(response.data.index).to.be.equal(parseInt(validatorIndex));
+    expect(response.data.index).to.be.equal(validatorIndex);
   }
 );
 


### PR DESCRIPTION
**Motivation**

Validator index can be provided as a `number` as it seems to be converted to a `string` before `getStateValidator` is called.
I added the TODO in [this commit](https://github.com/ChainSafe/lodestar/pull/4734/commits/210c2ec5e5781d80a2cd7b22fc4e3fbc2aeb967d#diff-3e3b0cf286453eacaa2f830afecc022079066589e9384557e66289efabb7328cR147) but I think it is misleading/incorrect and therefore should be removed.

**Description**

- pass validator index as a `number`
- removed type conversion (`parseInt`) in assertion
- remove TODO

