### PR TITLE
Track sync committee metrics

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -564,12 +564,15 @@ export function getValidatorApi({
         contributionAndProofs.map(async (contributionAndProof, i) => {
           try {
             // TODO: Validate in batch
-            const {syncCommitteeParticipants} = await validateSyncCommitteeGossipContributionAndProof(
+            const {syncCommitteeParticipantIndices} = await validateSyncCommitteeGossipContributionAndProof(
               chain,
               contributionAndProof,
               true // skip known participants check
             );
-            chain.syncContributionAndProofPool.add(contributionAndProof.message, syncCommitteeParticipants);
+            chain.syncContributionAndProofPool.add(
+              contributionAndProof.message,
+              syncCommitteeParticipantIndices.length
+            );
             await network.gossip.publishContributionAndProof(contributionAndProof);
           } catch (e) {
             errors.push(e as Error);

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -647,6 +647,12 @@ export function getValidatorApi({
       }
 
       network.prepareSyncCommitteeSubnets(subs);
+
+      if (metrics) {
+        for (const subscription of subscriptions) {
+          metrics.registerLocalValidatorInSyncCommittee(subscription.validatorIndex, subscription.untilEpoch);
+        }
+      }
     },
 
     async prepareBeaconProposer(proposers) {

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -385,7 +385,7 @@ export async function importBlock(
   this.metrics?.proposerBalanceDeltaAny.observe(fullyVerifiedBlock.proposerBalanceDelta);
   this.metrics?.registerImportedBlock(block.message, fullyVerifiedBlock);
   if (this.config.getForkSeq(block.message.slot) >= ForkSeq.altair) {
-    this.metrics?.registerImportedBlockSyncAggregate(
+    this.metrics?.registerSyncAggregateInBlock(
       blockEpoch,
       (block as altair.SignedBeaconBlock).message.body.syncAggregate,
       fullyVerifiedBlock.postState.epochCtx.currentSyncCommitteeIndexed.validatorIndices

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -1,5 +1,5 @@
-import {capella, ssz, allForks} from "@lodestar/types";
-import {MAX_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {capella, ssz, allForks, altair} from "@lodestar/types";
+import {ForkSeq, MAX_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {toHexString} from "@chainsafe/ssz";
 import {
   CachedBeaconStateAltair,
@@ -384,6 +384,13 @@ export async function importBlock(
   this.metrics?.parentBlockDistance.observe(block.message.slot - parentBlockSlot);
   this.metrics?.proposerBalanceDeltaAny.observe(fullyVerifiedBlock.proposerBalanceDelta);
   this.metrics?.registerImportedBlock(block.message, fullyVerifiedBlock);
+  if (this.config.getForkSeq(block.message.slot) >= ForkSeq.altair) {
+    this.metrics?.registerImportedBlockSyncAggregate(
+      blockEpoch,
+      (block as altair.SignedBeaconBlock).message.body.syncAggregate,
+      fullyVerifiedBlock.postState.epochCtx.currentSyncCommitteeIndexed.validatorIndices
+    );
+  }
 
   const advancedSlot = this.clock.slotWithFutureTolerance(REPROCESS_MIN_TIME_TO_NEXT_SLOT_SEC);
 

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -862,6 +862,11 @@ export function createLodestarMetrics(
         name: "validator_monitor_prev_epoch_sync_committee_misses",
         help: "Count of times in prev epoch connected validators fail to participate in imported block's syncAggregate",
       }),
+      prevEpochSyncSignatureAggregateInclusions: register.histogram({
+        name: "validator_monitor_prev_epoch_sync_signature_aggregate_inclusions",
+        help: "The count of times a sync signature was seen inside an aggregate",
+        buckets: [0, 1, 2, 3, 5, 10],
+      }),
 
       // Validator Monitor Metrics (real-time)
 
@@ -914,6 +919,10 @@ export function createLodestarMetrics(
         name: "validator_monitor_attestation_in_block_delay_slots",
         help: "The excess slots (beyond the minimum delay) between the attestation slot and the block slot",
         buckets: [0.1, 0.25, 0.5, 1, 2, 5, 10],
+      }),
+      syncSignatureInAggregateTotal: register.gauge({
+        name: "validator_monitor_sync_signature_in_aggregate_total",
+        help: "Number of times a sync signature has been seen in an aggregate",
       }),
       beaconBlockTotal: register.gauge<"src">({
         name: "validator_monitor_beacon_block_total",

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -854,6 +854,14 @@ export function createLodestarMetrics(
         help: "The min delay between when the validator should send the aggregate and when it was received",
         buckets: [0.1, 0.25, 0.5, 1, 2, 5, 10],
       }),
+      prevEpochSyncCommitteeHits: register.gauge({
+        name: "validator_monitor_prev_epoch_sync_committee_hits",
+        help: "Count of times in prev epoch connected validators participated in imported block's syncAggregate",
+      }),
+      prevEpochSyncCommitteeMisses: register.gauge({
+        name: "validator_monitor_prev_epoch_sync_committee_misses",
+        help: "Count of times in prev epoch connected validators fail to participate in imported block's syncAggregate",
+      }),
 
       // Validator Monitor Metrics (real-time)
 

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -746,7 +746,11 @@ export function createLodestarMetrics(
       validatorsConnected: register.gauge({
         name: "validator_monitor_validators",
         help: "Count of validators that are specifically monitored by this beacon node",
-        labelNames: ["index"],
+      }),
+
+      validatorsInSyncCommittee: register.gauge({
+        name: "validator_monitor_validators_in_sync_committee",
+        help: "Count of validators monitored by this beacon node that are part of sync committee",
       }),
 
       // Validator Monitor Metrics (per-epoch summaries)

--- a/packages/beacon-node/src/network/gossip/handlers/index.ts
+++ b/packages/beacon-node/src/network/gossip/handlers/index.ts
@@ -301,7 +301,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
     },
 
     [GossipType.sync_committee_contribution_and_proof]: async (contributionAndProof) => {
-      const {syncCommitteeParticipants} = await validateSyncCommitteeGossipContributionAndProof(
+      const {syncCommitteeParticipantIndices} = await validateSyncCommitteeGossipContributionAndProof(
         chain,
         contributionAndProof
       ).catch((e) => {
@@ -312,9 +312,10 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
       });
 
       // Handler
+      metrics?.registerGossipSyncContributionAndProof(contributionAndProof.message, syncCommitteeParticipantIndices);
 
       try {
-        chain.syncContributionAndProofPool.add(contributionAndProof.message, syncCommitteeParticipants);
+        chain.syncContributionAndProofPool.add(contributionAndProof.message, syncCommitteeParticipantIndices.length);
       } catch (e) {
         logger.error("Error adding to contributionAndProof pool", {}, e as Error);
       }


### PR DESCRIPTION
**Motivation**

Track multiple sync committee metrics relevant for local validator performance

**Description**

Adds:
- `validator_monitor_validators_in_sync_committee`
- `validator_monitor_prev_epoch_sync_committee_hits`
- `validator_monitor_prev_epoch_sync_committee_misses`
- `validator_monitor_prev_epoch_sync_signature_aggregate_inclusions`
- `validator_monitor_sync_signature_in_aggregate_total`

Closes https://github.com/ChainSafe/lodestar/issues/3413
