### PR TITLE
Fix zero finalized header in lightclient update gen

### DIFF
--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -193,7 +193,8 @@ export class LightClientServer {
     this.logger = logger;
 
     this.zero = {
-      finalizedHeader: ssz.altair.LightClientHeader.defaultValue(),
+      // Assign the hightest fork's default value because it can always be typecasted down to correct fork
+      finalizedHeader: Object.values(ssz.allForksLightClient).slice(-1)[0].LightClientHeader.defaultValue(),
       finalityBranch: ssz.altair.LightClientUpdate.fields["finalityBranch"].defaultValue(),
     };
 


### PR DESCRIPTION
PR https://github.com/ChainSafe/lodestar/pull/5027 makes the light client update gen multi fork, however in the networks that start for e.g. with capella genesis, the zero assignment of finalized header is not correct

This PR fixes the finalized zero start