### PR TITLE
Increase chance of ssz cache populated

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -298,7 +298,12 @@ export function getValidatorApi({
         attEpoch <= headEpoch
           ? headState
           : // Will advance the state to the correct next epoch if necessary
-            await chain.regen.getBlockSlotState(headBlockRootHex, slot, RegenCaller.produceAttestationData);
+            await chain.regen.getBlockSlotState(
+              headBlockRootHex,
+              slot,
+              {dontTransferCache: true},
+              RegenCaller.produceAttestationData
+            );
 
       return {
         data: {

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -5,6 +5,7 @@ import {
   CachedBeaconStateAltair,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
+  isStateValidatorsNodesPopulated,
   RootCache,
 } from "@lodestar/state-transition";
 import {routes} from "@lodestar/api";
@@ -328,6 +329,10 @@ export async function importBlock(
   //
   // This adds the state necessary to process the next block
   this.stateCache.add(postState);
+
+  if (!isStateValidatorsNodesPopulated(postState)) {
+    this.logger.verbose("After importBlock caching postState without SSZ cache", {slot: postState.slot});
+  }
 
   if (block.message.slot % SLOTS_PER_EPOCH === 0) {
     // Cache state to preserve epoch transition work

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -1,4 +1,8 @@
-import {CachedBeaconStateAllForks, computeEpochAtSlot} from "@lodestar/state-transition";
+import {
+  CachedBeaconStateAllForks,
+  computeEpochAtSlot,
+  isStateValidatorsNodesPopulated,
+} from "@lodestar/state-transition";
 import {bellatrix} from "@lodestar/types";
 import {ForkName} from "@lodestar/params";
 import {toHexString} from "@chainsafe/ssz";
@@ -60,6 +64,15 @@ export async function verifyBlocksInEpoch(
     .catch((e) => {
       throw new BlockError(block0, {code: BlockErrorCode.PRESTATE_MISSING, error: e as Error});
     });
+
+  if (!isStateValidatorsNodesPopulated(preState0)) {
+    this.logger.verbose("verifyBlocksInEpoch preState0 SSZ cache stats", {
+      cache: isStateValidatorsNodesPopulated(preState0),
+      clonedCount: preState0.clonedCount,
+      clonedCountWithTransferCache: preState0.clonedCountWithTransferCache,
+      createdWithTransferCache: preState0.createdWithTransferCache,
+    });
+  }
 
   // Ensure the state is in the same epoch as block0
   if (block0Epoch !== computeEpochAtSlot(preState0.slot)) {

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -55,9 +55,11 @@ export async function verifyBlocksInEpoch(
 
   // TODO: Skip in process chain segment
   // Retrieve preState from cache (regen)
-  const preState0 = await this.regen.getPreState(block0.message, RegenCaller.processBlocksInEpoch).catch((e) => {
-    throw new BlockError(block0, {code: BlockErrorCode.PRESTATE_MISSING, error: e as Error});
-  });
+  const preState0 = await this.regen
+    .getPreState(block0.message, {dontTransferCache: false}, RegenCaller.processBlocksInEpoch)
+    .catch((e) => {
+      throw new BlockError(block0, {code: BlockErrorCode.PRESTATE_MISSING, error: e as Error});
+    });
 
   // Ensure the state is in the same epoch as block0
   if (block0Epoch !== computeEpochAtSlot(preState0.slot)) {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -338,7 +338,7 @@ export class BeaconChain implements IBeaconChain {
     const currentEpochStartSlot = computeStartSlotAtEpoch(this.clock.currentEpoch);
     const head = this.forkChoice.getHead();
     const bestSlot = currentEpochStartSlot > head.slot ? currentEpochStartSlot : head.slot;
-    return this.regen.getBlockSlotState(head.blockRoot, bestSlot, RegenCaller.getDuties);
+    return this.regen.getBlockSlotState(head.blockRoot, bestSlot, {dontTransferCache: true}, RegenCaller.getDuties);
   }
 
   async getCanonicalBlockAtSlot(slot: Slot): Promise<allForks.SignedBeaconBlock | null> {
@@ -368,7 +368,12 @@ export class BeaconChain implements IBeaconChain {
     {randaoReveal, graffiti, slot}: BlockAttributes
   ): Promise<{block: AssembledBlockType<T>; blockValue: Wei}> {
     const head = this.forkChoice.getHead();
-    const state = await this.regen.getBlockSlotState(head.blockRoot, slot, RegenCaller.produceBlock);
+    const state = await this.regen.getBlockSlotState(
+      head.blockRoot,
+      slot,
+      {dontTransferCache: true},
+      RegenCaller.produceBlock
+    );
     const parentBlockRoot = fromHexString(head.blockRoot);
     const proposerIndex = state.epochCtx.getBeaconProposer(slot);
     const proposerPubKey = state.epochCtx.index2pubkey[proposerIndex].toBytes();

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -95,7 +95,12 @@ export class PrepareNextSlotScheduler {
       // No need to wait for this or the clock drift
       // Pre Bellatrix: we only do precompute state transition for the last slot of epoch
       // For Bellatrix, we always do the `processSlots()` to prepare payload for the next slot
-      const prepareState = await this.chain.regen.getBlockSlotState(headRoot, prepareSlot, RegenCaller.precomputeEpoch);
+      const prepareState = await this.chain.regen.getBlockSlotState(
+        headRoot,
+        prepareSlot,
+        {dontTransferCache: true},
+        RegenCaller.precomputeEpoch
+      );
 
       // assuming there is no reorg, it caches the checkpoint state & helps avoid doing a full state transition in the next slot
       //  + when gossip block comes, we need to validate and run state transition

--- a/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
+++ b/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
@@ -38,6 +38,8 @@ export function computeNewStateRoot(
       verifyProposer: false,
       // verifySignatures: false | since the data to assemble the block is trusted
       verifySignatures: false,
+      // Preserve cache in source state, since the resulting state is not added to the state cache
+      dontTransferCache: true,
     },
     metrics
   );

--- a/packages/beacon-node/src/chain/regen/interface.ts
+++ b/packages/beacon-node/src/chain/regen/interface.ts
@@ -21,6 +21,10 @@ export enum RegenFnName {
   getCheckpointState = "getCheckpointState",
 }
 
+export type StateCloneOpts = {
+  dontTransferCache: boolean;
+};
+
 /**
  * Regenerates states that have already been processed by the fork choice
  */
@@ -29,18 +33,31 @@ export interface IStateRegenerator {
    * Return a valid pre-state for a beacon block
    * This will always return a state in the latest viable epoch
    */
-  getPreState(block: allForks.BeaconBlock, rCaller: RegenCaller): Promise<CachedBeaconStateAllForks>;
+  getPreState(
+    block: allForks.BeaconBlock,
+    opts: StateCloneOpts,
+    rCaller: RegenCaller
+  ): Promise<CachedBeaconStateAllForks>;
 
   /**
    * Return a valid checkpoint state
    * This will always return a state with `state.slot % SLOTS_PER_EPOCH === 0`
    */
-  getCheckpointState(cp: phase0.Checkpoint, rCaller: RegenCaller): Promise<CachedBeaconStateAllForks>;
+  getCheckpointState(
+    cp: phase0.Checkpoint,
+    opts: StateCloneOpts,
+    rCaller: RegenCaller
+  ): Promise<CachedBeaconStateAllForks>;
 
   /**
    * Return the state of `blockRoot` processed to slot `slot`
    */
-  getBlockSlotState(blockRoot: RootHex, slot: Slot, rCaller: RegenCaller): Promise<CachedBeaconStateAllForks>;
+  getBlockSlotState(
+    blockRoot: RootHex,
+    slot: Slot,
+    opts: StateCloneOpts,
+    rCaller: RegenCaller
+  ): Promise<CachedBeaconStateAllForks>;
 
   /**
    * Return the exact state with `stateRoot`

--- a/packages/beacon-node/src/chain/regen/queued.ts
+++ b/packages/beacon-node/src/chain/regen/queued.ts
@@ -5,7 +5,7 @@ import {toHexString} from "@chainsafe/ssz";
 import {CheckpointStateCache, StateContextCache, toCheckpointHex} from "../stateCache/index.js";
 import {Metrics} from "../../metrics/index.js";
 import {JobItemQueue} from "../../util/queue/index.js";
-import {IStateRegenerator, RegenCaller, RegenFnName} from "./interface.js";
+import {IStateRegenerator, RegenCaller, RegenFnName, StateCloneOpts} from "./interface.js";
 import {StateRegenerator, RegenModules} from "./regen.js";
 import {RegenError, RegenErrorCode} from "./errors.js";
 
@@ -50,7 +50,11 @@ export class QueuedStateRegenerator implements IStateRegenerator {
    * Get the state to run with `block`.
    * - State after `block.parentRoot` dialed forward to block.slot
    */
-  async getPreState(block: allForks.BeaconBlock, rCaller: RegenCaller): Promise<CachedBeaconStateAllForks> {
+  async getPreState(
+    block: allForks.BeaconBlock,
+    opts: StateCloneOpts,
+    rCaller: RegenCaller
+  ): Promise<CachedBeaconStateAllForks> {
     this.metrics?.regenFnCallTotal.inc({caller: rCaller, entrypoint: RegenFnName.getPreState});
 
     // First attempt to fetch the state from caches before queueing
@@ -93,10 +97,14 @@ export class QueuedStateRegenerator implements IStateRegenerator {
 
     // The state is not immediately available in the caches, enqueue the job
     this.metrics?.regenFnQueuedTotal.inc({caller: rCaller, entrypoint: RegenFnName.getPreState});
-    return this.jobQueue.push({key: "getPreState", args: [block, rCaller]});
+    return this.jobQueue.push({key: "getPreState", args: [block, opts, rCaller]});
   }
 
-  async getCheckpointState(cp: phase0.Checkpoint, rCaller: RegenCaller): Promise<CachedBeaconStateAllForks> {
+  async getCheckpointState(
+    cp: phase0.Checkpoint,
+    opts: StateCloneOpts,
+    rCaller: RegenCaller
+  ): Promise<CachedBeaconStateAllForks> {
     this.metrics?.regenFnCallTotal.inc({caller: rCaller, entrypoint: RegenFnName.getCheckpointState});
 
     // First attempt to fetch the state from cache before queueing
@@ -107,14 +115,19 @@ export class QueuedStateRegenerator implements IStateRegenerator {
 
     // The state is not immediately available in the caches, enqueue the job
     this.metrics?.regenFnQueuedTotal.inc({caller: rCaller, entrypoint: RegenFnName.getCheckpointState});
-    return this.jobQueue.push({key: "getCheckpointState", args: [cp, rCaller]});
+    return this.jobQueue.push({key: "getCheckpointState", args: [cp, opts, rCaller]});
   }
 
-  async getBlockSlotState(blockRoot: RootHex, slot: Slot, rCaller: RegenCaller): Promise<CachedBeaconStateAllForks> {
+  async getBlockSlotState(
+    blockRoot: RootHex,
+    slot: Slot,
+    opts: StateCloneOpts,
+    rCaller: RegenCaller
+  ): Promise<CachedBeaconStateAllForks> {
     this.metrics?.regenFnCallTotal.inc({caller: rCaller, entrypoint: RegenFnName.getBlockSlotState});
 
     // The state is not immediately available in the caches, enqueue the job
-    return this.jobQueue.push({key: "getBlockSlotState", args: [blockRoot, slot, rCaller]});
+    return this.jobQueue.push({key: "getBlockSlotState", args: [blockRoot, slot, opts, rCaller]});
   }
 
   async getState(stateRoot: RootHex, rCaller: RegenCaller): Promise<CachedBeaconStateAllForks> {

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -117,7 +117,7 @@ export async function validateGossipBlock(
   // [IGNORE] The block's parent (defined by block.parent_root) has been seen (via both gossip and non-gossip sources) (a client MAY queue blocks for processing once the parent block is retrieved).
   // [REJECT] The block's parent (defined by block.parent_root) passes validation.
   const blockState = await chain.regen
-    .getBlockSlotState(parentRoot, blockSlot, RegenCaller.validateGossipBlock)
+    .getBlockSlotState(parentRoot, blockSlot, {dontTransferCache: true}, RegenCaller.validateGossipBlock)
     .catch(() => {
       throw new BlockGossipError(GossipAction.IGNORE, {code: BlockErrorCode.PARENT_UNKNOWN, parentRoot});
     });

--- a/packages/beacon-node/test/utils/node/simTest.ts
+++ b/packages/beacon-node/test/utils/node/simTest.ts
@@ -66,7 +66,11 @@ export function simTestInfoTracker(bn: BeaconNode, logger: Logger): () => void {
     lastSeenEpoch = checkpoint.epoch;
 
     // Recover the pre-epoch transition state, use any random caller for regen
-    const checkpointState = await bn.chain.regen.getCheckpointState(checkpoint, RegenCaller.onForkChoiceFinalized);
+    const checkpointState = await bn.chain.regen.getCheckpointState(
+      checkpoint,
+      {dontTransferCache: true},
+      RegenCaller.onForkChoiceFinalized
+    );
     const lastSlot = computeStartSlotAtEpoch(checkpoint.epoch) - 1;
     const lastStateRoot = checkpointState.stateRoots.get(lastSlot % SLOTS_PER_HISTORICAL_ROOT);
     const lastState = await bn.chain.regen.getState(toHexString(lastStateRoot), RegenCaller.onForkChoiceFinalized);

--- a/packages/state-transition/src/cache/stateCache.ts
+++ b/packages/state-transition/src/cache/stateCache.ts
@@ -15,7 +15,15 @@ export type BeaconStateCache = {
   epochCtx: EpochContext;
   /** Count of clones created from this BeaconStateCache instance. readonly to prevent accidental usage downstream */
   readonly clonedCount: number;
+  readonly clonedCountWithTransferCache: number;
+  readonly createdWithTransferCache: boolean;
 };
+
+type Mutable<T> = {
+  -readonly [P in keyof T]: T[P];
+};
+
+type BeaconStateCacheMutable = Mutable<BeaconStateCache>;
 
 /**
  * `BeaconState` with various caches
@@ -133,6 +141,8 @@ export function createCachedBeaconState<T extends BeaconStateAllForks>(
     config: immutableData.config,
     epochCtx: EpochContext.createFromState(state, immutableData, opts),
     clonedCount: 0,
+    clonedCountWithTransferCache: 0,
+    createdWithTransferCache: false,
   });
 }
 
@@ -146,7 +156,9 @@ export function getCachedBeaconState<T extends BeaconStateAllForks>(
   const cachedState = state as T & BeaconStateCache;
   cachedState.config = cache.config;
   cachedState.epochCtx = cache.epochCtx;
-  (cachedState as {clonedCount: number}).clonedCount = cache.clonedCount;
+  (cachedState as BeaconStateCacheMutable).clonedCount = cache.clonedCount;
+  (cachedState as BeaconStateCacheMutable).clonedCountWithTransferCache = cache.clonedCountWithTransferCache;
+  (cachedState as BeaconStateCacheMutable).createdWithTransferCache = cache.createdWithTransferCache;
 
   // Overwrite .clone function to preserve cache
   // TreeViewDU.clone() creates a new object that does not have the attached cache
@@ -156,12 +168,18 @@ export function getCachedBeaconState<T extends BeaconStateAllForks>(
     const viewDUCloned = viewDUClone(dontTransferCache);
 
     // Override `readonly` attribute in single place where `.clonedCount` is incremented
-    (this as {clonedCount: number}).clonedCount++;
+    (this as BeaconStateCacheMutable).clonedCount++;
+
+    if (!dontTransferCache) {
+      (this as BeaconStateCacheMutable).clonedCountWithTransferCache++;
+    }
 
     return getCachedBeaconState(viewDUCloned, {
       config: this.config,
       epochCtx: this.epochCtx.clone(),
       clonedCount: 0,
+      clonedCountWithTransferCache: 0,
+      createdWithTransferCache: !dontTransferCache,
     }) as T & BeaconStateCache;
   }
 
@@ -177,4 +195,15 @@ export function isCachedBeaconState<T extends BeaconStateAllForks>(
   state: T | (T & BeaconStateCache)
 ): state is T & BeaconStateCache {
   return (state as T & BeaconStateCache).epochCtx !== undefined;
+}
+
+// Given a CachedBeaconState, check if validators array internal cache is populated.
+// This cache is populated during epoch transition, and should be preserved for performance.
+// If the cache is missing too often, means that our clone strategy is not working well.
+export function isStateValidatorsNodesPopulated(state: CachedBeaconStateAllForks): boolean {
+  return state.validators["nodesPopulated"] === true;
+}
+
+export function isStateBalancesNodesPopulated(state: CachedBeaconStateAllForks): boolean {
+  return state.balances["nodesPopulated"] === true;
 }

--- a/packages/state-transition/src/cache/stateCache.ts
+++ b/packages/state-transition/src/cache/stateCache.ts
@@ -152,8 +152,8 @@ export function getCachedBeaconState<T extends BeaconStateAllForks>(
   // TreeViewDU.clone() creates a new object that does not have the attached cache
   const viewDUClone = cachedState.clone.bind(cachedState);
 
-  function clone(this: T & BeaconStateCache): T & BeaconStateCache {
-    const viewDUCloned = viewDUClone();
+  function clone(this: T & BeaconStateCache, dontTransferCache?: boolean): T & BeaconStateCache {
+    const viewDUCloned = viewDUClone(dontTransferCache);
 
     // Override `readonly` attribute in single place where `.clonedCount` is incremented
     (this as {clonedCount: number}).clonedCount++;

--- a/packages/state-transition/src/epoch/computeUnrealizedCheckpoints.ts
+++ b/packages/state-transition/src/epoch/computeUnrealizedCheckpoints.ts
@@ -19,7 +19,8 @@ export function computeUnrealizedCheckpoints(
 
   // For phase0, we need to create the cache through beforeProcessEpoch
   if (state.config.getForkSeq(state.slot) === ForkSeq.phase0) {
-    stateRealizedCheckpoints = state.clone();
+    // Clone state to mutate below         true = do not transfer cache
+    stateRealizedCheckpoints = state.clone(true);
     const epochProcess = beforeProcessEpoch(stateRealizedCheckpoints);
     processJustificationAndFinalization(stateRealizedCheckpoints, epochProcess);
   }
@@ -33,8 +34,8 @@ export function computeUnrealizedCheckpoints(
 
     // Clone state and use progressive balances
     else {
-      // Clone state to mutate below           false = do not transfer cache
-      stateRealizedCheckpoints = state.clone(false);
+      // Clone state to mutate below         true = do not transfer cache
+      stateRealizedCheckpoints = state.clone(true);
 
       weighJustificationAndFinalization(
         stateRealizedCheckpoints,

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -2,7 +2,7 @@ export * from "./stateTransition.js";
 export * from "./constants/index.js";
 export * from "./util/index.js";
 export * from "./signatureSets/index.js";
-export * from "./metrics.js";
+export {IBeaconStateTransitionMetrics} from "./metrics.js";
 
 export {
   CachedBeaconStatePhase0,
@@ -23,7 +23,13 @@ export {
 } from "./types.js";
 
 // Main state caches
-export {createCachedBeaconState, BeaconStateCache, isCachedBeaconState} from "./cache/stateCache.js";
+export {
+  createCachedBeaconState,
+  BeaconStateCache,
+  isCachedBeaconState,
+  isStateBalancesNodesPopulated,
+  isStateValidatorsNodesPopulated,
+} from "./cache/stateCache.js";
 export {EpochContext, EpochContextImmutableData, createEmptyEpochContextImmutableData} from "./cache/epochContext.js";
 export {EpochProcess, beforeProcessEpoch} from "./cache/epochProcess.js";
 

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -2,7 +2,7 @@ export * from "./stateTransition.js";
 export * from "./constants/index.js";
 export * from "./util/index.js";
 export * from "./signatureSets/index.js";
-export {IBeaconStateTransitionMetrics} from "./metrics.js";
+export {BeaconStateTransitionMetrics} from "./metrics.js";
 
 export {
   CachedBeaconStatePhase0,

--- a/packages/state-transition/src/metrics.ts
+++ b/packages/state-transition/src/metrics.ts
@@ -1,5 +1,4 @@
 import {Epoch} from "@lodestar/types";
-import {isStateBalancesNodesPopulated, isStateValidatorsNodesPopulated} from "./cache/stateCache.js";
 import {CachedBeaconStateAllForks} from "./types.js";
 import {AttesterStatus} from "./util/attesterStatus.js";
 

--- a/packages/state-transition/src/metrics.ts
+++ b/packages/state-transition/src/metrics.ts
@@ -1,4 +1,5 @@
 import {Epoch} from "@lodestar/types";
+import {isStateBalancesNodesPopulated, isStateValidatorsNodesPopulated} from "./cache/stateCache.js";
 import {CachedBeaconStateAllForks} from "./types.js";
 import {AttesterStatus} from "./util/attesterStatus.js";
 

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -33,6 +33,7 @@ export type StateTransitionOpts = BlockExternalData &
     verifyStateRoot?: boolean;
     verifyProposer?: boolean;
     verifySignatures?: boolean;
+    dontTransferCache?: boolean;
   };
 
 /**
@@ -54,7 +55,7 @@ export function stateTransition(
   const blockSlot = block.slot;
 
   // .clone() before mutating state in state transition
-  let postState = state.clone();
+  let postState = state.clone(options.dontTransferCache);
 
   if (metrics) {
     onStateCloneMetrics(postState, metrics, "stateTransition");
@@ -119,11 +120,11 @@ export function stateTransition(
 export function processSlots(
   state: CachedBeaconStateAllForks,
   slot: Slot,
-  epochProcessOpts?: EpochProcessOpts,
+  epochProcessOpts?: EpochProcessOpts & {dontTransferCache?: boolean},
   metrics?: BeaconStateTransitionMetrics | null
 ): CachedBeaconStateAllForks {
   // .clone() before mutating state in state transition
-  let postState = state.clone();
+  let postState = state.clone(epochProcessOpts?.dontTransferCache);
 
   if (metrics) {
     onStateCloneMetrics(postState, metrics, "processSlots");


### PR DESCRIPTION
**Motivation**

- Metrics from https://github.com/ChainSafe/lodestar/pull/5169 show that the internal SSZ cache of state data structures is almost never populated. Their design should ensure that unless there's heavy forking they should be populated in high probability. This PR intends to research the problem while being deployed in testing fleet

**Description**

Transfer cache to the cloned state only when importing blocks
