### PR TITLE
Cache and retransmit bls changes if submitted early

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -104,7 +104,11 @@ export function getBeaconPoolApi({
           try {
             await validateBlsToExecutionChange(chain, blsToExecutionChange);
             chain.opPool.insertBlsToExecutionChange(blsToExecutionChange);
-            await network.gossip.publishBlsToExecutionChange(blsToExecutionChange);
+            try {
+              await network.gossip.publishBlsToExecutionChange(blsToExecutionChange);
+            } catch (e) {
+              await chain.cacheBlsToExecutionChanges(blsToExecutionChange);
+            }
           } catch (e) {
             errors.push(e as Error);
             logger.error(

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -104,9 +104,9 @@ export function getBeaconPoolApi({
           try {
             await validateBlsToExecutionChange(chain, blsToExecutionChange);
             chain.opPool.insertBlsToExecutionChange(blsToExecutionChange);
-            try {
+            if (chain.clock.currentEpoch >= chain.config.CAPELLA_FORK_EPOCH) {
               await network.gossip.publishBlsToExecutionChange(blsToExecutionChange);
-            } catch (e) {
+            } else {
               await chain.cacheBlsToExecutionChanges(blsToExecutionChange);
             }
           } catch (e) {

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -112,7 +112,7 @@ export function getBeaconPoolApi({
           } catch (e) {
             errors.push(e as Error);
             logger.error(
-              `Error on submitPoolSyncCommitteeSignatures [${i}]`,
+              `Error on submitPoolBlsToExecutionChange [${i}]`,
               {validatorIndex: blsToExecutionChange.message.validatorIndex},
               e as Error
             );

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -104,7 +104,12 @@ export function getBeaconPoolApi({
           try {
             await validateBlsToExecutionChange(chain, blsToExecutionChange);
             chain.opPool.insertBlsToExecutionChange(blsToExecutionChange);
-            if (chain.clock.currentEpoch >= chain.config.CAPELLA_FORK_EPOCH) {
+            if (
+              chain.clock.currentEpoch >= chain.config.CAPELLA_FORK_EPOCH &&
+              // TODO: Remove below condition
+              // Only used for testing in devnet-3 of withdrawals
+              network.isSubscribedToGossipCoreTopics()
+            ) {
               await network.gossip.publishBlsToExecutionChange(blsToExecutionChange);
             } else {
               await chain.cacheBlsToExecutionChanges(blsToExecutionChange);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -12,7 +12,19 @@ import {
   PubkeyIndexMap,
 } from "@lodestar/state-transition";
 import {IBeaconConfig} from "@lodestar/config";
-import {allForks, UintNum64, Root, phase0, Slot, RootHex, Epoch, ValidatorIndex, eip4844, Wei} from "@lodestar/types";
+import {
+  allForks,
+  UintNum64,
+  Root,
+  phase0,
+  Slot,
+  RootHex,
+  Epoch,
+  ValidatorIndex,
+  eip4844,
+  Wei,
+  capella,
+} from "@lodestar/types";
 import {CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {ProcessShutdownCallback} from "@lodestar/validator";
 import {ILogger, pruneSetToMax, toHex} from "@lodestar/utils";
@@ -778,5 +790,10 @@ export class BeaconChain implements IBeaconChain {
         });
       }
     }
+  }
+
+  /** Must be validated beforehand */
+  async cacheBlsToExecutionChanges(blsToExecutionChange: capella.SignedBLSToExecutionChange): Promise<void> {
+    return this.db.blsToExecutionChangeCache.add(blsToExecutionChange);
   }
 }

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -134,9 +134,9 @@ export class BeaconChain implements IBeaconChain {
   /** Map keyed by executionPayload.blockHash of the block for those blobs */
   readonly producedBlobsSidecarCache = new Map<RootHex, eip4844.BlobsSidecar>();
   readonly opts: IChainOptions;
+  readonly db: IBeaconDb;
 
   protected readonly blockProcessor: BlockProcessor;
-  protected readonly db: IBeaconDb;
   private readonly archiver: Archiver;
   private abortController = new AbortController();
   private successfulExchangeTransition = false;

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -1,4 +1,16 @@
-import {allForks, UintNum64, Root, phase0, Slot, RootHex, Epoch, ValidatorIndex, eip4844, Wei} from "@lodestar/types";
+import {
+  allForks,
+  UintNum64,
+  Root,
+  phase0,
+  Slot,
+  RootHex,
+  Epoch,
+  ValidatorIndex,
+  eip4844,
+  Wei,
+  capella,
+} from "@lodestar/types";
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {IBeaconConfig} from "@lodestar/config";
 import {CompositeTypeAny, TreeView, Type} from "@chainsafe/ssz";
@@ -133,6 +145,7 @@ export interface IBeaconChain {
   /** Persist bad items to persistInvalidSszObjectsDir dir, for example invalid state, attestations etc. */
   persistInvalidSszView(view: TreeView<CompositeTypeAny>, suffix?: string): void;
   updateBuilderStatus(clockSlot: Slot): void;
+  cacheBlsToExecutionChanges(blsToExecutionChange: capella.SignedBLSToExecutionChange): Promise<void>;
 }
 
 export type SSZObjectType =

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -20,6 +20,7 @@ import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {IEth1ForBlockProduction} from "../eth1/index.js";
 import {IExecutionEngine, IExecutionBuilder} from "../execution/index.js";
 import {IMetrics} from "../metrics/metrics.js";
+import {IBeaconDb} from "../db/index.js";
 import {IBeaconClock} from "./clock/interface.js";
 import {ChainEventEmitter} from "./emitter.js";
 import {IStateRegenerator} from "./regen/index.js";
@@ -102,6 +103,7 @@ export interface IBeaconChain {
   readonly checkpointBalancesCache: CheckpointBalancesCache;
   readonly producedBlobsSidecarCache: Map<RootHex, eip4844.BlobsSidecar>;
   readonly opts: IChainOptions;
+  readonly db: IBeaconDb;
 
   /** Stop beacon chain processing */
   close(): Promise<void>;

--- a/packages/beacon-node/src/chain/opPools/opPool.ts
+++ b/packages/beacon-node/src/chain/opPools/opPool.ts
@@ -68,7 +68,7 @@ export class OpPool {
       this.insertVoluntaryExit(voluntaryExit);
     }
     for (const item of blsToExecutionChanges) {
-      this.blsToExecutionChanges.set(item.message.validatorIndex, item);
+      this.insertBlsToExecutionChange(item);
     }
   }
 

--- a/packages/beacon-node/src/chain/opPools/opPool.ts
+++ b/packages/beacon-node/src/chain/opPools/opPool.ts
@@ -1,6 +1,5 @@
 import {
   CachedBeaconStateAllForks,
-  CachedBeaconStateCapella,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   getAttesterSlashableIndices,
@@ -233,7 +232,7 @@ export class OpPool {
 
     const blsToExecutionChanges: capella.SignedBLSToExecutionChange[] = [];
     for (const blsToExecutionChange of this.blsToExecutionChanges.values()) {
-      if (isValidBlsToExecutionChangeForBlockInclusion(state as CachedBeaconStateCapella, blsToExecutionChange)) {
+      if (isValidBlsToExecutionChangeForBlockInclusion(state, blsToExecutionChange)) {
         blsToExecutionChanges.push(blsToExecutionChange);
         if (blsToExecutionChanges.length >= MAX_BLS_TO_EXECUTION_CHANGES) {
           break;

--- a/packages/beacon-node/src/chain/opPools/utils.ts
+++ b/packages/beacon-node/src/chain/opPools/utils.ts
@@ -1,7 +1,7 @@
 import bls from "@chainsafe/bls";
 import {CoordType, Signature} from "@chainsafe/bls/types";
 import {BLS_WITHDRAWAL_PREFIX} from "@lodestar/params";
-import {CachedBeaconStateCapella} from "@lodestar/state-transition";
+import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {Slot, capella} from "@lodestar/types";
 
 /**
@@ -38,7 +38,7 @@ export function signatureFromBytesNoCheck(signature: Uint8Array): Signature {
  * can become invalid for certain forks.
  */
 export function isValidBlsToExecutionChangeForBlockInclusion(
-  state: CachedBeaconStateCapella,
+  state: CachedBeaconStateAllForks,
   signedBLSToExecutionChange: capella.SignedBLSToExecutionChange
 ): boolean {
   // For each condition from https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#new-process_bls_to_execution_change

--- a/packages/beacon-node/src/db/beacon.ts
+++ b/packages/beacon-node/src/db/beacon.ts
@@ -18,6 +18,7 @@ import {
   BlobsSidecarRepository,
   BlobsSidecarArchiveRepository,
   BLSToExecutionChangeRepository,
+  BLSToExecutionChangeCacheRepository,
 } from "./repositories/index.js";
 import {PreGenesisState, PreGenesisStateLastProcessedBlock} from "./single/index.js";
 
@@ -33,6 +34,7 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
   attesterSlashing: AttesterSlashingRepository;
   depositEvent: DepositEventRepository;
   blsToExecutionChange: BLSToExecutionChangeRepository;
+  blsToExecutionChangeCache: BLSToExecutionChangeCacheRepository;
 
   depositDataRoot: DepositDataRootRepository;
   eth1Data: Eth1DataRepository;
@@ -58,6 +60,7 @@ export class BeaconDb extends DatabaseService implements IBeaconDb {
     this.stateArchive = new StateArchiveRepository(this.config, this.db);
     this.voluntaryExit = new VoluntaryExitRepository(this.config, this.db);
     this.blsToExecutionChange = new BLSToExecutionChangeRepository(this.config, this.db);
+    this.blsToExecutionChangeCache = new BLSToExecutionChangeCacheRepository(this.config, this.db);
     this.proposerSlashing = new ProposerSlashingRepository(this.config, this.db);
     this.attesterSlashing = new AttesterSlashingRepository(this.config, this.db);
     this.depositEvent = new DepositEventRepository(this.config, this.db);

--- a/packages/beacon-node/src/db/interface.ts
+++ b/packages/beacon-node/src/db/interface.ts
@@ -17,6 +17,7 @@ import {
   BlobsSidecarRepository,
   BlobsSidecarArchiveRepository,
   BLSToExecutionChangeRepository,
+  BLSToExecutionChangeCacheRepository,
 } from "./repositories/index.js";
 import {PreGenesisState, PreGenesisStateLastProcessedBlock} from "./single/index.js";
 
@@ -43,6 +44,7 @@ export interface IBeaconDb {
   attesterSlashing: AttesterSlashingRepository;
   depositEvent: DepositEventRepository;
   blsToExecutionChange: BLSToExecutionChangeRepository;
+  blsToExecutionChangeCache: BLSToExecutionChangeCacheRepository;
 
   // eth1 processing
   preGenesisState: PreGenesisState;

--- a/packages/beacon-node/src/db/repositories/blsToExecutionChange.ts
+++ b/packages/beacon-node/src/db/repositories/blsToExecutionChange.ts
@@ -11,3 +11,16 @@ export class BLSToExecutionChangeRepository extends Repository<ValidatorIndex, c
     return value.message.validatorIndex;
   }
 }
+
+export class BLSToExecutionChangeCacheRepository extends Repository<
+  ValidatorIndex,
+  capella.SignedBLSToExecutionChange
+> {
+  constructor(config: IChainForkConfig, db: Db) {
+    super(config, db, Bucket.capella_blsToExecutionChangeCache, ssz.capella.SignedBLSToExecutionChange);
+  }
+
+  getId(value: capella.SignedBLSToExecutionChange): ValidatorIndex {
+    return value.message.validatorIndex;
+  }
+}

--- a/packages/beacon-node/src/db/repositories/index.ts
+++ b/packages/beacon-node/src/db/repositories/index.ts
@@ -17,4 +17,4 @@ export {CheckpointHeaderRepository} from "./lightclientCheckpointHeader.js";
 export {SyncCommitteeRepository} from "./lightclientSyncCommittee.js";
 export {SyncCommitteeWitnessRepository} from "./lightclientSyncCommitteeWitness.js";
 export {BackfilledRanges} from "./backfilledRanges.js";
-export {BLSToExecutionChangeRepository} from "./blsToExecutionChange.js";
+export {BLSToExecutionChangeRepository, BLSToExecutionChangeCacheRepository} from "./blsToExecutionChange.js";

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -506,9 +506,7 @@ export class Network implements INetwork {
 
     try {
       const headState = this.chain.getHeadState();
-      for await (const value of this.chain.db.blsToExecutionChangeCache.valuesStream({
-        limit: CACHED_BLS_BATCH_GOSSIP_LIMIT,
-      })) {
+      for await (const value of this.chain.db.blsToExecutionChangeCache.valuesStream()) {
         if (isValidBlsToExecutionChangeForBlockInclusion(headState, value)) {
           await this.gossip.publishBlsToExecutionChange(value);
           gossipedKeys.push(value.message.validatorIndex);

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -502,6 +502,8 @@ export class Network implements INetwork {
         await this.gossip.publishBlsToExecutionChange(value);
         gossipedKeys.push(key);
       }
+    } catch (e) {
+      this.logger.error("Failed to gossip all cached bls changes", {}, e as Error);
     } finally {
       this.logger.info("Gossiped cached blsChanges", {size: gossipedKeys.length});
       await this.chain.db.blsToExecutionChangeCache.batchDelete(gossipedKeys).catch((e) => {

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -497,11 +497,13 @@ export class Network implements INetwork {
   private async gossipCachedBlsChanges(): Promise<void> {
     const gossipedKeys = [];
     try {
+      this.logger.info("Re-gossiping the cached bls changes");
       for await (const {key, value} of this.chain.db.blsToExecutionChangeCache.entriesStream()) {
         await this.gossip.publishBlsToExecutionChange(value);
         gossipedKeys.push(key);
       }
     } finally {
+      this.logger.info("Gossiped cached blsChanges", {size: gossipedKeys.length});
       await this.chain.db.blsToExecutionChangeCache.batchDelete(gossipedKeys).catch((e) => {
         this.logger.error("Could not clear gossiped blsChanges from blsToExecutionChangeCache", {}, e as Error);
       });

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -532,6 +532,7 @@ export class Network implements INetwork {
         // If this fails promise will not be set to null and hence gossipCachedBlsChanges will not be
         // triggered till reboot
         await this.chain.db.blsToExecutionChangeCache.batchDelete(gossipedKeys);
+        await this.chain.db.blsToExecutionChangeCache.batchDelete(includedKeys);
       }
     } while (processedKeys === CACHED_BLS_BATCH_GOSSIP_LIMIT);
     this.logger.info("Processed cached blsChanges", {totalProcessed});

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -509,7 +509,7 @@ export class Network implements INetwork {
       includedKeys = [];
       try {
         const headState = this.chain.getHeadState();
-        for await (const {key, value} of this.chain.db.blsToExecutionChangeCache.entriesStream({
+        for await (const value of this.chain.db.blsToExecutionChangeCache.valuesStream({
           limit: CACHED_BLS_BATCH_GOSSIP_LIMIT,
         })) {
           if (isValidBlsToExecutionChangeForBlockInclusion(headState, value)) {

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -226,7 +226,10 @@ export class MockBeaconChain implements IBeaconChain {
 
   async updateBeaconProposerData(): Promise<void> {}
   updateBuilderStatus(): void {}
-  async cacheBlsToExecutionChanges(): Promise<void> {}
+
+  async cacheBlsToExecutionChanges(blsToExecutionChange: capella.SignedBLSToExecutionChange): Promise<void> {
+    return this.db.blsToExecutionChangeCache.add(blsToExecutionChange);
+  }
 }
 
 const root = ssz.Root.defaultValue() as Uint8Array;

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -1,7 +1,20 @@
 import sinon from "sinon";
 
 import {CompositeTypeAny, toHexString, TreeView} from "@chainsafe/ssz";
-import {phase0, allForks, UintNum64, Root, Slot, ssz, Uint16, UintBn64, RootHex, eip4844, Wei} from "@lodestar/types";
+import {
+  phase0,
+  allForks,
+  UintNum64,
+  Root,
+  Slot,
+  ssz,
+  Uint16,
+  UintBn64,
+  RootHex,
+  eip4844,
+  Wei,
+  capella,
+} from "@lodestar/types";
 import {IBeaconConfig} from "@lodestar/config";
 import {BeaconStateAllForks, CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {CheckpointWithHex, IForkChoice, ProtoBlock, ExecutionStatus, AncestorStatus} from "@lodestar/fork-choice";

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -42,6 +42,7 @@ import {CheckpointBalancesCache} from "../../../../src/chain/balancesCache.js";
 import {IChainOptions} from "../../../../src/chain/options.js";
 import {BlockAttributes} from "../../../../src/chain/produceBlock/produceBlockBody.js";
 import {ReqRespBlockResponse} from "../../../../src/network/index.js";
+import {IBeaconDb} from "../../../../src/db/index.js";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 
@@ -67,6 +68,7 @@ export class MockBeaconChain implements IBeaconChain {
     safeSlotsToImportOptimistically: 0,
     suggestedFeeRecipient: "0x0000000000000000000000000000000000000000",
   };
+  readonly db: IBeaconDb;
   readonly anchorStateLatestBlockSlot: Slot;
 
   readonly bls: IBlsVerifier;
@@ -128,13 +130,13 @@ export class MockBeaconChain implements IBeaconChain {
     this.forkChoice = mockForkChoice();
     this.stateCache = new StateContextCache({});
     this.checkpointStateCache = new CheckpointStateCache({});
-    const db = new StubbedBeaconDb();
+    this.db = new StubbedBeaconDb();
     this.regen = new StateRegenerator({
       config: this.config,
       forkChoice: this.forkChoice,
       stateCache: this.stateCache,
       checkpointStateCache: this.checkpointStateCache,
-      db,
+      db: this.db,
       metrics: null,
       emitter: this.emitter,
     });
@@ -142,7 +144,7 @@ export class MockBeaconChain implements IBeaconChain {
       {},
       {
         config: this.config,
-        db: db,
+        db: this.db,
         metrics: null,
         emitter: this.emitter,
         logger: this.logger,
@@ -224,6 +226,7 @@ export class MockBeaconChain implements IBeaconChain {
 
   async updateBeaconProposerData(): Promise<void> {}
   updateBuilderStatus(): void {}
+  async cacheBlsToExecutionChanges(): Promise<void> {}
 }
 
 const root = ssz.Root.defaultValue() as Uint8Array;

--- a/packages/beacon-node/test/utils/mocks/db.ts
+++ b/packages/beacon-node/test/utils/mocks/db.ts
@@ -17,6 +17,7 @@ import {
   BlobsSidecarRepository,
   BlobsSidecarArchiveRepository,
   BLSToExecutionChangeRepository,
+  BLSToExecutionChangeCacheRepository,
 } from "../../../src/db/repositories/index.js";
 import {PreGenesisState, PreGenesisStateLastProcessedBlock} from "../../../src/db/single/index.js";
 import {createStubInstance} from "../types.js";
@@ -45,6 +46,7 @@ export function getStubbedBeaconDb(): IBeaconDb {
     attesterSlashing: createStubInstance(AttesterSlashingRepository),
     depositEvent: createStubInstance(DepositEventRepository),
     blsToExecutionChange: createStubInstance(BLSToExecutionChangeRepository),
+    blsToExecutionChangeCache: createStubInstance(BLSToExecutionChangeCacheRepository),
 
     // eth1 processing
     preGenesisState: createStubInstance(PreGenesisState),

--- a/packages/beacon-node/test/utils/stub/beaconDb.ts
+++ b/packages/beacon-node/test/utils/stub/beaconDb.ts
@@ -52,6 +52,7 @@ export class StubbedBeaconDb extends BeaconDb {
 
     this.voluntaryExit = createStubInstance(VoluntaryExitRepository);
     this.blsToExecutionChange = createStubInstance(BLSToExecutionChangeRepository);
+    this.blsToExecutionChangeCache = createStubInstance(BLSToExecutionChangeCacheRepository);
     this.proposerSlashing = createStubInstance(ProposerSlashingRepository);
     this.attesterSlashing = createStubInstance(AttesterSlashingRepository);
     this.depositEvent = createStubInstance(DepositEventRepository);

--- a/packages/beacon-node/test/utils/stub/beaconDb.ts
+++ b/packages/beacon-node/test/utils/stub/beaconDb.ts
@@ -14,6 +14,7 @@ import {
   StateArchiveRepository,
   VoluntaryExitRepository,
   BLSToExecutionChangeRepository,
+  BLSToExecutionChangeCacheRepository,
   BlobsSidecarRepository,
   BlobsSidecarArchiveRepository,
 } from "../../../src/db/repositories/index.js";
@@ -32,6 +33,8 @@ export class StubbedBeaconDb extends BeaconDb {
 
   voluntaryExit: SinonStubbedInstance<VoluntaryExitRepository> & VoluntaryExitRepository;
   blsToExecutionChange: SinonStubbedInstance<BLSToExecutionChangeRepository> & BLSToExecutionChangeRepository;
+  blsToExecutionChangeCache: SinonStubbedInstance<BLSToExecutionChangeCacheRepository> &
+    BLSToExecutionChangeCacheRepository;
   proposerSlashing: SinonStubbedInstance<ProposerSlashingRepository> & ProposerSlashingRepository;
   attesterSlashing: SinonStubbedInstance<AttesterSlashingRepository> & AttesterSlashingRepository;
   depositEvent: SinonStubbedInstance<DepositEventRepository> & DepositEventRepository;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -33,6 +33,7 @@ export enum Bucket {
   phase0_proposerSlashing = 14, // ValidatorIndex -> ProposerSlashing
   phase0_attesterSlashing = 15, // Root -> AttesterSlashing
   capella_blsToExecutionChange = 16, // ValidatorIndex -> SignedBLSToExecutionChange
+  capella_blsToExecutionChangeCache = 17, // ValidatorIndex -> SignedBLSToExecutionChange
   // validator
   // validator = 16, // DEPRECATED on v0.11.0
   // lastProposedBlock = 17, // DEPRECATED on v0.11.0


### PR DESCRIPTION
A user (most likely ) is expected to start submitting bls to execution changes earlier than capella hf . This would result in gossip error as the topic is not yet been subscribed by peers.

This PR would cache the bls changes and e re-gossip if there is any gossip publishing error.