### PR TITLE
`structuredClone`able INetworkOptions

### DIFF
--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -4,7 +4,13 @@ import {defaultGossipHandlerOpts, GossipHandlerOpts} from "./gossip/handlers/ind
 import {PeerManagerOpts} from "./peers/index.js";
 import {ReqRespBeaconNodeOpts} from "./reqresp/ReqRespBeaconNode.js";
 
-export interface INetworkOptions extends PeerManagerOpts, ReqRespBeaconNodeOpts, GossipHandlerOpts, Eth2GossipsubOpts {
+// Since Network is eventually intended to be run in a separate thread, ensure that all options are cloneable using structuredClone
+export interface INetworkOptions
+  extends PeerManagerOpts,
+    // remove all Functions
+    Omit<ReqRespBeaconNodeOpts, "getPeerLogMetadata" | "onRateLimit">,
+    GossipHandlerOpts,
+    Eth2GossipsubOpts {
   localMultiaddrs: string[];
   bootMultiaddrs?: string[];
   subscribeAllSubnets?: boolean;


### PR DESCRIPTION
**Motivation**

See description in #4856 
If the Network class is to move to a thread, its options need to be structuredClone-able (ref: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).

**Description**

Ensure (by hand) that the INetworkOptions is structuredClone-able.