### PR TITLE
Review eip-4844 sync code

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -131,6 +131,7 @@
     "@multiformats/multiaddr": "^11.0.0",
     "@types/datastore-level": "^3.0.0",
     "buffer-xor": "^2.0.2",
+    "c-kzg": "^1.0.9",
     "cross-fetch": "^3.1.4",
     "datastore-core": "^8.0.1",
     "datastore-level": "^9.0.1",

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -7,13 +7,11 @@ import {IChainForkConfig} from "@lodestar/config";
 export enum BlockInputType {
   preDeneb = "preDeneb",
   postDeneb = "postDeneb",
-  postDenebOldBlobs = "postDenebOldBlobs",
 }
 
 export type BlockInput =
   | {type: BlockInputType.preDeneb; block: allForks.SignedBeaconBlock}
-  | {type: BlockInputType.postDeneb; block: allForks.SignedBeaconBlock; blobs: deneb.BlobsSidecar}
-  | {type: BlockInputType.postDenebOldBlobs; block: allForks.SignedBeaconBlock};
+  | {type: BlockInputType.postDeneb; block: allForks.SignedBeaconBlock; blobs: deneb.BlobsSidecar};
 
 export function blockRequiresBlobs(config: IChainForkConfig, blockSlot: Slot, clockSlot: Slot): boolean {
   return (
@@ -42,16 +40,6 @@ export const getBlockInput = {
       type: BlockInputType.postDeneb,
       block,
       blobs,
-    };
-  },
-
-  postDenebOldBlobs(config: IChainForkConfig, block: allForks.SignedBeaconBlock): BlockInput {
-    if (config.getForkSeq(block.message.slot) < ForkSeq.deneb) {
-      throw Error(`Pre Deneb block slot ${block.message.slot}`);
-    }
-    return {
-      type: BlockInputType.postDenebOldBlobs,
-      block,
     };
   },
 };

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -128,9 +128,5 @@ function maybeValidateBlobs(
 
     case BlockInputType.preDeneb:
       return DataAvailableStatus.preDeneb;
-
-    // TODO: Ok to assume old data available?
-    case BlockInputType.postDenebOldBlobs:
-      return DataAvailableStatus.available;
   }
 }

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -10,11 +10,11 @@ import {deneb, Epoch, phase0, allForks} from "@lodestar/types";
 import {routes} from "@lodestar/api";
 import {IMetrics} from "../metrics/index.js";
 import {ChainEvent, IBeaconChain, IBeaconClock} from "../chain/index.js";
-import {BlockInput, BlockInputType, getBlockInput} from "../chain/blocks/types.js";
+import {BlockInput, BlockInputType} from "../chain/blocks/types.js";
 import {isValidBlsToExecutionChangeForBlockInclusion} from "../chain/opPools/utils.js";
 import {INetworkOptions} from "./options.js";
 import {INetwork, Libp2p} from "./interface.js";
