### PR TITLE
Implement verge spec feature

### DIFF
--- a/packages/beacon-node/test/spec/presets/fork.ts
+++ b/packages/beacon-node/test/spec/presets/fork.ts
@@ -4,6 +4,7 @@ import {
   CachedBeaconStateAltair,
   CachedBeaconStatePhase0,
   CachedBeaconStateCapella,
+  CachedBeaconStateDeneb,
 } from "@lodestar/state-transition";
 import * as slotFns from "@lodestar/state-transition/slot";
 import {phase0, ssz} from "@lodestar/types";
@@ -32,6 +33,8 @@ export const fork: TestRunnerFn<ForkStateCase, BeaconStateAllForks> = (forkNext)
           return slotFns.upgradeStateToCapella(preState as CachedBeaconStateBellatrix);
         case ForkName.deneb:
           return slotFns.upgradeStateToDeneb(preState as CachedBeaconStateCapella);
+        case ForkName.verge:
+          return slotFns.upgradeStateToVerge(preState as CachedBeaconStateDeneb);
       }
     },
     options: {

--- a/packages/beacon-node/test/spec/presets/genesis.ts
+++ b/packages/beacon-node/test/spec/presets/genesis.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import {phase0, Root, ssz, TimeSeconds, allForks, deneb} from "@lodestar/types";
+import {phase0, Root, ssz, TimeSeconds, allForks} from "@lodestar/types";
 import {InputType} from "@lodestar/spec-test-util";
 import {
   BeaconStateAllForks,
@@ -41,7 +41,7 @@ const genesisInitialization: TestRunnerFn<GenesisInitSpecTest, BeaconStateAllFor
         genesisValidatorsRoot: Buffer.alloc(32, 0),
       });
 
-      const executionPayloadHeaderType =
+      const executionPayloadHeaderType: allForks.AllForksExecutionSSZTypes["ExecutionPayloadHeader"] =
         fork !== ForkName.phase0 && fork !== ForkName.altair
           ? ssz.allForksExecution[fork as ExecutionFork].ExecutionPayloadHeader
           : ssz.bellatrix.ExecutionPayloadHeader;
@@ -54,7 +54,7 @@ const genesisInitialization: TestRunnerFn<GenesisInitSpecTest, BeaconStateAllFor
         deposits,
         undefined,
         testcase["execution_payload_header"] &&
-          executionPayloadHeaderType.toViewDU(testcase["execution_payload_header"] as deneb.ExecutionPayloadHeader)
+          executionPayloadHeaderType.toViewDU(testcase["execution_payload_header"])
       );
     },
     // eth1.yaml

--- a/packages/beacon-node/test/spec/presets/transition.ts
+++ b/packages/beacon-node/test/spec/presets/transition.ts
@@ -99,6 +99,14 @@ function getTransitionConfig(fork: ForkName, forkEpoch: number): Partial<IChainC
       return {ALTAIR_FORK_EPOCH: 0, BELLATRIX_FORK_EPOCH: 0, CAPELLA_FORK_EPOCH: forkEpoch};
     case ForkName.deneb:
       return {ALTAIR_FORK_EPOCH: 0, BELLATRIX_FORK_EPOCH: 0, CAPELLA_FORK_EPOCH: 0, EIP4844_FORK_EPOCH: forkEpoch};
+    case ForkName.verge:
+      return {
+        ALTAIR_FORK_EPOCH: 0,
+        BELLATRIX_FORK_EPOCH: 0,
+        CAPELLA_FORK_EPOCH: 0,
+        EIP4844_FORK_EPOCH: 0,
+        VERGE_FORK_EPOCH: forkEpoch,
+      };
   }
 }
 

