### PR TITLE
Use postMessage for Discv5 worker thread

### DIFF
--- a/packages/beacon-node/src/network/discv5/index.ts
+++ b/packages/beacon-node/src/network/discv5/index.ts
@@ -72,8 +72,8 @@ export class Discv5Worker extends (EventEmitter as {new (): StrictEventEmitter<E
 
   onMessage = (msg: Event): void => {
     const messageData = ((msg as unknown) as {data?: unknown})?.data as Discv5EventData | undefined;
-    if (messageData && messageData.type === "discv5-enr") {
-      this.onDiscovered(messageData.data);
+    if (messageData && messageData.type === "discv5-enr-result") {
+      this.onDiscovered(messageData.payload);
     }
   };
 

--- a/packages/beacon-node/src/network/discv5/types.ts
+++ b/packages/beacon-node/src/network/discv5/types.ts
@@ -14,8 +14,9 @@ export interface Discv5WorkerData {
 }
 
 export interface Discv5EventData {
-  type: "discv5-enr";
-  data: Uint8Array;
+  // threads library has different type, we define a specific type for Discv5
+  type: "discv5-enr-result";
+  payload: Uint8Array;
 }
 
 /**

--- a/packages/beacon-node/src/network/discv5/types.ts
+++ b/packages/beacon-node/src/network/discv5/types.ts
@@ -1,5 +1,4 @@
 import {Discv5} from "@chainsafe/discv5";
-import {Observable} from "@chainsafe/threads/observable";
 
 // TODO export IDiscv5Config so we don't need this convoluted type
 type Discv5Config = Parameters<typeof Discv5["create"]>[0]["config"];
@@ -12,6 +11,11 @@ export interface Discv5WorkerData {
   config: Discv5Config;
   bootEnrs: string[];
   metrics: boolean;
+}
+
+export interface Discv5EventData {
+  type: "discv5-enr";
+  data: Uint8Array;
 }
 
 /**
@@ -29,8 +33,6 @@ export type Discv5WorkerApi = {
   kadValuesBuf(): Promise<Uint8Array[]>;
   /** Begin a random search through the DHT, return discovered ENRs */
   findRandomNodeBuf(): Promise<Uint8Array[]>;
-  /** Stream of discovered ENRs */
-  discoveredBuf(): Observable<Uint8Array>;
 
   /** Prometheus metrics string */
   metrics(): Promise<string>;


### PR DESCRIPTION
**Motivation**

- Right now we use Observable inside `threads` library to inform a new enr to main thread from discv5 worker thread, the profiler shows that it takes almost 10% on a mainnet node subscribing to all subnets

**Description**

- Use `postMessage` instead
- Cannot see any differences after I run this branch for 3 hours so need to take a profile and a benchmark test to see

**TODO**
- [x] Make sure this works and we can have a lot of discovered peers/ENRs
- [ ] Let this branch run for a while and take another profile to see if `postMessage` is better or not
- [ ] Write a benchmark to see this is better or not