### PR TITLE
Explicitly start and stop validator level db

### DIFF
--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -102,6 +102,9 @@ export async function validatorHandler(args: IValidatorCliArgs & IGlobalArgs): P
     config,
     controller: new LevelDbController({name: dbPath}, {metrics: null}),
   };
+  onGracefulShutdownCbs.push(() => dbOps.controller.stop());
+  await dbOps.controller.start();
+
   const slashingProtection = new SlashingProtection(dbOps);
 
   // Create metrics registry if metrics are enabled


### PR DESCRIPTION
**Motivation**

The database connecting should be managed as a part of the validator lifecycle.

**Description**

Starts database in validator handler and adds stop callback on graceful shutdown.
