### PR TITLE
Add option to dump dev files to interop with LH

### DIFF
--- a/packages/cli/src/cmds/dev/files.ts
+++ b/packages/cli/src/cmds/dev/files.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs";
+import path from "node:path";
+import {nodeUtils} from "@lodestar/beacon-node";
+import {chainConfigToJson, IChainForkConfig} from "@lodestar/config";
+import {dumpYaml} from "@lodestar/utils";
+import {interopSecretKey} from "@lodestar/state-transition";
+import {Keystore} from "@chainsafe/bls-keystore";
+import {PersistedKeysBackend} from "../validator/keymanager/persistedKeys.js";
+
+/* eslint-disable @typescript-eslint/naming-convention, no-console */
+
+export async function writeTestnetFiles(
+  config: IChainForkConfig,
+  targetDir: string,
+  genesisValidators: number
+): Promise<void> {
+  const genesisTime = Math.floor(Date.now() / 1000);
+  const eth1BlockHash = Buffer.alloc(32, 0);
+
+  const {state} = nodeUtils.initDevState(config, genesisValidators, {genesisTime, eth1BlockHash});
+
+  // Write testnet data
+  fs.mkdirSync(targetDir, {recursive: true});
+  fs.writeFileSync(path.join(targetDir, "genesis.ssz"), state.serialize());
+  fs.writeFileSync(path.join(targetDir, "config.yaml"), dumpYaml(chainConfigToJson(config)));
+  fs.writeFileSync(path.join(targetDir, "deploy_block.txt"), "0");
+
+  const persistedKeystoresBackend = new PersistedKeysBackend({
+    keystoresDir: path.join(targetDir, "keystores"),
+    secretsDir: path.join(targetDir, "secrets"),
+    remoteKeysDir: path.join(targetDir, "remote_keys"),
+    proposerDir: path.join(targetDir, "proposer"),
+  });
+
+  const password = "test_password";
+
+  // Write keystores
+  for (let i = 0; i < genesisValidators; i++) {
+    console.log(`Generating keystore ${i}`);
+
+    const sk = interopSecretKey(i);
+
+    const keystore = await Keystore.create(password, sk.toBytes(), sk.toPublicKey().toBytes(), "");
+
+    persistedKeystoresBackend.writeKeystore({
+      keystoreStr: keystore.stringify(),
+      password,
+      // Not used immediately
+      lockBeforeWrite: false,
+      // Return duplicate status if already found
+      persistIfDuplicate: false,
+    });
+  }
+}

--- a/packages/cli/src/cmds/dev/handler.ts
+++ b/packages/cli/src/cmds/dev/handler.ts
@@ -11,12 +11,18 @@ import {getValidatorPaths} from "../validator/paths.js";
 import {beaconHandler} from "../beacon/handler.js";
 import {validatorHandler} from "../validator/handler.js";
 import {IDevArgs} from "./options.js";
+import {writeTestnetFiles} from "./files.js";
 
 /**
  * Run a beacon node with validator
  */
 export async function devHandler(args: IDevArgs & IGlobalArgs): Promise<void> {
   const {config} = getBeaconConfigFromArgs(args);
+
+  if (args.dumpTestnetFiles) {
+    await writeTestnetFiles(config, args.dumpTestnetFiles, args.genesisValidators);
+    return;
+  }
 
   // TODO: Is this necessary?
   const network = "dev";

--- a/packages/cli/src/cmds/dev/options.ts
+++ b/packages/cli/src/cmds/dev/options.ts
@@ -7,10 +7,11 @@ import {IValidatorCliArgs, validatorOptions} from "../validator/options.js";
 
 type IDevOwnArgs = {
   genesisEth1Hash?: string;
-  genesisValidators?: number;
+  genesisValidators: number;
   startValidators?: string;
   genesisTime?: number;
   reset?: boolean;
+  dumpTestnetFiles?: string;
 };
 
 const devOwnOptions: ICliCommandOptions<IDevOwnArgs> = {
@@ -45,6 +46,12 @@ const devOwnOptions: ICliCommandOptions<IDevOwnArgs> = {
     description: "To delete chain and validator directories",
     alias: ["r"],
     type: "boolean",
+    group: "dev",
+  },
+
+  dumpTestnetFiles: {
+    description: "Dump testnet files and exit",
+    type: "string",
     group: "dev",
   },
 };


### PR DESCRIPTION
**Motivation**

To run Lodestar in dev command mode with other implementations, those require multiple files to connect to that testnet.

**Description**

Running with command `--dumpTestnetFiles`, will write to disk:
- genesis
- configs
- keystores + secrets

