### PR TITLE
Reset peerScore histogram

### DIFF
--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -638,6 +638,7 @@ export class PeerManager {
 
     // peerLongLivedAttnets metric is a count
     metrics.peerLongLivedAttnets.reset();
+    metrics.peerScore.reset();
     metrics.peerConnectionLength.reset();
 
     // reset client counts _for each client_ to 0


### PR DESCRIPTION
**Motivation**

This specific histogram captures current state not a total, so must be reset before observing values

**Description**

Reset peerScore histogram
