### PR TITLE
Remove eip4844 withdrawals skipped tests fixed in the 1.3.* specs

### DIFF
--- a/packages/beacon-node/test/spec/presets/index.test.ts
+++ b/packages/beacon-node/test/spec/presets/index.test.ts
@@ -28,14 +28,7 @@ import {transition} from "./transition.js";
 //    "eip4844/operations/bls_to_execution_change",
 // ],
 // ```
-const skipOpts: SkipOpts = {
-  skippedPrefixes: [
-    // Skipped since this only test that withdrawals are de-activated.
-    // Enable once spec test v1.3.0 are released and withdrawals are active on eip488
-    "eip4844/operations/bls_to_execution_change",
-    "eip4844/operations/withdrawals",
-  ],
-};
+const skipOpts: SkipOpts = {};
 
 /* eslint-disable @typescript-eslint/naming-convention */
 


### PR DESCRIPTION
Remove eip4844 withdrawals skipped tests fixed in the 1.3.* specs

These tests were skipeed in pre 1.3.0 versions because of incorrect rebasing in the spec tests which has now been fixed