--- a/packages/beacon-node/test/unit/chain/lightclient/upgradeLightClientHeader.test.ts
+++ b/packages/beacon-node/test/unit/chain/lightclient/upgradeLightClientHeader.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import {ssz, capella, altair, deneb, allForks} from "@lodestar/types";
+import {ssz, capella, altair, deneb, allForks, verge} from "@lodestar/types";
 import {ForkName, ForkSeq} from "@lodestar/params";
 import {createIBeaconConfig, createIChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {upgradeLightClientHeader} from "@lodestar/light-client/spec";
@@ -30,8 +30,8 @@ describe("UpgradeLightClientHeader", function () {
     denebLCHeader = ssz.deneb.LightClientHeader.defaultValue();
     bellatrixLCHeader = ssz.altair.LightClientHeader.defaultValue();
 
-    update = [altairLCHeader, altairLCHeader, bellatrixLCHeader, capellaLCHeader, denebLCHeader];
-    testSlots = [0, 10, 17, 25, 33];
+    update = [altairLCHeader, altairLCHeader, bellatrixLCHeader, capellaLCHeader, denebLCHeader, denebLCHeader];
+    testSlots = [0, 10, 17, 25, 33, 41];
   });
 
   for (let i = ForkSeq.altair; i < Object.values(ForkName).length; i++) {

--- a/packages/beacon-node/test/unit/network/fork.test.ts
+++ b/packages/beacon-node/test/unit/network/fork.test.ts
@@ -9,12 +9,14 @@ function getForkConfig({
   bellatrix,
   capella,
   deneb,
+  verge,
 }: {
   phase0: number;
   altair: number;
   bellatrix: number;
   capella: number;
   deneb: number;
+  verge: number;
 }): IBeaconConfig {
   const forks: Record<ForkName, IForkInfo> = {
     phase0: {
@@ -53,6 +55,14 @@ function getForkConfig({
       name: ForkName.deneb,
       seq: ForkSeq.deneb,
       epoch: deneb,
+      version: Buffer.from([0, 0, 0, 4]),
+      prevVersion: Buffer.from([0, 0, 0, 3]),
+      prevForkName: ForkName.capella,
+    },
+    verge: {
+      name: ForkName.verge,
+      seq: ForkSeq.verge,
+      epoch: verge,
       version: Buffer.from([0, 0, 0, 4]),
       prevVersion: Buffer.from([0, 0, 0, 3]),
       prevForkName: ForkName.capella,
@@ -134,9 +144,10 @@ for (const testScenario of testScenarios) {
   const {phase0, altair, bellatrix, capella, testCases} = testScenario;
   // TODO DENEB: Is it necessary to test?
   const deneb = Infinity;
+  const verge = Infinity;
 
   describe(`network / fork: phase0: ${phase0}, altair: ${altair}, bellatrix: ${bellatrix} capella: ${capella}`, () => {
-    const forkConfig = getForkConfig({phase0, altair, bellatrix, capella, deneb});
+    const forkConfig = getForkConfig({phase0, altair, bellatrix, capella, deneb, verge});
     const forks = forkConfig.forks;
     for (const testCase of testCases) {
       const {epoch, currentFork, nextFork, activeForks} = testCase;

--- a/packages/beacon-node/test/utils/config.ts
+++ b/packages/beacon-node/test/utils/config.ts
@@ -31,5 +31,13 @@ export function getConfig(fork: ForkName, forkEpoch = 0): IChainForkConfig {
         CAPELLA_FORK_EPOCH: 0,
         EIP4844_FORK_EPOCH: forkEpoch,
       });
+    case ForkName.verge:
+      return createIChainForkConfig({
+        ALTAIR_FORK_EPOCH: 0,
+        BELLATRIX_FORK_EPOCH: 0,
+        CAPELLA_FORK_EPOCH: 0,
+        EIP4844_FORK_EPOCH: 0,
+        VERGE_FORK_EPOCH: forkEpoch,
+      });
   }
 }

--- a/packages/config/src/chainConfig/presets/mainnet.ts
+++ b/packages/config/src/chainConfig/presets/mainnet.ts
@@ -45,6 +45,10 @@ export const chainConfig: IChainConfig = {
   EIP4844_FORK_VERSION: b("0x04000000"),
   EIP4844_FORK_EPOCH: Infinity,
 
+  // VERGE
+  VERGE_FORK_VERSION: b("0x05000000"),
+  VERGE_FORK_EPOCH: Infinity,
+
   // Time parameters
   // ---------------------------------------------------------------
   // 12 seconds

--- a/packages/config/src/chainConfig/presets/minimal.ts
+++ b/packages/config/src/chainConfig/presets/minimal.ts
@@ -42,6 +42,9 @@ export const chainConfig: IChainConfig = {
   // Deneb
   EIP4844_FORK_VERSION: b("0x04000001"),
   EIP4844_FORK_EPOCH: Infinity,
+  // Verge
+  VERGE_FORK_VERSION: b("0x05000001"),
+  VERGE_FORK_EPOCH: Infinity,
 
   // Time parameters
   // ---------------------------------------------------------------

--- a/packages/config/src/chainConfig/types.ts
+++ b/packages/config/src/chainConfig/types.ts
@@ -40,6 +40,9 @@ export type IChainConfig = {
   // DENEB
   EIP4844_FORK_VERSION: Uint8Array;
   EIP4844_FORK_EPOCH: number;
+  // VERGE
+  VERGE_FORK_VERSION: Uint8Array;
+  VERGE_FORK_EPOCH: number;
 
   // Time parameters
   SECONDS_PER_SLOT: number;
@@ -98,6 +101,9 @@ export const chainConfigTypes: SpecTypes<IChainConfig> = {
   // DENEB
   EIP4844_FORK_VERSION: "bytes",
   EIP4844_FORK_EPOCH: "number",
+  // VERGE
+  VERGE_FORK_VERSION: "bytes",
+  VERGE_FORK_EPOCH: "number",
 
   // Time parameters
   SECONDS_PER_SLOT: "number",

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -55,10 +55,18 @@ export function createIForkConfig(config: IChainConfig): IForkConfig {
     prevVersion: config.CAPELLA_FORK_VERSION,
     prevForkName: ForkName.capella,
   };
+  const verge: IForkInfo = {
+    name: ForkName.verge,
+    seq: ForkSeq.verge,
+    epoch: config.VERGE_FORK_EPOCH,
+    version: config.VERGE_FORK_VERSION,
+    prevVersion: config.EIP4844_FORK_VERSION,
+    prevForkName: ForkName.deneb,
+  };
 
   /** Forks in order order of occurence, `phase0` first */
   // Note: Downstream code relies on proper ordering.
-  const forks = {phase0, altair, bellatrix, capella, deneb};
+  const forks = {phase0, altair, bellatrix, capella, deneb, verge};
 
   // Prevents allocating an array on every getForkInfo() call
   const forksAscendingEpochOrder = Object.values(forks);

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -7,6 +7,7 @@ export enum ForkName {
   bellatrix = "bellatrix",
   capella = "capella",
   deneb = "deneb",
+  verge = "verge",
 }
 
 /**
@@ -18,6 +19,7 @@ export enum ForkSeq {
   bellatrix = 2,
   capella = 3,
   deneb = 4,
+  verge = 5,
 }
 
 export type ForkLightClient = Exclude<ForkName, ForkName.phase0>;

--- a/packages/params/src/index.ts
+++ b/packages/params/src/index.ts
@@ -236,3 +236,10 @@ export const INTERVALS_PER_SLOT = 3;
 export const BYTES_PER_FIELD_ELEMENT = 32;
 export const BLOB_TX_TYPE = 0x05;
 export const VERSIONED_HASH_VERSION_KZG = 0x01;
+
+// TODO: Verge spec notes these as preset but there's only one value
+// https://github.com/ethereum/consensus-specs/blob/db74090c1e8dc1fb2c052bae268e22dc63061e32/specs/verge/beacon-chain.md#preset
+export const MAX_STEMS = 2 ** 16;
+export const MAX_COMMITMENTS_PER_STEM = 33;
+export const VERKLE_WIDTH = 256;
+export const IPA_PROOF_DEPTH = 8;

--- a/packages/state-transition/src/block/processExecutionPayload.ts
+++ b/packages/state-transition/src/block/processExecutionPayload.ts
@@ -1,4 +1,4 @@
-import {ssz, allForks, capella, deneb} from "@lodestar/types";
+import {ssz, allForks, capella, deneb, verge} from "@lodestar/types";
 import {toHexString, byteArrayEquals} from "@chainsafe/ssz";
 import {ForkSeq} from "@lodestar/params";
 import {CachedBeaconStateBellatrix, CachedBeaconStateCapella} from "../types.js";
@@ -104,6 +104,11 @@ export function executionPayloadToPayloadHeader(
     (bellatrixPayloadFields as deneb.ExecutionPayloadHeader).excessDataGas = (payload as
       | deneb.ExecutionPayloadHeader
       | deneb.ExecutionPayload).excessDataGas;
+  }
+
+  if (fork >= ForkSeq.verge) {
+    // https://github.com/ethereum/consensus-specs/blob/db74090c1e8dc1fb2c052bae268e22dc63061e32/specs/verge/beacon-chain.md#process_execution_payload
+    (bellatrixPayloadFields as verge.ExecutionPayloadHeader).executionWitness = (payload as verge.ExecutionPayload).executionWitness;
   }
 
   return bellatrixPayloadFields;

--- a/packages/state-transition/src/cache/stateCache.ts
+++ b/packages/state-transition/src/cache/stateCache.ts
@@ -8,6 +8,7 @@ import {
   BeaconStateBellatrix,
   BeaconStateCapella,
   BeaconStateDeneb,
+  BeaconStateVerge,
 } from "./types.js";
 
 export type BeaconStateCache = {
@@ -118,6 +119,7 @@ export type CachedBeaconStateAltair = CachedBeaconState<BeaconStateAltair>;
 export type CachedBeaconStateBellatrix = CachedBeaconState<BeaconStateBellatrix>;
 export type CachedBeaconStateCapella = CachedBeaconState<BeaconStateCapella>;
 export type CachedBeaconStateDeneb = CachedBeaconState<BeaconStateDeneb>;
+export type CachedBeaconStateVerge = CachedBeaconState<BeaconStateVerge>;
 
 export type CachedBeaconStateAllForks = CachedBeaconState<BeaconStateAllForks>;
 export type CachedBeaconStateExecutions = CachedBeaconState<BeaconStateExecutions>;

--- a/packages/state-transition/src/cache/types.ts
+++ b/packages/state-transition/src/cache/types.ts
@@ -6,6 +6,7 @@ export type BeaconStateAltair = CompositeViewDU<typeof ssz.altair.BeaconState>;
 export type BeaconStateBellatrix = CompositeViewDU<typeof ssz.bellatrix.BeaconState>;
 export type BeaconStateCapella = CompositeViewDU<typeof ssz.capella.BeaconState>;
 export type BeaconStateDeneb = CompositeViewDU<typeof ssz.deneb.BeaconState>;
+export type BeaconStateVerge = CompositeViewDU<typeof ssz.verge.BeaconState>;
 
 // Union at the TreeViewDU level
 // - Works well as function argument and as generic type for allForks functions
@@ -17,6 +18,7 @@ export type BeaconStateAllForks =
   | BeaconStateAltair
   | BeaconStateBellatrix
   | BeaconStateCapella
-  | BeaconStateDeneb;
+  | BeaconStateDeneb
+  | BeaconStateVerge;
 
-export type BeaconStateExecutions = BeaconStateBellatrix | BeaconStateCapella | BeaconStateDeneb;
+export type BeaconStateExecutions = BeaconStateBellatrix | BeaconStateCapella | BeaconStateDeneb | BeaconStateVerge;

--- a/packages/state-transition/src/slot/index.ts
+++ b/packages/state-transition/src/slot/index.ts
@@ -7,6 +7,7 @@ export {upgradeStateToAltair} from "./upgradeStateToAltair.js";
 export {upgradeStateToBellatrix} from "./upgradeStateToBellatrix.js";
 export {upgradeStateToCapella} from "./upgradeStateToCapella.js";
 export {upgradeStateToDeneb} from "./upgradeStateToDeneb.js";
+export {upgradeStateToVerge} from "./upgradeStateToVerge.js";
 
 /**
  * Dial state to next slot. Common for all forks

--- a/packages/state-transition/src/slot/upgradeStateToVerge.ts
+++ b/packages/state-transition/src/slot/upgradeStateToVerge.ts
@@ -1,0 +1,28 @@
+import {ssz} from "@lodestar/types";
+import {CachedBeaconStateDeneb, CachedBeaconStateVerge} from "../types.js";
+import {getCachedBeaconState} from "../cache/stateCache.js";
+
+/**
+ * Upgrade a state from Deneb to Verge.
+ */
+export function upgradeStateToVerge(stateDeneb: CachedBeaconStateDeneb): CachedBeaconStateVerge {
+  const {config} = stateDeneb;
+
+  const stateDenebNode = ssz.deneb.BeaconState.commitViewDU(stateDeneb);
+  const stateVergeView = ssz.verge.BeaconState.getViewDU(stateDenebNode);
+
+  const stateVerge = getCachedBeaconState(stateVergeView, stateDeneb);
+
+  stateVerge.fork = ssz.phase0.Fork.toViewDU({
+    previousVersion: stateDeneb.fork.currentVersion,
+    currentVersion: config.EIP4844_FORK_VERSION,
+    epoch: stateDeneb.epochCtx.epoch,
+  });
+
+  // Initialize ExecutionWitness empty List
+  stateVerge.latestExecutionPayloadHeader.executionWitness = ssz.verge.ExecutionWitness.defaultViewDU();
+
+  stateVerge.commit();
+
+  return stateVerge;
+}

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -9,6 +9,7 @@ import {
   CachedBeaconStateAltair,
   CachedBeaconStateBellatrix,
   CachedBeaconStateCapella,
+  CachedBeaconStateDeneb,
 } from "./types.js";
 import {computeEpochAtSlot} from "./util/index.js";
 import {verifyProposerSignature} from "./signatureSets/index.js";
@@ -23,6 +24,7 @@ import {processBlock} from "./block/index.js";
 import {processEpoch} from "./epoch/index.js";
 import {BlockExternalData, DataAvailableStatus, ExecutionPayloadStatus} from "./block/externalData.js";
 import {ProcessBlockOpts} from "./block/types.js";
+import {upgradeStateToVerge} from "./slot/upgradeStateToVerge.js";
 
 // Multifork capable state transition
 
@@ -178,6 +180,9 @@ function processSlotsWithTransientCache(
       }
       if (stateSlot === config.EIP4844_FORK_EPOCH) {
         postState = upgradeStateToDeneb(postState as CachedBeaconStateCapella) as CachedBeaconStateAllForks;
+      }
+      if (stateSlot === config.VERGE_FORK_EPOCH) {
+        postState = upgradeStateToVerge(postState as CachedBeaconStateDeneb) as CachedBeaconStateAllForks;
       }
     } else {
       postState.slot++;

--- a/packages/state-transition/src/types.ts
+++ b/packages/state-transition/src/types.ts
@@ -9,6 +9,7 @@ export {
   CachedBeaconStateBellatrix,
   CachedBeaconStateCapella,
   CachedBeaconStateDeneb,
+  CachedBeaconStateVerge,
 } from "./cache/stateCache.js";
 
 export {
@@ -19,4 +20,5 @@ export {
   BeaconStateBellatrix,
   BeaconStateCapella,
   BeaconStateDeneb,
+  BeaconStateVerge,
 } from "./cache/types.js";

--- a/packages/state-transition/src/util/genesis.ts
+++ b/packages/state-transition/src/util/genesis.ts
@@ -218,6 +218,7 @@ export function initializeBeaconStateFromEth1(
     | typeof ssz.bellatrix.ExecutionPayloadHeader
     | typeof ssz.capella.ExecutionPayloadHeader
     | typeof ssz.deneb.ExecutionPayloadHeader
+    | typeof ssz.verge.ExecutionPayloadHeader
   >
 ): CachedBeaconStateAllForks {
   const stateView = getGenesisBeaconState(

--- a/packages/types/src/allForks/sszTypes.ts
+++ b/packages/types/src/allForks/sszTypes.ts
@@ -3,6 +3,7 @@ import {ssz as altair} from "../altair/index.js";
 import {ssz as bellatrix} from "../bellatrix/index.js";
 import {ssz as capella} from "../capella/index.js";
 import {ssz as deneb} from "../deneb/index.js";
+import {ssz as verge} from "../verge/index.js";
 
 /**
  * Index the ssz types that differ by fork
@@ -44,6 +45,13 @@ export const allForks = {
     BeaconState: deneb.BeaconState,
     Metadata: altair.Metadata,
   },
+  verge: {
+    BeaconBlockBody: verge.BeaconBlockBody,
+    BeaconBlock: verge.BeaconBlock,
+    SignedBeaconBlock: verge.SignedBeaconBlock,
+    BeaconState: verge.BeaconState,
+    Metadata: altair.Metadata,
+  },
 };
 
 /**
@@ -82,6 +90,16 @@ export const allForksExecution = {
     BuilderBid: deneb.BuilderBid,
     SignedBuilderBid: deneb.SignedBuilderBid,
   },
+  verge: {
+    BeaconBlockBody: verge.BeaconBlockBody,
+    BeaconBlock: verge.BeaconBlock,
+    SignedBeaconBlock: verge.SignedBeaconBlock,
+    BeaconState: verge.BeaconState,
+    ExecutionPayload: verge.ExecutionPayload,
+    ExecutionPayloadHeader: verge.ExecutionPayloadHeader,
+    BuilderBid: deneb.BuilderBid,
+    SignedBuilderBid: deneb.SignedBuilderBid,
+  },
 };
 
 /**
@@ -103,6 +121,11 @@ export const allForksBlinded = {
     BeaconBlockBody: deneb.BlindedBeaconBlockBody,
     BeaconBlock: deneb.BlindedBeaconBlock,
     SignedBeaconBlock: deneb.SignedBlindedBeaconBlock,
+  },
+  verge: {
+    BeaconBlockBody: verge.BlindedBeaconBlockBody,
+    BeaconBlock: verge.BlindedBeaconBlock,
+    SignedBeaconBlock: verge.SignedBlindedBeaconBlock,
   },
 };
 
@@ -147,10 +170,23 @@ export const allForksLightClient = {
     LightClientOptimisticUpdate: deneb.LightClientOptimisticUpdate,
     LightClientStore: deneb.LightClientStore,
   },
+  verge: {
+    BeaconBlock: verge.BeaconBlock,
+    BeaconBlockBody: verge.BeaconBlockBody,
+    LightClientHeader: deneb.LightClientHeader,
+    LightClientBootstrap: deneb.LightClientBootstrap,
+    LightClientUpdate: deneb.LightClientUpdate,
+    LightClientFinalityUpdate: deneb.LightClientFinalityUpdate,
+    LightClientOptimisticUpdate: deneb.LightClientOptimisticUpdate,
+    LightClientStore: deneb.LightClientStore,
+  },
 };
 
 export const allForksBlobs = {
   deneb: {
+    SignedBeaconBlockAndBlobsSidecar: deneb.SignedBeaconBlockAndBlobsSidecar,
+  },
+  verge: {
     SignedBeaconBlockAndBlobsSidecar: deneb.SignedBeaconBlockAndBlobsSidecar,
   },
 };

--- a/packages/types/src/allForks/types.ts
+++ b/packages/types/src/allForks/types.ts
@@ -4,12 +4,14 @@ import {ts as altair} from "../altair/index.js";
 import {ts as bellatrix} from "../bellatrix/index.js";
 import {ts as capella} from "../capella/index.js";
 import {ts as deneb} from "../deneb/index.js";
+import {ts as verge} from "../verge/index.js";
 
 import {ssz as phase0Ssz} from "../phase0/index.js";
 import {ssz as altairSsz} from "../altair/index.js";
 import {ssz as bellatrixSsz} from "../bellatrix/index.js";
 import {ssz as capellaSsz} from "../capella/index.js";
 import {ssz as denebSsz} from "../deneb/index.js";
+import {ssz as vergeSsz} from "../verge/index.js";
 
 // Re-export union types for types that are _known_ to differ
 
@@ -18,47 +20,66 @@ export type BeaconBlockBody =
   | altair.BeaconBlockBody
   | bellatrix.BeaconBlockBody
   | capella.BeaconBlockBody
-  | deneb.BeaconBlockBody;
+  | deneb.BeaconBlockBody
+  | verge.BeaconBlockBody;
 export type BeaconBlock =
   | phase0.BeaconBlock
   | altair.BeaconBlock
   | bellatrix.BeaconBlock
   | capella.BeaconBlock
-  | deneb.BeaconBlock;
+  | deneb.BeaconBlock
+  | verge.BeaconBlock;
 export type SignedBeaconBlock =
   | phase0.SignedBeaconBlock
   | altair.SignedBeaconBlock
   | bellatrix.SignedBeaconBlock
   | capella.SignedBeaconBlock
-  | deneb.SignedBeaconBlock;
+  | deneb.SignedBeaconBlock
+  | verge.SignedBeaconBlock;
 export type BeaconState =
   | phase0.BeaconState
   | altair.BeaconState
   | bellatrix.BeaconState
   | capella.BeaconState
-  | deneb.BeaconState;
+  | deneb.BeaconState
+  | verge.BeaconState;
 export type Metadata = phase0.Metadata | altair.Metadata;
 
 // For easy reference in the assemble block for building payloads
-export type ExecutionBlockBody = bellatrix.BeaconBlockBody | capella.BeaconBlockBody | deneb.BeaconBlockBody;
+export type ExecutionBlockBody =
+  | bellatrix.BeaconBlockBody
+  | capella.BeaconBlockBody
+  | deneb.BeaconBlockBody
+  | verge.BeaconBlockBody;
 
 // These two additional types will also change bellatrix forward
-export type ExecutionPayload = bellatrix.ExecutionPayload | capella.ExecutionPayload | deneb.ExecutionPayload;
+export type ExecutionPayload =
+  | bellatrix.ExecutionPayload
+  | capella.ExecutionPayload
+  | deneb.ExecutionPayload
+  | verge.ExecutionPayload;
 export type ExecutionPayloadHeader =
   | bellatrix.ExecutionPayloadHeader
   | capella.ExecutionPayloadHeader
-  | deneb.ExecutionPayloadHeader;
+  | deneb.ExecutionPayloadHeader
+  | verge.ExecutionPayloadHeader;
 
 // Blinded types that will change across forks
 export type BlindedBeaconBlockBody =
   | bellatrix.BlindedBeaconBlockBody
   | capella.BlindedBeaconBlockBody
-  | deneb.BlindedBeaconBlockBody;
-export type BlindedBeaconBlock = bellatrix.BlindedBeaconBlock | capella.BlindedBeaconBlock | deneb.BlindedBeaconBlock;
+  | deneb.BlindedBeaconBlockBody
+  | verge.BlindedBeaconBlockBody;
+export type BlindedBeaconBlock =
+  | bellatrix.BlindedBeaconBlock
+  | capella.BlindedBeaconBlock
+  | deneb.BlindedBeaconBlock
+  | verge.BlindedBeaconBlock;
 export type SignedBlindedBeaconBlock =
   | bellatrix.SignedBlindedBeaconBlock
   | capella.SignedBlindedBeaconBlock
-  | deneb.SignedBlindedBeaconBlock;
+  | deneb.SignedBlindedBeaconBlock
+  | verge.SignedBlindedBeaconBlock;
 
 // Full or blinded types
 export type FullOrBlindedExecutionPayload =
@@ -162,6 +183,7 @@ export type AllForksSSZTypes = {
     | typeof bellatrixSsz.BeaconBlockBody
     | typeof capellaSsz.BeaconBlockBody
     | typeof denebSsz.BeaconBlockBody
+    | typeof vergeSsz.BeaconBlockBody
   >;
   BeaconBlock: AllForksTypeOf<
     | typeof phase0Ssz.BeaconBlock
@@ -169,6 +191,7 @@ export type AllForksSSZTypes = {
     | typeof bellatrixSsz.BeaconBlock
     | typeof capellaSsz.BeaconBlock
     | typeof denebSsz.BeaconBlock
+    | typeof vergeSsz.BeaconBlock
   >;
   SignedBeaconBlock: AllForksTypeOf<
     | typeof phase0Ssz.SignedBeaconBlock
@@ -176,6 +199,7 @@ export type AllForksSSZTypes = {
     | typeof bellatrixSsz.SignedBeaconBlock
     | typeof capellaSsz.SignedBeaconBlock
     | typeof denebSsz.SignedBeaconBlock
+    | typeof vergeSsz.SignedBeaconBlock
   >;
   BeaconState: AllForksTypeOf<
     | typeof phase0Ssz.BeaconState
@@ -183,30 +207,47 @@ export type AllForksSSZTypes = {
     | typeof bellatrixSsz.BeaconState
     | typeof capellaSsz.BeaconState
     | typeof denebSsz.BeaconState
+    | typeof vergeSsz.BeaconState
   >;
   Metadata: AllForksTypeOf<typeof phase0Ssz.Metadata | typeof altairSsz.Metadata>;
 };
 
 export type AllForksExecutionSSZTypes = {
   BeaconBlockBody: AllForksTypeOf<
-    typeof bellatrixSsz.BeaconBlockBody | typeof capellaSsz.BeaconBlockBody | typeof denebSsz.BeaconBlockBody
+    | typeof bellatrixSsz.BeaconBlockBody
+    | typeof capellaSsz.BeaconBlockBody
+    | typeof denebSsz.BeaconBlockBody
+    | typeof vergeSsz.BeaconBlockBody
   >;
   BeaconBlock: AllForksTypeOf<
-    typeof bellatrixSsz.BeaconBlock | typeof capellaSsz.BeaconBlock | typeof denebSsz.BeaconBlock
+    | typeof bellatrixSsz.BeaconBlock
+    | typeof capellaSsz.BeaconBlock
+    | typeof denebSsz.BeaconBlock
+    | typeof vergeSsz.BeaconBlock
   >;
   SignedBeaconBlock: AllForksTypeOf<
-    typeof bellatrixSsz.SignedBeaconBlock | typeof capellaSsz.SignedBeaconBlock | typeof denebSsz.SignedBeaconBlock
+    | typeof bellatrixSsz.SignedBeaconBlock
+    | typeof capellaSsz.SignedBeaconBlock
+    | typeof denebSsz.SignedBeaconBlock
+    | typeof vergeSsz.SignedBeaconBlock
   >;
   BeaconState: AllForksTypeOf<
-    typeof bellatrixSsz.BeaconState | typeof capellaSsz.BeaconState | typeof denebSsz.BeaconState
+    | typeof bellatrixSsz.BeaconState
+    | typeof capellaSsz.BeaconState
+    | typeof denebSsz.BeaconState
+    | typeof vergeSsz.BeaconState
   >;
   ExecutionPayload: AllForksTypeOf<
-    typeof bellatrixSsz.ExecutionPayload | typeof capellaSsz.ExecutionPayload | typeof denebSsz.ExecutionPayload
+    | typeof bellatrixSsz.ExecutionPayload
+    | typeof capellaSsz.ExecutionPayload
+    | typeof denebSsz.ExecutionPayload
+    | typeof vergeSsz.ExecutionPayload
   >;
   ExecutionPayloadHeader: AllForksTypeOf<
     | typeof bellatrixSsz.ExecutionPayloadHeader
     | typeof capellaSsz.ExecutionPayloadHeader
     | typeof denebSsz.ExecutionPayloadHeader
+    | typeof vergeSsz.ExecutionPayloadHeader
   >;
   BuilderBid: AllForksTypeOf<
     typeof bellatrixSsz.BuilderBid | typeof capellaSsz.BuilderBid | typeof denebSsz.BuilderBid
@@ -221,14 +262,19 @@ export type AllForksBlindedSSZTypes = {
     | typeof bellatrixSsz.BlindedBeaconBlockBody
     | typeof capellaSsz.BlindedBeaconBlock
     | typeof denebSsz.BlindedBeaconBlock
+    | typeof vergeSsz.BlindedBeaconBlock
   >;
   BeaconBlock: AllForksTypeOf<
-    typeof bellatrixSsz.BlindedBeaconBlock | typeof capellaSsz.BlindedBeaconBlock | typeof denebSsz.BlindedBeaconBlock
+    | typeof bellatrixSsz.BlindedBeaconBlock
+    | typeof capellaSsz.BlindedBeaconBlock
+    | typeof denebSsz.BlindedBeaconBlock
+    | typeof vergeSsz.BlindedBeaconBlock
   >;
   SignedBeaconBlock: AllForksTypeOf<
     | typeof bellatrixSsz.SignedBlindedBeaconBlock
     | typeof capellaSsz.SignedBlindedBeaconBlock
     | typeof denebSsz.SignedBlindedBeaconBlock
+    | typeof vergeSsz.SignedBlindedBeaconBlock
   >;
 };
 
@@ -238,12 +284,14 @@ export type AllForksLightClientSSZTypes = {
     | typeof bellatrixSsz.BeaconBlock
     | typeof capellaSsz.BeaconBlock
     | typeof denebSsz.BeaconBlock
+    | typeof vergeSsz.BeaconBlock
   >;
   BeaconBlockBody: AllForksTypeOf<
     | typeof altairSsz.BeaconBlockBody
     | typeof bellatrixSsz.BeaconBlockBody
     | typeof capellaSsz.BeaconBlockBody
     | typeof denebSsz.BeaconBlockBody
+    | typeof vergeSsz.BeaconBlockBody
   >;
   LightClientHeader: AllForksTypeOf<
     typeof altairSsz.LightClientHeader | typeof capellaSsz.LightClientHeader | typeof denebSsz.LightClientHeader

--- a/packages/types/src/sszTypes.ts
+++ b/packages/types/src/sszTypes.ts
@@ -4,6 +4,7 @@ export {ssz as altair} from "./altair/index.js";
 export {ssz as bellatrix} from "./bellatrix/index.js";
 export {ssz as capella} from "./capella/index.js";
 export {ssz as deneb} from "./deneb/index.js";
+export {ssz as verge} from "./verge/index.js";
 
 import {ssz as allForksSsz} from "./allForks/index.js";
 export const allForks = allForksSsz.allForks;

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -4,6 +4,7 @@ export {ts as altair} from "./altair/index.js";
 export {ts as bellatrix} from "./bellatrix/index.js";
 export {ts as capella} from "./capella/index.js";
 export {ts as deneb} from "./deneb/index.js";
+export {ts as verge} from "./verge/index.js";
 
 export {ts as allForks} from "./allForks/index.js";
 

--- a/packages/types/src/verge/index.ts
+++ b/packages/types/src/verge/index.ts
@@ -1,0 +1,3 @@
+export * from "./types.js";
+export * as ts from "./types.js";
+export * as ssz from "./sszTypes.js";

--- a/packages/types/src/verge/sszTypes.ts
+++ b/packages/types/src/verge/sszTypes.ts
@@ -1,0 +1,205 @@
+import {
+  ContainerType,
+  ListCompositeType,
+  ByteVectorType,
+  VectorCompositeType,
+  ListBasicType,
+  UnionType,
+  NoneType,
+} from "@chainsafe/ssz";
+import {
+  HISTORICAL_ROOTS_LIMIT,
+  VERKLE_WIDTH,
+  MAX_STEMS,
+  IPA_PROOF_DEPTH,
+  MAX_COMMITMENTS_PER_STEM,
+} from "@lodestar/params";
+import {ssz as primitiveSsz} from "../primitive/index.js";
+import {ssz as phase0Ssz} from "../phase0/index.js";
+import {ssz as altairSsz} from "../altair/index.js";
+import {ssz as capellaSsz} from "../capella/index.js";
+import {ssz as denebSsz} from "../deneb/index.js";
+
+const {UintNum64, Root, BLSSignature} = primitiveSsz;
+
+// Spec: https://github.com/ethereum/consensus-specs/blob/db74090c1e8dc1fb2c052bae268e22dc63061e32/specs/verge/beacon-chain.md
+
+// Custom types
+
+export const Bytes31 = new ByteVectorType(31);
+export const BanderwagonGroupElement = new ByteVectorType(32);
+export const BanderwagonFieldElement = new ByteVectorType(32);
+export const Stem = new ByteVectorType(31);
+
+// Beacon chain
+
+export const SuffixStateDiff = new ContainerType(
+  {
+    suffix: primitiveSsz.Byte,
+    // Null means not currently present
+    // TODO: Use new SSZ type Optional: https://github.com/ethereum/consensus-specs/commit/db74090c1e8dc1fb2c052bae268e22dc63061e32
+    currentValue: new UnionType([new NoneType(), primitiveSsz.Bytes32]),
+    // Null means value not updated
+    newValue: new UnionType([new NoneType(), primitiveSsz.Bytes32]),
+  },
+  {typeName: "SuffixStateDiff", jsonCase: "eth2"}
+);
+
+export const StemStateDiff = new ContainerType(
+  {
+    stem: Stem,
+    // Valid only if list is sorted by suffixes
+    suffixDiffs: new ListCompositeType(SuffixStateDiff, VERKLE_WIDTH),
+  },
+  {typeName: "StemStateDiff", jsonCase: "eth2"}
+);
+
+// Valid only if list is sorted by stems
+export const StateDiff = new ListCompositeType(StemStateDiff, MAX_STEMS);
+
+export const IpaProof = new ContainerType(
+  {
+    C_L: new VectorCompositeType(BanderwagonGroupElement, IPA_PROOF_DEPTH),
+    C_R: new VectorCompositeType(BanderwagonGroupElement, IPA_PROOF_DEPTH),
+    finalEvaluation: BanderwagonFieldElement,
+  },
+  {typeName: "IpaProof", jsonCase: "eth2"}
+);
+
+export const VerkleProof = new ContainerType(
+  {
+    other_stems: new ListCompositeType(Bytes31, MAX_STEMS),
+    depth_extension_present: new ListBasicType(primitiveSsz.Uint8, MAX_STEMS),
+    commitments_by_path: new ListCompositeType(BanderwagonGroupElement, MAX_STEMS * MAX_COMMITMENTS_PER_STEM),
+    D: BanderwagonGroupElement,
+    ipaProof: IpaProof,
+  },
+  {typeName: "VerkleProof", jsonCase: "eth2"}
+);
+
+export const ExecutionWitness = new ContainerType(
+  {
+    state_diff: StateDiff,
+    verkle_proof: VerkleProof,
+  },
+  {typeName: "ExecutionWitness", jsonCase: "eth2"}
+);
+
+// Beacon Chain types
+// https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/beacon-chain.md#containers
+
+export const ExecutionPayload = new ContainerType(
+  {
+    ...denebSsz.ExecutionPayload.fields,
+    executionWitness: ExecutionWitness, // New in verge
+  },
+  {typeName: "ExecutionPayload", jsonCase: "eth2"}
+);
+
+export const ExecutionPayloadHeader = new ContainerType(
+  {
+    ...denebSsz.ExecutionPayloadHeader.fields,
+    executionWitness: ExecutionWitness, // New in verge
+  },
+  {typeName: "ExecutionPayloadHeader", jsonCase: "eth2"}
+);
+
+// We have to preserve Fields ordering while changing the type of ExecutionPayload
+export const BeaconBlockBody = new ContainerType(
+  {
+    ...altairSsz.BeaconBlockBody.fields,
+    executionPayload: ExecutionPayload, // Modified in verge
+    blsToExecutionChanges: capellaSsz.BeaconBlockBody.fields.blsToExecutionChanges,
+    blobKzgCommitments: denebSsz.BlobKzgCommitments,
+  },
+  {typeName: "BeaconBlockBody", jsonCase: "eth2", cachePermanentRootStruct: true}
+);
+
+export const BeaconBlock = new ContainerType(
+  {
+    ...denebSsz.BeaconBlock.fields,
+    body: BeaconBlockBody, // Modified in verge
+  },
+  {typeName: "BeaconBlock", jsonCase: "eth2", cachePermanentRootStruct: true}
+);
+
+export const SignedBeaconBlock = new ContainerType(
+  {
+    message: BeaconBlock, // Modified in verge
+    signature: BLSSignature,
+  },
+  {typeName: "SignedBeaconBlock", jsonCase: "eth2"}
+);
+
+export const BlindedBeaconBlockBody = new ContainerType(
+  {
+    ...BeaconBlockBody.fields,
+    executionPayloadHeader: ExecutionPayloadHeader, // Modified in verge
+    blobKzgCommitments: denebSsz.BlobKzgCommitments,
+  },
+  {typeName: "BlindedBeaconBlockBody", jsonCase: "eth2", cachePermanentRootStruct: true}
+);
+
+export const BlindedBeaconBlock = new ContainerType(
+  {
+    ...denebSsz.BlindedBeaconBlock.fields,
+    body: BlindedBeaconBlockBody, // Modified in DENEB
+  },
+  {typeName: "BlindedBeaconBlock", jsonCase: "eth2", cachePermanentRootStruct: true}
+);
+
+export const SignedBlindedBeaconBlock = new ContainerType(
+  {
+    message: BlindedBeaconBlock, // Modified in DENEB
+    signature: BLSSignature,
+  },
+  {typeName: "SignedBlindedBeaconBlock", jsonCase: "eth2"}
+);
+
+// We don't spread capella.BeaconState fields since we need to replace
+// latestExecutionPayloadHeader and we cannot keep order doing that
+export const BeaconState = new ContainerType(
+  {
+    genesisTime: UintNum64,
+    genesisValidatorsRoot: Root,
+    slot: primitiveSsz.Slot,
+    fork: phase0Ssz.Fork,
+    // History
+    latestBlockHeader: phase0Ssz.BeaconBlockHeader,
+    blockRoots: phase0Ssz.HistoricalBlockRoots,
+    stateRoots: phase0Ssz.HistoricalStateRoots,
+    // historical_roots Frozen in Capella, replaced by historical_summaries
+    historicalRoots: new ListCompositeType(Root, HISTORICAL_ROOTS_LIMIT),
+    // Eth1
+    eth1Data: phase0Ssz.Eth1Data,
+    eth1DataVotes: phase0Ssz.Eth1DataVotes,
+    eth1DepositIndex: UintNum64,
+    // Registry
+    validators: phase0Ssz.Validators,
+    balances: phase0Ssz.Balances,
+    randaoMixes: phase0Ssz.RandaoMixes,
+    // Slashings
+    slashings: phase0Ssz.Slashings,
+    // Participation
+    previousEpochParticipation: altairSsz.EpochParticipation,
+    currentEpochParticipation: altairSsz.EpochParticipation,
+    // Finality
+    justificationBits: phase0Ssz.JustificationBits,
+    previousJustifiedCheckpoint: phase0Ssz.Checkpoint,
+    currentJustifiedCheckpoint: phase0Ssz.Checkpoint,
+    finalizedCheckpoint: phase0Ssz.Checkpoint,
+    // Inactivity
+    inactivityScores: altairSsz.InactivityScores,
+    // Sync
+    currentSyncCommittee: altairSsz.SyncCommittee,
+    nextSyncCommittee: altairSsz.SyncCommittee,
+    // Execution
+    latestExecutionPayloadHeader: ExecutionPayloadHeader, // Modified in verge
+    // Withdrawals
+    nextWithdrawalIndex: capellaSsz.BeaconState.fields.nextWithdrawalIndex,
+    nextWithdrawalValidatorIndex: capellaSsz.BeaconState.fields.nextWithdrawalValidatorIndex,
+    // Deep history valid from Capella onwards
+    historicalSummaries: capellaSsz.BeaconState.fields.historicalSummaries,
+  },
+  {typeName: "BeaconState", jsonCase: "eth2"}
+);

--- a/packages/types/src/verge/types.ts
+++ b/packages/types/src/verge/types.ts
@@ -1,0 +1,29 @@
+import {ValueOf} from "@chainsafe/ssz";
+import * as ssz from "./sszTypes.js";
+
+export type Bytes31 = ValueOf<typeof ssz.Bytes31>;
+export type BanderwagonGroupElement = ValueOf<typeof ssz.BanderwagonGroupElement>;
+export type BanderwagonFieldElement = ValueOf<typeof ssz.BanderwagonFieldElement>;
+export type Stem = ValueOf<typeof ssz.Stem>;
+
+export type SuffixStateDiff = ValueOf<typeof ssz.SuffixStateDiff>;
+export type StemStateDiff = ValueOf<typeof ssz.StemStateDiff>;
+export type StateDiff = ValueOf<typeof ssz.StateDiff>;
+export type IpaProof = ValueOf<typeof ssz.IpaProof>;
+export type VerkleProof = ValueOf<typeof ssz.VerkleProof>;
+export type ExecutionWitness = ValueOf<typeof ssz.ExecutionWitness>;
+
+export type ExecutionPayload = ValueOf<typeof ssz.ExecutionPayload>;
+export type ExecutionPayloadHeader = ValueOf<typeof ssz.ExecutionPayloadHeader>;
+
+export type BeaconBlockBody = ValueOf<typeof ssz.BeaconBlockBody>;
+export type BeaconBlock = ValueOf<typeof ssz.BeaconBlock>;
+export type SignedBeaconBlock = ValueOf<typeof ssz.SignedBeaconBlock>;
+
+export type BeaconState = ValueOf<typeof ssz.BeaconState>;
+
+export type BlindedBeaconBlockBody = ValueOf<typeof ssz.BlindedBeaconBlockBody>;
+export type BlindedBeaconBlock = ValueOf<typeof ssz.BlindedBeaconBlock>;
+export type SignedBlindedBeaconBlock = ValueOf<typeof ssz.SignedBlindedBeaconBlock>;
+
+export type FullOrBlindedExecutionPayload = ExecutionPayload | ExecutionPayloadHeader;

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -73,6 +73,7 @@ function getSpecCriticalParams(localConfig: IChainConfig): Record<keyof ConfigWi
   const bellatrixForkRelevant = localConfig.BELLATRIX_FORK_EPOCH < Infinity;
   const capellaForkRelevant = localConfig.CAPELLA_FORK_EPOCH < Infinity;
   const denebForkRelevant = localConfig.EIP4844_FORK_EPOCH < Infinity;
+  const vergeForkRelevant = localConfig.VERGE_FORK_EPOCH < Infinity;
 
   return {
     // # Config
@@ -105,6 +106,9 @@ function getSpecCriticalParams(localConfig: IChainConfig): Record<keyof ConfigWi
     // Deneb
     EIP4844_FORK_VERSION: denebForkRelevant,
     EIP4844_FORK_EPOCH: denebForkRelevant,
+    // Verge
+    VERGE_FORK_VERSION: vergeForkRelevant,
+    VERGE_FORK_EPOCH: vergeForkRelevant,
 
     // Time parameters
     SECONDS_PER_SLOT: true,


### PR DESCRIPTION
**Motivation**

- Develop "verge" spec feature on top of Deneb. https://github.com/ChainSafe/lodestar/issues/4681
- Spec: https://github.com/ethereum/consensus-specs/pull/3230

@gballet current spec is based on capella. Are there plans to rebase it on deneb?

**Description**

This fork currently only updates the execution payload type. There's no additional logic required in consensus side.

Closes https://github.com/ChainSafe/lodestar/issues/4681
