### PR TITLE
Track lodestar published blocks after 1/3 of slot

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -912,7 +912,7 @@ export function createLodestarMetrics(
         name: "validator_monitor_beacon_block_delay_seconds",
         help: "The delay between when the validator should send the block and when it was received",
         labelNames: ["src"],
-        buckets: [0.1, 0.25, 0.5, 1, 2, 5, 10],
+        buckets: [0.1, 0.25, 0.5, 1, 2, 4, 6, 10],
       }),
 
       // Only for known

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -913,7 +913,7 @@ export function createLodestarMetrics(
         help: "The delay between when the validator should send the block and when it was received",
         labelNames: ["src"],
         // we also want other nodes to received our published before 4s so add bucket 3 and 3.5
-        buckets: [0.1, 0.25, 0.5, 1, 2, 3, 3.5, 4, 6, 10],
+        buckets: [0.1, 0.25, 0.5, 1, 2, 3, 4, 6, 10],
       }),
 
       // Only for known

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -912,7 +912,8 @@ export function createLodestarMetrics(
         name: "validator_monitor_beacon_block_delay_seconds",
         help: "The delay between when the validator should send the block and when it was received",
         labelNames: ["src"],
-        buckets: [0.1, 0.25, 0.5, 1, 2, 4, 6, 10],
+        // we also want other nodes to received our published before 4s so add bucket 3 and 3.5
+        buckets: [0.1, 0.25, 0.5, 1, 2, 3, 3.5, 4, 6, 10],
       }),
 
       // Only for known


### PR DESCRIPTION
**Motivation**

If lodestar publishes a block after 4s, it may be reorged by other nodes so we have to track it (although it maybe rare on mainnet). But right now the bucket value is 5 instead of 4

**Description**

- Change the bucket value of `validator_monitor_beacon_block_delay_seconds` metric