-import {ReqRespBeaconNode, ReqRespHandlers, doBeaconBlocksMaybeBlobsByRange} from "./reqresp/index.js";
+import {beaconBlocksMaybeBlobsByRoot} from "./reqresp/beaconBlocksMaybeBlobsByRoot.js";
 import {
   Eth2Gossipsub,
   getGossipHandlers,
@@ -339,67 +339,14 @@ export class Network implements INetwork {
   }
 
   async beaconBlocksMaybeBlobsByRoot(peerId: PeerId, request: phase0.BeaconBlocksByRootRequest): Promise<BlockInput[]> {
-    // Assume all requests are post Deneb
-    if (this.config.getForkSeq(this.chain.forkChoice.getFinalizedBlock().slot) >= ForkSeq.deneb) {
-      const blocksAndBlobs = await this.reqResp.beaconBlockAndBlobsSidecarByRoot(peerId, request);
-      return blocksAndBlobs.map(({beaconBlock, blobsSidecar}) =>
-        getBlockInput.postDeneb(this.config, beaconBlock, blobsSidecar)
-      );
-    }
-
-    // Assume all request are pre Deneb
-    else if (this.config.getForkSeq(this.clock.currentSlot) < ForkSeq.deneb) {
-      const blocks = await this.reqResp.beaconBlocksByRoot(peerId, request);
-      return blocks.map((block) => getBlockInput.preDeneb(this.config, block));
-    }
-
-    // NOTE: Consider blocks may be post or pre Deneb
-    // TODO Deneb: Request either blocks, or blocks+blobs
-    else {
-      const results = await Promise.all(
-        request.map(
-          async (beaconBlockRoot): Promise<BlockInput | null> => {
-            const [resultBlockBlobs, resultBlocks] = await Promise.allSettled([
-              this.reqResp.beaconBlockAndBlobsSidecarByRoot(peerId, [beaconBlockRoot]),
-              this.reqResp.beaconBlocksByRoot(peerId, [beaconBlockRoot]),
-            ]);
-
-            if (resultBlockBlobs.status === "fulfilled" && resultBlockBlobs.value.length === 1) {
-              const {beaconBlock, blobsSidecar} = resultBlockBlobs.value[0];
-              return getBlockInput.postDeneb(this.config, beaconBlock, blobsSidecar);
-            }
-
-            if (resultBlocks.status === "rejected") {
-              return Promise.reject(resultBlocks.reason);
-            }
-
-            // Promise fullfilled + no result = block not found
-            if (resultBlocks.value.length < 1) {
-              return null;
-            }
-
-            const block = resultBlocks.value[0];
-
-            if (this.config.getForkSeq(block.message.slot) >= ForkSeq.deneb) {
-              // beaconBlockAndBlobsSidecarByRoot should have succeeded
-              if (resultBlockBlobs.status === "rejected") {
-                // Recycle existing error for beaconBlockAndBlobsSidecarByRoot if any
-                return Promise.reject(resultBlockBlobs.reason);
-              } else {
-                throw Error(
-                  `Received post Deneb ${beaconBlockRoot} over beaconBlocksByRoot not beaconBlockAndBlobsSidecarByRoot`
-                );
-              }
-            }
-
-            // Block is pre Deneb
-            return getBlockInput.preDeneb(this.config, block);
-          }
-        )
-      );
-
-      return results.filter((blockOrNull): blockOrNull is BlockInput => blockOrNull !== null);
-    }
+    return beaconBlocksMaybeBlobsByRoot(
+      this.config,
+      this.reqResp,
+      peerId,
+      request,
+      this.clock.currentSlot,
+      this.chain.forkChoice.getFinalizedBlock().slot
+    );
   }
 
   /**

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -328,9 +328,6 @@ export class Network implements INetwork {
           beaconBlock: blockInput.block as deneb.SignedBeaconBlock,
           blobsSidecar: blockInput.blobs,
         });
-
-      case BlockInputType.postDenebOldBlobs:
-        throw Error(`Attempting to broadcast old BlockInput slot ${blockInput.block.message.slot}`);
     }
   }
 

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -14,6 +14,7 @@ import {BlockInput, BlockInputType} from "../chain/blocks/types.js";
 import {isValidBlsToExecutionChangeForBlockInclusion} from "../chain/opPools/utils.js";
 import {INetworkOptions} from "./options.js";
 import {INetwork, Libp2p} from "./interface.js";
+import {ReqRespBeaconNode, ReqRespHandlers, beaconBlocksMaybeBlobsByRange} from "./reqresp/index.js";
 import {beaconBlocksMaybeBlobsByRoot} from "./reqresp/beaconBlocksMaybeBlobsByRoot.js";
 import {
   Eth2Gossipsub,
@@ -335,7 +336,7 @@ export class Network implements INetwork {
     peerId: PeerId,
     request: phase0.BeaconBlocksByRangeRequest
   ): Promise<BlockInput[]> {
-    return doBeaconBlocksMaybeBlobsByRange(this.config, this.reqResp, peerId, request, this.clock.currentEpoch);
+    return beaconBlocksMaybeBlobsByRange(this.config, this.reqResp, peerId, request, this.clock.currentEpoch);
   }
 
   async beaconBlocksMaybeBlobsByRoot(peerId: PeerId, request: phase0.BeaconBlocksByRootRequest): Promise<BlockInput[]> {

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -62,7 +62,7 @@ export async function beaconBlocksMaybeBlobsByRange(
             `Missing blobsSidecar for blockSlot=${block.message.slot} with blobKzgCommitmentsLen=${blobKzgCommitmentsLen}`
           );
         }
-        blobsSidecar = getEmptyBlobsSidecar(config, block as eip4844.SignedBeaconBlock);
+        blobsSidecar = getEmptyBlobsSidecar(config, block as deneb.SignedBeaconBlock);
       }
       blockInputs.push(getBlockInput.postDeneb(config, block, blobsSidecar));
     }

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -8,7 +8,7 @@ import {BlockInput, getBlockInput} from "../../chain/blocks/types.js";
 import {getEmptyBlobsSidecar} from "../../util/blobs.js";
 import {IReqRespBeaconNode} from "./interface.js";
 
-export async function doBeaconBlocksMaybeBlobsByRange(
+export async function beaconBlocksMaybeBlobsByRange(
   config: IBeaconConfig,
   reqResp: IReqRespBeaconNode,
   peerId: PeerId,
@@ -55,7 +55,7 @@ export async function doBeaconBlocksMaybeBlobsByRange(
             `Missing blobsSidecar for blockSlot=${block.message.slot} with blobKzgCommitmentsLen=${blobKzgCommitmentsLen}`
           );
         }
-        blobsSidecar = getEmptyBlobsSidecar(config, block);
+        blobsSidecar = getEmptyBlobsSidecar(config, block as eip4844.SignedBeaconBlock);
       }
       blockInputs.push(getBlockInput.postDeneb(config, block, blobsSidecar));
     }

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -18,6 +18,9 @@ export async function beaconBlocksMaybeBlobsByRange(
   // Code below assumes the request is in the same epoch
   // Range sync satisfies this condition, but double check here for sanity
   const {startSlot, count} = request;
+  if (count < 1) {
+    return [];
+  }
   const endSlot = startSlot + count - 1;
 
   const startEpoch = computeEpochAtSlot(startSlot);

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -1,0 +1,83 @@
+import {PeerId} from "@libp2p/interface-peer-id";
+import {IBeaconConfig} from "@lodestar/config";
+import {RequestError, RequestErrorCode} from "@lodestar/reqresp";
+import {Epoch, phase0, Root, Slot} from "@lodestar/types";
+import {toHex} from "@lodestar/utils";
+import {ForkSeq} from "@lodestar/params";
+import {BlockInput, getBlockInput} from "../../chain/blocks/types.js";
+import {wrapError} from "../../util/wrapError.js";
+import {IReqRespBeaconNode} from "./interface.js";
+
+export async function beaconBlocksMaybeBlobsByRoot(
+  config: IBeaconConfig,
+  reqResp: IReqRespBeaconNode,
+  peerId: PeerId,
+  request: phase0.BeaconBlocksByRootRequest,
+  currentSlot: Epoch,
+  finalizedSlot: Slot
+): Promise<BlockInput[]> {
+  // Assume all requests are post EIP-4844
+  if (config.getForkSeq(finalizedSlot) >= ForkSeq.eip4844) {
+    const blocksAndBlobs = await reqResp.beaconBlockAndBlobsSidecarByRoot(peerId, request);
+    return blocksAndBlobs.map(({beaconBlock, blobsSidecar}) =>
+      getBlockInput.postEIP4844(config, beaconBlock, blobsSidecar)
+    );
+  }
+
+  // Assume all request are pre EIP-4844
+  else if (config.getForkSeq(currentSlot) < ForkSeq.eip4844) {
+    const blocks = await reqResp.beaconBlocksByRoot(peerId, request);
+    return blocks.map((block) => getBlockInput.preEIP4844(config, block));
+  }
+
+  // We don't know if a requested root is after the eip4844 fork or not.
+  // Thus some sort of retry is necessary while eip4844 is not finalized
+  else {
+    return await Promise.all(
+      request.map(async (beaconBlockRoot) =>
+        beaconBlockAndBlobsSidecarByRootFallback(config, reqResp, peerId, beaconBlockRoot)
+      )
+    );
+  }
+}
+
+async function beaconBlockAndBlobsSidecarByRootFallback(
+  config: IBeaconConfig,
+  reqResp: IReqRespBeaconNode,
+  peerId: PeerId,
+  beaconBlockRoot: Root
+): Promise<BlockInput> {
+  const resBlockBlobs = await wrapError(reqResp.beaconBlockAndBlobsSidecarByRoot(peerId, [beaconBlockRoot]));
+
+  if (resBlockBlobs.err) {
+    // From the spec, if the block is from before the fork, errors with 3: ResourceUnavailable
+    // > Clients MUST support requesting blocks and sidecars since minimum_request_epoch, where
+    //   minimum_request_epoch = max(finalized_epoch, current_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS, EIP4844_FORK_EPOCH).
+    //   If any root in the request content references a block earlier than minimum_request_epoch,
+    //   peers SHOULD respond with error code 3: ResourceUnavailable.
+    // Ref: https://github.com/ethereum/consensus-specs/blob/aede132f4999ed54b98d35e27aca9451042a1ee9/specs/eip4844/p2p-interface.md#beaconblockandblobssidecarbyroot-v1
+    if (
+      resBlockBlobs.err instanceof RequestError &&
+      resBlockBlobs.err.type.code === RequestErrorCode.RESOURCE_UNAVAILABLE
+    ) {
+      // retry with blocks
+    } else {
+      // Unexpected error, throw
+      throw resBlockBlobs.err;
+    }
+  } else {
+    if (resBlockBlobs.result.length < 1) {
+      throw Error(`beaconBlockAndBlobsSidecarByRoot return empty for block root ${toHex(beaconBlockRoot)}`);
+    }
+
+    const {beaconBlock, blobsSidecar} = resBlockBlobs.result[0];
+    return getBlockInput.postEIP4844(config, beaconBlock, blobsSidecar);
+  }
+
+  const resBlocks = await reqResp.beaconBlocksByRoot(peerId, [beaconBlockRoot]);
+  if (resBlocks.length < 1) {
+    throw Error(`beaconBlocksByRoot return empty for block root ${toHex(beaconBlockRoot)}`);
+  }
+
+  return getBlockInput.preEIP4844(config, resBlocks[0]);
+}

--- a/packages/beacon-node/src/network/reqresp/doBeaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/doBeaconBlocksMaybeBlobsByRange.ts
@@ -33,9 +33,10 @@ export async function doBeaconBlocksMaybeBlobsByRange(
 
   // Only request blobs if they are recent enough
   else if (computeEpochAtSlot(request.startSlot) >= currentEpoch - config.MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS) {
-    // TODO Deneb: Do two requests at once for blocks and blobs
-    const blocks = await reqResp.beaconBlocksByRange(peerId, request);
-    const blobsSidecars = await reqResp.blobsSidecarsByRange(peerId, request);
+    const [blocks, blobsSidecars] = await Promise.all([
+      reqResp.beaconBlocksByRange(peerId, request),
+      reqResp.blobsSidecarsByRange(peerId, request),
+    ]);
 
     const blockInputs: BlockInput[] = [];
     let blobSideCarIndex = 0;

--- a/packages/beacon-node/src/network/reqresp/index.ts
+++ b/packages/beacon-node/src/network/reqresp/index.ts
@@ -1,3 +1,3 @@
 export * from "./ReqRespBeaconNode.js";
 export * from "./interface.js";
-export * from "./doBeaconBlocksMaybeBlobsByRange.js";
+export * from "./beaconBlocksMaybeBlobsByRange.js";

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -1,0 +1,24 @@
+import {IChainForkConfig} from "@lodestar/config";
+import {eip4844} from "@lodestar/types";
+import {ckzg} from "./kzg.js";
+
+// Cache empty KZG proof, compute once lazily if needed
+let emptyKzgAggregatedProof: Uint8Array | null = null;
+function getEmptyKzgAggregatedProof(): Uint8Array {
+  if (!emptyKzgAggregatedProof) {
+    emptyKzgAggregatedProof = ckzg.computeAggregateKzgProof([]);
+  }
+  return emptyKzgAggregatedProof;
+}
+
+/**
+ * Construct a valid BlobsSidecar for a SignedBeaconBlock that references 0 commitments
+ */
+export function getEmptyBlobsSidecar(config: IChainForkConfig, block: eip4844.SignedBeaconBlock): eip4844.BlobsSidecar {
+  return {
+    beaconBlockRoot: config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message),
+    beaconBlockSlot: block.message.slot,
+    blobs: [],
+    kzgAggregatedProof: getEmptyKzgAggregatedProof(),
+  };
+}

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -1,5 +1,5 @@
 import {IChainForkConfig} from "@lodestar/config";
