### PR TITLE
Upgrade spec to v1.3.0-rc.2-hotfix

### DIFF
--- a/packages/beacon-node/test/spec/presets/index.test.ts
+++ b/packages/beacon-node/test/spec/presets/index.test.ts
@@ -1,7 +1,5 @@
 import path from "node:path";
 import {ACTIVE_PRESET} from "@lodestar/params";
-import {Type} from "@chainsafe/ssz";
-import {ssz} from "@lodestar/types";
 
 import {RunnerType} from "../utils/types.js";
 import {SkipOpts, specTestIterator} from "../utils/specTestIterator.js";
@@ -31,36 +29,17 @@ import {transition} from "./transition.js";
 //    "eip4844/operations/bls_to_execution_change",
 // ],
 // ```
-const skipOpts: SkipOpts = {};
+const skipOpts: SkipOpts = {
+  // TODO: capella
+  // BeaconBlockBody proof in lightclient is the new addition in v1.3.0-rc.2-hotfix
+  // Skip them for now to enable subsequently
+  skippedPrefixes: [
+    "capella/light_client/single_merkle_proof/BeaconBlockBody",
+    "deneb/light_client/single_merkle_proof/BeaconBlockBody",
+  ],
+};
 
 /* eslint-disable @typescript-eslint/naming-convention */
