### PR TITLE
Add validatior option to specify builder block selection strategy

### DIFF
--- a/packages/beacon-node/test/sim/mergemock.test.ts
+++ b/packages/beacon-node/test/sim/mergemock.test.ts
@@ -5,7 +5,7 @@ import {LogLevel, sleep, TimestampFormatCode} from "@lodestar/utils";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {IChainConfig} from "@lodestar/config";
 import {Epoch} from "@lodestar/types";
-import {ValidatorProposerConfig} from "@lodestar/validator";
+import {ValidatorProposerConfig, BuilderSelection} from "@lodestar/validator";
 
 import {ChainEvent} from "../../src/chain/index.js";
 import {testLogger, TestLoggerOpts} from "../utils/logger.js";
@@ -163,6 +163,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
         builder: {
           enabled: true,
           gasLimit: 30000000,
+          selection: BuilderSelection.BuilderAlways,
         },
       },
     } as ValidatorProposerConfig;

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -1,7 +1,13 @@
 import path from "node:path";
 import {setMaxListeners} from "node:events";
 import {LevelDbController} from "@lodestar/db";
-import {ProcessShutdownCallback, SlashingProtection, Validator, ValidatorProposerConfig} from "@lodestar/validator";
+import {
+  ProcessShutdownCallback,
+  SlashingProtection,
+  Validator,
+  ValidatorProposerConfig,
+  BuilderSelection,
+} from "@lodestar/validator";
 import {getMetrics, MetricsRegister} from "@lodestar/validator";
 import {RegistryMetricCreator, collectNodeJSMetrics, HttpMetricsServer} from "@lodestar/beacon-node";
 import {getBeaconConfigFromArgs} from "../../config/index.js";
@@ -179,7 +185,11 @@ function getProposerConfigFromArgs(
     graffiti: args.graffiti || getDefaultGraffiti(),
     strictFeeRecipientCheck: args.strictFeeRecipientCheck,
     feeRecipient: args.suggestedFeeRecipient ? parseFeeRecipient(args.suggestedFeeRecipient) : undefined,
-    builder: {enabled: args.builder, gasLimit: args.defaultGasLimit},
+    builder: {
+      enabled: args.builder,
+      gasLimit: args.defaultGasLimit,
+      selection: parseBuilderSelection(args["builder.selection"]),
+    },
   };
 
   let valProposerConfig: ValidatorProposerConfig;
@@ -203,4 +213,18 @@ function getProposerConfigFromArgs(
     }
   }
   return valProposerConfig;
+}
+
+function parseBuilderSelection(builderSelection?: string): BuilderSelection | undefined {
+  if (builderSelection) {
+    switch (builderSelection) {
+      case "maxprofit":
+        break;
+      case "builderprefered":
+        break;
+      default:
+        throw Error("Invalid input for builder selection, check help.");
+    }
+  }
+  return builderSelection as BuilderSelection;
 }

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -220,7 +220,7 @@ function parseBuilderSelection(builderSelection?: string): BuilderSelection | un
     switch (builderSelection) {
       case "maxprofit":
         break;
-      case "builderprefered":
+      case "builderalways":
         break;
       default:
         throw Error("Invalid input for builder selection, check help.");

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -34,7 +34,9 @@ export type IValidatorCliArgs = AccountValidatorArgs &
     strictFeeRecipientCheck?: boolean;
     doppelgangerProtectionEnabled?: boolean;
     defaultGasLimit?: number;
+
     builder?: boolean;
+    "builder.selection"?: string;
 
     importKeystores?: string[];
     importKeystoresPassword?: string;
@@ -201,6 +203,13 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
   builder: {
     type: "boolean",
     description: "Enable execution payload production via a builder for better rewards",
+    group: "builder",
+  },
+
+  "builder.selection": {
+    type: "string",
+    description: "Default builder block selection strategy: maxprofit or builderprefered",
+    defaultDescription: `${defaultOptions.builderSelection}`,
     group: "builder",
   },
 

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -208,7 +208,7 @@ export const validatorOptions: ICliCommandOptions<IValidatorCliArgs> = {
 
   "builder.selection": {
     type: "string",
-    description: "Default builder block selection strategy: maxprofit or builderprefered",
+    description: "Default builder block selection strategy: maxprofit or builderalways",
     defaultDescription: `${defaultOptions.builderSelection}`,
     group: "builder",
   },

--- a/packages/cli/src/util/proposerConfig.ts
+++ b/packages/cli/src/util/proposerConfig.ts
@@ -2,7 +2,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import {ValidatorProposerConfig} from "@lodestar/validator";
+import {ValidatorProposerConfig, BuilderSelection} from "@lodestar/validator";
 import {parseFeeRecipient} from "./feeRecipient.js";
 
 import {readFile} from "./file.js";
@@ -18,6 +18,7 @@ type ProposerConfigFileSection = {
     // for js-yaml
     enabled?: string;
     gas_limit?: number;
+    selection?: BuilderSelection;
   };
 };
 
@@ -55,7 +56,7 @@ function parseProposerConfigSection(
   overrideConfig?: ProposerConfig
 ): ProposerConfig {
   const {graffiti, strict_fee_recipient_check, fee_recipient, builder} = proposerFileSection;
-  const {enabled, gas_limit} = builder || {};
+  const {enabled, gas_limit, selection: builderSelection} = builder || {};
 
   if (graffiti !== undefined && typeof graffiti !== "string") {
     throw Error("graffiti is not 'string");
@@ -90,6 +91,7 @@ function parseProposerConfigSection(
     builder: {
       enabled: overrideConfig?.builder?.enabled ?? (enabled ? stringtoBool(enabled) : undefined),
       gasLimit: overrideConfig?.builder?.gasLimit ?? (gas_limit !== undefined ? Number(gas_limit) : undefined),
+      selection: overrideConfig?.builder?.selection ?? builderSelection,
     },
   };
 }

--- a/packages/cli/test/unit/validator/parseProposerConfig.test.ts
+++ b/packages/cli/test/unit/validator/parseProposerConfig.test.ts
@@ -2,6 +2,8 @@
 import path from "node:path";
 import {fileURLToPath} from "node:url";
 import {expect} from "chai";
+import {BuilderSelection} from "@lodestar/validator";
+
 import {parseProposerConfig} from "../../../src/util/index.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -15,6 +17,7 @@ const testValue = {
       builder: {
         enabled: true,
         gasLimit: 30000000,
+        selection: undefined,
       },
     },
     "0xa4855c83d868f772a579133d9f23818008417b743e8447e235d8eb78b1d8f8a9f63f98c551beb7de254400f89592314d": {
@@ -24,6 +27,7 @@ const testValue = {
       builder: {
         enabled: true,
         gasLimit: 35000000,
+        selection: BuilderSelection.MaxProfit,
       },
     },
   },
@@ -34,6 +38,7 @@ const testValue = {
     builder: {
       enabled: true,
       gasLimit: 30000000,
+      selection: BuilderSelection.BuilderAlways,
     },
   },
 };

