### PR TITLE
Print out trimmed graffiti in published block info log

### DIFF
--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -106,7 +106,7 @@ export class BlockProposingService {
         this.metrics?.blockProposingErrors.inc({error: "publish"});
         throw extendError(e, "Failed to publish block");
       });
-      this.logger.info("Published block", {...logCtx, graffiti, ...block.debugLogCtx});
+      this.logger.info("Published block", {...logCtx, graffiti: graffiti.substring(0, 32), ...block.debugLogCtx});
       this.metrics?.blocksPublished.inc();
     } catch (e) {
       this.logger.error("Error proposing block", logCtx, e as Error);


### PR DESCRIPTION
**Motivation**

The graffiti included in the block body is limited to 32 bytes which means the length of the UTF-8 string is limited to 32 characters.

At the moment we are [silently trimming the graffiti](https://github.com/ChainSafe/lodestar/blob/4e2536888e5f69d4174559a67f28b27912283ac9/packages/beacon-node/src/util/graffiti.ts#L7) when converting it to a buffer on the beacon node. To avoid confusion, the published block info log printed out by the validator should display the graffiti as it was actually included in the block body.

**Description**

Updates publish block info log to display trimmed graffiti, only first 32 characters
