### PR TITLE
Update prometheus-grafana.md

### DIFF
--- a/docs/usage/prometheus-grafana.md
+++ b/docs/usage/prometheus-grafana.md
@@ -19,7 +19,7 @@ Unzip the downloaded .zip file and run Prometheus from its installed location wi
 Then run the Lodestar beacon node with
 
 ```
-lodestar --metrics=true --metrics.serverPort=8008
+lodestar --metrics=true --metrics.port=8008
 ```
 
 Navigate to http://localhost:9090/ in your browser to verify that Prometheus is monitoring Lodestar


### PR DESCRIPTION

**Motivation**

Improve documentation

**Description**

In [Prometheus & Grafana Setup](https://chainsafe.github.io/lodestar/usage/prometheus-grafana/) documentation: metrics.port instead of metrics.serverPort (metrics.serverPort did not work for me, also according to https://chainsafe.github.io/lodestar/reference/cli/ metrics.port is correct)
