### PR TITLE
Update to @chainsafe/discv5 v3.0.0

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -95,7 +95,7 @@
     "@chainsafe/as-chacha20poly1305": "^0.1.0",
     "@chainsafe/as-sha256": "^0.3.1",
     "@chainsafe/bls": "7.1.1",
-    "@chainsafe/discv5": "^2.1.1",
+    "@chainsafe/discv5": "^3.0.0",
     "@chainsafe/libp2p-gossipsub": "^6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0",
     "@chainsafe/persistent-merkle-tree": "^0.4.2",

--- a/packages/beacon-node/src/api/impl/node/index.ts
+++ b/packages/beacon-node/src/api/impl/node/index.ts
@@ -1,5 +1,4 @@
 import {routes, ServerApi} from "@lodestar/api";
-import {createKeypairFromPeerId} from "@chainsafe/discv5";
 import {ApiError} from "../errors.js";
 import {ApiModules} from "../types.js";
 import {IApiOptions} from "../../options.js";
@@ -12,7 +11,6 @@ export function getNodeApi(
   return {
     async getNetworkIdentity() {
       const enr = await network.getEnr();
-      const keypair = createKeypairFromPeerId(network.peerId);
       const discoveryAddresses = [
         enr?.getLocationMultiaddr("tcp")?.toString() ?? null,
         enr?.getLocationMultiaddr("udp")?.toString() ?? null,
@@ -21,7 +19,7 @@ export function getNodeApi(
       return {
         data: {
           peerId: network.peerId.toString(),
-          enr: enr?.encodeTxt(keypair.privateKey) || "",
+          enr: enr?.encodeTxt() || "",
           discoveryAddresses,
           p2pAddresses: network.localMultiaddrs.map((m) => m.toString()),
           metadata: network.metadata,

--- a/packages/beacon-node/src/network/discv5/index.ts
+++ b/packages/beacon-node/src/network/discv5/index.ts
@@ -2,7 +2,14 @@ import EventEmitter from "events";
 import {PeerId} from "@libp2p/interface-peer-id";
 import StrictEventEmitter from "strict-event-emitter-types";
 import {exportToProtobuf} from "@libp2p/peer-id-factory";
-import {createKeypairFromPeerId, ENR, ENRData, IDiscv5DiscoveryInputOptions, IKeypair, SignableENR} from "@chainsafe/discv5";
+import {
+  createKeypairFromPeerId,
+  ENR,
+  ENRData,
+  IDiscv5DiscoveryInputOptions,
+  IKeypair,
+  SignableENR,
+} from "@chainsafe/discv5";
 import {spawn, Thread, Worker} from "@chainsafe/threads";
 import {ILogger} from "@lodestar/utils";
 import {IMetrics} from "../../metrics/metrics.js";
@@ -42,7 +49,6 @@ export class Discv5Worker extends (EventEmitter as {new (): StrictEventEmitter<E
   async start(): Promise<void> {
     if (this.status.status === "started") return;
 
-    const keypair = createKeypairFromPeerId(this.opts.peerId);
     const workerData: Discv5WorkerData = {
       enr: (this.opts.discv5.enr as SignableENR).toObject(),
       peerIdProto: exportToProtobuf(this.opts.peerId),

--- a/packages/beacon-node/src/network/discv5/index.ts
+++ b/packages/beacon-node/src/network/discv5/index.ts
@@ -65,7 +65,7 @@ export class Discv5Worker extends (EventEmitter as {new (): StrictEventEmitter<E
       timeout: 5 * 60 * 1000,
     });
 
-    const subscription = workerApi.discovered().subscribe((enrStr) => this.onDiscovered(enrStr));
+    const subscription = workerApi.discovered().subscribe((enrObj) => this.onDiscovered(enrObj));
 
     this.status = {status: "started", workerApi, subscription};
   }

--- a/packages/beacon-node/src/network/discv5/index.ts
+++ b/packages/beacon-node/src/network/discv5/index.ts
@@ -2,7 +2,7 @@ import EventEmitter from "events";
 import {PeerId} from "@libp2p/interface-peer-id";
 import StrictEventEmitter from "strict-event-emitter-types";
 import {exportToProtobuf} from "@libp2p/peer-id-factory";
-import {createKeypairFromPeerId, ENR, IDiscv5DiscoveryInputOptions} from "@chainsafe/discv5";
+import {createKeypairFromPeerId, ENR, ENRData, IDiscv5DiscoveryInputOptions, IKeypair, SignableENR} from "@chainsafe/discv5";
 import {spawn, Thread, Worker} from "@chainsafe/threads";
 import {ILogger} from "@lodestar/utils";
 import {IMetrics} from "../../metrics/metrics.js";
@@ -29,12 +29,14 @@ type Discv5WorkerStatus =
 export class Discv5Worker extends (EventEmitter as {new (): StrictEventEmitter<EventEmitter, IDiscv5Events>}) {
   private logger: ILogger;
   private status: Discv5WorkerStatus;
+  private keypair: IKeypair;
 
   constructor(private opts: Discv5Opts) {
     super();
 
     this.logger = opts.logger;
     this.status = {status: "stopped"};
+    this.keypair = createKeypairFromPeerId(this.opts.peerId);
   }
 
   async start(): Promise<void> {
@@ -42,7 +44,7 @@ export class Discv5Worker extends (EventEmitter as {new (): StrictEventEmitter<E
 
     const keypair = createKeypairFromPeerId(this.opts.peerId);
     const workerData: Discv5WorkerData = {
-      enrStr: (this.opts.discv5.enr as ENR).encodeTxt(keypair.privateKey),
+      enr: (this.opts.discv5.enr as SignableENR).toObject(),
       peerIdProto: exportToProtobuf(this.opts.peerId),
       bindAddr: this.opts.discv5.bindAddr,
       config: this.opts.discv5,
@@ -57,7 +59,7 @@ export class Discv5Worker extends (EventEmitter as {new (): StrictEventEmitter<E
       timeout: 5 * 60 * 1000,
     });
 
-    const subscription = workerApi.discoveredBuf().subscribe((enrStr) => this.onDiscoveredStr(enrStr));
+    const subscription = workerApi.discovered().subscribe((enrStr) => this.onDiscovered(enrStr));
 
     this.status = {status: "started", workerApi, subscription};
   }
@@ -72,16 +74,17 @@ export class Discv5Worker extends (EventEmitter as {new (): StrictEventEmitter<E
     this.status = {status: "stopped"};
   }
 
-  onDiscoveredStr(enrBuf: Uint8Array): void {
-    const enr = this.decodeEnr(enrBuf);
+  onDiscovered(obj: ENRData): void {
+    const enr = this.decodeEnr(obj);
     if (enr) {
       this.emit("discovered", enr);
     }
   }
 
-  async enr(): Promise<ENR> {
+  async enr(): Promise<SignableENR> {
     if (this.status.status === "started") {
-      return ENR.decode(Buffer.from(await this.status.workerApi.enrBuf()));
+      const obj = await this.status.workerApi.enr();
+      return new SignableENR(obj.kvs, obj.seq, this.keypair);
     } else {
       throw new Error("Cannot get enr before module is started");
     }
@@ -97,7 +100,7 @@ export class Discv5Worker extends (EventEmitter as {new (): StrictEventEmitter<E
 
   async kadValues(): Promise<ENR[]> {
     if (this.status.status === "started") {
-      return this.decodeEnrs(await this.status.workerApi.kadValuesBuf());
+      return this.decodeEnrs(await this.status.workerApi.kadValues());
     } else {
       return [];
     }
@@ -105,7 +108,7 @@ export class Discv5Worker extends (EventEmitter as {new (): StrictEventEmitter<E
 
   async findRandomNode(): Promise<ENR[]> {
     if (this.status.status === "started") {
-      return this.decodeEnrs(await this.status.workerApi.findRandomNodeBuf());
+      return this.decodeEnrs(await this.status.workerApi.findRandomNode());
     } else {
       return [];
     }
@@ -119,10 +122,10 @@ export class Discv5Worker extends (EventEmitter as {new (): StrictEventEmitter<E
     }
   }
 
-  private decodeEnrs(enrBufs: Uint8Array[]): ENR[] {
+  private decodeEnrs(objs: ENRData[]): ENR[] {
     const enrs: ENR[] = [];
-    for (const enrBuf of enrBufs) {
-      const enr = this.decodeEnr(enrBuf);
+    for (const obj of objs) {
+      const enr = this.decodeEnr(obj);
       if (enr) {
         enrs.push(enr);
       }
@@ -130,18 +133,8 @@ export class Discv5Worker extends (EventEmitter as {new (): StrictEventEmitter<E
     return enrs;
   }
 
-  private decodeEnr(enrBuf: Uint8Array): ENR | null {
-    try {
-      this.opts.metrics?.discv5.decodeEnrAttemptCount.inc(1);
-      return ENR.decode(Buffer.from(enrBuf));
-    } catch (e) {
-      this.opts.metrics?.discv5.decodeEnrErrorCount.inc(1);
-      // Log to recover ENR from logs and debug why it is invalid
-      this.logger.debug("ENR decode error", {
-        enr: Buffer.from(enrBuf).toString("base64url"),
-        error: (e as Error).message,
-      });
-      return null;
-    }
+  private decodeEnr(obj: ENRData): ENR | null {
+    this.opts.metrics?.discv5.decodeEnrAttemptCount.inc(1);
+    return new ENR(obj.kvs, obj.seq, obj.signature);
   }
 }

--- a/packages/beacon-node/src/network/discv5/types.ts
+++ b/packages/beacon-node/src/network/discv5/types.ts
@@ -1,4 +1,4 @@
-import {Discv5} from "@chainsafe/discv5";
+import {Discv5, ENRData, SignableENRData} from "@chainsafe/discv5";
 import {Observable} from "@chainsafe/threads/observable";
 
 // TODO export IDiscv5Config so we don't need this convoluted type
@@ -6,7 +6,7 @@ type Discv5Config = Parameters<typeof Discv5["create"]>[0]["config"];
 
 /** discv5 worker constructor data */
 export interface Discv5WorkerData {
-  enrStr: string;
+  enr: SignableENRData;
   peerIdProto: Uint8Array;
   bindAddr: string;
   config: Discv5Config;
@@ -21,16 +21,16 @@ export interface Discv5WorkerData {
  */
 export type Discv5WorkerApi = {
   /** The current host ENR */
-  enrBuf(): Promise<Uint8Array>;
+  enr(): Promise<SignableENRData>;
   /** Set a key-value of the current host ENR */
   setEnrValue(key: string, value: Uint8Array): Promise<void>;
 
   /** Return the ENRs currently in the kad table */
-  kadValuesBuf(): Promise<Uint8Array[]>;
+  kadValues(): Promise<ENRData[]>;
   /** Begin a random search through the DHT, return discovered ENRs */
-  findRandomNodeBuf(): Promise<Uint8Array[]>;
+  findRandomNode(): Promise<ENRData[]>;
   /** Stream of discovered ENRs */
-  discoveredBuf(): Observable<Uint8Array>;
+  discovered(): Observable<ENRData>;
 
   /** Prometheus metrics string */
   metrics(): Promise<string>;

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -4,7 +4,7 @@ import {Registrar} from "@libp2p/interface-registrar";
 import {Multiaddr} from "@multiformats/multiaddr";
 import {PeerId} from "@libp2p/interface-peer-id";
 import {ConnectionManager} from "@libp2p/interface-connection-manager";
-import {ENR} from "@chainsafe/discv5";
+import {SignableENR} from "@chainsafe/discv5";
 import {phase0} from "@lodestar/types";
 import {BlockInput} from "../chain/blocks/types.js";
 import {INetworkEventBus} from "./events.js";
@@ -32,7 +32,7 @@ export interface INetwork {
   /** Our network identity */
   peerId: PeerId;
   localMultiaddrs: Multiaddr[];
-  getEnr(): Promise<ENR | undefined>;
+  getEnr(): Promise<SignableENR | undefined>;
   getConnectionsByPeer(): Map<string, Connection[]>;
   getConnectedPeers(): PeerId[];
   hasSomeConnectedPeer(): boolean;

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -4,7 +4,7 @@ import {Multiaddr} from "@multiformats/multiaddr";
 import {IBeaconConfig} from "@lodestar/config";
 import {ILogger, sleep} from "@lodestar/utils";
 import {ATTESTATION_SUBNET_COUNT, ForkName, ForkSeq, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
-import {ENR} from "@chainsafe/discv5";
+import {SignableENR} from "@chainsafe/discv5";
 import {computeEpochAtSlot, computeTimeAtSlot} from "@lodestar/state-transition";
 import {altair, eip4844, Epoch, phase0} from "@lodestar/types";
 import {routes} from "@lodestar/api";
@@ -199,7 +199,7 @@ export class Network implements INetwork {
     return this.libp2p.peerId;
   }
 
-  async getEnr(): Promise<ENR | undefined> {
+  async getEnr(): Promise<SignableENR | undefined> {
     return await this.peerManager["discovery"]?.discv5.enr();
   }
 

--- a/packages/beacon-node/src/network/nodejs/util.ts
+++ b/packages/beacon-node/src/network/nodejs/util.ts
@@ -1,6 +1,6 @@
 import {PeerId} from "@libp2p/interface-peer-id";
 import {Registry} from "prom-client";
-import {ENR} from "@chainsafe/discv5";
+import {ENR, SignableENR} from "@chainsafe/discv5";
 import {Libp2p} from "../interface.js";
 import {Eth2PeerDataStore} from "../peers/datastore.js";
 import {defaultDiscv5Options, defaultNetworkOptions, INetworkOptions} from "../options.js";
@@ -32,7 +32,7 @@ export async function createNodeJsLibp2p(
   const {peerStoreDir, disablePeerDiscovery} = nodeJsLibp2pOpts;
 
   if (enr !== undefined && typeof enr !== "string") {
-    if (enr instanceof ENR) {
+    if (enr instanceof SignableENR) {
       if (enr.getLocationMultiaddr("udp") && !isLocalMultiAddr(enr.getLocationMultiaddr("udp"))) {
         clearMultiaddrUDP(enr);
       }

--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -1,4 +1,4 @@
-import {ENR, IDiscv5DiscoveryInputOptions} from "@chainsafe/discv5";
+import {ENR, generateKeypair, IDiscv5DiscoveryInputOptions, KeypairType, SignableENR} from "@chainsafe/discv5";
 import {Eth2GossipsubOpts} from "./gossip/gossipsub.js";
 import {defaultGossipHandlerOpts, GossipHandlerOpts} from "./gossip/handlers/index.js";
 import {PeerManagerOpts} from "./peers/index.js";
@@ -15,7 +15,7 @@ export interface INetworkOptions extends PeerManagerOpts, ReqRespBeaconNodeOpts,
 
 export const defaultDiscv5Options: IDiscv5DiscoveryInputOptions = {
   bindAddr: "/ip4/0.0.0.0/udp/9000",
-  enr: new ENR(),
+  enr: SignableENR.createV4(generateKeypair(KeypairType.Secp256k1)),
   bootEnrs: [],
   enrUpdate: true,
   enabled: true,

--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -1,4 +1,4 @@
-import {ENR, generateKeypair, IDiscv5DiscoveryInputOptions, KeypairType, SignableENR} from "@chainsafe/discv5";
+import {generateKeypair, IDiscv5DiscoveryInputOptions, KeypairType, SignableENR} from "@chainsafe/discv5";
 import {Eth2GossipsubOpts} from "./gossip/gossipsub.js";
 import {defaultGossipHandlerOpts, GossipHandlerOpts} from "./gossip/handlers/index.js";
 import {PeerManagerOpts} from "./peers/index.js";

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -335,7 +335,7 @@ export class PeerDiscovery {
       }
 
       // Check if the ENR.eth2 field matches and is of interest
-      const eth2 = enr.get(ENRKey.eth2);
+      const eth2 = enr.kvs.get(ENRKey.eth2);
       if (!eth2) {
         return DiscoveredPeerStatus.no_eth2;
       }
@@ -370,8 +370,8 @@ export class PeerDiscovery {
       }
 
       // Are this fields mandatory?
-      const attnetsBytes = enr.get(ENRKey.attnets); // 64 bits
-      const syncnetsBytes = enr.get(ENRKey.syncnets); // 4 bits
+      const attnetsBytes = enr.kvs.get(ENRKey.attnets); // 64 bits
+      const syncnetsBytes = enr.kvs.get(ENRKey.syncnets); // 4 bits
 
       // Use faster version than ssz's implementation that leverages pre-cached.
       // Some nodes don't serialize the bitfields properly, encoding the syncnets as attnets,

--- a/packages/beacon-node/src/network/util.ts
+++ b/packages/beacon-node/src/network/util.ts
@@ -6,7 +6,7 @@ import type {ConnectionManager} from "@libp2p/interface-connection-manager";
 import type {Components} from "libp2p/components.js";
 import type {DefaultConnectionManager} from "libp2p/connection-manager/index.js";
 import type {DefaultDialer} from "libp2p/connection-manager/dialer/index.js";
-import type {ENR, SignableENR} from "@chainsafe/discv5";
+import type {SignableENR} from "@chainsafe/discv5";
 import type {Libp2p} from "./interface.js";
 
 // peers

--- a/packages/beacon-node/src/network/util.ts
+++ b/packages/beacon-node/src/network/util.ts
@@ -6,7 +6,7 @@ import type {ConnectionManager} from "@libp2p/interface-connection-manager";
 import type {Components} from "libp2p/components.js";
 import type {DefaultConnectionManager} from "libp2p/connection-manager/index.js";
 import type {DefaultDialer} from "libp2p/connection-manager/dialer/index.js";
-import type {ENR} from "@chainsafe/discv5";
+import type {ENR, SignableENR} from "@chainsafe/discv5";
 import type {Libp2p} from "./interface.js";
 
 // peers
@@ -53,7 +53,7 @@ export function isLocalMultiAddr(multiaddr: Multiaddr | undefined): boolean {
   return false;
 }
 
-export function clearMultiaddrUDP(enr: ENR): void {
+export function clearMultiaddrUDP(enr: SignableENR): void {
   // enr.multiaddrUDP = undefined in new version
   enr.delete("ip");
   enr.delete("udp");

--- a/packages/beacon-node/test/e2e/network/mdns.test.ts
+++ b/packages/beacon-node/test/e2e/network/mdns.test.ts
@@ -3,7 +3,7 @@ import {expect} from "chai";
 
 import {PeerId} from "@libp2p/interface-peer-id";
 import {multiaddr} from "@multiformats/multiaddr";
-import {createKeypairFromPeerId, ENR} from "@chainsafe/discv5";
+import {SignableENR} from "@chainsafe/discv5";
 import {createIBeaconConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
 import {ssz} from "@lodestar/types";
@@ -42,9 +42,8 @@ describe("mdns", function () {
 
   async function getOpts(peerId: PeerId): Promise<INetworkOptions> {
     const bindAddrUdp = `/ip4/0.0.0.0/udp/${port++}`;
-    const enr = ENR.createFromPeerId(peerId);
+    const enr = SignableENR.createFromPeerId(peerId);
     enr.setLocationMultiaddr(multiaddr(bindAddrUdp));
-    enr.encode(createKeypairFromPeerId(peerId).privateKey);
 
     return {
       ...defaultNetworkOptions,

--- a/packages/beacon-node/test/e2e/network/network.test.ts
+++ b/packages/beacon-node/test/e2e/network/network.test.ts
@@ -3,7 +3,7 @@ import {expect} from "chai";
 
 import {PeerId} from "@libp2p/interface-peer-id";
 import {multiaddr} from "@multiformats/multiaddr";
-import {createKeypairFromPeerId, ENR} from "@chainsafe/discv5";
+import {SignableENR} from "@chainsafe/discv5";
 import {createIBeaconConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
 import {phase0, ssz} from "@lodestar/types";
@@ -46,9 +46,8 @@ describe("network", function () {
 
   async function getOpts(peerId: PeerId): Promise<INetworkOptions> {
     const bindAddrUdp = `/ip4/0.0.0.0/udp/${port++}`;
-    const enr = ENR.createFromPeerId(peerId);
+    const enr = SignableENR.createFromPeerId(peerId);
     enr.setLocationMultiaddr(multiaddr(bindAddrUdp));
-    enr.encode(createKeypairFromPeerId(peerId).privateKey);
 
     return {
       ...defaultNetworkOptions,

--- a/packages/beacon-node/test/unit/api/impl/node/node.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/node/node.test.ts
@@ -4,7 +4,7 @@ import {PeerId} from "@libp2p/interface-peer-id";
 import {expect} from "chai";
 import {multiaddr} from "@multiformats/multiaddr";
 import {createSecp256k1PeerId} from "@libp2p/peer-id-factory";
-import {createKeypairFromPeerId, ENR} from "@chainsafe/discv5";
+import {createKeypairFromPeerId, SignableENR} from "@chainsafe/discv5";
 import {BitArray} from "@chainsafe/ssz";
 import {altair} from "@lodestar/types";
 import {routes} from "@lodestar/api";
@@ -49,7 +49,7 @@ describe("node api implementation", function () {
   describe("getNetworkIdentity", function () {
     it("should get node identity", async function () {
       const keypair = createKeypairFromPeerId(peerId);
-      const enr = ENR.createV4(keypair.publicKey);
+      const enr = SignableENR.createV4(keypair);
       enr.setLocationMultiaddr(multiaddr("/ip4/127.0.0.1/tcp/36001"));
       networkStub.getEnr.returns(Promise.resolve(enr));
       networkStub.metadata = {

--- a/packages/beacon-node/test/unit/network/util.test.ts
+++ b/packages/beacon-node/test/unit/network/util.test.ts
@@ -3,7 +3,7 @@ import {expect} from "chai";
 import {createSecp256k1PeerId} from "@libp2p/peer-id-factory";
 import {config} from "@lodestar/config/default";
 import {ForkName} from "@lodestar/params";
-import {ENR, generateKeypair, KeypairType, SignableENR} from "@chainsafe/discv5";
+import {generateKeypair, KeypairType, SignableENR} from "@chainsafe/discv5";
 import {defaultNetworkOptions} from "../../../src/network/options.js";
 import {createNodeJsLibp2p, isLocalMultiAddr} from "../../../src/network/index.js";
 import {getCurrentAndNextFork} from "../../../src/network/forks.js";

--- a/packages/beacon-node/test/unit/network/util.test.ts
+++ b/packages/beacon-node/test/unit/network/util.test.ts
@@ -3,7 +3,7 @@ import {expect} from "chai";
 import {createSecp256k1PeerId} from "@libp2p/peer-id-factory";
 import {config} from "@lodestar/config/default";
 import {ForkName} from "@lodestar/params";
-import {ENR} from "@chainsafe/discv5";
+import {ENR, generateKeypair, KeypairType, SignableENR} from "@chainsafe/discv5";
 import {defaultNetworkOptions} from "../../../src/network/options.js";
 import {createNodeJsLibp2p, isLocalMultiAddr} from "../../../src/network/index.js";
 import {getCurrentAndNextFork} from "../../../src/network/forks.js";
@@ -63,7 +63,7 @@ describe("createNodeJsLibp2p", () => {
         connectToDiscv5Bootnodes: true,
         discv5: {
           enabled: false,
-          enr: new ENR(),
+          enr: SignableENR.createV4(generateKeypair(KeypairType.Secp256k1)),
           bindAddr: "/ip4/127.0.0.1/udp/0",
           bootEnrs: enrWithTcp,
         },
@@ -93,7 +93,7 @@ describe("createNodeJsLibp2p", () => {
         connectToDiscv5Bootnodes: true,
         discv5: {
           enabled: false,
-          enr: new ENR(),
+          enr: SignableENR.createV4(generateKeypair(KeypairType.Secp256k1)),
           bindAddr: "/ip4/127.0.0.1/udp/0",
           bootEnrs: enrWithoutTcp,
         },

--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -10,7 +10,7 @@ import {phase0, ssz} from "@lodestar/types";
 import {ForkSeq, GENESIS_SLOT} from "@lodestar/params";
 import {BeaconStateAllForks} from "@lodestar/state-transition";
 import {isPlainObject} from "@lodestar/utils";
-import {createKeypairFromPeerId, ENR} from "@chainsafe/discv5";
+import {createKeypairFromPeerId, SignableENR} from "@chainsafe/discv5";
 import {BeaconNode} from "../../../src/index.js";
 import {createNodeJsLibp2p} from "../../../src/network/nodejs/index.js";
 import {defaultNetworkOptions} from "../../../src/network/options.js";
@@ -113,9 +113,9 @@ export async function getDevBeaconNode(
   });
 }
 
-function createEnr(peerId: PeerId): ENR {
+function createEnr(peerId: PeerId): SignableENR {
   const keypair = createKeypairFromPeerId(peerId);
-  return ENR.createV4(keypair.publicKey);
+  return SignableENR.createV4(keypair);
 }
 
 function overwriteTargetArrayIfItems(target: unknown[], source: unknown[]): unknown[] {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,7 +58,7 @@
     "@chainsafe/bls-keygen": "^0.3.0",
     "@chainsafe/bls-keystore": "^2.0.0",
     "@chainsafe/blst": "^0.2.8",
-    "@chainsafe/discv5": "^2.1.1",
+    "@chainsafe/discv5": "^3.0.0",
     "@chainsafe/ssz": "^0.9.2",
     "@libp2p/peer-id-factory": "^2.0.1",
     "@lodestar/api": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -477,10 +477,10 @@
     node-fetch "^2.6.1"
     node-gyp "^8.4.0"
 
-"@chainsafe/discv5@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/discv5/-/discv5-2.1.1.tgz#272526058e98c17515dfc209ed03efe2a83387cd"
-  integrity sha512-jKLpMAhx4/jXmUzrKIzMa9jDdXf5DFhnOwhw7ouRln9STzb5MbBDUKI98gqSglF1XdnJQZ4OBspGb9N9+4AnTg==
+"@chainsafe/discv5@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/discv5/-/discv5-3.0.0.tgz#ee9c7d1631c95382ee381831c2c87c5cf1dd75c2"
+  integrity sha512-NqRjJ9tfD8bbxCo6oI2y+Ih1fBlHmIs8l19f5ca5lY61nfISLKMUO+uCvJ6mguqcSzz0zxSsp5dmzhJ0E+J+HA==
   dependencies:
     "@libp2p/crypto" "^1.0.0"
     "@libp2p/interface-peer-discovery" "^1.0.1"


### PR DESCRIPTION
**Motivation**

Several things:
- Our ENR api was error-prone, and was refactored in 3.0.0
- We had to re-encode ENRs across the worker boundary (which costs us a signature verification in the main thread)
- We frequently had errors decoding ENRs (that we had successfully decoded and re-encoded within the worker)

**Description**

- Update to @chainsafe/discv5 v3.0.0
- Use new toObject / fromObject to pass ENRs as objects across the thread boundary (no encoding/decoding necessary, no decoding errors possible)