### PR TITLE
Filter enrs in worker

### DIFF
--- a/dashboards/lodestar_discv5.json
+++ b/dashboards/lodestar_discv5.json
@@ -45,6 +45,98 @@
   "liveNow": false,
   "panels": [
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus_local"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 54,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(lodestar_discv5_discovered_status_total_count[$rate_interval])",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Discovered ENR Relevancy Rate",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,

--- a/packages/beacon-node/src/network/discv5/index.ts
+++ b/packages/beacon-node/src/network/discv5/index.ts
@@ -11,7 +11,7 @@ import {
   SignableENR,
 } from "@chainsafe/discv5";
 import {spawn, Thread, Worker} from "@chainsafe/threads";
-import {IBeaconConfig} from "@lodestar/config";
+import {chainConfigFromJson, chainConfigToJson, IBeaconConfig} from "@lodestar/config";
 import {ILogger} from "@lodestar/utils";
 import {IMetrics} from "../../metrics/metrics.js";
 import {Discv5WorkerApi, Discv5WorkerData} from "./types.js";
@@ -58,7 +58,7 @@ export class Discv5Worker extends (EventEmitter as {new (): StrictEventEmitter<E
       config: this.opts.discv5,
       bootEnrs: this.opts.discv5.bootEnrs as string[],
       metrics: Boolean(this.opts.metrics),
-      chainConfig: this.opts.config,
+      chainConfig: chainConfigFromJson(chainConfigToJson(this.opts.config)),
       genesisValidatorsRoot: this.opts.config.genesisValidatorsRoot,
     };
     const worker = new Worker("./worker.js", {workerData} as ConstructorParameters<typeof Worker>[1]);

--- a/packages/beacon-node/src/network/discv5/types.ts
+++ b/packages/beacon-node/src/network/discv5/types.ts
@@ -1,5 +1,6 @@
 import {Discv5, ENRData, SignableENRData} from "@chainsafe/discv5";
 import {Observable} from "@chainsafe/threads/observable";
+import {IChainConfig} from "@lodestar/config";
 
 // TODO export IDiscv5Config so we don't need this convoluted type
 type Discv5Config = Parameters<typeof Discv5["create"]>[0]["config"];
@@ -12,6 +13,8 @@ export interface Discv5WorkerData {
   config: Discv5Config;
   bootEnrs: string[];
   metrics: boolean;
+  chainConfig: IChainConfig;
+  genesisValidatorsRoot: Uint8Array;
 }
 
 /**
@@ -27,6 +30,8 @@ export type Discv5WorkerApi = {
 
   /** Return the ENRs currently in the kad table */
   kadValues(): Promise<ENRData[]>;
+  /** emit thethe ENRs currently in the kad table */
+  discoverKadValues(): Promise<void>;
   /** Begin a random search through the DHT, return discovered ENRs */
   findRandomNode(): Promise<ENRData[]>;
   /** Stream of discovered ENRs */

--- a/packages/beacon-node/src/network/discv5/types.ts
+++ b/packages/beacon-node/src/network/discv5/types.ts
@@ -30,7 +30,7 @@ export type Discv5WorkerApi = {
 
   /** Return the ENRs currently in the kad table */
   kadValues(): Promise<ENRData[]>;
-  /** emit thethe ENRs currently in the kad table */
+  /** emit the ENRs currently in the kad table */
   discoverKadValues(): Promise<void>;
   /** Begin a random search through the DHT, return discovered ENRs */
   findRandomNode(): Promise<ENRData[]>;

--- a/packages/beacon-node/src/network/discv5/worker.ts
+++ b/packages/beacon-node/src/network/discv5/worker.ts
@@ -1,12 +1,50 @@
 import worker from "worker_threads";
 import {createFromProtobuf} from "@libp2p/peer-id-factory";
 import {multiaddr} from "@multiformats/multiaddr";
+import {Gauge} from "prom-client";
 import {expose} from "@chainsafe/threads/worker";
 import {Observable, Subject} from "@chainsafe/threads/observable";
 import {createKeypairFromPeerId, Discv5, ENR, ENRData, SignableENR, SignableENRData} from "@chainsafe/discv5";
+import {createIBeaconConfig, IBeaconConfig} from "@lodestar/config";
 import {RegistryMetricCreator} from "../../metrics/index.js";
 import {collectNodeJSMetrics} from "../../metrics/nodeJsMetrics.js";
+import {ENRKey} from "../metadata.js";
 import {Discv5WorkerApi, Discv5WorkerData} from "./types.js";
+
+enum ENRRelevance {
+  no_tcp = "no_tcp",
+  no_eth2 = "no_eth2",
+  unknown_forkDigest = "unknown_forkDigest",
+
+  relevant = "relevant",
+}
+
+function enrRelevance(enr: ENR, config: IBeaconConfig): ENRRelevance {
+  // We are not interested in peers that don't advertise their tcp addr
+  const multiaddrTCP = enr.getLocationMultiaddr(ENRKey.tcp);
+  if (!multiaddrTCP) {
+    return ENRRelevance.no_tcp;
+  }
+
+  // Check if the ENR.eth2 field matches and is of interest
+  const eth2 = enr.kvs.get(ENRKey.eth2);
+  if (!eth2) {
+    return ENRRelevance.no_eth2;
+  }
+
+  // Fast de-serialization without SSZ
+  const forkDigest = eth2.slice(0, 4);
+  // Check if forkDigest matches any of our known forks.
+  const forkName = config.forkDigest2ForkNameOption(forkDigest);
+  if (!forkName) {
+    return ENRRelevance.unknown_forkDigest;
+  }
+
+  // TODO: Then check if the next fork info matches ours
+  // const enrForkId = ssz.phase0.ENRForkID.deserialize(eth2);
+
+  return ENRRelevance.relevant;
+}
 
 // This discv5 worker will start discv5 on initialization (there is no `start` function to call)
 // A consumer _should_ call `close` before terminating the worker to cleanly exit discv5 before destroying the thread
@@ -19,13 +57,23 @@ if (!workerData) throw Error("workerData must be defined");
 
 // Set up metrics, nodejs and discv5-specific
 let metricsRegistry: RegistryMetricCreator | undefined;
+let enrRelevanceMetric: Gauge<"status"> | undefined;
 if (workerData.metrics) {
   metricsRegistry = new RegistryMetricCreator();
   collectNodeJSMetrics(metricsRegistry, "discv5_worker_");
+
+  // add enr relevance metric
+  enrRelevanceMetric = metricsRegistry.gauge<"status">({
+    name: "lodestar_discv5_discovered_status_total_count",
+    help: "Total count of status results of enrRelevance() function",
+    labelNames: ["status"],
+  });
 }
 
 const peerId = await createFromProtobuf(workerData.peerIdProto);
 const keypair = createKeypairFromPeerId(peerId);
+
+const config = createIBeaconConfig(workerData.chainConfig, workerData.genesisValidatorsRoot);
 
 // Initialize discv5
 const discv5 = Discv5.create({
@@ -44,7 +92,13 @@ for (const bootEnr of workerData.bootEnrs) {
 /** Used to push discovered ENRs */
 const subject = new Subject<ENRData>();
 
-const onDiscovered = (enr: ENR): void => subject.next(enr.toObject());
+const onDiscovered = (enr: ENR): void => {
+  const status = enrRelevance(enr, config);
+  enrRelevanceMetric?.inc({status});
+  if (status === ENRRelevance.relevant) {
+    subject.next(enr.toObject());
+  }
+};
 discv5.addListener("discovered", onDiscovered);
 
 // Discv5 will now begin accepting request/responses
@@ -59,6 +113,9 @@ const module: Discv5WorkerApi = {
   },
   async kadValues(): Promise<ENRData[]> {
     return discv5.kadValues().map((enr) => enr.toObject());
+  },
+  async discoverKadValues(): Promise<void> {
+    discv5.kadValues().map(onDiscovered);
   },
   async findRandomNode(): Promise<ENRData[]> {
     return (await discv5.findRandomNode()).map((enr) => enr.toObject());


### PR DESCRIPTION
**Motivation**

Seen in metrics, most ENRs discovered are not relevant. If irrelevant ENRs can be filtered in a separate thread, than that's fewer messages needed to be sent to the main thread.

![Screenshot from 2023-02-05 18-58-52](https://user-images.githubusercontent.com/1348242/216853549-cf962fb3-515e-4305-b7d8-b90be4816baa.png)


**Description**

- Check for relevant ENR kvs in worker thread (move logic from `onDisoveredENR`)
- Metric to track ENR relevance of all discovered ENRs
- Refactor `onDiscoveredENR` and `onDiscoveredPeer` into a single function (remove duplicate logic)
- add `discoverKadValues` to emit all enrs in `kadValues` for proper ENR relevance filtering.