### PR TITLE
Fix prometheus in local metrics docker setup

### DIFF
--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -11,11 +11,11 @@ services:
   prometheus:
     build:
       context: prometheus
-      args:
-        # Linux:  http://localhost:8008
-        # MacOSX: http://host.docker.internal:8008
-        BEACON_URL: localhost:8008
-        VC_URL: localhost:5064
+    environment:
+      # Linux:  http://localhost:8008
+      # MacOSX: http://host.docker.internal:8008
+      BEACON_URL: localhost:8008
+      VC_URL: localhost:5064
     restart: always
     network_mode: host
     volumes:

--- a/docker/prometheus/Dockerfile
+++ b/docker/prometheus/Dockerfile
@@ -9,7 +9,7 @@ RUN chmod +x /etc/prometheus/entrypoint.sh
 # net host: "localhost:8008"
 # MacOSX: "host.docker.internal:8008"
 ENV BEACON_URL='beacon_node:8008'
-ENV VC_URL='validator'
+ENV VC_URL='validator:5064'
 VOLUME /prometheus
 
 ENTRYPOINT ["/etc/prometheus/entrypoint.sh"]
@@ -17,4 +17,4 @@ ENTRYPOINT ["/etc/prometheus/entrypoint.sh"]
 CMD [ \
   "--config.file=/etc/prometheus/prometheus.yml", \
   "--storage.tsdb.path=/prometheus" \
-]
+  ]


### PR DESCRIPTION
**Motivation**

Dockerized setup to collect metrics from local beacon node and validator client is broken

**Description**

need to set in `environment` now instead of `args` else default values set in Dockerfile will be used

https://github.com/ChainSafe/lodestar/blob/d5e05d3d850e5fe6374b3c832250036f0da4c9f5/docker/prometheus/Dockerfile#L11-L13

also fixed default value for `VC_URL` to use default metric port


One other thing, the local grafana docker build is also broken but not sure how to go about that and I think the issue is already known

this is not docker build compliant

https://github.com/ChainSafe/lodestar/blob/d5e05d3d850e5fe6374b3c832250036f0da4c9f5/docker/grafana/Dockerfile#L10-L11

should not rely on `buildx` features here if possible


