### PR TITLE
Fix the args order in evaluating isBetterUpdate for new partial update

### DIFF
--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -560,7 +560,7 @@ export class LightClientServer {
         isFinalityUpdate: attestedData.isFinalized,
       };
 
-      if (!isBetterUpdate(prevBestUpdateSummary, nextBestUpdate)) {
+      if (!isBetterUpdate(nextBestUpdate, prevBestUpdateSummary)) {
         this.metrics?.lightclientServer.updateNotBetter.inc();
         return;
       }


### PR DESCRIPTION
As reported by @claravanstaden in discord, the light client updates were not seemingly correct, on debugging figured out that the first assigned update of the period might not be getting replaced by better updates which may arrive later.

On log debugging + code inspection it was discovered that the arg order to isBetterUpdate function was incorrect leading to opposite evalution.

this PR fixes the same