### PR TITLE
Support client monitoring by a remote service (e.g. beaconcha.in)

### DIFF
--- a/dashboards/lodestar_vm_host.json
+++ b/dashboards/lodestar_vm_host.json
@@ -22,7 +22,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": 35,
-  "iteration": 1672991883959,
+  "iteration": 1674481074076,
   "links": [
     {
       "asDropdown": true,
@@ -2624,6 +2624,200 @@
         "x": 0,
         "y": 44
       },
+      "id": 527,
+      "panels": [
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 30,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 45
+          },
+          "id": 529,
+          "options": {
+            "graph": {},
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "7.4.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": false,
+              "expr": "rate(lodestar_monitoring_collect_data_seconds_sum[$rate_interval])\r\n/\r\nrate(lodestar_monitoring_collect_data_seconds_count[$rate_interval])",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{job}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Collect data duration",
+          "type": "timeseries"
+        },
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 30,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 45
+          },
+          "id": 531,
+          "options": {
+            "graph": {},
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "7.4.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "exemplar": false,
+              "expr": "rate(lodestar_monitoring_send_data_seconds_sum[$rate_interval])\r\n/\r\nrate(lodestar_monitoring_send_data_seconds_count[$rate_interval])",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{job}} - {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Send data duration",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Monitoring",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
       "id": 86,
       "panels": [
         {
@@ -3158,7 +3352,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 164,
       "panels": [

--- a/docs/usage/client-monitoring.md
+++ b/docs/usage/client-monitoring.md
@@ -1,0 +1,49 @@
+# Client monitoring
+
+Lodestar has the ability to send client stats to a remote service for collection.
+At the moment, the main service offering remote monitoring is [beaconcha.in](https://beaconcha.in/).
+
+Instructions for setting up client monitoring with *beaconcha.in* can be found in their docs about
+[Mobile App <> Node Monitoring](https://kb.beaconcha.in/beaconcha.in-explorer/mobile-app-less-than-greater-than-beacon-node)
+and in your [account settings](https://beaconcha.in/user/settings#app).
+
+## Configuration
+
+Lodestar provides CLI options to configure monitoring on both the beacon node and validator client.
+
+### Remote endpoint URL
+
+Client monitoring can be enabled by setting the `--monitoring.endpoint` flag to a remote service endpoint URL.
+As monitoring relies on metrics data, it is required that metrics are also enabled by supplying the `--metrics` flag.
+
+```bash
+lodestar beacon --monitoring.endpoint "https://beaconcha.in/api/v1/client/metrics?apikey={apikey}&machine={machineName}" --metrics
+```
+
+In case of *beaconcha.in*, the API key can be found in your [account settings](https://beaconcha.in/user/settings#api).
+Setting the machine is optional but it is especially useful if you are monitoring multiple nodes.
+
+<!-- prettier-ignore-start -->
+!!! note
+    When sending data to a remote service you should be conscious about security:
+
+    - Only use a service that you trust as this will send information which may identify you
+      and associate your validators, IP address and other personal information.
+    - Always use a HTTPS connection (i.e. a URL starting with `https://`) to prevent the traffic
+      from being intercepted in transit and leaking information.
+<!-- prettier-ignore-end -->
+
+More details about the data sent to the remote service can be found in the [specification](https://docs.google.com/document/d/1qPWAVRjPCENlyAjUBwGkHMvz9qLdd_6u9DPZcNxDBpc).
+
+It is also possible to print out the data sent to the remote service by enabling debug logs which can be done by supplying the `--logLevel debug` flag.
+
+### Monitoring interval
+
+It is possible to adjust the interval between sending client stats to the remote service by
+setting the `--monitoring.interval` flag. It takes an integer value in milliseconds, the default is `60000` which means data is sent once a minute.
+
+```bash
+lodestar beacon --monitoring.interval 60000
+```
+
+Increasing the monitoring interval can be useful if you are running into rate limit errors when posting large amounts of data for multiple nodes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
       - Validator management: usage/validator-management.md
       - Prometheus & Grafana Setup: usage/prometheus-grafana.md
       - MEV Builder Integration: usage/mev-integration.md 
+      - Client monitoring: usage/client-monitoring.md
   - Reference:
       - Command line: reference/cli.md
   - Libraries: libraries/index.md

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -35,6 +35,9 @@
     "./metrics": {
       "import": "./lib/metrics/index.js"
     },
+    "./monitoring": {
+      "import": "./lib/monitoring/index.js"
+    },
     "./network": {
       "import": "./lib/network/index.js"
     },

--- a/packages/beacon-node/src/index.ts
+++ b/packages/beacon-node/src/index.ts
@@ -8,7 +8,7 @@ export * from "./node/index.js";
 export {RegistryMetricCreator, collectNodeJSMetrics, HttpMetricsServer} from "./metrics/index.js";
 
 // Export monitoring service to make it usable by validator
-export {MonitoringService, ProcessType} from "./monitoring/index.js";
+export {MonitoringService} from "./monitoring/index.js";
 
 // Export generic RestApi server for CLI
 export {RestApiServer, RestApiServerOpts, RestApiServerModules, RestApiServerMetrics} from "./api/rest/base.js";

--- a/packages/beacon-node/src/index.ts
+++ b/packages/beacon-node/src/index.ts
@@ -7,6 +7,9 @@ export * from "./node/index.js";
 // Export metrics utilities to de-duplicate validator metrics
 export {RegistryMetricCreator, collectNodeJSMetrics, HttpMetricsServer} from "./metrics/index.js";
 
+// Export monitoring service to make it usable by validator
+export {MonitoringService, ProcessType} from "./monitoring/index.js";
+
 // Export generic RestApi server for CLI
 export {RestApiServer, RestApiServerOpts, RestApiServerModules, RestApiServerMetrics} from "./api/rest/base.js";
 

--- a/packages/beacon-node/src/monitoring/clientStats.ts
+++ b/packages/beacon-node/src/monitoring/clientStats.ts
@@ -1,0 +1,162 @@
+import {DynamicProperty, MetricProperty, StaticProperty} from "./properties.js";
+import {ClientStats, JsonType, ProcessType} from "./types.js";
+
+// Definition of client stats based on specification
+// see https://docs.google.com/document/d/1qPWAVRjPCENlyAjUBwGkHMvz9qLdd_6u9DPZcNxDBpc
+
+const CLIENT_STATS_SPEC_VERSION = 1;
+
+export function createClientStats(processes: ProcessType[]): ClientStats[] {
+  const processToStats = {
+    [ProcessType.BeaconNode]: createBeaconNodeStats,
+    [ProcessType.Validator]: createValidatorStats,
+    [ProcessType.System]: createSystemStats,
+  };
+
+  return processes.map((p) => processToStats[p]());
+}
+
+function createCommonStats(process: ProcessType): ClientStats {
+  return {
+    version: new StaticProperty({
+      jsonKey: "version",
+      value: CLIENT_STATS_SPEC_VERSION,
+    }),
+    timestamp: new DynamicProperty({
+      jsonKey: "timestamp",
+      provider: Date.now,
+    }),
+    process: new StaticProperty({
+      jsonKey: "process",
+      value: process,
+    }),
+  };
+}
+
+function createProcessStats(process: ProcessType): ClientStats {
+  return {
+    ...createCommonStats(process),
+    cpuProcessSecondsTotal: new MetricProperty({
+      jsonKey: "cpu_process_seconds_total",
+      // TODO: only collected if /metrics API is called?? might be related to counter
+      metricName: "process_cpu_seconds_total",
+      jsonType: JsonType.Number,
+      defaultValue: 0,
+    }),
+    memoryProcessBytes: new MetricProperty({
+      jsonKey: "memory_process_bytes",
+      metricName: "process_resident_memory_bytes",
+      jsonType: JsonType.Number,
+      defaultValue: 0,
+    }),
+    clientName: new StaticProperty({
+      jsonKey: "client_name",
+      value: "lodestar",
+    }),
+    clientVersion: new MetricProperty({
+      jsonKey: "client_version",
+      metricName: "lodestar_version",
+      fromLabel: "version",
+      formatter: (value) => {
+        // remove "v" prefix from value
+        return (value as string).substring(1);
+      },
+      jsonType: JsonType.String,
+      cacheResult: true,
+      defaultValue: "",
+    }),
+    clientBuild: new StaticProperty({
+      jsonKey: "client_build",
+      value: 0,
+    }),
+    syncEth2FallbackConfigured: new StaticProperty({
+      jsonKey: "sync_eth2_fallback_configured",
+      value: false,
+    }),
+    syncEth2FallbackConnected: new StaticProperty({
+      jsonKey: "sync_eth2_fallback_connected",
+      value: false,
+    }),
+  };
+}
+
+function createBeaconNodeStats(): ClientStats {
+  return {
+    ...createProcessStats(ProcessType.BeaconNode),
+    diskBeaconChainBytesTotal: new StaticProperty({
+      jsonKey: "disk_beaconchain_bytes_total",
+      value: 0,
+    }),
+    networkLibp2pBytesTotalReceive: new MetricProperty({
+      jsonKey: "network_libp2p_bytes_total_receive",
+      metricName: "libp2p_data_transfer_bytes_total",
+      withLabel: {name: "protocol", value: "global received"},
+      jsonType: JsonType.Number,
+      defaultValue: 0,
+    }),
+    networkLibp2pBytesTotalTransmit: new MetricProperty({
+      jsonKey: "network_libp2p_bytes_total_transmit",
+      metricName: "libp2p_data_transfer_bytes_total",
+      withLabel: {name: "protocol", value: "global sent"},
+      jsonType: JsonType.Number,
+      defaultValue: 0,
+    }),
+    networkPeersConnected: new MetricProperty({
+      jsonKey: "network_peers_connected",
+      metricName: "libp2p_peers",
+      jsonType: JsonType.Number,
+      defaultValue: 0,
+    }),
+    syncEth1Connected: new StaticProperty({
+      jsonKey: "sync_eth1_connected",
+      value: true,
+    }),
+    syncEth2Synced: new MetricProperty({
+      jsonKey: "sync_eth2_synced",
+      metricName: "lodestar_sync_status",
+      rangeValue: 3,
+      jsonType: JsonType.Boolean,
+      defaultValue: true,
+    }),
+    syncBeaconHeadSlot: new MetricProperty({
+      jsonKey: "sync_beacon_head_slot",
+      metricName: "beacon_head_slot",
+      jsonType: JsonType.Number,
+      defaultValue: 0,
+    }),
+    syncEth1FallbackConfigured: new StaticProperty({
+      jsonKey: "sync_eth1_fallback_configured",
+      value: false,
+    }),
+    syncEth1FallbackConnected: new StaticProperty({
+      jsonKey: "sync_eth1_fallback_connected",
+      value: false,
+    }),
+    slasherActive: new StaticProperty({
+      jsonKey: "slasher_active",
+      value: false,
+    }),
+  };
+}
+
+function createValidatorStats(): ClientStats {
+  return {
+    ...createProcessStats(ProcessType.Validator),
+    validatorTotal: new MetricProperty({
+      jsonKey: "validator_total",
+      metricName: "vc_indices_count",
+      jsonType: JsonType.Number,
+      defaultValue: 0,
+    }),
+    validatorActive: new MetricProperty({
+      jsonKey: "validator_active",
+      metricName: "vc_indices_count",
+      jsonType: JsonType.Number,
+      defaultValue: 0,
+    }),
+  };
+}
+
+function createSystemStats(): ClientStats {
+  return {};
+}

--- a/packages/beacon-node/src/monitoring/clientStats.ts
+++ b/packages/beacon-node/src/monitoring/clientStats.ts
@@ -1,19 +1,25 @@
 import {DynamicProperty, MetricProperty, StaticProperty} from "./properties.js";
-import {ClientStats, JsonType, ProcessType} from "./types.js";
+import {Client, ClientStats, JsonType, ProcessType} from "./types.js";
 
 // Definition of client stats based on specification
 // see https://docs.google.com/document/d/1qPWAVRjPCENlyAjUBwGkHMvz9qLdd_6u9DPZcNxDBpc
 
 const CLIENT_STATS_SPEC_VERSION = 1;
 
-export function createClientStats(processes: ProcessType[]): ClientStats[] {
-  const processToStats = {
-    [ProcessType.BeaconNode]: createBeaconNodeStats,
-    [ProcessType.Validator]: createValidatorStats,
-    [ProcessType.System]: createSystemStats,
-  };
+export function createClientStats(client: Client, collectSystemStats?: boolean): ClientStats[] {
+  const clientStats: ClientStats[] = [];
 
-  return processes.map((p) => processToStats[p]());
+  if (client === "beacon") {
+    clientStats.push(createBeaconNodeStats());
+  } else if (client === "validator") {
+    clientStats.push(createValidatorStats());
+  }
+
+  if (collectSystemStats) {
+    clientStats.push(createSystemStats());
+  }
+
+  return clientStats;
 }
 
 function createCommonStats(process: ProcessType): ClientStats {

--- a/packages/beacon-node/src/monitoring/clientStats.ts
+++ b/packages/beacon-node/src/monitoring/clientStats.ts
@@ -38,8 +38,7 @@ function createProcessStats(process: ProcessType): ClientStats {
     ...createCommonStats(process),
     cpuProcessSecondsTotal: new MetricProperty({
       jsonKey: "cpu_process_seconds_total",
-      // TODO: only collected if /metrics API is called?? might be related to counter
-      metricName: "process_cpu_seconds_total",
+      metricName: "process_cpu_user_seconds_total",
       jsonType: JsonType.Number,
       defaultValue: 0,
     }),

--- a/packages/beacon-node/src/monitoring/clientStats.ts
+++ b/packages/beacon-node/src/monitoring/clientStats.ts
@@ -163,5 +163,86 @@ function createValidatorStats(): ClientStats {
 }
 
 function createSystemStats(): ClientStats {
-  return {};
+  return {
+    ...createCommonStats(ProcessType.System),
+    cpuCores: new DynamicProperty({
+      jsonKey: "cpu_cores",
+      provider: () => 0,
+      cacheResult: true,
+    }),
+    cpuThreads: new DynamicProperty({
+      jsonKey: "cpu_threads",
+      provider: () => 0,
+      cacheResult: true,
+    }),
+    cpuNodeSystemSecondsTotal: new DynamicProperty({
+      jsonKey: "cpu_node_system_seconds_total",
+      provider: () => 0,
+    }),
+    cpuNodeUserSecondsTotal: new DynamicProperty({
+      jsonKey: "cpu_node_user_seconds_total",
+      provider: () => 0,
+    }),
+    cpuNodeIOWaitSecondsTotal: new DynamicProperty({
+      jsonKey: "cpu_node_iowait_seconds_total",
+      provider: () => 0,
+    }),
+    cpuNodeIdleSecondsTotal: new DynamicProperty({
+      jsonKey: "cpu_node_idle_seconds_total",
+      provider: () => 0,
+    }),
+    memoryNodeBytesTotal: new DynamicProperty({
+      jsonKey: "memory_node_bytes_total",
+      provider: () => 0,
+      cacheResult: true,
+    }),
+    memoryNodeBytesFree: new DynamicProperty({
+      jsonKey: "memory_node_bytes_free",
+      provider: () => 0,
+    }),
+    memoryNodeBytesCached: new DynamicProperty({
+      jsonKey: "memory_node_bytes_cached",
+      provider: () => 0,
+    }),
+    memoryNodeBytesBuffers: new DynamicProperty({
+      jsonKey: "memory_node_bytes_buffers",
+      provider: () => 0,
+    }),
+    diskNodeBytesTotal: new DynamicProperty({
+      jsonKey: "disk_node_bytes_total",
+      provider: () => 0,
+    }),
+    diskNodeBytesFree: new DynamicProperty({
+      jsonKey: "disk_node_bytes_free",
+      provider: () => 0,
+    }),
+    diskNodeIOSeconds: new DynamicProperty({
+      jsonKey: "disk_node_io_seconds",
+      provider: () => 0,
+    }),
+    diskNodeReadsTotal: new DynamicProperty({
+      jsonKey: "disk_node_reads_total",
+      provider: () => 0,
+    }),
+    diskNodeWritesTotal: new DynamicProperty({
+      jsonKey: "disk_node_writes_total",
+      provider: () => 0,
+    }),
+    networkNodeBytesTotalReceive: new DynamicProperty({
+      jsonKey: "network_node_bytes_total_receive",
+      provider: () => 0,
+    }),
+    networkNodeBytesTotalTransmit: new DynamicProperty({
+      jsonKey: "network_node_bytes_total_transmit",
+      provider: () => 0,
+    }),
+    miscNodeBootTsSeconds: new DynamicProperty({
+      jsonKey: "misc_node_boot_ts_seconds",
+      provider: () => 0,
+    }),
+    miscOs: new DynamicProperty({
+      jsonKey: "misc_os",
+      provider: () => "unk",
+    }),
+  };
 }

--- a/packages/beacon-node/src/monitoring/clientStats.ts
+++ b/packages/beacon-node/src/monitoring/clientStats.ts
@@ -8,7 +8,7 @@ import {ClientStats, JsonType, ProcessType} from "./types.js";
 const CLIENT_STATS_SPEC_VERSION = 1;
 
 export function createClientStats(client: Client, collectSystemStats?: boolean): ClientStats[] {
-  const clientStats: ClientStats[] = [];
+  const clientStats = [];
 
   if (client === "beacon") {
     clientStats.push(createBeaconNodeStats());

--- a/packages/beacon-node/src/monitoring/clientStats.ts
+++ b/packages/beacon-node/src/monitoring/clientStats.ts
@@ -1,8 +1,9 @@
 import {DynamicProperty, MetricProperty, StaticProperty} from "./properties.js";
-import {Client, ClientStats, JsonType, ProcessType} from "./types.js";
+import {Client} from "./service.js";
+import {ClientStats, JsonType, ProcessType} from "./types.js";
 
 // Definition of client stats based on specification
-// see https://docs.google.com/document/d/1qPWAVRjPCENlyAjUBwGkHMvz9qLdd_6u9DPZcNxDBpc
+// See https://docs.google.com/document/d/1qPWAVRjPCENlyAjUBwGkHMvz9qLdd_6u9DPZcNxDBpc
 
 const CLIENT_STATS_SPEC_VERSION = 1;
 

--- a/packages/beacon-node/src/monitoring/clientStats.ts
+++ b/packages/beacon-node/src/monitoring/clientStats.ts
@@ -30,14 +30,17 @@ function createCommonStats(process: ProcessType): ClientStats {
     version: new StaticProperty({
       jsonKey: "version",
       value: CLIENT_STATS_SPEC_VERSION,
+      description: "Client Stats data specification version",
     }),
     timestamp: new DynamicProperty({
       jsonKey: "timestamp",
       provider: Date.now,
+      description: "Unix timestamp in milliseconds",
     }),
     process: new StaticProperty({
       jsonKey: "process",
       value: process,
+      description: "Process type, can be one of: validator, beaconnode, system",
     }),
   };
 }
@@ -50,16 +53,19 @@ function createProcessStats(process: ProcessType): ClientStats {
       metricName: "process_cpu_user_seconds_total",
       jsonType: JsonType.Number,
       defaultValue: 0,
+      description: "CPU seconds consumed by the process",
     }),
     memoryProcessBytes: new MetricProperty({
       jsonKey: "memory_process_bytes",
       metricName: "process_resident_memory_bytes",
       jsonType: JsonType.Number,
       defaultValue: 0,
+      description: "Amount of memory in bytes allocated to the process",
     }),
     clientName: new StaticProperty({
       jsonKey: "client_name",
       value: CLIENT_NAME,
+      description: "Name of client, e.g. lodestar, prysm, lighthouse, teku, nimbus",
     }),
     clientVersion: new MetricProperty({
       jsonKey: "client_version",
@@ -72,18 +78,22 @@ function createProcessStats(process: ProcessType): ClientStats {
       jsonType: JsonType.String,
       cacheResult: true,
       defaultValue: "",
+      description: "Version of client, e.g. 1.3.0/2d0938e",
     }),
     clientBuild: new StaticProperty({
       jsonKey: "client_build",
       value: 0,
+      description: "Incrementing integer representation of build for easier comparison",
     }),
     syncEth2FallbackConfigured: new StaticProperty({
       jsonKey: "sync_eth2_fallback_configured",
       value: false,
+      description: "Whether the client has a fallback eth2 endpoint configured",
     }),
     syncEth2FallbackConnected: new StaticProperty({
       jsonKey: "sync_eth2_fallback_connected",
       value: false,
+      description: "Whether the client is currently connected to a fallback eth2 endpoint",
     }),
   };
 }
@@ -94,6 +104,7 @@ function createBeaconNodeStats(): ClientStats {
     diskBeaconChainBytesTotal: new StaticProperty({
       jsonKey: "disk_beaconchain_bytes_total",
       value: 0,
+      description: "Amount of bytes consumed on disk by the beacon node's database",
     }),
     networkLibp2pBytesTotalReceive: new MetricProperty({
       jsonKey: "network_libp2p_bytes_total_receive",
@@ -101,6 +112,7 @@ function createBeaconNodeStats(): ClientStats {
       withLabel: {name: "protocol", value: "global received"},
       jsonType: JsonType.Number,
       defaultValue: 0,
+      description: "Number of bytes received via libp2p traffic",
     }),
     networkLibp2pBytesTotalTransmit: new MetricProperty({
       jsonKey: "network_libp2p_bytes_total_transmit",
@@ -108,18 +120,21 @@ function createBeaconNodeStats(): ClientStats {
       withLabel: {name: "protocol", value: "global sent"},
       jsonType: JsonType.Number,
       defaultValue: 0,
+      description: "Number of bytes transmitted via libp2p traffic",
     }),
     networkPeersConnected: new MetricProperty({
       jsonKey: "network_peers_connected",
       metricName: "libp2p_peers",
       jsonType: JsonType.Number,
       defaultValue: 0,
+      description: "Number of connected peers",
     }),
     syncEth1Connected: new MetricProperty({
       jsonKey: "sync_eth1_connected",
       metricName: "lodestar_execution_engine_http_client_config_urls_count",
       jsonType: JsonType.Boolean,
       defaultValue: false,
+      description: "Whether the beacon node is connected to a eth1 node",
     }),
     syncEth2Synced: new MetricProperty({
       jsonKey: "sync_eth2_synced",
@@ -127,12 +142,14 @@ function createBeaconNodeStats(): ClientStats {
       rangeValue: 3,
       jsonType: JsonType.Boolean,
       defaultValue: true,
+      description: "Whether the beacon node is in sync with the beacon chain network",
     }),
     syncBeaconHeadSlot: new MetricProperty({
       jsonKey: "sync_beacon_head_slot",
       metricName: "beacon_head_slot",
       jsonType: JsonType.Number,
       defaultValue: 0,
+      description: "Slot of the head block of the beacon chain",
     }),
     syncEth1FallbackConfigured: new MetricProperty({
       jsonKey: "sync_eth1_fallback_configured",
@@ -140,14 +157,17 @@ function createBeaconNodeStats(): ClientStats {
       threshold: 2,
       jsonType: JsonType.Boolean,
       defaultValue: false,
+      description: "Whether the beacon node has a fallback eth1 endpoint configured",
     }),
     syncEth1FallbackConnected: new StaticProperty({
       jsonKey: "sync_eth1_fallback_connected",
       value: false,
+      description: "Whether the beacon node is currently connected to a fallback eth1 endpoint",
     }),
     slasherActive: new StaticProperty({
       jsonKey: "slasher_active",
       value: false,
+      description: "Whether slasher functionality is enabled",
     }),
   };
 }
@@ -160,12 +180,14 @@ function createValidatorStats(): ClientStats {
       metricName: "vc_indices_count",
       jsonType: JsonType.Number,
       defaultValue: 0,
+      description: "Number of validator keys in use",
     }),
     validatorActive: new MetricProperty({
       jsonKey: "validator_active",
       metricName: "vc_indices_count",
       jsonType: JsonType.Number,
       defaultValue: 0,
+      description: "Number of validator keys that are currently active",
     }),
   };
 }
@@ -177,80 +199,99 @@ function createSystemStats(): ClientStats {
       jsonKey: "cpu_cores",
       provider: () => 0,
       cacheResult: true,
+      description: "Number of CPU cores available",
     }),
     cpuThreads: new DynamicProperty({
       jsonKey: "cpu_threads",
       provider: () => 0,
       cacheResult: true,
+      description: "Number of CPU threads available",
     }),
     cpuNodeSystemSecondsTotal: new DynamicProperty({
       jsonKey: "cpu_node_system_seconds_total",
       provider: () => 0,
+      description: "CPU seconds consumed by all processes",
     }),
     cpuNodeUserSecondsTotal: new DynamicProperty({
       jsonKey: "cpu_node_user_seconds_total",
       provider: () => 0,
+      description: "CPU seconds consumed by user processes",
     }),
     cpuNodeIOWaitSecondsTotal: new DynamicProperty({
       jsonKey: "cpu_node_iowait_seconds_total",
       provider: () => 0,
+      description: "CPU seconds spent in I/O wait state",
     }),
     cpuNodeIdleSecondsTotal: new DynamicProperty({
       jsonKey: "cpu_node_idle_seconds_total",
       provider: () => 0,
+      description: "CPU seconds spent in idle state",
     }),
     memoryNodeBytesTotal: new DynamicProperty({
       jsonKey: "memory_node_bytes_total",
       provider: () => 0,
       cacheResult: true,
+      description: "Total amount of memory in bytes available",
     }),
     memoryNodeBytesFree: new DynamicProperty({
       jsonKey: "memory_node_bytes_free",
       provider: () => 0,
+      description: "Amount of free memory in bytes",
     }),
     memoryNodeBytesCached: new DynamicProperty({
       jsonKey: "memory_node_bytes_cached",
       provider: () => 0,
+      description: "Amount of memory in bytes used by cache",
     }),
     memoryNodeBytesBuffers: new DynamicProperty({
       jsonKey: "memory_node_bytes_buffers",
       provider: () => 0,
+      description: "Amount of memory in bytes used by buffers",
     }),
     diskNodeBytesTotal: new DynamicProperty({
       jsonKey: "disk_node_bytes_total",
       provider: () => 0,
+      description: "Total amount of available disk space in bytes",
     }),
     diskNodeBytesFree: new DynamicProperty({
       jsonKey: "disk_node_bytes_free",
       provider: () => 0,
+      description: "Amount of free disk space in bytes",
     }),
     diskNodeIOSeconds: new DynamicProperty({
       jsonKey: "disk_node_io_seconds",
       provider: () => 0,
+      description: "Total time spent in seconds on disk I/O operations",
     }),
     diskNodeReadsTotal: new DynamicProperty({
       jsonKey: "disk_node_reads_total",
       provider: () => 0,
+      description: "Total amount of bytes read from disk",
     }),
     diskNodeWritesTotal: new DynamicProperty({
       jsonKey: "disk_node_writes_total",
       provider: () => 0,
+      description: "Total amount of bytes written to disk",
     }),
     networkNodeBytesTotalReceive: new DynamicProperty({
       jsonKey: "network_node_bytes_total_receive",
       provider: () => 0,
+      description: "Total amount of bytes received over the network",
     }),
     networkNodeBytesTotalTransmit: new DynamicProperty({
       jsonKey: "network_node_bytes_total_transmit",
       provider: () => 0,
+      description: "Total amount of bytes transmitted over the network",
     }),
     miscNodeBootTsSeconds: new DynamicProperty({
       jsonKey: "misc_node_boot_ts_seconds",
       provider: () => 0,
+      description: "Unix timestamp in seconds of boot time",
     }),
     miscOs: new DynamicProperty({
       jsonKey: "misc_os",
       provider: () => "unk",
+      description: "Operating system, can be one of: lin, win, mac, unk for unknown",
     }),
   };
 }

--- a/packages/beacon-node/src/monitoring/clientStats.ts
+++ b/packages/beacon-node/src/monitoring/clientStats.ts
@@ -7,6 +7,8 @@ import {ClientStats, JsonType, ProcessType} from "./types.js";
 
 const CLIENT_STATS_SPEC_VERSION = 1;
 
+const CLIENT_NAME = "lodestar";
+
 export function createClientStats(client: Client, collectSystemStats?: boolean): ClientStats[] {
   const clientStats = [];
 
@@ -57,7 +59,7 @@ function createProcessStats(process: ProcessType): ClientStats {
     }),
     clientName: new StaticProperty({
       jsonKey: "client_name",
-      value: "lodestar",
+      value: CLIENT_NAME,
     }),
     clientVersion: new MetricProperty({
       jsonKey: "client_version",

--- a/packages/beacon-node/src/monitoring/clientStats.ts
+++ b/packages/beacon-node/src/monitoring/clientStats.ts
@@ -115,9 +115,11 @@ function createBeaconNodeStats(): ClientStats {
       jsonType: JsonType.Number,
       defaultValue: 0,
     }),
-    syncEth1Connected: new StaticProperty({
+    syncEth1Connected: new MetricProperty({
       jsonKey: "sync_eth1_connected",
-      value: true,
+      metricName: "lodestar_execution_engine_http_client_config_urls_count",
+      jsonType: JsonType.Boolean,
+      defaultValue: false,
     }),
     syncEth2Synced: new MetricProperty({
       jsonKey: "sync_eth2_synced",
@@ -132,9 +134,12 @@ function createBeaconNodeStats(): ClientStats {
       jsonType: JsonType.Number,
       defaultValue: 0,
     }),
-    syncEth1FallbackConfigured: new StaticProperty({
+    syncEth1FallbackConfigured: new MetricProperty({
       jsonKey: "sync_eth1_fallback_configured",
-      value: false,
+      metricName: "lodestar_execution_engine_http_client_config_urls_count",
+      threshold: 2,
+      jsonType: JsonType.Boolean,
+      defaultValue: false,
     }),
     syncEth1FallbackConnected: new StaticProperty({
       jsonKey: "sync_eth1_fallback_connected",

--- a/packages/beacon-node/src/monitoring/index.ts
+++ b/packages/beacon-node/src/monitoring/index.ts
@@ -1,3 +1,2 @@
 export * from "./options.js";
 export {MonitoringService} from "./service.js";
-export {ProcessType} from "./types.js";

--- a/packages/beacon-node/src/monitoring/index.ts
+++ b/packages/beacon-node/src/monitoring/index.ts
@@ -1,0 +1,3 @@
+export * from "./options.js";
+export {MonitoringService} from "./service.js";
+export {ProcessType} from "./types.js";

--- a/packages/beacon-node/src/monitoring/options.ts
+++ b/packages/beacon-node/src/monitoring/options.ts
@@ -1,0 +1,13 @@
+import {MONITORING_UPDATE_INTERVAL_SECONDS} from "./service.js";
+
+export type MonitoringOptions = {
+  /** Remote endpoint where client stats are sent */
+  endpoint: string;
+  /** Interval in seconds between sending client stats */
+  interval?: number;
+};
+
+export const defaultMonitoringOptions: MonitoringOptions = {
+  endpoint: "",
+  interval: MONITORING_UPDATE_INTERVAL_SECONDS,
+};

--- a/packages/beacon-node/src/monitoring/options.ts
+++ b/packages/beacon-node/src/monitoring/options.ts
@@ -7,6 +7,8 @@ export type MonitoringOptions = {
   initialDelay?: number;
   /** Timeout in seconds for sending client stats */
   requestTimeout?: number;
+  /** Enable collecting system stats */
+  collectSystemStats?: boolean;
 };
 
 export const defaultMonitoringOptions: Required<MonitoringOptions> = {
@@ -14,4 +16,5 @@ export const defaultMonitoringOptions: Required<MonitoringOptions> = {
   interval: 60,
   initialDelay: 30,
   requestTimeout: 30,
+  collectSystemStats: true,
 };

--- a/packages/beacon-node/src/monitoring/options.ts
+++ b/packages/beacon-node/src/monitoring/options.ts
@@ -5,10 +5,13 @@ export type MonitoringOptions = {
   interval?: number;
   /** Initial delay in seconds before client stats are sent */
   initialDelay?: number;
+  /** Timeout in seconds for sending client stats */
+  requestTimeout?: number;
 };
 
 export const defaultMonitoringOptions: Required<MonitoringOptions> = {
   endpoint: "",
   interval: 60,
   initialDelay: 30,
+  requestTimeout: 30,
 };

--- a/packages/beacon-node/src/monitoring/options.ts
+++ b/packages/beacon-node/src/monitoring/options.ts
@@ -1,13 +1,14 @@
-import {MONITORING_UPDATE_INTERVAL_SECONDS} from "./service.js";
-
 export type MonitoringOptions = {
-  /** Remote endpoint where client stats are sent */
+  /** Remote endpoint URL where client stats are sent */
   endpoint: string;
   /** Interval in seconds between sending client stats */
   interval?: number;
+  /** Initial delay in seconds before client stats are sent */
+  initialDelay?: number;
 };
 
-export const defaultMonitoringOptions: MonitoringOptions = {
+export const defaultMonitoringOptions: Required<MonitoringOptions> = {
   endpoint: "",
-  interval: MONITORING_UPDATE_INTERVAL_SECONDS,
+  interval: 60,
+  initialDelay: 30,
 };

--- a/packages/beacon-node/src/monitoring/options.ts
+++ b/packages/beacon-node/src/monitoring/options.ts
@@ -1,11 +1,11 @@
 export type MonitoringOptions = {
   /** Remote endpoint URL where client stats are sent */
   endpoint: string;
-  /** Interval in seconds between sending client stats */
+  /** Interval in milliseconds between sending client stats */
   interval?: number;
-  /** Initial delay in seconds before client stats are sent */
+  /** Initial delay in milliseconds before client stats are sent */
   initialDelay?: number;
-  /** Timeout in seconds for sending client stats */
+  /** Timeout in milliseconds for sending client stats */
   requestTimeout?: number;
   /** Enable collecting system stats */
   collectSystemStats?: boolean;
@@ -13,8 +13,8 @@ export type MonitoringOptions = {
 
 export const defaultMonitoringOptions: Required<MonitoringOptions> = {
   endpoint: "",
-  interval: 60,
-  initialDelay: 30,
-  requestTimeout: 10,
+  interval: 60_000,
+  initialDelay: 30_000,
+  requestTimeout: 10_000,
   collectSystemStats: true,
 };

--- a/packages/beacon-node/src/monitoring/options.ts
+++ b/packages/beacon-node/src/monitoring/options.ts
@@ -15,6 +15,6 @@ export const defaultMonitoringOptions: Required<MonitoringOptions> = {
   endpoint: "",
   interval: 60,
   initialDelay: 30,
-  requestTimeout: 30,
+  requestTimeout: 10,
   collectSystemStats: true,
 };

--- a/packages/beacon-node/src/monitoring/properties.ts
+++ b/packages/beacon-node/src/monitoring/properties.ts
@@ -1,0 +1,142 @@
+import {Registry} from "prom-client";
+import {JsonRecord, JsonType, MetricObject, MetricValue, MetricWithGetter, RecordValue} from "./types.js";
+
+interface PropertyDefinition {
+  /** Key of value to be sent to remote server */
+  jsonKey: string;
+}
+
+interface StaticPropertyDefinition<T extends RecordValue> extends PropertyDefinition {
+  /** Static value */
+  value: T;
+}
+
+interface DynamicPropertyDefinition<T extends RecordValue> extends PropertyDefinition {
+  /** Value provider function */
+  provider: () => T | Promise<T>;
+  /** Only call provider once and then use cached value */
+  cacheResult?: boolean;
+}
+
+interface MetricPropertyDefinition<T extends RecordValue> extends PropertyDefinition {
+  /** Type of value to be sent to remote server */
+  jsonType: JsonType;
+  /** Name of the metric */
+  metricName: string;
+  /** Get value from metric with label */
+  withLabel?: {name: string; value: string};
+  /** Get value from label instead of metric value */
+  fromLabel?: string;
+  /** Range value to evaluate to true */
+  rangeValue?: number;
+  /** Function to format retrieved metric value */
+  formatter?: (value: MetricValue) => MetricValue;
+  /** Only fetch metric once and then use cached value */
+  cacheResult?: boolean;
+  /** Default value if metric does not exist */
+  defaultValue: T;
+}
+
+export interface ClientStatsProperty<T extends RecordValue> {
+  getRecord(register: Registry): JsonRecord<T> | Promise<JsonRecord<T>>;
+}
+
+export class StaticProperty<T extends RecordValue> implements ClientStatsProperty<T> {
+  constructor(private readonly definition: StaticPropertyDefinition<T>) {}
+
+  getRecord(): JsonRecord<T> {
+    return {key: this.definition.jsonKey, value: this.definition.value};
+  }
+}
+
+export class DynamicProperty<T extends RecordValue> implements ClientStatsProperty<T> {
+  private cachedValue?: T;
+
+  constructor(private readonly definition: DynamicPropertyDefinition<T>) {}
+
+  async getRecord(): Promise<JsonRecord<T>> {
+    if (this.cachedValue != null) {
+      return {key: this.definition.jsonKey, value: this.cachedValue};
+    }
+
+    const value = await this.definition.provider();
+
+    if (this.definition.cacheResult) {
+      this.cachedValue = value;
+    }
+
+    return {key: this.definition.jsonKey, value};
+  }
+}
+
+export class MetricProperty<T extends RecordValue> implements ClientStatsProperty<T> {
+  private cachedValue?: T;
+
+  constructor(private readonly definition: MetricPropertyDefinition<T>) {}
+
+  async getRecord(register: Registry): Promise<JsonRecord<T>> {
+    if (this.cachedValue != null) {
+      return {key: this.definition.jsonKey, value: this.cachedValue};
+    }
+
+    const metric = register.getSingleMetric(this.definition.metricName);
+
+    if (metric) {
+      const metricObject = await (metric as MetricWithGetter).get();
+
+      const metricValue = this.extractMetricValue(metricObject);
+
+      if (metricValue != null) {
+        const formattedValue = this.formatMetricValue(metricValue);
+
+        const typedValue = this.convertMetricValue(formattedValue) as T;
+
+        if (this.definition.cacheResult) {
+          this.cachedValue = typedValue;
+        }
+
+        return {key: this.definition.jsonKey, value: typedValue};
+      }
+    }
+
+    return {key: this.definition.jsonKey, value: this.definition.defaultValue};
+  }
+
+  private extractMetricValue(metricObject: MetricObject): MetricValue | undefined {
+    const {withLabel, fromLabel} = this.definition;
+
+    if (withLabel) {
+      // get value from metric with specific label, e.g. protocol="global received"
+      return metricObject.values.find((v) => v.labels[withLabel.name] === withLabel.value)?.value;
+    }
+
+    if (fromLabel) {
+      // get value from label, e.g. lodestar_version{version="v1.3.0/2d0938e"} => v1.3.0/2d0938e
+      return metricObject.values[0].labels[fromLabel];
+    }
+
+    // metric value e.g. beacon_head_slot 5603174 => 5603174
+    return metricObject.values[0].value;
+  }
+
+  private formatMetricValue(value: MetricValue): MetricValue {
+    if (!this.definition.formatter) {
+      return value;
+    }
+    return this.definition.formatter(value);
+  }
+
+  private convertMetricValue(value: MetricValue): RecordValue {
+    if (typeof value === "number") {
+      switch (this.definition.jsonType) {
+        case JsonType.String:
+          return value.toString();
+        case JsonType.Number:
+          return Math.round(value);
+        case JsonType.Boolean:
+          return this.definition.rangeValue != null ? value === this.definition.rangeValue : value > 0;
+      }
+    }
+    return value;
+  }
+}

--- a/packages/beacon-node/src/monitoring/properties.ts
+++ b/packages/beacon-node/src/monitoring/properties.ts
@@ -38,11 +38,13 @@ interface MetricPropertyDefinition<T extends RecordValue> extends PropertyDefini
 }
 
 export interface ClientStatsProperty<T extends RecordValue> {
+  readonly definition: PropertyDefinition;
+
   getRecord(register: Registry): JsonRecord<T> | Promise<JsonRecord<T>>;
 }
 
 export class StaticProperty<T extends RecordValue> implements ClientStatsProperty<T> {
-  constructor(private readonly definition: StaticPropertyDefinition<T>) {}
+  constructor(readonly definition: StaticPropertyDefinition<T>) {}
 
   getRecord(): JsonRecord<T> {
     return {key: this.definition.jsonKey, value: this.definition.value};
@@ -52,7 +54,7 @@ export class StaticProperty<T extends RecordValue> implements ClientStatsPropert
 export class DynamicProperty<T extends RecordValue> implements ClientStatsProperty<T> {
   private cachedValue?: T;
 
-  constructor(private readonly definition: DynamicPropertyDefinition<T>) {}
+  constructor(readonly definition: DynamicPropertyDefinition<T>) {}
 
   async getRecord(): Promise<JsonRecord<T>> {
     if (this.cachedValue != null) {
@@ -72,7 +74,7 @@ export class DynamicProperty<T extends RecordValue> implements ClientStatsProper
 export class MetricProperty<T extends RecordValue> implements ClientStatsProperty<T> {
   private cachedValue?: T;
 
-  constructor(private readonly definition: MetricPropertyDefinition<T>) {}
+  constructor(readonly definition: MetricPropertyDefinition<T>) {}
 
   async getRecord(register: Registry): Promise<JsonRecord<T>> {
     if (this.cachedValue != null) {

--- a/packages/beacon-node/src/monitoring/properties.ts
+++ b/packages/beacon-node/src/monitoring/properties.ts
@@ -29,6 +29,8 @@ interface MetricPropertyDefinition<T extends RecordValue> extends PropertyDefini
   fromLabel?: string;
   /** Range value to evaluate to true */
   rangeValue?: number;
+  /** Evaluate to true if value is greater than or equal to threshold */
+  threshold?: number;
   /** Function to format retrieved metric value */
   formatter?: (value: MetricValue) => MetricValue;
   /** Only fetch metric once and then use cached value */
@@ -136,7 +138,13 @@ export class MetricProperty<T extends RecordValue> implements ClientStatsPropert
         case JsonType.Number:
           return Math.round(value);
         case JsonType.Boolean:
-          return this.definition.rangeValue != null ? value === this.definition.rangeValue : value > 0;
+          if (this.definition.rangeValue != null) {
+            return value === this.definition.rangeValue;
+          } else if (this.definition.threshold != null) {
+            return value >= this.definition.threshold;
+          } else {
+            return value > 0;
+          }
       }
     }
     return value;

--- a/packages/beacon-node/src/monitoring/properties.ts
+++ b/packages/beacon-node/src/monitoring/properties.ts
@@ -2,7 +2,7 @@ import {Registry} from "prom-client";
 import {JsonRecord, JsonType, MetricObject, MetricValue, MetricWithGetter, RecordValue} from "./types.js";
 
 interface PropertyDefinition {
-  /** Key of value to be sent to remote server */
+  /** Key of value to be sent to remote service */
   jsonKey: string;
 }
 
@@ -19,7 +19,7 @@ interface DynamicPropertyDefinition<T extends RecordValue> extends PropertyDefin
 }
 
 interface MetricPropertyDefinition<T extends RecordValue> extends PropertyDefinition {
-  /** Type of value to be sent to remote server */
+  /** Type of value to be sent to remote service */
   jsonType: JsonType;
   /** Name of the metric */
   metricName: string;

--- a/packages/beacon-node/src/monitoring/properties.ts
+++ b/packages/beacon-node/src/monitoring/properties.ts
@@ -4,6 +4,8 @@ import {JsonRecord, JsonType, MetricObject, MetricValue, MetricWithGetter, Recor
 interface PropertyDefinition {
   /** Key of value to be sent to remote service */
   jsonKey: string;
+  /** Description of the property */
+  description?: string;
 }
 
 interface StaticPropertyDefinition<T extends RecordValue> extends PropertyDefinition {

--- a/packages/beacon-node/src/monitoring/properties.ts
+++ b/packages/beacon-node/src/monitoring/properties.ts
@@ -14,7 +14,7 @@ interface StaticPropertyDefinition<T extends RecordValue> extends PropertyDefini
 interface DynamicPropertyDefinition<T extends RecordValue> extends PropertyDefinition {
   /** Value provider function */
   provider: () => T | Promise<T>;
-  /** Only call provider once and then use cached value */
+  /** Only call provider function once and then use cached value */
   cacheResult?: boolean;
 }
 

--- a/packages/beacon-node/src/monitoring/service.ts
+++ b/packages/beacon-node/src/monitoring/service.ts
@@ -85,7 +85,7 @@ export class MonitoringService {
             throw new Error(error.status);
           }
 
-          this.logger.debug(`Sent client stats to ${this.remoteHost}: ${JSON.stringify(data)}`);
+          this.logger.debug(`Sent client stats to ${this.remoteHost}`, {data: JSON.stringify(data)});
         } catch (e) {
           this.logger.error(`Failed to send client stats to ${this.remoteHost}`, {}, e as Error);
         } finally {
@@ -159,19 +159,17 @@ export class MonitoringService {
     }
 
     try {
-      const remoteServerUrl = new URL(endpoint);
+      const url = new URL(endpoint);
 
-      if (!["http:", "https:"].includes(remoteServerUrl.protocol)) {
-        throw new Error();
-      }
-
-      if (remoteServerUrl.protocol === "http:") {
+      if (url.protocol === "http:") {
         this.logger.warn(
           "Insecure monitoring endpoint, please make sure to always use a HTTPS connection in production"
         );
+      } else if (url.protocol !== "https:") {
+        throw new Error();
       }
 
-      return remoteServerUrl;
+      return url;
     } catch {
       throw new Error("Monitoring endpoint must be a valid URL");
     }

--- a/packages/beacon-node/src/monitoring/service.ts
+++ b/packages/beacon-node/src/monitoring/service.ts
@@ -1,0 +1,114 @@
+import {Registry} from "prom-client";
+import {ILogger, sleep} from "@lodestar/utils";
+import {MonitoringOptions} from "./options.js";
+import {createClientStats} from "./clientStats.js";
+import {ProcessType} from "./types.js";
+
+/** Interval between sending client stats */
+export const MONITORING_UPDATE_INTERVAL_SECONDS = 60;
+
+/** Initial delay before client stats are sent */
+export const MONITORING_INITIAL_DELAY_SECONDS = 30;
+
+type MonitoringData = Record<string, string | number | boolean>;
+
+type RemoteServerError = {
+  status: string;
+  data: null;
+};
+
+/**
+ * Service for sending clients stats to a remote server (e.g. beaconcha.in)
+ */
+export class MonitoringService {
+  private readonly register: Registry;
+  private readonly logger: ILogger;
+
+  private sendDataInterval?: NodeJS.Timeout;
+
+  constructor(
+    private readonly processes: ProcessType[],
+    private readonly opts: MonitoringOptions,
+    {register, logger}: {register: Registry; logger: ILogger}
+  ) {
+    if (!opts.endpoint) {
+      throw new Error("Monitoring endpoint must be provided");
+    }
+
+    // TODO: validate if URL is properly formatted?
+
+    this.logger = logger;
+    this.register = register;
+  }
+
+  start(delaySeconds = MONITORING_INITIAL_DELAY_SECONDS): void {
+    if (this.sendDataInterval) {
+      throw new Error("Monitoring service is already started");
+    }
+
+    const {endpoint, interval} = this.opts;
+    const updateInterval = interval ?? MONITORING_UPDATE_INTERVAL_SECONDS;
+
+    sleep(delaySeconds * 1000).finally(async () => {
+      await this.sendData();
+
+      this.sendDataInterval = setInterval(async () => {
+        await this.sendData();
+      }, updateInterval * 1000);
+    });
+
+    // TODO: endpoint contains sensitive API key and should probably not be logged
+    this.logger.info("Started monitoring service", {endpoint, interval: `${updateInterval}s`});
+  }
+
+  stop(): void {
+    if (this.sendDataInterval) {
+      clearInterval(this.sendDataInterval);
+      this.sendDataInterval = undefined;
+    }
+  }
+
+  private async sendData(): Promise<void> {
+    try {
+      const data = await this.collectData();
+
+      // TODO: add AbortController? see JsonRpcHttpCLient
+      const res = await fetch(this.opts.endpoint, {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify(data),
+      });
+
+      if (!res.ok) {
+        const error = (await res.json()) as RemoteServerError;
+        this.logger.error(error.status);
+      } else {
+        this.logger.info(`Sent client stats to remote server: ${JSON.stringify(data)}`);
+      }
+    } catch (e) {
+      this.logger.error("Error sending client stats", {}, e as Error);
+    }
+  }
+
+  private async collectData(): Promise<MonitoringData[]> {
+    const stats = createClientStats(this.processes);
+    const data: MonitoringData[] = [];
+
+    const recordPromises = [];
+
+    for (const [i, s] of stats.entries()) {
+      data[i] = {};
+
+      recordPromises.push(
+        ...Object.values(s).map(async (property) => {
+          const record = await property.getRecord(this.register);
+          data[i][record.key] = record.value;
+        })
+      );
+    }
+
+    await Promise.all(recordPromises);
+
+    return data;
+  }
+}

--- a/packages/beacon-node/src/monitoring/service.ts
+++ b/packages/beacon-node/src/monitoring/service.ts
@@ -1,5 +1,5 @@
 import {Registry} from "prom-client";
-import {ILogger, sleep} from "@lodestar/utils";
+import {ErrorAborted, ILogger, sleep, TimeoutError} from "@lodestar/utils";
 import {defaultMonitoringOptions, MonitoringOptions} from "./options.js";
 import {createClientStats} from "./clientStats.js";
 import {ProcessType} from "./types.js";
@@ -10,6 +10,11 @@ type RemoteServerError = {
   status: string;
   data: null;
 };
+
+enum FetchAbortReason {
+  Stop = "stop",
+  Timeout = "timeout",
+}
 
 /**
  * Service for sending clients stats to a remote server (e.g. beaconcha.in)
@@ -22,6 +27,7 @@ export class MonitoringService {
   private readonly logger: ILogger;
 
   private sendDataInterval?: NodeJS.Timeout;
+  private fetchAbortController?: AbortController;
 
   constructor(
     private readonly processes: ProcessType[],
@@ -60,18 +66,17 @@ export class MonitoringService {
       clearInterval(this.sendDataInterval);
       this.sendDataInterval = undefined;
     }
+    if (this.fetchAbortController) {
+      this.fetchAbortController.abort(FetchAbortReason.Stop);
+      this.fetchAbortController = undefined;
+    }
   }
 
   private async sendData(): Promise<void> {
     try {
       const data = await this.collectData();
 
-      // TODO: add AbortController? see JsonRpcHttpCLient
-      const res = await fetch(this.remoteServerUrl, {
-        method: "POST",
-        headers: {"Content-Type": "application/json"},
-        body: JSON.stringify(data),
-      });
+      const res = await this.fetchRemoteServerUrl(this.remoteServerUrl, data);
 
       if (!res.ok) {
         const error = (await res.json()) as RemoteServerError;
@@ -104,6 +109,41 @@ export class MonitoringService {
     await Promise.all(recordPromises);
 
     return data;
+  }
+
+  private async fetchRemoteServerUrl(url: URL, data: MonitoringData[]): Promise<Response> {
+    this.fetchAbortController = new AbortController();
+
+    const timeout = setTimeout(
+      () => this.fetchAbortController?.abort(FetchAbortReason.Timeout),
+      this.options.requestTimeout * 1000
+    );
+
+    try {
+      return await fetch(url, {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify(data),
+        signal: this.fetchAbortController.signal,
+      });
+    } catch (e) {
+      const {signal} = this.fetchAbortController;
+
+      if (signal.aborted) {
+        if (signal.reason === FetchAbortReason.Stop) {
+          throw new ErrorAborted("fetch");
+        } else if (signal.reason === FetchAbortReason.Timeout) {
+          throw new TimeoutError("fetch");
+        } else {
+          throw e;
+        }
+      } else {
+        throw e;
+      }
+    } finally {
+      clearTimeout(timeout);
+      this.fetchAbortController = undefined;
+    }
   }
 
   private parseMonitoringEndpoint(endpoint: string): URL {

--- a/packages/beacon-node/src/monitoring/service.ts
+++ b/packages/beacon-node/src/monitoring/service.ts
@@ -60,7 +60,7 @@ export class MonitoringService {
       name: "lodestar_monitoring_send_data_seconds",
       help: "Time spent to send monitoring data to remote service in seconds",
       labelNames: ["status"],
-      buckets: [0.1, 0.5, 1, 10, this.options.requestTimeout],
+      buckets: [0.1, 0.3, 0.5, 1, 10, this.options.requestTimeout],
     });
   }
 

--- a/packages/beacon-node/src/monitoring/service.ts
+++ b/packages/beacon-node/src/monitoring/service.ts
@@ -17,7 +17,7 @@ enum FetchAbortReason {
 }
 
 /**
- * Service for sending clients stats to a remote server (e.g. beaconcha.in)
+ * Service for sending clients stats to a remote service (e.g. beaconcha.in)
  */
 export class MonitoringService {
   private readonly clientStats: ClientStats[];

--- a/packages/beacon-node/src/monitoring/service.ts
+++ b/packages/beacon-node/src/monitoring/service.ts
@@ -79,7 +79,7 @@ export class MonitoringService {
     if (this.status === Status.Started) return;
     this.status = Status.Started;
 
-    const {interval, initialDelay, requestTimeout, collectSystemStats} = this.options;
+    const {interval, initialDelay} = this.options;
 
     this.initialDelayTimeout = setTimeout(async () => {
       await this.send();
@@ -92,10 +92,7 @@ export class MonitoringService {
     this.logger.info("Started monitoring service", {
       remote: this.remoteServiceHost,
       machine: this.remoteServiceUrl.searchParams.get("machine"),
-      interval: `${interval}ms`,
-      initialDelay: `${initialDelay}ms`,
-      requestTimeout: `${requestTimeout}ms`,
-      collectSystemStats,
+      interval,
     });
   }
 

--- a/packages/beacon-node/src/monitoring/service.ts
+++ b/packages/beacon-node/src/monitoring/service.ts
@@ -82,6 +82,7 @@ export class MonitoringService {
 
     this.logger.info("Started monitoring service", {
       remote: this.remoteServiceHost,
+      machine: this.remoteServiceUrl.searchParams.get("machine"),
       interval: `${interval}s`,
       initialDelay: `${initialDelay}s`,
       requestTimeout: `${requestTimeout}s`,

--- a/packages/beacon-node/src/monitoring/service.ts
+++ b/packages/beacon-node/src/monitoring/service.ts
@@ -2,7 +2,7 @@ import {Registry} from "prom-client";
 import {ErrorAborted, ILogger, sleep, TimeoutError} from "@lodestar/utils";
 import {defaultMonitoringOptions, MonitoringOptions} from "./options.js";
 import {createClientStats} from "./clientStats.js";
-import {Client, ClientStats} from "./types.js";
+import {ClientStats} from "./types.js";
 
 type MonitoringData = Record<string, string | number | boolean>;
 
@@ -15,6 +15,8 @@ enum FetchAbortReason {
   Stop = "stop",
   Timeout = "timeout",
 }
+
+export type Client = "beacon" | "validator";
 
 /**
  * Service for sending clients stats to a remote service (e.g. beaconcha.in)

--- a/packages/beacon-node/src/monitoring/service.ts
+++ b/packages/beacon-node/src/monitoring/service.ts
@@ -62,7 +62,7 @@ export class MonitoringService {
       name: "lodestar_monitoring_send_data_seconds",
       help: "Time spent to send monitoring data to remote service in seconds",
       labelNames: ["status"],
-      buckets: [0.3, 0.5, 1, this.options.requestTimeout],
+      buckets: [0.3, 0.5, 1, Math.floor(this.options.requestTimeout / 1000)],
     });
   }
 
@@ -82,15 +82,15 @@ export class MonitoringService {
 
       this.monitoringInterval = setInterval(async () => {
         await this.send();
-      }, interval * 1000);
-    }, initialDelay * 1000);
+      }, interval);
+    }, initialDelay);
 
     this.logger.info("Started monitoring service", {
       remote: this.remoteServiceHost,
       machine: this.remoteServiceUrl.searchParams.get("machine"),
-      interval: `${interval}s`,
-      initialDelay: `${initialDelay}s`,
-      requestTimeout: `${requestTimeout}s`,
+      interval: `${interval}ms`,
+      initialDelay: `${initialDelay}ms`,
+      requestTimeout: `${requestTimeout}ms`,
       collectSystemStats,
     });
   }
@@ -167,7 +167,7 @@ export class MonitoringService {
 
     const timeout = setTimeout(
       () => this.fetchAbortController?.abort(FetchAbortReason.Timeout),
-      this.options.requestTimeout * 1000
+      this.options.requestTimeout
     );
 
     let res: Response | undefined;
@@ -193,7 +193,7 @@ export class MonitoringService {
       if (signal.reason === FetchAbortReason.Stop) {
         throw new ErrorAborted(`request to ${this.remoteServiceHost}`);
       } else if (signal.reason === FetchAbortReason.Timeout) {
-        throw new TimeoutError(`reached of request to ${this.remoteServiceHost}`);
+        throw new TimeoutError(`reached for request to ${this.remoteServiceHost}`);
       } else {
         throw e;
       }

--- a/packages/beacon-node/src/monitoring/service.ts
+++ b/packages/beacon-node/src/monitoring/service.ts
@@ -46,17 +46,22 @@ export class MonitoringService {
       return;
     }
 
-    sleep(this.options.initialDelay * 1000).finally(async () => {
+    const {interval, initialDelay, requestTimeout, collectSystemStats} = this.options;
+
+    sleep(initialDelay * 1000).finally(async () => {
       await this.sendData();
 
       this.sendDataInterval = setInterval(async () => {
         await this.sendData();
-      }, this.options.interval * 1000);
+      }, interval * 1000);
     });
 
     this.logger.info("Started monitoring service", {
       remote: this.remoteHost,
-      interval: `${this.options.interval}s`,
+      interval: `${interval}s`,
+      initialDelay: `${initialDelay}s`,
+      requestTimeout: `${requestTimeout}s`,
+      collectSystemStats,
     });
   }
 

--- a/packages/beacon-node/src/monitoring/types.ts
+++ b/packages/beacon-node/src/monitoring/types.ts
@@ -30,3 +30,5 @@ export enum JsonType {
   Number,
   Boolean,
 }
+
+export type Client = "beacon" | "validator";

--- a/packages/beacon-node/src/monitoring/types.ts
+++ b/packages/beacon-node/src/monitoring/types.ts
@@ -1,0 +1,32 @@
+import {Metric} from "prom-client";
+import {ClientStatsProperty} from "./properties.js";
+
+// get methods are missing in prom-client type definitions
+// see https://github.com/siimon/prom-client/pull/531
+export type MetricWithGetter = Metric & {
+  get(): Promise<MetricObject>;
+};
+
+export type MetricObject = {
+  values: Array<{value: number; labels: Record<string, string>}>;
+};
+
+export type MetricValue = string | number;
+
+export type RecordValue = string | number | boolean;
+
+export type JsonRecord<T extends RecordValue> = {key: string; value: T};
+
+export type ClientStats = Record<string, ClientStatsProperty<RecordValue>>;
+
+export enum ProcessType {
+  BeaconNode = "beaconnode",
+  Validator = "validator",
+  System = "system",
+}
+
+export enum JsonType {
+  String,
+  Number,
+  Boolean,
+}

--- a/packages/beacon-node/src/monitoring/types.ts
+++ b/packages/beacon-node/src/monitoring/types.ts
@@ -30,5 +30,3 @@ export enum JsonType {
   Number,
   Boolean,
 }
-
-export type Client = "beacon" | "validator";

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -14,7 +14,7 @@ import {BeaconSync, IBeaconSync} from "../sync/index.js";
 import {BackfillSync} from "../sync/backfill/index.js";
 import {BeaconChain, IBeaconChain, initBeaconMetrics} from "../chain/index.js";
 import {createMetrics, IMetrics, HttpMetricsServer} from "../metrics/index.js";
-import {MonitoringService, ProcessType} from "../monitoring/index.js";
+import {MonitoringService} from "../monitoring/index.js";
 import {getApi, BeaconRestApiServer} from "../api/index.js";
 import {initializeExecutionEngine, initializeExecutionBuilder} from "../execution/index.js";
 import {initializeEth1ForBlockProduction} from "../eth1/index.js";
@@ -179,7 +179,7 @@ export class BeaconNode {
       if (metrics == null) {
         throw new Error("Metrics must be enabled to use monitoring");
       }
-      monitoring = new MonitoringService([ProcessType.BeaconNode], opts.monitoring, {
+      monitoring = new MonitoringService("beacon", opts.monitoring, {
         register: metrics.register,
         logger: logger.child({module: LoggerModule.monitoring}),
       });

--- a/packages/beacon-node/src/node/options.ts
+++ b/packages/beacon-node/src/node/options.ts
@@ -3,6 +3,7 @@ import {defaultChainOptions, IChainOptions} from "../chain/options.js";
 import {defaultDbOptions, IDatabaseOptions} from "../db/options.js";
 import {defaultEth1Options, Eth1Options} from "../eth1/options.js";
 import {defaultMetricsOptions, MetricsOptions} from "../metrics/options.js";
+import {defaultMonitoringOptions, MonitoringOptions} from "../monitoring/options.js";
 import {defaultNetworkOptions, INetworkOptions} from "../network/options.js";
 import {defaultSyncOptions, SyncOptions} from "../sync/options.js";
 import {
@@ -22,6 +23,7 @@ export interface IBeaconNodeOptions {
   executionEngine: ExecutionEngineOpts;
   executionBuilder: ExecutionBuilderOpts;
   metrics: MetricsOptions;
+  monitoring: MonitoringOptions;
   network: INetworkOptions;
   sync: SyncOptions;
 }
@@ -34,6 +36,7 @@ export const defaultOptions: IBeaconNodeOptions = {
   executionEngine: defaultExecutionEngineOpts,
   executionBuilder: defaultExecutionBuilderOpts,
   metrics: defaultMetricsOptions,
+  monitoring: defaultMonitoringOptions,
   network: defaultNetworkOptions,
   sync: defaultSyncOptions,
 };

--- a/packages/beacon-node/test/unit/monitoring/clientStats.test.ts
+++ b/packages/beacon-node/test/unit/monitoring/clientStats.test.ts
@@ -1,0 +1,38 @@
+import {expect} from "chai";
+import {ClientStats} from "../../../src/monitoring/types.js";
+import {createClientStats} from "../../../src/monitoring/clientStats.js";
+import {beaconNodeStatsSchema, ClientStatsSchema, systemStatsSchema, validatorStatsSchema} from "./schemas.js";
+
+describe("monitoring / clientStats", () => {
+  describe("BeaconNodeStats", () => {
+    it("should contain all required keys", () => {
+      const beaconNodeStats = createClientStats("beacon")[0];
+
+      expect(getJsonKeys(beaconNodeStats)).to.have.all.members(getSchemaKeys(beaconNodeStatsSchema));
+    });
+  });
+
+  describe("ValidatorStats", () => {
+    it("should contain all required keys", () => {
+      const validatorNodeStats = createClientStats("validator")[0];
+
+      expect(getJsonKeys(validatorNodeStats)).to.have.all.members(getSchemaKeys(validatorStatsSchema));
+    });
+  });
+
+  describe("SystemStats", () => {
+    it("should contain all required keys", () => {
+      const systemStats = createClientStats("beacon", true)[1];
+
+      expect(getJsonKeys(systemStats)).to.have.all.members(getSchemaKeys(systemStatsSchema));
+    });
+  });
+});
+
+function getJsonKeys(stats: ClientStats): string[] {
+  return Object.values(stats).map((property) => property.definition.jsonKey);
+}
+
+function getSchemaKeys(schema: ClientStatsSchema): string[] {
+  return schema.map((s) => s.key);
+}

--- a/packages/beacon-node/test/unit/monitoring/properties.test.ts
+++ b/packages/beacon-node/test/unit/monitoring/properties.test.ts
@@ -1,0 +1,247 @@
+import {expect} from "chai";
+import {IMetrics} from "../../../src/metrics/index.js";
+import {DynamicProperty, MetricProperty, StaticProperty} from "../../../src/monitoring/properties.js";
+import {JsonType} from "../../../src/monitoring/types.js";
+import {createMetricsTest} from "../metrics/utils.js";
+
+describe("monitoring / properties", () => {
+  const jsonKey = "test_key";
+  const value = 1;
+
+  describe("StaticProperty", () => {
+    it("should return a json record with the configured key and value", () => {
+      const staticProperty = new StaticProperty({jsonKey, value});
+
+      const jsonRecord = staticProperty.getRecord();
+
+      expect(jsonRecord.key).to.equal(jsonKey);
+      expect(jsonRecord.value).to.equal(value);
+    });
+  });
+
+  describe("DynamicProperty", () => {
+    it("should return a json record with the configured key and return value of provider", async () => {
+      const dynamicProperty = new DynamicProperty({jsonKey, provider: () => value});
+
+      const jsonRecord = await dynamicProperty.getRecord();
+
+      expect(jsonRecord.key).to.equal(jsonKey);
+      expect(jsonRecord.value).to.equal(value);
+    });
+
+    it("should return the same value on consecutive calls if cacheResult is set to true", async () => {
+      const initialValue = 1;
+      let updatedValue = initialValue;
+
+      const provider = (): number => {
+        const value = updatedValue;
+        updatedValue++;
+        return value;
+      };
+
+      const dynamicProperty = new DynamicProperty({jsonKey, provider, cacheResult: true});
+
+      // ensure consecutive calls still return initial provider value
+      expect((await dynamicProperty.getRecord()).value).to.equal(initialValue);
+      expect((await dynamicProperty.getRecord()).value).to.equal(initialValue);
+      expect((await dynamicProperty.getRecord()).value).to.equal(initialValue);
+    });
+  });
+
+  describe("MetricProperty", () => {
+    let metrics: IMetrics;
+
+    before(() => {
+      metrics = createMetricsTest();
+    });
+
+    it("should return a json record with the configured key and metric value", async () => {
+      const peerCount = 50;
+      metrics.peers.set(peerCount);
+
+      const metricProperty = new MetricProperty({
+        jsonKey,
+        metricName: "libp2p_peers",
+        jsonType: JsonType.Number,
+        defaultValue: 0,
+      });
+
+      const jsonRecord = await metricProperty.getRecord(metrics.register);
+
+      expect(jsonRecord.key).to.equal(jsonKey);
+      expect(jsonRecord.value).to.equal(peerCount);
+    });
+
+    it("should return the default value if metric with name does not exist", async () => {
+      const defaultValue = 10;
+
+      const metricProperty = new MetricProperty({
+        jsonKey,
+        metricName: "does_not_exist",
+        jsonType: JsonType.Number,
+        defaultValue,
+      });
+
+      expect((await metricProperty.getRecord(metrics.register)).value).to.equal(defaultValue);
+    });
+
+    it("should get the value from label instead of metric value if fromLabel is defined", async () => {
+      const metricName = "static_metric";
+      const labelName = "test_label";
+      const labelValue = "test_value";
+
+      metrics.register.static({name: metricName, help: "fromLabel test", value: {[labelName]: labelValue}});
+
+      const metricProperty = new MetricProperty({
+        jsonKey,
+        metricName,
+        fromLabel: labelName,
+        jsonType: JsonType.String,
+        defaultValue: "",
+      });
+
+      expect((await metricProperty.getRecord(metrics.register)).value).to.equal(labelValue);
+    });
+
+    it("should get the value from metric with label if withLabel is defined", async () => {
+      const metricName = "metric_with_labels";
+      const labelName = "test_label_name";
+      const labelValue = "test_label_value";
+      const metricValue = 10;
+
+      const metric = metrics.register.gauge({name: metricName, help: "withLabel test", labelNames: [labelName]});
+      metric.set({[labelName]: "different_value"}, metricValue + 1);
+      metric.set({[labelName]: labelValue}, metricValue);
+
+      const metricProperty = new MetricProperty({
+        jsonKey,
+        metricName,
+        withLabel: {name: labelName, value: labelValue},
+        jsonType: JsonType.Number,
+        defaultValue: 0,
+      });
+
+      expect((await metricProperty.getRecord(metrics.register)).value).to.equal(metricValue);
+    });
+
+    it("should return the same value on consecutive calls if cacheResult is set to true", async () => {
+      const metricName = "metric_test_caching";
+      const initialValue = 10;
+
+      const metric = metrics.register.gauge({name: metricName, help: "cacheResult test"});
+      metric.set(initialValue);
+
+      const metricProperty = new MetricProperty({
+        jsonKey,
+        metricName,
+        jsonType: JsonType.Number,
+        defaultValue: 0,
+        cacheResult: true,
+      });
+
+      // initial call which will cache the result
+      expect((await metricProperty.getRecord(metrics.register)).value).to.equal(initialValue);
+
+      // set different value
+      metric.set(initialValue + 1);
+
+      // ensure consecutive calls still return initial value
+      expect((await metricProperty.getRecord(metrics.register)).value).to.equal(initialValue);
+      expect((await metricProperty.getRecord(metrics.register)).value).to.equal(initialValue);
+    });
+
+    it("should convert the metric value to a string if jsonType is JsonType.String", async () => {
+      const metricName = "metric_test_string";
+
+      const metric = metrics.register.gauge({name: metricName, help: "JsonType.String test"});
+
+      const metricProperty = new MetricProperty({
+        jsonKey,
+        metricName,
+        jsonType: JsonType.String,
+        defaultValue: "",
+      });
+
+      metric.set(10);
+      expect((await metricProperty.getRecord(metrics.register)).value).to.equal("10");
+    });
+
+    it("should round the metric value to the nearest integer if jsonType is JsonType.Number", async () => {
+      const metricName = "metric_test_number";
+
+      const metric = metrics.register.gauge({name: metricName, help: "JsonType.Number test"});
+
+      const metricProperty = new MetricProperty({
+        jsonKey,
+        metricName,
+        jsonType: JsonType.Number,
+        defaultValue: 0,
+      });
+
+      metric.set(1.49);
+      expect((await metricProperty.getRecord(metrics.register)).value).to.equal(1);
+    });
+
+    it("should convert the metric value to a boolean if jsonType is JsonType.Boolean", async () => {
+      const metricName = "metric_test_boolean";
+
+      const metric = metrics.register.gauge({name: metricName, help: "JsonType.Boolean test"});
+
+      const metricProperty = new MetricProperty({
+        jsonKey,
+        metricName,
+        jsonType: JsonType.Boolean,
+        defaultValue: false,
+      });
+
+      metric.set(0);
+      // metric value of 0 should be converted to false
+      expect((await metricProperty.getRecord(metrics.register)).value).to.equal(false);
+
+      metric.set(1);
+      // metric value > 0 should be converted to true
+      expect((await metricProperty.getRecord(metrics.register)).value).to.equal(true);
+    });
+
+    it("should convert the metric value to true if the specified rangeValue is matched", async () => {
+      const metricName = "metric_test_range_value";
+      const rangeValue = 3;
+
+      const metric = metrics.register.gauge({name: metricName, help: "rangeValue test"});
+
+      const metricProperty = new MetricProperty({
+        jsonKey,
+        metricName,
+        rangeValue,
+        jsonType: JsonType.Boolean,
+        defaultValue: false,
+      });
+
+      metric.set(rangeValue + 1);
+      // value does not match range value and should be converted to false
+      expect((await metricProperty.getRecord(metrics.register)).value).to.equal(false);
+
+      metric.set(rangeValue);
+      // value matches range value and should be converted to true
+      expect((await metricProperty.getRecord(metrics.register)).value).to.equal(true);
+    });
+
+    it("should apply the defined formatter to the metric value", async () => {
+      const metricName = "metric_test_formatting";
+      const metricValue = 10;
+
+      const metric = metrics.register.gauge({name: metricName, help: "formatter test"});
+
+      const metricProperty = new MetricProperty({
+        jsonKey,
+        metricName,
+        jsonType: JsonType.String,
+        formatter: (value) => `prefix_${value}`,
+        defaultValue: "",
+      });
+
+      metric.set(metricValue);
+      expect((await metricProperty.getRecord(metrics.register)).value).to.equal(`prefix_${metricValue}`);
+    });
+  });
+});

--- a/packages/beacon-node/test/unit/monitoring/properties.test.ts
+++ b/packages/beacon-node/test/unit/monitoring/properties.test.ts
@@ -226,6 +226,33 @@ describe("monitoring / properties", () => {
       expect((await metricProperty.getRecord(metrics.register)).value).to.equal(true);
     });
 
+    it("should convert the metric value to true if value is greater than or equal to threshold", async () => {
+      const metricName = "metric_test_threshold";
+      const threshold = 2;
+
+      const metric = metrics.register.gauge({name: metricName, help: "threshold test"});
+
+      const metricProperty = new MetricProperty({
+        jsonKey,
+        metricName,
+        threshold,
+        jsonType: JsonType.Boolean,
+        defaultValue: false,
+      });
+
+      metric.set(threshold - 1);
+      // value is below threshold and should be converted to false
+      expect((await metricProperty.getRecord(metrics.register)).value).to.equal(false);
+
+      metric.set(threshold);
+      // value is equal to threshold and should be converted to true
+      expect((await metricProperty.getRecord(metrics.register)).value).to.equal(true);
+
+      metric.set(threshold + 1);
+      // value is greater than threshold and should be converted to true
+      expect((await metricProperty.getRecord(metrics.register)).value).to.equal(true);
+    });
+
     it("should apply the defined formatter to the metric value", async () => {
       const metricName = "metric_test_formatting";
       const metricValue = 10;

--- a/packages/beacon-node/test/unit/monitoring/remoteService.ts
+++ b/packages/beacon-node/test/unit/monitoring/remoteService.ts
@@ -1,0 +1,86 @@
+import {expect} from "chai";
+import fastify from "fastify";
+import {RemoteServiceError} from "../../../src/monitoring/service.js";
+import {ProcessType} from "../../../src/monitoring/types.js";
+import {beaconNodeStatsSchema, ClientStatsSchema, systemStatsSchema, validatorStatsSchema} from "./schemas.js";
+
+/* eslint-disable no-console */
+
+type ReceivedData = Record<string, unknown>;
+
+export const remoteServiceRoutes = {
+  success: "/success",
+  error: "/error",
+  pending: "/pending",
+};
+
+export const remoteServiceError: RemoteServiceError = {status: "error", data: null};
+
+/**
+ * Starts mocked remote service to receive and validate client stats
+ */
+export async function startRemoteService(): Promise<{baseUrl: URL}> {
+  const server = fastify();
+
+  server.post(remoteServiceRoutes.success, {}, async function (request, reply) {
+    if (Array.isArray(request.body)) {
+      request.body.forEach(validateRequestData);
+    } else {
+      validateRequestData(request.body as ReceivedData);
+    }
+
+    return reply.status(200).send();
+  });
+
+  server.post(remoteServiceRoutes.error, {}, async function (_request, reply) {
+    return reply.status(400).send(remoteServiceError);
+  });
+
+  server.post(remoteServiceRoutes.pending, {}, function () {
+    // keep request pending until timeout is reached or aborted
+  });
+
+  server.addHook("onError", (_request, _reply, error, done) => {
+    console.log(`Error: ${error.message}`);
+    done();
+  });
+
+  // ask the operating system to assign a free (ephemeral) port
+  // and use IPv4 localhost "127.0.0.1" to avoid known IPv6 issues
+  const baseUrl = await server.listen({host: "127.0.0.1", port: 0});
+
+  after(() => {
+    // there is no need to wait for server to be closed
+    server.close().catch(console.log);
+  });
+
+  return {baseUrl: new URL(baseUrl)};
+}
+
+function validateRequestData(data: ReceivedData): void {
+  switch (data.process) {
+    case ProcessType.BeaconNode:
+      validateClientStats(data, beaconNodeStatsSchema);
+      break;
+    case ProcessType.Validator:
+      validateClientStats(data, validatorStatsSchema);
+      break;
+    case ProcessType.System:
+      validateClientStats(data, systemStatsSchema);
+      break;
+    default:
+      throw new Error(`Invalid process type "${data.process}"`);
+  }
+}
+
+function validateClientStats(data: ReceivedData, schema: ClientStatsSchema): void {
+  schema.forEach((s) => {
+    try {
+      expect(data[s.key]).to.be.a(s.type);
+    } catch {
+      throw new Error(
+        `Validation of property "${s.key}" failed. Expected type "${s.type}" but received "${typeof data[s.key]}".`
+      );
+    }
+  });
+}

--- a/packages/beacon-node/test/unit/monitoring/schemas.ts
+++ b/packages/beacon-node/test/unit/monitoring/schemas.ts
@@ -1,0 +1,63 @@
+// See https://docs.google.com/document/d/1qPWAVRjPCENlyAjUBwGkHMvz9qLdd_6u9DPZcNxDBpc
+
+export type ClientStatsSchema = {key: string; type: "string" | "number" | "boolean"}[];
+
+export const commonStatsSchema: ClientStatsSchema = [
+  {key: "version", type: "number"},
+  {key: "timestamp", type: "number"},
+  {key: "process", type: "string"},
+];
+
+export const processStatsSchema: ClientStatsSchema = [
+  ...commonStatsSchema,
+  {key: "cpu_process_seconds_total", type: "number"},
+  {key: "memory_process_bytes", type: "number"},
+  {key: "client_name", type: "string"},
+  {key: "client_version", type: "string"},
+  {key: "client_build", type: "number"},
+  {key: "sync_eth2_fallback_configured", type: "boolean"},
+  {key: "sync_eth2_fallback_connected", type: "boolean"},
+];
+
+export const beaconNodeStatsSchema: ClientStatsSchema = [
+  ...processStatsSchema,
+  {key: "disk_beaconchain_bytes_total", type: "number"},
+  {key: "network_libp2p_bytes_total_receive", type: "number"},
+  {key: "network_libp2p_bytes_total_transmit", type: "number"},
+  {key: "network_peers_connected", type: "number"},
+  {key: "sync_eth1_connected", type: "boolean"},
+  {key: "sync_eth2_synced", type: "boolean"},
+  {key: "sync_beacon_head_slot", type: "number"},
+  {key: "sync_eth1_fallback_configured", type: "boolean"},
+  {key: "sync_eth1_fallback_connected", type: "boolean"},
+  {key: "slasher_active", type: "boolean"},
+];
+
+export const validatorStatsSchema: ClientStatsSchema = [
+  ...processStatsSchema,
+  {key: "validator_total", type: "number"},
+  {key: "validator_active", type: "number"},
+];
+
+export const systemStatsSchema: ClientStatsSchema = [
+  ...commonStatsSchema,
+  {key: "cpu_cores", type: "number"},
+  {key: "cpu_threads", type: "number"},
+  {key: "cpu_node_system_seconds_total", type: "number"},
+  {key: "cpu_node_user_seconds_total", type: "number"},
+  {key: "cpu_node_iowait_seconds_total", type: "number"},
+  {key: "cpu_node_idle_seconds_total", type: "number"},
+  {key: "memory_node_bytes_total", type: "number"},
+  {key: "memory_node_bytes_free", type: "number"},
+  {key: "memory_node_bytes_cached", type: "number"},
+  {key: "memory_node_bytes_buffers", type: "number"},
+  {key: "disk_node_bytes_total", type: "number"},
+  {key: "disk_node_bytes_free", type: "number"},
+  {key: "disk_node_io_seconds", type: "number"},
+  {key: "disk_node_reads_total", type: "number"},
+  {key: "disk_node_writes_total", type: "number"},
+  {key: "network_node_bytes_total_receive", type: "number"},
+  {key: "network_node_bytes_total_transmit", type: "number"},
+  {key: "misc_node_boot_ts_seconds", type: "number"},
+  {key: "misc_os", type: "string"},
+];

--- a/packages/beacon-node/test/unit/monitoring/service.test.ts
+++ b/packages/beacon-node/test/unit/monitoring/service.test.ts
@@ -11,13 +11,13 @@ import {startRemoteService, remoteServiceRoutes, remoteServiceError} from "./rem
 
 describe("monitoring / service", () => {
   const sandbox = sinon.createSandbox();
-  const endpoint = "https://test.example.com:3000/api/v1/client/metrics";
+  const endpoint = "https://test.example.com/api/v1/client/metrics";
 
   let register: RegistryMetricCreator;
   let logger: ILogger;
 
   beforeEach(() => {
-    // re-create to avoid "metric has already been registered" errors
+    // recreate to avoid "metric has already been registered" errors
     register = new RegistryMetricCreator();
     logger = createStubbedLogger();
   });
@@ -39,7 +39,7 @@ describe("monitoring / service", () => {
     });
 
     it("should log a warning message if insecure monitoring endpoint is provided ", () => {
-      const insecureEndpoint = "http://localhost:3000/api/v1/client/metrics";
+      const insecureEndpoint = "http://test.example.com/api/v1/client/metrics";
 
       new MonitoringService("beacon", {endpoint: insecureEndpoint}, {register, logger});
 
@@ -78,12 +78,12 @@ describe("monitoring / service", () => {
     });
 
     it("should send client stats after interval", async () => {
-      const interval = 0.01;
+      const interval = 10;
 
       const service = await startedMonitoringService({interval});
 
       // wait for interval to be executed
-      await sleep(interval * 1000);
+      await sleep(interval);
 
       expect(service.send).to.have.been.calledTwice;
     });
@@ -120,7 +120,7 @@ describe("monitoring / service", () => {
     it("should clear the initial delay timeout", async () => {
       const clearTimeout = sandbox.spy(global, "clearTimeout");
 
-      const service = await startedMonitoringService({initialDelay: 10});
+      const service = await startedMonitoringService({initialDelay: 1000});
 
       service.stop();
 
@@ -185,13 +185,13 @@ describe("monitoring / service", () => {
       const endpoint = `${baseUrl}${remoteServiceRoutes.pending}`;
       const service = new MonitoringService(
         "beacon",
-        {endpoint, requestTimeout: 0.01, collectSystemStats: false},
+        {endpoint, requestTimeout: 10, collectSystemStats: false},
         {register, logger}
       );
 
       await service.send();
 
-      assertError({message: new TimeoutError(`reached of request to ${remoteServiceUrl.host}`).message});
+      assertError({message: new TimeoutError(`reached for request to ${remoteServiceUrl.host}`).message});
     });
 
     it("should abort pending requests if monitoring service is stopped", (done) => {

--- a/packages/beacon-node/test/unit/monitoring/service.test.ts
+++ b/packages/beacon-node/test/unit/monitoring/service.test.ts
@@ -22,6 +22,10 @@ describe("monitoring / service", () => {
     logger = createStubbedLogger();
   });
 
+  after(() => {
+    sandbox.restore();
+  });
+
   describe("MonitoringService - constructor", () => {
     it("should return an instance of the monitoring service", () => {
       const service = new MonitoringService("beacon", {endpoint}, {register, logger});

--- a/packages/beacon-node/test/unit/monitoring/service.test.ts
+++ b/packages/beacon-node/test/unit/monitoring/service.test.ts
@@ -1,11 +1,12 @@
 import {expect} from "chai";
 import sinon from "sinon";
-import {ErrorAborted, ILogger, sleep, TimeoutError} from "@lodestar/utils";
+import {ErrorAborted, ILogger, TimeoutError} from "@lodestar/utils";
 import {RegistryMetricCreator} from "../../../src/index.js";
 import {HistogramExtra} from "../../../src/metrics/utils/histogram.js";
 import {MonitoringService} from "../../../src/monitoring/service.js";
 import {createStubbedLogger} from "../../utils/mocks/logger.js";
 import {MonitoringOptions} from "../../../src/monitoring/options.js";
+import {sleep} from "../../utils/sleep.js";
 import {startRemoteService, remoteServiceRoutes, remoteServiceError} from "./remoteService.js";
 
 describe("monitoring / service", () => {
@@ -114,6 +115,17 @@ describe("monitoring / service", () => {
 
       expect(clearInterval).to.have.been.calledOnce;
       expect(service["monitoringInterval"]).to.be.undefined;
+    });
+
+    it("should clear the initial delay timeout", async () => {
+      const clearTimeout = sandbox.spy(global, "clearTimeout");
+
+      const service = await startedMonitoringService({initialDelay: 10});
+
+      service.stop();
+
+      expect(clearTimeout).to.have.been.calledOnce;
+      expect(service["initialDelayTimeout"]).to.be.undefined;
     });
 
     it("should abort pending requests", async () => {

--- a/packages/beacon-node/test/unit/monitoring/service.test.ts
+++ b/packages/beacon-node/test/unit/monitoring/service.test.ts
@@ -1,0 +1,237 @@
+import {expect} from "chai";
+import sinon from "sinon";
+import {ErrorAborted, ILogger, sleep, TimeoutError} from "@lodestar/utils";
+import {RegistryMetricCreator} from "../../../src/index.js";
+import {HistogramExtra} from "../../../src/metrics/utils/histogram.js";
+import {MonitoringService} from "../../../src/monitoring/service.js";
+import {createStubbedLogger} from "../../utils/mocks/logger.js";
+import {MonitoringOptions} from "../../../src/monitoring/options.js";
+import {startRemoteService, remoteServiceRoutes, remoteServiceError} from "./remoteService.js";
+
+describe("monitoring / service", () => {
+  const sandbox = sinon.createSandbox();
+  const endpoint = "https://test.example.com:3000/api/v1/client/metrics";
+
+  let register: RegistryMetricCreator;
+  let logger: ILogger;
+
+  beforeEach(() => {
+    // re-create to avoid "metric has already been registered" errors
+    register = new RegistryMetricCreator();
+    logger = createStubbedLogger();
+  });
+
+  describe("MonitoringService - constructor", () => {
+    it("should return an instance of the monitoring service", () => {
+      const service = new MonitoringService("beacon", {endpoint}, {register, logger});
+
+      expect(service.start).to.be.a("function");
+      expect(service.stop).to.be.a("function");
+      expect(service.send).to.be.a("function");
+    });
+
+    it("should register metrics for collecting and sending data", () => {
+      new MonitoringService("beacon", {endpoint}, {register, logger});
+
+      expect(register.getSingleMetric("lodestar_monitoring_collect_data_seconds")).to.be.instanceOf(HistogramExtra);
+      expect(register.getSingleMetric("lodestar_monitoring_send_data_seconds")).to.be.instanceOf(HistogramExtra);
+    });
+
+    it("should log a warning message if insecure monitoring endpoint is provided ", () => {
+      const insecureEndpoint = "http://localhost:3000/api/v1/client/metrics";
+
+      new MonitoringService("beacon", {endpoint: insecureEndpoint}, {register, logger});
+
+      expect(logger.warn).to.have.been.calledWith(
+        "Insecure monitoring endpoint, please make sure to always use a HTTPS connection in production"
+      );
+    });
+
+    it("should throw an error if monitoring endpoint is not provided", () => {
+      expect(() => new MonitoringService("beacon", {endpoint: ""}, {register, logger})).to.throw(
+        "Monitoring endpoint must be provided"
+      );
+    });
+
+    it("should throw an error if monitoring endpoint is not a valid URL", () => {
+      expect(() => new MonitoringService("beacon", {endpoint: "invalid"}, {register, logger})).to.throw(
+        "Monitoring endpoint must be a valid URL"
+      );
+    });
+  });
+
+  describe("MonitoringService - start", () => {
+    it("should set interval to continuously send client stats", async () => {
+      const setInterval = sandbox.spy(global, "setInterval");
+
+      const service = await startedMonitoringService();
+
+      expect(setInterval).to.have.been.calledOnce;
+      expect(service["monitoringInterval"]).to.be.an("object");
+    });
+
+    it("should send client stats after initial delay", async () => {
+      const service = await startedMonitoringService();
+
+      expect(service.send).to.have.been.calledOnce;
+    });
+
+    it("should send client stats after interval", async () => {
+      const interval = 0.01;
+
+      const service = await startedMonitoringService({interval});
+
+      // wait for interval to be executed
+      await sleep(interval * 1000);
+
+      expect(service.send).to.have.been.calledTwice;
+    });
+
+    it("should log an info message that service was started", async () => {
+      await startedMonitoringService();
+
+      expect(logger.info).to.have.been.calledWith("Started monitoring service");
+    });
+
+    it("should not send client stats if service is already started", async () => {
+      const service = await startedMonitoringService();
+
+      // invoke start a second time
+      service.start();
+      await waitForStart();
+
+      expect(service.send).to.have.been.calledOnce;
+    });
+  });
+
+  describe("MonitoringService - stop", () => {
+    it("should clear the monitoring interval", async () => {
+      const clearInterval = sandbox.spy(global, "clearInterval");
+
+      const service = await startedMonitoringService();
+
+      service.stop();
+
+      expect(clearInterval).to.have.been.calledOnce;
+      expect(service["monitoringInterval"]).to.be.undefined;
+    });
+
+    it("should abort pending requests", async () => {
+      const service = await startedMonitoringService();
+      service["pendingRequest"] = Promise.resolve();
+
+      service.stop();
+
+      expect(service["fetchAbortController"]?.abort).to.have.been.calledOnce;
+    });
+  });
+
+  describe("MonitoringService - send", () => {
+    let remoteServiceUrl: URL;
+    let baseUrl: string;
+
+    before(async () => {
+      ({baseUrl: remoteServiceUrl} = await startRemoteService());
+      // get base URL from origin to remove trailing slash
+      baseUrl = remoteServiceUrl.origin;
+    });
+
+    (["beacon", "validator"] as const).forEach((client) => {
+      it(`should collect and send ${client} stats to remote service`, async () => {
+        const endpoint = `${baseUrl}${remoteServiceRoutes.success}`;
+        const service = new MonitoringService(client, {endpoint, collectSystemStats: true}, {register, logger});
+
+        await service.send();
+
+        // Validation of sent data happens inside the mocked remote service
+        // which returns a 500 error if data does not match expected schema.
+        // Fail test if error was logged due to a 500 response.
+        expect(logger.error).to.not.have.been.calledOnce;
+      });
+    });
+
+    it("should properly handle remote service errors", async () => {
+      const endpoint = `${baseUrl}${remoteServiceRoutes.error}`;
+      const service = new MonitoringService("beacon", {endpoint, collectSystemStats: false}, {register, logger});
+
+      await service.send();
+
+      assertError({message: remoteServiceError.status});
+    });
+
+    it("should properly handle errors if remote service is unreachable", async () => {
+      const differentPort = Number(remoteServiceUrl.port) - 1;
+      const endpoint = `http://127.0.0.1:${differentPort}`;
+      const service = new MonitoringService("beacon", {endpoint}, {register, logger});
+
+      await service.send();
+
+      assertError({name: "FetchError"});
+    });
+
+    it("should abort pending requests if timeout is reached", async () => {
+      const endpoint = `${baseUrl}${remoteServiceRoutes.pending}`;
+      const service = new MonitoringService(
+        "beacon",
+        {endpoint, requestTimeout: 0.01, collectSystemStats: false},
+        {register, logger}
+      );
+
+      await service.send();
+
+      assertError({message: new TimeoutError(`reached of request to ${remoteServiceUrl.host}`).message});
+    });
+
+    it("should abort pending requests if monitoring service is stopped", (done) => {
+      const endpoint = `${baseUrl}${remoteServiceRoutes.pending}`;
+      const service = new MonitoringService("beacon", {endpoint, collectSystemStats: false}, {register, logger});
+
+      service.send().finally(() => {
+        try {
+          assertError({message: new ErrorAborted(`request to ${remoteServiceUrl.host}`).message});
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+
+      // wait for request to be sent before stopping
+      setTimeout(() => service.stop(), 10);
+    });
+
+    function assertError(error: {name?: string; message?: string}): void {
+      expect(logger.error).to.have.been.calledOnce;
+      // errors are not thrown and need to be asserted based on the error log
+      expect(logger.error).to.have.been.calledWithMatch("Failed to send client stats", {}, error);
+    }
+  });
+
+  function stubbedMonitoringService(options: Partial<MonitoringOptions> = {}): MonitoringService {
+    const service = new MonitoringService(
+      "beacon",
+      {endpoint, initialDelay: 0, ...options},
+      {register: new RegistryMetricCreator(), logger}
+    );
+    service.send = sandbox.stub();
+    service["fetchAbortController"] = sandbox.createStubInstance(AbortController);
+
+    return service;
+  }
+
+  async function startedMonitoringService(options: Partial<MonitoringOptions> = {}): Promise<MonitoringService> {
+    const service = stubbedMonitoringService(options);
+    service.start();
+
+    // ensure start is finished
+    await waitForStart();
+
+    after(service.stop);
+
+    return service;
+  }
+
+  async function waitForStart(): Promise<void> {
+    // value of 0 seems to do the job
+    await sleep(0);
+  }
+});

--- a/packages/beacon-node/test/unit/monitoring/service.test.ts
+++ b/packages/beacon-node/test/unit/monitoring/service.test.ts
@@ -66,6 +66,12 @@ describe("monitoring / service", () => {
   });
 
   describe("MonitoringService - start", () => {
+    it("should set the status to started", async () => {
+      const service = await startedMonitoringService();
+
+      expect(service["status"]).to.equal("started");
+    });
+
     it("should set interval to continuously send client stats", async () => {
       const setInterval = sandbox.spy(global, "setInterval");
 
@@ -110,6 +116,14 @@ describe("monitoring / service", () => {
   });
 
   describe("MonitoringService - stop", () => {
+    it("should set the status to stopped", async () => {
+      const service = await startedMonitoringService();
+
+      service.stop();
+
+      expect(service["status"]).to.equal("stopped");
+    });
+
     it("should clear the monitoring interval", async () => {
       const clearInterval = sandbox.spy(global, "clearInterval");
 
@@ -117,8 +131,7 @@ describe("monitoring / service", () => {
 
       service.stop();
 
-      expect(clearInterval).to.have.been.calledOnce;
-      expect(service["monitoringInterval"]).to.be.undefined;
+      expect(clearInterval).to.have.been.calledOnceWith(service["monitoringInterval"]);
     });
 
     it("should clear the initial delay timeout", async () => {
@@ -128,8 +141,7 @@ describe("monitoring / service", () => {
 
       service.stop();
 
-      expect(clearTimeout).to.have.been.calledOnce;
-      expect(service["initialDelayTimeout"]).to.be.undefined;
+      expect(clearTimeout).to.have.been.calledOnceWith(service["initialDelayTimeout"]);
     });
 
     it("should abort pending requests", async () => {
@@ -201,6 +213,7 @@ describe("monitoring / service", () => {
     it("should abort pending requests if monitoring service is stopped", (done) => {
       const endpoint = `${baseUrl}${remoteServiceRoutes.pending}`;
       const service = new MonitoringService("beacon", {endpoint, collectSystemStats: false}, {register, logger});
+      service.start();
 
       service.send().finally(() => {
         try {

--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -80,6 +80,7 @@ export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
     // Note: recycle entire validator handler:
     // - keystore handling
     // - metrics
+    // - monitoring
     // - keymanager server
     await validatorHandler(args);
   }

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -3,14 +3,20 @@ import {setMaxListeners} from "node:events";
 import {LevelDbController} from "@lodestar/db";
 import {ProcessShutdownCallback, SlashingProtection, Validator, ValidatorProposerConfig} from "@lodestar/validator";
 import {getMetrics, MetricsRegister} from "@lodestar/validator";
-import {RegistryMetricCreator, collectNodeJSMetrics, HttpMetricsServer} from "@lodestar/beacon-node";
+import {
+  RegistryMetricCreator,
+  collectNodeJSMetrics,
+  HttpMetricsServer,
+  MonitoringService,
+  ProcessType,
+} from "@lodestar/beacon-node";
 import {getBeaconConfigFromArgs} from "../../config/index.js";
 import {IGlobalArgs} from "../../options/index.js";
 import {YargsError, getDefaultGraffiti, mkdir, getCliLogger, cleanOldLogFiles} from "../../util/index.js";
 import {onGracefulShutdown, parseFeeRecipient, parseProposerConfig} from "../../util/index.js";
 import {getVersionData} from "../../util/version.js";
 import {getAccountPaths, getValidatorPaths} from "./paths.js";
-import {IValidatorCliArgs, validatorMetricsDefaultOptions} from "./options.js";
+import {IValidatorCliArgs, validatorMetricsDefaultOptions, validatorMonitoringDefaultOptions} from "./options.js";
 import {getSignersFromArgs} from "./signers/index.js";
 import {logSigners} from "./signers/logSigners.js";
 import {KeymanagerApi} from "./keymanager/impl.js";
@@ -116,6 +122,19 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
 
     onGracefulShutdownCbs.push(() => metricsServer.stop());
     await metricsServer.start();
+  }
+
+  if (args["monitoring.endpoint"]) {
+    if (register == null) {
+      throw new Error("Metrics must be enabled to use monitoring");
+    }
+
+    const endpoint = args["monitoring.endpoint"];
+    const interval = args["monitoring.interval"] ?? validatorMonitoringDefaultOptions.interval;
+    const monitoring = new MonitoringService([ProcessType.Validator], {endpoint, interval}, {register, logger});
+
+    onGracefulShutdownCbs.push(() => monitoring.stop());
+    monitoring.start();
   }
 
   // This promise resolves once genesis is available.

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -123,13 +123,15 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
       throw new Error("Metrics must be enabled to use monitoring");
     }
 
-    const {interval, collectSystemStats} = validatorMonitoringDefaultOptions;
+    const {interval, initialDelay, requestTimeout, collectSystemStats} = validatorMonitoringDefaultOptions;
 
     const monitoring = new MonitoringService(
       "validator",
       {
         endpoint: args["monitoring.endpoint"],
         interval: args["monitoring.interval"] ?? interval,
+        initialDelay: args["monitoring.initialDelay"] ?? initialDelay,
+        requestTimeout: args["monitoring.requestTimeout"] ?? requestTimeout,
         collectSystemStats: args["monitoring.collectSystemStats"] ?? collectSystemStats,
       },
       {register, logger}

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -19,6 +19,7 @@ export const validatorMetricsDefaultOptions = {
 
 export const validatorMonitoringDefaultOptions = {
   interval: 60,
+  collectSystemStats: false,
 };
 
 // Defined as variable to not set yargs.default to an array
@@ -57,6 +58,7 @@ export type IValidatorCliArgs = AccountValidatorArgs &
 
     "monitoring.endpoint": string;
     "monitoring.interval": number;
+    "monitoring.collectSystemStats": boolean;
   };
 
 export type KeymanagerArgs = {
@@ -298,6 +300,15 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
     type: "number",
     description: "Interval in seconds between sending client stats to the remote server",
     defaultDescription: String(validatorMonitoringDefaultOptions.interval),
+    group: "monitoring",
+    hidden: true,
+  },
+
+  "monitoring.collectSystemStats": {
+    type: "boolean",
+    description:
+      "Enable collecting system stats. This should only be enabled if validator client and beacon node are running on different hosts.",
+    defaultDescription: String(validatorMonitoringDefaultOptions.collectSystemStats),
     group: "monitoring",
     hidden: true,
   },

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -17,6 +17,10 @@ export const validatorMetricsDefaultOptions = {
   address: "127.0.0.1",
 };
 
+export const validatorMonitoringDefaultOptions = {
+  interval: 60,
+};
+
 // Defined as variable to not set yargs.default to an array
 export const DEFAULT_BEACON_NODE_URL = "";
 
@@ -50,6 +54,9 @@ export type IValidatorCliArgs = AccountValidatorArgs &
     metrics?: boolean;
     "metrics.port"?: number;
     "metrics.address"?: string;
+
+    "monitoring.endpoint": string;
+    "monitoring.interval": number;
   };
 
 export type KeymanagerArgs = {
@@ -276,6 +283,23 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
     description: "Listen address for the Prometheus metrics HTTP server",
     defaultDescription: String(validatorMetricsDefaultOptions.address),
     group: "metrics",
+  },
+
+  // Monitoring
+
+  "monitoring.endpoint": {
+    type: "string",
+    description:
+      "Enables monitoring service for sending clients stats to the specified endpoint of a remote server (e.g. beaconcha.in). It is required that metrics are enabled by supplying the --metrics flag.",
+    group: "monitoring",
+  },
+
+  "monitoring.interval": {
+    type: "number",
+    description: "Interval in seconds between sending client stats to the remote server",
+    defaultDescription: String(validatorMonitoringDefaultOptions.interval),
+    group: "monitoring",
+    hidden: true,
   },
 
   // For testing only

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -292,7 +292,7 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
   "monitoring.endpoint": {
     type: "string",
     description:
-      "Enables monitoring service for sending clients stats to the specified endpoint of a remote service (e.g. beaconcha.in). It is required that metrics are enabled by supplying the --metrics flag.",
+      "Enables monitoring service for sending clients stats to the specified endpoint of a remote service (e.g. beaconcha.in). It is required that metrics are also enabled by supplying the --metrics flag.",
     group: "monitoring",
   },
 

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -18,7 +18,9 @@ export const validatorMetricsDefaultOptions = {
 };
 
 export const validatorMonitoringDefaultOptions = {
-  interval: 60,
+  interval: 60_000,
+  initialDelay: 30_000,
+  requestTimeout: 10_000,
   collectSystemStats: false,
 };
 
@@ -56,9 +58,11 @@ export type IValidatorCliArgs = AccountValidatorArgs &
     "metrics.port"?: number;
     "metrics.address"?: string;
 
-    "monitoring.endpoint": string;
-    "monitoring.interval": number;
-    "monitoring.collectSystemStats": boolean;
+    "monitoring.endpoint"?: string;
+    "monitoring.interval"?: number;
+    "monitoring.initialDelay"?: number;
+    "monitoring.requestTimeout"?: number;
+    "monitoring.collectSystemStats"?: boolean;
   };
 
 export type KeymanagerArgs = {
@@ -298,8 +302,24 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
 
   "monitoring.interval": {
     type: "number",
-    description: "Interval in seconds between sending client stats to the remote service",
+    description: "Interval in milliseconds between sending client stats to the remote service",
     defaultDescription: String(validatorMonitoringDefaultOptions.interval),
+    group: "monitoring",
+    hidden: true,
+  },
+
+  "monitoring.initialDelay": {
+    type: "number",
+    description: "Initial delay in milliseconds before client stats are sent to the remote service",
+    defaultDescription: String(validatorMonitoringDefaultOptions.initialDelay),
+    group: "monitoring",
+    hidden: true,
+  },
+
+  "monitoring.requestTimeout": {
+    type: "number",
+    description: "Timeout in milliseconds for sending client stats to the remote service",
+    defaultDescription: String(validatorMonitoringDefaultOptions.requestTimeout),
     group: "monitoring",
     hidden: true,
   },

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -292,13 +292,13 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
   "monitoring.endpoint": {
     type: "string",
     description:
-      "Enables monitoring service for sending clients stats to the specified endpoint of a remote server (e.g. beaconcha.in). It is required that metrics are enabled by supplying the --metrics flag.",
+      "Enables monitoring service for sending clients stats to the specified endpoint of a remote service (e.g. beaconcha.in). It is required that metrics are enabled by supplying the --metrics flag.",
     group: "monitoring",
   },
 
   "monitoring.interval": {
     type: "number",
-    description: "Interval in seconds between sending client stats to the remote server",
+    description: "Interval in seconds between sending client stats to the remote service",
     defaultDescription: String(validatorMonitoringDefaultOptions.interval),
     group: "monitoring",
     hidden: true,

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -305,7 +305,6 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
     description: "Interval in milliseconds between sending client stats to the remote service",
     defaultDescription: String(validatorMonitoringDefaultOptions.interval),
     group: "monitoring",
-    hidden: true,
   },
 
   "monitoring.initialDelay": {

--- a/packages/cli/src/options/beaconNodeOptions/index.ts
+++ b/packages/cli/src/options/beaconNodeOptions/index.ts
@@ -7,6 +7,7 @@ import * as chain from "./chain.js";
 import * as eth1 from "./eth1.js";
 import * as execution from "./execution.js";
 import * as metrics from "./metrics.js";
+import * as monitoring from "./monitoring.js";
 import * as network from "./network.js";
 import * as sync from "./sync.js";
 
@@ -16,6 +17,7 @@ export type IBeaconNodeArgs = api.IApiArgs &
   execution.ExecutionEngineArgs &
   builder.ExecutionBuilderArgs &
   metrics.IMetricsArgs &
+  monitoring.IMonitoringArgs &
   network.INetworkArgs &
   sync.ISyncArgs;
 
@@ -29,6 +31,7 @@ export function parseBeaconNodeArgs(args: IBeaconNodeArgs): RecursivePartial<IBe
     executionEngine: execution.parseArgs(args),
     executionBuilder: builder.parseArgs(args),
     metrics: metrics.parseArgs(args),
+    monitoring: monitoring.parseArgs(args),
     network: network.parseArgs(args),
     sync: sync.parseArgs(args),
   });
@@ -41,6 +44,7 @@ export const beaconNodeOptions = {
   ...execution.options,
   ...builder.options,
   ...metrics.options,
+  ...monitoring.options,
   ...network.options,
   ...sync.options,
 };

--- a/packages/cli/src/options/beaconNodeOptions/monitoring.ts
+++ b/packages/cli/src/options/beaconNodeOptions/monitoring.ts
@@ -1,0 +1,31 @@
+import {defaultOptions, IBeaconNodeOptions} from "@lodestar/beacon-node";
+import {ICliCommandOptions} from "../../util/index.js";
+
+export interface IMonitoringArgs {
+  "monitoring.endpoint": string;
+  "monitoring.interval": number;
+}
+
+export function parseArgs(args: IMonitoringArgs): IBeaconNodeOptions["monitoring"] {
+  return {
+    endpoint: args["monitoring.endpoint"],
+    interval: args["monitoring.interval"],
+  };
+}
+
+export const options: ICliCommandOptions<IMonitoringArgs> = {
+  "monitoring.endpoint": {
+    type: "string",
+    description:
+      "Enables monitoring service for sending clients stats to the specified endpoint of a remote server (e.g. beaconcha.in). It is required that metrics are enabled by supplying the --metrics flag.",
+    group: "monitoring",
+  },
+
+  "monitoring.interval": {
+    type: "number",
+    description: "Interval in seconds between sending client stats to the remote server",
+    defaultDescription: String(defaultOptions.monitoring.interval),
+    group: "monitoring",
+    hidden: true,
+  },
+};

--- a/packages/cli/src/options/beaconNodeOptions/monitoring.ts
+++ b/packages/cli/src/options/beaconNodeOptions/monitoring.ts
@@ -4,12 +4,14 @@ import {ICliCommandOptions} from "../../util/index.js";
 export interface IMonitoringArgs {
   "monitoring.endpoint": string;
   "monitoring.interval": number;
+  "monitoring.collectSystemStats": boolean;
 }
 
 export function parseArgs(args: IMonitoringArgs): IBeaconNodeOptions["monitoring"] {
   return {
     endpoint: args["monitoring.endpoint"],
     interval: args["monitoring.interval"],
+    collectSystemStats: args["monitoring.collectSystemStats"],
   };
 }
 
@@ -25,6 +27,15 @@ export const options: ICliCommandOptions<IMonitoringArgs> = {
     type: "number",
     description: "Interval in seconds between sending client stats to the remote server",
     defaultDescription: String(defaultOptions.monitoring.interval),
+    group: "monitoring",
+    hidden: true,
+  },
+
+  "monitoring.collectSystemStats": {
+    type: "boolean",
+    description:
+      "Enable collecting system stats. By default, the beacon node will collect the system stats but it can also be handled by the validator client.",
+    defaultDescription: String(defaultOptions.monitoring.collectSystemStats),
     group: "monitoring",
     hidden: true,
   },

--- a/packages/cli/src/options/beaconNodeOptions/monitoring.ts
+++ b/packages/cli/src/options/beaconNodeOptions/monitoring.ts
@@ -32,7 +32,6 @@ export const options: ICliCommandOptions<IMonitoringArgs> = {
     description: "Interval in milliseconds between sending client stats to the remote service",
     defaultDescription: String(defaultOptions.monitoring.interval),
     group: "monitoring",
-    hidden: true,
   },
 
   "monitoring.initialDelay": {

--- a/packages/cli/src/options/beaconNodeOptions/monitoring.ts
+++ b/packages/cli/src/options/beaconNodeOptions/monitoring.ts
@@ -19,13 +19,13 @@ export const options: ICliCommandOptions<IMonitoringArgs> = {
   "monitoring.endpoint": {
     type: "string",
     description:
-      "Enables monitoring service for sending clients stats to the specified endpoint of a remote server (e.g. beaconcha.in). It is required that metrics are enabled by supplying the --metrics flag.",
+      "Enables monitoring service for sending clients stats to the specified endpoint of a remote service (e.g. beaconcha.in). It is required that metrics are enabled by supplying the --metrics flag.",
     group: "monitoring",
   },
 
   "monitoring.interval": {
     type: "number",
-    description: "Interval in seconds between sending client stats to the remote server",
+    description: "Interval in seconds between sending client stats to the remote service",
     defaultDescription: String(defaultOptions.monitoring.interval),
     group: "monitoring",
     hidden: true,

--- a/packages/cli/src/options/beaconNodeOptions/monitoring.ts
+++ b/packages/cli/src/options/beaconNodeOptions/monitoring.ts
@@ -4,6 +4,8 @@ import {ICliCommandOptions} from "../../util/index.js";
 export interface IMonitoringArgs {
   "monitoring.endpoint": string;
   "monitoring.interval": number;
+  "monitoring.initialDelay": number;
+  "monitoring.requestTimeout": number;
   "monitoring.collectSystemStats": boolean;
 }
 
@@ -11,6 +13,8 @@ export function parseArgs(args: IMonitoringArgs): IBeaconNodeOptions["monitoring
   return {
     endpoint: args["monitoring.endpoint"],
     interval: args["monitoring.interval"],
+    initialDelay: args["monitoring.initialDelay"],
+    requestTimeout: args["monitoring.requestTimeout"],
     collectSystemStats: args["monitoring.collectSystemStats"],
   };
 }
@@ -25,8 +29,24 @@ export const options: ICliCommandOptions<IMonitoringArgs> = {
 
   "monitoring.interval": {
     type: "number",
-    description: "Interval in seconds between sending client stats to the remote service",
+    description: "Interval in milliseconds between sending client stats to the remote service",
     defaultDescription: String(defaultOptions.monitoring.interval),
+    group: "monitoring",
+    hidden: true,
+  },
+
+  "monitoring.initialDelay": {
+    type: "number",
+    description: "Initial delay in milliseconds before client stats are sent to the remote service",
+    defaultDescription: String(defaultOptions.monitoring.initialDelay),
+    group: "monitoring",
+    hidden: true,
+  },
+
+  "monitoring.requestTimeout": {
+    type: "number",
+    description: "Timeout in milliseconds for sending client stats to the remote service",
+    defaultDescription: String(defaultOptions.monitoring.requestTimeout),
     group: "monitoring",
     hidden: true,
   },

--- a/packages/cli/src/options/beaconNodeOptions/monitoring.ts
+++ b/packages/cli/src/options/beaconNodeOptions/monitoring.ts
@@ -19,7 +19,7 @@ export const options: ICliCommandOptions<IMonitoringArgs> = {
   "monitoring.endpoint": {
     type: "string",
     description:
-      "Enables monitoring service for sending clients stats to the specified endpoint of a remote service (e.g. beaconcha.in). It is required that metrics are enabled by supplying the --metrics flag.",
+      "Enables monitoring service for sending clients stats to the specified endpoint of a remote service (e.g. beaconcha.in). It is required that metrics are also enabled by supplying the --metrics flag.",
     group: "monitoring",
   },
 
@@ -34,7 +34,7 @@ export const options: ICliCommandOptions<IMonitoringArgs> = {
   "monitoring.collectSystemStats": {
     type: "boolean",
     description:
-      "Enable collecting system stats. By default, the beacon node will collect the system stats but it can also be handled by the validator client.",
+      "Enable collecting system stats. By default, the beacon node will collect system stats but this can also be handled by the validator client.",
     defaultDescription: String(defaultOptions.monitoring.collectSystemStats),
     group: "monitoring",
     hidden: true,

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -52,6 +52,10 @@ describe("options / beaconNodeOptions", () => {
       "metrics.port": 8765,
       "metrics.address": "0.0.0.0",
 
+      "monitoring.endpoint": "https://beaconcha.in/api/v1/client/metrics?apikey=secretKey&machine=machine1",
+      "monitoring.interval": 60,
+      "monitoring.collectSystemStats": true,
+
       discv5: true,
       listenAddress: "127.0.0.1",
       port: 9001,
@@ -131,6 +135,11 @@ describe("options / beaconNodeOptions", () => {
         enabled: true,
         port: 8765,
         address: "0.0.0.0",
+      },
+      monitoring: {
+        endpoint: "https://beaconcha.in/api/v1/client/metrics?apikey=secretKey&machine=machine1",
+        interval: 60,
+        collectSystemStats: true,
       },
       network: {
         discv5: {

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -53,7 +53,9 @@ describe("options / beaconNodeOptions", () => {
       "metrics.address": "0.0.0.0",
 
       "monitoring.endpoint": "https://beaconcha.in/api/v1/client/metrics?apikey=secretKey&machine=machine1",
-      "monitoring.interval": 60,
+      "monitoring.interval": 60000,
+      "monitoring.initialDelay": 30000,
+      "monitoring.requestTimeout": 10000,
       "monitoring.collectSystemStats": true,
 
       discv5: true,
@@ -138,7 +140,9 @@ describe("options / beaconNodeOptions", () => {
       },
       monitoring: {
         endpoint: "https://beaconcha.in/api/v1/client/metrics?apikey=secretKey&machine=machine1",
-        interval: 60,
+        interval: 60000,
+        initialDelay: 30000,
+        requestTimeout: 10000,
         collectSystemStats: true,
       },
       network: {


### PR DESCRIPTION
### Motivation

At the moment Lodestar is the only client that does not support [beaconcha.in's mobile app node monitoring](https://kb.beaconcha.in/beaconcha.in-explorer/mobile-app-less-than-greater-than-beacon-node). This feature is quite useful for node operators to have real-time stats about their system and also get notifications if there are any issues.

### Description

Adds support for pushing client and system metrics to a remote service. The implementation is based on [this specification](https://docs.google.com/document/d/1qPWAVRjPCENlyAjUBwGkHMvz9qLdd_6u9DPZcNxDBpc) and should be service agnostic but will be initially tested against [beaconcha.in](https://beaconcha.in/).

The implementation supports all three types of client stats (beacon node, validator and system). Most of the stats are collected from existing metrics but there are also static values and other dynamic values retrieved from defined provider functions. Both the beacon node and validator support pushing client and system metrics but by default only the beacon node enables collecting system stats as in most cases both clients run on the same host.

The client monitoring is disabled by default but can be enabled by passing the `--monitoring.endpoint` cli flag. ~~As monitoring relies on metrics data, it is required that metrics are enabled by supplying the `--metrics` flag.~~ `--metrics` flag is no longer required as of https://github.com/ChainSafe/lodestar/pull/5328

```bash
lodestar beacon --monitoring.endpoint "https://beaconcha.in/api/v1/client/metrics?apikey={apikey}"
```

### Design decisions

- independent from metrics (metrics are just a data provider), introduce new term "monitoring"
- declarative approach to define client stats which makes it easy to maintain and extend in the future as spec evolves
- independent from beacon node and validator, just relies on metrics register to be injected
- use metric name (e.g. `beacon_head_slot`) to select the metric (other option would be to use [metric object](https://github.com/ChainSafe/lodestar/blob/3c1db8d850c18dea8d5cb9beaf4a28066e51b61e/packages/beacon-node/src/metrics/metrics/beacon.ts#L11) but not all metrics are available there, e.g. nodejs metrics, libp2p metrics)
- use good default values and only expose minimal set of options as cli args
- assume that remote service is unreliable, properly handle timeouts, aborts and pending requests

### Considerations

- Create separate package  (e.g. `@lodestar/monitoring`) to better decouple from beacon node and improve reuseability, could also think about a package called `@lodestar/common` which includes things that are reused by the beacon node and validator such as metrics and monitoring.

### Problematic/missing values

- [x] `disk_beaconchain_bytes_total` is not retrievable from metrics, add metric for this? other option how this value can be retrieved? (teku hard-codes this to `0`, prysm and lighthouse have a prom metric for this), metric added in #5087 and beacon node stats updated in https://github.com/ChainSafe/lodestar/pull/5162
- [x] `network_libp2p_bytes_total_receive` uses `libp2p_data_transfer_bytes_total{protocol="global received"}` ~~but this metric is not available most of the time, other metric to get this data from?~~ (teku and prysm both hard-code this to `0`, lighthouse gets it from `libp2p_inbound_bytes` prom metric)
- [x] `network_libp2p_bytes_total_transmit` same as above but `libp2p_data_transfer_bytes_total{protocol="global sent"}` is used  (teku and prysm both hard-code this to `0`, lighthouse gets it from `libp2p_outbound_bytes` prom metric)
- [x] `validator_active` uses `vc_indices_count` metric which is the total amount of validators but we only want active validators here (other CL clients have a metric for this, mostly use a label to differentiate between total and active) #5158 
- [x] `sync_eth1_connected` ~~hard-coded to `true`~~ (based on `lodestar_execution_engine_http_client_config_urls_count`, if count is above 0 this will be set to `true`, any way to check if connected eth1 node is synced?)
- [x] `client_build` hard-coded to `0` (lodestar does not use incremental build numbers, teku and lighthouse also hard-code this to `0`)
- [x] `sync_eth2_fallback_configured` hard-coded to `false` (teku and prysm both hard-code this to `false`, lighthouse gets it from `sync_eth2_fallback_configured` prom metric)
- [x] `sync_eth2_fallback_connected` hard-coded to `false` (teku and prysm both hard-code this to `false`, lighthouse gets it from `sync_eth2_fallback_configured` prom metric)
- [x] `sync_eth1_fallback_configured` ~~hard-coded to `false`~~ (based on `lodestar_execution_engine_http_client_config_urls_count`, if count is above 1 a fallback url is configured and this will be set to `true`)
- [x] `sync_eth1_fallback_connected` hard-coded to `false` (teku hard-codes this to `false`, prysm and lighthouse have a prom metric for this, in lodestar we only track the total requests done to a fallback node with `lodestar_execution_engine_http_client_request_used_fallback_url_total` prom metrics but this can't really be used here)
- [x] `slasher_active` hard-coded to `false` (currently lodestar does not implement a slasher)

### Open tasks

- [x] Collect system stats, internally with [systeminformation](https://www.npmjs.com/package/systeminformation) ~~vs scrape from [node exporter](https://github.com/prometheus/node_exporter)~~, implemented in https://github.com/ChainSafe/lodestar/pull/5182
- [x] Update Lodestar documentation, add separate page for client monitoring
- [x] Create issue to track updates required in other repositories (e.g. [eth-docker](https://github.com/eth-educators/eth-docker), [eth2-client-metrics](https://github.com/gobitfly/eth2-client-metrics#ethereum-consensus-client-metrics), etc.), #5095 
- [x] Add unit tests (data validation, misconfiguration handling, other failure scenarios, e.g. remote service offline)
- [x] Ensure that client stats are collected correctly from metrics or system info and sent in the right format, see Mobile app screenshots in https://github.com/ChainSafe/lodestar/pull/5182
- [x] Add metrics to monitoring service. Track failed requests, request duration, time spent collecting data, etc.
- [x] Add dashboard panel to visualize monitoring service metrics


Closes #4666
