### PR TITLE
Ignore new closed connection

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -66,10 +66,10 @@ export function createLodestarMetrics(
       name: "lodestar_peers_sync_count",
       help: "Current count of peers useful for sync",
     }),
-    peerConnectedEvent: register.gauge<"direction">({
+    peerConnectedEvent: register.gauge<"direction" | "status">({
       name: "lodestar_peer_connected_total",
       help: "Total number of peer:connected event, labeled by direction",
-      labelNames: ["direction"],
+      labelNames: ["direction", "status"],
     }),
     peerDisconnectedEvent: register.gauge<"direction">({
       name: "lodestar_peer_disconnected_total",

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -454,19 +454,20 @@ export class PeerManager {
       }
     }
 
+    // disconnect first to have more slots before we dial new peers
+    for (const [reason, peers] of peersToDisconnect) {
+      this.metrics?.peersRequestedToDisconnect.inc({reason}, peers.length);
+      for (const peer of peers) {
+        void this.goodbyeAndDisconnect(peer, GoodByeReasonCode.TOO_MANY_PEERS);
+      }
+    }
+
     if (this.discovery) {
       try {
         this.metrics?.peersRequestedToConnect.inc(peersToConnect);
         this.discovery.discoverPeers(peersToConnect, queriesMerged);
       } catch (e) {
         this.logger.error("Error on discoverPeers", {}, e as Error);
-      }
-    }
-
-    for (const [reason, peers] of peersToDisconnect) {
-      this.metrics?.peersRequestedToDisconnect.inc({reason}, peers.length);
-      for (const peer of peers) {
-        void this.goodbyeAndDisconnect(peer, GoodByeReasonCode.TOO_MANY_PEERS);
       }
     }
 


### PR DESCRIPTION
**Motivation**

- libp2p may emit `peer:connect` event with a closed connection and we want to ignore it because it's not guarantee we receive a `peer:disconnect` event later, see https://github.com/libp2p/js-libp2p/issues/1565

**Description**

- Ignore new closed connection, track the status in `lodestar_peer_connected_total` metric
- Also we should disconnect peers before connect peers, it may not be a different since it's all async code but we should logically do it
