### PR TITLE
Refactor network/libp2p initialization

### DIFF
--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -54,9 +54,7 @@ export interface INetwork {
   isSubscribedToGossipCoreTopics(): boolean;
 
   // Service
-  start(): Promise<void>;
-  stop(): Promise<void>;
-  close(): void;
+  close(): Promise<void>;
 
   // Debug
   connectToPeer(peer: PeerId, multiaddr: Multiaddr[]): Promise<void>;

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -11,7 +11,7 @@ import {Epoch, Slot, ssz} from "@lodestar/types";
 import {ILogger, randBetween} from "@lodestar/utils";
 import {shuffle} from "../../util/shuffle.js";
 import {ChainEvent, IBeaconChain} from "../../chain/index.js";
-import {Eth2Gossipsub, GossipType} from "../gossip/index.js";
+import {GossipTopic, GossipType} from "../gossip/index.js";
 import {MetadataController} from "../metadata.js";
 import {SubnetMap, RequestedSubnet} from "../peers/utils/index.js";
 import {getActiveForks} from "../forks.js";
@@ -59,7 +59,10 @@ export class AttnetsService implements IAttnetsService {
   constructor(
     private readonly config: IChainForkConfig,
     private readonly chain: IBeaconChain,
-    private readonly gossip: Eth2Gossipsub,
+    private readonly gossip: {
+      subscribeTopic: (topic: GossipTopic) => void;
+      unsubscribeTopic: (topic: GossipTopic) => void;
+    },
     private readonly metadata: MetadataController,
     private readonly logger: ILogger,
     private readonly metrics: IMetrics | null,

--- a/packages/beacon-node/test/e2e/network/mdns.test.ts
+++ b/packages/beacon-node/test/e2e/network/mdns.test.ts
@@ -25,7 +25,7 @@ let port = 9000;
 const mu = "/ip4/127.0.0.1/tcp/0";
 
 describe("mdns", function () {
-  this.timeout(70000);
+  this.timeout(50000);
   this.retries(2); // This test fail sometimes, with a 5% rate.
 
   const afterEachCallbacks: (() => Promise<void> | void)[] = [];
@@ -112,8 +112,8 @@ describe("mdns", function () {
 
     afterEachCallbacks.push(async () => {
       await chain.close();
-      controller.abort();
       await network.close();
+      controller.abort();
       sinon.restore();
     });
 

--- a/packages/beacon-node/test/e2e/network/mdns.test.ts
+++ b/packages/beacon-node/test/e2e/network/mdns.test.ts
@@ -25,7 +25,7 @@ let port = 9000;
 const mu = "/ip4/127.0.0.1/tcp/0";
 
 describe("mdns", function () {
-  this.timeout(50000);
+  this.timeout(70000);
   this.retries(2); // This test fail sometimes, with a 5% rate.
 
   const afterEachCallbacks: (() => Promise<void> | void)[] = [];

--- a/packages/beacon-node/test/e2e/network/mdns.test.ts
+++ b/packages/beacon-node/test/e2e/network/mdns.test.ts
@@ -3,6 +3,7 @@ import {expect} from "chai";
 
 import {PeerId} from "@libp2p/interface-peer-id";
 import {multiaddr} from "@multiformats/multiaddr";
+import {createSecp256k1PeerId} from "@libp2p/peer-id-factory";
 import {SignableENR} from "@chainsafe/discv5";
 import {createIBeaconConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
@@ -13,10 +14,9 @@ import {Network, getReqRespHandlers} from "../../../src/network/index.js";
 import {defaultNetworkOptions, INetworkOptions} from "../../../src/network/options.js";
 
 import {MockBeaconChain, zeroProtoBlock} from "../../utils/mocks/chain/chain.js";
-import {createNode} from "../../utils/network.js";
+import {createNetworkModules, onPeerConnect} from "../../utils/network.js";
 import {generateState} from "../../utils/state.js";
 import {StubbedBeaconDb} from "../../utils/stub/index.js";
-import {onPeerConnect} from "../../utils/network.js";
 import {testLogger} from "../../utils/logger.js";
 import {GossipHandlers} from "../../../src/network/gossip/index.js";
 import {memoOnce} from "../../utils/cache.js";
@@ -89,10 +89,10 @@ describe("mdns", function () {
     const reqRespHandlers = getReqRespHandlers({db, chain});
     const gossipHandlers = {} as GossipHandlers;
 
-    const libp2p = await createNode(mu, undefined, {mdns: true});
+    const peerId = await createSecp256k1PeerId();
     const logger = testLogger(nodeName);
 
-    const opts = await getOpts(libp2p.peerId);
+    const opts = await getOpts(peerId);
 
     const modules = {
       config,
@@ -104,13 +104,16 @@ describe("mdns", function () {
       metrics: null,
     };
 
-    const network = new Network(opts, {...modules, libp2p, logger});
-    await network.start();
+    const network = await Network.init({
+      ...modules,
+      ...(await createNetworkModules(mu, peerId, {...opts, mdns: true})),
+      logger,
+    });
 
     afterEachCallbacks.push(async () => {
       await chain.close();
       controller.abort();
-      await network.stop();
+      await network.close();
       sinon.restore();
     });
 

--- a/packages/beacon-node/test/e2e/network/network.test.ts
+++ b/packages/beacon-node/test/e2e/network/network.test.ts
@@ -29,7 +29,7 @@ let port = 9000;
 const mu = "/ip4/127.0.0.1/tcp/0";
 
 describe("network", function () {
-  this.timeout(50000);
+  this.timeout(70000);
   this.retries(2); // This test fail sometimes, with a 5% rate.
 
   const afterEachCallbacks: (() => Promise<void> | void)[] = [];

--- a/packages/beacon-node/test/e2e/network/network.test.ts
+++ b/packages/beacon-node/test/e2e/network/network.test.ts
@@ -29,7 +29,7 @@ let port = 9000;
 const mu = "/ip4/127.0.0.1/tcp/0";
 
 describe("network", function () {
-  this.timeout(70000);
+  this.timeout(50000);
   this.retries(2); // This test fail sometimes, with a 5% rate.
 
   const afterEachCallbacks: (() => Promise<void> | void)[] = [];
@@ -112,8 +112,8 @@ describe("network", function () {
 
     afterEachCallbacks.push(async () => {
       await chain.close();
-      controller.abort();
       await network.close();
+      controller.abort();
       sinon.restore();
     });
 

--- a/packages/beacon-node/test/utils/network.ts
+++ b/packages/beacon-node/test/utils/network.ts
@@ -7,6 +7,7 @@ import {INetwork, Network} from "../../src/network/index.js";
 import {createNodejsLibp2p, ILibp2pOptions} from "../../src/network/nodejs/index.js";
 import {Libp2p} from "../../src/network/interface.js";
 import {Libp2pEvent} from "../../src/constants/index.js";
+import {defaultNetworkOptions, INetworkOptions} from "../../src/network/options.js";
 
 export async function createNode(
   multiaddr: string,
@@ -19,6 +20,17 @@ export async function createNode(
     addresses: {listen: [multiaddr]},
     ...opts,
   });
+}
+
+export async function createNetworkModules(
+  multiaddr: string,
+  peerId?: PeerId,
+  opts?: Partial<INetworkOptions>
+): Promise<{opts: INetworkOptions; peerId: PeerId}> {
+  return {
+    peerId: peerId ?? (await createSecp256k1PeerId()),
+    opts: {...defaultNetworkOptions, ...opts, localMultiaddrs: [multiaddr]},
+  };
 }
 
 /**

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -4,7 +4,7 @@ import {createSecp256k1PeerId} from "@libp2p/peer-id-factory";
 import {createKeypairFromPeerId, SignableENR} from "@chainsafe/discv5";
 import {ErrorAborted} from "@lodestar/utils";
 import {LevelDbController} from "@lodestar/db";
-import {BeaconNode, BeaconDb, createNodeJsLibp2p} from "@lodestar/beacon-node";
+import {BeaconNode, BeaconDb} from "@lodestar/beacon-node";
 import {createIBeaconConfig} from "@lodestar/config";
 import {ACTIVE_PRESET, PresetName} from "@lodestar/params";
 import {ProcessShutdownCallback} from "@lodestar/validator";
@@ -88,11 +88,8 @@ export async function beaconHandler(args: IBeaconArgs & IGlobalArgs): Promise<vo
       db,
       logger,
       processShutdownCallback,
-      libp2p: await createNodeJsLibp2p(peerId, options.network, {
-        peerStoreDir: beaconPaths.peerStoreDir,
-        metrics: options.metrics.enabled,
-        metricsRegistry: networkRegistry,
-      }),
+      peerId,
+      peerStoreDir: beaconPaths.peerStoreDir,
       anchorState,
       wsCheckpoint,
       metricsRegistries,


### PR DESCRIPTION
**Motivation**

See discussion in #4856 

Initializing libp2p inside the network class, rather than inside the cli, is a first step towards moving the network into a separate thread.

**Description**

- Refactor the `Network` class to use the async initialization pattern used elsewhere in the codebase (eg: `BeaconNode`)
  - `await Network.init(...)`
  - `await network.close()`
- Initialize libp2p inside `Network.init`
- A circular dependency was uncovered between the attnetsService and gossipsub. Resolved by adding a level of indirection rather than passing the entire network class around.