### PR TITLE
Fix the zero finalized light client header upgrade

### DIFF
--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -602,16 +602,16 @@ export class LightClientServer {
       isFinalized = true;
       finalityBranch = attestedData.finalityBranch;
       finalizedHeader = finalizedHeaderAttested;
+      // Fork of LightClientUpdate is based off on attested header's fork
+      const attestedFork = this.config.getForkName(attestedHeader.beacon.slot);
+      if (this.config.getForkName(finalizedHeader.beacon.slot) !== attestedFork) {
+        finalizedHeader = upgradeLightClientHeader(this.config, attestedFork, finalizedHeader);
+      }
     } else {
       isFinalized = false;
       finalityBranch = this.zero.finalityBranch;
+      // No need to upgrade finalizedHeader because its anyway set to zero of highest fork
       finalizedHeader = this.zero.finalizedHeader;
-    }
-
-    // Fork of LightClientUpdate is based off on attested header's fork
-    const attestedFork = this.config.getForkName(attestedHeader.beacon.slot);
-    if (this.config.getForkName(finalizedHeader.beacon.slot) !== attestedFork) {
-      finalizedHeader = upgradeLightClientHeader(this.config, attestedFork, finalizedHeader);
     }
 
     const newUpdate = {

--- a/packages/light-client/src/spec/utils.ts
+++ b/packages/light-client/src/spec/utils.ts
@@ -55,9 +55,11 @@ export function upgradeLightClientHeader(
   const upgradedHeader = header;
 
   const headerFork = config.getForkName(header.beacon.slot);
-  switch (headerFork) {
-    case ForkName.phase0:
-      throw Error(`Invalid headerFork=${headerFork} for upgradeLightClientHeader`);
+  const startUpgradeFromFork = Object.values(ForkName)[ForkSeq[headerFork]+1];
+
+  switch (startUpgradeFromFork) {
+    default:
+      throw Error(`Invalid startUpgradeFromFork=${startUpgradeFromFork} for headerFork=${headerFork} in upgradeLightClientHeader to targetFork=${targetFork}`);
 
     case ForkName.altair:
     case ForkName.bellatrix:

--- a/packages/light-client/src/spec/utils.ts
+++ b/packages/light-client/src/spec/utils.ts
@@ -57,7 +57,7 @@ export function upgradeLightClientHeader(
   const headerFork = config.getForkName(header.beacon.slot);
   switch (headerFork) {
     case ForkName.phase0:
-      throw Error(`Invalid target fork=${headerFork} for LightClientHeader`);
+      throw Error(`Invalid headerFork=${headerFork} for upgradeLightClientHeader`);
 
     case ForkName.altair:
     case ForkName.bellatrix:

--- a/packages/light-client/src/spec/utils.ts
+++ b/packages/light-client/src/spec/utils.ts
@@ -52,14 +52,21 @@ export function upgradeLightClientHeader(
   targetFork: ForkName,
   header: altair.LightClientHeader
 ): allForks.LightClientHeader {
-  const upgradedHeader = header;
-
   const headerFork = config.getForkName(header.beacon.slot);
-  const startUpgradeFromFork = Object.values(ForkName)[ForkSeq[headerFork]+1];
+  if (ForkSeq[headerFork] >= ForkSeq[targetFork]) {
+    throw Error(`Invalid upgrade request from headerFork=${headerFork} to targetFork=${targetFork}`);
+  }
+
+  // We are modifying the same header object, may be we could create a copy, but its
+  // not required as of now
+  const upgradedHeader = header as allForks.LightClientHeader;
+  const startUpgradeFromFork = Object.values(ForkName)[ForkSeq[headerFork] + 1];
 
   switch (startUpgradeFromFork) {
     default:
-      throw Error(`Invalid startUpgradeFromFork=${startUpgradeFromFork} for headerFork=${headerFork} in upgradeLightClientHeader to targetFork=${targetFork}`);
+      throw Error(
+        `Invalid startUpgradeFromFork=${startUpgradeFromFork} for headerFork=${headerFork} in upgradeLightClientHeader to targetFork=${targetFork}`
+      );
 
     case ForkName.altair:
     case ForkName.bellatrix:


### PR DESCRIPTION
Starting on a checkpoint sync, when the finalized header for the light client update store will be zero (till a finalization happens post startup), the upgrade would fail as zero finalized header's slot (use to upgrade from) is 0 and would result in such kind of error as reported by @philknows 

![image](https://user-images.githubusercontent.com/76567250/218401087-73808086-59b4-4b72-a013-8ded03fd1491.png)


However the upgrade neednot be applied as zero finalized already belongs to the highest fork, this PR fixes the same 