-import {eip4844} from "@lodestar/types";
+import {deneb} from "@lodestar/types";
 import {ckzg} from "./kzg.js";
 
 // Cache empty KZG proof, compute once lazily if needed
@@ -14,7 +14,7 @@ function getEmptyKzgAggregatedProof(): Uint8Array {
 /**
  * Construct a valid BlobsSidecar for a SignedBeaconBlock that references 0 commitments
  */
-export function getEmptyBlobsSidecar(config: IChainForkConfig, block: eip4844.SignedBeaconBlock): eip4844.BlobsSidecar {
+export function getEmptyBlobsSidecar(config: IChainForkConfig, block: deneb.SignedBeaconBlock): deneb.BlobsSidecar {
   return {
     beaconBlockRoot: config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message),
     beaconBlockSlot: block.message.slot,

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -3,7 +3,7 @@ import {BeaconStateAllForks, isExecutionStateType} from "@lodestar/state-transit
 import {InputType} from "@lodestar/spec-test-util";
 import {toHexString} from "@chainsafe/ssz";
 import {CheckpointWithHex, ForkChoice} from "@lodestar/fork-choice";
-import {phase0, allForks, bellatrix, ssz, RootHex} from "@lodestar/types";
+import {phase0, allForks, bellatrix, ssz, RootHex, deneb} from "@lodestar/types";
 import {bnToNum} from "@lodestar/utils";
 import {createIBeaconConfig} from "@lodestar/config";
 import {ForkSeq} from "@lodestar/params";
@@ -151,7 +151,11 @@ export const forkChoiceTest = (opts: {onlyPredefinedResponses: boolean}): TestRu
             const blockImport =
               config.getForkSeq(slot) < ForkSeq.deneb
                 ? getBlockInput.preDeneb(config, signedBlock)
-                : getBlockInput.postDeneb(config, signedBlock, getEmptyBlobsSidecar(config, signedBlock));
+                : getBlockInput.postDeneb(
+                    config,
+                    signedBlock,
+                    getEmptyBlobsSidecar(config, signedBlock as deneb.SignedBeaconBlock)
+                  );
 
             try {
               await chain.processBlock(blockImport, {

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -151,7 +151,7 @@ export const forkChoiceTest = (opts: {onlyPredefinedResponses: boolean}): TestRu
             const blockImport =
               config.getForkSeq(slot) < ForkSeq.deneb
                 ? getBlockInput.preDeneb(config, signedBlock)
-                : getBlockInput.postDenebOldBlobs(config, signedBlock, getEmptyBlobsSidecar(config, signedBlock));
+                : getBlockInput.postDeneb(config, signedBlock, getEmptyBlobsSidecar(config, signedBlock));
 
             try {
               await chain.processBlock(blockImport, {

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -20,6 +20,7 @@ import {defaultChainOptions} from "../../../src/chain/options.js";
 import {getStubbedBeaconDb} from "../../utils/mocks/db.js";
 import {ClockStopped} from "../../utils/mocks/clock.js";
 import {getBlockInput, AttestationImportOpt} from "../../../src/chain/blocks/types.js";
+import {getEmptyBlobsSidecar} from "../../../src/util/blobs.js";
 import {ZERO_HASH_HEX} from "../../../src/constants/constants.js";
 import {PowMergeBlock} from "../../../src/eth1/interface.js";
 import {assertCorrectProgressiveBalances} from "../config.js";
@@ -150,7 +151,7 @@ export const forkChoiceTest = (opts: {onlyPredefinedResponses: boolean}): TestRu
             const blockImport =
               config.getForkSeq(slot) < ForkSeq.deneb
                 ? getBlockInput.preDeneb(config, signedBlock)
-                : getBlockInput.postDenebOldBlobs(config, signedBlock);
+                : getBlockInput.postDenebOldBlobs(config, signedBlock, getEmptyBlobsSidecar(config, signedBlock));
 
             try {
               await chain.processBlock(blockImport, {

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -24,6 +24,7 @@ import {getEmptyBlobsSidecar} from "../../../src/util/blobs.js";
 import {ZERO_HASH_HEX} from "../../../src/constants/constants.js";
 import {PowMergeBlock} from "../../../src/eth1/interface.js";
 import {assertCorrectProgressiveBalances} from "../config.js";
+import {initCKZG, loadEthereumTrustedSetup} from "../../../src/util/kzg.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -41,6 +42,9 @@ export const forkChoiceTest = (opts: {onlyPredefinedResponses: boolean}): TestRu
 ) => {
   return {
     testFunction: async (testcase) => {
+      await initCKZG();
+      loadEthereumTrustedSetup();
+
       const {steps, anchorState} = testcase;
       const currentSlot = anchorState.slot;
       const config = getConfig(fork);

--- a/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
+++ b/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
@@ -4,11 +4,11 @@ import {peerIdFromString} from "@libp2p/peer-id";
 import {ssz, deneb} from "@lodestar/types";
 import {createIBeaconConfig, createIChainForkConfig, defaultChainConfig} from "@lodestar/config";
 
-import {doBeaconBlocksMaybeBlobsByRange, ReqRespBeaconNode} from "../../../src/network/reqresp/index.js";
+import {beaconBlocksMaybeBlobsByRange, ReqRespBeaconNode} from "../../../src/network/reqresp/index.js";
 import {BlockInputType} from "../../../src/chain/blocks/types.js";
 import {ckzg, initCKZG, loadEthereumTrustedSetup} from "../../../src/util/kzg.js";
 
-describe("doBeaconBlocksMaybeBlobsByRange", () => {
+describe("beaconBlocksMaybeBlobsByRange", () => {
   before(async function () {
     this.timeout(10000); // Loading trusted setup is slow
     await initCKZG();
@@ -80,7 +80,7 @@ describe("doBeaconBlocksMaybeBlobsByRange", () => {
       reqResp.beaconBlocksByRange.resolves(blocks);
       reqResp.blobsSidecarsByRange.resolves(blobsSidecars);
 
-      const response = await doBeaconBlocksMaybeBlobsByRange(config, reqResp, peerId, rangeRequest, 0);
+      const response = await beaconBlocksMaybeBlobsByRange(config, reqResp, peerId, rangeRequest, 0);
       expect(response).to.be.deep.equal(expectedResponse);
     });
   });

--- a/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
+++ b/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
@@ -31,6 +31,7 @@ describe("beaconBlocksMaybeBlobsByRange", () => {
   const genesisValidatorsRoot = Buffer.alloc(32, 0xaa);
   const config = createIBeaconConfig(chainConfig, genesisValidatorsRoot);
   const rangeRequest = ssz.phase0.BeaconBlocksByRangeRequest.defaultValue();
+  rangeRequest.count = 1;
 
   const block1 = ssz.deneb.SignedBeaconBlock.defaultValue();
   block1.message.slot = 1;


### PR DESCRIPTION
**Motivation**

Spec clarified a couple points that influence our implementation:
- Old blobs must not be considered available if its data availability has not been checked in the past. This means that Lodestar cannot sync from outside the blobs prune window. A better UX strategy should be communicated on boot for users. So far this PR removes `BlockInputType.postEIP4844OldBlobs`. This causes blobs by range calls to a range previous to prune window to have to throw an error, stalling sync effectively. See https://github.com/ethereum/consensus-specs/pull/3141
- To handle the edge case on a by root request after eip-4844 fork and before finalizing it, the server will return a specific error code which we can handle to trigger a retry. See https://github.com/ethereum/consensus-specs/pull/3154

**Description**

- [Compute emptyKzgAggregatedProof once lazily](https://github.com/ChainSafe/lodestar/commit/88b0eee2180e961169ed101c50ff43a00d47c0f9)
- [Fetch blocks and blobs in concurrently](https://github.com/ChainSafe/lodestar/commit/8b749903dcf63330fd6eb3cf4b709dd3f749dd7a)
- [Remove BlockInput case postEIP4844OldBlobs](https://github.com/ChainSafe/lodestar/commit/868df381d6eb21f2513978ceefcd95889ccdbb2b)
- [Review beaconBlocksMaybeBlobsByRoot](https://github.com/ChainSafe/lodestar/commit/7026386f6adea611550bf82b83d6e6a1459dc2b6)
- [Rename beaconBlocksMaybeBlobsByRange](https://github.com/ChainSafe/lodestar/commit/cf5afaaa33f8c02f38f7065565c2e03613b57a5b)
- [Ensure beaconBlocksMaybeBlobsByRange is same epoch](https://github.com/ChainSafe/lodestar/commit/20111de6daaaa4a77521ed05d290300ec9e4d875)

