### PR TITLE
Re-activate eip4844 transition spec test

### DIFF
--- a/packages/beacon-node/test/spec/presets/index.test.ts
+++ b/packages/beacon-node/test/spec/presets/index.test.ts
@@ -69,11 +69,7 @@ specTestIterator(
     sync: {type: RunnerType.default, fn: forkChoiceTest({onlyPredefinedResponses: true})},
     transition: {
       type: RunnerType.default,
-      fn: transition([
-        // This test right now has been escalted as history summary should have been pushed
-        // in the state, but in the expected state as per test, nothing has been pushed
-        "eip4844/transition/core/pyspec_tests/transition_randomized_state",
-      ]),
+      fn: transition(),
     },
   },
   skipOpts


### PR DESCRIPTION
Re-activate eip4844 transition spec test as the fix for the test was included in the new rc1 spec release.