### PR TITLE
Fix PeerScore.update() function

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -49,11 +49,12 @@ export function createLodestarMetrics(
       help: "Histogram of current count of long lived attnets of connected peers",
       buckets: [0, 4, 16, 32, 64],
     }),
-    peerScore: register.histogram({
+    peerScoreByClient: register.histogram<"client">({
       name: "lodestar_app_peer_score",
       help: "Current peer score at lodestar app side",
       // Min score = -100, max score = 100, disconnect = -20, ban = -50
       buckets: [-100, -50, -20, 0, 25],
+      labelNames: ["client"],
     }),
     peerConnectionLength: register.histogram({
       name: "lodestar_peer_connection_seconds",
@@ -173,6 +174,13 @@ export function createLodestarMetrics(
         name: "lodestar_gossip_mesh_peers_by_client_count",
         help: "number of mesh peers, labeled by client",
         labelNames: ["client"],
+      }),
+      scoreByClient: register.histogram<"client">({
+        name: "lodestar_gossip_score_by_client",
+        help: "Gossip peer score by client",
+        labelNames: ["client"],
+        // based on gossipScoreThresholds and negativeGossipScoreIgnoreThreshold
+        buckets: [-16000, -8000, -4000, -1000, 0, 5, 100],
       }),
       score: register.avgMinMax({
         name: "lodestar_gossip_score_avg_min_max",

--- a/packages/beacon-node/src/network/gossip/scoringParameters.ts
+++ b/packages/beacon-node/src/network/gossip/scoringParameters.ts
@@ -51,6 +51,12 @@ export const gossipScoreThresholds: PeerScoreThresholds = {
   opportunisticGraftThreshold: 5,
 };
 
+/**
+ * Peer may sometimes has negative gossipsub score and we give it time to recover, however gossipsub score comes below this we need to take into account.
+ * Given gossipsubThresold = -4000, it's comfortable to only ignore negative score gossip peer score > -1000
+ */
+export const negativeGossipScoreIgnoreThreshold = -1000;
+
 type MeshMessageInfo = {
   decaySlots: number;
   capFactor: number;

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -638,7 +638,7 @@ export class PeerManager {
 
     // peerLongLivedAttnets metric is a count
     metrics.peerLongLivedAttnets.reset();
-    metrics.peerScore.reset();
+    metrics.peerScoreByClient.reset();
     metrics.peerConnectionLength.reset();
 
     // reset client counts _for each client_ to 0
@@ -660,7 +660,8 @@ export class PeerManager {
 
         // TODO: Consider optimizing by doing observe in batch
         metrics.peerLongLivedAttnets.observe(attnets ? attnets.getTrueBitIndexes().length : 0);
-        metrics.peerScore.observe(this.peerRpcScores.getScore(peerId));
+        metrics.peerScoreByClient.observe({client}, this.peerRpcScores.getScore(peerId));
+        metrics.gossipPeer.scoreByClient.observe({client}, this.peerRpcScores.getGossipScore(peerId));
         metrics.peerConnectionLength.observe((now - openCnx.stat.timeline.open) / 1000);
         total++;
       }

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -640,6 +640,7 @@ export class PeerManager {
     metrics.peerLongLivedAttnets.reset();
     metrics.peerScoreByClient.reset();
     metrics.peerConnectionLength.reset();
+    metrics.gossipPeer.scoreByClient.reset();
 
     // reset client counts _for each client_ to 0
     for (const client of Object.values(ClientKind)) {

--- a/packages/beacon-node/src/network/peers/score.ts
+++ b/packages/beacon-node/src/network/peers/score.ts
@@ -198,7 +198,7 @@ export class PeerScore {
     // Using exponential decay based on a constant half life.
     const sinceLastUpdateMs = nowMs - this.lastUpdate;
     // If peer was banned, lastUpdate will be in the future
-    if (sinceLastUpdateMs > 0 && this.lodestarScore !== 0) {
+    if (sinceLastUpdateMs > 0) {
       this.lastUpdate = nowMs;
       // e^(-ln(2)/HL*t)
       const decayFactor = Math.exp(HALFLIFE_DECAY_MS * sinceLastUpdateMs);

--- a/packages/beacon-node/src/network/peers/score.ts
+++ b/packages/beacon-node/src/network/peers/score.ts
@@ -78,6 +78,7 @@ type PeerIdStr = string;
 
 export interface IPeerRpcScoreStore {
   getScore(peer: PeerId): number;
+  getGossipScore(peer: PeerId): number;
   getScoreState(peer: PeerId): ScoreState;
   dumpPeerScoreStats(): PeerScoreStats;
   applyAction(peer: PeerId, action: PeerAction, actionName: string): void;
@@ -116,6 +117,10 @@ export class PeerRpcScoreStore implements IPeerRpcScoreStore {
 
   getScore(peer: PeerId): number {
     return this.scores.get(peer.toString())?.getScore() ?? DEFAULT_SCORE;
+  }
+
+  getGossipScore(peer: PeerId): number {
+    return this.scores.get(peer.toString())?.getGossipScore() ?? DEFAULT_SCORE;
   }
 
   getScoreState(peer: PeerId): ScoreState {
@@ -174,6 +179,10 @@ export class PeerScore {
 
   getScore(): number {
     return this.score;
+  }
+
+  getGossipScore(): number {
+    return this.gossipScore;
   }
 
   add(scoreDelta: number): void {


### PR DESCRIPTION
**Motivation**

1. Some incorrect computation where final score is 0, lodestar score is 0 and gossipScore < 0 as below:

```
{"peer_id":"16Uiu2HAmVcU5cjAGqRwCM1PyniSbhMPEEAgCM5aJ6qZwSFfsDgX5","lodestar_score":0,"gossip_score":-6810.915930589742,"ignore_negative_gossip_score":false,"score":0,"last_update":1675327150937}
```

2. Right now we ignore 5 biggest negative gossip score to allow them to recover but some of them are very small, for example -6000

4. We have no idea how clients perform in our peers

**Description**

1. In the above case the final score should be < 0, should remove the small optimization to check `lodestarScore !== 0` (which was done before we take gossipsub score into account)
2. Only ignore negative gossipsub if it's > -1000
3. Track scores by client

part of #5074
