### PR TITLE
Fix and extract payload to header conversion

### DIFF
--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -47,3 +47,4 @@ export {ExecutionPayloadStatus, DataAvailableStatus, BlockExternalData} from "./
 export {becomesNewEth1Data} from "./block/processEth1Data.js";
 // Withdrawals for new blocks
 export {getExpectedWithdrawals} from "./block/processWithdrawals.js";
+export {executionPayloadToPayloadHeader} from "./block/processExecutionPayload.js";


### PR DESCRIPTION
Earlier blinded header on/post capella was assumed to be different  fromexecution header in terms of having only transactions replaced by transaction root.

However since, blinded header is just same as execution header now  so blinded will already have withdrawalsRoot rather than withdrawals
This is relevant from capella onwards and doesn't affect bellatrix

and the conversion is abstracted and imported to be used in PR:
 - https://github.com/ChainSafe/lodestar/pull/5027
 