--- a/packages/cli/test/unit/validator/proposerConfigs/validData.yaml
+++ b/packages/cli/test/unit/validator/proposerConfigs/validData.yaml
@@ -11,6 +11,7 @@ proposer_config:
     builder:
       enabled: "true"
       gas_limit: "35000000"
+      selection: "maxprofit"
 default_config:
   graffiti: 'default graffiti'
   strict_fee_recipient_check: "true"
@@ -18,3 +19,4 @@ default_config:
   builder:
     enabled: true
     gas_limit: "30000000"
+    selection: "builderalways"

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -8,6 +8,7 @@ export {
   ValidatorProposerConfig,
   defaultOptions,
   ProposerConfig,
+  BuilderSelection,
 } from "./services/validatorStore.js";
 export {waitForGenesis} from "./genesis.js";
 export {getMetrics, Metrics, MetricsRegister} from "./metrics.js";

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -126,7 +126,7 @@ export class BlockProposingService {
     {expectedFeeRecipient, strictFeeRecipientCheck, isBuilderEnabled, builderSelection}: ProduceBlockOpts
   ): Promise<{data: allForks.FullOrBlindedBeaconBlock} & {debugLogCtx: Record<string, string>}> => {
     const blindedBlockPromise = isBuilderEnabled
-      ? this.api.validator.produceBlindedBlock(slot, randaoReveal, graffiti).catch((e: Error) => {
+      ? this.produceBlindedBlock(slot, randaoReveal, graffiti).catch((e: Error) => {
           this.logger.error("Failed to produce builder block", {}, e as Error);
           return null;
         })
@@ -200,11 +200,7 @@ export class BlockProposingService {
   }
 
   /** Wrapper around the API's different methods for producing blocks across forks */
-  private produceBlock: ServerApi<Api["validator"]>["produceBlock"] = async (
-    slot,
-    randaoReveal,
-    graffiti
-  ): Promise<{data: allForks.BeaconBlock; blockValue: Wei}> => {
+  private produceBlock: ServerApi<Api["validator"]>["produceBlock"] = async (slot, randaoReveal, graffiti) => {
     switch (this.config.getForkName(slot)) {
       case ForkName.phase0: {
         const res = await this.api.validator.produceBlock(slot, randaoReveal, graffiti);
@@ -219,5 +215,15 @@ export class BlockProposingService {
         return res.response;
       }
     }
+  };
+
+  private produceBlindedBlock: ServerApi<Api["validator"]>["produceBlindedBlock"] = async (
+    slot,
+    randaoReveal,
+    graffiti
+  ) => {
+    const res = await this.api.validator.produceBlindedBlock(slot, randaoReveal, graffiti);
+    ApiError.assert(res, "Failed to produce block: validator.produceBlindedBlock");
+    return res.response;
   };
 }

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -151,31 +151,31 @@ export class BlockProposingService {
             this.logger.debug(
               "Returning Fullblock as fullblock.blockValue > blindedBlock.blockValue and BuilderSelection = MaxProfit "
             );
-            return this.getFullorBlindedBlockBundle(fullBlock, "engine", feeRecipientCheck);
+            return this.getBlockWithDebugLog(fullBlock, "engine", feeRecipientCheck);
           } else {
             this.logger.debug("Returning blindedBlock");
-            return this.getFullorBlindedBlockBundle(blindedBlock, "builder", feeRecipientCheck);
+            return this.getBlockWithDebugLog(blindedBlock, "builder", feeRecipientCheck);
           }
           break;
         }
         case BuilderSelection.BuilderAlways:
         default: {
           this.logger.debug("Returning blindedBlock");
-          return this.getFullorBlindedBlockBundle(blindedBlock, "builder", feeRecipientCheck);
+          return this.getBlockWithDebugLog(blindedBlock, "builder", feeRecipientCheck);
         }
       }
     } else if (fullBlock && !blindedBlock) {
       this.logger.debug("Returning fullBlock - No builder block produced");
-      return this.getFullorBlindedBlockBundle(fullBlock, "engine", feeRecipientCheck);
+      return this.getBlockWithDebugLog(fullBlock, "engine", feeRecipientCheck);
     } else if (blindedBlock && !fullBlock) {
       this.logger.debug("Returning blindedBlock - No execution block produced");
-      return this.getFullorBlindedBlockBundle(blindedBlock, "builder", feeRecipientCheck);
+      return this.getBlockWithDebugLog(blindedBlock, "builder", feeRecipientCheck);
     } else {
       throw Error("Failed to produce engine or builder block");
     }
   };
 
