### PR TITLE
Allow to run dev command with mainnet preset

### DIFF
--- a/packages/cli/src/applyPreset.ts
+++ b/packages/cli/src/applyPreset.ts
@@ -20,6 +20,11 @@ if (preset) {
   process.env.LODESTAR_PRESET = preset;
 }
 
+// If ENV is set overrides, network (otherwise can not override network --dev in mainnet mode)
+else if (process.env.LODESTAR_PRESET) {
+  // break
+}
+
 // Translate network to preset
 else if (network) {
   if (network === "dev") {

--- a/packages/cli/src/networks/dev.ts
+++ b/packages/cli/src/networks/dev.ts
@@ -1,4 +1,19 @@
-export {minimalChainConfig as chainConfig} from "@lodestar/config/presets";
+import {minimalChainConfig, mainnetChainConfig} from "@lodestar/config/presets";
+import {ACTIVE_PRESET, PresetName} from "@lodestar/params";
+
+let chainConfig;
+switch (ACTIVE_PRESET) {
+  case PresetName.mainnet:
+    chainConfig = mainnetChainConfig;
+    break;
+  case PresetName.minimal:
+    chainConfig = minimalChainConfig;
+    break;
+  default:
+    throw Error(`Preset ${ACTIVE_PRESET} not supported with dev command`);
+}
+
+export {chainConfig};
 
 /* eslint-disable max-len */
 


### PR DESCRIPTION
**Motivation**

Current running
```
LODESTAR_PRESET=mainnet lodestar dev
```

results in error

```
 ✖ Error: Can only create a config for the active preset: ACTIVE_PRESET=mainnet PRESET_BASE=minimal
    at createIChainConfig (file:///home/lion/Code/eth2.0/lodestar/packages/config/src/chainConfig/index.ts:22:11)
    at getBeaconParams (file:///home/lion/Code/eth2.0/lodestar/packages/cli/src/config/beaconParams.ts:82:10)
    at getBeaconParamsFromArgs (file:///home/lion/Code/eth2.0/lodestar/packages/cli/src/config/beaconParams.ts:42:10)
    at getBeaconConfigFromArgs (file:///home/lion/Code/eth2.0/lodestar/packages/cli/src/config/beaconParams.ts:30:41)
    at Object.devHandler [as handler] (file:///home/lion/Code/eth2.0/lodestar/packages/cli/src/cmds/dev/handler.ts:19:20)
    at Object.runCommand (file:///home/lion/Code/eth2.0/lodestar/node_modules/yargs/build/lib/command.js:174:48)
    at Object.parseArgs [as _parseArgs] (file:///home/lion/Code/eth2.0/lodestar/node_modules/yargs/build/lib/yargs-factory.js:992:55)
    at Object.parse (file:///home/lion/Code/eth2.0/lodestar/node_modules/yargs/build/lib/yargs-factory.js:555:31)
    at file:///home/lion/Code/eth2.0/lodestar/packages/cli/src/index.ts:31:4
```

**Description**

- Allow to run dev command with mainnet preset
