### PR TITLE
Add and use LightClientHeader for lightclient updates

### DIFF
--- a/packages/api/src/beacon/routes/events.ts
+++ b/packages/api/src/beacon/routes/events.ts
@@ -175,15 +175,15 @@ export function getTypeByEvent(): {[K in EventType]: Type<EventData[K]>} {
     [EventType.lightClientOptimisticUpdate]: new ContainerType(
       {
         syncAggregate: ssz.altair.SyncAggregate,
-        attestedHeader: ssz.phase0.BeaconBlockHeader,
+        attestedHeader: ssz.altair.LightClientHeader,
         signatureSlot: ssz.Slot,
       },
       {jsonCase: "eth2"}
     ),
     [EventType.lightClientFinalityUpdate]: new ContainerType(
       {
-        attestedHeader: ssz.phase0.BeaconBlockHeader,
-        finalizedHeader: ssz.phase0.BeaconBlockHeader,
+        attestedHeader: ssz.altair.LightClientHeader,
+        finalizedHeader: ssz.altair.LightClientHeader,
         finalityBranch: new VectorCompositeType(ssz.Bytes32, FINALIZED_ROOT_DEPTH),
         syncAggregate: ssz.altair.SyncAggregate,
         signatureSlot: ssz.Slot,

--- a/packages/api/src/beacon/routes/lightclient.ts
+++ b/packages/api/src/beacon/routes/lightclient.ts
@@ -1,4 +1,4 @@
-import {altair, phase0, ssz, StringType, SyncPeriod} from "@lodestar/types";
+import {altair, ssz, StringType, SyncPeriod} from "@lodestar/types";
 import {ForkName} from "@lodestar/params";
 import {ContainerType} from "@chainsafe/ssz";
 import {
@@ -16,7 +16,7 @@ import {
 // See /packages/api/src/routes/index.ts for reasoning and instructions to add new routes
 
 export type LightClientBootstrap = {
-  header: phase0.BeaconBlockHeader;
+  header: altair.LightClientHeader;
   currentSyncCommittee: altair.SyncCommittee;
   /** Single branch proof from state root to currentSyncCommittee */
   currentSyncCommitteeBranch: Uint8Array[];

--- a/packages/api/test/unit/beacon/testData/events.ts
+++ b/packages/api/test/unit/beacon/testData/events.ts
@@ -93,12 +93,12 @@ export const eventTestData: EventData = {
   }),
   [EventType.lightClientOptimisticUpdate]: {
     syncAggregate: ssz.altair.SyncAggregate.defaultValue(),
-    attestedHeader: ssz.phase0.BeaconBlockHeader.defaultValue(),
+    attestedHeader: ssz.altair.LightClientHeader.defaultValue(),
     signatureSlot: ssz.Slot.defaultValue(),
   },
   [EventType.lightClientFinalityUpdate]: {
-    attestedHeader: ssz.phase0.BeaconBlockHeader.defaultValue(),
-    finalizedHeader: ssz.phase0.BeaconBlockHeader.defaultValue(),
+    attestedHeader: ssz.altair.LightClientHeader.defaultValue(),
+    finalizedHeader: ssz.altair.LightClientHeader.defaultValue(),
     finalityBranch: [root],
     syncAggregate: ssz.altair.SyncAggregate.defaultValue(),
     signatureSlot: ssz.Slot.defaultValue(),

--- a/packages/api/test/unit/beacon/testData/lightclient.ts
+++ b/packages/api/test/unit/beacon/testData/lightclient.ts
@@ -8,7 +8,7 @@ const root = Uint8Array.from(Buffer.alloc(32, 1));
 
 const lightClientUpdate = ssz.altair.LightClientUpdate.defaultValue();
 const syncAggregate = ssz.altair.SyncAggregate.defaultValue();
-const header = ssz.phase0.BeaconBlockHeader.defaultValue();
+const header = ssz.altair.LightClientHeader.defaultValue();
 const signatureSlot = ssz.Slot.defaultValue();
 
 export const testData: GenericServerTestCases<Api> = {
@@ -29,7 +29,7 @@ export const testData: GenericServerTestCases<Api> = {
         attestedHeader: header,
         finalizedHeader: lightClientUpdate.finalizedHeader,
         finalityBranch: lightClientUpdate.finalityBranch,
-        signatureSlot: lightClientUpdate.attestedHeader.slot + 1,
+        signatureSlot: lightClientUpdate.attestedHeader.beacon.slot + 1,
       },
     },
   },

--- a/packages/beacon-node/src/api/impl/lightclient/index.ts
+++ b/packages/beacon-node/src/api/impl/lightclient/index.ts
@@ -13,7 +13,7 @@ export function getLightclientApi({chain, config}: Pick<ApiModules, "chain" | "c
       const periods = Array.from({length: maxAllowedCount}, (_ignored, i) => i + startPeriod);
       const updates = await Promise.all(periods.map((period) => chain.lightClientServer.getUpdate(period)));
       return updates.map((update) => ({
-        version: config.getForkName(update.attestedHeader.slot),
+        version: config.getForkName(update.attestedHeader.beacon.slot),
         data: update,
       }));
     },
@@ -23,7 +23,7 @@ export function getLightclientApi({chain, config}: Pick<ApiModules, "chain" | "c
       if (data === null) {
         throw Error("No optimistic update available");
       }
-      return {version: config.getForkName(data.attestedHeader.slot), data};
+      return {version: config.getForkName(data.attestedHeader.beacon.slot), data};
     },
 
     async getFinalityUpdate() {
@@ -31,12 +31,12 @@ export function getLightclientApi({chain, config}: Pick<ApiModules, "chain" | "c
       if (data === null) {
         throw Error("No finality update available");
       }
-      return {version: config.getForkName(data.attestedHeader.slot), data};
+      return {version: config.getForkName(data.attestedHeader.beacon.slot), data};
     },
 
     async getBootstrap(blockRoot) {
       const bootstrapProof = await chain.lightClientServer.getBootstrap(fromHexString(blockRoot));
-      return {version: config.getForkName(bootstrapProof.header.slot), data: bootstrapProof};
+      return {version: config.getForkName(bootstrapProof.header.beacon.slot), data: bootstrapProof};
     },
 
     async getCommitteeRoot(startPeriod: SyncPeriod, count: number) {

--- a/packages/beacon-node/src/chain/validation/lightClientFinalityUpdate.ts
+++ b/packages/beacon-node/src/chain/validation/lightClientFinalityUpdate.ts
@@ -12,10 +12,10 @@ export function validateLightClientFinalityUpdate(
   gossipedFinalityUpdate: altair.LightClientFinalityUpdate
 ): void {
   // [IGNORE] No other finality_update with a lower or equal finalized_header.slot was already forwarded on the network
-  const gossipedFinalitySlot = gossipedFinalityUpdate.finalizedHeader.slot;
+  const gossipedFinalitySlot = gossipedFinalityUpdate.finalizedHeader.beacon.slot;
   const localFinalityUpdate = chain.lightClientServer.getFinalityUpdate();
 
-  if (localFinalityUpdate && gossipedFinalitySlot <= localFinalityUpdate.finalizedHeader.slot) {
+  if (localFinalityUpdate && gossipedFinalitySlot <= localFinalityUpdate.finalizedHeader.beacon.slot) {
     throw new LightClientError(GossipAction.IGNORE, {
       code: LightClientErrorCode.FINALITY_UPDATE_ALREADY_FORWARDED,
     });

--- a/packages/beacon-node/src/chain/validation/lightClientOptimisticUpdate.ts
+++ b/packages/beacon-node/src/chain/validation/lightClientOptimisticUpdate.ts
@@ -13,10 +13,10 @@ export function validateLightClientOptimisticUpdate(
   gossipedOptimisticUpdate: altair.LightClientOptimisticUpdate
 ): void {
   // [IGNORE] No other optimistic_update with a lower or equal attested_header.slot was already forwarded on the network
-  const gossipedAttestedSlot = gossipedOptimisticUpdate.attestedHeader.slot;
+  const gossipedAttestedSlot = gossipedOptimisticUpdate.attestedHeader.beacon.slot;
   const localOptimisticUpdate = chain.lightClientServer.getOptimisticUpdate();
 
-  if (localOptimisticUpdate && gossipedAttestedSlot <= localOptimisticUpdate.attestedHeader.slot) {
+  if (localOptimisticUpdate && gossipedAttestedSlot <= localOptimisticUpdate.attestedHeader.beacon.slot) {
     throw new LightClientError(GossipAction.IGNORE, {
       code: LightClientErrorCode.OPTIMISTIC_UPDATE_ALREADY_FORWARDED,
     });

--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -78,7 +78,7 @@ describe("lightclient api", function () {
     const slot = bn.chain.clock.currentSlot;
     expect(updates.length).to.be.equal(1);
     // at slot 2 we got attestedHeader for slot 1
-    expect(updates[0].data.attestedHeader.slot).to.be.equal(slot - 1);
+    expect(updates[0].data.attestedHeader.beacon.slot).to.be.equal(slot - 1);
     // version is set
     expect(updates[0].version).to.be.equal(ForkName.altair);
   });
@@ -89,7 +89,7 @@ describe("lightclient api", function () {
     const update = await client.getOptimisticUpdate();
     const slot = bn.chain.clock.currentSlot;
     // at slot 2 we got attestedHeader for slot 1
-    expect(update.data.attestedHeader.slot).to.be.equal(slot - 1);
+    expect(update.data.attestedHeader.beacon.slot).to.be.equal(slot - 1);
     // version is set
     expect(update.version).to.be.equal(ForkName.altair);
   });

--- a/packages/beacon-node/test/e2e/chain/lightclient.test.ts
+++ b/packages/beacon-node/test/e2e/chain/lightclient.test.ts
@@ -132,7 +132,7 @@ describe("chain / lightclient", function () {
         lightclient.stop();
       });
 
-      loggerLC.info("Initialized lightclient", {headSlot: lightclient.getHead().slot});
+      loggerLC.info("Initialized lightclient", {headSlot: lightclient.getHead().beacon.slot});
       lightclient.start();
 
       return new Promise<void>((resolve, reject) => {
@@ -153,7 +153,7 @@ describe("chain / lightclient", function () {
             );
 
             // Stop test if reached target head slot
-            const lcHeadSlot = lightclient.getHead().slot;
+            const lcHeadSlot = lightclient.getHead().beacon.slot;
             if (head.slot - lcHeadSlot > maxLcHeadTrackingDiffSlots) {
               throw Error(`Lightclient head ${lcHeadSlot} is too far behind the beacon node ${head.slot}`);
             } else if (head.slot > targetSlotToReach) {

--- a/packages/beacon-node/test/spec/presets/index.test.ts
+++ b/packages/beacon-node/test/spec/presets/index.test.ts
@@ -64,16 +64,7 @@ specTestIterator(
     shuffling: {type: RunnerType.default, fn: shuffling},
     ssz_static: {
       type: RunnerType.custom,
-      fn: sszStatic([
-        // The LightClient types are disabled momentarily as there is LightClientHeader introduced
-        // in this spec release and is being addressed in separate PR which will fix and
-        // reenable all these types
-        "LightClientHeader",
-        "LightClientUpdate",
-        "LightClientFinalityUpdate",
-        "LightClientBootstrap",
-        "LightClientOptimisticUpdate",
-      ]),
+      fn: sszStatic(),
     },
     sync: {type: RunnerType.default, fn: forkChoiceTest({onlyPredefinedResponses: true})},
     transition: {

--- a/packages/beacon-node/test/spec/presets/light_client/sync.ts
+++ b/packages/beacon-node/test/spec/presets/light_client/sync.ts
@@ -107,8 +107,12 @@ export const sync: TestRunnerFn<SyncTestCase, void> = () => {
       }
 
       function runChecks(update: {checks: Checks}): void {
-        assertHeader(lightClient.store.finalizedHeader, update.checks.finalized_header, "wrong finalizedHeader");
-        assertHeader(lightClient.store.optimisticHeader, update.checks.optimistic_header, "wrong optimisticHeader");
+        assertHeader(lightClient.store.finalizedHeader.beacon, update.checks.finalized_header, "wrong finalizedHeader");
+        assertHeader(
+          lightClient.store.optimisticHeader.beacon,
+          update.checks.optimistic_header,
+          "wrong optimisticHeader"
+        );
       }
 
       function renderSlot(currentSlot: Slot): {currentSlot: number; curretPeriod: number} {
@@ -145,8 +149,8 @@ export const sync: TestRunnerFn<SyncTestCase, void> = () => {
           }
 
           logger.debug(
-            `finalizedHeader = ${JSON.stringify(toHeaderSummary(lightClient.store.finalizedHeader))}` +
-              ` optimisticHeader = ${JSON.stringify(toHeaderSummary(lightClient.store.optimisticHeader))}`
+            `finalizedHeader = ${JSON.stringify(toHeaderSummary(lightClient.store.finalizedHeader.beacon))}` +
+              ` optimisticHeader = ${JSON.stringify(toHeaderSummary(lightClient.store.optimisticHeader.beacon))}`
           );
         } catch (e) {
           (e as Error).message = `Error on step ${i}/${stepsLen}: ${(e as Error).message}`;

--- a/packages/beacon-node/test/unit/chain/validation/lightClientFinalityUpdate.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/lightClientFinalityUpdate.test.ts
@@ -58,7 +58,7 @@ describe("Light Client Finality Update validation", function () {
     chain.lightClientServer.getFinalityUpdate = () => {
       const defaultValue = ssz.altair.LightClientFinalityUpdate.defaultValue();
       // make the local slot higher than gossiped
-      defaultValue.finalizedHeader.slot = lightclientFinalityUpdate.finalizedHeader.slot + 1;
+      defaultValue.finalizedHeader.slot = lightclientFinalityUpdate.finalizedHeader.beacon.slot + 1;
       return defaultValue;
     };
 
@@ -94,7 +94,7 @@ describe("Light Client Finality Update validation", function () {
   it("should return invalid - finality update not matching local", async () => {
     const lightClientFinalityUpdate: altair.LightClientFinalityUpdate = ssz.altair.LightClientFinalityUpdate.defaultValue();
     lightClientFinalityUpdate.finalizedHeader.slot = 2;
-    lightClientFinalityUpdate.signatureSlot = lightClientFinalityUpdate.finalizedHeader.slot + 1;
+    lightClientFinalityUpdate.signatureSlot = lightClientFinalityUpdate.finalizedHeader.beacon.slot + 1;
 
     const chain = mockChain();
 
@@ -121,7 +121,7 @@ describe("Light Client Finality Update validation", function () {
   it("should return invalid - not matching local when no local finality update yet", async () => {
     const lightClientFinalityUpdate: altair.LightClientFinalityUpdate = ssz.altair.LightClientFinalityUpdate.defaultValue();
     lightClientFinalityUpdate.finalizedHeader.slot = 2;
-    lightClientFinalityUpdate.signatureSlot = lightClientFinalityUpdate.finalizedHeader.slot + 1;
+    lightClientFinalityUpdate.signatureSlot = lightClientFinalityUpdate.finalizedHeader.beacon.slot + 1;
 
     const chain = mockChain();
 

--- a/packages/beacon-node/test/unit/chain/validation/lightClientFinalityUpdate.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/lightClientFinalityUpdate.test.ts
@@ -52,13 +52,13 @@ describe("Light Client Finality Update validation", function () {
 
   it("should return invalid - finality update already forwarded", async () => {
     const lightclientFinalityUpdate: altair.LightClientFinalityUpdate = ssz.altair.LightClientFinalityUpdate.defaultValue();
-    lightclientFinalityUpdate.finalizedHeader.slot = 2;
+    lightclientFinalityUpdate.finalizedHeader.beacon.slot = 2;
 
     const chain = mockChain();
     chain.lightClientServer.getFinalityUpdate = () => {
       const defaultValue = ssz.altair.LightClientFinalityUpdate.defaultValue();
       // make the local slot higher than gossiped
-      defaultValue.finalizedHeader.slot = lightclientFinalityUpdate.finalizedHeader.beacon.slot + 1;
+      defaultValue.finalizedHeader.beacon.slot = lightclientFinalityUpdate.finalizedHeader.beacon.slot + 1;
       return defaultValue;
     };
 
@@ -71,15 +71,15 @@ describe("Light Client Finality Update validation", function () {
   });
 
   it("should return invalid - finality update received too early", async () => {
-    //No other optimistic_update with a lower or equal attested_header.slot was already forwarded on the network
+    //No other optimistic_update with a lower or equal attested_header.beacon.slot was already forwarded on the network
     const lightClientFinalityUpdate: altair.LightClientFinalityUpdate = ssz.altair.LightClientFinalityUpdate.defaultValue();
-    lightClientFinalityUpdate.finalizedHeader.slot = 2;
+    lightClientFinalityUpdate.finalizedHeader.beacon.slot = 2;
     lightClientFinalityUpdate.signatureSlot = 4;
 
     const chain = mockChain();
     chain.lightClientServer.getFinalityUpdate = () => {
       const defaultValue = ssz.altair.LightClientFinalityUpdate.defaultValue();
-      defaultValue.finalizedHeader.slot = 1;
+      defaultValue.finalizedHeader.beacon.slot = 1;
       return defaultValue;
     };
 
@@ -93,7 +93,7 @@ describe("Light Client Finality Update validation", function () {
 
   it("should return invalid - finality update not matching local", async () => {
     const lightClientFinalityUpdate: altair.LightClientFinalityUpdate = ssz.altair.LightClientFinalityUpdate.defaultValue();
-    lightClientFinalityUpdate.finalizedHeader.slot = 2;
+    lightClientFinalityUpdate.finalizedHeader.beacon.slot = 2;
     lightClientFinalityUpdate.signatureSlot = lightClientFinalityUpdate.finalizedHeader.beacon.slot + 1;
 
     const chain = mockChain();
@@ -101,7 +101,7 @@ describe("Light Client Finality Update validation", function () {
     // make lightclientserver return another update with different value from gossiped
     chain.lightClientServer.getFinalityUpdate = () => {
       const defaultValue = ssz.altair.LightClientFinalityUpdate.defaultValue();
-      defaultValue.finalizedHeader.slot = 1;
+      defaultValue.finalizedHeader.beacon.slot = 1;
       return defaultValue;
     };
 
@@ -120,7 +120,7 @@ describe("Light Client Finality Update validation", function () {
 
   it("should return invalid - not matching local when no local finality update yet", async () => {
     const lightClientFinalityUpdate: altair.LightClientFinalityUpdate = ssz.altair.LightClientFinalityUpdate.defaultValue();
-    lightClientFinalityUpdate.finalizedHeader.slot = 2;
+    lightClientFinalityUpdate.finalizedHeader.beacon.slot = 2;
     lightClientFinalityUpdate.signatureSlot = lightClientFinalityUpdate.finalizedHeader.beacon.slot + 1;
 
     const chain = mockChain();
@@ -147,12 +147,12 @@ describe("Light Client Finality Update validation", function () {
     const chain = mockChain();
 
     // satisfy:
-    // No other finality_update with a lower or equal finalized_header.slot was already forwarded on the network
-    lightClientFinalityUpdate.finalizedHeader.slot = 2;
+    // No other finality_update with a lower or equal finalized_header.beacon.slot was already forwarded on the network
+    lightClientFinalityUpdate.finalizedHeader.beacon.slot = 2;
 
     chain.lightClientServer.getFinalityUpdate = () => {
       const defaultValue = ssz.altair.LightClientFinalityUpdate.defaultValue();
-      defaultValue.finalizedHeader.slot = 1;
+      defaultValue.finalizedHeader.beacon.slot = 1;
       return defaultValue;
     };
 

--- a/packages/beacon-node/test/unit/chain/validation/lightClientOptimisticUpdate.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/lightClientOptimisticUpdate.test.ts
@@ -59,7 +59,7 @@ describe("Light Client Optimistic Update validation", function () {
     chain.lightClientServer.getOptimisticUpdate = () => {
       const defaultValue = ssz.altair.LightClientOptimisticUpdate.defaultValue();
       // make the local slot higher than gossiped
-      defaultValue.attestedHeader.slot = lightclientOptimisticUpdate.attestedHeader.slot + 1;
+      defaultValue.attestedHeader.slot = lightclientOptimisticUpdate.attestedHeader.beacon.slot + 1;
       return defaultValue;
     };
 

--- a/packages/beacon-node/test/unit/chain/validation/lightClientOptimisticUpdate.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/lightClientOptimisticUpdate.test.ts
@@ -53,13 +53,13 @@ describe("Light Client Optimistic Update validation", function () {
   it("should return invalid - optimistic update already forwarded", async () => {
     const lightclientOptimisticUpdate: altair.LightClientOptimisticUpdate = ssz.altair.LightClientOptimisticUpdate.defaultValue();
 
-    lightclientOptimisticUpdate.attestedHeader.slot = 2;
+    lightclientOptimisticUpdate.attestedHeader.beacon.slot = 2;
 
     const chain = mockChain();
     chain.lightClientServer.getOptimisticUpdate = () => {
       const defaultValue = ssz.altair.LightClientOptimisticUpdate.defaultValue();
       // make the local slot higher than gossiped
-      defaultValue.attestedHeader.slot = lightclientOptimisticUpdate.attestedHeader.beacon.slot + 1;
+      defaultValue.attestedHeader.beacon.slot = lightclientOptimisticUpdate.attestedHeader.beacon.slot + 1;
       return defaultValue;
     };
 
@@ -73,13 +73,13 @@ describe("Light Client Optimistic Update validation", function () {
 
   it("should return invalid - optimistic update received too early", async () => {
     const lightclientOptimisticUpdate: altair.LightClientOptimisticUpdate = ssz.altair.LightClientOptimisticUpdate.defaultValue();
-    lightclientOptimisticUpdate.attestedHeader.slot = 2;
+    lightclientOptimisticUpdate.attestedHeader.beacon.slot = 2;
     lightclientOptimisticUpdate.signatureSlot = 4;
 
     const chain = mockChain();
     chain.lightClientServer.getOptimisticUpdate = () => {
       const defaultValue = ssz.altair.LightClientOptimisticUpdate.defaultValue();
-      defaultValue.attestedHeader.slot = 1;
+      defaultValue.attestedHeader.beacon.slot = 1;
       return defaultValue;
     };
 
@@ -93,7 +93,7 @@ describe("Light Client Optimistic Update validation", function () {
 
   it("should return invalid - optimistic update not matching local", async () => {
     const lightclientOptimisticUpdate: altair.LightClientOptimisticUpdate = ssz.altair.LightClientOptimisticUpdate.defaultValue();
-    lightclientOptimisticUpdate.attestedHeader.slot = 2;
+    lightclientOptimisticUpdate.attestedHeader.beacon.slot = 2;
 
     const chain = mockChain();
 
@@ -104,7 +104,7 @@ describe("Light Client Optimistic Update validation", function () {
     // make lightclientserver return another update with different value from gossiped
     chain.lightClientServer.getOptimisticUpdate = () => {
       const defaultValue = ssz.altair.LightClientOptimisticUpdate.defaultValue();
-      defaultValue.attestedHeader.slot = 1;
+      defaultValue.attestedHeader.beacon.slot = 1;
       return defaultValue;
     };
 
@@ -118,7 +118,7 @@ describe("Light Client Optimistic Update validation", function () {
 
   it("should return invalid - not matching local when no local optimistic update yet", async () => {
     const lightclientOptimisticUpdate: altair.LightClientOptimisticUpdate = ssz.altair.LightClientOptimisticUpdate.defaultValue();
-    lightclientOptimisticUpdate.attestedHeader.slot = 2;
+    lightclientOptimisticUpdate.attestedHeader.beacon.slot = 2;
 
     const chain = mockChain();
 
@@ -142,12 +142,12 @@ describe("Light Client Optimistic Update validation", function () {
     const chain = mockChain();
 
     // satisfy:
-    // No other optimistic_update with a lower or equal attested_header.slot was already forwarded on the network
-    lightclientOptimisticUpdate.attestedHeader.slot = 2;
+    // No other optimistic_update with a lower or equal attested_header.beacon.slot was already forwarded on the network
+    lightclientOptimisticUpdate.attestedHeader.beacon.slot = 2;
 
     chain.lightClientServer.getOptimisticUpdate = () => {
       const defaultValue = ssz.altair.LightClientOptimisticUpdate.defaultValue();
-      defaultValue.attestedHeader.slot = 1;
+      defaultValue.attestedHeader.beacon.slot = 1;
       return defaultValue;
     };
 

--- a/packages/light-client/src/events.ts
+++ b/packages/light-client/src/events.ts
@@ -1,4 +1,4 @@
-import {phase0} from "@lodestar/types";
+import {altair} from "@lodestar/types";
 
 export enum LightclientEvent {
   lightClientOptimisticUpdate = "light_client_optimistic_update",
@@ -6,8 +6,8 @@ export enum LightclientEvent {
 }
 
 export type LightclientEmitterEvents = {
-  [LightclientEvent.lightClientOptimisticUpdate]: (newHeader: phase0.BeaconBlockHeader) => void;
-  [LightclientEvent.lightClientFinalityUpdate]: (newHeader: phase0.BeaconBlockHeader) => void;
+  [LightclientEvent.lightClientOptimisticUpdate]: (newHeader: altair.LightClientHeader) => void;
+  [LightclientEvent.lightClientFinalityUpdate]: (newHeader: altair.LightClientHeader) => void;
 };
 
 export type LightclientEmitter = MittEmitter<LightclientEmitterEvents>;

--- a/packages/light-client/src/index.ts
+++ b/packages/light-client/src/index.ts
@@ -122,11 +122,11 @@ export class Lightclient {
         allowForcedUpdates: ALLOW_FORCED_UPDATES,
         onSetFinalizedHeader: (header) => {
           this.emitter.emit(LightclientEvent.lightClientFinalityUpdate, header);
-          this.logger.debug("Updated state.finalizedHeader", {slot: header.slot});
+          this.logger.debug("Updated state.finalizedHeader", {slot: header.beacon.slot});
         },
         onSetOptimisticHeader: (header) => {
           this.emitter.emit(LightclientEvent.lightClientOptimisticUpdate, header);
-          this.logger.debug("Updated state.optimisticHeader", {slot: header.slot});
+          this.logger.debug("Updated state.optimisticHeader", {slot: header.beacon.slot});
         },
       },
       bootstrap
@@ -172,7 +172,7 @@ export class Lightclient {
     this.status = {code: RunStatusCode.stopped};
   }
 
-  getHead(): phase0.BeaconBlockHeader {
+  getHead(): altair.LightClientHeader {
     return this.lightclientSpec.store.optimisticHeader;
   }
 
@@ -190,7 +190,7 @@ export class Lightclient {
       const updates = await this.transport.getUpdates(fromPeriodRng, count);
       for (const update of updates) {
         this.processSyncCommitteeUpdate(update.data);
-        this.logger.debug("processed sync update", {slot: update.data.attestedHeader.slot});
+        this.logger.debug("processed sync update", {slot: update.data.attestedHeader.beacon.slot});
 
         // Yield to the macro queue, verifying updates is somewhat expensive and we want responsiveness
         await new Promise((r) => setTimeout(r, 0));
@@ -217,7 +217,7 @@ export class Lightclient {
 
         // Go into sync mode
         this.status = {code: RunStatusCode.syncing};
-        const headPeriod = computeSyncPeriodAtSlot(this.getHead().slot);
+        const headPeriod = computeSyncPeriodAtSlot(this.getHead().beacon.slot);
         this.logger.debug("Syncing", {lastPeriod: headPeriod, currentPeriod});
 
         try {

--- a/packages/light-client/src/spec/index.ts
+++ b/packages/light-client/src/spec/index.ts
@@ -40,7 +40,7 @@ export class LightclientSpec {
       attestedHeader: optimisticUpdate.attestedHeader,
       nextSyncCommittee: ZERO_SYNC_COMMITTEE,
       nextSyncCommitteeBranch: ZERO_NEXT_SYNC_COMMITTEE_BRANCH,
-      finalizedHeader: ZERO_HEADER,
+      finalizedHeader: {beacon: ZERO_HEADER},
       finalityBranch: ZERO_FINALITY_BRANCH,
       syncAggregate: optimisticUpdate.syncAggregate,
       signatureSlot: optimisticUpdate.signatureSlot,
@@ -49,7 +49,7 @@ export class LightclientSpec {
 
   forceUpdate(currentSlot: Slot): void {
     for (const bestValidUpdate of this.store.bestValidUpdates.values()) {
-      if (currentSlot > bestValidUpdate.update.finalizedHeader.slot + UPDATE_TIMEOUT) {
+      if (currentSlot > bestValidUpdate.update.finalizedHeader.beacon.slot + UPDATE_TIMEOUT) {
         const updatePeriod = computeSyncPeriodAtSlot(bestValidUpdate.update.signatureSlot);
         // Simulate process_light_client_store_force_update() by forcing to apply a bestValidUpdate
         // https://github.com/ethereum/consensus-specs/blob/a57e15636013eeba3610ff3ade41781dba1bb0cd/specs/altair/light-client/sync-protocol.md?plain=1#L394

--- a/packages/light-client/src/spec/isBetterUpdate.ts
+++ b/packages/light-client/src/spec/isBetterUpdate.ts
@@ -85,9 +85,9 @@ export function isSafeLightClientUpdate(update: LightClientUpdateSummary): boole
 export function toLightClientUpdateSummary(update: altair.LightClientUpdate): LightClientUpdateSummary {
   return {
     activeParticipants: sumBits(update.syncAggregate.syncCommitteeBits),
-    attestedHeaderSlot: update.attestedHeader.slot,
+    attestedHeaderSlot: update.attestedHeader.beacon.slot,
     signatureSlot: update.signatureSlot,
-    finalizedHeaderSlot: update.finalizedHeader.slot,
+    finalizedHeaderSlot: update.finalizedHeader.beacon.slot,
     isSyncCommitteeUpdate: isSyncCommitteeUpdate(update),
     isFinalityUpdate: isFinalityUpdate(update),
   };

--- a/packages/light-client/src/spec/processLightClientUpdate.ts
+++ b/packages/light-client/src/spec/processLightClientUpdate.ts
@@ -36,7 +36,7 @@ export function processLightClientUpdate(
   // Update the optimistic header
   if (
     syncCommitteeTrueBits > getSafetyThreshold(store.getMaxActiveParticipants(updateSignaturePeriod)) &&
-    update.attestedHeader.slot > store.optimisticHeader.slot
+    update.attestedHeader.beacon.slot > store.optimisticHeader.beacon.slot
   ) {
     store.optimisticHeader = update.attestedHeader;
   }
@@ -44,10 +44,10 @@ export function processLightClientUpdate(
   // Update finalized header
   if (
     syncCommitteeTrueBits * 3 >= SYNC_COMMITTEE_SIZE * 2 &&
-    update.finalizedHeader.slot > store.finalizedHeader.slot
+    update.finalizedHeader.beacon.slot > store.finalizedHeader.beacon.slot
   ) {
     store.finalizedHeader = update.finalizedHeader;
-    if (store.finalizedHeader.slot > store.optimisticHeader.slot) {
+    if (store.finalizedHeader.beacon.slot > store.optimisticHeader.beacon.slot) {
       store.optimisticHeader = store.finalizedHeader;
     }
   }
@@ -86,15 +86,15 @@ export function getSyncCommitteeAtPeriod(
 
       if (opts.updateHeadersOnForcedUpdate) {
         // From https://github.com/ethereum/consensus-specs/blob/a57e15636013eeba3610ff3ade41781dba1bb0cd/specs/altair/light-client/sync-protocol.md?plain=1#L403
-        if (update.finalizedHeader.slot <= store.finalizedHeader.slot) {
+        if (update.finalizedHeader.beacon.slot <= store.finalizedHeader.beacon.slot) {
           update.finalizedHeader = update.attestedHeader;
         }
 
         // From https://github.com/ethereum/consensus-specs/blob/a57e15636013eeba3610ff3ade41781dba1bb0cd/specs/altair/light-client/sync-protocol.md?plain=1#L374
-        if (update.finalizedHeader.slot > store.finalizedHeader.slot) {
+        if (update.finalizedHeader.beacon.slot > store.finalizedHeader.beacon.slot) {
           store.finalizedHeader = update.finalizedHeader;
         }
-        if (store.finalizedHeader.slot > store.optimisticHeader.slot) {
+        if (store.finalizedHeader.beacon.slot > store.optimisticHeader.beacon.slot) {
           store.optimisticHeader = store.finalizedHeader;
         }
       }

--- a/packages/light-client/src/spec/store.ts
+++ b/packages/light-client/src/spec/store.ts
@@ -1,6 +1,6 @@
 import type {PublicKey} from "@chainsafe/bls/types";
 import {IBeaconConfig} from "@lodestar/config";
-import {altair, phase0, SyncPeriod} from "@lodestar/types";
+import {altair, SyncPeriod} from "@lodestar/types";
 import {computeSyncPeriodAtSlot, deserializeSyncCommittee} from "../utils/index.js";
 import {LightClientUpdateSummary} from "./isBetterUpdate.js";
 
@@ -18,23 +18,23 @@ export interface ILightClientStore {
   setActiveParticipants(period: SyncPeriod, activeParticipants: number): void;
 
   // Header that is finalized
-  finalizedHeader: phase0.BeaconBlockHeader;
+  finalizedHeader: altair.LightClientHeader;
 
   // Most recent available reasonably-safe header
-  optimisticHeader: phase0.BeaconBlockHeader;
+  optimisticHeader: altair.LightClientHeader;
 }
 
 export interface LightClientStoreEvents {
-  onSetFinalizedHeader?: (header: phase0.BeaconBlockHeader) => void;
-  onSetOptimisticHeader?: (header: phase0.BeaconBlockHeader) => void;
+  onSetFinalizedHeader?: (header: altair.LightClientHeader) => void;
+  onSetOptimisticHeader?: (header: altair.LightClientHeader) => void;
 }
 
 export class LightClientStore implements ILightClientStore {
   readonly syncCommittees = new Map<SyncPeriod, SyncCommitteeFast>();
   readonly bestValidUpdates = new Map<SyncPeriod, LightClientUpdateWithSummary>();
 
-  private _finalizedHeader: phase0.BeaconBlockHeader;
-  private _optimisticHeader: phase0.BeaconBlockHeader;
+  private _finalizedHeader: altair.LightClientHeader;
+  private _optimisticHeader: altair.LightClientHeader;
 
   private readonly maxActiveParticipants = new Map<SyncPeriod, number>();
 
@@ -43,26 +43,26 @@ export class LightClientStore implements ILightClientStore {
     bootstrap: altair.LightClientBootstrap,
     private readonly events: LightClientStoreEvents
   ) {
-    const bootstrapPeriod = computeSyncPeriodAtSlot(bootstrap.header.slot);
+    const bootstrapPeriod = computeSyncPeriodAtSlot(bootstrap.header.beacon.slot);
     this.syncCommittees.set(bootstrapPeriod, deserializeSyncCommittee(bootstrap.currentSyncCommittee));
     this._finalizedHeader = bootstrap.header;
     this._optimisticHeader = bootstrap.header;
   }
 
-  get finalizedHeader(): phase0.BeaconBlockHeader {
+  get finalizedHeader(): altair.LightClientHeader {
     return this._finalizedHeader;
   }
 
-  set finalizedHeader(value: phase0.BeaconBlockHeader) {
+  set finalizedHeader(value: altair.LightClientHeader) {
     this._finalizedHeader = value;
     this.events.onSetFinalizedHeader?.(value);
   }
 
-  get optimisticHeader(): phase0.BeaconBlockHeader {
+  get optimisticHeader(): altair.LightClientHeader {
     return this._optimisticHeader;
   }
 
-  set optimisticHeader(value: phase0.BeaconBlockHeader) {
+  set optimisticHeader(value: altair.LightClientHeader) {
     this._optimisticHeader = value;
     this.events.onSetOptimisticHeader?.(value);
   }

--- a/packages/light-client/src/spec/validateLightClientBootstrap.ts
+++ b/packages/light-client/src/spec/validateLightClientBootstrap.ts
@@ -7,7 +7,7 @@ const CURRENT_SYNC_COMMITTEE_INDEX = 22;
 const CURRENT_SYNC_COMMITTEE_DEPTH = 5;
 
 export function validateLightClientBootstrap(trustedBlockRoot: Root, bootstrap: altair.LightClientBootstrap): void {
-  const headerRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(bootstrap.header);
+  const headerRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(bootstrap.header.beacon);
   if (!byteArrayEquals(headerRoot, trustedBlockRoot)) {
     throw Error(`bootstrap header root ${toHex(headerRoot)} != trusted root ${toHex(trustedBlockRoot)}`);
   }
@@ -18,7 +18,7 @@ export function validateLightClientBootstrap(trustedBlockRoot: Root, bootstrap: 
       bootstrap.currentSyncCommitteeBranch,
       CURRENT_SYNC_COMMITTEE_DEPTH,
       CURRENT_SYNC_COMMITTEE_INDEX,
-      bootstrap.header.stateRoot
+      bootstrap.header.beacon.stateRoot
     )
   ) {
     throw Error("Invalid currentSyncCommittee merkle branch");

--- a/packages/light-client/src/types.ts
+++ b/packages/light-client/src/types.ts
@@ -1,5 +1,5 @@
 import type {PublicKey} from "@chainsafe/bls/types";
-import {altair, phase0, SyncPeriod} from "@lodestar/types";
+import {altair, SyncPeriod} from "@lodestar/types";
 
 export type LightClientStoreFast = {
   snapshot: LightClientSnapshotFast;
@@ -8,7 +8,7 @@ export type LightClientStoreFast = {
 
 export type LightClientSnapshotFast = {
   /** Beacon block header */
-  header: phase0.BeaconBlockHeader;
+  header: altair.LightClientHeader;
   /** Sync committees corresponding to the header */
   currentSyncCommittee: SyncCommitteeFast;
   nextSyncCommittee: SyncCommitteeFast;

--- a/packages/light-client/src/validation.ts
+++ b/packages/light-client/src/validation.ts
@@ -35,7 +35,7 @@ export function assertValidLightClientUpdate(
   // }
 
   // Verify update header root is the finalized root of the finality header, if specified
-  const isFinalized = !isEmptyHeader(update.finalizedHeader);
+  const isFinalized = !isEmptyHeader(update.finalizedHeader.beacon);
   if (isFinalized) {
     assertValidFinalityProof(update);
   } else {
@@ -48,8 +48,8 @@ export function assertValidLightClientUpdate(
   assertValidSyncCommitteeProof(update);
 
   const {attestedHeader} = update;
-  const headerBlockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(attestedHeader);
-  assertValidSignedHeader(config, syncCommittee, update.syncAggregate, headerBlockRoot, attestedHeader.slot);
+  const headerBlockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(attestedHeader.beacon);
+  assertValidSignedHeader(config, syncCommittee, update.syncAggregate, headerBlockRoot, attestedHeader.beacon.slot);
 }
 
 /**
@@ -67,18 +67,18 @@ export function assertValidLightClientUpdate(
 export function assertValidFinalityProof(update: altair.LightClientFinalityUpdate): void {
   if (
     !isValidMerkleBranch(
-      ssz.phase0.BeaconBlockHeader.hashTreeRoot(update.finalizedHeader),
+      ssz.phase0.BeaconBlockHeader.hashTreeRoot(update.finalizedHeader.beacon),
       update.finalityBranch,
       FINALIZED_ROOT_DEPTH,
       FINALIZED_ROOT_INDEX,
-      update.attestedHeader.stateRoot
+      update.attestedHeader.beacon.stateRoot
     )
   ) {
     throw Error("Invalid finality header merkle branch");
   }
 
-  const updatePeriod = computeSyncPeriodAtSlot(update.attestedHeader.slot);
-  const updateFinalityPeriod = computeSyncPeriodAtSlot(update.finalizedHeader.slot);
+  const updatePeriod = computeSyncPeriodAtSlot(update.attestedHeader.beacon.slot);
+  const updateFinalityPeriod = computeSyncPeriodAtSlot(update.finalizedHeader.beacon.slot);
   if (updateFinalityPeriod !== updatePeriod) {
     throw Error(`finalityHeader period ${updateFinalityPeriod} != header period ${updatePeriod}`);
   }
@@ -101,7 +101,7 @@ export function assertValidSyncCommitteeProof(update: altair.LightClientUpdate):
       update.nextSyncCommitteeBranch,
       NEXT_SYNC_COMMITTEE_DEPTH,
       NEXT_SYNC_COMMITTEE_INDEX,
-      update.attestedHeader.stateRoot
+      update.attestedHeader.beacon.stateRoot
     )
   ) {
     throw Error("Invalid next sync committee merkle branch");

--- a/packages/light-client/test/mocks/BeaconChainLcMock.ts
+++ b/packages/light-client/test/mocks/BeaconChainLcMock.ts
@@ -1,6 +1,6 @@
 import {toHexString} from "@chainsafe/ssz";
 import {BeaconStateAltair} from "@lodestar/state-transition";
-import {altair, phase0, Root, ssz} from "@lodestar/types";
+import {altair, Root, ssz} from "@lodestar/types";
 import {IBeaconChainLc} from "../utils/prepareUpdateNaive.js";
 
 /**
@@ -8,16 +8,16 @@ import {IBeaconChainLc} from "../utils/prepareUpdateNaive.js";
  * Throws for any unknown root
  */
 export class BeaconChainLcMock implements IBeaconChainLc {
-  private readonly blockHeaders = new Map<string, phase0.BeaconBlockHeader>();
+  private readonly blockHeaders = new Map<string, altair.LightClientHeader>();
   private readonly states = new Map<string, altair.BeaconState>();
 
-  constructor(blockHeaders: phase0.BeaconBlockHeader[], states: altair.BeaconState[]) {
+  constructor(blockHeaders: altair.LightClientHeader[], states: altair.BeaconState[]) {
     for (const blockHeader of blockHeaders)
-      this.blockHeaders.set(toHexString(ssz.phase0.BeaconBlockHeader.hashTreeRoot(blockHeader)), blockHeader);
+      this.blockHeaders.set(toHexString(ssz.altair.LightClientHeader.hashTreeRoot(blockHeader)), blockHeader);
     for (const state of states) this.states.set(toHexString(ssz.altair.BeaconState.hashTreeRoot(state)), state);
   }
 
-  async getBlockHeaderByRoot(blockRoot: Root): Promise<phase0.BeaconBlockHeader> {
+  async getBlockHeaderByRoot(blockRoot: Root): Promise<altair.LightClientHeader> {
     const rootHex = toHexString(blockRoot);
     const blockHeader = this.blockHeaders.get(rootHex);
     if (!blockHeader) throw Error(`No blockHeader for ${rootHex}`);

--- a/packages/light-client/test/unit/syncInMemory.test.ts
+++ b/packages/light-client/test/unit/syncInMemory.test.ts
@@ -54,25 +54,25 @@ describe("syncInMemory", function () {
     const headerBlockSlot = finalizedBlockSlot + 1;
 
     const finalizedState = ssz.altair.BeaconState.defaultValue();
-    const finalizedBlockHeader = ssz.phase0.BeaconBlockHeader.defaultValue();
-    finalizedBlockHeader.slot = finalizedBlockSlot;
-    finalizedBlockHeader.stateRoot = ssz.altair.BeaconState.hashTreeRoot(finalizedState);
+    const finalizedBlockHeader = ssz.altair.LightClientHeader.defaultValue();
+    finalizedBlockHeader.beacon.slot = finalizedBlockSlot;
+    finalizedBlockHeader.beacon.stateRoot = ssz.altair.BeaconState.hashTreeRoot(finalizedState);
 
     // Create a state that has the next sync committee and finalizedState as finalized checkpoint
     const syncAttestedState = ssz.altair.BeaconState.defaultValue();
     syncAttestedState.nextSyncCommittee = getSyncCommittee(syncCommitteesKeys, 0).syncCommittee;
     syncAttestedState.finalizedCheckpoint = {
       epoch: 0, // Checkpoint { epoch, blockRoot }
-      root: ssz.phase0.BeaconBlockHeader.hashTreeRoot(finalizedBlockHeader),
+      root: ssz.altair.LightClientHeader.hashTreeRoot(finalizedBlockHeader),
     };
-    const syncAttestedBlockHeader = ssz.phase0.BeaconBlockHeader.defaultValue();
-    syncAttestedBlockHeader.slot = headerBlockSlot;
-    syncAttestedBlockHeader.stateRoot = ssz.altair.BeaconState.hashTreeRoot(syncAttestedState);
+    const syncAttestedBlockHeader = ssz.altair.LightClientHeader.defaultValue();
+    syncAttestedBlockHeader.beacon.slot = headerBlockSlot;
+    syncAttestedBlockHeader.beacon.stateRoot = ssz.altair.BeaconState.hashTreeRoot(syncAttestedState);
 
     // Create a state with the block blockWithSyncAggregate
     const stateWithSyncAggregate = ssz.altair.BeaconState.defaultValue();
     stateWithSyncAggregate.slot = 1;
-    stateWithSyncAggregate.blockRoots[0] = ssz.phase0.BeaconBlockHeader.hashTreeRoot(syncAttestedBlockHeader);
+    stateWithSyncAggregate.blockRoots[0] = ssz.altair.LightClientHeader.hashTreeRoot(syncAttestedBlockHeader);
 
     // Create a signature from current committee to "attest" syncAttestedBlockHeader
     const signingRoot = getSyncAggregateSigningRoot(config, syncAttestedBlockHeader);
@@ -101,7 +101,7 @@ describe("syncInMemory", function () {
     const store: LightClientStoreFast = {
       bestUpdates: new Map<SyncPeriod, altair.LightClientUpdate>(),
       snapshot: {
-        header: ssz.phase0.BeaconBlockHeader.defaultValue(),
+        header: ssz.altair.LightClientHeader.defaultValue(),
         currentSyncCommittee: getSyncCommittee(syncCommitteesKeys, 0).syncCommitteeFast,
         nextSyncCommittee: getSyncCommittee(syncCommitteesKeys, 0).syncCommitteeFast,
       },

--- a/packages/light-client/test/unit/validation.test.ts
+++ b/packages/light-client/test/unit/validation.test.ts
@@ -60,13 +60,13 @@ describe("validation", function () {
 
     // finalized header must have stateRoot to finalizedState
     const finalizedHeader = defaultBeaconBlockHeader(updateHeaderSlot);
-    finalizedHeader.stateRoot = finalizedState.hashTreeRoot();
+    finalizedHeader.beacon.stateRoot = finalizedState.hashTreeRoot();
 
     // attestedState must have `finalizedHeader` as finalizedCheckpoint
     const attestedState = ssz.altair.BeaconState.defaultViewDU();
     attestedState.finalizedCheckpoint = ssz.phase0.Checkpoint.toViewDU({
       epoch: 0,
-      root: ssz.phase0.BeaconBlockHeader.hashTreeRoot(finalizedHeader),
+      root: ssz.altair.LightClientHeader.hashTreeRoot(finalizedHeader),
     });
 
     // attested state must contain next sync committees
@@ -74,7 +74,7 @@ describe("validation", function () {
 
     // attestedHeader must have stateRoot to attestedState
     const attestedHeader = defaultBeaconBlockHeader(attestedHeaderSlot);
-    attestedHeader.stateRoot = attestedState.hashTreeRoot();
+    attestedHeader.beacon.stateRoot = attestedState.hashTreeRoot();
 
     // Creates proofs for nextSyncCommitteeBranch and finalityBranch rooted in attested state
     const nextSyncCommitteeBranch = new Tree(attestedState.node).getSingleProof(BigInt(NEXT_SYNC_COMMITTEE_GINDEX));

--- a/packages/light-client/test/utils/prepareUpdateNaive.ts
+++ b/packages/light-client/test/utils/prepareUpdateNaive.ts
@@ -1,10 +1,10 @@
-import {altair, phase0, Root, ssz} from "@lodestar/types";
+import {altair, Root, ssz} from "@lodestar/types";
 import {CompositeViewDU} from "@chainsafe/ssz";
 import {FINALIZED_ROOT_GINDEX, NEXT_SYNC_COMMITTEE_GINDEX, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {Tree} from "@chainsafe/persistent-merkle-tree";
 
 export interface IBeaconChainLc {
-  getBlockHeaderByRoot(blockRoot: Root): Promise<phase0.BeaconBlockHeader>;
+  getBlockHeaderByRoot(blockRoot: Root): Promise<altair.LightClientHeader>;
   getStateByRoot(stateRoot: Root): Promise<CompositeViewDU<typeof ssz.altair.BeaconState>>;
 }
 
@@ -74,7 +74,7 @@ export async function prepareUpdateNaive(
   const syncAttestedBlockHeader = await chain.getBlockHeaderByRoot(syncAttestedBlockRoot);
 
   // Get the finalized state defined in the block "attested" by the current sync committee
-  const syncAttestedState = await chain.getStateByRoot(syncAttestedBlockHeader.stateRoot);
+  const syncAttestedState = await chain.getStateByRoot(syncAttestedBlockHeader.beacon.stateRoot);
   const finalizedCheckpointBlockHeader = await chain.getBlockHeaderByRoot(syncAttestedState.finalizedCheckpoint.root);
 
   // Prove that the `finalizedCheckpointRoot` belongs in that block
@@ -95,6 +95,6 @@ export async function prepareUpdateNaive(
     finalizedHeader: finalizedCheckpointBlockHeader,
     finalityBranch: finalityBranch,
     syncAggregate,
-    signatureSlot: syncAttestedBlockHeader.slot + 1,
+    signatureSlot: syncAttestedBlockHeader.beacon.slot + 1,
   };
 }

--- a/packages/light-client/test/utils/utils.ts
+++ b/packages/light-client/test/utils/utils.ts
@@ -255,7 +255,7 @@ export function committeeUpdateToLatestHeadUpdate(
       syncCommitteeBits: committeeUpdate.syncAggregate.syncCommitteeBits,
       syncCommitteeSignature: committeeUpdate.syncAggregate.syncCommitteeSignature,
     },
-    signatureSlot: committeeUpdate.attestedHeader.slot + 1,
+    signatureSlot: committeeUpdate.attestedHeader.beacon.slot + 1,
   };
 }
 

--- a/packages/reqresp/src/protocols/LightClientBootstrap.ts
+++ b/packages/reqresp/src/protocols/LightClientBootstrap.ts
@@ -16,7 +16,10 @@ export const LightClientBootstrap: ProtocolDefinitionGenerator<Root, altair.Ligh
     requestType: () => ssz.Root,
     responseType: () => ssz.altair.LightClientBootstrap,
     renderRequestBody: (req) => toHex(req),
-    contextBytes: getContextBytesLightclient((bootstrap) => modules.config.getForkName(bootstrap.header.slot), modules),
+    contextBytes: getContextBytesLightclient(
+      (bootstrap) => modules.config.getForkName(bootstrap.header.beacon.slot),
+      modules
+    ),
     inboundRateLimits: {
       // As similar in the nature of `Status` protocol so we use the same rate limits.
       byPeer: {quota: 5, quotaTimeMs: 15_000},

--- a/packages/types/src/altair/sszTypes.ts
+++ b/packages/types/src/altair/sszTypes.ts
@@ -170,9 +170,16 @@ export const BeaconState = new ContainerType(
   {typeName: "BeaconState", jsonCase: "eth2"}
 );
 
+export const LightClientHeader = new ContainerType(
+  {
+    beacon: phase0Ssz.BeaconBlockHeader,
+  },
+  {typeName: "LightClientHeader", jsonCase: "eth2"}
+);
+
 export const LightClientBootstrap = new ContainerType(
   {
-    header: phase0Ssz.BeaconBlockHeader,
+    header: LightClientHeader,
     currentSyncCommittee: SyncCommittee,
     currentSyncCommitteeBranch: new VectorCompositeType(Bytes32, NEXT_SYNC_COMMITTEE_DEPTH),
   },
@@ -181,10 +188,10 @@ export const LightClientBootstrap = new ContainerType(
 
 export const LightClientUpdate = new ContainerType(
   {
-    attestedHeader: phase0Ssz.BeaconBlockHeader,
+    attestedHeader: LightClientHeader,
     nextSyncCommittee: SyncCommittee,
     nextSyncCommitteeBranch: new VectorCompositeType(Bytes32, NEXT_SYNC_COMMITTEE_DEPTH),
-    finalizedHeader: phase0Ssz.BeaconBlockHeader,
+    finalizedHeader: LightClientHeader,
     finalityBranch: new VectorCompositeType(Bytes32, FINALIZED_ROOT_DEPTH),
     syncAggregate: SyncAggregate,
     signatureSlot: Slot,
@@ -194,8 +201,8 @@ export const LightClientUpdate = new ContainerType(
 
 export const LightClientFinalityUpdate = new ContainerType(
   {
-    attestedHeader: phase0Ssz.BeaconBlockHeader,
-    finalizedHeader: phase0Ssz.BeaconBlockHeader,
+    attestedHeader: LightClientHeader,
+    finalizedHeader: LightClientHeader,
     finalityBranch: new VectorCompositeType(Bytes32, FINALIZED_ROOT_DEPTH),
     syncAggregate: SyncAggregate,
     signatureSlot: Slot,
@@ -205,7 +212,7 @@ export const LightClientFinalityUpdate = new ContainerType(
 
 export const LightClientOptimisticUpdate = new ContainerType(
   {
-    attestedHeader: phase0Ssz.BeaconBlockHeader,
+    attestedHeader: LightClientHeader,
     syncAggregate: SyncAggregate,
     signatureSlot: Slot,
   },

--- a/packages/types/src/altair/types.ts
+++ b/packages/types/src/altair/types.ts
@@ -14,6 +14,7 @@ export type BeaconBlockBody = ValueOf<typeof ssz.BeaconBlockBody>;
 export type BeaconBlock = ValueOf<typeof ssz.BeaconBlock>;
 export type SignedBeaconBlock = ValueOf<typeof ssz.SignedBeaconBlock>;
 export type BeaconState = ValueOf<typeof ssz.BeaconState>;
+export type LightClientHeader = ValueOf<typeof ssz.LightClientHeader>;
 export type LightClientBootstrap = ValueOf<typeof ssz.LightClientBootstrap>;
 export type LightClientUpdate = ValueOf<typeof ssz.LightClientUpdate>;
 export type LightClientFinalityUpdate = ValueOf<typeof ssz.LightClientFinalityUpdate>;


### PR DESCRIPTION
Add and use LightClientHeader for lightclient updates

ref: 
- https://github.com/ethereum/consensus-specs/pull/3190

and re-enable all the lightclient ssz spec tests which were disabled in the spec update  to `v1.3.0-rc.1` by the PR: https://github.com/ChainSafe/lodestar/pull/5005