### PR TITLE
Validator Apis: avoid unknown block root error in fallback urls setup

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -9,6 +9,7 @@ import {validateBlsToExecutionChange} from "../../../../chain/validation/blsToEx
 import {validateSyncCommitteeSigOnly} from "../../../../chain/validation/syncCommittee.js";
 import {ApiModules} from "../../types.js";
 import {AttestationError, GossipAction, SyncCommitteeError} from "../../../../chain/errors/index.js";
+import {validateGossipFnRetryUnknownRoot} from "../../../../network/gossip/handlers/index.js";
 
 export function getBeaconPoolApi({
   chain,
@@ -51,7 +52,18 @@ export function getBeaconPoolApi({
       await Promise.all(
         attestations.map(async (attestation, i) => {
           try {
-            const {indexedAttestation, subnet} = await validateGossipAttestation(chain, attestation, null);
+            // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+            const validateFn = () => validateGossipAttestation(chain, attestation, null);
+            const {slot, beaconBlockRoot} = attestation.data;
+            // when a validator is configured with multiple beacon node urls, this attestation data may come from another beacon node
+            // and the block hasn't been in our forkchoice since we haven't seen / processing that block
+            // see https://github.com/ChainSafe/lodestar/issues/5098
+            const {indexedAttestation, subnet} = await validateGossipFnRetryUnknownRoot(
+              validateFn,
+              chain,
+              slot,
+              beaconBlockRoot
+            );
 
             const insertOutcome = chain.attestationPool.add(attestation);
             const sentPeers = await network.gossip.publishBeaconAttestation(attestation, subnet);

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -25,8 +25,8 @@ import {CommitteeSubscription} from "../../../network/subnets/index.js";
 import {ApiModules} from "../types.js";
 import {RegenCaller} from "../../../chain/regen/index.js";
 import {getValidatorStatus} from "../beacon/state/utils.js";
+import {validateGossipFnRetryUnknownRoot} from "../../../network/gossip/handlers/index.js";
 import {computeSubnetForCommitteesAtSlot, getPubkeysForIndices} from "./utils.js";
-import { validateGossipFnRetryUnknownRoot } from "../../../network/gossip/handlers/index.js";
 
 /**
  * If the node is within this many epochs from the head, we declare it to be synced regardless of

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -479,7 +479,7 @@ export class BeaconChain implements IBeaconChain {
    * Used to handle unknown block root for both unaggregated and aggregated attestations.
    * @returns true if blockFound
    */
-  waitForBlockOfAttestation(slot: Slot, root: RootHex): Promise<boolean> {
+  waitForBlock(slot: Slot, root: RootHex): Promise<boolean> {
     return this.reprocessController.waitForBlockOfAttestation(slot, root);
   }
 

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -125,7 +125,7 @@ export interface IBeaconChain {
 
   recomputeForkChoiceHead(): ProtoBlock;
 
-  waitForBlockOfAttestation(slot: Slot, root: RootHex): Promise<boolean>;
+  waitForBlock(slot: Slot, root: RootHex): Promise<boolean>;
 
   updateBeaconProposerData(epoch: Epoch, proposers: ProposerPreparationData[]): Promise<void>;
 

--- a/packages/beacon-node/src/network/gossip/handlers/index.ts
+++ b/packages/beacon-node/src/network/gossip/handlers/index.ts
@@ -1,8 +1,8 @@
 import {peerIdFromString} from "@libp2p/peer-id";
 import {toHexString} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
-import {phase0, ssz} from "@lodestar/types";
 import {Logger, prettyBytes} from "@lodestar/utils";
+import {phase0, Root, Slot, ssz} from "@lodestar/types";
 import {ForkName, ForkSeq} from "@lodestar/params";
 import {Metrics} from "../../../metrics/index.js";
 import {OpSource} from "../../../metrics/validatorMonitor.js";
@@ -194,7 +194,14 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
     [GossipType.beacon_aggregate_and_proof]: async (signedAggregateAndProof, _topic, _peer, seenTimestampSec) => {
       let validationResult: {indexedAttestation: phase0.IndexedAttestation; committeeIndices: number[]};
       try {
-        validationResult = await validateGossipAggregateAndProofRetryUnknownRoot(chain, signedAggregateAndProof);
+        // If an attestation refers to a block root that's not known, it will wait for 1 slot max
+        // See https://github.com/ChainSafe/lodestar/pull/3564 for reasoning and results
+        // Waiting here requires minimal code and automatically affects attestation, and aggregate validation
+        // both from gossip and the API. I also prevents having to catch and re-throw in multiple places.
+        // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+        const validateFn = () => validateGossipAggregateAndProof(chain, signedAggregateAndProof);
+        const {slot, beaconBlockRoot} = signedAggregateAndProof.message.aggregate.data;
+        validationResult = await validateGossipFnRetryUnknownRoot(validateFn, chain, slot, beaconBlockRoot);
       } catch (e) {
         if (e instanceof AttestationError && e.action === GossipAction.REJECT) {
           chain.persistInvalidSszValue(ssz.phase0.SignedAggregateAndProof, signedAggregateAndProof, "gossip_reject");
@@ -229,7 +236,14 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
     [GossipType.beacon_attestation]: async (attestation, {subnet}, _peer, seenTimestampSec) => {
       let validationResult: {indexedAttestation: phase0.IndexedAttestation; subnet: number};
       try {
-        validationResult = await validateGossipAttestationRetryUnknownRoot(chain, attestation, subnet);
+        // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+        const validateFn = () => validateGossipAttestation(chain, attestation, subnet);
+        const {slot, beaconBlockRoot} = attestation.data;
+        // If an attestation refers to a block root that's not known, it will wait for 1 slot max
+        // See https://github.com/ChainSafe/lodestar/pull/3564 for reasoning and results
+        // Waiting here requires minimal code and automatically affects attestation, and aggregate validation
+        // both from gossip and the API. I also prevents having to catch and re-throw in multiple places.
+        validationResult = await validateGossipFnRetryUnknownRoot(validateFn, chain, slot, beaconBlockRoot);
       } catch (e) {
         if (e instanceof AttestationError && e.action === GossipAction.REJECT) {
           chain.persistInvalidSszValue(ssz.phase0.Attestation, attestation, "gossip_reject");
@@ -364,20 +378,19 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
 }
 
 /**
- * If an attestation refers to a block root that's not known, it will wait for 1 slot max
- * See https://github.com/ChainSafe/lodestar/pull/3564 for reasoning and results
- * Waiting here requires minimal code and automatically affects attestation, and aggregate validation
- * both from gossip and the API. I also prevents having to catch and re-throw in multiple places.
+ * Retry a function if it throws error code UNKNOWN_OR_PREFINALIZED_BEACON_BLOCK_ROOT
  */
-async function validateGossipAggregateAndProofRetryUnknownRoot(
+export async function validateGossipFnRetryUnknownRoot<T>(
+  fn: () => Promise<T>,
   chain: IBeaconChain,
-  signedAggregateAndProof: phase0.SignedAggregateAndProof
-): Promise<ReturnType<typeof validateGossipAggregateAndProof>> {
+  slot: Slot,
+  blockRoot: Root
+): Promise<T> {
   let unknownBlockRootRetries = 0;
   // eslint-disable-next-line no-constant-condition
   while (true) {
     try {
-      return await validateGossipAggregateAndProof(chain, signedAggregateAndProof);
+      return await fn();
     } catch (e) {
       if (
         e instanceof AttestationError &&
@@ -385,53 +398,7 @@ async function validateGossipAggregateAndProofRetryUnknownRoot(
       ) {
         if (unknownBlockRootRetries++ < MAX_UNKNOWN_BLOCK_ROOT_RETRIES) {
           // Trigger unknown block root search here
-
-          const attestation = signedAggregateAndProof.message.aggregate;
-          const foundBlock = await chain.waitForBlockOfAttestation(
-            attestation.data.slot,
-            toHexString(attestation.data.beaconBlockRoot)
-          );
-          // Returns true if the block was found on time. In that case, try to get it from the fork-choice again.
-          // Otherwise, throw the error below.
-          if (foundBlock) {
-            continue;
-          }
-        }
-      }
-
-      throw e;
-    }
-  }
-}
-
-/**
- * If an attestation refers to a block root that's not known, it will wait for 1 slot max
- * See https://github.com/ChainSafe/lodestar/pull/3564 for reasoning and results
- * Waiting here requires minimal code and automatically affects attestation, and aggregate validation
- * both from gossip and the API. I also prevents having to catch and re-throw in multiple places.
- */
-async function validateGossipAttestationRetryUnknownRoot(
-  chain: IBeaconChain,
-  attestation: phase0.Attestation,
-  subnet: number | null
-): Promise<ReturnType<typeof validateGossipAttestation>> {
-  let unknownBlockRootRetries = 0;
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    try {
-      return await validateGossipAttestation(chain, attestation, subnet);
-    } catch (e) {
-      if (
-        e instanceof AttestationError &&
-        e.type.code === AttestationErrorCode.UNKNOWN_OR_PREFINALIZED_BEACON_BLOCK_ROOT
-      ) {
-        if (unknownBlockRootRetries++ < MAX_UNKNOWN_BLOCK_ROOT_RETRIES) {
-          // Trigger unknown block root search here
-
-          const foundBlock = await chain.waitForBlockOfAttestation(
-            attestation.data.slot,
-            toHexString(attestation.data.beaconBlockRoot)
-          );
+          const foundBlock = await chain.waitForBlock(slot, toHexString(blockRoot));
           // Returns true if the block was found on time. In that case, try to get it from the fork-choice again.
           // Otherwise, throw the error below.
           if (foundBlock) {

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -211,7 +211,7 @@ export class MockBeaconChain implements IBeaconChain {
     return this.forkChoice.getHead();
   }
 
-  async waitForBlockOfAttestation(): Promise<boolean> {
+  async waitForBlock(): Promise<boolean> {
     return false;
   }
 

--- a/packages/beacon-node/test/utils/validationData/attestation.ts
+++ b/packages/beacon-node/test/utils/validationData/attestation.ts
@@ -123,7 +123,7 @@ export function getAttestationValidData(
     seenAttesters: new SeenAttesters(),
     seenAggregatedAttestations: new SeenAggregatedAttestations(null),
     bls: new BlsSingleThreadVerifier({metrics: null}),
-    waitForBlockOfAttestation: () => Promise.resolve(false),
+    waitForBlock: () => Promise.resolve(false),
   } as Partial<IBeaconChain>) as IBeaconChain;
 
   return {chain, attestation, subnet, validatorIndex};


### PR DESCRIPTION
**Motivation**

- Due to the fallback urls setup in validator, "unknown beacon block root" error may happen if data is produced from one beacon node and published to another beacon node since HttpClient will call all beacon urls in parallel
- Even through the final HttpClient call is a success, we may see "unknown beacon block" error from both beacon node and validator client, this is not good for UX
- See https://github.com/ChainSafe/lodestar/issues/5098#issuecomment-1427504993

**Description**
- We already have an API to wait for head block when validating gossip attestations
- Refactor that API to make it generic and use it for concerning validator APIs
- Affected APIs:
  - submitPoolAttestations
  - publishAggregateAndProofs
  - produceSyncCommitteeContribution
- This change does not affect single beacon node url setup, it only affects fallback urls setup
- It does not affect the flow or anything, the main thing is for UX improvement: users will not see these "unknown block" errors most of the time

part of #5098
related to #5063
Closes #5152
