### PR TITLE
Change EventType to normal enum

### DIFF
--- a/packages/api/src/beacon/routes/events.ts
+++ b/packages/api/src/beacon/routes/events.ts
@@ -7,7 +7,7 @@ import {ApiClientResponse} from "../../interfaces.js";
 
 // See /packages/api/src/routes/index.ts for reasoning and instructions to add new routes
 
-export const enum EventType {
+export enum EventType {
   /**
    * The node has finished processing, resulting in a new head. previous_duty_dependent_root is
    * `get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch - 1) - 1)` and


### PR DESCRIPTION
**Motivation**

Const enums are completely removed during compilation which means that they do not exist at runtime and can not be used outside of the library, see [discord](https://discord.com/channels/593655374469660673/667606053877317642/1065521781026332682)

**Description**

Changes `EventType` to a normal enum