-  private getFullorBlindedBlockBundle(
+  private getBlockWithDebugLog(
     fullOrBlindedBlock: {data: allForks.FullOrBlindedBeaconBlock; blockValue: Wei},
     source: string,
     {expectedFeeRecipient, strictFeeRecipientCheck}: {expectedFeeRecipient: string; strictFeeRecipientCheck: boolean}

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -170,13 +170,24 @@ export class BlockProposingService {
           selectedBlock = blindedBlock;
         }
       }
-      this.logger.debug(`Selected ${selectedSource} block`, {builderSelection, engineBlockValue, builderBlockValue});
+      this.logger.debug(`Selected ${selectedSource} block`, {
+        builderSelection,
+        // winston logger doesn't like bigint
+        engineBlockValue: `${engineBlockValue}`,
+        builderBlockValue: `${builderBlockValue}`,
+      });
       return this.getBlockWithDebugLog(selectedBlock, selectedSource, feeRecipientCheck);
     } else if (fullBlock && !blindedBlock) {
-      this.logger.debug("Selected engine block: no builder block produced", {engineBlockValue});
+      this.logger.debug("Selected engine block: no builder block produced", {
+        // winston logger doesn't like bigint
+        engineBlockValue: `${engineBlockValue}`,
+      });
       return this.getBlockWithDebugLog(fullBlock, "engine", feeRecipientCheck);
     } else if (blindedBlock && !fullBlock) {
-      this.logger.debug("Selected builder block: no engine block produced", {builderBlockValue});
+      this.logger.debug("Selected builder block: no engine block produced", {
+        // winston logger doesn't like bigint
+        builderBlockValue: `${builderBlockValue}`,
+      });
       return this.getBlockWithDebugLog(blindedBlock, "builder", feeRecipientCheck);
     } else {
       throw Error("Failed to produce engine or builder block");
@@ -188,7 +199,11 @@ export class BlockProposingService {
     source: string,
     {expectedFeeRecipient, strictFeeRecipientCheck}: {expectedFeeRecipient: string; strictFeeRecipientCheck: boolean}
   ): {data: allForks.FullOrBlindedBeaconBlock} & {debugLogCtx: Record<string, string>} {
-    const debugLogCtx = {source: source, "blockValue(eth)": (fullOrBlindedBlock.blockValue / ETH_TO_WEI).toString()};
+    const debugLogCtx = {
+      source: source,
+      // winston logger doesn't like bigint
+      "blockValue(eth)": `${fullOrBlindedBlock.blockValue / ETH_TO_WEI}`,
+    };
     const blockFeeRecipient = (fullOrBlindedBlock.data as bellatrix.BeaconBlock).body.executionPayload?.feeRecipient;
     const feeRecipient = blockFeeRecipient !== undefined ? toHexString(blockFeeRecipient) : undefined;
 

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -62,6 +62,11 @@ export type SignerRemote = {
   pubkey: PubkeyHex;
 };
 
+export enum BuilderSelection {
+  BuilderAlways = "builderprefered",
+  MaxProfit = "maxprofit",
+}
+
 type DefaultProposerConfig = {
   graffiti: string;
   strictFeeRecipientCheck: boolean;
@@ -69,6 +74,7 @@ type DefaultProposerConfig = {
   builder: {
     enabled: boolean;
     gasLimit: number;
+    selection: BuilderSelection;
   };
 };
 
@@ -79,6 +85,7 @@ export type ProposerConfig = {
   builder?: {
     enabled?: boolean;
     gasLimit?: number;
+    selection?: BuilderSelection;
   };
 };
 
@@ -113,6 +120,7 @@ type ValidatorData = ProposerConfig & {
 export const defaultOptions = {
   suggestedFeeRecipient: "0x0000000000000000000000000000000000000000",
   defaultGasLimit: 30_000_000,
+  builderSelection: BuilderSelection.MaxProfit,
 };
 
 /**
@@ -142,6 +150,7 @@ export class ValidatorStore {
       builder: {
         enabled: defaultConfig.builder?.enabled ?? false,
         gasLimit: defaultConfig.builder?.gasLimit ?? defaultOptions.defaultGasLimit,
+        selection: defaultConfig.builder?.selection ?? defaultOptions.builderSelection,
       },
     };
 
@@ -206,7 +215,11 @@ export class ValidatorStore {
   }
 
   isBuilderEnabled(pubkeyHex: PubkeyHex): boolean {
-    return (this.validators.get(pubkeyHex)?.builder || {}).enabled ?? this.defaultProposerConfig?.builder.enabled;
+    return (this.validators.get(pubkeyHex)?.builder || {}).enabled ?? this.defaultProposerConfig.builder.enabled;
+  }
+
+  getBuilderSelection(pubkeyHex: PubkeyHex): BuilderSelection {
+    return (this.validators.get(pubkeyHex)?.builder || {}).selection ?? this.defaultProposerConfig.builder.selection;
   }
 
   strictFeeRecipientCheck(pubkeyHex: PubkeyHex): boolean {

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -63,7 +63,7 @@ export type SignerRemote = {
 };
 
 export enum BuilderSelection {
-  BuilderAlways = "builderprefered",
+  BuilderAlways = "builderalways",
   MaxProfit = "maxprofit",
 }
 
@@ -120,7 +120,7 @@ type ValidatorData = ProposerConfig & {
 export const defaultOptions = {
   suggestedFeeRecipient: "0x0000000000000000000000000000000000000000",
   defaultGasLimit: 30_000_000,
-  builderSelection: BuilderSelection.MaxProfit,
+  builderSelection: BuilderSelection.BuilderAlways,
 };
 
 /**

--- a/packages/validator/test/unit/services/produceBlockwrapper.test.ts
+++ b/packages/validator/test/unit/services/produceBlockwrapper.test.ts
@@ -1,0 +1,170 @@
+import {expect} from "chai";
+import sinon from "sinon";
+import {createIChainForkConfig} from "@lodestar/config";
+import {config as mainnetConfig} from "@lodestar/config/default";
+import {ssz} from "@lodestar/types";
+import {ForkName} from "@lodestar/params";
+import {BlockProposingService} from "../../../src/services/block.js";
+import {ValidatorStore, BuilderSelection} from "../../../src/services/validatorStore.js";
+import {getApiClientStub} from "../../utils/apiStub.js";
+import {loggerVc} from "../../utils/logger.js";
+import {ClockMock} from "../../utils/clock.js";
+
+describe("Produce Block with BuilderSelection", function () {
+  const sandbox = sinon.createSandbox();
+  const api = getApiClientStub(sandbox);
+  const validatorStore = sinon.createStubInstance(ValidatorStore) as ValidatorStore &
+    sinon.SinonStubbedInstance<ValidatorStore>;
+
+  const config = createIChainForkConfig(mainnetConfig);
+
+  const clock = new ClockMock();
+  const blockService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, null);
+  const produceBlockWrapper = blockService["produceBlockWrapper"];
+
+  let controller: AbortController; // To stop clock
+  beforeEach(() => (controller = new AbortController()));
+  afterEach(() => controller.abort());
+
+  it("1. BuilderSelection = MaxProfit -  BlindedBlock blockValue > fullBlock blockValue - return blindedBlock ", async function () {
+    const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
+    const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
+
+    api.validator.produceBlindedBlock.resolves({
+      data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(),
+      version: ForkName.bellatrix,
+      blockValue: BigInt(1),
+    });
+    api.validator.produceBlock.resolves({data: fullBlock, blockValue: ssz.Wei.defaultValue()});
+    api.validator.produceBlockV2.resolves({
+      data: fullBlock,
+      version: ForkName.bellatrix,
+      blockValue: ssz.Wei.defaultValue(),
+    });
+
+    const produceBlockOpts = {
+      strictFeeRecipientCheck: false,
+      expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      isBuilderEnabled: true,
+      builderSelection: BuilderSelection.MaxProfit,
+    };
+    const returnedBlock = await produceBlockWrapper(144897, signedBlock.body.randaoReveal, "", produceBlockOpts);
+    expect(returnedBlock.data).to.deep.equal(signedBlock, "blindedBlock must be returned");
+  });
+  it("2. BuilderSelection = MaxProfit - fullBlock blockValue > BlindedBlock blockValue - return FullBlock", async function () {
+    const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
+    const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
+
+    api.validator.produceBlindedBlock.resolves({
+      data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(),
+      version: ForkName.bellatrix,
+      blockValue: ssz.Wei.defaultValue(),
+    });
+    api.validator.produceBlock.resolves({data: fullBlock, blockValue: BigInt(1)});
+    api.validator.produceBlockV2.resolves({data: fullBlock, version: ForkName.bellatrix, blockValue: BigInt(1)});
+
+    const produceBlockOpts = {
+      strictFeeRecipientCheck: false,
+      expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      isBuilderEnabled: true,
+      builderSelection: BuilderSelection.MaxProfit,
+    };
+    const returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
+    expect(returnedBlock.data).to.deep.equal(fullBlock, "fullBlock must be returned");
+  });
+  it("3. BuilderSelection = BuilderAlways - return BlindedBlock", async function () {
+    const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
+    const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
+
+    api.validator.produceBlindedBlock.resolves({
+      data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(),
+      version: ForkName.bellatrix,
+      blockValue: ssz.Wei.defaultValue(),
+    });
+    api.validator.produceBlock.resolves({data: fullBlock, blockValue: BigInt(1)});
+    api.validator.produceBlockV2.resolves({data: fullBlock, version: ForkName.bellatrix, blockValue: BigInt(1)});
+
+    const produceBlockOpts = {
+      strictFeeRecipientCheck: false,
+      expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      isBuilderEnabled: true,
+      builderSelection: BuilderSelection.BuilderAlways,
+    };
+    const returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
+    expect(returnedBlock.data).to.deep.equal(signedBlock, "blindedBlock must be returned");
+  });
+  it("4. fullBlock - null, BlindedBlock !=null return blindedBlock", async function () {
+    const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
+    //const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
+
+    api.validator.produceBlindedBlock.resolves({
+      data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(),
+      version: ForkName.bellatrix,
+      blockValue: ssz.Wei.defaultValue(),
+    });
+    api.validator.produceBlock.resolves();
+    api.validator.produceBlockV2.resolves();
+
+    let produceBlockOpts = {
+      strictFeeRecipientCheck: false,
+      expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      isBuilderEnabled: true,
+      builderSelection: BuilderSelection.BuilderAlways,
+    };
+    let returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
+    expect(returnedBlock.data).to.deep.equal(signedBlock, "blindedBlock must be returned");
+    produceBlockOpts = {
+      strictFeeRecipientCheck: false,
+      expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      isBuilderEnabled: true,
+      builderSelection: BuilderSelection.MaxProfit,
+    };
+    returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
+    expect(returnedBlock.data).to.deep.equal(signedBlock, "blindedBlock must be returned");
+  });
+  it("5. fullBlock != null, BlindedBlock =null return fullBlock", async function () {
+    const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
+    const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
+
+    api.validator.produceBlindedBlock.resolves();
+    api.validator.produceBlock.resolves({data: fullBlock, blockValue: BigInt(1)});
+    api.validator.produceBlockV2.resolves({data: fullBlock, version: ForkName.bellatrix, blockValue: BigInt(1)});
+
+    let produceBlockOpts = {
+      strictFeeRecipientCheck: false,
+      expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      isBuilderEnabled: true,
+      builderSelection: BuilderSelection.BuilderAlways,
+    };
+    let returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
+    expect(returnedBlock.data).to.deep.equal(fullBlock, "fullBlock must be returned");
+    produceBlockOpts = {
+      strictFeeRecipientCheck: false,
+      expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      isBuilderEnabled: true,
+      builderSelection: BuilderSelection.MaxProfit,
+    };
+    returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
+    expect(returnedBlock.data).to.deep.equal(fullBlock, "fullBlock must be returned");
+  });
+  it("6. !fullBlock, !BlindedBlock, throw error", async function () {
+    const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
+
+    api.validator.produceBlindedBlock.resolves();
+    api.validator.produceBlock.resolves();
+    api.validator.produceBlockV2.resolves();
+
+    const produceBlockOpts = {
+      strictFeeRecipientCheck: false,
+      expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      isBuilderEnabled: true,
+      builderSelection: BuilderSelection.MaxProfit,
+    };
+
+    try {
+      await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
+    } catch (e) {
+      expect(e).to.be.instanceOf(Error);
+    }
+  });
+});

--- a/packages/validator/test/unit/services/produceBlockwrapper.test.ts
+++ b/packages/validator/test/unit/services/produceBlockwrapper.test.ts
@@ -4,6 +4,8 @@ import {createIChainForkConfig} from "@lodestar/config";
 import {config as mainnetConfig} from "@lodestar/config/default";
 import {ssz} from "@lodestar/types";
 import {ForkName} from "@lodestar/params";
+import {HttpStatusCode} from "@lodestar/api";
+
 import {BlockProposingService} from "../../../src/services/block.js";
 import {ValidatorStore, BuilderSelection} from "../../../src/services/validatorStore.js";
 import {getApiClientStub} from "../../utils/apiStub.js";
@@ -22,149 +24,184 @@ describe("Produce Block with BuilderSelection", function () {
   const blockService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, null);
   const produceBlockWrapper = blockService["produceBlockWrapper"];
 
+  const blindedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
+  const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
+  const randaoReveal = fullBlock.body.randaoReveal;
+
   let controller: AbortController; // To stop clock
   beforeEach(() => (controller = new AbortController()));
   afterEach(() => controller.abort());
 
-  it("1. BuilderSelection = MaxProfit -  BlindedBlock blockValue > fullBlock blockValue - return blindedBlock ", async function () {
-    const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
-    const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
+  // Testcase: BuilderSelection, builderBlockValue, engineBlockValue, selection
+  // null blockValue means the block was not produced
+  const testCases: [BuilderSelection, number | null, number, string][] = [
+    [BuilderSelection.MaxProfit, 1, 0, "builder"],
+  ];
+  testCases.forEach(([builderSelection, builderBlockValue, engineBlockValue, finalSelection]) => {
+    it(`builder selection = ${builderSelection}, builder blockValue = ${builderBlockValue}, engine blockValue = ${engineBlockValue} - expected selection = ${finalSelection} `, async function () {
+      if (builderBlockValue !== null) {
+        api.validator.produceBlindedBlock.resolves({
+          response: {
+            data: blindedBlock,
+            version: ForkName.bellatrix,
+            blockValue: BigInt(builderBlockValue),
+          },
+          ok: true,
+          status: HttpStatusCode.OK,
+        });
+      } else {
+        api.validator.produceBlindedBlock.throws(Error("not produced"));
+      }
 
-    api.validator.produceBlindedBlock.resolves({
-      data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(),
-      version: ForkName.bellatrix,
-      blockValue: BigInt(1),
+      if (engineBlockValue !== null) {
+        api.validator.produceBlock.resolves({
+          response: {data: fullBlock, blockValue: BigInt(engineBlockValue)},
+          ok: true,
+          status: HttpStatusCode.OK,
+        });
+        api.validator.produceBlockV2.resolves({
+          response: {
+            data: fullBlock,
+            version: ForkName.bellatrix,
+            blockValue: BigInt(engineBlockValue),
+          },
+          ok: true,
+          status: HttpStatusCode.OK,
+        });
+      } else {
+        api.validator.produceBlock.throws(Error("not produced"));
+        api.validator.produceBlockV2.throws(Error("not produced"));
+      }
+
+      const produceBlockOpts = {
+        strictFeeRecipientCheck: false,
+        expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        isBuilderEnabled: true,
+        builderSelection,
+      };
+      const {
+        debugLogCtx: {source},
+      } = ((await produceBlockWrapper(144897, randaoReveal, "", produceBlockOpts)) as unknown) as {
+        debugLogCtx: {source: string};
+      };
+      expect(source).to.equal(finalSelection, "blindedBlock must be returned");
     });
-    api.validator.produceBlock.resolves({data: fullBlock, blockValue: ssz.Wei.defaultValue()});
-    api.validator.produceBlockV2.resolves({
-      data: fullBlock,
-      version: ForkName.bellatrix,
-      blockValue: ssz.Wei.defaultValue(),
-    });
-
-    const produceBlockOpts = {
-      strictFeeRecipientCheck: false,
-      expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      isBuilderEnabled: true,
-      builderSelection: BuilderSelection.MaxProfit,
-    };
-    const returnedBlock = await produceBlockWrapper(144897, signedBlock.body.randaoReveal, "", produceBlockOpts);
-    expect(returnedBlock.data).to.deep.equal(signedBlock, "blindedBlock must be returned");
   });
-  it("2. BuilderSelection = MaxProfit - fullBlock blockValue > BlindedBlock blockValue - return FullBlock", async function () {
-    const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
-    const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
 
-    api.validator.produceBlindedBlock.resolves({
-      data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(),
-      version: ForkName.bellatrix,
-      blockValue: ssz.Wei.defaultValue(),
-    });
-    api.validator.produceBlock.resolves({data: fullBlock, blockValue: BigInt(1)});
-    api.validator.produceBlockV2.resolves({data: fullBlock, version: ForkName.bellatrix, blockValue: BigInt(1)});
+  // it("2. BuilderSelection = MaxProfit - fullBlock blockValue > BlindedBlock blockValue - return FullBlock", async function () {
+  //   const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
+  //   const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
 
-    const produceBlockOpts = {
-      strictFeeRecipientCheck: false,
-      expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      isBuilderEnabled: true,
-      builderSelection: BuilderSelection.MaxProfit,
-    };
-    const returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
-    expect(returnedBlock.data).to.deep.equal(fullBlock, "fullBlock must be returned");
-  });
-  it("3. BuilderSelection = BuilderAlways - return BlindedBlock", async function () {
-    const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
-    const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
+  //   api.validator.produceBlindedBlock.resolves({
+  //     data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(),
+  //     version: ForkName.bellatrix,
+  //     blockValue: ssz.Wei.defaultValue(),
+  //   });
+  //   api.validator.produceBlock.resolves({data: fullBlock, blockValue: BigInt(1)});
+  //   api.validator.produceBlockV2.resolves({data: fullBlock, version: ForkName.bellatrix, blockValue: BigInt(1)});
 
-    api.validator.produceBlindedBlock.resolves({
-      data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(),
-      version: ForkName.bellatrix,
-      blockValue: ssz.Wei.defaultValue(),
-    });
-    api.validator.produceBlock.resolves({data: fullBlock, blockValue: BigInt(1)});
-    api.validator.produceBlockV2.resolves({data: fullBlock, version: ForkName.bellatrix, blockValue: BigInt(1)});
+  //   const produceBlockOpts = {
+  //     strictFeeRecipientCheck: false,
+  //     expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  //     isBuilderEnabled: true,
+  //     builderSelection: BuilderSelection.MaxProfit,
+  //   };
+  //   const returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
+  //   expect(returnedBlock.data).to.deep.equal(fullBlock, "fullBlock must be returned");
+  // });
+  // it("3. BuilderSelection = BuilderAlways - return BlindedBlock", async function () {
+  //   const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
+  //   const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
 
-    const produceBlockOpts = {
-      strictFeeRecipientCheck: false,
-      expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      isBuilderEnabled: true,
-      builderSelection: BuilderSelection.BuilderAlways,
-    };
-    const returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
-    expect(returnedBlock.data).to.deep.equal(signedBlock, "blindedBlock must be returned");
-  });
-  it("4. fullBlock - null, BlindedBlock !=null return blindedBlock", async function () {
-    const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
-    //const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
+  //   api.validator.produceBlindedBlock.resolves({
+  //     data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(),
+  //     version: ForkName.bellatrix,
+  //     blockValue: ssz.Wei.defaultValue(),
+  //   });
+  //   api.validator.produceBlock.resolves({data: fullBlock, blockValue: BigInt(1)});
+  //   api.validator.produceBlockV2.resolves({data: fullBlock, version: ForkName.bellatrix, blockValue: BigInt(1)});
 
-    api.validator.produceBlindedBlock.resolves({
-      data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(),
-      version: ForkName.bellatrix,
-      blockValue: ssz.Wei.defaultValue(),
-    });
-    api.validator.produceBlock.resolves();
-    api.validator.produceBlockV2.resolves();
+  //   const produceBlockOpts = {
+  //     strictFeeRecipientCheck: false,
+  //     expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  //     isBuilderEnabled: true,
+  //     builderSelection: BuilderSelection.BuilderAlways,
+  //   };
+  //   const returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
+  //   expect(returnedBlock.data).to.deep.equal(signedBlock, "blindedBlock must be returned");
+  // });
+  // it("4. fullBlock - null, BlindedBlock !=null return blindedBlock", async function () {
+  //   const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
+  //   //const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
 
-    let produceBlockOpts = {
-      strictFeeRecipientCheck: false,
-      expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      isBuilderEnabled: true,
-      builderSelection: BuilderSelection.BuilderAlways,
-    };
-    let returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
-    expect(returnedBlock.data).to.deep.equal(signedBlock, "blindedBlock must be returned");
-    produceBlockOpts = {
-      strictFeeRecipientCheck: false,
-      expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      isBuilderEnabled: true,
-      builderSelection: BuilderSelection.MaxProfit,
-    };
-    returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
-    expect(returnedBlock.data).to.deep.equal(signedBlock, "blindedBlock must be returned");
-  });
-  it("5. fullBlock != null, BlindedBlock =null return fullBlock", async function () {
-    const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
-    const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
+  //   api.validator.produceBlindedBlock.resolves({
+  //     data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(),
+  //     version: ForkName.bellatrix,
+  //     blockValue: ssz.Wei.defaultValue(),
+  //   });
+  //   api.validator.produceBlock.resolves();
+  //   api.validator.produceBlockV2.resolves();
 
-    api.validator.produceBlindedBlock.resolves();
-    api.validator.produceBlock.resolves({data: fullBlock, blockValue: BigInt(1)});
-    api.validator.produceBlockV2.resolves({data: fullBlock, version: ForkName.bellatrix, blockValue: BigInt(1)});
+  //   let produceBlockOpts = {
+  //     strictFeeRecipientCheck: false,
+  //     expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  //     isBuilderEnabled: true,
+  //     builderSelection: BuilderSelection.BuilderAlways,
+  //   };
+  //   let returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
+  //   expect(returnedBlock.data).to.deep.equal(signedBlock, "blindedBlock must be returned");
+  //   produceBlockOpts = {
+  //     strictFeeRecipientCheck: false,
+  //     expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  //     isBuilderEnabled: true,
+  //     builderSelection: BuilderSelection.MaxProfit,
+  //   };
+  //   returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
+  //   expect(returnedBlock.data).to.deep.equal(signedBlock, "blindedBlock must be returned");
+  // });
+  // it("5. fullBlock != null, BlindedBlock =null return fullBlock", async function () {
+  //   const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
+  //   const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
 
-    let produceBlockOpts = {
-      strictFeeRecipientCheck: false,
-      expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      isBuilderEnabled: true,
-      builderSelection: BuilderSelection.BuilderAlways,
-    };
-    let returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
-    expect(returnedBlock.data).to.deep.equal(fullBlock, "fullBlock must be returned");
-    produceBlockOpts = {
-      strictFeeRecipientCheck: false,
-      expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      isBuilderEnabled: true,
-      builderSelection: BuilderSelection.MaxProfit,
-    };
-    returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
-    expect(returnedBlock.data).to.deep.equal(fullBlock, "fullBlock must be returned");
-  });
-  it("6. !fullBlock, !BlindedBlock, throw error", async function () {
-    const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
+  //   api.validator.produceBlindedBlock.resolves();
+  //   api.validator.produceBlock.resolves({data: fullBlock, blockValue: BigInt(1)});
+  //   api.validator.produceBlockV2.resolves({data: fullBlock, version: ForkName.bellatrix, blockValue: BigInt(1)});
 
-    api.validator.produceBlindedBlock.resolves();
-    api.validator.produceBlock.resolves();
-    api.validator.produceBlockV2.resolves();
+  //   let produceBlockOpts = {
+  //     strictFeeRecipientCheck: false,
+  //     expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  //     isBuilderEnabled: true,
+  //     builderSelection: BuilderSelection.BuilderAlways,
+  //   };
+  //   let returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
+  //   expect(returnedBlock.data).to.deep.equal(fullBlock, "fullBlock must be returned");
+  //   produceBlockOpts = {
+  //     strictFeeRecipientCheck: false,
+  //     expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  //     isBuilderEnabled: true,
+  //     builderSelection: BuilderSelection.MaxProfit,
+  //   };
+  //   returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
+  //   expect(returnedBlock.data).to.deep.equal(fullBlock, "fullBlock must be returned");
+  // });
+  // it("6. !fullBlock, !BlindedBlock, throw error", async function () {
+  //   const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
 
-    const produceBlockOpts = {
-      strictFeeRecipientCheck: false,
-      expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      isBuilderEnabled: true,
-      builderSelection: BuilderSelection.MaxProfit,
-    };
+  //   api.validator.produceBlindedBlock.resolves();
+  //   api.validator.produceBlock.resolves();
+  //   api.validator.produceBlockV2.resolves();
 
-    try {
-      await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
-    } catch (e) {
-      expect(e).to.be.instanceOf(Error);
-    }
-  });
+  //   const produceBlockOpts = {
+  //     strictFeeRecipientCheck: false,
+  //     expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  //     isBuilderEnabled: true,
+  //     builderSelection: BuilderSelection.MaxProfit,
+  //   };
+
+  //   try {
+  //     await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
+  //   } catch (e) {
+  //     expect(e).to.be.instanceOf(Error);
+  //   }
+  // });
 });

--- a/packages/validator/test/unit/services/produceBlockwrapper.test.ts
+++ b/packages/validator/test/unit/services/produceBlockwrapper.test.ts
@@ -34,8 +34,16 @@ describe("Produce Block with BuilderSelection", function () {
 
   // Testcase: BuilderSelection, builderBlockValue, engineBlockValue, selection
   // null blockValue means the block was not produced
-  const testCases: [BuilderSelection, number | null, number, string][] = [
+  const testCases: [BuilderSelection, number | null, number | null, string][] = [
     [BuilderSelection.MaxProfit, 1, 0, "builder"],
+    [BuilderSelection.MaxProfit, 1, 2, "engine"],
+    [BuilderSelection.MaxProfit, null, 0, "engine"],
+    [BuilderSelection.MaxProfit, 0, null, "builder"],
+
+    [BuilderSelection.BuilderAlways, 1, 2, "builder"],
+    [BuilderSelection.BuilderAlways, 1, 0, "builder"],
+    [BuilderSelection.BuilderAlways, null, 0, "engine"],
+    [BuilderSelection.BuilderAlways, 0, null, "builder"],
   ];
   testCases.forEach(([builderSelection, builderBlockValue, engineBlockValue, finalSelection]) => {
     it(`builder selection = ${builderSelection}, builder blockValue = ${builderBlockValue}, engine blockValue = ${engineBlockValue} - expected selection = ${finalSelection} `, async function () {
@@ -87,121 +95,4 @@ describe("Produce Block with BuilderSelection", function () {
       expect(source).to.equal(finalSelection, "blindedBlock must be returned");
     });
   });
-
-  // it("2. BuilderSelection = MaxProfit - fullBlock blockValue > BlindedBlock blockValue - return FullBlock", async function () {
-  //   const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
-  //   const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
-
-  //   api.validator.produceBlindedBlock.resolves({
-  //     data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(),
-  //     version: ForkName.bellatrix,
-  //     blockValue: ssz.Wei.defaultValue(),
-  //   });
-  //   api.validator.produceBlock.resolves({data: fullBlock, blockValue: BigInt(1)});
-  //   api.validator.produceBlockV2.resolves({data: fullBlock, version: ForkName.bellatrix, blockValue: BigInt(1)});
-
-  //   const produceBlockOpts = {
-  //     strictFeeRecipientCheck: false,
-  //     expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  //     isBuilderEnabled: true,
-  //     builderSelection: BuilderSelection.MaxProfit,
-  //   };
-  //   const returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
-  //   expect(returnedBlock.data).to.deep.equal(fullBlock, "fullBlock must be returned");
-  // });
-  // it("3. BuilderSelection = BuilderAlways - return BlindedBlock", async function () {
-  //   const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
-  //   const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
-
-  //   api.validator.produceBlindedBlock.resolves({
-  //     data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(),
-  //     version: ForkName.bellatrix,
-  //     blockValue: ssz.Wei.defaultValue(),
-  //   });
-  //   api.validator.produceBlock.resolves({data: fullBlock, blockValue: BigInt(1)});
-  //   api.validator.produceBlockV2.resolves({data: fullBlock, version: ForkName.bellatrix, blockValue: BigInt(1)});
-
-  //   const produceBlockOpts = {
-  //     strictFeeRecipientCheck: false,
-  //     expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  //     isBuilderEnabled: true,
-  //     builderSelection: BuilderSelection.BuilderAlways,
-  //   };
-  //   const returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
-  //   expect(returnedBlock.data).to.deep.equal(signedBlock, "blindedBlock must be returned");
-  // });
-  // it("4. fullBlock - null, BlindedBlock !=null return blindedBlock", async function () {
-  //   const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
-  //   //const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
-
-  //   api.validator.produceBlindedBlock.resolves({
-  //     data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(),
-  //     version: ForkName.bellatrix,
-  //     blockValue: ssz.Wei.defaultValue(),
-  //   });
-  //   api.validator.produceBlock.resolves();
-  //   api.validator.produceBlockV2.resolves();
-
-  //   let produceBlockOpts = {
-  //     strictFeeRecipientCheck: false,
-  //     expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  //     isBuilderEnabled: true,
-  //     builderSelection: BuilderSelection.BuilderAlways,
-  //   };
-  //   let returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
-  //   expect(returnedBlock.data).to.deep.equal(signedBlock, "blindedBlock must be returned");
-  //   produceBlockOpts = {
-  //     strictFeeRecipientCheck: false,
-  //     expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  //     isBuilderEnabled: true,
-  //     builderSelection: BuilderSelection.MaxProfit,
-  //   };
-  //   returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
-  //   expect(returnedBlock.data).to.deep.equal(signedBlock, "blindedBlock must be returned");
-  // });
-  // it("5. fullBlock != null, BlindedBlock =null return fullBlock", async function () {
-  //   const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
-  //   const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
-
-  //   api.validator.produceBlindedBlock.resolves();
-  //   api.validator.produceBlock.resolves({data: fullBlock, blockValue: BigInt(1)});
-  //   api.validator.produceBlockV2.resolves({data: fullBlock, version: ForkName.bellatrix, blockValue: BigInt(1)});
-
-  //   let produceBlockOpts = {
-  //     strictFeeRecipientCheck: false,
-  //     expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  //     isBuilderEnabled: true,
-  //     builderSelection: BuilderSelection.BuilderAlways,
-  //   };
-  //   let returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
-  //   expect(returnedBlock.data).to.deep.equal(fullBlock, "fullBlock must be returned");
-  //   produceBlockOpts = {
-  //     strictFeeRecipientCheck: false,
-  //     expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  //     isBuilderEnabled: true,
-  //     builderSelection: BuilderSelection.MaxProfit,
-  //   };
-  //   returnedBlock = await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
-  //   expect(returnedBlock.data).to.deep.equal(fullBlock, "fullBlock must be returned");
-  // });
-  // it("6. !fullBlock, !BlindedBlock, throw error", async function () {
-  //   const signedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
-
-  //   api.validator.produceBlindedBlock.resolves();
-  //   api.validator.produceBlock.resolves();
-  //   api.validator.produceBlockV2.resolves();
-
-  //   const produceBlockOpts = {
-  //     strictFeeRecipientCheck: false,
-  //     expectedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  //     isBuilderEnabled: true,
-  //     builderSelection: BuilderSelection.MaxProfit,
-  //   };
-
-  //   try {
-  //     await produceBlockWrapper(144900, signedBlock.body.randaoReveal, "", produceBlockOpts);
-  //   } catch (e) {
-  //     expect(e).to.be.instanceOf(Error);
-  //   }
-  // });
 });


### PR DESCRIPTION
PR 
- https://github.com/ChainSafe/lodestar/pull/5003
enabled propagating `blockValue` to validator for builder and engine blocks but the selection logic was unchanged.

This PR takes #5003 to completion by adding a validator option to specify the builder vs engine block strategy with two options:
- either  `--builder.selection builderalways`
- or `--builder.selection maxprofit`
with the self explanatory selection behavior

PS:
Even though builder `blockValue` is always available, but engine's blockValue is/will be only available capella onwards where execution engine provide get_payloadV2 endpoint which returns `blockValue` of the engine block. 
In the case of non-availability, the engine blockValue will be defauled to `0` and hence builder will always be picked so `maxprofit` startegy collapses to `builderalways` in that case
