### PR TITLE
Add metric value for `disk_beaconchain_bytes_total`

### DIFF
--- a/packages/beacon-node/src/monitoring/clientStats.ts
+++ b/packages/beacon-node/src/monitoring/clientStats.ts
@@ -101,9 +101,11 @@ function createProcessStats(process: ProcessType): ClientStats {
 function createBeaconNodeStats(): ClientStats {
   return {
     ...createProcessStats(ProcessType.BeaconNode),
-    diskBeaconChainBytesTotal: new StaticProperty({
+    diskBeaconChainBytesTotal: new MetricProperty({
       jsonKey: "disk_beaconchain_bytes_total",
-      value: 0,
+      metricName: "lodestar_db_size_bytes_total",
+      jsonType: JsonType.Number,
+      defaultValue: 0,
       description: "Amount of bytes consumed on disk by the beacon node's database",
     }),
     networkLibp2pBytesTotalReceive: new MetricProperty({


### PR DESCRIPTION
Follow up PR for https://github.com/ChainSafe/lodestar/pull/5037 to add missing value for amount of bytes consumed on disk by the beacon node's database (`disk_beaconchain_bytes_total`) which was implemented in https://github.com/ChainSafe/lodestar/pull/5087.
