### PR TITLE
Fix grafana dashboard validation

### DIFF
--- a/scripts/validate-grafana-dashboards.sh
+++ b/scripts/validate-grafana-dashboards.sh
@@ -3,7 +3,7 @@
 # This script will mutate the dashboards if anything needs linting
 node scripts/lint-grafana-dashboards.mjs ./dashboards
 
-if [[ $(git diff ./dashboards --stat) != '' ]]; then
+if [[ $(git diff --stat ./dashboards) != '' ]]; then
   git --no-pager diff
   echo 'dashboards need fixing'
   exit 1


### PR DESCRIPTION
**Motivation**

Grafana dashboard validation [CI job](https://github.com/ChainSafe/lodestar/actions/runs/4071997583/jobs/7014320643) currently succeeds even if dashboards are invalid because `git diff` throws an error.

![image](https://user-images.githubusercontent.com/38436224/216276971-9b0e3b4b-645e-4941-9215-e51517532a57.png)

**Description**

Add `--stat` before non-option arguments

