### PR TITLE
Add getPeerLogMetadata to ReqResp

### DIFF
--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -85,6 +85,9 @@ export class ReqRespBeaconNode extends ReqResp implements IReqRespBeaconNode {
           peerRpcScores.applyAction(peerId, PeerAction.Fatal, "rate_limit_rpc");
           metrics?.reqResp.rateLimitErrors.inc({method});
         },
+        getPeerLogMetadata(peerId) {
+          return peersData.getPeerKind(peerId);
+        },
       }
     );
 


### PR DESCRIPTION
**Motivation**

ReqResp logs allways print `client=undefined`, because it's missing a getter for the client kind

**Description**

- Add getPeerLogMetadata to ReqResp