### PR TITLE
Fix genesis api's fork version

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/index.ts
@@ -20,10 +20,9 @@ export function getBeaconApi(
     ...state,
 
     async getGenesis() {
-      const genesisForkVersion = config.getForkVersion(GENESIS_SLOT);
       return {
         data: {
-          genesisForkVersion,
+          genesisForkVersion: config.GENESIS_FORK_VERSION,
           genesisTime: chain.genesisTime,
           genesisValidatorsRoot: chain.genesisValidatorsRoot,
         },

--- a/packages/beacon-node/src/api/impl/beacon/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/index.ts
@@ -1,5 +1,4 @@
 import {routes, ServerApi} from "@lodestar/api";
-import {GENESIS_SLOT} from "@lodestar/params";
 import {ApiModules} from "../types.js";
 import {getBeaconBlockApi} from "./blocks/index.js";
 import {getBeaconPoolApi} from "./pool/index.js";


### PR DESCRIPTION
While testing for withdrawals devnet4/6, it surfaced that in getGenesis api response, genesis fork version is expected to be the config's GENESIS_FORK_VERSION constant in spite of other forks being scheduled at genesis:

![image](https://user-images.githubusercontent.com/76567250/215402113-bd224696-7886-4dc9-a585-b87c317df88e.png)

This PR fixes the same