### PR TITLE
Fix github action warnings

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,8 +26,8 @@ jobs:
 
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
       - name: Node.js version

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
       - name: Node.js version

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
           registry-url: "https://registry.npmjs.org"
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: npm
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
     if: needs.tag.outputs.is_rc == 'true'
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Needs full depth for changelog generation
       - uses: actions/setup-node@v2
@@ -130,7 +130,7 @@ jobs:
     needs: [tag, npm]
     if: needs.tag.outputs.is_rc == 'true'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: scripts/await-release.sh ${{ needs.tag.outputs.tag }} rc 900
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -55,10 +55,10 @@ jobs:
     if: needs.tag.outputs.is_stable == 'true'
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Needs full depth for changelog generation
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
       - name: Node.js version
@@ -120,7 +120,7 @@ jobs:
     needs: [tag, npm]
     if: needs.tag.outputs.is_stable == 'true'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: scripts/await-release.sh ${{ needs.tag.outputs.tag }} latest 900
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -17,11 +17,11 @@ jobs:
         node: [18]
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: browser-actions/setup-firefox@latest
         with:
           firefox-version: "latest"
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node}}
       - name: Node.js version

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -20,8 +20,8 @@ jobs:
         node: [18]
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node}}
       - name: Node.js version

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
       - name: Node.js version
@@ -89,7 +89,7 @@ jobs:
           name: debug-test-logs
           path: packages/beacon-node/test-logs
 
-      # - name: Pull geth withdrawals 
+      # - name: Pull geth withdrawals
       #   run: docker pull $GETH_WITHDRAWALS_IMAGE
 
       # - name: Test Lodestar <> geth withdrawals
@@ -99,7 +99,7 @@ jobs:
       #     EL_BINARY_DIR: ${{ env.GETH_WITHDRAWALS_IMAGE }}
       #     EL_SCRIPT_DIR: gethdocker
 
-      # - name: Pull ethereumjs withdrawals 
+      # - name: Pull ethereumjs withdrawals
       #   run: docker pull $ETHEREUMJS_WITHDRAWALS_IMAGE
 
       # - name: Test Lodestar <> ethereumjs withdrawals

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
       - name: Node.js version

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -16,8 +16,8 @@ jobs:
       # - run: ./scripts/free-disk-space.sh
 
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
       - name: Node.js version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ jobs:
         node: [18]
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node}}
       - name: Node.js version

--- a/scripts/get_prev_tag.js
+++ b/scripts/get_prev_tag.js
@@ -30,7 +30,9 @@ async function run() {
   const tags = stdout.trim().split("\n");
   for (const tag of tags) {
     if (tag !== CURRENT_TAG && !tag.includes(IGNORE_PATTERN)) {
-      console.log(`::set-output name=prev_tag::${tag}`);
+      const cmd = `echo "prev_tag=${tag}" >> ${process.env.GITHUB_OUTPUT}`;
+      console.log("Execute command on shell", cmd);
+      await promisify(exec)(cmd);
       return;
     }
   }


### PR DESCRIPTION
**Motivation**
- Fix warnings in https://github.com/ChainSafe/lodestar/actions/runs/4040952032

**Description**

- `set-output`: same fix to #5002 but for `js` file
- `Node.js 12 actions`: migrate to latest version of actions
- `set-state`: I don't see we use it in lodestar, not sure where it comes from

Closes #4967
