### PR TITLE
Fix Memory usage panel in VM + host dashboard

### DIFF
--- a/dashboards/lodestar_vm_host.json
+++ b/dashboards/lodestar_vm_host.json
@@ -346,7 +346,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "process_heap_bytes{scrape_location=\"beacon\"}",
+          "expr": "process_heap_bytes{job=\"beacon\"}",
           "interval": "",
           "legendFormat": "process_heap_bytes",
           "refId": "A"
@@ -357,7 +357,7 @@
             "uid": "prometheus_local"
           },
           "exemplar": false,
-          "expr": "nodejs_heap_size_total_bytes{scrape_location=\"beacon\"}",
+          "expr": "nodejs_heap_size_total_bytes{job=\"beacon\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "heap_total",
@@ -369,7 +369,7 @@
             "uid": "prometheus_local"
           },
           "exemplar": false,
-          "expr": "nodejs_heap_size_used_bytes{scrape_location=\"beacon\"}",
+          "expr": "nodejs_heap_size_used_bytes{job=\"beacon\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "heap_used",
@@ -381,7 +381,7 @@
             "uid": "prometheus_local"
           },
           "exemplar": false,
-          "expr": "nodejs_external_memory_bytes{scrape_location=\"beacon\"}",
+          "expr": "nodejs_external_memory_bytes{job=\"beacon\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "external_memory",
@@ -393,7 +393,7 @@
             "uid": "prometheus_local"
           },
           "exemplar": false,
-          "expr": "process_resident_memory_bytes{scrape_location=\"beacon\"}",
+          "expr": "process_resident_memory_bytes{job=\"beacon\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "rss",


### PR DESCRIPTION
**Motivation**

As introduced in #4952 the `job` default label should be used to differentiate between beacon and validator metrics.

**Description**

Replaces `scrape_location` with `job` label.
