### PR TITLE
Add chain.archiveStateEpochFrequency cli option

### DIFF
--- a/packages/beacon-node/src/chain/archiver/archiveStates.ts
+++ b/packages/beacon-node/src/chain/archiver/archiveStates.ts
@@ -7,14 +7,17 @@ import {IBeaconDb} from "../../db/index.js";
 import {CheckpointStateCache} from "../stateCache/index.js";
 
 /**
- * Minimum number of epochs between archived states
- */
-export const PERSIST_STATE_EVERY_EPOCHS = 1024;
-/**
  * Minimum number of epochs between single temp archived states
  * These states will be pruned once a new state is persisted
  */
 const PERSIST_TEMP_STATE_EVERY_EPOCHS = 32;
+
+export interface StatesArchiverOpts {
+  /**
+   * Minimum number of epochs between archived states
+   */
+  archiveStateEpochFrequency: number;
+}
 
 /**
  * Archives finalized states from active bucket to archive bucket.
@@ -25,7 +28,8 @@ export class StatesArchiver {
   constructor(
     private readonly checkpointStateCache: CheckpointStateCache,
     private readonly db: IBeaconDb,
-    private readonly logger: ILogger
+    private readonly logger: ILogger,
+    private readonly opts: StatesArchiverOpts
   ) {}
 
   /**
@@ -43,14 +47,15 @@ export class StatesArchiver {
   async maybeArchiveState(finalized: CheckpointWithHex): Promise<void> {
     const lastStoredSlot = await this.db.stateArchive.lastKey();
     const lastStoredEpoch = computeEpochAtSlot(lastStoredSlot ?? 0);
+    const archiveStateEpochFrequency = this.opts.archiveStateEpochFrequency;
 
-    if (finalized.epoch - lastStoredEpoch > PERSIST_TEMP_STATE_EVERY_EPOCHS) {
+    if (finalized.epoch - lastStoredEpoch > Math.min(PERSIST_TEMP_STATE_EVERY_EPOCHS, archiveStateEpochFrequency)) {
       await this.archiveState(finalized);
 
       // Only check the current and previous intervals
       const minEpoch = Math.max(
         0,
-        (Math.floor(finalized.epoch / PERSIST_STATE_EVERY_EPOCHS) - 1) * PERSIST_STATE_EVERY_EPOCHS
+        (Math.floor(finalized.epoch / archiveStateEpochFrequency) - 1) * archiveStateEpochFrequency
       );
 
       const storedStateSlots = await this.db.stateArchive.keys({
@@ -58,7 +63,7 @@ export class StatesArchiver {
         gte: computeStartSlotAtEpoch(minEpoch),
       });
 
-      const statesSlotsToDelete = computeStateSlotsToDelete(storedStateSlots, PERSIST_STATE_EVERY_EPOCHS);
+      const statesSlotsToDelete = computeStateSlotsToDelete(storedStateSlots, archiveStateEpochFrequency);
       if (statesSlotsToDelete.length > 0) {
         await this.db.stateArchive.batchDelete(statesSlotsToDelete);
       }

--- a/packages/beacon-node/src/chain/archiver/archiveStates.ts
+++ b/packages/beacon-node/src/chain/archiver/archiveStates.ts
@@ -47,7 +47,7 @@ export class StatesArchiver {
   async maybeArchiveState(finalized: CheckpointWithHex): Promise<void> {
     const lastStoredSlot = await this.db.stateArchive.lastKey();
     const lastStoredEpoch = computeEpochAtSlot(lastStoredSlot ?? 0);
-    const archiveStateEpochFrequency = this.opts.archiveStateEpochFrequency;
+    const {archiveStateEpochFrequency} = this.opts;
 
     if (finalized.epoch - lastStoredEpoch > Math.min(PERSIST_TEMP_STATE_EVERY_EPOCHS, archiveStateEpochFrequency)) {
       await this.archiveState(finalized);

--- a/packages/beacon-node/src/chain/archiver/index.ts
+++ b/packages/beacon-node/src/chain/archiver/index.ts
@@ -5,12 +5,12 @@ import {IBeaconDb} from "../../db/index.js";
 import {JobItemQueue} from "../../util/queue/index.js";
 import {IBeaconChain} from "../interface.js";
 import {ChainEvent} from "../emitter.js";
-import {StatesArchiver} from "./archiveStates.js";
+import {StatesArchiver, StatesArchiverOpts} from "./archiveStates.js";
 import {archiveBlocks} from "./archiveBlocks.js";
 
 const PROCESS_FINALIZED_CHECKPOINT_QUEUE_LEN = 256;
 
-export type ArchiverOpts = {
+export type ArchiverOpts = StatesArchiverOpts & {
   disableArchiveOnCheckpoint?: boolean;
 };
 
@@ -30,7 +30,7 @@ export class Archiver {
     signal: AbortSignal,
     opts: ArchiverOpts
   ) {
-    this.statesArchiver = new StatesArchiver(chain.checkpointStateCache, db, logger);
+    this.statesArchiver = new StatesArchiver(chain.checkpointStateCache, db, logger, opts);
     this.jobQueue = new JobItemQueue<[CheckpointWithHex], void>(this.processFinalizedCheckpoint, {
       maxLength: PROCESS_FINALIZED_CHECKPOINT_QUEUE_LEN,
       signal,

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -60,4 +60,5 @@ export const defaultChainOptions: IChainOptions = {
   safeSlotsToImportOptimistically: SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY,
   suggestedFeeRecipient: defaultValidatorOptions.suggestedFeeRecipient,
   assertCorrectProgressiveBalances: false,
+  archiveStateEpochFrequency: 1024,
 };

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -86,6 +86,7 @@ describe.skip("verify+import blocks - range sync perf test", () => {
           disableArchiveOnCheckpoint: true,
           suggestedFeeRecipient: defaultValidatorOptions.suggestedFeeRecipient,
           skipCreateStateCacheIfAvailable: true,
+          archiveStateEpochFrequency: 1024,
         },
         {
           config: state.config,

--- a/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
@@ -11,7 +11,6 @@ import {
   getStateValidatorIndex,
 } from "../../../../../../src/api/impl/beacon/state/utils.js";
 import {IBeaconChain} from "../../../../../../src/chain/index.js";
-import {PERSIST_STATE_EVERY_EPOCHS} from "../../../../../../src/chain/archiver/archiveStates.js";
 import {generateProtoBlock} from "../../../../../utils/typeGenerator.js";
 import {generateCachedAltairState, generateCachedState, generateState} from "../../../../../utils/state.js";
 import {StubbedBeaconDb} from "../../../../../utils/stub/index.js";
@@ -91,7 +90,7 @@ describe("beacon state api utils", function () {
     });
 
     it("resolve state on unarchived finalized slot", async function () {
-      const nearestArchiveSlot = PERSIST_STATE_EVERY_EPOCHS * SLOTS_PER_EPOCH;
+      const nearestArchiveSlot = 1024 * SLOTS_PER_EPOCH;
       const finalizedEpoch = 1028;
       const requestedSlot = 1026 * SLOTS_PER_EPOCH;
 

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -66,6 +66,7 @@ export class MockBeaconChain implements IBeaconChain {
     proposerBoostEnabled: false,
     safeSlotsToImportOptimistically: 0,
     suggestedFeeRecipient: "0x0000000000000000000000000000000000000000",
+    archiveStateEpochFrequency: 1024,
   };
   readonly anchorStateLatestBlockSlot: Slot;
 

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -17,6 +17,7 @@ export interface IChainArgs {
   "chain.assertCorrectProgressiveBalances": boolean;
   "chain.maxSkipSlots": number;
   "safe-slots-to-import-optimistically": number;
+  "chain.archiveStateEpochFrequency": number;
 }
 
 export function parseArgs(args: IChainArgs): IBeaconNodeOptions["chain"] {
@@ -35,6 +36,7 @@ export function parseArgs(args: IChainArgs): IBeaconNodeOptions["chain"] {
     assertCorrectProgressiveBalances: args["chain.assertCorrectProgressiveBalances"],
     maxSkipSlots: args["chain.maxSkipSlots"],
     safeSlotsToImportOptimistically: args["safe-slots-to-import-optimistically"],
+    archiveStateEpochFrequency: args["chain.archiveStateEpochFrequency"],
   };
 }
 
@@ -131,6 +133,13 @@ Will double processing times. Use only for debugging purposes.",
     description:
       "Slots from current (clock) slot till which its safe to import a block optimistically if the merge is not justified yet.",
     defaultDescription: String(defaultOptions.chain.safeSlotsToImportOptimistically),
+    group: "chain",
+  },
+
+  "chain.archiveStateEpochFrequency": {
+    hidden: true,
+    description: "Minimum number of epochs between archived states",
+    type: "number",
     group: "chain",
   },
 };

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -29,6 +29,7 @@ describe("options / beaconNodeOptions", () => {
       "chain.assertCorrectProgressiveBalances": true,
       "chain.maxSkipSlots": 100,
       "safe-slots-to-import-optimistically": 256,
+      "chain.archiveStateEpochFrequency": 1024,
 
       eth1: true,
       "eth1.providerUrl": "http://my.node:8545",

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -107,6 +107,7 @@ describe("options / beaconNodeOptions", () => {
         suggestedFeeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         assertCorrectProgressiveBalances: true,
         maxSkipSlots: 100,
+        archiveStateEpochFrequency: 1024,
       },
       eth1: {
         enabled: true,


### PR DESCRIPTION
**Motivation**

A few lodestar consumers have wanted finer grained control over historical state retrieval.
This is a cheap win, since this merely exposes a constant as a configurable value, doesn't require any additional implementation work.

**Description**

- Replace `PERSIST_STATE_EVERY_EPOCHS` constant with `chain.archiveStateEpochFrequency` hidden cli option
- Handle case where `chain.archiveStateEpochFrequency` can now be smaller than `PERSIST_TEMP_STATE_EVERY_EPOCHS`
  - Ensures that `chain.archiveStateEpochFrequency` will not have a de-facto minimum of `PERSIST_TEMP_STATE_EVERY_EPOCHS`