### PR TITLE
fix(bug): set `subscribedEventstream` to `true`. Prevents double processing of headers

### DIFF
--- a/packages/light-client/src/transport/rest.ts
+++ b/packages/light-client/src/transport/rest.ts
@@ -89,5 +89,6 @@ export class LightClientRestTransport extends (EventEmitter as {new (): RestEven
         }
       }
     );
+    this.subscribedEventstream = true;
   }
 }


### PR DESCRIPTION
Signed-off-by: Daniel-K-Ivanov [daniel.k.ivanov95@gmail.com](mailto:daniel.k.ivanov95@gmail.com)

# Motivation
This PR prevents double subscriptions thus double processing of headers

# Description
onOptimisticUpdate and onFinalityUpdate functions call the subcribeEventStream function to subscribe to the 2 events they care about. The subscribeEventStream function checks whether the subscriptions are already turned on, but does not mark them as turned on after the initial subscription. **This makes the light client to process every optimistic and finality header update twice.**