-
-// TODO: capella
-// Map all lightclient types to altair for addressing the specs
-// which are are to be updated in separate PR
-const overrideSSZTypes: Record<string, Record<string, Type<any>>> = {
-  deneb: {
-    LightClientHeader: ssz.altair.LightClientHeader,
-    LightClientUpdate: ssz.altair.LightClientUpdate,
-    LightClientOptimisticUpdate: ssz.altair.LightClientOptimisticUpdate,
-    LightClientFinalityUpdate: ssz.altair.LightClientFinalityUpdate,
-    LightClientBootstrap: ssz.altair.LightClientBootstrap,
-  },
-  capella: {
-    LightClientHeader: ssz.altair.LightClientHeader,
-    LightClientUpdate: ssz.altair.LightClientUpdate,
-    LightClientOptimisticUpdate: ssz.altair.LightClientOptimisticUpdate,
-    LightClientFinalityUpdate: ssz.altair.LightClientFinalityUpdate,
-    LightClientBootstrap: ssz.altair.LightClientBootstrap,
-  },
-  bellatrix: {
-    LightClientHeader: ssz.altair.LightClientHeader,
-    LightClientUpdate: ssz.altair.LightClientUpdate,
-    LightClientOptimisticUpdate: ssz.altair.LightClientOptimisticUpdate,
-    LightClientFinalityUpdate: ssz.altair.LightClientFinalityUpdate,
-    LightClientBootstrap: ssz.altair.LightClientBootstrap,
-  },
-};
 
 specTestIterator(
   path.join(ethereumConsensusSpecsTests.outputDir, "tests", ACTIVE_PRESET),
@@ -87,7 +66,7 @@ specTestIterator(
     shuffling: {type: RunnerType.default, fn: shuffling},
     ssz_static: {
       type: RunnerType.custom,
-      fn: sszStatic(undefined, overrideSSZTypes),
+      fn: sszStatic(),
     },
     sync: {type: RunnerType.default, fn: forkChoiceTest({onlyPredefinedResponses: true})},
     transition: {

--- a/packages/beacon-node/test/spec/presets/light_client/single_merkle_proof.ts
+++ b/packages/beacon-node/test/spec/presets/light_client/single_merkle_proof.ts
@@ -51,6 +51,8 @@ function getObjectType(fork: ForkName, objectName: string): Type<unknown> {
   switch (objectName) {
     case "BeaconState":
       return ssz[fork].BeaconState;
+    case "BeaconBlockBody":
+      return ssz[fork].BeaconBlockBody;
     default:
       throw Error(`Unknown objectName ${objectName}`);
   }

--- a/packages/beacon-node/test/spec/presets/light_client/sync.ts
+++ b/packages/beacon-node/test/spec/presets/light_client/sync.ts
@@ -32,6 +32,7 @@ type SyncTestCase = {
   };
 
   // Injected after parsing
+  // However updates are multifork and need config and step access to deserialize inside test
   updates: Map<string, Uint8Array>;
 };
 

--- a/packages/beacon-node/test/spec/presets/light_client/sync.ts
+++ b/packages/beacon-node/test/spec/presets/light_client/sync.ts
@@ -1,4 +1,5 @@
 import {expect} from "chai";
+import {isForkLightClient} from "@lodestar/params";
 import {altair, phase0, RootHex, Slot, ssz} from "@lodestar/types";
 import {init} from "@chainsafe/bls/switchable";
 import {InputType} from "@lodestar/spec-test-util";
@@ -31,7 +32,7 @@ type SyncTestCase = {
   };
 
   // Injected after parsing
-  updates: Map<string, altair.LightClientUpdate>;
+  updates: Map<string, Uint8Array>;
 };
 
 type CheckHeader = {
@@ -73,7 +74,7 @@ type LightclientSyncSteps = ProcessUpdateStep | ForceUpdateStep;
 const logger = testLogger("spec-test");
 const UPDATE_FILE_NAME = "^(update)_([0-9a-zA-Z_]+)$";
 
-export const sync: TestRunnerFn<SyncTestCase, void> = () => {
+export const sync: TestRunnerFn<SyncTestCase, void> = (fork) => {
   return {
     testFunction: async (testcase) => {
       await init("blst-native");
@@ -125,10 +126,13 @@ export const sync: TestRunnerFn<SyncTestCase, void> = () => {
             const currentSlot = Number(step.process_update.current_slot as bigint);
             logger.debug(`Step ${i}/${stepsLen} process_update`, renderSlot(currentSlot));
 
-            const update = testcase.updates.get(step.process_update.update);
-            if (!update) {
+            const updateBytes = testcase.updates.get(step.process_update.update);
+            if (!updateBytes) {
               throw Error(`update ${step.process_update.update} not found`);
             }
+
+            const headerSlot = Number(step.process_update.checks.optimistic_header.slot);
+            const update = config.getLightClientForkTypes(headerSlot)["LightClientUpdate"].deserialize(updateBytes);
 
             logger.debug(`LightclientUpdateSummary: ${JSON.stringify(toLightClientUpdateSummary(update))}`);
 
@@ -165,12 +169,15 @@ export const sync: TestRunnerFn<SyncTestCase, void> = () => {
         config: InputType.YAML,
       },
       sszTypes: {
-        bootstrap: ssz.altair.LightClientBootstrap,
-        [UPDATE_FILE_NAME]: ssz.altair.LightClientUpdate,
+        bootstrap: isForkLightClient(fork)
+          ? ssz.allForksLightClient[fork].LightClientBootstrap
+          : ssz.altair.LightClientBootstrap,
+        // The updates are multifork and need config and step info to be deserialized within the test
+        [UPDATE_FILE_NAME]: {typeName: "LightClientUpdate", deserialize: (bytes: Uint8Array) => bytes},
       },
       mapToTestCase: (t: Record<string, any>) => {
         // t has input file name as key
-        const updates = new Map<string, altair.LightClientUpdate>();
+        const updates = new Map<string, Uint8Array>();
         for (const key in t) {
           const updateMatch = key.match(UPDATE_FILE_NAME);
           if (updateMatch) {

--- a/packages/beacon-node/test/spec/presets/light_client/update_ranking.ts
+++ b/packages/beacon-node/test/spec/presets/light_client/update_ranking.ts
@@ -1,5 +1,6 @@
 import {expect} from "chai";
-import {altair, ssz} from "@lodestar/types";
+import {altair, ssz, allForks} from "@lodestar/types";
+import {isForkLightClient} from "@lodestar/params";
 import {InputType} from "@lodestar/spec-test-util";
 import {isBetterUpdate, LightClientUpdateSummary, toLightClientUpdateSummary} from "@lodestar/light-client/spec";
 import {TestRunnerFn} from "../../utils/types.js";
@@ -16,12 +17,12 @@ type UpdateRankingTestCase = {
 // updates_<index>.ssz_snappy
 const UPDATES_FILE_NAME = "^updates_([0-9]+)$";
 
-export const updateRanking: TestRunnerFn<UpdateRankingTestCase, void> = () => {
+export const updateRanking: TestRunnerFn<UpdateRankingTestCase, void> = (fork) => {
   return {
     testFunction: (testcase) => {
       // Parse update files
       const updatesCount = Number(testcase.meta.updates_count as bigint);
-      const updates: altair.LightClientUpdate[] = [];
+      const updates: allForks.LightClientUpdate[] = [];
 
       for (let i = 0; i < updatesCount; i++) {
         const update = ((testcase as unknown) as Record<string, altair.LightClientUpdate>)[`updates_${i}`];
@@ -52,7 +53,9 @@ newUpdate = ${renderUpdate(newUpdate)}
         meta: InputType.YAML,
       },
       sszTypes: {
-        [UPDATES_FILE_NAME]: ssz.altair.LightClientUpdate,
+        [UPDATES_FILE_NAME]: isForkLightClient(fork)
+          ? ssz.allForksLightClient[fork].LightClientUpdate
+          : ssz.altair.LightClientUpdate,
       },
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       expectFunc: () => {},

--- a/packages/beacon-node/test/spec/presets/ssz_static.ts
+++ b/packages/beacon-node/test/spec/presets/ssz_static.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import {ssz} from "@lodestar/types";
 import {Type} from "@chainsafe/ssz";
-import {ACTIVE_PRESET, ForkName} from "@lodestar/params";
+import {ACTIVE_PRESET, ForkName, ForkLightClient} from "@lodestar/params";
 import {replaceUintTypeWithUintBigintType} from "../utils/replaceUintTypeWithUintBigintType.js";
 import {parseSszStaticTestcase} from "../utils/sszTestCaseParser.js";
 import {runValidSszTest} from "../utils/runValidSszTest.js";
@@ -26,7 +26,7 @@ type Types = Record<string, Type<any>>;
 // tests / mainnet / altair / ssz_static       / Validator    / ssz_random   / case_0/roots.yaml
 //
 
-export const sszStatic = (skippedTypes?: string[], overrideSSZTypes?: Record<string, Types>) => (
+export const sszStatic = (skippedTypes?: string[]) => (
   fork: ForkName,
   typeName: string,
   testSuite: string,
@@ -39,7 +39,9 @@ export const sszStatic = (skippedTypes?: string[], overrideSSZTypes?: Record<str
 
   /* eslint-disable @typescript-eslint/strict-boolean-expressions */
   const sszType =
-    (((overrideSSZTypes ?? {})[fork] ?? {}) as Types)[typeName] ||
+    // Since lightclient types are not updated/declared at all forks, this allForksLightClient
+    // will help us get the right type for lightclient objects
+    ((ssz.allForksLightClient[fork as ForkLightClient] || {}) as Types)[typeName] ||
     (ssz[fork] as Types)[typeName] ||
     (ssz.capella as Types)[typeName] ||
     (ssz.bellatrix as Types)[typeName] ||

--- a/packages/beacon-node/test/spec/specTestVersioning.ts
+++ b/packages/beacon-node/test/spec/specTestVersioning.ts
@@ -15,7 +15,7 @@ import {IDownloadTestsOptions} from "@lodestar/spec-test-util";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const ethereumConsensusSpecsTests: IDownloadTestsOptions = {
-  specVersion: "v1.3.0-rc.1",
+  specVersion: "v1.3.0-rc.2-hotfix",
   // Target directory is the host package root: 'packages/*/spec-tests'
   outputDir: path.join(__dirname, "../../spec-tests"),
   specTestsRepoUrl: "https://github.com/ethereum/consensus-spec-tests",

--- a/packages/params/src/index.ts
+++ b/packages/params/src/index.ts
@@ -9,6 +9,7 @@ export {BeaconPreset} from "./interface.js";
 export {
   ForkName,
   ForkSeq,
+  ForkLightClient,
   ForkExecution,
   ForkBlobs,
   isForkExecution,

--- a/packages/params/test/e2e/ensure-config-is-synced.test.ts
+++ b/packages/params/test/e2e/ensure-config-is-synced.test.ts
@@ -8,7 +8,7 @@ import {loadConfigYaml} from "../yaml.js";
 // Not e2e, but slow. Run with e2e tests
 
 /** https://github.com/ethereum/consensus-specs/releases */
-const specConfigCommit = "v1.3.0-alpha.2";
+const specConfigCommit = "v1.3.0-rc.2";
 
 describe("Ensure config is synced", function () {
   this.timeout(60 * 1000);


### PR DESCRIPTION
Upgrade spec to v1.3.0-rc.2-hotfix

Right now skips 2 new tests added in  `v1.3.0-rc.2-hotfix` regarding light sync beacon block merkle proofs, to be enabled in a followup PR