### PR TITLE
Enable eslint rules after kzg import line

### DIFF
--- a/packages/beacon-node/src/util/kzg.ts
+++ b/packages/beacon-node/src/util/kzg.ts
@@ -48,6 +48,7 @@ export async function initCKZG(): Promise<void> {
   /* eslint-disable import/no-extraneous-dependencies, @typescript-eslint/ban-ts-comment */
   // @ts-ignore
   ckzg = (await import("c-kzg")) as typeof ckzg;
+  /* eslint-enable import/no-extraneous-dependencies, @typescript-eslint/ban-ts-comment */
 }
 
 /**


### PR DESCRIPTION
Related to #5046, accidentally removed the line which re-enables the eslint rules after kzg import line.