### PR TITLE
ci: add some more juicy runners

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     # Skip for dependabot PRs, secrets are not made available and will fail
     # Don't run on forks. Forks don't have access to the S3 credentials and the workflow will fail
     if: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     permissions:
       actions: read
       contents: read
@@ -52,11 +52,11 @@ jobs:
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
-        
+
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-        
+
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
@@ -65,7 +65,7 @@ jobs:
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
     # - run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v2

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   npm:
     name: Publish to NPM Registry
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v2
@@ -104,7 +104,7 @@ jobs:
 
   docker:
     name: Publish to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     needs: npm
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   tag:
     name: Check tag
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
 
   npm:
     name: Publish to NPM & Github
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     needs: tag
     if: needs.tag.outputs.is_rc == 'true'
     steps:
@@ -126,7 +126,7 @@ jobs:
 
   docker:
     name: Publish to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     needs: [tag, npm]
     if: needs.tag.outputs.is_rc == 'true'
     steps:

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   tag:
     name: Check tag
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -50,7 +50,7 @@ jobs:
 
   npm:
     name: Publish to NPM & Github
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     needs: tag
     if: needs.tag.outputs.is_stable == 'true'
     steps:
@@ -116,7 +116,7 @@ jobs:
 
   docker:
     name: Publish to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     needs: [tag, npm]
     if: needs.tag.outputs.is_stable == 'true'
     steps:

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   tests-main:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   tests-main:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   sim-merge-tests:
     name: Sim merge tests
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v2
@@ -89,7 +89,7 @@ jobs:
           name: debug-test-logs
           path: packages/beacon-node/test-logs
 
-      # - name: Pull geth withdrawals 
+      # - name: Pull geth withdrawals
       #   run: docker pull $GETH_WITHDRAWALS_IMAGE
 
       # - name: Test Lodestar <> geth withdrawals
@@ -99,7 +99,7 @@ jobs:
       #     EL_BINARY_DIR: ${{ env.GETH_WITHDRAWALS_IMAGE }}
       #     EL_SCRIPT_DIR: gethdocker
 
-      # - name: Pull ethereumjs withdrawals 
+      # - name: Pull ethereumjs withdrawals
       #   run: docker pull $ETHEREUMJS_WITHDRAWALS_IMAGE
 
       # - name: Test Lodestar <> ethereumjs withdrawals
@@ -128,4 +128,3 @@ jobs:
         with:
           name: debug-test-logs
           path: packages/beacon-node/test-logs
-

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   tests-sim:
     name: Sim tests
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v2

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   tests-spec:
     name: Spec tests
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # As of October 2020, runner has +8GB of free space w/out this script (takes 1m30s to run)
       # - run: ./scripts/free-disk-space.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   tests-main:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Motivation**

cut ci times in half

**Description**

uses build jet external runners. should not make any difference (except for speed).

**Steps to test or reproduce**

open a pull request

**Results**

Job | Github | Buildjet | Difference
-- | -- | -- | --
Benchmark / run | 13m | 12m | -8%
Browser tests / Tests (18) | 3m | 1m | -67%
CodeQL / Analyze (javascript) | 3m | 3m | 0%
E2E tests / Tests (18) | 11m | 8m | -27%
Sim merge execution/builder tests / Sim merge tests | 12m | 10m | -17%
Sim tests / Sim tests | 20m | **N/A** | _Fails_
Spec tests / Spec tests | 27m | 17m | -37%
Tests / Tests (18) | 10m | 6m | -40%
Code scanning results | 4s | 3s | -25%
license/cla | 0s | 0s | 0%
**Total** | **27m** | **17m** | **-37%**