### PR TITLE
Allow to set empty graffiti

### DIFF
--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -185,7 +185,7 @@ function getProposerConfigFromArgs(
   }: {persistedKeysBackend: IPersistedKeysBackend; accountPaths: {proposerDir: string}}
 ): ValidatorProposerConfig {
   const defaultConfig = {
-    graffiti: args.graffiti || getDefaultGraffiti(),
+    graffiti: args.graffiti ?? getDefaultGraffiti(),
     strictFeeRecipientCheck: args.strictFeeRecipientCheck,
     feeRecipient: args.suggestedFeeRecipient ? parseFeeRecipient(args.suggestedFeeRecipient) : undefined,
     builder: {


### PR DESCRIPTION
`--graffiti=""` should result in an empty graffiti being used instead of the default graffiti which is `Lodestar-<version>/<short-commit-sha>`. If graffiti CLI option is omitted it will still use the default one.

Closes #5110
